### PR TITLE
Remove INFO prefix from log line

### DIFF
--- a/cli/integration_tests/single_package/run.t
+++ b/cli/integration_tests/single_package/run.t
@@ -5,7 +5,7 @@ Setup
 Check
   $ ${TURBO} run build --single-package
   \xe2\x80\xa2 Running build (esc)
-   INFO  \xe2\x80\xa2 Remote caching disabled (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
   build: cache miss, executing d415b27c3e54b6ed
   build: 
   build: > build
@@ -19,7 +19,7 @@ Check
 Run a second time, verify caching works because there is a config
   $ ${TURBO} run build --single-package
   \xe2\x80\xa2 Running build (esc)
-   INFO  \xe2\x80\xa2 Remote caching disabled (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
   build: cache hit, replaying output d415b27c3e54b6ed
   build: 
   build: > build

--- a/cli/integration_tests/single_package_deps/run.t
+++ b/cli/integration_tests/single_package_deps/run.t
@@ -5,7 +5,7 @@ Setup
 Check
   $ ${TURBO} run test --single-package
   \xe2\x80\xa2 Running test (esc)
-   INFO  \xe2\x80\xa2 Remote caching disabled (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
   build: cache miss, executing ad0ecb9fac7f41b0
   build: 
   build: > build
@@ -24,7 +24,7 @@ Check
 Run a second time, verify caching works because there is a config
   $ ${TURBO} run test --single-package
   \xe2\x80\xa2 Running test (esc)
-   INFO  \xe2\x80\xa2 Remote caching disabled (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
   build: cache hit, replaying output ad0ecb9fac7f41b0
   build: 
   build: > build

--- a/cli/integration_tests/single_package_no_config/run.t
+++ b/cli/integration_tests/single_package_no_config/run.t
@@ -5,7 +5,7 @@ Setup
 Check
   $ ${TURBO} run build --single-package
   \xe2\x80\xa2 Running build (esc)
-   INFO  \xe2\x80\xa2 Remote caching disabled (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
   build: cache bypass, force executing 17e3707692e8bac9
   build: 
   build: > build
@@ -20,7 +20,7 @@ Check
 Run a second time, verify no caching because there is no config
   $ ${TURBO} run build --single-package
   \xe2\x80\xa2 Running build (esc)
-   INFO  \xe2\x80\xa2 Remote caching disabled (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
   build: cache bypass, force executing 17e3707692e8bac9
   build: 
   build: > build

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -740,9 +740,9 @@ func (r *run) executeTasks(ctx gocontext.Context, g *completeGraph, rs *runSpec,
 
 	useHTTPCache := !rs.Opts.cacheOpts.SkipRemote
 	if useHTTPCache {
-		r.base.LogInfo("• Remote caching enabled")
+		r.base.UI.Info(ui.Dim("• Remote caching enabled"))
 	} else {
-		r.base.LogInfo("• Remote caching disabled")
+		r.base.UI.Info(ui.Dim("• Remote caching disabled"))
 	}
 
 	turboCache, err := r.initCache(ctx, rs, analyticsClient)


### PR DESCRIPTION
Revert log "Remote caching enabled" line to how it used to be, without the `INFO` prefix, but keep additional "Remote caching disabled". 