### PR TITLE
Fix yarn lockfile parsing on Windows

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -38,6 +38,6 @@ require (
 	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf // indirect
 	golang.org/x/text v0.3.6 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
-	gopkg.in/yaml.v2 v2.4.0
-	gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -148,5 +148,5 @@ gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c h1:grhR+C34yXImVGp7EzNk+DTIk+323eIUWOmEevy6bDo=
-gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/cli/internal/backends/nodejs/nodejs.go
+++ b/cli/internal/backends/nodejs/nodejs.go
@@ -7,7 +7,7 @@ import (
 	"turbo/internal/api"
 	"turbo/internal/fs"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // nodejsPatterns is the FilenamePatterns value for NodejsBackend.

--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -126,7 +126,7 @@ func WithGraph(rootpath string, config *config.Config) Option {
 		}
 
 		// this should go into the bacend abstraction
-		if c.Backend.Name == "nodejs-yarn" && !fs.CheckIfWindows() {
+		if c.Backend.Name == "nodejs-yarn" {
 			lockfile, err := fs.ReadLockfile(config.Cache.Dir)
 			if err != nil {
 				return fmt.Errorf("yarn.lock: %w", err)
@@ -154,7 +154,7 @@ func WithGraph(rootpath string, config *config.Config) Option {
 				globalDeps.Add(val)
 			}
 		}
-		if c.Backend.Name != "nodejs-yarn" || fs.CheckIfWindows() {
+		if c.Backend.Name != "nodejs-yarn" {
 			// If we are not in Yarn, add the specfile and lockfile to global deps
 			globalDeps.Add(c.Backend.Specfile)
 			globalDeps.Add(c.Backend.Lockfile)
@@ -296,7 +296,7 @@ func (c *Context) ResolveWorkspaceRootDeps() (*fs.PackageJSON, error) {
 	for dep, version := range pkg.PeerDependencies {
 		pkg.UnresolvedExternalDeps[dep] = version
 	}
-	if c.Backend.Name == "nodejs-yarn" && !fs.CheckIfWindows() {
+	if c.Backend.Name == "nodejs-yarn" {
 		pkg.SubLockfile = make(fs.YarnLockfile)
 		c.ResolveDepGraph(&lockfileWg, pkg.UnresolvedExternalDeps, depSet, seen, pkg)
 		lockfileWg.Wait()
@@ -441,7 +441,7 @@ func (c *Context) parsePackageJSON(buildFilePath string) error {
 }
 
 func (c *Context) ResolveDepGraph(wg *sync.WaitGroup, unresolvedDirectDeps map[string]string, resolveDepsSet mapset.Set, seen mapset.Set, pkg *fs.PackageJSON) {
-	if fs.CheckIfWindows() || c.Backend.Name != "nodejs-yarn" {
+	if c.Backend.Name != "nodejs-yarn" {
 		return
 	}
 	for directDepName, unresolvedVersion := range unresolvedDirectDeps {

--- a/cli/internal/fs/lockfile.go
+++ b/cli/internal/fs/lockfile.go
@@ -14,7 +14,7 @@ import (
 )
 
 // ReadLockfile will read `yarn.lock` into memory (either from the cache or fresh)
-func ReadLockfile(cacheDir string) (*YarnLockfile, error) {.
+func ReadLockfile(cacheDir string) (*YarnLockfile, error) {
 	var lockfile YarnLockfile
 	var prettyLockFile = YarnLockfile{}
 	hash, err := HashFile("yarn.lock")

--- a/cli/internal/fs/lockfile_windows.go
+++ b/cli/internal/fs/lockfile_windows.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build windows
+// +build windows
 
 package fs
 
@@ -14,7 +14,7 @@ import (
 )
 
 // ReadLockfile will read `yarn.lock` into memory (either from the cache or fresh)
-func ReadLockfile(cacheDir string) (*YarnLockfile, error) {.
+func ReadLockfile(cacheDir string) (*YarnLockfile, error) {
 	var lockfile YarnLockfile
 	var prettyLockFile = YarnLockfile{}
 	hash, err := HashFile("yarn.lock")
@@ -27,10 +27,10 @@ func ReadLockfile(cacheDir string) (*YarnLockfile, error) {.
 		if err != nil {
 			return nil, fmt.Errorf("reading yarn.lock: %w", err)
 		}
-		lines := strings.Split(string(contentsB), "\n")
+		lines := strings.Split(strings.TrimRight(string(contentsB), "\r\n"), "\r\n")
 		r := regexp.MustCompile(`^[\w"]`)
 		double := regexp.MustCompile(`\:\"\:`)
-		l := regexp.MustCompile("\"|:\n$")
+		l := regexp.MustCompile("\"|:\r\n$")
 		o := regexp.MustCompile(`\"\s\"`)
 		// deals with colons
 		// integrity sha-... -> integrity: sha-...
@@ -45,7 +45,7 @@ func ReadLockfile(cacheDir string) (*YarnLockfile, error) {.
 				lines[i] = double.ReplaceAllString(first, "\":")
 			}
 		}
-		output := o.ReplaceAllString(strings.Join(lines, "\n"), "\": \"")
+		output := o.ReplaceAllString(strings.Join(lines, "\r\n"), "\": \"")
 
 		next := a.ReplaceAllStringFunc(output, func(m string) string {
 			parts := a.FindStringSubmatch(m)

--- a/cli/internal/fs/yarn_lockfile.go
+++ b/cli/internal/fs/yarn_lockfile.go
@@ -1,0 +1,14 @@
+package fs
+
+type LockfileEntry struct {
+	// resolved version for the particular entry based on the provided semver revision
+	Version   string `yaml:"version"`
+	Resolved  string `yaml:"resolved"`
+	Integrity string `yaml:"integrity"`
+	// the list of unresolved modules and revisions (e.g. type-detect : ^4.0.0)
+	Dependencies map[string]string `yaml:"dependencies,omitempty"`
+	// the list of unresolved modules and revisions (e.g. type-detect : ^4.0.0)
+	OptionalDependencies map[string]string `yaml:"optionalDependencies,omitempty"`
+}
+
+type YarnLockfile map[string]*LockfileEntry

--- a/cli/internal/prune/prune.go
+++ b/cli/internal/prune/prune.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/mitchellh/cli"
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // PruneCommand is a Command implementation that tells Turbo to run a task

--- a/cli/package.json
+++ b/cli/package.json
@@ -4,10 +4,13 @@
   "version": "0.0.0",
   "scripts": {
     "clean": "make clean",
-    "build": "CGO_ENABLED=0 go build ./cmd/turbo",
+    "build": "cross-env CGO_ENABLED=0 go build ./cmd/turbo",
     "test": "go test -race ./internal/...",
     "publish": "make publish-all",
     "format": "go fmt ./cmd/... ./internal/...",
     "lint": "go vet ./cmd/... ./internal/..."
+  },
+  "devDependencies": {
+    "cross-env": "^7.0.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2634,6 +2634,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -2643,7 +2650,7 @@ cross-spawn@^5.0.1:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
Fix #252 #145

Finally got a Windows machine for work. This PR fixes a handful of Windows bugs:

- Fixes yarn based build command w/ `cross-env` package
- Fixes "parsing" (i.e. regexing yarn.lock SYML into YAML with correct line endings)
- Removes hacky `CheckIfWindows` 
- Windows users should now have same hashes as non-windows users