### PR TITLE
fix(docs): update eslint-plugin-turbo README

### DIFF
--- a/packages/eslint-plugin-turbo/docs/rules/no-undeclared-env-vars.md
+++ b/packages/eslint-plugin-turbo/docs/rules/no-undeclared-env-vars.md
@@ -35,7 +35,7 @@ Examples of **correct** code for this rule:
 
 ```json
 {
-  "globalDependencies": ["$MY_API_TOKEN"]
+  "globalEnv": ["MY_API_TOKEN"],
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],
@@ -55,7 +55,8 @@ Examples of **correct** code for this rule:
 {
   "pipeline": {
     "build": {
-      "dependsOn": ["^build", "$MY_API_TOKEN"],
+      "dependsOn": ["^build"],
+      "env": ["MY_API_TOKEN"],
       "outputs": ["dist/**", ".next/**"]
     },
     "lint": {


### PR DESCRIPTION
The documentation of eslint-plugin-turbo still referred to envs with the $ prefix which is deprecated