### PR TITLE
[FIX] Docs: Registering Root Tasks - Incorrect/Unclear example

### DIFF
--- a/docs/repo-docs/crafting-your-repository/configuring-tasks.mdx
+++ b/docs/repo-docs/crafting-your-repository/configuring-tasks.mdx
@@ -280,7 +280,7 @@ You can also run scripts in the `package.json` in the Workspace root using `turb
 ```json title="./package.json"
 {
   "scripts": {
-    "lint": "turbo run lint",
+    "lint": "turbo run lint lint:root",
     "lint:root": "eslint ." // [!code highlight]
   }
 }


### PR DESCRIPTION
### Description

Updates example for adding a root task, and calling it along with the other package level tasks.

### Testing Instructions

Review options listed in issue https://github.com/vercel/turbo/issues/8972, and confirm this is the correct implementation of this example.
