### PR TITLE
support new paused status

### DIFF
--- a/cli/internal/client/client.go
+++ b/cli/internal/client/client.go
@@ -572,7 +572,7 @@ type statusResponse struct {
 	Status string `json:"status"`
 }
 
-// GetCachingStatus returns the server's perspective on whether or not remove caching
+// GetCachingStatus returns the server's perspective on whether or not remote caching
 // requests will be allowed.
 func (c *ApiClient) GetCachingStatus() (util.CachingStatus, error) {
 	values := make(url.Values)

--- a/cli/internal/login/link.go
+++ b/cli/internal/login/link.go
@@ -187,6 +187,8 @@ func (l *link) run() error {
 		return errNeedCachingEnabled
 	case util.CachingStatusOverLimit:
 		return errOverage
+	case util.CachingStatusPaused:
+		return errPaused
 	case util.CachingStatusEnabled:
 	default:
 	}

--- a/cli/internal/login/login.go
+++ b/cli/internal/login/login.go
@@ -264,6 +264,8 @@ func (l *login) verifyCachingEnabled(teamID string) error {
 		return errNeedCachingEnabled
 	case util.CachingStatusOverLimit:
 		return errOverage
+	case util.CachingStatusPaused:
+		return errPaused
 	case util.CachingStatusEnabled:
 	default:
 	}

--- a/cli/internal/login/status.go
+++ b/cli/internal/login/status.go
@@ -8,6 +8,7 @@ import (
 
 var (
 	errOverage            = errors.New("usage limit")
+	errPaused             = errors.New("spending paused")
 	errNeedCachingEnabled = errors.New("caching not enabled")
 	errTryAfterEnable     = errors.New("link after enabling caching")
 )

--- a/cli/internal/util/status.go
+++ b/cli/internal/util/status.go
@@ -12,8 +12,11 @@ const (
 	// CachingStatusEnabled indicates that the server will accept and serve artifacts
 	CachingStatusEnabled
 	// CachingStatusOverLimit indicates that a usage limit has been hit and the
-	// server will temporarily not accept or server artifacts
+	// server will temporarily not accept or serve artifacts
 	CachingStatusOverLimit
+	// CachingStatusPaused indicates that a customer's spending has been paused and the
+	// server will temporarily not accept or serve artifacts
+	CachingStatusPaused
 )
 
 // CachingStatusFromString parses a raw string to a caching status enum value
@@ -25,6 +28,8 @@ func CachingStatusFromString(raw string) (CachingStatus, error) {
 		return CachingStatusEnabled, nil
 	case "over_limit":
 		return CachingStatusOverLimit, nil
+	case "paused":
+		return CachingStatusPaused, nil
 	default:
 		return CachingStatusDisabled, fmt.Errorf("unknown caching status: %v", raw)
 	}


### PR DESCRIPTION
Part of PI-1319

Handles the new `paused` status from https://github.com/vercel/api/pull/14585 for when a customer has reached their defined spend cap and their spending has been paused.