### PR TITLE
Ensure that the Engines field parses correctly.

### DIFF
--- a/cli/internal/lockfile/npm_lockfile.go
+++ b/cli/internal/lockfile/npm_lockfile.go
@@ -46,10 +46,16 @@ type NpmPackage struct {
 	PeerDependencies     map[string]string `json:"peerDependencies,omitempty"`
 	OptionalDependencies map[string]string `json:"optionalDependencies,omitempty"`
 
-	Bin     map[string]string `json:"bin,omitempty"`
-	Engines map[string]string `json:"engines,omitempty"`
-	CPU     []string          `json:"cpu,omitempty"`
-	OS      []string          `json:"os,omitempty"`
+	Bin map[string]string `json:"bin,omitempty"`
+
+	// Engines has two valid formats historically, an array and an object.
+	// Since we don't use this property we just need to propagate it through.
+	//
+	// Go serializes correctly even with `interface{}`.
+	Engines interface{} `json:"engines,omitempty"`
+
+	CPU []string `json:"cpu,omitempty"`
+	OS  []string `json:"os,omitempty"`
 
 	// Only used for root level package
 	Workspaces []string `json:"workspaces,omitempty"`

--- a/cli/internal/lockfile/testdata/npm-lock.json
+++ b/cli/internal/lockfile/testdata/npm-lock.json
@@ -63,7 +63,10 @@
     "apps/web/node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "engines": [
+        "node >= 0.8.0"
+      ]
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",


### PR DESCRIPTION
`npm` has an additional historically-valid format for the `engines` field in `package.json`. This PR changes the parsing behavior to support _any_ value for the `engines` object.

Closes #2270