### PR TITLE
log::debug and ignore on daemon usage in CI

### DIFF
--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -14,7 +14,7 @@ use miette::{Diagnostic, NamedSource, SourceSpan};
 use serde::Deserialize;
 use struct_iterable::Iterable;
 use thiserror::Error;
-use tracing::warn;
+use tracing::debug;
 use turbo_json::TurboJsonReader;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_errors::TURBO_SITE;
@@ -333,7 +333,7 @@ impl ConfigurationOptions {
         // hardcode to off in CI
         if turborepo_ci::is_ci() {
             if Some(true) == self.daemon {
-                warn!("Ignoring daemon setting and disabling the daemon because we're in CI");
+                debug!("Ignoring daemon setting and disabling the daemon because we're in CI");
             }
 
             return Some(false);

--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -329,6 +329,11 @@ impl ConfigurationOptions {
     }
 
     pub fn daemon(&self) -> Option<bool> {
+        // hardcode to off in CI
+        if turborepo_ci::is_ci() {
+            return Some(false);
+        }
+
         self.daemon
     }
 

--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -14,6 +14,7 @@ use miette::{Diagnostic, NamedSource, SourceSpan};
 use serde::Deserialize;
 use struct_iterable::Iterable;
 use thiserror::Error;
+use tracing::warn;
 use turbo_json::TurboJsonReader;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_errors::TURBO_SITE;
@@ -331,6 +332,10 @@ impl ConfigurationOptions {
     pub fn daemon(&self) -> Option<bool> {
         // hardcode to off in CI
         if turborepo_ci::is_ci() {
+            if Some(true) == self.daemon {
+                warn!("Ignoring daemon setting and disabling the daemon because we're in CI");
+            }
+
             return Some(false);
         }
 

--- a/docs/repo-docs/reference/configuration.mdx
+++ b/docs/repo-docs/reference/configuration.mdx
@@ -141,6 +141,12 @@ Turborepo runs a background process to pre-calculate some expensive operations. 
 }
 ```
 
+<Callout type="good-to-know">
+  Note that when running in a CI environment the daemon is disabled, even if you
+  set this value to `true`. This is because the daemon is not useful in a CI
+  environment and can cause timing out on deploys.
+</Callout>
+
 ### `envMode`
 
 Default: `"strict"`

--- a/docs/repo-docs/reference/configuration.mdx
+++ b/docs/repo-docs/reference/configuration.mdx
@@ -142,9 +142,7 @@ Turborepo runs a background process to pre-calculate some expensive operations. 
 ```
 
 <Callout type="good-to-know">
-  Note that when running in a CI environment the daemon is disabled, even if you
-  set this value to `true`. This is because the daemon is not useful in a CI
-  environment and can cause timing out on deploys.
+  When running in a CI environment the daemon is always disabled regardless of this setting.
 </Callout>
 
 ### `envMode`


### PR DESCRIPTION
Setting `daemon: true` in `turbo.json` can cause timing out on deploys.  Using the daemon in CI/CD is almost* never the desired behavior.  Instead, we will detect a CI environment and force the daemon off in these situations.

<sub>*perhaps the only use-case is for us, internally, testing the daemon in our internal tests (which, run on the CI).</sub>
