### PR TITLE
gaspar/revert trailer md5

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Build Basic",
+      "name": "Basic Turbo Build",
       "type": "go",
       "request": "launch",
       "mode": "debug",
@@ -21,15 +21,6 @@
       "program": "${workspaceRoot}/cli/cmd/turbo",
       "cwd": "${workspaceRoot}/examples/basic",
       "args": ["--version"]
-    },
-    {
-      "name": "Build All (Force)",
-      "type": "go",
-      "request": "launch",
-      "mode": "debug",
-      "program": "${workspaceRoot}/cli/cmd/turbo",
-      "cwd": "${workspaceRoot}",
-      "args": ["run", "build", "--force"]
     }
   ]
 }

--- a/cli/internal/client/client_test.go
+++ b/cli/internal/client/client_test.go
@@ -1,14 +1,10 @@
 package client
 
 import (
-	"crypto/md5"
-	"encoding/base64"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
-	"net/http/httptest"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -16,21 +12,22 @@ import (
 )
 
 func Test_sendToServer(t *testing.T) {
+	handler := http.NewServeMux()
 	ch := make(chan []byte, 1)
-	ts := httptest.NewServer(
-		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			defer req.Body.Close()
-			b, err := ioutil.ReadAll(req.Body)
-			if err != nil {
-				t.Errorf("failed to read request %v", err)
-			}
-			ch <- b
-			w.WriteHeader(200)
-			w.Write([]byte{})
-		}))
-	defer ts.Close()
+	handler.HandleFunc("/v8/artifacts/events", func(w http.ResponseWriter, req *http.Request) {
+		defer req.Body.Close()
+		b, err := ioutil.ReadAll(req.Body)
+		if err != nil {
+			t.Errorf("failed to read request %v", err)
+		}
+		ch <- b
+		w.WriteHeader(200)
+		w.Write([]byte{})
+	})
+	server := &http.Server{Addr: "localhost:8888", Handler: handler}
+	go server.ListenAndServe()
 
-	apiClient := NewClient(ts.URL, hclog.Default(), "v1", "", "my-team-slug", 1)
+	apiClient := NewClient("http://localhost:8888", hclog.Default(), "v1", "", "my-team-slug", 1)
 	apiClient.SetToken("my-token")
 
 	myUUID, err := uuid.NewUUID()
@@ -64,42 +61,6 @@ func Test_sendToServer(t *testing.T) {
 	if !reflect.DeepEqual(events, result) {
 		t.Errorf("roundtrip got %v, want %v", result, events)
 	}
-}
 
-func Test_PutArtifact(t *testing.T) {
-	ch := make(chan string, 2)
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		defer req.Body.Close()
-		b, err := ioutil.ReadAll(req.Body)
-		if err != nil {
-			t.Errorf("failed to read request %v", err)
-		}
-		ch <- string(b)
-		trailerMd5 := req.Trailer.Get("Content-MD5")
-		ch <- trailerMd5
-		w.WriteHeader(200)
-		w.Write([]byte{})
-	}))
-	defer ts.Close()
-
-	// Set up test expected values
-	apiClient := NewClient(ts.URL+"/hash", hclog.Default(), "v1", "", "my-team-slug", 1)
-	apiClient.SetToken("my-token")
-	expectedArtifactBody := "My string artifact"
-	artifactReader := strings.NewReader(expectedArtifactBody)
-	md5Sum := md5.Sum([]byte(expectedArtifactBody))
-	expectedMd5 := base64.StdEncoding.EncodeToString(md5Sum[:])
-
-	// Test Put Artifact
-	apiClient.PutArtifact("hash", 500, artifactReader)
-	testBody := <-ch
-	if expectedArtifactBody != testBody {
-		t.Errorf("Handler read '%v', wants '%v'", testBody, expectedArtifactBody)
-	}
-
-	testMd5 := <-ch
-	if expectedMd5 != testMd5 {
-		t.Errorf("Handler read trailer '%v', wants '%v'", testMd5, expectedMd5)
-	}
-
+	server.Close()
 }

--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -25,7 +25,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const GLOBAL_CACHE_KEY = "snozzberries are delicious"
+const GLOBAL_CACHE_KEY = "the hero we needed"
 
 // Context of the CLI
 type Context struct {


### PR DESCRIPTION
- Revert "Explicitly read the artifact into memory before uploading to the remote cache api (#898)"
- update global cache key
