### PR TITLE
Revert "hotfix: set height on marquee to avoid layout shift"

### DIFF
--- a/docs/components/clients/Marquee.tsx
+++ b/docs/components/clients/Marquee.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export function Marquee({ children, ...props }) {
   return (
-    <div className="overflow-x-hidden h-[40px]">
+    <div className="overflow-x-hidden">
       <div className="relative">
         <div className="inline-block wrapper">{children}</div>
       </div>


### PR DESCRIPTION
This reverts commit 2e2f54aa59c7f1ea426cc7091972b63917dd024e.

The static height was introduced to fix a layout shift that doesn't
reproduce anymore. The static height clips logos that are taller than
then 40px. Shows up even more on larger screens where images are scaled
larger. This static height isn't needed anymore.