### PR TITLE
Add missing command to package.json scripts

### DIFF
--- a/docs/pages/docs/getting-started.mdx
+++ b/docs/pages/docs/getting-started.mdx
@@ -206,10 +206,10 @@ Add or update `scripts` in your monorepo's root `package.json` file and have the
 ```jsonc filename="./package.json"
 {
   "scripts": {
-    "build": "turbo build",
-    "test": "turbo test",
-    "lint": "turbo lint",
-    "dev": "turbo dev"
+    "build": "turbo run build",
+    "test": "turbo run test",
+    "lint": "turbo run lint",
+    "dev": "turbo run dev"
   }
 }
 ```


### PR DESCRIPTION
The Getting Started guide contains broken commands. Without `run` the commands listed there fail to execute.