### PR TITLE
fix(turborepo): add berry support for built meta when pruning

### DIFF
--- a/crates/turborepo-lockfiles/fixtures/berry.lock
+++ b/crates/turborepo-lockfiles/fixtures/berry.lock
@@ -1263,6 +1263,7 @@ eslint-config-turbo@latest:
     debug: ^3.2.7
   dependenciesMeta:
     debug@4.3.4:
+      built: false
       unplugged: true
   peerDependenciesMeta:
     eslint:

--- a/crates/turborepo-lockfiles/src/berry/mod.rs
+++ b/crates/turborepo-lockfiles/src/berry/mod.rs
@@ -96,6 +96,7 @@ struct BerryPackage {
 
 #[derive(Debug, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, Copy)]
 struct DependencyMeta {
+    built: Option<bool>,
     optional: Option<bool>,
     unplugged: Option<bool>,
 }

--- a/crates/turborepo-lockfiles/src/berry/ser.rs
+++ b/crates/turborepo-lockfiles/src/berry/ser.rs
@@ -157,9 +157,9 @@ where
         for (i, (setting, field)) in settings.iter().enumerate() {
             if let Some(value) = setting {
                 string.push_str(&format!("      {}: {}", wrap_string(field), value));
-            }
-            if i < settings.len() - 1 {
-                string.push('\n');
+                if i < settings.len() - 1 {
+                    string.push('\n');
+                }
             }
         }
 

--- a/crates/turborepo-lockfiles/src/berry/ser.rs
+++ b/crates/turborepo-lockfiles/src/berry/ser.rs
@@ -147,31 +147,34 @@ where
     let mut string = String::new();
     let mut first = true;
 
-    let mut add_line = |dependency: &str, field: &str, setting: bool| {
+    let mut add_line = |dependency: &str, settings: &[(Option<bool>, &str)]| {
         if !first {
             string.push('\n');
         }
 
-        string.push_str(&format!(
-            "    {}:\n      {}: {}",
-            wrap_string(dependency),
-            wrap_string(field),
-            setting,
-        ));
+        string.push_str(&format!("    {}:\n", wrap_string(dependency)));
+
+        for (i, (setting, field)) in settings.iter().enumerate() {
+            if let Some(value) = setting {
+                string.push_str(&format!("      {}: {}", wrap_string(field), value));
+            }
+            if i < settings.len() - 1 {
+                string.push('\n');
+            }
+        }
 
         first = false;
     };
 
     for (dependency, meta) in metadata {
         let dependency = dependency.as_ref();
-        if let Some(built) = meta.built {
-            add_line(dependency, "built", built);
-        }
-        if let Some(optional) = meta.optional {
-            add_line(dependency, "optional", optional);
-        }
-        if let Some(unplugged) = meta.unplugged {
-            add_line(dependency, "unplugged", unplugged);
+        let settings = [
+            (meta.built, "built"),
+            (meta.optional, "optional"),
+            (meta.unplugged, "unplugged"),
+        ];
+        if settings.iter().any(|&(setting, _)| setting.is_some()) {
+            add_line(dependency, &settings);
         }
     }
 

--- a/crates/turborepo-lockfiles/src/berry/ser.rs
+++ b/crates/turborepo-lockfiles/src/berry/ser.rs
@@ -147,15 +147,16 @@ where
     let mut string = String::new();
     let mut first = true;
 
-    let mut add_line = |dependency: &str, field: &str| {
+    let mut add_line = |dependency: &str, field: &str, setting: bool| {
         if !first {
             string.push('\n');
         }
 
         string.push_str(&format!(
-            "    {}:\n      {}: true",
+            "    {}:\n      {}: {}",
             wrap_string(dependency),
-            wrap_string(field)
+            wrap_string(field),
+            setting,
         ));
 
         first = false;
@@ -163,14 +164,14 @@ where
 
     for (dependency, meta) in metadata {
         let dependency = dependency.as_ref();
-        if meta.built.unwrap_or_default() {
-            add_line(dependency, "built");
+        if let Some(built) = meta.built {
+            add_line(dependency, "built", built);
         }
-        if meta.optional.unwrap_or_default() {
-            add_line(dependency, "optional");
+        if let Some(optional) = meta.optional {
+            add_line(dependency, "optional", optional);
         }
-        if meta.unplugged.unwrap_or_default() {
-            add_line(dependency, "unplugged");
+        if let Some(unplugged) = meta.unplugged {
+            add_line(dependency, "unplugged", unplugged);
         }
     }
 

--- a/crates/turborepo-lockfiles/src/berry/ser.rs
+++ b/crates/turborepo-lockfiles/src/berry/ser.rs
@@ -163,6 +163,9 @@ where
 
     for (dependency, meta) in metadata {
         let dependency = dependency.as_ref();
+        if meta.built.unwrap_or_default() {
+            add_line(dependency, "built");
+        }
         if meta.optional.unwrap_or_default() {
             add_line(dependency, "optional");
         }


### PR DESCRIPTION
### Description

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

Add support for [yarn berry built option](https://yarnpkg.com/configuration/manifest#dependenciesMeta.built) for dependencies meta to `turbo prune`.

Without this change, `yarn install --immutable` fails because `built` is added after turbo accidentally removes it, triggering the following error.

> The lockfile would have been modified by this install, which is explicitly forbidden.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->

* Add a dependenciesMeta for a package and set it to `built: false`.
* Run yarn to generate a new lockfile
* Use turbo prune to produce a slim lockfile
* Run `yarn install --immutable` on that small lockfile