### PR TITLE
fix(daemon): use correct arg group for deciding daemon config

### DIFF
--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -88,7 +88,7 @@ impl CommandBase {
                     .dangerously_disable_package_manager_check
                     .then_some(true),
             )
-            .with_daemon(self.args.run_args.as_ref().and_then(|args| args.daemon()))
+            .with_daemon(self.args.run_args().and_then(|args| args.daemon()))
             .with_env_mode(
                 self.args
                     .command


### PR DESCRIPTION
### Description

https://github.com/vercel/turborepo/pull/8728 accidentally disconnected the `--no-daemon` and `--daemon` flags. The config was populated using `args.run_args` which is explicitly set to `None` for all `run` commands [here](https://github.com/vercel/turborepo/blob/main/crates/turborepo-lib/src/cli/mod.rs#L1044).

This resulted in the config never getting the flag values.

### Testing Instructions

Before
```
[0 olszewski@chriss-mbp] /tmp/turbo-bug $ turbo_dev run build --no-daemon -vv 2>&1 | rg turbod
2024-08-30T16:05:12.441-0400 [DEBUG] turborepo_lib::run::builder: skipping turbod since we appear to be in a non-interactive context
[0 olszewski@chriss-mbp] /tmp/turbo-bug $ turbo_dev run build --daemon -vv 2>&1 | rg turbod 
2024-08-30T16:05:23.639-0400 [DEBUG] turborepo_lib::run::builder: skipping turbod since we appear to be in a non-interactive context
```

After
```
[1 olszewski@chriss-mbp] /tmp/turbo-bug $ turbo_dev run build --no-daemon -vv 2>&1 | rg turbod 
2024-08-30T15:59:27.083-0400 [DEBUG] turborepo_lib::run::builder: skipping turbod since --no-daemon was passed
[0 olszewski@chriss-mbp] /tmp/turbo-bug $ turbo_dev run build --daemon -vv 2>&1 | rg turbod 
2024-08-30T15:59:34.093-0400 [DEBUG] turborepo_lib::daemon::connector: looking for pid in lockfile: AbsoluteSystemPathBuf("/var/folders/3m/rxkycvgs5jgfvs0k9xcgp6km0000gn/T/turbod/5e203d2ff6cb65bf/turbod.pid")
```
