### PR TITLE
Configure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,31 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
-    ignore:
-      # Husky v5 is currently in early-access and not open source licensed (you'd have to pay for a commercial license)
-      - dependency-name: 'husky'
-        versions: ['5.x']
+  - package-ecosystem: 'npm'
+    directory: '/packages/create-turbo'
+    schedule:
+      interval: 'monthly'
+  - package-ecosystem: 'npm'
+    directory: '/packages/turbo-codemod'
+    schedule:
+      interval: 'monthly'
+  - package-ecosystem: 'npm'
+    directory: '/packages/turbo-ignore'
+    schedule:
+      interval: 'monthly'
+  - package-ecosystem: 'npm'
+    directory: '/docs'
+    schedule:
+      interval: 'monthly'
+  - package-ecosystem: 'npm'
+    directory: '/benchmark'
+    schedule:
+      interval: 'monthly'
+  - package-ecosystem: 'npm'
+    directory: '/cli'
+    schedule:
+      interval: 'monthly'
+  - package-ecosystem: 'gomod'
+    directory: '/cli'
+    schedule:
+      interval: 'monthly'


### PR DESCRIPTION
This PR configures Dependabot to monitor dependencies across all of our own packages. It does not attempt to set up Dependabot for our `examples` or our `create-turbo` templates. (I want to address that update separately.)

Note: Dependabot does not officially support `pnpm` (dependabot/dependabot-core#1736) and is not workspaces-friendly (dependabot/dependabot-core#4993). All Dependabot PRs for the `npm` ecosystem *will* require checking out, regenerating the lockfile, and pushing back to the branch.

I've configured checks to be monthly which seems like a decent cadence to monitor things (and cluster everything to a few hours required to shepherd everything through).