### PR TITLE
codespaces need permissions to next.js

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -52,5 +52,18 @@
     "docker-in-docker": "latest",
     "git": "latest",
     "github-cli": "latest"
+  },
+
+  // Add permissions to next.js to allow committing from nextpack
+  "customizations": {
+    "codespaces": {
+      "repositories": {
+        "vercel/next.js": {
+          "permissions": {
+            "contents": "write"
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
### Description

The github token needs permissions to push to next.js repo to use codespaces with nextpack
