### PR TITLE
Turn off no-html-link-for-pages eslint rule causing false warning

### DIFF
--- a/create-turbo/templates/_shared_ts/packages/config/eslint-preset.js
+++ b/create-turbo/templates/_shared_ts/packages/config/eslint-preset.js
@@ -5,4 +5,7 @@ module.exports = {
       rootDir: ["apps/*/", "packages/*/"],
     },
   },
+  rules: {
+    "no-html-link-for-pages": "off",
+  },
 };

--- a/examples/basic/packages/config/eslint-preset.js
+++ b/examples/basic/packages/config/eslint-preset.js
@@ -5,4 +5,7 @@ module.exports = {
       rootDir: ["apps/*/", "packages/*/"],
     },
   },
+  rules: {
+    "no-html-link-for-pages": "off",
+  },
 };

--- a/examples/design-system/packages/eslint-preset-acme/index.js
+++ b/examples/design-system/packages/eslint-preset-acme/index.js
@@ -5,4 +5,7 @@ module.exports = {
       rootDir: ["./apps/*/", "./packages/*/"],
     },
   },
+  rules: {
+    "no-html-link-for-pages": "off",
+  },
 };

--- a/examples/with-pnpm/packages/config/eslint-preset.js
+++ b/examples/with-pnpm/packages/config/eslint-preset.js
@@ -6,4 +6,7 @@ module.exports = {
       rootDir: ["apps/*/", "packages/*/"],
     },
   },
+  rules: {
+    "no-html-link-for-pages": "off",
+  },
 };


### PR DESCRIPTION
Turning this off prevents new turbo users getting eslint-config-next warning about incorrect or unspecified pages directory in the `ui` starter package