### PR TITLE
Handle cycles in package dependency graph

### DIFF
--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -183,17 +183,9 @@ func (c *RunCommand) Run(args []string) int {
 		c.logError(c.Config.Logger, "", err)
 		return 1
 	}
-	cycles := ctx.TopologicalGraph.Cycles()
-	if len(cycles) > 0 {
-		cycleLines := make([]string, len(cycles))
-		for i, cycle := range cycles {
-			vertices := make([]string, len(cycle))
-			for j, vertex := range cycle {
-				vertices[j] = vertex.(string)
-			}
-			cycleLines[i] = "\t" + strings.Join(vertices, ",")
-		}
-		c.logError(c.Config.Logger, "", fmt.Errorf("Found cycles in package dependency graph:\n%v", strings.Join(cycleLines, "\n")))
+	err = ctx.TopologicalGraph.Validate()
+	if err != nil {
+		c.logError(c.Config.Logger, "", fmt.Errorf("Found cycles in package dependency graph: %v", err))
 		return 1
 	}
 	targets, err := getTargetsFromArguments(args, c.Config.TurboConfigJSON)

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -183,6 +183,19 @@ func (c *RunCommand) Run(args []string) int {
 		c.logError(c.Config.Logger, "", err)
 		return 1
 	}
+	cycles := ctx.TopologicalGraph.Cycles()
+	if len(cycles) > 0 {
+		cycleLines := make([]string, len(cycles))
+		for i, cycle := range cycles {
+			vertices := make([]string, len(cycle))
+			for j, vertex := range cycle {
+				vertices[j] = vertex.(string)
+			}
+			cycleLines[i] = "\t" + strings.Join(vertices, ",")
+		}
+		c.logError(c.Config.Logger, "", fmt.Errorf("Found cycles in package dependency graph:\n%v", strings.Join(cycleLines, "\n")))
+		return 1
+	}
 	targets, err := getTargetsFromArguments(args, c.Config.TurboConfigJSON)
 	if err != nil {
 		c.logError(c.Config.Logger, "", fmt.Errorf("failed to resolve targets: %w", err))

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -183,9 +183,17 @@ func (c *RunCommand) Run(args []string) int {
 		c.logError(c.Config.Logger, "", err)
 		return 1
 	}
-	err = ctx.TopologicalGraph.Validate()
-	if err != nil {
-		c.logError(c.Config.Logger, "", fmt.Errorf("Found cycles in package dependency graph: %v", err))
+	cycles := ctx.TopologicalGraph.Cycles()
+	if len(cycles) > 0 {
+		cycleLines := make([]string, len(cycles))
+		for i, cycle := range cycles {
+			vertices := make([]string, len(cycle))
+			for j, vertex := range cycle {
+				vertices[j] = vertex.(string)
+			}
+			cycleLines[i] = "\t" + strings.Join(vertices, ",")
+		}
+		c.logError(c.Config.Logger, "", fmt.Errorf("Found cycles in package dependency graph:\n%v", strings.Join(cycleLines, "\n")))
 		return 1
 	}
 	targets, err := getTargetsFromArguments(args, c.Config.TurboConfigJSON)

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -183,6 +183,9 @@ func (c *RunCommand) Run(args []string) int {
 		c.logError(c.Config.Logger, "", err)
 		return 1
 	}
+	// We use Cycles instead of Validate because
+	// our DAG has multiple roots (entrypoints).
+	// Validate mandates that there is only a single root node.
 	cycles := ctx.TopologicalGraph.Cycles()
 	if len(cycles) > 0 {
 		cycleLines := make([]string, len(cycles))


### PR DESCRIPTION
Fixes #1002 

Instead of hanging during graph traversal, we instead print out the list of packages that form a cycle and exit with exit code `1`