### PR TITLE
 Plumb through errors in globbing. 

### DIFF
--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -167,7 +167,10 @@ func WithGraph(rootpath string, config *config.Config) Option {
 			justJsons = append(justJsons, filepath.Join(space, "package.json"))
 		}
 
-		f := globby.GlobFiles(rootpath, justJsons, getWorkspaceIgnores())
+		f, err := globby.GlobFiles(rootpath, justJsons, getWorkspaceIgnores())
+		if err != nil {
+			return err
+		}
 
 		for _, val := range f {
 			relativePkgPath, err := filepath.Rel(rootpath, val)
@@ -423,7 +426,10 @@ func calculateGlobalHash(rootpath string, rootPackageJSON *fs.PackageJSON, exter
 		}
 
 		if len(globs) > 0 {
-			f := globby.GlobFiles(rootpath, globs, getWorkspaceIgnores())
+			f, err := globby.GlobFiles(rootpath, globs, getWorkspaceIgnores())
+			if err != nil {
+				return "", err
+			}
 			for _, val := range f {
 				globalDeps.Add(val)
 			}

--- a/cli/internal/globby/globby_test.go
+++ b/cli/internal/globby/globby_test.go
@@ -30,10 +30,11 @@ func TestGlobFilesFs(t *testing.T) {
 		excludePatterns []string
 	}
 	tests := []struct {
-		name  string
-		files []string
-		args  args
-		want  []string
+		name    string
+		files   []string
+		args    args
+		want    []string
+		wantErr bool
 	}{
 		{
 			name:  "hello world",
@@ -396,12 +397,8 @@ func TestGlobFilesFs(t *testing.T) {
 				includePatterns: []string{"../spanish-inquisition/**", "dist/**"},
 				excludePatterns: []string{},
 			},
-			want: []string{
-				"/repos/some-app/dist/index.html",
-				"/repos/some-app/dist/js/index.js",
-				"/repos/some-app/dist/js/lib.js",
-				"/repos/some-app/dist/js/node_modules/browserify.js",
-			},
+			want:    []string{},
+			wantErr: true,
 		},
 		{
 			name: "globs and traversal and globs do not cross base path",
@@ -417,7 +414,8 @@ func TestGlobFilesFs(t *testing.T) {
 				includePatterns: []string{"**/../../spanish-inquisition/**"},
 				excludePatterns: []string{},
 			},
-			want: []string{},
+			want:    []string{},
+			wantErr: true,
 		},
 		{
 			name: "traversal works within base path",
@@ -516,7 +514,12 @@ func TestGlobFilesFs(t *testing.T) {
 		fs := setup(tt.files)
 
 		t.Run(tt.name, func(t *testing.T) {
-			got := globFilesFs(fs, tt.args.basePath, tt.args.includePatterns, tt.args.excludePatterns)
+			got, err := globFilesFs(fs, tt.args.basePath, tt.args.includePatterns, tt.args.excludePatterns)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("globFilesFs() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
 
 			gotToSlash := make([]string, len(got))
 			for index, path := range got {

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -1006,7 +1006,12 @@ func (e *execContext) exec(pt *packageTask, deps dag.Set) error {
 		outputs := pt.HashableOutputs()
 		targetLogger.Debug("caching output", "outputs", outputs)
 		ignore := []string{}
-		filesToBeCached := globby.GlobFiles(filepath.Join(e.rs.Opts.cwd, pt.pkg.Dir), outputs, ignore)
+
+		filesToBeCached, err := globby.GlobFiles(filepath.Join(e.rs.Opts.cwd, pt.pkg.Dir), outputs, ignore)
+		if err != nil {
+			return err
+		}
+
 		relativePaths := make([]string, len(filesToBeCached))
 
 		for index, value := range filesToBeCached {


### PR DESCRIPTION
This PR is a fast-follow to #1108 to plumb through the error cases. This work is intentionally split to reduce the scope for each change (1. change implementation, 2. change interface).

This results in user-facing changes if they have globs or patterns that push them outside of their root directory.