### PR TITLE
Change some variable names

### DIFF
--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -967,42 +967,42 @@ type execContext struct {
 	isSinglePackage bool
 }
 
-func (e *execContext) logError(log hclog.Logger, prefix string, err error) {
-	e.logger.Error(prefix, "error", err)
+func (ec *execContext) logError(log hclog.Logger, prefix string, err error) {
+	ec.logger.Error(prefix, "error", err)
 
 	if prefix != "" {
 		prefix += ": "
 	}
 
-	e.ui.Error(fmt.Sprintf("%s%s%s", ui.ERROR_PREFIX, prefix, color.RedString(" %v", err)))
+	ec.ui.Error(fmt.Sprintf("%s%s%s", ui.ERROR_PREFIX, prefix, color.RedString(" %v", err)))
 }
 
-func (e *execContext) exec(ctx gocontext.Context, packageTask *nodes.PackageTask, deps dag.Set) error {
+func (ec *execContext) exec(ctx gocontext.Context, packageTask *nodes.PackageTask, deps dag.Set) error {
 	cmdTime := time.Now()
 
-	outputPrefix := packageTask.OutputPrefix(e.isSinglePackage)
-	targetLogger := e.logger.Named(outputPrefix)
+	outputPrefix := packageTask.OutputPrefix(ec.isSinglePackage)
+	targetLogger := ec.logger.Named(outputPrefix)
 	targetLogger.Debug("start")
 
 	// Setup tracer
-	tracer := e.runState.Run(packageTask.TaskID)
+	tracer := ec.runState.Run(packageTask.TaskID)
 
 	// Create a logger
-	colorPrefixer := e.colorCache.PrefixColor(packageTask.PackageName)
+	colorPrefixer := ec.colorCache.PrefixColor(packageTask.PackageName)
 	prettyTaskPrefix := colorPrefixer("%s: ", outputPrefix)
 	targetUI := &cli.PrefixedUi{
-		Ui:           e.ui,
+		Ui:           ec.ui,
 		OutputPrefix: prettyTaskPrefix,
 		InfoPrefix:   prettyTaskPrefix,
 		ErrorPrefix:  prettyTaskPrefix,
 		WarnPrefix:   prettyTaskPrefix,
 	}
 
-	passThroughArgs := e.rs.ArgsForTask(packageTask.Task)
-	hash, err := e.taskHashes.CalculateTaskHash(packageTask, deps, passThroughArgs)
-	e.logger.Debug("task hash", "value", hash)
+	passThroughArgs := ec.rs.ArgsForTask(packageTask.Task)
+	hash, err := ec.taskHashes.CalculateTaskHash(packageTask, deps, passThroughArgs)
+	ec.logger.Debug("task hash", "value", hash)
 	if err != nil {
-		e.ui.Error(fmt.Sprintf("Hashing error: %v", err))
+		ec.ui.Error(fmt.Sprintf("Hashing error: %v", err))
 		// @TODO probably should abort fatally???
 	}
 	// TODO(gsoltis): if/when we fix https://github.com/vercel/turborepo/issues/937
@@ -1016,7 +1016,7 @@ func (e *execContext) exec(ctx gocontext.Context, packageTask *nodes.PackageTask
 		return nil
 	}
 	// Cache ---------------------------------------------
-	taskCache := e.runCache.TaskCache(packageTask, hash)
+	taskCache := ec.runCache.TaskCache(packageTask, hash)
 	hit, err := taskCache.RestoreOutputs(ctx, targetUI, targetLogger)
 	if err != nil {
 		targetUI.Error(fmt.Sprintf("error fetching from cache: %s", err))
@@ -1028,15 +1028,15 @@ func (e *execContext) exec(ctx gocontext.Context, packageTask *nodes.PackageTask
 	argsactual := append([]string{"run"}, packageTask.Task)
 	if len(passThroughArgs) > 0 {
 		// This will be either '--' or a typed nil
-		argsactual = append(argsactual, e.packageManager.ArgSeparator...)
+		argsactual = append(argsactual, ec.packageManager.ArgSeparator...)
 		argsactual = append(argsactual, passThroughArgs...)
 	}
 
-	cmd := exec.Command(e.packageManager.Command, argsactual...)
+	cmd := exec.Command(ec.packageManager.Command, argsactual...)
 	// TODO: repoRoot probably should be AbsoluteSystemPath, but it's Join method
 	// takes a RelativeSystemPath. Resolve during migration from turbopath.AbsoluteSystemPath to
 	// AbsoluteSystemPath
-	cmd.Dir = e.repoRoot.UntypedJoin(packageTask.Pkg.Dir.ToStringDuringMigration()).ToString()
+	cmd.Dir = ec.repoRoot.UntypedJoin(packageTask.Pkg.Dir.ToStringDuringMigration()).ToString()
 	envs := fmt.Sprintf("TURBO_HASH=%v", hash)
 	cmd.Env = append(os.Environ(), envs)
 
@@ -1046,8 +1046,8 @@ func (e *execContext) exec(ctx gocontext.Context, packageTask *nodes.PackageTask
 	writer, err := taskCache.OutputWriter(outputPrefix)
 	if err != nil {
 		tracer(TargetBuildFailed, err)
-		e.logError(targetLogger, prettyTaskPrefix, err)
-		if !e.rs.Opts.runOpts.continueOnError {
+		ec.logError(targetLogger, prettyTaskPrefix, err)
+		if !ec.rs.Opts.runOpts.continueOnError {
 			os.Exit(1)
 		}
 	}
@@ -1083,7 +1083,7 @@ func (e *execContext) exec(ctx gocontext.Context, packageTask *nodes.PackageTask
 	}
 
 	// Run the command
-	if err := e.processes.Exec(cmd); err != nil {
+	if err := ec.processes.Exec(cmd); err != nil {
 		// close off our outputs. We errored, so we mostly don't care if we fail to close
 		_ = closeOutputs()
 		// if we already know we're in the process of exiting,
@@ -1093,9 +1093,9 @@ func (e *execContext) exec(ctx gocontext.Context, packageTask *nodes.PackageTask
 		}
 		tracer(TargetBuildFailed, err)
 		targetLogger.Error(fmt.Sprintf("Error: command finished with error: %v", err))
-		if !e.rs.Opts.runOpts.continueOnError {
+		if !ec.rs.Opts.runOpts.continueOnError {
 			targetUI.Error(fmt.Sprintf("ERROR: command finished with error: %s", err))
-			e.processes.Close()
+			ec.processes.Close()
 		} else {
 			targetUI.Warn("command finished with error, but continuing...")
 		}
@@ -1105,10 +1105,10 @@ func (e *execContext) exec(ctx gocontext.Context, packageTask *nodes.PackageTask
 	duration := time.Since(cmdTime)
 	// Close off our outputs and cache them
 	if err := closeOutputs(); err != nil {
-		e.logError(targetLogger, "", err)
+		ec.logError(targetLogger, "", err)
 	} else {
 		if err = taskCache.SaveOutputs(ctx, targetLogger, targetUI, int(duration.Milliseconds())); err != nil {
-			e.logError(targetLogger, "", fmt.Errorf("error caching output: %w", err))
+			ec.logError(targetLogger, "", fmt.Errorf("error caching output: %w", err))
 		}
 	}
 

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -990,7 +990,7 @@ func (e *execContext) exec(ctx gocontext.Context, packageTask *nodes.PackageTask
 	// Create a logger
 	colorPrefixer := e.colorCache.PrefixColor(packageTask.PackageName)
 	prettyTaskPrefix := colorPrefixer("%s: ", outputPrefix)
-	targetUi := &cli.PrefixedUi{
+	targetUI := &cli.PrefixedUi{
 		Ui:           e.ui,
 		OutputPrefix: prettyTaskPrefix,
 		InfoPrefix:   prettyTaskPrefix,
@@ -1017,9 +1017,9 @@ func (e *execContext) exec(ctx gocontext.Context, packageTask *nodes.PackageTask
 	}
 	// Cache ---------------------------------------------
 	taskCache := e.runCache.TaskCache(packageTask, hash)
-	hit, err := taskCache.RestoreOutputs(ctx, targetUi, targetLogger)
+	hit, err := taskCache.RestoreOutputs(ctx, targetUI, targetLogger)
 	if err != nil {
-		targetUi.Error(fmt.Sprintf("error fetching from cache: %s", err))
+		targetUI.Error(fmt.Sprintf("error fetching from cache: %s", err))
 	} else if hit {
 		tracer(TargetCached, nil)
 		return nil
@@ -1094,10 +1094,10 @@ func (e *execContext) exec(ctx gocontext.Context, packageTask *nodes.PackageTask
 		tracer(TargetBuildFailed, err)
 		targetLogger.Error(fmt.Sprintf("Error: command finished with error: %v", err))
 		if !e.rs.Opts.runOpts.continueOnError {
-			targetUi.Error(fmt.Sprintf("ERROR: command finished with error: %s", err))
+			targetUI.Error(fmt.Sprintf("ERROR: command finished with error: %s", err))
 			e.processes.Close()
 		} else {
-			targetUi.Warn("command finished with error, but continuing...")
+			targetUI.Warn("command finished with error, but continuing...")
 		}
 		return err
 	}
@@ -1107,7 +1107,7 @@ func (e *execContext) exec(ctx gocontext.Context, packageTask *nodes.PackageTask
 	if err := closeOutputs(); err != nil {
 		e.logError(targetLogger, "", err)
 	} else {
-		if err = taskCache.SaveOutputs(ctx, targetLogger, targetUi, int(duration.Milliseconds())); err != nil {
+		if err = taskCache.SaveOutputs(ctx, targetLogger, targetUI, int(duration.Milliseconds())); err != nil {
 			e.logError(targetLogger, "", fmt.Errorf("error caching output: %w", err))
 		}
 	}


### PR DESCRIPTION
Some small changes that will make the diff in #2126 a bit easier to read / work through.

- `targetUi` -> `targetUI` because lint fails when i change lines with that variable
- `e` -> `ec` because I wanted to find all instances of where execContext.log* things are happening