### PR TITLE
Configure VSCode to use the same lint tool as CI.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,6 @@
   "debug.javascript.unmapMissingSources": true,
   "gopls": {
     "experimentalWorkspaceModule": true
-  }
+  },
+  "go.lintTool": "golangci-lint",
 }


### PR DESCRIPTION
We adopted `golangci-lint` to handle linting on CI, this configures VSCode to use that by default.