### PR TITLE
Update using-environment-variables.mdx formatting to remove extra p tag

### DIFF
--- a/docs/repo-docs/crafting-your-repository/using-environment-variables.mdx
+++ b/docs/repo-docs/crafting-your-repository/using-environment-variables.mdx
@@ -63,9 +63,7 @@ Turborepo automatically adds prefix wildcards to your [`env`](/repo/docs/referen
     <tr>
       <th>Framework</th>
       <th>
-        <span>
-          <code>env</code> wildcards
-        </span>
+        <span><code>env</code> wildcards</span>
       </th>
     </tr>
   </thead>


### PR DESCRIPTION
### Description

The formatter hurt us here.  Here's what I originally wrote and tested:

| Code | Website | DOM |
| - | - | - |
| ![Screenshot_20240918_184346](https://github.com/user-attachments/assets/cde68cb0-10bf-4b12-908f-8a998d886f51) | ![Screenshot_20240918_184612](https://github.com/user-attachments/assets/a9290436-2bec-4031-bf1b-7155ae498ca8) | ![Screenshot_20240918_184433](https://github.com/user-attachments/assets/d60ae9a9-e0f4-432e-901e-ade4d880ad5e) |

But here's what happens with this seemingly insignificant formatting change that I wasn't aware would affect the rendered output and didn't test.

| Code | Website | DOM |
| - | - | - |
| ![Screenshot_20240918_184037](https://github.com/user-attachments/assets/fe4fcf6f-047b-4884-8fe4-80a30db3a9af) | ![Screenshot_20240918_184659](https://github.com/user-attachments/assets/45038303-8dba-49f7-a153-f69c4740c8c7) | ![Screenshot_20240918_184235](https://github.com/user-attachments/assets/20187da0-6e80-44e5-8e65-520d93ec691e) |

See what happens?  An extra `p` tag gets shoved in there when it's formatted.  No idea why.  Sounds like a bug in the markdown renderer, honestly.

### Testing Instructions

Check the preview link.
