### PR TITLE
Add dark/light mode aware Image and ThemedFigure

### DIFF
--- a/docs/components/image/ImageFigure.tsx
+++ b/docs/components/image/ImageFigure.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import Image from "next/future/image";
+
+type ImageProps = Parameters<typeof Image>[0];
+
+export type ImageFigureProps = ImageProps & {
+  caption?: string;
+  margin?: number;
+  captionSpacing?: number;
+  shadow?: boolean;
+  borderRadius?: boolean;
+};
+
+export function ImageFigure(props: ImageFigureProps): React.ReactNode {
+  const {
+    caption,
+    margin = 40,
+    captionSpacing = null,
+    shadow = false,
+    borderRadius = false,
+    ...rest
+  } = props;
+
+  return (
+    <figure className="block text-center" style={{ margin: `${margin}px 0` }}>
+      <div
+        className="relative inline-block w-full max-w-full overflow-hidden border-box"
+        style={{ fontSize: 0 }}
+      >
+        {/* eslint-disable-next-line jsx-a11y/alt-text */}
+        <Image {...rest} />
+      </div>
+      {caption && (
+        <figcaption
+          className="m-0 text-xs text-center text-gray-500"
+          style={captionSpacing ? { marginTop: captionSpacing } : {}}
+        >
+          {caption}
+        </figcaption>
+      )}
+    </figure>
+  );
+}

--- a/docs/components/image/ThemedImage.tsx
+++ b/docs/components/image/ThemedImage.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import Image from "next/future/image";
+
+export interface Image {
+  height: number;
+  width: number;
+  source: string;
+}
+
+export interface ThemedImageProps {
+  title?: string;
+  dark?: Image;
+  light?: Image;
+  priority?: boolean;
+}
+
+export function ThemedImage({
+  title,
+  light,
+  dark,
+  priority = false,
+}: ThemedImageProps) {
+  return (
+    <>
+      <div className="block w-full dark:hidden">
+        <Image
+          alt={title}
+          src={light.source}
+          width={light.width}
+          height={light.height}
+          priority={priority}
+        />
+      </div>
+      <div className="hidden w-full dark:block">
+        <Image
+          alt={title}
+          src={dark.source}
+          width={dark.width}
+          height={dark.height}
+          priority={priority}
+        />
+      </div>
+    </>
+  );
+}

--- a/docs/components/image/ThemedImageFigure.tsx
+++ b/docs/components/image/ThemedImageFigure.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { ImageFigureProps } from "./ImageFigure";
+import { ThemedImage, ThemedImageProps } from "./ThemedImage";
+import cn from "classnames";
+export type ThemedImageFigureProps = Omit<ImageFigureProps, "src"> &
+  ThemedImageProps;
+
+export function ThemedImageFigure(
+  props: ThemedImageFigureProps
+): React.ReactNode {
+  const {
+    caption,
+    margin = 40,
+    captionSpacing = null,
+    shadow = false,
+    borderRadius = false,
+    ...rest
+  } = props;
+
+  return (
+    <figure
+      className="block -mx-4 text-center sm:-mx-4 md:-mx-7 lg:-mx-12"
+      style={{ marginTop: `${margin}px`, marginBottom: `${margin}px` }}
+    >
+      <div
+        className={cn(
+          "relative inline-block max-w-full overflow-hidden border-box",
+          {
+            "rounded-md": borderRadius,
+          }
+        )}
+        style={{ fontSize: 0 }}
+      >
+        {/* eslint-disable-next-line jsx-a11y/alt-text */}
+        <ThemedImage {...rest} />
+      </div>
+      {caption && (
+        <figcaption
+          className="m-0 text-xs text-center text-gray-500"
+          style={captionSpacing ? { marginTop: captionSpacing } : {}}
+        >
+          {caption}
+        </figcaption>
+      )}
+    </figure>
+  );
+}


### PR DESCRIPTION
Added some image utils for us.

The one that's useful is `ThemedFigureImage` which gives use light/dark mode on blog posts

```jsx
<ThemedImageFigure 
  borderRadius={true}
  dark={{
    source: '/images/blog/turbo-1-1-0/dark.png?,
    height: 600,
    width: 1200
  }}
  light={{
    source: '/images/blog/turbo-1-1-0/light.png',
    height: 600,
    width: 1200
  }}
  caption="This is a caption"
/>
```
<img width="1100" alt="CleanShot 2022-07-30 at 13 48 30@2x" src="https://user-images.githubusercontent.com/4060187/181995726-2f98d9a7-c378-45c4-b73f-44ea4119ad30.png">
<img width="1281" alt="CleanShot 2022-07-30 at 13 48 39@2x" src="https://user-images.githubusercontent.com/4060187/181995727-34aa1698-e654-4f0c-acac-b9aaaca3b7fa.png">

