### PR TITLE
Fix remix example by pinning version

### DIFF
--- a/examples/kitchen-sink/apps/blog/package.json
+++ b/examples/kitchen-sink/apps/blog/package.json
@@ -9,15 +9,15 @@
     "start": "remix-serve build"
   },
   "dependencies": {
-    "@remix-run/react": "^1.0.6",
-    "@remix-run/serve": "^1.0.6",
+    "@remix-run/react": "1.0.6",
+    "@remix-run/serve": "1.0.6",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "remix": "^1.0.6",
+    "remix": "1.0.6",
     "ui": "*"
   },
   "devDependencies": {
-    "@remix-run/dev": "^1.0.6",
+    "@remix-run/dev": "1.0.6",
     "@types/react": "^17.0.24",
     "@types/react-dom": "^17.0.9",
     "tsconfig": "*",


### PR DESCRIPTION
Remix 1.4 does appear to work in Yarn, NPM, or PNPM workspaces at the moment (see screenshot below). In the interim, this pins Remix to 1.0.6. In another PR, we can upgrade it 1.3.5 (which also works), but I have to head out and don't have time. This change at least will fix our test suite


<img width="1058" alt="CleanShot 2022-04-15 at 15 09 39@2x" src="https://user-images.githubusercontent.com/4060187/163622286-4ac66233-c122-4771-a194-84380098b516.png">