### PR TITLE
Fix eslint config pkg name

### DIFF
--- a/examples/design-system/apps/docs/package.json
+++ b/examples/design-system/apps/docs/package.json
@@ -22,7 +22,7 @@
     "@storybook/builder-vite": "^0.1.33",
     "@storybook/react": "^6.4.18",
     "@vitejs/plugin-react": "^1.3.2",
-    "eslint-preset-acme": "*",
+    "eslint-config-acme": "*",
     "serve": "^13.0.2",
     "typescript": "^4.5.4",
     "vite": "^2.9.9"


### PR DESCRIPTION
Otherwise the build starts failing if you change the scope from `acme` as instructed in the README.