### PR TITLE
Fix: add ui package & types library in with-pnpm example

### DIFF
--- a/examples/with-pnpm/web/package.json
+++ b/examples/with-pnpm/web/package.json
@@ -15,6 +15,9 @@
   },
   "devDependencies": {
     "eslint": "7.32.0",
+    "@types/react": "^17.0.37",
+    "@types/react-dom": "^17.0.11",
+    "ui": "workspace:*",
     "config": "workspace:*",
     "next-transpile-modules": "^9.0.0",
     "typescript": "^4.4.4"


### PR DESCRIPTION
When i run "pnpm dev" (same as "pnpm run dev") inside the web directory, it comes up with this errors:

![msedge_c24kahZfMd](https://user-images.githubusercontent.com/27861064/145514570-8373162b-30b0-411a-a31b-448aa49bb08f.png)

These errors appear beacause the "ui" package has not been added yet, so I did it:

```diff
+ "ui": "workspace:*"
```

However, it continues to show other errors because we are using typescript but missing some types library:

![msedge_hni53fw9Tq](https://user-images.githubusercontent.com/27861064/145514595-8c2b823a-5bfa-4a7b-8f03-17ba6051d75b.png)

And i just added them:

```diff
+ "@types/react": "^17.0.37",
+ "@types/react-dom": "^17.0.11",
```

Run "pnpm dev" again and it worked:

![msedge_G28zR24sRU](https://user-images.githubusercontent.com/27861064/145514617-379029d1-7565-4fd7-884a-eefdee047a24.png)

