### PR TITLE
Running build with --cwd works

### DIFF
--- a/cli/internal/api/types.go
+++ b/cli/internal/api/types.go
@@ -32,7 +32,7 @@ type LanguageBackend struct {
 	GetPackageDir func() string
 
 	// Return the list of workspace glob
-	GetWorkspaceGlobs func() ([]string, error)
+	GetWorkspaceGlobs func(rootpath string) ([]string, error)
 	// Returns run command
 	GetRunCommand func() []string
 

--- a/cli/internal/backends/nodejs/nodejs.go
+++ b/cli/internal/backends/nodejs/nodejs.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"path"
 	"path/filepath"
+
 	"github.com/vercel/turborepo/cli/internal/api"
 	"github.com/vercel/turborepo/cli/internal/fs"
 	"github.com/vercel/turborepo/cli/internal/util"
@@ -20,8 +22,8 @@ var NodejsYarnBackend = api.LanguageBackend{
 	Specfile:         "package.json",
 	Lockfile:         "yarn.lock",
 	FilenamePatterns: nodejsPatterns,
-	GetWorkspaceGlobs: func() ([]string, error) {
-		pkg, err := fs.ReadPackageJSON("package.json")
+	GetWorkspaceGlobs: func(rootpath string) ([]string, error) {
+		pkg, err := fs.ReadPackageJSON(path.Join(rootpath, "package.json"))
 		if err != nil {
 			return nil, fmt.Errorf("package.json: %w", err)
 		}
@@ -81,8 +83,8 @@ var NodejsBerryBackend = api.LanguageBackend{
 	Specfile:         "package.json",
 	Lockfile:         "yarn.lock",
 	FilenamePatterns: nodejsPatterns,
-	GetWorkspaceGlobs: func() ([]string, error) {
-		pkg, err := fs.ReadPackageJSON("package.json")
+	GetWorkspaceGlobs: func(rootpath string) ([]string, error) {
+		pkg, err := fs.ReadPackageJSON(path.Join(rootpath, "package.json"))
 		if err != nil {
 			return nil, fmt.Errorf("package.json: %w", err)
 		}
@@ -161,8 +163,8 @@ var NodejsPnpmBackend = api.LanguageBackend{
 	Specfile:         "package.json",
 	Lockfile:         "pnpm-lock.yaml",
 	FilenamePatterns: nodejsPatterns,
-	GetWorkspaceGlobs: func() ([]string, error) {
-		bytes, err := ioutil.ReadFile("pnpm-workspace.yaml")
+	GetWorkspaceGlobs: func(rootpath string) ([]string, error) {
+		bytes, err := ioutil.ReadFile(path.Join(rootpath, "pnpm-workspace.yaml"))
 		if err != nil {
 			return nil, fmt.Errorf("pnpm-workspace.yaml: %w", err)
 		}
@@ -212,8 +214,8 @@ var NodejsNpmBackend = api.LanguageBackend{
 	Specfile:         "package.json",
 	Lockfile:         "package-lock.json",
 	FilenamePatterns: nodejsPatterns,
-	GetWorkspaceGlobs: func() ([]string, error) {
-		pkg, err := fs.ReadPackageJSON("package.json")
+	GetWorkspaceGlobs: func(rootpath string) ([]string, error) {
+		pkg, err := fs.ReadPackageJSON(path.Join(rootpath, "package.json"))
 		if err != nil {
 			return nil, fmt.Errorf("package.json: %w", err)
 		}

--- a/cli/internal/backends/nodejs/nodejs.go
+++ b/cli/internal/backends/nodejs/nodejs.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"path"
 	"path/filepath"
 
 	"github.com/vercel/turborepo/cli/internal/api"
@@ -23,7 +22,7 @@ var NodejsYarnBackend = api.LanguageBackend{
 	Lockfile:         "yarn.lock",
 	FilenamePatterns: nodejsPatterns,
 	GetWorkspaceGlobs: func(rootpath string) ([]string, error) {
-		pkg, err := fs.ReadPackageJSON(path.Join(rootpath, "package.json"))
+		pkg, err := fs.ReadPackageJSON(filepath.Join(rootpath, "package.json"))
 		if err != nil {
 			return nil, fmt.Errorf("package.json: %w", err)
 		}
@@ -84,7 +83,7 @@ var NodejsBerryBackend = api.LanguageBackend{
 	Lockfile:         "yarn.lock",
 	FilenamePatterns: nodejsPatterns,
 	GetWorkspaceGlobs: func(rootpath string) ([]string, error) {
-		pkg, err := fs.ReadPackageJSON(path.Join(rootpath, "package.json"))
+		pkg, err := fs.ReadPackageJSON(filepath.Join(rootpath, "package.json"))
 		if err != nil {
 			return nil, fmt.Errorf("package.json: %w", err)
 		}
@@ -164,7 +163,7 @@ var NodejsPnpmBackend = api.LanguageBackend{
 	Lockfile:         "pnpm-lock.yaml",
 	FilenamePatterns: nodejsPatterns,
 	GetWorkspaceGlobs: func(rootpath string) ([]string, error) {
-		bytes, err := ioutil.ReadFile(path.Join(rootpath, "pnpm-workspace.yaml"))
+		bytes, err := ioutil.ReadFile(filepath.Join(rootpath, "pnpm-workspace.yaml"))
 		if err != nil {
 			return nil, fmt.Errorf("pnpm-workspace.yaml: %w", err)
 		}
@@ -215,7 +214,7 @@ var NodejsNpmBackend = api.LanguageBackend{
 	Lockfile:         "package-lock.json",
 	FilenamePatterns: nodejsPatterns,
 	GetWorkspaceGlobs: func(rootpath string) ([]string, error) {
-		pkg, err := fs.ReadPackageJSON(path.Join(rootpath, "package.json"))
+		pkg, err := fs.ReadPackageJSON(filepath.Join(rootpath, "package.json"))
 		if err != nil {
 			return nil, fmt.Errorf("package.json: %w", err)
 		}

--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -93,7 +92,7 @@ func WithGraph(rootpath string, config *config.Config) Option {
 		// Need to ALWAYS have a root node, might as well do it now
 		c.TaskGraph.Add(core.ROOT_NODE_NAME)
 
-		packageJSONPath := path.Join(rootpath, "package.json")
+		packageJSONPath := filepath.Join(rootpath, "package.json")
 		pkg, err := fs.ReadPackageJSON(packageJSONPath)
 		if err != nil {
 			return fmt.Errorf("package.json: %w", err)
@@ -104,7 +103,7 @@ func WithGraph(rootpath string, config *config.Config) Option {
 		// If pkg.Turbo exists, we warn about running the migration
 		// Use pkg.Turbo if turbo.json doesn't exist
 		// If neither exists, it's a fatal error
-		turboJSONPath := path.Join(rootpath, "turbo.json")
+		turboJSONPath := filepath.Join(rootpath, "turbo.json")
 		if !fs.FileExists(turboJSONPath) {
 			if pkg.LegacyTurboConfig == nil {
 				// TODO: suggestion on how to create one
@@ -221,7 +220,7 @@ func WithGraph(rootpath string, config *config.Config) Option {
 		parseJSONWaitGroup := new(errgroup.Group)
 		justJsons := make([]string, 0, len(spaces))
 		for _, space := range spaces {
-			justJsons = append(justJsons, path.Join(space, "package.json"))
+			justJsons = append(justJsons, filepath.Join(space, "package.json"))
 		}
 
 		f := globby.GlobFiles(rootpath, justJsons, getWorkspaceIgnores())

--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -93,11 +93,6 @@ func WithGraph(rootpath string, config *config.Config) Option {
 		// Need to ALWAYS have a root node, might as well do it now
 		c.TaskGraph.Add(core.ROOT_NODE_NAME)
 
-		cwd, err := os.Getwd()
-		if err != nil {
-			return fmt.Errorf("could not get cwd: %w", err)
-		}
-
 		packageJSONPath := path.Join(rootpath, "package.json")
 		pkg, err := fs.ReadPackageJSON(packageJSONPath)
 		if err != nil {
@@ -130,7 +125,7 @@ func WithGraph(rootpath string, config *config.Config) Option {
 			}
 		}
 
-		if backend, err := backends.GetBackend(cwd, pkg); err != nil {
+		if backend, err := backends.GetBackend(rootpath, pkg); err != nil {
 			return err
 		} else {
 			c.Backend = backend
@@ -138,7 +133,7 @@ func WithGraph(rootpath string, config *config.Config) Option {
 
 		// this should go into the bacend abstraction
 		if util.IsYarn(c.Backend.Name) {
-			lockfile, err := fs.ReadLockfile(c.Backend.Name, config.Cache.Dir)
+			lockfile, err := fs.ReadLockfile(rootpath, c.Backend.Name, config.Cache.Dir)
 			if err != nil {
 				return fmt.Errorf("yarn.lock: %w", err)
 			}
@@ -149,7 +144,7 @@ func WithGraph(rootpath string, config *config.Config) Option {
 			return err
 		}
 
-		spaces, err := c.Backend.GetWorkspaceGlobs()
+		spaces, err := c.Backend.GetWorkspaceGlobs(rootpath)
 
 		if err != nil {
 			return fmt.Errorf("could not detect workspaces: %w", err)

--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -226,10 +226,13 @@ func WithGraph(rootpath string, config *config.Config) Option {
 
 		f := globby.GlobFiles(rootpath, justJsons, getWorkspaceIgnores())
 
-		for i, val := range f {
-			_, val := i, val // https://golang.org/doc/faq#closures_and_goroutines
+		for _, val := range f {
+			relativePkgPath, err := filepath.Rel(rootpath, val)
+			if err != nil {
+				return fmt.Errorf("non-nested package.json path %w", err)
+			}
 			parseJSONWaitGroup.Go(func() error {
-				return c.parsePackageJSON(val)
+				return c.parsePackageJSON(relativePkgPath)
 			})
 		}
 

--- a/cli/internal/fs/lockfile.go
+++ b/cli/internal/fs/lockfile.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -16,13 +15,13 @@ import (
 func ReadLockfile(rootpath string, backendName string, cacheDir string) (*YarnLockfile, error) {
 	var lockfile YarnLockfile
 	var prettyLockFile = YarnLockfile{}
-	hash, err := HashFile(path.Join(rootpath, "yarn.lock"))
+	hash, err := HashFile(filepath.Join(rootpath, "yarn.lock"))
 	if err != nil {
 		return &YarnLockfile{}, fmt.Errorf("failed to hash lockfile: %w", err)
 	}
 	contentsOfLock, err := ioutil.ReadFile(filepath.Join(cacheDir, fmt.Sprintf("%v-turbo-lock.yaml", hash)))
 	if err != nil {
-		contentsB, err := ioutil.ReadFile(path.Join(rootpath, "yarn.lock"))
+		contentsB, err := ioutil.ReadFile(filepath.Join(rootpath, "yarn.lock"))
 		if err != nil {
 			return nil, fmt.Errorf("reading yarn.lock: %w", err)
 		}

--- a/cli/internal/fs/lockfile.go
+++ b/cli/internal/fs/lockfile.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -12,16 +13,16 @@ import (
 )
 
 // ReadLockfile will read `yarn.lock` into memory (either from the cache or fresh)
-func ReadLockfile(backendName string, cacheDir string) (*YarnLockfile, error) {
+func ReadLockfile(rootpath string, backendName string, cacheDir string) (*YarnLockfile, error) {
 	var lockfile YarnLockfile
 	var prettyLockFile = YarnLockfile{}
-	hash, err := HashFile("yarn.lock")
+	hash, err := HashFile(path.Join(rootpath, "yarn.lock"))
 	if err != nil {
 		return &YarnLockfile{}, fmt.Errorf("failed to hash lockfile: %w", err)
 	}
 	contentsOfLock, err := ioutil.ReadFile(filepath.Join(cacheDir, fmt.Sprintf("%v-turbo-lock.yaml", hash)))
 	if err != nil {
-		contentsB, err := ioutil.ReadFile("yarn.lock")
+		contentsB, err := ioutil.ReadFile(path.Join(rootpath, "yarn.lock"))
 		if err != nil {
 			return nil, fmt.Errorf("reading yarn.lock: %w", err)
 		}

--- a/cli/internal/prune/prune.go
+++ b/cli/internal/prune/prune.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -131,7 +130,7 @@ func (c *PruneCommand) Run(args []string) int {
 	workspaces := []string{}
 	seen := mapset.NewSet()
 	var lockfileWg sync.WaitGroup
-	pkg, err := fs.ReadPackageJSON(path.Join(pruneOptions.cwd, "package.json"))
+	pkg, err := fs.ReadPackageJSON(filepath.Join(pruneOptions.cwd, "package.json"))
 	if err != nil {
 		c.logError(c.Config.Logger, "", fmt.Errorf("could not read package.json: %w", err))
 		return 1

--- a/cli/internal/prune/prune.go
+++ b/cli/internal/prune/prune.go
@@ -7,9 +7,11 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"sync"
+
 	"github.com/vercel/turborepo/cli/internal/config"
 	"github.com/vercel/turborepo/cli/internal/context"
 	"github.com/vercel/turborepo/cli/internal/fs"
@@ -99,7 +101,7 @@ func (c *PruneCommand) Run(args []string) int {
 		c.logError(c.Config.Logger, "", err)
 		return 1
 	}
-	ctx, err := context.New(context.WithTracer(""), context.WithArgs(args), context.WithGraph(".", c.Config))
+	ctx, err := context.New(context.WithTracer(""), context.WithArgs(args), context.WithGraph(pruneOptions.cwd, c.Config))
 
 	if err != nil {
 		c.logError(c.Config.Logger, "", fmt.Errorf("could not construct graph: %w", err))
@@ -129,7 +131,7 @@ func (c *PruneCommand) Run(args []string) int {
 	workspaces := []string{}
 	seen := mapset.NewSet()
 	var lockfileWg sync.WaitGroup
-	pkg, err := fs.ReadPackageJSON("package.json")
+	pkg, err := fs.ReadPackageJSON(path.Join(pruneOptions.cwd, "package.json"))
 	if err != nil {
 		c.logError(c.Config.Logger, "", fmt.Errorf("could not read package.json: %w", err))
 		return 1

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -820,6 +820,7 @@ func parseRunArgs(args []string, output cli.Ui) (*RunOptions, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid working directory: %w", err)
 	}
+	runOptions.cwd = cwd
 
 	unresolvedCacheFolder := filepath.FromSlash("./node_modules/.cache/turbo")
 
@@ -848,8 +849,6 @@ func parseRunArgs(args []string, output cli.Ui) (*RunOptions, error) {
 			case strings.HasPrefix(arg, "--cwd="):
 				if len(arg[len("--cwd="):]) > 0 {
 					runOptions.cwd = arg[len("--cwd="):]
-				} else {
-					runOptions.cwd = cwd
 				}
 			case strings.HasPrefix(arg, "--parallel"):
 				runOptions.parallel = true

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -818,7 +818,7 @@ func parseRunArgs(args []string, output cli.Ui) (*RunOptions, error) {
 
 	cwd, err := os.Getwd()
 	if err != nil {
-		return nil, fmt.Errorf("invalid working directory?: %w", err)
+		return nil, fmt.Errorf("invalid working directory: %w", err)
 	}
 
 	unresolvedCacheFolder := filepath.FromSlash("./node_modules/.cache/turbo")

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -135,13 +135,7 @@ func (c *RunCommand) Run(args []string) int {
 		return 1
 	}
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		c.logError(c.Config.Logger, "", fmt.Errorf("invalid working directory?: %w", err))
-		return 1
-	}
-
-	runOptions, err := parseRunArgs(args, cwd, c.Ui)
+	runOptions, err := parseRunArgs(args, c.Ui)
 	if err != nil {
 		c.logError(c.Config.Logger, "", err)
 		return 1
@@ -149,13 +143,13 @@ func (c *RunCommand) Run(args []string) int {
 
 	c.Config.Cache.Dir = runOptions.cacheFolder
 
-	ctx, err := context.New(context.WithTracer(runOptions.profile), context.WithArgs(args), context.WithGraph(".", c.Config))
+	ctx, err := context.New(context.WithTracer(runOptions.profile), context.WithArgs(args), context.WithGraph(runOptions.cwd, c.Config))
 	if err != nil {
 		c.logError(c.Config.Logger, "", err)
 		return 1
 	}
 
-	gitRepoRoot, err := fs.FindupFrom(".git", cwd)
+	gitRepoRoot, err := fs.FindupFrom(".git", runOptions.cwd)
 	if err != nil {
 		c.logWarning(c.Config.Logger, "Cannot find a .git folder in current working directory or in any parent directories. Falling back to manual file hashing (which may be slower). If you are running this build in a pruned directory, you can ignore this message. Otherwise, please initialize a git repository in the root of your monorepo.", err)
 	}
@@ -177,7 +171,7 @@ func (c *RunCommand) Run(args []string) int {
 	hasRepoGlobalFileChanged := false
 	var changedFiles []string
 	if runOptions.since != "" {
-		changedFiles = git.ChangedFiles(runOptions.since, true, cwd)
+		changedFiles = git.ChangedFiles(runOptions.since, true, runOptions.cwd)
 	}
 
 	ignoreSet := make(util.Set)
@@ -319,10 +313,10 @@ func (c *RunCommand) Run(args []string) int {
 		Opts:         runOptions,
 	}
 	backend := ctx.Backend
-	return c.runOperation(g, rs, backend, cwd, startAt)
+	return c.runOperation(g, rs, backend, startAt)
 }
 
-func (c *RunCommand) runOperation(g *completeGraph, rs *runSpec, backend *api.LanguageBackend, cwd string, startAt time.Time) int {
+func (c *RunCommand) runOperation(g *completeGraph, rs *runSpec, backend *api.LanguageBackend, startAt time.Time) int {
 	goctx := gocontext.Background()
 	var analyticsSink analytics.Sink
 	if c.Config.IsLoggedIn() {
@@ -685,7 +679,7 @@ func (c *RunCommand) runOperation(g *completeGraph, rs *runSpec, backend *api.La
 		}))
 		ext := filepath.Ext(rs.Opts.dotGraph)
 		if ext == ".html" {
-			f, err := os.Create(filepath.Join(cwd, rs.Opts.dotGraph))
+			f, err := os.Create(filepath.Join(rs.Opts.cwd, rs.Opts.dotGraph))
 			if err != nil {
 				c.logError(c.Config.Logger, "", fmt.Errorf("error writing graph: %w", err))
 				return 1
@@ -709,7 +703,7 @@ func (c *RunCommand) runOperation(g *completeGraph, rs *runSpec, backend *api.La
 			c.Ui.Output("")
 			c.Ui.Output(fmt.Sprintf("✔ Generated task graph in %s", ui.Bold(rs.Opts.dotGraph)))
 			if ui.IsTTY {
-				browser.OpenBrowser(filepath.Join(cwd, rs.Opts.dotGraph))
+				browser.OpenBrowser(filepath.Join(rs.Opts.cwd, rs.Opts.dotGraph))
 			}
 			return 0
 		}
@@ -815,11 +809,16 @@ func getDefaultRunOptions() *RunOptions {
 	}
 }
 
-func parseRunArgs(args []string, cwd string, output cli.Ui) (*RunOptions, error) {
+func parseRunArgs(args []string, output cli.Ui) (*RunOptions, error) {
 	var runOptions = getDefaultRunOptions()
 
 	if len(args) == 0 {
 		return nil, errors.Errorf("At least one task must be specified.")
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("invalid working directory?: %w", err)
 	}
 
 	unresolvedCacheFolder := filepath.FromSlash("./node_modules/.cache/turbo")

--- a/cli/internal/run/run_test.go
+++ b/cli/internal/run/run_test.go
@@ -3,7 +3,6 @@ package run
 import (
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"testing"
 
@@ -19,7 +18,7 @@ func TestParseConfig(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to get cwd: %v", err)
 	}
-	defaultCacheFolder := path.Join(defaultCwd, filepath.FromSlash("node_modules/.cache/turbo"))
+	defaultCacheFolder := filepath.Join(defaultCwd, filepath.FromSlash("node_modules/.cache/turbo"))
 	cases := []struct {
 		Name     string
 		Args     []string

--- a/cli/internal/run/run_test.go
+++ b/cli/internal/run/run_test.go
@@ -3,6 +3,7 @@ package run
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 
@@ -14,6 +15,11 @@ import (
 )
 
 func TestParseConfig(t *testing.T) {
+	defaultCwd, err := os.Getwd()
+	if err != nil {
+		t.Errorf("failed to get cwd: %v", err)
+	}
+	defaultCacheFolder := path.Join(defaultCwd, filepath.FromSlash("node_modules/.cache/turbo"))
 	cases := []struct {
 		Name     string
 		Args     []string
@@ -32,7 +38,8 @@ func TestParseConfig(t *testing.T) {
 				cache:               true,
 				forceExecution:      false,
 				profile:             "",
-				cacheFolder:         filepath.FromSlash("node_modules/.cache/turbo"),
+				cwd:                 defaultCwd,
+				cacheFolder:         defaultCacheFolder,
 			},
 		},
 		{
@@ -66,7 +73,8 @@ func TestParseConfig(t *testing.T) {
 				forceExecution:      false,
 				profile:             "",
 				scope:               []string{"foo", "blah"},
-				cacheFolder:         filepath.FromSlash("node_modules/.cache/turbo"),
+				cwd:                 defaultCwd,
+				cacheFolder:         defaultCacheFolder,
 			},
 		},
 		{
@@ -82,7 +90,8 @@ func TestParseConfig(t *testing.T) {
 				cache:               true,
 				forceExecution:      false,
 				profile:             "",
-				cacheFolder:         filepath.FromSlash("node_modules/.cache/turbo"),
+				cwd:                 defaultCwd,
+				cacheFolder:         defaultCacheFolder,
 			},
 		},
 		{
@@ -98,7 +107,8 @@ func TestParseConfig(t *testing.T) {
 				cache:               true,
 				forceExecution:      false,
 				profile:             "",
-				cacheFolder:         filepath.FromSlash("node_modules/.cache/turbo"),
+				cwd:                 defaultCwd,
+				cacheFolder:         defaultCacheFolder,
 			},
 		},
 		{
@@ -114,7 +124,8 @@ func TestParseConfig(t *testing.T) {
 				cache:               true,
 				forceExecution:      false,
 				profile:             "",
-				cacheFolder:         filepath.FromSlash("node_modules/.cache/turbo"),
+				cwd:                 defaultCwd,
+				cacheFolder:         defaultCacheFolder,
 				passThroughArgs:     []string{"--boop", "zoop"},
 			},
 		},
@@ -131,7 +142,8 @@ func TestParseConfig(t *testing.T) {
 				cache:               true,
 				forceExecution:      false,
 				profile:             "",
-				cacheFolder:         filepath.FromSlash("node_modules/.cache/turbo"),
+				cwd:                 defaultCwd,
+				cacheFolder:         defaultCacheFolder,
 				passThroughArgs:     []string{},
 			},
 		},

--- a/cli/internal/run/run_test.go
+++ b/cli/internal/run/run_test.go
@@ -146,7 +146,7 @@ func TestParseConfig(t *testing.T) {
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.Name), func(t *testing.T) {
 
-			actual, err := parseRunArgs(tc.Args, ".", ui)
+			actual, err := parseRunArgs(tc.Args, ui)
 			if err != nil {
 				t.Fatalf("invalid parse: %#v", err)
 			}


### PR DESCRIPTION
`turbo run` should now work properly with the `--cwd` flag. Cleaned up a bunch of usages of implicit current directory as well as `os.Getwd()`