### PR TITLE
Show branch name rather than commit

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -38,6 +38,6 @@ jobs:
           ./scripts/version.js ${{ inputs.increment }}
           cat version.txt
       - name: Stage Commit
-        run: cd cli && make stage-release && echo "STAGE_BRANCH=$(git rev-parse HEAD)" >> $GITHUB_ENV
+        run: cd cli && make stage-release && echo "STAGE_BRANCH=$(git branch --show-current)" >> $GITHUB_ENV
       - name: Show Stage Commit
         run: echo "${{ env.STAGE_BRANCH }}"


### PR DESCRIPTION
Show the branch that we're going to release from, rather than the hash. This is more useful for the second phase where we build from a branch.