### PR TITLE
Exclude variables from eslint-plugin-turbo's detection.

### DIFF
--- a/packages/eslint-plugin-turbo/__tests__/lib/no-undeclared-env-vars.test.ts
+++ b/packages/eslint-plugin-turbo/__tests__/lib/no-undeclared-env-vars.test.ts
@@ -149,6 +149,18 @@ ruleTester.run(RULES.noUndeclaredEnvVars, rule, {
         },
       ],
     },
+    {
+      code: "const getEnv = (key) => process.env[key];",
+      options: [{ turboConfig: getTestTurboConfig() }],
+    },
+    {
+      code: "function getEnv(key) { return process.env[key]; }",
+      options: [{ turboConfig: getTestTurboConfig() }],
+    },
+    {
+      code: "for (let x of ['ONE', 'TWO', 'THREE']) { console.log(process.env[x]); }",
+      options: [{ turboConfig: getTestTurboConfig() }],
+    },
   ],
 
   invalid: [

--- a/packages/eslint-plugin-turbo/lib/rules/no-undeclared-env-vars.ts
+++ b/packages/eslint-plugin-turbo/lib/rules/no-undeclared-env-vars.ts
@@ -96,9 +96,12 @@ function create(context: Rule.RuleContext): Rule.RuleListener {
           // accessing key on process.env
           else if (
             "property" in node.parent &&
-            "name" in node.parent.property
+            "name" in node.parent.property &&
+            // && the property is not a variable.
+            // Types do not map to reality here.
+            (node.parent.property as any).parent?.computed !== true
           ) {
-            checkKey(node.parent, node.parent.property?.name);
+            checkKey(node.parent, node.parent.property.name);
           }
         }
       }


### PR DESCRIPTION
`eslint-plugin-turbo` will happily treat JavaScript variable names as environment variable names because it doesn't attempt to detect if the property being accessed is dynamic. This adds tests and a fix for that issue.

Note that `@types/estree` does not match reality so this leverages an `any` escape valve to be able to perform the check.