### PR TITLE
Fix `yarn start` not working

### DIFF
--- a/examples/kitchen-sink/apps/blog/package.json
+++ b/examples/kitchen-sink/apps/blog/package.json
@@ -6,7 +6,7 @@
     "build": "remix build",
     "dev": "remix dev",
     "postinstall": "remix setup node",
-    "start": "remix-serve build"
+    "start": "remix-serve api/build"
   },
   "dependencies": {
     "@remix-run/react": "1.0.6",


### PR DESCRIPTION
When trying to run the app using `yarn start` it will fail with the following error:

```
turbo-kitchensink/apps/blog is 📦 v0.0.0 via ⬢ v16.13.1
➜ yarn start
yarn run v1.22.17
$ remix-serve build
node:internal/modules/cjs/loader:936
  throw err;
  ^

Error: Cannot find module '/Users/eli/projects/temp/turbo-kitchensink/apps/blog/build'
```

The issue being the `build` directory isn't at the top level as the script expects.

Changing the script to run `remix-serve api/build` resolves the issue.