### PR TITLE
fix(cli): Fix install on node 16 on ubuntu

### DIFF
--- a/cli/npm/turbo-install/install.js
+++ b/cli/npm/turbo-install/install.js
@@ -22,7 +22,20 @@ let isToPathJS = true;
 function validateBinaryVersion(...command) {
   command.push("--version");
   const stdout = child_process
-    .execFileSync(command.shift(), command)
+    .execFileSync(command.shift(), command, {
+      // Without this, this install script strangely crashes with the error
+      // "EACCES: permission denied, write" but only on Ubuntu Linux when node is
+      // installed from the Snap Store. This is not a problem when you download
+      // the official version of node. The problem appears to be that stderr
+      // (i.e. file descriptor 2) isn't writable?
+      //
+      // More info:
+      // - https://snapcraft.io/ (what the Snap Store is)
+      // - https://nodejs.org/dist/ (download the official version of node)
+      // - https://github.com/evanw/esbuild/issues/1711#issuecomment-1027554035
+      //
+      stdio: "pipe",
+    })
     .toString()
     .trim();
   if (stdout !== TURBO_VERSION) {


### PR DESCRIPTION
Fix #766 

See https://github.com/evanw/esbuild/issues/1711#issuecomment-1027554035

Following behind `esbuild`, this patches `turbo` postinstall script to fix node 16 ubuntu installation