### PR TITLE
chore: Remove `display` key from generated `tsconfig`

### DIFF
--- a/examples/basic/packages/typescript-config/base.json
+++ b/examples/basic/packages/typescript-config/base.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Default",
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,

--- a/examples/basic/packages/typescript-config/nextjs.json
+++ b/examples/basic/packages/typescript-config/nextjs.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Next.js",
   "extends": "./base.json",
   "compilerOptions": {
     "plugins": [{ "name": "next" }],

--- a/examples/basic/packages/typescript-config/react-library.json
+++ b/examples/basic/packages/typescript-config/react-library.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "React Library",
   "extends": "./base.json",
   "compilerOptions": {
     "jsx": "react-jsx"

--- a/examples/design-system/packages/typescript-config/base.json
+++ b/examples/design-system/packages/typescript-config/base.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Default",
   "compilerOptions": {
     "composite": false,
     "declaration": true,

--- a/examples/design-system/packages/typescript-config/react-app.json
+++ b/examples/design-system/packages/typescript-config/react-app.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Next.js",
   "extends": "./base.json",
   "compilerOptions": {
     "allowJs": true,

--- a/examples/design-system/packages/typescript-config/react-library.json
+++ b/examples/design-system/packages/typescript-config/react-library.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "React Library",
   "extends": "./base.json",
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/examples/kitchen-sink/packages/config-typescript/base.json
+++ b/examples/kitchen-sink/packages/config-typescript/base.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Default",
   "compilerOptions": {
     "composite": false,
     "declaration": true,

--- a/examples/kitchen-sink/packages/config-typescript/nextjs.json
+++ b/examples/kitchen-sink/packages/config-typescript/nextjs.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Next.js",
   "extends": "./base.json",
   "compilerOptions": {
     "plugins": [{ "name": "next" }],

--- a/examples/kitchen-sink/packages/config-typescript/react-app.json
+++ b/examples/kitchen-sink/packages/config-typescript/react-app.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Next.js",
   "extends": "./base.json",
   "compilerOptions": {
     "allowJs": true,

--- a/examples/kitchen-sink/packages/config-typescript/react-library.json
+++ b/examples/kitchen-sink/packages/config-typescript/react-library.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "React Library",
   "extends": "./base.json",
   "compilerOptions": {
     "lib": ["ES2015"],

--- a/examples/kitchen-sink/packages/config-typescript/remix.json
+++ b/examples/kitchen-sink/packages/config-typescript/remix.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Remix",
   "extends": "./base.json",
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2019"],

--- a/examples/kitchen-sink/packages/config-typescript/vite.json
+++ b/examples/kitchen-sink/packages/config-typescript/vite.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "./base.json",
-  "Display": "Vite",
   "compilerOptions": {
     "allowJs": false,
     "esModuleInterop": false,

--- a/examples/with-berry/packages/tsconfig/base.json
+++ b/examples/with-berry/packages/tsconfig/base.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Default",
   "compilerOptions": {
     "composite": false,
     "declaration": true,

--- a/examples/with-berry/packages/tsconfig/nextjs.json
+++ b/examples/with-berry/packages/tsconfig/nextjs.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Next.js",
   "extends": "./base.json",
   "compilerOptions": {
     "plugins": [{ "name": "next" }],

--- a/examples/with-berry/packages/tsconfig/react-library.json
+++ b/examples/with-berry/packages/tsconfig/react-library.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "React Library",
   "extends": "./base.json",
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/examples/with-changesets/packages/acme-tsconfig/base.json
+++ b/examples/with-changesets/packages/acme-tsconfig/base.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Default",
   "compilerOptions": {
     "composite": false,
     "declaration": true,

--- a/examples/with-changesets/packages/acme-tsconfig/nextjs.json
+++ b/examples/with-changesets/packages/acme-tsconfig/nextjs.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Next.js",
   "extends": "./base.json",
   "compilerOptions": {
     "allowJs": true,

--- a/examples/with-changesets/packages/acme-tsconfig/node14.json
+++ b/examples/with-changesets/packages/acme-tsconfig/node14.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Node 14",
   "extends": "./base.json",
   "compilerOptions": {
     "lib": ["ES2020"],

--- a/examples/with-changesets/packages/acme-tsconfig/react-library.json
+++ b/examples/with-changesets/packages/acme-tsconfig/react-library.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "React Library",
   "extends": "./base.json",
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/examples/with-docker/packages/typescript-config/base.json
+++ b/examples/with-docker/packages/typescript-config/base.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Default",
   "compilerOptions": {
     "composite": false,
     "declaration": true,

--- a/examples/with-docker/packages/typescript-config/nextjs.json
+++ b/examples/with-docker/packages/typescript-config/nextjs.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Next.js",
   "extends": "./base.json",
   "compilerOptions": {
     "plugins": [{ "name": "next" }],

--- a/examples/with-docker/packages/typescript-config/react-library.json
+++ b/examples/with-docker/packages/typescript-config/react-library.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "React Library",
   "extends": "./base.json",
   "compilerOptions": {
     "lib": ["ES2015"],

--- a/examples/with-gatsby/packages/typescript-config/base.json
+++ b/examples/with-gatsby/packages/typescript-config/base.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Default",
   "compilerOptions": {
     "composite": false,
     "declaration": true,

--- a/examples/with-gatsby/packages/typescript-config/gatsby.json
+++ b/examples/with-gatsby/packages/typescript-config/gatsby.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Gatsby",
   "extends": "./base.json",
   "compilerOptions": {
     "target": "esnext",

--- a/examples/with-gatsby/packages/typescript-config/nextjs.json
+++ b/examples/with-gatsby/packages/typescript-config/nextjs.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Next.js",
   "extends": "./base.json",
   "compilerOptions": {
     "target": "es5",

--- a/examples/with-gatsby/packages/typescript-config/react-library.json
+++ b/examples/with-gatsby/packages/typescript-config/react-library.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "React Library",
   "extends": "./base.json",
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/examples/with-nestjs/packages/typescript-config/base.json
+++ b/examples/with-nestjs/packages/typescript-config/base.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Default",
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,

--- a/examples/with-nestjs/packages/typescript-config/nestjs.json
+++ b/examples/with-nestjs/packages/typescript-config/nestjs.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "NestJS",
   "extends": "./base.json",
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,

--- a/examples/with-nestjs/packages/typescript-config/nextjs.json
+++ b/examples/with-nestjs/packages/typescript-config/nextjs.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Next.js",
   "extends": "./base.json",
   "compilerOptions": {
     "plugins": [{ "name": "next" }],

--- a/examples/with-nestjs/packages/typescript-config/react-library.json
+++ b/examples/with-nestjs/packages/typescript-config/react-library.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "React Library",
   "extends": "./base.json",
   "compilerOptions": {
     "jsx": "react-jsx"

--- a/examples/with-npm/packages/typescript-config/base.json
+++ b/examples/with-npm/packages/typescript-config/base.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Default",
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,

--- a/examples/with-npm/packages/typescript-config/nextjs.json
+++ b/examples/with-npm/packages/typescript-config/nextjs.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Next.js",
   "extends": "./base.json",
   "compilerOptions": {
     "plugins": [{ "name": "next" }],

--- a/examples/with-npm/packages/typescript-config/react-library.json
+++ b/examples/with-npm/packages/typescript-config/react-library.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "React Library",
   "extends": "./base.json",
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/examples/with-prisma/packages/config-typescript/base.json
+++ b/examples/with-prisma/packages/config-typescript/base.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Default",
   "compilerOptions": {
     "composite": false,
     "declaration": true,

--- a/examples/with-prisma/packages/config-typescript/nextjs.json
+++ b/examples/with-prisma/packages/config-typescript/nextjs.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Next.js",
   "extends": "./base.json",
   "compilerOptions": {
     "plugins": [{ "name": "next" }],

--- a/examples/with-react-native-web/packages/typescript-config/base.json
+++ b/examples/with-react-native-web/packages/typescript-config/base.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Default",
   "compilerOptions": {
     "composite": false,
     "declaration": true,

--- a/examples/with-react-native-web/packages/typescript-config/nextjs.json
+++ b/examples/with-react-native-web/packages/typescript-config/nextjs.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Next.js",
   "extends": "./base.json",
   "compilerOptions": {
     "allowJs": true,

--- a/examples/with-react-native-web/packages/typescript-config/react-native-library.json
+++ b/examples/with-react-native-web/packages/typescript-config/react-native-library.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "React Native Library",
   "extends": "./base.json",
   "compilerOptions": {
     "allowJs": true,

--- a/examples/with-rollup/packages/config-typescript/base.json
+++ b/examples/with-rollup/packages/config-typescript/base.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Default",
   "compilerOptions": {
     "composite": false,
     "declaration": true,

--- a/examples/with-rollup/packages/config-typescript/nextjs.json
+++ b/examples/with-rollup/packages/config-typescript/nextjs.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Next.js",
   "extends": "./base.json",
   "compilerOptions": {
     "plugins": [{ "name": "next" }],

--- a/examples/with-rollup/packages/config-typescript/react-library.json
+++ b/examples/with-rollup/packages/config-typescript/react-library.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "React Library",
   "extends": "./base.json",
   "compilerOptions": {
     "jsx": "react-jsx",

--- a/examples/with-tailwind/packages/config-typescript/base.json
+++ b/examples/with-tailwind/packages/config-typescript/base.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Default",
   "compilerOptions": {
     "composite": false,
     "declaration": true,

--- a/examples/with-tailwind/packages/config-typescript/nextjs.json
+++ b/examples/with-tailwind/packages/config-typescript/nextjs.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Next.js",
   "extends": "./base.json",
   "compilerOptions": {
     "plugins": [{ "name": "next" }],

--- a/examples/with-tailwind/packages/config-typescript/react-library.json
+++ b/examples/with-tailwind/packages/config-typescript/react-library.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "React Library",
   "extends": "./base.json",
   "compilerOptions": {
     "lib": ["ES2015", "DOM"],

--- a/examples/with-typeorm/packages/typescript-config/base.json
+++ b/examples/with-typeorm/packages/typescript-config/base.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Default",
   "compilerOptions": {
     "composite": false,
     "declaration": true,

--- a/examples/with-typeorm/packages/typescript-config/nextjs.json
+++ b/examples/with-typeorm/packages/typescript-config/nextjs.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Next.js",
   "extends": "./base.json",
   "compilerOptions": {
     "plugins": [{ "name": "next" }],

--- a/examples/with-typeorm/packages/typescript-config/react-library.json
+++ b/examples/with-typeorm/packages/typescript-config/react-library.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "React Library",
   "extends": "./base.json",
   "compilerOptions": {
     "jsx": "react-jsx"

--- a/examples/with-vite/packages/typescript-config/base.json
+++ b/examples/with-vite/packages/typescript-config/base.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Default",
   "compilerOptions": {
     "composite": false,
     "declaration": true,

--- a/examples/with-vue-nuxt/packages/tsconfig/base.json
+++ b/examples/with-vue-nuxt/packages/tsconfig/base.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Default",
   "compilerOptions": {
     "composite": false,
     "esModuleInterop": true,

--- a/examples/with-vue-nuxt/packages/tsconfig/nuxt.json
+++ b/examples/with-vue-nuxt/packages/tsconfig/nuxt.json
@@ -1,5 +1,4 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Nuxt",
   "extends": ["./base.json"]
 }

--- a/examples/with-vue-nuxt/packages/tsconfig/vue.json
+++ b/examples/with-vue-nuxt/packages/tsconfig/vue.json
@@ -1,5 +1,4 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Vue",
   "extends": ["./base.json", "@vue/tsconfig/tsconfig.dom.json"]
 }

--- a/examples/with-yarn/packages/typescript-config/base.json
+++ b/examples/with-yarn/packages/typescript-config/base.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Default",
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,

--- a/examples/with-yarn/packages/typescript-config/nextjs.json
+++ b/examples/with-yarn/packages/typescript-config/nextjs.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Next.js",
   "extends": "./base.json",
   "compilerOptions": {
     "plugins": [{ "name": "next" }],

--- a/examples/with-yarn/packages/typescript-config/react-library.json
+++ b/examples/with-yarn/packages/typescript-config/react-library.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "React Library",
   "extends": "./base.json",
   "compilerOptions": {
     "jsx": "react-jsx"

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "display": "Default",
   "compilerOptions": {
     "composite": false,
     "declaration": true,

--- a/packages/tsconfig/library.json
+++ b/packages/tsconfig/library.json
@@ -1,6 +1,5 @@
 {
   "extends": "./base.json",
-  "display": "TS Library",
   "compilerOptions": {
     "lib": ["ES2019"],
     "target": "ES2019",


### PR DESCRIPTION
### Description

https://github.com/vercel/turborepo/discussions/9221

I noticed that the default `create-turbo` command would create `tsconfig`s that contained a `display` key, which isn't part of the TS schema spec.

I opened a discussion to ask about this, because it might've been a Turbo-specific feature, for example I thought it was maybe used to display the list of projects in the repo in a nice human-readable way, but according to Anthony it's not actually used for anything.

From a quick read through of the `create-turbo` code, what I gathered is that it basically just copies these files based on the hardcoded example repos, hence why I only modified the `tsconfig`s themselves. It's possible I missed something as this is my first time interacting with this codebase (and the word `display` is generic enough that it shows up in a billion places all over the code), so please do let me know if my assumption here was wrong.

### Testing Instructions

1. Create a new turborepo with `create-turbo`
2. The example `tsconfig`s should no longer contain the `display` key.
