### PR TITLE
Route around pnpm action

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -27,9 +27,19 @@ jobs:
           go-version: 1.18.0
         id: go
 
-      - uses: pnpm/action-setup@v2.2.1
+      # Can re-enable when https://github.com/pnpm/action-setup/issues/44 is fixed
+      # - uses: pnpm/action-setup@v2.2.1
+      #   with:
+      #     version: 6.32.11
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
         with:
-          version: 6.32.11
+          node-version: 16
+          # cache: pnpm
+
+      - name: Install pnpm
+        run: npm install -g pnpm@6.32.11
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
@@ -131,15 +141,18 @@ jobs:
           go-version: 1.18.0
         id: go
 
-      - uses: pnpm/action-setup@v2.1.0
-        with:
-          version: 6.32.11
+      # - uses: pnpm/action-setup@v2.1.0
+      #   with:
+      #     version: 6.32.11
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          cache: pnpm
+          # cache: pnpm
+
+      - name: Install pnpm
+        run: npm install -g pnpm@6.32.11
 
       - name: Check ${{matrix.example}} example with ${{ matrix.manager }}
         shell: bash

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -36,12 +36,11 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          # cache: pnpm
 
       - name: Install pnpm
         run: npm install -g pnpm@6.32.11
 
-      - name: Setup Node.js environment
+      - name: Setup Node.js environment, now with pnpm
         uses: actions/setup-node@v3
         with:
           node-version: 16
@@ -141,7 +140,7 @@ jobs:
           go-version: 1.18.0
         id: go
 
-      # - uses: pnpm/action-setup@v2.1.0
+      # - uses: pnpm/action-setup@v2.2.1
       #   with:
       #     version: 6.32.11
 
@@ -149,10 +148,15 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          # cache: pnpm
 
       - name: Install pnpm
         run: npm install -g pnpm@6.32.11
+
+      - name: Setup Node.js environment, now with pnpm
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: pnpm
 
       - name: Check ${{matrix.example}} example with ${{ matrix.manager }}
         shell: bash

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -27,7 +27,7 @@ jobs:
           go-version: 1.18.0
         id: go
 
-      - uses: pnpm/action-setup@v2.1.0
+      - uses: pnpm/action-setup@v2.2.1
         with:
           version: 6.32.11
 


### PR DESCRIPTION
We can revert back to `pnpm/action-setup` when https://github.com/pnpm/action-setup/issues/44 is fixed.