### PR TITLE
Refactor Pipeline parsing

### DIFF
--- a/cli/internal/fs/package_json.go
+++ b/cli/internal/fs/package_json.go
@@ -19,7 +19,7 @@ type TurboConfigJSON struct {
 	GlobalDependencies []string `json:"globalDependencies,omitempty"`
 	// Pipeline is a map of Turbo pipeline entries which define the task graph
 	// and cache behavior on a per task or per package-task basis.
-	Pipeline PipelineConfig
+	Pipeline Pipeline
 	// Configuration options when interfacing with the remote cache
 	RemoteCacheOptions RemoteCacheOptions `json:"remoteCache,omitempty"`
 }
@@ -52,9 +52,9 @@ type pipelineJSON struct {
 	Inputs    []string  `json:"inputs,omitempty"`
 }
 
-type PipelineConfig map[string]Pipeline
+type Pipeline map[string]TaskDefinition
 
-func (pc PipelineConfig) GetPipeline(taskID string) (Pipeline, bool) {
+func (pc Pipeline) GetTaskDefinition(taskID string) (TaskDefinition, bool) {
 	if entry, ok := pc[taskID]; ok {
 		return entry, true
 	}
@@ -63,7 +63,7 @@ func (pc PipelineConfig) GetPipeline(taskID string) (Pipeline, bool) {
 	return entry, ok
 }
 
-type Pipeline struct {
+type TaskDefinition struct {
 	Outputs                 []string
 	ShouldCache             bool
 	EnvVarDependencies      []string
@@ -79,7 +79,7 @@ const (
 
 var defaultOutputs = []string{"dist/**/*", "build/**/*"}
 
-func (c *Pipeline) UnmarshalJSON(data []byte) error {
+func (c *TaskDefinition) UnmarshalJSON(data []byte) error {
 	rawPipeline := &pipelineJSON{}
 	if err := json.Unmarshal(data, &rawPipeline); err != nil {
 		return err

--- a/cli/internal/fs/package_json_test.go
+++ b/cli/internal/fs/package_json_test.go
@@ -20,7 +20,7 @@ func Test_ParseTurboConfigJson(t *testing.T) {
 		t.Fatalf("invalid parse: %#v", err)
 	}
 
-	pipelineExpected := map[string]Pipeline{
+	pipelineExpected := map[string]TaskDefinition{
 		"build": {
 			Outputs:                 []string{"dist/**", ".next/**"},
 			TopologicalDependencies: []string{"build"},

--- a/cli/internal/fs/package_json_test.go
+++ b/cli/internal/fs/package_json_test.go
@@ -3,6 +3,7 @@ package fs
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,29 +19,57 @@ func Test_ParseTurboConfigJson(t *testing.T) {
 	if err != nil {
 		t.Fatalf("invalid parse: %#v", err)
 	}
-	BoolFalse := false
 
-	build := Pipeline{
-		Outputs:   []string{"dist/**", ".next/**"},
-		DependsOn: []string{"^build"},
-		PPipeline: PPipeline{
-			Outputs:   &[]string{"dist/**", ".next/**"},
-			DependsOn: []string{"^build"},
+	pipelineExpected := map[string]Pipeline{
+		"build": {
+			Outputs:                 []string{"dist/**", ".next/**"},
+			TopologicalDependencies: []string{"build"},
+			EnvVarDependencies:      []string{},
+			TaskDependencies:        []string{},
+			ShouldCache:             true,
+		},
+		"lint": {
+			Outputs:                 []string{},
+			TopologicalDependencies: []string{},
+			EnvVarDependencies:      []string{"MY_VAR"},
+			TaskDependencies:        []string{},
+			ShouldCache:             true,
+		},
+		"dev": {
+			Outputs:                 defaultOutputs,
+			EnvVarDependencies:      []string{},
+			TopologicalDependencies: []string{},
+			TaskDependencies:        []string{},
+			ShouldCache:             false,
+		},
+		"publish": {
+			Outputs:                 []string{"dist/**"},
+			EnvVarDependencies:      []string{},
+			TopologicalDependencies: []string{"publish"},
+			TaskDependencies:        []string{"build", "admin#lint"},
+			ShouldCache:             false,
+			Inputs:                  []string{"build/**/*"},
 		},
 	}
-	lint := Pipeline{
-		Outputs:   []string{},
-		PPipeline: PPipeline{Outputs: &[]string{}},
-	}
-	dev := Pipeline{
-		Cache: &BoolFalse,
-		PPipeline: PPipeline{
-			Cache: &BoolFalse,
-		},
-	}
-	pipelineExpected := map[string]Pipeline{"build": build, "lint": lint, "dev": dev}
 
 	remoteCacheOptionsExpected := RemoteCacheOptions{"team_id", true}
-	assert.EqualValues(t, pipelineExpected, turboConfig.Pipeline)
+	if len(turboConfig.Pipeline) != len(pipelineExpected) {
+		expectedKeys := []string{}
+		for k := range pipelineExpected {
+			expectedKeys = append(expectedKeys, k)
+		}
+		actualKeys := []string{}
+		for k := range turboConfig.Pipeline {
+			actualKeys = append(actualKeys, k)
+		}
+		t.Errorf("pipeline tasks mismatch. got %v, want %v", strings.Join(actualKeys, ","), strings.Join(expectedKeys, ","))
+	}
+	for taskName, expectedTaskDefinition := range pipelineExpected {
+		actualTaskDefinition, ok := turboConfig.Pipeline[taskName]
+		if !ok {
+			t.Errorf("missing expected task: %v", taskName)
+		}
+		assert.EqualValuesf(t, expectedTaskDefinition, actualTaskDefinition, "task definition mismatch for %v", taskName)
+	}
 	assert.EqualValues(t, remoteCacheOptionsExpected, turboConfig.RemoteCacheOptions)
 }

--- a/cli/internal/fs/testdata/turbo.json
+++ b/cli/internal/fs/testdata/turbo.json
@@ -1,13 +1,36 @@
 {
   "pipeline": {
     "build": {
-      "dependsOn": ["^build"],
-      "outputs": ["dist/**", ".next/**"]
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "dist/**",
+        ".next/**"
+      ]
     },
     "lint": {
-      "outputs": []
+      "outputs": [],
+      "dependsOn": [
+        "$MY_VAR"
+      ],
+      "cache": true
     },
     "dev": {
+      "cache": false
+    },
+    "publish": {
+      "outputs": [
+        "dist/**"
+      ],
+      "inputs": [
+        "build/**/*"
+      ],
+      "dependsOn": [
+        "^publish",
+        "build",
+        "admin#lint"
+      ],
       "cache": false
     }
   },

--- a/cli/internal/run/hash.go
+++ b/cli/internal/run/hash.go
@@ -105,7 +105,7 @@ func manuallyHashPackage(pkg *fs.PackageJSON, inputs []string, rootPath string) 
 	}
 
 	pathPrefix := filepath.Join(rootPath, pkg.Dir)
-  toTrim := filepath.FromSlash(pathPrefix + "/")
+	toTrim := filepath.FromSlash(pathPrefix + "/")
 	fs.Walk(pathPrefix, func(name string, isDir bool) error {
 		rootMatch := ignore.MatchesPath(name)
 		otherMatch := ignorePkg.MatchesPath(name)
@@ -245,11 +245,8 @@ func (th *Tracker) CalculateTaskHash(pt *packageTask, dependencySet dag.Set, arg
 	}
 	outputs := pt.HashableOutputs()
 	hashableEnvPairs := []string{}
-	for _, v := range pt.pipeline.DependsOn {
-		if strings.Contains(v, ENV_PIPELINE_DELIMITER) {
-			trimmed := strings.TrimPrefix(v, ENV_PIPELINE_DELIMITER)
-			hashableEnvPairs = append(hashableEnvPairs, fmt.Sprintf("%v=%v", trimmed, os.Getenv(trimmed)))
-		}
+	for _, envVar := range pt.pipeline.EnvVarDependencies {
+		hashableEnvPairs = append(hashableEnvPairs, fmt.Sprintf("%v=%v", envVar, os.Getenv(envVar)))
 	}
 	sort.Strings(hashableEnvPairs)
 	taskDependencyHashes, err := th.calculateDependencyHashes(dependencySet)

--- a/cli/internal/run/run_test.go
+++ b/cli/internal/run/run_test.go
@@ -313,15 +313,13 @@ func Test_dontSquashTasks(t *testing.T) {
 	pipeline := map[string]fs.Pipeline{
 		"build": {
 			Outputs:   []string{},
-			DependsOn: []string{"generate"},
+			TaskDependencies: []string{"generate"},
 		},
 		"generate": {
 			Outputs:   []string{},
-			DependsOn: []string{},
 		},
 		"b#build": {
 			Outputs:   []string{},
-			DependsOn: []string{},
 		},
 	}
 	filteredPkgs := make(util.Set)

--- a/cli/internal/run/run_test.go
+++ b/cli/internal/run/run_test.go
@@ -232,7 +232,7 @@ func TestGetTargetsFromArguments(t *testing.T) {
 			args: args{
 				arguments: []string{"build"},
 				configJson: &fs.TurboConfigJSON{
-					Pipeline: map[string]fs.Pipeline{
+					Pipeline: map[string]fs.TaskDefinition{
 						"build":      {},
 						"test":       {},
 						"thing#test": {},
@@ -247,7 +247,7 @@ func TestGetTargetsFromArguments(t *testing.T) {
 			args: args{
 				arguments: []string{"build", "test", "--foo", "--bar"},
 				configJson: &fs.TurboConfigJSON{
-					Pipeline: map[string]fs.Pipeline{
+					Pipeline: map[string]fs.TaskDefinition{
 						"build":      {},
 						"test":       {},
 						"thing#test": {},
@@ -262,7 +262,7 @@ func TestGetTargetsFromArguments(t *testing.T) {
 			args: args{
 				arguments: []string{"build", "test", "--", "--foo", "build", "--cache-dir"},
 				configJson: &fs.TurboConfigJSON{
-					Pipeline: map[string]fs.Pipeline{
+					Pipeline: map[string]fs.TaskDefinition{
 						"build":      {},
 						"test":       {},
 						"thing#test": {},
@@ -277,7 +277,7 @@ func TestGetTargetsFromArguments(t *testing.T) {
 			args: args{
 				arguments: []string{"foo", "test", "--", "--foo", "build", "--cache-dir"},
 				configJson: &fs.TurboConfigJSON{
-					Pipeline: map[string]fs.Pipeline{
+					Pipeline: map[string]fs.TaskDefinition{
 						"build":      {},
 						"test":       {},
 						"thing#test": {},
@@ -310,7 +310,7 @@ func Test_dontSquashTasks(t *testing.T) {
 	topoGraph.Add("b")
 	// no dependencies between packages
 
-	pipeline := map[string]fs.Pipeline{
+	pipeline := map[string]fs.TaskDefinition{
 		"build": {
 			Outputs:   []string{},
 			TaskDependencies: []string{"generate"},


### PR DESCRIPTION
 * Avoid leaking the struct we parse to from JSON in the struct that we use in the remainder of the code
 * Make the struct we use in the remainder of the code more semantically useful. 
   * Parse out environment dependencies
   * Split task and topological dependencies
 * Apply default outputs during parsing, rather than during use
 * Rename `Pipeline` -> `TaskDefinition` and `PipelineConfig` -> `Pipeline`.
 
 Note that the merge base is #951, which we ought to merge first, and then update this to be against `main`.