### PR TITLE
feat(cli): log auto included envs and framework

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -66,7 +66,16 @@
       "mode": "debug",
       "program": "${workspaceRoot}/cli/cmd/turbo",
       "cwd": "${workspaceRoot}/examples/basic",
-      "args": ["run", "build"]
+      "args": ["run", "build", "--dry-run", "-vvv"]
+    },
+    {
+      "name": "Build Basic (Dry Run / Debug)",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceRoot}/cli/cmd/turbo",
+      "cwd": "${workspaceRoot}/examples/basic",
+      "args": ["run", "build", "--dry-run", "-vv"]
     },
     {
       "name": "Build Kitchen Sink",
@@ -75,7 +84,7 @@
       "mode": "debug",
       "program": "${workspaceRoot}/cli/cmd/turbo",
       "cwd": "${workspaceRoot}/examples/kitchen-sink",
-      "args": ["run", "build"]
+      "args": ["run", "build", "-vv"]
     },
     {
       "name": "Build Kitchen Sink (Dry Run)",
@@ -84,7 +93,7 @@
       "mode": "debug",
       "program": "${workspaceRoot}/cli/cmd/turbo",
       "cwd": "${workspaceRoot}/examples/kitchen-sink",
-      "args": ["run", "build"]
+      "args": ["run", "build", "--dry-run"]
     },
     {
       "name": "Build All",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -66,7 +66,7 @@
       "mode": "debug",
       "program": "${workspaceRoot}/cli/cmd/turbo",
       "cwd": "${workspaceRoot}/examples/basic",
-      "args": ["run", "build", "--dry-run", "-vvv"]
+      "args": ["run", "build"]
     },
     {
       "name": "Build Basic (Dry Run / Debug)",

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -876,7 +876,7 @@ func (r *run) executeDryRun(ctx gocontext.Context, engine *core.Scheduler, g *co
 	errs := engine.Execute(g.getPackageTaskVisitor(ctx, func(ctx gocontext.Context, packageTask *nodes.PackageTask) error {
 		passThroughArgs := rs.ArgsForTask(packageTask.Task)
 		deps := engine.TaskGraph.DownEdges(packageTask.TaskID)
-		hash, err := taskHashes.CalculateTaskHash(packageTask, deps, passThroughArgs)
+		hash, err := taskHashes.CalculateTaskHash(packageTask, deps, r.base.Logger, passThroughArgs)
 		if err != nil {
 			return err
 		}
@@ -998,7 +998,7 @@ func (ec *execContext) exec(ctx gocontext.Context, packageTask *nodes.PackageTas
 	tracer := ec.runState.Run(packageTask.TaskID)
 
 	passThroughArgs := ec.rs.ArgsForTask(packageTask.Task)
-	hash, err := ec.taskHashes.CalculateTaskHash(packageTask, deps, passThroughArgs)
+	hash, err := ec.taskHashes.CalculateTaskHash(packageTask, deps, ec.logger, passThroughArgs)
 	ec.logger.Debug("task hash", "value", hash)
 	if err != nil {
 		ec.ui.Error(fmt.Sprintf("Hashing error: %v", err))


### PR DESCRIPTION
Log any auto included env variables and their respective framework. 

We treat auto detected global env vars similarly: https://github.com/vercel/turborepo/blob/main/cli/internal/run/global_hash.go#L67
So adding this as a debug log for consistency. 

In the future, we should include these (framework at the very least) in dry run as well. 