### PR TITLE
Transient tasks

### DIFF
--- a/crates/turbo-tasks-macros/src/func.rs
+++ b/crates/turbo-tasks-macros/src/func.rs
@@ -319,13 +319,27 @@ impl TurboFn {
             let inputs = self.inputs();
             parse_quote! {
                 {
+                    let turbo_tasks_transient = #( turbo_tasks::TaskInput::is_transient(&#inputs) ||)* false;
+                    let turbo_tasks_trait = *#trait_type_id_ident;
+                    let turbo_tasks_name = std::borrow::Cow::Borrowed(stringify!(#ident));
+                    let turbo_tasks_this = #converted_this;
+                    let turbo_tasks_arg = Box::new((#(#inputs,)*)) as Box<dyn turbo_tasks::MagicAny>;
                     <#output as turbo_tasks::task::TaskOutput>::try_from_raw_vc(
-                        turbo_tasks::trait_call(
-                            *#trait_type_id_ident,
-                            std::borrow::Cow::Borrowed(stringify!(#ident)),
-                            #converted_this,
-                            Box::new((#(#inputs,)*)) as Box<dyn turbo_tasks::MagicAny>,
-                        )
+                        if turbo_tasks_transient {
+                            turbo_tasks::transient_trait_call(
+                                turbo_tasks_trait,
+                                turbo_tasks_name,
+                                turbo_tasks_this,
+                                turbo_tasks_arg,
+                            )
+                        } else {
+                            turbo_tasks::trait_call(
+                                turbo_tasks_trait,
+                                turbo_tasks_name,
+                                turbo_tasks_this,
+                                turbo_tasks_arg,
+                            )
+                        }
                     )
                 }
             }
@@ -346,23 +360,45 @@ impl TurboFn {
         if let Some(converted_this) = self.converted_this() {
             parse_quote! {
                 {
+                    let turbo_tasks_transient = #( turbo_tasks::TaskInput::is_transient(&#inputs) ||)* false;
+                    let turbo_tasks_func = *#native_function_id_ident;
+                    let turbo_tasks_this = #converted_this;
+                    let turbo_tasks_arg = Box::new((#(#inputs,)*)) as Box<dyn turbo_tasks::MagicAny>;
                     <#output as turbo_tasks::task::TaskOutput>::try_from_raw_vc(
-                        turbo_tasks::dynamic_this_call(
-                            *#native_function_id_ident,
-                            #converted_this,
-                            Box::new((#(#inputs,)*)) as Box<dyn turbo_tasks::MagicAny>,
-                        )
+                        if turbo_tasks_transient {
+                            turbo_tasks::transient_dynamic_this_call(
+                                turbo_tasks_func,
+                                turbo_tasks_this,
+                                turbo_tasks_arg,
+                            )
+                        } else {
+                            turbo_tasks::dynamic_this_call(
+                                turbo_tasks_func,
+                                turbo_tasks_this,
+                                turbo_tasks_arg,
+                            )
+                        }
                     )
                 }
             }
         } else {
             parse_quote! {
                 {
+                    let turbo_tasks_transient = #( turbo_tasks::TaskInput::is_transient(&#inputs) ||)* false;
+                    let turbo_tasks_func = *#native_function_id_ident;
+                    let turbo_tasks_arg = Box::new((#(#inputs,)*)) as Box<dyn turbo_tasks::MagicAny>;
                     <#output as turbo_tasks::task::TaskOutput>::try_from_raw_vc(
-                        turbo_tasks::dynamic_call(
-                            *#native_function_id_ident,
-                            Box::new((#(#inputs,)*)) as Box<dyn turbo_tasks::MagicAny>,
-                        )
+                        if turbo_tasks_transient {
+                            turbo_tasks::transient_dynamic_call(
+                                turbo_tasks_func,
+                                turbo_tasks_arg,
+                            )
+                        } else {
+                            turbo_tasks::dynamic_call(
+                                turbo_tasks_func,
+                                turbo_tasks_arg,
+                            )
+                        }
                     )
                 }
             }

--- a/crates/turbo-tasks-memory/src/memory_backend.rs
+++ b/crates/turbo-tasks-memory/src/memory_backend.rs
@@ -21,12 +21,13 @@ use tracing::trace_span;
 use turbo_prehash::{BuildHasherExt, PassThroughHash, PreHashed};
 use turbo_tasks::{
     backend::{
-        Backend, BackendJobId, CellContent, PersistentTaskType, TaskCollectiblesMap,
-        TaskExecutionSpec, TransientTaskType, TypedCellContent,
+        Backend, BackendJobId, CachedTaskType, CellContent, TaskCollectiblesMap, TaskExecutionSpec,
+        TransientTaskType, TypedCellContent,
     },
     event::EventListener,
     util::{IdFactoryWithReuse, NoMoveVec},
     CellId, RawVc, TaskId, TaskIdSet, TraitTypeId, TurboTasksBackendApi, Unused, ValueTypeId,
+    TRANSIENT_TASK_BIT,
 };
 
 use crate::{
@@ -40,16 +41,19 @@ use crate::{
     task_statistics::TaskStatisticsApi,
 };
 
-fn prehash_task_type(task_type: PersistentTaskType) -> PreHashed<PersistentTaskType> {
+fn prehash_task_type(task_type: CachedTaskType) -> PreHashed<CachedTaskType> {
     BuildHasherDefault::<FxHasher>::prehash(&Default::default(), task_type)
 }
 
 pub struct MemoryBackend {
-    memory_tasks: NoMoveVec<Task, 13>,
+    persistent_tasks: NoMoveVec<Task, 13>,
+    transient_tasks: NoMoveVec<Task, 10>,
     backend_jobs: NoMoveVec<Job>,
     backend_job_id_factory: IdFactoryWithReuse<BackendJobId>,
     task_cache:
-        DashMap<Arc<PreHashed<PersistentTaskType>>, TaskId, BuildHasherDefault<PassThroughHash>>,
+        DashMap<Arc<PreHashed<CachedTaskType>>, TaskId, BuildHasherDefault<PassThroughHash>>,
+    transient_task_cache:
+        DashMap<Arc<PreHashed<CachedTaskType>>, TaskId, BuildHasherDefault<PassThroughHash>>,
     memory_limit: AtomicUsize,
     gc_queue: Option<GcQueue>,
     idle_gc_active: AtomicBool,
@@ -64,14 +68,17 @@ impl Default for MemoryBackend {
 
 impl MemoryBackend {
     pub fn new(memory_limit: usize) -> Self {
+        let shard_amount =
+            (std::thread::available_parallelism().map_or(1, usize::from) * 32).next_power_of_two();
         Self {
-            memory_tasks: NoMoveVec::new(),
+            persistent_tasks: NoMoveVec::new(),
+            transient_tasks: NoMoveVec::new(),
             backend_jobs: NoMoveVec::new(),
             backend_job_id_factory: IdFactoryWithReuse::new(),
-            task_cache: DashMap::with_hasher_and_shard_amount(
+            task_cache: DashMap::with_hasher_and_shard_amount(Default::default(), shard_amount),
+            transient_task_cache: DashMap::with_hasher_and_shard_amount(
                 Default::default(),
-                (std::thread::available_parallelism().map_or(1, usize::from) * 32)
-                    .next_power_of_two(),
+                shard_amount,
             ),
             memory_limit: AtomicUsize::new(memory_limit),
             gc_queue: (memory_limit != usize::MAX).then(GcQueue::new),
@@ -122,16 +129,33 @@ impl MemoryBackend {
         for id in self.task_cache.clone().into_read_only().values() {
             func(*id);
         }
+        for id in self.transient_task_cache.clone().into_read_only().values() {
+            func(*id);
+        }
     }
 
     #[inline(always)]
     pub fn with_task<T>(&self, id: TaskId, func: impl FnOnce(&Task) -> T) -> T {
-        func(self.memory_tasks.get(*id as usize).unwrap())
+        let value = *id;
+        let index = (value & !TRANSIENT_TASK_BIT) as usize;
+        let item = if value & TRANSIENT_TASK_BIT == 0 {
+            self.persistent_tasks.get(index)
+        } else {
+            self.transient_tasks.get(index)
+        };
+        func(item.unwrap())
     }
 
     #[inline(always)]
     pub fn task(&self, id: TaskId) -> &Task {
-        self.memory_tasks.get(*id as usize).unwrap()
+        let value = *id;
+        let index = (value & !TRANSIENT_TASK_BIT) as usize;
+        let item = if value & TRANSIENT_TASK_BIT == 0 {
+            self.persistent_tasks.get(index)
+        } else {
+            self.transient_tasks.get(index)
+        };
+        item.unwrap()
     }
 
     /// Runs the garbage collection until reaching the target memory. An `idle`
@@ -221,18 +245,21 @@ impl MemoryBackend {
         false
     }
 
-    fn insert_and_connect_fresh_task<K: Eq + Hash, H: BuildHasher + Clone>(
+    fn insert_and_connect_fresh_task<K: Eq + Hash, H: BuildHasher + Clone, const N: u32>(
         &self,
         parent_task: TaskId,
         task_cache: &DashMap<K, TaskId, H>,
+        task_storage: &NoMoveVec<Task, N>,
+        task_storage_offset: u32,
         key: K,
         new_id: Unused<TaskId>,
         task: Task,
         turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
     ) -> TaskId {
         let new_id = new_id.into();
+        let index = (*new_id - task_storage_offset) as usize;
         // Safety: We have a fresh task id that nobody knows about yet
-        unsafe { self.memory_tasks.insert(*new_id as usize, task) };
+        unsafe { task_storage.insert(index, task) };
         let result_task = match task_cache.entry(key) {
             Entry::Vacant(entry) => {
                 // This is the most likely case
@@ -244,7 +271,7 @@ impl MemoryBackend {
                 let task_id = *entry.get();
                 drop(entry);
                 unsafe {
-                    self.memory_tasks.remove(*new_id as usize);
+                    task_storage.remove(index);
                     let new_id = Unused::new_unchecked(new_id);
                     turbo_tasks.reuse_persistent_task_id(new_id);
                 }
@@ -291,6 +318,74 @@ impl MemoryBackend {
 
     pub fn task_statistics(&self) -> &TaskStatisticsApi {
         &self.task_statistics
+    }
+
+    fn track_cache_hit(
+        &self,
+        task_type: &PreHashed<CachedTaskType>,
+        turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
+    ) {
+        self.task_statistics().map(|stats| match &**task_type {
+            CachedTaskType::ResolveNative {
+                fn_type: function_id,
+                this: _,
+                arg: _,
+            }
+            | CachedTaskType::Native {
+                fn_type: function_id,
+                this: _,
+                arg: _,
+            } => {
+                stats.increment_cache_hit(*function_id);
+            }
+            CachedTaskType::ResolveTrait {
+                trait_type,
+                method_name: name,
+                this,
+                arg: _,
+            } => {
+                // HACK: Resolve the this argument (`self`) in order to attribute the cache hit
+                // to the concrete trait implementation, rather than the dynamic trait method.
+                // This ensures cache hits and misses are both attributed to the same thing.
+                //
+                // Because this task already resolved, in most cases `self` should either be
+                // resolved, or already in the process of being resolved.
+                //
+                // However, `self` could become unloaded due to cache eviction, and this might
+                // trigger an otherwise unnecessary re-evalutation.
+                //
+                // This is a potentially okay trade-off as long as we don't log statistics by
+                // default. The alternative would be to store function ids on completed
+                // ResolveTrait tasks.
+                let trait_type = *trait_type;
+                let name = name.clone();
+                let this = *this;
+                let stats = Arc::clone(stats);
+                turbo_tasks.run_once(Box::pin(async move {
+                    let function_id =
+                        CachedTaskType::resolve_trait_method(trait_type, name, this).await?;
+                    stats.increment_cache_hit(function_id);
+                    Ok(())
+                }));
+            }
+        });
+    }
+
+    fn track_cache_miss(&self, task_type: &PreHashed<CachedTaskType>) {
+        self.task_statistics().map(|stats| match &**task_type {
+            CachedTaskType::Native {
+                fn_type: function_id,
+                this: _,
+                arg: _,
+            } => {
+                stats.increment_cache_miss(*function_id);
+            }
+            CachedTaskType::ResolveTrait { .. } | CachedTaskType::ResolveNative { .. } => {
+                // these types re-execute themselves as `Native` after
+                // resolving their arguments, skip counting their
+                // executions here to avoid double-counting
+            }
+        });
     }
 }
 
@@ -593,7 +688,7 @@ impl Backend for MemoryBackend {
 
     fn get_or_create_persistent_task(
         &self,
-        task_type: PersistentTaskType,
+        task_type: CachedTaskType,
         parent_task: TaskId,
         turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
     ) -> TaskId {
@@ -602,68 +697,10 @@ impl Backend for MemoryBackend {
             self.lookup_and_connect_task(parent_task, &self.task_cache, &task_type, turbo_tasks)
         {
             // fast pass without creating a new task
-            self.task_statistics().map(|stats| match &*task_type {
-                PersistentTaskType::ResolveNative {
-                    fn_type: function_id,
-                    this: _,
-                    arg: _,
-                }
-                | PersistentTaskType::Native {
-                    fn_type: function_id,
-                    this: _,
-                    arg: _,
-                } => {
-                    stats.increment_cache_hit(*function_id);
-                }
-                PersistentTaskType::ResolveTrait {
-                    trait_type,
-                    method_name: name,
-                    this,
-                    arg: _,
-                } => {
-                    // HACK: Resolve the this argument (`self`) in order to attribute the cache hit
-                    // to the concrete trait implementation, rather than the dynamic trait method.
-                    // This ensures cache hits and misses are both attributed to the same thing.
-                    //
-                    // Because this task already resolved, in most cases `self` should either be
-                    // resolved, or already in the process of being resolved.
-                    //
-                    // However, `self` could become unloaded due to cache eviction, and this might
-                    // trigger an otherwise unnecessary re-evalutation.
-                    //
-                    // This is a potentially okay trade-off as long as we don't log statistics by
-                    // default. The alternative would be to store function ids on completed
-                    // ResolveTrait tasks.
-                    let trait_type = *trait_type;
-                    let name = name.clone();
-                    let this = *this;
-                    let stats = Arc::clone(stats);
-                    turbo_tasks.run_once(Box::pin(async move {
-                        let function_id =
-                            PersistentTaskType::resolve_trait_method(trait_type, name, this)
-                                .await?;
-                        stats.increment_cache_hit(function_id);
-                        Ok(())
-                    }));
-                }
-            });
+            self.track_cache_hit(&task_type, turbo_tasks);
             task
         } else {
-            self.task_statistics().map(|stats| match &*task_type {
-                PersistentTaskType::Native {
-                    fn_type: function_id,
-                    this: _,
-                    arg: _,
-                } => {
-                    stats.increment_cache_miss(*function_id);
-                }
-                PersistentTaskType::ResolveTrait { .. }
-                | PersistentTaskType::ResolveNative { .. } => {
-                    // these types re-execute themselves as `Native` after
-                    // resolving their arguments, skip counting their
-                    // executions here to avoid double-counting
-                }
-            });
+            self.track_cache_miss(&task_type);
             // It's important to avoid overallocating memory as this will go into the task
             // cache and stay there forever. We can to be as small as possible.
             let (task_type_hash, task_type) = PreHashed::into_parts(task_type);
@@ -679,6 +716,51 @@ impl Backend for MemoryBackend {
             self.insert_and_connect_fresh_task(
                 parent_task,
                 &self.task_cache,
+                &self.persistent_tasks,
+                0,
+                task_type,
+                id,
+                task,
+                turbo_tasks,
+            )
+        }
+    }
+
+    fn get_or_create_transient_task(
+        &self,
+        task_type: CachedTaskType,
+        parent_task: TaskId,
+        turbo_tasks: &dyn TurboTasksBackendApi<Self>,
+    ) -> TaskId {
+        let task_type = prehash_task_type(task_type);
+        if let Some(task) = self.lookup_and_connect_task(
+            parent_task,
+            &self.transient_task_cache,
+            &task_type,
+            turbo_tasks,
+        ) {
+            // fast pass without creating a new task
+            self.track_cache_hit(&task_type, turbo_tasks);
+            task
+        } else {
+            self.track_cache_miss(&task_type);
+            // It's important to avoid overallocating memory as this will go into the task
+            // cache and stay there forever. We can to be as small as possible.
+            let (task_type_hash, task_type) = PreHashed::into_parts(task_type);
+            let task_type = Arc::new(PreHashed::new(task_type_hash, task_type));
+            // slow pass with key lock
+            let id = turbo_tasks.get_fresh_transient_task_id();
+            let task = Task::new_transient(
+                // Safety: That task will hold the value, but we are still in
+                // control of the task
+                *unsafe { id.get_unchecked() },
+                task_type.clone(),
+            );
+            self.insert_and_connect_fresh_task(
+                parent_task,
+                &self.transient_task_cache,
+                &self.transient_tasks,
+                TRANSIENT_TASK_BIT,
                 task_type,
                 id,
                 task,
@@ -711,17 +793,18 @@ impl Backend for MemoryBackend {
     ) -> TaskId {
         let id = turbo_tasks.get_fresh_transient_task_id();
         let id = id.into();
+        let index = (*id - TRANSIENT_TASK_BIT) as usize;
         match task_type {
             TransientTaskType::Root(f) => {
                 let task = Task::new_root(id, move || f() as _);
                 // SAFETY: We have a fresh task id where nobody knows about yet
-                unsafe { self.memory_tasks.insert(*id as usize, task) };
+                unsafe { self.transient_tasks.insert(index, task) };
                 Task::set_root(id, self, turbo_tasks);
             }
             TransientTaskType::Once(f) => {
                 let task = Task::new_once(id, f);
                 // SAFETY: We have a fresh task id where nobody knows about yet
-                unsafe { self.memory_tasks.insert(*id as usize, task) };
+                unsafe { self.transient_tasks.insert(index, task) };
                 Task::set_once(id, self, turbo_tasks);
             }
         };

--- a/crates/turbo-tasks-memory/src/memory_backend.rs
+++ b/crates/turbo-tasks-memory/src/memory_backend.rs
@@ -246,7 +246,7 @@ impl MemoryBackend {
                 unsafe {
                     self.memory_tasks.remove(*new_id as usize);
                     let new_id = Unused::new_unchecked(new_id);
-                    turbo_tasks.reuse_task_id(new_id);
+                    turbo_tasks.reuse_persistent_task_id(new_id);
                 }
                 task_id
             }
@@ -669,7 +669,7 @@ impl Backend for MemoryBackend {
             let (task_type_hash, task_type) = PreHashed::into_parts(task_type);
             let task_type = Arc::new(PreHashed::new(task_type_hash, task_type));
             // slow pass with key lock
-            let id = turbo_tasks.get_fresh_task_id();
+            let id = turbo_tasks.get_fresh_persistent_task_id();
             let task = Task::new_persistent(
                 // Safety: That task will hold the value, but we are still in
                 // control of the task
@@ -709,7 +709,7 @@ impl Backend for MemoryBackend {
         task_type: TransientTaskType,
         turbo_tasks: &dyn TurboTasksBackendApi<MemoryBackend>,
     ) -> TaskId {
-        let id = turbo_tasks.get_fresh_task_id();
+        let id = turbo_tasks.get_fresh_transient_task_id();
         let id = id.into();
         match task_type {
             TransientTaskType::Root(f) => {

--- a/crates/turbo-tasks-memory/src/task.rs
+++ b/crates/turbo-tasks-memory/src/task.rs
@@ -21,7 +21,7 @@ use tokio::task_local;
 use tracing::Span;
 use turbo_prehash::PreHashed;
 use turbo_tasks::{
-    backend::{CellContent, PersistentTaskType, TaskCollectiblesMap, TaskExecutionSpec},
+    backend::{CachedTaskType, CellContent, TaskCollectiblesMap, TaskExecutionSpec},
     event::{Event, EventListener},
     get_invalidator, registry, CellId, Invalidator, RawVc, TaskId, TaskIdSet, TraitTypeId,
     TurboTasksBackendApi, ValueTypeId,
@@ -71,16 +71,17 @@ enum TaskType {
     Once(Box<OnceTaskFn>),
 
     /// A normal persistent task
-    Persistent {
-        ty: Arc<PreHashed<PersistentTaskType>>,
-    },
+    Persistent { ty: Arc<PreHashed<CachedTaskType>> },
+
+    /// A cached transient task
+    Transient { ty: Arc<PreHashed<CachedTaskType>> },
 }
 
 #[derive(Clone)]
 enum TaskTypeForDescription {
     Root,
     Once,
-    Persistent(Arc<PreHashed<PersistentTaskType>>),
+    Persistent(Arc<PreHashed<CachedTaskType>>),
 }
 
 impl TaskTypeForDescription {
@@ -89,6 +90,7 @@ impl TaskTypeForDescription {
             TaskType::Root(..) => Self::Root,
             TaskType::Once(..) => Self::Once,
             TaskType::Persistent { ty, .. } => Self::Persistent(ty.clone()),
+            TaskType::Transient { ty, .. } => Self::Persistent(ty.clone()),
         }
     }
 }
@@ -99,6 +101,7 @@ impl Debug for TaskType {
             Self::Root(..) => f.debug_tuple("Root").finish(),
             Self::Once(..) => f.debug_tuple("Once").finish(),
             Self::Persistent { ty, .. } => Debug::fmt(ty, f),
+            Self::Transient { ty } => Debug::fmt(ty, f),
         }
     }
 }
@@ -109,6 +112,7 @@ impl Display for TaskType {
             Self::Root(..) => f.debug_tuple("Root").finish(),
             Self::Once(..) => f.debug_tuple("Once").finish(),
             Self::Persistent { ty, .. } => Display::fmt(ty, f),
+            Self::Transient { ty } => Display::fmt(ty, f),
         }
     }
 }
@@ -464,11 +468,18 @@ pub enum ReadCellError {
 }
 
 impl Task {
-    pub(crate) fn new_persistent(
-        id: TaskId,
-        task_type: Arc<PreHashed<PersistentTaskType>>,
-    ) -> Self {
+    pub(crate) fn new_persistent(id: TaskId, task_type: Arc<PreHashed<CachedTaskType>>) -> Self {
         let ty = TaskType::Persistent { ty: task_type };
+        Self {
+            id,
+            ty,
+            state: RwLock::new(TaskMetaState::Full(Box::new(TaskState::new()))),
+            graph_modification_in_progress_counter: AtomicU32::new(0),
+        }
+    }
+
+    pub(crate) fn new_transient(id: TaskId, task_type: Arc<PreHashed<CachedTaskType>>) -> Self {
+        let ty = TaskType::Transient { ty: task_type };
         Self {
             id,
             ty,
@@ -512,6 +523,7 @@ impl Task {
     pub(crate) fn is_pure(&self) -> bool {
         match &self.ty {
             TaskType::Persistent { .. } => true,
+            TaskType::Transient { .. } => true,
             TaskType::Root(_) => false,
             TaskType::Once(_) => false,
         }
@@ -520,6 +532,7 @@ impl Task {
     pub(crate) fn is_once(&self) -> bool {
         match &self.ty {
             TaskType::Persistent { .. } => false,
+            TaskType::Transient { .. } => false,
             TaskType::Root(_) => false,
             TaskType::Once(_) => true,
         }
@@ -583,7 +596,7 @@ impl Task {
     }
 
     pub(crate) fn get_function_name(&self) -> Option<Cow<'static, str>> {
-        if let TaskType::Persistent { ty, .. } = &self.ty {
+        if let TaskType::Persistent { ty, .. } | TaskType::Transient { ty, .. } = &self.ty {
             Some(ty.get_name())
         } else {
             None
@@ -599,14 +612,14 @@ impl Task {
             TaskTypeForDescription::Root => format!("[{}] root", id),
             TaskTypeForDescription::Once => format!("[{}] once", id),
             TaskTypeForDescription::Persistent(ty) => match &***ty {
-                PersistentTaskType::Native {
+                CachedTaskType::Native {
                     fn_type: native_fn,
                     this: _,
                     arg: _,
                 } => {
                     format!("[{}] {}", id, registry::get_function(*native_fn).name)
                 }
-                PersistentTaskType::ResolveNative {
+                CachedTaskType::ResolveNative {
                     fn_type: native_fn,
                     this: _,
                     arg: _,
@@ -617,7 +630,7 @@ impl Task {
                         registry::get_function(*native_fn).name
                     )
                 }
-                PersistentTaskType::ResolveTrait {
+                CachedTaskType::ResolveTrait {
                     trait_type,
                     method_name: fn_name,
                     this: _,
@@ -774,8 +787,8 @@ impl Task {
                 mutex.lock().take().expect("Task can only be executed once"),
                 tracing::trace_span!("turbo_tasks::once_task"),
             ),
-            TaskType::Persistent { ty, .. } => match &***ty {
-                PersistentTaskType::Native {
+            TaskType::Persistent { ty, .. } | TaskType::Transient { ty, .. } => match &***ty {
+                CachedTaskType::Native {
                     fn_type: native_fn,
                     this,
                     arg,
@@ -787,7 +800,7 @@ impl Task {
                     drop(entered);
                     (future, span)
                 }
-                PersistentTaskType::ResolveNative {
+                CachedTaskType::ResolveNative {
                     fn_type: ref native_fn_id,
                     this,
                     arg,
@@ -797,7 +810,7 @@ impl Task {
                     let span = func.resolve_span();
                     let entered = span.enter();
                     let turbo_tasks = turbo_tasks.pin();
-                    let future = Box::pin(PersistentTaskType::run_resolve_native(
+                    let future = Box::pin(CachedTaskType::run_resolve_native(
                         native_fn_id,
                         *this,
                         &**arg,
@@ -806,7 +819,7 @@ impl Task {
                     drop(entered);
                     (future, span)
                 }
-                PersistentTaskType::ResolveTrait {
+                CachedTaskType::ResolveTrait {
                     trait_type: trait_type_id,
                     method_name: name,
                     this,
@@ -818,7 +831,7 @@ impl Task {
                     let entered = span.enter();
                     let name = name.clone();
                     let turbo_tasks = turbo_tasks.pin();
-                    let future = Box::pin(PersistentTaskType::run_resolve_trait(
+                    let future = Box::pin(CachedTaskType::run_resolve_trait(
                         trait_type_id,
                         name,
                         *this,

--- a/crates/turbo-tasks-memory/tests/task_statistics.rs
+++ b/crates/turbo-tasks-memory/tests/task_statistics.rs
@@ -184,13 +184,13 @@ async fn test_no_execution() {
     .await;
 }
 
-// Internally, this function uses `PersistentTaskType::Native`.
+// Internally, this function uses `CachedTaskType::Native`.
 #[turbo_tasks::function]
 fn double(val: u64) -> Vc<u64> {
     Vc::cell(val * 2)
 }
 
-// Internally, this function uses `PersistentTaskType::ResolveNative`.
+// Internally, this function uses `CachedTaskType::ResolveNative`.
 #[turbo_tasks::function]
 async fn double_vc(val: Vc<u64>) -> Result<Vc<u64>> {
     let val = *val.await?;

--- a/crates/turbo-tasks/src/backend.rs
+++ b/crates/turbo-tasks/src/backend.rs
@@ -26,16 +26,6 @@ use crate::{
     ValueTypeId, VcValueTrait, VcValueType,
 };
 
-pub enum TaskType {
-    /// Tasks that only exist for a certain operation and
-    /// won't persist between sessions
-    Transient(TransientTaskType),
-
-    /// Tasks that can persist between sessions and potentially
-    /// shared globally
-    Persistent(CachedTaskType),
-}
-
 type TransientTaskRoot =
     Box<dyn Fn() -> Pin<Box<dyn Future<Output = Result<RawVc>> + Send>> + Send + Sync>;
 

--- a/crates/turbo-tasks/src/backend.rs
+++ b/crates/turbo-tasks/src/backend.rs
@@ -22,8 +22,8 @@ use crate::{
     raw_vc::CellId,
     registry,
     trait_helpers::{get_trait_method, has_trait, traits},
-    FunctionId, RawVc, ReadRef, SharedReference, TaskId, TaskIdProvider, TaskIdSet, TraitRef,
-    TraitTypeId, ValueTypeId, VcValueTrait, VcValueType,
+    FunctionId, RawVc, ReadRef, SharedReference, TaskId, TaskIdSet, TraitRef, TraitTypeId,
+    ValueTypeId, VcValueTrait, VcValueType,
 };
 
 pub enum TaskType {
@@ -393,7 +393,7 @@ pub type TaskCollectiblesMap = AutoMap<RawVc, i32, BuildHasherDefault<FxHasher>,
 
 pub trait Backend: Sync + Send {
     #[allow(unused_variables)]
-    fn initialize(&mut self, task_id_provider: &dyn TaskIdProvider) {}
+    fn initialize(&mut self) {}
 
     #[allow(unused_variables)]
     fn startup(&self, turbo_tasks: &dyn TurboTasksBackendApi<Self>) {}

--- a/crates/turbo-tasks/src/id.rs
+++ b/crates/turbo-tasks/src/id.rs
@@ -77,6 +77,14 @@ impl Debug for TaskId {
     }
 }
 
+pub const TRANSIENT_TASK_BIT: u32 = 0x8000_0000;
+
+impl TaskId {
+    pub fn is_transient(&self) -> bool {
+        **self & TRANSIENT_TASK_BIT != 0
+    }
+}
+
 macro_rules! make_serializable {
     ($ty:ty, $get_global_name:path, $get_id:path, $visitor_name:ident) => {
         impl Serialize for $ty {

--- a/crates/turbo-tasks/src/id_factory.rs
+++ b/crates/turbo-tasks/src/id_factory.rs
@@ -23,8 +23,8 @@ impl<T> IdFactory<T> {
 
     pub const fn new_with_range(start: u64, max: u64) -> Self {
         Self {
-            next_id: AtomicU64::new(start as u64),
-            max_id: max as u64,
+            next_id: AtomicU64::new(start),
+            max_id: max,
             _phantom_data: PhantomData,
         }
     }

--- a/crates/turbo-tasks/src/lib.rs
+++ b/crates/turbo-tasks/src/lib.rs
@@ -90,8 +90,8 @@ pub use magic_any::MagicAny;
 pub use manager::{
     dynamic_call, dynamic_this_call, emit, get_invalidator, mark_finished, mark_stateful,
     prevent_gc, run_once, run_once_with_reason, spawn_blocking, spawn_thread, trait_call,
-    turbo_tasks, CurrentCellRef, Invalidator, TaskIdProvider, TurboTasks, TurboTasksApi,
-    TurboTasksBackendApi, TurboTasksCallApi, Unused, UpdateInfo,
+    turbo_tasks, CurrentCellRef, Invalidator, TurboTasks, TurboTasksApi, TurboTasksBackendApi,
+    TurboTasksCallApi, Unused, UpdateInfo,
 };
 pub use native_function::NativeFunction;
 pub use raw_vc::{CellId, RawVc, ReadRawVcFuture, ResolveTypeError};

--- a/crates/turbo-tasks/src/lib.rs
+++ b/crates/turbo-tasks/src/lib.rs
@@ -81,7 +81,7 @@ use auto_hash_map::AutoSet;
 pub use collectibles::CollectiblesSource;
 pub use completion::{Completion, Completions};
 pub use display::ValueToString;
-pub use id::{FunctionId, TaskId, TraitTypeId, ValueTypeId};
+pub use id::{FunctionId, TaskId, TraitTypeId, ValueTypeId, TRANSIENT_TASK_BIT};
 pub use invalidation::{
     DynamicEqHash, InvalidationReason, InvalidationReasonKind, InvalidationReasonSet,
 };
@@ -90,7 +90,8 @@ pub use magic_any::MagicAny;
 pub use manager::{
     dynamic_call, dynamic_this_call, emit, get_invalidator, mark_finished, mark_stateful,
     prevent_gc, run_once, run_once_with_reason, spawn_blocking, spawn_thread, trait_call,
-    turbo_tasks, CurrentCellRef, Invalidator, TurboTasks, TurboTasksApi, TurboTasksBackendApi,
+    transient_dynamic_call, transient_dynamic_this_call, transient_trait_call, turbo_tasks,
+    CurrentCellRef, Invalidator, TurboTasks, TurboTasksApi, TurboTasksBackendApi,
     TurboTasksCallApi, Unused, UpdateInfo,
 };
 pub use native_function::NativeFunction;

--- a/crates/turbo-tasks/src/manager.rs
+++ b/crates/turbo-tasks/src/manager.rs
@@ -207,7 +207,13 @@ pub trait TurboTasksBackendApi<B: Backend + 'static>: TurboTasksCallApi + Sync +
 
     fn get_fresh_persistent_task_id(&self) -> Unused<TaskId>;
     fn get_fresh_transient_task_id(&self) -> Unused<TaskId>;
+    /// # Safety
+    ///
+    /// The caller must ensure that the task id is not used anymore.
     unsafe fn reuse_persistent_task_id(&self, id: Unused<TaskId>);
+    /// # Safety
+    ///
+    /// The caller must ensure that the task id is not used anymore.
     unsafe fn reuse_transient_task_id(&self, id: Unused<TaskId>);
 
     fn schedule(&self, task: TaskId);

--- a/crates/turbo-tasks/src/manager.rs
+++ b/crates/turbo-tasks/src/manager.rs
@@ -25,7 +25,7 @@ use turbo_tasks_malloc::TurboMalloc;
 
 use crate::{
     backend::{
-        Backend, CellContent, PersistentTaskType, TaskCollectiblesMap, TaskExecutionSpec,
+        Backend, CachedTaskType, CellContent, TaskCollectiblesMap, TaskExecutionSpec,
         TransientTaskType, TypedCellContent,
     },
     capture_future::{self, CaptureFuture},
@@ -44,10 +44,37 @@ use crate::{
 };
 
 pub trait TurboTasksCallApi: Sync + Send {
+    /// Calls a native function with arguments. Resolves arguments when needed
+    /// with a wrapper task.
     fn dynamic_call(&self, func: FunctionId, arg: Box<dyn MagicAny>) -> RawVc;
+    fn transient_dynamic_call(&self, func: FunctionId, arg: Box<dyn MagicAny>) -> RawVc {
+        self.dynamic_call(func, arg)
+    }
+    /// Calls a native function with arguments. Resolves arguments when needed
+    /// with a wrapper task.
     fn dynamic_this_call(&self, func: FunctionId, this: RawVc, arg: Box<dyn MagicAny>) -> RawVc;
+    fn transient_dynamic_this_call(
+        &self,
+        func: FunctionId,
+        this: RawVc,
+        arg: Box<dyn MagicAny>,
+    ) -> RawVc {
+        self.dynamic_this_call(func, this, arg)
+    }
+    /// Call a native function with arguments.
+    /// All inputs must be resolved.
     fn native_call(&self, func: FunctionId, arg: Box<dyn MagicAny>) -> RawVc;
+    fn transient_native_call(&self, func: FunctionId, arg: Box<dyn MagicAny>) -> RawVc {
+        self.native_call(func, arg)
+    }
+    /// Call a native function with arguments.
+    /// All inputs must be resolved.
     fn this_call(&self, func: FunctionId, this: RawVc, arg: Box<dyn MagicAny>) -> RawVc;
+    fn transient_this_call(&self, func: FunctionId, this: RawVc, arg: Box<dyn MagicAny>) -> RawVc {
+        self.this_call(func, this, arg)
+    }
+    /// Calls a trait method with arguments. First input is the `self` object.
+    /// Uses a wrapper task to resolve
     fn trait_call(
         &self,
         trait_type: TraitTypeId,
@@ -55,6 +82,15 @@ pub trait TurboTasksCallApi: Sync + Send {
         this: RawVc,
         arg: Box<dyn MagicAny>,
     ) -> RawVc;
+    fn transient_trait_call(
+        &self,
+        trait_type: TraitTypeId,
+        trait_fn_name: Cow<'static, str>,
+        this: RawVc,
+        arg: Box<dyn MagicAny>,
+    ) -> RawVc {
+        self.trait_call(trait_type, trait_fn_name, this, arg)
+    }
 
     fn run_once(
         &self,
@@ -345,11 +381,9 @@ impl<B: Backend + 'static> TurboTasks<B> {
         Ok(rx.await?)
     }
 
-    /// Call a native function with arguments.
-    /// All inputs must be resolved.
     pub(crate) fn native_call(&self, func: FunctionId, arg: Box<dyn MagicAny>) -> RawVc {
         RawVc::TaskOutput(self.backend.get_or_create_persistent_task(
-            PersistentTaskType::Native {
+            CachedTaskType::Native {
                 fn_type: func,
                 this: None,
                 arg,
@@ -359,11 +393,21 @@ impl<B: Backend + 'static> TurboTasks<B> {
         ))
     }
 
-    /// Call a native function with arguments.
-    /// All inputs must be resolved.
+    pub(crate) fn transient_native_call(&self, func: FunctionId, arg: Box<dyn MagicAny>) -> RawVc {
+        RawVc::TaskOutput(self.backend.get_or_create_transient_task(
+            CachedTaskType::Native {
+                fn_type: func,
+                this: None,
+                arg,
+            },
+            current_task("turbo_function calls"),
+            self,
+        ))
+    }
+
     pub(crate) fn this_call(&self, func: FunctionId, this: RawVc, arg: Box<dyn MagicAny>) -> RawVc {
         RawVc::TaskOutput(self.backend.get_or_create_persistent_task(
-            PersistentTaskType::Native {
+            CachedTaskType::Native {
                 fn_type: func,
                 this: Some(this),
                 arg,
@@ -373,14 +417,29 @@ impl<B: Backend + 'static> TurboTasks<B> {
         ))
     }
 
-    /// Calls a native function with arguments. Resolves arguments when needed
-    /// with a wrapper task.
+    pub(crate) fn transient_this_call(
+        &self,
+        func: FunctionId,
+        this: RawVc,
+        arg: Box<dyn MagicAny>,
+    ) -> RawVc {
+        RawVc::TaskOutput(self.backend.get_or_create_transient_task(
+            CachedTaskType::Native {
+                fn_type: func,
+                this: Some(this),
+                arg,
+            },
+            current_task("turbo_function calls"),
+            self,
+        ))
+    }
+
     pub fn dynamic_call(&self, func: FunctionId, arg: Box<dyn MagicAny>) -> RawVc {
         if registry::get_function(func).arg_meta.is_resolved(&*arg) {
             self.native_call(func, arg)
         } else {
             RawVc::TaskOutput(self.backend.get_or_create_persistent_task(
-                PersistentTaskType::ResolveNative {
+                CachedTaskType::ResolveNative {
                     fn_type: func,
                     this: None,
                     arg,
@@ -391,8 +450,22 @@ impl<B: Backend + 'static> TurboTasks<B> {
         }
     }
 
-    /// Calls a native function with arguments. Resolves arguments when needed
-    /// with a wrapper task.
+    pub fn transient_dynamic_call(&self, func: FunctionId, arg: Box<dyn MagicAny>) -> RawVc {
+        if registry::get_function(func).arg_meta.is_resolved(&*arg) {
+            self.transient_native_call(func, arg)
+        } else {
+            RawVc::TaskOutput(self.backend.get_or_create_transient_task(
+                CachedTaskType::ResolveNative {
+                    fn_type: func,
+                    this: None,
+                    arg,
+                },
+                current_task("turbo_function calls"),
+                self,
+            ))
+        }
+    }
+
     pub fn dynamic_this_call(
         &self,
         func: FunctionId,
@@ -403,7 +476,7 @@ impl<B: Backend + 'static> TurboTasks<B> {
             self.this_call(func, this, arg)
         } else {
             RawVc::TaskOutput(self.backend.get_or_create_persistent_task(
-                PersistentTaskType::ResolveNative {
+                CachedTaskType::ResolveNative {
                     fn_type: func,
                     this: Some(this),
                     arg,
@@ -414,8 +487,27 @@ impl<B: Backend + 'static> TurboTasks<B> {
         }
     }
 
-    /// Calls a trait method with arguments. First input is the `self` object.
-    /// Uses a wrapper task to resolve
+    pub fn transient_dynamic_this_call(
+        &self,
+        func: FunctionId,
+        this: RawVc,
+        arg: Box<dyn MagicAny>,
+    ) -> RawVc {
+        if this.is_resolved() && registry::get_function(func).arg_meta.is_resolved(&*arg) {
+            self.transient_this_call(func, this, arg)
+        } else {
+            RawVc::TaskOutput(self.backend.get_or_create_transient_task(
+                CachedTaskType::ResolveNative {
+                    fn_type: func,
+                    this: Some(this),
+                    arg,
+                },
+                current_task("turbo_function calls"),
+                self,
+            ))
+        }
+    }
+
     pub fn trait_call(
         &self,
         trait_type: TraitTypeId,
@@ -439,7 +531,41 @@ impl<B: Backend + 'static> TurboTasks<B> {
 
         // create a wrapper task to resolve all inputs
         RawVc::TaskOutput(self.backend.get_or_create_persistent_task(
-            PersistentTaskType::ResolveTrait {
+            CachedTaskType::ResolveTrait {
+                trait_type,
+                method_name: trait_fn_name,
+                this,
+                arg,
+            },
+            current_task("turbo_function calls"),
+            self,
+        ))
+    }
+
+    pub fn transient_trait_call(
+        &self,
+        trait_type: TraitTypeId,
+        mut trait_fn_name: Cow<'static, str>,
+        this: RawVc,
+        arg: Box<dyn MagicAny>,
+    ) -> RawVc {
+        // avoid creating a wrapper task if self is already resolved
+        // for resolved cells we already know the value type so we can lookup the
+        // function
+        if let RawVc::TaskCell(_, CellId { type_id, .. }) = this {
+            match get_trait_method(trait_type, type_id, trait_fn_name) {
+                Ok(native_fn) => {
+                    return self.transient_dynamic_this_call(native_fn, this, arg);
+                }
+                Err(name) => {
+                    trait_fn_name = name;
+                }
+            }
+        }
+
+        // create a wrapper task to resolve all inputs
+        RawVc::TaskOutput(self.backend.get_or_create_transient_task(
+            CachedTaskType::ResolveTrait {
                 trait_type,
                 method_name: trait_fn_name,
                 this,
@@ -832,14 +958,31 @@ impl<B: Backend + 'static> TurboTasksCallApi for TurboTasks<B> {
     fn dynamic_call(&self, func: FunctionId, arg: Box<dyn MagicAny>) -> RawVc {
         self.dynamic_call(func, arg)
     }
+    fn transient_dynamic_call(&self, func: FunctionId, arg: Box<dyn MagicAny>) -> RawVc {
+        self.transient_dynamic_call(func, arg)
+    }
     fn dynamic_this_call(&self, func: FunctionId, this: RawVc, arg: Box<dyn MagicAny>) -> RawVc {
         self.dynamic_this_call(func, this, arg)
+    }
+    fn transient_dynamic_this_call(
+        &self,
+        func: FunctionId,
+        this: RawVc,
+        arg: Box<dyn MagicAny>,
+    ) -> RawVc {
+        self.transient_dynamic_this_call(func, this, arg)
     }
     fn native_call(&self, func: FunctionId, arg: Box<dyn MagicAny>) -> RawVc {
         self.native_call(func, arg)
     }
+    fn transient_native_call(&self, func: FunctionId, arg: Box<dyn MagicAny>) -> RawVc {
+        self.transient_native_call(func, arg)
+    }
     fn this_call(&self, func: FunctionId, this: RawVc, arg: Box<dyn MagicAny>) -> RawVc {
         self.this_call(func, this, arg)
+    }
+    fn transient_this_call(&self, func: FunctionId, this: RawVc, arg: Box<dyn MagicAny>) -> RawVc {
+        self.transient_this_call(func, this, arg)
     }
     fn trait_call(
         &self,
@@ -849,6 +992,15 @@ impl<B: Backend + 'static> TurboTasksCallApi for TurboTasks<B> {
         arg: Box<dyn MagicAny>,
     ) -> RawVc {
         self.trait_call(trait_type, trait_fn_name, this, arg)
+    }
+    fn transient_trait_call(
+        &self,
+        trait_type: TraitTypeId,
+        trait_fn_name: Cow<'static, str>,
+        this: RawVc,
+        arg: Box<dyn MagicAny>,
+    ) -> RawVc {
+        self.transient_trait_call(trait_type, trait_fn_name, this, arg)
     }
 
     #[track_caller]
@@ -1335,10 +1487,22 @@ pub fn dynamic_call(func: FunctionId, arg: Box<dyn MagicAny>) -> RawVc {
     with_turbo_tasks(|tt| tt.dynamic_call(func, arg))
 }
 
+/// Calls [`TurboTasks::transient_dynamic_call`] for the current turbo tasks
+/// instance.
+pub fn transient_dynamic_call(func: FunctionId, arg: Box<dyn MagicAny>) -> RawVc {
+    with_turbo_tasks(|tt| tt.transient_dynamic_call(func, arg))
+}
+
 /// Calls [`TurboTasks::dynamic_this_call`] for the current turbo tasks
 /// instance.
 pub fn dynamic_this_call(func: FunctionId, this: RawVc, arg: Box<dyn MagicAny>) -> RawVc {
     with_turbo_tasks(|tt| tt.dynamic_this_call(func, this, arg))
+}
+
+/// Calls [`TurboTasks::transient_dynamic_this_call`] for the current turbo
+/// tasks instance.
+pub fn transient_dynamic_this_call(func: FunctionId, this: RawVc, arg: Box<dyn MagicAny>) -> RawVc {
+    with_turbo_tasks(|tt| tt.transient_dynamic_this_call(func, this, arg))
 }
 
 /// Calls [`TurboTasks::trait_call`] for the current turbo tasks instance.
@@ -1349,6 +1513,17 @@ pub fn trait_call(
     arg: Box<dyn MagicAny>,
 ) -> RawVc {
     with_turbo_tasks(|tt| tt.trait_call(trait_type, trait_fn_name, this, arg))
+}
+
+/// Calls [`TurboTasks::transient_trait_call`] for the current turbo tasks
+/// instance.
+pub fn transient_trait_call(
+    trait_type: TraitTypeId,
+    trait_fn_name: Cow<'static, str>,
+    this: RawVc,
+    arg: Box<dyn MagicAny>,
+) -> RawVc {
+    with_turbo_tasks(|tt| tt.transient_trait_call(trait_type, trait_fn_name, this, arg))
 }
 
 pub fn turbo_tasks() -> Arc<dyn TurboTasksApi> {

--- a/crates/turbo-tasks/src/manager.rs
+++ b/crates/turbo-tasks/src/manager.rs
@@ -30,7 +30,7 @@ use crate::{
     },
     capture_future::{self, CaptureFuture},
     event::{Event, EventListener},
-    id::{BackendJobId, FunctionId, TraitTypeId},
+    id::{BackendJobId, FunctionId, TraitTypeId, TRANSIENT_TASK_BIT},
     id_factory::IdFactoryWithReuse,
     magic_any::MagicAny,
     raw_vc::{CellId, RawVc},
@@ -136,22 +136,6 @@ pub trait TurboTasksApi: TurboTasksCallApi + Sync + Send {
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'static>>;
 }
 
-pub trait TaskIdProvider {
-    fn get_fresh_task_id(&self) -> Unused<TaskId>;
-    fn reuse_task_id(&self, id: Unused<TaskId>);
-}
-
-impl TaskIdProvider for IdFactoryWithReuse<TaskId> {
-    fn get_fresh_task_id(&self) -> Unused<TaskId> {
-        // Safety: This is a fresh id from the factory
-        unsafe { Unused::new_unchecked(self.get()) }
-    }
-
-    fn reuse_task_id(&self, id: Unused<TaskId>) {
-        unsafe { self.reuse(id.into()) }
-    }
-}
-
 /// A wrapper around a value that is unused.
 pub struct Unused<T> {
     inner: T,
@@ -182,10 +166,13 @@ impl<T> Unused<T> {
     }
 }
 
-pub trait TurboTasksBackendApi<B: Backend + 'static>:
-    TaskIdProvider + TurboTasksCallApi + Sync + Send
-{
+pub trait TurboTasksBackendApi<B: Backend + 'static>: TurboTasksCallApi + Sync + Send {
     fn pin(&self) -> Arc<dyn TurboTasksBackendApi<B>>;
+
+    fn get_fresh_persistent_task_id(&self) -> Unused<TaskId>;
+    fn get_fresh_transient_task_id(&self) -> Unused<TaskId>;
+    unsafe fn reuse_persistent_task_id(&self, id: Unused<TaskId>);
+    unsafe fn reuse_transient_task_id(&self, id: Unused<TaskId>);
 
     fn schedule(&self, task: TaskId);
     fn schedule_backend_background_job(&self, id: BackendJobId);
@@ -210,26 +197,6 @@ pub trait TurboTasksBackendApi<B: Backend + 'static>:
     fn backend(&self) -> &B;
 }
 
-impl<B: Backend + 'static> TaskIdProvider for &dyn TurboTasksBackendApi<B> {
-    fn get_fresh_task_id(&self) -> Unused<TaskId> {
-        (*self).get_fresh_task_id()
-    }
-
-    fn reuse_task_id(&self, id: Unused<TaskId>) {
-        (*self).reuse_task_id(id)
-    }
-}
-
-impl TaskIdProvider for &dyn TaskIdProvider {
-    fn get_fresh_task_id(&self) -> Unused<TaskId> {
-        (*self).get_fresh_task_id()
-    }
-
-    fn reuse_task_id(&self, id: Unused<TaskId>) {
-        (*self).reuse_task_id(id)
-    }
-}
-
 #[allow(clippy::manual_non_exhaustive)]
 pub struct UpdateInfo {
     pub duration: Duration,
@@ -243,6 +210,7 @@ pub struct TurboTasks<B: Backend + 'static> {
     this: Weak<Self>,
     backend: B,
     task_id_factory: IdFactoryWithReuse<TaskId>,
+    transient_task_id_factory: IdFactoryWithReuse<TaskId>,
     stopped: AtomicBool,
     currently_scheduled_tasks: AtomicUsize,
     currently_scheduled_foreground_jobs: AtomicUsize,
@@ -287,12 +255,16 @@ impl<B: Backend + 'static> TurboTasks<B> {
     // so we probably want to make sure that all tasks are joined
     // when trying to drop turbo tasks
     pub fn new(mut backend: B) -> Arc<Self> {
-        let task_id_factory = IdFactoryWithReuse::new();
-        backend.initialize(&task_id_factory);
+        let task_id_factory =
+            IdFactoryWithReuse::new_with_range(1, (TRANSIENT_TASK_BIT - 1) as u64);
+        let transient_task_id_factory =
+            IdFactoryWithReuse::new_with_range(TRANSIENT_TASK_BIT as u64, u32::MAX as u64);
+        backend.initialize();
         let this = Arc::new_cyclic(|this| Self {
             this: this.clone(),
             backend,
             task_id_factory,
+            transient_task_id_factory,
             stopped: AtomicBool::new(false),
             currently_scheduled_tasks: AtomicUsize::new(0),
             currently_scheduled_background_jobs: AtomicUsize::new(0),
@@ -1088,6 +1060,7 @@ impl<B: Backend + 'static> TurboTasksBackendApi<B> for TurboTasks<B> {
     fn backend(&self) -> &B {
         &self.backend
     }
+
     #[track_caller]
     fn schedule_backend_background_job(&self, id: BackendJobId) {
         self.schedule_background_job(move |this| async move {
@@ -1175,16 +1148,23 @@ impl<B: Backend + 'static> TurboTasksBackendApi<B> for TurboTasks<B> {
     fn program_duration_until(&self, instant: Instant) -> Duration {
         instant - self.program_start
     }
-}
 
-impl<B: Backend + 'static> TaskIdProvider for TurboTasks<B> {
-    fn get_fresh_task_id(&self) -> Unused<TaskId> {
-        // Safety: This is a fresh id from the factory
+    fn get_fresh_persistent_task_id(&self) -> Unused<TaskId> {
+        // SAFETY: This is a fresh id from the factory
         unsafe { Unused::new_unchecked(self.task_id_factory.get()) }
     }
 
-    fn reuse_task_id(&self, id: Unused<TaskId>) {
+    fn get_fresh_transient_task_id(&self) -> Unused<TaskId> {
+        // SAFETY: This is a fresh id from the factory
+        unsafe { Unused::new_unchecked(self.transient_task_id_factory.get()) }
+    }
+
+    unsafe fn reuse_persistent_task_id(&self, id: Unused<TaskId>) {
         unsafe { self.task_id_factory.reuse(id.into()) }
+    }
+
+    unsafe fn reuse_transient_task_id(&self, id: Unused<TaskId>) {
+        unsafe { self.transient_task_id_factory.reuse(id.into()) }
     }
 }
 

--- a/crates/turbo-tasks/src/persisted_graph.rs
+++ b/crates/turbo-tasks/src/persisted_graph.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use serde::{ser::SerializeSeq, Deserialize, Serialize};
 
 use crate::{
-    backend::{CellContent, PersistentTaskType},
+    backend::{CachedTaskType, CellContent},
     task::shared_reference::TypedSharedReference,
     CellId, RawVc, TaskId,
 };
@@ -160,14 +160,14 @@ pub trait PersistedGraph: Sync + Send {
     /// returns false if that were too many
     fn lookup(
         &self,
-        partial_task_type: &PersistentTaskType,
+        partial_task_type: &CachedTaskType,
         api: &dyn PersistedGraphApi,
     ) -> Result<bool>;
 
     /// lookup one cache entry
     fn lookup_one(
         &self,
-        task_type: &PersistentTaskType,
+        task_type: &CachedTaskType,
         api: &dyn PersistedGraphApi,
     ) -> Result<Option<TaskId>>;
 
@@ -252,9 +252,9 @@ pub trait PersistedGraph: Sync + Send {
 }
 
 pub trait PersistedGraphApi {
-    fn get_or_create_task_type(&self, ty: PersistentTaskType) -> TaskId;
+    fn get_or_create_task_type(&self, ty: CachedTaskType) -> TaskId;
 
-    fn lookup_task_type(&self, id: TaskId) -> &PersistentTaskType;
+    fn lookup_task_type(&self, id: TaskId) -> &CachedTaskType;
 }
 
 /*
@@ -262,8 +262,8 @@ pub trait PersistedGraphApi {
 read:
 
   data: (TaskId) => (TaskData)
-  cache: (PersistentTaskType) => (TaskId)
-  type: (TaskId) => (PersistentTaskType)
+  cache: (CachedTaskType) => (TaskId)
+  type: (TaskId) => (CachedTaskType)
 
 read_dependents:
 
@@ -293,7 +293,7 @@ impl PersistedGraph for () {
 
     fn lookup(
         &self,
-        _partial_task_type: &PersistentTaskType,
+        _partial_task_type: &CachedTaskType,
         _api: &dyn PersistedGraphApi,
     ) -> Result<bool> {
         Ok(false)
@@ -301,7 +301,7 @@ impl PersistedGraph for () {
 
     fn lookup_one(
         &self,
-        _task_type: &PersistentTaskType,
+        _task_type: &CachedTaskType,
         _api: &dyn PersistedGraphApi,
     ) -> Result<Option<TaskId>> {
         Ok(None)

--- a/crates/turbo-tasks/src/task/task_input.rs
+++ b/crates/turbo-tasks/src/task/task_input.rs
@@ -107,7 +107,7 @@ where
     }
 
     fn is_transient(&self) -> bool {
-        false
+        self.node.get_task_id().is_transient()
     }
 
     async fn resolve(&self) -> Result<Self> {
@@ -124,7 +124,7 @@ where
     }
 
     fn is_transient(&self) -> bool {
-        false
+        self.node.node.get_task_id().is_transient()
     }
 }
 
@@ -189,7 +189,7 @@ where
 
 impl<T> TaskInput for TransientInstance<T>
 where
-    T: Sync + Send,
+    T: Sync + Send + 'static,
 {
     fn is_transient(&self) -> bool {
         true


### PR DESCRIPTION
### Description

Track which tasks are transient and which are persistent. We need to track that for persistent caching.

We used a different task id space for transient tasks so they don't use up persistent ids and to easily identify transient tasks.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
