### PR TITLE
GitHashForFiles should care about path if it is abs path

### DIFF
--- a/cli/internal/fs/package_deps_hash.go
+++ b/cli/internal/fs/package_deps_hash.go
@@ -91,7 +91,11 @@ func GitHashForFiles(filesToHash []string, PackagePath string) (map[string]strin
 		var input = []string{"hash-object"}
 
 		for _, filename := range filesToHash {
-			input = append(input, filepath.Join(PackagePath, filename))
+			if filepath.IsAbs(filename) {
+				input = append(input, filename)
+			} else {
+				input = append(input, filepath.Join(PackagePath, filename))
+			}
 		}
 		// fmt.Println(input)
 		cmd := exec.Command("git", input...)


### PR DESCRIPTION
In `calculateGlobalHash`, There are:

```go
f := globby.GlobFiles(rootpath, globs, []string{})
for _, val := range f {
    globalDeps.Add(val)
}
```
And 
```go
globalFileHashMap, err := fs.GitHashForFiles(globalDeps.UnsafeListOfStrings(), rootpath)
```

The `globalFileHashMap` will be used to call `GitHashForFiles` which:
```go
filepath.Join(PackagePath, filename)
```

Which may cause incorrect cache match if `git object-hash files...` failed.