### PR TITLE
fix: `monroepo` to `monorepo` typo

### DIFF
--- a/docs/pages/docs/acknowledgments.mdx
+++ b/docs/pages/docs/acknowledgments.mdx
@@ -12,7 +12,7 @@ Today, Turborepo has dedicated full-time team working on it as well as a growing
 
 At [Vercel](https://vercel.com), we believe deeply in the open source movement and in the power of open collaboration. To that end, it's important to provide meaningful attribution to the projects and people that inspire(d) us and our work.
 
-We'd like to make a special shoutout to other build systems, monroepo tools, and prior art:
+We'd like to make a special shoutout to other build systems, monorepo tools, and prior art:
 
 - Bazel - https://bazel.build
 - Buck - https://buck.build


### PR DESCRIPTION
Small typo