### PR TITLE
Fix hashing uncommitted changes

### DIFF
--- a/cli/internal/fs/package_deps_hash.go
+++ b/cli/internal/fs/package_deps_hash.go
@@ -90,10 +90,10 @@ func GetHashableDeps(rootPath AbsolutePath, files []turbopath.AbsoluteSystemPath
 // gitHashObject returns a map of paths to their SHA hashes calculated by passing the paths `git hash-object`.
 // `git hash-object` expects paths to use Unix separators, even on Windows.
 //
-// Note: paths of files to hash passed to `git hash-object` are processed as relative to the *repository* root.
-// For that reason we convert all input paths and make them relative to the rootPath prior to passing them
+// Note: paths of files to hash passed to `git hash-object` are processed as relative to the given anchor.
+// For that reason we convert all input paths and make them relative to the anchor prior to passing them
 // to `git hash-object`.
-func gitHashObject(rootPath turbopath.AbsoluteSystemPath, filesToHash []turbopath.AnchoredSystemPath) (map[turbopath.AnchoredUnixPath]string, error) {
+func gitHashObject(anchor turbopath.AbsoluteSystemPath, filesToHash []turbopath.AnchoredSystemPath) (map[turbopath.AnchoredUnixPath]string, error) {
 	fileCount := len(filesToHash)
 	output := make(map[turbopath.AnchoredUnixPath]string, fileCount)
 
@@ -103,7 +103,7 @@ func gitHashObject(rootPath turbopath.AbsoluteSystemPath, filesToHash []turbopat
 			"hash-object",   // hash a file,
 			"--stdin-paths", // using a list of newline-separated paths from stdin.
 		)
-		cmd.Dir = rootPath.ToString() // Start at this directory.
+		cmd.Dir = anchor.ToString() // Start at this directory.
 
 		// The functionality for gitHashObject is different enough that it isn't reasonable to
 		// generalize the behavior for `runGitCmd`. In fact, it doesn't even use the `gitoutput`
@@ -126,7 +126,7 @@ func gitHashObject(rootPath turbopath.AbsoluteSystemPath, filesToHash []turbopat
 			// This function's result needs to be relative to `rootPath`.
 			// We convert all files to absolute paths and assume that they will be inside of the repository.
 			for _, file := range filesToHash {
-				converted := file.RestoreAnchor(rootPath)
+				converted := file.RestoreAnchor(anchor)
 
 				// `git hash-object` expects paths to use Unix separators, even on Windows.
 				// `git hash-object` expects paths to be one per line so we must escape newlines.

--- a/cli/internal/fs/package_deps_hash_test.go
+++ b/cli/internal/fs/package_deps_hash_test.go
@@ -242,10 +242,12 @@ func TestGetPackageDeps(t *testing.T) {
 	cmd.Dir = repoRoot.ToString()
 	err = cmd.Run()
 	assert.NilError(t, err, "Run")
-	cmd = exec.Command("git", "commit", "-m foo")
+	cmd = exec.Command("git", "commit", "-m", "foo")
 	cmd.Dir = repoRoot.ToString()
-	err = cmd.Run()
-	assert.NilError(t, err, "Run")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git commit failed: %v %v", err, string(out))
+	}
 	err = deletedFilePath.Remove()
 	assert.NilError(t, err, "Remove")
 	uncommittedFilePath := myPkgDir.Join("uncommitted-file")

--- a/cli/internal/fs/package_deps_hash_test.go
+++ b/cli/internal/fs/package_deps_hash_test.go
@@ -221,6 +221,7 @@ func TestGetPackageDeps(t *testing.T) {
 	// <root>/
 	//   my-pkg/
 	//     committed-file
+	//     deleted-file
 	//     uncommitted-file <- new file not added to git
 
 	repoRoot := AbsolutePathFromUpstream(t.TempDir())
@@ -229,6 +230,9 @@ func TestGetPackageDeps(t *testing.T) {
 	err := committedFilePath.EnsureDir()
 	assert.NilError(t, err, "EnsureDir")
 	err = committedFilePath.WriteFile([]byte("committed bytes"), 0644)
+	assert.NilError(t, err, "WriteFile")
+	deletedFilePath := myPkgDir.Join("deleted-file")
+	err = deletedFilePath.WriteFile([]byte("delete-me"), 0644)
 	assert.NilError(t, err, "WriteFile")
 	cmd := exec.Command("git", "init", ".")
 	cmd.Dir = repoRoot.ToString()
@@ -242,6 +246,8 @@ func TestGetPackageDeps(t *testing.T) {
 	cmd.Dir = repoRoot.ToString()
 	err = cmd.Run()
 	assert.NilError(t, err, "Run")
+	err = deletedFilePath.Remove()
+	assert.NilError(t, err, "Remove")
 	uncommittedFilePath := myPkgDir.Join("uncommitted-file")
 	err = uncommittedFilePath.WriteFile([]byte("uncommitted bytes"), 0644)
 	assert.NilError(t, err, "WriteFile")

--- a/cli/internal/fs/package_deps_hash_test.go
+++ b/cli/internal/fs/package_deps_hash_test.go
@@ -242,7 +242,7 @@ func TestGetPackageDeps(t *testing.T) {
 	cmd.Dir = repoRoot.ToString()
 	err = cmd.Run()
 	assert.NilError(t, err, "Run")
-	cmd = exec.Command("git", "commit", "-m", "foo")
+	cmd = exec.Command("git", "commit", "-m", "foo", "--author=\"Test <test@example.com>\"")
 	cmd.Dir = repoRoot.ToString()
 	out, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
We were passing the repo root and paths rooted at the package root to `gitHashObject`. Fixed to pass the package path. Also created array of paths to hash directly, rather than creating an intermediate array and converting.

Added a test for the hashing behavior.