### PR TITLE
Add new option for flag 'output-logs'

### DIFF
--- a/cli/internal/logstreamer/logstreamer.go
+++ b/cli/internal/logstreamer/logstreamer.go
@@ -24,6 +24,7 @@ type Logstreamer struct {
 	colorReset string
 }
 
+// NewLogstreamer returns a new Logstreamer instance
 func NewLogstreamer(logger *log.Logger, record bool) *Logstreamer {
 	streamer := &Logstreamer{
 		Logger:     logger,

--- a/cli/internal/logstreamer/logstreamer_test.go
+++ b/cli/internal/logstreamer/logstreamer_test.go
@@ -12,6 +12,8 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLogstreamerOk(t *testing.T) {
@@ -103,7 +105,8 @@ func TestLogstreamerFlush(t *testing.T) {
 	defer logStreamerOut.Close()
 
 	logStreamerOut.Write([]byte(text))
-	logStreamerOut.flush()
+	err := logStreamerOut.flush()
+	assert.Nil(t, err, "there should be no error when logStreamerOut is flushed")
 	byteWriter.Flush()
 
 	s := strings.TrimSpace(buffer.String())

--- a/cli/internal/logstreamer/logstreamer_test.go
+++ b/cli/internal/logstreamer/logstreamer_test.go
@@ -19,11 +19,11 @@ func TestLogstreamerOk(t *testing.T) {
 	logger := log.New(os.Stdout, "--> ", log.Ldate|log.Ltime)
 
 	// Setup a streamer that we'll pipe cmd.Stdout to
-	logStreamerOut := NewLogstreamer(logger, "stdout", false)
+	logStreamerOut := NewLogstreamer(logger, false)
 	defer logStreamerOut.Close()
 	// Setup a streamer that we'll pipe cmd.Stderr to.
 	// We want to record/buffer anything that's written to this (3rd argument true)
-	logStreamerErr := NewLogstreamer(logger, "stderr", true)
+	logStreamerErr := NewLogstreamer(logger, true)
 	defer logStreamerErr.Close()
 
 	// Execute something that succeeds
@@ -57,11 +57,11 @@ func TestLogstreamerErr(t *testing.T) {
 	logger := log.New(os.Stdout, "--> ", log.Ldate|log.Ltime)
 
 	// Setup a streamer that we'll pipe cmd.Stdout to
-	logStreamerOut := NewLogstreamer(logger, "stdout", false)
+	logStreamerOut := NewLogstreamer(logger, false)
 	defer logStreamerOut.Close()
 	// Setup a streamer that we'll pipe cmd.Stderr to.
 	// We want to record/buffer anything that's written to this (3rd argument true)
-	logStreamerErr := NewLogstreamer(logger, "stderr", true)
+	logStreamerErr := NewLogstreamer(logger, true)
 	defer logStreamerErr.Close()
 
 	// Execute something that succeeds
@@ -99,11 +99,11 @@ func TestLogstreamerFlush(t *testing.T) {
 	byteWriter := bufio.NewWriter(&buffer)
 
 	logger := log.New(byteWriter, "", 0)
-	logStreamerOut := NewLogstreamer(logger, "", false)
+	logStreamerOut := NewLogstreamer(logger, false)
 	defer logStreamerOut.Close()
 
 	logStreamerOut.Write([]byte(text))
-	logStreamerOut.Flush()
+	logStreamerOut.flush()
 	byteWriter.Flush()
 
 	s := strings.TrimSpace(buffer.String())

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -914,7 +914,7 @@ func (e *execContext) exec(ctx gocontext.Context, pt *nodes.PackageTask, deps da
 	// Create a logger
 	targetUI := taskCache.NewTerminal(e.ui)
 
-	hit, err := taskCache.RestoreOutputs(targetUI, targetLogger)
+	hit, err := taskCache.RestoreOutputs(ctx, targetUI, targetLogger)
 	if err != nil {
 		targetUI.Error(fmt.Sprintf("error fetching from cache: %s", err))
 	} else if hit {

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -912,11 +912,11 @@ func (e *execContext) exec(ctx gocontext.Context, pt *nodes.PackageTask, deps da
 	taskCache := e.runCache.TaskCache(pt, hash)
 	prettyTaskPrefix := taskCache.ColoredPrefix()
 	// Create a logger
-	targetUi := taskCache.NewTerminal(e.ui)
+	targetUI := taskCache.NewTerminal(e.ui)
 
-	hit, err := taskCache.RestoreOutputs(targetUi, targetLogger)
+	hit, err := taskCache.RestoreOutputs(targetUI, targetLogger)
 	if err != nil {
-		targetUi.Error(fmt.Sprintf("error fetching from cache: %s", err))
+		targetUI.Error(fmt.Sprintf("error fetching from cache: %s", err))
 	} else if hit {
 		tracer(TargetCached, nil)
 		return nil
@@ -991,10 +991,10 @@ func (e *execContext) exec(ctx gocontext.Context, pt *nodes.PackageTask, deps da
 		tracer(TargetBuildFailed, err)
 		targetLogger.Error("Error: command finished with error: %w", err)
 		if !e.rs.Opts.runOpts.continueOnError {
-			targetUi.Error(fmt.Sprintf("ERROR: command finished with error: %s", err))
+			targetUI.Error(fmt.Sprintf("ERROR: command finished with error: %s", err))
 			e.processes.Close()
 		} else {
-			targetUi.Warn("command finished with error, but continuing...")
+			targetUI.Warn("command finished with error, but continuing...")
 		}
 		return err
 	}
@@ -1004,7 +1004,7 @@ func (e *execContext) exec(ctx gocontext.Context, pt *nodes.PackageTask, deps da
 	if err := closeOutputs(); err != nil {
 		e.logError(targetLogger, "", err)
 	} else {
-		if err = taskCache.SaveOutputs(targetLogger, targetUi, int(duration.Milliseconds())); err != nil {
+		if err = taskCache.SaveOutputs(targetLogger, targetUI, int(duration.Milliseconds())); err != nil {
 			e.logError(targetLogger, "", fmt.Errorf("error caching output: %w", err))
 		}
 	}

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -891,18 +891,6 @@ func (e *execContext) exec(ctx gocontext.Context, pt *nodes.PackageTask, deps da
 	// Setup tracer
 	tracer := e.runState.Run(pt.TaskID)
 
-	// Create a logger
-	colorPrefixer := e.colorCache.PrefixColor(pt.PackageName)
-	prettyTaskPrefix := colorPrefixer("%s: ", pt.OutputPrefix())
-
-	targetUi := &cli.PrefixedUi{
-		Ui:           e.ui,
-		OutputPrefix: prettyTaskPrefix,
-		InfoPrefix:   prettyTaskPrefix,
-		ErrorPrefix:  prettyTaskPrefix,
-		WarnPrefix:   prettyTaskPrefix,
-	}
-
 	passThroughArgs := e.rs.ArgsForTask(pt.Task)
 	hash, err := e.taskHashes.CalculateTaskHash(pt, deps, passThroughArgs)
 	e.logger.Debug("task hash", "value", hash)
@@ -922,6 +910,10 @@ func (e *execContext) exec(ctx gocontext.Context, pt *nodes.PackageTask, deps da
 	}
 	// Cache ---------------------------------------------
 	taskCache := e.runCache.TaskCache(pt, hash)
+	prettyTaskPrefix := taskCache.ColoredPrefix()
+	// Create a logger
+	targetUi := taskCache.NewTerminal(e.ui)
+
 	hit, err := taskCache.RestoreOutputs(targetUi, targetLogger)
 	if err != nil {
 		targetUi.Error(fmt.Sprintf("error fetching from cache: %s", err))

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -894,6 +894,11 @@ func (e *execContext) exec(ctx gocontext.Context, pt *nodes.PackageTask, deps da
 	// Create a logger
 	colorPrefixer := e.colorCache.PrefixColor(pt.PackageName)
 	prettyTaskPrefix := colorPrefixer("%s: ", pt.OutputPrefix())
+	if (e.rs.Opts.runcacheOpts.CacheHitLogsMode == runcache.FullNoPrefix) ||
+		(e.rs.Opts.runcacheOpts.CacheMissLogsMode == runcache.FullNoPrefix) {
+		prettyTaskPrefix = colorPrefixer("")
+	}
+
 	targetUi := &cli.PrefixedUi{
 		Ui:           e.ui,
 		OutputPrefix: prettyTaskPrefix,

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -921,7 +921,7 @@ func (e *execContext) exec(ctx gocontext.Context, pt *nodes.PackageTask, deps da
 		return nil
 	}
 	// Cache ---------------------------------------------
-	taskCache := e.runCache.TaskCache(pt, hash, targetUi)
+	taskCache := e.runCache.TaskCache(pt, hash)
 	hit, err := taskCache.RestoreOutputs(targetUi, targetLogger)
 	if err != nil {
 		targetUi.Error(fmt.Sprintf("error fetching from cache: %s", err))

--- a/cli/internal/runcache/prefixed_writer.go
+++ b/cli/internal/runcache/prefixed_writer.go
@@ -1,0 +1,30 @@
+package runcache
+
+import (
+	"bytes"
+	"io"
+)
+
+type prefixedWriter struct {
+	underlyingWriter io.Writer
+	prefix           string
+}
+
+func (writer prefixedWriter) Write(payload []byte) (n int, err error) {
+	buf := bytes.NewBuffer([]byte{})
+	newLine := true
+	for _, data := range payload {
+		if newLine {
+			buf.WriteString(writer.prefix)
+			newLine = false
+		}
+
+		buf.WriteByte(data)
+
+		if data == '\n' {
+			newLine = true
+		}
+	}
+
+	return writer.underlyingWriter.Write(buf.Bytes())
+}

--- a/cli/internal/runcache/prefixed_writer.go
+++ b/cli/internal/runcache/prefixed_writer.go
@@ -1,7 +1,6 @@
 package runcache
 
 import (
-	"bytes"
 	"io"
 )
 
@@ -11,20 +10,23 @@ type prefixedWriter struct {
 }
 
 func (writer prefixedWriter) Write(payload []byte) (n int, err error) {
-	buf := bytes.NewBuffer([]byte{})
 	newLine := true
 	for _, data := range payload {
 		if newLine {
-			buf.WriteString(writer.prefix)
+			if n, err = writer.underlyingWriter.Write([]byte(writer.prefix)); err != nil {
+				return n, err
+			}
 			newLine = false
 		}
 
-		buf.WriteByte(data)
+		if n, err = writer.underlyingWriter.Write([]byte{data}); err != nil {
+			return n, err
+		}
 
 		if data == '\n' {
 			newLine = true
 		}
 	}
 
-	return writer.underlyingWriter.Write(buf.Bytes())
+	return n, err
 }

--- a/cli/internal/runcache/prefixed_writer.go
+++ b/cli/internal/runcache/prefixed_writer.go
@@ -14,16 +14,20 @@ type prefixedWriter struct {
 // Writes the given `payload` and add the `prefix` to each new line.
 func (writer prefixedWriter) Write(payload []byte) (n int, err error) {
 	newLine := true
+	var totalLength int
 	for _, data := range payload {
 		if newLine {
-			if n, err = writer.underlyingWriter.Write([]byte(writer.prefix)); err != nil {
-				return n, err
+			_, err = writer.underlyingWriter.Write([]byte(writer.prefix))
+			if err != nil {
+				return totalLength, err
 			}
 			newLine = false
 		}
 
-		if n, err = writer.underlyingWriter.Write([]byte{data}); err != nil {
-			return n, err
+		n, err = writer.underlyingWriter.Write([]byte{data})
+		totalLength += n
+		if err != nil {
+			return totalLength, err
 		}
 
 		if data == '\n' {
@@ -31,5 +35,5 @@ func (writer prefixedWriter) Write(payload []byte) (n int, err error) {
 		}
 	}
 
-	return n, err
+	return totalLength, err
 }

--- a/cli/internal/runcache/prefixed_writer.go
+++ b/cli/internal/runcache/prefixed_writer.go
@@ -4,11 +4,14 @@ import (
 	"io"
 )
 
+// prefixedWriter is responsible to write the log with the `underlyingWriter`.
+// It updates the log to write by adding the `prefix` string to each new line.
 type prefixedWriter struct {
 	underlyingWriter io.Writer
 	prefix           string
 }
 
+// Writes the given `payload` and add the `prefix` to each new line.
 func (writer prefixedWriter) Write(payload []byte) (n int, err error) {
 	newLine := true
 	for _, data := range payload {

--- a/cli/internal/runcache/prefixed_writer_test.go
+++ b/cli/internal/runcache/prefixed_writer_test.go
@@ -1,0 +1,39 @@
+package runcache
+
+import (
+	"fmt"
+	"os"
+)
+
+func ExamplePrefixedWriter_Write_withPrefixSet() {
+	prefixedWriter := prefixedWriter{
+		prefix:           "PREFIXED: ",
+		underlyingWriter: os.Stdout,
+	}
+
+	someLogs := "First line of log.\nSecond line.\n\tThird line a little different\n"
+	if _, err := prefixedWriter.Write([]byte(someLogs)); err != nil {
+		fmt.Print("Unexpected write error: ", err)
+	}
+
+	// Output:
+	// PREFIXED: First line of log.
+	// PREFIXED: Second line.
+	// PREFIXED: 	Third line a little different
+}
+
+func ExamplePrefixedWriter_Write_withNotPrefixSet() {
+	prefixedWriter := prefixedWriter{
+		underlyingWriter: os.Stdout,
+	}
+
+	someLogs := "First line of log.\nSecond line.\n\tThird line a little different\n"
+	if _, err := prefixedWriter.Write([]byte(someLogs)); err != nil {
+		fmt.Print("Unexpected write error: ", err)
+	}
+
+	// Output:
+	// First line of log.
+	// Second line.
+	// 	Third line a little different
+}

--- a/cli/internal/runcache/runcache.go
+++ b/cli/internal/runcache/runcache.go
@@ -148,7 +148,6 @@ type TaskCache struct {
 	taskOutputMode    util.TaskOutputMode
 	cachingDisabled   bool
 	LogFileName       fs.AbsolutePath
-	terminal          cli.Ui
 }
 
 // RestoreOutputs attempts to restore output for the corresponding task from the cache. Returns true
@@ -197,7 +196,7 @@ func (tc TaskCache) RestoreOutputs(terminal *cli.PrefixedUi, logger hclog.Logger
 	case util.FullTaskOutput:
 		logger.Debug("log file", "path", tc.LogFileName)
 		if tc.LogFileName.FileExists() {
-			tc.rc.logReplayer(logger, tc.terminal, tc.LogFileName)
+			tc.rc.logReplayer(logger, terminal, tc.LogFileName)
 		}
 	default:
 		// NoLogs, do not output anything
@@ -280,7 +279,7 @@ func (tc TaskCache) SaveOutputs(logger hclog.Logger, terminal cli.Ui, duration i
 		if err != nil {
 			logger.Error("error", err)
 			errorMessageColored := color.RedString("%v", fmt.Errorf("File path cannot be made relative: %w", err))
-			tc.terminal.Error(fmt.Sprintf("%s%s ", ui.ERROR_PREFIX, errorMessageColored))
+			terminal.Error(fmt.Sprintf("%s%s ", ui.ERROR_PREFIX, errorMessageColored))
 			continue
 		}
 		relativePaths[index] = relativePath
@@ -301,7 +300,7 @@ func (tc TaskCache) SaveOutputs(logger hclog.Logger, terminal cli.Ui, duration i
 
 // TaskCache returns a TaskCache instance, providing an interface to the underlying cache specific
 // to this run and the given PackageTask
-func (rc *RunCache) TaskCache(pt *nodes.PackageTask, hash string, terminal cli.Ui) TaskCache {
+func (rc *RunCache) TaskCache(pt *nodes.PackageTask, hash string) TaskCache {
 	logFileName := rc.repoRoot.Join(pt.RepoRelativeLogFile())
 	hashableOutputs := pt.HashableOutputs()
 	repoRelativeGlobs := make([]string, len(hashableOutputs))
@@ -322,7 +321,6 @@ func (rc *RunCache) TaskCache(pt *nodes.PackageTask, hash string, terminal cli.U
 		taskOutputMode:    taskOutputMode,
 		cachingDisabled:   !pt.TaskDefinition.ShouldCache,
 		LogFileName:       logFileName,
-		terminal:          terminal,
 	}
 }
 

--- a/cli/internal/runcache/runcache.go
+++ b/cli/internal/runcache/runcache.go
@@ -326,7 +326,7 @@ func (tc TaskCache) ColoredPrefix() string {
 	}
 
 	colorPrefixer := tc.rc.colorCache.PrefixColor(tc.pt.PackageName)
-	return colorPrefixer("%s ", tc.pt.OutputPrefix())
+	return colorPrefixer("%s: ", tc.pt.OutputPrefix())
 }
 
 func (tc TaskCache) newPrefixWriter(bufWriter io.Writer) prefixedWriter {

--- a/cli/internal/runcache/runcache.go
+++ b/cli/internal/runcache/runcache.go
@@ -2,6 +2,7 @@ package runcache
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -152,7 +153,7 @@ type TaskCache struct {
 
 // RestoreOutputs attempts to restore output for the corresponding task from the cache. Returns true
 // if successful.
-func (tc TaskCache) RestoreOutputs(terminal cli.Ui, logger hclog.Logger) (bool, error) {
+func (tc TaskCache) RestoreOutputs(ctx context.Context, terminal cli.Ui, logger hclog.Logger) (bool, error) {
 	if tc.cachingDisabled || tc.rc.readsDisabled {
 		if tc.taskOutputMode != util.NoTaskOutput {
 			terminal.Output(fmt.Sprintf("cache bypass, force executing %s", ui.Dim(tc.hash)))

--- a/cli/internal/runcache/runcache_test.go
+++ b/cli/internal/runcache/runcache_test.go
@@ -40,9 +40,9 @@ Second line.
 		// Given
 		taskCache.rc.prefixStripped = false
 
-		expectedOutputLogs := `testPackageName: First line of log.
-testPackageName: Second line.
-testPackageName: 	Third line a little different`
+		expectedOutputLogs := `testPackageName:: First line of log.
+testPackageName:: Second line.
+testPackageName:: 	Third line a little different`
 
 		// When
 		writer, err := taskCache.OutputWriter()

--- a/cli/internal/runcache/runcache_test.go
+++ b/cli/internal/runcache/runcache_test.go
@@ -1,0 +1,126 @@
+package runcache
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/vercel/turborepo/cli/internal/colorcache"
+	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/nodes"
+	"github.com/vercel/turborepo/cli/internal/util"
+	"gotest.tools/v3/assert"
+)
+
+func Test_OutputWriter(t *testing.T) {
+	// Setup
+	savedOutput := os.Stdout
+	tempFile := fs.AbsolutePath(t.TempDir() + "temp.log")
+	taskCache := TaskCache{
+		rc: &RunCache{
+			writesDisabled: false,
+			colorCache:     colorcache.New(),
+			prefixStripped: false,
+		},
+		pt: &nodes.PackageTask{
+			PackageName: "testPackageName",
+		},
+		cachingDisabled: false,
+		LogFileName:     tempFile,
+	}
+	someLogs := "First line of log.\nSecond line.\n\tThird line a little different"
+	expectedFileLogs := `cache hit, replaying output 
+First line of log.
+Second line.
+	Third line a little different`
+
+	t.Run("With active prefix", func(t *testing.T) {
+		readOutputPipe, writeOutputPipe, _ := os.Pipe()
+		os.Stdout = writeOutputPipe
+		// Given
+		taskCache.rc.prefixStripped = false
+
+		expectedOutputLogs := `testPackageName: First line of log.
+testPackageName: Second line.
+testPackageName: 	Third line a little different`
+
+		// When
+		writer, err := taskCache.OutputWriter()
+		if err != nil {
+			t.Error("Error during Output Writer:", err)
+		}
+		if _, err := writer.Write([]byte(someLogs)); err != nil {
+			t.Error("Error when writing logs:\n", err)
+		}
+		if err := writer.Close(); err != nil {
+			t.Error("Error when closing Writer:\n", err)
+		}
+		writeOutputPipe.Close()
+
+		// Then
+		outputContent, _ := io.ReadAll(readOutputPipe)
+		assert.Equal(t, expectedOutputLogs, string(outputContent), "Output log content is different from expected")
+		fileContent, _ := os.ReadFile(tempFile.ToString())
+		assert.Equal(t, expectedFileLogs, string(fileContent), "File log content is different from expected")
+	})
+
+	t.Run("Without active prefix", func(t *testing.T) {
+		readOutputPipe, writeOutputPipe, _ := os.Pipe()
+		os.Stdout = writeOutputPipe
+		// Given
+		taskCache.rc.prefixStripped = true
+		expectedOutputLogs := `First line of log.
+Second line.
+	Third line a little different`
+
+		// When
+		writer, err := taskCache.OutputWriter()
+		if err != nil {
+			t.Error("Error during Output Writer:", err)
+		}
+		if _, err := writer.Write([]byte(someLogs)); err != nil {
+			t.Error("Error when writing logs:\n", err)
+		}
+		if err := writer.Close(); err != nil {
+			t.Error("Error when closing Writer:\n", err)
+		}
+		writeOutputPipe.Close()
+
+		// Then
+		outputContent, _ := io.ReadAll(readOutputPipe)
+		assert.Equal(t, expectedOutputLogs, string(outputContent), "Output log content is different from expected")
+		fileContent, _ := os.ReadFile(tempFile.ToString())
+		assert.Equal(t, expectedFileLogs, string(fileContent), "File log content is different from expected")
+	})
+
+	t.Run("With taskOutputMode set to util.NoTaskOutput", func(t *testing.T) {
+		readOutputPipe, writeOutputPipe, _ := os.Pipe()
+		os.Stdout = writeOutputPipe
+		// Given
+		taskCache.taskOutputMode = util.NoTaskOutput
+		expectedOutputLogs := ""
+
+		// When
+		writer, err := taskCache.OutputWriter()
+		if err != nil {
+			t.Error("Error during Output Writer:", err)
+		}
+		if _, err := writer.Write([]byte(someLogs)); err != nil {
+			t.Error("Error when writing logs:\n", err)
+		}
+		if err := writer.Close(); err != nil {
+			t.Error("Error when closing Writer:\n", err)
+		}
+		writeOutputPipe.Close()
+
+		// Then
+		outputContent, _ := io.ReadAll(readOutputPipe)
+		assert.Equal(t, expectedOutputLogs, string(outputContent), "Output log content is different from expected")
+		fileContent, _ := os.ReadFile(tempFile.ToString())
+		assert.Equal(t, expectedFileLogs, string(fileContent), "File log content is different from expected")
+	})
+
+	t.Cleanup(func() {
+		os.Stdout = savedOutput
+	})
+}


### PR DESCRIPTION
Here is a quick proposition to solve [issue 901](https://github.com/vercel/turborepo/issues/901).

Not sure this is the correct way to do it. Don't hesitate to tell me, I will update the branch :) 

*Edit*

Add a `--raw` flag to strip all prefix from outputs.

Remove all logic for prefix management from ```logstreamer```. Centralize prefix management inside `runcache` (not the best choice in terms of architecture, but the quickest for the time being) as it is the key entry point for lot of write logic.