### PR TITLE
Fix flaky getTargetsFromArgs tests

### DIFF
--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -355,6 +355,8 @@ func (c *Context) ResolveWorkspaceRootDeps() (*fs.PackageJSON, error) {
 	return pkg, nil
 }
 
+// GetTargetsFromArguments returns a list of targets from the arguments and Turbo config.
+// Return targets are always unique sorted alphabetically.
 func GetTargetsFromArguments(arguments []string, configJson *fs.TurboConfigJSON) ([]string, error) {
 	targets := make(util.Set)
 	for _, arg := range arguments {
@@ -370,11 +372,13 @@ func GetTargetsFromArguments(arguments []string, configJson *fs.TurboConfigJSON)
 				}
 			}
 			if !found {
-				return nil, fmt.Errorf("Task `%v` not found in turbo pipeline in package.json. Are you sure you added it?", arg)
+				return nil, fmt.Errorf("task `%v` not found in turbo pipeline in package.json. Are you sure you added it?", arg)
 			}
 		}
 	}
-	return targets.UnsafeListOfStrings(), nil
+	stringTargets := targets.UnsafeListOfStrings()
+	sort.Strings(stringTargets)
+	return stringTargets, nil
 }
 
 func (c *Context) populateTopologicGraphForPackageJson(pkg *fs.PackageJSON) error {

--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -64,7 +64,7 @@ type Context struct {
 	Lockfile         *fs.YarnLockfile
 	SCC              [][]dag.Vertex
 	PendingTaskNodes dag.Set
-	Targets          util.Set
+	Targets          []string
 	Backend          *api.LanguageBackend
 	// Used to arbitrate access to the graph. We parallelise most build operations
 	// and Go maps aren't natively threadsafe so this is needed.
@@ -355,7 +355,7 @@ func (c *Context) ResolveWorkspaceRootDeps() (*fs.PackageJSON, error) {
 	return pkg, nil
 }
 
-func GetTargetsFromArguments(arguments []string, configJson *fs.TurboConfigJSON) (util.Set, error) {
+func GetTargetsFromArguments(arguments []string, configJson *fs.TurboConfigJSON) ([]string, error) {
 	targets := make(util.Set)
 	for _, arg := range arguments {
 		if arg == "--" {
@@ -374,7 +374,7 @@ func GetTargetsFromArguments(arguments []string, configJson *fs.TurboConfigJSON)
 			}
 		}
 	}
-	return targets, nil
+	return targets.UnsafeListOfStrings(), nil
 }
 
 func (c *Context) populateTopologicGraphForPackageJson(pkg *fs.PackageJSON) error {

--- a/cli/internal/context/context_test.go
+++ b/cli/internal/context/context_test.go
@@ -86,8 +86,9 @@ func TestGetTargetsFromArguments(t *testing.T) {
 				t.Errorf("GetTargetsFromArguments() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got.UnsafeListOfStrings(), tt.want) {
-				t.Errorf("GetTargetsFromArguments() = %v, want %v", got.UnsafeListOfStrings(), tt.want)
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetTargetsFromArguments() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -332,11 +332,7 @@ func (c *RunCommand) Run(args []string) int {
 	}
 
 	if runOptions.stream {
-		targetList := make([]string, ctx.Targets.Len())
-		for i, v := range ctx.Targets.List() {
-			targetList[i] = v.(string)
-		}
-		c.Ui.Output(fmt.Sprintf("%s %s %s", ui.Dim("• Running"), ui.Dim(ui.Bold(strings.Join(targetList, ", "))), ui.Dim(fmt.Sprintf("in %v packages", filteredPkgs.Len()))))
+		c.Ui.Output(fmt.Sprintf("%s %s %s", ui.Dim("• Running"), ui.Dim(ui.Bold(strings.Join(ctx.Targets, ", "))), ui.Dim(fmt.Sprintf("in %v packages", filteredPkgs.Len()))))
 	}
 	runState := NewRunState(runOptions)
 	runState.Listen(c.Ui, time.Now())
@@ -598,7 +594,7 @@ func (c *RunCommand) Run(args []string) int {
 
 	if err := engine.Prepare(&core.SchedulerExecutionOptions{
 		Packages:    filteredPkgs.UnsafeListOfStrings(),
-		TaskNames:   ctx.Targets.UnsafeListOfStrings(),
+		TaskNames:   ctx.Targets,
 		Concurrency: runOptions.concurrency,
 		Parallel:    runOptions.parallel,
 		TasksOnly:   runOptions.only,


### PR DESCRIPTION
Fix flaky getTargetsFromArgs tests by returning slices instead of util.Set