### PR TITLE
Typo: verifcation --> verification

### DIFF
--- a/cli/internal/cache/cache_http.go
+++ b/cli/internal/cache/cache_http.go
@@ -198,11 +198,11 @@ func (cache *httpCache) retrieve(hash string) (bool, []string, int, error) {
 		}
 		b, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return false, nil, 0, fmt.Errorf("artifact verifcation failed: %w", err)
+			return false, nil, 0, fmt.Errorf("artifact verification failed: %w", err)
 		}
 		isValid, err := cache.signerVerifier.validate(hash, b, expectedTag)
 		if err != nil {
-			return false, nil, 0, fmt.Errorf("artifact verifcation failed: %w", err)
+			return false, nil, 0, fmt.Errorf("artifact verification failed: %w", err)
 		}
 		if !isValid {
 			err = fmt.Errorf("artifact verification failed: artifact tag does not match expected tag %s", expectedTag)

--- a/docs/pages/blog/turbo-1-2-0.mdx
+++ b/docs/pages/blog/turbo-1-2-0.mdx
@@ -92,7 +92,7 @@ To enable this feature, set the `remoteCache` options in your `turbo.json` confi
 {
   "$schema": "[https://turborepo.org/schema.json](https://turborepo.org/schema.json)",
   "remoteCache": {
-    // Indicates if signature verifcation is enabled.
+    // Indicates if signature verification is enabled.
     "signature": true
   }
 }

--- a/docs/pages/docs/core-concepts/remote-caching.mdx
+++ b/docs/pages/docs/core-concepts/remote-caching.mdx
@@ -67,7 +67,7 @@ To enable this feature, set the `remoteCache` options on your turbo config to in
 {
   "$schema": "https://turborepo.org/schema.json",
   "remoteCache": {
-    // Indicates if signature verifcation is enabled.
+    // Indicates if signature verification is enabled.
     "signature": true
   }
 }


### PR DESCRIPTION
**summary**
While reading the TurboRepo docs I found a typo on the [Remote Caching](https://turborepo.org/docs/core-concepts/remote-caching) page. 
Searched for the typo and found it in a few more places.