### PR TITLE
Move some fields out of Config

### DIFF
--- a/cli/internal/cache/cache.go
+++ b/cli/internal/cache/cache.go
@@ -57,10 +57,11 @@ var ErrNoCachesEnabled = errors.New("no caches are enabled")
 // Opts holds configuration options for the cache
 // TODO(gsoltis): further refactor this into fs cache opts and http cache opts
 type Opts struct {
-	Dir            fs.AbsolutePath
-	SkipRemote     bool
-	SkipFilesystem bool
-	Workers        int
+	Dir             fs.AbsolutePath
+	SkipRemote      bool
+	SkipFilesystem  bool
+	Workers         int
+	RemoteCacheOpts fs.RemoteCacheOptions
 }
 
 var _remoteOnlyHelp = `Ignore the local filesystem cache for all tasks. Only

--- a/cli/internal/cache/cache.go
+++ b/cli/internal/cache/cache.go
@@ -115,7 +115,7 @@ func newSyncCache(opts Opts, config *config.Config, client client, recorder anal
 
 	if useHTTPCache {
 		fmt.Println(ui.Dim("• Remote computation caching enabled"))
-		implementation := newHTTPCache(opts, client, config, recorder)
+		implementation := newHTTPCache(opts, config, client, recorder, config.Cwd)
 		cacheImplementations = append(cacheImplementations, implementation)
 	}
 

--- a/cli/internal/cache/cache_fs.go
+++ b/cli/internal/cache/cache_fs.go
@@ -11,7 +11,6 @@ import (
 	"runtime"
 
 	"github.com/vercel/turborepo/cli/internal/analytics"
-	"github.com/vercel/turborepo/cli/internal/config"
 	"github.com/vercel/turborepo/cli/internal/fs"
 	"golang.org/x/sync/errgroup"
 )
@@ -20,15 +19,19 @@ import (
 type fsCache struct {
 	cacheDirectory string
 	recorder       analytics.Recorder
-	config         *config.Config
+	repoRoot       fs.AbsolutePath
 }
 
 // newFsCache creates a new filesystem cache
-func newFsCache(opts Opts, recorder analytics.Recorder, config *config.Config) (*fsCache, error) {
+func newFsCache(opts Opts, recorder analytics.Recorder, repoRoot fs.AbsolutePath) (*fsCache, error) {
 	if err := opts.Dir.MkdirAll(); err != nil {
 		return nil, err
 	}
-	return &fsCache{cacheDirectory: opts.Dir.ToStringDuringMigration(), recorder: recorder, config: config}, nil
+	return &fsCache{
+		cacheDirectory: opts.Dir.ToStringDuringMigration(),
+		recorder:       recorder,
+		repoRoot:       repoRoot,
+	}, nil
 }
 
 // Fetch returns true if items are cached. It moves them into position as a side effect.
@@ -81,7 +84,7 @@ func (f *fsCache) Put(target, hash string, duration int, files []string) error {
 	for i := 0; i < numDigesters; i++ {
 		g.Go(func() error {
 			for file := range fileQueue {
-				statedFile := fs.LstatCachedFile{Path: f.config.Cwd.Join(file)}
+				statedFile := fs.LstatCachedFile{Path: f.repoRoot.Join(file)}
 				fromType, err := statedFile.GetType()
 				if err != nil {
 					return fmt.Errorf("error stat'ing cache source %v: %v", file, err)

--- a/cli/internal/cache/cache_fs_test.go
+++ b/cli/internal/cache/cache_fs_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/vercel/turborepo/cli/internal/analytics"
-	"github.com/vercel/turborepo/cli/internal/config"
 	"github.com/vercel/turborepo/cli/internal/fs"
 	turbofs "github.com/vercel/turborepo/cli/internal/fs"
 	"gotest.tools/v3/assert"
@@ -103,16 +102,11 @@ func TestPut(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get cwd: %v", err)
 	}
-	cf := &config.Config{
-		Cwd:    defaultCwd,
-		Token:  "some-token",
-		TeamId: "my-team",
-	}
 
 	cache := &fsCache{
 		cacheDirectory: dst,
 		recorder:       dr,
-		config:         cf,
+		repoRoot:       defaultCwd,
 	}
 
 	hash := "the-hash"
@@ -207,16 +201,11 @@ func TestFetch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get cwd: %v", err)
 	}
-	cf := &config.Config{
-		Cwd:    defaultCwd,
-		Token:  "some-token",
-		TeamId: "my-team",
-	}
 
 	cache := &fsCache{
 		cacheDirectory: cacheDir,
 		recorder:       dr,
-		config:         cf,
+		repoRoot:       defaultCwd,
 	}
 
 	dstOutputPath := "some-package"

--- a/cli/internal/cache/cache_http.go
+++ b/cli/internal/cache/cache_http.go
@@ -339,7 +339,7 @@ func newHTTPCache(opts Opts, client client, config *config.Config, recorder anal
 			// TODO(Gaspar): this should use RemoteCacheOptions.TeamId once we start
 			// enforcing team restrictions for repositories.
 			teamId:  config.TeamId,
-			enabled: config.TurboJSON.RemoteCacheOptions.Signature,
+			enabled: opts.RemoteCacheOpts.Signature,
 		},
 		repoRoot: config.Cwd,
 	}

--- a/cli/internal/cache/cache_http.go
+++ b/cli/internal/cache/cache_http.go
@@ -329,7 +329,7 @@ func (cache *httpCache) CleanAll() {
 
 func (cache *httpCache) Shutdown() {}
 
-func newHTTPCache(opts Opts, client client, config *config.Config, recorder analytics.Recorder) *httpCache {
+func newHTTPCache(opts Opts, config *config.Config, client client, recorder analytics.Recorder, repoRoot fs.AbsolutePath) *httpCache {
 	return &httpCache{
 		writable:       true,
 		client:         client,
@@ -341,6 +341,6 @@ func newHTTPCache(opts Opts, client client, config *config.Config, recorder anal
 			teamId:  config.TeamId,
 			enabled: opts.RemoteCacheOpts.Signature,
 		},
-		repoRoot: config.Cwd,
+		repoRoot: repoRoot,
 	}
 }

--- a/cli/internal/cache/cache_http.go
+++ b/cli/internal/cache/cache_http.go
@@ -329,10 +329,10 @@ func (cache *httpCache) CleanAll() {
 
 func (cache *httpCache) Shutdown() {}
 
-func newHTTPCache(opts Opts, config *config.Config, recorder analytics.Recorder) *httpCache {
+func newHTTPCache(opts Opts, client client, config *config.Config, recorder analytics.Recorder) *httpCache {
 	return &httpCache{
 		writable:       true,
-		client:         config.ApiClient,
+		client:         client,
 		requestLimiter: make(limiter, 20),
 		recorder:       recorder,
 		signerVerifier: &ArtifactSignatureAuthentication{

--- a/cli/internal/cache/cache_test.go
+++ b/cli/internal/cache/cache_test.go
@@ -191,14 +191,11 @@ func TestNew(t *testing.T) {
 				opts: Opts{
 					SkipFilesystem: true,
 					SkipRemote:     false,
-				},
-				config: &config.Config{
-					TurboJSON: &fs.TurboJSON{
-						RemoteCacheOptions: fs.RemoteCacheOptions{
-							Signature: true,
-						},
+					RemoteCacheOpts: fs.RemoteCacheOptions{
+						Signature: true,
 					},
 				},
+				config:         &config.Config{},
 				recorder:       &nullRecorder{},
 				onCacheRemoved: func(Cache, error) {},
 			},
@@ -229,14 +226,11 @@ func TestNew(t *testing.T) {
 					Dir:            fs.AbsolutePath(cwd),
 					SkipFilesystem: false,
 					SkipRemote:     false,
-				},
-				config: &config.Config{
-					TurboJSON: &fs.TurboJSON{
-						RemoteCacheOptions: fs.RemoteCacheOptions{
-							Signature: true,
-						},
+					RemoteCacheOpts: fs.RemoteCacheOptions{
+						Signature: true,
 					},
 				},
+				config:         &config.Config{},
 				recorder:       &nullRecorder{},
 				onCacheRemoved: func(Cache, error) {},
 			},

--- a/cli/internal/cache/cache_test.go
+++ b/cli/internal/cache/cache_test.go
@@ -158,12 +158,12 @@ func (nullRecorder) LogEvent(analytics.EventPayload) {}
 func TestNew(t *testing.T) {
 	// Test will bomb if this fails, no need to specially handle the error
 	cwd, _ := os.Getwd()
-
 	type args struct {
 		opts           Opts
 		config         *config.Config
 		recorder       analytics.Recorder
 		onCacheRemoved OnCacheRemoved
+		client         client
 	}
 	tests := []struct {
 		name    string
@@ -240,10 +240,9 @@ func TestNew(t *testing.T) {
 			wantErr: false,
 		},
 	}
-	var nilClient client
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := New(tt.args.opts, tt.args.config, nilClient, tt.args.recorder, tt.args.onCacheRemoved)
+			got, err := New(tt.args.opts, tt.args.config, tt.args.client, tt.args.recorder, tt.args.onCacheRemoved)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/cli/internal/cache/cache_test.go
+++ b/cli/internal/cache/cache_test.go
@@ -246,9 +246,10 @@ func TestNew(t *testing.T) {
 			wantErr: false,
 		},
 	}
+	var nilClient client
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := New(tt.args.opts, tt.args.config, tt.args.recorder, tt.args.onCacheRemoved)
+			got, err := New(tt.args.opts, tt.args.config, nilClient, tt.args.recorder, tt.args.onCacheRemoved)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -48,8 +48,6 @@ type Config struct {
 	// Turborepo CLI Version
 	TurboVersion string
 	Cache        *CacheConfig
-	// turbo.json or legacy turbo config from package.json
-	TurboJSON *fs.TurboJSON
 	// package.json at the root of the repo
 	RootPackageJSON *fs.PackageJSON
 	// Current Working Directory
@@ -97,10 +95,6 @@ func ParseAndValidate(args []string, ui cli.Ui, turboVersion string) (c *Config,
 	rootPackageJSON, err := fs.ReadPackageJSON(packageJSONPath.ToStringDuringMigration())
 	if err != nil {
 		return nil, fmt.Errorf("package.json: %w", err)
-	}
-	turboJSON, err := fs.ReadTurboConfig(cwd, rootPackageJSON)
-	if err != nil {
-		return nil, err
 	}
 	userConfig, err := ReadUserConfigFile()
 	if err != nil {
@@ -212,7 +206,6 @@ func ParseAndValidate(args []string, ui cli.Ui, turboVersion string) (c *Config,
 			Workers: runtime.NumCPU() + 2,
 		},
 		RootPackageJSON: rootPackageJSON,
-		TurboJSON:       turboJSON,
 		Cwd:             cwd,
 
 		UsePreflight:      usePreflight,

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -32,6 +32,9 @@ func IsCI() bool {
 // Config is a struct that contains user inputs and our logger
 type Config struct {
 	Logger hclog.Logger
+	// TODO: Token through ApiUrl should maybe be grouped together
+	// in their own struct, as they will come from config files
+
 	// Bearer token
 	Token string
 	// vercel.com / remote cache team id
@@ -42,8 +45,6 @@ type Config struct {
 	ApiUrl string
 	// Login URL
 	LoginUrl string
-	// Backend retryable http client
-	ApiClient *client.ApiClient
 	// Turborepo CLI Version
 	TurboVersion string
 	Cache        *CacheConfig
@@ -53,6 +54,9 @@ type Config struct {
 	RootPackageJSON *fs.PackageJSON
 	// Current Working Directory
 	Cwd fs.AbsolutePath
+
+	UsePreflight      bool
+	MaxClientFailures uint64
 }
 
 // IsLoggedIn returns true if we have a token and either a team id or team slug
@@ -194,8 +198,7 @@ func ParseAndValidate(args []string, ui cli.Ui, turboVersion string) (c *Config,
 		Output: output,
 	})
 
-	maxRemoteFailCount := 3
-	apiClient := client.NewClient(partialConfig.ApiUrl, logger, turboVersion, partialConfig.TeamId, partialConfig.TeamSlug, uint64(maxRemoteFailCount), usePreflight)
+	maxRemoteFailCount := uint64(3)
 
 	c = &Config{
 		Logger:       logger,
@@ -204,7 +207,6 @@ func ParseAndValidate(args []string, ui cli.Ui, turboVersion string) (c *Config,
 		TeamId:       partialConfig.TeamId,
 		ApiUrl:       partialConfig.ApiUrl,
 		LoginUrl:     partialConfig.LoginUrl,
-		ApiClient:    apiClient,
 		TurboVersion: turboVersion,
 		Cache: &CacheConfig{
 			Workers: runtime.NumCPU() + 2,
@@ -212,11 +214,27 @@ func ParseAndValidate(args []string, ui cli.Ui, turboVersion string) (c *Config,
 		RootPackageJSON: rootPackageJSON,
 		TurboJSON:       turboJSON,
 		Cwd:             cwd,
+
+		UsePreflight:      usePreflight,
+		MaxClientFailures: maxRemoteFailCount,
 	}
-
-	c.ApiClient.SetToken(partialConfig.Token)
-
 	return c, nil
+}
+
+// NewClient returns a new ApiClient instance using the values from
+// this Config instance.
+func (c *Config) NewClient() *client.ApiClient {
+	apiClient := client.NewClient(
+		c.ApiUrl,
+		c.Logger,
+		c.TurboVersion,
+		c.TeamId,
+		c.TeamSlug,
+		c.MaxClientFailures,
+		c.UsePreflight,
+	)
+	apiClient.SetToken(c.Token)
+	return apiClient
 }
 
 // Selects the current working directory from OS

--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -124,7 +124,7 @@ func isWorkspaceReference(packageVersion string, dependencyVersion string, cwd s
 
 // WithGraph attaches information about the package dependency graph to the Context instance being
 // constructed.
-func WithGraph(config *config.Config, cacheDir fs.AbsolutePath) Option {
+func WithGraph(config *config.Config, turboJSON *fs.TurboJSON, cacheDir fs.AbsolutePath) Option {
 	return func(c *Context) error {
 		rootpath := config.Cwd.ToStringDuringMigration()
 		c.PackageInfos = make(map[interface{}]*fs.PackageJSON)
@@ -150,7 +150,17 @@ func WithGraph(config *config.Config, cacheDir fs.AbsolutePath) Option {
 			return fmt.Errorf("could not resolve workspaces: %w", err)
 		}
 
-		globalHash, err := calculateGlobalHash(config.Cwd, config.RootPackageJSON, config.TurboJSON.Pipeline, config.TurboJSON.GlobalDependencies, c.PackageManager, config.Logger, os.Environ())
+		// TODO: it seems like calculating the global hash could be separate from
+		// construction of the package-dependency graph
+		globalHash, err := calculateGlobalHash(
+			config.Cwd,
+			config.RootPackageJSON,
+			turboJSON.Pipeline,
+			turboJSON.GlobalDependencies,
+			c.PackageManager,
+			config.Logger,
+			os.Environ(),
+		)
 		if err != nil {
 			return fmt.Errorf("failed to calculate global hash: %v", err)
 		}

--- a/cli/internal/login/link.go
+++ b/cli/internal/login/link.go
@@ -57,13 +57,14 @@ func getCmd(config *config.Config, ui cli.Ui) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			apiClient := config.NewClient()
 			link := &link{
 				ui:                  ui,
 				logger:              config.Logger,
 				cwd:                 config.Cwd,
 				modifyGitIgnore:     !dontModifyGitIgnore,
 				apiURL:              config.ApiUrl,
-				apiClient:           config.ApiClient,
+				apiClient:           apiClient,
 				promptSetup:         promptSetup,
 				promptTeam:          promptTeam,
 				promptEnableCaching: promptEnableCaching,

--- a/cli/internal/login/login.go
+++ b/cli/internal/login/login.go
@@ -63,12 +63,13 @@ func (c *LoginCommand) Run(args []string) int {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			apiClient := c.Config.NewClient()
 			login := login{
 				ui:                  c.UI,
 				logger:              c.Config.Logger,
 				repoRoot:            c.Config.Cwd,
 				openURL:             browser.OpenBrowser,
-				client:              c.Config.ApiClient,
+				client:              apiClient,
 				promptEnableCaching: promptEnableCaching,
 			}
 			if ssoTeam != "" {

--- a/cli/internal/prune/prune.go
+++ b/cli/internal/prune/prune.go
@@ -119,7 +119,11 @@ type prune struct {
 // Prune creates a smaller monorepo with only the required workspaces
 func (p *prune) prune(opts *opts) error {
 	cacheDir := cache.DefaultLocation(p.config.Cwd)
-	ctx, err := context.New(context.WithGraph(p.config, cacheDir))
+	turboJSON, err := fs.ReadTurboConfig(p.config.Cwd, p.config.RootPackageJSON)
+	if err != nil {
+		return err
+	}
+	ctx, err := context.New(context.WithGraph(p.config, turboJSON, cacheDir))
 	if err != nil {
 		return errors.Wrap(err, "could not construct graph")
 	}

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -204,7 +204,13 @@ type run struct {
 
 func (r *run) run(ctx gocontext.Context, targets []string) error {
 	startAt := time.Now()
-	pkgDepGraph, err := context.New(context.WithGraph(r.config, r.opts.cacheOpts.Dir))
+	turboJSON, err := fs.ReadTurboConfig(r.config.Cwd, r.config.RootPackageJSON)
+	if err != nil {
+		return err
+	}
+	// TODO: these values come from a config file, hopefully viper can help us merge these
+	r.opts.cacheOpts.RemoteCacheOpts = turboJSON.RemoteCacheOptions
+	pkgDepGraph, err := context.New(context.WithGraph(r.config, turboJSON, r.opts.cacheOpts.Dir))
 	if err != nil {
 		return err
 	}
@@ -226,7 +232,7 @@ func (r *run) run(ctx gocontext.Context, targets []string) error {
 		return errors.Wrap(err, "Invalid package dependency graph")
 	}
 
-	pipeline := r.config.TurboJSON.Pipeline
+	pipeline := turboJSON.Pipeline
 	if err := validateTasks(pipeline, targets); err != nil {
 		return err
 	}


### PR DESCRIPTION
First commit: 
 * moves `ApiClient` out of `config.Config`. Replaces it with a helper to construct it on demand. Currently all of the values for constructing one still come from a `config.Config` instance. No behavioral change

Second commit:
 * Move `TurboJSON` out of `config.Config`. Instead, read it on demand in `run` and `prune`
 * Behavioral change: running `turbo` in a directory w/o a `turbo.json` will no longer immediately error, so we can display usage / help information. `package.json` is, however, still required as of this change.

Notes on future work: `prune` requires `TurboJSON` because `context.WithGraph` requires it. But `WithGraph` only needs it to construct the global hash value, which isn't needed for constructing the package-dependency graph. If migrate `calculateGlobalHash` to its own top-level function, I think `prune` won't need `turbo.json` at all.