### PR TITLE
Add VERCEL_ENV to global dependencies

### DIFF
--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -417,6 +417,7 @@ func getHashableTurboEnvVarsFromOs(env []string) ([]string, []string) {
 // Variables that we always include
 var _defaultEnvVars = []string{
 	"VERCEL_ANALYTICS_ID",
+  "VERCEL_ENV",
 }
 
 func calculateGlobalHash(rootpath fs.AbsolutePath, rootPackageJSON *fs.PackageJSON, pipeline fs.Pipeline, externalGlobalDependencies []string, packageManager *packagemanager.PackageManager, logger hclog.Logger, env []string) (string, error) {


### PR DESCRIPTION
This prevents the Preview and Production environments from sharing the same cache which is important to prevent environment variables from preview being used in production.

See docs: https://vercel.com/docs/concepts/projects/environment-variables#system-environment-variables