### PR TITLE
Handle unknown package in graph traversal

### DIFF
--- a/cli/internal/core/scheduler.go
+++ b/cli/internal/core/scheduler.go
@@ -218,7 +218,11 @@ func (p *Scheduler) AddTask(task *Task) *Scheduler {
 	return p
 }
 
-func (p *Scheduler) AddDep(fromTaskId string, toTaskId string) *Scheduler {
+func (p *Scheduler) AddDep(fromTaskId string, toTaskId string) error {
+	fromPkg, _ := util.GetPackageTaskFromId(fromTaskId)
+	if fromPkg != ROOT_NODE_NAME && !p.TopologicGraph.HasVertex(fromPkg) {
+		return fmt.Errorf("found reference to unknown package: %v in task %v", fromPkg, fromTaskId)
+	}
 	p.PackageTaskDeps = append(p.PackageTaskDeps, []string{fromTaskId, toTaskId})
-	return p
+	return nil
 }

--- a/cli/internal/core/scheduler_test.go
+++ b/cli/internal/core/scheduler_test.go
@@ -79,6 +79,22 @@ func TestSchedulerDefault(t *testing.T) {
 	}
 }
 
+func TestUnknownDependency(t *testing.T) {
+	g := &dag.AcyclicGraph{}
+	g.Add("a")
+	g.Add("b")
+	g.Add("c")
+	p := NewScheduler(g)
+	err := p.AddDep("unknown#custom", "build")
+	if err == nil {
+		t.Error("expected error for unknown package, got nil")
+	}
+	err = p.AddDep("a#custom", "build")
+	if err != nil {
+		t.Errorf("expected no error for package task with known package, got %v", err)
+	}
+}
+
 func TestDependenciesOnUnspecifiedPackages(t *testing.T) {
 	// app1 -> libA
 	//              \


### PR DESCRIPTION
 * Check when adding package-task dependencies that the package in question exists
 * Don't crash if we somehow try to execute a task on a package that doesn't exist
 * Record an error if any tasks errored, even if none of them were child exit code errors