### PR TITLE
Use unix:path to address unix socket

### DIFF
--- a/cli/internal/daemon/connector/connector.go
+++ b/cli/internal/daemon/connector/connector.go
@@ -105,7 +105,11 @@ func (c *Connector) lockFile() lockfile.Lockfile {
 }
 
 func (c *Connector) addr() string {
-	return fmt.Sprintf("unix://%v", c.SockPath.ToString())
+	// grpc special-cases parsing of unix:<path> urls
+	// to avoid url.Parse. This lets us pass through our absolute
+	// paths unmodified, even on windows.
+	// See code here: https://github.com/grpc/grpc-go/blob/d83070ec0d9043f713b6a63e1963c593b447208c/internal/transport/http_util.go#L392
+	return fmt.Sprintf("unix:%v", c.SockPath.ToString())
 }
 
 // We defer to the daemon's pid file as the locking mechanism.

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -198,19 +197,17 @@ func (r *run) run(ctx gocontext.Context, targets []string) error {
 	if err != nil {
 		return err
 	}
-	if runtime.GOOS != "windows" {
-		if ui.IsCI && !r.opts.runOpts.noDaemon {
-			r.base.Logger.Info("skipping turbod since we appear to be in a non-interactive context")
-		} else if !r.opts.runOpts.noDaemon {
-			turbodClient, err := daemon.GetClient(ctx, r.base.RepoRoot, r.base.Logger, r.base.TurboVersion, daemon.ClientOpts{})
-			if err != nil {
-				r.base.LogWarning("", errors.Wrap(err, "failed to contact turbod. Continuing in standalone mode"))
-			} else {
-				defer func() { _ = turbodClient.Close() }()
-				r.base.Logger.Debug("running in daemon mode")
-				daemonClient := daemonclient.New(turbodClient)
-				r.opts.runcacheOpts.OutputWatcher = daemonClient
-			}
+	if ui.IsCI && !r.opts.runOpts.noDaemon {
+		r.base.Logger.Info("skipping turbod since we appear to be in a non-interactive context")
+	} else if !r.opts.runOpts.noDaemon {
+		turbodClient, err := daemon.GetClient(ctx, r.base.RepoRoot, r.base.Logger, r.base.TurboVersion, daemon.ClientOpts{})
+		if err != nil {
+			r.base.LogWarning("", errors.Wrap(err, "failed to contact turbod. Continuing in standalone mode"))
+		} else {
+			defer func() { _ = turbodClient.Close() }()
+			r.base.Logger.Debug("running in daemon mode")
+			daemonClient := daemonclient.New(turbodClient)
+			r.opts.runcacheOpts.OutputWatcher = daemonClient
 		}
 	}
 


### PR DESCRIPTION
 - Use a url format that survives grpc parsing to produce a valid unix domain socket on all platforms
 - Re-enable daemon on windows, now that we can properly address the socket