### PR TITLE
feat(turbo): warn on empty cache

### DIFF
--- a/crates/turborepo-cache/src/lib.rs
+++ b/crates/turborepo-cache/src/lib.rs
@@ -103,6 +103,18 @@ pub struct CacheHitMetadata {
     pub time_saved: u64,
 }
 
+#[derive(Debug, PartialEq)]
+pub enum OutputSaveResult {
+    /// Outputs saved successfully
+    Saved,
+    /// Outputs were empty, and were saved
+    SavedEmpty,
+    /// Outputs were empty, and the save was skipped
+    SkippedEmpty,
+    /// Outputs were not saved because the cache was disabled
+    Disabled,
+}
+
 #[derive(Debug, Default)]
 pub struct CacheOpts {
     pub override_dir: Option<Utf8PathBuf>,

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -815,6 +815,12 @@ pub struct RunArgs {
     #[clap(long)]
     pub no_cache: bool,
 
+    /// If outputs have been specified, but none exist - skip saving the (empty)
+    /// cache for the task. Enabling this can be a useful safety measure to
+    /// ensure proper outputs configuration.
+    #[clap(long, value_name = "BOOL", action = ArgAction::Set, default_value = "false", default_missing_value = "true", num_args = 0..=1)]
+    pub skip_empty_cache: bool,
+
     // clap does not have negation flags such as --daemon and --no-daemon
     // so we need to use a group to enforce that only one of them is set.
     // we set the long name as [no-]daemon with an alias of daemon such
@@ -860,6 +866,7 @@ impl Default for RunArgs {
             dry_run: None,
             graph: None,
             no_cache: false,
+            skip_empty_cache: false,
             daemon: false,
             no_daemon: false,
             profile: None,

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -130,6 +130,7 @@ struct OptsInputs<'a> {
 pub struct RunCacheOpts {
     pub(crate) skip_reads: bool,
     pub(crate) skip_writes: bool,
+    pub(crate) skip_empty_cache: bool,
     pub(crate) task_output_logs_override: Option<OutputLogsMode>,
 }
 
@@ -138,6 +139,7 @@ impl<'a> From<OptsInputs<'a>> for RunCacheOpts {
         RunCacheOpts {
             skip_reads: inputs.execution_args.force.flatten().is_some_and(|f| f),
             skip_writes: inputs.run_args.no_cache,
+            skip_empty_cache: inputs.run_args.skip_empty_cache,
             task_output_logs_override: inputs.execution_args.output_logs,
         }
     }

--- a/turborepo-tests/integration/tests/affected.t
+++ b/turborepo-tests/integration/tests/affected.t
@@ -19,6 +19,7 @@ Validate that we only run `my-app#build` with change not committed
   my-app:build: > echo building
   my-app:build: 
   my-app:build: building
+  my-app:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for my-app#build
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total

--- a/turborepo-tests/integration/tests/filter-run.t
+++ b/turborepo-tests/integration/tests/filter-run.t
@@ -35,6 +35,7 @@ Setup
   \xe2\x80\xa2 Packages in scope: //, another, my-app, util (esc)
   \xe2\x80\xa2 Running build in 4 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
+  my-app:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for my-app#build
   
    Tasks:    2 successful, 2 total
   Cached:    0 cached, 2 total

--- a/turborepo-tests/integration/tests/global-deps.t
+++ b/turborepo-tests/integration/tests/global-deps.t
@@ -7,6 +7,7 @@ Run a build
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   my-app:build: cache miss, executing 2a57e19ce0b2cfd5
+  my-app:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for my-app#build
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -19,6 +20,7 @@ Run a build
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   my-app:build: cache miss, executing 3883869b5e1dc9cf
+  my-app:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for my-app#build
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -70,6 +70,8 @@ Make sure exit code is 2 when no args are passed
             Generate a graph of the task execution and output to a file when a filename is specified (.svg, .png, .jpg, .pdf, .json, .html, .mermaid, .dot). Outputs dot graph to stdout when if no filename is provided
         --no-cache
             Avoid saving task results to the cache. Useful for development/watch tasks
+        --skip-empty-cache [<BOOL>]
+            If outputs have been specified, but none exist - skip saving the (empty) cache for the task. Enabling this can be a useful safety measure to ensure proper outputs configuration [default: false] [possible values: true, false]
         --[no-]daemon
             Force turbo to either use or not use the local daemon. If unset turbo will use the default detection logic
         --profile <PROFILE>

--- a/turborepo-tests/integration/tests/run-caching/cache-state.t
+++ b/turborepo-tests/integration/tests/run-caching/cache-state.t
@@ -6,6 +6,7 @@ Run a build to get a local cache.
   \xe2\x80\xa2 Packages in scope: another, my-app, util (esc)
   \xe2\x80\xa2 Running build in 3 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
+  my-app:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for my-app#build
   
    Tasks:    2 successful, 2 total
   Cached:    0 cached, 2 total

--- a/turborepo-tests/integration/tests/run-caching/excluded-inputs/excluded-inputs.t
+++ b/turborepo-tests/integration/tests/run-caching/excluded-inputs/excluded-inputs.t
@@ -15,6 +15,7 @@ Running build for my-app succeeds
   my-app:build: > echo building
   my-app:build: 
   my-app:build: building
+  my-app:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for my-app#build
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total

--- a/turborepo-tests/integration/tests/run-caching/global-deps.t
+++ b/turborepo-tests/integration/tests/run-caching/global-deps.t
@@ -6,6 +6,7 @@ Run a build to get a local cache.
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
+  my-app:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for my-app#build
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -28,6 +29,7 @@ Run again without env var to get cache miss
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
+  my-app:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for my-app#build
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total

--- a/turborepo-tests/integration/tests/run-caching/root-deps.t
+++ b/turborepo-tests/integration/tests/run-caching/root-deps.t
@@ -11,6 +11,7 @@ Warm the cache
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   another:build: cache miss, executing 6a4c300cb14847b0
+  another:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for another#build
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -38,6 +39,7 @@ All tasks should be a cache miss, even ones that don't depend on changed package
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   another:build: cache miss, executing 34787620f332fb95
+  another:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for another#build
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total

--- a/turborepo-tests/integration/tests/run-summary/discovery.t
+++ b/turborepo-tests/integration/tests/run-summary/discovery.t
@@ -12,6 +12,7 @@ Setup
   my-app:build: > echo building
   my-app:build: 
   my-app:build: building
+  my-app:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for my-app#build
   
     Tasks:    1 successful, 1 total
    Cached:    0 cached, 1 total

--- a/turborepo-tests/integration/tests/run-summary/enable.t
+++ b/turborepo-tests/integration/tests/run-summary/enable.t
@@ -26,6 +26,7 @@ Setup
 # env var=true, missing flag: yes
   $ rm -rf .turbo/runs
   $ TURBO_RUN_SUMMARY=true ${TURBO} run build > /dev/null
+  my-app:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for my-app#build
   $ /bin/ls .turbo/runs/*.json | wc -l
   \s*1 (re)
 # env var=true, --flag=true: yes

--- a/turborepo-tests/integration/tests/run-summary/monorepo.t
+++ b/turborepo-tests/integration/tests/run-summary/monorepo.t
@@ -5,6 +5,7 @@ Setup
   $ rm -rf .turbo/runs
 
   $ ${TURBO} run build --summarize -- someargs > /dev/null # first run (should be cache miss)
+  my-app:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for my-app#build
 
 # HACK: Generated run summaries are named with a ksuid, which is a time-sorted ID. This _generally_ works
 # but we're seeing in this test that sometimes a summary file is not sorted (with /bin/ls) in the order we expect

--- a/turborepo-tests/integration/tests/run-summary/strict-env.t
+++ b/turborepo-tests/integration/tests/run-summary/strict-env.t
@@ -12,6 +12,7 @@ Set the env vars
 Run as `infer`
   $ rm -rf .turbo/runs
   $ ${TURBO} run build --summarize > /dev/null
+  my-app:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for my-app#build
   $ cat .turbo/runs/*.json | jq -r '.envMode'
   strict
   $ cat .turbo/runs/*.json | jq -r '.tasks[0].envMode'
@@ -38,6 +39,7 @@ Run as `strict`
 Run as `loose`
   $ rm -rf .turbo/runs
   $ ${TURBO} run build --env-mode=loose --summarize > /dev/null
+  my-app:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for my-app#build
   $ cat .turbo/runs/*.json | jq -r '.envMode'
   loose
   $ cat .turbo/runs/*.json | jq -r '.tasks[0].envMode'
@@ -52,6 +54,7 @@ All specified + infer
   $ rm -rf .turbo/runs
   $ ${TESTDIR}/../../../helpers/replace_turbo_json.sh $(pwd) "strict_env_vars/all.json"
   $ ${TURBO} run build --summarize > /dev/null
+  my-app:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for my-app#build
   $ cat .turbo/runs/*.json | jq -r '.envMode'
   strict
   $ cat .turbo/runs/*.json | jq -r '.tasks[0].envMode'
@@ -68,6 +71,7 @@ All specified + loose
   $ rm -rf .turbo/runs
   $ ${TESTDIR}/../../../helpers/replace_turbo_json.sh $(pwd) "strict_env_vars/all.json"
   $ ${TURBO} run build --env-mode=loose --summarize > /dev/null
+  my-app:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for my-app#build
   $ cat .turbo/runs/*.json | jq -r '.envMode'
   loose
   $ cat .turbo/runs/*.json | jq -r '.tasks[0].envMode'
@@ -98,6 +102,7 @@ Global passthrough specified value + infer
   $ rm -rf .turbo/runs
   $ ${TESTDIR}/../../../helpers/replace_turbo_json.sh $(pwd) "strict_env_vars/global_pt.json"
   $ ${TURBO} run build --summarize > /dev/null
+  my-app:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for my-app#build
   $ cat .turbo/runs/*.json | jq -r '.envMode'
   strict
   $ cat .turbo/runs/*.json | jq -r '.tasks[0].envMode'
@@ -154,6 +159,7 @@ Task passthrough specified value + infer
   $ rm -rf .turbo/runs
   $ ${TESTDIR}/../../../helpers/replace_turbo_json.sh $(pwd) "strict_env_vars/task_pt.json"
   $ ${TURBO} run build --summarize > /dev/null
+  my-app:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for my-app#build
   $ cat .turbo/runs/*.json | jq -r '.envMode'
   strict
   $ cat .turbo/runs/*.json | jq -r '.tasks[0].envMode'

--- a/turborepo-tests/integration/tests/run/force.t
+++ b/turborepo-tests/integration/tests/run/force.t
@@ -25,6 +25,7 @@ baseline to generate cache
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   my-app:build: cache miss, executing 0555ce94ca234049
+  my-app:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for my-app#build
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -37,6 +38,7 @@ baseline to generate cache
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   my-app:build: cache bypass, force executing 0555ce94ca234049
+  my-app:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for my-app#build
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -48,6 +50,7 @@ baseline to generate cache
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   my-app:build: cache bypass, force executing 0555ce94ca234049
+  my-app:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for my-app#build
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -70,6 +73,7 @@ baseline to generate cache
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   my-app:build: cache bypass, force executing 0555ce94ca234049
+  my-app:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for my-app#build
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -93,6 +97,7 @@ baseline to generate cache
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   my-app:build: cache bypass, force executing 0555ce94ca234049
+  my-app:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for my-app#build
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -115,6 +120,7 @@ baseline to generate cache
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   my-app:build: cache bypass, force executing 0555ce94ca234049
+  my-app:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for my-app#build
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -138,6 +144,7 @@ baseline to generate cache
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   my-app:build: cache bypass, force executing 0555ce94ca234049
+  my-app:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for my-app#build
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total
@@ -160,6 +167,7 @@ baseline to generate cache
   \xe2\x80\xa2 Running build in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   my-app:build: cache bypass, force executing 0555ce94ca234049
+  my-app:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for my-app#build
   
    Tasks:    1 successful, 1 total
   Cached:    0 cached, 1 total

--- a/turborepo-tests/integration/tests/run/profile.t
+++ b/turborepo-tests/integration/tests/run/profile.t
@@ -4,5 +4,6 @@ Setup
 Run build and record a trace
 Ignore output since we want to focus on testing the generated profile
   $ ${TURBO} build --profile=build.trace > turbo.log
+  my-app:build: warning: no files were found that match the configured outputs - make sure "outputs" are correctly defined in your `turbo.json` for my-app#build
 Make sure the resulting trace is valid JSON
   $ node -e "require('./build.trace')"

--- a/turborepo-tests/integration/tests/turbo-help.t
+++ b/turborepo-tests/integration/tests/turbo-help.t
@@ -70,6 +70,8 @@ Test help flag
             Generate a graph of the task execution and output to a file when a filename is specified (.svg, .png, .jpg, .pdf, .json, .html, .mermaid, .dot). Outputs dot graph to stdout when if no filename is provided
         --no-cache
             Avoid saving task results to the cache. Useful for development/watch tasks
+        --skip-empty-cache [<BOOL>]
+            If outputs have been specified, but none exist - skip saving the (empty) cache for the task. Enabling this can be a useful safety measure to ensure proper outputs configuration [default: false] [possible values: true, false]
         --[no-]daemon
             Force turbo to either use or not use the local daemon. If unset turbo will use the default detection logic
         --profile <PROFILE>
@@ -214,6 +216,12 @@ Test help flag
   
         --no-cache
             Avoid saving task results to the cache. Useful for development/watch tasks
+  
+        --skip-empty-cache [<BOOL>]
+            If outputs have been specified, but none exist - skip saving the (empty) cache for the task. Enabling this can be a useful safety measure to ensure proper outputs configuration
+            
+            [default: false]
+            [possible values: true, false]
   
         --[no-]daemon
             Force turbo to either use or not use the local daemon. If unset turbo will use the default detection logic


### PR DESCRIPTION
### Description

Warn when you have specified outputs that do not exist. 

You can optionally pass `--skip-empty-cache` to skip caching entirely if the specified outputs do not exist. This should probably be the default, but it would be breaking behavior to enable for now. 





Co-authored-by: Mehul Kar <mehul.kar@vercel.com>