### PR TITLE
Include entry packages, not just dependencies when checking changed packages.

### DIFF
--- a/cli/internal/scope/filter/filter.go
+++ b/cli/internal/scope/filter/filter.go
@@ -292,7 +292,11 @@ func (r *Resolver) filterSubtreesWithSelector(selector *TargetSelector) (util.Se
 			return nil, err
 		}
 		for changedPkg := range changedPkgs {
-			if deps.Include(changedPkg) {
+			if !selector.excludeSelf && pkg == changedPkg {
+        roots.Add(pkg)
+        break
+      }
+      if deps.Include(changedPkg) {
 				roots.Add(pkg)
 				matched.Add(changedPkg)
 				break

--- a/cli/internal/scope/filter/filter_test.go
+++ b/cli/internal/scope/filter/filter_test.go
@@ -440,6 +440,19 @@ func Test_SCM(t *testing.T) {
 		},
 		// Note: missing test here that takes advantage of automatically exempting
 		// test-only changes from pulling in dependents
+		//
+		// turbo-specific tests below here
+		{
+			"changed package was requested scope, and we're matching dependencies",
+			[]*TargetSelector{
+				{
+					diff:              "HEAD~1",
+					namePattern:       "package-1",
+					matchDependencies: true,
+				},
+			},
+			[]string{"package-1"},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
When we're matching dependencies, make sure to check if the named package is the one that changed