### PR TITLE
Fix ui dep in examples

### DIFF
--- a/create-turbo/templates/_shared_ts/apps/docs/package.json
+++ b/create-turbo/templates/_shared_ts/apps/docs/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "12.0.3",
     "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react-dom": "17.0.2",
+    "ui": "*"
   },
   "devDependencies": {
     "config": "*",

--- a/create-turbo/templates/_shared_ts/apps/web/package.json
+++ b/create-turbo/templates/_shared_ts/apps/web/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "12.0.3",
     "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react-dom": "17.0.2",
+    "ui": "*"
   },
   "devDependencies": {
     "config": "*",

--- a/examples/basic/docs/package.json
+++ b/examples/basic/docs/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "12.0.3",
     "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react-dom": "17.0.2",
+    "ui": "*"
   },
   "devDependencies": {
     "eslint": "7.32.0",

--- a/examples/basic/web/package.json
+++ b/examples/basic/web/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "12.0.3",
     "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react-dom": "17.0.2",
+    "ui": "*"
   },
   "devDependencies": {
     "config": "*",

--- a/examples/with-pnpm/docs/package.json
+++ b/examples/with-pnpm/docs/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "12.0.3",
     "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react-dom": "17.0.2",
+    "ui": "*"
   },
   "devDependencies": {
     "eslint": "7.32.0",

--- a/examples/with-pnpm/web/package.json
+++ b/examples/with-pnpm/web/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "12.0.3",
     "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react-dom": "17.0.2",
+    "ui": "*"
   },
   "devDependencies": {
     "eslint": "7.32.0",


### PR DESCRIPTION
Fix #169 . Turbo does what it is supposed to, we forgot to add ui as a listed dependency