### PR TITLE
docs: Fix yarn tab storage key name

### DIFF
--- a/docs/pages/docs/getting-started.mdx
+++ b/docs/pages/docs/getting-started.mdx
@@ -35,7 +35,7 @@ You can also clone a Turborepo starter repository to get a head start on your mo
 
 You can configure workspaces any way you want, but a common folder structure example is keeping applications in the `/apps` folder and packages in the `/packages` folder. The configuration of these folders is different for each package manager.
 
-<Tabs items={['npm', 'Yarn', 'pnpm']} storageKey="selected-pkg-manager">
+<Tabs items={['npm', 'yarn', 'pnpm']} storageKey="selected-pkg-manager">
   <Tab>
 <div/>
 Specify your `workspaces` in your monorepo's root `package.json` file:
@@ -215,7 +215,7 @@ Add or update `scripts` in your monorepo's root `package.json` file and have the
 
 ## Build your monorepo
 
-<Tabs items={['npm', 'Yarn', 'pnpm']} storageKey="selected-pkg-manager">
+<Tabs items={['npm', 'yarn', 'pnpm']} storageKey="selected-pkg-manager">
   <Tab>
     ```sh
     npm run build


### PR DESCRIPTION
Update the tabs to use matching keys to keep in sync.