### PR TITLE
tar performance tuning

### DIFF
--- a/cli/internal/cacheitem/cacheitem.go
+++ b/cli/internal/cacheitem/cacheitem.go
@@ -3,7 +3,7 @@ package cacheitem
 
 import (
 	"archive/tar"
-	"compress/gzip"
+	"bufio"
 	"crypto/sha512"
 	"errors"
 	"hash"
@@ -30,9 +30,10 @@ type CacheItem struct {
 	Anchor turbopath.AbsoluteSystemPath
 
 	// For creation.
-	sha    hash.Hash
-	tw     *tar.Writer
-	gzw    *gzip.Writer
+	sha hash.Hash
+	tw  *tar.Writer
+	// gzw    *gzip.Writer
+	buffer *bufio.Writer
 	handle *os.File
 }
 
@@ -44,8 +45,14 @@ func (ci *CacheItem) Close() error {
 		}
 	}
 
-	if ci.gzw != nil {
-		if err := ci.gzw.Close(); err != nil {
+	// if ci.gzw != nil {
+	// 	if err := ci.gzw.Close(); err != nil {
+	// 		return err
+	// 	}
+	// }
+
+	if ci.buffer != nil {
+		if err := ci.buffer.Flush(); err != nil {
 			return err
 		}
 	}

--- a/cli/internal/cacheitem/restore.go
+++ b/cli/internal/cacheitem/restore.go
@@ -2,9 +2,9 @@ package cacheitem
 
 import (
 	"archive/tar"
-	"compress/gzip"
 	"errors"
 	"io"
+	"os"
 	"runtime"
 	"strings"
 
@@ -14,7 +14,7 @@ import (
 
 // Open returns an existing CacheItem at the specified path.
 func Open(path turbopath.AbsoluteSystemPath) (*CacheItem, error) {
-	handle, err := sequential.Open(path.ToString())
+	handle, err := sequential.OpenFile(path.ToString(), os.O_RDONLY, 0777)
 	if err != nil {
 		return nil, err
 	}
@@ -28,18 +28,18 @@ func Open(path turbopath.AbsoluteSystemPath) (*CacheItem, error) {
 // Restore extracts a cache to a specified disk location.
 func (ci *CacheItem) Restore(anchor turbopath.AbsoluteSystemPath) ([]turbopath.AnchoredSystemPath, error) {
 	// tar wrapped in gzip, we need to stream out of gzip first.
-	gzr, err := gzip.NewReader(ci.handle)
-	if err != nil {
-		return nil, err
-	}
+	// gzr, err := gzip.NewReader(ci.handle)
+	// if err != nil {
+	// 	return nil, err
+	// }
 
 	// The `Close` function for compression effectively just returns the singular
 	// error field on the decompressor instance. This is extremely unlikely to be
 	// set without triggering one of the numerous other errors, but we should still
 	// handle that possible edge case.
 	var closeError error
-	defer func() { closeError = gzr.Close() }()
-	tr := tar.NewReader(gzr)
+	// defer func() { closeError = gzr.Close() }()
+	tr := tar.NewReader(ci.handle)
 
 	// On first attempt to restore it's possible that a link target doesn't exist.
 	// Save them and topsort them.

--- a/cli/internal/cacheitem/restore_test.go
+++ b/cli/internal/cacheitem/restore_test.go
@@ -2,7 +2,6 @@ package cacheitem
 
 import (
 	"archive/tar"
-	"compress/gzip"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -39,8 +38,8 @@ func generateTar(t *testing.T, files []tarFile) turbopath.AbsoluteSystemPath {
 	handle, handleCreateErr := testArchivePath.Create()
 	assert.NilError(t, handleCreateErr, "os.Create")
 
-	gzw := gzip.NewWriter(handle)
-	tw := tar.NewWriter(gzw)
+	// gzw := gzip.NewWriter(handle)
+	tw := tar.NewWriter(handle)
 
 	for _, file := range files {
 		if file.Header.Typeflag == tar.TypeReg {
@@ -57,8 +56,8 @@ func generateTar(t *testing.T, files []tarFile) turbopath.AbsoluteSystemPath {
 	twCloseErr := tw.Close()
 	assert.NilError(t, twCloseErr, "tw.Close")
 
-	gzwCloseErr := gzw.Close()
-	assert.NilError(t, gzwCloseErr, "gzw.Close")
+	// gzwCloseErr := gzw.Close()
+	// assert.NilError(t, gzwCloseErr, "gzw.Close")
 
 	handleCloseErr := handle.Close()
 	assert.NilError(t, handleCloseErr, "handle.Close")


### PR DESCRIPTION
Current state:
- Opens all files in the optimal modes based upon their use.
- Buffers writes to the file system.
- Removes `gzip`, `MultiWriter`, and `sha` from the hot path.
- Makes tests pass.

Lots of comment-out code here but most-importantly, the entire implementation _works_. If we discover a need to release in the interim this PR is safe to land, gives us our desired performance _and_ correctness wins, and will keep things unblocked.

In the mean time, I'm going to continue to investigate fixing the performance issues in the writers.