### PR TITLE
fix(yarn): correct argSeparator for yarn >=1.0 invocations

### DIFF
--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -710,6 +710,10 @@ func (r *run) executeTasks(ctx gocontext.Context, g *completeGraph, rs *runSpec,
 		// vs if we tried to call "args = append(args, nil...)", which would not work. This could
 		// just as easily be []string{}, but the style guide says to prefer nil for empty slices.
 		argSeparator = nil
+	} else if is1PlusYarn, err := util.Is1PlusYarn(packageManager.Name); err != nil {
+		return errors.Wrap(err, "determining yarn version")
+	} else if is1PlusYarn {
+		argSeparator = nil
 	}
 	ec := &execContext{
 		colorCache:     colorCache,

--- a/cli/internal/util/backends.go
+++ b/cli/internal/util/backends.go
@@ -47,6 +47,7 @@ func mustCompileSemverConstraint(text string) *semver.Constraints {
 }
 
 var _pnpmPre7Constraint = mustCompileSemverConstraint(">=7.0.0")
+var _yarn1PlusConstraint = mustCompileSemverConstraint(">=1.0.0")
 
 // Is7PlusPnpm returns true if the given backend is both nodejs-pnpm *AND*
 // is version >=7.0.0
@@ -62,6 +63,23 @@ func Is7PlusPnpm(backedName string) (bool, error) {
 			return false, errors.Wrapf(err, "parsing semver for %v", versionRaw)
 		}
 		return _pnpmPre7Constraint.Check(version), nil
+	}
+	return false, nil
+}
+
+// Is1PlusYarn returns whether the active yarn installation is >=1
+func Is1PlusYarn(backedName string) (bool, error) {
+	if IsYarn(backedName) {
+		out, err := exec.Command("yarn", "--version").CombinedOutput()
+		if err != nil {
+			return false, err
+		}
+		versionRaw := strings.TrimSpace(string(out))
+		version, err := semver.NewVersion(versionRaw)
+		if err != nil {
+			return false, errors.Wrapf(err, "parsing semver for %v", versionRaw)
+		}
+		return _yarn1PlusConstraint.Check(version), nil
 	}
 	return false, nil
 }


### PR DESCRIPTION
# Problem

See #1477

# Solution

Detect >=1.0 `yarn` invocations, and drop the separator on detection

# ToDo

- [ ] tests