### PR TITLE
fix(affected): handle Github Actions provided commit not part of checkout

### DIFF
--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -64,7 +64,9 @@ impl SCM {
                 ) {
                     Ok(files) => Ok(ChangedFiles::Some(files)),
                     Err(ref error @ Error::Git(ref message, _))
-                        if allow_unknown_objects && message.contains("no merge base") =>
+                        if allow_unknown_objects
+                            && (message.contains("no merge base")
+                                || message.contains("bad object")) =>
                     {
                         unable_to_detect_range(error)
                     }

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -235,10 +235,10 @@ impl Git {
                 .execute_git_command(&["rev-parse", &github_base_ref], "")
                 .is_ok()
             {
-                println!("Resolved base ref from GitHub Actions event: {github_base_ref}");
+                eprintln!("Resolved base ref from GitHub Actions event: {github_base_ref}");
                 Ok(github_base_ref)
             } else {
-                println!("Failed to resolve base ref from GitHub Actions event");
+                eprintln!("Failed to resolve base ref from GitHub Actions event");
                 Err(Error::UnableToResolveRef)
             };
         }


### PR DESCRIPTION
### Description

Fixes #9208

With #9169 we started using `GITHUB_BASE_REF` to determine the base of our `--affected` comparison. This can return a commit that doesn't exist in the current checkout, but will pass `rev-parse` since the reference exists.

This PR avoids crashing by treating `bad object` git errors the same as `no merge base` so if we get passed a commit that is valid, but non-existent in the checkout we still run.

### Testing Instructions

I only have a manual test as creating a repository where a commit exists according to `rev-parse`, but not as part of the checkout is beyond my git-fu levels.

Create a shallow checkout:
`git clone git@github.com:vercel/turborepo.git --depth=1`

Find a commit that exists in the repo, but does not exist in the checkout e.g. `ce11d86705632160dd234ec4cf04bb1bd4ddeebc`
```
[0 olszewski@chriss-mbp] /tmp/turborepo $ git rev-parse ce11d86705632160dd234ec4cf04bb1bd4ddeebc                                           
ce11d86705632160dd234ec4cf04bb1bd4ddeebc
[0 olszewski@chriss-mbp] /tmp/turborepo $ git log
commit 18807def30191221415f027d446079fff3e9f722 (grafted, HEAD -> main, origin/main, origin/HEAD)
Author: Anthony Shew <anthony.shew@vercel.com>
Date:   Wed Oct 2 23:06:06 2024 -0600

    (docs) Fix spacing on link. (#9213)
    
    ### Description
    
    <!--
     ✍️✍  Write a short summary of your work.
      If necessary, include relevant screenshots.
    -->
    
    ### Testing Instructions
    
    <!--
      Give a quick description of steps to test your changes.
    -->
[0 olszewski@chriss-mbp] /tmp/turborepo $ git checkout ce11d86705632160dd234ec4cf04bb1bd4ddeebc
fatal: reference is not a tree: ce11d86705632160dd234ec4cf04bb1bd4ddeeb
```

Verify that `turbo ls --affected` crashes with "bad object" message:
```
GITHUB_ACTIONS=1 GITHUB_BASE_REF=ce11d86705632160dd234ec4cf04bb1bd4ddeebc turbo ls --affected 
 WARNING  No locally installed `turbo` found. Using version: 2.1.4-canary.0.
turbo 2.1.4-canary.0

 WARNING  ls command is experimental and may change in the future
Resolved base ref from GitHub Actions event: ce11d86705632160dd234ec4cf04bb1bd4ddeebc
  × Unable to query SCM: git error: fatal: bad object ce11d86705632160dd234ec4cf04bb1bd4ddeebc
  │ 
  ╰─▶ git error: fatal: bad object ce11d86705632160dd234ec4cf04bb1bd4ddeebc
```

Test PR and verify that since we can't diff the commit we assume everything has changed:
```
GITHUB_ACTIONS=1 GITHUB_BASE_REF=ce11d86705632160dd234ec4cf04bb1bd4ddeebc turbo_dev ls --affected
 WARNING  No locally installed `turbo` found. Using version: 2.1.4-canary.0.
turbo 2.1.4-canary.0

 WARNING  ls command is experimental and may change in the future
Resolved base ref from GitHub Actions event: ce11d86705632160dd234ec4cf04bb1bd4ddeebc
 WARNING  unable to detect git range, assuming all files have changed: git error: fatal: bad object ce11d86705632160dd234ec4cf04bb1bd4ddeebc

37 packages (pnpm)

  @turbo-internal/top-issues-gh-action packages/top-issues
  @turbo/benchmark packages/turbo-benchmark
...
```