### PR TITLE
fix(examples): fix inconsistent package naming in with-changesets example

### DIFF
--- a/examples/with-changesets/README.md
+++ b/examples/with-changesets/README.md
@@ -12,7 +12,7 @@ This Turborepo includes the following:
 - `@acme/core`: core React components
 - `@acme/utils`: shared React utilities
 - `@acme/tsconfig`: shared `tsconfig.json`s used throughout the monorepo
-- `eslint-preset-acme`: ESLint preset
+- `eslint-config-acme`: ESLint preset
 
 Each package and app is 100% [TypeScript](https://www.typescriptlang.org/).
 

--- a/examples/with-changesets/apps/docs/package.json
+++ b/examples/with-changesets/apps/docs/package.json
@@ -21,7 +21,7 @@
     "@types/node": "^17.0.12",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
-    "eslint-preset-acme": "*",
+    "eslint-config-acme": "*",
     "typescript": "^4.5.4"
   }
 }


### PR DESCRIPTION
In two places, the pakage eslint-config-acme is incorrectly referred to as eslint-preset-acme. This breaks the yarn install.