### PR TITLE
Remove recursive copy build tags.

### DIFF
--- a/cli/internal/fs/recursive_copy.go
+++ b/cli/internal/fs/recursive_copy.go
@@ -1,6 +1,3 @@
-//go:build rust
-// +build rust
-
 package fs
 
 import (


### PR DESCRIPTION
#4874 didn't remove the build tags, leaving the Go build in a broken state.