### PR TITLE
Track child exit codes and propagate them

### DIFF
--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -673,7 +673,15 @@ func (c *RunCommand) Run(args []string) int {
 	// run the thing
 	errs := engine.Execute()
 
+	// Track if we saw any child with a non-zero exit code
+	exitCode := 0
+	exitCodeErr := &process.ChildExit{}
 	for _, err := range errs {
+		if errors.As(err, &exitCodeErr) {
+			if exitCodeErr.ExitCode > exitCode {
+				exitCode = exitCodeErr.ExitCode
+			}
+		}
 		c.Ui.Error(err.Error())
 	}
 
@@ -684,7 +692,7 @@ func (c *RunCommand) Run(args []string) int {
 		return 1
 	}
 
-	return 0
+	return exitCode
 }
 
 // RunOptions holds the current run operations configuration


### PR DESCRIPTION
Track if we saw any child exit with a non-zero exit code, and use the highest one.

Fixes #694 