### PR TITLE
fix(zsh): fix completion generation for zsh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.2"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
@@ -1055,9 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.2"
+version = "4.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
+checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1065,9 +1065,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1077,20 +1077,20 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.1"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "885e4d7d5af40bfb99ae6f9433e292feac98d452dcb3ec3d25dfe7552b77da8c"
+checksum = "6d7db6eca8c205649e8d3ccd05aa5042b1800a784e56bc7c43524fde8abbfa9b"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.0"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,8 +111,8 @@ biome_json_syntax = { version = "0.5.7" }
 bytes = "1.1.0"
 camino = { version = "1.1.4", features = ["serde1"] }
 chrono = "0.4.23"
-clap = "4.5.2"
-clap_complete = "4.5.1"
+clap = "4.5.16"
+clap_complete = "4.5.24"
 concurrent-queue = "2.5.0"
 console = "0.15.5"
 console-subscriber = "0.1.8"

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -851,7 +851,7 @@ pub struct RunArgs {
     // -----------------------
     /// Force turbo to either use or not use the local daemon. If unset
     /// turbo will use the default detection logic.
-    #[clap(long = "[no-]daemon", alias = "daemon", group = "daemon-group")]
+    #[clap(long = "(no-)daemon", alias = "daemon", group = "daemon-group")]
     pub daemon: bool,
 
     #[clap(long, group = "daemon-group", hide = true)]

--- a/turborepo-tests/integration/tests/conflicting-flags.t
+++ b/turborepo-tests/integration/tests/conflicting-flags.t
@@ -1,9 +1,9 @@
 Setup
   $ . ${TESTDIR}/../../helpers/setup_integration_test.sh
   $ ${TURBO} run build --daemon --no-daemon
-   ERROR  the argument '--\[no-\]daemon' cannot be used with '--no-daemon' (re)
+   ERROR  the argument '--\(no-\)daemon' cannot be used with '--no-daemon' (re)
   
-  Usage: turbo(\.exe)? run --\[no-\]daemon (re)
+  Usage: turbo(\.exe)? run --\(no-\)daemon (re)
   
   For more information, try '--help'.
   

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -70,7 +70,7 @@ Make sure exit code is 2 when no args are passed
             Generate a graph of the task execution and output to a file when a filename is specified (.svg, .png, .jpg, .pdf, .json, .html, .mermaid, .dot). Outputs dot graph to stdout when if no filename is provided
         --no-cache
             Avoid saving task results to the cache. Useful for development/watch tasks
-        --[no-]daemon
+        --(no-)daemon
             Force turbo to either use or not use the local daemon. If unset turbo will use the default detection logic
         --profile <PROFILE>
             File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow

--- a/turborepo-tests/integration/tests/turbo-help.t
+++ b/turborepo-tests/integration/tests/turbo-help.t
@@ -70,7 +70,7 @@ Test help flag
             Generate a graph of the task execution and output to a file when a filename is specified (.svg, .png, .jpg, .pdf, .json, .html, .mermaid, .dot). Outputs dot graph to stdout when if no filename is provided
         --no-cache
             Avoid saving task results to the cache. Useful for development/watch tasks
-        --[no-]daemon
+        --(no-)daemon
             Force turbo to either use or not use the local daemon. If unset turbo will use the default detection logic
         --profile <PROFILE>
             File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
@@ -215,7 +215,7 @@ Test help flag
         --no-cache
             Avoid saving task results to the cache. Useful for development/watch tasks
   
-        --[no-]daemon
+        --(no-)daemon
             Force turbo to either use or not use the local daemon. If unset turbo will use the default detection logic
   
         --profile <PROFILE>


### PR DESCRIPTION
### Description

Fixes https://github.com/vercel/turborepo/issues/9080

Upgrade `clap` and completion generation to get https://github.com/clap-rs/clap/pull/5545

Also change the long flag name from `--[no-]daemon` to `--(no-)daemon` as `[]` are reserved chars for zsh autocompletes.

⚠️ This will break anyone who uses `--[no-]daemon` to enable the daemon.

### Testing Instructions

`turbo_dev completion zsh > ~/.zsh/completions/_turbo` (or where ever your completions are stored)
Open a new shell and enter `turbo -- <TAB> <TAB>`
```
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ turbo --
--__test-run                                 --no-daemon           --version                                                                                         
--experimental-space-id                      --pkg-inference-root  --dry-run  --                                                                                       
--affected                                                                    -- Run only tasks that are affected by changes between the current branch and `main`     
--anon-profile                                                                -- File to write turbo's performance profile output into. All identifying data omitted fr
--api                                                                         -- Override the endpoint for API calls                                                   
--cache-dir                                                                   -- Override the filesystem cache directory                                               
--cache-workers                                                               -- Set the number of concurrent cache operations (default 10)                            
--check-for-update                                                            -- Force a check for a new version of turbo                                              
--color                                                                       -- Force color usage in the terminal                                                     
--concurrency                                                                 -- Limit the concurrency of task execution. Use 1 for serial (i.e. one-at-a-time) executi
--continue                                                                    -- Continue execution even if a task exits with an error or non-zero exit code. The defau
--cwd                                                                         -- The directory in which to run turbo                                                   
--daemon                                                                      -- Force turbo to either use or not use the local daemon. If unset turbo will use the def
--dangerously-disable-package-manager-check                                   -- Allow for missing `packageManager` in `package.json`                                  
--env-mode                                                                    -- Environment variable mode. Use "loose" to pass the entire existing environment. Use "s
--filter                                                                      -- Use the given selector to specify package(s) to act as entry points. The syntax mirror
--force                                                                       -- Ignore the existing cache (to force execution)                                        
--framework-inference                                                         -- Specify whether or not to do framework inference for tasks                            
--global-deps                                                                 -- Specify glob of global filesystem dependencies to be hashed. Useful for .env and files
--graph                                                                       -- Generate a graph of the task execution and output to a file when a filename is specifi
--heap                                                                        -- Specify a file to save a pprof heap profile                                           
--help                                                                        -- Print help (see more with '--help')                                                   
--log-order                                                                   -- Set type of task output order. Use "stream" to show output as soon as it is available.
--log-prefix                                                                  -- Use "none" to remove prefixes from task logs. Use "task" to get task id prefixing. Use
--login                                                                       -- Override the login endpoint                                                           
--no-cache                                                                    -- Avoid saving task results to the cache. Useful for development/watch tasks            
--no-color                                                                    -- Suppress color usage in the terminal                                                  
--no-update-notifier                                                          -- Disable the turbo update notification                                                 
--only                                                                        -- Only executes the tasks specified, does not execute parent tasks                      
--output-logs                                                                 -- Set type of process output logging. Use "full" to show all output. Use "hash-only" to 
--parallel                                                                    -- Execute all tasks in parallel                                                         
--preflight                                                                   -- When enabled, turbo will precede HTTP requests with an OPTIONS request for authorizati
--profile                                                                     -- File to write turbo's performance profile output into. You can load the file up in chr
--remote-cache-read-only                                                      -- Treat remote cache as read only                                                       
--remote-cache-timeout                                                        -- Set a timeout for all HTTP requests                                                   
--remote-only                                                                 -- Ignore the local filesystem cache for all tasks. Only allow reading and caching artifa
--single-package                                                              -- Run turbo in single-package mode                                                      
--skip-infer                                                                  -- Skip any attempts to infer which version of Turbo the project is configured to use    
--summarize                                                                   -- Generate a summary of the turbo run                                                   
--team                                                                        -- Set the team slug for API calls                                                       
--token                                                                       -- Set the auth token for API calls                                                      
--trace                                                                       -- Specify a file to save a pprof trace                                                  
--ui                                                                          -- Specify whether to use the streaming UI or TUI                                        
--verbosity                                                                   -- Verbosity level
```