### PR TITLE
Switch task graph edges to direct dependencies

### DIFF
--- a/cli/internal/core/scheduler.go
+++ b/cli/internal/core/scheduler.go
@@ -157,15 +157,10 @@ func (p *Scheduler) generateTaskGraph(scope []string, taskNames []string, tasksO
 			}
 
 			if hasTopoDeps {
+        depPkgs := p.TopologicGraph.DownEdges(pkg)
 				for _, from := range task.TopoDeps.UnsafeListOfStrings() {
-					// TODO: this should move out of the loop???
-					depPkgs, err := p.TopologicGraph.Ancestors(pkg)
-					if err != nil {
-						return fmt.Errorf("error getting ancestors: %w", err)
-					}
-
 					// add task dep from all the package deps within repo
-					for _, depPkg := range depPkgs.List() {
+					for depPkg := range depPkgs {
 						fromTaskId := util.GetTaskId(depPkg, from)
 						taskDeps = append(taskDeps, []string{fromTaskId, toTaskId})
 						p.TaskGraph.Add(fromTaskId)


### PR DESCRIPTION
The main change in this PR switches the task graph construction to add edges only between direct dependencies, rather than the entire ancestor subtree. 

As an example, say `a` depends on `b`, `b` depends on `c`. If `b#build` depends on `c#some-task`, and a#build` depends on `^build`. 

Currently, running `a#build` will do `c#some-task`, `c#build`, `b#build`, and `a#build`.
But, we don't need `c#build`. We just need `c#some-task`, since that's what `b#build` depends on, and `a` doesn't really know anything about `c` directly, just via `b`. So, we instead just draw an edge to direct dependencies, and then let them sort out their own dependencies.

For a large example, here are before and after graphs for running `turbo run build` in `examples/kitchen-sink`:

Before:
![shallow](https://user-images.githubusercontent.com/418301/157995307-98883886-c485-4451-9a00-97f13fcc3c65.png)

After:
![deep](https://user-images.githubusercontent.com/418301/157995266-06823c82-2435-4443-bfa6-0a90c57130be.png)




Also get rid of an unused field, `taskDeps`, on `Scheduler`.
