### PR TITLE
docs: remove all topological dependencies from the dependsOn test task

### DIFF
--- a/docs/pages/docs/ci/circleci.mdx
+++ b/docs/pages/docs/ci/circleci.mdx
@@ -36,7 +36,7 @@ And a `turbo.json`:
       "outputs": []
     },
     "test": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["build"],
       "outputs": []
     },
   }

--- a/docs/pages/docs/ci/github-actions.mdx
+++ b/docs/pages/docs/ci/github-actions.mdx
@@ -36,7 +36,7 @@ And a `turbo.json`:
       "outputs": []
     },
     "test": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["build"],
       "outputs": []
     },
   }

--- a/docs/pages/docs/ci/gitlabci.mdx
+++ b/docs/pages/docs/ci/gitlabci.mdx
@@ -36,7 +36,7 @@ And a `turbo.json`:
       "outputs": []
     },
     "test": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["build"],
       "outputs": []
     },
   }

--- a/docs/pages/docs/ci/travisci.mdx
+++ b/docs/pages/docs/ci/travisci.mdx
@@ -36,7 +36,7 @@ And a `turbo.json`:
       "outputs": []
     },
     "test": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["build"],
       "outputs": []
     },
   }

--- a/docs/pages/docs/core-concepts/pipelines.mdx
+++ b/docs/pages/docs/core-concepts/pipelines.mdx
@@ -198,7 +198,7 @@ For these cases, you can express these relationships in your `pipeline` configur
       "dependsOn": ["^build"]
     },
     "test": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["build"],
       "outputs": [],
     },
     "deploy": {

--- a/docs/pages/docs/getting-started.mdx
+++ b/docs/pages/docs/getting-started.mdx
@@ -89,7 +89,7 @@ Your pipeline both defines the way in which your npm `package.json` scripts rela
       "outputs": [".next/**"]
     },
     "test": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["build"],
       "outputs": []
     },
     "lint": {

--- a/docs/pages/docs/reference/command-line-reference.mdx
+++ b/docs/pages/docs/reference/command-line-reference.mdx
@@ -289,7 +289,7 @@ Given this pipeline in `turbo.json`:
     },
     "test": {
       "dependsOn": [
-        "^build"
+        "build"
       ]
     }
   }


### PR DESCRIPTION
Reading through the docs, I found out many test tasks have the "^" topological
dependencies. This commit remove all "^" from test task to be consistent and
avoid confusion.