### PR TITLE
Use a queue to early merge changes during aggregation

### DIFF
--- a/crates/turbo-tasks-memory/src/aggregation_tree/changes_queue.rs
+++ b/crates/turbo-tasks-memory/src/aggregation_tree/changes_queue.rs
@@ -1,0 +1,125 @@
+use std::{
+    borrow::Cow,
+    cmp::{max, min},
+    collections::{hash_map::RawEntryMut, HashMap},
+    hash::Hash,
+    mem::take,
+};
+
+use nohash_hasher::IsEnabled;
+
+use super::{
+    inner_refs::{BottomRef, TopRef},
+    AggregationContext,
+};
+
+fn get_in_vec<K, V>(vec: &mut Vec<HashMap<K, V>>, index: usize) -> &mut HashMap<K, V> {
+    if vec.len() <= index {
+        vec.resize_with(index + 1, || HashMap::new());
+    }
+    &mut vec[index]
+}
+
+pub struct ChangesQueue<T, I: IsEnabled, U> {
+    bottom_tree_changes: Vec<HashMap<BottomRef<T, I>, U>>,
+    first_bottom_tree_height: u8,
+    top_tree_changes: Vec<HashMap<TopRef<T>, U>>,
+    first_top_tree_depth: u8,
+}
+
+impl<T, I: Clone + Eq + Hash + IsEnabled, U: Clone> ChangesQueue<T, I, U> {
+    pub fn new() -> Self {
+        Self {
+            bottom_tree_changes: Vec::new(),
+            first_bottom_tree_height: u8::MAX,
+            top_tree_changes: Vec::new(),
+            first_top_tree_depth: 0,
+        }
+    }
+
+    pub fn add_bottom_change<C: AggregationContext<Info = T, ItemRef = I, ItemChange = U>>(
+        &mut self,
+        aggregation_context: &C,
+        bottom_ref: &BottomRef<T, I>,
+        change: Cow<'_, U>,
+    ) {
+        let height = bottom_ref.upper.height;
+        let map = get_in_vec(&mut self.bottom_tree_changes, height as usize);
+        if map.is_empty() {
+            self.first_bottom_tree_height = min(self.first_bottom_tree_height, height);
+        }
+        match map.raw_entry_mut().from_key(bottom_ref) {
+            RawEntryMut::Occupied(mut entry) => {
+                let current = entry.get_mut();
+                aggregation_context.merge_change(current, change);
+            }
+            RawEntryMut::Vacant(entry) => {
+                entry.insert(bottom_ref.clone(), change.into_owned());
+            }
+        }
+    }
+
+    pub fn add_top_change<C: AggregationContext<Info = T, ItemRef = I, ItemChange = U>>(
+        &mut self,
+        aggregation_context: &C,
+        top_ref: &TopRef<T>,
+        change: Cow<'_, U>,
+    ) {
+        let depth = top_ref.upper.depth;
+        let map = get_in_vec(&mut self.top_tree_changes, depth as usize);
+        if map.is_empty() {
+            self.first_top_tree_depth = max(self.first_top_tree_depth, depth);
+        }
+        match map.raw_entry_mut().from_key(top_ref) {
+            RawEntryMut::Occupied(mut entry) => {
+                let current = entry.get_mut();
+                aggregation_context.merge_change(current, change);
+            }
+            RawEntryMut::Vacant(entry) => {
+                entry.insert(top_ref.clone(), change.into_owned());
+            }
+        }
+    }
+
+    pub fn apply_changes<C: AggregationContext<Info = T, ItemRef = I, ItemChange = U>>(
+        &mut self,
+        aggregation_context: &C,
+    ) {
+        while self.first_bottom_tree_height < self.bottom_tree_changes.len() as u8 {
+            let map = &mut self.bottom_tree_changes[self.first_bottom_tree_height as usize];
+            self.first_bottom_tree_height += 1;
+            for (bottom_ref, change) in take(map) {
+                let bottom_tree = &bottom_ref.upper;
+                bottom_tree.apply_change(aggregation_context, self, &change);
+            }
+        }
+        if !self.top_tree_changes.is_empty() {
+            loop {
+                let map = &mut self.top_tree_changes[self.first_top_tree_depth as usize];
+                if self.first_top_tree_depth == 0 {
+                    if map.is_empty() {
+                        break;
+                    }
+                } else {
+                    self.first_top_tree_depth -= 1;
+                }
+                for (top_ref, change) in take(map) {
+                    let top_tree = &top_ref.upper;
+                    top_tree.apply_change(aggregation_context, self, &change);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(debug_assertions)]
+impl<T, I: IsEnabled, U> Drop for ChangesQueue<T, I, U> {
+    fn drop(&mut self) {
+        if self.first_bottom_tree_height < self.bottom_tree_changes.len() as u8 {
+            panic!("ChangesQueue was dropped without applying all changes");
+        }
+        if self.first_top_tree_depth != 0 {
+            panic!("ChangesQueue was dropped without applying all changes");
+        }
+    }
+}

--- a/crates/turbo-tasks-memory/src/aggregation_tree/changes_queue.rs
+++ b/crates/turbo-tasks-memory/src/aggregation_tree/changes_queue.rs
@@ -3,7 +3,7 @@ use std::{
     cmp::{max, min},
     collections::{hash_map::RawEntryMut, HashMap},
     hash::Hash,
-    mem::take,
+    mem::{replace, take},
 };
 
 use nohash_hasher::IsEnabled;
@@ -21,19 +21,87 @@ fn get_in_vec<K, V>(vec: &mut Vec<HashMap<K, V>>, index: usize) -> &mut HashMap<
 }
 
 pub struct ChangesQueue<T, I: IsEnabled, U> {
-    bottom_tree_changes: Vec<HashMap<BottomRef<T, I>, U>>,
-    first_bottom_tree_height: u8,
-    top_tree_changes: Vec<HashMap<TopRef<T>, U>>,
-    first_top_tree_depth: u8,
+    inner: ChangesQueueInner<T, I, U>,
+}
+
+enum ChangesQueueInner<T, I: IsEnabled, U> {
+    Empty,
+    BottomTreeChange {
+        bottom_ref: BottomRef<T, I>,
+        change: U,
+    },
+    TopTreeChange {
+        top_ref: TopRef<T>,
+        change: U,
+    },
+    Queue {
+        bottom_tree_changes: Vec<HashMap<BottomRef<T, I>, U>>,
+        first_bottom_tree_height: u8,
+        top_tree_changes: Vec<HashMap<TopRef<T>, U>>,
+        first_top_tree_depth: u8,
+    },
+}
+
+fn add_to_bottom_queue<
+    C: AggregationContext<Info = T, ItemRef = I, ItemChange = U>,
+    T,
+    I: IsEnabled,
+    U: Clone,
+>(
+    aggregation_context: &C,
+    bottom_tree_changes: &mut Vec<HashMap<BottomRef<T, I>, U>>,
+    first_bottom_tree_height: &mut u8,
+    bottom_ref: &BottomRef<T, I>,
+    change: Cow<'_, U>,
+) {
+    let height = bottom_ref.upper.height;
+    let map = get_in_vec(bottom_tree_changes, height as usize);
+    if map.is_empty() {
+        *first_bottom_tree_height = min(*first_bottom_tree_height, height);
+    }
+    match map.raw_entry_mut().from_key(bottom_ref) {
+        RawEntryMut::Occupied(mut entry) => {
+            let current = entry.get_mut();
+            aggregation_context.merge_change(current, change);
+        }
+        RawEntryMut::Vacant(entry) => {
+            entry.insert(bottom_ref.clone(), change.into_owned());
+        }
+    }
+}
+
+fn add_to_top_queue<
+    C: AggregationContext<Info = T, ItemRef = I, ItemChange = U>,
+    T,
+    I: IsEnabled,
+    U: Clone,
+>(
+    aggregation_context: &C,
+    top_tree_changes: &mut Vec<HashMap<TopRef<T>, U>>,
+    first_top_tree_depth: &mut u8,
+    top_ref: &TopRef<T>,
+    change: Cow<'_, U>,
+) {
+    let depth = top_ref.upper.depth;
+    let map = get_in_vec(top_tree_changes, depth as usize);
+    if map.is_empty() {
+        *first_top_tree_depth = max(*first_top_tree_depth, depth);
+    }
+    match map.raw_entry_mut().from_key(top_ref) {
+        RawEntryMut::Occupied(mut entry) => {
+            let current = entry.get_mut();
+            aggregation_context.merge_change(current, change);
+        }
+        RawEntryMut::Vacant(entry) => {
+            entry.insert(top_ref.clone(), change.into_owned());
+        }
+    }
 }
 
 impl<T, I: Clone + Eq + Hash + IsEnabled, U: Clone> ChangesQueue<T, I, U> {
     pub fn new() -> Self {
         Self {
-            bottom_tree_changes: Vec::new(),
-            first_bottom_tree_height: u8::MAX,
-            top_tree_changes: Vec::new(),
-            first_top_tree_depth: 0,
+            inner: ChangesQueueInner::Empty,
         }
     }
 
@@ -43,18 +111,82 @@ impl<T, I: Clone + Eq + Hash + IsEnabled, U: Clone> ChangesQueue<T, I, U> {
         bottom_ref: &BottomRef<T, I>,
         change: Cow<'_, U>,
     ) {
-        let height = bottom_ref.upper.height;
-        let map = get_in_vec(&mut self.bottom_tree_changes, height as usize);
-        if map.is_empty() {
-            self.first_bottom_tree_height = min(self.first_bottom_tree_height, height);
-        }
-        match map.raw_entry_mut().from_key(bottom_ref) {
-            RawEntryMut::Occupied(mut entry) => {
-                let current = entry.get_mut();
-                aggregation_context.merge_change(current, change);
+        match &mut self.inner {
+            ChangesQueueInner::Empty => {
+                self.inner = ChangesQueueInner::BottomTreeChange {
+                    bottom_ref: bottom_ref.clone(),
+                    change: change.into_owned(),
+                };
             }
-            RawEntryMut::Vacant(entry) => {
-                entry.insert(bottom_ref.clone(), change.into_owned());
+            ChangesQueueInner::BottomTreeChange {
+                bottom_ref: old_bottom_ref,
+                change: old_change,
+            } => {
+                let mut bottom_tree_changes = Vec::new();
+                let mut first_bottom_tree_height = u8::MAX;
+                add_to_bottom_queue(
+                    aggregation_context,
+                    &mut bottom_tree_changes,
+                    &mut first_bottom_tree_height,
+                    old_bottom_ref,
+                    Cow::Borrowed(&*old_change),
+                );
+                add_to_bottom_queue(
+                    aggregation_context,
+                    &mut bottom_tree_changes,
+                    &mut first_bottom_tree_height,
+                    bottom_ref,
+                    change,
+                );
+                self.inner = ChangesQueueInner::Queue {
+                    bottom_tree_changes,
+                    first_bottom_tree_height,
+                    top_tree_changes: Vec::new(),
+                    first_top_tree_depth: 0,
+                };
+            }
+            ChangesQueueInner::TopTreeChange {
+                top_ref,
+                change: old_change,
+            } => {
+                let mut bottom_tree_changes = Vec::new();
+                let mut first_bottom_tree_height = u8::MAX;
+                let mut top_tree_changes = Vec::new();
+                let mut first_top_tree_depth = 0;
+                add_to_top_queue(
+                    aggregation_context,
+                    &mut top_tree_changes,
+                    &mut first_top_tree_depth,
+                    top_ref,
+                    Cow::Borrowed(&*old_change),
+                );
+                add_to_bottom_queue(
+                    aggregation_context,
+                    &mut bottom_tree_changes,
+                    &mut first_bottom_tree_height,
+                    bottom_ref,
+                    change,
+                );
+                self.inner = ChangesQueueInner::Queue {
+                    bottom_tree_changes,
+                    first_bottom_tree_height,
+                    top_tree_changes,
+                    first_top_tree_depth,
+                };
+            }
+            ChangesQueueInner::Queue {
+                bottom_tree_changes,
+                first_bottom_tree_height,
+                top_tree_changes: _,
+                first_top_tree_depth: _,
+            } => {
+                add_to_bottom_queue(
+                    aggregation_context,
+                    bottom_tree_changes,
+                    first_bottom_tree_height,
+                    bottom_ref,
+                    change,
+                );
             }
         }
     }
@@ -65,18 +197,82 @@ impl<T, I: Clone + Eq + Hash + IsEnabled, U: Clone> ChangesQueue<T, I, U> {
         top_ref: &TopRef<T>,
         change: Cow<'_, U>,
     ) {
-        let depth = top_ref.upper.depth;
-        let map = get_in_vec(&mut self.top_tree_changes, depth as usize);
-        if map.is_empty() {
-            self.first_top_tree_depth = max(self.first_top_tree_depth, depth);
-        }
-        match map.raw_entry_mut().from_key(top_ref) {
-            RawEntryMut::Occupied(mut entry) => {
-                let current = entry.get_mut();
-                aggregation_context.merge_change(current, change);
+        match &mut self.inner {
+            ChangesQueueInner::Empty => {
+                self.inner = ChangesQueueInner::TopTreeChange {
+                    top_ref: top_ref.clone(),
+                    change: change.into_owned(),
+                };
             }
-            RawEntryMut::Vacant(entry) => {
-                entry.insert(top_ref.clone(), change.into_owned());
+            ChangesQueueInner::BottomTreeChange {
+                bottom_ref,
+                change: old_change,
+            } => {
+                let mut bottom_tree_changes = Vec::new();
+                let mut first_bottom_tree_height = u8::MAX;
+                let mut top_tree_changes = Vec::new();
+                let mut first_top_tree_depth = 0;
+                add_to_bottom_queue(
+                    aggregation_context,
+                    &mut bottom_tree_changes,
+                    &mut first_bottom_tree_height,
+                    bottom_ref,
+                    Cow::Borrowed(&*old_change),
+                );
+                add_to_top_queue(
+                    aggregation_context,
+                    &mut top_tree_changes,
+                    &mut first_top_tree_depth,
+                    top_ref,
+                    change,
+                );
+                self.inner = ChangesQueueInner::Queue {
+                    bottom_tree_changes,
+                    first_bottom_tree_height,
+                    top_tree_changes,
+                    first_top_tree_depth,
+                };
+            }
+            ChangesQueueInner::TopTreeChange {
+                top_ref: old_top_ref,
+                change: old_change,
+            } => {
+                let mut top_tree_changes = Vec::new();
+                let mut first_top_tree_depth = 0;
+                add_to_top_queue(
+                    aggregation_context,
+                    &mut top_tree_changes,
+                    &mut first_top_tree_depth,
+                    old_top_ref,
+                    Cow::Borrowed(&*old_change),
+                );
+                add_to_top_queue(
+                    aggregation_context,
+                    &mut top_tree_changes,
+                    &mut first_top_tree_depth,
+                    top_ref,
+                    change,
+                );
+                self.inner = ChangesQueueInner::Queue {
+                    bottom_tree_changes: Vec::new(),
+                    first_bottom_tree_height: u8::MAX,
+                    top_tree_changes,
+                    first_top_tree_depth,
+                };
+            }
+            ChangesQueueInner::Queue {
+                bottom_tree_changes: _,
+                first_bottom_tree_height: _,
+                top_tree_changes,
+                first_top_tree_depth,
+            } => {
+                add_to_top_queue(
+                    aggregation_context,
+                    top_tree_changes,
+                    first_top_tree_depth,
+                    top_ref,
+                    change,
+                );
             }
         }
     }
@@ -85,27 +281,56 @@ impl<T, I: Clone + Eq + Hash + IsEnabled, U: Clone> ChangesQueue<T, I, U> {
         &mut self,
         aggregation_context: &C,
     ) {
-        while self.first_bottom_tree_height < self.bottom_tree_changes.len() as u8 {
-            let map = &mut self.bottom_tree_changes[self.first_bottom_tree_height as usize];
-            self.first_bottom_tree_height += 1;
-            for (bottom_ref, change) in take(map) {
-                let bottom_tree = &bottom_ref.upper;
-                bottom_tree.apply_change(aggregation_context, self, &change);
-            }
-        }
-        if !self.top_tree_changes.is_empty() {
-            loop {
-                let map = &mut self.top_tree_changes[self.first_top_tree_depth as usize];
-                if self.first_top_tree_depth == 0 {
-                    if map.is_empty() {
-                        break;
+        loop {
+            if let ChangesQueueInner::Queue {
+                bottom_tree_changes,
+                first_bottom_tree_height,
+                top_tree_changes,
+                first_top_tree_depth,
+            } = &mut self.inner
+            {
+                if *first_bottom_tree_height < bottom_tree_changes.len() as u8 {
+                    let map = take(&mut bottom_tree_changes[*first_bottom_tree_height as usize]);
+                    *first_bottom_tree_height += 1;
+                    for (bottom_ref, change) in map {
+                        let bottom_tree = &bottom_ref.upper;
+                        bottom_tree.apply_change(aggregation_context, self, &change);
                     }
-                } else {
-                    self.first_top_tree_depth -= 1;
+                } else if top_tree_changes.is_empty() {
+                    self.inner = ChangesQueueInner::Empty;
+                    return;
+                } else if *first_top_tree_depth < top_tree_changes.len() as u8 {
+                    let map = take(&mut top_tree_changes[*first_top_tree_depth as usize]);
+                    if *first_top_tree_depth == 0 {
+                        if map.is_empty() {
+                            self.inner = ChangesQueueInner::Empty;
+                            return;
+                        }
+                    } else {
+                        *first_top_tree_depth -= 1;
+                    }
+
+                    for (top_ref, change) in map {
+                        let top_tree = &top_ref.upper;
+                        top_tree.apply_change(aggregation_context, self, &change);
+                    }
                 }
-                for (top_ref, change) in take(map) {
-                    let top_tree = &top_ref.upper;
-                    top_tree.apply_change(aggregation_context, self, &change);
+            } else {
+                match replace(&mut self.inner, ChangesQueueInner::Empty) {
+                    ChangesQueueInner::Empty => {
+                        return;
+                    }
+                    ChangesQueueInner::BottomTreeChange { bottom_ref, change } => {
+                        bottom_ref
+                            .upper
+                            .apply_change(aggregation_context, self, &change);
+                    }
+                    ChangesQueueInner::TopTreeChange { top_ref, change } => {
+                        top_ref
+                            .upper
+                            .apply_change(aggregation_context, self, &change);
+                    }
+                    ChangesQueueInner::Queue { .. } => unreachable!(),
                 }
             }
         }
@@ -115,11 +340,8 @@ impl<T, I: Clone + Eq + Hash + IsEnabled, U: Clone> ChangesQueue<T, I, U> {
 #[cfg(debug_assertions)]
 impl<T, I: IsEnabled, U> Drop for ChangesQueue<T, I, U> {
     fn drop(&mut self) {
-        if self.first_bottom_tree_height < self.bottom_tree_changes.len() as u8 {
-            panic!("ChangesQueue was dropped without applying all changes");
-        }
-        if self.first_top_tree_depth != 0 {
-            panic!("ChangesQueue was dropped without applying all changes");
+        if !matches!(self.inner, ChangesQueueInner::Empty) {
+            panic!("ChangesQueue::apply_changes was not called");
         }
     }
 }

--- a/crates/turbo-tasks-memory/src/aggregation_tree/tests.rs
+++ b/crates/turbo-tasks-memory/src/aggregation_tree/tests.rs
@@ -25,7 +25,7 @@ impl Node {
         guard.value += 10000;
         guard
             .aggregation_leaf
-            .change(aggregation_context, &Change { value: 10000 });
+            .change(aggregation_context, Change { value: 10000 });
     }
 }
 
@@ -155,6 +155,13 @@ impl<'a> AggregationContext for NodeAggregationContext<'a> {
             info.value += change.value;
         }
         Some(*change)
+    }
+
+    fn merge_change(&self, current: &mut Change, change: Cow<'_, Change>) {
+        if current.value != 0 {
+            self.additions.fetch_add(1, Ordering::SeqCst);
+        }
+        current.value += change.value;
     }
 
     fn info_to_add_change(&self, info: &Self::Info) -> Option<Self::ItemChange> {

--- a/crates/turbo-tasks-memory/src/aggregation_tree/utils.rs
+++ b/crates/turbo-tasks-memory/src/aggregation_tree/utils.rs
@@ -1,0 +1,16 @@
+pub fn get_or_create_in_vec<T>(
+    vec: &mut Vec<Option<T>>,
+    index: usize,
+    create: impl FnOnce() -> T,
+) -> (&mut T, bool) {
+    if vec.len() <= index {
+        vec.resize_with(index + 1, || None);
+    }
+    let item = &mut vec[index];
+    if item.is_none() {
+        *item = Some(create());
+        (item.as_mut().unwrap(), true)
+    } else {
+        (item.as_mut().unwrap(), false)
+    }
+}

--- a/crates/turbo-tasks-memory/src/lib.rs
+++ b/crates/turbo-tasks-memory/src/lib.rs
@@ -5,6 +5,7 @@
 #![feature(box_patterns)]
 #![feature(int_roundings)]
 #![feature(impl_trait_in_assoc_type)]
+#![feature(hash_raw_entry)]
 #![deny(unsafe_op_in_unsafe_fn)]
 
 mod aggregation_tree;


### PR DESCRIPTION
### Description

This uses a ChangesQueue to aggregate changes in the aggregation tree in a breath-first order. The queue also merges changes to the same node early on and avoids bubbling up multiple changes along a whole branch.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
