### PR TITLE
Allow concurrency to be set with percentage values

### DIFF
--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -12,7 +12,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"text/tabwriter"
@@ -541,14 +540,11 @@ func parseRunArgs(args []string, output cli.Ui) (*RunOptions, error) {
 				output.Warn("[WARNING] The --serial flag has been deprecated and will be removed in future versions of turbo. Please use `--concurrency=1` instead")
 				runOptions.concurrency = 1
 			case strings.HasPrefix(arg, "--concurrency"):
-				if i, err := strconv.Atoi(arg[len("--concurrency="):]); err != nil {
-					return nil, fmt.Errorf("invalid value for --concurrency CLI flag. This should be a positive integer greater than or equal to 1: %w", err)
+				concurrencyRaw := arg[len("--concurrency="):]
+				if concurrency, err := util.ParseConcurrency(concurrencyRaw); err != nil {
+					return nil, err
 				} else {
-					if i >= 1 {
-						runOptions.concurrency = i
-					} else {
-						return nil, fmt.Errorf("invalid value %v for --concurrency CLI flag. This should be a positive integer greater than or equal to 1", i)
-					}
+					runOptions.concurrency = concurrency
 				}
 			case strings.HasPrefix(arg, "--includeDependencies"):
 				output.Warn("[WARNING] The --includeDependencies flag has renamed to --include-dependencies for consistency. Please use `--include-dependencies` instead")

--- a/cli/internal/run/run_test.go
+++ b/cli/internal/run/run_test.go
@@ -177,7 +177,7 @@ func TestParseConfig(t *testing.T) {
 			if err != nil {
 				t.Fatalf("invalid parse: %#v", err)
 			}
-			assert.EqualValues(t, actual, tc.Expected)
+			assert.EqualValues(t, tc.Expected, actual)
 		})
 	}
 }

--- a/cli/internal/util/parse_concurrency.go
+++ b/cli/internal/util/parse_concurrency.go
@@ -16,21 +16,21 @@ var (
 func ParseConcurrency(concurrencyRaw string) (int, error) {
 	if strings.HasSuffix(concurrencyRaw, "%") {
 		if percent, err := strconv.ParseFloat(concurrencyRaw[:len(concurrencyRaw)-1], 64); err != nil {
-			return -1, fmt.Errorf("invalid value for --concurrency CLI flag. This should be a number --concurrency=4 or percentage of CPU cores --concurrency=50%% : %w", err)
+			return 0, fmt.Errorf("invalid value for --concurrency CLI flag. This should be a number --concurrency=4 or percentage of CPU cores --concurrency=50%% : %w", err)
 		} else {
 			if percent > 0 {
 				return int(math.Max(1, float64(runtimeNumCPU())*percent/100)), nil
 			} else {
-				return -1, fmt.Errorf("invalid percentage value for --concurrency CLI flag. This should be a percentage of CPU cores, betteen 1%% and 100%% : %w", err)
+				return 0, fmt.Errorf("invalid percentage value for --concurrency CLI flag. This should be a percentage of CPU cores, betteen 1%% and 100%% : %w", err)
 			}
 		}
 	} else if i, err := strconv.Atoi(concurrencyRaw); err != nil {
-		return -1, fmt.Errorf("invalid value for --concurrency CLI flag. This should be a positive integer greater than or equal to 1: %w", err)
+		return 0, fmt.Errorf("invalid value for --concurrency CLI flag. This should be a positive integer greater than or equal to 1: %w", err)
 	} else {
 		if i >= 1 {
 			return i, nil
 		} else {
-			return -1, fmt.Errorf("invalid value %v for --concurrency CLI flag. This should be a positive integer greater than or equal to 1", i)
+			return 0, fmt.Errorf("invalid value %v for --concurrency CLI flag. This should be a positive integer greater than or equal to 1", i)
 		}
 	}
 }

--- a/cli/internal/util/parse_concurrency.go
+++ b/cli/internal/util/parse_concurrency.go
@@ -1,0 +1,36 @@
+package util
+
+import (
+	"fmt"
+	"math"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+var (
+	// alias so we can mock in tests
+	runtimeNumCPU = runtime.NumCPU
+)
+
+func ParseConcurrency(concurrencyRaw string) (int, error) {
+	if strings.HasSuffix(concurrencyRaw, "%") {
+		if percent, err := strconv.ParseFloat(concurrencyRaw[:len(concurrencyRaw)-1], 64); err != nil {
+			return -1, fmt.Errorf("invalid value for --concurrency CLI flag. This should be a number --concurrency=4 or percentage of CPU cores --concurrency=50%% : %w", err)
+		} else {
+			if percent > 0 {
+				return int(math.Max(1, float64(runtimeNumCPU())*percent/100)), nil
+			} else {
+				return -1, fmt.Errorf("invalid percentage value for --concurrency CLI flag. This should be a percentage of CPU cores, betteen 1%% and 100%% : %w", err)
+			}
+		}
+	} else if i, err := strconv.Atoi(concurrencyRaw); err != nil {
+		return -1, fmt.Errorf("invalid value for --concurrency CLI flag. This should be a positive integer greater than or equal to 1: %w", err)
+	} else {
+		if i >= 1 {
+			return i, nil
+		} else {
+			return -1, fmt.Errorf("invalid value %v for --concurrency CLI flag. This should be a positive integer greater than or equal to 1", i)
+		}
+	}
+}

--- a/cli/internal/util/parse_concurrency_test.go
+++ b/cli/internal/util/parse_concurrency_test.go
@@ -1,0 +1,69 @@
+package util
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestParseConcurrency(t *testing.T) {
+	cases := []struct {
+		Input    string
+		Expected int
+	}{
+		{
+			"12",
+			12,
+		},
+		{
+			"200%",
+			20,
+		},
+		{
+			"100%",
+			10,
+		},
+		{
+			"50%",
+			5,
+		},
+		{
+			"25%",
+			2,
+		},
+		{
+			"1%",
+			1,
+		},
+	}
+
+	// mock runtime.NumCPU() to 10
+	runtimeNumCPU = func() int {
+		return 10
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d) '%s' should be parsed at '%d'", i, tc.Input, tc.Expected), func(t *testing.T) {
+			if result, err := ParseConcurrency(tc.Input); err != nil {
+				t.Fatalf("invalid parse: %#v", err)
+			} else {
+				assert.EqualValues(t, tc.Expected, result)
+			}
+		})
+	}
+
+	t.Run("throw on invalid string input", func(t *testing.T) {
+		_, err := ParseConcurrency("asdf")
+		assert.Error(t, err)
+	})
+
+	t.Run("throw on invalid number input", func(t *testing.T) {
+		_, err := ParseConcurrency("-1")
+		assert.Error(t, err)
+	})
+
+	t.Run("throw on invalid percent input - negative", func(t *testing.T) {
+		_, err := ParseConcurrency("-1%")
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
Closes #761

This is modeled after the way that `jest` [allows to set workers by providing a percent with `--maxWorkers=50%`](https://jestjs.io/docs/configuration#maxworkers-number--string).

I've updated Turbo's CLI parsing to accept `--concurrency=50%`. It also supports percentages over 100%, so  `--concurrency=500%` is valid. It uses `runtime.NumCPU()` to get the number of available logical processors, and calculates from there.

Setting the percentage to zero or less is an error. Setting percentage very low, to eg `1%` results in always at least `1` as the value for concurrency.