### PR TITLE
fix(create-turbo): pnpm peer deps error

### DIFF
--- a/packages/create-turbo/templates/_shared_ts/apps/docs/package.json
+++ b/packages/create-turbo/templates/_shared_ts/apps/docs/package.json
@@ -15,6 +15,7 @@
     "ui": "*"
   },
   "devDependencies": {
+    "@babel/core": "^7.0.0",
     "eslint": "7.32.0",
     "eslint-config-custom": "*",
     "next-transpile-modules": "9.0.0",

--- a/packages/create-turbo/templates/_shared_ts/apps/web/package.json
+++ b/packages/create-turbo/templates/_shared_ts/apps/web/package.json
@@ -15,6 +15,7 @@
     "ui": "*"
   },
   "devDependencies": {
+    "@babel/core": "^7.0.0",
     "eslint": "7.32.0",
     "eslint-config-custom": "*",
     "next-transpile-modules": "9.0.0",

--- a/packages/create-turbo/templates/_shared_ts/packages/eslint-config-custom/package.json
+++ b/packages/create-turbo/templates/_shared_ts/packages/eslint-config-custom/package.json
@@ -4,9 +4,13 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
+    "eslint": "^7.23.0",
     "eslint-config-next": "^12.0.8",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-react": "7.28.0"
+  },
+  "devDependencies": {
+    "typescript": "^4.7.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/create-turbo/templates/pnpm/apps/docs/package.json
+++ b/packages/create-turbo/templates/pnpm/apps/docs/package.json
@@ -15,6 +15,7 @@
     "ui": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.0.0",
     "eslint-config-custom": "workspace:*",
     "eslint": "7.32.0",
     "next-transpile-modules": "9.0.0",

--- a/packages/create-turbo/templates/pnpm/apps/web/package.json
+++ b/packages/create-turbo/templates/pnpm/apps/web/package.json
@@ -15,6 +15,7 @@
     "ui": "workspace:*"
   },
   "devDependencies": {
+    "@babel/core": "^7.0.0",
     "eslint-config-custom": "workspace:*",
     "eslint": "7.32.0",
     "next-transpile-modules": "9.0.0",


### PR DESCRIPTION
Fix error where `npx create-turbo@latest` with `pnpm` throws an error on completion due to incorrect peer dependencies. 

Below stack trace is visible when reinstalling a repo created with `create-turbo@latest` and `pnpm` (after removing the `pnpm-lock.yaml` from the original install)

```
04:46 PM | ~/Desktop/turbo_tests/my-turborepo ()
0 > pnpm install
Scope: all 6 workspace projects
Already up-to-date
Progress: resolved 156, reused 133, downloaded 0, added 0, done
 ERR_PNPM_PEER_DEP_ISSUES  Unmet peer dependencies

apps/docs
└─┬ next
  └─┬ styled-jsx
    ├── ✕ missing peer @babel/core@"*"
    └─┬ @babel/plugin-syntax-jsx
      └── ✕ missing peer @babel/core@^7.0.0-0
Peer dependencies that should be installed:
  @babel/core@">=7.0.0 <8.0.0"

apps/web
└─┬ next
  └─┬ styled-jsx
    ├── ✕ missing peer @babel/core@"*"
    └─┬ @babel/plugin-syntax-jsx
      └── ✕ missing peer @babel/core@^7.0.0-0
Peer dependencies that should be installed:
  @babel/core@">=7.0.0 <8.0.0"

packages/eslint-config-custom
├─┬ eslint-config-next
│ ├── ✕ missing peer typescript@>=3.3.1
│ ├── ✕ missing peer eslint@"^7.23.0 || ^8.0.0"
│ ├─┬ @typescript-eslint/parser
│ │ ├── ✕ missing peer typescript@"*"
│ │ ├── ✕ missing peer eslint@"^6.0.0 || ^7.0.0 || ^8.0.0"
│ │ └─┬ @typescript-eslint/typescript-estree
│ │   ├── ✕ missing peer typescript@"*"
│ │   └─┬ tsutils
│ │     └── ✕ missing peer typescript@">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
│ ├─┬ eslint-import-resolver-typescript
│ │ └── ✕ missing peer eslint@"*"
│ ├─┬ eslint-plugin-import
│ │ └── ✕ missing peer eslint@"^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
│ ├─┬ eslint-plugin-jsx-a11y
│ │ └── ✕ missing peer eslint@"^3 || ^4 || ^5 || ^6 || ^7 || ^8"
│ ├─┬ eslint-plugin-react
│ │ └── ✕ missing peer eslint@"^3 || ^4 || ^5 || ^6 || ^7 || ^8"
│ └─┬ eslint-plugin-react-hooks
│   └── ✕ missing peer eslint@"^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
├─┬ eslint-config-prettier
│ └── ✕ missing peer eslint@>=7.0.0
└─┬ eslint-plugin-react
  └── ✕ missing peer eslint@"^3 || ^4 || ^5 || ^6 || ^7 || ^8"
Peer dependencies that should be installed:
  eslint@">=7.23.0 <8.0.0 || >=8.0.0-0 <8.0.0 || >=8.0.0 <9.0.0"  typescript@>=3.3.1
```