### PR TITLE
Add "go-to-definition" instructions to TypeScript docs.

### DIFF
--- a/docs/repo-docs/guides/tools/typescript.mdx
+++ b/docs/repo-docs/guides/tools/typescript.mdx
@@ -244,6 +244,8 @@ Exports from [Compiled Packages](/repo/docs/core-concepts/internal-packages#comp
   </Folder>
 </Files>
 
+With these two files in place, your editor will now go to the definition you're expecting.
+
 ### Use Node.js subpath imports instead of TypeScript compiler `paths`
 
 It's possible to create absolute imports in your packages using [the TypeScript compiler's `paths` option](https://www.typescriptlang.org/tsconfig#paths), but these paths can cause failed compilation when using [Just-in-Time Packages](https://turbo.build/repo/docs/core-concepts/internal-packages#just-in-time-packages). [As of TypeScript 5.4](https://devblogs.microsoft.com/typescript/announcing-typescript-5-4/#auto-import-support-for-subpath-imports), you can use [Node.js subpath imports](https://nodejs.org/api/packages.html#imports) instead for a more robust solution.

--- a/docs/repo-docs/guides/tools/typescript.mdx
+++ b/docs/repo-docs/guides/tools/typescript.mdx
@@ -244,7 +244,7 @@ Exports from [Compiled Packages](/repo/docs/core-concepts/internal-packages#comp
   </Folder>
 </Files>
 
-With these two files in place, your editor will now go to the definition you're expecting.
+With these two files in place, your editor will now navigate to the original source code.
 
 ### Use Node.js subpath imports instead of TypeScript compiler `paths`
 

--- a/docs/repo-docs/guides/tools/typescript.mdx
+++ b/docs/repo-docs/guides/tools/typescript.mdx
@@ -222,7 +222,7 @@ For [Internal Packages](/repo/docs/core-concepts/internal-packages), we recommen
 
 ### Enable go-to-definition across package boundaries
 
-"Go-to-definition" is an editor feature for quickly navigating to the original declaration or symbol (like a variable or function) with a click or hotkey. Once TypeScript is configured correctly, you can navigate across [Internal Packages](/repo/docs/core-concepts/internal-packages) with ease.
+"Go-to-definition" is an editor feature for quickly navigating to the original declaration or definition of a symbol (like a variable or function) with a click or hotkey. Once TypeScript is configured correctly, you can navigate across [Internal Packages](/repo/docs/core-concepts/internal-packages) with ease.
 
 #### Just-in-Time Packages
 

--- a/docs/repo-docs/guides/tools/typescript.mdx
+++ b/docs/repo-docs/guides/tools/typescript.mdx
@@ -207,8 +207,8 @@ Then, create a `check-types` task in `turbo.json`. From the [Configuring tasks g
     },
     "check-types": {
       "dependsOn": ["topo"]
-    },
-  },
+    }
+  }
 }
 ```
 
@@ -220,11 +220,35 @@ Then, run your task using `turbo check-types`.
 
 For [Internal Packages](/repo/docs/core-concepts/internal-packages), we recommend that you use `tsc` to compile your TypeScript libraries whenever possible. While you can use a bundler, it's not necessary and adds extra complexity to your build process. Additionally, bundling a library can mangle the code before it makes it to your applications' bundlers, causing hard to debug issues.
 
+### Enable go-to-definition across package boundaries
+
+"Go-to-definition" is an editor feature for quickly navigating to the original declaration or symbol (like a variable or function) with a click or hotkey. Once TypeScript is configured correctly, you can navigate across [Internal Packages](/repo/docs/core-concepts/internal-packages) with ease.
+
+#### Just-in-Time Packages
+
+Exports from Just-in-Time Packages will automatically bring you to the original TypeScript source code as long as you aren't using [entrypoint wildcards](#package-entrypoint-wildcards). Go-to-definition will work as expected.
+
+#### Compiled Packages
+
+Exports from [Compiled Packages](/repo/docs/core-concepts/internal-packages#compiled-packages) require the use of [`declaration`](https://www.typescriptlang.org/tsconfig/#declaration) and [`declarationMap`](https://www.typescriptlang.org/tsconfig/#declarationMap) configurations for go-to-definition to work. After you've enabled these two configurations for the package, compile the package with `tsc`, and open the output directory to find declaration files and source maps.
+
+<Files>
+  <Folder defaultOpen name="packages">
+    <Folder defaultOpen name="ui">
+      <Folder defaultOpen name="dist">
+        <File name="button.js" />
+        <File name="button.d.ts" green />
+        <File name="button.d.ts.map" green />
+      </Folder>
+    </Folder>
+  </Folder>
+</Files>
+
 ### Use Node.js subpath imports instead of TypeScript compiler `paths`
 
 It's possible to create absolute imports in your packages using [the TypeScript compiler's `paths` option](https://www.typescriptlang.org/tsconfig#paths), but these paths can cause failed compilation when using [Just-in-Time Packages](https://turbo.build/repo/docs/core-concepts/internal-packages#just-in-time-packages). [As of TypeScript 5.4](https://devblogs.microsoft.com/typescript/announcing-typescript-5-4/#auto-import-support-for-subpath-imports), you can use [Node.js subpath imports](https://nodejs.org/api/packages.html#imports) instead for a more robust solution.
 
-#### Just-in-Time packages
+#### Just-in-Time Packages
 
 In [Just-in-Time packages](https://turbo.build/repo/docs/core-concepts/internal-packages#just-in-time-packages), `imports` must target the source code in the package, since build outputs like `dist` won't be created.
 
@@ -252,9 +276,9 @@ export const Button = () => {
 
 </Tabs>
 
-#### Compiled packages
+#### Compiled Packages
 
-In [Compiled packages](https://turbo.build/repo/docs/core-concepts/internal-packages#compiled-packages), `imports` target the built ouptuts for the package.
+In [Compiled Packages](https://turbo.build/repo/docs/core-concepts/internal-packages#compiled-packages), `imports` target the built ouptuts for the package.
 
 <Tabs storageKey="ts-imports-compiled" items={["package.json", "Source code"]}>
   <Tab value="package.json">


### PR DESCRIPTION
### Description

Title!