### PR TITLE
Add schema dialect to example turbo.json files

### DIFF
--- a/examples/basic/turbo.json
+++ b/examples/basic/turbo.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://turborepo.org/schema.json",
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],

--- a/examples/design-system/turbo.json
+++ b/examples/design-system/turbo.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://turborepo.org/schema.json",
   "pipeline": {
     "build": {
       "outputs": [

--- a/examples/kitchen-sink/turbo.json
+++ b/examples/kitchen-sink/turbo.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://turborepo.org/schema.json",
   "pipeline": {
     "build": {
       "outputs": [

--- a/examples/with-changesets/turbo.json
+++ b/examples/with-changesets/turbo.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://turborepo.org/schema.json",
   "pipeline": {
     "build": {
       "outputs": [

--- a/examples/with-create-react-app/turbo.json
+++ b/examples/with-create-react-app/turbo.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://turborepo.org/schema.json",
   "pipeline": {
     "build": {
       "outputs": ["build/**", "dist/**"],

--- a/examples/with-docker/turbo.json
+++ b/examples/with-docker/turbo.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://turborepo.org/schema.json",
   "pipeline": {
     "build": {
       "outputs": ["dist/**", ".next/**", "public/dist/**"],

--- a/examples/with-pnpm/turbo.json
+++ b/examples/with-pnpm/turbo.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://turborepo.org/schema.json",
   "pipeline": {
     "build": {
       "dependsOn": [

--- a/examples/with-react-native-web/turbo.json
+++ b/examples/with-react-native-web/turbo.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://turborepo.org/schema.json",
   "pipeline": {
     "build": {
       "outputs": ["dist/**", ".next/**"],

--- a/examples/with-svelte/turbo.json
+++ b/examples/with-svelte/turbo.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://turborepo.org/schema.json",
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],

--- a/examples/with-tailwind/turbo.json
+++ b/examples/with-tailwind/turbo.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://turborepo.org/schema.json",
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],

--- a/examples/with-vite/turbo.json
+++ b/examples/with-vite/turbo.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://turborepo.org/schema.json",
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
While working with the examples I noticed only some of them specify the incredibly useful `turbo.json` schema dialect (`"$schema": "https://turborepo.org/schema.json"`). This PR adds it to all of them :)