### PR TITLE
Handle 403s

### DIFF
--- a/cli/internal/cache/cache.go
+++ b/cli/internal/cache/cache.go
@@ -1,16 +1,19 @@
 // Package cache abstracts storing and fetching previously run tasks
-
+//
 // Adapted from https://github.com/thought-machine/please
 // Copyright Thought Machine, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 package cache
 
 import (
+	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/vercel/turborepo/cli/internal/analytics"
 	"github.com/vercel/turborepo/cli/internal/config"
 	"github.com/vercel/turborepo/cli/internal/ui"
+	"github.com/vercel/turborepo/cli/internal/util"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -36,17 +39,24 @@ type CacheEvent struct {
 	Duration int    `mapstructure:"duration"`
 }
 
+// OnCacheRemoved defines a callback that the cache system calls if a particular cache
+// needs to be removed. In practice, this happens when Remote Caching has been disabled
+// the but CLI continues to try to use it.
+type OnCacheRemoved = func(cache Cache, err error)
+
 // New creates a new cache
-func New(config *config.Config, remoteOnly bool, recorder analytics.Recorder) Cache {
-	c := newSyncCache(config, remoteOnly, recorder)
+func New(config *config.Config, remoteOnly bool, recorder analytics.Recorder, onCacheRemoved OnCacheRemoved) Cache {
+	c := newSyncCache(config, remoteOnly, recorder, onCacheRemoved)
 	if config.Cache.Workers > 0 {
 		return newAsyncCache(c, config)
 	}
 	return c
 }
 
-func newSyncCache(config *config.Config, remoteOnly bool, recorder analytics.Recorder) Cache {
-	mplex := &cacheMultiplexer{}
+func newSyncCache(config *config.Config, remoteOnly bool, recorder analytics.Recorder, onCacheRemoved OnCacheRemoved) Cache {
+	mplex := &cacheMultiplexer{
+		onCacheRemoved: onCacheRemoved,
+	}
 	if config.Cache.Dir != "" && !remoteOnly {
 		mplex.caches = append(mplex.caches, newFsCache(config, recorder))
 	}
@@ -65,66 +75,128 @@ func newSyncCache(config *config.Config, remoteOnly bool, recorder analytics.Rec
 // A cacheMultiplexer multiplexes several caches into one.
 // Used when we have several active (eg. http, dir).
 type cacheMultiplexer struct {
-	caches []Cache
+	caches         []Cache
+	mu             sync.RWMutex
+	onCacheRemoved OnCacheRemoved
 }
 
-func (mplex cacheMultiplexer) Put(target string, key string, duration int, files []string) error {
+func (mplex *cacheMultiplexer) Put(target string, key string, duration int, files []string) error {
 	return mplex.storeUntil(target, key, duration, files, len(mplex.caches))
+}
+
+type cacheRemoval struct {
+	cache Cache
+	err   *util.CacheDisabledError
 }
 
 // storeUntil stores artifacts into higher priority caches than the given one.
 // Used after artifact retrieval to ensure we have them in eg. the directory cache after
 // downloading from the RPC cache.
-// This is a little inefficient since we could write the file to plz-out then copy it to the dir cache,
-// but it's hard to fix that without breaking the cache abstraction.
-func (mplex cacheMultiplexer) storeUntil(target string, key string, duration int, outputGlobs []string, stopAt int) error {
+func (mplex *cacheMultiplexer) storeUntil(target string, key string, duration int, outputGlobs []string, stopAt int) error {
 	// Attempt to store on all caches simultaneously.
+	toRemove := make([]*cacheRemoval, stopAt)
 	g := &errgroup.Group{}
+	mplex.mu.RLock()
 	for i, cache := range mplex.caches {
 		if i == stopAt {
 			break
 		}
 		c := cache
+		i := i
 		g.Go(func() error {
-			return c.Put(target, key, duration, outputGlobs)
+			err := c.Put(target, key, duration, outputGlobs)
+			if err != nil {
+				cd := &util.CacheDisabledError{}
+				if errors.As(err, &cd) {
+					toRemove[i] = &cacheRemoval{
+						cache: c,
+						err:   cd,
+					}
+					// we don't want this to cancel other cache actions
+					return nil
+				}
+				return err
+			}
+			return nil
 		})
 	}
+	mplex.mu.RUnlock()
 
 	if err := g.Wait(); err != nil {
 		return err
 	}
 
+	for _, removal := range toRemove {
+		if removal != nil {
+			mplex.removeCache(removal)
+		}
+	}
 	return nil
 }
 
-func (mplex cacheMultiplexer) Fetch(target string, key string, files []string) (bool, []string, int, error) {
+// removeCache takes a requested removal and tries to actually remove it. However,
+// multiple requests could result in concurrent requests to remove the same cache.
+// Let one of them win and propagate the error, the rest will no-op.
+func (mplex *cacheMultiplexer) removeCache(removal *cacheRemoval) {
+	mplex.mu.Lock()
+	defer mplex.mu.Unlock()
+	for i, cache := range mplex.caches {
+		if cache == removal.cache {
+			mplex.caches = append(mplex.caches[:i], mplex.caches[i+1:]...)
+			mplex.onCacheRemoved(cache, removal.err)
+			break
+		}
+	}
+}
+
+func (mplex *cacheMultiplexer) Fetch(target string, key string, files []string) (bool, []string, int, error) {
+	// Make a shallow copy of the caches, since storeUntil can call removeCache
+	mplex.mu.RLock()
+	caches := make([]Cache, len(mplex.caches))
+	copy(caches, mplex.caches)
+	mplex.mu.RUnlock()
+
 	// Retrieve from caches sequentially; if we did them simultaneously we could
 	// easily write the same file from two goroutines at once.
-	for i, cache := range mplex.caches {
-		if ok, actualFiles, duration, err := cache.Fetch(target, key, files); ok {
+	for i, cache := range caches {
+		ok, actualFiles, duration, err := cache.Fetch(target, key, files)
+		if err != nil {
+			cd := &util.CacheDisabledError{}
+			if errors.As(err, &cd) {
+				mplex.removeCache(&cacheRemoval{
+					cache: cache,
+					err:   cd,
+				})
+			}
+			// We're ignoring the error in the else case, since with this cache
+			// abstraction, we want to check lower priority caches rather than fail
+			// the operation. Future work that plumbs UI / Logging into the cache system
+			// should probably log this at least.
+		}
+		if ok {
 			// Store this into other caches. We can ignore errors here because we know
 			// we have previously successfully stored in a higher-priority cache, and so the overall
 			// result is a success at fetching. Storing in lower-priority caches is an optimization.
-			mplex.storeUntil(target, key, duration, actualFiles, i)
+			_ = mplex.storeUntil(target, key, duration, actualFiles, i)
 			return ok, actualFiles, duration, err
 		}
 	}
 	return false, files, 0, nil
 }
 
-func (mplex cacheMultiplexer) Clean(target string) {
+func (mplex *cacheMultiplexer) Clean(target string) {
 	for _, cache := range mplex.caches {
 		cache.Clean(target)
 	}
 }
 
-func (mplex cacheMultiplexer) CleanAll() {
+func (mplex *cacheMultiplexer) CleanAll() {
 	for _, cache := range mplex.caches {
 		cache.CleanAll()
 	}
 }
 
-func (mplex cacheMultiplexer) Shutdown() {
+func (mplex *cacheMultiplexer) Shutdown() {
 	for _, cache := range mplex.caches {
 		cache.Shutdown()
 	}

--- a/cli/internal/cache/cache_http.go
+++ b/cli/internal/cache/cache_http.go
@@ -169,22 +169,20 @@ func (cache *httpCache) retrieve(hash string) (bool, []string, int, error) {
 		return false, nil, 0, err
 	}
 	defer resp.Body.Close()
-	files := []string{}
-	missingLinks := []*tar.Header{}
-	duration := 0
+	if resp.StatusCode == http.StatusNotFound {
+		return false, nil, 0, nil // doesn't exist - not an error
+	} else if resp.StatusCode != http.StatusOK {
+		b, _ := ioutil.ReadAll(resp.Body)
+		return false, nil, 0, fmt.Errorf("%s", string(b))
+	}
 	// If present, extract the duration from the response.
+	duration := 0
 	if resp.Header.Get("x-artifact-duration") != "" {
 		intVar, err := strconv.Atoi(resp.Header.Get("x-artifact-duration"))
 		if err != nil {
 			return false, nil, 0, fmt.Errorf("invalid x-artifact-duration header: %w", err)
 		}
 		duration = intVar
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		return false, files, duration, nil // doesn't exist - not an error
-	} else if resp.StatusCode != http.StatusOK {
-		b, _ := ioutil.ReadAll(resp.Body)
-		return false, files, duration, fmt.Errorf("%s", string(b))
 	}
 	artifactReader := resp.Body
 	if cache.signerVerifier.isEnabled() {
@@ -208,6 +206,8 @@ func (cache *httpCache) retrieve(hash string) (bool, []string, int, error) {
 		// The artifact has been verified and the body can be read and untarred
 		artifactReader = ioutil.NopCloser(bytes.NewReader(b))
 	}
+	files := []string{}
+	missingLinks := []*tar.Header{}
 	gzr, err := gzip.NewReader(artifactReader)
 	if err != nil {
 		return false, nil, 0, err

--- a/cli/internal/cache/cache_http_test.go
+++ b/cli/internal/cache/cache_http_test.go
@@ -1,0 +1,45 @@
+package cache
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/vercel/turborepo/cli/internal/util"
+)
+
+type errorResp struct {
+	err error
+}
+
+func (sr *errorResp) PutArtifact(hash string, body []byte, duration int, tag string) error {
+	return sr.err
+}
+
+func (sr *errorResp) FetchArtifact(hash string) (*http.Response, error) {
+	return nil, sr.err
+}
+
+func TestRemoteCachingDisabled(t *testing.T) {
+	clientErr := &util.CacheDisabledError{
+		Status:  util.CachingStatusDisabled,
+		Message: "Remote Caching has been disabled for this team. A team owner can enable it here: $URL",
+	}
+	client := &errorResp{err: clientErr}
+	cache := &httpCache{
+		client:         client,
+		requestLimiter: make(limiter, 20),
+	}
+	cd := &util.CacheDisabledError{}
+	_, _, _, err := cache.Fetch("unused-target", "some-hash", []string{"unused", "outputs"})
+	if !errors.As(err, &cd) {
+		t.Errorf("cache.Fetch err got %v, want a CacheDisabled error", err)
+	}
+	if cd.Status != util.CachingStatusDisabled {
+		t.Errorf("CacheDisabled.Status got %v, want %v", cd.Status, util.CachingStatusDisabled)
+	}
+}
+
+// Note that testing Put will require mocking the filesystem and is not currently the most
+// interesting test. The current implementation directly returns the error from PutArtifact.
+// We should still add the test once feasible to avoid future breakage.

--- a/cli/internal/cache/cache_test.go
+++ b/cli/internal/cache/cache_test.go
@@ -1,0 +1,147 @@
+package cache
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/vercel/turborepo/cli/internal/util"
+)
+
+type testCache struct {
+	disabledErr *util.CacheDisabledError
+	entries     map[string][]string
+}
+
+func (tc *testCache) Fetch(target string, hash string, files []string) (bool, []string, int, error) {
+	if tc.disabledErr != nil {
+		return false, nil, 0, tc.disabledErr
+	}
+	foundFiles, ok := tc.entries[hash]
+	if ok {
+		duration := 5
+		return true, foundFiles, duration, nil
+	}
+	return false, nil, 0, nil
+}
+
+func (tc *testCache) Put(target string, hash string, duration int, files []string) error {
+	if tc.disabledErr != nil {
+		return tc.disabledErr
+	}
+	tc.entries[hash] = files
+	return nil
+}
+
+func (tc *testCache) Clean(target string) {}
+func (tc *testCache) CleanAll()           {}
+func (tc *testCache) Shutdown()           {}
+
+func newEnabledCache() *testCache {
+	return &testCache{
+		entries: make(map[string][]string),
+	}
+}
+
+func newDisabledCache() *testCache {
+	return &testCache{
+		disabledErr: &util.CacheDisabledError{
+			Status:  util.CachingStatusDisabled,
+			Message: "remote caching is disabled",
+		},
+	}
+}
+
+func TestPutCachingDisabled(t *testing.T) {
+	disabledCache := newDisabledCache()
+	caches := []Cache{
+		newEnabledCache(),
+		disabledCache,
+		newEnabledCache(),
+		newEnabledCache(),
+	}
+	var removeCalled uint64
+	mplex := &cacheMultiplexer{
+		caches: caches,
+		onCacheRemoved: func(cache Cache, err error) {
+			atomic.AddUint64(&removeCalled, 1)
+		},
+	}
+
+	err := mplex.Put("unused-target", "some-hash", 5, []string{"a-file"})
+	if err != nil {
+		// don't leak the cache removal
+		t.Errorf("Put got error %v, want <nil>", err)
+	}
+
+	removes := atomic.LoadUint64(&removeCalled)
+	if removes != 1 {
+		t.Errorf("removes count: %v, want 1", removes)
+	}
+
+	mplex.mu.RLock()
+	if len(mplex.caches) != 3 {
+		t.Errorf("found %v caches, expected to have 3 after one was removed", len(mplex.caches))
+	}
+	for _, cache := range mplex.caches {
+		if cache == disabledCache {
+			t.Error("found disabled cache, expected it to be removed")
+		}
+	}
+	mplex.mu.RUnlock()
+
+	// subsequent Fetch should still work
+	hit, _, _, err := mplex.Fetch("unused-target", "some-hash", []string{"unused", "files"})
+	if err != nil {
+		t.Errorf("got error fetching files: %v", err)
+	}
+	if !hit {
+		t.Error("failed to find previously stored files")
+	}
+
+	removes = atomic.LoadUint64(&removeCalled)
+	if removes != 1 {
+		t.Errorf("removes count: %v, want 1", removes)
+	}
+}
+
+func TestFetchCachingDisabled(t *testing.T) {
+	disabledCache := newDisabledCache()
+	caches := []Cache{
+		newEnabledCache(),
+		disabledCache,
+		newEnabledCache(),
+		newEnabledCache(),
+	}
+	var removeCalled uint64
+	mplex := &cacheMultiplexer{
+		caches: caches,
+		onCacheRemoved: func(cache Cache, err error) {
+			atomic.AddUint64(&removeCalled, 1)
+		},
+	}
+
+	hit, _, _, err := mplex.Fetch("unused-target", "some-hash", []string{"unused", "files"})
+	if err != nil {
+		// don't leak the cache removal
+		t.Errorf("Fetch got error %v, want <nil>", err)
+	}
+	if hit {
+		t.Error("hit on empty cache, expected miss")
+	}
+
+	removes := atomic.LoadUint64(&removeCalled)
+	if removes != 1 {
+		t.Errorf("removes count: %v, want 1", removes)
+	}
+
+	mplex.mu.RLock()
+	if len(mplex.caches) != 3 {
+		t.Errorf("found %v caches, expected to have 3 after one was removed", len(mplex.caches))
+	}
+	for _, cache := range mplex.caches {
+		if cache == disabledCache {
+			t.Error("found disabled cache, expected it to be removed")
+		}
+	}
+	mplex.mu.RUnlock()
+}

--- a/cli/internal/client/client.go
+++ b/cli/internal/client/client.go
@@ -181,6 +181,43 @@ func (c *ApiClient) doPreflight(requestURL string, requestMethod string, request
 	return resp, requestURL, nil
 }
 
+type apiError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func (ae *apiError) cacheDisabled() (*util.CacheDisabledError, error) {
+	if strings.HasPrefix(ae.Code, "remote_caching_") {
+		statusString := ae.Code[len("remote_caching_"):]
+		status, err := util.CachingStatusFromString(statusString)
+		if err != nil {
+			return nil, err
+		}
+		return &util.CacheDisabledError{
+			Status:  status,
+			Message: ae.Message,
+		}, nil
+	}
+	return nil, fmt.Errorf("unknown status %v: %v", ae.Code, ae.Message)
+}
+
+func (c *ApiClient) handle403(body io.Reader) error {
+	raw, err := ioutil.ReadAll(body)
+	if err != nil {
+		return fmt.Errorf("failed to read response %v", err)
+	}
+	apiError := &apiError{}
+	err = json.Unmarshal(raw, apiError)
+	if err != nil {
+		return fmt.Errorf("failed to read response (%v): %v", string(raw), err)
+	}
+	disabledErr, err := apiError.cacheDisabled()
+	if err != nil {
+		return err
+	}
+	return disabledErr
+}
+
 func (c *ApiClient) PutArtifact(hash string, artifactBody []byte, duration int, tag string) error {
 	if err := c.okToRequest(); err != nil {
 		return err
@@ -219,10 +256,13 @@ func (c *ApiClient) PutArtifact(hash string, artifactBody []byte, duration int, 
 		return fmt.Errorf("[WARNING] Invalid cache URL: %w", err)
 	}
 
-	if resp, err := c.HttpClient.Do(req); err != nil {
+	resp, err := c.HttpClient.Do(req)
+	if err != nil {
 		return fmt.Errorf("failed to store files in HTTP cache: %w", err)
-	} else {
-		resp.Body.Close()
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusForbidden {
+		return c.handle403(resp.Body)
 	}
 	return nil
 }
@@ -262,7 +302,15 @@ func (c *ApiClient) FetchArtifact(hash string) (*http.Response, error) {
 		return nil, fmt.Errorf("invalid cache URL: %w", err)
 	}
 
-	return c.HttpClient.Do(req)
+	resp, err := c.HttpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch artifact: %v", err)
+	} else if resp.StatusCode == http.StatusForbidden {
+		err = c.handle403(resp.Body)
+		_ = resp.Body.Close()
+		return nil, err
+	}
+	return resp, nil
 }
 
 func (c *ApiClient) RecordAnalyticsEvents(events []map[string]interface{}) error {

--- a/cli/internal/client/client_test.go
+++ b/cli/internal/client/client_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-hclog"
+	"github.com/vercel/turborepo/cli/internal/util"
 )
 
 func Test_sendToServer(t *testing.T) {
@@ -90,4 +92,52 @@ func Test_PutArtifact(t *testing.T) {
 		t.Errorf("Handler read '%v', wants '%v'", testBody, expectedArtifactBody)
 	}
 
+}
+
+func Test_PutWhenCachingDisabled(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		defer func() { _ = req.Body.Close() }()
+		w.WriteHeader(403)
+		_, _ = w.Write([]byte("{\"code\": \"remote_caching_disabled\",\"message\":\"caching disabled\"}"))
+	}))
+	defer ts.Close()
+
+	// Set up test expected values
+	apiClient := NewClient(ts.URL+"/hash", hclog.Default(), "v1", "", "my-team-slug", 1, false)
+	apiClient.SetToken("my-token")
+	expectedArtifactBody := []byte("My string artifact")
+	// Test Put Artifact
+	err := apiClient.PutArtifact("hash", expectedArtifactBody, 500, "")
+	cd := &util.CacheDisabledError{}
+	if !errors.As(err, &cd) {
+		t.Errorf("expected cache disabled error, got %v", err)
+	}
+	if cd.Status != util.CachingStatusDisabled {
+		t.Errorf("caching status: expected %v, got %v", util.CachingStatusDisabled, cd.Status)
+	}
+}
+
+func Test_FetchWhenCachingDisabled(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		defer func() { _ = req.Body.Close() }()
+		w.WriteHeader(403)
+		_, _ = w.Write([]byte("{\"code\": \"remote_caching_disabled\",\"message\":\"caching disabled\"}"))
+	}))
+	defer ts.Close()
+
+	// Set up test expected values
+	apiClient := NewClient(ts.URL+"/hash", hclog.Default(), "v1", "", "my-team-slug", 1, false)
+	apiClient.SetToken("my-token")
+	// Test Put Artifact
+	resp, err := apiClient.FetchArtifact("hash")
+	cd := &util.CacheDisabledError{}
+	if !errors.As(err, &cd) {
+		t.Errorf("expected cache disabled error, got %v", err)
+	}
+	if cd.Status != util.CachingStatusDisabled {
+		t.Errorf("caching status: expected %v, got %v", util.CachingStatusDisabled, cd.Status)
+	}
+	if resp != nil {
+		t.Errorf("response got %v, want <nil>", resp)
+	}
 }

--- a/cli/internal/util/status.go
+++ b/cli/internal/util/status.go
@@ -29,3 +29,14 @@ func CachingStatusFromString(raw string) (CachingStatus, error) {
 		return CachingStatusDisabled, fmt.Errorf("unknown caching status: %v", raw)
 	}
 }
+
+// CacheDisabledError is an error used to indicate that remote caching
+// is not available.
+type CacheDisabledError struct {
+	Status  CachingStatus
+	Message string
+}
+
+func (cd *CacheDisabledError) Error() string {
+	return cd.Message
+}


### PR DESCRIPTION
If the Remote Caching server returns a `403` indicating that caching is disabled, stop trying to use the HTTP cache.