### PR TITLE
(examples) Move types field into first position of exports of kitchen-sink example.

### DIFF
--- a/examples/kitchen-sink/packages/ui/package.json
+++ b/examples/kitchen-sink/packages/ui/package.json
@@ -9,14 +9,14 @@
   ],
   "exports": {
     "./counter-button": {
+      "types": "./src/counter-button/index.tsx",
       "require": "./dist/counter-button/index.js",
-      "import": "./dist/counter-button/index.mjs",
-      "types": "./src/counter-button/index.tsx"
+      "import": "./dist/counter-button/index.mjs"
     },
     "./link": {
+      "types": "./src/link/index.tsx",
       "require": "./dist/link/index.js",
-      "import": "./dist/link/index.mjs",
-      "types": "./src/link/index.tsx"
+      "import": "./dist/link/index.mjs"
     }
   },
   "scripts": {


### PR DESCRIPTION
### Description

The `types` field must come before the other `exports` to be read by tooling.
