### PR TITLE
eslint-plugin-turbo: notice env vars which are accessed by indicated functions

### DIFF
--- a/packages/eslint-plugin-turbo/__tests__/lib/no-undeclared-env-vars.test.ts
+++ b/packages/eslint-plugin-turbo/__tests__/lib/no-undeclared-env-vars.test.ts
@@ -161,6 +161,28 @@ ruleTester.run(RULES.noUndeclaredEnvVars, rule, {
       code: "for (let x of ['ONE', 'TWO', 'THREE']) { console.log(process.env[x]); }",
       options: [{ turboConfig: getTestTurboConfig() }],
     },
+    {
+      code: `
+        getEnv('GLOBAL_ENV_KEY');
+        getEnv("TASK_ENV_KEY");
+      `,
+      options: [
+        { turboConfig: getTestTurboConfig(), envAccessors: ["getEnv"] },
+      ],
+    },
+    {
+      code: `
+        getEnv("TASK_ENV_KEY");
+        getEnv("ENV_VAR_ALLOWED");
+      `,
+      options: [
+        {
+          turboConfig: getTestTurboConfig(),
+          envAccessors: ["getEnv"],
+          allowList: ["^ENV_VAR_[A-Z]+$"],
+        },
+      ],
+    },
   ],
 
   invalid: [
@@ -328,6 +350,48 @@ ruleTester.run(RULES.noUndeclaredEnvVars, rule, {
         {
           message:
             "$ENV_VAR_NOT_ALLOWED is not listed as a dependency in turbo.json",
+        },
+      ],
+    },
+    {
+      code: `
+        getEnv('GLOBAL_ENV_KEY');
+        getEnv('GLOBAL_ENV_KEY_NEW');
+        getEnv("TASK_ENV_KEY_NEW");
+      `,
+      options: [
+        { turboConfig: getTestTurboConfig(), envAccessors: ["getEnv"] },
+      ],
+      errors: [
+        {
+          message:
+            "$GLOBAL_ENV_KEY_NEW is not listed as a dependency in turbo.json",
+        },
+        {
+          message:
+            "$TASK_ENV_KEY_NEW is not listed as a dependency in turbo.json",
+        },
+      ],
+    },
+    {
+      code: `
+        getEnv("TASK_ENV_KEY_NEW");
+        getEnv("ENV_VAR_ALLOWED");
+      `,
+      options: [
+        {
+          turboConfig: getTestTurboConfig(),
+          envAccessors: ["getEnv"],
+        },
+      ],
+      errors: [
+        {
+          message:
+            "$TASK_ENV_KEY_NEW is not listed as a dependency in turbo.json",
+        },
+        {
+          message:
+            "$ENV_VAR_ALLOWED is not listed as a dependency in turbo.json",
         },
       ],
     },

--- a/packages/eslint-plugin-turbo/docs/rules/no-undeclared-env-vars.md
+++ b/packages/eslint-plugin-turbo/docs/rules/no-undeclared-env-vars.md
@@ -68,12 +68,81 @@ Examples of **correct** code for this rule:
 }
 ```
 
+### Environment accessor functions
+
+In addition to direct access to properties on `process.env`, this rule also allows for dynamic
+access to environment variables via accessor functions. Specify the function name with the
+`envAccessors` options.
+
+The following examples assume `envAccessors: ["ensureEnv"]` in `eslintrc` and the following code:
+
+```js
+const client = MyAPI({ token: ensureEnv("MY_API_TOKEN") });
+```
+
+Examples of **incorrect** code for this rule:
+
+```json
+{
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", ".next/**"]
+    },
+    "lint": {
+      "outputs": []
+    },
+    "dev": {
+      "cache": false
+    }
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```json
+{
+  "globalDependencies": ["$MY_API_TOKEN"]
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", ".next/**"]
+    },
+    "lint": {
+      "outputs": []
+    },
+    "dev": {
+      "cache": false
+    }
+  }
+}
+```
+
+```json
+{
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build", "$MY_API_TOKEN"],
+      "outputs": ["dist/**", ".next/**"]
+    },
+    "lint": {
+      "outputs": []
+    },
+    "dev": {
+      "cache": false
+    }
+  }
+}
+```
+
 ## Options
 
-| Option        | Required | Default     | Details                                                                                                                                     | Example                                      |
-| ------------- | -------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
-| `turboConfig` | No       | Auto-detect | Resolved `turbo.json` configuration                                                                                                         | `require("./turbo.json")`                    |
-| `allowList`   | No       | []          | An array of strings (or regular expressions) to exclude. NOTE: an env variable should only be excluded if it has no effect on build outputs | `["MY_API_TOKEN", "^MY_ENV_PREFIX_[A-Z]+$"]` |
+| Option         | Required | Default     | Details                                                                                                                                     | Example                                      |
+| -------------- | -------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| `turboConfig`  | No       | Auto-detect | Resolved `turbo.json` configuration                                                                                                         | `require("./turbo.json")`                    |
+| `allowList`    | No       | []          | An array of strings (or regular expressions) to exclude. NOTE: an env variable should only be excluded if it has no effect on build outputs | `["MY_API_TOKEN", "^MY_ENV_PREFIX_[A-Z]+$"]` |
+| `envAccessors` | No       | []          | An array of function identifier names which should be treated as environment accessors                                                      | `["getEnv", "ensureEnv"]`                    |
 
 ## Further Reading
 

--- a/packages/eslint-plugin-turbo/lib/rules/no-undeclared-env-vars.ts
+++ b/packages/eslint-plugin-turbo/lib/rules/no-undeclared-env-vars.ts
@@ -29,6 +29,13 @@ const meta: Rule.RuleMetaData = {
             type: "string",
           },
         },
+        envAccessors: {
+          default: [],
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
       },
     },
   ],
@@ -85,6 +92,22 @@ function create(context: Rule.RuleContext): Rule.RuleListener {
   };
 
   return {
+    // Check for invocations of envAccessors
+    CallExpression(node) {
+      const { callee } = node;
+      if (
+        callee.type === "Identifier" &&
+        options?.[0]?.envAccessors?.includes(callee.name)
+      ) {
+        const [firstArg] = node.arguments;
+        if (firstArg?.type === "Literal") {
+          if (typeof firstArg.value === "string") {
+            checkKey(node, firstArg.value);
+          }
+        }
+      }
+    },
+    // Check for literal process.env property access
     MemberExpression(node) {
       // we only care about complete process env declarations and non-computed keys
       if (


### PR DESCRIPTION
In our codebase, we have the pattern of writing a function like
```typescript
function assertEnvVarPresent(
  envName: string,
): string {
  const value = process.env[envName]
  if (value == null) {
    throw new Error(`Required environment variable missing on init: ${envName}`)
  }
  return value
}
```
to check at program start time that necessary environment variables are present.

Unfortunately, this prevents us from benefiting from the `no-undeclared-env-vars` rule, since our code looks like

```typescript
const secrets = {
  commitSha: assertEnvVarPresent("VERCEL_GIT_COMMIT_SHA");
};
```

This PR adds an option `envAccessors` to `no-undeclared-env-vars` which allows the user to specify a list of function names whose first arguments (if they are string literals) will be checked as environment variables.

Example config that would enable this usecase:
```json
"turbo/no-undeclared-env-vars": [
  "error",
  {
    "envAccessors": ["assertEnvPresent"]
  }
]
```

I hope you find this to be a usecase worth supporting! Happy to make changes if you think it's a good feature.
