### PR TITLE
Fix a typo in design-system example README.md

### DIFF
--- a/examples/design-system/README.md
+++ b/examples/design-system/README.md
@@ -84,7 +84,7 @@ Run `yarn build` to confirm compilation is working correctly. You should see a f
 ```bash
 acme-core
 └── dist
-    ├── index.t.ts  <-- Types
+    ├── index.d.ts  <-- Types
     ├── index.js    <-- CommonJS version
     └── index.mjs   <-- ES Modules version
 ```


### PR DESCRIPTION
This will fix a typo in the [docs of design-system](https://github.com/vercel/turborepo/blob/c8da722cf920b455e857501978adf0d0a6023547/examples/design-system/README.md?plain=1#L87) example.