### PR TITLE
Add yarn/berry switch in create-turbo tests.

### DIFF
--- a/packages/create-turbo/.gitignore
+++ b/packages/create-turbo/.gitignore
@@ -1,1 +1,5 @@
 !templates/*/.npmrc
+my-turborepo/
+.yarn/
+.yarnrc
+.yarnrc.yml

--- a/packages/create-turbo/__tests__/cli.test.ts
+++ b/packages/create-turbo/__tests__/cli.test.ts
@@ -346,12 +346,23 @@ function configurePackageManager(packageManager: PackageManager) {
   // If `corepack` plays nicer this can be uncommented to not rely on globals:
   // execSync(`corepack prepare ${packageManager.command}@latest --activate`, { stdio: "ignore" });
 
-  switch (packageManager) {
-    case PACKAGE_MANAGERS["yarn"]:
-      execSync("yarn set version", { stdio: "ignore" });
-      return;
-    case PACKAGE_MANAGERS["berry"]:
-      execSync("yarn set version berry", { stdio: "ignore" });
-      return;
+  try {
+    switch (packageManager) {
+      case PACKAGE_MANAGERS["yarn"]:
+        // Switch to classic.
+        execSync("yarn set version classic", { stdio: "ignore" });
+        // Ensure that it's the latest stable version.
+        execSync("yarn set version", { stdio: "ignore" });
+        return;
+      case PACKAGE_MANAGERS["berry"]:
+        // Switch to berry.
+        execSync("yarn set version berry", { stdio: "ignore" });
+        // Ensure that it's the latest stable version.
+        execSync("yarn set version stable", { stdio: "ignore" });
+        return;
+    }
+  } catch (e) {
+    // We only end up here if we try to set "classic" _from_ classic.
+    // The method shape in `yarn` does not match `berry`.
   }
 }

--- a/packages/create-turbo/src/constants.ts
+++ b/packages/create-turbo/src/constants.ts
@@ -1,0 +1,26 @@
+export type BaseVersions = "berry" | "yarn" | "pnpm" | "npm";
+export type CommandName = "yarn" | "pnpm" | "npm";
+
+export type PackageManager = {
+  name: BaseVersions;
+  command: CommandName;
+};
+
+export const PACKAGE_MANAGERS: Record<BaseVersions, PackageManager> = {
+  npm: {
+    name: "npm",
+    command: "npm",
+  },
+  pnpm: {
+    name: "pnpm",
+    command: "pnpm",
+  },
+  yarn: {
+    name: "yarn",
+    command: "yarn",
+  },
+  berry: {
+    name: "berry",
+    command: "yarn",
+  },
+};

--- a/packages/create-turbo/src/getPackageManagerVersion.ts
+++ b/packages/create-turbo/src/getPackageManagerVersion.ts
@@ -1,8 +1,9 @@
 import { execSync } from "child_process";
-import { PackageManager } from "./types";
+import { PackageManager } from "./constants";
 
 export const getPackageManagerVersion = (ws: PackageManager): string => {
-  switch (ws) {
+  switch (ws.name) {
+    case "berry":
     case "yarn":
       return execSync("yarn --version").toString().trim();
     case "pnpm":

--- a/packages/create-turbo/src/index.ts
+++ b/packages/create-turbo/src/index.ts
@@ -116,15 +116,15 @@ async function run() {
         type: "list",
         message: "Which package manager do you want to use?",
         choices: [
-          { name: "npm", value: "npm" },
+          { name: "npm", value: PACKAGE_MANAGERS["npm"] },
           {
             name: "pnpm",
-            value: "pnpm",
+            value: PACKAGE_MANAGERS["pnpm"],
             disabled: !isPnpmInstalled && "not installed",
           },
           {
             name: "yarn",
-            value: "yarn",
+            value: PACKAGE_MANAGERS["yarn"],
             disabled: !isYarnInstalled && "not installed",
           },
         ],
@@ -180,7 +180,7 @@ async function run() {
   });
 
   sharedPkg.packageManager = `${
-    answers.packageManager
+    answers.packageManager.command
   }@${getPackageManagerVersion(answers.packageManager)}`;
   sharedPkg.name = projectName;
 
@@ -236,7 +236,7 @@ async function run() {
       installArgs.push(`--registry=${npmRegistry}`);
     }
 
-    await execa(`${answers.packageManager}`, installArgs, {
+    await execa(`${answers.packageManager.command}`, installArgs, {
       stdio: "ignore",
       cwd: projectDir,
     });
@@ -280,10 +280,10 @@ async function run() {
   }
 
   console.log();
-  console.log(chalk.cyan(`  ${answers.packageManager} run build`));
+  console.log(chalk.cyan(`  ${answers.packageManager.command} run build`));
   console.log(`     Build all apps and packages`);
   console.log();
-  console.log(chalk.cyan(`  ${answers.packageManager} run dev`));
+  console.log(chalk.cyan(`  ${answers.packageManager.command} run dev`));
   console.log(`     Develop all apps and packages`);
   console.log();
   console.log(`Turborepo will cache locally by default. For an additional`);

--- a/packages/create-turbo/src/types.ts
+++ b/packages/create-turbo/src/types.ts
@@ -1,1 +1,0 @@
-export type PackageManager = "yarn" | "pnpm" | "npm";


### PR DESCRIPTION
This would be somewhat cleaned up in a `corepack` world.