### PR TITLE
fix(examples): correct turbo caching for storybook

### DIFF
--- a/examples/design-system/turbo.json
+++ b/examples/design-system/turbo.json
@@ -4,7 +4,7 @@
     "build": {
       "outputs": [
         "dist/**",
-        ".next/**"
+        "storybook-static/**"
       ],
       "dependsOn": [
         "^build"


### PR DESCRIPTION
We were not properly specifying the outputs for storybook in the design system docs. 

This resulted in incorrectly cached builds. 