### PR TITLE
fix(create-turbo): Require specific argument for example option

### DIFF
--- a/packages/create-turbo/src/cli.ts
+++ b/packages/create-turbo/src/cli.ts
@@ -69,7 +69,7 @@ createTurboCli
     "Use a specific version of turbo (default: latest)"
   )
   .option(
-    "-e, --example [name]|[github-url]",
+    "-e, --example <name>|<github-url>",
     `
   An example to bootstrap the app with. You can use an example name
   from the official Turborepo repo or a GitHub URL. The URL can use


### PR DESCRIPTION
### Description

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

When we forgot to add the example argument in create-turbo, example was treated as true.
The error log below makes me a little confused.

``` shell
vscode ➜ /workspaces $ npx create-turbo -e
Need to install the following packages:
create-turbo@2.1.2
Ok to proceed? (y) 

? Where would you like to create your Turborepo? ./my-turborepo
? Which package manager do you want to use? npm
>>> Could not locate an example named "true". It could be due to the following:
 1. Your spelling of example "true" might be incorrect.
 2. You might not be connected to the internet or you are behind a proxy.
```

I couldn't find a reason why the example argument is optional, so I'm making it require.

```
vscode ➜ /workspaces/turborepo (fix/create-turbo) $ ./packages/create-turbo/dist/cli.js -e
error: option '-e, --example <name>|<github-url>' argument missing
```

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->

We can check the changes by running the CLI itself.
Alternatively, if testing is required at the Commander level, I can implement it.

``` shell
./packages/create-turbo/dist/cli.js -e
```