### PR TITLE
chore: remove redundant `.turbo`

### DIFF
--- a/examples/design-system/.gitignore
+++ b/examples/design-system/.gitignore
@@ -10,5 +10,4 @@ dist-ssr
 .cache
 server/dist
 public/dist
-.turbo
 storybook-static/


### PR DESCRIPTION
Very minor: there are two `.turbo` declarations - I removed one.