### PR TITLE
Attempt at an alternative corepack implementation.

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -54,22 +54,18 @@ jobs:
           node-version: 16
           cache: pnpm
 
-      - name: Install dependencies
-        # corepack 0.10 has a race condition in it that can cause the inital
-        # package manger installs to fail.
-        # Once we update to a version of node that ships with corepack 0.12 or
-        # higher we can remove the second install command.
-        # Windows installs global packages to a directory that has lower priority than
-        # the default node install so we also need to edit $PATH
+      - name: Configure corepack
+        # Forcibly upgrade our available version of corepack.
+        # The bundled version in node 16 has known issues.
+        # Prepends the corepack bin dir so that it is always first.
         shell: bash
         run: |
-          pnpm install;
-          if [ "$RUNNER_OS" == "Windows" ]; then
-            npm install --force --global corepack@latest
-            npm config get prefix >> $GITHUB_PATH
-          else
-            npm install --global corepack@latest
-          fi
+          npm install --force --global corepack@latest
+          npm config get prefix >> $GITHUB_PATH
+          corepack enable
+
+      - name: Install dependencies
+        run: pnpm install
 
       - name: Build & Unit Test
         run: pnpm -- turbo run test --filter=cli --color

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -66,7 +66,11 @@ fmt-go: $(GO_FILES) go.mod go.sum
 install: | ./package.json
 	pnpm install --filter=cli
 
-e2e: install turbo
+corepack:
+	npm install -g corepack@latest
+	corepack enable
+
+e2e: corepack install turbo
 	node -r esbuild-register scripts/e2e/e2e.ts
 
 cmd/turbo/version.go: ../version.txt

--- a/cli/scripts/e2e/e2e.ts
+++ b/cli/scripts/e2e/e2e.ts
@@ -40,12 +40,10 @@ const basicPipeline = {
 // This is injected by github actions
 process.env.TURBO_TOKEN = "";
 
-const COREPACK_BIN_DIR = setupCorepack();
-
 let suites = [];
 for (let npmClient of ["yarn", "berry", "pnpm6", "pnpm", "npm"] as const) {
   const Suite = uvu.suite(`${npmClient}`);
-  const repo = new Monorepo("basics", COREPACK_BIN_DIR);
+  const repo = new Monorepo("basics");
   repo.init(npmClient, basicPipeline);
   repo.install();
   repo.addPackage("a", ["b"]);
@@ -54,7 +52,7 @@ for (let npmClient of ["yarn", "berry", "pnpm6", "pnpm", "npm"] as const) {
   repo.linkPackages();
   repo.expectCleanGitStatus();
   runSmokeTests(Suite, repo, npmClient);
-  const sub = new Monorepo("in-subdirectory", COREPACK_BIN_DIR);
+  const sub = new Monorepo("in-subdirectory");
   sub.init(npmClient, basicPipeline, "js");
   sub.install();
   sub.addPackage("a", ["b"]);
@@ -656,14 +654,4 @@ function getCachedLogFilePathForTask(
   taskName: string
 ): string {
   return path.join(cacheDir, pathToPackage, ".turbo", `turbo-${taskName}.log`);
-}
-
-// Setup corepack and provide the dir to the binaries that corepack installs
-// It is important that this dir has a higher priority in $PATH than any other
-// dirs that may versions of package managers installed by other mechanisms
-// e.g. homebrew or pnpm
-function setupCorepack(): string {
-  execa.sync("corepack", ["enable"]);
-  const corepack_path = execa.sync("which", ["corepack"]).stdout;
-  return path.dirname(corepack_path);
 }


### PR DESCRIPTION
I don't actually know if this will work, but I was trying to make the system itself responsible for maintaining the executable paths so that we didn't need to account for it in our e2e scripts.