### PR TITLE
Fix initiating a project within the current directory

### DIFF
--- a/create-turbo/src/index.ts
+++ b/create-turbo/src/index.ts
@@ -196,7 +196,7 @@ async function run() {
     spinner.stop();
   }
 
-  process.chdir(relativeProjectDir);
+  process.chdir(projectDir);
   tryGitInit(relativeProjectDir);
 
   if (projectDirIsCurrentDir) {


### PR DESCRIPTION
This PR is intended to address https://github.com/vercel/turborepo/issues/203. Reading through the code, it seems like this functionality was intended to be supported and seemed like a simple fix so I thought I'd give it a go!

### Before:
The installation would successfully create all template project files but fail on
```ts
process.chdir(relativeProjectDir);
```
Thus not completing the `git init` step and failing to print out success instructions.

**Output**
```
>>> TURBOREPO

>>> Welcome to Turborepo! Let's get you set up with a new codebase.

? Where would you like to create your turborepo? .
? Which package manager do you want to use? Yarn
? Do you want me to run `yarn install`? Yes

>>> Bootstrapping a new turborepo with the following:

 - apps/web: Next.js with TypeScript
 - apps/docs: Next.js with TypeScript
 - packages/ui: Shared React component library
 - packages/config: Shared configuration (ESLint)
 - packages/tsconfig: Shared TypeScript `tsconfig.json`


Aborting installation.
Unexpected error. Please report it as a bug:
Error: ENOENT: no such file or directory, chdir '/Users/sean/development/test-dir' -> ''
    at process.wrappedChdir (internal/bootstrap/switches/does_own_process_state.js:116:14)
    at process.chdir (/Users/sean/development/turborepo/node_modules/graceful-fs/polyfills.js:22:11)
    at run (/Users/sean/development/turborepo/create-turbo/dist/index.js:277:11)
    at processTicksAndRejections (internal/process/task_queues.js:95:5) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'chdir',
  path: '/Users/sean/development/test-dir',
  dest: ''
}

% ls -al
total 288
Dec 12 12:20 .
Dec 12 12:14 ..
Dec 12 12:20 .gitignore
Dec 12 12:20 README.md
Dec 12 12:20 apps
Dec 12 12:20 node_modules
Dec 12 12:20 package.json
Dec 12 12:20 packages
Dec 12 12:20 yarn.lock
```

### After:
Changes dir correctly for current directory by directly using `projectDir`. in preparation for the `tryGitInit` call.

**Output**
```
>>> TURBOREPO

>>> Welcome to Turborepo! Let's get you set up with a new codebase.

? Where would you like to create your turborepo? .
? Which package manager do you want to use? Yarn
? Do you want me to run `yarn install`? Yes

>>> Bootstrapping a new turborepo with the following:

 - apps/web: Next.js with TypeScript
 - apps/docs: Next.js with TypeScript
 - packages/ui: Shared React component library
 - packages/config: Shared configuration (ESLint)
 - packages/tsconfig: Shared TypeScript `tsconfig.json`

>>> Success! Check the README for development and deploy instructions!

% ls -al
total 288
Dec 12 12:32 .
Dec 12 12:31 ..
Dec 12 12:32 .git
Dec 12 12:32 .gitignore
Dec 12 12:32 README.md
Dec 12 12:32 apps
Dec 12 12:32 node_modules
Dec 12 12:32 package.json
Dec 12 12:32 packages
Dec 12 12:32 yarn.lock
```

### Testing

Can manually test by running create-turbo using `.` as the project directory.

I wasn't able to run the jest tests as is (`Jest encountered an unexpected token`), didn't have too much time to see what was required to make things work. Should the tests be working right now?

### Further Improvements
- Adding a test for current directory support at some point would be nice.
- Seems like the message for creating a project within a current directory simply says the following at the moment: (`Success! Check the README for development and deploy instructions!`) Can improve this output to produce similar instructions to those that are shown when not using the current directory. (`Your new Turborepo is ready. To build all apps and packages, run the following...`)

