### PR TITLE
docs: pin pnpm versions in ci to 6

### DIFF
--- a/docs/pages/docs/ci/gitlabci.mdx
+++ b/docs/pages/docs/ci/gitlabci.mdx
@@ -96,7 +96,7 @@ Create a file called `.gitlab-ci.yml` in your repository with the following cont
         build:
           stage: build
           before_script:
-            - curl -f https://get.pnpm.io/v6.16.js | node - add --global pnpm@7.0.0-rc.9
+            - curl -f https://get.pnpm.io/v6.16.js | node - add --global pnpm@6.32.2
             - pnpm config set store-dir .pnpm-store
           script:
             - pnpm install

--- a/docs/pages/docs/ci/travisci.mdx
+++ b/docs/pages/docs/ci/travisci.mdx
@@ -83,7 +83,7 @@ Create a file called `.travis.yml` in your repository with the following content
         directories:
           - "~/.pnpm-store"
       before_install:
-        - curl -f https://get.pnpm.io/v6.16.js | node - add --global pnpm@7.0.0-rc.9
+        - curl -f https://get.pnpm.io/v6.16.js | node - add --global pnpm@6.32.2
         - pnpm config set store-dir ~/.pnpm-store
       install:
         - pnpm install


### PR DESCRIPTION
lets make sure our ci scripts all pin the user to pnpm v6 