### PR TITLE
Improved success output for create-turbo

### DIFF
--- a/create-turbo/src/index.ts
+++ b/create-turbo/src/index.ts
@@ -226,9 +226,13 @@ async function run() {
   }
   console.log(`  npx turbo login`);
   console.log();
-  console.log(
-    `For more info, checkout the README in ${chalk.bold(relativeProjectDir)}`
-  );
+  if (projectDirIsCurrentDir) {
+    console.log(`For more info, checkout the README`);
+  } else {
+    console.log(
+      `For more info, checkout the README in ${chalk.bold(relativeProjectDir)}`
+    );
+  }
   console.log(
     `as well as the official Turborepo docs ${chalk.underline(
       "https://turborepo.org/docs"

--- a/create-turbo/src/index.ts
+++ b/create-turbo/src/index.ts
@@ -199,46 +199,41 @@ async function run() {
   process.chdir(projectDir);
   tryGitInit(relativeProjectDir);
 
-  if (projectDirIsCurrentDir) {
-    console;
-    console.log(
-      `${chalk.bold(
-        turboGradient(">>> Success!")
-      )} Check the README for development and deploy instructions!`
-    );
-  } else {
-    console.log(
-      `${chalk.bold(
-        turboGradient(">>> Success!")
-      )} Your new Turborepo is ready. `
-    );
-    console.log();
-    console.log(`To build all apps and packages, run the following:`);
-    console.log();
+  console.log(
+    `${chalk.bold(turboGradient(">>> Success!"))} Your new Turborepo is ready. `
+  );
+  console.log();
+  console.log(`To build all apps and packages, run the following:`);
+  console.log();
+  if (!projectDirIsCurrentDir) {
     console.log(`  cd ${relativeProjectDir}`);
-    console.log(`  ${answers.packageManager} run build`);
-    console.log();
-    console.log(`To develop all apps and packages, run the following:`);
-    console.log();
-    console.log(`  cd ${relativeProjectDir}`);
-    console.log(`  ${answers.packageManager} run dev`);
-    console.log();
-    console.log(`Turborepo will cache locally by default. For an additional`);
-    console.log(`speed boost, enable Remote Caching (beta) with Vercel by`);
-    console.log(`entering the following commands:`);
-    console.log();
-    console.log(`  cd ${relativeProjectDir}`);
-    console.log(`  npx turbo login`);
-    console.log();
-    console.log(
-      `For more info, checkout the README in ${chalk.bold(relativeProjectDir)}`
-    );
-    console.log(
-      `as well as the official Turborepo docs ${chalk.underline(
-        "https://turborepo.org"
-      )}`
-    );
   }
+  console.log(`  ${answers.packageManager} run build`);
+  console.log();
+  console.log(`To develop all apps and packages, run the following:`);
+  console.log();
+  if (!projectDirIsCurrentDir) {
+    console.log(`  cd ${relativeProjectDir}`);
+  }
+  console.log(`  ${answers.packageManager} run dev`);
+  console.log();
+  console.log(`Turborepo will cache locally by default. For an additional`);
+  console.log(`speed boost, enable Remote Caching (beta) with Vercel by`);
+  console.log(`entering the following commands:`);
+  console.log();
+  if (!projectDirIsCurrentDir) {
+    console.log(`  cd ${relativeProjectDir}`);
+  }
+  console.log(`  npx turbo login`);
+  console.log();
+  console.log(
+    `For more info, checkout the README in ${chalk.bold(relativeProjectDir)}`
+  );
+  console.log(
+    `as well as the official Turborepo docs ${chalk.underline(
+      "https://turborepo.org"
+    )}`
+  );
 }
 
 const update = checkForUpdate(cliPkgJson).catch(() => null);

--- a/create-turbo/src/index.ts
+++ b/create-turbo/src/index.ts
@@ -231,7 +231,7 @@ async function run() {
   );
   console.log(
     `as well as the official Turborepo docs ${chalk.underline(
-      "https://turborepo.org"
+      "https://turborepo.org/docs"
     )}`
   );
 }


### PR DESCRIPTION
Improved success output for `create-turbo` namely for  the current directory use case. (Follow-up task to https://github.com/vercel/turborepo/pull/212)

Items changed (since indentation was changed so diff is not as easy to parse):
- removed the `if (projectDirIsCurrentDir)` block, inlined the `else` logs
- check `projectDirIsCurrentDir` wherever `relativeProjectDir` is used in the logs
- changed docs link from `https://turborepo.org` -> `https://turborepo.org/docs`

### Before
<img width="709" alt="Screen Shot 2021-12-12 at 7 19 12 PM" src="https://user-images.githubusercontent.com/10479615/145738739-33ffb35b-aa53-4f66-9b11-97d35bf986fe.png">

### After
(notice no `cd ...` lines in the success output as we are already in the project directory)
<img width="681" alt="Screen Shot 2021-12-12 at 7 34 21 PM" src="https://user-images.githubusercontent.com/10479615/145739258-a7235aaf-c5b4-4912-8830-ab90944e67fb.png">

### Non-current directory case still works
<img width="687" alt="Screen Shot 2021-12-12 at 7 29 48 PM" src="https://user-images.githubusercontent.com/10479615/145738961-03adc73e-2760-44d3-9c0f-7f9dc87aad19.png">