### PR TITLE
docs(crates/turborepo): add capnp to build dependencies

### DIFF
--- a/crates/turborepo/README.md
+++ b/crates/turborepo/README.md
@@ -4,7 +4,7 @@
 
 1. Install `protobuf` and `golang` (note: Go must be pinned to v1.20.x, see https://github.com/vercel/turborepo/issues/5918 for details)
 
-- On macOS: `brew install protobuf protoc-gen-go protoc-gen-go-grpc go@1.20`
+- On macOS: `brew install protobuf protoc-gen-go protoc-gen-go-grpc go@1.20 capnp`
 - On Windows: `choco install golang --version=1.20.7` and `choco install protoc make python3 mingw`
 - On Ubuntu: `apt-get install golang golang-goprotobuf-dev`
 


### PR DESCRIPTION
### Description
I was setting up turborepo locally on macOS. ran into the follow error. installing capnp fixed it
```bash
   Compiling turborepo-lockfiles v0.1.0 (turborepo/crates/turborepo-lockfiles)
error: failed to run custom build command for `turborepo-lib v0.1.0 (turborepo/crates/turborepo-lib)`

Caused by:
  process didn't exit successfully: `turborepo/target/debug/build/turborepo-lib-167cf8cfecddd530/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-changed=./src/daemon/proto/turbod.proto
  cargo:rerun-if-changed=./src/daemon/proto

  --- stderr
  thread 'main' panicked at crates/turborepo-lib/build.rs:27:23:
  schema compiler command: Error { kind: Failed, extra: "Failed to execute `capnp --version`: No such file or directory (os error 2). Please verify that version 0.5.2 or higher of the capnp executable is installed on your system. See https://capnproto.org/install.html" }
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
```

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
