### PR TITLE
depending on "*" should match everything

### DIFF
--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -105,7 +105,9 @@ func isWorkspaceReference(packageVersion string, dependencyVersion string, cwd s
 	} else if isProtocolExternal(protocol) {
 		// Other protocols are assumed to be external references ("github:", "link:", "file:" etc)
 		return false
-	}
+	} else if dependencyVersion == "*" {
+    return true
+  }
 
 	// If we got this far, then we need to check the workspace package version to see it satisfies
 	// the dependencies range to determin whether or not its an internal or external dependency.

--- a/cli/internal/context/context_test.go
+++ b/cli/internal/context/context_test.go
@@ -113,6 +113,12 @@ func Test_isWorkspaceReference(t *testing.T) {
 			dependencyVersion: "file:../../../otherproject",
 			want:              false, // this is not within the repo root
 		},
+		{
+			name:              "handles development versions",
+			packageVersion:    "0.0.0-development",
+			dependencyVersion: "*",
+			want:              true, // "*" should always match
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This technically doesn't conform to semver. `yarn`, `berry`, `pnpm`, and `npm` use `includePrerelease` in their matching, which goes a bit beyond this, so there may be more work required.

However, this change unblocks usage of tools like [semantic release](https://github.com/semantic-release/semantic-release)