### PR TITLE
feat(cli): global defaults for filters

### DIFF
--- a/cli/internal/scope/filter/filter.go
+++ b/cli/internal/scope/filter/filter.go
@@ -22,11 +22,9 @@ type SelectedPackages struct {
 type PackagesChangedInRange = func(fromRef string, toRef string) (util.Set, error)
 
 type Resolver struct {
-	Graph        *dag.AcyclicGraph
-	PackageInfos map[interface{}]*fs.PackageJSON
-	// SCM                  scm.SCM
-	Cwd string
-	// HasGlobalChange      bool
+	Graph                  *dag.AcyclicGraph
+	PackageInfos           map[interface{}]*fs.PackageJSON
+	Cwd                    string
 	PackagesChangedInRange PackagesChangedInRange
 }
 

--- a/cli/internal/scope/scope.go
+++ b/cli/internal/scope/scope.go
@@ -178,6 +178,7 @@ func getDefaultGlobalDeps(packageManager *packagemanager.PackageManager) []strin
 		"package.json",
 	}
 	if packageManager != nil {
+		// TODO: we should be smarter here and determine if the lockfile changes actually impact the given scope
 		defaultGlobalDeps = append(defaultGlobalDeps, packageManager.Lockfile)
 	}
 

--- a/cli/internal/scope/scope.go
+++ b/cli/internal/scope/scope.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/vercel/turborepo/cli/internal/context"
 	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/packagemanager"
 	"github.com/vercel/turborepo/cli/internal/scm"
 	scope_filter "github.com/vercel/turborepo/cli/internal/scope/filter"
 	"github.com/vercel/turborepo/cli/internal/util"
@@ -61,7 +62,8 @@ turbo's documentation https://turborepo.org/docs/reference/command-line-referenc
 --filter can be specified multiple times. Packages that
 match any filter will be included.`
 	_ignoreHelp    = `Files to ignore when calculating changed files (i.e. --since). Supports globs.`
-	_globalDepHelp = `Specify glob of global filesystem dependencies to be hashed. Useful for .env and files in the root directory.`
+	_globalDepHelp = `Specify glob of global filesystem dependencies to be hashed. Useful for .env and files
+in the root directory. Includes turbo.json, root package.json, and the root lockfile by default.`
 )
 
 // AddFlags adds the flags relevant to this package to the given FlagSet
@@ -116,7 +118,7 @@ func ResolvePackages(opts *Opts, cwd string, scm scm.SCM, ctx *context.Context, 
 		Graph:                  &ctx.TopologicalGraph,
 		PackageInfos:           ctx.PackageInfos,
 		Cwd:                    cwd,
-		PackagesChangedInRange: opts.getPackageChangeFunc(scm, cwd, ctx.PackageInfos),
+		PackagesChangedInRange: opts.getPackageChangeFunc(scm, cwd, ctx.PackageInfos, ctx.PackageManager),
 	}
 	filterPatterns := opts.FilterPatterns
 	legacyFilterPatterns := opts.LegacyFilter.asFilterPatterns()
@@ -137,7 +139,7 @@ func ResolvePackages(opts *Opts, cwd string, scm scm.SCM, ctx *context.Context, 
 	return filteredPkgs, isAllPackages, nil
 }
 
-func (o *Opts) getPackageChangeFunc(scm scm.SCM, cwd string, packageInfos map[interface{}]*fs.PackageJSON) scope_filter.PackagesChangedInRange {
+func (o *Opts) getPackageChangeFunc(scm scm.SCM, cwd string, packageInfos map[interface{}]*fs.PackageJSON, packageManager *packagemanager.PackageManager) scope_filter.PackagesChangedInRange {
 	return func(fromRef string, toRef string) (util.Set, error) {
 		// We could filter changed files at the git level, since it's possible
 		// that the changes we're interested in are scoped, but we need to handle
@@ -151,7 +153,7 @@ func (o *Opts) getPackageChangeFunc(scm scm.SCM, cwd string, packageInfos map[in
 			}
 			changedFiles = scmChangedFiles
 		}
-		if hasRepoGlobalFileChanged, err := repoGlobalFileHasChanged(o, changedFiles); err != nil {
+		if hasRepoGlobalFileChanged, err := repoGlobalFileHasChanged(o, getDefaultGlobalDeps(packageManager), changedFiles); err != nil {
 			return nil, err
 		} else if hasRepoGlobalFileChanged {
 			allPkgs := make(util.Set)
@@ -169,8 +171,21 @@ func (o *Opts) getPackageChangeFunc(scm scm.SCM, cwd string, packageInfos map[in
 	}
 }
 
-func repoGlobalFileHasChanged(opts *Opts, changedFiles []string) (bool, error) {
-	globalDepsGlob, err := filter.Compile(opts.GlobalDepPatterns)
+func getDefaultGlobalDeps(packageManager *packagemanager.PackageManager) []string {
+	// include turbo.json, root package.json, and root lockfile as implicit global dependencies
+	defaultGlobalDeps := []string{
+		"turbo.json",
+		"package.json",
+	}
+	if packageManager != nil {
+		defaultGlobalDeps = append(defaultGlobalDeps, packageManager.Lockfile)
+	}
+
+	return defaultGlobalDeps
+}
+
+func repoGlobalFileHasChanged(opts *Opts, defaultGlobalDeps []string, changedFiles []string) (bool, error) {
+	globalDepsGlob, err := filter.Compile(append(opts.GlobalDepPatterns, defaultGlobalDeps...))
 	if err != nil {
 		return false, errors.Wrap(err, "invalid global deps glob")
 	}

--- a/cli/internal/scope/scope_test.go
+++ b/cli/internal/scope/scope_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pyr-sh/dag"
 	"github.com/vercel/turborepo/cli/internal/context"
 	"github.com/vercel/turborepo/cli/internal/fs"
+	"github.com/vercel/turborepo/cli/internal/packagemanager"
 	"github.com/vercel/turborepo/cli/internal/turbopath"
 	"github.com/vercel/turborepo/cli/internal/ui"
 	"github.com/vercel/turborepo/cli/internal/util"
@@ -97,6 +98,7 @@ func TestResolvePackages(t *testing.T) {
 		globalDeps          []string
 		includeDependencies bool
 		includeDependents   bool
+		lockfile            string
 	}{
 		{
 			name:                "Just scope and dependencies",
@@ -104,6 +106,44 @@ func TestResolvePackages(t *testing.T) {
 			includeDependencies: true,
 			scope:               []string{"app2"},
 			expected:            []string{"app2", "libB", "libC", "libD"},
+		},
+		{
+			name:                "Only turbo.json changed",
+			changed:             []string{"turbo.json"},
+			expected:            []string{"app0", "app1", "app2", "app2-a", "libA", "libB", "libC", "libD"},
+			since:               "dummy",
+			includeDependencies: true,
+		},
+		{
+			name:                "Only root package.json changed",
+			changed:             []string{"package.json"},
+			expected:            []string{"app0", "app1", "app2", "app2-a", "libA", "libB", "libC", "libD"},
+			since:               "dummy",
+			includeDependencies: true,
+		},
+		{
+			name:                "Only package-lock.json changed",
+			changed:             []string{"package-lock.json"},
+			expected:            []string{"app0", "app1", "app2", "app2-a", "libA", "libB", "libC", "libD"},
+			since:               "dummy",
+			includeDependencies: true,
+			lockfile:            "package-lock.json",
+		},
+		{
+			name:                "Only yarn.lock changed",
+			changed:             []string{"yarn.lock"},
+			expected:            []string{"app0", "app1", "app2", "app2-a", "libA", "libB", "libC", "libD"},
+			since:               "dummy",
+			includeDependencies: true,
+			lockfile:            "yarn.lock",
+		},
+		{
+			name:                "Only pnpm-lock.yaml changed",
+			changed:             []string{"pnpm-lock.yaml"},
+			expected:            []string{"app0", "app1", "app2", "app2-a", "libA", "libB", "libC", "libD"},
+			since:               "dummy",
+			includeDependencies: true,
+			lockfile:            "pnpm-lock.yaml",
 		},
 		{
 			name:     "One package changed",
@@ -237,6 +277,7 @@ func TestResolvePackages(t *testing.T) {
 			}, filepath.FromSlash("/dummy/repo/root"), scm, &context.Context{
 				PackageInfos:     packagesInfos,
 				PackageNames:     packageNames,
+				PackageManager:   &packagemanager.PackageManager{Lockfile: tc.lockfile},
 				TopologicalGraph: graph,
 			}, tui, logger)
 			if err != nil {


### PR DESCRIPTION
Filtering should take into account global changes when deciding what should run. This includes:

1. turbo.json
2. package manager lockfile
3. root package.json

With these included, this means when running a command like (for example):
`npx turbo run build --filter=docs...[HEAD^]`

Docs would build on changes to any of the three listed files above, even if there are no changes to docs or it's dependencies. 