### PR TITLE
docs: fix typo in migrate-from-lerna.mdx

### DIFF
--- a/docs/pages/docs/guides/migrate-from-lerna.mdx
+++ b/docs/pages/docs/guides/migrate-from-lerna.mdx
@@ -27,7 +27,7 @@ The above may not not look like much. But imagine that A's `build` task takes 20
 
 ### Package Publishing, Versioning, and Changelog Generation
 
-Lerna can version and publish packages to NPM registries as well as create changelogs. It's extremely good at this, especially for releasing canary pre-releases. While Turborepo may eventually tackle these features, at the time of writing, it is not a high priority goal (we suggest using using [Changesets](https://github.com/changesets/changesets) in the meantime). If Changesets isn't for you, and you want to stick with Lerna's publish flow, you can use Lerna and Turborepo together.
+Lerna can version and publish packages to NPM registries as well as create changelogs. It's extremely good at this, especially for releasing canary pre-releases. While Turborepo may eventually tackle these features, at the time of writing, it is not a high priority goal (we suggest using [Changesets](https://github.com/changesets/changesets) in the meantime). If Changesets isn't for you, and you want to stick with Lerna's publish flow, you can use Lerna and Turborepo together.
 
 ## Example migration
 


### PR DESCRIPTION
Removes an extra "using" in the docs