### PR TITLE
feat: allow usage of `turbo` without turbo.json

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -222,6 +222,8 @@ pub struct Args {
     /// should be used.
     #[clap(long, global = true)]
     pub dangerously_disable_package_manager_check: bool,
+    #[clap(long = "experimental-allow-no-turbo-json", hide = true, global = true)]
+    pub allow_no_turbo_json: bool,
     /// Use the `turbo.json` located at the provided path instead of one at the
     /// root of the repository.
     #[clap(long, global = true)]

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -108,6 +108,7 @@ impl CommandBase {
                     .and_then(|args| args.remote_cache_read_only()),
             )
             .with_run_summary(self.args.run_args().and_then(|args| args.summarize()))
+            .with_allow_no_turbo_json(self.args.allow_no_turbo_json.then_some(true))
             .build()
     }
 

--- a/crates/turborepo-lib/src/config/env.rs
+++ b/crates/turborepo-lib/src/config/env.rs
@@ -38,6 +38,7 @@ const TURBO_MAPPING: &[(&str, &str)] = [
     ("turbo_remote_only", "remote_only"),
     ("turbo_remote_cache_read_only", "remote_cache_read_only"),
     ("turbo_run_summary", "run_summary"),
+    ("turbo_allow_no_turbo_json", "allow_no_turbo_json"),
 ]
 .as_slice();
 
@@ -86,6 +87,7 @@ impl ResolvedConfigurationOptions for EnvVars {
         let remote_only = self.truthy_value("remote_only").flatten();
         let remote_cache_read_only = self.truthy_value("remote_cache_read_only").flatten();
         let run_summary = self.truthy_value("run_summary").flatten();
+        let allow_no_turbo_json = self.truthy_value("allow_no_turbo_json").flatten();
 
         // Process timeout
         let timeout = self
@@ -171,6 +173,7 @@ impl ResolvedConfigurationOptions for EnvVars {
             remote_only,
             remote_cache_read_only,
             run_summary,
+            allow_no_turbo_json,
 
             // Processed numbers
             timeout,
@@ -317,6 +320,7 @@ mod test {
         env.insert("turbo_remote_only".into(), "1".into());
         env.insert("turbo_remote_cache_read_only".into(), "1".into());
         env.insert("turbo_run_summary".into(), "true".into());
+        env.insert("turbo_allow_no_turbo_json".into(), "true".into());
 
         let config = EnvVars::new(&env)
             .unwrap()
@@ -328,6 +332,7 @@ mod test {
         assert!(config.remote_only());
         assert!(config.remote_cache_read_only());
         assert!(config.run_summary());
+        assert!(config.allow_no_turbo_json());
         assert_eq!(turbo_api, config.api_url.unwrap());
         assert_eq!(turbo_login, config.login_url.unwrap());
         assert_eq!(turbo_team, config.team_slug.unwrap());
@@ -365,6 +370,7 @@ mod test {
         env.insert("turbo_remote_only".into(), "".into());
         env.insert("turbo_remote_cache_read_only".into(), "".into());
         env.insert("turbo_run_summary".into(), "".into());
+        env.insert("turbo_allow_no_turbo_json".into(), "".into());
 
         let config = EnvVars::new(&env)
             .unwrap()
@@ -387,6 +393,7 @@ mod test {
         assert!(!config.remote_only());
         assert!(!config.remote_cache_read_only());
         assert!(!config.run_summary());
+        assert!(!config.allow_no_turbo_json());
     }
 
     #[test]

--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -242,6 +242,7 @@ pub struct ConfigurationOptions {
     pub(crate) remote_only: Option<bool>,
     pub(crate) remote_cache_read_only: Option<bool>,
     pub(crate) run_summary: Option<bool>,
+    pub(crate) allow_no_turbo_json: Option<bool>,
 }
 
 #[derive(Default)]
@@ -369,6 +370,10 @@ impl ConfigurationOptions {
         self.root_turbo_json_path
             .clone()
             .unwrap_or_else(|| repo_root.join_component(CONFIG_FILE))
+    }
+
+    pub fn allow_no_turbo_json(&self) -> bool {
+        self.allow_no_turbo_json.unwrap_or_default()
     }
 }
 

--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -17,6 +17,7 @@ use thiserror::Error;
 use turbo_json::TurboJsonReader;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_errors::TURBO_SITE;
+use turborepo_repository::package_graph::PackageName;
 
 pub use crate::turbo_json::{RawTurboJson, UIMode};
 use crate::{
@@ -179,6 +180,8 @@ pub enum Error {
         #[source_code]
         text: NamedSource,
     },
+    #[error("Cannot load turbo.json for in {0} single package mode")]
+    InvalidTurboJsonLoad(PackageName),
 }
 
 const DEFAULT_API_URL: &str = "https://vercel.com/api";

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -483,11 +483,6 @@ impl<'a> EngineBuilder<'a> {
     }
 
     fn load_turbo_json(&self, workspace: &PackageName) -> Result<TurboJson, Error> {
-        let package_json = self.package_graph.package_json(workspace).ok_or_else(|| {
-            Error::MissingPackageJson {
-                workspace: workspace.clone(),
-            }
-        })?;
         let workspace_dir =
             self.package_graph
                 .package_dir(workspace)
@@ -498,12 +493,7 @@ impl<'a> EngineBuilder<'a> {
             .repo_root
             .resolve(workspace_dir)
             .join_component(CONFIG_FILE);
-        Ok(TurboJson::load(
-            self.repo_root,
-            &workspace_turbo_json,
-            package_json,
-            self.is_single,
-        )?)
+        Ok(TurboJson::load(self.repo_root, &workspace_turbo_json)?)
     }
 }
 

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -369,23 +369,21 @@ impl<'a> EngineBuilder<'a> {
         task_name: &TaskName<'static>,
         task_id: &TaskId,
     ) -> Result<bool, Error> {
-        let turbo_json = loader
-            .load(workspace)
-            // If there was no turbo.json in the workspace, fallback to the root turbo.json
-            .map_or_else(
-                |e| {
-                    if matches!(e, config::Error::NoTurboJSON)
-                        && !matches!(workspace, PackageName::Root)
-                    {
-                        Ok(None)
-                    } else {
-                        Err(e)
-                    }
-                },
-                |v| Ok(Some(v)),
-            )?;
+        let turbo_json = loader.load(workspace).map_or_else(
+            |err| {
+                if matches!(err, config::Error::NoTurboJSON)
+                    && !matches!(workspace, PackageName::Root)
+                {
+                    Ok(None)
+                } else {
+                    Err(err)
+                }
+            },
+            |turbo_json| Ok(Some(turbo_json)),
+        )?;
 
         let Some(turbo_json) = turbo_json else {
+            // If there was no turbo.json in the workspace, fallback to the root turbo.json
             return Self::has_task_definition(loader, &PackageName::Root, task_name, task_id);
         };
 

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -21,7 +21,7 @@ use turborepo_repository::{
 };
 use turborepo_scm::package_deps::GitHashes;
 
-use crate::turbo_json::{TurboJson, CONFIG_FILE};
+use crate::turbo_json::{TurboJson, TurboJsonLoader, CONFIG_FILE};
 
 #[derive(Clone)]
 pub enum PackageChangeEvent {
@@ -162,8 +162,9 @@ impl Subscriber {
             return None;
         };
 
-        let root_turbo_json =
-            TurboJson::load(&self.repo_root, &self.repo_root.join_component(CONFIG_FILE)).ok();
+        let root_turbo_json = TurboJsonLoader::workspace(self.repo_root.clone())
+            .load(&self.repo_root.join_component(CONFIG_FILE))
+            .ok();
 
         let gitignore_path = self.repo_root.join_component(".gitignore");
         let (root_gitignore, _) = Gitignore::new(&gitignore_path);

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -21,7 +21,7 @@ use turborepo_repository::{
 };
 use turborepo_scm::package_deps::GitHashes;
 
-use crate::turbo_json::{package_turbo_jsons, TurboJson, TurboJsonLoader, CONFIG_FILE};
+use crate::turbo_json::{TurboJson, TurboJsonLoader, CONFIG_FILE};
 
 #[derive(Clone)]
 pub enum PackageChangeEvent {
@@ -169,16 +169,14 @@ impl Subscriber {
             return None;
         };
 
-        let package_turbo_jsons = package_turbo_jsons(
-            &self.repo_root,
+        let root_turbo_json = TurboJsonLoader::workspace(
+            self.repo_root.clone(),
             self.repo_root.join_component(CONFIG_FILE),
             pkg_dep_graph.packages(),
-        );
-        let root_turbo_json =
-            TurboJsonLoader::workspace(self.repo_root.clone(), package_turbo_jsons)
-                .load(&PackageName::Root)
-                .ok()
-                .cloned();
+        )
+        .load(&PackageName::Root)
+        .ok()
+        .cloned();
 
         let gitignore_path = self.repo_root.join_component(".gitignore");
         let (root_gitignore, _) = Gitignore::new(&gitignore_path);

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -177,7 +177,8 @@ impl Subscriber {
         let root_turbo_json =
             TurboJsonLoader::workspace(self.repo_root.clone(), package_turbo_jsons)
                 .load(&PackageName::Root)
-                .ok();
+                .ok()
+                .cloned();
 
         let gitignore_path = self.repo_root.join_component(".gitignore");
         let (root_gitignore, _) = Gitignore::new(&gitignore_path);

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -162,13 +162,8 @@ impl Subscriber {
             return None;
         };
 
-        let root_turbo_json = TurboJson::load(
-            &self.repo_root,
-            &self.repo_root.join_component(CONFIG_FILE),
-            &root_package_json,
-            false,
-        )
-        .ok();
+        let root_turbo_json =
+            TurboJson::load(&self.repo_root, &self.repo_root.join_component(CONFIG_FILE)).ok();
 
         let gitignore_path = self.repo_root.join_component(".gitignore");
         let (root_gitignore, _) = Gitignore::new(&gitignore_path);

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -21,7 +21,7 @@ use turborepo_repository::{
 };
 use turborepo_scm::package_deps::GitHashes;
 
-use crate::turbo_json::{TurboJson, TurboJsonLoader, CONFIG_FILE};
+use crate::turbo_json::{package_turbo_jsons, TurboJson, TurboJsonLoader, CONFIG_FILE};
 
 #[derive(Clone)]
 pub enum PackageChangeEvent {
@@ -161,14 +161,6 @@ impl Subscriber {
             tracing::debug!("no package.json found, package watcher not available");
             return None;
         };
-
-        let root_turbo_json = TurboJsonLoader::workspace(self.repo_root.clone())
-            .load(&self.repo_root.join_component(CONFIG_FILE))
-            .ok();
-
-        let gitignore_path = self.repo_root.join_component(".gitignore");
-        let (root_gitignore, _) = Gitignore::new(&gitignore_path);
-
         let Ok(pkg_dep_graph) = PackageGraphBuilder::new(&self.repo_root, root_package_json)
             .build()
             .await
@@ -176,6 +168,19 @@ impl Subscriber {
             tracing::debug!("package graph not available, package watcher not available");
             return None;
         };
+
+        let package_turbo_jsons = package_turbo_jsons(
+            &self.repo_root,
+            self.repo_root.join_component(CONFIG_FILE),
+            pkg_dep_graph.packages(),
+        );
+        let root_turbo_json =
+            TurboJsonLoader::workspace(self.repo_root.clone(), package_turbo_jsons)
+                .load(&PackageName::Root)
+                .ok();
+
+        let gitignore_path = self.repo_root.join_component(".gitignore");
+        let (root_gitignore, _) = Gitignore::new(&gitignore_path);
 
         Some((
             RepoState {

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -363,12 +363,15 @@ impl RunBuilder {
             .load_turbo_json(&self.root_turbo_json_path)
             .map_or_else(
                 || {
-                    TurboJson::load(
-                        &self.repo_root,
-                        &self.root_turbo_json_path,
-                        &root_package_json,
-                        is_single_package,
-                    )
+                    if is_single_package {
+                        TurboJson::from_root_package_json(
+                            &self.repo_root,
+                            &self.root_turbo_json_path,
+                            &root_package_json,
+                        )
+                    } else {
+                        TurboJson::load(&self.repo_root, &self.root_turbo_json_path)
+                    }
                 },
                 Result::Ok,
             )?;

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -37,7 +37,7 @@ use {
 };
 
 use crate::{
-    cli::{DryRunMode, EnvMode},
+    cli::DryRunMode,
     commands::CommandBase,
     engine::{Engine, EngineBuilder},
     opts::Opts,
@@ -375,9 +375,6 @@ impl RunBuilder {
                 root_package_json.clone(),
             )
         } else if self.allow_no_turbo_json && !self.root_turbo_json_path.exists() {
-            // We explicitly set env mode to loose as otherwise no env vars will be passed
-            // to tasks.
-            self.opts.run_opts.env_mode = EnvMode::Loose;
             TurboJsonLoader::workspace_no_turbo_json(
                 self.repo_root.clone(),
                 pkg_dep_graph.packages(),

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -359,7 +359,7 @@ impl RunBuilder {
         let task_access = TaskAccess::new(self.repo_root.clone(), async_cache.clone(), &scm);
         task_access.restore_config().await;
 
-        let turbo_json_loader = if task_access.is_enabled() {
+        let mut turbo_json_loader = if task_access.is_enabled() {
             TurboJsonLoader::task_access(
                 self.repo_root.clone(),
                 self.root_turbo_json_path.clone(),
@@ -380,7 +380,7 @@ impl RunBuilder {
             TurboJsonLoader::workspace(self.repo_root.clone(), package_turbo_jsons)
         };
 
-        let root_turbo_json = turbo_json_loader.load(&PackageName::Root)?;
+        let root_turbo_json = turbo_json_loader.load(&PackageName::Root)?.clone();
 
         pkg_dep_graph.validate()?;
 
@@ -464,11 +464,6 @@ impl RunBuilder {
             self.opts.run_opts.single_package,
         )
         .with_root_tasks(root_turbo_json.tasks.keys().cloned())
-        .with_turbo_jsons(Some(
-            Some((PackageName::Root, root_turbo_json.clone()))
-                .into_iter()
-                .collect(),
-        ))
         .with_tasks_only(self.opts.run_opts.only)
         .with_workspaces(filtered_pkgs.clone().into_iter().collect())
         .with_tasks(self.opts.run_opts.tasks.iter().map(|task| {

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -45,9 +45,7 @@ use crate::{
     run::{scope, task_access::TaskAccess, task_id::TaskName, Error, Run, RunCache},
     shim::TurboState,
     signal::{SignalHandler, SignalSubscriber},
-    turbo_json::{
-        package_turbo_jsons, workspace_package_scripts, TurboJson, TurboJsonLoader, UIMode,
-    },
+    turbo_json::{TurboJson, TurboJsonLoader, UIMode},
     DaemonConnector,
 };
 
@@ -377,18 +375,19 @@ impl RunBuilder {
                 root_package_json.clone(),
             )
         } else if self.allow_no_turbo_json && !self.root_turbo_json_path.exists() {
-            let package_scripts = workspace_package_scripts(pkg_dep_graph.packages());
             // We explicitly set env mode to loose as otherwise no env vars will be passed
             // to tasks.
             self.opts.run_opts.env_mode = EnvMode::Loose;
-            TurboJsonLoader::workspace_no_turbo_json(self.repo_root.clone(), package_scripts)
+            TurboJsonLoader::workspace_no_turbo_json(
+                self.repo_root.clone(),
+                pkg_dep_graph.packages(),
+            )
         } else {
-            let package_turbo_jsons = package_turbo_jsons(
-                &self.repo_root,
+            TurboJsonLoader::workspace(
+                self.repo_root.clone(),
                 self.root_turbo_json_path.clone(),
                 pkg_dep_graph.packages(),
-            );
-            TurboJsonLoader::workspace(self.repo_root.clone(), package_turbo_jsons)
+            )
         };
 
         let root_turbo_json = turbo_json_loader.load(&PackageName::Root)?.clone();

--- a/crates/turborepo-lib/src/run/summary/task.rs
+++ b/crates/turborepo-lib/src/run/summary/task.rs
@@ -104,6 +104,8 @@ pub struct TaskSummaryTaskDefinition {
     env: Vec<String>,
     pass_through_env: Option<Vec<String>>,
     interactive: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    env_mode: Option<EnvMode>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -279,6 +281,7 @@ impl From<TaskDefinition> for TaskSummaryTaskDefinition {
             output_logs,
             persistent,
             interactive,
+            env_mode,
         } = value;
 
         let mut outputs = inclusions;
@@ -313,6 +316,7 @@ impl From<TaskDefinition> for TaskSummaryTaskDefinition {
             interactive,
             env,
             pass_through_env,
+            env_mode,
         }
     }
 }

--- a/crates/turborepo-lib/src/run/task_access.rs
+++ b/crates/turborepo-lib/src/run/task_access.rs
@@ -7,13 +7,13 @@ use std::{
 
 use serde::Deserialize;
 use tracing::{debug, error, warn};
-use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, PathRelation};
+use turbopath::{AbsoluteSystemPathBuf, PathRelation};
 use turborepo_cache::AsyncCache;
 use turborepo_scm::SCM;
 use turborepo_unescape::UnescapedString;
 
 use super::ConfigCache;
-use crate::{config::RawTurboJson, gitignore::ensure_turbo_is_gitignored, turbo_json::TurboJson};
+use crate::{config::RawTurboJson, gitignore::ensure_turbo_is_gitignored};
 
 // Environment variable key that will be used to enable, and set the expected
 // trace location
@@ -243,25 +243,6 @@ impl TaskAccess {
         } else {
             Some(false)
         }
-    }
-
-    /// Attempt to load a task traced turbo.json
-    pub fn load_turbo_json(&self, root_turbo_json_path: &AbsoluteSystemPath) -> Option<TurboJson> {
-        if !self.enabled {
-            return None;
-        }
-        let trace_json_path = self.repo_root.join_components(&TASK_ACCESS_CONFIG_PATH);
-        let turbo_from_trace = TurboJson::read(&self.repo_root, &trace_json_path);
-
-        // check the zero config case (turbo trace file, but no turbo.json file)
-        if let Ok(turbo_from_trace) = turbo_from_trace {
-            if !root_turbo_json_path.exists() {
-                debug!("Using turbo.json synthesized from trace file");
-                return Some(turbo_from_trace);
-            }
-        }
-
-        None
     }
 
     async fn to_file(&self) -> Result<(), ToFileError> {

--- a/crates/turborepo-lib/src/task_graph/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/mod.rs
@@ -9,7 +9,7 @@ use turborepo_errors::Spanned;
 pub use visitor::{Error as VisitorError, Visitor};
 
 use crate::{
-    cli::OutputLogsMode,
+    cli::{EnvMode, OutputLogsMode},
     run::task_id::{TaskId, TaskName},
     turbo_json::RawTaskDefinition,
 };
@@ -76,6 +76,9 @@ pub struct TaskDefinition {
     // Tasks that take stdin input cannot be cached as their outputs may depend on the
     // input.
     pub interactive: bool,
+
+    // Override for global env mode setting
+    pub env_mode: Option<EnvMode>,
 }
 
 impl Default for TaskDefinition {
@@ -91,6 +94,7 @@ impl Default for TaskDefinition {
             output_logs: Default::default(),
             persistent: Default::default(),
             interactive: Default::default(),
+            env_mode: Default::default(),
         }
     }
 }

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -219,7 +219,7 @@ impl<'a> Visitor<'a> {
                 .task_definition(&info)
                 .ok_or(Error::MissingDefinition)?;
 
-            let task_env_mode = self.global_env_mode;
+            let task_env_mode = task_definition.env_mode.unwrap_or(self.global_env_mode);
             package_task_event.track_env_mode(&task_env_mode.to_string());
 
             let dependency_set = engine.dependencies(&info).ok_or(Error::MissingDefinition)?;

--- a/crates/turborepo-lib/src/turbo_json/loader.rs
+++ b/crates/turborepo-lib/src/turbo_json/loader.rs
@@ -1,9 +1,13 @@
+use tracing::debug;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_errors::Spanned;
 use turborepo_repository::package_json::PackageJson;
 
 use super::{Pipeline, RawTaskDefinition, TurboJson};
-use crate::{config::Error, run::task_id::TaskName};
+use crate::{
+    config::Error,
+    run::{task_access::TASK_ACCESS_CONFIG_PATH, task_id::TaskName},
+};
 
 /// Structure for loading TurboJson structures.
 /// Depending on the strategy used, TurboJson might not correspond to
@@ -18,6 +22,7 @@ pub struct TurboJsonLoader {
 enum Strategy {
     SinglePackage { package_json: PackageJson },
     Workspace,
+    TaskAccess { package_json: PackageJson },
 }
 
 impl TurboJsonLoader {
@@ -38,12 +43,24 @@ impl TurboJsonLoader {
         }
     }
 
+    /// Create a loader that will load a root turbo.json or synthesize one if
+    /// the file doesn't exist
+    pub fn task_access(repo_root: AbsoluteSystemPathBuf, package_json: PackageJson) -> Self {
+        Self {
+            repo_root,
+            strategy: Strategy::TaskAccess { package_json },
+        }
+    }
+
     pub fn load(&self, path: &AbsoluteSystemPath) -> Result<TurboJson, Error> {
         match &self.strategy {
             Strategy::SinglePackage { package_json } => {
                 load_from_root_package_json(&self.repo_root, path, package_json)
             }
             Strategy::Workspace => load_from_file(&self.repo_root, path),
+            Strategy::TaskAccess { package_json } => {
+                load_task_access_trace_turbo_json(&self.repo_root, path, package_json)
+            }
         }
     }
 }
@@ -122,16 +139,34 @@ fn load_from_root_package_json(
     Ok(turbo_json)
 }
 
+fn load_task_access_trace_turbo_json(
+    repo_root: &AbsoluteSystemPath,
+    turbo_json_path: &AbsoluteSystemPath,
+    root_package_json: &PackageJson,
+) -> Result<TurboJson, Error> {
+    let trace_json_path = repo_root.join_components(&TASK_ACCESS_CONFIG_PATH);
+    let turbo_from_trace = TurboJson::read(repo_root, &trace_json_path);
+
+    // check the zero config case (turbo trace file, but no turbo.json file)
+    if let Ok(turbo_from_trace) = turbo_from_trace {
+        if !turbo_json_path.exists() {
+            debug!("Using turbo.json synthesized from trace file");
+            return Ok(turbo_from_trace);
+        }
+    }
+    load_from_root_package_json(repo_root, turbo_json_path, root_package_json)
+}
+
 #[cfg(test)]
 mod test {
-    use std::fs;
+    use std::{collections::BTreeMap, fs};
 
     use anyhow::Result;
     use tempfile::tempdir;
     use test_case::test_case;
 
     use super::*;
-    use crate::turbo_json::CONFIG_FILE;
+    use crate::{task_graph::TaskDefinition, turbo_json::CONFIG_FILE};
 
     #[test_case(r"{}", TurboJson::default() ; "empty")]
     #[test_case(r#"{ "globalDependencies": ["tsconfig.json", "jest.config.js"] }"#,
@@ -235,6 +270,68 @@ mod test {
             task_definition.text = None;
         }
         assert_eq!(turbo_json, expected_turbo_json);
+
+        Ok(())
+    }
+
+    #[test_case(
+        Some(r#"{ "tasks": {"//#build": {"env": ["SPECIAL_VAR"]}} }"#),
+        Some(r#"{ "tasks": {"build": {"env": ["EXPLICIT_VAR"]}} }"#),
+        TaskDefinition { env: vec!["EXPLICIT_VAR".to_string()], .. Default::default() }
+    ; "both present")]
+    #[test_case(
+        None,
+        Some(r#"{ "tasks": {"build": {"env": ["EXPLICIT_VAR"]}} }"#),
+        TaskDefinition { env: vec!["EXPLICIT_VAR".to_string()], .. Default::default() }
+    ; "no trace")]
+    #[test_case(
+        Some(r#"{ "tasks": {"//#build": {"env": ["SPECIAL_VAR"]}} }"#),
+        None,
+        TaskDefinition { env: vec!["SPECIAL_VAR".to_string()], .. Default::default() }
+    ; "no turbo.json")]
+    #[test_case(
+        None,
+        None,
+        TaskDefinition { cache: false, .. Default::default() }
+    ; "both missing")]
+    fn test_task_access_loading(
+        trace_contents: Option<&str>,
+        turbo_json_content: Option<&str>,
+        expected_root_build: TaskDefinition,
+    ) -> Result<()> {
+        let root_dir = tempdir()?;
+        let repo_root = AbsoluteSystemPath::from_std_path(root_dir.path())?;
+
+        if let Some(content) = turbo_json_content {
+            repo_root
+                .join_component(CONFIG_FILE)
+                .create_with_contents(content.as_bytes())?;
+        }
+        if let Some(content) = trace_contents {
+            let trace_path = repo_root.join_components(&TASK_ACCESS_CONFIG_PATH);
+            trace_path.ensure_dir()?;
+            trace_path.create_with_contents(content.as_bytes())?;
+        }
+
+        let mut scripts = BTreeMap::new();
+        scripts.insert("build".into(), Spanned::new("echo building".into()));
+        let root_package_json = PackageJson {
+            scripts,
+            ..Default::default()
+        };
+
+        let loader = TurboJsonLoader::task_access(repo_root.to_owned(), root_package_json);
+        let turbo_json = loader.load(&repo_root.join_component(CONFIG_FILE))?;
+        let root_build = turbo_json
+            .tasks
+            .get(&TaskName::from("//#build"))
+            .expect("root build should always exist")
+            .as_inner();
+
+        assert_eq!(
+            expected_root_build,
+            TaskDefinition::try_from(root_build.clone())?
+        );
 
         Ok(())
     }

--- a/crates/turborepo-lib/src/turbo_json/loader.rs
+++ b/crates/turborepo-lib/src/turbo_json/loader.rs
@@ -1,0 +1,241 @@
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
+use turborepo_errors::Spanned;
+use turborepo_repository::package_json::PackageJson;
+
+use super::{Pipeline, RawTaskDefinition, TurboJson};
+use crate::{config::Error, run::task_id::TaskName};
+
+/// Structure for loading TurboJson structures.
+/// Depending on the strategy used, TurboJson might not correspond to
+/// `turbo.json` file.
+#[derive(Debug, Clone)]
+pub struct TurboJsonLoader {
+    repo_root: AbsoluteSystemPathBuf,
+    strategy: Strategy,
+}
+
+#[derive(Debug, Clone)]
+enum Strategy {
+    SinglePackage { package_json: PackageJson },
+    Workspace,
+}
+
+impl TurboJsonLoader {
+    /// Create a loader that will load turbo.json files throughout the workspace
+    pub fn workspace(repo_root: AbsoluteSystemPathBuf) -> Self {
+        Self {
+            repo_root,
+            strategy: Strategy::Workspace,
+        }
+    }
+
+    /// Create a loader that will load a root turbo.json or synthesize one if
+    /// the file doesn't exist
+    pub fn single_package(repo_root: AbsoluteSystemPathBuf, package_json: PackageJson) -> Self {
+        Self {
+            repo_root,
+            strategy: Strategy::SinglePackage { package_json },
+        }
+    }
+
+    pub fn load(&self, path: &AbsoluteSystemPath) -> Result<TurboJson, Error> {
+        match &self.strategy {
+            Strategy::SinglePackage { package_json } => {
+                load_from_root_package_json(&self.repo_root, path, package_json)
+            }
+            Strategy::Workspace => load_from_file(&self.repo_root, path),
+        }
+    }
+}
+
+fn load_from_file(
+    repo_root: &AbsoluteSystemPath,
+    turbo_json_path: &AbsoluteSystemPath,
+) -> Result<TurboJson, Error> {
+    match TurboJson::read(repo_root, turbo_json_path) {
+        // If the file didn't exist, throw a custom error here instead of propagating
+        Err(Error::Io(_)) => Err(Error::NoTurboJSON),
+        // There was an error, and we don't have any chance of recovering
+        // because we aren't synthesizing anything
+        Err(e) => Err(e),
+        // We're not synthesizing anything and there was no error, we're done
+        Ok(turbo) => Ok(turbo),
+    }
+}
+
+fn load_from_root_package_json(
+    repo_root: &AbsoluteSystemPath,
+    turbo_json_path: &AbsoluteSystemPath,
+    root_package_json: &PackageJson,
+) -> Result<TurboJson, Error> {
+    let mut turbo_json = match TurboJson::read(repo_root, turbo_json_path) {
+        // we're synthesizing, but we have a starting point
+        // Note: this will have to change to support task inference in a monorepo
+        // for now, we're going to error on any "root" tasks and turn non-root tasks into root
+        // tasks
+        Ok(mut turbo_json) => {
+            let mut pipeline = Pipeline::default();
+            for (task_name, task_definition) in turbo_json.tasks {
+                if task_name.is_package_task() {
+                    let (span, text) = task_definition.span_and_text("turbo.json");
+
+                    return Err(Error::PackageTaskInSinglePackageMode {
+                        task_id: task_name.to_string(),
+                        span,
+                        text,
+                    });
+                }
+
+                pipeline.insert(task_name.into_root_task(), task_definition);
+            }
+
+            turbo_json.tasks = pipeline;
+
+            turbo_json
+        }
+        // turbo.json doesn't exist, but we're going try to synthesize something
+        Err(Error::Io(_)) => TurboJson::default(),
+        // some other happened, we can't recover
+        Err(e) => {
+            return Err(e);
+        }
+    };
+
+    // TODO: Add location info from package.json
+    for script_name in root_package_json.scripts.keys() {
+        let task_name = TaskName::from(script_name.as_str());
+        if !turbo_json.has_task(&task_name) {
+            let task_name = task_name.into_root_task();
+            // Explicitly set cache to Some(false) in this definition
+            // so we can pretend it was set on purpose. That way it
+            // won't get clobbered by the merge function.
+            turbo_json.tasks.insert(
+                task_name,
+                Spanned::new(RawTaskDefinition {
+                    cache: Some(Spanned::new(false)),
+                    ..RawTaskDefinition::default()
+                }),
+            );
+        }
+    }
+
+    Ok(turbo_json)
+}
+
+#[cfg(test)]
+mod test {
+    use std::fs;
+
+    use anyhow::Result;
+    use tempfile::tempdir;
+    use test_case::test_case;
+
+    use super::*;
+    use crate::turbo_json::CONFIG_FILE;
+
+    #[test_case(r"{}", TurboJson::default() ; "empty")]
+    #[test_case(r#"{ "globalDependencies": ["tsconfig.json", "jest.config.js"] }"#,
+        TurboJson {
+            global_deps: vec!["jest.config.js".to_string(), "tsconfig.json".to_string()],
+            ..TurboJson::default()
+        }
+    ; "global dependencies (sorted)")]
+    #[test_case(r#"{ "globalPassThroughEnv": ["GITHUB_TOKEN", "AWS_SECRET_KEY"] }"#,
+        TurboJson {
+            global_pass_through_env: Some(vec!["AWS_SECRET_KEY".to_string(), "GITHUB_TOKEN".to_string()]),
+            ..TurboJson::default()
+        }
+    )]
+    #[test_case(r#"{ "//": "A comment"}"#, TurboJson::default() ; "faux comment")]
+    #[test_case(r#"{ "//": "A comment", "//": "Another comment" }"#, TurboJson::default() ; "two faux comments")]
+    fn test_get_root_turbo_no_synthesizing(
+        turbo_json_content: &str,
+        expected_turbo_json: TurboJson,
+    ) -> Result<()> {
+        let root_dir = tempdir()?;
+        let repo_root = AbsoluteSystemPath::from_std_path(root_dir.path())?;
+        fs::write(repo_root.join_component("turbo.json"), turbo_json_content)?;
+        let loader = TurboJsonLoader::workspace(repo_root.to_owned());
+
+        let mut turbo_json = loader.load(&repo_root.join_component(CONFIG_FILE))?;
+
+        turbo_json.text = None;
+        turbo_json.path = None;
+        assert_eq!(turbo_json, expected_turbo_json);
+
+        Ok(())
+    }
+
+    #[test_case(
+        None,
+        PackageJson {
+             scripts: [("build".to_string(), Spanned::new("echo build".to_string()))].into_iter().collect(),
+             ..PackageJson::default()
+        },
+        TurboJson {
+            tasks: Pipeline([(
+                "//#build".into(),
+                Spanned::new(RawTaskDefinition {
+                    cache: Some(Spanned::new(false)),
+                    ..RawTaskDefinition::default()
+                })
+              )].into_iter().collect()
+            ),
+            ..TurboJson::default()
+        }
+    )]
+    #[test_case(
+        Some(r#"{
+            "tasks": {
+                "build": {
+                    "cache": true
+                }
+            }
+        }"#),
+        PackageJson {
+             scripts: [("test".to_string(), Spanned::new("echo test".to_string()))].into_iter().collect(),
+             ..PackageJson::default()
+        },
+        TurboJson {
+            tasks: Pipeline([(
+                "//#build".into(),
+                Spanned::new(RawTaskDefinition {
+                    cache: Some(Spanned::new(true).with_range(81..85)),
+                    ..RawTaskDefinition::default()
+                }).with_range(50..103)
+            ),
+            (
+                "//#test".into(),
+                Spanned::new(RawTaskDefinition {
+                     cache: Some(Spanned::new(false)),
+                    ..RawTaskDefinition::default()
+                })
+            )].into_iter().collect()),
+            ..TurboJson::default()
+        }
+    )]
+    fn test_get_root_turbo_with_synthesizing(
+        turbo_json_content: Option<&str>,
+        root_package_json: PackageJson,
+        expected_turbo_json: TurboJson,
+    ) -> Result<()> {
+        let root_dir = tempdir()?;
+        let repo_root = AbsoluteSystemPath::from_std_path(root_dir.path())?;
+
+        if let Some(content) = turbo_json_content {
+            fs::write(repo_root.join_component("turbo.json"), content)?;
+        }
+
+        let loader = TurboJsonLoader::single_package(repo_root.to_owned(), root_package_json);
+        let mut turbo_json = loader.load(&repo_root.join_component(CONFIG_FILE))?;
+        turbo_json.text = None;
+        turbo_json.path = None;
+        for (_, task_definition) in turbo_json.tasks.iter_mut() {
+            task_definition.path = None;
+            task_definition.text = None;
+        }
+        assert_eq!(turbo_json, expected_turbo_json);
+
+        Ok(())
+    }
+}

--- a/crates/turborepo-lib/src/turbo_json/loader.rs
+++ b/crates/turborepo-lib/src/turbo_json/loader.rs
@@ -10,6 +10,7 @@ use turborepo_repository::{
 
 use super::{Pipeline, RawTaskDefinition, TurboJson, CONFIG_FILE};
 use crate::{
+    cli::EnvMode,
     config::Error,
     run::{task_access::TASK_ACCESS_CONFIG_PATH, task_id::TaskName},
 };
@@ -298,6 +299,7 @@ fn root_turbo_json_from_scripts(scripts: &[String]) -> Result<TurboJson, Error> 
             task_name,
             Spanned::new(RawTaskDefinition {
                 cache: Some(Spanned::new(false)),
+                env_mode: Some(EnvMode::Loose),
                 ..Default::default()
             }),
         );
@@ -316,6 +318,7 @@ fn workspace_turbo_json_from_scripts(scripts: &[String]) -> Result<TurboJson, Er
             task_name,
             Spanned::new(RawTaskDefinition {
                 cache: Some(Spanned::new(false)),
+                env_mode: Some(EnvMode::Loose),
                 ..Default::default()
             }),
         );

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -224,6 +224,10 @@ pub struct RawTaskDefinition {
     output_logs: Option<Spanned<OutputLogsMode>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     interactive: Option<Spanned<bool>>,
+    // TODO: Remove this once we have the ability to load task definitions directly
+    // instead of deriving them from a TurboJson
+    #[serde(skip)]
+    env_mode: Option<EnvMode>,
 }
 
 macro_rules! set_field {
@@ -256,6 +260,7 @@ impl RawTaskDefinition {
         set_field!(self, other, env);
         set_field!(self, other, pass_through_env);
         set_field!(self, other, interactive);
+        set_field!(self, other, env_mode);
     }
 }
 
@@ -404,6 +409,7 @@ impl TryFrom<RawTaskDefinition> for TaskDefinition {
             output_logs: *raw_task.output_logs.unwrap_or_default(),
             persistent: *raw_task.persistent.unwrap_or_default(),
             interactive,
+            env_mode: raw_task.env_mode,
         })
     }
 }
@@ -726,6 +732,7 @@ mod tests {
             output_logs: Some(Spanned::new(OutputLogsMode::Full).with_range(246..252)),
             persistent: Some(Spanned::new(true).with_range(278..282)),
             interactive: Some(Spanned::new(true).with_range(309..313)),
+            env_mode: None,
         },
         TaskDefinition {
           env: vec!["OS".to_string()],
@@ -741,6 +748,7 @@ mod tests {
           topological_dependencies: vec![],
           persistent: true,
           interactive: true,
+          env_mode: None,
         }
       ; "full"
     )]
@@ -765,6 +773,7 @@ mod tests {
             output_logs: Some(Spanned::new(OutputLogsMode::Full).with_range(279..285)),
             persistent: Some(Spanned::new(true).with_range(315..319)),
             interactive: None,
+            env_mode: None,
         },
         TaskDefinition {
             env: vec!["OS".to_string()],
@@ -780,6 +789,7 @@ mod tests {
             topological_dependencies: vec![],
             persistent: true,
             interactive: false,
+            env_mode: None,
         }
       ; "full (windows)"
     )]

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -28,7 +28,7 @@ use crate::{
 mod loader;
 pub mod parser;
 
-pub use loader::{package_turbo_jsons, workspace_package_scripts, TurboJsonLoader};
+pub use loader::TurboJsonLoader;
 
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone, Deserializable)]
 #[serde(rename_all = "camelCase")]

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -28,7 +28,7 @@ use crate::{
 mod loader;
 pub mod parser;
 
-pub use loader::{package_turbo_jsons, TurboJsonLoader};
+pub use loader::{package_turbo_jsons, workspace_package_scripts, TurboJsonLoader};
 
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone, Deserializable)]
 #[serde(rename_all = "camelCase")]

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -28,7 +28,7 @@ use crate::{
 mod loader;
 pub mod parser;
 
-pub use loader::TurboJsonLoader;
+pub use loader::{package_turbo_jsons, TurboJsonLoader};
 
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone, Deserializable)]
 #[serde(rename_all = "camelCase")]

--- a/turborepo-tests/integration/fixtures/monorepo_no_turbo_json/.gitignore
+++ b/turborepo-tests/integration/fixtures/monorepo_no_turbo_json/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.turbo
+.npmrc

--- a/turborepo-tests/integration/fixtures/monorepo_no_turbo_json/apps/my-app/package.json
+++ b/turborepo-tests/integration/fixtures/monorepo_no_turbo_json/apps/my-app/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "my-app",
+  "scripts": {
+    "build": "echo building",
+    "test": "echo $MY_VAR"
+  },
+  "dependencies": {
+    "util": "*"
+  }
+}

--- a/turborepo-tests/integration/fixtures/monorepo_no_turbo_json/bar.txt
+++ b/turborepo-tests/integration/fixtures/monorepo_no_turbo_json/bar.txt
@@ -1,0 +1,1 @@
+other file, not a global dependency

--- a/turborepo-tests/integration/fixtures/monorepo_no_turbo_json/foo.txt
+++ b/turborepo-tests/integration/fixtures/monorepo_no_turbo_json/foo.txt
@@ -1,0 +1,1 @@
+global dep! all tasks depend on this content!

--- a/turborepo-tests/integration/fixtures/monorepo_no_turbo_json/package.json
+++ b/turborepo-tests/integration/fixtures/monorepo_no_turbo_json/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "monorepo",
+  "scripts": {
+    "something": "turbo run build"
+  },
+  "packageManager": "bower",
+  "workspaces": [
+    "apps/**",
+    "packages/**"
+  ]
+}

--- a/turborepo-tests/integration/fixtures/monorepo_no_turbo_json/packages/another/package.json
+++ b/turborepo-tests/integration/fixtures/monorepo_no_turbo_json/packages/another/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "another",
+  "scripts": {}
+}

--- a/turborepo-tests/integration/fixtures/monorepo_no_turbo_json/packages/util/package.json
+++ b/turborepo-tests/integration/fixtures/monorepo_no_turbo_json/packages/util/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "util",
+  "scripts": {
+    "build": "echo building"
+  }
+}

--- a/turborepo-tests/integration/tests/run/allow-no-root-turbo.t
+++ b/turborepo-tests/integration/tests/run/allow-no-root-turbo.t
@@ -1,0 +1,50 @@
+Setup
+  $ . ${TESTDIR}/../../../helpers/setup_integration_test.sh monorepo_no_turbo_json
+
+Run fails if not configured to allow missing turbo.json
+  $ ${TURBO} test
+    x Could not find turbo.json.
+    | Follow directions at https://turbo.build/repo/docs to create one
+  
+  [1]
+Runs test tasks
+  $ MY_VAR=foo ${TURBO} test --experimental-allow-no-turbo-json
+  \xe2\x80\xa2 Packages in scope: another, my-app, util (esc)
+  \xe2\x80\xa2 Running test in 3 packages (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
+  my-app:test: cache bypass, force executing ac1233e4c102becc
+  my-app:test: 
+  my-app:test: > test
+  my-app:test: > echo $MY_VAR
+  my-app:test: 
+  my-app:test: foo
+  
+   Tasks:    1 successful, 1 total
+  Cached:    0 cached, 1 total
+    Time:\s*[\.0-9]+m?s  (re)
+  
+
+
+Ensure caching is disabled
+  $ MY_VAR=foo ${TURBO} test --experimental-allow-no-turbo-json
+  \xe2\x80\xa2 Packages in scope: another, my-app, util (esc)
+  \xe2\x80\xa2 Running test in 3 packages (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
+  my-app:test: cache bypass, force executing ac1233e4c102becc
+  my-app:test: 
+  my-app:test: > test
+  my-app:test: > echo $MY_VAR
+  my-app:test: 
+  my-app:test: foo
+  
+   Tasks:    1 successful, 1 total
+  Cached:    0 cached, 1 total
+    Time:\s*[\.0-9]+m?s  (re)
+  
+Finds all tasks based on scripts
+  $ TURBO_ALLOW_NO_TURBO_JSON=true ${TURBO} build test --dry=json | jq '.tasks | map(.taskId)| sort'
+  [
+    "my-app#build",
+    "my-app#test",
+    "util#build"
+  ]

--- a/turborepo-tests/integration/tests/run/allow-no-root-turbo.t
+++ b/turborepo-tests/integration/tests/run/allow-no-root-turbo.t
@@ -12,7 +12,7 @@ Runs test tasks
   \xe2\x80\xa2 Packages in scope: another, my-app, util (esc)
   \xe2\x80\xa2 Running test in 3 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:test: cache bypass, force executing ac1233e4c102becc
+  my-app:test: cache bypass, force executing d80016a1a60c4c0a
   my-app:test: 
   my-app:test: > test
   my-app:test: > echo $MY_VAR
@@ -30,7 +30,7 @@ Ensure caching is disabled
   \xe2\x80\xa2 Packages in scope: another, my-app, util (esc)
   \xe2\x80\xa2 Running test in 3 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:test: cache bypass, force executing ac1233e4c102becc
+  my-app:test: cache bypass, force executing d80016a1a60c4c0a
   my-app:test: 
   my-app:test: > test
   my-app:test: > echo $MY_VAR


### PR DESCRIPTION
### Description

This PR adds the ability to use `turbo` in a monorepo that doesn't have a `turbo.json`. This feature is currently gated behind `--experimental-allow-no-turbo-json`/`TURBO_ALLOW_NO_TURBO_JSON`.

A majority of the PR is refactoring the `EngineBuilder` so that it no longer directly loads `TurboJson`s, but delegates to a `TurboJsonLoader`. This allows us to use different strategies for resolving `TurboJson` loads depending on runtime options e.g. single package mode or task access.

Reviewing this PR is best done by viewing each commit individually.

### Testing Instructions

Unit testing for `turbo.json` loading changes.

Integration test for verifying the new loader is activated with the new env var/flag.
