### PR TITLE
Send proper paths to git cmd for file hashing

### DIFF
--- a/cli/internal/fs/package_deps_hash.go
+++ b/cli/internal/fs/package_deps_hash.go
@@ -36,7 +36,7 @@ type PackageDepsOptions struct {
 }
 
 // GetPackageDeps Builds an object containing git hashes for the files under the specified `packagePath` folder.
-func GetPackageDeps(p *PackageDepsOptions) (map[string]string, error) {
+func GetPackageDeps(repoRoot AbsolutePath, p *PackageDepsOptions) (map[string]string, error) {
 	// Add all the checked in hashes.
 	// TODO(gsoltis): are these platform-dependent paths?
 	var result map[string]string
@@ -47,7 +47,7 @@ func GetPackageDeps(p *PackageDepsOptions) (map[string]string, error) {
 		}
 		result = parseGitLsTree(gitLsOutput)
 	} else {
-		gitLsOutput, err := gitLsFiles(p.PackagePath, p.GitPath, p.InputPatterns)
+		gitLsOutput, err := gitLsFiles(repoRoot.Join(p.PackagePath), p.GitPath, p.InputPatterns)
 		if err != nil {
 			return nil, fmt.Errorf("could not get git hashes for file patterns %v in package %s: %w", p.InputPatterns, p.PackagePath, err)
 		}
@@ -195,10 +195,10 @@ func gitLsTree(path string, gitPath string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-func gitLsFiles(path string, gitPath string, patterns []string) (string, error) {
+func gitLsFiles(path AbsolutePath, gitPath string, patterns []string) (string, error) {
 	cmd := exec.Command("git", "ls-files", "-s", "--")
 	cmd.Args = append(cmd.Args, patterns...)
-	cmd.Dir = path
+	cmd.Dir = path.ToString()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("failed to read `git ls-tree`: %w", err)

--- a/cli/internal/fs/path.go
+++ b/cli/internal/fs/path.go
@@ -61,6 +61,12 @@ func (ap AbsolutePath) FileExists() bool {
 	return FileExists(ap.asString())
 }
 
+// ToString returns the string representation of this absolute path. Used for
+// interfacing with APIs that require a string
+func (ap AbsolutePath) ToString() string {
+	return ap.asString()
+}
+
 // EnsureDirFS ensures that the directory containing the given filename is created
 func EnsureDirFS(fs afero.Fs, filename AbsolutePath) error {
 	dir := filename.Dir()

--- a/cli/internal/run/hash_test.go
+++ b/cli/internal/run/hash_test.go
@@ -22,6 +22,7 @@ func Test_manuallyHashPackage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create temp dir: %v", err)
 	}
+	repoRoot := fs.UnsafeToAbsolutePath(root)
 	pkgName := "libA"
 	type fileHash struct {
 		contents string
@@ -85,7 +86,7 @@ func Test_manuallyHashPackage(t *testing.T) {
 	pkg := &fs.PackageJSON{
 		Dir: pkgName,
 	}
-	hashes, err := manuallyHashPackage(pkg, []string{}, root)
+	hashes, err := manuallyHashPackage(pkg, []string{}, repoRoot)
 	if err != nil {
 		t.Fatalf("failed to calculate manual hashes: %v", err)
 	}
@@ -111,7 +112,7 @@ func Test_manuallyHashPackage(t *testing.T) {
 	}
 
 	count = 0
-	justFileHashes, err := manuallyHashPackage(pkg, []string{filepath.FromSlash("**/*file")}, root)
+	justFileHashes, err := manuallyHashPackage(pkg, []string{filepath.FromSlash("**/*file")}, repoRoot)
 	if err != nil {
 		t.Fatalf("failed to calculate manual hashes: %v", err)
 	}

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -241,7 +241,7 @@ func (c *RunCommand) runOperation(g *completeGraph, rs *runSpec, packageManager 
 		return 1
 	}
 	hashTracker := NewTracker(g.RootNode, g.GlobalHash, g.Pipeline, g.PackageInfos)
-	err = hashTracker.CalculateFileHashes(engine.TaskGraph.Vertices(), rs.Opts.concurrency, rs.Opts.cwd)
+	err = hashTracker.CalculateFileHashes(engine.TaskGraph.Vertices(), rs.Opts.concurrency, c.Config.Cwd)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error hashing package files: %s", err))
 		return 1


### PR DESCRIPTION
We were setting the wrong (relative) path for `git ls-files`. Use `fs.AbsolutePath` to ensure that we have the right thing, and plumb it through from `Config`.

Fixes #1085 #1198 