### PR TITLE
Do not show >>> FULL TURBO on 0 attempt runs

### DIFF
--- a/cli/internal/run/run_state.go
+++ b/cli/internal/run/run_state.go
@@ -289,7 +289,7 @@ func (r *RunState) Close(Ui cli.Ui, filename string) error {
 		r.done <- "done"
 	}
 	maybeFullTurbo := ""
-	if r.Cached == r.Attempted {
+	if r.Cached == r.Attempted && r.Attempted > 0 {
 		maybeFullTurbo = ui.Rainbow(">>> FULL TURBO")
 	}
 	if r.runOptions.stream {


### PR DESCRIPTION
Close https://github.com/vercel/turborepo/issues/859

With this change, `>> FULL TURBO` will only ever show if more than 1 attempted task is run.

<img width="658" alt="CleanShot 2022-03-22 at 10 47 14@2x" src="https://user-images.githubusercontent.com/4060187/159509380-59ef4f8c-8642-4a83-8c02-a946e627a793.png">
