### PR TITLE
Unmark @next/font/google as unsupported and move feature to gate @next/font/local only

### DIFF
--- a/crates/next-core/Cargo.toml
+++ b/crates/next-core/Cargo.toml
@@ -34,4 +34,4 @@ turbopack-node = { path = "../turbopack-node" }
 turbo-tasks-build = { path = "../turbo-tasks-build" }
 
 [features]
-next-font = []
+next-font-local = []

--- a/crates/next-dev/Cargo.toml
+++ b/crates/next-dev/Cargo.toml
@@ -29,7 +29,7 @@ tokio_console = [
 ]
 profile = []
 custom_allocator = ["turbo-malloc/custom_allocator"]
-next-font = ["next-core/next-font"]
+next-font-local = ["next-core/next-font-local"]
 
 [dependencies]
 anyhow = "1.0.47"

--- a/crates/turbopack-ecmascript/src/transform/mod.rs
+++ b/crates/turbopack-ecmascript/src/transform/mod.rs
@@ -8,6 +8,7 @@ use swc_core::{
     common::{chain, util::take::Take, FileName, Mark, SourceMap},
     ecma::{
         ast::{Module, ModuleItem, Program},
+        atoms::JsWord,
         preset_env::{self, Targets},
         transforms::{
             base::{feature::FeatureFlag, helpers::inject_helpers, resolver, Assumptions},
@@ -16,7 +17,7 @@ use swc_core::{
         visit::{FoldWith, VisitMutWith},
     },
 };
-use turbo_tasks::primitives::StringVc;
+use turbo_tasks::primitives::{StringVc, StringsVc};
 use turbopack_core::environment::EnvironmentVc;
 
 use self::server_to_client_proxy::{create_proxy_module, is_client_module};
@@ -35,7 +36,7 @@ pub enum EcmascriptInputTransform {
     ///
     /// It also provides diagnostics for improper use of `getServerSideProps`.
     NextJsPageSsr,
-    NextJsFont,
+    NextJsFont(StringsVc),
     PresetEnv(EnvironmentVc),
     React {
         #[serde(default)]
@@ -181,9 +182,14 @@ impl EcmascriptInputTransform {
 
                 *program = module_program.fold_with(&mut next_ssg(eliminated_packages));
             }
-            EcmascriptInputTransform::NextJsFont => {
+            EcmascriptInputTransform::NextJsFont(font_loaders_vc) => {
+                let mut font_loaders = vec![];
+                for loader in &(*font_loaders_vc.await?) {
+                    font_loaders.push(std::convert::Into::<JsWord>::into(&**loader));
+                }
+
                 let mut next_font = next_font::next_font_loaders(next_font::Config {
-                    font_loaders: vec!["@next/font/google".into(), "@next/font/local".into()],
+                    font_loaders,
                     relative_file_path_from_root: file_name_str.into(),
                 });
 

--- a/crates/turbopack-tests/Cargo.toml
+++ b/crates/turbopack-tests/Cargo.toml
@@ -14,7 +14,7 @@ turbopack = { path = "../turbopack" }
 
 [dev-dependencies]
 anyhow = "1.0.47"
-next-core = { path = "../next-core", features = ["next-font"] }
+next-core = { path = "../next-core" }
 once_cell = "1.13.0"
 serde = "1.0.136"
 serde_json = "1.0.85"

--- a/crates/turbopack/src/lib.rs
+++ b/crates/turbopack/src/lib.rs
@@ -63,9 +63,9 @@ use self::{
 };
 
 lazy_static! {
-    static ref UNSUPPORTED_PACKAGES: HashSet<String> =
-        ["@vercel/og".to_owned(), "@next/font".to_owned()].into();
-    static ref UNSUPPORTED_PACKAGE_PATHS: HashSet<(String, String)> = [].into();
+    static ref UNSUPPORTED_PACKAGES: HashSet<String> = ["@vercel/og".to_owned()].into();
+    static ref UNSUPPORTED_PACKAGE_PATHS: HashSet<(String, String)> =
+        [("@next/font".to_owned(), "/local".to_owned())].into();
 }
 
 #[turbo_tasks::value]


### PR DESCRIPTION
This removes the warning stating that `@next/font/google` is unsupported, as many of its features are now supported in `next-dev`.

Currently, the largest omissions are automatic fallback font creation (WEB-283) and caching font resources (WEB-288). Aside from these, `@next/font/google` works as expected in development 🎉

Test Plan
* Build a test app that uses `@next/font/google` without any compiler
  feature flags. 
* Verify that fonts and properties are present.
* Verify no warning message about `@next/font/google` being unsupported is shown.
* Add `@next/font/local` to the test app and verify a warning message
  about it is now shown.
* Compile with the `next-font-local` flag. Verify that no warning is
  shown.
