### PR TITLE
docs: add -w flag to pnpm example

### DIFF
--- a/docs/repo-docs/getting-started/add-to-existing-repository.mdx
+++ b/docs/repo-docs/getting-started/add-to-existing-repository.mdx
@@ -69,7 +69,7 @@ We recommend you install `turbo` both globally and into your repository's root f
     # Global install
     pnpm add turbo --global
     # Install in repository
-    pnpm add turbo --save-dev
+    pnpm add turbo --save-dev -w
     ```
 
   </Tab>

--- a/docs/repo-docs/getting-started/add-to-existing-repository.mdx
+++ b/docs/repo-docs/getting-started/add-to-existing-repository.mdx
@@ -69,7 +69,7 @@ We recommend you install `turbo` both globally and into your repository's root f
     # Global install
     pnpm add turbo --global
     # Install in repository
-    pnpm add turbo --save-dev -w
+    pnpm add turbo --save-dev --workspace-root
     ```
 
   </Tab>


### PR DESCRIPTION
It's suggested to install this into the repository root. If you do this, you must use `--workspace-root` flag or you will get this error:


>  ERR_PNPM_ADDING_TO_ROOT  Running this command will add the dependency to the workspace root, which might not be what you want - if you really meant it, make it explicit by running this command again with the -w flag (or --workspace-root). If you don't want to see this warning anymore, you may set the ignore-workspace-root-check setting to true.
