### PR TITLE
Docs: fix line location for TURBO_TEAM env

### DIFF
--- a/docs/repo-docs/reference/run.mdx
+++ b/docs/repo-docs/reference/run.mdx
@@ -518,11 +518,11 @@ turbo run build --team=my-team
 turbo run build --team=my-team --token=xxxxxxxxxxxxxxxxx
 ```
 
+This value can also be set using [the `TURBO_TEAM` system variable](/repo/docs/reference/system-environment-variables). If both are present, the flag value will override the system variable.
+
 ### `--ui`
 
 Specify the UI to use for output. Accepts `stream` or `tui`.
-
-This value can also be set using [the `TURBO_TEAM` system variable](/repo/docs/reference/system-environment-variables). If both are present, the flag value will override the system variable.
 
 ### `--verbosity`
 


### PR DESCRIPTION
### Description

The "UI" section was added at the wrong place in the documentation