### PR TITLE
chore: fix clippy lint in filter tests

### DIFF
--- a/crates/turborepo-lib/src/run/scope/filter.rs
+++ b/crates/turborepo-lib/src/run/scope/filter.rs
@@ -1104,10 +1104,7 @@ mod test {
         let packages = resolver.get_filtered_packages(selectors).unwrap();
 
         assert_eq!(
-            packages
-                .into_iter()
-                .map(|(name, _)| name)
-                .collect::<HashSet<_>>(),
+            packages.into_keys().collect::<HashSet<_>>(),
             expected.iter().map(|s| PackageName::from(*s)).collect()
         );
     }
@@ -1339,10 +1336,7 @@ mod test {
 
         let packages = resolver.get_filtered_packages(selectors).unwrap();
         assert_eq!(
-            packages
-                .into_iter()
-                .map(|(name, _)| name)
-                .collect::<HashSet<_>>(),
+            packages.into_keys().collect::<HashSet<_>>(),
             expected.iter().map(|s| PackageName::from(*s)).collect()
         );
     }


### PR DESCRIPTION
### Description

Fixing some clippy lints that only get displayed if compiled with when `test` is enabled.

### Testing Instructions

👀 
