### PR TITLE
Add support for `--only` flag that matches lerna/pnpm run behavior

### DIFF
--- a/cli/internal/core/scheduler_test.go
+++ b/cli/internal/core/scheduler_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pyr-sh/dag"
 )
 
-func TestSchedulerAddTask(t *testing.T) {
+func TestSchedulerDefault(t *testing.T) {
 	var g dag.AcyclicGraph
 	g.Add("a")
 	g.Add("b")
@@ -61,6 +61,7 @@ func TestSchedulerAddTask(t *testing.T) {
 		TaskNames:   []string{"test"},
 		Concurrency: 10,
 		Parallel:    false,
+		TasksOnly:   false,
 	})
 
 	if err != nil {
@@ -74,23 +75,112 @@ func TestSchedulerAddTask(t *testing.T) {
 	}
 
 	actual := strings.TrimSpace(p.TaskGraph.String())
-	expected := strings.TrimSpace(leafString)
+	expected := strings.TrimSpace(leafStringAll)
 	if actual != expected {
 		t.Fatalf("bad: \n\nactual---\n%s\n\n expected---\n%s", actual, expected)
 	}
 }
 
-const leafString = `
+func TestSchedulerTasksOnly(t *testing.T) {
+	var g dag.AcyclicGraph
+	g.Add("a")
+	g.Add("b")
+	g.Add("c")
+	g.Connect(dag.BasicEdge("c", "b"))
+	g.Connect(dag.BasicEdge("c", "a"))
+
+	p := NewScheduler(&g)
+	topoDeps := make(util.Set)
+	topoDeps.Add("build")
+	deps := make(util.Set)
+	deps.Add("prepare")
+	p.AddTask(&Task{
+		Name:     "build",
+		TopoDeps: topoDeps,
+		Deps:     deps,
+		Run: func(cwd string) error {
+			fmt.Println(cwd)
+			return nil
+		},
+	})
+	p.AddTask(&Task{
+		Name:     "test",
+		TopoDeps: topoDeps,
+		Deps:     deps,
+		Run: func(cwd string) error {
+			fmt.Println(cwd)
+			return nil
+		},
+	})
+	p.AddTask(&Task{
+		Name: "prepare",
+		Run: func(cwd string) error {
+			fmt.Println(cwd)
+			return nil
+		},
+	})
+
+	if _, ok := p.Tasks["build"]; !ok {
+		t.Fatal("AddTask is not adding tasks (build)")
+	}
+
+	if _, ok := p.Tasks["test"]; !ok {
+		t.Fatal("AddTask is not adding tasks (test)")
+	}
+
+	err := p.Prepare(&SchedulerExecutionOptions{
+		Packages:    nil,
+		TaskNames:   []string{"test"},
+		Concurrency: 10,
+		Parallel:    false,
+		TasksOnly:   true,
+	})
+
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	errs := p.Execute()
+
+	for _, err := range errs {
+		t.Fatalf("%v", err)
+	}
+
+	actual := strings.TrimSpace(p.TaskGraph.String())
+	expected := strings.TrimSpace(leafStringOnly)
+	if actual != expected {
+		t.Fatalf("bad: \n\nactual---\n%s\n\n expected---\n%s", actual, expected)
+	}
+}
+
+const leafStringAll = `
 ___ROOT___
 a#build
+  a#prepare
+a#prepare
   ___ROOT___
 a#test
-  ___ROOT___
+  a#prepare
 b#build
+  b#prepare
+b#prepare
   ___ROOT___
 b#test
+  b#prepare
+c#prepare
   ___ROOT___
 c#test
   a#build
   b#build
+  c#prepare
+`
+
+const leafStringOnly = `
+___ROOT___
+a#test
+	___ROOT___
+b#test
+	___ROOT___
+c#test
+	___ROOT___
 `

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -608,6 +608,7 @@ func (c *RunCommand) Run(args []string) int {
 		TaskNames:   ctx.Targets.UnsafeListOfStrings(),
 		Concurrency: runOptions.concurrency,
 		Parallel:    runOptions.parallel,
+		TasksOnly:   runOptions.only,
 	}); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error preparing engine: %s", err))
 		return 1

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -692,6 +692,8 @@ type RunOptions struct {
 	// Immediately exit on task failure
 	bail            bool
 	passThroughArgs []string
+	// Restrict execution to only the listed task names. Default false
+	only bool
 }
 
 func getDefaultRunOptions() *RunOptions {
@@ -706,6 +708,7 @@ func getDefaultRunOptions() *RunOptions {
 		profile:        "", // empty string does no tracing
 		forceExecution: false,
 		stream:         true,
+		only:           false,
 	}
 }
 
@@ -789,6 +792,8 @@ func parseRunArgs(args []string, cwd string) (*RunOptions, error) {
 				}
 			case strings.HasPrefix(arg, "--includeDependencies"):
 				runOptions.ancestors = true
+			case strings.HasPrefix(arg, "--only"):
+				runOptions.only = true
 			case strings.HasPrefix(arg, "--team"):
 			case strings.HasPrefix(arg, "--token"):
 			default:

--- a/docs/pages/docs/reference/command-line-reference.mdx
+++ b/docs/pages/docs/reference/command-line-reference.mdx
@@ -145,6 +145,37 @@ turbo run build --no-cache
 turbo run dev --parallel --no-cache
 ```
 
+#### `--only`
+
+Default false. Restricts execution to only include specified tasks. This is very similar to how how `lerna` or `pnpm` run tasks by default.
+
+Given this pipeline:
+
+```json
+{
+  "turbo": {
+    "pipeline": {
+      "build": {
+        "dependsOn": [
+          "^build"
+        ]
+      },
+      "test": {
+        "dependsOn": [
+          "^build"
+        ]
+      }
+    }
+  }
+}
+```
+
+```shell
+turbo run test --only
+```
+
+Will execute _only_ the `test` tasks in each package. It will not `build`.
+
 #### `--parallel`
 
 Default `false`. Run commands in parallel across packages and apps and ignore the dependency graph. This is useful for developing with live reloading.


### PR DESCRIPTION
Add a new `--only` flag to support restricting task execution to only the tasks specified in `run`. This is to make it easier to adopt turbo in a Lerna codebase since `--only` behavior is effectively an exact match.

For this pipeline:

```json
"turbo": {
    "pipeline": {
      "build": {
        "outputs": [
          "dist/**/*"
        ],
        "dependsOn": [
          "^build"
        ]
      },
      "test": {
        "dependsOn": [
          "^build"
        ]
      }
    }
```

```sh
turbo run test
```    
    
![graph-1639160891531963000](https://user-images.githubusercontent.com/4060187/145623655-4e7a5397-e3f1-4e87-b311-9bc11688beea.jpg)

```sh
turbo run test --only --graph
```
![graph-1639160830365669000](https://user-images.githubusercontent.com/4060187/145623560-538c2716-87d0-4d0b-a75f-2ab1cd2bfead.jpg)