### PR TITLE
docs: consolidate install commands

### DIFF
--- a/docs/pages/docs/getting-started.mdx
+++ b/docs/pages/docs/getting-started.mdx
@@ -39,7 +39,7 @@ Add `turbo` as a development dependency in the root of your project.
 ### Yarn
 
 ```bash
-yarn add turbo -W --dev
+yarn add turbo -DW
 ```
 
 ### NPM
@@ -51,7 +51,7 @@ npm install turbo -D
 ### PNPM
 
 ```bash
-pnpm add turbo -w -D
+pnpm add turbo -DW
 ```
 
 The `turbo` package is a little shell that will install the proper `@turborepo/*` packages.


### PR DESCRIPTION
This PR aims to consolidate install commands across package manager examples to use the shorthand syntax.

While [pnpm's docs](https://pnpm.io/cli/add#--ignore-workspace-root-check--w) are confusing for workspace root installs, it accepts a capital W as the `workspace-root` flag

```
> pnpm add -h
# ...
-w, --workspace-root                Run the command on the root workspace project
```