### PR TITLE
chore: remove turbopack top level crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,23 +40,8 @@ strip = true
 # ref: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace
 [workspace.dependencies]
 async-recursion = "1.0.2"
-# Keep consistent with preset_env_base through swc_core
-browserslist-rs = { version = "0.16.0" }
 miette = { version = "5.10.0", features = ["fancy"] }
 markdown = "1.0.0-alpha.18"
-mdxjs = "0.2.5"
-modularize_imports = { version = "0.68.7" }
-styled_components = { version = "0.96.6" }
-styled_jsx = { version = "0.73.10" }
-swc_core = { version = "0.96.9", features = [
-  "ecma_loader_lru",
-  "ecma_loader_parking_lot",
-] }
-swc_emotion = { version = "0.72.6" }
-swc_relay = { version = "0.44.5" }
-testing = { version = "0.36.0" }
-# Temporary: Reference the latest git minor version of pathfinder_simd until it's published.
-pathfinder_simd = "0.5.3"
 
 turbo-updater = { path = "crates/turborepo-updater" }
 turbopath = { path = "crates/turborepo-paths" }
@@ -85,13 +70,6 @@ turborepo-vt100 = { path = "crates/turborepo-vt100" }
 # and some aren't buildable with rustls.
 reqwest = { version = "=0.11.17", default-features = false }
 
-chromiumoxide = { version = "0.5.0", features = [
-  "tokio-runtime",
-], default-features = false }
-# For matching on errors from chromiumoxide. Keep in
-# sync with chromiumoxide's tungstenite requirement.
-tungstenite = "0.18.0"
-
 anyhow = "1.0.69"
 assert_cmd = "2.0.8"
 async-compression = { version = "0.3.13", default-features = false, features = [
@@ -116,7 +94,6 @@ clap_complete = "4.5.24"
 concurrent-queue = "2.5.0"
 console = "0.15.5"
 console-subscriber = "0.1.8"
-criterion = "0.4.0"
 crossbeam-channel = "0.5.8"
 dashmap = "5.4.0"
 dialoguer = "0.10.3"
@@ -126,39 +103,29 @@ futures = "0.3.26"
 futures-retry = "0.6.0"
 hex = "0.4.3"
 httpmock = { version = "0.6.8", default-features = false }
-image = { version = "0.25.0", default-features = false }
 indexmap = "1.9.2"
 indicatif = "0.17.3"
 indoc = "2.0.0"
 itertools = "0.10.5"
 lazy_static = "1.4.0"
-lightningcss = { version = "1.0.0-alpha.57", features = [
-  "serde",
-  "visitor",
-  "into_owned",
-] }
 mime = "0.3.16"
 notify = "6.1.1"
 once_cell = "1.17.1"
 owo-colors = "3.5.0"
-parcel_selectors = "0.26.0"
 parking_lot = "0.12.1"
 path-clean = "1.0.1"
 pathdiff = "0.2.1"
 petgraph = "0.6.3"
 pin-project-lite = "0.2.9"
 port_scanner = "0.1.5"
-postcard = "1.0.4"
 predicates = "2.1.5"
 pretty_assertions = "1.3.0"
 proc-macro2 = "1.0.79"
-qstring = "0.7.2"
 quote = "1.0.23"
 radix_trie = "0.2.1"
 rand = "0.8.5"
 ratatui = "0.26.1"
 regex = "1.7.0"
-rstest = "0.16.0"
 rustc-hash = "1.1.0"
 semver = "1.0.16"
 serde = { version = "1.0.152", features = ["derive"] }
@@ -173,7 +140,6 @@ smallvec = { version = "1.13.1", features = [
   "union",
   "const_new",
 ] }
-sourcemap = "8.0.1"
 syn = "1.0.107"
 tempfile = "3.3.0"
 test-case = "3.0.0"
@@ -184,11 +150,9 @@ tokio-util = { version = "0.7.7", features = ["io"] }
 tracing = "0.1.37"
 tracing-appender = "0.2.2"
 tracing-subscriber = "0.3.16"
-triomphe = "0.1.13"
 tui-term = { version = "=0.1.9", default-features = false }
 url = "2.2.2"
 urlencoding = "2.1.2"
 webbrowser = "0.8.7"
 which = "4.4.0"
 unicode-segmentation = "1.10.1"
-unsize = "1.1.0"


### PR DESCRIPTION
### Description

Removing all top level dependencies that don't appear in our `Cargo.lock`:

List of crates to remove generated via
```
$ tail -n+42 < Cargo.toml | cut -d' ' -f1 > /tmp/top_level_crates.txt
$ rg -F -f /tmp/top_level_crates.txt Cargo.lock -o -N | sort -u > /tmp/matches.tx
$ rg -F -f /tmp/matches.txt -v /tmp/top_level_crates.txt
```

### Testing Instructions

Everything builds and passes on CI
