### PR TITLE
fix(prune): place workspace configuration file in json directory

### DIFF
--- a/cli/internal/prune/prune.go
+++ b/cli/internal/prune/prune.go
@@ -129,6 +129,14 @@ func (p *prune) prune(opts *opts) error {
 		if err := fs.CopyFile(&workspaceFile, outDir.UntypedJoin(ctx.PackageManager.WorkspaceConfigurationPath).ToStringDuringMigration()); err != nil {
 			return errors.Wrapf(err, "could not copy %s", ctx.PackageManager.WorkspaceConfigurationPath)
 		}
+		if err := fs.CopyFile(&workspaceFile, fullDir.UntypedJoin(ctx.PackageManager.WorkspaceConfigurationPath).ToStringDuringMigration()); err != nil {
+			return errors.Wrapf(err, "could not copy %s", ctx.PackageManager.WorkspaceConfigurationPath)
+		}
+		if opts.docker {
+			if err := fs.CopyFile(&workspaceFile, outDir.UntypedJoin("json", ctx.PackageManager.WorkspaceConfigurationPath).ToStringDuringMigration()); err != nil {
+				return errors.Wrapf(err, "could not copy %s", ctx.PackageManager.WorkspaceConfigurationPath)
+			}
+		}
 	}
 	workspaces := []turbopath.AnchoredSystemPath{}
 	targets := []interface{}{opts.scope}


### PR DESCRIPTION
Fix for issue that @mattpocock discovered.

This places the workspace definition file into the `json` directory and `full` directory instead of the `out` directory. This reflects the new documentation in #2013 