### PR TITLE
chore(config): add undocummented `remote` types to `turbo.json` schema

### DIFF
--- a/packages/turbo-types/schemas/schema.json
+++ b/packages/turbo-types/schemas/schema.json
@@ -171,6 +171,22 @@
         "enabled": {
           "type": "boolean",
           "description": "Indicates if the remote cache is enabled. When `false`, Turborepo will disable all remote cache operations, even if the repo has a valid token. If true, remote caching is enabled, but still requires the user to login and link their repo to a remote cache. Documentation: https://turbo.build/repo/docs/core-concepts/remote-caching"
+        },
+        "preflight": {
+          "type": "boolean",
+          "description": "When enabled, any HTTP request will be preceded by an OPTIONS request to determine if the request is supported by the endpoint.\n\nDocumentation: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#preflighted_requests"
+        },
+        "apiUrl": {
+          "type": "string",
+          "description": "Set endpoint for API calls to the remote cache. Documentation: https://turbo.build/repo/docs/core-concepts/remote-caching#self-hosting"
+        },
+        "loginUrl": {
+          "type": "string",
+          "description": "Set endpoint for requesting tokens during `turbo login`. Documentation: https://turbo.build/repo/docs/core-concepts/remote-caching#self-hosting"
+        },
+        "timeout": {
+          "type": "number",
+          "description": "Sets a timeout for remote cache operations. Value is given in seconds and only whole values are accepted. If `0` is passed, then there is no timeout for any cache operations."
         }
       },
       "additionalProperties": false

--- a/packages/turbo-types/schemas/schema.v2.json
+++ b/packages/turbo-types/schemas/schema.v2.json
@@ -171,6 +171,22 @@
         "enabled": {
           "type": "boolean",
           "description": "Indicates if the remote cache is enabled. When `false`, Turborepo will disable all remote cache operations, even if the repo has a valid token. If true, remote caching is enabled, but still requires the user to login and link their repo to a remote cache. Documentation: https://turbo.build/repo/docs/core-concepts/remote-caching"
+        },
+        "preflight": {
+          "type": "boolean",
+          "description": "When enabled, any HTTP request will be preceded by an OPTIONS request to determine if the request is supported by the endpoint.\n\nDocumentation: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#preflighted_requests"
+        },
+        "apiUrl": {
+          "type": "string",
+          "description": "Set endpoint for API calls to the remote cache. Documentation: https://turbo.build/repo/docs/core-concepts/remote-caching#self-hosting"
+        },
+        "loginUrl": {
+          "type": "string",
+          "description": "Set endpoint for requesting tokens during `turbo login`. Documentation: https://turbo.build/repo/docs/core-concepts/remote-caching#self-hosting"
+        },
+        "timeout": {
+          "type": "number",
+          "description": "Sets a timeout for remote cache operations. Value is given in seconds and only whole values are accepted. If `0` is passed, then there is no timeout for any cache operations."
         }
       },
       "additionalProperties": false

--- a/packages/turbo-types/src/types/config-v2.ts
+++ b/packages/turbo-types/src/types/config-v2.ts
@@ -304,6 +304,38 @@ export interface RemoteCache {
    * @defaultValue `true`
    */
   enabled?: boolean;
+
+  /**
+   * When enabled, any HTTP request will be preceded by an OPTIONS request to
+   * determine if the request is supported by the endpoint.
+   *
+   * Documentation: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#preflighted_requests
+   *
+   * @defaultValue `false`
+   */
+  preflight?: boolean;
+  /**
+   * Set endpoint for API calls to the remote cache.
+   * Documentation: https://turbo.build/repo/docs/core-concepts/remote-caching#self-hosting
+   *
+   * @defaultValue `"https://vercel.com/api"`
+   */
+  apiUrl?: string;
+  /**
+   * Set endpoint for requesting tokens during `turbo login`.
+   * Documentation: https://turbo.build/repo/docs/core-concepts/remote-caching#self-hosting
+   *
+   * @defaultValue `"https://vercel.com"`
+   */
+  loginUrl?: string;
+  /**
+   * Sets a timeout for remote cache operations. Value is given in seconds and
+   * only whole values are accepted. If `0` is passed, then there is no timeout
+   * for any cache operations.
+   *
+   * @defaultValue `30`
+   */
+  timeout?: number;
 }
 
 export const isRootSchemaV2 = (schema: Schema): schema is RootSchema =>


### PR DESCRIPTION
### Description

There has been an undocumented `remoteCache` field in `turbo.json` for quite awhile (at least since 1.10). This PR adds documentation for the it.

### Testing Instructions

Added unit tests to verify that when these are set in `turbo.json` they are respected in the built config.