### PR TITLE
Remove --no-gc flag, always run with garbage collection

### DIFF
--- a/cli/cmd/turbo/main.go
+++ b/cli/cmd/turbo/main.go
@@ -147,20 +147,17 @@ func main() {
 				}
 			}
 		} else {
-			// Don't disable the GC if this is a long-running process
-			isServe := false
+			// Check if the user has request GC be turned off
+			disableGC := false
 			for _, arg := range args {
 				if arg == "--no-gc" {
-					isServe = true
+					disableGC = true
 					break
 				}
 			}
 
-			// Disable the GC since we're just going to allocate a bunch of memory
-			// and then exit anyway. This speedup is not insignificant. Make sure to
-			// only do this here once we know that we're not going to be a long-lived
-			// process though.
-			if !isServe {
+			// If the user requests GC be disabled, honor that request.
+			if disableGC {
 				debug.SetGCPercent(-1)
 			}
 

--- a/cli/cmd/turbo/main.go
+++ b/cli/cmd/turbo/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"runtime/debug"
 	"strings"
 	"time"
 
@@ -147,20 +146,6 @@ func main() {
 				}
 			}
 		} else {
-			// Check if the user has request GC be turned off
-			disableGC := false
-			for _, arg := range args {
-				if arg == "--no-gc" {
-					disableGC = true
-					break
-				}
-			}
-
-			// If the user requests GC be disabled, honor that request.
-			if disableGC {
-				debug.SetGCPercent(-1)
-			}
-
 			exitCode, err = c.Run()
 			if err != nil {
 				ui.Error(err.Error())

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -542,12 +542,8 @@ var _persistentFlags = []string{
 
 func noopPersistentOptsDuringMigration(flags *pflag.FlagSet) {
 	_ = flags.CountP("verbosity", "v", "verbosity")
-	_ = flags.Bool("no-gc", false, "")
 	if err := flags.MarkHidden("verbosity"); err != nil {
 		// fail fast if we've misconfigured our flags
-		panic(err)
-	}
-	if err := flags.MarkHidden("no-gc"); err != nil {
 		panic(err)
 	}
 	for _, flag := range _persistentFlags {

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -537,14 +537,17 @@ var _persistentFlags = []string{
 	"trace",
 	"cpuprofile",
 	"heap",
-	"no-gc",
 	"cwd",
 }
 
 func noopPersistentOptsDuringMigration(flags *pflag.FlagSet) {
 	_ = flags.CountP("verbosity", "v", "verbosity")
+	_ = flags.Bool("no-gc", false, "")
 	if err := flags.MarkHidden("verbosity"); err != nil {
 		// fail fast if we've misconfigured our flags
+		panic(err)
+	}
+	if err := flags.MarkHidden("no-gc"); err != nil {
 		panic(err)
 	}
 	for _, flag := range _persistentFlags {


### PR DESCRIPTION
This PR:
 * Removes the `--no-gc` flag
 * Makes using the GC the default.

A parsing bug meant no one was using `--no-gc`, so use this opportunity to enable GC. Benchmarks show negligible difference in execution time.

