### PR TITLE
Don't impl PartialEq/Eq for SharedReference and wrapper types

### DIFF
--- a/crates/turbo-tasks-memory/src/cell.rs
+++ b/crates/turbo-tasks-memory/src/cell.rs
@@ -225,7 +225,7 @@ impl Cell {
                 content: ref mut cell_content,
                 dependent_tasks,
             } => {
-                if content != *cell_content {
+                if content.ptr_eq(cell_content) {
                     if !dependent_tasks.is_empty() {
                         turbo_tasks.schedule_notify_tasks_set(dependent_tasks);
                         dependent_tasks.clear();

--- a/crates/turbo-tasks/src/backend.rs
+++ b/crates/turbo-tasks/src/backend.rs
@@ -335,7 +335,7 @@ pub struct TaskExecutionSpec<'a> {
 
 // TODO technically CellContent is already indexed by the ValueTypeId, so we
 // don't need to store it here
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct CellContent(pub Option<SharedReference>);
 
 impl Display for CellContent {
@@ -376,6 +376,14 @@ impl CellContent {
 
     pub fn try_cast<T: Any + VcValueType>(self) -> Option<ReadRef<T>> {
         Some(ReadRef::new_arc(self.0?.downcast().ok()?))
+    }
+
+    pub fn ptr_eq(&self, other: &Self) -> bool {
+        match (&self.0, &other.0) {
+            (Some(this), Some(other)) => this.ptr_eq(other),
+            (None, None) => true,
+            (_, _) => false,
+        }
     }
 }
 

--- a/crates/turbo-tasks/src/manager.rs
+++ b/crates/turbo-tasks/src/manager.rs
@@ -1575,7 +1575,7 @@ impl CurrentCellRef {
         let tt = turbo_tasks();
         let content = tt.read_own_task_cell(self.current_task, self.index).ok();
         let update = if let Some(CellContent(Some(content))) = content {
-            content != shared_ref
+            content.ptr_eq(&shared_ref)
         } else {
             true
         };

--- a/crates/turbo-tasks/src/task/shared_reference.rs
+++ b/crates/turbo-tasks/src/task/shared_reference.rs
@@ -1,7 +1,6 @@
 use std::{
     any::Any,
     fmt::{Debug, Display},
-    hash::Hash,
 };
 
 use anyhow::Result;
@@ -32,22 +31,11 @@ impl SharedReference {
             Err(data) => Err(Self(self.0, data)),
         }
     }
-}
 
-impl Hash for SharedReference {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        Hash::hash(&(&*self.1 as *const (dyn Any + Send + Sync)), state)
-    }
-}
-impl PartialEq for SharedReference {
-    // Must compare with PartialEq rather than std::ptr::addr_eq since the latter
-    // only compares their addresses.
-    #[allow(ambiguous_wide_pointer_comparisons)]
-    fn eq(&self, other: &Self) -> bool {
+    pub fn ptr_eq(&self, other: &Self) -> bool {
         triomphe::Arc::ptr_eq(&self.1, &other.1)
     }
 }
-impl Eq for SharedReference {}
 
 impl Debug for SharedReference {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/turbo-tasks/src/trait_ref.rs
+++ b/crates/turbo-tasks/src/trait_ref.rs
@@ -40,20 +40,6 @@ impl<T> Clone for TraitRef<T> {
     }
 }
 
-impl<T> PartialEq for TraitRef<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.shared_reference == other.shared_reference
-    }
-}
-
-impl<T> Eq for TraitRef<T> {}
-
-impl<T> std::hash::Hash for TraitRef<T> {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.shared_reference.hash(state)
-    }
-}
-
 impl<T> Serialize for TraitRef<T> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         self.shared_reference.serialize(serializer)
@@ -88,6 +74,10 @@ where
             shared_reference,
             _t: PhantomData,
         }
+    }
+
+    pub fn ptr_eq(&self, other: &Self) -> bool {
+        self.shared_reference.ptr_eq(&other.shared_reference)
     }
 }
 

--- a/crates/turbo-tasks/src/value.rs
+++ b/crates/turbo-tasks/src/value.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, marker::PhantomData, ops::Deref};
+use std::{fmt::Debug, hash::Hash, marker::PhantomData, ops::Deref};
 
 use serde::{Deserialize, Serialize};
 
@@ -91,17 +91,17 @@ impl<T> Clone for TransientInstance<T> {
     }
 }
 
-impl<T> Eq for TransientInstance<T> {}
-
 impl<T> PartialEq for TransientInstance<T> {
     fn eq(&self, other: &Self) -> bool {
-        self.inner == other.inner
+        self.inner.ptr_eq(&other.inner)
     }
 }
 
-impl<T> std::hash::Hash for TransientInstance<T> {
+impl<T> Eq for TransientInstance<T> {}
+
+impl<T> Hash for TransientInstance<T> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.inner.hash(state);
+        self.inner.1.as_ptr().hash(state);
     }
 }
 


### PR DESCRIPTION
### Description

Where feasible (I gave up on `TransientInstance<T>`) don't impl `PartialEq`, `Eq` or `Hash` for `SharedReference` or it's various wrapper types.

These were previously using identity for equality, but I strongly prefer a more explicit approach (akin to `Arc::ptr_eq`) when using identity equality because it can lead to caching bugs where the caller didn't realize and expected value equality.

### Testing Instructions

This breaks the nextjs build and would require a companion nextjs PR if we wanted to go forward with this.