### PR TITLE
Filter in package

### DIFF
--- a/cli/internal/scope/scope.go
+++ b/cli/internal/scope/scope.go
@@ -3,6 +3,7 @@ package scope
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/hashicorp/go-hclog"
@@ -175,8 +176,8 @@ func repoGlobalFileHasChanged(opts *Opts, changedFiles []string) (bool, error) {
 	}
 
 	if globalDepsGlob != nil {
-		for _, f := range changedFiles {
-			if globalDepsGlob.Match(f) {
+		for _, file := range changedFiles {
+			if globalDepsGlob.Match(filepath.ToSlash(file)) {
 				return true, nil
 			}
 		}
@@ -185,6 +186,8 @@ func repoGlobalFileHasChanged(opts *Opts, changedFiles []string) (bool, error) {
 }
 
 func filterIgnoredFiles(opts *Opts, changedFiles []string) ([]string, error) {
+	// changedFiles is an array of repo-relative system paths.
+	// opts.IgnorePatterns is an array of unix-separator glob paths.
 	ignoreGlob, err := filter.Compile(opts.IgnorePatterns)
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid ignore globs")
@@ -193,7 +196,7 @@ func filterIgnoredFiles(opts *Opts, changedFiles []string) ([]string, error) {
 	for _, file := range changedFiles {
 		// If we don't have anything to ignore, or if this file doesn't match the ignore pattern,
 		// keep it as a changed file.
-		if ignoreGlob == nil || !ignoreGlob.Match(file) {
+		if ignoreGlob == nil || !ignoreGlob.Match(filepath.ToSlash(file)) {
 			filteredChanges = append(filteredChanges, file)
 		}
 	}

--- a/cli/internal/scope/scope.go
+++ b/cli/internal/scope/scope.go
@@ -2,7 +2,6 @@ package scope
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/hashicorp/go-hclog"
@@ -218,7 +217,7 @@ func fileInPackage(changedFile string, packagePath string) bool {
 		// We know changedFile is longer than packagePath.
 		// We can safely directly index into it.
 		// Look ahead one byte and see if it's the separator.
-		if changedFile[prefixLen] == os.PathSeparator {
+		if changedFile[prefixLen] == '/' {
 			return true
 		}
 	}

--- a/cli/internal/scope/scope.go
+++ b/cli/internal/scope/scope.go
@@ -2,7 +2,6 @@ package scope
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/hashicorp/go-hclog"
@@ -200,25 +199,12 @@ func filterIgnoredFiles(opts *Opts, changedFiles []string) ([]string, error) {
 	return filteredChanges, nil
 }
 
-func fileIncludesDir(changedFile string, dir string) bool {
-	const separator = string(os.PathSeparator)
-	filePath := strings.Split(changedFile, separator)
-	dirPath := strings.Split(dir, separator)
-
-	for i, pathSegment := range dirPath {
-		if pathSegment != filePath[i] {
-			return false
-		}
-	}
-	return true
-}
-
 func getChangedPackages(changedFiles []string, packageInfos map[interface{}]*fs.PackageJSON) util.Set {
 	changedPackages := make(util.Set)
 	for _, changedFile := range changedFiles {
 		found := false
 		for pkgName, pkgInfo := range packageInfos {
-			if pkgName != util.RootPkgName && fileIncludesDir(changedFile, pkgInfo.Dir) {
+			if pkgName != util.RootPkgName && strings.HasPrefix(changedFile, pkgInfo.Dir) {
 				changedPackages.Add(pkgName)
 				found = true
 				break

--- a/cli/internal/scope/scope.go
+++ b/cli/internal/scope/scope.go
@@ -2,6 +2,7 @@ package scope
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/hashicorp/go-hclog"
@@ -217,7 +218,7 @@ func fileInPackage(changedFile string, packagePath string) bool {
 		// We know changedFile is longer than packagePath.
 		// We can safely directly index into it.
 		// Look ahead one byte and see if it's the separator.
-		if changedFile[prefixLen] == '/' {
+		if changedFile[prefixLen] == os.PathSeparator {
 			return true
 		}
 	}

--- a/cli/internal/scope/scope.go
+++ b/cli/internal/scope/scope.go
@@ -204,8 +204,7 @@ func getChangedPackages(changedFiles []string, packageInfos map[interface{}]*fs.
 	for _, changedFile := range changedFiles {
 		found := false
 		for pkgName, pkgInfo := range packageInfos {
-			// Add trailing slash to avoid package substring conflicts: (e.g. react, react-dom)
-			if pkgName != util.RootPkgName && strings.HasPrefix(changedFile, pkgInfo.Dir+"/") {
+			if pkgName != util.RootPkgName && strings.HasPrefix(changedFile, pkgInfo.Dir) {
 				changedPackages.Add(pkgName)
 				found = true
 				break

--- a/cli/internal/scope/scope.go
+++ b/cli/internal/scope/scope.go
@@ -204,7 +204,8 @@ func getChangedPackages(changedFiles []string, packageInfos map[interface{}]*fs.
 	for _, changedFile := range changedFiles {
 		found := false
 		for pkgName, pkgInfo := range packageInfos {
-			if pkgName != util.RootPkgName && strings.HasPrefix(changedFile, pkgInfo.Dir) {
+			// Add trailing slash to avoid package substring conflicts: (e.g. react, react-dom)
+			if pkgName != util.RootPkgName && strings.HasPrefix(changedFile, pkgInfo.Dir+"/") {
 				changedPackages.Add(pkgName)
 				found = true
 				break

--- a/cli/internal/scope/scope_test.go
+++ b/cli/internal/scope/scope_test.go
@@ -111,14 +111,6 @@ func TestResolvePackages(t *testing.T) {
 			since:    "dummy",
 		},
 		{
-			// make sure multiple apps with the same prefix are handled separately.
-			// prevents this issue: https://github.com/vercel/turborepo/issues/1528
-			name:     "Two apps with an overlapping prefix changed",
-			changed:  []string{"app/app2/src/index.js", "app/app2-a/src/index.js"},
-			expected: []string{"app2", "app2-a"},
-			since:    "dummy",
-		},
-		{
 			name:     "An ignored package changed",
 			changed:  []string{"libs/libB/src/index.ts"},
 			expected: []string{},
@@ -214,9 +206,11 @@ func TestResolvePackages(t *testing.T) {
 			since:             "dummy",
 		},
 		{
-			name:     "substring package name, build both",
-			changed:  []string{"app/a/src/index.ts", "app/a-service/src/index.ts"},
-			expected: []string{"a", "a-service"},
+			// make sure multiple apps with the same prefix are handled separately.
+			// prevents this issue: https://github.com/vercel/turborepo/issues/1528
+			name:     "Two apps with an overlapping prefix changed",
+			changed:  []string{"app/app2/src/index.js", "app/app2-a/src/index.js"},
+			expected: []string{"app2", "app2-a"},
 			since:    "dummy",
 		},
 	}

--- a/cli/internal/scope/scope_test.go
+++ b/cli/internal/scope/scope_test.go
@@ -56,28 +56,28 @@ func TestResolvePackages(t *testing.T) {
 	graph.Connect(dag.BasicEdge("app2-a", "libC"))
 	packagesInfos := map[interface{}]*fs.PackageJSON{
 		"app0": {
-			Dir: "app/app0",
+			Dir: filepath.FromSlash("app/app0"),
 		},
 		"app1": {
-			Dir: "app/app1",
+			Dir: filepath.FromSlash("app/app1"),
 		},
 		"app2": {
-			Dir: "app/app2",
+			Dir: filepath.FromSlash("app/app2"),
 		},
 		"app2-a": {
-			Dir: "app/app2-a",
+			Dir: filepath.FromSlash("app/app2-a"),
 		},
 		"libA": {
-			Dir: "libs/libA",
+			Dir: filepath.FromSlash("libs/libA"),
 		},
 		"libB": {
-			Dir: "libs/libB",
+			Dir: filepath.FromSlash("libs/libB"),
 		},
 		"libC": {
-			Dir: "libs/libC",
+			Dir: filepath.FromSlash("libs/libC"),
 		},
 		"libD": {
-			Dir: "libs/libD",
+			Dir: filepath.FromSlash("libs/libD"),
 		},
 	}
 	packageNames := []string{}
@@ -216,8 +216,13 @@ func TestResolvePackages(t *testing.T) {
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("test #%v %v", i, tc.name), func(t *testing.T) {
+			// Convert test data to system separators.
+			systemSeparatorChanged := make([]string, len(tc.changed))
+			for index, path := range tc.changed {
+				systemSeparatorChanged[index] = filepath.FromSlash(path)
+			}
 			scm := &mockSCM{
-				changed: tc.changed,
+				changed: systemSeparatorChanged,
 			}
 			pkgs, isAllPackages, err := ResolvePackages(&Opts{
 				LegacyFilter: LegacyFilter{

--- a/cli/internal/scope/scope_test.go
+++ b/cli/internal/scope/scope_test.go
@@ -197,6 +197,12 @@ func TestResolvePackages(t *testing.T) {
 			includeDependents: true,
 			since:             "dummy",
 		},
+		{
+			name:     "substring package name, build both",
+			changed:  []string{"app/a/src/index.ts", "app/a-service/src/index.ts"},
+			expected: []string{"a", "a-service"},
+			since:    "dummy",
+		},
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("test #%v %v", i, tc.name), func(t *testing.T) {


### PR DESCRIPTION
Previously we didn't properly check for package prefixes being at actual file-addressing boundaries. This PR resolves the issue.

Fixes #1528
Closes #1533