### PR TITLE
fix(eslint): exclude variables in rule

### DIFF
--- a/packages/eslint-plugin-turbo/__tests__/lib/no-undeclared-env-vars.test.ts
+++ b/packages/eslint-plugin-turbo/__tests__/lib/no-undeclared-env-vars.test.ts
@@ -149,6 +149,18 @@ ruleTester.run(RULES.noUndeclaredEnvVars, rule, {
         },
       ],
     },
+    {
+      code: "const getEnv = (key) => process.env[key];",
+      options: [{ turboConfig: getTestTurboConfig() }],
+    },
+    {
+      code: "function getEnv(key) { return process.env[key]; }",
+      options: [{ turboConfig: getTestTurboConfig() }],
+    },
+    {
+      code: "for (let x of ['ONE', 'TWO', 'THREE']) { console.log(process.env[x]); }",
+      options: [{ turboConfig: getTestTurboConfig() }],
+    },
   ],
 
   invalid: [

--- a/packages/eslint-plugin-turbo/lib/rules/no-undeclared-env-vars.ts
+++ b/packages/eslint-plugin-turbo/lib/rules/no-undeclared-env-vars.ts
@@ -1,5 +1,5 @@
 import type { Rule } from "eslint";
-import { Node } from "estree";
+import { Node, MemberExpression } from "estree";
 import { RULES } from "../constants";
 import getEnvVarDependencies from "../utils/getEnvVarDependencies";
 
@@ -74,10 +74,24 @@ function create(context: Rule.RuleContext): Rule.RuleListener {
     }
   };
 
+  const isComputed = (
+    node: MemberExpression & Rule.NodeParentExtension
+  ): boolean => {
+    if ("computed" in node.parent) {
+      return node.parent.computed;
+    }
+
+    return false;
+  };
+
   return {
     MemberExpression(node) {
-      // we only care about complete process env declarations
-      if ("name" in node.object && "name" in node.property) {
+      // we only care about complete process env declarations and non-computed keys
+      if (
+        "name" in node.object &&
+        "name" in node.property &&
+        !isComputed(node)
+      ) {
         const objectName = node.object.name;
         const propertyName = node.property.name;
 


### PR DESCRIPTION
`eslint-plugin-turbo` will happily treat JavaScript variable names as environment variable names because it doesn't attempt to detect if the property being accessed is dynamic. This adds tests and a fix for that issue.