### PR TITLE
docs(watch): call out no caching

### DIFF
--- a/docs/repo-docs/reference/watch.mdx
+++ b/docs/repo-docs/reference/watch.mdx
@@ -29,6 +29,11 @@ Instead, you should make the task non-persistent and have `turbo watch` restart 
 
 ## Limitations
 
+### Caching
+
+All cache operations are disabled when executing tasks with `turbo watch`.
+This prevents accidental cache corruptions caused by tasks restarting before a caching operation completes.
+
 ### Task outputs
 
 If you have tasks that write to files checked into source control, there is a possibility that Watch Mode will run in an infinite loop. This is because Watch Mode watches your

--- a/docs/repo-docs/reference/watch.mdx
+++ b/docs/repo-docs/reference/watch.mdx
@@ -32,7 +32,6 @@ Instead, you should make the task non-persistent and have `turbo watch` restart 
 ### Caching
 
 All cache operations are disabled when executing tasks with `turbo watch`.
-This prevents accidental cache corruptions caused by tasks restarting before a caching operation completes.
 
 ### Task outputs
 


### PR DESCRIPTION
### Description

Document that caching is disabled for `turbo watch`

### Testing Instructions

👀 
