### PR TITLE
feat(ignore): check for turbo force

### DIFF
--- a/packages/turbo-ignore/src/index.ts
+++ b/packages/turbo-ignore/src/index.ts
@@ -11,7 +11,7 @@ console.log(
 // check for TURBO_FORCE and bail early if it's set
 if (process.env.TURBO_FORCE === "true") {
   console.log(
-    "\u226B Turbo force detected, skipping check and proceeding with build."
+    "\u226B `TURBO_FORCE` detected, skipping check and proceeding with build."
   );
   process.exit(1);
 }

--- a/packages/turbo-ignore/src/index.ts
+++ b/packages/turbo-ignore/src/index.ts
@@ -7,6 +7,15 @@ import { getComparison } from "./getComparison";
 console.log(
   "\u226B Using Turborepo to determine if this project is affected by the commit..."
 );
+
+// check for TURBO_FORCE and bail early if it's set
+if (process.env.TURBO_FORCE === "true") {
+  console.log(
+    "\u226B Turbo force detected, skipping check and proceeding with build."
+  );
+  process.exit(1);
+}
+
 // find the monorepo root
 const root = getTurboRoot();
 if (!root) {


### PR DESCRIPTION
Check for the presence of `TURBO_FORCE`, and skip the ignore check if it exists. 

Because `turbo-ignore` now checks against `VERCEL_GIT_PREVIOUS_SHA` when deploying on Vercel, manually queued builds that skip the cache will _not_ deploy if there are no changes between the selected build and production. This is confusing, and generally not what the user wants when redeploying a build. 

NOTE: This isn't a Vercel specific env var (hence it's not gated by a `process.env.VERCEL` check) - any CI provider could set this when manually skipping the cache is selected (similar to how Vercel is handling this)