### PR TITLE
Use double quotes for prettier file glob in yarn format

### DIFF
--- a/create-turbo/templates/_shared_ts/package.json
+++ b/create-turbo/templates/_shared_ts/package.json
@@ -10,7 +10,7 @@
     "build": "turbo run build",
     "dev": "turbo run dev --parallel",
     "lint": "turbo run lint",
-    "format": "prettier --write '**/*.{ts,tsx,md}'"
+    "format": "prettier --write \"**/*.{ts,tsx,md}\""
   },
   "devDependencies": {
     "prettier": "^2.5.1",

--- a/create-turbo/templates/npm/package.json
+++ b/create-turbo/templates/npm/package.json
@@ -10,7 +10,7 @@
     "build": "turbo run build",
     "dev": "turbo run dev --parallel",
     "lint": "turbo run lint",
-    "format": "prettier --write '**/*.{ts,tsx,md}'"
+    "format": "prettier --write \"**/*.{ts,tsx,md}\""
   },
   "devDependencies": {
     "prettier": "^2.5.1",

--- a/create-turbo/templates/pnpm/package.json
+++ b/create-turbo/templates/pnpm/package.json
@@ -6,7 +6,7 @@
     "build": "turbo run build",
     "dev": "turbo run dev --parallel",
     "lint": "turbo run lint",
-    "format": "prettier --write '**/*.{ts,tsx,md}'"
+    "format": "prettier --write \"**/*.{ts,tsx,md}\""
   },
   "devDependencies": {
     "prettier": "^2.5.1",

--- a/create-turbo/templates/yarn/package.json
+++ b/create-turbo/templates/yarn/package.json
@@ -10,7 +10,7 @@
     "build": "turbo run build",
     "dev": "turbo run dev --parallel",
     "lint": "turbo run lint",
-    "format": "prettier --write '**/*.{ts,tsx,md}'"
+    "format": "prettier --write \"**/*.{ts,tsx,md}\""
   },
   "devDependencies": {
     "prettier": "^2.5.1",


### PR DESCRIPTION
## Summary

When running the `yarn format` command on Windows Powershell, double quotes are added to the file pattern and makes it invalid.

```
PS C:\Users\yangshun\developer\my-turborepo> yarn format
yarn run v1.22.5
$ prettier --write '**/*.{ts,tsx,md}'
[error] No files matching the pattern were found: "'**/*.{ts,tsx,md}'".
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

The fix is to change the single quotes into escaped double quotes instead. This is used in [Docusaurus](https://github.com/facebook/docusaurus/blob/main/package.json#L44-L47)

## Test Plan

### Windows

```
PS C:\Users\yangshun\developer\my-turborepo> yarn format
yarn run v1.22.5
$ prettier --write "**/*.{ts,tsx,md}"
apps\docs\next-env.d.ts 19ms
apps\docs\pages\index.tsx 14ms
apps\docs\README.md 35ms
apps\web\next-env.d.ts 2ms
apps\web\pages\index.tsx 4ms
apps\web\README.md 14ms
packages\tsconfig\README.md 2ms
packages\ui\Button.tsx 5ms
README.md 33ms
Done in 0.90s.
```

### Windows Subsystem for Linux

```
yangshun@PC-YANGSHUN:/mnt/c/Users/yangshun/developer/my-turborepo$ yarn format
yarn run v1.22.5
$ prettier --write "**/*.{ts,tsx,md}"
apps/docs/next-env.d.ts 17ms
apps/docs/pages/index.tsx 13ms
apps/docs/README.md 41ms
apps/web/next-env.d.ts 3ms
apps/web/pages/index.tsx 5ms
apps/web/README.md 15ms
packages/tsconfig/README.md 4ms
packages/ui/Button.tsx 5ms
README.md 21ms
Done in 1.07s.
```