### PR TITLE
create-turbo: improve test cases and make them pass

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI Go
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -1,0 +1,78 @@
+name: CI JS
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  build:
+    name: build and test
+    timeout-minutes: 15
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [
+          ubuntu-latest,
+          macos-latest,
+          # windows-latest,
+        ]
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18.0
+          cache: true
+          cache-dependency-path: cli/go.sum
+
+      - name: Set Up Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: "3.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set Up Go and GRPC protobuf
+        run: |
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.0
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2.0
+
+      - uses: pnpm/action-setup@v2.2.2
+        with:
+          version: 7.2.1
+
+      - name: Setup Yarn
+        run: npm i -g yarn
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          cache: pnpm
+
+      - name: Configure corepack
+        # Forcibly upgrade our available version of corepack.
+        # The bundled version in node 16 has known issues.
+        # Prepends the corepack bin dir so that it is always first.
+        shell: bash
+        run: |
+          npm install --force --global corepack@latest
+          npm config get prefix >> $GITHUB_PATH
+          corepack enable
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run create-turbo tests
+        run: pnpm -- turbo run test --filter=create-turbo --color

--- a/packages/create-turbo/__tests__/cli.test.ts
+++ b/packages/create-turbo/__tests__/cli.test.ts
@@ -1,4 +1,4 @@
-import childProcess from "child_process";
+import childProcess, { execSync } from "child_process";
 import fs from "fs-extra";
 import path from "path";
 import util from "util";
@@ -9,6 +9,8 @@ const DEFAULT_APP_NAME = "my-turborepo";
 
 const execFile = util.promisify(childProcess.execFile);
 const spawn = childProcess.spawn;
+
+const PACKAGE_MANAGERS = ["npm", "yarn", "pnpm"];
 
 const keys = {
   up: "\x1B\x5B\x41",
@@ -21,8 +23,31 @@ const createTurbo = path.resolve(__dirname, "../dist/index.js");
 const testDir = path.join(__dirname, "../my-turborepo");
 const DEFAULT_JEST_TIMEOUT = 10000;
 
+const EXPECTED_HELP_MESSAGE = `
+"
+  Create a new Turborepo
+
+  Usage:
+    $ npx create-turbo [flags...] [<dir>]
+
+  If <dir> is not provided up front you will be prompted for it.
+
+  Flags:
+    --use-npm           Explicitly tell the CLI to bootstrap the app using npm
+    --use-pnpm          Explicitly tell the CLI to bootstrap the app using pnpm
+    --use-yarn          Explicitly tell the CLI to bootstrap the app using yarn
+    --no-install        Explicitly do not run the package manager's install command
+    --help, -h          Show this help message
+    --version, -v       Show the version of this script
+
+"
+`;
+
 describe("create-turbo cli", () => {
   beforeAll(() => {
+    execSync("corepack disable", { stdio: "ignore" });
+    cleanupTestDir();
+
     jest.setTimeout(DEFAULT_JEST_TIMEOUT * 3);
     if (fs.existsSync(testDir)) {
       fs.rmSync(testDir, { recursive: true });
@@ -38,17 +63,130 @@ describe("create-turbo cli", () => {
 
   afterAll(() => {
     jest.setTimeout(DEFAULT_JEST_TIMEOUT);
-    if (fs.existsSync(testDir)) {
-      fs.rmSync(testDir, { recursive: true });
-    }
+    execSync("corepack enable", { stdio: "ignore" });
+
+    // clean up after the whole test suite just in case any excptions prevented beforeEach callback from running
+    cleanupTestDir();
   });
 
-  it("guides the user through the process", (done) => {
-    let cli = spawn("node", [createTurbo, "--no-install"], {});
-    let promptCount = 0;
+  beforeEach(() => {
+    // cleanup before each test case in case the previous test timed out.
+    cleanupTestDir();
+  });
+
+  afterEach(() => {
+    // clean up test dir in between test cases since we are using the same directory for each one.
+    cleanupTestDir();
+  });
+
+  describe("--no-install", () => {
+    it("default: guides the user through the process", async () => {
+      const cli = spawn("node", [createTurbo, "--no-install"], {});
+
+      const messages = await runInteractiveCLI(cli);
+
+      expect(messages[0]).toEqual(
+        ">>> Welcome to Turborepo! Let's get you set up with a new codebase."
+      );
+
+      expect(messages[1]).toEqual(
+        `? Where would you like to create your turborepo? (./${DEFAULT_APP_NAME})`
+      );
+
+      expect(getPromptChoices(messages[2])).toEqual(["npm", "pnpm", "yarn"]);
+
+      expect(messages[3]).toMatch(
+        /^>>> Bootstrapped a new turborepo with the following:/
+      );
+
+      expect(
+        messages.find((msg) =>
+          msg.match(
+            new RegExp(
+              `>>> Success! Created a new Turborepo at "${DEFAULT_APP_NAME}"`
+            )
+          )
+        )
+      ).toBeTruthy();
+
+      expect(getGeneratedPackageJSON().packageManager).toMatch(/^npm/);
+
+      expect(fs.existsSync(path.join(testDir, "node_modules"))).toBe(false);
+    }, 10000);
+
+    PACKAGE_MANAGERS.forEach((packageManager) => {
+      it(`--use-${packageManager}: guides the user through the process`, async () => {
+        const cli = spawn(
+          "node",
+          [createTurbo, "--no-install", `--use-${packageManager}`],
+          {}
+        );
+        const messages = await runInteractiveCLI(cli);
+
+        expect(messages[0]).toEqual(
+          ">>> Welcome to Turborepo! Let's get you set up with a new codebase."
+        );
+
+        expect(messages[1]).toEqual(
+          `? Where would you like to create your turborepo? (./${DEFAULT_APP_NAME})`
+        );
+
+        expect(messages[2]).toMatch(
+          /^>>> Bootstrapped a new turborepo with the following:/
+        );
+
+        expect(
+          messages.find((msg) =>
+            msg.match(
+              new RegExp(
+                `>>> Success! Created a new Turborepo at "${DEFAULT_APP_NAME}"`
+              )
+            )
+          )
+        ).toBeTruthy();
+
+        expect(getGeneratedPackageJSON().packageManager).toMatch(
+          new RegExp(`^${packageManager}`)
+        );
+
+        expect(fs.existsSync(path.join(testDir, "node_modules"))).toBe(false);
+      }, 10000);
+    });
+  });
+
+  describe("printing version", () => {
+    it("--version flag works", async () => {
+      let { stdout } = await execFile("node", [createTurbo, "--version"]);
+      expect(!!semver.valid(stdout.trim())).toBe(true);
+    });
+
+    it("-v flag works", async () => {
+      let { stdout } = await execFile("node", [createTurbo, "-v"]);
+      expect(!!semver.valid(stdout.trim())).toBe(true);
+    });
+  });
+
+  describe("printing help message", () => {
+    it("--help flag works", async () => {
+      let { stdout } = await execFile("node", [createTurbo, "--help"]);
+      expect(stdout).toMatchInlineSnapshot(EXPECTED_HELP_MESSAGE);
+    });
+
+    it("-h flag works", async () => {
+      let { stdout } = await execFile("node", [createTurbo, "-h"]);
+      expect(stdout).toMatchInlineSnapshot(EXPECTED_HELP_MESSAGE);
+    });
+  });
+});
+
+async function runInteractiveCLI(
+  cli: childProcess.ChildProcessWithoutNullStreams
+): Promise<string[]> {
+  return new Promise((resolve, reject) => {
     let previousPrompt: string;
     const messages: string[] = [];
-    cli.stdout.on("data", async (data) => {
+
+    cli.stdout.on("data", (data) => {
       let prompt = cleanPrompt(data);
 
       if (
@@ -59,114 +197,28 @@ describe("create-turbo cli", () => {
         return;
       }
 
-      promptCount++;
+      messages.push(prompt);
 
-      switch (promptCount) {
-        case 1:
-          expect(prompt).toEqual(
-            ">>> Welcome to Turborepo! Let's get you set up with a new codebase."
-          );
-          break;
-        case 2:
-          expect(prompt).toEqual(
-            `? Where would you like to create your turborepo? (./${DEFAULT_APP_NAME})`
-          );
-          cli.stdin.write(keys.enter);
-          break;
+      if (prompt.match(/Which package manager do you want to use/)) {
+        cli.stdin.write(keys.enter);
+      }
 
-        case 3:
-          // Which package manager do you want to use?
-          // easy to change deployment targets.
-          expect(getPromptChoices(prompt)).toEqual(["npm", "pnpm", "yarn"]);
-          cli.stdin.write(keys.enter);
-          break;
-        case 4:
-          // Bootstrap info
-          expect(
-            prompt.startsWith(
-              ">>> Bootstrapped a new turborepo with the following:"
-            )
-          ).toBe(true);
-
-          break;
+      if (prompt.match(/Where would you like to create your turborepo/)) {
+        cli.stdin.write(keys.enter);
       }
 
       previousPrompt = prompt;
     });
 
     cli.on("exit", () => {
-      try {
-        done();
-      } catch (error) {
-        done(error);
-      }
-      return;
+      resolve(messages);
     });
-  }, 10000);
 
-  describe("the --version flag", () => {
-    it("prints the current version", async () => {
-      let { stdout } = await execFile("node", [createTurbo, "--version"]);
-      expect(!!semver.valid(stdout.trim())).toBe(true);
+    cli.on("error", (e) => {
+      reject(e);
     });
   });
-
-  describe("the -v flag", () => {
-    it("prints the current version", async () => {
-      let { stdout } = await execFile("node", [createTurbo, "-v"]);
-      expect(!!semver.valid(stdout.trim())).toBe(true);
-    });
-  });
-
-  describe("the --help flag", () => {
-    it("prints help info", async () => {
-      let { stdout } = await execFile("node", [createTurbo, "--help"]);
-
-      expect(stdout).toMatchInlineSnapshot(`
-        "
-          Create a new Turborepo
-
-          Usage:
-            $ npx create-turbo [flags...] [<dir>]
-
-          If <dir> is not provided up front you will be prompted for it.
-
-          Flags:
-            --use-npm           Explicitly tell the CLI to bootstrap the app using npm
-            --use-pnpm          Explicitly tell the CLI to bootstrap the app using pnpm
-            --no-install        Explicitly do not run the package manager's install command
-            --help, -h          Show this help message
-            --version, -v       Show the version of this script
-
-        "
-      `);
-    });
-  });
-
-  describe("the -h flag", () => {
-    it("prints help info", async () => {
-      let { stdout } = await execFile("node", [createTurbo, "-h"]);
-      expect(stdout).toMatchInlineSnapshot(`
-        "
-          Create a new Turborepo
-
-          Usage:
-            $ npx create-turbo [flags...] [<dir>]
-
-          If <dir> is not provided up front you will be prompted for it.
-
-          Flags:
-            --use-npm           Explicitly tell the CLI to bootstrap the app using npm
-            --use-pnpm          Explicitly tell the CLI to bootstrap the app using pnpm
-            --no-install        Explicitly do not run the package manager's install command
-            --help, -h          Show this help message
-            --version, -v       Show the version of this script
-
-        "
-      `);
-    });
-  });
-});
+}
 
 // These utils are a bit gnarly but they help me deal with the weirdness of node
 // process stdout data formatting and inquirer. They're gross but make the tests
@@ -197,4 +249,16 @@ function isSamePrompt(
   promptStart = promptStart.slice(0, promptStart.lastIndexOf("("));
 
   return currentPrompt.startsWith(promptStart);
+}
+
+function cleanupTestDir() {
+  if (fs.existsSync(testDir)) {
+    fs.rmSync(testDir, { recursive: true });
+  }
+}
+
+function getGeneratedPackageJSON() {
+  return JSON.parse(
+    fs.readFileSync(path.join(testDir, "package.json")).toString()
+  );
 }


### PR DESCRIPTION
- Make existing tests pass
- Add GH action to run tests in CI

  Set up a new Github Action that builds the turbo CLI (since that is
  required for the create-turbo tests) and runs the JS tests for that
  package.

  Notable things:

  - Installs yarn and disables corepack as part of the test suite. This
    is the pristine state we want for the tests that exist today. For
    future tests cases that have a different setup, we may need to
    modify this more.

  - Disables Windows tests. This yarn setup on Windows does not seem to
    work, but this gets us one step forward.