### PR TITLE
docs: make remote caching evergreen

### DIFF
--- a/docs/pages/docs/getting-started.mdx
+++ b/docs/pages/docs/getting-started.mdx
@@ -166,7 +166,7 @@ Turborepo can use a technique known as Remote Caching to share cache artifacts a
 
 ### Link Your Turborepo to Your Remote Cache
 
-As part of Turborepo's initial public launch, [Vercel](https://vercel.com?utm_source=turborepo.org&utm_medium=referral&utm_campaign=docs-link) is offering **free remote caching** on all accounts with zero-configuration needed.
+Remote caching is available with zero configuration on [Vercel](https://vercel.com?utm_source=turborepo.org&utm_medium=referral&utm_campaign=docs-link).
 
 #### Using Remote Caching for Local development
 


### PR DESCRIPTION
Since Turborepo is moving past its "initial public launch" phase, here's a more evergreen statement about remote caching on Vercel.