### PR TITLE
Only check for yarn berry if it is installed

### DIFF
--- a/cli/internal/util/backends.go
+++ b/cli/internal/util/backends.go
@@ -33,6 +33,9 @@ func IsBerry(cwd string, version string, pkgManager bool) (bool, error) {
 
 		return c.Check(v), nil
 	} else {
+		if !commandExists("yarn") {
+			return false, nil
+		}
 		cmd := exec.Command("yarn", "--version")
 		cmd.Dir = cwd
 		out, err := cmd.Output()
@@ -51,6 +54,11 @@ func IsBerry(cwd string, version string, pkgManager bool) (bool, error) {
 
 		return c.Check(v), nil
 	}
+}
+
+func commandExists(cmd string) bool {
+	_, err := exec.LookPath(cmd)
+	return err == nil
 }
 
 func IsNMLinker(cwd string) (bool, error) {


### PR DESCRIPTION
Fix https://github.com/vercel/turborepo/issues/962

In a follow up, we ideally should not need to make an `exec` call to start `yarn` which is written in node.js just to determine it's version. All we need to know is if it is greater than 2. We Also don't need to be parsing full semver. As soon as we know the first character is a >= 2 we know it is berry