### PR TITLE
Removed blocks from storybook import

### DIFF
--- a/examples/design-system/apps/docs/stories/button.stories.mdx
+++ b/examples/design-system/apps/docs/stories/button.stories.mdx
@@ -1,5 +1,5 @@
 import { Button } from "@acme/core/src";
-import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Preview, Props } from "@storybook/addon-docs";
 
 <Meta title="Components/Button" component={Button} />
 


### PR DESCRIPTION
Removed "/blocks" from "@storybook/addon-docs/blocks" since it's deprecated, one should only use "@storybook/addon-docs".