### PR TITLE
allow multiple fallbacks for --affected base branch

### DIFF
--- a/crates/turborepo-lib/src/commands/config.rs
+++ b/crates/turborepo-lib/src/commands/config.rs
@@ -23,7 +23,7 @@ struct ConfigOutput<'a> {
     package_manager: PackageManager,
     daemon: Option<bool>,
     env_mode: EnvMode,
-    scm_base: &'a str,
+    scm_base: Option<&'a str>,
     scm_head: &'a str,
     cache_dir: &'a Utf8Path,
 }

--- a/crates/turborepo-lib/src/config.rs
+++ b/crates/turborepo-lib/src/config.rs
@@ -298,8 +298,8 @@ impl ConfigurationOptions {
         self.ui.unwrap_or(UIMode::Stream)
     }
 
-    pub fn scm_base(&self) -> &str {
-        self.scm_base.as_deref().unwrap_or("main")
+    pub fn scm_base(&self) -> Option<&str> {
+        self.scm_base.as_deref()
     }
 
     pub fn scm_head(&self) -> &str {

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -513,7 +513,7 @@ mod test {
             pkg_inference_root: None,
             global_deps: vec![],
             filter_patterns: opts_input.filter_patterns,
-            affected_range: opts_input.affected,
+            affected_range: opts_input.affected.map(|(base, head)| (Some(base), head)),
         };
         let opts = Opts {
             run_opts,

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -307,7 +307,7 @@ pub struct ScopeOpts {
     pub pkg_inference_root: Option<AnchoredSystemPathBuf>,
     pub global_deps: Vec<String>,
     pub filter_patterns: Vec<String>,
-    pub affected_range: Option<(String, String)>,
+    pub affected_range: Option<(Option<String>, String)>,
 }
 
 impl<'a> TryFrom<OptsInputs<'a>> for ScopeOpts {
@@ -324,7 +324,7 @@ impl<'a> TryFrom<OptsInputs<'a>> for ScopeOpts {
         let affected_range = inputs.execution_args.affected.then(|| {
             let scm_base = inputs.config.scm_base();
             let scm_head = inputs.config.scm_head();
-            (scm_base.to_string(), scm_head.to_string())
+            (scm_base.map(|b| b.to_owned()), scm_head.to_string())
         });
 
         Ok(Self {

--- a/crates/turborepo-lib/src/query.rs
+++ b/crates/turborepo-lib/src/query.rs
@@ -242,10 +242,10 @@ impl Query {
         base: Option<String>,
         head: Option<String>,
     ) -> Result<Vec<Package>, Error> {
-        let base = base.unwrap_or_else(|| "main".to_string());
+        let base = base.unwrap_or_else(|| "main".to_string()); // TODO
         let head = head.unwrap_or_else(|| "HEAD".to_string());
         let mut opts = self.run.opts().clone();
-        opts.scope_opts.affected_range = Some((base, head));
+        opts.scope_opts.affected_range = Some((Some(base), head));
 
         Ok(RunBuilder::calculate_filtered_packages(
             self.run.repo_root(),

--- a/crates/turborepo-lib/src/query.rs
+++ b/crates/turborepo-lib/src/query.rs
@@ -242,7 +242,7 @@ impl Query {
         base: Option<String>,
         head: Option<String>,
     ) -> Result<Vec<Package>, Error> {
-        let base = base.unwrap_or_else(|| "main".to_string()); // TODO
+        let base = base.map(|s| s.to_owned());
         let head = head.unwrap_or_else(|| "HEAD".to_string());
         let mut opts = self.run.opts().clone();
         opts.scope_opts.affected_range = Some((Some(base), head));

--- a/crates/turborepo-lib/src/query.rs
+++ b/crates/turborepo-lib/src/query.rs
@@ -245,7 +245,7 @@ impl Query {
         let base = base.map(|s| s.to_owned());
         let head = head.unwrap_or_else(|| "HEAD".to_string());
         let mut opts = self.run.opts().clone();
-        opts.scope_opts.affected_range = Some((Some(base), head));
+        opts.scope_opts.affected_range = Some((base, head));
 
         Ok(RunBuilder::calculate_filtered_packages(
             self.run.repo_root(),

--- a/crates/turborepo-lib/src/run/scope/change_detector.rs
+++ b/crates/turborepo-lib/src/run/scope/change_detector.rs
@@ -94,7 +94,7 @@ impl<'a> GitChangeDetector for ScopeChangeDetector<'a> {
         allow_unknown_objects: bool,
     ) -> Result<HashSet<PackageName>, ResolutionError> {
         let mut changed_files = HashSet::new();
-        if !from_ref.map_or(true, |s| s.is_empty()) {
+        if !from_ref.map_or(false, |s| s.is_empty()) {
             changed_files = match self.scm.changed_files(
                 self.turbo_root,
                 from_ref,

--- a/crates/turborepo-lib/src/run/scope/change_detector.rs
+++ b/crates/turborepo-lib/src/run/scope/change_detector.rs
@@ -93,26 +93,23 @@ impl<'a> GitChangeDetector for ScopeChangeDetector<'a> {
         include_uncommitted: bool,
         allow_unknown_objects: bool,
     ) -> Result<HashSet<PackageName>, ResolutionError> {
-        let mut changed_files = HashSet::new();
-        if !from_ref.map_or(false, |s| s.is_empty()) {
-            changed_files = match self.scm.changed_files(
-                self.turbo_root,
-                from_ref,
-                to_ref,
-                include_uncommitted,
-                allow_unknown_objects,
-            )? {
-                ChangedFiles::All => {
-                    debug!("all packages changed");
-                    return Ok(self
-                        .pkg_graph
-                        .packages()
-                        .map(|(name, _)| name.to_owned())
-                        .collect());
-                }
-                ChangedFiles::Some(changed_files) => changed_files,
+        let changed_files = match self.scm.changed_files(
+            self.turbo_root,
+            from_ref,
+            to_ref,
+            include_uncommitted,
+            allow_unknown_objects,
+        )? {
+            ChangedFiles::All => {
+                debug!("all packages changed");
+                return Ok(self
+                    .pkg_graph
+                    .packages()
+                    .map(|(name, _)| name.to_owned())
+                    .collect());
             }
-        }
+            ChangedFiles::Some(changed_files) => changed_files,
+        };
 
         let lockfile_contents = self.get_lockfile_contents(from_ref, &changed_files);
 

--- a/crates/turborepo-lib/src/run/scope/change_detector.rs
+++ b/crates/turborepo-lib/src/run/scope/change_detector.rs
@@ -17,7 +17,7 @@ use crate::{
 pub trait GitChangeDetector {
     fn changed_packages(
         &self,
-        from_ref: &str,
+        from_ref: Option<&str>,
         to_ref: Option<&str>,
         include_uncommitted: bool,
         allow_unknown_objects: bool,
@@ -55,7 +55,7 @@ impl<'a> ScopeChangeDetector<'a> {
     /// returns an empty lockfile change
     fn get_lockfile_contents(
         &self,
-        from_ref: &str,
+        from_ref: Option<&str>,
         changed_files: &HashSet<AnchoredSystemPathBuf>,
     ) -> Option<LockfileChange> {
         let lockfile_path = self
@@ -88,13 +88,13 @@ impl<'a> ScopeChangeDetector<'a> {
 impl<'a> GitChangeDetector for ScopeChangeDetector<'a> {
     fn changed_packages(
         &self,
-        from_ref: &str,
+        from_ref: Option<&str>,
         to_ref: Option<&str>,
         include_uncommitted: bool,
         allow_unknown_objects: bool,
     ) -> Result<HashSet<PackageName>, ResolutionError> {
         let mut changed_files = HashSet::new();
-        if !from_ref.is_empty() {
+        if !from_ref.map_or(true, |s| s.is_empty()) {
             changed_files = match self.scm.changed_files(
                 self.turbo_root,
                 from_ref,

--- a/crates/turborepo-lib/src/run/scope/target_selector.rs
+++ b/crates/turborepo-lib/src/run/scope/target_selector.rs
@@ -6,7 +6,7 @@ use turbopath::AnchoredSystemPathBuf;
 
 #[derive(Debug, Default, PartialEq)]
 pub struct GitRange {
-    pub from_ref: String,
+    pub from_ref: Option<String>,
     pub to_ref: Option<String>,
     pub include_uncommitted: bool,
     // Allow unknown objects to be included in the range, without returning an error.
@@ -155,7 +155,7 @@ impl FromStr for TargetSelector {
                     ));
                 }
                 GitRange {
-                    from_ref: a.to_string(),
+                    from_ref: Some(a.to_string()),
                     to_ref: Some(b.to_string()),
                     include_uncommitted: false,
                     allow_unknown_objects: false,
@@ -164,7 +164,7 @@ impl FromStr for TargetSelector {
                 // If only the start of the range is specified, we assume that
                 // we want to include uncommitted changes
                 GitRange {
-                    from_ref: commits_str.to_string(),
+                    from_ref: Some(commits_str.to_string()),
                     to_ref: None,
                     include_uncommitted: true,
                     allow_unknown_objects: false,
@@ -252,17 +252,17 @@ mod test {
     #[test_case("...{./foo}", TargetSelector { raw: "...{./foo}".to_string(), parent_dir: Some(AnchoredSystemPathBuf::try_from("foo").unwrap()), include_dependents: true, ..Default::default() }; "dot dot dot curly bracket foo")]
     #[test_case(".", TargetSelector { raw: ".".to_string(), parent_dir: Some(AnchoredSystemPathBuf::try_from(".").unwrap()), ..Default::default() }; "parent dir dot")]
     #[test_case("..", TargetSelector { raw: "..".to_string(), parent_dir: Some(AnchoredSystemPathBuf::try_from("..").unwrap()), ..Default::default() }; "parent dir dot dot")]
-    #[test_case("[master]", TargetSelector { raw: "[master]".to_string(), git_range: Some(GitRange { from_ref: "master".to_string(), to_ref: None, include_uncommitted: true, ..Default::default() }), ..Default::default() }; "square brackets master")]
-    #[test_case("[from...to]", TargetSelector { raw: "[from...to]".to_string(), git_range: Some(GitRange { from_ref: "from".to_string(), to_ref: Some("to".to_string()), ..Default::default() }), ..Default::default() }; "[from...to]")]
-    #[test_case("{foo}[master]", TargetSelector { raw: "{foo}[master]".to_string(), git_range: Some(GitRange { from_ref: "master".to_string(), to_ref: None, include_uncommitted: true, ..Default::default() }), parent_dir: Some(AnchoredSystemPathBuf::try_from("foo").unwrap()), ..Default::default() }; "{foo}[master]")]
-    #[test_case("pattern{foo}[master]", TargetSelector { raw: "pattern{foo}[master]".to_string(), git_range: Some(GitRange { from_ref: "master".to_string(), to_ref: None, include_uncommitted: true, ..Default::default() }), parent_dir: Some(AnchoredSystemPathBuf::try_from("foo").unwrap()), name_pattern: "pattern".to_string(), ..Default::default() }; "pattern{foo}[master]")]
-    #[test_case("[master]...", TargetSelector { raw: "[master]...".to_string(), git_range: Some(GitRange { from_ref: "master".to_string(), to_ref: None, include_uncommitted: true, ..Default::default() }), include_dependencies: true, ..Default::default() }; "square brackets master dot dot dot")]
-    #[test_case("...[master]", TargetSelector { raw: "...[master]".to_string(), git_range: Some(GitRange { from_ref: "master".to_string(), to_ref: None, include_uncommitted: true, ..Default::default() }), include_dependents: true, ..Default::default() }; "dot dot dot master square brackets")]
-    #[test_case("...[master]...", TargetSelector { raw: "...[master]...".to_string(), git_range: Some(GitRange { from_ref: "master".to_string(), to_ref: None, include_uncommitted: true, ..Default::default() }), include_dependencies: true, include_dependents: true, ..Default::default() }; "dot dot dot master square brackets dot dot dot")]
-    #[test_case("...[from...to]...", TargetSelector { raw: "...[from...to]...".to_string(), git_range: Some(GitRange { from_ref: "from".to_string(), to_ref: Some("to".to_string()), ..Default::default() }), include_dependencies: true, include_dependents: true, ..Default::default() }; "dot dot dot [from...to] dot dot dot")]
-    #[test_case("foo...[master]", TargetSelector { raw: "foo...[master]".to_string(), git_range: Some(GitRange { from_ref: "master".to_string(), to_ref: None, include_uncommitted: true, ..Default::default() }), name_pattern: "foo".to_string(), match_dependencies: true, ..Default::default() }; "foo...[master]")]
-    #[test_case("foo...[master]...", TargetSelector { raw: "foo...[master]...".to_string(), git_range: Some(GitRange { from_ref: "master".to_string(), to_ref: None, include_uncommitted: true, ..Default::default() }), name_pattern: "foo".to_string(), match_dependencies: true, include_dependencies: true, ..Default::default() }; "foo...[master] dot dot dot")]
-    #[test_case("{foo}...[master]", TargetSelector { raw: "{foo}...[master]".to_string(), git_range: Some(GitRange { from_ref: "master".to_string(), to_ref: None, include_uncommitted: true, ..Default::default() }), parent_dir: Some(AnchoredSystemPathBuf::try_from("foo").unwrap()), match_dependencies: true, ..Default::default() }; " curly brackets foo...[master]")]
+    #[test_case("[master]", TargetSelector { raw: "[master]".to_string(), git_range: Some(GitRange { from_ref: Some("master".to_string()), to_ref: None, include_uncommitted: true, ..Default::default() }), ..Default::default() }; "square brackets master")]
+    #[test_case("[from...to]", TargetSelector { raw: "[from...to]".to_string(), git_range: Some(GitRange { from_ref: Some("from".to_string()), to_ref: Some("to".to_string()), ..Default::default() }), ..Default::default() }; "[from...to]")]
+    #[test_case("{foo}[master]", TargetSelector { raw: "{foo}[master]".to_string(), git_range: Some(GitRange { from_ref: Some("master".to_string()), to_ref: None, include_uncommitted: true, ..Default::default() }), parent_dir: Some(AnchoredSystemPathBuf::try_from("foo").unwrap()), ..Default::default() }; "{foo}[master]")]
+    #[test_case("pattern{foo}[master]", TargetSelector { raw: "pattern{foo}[master]".to_string(), git_range: Some(GitRange { from_ref: Some("master".to_string()), to_ref: None, include_uncommitted: true, ..Default::default() }), parent_dir: Some(AnchoredSystemPathBuf::try_from("foo").unwrap()), name_pattern: "pattern".to_string(), ..Default::default() }; "pattern{foo}[master]")]
+    #[test_case("[master]...", TargetSelector { raw: "[master]...".to_string(), git_range: Some(GitRange { from_ref: Some("master".to_string()), to_ref: None, include_uncommitted: true, ..Default::default() }), include_dependencies: true, ..Default::default() }; "square brackets master dot dot dot")]
+    #[test_case("...[master]", TargetSelector { raw: "...[master]".to_string(), git_range: Some(GitRange { from_ref: Some("master".to_string()), to_ref: None, include_uncommitted: true, ..Default::default() }), include_dependents: true, ..Default::default() }; "dot dot dot master square brackets")]
+    #[test_case("...[master]...", TargetSelector { raw: "...[master]...".to_string(), git_range: Some(GitRange { from_ref: Some("master".to_string()), to_ref: None, include_uncommitted: true, ..Default::default() }), include_dependencies: true, include_dependents: true, ..Default::default() }; "dot dot dot master square brackets dot dot dot")]
+    #[test_case("...[from...to]...", TargetSelector { raw: "...[from...to]...".to_string(), git_range: Some(GitRange { from_ref: Some("from".to_string()), to_ref: Some("to".to_string()), ..Default::default() }), include_dependencies: true, include_dependents: true, ..Default::default() }; "dot dot dot [from...to] dot dot dot")]
+    #[test_case("foo...[master]", TargetSelector { raw: "foo...[master]".to_string(), git_range: Some(GitRange { from_ref: Some("master".to_string()), to_ref: None, include_uncommitted: true, ..Default::default() }), name_pattern: "foo".to_string(), match_dependencies: true, ..Default::default() }; "foo...[master]")]
+    #[test_case("foo...[master]...", TargetSelector { raw: "foo...[master]...".to_string(), git_range: Some(GitRange { from_ref: Some("master".to_string()), to_ref: None, include_uncommitted: true, ..Default::default() }), name_pattern: "foo".to_string(), match_dependencies: true, include_dependencies: true, ..Default::default() }; "foo...[master] dot dot dot")]
+    #[test_case("{foo}...[master]", TargetSelector { raw: "{foo}...[master]".to_string(), git_range: Some(GitRange { from_ref: Some("master".to_string()), to_ref: None, include_uncommitted: true, ..Default::default() }), parent_dir: Some(AnchoredSystemPathBuf::try_from("foo").unwrap()), match_dependencies: true, ..Default::default() }; " curly brackets foo...[master]")]
     fn parse_target_selector(raw_selector: &str, want: TargetSelector) {
         let result = TargetSelector::from_str(raw_selector);
 

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -94,7 +94,7 @@ impl Git {
         if master_result.is_ok() {
             return Ok("master");
         }
-        Err(Error::UnableToResolveRef())
+        Err(Error::UnableToResolveRef)
     }
 
     fn changed_files(

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -64,7 +64,7 @@ pub enum Error {
     #[error(transparent)]
     Walk(#[from] globwalk::WalkError),
     #[error("unable to resolve base branch, please set with TURBO_SCM_BASE")]
-    UnableToResolveRef(),
+    UnableToResolveRef,
 }
 
 impl From<wax::BuildError> for Error {

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -63,6 +63,8 @@ pub enum Error {
     Globwalk(#[from] globwalk::GlobError),
     #[error(transparent)]
     Walk(#[from] globwalk::WalkError),
+    #[error("unable to resolve base branch, please set with TURBO_SCM_BASE")]
+    UnableToResolveRef(),
 }
 
 impl From<wax::BuildError> for Error {

--- a/turborepo-tests/integration/tests/config.t
+++ b/turborepo-tests/integration/tests/config.t
@@ -18,7 +18,7 @@ Run test run
     "packageManager": "npm",
     "daemon": null,
     "envMode": "strict",
-    "scmBase": "main",
+    "scmBase": null,
     "scmHead": "HEAD",
     "cacheDir": ".turbo[\\/]+cache" (re)
   }


### PR DESCRIPTION
### Description

We use `main` as our default for base branch, but a lot of repos are likely using `master`, we should fall back to that if `main` isn't a valid ref.

### Testing Instructions

see unit tests https://github.com/vercel/turborepo/pull/9045/files#diff-db1296fb6f1a06e197e7cd6cdf5979b738c6b56b7700b048ab3b00fd767f8aecR734-R746 for situations to test manually.
