### PR TITLE
Allow specifying cache outputs outside of package folder

### DIFF
--- a/cli/internal/cache/cache_fs.go
+++ b/cli/internal/cache/cache_fs.go
@@ -3,9 +3,10 @@ package cache
 import (
 	"encoding/json"
 	"fmt"
-	"runtime"
-	"path/filepath"
 	"io/ioutil"
+	"path/filepath"
+	"runtime"
+
 	"github.com/vercel/turborepo/cli/internal/analytics"
 	"github.com/vercel/turborepo/cli/internal/config"
 	"github.com/vercel/turborepo/cli/internal/fs"
@@ -67,22 +68,18 @@ func (f *fsCache) logFetch(hit bool, hash string, duration int) {
 func (f *fsCache) Put(target, hash string, duration int, files []string) error {
 	g := new(errgroup.Group)
 
-  numDigesters := runtime.NumCPU()
+	numDigesters := runtime.NumCPU()
 	fileQueue := make(chan string, numDigesters)
 
 	for i := 0; i < numDigesters; i++ {
 		g.Go(func() error {
 			for file := range fileQueue {
-				rel, err := filepath.Rel(target, file)
-				if err != nil {
-					return fmt.Errorf("error constructing relative path from %v to %v: %w", target, file, err)
-				}
 				if !fs.IsDirectory(file) {
-					if err := fs.EnsureDir(filepath.Join(f.cacheDirectory, hash, rel)); err != nil {
+					if err := fs.EnsureDir(filepath.Join(f.cacheDirectory, hash, file)); err != nil {
 						return fmt.Errorf("error ensuring directory file from cache: %w", err)
 					}
 
-					if err := fs.CopyOrLinkFile(file, filepath.Join(f.cacheDirectory, hash, rel), fs.DirPermissions, fs.DirPermissions, true, true); err != nil {
+					if err := fs.CopyOrLinkFile(file, filepath.Join(f.cacheDirectory, hash, file), fs.DirPermissions, fs.DirPermissions, true, true); err != nil {
 						return fmt.Errorf("error copying file from cache: %w", err)
 					}
 				}

--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -25,7 +25,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const GLOBAL_CACHE_KEY = "snozzberries"
+const GLOBAL_CACHE_KEY = "snozzberries are delicious"
 
 // Context of the CLI
 type Context struct {
@@ -106,8 +106,8 @@ func isWorkspaceReference(packageVersion string, dependencyVersion string, cwd s
 		// Other protocols are assumed to be external references ("github:", "link:", "file:" etc)
 		return false
 	} else if dependencyVersion == "*" {
-    return true
-  }
+		return true
+	}
 
 	// If we got this far, then we need to check the workspace package version to see it satisfies
 	// the dependencies range to determin whether or not its an internal or external dependency.

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -407,7 +407,7 @@ func (c *RunCommand) runOperation(g *completeGraph, rs *runSpec, backend *api.La
 				// Cache ---------------------------------------------
 				var hit bool
 				if !rs.Opts.forceExecution {
-					hit, _, _, err = turboCache.Fetch(pack.Dir, hash, nil)
+					hit, _, _, err = turboCache.Fetch(rs.Opts.cwd, hash, nil)
 					if err != nil {
 						targetUi.Error(fmt.Sprintf("error fetching from cache: %s", err))
 					} else if hit {

--- a/cli/scripts/e2e/e2e.ts
+++ b/cli/scripts/e2e/e2e.ts
@@ -74,6 +74,7 @@ function runSmokeTests<T>(
       assert.ok(!!hash, "No hash for c#test");
       const cachedLogFilePath = getCachedLogFilePathForTask(
         getCachedDirForHash(repo, hash),
+        path.join("packages", "c"),
         "test"
       );
       let text = "";
@@ -334,7 +335,8 @@ function getCachedDirForHash(repo: Monorepo, hash: string): string {
 
 function getCachedLogFilePathForTask(
   cacheDir: string,
+  pathToPackage: string,
   taskName: string
 ): string {
-  return path.join(cacheDir, ".turbo", `turbo-${taskName}.log`);
+  return path.join(cacheDir, pathToPackage, ".turbo", `turbo-${taskName}.log`);
 }


### PR DESCRIPTION
This allows people to specify `outputs` outside of the package folder from which the command originated, which is especially useful for code-generation tools and polyglot repos. To enable this, we store artifacts in the cache relative to the root of the monorepo (see screenshot) below for before (top) and after (bottom).

<img width="419" alt="CleanShot 2022-03-10 at 12 58 21@2x" src="https://user-images.githubusercontent.com/4060187/157725834-a19ffb57-d310-41d7-b44e-b95ddcd48a17.png">

Since we are changing how cache is structured, I updated the global cache key in turbo in order to prevent prior old artifacts from ever ever being cache hits with after this change

The only downside to this change, which might not be a downside at all, I guess, is possibility that artifacts are now tied to the directory structure of outputs relative to the root of the monorepo. 