### PR TITLE
Fix parsing concurrency as a number or percent

### DIFF
--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -430,7 +430,14 @@ but don't actually run them. Passing --dry=json or
 
 func addRunOpts(opts *runOpts, flags *pflag.FlagSet, aliases map[string]string) {
 	flags.StringVar(&opts.dotGraph, "graph", "", "Generate a Dot graph of the task execution.")
-	flags.IntVar(&opts.concurrency, "concurrency", 10, "Limit the concurrency of task execution. Use 1 for serial (i.e. one-at-a-time) execution.")
+	flags.AddFlag(&pflag.Flag{
+		Name:     "concurrency",
+		Usage:    "Limit the concurrency of task execution. Use 1 for serial (i.e. one-at-a-time) execution.",
+		DefValue: "10",
+		Value: &util.ConcurrencyValue{
+			Value: &opts.concurrency,
+		},
+	})
 	flags.BoolVar(&opts.parallel, "parallel", false, "Execute all tasks in parallel.")
 	flags.StringVar(&opts.profile, "profile", "", _profileHelp)
 	flags.BoolVar(&opts.continueOnError, "continue", false, _continueHelp)

--- a/cli/internal/run/run_test.go
+++ b/cli/internal/run/run_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vercel/turborepo/cli/internal/fs"
 	"github.com/vercel/turborepo/cli/internal/runcache"
 	"github.com/vercel/turborepo/cli/internal/scope"
+	"github.com/vercel/turborepo/cli/internal/ui"
 	"github.com/vercel/turborepo/cli/internal/util"
 
 	"github.com/stretchr/testify/assert"
@@ -406,4 +407,27 @@ func Test_taskSelfRef(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected to failed to build task graph: %v", err)
 	}
+}
+
+func TestUsageText(t *testing.T) {
+	defaultCwd, err := fs.GetCwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	cf := &config.Config{
+		Cwd:    defaultCwd,
+		Token:  "some-token",
+		TeamId: "my-team",
+		Cache: &config.CacheConfig{
+			Workers: 10,
+		},
+	}
+	output := ui.Default()
+	cmd := &RunCommand{
+		Config: cf,
+		Ui:     output,
+	}
+	// just ensure it doesn't panic for now
+	usage := cmd.Help()
+	assert.NotEmpty(t, usage, "expected usage text")
 }

--- a/cli/internal/run/run_test.go
+++ b/cli/internal/run/run_test.go
@@ -3,6 +3,7 @@ package run
 import (
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/pyr-sh/dag"
@@ -18,6 +19,7 @@ import (
 )
 
 func TestParseConfig(t *testing.T) {
+	cpus := runtime.NumCPU()
 	defaultCwd, err := fs.GetCwd()
 	if err != nil {
 		t.Errorf("failed to get cwd: %v", err)
@@ -71,6 +73,22 @@ func TestParseConfig(t *testing.T) {
 			&Opts{
 				runOpts: runOpts{
 					concurrency: 12,
+				},
+				cacheOpts: cache.Opts{
+					Dir:     defaultCacheFolder,
+					Workers: 10,
+				},
+				runcacheOpts: runcache.Opts{},
+				scopeOpts:    scope.Opts{},
+			},
+			[]string{"foo"},
+		},
+		{
+			"concurrency percent",
+			[]string{"foo", "--concurrency=100%"},
+			&Opts{
+				runOpts: runOpts{
+					concurrency: cpus,
 				},
 				cacheOpts: cache.Opts{
 					Dir:     defaultCacheFolder,

--- a/cli/internal/runcache/runcache.go
+++ b/cli/internal/runcache/runcache.go
@@ -64,7 +64,11 @@ type taskOutputModeValue struct {
 }
 
 func (l *taskOutputModeValue) String() string {
-	taskOutputMode, err := util.ToTaskOutputModeString(*l.opts.TaskOutputModeOverride)
+	var outputMode util.TaskOutputMode
+	if l.opts.TaskOutputModeOverride != nil {
+		outputMode = *l.opts.TaskOutputModeOverride
+	}
+	taskOutputMode, err := util.ToTaskOutputModeString(outputMode)
 	if err != nil {
 		panic(err)
 	}

--- a/cli/internal/util/parse_concurrency.go
+++ b/cli/internal/util/parse_concurrency.go
@@ -13,6 +13,8 @@ import (
 var (
 	// alias so we can mock in tests
 	runtimeNumCPU = runtime.NumCPU
+	// positive values check for +Inf
+	_positiveInfinity = 1
 )
 
 func parseConcurrency(concurrencyRaw string) (int, error) {
@@ -20,7 +22,7 @@ func parseConcurrency(concurrencyRaw string) (int, error) {
 		if percent, err := strconv.ParseFloat(concurrencyRaw[:len(concurrencyRaw)-1], 64); err != nil {
 			return 0, fmt.Errorf("invalid value for --concurrency CLI flag. This should be a number --concurrency=4 or percentage of CPU cores --concurrency=50%% : %w", err)
 		} else {
-			if percent > 0 {
+			if percent > 0 && !math.IsInf(percent, _positiveInfinity) {
 				return int(math.Max(1, float64(runtimeNumCPU())*percent/100)), nil
 			} else {
 				return 0, fmt.Errorf("invalid percentage value for --concurrency CLI flag. This should be a percentage of CPU cores, betteen 1%% and 100%% : %w", err)

--- a/cli/internal/util/parse_concurrency.go
+++ b/cli/internal/util/parse_concurrency.go
@@ -37,6 +37,8 @@ func parseConcurrency(concurrencyRaw string) (int, error) {
 	}
 }
 
+// ConcurrencyValue allows pflag to accept either a number or percentage
+// of available CPUs as a value for concurrency
 type ConcurrencyValue struct {
 	Value *int
 	raw   string
@@ -44,10 +46,12 @@ type ConcurrencyValue struct {
 
 var _ pflag.Value = &ConcurrencyValue{}
 
+// String implements pflag.Value.String for ConcurrencyValue
 func (cv *ConcurrencyValue) String() string {
 	return cv.raw
 }
 
+// Set implements pflag.Value.Set for ConcurrencyValue
 func (cv *ConcurrencyValue) Set(value string) error {
 	parsed, err := parseConcurrency(value)
 	if err != nil {
@@ -58,6 +62,7 @@ func (cv *ConcurrencyValue) Set(value string) error {
 	return nil
 }
 
+// Type implements pflag.Value.Type for ConcurrencyValue
 func (cv *ConcurrencyValue) Type() string {
 	return "number|percentage"
 }

--- a/cli/internal/util/parse_concurrency.go
+++ b/cli/internal/util/parse_concurrency.go
@@ -25,7 +25,7 @@ func parseConcurrency(concurrencyRaw string) (int, error) {
 			if percent > 0 && !math.IsInf(percent, _positiveInfinity) {
 				return int(math.Max(1, float64(runtimeNumCPU())*percent/100)), nil
 			} else {
-				return 0, fmt.Errorf("invalid percentage value for --concurrency CLI flag. This should be a percentage of CPU cores, betteen 1%% and 100%% : %w", err)
+				return 0, fmt.Errorf("invalid percentage value for --concurrency CLI flag. This should be a percentage of CPU cores, between 1%% and 100%% : %w", err)
 			}
 		}
 	} else if i, err := strconv.Atoi(concurrencyRaw); err != nil {

--- a/cli/internal/util/parse_concurrency_test.go
+++ b/cli/internal/util/parse_concurrency_test.go
@@ -2,8 +2,9 @@ package util
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseConcurrency(t *testing.T) {
@@ -44,7 +45,7 @@ func TestParseConcurrency(t *testing.T) {
 
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("%d) '%s' should be parsed at '%d'", i, tc.Input, tc.Expected), func(t *testing.T) {
-			if result, err := ParseConcurrency(tc.Input); err != nil {
+			if result, err := parseConcurrency(tc.Input); err != nil {
 				t.Fatalf("invalid parse: %#v", err)
 			} else {
 				assert.EqualValues(t, tc.Expected, result)
@@ -53,17 +54,17 @@ func TestParseConcurrency(t *testing.T) {
 	}
 
 	t.Run("throw on invalid string input", func(t *testing.T) {
-		_, err := ParseConcurrency("asdf")
+		_, err := parseConcurrency("asdf")
 		assert.Error(t, err)
 	})
 
 	t.Run("throw on invalid number input", func(t *testing.T) {
-		_, err := ParseConcurrency("-1")
+		_, err := parseConcurrency("-1")
 		assert.Error(t, err)
 	})
 
 	t.Run("throw on invalid percent input - negative", func(t *testing.T) {
-		_, err := ParseConcurrency("-1%")
+		_, err := parseConcurrency("-1%")
 		assert.Error(t, err)
 	})
 }

--- a/cli/internal/util/parse_concurrency_test.go
+++ b/cli/internal/util/parse_concurrency_test.go
@@ -36,6 +36,10 @@ func TestParseConcurrency(t *testing.T) {
 			"1%",
 			1,
 		},
+		{
+			"0644", // we parse in base 10
+			644,
+		},
 	}
 
 	// mock runtime.NumCPU() to 10
@@ -52,19 +56,24 @@ func TestParseConcurrency(t *testing.T) {
 			}
 		})
 	}
+}
 
-	t.Run("throw on invalid string input", func(t *testing.T) {
-		_, err := parseConcurrency("asdf")
-		assert.Error(t, err)
-	})
-
-	t.Run("throw on invalid number input", func(t *testing.T) {
-		_, err := parseConcurrency("-1")
-		assert.Error(t, err)
-	})
-
-	t.Run("throw on invalid percent input - negative", func(t *testing.T) {
-		_, err := parseConcurrency("-1%")
-		assert.Error(t, err)
-	})
+func TestInvalidPercents(t *testing.T) {
+	inputs := []string{
+		"asdf",
+		"-1",
+		"-l%",
+		"infinity%",
+		"-infinity%",
+		"nan%",
+		"0b01",
+		"0o644",
+		"0xFF",
+	}
+	for _, tc := range inputs {
+		t.Run(tc, func(t *testing.T) {
+			val, err := parseConcurrency(tc)
+			assert.Error(t, err, "input %v got %v", tc, val)
+		})
+	}
 }


### PR DESCRIPTION
Fixes #1336 

Implemented a custom value to accept either a number or percentage.