### PR TITLE
Add clean to turbo pipeline in design system example

### DIFF
--- a/examples/design-system/package.json
+++ b/examples/design-system/package.json
@@ -40,6 +40,9 @@
       },
       "dev": {
         "cache": false
+      },
+      "clean": {
+        "cache": false
       }
     }
   }


### PR DESCRIPTION
It isn't possible to run `yarn clean` in the current example since `clean` is not part of the turbo pipeline. This PR fixes that.