### PR TITLE
Run lint against Go 1.17 to constrain introduction of 1.18 features.

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.17
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2


### PR DESCRIPTION
@gsoltis had a good minimally-invasive suggestion which gets our linters back working: https://github.com/vercel/turborepo/pull/1168#issuecomment-1150243992

This PR implements that suggestion. We still build and publish with 1.18, the only real difference is we run lint against 1.17; which will happily break us if we introduce 1.18-specific features.