### PR TITLE
chore: unbreak turborepo_2

### DIFF
--- a/turborepo-tests/integration/fixtures/dir_globs/turbo.json
+++ b/turborepo-tests/integration/fixtures/dir_globs/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "build": {
       "inputs": ["src/"],
       "outputs": ["dist"]


### PR DESCRIPTION
### Description

#8180 and #8157 ended up landing in a way where `globs.t` will fail due to using a test fixture that uses the now removed `pipeline` field.

### Testing Instructions

CI