### PR TITLE
fix(yarn): include prerelease versions in constraints

### DIFF
--- a/cli/internal/packagemanager/berry.go
+++ b/cli/internal/packagemanager/berry.go
@@ -49,7 +49,8 @@ var nodejsBerry = PackageManager{
 		if err != nil {
 			return false, fmt.Errorf("could not parse yarn version: %w", err)
 		}
-		c, err := semver.NewConstraint(">=2.0.0")
+		// -0 allows pre-releases versions to be considered valid
+		c, err := semver.NewConstraint(">=2.0.0-0")
 		if err != nil {
 			return false, fmt.Errorf("could not create constraint: %w", err)
 		}

--- a/cli/internal/packagemanager/yarn.go
+++ b/cli/internal/packagemanager/yarn.go
@@ -61,7 +61,7 @@ var nodejsYarn = PackageManager{
 		if err != nil {
 			return false, fmt.Errorf("could not parse yarn version: %w", err)
 		}
-		c, err := semver.NewConstraint("<2.0.0")
+		c, err := semver.NewConstraint("<2.0.0-0")
 		if err != nil {
 			return false, fmt.Errorf("could not create constraint: %w", err)
 		}


### PR DESCRIPTION
Fixes https://github.com/vercel/turborepo/issues/1311

See note https://github.com/Masterminds/semver#checking-version-constraints:

> If you want to have it include pre-releases a simple solution is to include -0 in your range.

Tested with both prerelease, and major releases. 