### PR TITLE
docs(guides): give appropriate attribution to Microsoft Lage

### DIFF
--- a/docs/pages/docs/features/pipelines.mdx
+++ b/docs/pages/docs/features/pipelines.mdx
@@ -4,6 +4,10 @@ title: Pipelines
 
 import Callout from "../../../components/callout";
 
+<Callout>
+This page and Turborepo's Pipeline API design was copied from the Microsoft Lage [Pipelines Page](https://microsoft.github.io/lage/guide/pipeline.html#defining-a-pipeline).
+</Callout>
+
 # Pipelining Package Tasks
 
 In traditional monorepo task runners, like `lerna` or even `yarn`'s own built-in `workspaces run` command, each NPM lifecycle script like `build` or `test` is run [topologically](./glossary#topological-order) (which is the mathematical term for "dependency-first" order) or in parallel individually. Depending on the dependency graph of the monorepo, CPU cores might be left idle—wasting valuable time and resources.

--- a/docs/pages/docs/features/scopes.mdx
+++ b/docs/pages/docs/features/scopes.mdx
@@ -4,6 +4,10 @@ title: Scoped tasks
 
 import Callout from "../../../components/callout";
 
+<Callout>
+This page and Turborepo's Scoped Tasks API design was copied from the Microsoft Lage [Scoped Builds Page](https://microsoft.github.io/lage/guide/scopes.html#scoped-builds-with-all-its-dependents).
+</Callout>
+
 # Scoped Tasks
 
 Scoping task execution can speed up the process especially if there are distinct clusters of packages that are not related to each other within your repository. Turborepo has a `scope` option that allows the task running to proceed up to the packages found that matches the `scope` argument. It's useful to think of `scope` as an "entry point" into your monorepo's package/task graph. This is a string matcher based on the name of the packages (not the package path).


### PR DESCRIPTION
This pull request adds a note to the docs pages for “Scoped Tasks” and “Pipelines” to properly attribute Microsoft for copyrighted content that Turborepo copied from the documentation for Microsoft’s monorepo tool, Lage. Currently, both pages on Turborepo’s documentation come across as original work by the Turborepo team, even though the credit seems it mostly belongs with the Lage maintainers at Microsoft. 

If you compare the pages on Turborepo’s and Lage’s docs, you can see how similar the text content, and APIs are:
* Turborepo’s “Scope Tasks” page: https://turborepo.org/docs/features/scopes
* Lage’s “Scoped Builds” page: https://microsoft.github.io/lage/guide/scopes.html
* Turborepo’s “Pipelines” page: https://turborepo.org/docs/features/pipelines
* Lage’s “Pipelines” page: https://microsoft.github.io/lage/guide/pipeline.html#defining-a-pipeline

The headings on both sites are nearly identical, and most of the text content is the same. As you can see by looking at the source for Lage’s Scoped Tasks page, the last edit was made on July 24, 2020, long before Turborepo was ever created. https://github.com/microsoft/lage/blob/master/docs/guide/scopes.md. 
As you can see by looking at the source for Lage’s Pipelines page, the last edit was made on August 16, 2020, long before Turborepo was ever created. https://github.com/microsoft/lage/blob/master/docs/guide/pipeline.md.

@jaredpalmer acknowledged the Pipeline design came from Lage on Twitter back in March, but hasn’t given proper attribution for the docs pages that were copied from Lage. https://twitter.com/jaredpalmer/status/1377617245510250496?s=20

<img width="629" alt="2021-03-31-kenneth_chau_jaredpalmer" src="https://user-images.githubusercontent.com/463703/146803061-dacf4142-48b3-4ce5-b22d-a86cb4175aed.png">


The Lage repository is MIT licensed, which can be found here: https://github.com/microsoft/lage/blob/master/LICENSE. Note the following excerpt from the MIT license: 

```
The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
```

For convenience, I’ve attached the text diff of the markdown files for both Turborepo and Lage, as well as screenshots of the pages on both sites.
Here is the Copyleaks report for the Pipelines page: https://copyleaks.com/education/report/dj88n4iptch6myn2/preview?key=ulrhw01ot1sqkiyk&viewMode=one-to-many&contentMode=html&sourcePage=1&suspectPage=1
Here is the Copyleaks report for the Scoped Tasks page: https://copyleaks.com/education/report/edkgued679mhw2kq/preview?key=v0bfr6qjy8qim9jg&viewMode=one-to-many&contentMode=html&sourcePage=1&suspectPage=1

If Turborepo has an agreement with Microsoft to use their intellectual property without attribution, please disregard this pull request. 

![pipeline-lage](https://user-images.githubusercontent.com/463703/146803183-495bd7b2-c2f8-4507-b09b-9b9632527005.png)
![pipeline-turborepo](https://user-images.githubusercontent.com/463703/146803191-38f98048-032b-4d79-97c2-42caaaaa266d.png)
![scopes-lage](https://user-images.githubusercontent.com/463703/146803198-dec4fde8-f1fe-4edc-a3b6-c5f389caccb0.png)
![scopes-turborepo](https://user-images.githubusercontent.com/463703/146803201-c37e687f-7906-4c98-b9ea-ff267fbc1808.png)
![pipeline-diff html](https://user-images.githubusercontent.com/463703/146803467-bf024111-f705-4c49-98fc-1b7d340f9c76.png)
![scoped-builds-diff html](https://user-images.githubusercontent.com/463703/146803483-c19c16bf-7cf6-43c2-b07a-f69a5118f69a.png)

