### PR TITLE
(docs) Fix spacing on link.

### DIFF
--- a/docs/repo-docs/guides/tools/typescript.mdx
+++ b/docs/repo-docs/guides/tools/typescript.mdx
@@ -73,9 +73,7 @@ Inside `packages/typescript-config`, you have a few `json` files which represent
 }
 ```
 
-<LinkToDocumentation href="https://www.typescriptlang.org/tsconfig">
-  `tsconfig` options reference
-</LinkToDocumentation>
+<LinkToDocumentation href="https://www.typescriptlang.org/tsconfig">`tsconfig` options reference</LinkToDocumentation>
 
 ### Creating the rest of the package
 


### PR DESCRIPTION
### Description

The newline was rending an extra `<p>` tag and messing up the layout.
