### PR TITLE
fix: Move runOptions stream checks before the `for` loop to prevent cpu load

### DIFF
--- a/cli/internal/run/run_state.go
+++ b/cli/internal/run/run_state.go
@@ -200,6 +200,9 @@ func (r *RunState) add(result *RunResult, previous string, active bool) {
 }
 
 func (r *RunState) Listen(Ui cli.Ui, startAt time.Time) {
+	if r.runOptions.stream {
+		return
+	}
 	lineBuffer := 10
 	go func(r *RunState, Ui cli.Ui) {
 		z := r
@@ -207,26 +210,22 @@ func (r *RunState) Listen(Ui cli.Ui, startAt time.Time) {
 		for {
 			select {
 			case outcome := <-z.done:
-				if !r.runOptions.stream {
-					if outcome == "done" {
-						if i != 0 {
-							cursor.EraseLinesAbove(os.Stdout, lineBuffer+2)
-						}
-					} else {
-						if i != 0 {
-							cursor.EraseLinesAbove(os.Stdout, lineBuffer+2)
-						}
-						z.Render(Ui, startAt, i, lineBuffer)
+				if outcome == "done" {
+					if i != 0 {
+						cursor.EraseLinesAbove(os.Stdout, lineBuffer+2)
 					}
-				}
-			case <-z.ticker.C:
-				if !r.runOptions.stream {
+				} else {
 					if i != 0 {
 						cursor.EraseLinesAbove(os.Stdout, lineBuffer+2)
 					}
 					z.Render(Ui, startAt, i, lineBuffer)
-					i++
 				}
+			case <-z.ticker.C:
+				if i != 0 {
+					cursor.EraseLinesAbove(os.Stdout, lineBuffer+2)
+				}
+				z.Render(Ui, startAt, i, lineBuffer)
+				i++
 			default:
 				continue
 			}


### PR DESCRIPTION
`runOptions.stream` is now `true` by default, so `Listen` now performs
a lot of empty runs, causing cpu load (one core having 100% load all the time).

This fix prevents the overload by never running the loop if `stream` is set
to `true`, as all cases in the loop relied on it being false.

I left a bunch of debugging notes here: https://github.com/vercel/turborepo/issues/205#issuecomment-1008337702

Should solve these two issues:

Fix https://github.com/vercel/turborepo/issues/205
Fix https://github.com/vercel/turborepo/issues/521