### PR TITLE
We can infer identifer, we don't need to specify it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,26 +7,18 @@ on:
   workflow_dispatch:
     inputs:
       increment:
-        description: 'SemVer Increment'
+        description: "SemVer Increment"
         required: true
-        default: 'prerelease'
+        default: "prerelease"
         type: choice
         options:
-        - prerelease
-        - prepatch
-        - preminor
-        - premajor
-        - patch
-        - minor
-        - major
-      identifier:
-        description: 'npm Tag'
-        required: true
-        default: 'canary'
-        type: choice
-        options:
-        - canary
-        - latest
+          - prerelease
+          - prepatch
+          - preminor
+          - premajor
+          - patch
+          - minor
+          - major
 jobs:
   build:
     runs-on: macos-latest
@@ -70,7 +62,7 @@ jobs:
 
       - name: Version
         run: |
-          ./scripts/version.js ${{ inputs.increment }} ${{ inputs.identifier }}
+          ./scripts/version.js ${{ inputs.increment }}
           cat version.txt
 
       - name: Release

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -6,7 +6,6 @@ const semver = require("semver");
 
 // These values come from the invocation of release.
 const increment = process.argv[2];
-const identifier = process.argv[3];
 
 // Now we get the current version of the package.
 const versionFilePath = path.join(__dirname, "..", "version.txt");
@@ -14,7 +13,8 @@ const versionFileContents = fs.readFileSync(versionFilePath, "utf-8");
 const [currentVersion] = versionFileContents.split("\n");
 
 // Now that we know current state, figure out what the target state is.
-// The `identifier` is unused unless the increment is `pre____`.
+// If we're doing a "pre" release, set the identifier to canary
+const identifier = increment.startsWith("pre") ? "canary" : "latest";
 const newVersion = semver.inc(currentVersion, increment, identifier);
 
 // Parse the output semver identifer to identify which npm tag to publish to.


### PR DESCRIPTION
We don't do "latest" versions of "pre" releases, so infer the "canary" or "latest" identifier based on the kind of release we're doing.