### PR TITLE
docs: fix capitalization of npm and pnpm

### DIFF
--- a/cli/internal/packagemanager/npm.go
+++ b/cli/internal/packagemanager/npm.go
@@ -21,7 +21,7 @@ var nodejsNpm = PackageManager{
 			return nil, fmt.Errorf("package.json: %w", err)
 		}
 		if len(pkg.Workspaces) == 0 {
-			return nil, fmt.Errorf("package.json: no workspaces found. Turborepo requires NPM workspaces to be defined in the root package.json")
+			return nil, fmt.Errorf("package.json: no workspaces found. Turborepo requires npm workspaces to be defined in the root package.json")
 		}
 		return pkg.Workspaces, nil
 	},

--- a/cli/internal/packagemanager/pnpm.go
+++ b/cli/internal/packagemanager/pnpm.go
@@ -34,7 +34,7 @@ var nodejsPnpm = PackageManager{
 		}
 
 		if len(pnpmWorkspaces.Packages) == 0 {
-			return nil, fmt.Errorf("pnpm-workspace.yaml: no packages found. Turborepo requires PNPM workspaces and thus packages to be defined in the root pnpm-workspace.yaml")
+			return nil, fmt.Errorf("pnpm-workspace.yaml: no packages found. Turborepo requires pnpm workspaces and thus packages to be defined in the root pnpm-workspace.yaml")
 		}
 
 		return pnpmWorkspaces.Packages, nil

--- a/cli/internal/scope/filter/parse_target_selector.go
+++ b/cli/internal/scope/filter/parse_target_selector.go
@@ -26,7 +26,7 @@ func (ts *TargetSelector) IsValid() bool {
 
 var errCantMatchDependencies = errors.New("cannot use match dependencies without specifying either a directory or package")
 
-// ParseTargetSelector is a function that returns PNPM compatible --filter command line flags
+// ParseTargetSelector is a function that returns pnpm compatible --filter command line flags
 func ParseTargetSelector(rawSelector string, prefix string) (TargetSelector, error) {
 	exclude := false
 	firstChar := rawSelector[0]

--- a/cli/npm/turbo-install/README.md
+++ b/cli/npm/turbo-install/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <a aria-label="NPM version" href="https://www.npmjs.com/package/turbo">
+  <a aria-label="npm version" href="https://www.npmjs.com/package/turbo">
     <img alt="" src="https://badgen.net/npm/v/turbo">
   </a>
   <a aria-label="Vercel logo" href="https://vercel.com">

--- a/docs/components/features.js
+++ b/docs/components/features.js
@@ -43,7 +43,7 @@ const features = [
   },
   // {
   //   name: 'Package manager agnostic',
-  //   description: `Turborepo works with Yarn v1, Yarn v2, NPM, and PNPM workspaces.`,
+  //   description: `Turborepo works with Yarn v1, Yarn v2, npm, and pnpm workspaces.`,
   //   icon: LightningBoltIcon,
   // },
   // {

--- a/docs/pages/blog/turbo-0-4-0.mdx
+++ b/docs/pages/blog/turbo-0-4-0.mdx
@@ -29,7 +29,7 @@ Not only is hashing faster in v0.4.0, but also _a lot_ smarter.
 
 The major change is that `turbo` no longer includes the hash of the contents of the root lockfile in its hasher (the algorithm responsible for determining if a given task exists in the cache or needs to be executed). Instead, `turbo` now hashes the set of the resolved versions of a package's `dependencies` and `devDependencies` based on the root lockfile.
 
-The old behavior would explode the cache whenever the root lockfile changed in any way. With this new behavior, changing the lockfile will only bust the cache for those package's impacted by the added/changed/removed dependencies. While this sounds complicated, again all it means is that when you install/remove/update dependencies from NPM, only those packages that are actually impacted by the changes will need to be rebuilt.
+The old behavior would explode the cache whenever the root lockfile changed in any way. With this new behavior, changing the lockfile will only bust the cache for those package's impacted by the added/changed/removed dependencies. While this sounds complicated, again all it means is that when you install/remove/update dependencies from npm, only those packages that are actually impacted by the changes will need to be rebuilt.
 
 ## Experimental: Pruned Workspaces
 
@@ -119,13 +119,13 @@ So what exactly is the output of the `turbo prune`? A folder called `out` with t
 - A folder `full` with the pruned workspace's full source code, but only including the internal packages that are needed to build the target
 - A _new_ pruned lockfile that only contains the pruned subset of the original root lockfile with the dependencies that are actually used by the packages in the pruned workspace.
 
-Thanks to the above, Docker can now be set up to only rebuild each application when there is a real reason to do so. So `frontend` will only rebuild when its source or dependencies (either internal or from NPM) have actually changed. Same same for `admin` and `backend`. Changes to `ui`, either to its source code or dependencies, will trigger rebuilds of both `frontend` and `admin`, but _not_ `backend`.
+Thanks to the above, Docker can now be set up to only rebuild each application when there is a real reason to do so. So `frontend` will only rebuild when its source or dependencies (either internal or from npm) have actually changed. Same same for `admin` and `backend`. Changes to `ui`, either to its source code or dependencies, will trigger rebuilds of both `frontend` and `admin`, but _not_ `backend`.
 
 While this example seems trivial, just imagine if each app takes up to 20 minutes to build and deploy. These savings really start to add up quickly, especially on large teams.
 
 ## Pipelines
 
-To give you even more control over your Turborepo, we've added `pipeline` to `turbo`'s configuration. This new field in lets you specify how the NPM scripts in your monorepo relate to each other as well as some additional per-task options. `turbo` then uses this information to optimally schedule your tasks in your monorepo, collapsing waterfalls that would otherwise exist.
+To give you even more control over your Turborepo, we've added `pipeline` to `turbo`'s configuration. This new field in lets you specify how the npm scripts in your monorepo relate to each other as well as some additional per-task options. `turbo` then uses this information to optimally schedule your tasks in your monorepo, collapsing waterfalls that would otherwise exist.
 
 Here's how it works:
 

--- a/docs/pages/blog/turbo-1-1-0.mdx
+++ b/docs/pages/blog/turbo-1-1-0.mdx
@@ -15,12 +15,12 @@ import { Authors } from '../../components/Authors'
 Since releasing Turborepo v1.0 in mid-December, we've seen incredible adoption:
 
 - 5.5k+ GitHub Stars
-- 70k+ weekly NPM downloads
+- 70k+ weekly npm downloads
 - 65+ OSS contributors
 - In production at [Vercel](https://github.com/vercel/next.js), [AWS](https://github.com/aws-amplify/amplify-ui), [PayPal](https://twitter.com/jaredpalmer/status/1485617973477978121?s=20&t=E5K-_H-Uo0Q1qIB_uAvdXw), [Twilio](https://github.com/twilio-labs/function-templates), [Contentful](https://github.com/contentful/forma-36), [Miro](https://github.com/miroapp/app-examples), [Framer](https://github.com/framer/motion), [Discord.js](https://github.com/discordjs/discord.js), [Rocket.chat](https://github.com/RocketChat/Rocket.Chat.Fuselage), [Astro.build](https://github.com/withastro/astro)
 - 585+ members of the [Turborepo Community Discord](https://turborepo.org/discord)
 
-![Weekly NPM downloads of `turbo`](../../public/images/blog/turbo-1-1-0/turborepo-weekly-npm-downloads.png)
+![Weekly npm downloads of `turbo`](../../public/images/blog/turbo-1-1-0/turborepo-weekly-npm-downloads.png)
 
 We're further improving build performance and caching with Turborepo v1.1, featuring:
 

--- a/docs/pages/blog/turbo-1-2-0.mdx
+++ b/docs/pages/blog/turbo-1-2-0.mdx
@@ -17,7 +17,7 @@ import { Authors } from '../../components/Authors'
 Since releasing Turborepo v1.1 in late January, we've seen incredible adoption and community growth:
 
 - **6.5k+** [GitHub Stars](https://github.com/vercel/turborepo)
-- **140k+** weekly NPM downloads (doubling since our [last blog post for v1.1](/blog/turbo-1-1-0))
+- **140k+** weekly npm downloads (doubling since our [last blog post for v1.1](/blog/turbo-1-1-0))
 - **95+** OSS contributors
 - **900+** members of the [Turborepo Community Discord](https://turborepo.org/discord)
 - **1.6 years** of Time Saved through Remote Caching on Vercel, saving more than 2.5 months every week

--- a/docs/pages/blog/you-might-not-need-typescript-project-references.mdx
+++ b/docs/pages/blog/you-might-not-need-typescript-project-references.mdx
@@ -50,9 +50,9 @@ As it turns out, the TypeScript Language Server (in VSCode) and Type Checker can
 Once you do this, this package can then be used _without_ project references or a TypeScript build step (either via `tsc` or `esbuild` etc) as long as you adhere to 2 rules:
 
 - **The consuming application of an internal package must transpile and typecheck it.**
-- **You should never publish an internal package to NPM.**
+- **You should never publish an internal package to npm.**
 
-As far as I can tell, this internal package pattern works with all Yarn/NPM/PNPM workspace implementations regardless of whether you are using Turborepo or some other tool. I have personally tested this pattern with several different meta frameworks (see below), but I'm sure that it works with others as well.
+As far as I can tell, this internal package pattern works with all yarn/npm/pnpm workspace implementations regardless of whether you are using Turborepo or some other tool. I have personally tested this pattern with several different meta frameworks (see below), but I'm sure that it works with others as well.
 
 ### Next.js
 

--- a/docs/pages/docs/acknowledgements.mdx
+++ b/docs/pages/docs/acknowledgements.mdx
@@ -29,8 +29,8 @@ We'd like to make a special shoutout to other build systems, monorepo tools, and
 - Preconstruct - https://preconstruct.tools
 - Nx - https://nx.dev
 - Yarn - https://yarnpkg.com
-- NPM - https://www.npmjs.com
-- PNPM - https://pnpm.js.org
+- npm - https://www.npmjs.com
+- pnpm - https://pnpm.js.org
 
 Throughout the documentation, wherever applicable, we also provide inline callouts and links to the projects and people that have inspired us.
 
@@ -38,7 +38,7 @@ Throughout the documentation, wherever applicable, we also provide inline callou
 
 Additionally, we're grateful to:
 
-- [Rick Button](https://twitter.com/rickbutton) for donating the `turbo` package name on NPM
+- [Rick Button](https://twitter.com/rickbutton) for donating the `turbo` package name on npm
 - [Iheanyi Ekechukwu](https://twitter.com/kwuchu) for helping Jared pick up Golang during the Pandemic!
 - [Kenneth Chau](https://twitter.com/kenneth_chau) for Lage's Scope and Pipeline API and docs
 - [Miguel Oller](https://mobile.twitter.com/ollermi) and [MakeSwift.com](https://makeswift.com) for piloting Turbo

--- a/docs/pages/docs/core-concepts/pipelines.mdx
+++ b/docs/pages/docs/core-concepts/pipelines.mdx
@@ -8,7 +8,7 @@ import HeartIcon from "@heroicons/react/solid/HeartIcon";
 
 # Pipelining Package Tasks
 
-In traditional monorepo task runners, like `lerna` or even `yarn`'s own built-in `workspaces run` command, each NPM lifecycle script like `build` or `test` is run [topologically](../glossary#topological-order) (which is the mathematical term for "dependency-first" order) or in parallel individually. Depending on the dependency graph of the monorepo, CPU cores might be left idle—wasting valuable time and resources.
+In traditional monorepo task runners, like `lerna` or even `yarn`'s own built-in `workspaces run` command, each npm lifecycle script like `build` or `test` is run [topologically](../glossary#topological-order) (which is the mathematical term for "dependency-first" order) or in parallel individually. Depending on the dependency graph of the monorepo, CPU cores might be left idle—wasting valuable time and resources.
 
 Turborepo gives developers a way to specify task relationships explicitly and conventionally. The advantage here is twofold.
 
@@ -213,7 +213,7 @@ For these cases, you can express these relationships in your `pipeline` configur
 }
 ```
 
-In this example, we illustrate a `deploy` script of a `frontend` application depends on both the `deploy` and `health-check` NPM scripts of `backend` as well as the `test` script of a `ui` package. The syntax is `<package>#<task>`.
+In this example, we illustrate a `deploy` script of a `frontend` application depends on both the `deploy` and `health-check` npm scripts of `backend` as well as the `test` script of a `ui` package. The syntax is `<package>#<task>`.
 
 This seems like it goes against the `"test": { "dependsOn": ["build"] }` and `"deploy": { "dependsOn": ["test"] }`, but it does not. Since `test` and `deploy` scripts do not have topological dependencies (e.g. `^<task>`), they theoretically can get triggered anytime once their own package's `build` and `test` scripts have finished! Unless they are being used for applications/services for deployment orchestration, the general guidance is to get rid of these specific package-task to package-task dependencies in the pipeline as quickly as possible (so the builds can be optimized better).
 

--- a/docs/pages/docs/getting-started.mdx
+++ b/docs/pages/docs/getting-started.mdx
@@ -25,7 +25,7 @@ To see more examples and starters, have a look at the [examples directory on Git
 
 Turborepo was designed to be incrementally adopted. Adding it to an existing monorepo takes only a few minutes.
 
-Turborepo works with [Yarn v1](https://classic.yarnpkg.com/lang/en/), [NPM](https://npmjs.com), and [PNPM](https://pnpm.io/) workspaces. The `turbo` CLI works on the following operating systems.
+Turborepo works with [Yarn v1](https://classic.yarnpkg.com/lang/en/), [npm](https://npmjs.com), and [pnpm](https://pnpm.io/) workspaces. The `turbo` CLI works on the following operating systems.
 
 - macOS darwin 64-bit (Intel), ARM 64-bit (Apple Silicon)
 - Linux 32-bit, 64-bit, ARM, ARM 64-bit, MIPS 64-bit Little Endian, PowerPC 64-bit Little Endian, IBM Z 64-bit Big Endian
@@ -38,7 +38,7 @@ Turborepo works with [Yarn v1](https://classic.yarnpkg.com/lang/en/), [NPM](http
 
 Add `turbo` as a development dependency in the root of your project.
 
-<Tabs items={['NPM', 'Yarn', 'PNPM']} storageKey="selected-pkg-manager">
+<Tabs items={['npm', 'yarn', 'pnpm']} storageKey="selected-pkg-manager">
   <Tab>
     ```bash
     npm install turbo -D
@@ -75,7 +75,7 @@ If your git repo's base branch is NOT `origin/master` then you need to specify a
 
 In `turbo.json`, add the commands you want to "turbocharge" to your pipeline.
 
-Your pipeline both defines the way in which your NPM `package.json` scripts relate to each other, and configures cache artifacts for those scripts. These relationships and cache settings are then fanned out and applied to all package tasks across your entire monorepo.
+Your pipeline both defines the way in which your npm `package.json` scripts relate to each other, and configures cache artifacts for those scripts. These relationships and cache settings are then fanned out and applied to all package tasks across your entire monorepo.
 
 ```jsonc
 {
@@ -140,7 +140,7 @@ If you are moving from another tool to [Yarn workspaces](https://classic.yarnpkg
 }
 ```
 
-Now re-run your NPM client's install command just to be sure. You should be good to go now.
+Now re-run your npm client's install command just to be sure. You should be good to go now.
 
 ## Run stuff!
 

--- a/docs/pages/docs/guides/migrate-from-lerna.mdx
+++ b/docs/pages/docs/guides/migrate-from-lerna.mdx
@@ -14,7 +14,7 @@ Turborepo and Lerna have a lot a in common, but also some key differences.
 
 ## Tool Comparison
 
-Lerna is a monorepo task runner and NPM workspace implementation. Both Turborepo and Lerna can be used to run tasks across packages in parallel and also topologically (i.e. if A depends on B, run B before A).
+Lerna is a monorepo task runner and npm workspace implementation. Both Turborepo and Lerna can be used to run tasks across packages in parallel and also topologically (i.e. if A depends on B, run B before A).
 
 ### Caching
 
@@ -32,7 +32,7 @@ The above may not not look like much. But imagine that A's `build` task takes 20
 
 ### Package Publishing, Versioning, and Changelog Generation
 
-Lerna can version and publish packages to NPM registries as well as create changelogs. It's extremely good at this, especially for releasing canary pre-releases. While Turborepo may eventually tackle these features, at the time of writing, it is not a high priority goal (we suggest using [Changesets](https://github.com/changesets/changesets) in the meantime). If Changesets isn't for you, and you want to stick with Lerna's publish flow, you can use Lerna and Turborepo together.
+Lerna can version and publish packages to npm registries as well as create changelogs. It's extremely good at this, especially for releasing canary pre-releases. While Turborepo may eventually tackle these features, at the time of writing, it is not a high priority goal (we suggest using [Changesets](https://github.com/changesets/changesets) in the meantime). If Changesets isn't for you, and you want to stick with Lerna's publish flow, you can use Lerna and Turborepo together.
 
 ## Example migration
 
@@ -123,4 +123,4 @@ Create a `turbo.json` file in the root of your project.
 }
 ```
 
-If you're not using yarn or NPM workspaces with Lerna, you should keep around your `lerna bootstrap` command if you have one. Turborepo considers Lerna a valid workspace implementation. Everything should work as expected.
+If you're not using yarn or npm workspaces with Lerna, you should keep around your `lerna bootstrap` command if you have one. Turborepo considers Lerna a valid workspace implementation. Everything should work as expected.

--- a/docs/pages/docs/guides/monorepo-tools.mdx
+++ b/docs/pages/docs/guides/monorepo-tools.mdx
@@ -11,7 +11,7 @@ Below is a running list of additional monorepo tools that you may find useful in
 
 ## Versioning, Publishing, and Changelog Generation
 
-For the foreseeable future, `turbo` is not going to deal with package publishing. Versioning/Publishing is an extremely opinionated topic with a lot of existing solutions. Our advice is to avoid versioning packages altogether unless you actually need to publish them to NPM for external consumption. If you have to version your packages, we really like the workflow of Changesets (especially for open source projects).
+For the foreseeable future, `turbo` is not going to deal with package publishing. Versioning/Publishing is an extremely opinionated topic with a lot of existing solutions. Our advice is to avoid versioning packages altogether unless you actually need to publish them to npm for external consumption. If you have to version your packages, we really like the workflow of Changesets (especially for open source projects).
 
 - [changesets/changesets](https://github.com/changesets/changesets) - 🦋 A way to manage your versioning and changelogs with a focus on monorepos
 - [microsoft/beachball](https://github.com/microsoft/beachball) - The Sunniest Semantic Version Bumper

--- a/docs/pages/docs/reference/command-line-reference.mdx
+++ b/docs/pages/docs/reference/command-line-reference.mdx
@@ -67,7 +67,7 @@ turbo run build
 
 ## `turbo run <task>`
 
-Run NPM scripts across all packages in specified scope. Tasks must be specified in your `pipeline` configuration.
+Run npm scripts across all packages in specified scope. Tasks must be specified in your `pipeline` configuration.
 
 `turbo run <task1> <task2> [options] [-- <args passed to task1 and task2>]`
 

--- a/docs/pages/docs/reference/configuration.mdx
+++ b/docs/pages/docs/reference/configuration.mdx
@@ -5,7 +5,7 @@ description: Learn how to configure Turborepo through `turbo.json`.
 
 # Configuration Options
 
-You can configure the behavior of `turbo` by adding a `turbo.json` file in your monorepo's root (i.e. the same one you specify your `workspaces` key is set for Yarn and NPM users).
+You can configure the behavior of `turbo` by adding a `turbo.json` file in your monorepo's root (i.e. the same one you specify your `workspaces` key is set for Yarn and npm users).
 
 ## `baseBranch`
 
@@ -41,7 +41,7 @@ This is useful for busting the cache based on `.env` files (not in Git), environ
 
 An object representing the task dependency graph of your project. `turbo` interprets these conventions to properly schedule, execute, and cache the outputs of tasks in your project.
 
-Each key in the `pipeline` object is the name of a task that can be executed by `turbo run`. If `turbo` finds a workspace package with a `package.json` `scripts` object with a matching key, it will apply the pipeline task configuration to that NPM script during execution. This allows you to use `pipeline` to set conventions across your entire Turborepo.
+Each key in the `pipeline` object is the name of a task that can be executed by `turbo run`. If `turbo` finds a workspace package with a `package.json` `scripts` object with a matching key, it will apply the pipeline task configuration to that npm script during execution. This allows you to use `pipeline` to set conventions across your entire Turborepo.
 
 ```jsonc
 {

--- a/docs/schema.d.ts
+++ b/docs/schema.d.ts
@@ -41,7 +41,7 @@ export interface Schema {
     /**
      * The name of a task that can be executed by turbo run. If turbo finds a workspace
      * package with a package.json scripts object with a matching key, it will apply the
-     * pipeline task configuration to that NPM script during execution. This allows you to
+     * pipeline task configuration to that npm script during execution. This allows you to
      * use pipeline to set conventions across your entire Turborepo.
      */
     [script: string]: Pipeline;

--- a/examples/design-system/README.md
+++ b/examples/design-system/README.md
@@ -35,9 +35,9 @@ yarn install
 git init . && git add . && git commit -m "Init"
 ```
 
-### Changing the NPM organization scope
+### Changing the npm organization scope
 
-The NPM organization scope for this design system starter is `@acme`. To change this, it's a bit manual at the moment, but you'll need to do the following:
+The npm organization scope for this design system starter is `@acme`. To change this, it's a bit manual at the moment, but you'll need to do the following:
 
 - Rename folders in `packages/*` to replace `acme` with your desired scope
 - Search and replace `acme` with your desired scope
@@ -45,11 +45,11 @@ The NPM organization scope for this design system starter is `@acme`. To change 
 
 ### Publishing packages
 
-#### NPM
+#### npm
 
-If you want to publish package to the public NPM registry and make them publicly available, this is already setup for you.
+If you want to publish package to the public npm registry and make them publicly available, this is already setup for you.
 
-To publish packages to a private NPM organization scope, **remove** the following from each of the `package.json`'s
+To publish packages to a private npm organization scope, **remove** the following from each of the `package.json`'s
 
 ```diff
 - "publishConfig": {

--- a/examples/with-changesets/README.md
+++ b/examples/with-changesets/README.md
@@ -43,9 +43,9 @@ git init . && git add . && git commit -m "Init"
 - `yarn changeset` - Generate a changeset
 - `yarn clean` - Clean up all `node_modules` and `dist` folders (runs each package's clean script)
 
-### Changing the NPM organization scope
+### Changing the npm organization scope
 
-The NPM organization scope for this design system starter is `@acme`. To change this, it's a bit manual at the moment, but you'll need to do the following:
+The npm organization scope for this design system starter is `@acme`. To change this, it's a bit manual at the moment, but you'll need to do the following:
 
 - Rename folders in `packages/*` to replace `acme` with your desired scope
 - Search and replace `acme` with your desired scope

--- a/examples/with-pnpm/README.md
+++ b/examples/with-pnpm/README.md
@@ -1,10 +1,10 @@
-# Turborepo starter with PNPM
+# Turborepo starter with pnpm
 
 This is an official starter turborepo.
 
 ## What's inside?
 
-This turborepo uses [PNPM](https://pnpm.io) as a packages manager. It includes the following packages/apps:
+This turborepo uses [pnpm](https://pnpm.io) as a packages manager. It includes the following packages/apps:
 
 ### Apps and Packages
 
@@ -26,7 +26,7 @@ This turborepo has some additional tools already setup for you:
 
 ## Setup
 
-This repository is used in the `npx create-turbo@latest` command, and selected when choosing which package manager you wish to use with your monorepo (PNPM).
+This repository is used in the `npx create-turbo@latest` command, and selected when choosing which package manager you wish to use with your monorepo (pnpm).
 
 ### Build
 

--- a/packages/create-turbo/templates/npm/README.md
+++ b/packages/create-turbo/templates/npm/README.md
@@ -1,10 +1,10 @@
-# Turborepo starter with NPM
+# Turborepo starter with npm
 
 This is an official starter turborepo.
 
 ## What's inside?
 
-This turborepo uses [NPM](https://www.npmjs.com/) as a package manager. It includes the following packages/apps:
+This turborepo uses [npm](https://www.npmjs.com/) as a package manager. It includes the following packages/apps:
 
 ### Apps and Packages
 
@@ -26,7 +26,7 @@ This turborepo has some additional tools already setup for you:
 
 ## Setup
 
-This repository is used in the `npx create-turbo@latest` command, and selected when choosing which package manager you wish to use with your monorepo (NPM).
+This repository is used in the `npx create-turbo@latest` command, and selected when choosing which package manager you wish to use with your monorepo (npm).
 
 ### Build
 

--- a/packages/create-turbo/templates/pnpm/README.md
+++ b/packages/create-turbo/templates/pnpm/README.md
@@ -26,7 +26,7 @@ This turborepo has some additional tools already setup for you:
 
 ## Setup
 
-This repository is used in the `npx create-turbo@latest` command, and selected when choosing which package manager you wish to use with your monorepo (PNPM).
+This repository is used in the `npx create-turbo@latest` command, and selected when choosing which package manager you wish to use with your monorepo (pnpm).
 
 ### Build
 


### PR DESCRIPTION
as titled. the npm and pnpm brands prefer to use all lowercase. yarn seems to alternate between Yarn and yarn so I didn't modify that one