### PR TITLE
Set a fallback for the user's name when running turbo link

### DIFF
--- a/cli/internal/login/link.go
+++ b/cli/internal/login/link.go
@@ -23,12 +23,12 @@ type LinkCommand struct {
 	Ui     *cli.ColoredUi
 }
 
-// Synopsis of run command
+// Synopsis of link command
 func (c *LinkCommand) Synopsis() string {
 	return "Link your local directory to a Vercel organization and enable remote caching."
 }
 
-// Help returns information about the `run` command
+// Help returns information about the `link` command
 func (c *LinkCommand) Help() string {
 	helpText := `
 Usage: turbo link
@@ -43,7 +43,7 @@ Options:
 	return strings.TrimSpace(helpText)
 }
 
-// Run executes tasks in the monorepo
+// Run links a local directory to a Vercel organization and enables remote caching
 func (c *LinkCommand) Run(args []string) int {
 	var dontModifyGitIgnore bool
 	shouldSetup := true
@@ -108,10 +108,14 @@ func (c *LinkCommand) Run(args []string) int {
 	}
 
 	var chosenTeamName string
+	nameWithFallback := userResponse.User.Name
+	if nameWithFallback == "" {
+		nameWithFallback = userResponse.User.Username
+	}
 	survey.AskOne(
 		&survey.Select{
 			Message: "Which Vercel scope (and Remote Cache) do you want associate with this Turborepo? ",
-			Options: append([]string{userResponse.User.Name}, teamOptions...),
+			Options: append([]string{nameWithFallback}, teamOptions...),
 		},
 		&chosenTeamName,
 		survey.WithValidator(survey.Required),


### PR DESCRIPTION
This PR adds a fallback for a User's name to their username. Name is an optional field in Vercel. My user, for example, does not have a name (I don't know how or why). 

This then makes it impossible to set up `turbo link` to a personal workspace. 
e.g. 
 
![Screenshot 2021-12-09 at 16 31 42](https://user-images.githubusercontent.com/8166969/145436807-0dcab158-0818-40bd-bdf2-68df315e0ad9.png)

Selecting the empty option prompts: `X Sorry, your reply was invalid: Value is required`

Post change: 
![Screenshot 2021-12-09 at 16 34 15](https://user-images.githubusercontent.com/8166969/145437275-99c7831b-043d-4d0f-8d0b-ff21e0c796b6.png)


