### PR TITLE
Flip benchmark to manual, only run on ubuntu, add protoc setup

### DIFF
--- a/.github/workflows/large-monorepo.yml
+++ b/.github/workflows/large-monorepo.yml
@@ -1,8 +1,6 @@
 name: Large Repo Benchmark
 
-on:
-  schedule:
-    - cron: "0 0 * * *"
+on: workflow_dispatch
 
 jobs:
   build:
@@ -26,6 +24,17 @@ jobs:
           cache: true
           cache-dependency-path: cli/go.sum
         id: go
+
+      - name: Set Up Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: "3.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set Up Go and GRPC protobuf
+        run: |
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.0
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2.0
 
       - uses: pnpm/action-setup@v2.2.2
         with:

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -8,5 +8,8 @@
   },
   "scripts": {
     "benchmark": "node -r esbuild-register src/index.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^16.11.12"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ importers:
 
   benchmark:
     specifiers:
+      '@types/node': ^16.11.12
       esbuild: ^0.14.38
       esbuild-register: ^3.3.2
       fs-extra: ^10.0.0
@@ -21,6 +22,8 @@ importers:
       esbuild: 0.14.49
       esbuild-register: 3.3.3_esbuild@0.14.49
       fs-extra: 10.1.0
+    devDependencies:
+      '@types/node': 16.11.44
 
   cli:
     specifiers:


### PR DESCRIPTION
Baby steps to getting our benchmark up and running. 

Removed cron trigger, will only trigger manually, and only run on ubuntu. Once we can verify that's all working, we can add more triggers / platforms.