### PR TITLE
Running create-turbo tests

### DIFF
--- a/create-turbo/__tests__/cli.test.ts
+++ b/create-turbo/__tests__/cli.test.ts
@@ -36,7 +36,7 @@ describe("create-turbo cli", () => {
     jest.setTimeout(DEFAULT_JEST_TIMEOUT);
   });
 
-  it("guides the user through the process", async () => {
+  it("guides the user through the process", (done) => {
     let cli = spawn("node", [createTurbo], {});
     let promptCount = 0;
     let previousPrompt: string;
@@ -89,6 +89,12 @@ describe("create-turbo cli", () => {
     });
 
     cli.on("exit", () => {
+      try {
+        expect(promptCount).toEqual(4);
+        done();
+      } catch (error) {
+        done(error);
+      }
       return;
     });
   });

--- a/create-turbo/jest.config.js
+++ b/create-turbo/jest.config.js
@@ -1,5 +1,6 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
-  preset: "ts-jest",
+  preset: "ts-jest/presets/js-with-ts",
   testEnvironment: "node",
+  transformIgnorePatterns: ["/node_modules/(?!(strip-ansi|ansi-regex)/)"],
 };

--- a/create-turbo/tsconfig.json
+++ b/create-turbo/tsconfig.json
@@ -11,6 +11,7 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "outDir": "dist",
-    "rootDir": "."
+    "rootDir": ".",
+    "allowJs": true
   }
 }


### PR DESCRIPTION
Got tests running for `create-turbo`.

----

Initially running into:
```
$ jest
 FAIL  __tests__/cli.test.ts
  ● Test suite failed to run

    Jest encountered an unexpected token

    Details:

    /Users/sean/development/turborepo/create-turbo/node_modules/strip-ansi/index.js:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,jest){import ansiRegex from 'ansi-regex';
                                                                                      ^^^^^^

    SyntaxError: Cannot use import statement outside a module
```

This was happening for both the `strip-ansi` and the `ansi-regex` libraries.

The combination of the changes in `create-turbo/jest.config.js` and `create-turbo/tsconfig.json` allows the specific modules to be correctly transformed and run by `jest`/`ts-jest`. Not 100% sure if this is the ideal answer here.
Commit: https://github.com/vercel/turborepo/commit/0377412f60f600c67448346f60967c9644a2676b

----

Then fixed the `"guides the user through the process"` test to successfully finish by using [jest.DoneCallback](https://jestjs.io/docs/asynchronous#callbacks).
The specific test was exiting before anything was checked and notifying that "Jest did not exit one second after the test run has completed." after the tests ran and it would hang:
```
Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   2 passed, 2 total
Time:        4.511 s
Ran all test suites.
Jest did not exit one second after the test run has completed.

This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.
```
Commit: https://github.com/vercel/turborepo/commit/ef9a40a5e0c7382e6eba40cae46b023791b5b9ad

## Test Plan

```
cd create-turbo
yarn test
```

**Output**

```
$ jest
 PASS  __tests__/cli.test.ts (6.007 s)
  create-turbo cli
    ✓ guides the user through the process (1453 ms)
    the --version flag
      ✓ prints the current version (392 ms)
    the -v flag
      ✓ prints the current version (385 ms)
    the --help flag
      ✓ prints help info (389 ms)
    the -h flag
      ✓ prints help info (385 ms)

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   2 passed, 2 total
Time:        6.167 s, estimated 8 s
Ran all test suites.
```

Runs with turbo too! (from the root):
```
yarn turbo run test
```

**Output**

```
$ ./turbow.sh run test
• Running test in 3 packages
cli:test: cache hit, replaying output 903a6bf0f34c97a9
create-turbo:test: cache hit, replaying output bc2b8a8d956c7662
cli:test: $ go test -race ./internal/...
cli:test: ?   	turbo/internal/api	[no test files]
cli:test: ?   	turbo/internal/backends	[no test files]
cli:test: ?   	turbo/internal/backends/nodejs	[no test files]
cli:test: ?   	turbo/internal/cache	[no test files]
cli:test: ?   	turbo/internal/client	[no test files]
cli:test: ?   	turbo/internal/config	[no test files]
cli:test: ?   	turbo/internal/context	[no test files]
cli:test: ok  	turbo/internal/core	(cached)
cli:test: ok  	turbo/internal/fs	0.237s
cli:test: ?   	turbo/internal/info	[no test files]
cli:test: ?   	turbo/internal/login	[no test files]
cli:test: ok  	turbo/internal/logstreamer	0.212s
cli:test: ?   	turbo/internal/prune	[no test files]
cli:test: ok  	turbo/internal/run	0.316s
cli:test: ?   	turbo/internal/scm	[no test files]
cli:test: ?   	turbo/internal/ui	[no test files]
cli:test: ok  	turbo/internal/ui/term	0.337s
cli:test: ok  	turbo/internal/util	(cached)
cli:test: ?   	turbo/internal/xxhash	[no test files]
create-turbo:test: $ jest
create-turbo:test: PASS __tests__/cli.test.ts (7.991 s)
create-turbo:test:   create-turbo cli
create-turbo:test:     ✓ guides the user through the process (1397 ms)
create-turbo:test:     the --version flag
create-turbo:test:       ✓ prints the current version (381 ms)
create-turbo:test:     the -v flag
create-turbo:test:       ✓ prints the current version (368 ms)
create-turbo:test:     the --help flag
create-turbo:test:       ✓ prints help info (370 ms)
create-turbo:test:     the -h flag
create-turbo:test:       ✓ prints help info (366 ms)
create-turbo:test:
create-turbo:test: Test Suites: 1 passed, 1 total
create-turbo:test: Tests:       5 passed, 5 total
create-turbo:test: Snapshots:   2 passed, 2 total
create-turbo:test: Time:        8.129 s
create-turbo:test: Ran all test suites.

 Tasks:    2 successful, 2 total
Cached:    2 cached, 2 total
  Time:    89ms >>> FULL TURBO

✨  Done in 0.55s.
```