### PR TITLE
chore(readme): fix typo

### DIFF
--- a/examples/with-tailwind/README.md
+++ b/examples/with-tailwind/README.md
@@ -47,7 +47,7 @@ This Turborepo has some additional tools already setup for you:
 Run the following command:
 
 ```sh
-npx degit vercel/turborepo/examples/with-tailwind with-tailwind
+npx degit vercel/turbo/examples/with-tailwind with-tailwind
 cd with-tailwind
 yarn install
 git init . && git add . && git commit -m "Init"


### PR DESCRIPTION
There is a typo in the degit command that results in an empty `with-tailwind` directory. This is because `degit` is looking for `vercel/turborepo` when it should be looking at `vercel/turbo`.