### PR TITLE
fix(docs): use exact version

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -25,7 +25,7 @@
     "js-cookie": "3.0.1",
     "next": "12.1.0",
     "nextra": "2.0.0-alpha.48",
-    "nextra-theme-docs": "^2.0.0-alpha.48",
+    "nextra-theme-docs": "2.0.0-alpha.48",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-hot-toast": "2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,7 +79,7 @@ importers:
       js-cookie: 3.0.1
       next: 12.1.0
       nextra: 2.0.0-alpha.48
-      nextra-theme-docs: ^2.0.0-alpha.48
+      nextra-theme-docs: 2.0.0-alpha.48
       postcss: 8.3.5
       react: 17.0.2
       react-dom: 17.0.2


### PR DESCRIPTION
Since it's an alpha build, it should be exact version, otherwise managers do weird things