### PR TITLE
We lost -- prefixing passthrough args

### DIFF
--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -817,7 +817,10 @@ func (e *execContext) exec(pt *nodes.PackageTask, deps dag.Set) error {
 	}
 	// Setup command execution
 	argsactual := append([]string{"run"}, pt.Task)
-	argsactual = append(argsactual, passThroughArgs...)
+	if len(passThroughArgs) > 0 {
+		argsactual = append(argsactual, "--")
+		argsactual = append(argsactual, passThroughArgs...)
+	}
 
 	cmd := exec.Command(e.packageManager.Command, argsactual...)
 	cmd.Dir = pt.Pkg.Dir


### PR DESCRIPTION
Fixes #1355 

Prefix passthrough args with `--` so that they get routed through the package manager