### PR TITLE
Use interface for API Client in HTTP Cache

### DIFF
--- a/cli/internal/cache/cache_http.go
+++ b/cli/internal/cache/cache_http.go
@@ -24,9 +24,14 @@ import (
 	"github.com/vercel/turborepo/cli/internal/fs"
 )
 
+type client interface {
+	PutArtifact(hash string, body []byte, duration int, tag string) error
+	FetchArtifact(hash string) (*http.Response, error)
+}
+
 type httpCache struct {
 	writable       bool
-	config         *config.Config
+	client         client
 	requestLimiter limiter
 	recorder       analytics.Recorder
 	signerVerifier *ArtifactSignatureAuthentication
@@ -70,7 +75,7 @@ func (cache *httpCache) Put(target, hash string, duration int, files []string) e
 			return fmt.Errorf("failed to store files in HTTP cache: %w", err)
 		}
 	}
-	return cache.config.ApiClient.PutArtifact(hash, artifactBody, duration, tag)
+	return cache.client.PutArtifact(hash, artifactBody, duration, tag)
 }
 
 // write writes a series of files into the given Writer.
@@ -159,7 +164,7 @@ func (cache *httpCache) logFetch(hit bool, hash string, duration int) {
 }
 
 func (cache *httpCache) retrieve(hash string) (bool, []string, int, error) {
-	resp, err := cache.config.ApiClient.FetchArtifact(hash, nil)
+	resp, err := cache.client.FetchArtifact(hash)
 	if err != nil {
 		return false, nil, 0, err
 	}
@@ -299,7 +304,7 @@ func (cache *httpCache) Shutdown() {}
 func newHTTPCache(config *config.Config, recorder analytics.Recorder) *httpCache {
 	return &httpCache{
 		writable:       true,
-		config:         config,
+		client:         config.ApiClient,
 		requestLimiter: make(limiter, 20),
 		recorder:       recorder,
 		signerVerifier: &ArtifactSignatureAuthentication{

--- a/cli/internal/client/client.go
+++ b/cli/internal/client/client.go
@@ -216,6 +216,8 @@ func (c *ApiClient) PutArtifact(hash string, artifactBody []byte, duration int, 
 	return nil
 }
 
+// FetchArtifact attempts to retrieve the build artifact with the given hash from the
+// Remote Caching server
 func (c *ApiClient) FetchArtifact(hash string) (*http.Response, error) {
 	if err := c.okToRequest(); err != nil {
 		return nil, err

--- a/cli/internal/client/client.go
+++ b/cli/internal/client/client.go
@@ -210,7 +210,7 @@ func (c *ApiClient) PutArtifact(hash string, artifactBody []byte, duration int, 
 	return nil
 }
 
-func (c *ApiClient) FetchArtifact(hash string, rawBody interface{}) (*http.Response, error) {
+func (c *ApiClient) FetchArtifact(hash string) (*http.Response, error) {
 	if err := c.okToRequest(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Replace direct config dependency in http cache with an interface that can be mocked in tests.

Also deletes an unused argument in `ApiClient.FetchArtifact`.