### PR TITLE
Vendor chrometracing, add Close method

### DIFF
--- a/cli/.golangci.yml
+++ b/cli/.golangci.yml
@@ -5,8 +5,8 @@ run:
   timeout: 5m
   modules-download-mode: readonly
   go: 1.17
-  skip-dirs:
-    - internal/chrometracing # vendored upstream library
+  skip-files:
+    - internal/chrometracing/chrometracing.go # vendored upstream library
 
 linters:
   enable:

--- a/cli/.golangci.yml
+++ b/cli/.golangci.yml
@@ -5,6 +5,8 @@ run:
   timeout: 5m
   modules-download-mode: readonly
   go: 1.17
+  skip-dirs:
+    - internal/chrometracing # vendored upstream library
 
 linters:
   enable:

--- a/cli/internal/chrometracing/chrometracing.go
+++ b/cli/internal/chrometracing/chrometracing.go
@@ -1,0 +1,239 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package chrometracing writes per-process Chrome trace_event files that can be
+// loaded into chrome://tracing.
+package chrometracing
+
+// TODO: use upstream when https://github.com/google/chrometracing/pull/8 is merged
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/chrometracing/traceinternal"
+)
+
+var trace = struct {
+	start time.Time
+	pid   uint64
+
+	fileMu sync.Mutex
+	file   *os.File
+}{
+	pid: uint64(os.Getpid()),
+}
+
+var out = setup(false)
+
+// Path returns the full path of the chrome://tracing trace_event file for
+// display in log messages.
+func Path() string { return out }
+
+// EnableTracing turns on tracing, regardless of running in a test or
+// not. Tracing is enabled by default if the CHROMETRACING_DIR environment
+// variable is present and non-empty.
+func EnableTracing() {
+	trace.fileMu.Lock()
+	alreadyEnabled := trace.file != nil
+	trace.fileMu.Unlock()
+	if alreadyEnabled {
+		return
+	}
+	out = setup(true)
+}
+
+func setup(overrideEnable bool) string {
+	inTest := os.Getenv("TEST_TMPDIR") != ""
+	explicitlyEnabled := os.Getenv("CHROMETRACING_DIR") != ""
+	enableTracing := inTest || explicitlyEnabled || overrideEnable
+	if !enableTracing {
+		return ""
+	}
+
+	var err error
+	dir := os.Getenv("TEST_UNDECLARED_OUTPUTS_DIR")
+	if dir == "" {
+		dir = os.Getenv("CHROMETRACING_DIR")
+	}
+	if dir == "" {
+		dir = os.TempDir()
+	}
+	fn := filepath.Join(dir, fmt.Sprintf("%s.%d.trace", filepath.Base(os.Args[0]), trace.pid))
+	trace.file, err = os.OpenFile(fn, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_EXCL, 0644)
+	if err != nil {
+		// Using the log package from func init results in an error message
+		// being printed.
+		fmt.Fprintf(os.Stderr, "continuing without tracing: %v\n", err)
+		return ""
+	}
+
+	// We only ever open a JSON array. Ending the array is optional as per
+	// go/trace_event so that not cleanly finished traces can still be read.
+	trace.file.Write([]byte{'['})
+	trace.start = time.Now()
+
+	writeEvent(&traceinternal.ViewerEvent{
+		Name:  "process_name",
+		Phase: "M", // Metadata Event
+		Pid:   trace.pid,
+		Tid:   trace.pid,
+		Arg: struct {
+			Name string `json:"name"`
+		}{
+			Name: strings.Join(os.Args, " "),
+		},
+	})
+	return fn
+}
+
+func writeEvent(ev *traceinternal.ViewerEvent) {
+	b, err := json.Marshal(&ev)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		return
+	}
+	trace.fileMu.Lock()
+	defer trace.fileMu.Unlock()
+	if _, err = trace.file.Write(b); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		return
+	}
+	if _, err = trace.file.Write([]byte{',', '\n'}); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		return
+	}
+}
+
+const (
+	begin = "B"
+	end   = "E"
+)
+
+// A PendingEvent represents an ongoing unit of work. The begin trace event has
+// already been written, and calling Done will write the end trace event.
+type PendingEvent struct {
+	name string
+	tid  uint64
+}
+
+// Done writes the end trace event for this unit of work.
+func (pe *PendingEvent) Done() {
+	if pe == nil || pe.name == "" || trace.file == nil {
+		return
+	}
+	writeEvent(&traceinternal.ViewerEvent{
+		Name:  pe.name,
+		Phase: end,
+		Pid:   trace.pid,
+		Tid:   pe.tid,
+		Time:  float64(time.Since(trace.start).Microseconds()),
+	})
+	releaseTid(pe.tid)
+}
+
+// Event logs a unit of work. To instrument a Go function, use e.g.:
+//
+//   func calcPi() {
+//     defer chrometracing.Event("calculate pi").Done()
+//     // …
+//   }
+//
+// For more finely-granular traces, use e.g.:
+//
+//   for _, cmd := range commands {
+//     ev := chrometracing.Event("initialize " + cmd.Name)
+//     cmd.Init()
+//     ev.Done()
+//   }
+func Event(name string) *PendingEvent {
+	if trace.file == nil {
+		return &PendingEvent{}
+	}
+	tid := tid()
+	writeEvent(&traceinternal.ViewerEvent{
+		Name:  name,
+		Phase: begin,
+		Pid:   trace.pid,
+		Tid:   tid,
+		Time:  float64(time.Since(trace.start).Microseconds()),
+	})
+	return &PendingEvent{
+		name: name,
+		tid:  tid,
+	}
+}
+
+// tids is a chrome://tracing thread id pool. Go does not permit accessing the
+// goroutine id, so we need to maintain our own identifier. The chrome://tracing
+// file format requires a numeric thread id, so we just increment whenever we
+// need a thread id, and reuse the ones no longer in use.
+//
+// In practice, parallelized sections of the code (many goroutines) end up using
+// only as few thread ids as are concurrently in use, and the rest of the events
+// mirror the code call stack nicely. See e.g. http://screen/7MPcAcvXQNUE3JZ
+var tids struct {
+	sync.Mutex
+
+	// We allocate chrome://tracing thread ids based on the index of the
+	// corresponding entry in the used slice.
+	used []bool
+
+	// next points to the earliest unused tid to consider for the next tid to
+	// hand out. This is purely a performance optimization to avoid O(n) slice
+	// iteration.
+	next int
+}
+
+func tid() uint64 {
+	tids.Lock()
+	defer tids.Unlock()
+	// re-use released tids if any
+	for t := tids.next; t < len(tids.used); t++ {
+		if !tids.used[t] {
+			tids.used[t] = true
+			tids.next = t + 1
+			return uint64(t)
+		}
+	}
+	// allocate a new tid
+	t := len(tids.used)
+	tids.used = append(tids.used, true)
+	tids.next = t + 1
+	return uint64(t)
+}
+
+func releaseTid(t uint64) {
+	tids.Lock()
+	defer tids.Unlock()
+	tids.used[int(t)] = false
+	if tids.next > int(t) {
+		tids.next = int(t)
+	}
+}
+
+// Flush should be called before your program terminates, and/or periodically
+// for long-running programs, to flush any pending chrome://tracing events out
+// to disk.
+func Flush() error {
+	if err := trace.file.Sync(); err != nil {
+		return fmt.Errorf("flushing trace file: %v", err)
+	}
+	return nil
+}

--- a/cli/internal/chrometracing/chrometracing.go
+++ b/cli/internal/chrometracing/chrometracing.go
@@ -16,8 +16,6 @@
 // loaded into chrome://tracing.
 package chrometracing
 
-// TODO: use upstream when https://github.com/google/chrometracing/pull/8 is merged
-
 import (
 	"encoding/json"
 	"fmt"
@@ -226,22 +224,4 @@ func releaseTid(t uint64) {
 	if tids.next > int(t) {
 		tids.next = int(t)
 	}
-}
-
-// Close overwrites the trailing (,\n) with (]\n) and closes the trace file.
-func Close() error {
-	trace.fileMu.Lock()
-	defer trace.fileMu.Unlock()
-	// Seek backwards two bytes (,\n)
-	if _, err := trace.file.Seek(-2, 1); err != nil {
-		return err
-	}
-	// Write 1 byte, ']', leaving the trailing '\n' in place
-	if _, err := trace.file.Write([]byte{']'}); err != nil {
-		return err
-	}
-	if err := trace.file.Close(); err != nil {
-		return err
-	}
-	return nil
 }

--- a/cli/internal/chrometracing/chrometracing_close.go
+++ b/cli/internal/chrometracing/chrometracing_close.go
@@ -1,0 +1,22 @@
+package chrometracing
+
+// Close overwrites the trailing (,\n) with (]\n) and closes the trace file.
+// Close is implemented in a separate file to keep a separation between custom
+// code and upstream from github.com/google/chrometracing. Additionally, we can
+// enable linting for code we author, while leaving upstream code alone.
+func Close() error {
+	trace.fileMu.Lock()
+	defer trace.fileMu.Unlock()
+	// Seek backwards two bytes (,\n)
+	if _, err := trace.file.Seek(-2, 1); err != nil {
+		return err
+	}
+	// Write 1 byte, ']', leaving the trailing '\n' in place
+	if _, err := trace.file.Write([]byte{']'}); err != nil {
+		return err
+	}
+	if err := trace.file.Close(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cli/internal/run/run_state.go
+++ b/cli/internal/run/run_state.go
@@ -8,12 +8,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/vercel/turborepo/cli/internal/chrometracing"
 	"github.com/vercel/turborepo/cli/internal/config"
 	"github.com/vercel/turborepo/cli/internal/fs"
 	"github.com/vercel/turborepo/cli/internal/ui"
 	"github.com/vercel/turborepo/cli/internal/util"
 
-	"github.com/google/chrometracing"
 	"github.com/mitchellh/cli"
 )
 
@@ -235,11 +235,13 @@ func (r *RunState) Close(Ui cli.Ui, filename string) error {
 	// so we have to account for that before converting to AbsolutePath
 	root := fs.AbsolutePathFromUpstream(cwd)
 	name := fmt.Sprintf("turbo-%s.trace", time.Now().Format(time.RFC3339))
-	println("source: ", fs.ResolveUnknownPath(root, outputPath))
 	if filename != "" {
 		name = filename
 	}
 	if outputPath != "" {
+		if err := chrometracing.Flush(); err != nil {
+			Ui.Warn(fmt.Sprintf("Failed to flush tracing data: %v", err))
+		}
 		if err := fs.CopyFile(&fs.LstatCachedFile{Path: fs.ResolveUnknownPath(root, outputPath)}, name); err != nil {
 			return err
 		}

--- a/cli/internal/run/run_state.go
+++ b/cli/internal/run/run_state.go
@@ -239,7 +239,7 @@ func (r *RunState) Close(Ui cli.Ui, filename string) error {
 		name = filename
 	}
 	if outputPath != "" {
-		if err := chrometracing.Flush(); err != nil {
+		if err := chrometracing.Close(); err != nil {
 			Ui.Warn(fmt.Sprintf("Failed to flush tracing data: %v", err))
 		}
 		if err := fs.CopyFile(&fs.LstatCachedFile{Path: fs.ResolveUnknownPath(root, outputPath)}, name); err != nil {

--- a/cli/scripts/e2e/e2e.ts
+++ b/cli/scripts/e2e/e2e.ts
@@ -189,9 +189,13 @@ function runSmokeTests<T>(
       }, `Could not read cached log file from cache ${cachedLogFilePath}`);
       assert.ok(text.includes("testing c"), "Contains correct output");
 
-      const tracingBuf = fs.readFileSync(path.join(repo.root, "chrometracing"));
+      const root = options.cwd ? options.cwd : repo.root;
+      const tracingFile = path.join(root, "chrometracing");
+      const tracingBuf = fs.readFileSync(tracingFile);
       // ensure it doesn't throw
       JSON.parse(tracingBuf.toString("utf-8"));
+      // don't throw off hashes for later tests
+      fs.unlinkSync(tracingFile);
     }
   );
 
@@ -227,7 +231,6 @@ function runSmokeTests<T>(
       repo.commitFiles({
         [path.join("packages", "a", "test.js")]: `console.log('testingz a');`,
       });
-
       const sinceCommandOutputNoCache = getCommandOutputAsArray(
         repo.turbo(
           "run",

--- a/cli/scripts/e2e/e2e.ts
+++ b/cli/scripts/e2e/e2e.ts
@@ -45,6 +45,7 @@ for (let npmClient of ["yarn", "berry", "pnpm", "npm"] as const) {
   repo.addPackage("b");
   repo.addPackage("c");
   repo.linkPackages();
+  repo.expectCleanGitStatus();
   runSmokeTests(Suite, repo, npmClient);
   const sub = new Monorepo("in-subdirectory");
   sub.init(npmClient, basicPipeline, "js");

--- a/cli/scripts/e2e/e2e.ts
+++ b/cli/scripts/e2e/e2e.ts
@@ -3,6 +3,7 @@ import * as uvu from "uvu";
 import * as assert from "uvu/assert";
 import { Monorepo } from "../monorepo";
 import path from "path";
+import * as fs from "fs";
 
 const basicPipeline = {
   pipeline: {
@@ -168,7 +169,11 @@ function runSmokeTests<T>(
       options.cwd ? " from " + options.cwd : ""
     }`,
     async () => {
-      const results = repo.turbo("run", ["test", "--stream"], options);
+      const results = repo.turbo(
+        "run",
+        ["test", "--stream", "--profile=chrometracing"],
+        options
+      );
       assert.equal(0, results.exitCode, "exit code should be 0");
       const commandOutput = getCommandOutputAsArray(results);
       const hash = getHashFromOutput(commandOutput, "c#test");
@@ -183,6 +188,10 @@ function runSmokeTests<T>(
         text = repo.readFileSync(cachedLogFilePath);
       }, `Could not read cached log file from cache ${cachedLogFilePath}`);
       assert.ok(text.includes("testing c"), "Contains correct output");
+
+      const tracingBuf = fs.readFileSync(path.join(repo.root, "chrometracing"));
+      // ensure it doesn't throw
+      JSON.parse(tracingBuf.toString("utf-8"));
     }
   );
 

--- a/cli/scripts/monorepo.ts
+++ b/cli/scripts/monorepo.ts
@@ -77,7 +77,7 @@ export class Monorepo {
         pkg.packageManager = "yarn@3.1.1";
         break;
       case "pnpm":
-        pkg.packageManager = "pnpm@6.26.1";
+        pkg.packageManager = "pnpm@7.2.1";
         break;
       case "npm":
         pkg.packageManager = "npm@8.3.0";
@@ -94,7 +94,7 @@ export class Monorepo {
       this.commitFiles({
         "pnpm-workspace.yaml": `packages:
 - packages/*`,
-        "pnpm-lock.yaml": `lockfileVersion: 5.3
+        "pnpm-lock.yaml": `lockfileVersion: 5.4
 
 importers:
 
@@ -112,7 +112,6 @@ importers:
 
   packages/c:
     specifiers: {}
-
         `,
       });
       execa.sync("pnpm", ["install", "--recursive"], {
@@ -299,6 +298,17 @@ fs.copyFileSync(
     return execa.sync("git", ["commit", "-m", "foo"], {
       cwd: this.root,
     });
+  }
+
+  expectCleanGitStatus() {
+    const status = execa.sync("git", ["status", "-s"], {
+      cwd: this.root,
+    });
+    if (status.stdout !== "" || status.stderr !== "") {
+      throw new Error(
+        `Found git status: stdout ${status.stdout} / stderr ${status.stderr}`
+      );
+    }
   }
 
   turbo(


### PR DESCRIPTION
 - Vendor `chrometracing` (mostly, it still references a sub-package that is just a `struct` definition)
 - Implement `Close` function for `chrometracing`: it overwrites the trailing `,\n` with `]\n` and closes the file.
 - Add an `e2e` test to make sure `JSON.parse` succeeds on the profiling output.
 - Exempt `chrometracing` from linting