### PR TITLE
fix(cli): don’t exit when no tasks are found

### DIFF
--- a/cli/internal/core/scheduler.go
+++ b/cli/internal/core/scheduler.go
@@ -132,9 +132,6 @@ func (p *Scheduler) generateTaskGraph(pkgs []string, taskNames []string, tasksOn
 			}
 		}
 	}
-	if len(traversalQueue) == 0 {
-		return fmt.Errorf("no tasks found to execute. Requested tasks %v in packages %v", strings.Join(taskNames, ", "), strings.Join(pkgs, ", "))
-	}
 
 	visited := make(util.Set)
 

--- a/cli/internal/core/scheduler_test.go
+++ b/cli/internal/core/scheduler_test.go
@@ -209,6 +209,24 @@ libA#build
 	assert.Equal(t, expected, actual)
 }
 
+func TestRunWithNoTasksFound(t *testing.T) {
+	graph := &dag.AcyclicGraph{}
+	graph.Add("app")
+	graph.Add("lib")
+	graph.Connect(dag.BasicEdge("app", "lib"))
+
+	p := NewScheduler(graph)
+	dependOnBuild := make(util.Set)
+	dependOnBuild.Add("build")
+
+	err := p.Prepare(&SchedulerExecutionOptions{
+		Packages:  []string{"app", "lib"},
+		TaskNames: []string{"build"},
+	})
+	// should not fail because we have no tasks in the scheduler
+	assert.NilError(t, err, "Prepare")
+}
+
 func TestIncludeRootTasks(t *testing.T) {
 	graph := &dag.AcyclicGraph{}
 	graph.Add("app1")


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/vercel/turborepo/pull/1485 which causes turbo to exit when no dependent tasks are found to run. 

This breaks expected behavior (turbo should skip packages that don't contain the specified task) 