### PR TITLE
No shallow checkout for linting.

### DIFF
--- a/.github/workflows/pr-go-lint.yml
+++ b/.github/workflows/pr-go-lint.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/setup-go
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
`golangci-lint` expects to be able to find the previous revision, this guarantees it will be there.