### PR TITLE
Turn off golang dependency auto updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,5 +16,7 @@
   ],
   "prCreation": "not-pending",
   "prConcurrentLimit": 5,
-  "stabilityDays": 2
+  "stabilityDays": 2,
+  // Explicitly specify npm, so golang deps aren't updated
+  "enabledManagers": ["npm"]
 }


### PR DESCRIPTION
We haven't merged any of these PRs before as far as I can tell

https://github.com/vercel/turborepo/pulls?q=is%3Apr+author%3Aapp%2Frenovate+golang+is%3Amerged, 

we generally close them all:

https://github.com/vercel/turborepo/pulls?q=is%3Apr+author%3Aapp%2Frenovate+golang+is%3Aclosed