### PR TITLE
Include os and architecture in global hash

### DIFF
--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -461,12 +462,16 @@ func calculateGlobalHash(rootpath string, rootPackageJSON *fs.PackageJSON, pipel
 		hashedSortedEnvPairs []string
 		globalCacheKey       string
 		pipeline             fs.Pipeline
+		os                   string
+		arch                 string
 	}{
 		globalFileHashMap:    globalFileHashMap,
 		rootExternalDepsHash: rootPackageJSON.ExternalDepsHash,
 		hashedSortedEnvPairs: globalHashableEnvPairs,
 		globalCacheKey:       GLOBAL_CACHE_KEY,
 		pipeline:             pipeline,
+		os:                   runtime.GOOS,
+		arch:                 runtime.GOARCH,
 	}
 	globalHash, err := fs.HashObject(globalHashable)
 	if err != nil {


### PR DESCRIPTION
Behavior can vary based on OS and architecture, so we need to include those in the global hash.