### PR TITLE
Set packageManager in create-turbo before install

### DIFF
--- a/create-turbo/src/getPackageManagerVersion.ts
+++ b/create-turbo/src/getPackageManagerVersion.ts
@@ -1,0 +1,15 @@
+import { execSync } from "child_process";
+import { PackageManager } from "./types";
+
+export const getPackageManagerVersion = (ws: PackageManager): string => {
+  switch (ws) {
+    case "yarn":
+      return execSync("yarn --version").toString().trim();
+    case "pnpm":
+      return execSync("pnpm --version").toString().trim();
+    case "npm":
+      return execSync("npm --version").toString().trim();
+    default:
+      throw new Error(`${ws} is not supported`);
+  }
+};

--- a/create-turbo/src/types.ts
+++ b/create-turbo/src/types.ts
@@ -1,0 +1,1 @@
+export type PackageManager = "yarn" | "pnpm" | "npm";


### PR DESCRIPTION
Set `packageManager` in `create-turbo` before install so that the `--no-install` flag will yield a turborepo that will work on the first run without warnings