### PR TITLE
Split notion of logged in into user and linked-team

### DIFF
--- a/cli/internal/client/client.go
+++ b/cli/internal/client/client.go
@@ -85,9 +85,14 @@ func NewClient(remoteConfig RemoteConfig, logger hclog.Logger, turboVersion stri
 	return client
 }
 
-// IsLoggedIn returns true if this ApiClient has appropriate credentials
-func (c *ApiClient) IsLoggedIn() bool {
-	return c.token != "" && (c.teamID != "" || c.teamSlug != "")
+// HasUser returns true if we have credentials for a user
+func (c *ApiClient) HasUser() bool {
+	return c.token != ""
+}
+
+// IsLinked returns true if we have a user and linked team
+func (c *ApiClient) IsLinked() bool {
+	return c.HasUser() && (c.teamID != "" || c.teamSlug != "")
 }
 
 // SetTeamID sets the team parameter used on all requests by this client

--- a/cli/internal/login/link.go
+++ b/cli/internal/login/link.go
@@ -43,7 +43,7 @@ type link struct {
 }
 
 type linkAPIClient interface {
-	IsLoggedIn() bool
+	HasUser() bool
 	GetTeams() (*client.TeamsResponse, error)
 	GetUser() (*client.UserResponse, error)
 	SetTeamID(teamID string)
@@ -140,7 +140,7 @@ func (l *link) run() error {
 		return errUserCanceled
 	}
 
-	if !l.apiClient.IsLoggedIn() {
+	if !l.apiClient.HasUser() {
 		return fmt.Errorf(util.Sprintf("User not found. Please login to Turborepo first by running ${BOLD}`npx turbo login`${RESET}."))
 	}
 

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -685,7 +685,7 @@ func (r *run) logWarning(prefix string, err error) {
 func (r *run) executeTasks(ctx gocontext.Context, g *completeGraph, rs *runSpec, engine *core.Scheduler, packageManager *packagemanager.PackageManager, hashes *taskhash.Tracker, startAt time.Time) error {
 	apiClient := r.config.NewClient()
 	var analyticsSink analytics.Sink
-	if apiClient.IsLoggedIn() {
+	if apiClient.IsLinked() {
 		analyticsSink = apiClient
 	} else {
 		r.opts.cacheOpts.SkipRemote = true


### PR DESCRIPTION
Fixes a bug where `turbo link` tried to verify that we were already linked, while `turbo run` needs to know if we're linked to use analytics.