### PR TITLE
Better ESLint configuration examples

### DIFF
--- a/examples/basic/.eslintrc.js
+++ b/examples/basic/.eslintrc.js
@@ -1,1 +1,10 @@
-module.exports = require("./packages/config/eslint-preset.js");
+module.exports = {
+  root: true,
+  // This tells ESLint to load the config from the package `eslint-config-acme`
+  extends: ["acme"],
+  settings: {
+    next: {
+      rootDir: ["apps/*/"],
+    },
+  },
+};

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -11,7 +11,7 @@ This turborepo includes the following packages/apps:
 - `docs`: a [Next.js](https://nextjs.org) app
 - `web`: another [Next.js](https://nextjs.org) app
 - `ui`: a stub React component library shared by both `web` and `docs` applications
-- `config`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
+- `eslint-config-acme`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
 - `tsconfig`: `tsconfig.json`s used throughout the monorepo
 
 Each package/app is 100% [TypeScript](https://www.typescriptlang.org/).

--- a/examples/basic/apps/docs/.eslintrc.js
+++ b/examples/basic/apps/docs/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ["acme"],
+};

--- a/examples/basic/apps/docs/package.json
+++ b/examples/basic/apps/docs/package.json
@@ -18,8 +18,7 @@
     "@types/node": "^17.0.12",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
-    "config": "*",
-    "eslint": "^7.32.0",
+    "eslint-config-acme": "*",
     "next-transpile-modules": "^9.0.0",
     "tsconfig": "*",
     "typescript": "^4.5.3"

--- a/examples/basic/apps/web/.eslintrc.js
+++ b/examples/basic/apps/web/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ["acme"],
+};

--- a/examples/basic/apps/web/package.json
+++ b/examples/basic/apps/web/package.json
@@ -18,8 +18,7 @@
     "@types/node": "^17.0.12",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
-    "config": "*",
-    "eslint": "^7.32.0",
+    "eslint-config-acme": "*",
     "next-transpile-modules": "^9.0.0",
     "tsconfig": "*",
     "typescript": "^4.5.3"

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -11,6 +11,8 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\""
   },
   "devDependencies": {
+    "eslint": "^7.32.0",
+    "eslint-config-acme": "*",
     "prettier": "^2.5.1",
     "turbo": "latest"
   }

--- a/examples/basic/packages/eslint-config-acme/index.js
+++ b/examples/basic/packages/eslint-config-acme/index.js
@@ -1,10 +1,5 @@
 module.exports = {
   extends: ["next", "prettier"],
-  settings: {
-    next: {
-      rootDir: ["apps/*/", "packages/*/"],
-    },
-  },
   rules: {
     "@next/next/no-html-link-for-pages": "off",
     "react/jsx-key": "off",

--- a/examples/basic/packages/eslint-config-acme/package.json
+++ b/examples/basic/packages/eslint-config-acme/package.json
@@ -1,17 +1,14 @@
 {
-  "name": "config",
-  "version": "1.0.0",
+  "name": "eslint-config-acme",
+  "version": "0.0.0",
   "main": "index.js",
   "license": "MIT",
-  "files": [
-    "eslint-preset.js"
-  ],
   "dependencies": {
     "eslint-config-next": "^12.0.8",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-react": "7.28.0"
   },
-  "devDependencies": {
-    "typescript": "^4.5.3"
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/examples/basic/packages/ui/package.json
+++ b/examples/basic/packages/ui/package.json
@@ -8,7 +8,6 @@
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
     "tsconfig": "*",
-    "config": "*",
     "typescript": "^4.5.2"
   }
 }

--- a/examples/design-system/.eslintrc.js
+++ b/examples/design-system/.eslintrc.js
@@ -1,1 +1,10 @@
-module.exports = require("./packages/eslint-preset-acme");
+module.exports = {
+  root: true,
+  // This tells ESLint to load the config from the package `eslint-config-acme`
+  extends: ["acme"],
+  settings: {
+    next: {
+      rootDir: ["apps/*/"],
+    },
+  },
+};

--- a/examples/design-system/README.md
+++ b/examples/design-system/README.md
@@ -12,7 +12,7 @@ This Turborepo includes the following packages and apps:
 - `@acme/core`: core React components
 - `@acme/utils`: shared React utilities
 - `@acme/tsconfig`: shared `tsconfig.json`s used throughout the monorepo
-- `eslint-preset-acme`: ESLint preset
+- `eslint-config-acme`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
 
 Each package and app is 100% [TypeScript](https://www.typescriptlang.org/).
 

--- a/examples/design-system/apps/docs/.eslintrc.js
+++ b/examples/design-system/apps/docs/.eslintrc.js
@@ -1,1 +1,4 @@
-module.exports = require("eslint-preset-acme");
+module.exports = {
+  root: true,
+  extends: ["acme"],
+};

--- a/examples/design-system/apps/docs/package.json
+++ b/examples/design-system/apps/docs/package.json
@@ -21,7 +21,7 @@
     "@types/node": "^17.0.12",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
-    "eslint-preset-acme": "*",
+    "eslint-config-acme": "*",
     "typescript": "^4.5.4"
   }
 }

--- a/examples/design-system/package.json
+++ b/examples/design-system/package.json
@@ -13,7 +13,8 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\""
   },
   "devDependencies": {
-    "eslint": "7.32.0",
+    "eslint": "^7.32.0",
+    "eslint-config-acme": "*",
     "prettier": "^2.5.1",
     "turbo": "latest"
   }

--- a/examples/design-system/packages/acme-core/.eslintrc.js
+++ b/examples/design-system/packages/acme-core/.eslintrc.js
@@ -1,1 +1,4 @@
-module.exports = require("eslint-preset-acme");
+module.exports = {
+  root: true,
+  extends: ["acme"],
+};

--- a/examples/design-system/packages/acme-core/package.json
+++ b/examples/design-system/packages/acme-core/package.json
@@ -12,14 +12,15 @@
   "scripts": {
     "build": "tsup src/index.tsx --format esm,cjs --dts --external react",
     "dev": "tsup src/index.tsx --format esm,cjs --watch --dts --external react",
-    "lint": "TIMING=1 eslint src --fix",
+    "lint": "TIMING=1 eslint src/**/*.ts* --fix",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },
   "devDependencies": {
     "@acme/tsconfig": "*",
-    "eslint-preset-acme": "*",
     "@types/react": "^17.0.13",
     "@types/react-dom": "^17.0.8",
+    "eslint": "^7.32.0",
+    "eslint-config-acme": "*",
     "react": "^17.0.2",
     "tsup": "^5.10.1",
     "typescript": "^4.5.3"

--- a/examples/design-system/packages/acme-utils/.eslintrc.js
+++ b/examples/design-system/packages/acme-utils/.eslintrc.js
@@ -1,1 +1,4 @@
-module.exports = require("eslint-preset-acme");
+module.exports = {
+  root: true,
+  extends: ["acme"],
+};

--- a/examples/design-system/packages/acme-utils/package.json
+++ b/examples/design-system/packages/acme-utils/package.json
@@ -12,14 +12,15 @@
   "scripts": {
     "build": "tsup src/index.tsx --format esm,cjs --dts --external react",
     "dev": "tsup src/index.tsx --format esm,cjs --watch --dts --external react",
-    "lint": "TIMING=1 eslint src --fix",
+    "lint": "TIMING=1 eslint src/**/*.ts* --fix",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },
   "devDependencies": {
     "@acme/tsconfig": "*",
     "@types/react": "^17.0.13",
     "@types/react-dom": "^17.0.8",
-    "eslint-preset-acme": "*",
+    "eslint": "^7.32.0",
+    "eslint-config-acme": "*",
     "react": "^17.0.2",
     "tsup": "^5.10.1",
     "typescript": "^4.5.3"

--- a/examples/design-system/packages/eslint-config-acme/index.js
+++ b/examples/design-system/packages/eslint-config-acme/index.js
@@ -1,10 +1,5 @@
 module.exports = {
   extends: ["next", "prettier"],
-  settings: {
-    next: {
-      rootDir: ["apps/*/", "packages/*/"],
-    },
-  },
   rules: {
     "@next/next/no-html-link-for-pages": "off",
     "react/jsx-key": "off",

--- a/examples/design-system/packages/eslint-config-acme/package.json
+++ b/examples/design-system/packages/eslint-config-acme/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eslint-preset-acme",
+  "name": "eslint-config-acme",
   "version": "0.0.0",
   "main": "index.js",
   "license": "MIT",

--- a/examples/kitchen-sink/apps/admin/.eslintrc.js
+++ b/examples/kitchen-sink/apps/admin/.eslintrc.js
@@ -1,1 +1,4 @@
-module.exports = require("scripts/eslint-preset");
+module.exports = {
+  root: true,
+  extends: ["acme"],
+};

--- a/examples/kitchen-sink/apps/admin/package.json
+++ b/examples/kitchen-sink/apps/admin/package.json
@@ -6,7 +6,7 @@
     "dev": "vite --port 3001 --clearScreen false",
     "build": "vite build",
     "deploy": "vercel deploy dist --team=turborepo --confirm",
-    "lint": "TIMING=1 eslint src/**/*.tsx --fix && tsc --noEmit",
+    "lint": "tsc --noEmit && TIMING=1 eslint src/**/*.ts* --fix",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },
   "dependencies": {
@@ -19,6 +19,8 @@
     "@types/react-dom": "^17.0.0",
     "@vitejs/plugin-react-refresh": "^1.3.6",
     "scripts": "*",
+    "eslint": "^7.32.0",
+    "eslint-config-acme": "*",
     "tsconfig": "*",
     "typescript": "^4.5.3",
     "vite": "^2.6.14"

--- a/examples/kitchen-sink/apps/api/.eslintrc.js
+++ b/examples/kitchen-sink/apps/api/.eslintrc.js
@@ -1,1 +1,4 @@
-module.exports = require("scripts/eslint-preset");
+module.exports = {
+  root: true,
+  extends: ['acme-server'],
+}

--- a/examples/kitchen-sink/apps/api/package.json
+++ b/examples/kitchen-sink/apps/api/package.json
@@ -7,7 +7,7 @@
     "dev": "nodemon --exec \"node -r esbuild-register ./src/index.ts\" -e .ts",
     "start": "node -r esbuild-register ./src/index.ts",
     "build": "tsc",
-    "lint": "tsc --noEmit && TIMING=1 eslint src --fix",
+    "lint": "tsc --noEmit && TIMING=1 eslint src/**/*.ts* --fix",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },
   "devDependencies": {
@@ -24,6 +24,7 @@
     "scripts": "*",
     "jest": "^26.6.3",
     "eslint": "^7.32.0",
+    "eslint-config-acme-server": "*",
     "supertest": "^6.1.3",
     "tsconfig": "*",
     "typescript": "^4.5.3"

--- a/examples/kitchen-sink/apps/storefront/.eslintrc.js
+++ b/examples/kitchen-sink/apps/storefront/.eslintrc.js
@@ -1,1 +1,4 @@
-module.exports = require("scripts/eslint-preset");
+module.exports = {
+  root: true,
+  extends: ['acme'],
+}

--- a/examples/kitchen-sink/apps/storefront/package.json
+++ b/examples/kitchen-sink/apps/storefront/package.json
@@ -23,7 +23,7 @@
     "@types/react-dom": "^17.0.8",
     "scripts": "*",
     "jest": "^26.6.3",
-    "eslint": "^7.32.0",
+    "eslint-config-acme": "*",
     "tsconfig": "*",
     "typescript": "^4.5.3"
   }

--- a/examples/kitchen-sink/packages/eslint-config-acme-server/index.js
+++ b/examples/kitchen-sink/packages/eslint-config-acme-server/index.js
@@ -1,0 +1,19 @@
+module.exports = {
+  extends: ["eslint:recommended"],
+  env: {
+    node: true,
+    es6: true
+  },
+  parserOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module",
+  },
+  overrides: [
+    {
+      files: ["**/__tests__/**/*"],
+      env: {
+        jest: true
+      }
+    }
+  ]
+};

--- a/examples/kitchen-sink/packages/eslint-config-acme-server/package.json
+++ b/examples/kitchen-sink/packages/eslint-config-acme-server/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "eslint-config-acme-server",
+  "version": "0.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "eslint": "^7.32.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/examples/kitchen-sink/packages/eslint-config-acme/index.js
+++ b/examples/kitchen-sink/packages/eslint-config-acme/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ["react-app"],
+  extends: ["next"],
   settings: {
     react: {
       version: "detect",

--- a/examples/kitchen-sink/packages/eslint-config-acme/package.json
+++ b/examples/kitchen-sink/packages/eslint-config-acme/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "eslint-config-acme",
+  "version": "0.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "eslint-config-next": "^12.0.8",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-react": "7.28.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/examples/kitchen-sink/packages/logger/.eslintrc.js
+++ b/examples/kitchen-sink/packages/logger/.eslintrc.js
@@ -1,1 +1,4 @@
-module.exports = require("scripts/eslint-preset");
+module.exports = {
+  root: true,
+  extends: ['acme'],
+}

--- a/examples/kitchen-sink/packages/logger/package.json
+++ b/examples/kitchen-sink/packages/logger/package.json
@@ -12,7 +12,7 @@
     "test": "jest",
     "dev": "tsc -w",
     "build": "tsc",
-    "lint": "TIMING=1 eslint src --fix",
+    "lint": "TIMING=1 eslint src/**/*.ts* --fix",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },
   "devDependencies": {
@@ -20,6 +20,7 @@
     "scripts": "*",
     "jest": "^26.6.3",
     "eslint": "^7.32.0",
+    "eslint-config-acme": "*",
     "tsconfig": "*",
     "typescript": "^4.5.3"
   },

--- a/examples/kitchen-sink/packages/scripts/package.json
+++ b/examples/kitchen-sink/packages/scripts/package.json
@@ -5,8 +5,7 @@
   "main": "index.js",
   "private": true,
   "files": [
-    "jest",
-    "eslint-preset.js"
+    "jest"
   ],
   "scripts": {
     "clean": "rm -rf .turbo && rm -rf node_modules"

--- a/examples/kitchen-sink/packages/ui/.eslintrc.js
+++ b/examples/kitchen-sink/packages/ui/.eslintrc.js
@@ -1,1 +1,4 @@
-module.exports = require("scripts/eslint-preset");
+module.exports = {
+  root: true,
+  extends: ['acme'],
+}

--- a/examples/kitchen-sink/packages/ui/package.json
+++ b/examples/kitchen-sink/packages/ui/package.json
@@ -14,7 +14,7 @@
     "test": "jest",
     "build": "tsup src/index.tsx --format esm,cjs --dts --external react",
     "dev": "tsup src/index.tsx --format esm,cjs --watch --dts --external react",
-    "lint": "TIMING=1 eslint src --fix",
+    "lint": "TIMING=1 eslint src/**/*.ts* --fix",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },
   "devDependencies": {
@@ -26,6 +26,7 @@
     "scripts": "*",
     "jest": "^26.6.3",
     "eslint": "^7.32.0",
+    "eslint-config-acme": "*",
     "tsup": "^5.10.1",
     "typescript": "^4.5.3"
   },

--- a/examples/with-changesets/.eslintrc.js
+++ b/examples/with-changesets/.eslintrc.js
@@ -1,1 +1,10 @@
-module.exports = require("./packages/eslint-preset-acme");
+module.exports = {
+  root: true,
+  // This tells ESLint to load the config from the package `eslint-config-acme`
+  extends: ["acme"],
+  settings: {
+    next: {
+      rootDir: ["apps/*/"],
+    },
+  },
+};

--- a/examples/with-changesets/apps/docs/.eslintrc.js
+++ b/examples/with-changesets/apps/docs/.eslintrc.js
@@ -1,1 +1,4 @@
-module.exports = require("eslint-preset-acme");
+module.exports = {
+  root: true,
+  extends: ["acme"],
+};

--- a/examples/with-changesets/package.json
+++ b/examples/with-changesets/package.json
@@ -16,7 +16,8 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.22.0",
-    "eslint": "7.32.0",
+    "eslint": "^7.32.0",
+    "eslint-config-acme": "*",
     "prettier": "^2.5.1",
     "turbo": "latest"
   }

--- a/examples/with-changesets/packages/acme-core/.eslintrc.js
+++ b/examples/with-changesets/packages/acme-core/.eslintrc.js
@@ -1,1 +1,4 @@
-module.exports = require("eslint-preset-acme");
+module.exports = {
+  root: true,
+  extends: ["acme"],
+};

--- a/examples/with-changesets/packages/acme-core/package.json
+++ b/examples/with-changesets/packages/acme-core/package.json
@@ -12,12 +12,13 @@
   "scripts": {
     "build": "tsup src/index.tsx --format esm,cjs --dts --external react",
     "dev": "tsup src/index.tsx --format esm,cjs --watch --dts --external react",
-    "lint": "TIMING=1 eslint src --fix",
+    "lint": "TIMING=1 eslint src/**/*.ts* --fix",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },
   "devDependencies": {
     "@acme/tsconfig": "*",
-    "eslint-preset-acme": "*",
+    "eslint": "^7.32.0",
+    "eslint-config-acme": "*",
     "@types/react": "^17.0.13",
     "@types/react-dom": "^17.0.8",
     "react": "^17.0.2",

--- a/examples/with-changesets/packages/acme-utils/.eslintrc.js
+++ b/examples/with-changesets/packages/acme-utils/.eslintrc.js
@@ -1,1 +1,4 @@
-module.exports = require("eslint-preset-acme");
+module.exports = {
+  root: true,
+  extends: ["acme"],
+};

--- a/examples/with-changesets/packages/acme-utils/package.json
+++ b/examples/with-changesets/packages/acme-utils/package.json
@@ -12,14 +12,15 @@
   "scripts": {
     "build": "tsup src/index.tsx --format esm,cjs --dts --external react",
     "dev": "tsup src/index.tsx --format esm,cjs --watch --dts --external react",
-    "lint": "TIMING=1 eslint src --fix",
+    "lint": "TIMING=1 eslint src/**/*.ts* --fix",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
   },
   "devDependencies": {
     "@acme/tsconfig": "*",
     "@types/react": "^17.0.13",
     "@types/react-dom": "^17.0.8",
-    "eslint-preset-acme": "*",
+    "eslint": "^7.32.0",
+    "eslint-config-acme": "*",
     "react": "^17.0.2",
     "tsup": "^5.10.1",
     "typescript": "^4.5.3"

--- a/examples/with-changesets/packages/eslint-config-acme/index.js
+++ b/examples/with-changesets/packages/eslint-config-acme/index.js
@@ -1,10 +1,5 @@
 module.exports = {
   extends: ["next", "prettier"],
-  settings: {
-    next: {
-      rootDir: ["apps/*/", "packages/*/"],
-    },
-  },
   rules: {
     "@next/next/no-html-link-for-pages": "off",
     "react/jsx-key": "off",

--- a/examples/with-changesets/packages/eslint-config-acme/package.json
+++ b/examples/with-changesets/packages/eslint-config-acme/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eslint-preset-acme",
+  "name": "eslint-config-acme",
   "version": "0.0.0",
   "main": "index.js",
   "license": "MIT",

--- a/examples/with-pnpm/.eslintrc.js
+++ b/examples/with-pnpm/.eslintrc.js
@@ -1,1 +1,10 @@
-module.exports = require("./packages/config/eslint-preset.js");
+module.exports = {
+  root: true,
+  // This tells ESLint to load the config from the package `eslint-config-acme`
+  extends: ["acme"],
+  settings: {
+    next: {
+      rootDir: ["apps/*/"],
+    },
+  },
+};

--- a/examples/with-pnpm/README.md
+++ b/examples/with-pnpm/README.md
@@ -11,7 +11,7 @@ This turborepo uses [pnpm](https://pnpm.io) as a packages manager. It includes t
 - `docs`: a [Next.js](https://nextjs.org) app
 - `web`: another [Next.js](https://nextjs.org) app
 - `ui`: a stub React component library shared by both `web` and `docs` applications
-- `config`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
+- `eslint-config-acme`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
 - `tsconfig`: `tsconfig.json`s used throughout the monorepo
 
 Each package/app is 100% [TypeScript](https://www.typescriptlang.org/).

--- a/examples/with-pnpm/apps/docs/.eslintrc.js
+++ b/examples/with-pnpm/apps/docs/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ["acme"],
+};

--- a/examples/with-pnpm/apps/docs/package.json
+++ b/examples/with-pnpm/apps/docs/package.json
@@ -18,8 +18,7 @@
     "@types/node": "^17.0.12",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
-    "config": "workspace:*",
-    "eslint": "^7.32.0",
+    "eslint-config-acme": "workspace:*",
     "next-transpile-modules": "^9.0.0",
     "tsconfig": "workspace:*",
     "typescript": "^4.5.3"

--- a/examples/with-pnpm/apps/web/.eslintrc.js
+++ b/examples/with-pnpm/apps/web/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ["acme"],
+};

--- a/examples/with-pnpm/apps/web/package.json
+++ b/examples/with-pnpm/apps/web/package.json
@@ -18,8 +18,7 @@
     "@types/node": "^17.0.12",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
-    "config": "workspace:*",
-    "eslint": "^7.32.0",
+    "eslint-config-acme": "workspace:*",
     "next-transpile-modules": "^9.0.0",
     "tsconfig": "workspace:*",
     "typescript": "^4.5.3"

--- a/examples/with-pnpm/package.json
+++ b/examples/with-pnpm/package.json
@@ -6,6 +6,7 @@
     "lint": "turbo run lint"
   },
   "devDependencies": {
+    "eslint-config-acme": "workspace:*",
     "eslint": "7.32.0",
     "prettier": "^2.5.1",
     "turbo": "latest"

--- a/examples/with-pnpm/packages/eslint-config-acme/index.js
+++ b/examples/with-pnpm/packages/eslint-config-acme/index.js
@@ -1,11 +1,5 @@
 module.exports = {
-  root: true,
   extends: ["next", "prettier"],
-  settings: {
-    next: {
-      rootDir: ["apps/*/", "packages/*/"],
-    },
-  },
   rules: {
     "@next/next/no-html-link-for-pages": "off",
     "react/jsx-key": "off",

--- a/examples/with-pnpm/packages/eslint-config-acme/package.json
+++ b/examples/with-pnpm/packages/eslint-config-acme/package.json
@@ -1,17 +1,14 @@
 {
-  "name": "config",
-  "version": "1.0.0",
+  "name": "eslint-config-acme",
+  "version": "0.0.0",
   "main": "index.js",
   "license": "MIT",
-  "files": [
-    "eslint-preset.js"
-  ],
   "dependencies": {
     "eslint-config-next": "^12.0.8",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-react": "7.28.0"
   },
-  "devDependencies": {
-    "typescript": "^4.5.3"
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/examples/with-pnpm/packages/ui/package.json
+++ b/examples/with-pnpm/packages/ui/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
-    "config": "workspace:*",
+    "eslint-config-acme": "workspace:*",
     "tsconfig": "workspace:*",
     "typescript": "^4.5.2"
   }

--- a/packages/create-turbo/templates/_shared_ts/.eslintrc.js
+++ b/packages/create-turbo/templates/_shared_ts/.eslintrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+  root: true,
+  // This tells ESLint to load the config from the package `eslint-config-acme`
+  extends: ["acme"],
+  settings: {
+    next: {
+      rootDir: ["apps/*/"],
+    },
+  },
+};

--- a/packages/create-turbo/templates/_shared_ts/README.md
+++ b/packages/create-turbo/templates/_shared_ts/README.md
@@ -11,7 +11,7 @@ This turborepo includes the following packages/apps:
 - `docs`: a [Next.js](https://nextjs.org) app
 - `web`: another [Next.js](https://nextjs.org) app
 - `ui`: a stub React component library shared by both `web` and `docs` applications
-- `config`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
+- `eslint-config-acme`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
 - `tsconfig`: `tsconfig.json`s used throughout the monorepo
 
 Each package/app is 100% [TypeScript](https://www.typescriptlang.org/).

--- a/packages/create-turbo/templates/_shared_ts/apps/docs/.eslintrc.js
+++ b/packages/create-turbo/templates/_shared_ts/apps/docs/.eslintrc.js
@@ -1,1 +1,4 @@
-module.exports = require("config/eslint-preset");
+module.exports = {
+  root: true,
+  extends: ["acme"],
+};

--- a/packages/create-turbo/templates/_shared_ts/apps/docs/package.json
+++ b/packages/create-turbo/templates/_shared_ts/apps/docs/package.json
@@ -15,8 +15,8 @@
     "ui": "*"
   },
   "devDependencies": {
-    "config": "*",
     "eslint": "7.32.0",
+    "eslint-config-acme": "*",
     "next-transpile-modules": "9.0.0",
     "tsconfig": "*",
     "@types/node": "^17.0.12",

--- a/packages/create-turbo/templates/_shared_ts/apps/web/.eslintrc.js
+++ b/packages/create-turbo/templates/_shared_ts/apps/web/.eslintrc.js
@@ -1,1 +1,4 @@
-module.exports = require("config/eslint-preset");
+module.exports = {
+  root: true,
+  extends: ["acme"],
+};

--- a/packages/create-turbo/templates/_shared_ts/apps/web/package.json
+++ b/packages/create-turbo/templates/_shared_ts/apps/web/package.json
@@ -15,8 +15,8 @@
     "ui": "*"
   },
   "devDependencies": {
-    "config": "*",
     "eslint": "7.32.0",
+    "eslint-config-acme": "*",
     "next-transpile-modules": "9.0.0",
     "tsconfig": "*",
     "@types/node": "^17.0.12",

--- a/packages/create-turbo/templates/_shared_ts/packages/eslint-config-acme/index.js
+++ b/packages/create-turbo/templates/_shared_ts/packages/eslint-config-acme/index.js
@@ -1,10 +1,5 @@
 module.exports = {
   extends: ["next", "prettier"],
-  settings: {
-    next: {
-      rootDir: ["apps/*/", "packages/*/"],
-    },
-  },
   rules: {
     "@next/next/no-html-link-for-pages": "off",
     "react/jsx-key": "off",

--- a/packages/create-turbo/templates/_shared_ts/packages/eslint-config-acme/package.json
+++ b/packages/create-turbo/templates/_shared_ts/packages/eslint-config-acme/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "config",
+  "name": "eslint-config-acme",
   "version": "0.0.0",
   "main": "index.js",
   "license": "MIT",
-  "files": [
-    "eslint-preset.js"
-  ],
   "dependencies": {
     "eslint-config-next": "^12.0.8",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-react": "7.28.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/create-turbo/templates/_shared_ts/packages/ui/package.json
+++ b/packages/create-turbo/templates/_shared_ts/packages/ui/package.json
@@ -8,7 +8,6 @@
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
     "tsconfig": "*",
-    "config": "*",
     "typescript": "^4.5.3"
   }
 }

--- a/packages/create-turbo/templates/npm/README.md
+++ b/packages/create-turbo/templates/npm/README.md
@@ -11,7 +11,7 @@ This turborepo uses [npm](https://www.npmjs.com/) as a package manager. It inclu
 - `docs`: a [Next.js](https://nextjs.org) app
 - `web`: another [Next.js](https://nextjs.org) app
 - `ui`: a stub React component library shared by both `web` and `docs` applications
-- `config`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
+- `eslint-config-acme`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
 - `tsconfig`: `tsconfig.json`s used throughout the monorepo
 
 Each package/app is 100% [TypeScript](https://www.typescriptlang.org/).

--- a/packages/create-turbo/templates/pnpm/README.md
+++ b/packages/create-turbo/templates/pnpm/README.md
@@ -11,7 +11,7 @@ This turborepo uses [pnpm](https://pnpm.io) as a packages manager. It includes t
 - `docs`: a [Next.js](https://nextjs.org) app
 - `web`: another [Next.js](https://nextjs.org) app
 - `ui`: a stub React component library shared by both `web` and `docs` applications
-- `config`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
+- `eslint-config-acme`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
 - `tsconfig`: `tsconfig.json`s used throughout the monorepo
 
 Each package/app is 100% [TypeScript](https://www.typescriptlang.org/).

--- a/packages/create-turbo/templates/pnpm/apps/docs/package.json
+++ b/packages/create-turbo/templates/pnpm/apps/docs/package.json
@@ -15,7 +15,7 @@
     "ui": "workspace:*"
   },
   "devDependencies": {
-    "config": "workspace:*",
+    "eslint-config-acme": "workspace:*",
     "eslint": "7.32.0",
     "next-transpile-modules": "9.0.0",
     "tsconfig": "workspace:*",

--- a/packages/create-turbo/templates/pnpm/apps/web/package.json
+++ b/packages/create-turbo/templates/pnpm/apps/web/package.json
@@ -15,7 +15,7 @@
     "ui": "workspace:*"
   },
   "devDependencies": {
-    "config": "workspace:*",
+    "eslint-config-acme": "workspace:*",
     "eslint": "7.32.0",
     "next-transpile-modules": "9.0.0",
     "tsconfig": "workspace:*",

--- a/packages/create-turbo/templates/pnpm/package.json
+++ b/packages/create-turbo/templates/pnpm/package.json
@@ -9,6 +9,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\""
   },
   "devDependencies": {
+    "eslint-config-acme": "workspace:*",
     "prettier": "latest",
     "turbo": "latest"
   }

--- a/packages/create-turbo/templates/pnpm/packages/ui/package.json
+++ b/packages/create-turbo/templates/pnpm/packages/ui/package.json
@@ -8,7 +8,6 @@
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
     "tsconfig": "workspace:*",
-    "config": "workspace:*",
     "typescript": "^4.5.3"
   }
 }

--- a/packages/create-turbo/templates/yarn/README.md
+++ b/packages/create-turbo/templates/yarn/README.md
@@ -11,7 +11,7 @@ This turborepo uses [Yarn](https://classic.yarnpkg.com/lang/en/) as a package ma
 - `docs`: a [Next.js](https://nextjs.org) app
 - `web`: another [Next.js](https://nextjs.org) app
 - `ui`: a stub React component library shared by both `web` and `docs` applications
-- `config`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
+- `eslint-config-acme`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
 - `tsconfig`: `tsconfig.json`s used throughout the monorepo
 
 Each package/app is 100% [TypeScript](https://www.typescriptlang.org/).


### PR DESCRIPTION
Our `eslint` configurations in examples were not actually relying on the `eslint`-recommended approach to sharing configurations and were instead directly requiring files. This switches the approach to what ESLint would recommend.

Originally detected by @darrylblake in #1151, this corrects all of our examples.