### PR TITLE
Fix syml/yaml lockfile indentation in turbo prune

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -137,5 +137,3 @@ jobs:
       - name: Check examples
         shell: bash
         run: ./scripts/run-examples.sh
-        env:
-          TURBO_BINARY_PATH: ./cli/turbo

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -137,3 +137,5 @@ jobs:
       - name: Check examples
         shell: bash
         run: ./scripts/run-examples.sh
+        env:
+          TURBO_BINARY_PATH: ./cli/turbo

--- a/scripts/run-examples.sh
+++ b/scripts/run-examples.sh
@@ -13,6 +13,8 @@ if [ -f ".eslintrc.js" ]; then
   mv .eslintrc.js .eslintrc.js.bak
 fi
 
+echo "'env:\n\tTURBO_BINARY_PATH: $TURBO_BINARY_PATH'" > examples/.yarnrc;
+
 function cleanup {
     rm -rf node_modules
     rm -rf apps/*/node_modules
@@ -141,3 +143,5 @@ if [[ ! -z $(git status -s | grep -v package.json) ]];then
   git status
   exit 1
 fi
+
+rm -rf examples/.yarnrc;


### PR DESCRIPTION
Fixes #503 

Sets correct indentation of generated yarn.lock from `turbo prune`. This fixes a regression from <1.0 and re-enables `yarn install --frozen-lockfile` flag to work from within a pruned subset