### PR TITLE
fix: remove debug action from CI

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -71,10 +71,6 @@ jobs:
             npm install --global corepack@latest
           fi
 
-
-      - name: Debug CI @donotmerge
-        run: which -a corepack; echo $PATH; corepack -v
-
       - name: Build & Unit Test
         run: pnpm -- turbo run test --filter=cli --color
 


### PR DESCRIPTION
An action I was using to debug CI jobs in #1632 accidentally got merged