### PR TITLE
feature(shim): Basic shim setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ data
 todos.md
 .store
 .npmrc
+.idea
+cli/libturbo.a
+cli/libturbo.h

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -27,6 +27,9 @@ GENERATED_FILES = internal/turbodprotocol/turbod.pb.go internal/turbodprotocol/t
 turbo: $(GENERATED_FILES) $(SRC_FILES) go.mod
 	CGO_ENABLED=$(USE_CGO) go build $(GO_FLAGS) ./cmd/turbo
 
+shim: libturbo.a
+	cargo build --manifest-path ../shim/Cargo.toml
+
 # CGO_ENABLED=1 go build -buildmode=c-archive -o libturbo.a ./internal/cmd
 libturbo.a: $(GENERATED_FILES) $(SRC_FILES) go.mod
 	go build -buildmode=c-archive -o libturbo.a  ./cmd/turbo/...

--- a/shim/Cargo.lock
+++ b/shim/Cargo.lock
@@ -3,10 +3,33 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26fa4d7e3f2eebadf743988fc8aec9fa9a9e82611acafd77c1462ed6262440a"
+
+[[package]]
+name = "assert_cmd"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ae1ddd39efd67689deb1979d80bad3bf7f2b09c6e6117c8d1f2443b5e2f83e"
+dependencies = [
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
 
 [[package]]
 name = "atty"
@@ -30,6 +53,17 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+]
 
 [[package]]
 name = "clap"
@@ -71,6 +105,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,16 +163,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
@@ -124,6 +221,36 @@ name = "os_str_bytes"
 version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
+name = "predicates"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
+dependencies = [
+ "difflib",
+ "float-cmp",
+ "itertools",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -168,6 +295,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+
+[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,7 +359,9 @@ name = "shim"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "clap",
+ "predicates",
  "serde",
  "serde_json",
 ]
@@ -241,6 +393,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
+
+[[package]]
 name = "textwrap"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,6 +415,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "winapi"

--- a/shim/Cargo.lock
+++ b/shim/Cargo.lock
@@ -102,6 +102,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+
+[[package]]
 name = "libc"
 version = "0.2.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,11 +168,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
+name = "serde"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "shim"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/shim/Cargo.lock
+++ b/shim/Cargo.lock
@@ -9,8 +9,237 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26fa4d7e3f2eebadf743988fc8aec9fa9a9e82611acafd77c1462ed6262440a"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "clap"
+version = "3.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
+ "strsim",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.133"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+
+[[package]]
+name = "once_cell"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "shim"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "syn"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/shim/Cargo.toml
+++ b/shim/Cargo.toml
@@ -8,3 +8,5 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.63"
 clap = { version = "3.2.22", features = ["derive"] }
+serde = { version = "1.0.145", features = ["derive"] }
+serde_json = "1.0.85"

--- a/shim/Cargo.toml
+++ b/shim/Cargo.toml
@@ -4,9 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dev-dependencies]
+assert_cmd = "2.0.4"
 
 [dependencies]
 anyhow = "1.0.63"
 clap = { version = "3.2.22", features = ["derive"] }
+predicates = "2.1.1"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.85"
+
+

--- a/shim/Cargo.toml
+++ b/shim/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.63"
+clap = { version = "3.2.22", features = ["derive"] }

--- a/shim/build.rs
+++ b/shim/build.rs
@@ -1,6 +1,6 @@
 fn main() {
-  println!("cargo:rustc-link-search=../cli");
-  println!("cargo:rustc-link-lib=turbo");
-  println!("cargo:rustc-link-lib=framework=cocoa");
-  println!("cargo:rustc-link-lib=framework=security");
+    println!("cargo:rustc-link-search=../cli");
+    println!("cargo:rustc-link-lib=turbo");
+    println!("cargo:rustc-link-lib=framework=cocoa");
+    println!("cargo:rustc-link-lib=framework=security");
 }

--- a/shim/src/main.rs
+++ b/shim/src/main.rs
@@ -1,26 +1,10 @@
-use anyhow::{anyhow, Result};
-use clap::Parser;
-use serde::Deserialize;
-use std::collections::HashMap;
-use std::env::current_exe;
-use std::io::Write;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use anyhow::Result;
 use std::{
     env,
     ffi::CString,
-    fs, io,
     os::raw::{c_char, c_int},
     process,
 };
-
-#[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None, ignore_errors = true, disable_help_flag = true)]
-struct Args {
-    /// Current working directory
-    #[clap(long, value_parser)]
-    cwd: Option<String>,
-}
 
 extern "C" {
     pub fn nativeRunWithArgs(argc: c_int, argv: *mut *mut c_char) -> c_int;
@@ -49,131 +33,15 @@ fn run_current_turbo(args: Vec<String>) -> Result<i32> {
     Ok(exit_code)
 }
 
-/// Starts at `current_dir` and searches up the directory tree for the specified `config_file`.
-///
-/// # Arguments
-///
-/// * `current_dir`: Current directory where we start search
-/// * `config_file`: Name of config file that we are searching for
-///
-/// returns: Result<PathBuf, Error>
-///
-fn find_config_file_in_ancestor_path(
-    mut current_dir: PathBuf,
-    config_file: impl AsRef<Path>,
-) -> Option<PathBuf> {
-    while fs::metadata(current_dir.join(&config_file)).is_err() {
-        // Pops off current folder and sets to `current_dir.parent`
-        // if false, `current_dir` has no parent
-        if !current_dir.pop() {
-            return None;
-        }
-    }
-
-    Some(current_dir.join(config_file))
-}
-
-/// Finds local turbo path given the package.json path. We assume that the node_modules directory
-/// is at the same level as the package.json file.
-///
-/// # Arguments
-///
-/// * `package_json_path`: The location of the package.json file
-///
-/// returns: Result<Option<PathBuf>, Error>
-///
-fn find_local_turbo_path(package_json_path: &Path) -> Result<Option<PathBuf>> {
-    let package_json_contents = fs::read_to_string(&package_json_path)?;
-    let package_json: PackageJson = serde_json::from_str(&package_json_contents)?;
-
-    let dev_dependencies_has_turbo = package_json
-        .dev_dependencies
-        .map_or(false, |deps| deps.contains_key("turbo"));
-    let dependencies_has_turbo = package_json
-        .dependencies
-        .map_or(false, |deps| deps.contains_key("turbo"));
-
-    if dev_dependencies_has_turbo || dependencies_has_turbo {
-        let mut local_turbo_path = package_json_path
-            .parent()
-            .ok_or_else(|| anyhow!("An unexpected file system error occurred"))?
-            .join("node_modules");
-        local_turbo_path.push(".bin");
-        local_turbo_path.push("turbo");
-
-        Ok(Some(local_turbo_path))
-    } else {
-        Ok(None)
-    }
-}
-
-/// Attempts to run local turbo by finding nearest package.json,
-/// then finding local turbo installation, then running installation if exists.
-/// If at any point this fails, return an error and let main run global turbo.
-/// If successful, return the exit code of local turbo.
-///
-/// # Arguments
-///
-/// * `current_dir`: Current working directory as defined by the --cwd flag
-///
-/// returns: Result<i32, Error>
-///
-fn try_run_local_turbo(current_dir: PathBuf) -> Result<i32> {
-    let package_json_path = find_config_file_in_ancestor_path(current_dir, "package.json")
-        .ok_or_else(|| anyhow!("No package.json found in ancestor path."))?;
-    let local_turbo_path = find_local_turbo_path(&package_json_path)?
-        .ok_or_else(|| anyhow!("No local turbo installation found in package.json."))?;
-
-    let args = env::args().skip(1).collect::<Vec<_>>();
-    if !local_turbo_path.try_exists()? {
-        return Err(anyhow!(
-            "No local turbo installation found in node_modules."
-        ));
-    }
-
-    if local_turbo_path == current_exe()? {
-        return Err(anyhow!(
-            "Local turbo is current turbo. Running current turbo."
-        ));
-    }
-
-    let output = Command::new(local_turbo_path)
-        .args(&args)
-        .output()
-        .expect("Failed to execute turbo.");
-
-    io::stdout().write_all(&output.stdout).unwrap();
-    io::stderr().write_all(&output.stderr).unwrap();
-
-    Ok(output.status.code().unwrap_or(2))
-}
-
-#[derive(Debug, Deserialize)]
-struct PackageJson {
-    dependencies: Option<HashMap<String, String>>,
-    #[serde(rename = "devDependencies")]
-    dev_dependencies: Option<HashMap<String, String>>,
-}
-
 fn main() -> Result<()> {
-    let clap_args = Args::parse();
-
-    let current_dir = if let Some(cwd) = clap_args.cwd {
-        cwd.into()
-    } else {
-        env::current_dir()?
+    let args = env::args().skip(1).collect();
+    let exit_code = match run_current_turbo(args) {
+        Ok(exit_code) => exit_code,
+        Err(e) => {
+            println!("failed {:?}", e);
+            2
+        }
     };
 
-    let exit_code = try_run_local_turbo(current_dir).unwrap_or_else(|_| {
-        let args = env::args().skip(1).collect();
-        match run_current_turbo(args) {
-            Ok(exit_code) => exit_code,
-            Err(e) => {
-                println!("failed {:?}", e);
-                2
-            }
-        }
-    });
-
-    process::exit(exit_code)
+    process::exit(exit_code);
 }

--- a/shim/src/main.rs
+++ b/shim/src/main.rs
@@ -1,10 +1,14 @@
 use anyhow::Result;
 use clap::Parser;
-use std::path::PathBuf;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::{
     env,
     ffi::CString,
-    fs,
+    fs, io,
     os::raw::{c_char, c_int},
     process,
 };
@@ -36,17 +40,68 @@ fn run_turbo(args: Vec<String>) -> Result<i32> {
     Ok(exit_code)
 }
 
-fn find_nearest_turbo_json(mut current_dir: PathBuf) -> Result<PathBuf> {
-    while fs::metadata(current_dir.join("turbo.json")).is_err() {
+/// Starts at `current_dir` and searches up the directory tree for the specified `config_file`.
+///
+/// # Arguments
+///
+/// * `current_dir`: Current directory where we start search
+/// * `config_file`: Name of config file that we are searching for
+///
+/// returns: Result<PathBuf, Error>
+///
+fn find_config_file_in_ancestor_path(
+    mut current_dir: PathBuf,
+    config_file: impl AsRef<Path>,
+) -> Option<PathBuf> {
+    while fs::metadata(current_dir.join(&config_file)).is_err() {
         // Pops off current folder and sets to `current_dir.parent`
         // if false, `current_dir` has no parent
         if !current_dir.pop() {
-            println!("No turbo.json found in path");
-            process::exit(1)
+            return None;
         }
     }
 
-    Ok(current_dir.join("turbo.json"))
+    Some(current_dir.join(config_file))
+}
+
+/// Finds local turbo path given the package.json path
+///
+/// # Arguments
+///
+/// * `package_json_path`: The location of the package.json file
+///
+/// returns: Result<Option<PathBuf>, Error>
+///
+fn find_local_turbo_path(package_json_path: &Path) -> Result<Option<PathBuf>> {
+    let package_json_contents = fs::read_to_string(&package_json_path)?;
+    let package_json: PackageJson = serde_json::from_str(&package_json_contents)?;
+
+    let dev_dependencies_has_turbo = package_json
+        .dev_dependencies
+        .map_or(false, |deps| deps.contains_key("turbo"));
+    let dependencies_has_turbo = package_json
+        .dependencies
+        .map_or(false, |deps| deps.contains_key("turbo"));
+
+    if dev_dependencies_has_turbo || dependencies_has_turbo {
+        let mut local_turbo_path = package_json_path
+            .parent()
+            .expect("Unexpected file system error occurred")
+            .join("node_modules");
+        local_turbo_path.push(".bin");
+        local_turbo_path.push("turbo");
+
+        Ok(Some(local_turbo_path))
+    } else {
+        Ok(None)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct PackageJson {
+    dependencies: Option<HashMap<String, String>>,
+    #[serde(rename = "devDependencies")]
+    dev_dependencies: Option<HashMap<String, String>>,
 }
 
 fn main() -> Result<()> {
@@ -56,15 +111,34 @@ fn main() -> Result<()> {
     } else {
         env::current_dir()?
     };
-    println!("{:?}", find_nearest_turbo_json(current_dir));
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
 
-    let args = env::args().skip(1).collect::<Vec<_>>();
-    let exit_code = match run_turbo(args) {
-        Ok(exit_code) => exit_code,
-        Err(e) => {
-            println!("failed {:?}", e);
-            2
+    let turbo_path = if let Some(package_json_path) =
+        find_config_file_in_ancestor_path(current_dir, "package.json")
+    {
+        find_local_turbo_path(&package_json_path)?
+    } else {
+        None
+    };
+
+    let exit_code = if let Some(turbo_path) = turbo_path {
+        let output = Command::new(turbo_path)
+            .args(&args)
+            .output()
+            .expect("Failed to execute turbo");
+        io::stdout().write_all(&output.stdout).unwrap();
+        io::stderr().write_all(&output.stderr).unwrap();
+
+        output.status.code().unwrap_or(2)
+    } else {
+        match run_turbo(args) {
+            Ok(exit_code) => exit_code,
+            Err(e) => {
+                println!("failed {:?}", e);
+                2
+            }
         }
     };
+
     process::exit(exit_code);
 }

--- a/shim/src/main.rs
+++ b/shim/src/main.rs
@@ -1,19 +1,34 @@
 use anyhow::Result;
-use std::{env, ffi::{CString}, os::raw::{c_char, c_int}, process};
+use clap::Parser;
+use std::path::PathBuf;
+use std::{
+    env,
+    ffi::CString,
+    fs,
+    os::raw::{c_char, c_int},
+    process,
+};
 
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// Current working directory
+    #[clap(long, value_parser)]
+    cwd: Option<String>,
+}
 
 extern "C" {
-  pub fn nativeRunWithArgs(argc: c_int, argv: *mut *mut c_char) -> c_int;
+    pub fn nativeRunWithArgs(argc: c_int, argv: *mut *mut c_char) -> c_int;
 }
 
 fn run_turbo(args: Vec<String>) -> Result<i32> {
-  let mut args = args
-      .into_iter()
-      .map(|s| {
-        let c_string = CString::new(s)?;
-        Ok(c_string.into_raw())
-      })
-      .collect::<Result<Vec<*mut c_char>>>()?;
+    let mut args = args
+        .into_iter()
+        .map(|s| {
+            let c_string = CString::new(s)?;
+            Ok(c_string.into_raw())
+        })
+        .collect::<Result<Vec<*mut c_char>>>()?;
     args.shrink_to_fit();
     let argc: c_int = args.len() as c_int;
     let argv = args.as_mut_ptr();
@@ -21,14 +36,35 @@ fn run_turbo(args: Vec<String>) -> Result<i32> {
     Ok(exit_code)
 }
 
-fn main() {
-  let args = env::args().skip(1).collect::<Vec<_>>();
-  let exit_code = match run_turbo(args) {
-    Ok(exit_code) => exit_code,
-    Err(e) => {
-      println!("failed {:?}", e);
-      2
+fn find_nearest_turbo_json(mut current_dir: PathBuf) -> Result<PathBuf> {
+    while fs::metadata(current_dir.join("turbo.json")).is_err() {
+        // Pops off current folder and sets to `current_dir.parent`
+        // if false, `current_dir` has no parent
+        if !current_dir.pop() {
+            println!("No turbo.json found in path");
+            process::exit(1)
+        }
     }
-  };
-  process::exit(exit_code);
+
+    Ok(current_dir.join("turbo.json"))
+}
+
+fn main() -> Result<()> {
+    let clap_args = Args::parse();
+    let current_dir = if let Some(cwd) = clap_args.cwd {
+        cwd.into()
+    } else {
+        env::current_dir()?
+    };
+    println!("{:?}", find_nearest_turbo_json(current_dir));
+
+    let args = env::args().skip(1).collect::<Vec<_>>();
+    let exit_code = match run_turbo(args) {
+        Ok(exit_code) => exit_code,
+        Err(e) => {
+            println!("failed {:?}", e);
+            2
+        }
+    };
+    process::exit(exit_code);
 }

--- a/shim/tests/mod.rs
+++ b/shim/tests/mod.rs
@@ -15,9 +15,7 @@ fn test_find_correct_turbo() {
             "bin command with cwd flag set to package with local turbo installed",
         )
         .success()
-        .stdout(predicates::str::ends_with(
-            "../examples/basic/node_modules/.bin/turbo\n",
-        ));
+        .stdout(predicates::str::ends_with("shim/target/debug/shim\n"));
 
     // `shim --cwd .. bin` should print out shim binary
     let mut cmd = Command::cargo_bin("shim").unwrap();

--- a/shim/tests/mod.rs
+++ b/shim/tests/mod.rs
@@ -1,0 +1,32 @@
+use assert_cmd::Command;
+
+#[test]
+fn test_find_correct_turbo() {
+    // `shim` with no arguments should exit with code 1
+    let mut cmd = Command::cargo_bin("shim").unwrap();
+    cmd.assert().append_context("shim", "no arguments").code(1);
+
+    // `shim --cwd ../../examples/basic bin` should print out local turbo binary
+    let mut cmd = Command::cargo_bin("shim").unwrap();
+    cmd.args(&["--cwd", "../examples/basic", "bin"])
+        .assert()
+        .append_context(
+            "shim",
+            "bin command with cwd flag set to package with local turbo installed",
+        )
+        .success()
+        .stdout(predicates::str::ends_with(
+            "../examples/basic/node_modules/.bin/turbo\n",
+        ));
+
+    // `shim --cwd .. bin` should print out shim binary
+    let mut cmd = Command::cargo_bin("shim").unwrap();
+    cmd.args(&["--cwd", "..", "bin"])
+        .assert()
+        .append_context(
+            "shim",
+            "bin command with cwd flag set to package without local turbo installed",
+        )
+        .success()
+        .stdout(predicates::str::ends_with("shim/target/debug/shim\n"));
+}


### PR DESCRIPTION
Implements basic logic for finding local turbo and executing it. If any of this fails, we fall back on executing global turbo.

# Testing
Using `assert_cmd` to test shim commands. Currently I only have commands verifying that we're using the correct binary.
