### PR TITLE
docs: Task outputs clarifications

### DIFF
--- a/docs/repo-docs/crafting-your-repository/caching.mdx
+++ b/docs/repo-docs/crafting-your-repository/caching.mdx
@@ -127,6 +127,8 @@ Turborepo caches two types of outputs: Task outputs and Logs.
 
 Turborepo caches the file outputs of a task that are defined in [the `outputs` key](/repo/docs/reference/configuration#outputs) of `turbo.json`. When there's a cache hit, Turborepo will restore the files from the cache.
 
+The `outputs` key is optional, see [the API reference](/repo/docs/reference/configuration#outputs) for how Turborepo behaves in this case.
+
 <Callout type="warn" title="Providing file outputs">
 If you do not declare file outputs for a task, Turborepo will not cache them. This might be okay for some tasks (like linters) - but many tasks produce files that you will want to be cached.
 

--- a/docs/repo-docs/crafting-your-repository/caching.mdx
+++ b/docs/repo-docs/crafting-your-repository/caching.mdx
@@ -121,6 +121,8 @@ For information on how to connect your CI machines to Remote Cache, visit [the C
 
 ## What gets cached?
 
+Turborepo caches two types of outputs: Task outputs and Logs.
+
 ### Task outputs
 
 Turborepo caches the file outputs of a task that are defined in [the `outputs` key](/repo/docs/reference/configuration#outputs) of `turbo.json`. When there's a cache hit, Turborepo will restore the files from the cache.

--- a/docs/repo-docs/crafting-your-repository/configuring-tasks.mdx
+++ b/docs/repo-docs/crafting-your-repository/configuring-tasks.mdx
@@ -172,7 +172,7 @@ Some tasks may not have any dependencies. For example, a task for finding typos 
   tasks are properly configured first.
 </Callout>
 
-The `outputs` key tells Turborepo **files and directories** it should cache when the task has successfully completed. **Without this key defined, Turborepo will not cache any files. Hitting cache on subsequent runs will not restore any file outputs.**
+The `outputs` key tells Turborepo **files and directories** it should cache when the task has successfully completed.
 
 Below are a few examples of outputs for common tools:
 
@@ -214,6 +214,8 @@ Below are a few examples of outputs for common tools:
 </Tabs>
 
 For more on building globbing patterns for the `outputs` key, see [the globbing specification](/repo/docs/reference/globs).
+
+The `outputs` key is optional, see [the API reference](/repo/docs/reference/configuration#outputs) for how Turborepo behaves in this case.
 
 ### Specifying `inputs`
 

--- a/docs/repo-docs/crafting-your-repository/configuring-tasks.mdx
+++ b/docs/repo-docs/crafting-your-repository/configuring-tasks.mdx
@@ -172,7 +172,7 @@ Some tasks may not have any dependencies. For example, a task for finding typos 
   tasks are properly configured first.
 </Callout>
 
-The `outputs` key tells Turborepo **files and directories** it should cache when the task has successfully completed.
+The `outputs` key tells Turborepo **files and directories** it should cache when the task has successfully completed. **Without this key defined, Turborepo will not cache any files. Hitting cache on subsequent runs will not restore any file outputs.**
 
 Below are a few examples of outputs for common tools:
 
@@ -214,8 +214,6 @@ Below are a few examples of outputs for common tools:
 </Tabs>
 
 For more on building globbing patterns for the `outputs` key, see [the globbing specification](/repo/docs/reference/globs).
-
-The `outputs` key is optional, see [the API reference](/repo/docs/reference/configuration#outputs) for how Turborepo behaves in this case.
 
 ### Specifying `inputs`
 

--- a/docs/repo-docs/reference/configuration.mdx
+++ b/docs/repo-docs/reference/configuration.mdx
@@ -352,17 +352,6 @@ A list of file glob patterns relative to the package's `package.json` to cache w
 
 Omitting this key or passing an empty array tells `turbo` to cache nothing (except logs, which are always cached when caching is enabled).
 
-```jsonc title="./turbo.json"
-{
-  "tasks": {
-    "lint": {
-      // Typically, linters don't generate a file, so there are none to cache.
-      "outputs": [] // or could be omitted
-    }
-  }
-}
-```
-
 ### `cache`
 
 Default: `true`

--- a/docs/repo-docs/reference/configuration.mdx
+++ b/docs/repo-docs/reference/configuration.mdx
@@ -339,14 +339,25 @@ An allowlist of environment variables that should be made available to this task
 
 A list of file glob patterns relative to the package's `package.json` to cache when the task is successfully completed.
 
-Omitting this key or passing an empty array tells `turbo` to cache nothing (except logs, which are always cached when caching is enabled).
-
 ```jsonc title="./turbo.json"
 {
   "tasks": {
     "build": {
       // Cache all files emitted to the packages's `dist` directory
       "outputs": ["dist/**"]
+    }
+  }
+}
+```
+
+Omitting this key or passing an empty array tells `turbo` to cache nothing (except logs, which are always cached when caching is enabled).
+
+```jsonc title="./turbo.json"
+{
+  "tasks": {
+    "lint": {
+      // Typically, linters don't generate a file, so there are none to cache.
+      "outputs": [] // or could be omitted
     }
   }
 }


### PR DESCRIPTION
To avoid the impression that cache is disabled when Task `outputs` key is ommitted.

`API reference` was more accurate for that behavior, than `Crafting your repository`.

### Description

I'm new to Turborepo, and was reading [Crafting your repository](https://turbo.build/repo/docs/crafting-your-repository). Two sections lead me to conclude that when there is no `outputs` key in a Task, then caching is disabled. I think the wording in `API reference` is better.

We have to account for Logs output even if there are no file outputs (which is really nice for linters).

### Testing Instructions

* Review the modified documentations.
* Take into account that I'm not a native english speaker (you probably notice already ;) )
