### PR TITLE
feat: is dev for packages installed under npm and pnpm

### DIFF
--- a/crates/turborepo-lib/src/hash/mod.rs
+++ b/crates/turborepo-lib/src/hash/mod.rs
@@ -120,7 +120,9 @@ impl From<LockFilePackages> for Builder<HeapAllocator> {
 
         {
             let mut packages_builder = builder.reborrow().init_packages(packages.len() as u32);
-            for (i, turborepo_lockfiles::Package { key, version }) in packages.iter().enumerate() {
+            for (i, turborepo_lockfiles::Package { key, version, .. }) in
+                packages.iter().enumerate()
+            {
                 let mut package = packages_builder.reborrow().get(i as u32);
                 package.set_key(key);
                 package.set_version(version);
@@ -441,24 +443,30 @@ mod test {
     #[test_case(vec![Package {
         key: "key".to_string(),
         version: "version".to_string(),
+        is_dev: false,
     }], "1b266409f3ae154e" ; "non-empty")]
     #[test_case(vec![Package {
         key: "key".to_string(),
         version: "".to_string(),
+        is_dev: false,
     }], "bde280722f61644a" ; "empty version")]
     #[test_case(vec![Package {
         key: "key".to_string(),
         version: "version".to_string(),
+        is_dev: false,
     }, Package {
         key: "zey".to_string(),
         version: "version".to_string(),
+        is_dev: false,
     }], "6c0185544234b6dc" ; "multiple in-order")]
     #[test_case(vec![Package {
         key: "zey".to_string(),
         version: "version".to_string(),
+        is_dev: false,
     }, Package {
         key: "key".to_string(),
         version: "version".to_string(),
+        is_dev: false,
     }], "26a67c9beeb0d16f" ; "care about order")]
     fn lock_file_packages(vec: Vec<Package>, expected: &str) {
         let packages = LockFilePackages(vec);
@@ -470,6 +478,7 @@ mod test {
         let packages = (0..100).map(|i| Package {
             key: format!("key{}", i),
             version: format!("version{}", i),
+            is_dev: false,
         });
 
         lock_file_packages(packages.collect(), "4fd770c37194168e");

--- a/crates/turborepo-lockfiles/src/berry/mod.rs
+++ b/crates/turborepo-lockfiles/src/berry/mod.rs
@@ -455,6 +455,7 @@ impl Lockfile for BerryLockfile {
         Ok(Some(crate::Package {
             key: locator.to_string(),
             version: package.version.clone(),
+            is_dev: false,
         }))
     }
 
@@ -641,7 +642,8 @@ mod test {
                 .unwrap(),
             Some(Package {
                 key: "js-tokens@npm:4.0.0".into(),
-                version: "4.0.0".into()
+                version: "4.0.0".into(),
+                is_dev: false,
             }),
         );
         assert_eq!(
@@ -650,7 +652,8 @@ mod test {
                 .unwrap(),
             Some(Package {
                 key: "js-tokens@npm:4.0.0".into(),
-                version: "4.0.0".into()
+                version: "4.0.0".into(),
+                is_dev: false,
             }),
         );
         assert_eq!(
@@ -659,7 +662,8 @@ mod test {
                 .unwrap(),
             Some(Package {
                 key: "eslint-config-custom@workspace:packages/eslint-config-custom".into(),
-                version: "0.0.0-use.local".into()
+                version: "0.0.0-use.local".into(),
+                is_dev: false,
             }),
         );
         assert_eq!(
@@ -790,7 +794,8 @@ mod test {
 
         assert!(closure.contains(&Package {
             key: "lodash@npm:4.17.21".into(),
-            version: "4.17.21".into()
+            version: "4.17.21".into(),
+            is_dev: false,
         }));
     }
 
@@ -818,7 +823,8 @@ mod test {
             pkg,
             Package {
                 key: "debug@npm:1.0.0".into(),
-                version: "1.0.0".into()
+                version: "1.0.0".into(),
+                is_dev: false,
             }
         );
     }
@@ -862,7 +868,8 @@ mod test {
             pkg,
             Package {
                 key: "ms@npm:0.6.0".into(),
-                version: "0.6.0".into()
+                version: "0.6.0".into(),
+                is_dev: false,
             }
         );
     }
@@ -898,11 +905,13 @@ mod test {
 
         assert!(closure.contains(&Package {
             key: "ajv@npm:8.11.2".into(),
-            version: "8.11.2".into()
+            version: "8.11.2".into(),
+            is_dev: false,
         }));
         assert!(closure.contains(&Package {
             key: "uri-js@npm:4.4.1".into(),
-            version: "4.4.1".into()
+            version: "4.4.1".into(),
+            is_dev: false,
         }));
     }
 
@@ -927,6 +936,7 @@ mod test {
         let expected = Package {
             key: "react@npm:18.1.0".into(),
             version: "18.1.0".into(),
+            is_dev: false,
         };
         assert_eq!(actual, expected,);
 
@@ -1061,6 +1071,7 @@ mod test {
             crate::Package {
                 key: expected_key.into(),
                 version: "3.0.1".into(),
+                is_dev: false,
             }
         );
 
@@ -1083,11 +1094,13 @@ mod test {
             vec![
                 crate::Package {
                     key: expected_key.into(),
-                    version: "3.0.1".into()
+                    version: "3.0.1".into(),
+                    is_dev: false,
                 },
                 crate::Package {
                     key: "is-number@npm:6.0.0".into(),
-                    version: "6.0.0".into()
+                    version: "6.0.0".into(),
+                    is_dev: false,
                 }
             ]
             .into_iter()

--- a/crates/turborepo-lockfiles/src/bun/mod.rs
+++ b/crates/turborepo-lockfiles/src/bun/mod.rs
@@ -68,6 +68,7 @@ impl Lockfile for BunLockfile {
                 return Ok(Some(crate::Package {
                     key,
                     version: entry.version.clone(),
+                    is_dev: false,
                 }));
             }
         }

--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -29,6 +29,7 @@ pub use yarn1::{yarn_subgraph, Yarn1Lockfile};
 pub struct Package {
     pub key: String,
     pub version: String,
+    pub is_dev: bool,
 }
 
 // This trait will only be used when migrating the Go lockfile implementations
@@ -156,6 +157,11 @@ impl Package {
     pub fn new(key: impl Into<String>, version: impl Into<String>) -> Self {
         let key = key.into();
         let version = version.into();
-        Self { key, version }
+        let is_dev: bool = false;
+        Self {
+            key,
+            version,
+            is_dev,
+        }
     }
 }

--- a/crates/turborepo-lockfiles/src/yarn1/mod.rs
+++ b/crates/turborepo-lockfiles/src/yarn1/mod.rs
@@ -67,6 +67,7 @@ impl Lockfile for Yarn1Lockfile {
                 return Ok(Some(crate::Package {
                     key,
                     version: entry.version.clone(),
+                    is_dev: false,
                 }));
             }
         }


### PR DESCRIPTION
### Description

Hey,

My team and I have been experiencing issues with development dependencies being installed even when using the 
--omit=dev flag with turbo prune.
I came across the issue discussed here: [Issue #1100](https://github.com/vercel/turbo/issues/1100), particularly the [comment](https://github.com/vercel/turbo/issues/1100#issuecomment-1828353576) outlining the proposed solution.

To help advance the process, I decided to start contributing to this feature. I've begun implementing the first step mentioned:

> "We need to change our package graph to contain what dependency types in the edges."

I've added an `is_dev` flag to each package in the graph, allowing us to identify and remove development dependencies in the later stages of the pruning process.

For this MVP, I focused on `npm` and `pnpm`, extracting the necessary information directly from `package-lock.json`/`pnpm-lock.yaml`. 
I haven't implemented this for other package managers like yarn or bun yet, but I can extend it later if needed.

I'd appreciate your feedback on whether this aligns with your intended approach. 
If not, could you please provide more direction?

Additional Notes:
 - I'm not very experienced with Rust, so the code quality might not be optimal. Any guidance or suggestions for improvement would be greatly appreciated.
 - I've added relevant unit tests, but some integration tests failed. I had trouble running only the failed integration tests, so I haven't been able to address those yet. Any advice on how to run and fix those specific tests would be helpful.

Thanks for your time and consideration!
### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
