### PR TITLE
feat(examples): update docker file to install libc6-compact

### DIFF
--- a/examples/with-docker/apps/api/Dockerfile
+++ b/examples/with-docker/apps/api/Dockerfile
@@ -2,6 +2,8 @@
 # Make sure you update both files!
 
 FROM node:alpine AS builder
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
 RUN apk update
 # Set working directory
 WORKDIR /app

--- a/examples/with-docker/apps/web/Dockerfile
+++ b/examples/with-docker/apps/web/Dockerfile
@@ -2,6 +2,8 @@
 # Make sure you update both files!
 
 FROM node:alpine AS builder
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
 RUN apk update
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
- update Dockerfile examples  to ensure libc6-compat is installed as well as per latest turbo update  

command : `RUN apk add --no-cache libc6-compat`