### PR TITLE
refactor: Prune prefactor

### DIFF
--- a/cli/internal/packagemanager/berry.go
+++ b/cli/internal/packagemanager/berry.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 
 	"github.com/Masterminds/semver"
+	"github.com/pkg/errors"
 	"github.com/vercel/turborepo/cli/internal/fs"
 	"github.com/vercel/turborepo/cli/internal/util"
 )
@@ -36,6 +37,15 @@ var nodejsBerry = PackageManager{
 			"**/.git",
 			"**/.yarn",
 		}, nil
+	},
+
+	canPrune: func(cwd fs.AbsolutePath) (bool, error) {
+		if isNMLinker, err := util.IsNMLinker(cwd.ToStringDuringMigration()); err != nil {
+			return false, errors.Wrap(err, "could not determine if yarn is using `nodeLinker: node-modules`")
+		} else if !isNMLinker {
+			return false, errors.New("only yarn v2/v3 with `nodeLinker: node-modules` is supported at this time")
+		}
+		return true, nil
 	},
 
 	// Versions newer than 2.0 are berry, and before that we simply call them yarn.

--- a/cli/internal/packagemanager/packagemanager.go
+++ b/cli/internal/packagemanager/packagemanager.go
@@ -155,7 +155,7 @@ func (pm PackageManager) GetWorkspaceIgnores(rootpath fs.AbsolutePath) ([]string
 
 // CanPrune returns if turbo can produce a pruned workspace. Can error if fs issues occur
 func (pm PackageManager) CanPrune(projectDirectory fs.AbsolutePath) (bool, error) {
-	if canPrune := pm.canPrune; canPrune != nil {
+	if pm.canPrune != nil {
 		return pm.canPrune(projectDirectory)
 	}
 	return false, nil

--- a/cli/internal/packagemanager/packagemanager.go
+++ b/cli/internal/packagemanager/packagemanager.go
@@ -46,6 +46,9 @@ type PackageManager struct {
 	// Return the list of workspace ignore globs
 	getWorkspaceIgnores func(pm PackageManager, rootpath fs.AbsolutePath) ([]string, error)
 
+	// Detect if Turbo knows how to produce a pruned workspace for the project
+	canPrune func(cwd fs.AbsolutePath) (bool, error)
+
 	// Test a manager and version tuple to see if it is the Package Manager.
 	Matches func(manager string, version string) (bool, error)
 
@@ -148,4 +151,12 @@ func (pm PackageManager) GetWorkspaces(rootpath fs.AbsolutePath) ([]string, erro
 // GetWorkspaceIgnores returns an array of globs not to search for workspaces.
 func (pm PackageManager) GetWorkspaceIgnores(rootpath fs.AbsolutePath) ([]string, error) {
 	return pm.getWorkspaceIgnores(pm, rootpath)
+}
+
+// CanPrune returns if turbo can produce a pruned workspace. Can error if fs issues occur
+func (pm PackageManager) CanPrune(projectDirectory fs.AbsolutePath) (bool, error) {
+	if canPrune := pm.canPrune; canPrune != nil {
+		return pm.canPrune(projectDirectory)
+	}
+	return false, nil
 }

--- a/cli/internal/packagemanager/yarn.go
+++ b/cli/internal/packagemanager/yarn.go
@@ -52,6 +52,10 @@ var nodejsYarn = PackageManager{
 		return ignores, nil
 	},
 
+	canPrune: func(cwd fs.AbsolutePath) (bool, error) {
+		return true, nil
+	},
+
 	// Versions older than 2.0 are yarn, after that they become berry
 	Matches: func(manager string, version string) (bool, error) {
 		if manager != "yarn" {

--- a/cli/internal/prune/prune.go
+++ b/cli/internal/prune/prune.go
@@ -140,14 +140,12 @@ func (p *prune) prune(opts *opts) error {
 	p.logger.Trace("docker", "value", opts.docker)
 	p.logger.Trace("out dir", "value", outDir.ToString())
 
-	if !util.IsYarn(ctx.PackageManager.Name) {
+	canPrune, err := ctx.PackageManager.CanPrune(p.config.Cwd)
+	if err != nil {
+		return err
+	}
+	if !canPrune {
 		return errors.Errorf("this command is not yet implemented for %s", ctx.PackageManager.Name)
-	} else if ctx.PackageManager.Name == "nodejs-berry" {
-		if isNMLinker, err := util.IsNMLinker(p.config.Cwd.ToStringDuringMigration()); err != nil {
-			return errors.Wrap(err, "could not determine if yarn is using `nodeLinker: node-modules`")
-		} else if !isNMLinker {
-			return errors.New("only yarn v2/v3 with `nodeLinker: node-modules` is supported at this time")
-		}
 	}
 
 	p.ui.Output(fmt.Sprintf("Generating pruned monorepo for %v in %v", ui.Bold(opts.scope), ui.Bold(outDir.ToString())))


### PR DESCRIPTION
Before I add support for pnpm in the prune command I wanted to add some more tests and take a quick pass at deduping some code.
 - Add e2e test for `--docker` flag
 - Move the check for if a package manager supports the prune command into the PM abstraction
 - Dedupe the `--docker` vs vanilla codepaths

Unsure of the signature of `CanPrune` as it could be simplified to just return an error if the package manager doesn't support, but that feels off to me. Would appreciate any thoughts on this.