### PR TITLE
fix: error when workspaces are not defined

### DIFF
--- a/cli/internal/backends/nodejs/nodejs.go
+++ b/cli/internal/backends/nodejs/nodejs.go
@@ -23,6 +23,9 @@ var NodejsYarnBackend = api.LanguageBackend{
 		if err != nil {
 			return nil, fmt.Errorf("package.json: %w", err)
 		}
+		if len(pkg.Workspaces) == 0 {
+			return nil, fmt.Errorf("package.json: no workspaces found. Turborepo requires Yarn workspaces to be defined in the root package.json")
+		}
 		return pkg.Workspaces, nil
 	},
 	GetPackageDir: func() string {
@@ -53,6 +56,11 @@ var NodejsPnpmBackend = api.LanguageBackend{
 		if err := yaml.Unmarshal(bytes, &pnpmWorkspaces); err != nil {
 			return nil, fmt.Errorf("pnpm-workspace.yaml: %w", err)
 		}
+
+		if len(pnpmWorkspaces.Packages) == 0 {
+			return nil, fmt.Errorf("pnpm-workspace.yaml: no packages found. Turborepo requires PNPM workspaces and thus packages to be defined in the root pnpm-workspace.yaml")
+		}
+
 		return pnpmWorkspaces.Packages, nil
 	},
 	GetPackageDir: func() string {
@@ -72,6 +80,9 @@ var NodejsNpmBackend = api.LanguageBackend{
 		pkg, err := fs.ReadPackageJSON("package.json")
 		if err != nil {
 			return nil, fmt.Errorf("package.json: %w", err)
+		}
+		if len(pkg.Workspaces) == 0 {
+			return nil, fmt.Errorf("package.json: no workspaces found. Turborepo requires NPM workspaces to be defined in the root package.json")
 		}
 		return pkg.Workspaces, nil
 	},

--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -142,11 +142,9 @@ func WithGraph(rootpath string, config *config.Config) Option {
 		c.RootPackageJSON = pkg
 
 		spaces, err := c.Backend.GetWorkspaceGlobs()
-		if (spaces == nil) {
-			return fmt.Errorf("Couldn't find workspaces defined for %s", c.Backend.Name)
-		}
+
 		if err != nil {
-			return err
+			return fmt.Errorf("could not detect workspaces: %w", err)
 		}
 
 		// Calculate the global hash

--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -49,7 +49,6 @@ type Context struct {
 	TraceFilePath    string
 	Lockfile         *fs.YarnLockfile
 	SCC              [][]dag.Vertex
-	PendingTaskNodes dag.Set
 	Targets          []string
 	Backend          *api.LanguageBackend
 	// Used to arbitrate access to the graph. We parallelise most build operations
@@ -115,7 +114,6 @@ func WithGraph(rootpath string, config *config.Config) Option {
 		c.PackageInfos = make(map[interface{}]*fs.PackageJSON)
 		c.ColorCache = NewColorCache()
 		c.RootNode = ROOT_NODE_NAME
-		c.PendingTaskNodes = make(dag.Set)
 		// Need to ALWAYS have a root node, might as well do it now
 		c.TaskGraph.Add(ROOT_NODE_NAME)
 

--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -139,6 +139,9 @@ func WithGraph(rootpath string, config *config.Config) Option {
 		c.RootPackageJSON = pkg
 
 		spaces, err := c.Backend.GetWorkspaceGlobs()
+		if (spaces == nil) {
+			return fmt.Errorf("Couldn't find workspaces defined for %s", c.Backend.Name)
+		}
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The workspaces are required for turborepo to work, but lack of them results in unfriendly error message that does not explain that. The PR may need some changes, that's just a quick fix you could use.