### PR TITLE
Drop behavior that was previously used in tests

### DIFF
--- a/cli/internal/core/scheduler.go
+++ b/cli/internal/core/scheduler.go
@@ -53,13 +53,6 @@ type SchedulerExecutionOptions struct {
 
 func (p *Scheduler) Prepare(options *SchedulerExecutionOptions) error {
 	pkgs := options.Packages
-	if len(pkgs) == 0 {
-		// TODO(gsoltis): Is this behavior only used in tests?
-		for _, v := range p.TopologicGraph.Vertices() {
-			pkgs = append(pkgs, dag.VertexName(v))
-		}
-	}
-
 	tasks := options.TaskNames
 	if len(tasks) == 0 {
 		// TODO(gsoltis): Is this behavior used?


### PR DESCRIPTION
We used to have some tests that depended on running against all packages if none were specified. Those tests have been refactored, and now we no longer need that specific hook.

Fixes #958 