### PR TITLE
[Fix] Update CONTRIBUTING.md for pnpm. Use pnpm to run line-staged

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Dependencies
 
 1.  On OSX: `brew install sponge`
-2.  Run `yarn` at root
+2.  Run `pnpm install` at root
 
 Building
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     ]
   },
   "simple-git-hooks": {
-    "pre-commit": "lint-staged"
+    "pre-commit": "pnpm exec lint-staged"
   },
   "packageManager": "pnpm@6.32.2"
 }


### PR DESCRIPTION
Was hitting `lint-staged` command not found. 
I think the pre-commit linting was misconfigured based on https://github.com/toplenboren/simple-git-hooks