### PR TITLE
chore: Extract a couple packages

### DIFF
--- a/cli/internal/nodes/packagetask.go
+++ b/cli/internal/nodes/packagetask.go
@@ -1,0 +1,46 @@
+// package nodes defines the nodes that are present in the execution graph
+// used by turbo.
+
+package nodes
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/vercel/turborepo/cli/internal/fs"
+)
+
+// PackageTask represents running a particular task in a particular package
+type PackageTask struct {
+	TaskID         string
+	Task           string
+	PackageName    string
+	Pkg            *fs.PackageJSON
+	TaskDefinition *fs.TaskDefinition
+}
+
+// Command returns the script for this task from package.json and a boolean indicating
+// whether or not it exists
+func (pt *PackageTask) Command() (string, bool) {
+	cmd, ok := pt.Pkg.Scripts[pt.Task]
+	return cmd, ok
+}
+
+// OutputPrefix returns the prefix to be used for logging and ui for this task
+func (pt *PackageTask) OutputPrefix() string {
+	return fmt.Sprintf("%v:%v", pt.PackageName, pt.Task)
+}
+
+// RepoRelativeLogFile returns the path to the log file for this task execution as a
+// relative path from the root of the monorepo.
+func (pt *PackageTask) RepoRelativeLogFile() string {
+	return filepath.Join(pt.Pkg.Dir, ".turbo", fmt.Sprintf("turbo-%v.log", pt.Task))
+}
+
+// HashableOutputs returns the package-relative globs for files to be considered outputs
+// of this task
+func (pt *PackageTask) HashableOutputs() []string {
+	outputs := []string{fmt.Sprintf(".turbo/turbo-%v.log", pt.Task)}
+	outputs = append(outputs, pt.TaskDefinition.Outputs...)
+	return outputs
+}

--- a/cli/internal/run/hash.go
+++ b/cli/internal/run/hash.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pyr-sh/dag"
 	gitignore "github.com/sabhiram/go-gitignore"
 	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/nodes"
 	"github.com/vercel/turborepo/cli/internal/util"
 	"golang.org/x/sync/errgroup"
 )
@@ -50,10 +51,17 @@ type packageFileSpec struct {
 	inputs []string
 }
 
+func specFromPackageTask(pt *nodes.PackageTask) packageFileSpec {
+	return packageFileSpec{
+		pkg:    pt.PackageName,
+		inputs: pt.TaskDefinition.Inputs,
+	}
+}
+
 // packageFileHashKey is a hashable representation of a packageFileSpec.
 type packageFileHashKey string
 
-func (pfs *packageFileSpec) ToKey() packageFileHashKey {
+func (pfs packageFileSpec) ToKey() packageFileHashKey {
 	sort.Strings(pfs.inputs)
 	return packageFileHashKey(fmt.Sprintf("%v#%v", pfs.pkg, strings.Join(pfs.inputs, "!")))
 }
@@ -237,15 +245,15 @@ func (th *Tracker) calculateDependencyHashes(dependencySet dag.Set) ([]string, e
 // CalculateTaskHash calculates the hash for package-task combination. It is threadsafe, provided
 // that it has previously been called on its task-graph dependencies. File hashes must be calculated
 // first.
-func (th *Tracker) CalculateTaskHash(pt *packageTask, dependencySet dag.Set, args []string) (string, error) {
-	pkgFileHashKey := pt.ToPackageFileHashKey()
+func (th *Tracker) CalculateTaskHash(pt *nodes.PackageTask, dependencySet dag.Set, args []string) (string, error) {
+	pkgFileHashKey := specFromPackageTask(pt).ToKey()
 	hashOfFiles, ok := th.packageInputsHashes[pkgFileHashKey]
 	if !ok {
 		return "", fmt.Errorf("cannot find package-file hash for %v", pkgFileHashKey)
 	}
 	outputs := pt.HashableOutputs()
 	hashableEnvPairs := []string{}
-	for _, envVar := range pt.taskDefinition.EnvVarDependencies {
+	for _, envVar := range pt.TaskDefinition.EnvVarDependencies {
 		hashableEnvPairs = append(hashableEnvPairs, fmt.Sprintf("%v=%v", envVar, os.Getenv(envVar)))
 	}
 	sort.Strings(hashableEnvPairs)
@@ -255,8 +263,8 @@ func (th *Tracker) CalculateTaskHash(pt *packageTask, dependencySet dag.Set, arg
 	}
 	hash, err := fs.HashObject(&taskHashInputs{
 		hashOfFiles:          hashOfFiles,
-		externalDepsHash:     pt.pkg.ExternalDepsHash,
-		task:                 pt.task,
+		externalDepsHash:     pt.Pkg.ExternalDepsHash,
+		task:                 pt.Task,
 		outputs:              outputs,
 		passThruArgs:         args,
 		hashableEnvPairs:     hashableEnvPairs,
@@ -264,10 +272,10 @@ func (th *Tracker) CalculateTaskHash(pt *packageTask, dependencySet dag.Set, arg
 		taskDependencyHashes: taskDependencyHashes,
 	})
 	if err != nil {
-		return "", fmt.Errorf("failed to hash task %v: %v", pt.taskID, hash)
+		return "", fmt.Errorf("failed to hash task %v: %v", pt.TaskID, hash)
 	}
 	th.mu.Lock()
-	th.packageTaskHashes[pt.taskID] = hash
+	th.packageTaskHashes[pt.TaskID] = hash
 	th.mu.Unlock()
 	return hash, nil
 }

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -26,6 +26,7 @@ import (
 	"github.com/vercel/turborepo/cli/internal/fs"
 	"github.com/vercel/turborepo/cli/internal/globby"
 	"github.com/vercel/turborepo/cli/internal/logstreamer"
+	"github.com/vercel/turborepo/cli/internal/nodes"
 	"github.com/vercel/turborepo/cli/internal/packagemanager"
 	"github.com/vercel/turborepo/cli/internal/process"
 	"github.com/vercel/turborepo/cli/internal/scm"
@@ -681,8 +682,8 @@ func (c *RunCommand) executeTasks(g *completeGraph, rs *runSpec, engine *core.Sc
 	}
 
 	// run the thing
-	errs := engine.Execute(g.getPackageTaskVisitor(func(pt *packageTask) error {
-		deps := engine.TaskGraph.DownEdges(pt.taskID)
+	errs := engine.Execute(g.getPackageTaskVisitor(func(pt *nodes.PackageTask) error {
+		deps := engine.TaskGraph.DownEdges(pt.TaskID)
 		return ec.exec(pt, deps)
 	}), core.ExecOpts{
 		Parallel:    rs.Opts.parallel,
@@ -726,22 +727,22 @@ type hashedTask struct {
 
 func (c *RunCommand) executeDryRun(engine *core.Scheduler, g *completeGraph, taskHashes *Tracker, rs *runSpec) ([]hashedTask, error) {
 	taskIDs := []hashedTask{}
-	errs := engine.Execute(g.getPackageTaskVisitor(func(pt *packageTask) error {
-		passThroughArgs := rs.ArgsForTask(pt.task)
-		deps := engine.TaskGraph.DownEdges(pt.taskID)
+	errs := engine.Execute(g.getPackageTaskVisitor(func(pt *nodes.PackageTask) error {
+		passThroughArgs := rs.ArgsForTask(pt.Task)
+		deps := engine.TaskGraph.DownEdges(pt.TaskID)
 		hash, err := taskHashes.CalculateTaskHash(pt, deps, passThroughArgs)
 		if err != nil {
 			return err
 		}
-		command, ok := pt.pkg.Scripts[pt.task]
+		command, ok := pt.Command()
 		if !ok {
 			command = "<NONEXISTENT>"
 		}
-		isRootTask := pt.packageName == util.RootPkgName
+		isRootTask := pt.PackageName == util.RootPkgName
 		if isRootTask && commandLooksLikeTurbo(command) {
-			return fmt.Errorf("root task %v (%v) looks like it invokes turbo and might cause a loop", pt.task, command)
+			return fmt.Errorf("root task %v (%v) looks like it invokes turbo and might cause a loop", pt.Task, command)
 		}
-		ancestors, err := engine.TaskGraph.Ancestors(pt.taskID)
+		ancestors, err := engine.TaskGraph.Ancestors(pt.TaskID)
 		if err != nil {
 			return err
 		}
@@ -752,7 +753,7 @@ func (c *RunCommand) executeDryRun(engine *core.Scheduler, g *completeGraph, tas
 				stringAncestors = append(stringAncestors, dep.(string))
 			}
 		}
-		descendents, err := engine.TaskGraph.Descendents(pt.taskID)
+		descendents, err := engine.TaskGraph.Descendents(pt.TaskID)
 		if err != nil {
 			return err
 		}
@@ -766,13 +767,13 @@ func (c *RunCommand) executeDryRun(engine *core.Scheduler, g *completeGraph, tas
 		sort.Strings(stringDescendents)
 
 		taskIDs = append(taskIDs, hashedTask{
-			TaskID:       pt.taskID,
-			Task:         pt.task,
-			Package:      pt.packageName,
+			TaskID:       pt.TaskID,
+			Task:         pt.Task,
+			Package:      pt.PackageName,
 			Hash:         hash,
 			Command:      command,
-			Dir:          pt.pkg.Dir,
-			Outputs:      pt.taskDefinition.Outputs,
+			Dir:          pt.Pkg.Dir,
+			Outputs:      pt.TaskDefinition.Outputs,
 			LogFile:      pt.RepoRelativeLogFile(),
 			Dependencies: stringAncestors,
 			Dependents:   stringDescendents,
@@ -857,18 +858,18 @@ func (e *execContext) logError(log hclog.Logger, prefix string, err error) {
 	e.ui.Error(fmt.Sprintf("%s%s%s", ui.ERROR_PREFIX, prefix, color.RedString(" %v", err)))
 }
 
-func (e *execContext) exec(pt *packageTask, deps dag.Set) error {
+func (e *execContext) exec(pt *nodes.PackageTask, deps dag.Set) error {
 	cmdTime := time.Now()
 
-	targetLogger := e.logger.Named(fmt.Sprintf("%v:%v", pt.packageName, pt.task))
+	targetLogger := e.logger.Named(pt.OutputPrefix())
 	targetLogger.Debug("start")
 
 	// Setup tracer
-	tracer := e.runState.Run(util.GetTaskId(pt.packageName, pt.task))
+	tracer := e.runState.Run(pt.TaskID)
 
 	// Create a logger
-	pref := e.colorCache.PrefixColor(pt.packageName)
-	actualPrefix := pref("%s:%s: ", pt.packageName, pt.task)
+	pref := e.colorCache.PrefixColor(pt.PackageName)
+	actualPrefix := pref("%s: ", pt.OutputPrefix())
 	targetUi := &cli.PrefixedUi{
 		Ui:           e.ui,
 		OutputPrefix: actualPrefix,
@@ -877,10 +878,10 @@ func (e *execContext) exec(pt *packageTask, deps dag.Set) error {
 		WarnPrefix:   actualPrefix,
 	}
 
-	logFileName := filepath.Join(pt.pkg.Dir, ".turbo", fmt.Sprintf("turbo-%v.log", pt.task))
+	logFileName := pt.RepoRelativeLogFile()
 	targetLogger.Debug("log file", "path", filepath.Join(e.rs.Opts.cwd, logFileName))
 
-	passThroughArgs := e.rs.ArgsForTask(pt.task)
+	passThroughArgs := e.rs.ArgsForTask(pt.Task)
 	hash, err := e.taskHashes.CalculateTaskHash(pt, deps, passThroughArgs)
 	e.logger.Debug("task hash", "value", hash)
 	if err != nil {
@@ -892,7 +893,7 @@ func (e *execContext) exec(pt *packageTask, deps dag.Set) error {
 	// so that downstream tasks can count on the hash existing
 	//
 	// bail if the script doesn't exist
-	if _, ok := pt.pkg.Scripts[pt.task]; !ok {
+	if _, ok := pt.Command(); !ok {
 		targetLogger.Debug("no task in package, skipping")
 		targetLogger.Debug("done", "status", "skipped", "duration", time.Since(cmdTime))
 		return nil
@@ -901,7 +902,7 @@ func (e *execContext) exec(pt *packageTask, deps dag.Set) error {
 	var hit bool
 	// If we aren't forcing execution, and the task is not explicitly marked cache: false,
 	// then try to read from the cache first.
-	if !e.rs.Opts.forceExecution && pt.taskDefinition.ShouldCache {
+	if !e.rs.Opts.forceExecution && pt.TaskDefinition.ShouldCache {
 		hit, _, _, err = e.turboCache.Fetch(e.rs.Opts.cwd, hash, nil)
 		if err != nil {
 			targetUi.Error(fmt.Sprintf("error fetching from cache: %s", err))
@@ -931,11 +932,11 @@ func (e *execContext) exec(pt *packageTask, deps dag.Set) error {
 	}
 
 	// Setup command execution
-	argsactual := append([]string{"run"}, pt.task)
+	argsactual := append([]string{"run"}, pt.Task)
 	argsactual = append(argsactual, passThroughArgs...)
 
 	cmd := exec.Command(e.packageManager.Command, argsactual...)
-	cmd.Dir = pt.pkg.Dir
+	cmd.Dir = pt.Pkg.Dir
 	envs := fmt.Sprintf("TURBO_HASH=%v", hash)
 	cmd.Env = append(os.Environ(), envs)
 
@@ -943,7 +944,7 @@ func (e *execContext) exec(pt *packageTask, deps dag.Set) error {
 	// If we are not caching anything, then we don't need to write logs to disk
 	// be careful about this conditional given the default of cache = true
 	var writer io.Writer
-	if !e.rs.Opts.cache || !pt.taskDefinition.ShouldCache {
+	if !e.rs.Opts.cache || !pt.TaskDefinition.ShouldCache {
 		writer = os.Stdout
 	} else {
 		// Setup log file
@@ -1004,14 +1005,14 @@ func (e *execContext) exec(pt *packageTask, deps dag.Set) error {
 	}
 
 	// Cache command outputs
-	if e.rs.Opts.cache && pt.taskDefinition.ShouldCache {
+	if e.rs.Opts.cache && pt.TaskDefinition.ShouldCache {
 		outputs := pt.HashableOutputs()
 		targetLogger.Debug("caching output", "outputs", outputs)
 		ignore := []string{}
 
 		repoRelativeGlobs := make([]string, len(outputs))
 		for index, output := range outputs {
-			repoRelativeGlobs[index] = filepath.Join(pt.pkg.Dir, output)
+			repoRelativeGlobs[index] = filepath.Join(pt.Pkg.Dir, output)
 		}
 
 		filesToBeCached, err := globby.GlobFiles(e.rs.Opts.cwd, repoRelativeGlobs, ignore)
@@ -1030,7 +1031,7 @@ func (e *execContext) exec(pt *packageTask, deps dag.Set) error {
 			relativePaths[index] = relativePath
 		}
 
-		if err := e.turboCache.Put(pt.pkg.Dir, hash, int(time.Since(cmdTime).Milliseconds()), relativePaths); err != nil {
+		if err := e.turboCache.Put(pt.Pkg.Dir, hash, int(time.Since(cmdTime).Milliseconds()), relativePaths); err != nil {
 			e.logError(targetLogger, "", fmt.Errorf("error caching output: %w", err))
 		}
 	}
@@ -1095,32 +1096,7 @@ func (c *RunCommand) generateDotGraph(taskGraph *dag.AcyclicGraph, outputFilenam
 	return nil
 }
 
-type packageTask struct {
-	taskID         string
-	task           string
-	packageName    string
-	pkg            *fs.PackageJSON
-	taskDefinition *fs.TaskDefinition
-}
-
-func (pt *packageTask) RepoRelativeLogFile() string {
-	return filepath.Join(pt.pkg.Dir, ".turbo", fmt.Sprintf("turbo-%v.log", pt.task))
-}
-
-func (pt *packageTask) HashableOutputs() []string {
-	outputs := []string{fmt.Sprintf(".turbo/turbo-%v.log", pt.task)}
-	outputs = append(outputs, pt.taskDefinition.Outputs...)
-	return outputs
-}
-
-func (pt *packageTask) ToPackageFileHashKey() packageFileHashKey {
-	return (&packageFileSpec{
-		pkg:    pt.packageName,
-		inputs: pt.taskDefinition.Inputs,
-	}).ToKey()
-}
-
-func (g *completeGraph) getPackageTaskVisitor(visitor func(pt *packageTask) error) func(taskID string) error {
+func (g *completeGraph) getPackageTaskVisitor(visitor func(pt *nodes.PackageTask) error) func(taskID string) error {
 	return func(taskID string) error {
 		name, task := util.GetPackageTaskFromId(taskID)
 		pkg, ok := g.PackageInfos[name]
@@ -1139,12 +1115,12 @@ func (g *completeGraph) getPackageTaskVisitor(visitor func(pt *packageTask) erro
 			// override if we need to...
 			pipeline = altpipe
 		}
-		return visitor(&packageTask{
-			taskID:         taskID,
-			task:           task,
-			packageName:    name,
-			pkg:            pkg,
-			taskDefinition: &pipeline,
+		return visitor(&nodes.PackageTask{
+			TaskID:         taskID,
+			Task:           task,
+			PackageName:    name,
+			Pkg:            pkg,
+			TaskDefinition: &pipeline,
 		})
 	}
 }

--- a/cli/internal/taskhash/taskhash.go
+++ b/cli/internal/taskhash/taskhash.go
@@ -1,6 +1,7 @@
-package run
+// package taskhash handles calculating dependency hashes for nodes in the task execution
+// graph.
 
-// TODO(gsoltis): This should eventually either be its own package or part of core
+package taskhash
 
 import (
 	"fmt"

--- a/cli/internal/taskhash/taskhash_test.go
+++ b/cli/internal/taskhash/taskhash_test.go
@@ -1,4 +1,4 @@
-package run
+package taskhash
 
 import (
 	"os"


### PR DESCRIPTION
 * Move `packageTask` from `run` to `nodes.PackageTask`. If we eventually have other kinds of nodes, they can perhaps be colocated
 * Move `run/hash.go` to `taskhash/taskhash.go` with associated test