### PR TITLE
Throw if empty filter set is calculated

### DIFF
--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -200,7 +200,8 @@ func (c *RunCommand) Run(args []string) int {
 	}
 	filteredPkgs, err := scope.ResolvePackages(runOptions.scopeOpts(), scmInstance, ctx, c.Ui, c.Config.Logger)
 	if err != nil {
-		c.logError(c.Config.Logger, "", fmt.Errorf("failed resolve packages to run %v", err))
+		c.logError(c.Config.Logger, "", fmt.Errorf("failed resolve packages to run: %v", err))
+		return 1
 	}
 	c.Config.Logger.Debug("global hash", "value", ctx.GlobalHash)
 	c.Config.Logger.Debug("local cache folder", "path", runOptions.cacheFolder)

--- a/cli/internal/scope/scope.go
+++ b/cli/internal/scope/scope.go
@@ -74,6 +74,10 @@ func ResolvePackages(opts *Opts, scm scm.SCM, ctx *context.Context, tui cli.Ui, 
 		return nil, err
 	}
 
+	if len(filterPatterns) > 0 && len(filteredPkgs) == 0 {
+		return nil, fmt.Errorf("no packages match the provided flag(s)")
+	}
+
 	if len(filterPatterns) == 0 {
 		// no filters specified, run every package
 		for _, f := range ctx.PackageNames {

--- a/cli/internal/scope/scope_test.go
+++ b/cli/internal/scope/scope_test.go
@@ -88,6 +88,7 @@ func TestResolvePackages(t *testing.T) {
 		name                string
 		changed             []string
 		expected            []string
+		wantErr             bool
 		scope               []string
 		since               string
 		ignore              string
@@ -105,6 +106,7 @@ func TestResolvePackages(t *testing.T) {
 			name:     "An ignored package changed",
 			changed:  []string{"libs/libB/src/index.ts"},
 			expected: []string{},
+			wantErr:  true,
 			since:    "dummy",
 			ignore:   "libs/libB/**/*.ts",
 		},
@@ -113,6 +115,7 @@ func TestResolvePackages(t *testing.T) {
 			name:                "unrelated library changed",
 			changed:             []string{"libs/libC/src/index.ts"},
 			expected:            []string{},
+			wantErr:             true,
 			since:               "dummy",
 			scope:               []string{"app1"},
 			includeDependencies: true, // scope implies include-dependencies
@@ -214,15 +217,21 @@ func TestResolvePackages(t *testing.T) {
 				TopologicalGraph: graph,
 				SCC:              scc,
 			}, tui, logger)
-			if err != nil {
-				t.Errorf("expected no error, got %v", err)
-			}
-			expected := make(util.Set)
-			for _, pkg := range tc.expected {
-				expected.Add(pkg)
-			}
-			if !reflect.DeepEqual(pkgs, expected) {
-				t.Errorf("ResolvePackages got %v, want %v", pkgs, expected)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("ResolvePackages got %#v, wantErr %#v", err, tc.wantErr)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, got %v", err)
+				}
+				expected := make(util.Set)
+				for _, pkg := range tc.expected {
+					expected.Add(pkg)
+				}
+				if !reflect.DeepEqual(pkgs, expected) {
+					t.Errorf("ResolvePackages got %v, want %v", pkgs, expected)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Fix #958 

This attempts to fix regression from 1.1.x. We currently throw if filters return an empty set. 

One weird thing think through, however, is what the exit code should be? Especially when doing stuff with `--since` and `--ignore-files`

- In the case of totally wrong match like `--filter=nonsense`, it's definitely an error, exit 1, and we should throw accordingly. 
- In the case of `--filter=app --since=something --ignore=files-in-the-app-that-have-changed` and that results in nothing to run, I think that should just be a no-op? No changes = no run, but exit 0. In CI, I would expect this to not to count as a failed run. 

@elado @migueloller what do you expect behavior to be here?