### PR TITLE
fix: Enable chrome tracing if `--profile` is specified

### DIFF
--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -691,7 +691,7 @@ func (c *RunCommand) executeTasks(g *completeGraph, rs *runSpec, engine *core.Sc
 	}
 
 	ec.logReplayWaitGroup.Wait()
-
+	fmt.Println(rs.Opts.profile)
 	if err := runState.Close(c.Ui, rs.Opts.profile); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error with profiler: %s", err.Error()))
 		return 1

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -691,7 +691,7 @@ func (c *RunCommand) executeTasks(g *completeGraph, rs *runSpec, engine *core.Sc
 	}
 
 	ec.logReplayWaitGroup.Wait()
-	fmt.Println(rs.Opts.profile)
+
 	if err := runState.Close(c.Ui, rs.Opts.profile); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error with profiler: %s", err.Error()))
 		return 1

--- a/cli/internal/run/run_state.go
+++ b/cli/internal/run/run_state.go
@@ -282,7 +282,7 @@ func (r *RunState) Close(Ui cli.Ui, filename string) error {
 		name = filename
 	}
 	if outputPath != "" {
-		if err := fs.CopyFile(chrometracing.Path(), name, fs.DirPermissions); err != nil {
+		if err := fs.CopyFile(outputPath, name, fs.DirPermissions); err != nil {
 			return err
 		}
 	}

--- a/cli/internal/run/run_state.go
+++ b/cli/internal/run/run_state.go
@@ -88,6 +88,9 @@ type RunState struct {
 }
 
 func NewRunState(runOptions *RunOptions, startedAt time.Time) *RunState {
+	if runOptions.profile != "" {
+		chrometracing.EnableTracing()
+	}
 	return &RunState{
 		Success:   0,
 		Failure:   0,


### PR DESCRIPTION
During refactoring of `context` it seems that `--profile` flag was no longer working. This turns on chrometracing if `--profile` has a value