### PR TITLE
Add back bin/ directory

### DIFF
--- a/cli/combined-release.yml
+++ b/cli/combined-release.yml
@@ -19,7 +19,7 @@ builds:
     hooks:
       pre:
         - cmd: ./scripts/npm-native-packages/npm-native-packages.js {{ .Os }} {{ .Arch }} {{ .Version }}
-    binary: turbo
+    binary: bin/turbo
 checksum:
   name_template: "checksums.txt"
 snapshot:


### PR DESCRIPTION
The rest of our scripts expect the `turbo` binary at `bin/turbo`