### PR TITLE
Increased contrast on the sidebar text in darkmode

### DIFF
--- a/docs/nextra-theme-docs/styles.css
+++ b/docs/nextra-theme-docs/styles.css
@@ -105,7 +105,7 @@ article a code {
 }
 .dark .sidebar button,
 .dark .sidebar a {
-  @apply text-gray-500;
+  @apply text-gray-400;
 }
 .sidebar a:hover,
 .sidebar button:hover {


### PR DESCRIPTION
Currently the sidebar text in darmode is text-gray-500 which does not contrast well against the background compared to lightmode and other text in darkmode.