### PR TITLE
Remove command flag shorthands from docs.

### DIFF
--- a/docs/pages/docs/getting-started.mdx
+++ b/docs/pages/docs/getting-started.mdx
@@ -88,17 +88,17 @@ Add [`turbo`](https://www.npmjs.com/package/turbo) as a development dependency a
 <Tabs items={['npm', 'yarn', 'pnpm']} storageKey="selected-pkg-manager">
   <Tab>
     ```bash
-    npm install turbo -D
+    npm install turbo --save-dev
     ```
   </Tab>
   <Tab>
     ```bash
-    yarn add turbo -DW
+    yarn add turbo --dev --ignore-workspace-root-check
     ```
   </Tab>
   <Tab>
     ```bash
-    pnpm add turbo -Dw
+    yarn add turbo --save-dev --ignore-workspace-root-check
     ```
   </Tab>
 </Tabs>

--- a/docs/pages/docs/guides/migrate-from-lerna.mdx
+++ b/docs/pages/docs/guides/migrate-from-lerna.mdx
@@ -81,17 +81,17 @@ import { Tabs, Tab } from '../../../components/Tabs'
 <Tabs items={['npm', 'yarn', 'pnpm']} storageKey="selected-pkg-manager">
   <Tab>
     ```bash
-    npm install turbo -D
+    npm install turbo --save-dev
     ```
   </Tab>
   <Tab>
     ```bash
-    yarn add turbo --dev -W
+    yarn add turbo --dev --ignore-workspace-root-check
     ```
   </Tab>
   <Tab>
     ```bash
-    pnpm add turbo -Dw
+    yarn add turbo --save-dev --ignore-workspace-root-check
     ```
   </Tab>
 </Tabs>

--- a/docs/pages/docs/upgrading-to-v1.mdx
+++ b/docs/pages/docs/upgrading-to-v1.mdx
@@ -34,7 +34,7 @@ rm -rf .turbo
 Install the latest version version of `turbo`:
 
 ```sh
-yarn add turbo -W --dev
+yarn add turbo --save-dev --ignore-workspace-root-check
 ```
 
 ## 3. Setup Remote Caching


### PR DESCRIPTION
Shorthand command flags are for expert users, we want to teach users what is happening.