### PR TITLE
feat(examples): add nextjs

### DIFF
--- a/examples/with-nextjs/README.md
+++ b/examples/with-nextjs/README.md
@@ -1,0 +1,9 @@
+The following turborepo examples contain [Next.js](https://nextjs.org) applications:
+
+1. [basic](../basic/)
+1. [design-system](../design-system/)
+1. [kitchen-sink](../kitchen-sink/)
+1. [with-changesets](../with-changesets/)
+1. [with-pnpm](../with-pnpm/)
+1. [with-react-native-web](../with-react-native-web/)
+1. [with-tailwind](../with-tailwind/)


### PR DESCRIPTION
Add a `with-nextjs` directory with pointers to other examples that contain `Next.js` applications.