### PR TITLE
Apply inputs filter to uncommitted changes

### DIFF
--- a/cli/scripts/e2e/e2e.ts
+++ b/cli/scripts/e2e/e2e.ts
@@ -300,6 +300,11 @@ function runSmokeTests<T>(
       );
 
       // run a task without dependencies
+
+      // ensure that uncommitted irrelevant changes are also ignored
+      repo.modifyFiles({
+        [path.join("packages", "a", "README.md")]: "important text",
+      });
       const lintOutput = getCommandOutputAsArray(
         repo.turbo(
           "run",

--- a/cli/scripts/monorepo.ts
+++ b/cli/scripts/monorepo.ts
@@ -246,7 +246,7 @@ fs.copyFileSync(
     return execa.sync("git", ["checkout", "-B", branch], { cwd: this.root });
   }
 
-  commitFiles(files, options: { executable: boolean } = { executable: false }) {
+  modifyFiles(files: { [filename: string]: string }) {
     for (const [file, contents] of Object.entries(files)) {
       let out = "";
       if (typeof contents !== "string") {
@@ -265,16 +265,11 @@ fs.copyFileSync(
       }
 
       fs.writeFileSync(fullPath, out);
-
-      if (options.executable) {
-        fs.chmodSync(
-          this.subdir != null
-            ? path.join(this.root, this.subdir, file)
-            : path.join(this.root, file),
-          fs.constants.S_IXUSR | fs.constants.S_IRUSR | fs.constants.S_IROTH
-        );
-      }
     }
+  }
+
+  commitFiles(files) {
+    this.modifyFiles(files);
     execa.sync(
       "git",
       [


### PR DESCRIPTION
When hashing files for `inputs` calculations, we were also including any uncommitted changes. So, in the event that an irrelevant file had changes, it would cause a cache miss. Apply the filtering properly, and add an `e2e` test.

Fixes #1085 