### PR TITLE
Remove test directories from workspace ignores.

### DIFF
--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -382,8 +382,6 @@ func getWorkspaceIgnores() []string {
 	return []string{
 		"**/node_modules/",
 		"**/bower_components/",
-		"**/test/",
-		"**/tests/",
 	}
 }
 


### PR DESCRIPTION
These directories aren't excluded by default in any package manager. We should aim to match the behavior of the upstream package managers even if this may result in a quality of life improvement for some users.

This is an incomplete fix, but I believe that addressing a compatibility issue is more-important than trying to deliver the complete fix.

Closes #1143