### PR TITLE
Removed an extra comma

### DIFF
--- a/docs/repo-docs/crafting-your-repository/creating-an-internal-package.mdx
+++ b/docs/repo-docs/crafting-your-repository/creating-an-internal-package.mdx
@@ -62,7 +62,7 @@ Next, create the `package.json` for the package. By adding this file, you'll ful
     "./subtract": {
       "types": "./src/subtract.ts",
       "default": "./dist/subtract.js"
-    },
+    }
   },
   "devDependencies": {
     "@repo/typescript-config": "*",


### PR DESCRIPTION
The trailing comma is a compile time problem

### Description

<!--
 While copying the package.json template you will notice an extra traling comma leading to a compilation issue
-->

### Testing Instructions

<!--
Copy & paste the package.json in your project
-->
