### PR TITLE
fix: allow cache outputs external, but relative to packages

### DIFF
--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -1024,7 +1024,12 @@ func (e *execContext) exec(pt *packageTask, deps dag.Set) error {
 		targetLogger.Debug("caching output", "outputs", outputs)
 		ignore := []string{}
 
-		filesToBeCached, err := globby.GlobFiles(filepath.Join(e.rs.Opts.cwd, pt.pkg.Dir), outputs, ignore)
+		repoRelativeGlobs := make([]string, len(outputs))
+		for index, output := range outputs {
+			repoRelativeGlobs[index] = filepath.Join(pt.pkg.Dir, output)
+		}
+
+		filesToBeCached, err := globby.GlobFiles(e.rs.Opts.cwd, repoRelativeGlobs, ignore)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
You should be allowed to traverse up to the repository root for package outputs.