### PR TITLE
chore(force_color): use FORCE_COLOR instead of FORCED_COLOR

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -144,5 +144,5 @@ jobs:
       - name: Check examples
         shell: bash
         env:
-          FORCED_COLOR: true
+          FORCE_COLOR: true
         run: ./scripts/run-examples.sh

--- a/cli/internal/ui/colors.go
+++ b/cli/internal/ui/colors.go
@@ -24,10 +24,10 @@ func GetColorModeFromEnv() ColorMode {
 	// respectively, so that behavior is reproduced here as well. 
 	// https://www.npmjs.com/package/supports-color
 
-	switch forcedColor := os.Getenv("FORCED_COLOR"); {
-	case forcedColor == "false" || forcedColor == "0":
+	switch forceColor := os.Getenv("FORCE_COLOR"); {
+	case forceColor == "false" || forceColor == "0":
 		return ColorModeSuppressed
-	case forcedColor == "true" || forcedColor == "1" || forcedColor == "2" || forcedColor == "3":
+	case forceColor == "true" || forceColor == "1" || forceColor == "2" || forceColor == "3":
 		return ColorModeForced
 	default:
 		return ColorModeUndefined

--- a/docs/pages/docs/reference/command-line-reference.mdx
+++ b/docs/pages/docs/reference/command-line-reference.mdx
@@ -39,13 +39,13 @@ have support for rendering color in their log output.
 turbo run build --color
 ```
 
-Alternatively, you can also enable color using the `FORCED_COLOR` environment variable (borrowed
+Alternatively, you can also enable color using the `FORCE_COLOR` environment variable (borrowed
 from the [supports-color nodejs package](https://www.npmjs.com/package/supports-color)). Going
 this route may also unlock some additional colored output from the actual tasks themselves if
 they use `supports-color` to determine whether or not to output with colored output.
 
 ```sh
-declare -x FORCED_COLOR=1
+declare -x FORCE_COLOR=1
 turbo run build
 ```
 
@@ -57,11 +57,11 @@ Suppresses the use of color in the output when running turbo in an interactive /
 turbo run build --no-color
 ```
 
-Alternatively, you can also suppress color using the `FORCED_COLOR` environment variable (borrowed
+Alternatively, you can also suppress color using the `FORCE_COLOR` environment variable (borrowed
 from the [supports-color nodejs package](https://www.npmjs.com/package/supports-color)).
 
 ```sh
-declare -x FORCED_COLOR=0
+declare -x FORCE_COLOR=0
 turbo run build
 ```
 


### PR DESCRIPTION
I had a typo in the environment variable name for the original commits.