### PR TITLE
Follow up to porting run to cobra

### DIFF
--- a/cli/internal/fs/path_test.go
+++ b/cli/internal/fs/path_test.go
@@ -1,0 +1,57 @@
+package fs
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"gotest.tools/v3/assert"
+)
+
+// absolute unix paths parse differently based on whether or not we're on windows.
+// Windows will treat them as relative paths, to be made relative to cwd.
+// Unix-like OSes will treat them as absolute and can be returned directly.
+func platformSpecificAbsoluteUnixPathExpectation(cwd AbsolutePath, absoluteUnixPath string) AbsolutePath {
+	if runtime.GOOS == "windows" {
+		return cwd.Join(absoluteUnixPath)
+	}
+	return UnsafeToAbsolutePath(absoluteUnixPath)
+}
+
+func TestAbsPathVar(t *testing.T) {
+	cwd, err := GetCwd()
+	assert.NilError(t, err, "GetCwd")
+	flags := pflag.NewFlagSet("foo", pflag.ContinueOnError)
+	var target AbsolutePath
+	AbsolutePathVar(flags, &target, "foo", cwd, "some usage info", "")
+
+	for _, test := range []struct {
+		input    string
+		expected AbsolutePath
+	}{
+		{
+			"bar",
+			cwd.Join("bar"),
+		},
+		{
+			filepath.Join("bar", "baz"),
+			cwd.Join("bar", "baz"),
+		},
+		{
+			// explicitly use a unix-like separator, but on a relative path
+			"bar/baz",
+			cwd.Join("bar", "baz"),
+		},
+		{
+			"/bar/baz",
+			platformSpecificAbsoluteUnixPathExpectation(cwd, "/bar/baz"),
+		},
+	} {
+		err = flags.Parse([]string{"--foo", test.input})
+		assert.NilError(t, err, "Parse")
+		if target != test.expected {
+			t.Errorf("path got %v, want %v", target, test.expected)
+		}
+	}
+}

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -460,6 +460,11 @@ var _persistentFlags = []string{
 }
 
 func noopPersistentOptsDuringMigration(flags *pflag.FlagSet) {
+	_ = flags.CountP("verbosity", "v", "verbosity")
+	if err := flags.MarkHidden("verbosity"); err != nil {
+		// fail fast if we've misconfigured our flags
+		panic(err)
+	}
 	for _, flag := range _persistentFlags {
 		_ = flags.String(flag, "", "")
 		if err := flags.MarkHidden(flag); err != nil {

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -441,7 +441,7 @@ func addRunOpts(opts *runOpts, flags *pflag.FlagSet, aliases map[string]string) 
 		Name:        "dry-run",
 		Usage:       _dryRunHelp,
 		DefValue:    "",
-		NoOptDefVal: "text|json",
+		NoOptDefVal: _dryRunNoValue,
 		Value:       &dryRunValue{opts: opts},
 	})
 }
@@ -469,6 +469,16 @@ func noopPersistentOptsDuringMigration(flags *pflag.FlagSet) {
 	}
 }
 
+const (
+	_dryRunText      = "dry run"
+	_dryRunJSONText  = "json"
+	_dryRunJSONValue = "json"
+	_dryRunNoValue   = "text|json"
+	_dryRunTextValue = "text"
+)
+
+// dryRunValue implements a flag that can be treated as a boolean (--dry-run)
+// or a string (--dry-run=json).
 type dryRunValue struct {
 	opts *runOpts
 }
@@ -477,18 +487,23 @@ var _ pflag.Value = &dryRunValue{}
 
 func (d *dryRunValue) String() string {
 	if d.opts.dryRunJSON {
-		return "json"
+		return _dryRunJSONText
 	} else if d.opts.dryRun {
-		return "dry run"
+		return _dryRunText
 	}
 	return ""
 }
 
 func (d *dryRunValue) Set(value string) error {
-	if value == "json" {
+	if value == _dryRunJSONValue {
 		d.opts.dryRun = true
 		d.opts.dryRunJSON = true
-	} else if value == "text|json" {
+	} else if value == _dryRunNoValue {
+		// this case matches the NoOptDefValue, which is used when the flag
+		// is passed, but does not have a value (i.e. boolean flag)
+		d.opts.dryRun = true
+	} else if value == _dryRunTextValue {
+		// "text" is equivalent to just setting the boolean flag
 		d.opts.dryRun = true
 	} else {
 		return fmt.Errorf("invalid dry-run mode: %v", value)
@@ -496,6 +511,8 @@ func (d *dryRunValue) Set(value string) error {
 	return nil
 }
 
+// Type implements Value.Type, and in this case is used to
+// show the alias in the usage test.
 func (d *dryRunValue) Type() string {
 	return "/ dry "
 }

--- a/cli/internal/run/run_test.go
+++ b/cli/internal/run/run_test.go
@@ -317,7 +317,6 @@ func TestParseRunOptionsUsesCWDFlag(t *testing.T) {
 		// the `--cwd=` is parsed when setting up the global Config. This value is
 		// passed directly as an argument to the parser.
 		// We still need to ensure run accepts cwd flag and doesn't error.
-		//actual, err := parseRunArgs([]string{"foo", "--cwd=zop"}, cf, ui)
 		if err != nil {
 			t.Fatalf("invalid parse: %#v", err)
 		}

--- a/cli/internal/runcache/runcache.go
+++ b/cli/internal/runcache/runcache.go
@@ -33,6 +33,13 @@ const (
 	NoLogs
 )
 
+const (
+	logsModeFull     = "full"
+	logsModeHashOnly = "hash-only"
+	logsModeNewOnly  = "new-only"
+	logsModeNone     = "none"
+)
+
 // Opts holds the configurable options for a RunCache instance
 type Opts struct {
 	SkipReads         bool
@@ -71,13 +78,13 @@ type logsModeValue struct {
 
 func (l *logsModeValue) String() string {
 	if l.opts.CacheHitLogsMode == FullLogs && l.opts.CacheMissLogsMode == FullLogs {
-		return "full"
+		return logsModeFull
 	} else if l.opts.CacheHitLogsMode == NoLogs && l.opts.CacheMissLogsMode == NoLogs {
-		return "none"
+		return logsModeNone
 	} else if l.opts.CacheHitLogsMode == HashLogs && l.opts.CacheMissLogsMode == HashLogs {
-		return "hash-only"
+		return logsModeHashOnly
 	} else if l.opts.CacheHitLogsMode == HashLogs && l.opts.CacheMissLogsMode == FullLogs {
-		return "new-only"
+		return logsModeNewOnly
 	} else {
 		panic(fmt.Sprintf("Invalid output logs mode. Hit %v, miss %v", l.opts.CacheHitLogsMode, l.opts.CacheMissLogsMode))
 	}
@@ -85,16 +92,16 @@ func (l *logsModeValue) String() string {
 
 func (l *logsModeValue) Set(value string) error {
 	switch value {
-	case "full":
+	case logsModeFull:
 		l.opts.CacheMissLogsMode = FullLogs
 		l.opts.CacheHitLogsMode = FullLogs
-	case "none":
+	case logsModeNone:
 		l.opts.CacheMissLogsMode = NoLogs
 		l.opts.CacheHitLogsMode = NoLogs
-	case "hash-only":
+	case logsModeHashOnly:
 		l.opts.CacheMissLogsMode = HashLogs
 		l.opts.CacheHitLogsMode = HashLogs
-	case "new-only":
+	case logsModeNewOnly:
 		l.opts.CacheMissLogsMode = FullLogs
 		l.opts.CacheHitLogsMode = HashLogs
 	default:


### PR DESCRIPTION
Addressing some of @nathanhammond's review comments from #1298 

I added a test for `AbsolutePathVar` so that we can have a way to discuss the intended behavior. 