### PR TITLE
fix(prune) respect dir permissions during prune

### DIFF
--- a/cli/internal/fs/copy_file.go
+++ b/cli/internal/fs/copy_file.go
@@ -24,6 +24,7 @@ func RecursiveCopy(from string, to string) error {
 	if fromType.IsDir() {
 		return WalkMode(statedFrom.Path.ToStringDuringMigration(), func(name string, isDir bool, fileType os.FileMode) error {
 			dest := filepath.Join(to, name[len(statedFrom.Path.ToString()):])
+			// name is absolute, (originates from godirwalk)
 			src := LstatCachedFile{Path: UnsafeToAbsoluteSystemPath(name), fileType: &fileType}
 			if isDir {
 				mode, err := src.GetMode()
@@ -32,7 +33,6 @@ func RecursiveCopy(from string, to string) error {
 				}
 				return os.MkdirAll(dest, mode)
 			}
-			// name is absolute, (originates from godirwalk)
 			return CopyFile(&src, dest)
 		})
 	}

--- a/cli/internal/fs/copy_file.go
+++ b/cli/internal/fs/copy_file.go
@@ -24,11 +24,16 @@ func RecursiveCopy(from string, to string) error {
 	if fromType.IsDir() {
 		return WalkMode(statedFrom.Path.ToStringDuringMigration(), func(name string, isDir bool, fileType os.FileMode) error {
 			dest := filepath.Join(to, name[len(statedFrom.Path.ToString()):])
+			src := LstatCachedFile{Path: UnsafeToAbsoluteSystemPath(name), fileType: &fileType}
 			if isDir {
-				return os.MkdirAll(dest, DirPermissions)
+				mode, err := src.GetMode()
+				if err != nil {
+					return err
+				}
+				return os.MkdirAll(dest, mode)
 			}
 			// name is absolute, (originates from godirwalk)
-			return CopyFile(&LstatCachedFile{Path: UnsafeToAbsoluteSystemPath(name), fileType: &fileType}, dest)
+			return CopyFile(&src, dest)
 		})
 	}
 	return CopyFile(&statedFrom, to)

--- a/cli/internal/fs/copy_file_test.go
+++ b/cli/internal/fs/copy_file_test.go
@@ -135,6 +135,8 @@ func TestRecursiveCopy(t *testing.T) {
 	err = RecursiveCopy(src.Path(), dst.Path())
 	assert.NilError(t, err, "RecursiveCopy")
 
+	dstChildDir := filepath.Join(dst.Path(), "child")
+	assertDirMatches(t, childDir, dstChildDir)
 	dstAPath := filepath.Join(dst.Path(), "child", "a")
 	assertFileMatches(t, aPath, dstAPath)
 	dstBPath := filepath.Join(dst.Path(), "b")
@@ -170,6 +172,15 @@ func assertFileMatches(t *testing.T, orig string, copy string) {
 	copyBytes, err := ioutil.ReadFile(copy)
 	assert.NilError(t, err, "ReadFile")
 	assert.DeepEqual(t, origBytes, copyBytes)
+	origStat, err := os.Lstat(orig)
+	assert.NilError(t, err, "Lstat")
+	copyStat, err := os.Lstat(copy)
+	assert.NilError(t, err, "Lstat")
+	assert.Equal(t, origStat.Mode(), copyStat.Mode())
+}
+
+func assertDirMatches(t *testing.T, orig string, copy string) {
+	t.Helper()
 	origStat, err := os.Lstat(orig)
 	assert.NilError(t, err, "Lstat")
 	copyStat, err := os.Lstat(copy)

--- a/cli/internal/prune/prune.go
+++ b/cli/internal/prune/prune.go
@@ -146,13 +146,13 @@ func (p *prune) prune(opts *opts) error {
 			continue
 		}
 		workspaces = append(workspaces, ctx.PackageInfos[internalDep].Dir)
-		originalDir := p.base.RepoRoot.UntypedJoin(ctx.PackageInfos[internalDep].Dir.ToStringDuringMigration())
+		originalDir := ctx.PackageInfos[internalDep].Dir.RestoreAnchor(p.base.RepoRoot)
 		info, err := originalDir.Lstat()
 		if err != nil {
 			return errors.Wrapf(err, "failed to lstat %s", originalDir)
 		}
-		targetDir := fullDir.UntypedJoin(ctx.PackageInfos[internalDep].Dir.ToStringDuringMigration())
-		if err = targetDir.MkdirAllMode(info.Mode()); err != nil {
+		targetDir := ctx.PackageInfos[internalDep].Dir.RestoreAnchor(fullDir)
+		if err := targetDir.MkdirAllMode(info.Mode()); err != nil {
 			return errors.Wrapf(err, "failed to create folder %s for %v", targetDir, internalDep)
 		}
 

--- a/cli/internal/turbopath/absolute_system_path.go
+++ b/cli/internal/turbopath/absolute_system_path.go
@@ -136,12 +136,12 @@ func (p AbsoluteSystemPath) MkdirAllMode(mode os.FileMode) error {
 			return os.Chmod(p.ToString(), mode)
 		} else {
 			// Path exists as file, remove it
-			if err = p.Remove(); err != nil {
+			if err := p.Remove(); err != nil {
 				return err
 			}
 		}
 	}
-	if err = os.MkdirAll(p.ToString(), mode); err != nil {
+	if err := os.MkdirAll(p.ToString(), mode); err != nil {
 		return err
 	}
 	// This is necessary only when umask results in creating a directory with permissions different than the one passed by the user

--- a/cli/internal/turbopath/absolute_system_path.go
+++ b/cli/internal/turbopath/absolute_system_path.go
@@ -124,6 +124,30 @@ func (p AbsoluteSystemPath) EnsureDir() error {
 	return err
 }
 
+// MkdirAllMode Create directory at path and all necessary parents ensuring that path has the correct mode set
+func (p AbsoluteSystemPath) MkdirAllMode(mode os.FileMode) error {
+	info, err := p.Lstat()
+	if err == nil {
+		if info.IsDir() && info.Mode() == mode {
+			// Dir exists with the correct mode
+			return nil
+		} else if info.IsDir() {
+			// Dir exists with incorrect mode
+			return os.Chmod(p.ToString(), mode)
+		} else {
+			// Path exists as file, remove it
+			if err = p.Remove(); err != nil {
+				return err
+			}
+		}
+	}
+	if err = os.MkdirAll(p.ToString(), mode); err != nil {
+		return err
+	}
+	// This is necessary only when umask results in creating a directory with permissions different than the one passed by the user
+	return os.Chmod(p.ToString(), mode)
+}
+
 // Create is the AbsoluteSystemPath wrapper for os.Create
 func (p AbsoluteSystemPath) Create() (*os.File, error) {
 	return os.Create(p.ToString())

--- a/cli/internal/turbopath/absolute_system_path_test.go
+++ b/cli/internal/turbopath/absolute_system_path_test.go
@@ -58,6 +58,8 @@ func Test_Mkdir(t *testing.T) {
 			assert.NilError(t, err, "%s: Create", testName)
 			err = file.Chmod(testCase.mode)
 			assert.NilError(t, err, "%s: Chmod", testName)
+			err = file.Close()
+			assert.NilError(t, err, "%s: Close", testName)
 		}
 
 		testPath := AbsoluteSystemPath(path)

--- a/cli/internal/turbopath/absolute_system_path_test.go
+++ b/cli/internal/turbopath/absolute_system_path_test.go
@@ -75,7 +75,7 @@ func Test_Mkdir(t *testing.T) {
 
 		if runtime.GOOS == "windows" {
 			// For windows os.Chmod will only change the writable bit so that's all we check
-			assert.Equal(t, stat.Mode().Perm(), testCase.expectedMode.Perm()&0200, testName)
+			assert.Equal(t, stat.Mode().Perm()&0200, testCase.expectedMode.Perm()&0200, testName)
 		} else {
 			assert.Equal(t, stat.Mode(), testCase.expectedMode, testName)
 		}

--- a/cli/internal/turbopath/absolute_system_path_test.go
+++ b/cli/internal/turbopath/absolute_system_path_test.go
@@ -2,6 +2,7 @@ package turbopath
 
 import (
 	"os"
+	"runtime"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -69,6 +70,15 @@ func Test_Mkdir(t *testing.T) {
 		stat, err := testPath.Lstat()
 		assert.NilError(t, err, "%s: Lstat", testName)
 		assert.Assert(t, stat.IsDir(), testName)
-		assert.Equal(t, stat.Mode(), testCase.expectedMode, testName)
+
+		assert.Assert(t, stat.IsDir(), testName)
+
+		if runtime.GOOS == "windows" {
+			// For windows os.Chmod will only change the writable bit so that's all we check
+			assert.Equal(t, stat.Mode().Perm(), testCase.expectedMode.Perm()&0200, testName)
+		} else {
+			assert.Equal(t, stat.Mode(), testCase.expectedMode, testName)
+		}
+
 	}
 }


### PR DESCRIPTION
Fixes #1872

This PR ended up having larger scope than I originally intended. A few things that changed:
 - `RecursiveCopyFile` now attempts to copy directories with the correct permissions
 - Added `MkdirAllMode` which is similar to `MkdirAll` but it will ensure that the created directory has the permissions passed
 - Change prune to use `MkdirAllMode` instead of `EnsureDir`

## Interaction with umask
Currently we don't consider [`umask`](https://en.wikipedia.org/wiki/Umask) when creating files. When copying files that we get from users we should make sure that the permissions are kept, but when creating files for turbo itself, we should probably respect `umask`.

When copying user files and we want to make sure permissions remain the same, the standard solution is to `chmod` after creating a new dir/file. This would add an additional syscall to all of the file/directory copy methods which seems like a little much. Another option would be to [blow away `umask`](https://pkg.go.dev/syscall#Umask) at the beginning to ensure that we are creating files with the permissions we expect.
 
## Testing
Wrote some unit tests, also did a quick spot check that dir permissions are copied over
```
olszewski@chriss-mbp perm-issue % turbo_dev prune --scope=ui                                 
Generating pruned monorepo for ui in /private/tmp/perm-issue/out
 - Added ui
 - Added eslint-config-custom
 - Added tsconfig
olszewski@chriss-mbp perm-issue % ls -lh packages 
total 0
drwxr-xr-x  5 olszewski  wheel   160B Sep 22 10:43 eslint-config-custom
drwxr-xr-x  7 olszewski  wheel   224B Sep 22 10:43 tsconfig
drwxrwxrwx  7 olszewski  wheel   224B Sep 22 10:43 ui
olszewski@chriss-mbp perm-issue % ls -lh out/packages
total 0
drwxr-xr-x  5 olszewski  wheel   160B Sep 23 11:34 eslint-config-custom
drwxr-xr-x  7 olszewski  wheel   224B Sep 23 11:34 tsconfig
drwxrwxrwx  7 olszewski  wheel   224B Sep 23 11:34 ui
```