### PR TITLE
Move `fs.AbsolutePath` to `turbopath.AbsolutePath`

### DIFF
--- a/cli/internal/cache/cache.go
+++ b/cli/internal/cache/cache.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vercel/turborepo/cli/internal/analytics"
 	"github.com/vercel/turborepo/cli/internal/config"
 	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"github.com/vercel/turborepo/cli/internal/ui"
 	"github.com/vercel/turborepo/cli/internal/util"
 	"golang.org/x/sync/errgroup"
@@ -42,7 +43,7 @@ type CacheEvent struct {
 }
 
 // DefaultLocation returns the default filesystem cache location, given a repo root
-func DefaultLocation(repoRoot fs.AbsolutePath) fs.AbsolutePath {
+func DefaultLocation(repoRoot turbopath.AbsolutePath) turbopath.AbsolutePath {
 	return repoRoot.Join("node_modules", ".cache", "turbo")
 }
 
@@ -57,7 +58,7 @@ var ErrNoCachesEnabled = errors.New("no caches are enabled")
 // Opts holds configuration options for the cache
 // TODO(gsoltis): further refactor this into fs cache opts and http cache opts
 type Opts struct {
-	Dir             fs.AbsolutePath
+	Dir             turbopath.AbsolutePath
 	SkipRemote      bool
 	SkipFilesystem  bool
 	Workers         int
@@ -68,7 +69,7 @@ var _remoteOnlyHelp = `Ignore the local filesystem cache for all tasks. Only
 allow reading and caching artifacts using the remote cache.`
 
 // AddFlags adds cache-related flags to the given FlagSet
-func AddFlags(opts *Opts, flags *pflag.FlagSet, repoRoot fs.AbsolutePath) {
+func AddFlags(opts *Opts, flags *pflag.FlagSet, repoRoot turbopath.AbsolutePath) {
 	// skipping remote caching not currently a flag
 	flags.BoolVar(&opts.SkipFilesystem, "remote-only", false, _remoteOnlyHelp)
 	fs.AbsolutePathVar(flags, &opts.Dir, "cache-dir", repoRoot, "Specify local filesystem cache directory.", "./node_modules/.cache/turbo")

--- a/cli/internal/cache/cache_fs.go
+++ b/cli/internal/cache/cache_fs.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/vercel/turborepo/cli/internal/analytics"
 	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -19,11 +20,11 @@ import (
 type fsCache struct {
 	cacheDirectory string
 	recorder       analytics.Recorder
-	repoRoot       fs.AbsolutePath
+	repoRoot       turbopath.AbsolutePath
 }
 
 // newFsCache creates a new filesystem cache
-func newFsCache(opts Opts, recorder analytics.Recorder, repoRoot fs.AbsolutePath) (*fsCache, error) {
+func newFsCache(opts Opts, recorder analytics.Recorder, repoRoot turbopath.AbsolutePath) (*fsCache, error) {
 	if err := opts.Dir.MkdirAll(); err != nil {
 		return nil, err
 	}

--- a/cli/internal/cache/cache_http.go
+++ b/cli/internal/cache/cache_http.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	"github.com/vercel/turborepo/cli/internal/analytics"
-	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 )
 
 type client interface {
@@ -33,7 +33,7 @@ type httpCache struct {
 	requestLimiter limiter
 	recorder       analytics.Recorder
 	signerVerifier *ArtifactSignatureAuthentication
-	repoRoot       fs.AbsolutePath
+	repoRoot       turbopath.AbsolutePath
 }
 
 type limiter chan struct{}
@@ -223,7 +223,7 @@ func (cache *httpCache) retrieve(hash string) (bool, []string, int, error) {
 // restored. In the future, these should likely be repo-relative system paths
 // so that they are suitable for being fed into cache.Put for other caches.
 // For now, I think this is working because windows also accepts /-delimited paths.
-func restoreTar(root fs.AbsolutePath, reader io.Reader) ([]string, error) {
+func restoreTar(root turbopath.AbsolutePath, reader io.Reader) ([]string, error) {
 	files := []string{}
 	missingLinks := []*tar.Header{}
 	gzr, err := gzip.NewReader(reader)
@@ -288,7 +288,7 @@ func restoreTar(root fs.AbsolutePath, reader io.Reader) ([]string, error) {
 
 var errNonexistentLinkTarget = errors.New("the link target does not exist")
 
-func restoreSymlink(root fs.AbsolutePath, hdr *tar.Header, allowNonexistentTargets bool) error {
+func restoreSymlink(root turbopath.AbsolutePath, hdr *tar.Header, allowNonexistentTargets bool) error {
 	// Note that hdr.Linkname is really the link target
 	relativeLinkTarget := filepath.FromSlash(hdr.Linkname)
 	linkFilename := root.Join(hdr.Name)
@@ -328,7 +328,7 @@ func (cache *httpCache) CleanAll() {
 
 func (cache *httpCache) Shutdown() {}
 
-func newHTTPCache(opts Opts, teamID string, client client, recorder analytics.Recorder, repoRoot fs.AbsolutePath) *httpCache {
+func newHTTPCache(opts Opts, teamID string, client client, recorder analytics.Recorder, repoRoot turbopath.AbsolutePath) *httpCache {
 	return &httpCache{
 		writable:       true,
 		client:         client,

--- a/cli/internal/cache/cache_test.go
+++ b/cli/internal/cache/cache_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/vercel/turborepo/cli/internal/analytics"
 	"github.com/vercel/turborepo/cli/internal/config"
 	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"github.com/vercel/turborepo/cli/internal/util"
 )
 
@@ -208,7 +209,7 @@ func TestNew(t *testing.T) {
 			name: "With just fsCache configured, new returns only an fsCache",
 			args: args{
 				opts: Opts{
-					Dir:            fs.AbsolutePath(cwd),
+					Dir:            turbopath.AbsolutePath(cwd),
 					SkipFilesystem: false,
 					SkipRemote:     true,
 				},
@@ -223,7 +224,7 @@ func TestNew(t *testing.T) {
 			name: "With both configured, new returns an fsCache and httpCache",
 			args: args{
 				opts: Opts{
-					Dir:            fs.AbsolutePath(cwd),
+					Dir:            turbopath.AbsolutePath(cwd),
 					SkipFilesystem: false,
 					SkipRemote:     false,
 					RemoteCacheOpts: fs.RemoteCacheOptions{

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/vercel/turborepo/cli/internal/client"
 	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/mattn/go-isatty"
@@ -35,7 +36,7 @@ type Config struct {
 	TurboVersion string
 	Cache        *CacheConfig
 	// Current Working Directory
-	Cwd fs.AbsolutePath
+	Cwd turbopath.AbsolutePath
 
 	UsePreflight      bool
 	MaxClientFailures uint64
@@ -56,7 +57,7 @@ type CacheConfig struct {
 // ParseAndValidate parses the cmd line flags / env vars, and verifies that all required
 // flags have been set. Users can pass in flags when calling a subcommand, or set env vars
 // with the prefix 'TURBO_'. If both values are set, the env var value will be used.
-func ParseAndValidate(args []string, ui cli.Ui, turboVersion string, userConfigFile fs.AbsolutePath) (c *Config, err error) {
+func ParseAndValidate(args []string, ui cli.Ui, turboVersion string, userConfigFile turbopath.AbsolutePath) (c *Config, err error) {
 
 	// Special check for ./turbo invocation without any args
 	// Return the help message
@@ -209,7 +210,7 @@ func (c *Config) NewClient() *client.ApiClient {
 // so we do as well. This means that relative references out of the monorepo
 // will be relative to the resolved path, not necessarily the path that the
 // user uses to access the monorepo.
-func selectCwd(inputArgs []string) (fs.AbsolutePath, error) {
+func selectCwd(inputArgs []string) (turbopath.AbsolutePath, error) {
 	cwd, err := fs.GetCwd()
 	if err != nil {
 		return "", err

--- a/cli/internal/config/config_file.go
+++ b/cli/internal/config/config_file.go
@@ -6,12 +6,13 @@ import (
 	"github.com/spf13/viper"
 	"github.com/vercel/turborepo/cli/internal/client"
 	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 )
 
 // RepoConfig is a configuration object for the logged-in turborepo.com user
 type RepoConfig struct {
 	repoViper *viper.Viper
-	path      fs.AbsolutePath
+	path      turbopath.AbsolutePath
 }
 
 // LoginURL returns the configured URL for authenticating the user
@@ -60,7 +61,7 @@ func (rc *RepoConfig) Delete() error {
 // for Turborepo.
 type UserConfig struct {
 	userViper *viper.Viper
-	path      fs.AbsolutePath
+	path      turbopath.AbsolutePath
 }
 
 // Token returns the Bearer token for this user if it exists
@@ -95,7 +96,7 @@ func (uc *UserConfig) Delete() error {
 // ReadUserConfigFile creates a UserConfig using the
 // specified path as the user config file. Note that the path or its parents
 // do not need to exist. On a write to this configuration, they will be created.
-func ReadUserConfigFile(path fs.AbsolutePath) (*UserConfig, error) {
+func ReadUserConfigFile(path turbopath.AbsolutePath) (*UserConfig, error) {
 	userViper := viper.New()
 	userViper.SetConfigFile(path.ToString())
 	userViper.SetConfigType("json")
@@ -112,7 +113,7 @@ func ReadUserConfigFile(path fs.AbsolutePath) (*UserConfig, error) {
 
 // DefaultUserConfigPath returns the default platform-dependent place that
 // we store the user-specific configuration.
-func DefaultUserConfigPath() fs.AbsolutePath {
+func DefaultUserConfigPath() turbopath.AbsolutePath {
 	return fs.GetUserConfigDir().Join("config.json")
 }
 
@@ -125,7 +126,7 @@ const (
 // specified path as the repo config file. Note that the path or its
 // parents do not need to exist. On a write to this configuration, they
 // will be created.
-func ReadRepoConfigFile(path fs.AbsolutePath) (*RepoConfig, error) {
+func ReadRepoConfigFile(path turbopath.AbsolutePath) (*RepoConfig, error) {
 	repoViper := viper.New()
 	repoViper.SetConfigFile(path.ToString())
 	repoViper.SetConfigType("json")
@@ -146,6 +147,6 @@ func ReadRepoConfigFile(path fs.AbsolutePath) (*RepoConfig, error) {
 }
 
 // GetRepoConfigPath reads the user-specific configuration values
-func GetRepoConfigPath(repoRoot fs.AbsolutePath) fs.AbsolutePath {
+func GetRepoConfigPath(repoRoot turbopath.AbsolutePath) turbopath.AbsolutePath {
 	return repoRoot.Join(".turbo", "config.json")
 }

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"github.com/vercel/turborepo/cli/internal/ui"
 )
 
@@ -55,7 +56,7 @@ func TestSelectCwd(t *testing.T) {
 	cases := []struct {
 		Name      string
 		InputArgs []string
-		Expected  fs.AbsolutePath
+		Expected  turbopath.AbsolutePath
 	}{
 		{
 			Name:      "default",

--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -118,7 +118,7 @@ func isWorkspaceReference(packageVersion string, dependencyVersion string, cwd s
 
 // WithGraph attaches information about the package dependency graph to the Context instance being
 // constructed.
-func WithGraph(repoRoot fs.AbsolutePath, rootPackageJSON *fs.PackageJSON, cacheDir fs.AbsolutePath) Option {
+func WithGraph(repoRoot turbopath.AbsolutePath, rootPackageJSON *fs.PackageJSON, cacheDir turbopath.AbsolutePath) Option {
 	return func(c *Context) error {
 		rootpath := repoRoot.ToStringDuringMigration()
 		c.PackageInfos = make(map[interface{}]*fs.PackageJSON)
@@ -302,7 +302,7 @@ func (c *Context) populateTopologicGraphForPackageJSON(pkg *fs.PackageJSON, root
 	return nil
 }
 
-func (c *Context) parsePackageJSON(repoRoot fs.AbsolutePath, pkgJSONPath fs.AbsolutePath) error {
+func (c *Context) parsePackageJSON(repoRoot turbopath.AbsolutePath, pkgJSONPath turbopath.AbsolutePath) error {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 

--- a/cli/internal/daemon/connector/connector.go
+++ b/cli/internal/daemon/connector/connector.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/nightlyone/lockfile"
 	"github.com/pkg/errors"
-	"github.com/vercel/turborepo/cli/internal/fs"
 	"github.com/vercel/turborepo/cli/internal/turbodprotocol"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -43,9 +43,9 @@ type Opts struct {
 type Client struct {
 	turbodprotocol.TurbodClient
 	*grpc.ClientConn
-	SockPath fs.AbsolutePath
-	PidPath  fs.AbsolutePath
-	LogPath  fs.AbsolutePath
+	SockPath turbopath.AbsolutePath
+	PidPath  turbopath.AbsolutePath
+	LogPath  turbopath.AbsolutePath
 }
 
 // Connector instances are used to create a connection to turbo's daemon process
@@ -54,18 +54,18 @@ type Connector struct {
 	Logger       hclog.Logger
 	Bin          string
 	Opts         Opts
-	SockPath     fs.AbsolutePath
-	PidPath      fs.AbsolutePath
-	LogPath      fs.AbsolutePath
+	SockPath     turbopath.AbsolutePath
+	PidPath      turbopath.AbsolutePath
+	LogPath      turbopath.AbsolutePath
 	TurboVersion string
 }
 
 // ConnectionError is returned in the error case from connect. It wraps the underlying
 // cause and adds a message with the relevant files for the user to check.
 type ConnectionError struct {
-	SockPath fs.AbsolutePath
-	PidPath  fs.AbsolutePath
-	LogPath  fs.AbsolutePath
+	SockPath turbopath.AbsolutePath
+	PidPath  turbopath.AbsolutePath
+	LogPath  turbopath.AbsolutePath
 	cause    error
 }
 
@@ -94,7 +94,7 @@ func (c *Connector) wrapConnectionError(err error) error {
 // lockFile returns a pointer to where a lockfile should be.
 // lockfile.New does not perform IO and the only error it produces
 // is in the case a non-absolute path was provided. We're guaranteeing an
-// AbsolutePath, so an error here is an indication of a bug and
+// turbopath.AbsolutePath, so an error here is an indication of a bug and
 // we should crash.
 func (c *Connector) lockFile() lockfile.Lockfile {
 	lockFile, err := lockfile.New(c.PidPath.ToString())

--- a/cli/internal/daemon/connector/connector_test.go
+++ b/cli/internal/daemon/connector/connector_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nightlyone/lockfile"
 	"github.com/vercel/turborepo/cli/internal/fs"
 	"github.com/vercel/turborepo/cli/internal/turbodprotocol"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -32,11 +33,11 @@ func testBin() string {
 	return "node"
 }
 
-func getUnixSocket(dir fs.AbsolutePath) fs.AbsolutePath {
+func getUnixSocket(dir turbopath.AbsolutePath) turbopath.AbsolutePath {
 	return dir.Join("turbod-test.sock")
 }
 
-func getPidFile(dir fs.AbsolutePath) fs.AbsolutePath {
+func getPidFile(dir turbopath.AbsolutePath) turbopath.AbsolutePath {
 	return dir.Join("turbod-test.pid")
 }
 
@@ -157,7 +158,7 @@ type mockServer struct {
 	turbodprotocol.UnimplementedTurbodServer
 	helloErr     error
 	shutdownResp *turbodprotocol.ShutdownResponse
-	pidFile      fs.AbsolutePath
+	pidFile      turbopath.AbsolutePath
 }
 
 // Simulates server exiting by cleaning up the pid file

--- a/cli/internal/daemon/daemon_test.go
+++ b/cli/internal/daemon/daemon_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/vercel/turborepo/cli/internal/fs"
 	"github.com/vercel/turborepo/cli/internal/server"
 	"github.com/vercel/turborepo/cli/internal/signals"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/grpc_testing"
@@ -93,7 +94,7 @@ func newTestRPCServer() *testRPCServer {
 	}
 }
 
-func waitForFile(t *testing.T, filename fs.AbsolutePath, timeout time.Duration) {
+func waitForFile(t *testing.T, filename turbopath.AbsolutePath, timeout time.Duration) {
 	t.Helper()
 	deadline := time.After(timeout)
 outer:

--- a/cli/internal/daemon/lifecycle.go
+++ b/cli/internal/daemon/lifecycle.go
@@ -9,8 +9,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/vercel/turborepo/cli/internal/config"
 	"github.com/vercel/turborepo/cli/internal/daemon/connector"
-	"github.com/vercel/turborepo/cli/internal/fs"
 	"github.com/vercel/turborepo/cli/internal/turbodprotocol"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 )
 
 func addStartCmd(root *cobra.Command, config *config.Config, output cli.Ui) {
@@ -87,7 +87,7 @@ func addRestartCmd(root *cobra.Command, config *config.Config, output cli.Ui) {
 }
 
 type lifecycle struct {
-	repoRoot     fs.AbsolutePath
+	repoRoot     turbopath.AbsolutePath
 	logger       hclog.Logger
 	output       cli.Ui
 	turboVersion string

--- a/cli/internal/daemonclient/daemonclient.go
+++ b/cli/internal/daemonclient/daemonclient.go
@@ -6,8 +6,8 @@ import (
 	"context"
 
 	"github.com/vercel/turborepo/cli/internal/daemon/connector"
-	"github.com/vercel/turborepo/cli/internal/fs"
 	"github.com/vercel/turborepo/cli/internal/turbodprotocol"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 )
 
 // DaemonClient provides access to higher-level functionality from the daemon to a turbo run.
@@ -17,10 +17,10 @@ type DaemonClient struct {
 
 // Status provides details about the daemon's status
 type Status struct {
-	UptimeMs uint64          `json:"uptimeMs"`
-	LogFile  fs.AbsolutePath `json:"logFile"`
-	PidFile  fs.AbsolutePath `json:"pidFile"`
-	SockFile fs.AbsolutePath `json:"sockFile"`
+	UptimeMs uint64                 `json:"uptimeMs"`
+	LogFile  turbopath.AbsolutePath `json:"logFile"`
+	PidFile  turbopath.AbsolutePath `json:"pidFile"`
+	SockFile turbopath.AbsolutePath `json:"sockFile"`
 }
 
 // New creates a new instance of a DaemonClient.

--- a/cli/internal/filewatcher/backend.go
+++ b/cli/internal/filewatcher/backend.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/vercel/turborepo/cli/internal/doublestar"
 	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 )
 
 // watchAddMode is used to indicate whether watchRecursively should synthesize events

--- a/cli/internal/filewatcher/backend.go
+++ b/cli/internal/filewatcher/backend.go
@@ -64,7 +64,7 @@ func (f *fsNotifyBackend) Close() error {
 // Some fsnotify backends automatically add the contents of directories. Some do
 // not. Adding a watch is idempotent, so anytime any file we care about gets added,
 // watch it.
-func (f *fsNotifyBackend) onFileAdded(name fs.AbsolutePath) error {
+func (f *fsNotifyBackend) onFileAdded(name turbopath.AbsolutePath) error {
 	info, err := name.Lstat()
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -86,7 +86,7 @@ func (f *fsNotifyBackend) onFileAdded(name fs.AbsolutePath) error {
 	return nil
 }
 
-func (f *fsNotifyBackend) watchRecursively(root fs.AbsolutePath, excludePatterns []string, addMode watchAddMode) error {
+func (f *fsNotifyBackend) watchRecursively(root turbopath.AbsolutePath, excludePatterns []string, addMode watchAddMode) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	err := fs.WalkMode(root.ToString(), func(name string, isDir bool, info os.FileMode) error {
@@ -187,7 +187,7 @@ func (f *fsNotifyBackend) Start() error {
 	return nil
 }
 
-func (f *fsNotifyBackend) AddRoot(root fs.AbsolutePath, excludePatterns ...string) error {
+func (f *fsNotifyBackend) AddRoot(root turbopath.AbsolutePath, excludePatterns ...string) error {
 	// We don't synthesize events for the initial watch
 	return f.watchRecursively(root, excludePatterns, dontSynthesizeEvents)
 }

--- a/cli/internal/filewatcher/backend_darwin.go
+++ b/cli/internal/filewatcher/backend_darwin.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/vercel/turborepo/cli/internal/doublestar"
 	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 )
 
 type fseventsBackend struct {
@@ -61,7 +62,7 @@ var (
 
 // AddRoot starts watching a new directory hierarchy. Events matching the provided excludePatterns
 // will not be forwarded.
-func (f *fseventsBackend) AddRoot(someRoot fs.AbsolutePath, excludePatterns ...string) error {
+func (f *fseventsBackend) AddRoot(someRoot turbopath.AbsolutePath, excludePatterns ...string) error {
 	// We need to resolve the real path to the hierarchy that we are going to watch
 	realRoot, err := realpath.Realpath(someRoot.ToString())
 	if err != nil {
@@ -145,7 +146,7 @@ func (f *fseventsBackend) AddRoot(someRoot fs.AbsolutePath, excludePatterns ...s
 	return nil
 }
 
-func waitForCookie(root fs.AbsolutePath, events <-chan []fsevents.Event, timeout time.Duration) error {
+func waitForCookie(root turbopath.AbsolutePath, events <-chan []fsevents.Event, timeout time.Duration) error {
 	cookiePath := root.Join(".turbo-cookie")
 	if err := cookiePath.WriteFile([]byte("cookie"), 0755); err != nil {
 		return err

--- a/cli/internal/filewatcher/cookie.go
+++ b/cli/internal/filewatcher/cookie.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 )
 
 // CookieWaiter is the interface used by clients that need to wait
@@ -27,16 +28,16 @@ var (
 // CookieJar is used for tracking roundtrips through the filesystem watching API
 type CookieJar struct {
 	timeout time.Duration
-	dir     fs.AbsolutePath
+	dir     turbopath.AbsolutePath
 	serial  uint64
 	mu      sync.Mutex
-	cookies map[fs.AbsolutePath]chan error
+	cookies map[turbopath.AbsolutePath]chan error
 	closed  bool
 }
 
 // NewCookieJar returns a new instance of a CookieJar. There should only ever be a single
 // instance live per cookieDir, since they expect to have full control over that directory.
-func NewCookieJar(cookieDir fs.AbsolutePath, timeout time.Duration) (*CookieJar, error) {
+func NewCookieJar(cookieDir turbopath.AbsolutePath, timeout time.Duration) (*CookieJar, error) {
 	if err := cookieDir.RemoveAll(); err != nil {
 		return nil, err
 	}
@@ -46,7 +47,7 @@ func NewCookieJar(cookieDir fs.AbsolutePath, timeout time.Duration) (*CookieJar,
 	return &CookieJar{
 		timeout: timeout,
 		dir:     cookieDir,
-		cookies: make(map[fs.AbsolutePath]chan error),
+		cookies: make(map[turbopath.AbsolutePath]chan error),
 	}, nil
 }
 
@@ -82,7 +83,7 @@ func (cj *CookieJar) OnFileWatchError(err error) {
 	cj.mu.Lock()
 	defer cj.mu.Unlock()
 	cj.removeAllCookiesWithError(err)
-	cj.cookies = make(map[fs.AbsolutePath]chan error)
+	cj.cookies = make(map[turbopath.AbsolutePath]chan error)
 }
 
 // OnFileWatchEvent determines if the specified event is relevant
@@ -133,7 +134,7 @@ func (cj *CookieJar) WaitForCookie() error {
 	}
 }
 
-func (cj *CookieJar) notifyCookie(cookie fs.AbsolutePath, err error) {
+func (cj *CookieJar) notifyCookie(cookie turbopath.AbsolutePath, err error) {
 	cj.mu.Lock()
 	ch, ok := cj.cookies[cookie]
 	// delete is a no-op if the key doesn't exist
@@ -147,7 +148,7 @@ func (cj *CookieJar) notifyCookie(cookie fs.AbsolutePath, err error) {
 	}
 }
 
-func touchCookieFile(cookie fs.AbsolutePath) error {
+func touchCookieFile(cookie turbopath.AbsolutePath) error {
 	f, err := cookie.OpenFile(os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0700)
 	if err != nil {
 		return err

--- a/cli/internal/filewatcher/filewatcher.go
+++ b/cli/internal/filewatcher/filewatcher.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/pkg/errors"
-	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 )
 
 // _ignores is the set of paths we exempt from file-watching
@@ -50,14 +50,14 @@ var (
 
 // Event is the backend-independent information about a file change
 type Event struct {
-	Path      fs.AbsolutePath
+	Path      turbopath.AbsolutePath
 	EventType FileEvent
 }
 
 // Backend is the interface that describes what an underlying filesystem watching backend
 // must provide.
 type Backend interface {
-	AddRoot(root fs.AbsolutePath, excludePatterns ...string) error
+	AddRoot(root turbopath.AbsolutePath, excludePatterns ...string) error
 	Events() <-chan Event
 	Errors() <-chan error
 	Close() error
@@ -71,7 +71,7 @@ type FileWatcher struct {
 	backend Backend
 
 	logger         hclog.Logger
-	repoRoot       fs.AbsolutePath
+	repoRoot       turbopath.AbsolutePath
 	excludePattern string
 
 	clientsMu sync.RWMutex
@@ -80,7 +80,7 @@ type FileWatcher struct {
 }
 
 // New returns a new FileWatcher instance
-func New(logger hclog.Logger, repoRoot fs.AbsolutePath, backend Backend) *FileWatcher {
+func New(logger hclog.Logger, repoRoot turbopath.AbsolutePath, backend Backend) *FileWatcher {
 	excludes := make([]string, len(_ignores))
 	for i, ignore := range _ignores {
 		excludes[i] = filepath.ToSlash(repoRoot.Join(ignore).ToString() + "/**")
@@ -116,7 +116,7 @@ func (fw *FileWatcher) Start() error {
 // fired for existing files when AddRoot is called, only for subsequent changes.
 // NOTE: if it appears helpful, we could change this behavior so that we provide a stream of initial
 // events.
-func (fw *FileWatcher) AddRoot(root fs.AbsolutePath, excludePatterns ...string) error {
+func (fw *FileWatcher) AddRoot(root turbopath.AbsolutePath, excludePatterns ...string) error {
 	return fw.backend.AddRoot(root, excludePatterns...)
 }
 

--- a/cli/internal/filewatcher/filewatcher_test.go
+++ b/cli/internal/filewatcher/filewatcher_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"gotest.tools/v3/assert"
 )
 
@@ -63,7 +64,7 @@ func expectNoFilesystemEvent(t *testing.T, ch <-chan Event) {
 	}
 }
 
-func expectWatching(t *testing.T, c *testClient, dirs []fs.AbsolutePath) {
+func expectWatching(t *testing.T, c *testClient, dirs []turbopath.AbsolutePath) {
 	t.Helper()
 	now := time.Now()
 	filename := fmt.Sprintf("test-%v", now.UnixMilli())
@@ -112,7 +113,7 @@ func TestFileWatching(t *testing.T) {
 		notify: ch,
 	}
 	fw.AddClient(c)
-	expectedWatching := []fs.AbsolutePath{
+	expectedWatching := []turbopath.AbsolutePath{
 		repoRoot,
 		repoRoot.Join("parent"),
 		repoRoot.Join("parent", "child"),

--- a/cli/internal/fs/copy_file_test.go
+++ b/cli/internal/fs/copy_file_test.go
@@ -7,13 +7,14 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/fs"
 )
 
 func TestCopyFile(t *testing.T) {
-	srcFilePath := AbsolutePath(filepath.Join(t.TempDir(), "src"))
-	destFilePath := AbsolutePath(filepath.Join(t.TempDir(), "dest"))
+	srcFilePath := turbopath.AbsolutePath(filepath.Join(t.TempDir(), "src"))
+	destFilePath := turbopath.AbsolutePath(filepath.Join(t.TempDir(), "dest"))
 	from := &LstatCachedFile{Path: srcFilePath}
 
 	// The src file doesn't exist, will error.
@@ -35,9 +36,9 @@ func TestCopyFile(t *testing.T) {
 	assert.NilError(t, err, "src exists dest does not, should not error.")
 
 	// Now test for symlinks.
-	symlinkSrcPath := AbsolutePath(filepath.Join(t.TempDir(), "symlink"))
-	symlinkTargetPath := AbsolutePath(filepath.Join(t.TempDir(), "target"))
-	symlinkDestPath := AbsolutePath(filepath.Join(t.TempDir(), "dest"))
+	symlinkSrcPath := turbopath.AbsolutePath(filepath.Join(t.TempDir(), "symlink"))
+	symlinkTargetPath := turbopath.AbsolutePath(filepath.Join(t.TempDir(), "target"))
+	symlinkDestPath := turbopath.AbsolutePath(filepath.Join(t.TempDir(), "dest"))
 	fromSymlink := &LstatCachedFile{Path: symlinkSrcPath}
 
 	// Create the symlink target.
@@ -87,7 +88,7 @@ func TestCopyOrLinkFileWithPerms(t *testing.T) {
 	assert.NilError(t, err, "Create")
 	err = srcFile.Chmod(readonlyMode)
 	assert.NilError(t, err, "Chmod")
-	err = CopyFile(&LstatCachedFile{Path: AbsolutePath(srcFilePath)}, dstFilePath)
+	err = CopyFile(&LstatCachedFile{Path: turbopath.AbsolutePath(srcFilePath)}, dstFilePath)
 	assert.NilError(t, err, "CopyOrLinkFile")
 	info, err := os.Lstat(dstFilePath)
 	assert.NilError(t, err, "Lstat")

--- a/cli/internal/fs/lstat.go
+++ b/cli/internal/fs/lstat.go
@@ -3,11 +3,13 @@ package fs
 import (
 	"io/fs"
 	"os"
+
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 )
 
 // LstatCachedFile maintains a cache of file info, mode and type for the given Path
 type LstatCachedFile struct {
-	Path     AbsolutePath
+	Path     turbopath.AbsolutePath
 	fileInfo fs.FileInfo
 	fileMode *fs.FileMode
 	fileType *fs.FileMode

--- a/cli/internal/fs/package_json.go
+++ b/cli/internal/fs/package_json.go
@@ -52,7 +52,7 @@ func (r *Workspaces) UnmarshalJSON(data []byte) error {
 }
 
 // ReadPackageJSON returns a struct of package.json
-func ReadPackageJSON(path AbsolutePath) (*PackageJSON, error) {
+func ReadPackageJSON(path turbopath.AbsolutePath) (*PackageJSON, error) {
 	b, err := path.ReadFile()
 	if err != nil {
 		return nil, err

--- a/cli/internal/fs/path.go
+++ b/cli/internal/fs/path.go
@@ -9,37 +9,38 @@ import (
 
 	"github.com/adrg/xdg"
 	"github.com/spf13/pflag"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 )
 
-func CheckedToAbsolutePath(s string) (AbsolutePath, error) {
+func CheckedToAbsolutePath(s string) (turbopath.AbsolutePath, error) {
 	if filepath.IsAbs(s) {
-		return AbsolutePath(s), nil
+		return turbopath.AbsolutePath(s), nil
 	}
 	return "", fmt.Errorf("%v is not an absolute path", s)
 }
 
 // ResolveUnknownPath returns unknown if it is an absolute path, otherwise, it
 // assumes unknown is a path relative to the given root.
-func ResolveUnknownPath(root AbsolutePath, unknown string) AbsolutePath {
+func ResolveUnknownPath(root turbopath.AbsolutePath, unknown string) turbopath.AbsolutePath {
 	if filepath.IsAbs(unknown) {
-		return AbsolutePath(unknown)
+		return turbopath.AbsolutePath(unknown)
 	}
 	return root.Join(unknown)
 }
 
-func UnsafeToAbsolutePath(s string) AbsolutePath {
-	return AbsolutePath(s)
+func UnsafeToAbsolutePath(s string) turbopath.AbsolutePath {
+	return turbopath.AbsolutePath(s)
 }
 
 // AbsolutePathFromUpstream is used to mark return values from APIs that we
 // expect to give us absolute paths. No checking is performed.
 // Prefer to use this over a cast to maintain the search-ability of interfaces
-// into and out of the AbsolutePath type.
-func AbsolutePathFromUpstream(s string) AbsolutePath {
-	return AbsolutePath(s)
+// into and out of the turbopath.AbsolutePath type.
+func AbsolutePathFromUpstream(s string) turbopath.AbsolutePath {
+	return turbopath.AbsolutePath(s)
 }
 
-func GetCwd() (AbsolutePath, error) {
+func GetCwd() (turbopath.AbsolutePath, error) {
 	cwdRaw, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("invalid working directory: %w", err)
@@ -90,27 +91,27 @@ func IofsRelativePath(fsysRoot string, absolutePath string) (string, error) {
 
 // TempDir returns the absolute path of a directory with the given name
 // under the system's default temp directory location
-func TempDir(subDir string) AbsolutePath {
-	return AbsolutePath(os.TempDir()).Join(subDir)
+func TempDir(subDir string) turbopath.AbsolutePath {
+	return turbopath.AbsolutePath(os.TempDir()).Join(subDir)
 }
 
 // GetTurboDataDir returns a directory outside of the repo
 // where turbo can store data files related to turbo.
-func GetTurboDataDir() AbsolutePath {
+func GetTurboDataDir() turbopath.AbsolutePath {
 	dataHome := AbsolutePathFromUpstream(xdg.DataHome)
 	return dataHome.Join("turborepo")
 }
 
 // GetUserConfigDir returns the platform-specific common location
 // for configuration files that belong to a user.
-func GetUserConfigDir() AbsolutePath {
+func GetUserConfigDir() turbopath.AbsolutePath {
 	configHome := AbsolutePathFromUpstream(xdg.ConfigHome)
 	return configHome.Join("turborepo")
 }
 
 type pathValue struct {
-	base     AbsolutePath
-	current  *AbsolutePath
+	base     turbopath.AbsolutePath
+	current  *turbopath.AbsolutePath
 	defValue string
 }
 
@@ -135,7 +136,7 @@ var _ pflag.Value = &pathValue{}
 // AbsolutePathVar adds a flag interpreted as an absolute path to the given FlagSet.
 // It currently requires a root because relative paths are interpreted relative to the
 // given root.
-func AbsolutePathVar(flags *pflag.FlagSet, target *AbsolutePath, name string, root AbsolutePath, usage string, defValue string) {
+func AbsolutePathVar(flags *pflag.FlagSet, target *turbopath.AbsolutePath, name string, root turbopath.AbsolutePath, usage string, defValue string) {
 	value := &pathValue{
 		base:     root,
 		current:  target,

--- a/cli/internal/fs/path.go
+++ b/cli/internal/fs/path.go
@@ -3,7 +3,6 @@ package fs
 import (
 	"fmt"
 	iofs "io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -11,10 +10,6 @@ import (
 	"github.com/adrg/xdg"
 	"github.com/spf13/pflag"
 )
-
-// AbsolutePath represents a platform-dependent absolute path on the filesystem,
-// and is used to enfore correct path manipulation
-type AbsolutePath string
 
 func CheckedToAbsolutePath(s string) (AbsolutePath, error) {
 	if filepath.IsAbs(s) {
@@ -60,128 +55,6 @@ func GetCwd() (AbsolutePath, error) {
 		return "", fmt.Errorf("cwd is not an absolute path %v: %v", cwdRaw, err)
 	}
 	return cwd, nil
-}
-
-func (ap AbsolutePath) ToStringDuringMigration() string {
-	return ap.asString()
-}
-
-func (ap AbsolutePath) Join(args ...string) AbsolutePath {
-	return AbsolutePath(filepath.Join(ap.asString(), filepath.Join(args...)))
-}
-func (ap AbsolutePath) asString() string {
-	return string(ap)
-}
-func (ap AbsolutePath) Dir() AbsolutePath {
-	return AbsolutePath(filepath.Dir(ap.asString()))
-}
-
-// MkdirAll implements os.MkdirAll(ap, DirPermissions|0644)
-func (ap AbsolutePath) MkdirAll() error {
-	return os.MkdirAll(ap.asString(), DirPermissions|0644)
-}
-
-// Open implements os.Open(ap) for an absolute path
-func (ap AbsolutePath) Open() (*os.File, error) {
-	return os.Open(ap.asString())
-}
-
-// OpenFile implements os.OpenFile for an absolute path
-func (ap AbsolutePath) OpenFile(flags int, mode os.FileMode) (*os.File, error) {
-	return os.OpenFile(ap.asString(), flags, mode)
-}
-
-func (ap AbsolutePath) FileExists() bool {
-	return FileExists(ap.asString())
-}
-
-// Lstat implements os.Lstat for absolute path
-func (ap AbsolutePath) Lstat() (os.FileInfo, error) {
-	return os.Lstat(ap.asString())
-}
-
-// DirExists returns true if this path points to a directory
-func (ap AbsolutePath) DirExists() bool {
-	info, err := ap.Lstat()
-	return err == nil && info.IsDir()
-}
-
-// ContainsPath returns true if this absolute path is a parent of the
-// argument.
-func (ap AbsolutePath) ContainsPath(other AbsolutePath) (bool, error) {
-	return DirContainsPath(ap.asString(), other.asString())
-}
-
-// ReadFile reads the contents of the specified file
-func (ap AbsolutePath) ReadFile() ([]byte, error) {
-	return ioutil.ReadFile(ap.asString())
-}
-
-// WriteFile writes the contents of the specified file
-func (ap AbsolutePath) WriteFile(contents []byte, mode os.FileMode) error {
-	return ioutil.WriteFile(ap.asString(), contents, mode)
-}
-
-// EnsureDir ensures that the directory containing this file exists
-func (ap AbsolutePath) EnsureDir() error {
-	return EnsureDir(ap.asString())
-}
-
-// Create is the AbsolutePath wrapper for os.Create
-func (ap AbsolutePath) Create() (*os.File, error) {
-	return os.Create(ap.asString())
-}
-
-// Ext implements filepath.Ext(ap) for an absolute path
-func (ap AbsolutePath) Ext() string {
-	return filepath.Ext(ap.asString())
-}
-
-// ToString returns the string representation of this absolute path. Used for
-// interfacing with APIs that require a string
-func (ap AbsolutePath) ToString() string {
-	return ap.asString()
-}
-
-// RelativePathString returns the relative path from this AbsolutePath to another absolute path in string form as a string
-func (ap AbsolutePath) RelativePathString(path string) (string, error) {
-	return filepath.Rel(ap.asString(), path)
-}
-
-// PathTo returns the relative path between two absolute paths
-// This should likely eventually return an AnchoredSystemPath
-func (ap AbsolutePath) PathTo(other AbsolutePath) (string, error) {
-	return ap.RelativePathString(other.asString())
-}
-
-// Symlink implements os.Symlink(target, ap) for absolute path
-func (ap AbsolutePath) Symlink(target string) error {
-	return os.Symlink(target, ap.asString())
-}
-
-// Readlink implements os.Readlink(ap) for an absolute path
-func (ap AbsolutePath) Readlink() (string, error) {
-	return os.Readlink(ap.asString())
-}
-
-// Remove removes the file or (empty) directory at the given path
-func (ap AbsolutePath) Remove() error {
-	return os.Remove(ap.asString())
-}
-
-// RemoveAll implements os.RemoveAll for absolute paths.
-func (ap AbsolutePath) RemoveAll() error {
-	return os.RemoveAll(ap.asString())
-}
-
-// Base implements filepath.Base for an absolute path
-func (ap AbsolutePath) Base() string {
-	return filepath.Base(ap.asString())
-}
-
-// Rename implements os.Rename(ap, dest) for absolute paths
-func (ap AbsolutePath) Rename(dest AbsolutePath) error {
-	return os.Rename(ap.asString(), dest.asString())
 }
 
 // GetVolumeRoot returns the root directory given an absolute path.

--- a/cli/internal/fs/path_test.go
+++ b/cli/internal/fs/path_test.go
@@ -6,13 +6,14 @@ import (
 	"testing"
 
 	"github.com/spf13/pflag"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"gotest.tools/v3/assert"
 )
 
 // absolute unix paths parse differently based on whether or not we're on windows.
 // Windows will treat them as relative paths, to be made relative to cwd.
 // Unix-like OSes will treat them as absolute and can be returned directly.
-func platformSpecificAbsoluteUnixPathExpectation(cwd AbsolutePath, absoluteUnixPath string) AbsolutePath {
+func platformSpecificAbsoluteUnixPathExpectation(cwd turbopath.AbsolutePath, absoluteUnixPath string) turbopath.AbsolutePath {
 	if runtime.GOOS == "windows" {
 		return cwd.Join(absoluteUnixPath)
 	}
@@ -23,12 +24,12 @@ func TestAbsPathVar(t *testing.T) {
 	cwd, err := GetCwd()
 	assert.NilError(t, err, "GetCwd")
 	flags := pflag.NewFlagSet("foo", pflag.ContinueOnError)
-	var target AbsolutePath
+	var target turbopath.AbsolutePath
 	AbsolutePathVar(flags, &target, "foo", cwd, "some usage info", "")
 
 	for _, test := range []struct {
 		input    string
-		expected AbsolutePath
+		expected turbopath.AbsolutePath
 	}{
 		{
 			"bar",

--- a/cli/internal/fs/turbo_json.go
+++ b/cli/internal/fs/turbo_json.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"github.com/vercel/turborepo/cli/internal/util"
 	"muzzammil.xyz/jsonc"
 )
@@ -25,7 +26,7 @@ type TurboJSON struct {
 const configFile = "turbo.json"
 
 // ReadTurboConfig toggles between reading from package.json or the configFile to support early adopters.
-func ReadTurboConfig(rootPath AbsolutePath, rootPackageJSON *PackageJSON) (*TurboJSON, error) {
+func ReadTurboConfig(rootPath turbopath.AbsolutePath, rootPackageJSON *PackageJSON) (*TurboJSON, error) {
 	// If the configFile exists, we use that
 	// If pkg.Turbo exists, we warn about running the migration
 	// Use pkg.Turbo if the configFile doesn't exist
@@ -55,7 +56,7 @@ func ReadTurboConfig(rootPath AbsolutePath, rootPackageJSON *PackageJSON) (*Turb
 }
 
 // readTurboJSON reads the configFile in to a struct
-func readTurboJSON(path AbsolutePath) (*TurboJSON, error) {
+func readTurboJSON(path turbopath.AbsolutePath) (*TurboJSON, error) {
 	file, err := path.Open()
 	if err != nil {
 		return nil, err

--- a/cli/internal/globwatcher/globwatcher.go
+++ b/cli/internal/globwatcher/globwatcher.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/vercel/turborepo/cli/internal/doublestar"
 	"github.com/vercel/turborepo/cli/internal/filewatcher"
-	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"github.com/vercel/turborepo/cli/internal/util"
 )
 
@@ -21,7 +21,7 @@ var ErrClosed = errors.New("glob watching is closed")
 // have changed, that hash is no longer tracked.
 type GlobWatcher struct {
 	logger       hclog.Logger
-	repoRoot     fs.AbsolutePath
+	repoRoot     turbopath.AbsolutePath
 	cookieWaiter filewatcher.CookieWaiter
 
 	mu         sync.RWMutex // protects field below
@@ -32,7 +32,7 @@ type GlobWatcher struct {
 }
 
 // New returns a new GlobWatcher instance
-func New(logger hclog.Logger, repoRoot fs.AbsolutePath, cookieWaiter filewatcher.CookieWaiter) *GlobWatcher {
+func New(logger hclog.Logger, repoRoot turbopath.AbsolutePath, cookieWaiter filewatcher.CookieWaiter) *GlobWatcher {
 	return &GlobWatcher{
 		logger:       logger,
 		repoRoot:     repoRoot,

--- a/cli/internal/globwatcher/globwatcher_test.go
+++ b/cli/internal/globwatcher/globwatcher_test.go
@@ -6,10 +6,11 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/vercel/turborepo/cli/internal/filewatcher"
 	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"gotest.tools/v3/assert"
 )
 
-func setup(t *testing.T, repoRoot fs.AbsolutePath) {
+func setup(t *testing.T, repoRoot turbopath.AbsolutePath) {
 	// Directory layout:
 	// <repoRoot>/
 	//   my-pkg/

--- a/cli/internal/hashing/package_deps_hash.go
+++ b/cli/internal/hashing/package_deps_hash.go
@@ -27,7 +27,7 @@ type PackageDepsOptions struct {
 }
 
 // GetPackageDeps Builds an object containing git hashes for the files under the specified `packagePath` folder.
-func GetPackageDeps(rootPath fs.AbsolutePath, p *PackageDepsOptions) (map[turbopath.AnchoredUnixPath]string, error) {
+func GetPackageDeps(rootPath turbopath.AbsolutePath, p *PackageDepsOptions) (map[turbopath.AnchoredUnixPath]string, error) {
 	pkgPath := rootPath.Join(p.PackagePath.ToStringDuringMigration())
 	// Add all the checked in hashes.
 	var result map[turbopath.AnchoredUnixPath]string
@@ -101,7 +101,7 @@ func manuallyHashFiles(rootPath turbopath.AbsoluteSystemPath, files []turbopath.
 
 // GetHashableDeps hashes the list of given files, then returns a map of normalized path to hash
 // this map is suitable for cross-platform caching.
-func GetHashableDeps(rootPath fs.AbsolutePath, files []turbopath.AbsoluteSystemPath) (map[turbopath.AnchoredUnixPath]string, error) {
+func GetHashableDeps(rootPath turbopath.AbsolutePath, files []turbopath.AbsoluteSystemPath) (map[turbopath.AnchoredUnixPath]string, error) {
 	output := make([]turbopath.AnchoredSystemPath, len(files))
 	convertedRootPath := turbopath.AbsoluteSystemPathFromUpstream(rootPath.ToString())
 
@@ -270,7 +270,7 @@ func runGitCommand(cmd *exec.Cmd, commandName string, handler func(io.Reader) *g
 
 // gitLsTree returns a map of paths to their SHA hashes starting at a particular directory
 // that are present in the `git` index at a particular revision.
-func gitLsTree(rootPath fs.AbsolutePath) (map[turbopath.AnchoredUnixPath]string, error) {
+func gitLsTree(rootPath turbopath.AbsolutePath) (map[turbopath.AnchoredUnixPath]string, error) {
 	cmd := exec.Command(
 		"git",     // Using `git` from $PATH,
 		"ls-tree", // list the contents of the git index,
@@ -361,7 +361,7 @@ func (s statusCode) isDelete() bool {
 // We need to calculate where the repository's location is in order to determine what the full path is
 // before we can return those paths relative to the calling directory, normalizing to the behavior of
 // `ls-files` and `ls-tree`.
-func gitStatus(rootPath fs.AbsolutePath, patterns []string) (map[turbopath.AnchoredUnixPath]statusCode, error) {
+func gitStatus(rootPath turbopath.AbsolutePath, patterns []string) (map[turbopath.AnchoredUnixPath]statusCode, error) {
 	cmd := exec.Command(
 		"git",               // Using `git` from $PATH,
 		"status",            // tell me about the status of the working tree,

--- a/cli/internal/hashing/package_deps_hash_test.go
+++ b/cli/internal/hashing/package_deps_hash_test.go
@@ -217,7 +217,7 @@ func Test_getTraversePath(t *testing.T) {
 	}
 }
 
-func requireGitCmd(t *testing.T, repoRoot fs.AbsolutePath, args ...string) {
+func requireGitCmd(t *testing.T, repoRoot turbopath.AbsolutePath, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)
 	cmd.Dir = repoRoot.ToString()

--- a/cli/internal/login/link.go
+++ b/cli/internal/login/link.go
@@ -12,6 +12,7 @@ import (
 	"github.com/vercel/turborepo/cli/internal/client"
 	"github.com/vercel/turborepo/cli/internal/config"
 	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"github.com/vercel/turborepo/cli/internal/ui"
 	"github.com/vercel/turborepo/cli/internal/util"
 	"github.com/vercel/turborepo/cli/internal/util/browser"
@@ -31,7 +32,7 @@ type LinkCommand struct {
 type link struct {
 	ui                  cli.Ui
 	logger              hclog.Logger
-	cwd                 fs.AbsolutePath
+	cwd                 turbopath.AbsolutePath
 	modifyGitIgnore     bool
 	repoConfig          *config.RepoConfig
 	apiClient           linkAPIClient

--- a/cli/internal/login/login.go
+++ b/cli/internal/login/login.go
@@ -14,7 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/vercel/turborepo/cli/internal/client"
 	"github.com/vercel/turborepo/cli/internal/config"
-	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"github.com/vercel/turborepo/cli/internal/ui"
 	"github.com/vercel/turborepo/cli/internal/util"
 	"github.com/vercel/turborepo/cli/internal/util/browser"
@@ -120,7 +120,7 @@ type userClient interface {
 type login struct {
 	ui                  *cli.ColoredUi
 	logger              hclog.Logger
-	repoRoot            fs.AbsolutePath
+	repoRoot            turbopath.AbsolutePath
 	openURL             browserClient
 	client              userClient
 	promptEnableCaching func() (bool, error)

--- a/cli/internal/login/login_test.go
+++ b/cli/internal/login/login_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/vercel/turborepo/cli/internal/client"
 	"github.com/vercel/turborepo/cli/internal/config"
 	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"github.com/vercel/turborepo/cli/internal/ui"
 	"github.com/vercel/turborepo/cli/internal/util"
 )
@@ -82,7 +83,7 @@ func getConfig(t *testing.T) *config.Config {
 }
 
 type testResult struct {
-	repoRoot            fs.AbsolutePath
+	repoRoot            turbopath.AbsolutePath
 	clientErr           error
 	openedURL           string
 	stepCh              chan struct{}
@@ -116,7 +117,7 @@ func (tr *testResult) getTestLogin() login {
 	}
 }
 
-func newTest(t *testing.T, repoRoot fs.AbsolutePath, redirectedURL string) *testResult {
+func newTest(t *testing.T, repoRoot turbopath.AbsolutePath, redirectedURL string) *testResult {
 	stepCh := make(chan struct{}, 1)
 	tr := &testResult{
 		repoRoot: repoRoot,

--- a/cli/internal/packagemanager/berry.go
+++ b/cli/internal/packagemanager/berry.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/vercel/turborepo/cli/internal/fs"
 	"github.com/vercel/turborepo/cli/internal/lockfile"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"github.com/vercel/turborepo/cli/internal/util"
 )
 
@@ -19,7 +20,7 @@ var nodejsBerry = PackageManager{
 	Lockfile:   "yarn.lock",
 	PackageDir: "node_modules",
 
-	getWorkspaceGlobs: func(rootpath fs.AbsolutePath) ([]string, error) {
+	getWorkspaceGlobs: func(rootpath turbopath.AbsolutePath) ([]string, error) {
 		pkg, err := fs.ReadPackageJSON(rootpath.Join("package.json"))
 		if err != nil {
 			return nil, fmt.Errorf("package.json: %w", err)
@@ -30,7 +31,7 @@ var nodejsBerry = PackageManager{
 		return pkg.Workspaces, nil
 	},
 
-	getWorkspaceIgnores: func(pm PackageManager, rootpath fs.AbsolutePath) ([]string, error) {
+	getWorkspaceIgnores: func(pm PackageManager, rootpath turbopath.AbsolutePath) ([]string, error) {
 		// Matches upstream values:
 		// Key code: https://github.com/yarnpkg/berry/blob/8e0c4b897b0881878a1f901230ea49b7c8113fbe/packages/yarnpkg-core/sources/Workspace.ts#L64-L70
 		return []string{
@@ -40,7 +41,7 @@ var nodejsBerry = PackageManager{
 		}, nil
 	},
 
-	canPrune: func(cwd fs.AbsolutePath) (bool, error) {
+	canPrune: func(cwd turbopath.AbsolutePath) (bool, error) {
 		if isNMLinker, err := util.IsNMLinker(cwd.ToStringDuringMigration()); err != nil {
 			return false, errors.Wrap(err, "could not determine if yarn is using `nodeLinker: node-modules`")
 		} else if !isNMLinker {
@@ -70,7 +71,7 @@ var nodejsBerry = PackageManager{
 
 	// Detect for berry needs to identify which version of yarn is running on the system.
 	// Further, berry can be configured in an incompatible way, so we check for compatibility here as well.
-	detect: func(projectDirectory fs.AbsolutePath, packageManager *PackageManager) (bool, error) {
+	detect: func(projectDirectory turbopath.AbsolutePath, packageManager *PackageManager) (bool, error) {
 		specfileExists := projectDirectory.Join(packageManager.Specfile).FileExists()
 		lockfileExists := projectDirectory.Join(packageManager.Lockfile).FileExists()
 

--- a/cli/internal/packagemanager/npm.go
+++ b/cli/internal/packagemanager/npm.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 )
 
 var nodejsNpm = PackageManager{
@@ -15,7 +16,7 @@ var nodejsNpm = PackageManager{
 	PackageDir:   "node_modules",
 	ArgSeparator: []string{"--"},
 
-	getWorkspaceGlobs: func(rootpath fs.AbsolutePath) ([]string, error) {
+	getWorkspaceGlobs: func(rootpath turbopath.AbsolutePath) ([]string, error) {
 		pkg, err := fs.ReadPackageJSON(rootpath.Join("package.json"))
 		if err != nil {
 			return nil, fmt.Errorf("package.json: %w", err)
@@ -26,7 +27,7 @@ var nodejsNpm = PackageManager{
 		return pkg.Workspaces, nil
 	},
 
-	getWorkspaceIgnores: func(pm PackageManager, rootpath fs.AbsolutePath) ([]string, error) {
+	getWorkspaceIgnores: func(pm PackageManager, rootpath turbopath.AbsolutePath) ([]string, error) {
 		// Matches upstream values:
 		// function: https://github.com/npm/map-workspaces/blob/a46503543982cb35f51cc2d6253d4dcc6bca9b32/lib/index.js#L73
 		// key code: https://github.com/npm/map-workspaces/blob/a46503543982cb35f51cc2d6253d4dcc6bca9b32/lib/index.js#L90-L96
@@ -40,7 +41,7 @@ var nodejsNpm = PackageManager{
 		return manager == "npm", nil
 	},
 
-	detect: func(projectDirectory fs.AbsolutePath, packageManager *PackageManager) (bool, error) {
+	detect: func(projectDirectory turbopath.AbsolutePath, packageManager *PackageManager) (bool, error) {
 		specfileExists := projectDirectory.Join(packageManager.Specfile).FileExists()
 		lockfileExists := projectDirectory.Join(packageManager.Lockfile).FileExists()
 

--- a/cli/internal/packagemanager/packagemanager_test.go
+++ b/cli/internal/packagemanager/packagemanager_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"gotest.tools/v3/assert"
 )
 
@@ -105,7 +106,7 @@ func TestGetPackageManager(t *testing.T) {
 	assert.NilError(t, err, "GetCwd")
 	tests := []struct {
 		name             string
-		projectDirectory fs.AbsolutePath
+		projectDirectory turbopath.AbsolutePath
 		pkg              *fs.PackageJSON
 		want             string
 		wantErr          bool
@@ -216,7 +217,7 @@ func Test_GetWorkspaces(t *testing.T) {
 	type test struct {
 		name     string
 		pm       PackageManager
-		rootPath fs.AbsolutePath
+		rootPath turbopath.AbsolutePath
 		want     []string
 		wantErr  bool
 	}
@@ -225,7 +226,7 @@ func Test_GetWorkspaces(t *testing.T) {
 
 	repoRoot, err := fs.GetCwd()
 	assert.NilError(t, err, "GetCwd")
-	rootPath := map[string]fs.AbsolutePath{
+	rootPath := map[string]turbopath.AbsolutePath{
 		"nodejs-npm":   repoRoot.Join("../../../examples/basic"),
 		"nodejs-berry": repoRoot.Join("../../../examples/basic"),
 		"nodejs-yarn":  repoRoot.Join("../../../examples/basic"),
@@ -307,7 +308,7 @@ func Test_GetWorkspaceIgnores(t *testing.T) {
 	type test struct {
 		name     string
 		pm       PackageManager
-		rootPath fs.AbsolutePath
+		rootPath turbopath.AbsolutePath
 		want     []string
 		wantErr  bool
 	}
@@ -357,7 +358,7 @@ func Test_CanPrune(t *testing.T) {
 	type test struct {
 		name     string
 		pm       PackageManager
-		rootPath fs.AbsolutePath
+		rootPath turbopath.AbsolutePath
 		want     bool
 		wantErr  bool
 	}

--- a/cli/internal/packagemanager/pnpm.go
+++ b/cli/internal/packagemanager/pnpm.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 
 	"github.com/Masterminds/semver"
-	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"gopkg.in/yaml.v3"
 )
 
@@ -30,7 +30,7 @@ var nodejsPnpm = PackageManager{
 	// nil for empty slices.
 	ArgSeparator: nil,
 
-	getWorkspaceGlobs: func(rootpath fs.AbsolutePath) ([]string, error) {
+	getWorkspaceGlobs: func(rootpath turbopath.AbsolutePath) ([]string, error) {
 		bytes, err := ioutil.ReadFile(rootpath.Join("pnpm-workspace.yaml").ToStringDuringMigration())
 		if err != nil {
 			return nil, fmt.Errorf("pnpm-workspace.yaml: %w", err)
@@ -47,7 +47,7 @@ var nodejsPnpm = PackageManager{
 		return pnpmWorkspaces.Packages, nil
 	},
 
-	getWorkspaceIgnores: func(pm PackageManager, rootpath fs.AbsolutePath) ([]string, error) {
+	getWorkspaceIgnores: func(pm PackageManager, rootpath turbopath.AbsolutePath) ([]string, error) {
 		// Matches upstream values:
 		// function: https://github.com/pnpm/pnpm/blob/d99daa902442e0c8ab945143ebaf5cdc691a91eb/packages/find-packages/src/index.ts#L27
 		// key code: https://github.com/pnpm/pnpm/blob/d99daa902442e0c8ab945143ebaf5cdc691a91eb/packages/find-packages/src/index.ts#L30
@@ -75,7 +75,7 @@ var nodejsPnpm = PackageManager{
 		return c.Check(v), nil
 	},
 
-	detect: func(projectDirectory fs.AbsolutePath, packageManager *PackageManager) (bool, error) {
+	detect: func(projectDirectory turbopath.AbsolutePath, packageManager *PackageManager) (bool, error) {
 		specfileExists := projectDirectory.Join(packageManager.Specfile).FileExists()
 		lockfileExists := projectDirectory.Join(packageManager.Lockfile).FileExists()
 

--- a/cli/internal/packagemanager/pnpm6.go
+++ b/cli/internal/packagemanager/pnpm6.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 
 	"github.com/Masterminds/semver"
-	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"gopkg.in/yaml.v3"
 )
 
@@ -24,7 +24,7 @@ var nodejsPnpm6 = PackageManager{
 	PackageDir:   "node_modules",
 	ArgSeparator: []string{"--"},
 
-	getWorkspaceGlobs: func(rootpath fs.AbsolutePath) ([]string, error) {
+	getWorkspaceGlobs: func(rootpath turbopath.AbsolutePath) ([]string, error) {
 		bytes, err := ioutil.ReadFile(rootpath.Join("pnpm-workspace.yaml").ToStringDuringMigration())
 		if err != nil {
 			return nil, fmt.Errorf("pnpm-workspace.yaml: %w", err)
@@ -41,7 +41,7 @@ var nodejsPnpm6 = PackageManager{
 		return pnpmWorkspaces.Packages, nil
 	},
 
-	getWorkspaceIgnores: func(pm PackageManager, rootpath fs.AbsolutePath) ([]string, error) {
+	getWorkspaceIgnores: func(pm PackageManager, rootpath turbopath.AbsolutePath) ([]string, error) {
 		// Matches upstream values:
 		// function: https://github.com/pnpm/pnpm/blob/d99daa902442e0c8ab945143ebaf5cdc691a91eb/packages/find-packages/src/index.ts#L27
 		// key code: https://github.com/pnpm/pnpm/blob/d99daa902442e0c8ab945143ebaf5cdc691a91eb/packages/find-packages/src/index.ts#L30
@@ -69,7 +69,7 @@ var nodejsPnpm6 = PackageManager{
 		return c.Check(v), nil
 	},
 
-	detect: func(projectDirectory fs.AbsolutePath, packageManager *PackageManager) (bool, error) {
+	detect: func(projectDirectory turbopath.AbsolutePath, packageManager *PackageManager) (bool, error) {
 		specfileExists := projectDirectory.Join(packageManager.Specfile).FileExists()
 		lockfileExists := projectDirectory.Join(packageManager.Lockfile).FileExists()
 

--- a/cli/internal/packagemanager/yarn.go
+++ b/cli/internal/packagemanager/yarn.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/vercel/turborepo/cli/internal/fs"
 	"github.com/vercel/turborepo/cli/internal/lockfile"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 )
 
 var nodejsYarn = PackageManager{
@@ -20,7 +21,7 @@ var nodejsYarn = PackageManager{
 	PackageDir:   "node_modules",
 	ArgSeparator: []string{"--"},
 
-	getWorkspaceGlobs: func(rootpath fs.AbsolutePath) ([]string, error) {
+	getWorkspaceGlobs: func(rootpath turbopath.AbsolutePath) ([]string, error) {
 		pkg, err := fs.ReadPackageJSON(rootpath.Join("package.json"))
 		if err != nil {
 			return nil, fmt.Errorf("package.json: %w", err)
@@ -31,7 +32,7 @@ var nodejsYarn = PackageManager{
 		return pkg.Workspaces, nil
 	},
 
-	getWorkspaceIgnores: func(pm PackageManager, rootpath fs.AbsolutePath) ([]string, error) {
+	getWorkspaceIgnores: func(pm PackageManager, rootpath turbopath.AbsolutePath) ([]string, error) {
 		// function: https://github.com/yarnpkg/yarn/blob/3119382885ea373d3c13d6a846de743eca8c914b/src/config.js#L799
 
 		// Yarn is unique in ignore patterns handling.
@@ -53,7 +54,7 @@ var nodejsYarn = PackageManager{
 		return ignores, nil
 	},
 
-	canPrune: func(cwd fs.AbsolutePath) (bool, error) {
+	canPrune: func(cwd turbopath.AbsolutePath) (bool, error) {
 		return true, nil
 	},
 
@@ -76,7 +77,7 @@ var nodejsYarn = PackageManager{
 	},
 
 	// Detect for yarn needs to identify which version of yarn is running on the system.
-	detect: func(projectDirectory fs.AbsolutePath, packageManager *PackageManager) (bool, error) {
+	detect: func(projectDirectory turbopath.AbsolutePath, packageManager *PackageManager) (bool, error) {
 		specfileExists := projectDirectory.Join(packageManager.Specfile).FileExists()
 		lockfileExists := projectDirectory.Join(packageManager.Lockfile).FileExists()
 

--- a/cli/internal/run/global_hash.go
+++ b/cli/internal/run/global_hash.go
@@ -23,7 +23,7 @@ var _defaultEnvVars = []string{
 	"VERCEL_ANALYTICS_ID",
 }
 
-func calculateGlobalHash(rootpath fs.AbsolutePath, rootPackageJSON *fs.PackageJSON, pipeline fs.Pipeline, externalGlobalDependencies []string, packageManager *packagemanager.PackageManager, logger hclog.Logger, env []string) (string, error) {
+func calculateGlobalHash(rootpath turbopath.AbsolutePath, rootPackageJSON *fs.PackageJSON, pipeline fs.Pipeline, externalGlobalDependencies []string, packageManager *packagemanager.PackageManager, logger hclog.Logger, env []string) (string, error) {
 	// Calculate the global hash
 	globalDeps := make(util.Set)
 

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -38,6 +38,7 @@ import (
 	"github.com/vercel/turborepo/cli/internal/signals"
 	"github.com/vercel/turborepo/cli/internal/spinner"
 	"github.com/vercel/turborepo/cli/internal/taskhash"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"github.com/vercel/turborepo/cli/internal/ui"
 	"github.com/vercel/turborepo/cli/internal/util"
 
@@ -868,7 +869,7 @@ type execContext struct {
 	packageManager *packagemanager.PackageManager
 	processes      *process.Manager
 	taskHashes     *taskhash.Tracker
-	repoRoot       fs.AbsolutePath
+	repoRoot       turbopath.AbsolutePath
 }
 
 func (e *execContext) logError(log hclog.Logger, prefix string, err error) {
@@ -937,7 +938,7 @@ func (e *execContext) exec(ctx gocontext.Context, pt *nodes.PackageTask, deps da
 
 	cmd := exec.Command(e.packageManager.Command, argsactual...)
 	// TODO: repoRoot probably should be AbsoluteSystemPath, but it's Join method
-	// takes a RelativeSystemPath. Resolve during migration from AbsolutePath to
+	// takes a RelativeSystemPath. Resolve during migration from turbopath.AbsolutePath to
 	// AbsoluteSystemPath
 	cmd.Dir = e.repoRoot.Join(pt.Pkg.Dir.ToStringDuringMigration()).ToString()
 	envs := fmt.Sprintf("TURBO_HASH=%v", hash)

--- a/cli/internal/run/run_state.go
+++ b/cli/internal/run/run_state.go
@@ -172,7 +172,7 @@ func writeChrometracing(filename string, terminal cli.Ui) error {
 		return err
 	}
 	// chrometracing.Path() is absolute by default, but can still be relative if overriden via $CHROMETRACING_DIR
-	// so we have to account for that before converting to AbsolutePath
+	// so we have to account for that before converting to turbopath.AbsolutePath
 	if err := fs.CopyFile(&fs.LstatCachedFile{Path: fs.ResolveUnknownPath(root, outputPath)}, name); err != nil {
 		return err
 	}

--- a/cli/internal/runcache/runcache.go
+++ b/cli/internal/runcache/runcache.go
@@ -15,15 +15,15 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/vercel/turborepo/cli/internal/cache"
 	"github.com/vercel/turborepo/cli/internal/colorcache"
-	"github.com/vercel/turborepo/cli/internal/fs"
 	"github.com/vercel/turborepo/cli/internal/globby"
 	"github.com/vercel/turborepo/cli/internal/nodes"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"github.com/vercel/turborepo/cli/internal/ui"
 	"github.com/vercel/turborepo/cli/internal/util"
 )
 
 // LogReplayer is a function that is responsible for replaying the contents of a given log file
-type LogReplayer = func(logger hclog.Logger, output cli.Ui, logFile fs.AbsolutePath)
+type LogReplayer = func(logger hclog.Logger, output cli.Ui, logFile turbopath.AbsolutePath)
 
 // Opts holds the configurable options for a RunCache instance
 type Opts struct {
@@ -108,14 +108,14 @@ type RunCache struct {
 	cache                  cache.Cache
 	readsDisabled          bool
 	writesDisabled         bool
-	repoRoot               fs.AbsolutePath
+	repoRoot               turbopath.AbsolutePath
 	logReplayer            LogReplayer
 	outputWatcher          OutputWatcher
 	colorCache             *colorcache.ColorCache
 }
 
 // New returns a new instance of RunCache, wrapping the given cache
-func New(cache cache.Cache, repoRoot fs.AbsolutePath, opts Opts, colorCache *colorcache.ColorCache) *RunCache {
+func New(cache cache.Cache, repoRoot turbopath.AbsolutePath, opts Opts, colorCache *colorcache.ColorCache) *RunCache {
 	rc := &RunCache{
 		taskOutputModeOverride: opts.TaskOutputModeOverride,
 		cache:                  cache,
@@ -144,7 +144,7 @@ type TaskCache struct {
 	pt                *nodes.PackageTask
 	taskOutputMode    util.TaskOutputMode
 	cachingDisabled   bool
-	LogFileName       fs.AbsolutePath
+	LogFileName       turbopath.AbsolutePath
 }
 
 // RestoreOutputs attempts to restore output for the corresponding task from the cache. Returns true
@@ -326,7 +326,7 @@ func (rc *RunCache) TaskCache(pt *nodes.PackageTask, hash string) TaskCache {
 }
 
 // defaultLogReplayer will try to replay logs back to the given Ui instance
-func defaultLogReplayer(logger hclog.Logger, output cli.Ui, logFileName fs.AbsolutePath) {
+func defaultLogReplayer(logger hclog.Logger, output cli.Ui, logFileName turbopath.AbsolutePath) {
 	logger.Debug("start replaying logs")
 	f, err := logFileName.Open()
 	if err != nil {

--- a/cli/internal/server/server.go
+++ b/cli/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/vercel/turborepo/cli/internal/fs"
 	"github.com/vercel/turborepo/cli/internal/globwatcher"
 	"github.com/vercel/turborepo/cli/internal/turbodprotocol"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -28,8 +29,8 @@ type Server struct {
 	globWatcher  *globwatcher.GlobWatcher
 	turboVersion string
 	started      time.Time
-	logFilePath  fs.AbsolutePath
-	repoRoot     fs.AbsolutePath
+	logFilePath  turbopath.AbsolutePath
+	repoRoot     turbopath.AbsolutePath
 	closerMu     sync.Mutex
 	closer       *closer
 }
@@ -62,7 +63,7 @@ func (c *closer) close() {
 var _defaultCookieTimeout = 500 * time.Millisecond
 
 // New returns a new instance of Server
-func New(serverName string, logger hclog.Logger, repoRoot fs.AbsolutePath, turboVersion string, logFilePath fs.AbsolutePath) (*Server, error) {
+func New(serverName string, logger hclog.Logger, repoRoot turbopath.AbsolutePath, turboVersion string, logFilePath turbopath.AbsolutePath) (*Server, error) {
 	cookieDir := fs.GetTurboDataDir().Join("cookies", serverName)
 	cookieJar, err := filewatcher.NewCookieJar(cookieDir, _defaultCookieTimeout)
 	if err != nil {

--- a/cli/internal/taskhash/taskhash.go
+++ b/cli/internal/taskhash/taskhash.go
@@ -77,7 +77,7 @@ func safeCompileIgnoreFile(filepath string) (*gitignore.GitIgnore, error) {
 	return gitignore.CompileIgnoreLines([]string{}...), nil
 }
 
-func (pfs *packageFileSpec) hash(pkg *fs.PackageJSON, repoRoot fs.AbsolutePath) (string, error) {
+func (pfs *packageFileSpec) hash(pkg *fs.PackageJSON, repoRoot turbopath.AbsolutePath) (string, error) {
 	hashObject, pkgDepsErr := hashing.GetPackageDeps(repoRoot, &hashing.PackageDepsOptions{
 		PackagePath:   pkg.Dir,
 		InputPatterns: pfs.inputs,
@@ -96,7 +96,7 @@ func (pfs *packageFileSpec) hash(pkg *fs.PackageJSON, repoRoot fs.AbsolutePath) 
 	return hashOfFiles, nil
 }
 
-func manuallyHashPackage(pkg *fs.PackageJSON, inputs []string, rootPath fs.AbsolutePath) (map[turbopath.AnchoredUnixPath]string, error) {
+func manuallyHashPackage(pkg *fs.PackageJSON, inputs []string, rootPath turbopath.AbsolutePath) (map[turbopath.AnchoredUnixPath]string, error) {
 	hashObject := make(map[turbopath.AnchoredUnixPath]string)
 	// Instead of implementing all gitignore properly, we hack it. We only respect .gitignore in the root and in
 	// the directory of a package.
@@ -155,7 +155,7 @@ type packageFileHashes map[packageFileHashKey]string
 
 // CalculateFileHashes hashes each unique package-inputs combination that is present
 // in the task graph. Must be called before calculating task hashes.
-func (th *Tracker) CalculateFileHashes(allTasks []dag.Vertex, workerCount int, repoRoot fs.AbsolutePath) error {
+func (th *Tracker) CalculateFileHashes(allTasks []dag.Vertex, workerCount int, repoRoot turbopath.AbsolutePath) error {
 	hashTasks := make(util.Set)
 	for _, v := range allTasks {
 		taskID, ok := v.(string)

--- a/cli/internal/taskhash/taskhash_test.go
+++ b/cli/internal/taskhash/taskhash_test.go
@@ -87,7 +87,7 @@ func Test_manuallyHashPackage(t *testing.T) {
 	pkg := &fs.PackageJSON{
 		Dir: pkgName,
 	}
-	hashes, err := manuallyHashPackage(pkg, []string{}, fs.AbsolutePath(repoRoot.ToString()))
+	hashes, err := manuallyHashPackage(pkg, []string{}, turbopath.AbsolutePath(repoRoot.ToString()))
 	if err != nil {
 		t.Fatalf("failed to calculate manual hashes: %v", err)
 	}
@@ -113,7 +113,7 @@ func Test_manuallyHashPackage(t *testing.T) {
 	}
 
 	count = 0
-	justFileHashes, err := manuallyHashPackage(pkg, []string{filepath.FromSlash("**/*file")}, fs.AbsolutePath(repoRoot.ToString()))
+	justFileHashes, err := manuallyHashPackage(pkg, []string{filepath.FromSlash("**/*file")}, turbopath.AbsolutePath(repoRoot.ToString()))
 	if err != nil {
 		t.Fatalf("failed to calculate manual hashes: %v", err)
 	}

--- a/cli/internal/turbopath/absolute_path.go
+++ b/cli/internal/turbopath/absolute_path.go
@@ -1,0 +1,178 @@
+package turbopath
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// dirPermissions are the default permission bits we apply to directories.
+const dirPermissions = os.ModeDir | 0775
+
+// ensureDir ensures that the directory of the given file has been created.
+func ensureDir(filename string) error {
+	dir := filepath.Dir(filename)
+	err := os.MkdirAll(dir, dirPermissions)
+	if err != nil && fileExists(dir) {
+		// It looks like this is a file and not a directory. Attempt to remove it; this can
+		// happen in some cases if you change a rule from outputting a file to a directory.
+		log.Printf("Attempting to remove file %s; a subdirectory is required", dir)
+		if err2 := os.Remove(dir); err2 == nil {
+			err = os.MkdirAll(dir, dirPermissions)
+		} else {
+			return err
+		}
+	}
+	return err
+}
+
+var nonRelativeSentinel string = ".." + string(filepath.Separator)
+
+// dirContainsPath returns true if the path 'target' is contained within 'dir'
+// Expects both paths to be absolute and does not verify that either path exists.
+func dirContainsPath(dir string, target string) (bool, error) {
+	// In Go, filepath.Rel can return a path that starts with "../" or equivalent.
+	// Checking filesystem-level contains can get extremely complicated
+	// (see https://github.com/golang/dep/blob/f13583b555deaa6742f141a9c1185af947720d60/internal/fs/fs.go#L33)
+	// As a compromise, rely on the stdlib to generate a relative path and then check
+	// if the first step is "../".
+	rel, err := filepath.Rel(dir, target)
+	if err != nil {
+		return false, err
+	}
+	return !strings.HasPrefix(rel, nonRelativeSentinel), nil
+}
+
+// fileExists returns true if the given path exists and is a file.
+func fileExists(filename string) bool {
+	info, err := os.Lstat(filename)
+	return err == nil && !info.IsDir()
+}
+
+// AbsolutePath represents a platform-dependent absolute path on the filesystem,
+// and is used to enfore correct path manipulation
+type AbsolutePath string
+
+func (ap AbsolutePath) ToStringDuringMigration() string {
+	return ap.asString()
+}
+
+func (ap AbsolutePath) Join(args ...string) AbsolutePath {
+	return AbsolutePath(filepath.Join(ap.asString(), filepath.Join(args...)))
+}
+func (ap AbsolutePath) asString() string {
+	return string(ap)
+}
+func (ap AbsolutePath) Dir() AbsolutePath {
+	return AbsolutePath(filepath.Dir(ap.asString()))
+}
+
+// MkdirAll implements os.MkdirAll(ap, DirPermissions|0644)
+func (ap AbsolutePath) MkdirAll() error {
+	return os.MkdirAll(ap.asString(), dirPermissions|0644)
+}
+
+// Open implements os.Open(ap) for an absolute path
+func (ap AbsolutePath) Open() (*os.File, error) {
+	return os.Open(ap.asString())
+}
+
+// OpenFile implements os.OpenFile for an absolute path
+func (ap AbsolutePath) OpenFile(flags int, mode os.FileMode) (*os.File, error) {
+	return os.OpenFile(ap.asString(), flags, mode)
+}
+
+func (ap AbsolutePath) FileExists() bool {
+	return fileExists(ap.asString())
+}
+
+// Lstat implements os.Lstat for absolute path
+func (ap AbsolutePath) Lstat() (os.FileInfo, error) {
+	return os.Lstat(ap.asString())
+}
+
+// DirExists returns true if this path points to a directory
+func (ap AbsolutePath) DirExists() bool {
+	info, err := ap.Lstat()
+	return err == nil && info.IsDir()
+}
+
+// ContainsPath returns true if this absolute path is a parent of the
+// argument.
+func (ap AbsolutePath) ContainsPath(other AbsolutePath) (bool, error) {
+	return dirContainsPath(ap.asString(), other.asString())
+}
+
+// ReadFile reads the contents of the specified file
+func (ap AbsolutePath) ReadFile() ([]byte, error) {
+	return ioutil.ReadFile(ap.asString())
+}
+
+// WriteFile writes the contents of the specified file
+func (ap AbsolutePath) WriteFile(contents []byte, mode os.FileMode) error {
+	return ioutil.WriteFile(ap.asString(), contents, mode)
+}
+
+// EnsureDir ensures that the directory containing this file exists
+func (ap AbsolutePath) EnsureDir() error {
+	return ensureDir(ap.asString())
+}
+
+// Create is the AbsolutePath wrapper for os.Create
+func (ap AbsolutePath) Create() (*os.File, error) {
+	return os.Create(ap.asString())
+}
+
+// Ext implements filepath.Ext(ap) for an absolute path
+func (ap AbsolutePath) Ext() string {
+	return filepath.Ext(ap.asString())
+}
+
+// ToString returns the string representation of this absolute path. Used for
+// interfacing with APIs that require a string
+func (ap AbsolutePath) ToString() string {
+	return ap.asString()
+}
+
+// RelativePathString returns the relative path from this AbsolutePath to another absolute path in string form as a string
+func (ap AbsolutePath) RelativePathString(path string) (string, error) {
+	return filepath.Rel(ap.asString(), path)
+}
+
+// PathTo returns the relative path between two absolute paths
+// This should likely eventually return an AnchoredSystemPath
+func (ap AbsolutePath) PathTo(other AbsolutePath) (string, error) {
+	return ap.RelativePathString(other.asString())
+}
+
+// Symlink implements os.Symlink(target, ap) for absolute path
+func (ap AbsolutePath) Symlink(target string) error {
+	return os.Symlink(target, ap.asString())
+}
+
+// Readlink implements os.Readlink(ap) for an absolute path
+func (ap AbsolutePath) Readlink() (string, error) {
+	return os.Readlink(ap.asString())
+}
+
+// Remove removes the file or (empty) directory at the given path
+func (ap AbsolutePath) Remove() error {
+	return os.Remove(ap.asString())
+}
+
+// RemoveAll implements os.RemoveAll for absolute paths.
+func (ap AbsolutePath) RemoveAll() error {
+	return os.RemoveAll(ap.asString())
+}
+
+// Base implements filepath.Base for an absolute path
+func (ap AbsolutePath) Base() string {
+	return filepath.Base(ap.asString())
+}
+
+// Rename implements os.Rename(ap, dest) for absolute paths
+func (ap AbsolutePath) Rename(dest AbsolutePath) error {
+	return os.Rename(ap.asString(), dest.asString())
+}


### PR DESCRIPTION
This PR does a few things:
1. Moves `fs.AbsolutePath` to `turbopath.AbsolutePath`.
2. (temporarily) Duplicates some utils and constants from `fs` into `turbopath/absolute_path.go` to prevent cycles. These will be removed in a followup commit.
3. (in a separate commit) `\b(fs\.)?AbsolutePath\b` => `turbopath.AbsolutePath`. (excluding the turbopath folder)

The goal here is to make what are sweeping changes to the codebase still feel as incremental as possible. The next increment is `turbopath.AbsolutePath` to `turbopath.AbsoluteSystemPath` by combining the files and fixing the expectations of method calls throughout the codebase.