### PR TITLE
seo: Add rewrite to turbo sitemap crawler

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -11,6 +11,16 @@ module.exports = withNextra({
     legacyBrowsers: false,
     images: { allowFutureImage: true },
   },
+  rewrites() {
+    return {
+      beforeFiles: [
+        {
+          source: "/sitemap.xml",
+          destination: "https://crawled-sitemap.vercel.sh/turbo-sitemap.xml",
+        },
+      ],
+    };
+  },
   async redirects() {
     return [
       {


### PR DESCRIPTION
This adds a rewrite to Vercel's [internal sitemap service](https://github.com/vercel/crawled-sitemap) (not OSS) which now scans turborepo.org