### PR TITLE
docs: fix link to Scoped builds from Microsoft Lage

### DIFF
--- a/docs/pages/docs/core-concepts/scopes.mdx
+++ b/docs/pages/docs/core-concepts/scopes.mdx
@@ -41,7 +41,7 @@ turbo run build --scope=*build-tools* --no-deps --include-dependencies
 ```
 
 <Callout type="idea" icon={<HeartIcon className="h-5 w-5 text-gray-400" aria-hidden="true" />}>
-Turborepo's Scoped Tasks API design and docs were/are inspired [Microsoft's Lage project](https://microsoft.github.io/lage/guide/scopes.html#scoped-builds-with-all-its-dependents) `--scope` flag which was inspired by [Lerna's](https://github.com/lerna/lerna/tree/main/commands/run#readme).
+Turborepo's Scoped Tasks API design and docs were/are inspired [Microsoft's Lage project](https://microsoft.github.io/lage/docs/Guide/scopes#scoped-builds-with-all-its-dependents) `--scope` flag which was inspired by [Lerna's](https://github.com/lerna/lerna/tree/main/commands/run#readme).
 
 We are working toward a new, more expressive task filtering/scoping syntax. [Read the RFC here.](https://github.com/vercel/turborepo/discussions/105)
 


### PR DESCRIPTION
Current link shows a "Page Not Found". I fixed that by linking to https://microsoft.github.io/lage/docs/Guide/scopes#scoped-builds-with-all-its-dependents