### PR TITLE
docs(typo): corrects "sepecify"

### DIFF
--- a/docs/pages/docs/reference/command-line-reference.mdx
+++ b/docs/pages/docs/reference/command-line-reference.mdx
@@ -307,7 +307,7 @@ turbo run build --cpuprofile="<cpu-profile-file-name>"
 ```
 #### `-v`, `-vv`, `-vvv`
 
-To sepecify log level, use `-v` for `Info`, `-vv` for `Debug` and `-vvv` for `Trace` flags.
+To specify log level, use `-v` for `Info`, `-vv` for `Debug` and `-vvv` for `Trace` flags.
 
 ```sh
 turbo run build -v


### PR DESCRIPTION
This PR corrects a minor typo
- `sepecify` => `specify`