### PR TITLE
Don't filter non-existent tasks in dry run

### DIFF
--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -734,9 +734,7 @@ func (c *RunCommand) executeDryRun(engine *core.Scheduler, g *completeGraph, tas
 		}
 		command, ok := pt.pkg.Scripts[pt.task]
 		if !ok {
-			c.Config.Logger.Debug("no task in package, skipping")
-			c.Config.Logger.Debug("done", "status", "skipped")
-			return nil
+			command = "<NONEXISTENT>"
 		}
 		ancestors, err := engine.TaskGraph.Ancestors(pt.taskID)
 		if err != nil {


### PR DESCRIPTION
Related to #937 and #1135

When executing a dry run, don't short-circuit on tasks with a non-existent command. Instead, set the command to `<NONEXISTENT>` and include it in the display.