### PR TITLE
Fix forseeable typo in complimentary-tools

### DIFF
--- a/docs/pages/docs/guides/complimentary-tools.mdx
+++ b/docs/pages/docs/guides/complimentary-tools.mdx
@@ -10,7 +10,7 @@ Below is a running list of additional monorepo tools that you may find useful in
 
 ## Versioning, Publishing, and Changelog Generation
 
-For the foreseable future, `turbo` is not going to deal with package publishing. Versioning/Publishing is an extremely opinionated topic with a lot of existing solutions. Our advice is to avoid versioning packages altogether unless you actually need to publish them to NPM for external consumption. If you have to version your packages, we really like the workflow of Changesets (especially for open source projects).
+For the foreseeable future, `turbo` is not going to deal with package publishing. Versioning/Publishing is an extremely opinionated topic with a lot of existing solutions. Our advice is to avoid versioning packages altogether unless you actually need to publish them to NPM for external consumption. If you have to version your packages, we really like the workflow of Changesets (especially for open source projects).
 
 - [changesets/changesets](https://github.com/changesets/changesets) - 🦋 A way to manage your versioning and changelogs with a focus on monorepos
 - [microsoft/beachball](https://github.com/microsoft/beachball) - The Sunniest Semantic Version Bumper


### PR DESCRIPTION
According to Cambridge dictionary, `foreseeable` is the correct writing

https://dictionary.cambridge.org/dictionary/english/foreseeable