### PR TITLE
Rename eslint-config-acme to eslint-config-custom

### DIFF
--- a/examples/basic/.eslintrc.js
+++ b/examples/basic/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   root: true,
-  // This tells ESLint to load the config from the package `eslint-config-acme`
-  extends: ["acme"],
+  // This tells ESLint to load the config from the package `eslint-config-custom`
+  extends: ["custom"],
   settings: {
     next: {
       rootDir: ["apps/*/"],

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -11,7 +11,7 @@ This turborepo includes the following packages/apps:
 - `docs`: a [Next.js](https://nextjs.org) app
 - `web`: another [Next.js](https://nextjs.org) app
 - `ui`: a stub React component library shared by both `web` and `docs` applications
-- `eslint-config-acme`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
+- `eslint-config-custom`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
 - `tsconfig`: `tsconfig.json`s used throughout the monorepo
 
 Each package/app is 100% [TypeScript](https://www.typescriptlang.org/).

--- a/examples/basic/apps/docs/.eslintrc.js
+++ b/examples/basic/apps/docs/.eslintrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   root: true,
-  extends: ["acme"],
+  extends: ["custom"],
 };

--- a/examples/basic/apps/docs/package.json
+++ b/examples/basic/apps/docs/package.json
@@ -18,7 +18,7 @@
     "@types/node": "^17.0.12",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
-    "eslint-config-acme": "*",
+    "eslint-config-custom": "*",
     "next-transpile-modules": "^9.0.0",
     "tsconfig": "*",
     "typescript": "^4.5.3"

--- a/examples/basic/apps/web/.eslintrc.js
+++ b/examples/basic/apps/web/.eslintrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   root: true,
-  extends: ["acme"],
+  extends: ["custom"],
 };

--- a/examples/basic/apps/web/package.json
+++ b/examples/basic/apps/web/package.json
@@ -18,7 +18,7 @@
     "@types/node": "^17.0.12",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
-    "eslint-config-acme": "*",
+    "eslint-config-custom": "*",
     "next-transpile-modules": "^9.0.0",
     "tsconfig": "*",
     "typescript": "^4.5.3"

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "eslint": "^7.32.0",
-    "eslint-config-acme": "*",
+    "eslint-config-custom": "*",
     "prettier": "^2.5.1",
     "turbo": "latest"
   }

--- a/examples/basic/packages/eslint-config-acme/package.json
+++ b/examples/basic/packages/eslint-config-acme/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eslint-config-acme",
+  "name": "eslint-config-custom",
   "version": "0.0.0",
   "main": "index.js",
   "license": "MIT",

--- a/examples/kitchen-sink/apps/admin/package.json
+++ b/examples/kitchen-sink/apps/admin/package.json
@@ -20,7 +20,7 @@
     "@vitejs/plugin-react-refresh": "^1.3.6",
     "scripts": "*",
     "eslint": "^7.32.0",
-    "eslint-config-acme": "*",
+    "eslint-config-custom": "*",
     "tsconfig": "*",
     "typescript": "^4.5.3",
     "vite": "^2.6.14"

--- a/examples/kitchen-sink/apps/api/.eslintrc.js
+++ b/examples/kitchen-sink/apps/api/.eslintrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   root: true,
-  extends: ['acme-server'],
-}
+  extends: ["kitchen-sink-server"],
+};

--- a/examples/kitchen-sink/apps/api/package.json
+++ b/examples/kitchen-sink/apps/api/package.json
@@ -24,7 +24,7 @@
     "scripts": "*",
     "jest": "^26.6.3",
     "eslint": "^7.32.0",
-    "eslint-config-acme-server": "*",
+    "eslint-config-custom-server": "*",
     "supertest": "^6.1.3",
     "tsconfig": "*",
     "typescript": "^4.5.3"

--- a/examples/kitchen-sink/apps/storefront/.eslintrc.js
+++ b/examples/kitchen-sink/apps/storefront/.eslintrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   root: true,
-  extends: ['acme'],
-}
+  extends: ["custom"],
+};

--- a/examples/kitchen-sink/apps/storefront/package.json
+++ b/examples/kitchen-sink/apps/storefront/package.json
@@ -23,7 +23,7 @@
     "@types/react-dom": "^17.0.8",
     "scripts": "*",
     "jest": "^26.6.3",
-    "eslint-config-acme": "*",
+    "eslint-config-custom": "*",
     "tsconfig": "*",
     "typescript": "^4.5.3"
   }

--- a/examples/kitchen-sink/packages/eslint-config-acme-server/package.json
+++ b/examples/kitchen-sink/packages/eslint-config-acme-server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eslint-config-acme-server",
+  "name": "eslint-config-custom-server",
   "version": "0.0.0",
   "main": "index.js",
   "license": "MIT",

--- a/examples/kitchen-sink/packages/eslint-config-acme/package.json
+++ b/examples/kitchen-sink/packages/eslint-config-acme/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eslint-config-acme",
+  "name": "eslint-config-custom",
   "version": "0.0.0",
   "main": "index.js",
   "license": "MIT",

--- a/examples/kitchen-sink/packages/logger/.eslintrc.js
+++ b/examples/kitchen-sink/packages/logger/.eslintrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   root: true,
-  extends: ['acme'],
-}
+  extends: ["custom"],
+};

--- a/examples/kitchen-sink/packages/logger/package.json
+++ b/examples/kitchen-sink/packages/logger/package.json
@@ -20,7 +20,7 @@
     "scripts": "*",
     "jest": "^26.6.3",
     "eslint": "^7.32.0",
-    "eslint-config-acme": "*",
+    "eslint-config-custom": "*",
     "tsconfig": "*",
     "typescript": "^4.5.3"
   },

--- a/examples/kitchen-sink/packages/ui/.eslintrc.js
+++ b/examples/kitchen-sink/packages/ui/.eslintrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   root: true,
-  extends: ['acme'],
-}
+  extends: ["custom"],
+};

--- a/examples/kitchen-sink/packages/ui/package.json
+++ b/examples/kitchen-sink/packages/ui/package.json
@@ -26,7 +26,7 @@
     "scripts": "*",
     "jest": "^26.6.3",
     "eslint": "^7.32.0",
-    "eslint-config-acme": "*",
+    "eslint-config-custom": "*",
     "tsup": "^5.10.1",
     "typescript": "^4.5.3"
   },

--- a/examples/with-changesets/.eslintrc.js
+++ b/examples/with-changesets/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   root: true,
-  // This tells ESLint to load the config from the package `eslint-config-acme`
-  extends: ["acme"],
+  // This tells ESLint to load the config from the package `eslint-config-custom`
+  extends: ["kitchen-sink"],
   settings: {
     next: {
       rootDir: ["apps/*/"],

--- a/examples/with-pnpm/.eslintrc.js
+++ b/examples/with-pnpm/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   root: true,
-  // This tells ESLint to load the config from the package `eslint-config-acme`
-  extends: ["acme"],
+  // This tells ESLint to load the config from the package `eslint-config-custom`
+  extends: ["custom"],
   settings: {
     next: {
       rootDir: ["apps/*/"],

--- a/examples/with-pnpm/README.md
+++ b/examples/with-pnpm/README.md
@@ -11,7 +11,7 @@ This turborepo uses [pnpm](https://pnpm.io) as a packages manager. It includes t
 - `docs`: a [Next.js](https://nextjs.org) app
 - `web`: another [Next.js](https://nextjs.org) app
 - `ui`: a stub React component library shared by both `web` and `docs` applications
-- `eslint-config-acme`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
+- `eslint-config-custom`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
 - `tsconfig`: `tsconfig.json`s used throughout the monorepo
 
 Each package/app is 100% [TypeScript](https://www.typescriptlang.org/).

--- a/examples/with-pnpm/apps/docs/.eslintrc.js
+++ b/examples/with-pnpm/apps/docs/.eslintrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   root: true,
-  extends: ["acme"],
+  extends: ["custom"],
 };

--- a/examples/with-pnpm/apps/docs/package.json
+++ b/examples/with-pnpm/apps/docs/package.json
@@ -18,7 +18,7 @@
     "@types/node": "^17.0.12",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
-    "eslint-config-acme": "workspace:*",
+    "eslint-config-custom": "workspace:*",
     "next-transpile-modules": "^9.0.0",
     "tsconfig": "workspace:*",
     "typescript": "^4.5.3"

--- a/examples/with-pnpm/apps/web/.eslintrc.js
+++ b/examples/with-pnpm/apps/web/.eslintrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   root: true,
-  extends: ["acme"],
+  extends: ["custom"],
 };

--- a/examples/with-pnpm/apps/web/package.json
+++ b/examples/with-pnpm/apps/web/package.json
@@ -18,7 +18,7 @@
     "@types/node": "^17.0.12",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
-    "eslint-config-acme": "workspace:*",
+    "eslint-config-custom": "workspace:*",
     "next-transpile-modules": "^9.0.0",
     "tsconfig": "workspace:*",
     "typescript": "^4.5.3"

--- a/examples/with-pnpm/package.json
+++ b/examples/with-pnpm/package.json
@@ -6,7 +6,7 @@
     "lint": "turbo run lint"
   },
   "devDependencies": {
-    "eslint-config-acme": "workspace:*",
+    "eslint-config-custom": "workspace:*",
     "eslint": "7.32.0",
     "prettier": "^2.5.1",
     "turbo": "latest"

--- a/examples/with-pnpm/packages/eslint-config-acme/package.json
+++ b/examples/with-pnpm/packages/eslint-config-acme/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eslint-config-acme",
+  "name": "eslint-config-custom",
   "version": "0.0.0",
   "main": "index.js",
   "license": "MIT",

--- a/examples/with-pnpm/packages/ui/package.json
+++ b/examples/with-pnpm/packages/ui/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
-    "eslint-config-acme": "workspace:*",
+    "eslint-config-custom": "workspace:*",
     "tsconfig": "workspace:*",
     "typescript": "^4.5.2"
   }

--- a/packages/create-turbo/templates/_shared_ts/.eslintrc.js
+++ b/packages/create-turbo/templates/_shared_ts/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   root: true,
-  // This tells ESLint to load the config from the package `eslint-config-acme`
-  extends: ["acme"],
+  // This tells ESLint to load the config from the package `eslint-config-custom`
+  extends: ["custom"],
   settings: {
     next: {
       rootDir: ["apps/*/"],

--- a/packages/create-turbo/templates/_shared_ts/README.md
+++ b/packages/create-turbo/templates/_shared_ts/README.md
@@ -11,7 +11,7 @@ This turborepo includes the following packages/apps:
 - `docs`: a [Next.js](https://nextjs.org) app
 - `web`: another [Next.js](https://nextjs.org) app
 - `ui`: a stub React component library shared by both `web` and `docs` applications
-- `eslint-config-acme`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
+- `eslint-config-custom`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
 - `tsconfig`: `tsconfig.json`s used throughout the monorepo
 
 Each package/app is 100% [TypeScript](https://www.typescriptlang.org/).

--- a/packages/create-turbo/templates/_shared_ts/apps/docs/.eslintrc.js
+++ b/packages/create-turbo/templates/_shared_ts/apps/docs/.eslintrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   root: true,
-  extends: ["acme"],
+  extends: ["custom"],
 };

--- a/packages/create-turbo/templates/_shared_ts/apps/docs/package.json
+++ b/packages/create-turbo/templates/_shared_ts/apps/docs/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "eslint": "7.32.0",
-    "eslint-config-acme": "*",
+    "eslint-config-custom": "*",
     "next-transpile-modules": "9.0.0",
     "tsconfig": "*",
     "@types/node": "^17.0.12",

--- a/packages/create-turbo/templates/_shared_ts/apps/web/.eslintrc.js
+++ b/packages/create-turbo/templates/_shared_ts/apps/web/.eslintrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   root: true,
-  extends: ["acme"],
+  extends: ["custom"],
 };

--- a/packages/create-turbo/templates/_shared_ts/apps/web/package.json
+++ b/packages/create-turbo/templates/_shared_ts/apps/web/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "eslint": "7.32.0",
-    "eslint-config-acme": "*",
+    "eslint-config-custom": "*",
     "next-transpile-modules": "9.0.0",
     "tsconfig": "*",
     "@types/node": "^17.0.12",

--- a/packages/create-turbo/templates/_shared_ts/packages/eslint-config-acme/package.json
+++ b/packages/create-turbo/templates/_shared_ts/packages/eslint-config-acme/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eslint-config-acme",
+  "name": "eslint-config-custom",
   "version": "0.0.0",
   "main": "index.js",
   "license": "MIT",

--- a/packages/create-turbo/templates/npm/README.md
+++ b/packages/create-turbo/templates/npm/README.md
@@ -11,7 +11,7 @@ This turborepo uses [npm](https://www.npmjs.com/) as a package manager. It inclu
 - `docs`: a [Next.js](https://nextjs.org) app
 - `web`: another [Next.js](https://nextjs.org) app
 - `ui`: a stub React component library shared by both `web` and `docs` applications
-- `eslint-config-acme`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
+- `eslint-config-custom`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
 - `tsconfig`: `tsconfig.json`s used throughout the monorepo
 
 Each package/app is 100% [TypeScript](https://www.typescriptlang.org/).

--- a/packages/create-turbo/templates/pnpm/README.md
+++ b/packages/create-turbo/templates/pnpm/README.md
@@ -11,7 +11,7 @@ This turborepo uses [pnpm](https://pnpm.io) as a packages manager. It includes t
 - `docs`: a [Next.js](https://nextjs.org) app
 - `web`: another [Next.js](https://nextjs.org) app
 - `ui`: a stub React component library shared by both `web` and `docs` applications
-- `eslint-config-acme`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
+- `eslint-config-custom`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
 - `tsconfig`: `tsconfig.json`s used throughout the monorepo
 
 Each package/app is 100% [TypeScript](https://www.typescriptlang.org/).

--- a/packages/create-turbo/templates/pnpm/apps/docs/package.json
+++ b/packages/create-turbo/templates/pnpm/apps/docs/package.json
@@ -15,7 +15,7 @@
     "ui": "workspace:*"
   },
   "devDependencies": {
-    "eslint-config-acme": "workspace:*",
+    "eslint-config-custom": "workspace:*",
     "eslint": "7.32.0",
     "next-transpile-modules": "9.0.0",
     "tsconfig": "workspace:*",

--- a/packages/create-turbo/templates/pnpm/apps/web/package.json
+++ b/packages/create-turbo/templates/pnpm/apps/web/package.json
@@ -15,7 +15,7 @@
     "ui": "workspace:*"
   },
   "devDependencies": {
-    "eslint-config-acme": "workspace:*",
+    "eslint-config-custom": "workspace:*",
     "eslint": "7.32.0",
     "next-transpile-modules": "9.0.0",
     "tsconfig": "workspace:*",

--- a/packages/create-turbo/templates/pnpm/package.json
+++ b/packages/create-turbo/templates/pnpm/package.json
@@ -9,7 +9,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\""
   },
   "devDependencies": {
-    "eslint-config-acme": "workspace:*",
+    "eslint-config-custom": "workspace:*",
     "prettier": "latest",
     "turbo": "latest"
   }

--- a/packages/create-turbo/templates/yarn/README.md
+++ b/packages/create-turbo/templates/yarn/README.md
@@ -11,7 +11,7 @@ This turborepo uses [Yarn](https://classic.yarnpkg.com/lang/en/) as a package ma
 - `docs`: a [Next.js](https://nextjs.org) app
 - `web`: another [Next.js](https://nextjs.org) app
 - `ui`: a stub React component library shared by both `web` and `docs` applications
-- `eslint-config-acme`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
+- `eslint-config-custom`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
 - `tsconfig`: `tsconfig.json`s used throughout the monorepo
 
 Each package/app is 100% [TypeScript](https://www.typescriptlang.org/).


### PR DESCRIPTION
In #1172 we introduced an implicit onboarding step by naming the generated eslint configuration package `eslint-config-acme` in the non-design system starters/examples. This PR renames those packages to something more generic, so that folks don't immediately feel the urge to do a search and replace. In the future, we should prompt for an npm organization scope in `create-turbo` and then use that as the `eslint-config-<scope>` name