### PR TITLE
fix(filter): validate package name on full graph

### DIFF
--- a/crates/turborepo-lib/src/run/scope/filter.rs
+++ b/crates/turborepo-lib/src/run/scope/filter.rs
@@ -1206,6 +1206,17 @@ mod test {
         &["package-1", "package-2"] ;
         "match dependency subtree"
     )]
+    #[test_case(
+        vec![
+            TargetSelector {
+                name_pattern: "package-3".to_string(),
+                git_range: Some(GitRange { from_ref: Some("HEAD~1".to_string()), to_ref: None, ..Default::default() }),
+                ..Default::default()
+            }
+        ],
+        &[] ;
+        "gh 9096"
+    )]
     fn scm(selectors: Vec<TargetSelector>, expected: &[&str]) {
         let scm_resolver = TestChangeDetector::new(&[
             ("HEAD~1", None, &["package-1", "package-2", ROOT_PKG_NAME]),

--- a/crates/turborepo-lib/src/run/scope/target_selector.rs
+++ b/crates/turborepo-lib/src/run/scope/target_selector.rs
@@ -234,6 +234,7 @@ pub fn is_selector_by_location(
 mod test {
     use std::str::FromStr;
 
+    use pretty_assertions::assert_eq;
     use test_case::test_case;
     use turbopath::AnchoredSystemPathBuf;
 
@@ -263,6 +264,7 @@ mod test {
     #[test_case("foo...[master]", TargetSelector { raw: "foo...[master]".to_string(), git_range: Some(GitRange { from_ref: Some("master".to_string()), to_ref: None, include_uncommitted: true, ..Default::default() }), name_pattern: "foo".to_string(), match_dependencies: true, ..Default::default() }; "foo...[master]")]
     #[test_case("foo...[master]...", TargetSelector { raw: "foo...[master]...".to_string(), git_range: Some(GitRange { from_ref: Some("master".to_string()), to_ref: None, include_uncommitted: true, ..Default::default() }), name_pattern: "foo".to_string(), match_dependencies: true, include_dependencies: true, ..Default::default() }; "foo...[master] dot dot dot")]
     #[test_case("{foo}...[master]", TargetSelector { raw: "{foo}...[master]".to_string(), git_range: Some(GitRange { from_ref: Some("master".to_string()), to_ref: None, include_uncommitted: true, ..Default::default() }), parent_dir: Some(AnchoredSystemPathBuf::try_from("foo").unwrap()), match_dependencies: true, ..Default::default() }; " curly brackets foo...[master]")]
+    #[test_case("...@repo/pkg[master]", TargetSelector { raw: "...@repo/pkg[master]".to_string(), git_range: Some(GitRange { from_ref: Some("master".to_string()), to_ref: None, include_uncommitted: true, ..Default::default() }), name_pattern: "@repo/pkg".to_string(), include_dependents: true, ..Default::default() }; "gh 9096")]
     fn parse_target_selector(raw_selector: &str, want: TargetSelector) {
         let result = TargetSelector::from_str(raw_selector);
 


### PR DESCRIPTION
### Description

Fixes #9096

The issue was that the validation was run against an already filtered set of packages if another selector was provided i.e. `--filter foo[commit]` the name filter `foo` would run against only packages that were changed since `commit`. This meant that `foo` would be incorrectly reported as not existing.

This PR changes so the package existence check is run against all packages in the graph instead of an already filtered set.

### Testing Instructions

Added red->green unit test


Verify that this PR correctly handles the repro provided in #9096 
```
[1 olszewski@chriss-mbp] /tmp/turbo-filter-break $ turbo_dev --skip-infer run lint '--filter=...@repo/eslint-config[HEAD~1]' 
turbo 2.1.1

• Packages in scope: 
• Running lint in 0 packages
• Remote caching disabled

No tasks were executed as part of this run.

 Tasks:    0 successful, 0 total
Cached:    0 cached, 0 total
  Time:    75ms
```