### PR TITLE
fix napi double .d.ts formatting

### DIFF
--- a/packages/turbo-repository/package.json
+++ b/packages/turbo-repository/package.json
@@ -5,8 +5,8 @@
   "bugs": "https://github.com/vercel/turborepo/issues",
   "homepage": "https://turbo.build/repo",
   "scripts": {
-    "build": "napi build --platform -p turborepo-napi --cargo-cwd ../../ --cargo-name turborepo_napi native --js false --dts ../js/index.d.ts && mkdir -p js/dist && cp js/index.js js/dist/index.js && cp js/index.d.ts js/dist/index.d.ts",
-    "build:release": "napi build --release --platform -p turborepo-napi --cargo-cwd ../../ --cargo-name turborepo_napi native --js false",
+    "build": "bash scripts/build.sh",
+    "build:release": "bash scripts/build.sh release",
     "package": "node scripts/publish.mjs",
     "test": "node --import tsx --test __tests__/*.test.ts"
   },
@@ -17,6 +17,7 @@
     "@napi-rs/cli": "^2.16.3",
     "execa": "^8.0.1",
     "fs-extra": "^11.1.1",
+    "prettier": "^3.2.5",
     "tsx": "^4.7.2"
   },
   "main": "dist/index.js",

--- a/packages/turbo-repository/scripts/build.sh
+++ b/packages/turbo-repository/scripts/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+flags="\
+  --platform \
+  -p turborepo-napi \
+  --cargo-cwd ../../ \
+  --cargo-name turborepo_napi \
+  native \
+  --js false \
+"
+
+if [ "$1" == "release" ]; then
+  flags+=" --release"
+else
+  flags+=" --dts ../js/index.d.ts"
+fi
+
+node_modules/.bin/napi build $flags
+
+# Unfortunately, when napi generates a .d.ts file, it doesn't match our formatting rules (it doesn't have semicolons).
+# Since there's now way to configure this from napi itself, so we need to run prettier on it after generating it.
+node_modules/.bin/prettier --write js/index.d.ts
+
+mkdir -p js/dist
+cp js/index.{js,d.ts} js/dist/

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -561,6 +561,9 @@ importers:
       fs-extra:
         specifier: ^11.1.1
         version: 11.1.1
+      prettier:
+        specifier: ^3.2.5
+        version: 3.3.3
       tsx:
         specifier: ^4.7.2
         version: 4.7.2
@@ -9486,6 +9489,12 @@ packages:
   /prettier@2.8.7:
     resolution: {integrity: sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==}
     engines: {node: '>=10.13.0'}
+    hasBin: true
+    dev: true
+
+  /prettier@3.3.3:
+    resolution: {integrity: sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==}
+    engines: {node: '>=14'}
     hasBin: true
     dev: true
 


### PR DESCRIPTION
### Description

`napi-rs` generates a .d.ts file for us in `turbo-repository`.  Unfortunately, this file doesn't match our project's formatting (the generated file doesn't include semicolons).  This means that every time we locally run a command (for example, `pnpm test`) that courses through this generation we jiggle this file, creating a lot of noise when developing.

This small PR fixes this by simplifying the script and running prettier on it.

### Testing Instructions

run `pnpm build` from `packages/turbo-repository` before this PR and see the file change, and notice that after this PR the file change goes away.
