### PR TITLE
Change "Bootstrapping" to "Creating" in `create-turbo`

### DIFF
--- a/packages/create-turbo/src/index.ts
+++ b/packages/create-turbo/src/index.ts
@@ -185,7 +185,7 @@ async function run() {
 
   if (flags.install) {
     console.log();
-    console.log(`>>> Bootstrapping a new turborepo with the following:`);
+    console.log(`>>> Creating a new turborepo with the following:`);
     console.log();
     console.log(` - ${chalk.bold("apps/web")}: Next.js with TypeScript`);
     console.log(` - ${chalk.bold("apps/docs")}: Next.js with TypeScript`);


### PR DESCRIPTION
To avoid confusion with `lerna boostrap`, this PR changes the word "Bootstrapping" for "Creating" in `create-turbo`