### PR TITLE
Revert #1297

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -27,7 +27,7 @@ jobs:
           go-version: 1.18.0
         id: go
 
-      - uses: pnpm/action-setup@v2.1.0
+      - uses: pnpm/action-setup@v2
         with:
           version: 6.32.11
 
@@ -67,7 +67,7 @@ jobs:
           go-version: 1.18.0
         id: wingo
 
-      - uses: pnpm/action-setup@v2.1.0
+      - uses: pnpm/action-setup@v2
         with:
           version: 6.32.11
 
@@ -128,7 +128,7 @@ jobs:
           go-version: 1.18.0
         id: go
 
-      - uses: pnpm/action-setup@v2.1.0
+      - uses: pnpm/action-setup@v2
         with:
           version: 6.32.11
 


### PR DESCRIPTION
I've been seeing *frequent* intermittent `pnpm` failures in CI. In theory #1297 is safe to revert and I'm trying to see if that makes problems go away.