### PR TITLE
update create-turbo template gitignore pnpm

### DIFF
--- a/create-turbo/templates/_shared_ts/gitignore
+++ b/create-turbo/templates/_shared_ts/gitignore
@@ -21,6 +21,7 @@ build
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.pnpm-debug.log*
 
 # local env files
 .env.local


### PR DESCRIPTION
Thank you for the great work on turborepo!

Was using pnpm and noticed the .gitignore from create-turbo does not include pnpm. 