### PR TITLE
Use Go 1.17 mode for lint

### DIFF
--- a/cli/.golangci.yml
+++ b/cli/.golangci.yml
@@ -4,6 +4,7 @@
 run:
   timeout: 5m
   modules-download-mode: readonly
+  go: 1.17
 
 linters:
   enable:


### PR DESCRIPTION
Since we're using Go `1.17` when running `golangci-lint`, mark the linter mode as `1.17` until https://github.com/golangci/golangci-lint/issues/2649 is resolved.