### PR TITLE
feat: support rust 1.81.0

### DIFF
--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -4,7 +4,6 @@
 #![feature(hash_extract_if)]
 #![feature(option_get_or_insert_default)]
 #![feature(once_cell_try)]
-#![feature(panic_info_message)]
 #![feature(try_blocks)]
 #![feature(impl_trait_in_assoc_type)]
 #![deny(clippy::all)]

--- a/crates/turborepo-lib/src/panic_handler.rs
+++ b/crates/turborepo-lib/src/panic_handler.rs
@@ -5,11 +5,8 @@ use crate::get_version;
 const OPEN_ISSUE_MESSAGE: &str =
     "Please open an issue at https://github.com/vercel/turborepo/issues/new/choose";
 
-pub fn panic_handler(panic_info: &std::panic::PanicInfo) {
-    let cause = panic_info
-        .message()
-        .map(ToString::to_string)
-        .unwrap_or_else(|| "Unknown".to_string());
+pub fn panic_handler(panic_info: &std::panic::PanicHookInfo) {
+    let cause = panic_info.to_string();
 
     let explanation = match panic_info.location() {
         Some(location) => format!("file '{}' at line {}\n", location.file(), location.line()),

--- a/crates/turborepo-lib/src/shim/mod.rs
+++ b/crates/turborepo-lib/src/shim/mod.rs
@@ -161,7 +161,7 @@ fn spawn_npx_turbo(
 
     let mut command = process::Command::new(npx_path);
     command.arg("-y");
-    command.arg(&format!("turbo@{turbo_version}"));
+    command.arg(format!("turbo@{turbo_version}"));
 
     // rather than passing an argument that local turbo might not understand, set
     // an environment variable that can be optionally used

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -980,9 +980,8 @@ impl ExecContext {
         let mut stdout_writer = self
             .task_cache
             .output_writer(prefixed_ui.task_writer())
-            .map_err(|e| {
+            .inspect_err(|_| {
                 telemetry.track_error(TrackedErrors::FailedToCaptureOutputs);
-                e
             })?;
 
         let exit_status = match process.wait_with_piped_outputs(&mut stdout_writer).await {

--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -142,12 +142,11 @@ impl PackageInputsHashes {
                                     )
                                     .await
                                 })
-                                .map_err(|e| {
+                                .inspect_err(|_| {
                                     tracing::debug!(
                                         "daemon file hashing timed out for {}",
                                         package_path
                                     );
-                                    e
                                 })
                                 .ok() // If we timed out, we don't need to
                                       // error,

--- a/crates/turborepo-paths/src/absolute_system_path.rs
+++ b/crates/turborepo-paths/src/absolute_system_path.rs
@@ -193,7 +193,7 @@ impl AbsoluteSystemPath {
 
     pub fn try_exists(&self) -> Result<bool, PathError> {
         // try_exists is an experimental API and not yet in fs_err
-        Ok(std::fs::try_exists(&self.0)?)
+        Ok(std::fs::exists(&self.0)?)
     }
 
     pub fn extension(&self) -> Option<&str> {

--- a/crates/turborepo-paths/src/lib.rs
+++ b/crates/turborepo-paths/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(assert_matches)]
-#![feature(fs_try_exists)]
 #![deny(clippy::all)]
 
 //! Turborepo's path handling library.

--- a/crates/turborepo-scm/src/ls_tree.rs
+++ b/crates/turborepo-scm/src/ls_tree.rs
@@ -72,7 +72,7 @@ fn nom_parse_ls_tree(i: &[u8]) -> nom::IResult<&[u8], LsTreeEntry<'_>> {
     let (i, _) = nom::bytes::complete::take(1usize)(i)?;
     let (i, filename) = nom::bytes::complete::is_not("\0")(i)?;
     // We explicitly support a missing terminator
-    let (i, _) = nom::combinator::opt(nom::bytes::complete::tag(&[b'\0']))(i)?;
+    let (i, _) = nom::combinator::opt(nom::bytes::complete::tag(b"\0"))(i)?;
     Ok((i, LsTreeEntry { filename, hash }))
 }
 

--- a/crates/turborepo-scm/src/status.rs
+++ b/crates/turborepo-scm/src/status.rs
@@ -94,7 +94,7 @@ fn nom_parse_status(i: &[u8]) -> nom::IResult<&[u8], StatusEntry<'_>> {
     let (i, _) = nom::character::complete::space1(i)?;
     let (i, filename) = nom::bytes::complete::is_not("\0")(i)?;
     // We explicitly support a missing terminator
-    let (i, _) = nom::combinator::opt(nom::bytes::complete::tag(&[b'\0']))(i)?;
+    let (i, _) = nom::combinator::opt(nom::bytes::complete::tag(b"\0"))(i)?;
     Ok((
         i,
         StatusEntry {

--- a/crates/turborepo-vt100/src/screen.rs
+++ b/crates/turborepo-vt100/src/screen.rs
@@ -1294,7 +1294,7 @@ impl Screen {
 
     // CSI h
     #[allow(clippy::unused_self)]
-    pub(crate) fn sm(&mut self, params: &vte::Params) {
+    pub(crate) fn sm(&self, params: &vte::Params) {
         // nothing, i think?
         if log::log_enabled!(log::Level::Debug) {
             log::debug!(
@@ -1353,7 +1353,7 @@ impl Screen {
 
     // CSI l
     #[allow(clippy::unused_self)]
-    pub(crate) fn rm(&mut self, params: &vte::Params) {
+    pub(crate) fn rm(&self, params: &vte::Params) {
         // nothing, i think?
         if log::log_enabled!(log::Level::Debug) {
             log::debug!(

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-05-31"
+channel = "nightly-2024-07-19"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
### Description

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

- features `fs_try_exists` and `panic_info_message` are stable
- fs::try_exists is now fs::exists
- PanicInfo is now PanicHookInfo (use `to_string` method for it)
- switch to 1.81.0-nightly in rust-toolchain.toml

### Testing Instructions

`cargo test` to ensure the code has the same behavior as before

<!--
  Give a quick description of steps to test your changes.
-->
