### PR TITLE
Papercuts in context.go

### DIFF
--- a/cli/internal/context/color_cache.go
+++ b/cli/internal/context/color_cache.go
@@ -1,0 +1,54 @@
+package context
+
+import (
+	"sync"
+
+	"github.com/fatih/color"
+)
+
+type colorFn = func(format string, a ...interface{}) string
+
+func getTerminalPackageColors() []colorFn {
+	return []colorFn{color.CyanString, color.MagentaString, color.GreenString, color.YellowString, color.BlueString}
+}
+
+type ColorCache struct {
+	mu         sync.Mutex
+	index      int
+	TermColors []colorFn
+	Cache      map[interface{}]colorFn
+}
+
+func NewColorCache() *ColorCache {
+	return &ColorCache{
+		TermColors: getTerminalPackageColors(),
+		index:      0,
+		Cache:      make(map[interface{}]colorFn),
+	}
+}
+
+// PrefixColor returns a color function for a given package name
+func (c *ColorCache) PrefixColor(name string) colorFn {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	colorFn, ok := c.Cache[name]
+	if ok {
+		return colorFn
+	}
+	c.index++
+	colorFn = c.TermColors[positiveMod(c.index, 5)] // 5 possible colors
+	c.Cache[name] = colorFn
+	return colorFn
+}
+
+// postitiveMod returns a modulo operator like JavaScripts
+func positiveMod(x, d int) int {
+	x = x % d
+	if x >= 0 {
+		return x
+	}
+	if d < 0 {
+		return x - d
+	}
+	return x + d
+}

--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -297,12 +297,12 @@ func (c *Context) ResolveWorkspaceRootDeps() (*fs.PackageJSON, error) {
 		pkg.UnresolvedExternalDeps[dep] = version
 	}
 	if c.Backend.Name == "nodejs-yarn" && !fs.CheckIfWindows() {
-		pkg.SubLockfile = fs.YarnLockfile{}
+		pkg.SubLockfile = make(fs.YarnLockfile)
 		c.ResolveDepGraph(&lockfileWg, pkg.UnresolvedExternalDeps, depSet, seen, pkg)
 		lockfileWg.Wait()
 		pkg.ExternalDeps = make([]string, 0, depSet.Cardinality())
-		for _, v := range depSet.ToSlice() {
-			pkg.ExternalDeps = append(pkg.ExternalDeps, fmt.Sprintf("%s", v))
+		for v := range depSet.ToSlice() {
+			pkg.ExternalDeps = append(pkg.ExternalDeps, fmt.Sprintf("%v", v))
 		}
 		sort.Strings(pkg.ExternalDeps)
 		hashOfExternalDeps, err := fs.HashObject(pkg.ExternalDeps)
@@ -402,12 +402,12 @@ func (c *Context) populateTopologicGraphForPackageJson(pkg *fs.PackageJSON) erro
 		c.TopologicalGraph.Connect(dag.BasicEdge(pkg.Name, ROOT_NODE_NAME))
 	}
 	pkg.ExternalDeps = make([]string, 0, externalDepSet.Cardinality())
-	for _, v := range externalDepSet.ToSlice() {
-		pkg.ExternalDeps = append(pkg.ExternalDeps, fmt.Sprintf("%s", v))
+	for v := range externalDepSet.ToSlice() {
+		pkg.ExternalDeps = append(pkg.ExternalDeps, fmt.Sprintf("%v", v))
 	}
 	pkg.InternalDeps = make([]string, 0, internalDepsSet.Len())
-	for _, v := range internalDepsSet.List() {
-		pkg.ExternalDeps = append(pkg.InternalDeps, fmt.Sprintf("%s", v))
+	for v := range internalDepsSet.List() {
+		pkg.ExternalDeps = append(pkg.InternalDeps, fmt.Sprintf("%v", v))
 	}
 	sort.Strings(pkg.InternalDeps)
 	sort.Strings(pkg.ExternalDeps)

--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -423,7 +423,7 @@ func (c *Context) parsePackageJSON(buildFilePath string) error {
 	if fs.FileExists(buildFilePath) {
 		pkg, err := fs.ReadPackageJSON(buildFilePath)
 		if err != nil {
-			return fmt.Errorf("error parsing %v: %w", buildFilePath, err)
+			return fmt.Errorf("parsing %s: %w", buildFilePath, err)
 		}
 
 		// log.Printf("[TRACE] adding %+v to graph", pkg.Name)

--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -300,9 +300,9 @@ func (c *Context) ResolveWorkspaceRootDeps() (*fs.PackageJSON, error) {
 		pkg.SubLockfile = make(fs.YarnLockfile)
 		c.ResolveDepGraph(&lockfileWg, pkg.UnresolvedExternalDeps, depSet, seen, pkg)
 		lockfileWg.Wait()
-		pkg.ExternalDeps = make([]string, depSet.Cardinality())
-		for i, v := range depSet.ToSlice() {
-			pkg.ExternalDeps[i] = v.(string)
+		pkg.ExternalDeps = make([]string, 0, depSet.Cardinality())
+		for _, v := range depSet.ToSlice() {
+			pkg.ExternalDeps = append(pkg.ExternalDeps, fmt.Sprintf("%s", v))
 		}
 		sort.Strings(pkg.ExternalDeps)
 		hashOfExternalDeps, err := fs.HashObject(pkg.ExternalDeps)

--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -297,7 +297,7 @@ func (c *Context) ResolveWorkspaceRootDeps() (*fs.PackageJSON, error) {
 		pkg.UnresolvedExternalDeps[dep] = version
 	}
 	if c.Backend.Name == "nodejs-yarn" && !fs.CheckIfWindows() {
-		pkg.SubLockfile = make(fs.YarnLockfile)
+		pkg.SubLockfile = fs.YarnLockfile{}
 		c.ResolveDepGraph(&lockfileWg, pkg.UnresolvedExternalDeps, depSet, seen, pkg)
 		lockfileWg.Wait()
 		pkg.ExternalDeps = make([]string, 0, depSet.Cardinality())
@@ -397,13 +397,13 @@ func (c *Context) populateTopologicGraphForPackageJson(pkg *fs.PackageJSON) erro
 	if internalDepsSet.Len() == 0 {
 		c.TopologicalGraph.Connect(dag.BasicEdge(pkg.Name, ROOT_NODE_NAME))
 	}
-	pkg.ExternalDeps = make([]string, externalDepSet.Cardinality())
-	for i, v := range externalDepSet.ToSlice() {
-		pkg.ExternalDeps[i] = v.(string)
+	pkg.ExternalDeps = make([]string, 0, externalDepSet.Cardinality())
+	for _, v := range externalDepSet.ToSlice() {
+		pkg.ExternalDeps = append(pkg.ExternalDeps, fmt.Sprintf("%s", v))
 	}
-	pkg.InternalDeps = make([]string, internalDepsSet.Len())
-	for i, v := range internalDepsSet.List() {
-		pkg.InternalDeps[i] = v.(string)
+	pkg.InternalDeps = make([]string, 0, internalDepsSet.Len())
+	for _, v := range internalDepsSet.List() {
+		pkg.ExternalDeps = append(pkg.InternalDeps, fmt.Sprintf("%s", v))
 	}
 	sort.Strings(pkg.InternalDeps)
 	sort.Strings(pkg.ExternalDeps)

--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -219,15 +219,9 @@ func WithGraph(rootpath string, config *config.Config) Option {
 		// until all parsing is complete
 		// and populate the graph
 		parseJSONWaitGroup := new(errgroup.Group)
-		justJsons := make([]string, len(spaces))
-		for i, space := range spaces {
-			justJsons[i] = path.Join(space, "package.json")
-		}
-		ignore := []string{
-			"**/node_modules/**/*",
-			"**/bower_components/**/*",
-			"**/test/**/*",
-			"**/tests/**/*",
+		justJsons := make([]string, 0, len(spaces))
+		for _, space := range spaces {
+			justJsons = append(justJsons, path.Join(space, "package.json"))
 		}
 
 		f := globby.GlobFiles(rootpath, justJsons, ignore)

--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -224,7 +224,7 @@ func WithGraph(rootpath string, config *config.Config) Option {
 			justJsons = append(justJsons, path.Join(space, "package.json"))
 		}
 
-		f := globby.GlobFiles(rootpath, justJsons, ignore)
+		f := globby.GlobFiles(rootpath, justJsons, getWorkspaceIgnores())
 
 		for i, val := range f {
 			_, val := i, val // https://golang.org/doc/faq#closures_and_goroutines
@@ -506,4 +506,13 @@ func safeCompileIgnoreFile(filepath string) (*gitignore.GitIgnore, error) {
 	}
 	// no op
 	return gitignore.CompileIgnoreLines([]string{}...), nil
+}
+
+func getWorkspaceIgnores() []string {
+	return []string{
+		"**/node_modules/**/*",
+		"**/bower_components/**/*",
+		"**/test/**/*",
+		"**/tests/**/*",
+	}
 }

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -391,8 +391,8 @@ func (c *RunCommand) Run(args []string) int {
 				tracer := runState.Run(context.GetTaskId(pack.Name, task))
 
 				// Create a logger
-				pref := context.PrefixColor(ctx, &pack.Name)
-				actualPrefix := pref("%v:%v: ", pack.Name, task)
+				pref := ctx.ColorCache.PrefixColor(pack.Name)
+				actualPrefix := pref("%s:%s: ", pack.Name, task)
 				targetUi := &cli.PrefixedUi{
 					Ui:           c.Ui,
 					OutputPrefix: actualPrefix,


### PR DESCRIPTION
* Allocate correct capacity for workspace json globs
* Extract workspace ignores into constant slice
* Better encapsulate ColorCache and remove global
* Set ExternalDeps capacity
* Remove redudant word
* Better slice allocation in dependency analysis