### PR TITLE
ci: build all rust packages

### DIFF
--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -229,7 +229,7 @@ jobs:
 
       - name: Run cargo clippy
         run: |
-          cargo groups clippy turborepo-libraries --features rustls-tls -- --deny clippy::all
+          cargo clippy --workspace --features rustls-tls -- --deny clippy::all
 
       - name: Run ast-grep lints
         run: |
@@ -260,7 +260,7 @@ jobs:
 
       - name: Run cargo check
         run: |
-          cargo groups check turborepo-libraries
+          cargo check --workspace
 
   rust_test:
     needs: [rust_check]
@@ -309,7 +309,7 @@ jobs:
           if [ -z "${RUSTC_WRAPPER}" ]; then
             unset RUSTC_WRAPPER
           fi          
-          cargo groups test turborepo-libraries
+          cargo nextest run --workspace
         shell: bash
         env:
           SCCACHE_BUCKET: turborepo-sccache

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -308,8 +308,12 @@ jobs:
         run: |
           if [ -z "${RUSTC_WRAPPER}" ]; then
             unset RUSTC_WRAPPER
-          fi          
-          cargo test --workspace
+          fi
+          if [ "$RUNNER_OS" == "Windows" ]; then
+              cargo test --workspace --exclude turborepo-napi
+          else
+              cargo test --workspace
+          fi
         shell: bash
         env:
           SCCACHE_BUCKET: turborepo-sccache

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -309,7 +309,7 @@ jobs:
           if [ -z "${RUSTC_WRAPPER}" ]; then
             unset RUSTC_WRAPPER
           fi          
-          cargo nextest run --workspace
+          cargo test --workspace
         shell: bash
         env:
           SCCACHE_BUCKET: turborepo-sccache

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -219,7 +219,7 @@ impl Workspace {
                     path: info.package_path().to_owned(),
                 })
                 .collect::<Vec<WorkspacePackage>>(),
-            PackageChanges::Some(packages) => packages.into_iter().map(|(p, _)| p).collect(),
+            PackageChanges::Some(packages) => packages.into_keys().collect(),
         };
 
         let mut serializable_packages: Vec<Package> = packages


### PR DESCRIPTION
### Description

Since we're no longer sharing a repo with turbopack, we can now build all the crates instead of using cargo groups

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
