### PR TITLE
docs: add missing `}` and remove comma

### DIFF
--- a/docs/repo-docs/crafting-your-repository/creating-an-internal-package.mdx
+++ b/docs/repo-docs/crafting-your-repository/creating-an-internal-package.mdx
@@ -263,7 +263,6 @@ Add the artifacts for the new `@repo/math` library to the `outputs` for the `bui
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     }
   }

--- a/docs/repo-docs/crafting-your-repository/creating-an-internal-package.mdx
+++ b/docs/repo-docs/crafting-your-repository/creating-an-internal-package.mdx
@@ -260,12 +260,12 @@ Add the artifacts for the new `@repo/math` library to the `outputs` for the `bui
 ```json title="./turbo.json"
 // [!code word:"dist/**"]
 {
-  "tasks": {
-    "build": {
-      "dependsOn": ["^build"],
-      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
-    }
+"tasks": {
+  "build": {
+    "dependsOn": ["^build"],
+    "outputs": [".next/**", "!.next/cache/**", "dist/**"]
   }
+}
 }
 ```
 

--- a/docs/repo-docs/crafting-your-repository/creating-an-internal-package.mdx
+++ b/docs/repo-docs/crafting-your-repository/creating-an-internal-package.mdx
@@ -260,11 +260,13 @@ Add the artifacts for the new `@repo/math` library to the `outputs` for the `bui
 ```json title="./turbo.json"
 // [!code word:"dist/**"]
 {
-"tasks": {
-  "build": {
-    "dependsOn": ["^build"],
-    "outputs": [".next/**", "!.next/cache/**", "dist/**"]
-  },
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", ".env*"],
+      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
### Description

- ~~The JSON code block's indentation has been corrected for better readability and proper JSON structure~~
- ~~Added the `inputs` property to `build` to match the actual [turbo.json](https://github.com/vercel/turborepo/blob/053a46031df7970059e458d3cc705f11b1daf313/examples/basic/turbo.json#L7) content~~
- Added a missing `}` to the JSON code block and removed a trailing comma

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
