### PR TITLE
fix(tui): start pty with matching TUI size

### DIFF
--- a/crates/turborepo-lib/src/process/mod.rs
+++ b/crates/turborepo-lib/src/process/mod.rs
@@ -39,6 +39,13 @@ pub struct ProcessManager {
 struct ProcessManagerInner {
     is_closing: bool,
     children: Vec<child::Child>,
+    size: Option<PtySize>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct PtySize {
+    rows: u16,
+    cols: u16,
 }
 
 impl ProcessManager {
@@ -48,6 +55,7 @@ impl ProcessManager {
             state: Arc::new(Mutex::new(ProcessManagerInner {
                 is_closing: false,
                 children: Vec::new(),
+                size: None,
             })),
             use_pty,
         }
@@ -99,10 +107,11 @@ impl ProcessManager {
             debug!("process manager closing");
             return None;
         }
+        let pty_size = self.use_pty.then(|| lock.pty_size()).flatten();
         let child = child::Child::spawn(
             command,
             child::ShutdownStyle::Graceful(stop_timeout),
-            self.use_pty,
+            pty_size,
         );
         if let Ok(child) = &child {
             lock.children.push(child.clone());
@@ -160,6 +169,33 @@ impl ProcessManager {
             // just allocate a new vec rather than clearing the old one
             lock.children = vec![];
         }
+    }
+
+    pub fn set_pty_size(&self, rows: u16, cols: u16) {
+        self.state.lock().expect("not poisoned").size = Some(PtySize { rows, cols });
+    }
+}
+
+impl ProcessManagerInner {
+    fn pty_size(&mut self) -> Option<PtySize> {
+        if self.size.is_none() {
+            self.size = PtySize::from_tty();
+        }
+        self.size
+    }
+}
+
+impl PtySize {
+    fn from_tty() -> Option<Self> {
+        console::Term::stdout()
+            .size_checked()
+            .map(|(rows, cols)| Self { rows, cols })
+    }
+}
+
+impl Default for PtySize {
+    fn default() -> Self {
+        Self { rows: 24, cols: 80 }
     }
 }
 

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -129,6 +129,13 @@ impl<'a> Visitor<'a> {
 
         let sink = Self::sink(run_opts);
         let color_cache = ColorSelector::default();
+        // Set up correct size for underlying pty
+        if let Some(pane_size) = experimental_ui_sender
+            .as_ref()
+            .and_then(|sender| sender.pane_size())
+        {
+            manager.set_pty_size(pane_size.rows, pane_size.cols);
+        }
 
         Self {
             color_cache,

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -18,7 +18,7 @@ const FRAMERATE: Duration = Duration::from_millis(3);
 const RESIZE_DEBOUNCE_DELAY: Duration = Duration::from_millis(10);
 
 use super::{
-    event::{CacheResult, Direction, OutputLogs, TaskResult},
+    event::{CacheResult, Direction, OutputLogs, PaneSize, TaskResult},
     input,
     search::SearchResults,
     AppReceiver, Debouncer, Error, Event, InputOptions, SizeInfo, TaskTable, TerminalPane,
@@ -770,6 +770,15 @@ fn update(
         }
         Event::SearchBackspace => {
             app.search_remove_char()?;
+        }
+        Event::PaneSizeQuery(callback) => {
+            // If caller has already hung up do nothing
+            callback
+                .send(PaneSize {
+                    rows: app.size.pane_rows(),
+                    cols: app.size.pane_cols(),
+                })
+                .ok();
         }
     }
     Ok(None)

--- a/crates/turborepo-ui/src/tui/event.rs
+++ b/crates/turborepo-ui/src/tui/event.rs
@@ -16,6 +16,7 @@ pub enum Event {
         status: String,
         result: CacheResult,
     },
+    PaneSizeQuery(std::sync::mpsc::SyncSender<PaneSize>),
     Stop(std::sync::mpsc::SyncSender<()>),
     // Stop initiated by the TUI itself
     InternalStop,
@@ -86,6 +87,12 @@ pub enum OutputLogs {
     NewOnly,
     // Output is only persisted if the task failed
     ErrorsOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PaneSize {
+    pub rows: u16,
+    pub cols: u16,
 }
 
 #[cfg(test)]

--- a/crates/turborepo-ui/src/tui/handle.rs
+++ b/crates/turborepo-ui/src/tui/handle.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use super::{
-    event::{CacheResult, OutputLogs},
+    event::{CacheResult, OutputLogs, PaneSize},
     Event, TaskResult,
 };
 
@@ -71,6 +71,15 @@ impl AppSender {
     /// Restart the list of tasks displayed in the TUI
     pub fn restart_tasks(&self, tasks: Vec<String>) -> Result<(), mpsc::SendError<Event>> {
         self.primary.send(Event::RestartTasks { tasks })
+    }
+
+    /// Fetches the size of the terminal pane
+    pub fn pane_size(&self) -> Option<PaneSize> {
+        let (callback_tx, callback_rx) = mpsc::sync_channel(1);
+        // Send query, if no receiver to handle the request return None
+        self.primary.send(Event::PaneSizeQuery(callback_tx)).ok()?;
+        // Wait for callback to be sent
+        callback_rx.recv().ok()
     }
 }
 


### PR DESCRIPTION
### Description

Fixes https://github.com/vercel/turborepo/issues/9060

[From the issue](https://github.com/vercel/turborepo/issues/9060#issuecomment-2312651231)

> I think I see the issue, it appears that rspack adds enough trailing spaces in the progress bar output the fill the current line:
> 
> ```
> ● ESC[1mESC[0m ESC[32mESC[37mESC[2m━━━━━━━━━━━━━━━━━━━━━━━━━ESC[0mESC[0m (0%) ESC[2msetup compilation                                                                                                                                           ESC[0m^MESC[2K
> ```
> 
> The `ESC[2K` operation at the erases the current line, but if the trailing spaces have caused the line to wrap, it won't erase the intended line instead just the line overflow. This probably indicates we have a mismatch in the PTY dimensions and the virtual terminal dimensions so `rspack` is outputting too many spaces for the terminal.
> 
> I'll look at making sure the underlying PTY has the exact same dimensions as the virtual terminal.


There is future work to make sure that we update underlying PTY instances if the pane changes sizes, but that requires a pretty heavy refactor to our process management code to communicate with the PTY "controller" as we only hold onto the "receiver".

### Testing Instructions

Before:
<img width="899" alt="Screenshot 2024-09-03 at 9 34 21 AM" src="https://github.com/user-attachments/assets/b773457e-33ef-4075-aae4-9b0b9932a47a">


After:
<img width="483" alt="Screenshot 2024-09-03 at 9 30 20 AM" src="https://github.com/user-attachments/assets/34997ea3-1032-4cf5-96db-b3a30e1c752e">

