### PR TITLE
docs: Stop suggesting globs for whole directories in docs

### DIFF
--- a/docs/pages/blog/turbo-0-4-0.mdx
+++ b/docs/pages/blog/turbo-0-4-0.mdx
@@ -168,12 +168,12 @@ Building on the example from above, you can now set cache output conventions acr
     "pipeline": {
       "build": {
         // Cache anything in dist or .next directories emitted by a `build` command
-        "outputs": ["dist/**", ".next/**"]
+        "outputs": ["dist", ".next"]
         "dependsOn": ["^build"]
       },
       "test": {
         // Cache the test coverage report
-        "outputs": ["coverage/**"],
+        "outputs": ["coverage"],
         "dependsOn": ["lint", "build"]
       },
        "dev": {

--- a/docs/pages/docs/features/caching.mdx
+++ b/docs/pages/docs/features/caching.mdx
@@ -8,7 +8,7 @@ import Callout from "../../../components/callout";
 
 Unlike other tools you may have used, `turbo` can cache emitted files and logs of previously run commands. It does this so it can skip work that's already been done, yielding incredible time savings.
 
-By default, [`turbo run`](../reference/command-line-reference#turbo-run-task1-task2-1) considers any files emitted in the `dist/**` or `build/**` folders of a package task (defined in that package's `package.json` `scripts` object) to be cacheable. In addition, `turbo run` treats logs (`stderr` and`stdout`), which are automatically written to `.turbo/run-<command>.log`, as a cacheable artifact. By treating logs as artifacts, you can cache just about any command in your Turborepo.
+By default, [`turbo run`](../reference/command-line-reference#turbo-run-task1-task2-1) considers any files emitted in the `dist` or `build` folders of a package task (defined in that package's `package.json` `scripts` object) to be cacheable. In addition, `turbo run` treats logs (`stderr` and`stdout`), which are automatically written to `.turbo/run-<command>.log`, as a cacheable artifact. By treating logs as artifacts, you can cache just about any command in your Turborepo.
 
 ## Configuring Cache Outputs
 
@@ -21,7 +21,7 @@ To override the default cache folder behavior, pass an array of globs to a [`pip
   "turbo": {
     "pipeline": {
       "build": {
-        "outputs": ["dist/**", ".next/**"],
+        "outputs": ["dist", ".next"],
         "dependsOn": ["^build"]
       },
       "test": {

--- a/docs/pages/docs/getting-started.mdx
+++ b/docs/pages/docs/getting-started.mdx
@@ -79,7 +79,7 @@ Your pipeline both defines the way in which your NPM `package.json` scripts rela
     "pipeline": {
       "build": {
         "dependsOn": ["^build"],
-        "outputs": [".next/**"]
+        "outputs": [".next"]
       },
       "test": {
         "dependsOn": ["^build"],
@@ -98,8 +98,8 @@ Your pipeline both defines the way in which your NPM `package.json` scripts rela
 
 In the above example, the `build` and `test` tasks are dependent on their packages `dependencies` and `devDependencies` being built first, this is denoted with the `^` prefix.
 
-For each script in each workspace's `package.json`, Turborepo will cache files outputted to `dist/**` and `build/**` folders by default if an override isn't added. Using the [`outputs`](./features/caching#configuring-cache-outputs-1) array allows you to override the default cache folders,
-like in the example above, where the `.next/**` folder is selected to be the default cache folder for the `build` task. Turborepo will automatically record and cache logs to `.turbo/turbo-<script>.log` for you, so you don't ever need to specify that in the `outputs` array.
+For each script in each workspace's `package.json`, Turborepo will cache files outputted to `dist` and `build` folders by default if an override isn't added. Using the [`outputs`](./features/caching#configuring-cache-outputs-1) array allows you to override the default cache folders,
+like in the example above, where the `.next` folder is selected to be the default cache folder for the `build` task. Turborepo will automatically record and cache logs to `.turbo/turbo-<script>.log` for you, so you don't ever need to specify that in the `outputs` array.
 
 Finally, the `dev` task has its caching disabled using the `cache` key with a value of `false`.
 
@@ -116,9 +116,9 @@ Next, add `.turbo` to your `.gitignore` file. The CLI uses these folders for log
 Make sure that your task artifacts (the files you want to be cached) are also ignored. As a rule, any files/folder that you want cached should be gitignored.
 
 ```diff
-+ build/**
-+ dist/**
-+ .next/**
++ build
++ dist
++ .next
 ```
 
 ### Ensure workspaces are configured

--- a/docs/pages/docs/guides/migrate-from-lerna.mdx
+++ b/docs/pages/docs/guides/migrate-from-lerna.mdx
@@ -99,7 +99,7 @@ Alter `package.json` to use `turbo` for task running, but keep `lerna` for versi
 +   "pipeline": {
 +     "build": {
 +       "dependsOn": ["^build"],
-+       "outputs": ["dist/**"]
++       "outputs": ["dist"]
 +     },
 +     "test": {
 +       "outputs": []

--- a/docs/pages/docs/reference/command-line-reference.mdx
+++ b/docs/pages/docs/reference/command-line-reference.mdx
@@ -101,9 +101,9 @@ turbo run build test lint --graph=my-graph.html
   graph at the moment, even if that pipeline task does not actually exist in a
   given package. This has no impact on execution, it means that:
 
-  - the terminal output may overstate the number of packages in which a task is running.
-  - your dot viz graph may contain additional nodes that represents tasks that do not exist.
-</Callout>
+- the terminal output may overstate the number of packages in which a task is running.
+- your dot viz graph may contain additional nodes that represents tasks that do not exist.
+  </Callout>
 
 #### `--force`
 
@@ -128,12 +128,12 @@ You can also specify these in your `turbo` configuration as `globalDependencies`
 
 `type: string[]`
 
-Ignore **files or directories** from impacting scope. Uses glob patterns via [`multimatch`](https://github.com/sindresorhus/multimatch) under the hood.
+Ignore **files or directories** from impacting scope. Uses glob patterns
 
 ```
-turbo run build --ignore="apps/**/*"
-turbo run build --ignore="packages/**/*"
-turbo run build --ignore="packages/**/*" --ignore="\!/packages/not-this-one/**/*"
+turbo run build --ignore="apps/*"
+turbo run build --ignore="packages/*"
+turbo run build --ignore="packages/*" --ignore="\!/packages/not-this-one"
 ```
 
 ##### How multiple patterns work
@@ -214,7 +214,7 @@ turbo run dev --parallel --no-cache
 Specify/filter package(s)/apps to act as entry points for execution. Globs against package.json `name` field (and not the file system.)
 
 ```sh
-turbo run lint --scope="@example/**"
+turbo run lint --scope="@example/*"
 turbo run dev --parallel --scope="@example/a" --scope="@example/b" --no-cache --no-deps
 ```
 
@@ -269,7 +269,7 @@ You can also set the value of the current team by setting an environment variabl
 
 `type: string`
 
-To view CPU trace, outputs the trace to the given file,  use `go tool trace [file]`.
+To view CPU trace, outputs the trace to the given file, use `go tool trace [file]`.
 
 <Callout emoji="🚨">
   **Important**: The trace viewer doesn't work under Windows Subsystem for Linux.
@@ -301,10 +301,10 @@ To view CPU profile, outputs the profile to the given file, drop the file into [
   for native Windows and run using the command prompt instead.
 </Callout>
 
-
 ```sh
 turbo run build --cpuprofile="<cpu-profile-file-name>"
 ```
+
 #### `-v`, `-vv`, `-vvv`
 
 To sepecify log level, use `-v` for `Info`, `-vv` for `Debug` and `-vvv` for `Trace` flags.

--- a/docs/pages/docs/reference/configuration.mdx
+++ b/docs/pages/docs/reference/configuration.mdx
@@ -39,7 +39,7 @@ Each key in the `pipeline` object is the name of a task that can be executed by 
         "dependsOn": ["^build"]
       },
       "test": {
-        "outputs": ["coverage/**"],
+        "outputs": ["coverage"],
         "dependsOn": ["build"]
       },
       "dev": {
@@ -92,7 +92,7 @@ Items in `dependsOn` without `^` prefix, express the relationships between tasks
 
 `type: string[]`
 
-Defaults to `["dist/**", "build/**"]`. The set of glob patterns of a task's cacheable filesystem outputs.
+Defaults to `["dist", "build"]`. The set of glob patterns of a task's cacheable filesystem outputs.
 
 Note: `turbo` automatically logs `stderr`/`stdout` to `.turbo/run-<task>.log`. This file is _always_ treated as a cacheable artifact and never needs to be specified.
 
@@ -104,9 +104,9 @@ Passing an empty array can be used to tell `turbo` that a task is a side-effect 
 {
   "pipeline": {
     "build": {
-      // "Cache all files emitted to package's dist/** or .next
+      // "Cache all files emitted to package's dist or .next
       // directories by a `build` task"
-      "outputs": ["dist/**", ".next/**"],
+      "outputs": ["dist", ".next"],
       "dependsOn": ["^build"]
     },
     "test": {
@@ -117,7 +117,7 @@ Passing an empty array can be used to tell `turbo` that a task is a side-effect 
     },
     "test:ci": {
       // "Cache the coverage report of a `test:ci` command"
-      "outputs": ["coverage/**"],
+      "outputs": ["coverage"],
       "dependsOn": ["build"]
     },
     "dev": {


### PR DESCRIPTION
This removes most usage of `/**` in documentation. By removing this, we seen a small perf boost everywhere. 