### PR TITLE
Reconcile cram tests and help text

### DIFF
--- a/cli/integration_tests/turbo_help.t
+++ b/cli/integration_tests/turbo_help.t
@@ -47,7 +47,7 @@ Test help flag
   Available Commands:
     bin         Get the path to the Turbo binary
     completion  Generate the autocompletion script for the specified shell
-    daemon      Runs turbod
+    daemon      Runs the Turborepo background daemon
     help        Help about any command
     link        Link your local directory to a Vercel organization and enable remote caching.
     login       Login to your Vercel account

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -79,7 +79,7 @@ func getCmd(helper *cmdutil.Helper, signalWatcher *signals.Watcher) *cobra.Comma
 
 	cmd := &cobra.Command{
 		Use:              "turbo",
-		Short:            "Turbo charge your monorepo",
+		Short:            "Turbocharge your monorepo",
 		TraverseChildren: true,
 		Version:          helper.TurboVersion,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/internal/daemon/daemon.go
+++ b/cli/internal/daemon/daemon.go
@@ -80,7 +80,7 @@ func GetCmd(helper *cmdutil.Helper, signalWatcher *signals.Watcher) *cobra.Comma
 	var idleTimeout time.Duration
 	cmd := &cobra.Command{
 		Use:           "daemon",
-		Short:         "Runs turbod",
+		Short:         "Runs the Turborepo background daemon",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
 * Change the root command to match the expectation in the help test
 * Change the daemon subcommand to match the expectation in the help test
 * Fix the help test to expect a consistent description for the daemon subcommand

This is probably at the point where we want to wire it to CI, so that'll be coming shortly.