### PR TITLE
docs: Add missing "backend#health-check" in pipelines example

### DIFF
--- a/docs/pages/docs/features/pipelines.mdx
+++ b/docs/pages/docs/features/pipelines.mdx
@@ -206,7 +206,7 @@ For these cases, you can express these relationships in your `pipeline` configur
       "outputs": [""]
     },
     "frontend#deploy": {
-      "dependsOn": ["ui#test", "backend#deploy"],
+      "dependsOn": ["ui#test", "backend#deploy", "backend#health-check"],
       "outputs": [""]
     }
   }


### PR DESCRIPTION
Update 'Implicit Dependencies and Specific Package Task' example in pipelines.mdx with missing "backend#health-check" referenced in text.