### PR TITLE
feat: Avoid panic from lockfile issues

### DIFF
--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -21,9 +21,10 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// Warning Error type for errors that don't prevent the creation of a functional Context
+// Warnings Error type for errors that don't prevent the creation of a functional Context
 type Warnings struct {
 	warns *multierror.Error
+	mu    sync.Mutex
 }
 
 var _ error = (*Warnings)(nil)
@@ -37,6 +38,12 @@ func (w *Warnings) errorOrNil() error {
 		return w
 	}
 	return nil
+}
+
+func (w *Warnings) append(err error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.warns = multierror.Append(w.warns, err)
 }
 
 // Context of the CLI
@@ -153,12 +160,12 @@ func BuildPackageGraph(repoRoot turbopath.AbsoluteSystemPath, rootPackageJSON *f
 	c.PackageManager = packageManager
 
 	if lockfile, err := c.PackageManager.ReadLockfile(cacheDir, repoRoot); err != nil {
-		warnings.warns = multierror.Append(warnings.warns, err)
+		warnings.append(err)
 	} else {
 		c.Lockfile = lockfile
 	}
 
-	if err := c.resolveWorkspaceRootDeps(rootPackageJSON); err != nil {
+	if err := c.resolveWorkspaceRootDeps(rootPackageJSON, &warnings); err != nil {
 		// TODO(Gaspar) was this the intended return error?
 		return nil, fmt.Errorf("could not resolve workspaces: %w", err)
 	}
@@ -189,7 +196,7 @@ func BuildPackageGraph(repoRoot turbopath.AbsoluteSystemPath, rootPackageJSON *f
 	for _, pkg := range c.PackageInfos {
 		pkg := pkg
 		populateGraphWaitGroup.Go(func() error {
-			return c.populateTopologicGraphForPackageJSON(pkg, rootpath, pkg.Name)
+			return c.populateTopologicGraphForPackageJSON(pkg, rootpath, pkg.Name, &warnings)
 		})
 	}
 
@@ -199,7 +206,7 @@ func BuildPackageGraph(repoRoot turbopath.AbsoluteSystemPath, rootPackageJSON *f
 	// Resolve dependencies for the root package. We override the vertexName in the graph
 	// for the root package, since it can have an arbitrary name. We need it to have our
 	// RootPkgName so that we can identify it as the root later on.
-	err = c.populateTopologicGraphForPackageJSON(rootPackageJSON, rootpath, util.RootPkgName)
+	err = c.populateTopologicGraphForPackageJSON(rootPackageJSON, rootpath, util.RootPkgName, &warnings)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve dependencies for root package: %v", err)
 	}
@@ -208,9 +215,9 @@ func BuildPackageGraph(repoRoot turbopath.AbsoluteSystemPath, rootPackageJSON *f
 	return c, warnings.errorOrNil()
 }
 
-func (c *Context) resolveWorkspaceRootDeps(rootPackageJSON *fs.PackageJSON) error {
+func (c *Context) resolveWorkspaceRootDeps(rootPackageJSON *fs.PackageJSON, warnings *Warnings) error {
 	seen := mapset.NewSet()
-	var lockfileWg sync.WaitGroup
+	var lockfileEg errgroup.Group
 	pkg := rootPackageJSON
 	depSet := mapset.NewSet()
 	pkg.UnresolvedExternalDeps = make(map[string]string)
@@ -225,8 +232,12 @@ func (c *Context) resolveWorkspaceRootDeps(rootPackageJSON *fs.PackageJSON) erro
 	}
 	if c.Lockfile != nil {
 		pkg.TransitiveDeps = []string{}
-		c.resolveDepGraph(&lockfileWg, pkg, pkg.UnresolvedExternalDeps, depSet, seen, pkg)
-		lockfileWg.Wait()
+		c.resolveDepGraph(&lockfileEg, pkg, pkg.UnresolvedExternalDeps, depSet, seen, pkg)
+		if err := lockfileEg.Wait(); err != nil {
+			warnings.append(err)
+			// Return early to skip using results of incomplete dep graph resolution
+			return nil
+		}
 		pkg.ExternalDeps = make([]string, 0, depSet.Cardinality())
 		for _, v := range depSet.ToSlice() {
 			pkg.ExternalDeps = append(pkg.ExternalDeps, fmt.Sprintf("%v", v))
@@ -249,7 +260,7 @@ func (c *Context) resolveWorkspaceRootDeps(rootPackageJSON *fs.PackageJSON) erro
 // that are within the monorepo, as well as collecting and hashing the dependencies of the package
 // that are not within the monorepo. The vertexName is used to override the package name in the graph.
 // This can happen when adding the root package, which can have an arbitrary name.
-func (c *Context) populateTopologicGraphForPackageJSON(pkg *fs.PackageJSON, rootpath string, vertexName string) error {
+func (c *Context) populateTopologicGraphForPackageJSON(pkg *fs.PackageJSON, rootpath string, vertexName string, warnings *Warnings) error {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	depMap := make(map[string]string)
@@ -297,9 +308,13 @@ func (c *Context) populateTopologicGraphForPackageJSON(pkg *fs.PackageJSON, root
 
 	pkg.TransitiveDeps = []string{}
 	seen := mapset.NewSet()
-	var lockfileWg sync.WaitGroup
-	c.resolveDepGraph(&lockfileWg, pkg, pkg.UnresolvedExternalDeps, externalDepSet, seen, pkg)
-	lockfileWg.Wait()
+	lockfileEg := &errgroup.Group{}
+	c.resolveDepGraph(lockfileEg, pkg, pkg.UnresolvedExternalDeps, externalDepSet, seen, pkg)
+	if err := lockfileEg.Wait(); err != nil {
+		warnings.append(err)
+		// reset external deps to original state
+		externalDepSet = mapset.NewSet()
+	}
 
 	// when there are no internal dependencies, we need to still add these leafs to the graph
 	if internalDepsSet.Len() == 0 {
@@ -346,38 +361,43 @@ func (c *Context) parsePackageJSON(repoRoot turbopath.AbsoluteSystemPath, pkgJSO
 	return nil
 }
 
-func (c *Context) resolveDepGraph(wg *sync.WaitGroup, workspace *fs.PackageJSON, unresolvedDirectDeps map[string]string, resolvedDepsSet mapset.Set, seen mapset.Set, pkg *fs.PackageJSON) {
-	if c.Lockfile == nil {
+func (c *Context) resolveDepGraph(wg *errgroup.Group, workspace *fs.PackageJSON, unresolvedDirectDeps map[string]string, resolvedDepsSet mapset.Set, seen mapset.Set, pkg *fs.PackageJSON) {
+	if c.Lockfile == (lockfile.Lockfile)(nil) {
 		return
 	}
 	for directDepName, unresolvedVersion := range unresolvedDirectDeps {
-		wg.Add(1)
-		go func(directDepName, unresolvedVersion string) {
-			defer wg.Done()
+		directDepName := directDepName
+		unresolvedVersion := unresolvedVersion
+		wg.Go(func() error {
 
-			key, resolvedVersion, ok := c.Lockfile.ResolvePackage(workspace.Dir.ToUnixPath(), directDepName, unresolvedVersion)
-			if seen.Contains(key) {
-				return
-			}
-			seen.Add(key)
+			lockfilePkg, err := c.Lockfile.ResolvePackage(workspace.Dir.ToUnixPath(), directDepName, unresolvedVersion)
 
-			if !ok {
-				return
+			if err != nil {
+				return err
 			}
+
+			if !lockfilePkg.Found || seen.Contains(lockfilePkg.Key) {
+				return nil
+			}
+
+			seen.Add(lockfilePkg.Key)
 
 			pkg.Mu.Lock()
-			pkg.TransitiveDeps = append(pkg.TransitiveDeps, key)
+			pkg.TransitiveDeps = append(pkg.TransitiveDeps, lockfilePkg.Key)
 			pkg.Mu.Unlock()
-			resolvedDepsSet.Add(fmt.Sprintf("%v@%v", directDepName, resolvedVersion))
+			resolvedDepsSet.Add(fmt.Sprintf("%v@%v", directDepName, lockfilePkg.Version))
 
-			allDeps, ok := c.Lockfile.AllDependencies(key)
+			allDeps, ok := c.Lockfile.AllDependencies(lockfilePkg.Key)
+
 			if !ok {
-				panic(fmt.Sprintf("Unable to find entry for %s", key))
+				panic(fmt.Sprintf("Unable to find entry for %s", lockfilePkg.Key))
 			}
 
 			if len(allDeps) > 0 {
 				c.resolveDepGraph(wg, workspace, allDeps, resolvedDepsSet, seen, pkg)
 			}
-		}(directDepName, unresolvedVersion)
+
+			return nil
+		})
 	}
 }

--- a/cli/internal/lockfile/berry_lockfile.go
+++ b/cli/internal/lockfile/berry_lockfile.go
@@ -89,15 +89,19 @@ type BerryDependencyMetaEntry struct {
 var _ Lockfile = (*BerryLockfile)(nil)
 
 // ResolvePackage Given a package and version returns the key, resolved version, and if it was found
-func (l *BerryLockfile) ResolvePackage(_workspace turbopath.AnchoredUnixPath, name string, version string) (string, string, bool) {
+func (l *BerryLockfile) ResolvePackage(_workspace turbopath.AnchoredUnixPath, name string, version string) (Package, error) {
 	for _, key := range berryPossibleKeys(name, version) {
 		if locator, ok := l.descriptors[key]; ok {
 			entry := l.packages[locator]
-			return locator.String(), entry.Version, true
+			return Package{
+				Found:   true,
+				Key:     locator.String(),
+				Version: entry.Version,
+			}, nil
 		}
 	}
 
-	return "", "", false
+	return Package{}, nil
 }
 
 // AllDependencies Given a lockfile key return all (dev/optional/peer) dependencies of that package

--- a/cli/internal/lockfile/berry_lockfile_test.go
+++ b/cli/internal/lockfile/berry_lockfile_test.go
@@ -67,26 +67,29 @@ func Test_ResolvePackage(t *testing.T) {
 	}
 
 	for testName, testCase := range cases {
-		key, version, found := lockfile.ResolvePackage("some-pkg", testCase.name, testCase.semver)
+		pkg, err := lockfile.ResolvePackage("some-pkg", testCase.name, testCase.semver)
+		assert.NilError(t, err)
 		if testCase.found {
-			assert.Equal(t, key, testCase.key, testName)
-			assert.Equal(t, version, testCase.version, testName)
+			assert.Equal(t, pkg.Key, testCase.key, testName)
+			assert.Equal(t, pkg.Version, testCase.version, testName)
 		}
-		assert.Equal(t, found, testCase.found, testName)
+		assert.Equal(t, pkg.Found, testCase.found, testName)
 	}
 }
 
 func Test_AllDependencies(t *testing.T) {
 	lockfile := getBerryLockfile(t, "berry.lock")
 
-	key, _, found := lockfile.ResolvePackage("some-pkg", "react-dom", "18.2.0")
-	assert.Assert(t, found, "expected to find react-dom")
-	deps, found := lockfile.AllDependencies(key)
+	pkg, err := lockfile.ResolvePackage("some-pkg", "react-dom", "18.2.0")
+	assert.NilError(t, err)
+	assert.Assert(t, pkg.Found, "expected to find react-dom")
+	deps, found := lockfile.AllDependencies(pkg.Key)
 	assert.Assert(t, found, "expected lockfile key for react-dom to be present")
 	assert.Equal(t, len(deps), 3, "expected to find all react-dom direct dependencies")
 	for pkgName, version := range deps {
-		_, _, found := lockfile.ResolvePackage("some-pkg", pkgName, version)
-		assert.Assert(t, found, "expected to find lockfile entry for %s@%s", pkgName, version)
+		pkg, err := lockfile.ResolvePackage("some-pkg", pkgName, version)
+		assert.NilError(t, err, "error finding %s@%s", pkgName, version)
+		assert.Assert(t, pkg.Found, "expected to find lockfile entry for %s@%s", pkgName, version)
 	}
 }
 

--- a/cli/internal/lockfile/lockfile.go
+++ b/cli/internal/lockfile/lockfile.go
@@ -10,7 +10,7 @@ import (
 // Lockfile Interface for general operations that work accross all lockfiles
 type Lockfile interface {
 	// ResolvePackage Given a workspace, a package it imports and version returns the key, resolved version, and if it was found
-	ResolvePackage(workspacePath turbopath.AnchoredUnixPath, name string, version string) (string, string, bool)
+	ResolvePackage(workspacePath turbopath.AnchoredUnixPath, name string, version string) (Package, error)
 	// AllDependencies Given a lockfile key return all (dev/optional/peer) dependencies of that package
 	AllDependencies(key string) (map[string]string, bool)
 	// Subgraph Given a list of lockfile keys returns a Lockfile based off the original one that only contains the packages given
@@ -19,4 +19,14 @@ type Lockfile interface {
 	Encode(w io.Writer) error
 	// Patches return a list of patches used in the lockfile
 	Patches() []turbopath.AnchoredUnixPath
+}
+
+// Package Structure representing a possible Pack
+type Package struct {
+	// Key used to lookup a package in the lockfile
+	Key string
+	// The resolved version of a package as it appears in the lockfile
+	Version string
+	// Set to true iff Key and Version are set
+	Found bool
 }

--- a/cli/internal/lockfile/pnpm_lockfile.go
+++ b/cli/internal/lockfile/pnpm_lockfile.go
@@ -127,10 +127,10 @@ func DecodePnpmLockfile(contents []byte) (*PnpmLockfile, error) {
 }
 
 // ResolvePackage Given a package and version returns the key, resolved version, and if it was found
-func (p *PnpmLockfile) ResolvePackage(workspacePath turbopath.AnchoredUnixPath, name string, version string) (string, string, bool) {
-	resolvedVersion, ok := p.resolveSpecifier(workspacePath, name, version)
-	if !ok {
-		return "", "", false
+func (p *PnpmLockfile) ResolvePackage(workspacePath turbopath.AnchoredUnixPath, name string, version string) (Package, error) {
+	resolvedVersion, ok, err := p.resolveSpecifier(workspacePath, name, version)
+	if !ok || err != nil {
+		return Package{}, err
 	}
 	key := formatPnpmKey(name, resolvedVersion)
 	if entry, ok := (p.Packages)[key]; ok {
@@ -140,10 +140,10 @@ func (p *PnpmLockfile) ResolvePackage(workspacePath turbopath.AnchoredUnixPath, 
 		} else {
 			version = resolvedVersion
 		}
-		return key, version, true
+		return Package{Key: key, Version: version, Found: true}, nil
 	}
 
-	return "", "", false
+	return Package{}, nil
 }
 
 // AllDependencies Given a lockfile key return all (dev/optional/peer) dependencies of that package
@@ -267,11 +267,11 @@ func (p *PnpmLockfile) Patches() []turbopath.AnchoredUnixPath {
 	return patches
 }
 
-func (p *PnpmLockfile) resolveSpecifier(workspacePath turbopath.AnchoredUnixPath, name string, specifier string) (string, bool) {
+func (p *PnpmLockfile) resolveSpecifier(workspacePath turbopath.AnchoredUnixPath, name string, specifier string) (string, bool, error) {
 	// Check if the specifier is already a resolved version
 	_, ok := p.Packages[formatPnpmKey(name, specifier)]
 	if ok {
-		return specifier, true
+		return specifier, true, nil
 	}
 	pnpmWorkspacePath := workspacePath.ToString()
 	if pnpmWorkspacePath == "" {
@@ -280,25 +280,25 @@ func (p *PnpmLockfile) resolveSpecifier(workspacePath turbopath.AnchoredUnixPath
 	}
 	importer, ok := p.Importers[pnpmWorkspacePath]
 	if !ok {
-		panic(fmt.Sprintf("resolving dependency for unknown workspace at %v", workspacePath))
+		return "", false, fmt.Errorf("no workspace '%v' found in lockfile", workspacePath)
 	}
 	foundSpecifier, ok := importer.Specifiers[name]
 	if !ok {
-		return "", false
+		return "", false, nil
 	}
 	if foundSpecifier != specifier {
-		return "", false
+		return "", false, nil
 	}
 	if resolvedVersion, ok := importer.Dependencies[name]; ok {
-		return resolvedVersion, true
+		return resolvedVersion, true, nil
 	}
 	if resolvedVersion, ok := importer.DevDependencies[name]; ok {
-		return resolvedVersion, true
+		return resolvedVersion, true, nil
 	}
 	if resolvedVersion, ok := importer.OptionalDependencies[name]; ok {
-		return resolvedVersion, true
+		return resolvedVersion, true, nil
 	}
-	panic(fmt.Sprintf("Unable to find resolved version for %s@%s in %s", name, specifier, workspacePath))
+	return "", false, fmt.Errorf("Unable to find resolved version for %s@%s in %s", name, specifier, workspacePath)
 }
 
 func formatPnpmKey(name string, version string) string {

--- a/cli/internal/lockfile/pnpm_lockfile_test.go
+++ b/cli/internal/lockfile/pnpm_lockfile_test.go
@@ -68,6 +68,7 @@ func Test_SpecifierResolution(t *testing.T) {
 		specifier     string
 		version       string
 		found         bool
+		err           string
 	}
 
 	cases := []Case{
@@ -77,11 +78,16 @@ func Test_SpecifierResolution(t *testing.T) {
 		{workspacePath: "apps/web", pkg: "lodash", specifier: "bad-tag", version: "", found: false},
 		{workspacePath: "apps/web", pkg: "lodash", specifier: "^4.17.21", version: "4.17.21_ehchni3mpmovsvjxesffg2i5a4", found: true},
 		{workspacePath: "", pkg: "turbo", specifier: "latest", version: "1.4.6", found: true},
+		{workspacePath: "apps/bad_workspace", pkg: "turbo", specifier: "latest", version: "1.4.6", err: "no workspace 'apps/bad_workspace' found in lockfile"},
 	}
 
 	for _, testCase := range cases {
-		actualVersion, actualFound := lockfile.resolveSpecifier(testCase.workspacePath, testCase.pkg, testCase.specifier)
-		assert.Equal(t, actualFound, testCase.found, "%s@%s", testCase.pkg, testCase.version)
-		assert.Equal(t, actualVersion, testCase.version, "%s@%s", testCase.pkg, testCase.version)
+		actualVersion, actualFound, err := lockfile.resolveSpecifier(testCase.workspacePath, testCase.pkg, testCase.specifier)
+		if testCase.err != "" {
+			assert.Error(t, err, testCase.err)
+		} else {
+			assert.Equal(t, actualFound, testCase.found, "%s@%s", testCase.pkg, testCase.version)
+			assert.Equal(t, actualVersion, testCase.version, "%s@%s", testCase.pkg, testCase.version)
+		}
 	}
 }

--- a/cli/internal/lockfile/yarn_lockfile.go
+++ b/cli/internal/lockfile/yarn_lockfile.go
@@ -22,14 +22,18 @@ type YarnLockfile struct {
 var _ Lockfile = (*YarnLockfile)(nil)
 
 // ResolvePackage Given a package and version returns the key, resolved version, and if it was found
-func (l *YarnLockfile) ResolvePackage(_workspacePath turbopath.AnchoredUnixPath, name string, version string) (string, string, bool) {
+func (l *YarnLockfile) ResolvePackage(_workspacePath turbopath.AnchoredUnixPath, name string, version string) (Package, error) {
 	for _, key := range yarnPossibleKeys(name, version) {
 		if entry, ok := (l.inner)[key]; ok {
-			return key, entry.Version, true
+			return Package{
+				Found:   true,
+				Key:     key,
+				Version: entry.Version,
+			}, nil
 		}
 	}
 
-	return "", "", false
+	return Package{}, nil
 }
 
 // AllDependencies Given a lockfile key return all (dev/optional/peer) dependencies of that package

--- a/cli/internal/prune/prune.go
+++ b/cli/internal/prune/prune.go
@@ -117,6 +117,9 @@ func (p *prune) prune(opts *opts) error {
 	if !canPrune {
 		return errors.Errorf("this command is not yet implemented for %s", ctx.PackageManager.Name)
 	}
+	if ctx.Lockfile == nil {
+		return errors.New("Cannot prune without parsed lockfile")
+	}
 
 	p.base.UI.Output(fmt.Sprintf("Generating pruned monorepo for %v in %v", ui.Bold(opts.scope), ui.Bold(outDir.ToString())))
 

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -195,7 +195,12 @@ func (r *run) run(ctx gocontext.Context, targets []string) error {
 		pkgDepGraph, err = context.BuildPackageGraph(r.base.RepoRoot, rootPackageJSON, r.opts.cacheOpts.ResolveCacheDir(r.base.RepoRoot))
 	}
 	if err != nil {
-		return err
+		var warnings *context.Warnings
+		if errors.As(err, &warnings) {
+			r.base.LogWarning("Issues occurred when constructing package graph. Turbo will function, but some features may not be available", err)
+		} else {
+			return err
+		}
 	}
 	if ui.IsCI && !r.opts.runOpts.noDaemon {
 		r.base.Logger.Info("skipping turbod since we appear to be in a non-interactive context")


### PR DESCRIPTION
This PR lets turbo fallback to the "dumb" behavior if there's an issue with parsing or querying the lockfile. Operations such as prune will still hard error if there's a lockfile failure due to prune's reliance on accurate lockfile information.

Notes:
 - Adds `context.Warnings` as an error type for indicating when the construction of `Context` produces a functional structure, but might be missing some features. It's expected that callers handle this error type and choose to proceed. The default Go error handling process will throw on any warnings.
 -  `lockfile.ResolvePackage` now returns a product type instead of a tuple along with an error so we can avoid panicking during the creation of `Context`

Testing:
Example of unparseable lockfile:
```
olszewski@chriss-mbp pnpm-patch % turbo_dev build --filter=docs
     WARNING  Issues occurred when constructing package graph. Turbo will function, but some features may not be available:  1 error occurred:
            * could not unmarshal lockfile: : yaml: line 2: did not find expected ',' or '}'
    
    • Packages in scope: docs
    • Running build in 1 packages
     INFO  • Remote caching disabled
    docs:build: cache miss, executing 9689a6319a885c5d
    docs:build:
    docs:build: > docs@0.0.0 build /private/tmp/pnpm-patch/apps/docs
    docs:build: > next build
    docs:build:
    docs:build: info  - Linting and checking validity of types...
    docs:build: info  - Creating an optimized production build...
    docs:build: info  - Compiled successfully
    docs:build: info  - Collecting page data...
    docs:build: info  - Generating static pages (0/3)
    docs:build: info  - Generating static pages (3/3)
    docs:build: info  - Finalizing page optimization...
    docs:build:
    docs:build: Route (pages)                              Size     First Load JS
    docs:build: ┌ ○ /                                      632 B          77.8 kB
    docs:build: └ ○ /404                                   195 B          77.3 kB
    docs:build: + First Load JS shared by all              77.1 kB
    docs:build:   ├ chunks/framework-3306dfb85e07225c.js   43 kB
    docs:build:   ├ chunks/main-eee301a3cd4ea15f.js        33.2 kB
    docs:build:   ├ chunks/pages/_app-5d76105b8238fa9a.js  200 B
    docs:build:   └ chunks/webpack-fd82975a6094609f.js     727 B
    docs:build:
    docs:build: ○  (Static)  automatically rendered as static HTML (uses no initial props)
    docs:build:
    
     Tasks:    1 successful, 1 total
    Cached:    0 cached, 1 total
      Time:    3.891s
    
    olszewski@chriss-mbp pnpm-patch % turbo_dev prune --scope=docs
     ERROR  could not construct graph: 1 error occurred:
            * could not unmarshal lockfile: : yaml: line 2: did not find expected ',' or '}'
```
In the example of a user moving a workspace package, but forgetting to run `pnpm i` (downstream failure omitted):
```
olszewski@chriss-mbp pnpm-patch % turbo_dev build --filter=docs 
 WARNING  Issues occurred when constructing package graph. Turbo will function, but some features may not be available:  1 error occurred:        * no workspace 'packages/new_ui' found in lockfile

• Packages in scope: docs
• Running build in 1 packages
...
```