### PR TITLE
Consolidate engine, taskGraph, and scheduler naming to Engine

### DIFF
--- a/cli/internal/core/engine.go
+++ b/cli/internal/core/engine.go
@@ -24,6 +24,7 @@ type Task struct {
 
 type Visitor = func(taskID string) error
 
+// Engine contains both the DAG for the packages and the tasks and implements the methods to execute tasks in them
 type Engine struct {
 	// TopologicGraph is a graph of workspaces
 	TopologicGraph *dag.AcyclicGraph
@@ -56,6 +57,7 @@ type EngineExecutionOptions struct {
 	TasksOnly bool
 }
 
+// Prepare constructs the Task Graph for a list of packages and tasks
 func (e *Engine) Prepare(options *EngineExecutionOptions) error {
 	pkgs := options.Packages
 	tasks := options.TaskNames
@@ -231,6 +233,7 @@ func getPackageTaskDepsMap(packageTaskDeps [][]string) map[string][]string {
 	return depMap
 }
 
+// AddTask adds a task to the Engine so it can be looked up later.
 func (e *Engine) AddTask(task *Task) *Engine {
 	// If a root task is added, mark the task name as eligible for
 	// root execution. Otherwise, it will be skipped.
@@ -244,6 +247,7 @@ func (e *Engine) AddTask(task *Task) *Engine {
 	return e
 }
 
+// AddDep adds tuples from+to task ID combos in tuple format so they can be looked up later.
 func (e *Engine) AddDep(fromTaskId string, toTaskId string) error {
 	fromPkg, _ := util.GetPackageTaskFromId(fromTaskId)
 	if fromPkg != ROOT_NODE_NAME && fromPkg != util.RootPkgName && !e.TopologicGraph.HasVertex(fromPkg) {

--- a/cli/internal/core/engine.go
+++ b/cli/internal/core/engine.go
@@ -56,17 +56,17 @@ type EngineExecutionOptions struct {
 	TasksOnly bool
 }
 
-func (p *Engine) Prepare(options *EngineExecutionOptions) error {
+func (e *Engine) Prepare(options *EngineExecutionOptions) error {
 	pkgs := options.Packages
 	tasks := options.TaskNames
 	if len(tasks) == 0 {
 		// TODO(gsoltis): Is this behavior used?
-		for key := range p.Tasks {
+		for key := range e.Tasks {
 			tasks = append(tasks, key)
 		}
 	}
 
-	if err := p.generateTaskGraph(pkgs, tasks, options.TasksOnly); err != nil {
+	if err := e.generateTaskGraph(pkgs, tasks, options.TasksOnly); err != nil {
 		return err
 	}
 
@@ -82,9 +82,9 @@ type ExecOpts struct {
 }
 
 // Execute executes the pipeline, constructing an internal task graph and walking it accordingly.
-func (p *Engine) Execute(visitor Visitor, opts ExecOpts) []error {
+func (e *Engine) Execute(visitor Visitor, opts ExecOpts) []error {
 	var sema = util.NewSemaphore(opts.Concurrency)
-	return p.TaskGraph.Walk(func(v dag.Vertex) error {
+	return e.TaskGraph.Walk(func(v dag.Vertex) error {
 		// Always return if it is the root node
 		if strings.Contains(dag.VertexName(v), ROOT_NODE_NAME) {
 			return nil
@@ -98,31 +98,30 @@ func (p *Engine) Execute(visitor Visitor, opts ExecOpts) []error {
 	})
 }
 
-func (p *Engine) getTaskDefinition(pkg string, taskName string, taskID string) (*Task, error) {
-	if task, ok := p.Tasks[taskID]; ok {
+func (e *Engine) getTaskDefinition(pkg string, taskName string, taskID string) (*Task, error) {
+	if task, ok := e.Tasks[taskID]; ok {
 		return task, nil
 	}
-	if task, ok := p.Tasks[taskName]; ok {
+	if task, ok := e.Tasks[taskName]; ok {
 		return task, nil
 	}
 	return nil, errNoTask
 }
 
-func (p *Engine) generateTaskGraph(pkgs []string, taskNames []string, tasksOnly bool) error {
-	if p.PackageTaskDeps == nil {
-		p.PackageTaskDeps = [][]string{}
+func (e *Engine) generateTaskGraph(pkgs []string, taskNames []string, tasksOnly bool) error {
+	if e.PackageTaskDeps == nil {
+		e.PackageTaskDeps = [][]string{}
 	}
 
-	packageTasksDepsMap := getPackageTaskDepsMap(p.PackageTaskDeps)
+	packageTasksDepsMap := getPackageTaskDepsMap(e.PackageTaskDeps)
 
 	traversalQueue := []string{}
-
 	for _, pkg := range pkgs {
 		isRootPkg := pkg == util.RootPkgName
 		for _, taskName := range taskNames {
-			if !isRootPkg || p.rootEnabledTasks.Includes(taskName) {
+			if !isRootPkg || e.rootEnabledTasks.Includes(taskName) {
 				taskID := util.GetTaskId(pkg, taskName)
-				if _, err := p.getTaskDefinition(pkg, taskName, taskID); err != nil {
+				if _, err := e.getTaskDefinition(pkg, taskName, taskID); err != nil {
 					// Initial, non-package tasks are not required to exist, as long as some
 					// package in the list packages defines it as a package-task. Dependencies
 					// *are* required to have a definition.
@@ -138,11 +137,12 @@ func (p *Engine) generateTaskGraph(pkgs []string, taskNames []string, tasksOnly 
 	for len(traversalQueue) > 0 {
 		taskId := traversalQueue[0]
 		traversalQueue = traversalQueue[1:]
+
 		pkg, taskName := util.GetPackageTaskFromId(taskId)
-		if pkg == util.RootPkgName && !p.rootEnabledTasks.Includes(taskName) {
+		if pkg == util.RootPkgName && !e.rootEnabledTasks.Includes(taskName) {
 			return fmt.Errorf("%v needs an entry in turbo.json before it can be depended on because it is a task run from the root package", taskId)
 		}
-		task, err := p.getTaskDefinition(pkg, taskName, taskId)
+		task, err := e.getTaskDefinition(pkg, taskName, taskId)
 		if err != nil {
 			return err
 		}
@@ -166,7 +166,7 @@ func (p *Engine) generateTaskGraph(pkgs []string, taskNames []string, tasksOnly 
 			}
 
 			toTaskId := taskId
-			hasTopoDeps := task.TopoDeps.Len() > 0 && p.TopologicGraph.DownEdges(pkg).Len() > 0
+			hasTopoDeps := task.TopoDeps.Len() > 0 && e.TopologicGraph.DownEdges(pkg).Len() > 0
 			hasDeps := deps.Len() > 0
 			hasPackageTaskDeps := false
 			if _, ok := packageTasksDepsMap[toTaskId]; ok {
@@ -174,14 +174,14 @@ func (p *Engine) generateTaskGraph(pkgs []string, taskNames []string, tasksOnly 
 			}
 
 			if hasTopoDeps {
-				depPkgs := p.TopologicGraph.DownEdges(pkg)
+				depPkgs := e.TopologicGraph.DownEdges(pkg)
 				for _, from := range task.TopoDeps.UnsafeListOfStrings() {
 					// add task dep from all the package deps within repo
 					for depPkg := range depPkgs {
 						fromTaskId := util.GetTaskId(depPkg, from)
-						p.TaskGraph.Add(fromTaskId)
-						p.TaskGraph.Add(toTaskId)
-						p.TaskGraph.Connect(dag.BasicEdge(toTaskId, fromTaskId))
+						e.TaskGraph.Add(fromTaskId)
+						e.TaskGraph.Add(toTaskId)
+						e.TaskGraph.Connect(dag.BasicEdge(toTaskId, fromTaskId))
 						traversalQueue = append(traversalQueue, fromTaskId)
 					}
 				}
@@ -190,9 +190,9 @@ func (p *Engine) generateTaskGraph(pkgs []string, taskNames []string, tasksOnly 
 			if hasDeps {
 				for _, from := range deps.UnsafeListOfStrings() {
 					fromTaskId := util.GetTaskId(pkg, from)
-					p.TaskGraph.Add(fromTaskId)
-					p.TaskGraph.Add(toTaskId)
-					p.TaskGraph.Connect(dag.BasicEdge(toTaskId, fromTaskId))
+					e.TaskGraph.Add(fromTaskId)
+					e.TaskGraph.Add(toTaskId)
+					e.TaskGraph.Connect(dag.BasicEdge(toTaskId, fromTaskId))
 					traversalQueue = append(traversalQueue, fromTaskId)
 				}
 			}
@@ -200,18 +200,18 @@ func (p *Engine) generateTaskGraph(pkgs []string, taskNames []string, tasksOnly 
 			if hasPackageTaskDeps {
 				if pkgTaskDeps, ok := packageTasksDepsMap[toTaskId]; ok {
 					for _, fromTaskId := range pkgTaskDeps {
-						p.TaskGraph.Add(fromTaskId)
-						p.TaskGraph.Add(toTaskId)
-						p.TaskGraph.Connect(dag.BasicEdge(toTaskId, fromTaskId))
+						e.TaskGraph.Add(fromTaskId)
+						e.TaskGraph.Add(toTaskId)
+						e.TaskGraph.Connect(dag.BasicEdge(toTaskId, fromTaskId))
 						traversalQueue = append(traversalQueue, fromTaskId)
 					}
 				}
 			}
 
 			if !hasDeps && !hasTopoDeps && !hasPackageTaskDeps {
-				p.TaskGraph.Add(ROOT_NODE_NAME)
-				p.TaskGraph.Add(toTaskId)
-				p.TaskGraph.Connect(dag.BasicEdge(toTaskId, ROOT_NODE_NAME))
+				e.TaskGraph.Add(ROOT_NODE_NAME)
+				e.TaskGraph.Add(toTaskId)
+				e.TaskGraph.Connect(dag.BasicEdge(toTaskId, ROOT_NODE_NAME))
 			}
 		}
 	}
@@ -231,24 +231,24 @@ func getPackageTaskDepsMap(packageTaskDeps [][]string) map[string][]string {
 	return depMap
 }
 
-func (p *Engine) AddTask(task *Task) *Engine {
+func (e *Engine) AddTask(task *Task) *Engine {
 	// If a root task is added, mark the task name as eligible for
 	// root execution. Otherwise, it will be skipped.
 	if util.IsPackageTask(task.Name) {
 		pkg, taskName := util.GetPackageTaskFromId(task.Name)
 		if pkg == util.RootPkgName {
-			p.rootEnabledTasks.Add(taskName)
+			e.rootEnabledTasks.Add(taskName)
 		}
 	}
-	p.Tasks[task.Name] = task
-	return p
+	e.Tasks[task.Name] = task
+	return e
 }
 
-func (p *Engine) AddDep(fromTaskId string, toTaskId string) error {
+func (e *Engine) AddDep(fromTaskId string, toTaskId string) error {
 	fromPkg, _ := util.GetPackageTaskFromId(fromTaskId)
-	if fromPkg != ROOT_NODE_NAME && fromPkg != util.RootPkgName && !p.TopologicGraph.HasVertex(fromPkg) {
+	if fromPkg != ROOT_NODE_NAME && fromPkg != util.RootPkgName && !e.TopologicGraph.HasVertex(fromPkg) {
 		return fmt.Errorf("found reference to unknown package: %v in task %v", fromPkg, fromTaskId)
 	}
-	p.PackageTaskDeps = append(p.PackageTaskDeps, []string{fromTaskId, toTaskId})
+	e.PackageTaskDeps = append(e.PackageTaskDeps, []string{fromTaskId, toTaskId})
 	return nil
 }

--- a/cli/internal/core/engine.go
+++ b/cli/internal/core/engine.go
@@ -137,19 +137,19 @@ func (e *Engine) generateTaskGraph(pkgs []string, taskNames []string, tasksOnly 
 	visited := make(util.Set)
 
 	for len(traversalQueue) > 0 {
-		taskId := traversalQueue[0]
+		taskID := traversalQueue[0]
 		traversalQueue = traversalQueue[1:]
 
-		pkg, taskName := util.GetPackageTaskFromId(taskId)
+		pkg, taskName := util.GetPackageTaskFromId(taskID)
 		if pkg == util.RootPkgName && !e.rootEnabledTasks.Includes(taskName) {
-			return fmt.Errorf("%v needs an entry in turbo.json before it can be depended on because it is a task run from the root package", taskId)
+			return fmt.Errorf("%v needs an entry in turbo.json before it can be depended on because it is a task run from the root package", taskID)
 		}
-		task, err := e.getTaskDefinition(pkg, taskName, taskId)
+		task, err := e.getTaskDefinition(pkg, taskName, taskID)
 		if err != nil {
 			return err
 		}
-		if !visited.Includes(taskId) {
-			visited.Add(taskId)
+		if !visited.Includes(taskID) {
+			visited.Add(taskID)
 			deps := task.Deps
 
 			if tasksOnly {
@@ -167,11 +167,11 @@ func (e *Engine) generateTaskGraph(pkgs []string, taskNames []string, tasksOnly 
 				})
 			}
 
-			toTaskId := taskId
+			toTaskID := taskID
 			hasTopoDeps := task.TopoDeps.Len() > 0 && e.TopologicGraph.DownEdges(pkg).Len() > 0
 			hasDeps := deps.Len() > 0
 			hasPackageTaskDeps := false
-			if _, ok := packageTasksDepsMap[toTaskId]; ok {
+			if _, ok := packageTasksDepsMap[toTaskID]; ok {
 				hasPackageTaskDeps = true
 			}
 
@@ -180,40 +180,40 @@ func (e *Engine) generateTaskGraph(pkgs []string, taskNames []string, tasksOnly 
 				for _, from := range task.TopoDeps.UnsafeListOfStrings() {
 					// add task dep from all the package deps within repo
 					for depPkg := range depPkgs {
-						fromTaskId := util.GetTaskId(depPkg, from)
-						e.TaskGraph.Add(fromTaskId)
-						e.TaskGraph.Add(toTaskId)
-						e.TaskGraph.Connect(dag.BasicEdge(toTaskId, fromTaskId))
-						traversalQueue = append(traversalQueue, fromTaskId)
+						fromTaskID := util.GetTaskId(depPkg, from)
+						e.TaskGraph.Add(fromTaskID)
+						e.TaskGraph.Add(toTaskID)
+						e.TaskGraph.Connect(dag.BasicEdge(toTaskID, fromTaskID))
+						traversalQueue = append(traversalQueue, fromTaskID)
 					}
 				}
 			}
 
 			if hasDeps {
 				for _, from := range deps.UnsafeListOfStrings() {
-					fromTaskId := util.GetTaskId(pkg, from)
-					e.TaskGraph.Add(fromTaskId)
-					e.TaskGraph.Add(toTaskId)
-					e.TaskGraph.Connect(dag.BasicEdge(toTaskId, fromTaskId))
-					traversalQueue = append(traversalQueue, fromTaskId)
+					fromTaskID := util.GetTaskId(pkg, from)
+					e.TaskGraph.Add(fromTaskID)
+					e.TaskGraph.Add(toTaskID)
+					e.TaskGraph.Connect(dag.BasicEdge(toTaskID, fromTaskID))
+					traversalQueue = append(traversalQueue, fromTaskID)
 				}
 			}
 
 			if hasPackageTaskDeps {
-				if pkgTaskDeps, ok := packageTasksDepsMap[toTaskId]; ok {
-					for _, fromTaskId := range pkgTaskDeps {
-						e.TaskGraph.Add(fromTaskId)
-						e.TaskGraph.Add(toTaskId)
-						e.TaskGraph.Connect(dag.BasicEdge(toTaskId, fromTaskId))
-						traversalQueue = append(traversalQueue, fromTaskId)
+				if pkgTaskDeps, ok := packageTasksDepsMap[toTaskID]; ok {
+					for _, fromTaskID := range pkgTaskDeps {
+						e.TaskGraph.Add(fromTaskID)
+						e.TaskGraph.Add(toTaskID)
+						e.TaskGraph.Connect(dag.BasicEdge(toTaskID, fromTaskID))
+						traversalQueue = append(traversalQueue, fromTaskID)
 					}
 				}
 			}
 
 			if !hasDeps && !hasTopoDeps && !hasPackageTaskDeps {
 				e.TaskGraph.Add(ROOT_NODE_NAME)
-				e.TaskGraph.Add(toTaskId)
-				e.TaskGraph.Connect(dag.BasicEdge(toTaskId, ROOT_NODE_NAME))
+				e.TaskGraph.Add(toTaskID)
+				e.TaskGraph.Connect(dag.BasicEdge(toTaskID, ROOT_NODE_NAME))
 			}
 		}
 	}
@@ -248,11 +248,11 @@ func (e *Engine) AddTask(task *Task) *Engine {
 }
 
 // AddDep adds tuples from+to task ID combos in tuple format so they can be looked up later.
-func (e *Engine) AddDep(fromTaskId string, toTaskId string) error {
-	fromPkg, _ := util.GetPackageTaskFromId(fromTaskId)
+func (e *Engine) AddDep(fromTaskID string, toTaskID string) error {
+	fromPkg, _ := util.GetPackageTaskFromId(fromTaskID)
 	if fromPkg != ROOT_NODE_NAME && fromPkg != util.RootPkgName && !e.TopologicGraph.HasVertex(fromPkg) {
-		return fmt.Errorf("found reference to unknown package: %v in task %v", fromPkg, fromTaskId)
+		return fmt.Errorf("found reference to unknown package: %v in task %v", fromPkg, fromTaskID)
 	}
-	e.PackageTaskDeps = append(e.PackageTaskDeps, []string{fromTaskId, toTaskId})
+	e.PackageTaskDeps = append(e.PackageTaskDeps, []string{fromTaskID, toTaskID})
 	return nil
 }

--- a/cli/internal/run/run.go
+++ b/cli/internal/run/run.go
@@ -288,7 +288,7 @@ func (r *run) runOperation(ctx gocontext.Context, g *completeGraph, rs *runSpec,
 		vertexSet.Add(v)
 	}
 
-	engine, err := buildTaskGraph(&g.TopologicalGraph, g.Pipeline, rs)
+	engine, err := buildTaskGraphEngine(&g.TopologicalGraph, g.Pipeline, rs)
 	if err != nil {
 		return errors.Wrap(err, "error preparing engine")
 	}
@@ -307,7 +307,7 @@ func (r *run) runOperation(ctx gocontext.Context, g *completeGraph, rs *runSpec,
 				g.TopologicalGraph.RemoveEdge(edge)
 			}
 		}
-		engine, err = buildTaskGraph(&g.TopologicalGraph, g.Pipeline, rs)
+		engine, err = buildTaskGraphEngine(&g.TopologicalGraph, g.Pipeline, rs)
 		if err != nil {
 			return errors.Wrap(err, "error preparing engine")
 		}
@@ -470,8 +470,9 @@ func filterSinglePackageGraphForDisplay(originalGraph *dag.AcyclicGraph) *dag.Ac
 	return graph
 }
 
-func buildTaskGraph(topoGraph *dag.AcyclicGraph, pipeline fs.Pipeline, rs *runSpec) (*core.Scheduler, error) {
-	engine := core.NewScheduler(topoGraph)
+func buildTaskGraphEngine(topoGraph *dag.AcyclicGraph, pipeline fs.Pipeline, rs *runSpec) (*core.Engine, error) {
+	engine := core.NewEngine(topoGraph)
+
 	for taskName, taskDefinition := range pipeline {
 		topoDeps := make(util.Set)
 		deps := make(util.Set)
@@ -496,7 +497,7 @@ func buildTaskGraph(topoGraph *dag.AcyclicGraph, pipeline fs.Pipeline, rs *runSp
 		})
 	}
 
-	if err := engine.Prepare(&core.SchedulerExecutionOptions{
+	if err := engine.Prepare(&core.EngineExecutionOptions{
 		Packages:  rs.FilteredPkgs.UnsafeListOfStrings(),
 		TaskNames: rs.Targets,
 		TasksOnly: rs.Opts.runOpts.only,
@@ -731,7 +732,7 @@ func (r *run) initCache(ctx gocontext.Context, rs *runSpec, analyticsClient anal
 	})
 }
 
-func (r *run) executeTasks(ctx gocontext.Context, g *completeGraph, rs *runSpec, engine *core.Scheduler, packageManager *packagemanager.PackageManager, hashes *taskhash.Tracker, startAt time.Time) error {
+func (r *run) executeTasks(ctx gocontext.Context, g *completeGraph, rs *runSpec, engine *core.Engine, packageManager *packagemanager.PackageManager, hashes *taskhash.Tracker, startAt time.Time) error {
 	analyticsClient := r.initAnalyticsClient(ctx)
 	defer analyticsClient.CloseWithTimeout(50 * time.Millisecond)
 
@@ -854,7 +855,7 @@ type hashedSinglePackageTask struct {
 	Dependents      []string `json:"dependents"`
 }
 
-func (r *run) executeDryRun(ctx gocontext.Context, engine *core.Scheduler, g *completeGraph, taskHashes *taskhash.Tracker, rs *runSpec) ([]hashedTask, error) {
+func (r *run) executeDryRun(ctx gocontext.Context, engine *core.Engine, g *completeGraph, taskHashes *taskhash.Tracker, rs *runSpec) ([]hashedTask, error) {
 	analyticsClient := r.initAnalyticsClient(ctx)
 	defer analyticsClient.CloseWithTimeout(50 * time.Millisecond)
 	turboCache, err := r.initCache(ctx, rs, analyticsClient)

--- a/cli/internal/run/run_test.go
+++ b/cli/internal/run/run_test.go
@@ -324,7 +324,7 @@ func Test_dontSquashTasks(t *testing.T) {
 		Targets:      []string{"build"},
 		Opts:         &Opts{},
 	}
-	engine, err := buildTaskGraph(topoGraph, pipeline, rs)
+	engine, err := buildTaskGraphEngine(topoGraph, pipeline, rs)
 	if err != nil {
 		t.Fatalf("failed to build task graph: %v", err)
 	}
@@ -357,7 +357,7 @@ func Test_taskSelfRef(t *testing.T) {
 		Targets:      []string{"build"},
 		Opts:         &Opts{},
 	}
-	_, err := buildTaskGraph(topoGraph, pipeline, rs)
+	_, err := buildTaskGraphEngine(topoGraph, pipeline, rs)
 	if err == nil {
 		t.Fatalf("expected to failed to build task graph: %v", err)
 	}


### PR DESCRIPTION
This PR consolidates some internal terminology around the task graph.
"Scheduler", "Engine" and "TaskGraph"[^1] are all the same thing. The receiver
on the methods for the now `Engine` struct was also confusingly named `p`,
so I've replaced that with `e`.

Touching this file also triggered errors from the linter, so I've also fixed those.

[^1]: Task Graph, as opposed to the "Topological Graph", which refers to the package dependencies
graph.