### PR TITLE
add --colors support to turbo CLI

### DIFF
--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -67,21 +67,21 @@ Options:
                          execution. Supports globs.
   --cache-dir            Specify local filesystem cache directory.
 												 (default "./node_modules/.cache/turbo")
-  --concurrency          Limit the concurrency of task execution. Use 1 for 
+  --concurrency          Limit the concurrency of task execution. Use 1 for
                          serial (i.e. one-at-a-time) execution. (default 10)
   --continue             Continue execution even if a task exits with an error
                          or non-zero exit code. The default behavior is to bail
                          immediately. (default false)
-  --force                Ignore the existing cache (to force execution). 
+  --force                Ignore the existing cache (to force execution).
                          (default false)
-  --graph                Generate a Dot graph of the task execution.   
-  --global-deps          Specify glob of global filesystem dependencies to 
+  --graph                Generate a Dot graph of the task execution.
+  --global-deps          Specify glob of global filesystem dependencies to
 	                       be hashed. Useful for .env and files in the root
 												 directory. Can be specified multiple times.
   --since                Limit/Set scope to changed packages since a
                          mergebase. This uses the git diff ${target_branch}...
                          mechanism to identify which packages have changed.
-  --team                 The slug of the turborepo.com team.                         
+  --team                 The slug of the turborepo.com team.
   --token                A turborepo.com personal access token.
   --ignore               Files to ignore when calculating changed files
                          (i.e. --since). Supports globs.
@@ -261,7 +261,7 @@ func (c *RunCommand) Run(args []string) int {
 			}
 			c.Config.Logger.Debug("dependencies", ancestors)
 			for _, d := range ancestors {
-				// we need to exlcude the fake root node
+				// we need to exclude the fake root node
 				// since it is not a real package
 				if d != ctx.RootNode {
 					filteredPkgs.Add(d)
@@ -484,6 +484,7 @@ func (c *RunCommand) Run(args []string) int {
 				}
 				argsactual := append([]string{"run"}, task)
 				argsactual = append(argsactual, runOptions.passThroughArgs...)
+				// os.Setenv("FORCE_COLOR", "0")
 				// @TODO: @jaredpalmer fix this hack to get the package manager's name
 				cmd := exec.Command(strings.TrimPrefix(ctx.Backend.Name, "nodejs-"), argsactual...)
 				cmd.Dir = pack.Dir
@@ -685,7 +686,7 @@ type RunOptions struct {
 	deps bool
 	// Whether to include ancestors (pkg.dependencies) in execution (defaults to false)
 	ancestors bool
-	// List of globs of file paths to ignore from exection scope calculation
+	// List of globs of file paths to ignore from execution scope calculation
 	ignore []string
 	// Whether to stream log outputs
 	stream bool
@@ -820,6 +821,9 @@ func parseRunArgs(args []string, cwd string) (*RunOptions, error) {
 				runOptions.ancestors = true
 			case strings.HasPrefix(arg, "--only"):
 				runOptions.only = true
+			case strings.HasPrefix(arg, "--colors"):
+				fmt.Printf("--colors is given")
+				os.Setenv("FORCE_COLOR", "1")
 			case strings.HasPrefix(arg, "--team"):
 			case strings.HasPrefix(arg, "--token"):
 			case strings.HasPrefix(arg, "--api"):

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -484,7 +484,6 @@ func (c *RunCommand) Run(args []string) int {
 				}
 				argsactual := append([]string{"run"}, task)
 				argsactual = append(argsactual, runOptions.passThroughArgs...)
-				// os.Setenv("FORCE_COLOR", "0")
 				// @TODO: @jaredpalmer fix this hack to get the package manager's name
 				cmd := exec.Command(strings.TrimPrefix(ctx.Backend.Name, "nodejs-"), argsactual...)
 				cmd.Dir = pack.Dir

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -822,7 +822,6 @@ func parseRunArgs(args []string, cwd string) (*RunOptions, error) {
 			case strings.HasPrefix(arg, "--only"):
 				runOptions.only = true
 			case strings.HasPrefix(arg, "--colors"):
-				fmt.Printf("--colors is given")
 				os.Setenv("FORCE_COLOR", "1")
 			case strings.HasPrefix(arg, "--team"):
 			case strings.HasPrefix(arg, "--token"):

--- a/docs/pages/docs/reference/command-line-reference.mdx
+++ b/docs/pages/docs/reference/command-line-reference.mdx
@@ -109,9 +109,9 @@ turbo run build test lint --graph=my-graph.html
   graph at the moment, even if that pipeline task does not actually exist in a
   given package. This has no impact on execution, it means that:
 
-- the terminal output may overstate the number of packages in which a task is running.
-- your dot viz graph may contain additional nodes that represents tasks that do not exist.
-  </Callout>
+  - the terminal output may overstate the number of packages in which a task is running.
+  - your dot viz graph may contain additional nodes that represents tasks that do not exist.
+</Callout>
 
 #### `--force`
 

--- a/docs/pages/docs/reference/command-line-reference.mdx
+++ b/docs/pages/docs/reference/command-line-reference.mdx
@@ -57,6 +57,14 @@ When `--continue` is `true`, `turbo` will exit with the highest exit code value 
 turbo run build --continue
 ```
 
+#### `--colors`
+
+Allow colors in the output of tasks run by `turbo`.
+
+```sh
+turbo run build --colors
+```
+
 #### `--cwd`
 
 Set the working directory of the command.
@@ -101,9 +109,9 @@ turbo run build test lint --graph=my-graph.html
   graph at the moment, even if that pipeline task does not actually exist in a
   given package. This has no impact on execution, it means that:
 
-  - the terminal output may overstate the number of packages in which a task is running.
-  - your dot viz graph may contain additional nodes that represents tasks that do not exist.
-</Callout>
+- the terminal output may overstate the number of packages in which a task is running.
+- your dot viz graph may contain additional nodes that represents tasks that do not exist.
+  </Callout>
 
 #### `--force`
 
@@ -269,7 +277,7 @@ You can also set the value of the current team by setting an environment variabl
 
 `type: string`
 
-To view CPU trace, outputs the trace to the given file,  use `go tool trace [file]`.
+To view CPU trace, outputs the trace to the given file, use `go tool trace [file]`.
 
 <Callout emoji="🚨">
   **Important**: The trace viewer doesn't work under Windows Subsystem for Linux.
@@ -301,10 +309,10 @@ To view CPU profile, outputs the profile to the given file, drop the file into [
   for native Windows and run using the command prompt instead.
 </Callout>
 
-
 ```sh
 turbo run build --cpuprofile="<cpu-profile-file-name>"
 ```
+
 #### `-v`, `-vv`, `-vvv`
 
 To sepecify log level, use `-v` for `Info`, `-vv` for `Debug` and `-vvv` for `Trace` flags.


### PR DESCRIPTION
- Adds `turbo` flag support colors in CLI output from commands run by `turbo`. 
- Fixes incorrect spelling
- Prettier/Lint-Staged adjusted some spacing on things. 

Usage:
`turbo --colors`

Two questions: 
- should this flag affect the colors in the output from `turbo` or just the command `turbo` runs?
- would you like me to add tests to `run_test.go`?

With colors
![image](https://user-images.githubusercontent.com/33156025/146656730-26473e58-9332-4955-b1d4-2e2965a41e34.png)

No colors
![image](https://user-images.githubusercontent.com/33156025/146656740-519ce1c7-bd85-4be1-915c-e1a09fa29fdb.png)



Closes #223 
