### PR TITLE
perf(vt100): increase render performance for `tui_term` codepath

### DIFF
--- a/crates/turborepo-vt100/src/grid.rs
+++ b/crates/turborepo-vt100/src/grid.rs
@@ -198,7 +198,21 @@ impl Grid {
     }
 
     pub fn visible_row(&self, row: u16) -> Option<&crate::row::Row> {
-        self.visible_rows().nth(usize::from(row))
+        // The number of rows that are in scrollback before the current screen
+        let scrollback_rows_before_screen =
+            self.scrollback.len().saturating_sub(self.scrollback_offset);
+        // The index for row if it is in the scrollback
+        let scrollback_idx = scrollback_rows_before_screen + usize::from(row);
+        // If this is a valid scrollback index, then return that row
+        if scrollback_idx < self.scrollback.len() {
+            self.scrollback.get(scrollback_idx)
+        } else {
+            // Need to subtract scrollback offset
+            // e.g. if we are showing 1 row of scrollback, and user requests 3rd visible row
+            // we should return the second row in self.rows
+            self.rows
+                .get(usize::from(row).saturating_sub(self.scrollback_offset))
+        }
     }
 
     pub fn drawing_row(&self, row: u16) -> Option<&crate::row::Row> {

--- a/crates/turborepo-vt100/src/row.rs
+++ b/crates/turborepo-vt100/src/row.rs
@@ -135,7 +135,7 @@ impl Row {
                 }
                 prev_col += col - prev_col;
 
-                contents.push_str(&cell.contents());
+                contents.push_str(cell.contents());
                 prev_col += if cell.is_wide() { 2 } else { 1 };
             }
         }
@@ -322,7 +322,7 @@ impl Row {
             }
             let mut cell_contents = prev_first_cell.contents();
             let need_erase = if cell_contents.is_empty() {
-                cell_contents = " ".to_string();
+                cell_contents = " ";
                 true
             } else {
                 false

--- a/crates/turborepo-vt100/src/row.rs
+++ b/crates/turborepo-vt100/src/row.rs
@@ -1,6 +1,6 @@
 use crate::term::BufWrite as _;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Row {
     cells: Vec<crate::Cell>,
     wrapped: bool,

--- a/crates/turborepo-vt100/src/screen.rs
+++ b/crates/turborepo-vt100/src/screen.rs
@@ -1621,3 +1621,32 @@ fn u16_to_u8(i: u16) -> Option<u8> {
         Some(i.try_into().unwrap())
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::screen;
+
+    use super::*;
+
+    #[test]
+    fn test_visible_row_matches_visible_rows() {
+        // do some fuzzing
+        let rows = 10;
+        let scrollback = 100;
+        let mut parser = crate::Parser::new(rows, 10, scrollback);
+        for i in 1..120 {
+            parser.process(format!("{i}\n\n").as_bytes());
+        }
+        for i in 0..scrollback {
+            let screen = parser.screen_mut();
+            screen.set_scrollback(i);
+            let grid = screen.grid();
+            for row_ix in 0..rows {
+                assert_eq!(
+                    grid.visible_row(row_ix),
+                    grid.visible_rows().nth(usize::from(row_ix))
+                );
+            }
+        }
+    }
+}

--- a/crates/turborepo-vt100/src/tui_term.rs
+++ b/crates/turborepo-vt100/src/tui_term.rs
@@ -49,7 +49,7 @@ fn fill_buf_cell(
     let fg = screen_cell.fgcolor();
     let bg = screen_cell.bgcolor();
 
-    buf_cell.set_symbol(&screen_cell.contents());
+    buf_cell.set_symbol(screen_cell.contents());
     let fg: Color = fg.into();
     let bg: Color = bg.into();
     let mut style = Style::reset();

--- a/crates/turborepo-vt100/tests/helpers/fixtures.rs
+++ b/crates/turborepo-vt100/tests/helpers/fixtures.rs
@@ -38,7 +38,7 @@ impl FixtureCell {
     #[allow(dead_code)]
     pub fn from_cell(cell: &vt100::Cell) -> Self {
         Self {
-            contents: cell.contents(),
+            contents: cell.contents().to_string(),
             is_wide: cell.is_wide(),
             is_wide_continuation: cell.is_wide_continuation(),
             fgcolor: cell.fgcolor(),


### PR DESCRIPTION
### Description

The crate `tui_term` renders the `vt100::Screen` by [fetching each cell](https://github.com/a-kenji/tui-term/blob/development/src/state.rs#L27) and then filling the `ratatui::buffer:Cell` [with the vt100 cell's contents](https://github.com/a-kenji/tui-term/blob/development/src/vt100_imp.rs#L37).

This leads to the following functions being called once for each cell on the users terminal:
 - [`Cell::contents`](https://github.com/vercel/turborepo/blob/main/crates/turborepo-vt100/src/cell.rs#L90) which unnecessarily allocates on every call even though there's a fixed limit to the size of the `str` that could be returned. This PR changes this method to return a `&str` that is constructed from the content bytes. The new helper function `append_char` is basically [`String::push`](https://doc.rust-lang.org/src/alloc/string.rs.html#1358)
 - [`Grid::visible_row`](https://github.com/vercel/turborepo/blob/main/crates/turborepo-vt100/src/grid.rs#L200) which iterates through the scrollback rows and screen rows. This PR changes this to instead index directly into the rows

### Testing Instructions

Tested by profiling this basic script that render a tui_term 1000 times.
```rust
use std::io;

use ratatui::{
    prelude::CrosstermBackend,
    style::{Style, Stylize},
    widgets::{Block, Borders, Widget},
    Terminal,
};
use tui_term::widget::PseudoTerminal;

pub fn main() {
    let input = include_bytes!("turbo-build.log");
    let mut terminal =
        Terminal::new(CrosstermBackend::new(io::stdout())).unwrap();
    terminal.hide_cursor().unwrap();
    let size = terminal.size().unwrap();

    let mut parser =
        turborepo_vt100::Parser::new(size.height, size.width, 1024);
    parser.process(input);

    let screen = parser.screen();

    for _ in 0..1000 {
        let block = Block::default()
            .borders(Borders::ALL)
            .border_style(Style::default().blue());
        let term = PseudoTerminal::new(screen).block(block);
        terminal
            .draw(|frame| {
                let area = frame.size();
                term.render(area, frame.buffer_mut())
            })
            .unwrap();
    }
}

```

The two functions that this targets:

`fill_buf_cell` codepath
Before
<img width="1329" alt="Screenshot 2024-09-06 at 4 23 47 PM" src="https://github.com/user-attachments/assets/6b5e27c6-31d6-4f71-842b-3efd37fa606e">

After
<img width="1327" alt="Screenshot 2024-09-06 at 4 24 32 PM" src="https://github.com/user-attachments/assets/bf966a03-b093-48e3-8848-5d725c22b637">

`visible_cell` codepath
Before

<img width="1511" alt="Screenshot 2024-09-06 at 4 25 09 PM" src="https://github.com/user-attachments/assets/c0052806-98e7-4d0a-94c9-6f2aff1867e2">
After
<img width="1396" alt="Screenshot 2024-09-06 at 4 25 41 PM" src="https://github.com/user-attachments/assets/f1360722-82ea-4ff1-8d5e-2035dc774ccb">