### PR TITLE
Fix typo in monorepo docs

### DIFF
--- a/docs/pages/docs/handbook/what-is-a-monorepo.mdx
+++ b/docs/pages/docs/handbook/what-is-a-monorepo.mdx
@@ -81,5 +81,5 @@ Workspaces are managed by the same CLI which [installs your dependencies](/docs/
 You'll also have a root workspace - a `package.json` in the root folder of your codebase. This is a useful place for:
 
 1. Specifying dependencies which are present across your entire monorepo
-1. Adding tasks that operate on the _whole_ monorepo, not just invidual workspaces
+1. Adding tasks that operate on the _whole_ monorepo, not just individual workspaces
 1. Adding documentation on how to use the monorepo


### PR DESCRIPTION
Small typo I noticed while reading the "[What is a monorepo](https://turborepo.org/docs/handbook/what-is-a-monorepo#the-root-workspace)" page