### PR TITLE
perf(tui): bring async to tui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,6 +1388,7 @@ checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
  "bitflags 2.5.0",
  "crossterm_winapi",
+ "futures-core",
  "libc",
  "mio 0.8.11",
  "parking_lot",
@@ -6569,6 +6570,7 @@ dependencies = [
  "console",
  "crossterm 0.27.0",
  "dialoguer",
+ "futures",
  "indicatif",
  "indoc",
  "lazy_static",

--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -57,7 +57,7 @@ pub async fn run(base: CommandBase, telemetry: CommandEventBuilder) -> Result<i3
 
         // We only stop if it's the TUI, for the web UI we don't need to stop
         if let Some(UISender::Tui(sender)) = sender {
-            sender.stop();
+            sender.stop().await;
         }
 
         if let Some(handle) = handle {

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -253,7 +253,8 @@ impl Run {
         }
 
         let (sender, receiver) = TuiSender::new();
-        let handle = tokio::task::spawn_blocking(move || Ok(tui::run_app(task_names, receiver)?));
+        let handle =
+            tokio::task::spawn(async move { Ok(tui::run_app(task_names, receiver).await?) });
 
         Ok(Some((sender, handle)))
     }
@@ -454,7 +455,8 @@ impl Run {
             global_env,
             ui_sender,
             is_watch,
-        );
+        )
+        .await;
 
         if self.opts.run_opts.dry_run.is_some() {
             visitor.dry_run();

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -106,7 +106,7 @@ impl<'a> Visitor<'a> {
     // Once we have the full picture we will go about grouping these pieces of data
     // together
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub async fn new(
         package_graph: Arc<PackageGraph>,
         run_cache: Arc<RunCache>,
         run_tracker: RunTracker,
@@ -133,8 +133,11 @@ impl<'a> Visitor<'a> {
         let sink = Self::sink(run_opts);
         let color_cache = ColorSelector::default();
         // Set up correct size for underlying pty
-        if let Some(pane_size) = ui_sender.as_ref().and_then(|sender| sender.pane_size()) {
-            manager.set_pty_size(pane_size.rows, pane_size.cols);
+
+        if let Some(app) = ui_sender.as_ref() {
+            if let Some(pane_size) = app.pane_size().await {
+                manager.set_pty_size(pane_size.rows, pane_size.cols);
+            }
         }
 
         Self {
@@ -330,7 +333,7 @@ impl<'a> Visitor<'a> {
 
         if !self.is_watch {
             if let Some(handle) = &self.ui_sender {
-                handle.stop();
+                handle.stop().await;
             }
         }
 

--- a/crates/turborepo-ui/Cargo.toml
+++ b/crates/turborepo-ui/Cargo.toml
@@ -34,7 +34,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-
 tracing = { workspace = true }
 tui-term = { workspace = true }
 turbopath = { workspace = true }

--- a/crates/turborepo-ui/Cargo.toml
+++ b/crates/turborepo-ui/Cargo.toml
@@ -24,8 +24,9 @@ axum-server = { workspace = true }
 base64 = "0.22"
 chrono = { workspace = true }
 console = { workspace = true }
-crossterm = "0.27.0"
+crossterm = { version = "0.27.0", features = ["event-stream"] }
 dialoguer = { workspace = true }
+futures = { workspace = true }
 indicatif = { workspace = true }
 lazy_static = { workspace = true }
 nix = { version = "0.26.2", features = ["signal"] }

--- a/crates/turborepo-ui/src/sender.rs
+++ b/crates/turborepo-ui/src/sender.rs
@@ -62,9 +62,9 @@ impl UISender {
             UISender::Wui(sender) => sender.task(task),
         }
     }
-    pub fn stop(&self) {
+    pub async fn stop(&self) {
         match self {
-            UISender::Tui(sender) => sender.stop(),
+            UISender::Tui(sender) => sender.stop().await,
             UISender::Wui(sender) => sender.stop(),
         }
     }
@@ -75,9 +75,9 @@ impl UISender {
         }
     }
 
-    pub fn pane_size(&self) -> Option<PaneSize> {
+    pub async fn pane_size(&self) -> Option<PaneSize> {
         match self {
-            UISender::Tui(sender) => sender.pane_size(),
+            UISender::Tui(sender) => sender.pane_size().await,
             // Not applicable to the web UI
             UISender::Wui(_) => None,
         }

--- a/crates/turborepo-ui/src/tui/event.rs
+++ b/crates/turborepo-ui/src/tui/event.rs
@@ -1,5 +1,6 @@
 use async_graphql::Enum;
 use serde::Serialize;
+use tokio::sync::oneshot;
 
 pub enum Event {
     StartTask {
@@ -19,8 +20,8 @@ pub enum Event {
         status: String,
         result: CacheResult,
     },
-    PaneSizeQuery(std::sync::mpsc::SyncSender<PaneSize>),
-    Stop(std::sync::mpsc::SyncSender<()>),
+    PaneSizeQuery(oneshot::Sender<PaneSize>),
+    Stop(oneshot::Sender<()>),
     // Stop initiated by the TUI itself
     InternalStop,
     Tick,

--- a/crates/turborepo-ui/src/tui/handle.rs
+++ b/crates/turborepo-ui/src/tui/handle.rs
@@ -1,4 +1,7 @@
-use std::{sync::mpsc, time::Instant};
+use tokio::{
+    sync::{mpsc, oneshot},
+    time::Instant,
+};
 
 use super::{
     event::{CacheResult, OutputLogs, PaneSize},
@@ -9,12 +12,12 @@ use crate::sender::{TaskSender, UISender};
 /// Struct for sending app events to TUI rendering
 #[derive(Debug, Clone)]
 pub struct TuiSender {
-    primary: mpsc::Sender<Event>,
+    primary: mpsc::UnboundedSender<Event>,
 }
 
 /// Struct for receiving app events
 pub struct AppReceiver {
-    primary: mpsc::Receiver<Event>,
+    primary: mpsc::UnboundedReceiver<Event>,
 }
 
 impl TuiSender {
@@ -23,7 +26,7 @@ impl TuiSender {
     /// AppSender is meant to be held by the actual task runner
     /// AppReceiver should be passed to `crate::tui::run_app`
     pub fn new() -> (Self, AppReceiver) {
-        let (primary_tx, primary_rx) = mpsc::channel();
+        let (primary_tx, primary_rx) = mpsc::unbounded_channel();
         (
             Self {
                 primary: primary_tx,
@@ -70,13 +73,13 @@ impl TuiSender {
     }
 
     /// Stop rendering TUI and restore terminal to default configuration
-    pub fn stop(&self) {
-        let (callback_tx, callback_rx) = mpsc::sync_channel(1);
+    pub async fn stop(&self) {
+        let (callback_tx, callback_rx) = oneshot::channel();
         // Send stop event, if receiver has dropped ignore error as
         // it'll be a no-op.
         self.primary.send(Event::Stop(callback_tx)).ok();
         // Wait for callback to be sent or the channel closed.
-        callback_rx.recv().ok();
+        callback_rx.await.ok();
     }
 
     /// Update the list of tasks displayed in the TUI
@@ -103,23 +106,25 @@ impl TuiSender {
     }
 
     /// Fetches the size of the terminal pane
-    pub fn pane_size(&self) -> Option<PaneSize> {
-        let (callback_tx, callback_rx) = mpsc::sync_channel(1);
+    pub async fn pane_size(&self) -> Option<PaneSize> {
+        let (callback_tx, callback_rx) = oneshot::channel();
         // Send query, if no receiver to handle the request return None
         self.primary.send(Event::PaneSizeQuery(callback_tx)).ok()?;
         // Wait for callback to be sent
-        callback_rx.recv().ok()
+        callback_rx.await.ok()
     }
 }
 
 impl AppReceiver {
     /// Receive an event, producing a tick event if no events are rec eived by
     /// the deadline.
-    pub fn recv(&self, deadline: Instant) -> Result<Event, mpsc::RecvError> {
-        match self.primary.recv_deadline(deadline) {
-            Ok(event) => Ok(event),
-            Err(mpsc::RecvTimeoutError::Timeout) => Ok(Event::Tick),
-            Err(mpsc::RecvTimeoutError::Disconnected) => Err(mpsc::RecvError),
+    pub async fn recv(&mut self, deadline: Instant) -> Option<Event> {
+        match tokio::time::timeout_at(deadline, self.primary.recv()).await {
+            Ok(Some(event)) => Some(event),
+            // Receiving event timed out, produce tick
+            Err(_) => Some(Event::Tick),
+            // Channel was closed
+            Ok(None) => None,
         }
     }
 }

--- a/crates/turborepo-ui/src/tui/handle.rs
+++ b/crates/turborepo-ui/src/tui/handle.rs
@@ -1,7 +1,4 @@
-use tokio::{
-    sync::{mpsc, oneshot},
-    time::Instant,
-};
+use tokio::sync::{mpsc, oneshot};
 
 use super::{
     event::{CacheResult, OutputLogs, PaneSize},
@@ -118,13 +115,7 @@ impl TuiSender {
 impl AppReceiver {
     /// Receive an event, producing a tick event if no events are rec eived by
     /// the deadline.
-    pub async fn recv(&mut self, deadline: Instant) -> Option<Event> {
-        match tokio::time::timeout_at(deadline, self.primary.recv()).await {
-            Ok(Some(event)) => Some(event),
-            // Receiving event timed out, produce tick
-            Err(_) => Some(Event::Tick),
-            // Channel was closed
-            Ok(None) => None,
-        }
+    pub async fn recv(&mut self) -> Option<Event> {
+        self.primary.recv().await
     }
 }

--- a/crates/turborepo-ui/src/tui/mod.rs
+++ b/crates/turborepo-ui/src/tui/mod.rs
@@ -17,7 +17,7 @@ use clipboard::copy_to_clipboard;
 use debouncer::Debouncer;
 use event::{Event, TaskResult};
 pub use handle::{AppReceiver, TuiSender};
-use input::{input, InputOptions};
+use input::InputOptions;
 pub use pane::TerminalPane;
 use size::SizeInfo;
 pub use table::TaskTable;

--- a/crates/turborepo-ui/src/tui/search.rs
+++ b/crates/turborepo-ui/src/tui/search.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, rc::Rc};
+use std::{collections::HashSet, sync::Arc};
 
 use super::task::TasksByStatus;
 
@@ -9,8 +9,8 @@ pub struct SearchResults {
     // - Rc for cheap clones since elements in `matches` will always be in `tasks` as well
     // - Rc<str> implements Borrow<str> meaning we can query a `HashSet<Rc<str>>` using a `&str`
     // We do not modify the provided task names so we do not need the capabilities of String.
-    tasks: Vec<Rc<str>>,
-    matches: HashSet<Rc<str>>,
+    tasks: Vec<Arc<str>>,
+    matches: HashSet<Arc<str>>,
 }
 
 impl SearchResults {
@@ -18,7 +18,7 @@ impl SearchResults {
         Self {
             tasks: tasks
                 .task_names_in_displayed_order()
-                .map(Rc::from)
+                .map(Arc::from)
                 .collect(),
             query: String::new(),
             matches: HashSet::new(),
@@ -29,7 +29,7 @@ impl SearchResults {
     pub fn update_tasks(&mut self, tasks: &TasksByStatus) {
         self.tasks.clear();
         self.tasks
-            .extend(tasks.task_names_in_displayed_order().map(Rc::from));
+            .extend(tasks.task_names_in_displayed_order().map(Arc::from));
         self.update_matches();
     }
 


### PR DESCRIPTION
### Description

This PR makes the driving the TUI async, the actual operation on the state is still completely sync. The primary driver behind this PR is it allows us to make use of [`crossterm::event::EventStream`](https://docs.rs/crossterm/latest/crossterm/event/struct.EventStream.html) which seems to be far more performant than polling for user input.

The first commit of the PR just changes types from `std::sync::mpsc` to `tokio::sync::mpsc` (and make use of `tokio::sync::oneshot` for our callbacks instead of a channel of size 1). 

The second commit removes our usage of `crossterm::event::poll` in favor of a dedicated task that reads and forwards events from `crossterm::event::EventStream`.

The final commit moves the production of ticks to it's own task to avoid the need for timing out our reads. 

### Testing Instructions

Notice large reduction in CPU usage from `turbo` when tasks are not producing output and the TUI is just waiting for user input.

Before
<img width="331" alt="Screenshot 2024-09-10 at 2 57 45 PM" src="https://github.com/user-attachments/assets/ad85fa7a-7b55-4459-a6c0-c0a7931e8738">

After
<img width="393" alt="Screenshot 2024-09-10 at 2 56 17 PM" src="https://github.com/user-attachments/assets/9b6793b2-bca6-4baa-ab4d-3182e561212e">
