### PR TITLE
feat(query): add `currentRun` field to `turbo query`

### DIFF
--- a/crates/turborepo-lib/src/commands/query.rs
+++ b/crates/turborepo-lib/src/commands/query.rs
@@ -100,7 +100,7 @@ pub async fn run(
             }
         }
     } else {
-        query::run_server(run, handler).await?;
+        query::run_query_server(run, handler).await?;
     }
 
     Ok(0)

--- a/crates/turborepo-lib/src/query/server.rs
+++ b/crates/turborepo-lib/src/query/server.rs
@@ -1,0 +1,45 @@
+use std::sync::Arc;
+
+use async_graphql::{EmptyMutation, EmptySubscription, MergedObject, Schema};
+use async_graphql_axum::GraphQL;
+use axum::{http::Method, routing::get, Router};
+use tokio::net::TcpListener;
+use tower_http::cors::{Any, CorsLayer};
+use turborepo_ui::wui::query::SharedState;
+
+use crate::{query, query::graphiql, run::Run};
+
+#[derive(MergedObject)]
+struct Query(turborepo_ui::wui::RunQuery, query::RepositoryQuery);
+
+pub async fn run_server(
+    state: Option<SharedState>,
+    run: Arc<Run>,
+) -> Result<(), turborepo_ui::Error> {
+    let cors = CorsLayer::new()
+        // allow `GET` and `POST` when accessing the resource
+        .allow_methods([Method::GET, Method::POST])
+        .allow_headers(Any)
+        // allow requests from any origin
+        .allow_origin(Any);
+
+    let web_ui_query = turborepo_ui::wui::RunQuery::new(state.clone());
+    let turbo_query = query::RepositoryQuery::new(run);
+    let combined_query = Query(web_ui_query, turbo_query);
+
+    let schema = Schema::new(combined_query, EmptyMutation, EmptySubscription);
+    let app = Router::new()
+        .route("/", get(graphiql).post_service(GraphQL::new(schema)))
+        .layer(cors);
+
+    axum::serve(
+        TcpListener::bind("127.0.0.1:8000")
+            .await
+            .map_err(turborepo_ui::wui::Error::Server)?,
+        app,
+    )
+    .await
+    .map_err(turborepo_ui::wui::Error::Server)?;
+
+    Ok(())
+}

--- a/crates/turborepo-lib/src/run/ui.rs
+++ b/crates/turborepo-lib/src/run/ui.rs
@@ -1,13 +1,8 @@
 use std::sync::Arc;
 
-use async_graphql::{EmptyMutation, EmptySubscription, MergedObject, Schema};
-use async_graphql_axum::GraphQL;
-use axum::{http::Method, routing::get, Router};
-use tokio::net::TcpListener;
-use tower_http::cors::{Any, CorsLayer};
-use turborepo_ui::wui::{event::WebUIEvent, server::SharedState};
+use turborepo_ui::wui::{event::WebUIEvent, query::SharedState};
 
-use crate::{query, query::graphiql, run::Run};
+use crate::{query, run::Run};
 
 pub async fn start_web_ui_server(
     rx: tokio::sync::mpsc::UnboundedReceiver<WebUIEvent>,
@@ -17,39 +12,7 @@ pub async fn start_web_ui_server(
     let subscriber = turborepo_ui::wui::subscriber::Subscriber::new(rx);
     tokio::spawn(subscriber.watch(state.clone()));
 
-    run_server(state.clone(), run).await?;
-
-    Ok(())
-}
-
-#[derive(MergedObject)]
-struct Query(turborepo_ui::wui::RunQuery, query::RepositoryQuery);
-
-async fn run_server(state: SharedState, run: Arc<Run>) -> Result<(), turborepo_ui::Error> {
-    let cors = CorsLayer::new()
-        // allow `GET` and `POST` when accessing the resource
-        .allow_methods([Method::GET, Method::POST])
-        .allow_headers(Any)
-        // allow requests from any origin
-        .allow_origin(Any);
-
-    let web_ui_query = turborepo_ui::wui::RunQuery::new(state.clone());
-    let turbo_query = query::RepositoryQuery::new(run);
-    let combined_query = Query(web_ui_query, turbo_query);
-
-    let schema = Schema::new(combined_query, EmptyMutation, EmptySubscription);
-    let app = Router::new()
-        .route("/", get(graphiql).post_service(GraphQL::new(schema)))
-        .layer(cors);
-
-    axum::serve(
-        TcpListener::bind("127.0.0.1:8000")
-            .await
-            .map_err(turborepo_ui::wui::Error::Server)?,
-        app,
-    )
-    .await
-    .map_err(turborepo_ui::wui::Error::Server)?;
+    query::run_server(Some(state.clone()), run).await?;
 
     Ok(())
 }

--- a/crates/turborepo-ui/src/wui/mod.rs
+++ b/crates/turborepo-ui/src/wui/mod.rs
@@ -2,12 +2,12 @@
 //! by a web client to display the status of tasks.
 
 pub mod event;
+pub mod query;
 pub mod sender;
-pub mod server;
 pub mod subscriber;
 
 use event::WebUIEvent;
-pub use server::RunQuery;
+pub use query::RunQuery;
 use thiserror::Error;
 
 #[derive(Debug, Error)]

--- a/crates/turborepo-ui/src/wui/query.rs
+++ b/crates/turborepo-ui/src/wui/query.rs
@@ -39,19 +39,22 @@ pub type SharedState = Arc<Mutex<WebUIState>>;
 
 /// The query for actively running tasks (as opposed to the query for general
 /// repository state `RepositoryQuery` in `turborepo_lib::query`)
+/// This is `None` when we're not actually running a task (e.g. `turbo query`)
 pub struct RunQuery {
-    state: SharedState,
+    state: Option<SharedState>,
 }
 
 impl RunQuery {
-    pub fn new(state: SharedState) -> Self {
+    pub fn new(state: Option<SharedState>) -> Self {
         Self { state }
     }
 }
 
 #[Object]
 impl RunQuery {
-    async fn current_run(&self) -> CurrentRun {
-        CurrentRun { state: &self.state }
+    async fn current_run(&self) -> Option<CurrentRun> {
+        Some(CurrentRun {
+            state: self.state.as_ref()?,
+        })
     }
 }

--- a/crates/turborepo-ui/src/wui/subscriber.rs
+++ b/crates/turborepo-ui/src/wui/subscriber.rs
@@ -200,7 +200,7 @@ mod test {
         );
 
         // Now let's check with the GraphQL API
-        let schema = Schema::new(RunQuery::new(state), EmptyMutation, EmptySubscription);
+        let schema = Schema::new(RunQuery::new(Some(state)), EmptyMutation, EmptySubscription);
         let result = schema
             .execute("query { currentRun { tasks { name state { status } } } }")
             .await;

--- a/crates/turborepo-ui/src/wui/subscriber.rs
+++ b/crates/turborepo-ui/src/wui/subscriber.rs
@@ -6,7 +6,7 @@ use tokio::sync::Mutex;
 
 use crate::{
     tui::event::{CacheResult, TaskResult},
-    wui::{event::WebUIEvent, server::SharedState},
+    wui::{event::WebUIEvent, query::SharedState},
 };
 
 /// Subscribes to the Web UI events and updates the state
@@ -150,7 +150,7 @@ mod test {
     use super::*;
     use crate::{
         tui::event::OutputLogs,
-        wui::{sender::WebUISender, server::RunQuery},
+        wui::{query::RunQuery, sender::WebUISender},
     };
 
     #[tokio::test]


### PR DESCRIPTION


### Description

We need the `currentRun` field to exist on `turbo query` to easily generate types from the GraphQL server.  This adds the field and also deduplicates the server code so both `wui` and `query` use the same `run_server` code

### Testing Instructions

