### PR TITLE
Update deploying-with-docker.mdx to indicate it does not work with npm

### DIFF
--- a/docs/pages/docs/handbook/deploying-with-docker.mdx
+++ b/docs/pages/docs/handbook/deploying-with-docker.mdx
@@ -4,6 +4,11 @@ import Callout from '../../../components/Callout'
 
 Building a [Docker](https://www.docker.com/) image is a common way to deploy all sorts of applications. However, doing so from a monorepo has several challenges.
 
+<Callout>
+  This command is not yet implemented for `npm`.
+</Callout>
+
+
 ## The problem
 
 **TL;DR:** In a monorepo, unrelated changes can make Docker do unnecessary work when deploying your app.


### PR DESCRIPTION
All the examples are with npm except the last full example of the Dockerfile

That gives the impression that it does work with npm :)