### PR TITLE
remove design system from next.js apps

### DIFF
--- a/examples/with-nextjs/README.md
+++ b/examples/with-nextjs/README.md
@@ -1,7 +1,6 @@
 The following turborepo examples contain [Next.js](https://nextjs.org) applications:
 
 1. [basic](../basic/)
-1. [design-system](../design-system/)
 1. [kitchen-sink](../kitchen-sink/)
 1. [with-changesets](../with-changesets/)
 1. [with-docker](../docker/)


### PR DESCRIPTION
a design system is running storybook as docs and not next.js app