### PR TITLE
fix(examples): cache .vercel for adapter-vercel

### DIFF
--- a/examples/with-svelte/turbo.json
+++ b/examples/with-svelte/turbo.json
@@ -3,7 +3,7 @@
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": [".svelte-kit/**"]
+      "outputs": [".svelte-kit/**", ".vercel/**"]
     },
     "lint": {
       "outputs": []


### PR DESCRIPTION
Correct caching for sveltekit example. if using adapter-auto. it will detect `process.env.VERCEL` when deploying to Vercel and delegate to `adapter-vercel`. This takes the intermediate output in `.svelte-kit` and writes a build to `.vercel`.
