### PR TITLE
chore(tui): redirect tracing output to files during tui usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5509,6 +5509,7 @@ dependencies = [
  "turborepo-vercel-api-mock",
  "twox-hash",
  "uds_windows",
+ "uuid",
  "wax",
  "webbrowser",
  "which",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,6 +188,7 @@ triomphe = "0.1.13"
 tui-term = { version = "0.1.9", default-features = false }
 url = "2.2.2"
 urlencoding = "2.1.2"
+uuid = "1.5.0"
 webbrowser = "0.8.7"
 which = "4.4.0"
 unicode-segmentation = "1.10.1"

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -131,6 +131,7 @@ turborepo-unescape = { workspace = true }
 turborepo-vercel-api = { path = "../turborepo-vercel-api" }
 twox-hash = "1.6.3"
 uds_windows = "1.0.2"
+uuid = { workspace = true }
 wax = { workspace = true }
 webbrowser = { workspace = true }
 which = { workspace = true }

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1270,7 +1270,7 @@ pub async fn run(
             }
 
             run_args.track(&event);
-            let exit_code = run::run(base, event).await.inspect(|code| {
+            let exit_code = run::run(base, event, logger).await.inspect(|code| {
                 if *code != 0 {
                     error!("run failed: command  exited ({code})");
                 }
@@ -1282,7 +1282,7 @@ pub async fn run(
             event.track_call();
             let base = CommandBase::new(cli_args, repo_root, version, color_config);
 
-            let mut client = WatchClient::new(base, event).await?;
+            let mut client = WatchClient::new(base, event, logger).await?;
             client.start().await?;
             // We only exit if we get a signal, so we return a non-zero exit code
             return Ok(1);

--- a/crates/turborepo-lib/src/tracing.rs
+++ b/crates/turborepo-lib/src/tracing.rs
@@ -99,10 +99,10 @@ impl TurboSubscriber {
             .boxed();
 
         // we set this layer to None to start with, effectively disabling it
-        let (logrotate, daemon_update) = reload::Layer::new(Option::<_>::None);
+        let (logrotate, daemon_update) = reload::Layer::new(None);
         let logrotate = logrotate.with_filter(env_filter(LevelFilter::INFO)).boxed();
 
-        let (chrome, chrome_update) = reload::Layer::new(Option::<DynamicLayer<_>>::None);
+        let (chrome, chrome_update) = reload::Layer::new(None);
 
         let registry = Registry::default()
             .with(stderr)
@@ -136,7 +136,7 @@ impl TurboSubscriber {
         let (file_writer, guard) = tracing_appender::non_blocking(appender);
         trace!("created non-blocking file writer");
 
-        let layer: DynamicLayer<StdErrSubscriber> = tracing_subscriber::fmt::layer()
+        let layer = tracing_subscriber::fmt::layer()
             .with_writer(file_writer)
             .with_ansi(false)
             .boxed();
@@ -164,7 +164,7 @@ impl TurboSubscriber {
             .trace_style(tracing_chrome::TraceStyle::Async)
             .build();
 
-        let layer: DynamicLayer<DaemonLogSubscriber> = layer.boxed();
+        let layer = layer.boxed();
 
         self.chrome_update.reload(Some(layer))?;
         self.chrome_guard

--- a/crates/turborepo-lib/src/tracing.rs
+++ b/crates/turborepo-lib/src/tracing.rs
@@ -35,6 +35,7 @@ type StdErrSubscriber = DynamicLayered<Registry>;
 type DaemonLogSubscriber = DynamicLayered<StdErrSubscriber>;
 
 pub struct TurboSubscriber {
+    level_override: Option<LevelFilter>,
     daemon_update: Handle<Option<DynamicLayer<StdErrSubscriber>>, StdErrSubscriber>,
 
     /// The non-blocking file logger only continues to log while this guard is
@@ -74,33 +75,19 @@ impl TurboSubscriber {
             _ => Some(LevelFilter::TRACE),
         };
 
-        let env_filter = |level: LevelFilter| {
-            let filter = EnvFilter::builder()
-                .with_default_directive(level.into())
-                .with_env_var("TURBO_LOG_VERBOSITY")
-                .from_env_lossy()
-                .add_directive("reqwest=error".parse().unwrap())
-                .add_directive("hyper=warn".parse().unwrap())
-                .add_directive("h2=warn".parse().unwrap());
-
-            if let Some(max_level) = level_override {
-                filter.add_directive(max_level.into())
-            } else {
-                filter
-            }
-        };
-
         let stderr = fmt::layer()
             .with_writer(io::stderr)
             .event_format(TurboFormatter::new_with_ansi(
                 !color_config.should_strip_ansi,
             ))
-            .with_filter(env_filter(LevelFilter::WARN))
+            .with_filter(Self::env_filter(LevelFilter::WARN, level_override))
             .boxed();
 
         // we set this layer to None to start with, effectively disabling it
         let (logrotate, daemon_update) = reload::Layer::new(None);
-        let logrotate = logrotate.with_filter(env_filter(LevelFilter::INFO)).boxed();
+        let logrotate = logrotate
+            .with_filter(Self::env_filter(LevelFilter::INFO, level_override))
+            .boxed();
 
         let (chrome, chrome_update) = reload::Layer::new(None);
 
@@ -119,6 +106,7 @@ impl TurboSubscriber {
         registry.init();
 
         Self {
+            level_override,
             daemon_update,
             daemon_guard: Mutex::new(None),
             chrome_update,
@@ -173,6 +161,22 @@ impl TurboSubscriber {
             .replace(guard);
 
         Ok(())
+    }
+
+    fn env_filter(level: LevelFilter, level_override: Option<LevelFilter>) -> EnvFilter {
+        let filter = EnvFilter::builder()
+            .with_default_directive(level.into())
+            .with_env_var("TURBO_LOG_VERBOSITY")
+            .from_env_lossy()
+            .add_directive("reqwest=error".parse().unwrap())
+            .add_directive("hyper=warn".parse().unwrap())
+            .add_directive("h2=warn".parse().unwrap());
+
+        if let Some(max_level) = level_override {
+            filter.add_directive(max_level.into())
+        } else {
+            filter
+        }
     }
 }
 

--- a/crates/turborepo-lib/src/tracing.rs
+++ b/crates/turborepo-lib/src/tracing.rs
@@ -278,7 +278,7 @@ impl TracingConfig {
         }) {
             let (non_blocking, guard) = tracing_appender::non_blocking(log_file);
             (
-                layer.with_writer(non_blocking).with_filter(filter).boxed(),
+                layer.with_writer(non_blocking).boxed(),
                 Some(LogFileGuard { log_path, guard }),
             )
         } else {


### PR DESCRIPTION
### Description

This is an incomplete implementation as it currently crashes when we try to reload the `stderr` subscriber. This is due to https://github.com/tokio-rs/tracing/issues/1629 which can be worked around, but we do not have time to do that at this moment.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
