### PR TITLE
feat: update Prisma schema

### DIFF
--- a/examples/with-prisma/packages/database/prisma/schema.prisma
+++ b/examples/with-prisma/packages/database/prisma/schema.prisma
@@ -4,12 +4,11 @@
 datasource db {
   provider = "mysql"
   url      = env("DATABASE_URL")
-  referentialIntegrity = "prisma"
+  relationMode = "prisma"
 }
 
 generator client {
   provider = "prisma-client-js"
-  previewFeatures = ["referentialIntegrity"]
 }
 
 model User {


### PR DESCRIPTION
### Description

`referentialIntegrity = "prisma"` is deprecated, the latest feature is `relationMode = "prisma"`.
Also since `"referentialIntegrity"` is deprecated, preview feature functionality can be used without specifying it.

### Testing Instructions

Didn't do any testing steps, i just saw this warning as i'm setting up my own monorepo and decided to update your example aswell. (should not mess anything up, based on https://pris.ly/d/relation-mode)
