### PR TITLE
documentation for for `cacheDir`, `daemon`, and `envMode` (config values, and env vars)

### DIFF
--- a/docs/repo-docs/reference/configuration.mdx
+++ b/docs/repo-docs/reference/configuration.mdx
@@ -131,7 +131,7 @@ Specify the filesystem cache directory.
 
 ### `daemon`
 
-Default: `false`
+Default: `true`
 
 Turbo can run a background process to pre-calculate values used for determining work that needs to be done. This standalone process (daemon) is an optimization, and not required for proper functioning of turbo.
 

--- a/docs/repo-docs/reference/configuration.mdx
+++ b/docs/repo-docs/reference/configuration.mdx
@@ -117,6 +117,47 @@ To help with incremental migration or in situations where you can't use the `pac
   environment variable.
 </Callout>
 
+### `cacheDir`
+
+Default: `".turbo/cache"`
+
+Specify the filesystem cache directory.
+
+```jsonc title="./turbo.json"
+{
+  "cacheDir": ".turbo/cache"
+}
+```
+
+### `daemon`
+
+Default: `false`
+
+Turbo can run a background process to pre-calculate values used for determining work that needs to be done. This standalone process (daemon) is an optimization, and not required for proper functioning of turbo.
+
+```jsonc title="./turbo.json"
+{
+  "daemon": true
+}
+```
+
+### `envMode`
+
+Default: `"strict"`
+
+Turborepo's Environment Modes allow you to control which environment variables are available to a task at runtime:
+
+- `"strict"`: Filter environment variables to only those that are specified in the `env` and `globalEnv` keys in `turbo.json`.
+- `"loose"`: Allow all environment variables for the process to be available.
+
+Read more about [Environment Modes](/repo/docs/crafting-your-repository/using-environment-variables#environment-modes).
+
+```jsonc title="./turbo.json"
+{
+  "envMode": "strict"
+}
+```
+
 ## Defining tasks
 
 ### `tasks`

--- a/docs/repo-docs/reference/configuration.mdx
+++ b/docs/repo-docs/reference/configuration.mdx
@@ -133,7 +133,7 @@ Specify the filesystem cache directory.
 
 Default: `true`
 
-Turbo can run a background process to pre-calculate values used for determining work that needs to be done. This standalone process (daemon) is an optimization, and not required for proper functioning of turbo.
+Turborepo runs a background process to pre-calculate some expensive operations. This standalone process (daemon) is a performance optimization, and not required for proper functioning of `turbo`.
 
 ```jsonc title="./turbo.json"
 {

--- a/docs/repo-docs/reference/run.mdx
+++ b/docs/repo-docs/reference/run.mdx
@@ -40,6 +40,8 @@ turbo run build --cache-dir="./my-cache"
   Ensure the directory is in your `.gitignore` when changing it.
 </Callout>
 
+The same behavior can also be set via the `TURBO_CACHE_DIR=example/path` system variable.
+
 ### `--concurrency <number | percentage>`
 
 Default: `10`
@@ -136,6 +138,8 @@ Controls the available environment variables in the task's runtime.
 ```bash title="Terminal"
 turbo run build --env-mode=loose
 ```
+
+The same behavior can also be set via the `TURBO_ENV_MODE=strict` system variable.
 
 #### `strict`
 
@@ -320,13 +324,13 @@ Do not cache results of the task.
 turbo run dev --no-cache
 ```
 
-### `--no-daemon`
-
-Default: `false`
+### `--daemon` and `--no-daemon`
 
 `turbo` can run a background process to pre-calculate values used for determining work that needs to be done. This standalone process (daemon) is an optimization, and not required for proper functioning of `turbo`.
 
-Passing `--no-daemon` instructs `turbo` to avoid using or creating the standalone process.
+Passing `--daemon` instructs `turbo` to use the standalone process, while `--no-daemon` instructs `turbo` to avoid using or creating the standalone process.
+
+The same behavior can also be set via the `TURBO_DAEMON=true` system variable.
 
 ### `--output-logs <option>`
 

--- a/packages/turbo-types/schemas/schema.json
+++ b/packages/turbo-types/schemas/schema.json
@@ -72,7 +72,7 @@
         },
         "daemon": {
           "type": "boolean",
-          "description": "Turbo can run a background process to pre-calculate values used for determining work that needs to be done. This standalone process (daemon) is an optimization, and not required for proper functioning of turbo.\n\nDocumentation: https://turbo.build/repo/docs/reference/configuration#daemon"
+          "description": "Turborepo runs a background process to pre-calculate some expensive operations. This standalone process (daemon) is a performance optimization, and not required for proper functioning of `turbo`.\n\nDocumentation: https://turbo.build/repo/docs/reference/configuration#daemon"
         },
         "envMode": {
           "$ref": "#/definitions/EnvMode",

--- a/packages/turbo-types/schemas/schema.json
+++ b/packages/turbo-types/schemas/schema.json
@@ -68,7 +68,7 @@
         },
         "cacheDir": {
           "$ref": "#/definitions/RelativeUnixPath",
-          "description": "Specify the filesystem cache directory.\n\nDocumentation: https://turbo.build/repo/docs/reference/configuration#tasks"
+          "description": "Specify the filesystem cache directory.\n\nDocumentation: https://turbo.build/repo/docs/reference/configuration#cachedir"
         },
         "daemon": {
           "type": "boolean",
@@ -76,7 +76,7 @@
         },
         "envMode": {
           "$ref": "#/definitions/EnvMode",
-          "description": "Turborepo's Environment Modes allow you to control which environment variables are available to a task at runtime:\n\n- **Strict Mode**: Filter environment variables to only those that are specified in the `env` and `globalEnv` keys in `turbo.json`.\n- **Loose Mode**: Allow all environment variables for the process to be available.\n\nDocumentation: https://turbo.build/repo/docs/crafting-your-repository/using-environment-variables#environment-modes"
+          "description": "Turborepo's Environment Modes allow you to control which environment variables are available to a task at runtime:\n\n- `\"strict\"`: Filter environment variables to only those that are specified in the `env` and `globalEnv` keys in `turbo.json`.\n- `\"loose\"`: Allow all environment variables for the process to be available.\n\nDocumentation: https://turbo.build/repo/docs/reference/configuration#envmode"
         }
       },
       "additionalProperties": false,

--- a/packages/turbo-types/schemas/schema.v2.json
+++ b/packages/turbo-types/schemas/schema.v2.json
@@ -72,7 +72,7 @@
         },
         "daemon": {
           "type": "boolean",
-          "description": "Turbo can run a background process to pre-calculate values used for determining work that needs to be done. This standalone process (daemon) is an optimization, and not required for proper functioning of turbo.\n\nDocumentation: https://turbo.build/repo/docs/reference/configuration#daemon"
+          "description": "Turborepo runs a background process to pre-calculate some expensive operations. This standalone process (daemon) is a performance optimization, and not required for proper functioning of `turbo`.\n\nDocumentation: https://turbo.build/repo/docs/reference/configuration#daemon"
         },
         "envMode": {
           "$ref": "#/definitions/EnvMode",

--- a/packages/turbo-types/schemas/schema.v2.json
+++ b/packages/turbo-types/schemas/schema.v2.json
@@ -68,7 +68,7 @@
         },
         "cacheDir": {
           "$ref": "#/definitions/RelativeUnixPath",
-          "description": "Specify the filesystem cache directory.\n\nDocumentation: https://turbo.build/repo/docs/reference/configuration#tasks"
+          "description": "Specify the filesystem cache directory.\n\nDocumentation: https://turbo.build/repo/docs/reference/configuration#cachedir"
         },
         "daemon": {
           "type": "boolean",
@@ -76,7 +76,7 @@
         },
         "envMode": {
           "$ref": "#/definitions/EnvMode",
-          "description": "Turborepo's Environment Modes allow you to control which environment variables are available to a task at runtime:\n\n- **Strict Mode**: Filter environment variables to only those that are specified in the `env` and `globalEnv` keys in `turbo.json`.\n- **Loose Mode**: Allow all environment variables for the process to be available.\n\nDocumentation: https://turbo.build/repo/docs/crafting-your-repository/using-environment-variables#environment-modes"
+          "description": "Turborepo's Environment Modes allow you to control which environment variables are available to a task at runtime:\n\n- `\"strict\"`: Filter environment variables to only those that are specified in the `env` and `globalEnv` keys in `turbo.json`.\n- `\"loose\"`: Allow all environment variables for the process to be available.\n\nDocumentation: https://turbo.build/repo/docs/reference/configuration#envmode"
         }
       },
       "additionalProperties": false,

--- a/packages/turbo-types/src/types/config-v2.ts
+++ b/packages/turbo-types/src/types/config-v2.ts
@@ -136,7 +136,7 @@ export interface RootSchema extends BaseSchema {
   cacheDir?: RelativeUnixPath;
 
   /**
-   * Turbo can run a background process to pre-calculate values used for determining work that needs to be done. This standalone process (daemon) is an optimization, and not required for proper functioning of turbo.
+   * Turborepo runs a background process to pre-calculate some expensive operations. This standalone process (daemon) is a performance optimization, and not required for proper functioning of `turbo`.
    *
    * Documentation: https://turbo.build/repo/docs/reference/configuration#daemon
    *

--- a/packages/turbo-types/src/types/config-v2.ts
+++ b/packages/turbo-types/src/types/config-v2.ts
@@ -129,7 +129,7 @@ export interface RootSchema extends BaseSchema {
   /**
    * Specify the filesystem cache directory.
    *
-   * Documentation: https://turbo.build/repo/docs/reference/configuration#tasks
+   * Documentation: https://turbo.build/repo/docs/reference/configuration#cachedir
    *
    * @defaultValue `"".turbo/cache"`
    */
@@ -147,10 +147,10 @@ export interface RootSchema extends BaseSchema {
   /**
    * Turborepo's Environment Modes allow you to control which environment variables are available to a task at runtime:
    *
-   * - **Strict Mode**: Filter environment variables to only those that are specified in the `env` and `globalEnv` keys in `turbo.json`.
-   * - **Loose Mode**: Allow all environment variables for the process to be available.
+   * - `"strict"`: Filter environment variables to only those that are specified in the `env` and `globalEnv` keys in `turbo.json`.
+   * - `"loose"`: Allow all environment variables for the process to be available.
    *
-   * Documentation: https://turbo.build/repo/docs/crafting-your-repository/using-environment-variables#environment-modes
+   * Documentation: https://turbo.build/repo/docs/reference/configuration#envmode
    *
    * @defaultValue `"strict"`
    */

--- a/packages/turbo-types/src/types/config-v2.ts
+++ b/packages/turbo-types/src/types/config-v2.ts
@@ -131,7 +131,7 @@ export interface RootSchema extends BaseSchema {
    *
    * Documentation: https://turbo.build/repo/docs/reference/configuration#cachedir
    *
-   * @defaultValue `"".turbo/cache"`
+   * @defaultValue `".turbo/cache"`
    */
   cacheDir?: RelativeUnixPath;
 


### PR DESCRIPTION
### Description

This PR adds documentation for https://github.com/vercel/turborepo/pull/8947, https://github.com/vercel/turborepo/pull/8728, and https://github.com/vercel/turborepo/pull/8757, all recently added items to the turbo.json (and env vars).

### Testing Instructions

View the preview deployment :point_down: 