### PR TITLE
Fixed crash and added error message if packageManager field is invalid.

### DIFF
--- a/cli/internal/backends/nodejs/nodejs.go
+++ b/cli/internal/backends/nodejs/nodejs.go
@@ -38,7 +38,11 @@ var NodejsYarnBackend = api.LanguageBackend{
 	},
 	Detect: func(cwd string, pkg *fs.PackageJSON, backend *api.LanguageBackend) (bool, error) {
 		if pkg.PackageManager != "" {
-			packageManager, version := util.GetPackageManagerAndVersion(pkg.PackageManager)
+			packageManager, version, err := util.GetPackageManagerAndVersion(pkg.PackageManager)
+
+			if err != nil {
+				return false, err
+			}
 
 			if packageManager != "yarn" {
 				return false, nil
@@ -95,8 +99,11 @@ var NodejsBerryBackend = api.LanguageBackend{
 	},
 	Detect: func(cwd string, pkg *fs.PackageJSON, backend *api.LanguageBackend) (bool, error) {
 		if pkg.PackageManager != "" {
-			packageManager, version := util.GetPackageManagerAndVersion(pkg.PackageManager)
+			packageManager, version, err := util.GetPackageManagerAndVersion(pkg.PackageManager)
 
+			if err != nil {
+				return false, err
+			}
 			if packageManager != "yarn" {
 				return false, nil
 			}
@@ -178,8 +185,10 @@ var NodejsPnpmBackend = api.LanguageBackend{
 	},
 	Detect: func(cwd string, pkg *fs.PackageJSON, backend *api.LanguageBackend) (bool, error) {
 		if pkg.PackageManager != "" {
-			packageManager, _ := util.GetPackageManagerAndVersion(pkg.PackageManager)
-
+			packageManager, _, err := util.GetPackageManagerAndVersion(pkg.PackageManager)
+			if err != nil {
+				return false, err
+			}
 			if packageManager == "pnpm" {
 				return true, nil
 			}
@@ -221,8 +230,10 @@ var NodejsNpmBackend = api.LanguageBackend{
 	},
 	Detect: func(cwd string, pkg *fs.PackageJSON, backend *api.LanguageBackend) (bool, error) {
 		if pkg.PackageManager != "" {
-			packageManager, _ := util.GetPackageManagerAndVersion(pkg.PackageManager)
-
+			packageManager, _, err := util.GetPackageManagerAndVersion(pkg.PackageManager)
+			if err != nil {
+				return false, err
+			}
 			if packageManager == "npm" {
 				return true, nil
 			}

--- a/cli/internal/fs/package_json.go
+++ b/cli/internal/fs/package_json.go
@@ -9,16 +9,16 @@ import (
 // TurboConfigJSON is the root turborepo configuration
 type TurboConfigJSON struct {
 	// Base Git branch
-	Base               string   `json:"baseBranch,omitempty"`
+	Base string `json:"baseBranch,omitempty"`
 	// Global root filesystem dependencies
 	GlobalDependencies []string `json:"globalDependencies,omitempty"`
 	TurboCacheOptions  string   `json:"cacheOptions,omitempty"`
 	Outputs            []string `json:"outputs,omitempty"`
 	// RemoteCacheUrl is the Remote Cache API URL
-	RemoteCacheUrl     string   `json:"remoteCacheUrl,omitempty"`
+	RemoteCacheUrl string `json:"remoteCacheUrl,omitempty"`
 	// Pipeline is a map of Turbo pipeline entries which define the task graph
 	// and cache behavior on a per task or per package-task basis.
-	Pipeline           map[string]Pipeline
+	Pipeline map[string]Pipeline
 }
 
 func ReadTurboConfigJSON(path string) (*TurboConfigJSON, error) {

--- a/cli/internal/util/backends.go
+++ b/cli/internal/util/backends.go
@@ -68,9 +68,13 @@ func IsNMLinker(cwd string) (bool, error) {
 	return yarnRC.NodeLinker == "node-modules", nil
 }
 
-func GetPackageManagerAndVersion(packageManager string) (string, string) {
-	re := regexp.MustCompile(`(npm|pnpm|yarn)@(\d+)\.\d+\.\d+(-.+)?`)
+func GetPackageManagerAndVersion(packageManager string) (string, string, error) {
+	pattern := `(npm|pnpm|yarn)@(\d+)\.\d+\.\d+(-.+)?`
+	re := regexp.MustCompile(pattern)
 	match := re.FindString(packageManager)
+	if len(match) == 0 {
+		return "", "", fmt.Errorf("could not parse packageManager field in package.json, expected: %s, received: %s", pattern, packageManager)
+	}
 
-	return strings.Split(match, "@")[0], strings.Split(match, "@")[1]
+	return strings.Split(match, "@")[0], strings.Split(match, "@")[1], nil
 }


### PR DESCRIPTION
Hi.
I fixed a small issue: if there is no version specified in `packageManager` (or just if a value is invalid), the CLI goes into panic. I have also added a friendly error message. I hope it'll make CLI a bit friendlier 🙂