### PR TITLE
Add path types for cache.

### DIFF
--- a/cli/internal/cache/async_cache.go
+++ b/cli/internal/cache/async_cache.go
@@ -76,7 +76,7 @@ func (c *asyncCache) Shutdown() {
 // run implements the actual async logic.
 func (c *asyncCache) run() {
 	for r := range c.requests {
-		c.realCache.Put(r.anchor, r.key, r.duration, r.files)
+		_ = c.realCache.Put(r.anchor, r.key, r.duration, r.files)
 	}
 	c.wg.Done()
 }

--- a/cli/internal/cache/async_cache.go
+++ b/cli/internal/cache/async_cache.go
@@ -22,7 +22,7 @@ type asyncCache struct {
 
 // A cacheRequest models an incoming cache request on our queue.
 type cacheRequest struct {
-	target   string
+	anchor   turbopath.AbsoluteSystemPath
 	key      string
 	duration int
 	files    []turbopath.AnchoredSystemPath
@@ -40,9 +40,9 @@ func newAsyncCache(realCache Cache, opts Opts) Cache {
 	return c
 }
 
-func (c *asyncCache) Put(target string, key string, duration int, files []turbopath.AnchoredSystemPath) error {
+func (c *asyncCache) Put(anchor turbopath.AbsoluteSystemPath, key string, duration int, files []turbopath.AnchoredSystemPath) error {
 	c.requests <- cacheRequest{
-		target:   target,
+		anchor:   anchor,
 		key:      key,
 		files:    files,
 		duration: duration,
@@ -50,16 +50,16 @@ func (c *asyncCache) Put(target string, key string, duration int, files []turbop
 	return nil
 }
 
-func (c *asyncCache) Fetch(target string, key string, files []string) (bool, []turbopath.AnchoredSystemPath, int, error) {
-	return c.realCache.Fetch(target, key, files)
+func (c *asyncCache) Fetch(anchor turbopath.AbsoluteSystemPath, key string, files []string) (bool, []turbopath.AnchoredSystemPath, int, error) {
+	return c.realCache.Fetch(anchor, key, files)
 }
 
 func (c *asyncCache) Exists(key string) (ItemStatus, error) {
 	return c.realCache.Exists(key)
 }
 
-func (c *asyncCache) Clean(target string) {
-	c.realCache.Clean(target)
+func (c *asyncCache) Clean(anchor turbopath.AbsoluteSystemPath) {
+	c.realCache.Clean(anchor)
 }
 
 func (c *asyncCache) CleanAll() {
@@ -76,7 +76,7 @@ func (c *asyncCache) Shutdown() {
 // run implements the actual async logic.
 func (c *asyncCache) run() {
 	for r := range c.requests {
-		c.realCache.Put(r.target, r.key, r.duration, r.files)
+		c.realCache.Put(r.anchor, r.key, r.duration, r.files)
 	}
 	c.wg.Done()
 }

--- a/cli/internal/cache/async_cache.go
+++ b/cli/internal/cache/async_cache.go
@@ -5,6 +5,8 @@ package cache
 
 import (
 	"sync"
+
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 )
 
 // An asyncCache is a wrapper around a Cache interface that handles incoming
@@ -23,7 +25,7 @@ type cacheRequest struct {
 	target   string
 	key      string
 	duration int
-	files    []string
+	files    []turbopath.AnchoredSystemPath
 }
 
 func newAsyncCache(realCache Cache, opts Opts) Cache {
@@ -38,7 +40,7 @@ func newAsyncCache(realCache Cache, opts Opts) Cache {
 	return c
 }
 
-func (c *asyncCache) Put(target string, key string, duration int, files []string) error {
+func (c *asyncCache) Put(target string, key string, duration int, files []turbopath.AnchoredSystemPath) error {
 	c.requests <- cacheRequest{
 		target:   target,
 		key:      key,

--- a/cli/internal/cache/async_cache.go
+++ b/cli/internal/cache/async_cache.go
@@ -50,7 +50,7 @@ func (c *asyncCache) Put(target string, key string, duration int, files []turbop
 	return nil
 }
 
-func (c *asyncCache) Fetch(target string, key string, files []string) (bool, []string, int, error) {
+func (c *asyncCache) Fetch(target string, key string, files []string) (bool, []turbopath.AnchoredSystemPath, int, error) {
 	return c.realCache.Fetch(target, key, files)
 }
 

--- a/cli/internal/cache/cache.go
+++ b/cli/internal/cache/cache.go
@@ -274,7 +274,6 @@ func (mplex *cacheMultiplexer) Fetch(anchor turbopath.AbsoluteSystemPath, key st
 		}
 	}
 
-	// FIXES BUG
 	return false, nil, 0, nil
 }
 

--- a/cli/internal/cache/cache.go
+++ b/cli/internal/cache/cache.go
@@ -24,7 +24,7 @@ type Cache interface {
 	Fetch(target string, hash string, files []string) (bool, []string, int, error)
 	Exists(hash string) (ItemStatus, error)
 	// Put caches files for a given hash
-	Put(target string, hash string, duration int, files []string) error
+	Put(target string, hash string, duration int, files []turbopath.AnchoredSystemPath) error
 	Clean(target string)
 	CleanAll()
 	Shutdown()
@@ -172,7 +172,7 @@ type cacheMultiplexer struct {
 	onCacheRemoved OnCacheRemoved
 }
 
-func (mplex *cacheMultiplexer) Put(target string, key string, duration int, files []string) error {
+func (mplex *cacheMultiplexer) Put(target string, key string, duration int, files []turbopath.AnchoredSystemPath) error {
 	return mplex.storeUntil(target, key, duration, files, len(mplex.caches))
 }
 
@@ -184,7 +184,7 @@ type cacheRemoval struct {
 // storeUntil stores artifacts into higher priority caches than the given one.
 // Used after artifact retrieval to ensure we have them in eg. the directory cache after
 // downloading from the RPC cache.
-func (mplex *cacheMultiplexer) storeUntil(target string, key string, duration int, files []string, stopAt int) error {
+func (mplex *cacheMultiplexer) storeUntil(target string, key string, duration int, files []turbopath.AnchoredSystemPath, stopAt int) error {
 	// Attempt to store on all caches simultaneously.
 	toRemove := make([]*cacheRemoval, stopAt)
 	g := &errgroup.Group{}

--- a/cli/internal/cache/cache.go
+++ b/cli/internal/cache/cache.go
@@ -21,7 +21,7 @@ import (
 type Cache interface {
 	// Fetch returns true if there is a cache it. It is expected to move files
 	// into their correct position as a side effect
-	Fetch(target string, hash string, files []string) (bool, []string, int, error)
+	Fetch(target string, hash string, files []string) (bool, []turbopath.AnchoredSystemPath, int, error)
 	Exists(hash string) (ItemStatus, error)
 	// Put caches files for a given hash
 	Put(target string, hash string, duration int, files []turbopath.AnchoredSystemPath) error
@@ -241,7 +241,7 @@ func (mplex *cacheMultiplexer) removeCache(removal *cacheRemoval) {
 	}
 }
 
-func (mplex *cacheMultiplexer) Fetch(target string, key string, files []string) (bool, []string, int, error) {
+func (mplex *cacheMultiplexer) Fetch(target string, key string, files []string) (bool, []turbopath.AnchoredSystemPath, int, error) {
 	// Make a shallow copy of the caches, since storeUntil can call removeCache
 	mplex.mu.RLock()
 	caches := make([]Cache, len(mplex.caches))
@@ -273,7 +273,9 @@ func (mplex *cacheMultiplexer) Fetch(target string, key string, files []string) 
 			return ok, actualFiles, duration, err
 		}
 	}
-	return false, files, 0, nil
+
+	// FIXES BUG
+	return false, nil, 0, nil
 }
 
 func (mplex *cacheMultiplexer) Exists(target string) (ItemStatus, error) {

--- a/cli/internal/cache/cache.go
+++ b/cli/internal/cache/cache.go
@@ -21,11 +21,11 @@ import (
 type Cache interface {
 	// Fetch returns true if there is a cache it. It is expected to move files
 	// into their correct position as a side effect
-	Fetch(target string, hash string, files []string) (bool, []turbopath.AnchoredSystemPath, int, error)
+	Fetch(anchor turbopath.AbsoluteSystemPath, hash string, files []string) (bool, []turbopath.AnchoredSystemPath, int, error)
 	Exists(hash string) (ItemStatus, error)
 	// Put caches files for a given hash
-	Put(target string, hash string, duration int, files []turbopath.AnchoredSystemPath) error
-	Clean(target string)
+	Put(anchor turbopath.AbsoluteSystemPath, hash string, duration int, files []turbopath.AnchoredSystemPath) error
+	Clean(anchor turbopath.AbsoluteSystemPath)
 	CleanAll()
 	Shutdown()
 }
@@ -172,8 +172,8 @@ type cacheMultiplexer struct {
 	onCacheRemoved OnCacheRemoved
 }
 
-func (mplex *cacheMultiplexer) Put(target string, key string, duration int, files []turbopath.AnchoredSystemPath) error {
-	return mplex.storeUntil(target, key, duration, files, len(mplex.caches))
+func (mplex *cacheMultiplexer) Put(anchor turbopath.AbsoluteSystemPath, key string, duration int, files []turbopath.AnchoredSystemPath) error {
+	return mplex.storeUntil(anchor, key, duration, files, len(mplex.caches))
 }
 
 type cacheRemoval struct {
@@ -184,7 +184,7 @@ type cacheRemoval struct {
 // storeUntil stores artifacts into higher priority caches than the given one.
 // Used after artifact retrieval to ensure we have them in eg. the directory cache after
 // downloading from the RPC cache.
-func (mplex *cacheMultiplexer) storeUntil(target string, key string, duration int, files []turbopath.AnchoredSystemPath, stopAt int) error {
+func (mplex *cacheMultiplexer) storeUntil(anchor turbopath.AbsoluteSystemPath, key string, duration int, files []turbopath.AnchoredSystemPath, stopAt int) error {
 	// Attempt to store on all caches simultaneously.
 	toRemove := make([]*cacheRemoval, stopAt)
 	g := &errgroup.Group{}
@@ -196,7 +196,7 @@ func (mplex *cacheMultiplexer) storeUntil(target string, key string, duration in
 		c := cache
 		i := i
 		g.Go(func() error {
-			err := c.Put(target, key, duration, files)
+			err := c.Put(anchor, key, duration, files)
 			if err != nil {
 				cd := &util.CacheDisabledError{}
 				if errors.As(err, &cd) {
@@ -241,7 +241,7 @@ func (mplex *cacheMultiplexer) removeCache(removal *cacheRemoval) {
 	}
 }
 
-func (mplex *cacheMultiplexer) Fetch(target string, key string, files []string) (bool, []turbopath.AnchoredSystemPath, int, error) {
+func (mplex *cacheMultiplexer) Fetch(anchor turbopath.AbsoluteSystemPath, key string, files []string) (bool, []turbopath.AnchoredSystemPath, int, error) {
 	// Make a shallow copy of the caches, since storeUntil can call removeCache
 	mplex.mu.RLock()
 	caches := make([]Cache, len(mplex.caches))
@@ -251,7 +251,7 @@ func (mplex *cacheMultiplexer) Fetch(target string, key string, files []string) 
 	// Retrieve from caches sequentially; if we did them simultaneously we could
 	// easily write the same file from two goroutines at once.
 	for i, cache := range caches {
-		ok, actualFiles, duration, err := cache.Fetch(target, key, files)
+		ok, actualFiles, duration, err := cache.Fetch(anchor, key, files)
 		if err != nil {
 			cd := &util.CacheDisabledError{}
 			if errors.As(err, &cd) {
@@ -269,7 +269,7 @@ func (mplex *cacheMultiplexer) Fetch(target string, key string, files []string) 
 			// Store this into other caches. We can ignore errors here because we know
 			// we have previously successfully stored in a higher-priority cache, and so the overall
 			// result is a success at fetching. Storing in lower-priority caches is an optimization.
-			_ = mplex.storeUntil(target, key, duration, actualFiles, i)
+			_ = mplex.storeUntil(anchor, key, duration, actualFiles, i)
 			return ok, actualFiles, duration, err
 		}
 	}
@@ -292,9 +292,9 @@ func (mplex *cacheMultiplexer) Exists(target string) (ItemStatus, error) {
 	return syncCacheState, nil
 }
 
-func (mplex *cacheMultiplexer) Clean(target string) {
+func (mplex *cacheMultiplexer) Clean(anchor turbopath.AbsoluteSystemPath) {
 	for _, cache := range mplex.caches {
-		cache.Clean(target)
+		cache.Clean(anchor)
 	}
 }
 

--- a/cli/internal/cache/cache.go
+++ b/cli/internal/cache/cache.go
@@ -130,7 +130,7 @@ func newSyncCache(opts Opts, repoRoot turbopath.AbsoluteSystemPath, client clien
 	}
 
 	if useHTTPCache {
-		implementation := newHTTPCache(opts, client, recorder, repoRoot)
+		implementation := newHTTPCache(opts, client, recorder)
 		cacheImplementations = append(cacheImplementations, implementation)
 	}
 

--- a/cli/internal/cache/cache_fs.go
+++ b/cli/internal/cache/cache_fs.go
@@ -6,7 +6,6 @@ package cache
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"runtime"
 
 	"github.com/vercel/turborepo/cli/internal/analytics"
@@ -123,7 +122,7 @@ func (f *fsCache) Put(anchor turbopath.AbsoluteSystemPath, hash string, duration
 		return err
 	}
 
-	WriteCacheMetaFile(f.cacheDirectory.UntypedJoin(hash+"-meta.json").ToString(), &CacheMetadata{
+	WriteCacheMetaFile(f.cacheDirectory.UntypedJoin(hash+"-meta.json"), &CacheMetadata{
 		Duration: duration,
 		Hash:     hash,
 	})
@@ -149,12 +148,12 @@ type CacheMetadata struct {
 }
 
 // WriteCacheMetaFile writes cache metadata file at a path
-func WriteCacheMetaFile(path string, config *CacheMetadata) error {
+func WriteCacheMetaFile(path turbopath.AbsoluteSystemPath, config *CacheMetadata) error {
 	jsonBytes, marshalErr := json.Marshal(config)
 	if marshalErr != nil {
 		return marshalErr
 	}
-	writeFilErr := ioutil.WriteFile(path, jsonBytes, 0644)
+	writeFilErr := path.WriteFile(jsonBytes, 0644)
 	if writeFilErr != nil {
 		return writeFilErr
 	}

--- a/cli/internal/cache/cache_fs.go
+++ b/cli/internal/cache/cache_fs.go
@@ -36,7 +36,7 @@ func newFsCache(opts Opts, recorder analytics.Recorder, repoRoot turbopath.Absol
 }
 
 // Fetch returns true if items are cached. It moves them into position as a side effect.
-func (f *fsCache) Fetch(target, hash string, _unusedOutputGlobs []string) (bool, []string, int, error) {
+func (f *fsCache) Fetch(target, hash string, _unusedOutputGlobs []string) (bool, []turbopath.AnchoredSystemPath, int, error) {
 	cachedFolder := f.cacheDirectory.UntypedJoin(hash)
 
 	// If it's not in the cache bail now

--- a/cli/internal/cache/cache_fs.go
+++ b/cli/internal/cache/cache_fs.go
@@ -121,10 +121,14 @@ func (f *fsCache) Put(anchor turbopath.AbsoluteSystemPath, hash string, duration
 		return err
 	}
 
-	WriteCacheMetaFile(f.cacheDirectory.UntypedJoin(hash+"-meta.json"), &CacheMetadata{
+	writeErr := WriteCacheMetaFile(f.cacheDirectory.UntypedJoin(hash+"-meta.json"), &CacheMetadata{
 		Duration: duration,
 		Hash:     hash,
 	})
+
+	if writeErr != nil {
+		return writeErr
+	}
 
 	return nil
 }

--- a/cli/internal/cache/cache_fs.go
+++ b/cli/internal/cache/cache_fs.go
@@ -63,7 +63,7 @@ func (f *fsCache) Fetch(anchor turbopath.AbsoluteSystemPath, hash string, _unuse
 func (f *fsCache) Exists(hash string) (ItemStatus, error) {
 	cachedFolder := f.cacheDirectory.UntypedJoin(hash)
 
-	if cachedFolder.Exists() {
+	if cachedFolder.DirExists() {
 		return ItemStatus{Local: false}, nil
 	}
 

--- a/cli/internal/cache/cache_fs.go
+++ b/cli/internal/cache/cache_fs.go
@@ -30,7 +30,6 @@ func newFsCache(opts Opts, recorder analytics.Recorder, repoRoot turbopath.Absol
 	return &fsCache{
 		cacheDirectory: cacheDir,
 		recorder:       recorder,
-		repoRoot:       repoRoot,
 	}, nil
 }
 

--- a/cli/internal/cache/cache_fs.go
+++ b/cli/internal/cache/cache_fs.go
@@ -63,7 +63,7 @@ func (f *fsCache) Fetch(anchor turbopath.AbsoluteSystemPath, hash string, _unuse
 func (f *fsCache) Exists(hash string) (ItemStatus, error) {
 	cachedFolder := f.cacheDirectory.UntypedJoin(hash)
 
-	if cachedFolder.DirExists() {
+	if !cachedFolder.DirExists() {
 		return ItemStatus{Local: false}, nil
 	}
 

--- a/cli/internal/cache/cache_fs_test.go
+++ b/cli/internal/cache/cache_fs_test.go
@@ -59,14 +59,14 @@ func TestPut(t *testing.T) {
 	circlePath := childDir.Join("circle")
 	assert.NilError(t, circlePath.Symlink(filepath.FromSlash("../child")), "Symlink")
 
-	files := []string{
-		src.UntypedJoin(filepath.FromSlash("/")).ToStringDuringMigration(),            // src
-		src.UntypedJoin(filepath.FromSlash("child/")).ToStringDuringMigration(),       // childDir
-		src.UntypedJoin(filepath.FromSlash("child/a")).ToStringDuringMigration(),      // aPath,
-		src.UntypedJoin("b").ToStringDuringMigration(),                                // bPath,
-		src.UntypedJoin(filepath.FromSlash("child/link")).ToStringDuringMigration(),   // srcLinkPath,
-		src.UntypedJoin(filepath.FromSlash("child/broken")).ToStringDuringMigration(), // srcBrokenLinkPath,
-		src.UntypedJoin(filepath.FromSlash("child/circle")).ToStringDuringMigration(), // circlePath
+	files := []turbopath.AnchoredSystemPath{
+		turbopath.AnchoredUnixPath(".").ToSystemPath(),            // src
+		turbopath.AnchoredUnixPath("child/").ToSystemPath(),       // childDir
+		turbopath.AnchoredUnixPath("child/a").ToSystemPath(),      // aPath,
+		turbopath.AnchoredUnixPath("b").ToSystemPath(),            // bPath,
+		turbopath.AnchoredUnixPath("child/link").ToSystemPath(),   // srcLinkPath,
+		turbopath.AnchoredUnixPath("child/broken").ToSystemPath(), // srcBrokenLinkPath,
+		turbopath.AnchoredUnixPath("child/circle").ToSystemPath(), // circlePath
 	}
 
 	dst := turbopath.AbsoluteSystemPath(t.TempDir())

--- a/cli/internal/cache/cache_fs_test.go
+++ b/cli/internal/cache/cache_fs_test.go
@@ -147,8 +147,6 @@ func TestFetch(t *testing.T) {
 	//
 	// "some-package"/...
 
-	// cwd, err := fs.GetCwd()
-	// assert.NilError(t, err, "GetCwd")
 	cacheDir := turbopath.AbsoluteSystemPath(t.TempDir())
 	src := cacheDir.UntypedJoin("the-hash", "some-package")
 	err := src.MkdirAll()

--- a/cli/internal/cache/cache_fs_test.go
+++ b/cli/internal/cache/cache_fs_test.go
@@ -154,11 +154,11 @@ func TestFetch(t *testing.T) {
 	//
 	// "some-package"/...
 
-	cwd, err := fs.GetCwd()
-	assert.NilError(t, err, "GetCwd")
+	// cwd, err := fs.GetCwd()
+	// assert.NilError(t, err, "GetCwd")
 	cacheDir := turbopath.AbsoluteSystemPath(t.TempDir())
 	src := cacheDir.UntypedJoin("the-hash", "some-package")
-	err = src.MkdirAll()
+	err := src.MkdirAll()
 	assert.NilError(t, err, "mkdirAll")
 
 	childDir := src.UntypedJoin("child")
@@ -204,8 +204,9 @@ func TestFetch(t *testing.T) {
 		repoRoot:       defaultCwd,
 	}
 
+	outputDir := turbopath.AbsoluteSystemPath(t.TempDir())
 	dstOutputPath := "some-package"
-	hit, files, _, err := cache.Fetch(cwd.ToStringDuringMigration(), "the-hash", []string{})
+	hit, files, _, err := cache.Fetch(outputDir.ToStringDuringMigration(), "the-hash", []string{})
 	assert.NilError(t, err, "Fetch")
 	if !hit {
 		t.Error("Fetch got false, want true")
@@ -217,13 +218,13 @@ func TestFetch(t *testing.T) {
 	}
 	t.Logf("files %v", files)
 
-	dstAPath := filepath.Join(dstOutputPath, "child", "a")
+	dstAPath := filepath.Join(outputDir.ToStringDuringMigration(), dstOutputPath, "child", "a")
 	assertFileMatches(t, aPath.ToStringDuringMigration(), dstAPath)
 
-	dstBPath := filepath.Join(dstOutputPath, "b")
+	dstBPath := filepath.Join(outputDir.ToStringDuringMigration(), dstOutputPath, "b")
 	assertFileMatches(t, bPath.ToStringDuringMigration(), dstBPath)
 
-	dstLinkPath := filepath.Join(dstOutputPath, "child", "link")
+	dstLinkPath := filepath.Join(outputDir.ToStringDuringMigration(), dstOutputPath, "child", "link")
 	target, err := os.Readlink(dstLinkPath)
 	assert.NilError(t, err, "Readlink")
 	if target != linkTarget {
@@ -231,14 +232,14 @@ func TestFetch(t *testing.T) {
 	}
 
 	// We currently don't restore broken symlinks. This is probably a bug
-	dstBrokenLinkPath := filepath.Join(dstOutputPath, "child", "broken")
+	dstBrokenLinkPath := filepath.Join(outputDir.ToStringDuringMigration(), dstOutputPath, "child", "broken")
 	_, err = os.Readlink(dstBrokenLinkPath)
 	assert.ErrorIs(t, err, os.ErrNotExist)
 
 	// Currently, on restore, we convert symlink-to-directory to empty-directory
 	// This is very likely not ideal behavior, but leaving this test here to verify
 	// that it is what we expect at this point in time.
-	dstCirclePath := filepath.Join(dstOutputPath, "child", "circle")
+	dstCirclePath := filepath.Join(outputDir.ToStringDuringMigration(), dstOutputPath, "child", "circle")
 	circleStat, err := os.Lstat(dstCirclePath)
 	assert.NilError(t, err, "Lstat")
 	assert.Equal(t, circleStat.IsDir(), true)

--- a/cli/internal/cache/cache_fs_test.go
+++ b/cli/internal/cache/cache_fs_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/vercel/turborepo/cli/internal/analytics"
-	"github.com/vercel/turborepo/cli/internal/fs"
 	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"gotest.tools/v3/assert"
 )
@@ -72,15 +71,9 @@ func TestPut(t *testing.T) {
 	dst := turbopath.AbsoluteSystemPath(t.TempDir())
 	dr := &dummyRecorder{}
 
-	defaultCwd, err := fs.GetCwd()
-	if err != nil {
-		t.Fatalf("failed to get cwd: %v", err)
-	}
-
 	cache := &fsCache{
 		cacheDirectory: dst,
 		recorder:       dr,
-		repoRoot:       defaultCwd,
 	}
 
 	hash := "the-hash"
@@ -193,15 +186,9 @@ func TestFetch(t *testing.T) {
 
 	dr := &dummyRecorder{}
 
-	defaultCwd, err := fs.GetCwd()
-	if err != nil {
-		t.Fatalf("failed to get cwd: %v", err)
-	}
-
 	cache := &fsCache{
 		cacheDirectory: cacheDir,
 		recorder:       dr,
-		repoRoot:       defaultCwd,
 	}
 
 	outputDir := turbopath.AbsoluteSystemPath(t.TempDir())

--- a/cli/internal/cache/cache_fs_test.go
+++ b/cli/internal/cache/cache_fs_test.go
@@ -85,7 +85,7 @@ func TestPut(t *testing.T) {
 
 	hash := "the-hash"
 	duration := 0
-	err = cache.Put("unused", hash, duration, files)
+	err = cache.Put(src, hash, duration, files)
 	assert.NilError(t, err, "Put")
 
 	// Verify that we got the files that we're expecting
@@ -206,7 +206,7 @@ func TestFetch(t *testing.T) {
 
 	outputDir := turbopath.AbsoluteSystemPath(t.TempDir())
 	dstOutputPath := "some-package"
-	hit, files, _, err := cache.Fetch(outputDir.ToStringDuringMigration(), "the-hash", []string{})
+	hit, files, _, err := cache.Fetch(outputDir, "the-hash", []string{})
 	assert.NilError(t, err, "Fetch")
 	if !hit {
 		t.Error("Fetch got false, want true")

--- a/cli/internal/cache/cache_http.go
+++ b/cli/internal/cache/cache_http.go
@@ -358,7 +358,7 @@ func (cache *httpCache) CleanAll() {
 
 func (cache *httpCache) Shutdown() {}
 
-func newHTTPCache(opts Opts, client client, recorder analytics.Recorder, repoRoot turbopath.AbsoluteSystemPath) *httpCache {
+func newHTTPCache(opts Opts, client client, recorder analytics.Recorder) *httpCache {
 	return &httpCache{
 		writable:       true,
 		client:         client,
@@ -370,6 +370,5 @@ func newHTTPCache(opts Opts, client client, recorder analytics.Recorder, repoRoo
 			teamId:  client.GetTeamID(),
 			enabled: opts.RemoteCacheOpts.Signature,
 		},
-		repoRoot: repoRoot,
 	}
 }

--- a/cli/internal/cache/cache_http.go
+++ b/cli/internal/cache/cache_http.go
@@ -54,7 +54,7 @@ var mtime = time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
 // nobody is the usual uid / gid of the 'nobody' user.
 const nobody = 65534
 
-func (cache *httpCache) Put(target, hash string, duration int, files []turbopath.AnchoredSystemPath) error {
+func (cache *httpCache) Put(anchor turbopath.AbsoluteSystemPath, hash string, duration int, files []turbopath.AnchoredSystemPath) error {
 	// if cache.writable {
 	cache.requestLimiter.acquire()
 	defer cache.requestLimiter.release()
@@ -140,7 +140,7 @@ func (cache *httpCache) storeFile(tw *tar.Writer, repoRelativePath turbopath.Anc
 	return err
 }
 
-func (cache *httpCache) Fetch(target, key string, _unusedOutputGlobs []string) (bool, []turbopath.AnchoredSystemPath, int, error) {
+func (cache *httpCache) Fetch(anchor turbopath.AbsoluteSystemPath, key string, _unusedOutputGlobs []string) (bool, []turbopath.AnchoredSystemPath, int, error) {
 	cache.requestLimiter.acquire()
 	defer cache.requestLimiter.release()
 	hit, files, duration, err := cache.retrieve(key)
@@ -348,7 +348,7 @@ func restoreSymlink(root turbopath.AbsoluteSystemPath, hdr *tar.Header, allowNon
 	return nil
 }
 
-func (cache *httpCache) Clean(target string) {
+func (cache *httpCache) Clean(anchor turbopath.AbsoluteSystemPath) {
 	// Not possible; this implementation can only clean for a hash.
 }
 

--- a/cli/internal/cache/cache_http_test.go
+++ b/cli/internal/cache/cache_http_test.go
@@ -189,7 +189,10 @@ func TestRestoreTar(t *testing.T) {
 	assert.NilError(t, err, "readTar")
 
 	expectedSet := util.SetFromStrings(expectedFiles)
-	gotSet := util.SetFromStrings(files)
+	gotSet := util.SetFromStrings(nil)
+	for _, file := range files {
+		gotSet.Add(file.ToString())
+	}
 	extraFiles := gotSet.Difference(expectedSet)
 	if extraFiles.Len() > 0 {
 		t.Errorf("got extra files: %v", extraFiles.UnsafeListOfStrings())

--- a/cli/internal/cache/cache_http_test.go
+++ b/cli/internal/cache/cache_http_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"github.com/vercel/turborepo/cli/internal/util"
 	"gotest.tools/v3/assert"
 )
@@ -178,17 +179,20 @@ func TestRestoreTar(t *testing.T) {
 
 	tar := makeValidTar(t)
 
-	expectedFiles := []string{
-		"extra-file",
-		"my-pkg/",
-		"my-pkg/some-file",
-		"my-pkg/link-to-extra-file",
-		"my-pkg/broken-link",
+	expectedFiles := []turbopath.AnchoredSystemPath{
+		turbopath.AnchoredUnixPath("extra-file").ToSystemPath(),
+		turbopath.AnchoredUnixPath("my-pkg/").ToSystemPath(),
+		turbopath.AnchoredUnixPath("my-pkg/some-file").ToSystemPath(),
+		turbopath.AnchoredUnixPath("my-pkg/link-to-extra-file").ToSystemPath(),
+		turbopath.AnchoredUnixPath("my-pkg/broken-link").ToSystemPath(),
 	}
 	files, err := restoreTar(root, tar)
 	assert.NilError(t, err, "readTar")
 
-	expectedSet := util.SetFromStrings(expectedFiles)
+	expectedSet := make(util.Set)
+	for _, file := range expectedFiles {
+		expectedSet.Add(file.ToString())
+	}
 	gotSet := make(util.Set)
 	for _, file := range files {
 		gotSet.Add(file.ToString())

--- a/cli/internal/cache/cache_http_test.go
+++ b/cli/internal/cache/cache_http_test.go
@@ -189,7 +189,7 @@ func TestRestoreTar(t *testing.T) {
 	assert.NilError(t, err, "readTar")
 
 	expectedSet := util.SetFromStrings(expectedFiles)
-	gotSet := util.SetFromStrings(nil)
+	gotSet := make(util.Set)
 	for _, file := range files {
 		gotSet.Add(file.ToString())
 	}

--- a/cli/internal/cache/cache_noop.go
+++ b/cli/internal/cache/cache_noop.go
@@ -1,12 +1,14 @@
 package cache
 
+import "github.com/vercel/turborepo/cli/internal/turbopath"
+
 type noopCache struct{}
 
 func newNoopCache() *noopCache {
 	return &noopCache{}
 }
 
-func (c *noopCache) Put(target string, key string, duration int, files []string) error {
+func (c *noopCache) Put(target string, key string, duration int, files []turbopath.AnchoredSystemPath) error {
 	return nil
 }
 func (c *noopCache) Fetch(target string, key string, files []string) (bool, []string, int, error) {

--- a/cli/internal/cache/cache_noop.go
+++ b/cli/internal/cache/cache_noop.go
@@ -8,16 +8,16 @@ func newNoopCache() *noopCache {
 	return &noopCache{}
 }
 
-func (c *noopCache) Put(target string, key string, duration int, files []turbopath.AnchoredSystemPath) error {
+func (c *noopCache) Put(anchor turbopath.AbsoluteSystemPath, key string, duration int, files []turbopath.AnchoredSystemPath) error {
 	return nil
 }
-func (c *noopCache) Fetch(target string, key string, files []string) (bool, []turbopath.AnchoredSystemPath, int, error) {
+func (c *noopCache) Fetch(anchor turbopath.AbsoluteSystemPath, key string, files []string) (bool, []turbopath.AnchoredSystemPath, int, error) {
 	return false, nil, 0, nil
 }
 func (c *noopCache) Exists(key string) (ItemStatus, error) {
 	return ItemStatus{}, nil
 }
 
-func (c *noopCache) Clean(target string) {}
-func (c *noopCache) CleanAll()           {}
-func (c *noopCache) Shutdown()           {}
+func (c *noopCache) Clean(anchor turbopath.AbsoluteSystemPath) {}
+func (c *noopCache) CleanAll()                                 {}
+func (c *noopCache) Shutdown()                                 {}

--- a/cli/internal/cache/cache_noop.go
+++ b/cli/internal/cache/cache_noop.go
@@ -11,7 +11,7 @@ func newNoopCache() *noopCache {
 func (c *noopCache) Put(target string, key string, duration int, files []turbopath.AnchoredSystemPath) error {
 	return nil
 }
-func (c *noopCache) Fetch(target string, key string, files []string) (bool, []string, int, error) {
+func (c *noopCache) Fetch(target string, key string, files []string) (bool, []turbopath.AnchoredSystemPath, int, error) {
 	return false, nil, 0, nil
 }
 func (c *noopCache) Exists(key string) (ItemStatus, error) {

--- a/cli/internal/cache/cache_test.go
+++ b/cli/internal/cache/cache_test.go
@@ -8,12 +8,13 @@ import (
 
 	"github.com/vercel/turborepo/cli/internal/analytics"
 	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"github.com/vercel/turborepo/cli/internal/util"
 )
 
 type testCache struct {
 	disabledErr *util.CacheDisabledError
-	entries     map[string][]string
+	entries     map[string][]turbopath.AnchoredSystemPath
 }
 
 func (tc *testCache) Fetch(target string, hash string, files []string) (bool, []string, int, error) {
@@ -39,7 +40,7 @@ func (tc *testCache) Exists(hash string) (ItemStatus, error) {
 	return ItemStatus{}, nil
 }
 
-func (tc *testCache) Put(target string, hash string, duration int, files []string) error {
+func (tc *testCache) Put(target string, hash string, duration int, files []turbopath.AnchoredSystemPath) error {
 	if tc.disabledErr != nil {
 		return tc.disabledErr
 	}
@@ -53,7 +54,7 @@ func (tc *testCache) Shutdown()           {}
 
 func newEnabledCache() *testCache {
 	return &testCache{
-		entries: make(map[string][]string),
+		entries: make(map[string][]turbopath.AnchoredSystemPath),
 	}
 }
 
@@ -82,7 +83,7 @@ func TestPutCachingDisabled(t *testing.T) {
 		},
 	}
 
-	err := mplex.Put("unused-target", "some-hash", 5, []string{"a-file"})
+	err := mplex.Put("unused-target", "some-hash", 5, []turbopath.AnchoredSystemPath{"a-file"})
 	if err != nil {
 		// don't leak the cache removal
 		t.Errorf("Put got error %v, want <nil>", err)
@@ -136,7 +137,7 @@ func TestExists(t *testing.T) {
 		t.Error("did not expect file to exist")
 	}
 
-	err = mplex.Put("unused-target", "some-hash", 5, []string{"a-file"})
+	err = mplex.Put("unused-target", "some-hash", 5, []turbopath.AnchoredSystemPath{"a-file"})
 	if err != nil {
 		// don't leak the cache removal
 		t.Errorf("Put got error %v, want <nil>", err)

--- a/cli/internal/cache/cache_test.go
+++ b/cli/internal/cache/cache_test.go
@@ -17,7 +17,7 @@ type testCache struct {
 	entries     map[string][]turbopath.AnchoredSystemPath
 }
 
-func (tc *testCache) Fetch(target string, hash string, files []string) (bool, []string, int, error) {
+func (tc *testCache) Fetch(target string, hash string, files []string) (bool, []turbopath.AnchoredSystemPath, int, error) {
 	if tc.disabledErr != nil {
 		return false, nil, 0, tc.disabledErr
 	}

--- a/cli/internal/cache/cache_test.go
+++ b/cli/internal/cache/cache_test.go
@@ -17,7 +17,7 @@ type testCache struct {
 	entries     map[string][]turbopath.AnchoredSystemPath
 }
 
-func (tc *testCache) Fetch(target string, hash string, files []string) (bool, []turbopath.AnchoredSystemPath, int, error) {
+func (tc *testCache) Fetch(anchor turbopath.AbsoluteSystemPath, hash string, files []string) (bool, []turbopath.AnchoredSystemPath, int, error) {
 	if tc.disabledErr != nil {
 		return false, nil, 0, tc.disabledErr
 	}
@@ -40,7 +40,7 @@ func (tc *testCache) Exists(hash string) (ItemStatus, error) {
 	return ItemStatus{}, nil
 }
 
-func (tc *testCache) Put(target string, hash string, duration int, files []turbopath.AnchoredSystemPath) error {
+func (tc *testCache) Put(anchor turbopath.AbsoluteSystemPath, hash string, duration int, files []turbopath.AnchoredSystemPath) error {
 	if tc.disabledErr != nil {
 		return tc.disabledErr
 	}
@@ -48,9 +48,9 @@ func (tc *testCache) Put(target string, hash string, duration int, files []turbo
 	return nil
 }
 
-func (tc *testCache) Clean(target string) {}
-func (tc *testCache) CleanAll()           {}
-func (tc *testCache) Shutdown()           {}
+func (tc *testCache) Clean(anchor turbopath.AbsoluteSystemPath) {}
+func (tc *testCache) CleanAll()                                 {}
+func (tc *testCache) Shutdown()                                 {}
 
 func newEnabledCache() *testCache {
 	return &testCache{

--- a/cli/internal/fs/path.go
+++ b/cli/internal/fs/path.go
@@ -33,6 +33,11 @@ func UnsafeToAbsoluteSystemPath(s string) turbopath.AbsoluteSystemPath {
 	return turbopath.AbsoluteSystemPath(s)
 }
 
+// UnsafeToAnchoredSystemPath directly converts a string to an AbsoluteSystemPath
+func UnsafeToAnchoredSystemPath(s string) turbopath.AnchoredSystemPath {
+	return turbopath.AnchoredSystemPath(s)
+}
+
 // AbsoluteSystemPathFromUpstream is used to mark return values from APIs that we
 // expect to give us absolute paths. No checking is performed.
 // Prefer to use this over a cast to maintain the search-ability of interfaces

--- a/cli/internal/runcache/runcache.go
+++ b/cli/internal/runcache/runcache.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/vercel/turborepo/cli/internal/cache"
 	"github.com/vercel/turborepo/cli/internal/colorcache"
+	"github.com/vercel/turborepo/cli/internal/fs"
 	"github.com/vercel/turborepo/cli/internal/globby"
 	"github.com/vercel/turborepo/cli/internal/nodes"
 	"github.com/vercel/turborepo/cli/internal/turbopath"
@@ -274,7 +275,7 @@ func (tc TaskCache) SaveOutputs(ctx context.Context, logger hclog.Logger, termin
 		return err
 	}
 
-	relativePaths := make([]string, len(filesToBeCached))
+	relativePaths := make([]turbopath.AnchoredSystemPath, len(filesToBeCached))
 
 	for index, value := range filesToBeCached {
 		relativePath, err := tc.rc.repoRoot.RelativePathString(value)
@@ -283,7 +284,7 @@ func (tc TaskCache) SaveOutputs(ctx context.Context, logger hclog.Logger, termin
 			terminal.Error(fmt.Sprintf("%s%s", ui.ERROR_PREFIX, color.RedString(" %v", fmt.Errorf("File path cannot be made relative: %w", err))))
 			continue
 		}
-		relativePaths[index] = relativePath
+		relativePaths[index] = fs.UnsafeToAnchoredSystemPath(relativePath)
 	}
 
 	if err = tc.rc.cache.Put(tc.pt.Pkg.Dir.ToStringDuringMigration(), tc.hash, duration, relativePaths); err != nil {

--- a/cli/internal/runcache/runcache.go
+++ b/cli/internal/runcache/runcache.go
@@ -167,7 +167,7 @@ func (tc TaskCache) RestoreOutputs(ctx context.Context, terminal *cli.PrefixedUi
 	if hasChangedOutputs {
 		// Note that we currently don't use the output globs when restoring, but we could in the
 		// future to avoid doing unnecessary file I/O
-		hit, _, _, err := tc.rc.cache.Fetch(tc.rc.repoRoot.ToString(), tc.hash, changedOutputGlobs)
+		hit, _, _, err := tc.rc.cache.Fetch(tc.rc.repoRoot, tc.hash, changedOutputGlobs)
 		if err != nil {
 			return false, err
 		} else if !hit {
@@ -287,7 +287,7 @@ func (tc TaskCache) SaveOutputs(ctx context.Context, logger hclog.Logger, termin
 		relativePaths[index] = fs.UnsafeToAnchoredSystemPath(relativePath)
 	}
 
-	if err = tc.rc.cache.Put(tc.pt.Pkg.Dir.ToStringDuringMigration(), tc.hash, duration, relativePaths); err != nil {
+	if err = tc.rc.cache.Put(tc.rc.repoRoot, tc.hash, duration, relativePaths); err != nil {
 		return err
 	}
 	err = tc.rc.outputWatcher.NotifyOutputsWritten(ctx, tc.hash, tc.repoRelativeGlobs)

--- a/cli/internal/turbopath/absolute_system_path.go
+++ b/cli/internal/turbopath/absolute_system_path.go
@@ -66,21 +66,27 @@ func (p AbsoluteSystemPath) OpenFile(flags int, mode os.FileMode) (*os.File, err
 	return os.OpenFile(p.ToString(), flags, mode)
 }
 
-// FileExists returns true if the given path exists and is a file.
-func (p AbsoluteSystemPath) FileExists() bool {
-	info, err := os.Lstat(p.ToString())
-	return err == nil && !info.IsDir()
-}
-
 // Lstat implements os.Lstat for absolute path
 func (p AbsoluteSystemPath) Lstat() (os.FileInfo, error) {
 	return os.Lstat(p.ToString())
 }
 
-// DirExists returns true if this path points to a directory
+// Exists returns true if the given path exists.
+func (p AbsoluteSystemPath) Exists() bool {
+	_, err := p.Lstat()
+	return err == nil
+}
+
+// DirExists returns true if the given path exists and is a directory.
 func (p AbsoluteSystemPath) DirExists() bool {
 	info, err := p.Lstat()
 	return err == nil && info.IsDir()
+}
+
+// FileExists returns true if the given path exists and is a file.
+func (p AbsoluteSystemPath) FileExists() bool {
+	info, err := os.Lstat(p.ToString())
+	return err == nil && !info.IsDir()
 }
 
 // ContainsPath returns true if this absolute path is a parent of the


### PR DESCRIPTION
As prework for merging cache-to-tar, this ensures that we know what types of paths we're dealing with at (almost) every step in the cache process.

It also makes the first argument to `Put` (previously unused) and `Fetch` the anchor of the enumerated list of files being saved or restored.