### PR TITLE
Start splitting the Run command up

### DIFF
--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+
 	"github.com/vercel/turborepo/cli/internal/api"
 	"github.com/vercel/turborepo/cli/internal/backends"
 	"github.com/vercel/turborepo/cli/internal/config"
@@ -30,7 +31,6 @@ const GLOBAL_CACHE_KEY = "snozzberries"
 type Context struct {
 	Args                   []string
 	PackageInfos           map[interface{}]*fs.PackageJSON
-	ColorCache             *ColorCache
 	PackageNames           []string
 	TopologicalGraph       dag.AcyclicGraph
 	TaskGraph              dag.AcyclicGraph
@@ -89,7 +89,6 @@ func WithTracer(filename string) Option {
 func WithGraph(rootpath string, config *config.Config) Option {
 	return func(c *Context) error {
 		c.PackageInfos = make(map[interface{}]*fs.PackageJSON)
-		c.ColorCache = NewColorCache()
 		c.RootNode = core.ROOT_NODE_NAME
 		// Need to ALWAYS have a root node, might as well do it now
 		c.TaskGraph.Add(core.ROOT_NODE_NAME)

--- a/cli/internal/run/color_cache.go
+++ b/cli/internal/run/color_cache.go
@@ -1,7 +1,8 @@
-package context
+package run
 
 import (
 	"sync"
+
 	"github.com/vercel/turborepo/cli/internal/util"
 
 	"github.com/fatih/color"

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -364,7 +364,7 @@ func (c *RunCommand) Run(args []string) int {
 	if runOptions.stream {
 		c.Ui.Output(fmt.Sprintf("%s %s %s", ui.Dim("• Running"), ui.Dim(ui.Bold(strings.Join(targets, ", "))), ui.Dim(fmt.Sprintf("in %v packages", filteredPkgs.Len()))))
 	}
-	runState := NewRunState(runOptions)
+	runState := NewRunState(runOptions, startAt)
 	runState.Listen(c.Ui, time.Now())
 	engine := core.NewScheduler(&g.TopologicalGraph)
 	colorCache := NewColorCache()
@@ -717,7 +717,7 @@ func (c *RunCommand) Run(args []string) int {
 
 	logReplayWaitGroup.Wait()
 
-	if err := runState.Close(c.Ui, startAt, runOptions.profile); err != nil {
+	if err := runState.Close(c.Ui, runOptions.profile); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error with profiler: %s", err.Error()))
 		return 1
 	}

--- a/cli/internal/run/run_test.go
+++ b/cli/internal/run/run_test.go
@@ -2,8 +2,11 @@ package run
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/mitchellh/cli"
 	"github.com/vercel/turborepo/cli/internal/context"
 	"github.com/vercel/turborepo/cli/internal/util"
 
@@ -134,10 +137,16 @@ func TestParseConfig(t *testing.T) {
 		},
 	}
 
+	ui := &cli.BasicUi{
+		Reader:      os.Stdin,
+		Writer:      os.Stdout,
+		ErrorWriter: os.Stderr,
+	}
+
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.Name), func(t *testing.T) {
 
-			actual, err := parseRunArgs(tc.Args, ".")
+			actual, err := parseRunArgs(tc.Args, ".", ui)
 			if err != nil {
 				t.Fatalf("invalid parse: %#v", err)
 			}


### PR DESCRIPTION
This PR makes a few changes to `Run`. The intention is to separate out a few distinct pieces:
 * The complete graph, inferred from the the filesystem and pipeline configuration. This should be reusable across multiple runs on the same filesystem / pipeline
 * Run specific configuration: what tasks to run, whether to include dependencies, etc.
 * The mechanics of how to execute the run. In parallel? Cache the output? etc.

Review note: it may be easier to go commit by commit.

