### PR TITLE
Fix lint error in VS Code settings.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,8 @@
   "eslint.validate": [
     "javascript",
     "javascriptreact",
-    { "language": "typescript", "autoFix": true },
-    { "language": "typescriptreact", "autoFix": true }
+    "typescript",
+    "typescriptreact"
   ],
   "eslint.packageManager": "yarn",
   "debug.javascript.unmapMissingSources": true,


### PR DESCRIPTION
VS Code was complaining about this error where `autoFix` is `true` by default and doesn't need to be specified.