### PR TITLE
Remove yarn from npm template scripts

### DIFF
--- a/create-turbo/templates/npm/package.json
+++ b/create-turbo/templates/npm/package.json
@@ -7,9 +7,9 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "yarn turbo run build",
-    "dev": "yarn turbo run dev --parallel",
-    "lint": "yarn turbo run lint",
+    "build": "turbo run build",
+    "dev": "turbo run dev --parallel",
+    "lint": "turbo run lint",
     "format": "prettier --write '**/*.{ts,tsx,.md}'"
   },
   "devDependencies": {


### PR DESCRIPTION
It looks like this isn't necessary and I got an error trying this out with the npm template because yarn was not installed. 