### PR TITLE
feat: warn on empty cache

### DIFF
--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -4,6 +4,7 @@ use std::{
     time::Duration,
 };
 
+use itertools::Itertools;
 use tokio::sync::oneshot;
 use tracing::{debug, error, log::warn};
 use turbopath::{
@@ -47,6 +48,7 @@ pub enum Error {
 pub struct RunCache {
     task_output_logs: Option<OutputLogsMode>,
     cache: AsyncCache,
+    warnings: Arc<Mutex<Vec<String>>>,
     reads_disabled: bool,
     writes_disabled: bool,
     repo_root: AbsoluteSystemPathBuf,
@@ -80,6 +82,7 @@ impl RunCache {
         RunCache {
             task_output_logs,
             cache,
+            warnings: Default::default(),
             reads_disabled: opts.skip_reads,
             writes_disabled: opts.skip_writes,
             repo_root: repo_root.to_owned(),
@@ -122,12 +125,18 @@ impl RunCache {
             log_file_path,
             daemon_client: self.daemon_client.clone(),
             ui: self.ui,
+            warnings: self.warnings.clone(),
         }
     }
 
     pub async fn shutdown_cache(
         &self,
     ) -> Result<(Arc<Mutex<UploadMap>>, oneshot::Receiver<()>), CacheError> {
+        if let Ok(warnings) = self.warnings.lock() {
+            for warning in warnings.iter().sorted() {
+                warn!("{}", warning);
+            }
+        }
         // Ignore errors coming from cache already shutting down
         self.cache.start_shutdown().await
     }
@@ -144,6 +153,7 @@ pub struct TaskCache {
     daemon_client: Option<DaemonClient<DaemonConnector>>,
     ui: ColorConfig,
     task_id: TaskId<'static>,
+    warnings: Arc<Mutex<Vec<String>>>,
 }
 
 impl TaskCache {
@@ -363,11 +373,13 @@ impl TaskCache {
         // If we're only caching the log output, *and* output globs are not empty,
         // we should warn the user
         if files_to_be_cached.len() == 1 && !self.repo_relative_globs.is_empty() {
-            warn!(
-                "no output files found for task {}. Please check your `outputs` key in \
-                 `turbo.json`",
-                self.task_id
-            );
+            let _ = self.warnings.lock().map(|mut warnings| {
+                warnings.push(format!(
+                    "no output files found for task {}. Please check your `outputs` key in \
+                     `turbo.json`",
+                    self.task_id
+                ))
+            });
         }
 
         let mut relative_paths = files_to_be_cached

--- a/crates/turborepo-lib/src/run/cache.rs
+++ b/crates/turborepo-lib/src/run/cache.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use tokio::sync::oneshot;
-use tracing::{debug, error};
+use tracing::{debug, error, log::warn};
 use turbopath::{
     AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPath, AnchoredSystemPathBuf,
 };
@@ -359,6 +359,16 @@ impl TaskCache {
             &validated_exclusions,
             globwalk::WalkType::All,
         )?;
+
+        // If we're only caching the log output, *and* output globs are not empty,
+        // we should warn the user
+        if files_to_be_cached.len() == 1 && !self.repo_relative_globs.is_empty() {
+            warn!(
+                "no output files found for task {}. Please check your `outputs` key in \
+                 `turbo.json`",
+                self.task_id
+            );
+        }
 
         let mut relative_paths = files_to_be_cached
             .into_iter()

--- a/crates/turborepo-lib/src/task_graph/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/mod.rs
@@ -23,6 +23,9 @@ pub struct TaskOutputs {
 }
 
 impl TaskOutputs {
+    pub fn is_empty(&self) -> bool {
+        self.inclusions.is_empty() && self.exclusions.is_empty()
+    }
     pub fn validated_inclusions(&self) -> Result<Vec<ValidatedGlob>, GlobError> {
         self.inclusions
             .iter()

--- a/turborepo-tests/integration/tests/affected.t
+++ b/turborepo-tests/integration/tests/affected.t
@@ -30,6 +30,7 @@ Validate that we only run `my-app#build` with change not committed
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
 
 
 Do the same thing with the `ls` command
@@ -80,6 +81,7 @@ Validate that we only run `my-app#build` with change not committed
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
 
 Do the same thing with the `ls` command
   $ ${TURBO} ls --affected

--- a/turborepo-tests/integration/tests/filter-run.t
+++ b/turborepo-tests/integration/tests/filter-run.t
@@ -40,6 +40,8 @@ Setup
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
+   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
 
 Non existent package name should error
   $ ${TURBO} run build --filter="foo" --output-logs none

--- a/turborepo-tests/integration/tests/global-deps.t
+++ b/turborepo-tests/integration/tests/global-deps.t
@@ -12,6 +12,7 @@ Run a build
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
 
   $ echo "new text" > global_deps/foo.txt
   $ ${TURBO} build -F my-app --output-logs=hash-only
@@ -24,6 +25,7 @@ Run a build
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
   $ echo "Submit a PR!" >> global_deps/CONTRIBUTING.md
   $ ${TURBO} build -F my-app --output-logs=hash-only
   \xe2\x80\xa2 Packages in scope: my-app (esc)

--- a/turborepo-tests/integration/tests/global-env.t
+++ b/turborepo-tests/integration/tests/global-env.t
@@ -14,6 +14,7 @@ Setup
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
 # run again and ensure there's a cache hit
   $ ${TURBO} run build --filter=util --output-logs=hash-only
   \xe2\x80\xa2 Packages in scope: util (esc)
@@ -36,6 +37,7 @@ Setup
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
 # set env var with "THASH" and ensure cache miss
   $ SOMETHING_THASH_YES=hi ${TURBO} run build --filter=util --output-logs=hash-only
   \xe2\x80\xa2 Packages in scope: util (esc)
@@ -58,6 +60,7 @@ Setup
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
 # THASH deprecation doesn't break --dry=json
   $ SOMETHING_THASH_YES=hi ${TURBO} run build --filter=util --dry=json | jq -r '.tasks[0].environmentVariables.global[0]'
   null

--- a/turborepo-tests/integration/tests/lockfile-aware-caching/berry.t
+++ b/turborepo-tests/integration/tests/lockfile-aware-caching/berry.t
@@ -14,6 +14,7 @@ Populate cache
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task a#build. Please check your `outputs` key in `turbo.json`
   $ ${TURBO} build --filter=b
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
@@ -25,6 +26,7 @@ Populate cache
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task b#build. Please check your `outputs` key in `turbo.json`
 
 Bump dependency for b and rebuild
 Only b should have a cache miss
@@ -53,6 +55,7 @@ Only b should have a cache miss
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task b#build. Please check your `outputs` key in `turbo.json`
 Add lockfile changes to a commit
   $ git add . && git commit -m "bump lockfile" --quiet
 Only root and b should be rebuilt since only the deps for b had a version bump
@@ -76,6 +79,7 @@ Bump of root workspace invalidates all packages
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task a#build. Please check your `outputs` key in `turbo.json`
   $ ${TURBO} build  --filter=b
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
@@ -87,6 +91,7 @@ Bump of root workspace invalidates all packages
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task b#build. Please check your `outputs` key in `turbo.json`
 Add lockfile changes to a commit
   $ git add . && git commit -m "global lockfile change" --quiet
 Everything should be rebuilt as a dependency of the root package got bumped

--- a/turborepo-tests/integration/tests/lockfile-aware-caching/npm.t
+++ b/turborepo-tests/integration/tests/lockfile-aware-caching/npm.t
@@ -18,6 +18,7 @@ Populate cache
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task a#build. Please check your `outputs` key in `turbo.json`
   $ ${TURBO} build --filter=b
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
@@ -33,6 +34,7 @@ Populate cache
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task b#build. Please check your `outputs` key in `turbo.json`
 
 Bump dependency for b and rebuild
 Only b should have a cache miss
@@ -69,6 +71,7 @@ Only b should have a cache miss
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task b#build. Please check your `outputs` key in `turbo.json`
 Add lockfile changes to a commit
   $ git add . && git commit -m "bump lockfile" --quiet
 Only root and b should be rebuilt since only the deps for b had a version bump
@@ -96,6 +99,7 @@ Bump of root workspace invalidates all packages
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task a#build. Please check your `outputs` key in `turbo.json`
   $ ${TURBO} build  --filter=b
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
@@ -111,6 +115,7 @@ Bump of root workspace invalidates all packages
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task b#build. Please check your `outputs` key in `turbo.json`
 Add lockfile changes to a commit
   $ git add . && git commit -m "global lockfile change" --quiet
 Everything should be rebuilt as a dependency of the root package got bumped

--- a/turborepo-tests/integration/tests/lockfile-aware-caching/pnpm.t
+++ b/turborepo-tests/integration/tests/lockfile-aware-caching/pnpm.t
@@ -18,6 +18,7 @@ Populate cache
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task a#build. Please check your `outputs` key in `turbo.json`
   $ ${TURBO} build --filter=b
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
@@ -33,6 +34,7 @@ Populate cache
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task b#build. Please check your `outputs` key in `turbo.json`
 
 Bump dependency for b and rebuild
 Only b should have a cache miss
@@ -69,6 +71,7 @@ Only b should have a cache miss
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task b#build. Please check your `outputs` key in `turbo.json`
 Add lockfile changes to a commit
   $ git add . && git commit -m "bump pnpm-lock" --quiet
 Only root and b should be rebuilt since only the deps for b had a version bump
@@ -96,6 +99,7 @@ Bump of root workspace invalidates all packages
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task a#build. Please check your `outputs` key in `turbo.json`
   $ ${TURBO} build  --filter=b
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
@@ -111,6 +115,7 @@ Bump of root workspace invalidates all packages
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task b#build. Please check your `outputs` key in `turbo.json`
 Add lockfile changes to a commit
   $ git add . && git commit -m "global lockfile change" --quiet
 Everything should be rebuilt as a dependency of the root package got bumped

--- a/turborepo-tests/integration/tests/lockfile-aware-caching/yarn.t
+++ b/turborepo-tests/integration/tests/lockfile-aware-caching/yarn.t
@@ -18,6 +18,7 @@ Populate cache
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task a#build. Please check your `outputs` key in `turbo.json`
   $ ${TURBO} build --filter=b
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
@@ -33,6 +34,7 @@ Populate cache
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task b#build. Please check your `outputs` key in `turbo.json`
 
 Bump dependency for b and rebuild
 Only b should have a cache miss
@@ -69,6 +71,7 @@ Only b should have a cache miss
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task b#build. Please check your `outputs` key in `turbo.json`
 Add lockfile changes to a commit
   $ git add . && git commit -m "bump lockfile" --quiet
 Only root and b should be rebuilt since only the deps for b had a version bump
@@ -96,6 +99,7 @@ Bump of root workspace invalidates all packages
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task a#build. Please check your `outputs` key in `turbo.json`
   $ ${TURBO} build  --filter=b
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
@@ -111,6 +115,7 @@ Bump of root workspace invalidates all packages
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task b#build. Please check your `outputs` key in `turbo.json`
 Add lockfile changes to a commit
   $ git add . && git commit -m "global lockfile change" --quiet
 Everything should be rebuilt as a dependency of the root package got bumped

--- a/turborepo-tests/integration/tests/persistent-dependencies/6-topological-unimplemented.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/6-topological-unimplemented.t
@@ -28,3 +28,4 @@
   Cached:    0 cached, 1 total
     Time:\s+[.0-9]+m?s  (re)
   
+   WARNING  no output files found for task app-a#dev. Please check your `outputs` key in `turbo.json`

--- a/turborepo-tests/integration/tests/pkg-inference.t
+++ b/turborepo-tests/integration/tests/pkg-inference.t
@@ -17,3 +17,4 @@ Setup
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`

--- a/turborepo-tests/integration/tests/prune/composable-config.t
+++ b/turborepo-tests/integration/tests/prune/composable-config.t
@@ -22,5 +22,6 @@ Make sure that the internal util package is part of the prune output
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task docs#new-task. Please check your `outputs` key in `turbo.json`
 
 

--- a/turborepo-tests/integration/tests/run-caching/cache-state.t
+++ b/turborepo-tests/integration/tests/run-caching/cache-state.t
@@ -11,6 +11,9 @@ Run a build to get a local cache.
   Cached:    0 cached, 2 total
     Time:\s+[.0-9]+m?s  (re)
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
+   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
+
 
 Do a dry run so we can see the state of the cache
   $ ${TURBO} run build --dry=json > dry.json

--- a/turborepo-tests/integration/tests/run-caching/excluded-inputs/excluded-inputs.t
+++ b/turborepo-tests/integration/tests/run-caching/excluded-inputs/excluded-inputs.t
@@ -20,6 +20,7 @@ Running build for my-app succeeds
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
 Update exluded file and try again
   $ echo "new excluded value" > apps/my-app/excluded.txt
   $ ${TURBO} run build --filter=my-app

--- a/turborepo-tests/integration/tests/run-caching/global-deps.t
+++ b/turborepo-tests/integration/tests/run-caching/global-deps.t
@@ -11,6 +11,7 @@ Run a build to get a local cache.
   Cached:    0 cached, 1 total
     Time:\s+[.0-9]+m?s  (re)
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
 
 Run again to get cache hit
   $ SOME_ENV_VAR=hi ${TURBO} run build --output-logs=none --filter=my-app
@@ -33,3 +34,4 @@ Run again without env var to get cache miss
   Cached:    0 cached, 1 total
     Time:\s+[.0-9]+m?s  (re)
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`

--- a/turborepo-tests/integration/tests/run-caching/root-deps.t
+++ b/turborepo-tests/integration/tests/run-caching/root-deps.t
@@ -16,6 +16,7 @@ Warm the cache
   Cached:    0 cached, 1 total
     Time:\s+[.0-9]+m?s  (re)
   
+   WARNING  no output files found for task another#build. Please check your `outputs` key in `turbo.json`
 
 Confirm cache hit
   $ ${TURBO} build --filter=another --output-logs=hash-only
@@ -43,6 +44,7 @@ All tasks should be a cache miss, even ones that don't depend on changed package
   Cached:    0 cached, 1 total
     Time:\s+[.0-9]+m?s  (re)
   
+   WARNING  no output files found for task another#build. Please check your `outputs` key in `turbo.json`
 
 Verify that all packages are in scope on a internal root dep change
   $ ${TURBO} build --filter='[HEAD]' --dry=json | jq '.packages'

--- a/turborepo-tests/integration/tests/run-logging/errors-only.t
+++ b/turborepo-tests/integration/tests/run-logging/errors-only.t
@@ -13,6 +13,7 @@ Setup
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task app-a#build. Please check your `outputs` key in `turbo.json`
 
 
 
@@ -28,6 +29,7 @@ Setup
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task app-a#buildsuccess. Please check your `outputs` key in `turbo.json`
 
 
 # [x] error exit

--- a/turborepo-tests/integration/tests/run-logging/log-order-github.t
+++ b/turborepo-tests/integration/tests/run-logging/log-order-github.t
@@ -31,7 +31,9 @@ because otherwise prysk interprets them as multiline commands
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
-# Build as if we are in GitHub Actions with a task log prefix.
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
+   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
+# Build as if we are in Github Actions with a task log prefix.
   $ GITHUB_ACTIONS=1 ${TURBO} run build --force --log-prefix="task" --filter=util
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
@@ -50,6 +52,7 @@ because otherwise prysk interprets them as multiline commands
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
 
 Verify that errors are grouped properly
   $ GITHUB_ACTIONS=1 ${TURBO} run fail

--- a/turborepo-tests/integration/tests/run-logging/log-order-grouped.t
+++ b/turborepo-tests/integration/tests/run-logging/log-order-grouped.t
@@ -6,14 +6,14 @@
   \xe2\x80\xa2 Packages in scope: my-app, util (esc)
   \xe2\x80\xa2 Running build in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing [0-9a-f]+ (re)
+  my-app:build: cache bypass, force executing 0af90ec6a57471be
   my-app:build: 
   my-app:build: > build
   my-app:build: > echo building && sleep 1 && echo done
   my-app:build: 
   my-app:build: building
   my-app:build: done
-  util:build: cache bypass, force executing [0-9a-f]+ (re)
+  util:build: cache bypass, force executing 2da422600daca8be
   util:build: 
   util:build: > build
   util:build: > sleep 0.5 && echo building && sleep 1 && echo completed
@@ -25,20 +25,23 @@
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
+   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
+
 
 # We can get the same behavior with an env var
   $ TURBO_LOG_ORDER=grouped ${TURBO} run build --force
   \xe2\x80\xa2 Packages in scope: my-app, util (esc)
   \xe2\x80\xa2 Running build in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing [0-9a-f]+ (re)
+  my-app:build: cache bypass, force executing 0af90ec6a57471be
   my-app:build: 
   my-app:build: > build
   my-app:build: > echo building && sleep 1 && echo done
   my-app:build: 
   my-app:build: building
   my-app:build: done
-  util:build: cache bypass, force executing [0-9a-f]+ (re)
+  util:build: cache bypass, force executing 2da422600daca8be
   util:build: 
   util:build: > build
   util:build: > sleep 0.5 && echo building && sleep 1 && echo completed
@@ -50,19 +53,22 @@
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
+   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
+
 # The flag wins over the env var
   $ TURBO_LOG_ORDER=stream ${TURBO} run build --log-order grouped --force
   \xe2\x80\xa2 Packages in scope: my-app, util (esc)
   \xe2\x80\xa2 Running build in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:build: cache bypass, force executing [0-9a-f]+ (re)
+  my-app:build: cache bypass, force executing 0af90ec6a57471be
   my-app:build: 
   my-app:build: > build
   my-app:build: > echo building && sleep 1 && echo done
   my-app:build: 
   my-app:build: building
   my-app:build: done
-  util:build: cache bypass, force executing [0-9a-f]+ (re)
+  util:build: cache bypass, force executing 2da422600daca8be
   util:build: 
   util:build: > build
   util:build: > sleep 0.5 && echo building && sleep 1 && echo completed
@@ -74,3 +80,6 @@
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
+   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
+

--- a/turborepo-tests/integration/tests/run-logging/log-order-stream.t
+++ b/turborepo-tests/integration/tests/run-logging/log-order-stream.t
@@ -25,6 +25,9 @@
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
+   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
+
 The env var set to stream works (this is default, so this test doesn't guarantee the env var is "working"),
 it just guarantees setting this env var won't crash.
   $ TURBO_LOG_ORDER=stream ${TURBO} run build --force
@@ -32,7 +35,6 @@ it just guarantees setting this env var won't crash.
   \xe2\x80\xa2 Running build in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   (my-app|util):build: cache bypass, force executing [0-9a-f]+ (re)
-  (my-app|util):build: cache bypass, force executing [0-9a-f]+ (re)
   .* (re)
   .* (re)
   .* (re)
@@ -42,6 +44,7 @@ it just guarantees setting this env var won't crash.
   .* (re)
   .* (re)
   .* (re)
+  my-app:build: building
   util:build: building
   my-app:build: done
   util:build: completed
@@ -50,13 +53,14 @@ it just guarantees setting this env var won't crash.
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
+   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
+
 The flag wins over the env var
   $ TURBO_LOG_ORDER=grouped ${TURBO} run build --log-order stream --force
   \xe2\x80\xa2 Packages in scope: my-app, util (esc)
   \xe2\x80\xa2 Running build in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  (my-app|util):build: cache bypass, force executing [0-9a-f]+ (re)
-  (my-app|util):build: cache bypass, force executing [0-9a-f]+ (re)
   .* (re)
   .* (re)
   .* (re)
@@ -66,6 +70,8 @@ The flag wins over the env var
   .* (re)
   .* (re)
   .* (re)
+  my-app:build: 
+  my-app:build: building
   util:build: building
   my-app:build: done
   util:build: completed
@@ -74,3 +80,6 @@ The flag wins over the env var
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
+   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
+ 

--- a/turborepo-tests/integration/tests/run-logging/log-order-stream.t
+++ b/turborepo-tests/integration/tests/run-logging/log-order-stream.t
@@ -70,7 +70,7 @@ The flag wins over the env var
   .* (re)
   .* (re)
   .* (re)
-  my-app:build: 
+  (my-app|util):build: (re)
   my-app:build: building
   util:build: building
   my-app:build: done

--- a/turborepo-tests/integration/tests/run-logging/log-order-stream.t
+++ b/turborepo-tests/integration/tests/run-logging/log-order-stream.t
@@ -70,7 +70,7 @@ The flag wins over the env var
   .* (re)
   .* (re)
   .* (re)
-  (my-app|util):build: (re)
+  (my-app|util):build:  (re)
   my-app:build: building
   util:build: building
   my-app:build: done

--- a/turborepo-tests/integration/tests/run-logging/log-prefix.t
+++ b/turborepo-tests/integration/tests/run-logging/log-prefix.t
@@ -17,6 +17,7 @@ Setup
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task app-a#build. Please check your `outputs` key in `turbo.json`
 # Check that the cached logs don't have prefixes
   $ cat app-a/.turbo/turbo-build.log
   

--- a/turborepo-tests/integration/tests/run-logging/verbosity.t
+++ b/turborepo-tests/integration/tests/run-logging/verbosity.t
@@ -17,6 +17,7 @@ Verbosity level 1
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
   $ ${TURBO} build --verbosity=1 --filter=util --force
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
@@ -32,6 +33,7 @@ Verbosity level 1
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
 
 Verbosity level 2
   $ ${TURBO} build -vv --filter=util --force 1> VERBOSEVV 2>&1

--- a/turborepo-tests/integration/tests/run-summary/discovery.t
+++ b/turborepo-tests/integration/tests/run-summary/discovery.t
@@ -18,3 +18,4 @@ Setup
      Time:\s*[\.0-9]+m?s  (re)
   Summary:    .+\.turbo(\/|\\)runs(\/|\\)[a-zA-Z0-9]+.json (re)
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`

--- a/turborepo-tests/integration/tests/run-summary/enable.t
+++ b/turborepo-tests/integration/tests/run-summary/enable.t
@@ -26,6 +26,8 @@ Setup
 # env var=true, missing flag: yes
   $ rm -rf .turbo/runs
   $ TURBO_RUN_SUMMARY=true ${TURBO} run build > /dev/null
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
+   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
   $ /bin/ls .turbo/runs/*.json | wc -l
   \s*1 (re)
 # env var=true, --flag=true: yes

--- a/turborepo-tests/integration/tests/run-summary/monorepo.t
+++ b/turborepo-tests/integration/tests/run-summary/monorepo.t
@@ -5,6 +5,8 @@ Setup
   $ rm -rf .turbo/runs
 
   $ ${TURBO} run build --summarize -- someargs > /dev/null # first run (should be cache miss)
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
+   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
 
 # HACK: Generated run summaries are named with a ksuid, which is a time-sorted ID. This _generally_ works
 # but we're seeing in this test that sometimes a summary file is not sorted (with /bin/ls) in the order we expect

--- a/turborepo-tests/integration/tests/run-summary/strict-env.t
+++ b/turborepo-tests/integration/tests/run-summary/strict-env.t
@@ -12,6 +12,7 @@ Set the env vars
 Run as `infer`
   $ rm -rf .turbo/runs
   $ ${TURBO} run build --summarize > /dev/null
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
   $ cat .turbo/runs/*.json | jq -r '.envMode'
   strict
   $ cat .turbo/runs/*.json | jq -r '.tasks[0].envMode'
@@ -38,6 +39,7 @@ Run as `strict`
 Run as `loose`
   $ rm -rf .turbo/runs
   $ ${TURBO} run build --env-mode=loose --summarize > /dev/null
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
   $ cat .turbo/runs/*.json | jq -r '.envMode'
   loose
   $ cat .turbo/runs/*.json | jq -r '.tasks[0].envMode'
@@ -52,6 +54,7 @@ All specified + infer
   $ rm -rf .turbo/runs
   $ ${TESTDIR}/../../../helpers/replace_turbo_json.sh $(pwd) "strict_env_vars/all.json"
   $ ${TURBO} run build --summarize > /dev/null
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
   $ cat .turbo/runs/*.json | jq -r '.envMode'
   strict
   $ cat .turbo/runs/*.json | jq -r '.tasks[0].envMode'
@@ -68,6 +71,7 @@ All specified + loose
   $ rm -rf .turbo/runs
   $ ${TESTDIR}/../../../helpers/replace_turbo_json.sh $(pwd) "strict_env_vars/all.json"
   $ ${TURBO} run build --env-mode=loose --summarize > /dev/null
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
   $ cat .turbo/runs/*.json | jq -r '.envMode'
   loose
   $ cat .turbo/runs/*.json | jq -r '.tasks[0].envMode'
@@ -98,6 +102,7 @@ Global passthrough specified value + infer
   $ rm -rf .turbo/runs
   $ ${TESTDIR}/../../../helpers/replace_turbo_json.sh $(pwd) "strict_env_vars/global_pt.json"
   $ ${TURBO} run build --summarize > /dev/null
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
   $ cat .turbo/runs/*.json | jq -r '.envMode'
   strict
   $ cat .turbo/runs/*.json | jq -r '.tasks[0].envMode'
@@ -154,6 +159,7 @@ Task passthrough specified value + infer
   $ rm -rf .turbo/runs
   $ ${TESTDIR}/../../../helpers/replace_turbo_json.sh $(pwd) "strict_env_vars/task_pt.json"
   $ ${TURBO} run build --summarize > /dev/null
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
   $ cat .turbo/runs/*.json | jq -r '.envMode'
   strict
   $ cat .turbo/runs/*.json | jq -r '.tasks[0].envMode'

--- a/turborepo-tests/integration/tests/run/continue.t
+++ b/turborepo-tests/integration/tests/run/continue.t
@@ -84,5 +84,6 @@ Run with --continue
     Time:\s*[\.0-9]+m?s  (re)
   Failed:    other-app#build, some-lib#build
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
    ERROR  run failed: command  exited (1)
   [1]

--- a/turborepo-tests/integration/tests/run/force.t
+++ b/turborepo-tests/integration/tests/run/force.t
@@ -30,6 +30,7 @@ baseline to generate cache
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
 
 # env var=true, missing flag: cache bypass
   $ TURBO_FORCE=true ${TURBO} run build --output-logs=hash-only --filter=my-app
@@ -42,6 +43,7 @@ baseline to generate cache
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
 # env var=true, --flag=true: cache bypass
   $ TURBO_FORCE=true ${TURBO} run build --output-logs=hash-only --filter=my-app --force=true
   \xe2\x80\xa2 Packages in scope: my-app (esc)
@@ -53,6 +55,7 @@ baseline to generate cache
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
 # env var=true, --flag=false: cache hit
   $ TURBO_FORCE=true ${TURBO} run build --output-logs=hash-only --filter=my-app --force=false
   \xe2\x80\xa2 Packages in scope: my-app (esc)
@@ -75,6 +78,7 @@ baseline to generate cache
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
 
 # env var=false, missing flag, cache hit
   $ TURBO_FORCE=false ${TURBO} run build --output-logs=hash-only --filter=my-app
@@ -98,6 +102,7 @@ baseline to generate cache
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
 # env var=false, --flag=false: cache hit
   $ TURBO_FORCE=false ${TURBO} run build --output-logs=hash-only --filter=my-app --force=false
   \xe2\x80\xa2 Packages in scope: my-app (esc)
@@ -120,6 +125,7 @@ baseline to generate cache
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
 
 # missing env var, missing flag: cache hit
   $ ${TURBO} run build --output-logs=hash-only --filter=my-app
@@ -143,6 +149,7 @@ baseline to generate cache
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
 # missing env var, --flag=false: cache hit
   $ ${TURBO} run build --output-logs=hash-only --filter=my-app --force=false
   \xe2\x80\xa2 Packages in scope: my-app (esc)
@@ -165,3 +172,4 @@ baseline to generate cache
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`

--- a/turborepo-tests/integration/tests/run/gitignored-inputs.t
+++ b/turborepo-tests/integration/tests/run/gitignored-inputs.t
@@ -16,6 +16,7 @@ Some helper functions to parse the summary file
 
 Just run the util package, it's simpler
   $ ${TURBO} run build --filter=util --output-logs=hash-only --summarize | grep "util:build: cache"
+   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
   util:build: cache miss, executing 11cff3dd389fdfed
 
   $ FIRST=$(/bin/ls .turbo/runs/*.json | head -n1)
@@ -30,6 +31,7 @@ Change the content of internal.txt
 
 Hash does not change, because it is gitignored
   $ ${TURBO} run build --filter=util --output-logs=hash-only --summarize | grep "util:build: cache"
+   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
   util:build: cache miss, executing a489883a3c7cd307
 
 The internal.txt hash should be different from the one before

--- a/turborepo-tests/integration/tests/run/no-root-turbo.t
+++ b/turborepo-tests/integration/tests/run/no-root-turbo.t
@@ -25,6 +25,7 @@ Run with --root-turbo-json should use specified config
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
 
 Run with TURBO_ROOT_TURBO_JSON should use specified config
   $ TURBO_ROOT_TURBO_JSON=turborepo.json ${TURBO} build --filter=my-app

--- a/turborepo-tests/integration/tests/run/one-script-error.t
+++ b/turborepo-tests/integration/tests/run/one-script-error.t
@@ -30,6 +30,7 @@ Note that npm reports any failed script as exit code 1, even though we "exit 2"
     Time:\s*[\.0-9]+m?s  (re)
   Failed:    my-app#error
   
+   WARNING  no output files found for task my-app#okay. Please check your `outputs` key in `turbo.json`
    ERROR  run failed: command  exited (1)
   [1]
 
@@ -98,5 +99,6 @@ Make sure error code isn't swallowed with continue
     Time:\s*[\.0-9]+m?s  (re)
   Failed:    my-app#error
   
+   WARNING  no output files found for task my-app#okay2. Please check your `outputs` key in `turbo.json`
    ERROR  run failed: command  exited (1)
   [1]

--- a/turborepo-tests/integration/tests/run/profile.t
+++ b/turborepo-tests/integration/tests/run/profile.t
@@ -4,5 +4,7 @@ Setup
 Run build and record a trace
 Ignore output since we want to focus on testing the generated profile
   $ ${TURBO} build --profile=build.trace > turbo.log
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
+   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
 Make sure the resulting trace is valid JSON
   $ node -e "require('./build.trace')"

--- a/turborepo-tests/integration/tests/run/single-package/with-deps-run.t
+++ b/turborepo-tests/integration/tests/run/single-package/with-deps-run.t
@@ -21,6 +21,7 @@ Check
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task //#test. Please check your `outputs` key in `turbo.json`
 Run a second time, verify caching works because there is a config
   $ ${TURBO} run test
   \xe2\x80\xa2 Running test (esc)

--- a/turborepo-tests/integration/tests/run/unnamed-packages.t
+++ b/turborepo-tests/integration/tests/run/unnamed-packages.t
@@ -18,3 +18,4 @@ which does not have a name should be ignored. We should process it but filter.
   Cached:    0 cached, 1 total
     Time:    (.+)  (re)
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`

--- a/turborepo-tests/integration/tests/task-dependencies/overwriting.t
+++ b/turborepo-tests/integration/tests/task-dependencies/overwriting.t
@@ -4,6 +4,9 @@ Setup
 
 Test
   $ ${TURBO} run build > tmp.log
+   WARNING  no output files found for task workspace-a#build. Please check your `outputs` key in `turbo.json`
+   WARNING  no output files found for task workspace-a#generate. Please check your `outputs` key in `turbo.json`
+   WARNING  no output files found for task workspace-b#build. Please check your `outputs` key in `turbo.json`
   $ cat tmp.log | grep "Packages in scope" -A2
   \xe2\x80\xa2 Packages in scope: workspace-a, workspace-b (esc)
   \xe2\x80\xa2 Running build in 2 packages (esc)

--- a/turborepo-tests/integration/tests/task-dependencies/root-workspace.t
+++ b/turborepo-tests/integration/tests/task-dependencies/root-workspace.t
@@ -22,3 +22,5 @@ This tests asserts that root tasks can depend on workspace#task
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9ms]+  (re)
   
+   WARNING  no output files found for task //#mytask. Please check your `outputs` key in `turbo.json`
+   WARNING  no output files found for task lib-a#build. Please check your `outputs` key in `turbo.json`

--- a/turborepo-tests/integration/tests/task-dependencies/topological.t
+++ b/turborepo-tests/integration/tests/task-dependencies/topological.t
@@ -23,6 +23,8 @@ Check my-app#build output
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
+   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
 
 
 

--- a/turborepo-tests/integration/tests/workspace-configs/add-keys.t
+++ b/turborepo-tests/integration/tests/workspace-configs/add-keys.t
@@ -10,6 +10,7 @@ Setup
 
 # 1. First run, assert for `dependsOn` and `outputs` keys
   $ ${TURBO} run add-keys-task --filter=add-keys > tmp.log
+   WARNING  no output files found for task add-keys#add-keys-underlying-task. Please check your `outputs` key in `turbo.json`
   $ cat tmp.log
   \xe2\x80\xa2 Packages in scope: add-keys (esc)
   \xe2\x80\xa2 Running add-keys-task in 1 packages (esc)
@@ -76,6 +77,7 @@ Setup
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task add-keys#add-keys-underlying-task. Please check your `outputs` key in `turbo.json`
 # 4. Set env var and assert cache miss
   $ SOME_VAR=somevalue ${TURBO} run add-keys-task --filter=add-keys
   \xe2\x80\xa2 Packages in scope: add-keys (esc)

--- a/turborepo-tests/integration/tests/workspace-configs/cross-workspace.t
+++ b/turborepo-tests/integration/tests/workspace-configs/cross-workspace.t
@@ -21,3 +21,5 @@ Setup
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task blank-pkg#cross-workspace-underlying-task. Please check your `outputs` key in `turbo.json`
+   WARNING  no output files found for task cross-workspace#cross-workspace-task. Please check your `outputs` key in `turbo.json`

--- a/turborepo-tests/integration/tests/workspace-configs/missing-workspace-config-deps.t
+++ b/turborepo-tests/integration/tests/workspace-configs/missing-workspace-config-deps.t
@@ -7,6 +7,8 @@ Setup
 
 # 1. First run, assert that dependet tasks run `dependsOn`
   $ ${TURBO} run missing-workspace-config-task-with-deps --filter=missing-workspace-config > tmp.log
+   WARNING  no output files found for task blank-pkg#missing-workspace-config-underlying-topo-task. Please check your `outputs` key in `turbo.json`
+   WARNING  no output files found for task missing-workspace-config#missing-workspace-config-underlying-task. Please check your `outputs` key in `turbo.json`
 # Validate in pieces. `omit-key` task has two dependsOn values, and those tasks
 # can run in non-deterministic order. So we need to validate the logs in the pieces.
   $ cat tmp.log | grep "in scope" -A 2

--- a/turborepo-tests/integration/tests/workspace-configs/omit-keys-deps.t
+++ b/turborepo-tests/integration/tests/workspace-configs/omit-keys-deps.t
@@ -8,6 +8,8 @@ Setup
 
 # 1. First run, assert for `dependsOn` and `outputs` keys
   $ ${TURBO} run omit-keys-task-with-deps --filter=omit-keys > tmp.log
+   WARNING  no output files found for task blank-pkg#omit-keys-underlying-topo-task. Please check your `outputs` key in `turbo.json`
+   WARNING  no output files found for task omit-keys#omit-keys-underlying-task. Please check your `outputs` key in `turbo.json`
 # Validate in pieces. `omit-key` task has two dependsOn values, and those tasks
 # can run in non-deterministic order. So we need to validatte the logs in pieces.
   $ cat tmp.log | grep "in scope" -A 1

--- a/turborepo-tests/integration/tests/workspace-configs/override-values-deps.t
+++ b/turborepo-tests/integration/tests/workspace-configs/override-values-deps.t
@@ -22,6 +22,7 @@ Setup
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task override-values#override-values-task-with-deps. Please check your `outputs` key in `turbo.json`
 
 # This is the same test as above, but with --dry and testing the resolvedTaskDefinition has the same value for dependsOn
   $ ${TURBO} run override-values-task-with-deps --filter=override-values --dry=json | jq '.tasks | map(select(.taskId == "override-values#override-values-task-with-deps")) | .[0].resolvedTaskDefinition'

--- a/turborepo-tests/integration/tests/workspace-configs/persistent.t
+++ b/turborepo-tests/integration/tests/workspace-configs/persistent.t
@@ -47,6 +47,8 @@ This test covers:
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
+   WARNING  no output files found for task persistent#persistent-task-2-parent. Please check your `outputs` key in `turbo.json`
+   WARNING  no output files found for task persistent#persistent-task-2. Please check your `outputs` key in `turbo.json`
 # persistent-task-3-parent dependsOn persistent-task-3
 # persistent-task-3 is persistent:true in the root workspace
 # persistent-task-3 is defined in workspace, but does NOT have the persistent flag


### PR DESCRIPTION
### Description

Warns if cache payload consists of just the log file and output globs are specified.

### Testing Instructions

Turns out all of our test fixtures have empty outputs so we get a lot of these warnings in tests