### PR TITLE
Fix cache index being missing after incremental builds

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -44,7 +44,7 @@
     "match-sorter": "^6.3.1",
     "next": "^12.0.9",
     "next-themes": "^0.0.15",
-    "nextra": "^2.0.0-alpha.23",
+    "nextra": "^2.0.0-alpha.24",
     "parse-git-url": "^1.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/docs/pages/docs/guides/migrate-from-lerna.mdx
+++ b/docs/pages/docs/guides/migrate-from-lerna.mdx
@@ -1,5 +1,7 @@
 # Using with Lerna
 
+( test: nextraordinary )
+
 Turborepo and Lerna have a lot a in common, but also some key differences.
 
 **tl;dr** you can use Lerna and Turbo together.

--- a/docs/pages/docs/guides/migrate-from-lerna.mdx
+++ b/docs/pages/docs/guides/migrate-from-lerna.mdx
@@ -1,7 +1,5 @@
 # Using with Lerna
 
-( test: nextraordinary )
-
 Turborepo and Lerna have a lot a in common, but also some key differences.
 
 **tl;dr** you can use Lerna and Turbo together.

--- a/yarn.lock
+++ b/yarn.lock
@@ -5415,10 +5415,10 @@ next@^12.0.9:
     "@next/swc-win32-ia32-msvc" "12.0.9"
     "@next/swc-win32-x64-msvc" "12.0.9"
 
-nextra@^2.0.0-alpha.23:
-  version "2.0.0-alpha.23"
-  resolved "https://registry.yarnpkg.com/nextra/-/nextra-2.0.0-alpha.23.tgz#01d3ad1c6cc78ad86615e0b33ed02453bd9bddce"
-  integrity sha512-o2Lbtf5yq2uMYOWJKhVjDpp/IL4filx++5rzrltu0fH9ERitiKarXk+S+fj0LDtAQB+rI6Q3FR/c8ER4z3DWIQ==
+nextra@^2.0.0-alpha.24:
+  version "2.0.0-alpha.24"
+  resolved "https://registry.yarnpkg.com/nextra/-/nextra-2.0.0-alpha.24.tgz#32d83d34e724a7536f4a1ac7d70f72c0f08cd36f"
+  integrity sha512-Vt98hlyTEWQguRnkALq9aXhUcxDVwNN3LND/NXvXCSYxZjEY6f2Ujdew1HxBn78xa3k0WCmne1Xzb39Yy9dbNg==
   dependencies:
     "@mdx-js/mdx" "^2.0.0-rc.2"
     github-slugger "^1.4.0"


### PR DESCRIPTION
- initial build: https://turbo-site-bd3h6v06j.vercel.sh
- incremental build (edited a page ef3d5d0cd3483f527dfe941c70cd93e63721363d) with cache enabled: https://turbo-site-ji7y3vjb2.vercel.sh 

And the new added word is indexed (along with other pages):

<img width="604" alt="CleanShot 2022-02-09 at 15 43 25@2x" src="https://user-images.githubusercontent.com/3676859/153224468-7b9114d6-2612-4c01-993f-7cd880e34b77.png">
