### PR TITLE
Support loading preflight option from env var TURBO_PREFLIGHT

### DIFF
--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -133,7 +133,7 @@ func ParseAndValidate(args []string, ui cli.Ui, turboVersion string) (c *Config,
 		}
 	}
 
-	usePreflight := false
+	usePreflight := os.Getenv("TURBO_PREFLIGHT") == "true"
 
 	// Process arguments looking for `-v` flags to control the log level.
 	// This overrides whatever the env var set.

--- a/docs/pages/docs/reference/command-line-reference.mdx
+++ b/docs/pages/docs/reference/command-line-reference.mdx
@@ -395,6 +395,8 @@ Only applicable when remote artifact caching is configured. Enables sending a pr
 turbo run build --preflight
 ```
 
+The same behavior can also be set via the `TURBO_PREFLIGHT=true` environment variable.
+
 #### `--trace`
 
 `type: string`


### PR DESCRIPTION
Follow-up to #1052 per @jaredpalmer's [request](https://github.com/vercel/turborepo/pull/1052#issuecomment-1100316913) to reduce CLI args clutter.