### PR TITLE
Fix wildcard typo in scopes docs

### DIFF
--- a/docs/pages/docs/features/scopes.mdx
+++ b/docs/pages/docs/features/scopes.mdx
@@ -18,7 +18,7 @@ Scoping task execution can speed up the process especially if there are distinct
 By default, it is helpful to be able to run tasks on all affected packages within a scope. Packages that changed will affect downstream consumers. In this case, pass along the `scope` to build all the dependencies as well.
 
 <Callout type="info">
-  You can use wild card character: `*`. This is particularly helpful when
+  You can use wildcard character: `*`. This is particularly helpful when
   packages are named by group or by scope.
 </Callout>
 


### PR DESCRIPTION
According to [Wikipedia](https://en.wikipedia.org/wiki/Wildcard_character), [Microsoft](https://support.microsoft.com/en-us/office/examples-of-wildcard-characters-939e153f-bd30-47e4-a763-61897c87b3f4) and [NextJS](https://nextjs.org/docs/api-reference/next.config.js/headers#wildcard-path-matching), `wildcard` is the correct writing.

(Sorry for all the typo PR's 🙈 )