### PR TITLE
Fix invalid JSON

### DIFF
--- a/docs/repo-docs/guides/tools/typescript.mdx
+++ b/docs/repo-docs/guides/tools/typescript.mdx
@@ -207,6 +207,7 @@ Then, create a `check-types` task in `turbo.json`. From the [Configuring tasks g
     },
     "check-types": {
       "dependsOn": ["topo"]
+    },
   },
 }
 ```


### PR DESCRIPTION
More or less a typo fix.

Also, what does "topo" mean? Searching the docs for "topo" yields nothing, and searching the repo yields

https://github.com/vercel/turborepo/blob/a8f38f13b6cd2a4c12f3dd08f2f631a9af4df19c/turbo.json#L215-L219

Why should `check-types` depend on `topo`? The docs point me to "[Transit Nodes](https://turbo.build/repo/docs/core-concepts/package-and-task-graph#transit-nodes)", but I'm still confused. In particular,

> Turborepo calls the `ui` package a Transit Node in this scenario, because it doesn't have its own `build` script.

So should we not have a `topo` script? If this is the case, why do other `turbo.json` files in this repo have a `topo` task (which does nothing; see below)?

Also, this repo's own `check-types` [doesn't depend on topo](https://github.com/vercel/turborepo/blob/a8f38f13b6cd2a4c12f3dd08f2f631a9af4df19c/turbo.json#L202-L204). This is especially confusing when combined with this comment I found

https://github.com/vercel/turborepo/blob/a8f38f13b6cd2a4c12f3dd08f2f631a9af4df19c/examples/turbo.json#L3-L6

because uh... the root `turbo.json` _does_ have a `topo` task (see above).

I'm a turborepo noob so perhaps I'm missing something obvious, but I'm filled with confusion while trying to setup Typescript right now 😢.