### PR TITLE
Use git hash-object instead of git ls-files for inputs hashing

### DIFF
--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vercel/turborepo/cli/internal/core"
 	"github.com/vercel/turborepo/cli/internal/fs"
 	"github.com/vercel/turborepo/cli/internal/globby"
+	"github.com/vercel/turborepo/cli/internal/hashing"
 	"github.com/vercel/turborepo/cli/internal/packagemanager"
 	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"github.com/vercel/turborepo/cli/internal/util"
@@ -482,7 +483,7 @@ func calculateGlobalHash(rootpath fs.AbsolutePath, rootPackageJSON *fs.PackageJS
 		globalDepsPaths[i] = turbopath.AbsoluteSystemPathFromUpstream(path)
 	}
 
-	globalFileHashMap, err := fs.GetHashableDeps(rootpath, globalDepsPaths)
+	globalFileHashMap, err := hashing.GetHashableDeps(rootpath, globalDepsPaths)
 	if err != nil {
 		return "", fmt.Errorf("error hashing files. make sure that git has been initialized %w", err)
 	}

--- a/cli/internal/hashing/package_deps_hash.go
+++ b/cli/internal/hashing/package_deps_hash.go
@@ -1,4 +1,4 @@
-package fs
+package hashing
 
 import (
 	"bufio"
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/vercel/turborepo/cli/internal/encoding/gitoutput"
+	"github.com/vercel/turborepo/cli/internal/fs"
 	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"github.com/vercel/turborepo/cli/internal/util"
 )
@@ -24,7 +25,7 @@ type PackageDepsOptions struct {
 }
 
 // GetPackageDeps Builds an object containing git hashes for the files under the specified `packagePath` folder.
-func GetPackageDeps(rootPath AbsolutePath, p *PackageDepsOptions) (map[turbopath.AnchoredUnixPath]string, error) {
+func GetPackageDeps(rootPath fs.AbsolutePath, p *PackageDepsOptions) (map[turbopath.AnchoredUnixPath]string, error) {
 	pkgPath := rootPath.Join(p.PackagePath)
 	// Add all the checked in hashes.
 	var result map[turbopath.AnchoredUnixPath]string
@@ -73,7 +74,7 @@ func GetPackageDeps(rootPath AbsolutePath, p *PackageDepsOptions) (map[turbopath
 
 // GetHashableDeps hashes the list of given files, then returns a map of normalized path to hash
 // this map is suitable for cross-platform caching.
-func GetHashableDeps(rootPath AbsolutePath, files []turbopath.AbsoluteSystemPath) (map[turbopath.AnchoredUnixPath]string, error) {
+func GetHashableDeps(rootPath fs.AbsolutePath, files []turbopath.AbsoluteSystemPath) (map[turbopath.AnchoredUnixPath]string, error) {
 	output := make([]turbopath.AnchoredSystemPath, len(files))
 	convertedRootPath := turbopath.AbsoluteSystemPathFromUpstream(rootPath.ToString())
 
@@ -233,7 +234,7 @@ func runGitCommand(cmd *exec.Cmd, commandName string, handler func(io.Reader) *g
 
 // gitLsTree returns a map of paths to their SHA hashes starting at a particular directory
 // that are present in the `git` index at a particular revision.
-func gitLsTree(rootPath AbsolutePath) (map[turbopath.AnchoredUnixPath]string, error) {
+func gitLsTree(rootPath fs.AbsolutePath) (map[turbopath.AnchoredUnixPath]string, error) {
 	cmd := exec.Command(
 		"git",     // Using `git` from $PATH,
 		"ls-tree", // list the contents of the git index,
@@ -260,7 +261,7 @@ func gitLsTree(rootPath AbsolutePath) (map[turbopath.AnchoredUnixPath]string, er
 
 // gitLsTree returns a map of paths to their SHA hashes starting from a list of patterns relative to a directory
 // that are present in the `git` index at a particular revision.
-func gitLsFiles(rootPath AbsolutePath, patterns []string) (map[turbopath.AnchoredUnixPath]string, error) {
+func gitLsFiles(rootPath fs.AbsolutePath, patterns []string) (map[turbopath.AnchoredUnixPath]string, error) {
 	cmd := exec.Command(
 		"git",      // Using `git` from $PATH,
 		"ls-files", // tell me about git index information of some files,
@@ -354,7 +355,7 @@ func (s statusCode) isDelete() bool {
 // We need to calculate where the repository's location is in order to determine what the full path is
 // before we can return those paths relative to the calling directory, normalizing to the behavior of
 // `ls-files` and `ls-tree`.
-func gitStatus(rootPath AbsolutePath, patterns []string) (map[turbopath.AnchoredUnixPath]statusCode, error) {
+func gitStatus(rootPath fs.AbsolutePath, patterns []string) (map[turbopath.AnchoredUnixPath]statusCode, error) {
 	cmd := exec.Command(
 		"git",               // Using `git` from $PATH,
 		"status",            // tell me about the status of the working tree,

--- a/cli/internal/hashing/package_deps_hash_test.go
+++ b/cli/internal/hashing/package_deps_hash_test.go
@@ -1,4 +1,4 @@
-package fs
+package hashing
 
 import (
 	"errors"
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/vercel/turborepo/cli/internal/fs"
 	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"gotest.tools/v3/assert"
 )
@@ -216,7 +217,7 @@ func Test_getTraversePath(t *testing.T) {
 	}
 }
 
-func requireGitCmd(t *testing.T, repoRoot AbsolutePath, args ...string) {
+func requireGitCmd(t *testing.T, repoRoot fs.AbsolutePath, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)
 	cmd.Dir = repoRoot.ToString()
@@ -234,7 +235,7 @@ func TestGetPackageDeps(t *testing.T) {
 	//     deleted-file
 	//     uncommitted-file <- new file not added to git
 
-	repoRoot := AbsolutePathFromUpstream(t.TempDir())
+	repoRoot := fs.AbsolutePathFromUpstream(t.TempDir())
 	myPkgDir := repoRoot.Join("my-pkg")
 	committedFilePath := myPkgDir.Join("committed-file")
 	err := committedFilePath.EnsureDir()

--- a/cli/internal/hashing/package_deps_hash_test.go
+++ b/cli/internal/hashing/package_deps_hash_test.go
@@ -295,6 +295,16 @@ func TestGetPackageDeps(t *testing.T) {
 				"dir/nested-file":  "bfe53d766e64d78f80050b73cd1c88095bc70abb",
 			},
 		},
+		{
+			opts: &PackageDepsOptions{
+				PackagePath:   "my-pkg",
+				InputPatterns: []string{"**/{uncommitted,committed}-file"},
+			},
+			expected: map[turbopath.AnchoredUnixPath]string{
+				"committed-file":   "3a29e62ea9ba15c4a4009d1f605d391cdd262033",
+				"uncommitted-file": "4e56ad89387e6379e4e91ddfe9872cf6a72c9976",
+			},
+		},
 	}
 	for _, tt := range tests {
 		got, err := GetPackageDeps(repoRoot, tt.opts)

--- a/cli/internal/taskhash/taskhash.go
+++ b/cli/internal/taskhash/taskhash.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vercel/turborepo/cli/internal/doublestar"
 	"github.com/vercel/turborepo/cli/internal/env"
 	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/hashing"
 	"github.com/vercel/turborepo/cli/internal/inference"
 	"github.com/vercel/turborepo/cli/internal/nodes"
 	"github.com/vercel/turborepo/cli/internal/turbopath"
@@ -77,7 +78,7 @@ func safeCompileIgnoreFile(filepath string) (*gitignore.GitIgnore, error) {
 }
 
 func (pfs *packageFileSpec) hash(pkg *fs.PackageJSON, repoRoot fs.AbsolutePath) (string, error) {
-	hashObject, pkgDepsErr := fs.GetPackageDeps(repoRoot, &fs.PackageDepsOptions{
+	hashObject, pkgDepsErr := hashing.GetPackageDeps(repoRoot, &hashing.PackageDepsOptions{
 		PackagePath:   pkg.Dir,
 		InputPatterns: pfs.inputs,
 	})


### PR DESCRIPTION
Passing `"inputs"` directly to `git ls-files` uses `git`'s globbing, which is not the same as the rest of `turbo`. Do the globbing ourselves instead, and use `git hash-object`.