### PR TITLE
chore(query): fix query integration test

### DIFF
--- a/turborepo-tests/integration/tests/command-query.t
+++ b/turborepo-tests/integration/tests/command-query.t
@@ -208,10 +208,7 @@ Run the query
     }
   }
 
-  $ ${TURBO} query "query { version }"
+  $ ${TURBO} query "query { version }" | jq ".data.version" > QUERY_VERSION
    WARNING  query command is experimental and may change in the future
-  {
-    "data": {
-      "version": "2.1.3-canary.2"
-    }
-  }
+  $ VERSION=${MONOREPO_ROOT_DIR}/version.txt
+  $ diff --strip-trailing-cr <(head -n 1 ${VERSION}) <(${TURBO} --version)


### PR DESCRIPTION
### Description

The current `command-query.t` will start failing anytime a version is released and we merge in the version bump branch.

This PR changes the comparison to now check against the contents of `version.txt` instead of a literal string.

### Testing Instructions

Integration test should pass now. This is the same way we test the `--version` flag: [command-version.t](https://github.com/vercel/turborepo/blob/main/turborepo-tests/integration/tests/command-version.t)
