### PR TITLE
fix: lint staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
       "prettier --write"
     ],
     "*.go": [
-      "cd cli && npm run format"
+      "sh -c \"cd cli && pnpm format\""
     ]
   },
   "simple-git-hooks": {


### PR DESCRIPTION
`lint-staged` will no longer fail