### PR TITLE
Revert "Bump versions of dependencies. (Go, pnpm, CI, .devcontainer) (#1153)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.233.0/containers/go/.devcontainer/base.Dockerfile
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.209.6/containers/go/.devcontainer/base.Dockerfile
 
 # [Choice] Go version (use -bullseye variants on local arm64/Apple Silicon): 1, 1.16, 1.17, 1-bullseye, 1.16-bullseye, 1.17-bullseye, 1-buster, 1.16-buster, 1.17-buster
-ARG VARIANT="1.18-bullseye"
+ARG VARIANT="1.17-bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,25 +1,26 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.233.0/containers/go
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.209.6/containers/go
 {
   "name": "turbo (go, node)",
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-      // Update the VARIANT arg to pick a version of Go: 1, 1.18, 1.17
+      // Update the VARIANT arg to pick a version of Go: 1, 1.16, 1.17
       // Append -bullseye or -buster to pin to an OS version.
       // Use -bullseye variants on local arm64/Apple Silicon.
-      "VARIANT": "1.18-bullseye",
+      "VARIANT": "1.17-bullseye",
       // Options
       "NODE_VERSION": "lts/*"
     }
   },
-  "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+  "runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
 
   // Set *default* container specific settings.json values on container create.
   "settings": {
     "go.toolsManagement.checkForUpdates": "local",
     "go.useLanguageServer": true,
-    "go.gopath": "/go"
+    "go.gopath": "/go",
+    "go.goroot": "/usr/local/go"
   },
 
   // Add the IDs of extensions you want installed when the container is created.
@@ -45,7 +46,7 @@
   // Use 'postCreateCommand' to run commands after the container is created.
   "postCreateCommand": "go version",
 
-  // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "vscode",
   "features": {
     "docker-in-docker": "latest",

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -17,22 +17,22 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
           fetch-depth: 2
 
-      - name: Set up Go
-        uses: actions/setup-go@v3
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
         with:
-          go-version: 1.18.0
+          go-version: 1.17.6
         id: go
 
-      - uses: pnpm/action-setup@v2.1.0
+      - uses: pnpm/action-setup@v2.0.1
         with:
-          version: 6.32.11
+          version: 6.32.2
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v2
         with:
           node-version: 16
           cache: pnpm
@@ -63,22 +63,22 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
           fetch-depth: 2
 
-      - name: Set up Go
-        uses: actions/setup-go@v3
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
         with:
-          go-version: 1.18.0
+          go-version: 1.17.6
         id: wingo
 
-      - uses: pnpm/action-setup@v2.1.0
+      - uses: pnpm/action-setup@v2.0.1
         with:
-          version: 6.32.11
+          version: 6.32.2
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v2
         with:
           node-version: 16
           cache: pnpm
@@ -121,22 +121,22 @@ jobs:
           fi
 
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
           fetch-depth: 2
 
-      - name: Set up Go 1
-        uses: actions/setup-go@v3
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
         with:
-          go-version: 1.18.0
+          go-version: 1.17.6
         id: go
 
       - uses: pnpm/action-setup@v2.0.1
         with:
-          version: 6.32.11
+          version: 6.32.2
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v2
         with:
           node-version: 16
           cache: pnpm

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -4,7 +4,6 @@ on:
   #   tags:
   #     - v*
   #   branches:
-  #     - master
   #     - main
   pull_request:
 permissions:
@@ -16,14 +15,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: 1.18
-      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v2
         with:
           fetch-depth: 2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest

--- a/.github/workflows/large-monorepo.yml
+++ b/.github/workflows/large-monorepo.yml
@@ -15,22 +15,22 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
           fetch-depth: 2
 
-      - name: Set up Go
-        uses: actions/setup-go@v3
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
         with:
-          go-version: 1.18.0
+          go-version: 1.17.6
         id: go
 
-      - uses: pnpm/action-setup@v2.1.0
+      - uses: pnpm/action-setup@v2.0.1
         with:
-          version: 6.32.11
+          version: 6.32.2
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v2
         with:
           node-version: 16
           cache: pnpm

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -20,7 +20,7 @@ ewatch: scripts/...
 	nodemon --exec "make turbo && make e2e" -e .ts,.go
 
 check-go-version:
-	@go version | grep ' go1\.18\.0 ' || (echo 'Please install Go version 1.18.0' && false)
+	@go version | grep ' go1\.17\.5 ' || (echo 'Please install Go version 1.17.5' && false)
 
 # This "TURBO_RACE" variable exists at the request of a user on GitHub who
 # wants to run "make test" on an unsupported version of macOS (version 10.9).

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/vercel/turborepo/cli
 
-go 1.18
+go 1.16
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.12
@@ -13,15 +13,19 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/google/chrometracing v0.0.0-20210413150014-55fded0163e7
 	github.com/google/uuid v1.3.0
+	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-gatedio v0.5.0
 	github.com/hashicorp/go-hclog v1.1.0
 	github.com/hashicorp/go-retryablehttp v0.6.8
 	github.com/karrick/godirwalk v1.16.1
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.14
 	github.com/mitchellh/cli v1.1.2
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.4.3
+	github.com/mitchellh/reflectwalk v1.0.1 // indirect
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/pyr-sh/dag v1.0.0
 	github.com/sabhiram/go-gitignore v0.0.0-20201211210132-54b8a0bf510f
@@ -31,34 +35,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/yosuke-furukawa/json5 v0.1.1
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
-)
-
-require (
-	github.com/Masterminds/goutils v1.1.0 // indirect
-	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
-	github.com/armon/go-radix v1.0.0 // indirect
-	github.com/bgentry/speakeasy v0.1.0 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/huandu/xstrings v1.3.2 // indirect
-	github.com/imdario/mergo v0.3.11 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
-	github.com/kr/text v0.2.0 // indirect
-	github.com/mattn/go-colorable v0.1.12 // indirect
-	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
-	github.com/mitchellh/copystructure v1.0.0 // indirect
-	github.com/mitchellh/reflectwalk v1.0.1 // indirect
-	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/posener/complete v1.2.3 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa // indirect
-	golang.org/x/sys v0.0.0-20211205182925-97ca703d548d // indirect
 	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf // indirect
-	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -447,6 +447,7 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 h1:HWj/xjIHfjYU5nVXpTM0s39J9CbLn7Cc5a7IC5rwsMQ=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa h1:idItI2DDfCokpg0N51B2VtiLdJ4vAuXC9fnCb2gACo4=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=

--- a/package.json
+++ b/package.json
@@ -26,5 +26,5 @@
   "simple-git-hooks": {
     "pre-commit": "pnpm exec lint-staged"
   },
-  "packageManager": "pnpm@6.32.11"
+  "packageManager": "pnpm@6.32.2"
 }


### PR DESCRIPTION
This reverts commit 054fd07eb8f299ac5efa0ba97e25637bd7191f29.

Go version bump broke our linting :(

We should re-upgrade when https://github.com/golangci/golangci-lint/issues/2649 is resolved