### PR TITLE
Drop no-longer-supported platform references

### DIFF
--- a/packages/turbo/node-platform.js
+++ b/packages/turbo/node-platform.js
@@ -13,21 +13,13 @@ const TURBO_BINARY_PATH = process.env.TURBO_BINARY_PATH;
 
 const knownWindowsPackages = {
   "win32 arm64 LE": "turbo-windows-arm64",
-  "win32 ia32 LE": "turbo-windows-32",
   "win32 x64 LE": "turbo-windows-64",
 };
 
 const knownUnixlikePackages = {
-  "android arm64 LE": "turbo-android-arm64",
   "darwin arm64 LE": "turbo-darwin-arm64",
   "darwin x64 LE": "turbo-darwin-64",
-  "freebsd arm64 LE": "turbo-freebsd-arm64",
-  "freebsd x64 LE": "turbo-freebsd-64",
-  "linux arm LE": "turbo-linux-arm",
   "linux arm64 LE": "turbo-linux-arm64",
-  "linux ia32 LE": "turbo-linux-32",
-  "linux mips64el LE": "turbo-linux-mips64le",
-  "linux ppc64 LE": "turbo-linux-ppc64le",
   "linux x64 LE": "turbo-linux-64",
 };
 

--- a/packages/turbo/package.json
+++ b/packages/turbo/package.json
@@ -19,18 +19,10 @@
     "install.js"
   ],
   "optionalDependencies": {
-    "turbo-android-arm64": "1.5.0",
     "turbo-darwin-64": "1.5.0",
     "turbo-darwin-arm64": "1.5.0",
-    "turbo-freebsd-64": "1.5.0",
-    "turbo-freebsd-arm64": "1.5.0",
-    "turbo-linux-32": "1.5.0",
     "turbo-linux-64": "1.5.0",
-    "turbo-linux-arm": "1.5.0",
     "turbo-linux-arm64": "1.5.0",
-    "turbo-linux-mips64le": "1.5.0",
-    "turbo-linux-ppc64le": "1.5.0",
-    "turbo-windows-32": "1.5.0",
     "turbo-windows-64": "1.5.0",
     "turbo-windows-arm64": "1.5.0"
   }


### PR DESCRIPTION
Our `package.json` and installed script don't need references to these packages anymore