### PR TITLE
Autofix fixable lint issues

### DIFF
--- a/cli/internal/chrometracing/chrometracing.go
+++ b/cli/internal/chrometracing/chrometracing.go
@@ -148,18 +148,18 @@ func (pe *PendingEvent) Done() {
 
 // Event logs a unit of work. To instrument a Go function, use e.g.:
 //
-//   func calcPi() {
-//     defer chrometracing.Event("calculate pi").Done()
-//     // …
-//   }
+//	func calcPi() {
+//	  defer chrometracing.Event("calculate pi").Done()
+//	  // …
+//	}
 //
 // For more finely-granular traces, use e.g.:
 //
-//   for _, cmd := range commands {
-//     ev := chrometracing.Event("initialize " + cmd.Name)
-//     cmd.Init()
-//     ev.Done()
-//   }
+//	for _, cmd := range commands {
+//	  ev := chrometracing.Event("initialize " + cmd.Name)
+//	  cmd.Init()
+//	  ev.Done()
+//	}
 func Event(name string) *PendingEvent {
 	if trace.file == nil {
 		return &PendingEvent{}

--- a/cli/internal/doublestar/glob.go
+++ b/cli/internal/doublestar/glob.go
@@ -25,7 +25,6 @@ import (
 // Like `io/fs.Glob()`, patterns containing `/./`, `/../`, or starting with `/`
 // will return no results and no errors. You can use SplitPattern to divide a
 // pattern into a base path (to initialize an `FS` object) and pattern.
-//
 func Glob(fsys fs.FS, pattern string) ([]string, error) {
 	if !ValidatePattern(pattern) {
 		return nil, ErrBadPattern

--- a/cli/internal/doublestar/globwalk.go
+++ b/cli/internal/doublestar/globwalk.go
@@ -33,7 +33,6 @@ type GlobWalkFunc func(path string, d fs.DirEntry) error
 // separator even if that's not correct for your OS (like Windows). If you
 // aren't sure if that's the case, you can use filepath.ToSlash() on your
 // pattern before calling GlobWalk().
-//
 func GlobWalk(fsys fs.FS, pattern string, fn GlobWalkFunc) error {
 	if !ValidatePattern(pattern) {
 		return ErrBadPattern

--- a/cli/internal/doublestar/match.go
+++ b/cli/internal/doublestar/match.go
@@ -11,24 +11,24 @@ import (
 // Match reports whether name matches the shell pattern.
 // The pattern syntax is:
 //
-//  pattern:
-//    { term }
-//  term:
-//    '*'         matches any sequence of non-path-separators
-//    '/**/'      matches zero or more directories
-//    '?'         matches any single non-path-separator character
-//    '[' [ '^' '!' ] { character-range } ']'
-//                character class (must be non-empty)
-//                starting with `^` or `!` negates the class
-//    '{' { term } [ ',' { term } ... ] '}'
-//                alternatives
-//    c           matches character c (c != '*', '?', '\\', '[')
-//    '\\' c      matches character c
+//	pattern:
+//	  { term }
+//	term:
+//	  '*'         matches any sequence of non-path-separators
+//	  '/**/'      matches zero or more directories
+//	  '?'         matches any single non-path-separator character
+//	  '[' [ '^' '!' ] { character-range } ']'
+//	              character class (must be non-empty)
+//	              starting with `^` or `!` negates the class
+//	  '{' { term } [ ',' { term } ... ] '}'
+//	              alternatives
+//	  c           matches character c (c != '*', '?', '\\', '[')
+//	  '\\' c      matches character c
 //
-//  character-range:
-//    c           matches character c (c != '\\', '-', ']')
-//    '\\' c      matches character c
-//    lo '-' hi   matches character c for lo <= c <= hi
+//	character-range:
+//	  c           matches character c (c != '\\', '-', ']')
+//	  '\\' c      matches character c
+//	  lo '-' hi   matches character c for lo <= c <= hi
 //
 // Match returns true if `name` matches the file name `pattern`. `name` and
 // `pattern` are split on forward slash (`/`) characters and may be relative or
@@ -48,7 +48,6 @@ import (
 // which use a different path separator (such as Windows), what you want
 // is PathMatch(). Alternatively, you can run filepath.ToSlash() on both
 // pattern and name and then use this function.
-//
 func Match(pattern, name string) (bool, error) {
 	return matchWithSeparator(pattern, name, '/', true)
 }
@@ -62,7 +61,6 @@ func Match(pattern, name string) (bool, error) {
 // assumes that both `pattern` and `name` are using the system's path
 // separator. If you can't be sure of that, use filepath.ToSlash() on both
 // `pattern` and `name`, and then use the Match() function instead.
-//
 func PathMatch(pattern, name string) (bool, error) {
 	return matchWithSeparator(pattern, name, filepath.Separator, true)
 }

--- a/cli/internal/doublestar/utils.go
+++ b/cli/internal/doublestar/utils.go
@@ -9,16 +9,16 @@ package doublestar
 // The second string is everything after that slash. For example, given the
 // pattern:
 //
-//   ../../path/to/meta*/**
-//                ^----------- split here
+//	../../path/to/meta*/**
+//	             ^----------- split here
 //
 // SplitPattern returns "../../path/to" and "meta*/**". This is useful for
 // initializing os.DirFS() to call Glob() because Glob() will silently fail if
 // your pattern includes `/./` or `/../`. For example:
 //
-//   base, pattern := SplitPattern("../../path/to/meta*/**")
-//   fsys := os.DirFS(base)
-//   matches, err := Glob(fsys, pattern)
+//	base, pattern := SplitPattern("../../path/to/meta*/**")
+//	fsys := os.DirFS(base)
+//	matches, err := Glob(fsys, pattern)
 //
 // If SplitPattern cannot find somewhere to split the pattern (for example,
 // `meta*/**`), it will return "." and the unaltered pattern (`meta*/**` in
@@ -27,7 +27,6 @@ package doublestar
 // Of course, it is your responsibility to decide if the returned base path is
 // "safe" in the context of your application. Perhaps you could use Match() to
 // validate against a list of approved base directories?
-//
 func SplitPattern(p string) (string, string) {
 	base := "."
 	pattern := p

--- a/cli/internal/doublestar/validate.go
+++ b/cli/internal/doublestar/validate.go
@@ -12,7 +12,6 @@ import "path/filepath"
 // you might want to validate it.
 //
 // ValidatePattern assumes your pattern uses '/' as the path separator.
-//
 func ValidatePattern(s string) bool {
 	return doValidatePattern(s, '/')
 }
@@ -21,7 +20,6 @@ func ValidatePattern(s string) bool {
 // ValidatePattern if you would normally use Match() or Glob(). Use
 // ValidatePathPattern if you would normally use PathMatch(). Keep in mind,
 // Glob() requires '/' separators, even if your OS uses something else.
-//
 func ValidatePathPattern(s string) bool {
 	return doValidatePattern(s, filepath.Separator)
 }

--- a/cli/internal/util/closer.go
+++ b/cli/internal/util/closer.go
@@ -3,10 +3,10 @@ package util
 // CloseAndIgnoreError is a utility to tell our linter that we explicitly deem it okay
 // to not check a particular error on closing of a resource.
 //
-// We use `errcheck“ as a linter, which is super-opinionated about checking errors,
+// We use `errcheck` as a linter, which is super-opinionated about checking errors,
 // even in places where we don't necessarily care to check the error.
 //
-// `golangci-lint“ has a default ignore list for this lint problem (EXC0001) which
+// `golangci-lint` has a default ignore list for this lint problem (EXC0001) which
 // can be used to sidestep this problem but it's possibly a little too-heavy-handed
 // in exclusion. At the expense of discoverability, this utility function forces
 // opt-in to ignoring errors on closing of things that can be `Close`d.

--- a/cli/internal/util/closer.go
+++ b/cli/internal/util/closer.go
@@ -3,10 +3,10 @@ package util
 // CloseAndIgnoreError is a utility to tell our linter that we explicitly deem it okay
 // to not check a particular error on closing of a resource.
 //
-// We use `errcheck`` as a linter, which is super-opinionated about checking errors,
+// We use `errcheck“ as a linter, which is super-opinionated about checking errors,
 // even in places where we don't necessarily care to check the error.
 //
-// `golangci-lint`` has a default ignore list for this lint problem (EXC0001) which
+// `golangci-lint“ has a default ignore list for this lint problem (EXC0001) which
 // can be used to sidestep this problem but it's possibly a little too-heavy-handed
 // in exclusion. At the expense of discoverability, this utility function forces
 // opt-in to ignoring errors on closing of things that can be `Close`d.

--- a/cli/internal/util/filter/filter.go
+++ b/cli/internal/util/filter/filter.go
@@ -16,11 +16,10 @@ type Filter interface {
 // for matching a given string against the filter list. The filter list
 // supports glob matching too, ie:
 //
-//   f, _ := Compile([]string{"cpu", "mem", "net*"})
-//   f.Match("cpu")     // true
-//   f.Match("network") // true
-//   f.Match("memory")  // false
-//
+//	f, _ := Compile([]string{"cpu", "mem", "net*"})
+//	f.Match("cpu")     // true
+//	f.Match("network") // true
+//	f.Match("memory")  // false
 func Compile(filters []string) (Filter, error) {
 	// return if there is nothing to compile
 	if len(filters) == 0 {


### PR DESCRIPTION
We have a ton of lint errors not getting caught in CI right now, because it only runs lint on new code every PR. This at least runs the lint and fixes things that can be fixed automatically.

```
golangci-lint run --fix
```