### PR TITLE
Add a GlobalInformation struct

### DIFF
--- a/crates/turbopack-browser/src/chunking_context.rs
+++ b/crates/turbopack-browser/src/chunking_context.rs
@@ -6,6 +6,7 @@ use turbopack_core::{
     chunk::{
         availability_info::AvailabilityInfo,
         chunk_group::{make_chunk_group, MakeChunkGroupResult},
+        global_information::OptionGlobalInformation,
         Chunk, ChunkGroupResult, ChunkItem, ChunkableModule, ChunkingContext,
         EntryChunkGroupResult, EvaluatableAssets, MinifyType, ModuleId,
     },
@@ -122,6 +123,8 @@ pub struct BrowserChunkingContext {
     minify_type: MinifyType,
     /// Whether to use manifest chunks for lazy compilation
     manifest_chunks: bool,
+    /// Global information
+    global_information: Vc<OptionGlobalInformation>,
 }
 
 impl BrowserChunkingContext {
@@ -133,6 +136,7 @@ impl BrowserChunkingContext {
         asset_root_path: Vc<FileSystemPath>,
         environment: Vc<Environment>,
         runtime_type: RuntimeType,
+        global_information: Vc<OptionGlobalInformation>,
     ) -> BrowserChunkingContextBuilder {
         BrowserChunkingContextBuilder {
             chunking_context: BrowserChunkingContext {
@@ -151,6 +155,7 @@ impl BrowserChunkingContext {
                 runtime_type,
                 minify_type: MinifyType::NoMinify,
                 manifest_chunks: false,
+                global_information,
             },
         }
     }

--- a/crates/turbopack-cli/src/build/mod.rs
+++ b/crates/turbopack-cli/src/build/mod.rs
@@ -197,6 +197,7 @@ async fn build_internal(
                 NodeEnv::Development => RuntimeType::Development,
                 NodeEnv::Production => RuntimeType::Production,
             },
+            Vc::cell(None),
         )
         .minify_type(minify_type)
         .build(),

--- a/crates/turbopack-cli/src/dev/mod.rs
+++ b/crates/turbopack-cli/src/dev/mod.rs
@@ -255,6 +255,7 @@ async fn source(
         build_output_root.join("assets".into()),
         node_build_environment(),
         RuntimeType::Development,
+        Vc::cell(None),
     )
     .build();
 

--- a/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -45,6 +45,7 @@ pub fn get_client_chunking_context(
             server_root.join("/_assets".into()),
             environment,
             RuntimeType::Development,
+            Vc::cell(None),
         )
         .hot_module_replacement()
         .build(),

--- a/crates/turbopack-core/src/chunk/global_information.rs
+++ b/crates/turbopack-core/src/chunk/global_information.rs
@@ -1,0 +1,6 @@
+#[turbo_tasks::value]
+#[derive(Clone, Debug)]
+pub struct GlobalInformation {}
+
+#[turbo_tasks::value(transparent)]
+pub struct OptionGlobalInformation(Option<GlobalInformation>);

--- a/crates/turbopack-core/src/chunk/mod.rs
+++ b/crates/turbopack-core/src/chunk/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod chunking_context;
 pub(crate) mod containment_tree;
 pub(crate) mod data;
 pub(crate) mod evaluate;
+pub mod global_information;
 pub mod optimize;
 
 use std::{

--- a/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/crates/turbopack-nodejs/src/chunking_context.rs
@@ -8,6 +8,7 @@ use turbopack_core::{
     chunk::{
         availability_info::AvailabilityInfo,
         chunk_group::{make_chunk_group, MakeChunkGroupResult},
+        global_information::OptionGlobalInformation,
         Chunk, ChunkGroupResult, ChunkItem, ChunkableModule, ChunkingContext,
         EntryChunkGroupResult, EvaluatableAssets, MinifyType, ModuleId,
     },
@@ -84,6 +85,8 @@ pub struct NodeJsChunkingContext {
     minify_type: MinifyType,
     /// Whether to use manifest chunks for lazy compilation
     manifest_chunks: bool,
+    /// Global information
+    global_information: Vc<OptionGlobalInformation>,
 }
 
 impl NodeJsChunkingContext {
@@ -96,6 +99,7 @@ impl NodeJsChunkingContext {
         asset_root_path: Vc<FileSystemPath>,
         environment: Vc<Environment>,
         runtime_type: RuntimeType,
+        global_information: Vc<OptionGlobalInformation>,
     ) -> NodeJsChunkingContextBuilder {
         NodeJsChunkingContextBuilder {
             chunking_context: NodeJsChunkingContext {
@@ -109,6 +113,7 @@ impl NodeJsChunkingContext {
                 runtime_type,
                 minify_type: MinifyType::NoMinify,
                 manifest_chunks: false,
+                global_information,
             },
         }
     }
@@ -131,6 +136,14 @@ impl NodeJsChunkingContext {
 
 #[turbo_tasks::value_impl]
 impl NodeJsChunkingContext {
+    #[turbo_tasks::function]
+    async fn chunk_item_id_from_ident(
+        self: Vc<Self>,
+        ident: Vc<AssetIdent>,
+    ) -> Result<Vc<ModuleId>> {
+        Ok(ModuleId::String(ident.to_string().await?.clone_value()).cell())
+    }
+
     #[turbo_tasks::function]
     fn new(this: Value<NodeJsChunkingContext>) -> Vc<Self> {
         this.into_value().cell()

--- a/crates/turbopack-tests/tests/execution.rs
+++ b/crates/turbopack-tests/tests/execution.rs
@@ -322,6 +322,7 @@ async fn run_test(prepared_test: Vc<PreparedTest>) -> Result<Vc<RunTestResult>> 
         static_root_path,
         env,
         RuntimeType::Development,
+        Vc::cell(None),
     )
     .build();
 

--- a/crates/turbopack-tests/tests/snapshot.rs
+++ b/crates/turbopack-tests/tests/snapshot.rs
@@ -319,6 +319,7 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                 static_root_path,
                 env,
                 options.runtime_type,
+                Vc::cell(None),
             )
             .build(),
         ),
@@ -331,6 +332,7 @@ async fn run_test(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                 static_root_path,
                 env,
                 options.runtime_type,
+                Vc::cell(None),
             )
             .minify_type(options.minify_type)
             .build(),


### PR DESCRIPTION
### Description

A `GlobalInformation` struct is added, which is made available through the `ChunkingContext` trait. Constructing a new `GlobalInformation` takes a `Project` parameter, which gives the constructor access to global information. `ChunkingContext` builder methods now also take a `GlobalInformation` object.

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
