### PR TITLE
docs: Update with-nextjs readme to add prisma starter link

### DIFF
--- a/examples/with-nextjs/README.md
+++ b/examples/with-nextjs/README.md
@@ -5,6 +5,7 @@ The following turborepo examples contain [Next.js](https://nextjs.org) applicati
 1. [kitchen-sink](../kitchen-sink/)
 1. [with-changesets](../with-changesets/)
 1. [with-docker](../docker/)
+1. [with-prisma](../with-prisma) 
 1. [with-pnpm](../with-pnpm/)
 1. [with-react-native-web](../with-react-native-web/)
 1. [with-tailwind](../with-tailwind/)


### PR DESCRIPTION
Add a link to with-nextjs starter to Prisma starter.