### PR TITLE
fix: rule doc link

### DIFF
--- a/packages/eslint-plugin-turbo/lib/rules/no-undeclared-env-vars.ts
+++ b/packages/eslint-plugin-turbo/lib/rules/no-undeclared-env-vars.ts
@@ -10,7 +10,7 @@ const meta: Rule.RuleMetaData = {
       "Do not allow the use of `process.env` without including the env key in turbo.json",
     category: "Configuration Issues",
     recommended: true,
-    url: `https://github.com/vercel/turborepo/tree/main/packages/eslint-plugin-turbo/docs/rules/${RULES.noUndeclaredEnvVars}`,
+    url: `https://github.com/vercel/turborepo/tree/main/packages/eslint-plugin-turbo/docs/rules/${RULES.noUndeclaredEnvVars}.md`,
   },
   schema: [
     {


### PR DESCRIPTION
Tried to click on the linked doc in vscode and ended up with a 404. File extension was needed.