### PR TITLE
Revert find-up change.

### DIFF
--- a/cli/internal/packagemanager/infer_root.go
+++ b/cli/internal/packagemanager/infer_root.go
@@ -68,7 +68,7 @@ func InferRoot(directory turbopath.AbsoluteSystemPath) (turbopath.AbsoluteSystem
 	//       ii. If we're not one of the workspaces, nearestPackageJson + single.
 
 	nearestTurboJSON, findTurboJSONErr := directory.Findup("turbo.json")
-	if findTurboJSONErr != nil {
+	if nearestTurboJSON == "" || findTurboJSONErr != nil {
 		// We didn't find a turbo.json. We're in situation 2 or 3.
 
 		// Unroll the first loop for Scenario 2
@@ -77,7 +77,7 @@ func InferRoot(directory turbopath.AbsoluteSystemPath) (turbopath.AbsoluteSystem
 		// If we fail to find any package.json files we aren't in single package mode.
 		// We let things go through our existing failure paths.
 		// Scenario 2A.
-		if nearestPackageJSONErr != nil {
+		if nearestPackageJSON == "" || nearestPackageJSONErr != nil {
 			return directory, Multi
 		}
 
@@ -97,7 +97,7 @@ func InferRoot(directory turbopath.AbsoluteSystemPath) (turbopath.AbsoluteSystem
 		cursor := nearestPackageJSON.Dir().UntypedJoin("..")
 		for {
 			nextPackageJSON, nextPackageJSONErr := cursor.Findup("package.json")
-			if nextPackageJSONErr != nil {
+			if nextPackageJSON == "" || nextPackageJSONErr != nil {
 				// We haven't found a parent defining workspaces.
 				// So we're single package mode at nearestPackageJson.
 				// Scenario 3A.

--- a/cli/internal/turbopath/absolute_system_path.go
+++ b/cli/internal/turbopath/absolute_system_path.go
@@ -83,21 +83,10 @@ func (p AbsoluteSystemPath) Stat() (os.FileInfo, error) {
 
 // Findup checks all parent directories for a file.
 func (p AbsoluteSystemPath) Findup(name RelativeSystemPath) (AbsoluteSystemPath, error) {
-	root := AbsoluteSystemPath(p.VolumeName() + string(os.PathSeparator))
-	checking := p
+	path, err := FindupFrom(name.ToString(), p.ToString())
 
-	for checking != root {
-		targetPath := checking.Join(name)
-		fileInfo, _ := targetPath.Stat()
+	return AbsoluteSystemPath(path), err
 
-		if fileInfo != nil {
-			return targetPath, nil
-		}
-
-		checking = checking.Join("..")
-	}
-
-	return "", os.ErrNotExist
 }
 
 // Exists returns true if the given path exists.

--- a/cli/internal/turbopath/absolute_system_path_test.go
+++ b/cli/internal/turbopath/absolute_system_path_test.go
@@ -130,7 +130,7 @@ func TestAbsoluteSystemPath_Findup(t *testing.T) {
 			},
 			executionDirectory: AnchoredUnixPath("one/two/three/four").ToSystemPath(),
 			fileName:           RelativeUnixPath(".nonexistent").ToSystemPath(),
-			wantErr:            true,
+			want:               "",
 		},
 	}
 	for _, tt := range tests {
@@ -147,7 +147,7 @@ func TestAbsoluteSystemPath_Findup(t *testing.T) {
 				assert.ErrorIs(t, err, os.ErrNotExist)
 				return
 			}
-			if got != tt.want.RestoreAnchor(fsRoot) {
+			if got != "" && got != tt.want.RestoreAnchor(fsRoot) {
 				t.Errorf("AbsoluteSystemPath.Findup() = %v, want %v", got, tt.want)
 			}
 		})

--- a/cli/internal/turbopath/find_up.go
+++ b/cli/internal/turbopath/find_up.go
@@ -1,0 +1,55 @@
+package turbopath
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+type readDir func(string) ([]os.FileInfo, error)
+
+var defaultReadDir readDir = ioutil.ReadDir
+
+func hasFile(name, dir string, readdir readDir) (bool, error) {
+	files, err := readdir(dir)
+
+	if err != nil {
+		return false, err
+	}
+
+	for _, f := range files {
+		if name == f.Name() {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func findupFrom(name, dir string, readdir readDir) (string, error) {
+	for {
+		found, err := hasFile(name, dir, readdir)
+
+		if err != nil {
+			return "", err
+		}
+
+		if found {
+			return filepath.Join(dir, name), nil
+		}
+
+		parent := filepath.Dir(dir)
+
+		if parent == dir {
+			return "", nil
+		}
+
+		dir = parent
+	}
+}
+
+// Recursively find a file by walking up parents in the file tree
+// starting from a specific directory.
+func FindupFrom(name, dir string) (string, error) {
+	return findupFrom(name, dir, defaultReadDir)
+}


### PR DESCRIPTION
This reverts the changes to find-up and reuses the previous known-good implementation.

Fixes #2296