### PR TITLE
Compile regexes once

### DIFF
--- a/cli/internal/packagemanager/packagemanager.go
+++ b/cli/internal/packagemanager/packagemanager.go
@@ -56,13 +56,16 @@ var packageManagers = []PackageManager{
 	nodejsPnpm,
 }
 
+var (
+	packageManagerPattern = `(npm|pnpm|yarn)@(\d+)\.\d+\.\d+(-.+)?`
+	packageManagerRegex   = regexp.MustCompile(packageManagerPattern)
+)
+
 // ParsePackageManagerString takes a package manager version string parses it into consituent components
 func ParsePackageManagerString(packageManager string) (manager string, version string, err error) {
-	pattern := `(npm|pnpm|yarn)@(\d+)\.\d+\.\d+(-.+)?`
-	re := regexp.MustCompile(pattern)
-	match := re.FindString(packageManager)
+	match := packageManagerRegex.FindString(packageManager)
 	if len(match) == 0 {
-		return "", "", fmt.Errorf("We could not parse packageManager field in package.json, expected: %s, received: %s", pattern, packageManager)
+		return "", "", fmt.Errorf("We could not parse packageManager field in package.json, expected: %s, received: %s", packageManagerPattern, packageManager)
 	}
 
 	return strings.Split(match, "@")[0], strings.Split(match, "@")[1], nil

--- a/cli/internal/scope/filter/parse_target_selector.go
+++ b/cli/internal/scope/filter/parse_target_selector.go
@@ -26,6 +26,8 @@ func (ts *TargetSelector) IsValid() bool {
 
 var errCantMatchDependencies = errors.New("cannot use match dependencies without specifying either a directory or package")
 
+var targetSelectorRegex = regexp.MustCompile(`^([^.](?:[^{}[\]]*[^{}[\].])?)?(\{[^}]+\})?((?:\.{3})?\[[^\]]+\])?$`)
+
 // ParseTargetSelector is a function that returns pnpm compatible --filter command line flags
 func ParseTargetSelector(rawSelector string, prefix string) (TargetSelector, error) {
 	exclude := false
@@ -52,8 +54,8 @@ func ParseTargetSelector(rawSelector string, prefix string) (TargetSelector, err
 			selector = selector[1:]
 		}
 	}
-	regex := regexp.MustCompile(`^([^.](?:[^{}[\]]*[^{}[\].])?)?(\{[^}]+\})?((?:\.{3})?\[[^\]]+\])?$`)
-	matches := regex.FindAllStringSubmatch(selector, -1)
+
+	matches := targetSelectorRegex.FindAllStringSubmatch(selector, -1)
 
 	diff := ""
 	parentDir := ""


### PR DESCRIPTION
Don't compile regexes each time a function is called, do it once, statically instead.