### PR TITLE
fix(cli): avoid use of process exit

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1293,7 +1293,7 @@ pub async fn run(
 
             if execution_args.tasks.is_empty() {
                 print_potential_tasks(base, event).await?;
-                process::exit(1);
+                return Ok(1);
             }
 
             if let Some((file_path, include_args)) = run_args.profile_file_and_include_args() {


### PR DESCRIPTION
### Description

We've seen segfaults from running `turbo run` on [CI]()

We believe this is due to `process::exit` being called before some `Drop` implementations have been run. We make sure `Drop`s are run by returning the exit code instead of exiting.

### Testing Instructions

Run in CI multiple times:
 - [Run 1](https://github.com/vercel/turborepo/actions/runs/10562720469/job/29261407172?pr=9065)
 - [Run 2](https://github.com/vercel/turborepo/actions/runs/10562720469/job/29262901217?pr=9065)