### PR TITLE
fix(affected): include dependents in affected filter

### DIFF
--- a/crates/turborepo-lib/src/run/scope/filter.rs
+++ b/crates/turborepo-lib/src/run/scope/filter.rs
@@ -201,6 +201,7 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
                     include_uncommitted: true,
                     allow_unknown_objects: true,
                 }),
+                include_dependents: true,
                 ..Default::default()
             });
         }

--- a/turborepo-tests/integration/tests/affected-rdeps.t
+++ b/turborepo-tests/integration/tests/affected-rdeps.t
@@ -1,0 +1,19 @@
+Setup
+  $ . ${TESTDIR}/../../helpers/setup_integration_test.sh
+
+Create a new branch
+  $ git checkout -b my-branch
+  Switched to a new branch 'my-branch'
+
+Edit a file that affects `util` package
+  $ echo "foo" >> packages/util/index.js
+Commit the change
+  $ git add .
+  $ git commit -m "add foo" --quiet
+
+Validate that we run `util#build` and all rdeps
+  $ ${TURBO} run build --affected --dry=json | jq '.tasks |  map(select(.command != "<NONEXISTENT>")) | map(.taskId)| sort'
+  [
+    "my-app#build",
+    "util#build"
+  ]


### PR DESCRIPTION
### Description

This PR changes `--affected` so packages that depend on affected packages also get added.

### Testing Instructions

Added integration test to makes sure dependents of changed packages get ran for `--affected`.