### PR TITLE
chore(path): make path reading api more rusty

### DIFF
--- a/crates/turborepo-lib/src/commands/link.rs
+++ b/crates/turborepo-lib/src/commands/link.rs
@@ -215,11 +215,12 @@ pub async fn link(
 
             let local_config_path = base.local_config_path();
             let before = local_config_path
-                .read_existing_to_string_or(Ok("{}"))
+                .read_existing_to_string()
                 .map_err(|e| config::Error::FailedToReadConfig {
                     config_path: local_config_path.clone(),
                     error: e,
-                })?;
+                })?
+                .unwrap_or_else(|| String::from("{}"));
 
             let no_preexisting_id = unset_path(&before, &["teamid"], false)?.unwrap_or(before);
             let no_preexisting_slug =
@@ -314,11 +315,12 @@ pub async fn link(
 
             let local_config_path = base.local_config_path();
             let before = local_config_path
-                .read_existing_to_string_or(Ok("{}"))
+                .read_existing_to_string()
                 .map_err(|error| config::Error::FailedToReadConfig {
                     config_path: local_config_path.clone(),
                     error,
-                })?;
+                })?
+                .unwrap_or_else(|| String::from("{}"));
 
             let no_preexisting_id = unset_path(&before, &["teamid"], false)?.unwrap_or(before);
             let no_preexisting_slug =
@@ -541,11 +543,12 @@ fn add_turbo_to_gitignore(base: &CommandBase) -> Result<(), io::Error> {
 fn add_space_id_to_turbo_json(base: &CommandBase, space_id: &str) -> Result<(), Error> {
     let turbo_json_path = base.repo_root.join_component("turbo.json");
     let turbo_json = turbo_json_path
-        .read_existing_to_string_or(Ok("{}"))
+        .read_existing_to_string()
         .map_err(|error| config::Error::FailedToReadConfig {
             config_path: turbo_json_path.clone(),
             error,
-        })?;
+        })?
+        .unwrap_or_else(|| String::from("{}"));
 
     let space_id_json_value = format!("\"{}\"", space_id);
 

--- a/crates/turborepo-lib/src/commands/login.rs
+++ b/crates/turborepo-lib/src/commands/login.rs
@@ -37,11 +37,12 @@ pub async fn sso_login(
 
     let global_config_path = base.global_config_path()?;
     let before = global_config_path
-        .read_existing_to_string_or(Ok("{}"))
+        .read_existing_to_string()
         .map_err(|e| config::Error::FailedToReadConfig {
             config_path: global_config_path.clone(),
             error: e,
-        })?;
+        })?
+        .unwrap_or_else(|| String::from("{}"));
 
     let after = set_path(&before, &["token"], &format!("\"{}\"", token.into_inner()))?;
 
@@ -92,11 +93,12 @@ pub async fn login(
 
     let global_config_path = base.global_config_path()?;
     let before = global_config_path
-        .read_existing_to_string_or(Ok("{}"))
+        .read_existing_to_string()
         .map_err(|e| config::Error::FailedToReadConfig {
             config_path: global_config_path.clone(),
             error: e,
-        })?;
+        })?
+        .unwrap_or_else(|| String::from("{}"));
     let after = set_path(&before, &["token"], &format!("\"{}\"", token.into_inner()))?;
 
     global_config_path

--- a/crates/turborepo-lib/src/commands/unlink.rs
+++ b/crates/turborepo-lib/src/commands/unlink.rs
@@ -23,11 +23,12 @@ fn unlink_remote_caching(base: &mut CommandBase) -> Result<(), cli::Error> {
         let local_config_path = base.local_config_path();
 
         let before = local_config_path
-            .read_existing_to_string_or(Ok("{}"))
+            .read_existing_to_string()
             .map_err(|error| config::Error::FailedToReadConfig {
                 config_path: local_config_path.clone(),
                 error,
-            })?;
+            })?
+            .unwrap_or_else(|| String::from("{}"));
         let no_id = unset_path(&before, &["teamid"], false)?.unwrap_or(before);
         let no_slug = unset_path(&no_id, &["teamslug"], false)?.unwrap_or(no_id);
 
@@ -62,11 +63,12 @@ fn unlink_spaces(base: &mut CommandBase) -> Result<(), cli::Error> {
     if needs_disabling {
         let local_config_path = base.local_config_path();
         let before = local_config_path
-            .read_existing_to_string_or(Ok("{}"))
+            .read_existing_to_string()
             .map_err(|e| config::Error::FailedToReadConfig {
                 config_path: local_config_path.clone(),
                 error: e,
-            })?;
+            })?
+            .unwrap_or_else(|| String::from("{}"));
         let no_id = unset_path(&before, &["teamid"], false)?.unwrap_or(before);
         let no_slug = unset_path(&no_id, &["teamslug"], false)?.unwrap_or(no_id);
 

--- a/crates/turborepo-lib/src/config/file.rs
+++ b/crates/turborepo-lib/src/config/file.rs
@@ -25,17 +25,18 @@ impl ResolvedConfigurationOptions for ConfigFile {
         &self,
         _existing_config: &ConfigurationOptions,
     ) -> Result<ConfigurationOptions, Error> {
-        let mut contents = self
+        let contents = self
             .path
-            .read_existing_to_string_or(Ok("{}"))
+            .read_existing_to_string()
             .map_err(|error| Error::FailedToReadConfig {
                 config_path: self.path.clone(),
                 error,
-            })?;
-        if contents.is_empty() {
-            contents = String::from("{}");
-        }
-        let global_config: ConfigurationOptions = serde_json::from_str(&contents)?;
+            })?
+            .filter(|s| !s.is_empty());
+
+        let global_config = contents
+            .as_deref()
+            .map_or_else(|| Ok(ConfigurationOptions::default()), serde_json::from_str)?;
         Ok(global_config)
     }
 }

--- a/crates/turborepo-paths/src/absolute_system_path.rs
+++ b/crates/turborepo-paths/src/absolute_system_path.rs
@@ -441,22 +441,6 @@ impl AbsoluteSystemPath {
         fs::read_to_string(&self.0)
     }
 
-    /// Attempts to read a file, and:
-    /// If the file does not exist it returns the default value.
-    /// For all other scenarios passes through the `read_to_string` results.
-    pub fn read_existing_to_string_or<I>(
-        &self,
-        default_value: Result<I, io::Error>,
-    ) -> Result<String, io::Error>
-    where
-        I: Into<String>,
-    {
-        match self.read_existing_to_string()? {
-            Some(contents) => Ok(contents),
-            None => default_value.map(|value| value.into()),
-        }
-    }
-
     /// Attempts to read a file returning None if the file does not exist
     /// For all other scenarios passes through the `read_to_string` results.
     pub fn read_existing_to_string(&self) -> Result<Option<String>, io::Error> {


### PR DESCRIPTION
### Description

Remove `read_existing_to_string_or` in favor of `read_existing_to_string` to consolidate on the more Rust-y API for reading a path to a file.

`read_existing_to_string_or` is an awkward API due:
 - It conflates two outcomes: The file not existing and the file existing with the contents of the default
 - The default is provided as `Result<impl Into<String>, io::Error>`. `impl Into<String>` was chosen so unnecessary work could be avoided. This is limiting compared to `FnOnce() -> String`.
 - It prevents us from using the battle tested `Option` API

The benefits of not conflating the two outcomes is best displayed when trying to read a config file. Instead of defaulting having a default of `{}` and then parsing it as JSON we can skip the parse and just use `ConfigurationOptions::default()`

### Testing Instructions

Existing unit tests + 👀 
