### PR TITLE
chore(examples): update tsconfig declaration val

### DIFF
--- a/examples/basic/packages/tsconfig/nextjs.json
+++ b/examples/basic/packages/tsconfig/nextjs.json
@@ -3,20 +3,17 @@
   "display": "Next.js",
   "extends": "./base.json",
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "declaration": false,
     "allowJs": true,
-    "skipLibCheck": true,
-    "strict": false,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
     "incremental": true,
-    "esModuleInterop": true,
+    "jsx": "preserve",
+    "lib": ["dom", "dom.iterable", "esnext"],
     "module": "esnext",
+    "noEmit": true,
     "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "preserve"
+    "strict": false,
+    "target": "es5"
   },
   "include": ["src", "next-env.d.ts"],
   "exclude": ["node_modules"]

--- a/examples/basic/packages/tsconfig/nextjs.json
+++ b/examples/basic/packages/tsconfig/nextjs.json
@@ -5,6 +5,7 @@
   "compilerOptions": {
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
+    "declaration": false,
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,

--- a/examples/basic/packages/tsconfig/react-library.json
+++ b/examples/basic/packages/tsconfig/react-library.json
@@ -3,9 +3,9 @@
   "display": "React Library",
   "extends": "./base.json",
   "compilerOptions": {
+    "jsx": "react-jsx",
     "lib": ["ES2015"],
     "module": "ESNext",
-    "target": "ES6",
-    "jsx": "react-jsx"
+    "target": "ES6"
   }
 }

--- a/examples/basic/packages/tsconfig/react-library.json
+++ b/examples/basic/packages/tsconfig/react-library.json
@@ -6,6 +6,6 @@
     "jsx": "react-jsx",
     "lib": ["ES2015"],
     "module": "ESNext",
-    "target": "ES6"
+    "target": "es6"
   }
 }

--- a/examples/design-system/packages/acme-tsconfig/node16.json
+++ b/examples/design-system/packages/acme-tsconfig/node16.json
@@ -5,10 +5,6 @@
   "compilerOptions": {
     "lib": ["es2020"],
     "module": "commonjs",
-    "target": "es2020",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "target": "es2020"
   }
 }

--- a/examples/design-system/packages/acme-tsconfig/node16.json
+++ b/examples/design-system/packages/acme-tsconfig/node16.json
@@ -3,8 +3,8 @@
   "display": "Node 16",
   "extends": "./base.json",
   "compilerOptions": {
-    "lib": ["es2020"],
+    "lib": ["ES2020"],
     "module": "commonjs",
-    "target": "es2020"
+    "target": "ES2020"
   }
 }

--- a/examples/design-system/packages/acme-tsconfig/react-library.json
+++ b/examples/design-system/packages/acme-tsconfig/react-library.json
@@ -3,9 +3,9 @@
   "display": "React Library",
   "extends": "./base.json",
   "compilerOptions": {
+    "jsx": "react-jsx",
     "lib": ["dom", "ES2015"],
     "module": "ESNext",
-    "target": "ES6",
-    "jsx": "react-jsx"
+    "target": "ES6"
   }
 }

--- a/examples/design-system/packages/acme-tsconfig/react-library.json
+++ b/examples/design-system/packages/acme-tsconfig/react-library.json
@@ -6,6 +6,6 @@
     "jsx": "react-jsx",
     "lib": ["dom", "ES2015"],
     "module": "ESNext",
-    "target": "ES6"
+    "target": "es6"
   }
 }

--- a/examples/kitchen-sink/apps/blog/tsconfig.json
+++ b/examples/kitchen-sink/apps/blog/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "include": ["remix.env.d.ts", "**/*.ts", "**/*.tsx"],
   "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ES2019"],
+    "lib": ["dom", "dom.iterable", "ES2019"],
     "esModuleInterop": true,
     "jsx": "react-jsx",
     "moduleResolution": "node",

--- a/examples/kitchen-sink/packages/tsconfig/nextjs.json
+++ b/examples/kitchen-sink/packages/tsconfig/nextjs.json
@@ -5,6 +5,7 @@
   "compilerOptions": {
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
+    "declaration": false,
     "allowJs": true,
     "skipLibCheck": true,
     "noEmit": true,

--- a/examples/kitchen-sink/packages/tsconfig/nextjs.json
+++ b/examples/kitchen-sink/packages/tsconfig/nextjs.json
@@ -3,16 +3,15 @@
   "display": "Next.js",
   "extends": "./base.json",
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "declaration": false,
     "allowJs": true,
-    "skipLibCheck": true,
-    "noEmit": true,
-    "module": "esnext",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
+    "declaration": false,
+    "declarationMap": false,
     "incremental": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "module": "esnext",
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "target": "es5"
   }
 }

--- a/examples/kitchen-sink/packages/tsconfig/react-library.json
+++ b/examples/kitchen-sink/packages/tsconfig/react-library.json
@@ -3,9 +3,9 @@
   "display": "React Library",
   "extends": "./base.json",
   "compilerOptions": {
+    "jsx": "react-jsx",
     "lib": ["ES2015"],
     "module": "ESNext",
-    "target": "ES6",
-    "jsx": "react-jsx"
+    "target": "ES6"
   }
 }

--- a/examples/kitchen-sink/packages/tsconfig/react-library.json
+++ b/examples/kitchen-sink/packages/tsconfig/react-library.json
@@ -6,6 +6,6 @@
     "jsx": "react-jsx",
     "lib": ["ES2015"],
     "module": "ESNext",
-    "target": "ES6"
+    "target": "es6"
   }
 }

--- a/examples/kitchen-sink/packages/tsconfig/vite.json
+++ b/examples/kitchen-sink/packages/tsconfig/vite.json
@@ -3,16 +3,15 @@
   "extends": "./base.json",
   "Display": "Vite",
   "compilerOptions": {
-    "target": "ESNext",
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "types": ["vite/client"],
     "allowJs": false,
-    "skipLibCheck": false,
     "esModuleInterop": false,
+    "jsx": "react",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "module": "ESNext",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react"
+    "resolveJsonModule": true,
+    "skipLibCheck": false,
+    "target": "ESNext",
+    "types": ["vite/client"]
   }
 }

--- a/examples/kitchen-sink/packages/tsconfig/vite.json
+++ b/examples/kitchen-sink/packages/tsconfig/vite.json
@@ -6,7 +6,7 @@
     "allowJs": false,
     "esModuleInterop": false,
     "jsx": "react",
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "module": "ESNext",
     "noEmit": true,
     "resolveJsonModule": true,

--- a/examples/with-changesets/packages/acme-tsconfig/nextjs.json
+++ b/examples/with-changesets/packages/acme-tsconfig/nextjs.json
@@ -5,6 +5,7 @@
   "compilerOptions": {
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
+    "declaration": false,
     "allowJs": true,
     "skipLibCheck": true,
     "noEmit": true,

--- a/examples/with-changesets/packages/acme-tsconfig/nextjs.json
+++ b/examples/with-changesets/packages/acme-tsconfig/nextjs.json
@@ -3,18 +3,17 @@
   "display": "Next.js",
   "extends": "./base.json",
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "declaration": false,
     "allowJs": true,
-    "skipLibCheck": true,
-    "noEmit": true,
-    "module": "esnext",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
+    "declaration": false,
+    "declarationMap": false,
     "incremental": true,
     "jsx": "preserve",
-    "rootDir": "src"
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "module": "esnext",
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "rootDir": "src",
+    "target": "es5"
   },
   "include": ["src", "next-env.d.ts"],
   "exclude": ["node_modules"]

--- a/examples/with-changesets/packages/acme-tsconfig/node14.json
+++ b/examples/with-changesets/packages/acme-tsconfig/node14.json
@@ -5,10 +5,6 @@
   "compilerOptions": {
     "lib": ["es2020"],
     "module": "commonjs",
-    "target": "es2020",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "target": "es2020"
   }
 }

--- a/examples/with-changesets/packages/acme-tsconfig/node14.json
+++ b/examples/with-changesets/packages/acme-tsconfig/node14.json
@@ -3,8 +3,8 @@
   "display": "Node 14",
   "extends": "./base.json",
   "compilerOptions": {
-    "lib": ["es2020"],
+    "lib": ["ES2020"],
     "module": "commonjs",
-    "target": "es2020"
+    "target": "ES2020"
   }
 }

--- a/examples/with-changesets/packages/acme-tsconfig/react-library.json
+++ b/examples/with-changesets/packages/acme-tsconfig/react-library.json
@@ -3,9 +3,9 @@
   "display": "React Library",
   "extends": "./base.json",
   "compilerOptions": {
+    "jsx": "react-jsx",
     "lib": ["dom", "ES2015"],
     "module": "ESNext",
-    "target": "ES6",
-    "jsx": "react-jsx"
+    "target": "ES6"
   }
 }

--- a/examples/with-changesets/packages/acme-tsconfig/react-library.json
+++ b/examples/with-changesets/packages/acme-tsconfig/react-library.json
@@ -6,6 +6,6 @@
     "jsx": "react-jsx",
     "lib": ["dom", "ES2015"],
     "module": "ESNext",
-    "target": "ES6"
+    "target": "es6"
   }
 }

--- a/examples/with-pnpm/packages/tsconfig/nextjs.json
+++ b/examples/with-pnpm/packages/tsconfig/nextjs.json
@@ -3,20 +3,17 @@
   "display": "Next.js",
   "extends": "./base.json",
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "declaration": false,
     "allowJs": true,
-    "skipLibCheck": true,
-    "strict": false,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
     "incremental": true,
-    "esModuleInterop": true,
+    "jsx": "preserve",
+    "lib": ["dom", "dom.iterable", "esnext"],
     "module": "esnext",
+    "noEmit": true,
     "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "preserve"
+    "strict": false,
+    "target": "es5"
   },
   "include": ["src", "next-env.d.ts"],
   "exclude": ["node_modules"]

--- a/examples/with-pnpm/packages/tsconfig/nextjs.json
+++ b/examples/with-pnpm/packages/tsconfig/nextjs.json
@@ -5,6 +5,7 @@
   "compilerOptions": {
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
+    "declaration": false,
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,

--- a/examples/with-pnpm/packages/tsconfig/react-library.json
+++ b/examples/with-pnpm/packages/tsconfig/react-library.json
@@ -3,9 +3,9 @@
   "display": "React Library",
   "extends": "./base.json",
   "compilerOptions": {
+    "jsx": "react-jsx",
     "lib": ["ES2015"],
     "module": "ESNext",
-    "target": "ES6",
-    "jsx": "react-jsx"
+    "target": "ES6"
   }
 }

--- a/examples/with-pnpm/packages/tsconfig/react-library.json
+++ b/examples/with-pnpm/packages/tsconfig/react-library.json
@@ -6,6 +6,6 @@
     "jsx": "react-jsx",
     "lib": ["ES2015"],
     "module": "ESNext",
-    "target": "ES6"
+    "target": "es6"
   }
 }

--- a/packages/create-turbo/templates/_shared_ts/packages/tsconfig/react-library.json
+++ b/packages/create-turbo/templates/_shared_ts/packages/tsconfig/react-library.json
@@ -3,9 +3,9 @@
   "display": "React Library",
   "extends": "./base.json",
   "compilerOptions": {
+    "jsx": "react-jsx",
     "lib": ["ES2015"],
     "module": "ESNext",
-    "target": "ES6",
-    "jsx": "react-jsx"
+    "target": "es6"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/vercel/turborepo/issues/1446

This also:
- Alphabetically sorts all keys in TS config compiler options
- Removes redundant keys (keys with the same value specified both in the base config and an inheriting child config)