### PR TITLE
Use correct flag for graphviz version

### DIFF
--- a/cli/internal/graphvisualizer/graphvisualizer.go
+++ b/cli/internal/graphvisualizer/graphvisualizer.go
@@ -23,7 +23,7 @@ type GraphVisualizer struct {
 
 // hasGraphViz checks for the presence of https://graphviz.org/
 func hasGraphViz() bool {
-	err := exec.Command("dot", "-v").Run()
+	err := exec.Command("dot", "-V").Run()
 	return err == nil
 }
 


### PR DESCRIPTION
`dot --help` specifies that `-v` is for verbose mode, whereas `-V` is print version and exit. We want the latter, so change the flag to do that.