### PR TITLE
Improve error readability.

### DIFF
--- a/crates/turborepo-lib/src/config.rs
+++ b/crates/turborepo-lib/src/config.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use convert_case::{Case, Casing};
-use miette::{Diagnostic, NamedSource, SourceSpan};
+use miette::{Diagnostic, NamedSource, Result, SourceSpan};
 use serde::Deserialize;
 use struct_iterable::Iterable;
 use thiserror::Error;
@@ -18,17 +18,14 @@ pub use crate::turbo_json::RawTurboJson;
 use crate::{commands::CommandBase, turbo_json};
 
 #[derive(Debug, Error, Diagnostic)]
-#[error("Environment variables should not be prefixed with \"{env_pipeline_delimiter}\"")]
-#[diagnostic(
-    code(invalid_env_prefix),
-    url("{}/messages/{}", TURBO_SITE, self.code().unwrap().to_string().to_case(Case::Kebab))
-)]
+#[error("Environment variables shouldn't be prefixed with \"{env_pipeline_delimiter}\"")]
+#[diagnostic(url("{}/messages/invalid-env-prefix", TURBO_SITE))]
 pub struct InvalidEnvPrefixError {
     pub value: String,
     pub key: String,
     #[source_code]
     pub text: NamedSource,
-    #[label("variable with invalid prefix declared here")]
+    #[label("Remove \"{env_pipeline_delimiter}\"")]
     pub span: Option<SourceSpan>,
     pub env_pipeline_delimiter: &'static str,
 }


### PR DESCRIPTION
### Description

Currently in a sloppy state to get feedback.

#### Proposed improvements:
- Bring link to the bottom of the message. My eye skips over the URL because it naturally jumps to the more verbose code output. With the URL at the bottom, I have the chance as a user to read the error and give it a fix. If I keep reading because I need more info, I make it to the link.
- Remove the diagnostic code. It doesn't mean anything to me as a user (and I'd imagine those of us on core would be able to sort out the error's location in source using other heuristics?).

#### Things to fix:
- The dangling `(link)` at the top needs to actually become the link at the bottom.
- The custom miette handler I'm adding isn't in a good location. I only dropped it in the file to hear what folks think.
- Tests.

Before:
![CleanShot 2024-06-14 at 19 45 05@2x](https://github.com/vercel/turbo/assets/35677084/e4dcf5d8-bf93-471a-b49a-3d0b78239dc7)

After:
![CleanShot 2024-06-14 at 19 44 48@2x](https://github.com/vercel/turbo/assets/35677084/af58d137-6632-40ad-a9e9-71c215a738ff)


### Testing Instructions

👀 
