### PR TITLE
fix(docs): circleci config - remove excess colon when calling node/install-packages

### DIFF
--- a/docs/repo-docs/guides/ci-vendors/circleci.mdx
+++ b/docs/repo-docs/guides/ci-vendors/circleci.mdx
@@ -124,7 +124,7 @@ Create a file called `.circleci/config.yml` in your repository with the followin
           - image: cimg/node:lts
         steps:
           - checkout
-          - node/install-packages:
+          - node/install-packages
           - run:
             command: npm i -g pnpm
             environment:


### PR DESCRIPTION
In this example we need to remove the colon at the end, since we're calling the command without params.

Otherwise we get a schema validation error since it attempts to use lines below as mapping.

### Description

![image](https://github.com/user-attachments/assets/264d38d0-0cb9-44cf-a9b4-5061408dcd0c)


<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

