### PR TITLE
fix(docs): add missing schema back to public

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -21,7 +21,8 @@
       "dependsOn": []
     },
     "schema": {
-      "outputs": ["public/schema.json"]
+      "outputs": ["public/schema.json"],
+      "dependsOn": ["build"]
     },
     "create-turbo#test": {
       "dependsOn": ["create-turbo#build"],


### PR DESCRIPTION
Fix missing schema

Closes https://github.com/vercel/turborepo/issues/1654

Looks like this was accidentally lost as part of:
https://github.com/vercel/turborepo/pull/726