### PR TITLE
fix kitchen-sink test #466

### DIFF
--- a/examples/kitchen-sink/packages/ui/tsconfig.json
+++ b/examples/kitchen-sink/packages/ui/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "lib": ["dom", "ES2015"],
+  },
   "extends": "tsconfig/react-library.json",
   "include": ["."],
   "exclude": ["dist", "build", "node_modules"]


### PR DESCRIPTION
Fix #466

- add `dom` to `tsconfig.compilerOptions`.