### PR TITLE
Avoid glob walk if there's no glob patterns

### DIFF
--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -401,6 +401,13 @@ func getHashableTurboEnvVarsFromOs(env []string) ([]string, []string) {
 	return justNames, pairs
 }
 
+func hasGlobPatterns(dep string) bool {
+	return strings.Contains(dep, "*") ||
+		strings.Contains(dep, "?") ||
+		strings.Contains(dep, "[") ||
+		strings.Contains(dep, "{")
+}
+
 func calculateGlobalHash(rootpath string, rootPackageJSON *fs.PackageJSON, externalGlobalDependencies []string, backend *api.LanguageBackend, logger hclog.Logger, env []string) (string, error) {
 	// Calculate the global hash
 	globalDeps := make(util.Set)
@@ -415,6 +422,8 @@ func calculateGlobalHash(rootpath string, rootPackageJSON *fs.PackageJSON, exter
 				trimmed := strings.TrimPrefix(v, "$")
 				globalHashableEnvNames = append(globalHashableEnvNames, trimmed)
 				globalHashableEnvPairs = append(globalHashableEnvPairs, fmt.Sprintf("%v=%v", trimmed, os.Getenv(trimmed)))
+			} else if !hasGlobPatterns(v) {
+				globalDeps.Add(filepath.Join(rootpath, v))
 			} else {
 				globs = append(globs, v)
 			}


### PR DESCRIPTION
Fixes #720 .
Related: https://github.com/vercel/turborepo/pull/1075#issuecomment-1104256184

I guess we can assume items in globalDeps is the specific file if there's no glob patterns.
And we just add them in the deps. (If i'm not missing some glob patterns)