### PR TITLE
Don't special case version command

### DIFF
--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -68,7 +68,7 @@ func ParseAndValidate(args []string, ui cli.Ui, turboVersion string, userConfigF
 	cmd, inputFlags := args[0], args[1:]
 	// Special check for version command
 	// command is ./turbo --version
-	if len(inputFlags) == 0 && (cmd == "version" || cmd == "--version" || cmd == "-version") {
+	if len(inputFlags) == 0 && (cmd == "--version" || cmd == "-version") {
 		return nil, nil
 	}
 


### PR DESCRIPTION
We don't have a `turbo version` command, so don't special case it in argument parsing.

Fixes #1839 

This is superceded by #1792 