### PR TITLE
Add back support for `link:...` dependencies

### DIFF
--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -86,7 +86,7 @@ func isWorkspaceReference(packageVersion string, dependencyVersion string, cwd s
 		// versions of the same package name, just assume its a match and don't check the range
 		// for an exact match.
 		return true
-	} else if protocol == "file" {
+	} else if protocol == "file" || protocol == "link" {
 		abs, err := filepath.Abs(filepath.Join(cwd, dependencyVersion))
 		if err != nil {
 			// Default to internal if we have the package but somehow cannot get the path
@@ -101,7 +101,7 @@ func isWorkspaceReference(packageVersion string, dependencyVersion string, cwd s
 		}
 		return isWithinRepo
 	} else if isProtocolExternal(protocol) {
-		// Other protocols are assumed to be external references ("github:", "link:", "file:" etc)
+		// Other protocols are assumed to be external references ("github:", etc)
 		return false
 	} else if dependencyVersion == "*" {
 		return true

--- a/cli/internal/context/context_test.go
+++ b/cli/internal/context/context_test.go
@@ -114,6 +114,18 @@ func Test_isWorkspaceReference(t *testing.T) {
 			want:              false, // this is not within the repo root
 		},
 		{
+			name:              "handles link:... inside repo",
+			packageVersion:    "1.2.3",
+			dependencyVersion: "link:../libB",
+			want:              true, // this is a sibling package
+		},
+		{
+			name:              "handles link:... outside repo",
+			packageVersion:    "1.2.3",
+			dependencyVersion: "link:../../../otherproject",
+			want:              false, // this is not within the repo root
+		},
+		{
 			name:              "handles development versions",
 			packageVersion:    "0.0.0-development",
 			dependencyVersion: "*",


### PR DESCRIPTION
This is similar to the work done for `file:...` dependencies in 32cebb1094bfb572fcdff01c0cb6d09f7538b418.

Check if file paths pointed to by `link:...` are within the monorepo.
If so, consider them internal dependencies, and otherwise consider them as external dependencies.

This can be useful because pnpm uses the `link:` protocol when using `pnpm install ./package-a/`.