### PR TITLE
chore(trace): fix compilation error in turbo-trace

### DIFF
--- a/crates/turbo-trace/src/main.rs
+++ b/crates/turbo-trace/src/main.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), PathError> {
         .map(|f| AbsoluteSystemPathBuf::from_unknown(&abs_cwd, f))
         .collect();
 
-    let tracer = Tracer::new(abs_cwd, files, args.ts_config)?;
+    let tracer = Tracer::new(abs_cwd, files, args.ts_config);
 
     let result = tracer.trace();
 


### PR DESCRIPTION
### Description

`Tracer::new` returns `Tracer` not a try-able type so we remove the `?`

Future work is getting this crate covered by CI so we make sure it compiles.

### Testing Instructions

It compiles now
