### PR TITLE
docs: grammar error

### DIFF
--- a/docs/repo-docs/crafting-your-repository/caching.mdx
+++ b/docs/repo-docs/crafting-your-repository/caching.mdx
@@ -7,7 +7,7 @@ import { Step, Steps } from '#/components/steps';
 import { PackageManagerTabs, Tab } from '#/components/tabs';
 import { Callout } from '#/components/callout';
 
-Turborepo uses caching to speed up builds, ensuring you **never do the same work twice**. When your task is cacheable, Turborepo will restore the results of your task from cache using a fingerprint from the first time the task was ran.
+Turborepo uses caching to speed up builds, ensuring you **never do the same work twice**. When your task is cacheable, Turborepo will restore the results of your task from cache using a fingerprint from the first time the task ran.
 
 ![12 tasks are being ran in 3 packages, resulting in a ">>> FULL TURBO" cache hit. The total time it takes to restore these tasks from cache is 80 milliseconds.](/images/docs/why-turborepo-solution.png)
 
@@ -134,7 +134,7 @@ If you're running into errors with files not being available when you hit cache,
 
 ### Logs
 
-Turborepo always captures the terminal outputs of your tasks, restoring those logs to your terminal from the first time that the task was ran.
+Turborepo always captures the terminal outputs of your tasks, restoring those logs to your terminal from the first time that the task ran.
 
 You can configure the verbosity of the replayed logs using [the `--output-logs` flag](/repo/docs/reference/run#--output-logs-option) or [`outputLogs` configuration option](/repo/docs/reference/configuration#outputlogs).
 


### PR DESCRIPTION
### Description

Just happened to notice this grammatical error when reading the docs: "from the first time the task was run" and "the first time the task ran" are both good, but "was ran" is not grammatical with the "was" auxiliary.
