### PR TITLE
Replace css_chunk_root_path with ProxiedAsset

### DIFF
--- a/crates/turbopack-core/src/lib.rs
+++ b/crates/turbopack-core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod ident;
 pub mod introspect;
 pub mod issue;
 pub mod plugin;
+pub mod proxied_asset;
 pub mod reference;
 pub mod reference_type;
 pub mod resolve;

--- a/crates/turbopack-core/src/proxied_asset.rs
+++ b/crates/turbopack-core/src/proxied_asset.rs
@@ -1,0 +1,51 @@
+use anyhow::Result;
+use turbo_tasks_fs::FileSystemPathVc;
+
+use crate::{
+    asset::{Asset, AssetContentVc, AssetVc},
+    ident::AssetIdentVc,
+    reference::AssetReferencesVc,
+    version::VersionedContentVc,
+};
+
+/// An [`Asset`] with an overwritten path. This is helpful to expose an asset at
+/// a different path than it was originally set up to be, e.g. to expose layout
+/// CSS chunks under the server FS instead of the output FS when rendering
+/// Next.js apps.
+#[turbo_tasks::value]
+pub struct ProxiedAsset {
+    asset: AssetVc,
+    path: FileSystemPathVc,
+}
+
+#[turbo_tasks::value_impl]
+impl ProxiedAssetVc {
+    /// Creates a new [`ProxiedAsset`] from an [`Asset`] and a path.
+    #[turbo_tasks::function]
+    pub fn new(asset: AssetVc, path: FileSystemPathVc) -> Self {
+        ProxiedAsset { asset, path }.cell()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for ProxiedAsset {
+    #[turbo_tasks::function]
+    fn ident(&self) -> AssetIdentVc {
+        AssetIdentVc::from_path(self.path)
+    }
+
+    #[turbo_tasks::function]
+    fn content(&self) -> AssetContentVc {
+        self.asset.content()
+    }
+
+    #[turbo_tasks::function]
+    fn references(&self) -> AssetReferencesVc {
+        self.asset.references()
+    }
+
+    #[turbo_tasks::function]
+    fn versioned_content(&self) -> VersionedContentVc {
+        self.asset.versioned_content()
+    }
+}

--- a/crates/turbopack-dev/src/chunking_context.rs
+++ b/crates/turbopack-dev/src/chunking_context.rs
@@ -51,11 +51,6 @@ impl DevChunkingContextBuilder {
         self
     }
 
-    pub fn css_chunk_root_path(mut self, path: FileSystemPathVc) -> Self {
-        self.context.css_chunk_root_path = Some(path);
-        self
-    }
-
     pub fn reference_chunk_source_maps(mut self, source_maps: bool) -> Self {
         self.context.reference_chunk_source_maps = source_maps;
         self
@@ -87,8 +82,6 @@ pub struct DevChunkingContext {
     chunk_root_path: FileSystemPathVc,
     /// Chunks reference source maps assets
     reference_chunk_source_maps: bool,
-    /// Css Chunks are placed at this path
-    css_chunk_root_path: Option<FileSystemPathVc>,
     /// Css chunks reference source maps assets
     reference_css_chunk_source_maps: bool,
     /// Static assets are placed at this path
@@ -115,7 +108,6 @@ impl DevChunkingContextVc {
                 output_root,
                 chunk_root_path,
                 reference_chunk_source_maps: true,
-                css_chunk_root_path: None,
                 reference_css_chunk_source_maps: true,
                 asset_root_path,
                 layer: None,
@@ -301,16 +293,7 @@ impl ChunkingContext for DevChunkingContext {
             name += "._";
         }
         name += extension;
-        let mut root_path = self.chunk_root_path;
-        #[allow(clippy::single_match, reason = "future extensions")]
-        match extension {
-            ".css" => {
-                if let Some(path) = self.css_chunk_root_path {
-                    root_path = path;
-                }
-            }
-            _ => {}
-        }
+        let root_path = self.chunk_root_path;
         let root_path = if let Some(layer) = self.layer.as_deref() {
             root_path.join(layer)
         } else {


### PR DESCRIPTION
### Description

This replaces the use case of `css_chunk_root_path` with a `ProxiedAsset`, which allows the same kind of behavior but in a more granular way: the user decides which assets are exposed under which path, instead of it being a chunking context-wide setting.

### Testing Instructions

N/A

fix #4444
link WEB-856

See https://github.com/vercel/next.js/pull/48946