### PR TITLE
Address all SSA-dependent lint.

### DIFF
--- a/cli/internal/cache/cache_signature_authentication.go
+++ b/cli/internal/cache/cache_signature_authentication.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"hash"
-	"io"
 	"os"
 )
 
@@ -75,17 +74,6 @@ func (asa *ArtifactSignatureAuthentication) validate(hash string, artifactBody [
 	return hmac.Equal([]byte(computedTag), []byte(expectedTag)), nil
 }
 
-func (asa *ArtifactSignatureAuthentication) streamValidator(hash string, incomingReader io.ReadCloser) (io.ReadCloser, *StreamValidator, error) {
-	tag, err := asa.getTagGenerator(hash)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	tee := io.TeeReader(incomingReader, tag)
-	artifactReader := readCloser{tee, incomingReader}
-	return artifactReader, &StreamValidator{tag}, nil
-}
-
 type StreamValidator struct {
 	currentHash hash.Hash
 }
@@ -97,9 +85,4 @@ func (sv *StreamValidator) Validate(expectedTag string) bool {
 
 func (sv *StreamValidator) CurrentValue() string {
 	return base64.StdEncoding.EncodeToString(sv.currentHash.Sum(nil))
-}
-
-type readCloser struct {
-	io.Reader
-	io.Closer
 }

--- a/cli/internal/fs/package_deps_hash.go
+++ b/cli/internal/fs/package_deps_hash.go
@@ -166,9 +166,7 @@ func gitLsTree(path string, gitPath string) (string, error) {
 
 func gitLsFiles(path string, gitPath string, patterns []string) (string, error) {
 	cmd := exec.Command("git", "ls-files", "-s", "--")
-	for _, pattern := range patterns {
-		cmd.Args = append(cmd.Args, pattern)
-	}
+	cmd.Args = append(cmd.Args, patterns...)
 	cmd.Dir = path
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -222,7 +220,7 @@ func parseGitLsFiles(output string) (map[string]string, error) {
 				// 0 - the whole string
 				// 1 - the hash
 				// 2 - the filename
-				if match != nil && len(match) == 3 {
+				if len(match) == 3 {
 					hash := match[1]
 					filename := parseGitFilename(match[2])
 					changes[filename] = hash

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -308,7 +308,7 @@ func (c *RunCommand) runOperation(g *completeGraph, rs *runSpec, packageManager 
 			p := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
 			fmt.Fprintln(p, "Name\tPath\t")
 			for _, pkg := range packagesInScope {
-				fmt.Fprintln(p, fmt.Sprintf("%s\t%s\t", pkg, g.PackageInfos[pkg].Dir))
+				fmt.Fprintf(p, "%s\t%s\t\n", pkg, g.PackageInfos[pkg].Dir)
 			}
 			p.Flush()
 
@@ -924,8 +924,7 @@ func (e *execContext) exec(pt *packageTask, deps dag.Set) error {
 	argsactual := append([]string{"run"}, pt.task)
 	argsactual = append(argsactual, passThroughArgs...)
 
-	var cmd *exec.Cmd
-	cmd = exec.Command(e.packageManager.Command, argsactual...)
+	cmd := exec.Command(e.packageManager.Command, argsactual...)
 	cmd.Dir = pt.pkg.Dir
 	envs := fmt.Sprintf("TURBO_HASH=%v", hash)
 	cmd.Env = append(os.Environ(), envs)


### PR DESCRIPTION
Go has numerous linters which are dependent upon `x/tools/go/ssa` which has not yet been updated to support generics (https://github.com/golang/go/issues/48525).

This PR addresses all of the lint detected in our codebase via linters which depend on SSA analysis.

```
internal/cache/cache_signature_authentication.go:102:6: type `readCloser` is unused (unused)
internal/cache/cache_signature_authentication.go:78:45: func `(*ArtifactSignatureAuthentication).streamValidator` is unused (unused)
internal/fs/package_deps_hash.go:169:2: S1011: should replace loop with `cmd.Args = append(cmd.Args, patterns...)` (gosimple)
internal/fs/package_deps_hash.go:225:8: S1009: should omit nil check; len() for nil slices is defined as zero (gosimple)
internal/run/run.go:310:5: S1038: should use fmt.Fprintf instead of fmt.Fprintln(fmt.Sprintf(...)) (but don't forget the newline) (gosimple)
internal/run/run.go:917:2: S1021: should merge variable declaration with assignment on next line (gosimple)
```