### PR TITLE
Change fs.ReadPackageJSON to operate on AbsolutePath instances

### DIFF
--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -308,14 +308,12 @@ func (c *Context) parsePackageJSON(repoRoot fs.AbsolutePath, pkgJSONPath fs.Abso
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	// log.Printf("[TRACE] reading package.json : %+v", buildFilePath)
 	if pkgJSONPath.FileExists() {
 		pkg, err := fs.ReadPackageJSON(pkgJSONPath)
 		if err != nil {
 			return fmt.Errorf("parsing %s: %w", pkgJSONPath, err)
 		}
 
-		// log.Printf("[TRACE] adding %+v to graph", pkg.Name)
 		relativePkgJSONPath, err := repoRoot.PathTo(pkgJSONPath)
 		if err != nil {
 			return err

--- a/cli/internal/fs/package_json.go
+++ b/cli/internal/fs/package_json.go
@@ -2,25 +2,26 @@ package fs
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"sync"
+
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 )
 
 // PackageJSON represents NodeJS package.json
 type PackageJSON struct {
-	Name                   string            `json:"name,omitempty"`
-	Version                string            `json:"version,omitempty"`
-	Scripts                map[string]string `json:"scripts,omitempty"`
-	Dependencies           map[string]string `json:"dependencies,omitempty"`
-	DevDependencies        map[string]string `json:"devDependencies,omitempty"`
-	OptionalDependencies   map[string]string `json:"optionalDependencies,omitempty"`
-	PeerDependencies       map[string]string `json:"peerDependencies,omitempty"`
-	PackageManager         string            `json:"packageManager,omitempty"`
-	Os                     []string          `json:"os,omitempty"`
-	Workspaces             Workspaces        `json:"workspaces,omitempty"`
-	Private                bool              `json:"private,omitempty"`
-	PackageJSONPath        string
-	Dir                    string // relative path from repo root to the package
+	Name                   string                       `json:"name,omitempty"`
+	Version                string                       `json:"version,omitempty"`
+	Scripts                map[string]string            `json:"scripts,omitempty"`
+	Dependencies           map[string]string            `json:"dependencies,omitempty"`
+	DevDependencies        map[string]string            `json:"devDependencies,omitempty"`
+	OptionalDependencies   map[string]string            `json:"optionalDependencies,omitempty"`
+	PeerDependencies       map[string]string            `json:"peerDependencies,omitempty"`
+	PackageManager         string                       `json:"packageManager,omitempty"`
+	Os                     []string                     `json:"os,omitempty"`
+	Workspaces             Workspaces                   `json:"workspaces,omitempty"`
+	Private                bool                         `json:"private,omitempty"`
+	PackageJSONPath        turbopath.AnchoredSystemPath // relative path from repo root to the package.json file
+	Dir                    turbopath.AnchoredSystemPath // relative path from repo root to the package
 	InternalDeps           []string
 	UnresolvedExternalDeps map[string]string
 	ExternalDeps           []string
@@ -50,18 +51,15 @@ func (r *Workspaces) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// Parse parses package.json payload and returns structure.
-func Parse(payload []byte) (*PackageJSON, error) {
-	var packagejson *PackageJSON
-	err := json.Unmarshal(payload, &packagejson)
-	return packagejson, err
-}
-
 // ReadPackageJSON returns a struct of package.json
-func ReadPackageJSON(path string) (*PackageJSON, error) {
-	b, err := ioutil.ReadFile(path)
+func ReadPackageJSON(path AbsolutePath) (*PackageJSON, error) {
+	b, err := path.ReadFile()
 	if err != nil {
 		return nil, err
 	}
-	return Parse(b)
+	packageJSON := &PackageJSON{}
+	if err := json.Unmarshal(b, packageJSON); err != nil {
+		return nil, err
+	}
+	return packageJSON, nil
 }

--- a/cli/internal/fs/path.go
+++ b/cli/internal/fs/path.go
@@ -148,6 +148,12 @@ func (ap AbsolutePath) RelativePathString(path string) (string, error) {
 	return filepath.Rel(ap.asString(), path)
 }
 
+// PathTo returns the relative path between two absolute paths
+// This should likely eventually return an AnchoredSystemPath
+func (ap AbsolutePath) PathTo(other AbsolutePath) (string, error) {
+	return ap.RelativePathString(other.asString())
+}
+
 // Symlink implements os.Symlink(target, ap) for absolute path
 func (ap AbsolutePath) Symlink(target string) error {
 	return os.Symlink(target, ap.asString())

--- a/cli/internal/fs/turbo_json_test.go
+++ b/cli/internal/fs/turbo_json_test.go
@@ -22,7 +22,7 @@ func Test_ReadTurboConfig(t *testing.T) {
 	rootDir := "testdata"
 	turboJSONPath := cwd.Join(rootDir)
 	packageJSONPath := cwd.Join(rootDir, "package.json")
-	rootPackageJSON, pkgJSONReadErr := ReadPackageJSON(packageJSONPath.ToStringDuringMigration())
+	rootPackageJSON, pkgJSONReadErr := ReadPackageJSON(packageJSONPath)
 
 	if pkgJSONReadErr != nil {
 		t.Fatalf("invalid parse: %#v", pkgJSONReadErr)

--- a/cli/internal/globby/globby.go
+++ b/cli/internal/globby/globby.go
@@ -14,6 +14,7 @@ import (
 )
 
 // GlobFiles returns an array of files that match the specified set of glob patterns.
+// The return files are absolute paths, assuming that basePath is an absolute path.
 func GlobFiles(basePath string, includePatterns []string, excludePatterns []string) ([]string, error) {
 	fsys := fs.CreateDirFSAtRoot(basePath)
 	fsysRoot := fs.GetDirFSRootPath(fsys)

--- a/cli/internal/hashing/package_deps_hash.go
+++ b/cli/internal/hashing/package_deps_hash.go
@@ -21,14 +21,14 @@ import (
 type PackageDepsOptions struct {
 	// PackagePath is the folder path to derive the package dependencies from. This is typically the folder
 	// containing package.json. If omitted, the default value is the current working directory.
-	PackagePath string
+	PackagePath turbopath.AnchoredSystemPath
 
 	InputPatterns []string
 }
 
 // GetPackageDeps Builds an object containing git hashes for the files under the specified `packagePath` folder.
 func GetPackageDeps(rootPath fs.AbsolutePath, p *PackageDepsOptions) (map[turbopath.AnchoredUnixPath]string, error) {
-	pkgPath := rootPath.Join(p.PackagePath)
+	pkgPath := rootPath.Join(p.PackagePath.ToStringDuringMigration())
 	// Add all the checked in hashes.
 	var result map[turbopath.AnchoredUnixPath]string
 	if len(p.InputPatterns) == 0 {

--- a/cli/internal/nodes/packagetask.go
+++ b/cli/internal/nodes/packagetask.go
@@ -34,7 +34,7 @@ func (pt *PackageTask) OutputPrefix() string {
 // RepoRelativeLogFile returns the path to the log file for this task execution as a
 // relative path from the root of the monorepo.
 func (pt *PackageTask) RepoRelativeLogFile() string {
-	return filepath.Join(pt.Pkg.Dir, ".turbo", fmt.Sprintf("turbo-%v.log", pt.Task))
+	return filepath.Join(pt.Pkg.Dir.ToStringDuringMigration(), ".turbo", fmt.Sprintf("turbo-%v.log", pt.Task))
 }
 
 // HashableOutputs returns the package-relative globs for files to be considered outputs

--- a/cli/internal/packagemanager/berry.go
+++ b/cli/internal/packagemanager/berry.go
@@ -19,7 +19,7 @@ var nodejsBerry = PackageManager{
 	PackageDir: "node_modules",
 
 	getWorkspaceGlobs: func(rootpath fs.AbsolutePath) ([]string, error) {
-		pkg, err := fs.ReadPackageJSON(rootpath.Join("package.json").ToStringDuringMigration())
+		pkg, err := fs.ReadPackageJSON(rootpath.Join("package.json"))
 		if err != nil {
 			return nil, fmt.Errorf("package.json: %w", err)
 		}

--- a/cli/internal/packagemanager/npm.go
+++ b/cli/internal/packagemanager/npm.go
@@ -16,7 +16,7 @@ var nodejsNpm = PackageManager{
 	ArgSeparator: []string{"--"},
 
 	getWorkspaceGlobs: func(rootpath fs.AbsolutePath) ([]string, error) {
-		pkg, err := fs.ReadPackageJSON(rootpath.Join("package.json").ToStringDuringMigration())
+		pkg, err := fs.ReadPackageJSON(rootpath.Join("package.json"))
 		if err != nil {
 			return nil, fmt.Errorf("package.json: %w", err)
 		}

--- a/cli/internal/packagemanager/yarn.go
+++ b/cli/internal/packagemanager/yarn.go
@@ -20,7 +20,7 @@ var nodejsYarn = PackageManager{
 	ArgSeparator: []string{"--"},
 
 	getWorkspaceGlobs: func(rootpath fs.AbsolutePath) ([]string, error) {
-		pkg, err := fs.ReadPackageJSON(rootpath.Join("package.json").ToStringDuringMigration())
+		pkg, err := fs.ReadPackageJSON(rootpath.Join("package.json"))
 		if err != nil {
 			return nil, fmt.Errorf("package.json: %w", err)
 		}

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -203,7 +203,7 @@ type run struct {
 func (r *run) run(ctx gocontext.Context, targets []string) error {
 	startAt := time.Now()
 	packageJSONPath := r.config.Cwd.Join("package.json")
-	rootPackageJSON, err := fs.ReadPackageJSON(packageJSONPath.ToStringDuringMigration())
+	rootPackageJSON, err := fs.ReadPackageJSON(packageJSONPath)
 	if err != nil {
 		return fmt.Errorf("failed to read package.json: %w", err)
 	}
@@ -824,7 +824,7 @@ func (r *run) executeDryRun(ctx gocontext.Context, engine *core.Scheduler, g *co
 			Package:      pt.PackageName,
 			Hash:         hash,
 			Command:      command,
-			Dir:          pt.Pkg.Dir,
+			Dir:          pt.Pkg.Dir.ToString(),
 			Outputs:      pt.TaskDefinition.Outputs,
 			LogFile:      pt.RepoRelativeLogFile(),
 			Dependencies: stringAncestors,
@@ -937,7 +937,8 @@ func (e *execContext) exec(ctx gocontext.Context, pt *nodes.PackageTask, deps da
 	}
 
 	cmd := exec.Command(e.packageManager.Command, argsactual...)
-	cmd.Dir = pt.Pkg.Dir
+	// TODO(gsoltis): I think this might be an actual bug? cmd.Dir should probably be an absolute path
+	cmd.Dir = pt.Pkg.Dir.ToStringDuringMigration()
 	envs := fmt.Sprintf("TURBO_HASH=%v", hash)
 	cmd.Env = append(os.Environ(), envs)
 

--- a/cli/internal/runcache/runcache.go
+++ b/cli/internal/runcache/runcache.go
@@ -286,7 +286,7 @@ func (tc TaskCache) SaveOutputs(ctx context.Context, logger hclog.Logger, termin
 		relativePaths[index] = relativePath
 	}
 
-	if err = tc.rc.cache.Put(tc.pt.Pkg.Dir, tc.hash, duration, relativePaths); err != nil {
+	if err = tc.rc.cache.Put(tc.pt.Pkg.Dir.ToStringDuringMigration(), tc.hash, duration, relativePaths); err != nil {
 		return err
 	}
 	err = tc.rc.outputWatcher.NotifyOutputsWritten(ctx, tc.hash, tc.repoRelativeGlobs)
@@ -306,7 +306,7 @@ func (rc *RunCache) TaskCache(pt *nodes.PackageTask, hash string) TaskCache {
 	hashableOutputs := pt.HashableOutputs()
 	repoRelativeGlobs := make([]string, len(hashableOutputs))
 	for index, output := range hashableOutputs {
-		repoRelativeGlobs[index] = filepath.Join(pt.Pkg.Dir, output)
+		repoRelativeGlobs[index] = filepath.Join(pt.Pkg.Dir.ToStringDuringMigration(), output)
 	}
 
 	taskOutputMode := pt.TaskDefinition.OutputMode

--- a/cli/internal/scope/filter/filter.go
+++ b/cli/internal/scope/filter/filter.go
@@ -214,7 +214,7 @@ func (r *Resolver) filterNodesWithSelector(selector *TargetSelector) (util.Set, 
 					}
 				} else if pkg, ok := r.PackageInfos[pkgName]; !ok {
 					return nil, fmt.Errorf("missing info for package %v", pkgName)
-				} else if matches, err := doublestar.PathMatch(parentDir, filepath.Join(r.Cwd, pkg.Dir)); err != nil {
+				} else if matches, err := doublestar.PathMatch(parentDir, filepath.Join(r.Cwd, pkg.Dir.ToStringDuringMigration())); err != nil {
 					return nil, fmt.Errorf("failed to resolve directory relationship %v contains %v: %v", selector.parentDir, pkg.Dir, err)
 				} else if matches {
 					entryPackages.Add(pkgName)
@@ -231,7 +231,7 @@ func (r *Resolver) filterNodesWithSelector(selector *TargetSelector) (util.Set, 
 			entryPackages.Add(util.RootPkgName)
 		} else {
 			for name, pkg := range r.PackageInfos {
-				if matches, err := doublestar.PathMatch(parentDir, filepath.Join(r.Cwd, pkg.Dir)); err != nil {
+				if matches, err := doublestar.PathMatch(parentDir, filepath.Join(r.Cwd, pkg.Dir.ToStringDuringMigration())); err != nil {
 					return nil, fmt.Errorf("failed to resolve directory relationship %v contains %v: %v", selector.parentDir, pkg.Dir, err)
 				} else if matches {
 					entryPackages.Add(name)
@@ -281,7 +281,7 @@ func (r *Resolver) filterSubtreesWithSelector(selector *TargetSelector) (util.Se
 	for name, pkg := range r.PackageInfos {
 		if parentDir == "" {
 			entryPackages.Add(name)
-		} else if matches, err := doublestar.PathMatch(parentDir, pkg.Dir); err != nil {
+		} else if matches, err := doublestar.PathMatch(parentDir, pkg.Dir.ToStringDuringMigration()); err != nil {
 			return nil, fmt.Errorf("failed to resolve directory relationship %v contains %v: %v", selector.parentDir, pkg.Dir, err)
 		} else if matches {
 			entryPackages.Add(name)

--- a/cli/internal/scope/filter/filter_test.go
+++ b/cli/internal/scope/filter/filter_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pyr-sh/dag"
 	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"github.com/vercel/turborepo/cli/internal/util"
 )
 
@@ -37,12 +38,12 @@ func Test_filter(t *testing.T) {
 	graph.Add("project-0")
 	packageJSONs["project-0"] = &fs.PackageJSON{
 		Name: "project-0",
-		Dir:  filepath.Join("packages", "project-0"),
+		Dir:  turbopath.AnchoredSystemPath(filepath.Join("packages", "project-0")),
 	}
 	graph.Add("project-1")
 	packageJSONs["project-1"] = &fs.PackageJSON{
 		Name: "project-1",
-		Dir:  filepath.Join("packages", "project-1"),
+		Dir:  turbopath.AnchoredSystemPath(filepath.Join("packages", "project-1")),
 	}
 	graph.Add("project-2")
 	packageJSONs["project-2"] = &fs.PackageJSON{
@@ -68,7 +69,7 @@ func Test_filter(t *testing.T) {
 	graph.Add("project-6")
 	packageJSONs["project-6"] = &fs.PackageJSON{
 		Name: "project-6",
-		Dir:  filepath.Join("project-5", "packages", "project-6"),
+		Dir:  turbopath.AnchoredSystemPath(filepath.Join("project-5", "packages", "project-6")),
 	}
 	// Add dependencies
 	graph.Connect(dag.BasicEdge("project-0", "project-1"))
@@ -287,7 +288,7 @@ func Test_matchScopedPackage(t *testing.T) {
 	graph.Add("@foo/bar")
 	packageJSONs["@foo/bar"] = &fs.PackageJSON{
 		Name: "@foo/bar",
-		Dir:  filepath.Join(root, "packages", "bar"),
+		Dir:  turbopath.AnchoredSystemPath(filepath.Join(root, "packages", "bar")),
 	}
 	r := &Resolver{
 		Graph:        graph,
@@ -315,12 +316,12 @@ func Test_matchExactPackages(t *testing.T) {
 	graph.Add("@foo/bar")
 	packageJSONs["@foo/bar"] = &fs.PackageJSON{
 		Name: "@foo/bar",
-		Dir:  filepath.Join(root, "packages", "@foo", "bar"),
+		Dir:  turbopath.AnchoredSystemPath(filepath.Join(root, "packages", "@foo", "bar")),
 	}
 	graph.Add("bar")
 	packageJSONs["bar"] = &fs.PackageJSON{
 		Name: "bar",
-		Dir:  filepath.Join(root, "packages", "bar"),
+		Dir:  turbopath.AnchoredSystemPath(filepath.Join(root, "packages", "bar")),
 	}
 	r := &Resolver{
 		Graph:        graph,
@@ -348,12 +349,12 @@ func Test_matchMultipleScopedPackages(t *testing.T) {
 	graph.Add("@foo/bar")
 	packageJSONs["@foo/bar"] = &fs.PackageJSON{
 		Name: "@foo/bar",
-		Dir:  filepath.Join(root, "packages", "@foo", "bar"),
+		Dir:  turbopath.AnchoredSystemPath(filepath.Join(root, "packages", "@foo", "bar")),
 	}
 	graph.Add("@types/bar")
 	packageJSONs["@types/bar"] = &fs.PackageJSON{
 		Name: "@types/bar",
-		Dir:  filepath.Join(root, "packages", "@types", "bar"),
+		Dir:  turbopath.AnchoredSystemPath(filepath.Join(root, "packages", "@types", "bar")),
 	}
 	r := &Resolver{
 		Graph:        graph,

--- a/cli/internal/scope/scope.go
+++ b/cli/internal/scope/scope.go
@@ -235,7 +235,7 @@ func getChangedPackages(changedFiles []string, packageInfos map[interface{}]*fs.
 	for _, changedFile := range changedFiles {
 		found := false
 		for pkgName, pkgInfo := range packageInfos {
-			if pkgName != util.RootPkgName && fileInPackage(changedFile, pkgInfo.Dir) {
+			if pkgName != util.RootPkgName && fileInPackage(changedFile, pkgInfo.Dir.ToStringDuringMigration()) {
 				changedPackages.Add(pkgName)
 				found = true
 				break

--- a/cli/internal/scope/scope_test.go
+++ b/cli/internal/scope/scope_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pyr-sh/dag"
 	"github.com/vercel/turborepo/cli/internal/context"
 	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"github.com/vercel/turborepo/cli/internal/ui"
 	"github.com/vercel/turborepo/cli/internal/util"
 )
@@ -56,28 +57,28 @@ func TestResolvePackages(t *testing.T) {
 	graph.Connect(dag.BasicEdge("app2-a", "libC"))
 	packagesInfos := map[interface{}]*fs.PackageJSON{
 		"app0": {
-			Dir: filepath.FromSlash("app/app0"),
+			Dir: turbopath.AnchoredSystemPath(filepath.FromSlash("app/app0")),
 		},
 		"app1": {
-			Dir: filepath.FromSlash("app/app1"),
+			Dir: turbopath.AnchoredSystemPath(filepath.FromSlash("app/app1")),
 		},
 		"app2": {
-			Dir: filepath.FromSlash("app/app2"),
+			Dir: turbopath.AnchoredSystemPath(filepath.FromSlash("app/app2")),
 		},
 		"app2-a": {
-			Dir: filepath.FromSlash("app/app2-a"),
+			Dir: turbopath.AnchoredSystemPath(filepath.FromSlash("app/app2-a")),
 		},
 		"libA": {
-			Dir: filepath.FromSlash("libs/libA"),
+			Dir: turbopath.AnchoredSystemPath(filepath.FromSlash("libs/libA")),
 		},
 		"libB": {
-			Dir: filepath.FromSlash("libs/libB"),
+			Dir: turbopath.AnchoredSystemPath(filepath.FromSlash("libs/libB")),
 		},
 		"libC": {
-			Dir: filepath.FromSlash("libs/libC"),
+			Dir: turbopath.AnchoredSystemPath(filepath.FromSlash("libs/libC")),
 		},
 		"libD": {
-			Dir: filepath.FromSlash("libs/libD"),
+			Dir: turbopath.AnchoredSystemPath(filepath.FromSlash("libs/libD")),
 		},
 	}
 	packageNames := []string{}

--- a/cli/internal/taskhash/taskhash.go
+++ b/cli/internal/taskhash/taskhash.go
@@ -105,7 +105,7 @@ func manuallyHashPackage(pkg *fs.PackageJSON, inputs []string, rootPath fs.Absol
 		return nil, err
 	}
 
-	ignorePkg, err := safeCompileIgnoreFile(rootPath.Join(pkg.Dir, ".gitignore").ToString())
+	ignorePkg, err := safeCompileIgnoreFile(rootPath.Join(pkg.Dir.ToStringDuringMigration(), ".gitignore").ToString())
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +115,7 @@ func manuallyHashPackage(pkg *fs.PackageJSON, inputs []string, rootPath fs.Absol
 		includePattern = "{" + strings.Join(inputs, ",") + "}"
 	}
 
-	pathPrefix := rootPath.Join(pkg.Dir).ToString()
+	pathPrefix := rootPath.Join(pkg.Dir.ToStringDuringMigration()).ToString()
 	convertedPathPrefix := turbopath.AbsoluteSystemPathFromUpstream(pathPrefix)
 	fs.Walk(pathPrefix, func(name string, isDir bool) error {
 		convertedName := turbopath.AbsoluteSystemPathFromUpstream(name)

--- a/cli/internal/taskhash/taskhash_test.go
+++ b/cli/internal/taskhash/taskhash_test.go
@@ -51,7 +51,7 @@ func Test_manuallyHashPackage(t *testing.T) {
 		t.Fatalf("failed to write contents to .gitignore: %v", err)
 	}
 	rootIgnoreFile.Close()
-	pkgIgnoreFilename := repoRoot.Join(turbopath.RelativeSystemPath(pkgName.ToString()), ".gitignore")
+	pkgIgnoreFilename := pkgName.RestoreAnchor(repoRoot).Join(".gitignore")
 	err = fs.EnsureDir(pkgIgnoreFilename.ToString())
 	if err != nil {
 		t.Fatalf("failed to ensure directories for %v: %v", pkgIgnoreFilename, err)

--- a/cli/internal/taskhash/taskhash_test.go
+++ b/cli/internal/taskhash/taskhash_test.go
@@ -24,7 +24,7 @@ func Test_manuallyHashPackage(t *testing.T) {
 		t.Fatalf("failed to create temp dir: %v", err)
 	}
 	repoRoot := turbopath.AbsoluteSystemPathFromUpstream(root)
-	pkgName := turbopath.RelativeSystemPath("libA")
+	pkgName := turbopath.AnchoredSystemPath("libA")
 	type fileHash struct {
 		contents string
 		hash     string
@@ -51,7 +51,7 @@ func Test_manuallyHashPackage(t *testing.T) {
 		t.Fatalf("failed to write contents to .gitignore: %v", err)
 	}
 	rootIgnoreFile.Close()
-	pkgIgnoreFilename := repoRoot.Join(pkgName, ".gitignore")
+	pkgIgnoreFilename := repoRoot.Join(turbopath.RelativeSystemPath(pkgName.ToString()), ".gitignore")
 	err = fs.EnsureDir(pkgIgnoreFilename.ToString())
 	if err != nil {
 		t.Fatalf("failed to ensure directories for %v: %v", pkgIgnoreFilename, err)
@@ -85,7 +85,7 @@ func Test_manuallyHashPackage(t *testing.T) {
 	files[turbopath.AnchoredUnixPath("libA/.gitignore")] = fileHash{contents: "", hash: "3237694bc3312ded18386964a855074af7b066af"}
 
 	pkg := &fs.PackageJSON{
-		Dir: pkgName.ToString(),
+		Dir: pkgName,
 	}
 	hashes, err := manuallyHashPackage(pkg, []string{}, fs.AbsolutePath(repoRoot.ToString()))
 	if err != nil {

--- a/cli/internal/turbopath/anchored_system_path.go
+++ b/cli/internal/turbopath/anchored_system_path.go
@@ -11,6 +11,13 @@ func (p AnchoredSystemPath) ToString() string {
 	return string(p)
 }
 
+// ToStringDuringMigration returns the string representation of this path, and is for
+// use in situations where we expect a future path migration to remove the need for the
+// string representation
+func (p AnchoredSystemPath) ToStringDuringMigration() string {
+	return string(p)
+}
+
 // ToSystemPath returns itself.
 func (p AnchoredSystemPath) ToSystemPath() AnchoredSystemPath {
 	return p


### PR DESCRIPTION
Updates `fs.ReadPackageJSON` to take an `AbsolutePath` so that we respect `--cwd`
Pulls the thread on updating `PackageJSON.Dir` and `PackageJSON.PackageJSONPath` to have the correct `turbopath` types.

cc @nathanhammond note in particular changes to `taskhash_test.go`