### PR TITLE
Fix Spelling Errors in create-turbo readme

### DIFF
--- a/create-turbo/README.md
+++ b/create-turbo/README.md
@@ -1,6 +1,6 @@
 # Welcome to Turborepo
 
-[Turborepo](https://tureborepo.org) is a high-performance monorepo build-system for modern JavaScript and TypeScript codebases.
+[Turborepo](https://turborepo.org) is a high-performance monorepo build-system for modern JavaScript and TypeScript codebases.
 
 To get started, open a new shell and run:
 
@@ -10,4 +10,4 @@ $ npx create-turbo@latest
 
 Then follow the prompts you see in your terminal.
 
-For more information about Turborepo, [visit tuborepo.org](https://turborepo.org) and follow us on Twitter ([@turborepo](https://twitter.com/turborepo))!
+For more information about Turborepo, [visit turborepo.org](https://turborepo.org) and follow us on Twitter ([@turborepo](https://twitter.com/turborepo))!


### PR DESCRIPTION
`Turbo` has been misspelled as `tubro` or `turebo` in the create-turbo package readme