### PR TITLE
Fix: broken "topologically" link in pipelines docs

### DIFF
--- a/docs/pages/docs/features/pipelines.mdx
+++ b/docs/pages/docs/features/pipelines.mdx
@@ -6,7 +6,7 @@ import Callout from "../../../components/callout";
 
 # Pipelining Package Tasks
 
-In traditional monorepo task runners, like `lerna` or even `yarn`'s own built-in `workspaces run` command, each NPM lifecycle script like `build` or `test` is run [topologically](./glossary#topological-order) (which is the mathematical term for "dependency-first" order) or in parallel individually. Depending on the dependency graph of the monorepo, CPU cores might be left idle—wasting valuable time and resources.
+In traditional monorepo task runners, like `lerna` or even `yarn`'s own built-in `workspaces run` command, each NPM lifecycle script like `build` or `test` is run [topologically](../glossary#topological-order) (which is the mathematical term for "dependency-first" order) or in parallel individually. Depending on the dependency graph of the monorepo, CPU cores might be left idle—wasting valuable time and resources.
 
 Turborepo gives developers a way to specify task relationships explicitly and conventionally. The advantage here is twofold.
 


### PR DESCRIPTION
Sometimes one dot can make things different.

Before (on the official site):

![kDhkOXACpz](https://user-images.githubusercontent.com/27861064/145581838-fec89780-155f-4f03-a3d6-28531ce1ea59.gif)

Fixed:

![0wWe7KUo9j (2)](https://user-images.githubusercontent.com/27861064/145581942-a2d22dbe-3789-47e8-975a-cd7800977d68.gif)


