### PR TITLE
base.json is extended by other tsconfig.json, not package.json

### DIFF
--- a/docs/repo-docs/guides/tools/typescript.mdx
+++ b/docs/repo-docs/guides/tools/typescript.mdx
@@ -56,7 +56,7 @@ pnpm dlx create-turbo@latest
 
 ### Use a base `tsconfig` file
 
-Inside `packages/tsconfig`, we have a few `json` files which represent different ways you might want to configure TypeScript in various packages. The `base.json` file is extended by every other `package.json` in the workspace and looks like this:
+Inside `packages/tsconfig`, we have a few `json` files which represent different ways you might want to configure TypeScript in various packages. The `base.json` file is extended by every other `tsconfig.json` in the workspace and looks like this:
 
 ```json title="./packages/tsconfig/base.json"
 "compilerOptions": {


### PR DESCRIPTION
### Description

In [Use a base tsconfig file](https://turbo.build/repo/docs/guides/tools/typescript#use-a-base-tsconfig-file), it is state that `base.json`, a TypeScript config file, is extended by every other `package.json`. I guess we should say extended by every other `tsconfig.json` in the workspace.
