### PR TITLE
chore(tui): fix lint warnings in tests

### DIFF
--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -884,7 +884,7 @@ mod test {
         );
 
         // Restart b
-        app.restart_tasks(vec!["b".to_string()]);
+        app.restart_tasks(vec!["b".to_string()])?;
         app.start_task("b", OutputLogs::Full)?;
         assert_eq!(
             (
@@ -896,7 +896,7 @@ mod test {
         );
 
         // Restart a
-        app.restart_tasks(vec!["a".to_string()]);
+        app.restart_tasks(vec!["a".to_string()])?;
         app.start_task("a", OutputLogs::Full)?;
         assert_eq!(
             (
@@ -962,13 +962,13 @@ mod test {
         app.insert_stdin("b", Some(Vec::new())).unwrap();
 
         // Interact and type "hello"
-        app.interact();
+        app.interact()?;
         app.forward_input(b"hello!").unwrap();
 
         // Exit interaction and move up
-        app.interact();
+        app.interact()?;
         app.previous();
-        app.interact();
+        app.interact()?;
         app.forward_input(b"world").unwrap();
 
         assert_eq!(


### PR DESCRIPTION
### Description

We were getting lint warnings from not using the result of some functions with in these tests.

### Testing Instructions

`cargo test -p turborepo-ui ` should no longer produce build warnings.
