### PR TITLE
fix(docs): update circleci remote cache docs

### DIFF
--- a/docs/pages/docs/ci/circleci.mdx
+++ b/docs/pages/docs/ci/circleci.mdx
@@ -139,6 +139,10 @@ Copy the value to a safe place. You'll need it in a moment.
 ![CircleCI Environment Variables](/images/docs/circleci-environment-variables.png)
 ![CircleCI Create Environment Variables](/images/docs/circleci-create-environment-variables.png)
 
-3. Make a second secret called `TURBO_TEAM` and enter the value of your team's Vercel URL (or if you're on Hobby, your personal URL works as well). Do not include the `https://vercel.com/` part, only the slug.
+3. Make a second secret called `TURBO_TEAM` and enter the value of your team's Vercel URL _without_ the `vercel.com/`. Your Team URL can be found inside your team's general project settings from the dashboard.
+
+   If you're on a Hobby, you can use your username. Your username can be found in your [Vercel Personal Account Settings](https://vercel.com/account)
 
 ![Vercel Account Slug](/images/docs/vercel-slug.png)
+
+4. CircleCI automatically loads environment variables stored in project settings into the CI environment. No modifications are necessary for the CI file.

--- a/docs/pages/docs/ci/circleci.mdx
+++ b/docs/pages/docs/ci/circleci.mdx
@@ -141,7 +141,7 @@ Copy the value to a safe place. You'll need it in a moment.
 
 3. Make a second secret called `TURBO_TEAM` and enter the value of your team's Vercel URL _without_ the `vercel.com/`. Your Team URL can be found inside your team's general project settings from the dashboard.
 
-   If you're on a Hobby, you can use your username. Your username can be found in your [Vercel Personal Account Settings](https://vercel.com/account)
+   If you're using a Hobby Plan, you can use your username. Your username can be found in your [Vercel Personal Account Settings](https://vercel.com/account)
 
 ![Vercel Account Slug](/images/docs/vercel-slug.png)
 

--- a/docs/pages/docs/ci/circleci.mdx
+++ b/docs/pages/docs/ci/circleci.mdx
@@ -59,10 +59,6 @@ Create a file called `.circleci/config.yml` in your repository with the followin
       test:
         docker:
           - image: cimg/node:lts
-        # To use Remote Caching, uncomment the next lines and follow the steps below.
-        # environment:
-        #  TURBO_TOKEN: $TURBO_TOKEN
-        #  TURBO_TEAM: $TURBO_TEAM
         steps:
           - checkout
           - node/install-packages
@@ -85,10 +81,6 @@ Create a file called `.circleci/config.yml` in your repository with the followin
       test:
         docker:
           - image: cimg/node:lts
-        # To use Remote Caching, uncomment the next lines and follow the steps below.
-        # environment:
-        #  TURBO_TOKEN: $TURBO_TOKEN
-        #  TURBO_TEAM: $TURBO_TEAM
         steps:
           - checkout
           - node/install-packages:
@@ -112,10 +104,6 @@ Create a file called `.circleci/config.yml` in your repository with the followin
       test:
         docker:
           - image: cimg/node:lts
-        # To use Remote Caching, uncomment the next lines and follow the steps below.
-        # environment:
-        #  TURBO_TOKEN: $TURBO_TOKEN
-        #  TURBO_TEAM: $TURBO_TEAM
         steps:
           - checkout
           - node/install-packages:
@@ -131,7 +119,7 @@ Create a file called `.circleci/config.yml` in your repository with the followin
 
 ## Remote Caching
 
-To use Remote Caching with CircleCI, add the following environment variables to your CircleCI workflow
+To use Remote Caching with CircleCI, add the following environment variables to your CircleCI project
 to make them available to your `turbo` commands.
 
 - `TURBO_TOKEN` - The Bearer token to access the Remote Cache
@@ -154,18 +142,3 @@ Copy the value to a safe place. You'll need it in a moment.
 3. Make a second secret called `TURBO_TEAM` and enter the value of your team's Vercel URL (or if you're on Hobby, your personal URL works as well). Do not include the `https://vercel.com/` part, only the slug.
 
 ![Vercel Account Slug](/images/docs/vercel-slug.png)
-
-4. At the top of your CircleCI workflow, provide the following environment variables to jobs that use `turbo`:
-
-```yaml highlight="6-8"
-# ...
-jobs:
-  test:
-    docker:
-      - image: cimg/node:lts
-    environment:
-      TURBO_TOKEN: $TURBO_TOKEN
-      TURBO_TEAM: $TURBO_TEAM
-    steps:
-      # ...
-```

--- a/docs/pages/docs/ci/github-actions.mdx
+++ b/docs/pages/docs/ci/github-actions.mdx
@@ -213,7 +213,9 @@ Copy the value to a safe place. You'll need it in a moment.
 ![GitHub Secrets](/images/docs/github-actions-secrets.png)
 ![GitHub Secrets Create](/images/docs/github-actions-create-secret.png)
 
-3. Make a second secret called `TURBO_TEAM` and enter the value of your team's Vercel URL (or if you're on Hobby, your personal URL works as well). Do not include the `https://vercel.com/` part, only the slug.
+3. Make a second secret called `TURBO_TEAM` and enter the value of your team's Vercel URL _without_ the `vercel.com/`. Your Team URL can be found inside your team's general project settings from the dashboard.
+
+   If you're on a Hobby, you can use your username. Your username can be found in your [Vercel Personal Account Settings](https://vercel.com/account)
 
 ![Vercel Account Slug](/images/docs/vercel-slug.png)
 

--- a/docs/pages/docs/ci/github-actions.mdx
+++ b/docs/pages/docs/ci/github-actions.mdx
@@ -215,7 +215,7 @@ Copy the value to a safe place. You'll need it in a moment.
 
 3. Make a second secret called `TURBO_TEAM` and enter the value of your team's Vercel URL _without_ the `vercel.com/`. Your Team URL can be found inside your team's general project settings from the dashboard.
 
-   If you're on a Hobby, you can use your username. Your username can be found in your [Vercel Personal Account Settings](https://vercel.com/account)
+   If you're using a Hobby Plan, you can use your username. Your username can be found in your [Vercel Personal Account Settings](https://vercel.com/account)
 
 ![Vercel Account Slug](/images/docs/vercel-slug.png)
 

--- a/docs/pages/docs/ci/gitlabci.mdx
+++ b/docs/pages/docs/ci/gitlabci.mdx
@@ -134,6 +134,6 @@ Copy the value to a safe place. You'll need it in a moment.
 
 3. Make a second secret called `TURBO_TEAM` and enter the value of your team's Vercel URL _without_ the `vercel.com/`. Your Team URL can be found inside your team's general project settings from the dashboard.
 
-   If you're on a Hobby, you can use your username. Your username can be found in your [Vercel Personal Account Settings](https://vercel.com/account)
+   If you're using a Hobby Plan, you can use your username. Your username can be found in your [Vercel Personal Account Settings](https://vercel.com/account)
 
 ![Vercel Account Slug](/images/docs/vercel-slug.png)

--- a/docs/pages/docs/ci/gitlabci.mdx
+++ b/docs/pages/docs/ci/gitlabci.mdx
@@ -132,6 +132,8 @@ Copy the value to a safe place. You'll need it in a moment.
 ![GitLab CI Variables](/images/docs/gitlab-ci-variables.png)
 ![GitLab CI Create Variable](/images/docs/gitlab-ci-create-variable.png)
 
-3. Make a second secret called `TURBO_TEAM` and enter the value of your team's Vercel URL (or if you're on Hobby, your personal URL works as well). Do not include the `https://vercel.com/` part, only the slug.
+3. Make a second secret called `TURBO_TEAM` and enter the value of your team's Vercel URL _without_ the `vercel.com/`. Your Team URL can be found inside your team's general project settings from the dashboard.
+
+   If you're on a Hobby, you can use your username. Your username can be found in your [Vercel Personal Account Settings](https://vercel.com/account)
 
 ![Vercel Account Slug](/images/docs/vercel-slug.png)

--- a/docs/pages/docs/ci/travisci.mdx
+++ b/docs/pages/docs/ci/travisci.mdx
@@ -118,7 +118,7 @@ Copy the value to a safe place. You'll need it in a moment.
 
 3. Make a second secret called `TURBO_TEAM` and enter the value of your team's Vercel URL _without_ the `vercel.com/`. Your Team URL can be found inside your team's general project settings from the dashboard.
 
-   If you're on a Hobby, you can use your username. Your username can be found in your [Vercel Personal Account Settings](https://vercel.com/account)
+   If you're using a Hobby Plan, you can use your username. Your username can be found in your [Vercel Personal Account Settings](https://vercel.com/account)
 
 ![Vercel Account Slug](/images/docs/vercel-slug.png)
 

--- a/docs/pages/docs/ci/travisci.mdx
+++ b/docs/pages/docs/ci/travisci.mdx
@@ -116,7 +116,9 @@ Copy the value to a safe place. You'll need it in a moment.
 
 ![Travis CI Variables](/images/docs/travis-ci-environment-variables.png)
 
-3. Make a second secret called `TURBO_TEAM` and enter the value of your team's Vercel URL (or if you're on Hobby, your personal URL works as well). Do not include the `https://vercel.com/` part, only the slug.
+3. Make a second secret called `TURBO_TEAM` and enter the value of your team's Vercel URL _without_ the `vercel.com/`. Your Team URL can be found inside your team's general project settings from the dashboard.
+
+   If you're on a Hobby, you can use your username. Your username can be found in your [Vercel Personal Account Settings](https://vercel.com/account)
 
 ![Vercel Account Slug](/images/docs/vercel-slug.png)
 


### PR DESCRIPTION
Updates docs to reflect findings from https://github.com/vercel/turborepo/issues/1343

> This appears to be an issue with how CircleCI environment variables work. 
Because we're setting the environment variables [on the project](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project), you actually don't need to specify them in the workflow. Adding these in the workflow is overriding the variables set on the project [because they have a higher precedence](https://circleci.com/docs/2.0/env-vars/#order-of-precedence), so the environment variables literally end up being the strings $TURBO_TEAM and $TURBO_TOKEN, and your remote cache requests are failing to authenticate.