### PR TITLE
Hash correct file paths for global dependencies

### DIFF
--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -541,7 +541,7 @@ func calculateGlobalHash(rootpath string, rootPackageJSON *fs.PackageJSON, exter
 	}
 
 	// No prefix, global deps already have full paths
-	globalFileHashMap, err := fs.GitHashForFiles(globalDeps.UnsafeListOfStrings())
+	globalFileHashMap, err := fs.GetHashableDeps(globalDeps.UnsafeListOfStrings(), rootpath)
 	if err != nil {
 		return "", fmt.Errorf("error hashing files. make sure that git has been initialized %w", err)
 	}

--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -536,11 +536,12 @@ func calculateGlobalHash(rootpath string, rootPackageJSON *fs.PackageJSON, exter
 
 	if !util.IsYarn(backend.Name) {
 		// If we are not in Yarn, add the specfile and lockfile to global deps
-		globalDeps.Add(backend.Specfile)
-		globalDeps.Add(backend.Lockfile)
+		globalDeps.Add(filepath.Join(rootpath, backend.Specfile))
+		globalDeps.Add(filepath.Join(rootpath, backend.Lockfile))
 	}
 
-	globalFileHashMap, err := fs.GitHashForFiles(globalDeps.UnsafeListOfStrings(), rootpath)
+	// No prefix, global deps already have full paths
+	globalFileHashMap, err := fs.GitHashForFiles(globalDeps.UnsafeListOfStrings())
 	if err != nil {
 		return "", fmt.Errorf("error hashing files. make sure that git has been initialized %w", err)
 	}

--- a/cli/internal/fs/package_deps_hash.go
+++ b/cli/internal/fs/package_deps_hash.go
@@ -38,6 +38,7 @@ func GetPackageDeps(p *PackageDepsOptions) (map[string]string, error) {
 		return nil, fmt.Errorf("could not get git hashes for files in package %s: %w", p.PackagePath, err)
 	}
 	// Add all the checked in hashes.
+	// TODO(gsoltis): are these platform-dependent paths?
 	result := parseGitLsTree(gitLsOutput)
 
 	if len(p.ExcludedPaths) > 0 {
@@ -61,7 +62,14 @@ func GetPackageDeps(p *PackageDepsOptions) (map[string]string, error) {
 			filesToHash = append(filesToHash, filepath.Join(p.PackagePath, filename))
 		}
 	}
-	return GetHashableDeps(filesToHash, p.PackagePath)
+	hashes, err := GetHashableDeps(filesToHash, p.PackagePath)
+	if err != nil {
+		return nil, err
+	}
+	for key, hash := range hashes {
+		result[key] = hash
+	}
+	return result, nil
 }
 
 // GetHashableDeps hashes the list of given files, then returns a map of normalized path to hash

--- a/cli/internal/fs/package_deps_hash_test.go
+++ b/cli/internal/fs/package_deps_hash_test.go
@@ -1,6 +1,8 @@
 package fs
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -82,4 +84,43 @@ R  turbo.config.js -> turboooz.config.js
 ?? package_deps_hash.go
 ?? package_deps_hash_test.go`
 	assert.EqualValues(t, want, parseGitStatus(input, ""))
+}
+
+func Test_GetHashableDeps(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd %v", err)
+	}
+	cliDir, err := filepath.Abs(filepath.Join(cwd, "..", ".."))
+	if err != nil {
+		t.Fatalf("failed to get cli dir: %v", err)
+	}
+	if filepath.Base(cliDir) != "cli" {
+		t.Fatalf("did not find cli dir, found %v", cliDir)
+	}
+	turboPath := filepath.Join(cliDir, "..", "turbo.json")
+	makefilePath := filepath.Join(cliDir, "Makefile")
+	mainPath := filepath.Join(cliDir, "cmd", "turbo", "main.go")
+	hashes, err := GetHashableDeps([]string{turboPath, makefilePath, mainPath}, cliDir)
+	if err != nil {
+		t.Fatalf("failed to hash files: %v", err)
+	}
+	// Note that the paths here are platform independent, so hardcoded slashes should be fine
+	expected := []string{
+		"../turbo.json",
+		"Makefile",
+		"cmd/turbo/main.go",
+	}
+	for _, key := range expected {
+		if _, ok := hashes[key]; !ok {
+			t.Errorf("hashes missing %v", key)
+		}
+	}
+	if len(hashes) != len(expected) {
+		keys := []string{}
+		for key := range hashes {
+			keys = append(keys, key)
+		}
+		t.Errorf("hashes mismatch. got %v want %v", strings.Join(keys, ", "), strings.Join(expected, ", "))
+	}
 }

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -4,7 +4,7 @@ This is an official starter turborepo.
 
 ## What's inside?
 
-This turborepo uses [Yarn](https://classic.yarnpkg.com/lang/en/) as a package manager. It includes the following packages/apps:
+This turborepo includes the following packages/apps:
 
 ### Apps and Packages
 


### PR DESCRIPTION
Fixes #886 

`GitHashForFiles` now takes absolute paths for all files. It was previously receiving a mix of absolute and relative paths. Also clean up execution of `git hash-objects` a little.