### PR TITLE
fix: conditionally set arch when installing hyperfine

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,4 +20,5 @@ RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/
 RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g vercel yarn yalc pnpm nodemon" 2>&1
 
 # Add hyperfine, a usefule benchmarking tool
-RUN wget https://github.com/sharkdp/hyperfine/releases/download/v1.12.0/hyperfine_1.12.0_arm64.deb && dpkg -i hyperfine_1.12.0_arm64.deb
+RUN dpkgArch="$(dpkg --print-architecture)"; \
+    wget "https://github.com/sharkdp/hyperfine/releases/download/v1.12.0/hyperfine_1.12.0_${dpkgArch}.deb" && dpkg -i "hyperfine_1.12.0_${dpkgArch}.deb"


### PR DESCRIPTION
When running a dev container on a non arm64/Apple Silicon machine I got the following:

```sh
...
#7 0.924 2022-01-21 21:52:15 (7.02 MB/s) - 'hyperfine_1.12.0_arm64.deb' saved [553772/553772]
#7 0.924 
#7 0.938 dpkg: error processing archive hyperfine_1.12.0_arm64.deb (--install):
#7 0.938  package architecture (arm64) does not match system (amd64)
#7 0.944 Errors were encountered while pr
[2022-01-21T21:52:15.716Z] ocessing:
#7 0.944  hyperfine_1.12.0_arm64.deb
...
```

This PR will account for some architectures other than `arm64` (e.g. `amd64`)

See also: https://stackoverflow.com/a/58222507

_note:_ for architectures other than `arm64`, `amd64`, `armhf` or `i686` the install will still fail, so maybe we want a smarter check here. 
