### PR TITLE
fix(affected): prevent affected from being used with filter

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -732,7 +732,7 @@ pub struct ExecutionArgs {
 
     /// Run only tasks that are affected by changes between
     /// the current branch and `main`
-    #[clap(long, group = "scope-filter-group")]
+    #[clap(long, group = "scope-filter-group", conflicts_with = "filter")]
     pub affected: bool,
 
     /// Set type of process output logging. Use "full" to show
@@ -2613,5 +2613,16 @@ mod test {
             .unwrap()
             .dangerously_disable_package_manager_check
         );
+    }
+
+    #[test]
+    fn test_prevent_affected_and_filter() {
+        assert!(
+            Args::try_parse_from(["turbo", "run", "build", "--affected", "--filter", "foo"])
+                .is_err(),
+        );
+        assert!(Args::try_parse_from(["turbo", "build", "--affected", "--filter", "foo"]).is_err(),);
+        assert!(Args::try_parse_from(["turbo", "build", "--filter", "foo", "--affected"]).is_err(),);
+        assert!(Args::try_parse_from(["turbo", "ls", "--filter", "foo", "--affected"]).is_err(),);
     }
 }


### PR DESCRIPTION
### Description

We already would throw for `turbo ls`, but for some reason `clap` would accept `--filter` and `--affected` on `run`.
```
[0 olszewski@Chriss-MacBook-Pro] /Users/olszewski/code/vercel/turborepo $ turbo_dev ls --affected --filter='cli'                                     
 WARNING  No locally installed `turbo` found. Using version: 2.0.15-canary.0.
 ERROR  the argument '--affected' cannot be used with '--filter <FILTER>'

Usage: turbo ls --affected [PACKAGES]...

For more information, try '--help'.

[1 olszewski@Chriss-MacBook-Pro] /Users/olszewski/code/vercel/turborepo $ turbo_dev run build --affected --filter='!cli'
 WARNING  No locally installed `turbo` found. Using version: 2.0.15-canary.0.
turbo 2.0.15-canary.0

• Packages in scope: 
• Running build in 0 packages
• Remote caching enabled

No tasks were executed as part of this run.

 Tasks:    0 successful, 0 total
Cached:    0 cached, 0 total
  Time:    197ms 

Run: https://vercel.com/teams/vercel/repos/turbo-monorepo/runs/space_run_sAdkTu3ztxIjkUs0YpeIG82A
```

### Testing Instructions

Added unit tests to make sure this results in an error if both are used.
