### PR TITLE
fix(turbo-ignore): build on error

### DIFF
--- a/packages/turbo-ignore/index.js
+++ b/packages/turbo-ignore/index.js
@@ -20,7 +20,8 @@ exec(
   (error, stdout, stderr) => {
     if (error) {
       console.error(`exec error: ${error}`);
-      return;
+      console.error(`≫ Proceeding with build to be safe...`);
+      process.exit(1);
     }
 
     try {


### PR DESCRIPTION
When using `npx turbo-ignore`, the `HEAD^` used to fetch the previous commit will fail if there is _only one_ commit. 

This is a common case (especially when importing a project) and should be handled gracefully (the build should not be skipped when the diff encounters an unknown error)


Currently, this fails on Vercel with the following error when running on a repository with only a single commit:
```


Running "npx turbo-ignore"
--
15:00:41.493 | npx: installed 1 in 1.272s
15:00:41.515 | ≫ Using Turborepo to determine if this project is affected by the commit...
15:00:41.515 | ≫ Inferred `docs` as scope from "./package.json"
15:00:41.515 | ≫ Analyzing results of `npx turbo run build --filter=docs...[HEAD^] --dry=json`...
15:00:46.444 | exec error: Error: Command failed: npx turbo run build --filter=docs...[HEAD^] --dry=json
15:00:46.445 | ERROR  failed to resolve packages to run: commit HEAD^ does not exist
15:00:46.445 |  
15:00:46.451 | The Deployment has been canceled as a result of running the command defined in the "Ignored Build Step" setting.

```