### PR TITLE
Update workspaces docs link to npm 8

### DIFF
--- a/docs/pages/docs/guides/workspaces.mdx
+++ b/docs/pages/docs/guides/workspaces.mdx
@@ -14,7 +14,7 @@ Turborepo makes use of workspaces to organize your apps and packages. But how do
 Workspaces are a feature implemented by package managers to assist with working on multiple apps and packages in the same codebase.
 Turborepo is compatible with 3 different package managers. Each with its own implementation of workspaces, links to their respective documentation are listed below. Please note that there are slight nuances between implementations and functionality.
 
-- [npm workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces)
+- [npm workspaces](https://docs.npmjs.com/cli/v8/using-npm/workspaces)
 - [yarn workspaces](https://classic.yarnpkg.com/lang/en/docs/workspaces/)
 - [pnpm workspaces](https://pnpm.io/workspaces)
 


### PR DESCRIPTION
npm 8 is the current releas, npm 7 is no longer receiving updates

This was already updated on [/docs/core-concepts/workspaces](https://github.com/vercel/turborepo/blob/main/docs/pages/docs/core-concepts/workspaces.mdx) so this PR updates [/docs/guides/workspaces](https://github.com/vercel/turborepo/blob/main/docs/pages/docs/guides/workspaces.mdx)