### PR TITLE
fix(query): remove engine validation for query

### DIFF
--- a/crates/turborepo-lib/src/commands/query.rs
+++ b/crates/turborepo-lib/src/commands/query.rs
@@ -68,7 +68,9 @@ pub async fn run(
         execution_args: Box::default(),
     });
 
-    let run_builder = RunBuilder::new(base)?.add_all_tasks();
+    let run_builder = RunBuilder::new(base)?
+        .add_all_tasks()
+        .do_not_validate_engine();
     let run = run_builder.build(&handler, telemetry).await?;
 
     if let Some(query) = query {

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -101,6 +101,7 @@ pub struct EngineBuilder<'a> {
     root_enabled_tasks: HashSet<TaskName<'static>>,
     tasks_only: bool,
     add_all_tasks: bool,
+    should_validate_engine: bool,
 }
 
 impl<'a> EngineBuilder<'a> {
@@ -120,6 +121,7 @@ impl<'a> EngineBuilder<'a> {
             root_enabled_tasks: HashSet::new(),
             tasks_only: false,
             add_all_tasks: false,
+            should_validate_engine: true,
         }
     }
 
@@ -154,6 +156,11 @@ impl<'a> EngineBuilder<'a> {
     /// specified
     pub fn add_all_tasks(mut self) -> Self {
         self.add_all_tasks = true;
+        self
+    }
+
+    pub fn do_not_validate_engine(mut self) -> Self {
+        self.should_validate_engine = false;
         self
     }
 
@@ -502,7 +509,7 @@ impl<'a> EngineBuilder<'a> {
             }
         }
 
-        if task_definitions.is_empty() {
+        if task_definitions.is_empty() && self.should_validate_engine {
             let (span, text) = task_id.span_and_text("turbo.json");
             return Err(Error::MissingPackageTask {
                 span,

--- a/turborepo-tests/integration/fixtures/persistent_dependencies/3-workspace-specific/turbo.json
+++ b/turborepo-tests/integration/fixtures/persistent_dependencies/3-workspace-specific/turbo.json
@@ -2,9 +2,10 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build": {
-      "dependsOn": ["pkg-a#dev"]
+      "dependsOn": [
+        "pkg-a#dev"
+      ]
     },
-
     "pkg-a#dev": {
       "persistent": true
     }

--- a/turborepo-tests/integration/fixtures/persistent_dependencies/3-workspace-specific/turbo.json
+++ b/turborepo-tests/integration/fixtures/persistent_dependencies/3-workspace-specific/turbo.json
@@ -2,10 +2,9 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build": {
-      "dependsOn": [
-        "pkg-a#dev"
-      ]
+      "dependsOn": ["pkg-a#dev"]
     },
+
     "pkg-a#dev": {
       "persistent": true
     }

--- a/turborepo-tests/integration/fixtures/task_dependencies/invalid-dependency/app-a/package.json
+++ b/turborepo-tests/integration/fixtures/task_dependencies/invalid-dependency/app-a/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "app-a",
+  "scripts": {
+    "build": "echo 'build app-a'",
+    "test": "echo 'test app-a'"
+  },
+  "dependencies": {
+    "lib-a": "*"
+  }
+}

--- a/turborepo-tests/integration/fixtures/task_dependencies/invalid-dependency/app-b/package.json
+++ b/turborepo-tests/integration/fixtures/task_dependencies/invalid-dependency/app-b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "app-b",
+  "scripts": {
+    "build": "echo 'build app-b'",
+    "test": "echo 'test app-b'"
+  },
+  "dependencies": {
+    "lib-b": "*",
+    "lib-c": "*"
+  }
+}

--- a/turborepo-tests/integration/fixtures/task_dependencies/invalid-dependency/lib-a/package.json
+++ b/turborepo-tests/integration/fixtures/task_dependencies/invalid-dependency/lib-a/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "lib-a",
+  "scripts": {
+    "build": "echo 'build lib-a'",
+    "test": "echo 'test lib-a'"
+  },
+  "dependencies": {
+    "lib-b": "*"
+  }
+}

--- a/turborepo-tests/integration/fixtures/task_dependencies/invalid-dependency/lib-b/package.json
+++ b/turborepo-tests/integration/fixtures/task_dependencies/invalid-dependency/lib-b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "lib-b",
+  "scripts": {
+    "build": "echo 'build lib-b'",
+    "test": "echo 'test lib-b'"
+  },
+  "dependencies": {
+    "lib-d": "*"
+  }
+}

--- a/turborepo-tests/integration/fixtures/task_dependencies/invalid-dependency/lib-c/package.json
+++ b/turborepo-tests/integration/fixtures/task_dependencies/invalid-dependency/lib-c/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "lib-c",
+  "scripts": {
+    "build": "echo 'build lib-c'"
+  }
+}

--- a/turborepo-tests/integration/fixtures/task_dependencies/invalid-dependency/lib-d/package.json
+++ b/turborepo-tests/integration/fixtures/task_dependencies/invalid-dependency/lib-d/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "lib-d",
+  "scripts": {
+    "build": "echo 'build lib-d'",
+    "test": "echo 'test lib-d'"
+  }
+}

--- a/turborepo-tests/integration/fixtures/task_dependencies/invalid-dependency/package.json
+++ b/turborepo-tests/integration/fixtures/task_dependencies/invalid-dependency/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "unknown-dependency",
+  "workspaces": [
+    "app-a",
+    "app-b",
+    "lib-a",
+    "lib-b",
+    "lib-c",
+    "lib-d"
+  ]
+}

--- a/turborepo-tests/integration/fixtures/task_dependencies/invalid-dependency/turbo.json
+++ b/turborepo-tests/integration/fixtures/task_dependencies/invalid-dependency/turbo.json
@@ -1,0 +1,32 @@
+{
+  "tasks": {
+    "build0": {
+      "dependsOn": [
+        "^build0",
+        "prepare"
+      ]
+    },
+    "test": {
+      "dependsOn": [
+        "^build0",
+        "prepare"
+      ]
+    },
+    "prepare": {},
+    "side-quest": {
+      "dependsOn": [
+        "prepare"
+      ]
+    },
+    "build1": {
+      "dependsOn": [
+        "^build1"
+      ]
+    },
+    "build2": {
+      "dependsOn": [
+        "app-a#custom"
+      ]
+    }
+  }
+}

--- a/turborepo-tests/integration/tests/query/validation.t
+++ b/turborepo-tests/integration/tests/query/validation.t
@@ -1,0 +1,148 @@
+Setup
+  $ . ${TESTDIR}/../../../helpers/setup_integration_test.sh persistent_dependencies/10-too-many
+
+Validate that we get an error when we try to run multiple persistent tasks with concurrency 1
+  $ ${TURBO} run build --concurrency=1
+    x invalid task configuration
+  
+  Error:   x You have 2 persistent tasks but `turbo` is configured for concurrency of
+    | 1. Set --concurrency to at least 3
+  
+  [1]
+
+However on query, we ignore this validation
+  $ ${TURBO} query "query { packages { items { tasks { items { fullName } } } } }" | jq
+   WARNING  query command is experimental and may change in the future
+  {
+    "data": {
+      "packages": {
+        "items": [
+          {
+            "tasks": {
+              "items": []
+            }
+          },
+          {
+            "tasks": {
+              "items": [
+                {
+                  "fullName": "one#build"
+                }
+              ]
+            }
+          },
+          {
+            "tasks": {
+              "items": [
+                {
+                  "fullName": "two#build"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+
+Setup
+  $ . ${TESTDIR}/../../../helpers/setup_integration_test.sh task_dependencies/invalid-dependency
+  warning: re-init: ignored --initial-branch=main
+
+Validate that we get an error when trying to depend on a task that doesn't exist
+  $ ${TURBO} run build2
+    x Could not find "app-a#custom" in root turbo.json or "custom" in package
+      ,-[turbo.json:27:1]
+   27 |       "dependsOn": [
+   28 |         "app-a#custom"
+      :         ^^^^^^^^^^^^^^
+   29 |       ]
+      `----
+  
+  [1]
+
+However, we don't get an error when we query
+  $ ${TURBO} query "query { packages { items { tasks { items { fullName } } } } }" | jq
+   WARNING  query command is experimental and may change in the future
+  {
+    "data": {
+      "packages": {
+        "items": [
+          {
+            "tasks": {
+              "items": []
+            }
+          },
+          {
+            "tasks": {
+              "items": [
+                {
+                  "fullName": "app-a#build"
+                },
+                {
+                  "fullName": "app-a#test"
+                }
+              ]
+            }
+          },
+          {
+            "tasks": {
+              "items": [
+                {
+                  "fullName": "app-b#build"
+                },
+                {
+                  "fullName": "app-b#test"
+                }
+              ]
+            }
+          },
+          {
+            "tasks": {
+              "items": [
+                {
+                  "fullName": "lib-a#build"
+                },
+                {
+                  "fullName": "lib-a#test"
+                }
+              ]
+            }
+          },
+          {
+            "tasks": {
+              "items": [
+                {
+                  "fullName": "lib-b#build"
+                },
+                {
+                  "fullName": "lib-b#test"
+                }
+              ]
+            }
+          },
+          {
+            "tasks": {
+              "items": [
+                {
+                  "fullName": "lib-c#build"
+                }
+              ]
+            }
+          },
+          {
+            "tasks": {
+              "items": [
+                {
+                  "fullName": "lib-d#build"
+                },
+                {
+                  "fullName": "lib-d#test"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }


### PR DESCRIPTION
### Description

We don't want to validate certain issues with graphs with `turbo query`, because it should be still usable even with an invalid graph.

### Testing Instructions

Added a test that shows that `turbo query` is tolerant of issues that `turbo run` is not.
