### PR TITLE
Fix package substrings for getChangedPackages

### DIFF
--- a/cli/internal/scope/scope.go
+++ b/cli/internal/scope/scope.go
@@ -204,7 +204,8 @@ func getChangedPackages(changedFiles []string, packageInfos map[interface{}]*fs.
 	for _, changedFile := range changedFiles {
 		found := false
 		for pkgName, pkgInfo := range packageInfos {
-			if pkgName != util.RootPkgName && strings.HasPrefix(changedFile, pkgInfo.Dir) {
+			// Add trailing slash to avoid package substring conflicts: (e.g. react, react-dom)
+			if pkgName != util.RootPkgName && strings.HasPrefix(changedFile, pkgInfo.Dir+"/") {
 				changedPackages.Add(pkgName)
 				found = true
 				break

--- a/cli/internal/scope/scope_test.go
+++ b/cli/internal/scope/scope_test.go
@@ -197,6 +197,12 @@ func TestResolvePackages(t *testing.T) {
 			includeDependents: true,
 			since:             "dummy",
 		},
+		{
+			name:     "substring package name, build both",
+			changed:  []string{"app/a/src/index.ts", "app/a-service/src/index.ts"},
+			expected: []string{"a", "a-service"},
+			since:    "dummy",
+		},
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("test #%v %v", i, tc.name), func(t *testing.T) {


### PR DESCRIPTION
See https://github.com/vercel/turborepo/issues/1528

Changed files belonging to a package which was a substring of another package (e.g. `react`, `react-dom`) were sometimes not included in the turbo changed packages.

I haven't worked much in Golang, let me know if there's a more idiomatic way to handle this.