### PR TITLE
Drop unused dependency on cache location

### DIFF
--- a/cli/internal/cache/cache.go
+++ b/cli/internal/cache/cache.go
@@ -70,9 +70,9 @@ type Opts struct {
 	RemoteCacheOpts fs.RemoteCacheOptions
 }
 
-// ResolveCacheDir calculates the location turbo should use to cache artifacts,
+// resolveCacheDir calculates the location turbo should use to cache artifacts,
 // based on the options supplied by the user.
-func (o *Opts) ResolveCacheDir(repoRoot turbopath.AbsoluteSystemPath) turbopath.AbsoluteSystemPath {
+func (o *Opts) resolveCacheDir(repoRoot turbopath.AbsoluteSystemPath) turbopath.AbsoluteSystemPath {
 	if o.OverrideDir != "" {
 		return fs.ResolveUnknownPath(repoRoot, o.OverrideDir)
 	}

--- a/cli/internal/cache/cache_fs.go
+++ b/cli/internal/cache/cache_fs.go
@@ -22,7 +22,7 @@ type fsCache struct {
 
 // newFsCache creates a new filesystem cache
 func newFsCache(opts Opts, recorder analytics.Recorder, repoRoot turbopath.AbsoluteSystemPath) (*fsCache, error) {
-	cacheDir := opts.ResolveCacheDir(repoRoot)
+	cacheDir := opts.resolveCacheDir(repoRoot)
 	if err := cacheDir.MkdirAll(0775); err != nil {
 		return nil, err
 	}

--- a/cli/internal/context/context.go
+++ b/cli/internal/context/context.go
@@ -145,7 +145,7 @@ func SinglePackageGraph(repoRoot turbopath.AbsoluteSystemPath, rootPackageJSON *
 }
 
 // BuildPackageGraph constructs a Context instance with information about the package dependency graph
-func BuildPackageGraph(repoRoot turbopath.AbsoluteSystemPath, rootPackageJSON *fs.PackageJSON, cacheDir turbopath.AbsoluteSystemPath) (*Context, error) {
+func BuildPackageGraph(repoRoot turbopath.AbsoluteSystemPath, rootPackageJSON *fs.PackageJSON) (*Context, error) {
 	c := &Context{}
 	rootpath := repoRoot.ToStringDuringMigration()
 	c.PackageInfos = make(map[interface{}]*fs.PackageJSON)
@@ -159,7 +159,7 @@ func BuildPackageGraph(repoRoot turbopath.AbsoluteSystemPath, rootPackageJSON *f
 	}
 	c.PackageManager = packageManager
 
-	if lockfile, err := c.PackageManager.ReadLockfile(cacheDir, repoRoot); err != nil {
+	if lockfile, err := c.PackageManager.ReadLockfile(repoRoot); err != nil {
 		warnings.append(err)
 	} else {
 		c.Lockfile = lockfile

--- a/cli/internal/packagemanager/packagemanager.go
+++ b/cli/internal/packagemanager/packagemanager.go
@@ -7,7 +7,6 @@ package packagemanager
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -174,11 +173,11 @@ func (pm PackageManager) CanPrune(projectDirectory turbopath.AbsoluteSystemPath)
 }
 
 // ReadLockfile will read the applicable lockfile into memory
-func (pm PackageManager) ReadLockfile(cacheDir turbopath.AbsoluteSystemPath, projectDirectory turbopath.AbsoluteSystemPath) (lockfile.Lockfile, error) {
+func (pm PackageManager) ReadLockfile(projectDirectory turbopath.AbsoluteSystemPath) (lockfile.Lockfile, error) {
 	if pm.readLockfile == nil {
 		return nil, nil
 	}
-	contents, err := os.ReadFile(string(projectDirectory.UntypedJoin(pm.Lockfile)))
+	contents, err := projectDirectory.UntypedJoin(pm.Lockfile).ReadFile()
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %w", pm.Lockfile, err)
 	}

--- a/cli/internal/prune/prune.go
+++ b/cli/internal/prune/prune.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"github.com/vercel/turborepo/cli/internal/cache"
 	"github.com/vercel/turborepo/cli/internal/cmdutil"
 	"github.com/vercel/turborepo/cli/internal/context"
 	"github.com/vercel/turborepo/cli/internal/fs"
@@ -82,13 +81,12 @@ type prune struct {
 
 // Prune creates a smaller monorepo with only the required workspaces
 func (p *prune) prune(opts *opts) error {
-	cacheDir := cache.DefaultLocation(p.base.RepoRoot)
 	rootPackageJSONPath := p.base.RepoRoot.UntypedJoin("package.json")
 	rootPackageJSON, err := fs.ReadPackageJSON(rootPackageJSONPath)
 	if err != nil {
 		return fmt.Errorf("failed to read package.json: %w", err)
 	}
-	ctx, err := context.BuildPackageGraph(p.base.RepoRoot, rootPackageJSON, cacheDir)
+	ctx, err := context.BuildPackageGraph(p.base.RepoRoot, rootPackageJSON)
 	if err != nil {
 		return errors.Wrap(err, "could not construct graph")
 	}

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -192,7 +192,7 @@ func (r *run) run(ctx gocontext.Context, targets []string) error {
 	if r.opts.runOpts.singlePackage {
 		pkgDepGraph, err = context.SinglePackageGraph(r.base.RepoRoot, rootPackageJSON)
 	} else {
-		pkgDepGraph, err = context.BuildPackageGraph(r.base.RepoRoot, rootPackageJSON, r.opts.cacheOpts.ResolveCacheDir(r.base.RepoRoot))
+		pkgDepGraph, err = context.BuildPackageGraph(r.base.RepoRoot, rootPackageJSON)
 	}
 	if err != nil {
 		var warnings *context.Warnings


### PR DESCRIPTION
While reading through some packagemanager code, I noticed we were no longer using the cache directory while building up the package-graph, so I pulled it out of the function signature and unwound some dependencies from there.