### PR TITLE
examples: bump next package version

### DIFF
--- a/create-turbo/templates/_shared_ts/apps/docs/package.json
+++ b/create-turbo/templates/_shared_ts/apps/docs/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "12.0.3",
+    "next": "12.0.7",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "ui": "*"

--- a/create-turbo/templates/_shared_ts/apps/web/package.json
+++ b/create-turbo/templates/_shared_ts/apps/web/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "12.0.3",
+    "next": "12.0.7",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "ui": "*"

--- a/create-turbo/templates/_shared_ts/packages/config/package.json
+++ b/create-turbo/templates/_shared_ts/packages/config/package.json
@@ -7,7 +7,7 @@
     "eslint-preset.js"
   ],
   "dependencies": {
-    "eslint-config-next": "^12.0.3",
+    "eslint-config-next": "^12.0.7",
     "eslint-config-prettier": "^8.3.0"
   }
 }

--- a/create-turbo/templates/pnpm/apps/docs/package.json
+++ b/create-turbo/templates/pnpm/apps/docs/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "12.0.3",
+    "next": "12.0.7",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "ui": "workspace:*"

--- a/create-turbo/templates/pnpm/apps/web/package.json
+++ b/create-turbo/templates/pnpm/apps/web/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "12.0.3",
+    "next": "12.0.7",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "ui": "workspace:*"

--- a/examples/basic/packages/config/package.json
+++ b/examples/basic/packages/config/package.json
@@ -7,7 +7,7 @@
     "eslint-preset.js"
   ],
   "dependencies": {
-    "eslint-config-next": "^12.0.3",
+    "eslint-config-next": "^12.0.7",
     "eslint-config-prettier": "^8.3.0"
   },
   "devDependencies": {

--- a/examples/with-pnpm/packages/config/package.json
+++ b/examples/with-pnpm/packages/config/package.json
@@ -7,7 +7,7 @@
     "eslint-preset.js"
   ],
   "dependencies": {
-    "eslint-config-next": "^12.0.3",
+    "eslint-config-next": "^12.0.7",
     "eslint-config-prettier": "^8.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This updates Next.js-related packages to the latest version in `create-turbo` and in `examples`. 

v12.0.3 has a [security vulnerability](https://github.com/vercel/next.js/releases/tag/v12.0.5) that is fixed in versions >= 12.0.5 of `next`. Within `create-turbo` and the `examples`, the `next` version is pinned to v12.0.3.

Thanks for taking the time to review this!