### PR TITLE
docs: document run displaying available tasks

### DIFF
--- a/docs/repo-docs/reference/run.mdx
+++ b/docs/repo-docs/reference/run.mdx
@@ -24,6 +24,12 @@ turbo run [tasks] [options] [-- [args passed to tasks]]
   of use.
 </Callout>
 
+If no tasks are provided, `turbo` will display what tasks are available for the packages in the repository.
+
+```bash title="Terminal"
+turbo run
+```
+
 ## Options
 
 ### `--cache-dir <path>`


### PR DESCRIPTION
### Description

Add documentation for new `turbo run` behavior on the `run` reference.

I decided to not show the output as the syntax highlighting was odd
![Screenshot 2024-08-23 at 9 48 39 AM](https://github.com/user-attachments/assets/7b26daeb-d649-4e74-84c8-1b1615ef5007)


### Testing Instructions

![Screenshot 2024-08-23 at 9 48 09 AM](https://github.com/user-attachments/assets/99f91725-2c34-41fd-bdaa-9fc3e87e9661)

