### PR TITLE
Update schema generation script invocation.

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "build": "next build ",
     "lint": "next lint",
-    "schema": "ts-json-schema-generator -p ./schema.d.ts -o ./public/schema.json -t Schema --minify"
+    "schema": "ts-json-schema-generator -f tsconfig.json -p ./schema.d.ts -o ./public/schema.json -t Schema --minify"
   },
   "author": "Jared Palmer",
   "license": "MPL-2.0",


### PR DESCRIPTION
This is kind of a weird fix. I believe it works by resetting the execution root for the `compileProgram` execution; not based upon any actual configuration in our TSConfig file.

The previous state would succeed or fail based upon the `node_modules` directory structure, this changes the execution location to be from a known-good location.