### PR TITLE
fix: add extra detail to summary showing items from remote cache

### DIFF
--- a/crates/turborepo-cache/src/lib.rs
+++ b/crates/turborepo-cache/src/lib.rs
@@ -86,7 +86,7 @@ impl From<turborepo_api_client::Error> for CacheError {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Copy)]
+#[derive(Debug, Clone, PartialEq, Copy, Serialize)]
 pub enum CacheSource {
     Local,
     Remote,

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -12,6 +12,7 @@ use regex::Regex;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, error, Instrument, Span};
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPath};
+use turborepo_cache::CacheSource;
 use turborepo_ci::{Vendor, VendorBehavior};
 use turborepo_env::{EnvironmentVariableMap, ResolvedEnvMode};
 use turborepo_repository::{
@@ -663,7 +664,8 @@ enum ExecOutcome {
 }
 
 enum SuccessOutcome {
-    CacheHit,
+    /// The task was a cache hit, from the given source
+    CacheHit(CacheSource),
     Run,
 }
 
@@ -709,7 +711,7 @@ impl ExecContext {
         match result {
             ExecOutcome::Success(outcome) => {
                 let task_summary = match outcome {
-                    SuccessOutcome::CacheHit => tracker.cached().await,
+                    SuccessOutcome::CacheHit(source) => tracker.cached(source).await,
                     SuccessOutcome::Run => tracker.build_succeeded(0).await,
                 };
                 callback.send(Ok(())).ok();
@@ -784,7 +786,7 @@ impl ExecContext {
                 );
                 self.hash_tracker
                     .insert_cache_status(self.task_id.clone(), status);
-                return ExecOutcome::Success(SuccessOutcome::CacheHit);
+                return ExecOutcome::Success(SuccessOutcome::CacheHit(status.source));
             }
             Ok(None) => (),
             Err(e) => {

--- a/turborepo-tests/integration/tests/run-summary/error.t
+++ b/turborepo-tests/integration/tests/run-summary/error.t
@@ -20,6 +20,7 @@ Validate that there was a failed task and exitCode is 1 (which is what we get fr
     "success": 0,
     "failed": 1,
     "cached": 0,
+    "cachedRemote": 0,
     "attempted": 1,
     "startTime": [0-9]+, (re)
     "endTime": [0-9]+, (re)
@@ -102,6 +103,7 @@ success should be 1, and attempted should be 2
     "success": 1,
     "failed": 1,
     "cached": 0,
+    "cachedRemote": 0,
     "attempted": 2,
     "startTime": [0-9]+, (re)
     "endTime": [0-9]+, (re)

--- a/turborepo-tests/integration/tests/run-summary/single-package.t
+++ b/turborepo-tests/integration/tests/run-summary/single-package.t
@@ -19,6 +19,7 @@ Check
   [
     "attempted",
     "cached",
+    "cachedRemote",
     "command",
     "endTime",
     "exitCode",
@@ -130,6 +131,7 @@ Check Rust implementation
   [
     "attempted",
     "cached",
+    "cachedRemote",
     "command",
     "endTime",
     "exitCode",


### PR DESCRIPTION
### Description

A quick fix that closes https://github.com/vercel/turbo/issues/2129

It adds a small additional UI when tasks are loaded from the remote
cache. Tasks that were not fetched from cache do not have the extra
annotation and retain the original formatting.

### Testing Instructions

Run a build with remote cache set up:

 Tasks:    0 successful, 2 total
Cached:    2 (of which 2 remote) cached, 2 total
  Time:    1.141s

Run another build:

 Tasks:    0 successful, 2 total
Cached:    2 cached, 2 total
  Time:    1.141s


Closes TURBO-2590