### PR TITLE
Better logging for failing to upload an artifact

### DIFF
--- a/cli/internal/cache/cache_http.go
+++ b/cli/internal/cache/cache_http.go
@@ -88,7 +88,7 @@ func (cache *httpCache) write(w io.WriteCloser, hash string, files []string) {
 	for _, file := range files {
 		// log.Printf("caching file %v", file)
 		if err := cache.storeFile(tw, file); err != nil {
-			log.Printf("[ERROR] Error uploading artifacts to HTTP cache: %s", err)
+			log.Printf("[ERROR] Error uploading artifact %s to HTTP cache due to: %s", file, err)
 			// TODO(jaredpalmer): How can we cancel the request at this point?
 		}
 	}


### PR DESCRIPTION
As mentioned here https://github.com/vercel/turborepo/issues/487, in some situations I'd prefer to know which artifact is so large so I can track it down (most of our artifacts should not be so large).