### PR TITLE
remove alias for --daemon/--no-daemon

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -846,15 +846,15 @@ pub struct RunArgs {
 
     // clap does not have negation flags such as --daemon and --no-daemon
     // so we need to use a group to enforce that only one of them is set.
-    // we set the long name as [no-]daemon with an alias of daemon such
-    // that we can merge the help text together for both flags
     // -----------------------
-    /// Force turbo to either use or not use the local daemon. If unset
+    /// Force turbo to use the local daemon. If unset
     /// turbo will use the default detection logic.
-    #[clap(long = "(no-)daemon", alias = "daemon", group = "daemon-group")]
+    #[clap(long, group = "daemon-group")]
     pub daemon: bool,
 
-    #[clap(long, group = "daemon-group", hide = true)]
+    /// Force turbo to not use the local daemon. If unset
+    /// turbo will use the default detection logic.
+    #[clap(long, group = "daemon-group")]
     pub no_daemon: bool,
 
     /// File to write turbo's performance profile output into.

--- a/turborepo-tests/integration/tests/conflicting-flags.t
+++ b/turborepo-tests/integration/tests/conflicting-flags.t
@@ -1,7 +1,7 @@
 Setup
   $ . ${TESTDIR}/../../helpers/setup_integration_test.sh
   $ ${TURBO} run build --daemon --no-daemon
-   ERROR  the argument '--daemon' cannot be used with '--no-daemon' (re)
+   ERROR  the argument '--daemon' cannot be used with '--no-daemon'
   
   Usage: turbo(\.exe)? run --daemon (re)
   

--- a/turborepo-tests/integration/tests/conflicting-flags.t
+++ b/turborepo-tests/integration/tests/conflicting-flags.t
@@ -1,9 +1,9 @@
 Setup
   $ . ${TESTDIR}/../../helpers/setup_integration_test.sh
   $ ${TURBO} run build --daemon --no-daemon
-   ERROR  the argument '--\(no-\)daemon' cannot be used with '--no-daemon' (re)
+   ERROR  the argument '--daemon' cannot be used with '--no-daemon' (re)
   
-  Usage: turbo(\.exe)? run --\(no-\)daemon (re)
+  Usage: turbo(\.exe)? run --daemon (re)
   
   For more information, try '--help'.
   

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -70,8 +70,10 @@ Make sure exit code is 2 when no args are passed
             Generate a graph of the task execution and output to a file when a filename is specified (.svg, .png, .jpg, .pdf, .json, .html, .mermaid, .dot). Outputs dot graph to stdout when if no filename is provided
         --no-cache
             Avoid saving task results to the cache. Useful for development/watch tasks
-        --(no-)daemon
-            Force turbo to either use or not use the local daemon. If unset turbo will use the default detection logic
+        --daemon
+            Force turbo to use the local daemon. If unset turbo will use the default detection logic
+        --no-daemon
+            Force turbo to not use the local daemon. If unset turbo will use the default detection logic
         --profile <PROFILE>
             File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
         --anon-profile <ANON_PROFILE>

--- a/turborepo-tests/integration/tests/turbo-help.t
+++ b/turborepo-tests/integration/tests/turbo-help.t
@@ -70,8 +70,10 @@ Test help flag
             Generate a graph of the task execution and output to a file when a filename is specified (.svg, .png, .jpg, .pdf, .json, .html, .mermaid, .dot). Outputs dot graph to stdout when if no filename is provided
         --no-cache
             Avoid saving task results to the cache. Useful for development/watch tasks
-        --(no-)daemon
-            Force turbo to either use or not use the local daemon. If unset turbo will use the default detection logic
+        --daemon
+            Force turbo to use the local daemon. If unset turbo will use the default detection logic
+        --no-daemon
+            Force turbo to not use the local daemon. If unset turbo will use the default detection logic
         --profile <PROFILE>
             File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow
         --anon-profile <ANON_PROFILE>
@@ -215,8 +217,11 @@ Test help flag
         --no-cache
             Avoid saving task results to the cache. Useful for development/watch tasks
   
-        --(no-)daemon
-            Force turbo to either use or not use the local daemon. If unset turbo will use the default detection logic
+        --daemon
+            Force turbo to use the local daemon. If unset turbo will use the default detection logic
+  
+        --no-daemon
+            Force turbo to not use the local daemon. If unset turbo will use the default detection logic
   
         --profile <PROFILE>
             File to write turbo's performance profile output into. You can load the file up in chrome://tracing to see which parts of your build were slow


### PR DESCRIPTION
### Description

in https://github.com/vercel/turborepo/pull/9082 we determined that it's best to move forward with just removing the alias for --no-daemon/--daemon.

### Testing Instructions

- follow instructions in https://github.com/vercel/turborepo/pull/9082 and observe that `--daemon` now works
- `turbo --help` shows lines for both values, `--daemon` and `--no-daemon`

