### PR TITLE
Fix parsing weird formats of the keywords field of some package.json files

### DIFF
--- a/cli/internal/fs/package_json.go
+++ b/cli/internal/fs/package_json.go
@@ -38,12 +38,6 @@ type Pipeline struct {
 type PackageJSON struct {
 	Name                   string            `json:"name,omitempty"`
 	Version                string            `json:"version,omitempty"`
-	Description            string            `json:"description,omitempty"`
-	Keywords               []string          `json:"keywords,omitempty"`
-	Homepage               string            `json:"homepage,omitempty"`
-	License                string            `json:"license,omitempty"`
-	Files                  []string          `json:"files,omitempty"`
-	Main                   string            `json:"main,omitempty"`
 	Scripts                map[string]string `json:"scripts,omitempty"`
 	Dependencies           map[string]string `json:"dependencies,omitempty"`
 	DevDependencies        map[string]string `json:"devDependencies,omitempty"`

--- a/cli/internal/fs/package_json.go
+++ b/cli/internal/fs/package_json.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"reflect"
-	"strings"
 	"sync"
 
 	"github.com/pascaldekloe/name"
@@ -40,7 +39,7 @@ type PackageJSON struct {
 	Name                   string            `json:"name,omitempty"`
 	Version                string            `json:"version,omitempty"`
 	Description            string            `json:"description,omitempty"`
-	Keywords               Keywords          `json:"keywords,omitempty"`
+	Keywords               []string          `json:"keywords,omitempty"`
 	Homepage               string            `json:"homepage,omitempty"`
 	License                string            `json:"license,omitempty"`
 	Files                  []string          `json:"files,omitempty"`
@@ -66,7 +65,6 @@ type PackageJSON struct {
 	ExternalDepsHash       string
 }
 
-type Keywords []string
 type Workspaces []string
 
 type WorkspacesAlt struct {
@@ -84,43 +82,6 @@ func (r *Workspaces) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	*r = tempstr
-	return nil
-}
-
-func (k *Keywords) UnmarshalJSON(data []byte) error {
-	// First, attempt to get the keywords list expecting it's well defined
-	// as described by npm spec, an array of strings
-	// see: https://docs.npmjs.com/cli/v8/configuring-npm/package-json#keywords
-	var valid = []string{}
-	if err := json.Unmarshal(data, &valid); err == nil {
-		*k = Keywords(valid)
-		return nil
-	}
-	// Reaching this code path, the keywords list is defined in a non-standard
-	// or invalid format. Try to deal with that.
-
-	// Contain everything in a string
-	var tmpstr string
-	err := json.Unmarshal(data, &tmpstr)
-
-	// If we fail to unmarshal as string, give up at this point.
-	if err != nil {
-		return err
-	}
-
-	// Try removing extra chars, or chars meant to split the keywords list.
-	// Replace them with a whitespace instead, so we can split by it.
-	var removechars = []string{"[", "]", "/", ","}
-	for _, r := range removechars {
-		tmpstr = strings.ReplaceAll(tmpstr, r, " ")
-	}
-
-	// Trim leading/trailing spaces
-	tmpstr = strings.TrimSpace(tmpstr)
-	// Split by whitespace
-	var val = strings.Fields(tmpstr)
-	// fill the relevant type definition with the split result
-	*k = Keywords(val)
 	return nil
 }
 


### PR DESCRIPTION
Latest version of turborepo was having issues parsing [lodash](https://www.npmjs.com/package/lodash)'s `package.json` file. Because it has the `keywords` field defined as:

```json
"keywords": "modules, stdlib, util"
```

And not using the standard format:
```json
"keywords": ["modules", "stdlib", "util"]
```
- `lodash` version used is: `v4.17.21` (latest version).

Turborepo was failing (exiting) with errors like:
```
 ERROR  error parsing ... /node_modules/lodash/package.json: json: cannot unmarshal string into Go struct field PackageJSON.keywords of type []string
```

This PR handles the above and some slightly weirder ways of defining keywords in package.json

I incremented the version, LMK if this is not the scope of this PR. 