### PR TITLE
chore: sync the versions of `eslint` to the same 7.32.0 version

### DIFF
--- a/examples/basic/apps/docs/package.json
+++ b/examples/basic/apps/docs/package.json
@@ -18,7 +18,7 @@
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
     "config": "*",
-    "eslint": "^7.5.0",
+    "eslint": "^7.32.0",
     "next-transpile-modules": "^9.0.0",
     "tsconfig": "*",
     "typescript": "^4.5.3"

--- a/examples/basic/apps/web/package.json
+++ b/examples/basic/apps/web/package.json
@@ -18,7 +18,7 @@
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
     "config": "*",
-    "eslint": "^7.5.0",
+    "eslint": "^7.32.0",
     "next-transpile-modules": "^9.0.0",
     "tsconfig": "*",
     "typescript": "^4.5.3"

--- a/examples/kitchen-sink/apps/api/package.json
+++ b/examples/kitchen-sink/apps/api/package.json
@@ -22,7 +22,7 @@
     "nodemon": "^2.0.15",
     "scripts": "*",
     "jest": "^26.6.3",
-    "eslint": "^7.5.0",
+    "eslint": "^7.32.0",
     "supertest": "^6.1.3",
     "tsconfig": "*",
     "typescript": "^4.5.3"

--- a/examples/kitchen-sink/apps/storefront/package.json
+++ b/examples/kitchen-sink/apps/storefront/package.json
@@ -22,7 +22,7 @@
     "@types/react-dom": "^17.0.8",
     "scripts": "*",
     "jest": "^26.6.3",
-    "eslint": "^7.5.0",
+    "eslint": "^7.32.0",
     "tsconfig": "*",
     "typescript": "^4.5.3"
   }

--- a/examples/kitchen-sink/packages/logger/package.json
+++ b/examples/kitchen-sink/packages/logger/package.json
@@ -19,7 +19,7 @@
     "@types/jest": "^26.0.22",
     "scripts": "*",
     "jest": "^26.6.3",
-    "eslint": "^7.5.0",
+    "eslint": "^7.32.0",
     "tsconfig": "*",
     "typescript": "^4.5.3"
   },

--- a/examples/kitchen-sink/packages/ui/package.json
+++ b/examples/kitchen-sink/packages/ui/package.json
@@ -25,7 +25,7 @@
     "@types/jest": "^26.0.22",
     "scripts": "*",
     "jest": "^26.6.3",
-    "eslint": "^7.5.0",
+    "eslint": "^7.32.0",
     "tsup": "^5.10.1",
     "typescript": "^4.5.3"
   },

--- a/examples/with-pnpm/apps/docs/package.json
+++ b/examples/with-pnpm/apps/docs/package.json
@@ -18,7 +18,7 @@
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
     "config": "workspace:*",
-    "eslint": "^7.5.0",
+    "eslint": "^7.32.0",
     "next-transpile-modules": "^9.0.0",
     "tsconfig": "workspace:*",
     "typescript": "^4.5.3"

--- a/examples/with-pnpm/apps/web/package.json
+++ b/examples/with-pnpm/apps/web/package.json
@@ -18,7 +18,7 @@
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
     "config": "workspace:*",
-    "eslint": "^7.5.0",
+    "eslint": "^7.32.0",
     "next-transpile-modules": "^9.0.0",
     "tsconfig": "workspace:*",
     "typescript": "^4.5.3"


### PR DESCRIPTION
Update the version of `eslint` to the same version everywhere in the examples