### PR TITLE
fix: remove `.`, which is not needed

### DIFF
--- a/create-turbo/templates/_shared_ts/package.json
+++ b/create-turbo/templates/_shared_ts/package.json
@@ -10,7 +10,7 @@
     "build": "turbo run build",
     "dev": "turbo run dev --parallel",
     "lint": "turbo run lint",
-    "format": "prettier --write '**/*.{ts,tsx,.md}'"
+    "format": "prettier --write '**/*.{ts,tsx,md}'"
   },
   "devDependencies": {
     "prettier": "^2.5.1",

--- a/create-turbo/templates/npm/package.json
+++ b/create-turbo/templates/npm/package.json
@@ -10,7 +10,7 @@
     "build": "turbo run build",
     "dev": "turbo run dev --parallel",
     "lint": "turbo run lint",
-    "format": "prettier --write '**/*.{ts,tsx,.md}'"
+    "format": "prettier --write '**/*.{ts,tsx,md}'"
   },
   "devDependencies": {
     "prettier": "^2.5.1",

--- a/create-turbo/templates/pnpm/package.json
+++ b/create-turbo/templates/pnpm/package.json
@@ -6,7 +6,7 @@
     "build": "turbo run build",
     "dev": "turbo run dev --parallel",
     "lint": "turbo run lint",
-    "format": "prettier --write '**/*.{ts,tsx,.md}'"
+    "format": "prettier --write '**/*.{ts,tsx,md}'"
   },
   "devDependencies": {
     "prettier": "^2.5.1",

--- a/create-turbo/templates/yarn/package.json
+++ b/create-turbo/templates/yarn/package.json
@@ -10,7 +10,7 @@
     "build": "turbo run build",
     "dev": "turbo run dev --parallel",
     "lint": "turbo run lint",
-    "format": "prettier --write '**/*.{ts,tsx,.md}'"
+    "format": "prettier --write '**/*.{ts,tsx,md}'"
   },
   "devDependencies": {
     "prettier": "^2.5.1",


### PR DESCRIPTION
I tried [Getting Started with Turborepo](https://turborepo.org/docs/getting-started), and I found that perhaps some unintentional settings.

I hope it cloud help.