### PR TITLE
Refactor log streaming

### DIFF
--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	ROOT_NODE_NAME   = "___ROOT___"
-	GLOBAL_CACHE_KEY = "hello"
+	GLOBAL_CACHE_KEY = "snozzberries"
 )
 
 // A BuildResultStatus represents the status of a target when we log a build result.

--- a/cli/internal/ui/ui.go
+++ b/cli/internal/ui/ui.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/fatih/color"
@@ -12,6 +13,7 @@ import (
 )
 
 const ESC = 27
+const ansiEscapeStr = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"
 
 var IsTTY = isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
 var IsCI = os.Getenv("CI") == "true" || os.Getenv("BUILD_NUMBER") == "true" || os.Getenv("TEAMCITY_VERSION") != ""
@@ -25,6 +27,15 @@ var clear = fmt.Sprintf("%c[%dA%c[2K", ESC, 1, ESC)
 
 func ClearLines(writer io.Writer, count int) {
 	_, _ = fmt.Fprint(writer, strings.Repeat(clear, count))
+}
+
+var ansiRegex = regexp.MustCompile(ansiEscapeStr)
+
+func StripAnsi(str string) string {
+	if !IsTTY {
+		return ansiRegex.ReplaceAllString(str, "")
+	}
+	return str
 }
 
 // Dim prints out dimmed text


### PR DESCRIPTION
Fix #422 #374 #452 #453

- Refactor log streaming in to move away from `io.MultiReader` which was trying to concatenate streams, and failing when commands wrote directly to stderr. This PR inverts log steam logic to use `io.MultiWriter`, but only when actually caching, as well as new `logstreamer` primitive. 
- Logs now _include_ their own `cache hit, replaying output [hash]` line
    - Subsequently, we change the global internal cache key to force new artifacts
- Logs store colored output now
- Ansi-codes are stripped in non-TTY environments


The result of the last 3 bullets are a small perf gain since there is less work to be done when reading logs (colored prefixing isn't cheap). 



