### PR TITLE
fix: warn when no packageManager

### DIFF
--- a/cli/internal/backends/nodejs/nodejs.go
+++ b/cli/internal/backends/nodejs/nodejs.go
@@ -53,7 +53,7 @@ var NodejsYarnBackend = api.LanguageBackend{
 				return true, nil
 			}
 		} else {
-			log.Println("[WARNING] Did not find \"packageManager\" in your package.json. Please run \"npx @turbo/migrate add-package-manager\"")
+			log.Println("[WARNING] Did not find \"packageManager\" in your package.json. Please run \"npx @turbo/codemod add-package-manager\"")
 
 			specfileExists := fs.FileExists(filepath.Join(cwd, backend.Specfile))
 			lockfileExists := fs.FileExists(filepath.Join(cwd, backend.Lockfile))

--- a/cli/internal/backends/nodejs/nodejs.go
+++ b/cli/internal/backends/nodejs/nodejs.go
@@ -184,7 +184,7 @@ var NodejsPnpmBackend = api.LanguageBackend{
 				return true, nil
 			}
 		} else {
-			log.Println("[WARNING] Did not find \"packageManager\" in your package.json. Please run \"npx @turbo/migrate add-package-manager\"")
+			log.Println("[WARNING] Did not find \"packageManager\" in your package.json. Please run \"npx @turbo/codemod add-package-manager\"")
 
 			specfileExists := fs.FileExists(filepath.Join(cwd, backend.Specfile))
 			lockfileExists := fs.FileExists(filepath.Join(cwd, backend.Lockfile))

--- a/cli/internal/backends/nodejs/nodejs.go
+++ b/cli/internal/backends/nodejs/nodejs.go
@@ -227,7 +227,7 @@ var NodejsNpmBackend = api.LanguageBackend{
 				return true, nil
 			}
 		} else {
-			log.Println("[WARNING] Did not find \"packageManager\" in your package.json. Please run \"npx @turbo/migrate add-package-manager\"")
+			log.Println("[WARNING] Did not find \"packageManager\" in your package.json. Please run \"npx @turbo/codemod add-package-manager\"")
 
 			specfileExists := fs.FileExists(filepath.Join(cwd, backend.Specfile))
 			lockfileExists := fs.FileExists(filepath.Join(cwd, backend.Lockfile))

--- a/cli/internal/backends/nodejs/nodejs.go
+++ b/cli/internal/backends/nodejs/nodejs.go
@@ -3,6 +3,7 @@ package nodejs
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"path/filepath"
 	"turbo/internal/api"
 	"turbo/internal/fs"
@@ -52,6 +53,8 @@ var NodejsYarnBackend = api.LanguageBackend{
 				return true, nil
 			}
 		} else {
+			log.Println("[WARNING] Did not find \"packageManager\" in your package.json. Please run \"npx @turbo/migrate add-package-manager\"")
+
 			specfileExists := fs.FileExists(filepath.Join(cwd, backend.Specfile))
 			lockfileExists := fs.FileExists(filepath.Join(cwd, backend.Lockfile))
 
@@ -114,6 +117,8 @@ var NodejsBerryBackend = api.LanguageBackend{
 				return true, nil
 			}
 		} else {
+			log.Println("[WARNING] Did not find \"packageManager\" in your package.json. Please set the \"packageManager\" field to your package.json")
+
 			specfileExists := fs.FileExists(filepath.Join(cwd, backend.Specfile))
 			lockfileExists := fs.FileExists(filepath.Join(cwd, backend.Lockfile))
 
@@ -179,6 +184,8 @@ var NodejsPnpmBackend = api.LanguageBackend{
 				return true, nil
 			}
 		} else {
+			log.Println("[WARNING] Did not find \"packageManager\" in your package.json. Please run \"npx @turbo/migrate add-package-manager\"")
+
 			specfileExists := fs.FileExists(filepath.Join(cwd, backend.Specfile))
 			lockfileExists := fs.FileExists(filepath.Join(cwd, backend.Lockfile))
 
@@ -220,6 +227,8 @@ var NodejsNpmBackend = api.LanguageBackend{
 				return true, nil
 			}
 		} else {
+			log.Println("[WARNING] Did not find \"packageManager\" in your package.json. Please run \"npx @turbo/migrate add-package-manager\"")
+
 			specfileExists := fs.FileExists(filepath.Join(cwd, backend.Specfile))
 			lockfileExists := fs.FileExists(filepath.Join(cwd, backend.Lockfile))
 

--- a/cli/internal/backends/nodejs/nodejs.go
+++ b/cli/internal/backends/nodejs/nodejs.go
@@ -3,6 +3,7 @@ package nodejs
 import (
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 	"turbo/internal/api"
 	"turbo/internal/fs"
 	"turbo/internal/util"
@@ -42,12 +43,24 @@ var NodejsYarnBackend = api.LanguageBackend{
 				return false, nil
 			}
 
-			isBerry, err := util.IsBerry(cwd, version)
+			isBerry, err := util.IsBerry(cwd, version, true)
 			if err != nil {
 				return false, fmt.Errorf("could not determine yarn version (v1 or berry): %w", err)
 			}
 
 			if !isBerry {
+				return true, nil
+			}
+		} else {
+			specfileExists := fs.FileExists(filepath.Join(cwd, backend.Specfile))
+			lockfileExists := fs.FileExists(filepath.Join(cwd, backend.Lockfile))
+
+			isBerry, err := util.IsBerry(cwd, "", false)
+			if err != nil {
+				return false, fmt.Errorf("could not check if yarn is berry: %w", err)
+			}
+
+			if specfileExists && lockfileExists && !isBerry {
 				return true, nil
 			}
 		}
@@ -85,7 +98,7 @@ var NodejsBerryBackend = api.LanguageBackend{
 				return false, nil
 			}
 
-			isBerry, err := util.IsBerry(cwd, version)
+			isBerry, err := util.IsBerry(cwd, version, true)
 			if err != nil {
 				return false, fmt.Errorf("could not determine yarn version (v1 or berry): %w", err)
 			}
@@ -96,6 +109,25 @@ var NodejsBerryBackend = api.LanguageBackend{
 					return false, fmt.Errorf("could not determine if yarn is using `nodeLinker: node-modules`: %w", err)
 				} else if !isNMLinker {
 					return false, fmt.Errorf("only yarn v2/v3 with `nodeLinker: node-modules` is supported at this time")
+				}
+
+				return true, nil
+			}
+		} else {
+			specfileExists := fs.FileExists(filepath.Join(cwd, backend.Specfile))
+			lockfileExists := fs.FileExists(filepath.Join(cwd, backend.Lockfile))
+
+			isBerry, err := util.IsBerry(cwd, "", false)
+			if err != nil {
+				return false, fmt.Errorf("could not check if yarn is berry: %w", err)
+			}
+
+			if specfileExists && lockfileExists && isBerry {
+				isNMLinker, err := util.IsNMLinker(cwd)
+				if err != nil {
+					return false, fmt.Errorf("could not check if yarn is using nm-linker: %w", err)
+				} else if !isNMLinker {
+					return false, fmt.Errorf("only yarn nm-linker is supported")
 				}
 
 				return true, nil
@@ -139,11 +171,18 @@ var NodejsPnpmBackend = api.LanguageBackend{
 	GetRunCommand: func() []string {
 		return []string{"pnpm", "run"}
 	},
-	Detect: func(_ string, pkg *fs.PackageJSON, backend *api.LanguageBackend) (bool, error) {
+	Detect: func(cwd string, pkg *fs.PackageJSON, backend *api.LanguageBackend) (bool, error) {
 		if pkg.PackageManager != "" {
 			packageManager, _ := util.GetPackageManagerAndVersion(pkg.PackageManager)
 
 			if packageManager == "pnpm" {
+				return true, nil
+			}
+		} else {
+			specfileExists := fs.FileExists(filepath.Join(cwd, backend.Specfile))
+			lockfileExists := fs.FileExists(filepath.Join(cwd, backend.Lockfile))
+
+			if specfileExists && lockfileExists {
 				return true, nil
 			}
 		}
@@ -173,11 +212,18 @@ var NodejsNpmBackend = api.LanguageBackend{
 	GetRunCommand: func() []string {
 		return []string{"npm", "run"}
 	},
-	Detect: func(_ string, pkg *fs.PackageJSON, backend *api.LanguageBackend) (bool, error) {
+	Detect: func(cwd string, pkg *fs.PackageJSON, backend *api.LanguageBackend) (bool, error) {
 		if pkg.PackageManager != "" {
 			packageManager, _ := util.GetPackageManagerAndVersion(pkg.PackageManager)
 
 			if packageManager == "npm" {
+				return true, nil
+			}
+		} else {
+			specfileExists := fs.FileExists(filepath.Join(cwd, backend.Specfile))
+			lockfileExists := fs.FileExists(filepath.Join(cwd, backend.Lockfile))
+
+			if specfileExists && lockfileExists {
 				return true, nil
 			}
 		}


### PR DESCRIPTION
implements https://github.com/vercel/turborepo/pull/544#issuecomment-1013244988.

## What this PR brings:
This PR logs a warning when `packageManager` is not set and falls back as per https://github.com/vercel/turborepo/pull/544#issuecomment-1013244988.
