### PR TITLE
docs: add package manager tabs to CI

### DIFF
--- a/docs/pages/docs/ci/circleci.mdx
+++ b/docs/pages/docs/ci/circleci.mdx
@@ -44,7 +44,7 @@ And a `turbo.json`:
 
 Create a file called `.circleci/config.yml` in your repository with the following contents:
 
-<Tabs items={['NPM', 'Yarn', 'PNPM']} storageKey="selected-pkg-manager">
+<Tabs items={['npm', 'yarn', 'pnpm']} storageKey="selected-pkg-manager">
   <Tab>
     ```yaml
     version: 2.1

--- a/docs/pages/docs/ci/circleci.mdx
+++ b/docs/pages/docs/ci/circleci.mdx
@@ -5,33 +5,126 @@ description: How to use CircleCI with Turborepo to optimize your CI workflow
 
 # Using Turborepo with CircleCI
 
-The following example shows how to use Turborepo with [CircleCI](https://circleci.com) and [Yarn](https://classic.yarnpkg.com).
+The following example shows how to use Turborepo with [CircleCI](https://circleci.com).
+
+For a given root `package.json`:
+
+```json
+{
+  "scripts": {
+    "build": "turbo run build",
+    "test": "turbo run test"
+  },
+  "dependencies": {
+    "turbo": "1.2.5"
+  }
+}
+```
+
+And a `turbo.json`:
+
+```json
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "baseBranch": "origin/main",
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+  }
+}
+```
 
 Create a file called `.circleci/config.yml` in your repository with the following contents:
 
-```yaml
-version: 2.1
-orbs:
-  node: circleci/node@5.0.2
-workflows:
-  test:
+<Tabs items={['NPM', 'Yarn', 'PNPM']} storageKey="selected-pkg-manager">
+  <Tab>
+    ```yaml
+    version: 2.1
+    orbs:
+      node: circleci/node@5.0.2
+    workflows:
+      test:
+        jobs:
+          - test
     jobs:
-      - test
-jobs:
-  test:
-    docker:
-      - image: cimg/node:lts
-    # To use Remote Caching, uncomment the next lines and follow the steps below.
-    # environment:
-    #  TURBO_TOKEN: $TURBO_TOKEN
-    #  TURBO_TEAM: $TURBO_TEAM
-    steps:
-      - checkout
-      - node/install-packages:
-          pkg-manager: yarn
-      - run:
-          command: yarn turbo run test
-```
+      test:
+        docker:
+          - image: cimg/node:lts
+        # To use Remote Caching, uncomment the next lines and follow the steps below.
+        # environment:
+        #  TURBO_TOKEN: $TURBO_TOKEN
+        #  TURBO_TEAM: $TURBO_TEAM
+        steps:
+          - checkout
+          - node/install-packages
+          - run:
+            command: npm run build
+          - run:
+            command: npm run test
+    ```
+  </Tab>
+  <Tab>
+    ```yaml
+    version: 2.1
+    orbs:
+      node: circleci/node@5.0.2
+    workflows:
+      test:
+        jobs:
+          - test
+    jobs:
+      test:
+        docker:
+          - image: cimg/node:lts
+        # To use Remote Caching, uncomment the next lines and follow the steps below.
+        # environment:
+        #  TURBO_TOKEN: $TURBO_TOKEN
+        #  TURBO_TEAM: $TURBO_TEAM
+        steps:
+          - checkout
+          - node/install-packages:
+            pkg-manager: yarn
+          - run:
+            command: yarn build
+          - run:
+            command: yarn test
+    ```
+  </Tab>
+  <Tab>
+    ```yaml
+    version: 2.1
+    orbs:
+      node: circleci/node@5.0.2
+    workflows:
+      test:
+        jobs:
+          - test
+    jobs:
+      test:
+        docker:
+          - image: cimg/node:lts
+        # To use Remote Caching, uncomment the next lines and follow the steps below.
+        # environment:
+        #  TURBO_TOKEN: $TURBO_TOKEN
+        #  TURBO_TEAM: $TURBO_TEAM
+        steps:
+          - checkout
+          - node/install-packages:
+          - run:
+            command: npm i -g pnpm
+          - run:
+            command: pnpm build
+          - run:
+            command: pnpm test
+    ```
+  </Tab>
+</Tabs>
 
 ## Remote Caching
 

--- a/docs/pages/docs/ci/circleci.mdx
+++ b/docs/pages/docs/ci/circleci.mdx
@@ -3,7 +3,7 @@ title: Using Turborepo with CircleCI
 description: How to use CircleCI with Turborepo to optimize your CI workflow
 ---
 
-import { Tabs, Tab } from '../../components/Tabs'
+import { Tabs, Tab } from '../../../components/Tabs'
 
 # Using Turborepo with CircleCI
 

--- a/docs/pages/docs/ci/circleci.mdx
+++ b/docs/pages/docs/ci/circleci.mdx
@@ -13,11 +13,12 @@ For a given root `package.json`:
 
 ```json
 {
+  "name": "my-turborepo",
   "scripts": {
     "build": "turbo run build",
     "test": "turbo run test"
   },
-  "dependencies": {
+  "devDependencies": {
     "turbo": "1.2.5"
   }
 }

--- a/docs/pages/docs/ci/circleci.mdx
+++ b/docs/pages/docs/ci/circleci.mdx
@@ -3,6 +3,8 @@ title: Using Turborepo with CircleCI
 description: How to use CircleCI with Turborepo to optimize your CI workflow
 ---
 
+import { Tabs, Tab } from '../../components/Tabs'
+
 # Using Turborepo with CircleCI
 
 The following example shows how to use Turborepo with [CircleCI](https://circleci.com).

--- a/docs/pages/docs/ci/github-actions.mdx
+++ b/docs/pages/docs/ci/github-actions.mdx
@@ -3,56 +3,191 @@ title: Using Turborepo with GitHub Actions
 description: How to use GitHub Actions with Turborepo to optimize your CI workflow
 ---
 
+import { Tabs, Tab } from '../../components/Tabs'
+
 # Using Turborepo with GitHub Actions
 
-The following example shows how to use Turborepo with [GitHub Actions](https://github.com/features/actions) and [pnpm](https://pnpm.io).
+The following example shows how to use Turborepo with [GitHub Actions](https://github.com/features/actions).
+
+For a given root `package.json`:
+
+```json
+{
+  "scripts": {
+    "build": "turbo run build",
+    "test": "turbo run test"
+  },
+  "dependencies": {
+    "turbo": "1.2.5"
+  }
+}
+```
+
+And a `turbo.json`:
+
+```json
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "baseBranch": "origin/main",
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+  }
+}
+```
 
 Create file called `.github/workflows/ci.yml` in your repository with the following contents:
 
-```yaml
-name: CI
+<Tabs items={['NPM', 'Yarn', 'PNPM']} storageKey="selected-pkg-manager">
+  <Tab>
+    ```yaml
+    name: CI
 
-on:
-  push:
-    branches: ["main"]
-  pull_request:
-    types: [opened, synchronize]
+    on:
+      push:
+        branches: ["main"]
+      pull_request:
+        types: [opened, synchronize]
 
-jobs:
-  build:
-      name: Build and Test
-      timeout-minutes: 15
-      runs-on: ${{ matrix.os }}
-      # To use Remote Caching, uncomment the next lines and follow the steps below.
-      # env:
-      #  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      #  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-      strategy:
-        matrix:
-          os: [ubuntu-latest, macos-latest]
+    jobs:
+      build:
+          name: Build and Test
+          timeout-minutes: 15
+          runs-on: ${{ matrix.os }}
+          # To use Remote Caching, uncomment the next lines and follow the steps below.
+          # env:
+          #  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          #  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          strategy:
+            matrix:
+              os: [ubuntu-latest, macos-latest]
 
-      steps:
-        - name: Check out code
-          uses: actions/checkout@v2
-          with:
-            fetch-depth: 2
+          steps:
+            - name: Check out code
+              uses: actions/checkout@v2
+              with:
+                fetch-depth: 2
 
-        - uses: pnpm/action-setup@v2.0.1
-          with:
-            version: 6.32.2
+            - name: Setup Node.js environment
+              uses: actions/setup-node@v2
+              with:
+                node-version: 16
+                cache: 'npm'
 
-        - name: Setup Node.js environment
-          uses: actions/setup-node@v2
-          with:
-            node-version: 16
-            cache: pnpm
+            - name: Install dependencies
+              run: npm install
 
-        - name: Install dependencies
-          run: pnpm install
+            - name: Build
+              run: npm run build
 
-        - name: Test
-          run: pnpm turbo run test
-```
+            - name: Test
+              run: npm run test
+    ```
+
+  </Tab>
+  <Tab>
+    ```yaml
+    name: CI
+
+    on:
+      push:
+        branches: ["main"]
+      pull_request:
+        types: [opened, synchronize]
+
+    jobs:
+      build:
+          name: Build and Test
+          timeout-minutes: 15
+          runs-on: ${{ matrix.os }}
+          # To use Remote Caching, uncomment the next lines and follow the steps below.
+          # env:
+          #  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          #  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          strategy:
+            matrix:
+              os: [ubuntu-latest, macos-latest]
+
+          steps:
+            - name: Check out code
+              uses: actions/checkout@v2
+              with:
+                fetch-depth: 2
+
+            - name: Setup Node.js environment
+              uses: actions/setup-node@v2
+              with:
+                node-version: 16
+                cache: 'yarn'
+
+            - name: Install dependencies
+              run: yarn
+
+            - name: Build
+              run: yarn build
+
+            - name: Test
+              run: yarn test
+    ```
+
+  </Tab>
+  <Tab>
+    ```yaml
+    name: CI
+
+    on:
+      push:
+        branches: ["main"]
+      pull_request:
+        types: [opened, synchronize]
+
+    jobs:
+      build:
+          name: Build and Test
+          timeout-minutes: 15
+          runs-on: ${{ matrix.os }}
+          # To use Remote Caching, uncomment the next lines and follow the steps below.
+          # env:
+          #  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          #  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+          strategy:
+            matrix:
+              os: [ubuntu-latest, macos-latest]
+
+          steps:
+            - name: Check out code
+              uses: actions/checkout@v2
+              with:
+                fetch-depth: 2
+
+            - uses: pnpm/action-setup@v2.0.1
+              with:
+                version: 6.32.2
+
+            - name: Setup Node.js environment
+              uses: actions/setup-node@v2
+              with:
+                node-version: 16
+                cache: 'pnpm'
+
+            - name: Install dependencies
+              run: pnpm install
+
+            - name: Build
+              run: pnpm build
+
+            - name: Test
+              run: pnpm test
+    ```
+
+  </Tab>
+</Tabs>
 
 ## Remote Caching
 

--- a/docs/pages/docs/ci/github-actions.mdx
+++ b/docs/pages/docs/ci/github-actions.mdx
@@ -3,7 +3,7 @@ title: Using Turborepo with GitHub Actions
 description: How to use GitHub Actions with Turborepo to optimize your CI workflow
 ---
 
-import { Tabs, Tab } from '../../components/Tabs'
+import { Tabs, Tab } from '../../../components/Tabs'
 
 # Using Turborepo with GitHub Actions
 

--- a/docs/pages/docs/ci/github-actions.mdx
+++ b/docs/pages/docs/ci/github-actions.mdx
@@ -44,7 +44,7 @@ And a `turbo.json`:
 
 Create file called `.github/workflows/ci.yml` in your repository with the following contents:
 
-<Tabs items={['NPM', 'Yarn', 'PNPM']} storageKey="selected-pkg-manager">
+<Tabs items={['npm', 'yarn', 'pnpm']} storageKey="selected-pkg-manager">
   <Tab>
     ```yaml
     name: CI

--- a/docs/pages/docs/ci/github-actions.mdx
+++ b/docs/pages/docs/ci/github-actions.mdx
@@ -13,11 +13,12 @@ For a given root `package.json`:
 
 ```json
 {
+  "name": "my-turborepo",
   "scripts": {
     "build": "turbo run build",
     "test": "turbo run test"
   },
-  "dependencies": {
+  "devDependencies": {
     "turbo": "1.2.5"
   }
 }

--- a/docs/pages/docs/ci/gitlabci.mdx
+++ b/docs/pages/docs/ci/gitlabci.mdx
@@ -5,33 +5,108 @@ description: How to use GitLab CI with Turborepo to optimize your CI workflow
 
 # Using Turborepo with GitLab CI
 
-The following example shows how to use Turborepo with [GitLab CI](https://docs.gitlab.com/ee/ci/) and [pnpm](https://pnpm.io).
+The following example shows how to use Turborepo with [GitLab CI](https://docs.gitlab.com/ee/ci/).
+
+For a given root `package.json`:
+
+```json
+{
+  "scripts": {
+    "build": "turbo run build",
+    "test": "turbo run test"
+  },
+  "dependencies": {
+    "turbo": "1.2.5"
+  }
+}
+```
+
+And a `turbo.json`:
+
+```json
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "baseBranch": "origin/main",
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+  }
+}
+```
 
 Create a file called `.gitlab-ci.yml` in your repository with the following contents:
 
-```yaml
-image: node:latest
-# To use Remote Caching, uncomment the next lines and follow the steps below.
-# variables:
-#   TURBO_TOKEN: $TURBO_TOKEN
-#   TURBO_TEAM: $TURBO_TEAM
-stages:
-  - build
-build:
-  stage: build
-  before_script:
-    - curl -f https://get.pnpm.io/v6.16.js | node - add --global pnpm@7.0.0-rc.9
-    - pnpm config set store-dir .pnpm-store
-  script:
-    - pnpm install
-    - pnpm build
-  cache:
-    key: "$CI_COMMIT_REF_SLUG"
-    paths:
-      - .pnpm-store
-```
-
-> For more information visit the pnpm documenation section on GitLab CI integration, view it [here](https://pnpm.io/continuous-integration#gitlab)
+<Tabs items={['NPM', 'Yarn', 'PNPM']} storageKey="selected-pkg-manager">
+    <Tab>
+        ```yaml
+        image: node:latest
+        # To use Remote Caching, uncomment the next lines and follow the steps below.
+        # variables:
+        #   TURBO_TOKEN: $TURBO_TOKEN
+        #   TURBO_TEAM: $TURBO_TEAM
+        stages:
+          - build
+        build:
+          stage: build
+          script:
+            - npm install
+            - npm run build
+            - npm run test
+        ```
+    </Tab>
+    <Tab>
+        ```yaml
+        image: node:latest
+        # To use Remote Caching, uncomment the next lines and follow the steps below.
+        # variables:
+        #   TURBO_TOKEN: $TURBO_TOKEN
+        #   TURBO_TEAM: $TURBO_TEAM
+        stages:
+          - build
+        build:
+          stage: build
+          script:
+            - yarn install
+            - yarn build
+            - yarn test
+          cache:
+            paths:
+              - node_modules/
+              - .yarn
+        ```
+    </Tab>
+    <Tab>
+        ```yaml
+        image: node:latest
+        # To use Remote Caching, uncomment the next lines and follow the steps below.
+        # variables:
+        #   TURBO_TOKEN: $TURBO_TOKEN
+        #   TURBO_TEAM: $TURBO_TEAM
+        stages:
+          - build
+        build:
+          stage: build
+          before_script:
+            - curl -f https://get.pnpm.io/v6.16.js | node - add --global pnpm@7.0.0-rc.9
+            - pnpm config set store-dir .pnpm-store
+          script:
+            - pnpm install
+            - pnpm build
+            - pnpm test
+          cache:
+            key: "$CI_COMMIT_REF_SLUG"
+            paths:
+              - .pnpm-store
+        ```
+        > For more information visit the pnpm documenation section on GitLab CI integration, view it [here](https://pnpm.io/continuous-integration#gitlab)
+    </Tab>
+</Tabs>
 
 ## Remote Caching
 

--- a/docs/pages/docs/ci/gitlabci.mdx
+++ b/docs/pages/docs/ci/gitlabci.mdx
@@ -13,11 +13,12 @@ For a given root `package.json`:
 
 ```json
 {
+  "name": "my-turborepo",
   "scripts": {
     "build": "turbo run build",
     "test": "turbo run test"
   },
-  "dependencies": {
+  "devDependencies": {
     "turbo": "1.2.5"
   }
 }

--- a/docs/pages/docs/ci/gitlabci.mdx
+++ b/docs/pages/docs/ci/gitlabci.mdx
@@ -44,7 +44,7 @@ And a `turbo.json`:
 
 Create a file called `.gitlab-ci.yml` in your repository with the following contents:
 
-<Tabs items={['NPM', 'Yarn', 'PNPM']} storageKey="selected-pkg-manager">
+<Tabs items={['npm', 'yarn', 'pnpm']} storageKey="selected-pkg-manager">
     <Tab>
         ```yaml
         image: node:latest

--- a/docs/pages/docs/ci/gitlabci.mdx
+++ b/docs/pages/docs/ci/gitlabci.mdx
@@ -3,7 +3,7 @@ title: Using Turborepo with GitLab CI
 description: How to use GitLab CI with Turborepo to optimize your CI workflow
 ---
 
-import { Tabs, Tab } from '../../components/Tabs'
+import { Tabs, Tab } from '../../../components/Tabs'
 
 # Using Turborepo with GitLab CI
 

--- a/docs/pages/docs/ci/gitlabci.mdx
+++ b/docs/pages/docs/ci/gitlabci.mdx
@@ -3,6 +3,8 @@ title: Using Turborepo with GitLab CI
 description: How to use GitLab CI with Turborepo to optimize your CI workflow
 ---
 
+import { Tabs, Tab } from '../../components/Tabs'
+
 # Using Turborepo with GitLab CI
 
 The following example shows how to use Turborepo with [GitLab CI](https://docs.gitlab.com/ee/ci/).

--- a/docs/pages/docs/ci/travisci.mdx
+++ b/docs/pages/docs/ci/travisci.mdx
@@ -3,7 +3,7 @@ title: Using Turborepo with Travis CI
 description: How to use Travis CI with Turborepo to optimize your CI workflow
 ---
 
-import { Tabs, Tab } from '../../components/Tabs'
+import { Tabs, Tab } from '../../../components/Tabs'
 
 # Using Turborepo with Travis CI
 

--- a/docs/pages/docs/ci/travisci.mdx
+++ b/docs/pages/docs/ci/travisci.mdx
@@ -13,11 +13,12 @@ For a given root `package.json`:
 
 ```json
 {
+  "name": "my-turborepo",
   "scripts": {
     "build": "turbo run build",
     "test": "turbo run test"
   },
-  "dependencies": {
+  "devDependencies": {
     "turbo": "1.2.5"
   }
 }

--- a/docs/pages/docs/ci/travisci.mdx
+++ b/docs/pages/docs/ci/travisci.mdx
@@ -44,7 +44,7 @@ And a `turbo.json`:
 
 Create a file called `.travis.yml` in your repository with the following contents:
 
-<Tabs items={['NPM', 'Yarn', 'PNPM']} storageKey="selected-pkg-manager">
+<Tabs items={['npm', 'yarn', 'pnpm']} storageKey="selected-pkg-manager">
   <Tab>
     ```yaml
     language: node_js

--- a/docs/pages/docs/ci/travisci.mdx
+++ b/docs/pages/docs/ci/travisci.mdx
@@ -3,6 +3,8 @@ title: Using Turborepo with Travis CI
 description: How to use Travis CI with Turborepo to optimize your CI workflow
 ---
 
+import { Tabs, Tab } from '../../components/Tabs'
+
 # Using Turborepo with Travis CI
 
 The following example shows how to use Turborepo with [Travis CI](https://www.travis-ci.com/).

--- a/docs/pages/docs/ci/travisci.mdx
+++ b/docs/pages/docs/ci/travisci.mdx
@@ -5,28 +5,93 @@ description: How to use Travis CI with Turborepo to optimize your CI workflow
 
 # Using Turborepo with Travis CI
 
-The following example shows how to use Turborepo with [Travis CI](https://www.travis-ci.com/) and [pnpm](https://pnpm.io).
+The following example shows how to use Turborepo with [Travis CI](https://www.travis-ci.com/).
+
+For a given root `package.json`:
+
+```json
+{
+  "scripts": {
+    "build": "turbo run build",
+    "test": "turbo run test"
+  },
+  "dependencies": {
+    "turbo": "1.2.5"
+  }
+}
+```
+
+And a `turbo.json`:
+
+```json
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "baseBranch": "origin/main",
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+  }
+}
+```
 
 Create a file called `.travis.yml` in your repository with the following contents:
 
-```yaml
-language: node_js
-node_js:
-  - lts/*
-cache:
-  npm: false
-  directories:
-    - "~/.pnpm-store"
-before_install:
-  - curl -f https://get.pnpm.io/v6.16.js | node - add --global pnpm@7.0.0-rc.9
-  - pnpm config set store-dir ~/.pnpm-store
-install:
-  - pnpm install
-script:
-  - pnpm build
-```
-
-> For more information visit the pnpm documenation section on Travis CI integration, view it [here](https://pnpm.io/continuous-integration#travis)
+<Tabs items={['NPM', 'Yarn', 'PNPM']} storageKey="selected-pkg-manager">
+  <Tab>
+    ```yaml
+    language: node_js
+    node_js:
+      - lts/*
+    install:
+      - npm install
+    script:
+      - npm run build
+    script:
+      - npm run test
+    ```
+  </Tab>
+    <Tab>
+      Travis CI detects the use of Yarn by the presence of `yarn.lock`. It will automatically ensure it is installed.
+      ```yaml
+      language: node_js
+      node_js:
+        - lts/*
+      install:
+        - yarn
+      script:
+        - yarn build
+      script:
+        - yarn test
+      ```
+  </Tab>
+    <Tab>
+      ```yaml
+      language: node_js
+      node_js:
+        - lts/*
+      cache:
+        npm: false
+        directories:
+          - "~/.pnpm-store"
+      before_install:
+        - curl -f https://get.pnpm.io/v6.16.js | node - add --global pnpm@7.0.0-rc.9
+        - pnpm config set store-dir ~/.pnpm-store
+      install:
+        - pnpm install
+      script:
+        - pnpm build
+      script:
+        - pnpm test
+      ```
+      > For more information visit the pnpm documenation section on Travis CI integration, view it [here](https://pnpm.io/continuous-integration#travis)
+  </Tab>
+</Tabs>
 
 ## Remote Caching
 


### PR DESCRIPTION
Adds `npm` `yarn` and `pnpm` tabs for all of our CI guides