### PR TITLE
enable HMR for client-side navigated pages

### DIFF
--- a/crates/next-core/js/src/entry/page-loader.ts
+++ b/crates/next-core/js/src/entry/page-loader.ts
@@ -15,4 +15,5 @@ if (module.hot) {
   module.hot.dispose(function () {
     window.__NEXT_P.push([PAGE_PATH]);
   });
+  module.hot.accept();
 }


### PR DESCRIPTION
The root level page module might not be able to HMR on its own (e. g. for MDX modules which export a `meta` object, which makes them not pure component file which opts out React Refresh), so we accept the whole loaded page.

This is safe as the page is a component.

Depends on support from the next.js router to allow updating the current page.