### PR TITLE
Create noopCache to ensure that users always have a valid cache object.

### DIFF
--- a/cli/internal/cache/cache.go
+++ b/cli/internal/cache/cache.go
@@ -65,39 +65,75 @@ type Opts struct {
 // New creates a new cache
 func New(opts Opts, config *config.Config, recorder analytics.Recorder, onCacheRemoved OnCacheRemoved) (Cache, error) {
 	c, err := newSyncCache(opts, config, recorder, onCacheRemoved)
-	if err != nil {
+	if err != nil && !errors.Is(err, ErrNoCachesEnabled) {
 		return nil, err
 	}
 	if opts.Workers > 0 {
-		return newAsyncCache(c, opts), nil
+		return newAsyncCache(c, opts), err
 	}
-	return c, nil
+	return c, err
 }
 
+// newSyncCache can return an error with a usable noopCache.
 func newSyncCache(opts Opts, config *config.Config, recorder analytics.Recorder, onCacheRemoved OnCacheRemoved) (Cache, error) {
-	mplex := &cacheMultiplexer{
-		onCacheRemoved: onCacheRemoved,
-		opts:           opts,
-	}
-	// if config.Cache.Dir != "" && !remoteOnly {
-	if !opts.SkipFilesystem {
-		fsCache, err := newFsCache(opts, recorder)
+	// Check to see if the user has turned off particular cache implementations.
+	useFsCache := !opts.SkipFilesystem
+	useHTTPCache := !opts.SkipRemote
+
+	// Since the above two flags are not mutually exclusive it is possible to configure
+	// yourself out of having a cache. We should tell you about it but we shouldn't fail
+	// your build for that reason.
+	//
+	// Further, since the httpCache can be removed at runtime, we need to insert a noopCache
+	// as a backup if you are configured to have *just* an httpCache.
+	//
+	// This is reduced from (!useFsCache && !useHTTPCache) || (!useFsCache & useHTTPCache)
+	useNoopCache := !useFsCache
+
+	// Build up an array of cache implementations, we can only ever have 1 or 2.
+	cacheImplementations := make([]Cache, 0, 2)
+
+	if useFsCache {
+		implementation, err := newFsCache(opts, recorder)
 		if err != nil {
 			return nil, err
 		}
-		mplex.caches = append(mplex.caches, fsCache)
+		cacheImplementations = append(cacheImplementations, implementation)
 	}
-	//if config.IsLoggedIn() {
-	if !opts.SkipRemote {
+
+	if useHTTPCache {
 		fmt.Println(ui.Dim("• Remote computation caching enabled (experimental)"))
-		mplex.caches = append(mplex.caches, newHTTPCache(opts, config, recorder))
+		implementation := newHTTPCache(opts, config, recorder)
+		cacheImplementations = append(cacheImplementations, implementation)
 	}
-	if len(mplex.caches) == 0 {
-		return nil, ErrNoCachesEnabled
-	} else if len(mplex.caches) == 1 {
-		return mplex.caches[0], nil // Skip the extra layer of indirection
+
+	if useNoopCache {
+		implementation := newNoopCache()
+		cacheImplementations = append(cacheImplementations, implementation)
 	}
-	return mplex, nil
+
+	// Precisely two cache implementations:
+	// fsCache and httpCache OR httpCache and noopCache
+	useMultiplexer := len(cacheImplementations) > 1
+	if useMultiplexer {
+		// We have early-returned any possible errors for this scenario.
+		return &cacheMultiplexer{
+			onCacheRemoved: onCacheRemoved,
+			opts:           opts,
+			caches:         cacheImplementations,
+		}, nil
+	}
+
+	// Precisely one cache implementation: fsCache OR noopCache
+	implementation := cacheImplementations[0]
+	_, isNoopCache := implementation.(*noopCache)
+
+	// We want to let the user know something is wonky, but we don't want
+	// to trigger their build to fail.
+	if isNoopCache {
+		return implementation, ErrNoCachesEnabled
+	}
+	return implementation, nil
 }
 
 // A cacheMultiplexer multiplexes several caches into one.

--- a/cli/internal/cache/cache_fs.go
+++ b/cli/internal/cache/cache_fs.go
@@ -23,7 +23,7 @@ type fsCache struct {
 }
 
 // newFsCache creates a new filesystem cache
-func newFsCache(opts Opts, recorder analytics.Recorder) (Cache, error) {
+func newFsCache(opts Opts, recorder analytics.Recorder) (*fsCache, error) {
 	if err := opts.Dir.MkdirAll(); err != nil {
 		return nil, err
 	}

--- a/cli/internal/cache/cache_noop.go
+++ b/cli/internal/cache/cache_noop.go
@@ -1,0 +1,17 @@
+package cache
+
+type noopCache struct{}
+
+func newNoopCache() *noopCache {
+	return &noopCache{}
+}
+
+func (c *noopCache) Put(target string, key string, duration int, files []string) error {
+	return nil
+}
+func (c *noopCache) Fetch(target string, key string, files []string) (bool, []string, int, error) {
+	return false, nil, 0, nil
+}
+func (c *noopCache) Clean(target string) {}
+func (c *noopCache) CleanAll()           {}
+func (c *noopCache) Shutdown()           {}

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -612,11 +612,11 @@ func (c *RunCommand) executeTasks(g *completeGraph, rs *runSpec, engine *core.Sc
 	})
 	if err != nil {
 		if errors.Is(err, cache.ErrNoCachesEnabled) {
-			c.logError(c.Config.Logger, "No caches are enabled. You can try \"turbo login\", \"turbo link\", or ensuring you are not passing --remote-only to enable caching", nil)
+			c.logWarning(c.Config.Logger, "No caches are enabled. You can try \"turbo login\", \"turbo link\", or ensuring you are not passing --remote-only to enable caching", nil)
 		} else {
 			c.logError(c.Config.Logger, "Failed to set up caching", err)
+			return 1
 		}
-		return 1
 	}
 	defer turboCache.Shutdown()
 	runState := NewRunState(startAt, rs.Opts.runOpts.profile)


### PR DESCRIPTION
This makes it possible for a repository whose CI configuration is `--remote-only` to work when receiving pull-requests from forked repositories that do not have access to secrets configuration in CI.

Example failures:
- https://github.com/vercel/turborepo/pull/1302: [Error](https://github.com/vercel/turborepo/runs/6681959655?check_suite_focus=true#step:8:56)
- https://github.com/vercel/vercel/pull/7575: [Error](https://github.com/vercel/vercel/runs/6599439965?check_suite_focus=true#step:10:12)

One example workaround:
https://github.com/vercel/vercel/pull/7873

However, since this does not prevent the build from running to completion, I do not believe that it should be a hard error. While in the process of addressing this I also discovered that, since the `httpCache` can remove itself, there is an alternative path to triggering a panic if the `httpCache` is the only cache you have enabled and it removes itself.

Using a `noopCache` as a cache of last resort (similar to the [upstream solution](https://github.com/thought-machine/please/commit/e0b5e2900f5caab98a20d476d34bce66da28cdb8)) resolves both of these issues.

Related to: #1169