### PR TITLE
fix: lock tui-term version to pass rust type check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,7 +185,7 @@ tracing = "0.1.37"
 tracing-appender = "0.2.2"
 tracing-subscriber = "0.3.16"
 triomphe = "0.1.13"
-tui-term = { version = "0.1.9", default-features = false }
+tui-term = { version = "=0.1.9", default-features = false }
 url = "2.2.2"
 urlencoding = "2.1.2"
 webbrowser = "0.8.7"


### PR DESCRIPTION
### Description

In latest version of tui-term, it breaks the usage of ui_term::widget::Cell without change the minor number of version, makes turborepo-lib impossible to be build as crate without modify.

This fix lock the tui-term version and solve the problem above.