### PR TITLE
docs: add missing flag for pnpm install command

### DIFF
--- a/docs/pages/docs/getting-started.mdx
+++ b/docs/pages/docs/getting-started.mdx
@@ -51,7 +51,7 @@ npm install turbo -D
 ### PNPM
 
 ```bash
-pnpm add turbo -D
+pnpm add turbo -w -D
 ```
 
 The `turbo` package is a little shell that will install the proper `@turborepo/*` packages.


### PR DESCRIPTION
The current documentation to install Turborepo with pnpm results in an error, because of a safeguard to prevent unwanted dependencies in the workspace root:

<img width="1440" alt="Screen Shot 2022-01-07 at 9 15 02 pm" src="https://user-images.githubusercontent.com/772570/148529017-7596000c-29ee-4fa3-851c-536e05318451.png">

This is easily solved with the `-w` flag, which as far as I understand is equivalent to Yarn's `-W` flag.