### PR TITLE
fix: set eslint config to "root" inside examples

### DIFF
--- a/examples/basic/packages/config/eslint-preset.js
+++ b/examples/basic/packages/config/eslint-preset.js
@@ -1,4 +1,5 @@
 module.exports = {
+  root: true,
   extends: ["next", "prettier"],
   settings: {
     next: {

--- a/examples/design-system/packages/eslint-preset-acme/index.js
+++ b/examples/design-system/packages/eslint-preset-acme/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+  root: true,
   extends: ["next", "prettier"],
   settings: {
     next: {

--- a/examples/with-changesets/packages/eslint-preset-acme/index.js
+++ b/examples/with-changesets/packages/eslint-preset-acme/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+  root: true,
   extends: ["next", "prettier"],
   settings: {
     next: {


### PR DESCRIPTION
Prevents ESlint from referencing parent config and dependencies causing linting to fail if they've not been installed.