### PR TITLE
update: create-turbo templates to use react v18

### DIFF
--- a/packages/create-turbo/templates/_shared_ts/apps/docs/package.json
+++ b/packages/create-turbo/templates/_shared_ts/apps/docs/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "next": "12.2.4",
-    "react": "17.0.2",
-    "react-dom": "17.0.2",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "ui": "*"
   },
   "devDependencies": {
@@ -21,7 +21,7 @@
     "next-transpile-modules": "9.0.0",
     "tsconfig": "*",
     "@types/node": "^17.0.12",
-    "@types/react": "17.0.48",
+    "@types/react": "18.0.17",
     "typescript": "^4.5.3"
   }
 }

--- a/packages/create-turbo/templates/_shared_ts/apps/web/package.json
+++ b/packages/create-turbo/templates/_shared_ts/apps/web/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "next": "12.2.4",
-    "react": "17.0.2",
-    "react-dom": "17.0.2",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "ui": "*"
   },
   "devDependencies": {
@@ -21,7 +21,7 @@
     "next-transpile-modules": "9.0.0",
     "tsconfig": "*",
     "@types/node": "^17.0.12",
-    "@types/react": "17.0.48",
+    "@types/react": "18.0.17",
     "typescript": "^4.5.3"
   }
 }

--- a/packages/create-turbo/templates/_shared_ts/packages/ui/package.json
+++ b/packages/create-turbo/templates/_shared_ts/packages/ui/package.json
@@ -12,7 +12,7 @@
     "@types/react-dom": "^17.0.11",
     "eslint": "^7.32.0",
     "eslint-config-custom": "*",
-    "react": "^17.0.2",
+    "react": "^18.2.0",
     "tsconfig": "*",
     "typescript": "^4.5.2"
   }

--- a/packages/create-turbo/templates/pnpm/apps/docs/package.json
+++ b/packages/create-turbo/templates/pnpm/apps/docs/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "next": "12.2.4",
-    "react": "17.0.2",
-    "react-dom": "17.0.2",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "ui": "workspace:*"
   },
   "devDependencies": {
@@ -21,7 +21,7 @@
     "next-transpile-modules": "9.0.0",
     "tsconfig": "workspace:*",
     "@types/node": "^17.0.12",
-    "@types/react": "17.0.48",
+    "@types/react": "18.0.17",
     "typescript": "^4.5.3"
   }
 }

--- a/packages/create-turbo/templates/pnpm/apps/web/package.json
+++ b/packages/create-turbo/templates/pnpm/apps/web/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "next": "12.2.4",
-    "react": "17.0.2",
-    "react-dom": "17.0.2",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "ui": "workspace:*"
   },
   "devDependencies": {
@@ -21,7 +21,7 @@
     "next-transpile-modules": "9.0.0",
     "tsconfig": "workspace:*",
     "@types/node": "^17.0.12",
-    "@types/react": "17.0.48",
+    "@types/react": "18.0.17",
     "typescript": "^4.5.3"
   }
 }

--- a/packages/create-turbo/templates/pnpm/packages/ui/package.json
+++ b/packages/create-turbo/templates/pnpm/packages/ui/package.json
@@ -8,11 +8,11 @@
     "lint": "eslint *.ts*"
   },
   "devDependencies": {
-    "@types/react": "^17.0.37",
-    "@types/react-dom": "^17.0.11",
+    "@types/react": "^18.0.17",
+    "@types/react-dom": "^18.0.6",
     "eslint": "^7.32.0",
     "eslint-config-custom": "workspace:*",
-    "react": "^17.0.2",
+    "react": "^18.2.0",
     "tsconfig": "workspace:*",
     "typescript": "^4.5.2"
   }


### PR DESCRIPTION
This updates `create-turbo` package to use React 18 instead of React 17.

note: 2 snapshot tests fail but are unrelated to the changes made and not something I'm familiar enough to test presently. Tested locally and the examples apps run as expected without issue.