### PR TITLE
feat: throw when --scope returns an empty set

### DIFF
--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -895,6 +895,10 @@ func getScopedPackages(ctx *context.Context, scopePatterns []string) (scopePkgs 
 		}
 	}
 
+	if len(include) > 0 && scopedPkgs.Len() == 0 {
+		return nil, errors.Errorf("No packages found matching the provided scope pattern.")
+	}
+
 	return scopedPkgs, nil
 }
 

--- a/cli/internal/run/run_test.go
+++ b/cli/internal/run/run_test.go
@@ -150,7 +150,7 @@ func TestScopedPackages(t *testing.T) {
 	cases := []struct {
 		Name     string
 		Ctx      *context.Context
-		Patttern []string
+		Pattern  []string
 		Expected util.Set
 	}{
 		{
@@ -189,11 +189,16 @@ func TestScopedPackages(t *testing.T) {
 
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.Name), func(t *testing.T) {
-			actual, err := getScopedPackages(tc.Ctx, tc.Patttern)
+			actual, err := getScopedPackages(tc.Ctx, tc.Pattern)
 			if err != nil {
 				t.Fatalf("invalid scope parse: %#v", err)
 			}
 			assert.EqualValues(t, tc.Expected, actual)
 		})
 	}
+
+	t.Run(fmt.Sprintf("%d-%s", len(cases), "throws an error if no package matches the provided scope pattern"), func(t *testing.T) {
+		_, err := getScopedPackages(&context.Context{PackageNames: []string{"foo", "bar"}}, []string{"baz"})
+		assert.Error(t, err)
+	})
 }


### PR DESCRIPTION
This PR:
- Makes turbo throw an error when no packages found matching the provided scope pattern
- The default behaviour before was to run all packages.

Addresses: 
- https://github.com/vercel/turborepo/issues/716
- https://github.com/vercel/turborepo/issues/653