### PR TITLE
[turbopack] Node version guard

### DIFF
--- a/crates/turbopack-core/src/environment.rs
+++ b/crates/turbopack-core/src/environment.rs
@@ -214,7 +214,7 @@ impl NodeJsEnvironmentVc {
 
         if version < default_version {
             return Err(anyhow!(format!(
-                "Node.js version should be above {DEFAULT_NODEJS_VERSION}"
+                "Node.js version should be above or equal to {DEFAULT_NODEJS_VERSION}"
             )));
         }
 

--- a/crates/turbopack-core/src/environment.rs
+++ b/crates/turbopack-core/src/environment.rs
@@ -207,10 +207,19 @@ impl NodeJsEnvironmentVc {
         }
         .await?;
 
+        let version =
+            Version::from_str(&str).map_err(|_| anyhow!("Node.js version parse error"))?;
+
+        let default_version = Version::from_str(&DEFAULT_NODEJS_VERSION).unwrap();
+
+        if version < default_version {
+            return Err(anyhow!(format!(
+                "Node.js version should be above {DEFAULT_NODEJS_VERSION}"
+            )));
+        }
+
         Ok(RuntimeVersionsVc::cell(Versions {
-            node: Some(
-                Version::from_str(&str).map_err(|_| anyhow!("Node.js version parse error"))?,
-            ),
+            node: Some(version),
             ..Default::default()
         }))
     }


### PR DESCRIPTION
Closes #2336 

This patch adds a node version check to prevent users from using a version below the minimum supported node version.

PS: I am not sure where to put the requirement note within the docs and how I can add a test for this. Thanks :)