### PR TITLE
feat(turborepo): pass through arguments only for root tasks

### DIFF
--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -8,7 +8,6 @@ use crate::{
     cli::{
         Command, DryRunMode, EnvMode, ExecutionArgs, LogOrder, LogPrefix, OutputLogsMode, RunArgs,
     },
-    run::task_id::TaskId,
     Args,
 };
 
@@ -155,21 +154,6 @@ pub struct RunOpts {
     pub summarize: Option<Option<bool>>,
     pub(crate) experimental_space_id: Option<String>,
     pub is_github_actions: bool,
-}
-
-impl RunOpts {
-    pub fn args_for_task(&self, task_id: &TaskId) -> Option<Vec<String>> {
-        if !self.pass_through_args.is_empty()
-            && self
-                .tasks
-                .iter()
-                .any(|task| task.as_str() == task_id.task())
-        {
-            Some(self.pass_through_args.clone())
-        } else {
-            None
-        }
-    }
 }
 
 #[derive(Debug)]

--- a/crates/turborepo-lib/src/run/summary/task_factory.rs
+++ b/crates/turborepo-lib/src/run/summary/task_factory.rs
@@ -159,7 +159,7 @@ impl<'a> TaskSummaryFactory<'a> {
             ),
             cache: cache_summary,
             command,
-            cli_arguments: self.run_opts.pass_through_args.to_vec(),
+            cli_arguments: self.run_opts.args_for_task(&task_id).unwrap_or(vec![]),
             outputs: match task_definition.outputs.inclusions.is_empty() {
                 false => Some(task_definition.outputs.inclusions.clone()),
                 true => None,

--- a/crates/turborepo-lib/src/run/summary/task_factory.rs
+++ b/crates/turborepo-lib/src/run/summary/task_factory.rs
@@ -141,6 +141,11 @@ impl<'a> TaskSummaryFactory<'a> {
             .env_vars(task_id)
             .expect("env var map is inserted at the same time as hash");
 
+        let cli_arguments = self
+            .hash_tracker
+            .cli_args(task_id)
+            .expect("cli args is inserted at the same time as hash");
+
         let cache_summary = self.hash_tracker.cache_status(task_id).into();
 
         let (dependencies, dependents) = self.dependencies_and_dependents(task_id, display_task);
@@ -159,7 +164,7 @@ impl<'a> TaskSummaryFactory<'a> {
             ),
             cache: cache_summary,
             command,
-            cli_arguments: self.run_opts.args_for_task(&task_id).unwrap_or(vec![]),
+            cli_arguments,
             outputs: match task_definition.outputs.inclusions.is_empty() {
                 false => Some(task_definition.outputs.inclusions.clone()),
                 true => None,

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -218,9 +218,9 @@ impl<'a> Visitor<'a> {
 
             let is_root_task = engine.dependents(&info).map(|x| x.len()).unwrap_or(0) == 0;
             let task_args = if is_root_task {
-                self.run_opts.pass_through_args.to_vec()
+                Some(self.run_opts.pass_through_args.to_vec())
             } else {
-                vec![]
+                None
             };
             let dependency_set = engine.dependencies(&info).ok_or(Error::MissingDefinition)?;
 
@@ -229,7 +229,7 @@ impl<'a> Visitor<'a> {
                 &info,
                 task_definition,
                 task_env_mode,
-                &task_args,
+                task_args.as_ref().unwrap_or(&vec![]),
                 workspace_info,
                 dependency_set,
                 task_hash_telemetry,
@@ -282,6 +282,7 @@ impl<'a> Visitor<'a> {
                         task_cache,
                         workspace_directory,
                         execution_env,
+                        task_args,
                         takes_input,
                         self.task_access.clone(),
                     );
@@ -636,11 +637,11 @@ impl<'a> ExecContextFactory<'a> {
         task_cache: TaskCache,
         workspace_directory: AbsoluteSystemPathBuf,
         execution_env: EnvironmentVariableMap,
+        pass_through_args: Option<Vec<String>>,
         takes_input: bool,
         task_access: TaskAccess,
     ) -> ExecContext {
         let task_id_for_display = self.visitor.display_task_id(&task_id);
-        let pass_through_args = self.visitor.run_opts.args_for_task(&task_id);
         ExecContext {
             engine: self.engine.clone(),
             ui: self.visitor.ui,

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -216,6 +216,12 @@ impl<'a> Visitor<'a> {
             };
             package_task_event.track_env_mode(&task_env_mode.to_string());
 
+            let is_root_task = engine.dependents(&info).map(|x| x.len()).unwrap_or(0) == 0;
+            let task_args = if is_root_task {
+                self.run_opts.pass_through_args.to_vec()
+            } else {
+                vec![]
+            };
             let dependency_set = engine.dependencies(&info).ok_or(Error::MissingDefinition)?;
 
             let task_hash_telemetry = package_task_event.child();
@@ -223,6 +229,7 @@ impl<'a> Visitor<'a> {
                 &info,
                 task_definition,
                 task_env_mode,
+                &task_args,
                 workspace_info,
                 dependency_set,
                 task_hash_telemetry,

--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -396,7 +396,7 @@ impl<'a> TaskHasher<'a> {
             task: task_id.task(),
             outputs,
 
-            pass_through_args: &self.run_opts.pass_through_args,
+            pass_through_args: &self.run_opts.args_for_task(&task_id).unwrap_or_default(),
             env: &task_definition.env,
             resolved_env_vars: hashable_env_pairs,
             pass_through_env: task_definition

--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -559,6 +559,7 @@ impl TaskHashTracker {
             .package_task_env_vars
             .insert(task_id.clone(), env_vars);
         state.package_task_args.insert(task_id.clone(), args);
+
         if let Some(framework) = framework_slug {
             state
                 .package_task_framework

--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -236,6 +236,8 @@ pub struct TaskHashTracker {
 pub struct TaskHashTrackerState {
     #[serde(skip)]
     package_task_env_vars: HashMap<TaskId<'static>, DetailedMap>,
+    #[serde(skip)]
+    package_task_args: HashMap<TaskId<'static>, Vec<String>>,
     package_task_hashes: HashMap<TaskId<'static>, String>,
     #[serde(skip)]
     package_task_framework: HashMap<TaskId<'static>, String>,
@@ -282,6 +284,7 @@ impl<'a> TaskHasher<'a> {
         task_id: &TaskId<'static>,
         task_definition: &TaskDefinition,
         task_env_mode: ResolvedEnvMode,
+        task_args: &Vec<String>,
         workspace: &PackageInfo,
         dependency_set: HashSet<&TaskNode>,
         telemetry: PackageTaskEventBuilder,
@@ -396,7 +399,7 @@ impl<'a> TaskHasher<'a> {
             task: task_id.task(),
             outputs,
 
-            pass_through_args: &self.run_opts.args_for_task(&task_id).unwrap_or_default(),
+            pass_through_args: task_args,
             env: &task_definition.env,
             resolved_env_vars: hashable_env_pairs,
             pass_through_env: task_definition
@@ -412,6 +415,7 @@ impl<'a> TaskHasher<'a> {
         self.task_hash_tracker.insert_hash(
             task_id.clone(),
             env_vars,
+            task_args.clone(),
             task_hash.clone(),
             framework_slug,
         );
@@ -546,6 +550,7 @@ impl TaskHashTracker {
         &self,
         task_id: TaskId<'static>,
         env_vars: DetailedMap,
+        args: Vec<String>,
         hash: String,
         framework_slug: Option<String>,
     ) {
@@ -553,6 +558,7 @@ impl TaskHashTracker {
         state
             .package_task_env_vars
             .insert(task_id.clone(), env_vars);
+        state.package_task_args.insert(task_id.clone(), args);
         if let Some(framework) = framework_slug {
             state
                 .package_task_framework
@@ -564,6 +570,11 @@ impl TaskHashTracker {
     pub fn env_vars(&self, task_id: &TaskId) -> Option<DetailedMap> {
         let state = self.state.lock().expect("hash tracker mutex poisoned");
         state.package_task_env_vars.get(task_id).cloned()
+    }
+
+    pub fn cli_args(&self, task_id: &TaskId) -> Option<Vec<String>> {
+        let state = self.state.lock().expect("hash tracker mutex poisoned");
+        state.package_task_args.get(task_id).cloned()
     }
 
     pub fn framework(&self, task_id: &TaskId) -> Option<String> {


### PR DESCRIPTION
### Description
In the document, it says that cli arguments are not passed through task dependencies.

> Note that these additional arguments will not be passed to any additional tasks that are run due to dependencies from the [pipeline](https://turbo.build/repo/docs/reference/configuration#pipeline) configuration.

But when I actually run a task with additional arguments (e.g. `turbo run dev -- --env=stage`) the arguments (e.g. `--env=stage`) are passed through all the dependencies, and their caches are missed.

Related Issues: #1744 #5743

### Fixes
Only pass the additional cli arguments to the root tasks. (= tasks which are not required by other tasks)

### Testing Instructions
1. Open the `design-system` example.
2. In docs, run `turbo run build --summarize -- --disable-telemetry`.
3. Ensure that `--disable-telemetry` is only passed in `@repo/docs#build`, not `@acme/ui#build`
4. In docs, run `turbo run build --summarize -- --test`
5. Ensure that `@acme/ui#build` is cached.