### PR TITLE
Fix Pipeline API design link

### DIFF
--- a/docs/pages/docs/core-concepts/running-tasks.mdx
+++ b/docs/pages/docs/core-concepts/running-tasks.mdx
@@ -271,7 +271,7 @@ some best-effort checking to produce an error in the recursion situations, but i
 opt in those tasks which don't themselves trigger a `turbo` run that would recurse.
 
 <Callout type="idea" icon={<HeartIcon  className="h-5 w-5 mt-1 text-gray-400" aria-hidden="true" />}>
-Turborepo's Pipeline API design and this page of documentation was inspired by [Microsoft's Lage project](https://microsoft.github.io/lage/docs/Guide/pipeline#defining-a-pipeline).
+Turborepo's Pipeline API design and this page of documentation was inspired by [Microsoft's Lage project](https://microsoft.github.io/lage/docs/Tutorial/pipeline#defining-a-pipeline).
 Shoutout to [Kenneth Chau](https://twitter.com/kenneth_chau) for the idea of fanning out tasks in such a concise and elegant way.
 </Callout>
 


### PR DESCRIPTION
Hey Turbo folks 👋 ,
Just a tiny fix where a docs link is 404-ing.

| Prev. Link                                 | New Link                                  |
|--------------------------------------------|-------------------------------------------|
| ![before](https://i.imgur.com/tUpBO1n.png) | ![after](https://i.imgur.com/RUTzDO6.png) |

Cheers!

