### PR TITLE
Fix broken links at "Next Steps" on "Add to Existing Monorepo"

### DIFF
--- a/docs/pages/docs/getting-started/existing-monorepo.mdx
+++ b/docs/pages/docs/getting-started/existing-monorepo.mdx
@@ -269,8 +269,8 @@ npx turbo login --sso-team=<team-slug>
 
 You're now up and running with Turborepo, but there are still a few things to do:
 
-- [Understand how Turborepo caching works](./core-concepts/caching)
-- [Correctly handle environment variables](./core-concepts/caching#alter-caching-based-on-environment-variables-and-files)
-- [Learn to orchestrate task running with pipelines](./core-concepts/pipelines)
-- [Efficiently filter package tasks](./core-concepts/filtering)
-- [Configure Turborepo with your CI provider](./ci)
+- [Understand how Turborepo caching works](../core-concepts/caching)
+- [Correctly handle environment variables](../core-concepts/caching#alter-caching-based-on-environment-variables-and-files)
+- [Learn to orchestrate task running with pipelines](../core-concepts/pipelines)
+- [Efficiently filter package tasks](../core-concepts/filtering)
+- [Configure Turborepo with your CI provider](../ci)


### PR DESCRIPTION
The document was moved from `/docs` to `/docs/getting-started` in [the previous commit](eaab599b9214f22d184aa37647e6e55f7f1d916c)
which made the relative path referred to by those links change.

Ref. https://turborepo.org/docs/getting-started/existing-monorepo#next-steps

