### PR TITLE
Fix tailwind example

### DIFF
--- a/examples/with-tailwind/packages/ui/package.json
+++ b/examples/with-tailwind/packages/ui/package.json
@@ -4,7 +4,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./dist"
+    ".": "./dist",
+    "./styles.css": "./dist/styles.css"
   },
   "license": "MIT",
   "scripts": {
@@ -24,7 +25,7 @@
     "eslint-config-custom": "*",
     "npm-run-all": "^4.1.5",
     "react": "^17.0.2",
-    "tailwind": "^4.0.0",
+    "tailwindcss": "^3.1.5",
     "tailwind-config": "*",
     "tsconfig": "*",
     "tsup": "^6.1.3",


### PR DESCRIPTION
The wrong npm package was installed in the tailwind example `tailwind` => `tailwindcss`.

I also added exports field for styles.css as it was not found from within the `_app.tsx` in next applications, but I am not sure if this is required.

```
web:dev: error - ./pages/_app.tsx:3:0
web:dev: Module not found: Package path ./styles.css is not exported from package
~/turborepo/examples/with-tailwind/node_modules/ui (see exports field in ~/turborepo/examples/with-tailwind/node_modules/ui/package.json)
```