### PR TITLE
feat: color no longer tied to task execution order

### DIFF
--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -156,6 +156,10 @@ impl<'a> Visitor<'a> {
         engine: Arc<Engine>,
         telemetry: &GenericEventBuilder,
     ) -> Result<Vec<TaskError>, Error> {
+        for task in engine.tasks().sorted() {
+            self.color_cache.color_for_key(&task.to_string());
+        }
+
         let concurrency = self.run_opts.concurrency as usize;
         let (node_sender, mut node_stream) = mpsc::channel(concurrency);
 
@@ -659,6 +663,7 @@ impl<'a> ExecContextFactory<'a> {
     ) -> ExecContext {
         let task_id_for_display = self.visitor.display_task_id(&task_id);
         let pass_through_args = self.visitor.run_opts.args_for_task(&task_id);
+        let task_id_string = &task_id.to_string();
         ExecContext {
             engine: self.engine.clone(),
             color_config: self.visitor.color_config,
@@ -667,7 +672,7 @@ impl<'a> ExecContextFactory<'a> {
             pretty_prefix: self
                 .visitor
                 .color_cache
-                .prefix_with_color(&task_hash, &self.visitor.prefix(&task_id)),
+                .prefix_with_color(task_id_string, &self.visitor.prefix(&task_id)),
             task_id,
             task_id_for_display,
             task_cache,


### PR DESCRIPTION
### Description

Related to https://github.com/vercel/turborepo/pull/9008/files

- color order is no longer tied to task execution order
- color is no longer tied to task hashes which change frequently

This should end up with more consistent colors between runs

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
