### PR TITLE
feat(examples): add docker

### DIFF
--- a/examples/with-docker/.eslintrc.js
+++ b/examples/with-docker/.eslintrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+  root: true,
+  // This tells ESLint to load the config from the package `eslint-config-custom`
+  extends: ["custom"],
+  settings: {
+    next: {
+      rootDir: ["apps/*/"],
+    },
+  },
+};

--- a/examples/with-docker/.gitignore
+++ b/examples/with-docker/.gitignore
@@ -1,0 +1,36 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+node_modules
+.pnp
+.pnp.js
+
+# testing
+coverage
+
+# next.js
+.next/
+out/
+build
+
+# other
+dist/
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# turbo
+.turbo

--- a/examples/with-docker/README.md
+++ b/examples/with-docker/README.md
@@ -1,0 +1,54 @@
+# Turborepo Docker starter
+
+This is an official starter Turborepo.
+
+## What's inside?
+
+This turborepo uses [Yarn](https://classic.yarnpkg.com/lang/en/) as a package manager. It includes the following packages/apps:
+
+### Apps and Packages
+
+- `web`: a [Next.js](https://nextjs.org) app
+- `api`: an [Express](https://expressjs.com/) server
+- `ui`: ui: a React component library
+- `eslint-config-custom`: `eslint` configurations for client side applications (includes `eslint-config-next` and `eslint-config-prettier`)
+- `eslint-config-custom-server`: `eslint` configurations for server side applications (includes `eslint-config-next` and `eslint-config-prettier`)
+- `scripts`: Jest configurations
+- `logger`: Isomorphic logger (a small wrapper around console.log)
+- `tsconfig`: tsconfig.json;s used throughout the monorepo
+
+Each package/app is 100% [TypeScript](https://www.typescriptlang.org/).
+
+### Docker
+
+This repo is configured to be built with Docker, and Docker compose. To build all apps in this repo:
+
+```
+# Create a network, which allows containers to communicate
+# with each other, by using their container name as a hostname
+docker network create app_network
+
+# Build prod using new BuildKit engine
+COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -f docker-compose.yml build --parallel
+
+# Start prod in detached mode
+docker-compose -f docker-compose.yml up -d
+```
+
+Open http://localhost:3000.
+
+To shutdown all running containers:
+
+```
+# Stop all running containers
+docker kill $(docker ps -q) && docker rm $(docker ps -a -q)
+```
+
+### Utilities
+
+This Turborepo has some additional tools already setup for you:
+
+- [TypeScript](https://www.typescriptlang.org/) for static type checking
+- [ESLint](https://eslint.org/) for code linting
+- [Jest](https://jestjs.io) test runner for all things JavaScript
+- [Prettier](https://prettier.io) for code formatting

--- a/examples/with-docker/apps/api/.eslintrc.js
+++ b/examples/with-docker/apps/api/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ["custom-server"],
+};

--- a/examples/with-docker/apps/api/Dockerfile
+++ b/examples/with-docker/apps/api/Dockerfile
@@ -1,0 +1,32 @@
+FROM node:alpine AS builder
+RUN apk update
+# Set working directory
+WORKDIR /app
+RUN yarn global add turbo
+COPY . .
+RUN turbo prune --scope=api --docker
+
+# Add lockfile and package.json's of isolated subworkspace
+FROM node:alpine AS installer
+RUN apk update
+WORKDIR /app
+COPY --from=builder /app/out/json/ .
+COPY --from=builder /app/out/yarn.lock ./yarn.lock
+COPY --from=builder /app/out/full/ .
+COPY .gitignore .gitignore
+COPY turbo.json turbo.json
+
+RUN yarn install
+RUN yarn turbo run build --filter=api...
+
+FROM node:alpine AS runner
+WORKDIR /app
+
+# Don't run production as root
+RUN addgroup --system --gid 1001 expressjs
+RUN adduser --system --uid 1001 expressjs
+USER expressjs
+COPY --from=installer /app .
+
+CMD node apps/api/dist/index.js
+

--- a/examples/with-docker/apps/api/package.json
+++ b/examples/with-docker/apps/api/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "api",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "test": "jest --detectOpenHandles",
+    "dev": "nodemon --exec \"node -r esbuild-register ./src/index.ts\" -e .ts",
+    "start": "node -r esbuild-register ./src/index.ts",
+    "build": "tsc",
+    "lint": "tsc --noEmit && TIMING=1 eslint src/**/*.ts* --fix",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "@types/body-parser": "^1.19.0",
+    "@types/cors": "^2.8.10",
+    "@types/express": "^4.17.12",
+    "@types/jest": "^26.0.22",
+    "@types/morgan": "^1.9.2",
+    "@types/node": "^15.12.2",
+    "@types/supertest": "^2.0.11",
+    "esbuild": "^0.14.38",
+    "esbuild-register": "^3.3.2",
+    "nodemon": "^2.0.15",
+    "scripts": "*",
+    "jest": "^26.6.3",
+    "eslint": "^7.32.0",
+    "eslint-config-custom": "*",
+    "supertest": "^6.1.3",
+    "tsconfig": "*",
+    "typescript": "^4.5.3"
+  },
+  "jest": {
+    "preset": "scripts/jest/node"
+  },
+  "dependencies": {
+    "body-parser": "^1.19.0",
+    "cors": "^2.8.5",
+    "express": "^4.17.1",
+    "logger": "*",
+    "morgan": "^1.10.0"
+  }
+}

--- a/examples/with-docker/apps/api/src/__tests__/server.test.ts
+++ b/examples/with-docker/apps/api/src/__tests__/server.test.ts
@@ -1,0 +1,22 @@
+import supertest from "supertest";
+import { createServer } from "../server";
+
+describe("server", () => {
+  it("health check returns 200", async () => {
+    await supertest(createServer())
+      .get("/healthz")
+      .expect(200)
+      .then((res) => {
+        expect(res.body.ok).toBe(true);
+      });
+  });
+
+  it("message endpoint says hello", async () => {
+    await supertest(createServer())
+      .get("/message/jared")
+      .expect(200)
+      .then((res) => {
+        expect(res.body).toEqual({ message: "hello jared" });
+      });
+  });
+});

--- a/examples/with-docker/apps/api/src/__tests__/tsconfig.json
+++ b/examples/with-docker/apps/api/src/__tests__/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [".", "../."]
+}

--- a/examples/with-docker/apps/api/src/index.ts
+++ b/examples/with-docker/apps/api/src/index.ts
@@ -1,0 +1,9 @@
+import { createServer } from "./server";
+import { log } from "logger";
+
+const port = process.env.PORT || 3001;
+const server = createServer();
+
+server.listen(port, () => {
+  log(`api running on ${port}`);
+});

--- a/examples/with-docker/apps/api/src/server.ts
+++ b/examples/with-docker/apps/api/src/server.ts
@@ -1,0 +1,22 @@
+import { json, urlencoded } from "body-parser";
+import express from "express";
+import morgan from "morgan";
+import cors from "cors";
+
+export const createServer = () => {
+  const app = express();
+  app
+    .disable("x-powered-by")
+    .use(morgan("dev"))
+    .use(urlencoded({ extended: true }))
+    .use(json())
+    .use(cors())
+    .get("/message/:name", (req, res) => {
+      return res.json({ message: `hello ${req.params.name}` });
+    })
+    .get("/healthz", (req, res) => {
+      return res.json({ ok: true });
+    });
+
+  return app;
+};

--- a/examples/with-docker/apps/api/tsconfig.json
+++ b/examples/with-docker/apps/api/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "lib": ["ES2015"],
+    "module": "CommonJS",
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "exclude": ["node_modules"],
+  "extends": "tsconfig/base.json",
+  "include": ["src"]
+}

--- a/examples/with-docker/apps/web/.eslintrc.js
+++ b/examples/with-docker/apps/web/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ["custom"],
+};

--- a/examples/with-docker/apps/web/Dockerfile
+++ b/examples/with-docker/apps/web/Dockerfile
@@ -1,0 +1,38 @@
+FROM node:alpine AS builder
+RUN apk update
+# Set working directory
+WORKDIR /app
+RUN yarn global add turbo
+COPY . .
+RUN turbo prune --scope=web --docker
+
+# Add lockfile and package.json's of isolated subworkspace
+FROM node:alpine AS installer
+RUN apk update
+WORKDIR /app
+COPY --from=builder /app/out/json/ .
+COPY --from=builder /app/out/yarn.lock ./yarn.lock
+COPY --from=builder /app/out/full/ .
+COPY .gitignore .gitignore
+COPY turbo.json turbo.json
+
+RUN yarn install
+RUN yarn turbo run build --filter=web...
+
+FROM node:alpine AS runner
+WORKDIR /app
+
+# Don't run production as root
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+USER nextjs
+
+COPY --from=installer /app/apps/web/next.config.js .
+COPY --from=installer /app/apps/web/package.json .
+
+# Automatically leverage output traces to reduce image size 
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=installer --chown=nextjs:nodejs /app/apps/web/.next/standalone ./
+COPY --from=installer --chown=nextjs:nodejs /app/apps/web/.next/static ./apps/web/.next/static
+
+CMD node apps/web/server.js

--- a/examples/with-docker/apps/web/README.md
+++ b/examples/with-docker/apps/web/README.md
@@ -1,0 +1,30 @@
+## Getting Started
+
+First, run the development server:
+
+```bash
+yarn dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+You can start editing the page by modifying `pages/index.js`. The page auto-updates as you edit the file.
+
+[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.js`.
+
+The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
+
+## Learn More
+
+To learn more about Next.js, take a look at the following resources:
+
+- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
+- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+
+You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
+
+## Deploy on Vercel
+
+The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_source=github.com&utm_medium=referral&utm_campaign=turborepo-readme) from the creators of Next.js.
+
+Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.

--- a/examples/with-docker/apps/web/next-env.d.ts
+++ b/examples/with-docker/apps/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/examples/with-docker/apps/web/next.config.js
+++ b/examples/with-docker/apps/web/next.config.js
@@ -1,0 +1,10 @@
+const withTM = require("next-transpile-modules")(["ui"]);
+const path = require("path");
+
+module.exports = withTM({
+  reactStrictMode: true,
+  output: "standalone",
+  experimental: {
+    outputFileTracingRoot: path.join(__dirname, "../../"),
+  },
+});

--- a/examples/with-docker/apps/web/package.json
+++ b/examples/with-docker/apps/web/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "web",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
+    "ui": "*"
+  },
+  "devDependencies": {
+    "eslint": "7.32.0",
+    "eslint-config-custom": "*",
+    "next-transpile-modules": "9.0.0",
+    "tsconfig": "*",
+    "@types/node": "^17.0.12",
+    "@types/react": "17.0.37",
+    "typescript": "^4.5.3"
+  }
+}

--- a/examples/with-docker/apps/web/src/pages/index.tsx
+++ b/examples/with-docker/apps/web/src/pages/index.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+import { Button } from "ui";
+
+const API_HOST = process.env.NEXT_PUBLIC_API_HOST || "http://localhost:3001";
+
+export default function Web() {
+  const [name, setName] = useState<string>("");
+  const [response, setResponse] = useState<{ message: string } | null>(null);
+  const [error, setError] = useState<string | undefined>();
+
+  useEffect(() => {
+    setResponse(null);
+    setError(undefined);
+  }, [name]);
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) =>
+    setName(e.target.value);
+
+  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    try {
+      const result = await fetch(`${API_HOST}/message/${name}`);
+      const response = await result.json();
+      setResponse(response);
+    } catch (err) {
+      console.error(err);
+      setError("Unable to fetch response");
+    }
+  };
+
+  const onReset = () => {
+    setName("");
+  };
+
+  return (
+    <div>
+      <h1>Web</h1>
+      <form onSubmit={onSubmit}>
+        <label htmlFor="name">Name </label>
+        <input
+          type="text"
+          name="name"
+          id="name"
+          value={name}
+          onChange={onChange}
+        ></input>
+        <Button type="submit">Submit</Button>
+      </form>
+      {error && (
+        <div>
+          <h3>Error</h3>
+          <p>{error}</p>
+        </div>
+      )}
+      {response && (
+        <div>
+          <h3>Greeting</h3>
+          <p>{response.message}</p>
+          <Button onClick={onReset}>Reset</Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/examples/with-docker/apps/web/tsconfig.json
+++ b/examples/with-docker/apps/web/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "tsconfig/nextjs.json",
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/examples/with-docker/package.json
+++ b/examples/with-docker/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "with-docker",
+  "version": "0.0.0",
+  "private": true,
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "scripts": {
+    "build": "turbo run build",
+    "dev": "turbo run dev --parallel",
+    "lint": "turbo run lint",
+    "test": "turbo run test",
+    "clean": "turbo run clean",
+    "format": "prettier --write \"**/*.{ts,tsx,md}\""
+  },
+  "devDependencies": {
+    "eslint-config-custom": "*",
+    "prettier": "latest",
+    "turbo": "latest"
+  },
+  "engines": {
+    "npm": ">=7.0.0",
+    "node": ">=14.0.0"
+  },
+  "dependencies": {},
+  "packageManager": "yarn@1.22.15"
+}

--- a/examples/with-docker/packages/eslint-config-custom-server/index.js
+++ b/examples/with-docker/packages/eslint-config-custom-server/index.js
@@ -1,0 +1,19 @@
+module.exports = {
+  extends: ["eslint:recommended"],
+  env: {
+    node: true,
+    es6: true,
+  },
+  parserOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module",
+  },
+  overrides: [
+    {
+      files: ["**/__tests__/**/*"],
+      env: {
+        jest: true,
+      },
+    },
+  ],
+};

--- a/examples/with-docker/packages/eslint-config-custom-server/package.json
+++ b/examples/with-docker/packages/eslint-config-custom-server/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "eslint-config-custom-server",
+  "version": "0.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "eslint": "^7.32.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/examples/with-docker/packages/eslint-config-custom/index.js
+++ b/examples/with-docker/packages/eslint-config-custom/index.js
@@ -1,0 +1,8 @@
+module.exports = {
+  extends: ["next"],
+  settings: {
+    react: {
+      version: "detect",
+    },
+  },
+};

--- a/examples/with-docker/packages/eslint-config-custom/package.json
+++ b/examples/with-docker/packages/eslint-config-custom/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "eslint-config-custom",
+  "version": "0.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "eslint-config-next": "^12.0.8",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-react": "7.28.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/examples/with-docker/packages/logger/.eslintrc.js
+++ b/examples/with-docker/packages/logger/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ["custom"],
+};

--- a/examples/with-docker/packages/logger/package.json
+++ b/examples/with-docker/packages/logger/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "logger",
+  "version": "0.0.0",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "source": "./src/index.ts",
+  "private": true,
+  "files": [
+    "dist/**"
+  ],
+  "scripts": {
+    "test": "jest",
+    "dev": "tsc -w",
+    "build": "tsc",
+    "lint": "TIMING=1 eslint src/**/*.ts* --fix",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "@types/jest": "^26.0.22",
+    "scripts": "*",
+    "jest": "^26.6.3",
+    "eslint": "^7.32.0",
+    "eslint-config-custom": "*",
+    "tsconfig": "*",
+    "typescript": "^4.5.3"
+  },
+  "jest": {
+    "preset": "scripts/jest/node"
+  }
+}

--- a/examples/with-docker/packages/logger/src/__tests__/log.test.ts
+++ b/examples/with-docker/packages/logger/src/__tests__/log.test.ts
@@ -1,0 +1,10 @@
+import { log } from "..";
+
+jest.spyOn(global.console, "log");
+
+describe("logger", () => {
+  it("prints a message", () => {
+    log("hello");
+    expect(console.log).toBeCalled();
+  });
+});

--- a/examples/with-docker/packages/logger/src/__tests__/tsconfig.json
+++ b/examples/with-docker/packages/logger/src/__tests__/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [".", "../."]
+}

--- a/examples/with-docker/packages/logger/src/index.ts
+++ b/examples/with-docker/packages/logger/src/index.ts
@@ -1,0 +1,3 @@
+export const log = (str: any) => {
+  console.log("logger: " + str);
+};

--- a/examples/with-docker/packages/logger/tsconfig.json
+++ b/examples/with-docker/packages/logger/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "lib": ["ES2015"],
+    "module": "CommonJS",
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "exclude": ["node_modules"],
+  "extends": "tsconfig/base.json",
+  "include": ["src"]
+}

--- a/examples/with-docker/packages/scripts/jest/node/jest-preset.js
+++ b/examples/with-docker/packages/scripts/jest/node/jest-preset.js
@@ -1,0 +1,13 @@
+module.exports = {
+  roots: ["<rootDir>"],
+  transform: {
+    "^.+\\.tsx?$": "ts-jest",
+  },
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+  modulePathIgnorePatterns: [
+    "<rootDir>/test/__fixtures__",
+    "<rootDir>/node_modules",
+    "<rootDir>/dist",
+  ],
+  preset: "ts-jest",
+};

--- a/examples/with-docker/packages/scripts/jest/root/jest-preset.js
+++ b/examples/with-docker/packages/scripts/jest/root/jest-preset.js
@@ -1,0 +1,20 @@
+module.exports = {
+  transform: {
+    ".(ts|tsx)$": "ts-jest",
+    ".(js|jsx)$": "babel-jest", // jest's default
+  },
+  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+  projects: [
+    "<rootDir>/packages/*",
+    "<rootDir>/playground/*",
+    "<rootDir>/apps/*",
+  ],
+  coverageDirectory: "<rootDir>/coverage/",
+  collectCoverageFrom: ["<rootDir>/packages/*/src/**/*.{ts,tsx}"],
+  testURL: "http://localhost/",
+  moduleNameMapper: {
+    ".json$": "identity-obj-proxy",
+  },
+  moduleDirectories: ["node_modules"],
+};

--- a/examples/with-docker/packages/scripts/package.json
+++ b/examples/with-docker/packages/scripts/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "scripts",
+  "version": "0.0.0",
+  "license": "MIT",
+  "main": "index.js",
+  "private": true,
+  "files": [
+    "jest"
+  ],
+  "scripts": {
+    "clean": "rm -rf .turbo && rm -rf node_modules"
+  },
+  "dependencies": {
+    "@typescript-eslint/eslint-plugin": "^4.0.0",
+    "@typescript-eslint/parser": "^4.0.0",
+    "babel-eslint": "^10.0.0",
+    "eslint-config-react-app": "^6.0.0",
+    "eslint-plugin-flowtype": "^5.2.0",
+    "eslint-plugin-import": "^2.22.0",
+    "eslint-plugin-jest": "23.13.1",
+    "eslint-plugin-jsx-a11y": "^6.3.1",
+    "eslint-plugin-react": "^7.20.3",
+    "eslint-plugin-react-hooks": "^4.0.8",
+    "ts-jest": "^26.5.0"
+  },
+  "devDependencies": {
+    "typescript": "^4.5.3"
+  }
+}

--- a/examples/with-docker/packages/tsconfig/README.md
+++ b/examples/with-docker/packages/tsconfig/README.md
@@ -1,0 +1,3 @@
+# `tsconfig`
+
+These are base shared `tsconfig.json`s from which all other `tsconfig.json`'s inherit from.

--- a/examples/with-docker/packages/tsconfig/base.json
+++ b/examples/with-docker/packages/tsconfig/base.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Default",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "inlineSources": false,
+    "isolatedModules": true,
+    "moduleResolution": "node",
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "preserveWatchOutput": true,
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "exclude": ["node_modules"]
+}

--- a/examples/with-docker/packages/tsconfig/nextjs.json
+++ b/examples/with-docker/packages/tsconfig/nextjs.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Next.js",
+  "extends": "./base.json",
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["src", "next-env.d.ts"],
+  "exclude": ["node_modules"]
+}

--- a/examples/with-docker/packages/tsconfig/package.json
+++ b/examples/with-docker/packages/tsconfig/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "tsconfig",
+  "version": "0.0.0",
+  "private": true,
+  "main": "index.js",
+  "files": [
+    "base.json",
+    "nextjs.json",
+    "react-library.json"
+  ]
+}

--- a/examples/with-docker/packages/tsconfig/react-library.json
+++ b/examples/with-docker/packages/tsconfig/react-library.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "React Library",
+  "extends": "./base.json",
+  "compilerOptions": {
+    "lib": ["ES2015"],
+    "module": "ESNext",
+    "target": "ES6",
+    "jsx": "react-jsx"
+  }
+}

--- a/examples/with-docker/packages/ui/Button.tsx
+++ b/examples/with-docker/packages/ui/Button.tsx
@@ -1,0 +1,9 @@
+import * as React from "react";
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children: React.ReactNode;
+}
+
+export const Button = ({ children, ...rest }: ButtonProps) => {
+  return <button {...rest}>{children}</button>;
+};

--- a/examples/with-docker/packages/ui/index.tsx
+++ b/examples/with-docker/packages/ui/index.tsx
@@ -1,0 +1,2 @@
+import * as React from "react";
+export * from "./Button";

--- a/examples/with-docker/packages/ui/package.json
+++ b/examples/with-docker/packages/ui/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "ui",
+  "version": "0.0.0",
+  "main": "./index.tsx",
+  "types": "./index.tsx",
+  "license": "MIT",
+  "scripts": {
+    "lint": "eslint *.ts*"
+  },
+  "devDependencies": {
+    "@types/react": "^17.0.37",
+    "@types/react-dom": "^17.0.11",
+    "eslint": "^7.32.0",
+    "eslint-config-custom": "*",
+    "react": "^17.0.2",
+    "tsconfig": "*",
+    "typescript": "^4.5.2"
+  }
+}

--- a/examples/with-docker/packages/ui/tsconfig.json
+++ b/examples/with-docker/packages/ui/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "tsconfig/react-library.json",
+  "include": ["."],
+  "exclude": ["dist", "build", "node_modules"]
+}

--- a/examples/with-docker/turbo.json
+++ b/examples/with-docker/turbo.json
@@ -1,0 +1,22 @@
+{
+  "pipeline": {
+    "build": {
+      "outputs": ["dist/**", ".next/**", "public/dist/**"],
+      "dependsOn": ["^build", "$NEXT_PUBLIC_API_HOST"]
+    },
+    "test": {
+      "outputs": ["coverage/**"],
+      "dependsOn": []
+    },
+    "lint": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+    "dev": {
+      "cache": false
+    },
+    "clean": {
+      "cache": false
+    }
+  }
+}

--- a/examples/with-nextjs/README.md
+++ b/examples/with-nextjs/README.md
@@ -4,6 +4,7 @@ The following turborepo examples contain [Next.js](https://nextjs.org) applicati
 1. [design-system](../design-system/)
 1. [kitchen-sink](../kitchen-sink/)
 1. [with-changesets](../with-changesets/)
+1. [with-docker](../docker/)
 1. [with-pnpm](../with-pnpm/)
 1. [with-react-native-web](../with-react-native-web/)
 1. [with-tailwind](../with-tailwind/)


### PR DESCRIPTION
Docker example including a Next.js app which makes API requests to an Express API.

Can be built individually or via docker-compose (see `README.md`)