### PR TITLE
chore(renovate): disable golang

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,12 @@
     "before 5am every weekday",
     "every weekend"
   ],
+  "packageRules": [
+    {
+      "matchLanguages": ["golang"],
+      "enabled": false
+    }
+  ],
   "prCreation": "not-pending",
   "prConcurrentLimit": 5,
   "stabilityDays": 2


### PR DESCRIPTION
We need to do a little more work here before renovate can update golang deps for us:

1. We need renovate to know how to setup protoc, and GRPC protobuf
2. Or we just commit those instead of regenerating them everytime

This disables golang for now until this is configured. 