### PR TITLE
Implement reusable `Module`/`OutputAsset` graph helpers

### DIFF
--- a/crates/node-file-trace/src/lib.rs
+++ b/crates/node-file-trace/src/lib.rs
@@ -638,9 +638,9 @@ async fn main_operation(
     Ok(Vc::cell(Vec::new()))
 }
 
-/// Aggregates all [Module]s referenced by an [Module]. [ModuleReference]
-/// This does not include transitively references [Module]s, but it includes
-/// primary and secondary [Module]s referenced.
+/// Aggregates all [Module]s referenced by a [Module] through [ModuleReference]s.
+/// This does not include transitively referenced [Module]s, but it includes
+/// primary and secondary referenced [Module]s.
 #[turbo_tasks::function]
 pub async fn all_referenced_modules(module: Vc<Box<dyn Module>>) -> Result<Vc<Modules>> {
     let references_set = module.references().await?;
@@ -661,7 +661,7 @@ pub async fn all_referenced_modules(module: Vc<Box<dyn Module>>) -> Result<Vc<Mo
     Ok(Vc::cell(modules))
 }
 
-/// Aggregates all [Module]s referenced by an [Module] including transitively
+/// Aggregates all [Module]s referenced by a [Module], including transitively
 /// referenced [Module]s. This basically gives all [Module]s in a subgraph
 /// starting from the passed [Module].
 #[turbo_tasks::function]

--- a/crates/turbopack-core/src/reference/mod.rs
+++ b/crates/turbopack-core/src/reference/mod.rs
@@ -168,6 +168,10 @@ pub async fn all_modules(asset: Vc<Box<dyn Module>>) -> Result<Vc<Modules>> {
     ))
 }
 
+/// Aggregates all [Module]s referenced by an [Module] including transitively
+/// referenced [Module]s, returning an Iterator of each. This function is
+/// designed to be composed into larger chains, eg mapping the output before
+/// constructing a Vc.
 pub async fn all_modules_iter(
     assets: impl Iterator<Item = Vc<Box<dyn Module>>>,
 ) -> Result<impl Iterator<Item = Vc<Box<dyn Module>>>> {
@@ -190,7 +194,7 @@ async fn get_primary_modules_helper(
         .into_iter())
 }
 
-/// Walks the asset graph from multiple assets and collect all referenced
+/// Walks the asset graph from multiple assets and collects all referenced
 /// assets.
 #[turbo_tasks::function]
 pub async fn all_assets_from_entries(entries: Vc<OutputAssets>) -> Result<Vc<OutputAssets>> {
@@ -201,6 +205,9 @@ pub async fn all_assets_from_entries(entries: Vc<OutputAssets>) -> Result<Vc<Out
     ))
 }
 
+/// Walks the asset graph from multiple assets and collects all referenced
+/// assets, returning an Iterator of each. This function is designed to be
+/// composed into larger chains, eg mapping the output before constructing a Vc.
 pub async fn all_assets_from_entries_iter(
     entries: impl Iterator<Item = Vc<Box<dyn OutputAsset>>>,
 ) -> Result<impl Iterator<Item = Vc<Box<dyn OutputAsset>>>> {

--- a/crates/turbopack/src/rebase/mod.rs
+++ b/crates/turbopack/src/rebase/mod.rs
@@ -8,7 +8,7 @@ use turbopack_core::{
     ident::AssetIdent,
     module::Module,
     output::{OutputAsset, OutputAssets},
-    reference::all_referenced_modules,
+    reference::all_modules_iter,
 };
 
 /// Converts a [Module] graph into an [OutputAsset] graph by placing it into a
@@ -50,14 +50,10 @@ impl OutputAsset for RebasedAsset {
 
     #[turbo_tasks::function]
     async fn references(&self) -> Result<Vc<OutputAssets>> {
-        let mut references = Vec::new();
-        for &module in all_referenced_modules(self.source).await?.iter() {
-            references.push(Vc::upcast(RebasedAsset::new(
-                module,
-                self.input_dir,
-                self.output_dir,
-            )));
-        }
+        let references = all_modules_iter([self.source].into_iter())
+            .await?
+            .map(|module| Vc::upcast(RebasedAsset::new(module, self.input_dir, self.output_dir)))
+            .collect();
         Ok(Vc::cell(references))
     }
 }


### PR DESCRIPTION
### Description

This does 2 things:
- Implements 2 new graph traversal iterator functions, which return perform the graph traversal but return iterators that can be further chained
- Removes `all_referenced_modules` (which traverses transitive modules despite its doc comment) because it's the same `all_modules`

I found myself reimplementing the same graph traversal to get referenced `Module`/`OutputAsset`s. I didn't want to use `all_modules`/`all_assets_from_entries` because they already collect the result into their own `Vec`. The new methods return lazy iterators, allowing you to `map`/`flat_map` and collect that result into your output.

I had to move a few functions into `node-file-trace` due to it failing for some reason.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes WEB-1385