### PR TITLE
MacOS times out on large monorepo

### DIFF
--- a/.github/workflows/large-monorepo.yml
+++ b/.github/workflows/large-monorepo.yml
@@ -5,7 +5,7 @@ on: workflow_dispatch
 jobs:
   build:
     name: Run Benchmarks
-    timeout-minutes: 40
+    timeout-minutes: 60
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
40 minutes is sufficient for ubuntu, but not macOS apparently. 