### PR TITLE
Continue evolving `Context` towards a data structure that can be sent over the wire

### DIFF
--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -32,7 +32,6 @@ type Context struct {
 	PackageInfos           map[interface{}]*fs.PackageJSON
 	PackageNames           []string
 	TopologicalGraph       dag.AcyclicGraph
-	TaskGraph              dag.AcyclicGraph
 	Dir                    string
 	RootNode               string
 	RootPackageJSON        *fs.PackageJSON
@@ -89,8 +88,6 @@ func WithGraph(rootpath string, config *config.Config) Option {
 	return func(c *Context) error {
 		c.PackageInfos = make(map[interface{}]*fs.PackageJSON)
 		c.RootNode = core.ROOT_NODE_NAME
-		// Need to ALWAYS have a root node, might as well do it now
-		c.TaskGraph.Add(core.ROOT_NODE_NAME)
 
 		packageJSONPath := filepath.Join(rootpath, "package.json")
 		pkg, err := fs.ReadPackageJSON(packageJSONPath)

--- a/cli/internal/context/context_test.go
+++ b/cli/internal/context/context_test.go
@@ -1,9 +1,9 @@
 package context
 
 import (
-	"os"
 	"reflect"
 	"testing"
+
 	"github.com/vercel/turborepo/cli/internal/fs"
 )
 
@@ -96,14 +96,15 @@ func TestGetTargetsFromArguments(t *testing.T) {
 }
 
 func Test_getHashableTurboEnvVarsFromOs(t *testing.T) {
-	os.Setenv("SOME_ENV_VAR", "excluded")
-	os.Setenv("SOME_OTHER_ENV_VAR", "excluded")
-	os.Setenv("FIRST_THASH_ENV_VAR", "first")
-	os.Setenv("TURBO_TOKEN", "never")
-	os.Setenv("SOME_OTHER_THASH_ENV_VAR", "second")
-	os.Setenv("TURBO_TEAM", "never")
-
-	gotNames, gotPairs := getHashableTurboEnvVarsFromOs()
+	env := []string{
+		"SOME_ENV_VAR=excluded",
+		"SOME_OTHER_ENV_VAR=excluded",
+		"FIRST_THASH_ENV_VAR=first",
+		"TURBO_TOKEN=never",
+		"SOME_OTHER_THASH_ENV_VAR=second",
+		"TURBO_TEAM=never",
+	}
+	gotNames, gotPairs := getHashableTurboEnvVarsFromOs(env)
 	wantNames := []string{"FIRST_THASH_ENV_VAR", "SOME_OTHER_THASH_ENV_VAR"}
 	wantPairs := []string{"FIRST_THASH_ENV_VAR=first", "SOME_OTHER_THASH_ENV_VAR=second"}
 	if !reflect.DeepEqual(wantNames, gotNames) {

--- a/cli/internal/prune/prune.go
+++ b/cli/internal/prune/prune.go
@@ -100,7 +100,7 @@ func (c *PruneCommand) Run(args []string) int {
 		c.logError(c.Config.Logger, "", err)
 		return 1
 	}
-	ctx, err := context.New(context.WithTracer(""), context.WithArgs(args), context.WithGraph(pruneOptions.cwd, c.Config))
+	ctx, err := context.New(context.WithGraph(pruneOptions.cwd, c.Config))
 
 	if err != nil {
 		c.logError(c.Config.Logger, "", fmt.Errorf("could not construct graph: %w", err))

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -143,9 +143,14 @@ func (c *RunCommand) Run(args []string) int {
 
 	c.Config.Cache.Dir = runOptions.cacheFolder
 
-	ctx, err := context.New(context.WithTracer(runOptions.profile), context.WithArgs(args), context.WithGraph(runOptions.cwd, c.Config))
+	ctx, err := context.New(context.WithGraph(runOptions.cwd, c.Config))
 	if err != nil {
 		c.logError(c.Config.Logger, "", err)
+		return 1
+	}
+	targets, err := context.GetTargetsFromArguments(args, ctx.TurboConfig)
+	if err != nil {
+		c.logError(c.Config.Logger, "", fmt.Errorf("failed to resolve targets: %w", err))
 		return 1
 	}
 
@@ -308,7 +313,7 @@ func (c *RunCommand) Run(args []string) int {
 		RootNode:         ctx.RootNode,
 	}
 	rs := &runSpec{
-		Targets:      ctx.Targets,
+		Targets:      targets,
 		FilteredPkgs: filteredPkgs,
 		Opts:         runOptions,
 	}


### PR DESCRIPTION
 * `Args` doesn't need to hang off of `Context`
 * `TraceFilePath` isn't used, tracing is done via `RunState` instead.
 * global hash calculations and root `package.json` calculations can use local variables
 * `TaskGraph` is unused.