### PR TITLE
chore(tui): remove unwraps from tui

### DIFF
--- a/crates/turborepo-ui/src/tui/mod.rs
+++ b/crates/turborepo-ui/src/tui/mod.rs
@@ -26,6 +26,8 @@ pub use term_output::TerminalOutput;
 pub enum Error {
     #[error("No task found with name '{name}'")]
     TaskNotFound { name: String },
+    #[error("No task at index {index} (only {len} tasks) ")]
+    TaskNotFoundIndex { index: usize, len: usize },
     #[error("Unable to write to stdin for '{name}': {e}")]
     Stdin { name: String, e: std::io::Error },
     #[error(transparent)]

--- a/crates/turborepo-ui/src/tui/task.rs
+++ b/crates/turborepo-ui/src/tui/task.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 use std::{collections::HashSet, mem, time::Instant};
 
-use super::event::TaskResult;
+use super::{event::TaskResult, Error};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub struct Planned;
@@ -133,8 +133,13 @@ impl TasksByStatus {
         running_names.chain(planned_names).chain(finished_names)
     }
 
-    pub fn task_name(&self, index: usize) -> &str {
-        self.task_names_in_displayed_order().nth(index).unwrap()
+    pub fn task_name(&self, index: usize) -> Result<&str, Error> {
+        self.task_names_in_displayed_order()
+            .nth(index)
+            .ok_or_else(|| Error::TaskNotFoundIndex {
+                index,
+                len: self.count_all(),
+            })
     }
 
     pub fn tasks_started(&self) -> Vec<String> {


### PR DESCRIPTION
### Description

As https://github.com/vercel/turborepo/issues/9016 displayed, panicking in the render thread leads to a very poor user experience. We should do our best effort to avoid this by using errors so we can make sure the `cleanup` code gets run.

This PR removes (almost) all `unwrap`s/`expect`s in favor of returning an `Err` which will cause us to exit `run_app_inner`.

### Testing Instructions

Existing unit tests. 👀 
