### PR TITLE
fix: Add rustls-tls as default feature

### DIFF
--- a/crates/turborepo/Cargo.toml
+++ b/crates/turborepo/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [features]
+default = ["rustls-tls"]
 native-tls = ["turborepo-lib/native-tls"]
 rustls-tls = ["turborepo-lib/rustls-tls"]
 


### PR DESCRIPTION
Might as well have this as a default feature to avoid accidental runtime errors.