### PR TITLE
TypeScript types for `cacheDir`, `daemon`, and `envMode`

### DIFF
--- a/packages/turbo-types/src/types/config.ts
+++ b/packages/turbo-types/src/types/config.ts
@@ -280,6 +280,36 @@ export interface Pipeline {
    * Documentation: https://turbo.build/repo/docs/reference/configuration#interactive
    */
   interactive?: boolean;
+
+  /**
+   * Specify the filesystem cache directory.
+   *
+   * Documentation: https://turbo.build/repo/docs/reference/configuration#tasks
+   *
+   * @defaultValue `"".turbo/cache"`
+   */
+  cacheDir?: RelativeUnixPath;
+
+  /**
+   * Turbo can run a background process to pre-calculate values used for determining work that needs to be done. This standalone process (daemon) is an optimization, and not required for proper functioning of turbo.
+   *
+   * Documentation: https://turbo.build/repo/docs/reference/configuration#daemon
+   *
+   * @defaultValue `false`
+   */
+  daemon?: boolean;
+
+  /**
+   * Turborepo's Environment Modes allow you to control which environment variables are available to a task at runtime:
+   *
+   * - **Strict Mode**: Filter environment variables to only those that are specified in the `env` and `globalEnv` keys in `turbo.json`.
+   * - **Loose Mode**: Allow all environment variables for the process to be available.
+   *
+   * Documentation: https://turbo.build/repo/docs/crafting-your-repository/using-environment-variables#environment-modes
+   *
+   * @defaultValue `"strict"`
+   */
+  envMode?: EnvMode;
 }
 
 export interface RemoteCache {
@@ -310,8 +340,12 @@ export type OutputMode =
   | "new-only"
   | "errors-only"
   | "none";
-
+export type EnvMode = "strict" | "loose";
 export type UI = "tui" | "stream";
 
+/**
+ * This is a relative Unix-style path (e.g. `./src/index.ts` or `src/index.ts`).  Absolute paths (e.g. `/tmp/foo`) are not valid.
+ */
+export type RelativeUnixPath = string;
 export type AnchoredUnixPath = string;
 export type EnvWildcard = string;

--- a/packages/turbo-types/src/types/config.ts
+++ b/packages/turbo-types/src/types/config.ts
@@ -143,6 +143,36 @@ export interface RootSchema extends BaseSchema {
    * @defaultValue `false`
    */
   dangerouslyDisablePackageManagerCheck?: boolean;
+
+  /**
+   * Specify the filesystem cache directory.
+   *
+   * Documentation: https://turbo.build/repo/docs/reference/configuration#tasks
+   *
+   * @defaultValue `"".turbo/cache"`
+   */
+  cacheDir?: RelativeUnixPath;
+
+  /**
+   * Turbo can run a background process to pre-calculate values used for determining work that needs to be done. This standalone process (daemon) is an optimization, and not required for proper functioning of turbo.
+   *
+   * Documentation: https://turbo.build/repo/docs/reference/configuration#daemon
+   *
+   * @defaultValue `false`
+   */
+  daemon?: boolean;
+
+  /**
+   * Turborepo's Environment Modes allow you to control which environment variables are available to a task at runtime:
+   *
+   * - **Strict Mode**: Filter environment variables to only those that are specified in the `env` and `globalEnv` keys in `turbo.json`.
+   * - **Loose Mode**: Allow all environment variables for the process to be available.
+   *
+   * Documentation: https://turbo.build/repo/docs/crafting-your-repository/using-environment-variables#environment-modes
+   *
+   * @defaultValue `"strict"`
+   */
+  envMode?: EnvMode;
 }
 
 export type LegacyRootSchema = RootSchema & LegacyBaseSchema;
@@ -284,36 +314,6 @@ export interface Pipeline {
    * @defaultValue `false`
    */
   interactive?: boolean;
-
-  /**
-   * Specify the filesystem cache directory.
-   *
-   * Documentation: https://turbo.build/repo/docs/reference/configuration#tasks
-   *
-   * @defaultValue `"".turbo/cache"`
-   */
-  cacheDir?: RelativeUnixPath;
-
-  /**
-   * Turbo can run a background process to pre-calculate values used for determining work that needs to be done. This standalone process (daemon) is an optimization, and not required for proper functioning of turbo.
-   *
-   * Documentation: https://turbo.build/repo/docs/reference/configuration#daemon
-   *
-   * @defaultValue `false`
-   */
-  daemon?: boolean;
-
-  /**
-   * Turborepo's Environment Modes allow you to control which environment variables are available to a task at runtime:
-   *
-   * - **Strict Mode**: Filter environment variables to only those that are specified in the `env` and `globalEnv` keys in `turbo.json`.
-   * - **Loose Mode**: Allow all environment variables for the process to be available.
-   *
-   * Documentation: https://turbo.build/repo/docs/crafting-your-repository/using-environment-variables#environment-modes
-   *
-   * @defaultValue `"strict"`
-   */
-  envMode?: EnvMode;
 }
 
 export interface RemoteCache {


### PR DESCRIPTION
### Description

This PR adds to the TypeScript types for [cacheDir](https://github.com/vercel/turborepo/pull/8947), [daemon](https://github.com/vercel/turborepo/pull/8728), and [envMode](https://github.com/vercel/turborepo/pull/8757), all recently added items to the `turbo.json`.

### Testing Instructions

None, just ensure the values and documentation looks correct.  The links don't all exist yet, but are being added in a followup PR to the docs.
