### PR TITLE
resolve fully_specified in a strict esm context

### DIFF
--- a/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -1,3 +1,5 @@
+use core::str;
+
 use anyhow::{anyhow, bail, Result};
 use lazy_static::lazy_static;
 use swc_core::{
@@ -95,6 +97,7 @@ pub struct EsmAssetReference {
     pub issue_source: Option<Vc<IssueSource>>,
     pub export_name: Option<Vc<ModulePart>>,
     pub import_externals: bool,
+    pub strict: bool,
 }
 
 /// A list of [EsmAssetReference]s
@@ -121,6 +124,7 @@ impl EsmAssetReference {
         annotations: Value<ImportAnnotations>,
         export_name: Option<Vc<ModulePart>>,
         import_externals: bool,
+        strict: bool,
     ) -> Vc<Self> {
         Self::cell(EsmAssetReference {
             origin,
@@ -129,6 +133,7 @@ impl EsmAssetReference {
             annotations: annotations.into_value(),
             export_name,
             import_externals,
+            strict,
         })
     }
 
@@ -151,6 +156,7 @@ impl ModuleReference for EsmAssetReference {
             self.get_origin().resolve().await?,
             self.request,
             ty,
+            self.strict,
             IssueSeverity::Error.cell(),
             self.issue_source,
         ))

--- a/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/crates/turbopack-ecmascript/src/references/mod.rs
@@ -337,6 +337,7 @@ struct AnalysisState<'a> {
     first_import_meta: bool,
     tree_shaking_mode: Option<TreeShakingMode>,
     import_externals: bool,
+    strict_esm: bool,
 }
 
 impl<'a> AnalysisState<'a> {
@@ -411,6 +412,8 @@ pub(crate) async fn analyse_ecmascript_module_internal(
         module_type: specified_type,
         referenced_package_json,
     } = *module.determine_module_type().await?;
+
+    let strict_esm = matches!(specified_type, SpecifiedModuleType::EcmaScript);
 
     if let Some(package_json) = referenced_package_json {
         analysis.add_reference(PackageJsonReference::new(package_json));
@@ -552,6 +555,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
                 None => None,
             },
             import_externals,
+            strict_esm,
         );
         import_references.push(r);
     }
@@ -774,6 +778,7 @@ pub(crate) async fn analyse_ecmascript_module_internal(
         first_import_meta: true,
         tree_shaking_mode: options.tree_shaking_mode,
         import_externals: options.import_externals,
+        strict_esm,
     };
 
     enum Action {
@@ -1195,6 +1200,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                     issue_source(source, span),
                     in_try,
                     state.import_externals,
+                    state.strict_esm,
                 ));
                 return Ok(());
             }
@@ -1893,6 +1899,7 @@ async fn handle_free_var_reference(
                     None => None,
                 },
                 state.import_externals,
+                state.strict_esm,
             )
             .resolve()
             .await?;


### PR DESCRIPTION
### Description

This resolves fully specified in a strict ESM context (`type: module`, mjs).

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->


Closes PACK-2631