### PR TITLE
Start on a shim release process

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,9 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.rs]
+indent_size = 4
+
 [*.t]
 trim_trailing_whitespace = false
 

--- a/.github/workflows/build_go_lib.yml
+++ b/.github/workflows/build_go_lib.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: turbo-lib-darwin
+          name: turbo-lib-darwin-${{ inputs.release_branch }}
           path: cli/dist-darwin
 
   # compiles linux and windows in a container
@@ -89,5 +89,5 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: turbo-lib-cross
+          name: turbo-lib-cross-${{ inputs.release_branch }}
           path: cli/dist-cross

--- a/.github/workflows/build_go_lib.yml
+++ b/.github/workflows/build_go_lib.yml
@@ -1,0 +1,93 @@
+name: Build Go Library
+
+env:
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_branch:
+        description: "Staging branch to run release from"
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.release_branch }}
+      - uses: ./.github/actions/setup-node
+        with:
+          enable-corepack: false
+      - uses: ./.github/actions/setup-go
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Test
+        run: pnpm -- turbo run test --filter=cli --color
+
+  darwin:
+    needs: [smoke-test]
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.release_branch }}
+      - run: git fetch origin --tags
+      - uses: ./.github/actions/setup-node
+        with:
+          enable-corepack: false
+      - uses: ./.github/actions/setup-go
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          distribution: goreleaser-pro
+          version: latest
+          install-only: true
+        env:
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+      - name: Build Artifacts
+        run: cd cli && make build-lib-turbo-darwin
+        env:
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: turbo-lib-darwin
+          path: cli/dist-darwin
+
+  # compiles linux and windows in a container
+  cross:
+    needs: [smoke-test]
+    runs-on: ubuntu-latest
+    container:
+      image: docker://ghcr.io/vercel/turbo-cross:v1.18.5
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: "${{ inputs.release_branch }}"
+      - run: git fetch origin --tags
+      - uses: ./.github/actions/setup-node
+        with:
+          enable-corepack: false
+      - uses: ./.github/actions/setup-go
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          distribution: goreleaser-pro
+          version: latest
+          install-only: true
+        env:
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+      - name: Build Artifacts
+        run: cd cli && make build-lib-turbo-cross
+        env:
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: turbo-lib-cross
+          path: cli/dist-cross

--- a/.github/workflows/build_rust.yml
+++ b/.github/workflows/build_rust.yml
@@ -1,0 +1,186 @@
+name: Build Rust Wrapper
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-native:
+    name: "Build Native"
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          - host: macos-latest
+            target: "x86_64-apple-darwin"
+            lib-cache-key: turbo-lib-darwin
+          - host: macos-latest
+            target: "aarch64-apple-darwin"
+            lib-cache-key: turbo-lib-darwin
+          - host: ubuntu-latest
+            target: "x86_64-unknown-linux-gnu"
+            lib-cache-key: turbo-lib-cross
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
+          - host: ubuntu-latest
+            target: "aarch64-unknown-linux-gnu"
+            lib-cache-key: turbo-lib-cross
+            rustflags: 'RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc"'
+            setup: "sudo apt-get install -y gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu"
+          - host: windows-latest
+            target: x86_64-pc-windows-gnu
+            lib-cache-key: turbo-lib-cross
+    runs-on: ${{ matrix.settings.host }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install
+        uses: actions-rs/toolchain@v1
+        if: ${{ !matrix.settings.docker }}
+        with:
+          profile: minimal
+          override: true
+          # TODO: copied from turbo tooling, may need to make this file-driven
+          toolchain: nightly-2022-09-23
+          target: ${{ matrix.settings.target }}
+
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: ${{ matrix.settings.target }}-cargo-registry
+
+      - name: Cache cargo index
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/git
+          key: ${{ matrix.settings.target }}-cargo-index
+
+      - name: Download artifact
+        id: download-artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          # Optional, workflow file name or ID
+          # If not specified, will be inferred from run_id (if run_id is specified), or will be the current workflow
+          workflow: build_go_lib.yml
+          # Optional, the status or conclusion of a completed workflow to search for
+          # Can be one of a workflow conclusion:
+          #   "failure", "success", "neutral", "cancelled", "skipped", "timed_out", "action_required"
+          # Or a workflow status:
+          #   "completed", "in_progress", "queued"
+          # Use the empty string ("") to ignore status or conclusion in the search
+          workflow_conclusion: success
+          # Optional, will use the specified branch. Defaults to all branches
+          branch: main
+          # Optional, uploaded artifact name,
+          # will download all artifacts if not specified
+          # and extract them into respective subdirectories
+          # https://github.com/actions/download-artifact#download-all-artifacts
+          name: ${{ matrix.settings.lib-cache-key }}
+          # Optional, a directory where to extract artifact(s), defaults to the current directory
+          path: shim/libturbo
+          # Optional, choose how to exit the action if no artifact is found
+          # can be one of:
+          #  "fail", "warn", "ignore"
+          # default fail
+          if_no_artifact_found: fail
+
+      # TODO: re-enable this instead of the above when this runs together with the go library build
+      # - name: Download Cross-compiled Artifacts
+      #   uses: actions/download-artifact@v3
+      #   with:
+      #     name: ${{ matrix.settings.lib-cache-key }}
+      #     path: shim/libturbo
+      - name: Build Setup
+        if: ${{ matrix.settings.setup }}
+        run: ${{ matrix.settings.setup }}
+
+      - name: Build
+        if: ${{ !matrix.settings.docker }}
+        run: cd shim && ${{ matrix.settings.rustflags }} cargo build --release --target ${{ matrix.settings.target }}
+
+      - name: Build in Docker
+        if: ${{ matrix.settings.docker }}
+        run: cd shim && ${{ matrix.settings.rustflags }} cargo build --release --target ${{ matrix.settings.target }}
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: shim-${{ matrix.settings.target }}
+          # TODO: change binary name? goreleaser currently does the rename for us...
+          path: shim/target/${{ matrix.settings.target }}/release/shim*
+
+  final-publish:
+    name: "Publish To NPM"
+    runs-on: ubuntu-latest
+    needs: [build-native]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: "${{ inputs.release_branch }}"
+      - run: git fetch origin --tags
+      - uses: ./.github/actions/setup-node
+        with:
+          enable-corepack: false
+      - uses: ./.github/actions/setup-go
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Configure git
+        run: |
+          git config --global user.name 'Turbobot'
+          git config --global user.email 'turbobot@vercel.com'
+
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          distribution: goreleaser-pro
+          version: latest
+          install-only: true
+        env:
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+
+      - name: Download Apple ARM64 Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: shim-aarch64-apple-darwin
+          path: cli/dist-darwin-arm64
+
+      - name: Download Ubuntu ARM64 Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: shim-aarch64-unknown-linux-gnu
+          path: cli/dist-linux-arm64
+
+      - name: Download Windows ARM64 (Ships as x86_64) Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: shim-x86_64-pc-windows-gnu
+          path: cli/dist-windows-arm64
+
+      - name: Download Ubuntu x86_64 Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: shim-x86_64-unknown-linux-gnu
+          path: cli/dist-linux-amd64
+
+      - name: Download Apple x86_64 Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: shim-x86_64-apple-darwin
+          path: cli/dist-darwin-amd64
+
+      - name: Download Windows x86_64 Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: shim-x86_64-pc-windows-gnu
+          path: cli/dist-windows-amd64
+
+      # TODO: switch to publish-shim
+      - name: Perform Release (Snapshot)
+        run: cd cli && make snapshot-shim
+
+      # TODO: probably don't need to upload this once we've verified the snapshots
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: shim-combined
+          path: cli/dist

--- a/.github/workflows/build_rust.yml
+++ b/.github/workflows/build_rust.yml
@@ -173,9 +173,8 @@ jobs:
           name: shim-x86_64-pc-windows-gnu
           path: cli/dist-windows-amd64
 
-      # TODO: switch to publish-shim
-      - name: Perform Release (Snapshot)
-        run: cd cli && make snapshot-shim
+      - name: Perform Release
+        run: cd cli && make publish-shim
 
       # TODO: probably don't need to upload this once we've verified the snapshots
       - name: Upload Artifacts

--- a/.github/workflows/build_rust.yml
+++ b/.github/workflows/build_rust.yml
@@ -2,6 +2,9 @@ name: Build Rust Wrapper
 
 on:
   workflow_dispatch:
+    inputs:
+      release_branch:
+        description: "Staging branch to run release from"
 
 jobs:
   build-native:
@@ -12,22 +15,22 @@ jobs:
         settings:
           - host: macos-latest
             target: "x86_64-apple-darwin"
-            lib-cache-key: turbo-lib-darwin
+            lib-cache-key: turbo-lib-darwin-${{ inputs.release_branch }}
           - host: macos-latest
             target: "aarch64-apple-darwin"
-            lib-cache-key: turbo-lib-darwin
+            lib-cache-key: turbo-lib-darwin-${{ inputs.release_branch }}
           - host: ubuntu-latest
             target: "x86_64-unknown-linux-gnu"
-            lib-cache-key: turbo-lib-cross
+            lib-cache-key: turbo-lib-cross-${{ inputs.release_branch }}
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
           - host: ubuntu-latest
             target: "aarch64-unknown-linux-gnu"
-            lib-cache-key: turbo-lib-cross
+            lib-cache-key: turbo-lib-cross-${{ inputs.release_branch }}
             rustflags: 'RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc"'
             setup: "sudo apt-get install -y gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu"
           - host: windows-latest
             target: x86_64-pc-windows-gnu
-            lib-cache-key: turbo-lib-cross
+            lib-cache-key: turbo-lib-cross-${{ inputs.release_branch }}
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build_rust.yml
+++ b/.github/workflows/build_rust.yml
@@ -45,17 +45,17 @@ jobs:
           toolchain: nightly-2022-09-23
           target: ${{ matrix.settings.target }}
 
-      - name: Cache cargo registry
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo/registry
-          key: ${{ matrix.settings.target }}-cargo-registry
+      # - name: Cache cargo registry
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ~/.cargo/registry
+      #     key: ${{ matrix.settings.target }}-cargo-registry
 
-      - name: Cache cargo index
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo/git
-          key: ${{ matrix.settings.target }}-cargo-index
+      # - name: Cache cargo index
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ~/.cargo/git
+      #     key: ${{ matrix.settings.target }}-cargo-index
 
       - name: Download artifact
         id: download-artifact

--- a/.github/workflows/build_rust.yml
+++ b/.github/workflows/build_rust.yml
@@ -105,8 +105,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: shim-${{ matrix.settings.target }}
-          # TODO: change binary name? goreleaser currently does the rename for us...
-          path: shim/target/${{ matrix.settings.target }}/release/shim*
+          path: shim/target/${{ matrix.settings.target }}/release/turbo*
 
   final-publish:
     name: "Publish To NPM"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,4 +11,7 @@
     "experimentalWorkspaceModule": true
   },
   "go.lintTool": "golangci-lint",
+  "files.associations": {
+    "libturbo.h": "c"
+  },
 }

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -22,6 +22,9 @@ GENERATED_FILES = internal/turbodprotocol/turbod.pb.go internal/turbodprotocol/t
 turbo: $(GENERATED_FILES) $(SRC_FILES) go.mod
 	CGO_ENABLED=1 go build $(GO_FLAGS) ./cmd/turbo
 
+shim: libturbo.a
+	cargo build --manifest-path ../shim/Cargo.toml
+
 libturbo.a: $(GENERATED_FILES) $(SRC_FILES) go.mod
 	go build -buildmode=c-archive -o libturbo.a  ./cmd/turbo/...
 
@@ -109,6 +112,23 @@ snapshot-turbo-darwin:
 snapshot-turbo: clean
 	goreleaser release --snapshot --rm-dist -f combined-release.yml
 
+.PHONY: snapshot-lib-turbo-darwin
+snapshot-lib-turbo-darwin:
+	goreleaser release --snapshot --rm-dist -f darwin-lib.yml
+
+.PHONY: snapshot-lib-turbo-cross
+snapshot-lib-turbo-cross:
+	goreleaser release --snapshot --rm-dist -f cross-lib.yml
+
+.PHONY: build-lib-turbo-darwin
+build-lib-turbo-darwin:
+	goreleaser release --rm-dist -f darwin-lib.yml
+
+.PHONY: build-lib-turbo-cross
+build-lib-turbo-cross:
+	goreleaser release --rm-dist -f cross-lib.yml
+
+
 .PHONY: stage-release
 stage-release: cmd/turbo/version.go
 	echo "Version: $(TURBO_VERSION)"
@@ -147,6 +167,52 @@ publish: clean build
 
 	# Publishes the native npm modules.
 	goreleaser release --rm-dist -f combined-release.yml
+
+	# Split packing from the publish step so that npm locates the correct .npmrc file.
+	npm pack $(CLI_DIR)/../packages/turbo --pack-destination=$(CLI_DIR)/../
+	npm pack $(CLI_DIR)/../packages/turbo-ignore --pack-destination=$(CLI_DIR)/../
+	npm pack $(CLI_DIR)/../packages/create-turbo --pack-destination=$(CLI_DIR)/../
+	npm pack $(CLI_DIR)/../packages/turbo-codemod --pack-destination=$(CLI_DIR)/../
+
+	# Publish the remaining JS packages in order to avoid race conditions.
+	cd $(CLI_DIR)/../
+	npm publish -ddd --tag $(TURBO_TAG) $(CLI_DIR)/../turbo-$(TURBO_VERSION).tgz
+	# npm publish -ddd --tag $(TURBO_TAG) $(CLI_DIR)/../turbo-ignore-$(TURBO_VERSION).tgz
+	npm publish -ddd --tag $(TURBO_TAG) $(CLI_DIR)/../create-turbo-$(TURBO_VERSION).tgz
+	npm publish -ddd --tag $(TURBO_TAG) $(CLI_DIR)/../turbo-codemod-$(TURBO_VERSION).tgz
+
+.PHONY: snapshot-shim
+snapshot-shim:
+	echo "Version: $(TURBO_VERSION)"
+	echo "Tag: $(TURBO_TAG)"
+
+	# Include the patch in the log.
+	git format-patch HEAD~1 --stdout | cat
+
+	npm config set --location=project "//registry.npmjs.org/:_authToken" $(NPM_TOKEN)
+
+	# Publishes the native npm modules.
+	goreleaser release --rm-dist -f combined-shim.yml --snapshot
+
+	# Split packing from the publish step so that npm locates the correct .npmrc file.
+	npm pack $(CLI_DIR)/../packages/turbo --pack-destination=$(CLI_DIR)/../
+	npm pack $(CLI_DIR)/../packages/turbo-ignore --pack-destination=$(CLI_DIR)/../
+	npm pack $(CLI_DIR)/../packages/create-turbo --pack-destination=$(CLI_DIR)/../
+	npm pack $(CLI_DIR)/../packages/turbo-codemod --pack-destination=$(CLI_DIR)/../
+
+
+.PHONY: publish-shim
+publish-shim:
+	echo "Version: $(TURBO_VERSION)"
+	echo "Tag: $(TURBO_TAG)"
+
+	# Include the patch in the log.
+	git format-patch HEAD~1 --stdout | cat
+
+	npm config set --location=project "//registry.npmjs.org/:_authToken" $(NPM_TOKEN)
+
+	# Publishes the native npm modules.
+	goreleaser release --rm-dist -f combined-shim.yml
 
 	# Split packing from the publish step so that npm locates the correct .npmrc file.
 	npm pack $(CLI_DIR)/../packages/turbo --pack-destination=$(CLI_DIR)/../

--- a/cli/combined-shim.yml
+++ b/cli/combined-shim.yml
@@ -15,7 +15,7 @@ builds:
     goamd64:
       - v1
     prebuilt:
-      path: dist-{{ .Os }}-{{ .Arch }}/shim{{ .Ext }}
+      path: dist-{{ .Os }}-{{ .Arch }}/turbo{{ .Ext }}
     hooks:
       pre:
         - cmd: ./scripts/npm-native-packages/npm-native-packages.js {{ .Os }} {{ .Arch }} {{ .Version }}

--- a/cli/combined-shim.yml
+++ b/cli/combined-shim.yml
@@ -1,0 +1,75 @@
+project_name: turbo
+
+dist: dist
+
+builds:
+  - id: turbo
+    builder: prebuilt
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    goamd64:
+      - v1
+    prebuilt:
+      path: dist-{{ .Os }}-{{ .Arch }}/shim{{ .Ext }}
+    hooks:
+      pre:
+        - cmd: ./scripts/npm-native-packages/npm-native-packages.js {{ .Os }} {{ .Arch }} {{ .Version }}
+    binary: bin/turbo
+checksum:
+  name_template: "checksums.txt"
+snapshot:
+  name_template: "{{ incpatch .Version }}"
+archives:
+  - id: github
+    name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    wrap_in_directory: true
+    replacements:
+      amd64: 64
+    format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - LICENSE
+      - README.md
+  - id: npm
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
+    wrap_in_directory: true
+    replacements:
+      amd64: 64
+    format: tar.gz
+    files:
+      - LICENSE
+      - src: "scripts/npm-native-packages/build/{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}/package.json"
+        dst: "workaround/.."
+        strip_parent: true
+      - src: "scripts/npm-native-packages/build/{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}/README.md"
+        dst: "workaround/.."
+        strip_parent: true
+      - src: "scripts/npm-native-packages/build/{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}/bin/*"
+        dst: "bin/"
+        strip_parent: true
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+release:
+  github:
+    owner: vercel
+    name: turborepo
+  ids:
+    - github
+  prerelease: auto
+  disable: true
+publishers:
+  - name: npm
+    ids:
+      - npm
+    cmd: "npm publish{{ if .Prerelease }} --tag canary{{ end }} {{ abs .ArtifactPath }}"

--- a/cli/cross-lib.yml
+++ b/cli/cross-lib.yml
@@ -1,0 +1,67 @@
+project_name: turbo
+before:
+  hooks:
+    - make compile-protos
+    - go mod tidy
+
+dist: dist-cross
+
+builds:
+  - id: turbo-linux
+    main: ./cmd/turbo
+    binary: lib/libturbo.a
+    flags:
+      - -trimpath
+      - -buildmode=c-archive
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}} -X main.builtBy=goreleaser
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    env:
+      - CGO_ENABLED=1
+    targets:
+      - linux_arm64
+      - linux_amd64
+    overrides:
+      - goos: linux
+        goarch: arm64
+        env:
+          - CC=aarch64-linux-gnu-gcc
+          - CXX=aarch64-linux-gnu-g++
+      - goos: linux
+        goarch: amd64
+        goamd64: v1
+        env:
+          - CC=x86_64-linux-gnu-gcc
+          - CXX=x86_64-linux-gnu-g++
+  - id: turbo-windows
+    main: ./cmd/turbo
+    binary: lib/turbo
+    flags:
+      - -trimpath
+      - -buildmode=c-archive
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}} -X main.builtBy=goreleaser
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    env:
+      - CGO_ENABLED=1
+    targets:
+      - windows_arm64
+      - windows_amd64
+    overrides:
+      - goos: windows
+        goarch: arm64
+        env:
+          - CC=/llvm-mingw/llvm-mingw/bin/aarch64-w64-mingw32-gcc
+          - CXX=/llvm-mingw/llvm-mingw/bin/aarch64-w64-mingw32-g++
+      - goos: windows
+        goarch: amd64
+        goamd64: v1
+        env:
+          - CC=x86_64-w64-mingw32-gcc
+          - CXX=x86_64-w64-mingw32-g++
+
+archives:
+  - format: binary
+
+release:
+  disable: true

--- a/cli/darwin-lib.yml
+++ b/cli/darwin-lib.yml
@@ -1,0 +1,29 @@
+project_name: turbo
+before:
+  hooks:
+    - make compile-protos
+    - go mod tidy
+
+dist: dist-darwin
+
+builds:
+  - id: turbo-darwin
+    main: ./cmd/turbo
+    binary: lib/libturbo.a
+    flags:
+      - -trimpath
+      - -buildmode=c-archive
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}} -X main.builtBy=goreleaser
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    env:
+      - CGO_ENABLED=1
+    targets:
+      - darwin_arm64
+      - darwin_amd64
+
+archives:
+  - format: binary
+
+release:
+  disable: true


### PR DESCRIPTION
Add workflows to:
 - build Go static library
 - build Rust shim, linking against static library

Add Makefile targets:
 - snapshot static library
 - publish static library
 - snapshot rust shim
 - publish rust shim

There are some remaining TODOs in the code, beyond verifying final published artifacts:
 - [ ] probably combine `build_rust.yml` and `build_go_lib.yml` into a single workflow.
 - [ ] consider binary rename, or decide to just let `goreleaser` do it for us