### PR TITLE
Added warning about pnpm support for prune

### DIFF
--- a/docs/pages/docs/reference/command-line-reference.mdx
+++ b/docs/pages/docs/reference/command-line-reference.mdx
@@ -326,6 +326,8 @@ This command will generate folder called `out` with the following inside of it:
 - A new pruned lockfile that only contains the pruned subset of the original root lockfile with the dependencies that are actually used by the packages in the pruned workspace.
 - A copy of the root `package.json`
 
+⚠️ _This command is not yet implemented for `pnpm`_
+
 ```
 .                                 # Folder full source code for all package needed to build the target
 ├── package.json                  # The root `package.json`


### PR DESCRIPTION
Currently the prune command [isn't implemented for pnpm](https://github.com/vercel/turborepo/issues/534), but the docs don't mention that.