### PR TITLE
feat: implement a query interface for turborepo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2114,9 +2114,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.6"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2370,7 +2370,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.6",
+ "h2 0.4.5",
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad445822218ce64be7a341abfb0b1ea43b5c23aa83902542a4542e78309d8e5e"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -289,13 +289,13 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -306,9 +306,9 @@ checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.73"
+version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -768,9 +768,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "camino"
@@ -866,7 +866,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -906,7 +906,7 @@ version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.58",
@@ -1165,7 +1165,7 @@ dependencies = [
  "bitflags 1.3.2",
  "crossterm_winapi",
  "libc",
- "mio",
+ "mio 0.8.11",
  "parking_lot",
  "signal-hook",
  "signal-hook-mio",
@@ -1181,7 +1181,7 @@ dependencies = [
  "bitflags 2.5.0",
  "crossterm_winapi",
  "libc",
- "mio",
+ "mio 0.8.11",
  "parking_lot",
  "signal-hook",
  "signal-hook-mio",
@@ -1536,9 +1536,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "filedescriptor"
@@ -1901,6 +1901,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,9 +1917,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.2"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -2229,7 +2235,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -2255,7 +2261,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi 0.3.9",
  "rustix 0.38.31",
  "windows-sys 0.48.0",
 ]
@@ -2720,6 +2726,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+ "wasi",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2893,7 +2911,7 @@ dependencies = [
  "kqueue",
  "libc",
  "log",
- "mio",
+ "mio 0.8.11",
  "walkdir",
  "windows-sys 0.48.0",
 ]
@@ -2925,9 +2943,9 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
-version = "0.2.16"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -2938,7 +2956,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -3144,9 +3162,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.7.9"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fb059dee1a7b802f036316d790138c613a4e8b180c822e3925a662e9f0c95"
+checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
 dependencies = [
  "memchr",
  "thiserror",
@@ -3231,9 +3249,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -3455,7 +3473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c828f93f5ca4826f97fedcbd3f9a536c16b12cff3dbbb4a007f932bbad95b12"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.4.1",
  "itertools 0.10.5",
  "lazy_static",
  "log",
@@ -4228,7 +4246,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
 dependencies = [
  "libc",
- "mio",
+ "mio 0.8.11",
  "signal-hook",
 ]
 
@@ -4357,9 +4375,9 @@ checksum = "e9557cb6521e8d009c51a8666f09356f4b817ba9ba0981a305bd86aee47bd35c"
 
 [[package]]
 name = "strsim"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "struct_iterable"
@@ -4392,20 +4410,20 @@ checksum = "e9426b2a0c03e6cc2ea8dbc0168dbbf943f88755e409fb91bcb8f6a268305f4a"
 
 [[package]]
 name = "strum"
-version = "0.26.1"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.1"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -4557,15 +4575,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.8.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.0",
- "redox_syscall 0.3.5",
+ "fastrand 2.1.0",
+ "once_cell",
  "rustix 0.38.31",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4760,21 +4778,20 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.32.0"
+version = "1.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio",
- "num_cpus",
+ "mio 1.0.2",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.6",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4789,9 +4806,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6281,7 +6298,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6316,18 +6342,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -6344,9 +6370,9 @@ checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -6362,9 +6388,9 @@ checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6380,15 +6406,15 @@ checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6404,9 +6430,9 @@ checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6422,9 +6448,9 @@ checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6440,9 +6466,9 @@ checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6458,9 +6484,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,11 +479,7 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "tokio",
  "tower",
  "tower-layer",
  "tower-service",
@@ -576,6 +572,25 @@ dependencies = [
  "http-body 0.4.5",
  "hyper 0.14.28",
  "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56bac90848f6a9393ac03c63c640925c4b7c8ca21654de40d53f55964667c7d8"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower",
  "tower-service",
 ]
 
@@ -2098,6 +2113,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "handlebars"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2313,7 +2347,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.24",
  "http 0.2.11",
  "http-body 0.4.5",
  "httparse",
@@ -2336,6 +2370,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2 0.4.6",
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
@@ -4046,7 +4081,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.24",
  "http 0.2.11",
  "http-body 0.4.5",
  "hyper 0.14.28",
@@ -5295,7 +5330,7 @@ dependencies = [
  "axum 0.6.12",
  "base64 0.21.4",
  "bytes",
- "h2",
+ "h2 0.3.24",
  "http 0.2.11",
  "http-body 0.4.5",
  "hyper 0.14.28",
@@ -5650,8 +5685,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum 0.6.12",
- "axum-server",
+ "axum 0.7.5",
+ "axum-server 0.7.1",
  "chrono",
  "hostname",
  "lazy_static",
@@ -5812,7 +5847,7 @@ dependencies = [
  "async-io",
  "async-stream",
  "atty",
- "axum 0.6.12",
+ "axum 0.7.5",
  "biome_deserialize",
  "biome_deserialize_macros",
  "biome_diagnostics",
@@ -6117,8 +6152,8 @@ name = "turborepo-vercel-api-mock"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "axum 0.6.12",
- "axum-server",
+ "axum 0.7.5",
+ "axum-server 0.4.7",
  "futures-util",
  "port_scanner",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 3
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +133,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
+name = "ascii_utils"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +201,98 @@ dependencies = [
  "blocking",
  "futures-lite",
  "once_cell",
+]
+
+[[package]]
+name = "async-graphql"
+version = "7.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b76aba2f176af685c2229633881a3adeae51f87ae1811781e73910b7001c93e"
+dependencies = [
+ "async-graphql-derive",
+ "async-graphql-parser",
+ "async-graphql-value",
+ "async-stream",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "fast_chemail",
+ "fnv",
+ "futures-util",
+ "handlebars",
+ "http 1.1.0",
+ "indexmap 2.2.6",
+ "mime",
+ "multer",
+ "num-traits",
+ "once_cell",
+ "pin-project-lite",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "static_assertions_next",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "async-graphql-axum"
+version = "7.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686e48ce7820a1cf404b5c8e9b90ae24d03c867a408d8d651183945c7a554982"
+dependencies = [
+ "async-graphql",
+ "async-trait",
+ "axum 0.7.5",
+ "bytes",
+ "futures-util",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+]
+
+[[package]]
+name = "async-graphql-derive"
+version = "7.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72e2e26a6b44bc61df3ca8546402cf9204c28e30c06084cc8e75cd5e34d4f150"
+dependencies = [
+ "Inflector",
+ "async-graphql-parser",
+ "darling",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "strum",
+ "syn 2.0.58",
+ "thiserror",
+]
+
+[[package]]
+name = "async-graphql-parser"
+version = "7.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f801451484b4977d6fe67b29030f81353cabdcbb754e5a064f39493582dac0cf"
+dependencies = [
+ "async-graphql-value",
+ "pest",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-graphql-value"
+version = "7.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69117c43c01d81a69890a9f5dd6235f2f027ca8d1ec62d6d3c5e01ca0edb4f2b"
+dependencies = [
+ "bytes",
+ "indexmap 2.2.6",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -356,13 +464,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f8ccfd9221ee7d1f3d4b33e1f8319b3a81ed8f61f2ea40b37b859794b4491"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.3.3",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.11",
+ "http-body 0.4.5",
+ "hyper 0.14.28",
  "itoa",
  "matchit",
  "memchr",
@@ -374,11 +482,48 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tokio",
  "tower",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.3",
+ "base64 0.21.4",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper 1.0.1",
+ "tokio",
+ "tokio-tungstenite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -390,12 +535,33 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.11",
+ "http-body 0.4.5",
  "mime",
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 0.1.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -406,9 +572,9 @@ checksum = "bace45b270e36e3c27a190c65883de6dfc9f1d18c829907c127464815dc67b24"
 dependencies = [
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.11",
+ "http-body 0.4.5",
+ "hyper 0.14.28",
  "tokio",
  "tower-service",
 ]
@@ -771,6 +937,9 @@ name = "bytes"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "camino"
@@ -1265,6 +1434,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.58",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1276,6 +1480,12 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "debugid"
@@ -1524,6 +1734,15 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "fast_chemail"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "495a39d30d624c2caabe6312bfead73e7717692b44e0b32df168c275a2e8e9e4"
+dependencies = [
+ "ascii_utils",
+]
 
 [[package]]
 name = "fastrand"
@@ -1870,12 +2089,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.11",
  "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "handlebars"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08485b96a0e6393e9e4d1b8d48cf74ad6c063cd905eb33f42c1ce3f0377539b"
+dependencies = [
+ "log",
+ "pest",
+ "pest_derive",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -1959,13 +2192,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.11",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1994,7 +2261,7 @@ dependencies = [
  "crossbeam-utils",
  "form_urlencoded",
  "futures-util",
- "hyper",
+ "hyper 0.14.28",
  "isahc",
  "lazy_static",
  "levenshtein",
@@ -2047,8 +2314,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.11",
+ "http-body 0.4.5",
  "httparse",
  "httpdate",
  "itoa",
@@ -2061,13 +2328,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
- "http",
- "hyper",
+ "http 0.2.11",
+ "hyper 0.14.28",
  "rustls 0.20.9",
  "tokio",
  "tokio-rustls",
@@ -2079,7 +2365,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.28",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -2092,10 +2378,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.28",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.4.1",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2120,6 +2421,12 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -2286,7 +2593,7 @@ dependencies = [
  "encoding_rs",
  "event-listener",
  "futures-lite",
- "http",
+ "http 0.2.11",
  "log",
  "mime",
  "once_cell",
@@ -2727,14 +3034,31 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.1.0",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin 0.9.8",
+ "version_check",
 ]
 
 [[package]]
@@ -3414,6 +3738,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+dependencies = [
+ "toml_edit 0.21.1",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3714,9 +4047,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.11",
+ "http-body 0.4.5",
+ "hyper 0.14.28",
  "hyper-rustls",
  "hyper-tls",
  "ipnet",
@@ -4356,6 +4689,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "static_assertions_next"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7beae5182595e9a8b683fa98c4317f956c9a2dec3b9716990d20023cc60c766"
+
+[[package]]
 name = "stop-token"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4527,6 +4866,12 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "sysinfo"
@@ -4778,14 +5123,14 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.3"
+version = "1.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
+checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio 1.0.2",
+ "mio 1.0.1",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -4869,6 +5214,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4892,7 +5249,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.22.15",
 ]
 
 [[package]]
@@ -4902,6 +5259,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+dependencies = [
+ "indexmap 2.2.6",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -4924,13 +5292,13 @@ checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.6.12",
  "base64 0.21.4",
  "bytes",
  "h2",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.11",
+ "http-body 0.4.5",
+ "hyper 0.14.28",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -5166,6 +5534,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.1.0",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "turbo"
 version = "0.1.0"
 dependencies = [
@@ -5235,7 +5622,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "chrono",
- "http",
+ "http 0.2.11",
  "httpmock",
  "lazy_static",
  "port_scanner",
@@ -5263,7 +5650,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
+ "axum 0.6.12",
  "axum-server",
  "chrono",
  "hostname",
@@ -5420,10 +5807,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "async-graphql",
+ "async-graphql-axum",
  "async-io",
  "async-stream",
  "atty",
- "axum",
+ "axum 0.6.12",
  "biome_deserialize",
  "biome_deserialize_macros",
  "biome_diagnostics",
@@ -5728,7 +6117,7 @@ name = "turborepo-vercel-api-mock"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "axum",
+ "axum 0.6.12",
  "axum-server",
  "futures-util",
  "port_scanner",
@@ -5950,6 +6339,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8parse"
@@ -6487,6 +6882,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,8 +100,8 @@ async-compression = { version = "0.3.13", default-features = false, features = [
 ] }
 async-trait = "0.1.64"
 atty = "0.2.14"
-axum = "0.6.2"
-axum-server = "0.4.4"
+axum = "0.7.5"
+axum-server = "0.7.1"
 biome_console = { version = "0.5.7" }
 biome_deserialize = { version = "0.6.0", features = ["serde"] }
 biome_deserialize_macros = { version = "0.6.0" }

--- a/crates/turborepo-cache/src/lib.rs
+++ b/crates/turborepo-cache/src/lib.rs
@@ -103,7 +103,7 @@ pub struct CacheHitMetadata {
     pub time_saved: u64,
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct CacheOpts {
     pub cache_dir: Utf8PathBuf,
     pub remote_cache_read_only: bool,

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -32,6 +32,8 @@ turborepo-vercel-api-mock = { workspace = true }
 workspace = true
 
 [dependencies]
+async-graphql = "7.0.7"
+async-graphql-axum = "7.0.7"
 atty = { workspace = true }
 axum = { workspace = true }
 biome_deserialize = { workspace = true }

--- a/crates/turborepo-lib/src/cli/error.rs
+++ b/crates/turborepo-lib/src/cli/error.rs
@@ -10,6 +10,7 @@ use turborepo_ui::{color, BOLD, GREY};
 use crate::{
     commands::{bin, generate, ls, prune, run::get_signal, CommandBase},
     daemon::DaemonError,
+    query,
     rewrite_json::RewriteError,
     run,
     run::{builder::RunBuilder, watch},
@@ -53,6 +54,9 @@ pub enum Error {
     #[error(transparent)]
     #[diagnostic(transparent)]
     Run(#[from] run::Error),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Query(#[from] query::Error),
     #[error(transparent)]
     SerdeJson(#[from] serde_json::Error),
     #[error(transparent)]

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -588,7 +588,11 @@ pub enum Command {
         #[clap(flatten)]
         execution_args: Box<ExecutionArgs>,
     },
+    /// Query your monorepo using GraphQL. If no query is provided, spins up a
+    /// GraphQL server with GraphiQL.
+    #[clap(hide = true)]
     Query {
+        /// The query to run, either a file path or a query string
         query: Option<String>,
     },
     Watch(Box<ExecutionArgs>),

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1198,6 +1198,7 @@ pub async fn run(
             let filter = filter.clone();
             let packages = packages.clone();
             let base = CommandBase::new(cli_args, repo_root, version, color_config);
+
             ls::run(base, packages, event, filter, affected, output).await?;
 
             Ok(0)

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1310,6 +1310,7 @@ pub async fn run(
             Ok(exit_code)
         }
         Command::Query { query } => {
+            warn!("query command is experimental and may change in the future");
             let query = query.clone();
             let event = CommandEventBuilder::new("query").with_parent(&root_telemetry);
             event.track_call();

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -22,7 +22,7 @@ use turborepo_ui::{ColorConfig, GREY};
 use crate::{
     cli::error::print_potential_tasks,
     commands::{
-        bin, config, daemon, generate, link, login, logout, ls, prune, run, scan, telemetry,
+        bin, config, daemon, generate, link, login, logout, ls, prune, query, run, scan, telemetry,
         unlink, CommandBase,
     },
     get_version,
@@ -587,6 +587,9 @@ pub enum Command {
         run_args: Box<RunArgs>,
         #[clap(flatten)]
         execution_args: Box<ExecutionArgs>,
+    },
+    Query {
+        query: String,
     },
     Watch(Box<ExecutionArgs>),
     /// Unlink the current directory from your Vercel organization and disable
@@ -1301,6 +1304,16 @@ pub async fn run(
                 }
             })?;
             Ok(exit_code)
+        }
+        Command::Query { query } => {
+            let query = query.clone();
+            let event = CommandEventBuilder::new("query").with_parent(&root_telemetry);
+            event.track_call();
+            let base = CommandBase::new(cli_args, repo_root, version, ui);
+
+            let query = query::run(base, event, query).await?;
+
+            Ok(query)
         }
         Command::Watch(_) => {
             let event = CommandEventBuilder::new("watch").with_parent(&root_telemetry);

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -589,7 +589,7 @@ pub enum Command {
         execution_args: Box<ExecutionArgs>,
     },
     Query {
-        query: String,
+        query: Option<String>,
     },
     Watch(Box<ExecutionArgs>),
     /// Unlink the current directory from your Vercel organization and disable
@@ -1309,7 +1309,7 @@ pub async fn run(
             let query = query.clone();
             let event = CommandEventBuilder::new("query").with_parent(&root_telemetry);
             event.track_call();
-            let base = CommandBase::new(cli_args, repo_root, version, ui);
+            let base = CommandBase::new(cli_args, repo_root, version, color_config);
 
             let query = query::run(base, event, query).await?;
 

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -22,6 +22,7 @@ pub(crate) mod login;
 pub(crate) mod logout;
 pub(crate) mod ls;
 pub(crate) mod prune;
+pub(crate) mod query;
 pub(crate) mod run;
 pub(crate) mod scan;
 pub(crate) mod telemetry;

--- a/crates/turborepo-lib/src/commands/query.rs
+++ b/crates/turborepo-lib/src/commands/query.rs
@@ -1,0 +1,35 @@
+use async_graphql::{EmptyMutation, EmptySubscription, Schema};
+use turborepo_telemetry::events::command::CommandEventBuilder;
+
+use crate::{
+    cli::Command,
+    commands::{run::get_signal, CommandBase},
+    query::{Error, Query},
+    run::builder::RunBuilder,
+    signal::SignalHandler,
+};
+
+pub async fn run(
+    mut base: CommandBase,
+    telemetry: CommandEventBuilder,
+    query: String,
+) -> Result<i32, Error> {
+    let signal = get_signal()?;
+    let handler = SignalHandler::new(signal);
+
+    // We fake a run command, so we can construct a `Run` type
+    base.args_mut().command = Some(Command::Run {
+        run_args: Box::default(),
+        execution_args: Box::default(),
+    });
+
+    let run_builder = RunBuilder::new(base)?;
+    let run = run_builder.build(&handler, telemetry).await?;
+
+    let schema = Schema::new(Query::new(run), EmptyMutation, EmptySubscription);
+
+    let result = schema.execute(query).await;
+    println!("{}", serde_json::to_string_pretty(&result)?);
+
+    Ok(0)
+}

--- a/crates/turborepo-lib/src/commands/query.rs
+++ b/crates/turborepo-lib/src/commands/query.rs
@@ -1,4 +1,6 @@
-use async_graphql::{EmptyMutation, EmptySubscription, Schema};
+use async_graphql::{EmptyMutation, EmptySubscription, Schema, ServerError};
+use miette::{Diagnostic, Report, SourceSpan};
+use thiserror::Error;
 use turborepo_telemetry::events::command::CommandEventBuilder;
 
 use crate::{
@@ -8,6 +10,45 @@ use crate::{
     run::builder::RunBuilder,
     signal::SignalHandler,
 };
+
+#[derive(Debug, Diagnostic, Error)]
+#[error("{message}")]
+struct QueryError {
+    message: String,
+    #[source_code]
+    query: String,
+    #[label]
+    span: Option<SourceSpan>,
+    #[label]
+    span2: Option<SourceSpan>,
+    #[label]
+    span3: Option<SourceSpan>,
+}
+
+impl QueryError {
+    fn get_index_from_row_column(query: &str, row: usize, column: usize) -> usize {
+        let mut index = 0;
+        for line in query.lines().take(row + 1) {
+            index += line.len() + 1;
+        }
+        index + column
+    }
+    fn new(server_error: ServerError, query: String) -> Self {
+        let span: Option<SourceSpan> = server_error.locations.first().map(|location| {
+            let idx =
+                Self::get_index_from_row_column(query.as_ref(), location.line, location.column);
+            (idx, idx + 1).into()
+        });
+
+        QueryError {
+            message: server_error.message,
+            query,
+            span,
+            span2: None,
+            span3: None,
+        }
+    }
+}
 
 pub async fn run(
     mut base: CommandBase,
@@ -28,8 +69,15 @@ pub async fn run(
 
     let schema = Schema::new(Query::new(run), EmptyMutation, EmptySubscription);
 
-    let result = schema.execute(query).await;
-    println!("{}", serde_json::to_string_pretty(&result)?);
+    let result = schema.execute(&query).await;
+    if result.errors.is_empty() {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        for error in result.errors {
+            let error = QueryError::new(error, query.clone());
+            eprintln!("{:?}", Report::new(error));
+        }
+    }
 
     Ok(0)
 }

--- a/crates/turborepo-lib/src/daemon/default_timeout_layer.rs
+++ b/crates/turborepo-lib/src/daemon/default_timeout_layer.rs
@@ -85,7 +85,7 @@ mod test {
         sync::{Arc, Mutex},
     };
 
-    use axum::http::HeaderValue;
+    use reqwest::header::HeaderValue;
     use test_case::test_case;
 
     use super::*;

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -29,6 +29,7 @@ mod opts;
 mod package_changes_watcher;
 mod panic_handler;
 mod process;
+mod query;
 mod rewrite_json;
 mod run;
 mod shim;

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -37,7 +37,7 @@ pub enum Error {
     Config(#[from] crate::config::Error),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Opts {
     pub cache_opts: CacheOpts,
     pub run_opts: RunOpts,
@@ -127,7 +127,7 @@ struct OptsInputs<'a> {
     api_auth: &'a Option<APIAuth>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct RunCacheOpts {
     pub(crate) skip_reads: bool,
     pub(crate) skip_writes: bool,
@@ -144,7 +144,7 @@ impl<'a> From<OptsInputs<'a>> for RunCacheOpts {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct RunOpts {
     pub(crate) tasks: Vec<String>,
     pub(crate) concurrency: u32,
@@ -183,7 +183,7 @@ impl RunOpts {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum GraphOpts {
     Stdout,
     File(String),
@@ -302,7 +302,7 @@ impl From<LogPrefix> for ResolvedLogPrefix {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ScopeOpts {
     pub pkg_inference_root: Option<AnchoredSystemPathBuf>,
     pub global_deps: Vec<String>,

--- a/crates/turborepo-lib/src/query.rs
+++ b/crates/turborepo-lib/src/query.rs
@@ -1,0 +1,81 @@
+use std::sync::Arc;
+
+use async_graphql::*;
+use miette::Diagnostic;
+use thiserror::Error;
+use turborepo_repository::package_graph::{PackageName, PackageNode};
+
+use crate::run::Run;
+
+#[derive(Error, Debug, Diagnostic)]
+pub enum Error {
+    #[error("package not found: {0}")]
+    PackageNotFound(PackageName),
+    #[error("failed to serialize result: {0}")]
+    Serde(#[from] serde_json::Error),
+    #[error(transparent)]
+    Run(#[from] crate::run::Error),
+}
+
+pub struct Query {
+    run: Arc<Run>,
+}
+
+impl Query {
+    pub fn new(run: Run) -> Self {
+        Self { run: Arc::new(run) }
+    }
+}
+
+struct Package {
+    run: Arc<Run>,
+    name: PackageName,
+}
+
+#[Object]
+impl Query {
+    async fn package(&self, name: String) -> Result<Package, Error> {
+        let name = PackageName::from(name);
+        Ok(Package {
+            run: self.run.clone(),
+            name,
+        })
+    }
+}
+
+#[Object]
+impl Package {
+    async fn name(&self) -> String {
+        self.name.to_string()
+    }
+
+    async fn dependents(&self) -> Result<Vec<Package>, Error> {
+        let node: PackageNode = PackageNode::Workspace(self.name.clone());
+
+        Ok(self
+            .run
+            .pkg_dep_graph()
+            .ancestors(&node)
+            .iter()
+            .map(|package| Package {
+                run: self.run.clone(),
+                name: package.as_package_name().clone(),
+            })
+            .collect())
+    }
+
+    async fn dependencies(&self) -> Result<Vec<Package>, Error> {
+        let node: PackageNode = PackageNode::Workspace(self.name.clone());
+
+        Ok(self
+            .run
+            .pkg_dep_graph()
+            .dependencies(&node)
+            .iter()
+            .map(|package| Package {
+                run: self.run.clone(),
+                name: package.as_package_name().clone(),
+            })
+            .collect())
+    }
+}

--- a/crates/turborepo-lib/src/query.rs
+++ b/crates/turborepo-lib/src/query.rs
@@ -248,11 +248,11 @@ impl Query {
         opts.scope_opts.affected_range = Some((base, head));
 
         Ok(RunBuilder::calculate_filtered_packages(
-            &self.run.repo_root(),
+            self.run.repo_root(),
             &opts,
-            &self.run.pkg_dep_graph(),
-            &self.run.scm(),
-            &self.run.root_turbo_json(),
+            self.run.pkg_dep_graph(),
+            self.run.scm(),
+            self.run.root_turbo_json(),
         )?
         .into_iter()
         .map(|package| Package {

--- a/crates/turborepo-lib/src/query.rs
+++ b/crates/turborepo-lib/src/query.rs
@@ -3,6 +3,7 @@ use std::{io, sync::Arc};
 use async_graphql::{http::GraphiQLSource, *};
 use async_graphql_axum::GraphQL;
 use axum::{response, response::IntoResponse, routing::get, Router};
+use itertools::Itertools;
 use miette::Diagnostic;
 use thiserror::Error;
 use tokio::{net::TcpListener, select};
@@ -258,6 +259,7 @@ impl Query {
             run: self.run.clone(),
             name: package,
         })
+        .sorted_by(|a, b| a.name.cmp(&b.name))
         .collect())
     }
     /// Gets a single package by name
@@ -280,6 +282,7 @@ impl Query {
                     run: self.run.clone(),
                     name: name.clone(),
                 })
+                .sorted_by(|a, b| a.name.cmp(&b.name))
                 .collect());
         };
 
@@ -292,6 +295,7 @@ impl Query {
                 name: name.clone(),
             })
             .filter(|pkg| filter.check(pkg))
+            .sorted_by(|a, b| a.name.cmp(&b.name))
             .collect())
     }
 }

--- a/crates/turborepo-lib/src/query.rs
+++ b/crates/turborepo-lib/src/query.rs
@@ -363,6 +363,7 @@ impl Package {
                 run: self.run.clone(),
                 name: package.as_package_name().clone(),
             })
+            .sorted_by(|a, b| a.name.cmp(&b.name))
             .collect())
     }
 
@@ -379,6 +380,7 @@ impl Package {
                 run: self.run.clone(),
                 name: package.as_package_name().clone(),
             })
+            .sorted_by(|a, b| a.name.cmp(&b.name))
             .collect())
     }
 }

--- a/crates/turborepo-lib/src/query.rs
+++ b/crates/turborepo-lib/src/query.rs
@@ -1,14 +1,24 @@
-use std::sync::Arc;
+use std::{io, sync::Arc};
 
-use async_graphql::*;
+use async_graphql::{http::GraphiQLSource, *};
+use async_graphql_axum::GraphQL;
+use axum::{response, response::IntoResponse, routing::get, Router};
 use miette::Diagnostic;
 use thiserror::Error;
+use tokio::{net::TcpListener, select};
 use turborepo_repository::package_graph::{PackageName, PackageNode};
 
-use crate::run::Run;
+use crate::{
+    run::{builder::RunBuilder, Run},
+    signal::SignalHandler,
+};
 
 #[derive(Error, Debug, Diagnostic)]
 pub enum Error {
+    #[error("no signal handler")]
+    NoSignalHandler,
+    #[error("failed to start GraphQL server")]
+    Server(#[from] io::Error),
     #[error("package not found: {0}")]
     PackageNotFound(PackageName),
     #[error("failed to serialize result: {0}")]
@@ -75,7 +85,12 @@ struct FieldValuePair {
     value: Any,
 }
 
-/// Predicates are used to filter packages
+/// Predicates are used to filter packages. If you include multiple predicates,
+/// they are combined using AND. To combine predicates using OR, use the `or`
+/// field.
+///
+/// For pairs that do not obey type safety, e.g. `NAME` `greater_than` `10`, we
+/// default to `false`.
 #[derive(InputObject)]
 struct PackagePredicate {
     and: Option<Vec<PackagePredicate>>,
@@ -221,6 +236,31 @@ impl PackagePredicate {
 
 #[Object]
 impl Query {
+    async fn affected_packages(
+        &self,
+        base: Option<String>,
+        head: Option<String>,
+    ) -> Result<Vec<Package>, Error> {
+        let base = base.unwrap_or_else(|| "main".to_string());
+        let head = head.unwrap_or_else(|| "HEAD".to_string());
+        let mut opts = self.run.opts().clone();
+        opts.scope_opts.affected_range = Some((base, head));
+
+        Ok(RunBuilder::calculate_filtered_packages(
+            &self.run.repo_root(),
+            &opts,
+            &self.run.pkg_dep_graph(),
+            &self.run.scm(),
+            &self.run.root_turbo_json(),
+        )?
+        .into_iter()
+        .map(|package| Package {
+            run: self.run.clone(),
+            name: package,
+        })
+        .collect())
+    }
+    /// Gets a single package by name
     async fn package(&self, name: String) -> Result<Package, Error> {
         let name = PackageName::from(name);
         Ok(Package {
@@ -229,6 +269,7 @@ impl Query {
         })
     }
 
+    /// Gets a list of packages that match the given filter
     async fn packages(&self, filter: Option<PackagePredicate>) -> Result<Vec<Package>, Error> {
         let Some(filter) = filter else {
             return Ok(self
@@ -257,10 +298,55 @@ impl Query {
 
 #[Object]
 impl Package {
+    /// The name of the package
     async fn name(&self) -> String {
         self.name.to_string()
     }
 
+    /// The path to the package, relative to the repository root
+    async fn path(&self) -> Result<String, Error> {
+        Ok(self
+            .run
+            .pkg_dep_graph()
+            .package_info(&self.name)
+            .ok_or_else(|| Error::PackageNotFound(self.name.clone()))?
+            .package_path()
+            .to_string())
+    }
+
+    /// The upstream packages that have this package as a direct dependency
+    async fn immediate_dependents(&self) -> Result<Vec<Package>, Error> {
+        let node: PackageNode = PackageNode::Workspace(self.name.clone());
+        Ok(self
+            .run
+            .pkg_dep_graph()
+            .immediate_ancestors(&node)
+            .iter()
+            .flatten()
+            .map(|package| Package {
+                run: self.run.clone(),
+                name: package.as_package_name().clone(),
+            })
+            .collect())
+    }
+
+    /// The downstream packages that directly depend on this package
+    async fn immediate_dependencies(&self) -> Result<Vec<Package>, Error> {
+        let node: PackageNode = PackageNode::Workspace(self.name.clone());
+        Ok(self
+            .run
+            .pkg_dep_graph()
+            .immediate_dependencies(&node)
+            .iter()
+            .flatten()
+            .map(|package| Package {
+                run: self.run.clone(),
+                name: package.as_package_name().clone(),
+            })
+            .collect())
+    }
+
+    /// The downstream packages that depend on this package, transitively
     async fn dependents(&self) -> Result<Vec<Package>, Error> {
         let node: PackageNode = PackageNode::Workspace(self.name.clone());
 
@@ -276,6 +362,7 @@ impl Package {
             .collect())
     }
 
+    /// The upstream packages that this package depends on, transitively
     async fn dependencies(&self) -> Result<Vec<Package>, Error> {
         let node: PackageNode = PackageNode::Workspace(self.name.clone());
 
@@ -290,4 +377,29 @@ impl Package {
             })
             .collect())
     }
+}
+
+async fn graphiql() -> impl IntoResponse {
+    response::Html(GraphiQLSource::build().endpoint("/").finish())
+}
+
+pub async fn run_server(run: Run, signal: SignalHandler) -> Result<(), Error> {
+    let schema = Schema::new(Query::new(run), EmptyMutation, EmptySubscription);
+    let app = Router::new().route("/", get(graphiql).post_service(GraphQL::new(schema)));
+
+    let subscriber = signal.subscribe().ok_or(Error::NoSignalHandler)?;
+    println!("GraphiQL IDE: http://localhost:8000");
+    webbrowser::open("http://localhost:8000")?;
+    select! {
+        biased;
+        _ = subscriber.listen() => {
+            println!("Shutting down GraphQL server");
+            return Ok(());
+        }
+        result = axum::serve(TcpListener::bind("127.0.0.1:8000").await?, app) => {
+            result?;
+        }
+    }
+
+    Ok(())
 }

--- a/crates/turborepo-lib/src/query.rs
+++ b/crates/turborepo-lib/src/query.rs
@@ -32,6 +32,193 @@ struct Package {
     name: PackageName,
 }
 
+impl Package {
+    fn immediate_dependents_count(&self) -> usize {
+        self.run
+            .pkg_dep_graph()
+            .immediate_ancestors(&PackageNode::Workspace(self.name.clone()))
+            .map_or(0, |pkgs| pkgs.len())
+    }
+
+    fn immediate_dependencies_count(&self) -> usize {
+        self.run
+            .pkg_dep_graph()
+            .immediate_dependencies(&PackageNode::Workspace(self.name.clone()))
+            .map_or(0, |pkgs| pkgs.len())
+    }
+
+    fn dependent_count(&self) -> usize {
+        let node: PackageNode = PackageNode::Workspace(self.name.clone());
+
+        self.run.pkg_dep_graph().ancestors(&node).len()
+    }
+
+    fn dependency_count(&self) -> usize {
+        let node: PackageNode = PackageNode::Workspace(self.name.clone());
+
+        self.run.pkg_dep_graph().dependencies(&node).len()
+    }
+}
+
+#[derive(Enum, Copy, Clone, Eq, PartialEq, Debug)]
+enum PackageFields {
+    Name,
+    DependencyCount,
+    DependentCount,
+    ImmediateDependentCount,
+    ImmediateDependencyCount,
+}
+
+#[derive(InputObject)]
+struct FieldValuePair {
+    field: PackageFields,
+    value: Any,
+}
+
+/// Predicates are used to filter packages
+#[derive(InputObject)]
+struct PackagePredicate {
+    and: Option<Vec<PackagePredicate>>,
+    or: Option<Vec<PackagePredicate>>,
+    equal: Option<FieldValuePair>,
+    not_equal: Option<FieldValuePair>,
+    greater_than: Option<FieldValuePair>,
+    less_than: Option<FieldValuePair>,
+    not: Option<Box<PackagePredicate>>,
+}
+
+impl PackagePredicate {
+    fn check_equals(pkg: &Package, field: &PackageFields, value: &Any) -> bool {
+        match (field, &value.0) {
+            (PackageFields::Name, Value::String(name)) => pkg.name.as_ref() == name,
+            (PackageFields::DependencyCount, Value::Number(n)) => {
+                let Some(n) = n.as_u64() else {
+                    return false;
+                };
+                pkg.dependency_count() == n as usize
+            }
+            (PackageFields::DependentCount, Value::Number(n)) => {
+                let Some(n) = n.as_u64() else {
+                    return false;
+                };
+                pkg.dependent_count() == n as usize
+            }
+            (PackageFields::ImmediateDependentCount, Value::Number(n)) => {
+                let Some(n) = n.as_u64() else {
+                    return false;
+                };
+                pkg.immediate_dependents_count() == n as usize
+            }
+            (PackageFields::ImmediateDependencyCount, Value::Number(n)) => {
+                let Some(n) = n.as_u64() else {
+                    return false;
+                };
+                pkg.immediate_dependencies_count() == n as usize
+            }
+            _ => false,
+        }
+    }
+
+    fn check_greater_than(pkg: &Package, field: &PackageFields, value: &Any) -> bool {
+        match (field, &value.0) {
+            (PackageFields::DependencyCount, Value::Number(n)) => {
+                let Some(n) = n.as_u64() else {
+                    return false;
+                };
+                pkg.dependency_count() > n as usize
+            }
+            (PackageFields::DependentCount, Value::Number(n)) => {
+                let Some(n) = n.as_u64() else {
+                    return false;
+                };
+                pkg.dependent_count() > n as usize
+            }
+            (PackageFields::ImmediateDependentCount, Value::Number(n)) => {
+                let Some(n) = n.as_u64() else {
+                    return false;
+                };
+                pkg.immediate_dependents_count() > n as usize
+            }
+            (PackageFields::ImmediateDependencyCount, Value::Number(n)) => {
+                let Some(n) = n.as_u64() else {
+                    return false;
+                };
+                pkg.immediate_dependencies_count() > n as usize
+            }
+            _ => false,
+        }
+    }
+
+    fn check_less_than(pkg: &Package, field: &PackageFields, value: &Any) -> bool {
+        match (field, &value.0) {
+            (PackageFields::DependencyCount, Value::Number(n)) => {
+                let Some(n) = n.as_u64() else {
+                    return false;
+                };
+                pkg.dependency_count() < n as usize
+            }
+            (PackageFields::DependentCount, Value::Number(n)) => {
+                let Some(n) = n.as_u64() else {
+                    return false;
+                };
+                pkg.dependent_count() < n as usize
+            }
+            (PackageFields::ImmediateDependentCount, Value::Number(n)) => {
+                let Some(n) = n.as_u64() else {
+                    return false;
+                };
+                pkg.immediate_dependents_count() < n as usize
+            }
+            (PackageFields::ImmediateDependencyCount, Value::Number(n)) => {
+                let Some(n) = n.as_u64() else {
+                    return false;
+                };
+                pkg.immediate_dependencies_count() < n as usize
+            }
+            _ => false,
+        }
+    }
+
+    fn check(&self, pkg: &Package) -> bool {
+        let and = self
+            .and
+            .as_ref()
+            .map(|predicates| predicates.iter().all(|p| p.check(pkg)));
+        let or = self
+            .or
+            .as_ref()
+            .map(|predicates| predicates.iter().any(|p| p.check(pkg)));
+        let equal = self
+            .equal
+            .as_ref()
+            .map(|pair| Self::check_equals(pkg, &pair.field, &pair.value));
+        let not_equal = self
+            .not_equal
+            .as_ref()
+            .map(|pair| !Self::check_equals(pkg, &pair.field, &pair.value));
+
+        let greater_than = self
+            .greater_than
+            .as_ref()
+            .map(|pair| Self::check_greater_than(pkg, &pair.field, &pair.value));
+
+        let less_than = self
+            .less_than
+            .as_ref()
+            .map(|pair| Self::check_greater_than(pkg, &pair.field, &pair.value));
+        let not = self.not.as_ref().map(|predicate| !predicate.check(pkg));
+
+        and.into_iter()
+            .chain(or)
+            .chain(equal)
+            .chain(not_equal)
+            .chain(greater_than)
+            .chain(less_than)
+            .chain(not)
+            .all(|p| p)
+    }
+}
+
 #[Object]
 impl Query {
     async fn package(&self, name: String) -> Result<Package, Error> {
@@ -40,6 +227,31 @@ impl Query {
             run: self.run.clone(),
             name,
         })
+    }
+
+    async fn packages(&self, filter: Option<PackagePredicate>) -> Result<Vec<Package>, Error> {
+        let Some(filter) = filter else {
+            return Ok(self
+                .run
+                .pkg_dep_graph()
+                .packages()
+                .map(|(name, _)| Package {
+                    run: self.run.clone(),
+                    name: name.clone(),
+                })
+                .collect());
+        };
+
+        Ok(self
+            .run
+            .pkg_dep_graph()
+            .packages()
+            .map(|(name, _)| Package {
+                run: self.run.clone(),
+                name: name.clone(),
+            })
+            .filter(|pkg| filter.check(pkg))
+            .collect())
     }
 }
 

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -139,10 +139,10 @@ impl RunBuilder {
     ) -> Result<HashSet<PackageName>, Error> {
         let (mut filtered_pkgs, is_all_packages) = scope::resolve_packages(
             &opts.scope_opts,
-            &repo_root,
-            &pkg_dep_graph,
-            &scm,
-            &root_turbo_json,
+            repo_root,
+            pkg_dep_graph,
+            scm,
+            root_turbo_json,
         )?;
 
         if is_all_packages {

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -24,7 +24,7 @@ use chrono::{DateTime, Local};
 use rayon::iter::ParallelBridge;
 use tokio::{select, task::JoinHandle};
 use tracing::{debug, instrument};
-use turbopath::AbsoluteSystemPathBuf;
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_api_client::{APIAuth, APIClient};
 use turborepo_ci::Vendor;
 use turborepo_env::EnvironmentVariableMap;
@@ -110,6 +110,22 @@ impl Run {
         } else {
             cprintln!(self.color_config, GREY, "• Remote caching disabled");
         }
+    }
+
+    pub fn opts(&self) -> &Opts {
+        &self.opts
+    }
+
+    pub fn repo_root(&self) -> &AbsoluteSystemPath {
+        &self.repo_root
+    }
+
+    pub fn scm(&self) -> &SCM {
+        &self.scm
+    }
+
+    pub fn root_turbo_json(&self) -> &TurboJson {
+        &self.root_turbo_json
     }
 
     pub fn create_run_for_persistent_tasks(&self) -> Self {

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -375,7 +375,6 @@ impl<W> App<W> {
         self.scroll.select(Some(0));
         self.selected_task_index = 0;
     }
-<<<<<<< HEAD
 
     pub fn resize(&mut self, rows: u16, cols: u16) {
         self.size.resize(rows, cols);
@@ -385,9 +384,6 @@ impl<W> App<W> {
             term.resize(pane_rows, pane_cols);
         })
     }
-||||||| parent of 90f8a5566b (fix(watch): display which tasks will be rerun (#8960))
-=======
->>>>>>> 90f8a5566b (fix(watch): display which tasks will be rerun (#8960))
 }
 
 impl<W: Write> App<W> {

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -375,6 +375,7 @@ impl<W> App<W> {
         self.scroll.select(Some(0));
         self.selected_task_index = 0;
     }
+<<<<<<< HEAD
 
     pub fn resize(&mut self, rows: u16, cols: u16) {
         self.size.resize(rows, cols);
@@ -384,6 +385,9 @@ impl<W> App<W> {
             term.resize(pane_rows, pane_cols);
         })
     }
+||||||| parent of 90f8a5566b (fix(watch): display which tasks will be rerun (#8960))
+=======
+>>>>>>> 90f8a5566b (fix(watch): display which tasks will be rerun (#8960))
 }
 
 impl<W: Write> App<W> {
@@ -619,10 +623,15 @@ fn update(
             app.copy_selection();
         }
         Event::RestartTasks { tasks } => {
+<<<<<<< HEAD
             app.restart_tasks(tasks);
         }
         Event::Resize { rows, cols } => {
             app.resize(rows, cols);
+||||||| parent of 90f8a5566b (fix(watch): display which tasks will be rerun (#8960))
+=======
+            app.update_tasks(tasks);
+>>>>>>> 90f8a5566b (fix(watch): display which tasks will be rerun (#8960))
         }
     }
     Ok(None)
@@ -928,6 +937,7 @@ mod test {
             "selected b"
         );
     }
+<<<<<<< HEAD
 
     #[test]
     fn test_resize() {
@@ -986,4 +996,7 @@ mod test {
 
         app.start_task("d", OutputLogs::Full).unwrap();
     }
+||||||| parent of 90f8a5566b (fix(watch): display which tasks will be rerun (#8960))
+=======
+>>>>>>> 90f8a5566b (fix(watch): display which tasks will be rerun (#8960))
 }

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -619,15 +619,10 @@ fn update(
             app.copy_selection();
         }
         Event::RestartTasks { tasks } => {
-<<<<<<< HEAD
             app.restart_tasks(tasks);
         }
         Event::Resize { rows, cols } => {
             app.resize(rows, cols);
-||||||| parent of 90f8a5566b (fix(watch): display which tasks will be rerun (#8960))
-=======
-            app.update_tasks(tasks);
->>>>>>> 90f8a5566b (fix(watch): display which tasks will be rerun (#8960))
         }
     }
     Ok(None)
@@ -933,7 +928,6 @@ mod test {
             "selected b"
         );
     }
-<<<<<<< HEAD
 
     #[test]
     fn test_resize() {
@@ -992,7 +986,4 @@ mod test {
 
         app.start_task("d", OutputLogs::Full).unwrap();
     }
-||||||| parent of 90f8a5566b (fix(watch): display which tasks will be rerun (#8960))
-=======
->>>>>>> 90f8a5566b (fix(watch): display which tasks will be rerun (#8960))
 }

--- a/turborepo-tests/integration/tests/affected.t
+++ b/turborepo-tests/integration/tests/affected.t
@@ -29,7 +29,7 @@ Do the same thing with the `ls` command
   $ ${TURBO} ls --affected
    WARNING  ls command is experimental and may change in the future
   1 package (npm)
-  
+
     my-app apps[\/\\]my-app (re)
 
 Commit the change
@@ -57,7 +57,7 @@ Do the same thing with the `ls` command
   $ ${TURBO} ls --affected
    WARNING  ls command is experimental and may change in the future
   1 package (npm)
-  
+
     my-app apps[\/\\]my-app (re)
 
 Override the SCM base to be HEAD, so nothing runs
@@ -77,7 +77,7 @@ Do the same thing with the `ls` command
   $ TURBO_SCM_BASE="HEAD" ${TURBO} ls --affected
    WARNING  ls command is experimental and may change in the future
   0 no packages (npm)
-  
+
 
 
 Override the SCM head to be main, so nothing runs
@@ -97,7 +97,7 @@ Do the same thing with the `ls` command
   $ TURBO_SCM_HEAD="main" ${TURBO} ls --affected
    WARNING  ls command is experimental and may change in the future
   0 no packages (npm)
-  
+
 
 
 Now add a commit to `main` so the merge base is different from `main`
@@ -128,7 +128,7 @@ Do the same thing with the `ls` command
   $ ${TURBO} ls --affected
    WARNING  ls command is experimental and may change in the future
   1 package (npm)
-  
+
     my-app apps[\/\\]my-app (re)
 
 Now do some magic to change the repo to be shallow
@@ -168,7 +168,7 @@ Do the same thing with the `ls` command
    WARNING  unable to detect git range, assuming all files have changed: git error: fatal: main...HEAD: no merge base
   
   3 packages (npm)
-  
+
     another packages[\/\\]another (re)
     my-app apps[\/\\]my-app (re)
     util packages[\/\\]util (re)

--- a/turborepo-tests/integration/tests/affected.t
+++ b/turborepo-tests/integration/tests/affected.t
@@ -34,6 +34,15 @@ Do the same thing with the `ls` command
 
 Do the same thing with the `query` command
   $ ${TURBO} query "query { affectedPackages { name } }"
+  {
+    "data": {
+      "affectedPackages": [
+        {
+          "name": "my-app"
+        }
+      ]
+    }
+  }
 
 Commit the change
   $ git add .

--- a/turborepo-tests/integration/tests/affected.t
+++ b/turborepo-tests/integration/tests/affected.t
@@ -35,6 +35,7 @@ Do the same thing with the `ls` command
 
 Do the same thing with the `query` command
   $ ${TURBO} query "query { affectedPackages { name } }"
+   WARNING  query command is experimental and may change in the future
   {
     "data": {
       "affectedPackages": [
@@ -76,6 +77,7 @@ Do the same thing with the `ls` command
 
 Do the same thing with the `query` command
   $ ${TURBO} query "query { affectedPackages { name } }"
+   WARNING  query command is experimental and may change in the future
   {
     "data": {
       "affectedPackages": [
@@ -108,6 +110,7 @@ Do the same thing with the `ls` command
 
 Do the same thing with the `query` command
   $ ${TURBO} query "query { affectedPackages(base: \"HEAD\") { name } }"
+   WARNING  query command is experimental and may change in the future
   {
     "data": {
       "affectedPackages": []
@@ -136,6 +139,7 @@ Do the same thing with the `ls` command
 
 Do the same thing with the `query` command
   $ ${TURBO} query "query { affectedPackages(head: \"main\") { name } }"
+   WARNING  query command is experimental and may change in the future
   {
     "data": {
       "affectedPackages": []
@@ -176,6 +180,7 @@ Do the same thing with the `ls` command
 
 Do the same thing with the `query` command
   $ ${TURBO} query "query { affectedPackages { name } }"
+   WARNING  query command is experimental and may change in the future
   {
     "data": {
       "affectedPackages": [
@@ -231,6 +236,7 @@ Do the same thing with the `ls` command
 
 Do the same thing with the `query` command
   $ ${TURBO} query "query { affectedPackages { name } }"
+   WARNING  query command is experimental and may change in the future
    WARNING  unable to detect git range, assuming all files have changed: git error: fatal: main...HEAD: no merge base
   
   {

--- a/turborepo-tests/integration/tests/affected.t
+++ b/turborepo-tests/integration/tests/affected.t
@@ -30,7 +30,7 @@ Do the same thing with the `ls` command
    WARNING  ls command is experimental and may change in the future
   1 package (npm)
   
-    my-app apps/my-app
+    my-app apps[\/\\]my-app (re)
 
 
 Do the same thing with the `query` command
@@ -72,7 +72,7 @@ Do the same thing with the `ls` command
    WARNING  ls command is experimental and may change in the future
   1 package (npm)
   
-    my-app apps/my-app
+    my-app apps[\/\\]my-app (re)
 
 
 Do the same thing with the `query` command
@@ -175,7 +175,7 @@ Do the same thing with the `ls` command
    WARNING  ls command is experimental and may change in the future
   1 package (npm)
   
-    my-app apps/my-app
+    my-app apps[\/\\]my-app (re)
 
 
 Do the same thing with the `query` command

--- a/turborepo-tests/integration/tests/affected.t
+++ b/turborepo-tests/integration/tests/affected.t
@@ -72,6 +72,18 @@ Do the same thing with the `ls` command
 
     my-app apps[\/\\]my-app (re)
 
+Do the same thing with the `query` command
+  $ ${TURBO} query "query { affectedPackages { name } }"
+  {
+    "data": {
+      "affectedPackages": [
+        {
+          "name": "my-app"
+        }
+      ]
+    }
+  }
+
 Override the SCM base to be HEAD, so nothing runs
   $ TURBO_SCM_BASE="HEAD" ${TURBO} run build --affected --log-order grouped
   \xe2\x80\xa2 Packages in scope:  (esc)
@@ -91,6 +103,13 @@ Do the same thing with the `ls` command
   0 no packages (npm)
 
 
+Do the same thing with the `query` command
+  $ ${TURBO} query "query { affectedPackages(base: \"HEAD\") { name } }"
+  {
+    "data": {
+      "affectedPackages": []
+    }
+  }
 
 Override the SCM head to be main, so nothing runs
   $ TURBO_SCM_HEAD="main" ${TURBO} run build --affected --log-order grouped
@@ -111,6 +130,13 @@ Do the same thing with the `ls` command
   0 no packages (npm)
 
 
+Do the same thing with the `query` command
+  $ ${TURBO} query "query { affectedPackages(head: \"main\") { name } }"
+  {
+    "data": {
+      "affectedPackages": []
+    }
+  }
 
 Now add a commit to `main` so the merge base is different from `main`
   $ git checkout main --quiet
@@ -142,6 +168,18 @@ Do the same thing with the `ls` command
   1 package (npm)
 
     my-app apps[\/\\]my-app (re)
+
+Do the same thing with the `query` command
+  $ ${TURBO} query "query { affectedPackages { name } }"
+  {
+    "data": {
+      "affectedPackages": [
+        {
+          "name": "my-app"
+        }
+      ]
+    }
+  }
 
 Now do some magic to change the repo to be shallow
   $ SHALLOW=$(git rev-parse --show-toplevel)/.git/shallow
@@ -185,4 +223,25 @@ Do the same thing with the `ls` command
     my-app apps[\/\\]my-app (re)
     util packages[\/\\]util (re)
 
-
+Do the same thing with the `query` command
+  $ ${TURBO} query "query { affectedPackages { name } }"
+   WARNING  unable to detect git range, assuming all files have changed: git error: fatal: main...HEAD: no merge base
+  
+  {
+    "data": {
+      "affectedPackages": [
+        {
+          "name": "//"
+        },
+        {
+          "name": "another"
+        },
+        {
+          "name": "my-app"
+        },
+        {
+          "name": "util"
+        }
+      ]
+    }
+  }

--- a/turborepo-tests/integration/tests/affected.t
+++ b/turborepo-tests/integration/tests/affected.t
@@ -32,6 +32,9 @@ Do the same thing with the `ls` command
 
     my-app apps[\/\\]my-app (re)
 
+Do the same thing with the `query` command
+  $ ${TURBO} query "query { affectedPackages { name } }"
+
 Commit the change
   $ git add .
   $ git commit -m "add foo" --quiet

--- a/turborepo-tests/integration/tests/affected.t
+++ b/turborepo-tests/integration/tests/affected.t
@@ -29,8 +29,9 @@ Do the same thing with the `ls` command
   $ ${TURBO} ls --affected
    WARNING  ls command is experimental and may change in the future
   1 package (npm)
+  
+    my-app apps/my-app
 
-    my-app apps[\/\\]my-app (re)
 
 Do the same thing with the `query` command
   $ ${TURBO} query "query { affectedPackages { name } }"
@@ -69,8 +70,9 @@ Do the same thing with the `ls` command
   $ ${TURBO} ls --affected
    WARNING  ls command is experimental and may change in the future
   1 package (npm)
+  
+    my-app apps/my-app
 
-    my-app apps[\/\\]my-app (re)
 
 Do the same thing with the `query` command
   $ ${TURBO} query "query { affectedPackages { name } }"
@@ -101,6 +103,7 @@ Do the same thing with the `ls` command
   $ TURBO_SCM_BASE="HEAD" ${TURBO} ls --affected
    WARNING  ls command is experimental and may change in the future
   0 no packages (npm)
+  
 
 
 Do the same thing with the `query` command
@@ -128,6 +131,7 @@ Do the same thing with the `ls` command
   $ TURBO_SCM_HEAD="main" ${TURBO} ls --affected
    WARNING  ls command is experimental and may change in the future
   0 no packages (npm)
+  
 
 
 Do the same thing with the `query` command
@@ -166,8 +170,9 @@ Do the same thing with the `ls` command
   $ ${TURBO} ls --affected
    WARNING  ls command is experimental and may change in the future
   1 package (npm)
+  
+    my-app apps/my-app
 
-    my-app apps[\/\\]my-app (re)
 
 Do the same thing with the `query` command
   $ ${TURBO} query "query { affectedPackages { name } }"
@@ -218,10 +223,11 @@ Do the same thing with the `ls` command
    WARNING  unable to detect git range, assuming all files have changed: git error: fatal: main...HEAD: no merge base
   
   3 packages (npm)
-
+  
     another packages[\/\\]another (re)
     my-app apps[\/\\]my-app (re)
     util packages[\/\\]util (re)
+
 
 Do the same thing with the `query` command
   $ ${TURBO} query "query { affectedPackages { name } }"

--- a/turborepo-tests/integration/tests/command-query.t
+++ b/turborepo-tests/integration/tests/command-query.t
@@ -1,0 +1,82 @@
+Setup
+  $ . ${TESTDIR}/../../helpers/setup_integration_test.sh
+
+Query packages
+  $ ${TURBO} query "query { packages { name } }"
+  {
+    "data": {
+      "packages": [
+        {
+          "name": "//"
+        },
+        {
+          "name": "another"
+        },
+        {
+          "name": "my-app"
+        },
+        {
+          "name": "util"
+        }
+      ]
+    }
+  }
+
+Query packages with equals filter
+  $ ${TURBO} query "query { packages(filter: { equal: { field: NAME, value: \"my-app\" } }) { name } }"
+  {
+    "data": {
+      "packages": [
+        {
+          "name": "my-app"
+        }
+      ]
+    }
+  }
+
+Query packages that have at least one dependent package
+  $ ${TURBO} query "query { packages(filter: { greaterThan: { field: DEPENDENT_COUNT, value: 0 } }) { name } }"
+  {
+    "data": {
+      "packages": [
+        {
+          "name": "util"
+        }
+      ]
+    }
+  }
+
+Get dependents of `util`
+  $ ${TURBO} query "query { packages(filter: { equal: { field: NAME, value: \"util\" } }) { dependents { name } } }"
+  {
+    "data": {
+      "packages": [
+        {
+          "dependents": [
+            {
+              "name": "my-app"
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+Get dependencies of `my-app`
+  $ ${TURBO} query "query { packages(filter: { equal: { field: NAME, value: \"my-app\" } }) { dependencies { name } } }"
+  {
+    "data": {
+      "packages": [
+        {
+          "dependencies": [
+            {
+              "name": "//"
+            },
+            {
+              "name": "util"
+            }
+          ]
+        }
+      ]
+    }
+  }

--- a/turborepo-tests/integration/tests/command-query.t
+++ b/turborepo-tests/integration/tests/command-query.t
@@ -80,3 +80,27 @@ Get dependencies of `my-app`
       ]
     }
   }
+
+Write query to file
+  $ echo 'query { packages { name } }' > query.gql
+
+Run the query
+  $ ${TURBO} query query.gql
+  {
+    "data": {
+      "packages": [
+        {
+          "name": "//"
+        },
+        {
+          "name": "another"
+        },
+        {
+          "name": "my-app"
+        },
+        {
+          "name": "util"
+        }
+      ]
+    }
+  }

--- a/turborepo-tests/integration/tests/command-query.t
+++ b/turborepo-tests/integration/tests/command-query.t
@@ -2,7 +2,8 @@ Setup
   $ . ${TESTDIR}/../../helpers/setup_integration_test.sh
 
 Query packages
-  $ ${TURBO} query "query { packages { name } }"
+  $ ${TURBO} query "query { packages { name } }" | jq
+   WARNING  query command is experimental and may change in the future
   {
     "data": {
       "packages": [
@@ -23,7 +24,8 @@ Query packages
   }
 
 Query packages with equals filter
-  $ ${TURBO} query "query { packages(filter: { equal: { field: NAME, value: \"my-app\" } }) { name } }"
+  $ ${TURBO} query "query { packages(filter: { equal: { field: NAME, value: \"my-app\" } }) { name } }" | jq
+   WARNING  query command is experimental and may change in the future
   {
     "data": {
       "packages": [
@@ -35,7 +37,8 @@ Query packages with equals filter
   }
 
 Query packages that have at least one dependent package
-  $ ${TURBO} query "query { packages(filter: { greaterThan: { field: DEPENDENT_COUNT, value: 0 } }) { name } }"
+  $ ${TURBO} query "query { packages(filter: { greaterThan: { field: DEPENDENT_COUNT, value: 0 } }) { name } }" | jq
+   WARNING  query command is experimental and may change in the future
   {
     "data": {
       "packages": [
@@ -47,7 +50,8 @@ Query packages that have at least one dependent package
   }
 
 Get dependents of `util`
-  $ ${TURBO} query "query { packages(filter: { equal: { field: NAME, value: \"util\" } }) { dependents { name } } }"
+  $ ${TURBO} query "query { packages(filter: { equal: { field: NAME, value: \"util\" } }) { dependents { name } } }" | jq
+   WARNING  query command is experimental and may change in the future
   {
     "data": {
       "packages": [
@@ -63,7 +67,8 @@ Get dependents of `util`
   }
 
 Get dependencies of `my-app`
-  $ ${TURBO} query "query { packages(filter: { equal: { field: NAME, value: \"my-app\" } }) { dependencies { name } } }"
+  $ ${TURBO} query "query { packages(filter: { equal: { field: NAME, value: \"my-app\" } }) { dependencies { name } } }" | jq
+   WARNING  query command is experimental and may change in the future
   {
     "data": {
       "packages": [
@@ -85,7 +90,8 @@ Write query to file
   $ echo 'query { packages { name } }' > query.gql
 
 Run the query
-  $ ${TURBO} query query.gql
+  $ ${TURBO} query query.gql | jq
+   WARNING  query command is experimental and may change in the future
   {
     "data": {
       "packages": [


### PR DESCRIPTION
### Description

Adds a GraphQL query interface to turborepo via the `turbo query` command. If you pass it a query string, then it directly runs the query. If you pass it a file, it reads the file and runs the query. If you don't pass a query, then it opens up a server with GraphiQL (we can ITG this interface).


### Testing Instructions
Added tests to `affected.t` and `command-query.t`
