### PR TITLE
fix(yarn-pnp): fixing generateBinPath when yarn pnp is enabled

### DIFF
--- a/cli/npm/turbo-install/node-platform.js
+++ b/cli/npm/turbo-install/node-platform.js
@@ -107,7 +107,7 @@ by turbo to install the correct binary executable for your current platform.`);
     isYarnPnP = true;
   } catch (e) {}
   if (isYarnPnP) {
-    const turboLibDir = path.dirname(require.resolve("turbo"));
+    const turboLibDir = path.dirname(require.resolve("turbo/package.json"));
     const binTargetPath = path.join(
       turboLibDir,
       `pnpapi-${pkg}-${path.basename(subpath)}`


### PR DESCRIPTION
As mentioned here: https://github.com/vercel/turborepo/issues/693#issuecomment-1055497641

The call to require.resolve(turbo) was failing because the package does not have a main export
defined in the package.json, nor is there an index.js. Since we are just looking for the directory
the package is unplugged into, we can resolve the path to the package.json and get the dirname
of that.

This basically fixes things to the point where the binary is able to execute before hitting the nodeLinker
checks and bailing out with a proper error message.

Before:
```
> yarn turbo --version
C:\source\test-repo\.yarn\unplugged\turbo-npm-1.1.4-c2216ae885\node_modules\turbo\bin\turbo:13
    throw e;
    ^

Error: Qualified path resolution failed - none of those files can be found on the disk.

Source path: C:\source\test-repo\.yarn\unplugged\turbo-npm-1.1.4-c2216ae885\node_modules\turbo\
Not found: C:\source\test-repo\.yarn\unplugged\turbo-npm-1.1.4-c2216ae885\node_modules\turbo\
Not found: C:\source\test-repo\.yarn\unplugged\turbo-npm-1.1.4-c2216ae885\node_modules\turbo\.js
Not found: C:\source\test-repo\.yarn\unplugged\turbo-npm-1.1.4-c2216ae885\node_modules\turbo\.json
Not found: C:\source\test-repo\.yarn\unplugged\turbo-npm-1.1.4-c2216ae885\node_modules\turbo\.node
Not found: C:\source\test-repo\.yarn\unplugged\turbo-npm-1.1.4-c2216ae885\node_modules\turbo\index.js
Not found: C:\source\test-repo\.yarn\unplugged\turbo-npm-1.1.4-c2216ae885\node_modules\turbo\index.json
Not found: C:\source\test-repo\.yarn\unplugged\turbo-npm-1.1.4-c2216ae885\node_modules\turbo\index.node

Require stack:
- C:\source\test-repo\.yarn\unplugged\turbo-npm-1.1.4-c2216ae885\node_modules\turbo\node-platform.js
- C:\source\test-repo\.yarn\unplugged\turbo-npm-1.1.4-c2216ae885\node_modules\turbo\bin\turbo
```

After:
```
> yarn turbo --version
1.1.4
> yarn turbo run build
 ERROR  only yarn v2/v3 with `nodeLinker: node-modules` is supported at this time
```