### PR TITLE
Mark no-daemon as publicly visible

### DIFF
--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -577,11 +577,7 @@ func addRunOpts(opts *runOpts, flags *pflag.FlagSet, aliases map[string]string) 
 	flags.BoolVar(&opts.singlePackage, "single-package", false, "Run turbo in single-package mode")
 	// This is a no-op flag, we don't need it anymore
 	flags.Bool("experimental-use-daemon", false, "Use the experimental turbo daemon")
-	// Daemon-related flags hidden for now, we can unhide when daemon is ready.
 	if err := flags.MarkHidden("experimental-use-daemon"); err != nil {
-		panic(err)
-	}
-	if err := flags.MarkHidden("no-daemon"); err != nil {
 		panic(err)
 	}
 	if err := flags.MarkHidden("only"); err != nil {

--- a/docs/pages/docs/reference/command-line-reference.mdx
+++ b/docs/pages/docs/reference/command-line-reference.mdx
@@ -270,6 +270,12 @@ turbo run build --no-cache
 turbo run dev --parallel --no-cache
 ```
 
+### `--no-daemon`
+
+Default `false`. `turbo` can run a standalone process in some cases to precalculate values used for determining what work needs to be done.
+This standalone process (daemon) is an optimization, and not required for proper functioning of `turbo`.
+Passing `--no-daemon` instructs `turbo` to avoid using or creating the standalone process.
+
 #### `--output-logs`
 
 `type: string`


### PR DESCRIPTION
This flag no longer needs to be hidden, as the daemon is on by default.