### PR TITLE
fix: handle dead symlinks in walk

### DIFF
--- a/cli/internal/fs/copy_file.go
+++ b/cli/internal/fs/copy_file.go
@@ -76,7 +76,11 @@ func WalkMode(rootPath string, callback func(name string, isDir bool, mode os.Fi
 			if isDirLike, err := info.IsDirOrSymlinkToDir(); err == nil {
 				return callback(name, isDirLike, info.ModeType())
 			} else {
-				return err
+				// Skip running callback on "dead" symlink (symlink to directory that doesn't exist)
+				if err, ok := err.(*os.PathError); !ok {
+					return err
+				}
+				return nil
 			}
 		},
 		Unsorted:            true,


### PR DESCRIPTION
Fixes  #549

The issue is due to an unhandled error bubbling in the case where a symlink exists but the target has been deleted.

Two other things to note here, which may just show my naiveté w Go (this is my first project working with it):
1. I am unsure if there is a standard/best practice for error handling here. Seems errors can bubble/disappear really easily right now
2. A fix like this would benefit from a regression test, but I am not too sure how the testing in this project is handled. I think even a small doc on that would be valuable. I am happy to help put that together or contribute.