### PR TITLE
feat: implementing persistence with sqlite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -191,7 +191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
 dependencies = [
  "concurrent-queue",
- "event-listener",
+ "event-listener 2.5.3",
  "futures-core",
 ]
 
@@ -254,7 +254,7 @@ dependencies = [
  "serde_urlencoded",
  "static_assertions_next",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -288,8 +288,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strum",
- "syn 2.0.58",
- "thiserror",
+ "syn 2.0.87",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -342,7 +342,7 @@ version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
 dependencies = [
- "event-listener",
+ "event-listener 2.5.3",
 ]
 
 [[package]]
@@ -371,7 +371,7 @@ dependencies = [
  "autocfg",
  "blocking",
  "cfg-if",
- "event-listener",
+ "event-listener 2.5.3",
  "futures-lite",
  "libc",
  "signal-hook",
@@ -424,7 +424,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -441,7 +441,16 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -469,7 +478,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -656,6 +665,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "better_scoped_tls"
@@ -952,6 +967,9 @@ name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "block-buffer"
@@ -993,7 +1011,7 @@ checksum = "efeab2975f8102de445dcf898856a638332403c50216144653a89aec22fd79e0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1205,7 +1223,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1299,6 +1317,12 @@ dependencies = [
  "unicode-width",
  "windows-sys 0.45.0",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-random"
@@ -1396,6 +1420,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1444,6 +1483,15 @@ dependencies = [
  "crossbeam-utils",
  "memoffset 0.9.0",
  "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1517,7 +1565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd4056f63fce3b82d852c3da92b08ea59959890813a7f4ce9c0ff85b10cf301b"
 dependencies = [
  "quote",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1582,7 +1630,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1593,7 +1641,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1639,6 +1687,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1669,7 +1728,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1682,7 +1741,7 @@ dependencies = [
  "fuzzy-matcher",
  "shell-words",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.63",
  "zeroize",
 ]
 
@@ -1705,6 +1764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -1787,6 +1847,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1815,6 +1881,9 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "embedded-io"
@@ -1885,10 +1954,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b"
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fast_chemail"
@@ -1921,7 +2012,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7199d965852c3bac31f779ef99cbb4537f80e952e2d6aa0ffeb30cce00f4f46e"
 dependencies = [
  "libc",
- "thiserror",
+ "thiserror 1.0.63",
  "winapi",
 ]
 
@@ -1966,10 +2057,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "foreign-types"
@@ -2003,7 +2111,7 @@ checksum = "32016f1242eb82af5474752d00fd8ebcd9004bd69b462b1c91de833972d08ed4"
 dependencies = [
  "proc-macro2",
  "swc_macros_common",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2064,6 +2172,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2092,7 +2211,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2199,7 +2318,7 @@ dependencies = [
  "regex",
  "tempfile",
  "test-case",
- "thiserror",
+ "thiserror 1.0.63",
  "tracing",
  "turbopath",
  "walkdir",
@@ -2216,7 +2335,7 @@ dependencies = [
  "notify",
  "stop-token",
  "test-case",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2293,7 +2412,7 @@ dependencies = [
  "pest_derive",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -2310,6 +2429,26 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -2346,12 +2485,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2787,7 +2944,7 @@ dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2808,7 +2965,7 @@ dependencies = [
  "curl",
  "curl-sys",
  "encoding_rs",
- "event-listener",
+ "event-listener 2.5.3",
  "futures-lite",
  "http 0.2.11",
  "log",
@@ -2876,7 +3033,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror",
+ "thiserror 1.0.63",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -2980,6 +3137,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin 0.5.2",
+]
 
 [[package]]
 name = "levenshtein"
@@ -3029,6 +3189,17 @@ checksum = "959c25552127d2e1fa72f0e52548ec04fc386e827ba71a7bd01db46a447dc135"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3133,6 +3304,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3231,7 +3412,7 @@ dependencies = [
  "supports-unicode",
  "terminal_size 0.4.1",
  "textwrap",
- "thiserror",
+ "thiserror 1.0.63",
  "unicode-width",
 ]
 
@@ -3243,7 +3424,7 @@ checksum = "bf45bf44ab49be92fd1227a3be6fc6f617f1a337c06af54981048574d8783147"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3325,7 +3506,7 @@ dependencies = [
  "httparse",
  "memchr",
  "mime",
- "spin",
+ "spin 0.9.8",
  "version_check",
 ]
 
@@ -3366,7 +3547,7 @@ dependencies = [
  "napi-derive-backend",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3381,7 +3562,7 @@ dependencies = [
  "quote",
  "regex",
  "semver 1.0.23",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3482,7 +3663,7 @@ dependencies = [
  "miette",
  "nom",
  "serde",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -3545,6 +3726,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3560,12 +3758,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3723,7 +3933,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simdutf8",
- "thiserror",
+ "thiserror 1.0.63",
  "tracing",
 ]
 
@@ -3743,7 +3953,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simdutf8",
- "thiserror",
+ "thiserror 1.0.63",
  "tracing",
 ]
 
@@ -3811,6 +4021,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3823,7 +4042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 1.0.63",
  "ucd-trie",
 ]
 
@@ -3847,7 +4066,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3901,7 +4120,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3921,7 +4140,7 @@ dependencies = [
  "log",
  "rand",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.63",
  "windows-sys 0.45.0",
 ]
 
@@ -3942,7 +4161,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3962,6 +4181,27 @@ name = "pipe-trait"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1be1ec9e59f0360aefe84efa6f699198b685ab0d5718081e9f72aa2344289e2"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -4054,7 +4294,7 @@ dependencies = [
  "smallvec",
  "symbolic-demangle",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -4218,7 +4458,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4283,7 +4523,7 @@ dependencies = [
  "rustc-hash 2.0.0",
  "rustls",
  "socket2 0.5.6",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "tracing",
 ]
@@ -4300,7 +4540,7 @@ dependencies = [
  "rustc-hash 2.0.0",
  "rustls",
  "slab",
- "thiserror",
+ "thiserror 1.0.63",
  "tinyvec",
  "tracing",
 ]
@@ -4432,6 +4672,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
+dependencies = [
+ "bitflags 2.5.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4439,7 +4688,7 @@ checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
  "redox_syscall 0.2.16",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -4544,9 +4793,29 @@ dependencies = [
  "cc",
  "getrandom",
  "libc",
- "spin",
+ "spin 0.9.8",
  "untrusted",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c75d7c5c6b673e58bf54d8544a9f432e3a925b0e80f7cd3602ab5c50c55519"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -4823,7 +5092,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4877,7 +5146,7 @@ checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5050,6 +5319,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5096,6 +5375,9 @@ name = "smallvec"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smartstring"
@@ -5130,9 +5412,219 @@ dependencies = [
 
 [[package]]
 name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4410e73b3c0d8442c5f99b425d7a435b5ee0ae4167b3196771dd3f7a01be745f"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a007b6936676aa9ab40207cde35daab0a04b823be8ae004368c0793b96a61e0"
+dependencies = [
+ "bytes",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener 5.4.0",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.2",
+ "hashlink",
+ "indexmap 2.2.6",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror 2.0.11",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3112e2ad78643fef903618d78cf0aec1cb3134b019730edb039b69eaf531f310"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e9f90acc5ab146a99bf5061a7eb4976b573f560bc898ef3bf8435448dd5e7ad"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck 0.5.0",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 2.0.87",
+ "tempfile",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4560278f0e00ce64938540546f59f590d60beee33fffbd3b9cd47851e5fff233"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.5.0",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.11",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b98a57f363ed6764d5b3a12bfedf62f07aa16e1856a7ddc2a0bb190a959613"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.5.0",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.11",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f85ca71d3a5b24e64e1d08dd8fe36c6c95c339a896cc33068148906784620540"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "tracing",
+ "url",
+]
 
 [[package]]
 name = "stability"
@@ -5202,7 +5694,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.58",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -5231,7 +5734,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "struct_iterable_internal",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5259,7 +5762,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5418,7 +5921,7 @@ checksum = "63db0adcff29d220c3d151c5b25c0eabe7e32dd936212b84cdaa1392e3130497"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5429,7 +5932,7 @@ checksum = "f486687bfb7b5c560868f69ed2d458b880cebc9babebcb67e49f31b55c5bf847"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5478,9 +5981,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5661,7 +6164,16 @@ version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.63",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -5672,7 +6184,18 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5785,7 +6308,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6025,7 +6548,7 @@ checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6076,7 +6599,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6201,7 +6724,7 @@ dependencies = [
  "log",
  "rand",
  "sha1",
- "thiserror",
+ "thiserror 1.0.63",
  "url",
  "utf-8",
 ]
@@ -6239,7 +6762,7 @@ dependencies = [
  "swc_ecma_ast",
  "swc_ecma_parser",
  "swc_ecma_visit",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -6255,7 +6778,7 @@ dependencies = [
  "reqwest",
  "semver 1.0.23",
  "serde",
- "thiserror",
+ "thiserror 1.0.63",
  "update-informer",
 ]
 
@@ -6277,7 +6800,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "test-case",
- "thiserror",
+ "thiserror 1.0.63",
  "turborepo-unescape",
  "wax",
 ]
@@ -6287,7 +6810,7 @@ name = "turborepo-analytics"
 version = "0.1.0"
 dependencies = [
  "futures",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "tracing",
  "turborepo-api-client",
@@ -6300,6 +6823,7 @@ name = "turborepo-api-client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-graphql",
  "bytes",
  "chrono",
  "http 1.1.0",
@@ -6313,7 +6837,7 @@ dependencies = [
  "serde",
  "serde_json",
  "test-case",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -6343,7 +6867,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "tracing",
  "turbopath",
@@ -6381,7 +6905,7 @@ dependencies = [
  "tar",
  "tempfile",
  "test-case",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -6404,11 +6928,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "turborepo-db"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-graphql",
+ "camino",
+ "chrono",
+ "dotenvy",
+ "serde_json",
+ "sqlx",
+ "tempfile",
+ "thiserror 1.0.63",
+ "tokio",
+ "turbopath",
+ "turborepo-api-client",
+ "uuid",
+]
+
+[[package]]
 name = "turborepo-dirs"
 version = "0.1.0"
 dependencies = [
  "dirs-next",
- "thiserror",
+ "thiserror 1.0.63",
  "turbopath",
 ]
 
@@ -6421,7 +6964,7 @@ dependencies = [
  "serde",
  "sha2",
  "test-case",
- "thiserror",
+ "thiserror 1.0.63",
  "turborepo-ci",
  "turborepo-ui",
 ]
@@ -6437,7 +6980,7 @@ dependencies = [
  "serde",
  "serde_json",
  "test-case",
- "thiserror",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -6455,7 +6998,7 @@ dependencies = [
  "num_cpus",
  "radix_trie",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "tokio-scoped",
  "tracing",
@@ -6475,7 +7018,7 @@ dependencies = [
  "ignore",
  "tempfile",
  "test-case",
- "thiserror",
+ "thiserror 1.0.63",
  "turbopath",
 ]
 
@@ -6489,7 +7032,7 @@ dependencies = [
  "itertools 0.10.5",
  "log",
  "petgraph",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "tracing",
 ]
@@ -6580,7 +7123,7 @@ dependencies = [
  "tabwriter",
  "tempfile",
  "test-case",
- "thiserror",
+ "thiserror 1.0.63",
  "time",
  "tiny-gradient",
  "tokio",
@@ -6603,6 +7146,7 @@ dependencies = [
  "turborepo-auth",
  "turborepo-cache",
  "turborepo-ci",
+ "turborepo-db",
  "turborepo-dirs",
  "turborepo-env",
  "turborepo-errors",
@@ -6620,6 +7164,7 @@ dependencies = [
  "turborepo-vercel-api-mock",
  "twox-hash",
  "uds_windows",
+ "uuid",
  "wax",
  "webbrowser",
  "which",
@@ -6645,7 +7190,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "test-case",
- "thiserror",
+ "thiserror 1.0.63",
  "tracing",
  "turbopath",
  "turborepo-errors",
@@ -6684,7 +7229,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "test-case",
- "thiserror",
+ "thiserror 1.0.63",
  "turbopath",
  "turborepo-errors",
 ]
@@ -6697,7 +7242,7 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "pretty_assertions",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "turbopath",
  "turborepo-repository",
@@ -6728,7 +7273,7 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "test-case",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -6756,7 +7301,7 @@ dependencies = [
  "sha1",
  "tempfile",
  "test-case",
- "thiserror",
+ "thiserror 1.0.63",
  "tracing",
  "turbopath",
  "turborepo-ci",
@@ -6780,7 +7325,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "test-case",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "tracing",
  "turbopath",
@@ -6822,7 +7367,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "test-case",
- "thiserror",
+ "thiserror 1.0.63",
  "tokio",
  "tracing",
  "tui-term",
@@ -7015,6 +7560,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-properties"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7196,6 +7747,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7216,7 +7773,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
@@ -7250,7 +7807,7 @@ checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7289,7 +7846,7 @@ dependencies = [
  "regex",
  "tardar",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.63",
  "walkdir",
 ]
 
@@ -7338,6 +7895,16 @@ dependencies = [
  "either",
  "libc",
  "once_cell",
+]
+
+[[package]]
+name = "whoami"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
+dependencies = [
+ "redox_syscall 0.5.9",
+ "wasite",
 ]
 
 [[package]]
@@ -7691,7 +8258,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.87",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,7 @@ tracing-subscriber = "0.3.16"
 tui-term = { version = "=0.1.9", default-features = false }
 url = "2.2.2"
 urlencoding = "2.1.2"
+uuid = { version = "1.5.0", features = ["v4"] }
 webbrowser = "0.8.7"
 which = "4.4.0"
 unicode-segmentation = "1.10.1"

--- a/crates/turborepo-analytics/Cargo.toml
+++ b/crates/turborepo-analytics/Cargo.toml
@@ -16,4 +16,4 @@ tokio = { workspace = true, features = ["full", "time"] }
 tracing = { workspace = true }
 turborepo-api-client = { workspace = true }
 turborepo-vercel-api = { workspace = true }
-uuid = { version = "1.5.0", features = ["v4"] }
+uuid = { workspace = true, features = ["v4"] }

--- a/crates/turborepo-api-client/Cargo.toml
+++ b/crates/turborepo-api-client/Cargo.toml
@@ -22,6 +22,7 @@ turborepo-vercel-api-mock = { workspace = true }
 workspace = true
 
 [dependencies]
+async-graphql = { workspace = true }
 bytes.workspace = true
 chrono = { workspace = true, features = ["serde"] }
 lazy_static = { workspace = true }

--- a/crates/turborepo-db/Cargo.toml
+++ b/crates/turborepo-db/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "turborepo-db"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+async-graphql = "7.0.7"
+camino = { workspace = true }
+chrono = { workspace = true }
+serde_json = { workspace = true }
+sqlx = { version = "0.8.3", features = ["runtime-tokio", "sqlite", "chrono"] }
+tempfile = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+turbopath = { workspace = true }
+turborepo-api-client = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
+
+[dev-dependencies]
+anyhow = { workspace = true }
+
+[build-dependencies]
+dotenvy = "0.15.7"
+
+[lints]
+workspace = true

--- a/crates/turborepo-db/migrations/20240828183512_initial_tables.sql
+++ b/crates/turborepo-db/migrations/20240828183512_initial_tables.sql
@@ -1,0 +1,57 @@
+CREATE TABLE IF NOT EXISTS runs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    start_time TEXT NOT NULL,
+    end_time TEXT,
+    exit_code INTEGER,
+    command TEXT NOT NULL,
+    package_inference_root TEXT,
+    git_branch TEXT,
+    git_sha TEXT,
+    turbo_version TEXT NOT NULL,
+    full_turbo BOOLEAN
+);
+
+CREATE TABLE IF NOT EXISTS config (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    api_url TEXT NOT NULL,
+    login_url TEXT NOT NULL,
+    team_slug TEXT NOT NULL,
+    team_id TEXT NOT NULL,
+    signature BOOLEAN NOT NULL,
+    preflight BOOLEAN NOT NULL,
+    timeout INTEGER NOT NULL,
+    upload_timeout INTEGER NOT NULL,
+    enabled BOOLEAN NOT NULL,
+    spaces_id TEXT NOT NULL,
+    global_dependencies TEXT NOT NULL,
+    global_env TEXT NOT NULL,
+    global_pass_through_env TEXT NOT NULL,
+    tasks TEXT NOT NULL,
+    cache_dir TEXT NOT NULL,
+    root_turbo_json TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS packages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    path TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS package_dependencies (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    dependent_id INTEGER NOT NULL,
+    dependency_id INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS tasks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    hash TEXT NOT NULL,
+    package_id INTEGER NOT NULL,
+    start_time TEXT NOT NULL,
+    end_time TEXT,
+    cache_status TEXT,
+    exit_code INTEGER,
+    logs TEXT
+);

--- a/crates/turborepo-db/migrations/20240906152408_create_graph_tables.sql
+++ b/crates/turborepo-db/migrations/20240906152408_create_graph_tables.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS package_relations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    dependent_package_id INTEGER NOT NULL,
+    dependency_package_id INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS task_relations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    dependent_task_id INTEGER NOT NULL,
+    dependency_task_id INTEGER NOT NULL
+);

--- a/crates/turborepo-db/src/lib.rs
+++ b/crates/turborepo-db/src/lib.rs
@@ -1,0 +1,399 @@
+#![feature(assert_matches)]
+
+use camino::Utf8Path;
+use chrono::{DateTime, Utc};
+use sqlx::{sqlite::SqliteRow, Pool, Row, Sqlite, SqlitePool};
+use thiserror::Error;
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::Error),
+    #[error("failed to migrate database: {0}")]
+    Migrate(#[from] sqlx::migrate::MigrateError),
+    #[error("failed to serialize")]
+    Serialize(#[from] serde_json::Error),
+    #[error("invalid cache status: {status}")]
+    InvalidCacheStatus { status: String },
+}
+
+#[derive(Debug, Default)]
+pub struct Run {
+    id: u32,
+    start_time: DateTime<Utc>,
+    end_time: Option<DateTime<Utc>>,
+    exit_code: Option<u32>,
+    command: String,
+    package_inference_root: Option<String>,
+    git_branch: Option<String>,
+    git_sha: Option<String>,
+    turbo_version: String,
+    full_turbo: Option<bool>,
+}
+
+#[derive(Debug, Default)]
+pub struct StartRunPayload {
+    start_time: DateTime<Utc>,
+    command: String,
+    package_inference_root: Option<String>,
+    git_branch: Option<String>,
+    git_sha: Option<String>,
+    turbo_version: String,
+}
+
+pub struct FinishRunPayload {
+    end_time: DateTime<Utc>,
+    exit_code: i32,
+    full_turbo: bool,
+}
+
+pub struct Task {
+    id: u32,
+    run_id: u32,
+    name: String,
+    hash: String,
+    package: String,
+    start_time: DateTime<Utc>,
+    end_time: Option<DateTime<Utc>>,
+    cache_status: Option<CacheStatus>,
+    exit_code: Option<i32>,
+    output: Option<String>,
+}
+
+pub struct StartTaskPayload {
+    run_id: u32,
+    name: String,
+    hash: String,
+    package: String,
+    package_path: AnchoredSystemPathBuf,
+    start_time: DateTime<Utc>,
+}
+
+pub struct FinishTaskPayload {
+    end_time: DateTime<Utc>,
+    cache_status: CacheStatus,
+    exit_code: i32,
+    logs: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CacheStatus {
+    Miss,
+    Hit,
+}
+
+impl AsRef<str> for CacheStatus {
+    fn as_ref(&self) -> &str {
+        match self {
+            CacheStatus::Miss => "MISS",
+            CacheStatus::Hit => "HIT",
+        }
+    }
+}
+
+enum RunStatus {
+    Running,
+    Completed,
+}
+
+impl AsRef<str> for RunStatus {
+    fn as_ref(&self) -> &str {
+        match self {
+            RunStatus::Running => "RUNNING",
+            RunStatus::Completed => "COMPLETED",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DatabaseHandle {
+    pool: Pool<Sqlite>,
+}
+
+impl DatabaseHandle {
+    pub async fn new(cache_dir: &Utf8Path, repo_root: &AbsoluteSystemPath) -> Result<Self, Error> {
+        let cache_dir = AbsoluteSystemPathBuf::from_unknown(&repo_root, &cache_dir);
+        let pool = SqlitePool::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            cache_dir.join_component("turbo.db")
+        ))
+        .await?;
+
+        sqlx::migrate!().run(&pool).await?;
+
+        Ok(Self { pool })
+    }
+
+    pub async fn get_run(&self, id: u32) -> Result<Option<Run>, Error> {
+        let query = sqlx::query(
+            "SELECT id, start_time, end_time, exit_code, command, package_inference_root, \
+             git_branch, git_sha, turbo_version, full_turbo FROM runs WHERE id = $1",
+        )
+        .bind(id);
+
+        Ok(query
+            .map(|row| Run {
+                id: row.get("id"),
+                start_time: row.get("start_time"),
+                end_time: row.get("end_time"),
+                exit_code: row.get("exit_code"),
+                command: row.get("command"),
+                package_inference_root: row.get("package_inference_root"),
+                git_branch: row.get("git_branch"),
+                git_sha: row.get("git_sha"),
+                turbo_version: row.get("turbo_version"),
+                full_turbo: row.get("full_turbo"),
+            })
+            .fetch_optional(&self.pool)
+            .await?)
+    }
+
+    pub async fn get_runs(&self, limit: Option<u32>) -> Result<Vec<Run>, Error> {
+        let query = if let Some(limit) = limit {
+            sqlx::query(
+                "SELECT id, start_time, end_time, exit_code, command, package_inference_root, \
+                 git_branch, git_sha, turbo_version, full_turbo FROM runs LIMIT ?",
+            )
+            .bind(limit)
+        } else {
+            sqlx::query(
+                "SELECT id, start_time, end_time, exit_code, command, package_inference_root, \
+                 git_branch, git_sha, turbo_version, full_turbo FROM runs",
+            )
+        };
+
+        Ok(query
+            .map(|row| Run {
+                id: row.get("id"),
+                start_time: row.get("start_time"),
+                end_time: row.get("end_time"),
+                exit_code: row.get("exit_code"),
+                command: row.get("command"),
+                package_inference_root: row.get("package_inference_root"),
+                git_branch: row.get("git_branch"),
+                git_sha: row.get("git_sha"),
+                turbo_version: row.get("turbo_version"),
+                full_turbo: row.get("full_turbo"),
+            })
+            .fetch_all(&self.pool)
+            .await?)
+    }
+
+    pub async fn get_tasks_for_run(&self, run_id: u32) -> Result<Vec<Task>, Error> {
+        let query = sqlx::query(
+            "SELECT tasks.id, tasks.name AS task_name, packages.name AS package_name, hash, \
+             start_time, end_time, cache_status, exit_code, logs FROM tasks JOIN packages ON \
+             tasks.package_id = packages.id WHERE run_id = $1",
+        )
+        .bind(run_id);
+
+        Ok(query
+            .try_map(|row: SqliteRow| {
+                Ok(Task {
+                    id: row.get("id"),
+                    run_id,
+                    name: row.get("task_name"),
+                    package: row.get("package_name"),
+                    hash: row.get("hash"),
+                    start_time: row.get("start_time"),
+                    end_time: row.get("end_time"),
+                    cache_status: match row.get("cache_status") {
+                        Some("MISS") => Some(CacheStatus::Miss),
+                        Some("HIT") => Some(CacheStatus::Hit),
+                        Some(status) => {
+                            return Err(sqlx::Error::Decode(Box::new(Error::InvalidCacheStatus {
+                                status: status.to_string(),
+                            })))
+                        }
+                        None => None,
+                    },
+                    exit_code: row.get("exit_code"),
+                    output: None,
+                })
+            })
+            .fetch_all(&self.pool)
+            .await?)
+    }
+
+    pub async fn start_task(&self, task: &StartTaskPayload) -> Result<u32, Error> {
+        let package_row = sqlx::query("SELECT id FROM packages WHERE name = $1")
+            .bind(&task.package)
+            .fetch_optional(&self.pool)
+            .await?;
+
+        let package_id: u32 = if let Some(package_row) = package_row {
+            package_row.get("id")
+        } else {
+            sqlx::query("INSERT INTO packages (name, path) VALUES ($1, $2) RETURNING id")
+                .bind(&task.package)
+                .bind(task.package_path.as_str())
+                .fetch_one(&self.pool)
+                .await?
+                .get("id")
+        };
+
+        let row = sqlx::query(
+            "INSERT INTO tasks (
+              run_id,
+              name,
+              package_id,
+              hash,
+              start_time
+            ) VALUES ($1, $2, $3, $4, $5) RETURNING id",
+        )
+        .bind(task.run_id)
+        .bind(&task.name)
+        .bind(package_id)
+        .bind(&task.hash)
+        .bind(&task.start_time)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row.get("id"))
+    }
+
+    pub async fn start_run(&self, run: &StartRunPayload) -> Result<u32, Error> {
+        let row = sqlx::query(
+            "INSERT INTO runs (
+              start_time,
+              command,
+              package_inference_root,
+              git_branch,
+              git_sha,
+              turbo_version
+             ) VALUES ($1, $2, $3, $4, $5, $6) RETURNING id",
+        )
+        .bind(&run.start_time)
+        .bind(&run.command)
+        .bind(&run.package_inference_root)
+        .bind(&run.git_branch)
+        .bind(&run.git_sha)
+        .bind(&run.turbo_version)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row.get("id"))
+    }
+
+    pub async fn finish_run(&self, id: u32, payload: &FinishRunPayload) -> Result<(), Error> {
+        sqlx::query("UPDATE runs SET end_time = $1, exit_code = $2, full_turbo = $3 WHERE id = $4")
+            .bind(&payload.end_time)
+            .bind(&payload.exit_code)
+            .bind(&payload.full_turbo)
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn finish_task(&self, id: u32, payload: &FinishTaskPayload) -> Result<(), Error> {
+        sqlx::query(
+            "UPDATE tasks SET
+              end_time = $1,
+              cache_status = $2,
+              exit_code = $3,
+              logs = $4
+            WHERE id = $5",
+        )
+        .bind(payload.end_time)
+        .bind(&payload.cache_status.as_ref())
+        .bind(payload.exit_code)
+        .bind(&payload.logs)
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::assert_matches::assert_matches;
+
+    use chrono::Utc;
+    use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf};
+
+    use crate::{
+        CacheStatus, DatabaseHandle, FinishRunPayload, FinishTaskPayload, StartRunPayload,
+        StartTaskPayload,
+    };
+
+    #[tokio::test]
+    async fn test_persistence() -> Result<(), anyhow::Error> {
+        let dir = tempfile::tempdir().unwrap();
+
+        let db = DatabaseHandle::new(
+            dir.path().try_into()?,
+            AbsoluteSystemPath::from_std_path(dir.path())?,
+        )
+        .await?;
+
+        let run_id = db
+            .start_run(&StartRunPayload {
+                start_time: Utc::now(),
+                command: "test".to_string(),
+                package_inference_root: Some("foo/bar".to_string()),
+                git_branch: None,
+                git_sha: Some("my-sha".to_string()),
+                turbo_version: "".to_string(),
+            })
+            .await?;
+
+        let runs = db.get_runs(None).await?;
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].git_sha, Some("my-sha".to_string()));
+        assert_eq!(runs[0].package_inference_root, Some("foo/bar".to_string()));
+        assert_eq!(runs[0].end_time, None);
+
+        db.start_task(&StartTaskPayload {
+            run_id,
+            name: "test".to_string(),
+            package: "test".to_string(),
+            package_path: AnchoredSystemPathBuf::from_raw("packages/test")?,
+            hash: "test".to_string(),
+            start_time: Utc::now(),
+        })
+        .await?;
+
+        let tasks = db.get_tasks_for_run(run_id).await?;
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].name, "test");
+
+        db.finish_task(
+            tasks[0].id,
+            &FinishTaskPayload {
+                end_time: Utc::now(),
+                cache_status: CacheStatus::Hit,
+                exit_code: 0,
+                logs: "test".to_string(),
+            },
+        )
+        .await?;
+
+        let tasks = db.get_tasks_for_run(run_id).await?;
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].name, "test");
+        assert_matches!(tasks[0].cache_status, Some(CacheStatus::Hit));
+        assert_eq!(tasks[0].exit_code, Some(0));
+
+        db.finish_run(
+            run_id,
+            &FinishRunPayload {
+                end_time: Utc::now(),
+                exit_code: 0,
+                full_turbo: true,
+            },
+        )
+        .await?;
+
+        let run = db.get_run(run_id).await?.unwrap();
+        assert!(run.end_time.is_some());
+        assert_eq!(run.exit_code, Some(0));
+        assert!(run.full_turbo.unwrap());
+
+        Ok(())
+    }
+}

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -129,6 +129,7 @@ turborepo-api-client = { workspace = true }
 turborepo-auth = { path = "../turborepo-auth" }
 turborepo-cache = { workspace = true }
 turborepo-ci = { workspace = true }
+turborepo-db = { path = "../turborepo-db" }
 turborepo-dirs = { path = "../turborepo-dirs" }
 turborepo-env = { workspace = true }
 turborepo-errors = { workspace = true }
@@ -145,6 +146,7 @@ turborepo-unescape = { workspace = true }
 turborepo-vercel-api = { path = "../turborepo-vercel-api" }
 twox-hash = "1.6.3"
 uds_windows = "1.0.2"
+uuid = { version = "1.5.0", features = ["v4"] }
 wax = { workspace = true }
 webbrowser = { workspace = true }
 which = { workspace = true }

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -449,7 +449,9 @@ impl Run {
             self.version,
             Vendor::get_user(),
             &self.scm,
-        );
+            &self.opts.cache_opts.cache_dir,
+        )
+        .await;
 
         let mut visitor = Visitor::new(
             self.pkg_dep_graph.clone(),

--- a/crates/turborepo-telemetry/Cargo.toml
+++ b/crates/turborepo-telemetry/Cargo.toml
@@ -35,4 +35,4 @@ turborepo-dirs = { path = "../turborepo-dirs" }
 turborepo-ui = { workspace = true }
 turborepo-vercel-api = { workspace = true }
 url = { workspace = true }
-uuid = { version = "1.5.0", features = ["v4"] }
+uuid = { workspace = true, features = ["v4"] }

--- a/turborepo-tests/integration/fixtures/boundaries/apps/my-app/tsconfig.json
+++ b/turborepo-tests/integration/fixtures/boundaries/apps/my-app/tsconfig.json
@@ -4,7 +4,9 @@
       "@/*": [
         "./*"
       ],
-      "!": ["../../packages/another/index.jsx"]
+      "!": [
+        "../../packages/another/index.jsx"
+      ]
     }
   }
 }


### PR DESCRIPTION
### Description

First pass at a persistence layer for runs using sqlite. Saves to the cache directory a database called `turbo.db`. We use the spaces code since those are convenient hooks into turbo's lifecycle, but we can decouple if necessary.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
