### PR TITLE
feat(env mode): allow for tasks to override the global env mode

### DIFF
--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -37,7 +37,7 @@ use {
 };
 
 use crate::{
-    cli::{DryRunMode, EnvMode},
+    cli::DryRunMode,
     commands::CommandBase,
     engine::{Engine, EngineBuilder},
     opts::Opts,
@@ -375,9 +375,6 @@ impl RunBuilder {
                 root_package_json.clone(),
             )
         } else if self.allow_no_turbo_json && !self.root_turbo_json_path.exists() {
-            // We explicitly set env mode to loose as otherwise no env vars will be passed
-            // to tasks.
-            self.opts.run_opts.env_mode = EnvMode::Loose;
             TurboJsonLoader::workspace_no_turbo_json(
                 self.repo_root.clone(),
                 pkg_dep_graph.packages(),

--- a/crates/turborepo-lib/src/run/summary/task.rs
+++ b/crates/turborepo-lib/src/run/summary/task.rs
@@ -104,6 +104,8 @@ pub struct TaskSummaryTaskDefinition {
     env: Vec<String>,
     pass_through_env: Option<Vec<String>>,
     interactive: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    env_mode: Option<EnvMode>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -279,6 +281,7 @@ impl From<TaskDefinition> for TaskSummaryTaskDefinition {
             output_logs,
             persistent,
             interactive,
+            env_mode,
         } = value;
 
         let mut outputs = inclusions;
@@ -313,6 +316,7 @@ impl From<TaskDefinition> for TaskSummaryTaskDefinition {
             interactive,
             env,
             pass_through_env,
+            env_mode,
         }
     }
 }

--- a/crates/turborepo-lib/src/task_graph/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/mod.rs
@@ -9,7 +9,7 @@ use turborepo_errors::Spanned;
 pub use visitor::{Error as VisitorError, Visitor};
 
 use crate::{
-    cli::OutputLogsMode,
+    cli::{EnvMode, OutputLogsMode},
     run::task_id::{TaskId, TaskName},
     turbo_json::RawTaskDefinition,
 };
@@ -76,6 +76,9 @@ pub struct TaskDefinition {
     // Tasks that take stdin input cannot be cached as their outputs may depend on the
     // input.
     pub interactive: bool,
+
+    // Override for global env mode setting
+    pub env_mode: Option<EnvMode>,
 }
 
 impl Default for TaskDefinition {
@@ -91,6 +94,7 @@ impl Default for TaskDefinition {
             output_logs: Default::default(),
             persistent: Default::default(),
             interactive: Default::default(),
+            env_mode: Default::default(),
         }
     }
 }

--- a/crates/turborepo-lib/src/task_graph/visitor.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor.rs
@@ -219,7 +219,7 @@ impl<'a> Visitor<'a> {
                 .task_definition(&info)
                 .ok_or(Error::MissingDefinition)?;
 
-            let task_env_mode = self.global_env_mode;
+            let task_env_mode = task_definition.env_mode.unwrap_or(self.global_env_mode);
             package_task_event.track_env_mode(&task_env_mode.to_string());
 
             let dependency_set = engine.dependencies(&info).ok_or(Error::MissingDefinition)?;

--- a/crates/turborepo-lib/src/turbo_json/loader.rs
+++ b/crates/turborepo-lib/src/turbo_json/loader.rs
@@ -10,6 +10,7 @@ use turborepo_repository::{
 
 use super::{Pipeline, RawTaskDefinition, TurboJson, CONFIG_FILE};
 use crate::{
+    cli::EnvMode,
     config::Error,
     run::{task_access::TASK_ACCESS_CONFIG_PATH, task_id::TaskName},
 };
@@ -298,6 +299,7 @@ fn root_turbo_json_from_scripts(scripts: &[String]) -> Result<TurboJson, Error> 
             task_name,
             Spanned::new(RawTaskDefinition {
                 cache: Some(Spanned::new(false)),
+                env_mode: Some(EnvMode::Loose),
                 ..Default::default()
             }),
         );
@@ -316,6 +318,7 @@ fn workspace_turbo_json_from_scripts(scripts: &[String]) -> Result<TurboJson, Er
             task_name,
             Spanned::new(RawTaskDefinition {
                 cache: Some(Spanned::new(false)),
+                env_mode: Some(EnvMode::Loose),
                 ..Default::default()
             }),
         );

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -224,6 +224,10 @@ pub struct RawTaskDefinition {
     output_logs: Option<Spanned<OutputLogsMode>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     interactive: Option<Spanned<bool>>,
+    // TODO: Remove this once we have the ability to load task definitions directly
+    // instead of deriving them from a TurboJson
+    #[serde(skip)]
+    env_mode: Option<EnvMode>,
 }
 
 macro_rules! set_field {
@@ -256,6 +260,7 @@ impl RawTaskDefinition {
         set_field!(self, other, env);
         set_field!(self, other, pass_through_env);
         set_field!(self, other, interactive);
+        set_field!(self, other, env_mode);
     }
 }
 
@@ -404,6 +409,7 @@ impl TryFrom<RawTaskDefinition> for TaskDefinition {
             output_logs: *raw_task.output_logs.unwrap_or_default(),
             persistent: *raw_task.persistent.unwrap_or_default(),
             interactive,
+            env_mode: raw_task.env_mode,
         })
     }
 }
@@ -726,6 +732,7 @@ mod tests {
             output_logs: Some(Spanned::new(OutputLogsMode::Full).with_range(246..252)),
             persistent: Some(Spanned::new(true).with_range(278..282)),
             interactive: Some(Spanned::new(true).with_range(309..313)),
+            env_mode: None,
         },
         TaskDefinition {
           env: vec!["OS".to_string()],
@@ -741,6 +748,7 @@ mod tests {
           topological_dependencies: vec![],
           persistent: true,
           interactive: true,
+          env_mode: None,
         }
       ; "full"
     )]
@@ -765,6 +773,7 @@ mod tests {
             output_logs: Some(Spanned::new(OutputLogsMode::Full).with_range(279..285)),
             persistent: Some(Spanned::new(true).with_range(315..319)),
             interactive: None,
+            env_mode: None,
         },
         TaskDefinition {
             env: vec!["OS".to_string()],
@@ -780,6 +789,7 @@ mod tests {
             topological_dependencies: vec![],
             persistent: true,
             interactive: false,
+            env_mode: None,
         }
       ; "full (windows)"
     )]

--- a/turborepo-tests/integration/tests/run/allow-no-root-turbo.t
+++ b/turborepo-tests/integration/tests/run/allow-no-root-turbo.t
@@ -12,7 +12,7 @@ Runs test tasks
   \xe2\x80\xa2 Packages in scope: another, my-app, util (esc)
   \xe2\x80\xa2 Running test in 3 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:test: cache bypass, force executing ac1233e4c102becc
+  my-app:test: cache bypass, force executing d80016a1a60c4c0a
   my-app:test: 
   my-app:test: > test
   my-app:test: > echo $MY_VAR
@@ -30,7 +30,7 @@ Ensure caching is disabled
   \xe2\x80\xa2 Packages in scope: another, my-app, util (esc)
   \xe2\x80\xa2 Running test in 3 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:test: cache bypass, force executing ac1233e4c102becc
+  my-app:test: cache bypass, force executing d80016a1a60c4c0a
   my-app:test: 
   my-app:test: > test
   my-app:test: > echo $MY_VAR


### PR DESCRIPTION
### Description

In response to https://github.com/vercel/turborepo/pull/9149#discussion_r1761805304 this PR avoids mutating `opts` when building `Run` we now set env mode at the task level.

A majority of this PR is adding the ability to set env mode at the task level.

### Testing Instructions

Updated integration test (update needed as task hash changed since env mode is now set at the task level instead of the global level).
