### PR TITLE
Options cleanup

### DIFF
--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -123,8 +123,9 @@ func isWorkspaceReference(packageVersion string, dependencyVersion string, cwd s
 
 // WithGraph attaches information about the package dependency graph to the Context instance being
 // constructed.
-func WithGraph(rootpath string, config *config.Config, cacheDir fs.AbsolutePath) Option {
+func WithGraph(config *config.Config, cacheDir fs.AbsolutePath) Option {
 	return func(c *Context) error {
+		rootpath := config.Cwd.ToStringDuringMigration()
 		c.PackageInfos = make(map[interface{}]*fs.PackageJSON)
 		c.RootNode = core.ROOT_NODE_NAME
 

--- a/cli/internal/fs/path.go
+++ b/cli/internal/fs/path.go
@@ -99,6 +99,11 @@ func (ap AbsolutePath) Create() (*os.File, error) {
 	return os.Create(ap.asString())
 }
 
+// Ext implements filepath.Ext for an absolute path
+func (ap AbsolutePath) Ext() string {
+	return filepath.Ext(ap.asString())
+}
+
 // ToString returns the string representation of this absolute path. Used for
 // interfacing with APIs that require a string
 func (ap AbsolutePath) ToString() string {

--- a/cli/internal/prune/prune.go
+++ b/cli/internal/prune/prune.go
@@ -92,7 +92,7 @@ func (c *PruneCommand) Run(args []string) int {
 		return 1
 	}
 	cacheDir := cache.DefaultLocation(c.Config.Cwd)
-	ctx, err := context.New(context.WithGraph(pruneOptions.cwd, c.Config, cacheDir))
+	ctx, err := context.New(context.WithGraph(c.Config, cacheDir))
 
 	if err != nil {
 		c.logError(c.Config.Logger, "", fmt.Errorf("could not construct graph: %w", err))

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -450,11 +450,11 @@ func parseRunArgs(args []string, config *config.Config, output cli.Ui) (*RunOpti
 				}
 			case strings.HasPrefix(arg, "--since="):
 				if len(arg[len("--since="):]) > 0 {
-					runOptions.scopeOpts.Since = arg[len("--since="):]
+					runOptions.scopeOpts.LegacyFilter.Since = arg[len("--since="):]
 				}
 			case strings.HasPrefix(arg, "--scope="):
 				if len(arg[len("--scope="):]) > 0 {
-					runOptions.scopeOpts.Entrypoints = append(runOptions.scopeOpts.Entrypoints, arg[len("--scope="):])
+					runOptions.scopeOpts.LegacyFilter.Entrypoints = append(runOptions.scopeOpts.LegacyFilter.Entrypoints, arg[len("--scope="):])
 				}
 			case strings.HasPrefix(arg, "--ignore="):
 				if len(arg[len("--ignore="):]) > 0 {
@@ -474,7 +474,7 @@ func parseRunArgs(args []string, config *config.Config, output cli.Ui) (*RunOpti
 				runOptions.profile = fmt.Sprintf("%v-profile.json", time.Now().UnixNano())
 
 			case strings.HasPrefix(arg, "--no-deps"):
-				runOptions.scopeOpts.SkipDependents = true
+				runOptions.scopeOpts.LegacyFilter.SkipDependents = true
 			case strings.HasPrefix(arg, "--no-cache"):
 				runOptions.runcacheOpts.SkipWrites = true
 			case strings.HasPrefix(arg, "--cacheFolder"):
@@ -506,9 +506,9 @@ func parseRunArgs(args []string, config *config.Config, output cli.Ui) (*RunOpti
 				}
 			case strings.HasPrefix(arg, "--includeDependencies"):
 				output.Warn("[WARNING] The --includeDependencies flag has renamed to --include-dependencies for consistency. Please use `--include-dependencies` instead")
-				runOptions.scopeOpts.IncludeDependencies = true
+				runOptions.scopeOpts.LegacyFilter.IncludeDependencies = true
 			case strings.HasPrefix(arg, "--include-dependencies"):
-				runOptions.scopeOpts.IncludeDependencies = true
+				runOptions.scopeOpts.LegacyFilter.IncludeDependencies = true
 			case strings.HasPrefix(arg, "--only"):
 				runOptions.only = true
 			case strings.HasPrefix(arg, "--output-logs="):

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -414,9 +414,7 @@ func getDefaultRunOptions(config *config.Config) *RunOptions {
 			Dir:     cache.DefaultLocation(config.Cwd),
 			Workers: config.Cache.Workers,
 		},
-		scopeOpts: scope.Opts{
-			IncludeDependents: true,
-		},
+		scopeOpts: scope.Opts{},
 	}
 }
 
@@ -476,7 +474,7 @@ func parseRunArgs(args []string, config *config.Config, output cli.Ui) (*RunOpti
 				runOptions.profile = fmt.Sprintf("%v-profile.json", time.Now().UnixNano())
 
 			case strings.HasPrefix(arg, "--no-deps"):
-				runOptions.scopeOpts.IncludeDependents = false
+				runOptions.scopeOpts.SkipDependents = true
 			case strings.HasPrefix(arg, "--no-cache"):
 				runOptions.runcacheOpts.SkipWrites = true
 			case strings.HasPrefix(arg, "--cacheFolder"):

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -960,7 +960,9 @@ func (c *RunCommand) generateDotGraph(taskGraph *dag.AcyclicGraph, outputFilenam
 		c.Ui.Output("")
 		c.Ui.Output(fmt.Sprintf("✔ Generated task graph in %s", ui.Bold(outputFilename.ToString())))
 		if ui.IsTTY {
-			browser.OpenBrowser(outputFilename.ToString())
+			if err := browser.OpenBrowser(outputFilename.ToString()); err != nil {
+				c.Ui.Warn(color.New(color.FgYellow, color.Bold, color.ReverseVideo).Sprintf("failed to open browser. Please navigate to file://%v", outputFilename))
+			}
 		}
 		return nil
 	}

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -393,8 +393,7 @@ type runOpts struct {
 	parallel bool
 	// Whether to emit a perf profile
 	profile string
-	// Immediately exit on task failure
-	//bail            bool
+	// If true, continue task executions even if a task fails.
 	continueOnError bool
 	passThroughArgs []string
 	// Restrict execution to only the listed task names. Default false
@@ -961,7 +960,7 @@ func (c *RunCommand) generateDotGraph(taskGraph *dag.AcyclicGraph, outputFilenam
 		c.Ui.Output(fmt.Sprintf("✔ Generated task graph in %s", ui.Bold(outputFilename.ToString())))
 		if ui.IsTTY {
 			if err := browser.OpenBrowser(outputFilename.ToString()); err != nil {
-				c.Ui.Warn(color.New(color.FgYellow, color.Bold, color.ReverseVideo).Sprintf("failed to open browser. Please navigate to file://%v", outputFilename))
+				c.Ui.Warn(color.New(color.FgYellow, color.Bold, color.ReverseVideo).Sprintf("failed to open browser. Please navigate to file://%v", filepath.ToSlash(outputFilename.ToString())))
 			}
 		}
 		return nil

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -394,7 +394,8 @@ type runOpts struct {
 	// Whether to emit a perf profile
 	profile string
 	// Immediately exit on task failure
-	bail            bool
+	//bail            bool
+	continueOnError bool
 	passThroughArgs []string
 	// Restrict execution to only the listed task names. Default false
 	only       bool
@@ -405,7 +406,6 @@ type runOpts struct {
 func getDefaultOptions(config *config.Config) *Opts {
 	return &Opts{
 		runOpts: runOpts{
-			bail:        true,
 			concurrency: 10,
 		},
 		cacheOpts: cache.Opts{
@@ -479,7 +479,7 @@ func parseRunArgs(args []string, config *config.Config, output cli.Ui) (*Opts, e
 			case strings.HasPrefix(arg, "--cache-dir"):
 				unresolvedCacheFolder = arg[len("--cache-dir="):]
 			case strings.HasPrefix(arg, "--continue"):
-				opts.runOpts.bail = false
+				opts.runOpts.continueOnError = true
 			case strings.HasPrefix(arg, "--force"):
 				opts.runcacheOpts.SkipReads = true
 			case strings.HasPrefix(arg, "--stream"):
@@ -859,7 +859,7 @@ func (e *execContext) exec(pt *nodes.PackageTask, deps dag.Set) error {
 	if err != nil {
 		tracer(TargetBuildFailed, err)
 		e.logError(targetLogger, actualPrefix, err)
-		if e.rs.Opts.runOpts.bail {
+		if !e.rs.Opts.runOpts.continueOnError {
 			os.Exit(1)
 		}
 	}
@@ -905,7 +905,7 @@ func (e *execContext) exec(pt *nodes.PackageTask, deps dag.Set) error {
 		}
 		tracer(TargetBuildFailed, err)
 		targetLogger.Error("Error: command finished with error: %w", err)
-		if e.rs.Opts.runOpts.bail {
+		if !e.rs.Opts.runOpts.continueOnError {
 			targetUi.Error(fmt.Sprintf("ERROR: command finished with error: %s", err))
 			e.processes.Close()
 		} else {

--- a/cli/internal/run/run_test.go
+++ b/cli/internal/run/run_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vercel/turborepo/cli/internal/config"
 	"github.com/vercel/turborepo/cli/internal/fs"
 	"github.com/vercel/turborepo/cli/internal/runcache"
+	"github.com/vercel/turborepo/cli/internal/scope"
 	"github.com/vercel/turborepo/cli/internal/util"
 
 	"github.com/stretchr/testify/assert"
@@ -33,103 +34,107 @@ func TestParseConfig(t *testing.T) {
 			"string flags",
 			[]string{"foo"},
 			&RunOptions{
-				includeDependents:   true,
-				bail:                true,
-				dotGraph:            "",
-				concurrency:         10,
-				includeDependencies: false,
-				profile:             "",
-				cwd:                 defaultCwd.ToStringDuringMigration(),
+				bail:        true,
+				dotGraph:    "",
+				concurrency: 10,
+				profile:     "",
+				cwd:         defaultCwd.ToStringDuringMigration(),
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,
 					Workers: 10,
 				},
 				runcacheOpts: runcache.Opts{},
+				scopeOpts: scope.Opts{
+					IncludeDependents: true,
+				},
 			},
 		},
 		{
 			"scope",
 			[]string{"foo", "--scope=foo", "--scope=blah"},
 			&RunOptions{
-				includeDependents:   true,
-				bail:                true,
-				dotGraph:            "",
-				concurrency:         10,
-				includeDependencies: false,
-				profile:             "",
-				scope:               []string{"foo", "blah"},
-				cwd:                 defaultCwd.ToStringDuringMigration(),
+				bail:        true,
+				dotGraph:    "",
+				concurrency: 10,
+				profile:     "",
+				cwd:         defaultCwd.ToStringDuringMigration(),
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,
 					Workers: 10,
 				},
 				runcacheOpts: runcache.Opts{},
+				scopeOpts: scope.Opts{
+					IncludeDependents: true,
+					Entrypoints:       []string{"foo", "blah"},
+				},
 			},
 		},
 		{
 			"concurrency",
 			[]string{"foo", "--concurrency=12"},
 			&RunOptions{
-				includeDependents:   true,
-				bail:                true,
-				dotGraph:            "",
-				concurrency:         12,
-				includeDependencies: false,
-				profile:             "",
-				cwd:                 defaultCwd.ToStringDuringMigration(),
+				bail:        true,
+				dotGraph:    "",
+				concurrency: 12,
+				profile:     "",
+				cwd:         defaultCwd.ToStringDuringMigration(),
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,
 					Workers: 10,
 				},
 				runcacheOpts: runcache.Opts{},
+				scopeOpts: scope.Opts{
+					IncludeDependents: true,
+				},
 			},
 		},
 		{
 			"graph",
 			[]string{"foo", "--graph=g.png"},
 			&RunOptions{
-				includeDependents:   true,
-				bail:                true,
-				dotGraph:            "g.png",
-				concurrency:         10,
-				includeDependencies: false,
-				profile:             "",
-				cwd:                 defaultCwd.ToStringDuringMigration(),
+				bail:        true,
+				dotGraph:    "g.png",
+				concurrency: 10,
+				profile:     "",
+				cwd:         defaultCwd.ToStringDuringMigration(),
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,
 					Workers: 10,
 				},
 				runcacheOpts: runcache.Opts{},
+				scopeOpts: scope.Opts{
+					IncludeDependents: true,
+				},
 			},
 		},
 		{
 			"passThroughArgs",
 			[]string{"foo", "--graph=g.png", "--", "--boop", "zoop"},
 			&RunOptions{
-				includeDependents:   true,
-				bail:                true,
-				dotGraph:            "g.png",
-				concurrency:         10,
-				includeDependencies: false,
-				profile:             "",
-				cwd:                 defaultCwd.ToStringDuringMigration(),
-				passThroughArgs:     []string{"--boop", "zoop"},
+				bail:            true,
+				dotGraph:        "g.png",
+				concurrency:     10,
+				profile:         "",
+				cwd:             defaultCwd.ToStringDuringMigration(),
+				passThroughArgs: []string{"--boop", "zoop"},
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,
 					Workers: 10,
 				},
 				runcacheOpts: runcache.Opts{},
+				scopeOpts: scope.Opts{
+					IncludeDependents: true,
+				},
 			},
 		},
 		{
 			"force",
 			[]string{"foo", "--force"},
 			&RunOptions{
-				includeDependents: true,
-				bail:              true,
-				concurrency:       10,
-				profile:           "",
-				cwd:               defaultCwd.ToStringDuringMigration(),
+				bail:        true,
+				concurrency: 10,
+				profile:     "",
+				cwd:         defaultCwd.ToStringDuringMigration(),
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,
 					Workers: 10,
@@ -137,34 +142,38 @@ func TestParseConfig(t *testing.T) {
 				runcacheOpts: runcache.Opts{
 					SkipReads: true,
 				},
+				scopeOpts: scope.Opts{
+					IncludeDependents: true,
+				},
 			},
 		},
 		{
 			"remote-only",
 			[]string{"foo", "--remote-only"},
 			&RunOptions{
-				includeDependents: true,
-				bail:              true,
-				concurrency:       10,
-				profile:           "",
-				cwd:               defaultCwd.ToStringDuringMigration(),
+				bail:        true,
+				concurrency: 10,
+				profile:     "",
+				cwd:         defaultCwd.ToStringDuringMigration(),
 				cacheOpts: cache.Opts{
 					Dir:            defaultCacheFolder,
 					Workers:        10,
 					SkipFilesystem: true,
 				},
 				runcacheOpts: runcache.Opts{},
+				scopeOpts: scope.Opts{
+					IncludeDependents: true,
+				},
 			},
 		},
 		{
 			"no-cache",
 			[]string{"foo", "--no-cache"},
 			&RunOptions{
-				includeDependents: true,
-				bail:              true,
-				concurrency:       10,
-				profile:           "",
-				cwd:               defaultCwd.ToStringDuringMigration(),
+				bail:        true,
+				concurrency: 10,
+				profile:     "",
+				cwd:         defaultCwd.ToStringDuringMigration(),
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,
 					Workers: 10,
@@ -172,41 +181,47 @@ func TestParseConfig(t *testing.T) {
 				runcacheOpts: runcache.Opts{
 					SkipWrites: true,
 				},
+				scopeOpts: scope.Opts{
+					IncludeDependents: true,
+				},
 			},
 		},
 		{
 			"Empty passThroughArgs",
 			[]string{"foo", "--graph=g.png", "--"},
 			&RunOptions{
-				includeDependents:   true,
-				bail:                true,
-				dotGraph:            "g.png",
-				concurrency:         10,
-				includeDependencies: false,
-				profile:             "",
-				cwd:                 defaultCwd.ToStringDuringMigration(),
-				passThroughArgs:     []string{},
+				bail:            true,
+				dotGraph:        "g.png",
+				concurrency:     10,
+				profile:         "",
+				cwd:             defaultCwd.ToStringDuringMigration(),
+				passThroughArgs: []string{},
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,
 					Workers: 10,
 				},
 				runcacheOpts: runcache.Opts{},
+				scopeOpts: scope.Opts{
+					IncludeDependents: true,
+				},
 			},
 		},
 		{
 			"can specify filter patterns",
 			[]string{"foo", "--filter=bar", "--filter=...[main]"},
 			&RunOptions{
-				includeDependents: true,
-				filterPatterns:    []string{"bar", "...[main]"},
-				bail:              true,
-				concurrency:       10,
-				cwd:               defaultCwd.ToStringDuringMigration(),
+				bail:        true,
+				concurrency: 10,
+				cwd:         defaultCwd.ToStringDuringMigration(),
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,
 					Workers: 10,
 				},
 				runcacheOpts: runcache.Opts{},
+				scopeOpts: scope.Opts{
+					IncludeDependents: true,
+					FilterPatterns:    []string{"bar", "...[main]"},
+				},
 			},
 		},
 	}
@@ -244,18 +259,19 @@ func TestParseRunOptionsUsesCWDFlag(t *testing.T) {
 	}
 	cwd := defaultCwd.Join("zop")
 	expected := &RunOptions{
-		includeDependents:   true,
-		bail:                true,
-		dotGraph:            "",
-		concurrency:         10,
-		includeDependencies: false,
-		profile:             "",
-		cwd:                 cwd.ToStringDuringMigration(),
+		bail:        true,
+		dotGraph:    "",
+		concurrency: 10,
+		profile:     "",
+		cwd:         cwd.ToStringDuringMigration(),
 		cacheOpts: cache.Opts{
 			Dir:     cwd.Join("node_modules", ".cache", "turbo"),
 			Workers: 10,
 		},
 		runcacheOpts: runcache.Opts{},
+		scopeOpts: scope.Opts{
+			IncludeDependents: true,
+		},
 	}
 
 	ui := &cli.BasicUi{

--- a/cli/internal/run/run_test.go
+++ b/cli/internal/run/run_test.go
@@ -44,9 +44,7 @@ func TestParseConfig(t *testing.T) {
 					Workers: 10,
 				},
 				runcacheOpts: runcache.Opts{},
-				scopeOpts: scope.Opts{
-					IncludeDependents: true,
-				},
+				scopeOpts:    scope.Opts{},
 			},
 		},
 		{
@@ -64,8 +62,7 @@ func TestParseConfig(t *testing.T) {
 				},
 				runcacheOpts: runcache.Opts{},
 				scopeOpts: scope.Opts{
-					IncludeDependents: true,
-					Entrypoints:       []string{"foo", "blah"},
+					Entrypoints: []string{"foo", "blah"},
 				},
 			},
 		},
@@ -83,9 +80,7 @@ func TestParseConfig(t *testing.T) {
 					Workers: 10,
 				},
 				runcacheOpts: runcache.Opts{},
-				scopeOpts: scope.Opts{
-					IncludeDependents: true,
-				},
+				scopeOpts:    scope.Opts{},
 			},
 		},
 		{
@@ -102,9 +97,7 @@ func TestParseConfig(t *testing.T) {
 					Workers: 10,
 				},
 				runcacheOpts: runcache.Opts{},
-				scopeOpts: scope.Opts{
-					IncludeDependents: true,
-				},
+				scopeOpts:    scope.Opts{},
 			},
 		},
 		{
@@ -122,9 +115,7 @@ func TestParseConfig(t *testing.T) {
 					Workers: 10,
 				},
 				runcacheOpts: runcache.Opts{},
-				scopeOpts: scope.Opts{
-					IncludeDependents: true,
-				},
+				scopeOpts:    scope.Opts{},
 			},
 		},
 		{
@@ -142,9 +133,7 @@ func TestParseConfig(t *testing.T) {
 				runcacheOpts: runcache.Opts{
 					SkipReads: true,
 				},
-				scopeOpts: scope.Opts{
-					IncludeDependents: true,
-				},
+				scopeOpts: scope.Opts{},
 			},
 		},
 		{
@@ -161,9 +150,7 @@ func TestParseConfig(t *testing.T) {
 					SkipFilesystem: true,
 				},
 				runcacheOpts: runcache.Opts{},
-				scopeOpts: scope.Opts{
-					IncludeDependents: true,
-				},
+				scopeOpts:    scope.Opts{},
 			},
 		},
 		{
@@ -181,9 +168,7 @@ func TestParseConfig(t *testing.T) {
 				runcacheOpts: runcache.Opts{
 					SkipWrites: true,
 				},
-				scopeOpts: scope.Opts{
-					IncludeDependents: true,
-				},
+				scopeOpts: scope.Opts{},
 			},
 		},
 		{
@@ -201,9 +186,7 @@ func TestParseConfig(t *testing.T) {
 					Workers: 10,
 				},
 				runcacheOpts: runcache.Opts{},
-				scopeOpts: scope.Opts{
-					IncludeDependents: true,
-				},
+				scopeOpts:    scope.Opts{},
 			},
 		},
 		{
@@ -219,8 +202,7 @@ func TestParseConfig(t *testing.T) {
 				},
 				runcacheOpts: runcache.Opts{},
 				scopeOpts: scope.Opts{
-					IncludeDependents: true,
-					FilterPatterns:    []string{"bar", "...[main]"},
+					FilterPatterns: []string{"bar", "...[main]"},
 				},
 			},
 		},
@@ -269,9 +251,7 @@ func TestParseRunOptionsUsesCWDFlag(t *testing.T) {
 			Workers: 10,
 		},
 		runcacheOpts: runcache.Opts{},
-		scopeOpts: scope.Opts{
-			IncludeDependents: true,
-		},
+		scopeOpts:    scope.Opts{},
 	}
 
 	ui := &cli.BasicUi{

--- a/cli/internal/run/run_test.go
+++ b/cli/internal/run/run_test.go
@@ -62,7 +62,9 @@ func TestParseConfig(t *testing.T) {
 				},
 				runcacheOpts: runcache.Opts{},
 				scopeOpts: scope.Opts{
-					Entrypoints: []string{"foo", "blah"},
+					LegacyFilter: scope.LegacyFilter{
+						Entrypoints: []string{"foo", "blah"},
+					},
 				},
 			},
 		},

--- a/cli/internal/run/run_test.go
+++ b/cli/internal/run/run_test.go
@@ -35,7 +35,6 @@ func TestParseConfig(t *testing.T) {
 			[]string{"foo"},
 			&Opts{
 				runOpts: runOpts{
-					bail:        true,
 					concurrency: 10,
 				},
 				cacheOpts: cache.Opts{
@@ -51,7 +50,6 @@ func TestParseConfig(t *testing.T) {
 			[]string{"foo", "--scope=foo", "--scope=blah"},
 			&Opts{
 				runOpts: runOpts{
-					bail:        true,
 					concurrency: 10,
 				},
 				cacheOpts: cache.Opts{
@@ -71,7 +69,6 @@ func TestParseConfig(t *testing.T) {
 			[]string{"foo", "--concurrency=12"},
 			&Opts{
 				runOpts: runOpts{
-					bail:        true,
 					concurrency: 12,
 				},
 				cacheOpts: cache.Opts{
@@ -87,7 +84,6 @@ func TestParseConfig(t *testing.T) {
 			[]string{"foo", "--graph=g.png"},
 			&Opts{
 				runOpts: runOpts{
-					bail:        true,
 					concurrency: 10,
 					dotGraph:    "g.png",
 				},
@@ -104,7 +100,6 @@ func TestParseConfig(t *testing.T) {
 			[]string{"foo", "--graph=g.png", "--", "--boop", "zoop"},
 			&Opts{
 				runOpts: runOpts{
-					bail:            true,
 					concurrency:     10,
 					dotGraph:        "g.png",
 					passThroughArgs: []string{"--boop", "zoop"},
@@ -122,7 +117,6 @@ func TestParseConfig(t *testing.T) {
 			[]string{"foo", "--force"},
 			&Opts{
 				runOpts: runOpts{
-					bail:        true,
 					concurrency: 10,
 				},
 				cacheOpts: cache.Opts{
@@ -140,7 +134,6 @@ func TestParseConfig(t *testing.T) {
 			[]string{"foo", "--remote-only"},
 			&Opts{
 				runOpts: runOpts{
-					bail:        true,
 					concurrency: 10,
 				},
 				cacheOpts: cache.Opts{
@@ -157,7 +150,6 @@ func TestParseConfig(t *testing.T) {
 			[]string{"foo", "--no-cache"},
 			&Opts{
 				runOpts: runOpts{
-					bail:        true,
 					concurrency: 10,
 				},
 				cacheOpts: cache.Opts{
@@ -175,7 +167,6 @@ func TestParseConfig(t *testing.T) {
 			[]string{"foo", "--graph=g.png", "--"},
 			&Opts{
 				runOpts: runOpts{
-					bail:            true,
 					concurrency:     10,
 					dotGraph:        "g.png",
 					passThroughArgs: []string{},
@@ -193,7 +184,6 @@ func TestParseConfig(t *testing.T) {
 			[]string{"foo", "--filter=bar", "--filter=...[main]"},
 			&Opts{
 				runOpts: runOpts{
-					bail:        true,
 					concurrency: 10,
 				},
 				cacheOpts: cache.Opts{
@@ -204,6 +194,22 @@ func TestParseConfig(t *testing.T) {
 				scopeOpts: scope.Opts{
 					FilterPatterns: []string{"bar", "...[main]"},
 				},
+			},
+		},
+		{
+			"continue on errors",
+			[]string{"foo", "--continue"},
+			&Opts{
+				runOpts: runOpts{
+					continueOnError: true,
+					concurrency:     10,
+				},
+				cacheOpts: cache.Opts{
+					Dir:     defaultCacheFolder,
+					Workers: 10,
+				},
+				runcacheOpts: runcache.Opts{},
+				scopeOpts:    scope.Opts{},
 			},
 		},
 	}
@@ -242,7 +248,6 @@ func TestParseRunOptionsUsesCWDFlag(t *testing.T) {
 	cwd := defaultCwd.Join("zop")
 	expected := &Opts{
 		runOpts: runOpts{
-			bail:        true,
 			concurrency: 10,
 		},
 		cacheOpts: cache.Opts{

--- a/cli/internal/run/run_test.go
+++ b/cli/internal/run/run_test.go
@@ -38,7 +38,6 @@ func TestParseConfig(t *testing.T) {
 				dotGraph:    "",
 				concurrency: 10,
 				profile:     "",
-				cwd:         defaultCwd.ToStringDuringMigration(),
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,
 					Workers: 10,
@@ -55,7 +54,6 @@ func TestParseConfig(t *testing.T) {
 				dotGraph:    "",
 				concurrency: 10,
 				profile:     "",
-				cwd:         defaultCwd.ToStringDuringMigration(),
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,
 					Workers: 10,
@@ -76,7 +74,6 @@ func TestParseConfig(t *testing.T) {
 				dotGraph:    "",
 				concurrency: 12,
 				profile:     "",
-				cwd:         defaultCwd.ToStringDuringMigration(),
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,
 					Workers: 10,
@@ -93,7 +90,6 @@ func TestParseConfig(t *testing.T) {
 				dotGraph:    "g.png",
 				concurrency: 10,
 				profile:     "",
-				cwd:         defaultCwd.ToStringDuringMigration(),
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,
 					Workers: 10,
@@ -110,7 +106,6 @@ func TestParseConfig(t *testing.T) {
 				dotGraph:        "g.png",
 				concurrency:     10,
 				profile:         "",
-				cwd:             defaultCwd.ToStringDuringMigration(),
 				passThroughArgs: []string{"--boop", "zoop"},
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,
@@ -127,7 +122,6 @@ func TestParseConfig(t *testing.T) {
 				bail:        true,
 				concurrency: 10,
 				profile:     "",
-				cwd:         defaultCwd.ToStringDuringMigration(),
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,
 					Workers: 10,
@@ -145,7 +139,6 @@ func TestParseConfig(t *testing.T) {
 				bail:        true,
 				concurrency: 10,
 				profile:     "",
-				cwd:         defaultCwd.ToStringDuringMigration(),
 				cacheOpts: cache.Opts{
 					Dir:            defaultCacheFolder,
 					Workers:        10,
@@ -162,7 +155,6 @@ func TestParseConfig(t *testing.T) {
 				bail:        true,
 				concurrency: 10,
 				profile:     "",
-				cwd:         defaultCwd.ToStringDuringMigration(),
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,
 					Workers: 10,
@@ -181,7 +173,6 @@ func TestParseConfig(t *testing.T) {
 				dotGraph:        "g.png",
 				concurrency:     10,
 				profile:         "",
-				cwd:             defaultCwd.ToStringDuringMigration(),
 				passThroughArgs: []string{},
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,
@@ -197,7 +188,6 @@ func TestParseConfig(t *testing.T) {
 			&RunOptions{
 				bail:        true,
 				concurrency: 10,
-				cwd:         defaultCwd.ToStringDuringMigration(),
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,
 					Workers: 10,
@@ -247,7 +237,6 @@ func TestParseRunOptionsUsesCWDFlag(t *testing.T) {
 		dotGraph:    "",
 		concurrency: 10,
 		profile:     "",
-		cwd:         cwd.ToStringDuringMigration(),
 		cacheOpts: cache.Opts{
 			Dir:     cwd.Join("node_modules", ".cache", "turbo"),
 			Workers: 10,

--- a/cli/internal/run/run_test.go
+++ b/cli/internal/run/run_test.go
@@ -28,16 +28,16 @@ func TestParseConfig(t *testing.T) {
 	cases := []struct {
 		Name     string
 		Args     []string
-		Expected *RunOptions
+		Expected *Opts
 	}{
 		{
 			"string flags",
 			[]string{"foo"},
-			&RunOptions{
-				bail:        true,
-				dotGraph:    "",
-				concurrency: 10,
-				profile:     "",
+			&Opts{
+				runOpts: runOpts{
+					bail:        true,
+					concurrency: 10,
+				},
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,
 					Workers: 10,
@@ -49,11 +49,11 @@ func TestParseConfig(t *testing.T) {
 		{
 			"scope",
 			[]string{"foo", "--scope=foo", "--scope=blah"},
-			&RunOptions{
-				bail:        true,
-				dotGraph:    "",
-				concurrency: 10,
-				profile:     "",
+			&Opts{
+				runOpts: runOpts{
+					bail:        true,
+					concurrency: 10,
+				},
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,
 					Workers: 10,
@@ -69,11 +69,11 @@ func TestParseConfig(t *testing.T) {
 		{
 			"concurrency",
 			[]string{"foo", "--concurrency=12"},
-			&RunOptions{
-				bail:        true,
-				dotGraph:    "",
-				concurrency: 12,
-				profile:     "",
+			&Opts{
+				runOpts: runOpts{
+					bail:        true,
+					concurrency: 12,
+				},
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,
 					Workers: 10,
@@ -85,11 +85,12 @@ func TestParseConfig(t *testing.T) {
 		{
 			"graph",
 			[]string{"foo", "--graph=g.png"},
-			&RunOptions{
-				bail:        true,
-				dotGraph:    "g.png",
-				concurrency: 10,
-				profile:     "",
+			&Opts{
+				runOpts: runOpts{
+					bail:        true,
+					concurrency: 10,
+					dotGraph:    "g.png",
+				},
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,
 					Workers: 10,
@@ -101,12 +102,13 @@ func TestParseConfig(t *testing.T) {
 		{
 			"passThroughArgs",
 			[]string{"foo", "--graph=g.png", "--", "--boop", "zoop"},
-			&RunOptions{
-				bail:            true,
-				dotGraph:        "g.png",
-				concurrency:     10,
-				profile:         "",
-				passThroughArgs: []string{"--boop", "zoop"},
+			&Opts{
+				runOpts: runOpts{
+					bail:            true,
+					concurrency:     10,
+					dotGraph:        "g.png",
+					passThroughArgs: []string{"--boop", "zoop"},
+				},
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,
 					Workers: 10,
@@ -118,10 +120,11 @@ func TestParseConfig(t *testing.T) {
 		{
 			"force",
 			[]string{"foo", "--force"},
-			&RunOptions{
-				bail:        true,
-				concurrency: 10,
-				profile:     "",
+			&Opts{
+				runOpts: runOpts{
+					bail:        true,
+					concurrency: 10,
+				},
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,
 					Workers: 10,
@@ -135,10 +138,11 @@ func TestParseConfig(t *testing.T) {
 		{
 			"remote-only",
 			[]string{"foo", "--remote-only"},
-			&RunOptions{
-				bail:        true,
-				concurrency: 10,
-				profile:     "",
+			&Opts{
+				runOpts: runOpts{
+					bail:        true,
+					concurrency: 10,
+				},
 				cacheOpts: cache.Opts{
 					Dir:            defaultCacheFolder,
 					Workers:        10,
@@ -151,10 +155,11 @@ func TestParseConfig(t *testing.T) {
 		{
 			"no-cache",
 			[]string{"foo", "--no-cache"},
-			&RunOptions{
-				bail:        true,
-				concurrency: 10,
-				profile:     "",
+			&Opts{
+				runOpts: runOpts{
+					bail:        true,
+					concurrency: 10,
+				},
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,
 					Workers: 10,
@@ -168,12 +173,13 @@ func TestParseConfig(t *testing.T) {
 		{
 			"Empty passThroughArgs",
 			[]string{"foo", "--graph=g.png", "--"},
-			&RunOptions{
-				bail:            true,
-				dotGraph:        "g.png",
-				concurrency:     10,
-				profile:         "",
-				passThroughArgs: []string{},
+			&Opts{
+				runOpts: runOpts{
+					bail:            true,
+					concurrency:     10,
+					dotGraph:        "g.png",
+					passThroughArgs: []string{},
+				},
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,
 					Workers: 10,
@@ -185,9 +191,11 @@ func TestParseConfig(t *testing.T) {
 		{
 			"can specify filter patterns",
 			[]string{"foo", "--filter=bar", "--filter=...[main]"},
-			&RunOptions{
-				bail:        true,
-				concurrency: 10,
+			&Opts{
+				runOpts: runOpts{
+					bail:        true,
+					concurrency: 10,
+				},
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,
 					Workers: 10,
@@ -232,11 +240,11 @@ func TestParseRunOptionsUsesCWDFlag(t *testing.T) {
 		t.Errorf("failed to get cwd: %v", err)
 	}
 	cwd := defaultCwd.Join("zop")
-	expected := &RunOptions{
-		bail:        true,
-		dotGraph:    "",
-		concurrency: 10,
-		profile:     "",
+	expected := &Opts{
+		runOpts: runOpts{
+			bail:        true,
+			concurrency: 10,
+		},
 		cacheOpts: cache.Opts{
 			Dir:     cwd.Join("node_modules", ".cache", "turbo"),
 			Workers: 10,
@@ -377,7 +385,7 @@ func Test_dontSquashTasks(t *testing.T) {
 	rs := &runSpec{
 		FilteredPkgs: filteredPkgs,
 		Targets:      []string{"build"},
-		Opts:         &RunOptions{},
+		Opts:         &Opts{},
 	}
 	engine, err := buildTaskGraph(topoGraph, pipeline, rs)
 	if err != nil {
@@ -410,7 +418,7 @@ func Test_taskSelfRef(t *testing.T) {
 	rs := &runSpec{
 		FilteredPkgs: filteredPkgs,
 		Targets:      []string{"build"},
-		Opts:         &RunOptions{},
+		Opts:         &Opts{},
 	}
 	_, err := buildTaskGraph(topoGraph, pipeline, rs)
 	if err == nil {

--- a/cli/internal/scope/scope.go
+++ b/cli/internal/scope/scope.go
@@ -105,16 +105,16 @@ func ResolvePackages(opts *Opts, cwd string, scm scm.SCM, ctx *context.Context, 
 }
 
 func (o *Opts) getPackageChangeFunc(scm scm.SCM, cwd string, packageInfos map[interface{}]*fs.PackageJSON) scope_filter.PackagesChangedSince {
-	// Note that "since" here is *not* o.Since. Each filter expression can have its own value for
+	// Note that "since" here is *not* o.LegacyFilter.Since. Each filter expression can have its own value for
 	// "since", apart from the value specified via --since.
-	return func(since string) (util.Set, error) {
+	return func(filterSince string) (util.Set, error) {
 		// We could filter changed files at the git level, since it's possible
 		// that the changes we're interested in are scoped, but we need to handle
 		// global dependencies changing as well. A future optimization might be to
 		// scope changed files more deeply if we know there are no global dependencies.
 		var changedFiles []string
-		if since != "" {
-			scmChangedFiles, err := scm.ChangedFiles(since, true, cwd)
+		if filterSince != "" {
+			scmChangedFiles, err := scm.ChangedFiles(filterSince, true, cwd)
 			if err != nil {
 				return nil, err
 			}

--- a/cli/internal/scope/scope.go
+++ b/cli/internal/scope/scope.go
@@ -18,8 +18,8 @@ import (
 type Opts struct {
 	// IncludeDependencies is whether to include pkg.dependencies in execution (defaults to false)
 	IncludeDependencies bool
-	// IncludeDependents is whether to include dependent impacted consumers in execution (defaults to true)
-	IncludeDependents bool
+	// SkipDependents is whether to skip dependent impacted consumers in execution (defaults to false)
+	SkipDependents bool
 	// Entrypoints is a list of package entrypoints
 	Entrypoints []string
 	// Since is the git ref used to calculate changed packages
@@ -37,7 +37,7 @@ func (o *Opts) asFilterPatterns() []string {
 	patterns := make([]string, len(o.FilterPatterns))
 	copy(patterns, o.FilterPatterns)
 	prefix := ""
-	if o.IncludeDependents {
+	if !o.SkipDependents {
 		prefix = "..."
 	}
 	suffix := ""

--- a/cli/internal/scope/scope_test.go
+++ b/cli/internal/scope/scope_test.go
@@ -208,7 +208,7 @@ func TestResolvePackages(t *testing.T) {
 				IgnorePatterns:      []string{tc.ignore},
 				GlobalDepPatterns:   tc.globalDeps,
 				IncludeDependencies: tc.includeDependencies,
-				IncludeDependents:   tc.includeDependents,
+				SkipDependents:      !tc.includeDependents,
 			}, "dummy-repo-root", scm, &context.Context{
 				PackageInfos:     packagesInfos,
 				PackageNames:     packageNames,

--- a/cli/internal/scope/scope_test.go
+++ b/cli/internal/scope/scope_test.go
@@ -203,12 +203,14 @@ func TestResolvePackages(t *testing.T) {
 				changed: tc.changed,
 			}
 			pkgs, isAllPackages, err := ResolvePackages(&Opts{
-				Entrypoints:         tc.scope,
-				Since:               tc.since,
-				IgnorePatterns:      []string{tc.ignore},
-				GlobalDepPatterns:   tc.globalDeps,
-				IncludeDependencies: tc.includeDependencies,
-				SkipDependents:      !tc.includeDependents,
+				LegacyFilter: LegacyFilter{
+					Entrypoints:         tc.scope,
+					Since:               tc.since,
+					IncludeDependencies: tc.includeDependencies,
+					SkipDependents:      !tc.includeDependents,
+				},
+				IgnorePatterns:    []string{tc.ignore},
+				GlobalDepPatterns: tc.globalDeps,
 			}, "dummy-repo-root", scm, &context.Context{
 				PackageInfos:     packagesInfos,
 				PackageNames:     packageNames,

--- a/cli/internal/scope/scope_test.go
+++ b/cli/internal/scope/scope_test.go
@@ -2,6 +2,7 @@ package scope
 
 import (
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -211,7 +212,7 @@ func TestResolvePackages(t *testing.T) {
 				},
 				IgnorePatterns:    []string{tc.ignore},
 				GlobalDepPatterns: tc.globalDeps,
-			}, "dummy-repo-root", scm, &context.Context{
+			}, filepath.FromSlash("/dummy/repo/root"), scm, &context.Context{
 				PackageInfos:     packagesInfos,
 				PackageNames:     packageNames,
 				TopologicalGraph: graph,

--- a/cli/internal/scope/scope_test.go
+++ b/cli/internal/scope/scope_test.go
@@ -3,7 +3,6 @@ package scope
 import (
 	"fmt"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
@@ -18,14 +17,8 @@ type mockSCM struct {
 	changed []string
 }
 
-func (m *mockSCM) ChangedFiles(fromCommit string, includeUntracked bool, relativeTo string) ([]string, error) {
-	changed := []string{}
-	for _, change := range m.changed {
-		if strings.HasPrefix(change, relativeTo) {
-			changed = append(changed, change)
-		}
-	}
-	return changed, nil
+func (m *mockSCM) ChangedFiles(_fromCommit string, _includeUntracked bool, _relativeTo string) ([]string, error) {
+	return m.changed, nil
 }
 
 func TestResolvePackages(t *testing.T) {
@@ -210,13 +203,13 @@ func TestResolvePackages(t *testing.T) {
 				changed: tc.changed,
 			}
 			pkgs, isAllPackages, err := ResolvePackages(&Opts{
-				Patterns:            tc.scope,
+				Entrypoints:         tc.scope,
 				Since:               tc.since,
 				IgnorePatterns:      []string{tc.ignore},
 				GlobalDepPatterns:   tc.globalDeps,
 				IncludeDependencies: tc.includeDependencies,
 				IncludeDependents:   tc.includeDependents,
-			}, scm, &context.Context{
+			}, "dummy-repo-root", scm, &context.Context{
 				PackageInfos:     packagesInfos,
 				PackageNames:     packageNames,
 				TopologicalGraph: graph,


### PR DESCRIPTION
Cleans up our `RunOptions` in advance of porting over to `cobra`. Attempts to have the zero value be the default in as many cases as possible, which means that some booleans needed to be flipped to be expressed internally as default: false. The external-facing arguments are unchanged.

Going commit-by-commit is probably the best way to go through this one.

There's definitely some refactoring still to be done around `run` and `runOpts`, but this felt like a big enough change to stand on its own.