### PR TITLE
Depending on root tasks should work

### DIFF
--- a/cli/internal/core/scheduler.go
+++ b/cli/internal/core/scheduler.go
@@ -142,6 +142,9 @@ func (p *Scheduler) generateTaskGraph(pkgs []string, taskNames []string, tasksOn
 		taskId := traversalQueue[0]
 		traversalQueue = traversalQueue[1:]
 		pkg, taskName := util.GetPackageTaskFromId(taskId)
+		if pkg == util.RootPkgName && !p.rootEnabledTasks.Includes(taskName) {
+			return fmt.Errorf("%v needs an entry in turbo.json before it can be depended on because it is a task run from the root package", taskId)
+		}
 		task, err := p.getTaskDefinition(pkg, taskName, taskId)
 		if err != nil {
 			return err


### PR DESCRIPTION
Fixes #1471 

Previously, declaring a dependency on a root task would error due to the package-dependency graph (`TopologicGraph`) not including the root package. Special case the root package.

Included some more tests for scheduler behavior:
 * a task depending on a root task
   * should work if the root package has been opted in to that task
   * should fail if the root package has not been opted in to that task
 * depending on a task that doesn't exist should be an error (e.g. `foo#special-task` exists and depends on `bar#special-task`, which does not exist, and there is no top-level `"special-task"` entry)