### PR TITLE
Wait for initial delay even with no TTY

### DIFF
--- a/cli/internal/spinner/spinner.go
+++ b/cli/internal/spinner/spinner.go
@@ -71,7 +71,15 @@ func WaitFor(ctx context.Context, fn func(), terminal cli.Ui, msg string, initia
 			return nil
 		}
 	} else {
-		terminal.Output(msg)
+		// wait for the timeout before displaying a message, even with no tty
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-doneCh:
+			return nil
+		case <-time.After(initialDelay):
+			terminal.Output(msg)
+		}
 		select {
 		case <-ctx.Done():
 		case <-doneCh:


### PR DESCRIPTION
In the previous change, I accidentally forgot to wait for a timeout before displaying the message when we're not using a TTY. This unifies the behavior between TTY and no TTY.