### PR TITLE
fix(cli): fallback to manual hashing for global

### DIFF
--- a/cli/internal/hashing/package_deps_hash.go
+++ b/cli/internal/hashing/package_deps_hash.go
@@ -94,9 +94,6 @@ func manuallyHashFiles(rootPath turbopath.AbsoluteSystemPath, files []turbopath.
 			return nil, fmt.Errorf("could not hash file %v. \n%w", file.ToString(), err)
 		}
 
-		if err != nil {
-			return nil, fmt.Errorf("File path cannot be made relative: %w", err)
-		}
 		hashObject[file.ToUnixPath()] = hash
 	}
 	return hashObject, nil

--- a/cli/internal/hashing/package_deps_hash.go
+++ b/cli/internal/hashing/package_deps_hash.go
@@ -86,6 +86,22 @@ func GetPackageDeps(rootPath fs.AbsolutePath, p *PackageDepsOptions) (map[turbop
 	return result, nil
 }
 
+func manuallyHashFiles(rootPath turbopath.AbsoluteSystemPath, files []turbopath.AnchoredSystemPath) (map[turbopath.AnchoredUnixPath]string, error) {
+	hashObject := make(map[turbopath.AnchoredUnixPath]string)
+	for _, file := range files {
+		hash, err := fs.GitLikeHashFile(file.ToString())
+		if err != nil {
+			return nil, fmt.Errorf("could not hash file %v. \n%w", file.ToString(), err)
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("File path cannot be made relative: %w", err)
+		}
+		hashObject[file.ToUnixPath()] = hash
+	}
+	return hashObject, nil
+}
+
 // GetHashableDeps hashes the list of given files, then returns a map of normalized path to hash
 // this map is suitable for cross-platform caching.
 func GetHashableDeps(rootPath fs.AbsolutePath, files []turbopath.AbsoluteSystemPath) (map[turbopath.AnchoredUnixPath]string, error) {
@@ -99,10 +115,19 @@ func GetHashableDeps(rootPath fs.AbsolutePath, files []turbopath.AbsoluteSystemP
 		}
 		output[index] = anchoredSystemPath
 	}
-	return gitHashObject(convertedRootPath, output)
+	hashObject, err := gitHashObject(convertedRootPath, output)
+	if err != nil {
+		manuallyHashedObject, err := manuallyHashFiles(convertedRootPath, output)
+		if err != nil {
+			return nil, err
+		}
+		hashObject = manuallyHashedObject
+	}
+
+	return hashObject, nil
 }
 
-// gitHashObject returns a map of paths to their SHA hashes calculated by passing the paths `git hash-object`.
+// gitHashObject returns a map of paths to their SHA hashes calculated by passing the paths to `git hash-object`.
 // `git hash-object` expects paths to use Unix separators, even on Windows.
 //
 // Note: paths of files to hash passed to `git hash-object` are processed as relative to the given anchor.

--- a/cli/internal/run/global_hash.go
+++ b/cli/internal/run/global_hash.go
@@ -88,7 +88,7 @@ func calculateGlobalHash(rootpath fs.AbsolutePath, rootPackageJSON *fs.PackageJS
 
 	globalFileHashMap, err := hashing.GetHashableDeps(rootpath, globalDepsPaths)
 	if err != nil {
-		return "", fmt.Errorf("error hashing files. make sure that git has been initialized %w", err)
+		return "", fmt.Errorf("error hashing files. make sure that git has been initialized: %w", err)
 	}
 	globalHashable := struct {
 		globalFileHashMap    map[turbopath.AnchoredUnixPath]string

--- a/cli/internal/run/global_hash.go
+++ b/cli/internal/run/global_hash.go
@@ -88,7 +88,7 @@ func calculateGlobalHash(rootpath fs.AbsolutePath, rootPackageJSON *fs.PackageJS
 
 	globalFileHashMap, err := hashing.GetHashableDeps(rootpath, globalDepsPaths)
 	if err != nil {
-		return "", fmt.Errorf("error hashing files. make sure that git has been initialized: %w", err)
+		return "", fmt.Errorf("error hashing files: %w", err)
 	}
 	globalHashable := struct {
 		globalFileHashMap    map[turbopath.AnchoredUnixPath]string


### PR DESCRIPTION
Falls back to manual hashing when git is not available for global dependencies

Fixes https://github.com/vercel/turborepo/issues/1257 (follow up to https://github.com/vercel/turborepo/pull/1239/files)