### PR TITLE
chore: fix flakey log stream integration test

### DIFF
--- a/turborepo-tests/integration/tests/run-logging/log-order-stream.t
+++ b/turborepo-tests/integration/tests/run-logging/log-order-stream.t
@@ -35,6 +35,7 @@ it just guarantees setting this env var won't crash.
   \xe2\x80\xa2 Running build in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
   (my-app|util):build: cache bypass, force executing [0-9a-f]+ (re)
+  (my-app|util):build: cache bypass, force executing [0-9a-f]+ (re)
   .* (re)
   .* (re)
   .* (re)
@@ -44,7 +45,6 @@ it just guarantees setting this env var won't crash.
   .* (re)
   .* (re)
   .* (re)
-  my-app:build: building
   util:build: building
   my-app:build: done
   util:build: completed
@@ -61,6 +61,8 @@ The flag wins over the env var
   \xe2\x80\xa2 Packages in scope: my-app, util (esc)
   \xe2\x80\xa2 Running build in 2 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
+  (my-app|util):build: cache bypass, force executing [0-9a-f]+ (re)
+  (my-app|util):build: cache bypass, force executing [0-9a-f]+ (re)
   .* (re)
   .* (re)
   .* (re)
@@ -70,8 +72,6 @@ The flag wins over the env var
   .* (re)
   .* (re)
   .* (re)
-  (my-app|util):build:  (re)
-  (my-app:build): building (re)
   util:build: building
   my-app:build: done
   util:build: completed


### PR DESCRIPTION
### Description

I've noticed this integration test has been flakey lately:
 - https://github.com/vercel/turborepo/actions/runs/11387765428/job/31683165527
 - https://github.com/vercel/turborepo/actions/runs/11386983833/job/31680539914
 - https://github.com/vercel/turborepo/actions/runs/11356438462/job/31587646091

Partially reverts changes from #9236 for the cases that I've seen fail. I don't remember this test being flakey before, so I'm changing it back. I'm assuming we're now capturing [some lines](https://github.com/vercel/turborepo/blob/ef2dc90030c6103393d42bdd5fb7f3584f1466a8/turborepo-tests/integration/tests/run-logging/log-order-stream.t#L47) that aren't deterministic in ordering.

### Testing Instructions

Ran the test a few times and didn't get any failures. Hopefully CI is green.
