### PR TITLE
Don't squash tasks with package tasks

### DIFF
--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -370,8 +370,6 @@ func buildTaskGraph(topoGraph *dag.AcyclicGraph, pipeline map[string]fs.Pipeline
 					deps.Add(from)
 				}
 			}
-			_, id := util.GetPackageTaskFromId(taskName)
-			taskName = id
 		} else {
 			for _, from := range value.DependsOn {
 				if strings.HasPrefix(from, ENV_PIPELINE_DELIMITER) {

--- a/cli/internal/run/run_test.go
+++ b/cli/internal/run/run_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 
 	"github.com/mitchellh/cli"
+	"github.com/pyr-sh/dag"
 	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/util"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -299,5 +301,49 @@ func TestGetTargetsFromArguments(t *testing.T) {
 				t.Errorf("GetTargetsFromArguments() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func Test_dontSquashTasks(t *testing.T) {
+	topoGraph := &dag.AcyclicGraph{}
+	topoGraph.Add("a")
+	topoGraph.Add("b")
+	// no dependencies between packages
+
+	pipeline := map[string]fs.Pipeline{
+		"build": {
+			Outputs:   []string{},
+			DependsOn: []string{"generate"},
+		},
+		"generate": {
+			Outputs:   []string{},
+			DependsOn: []string{},
+		},
+		"b#build": {
+			Outputs:   []string{},
+			DependsOn: []string{},
+		},
+	}
+	filteredPkgs := make(util.Set)
+	filteredPkgs.Add("a")
+	filteredPkgs.Add("b")
+	rs := &runSpec{
+		FilteredPkgs: filteredPkgs,
+		Targets:      []string{"build"},
+		Opts:         &RunOptions{},
+	}
+	engine, err := buildTaskGraph(topoGraph, pipeline, rs)
+	if err != nil {
+		t.Fatalf("failed to build task graph: %v", err)
+	}
+	toRun := engine.TaskGraph.Vertices()
+	// 4 is the 3 tasks + root
+	if len(toRun) != 4 {
+		t.Errorf("expected 4 tasks, got %v", len(toRun))
+	}
+	for task := range pipeline {
+		if _, ok := engine.Tasks[task]; !ok {
+			t.Errorf("expected to find task %v in the task graph, but it is missing", task)
+		}
 	}
 }


### PR DESCRIPTION
Fixes #905 

Due to non-deterministic map iteration, we would squash one or the other of task definitions if we truncate package tasks to just their task name. Instead, use the full task name, with package qualifier if present, and properly pull them from the list of tasks inside the scheduler.