### PR TITLE
fix(remote-cache): use posix paths for tar archives

### DIFF
--- a/cli/internal/cache/cache_http.go
+++ b/cli/internal/cache/cache_http.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -76,11 +77,12 @@ func (cache *httpCache) storeFile(tw *tar.Writer, name string) error {
 	if info.Mode()&os.ModeSymlink != 0 {
 		target, _ = os.Readlink(name)
 	}
-	hdr, err := tar.FileInfoHeader(info, target)
+	hdr, err := tar.FileInfoHeader(info, filepath.ToSlash(target))
 	if err != nil {
 		return err
 	}
-	hdr.Name = name
+	// Ensure posix path for filename written in header.
+	hdr.Name = filepath.ToSlash(name)
 	// Zero out all timestamps.
 	hdr.ModTime = mtime
 	hdr.AccessTime = mtime


### PR DESCRIPTION
This should ensure that archives generated for remote caching have the directory
structure preserved in a consistant manner to what is generated on linux/mac

Fixes: #801

PR #891 I believe fixes the hash calculation so that a remote-cache generated on linux or mac can be consumed on windows and no longer results in a cache miss, but I still have concerns about consuming archives generated on windows from the linux environment. I have encountered some problems with builds failing because dependencies that should have been built were not found when building on CI and believe this may be the cause.