### PR TITLE
Fix: Docs Edit This Page Button not working

### DIFF
--- a/docs/theme.config.js
+++ b/docs/theme.config.js
@@ -8,7 +8,7 @@ const theme = {
     link: "https://github.com/vercel/turborepo",
   },
   docsRepositoryBase:
-    "https://github.com/vercel/turborepo/blob/main/docs/pages",
+    "https://github.com/vercel/turborepo/blob/main/docs",
   titleSuffix: " | Turborepo",
   unstable_flexsearch: true,
   unstable_staticImage: true,


### PR DESCRIPTION
This PR fixes the url of `Edit This Page on GitHub` button