### PR TITLE
fix(tui): generate stop event on ctrl c

### DIFF
--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -61,7 +61,8 @@ fn translate_key_event(options: InputOptions, key_event: KeyEvent) -> Option<Eve
     }
     match key_event.code {
         KeyCode::Char('c') if key_event.modifiers == crossterm::event::KeyModifiers::CONTROL => {
-            ctrl_c()
+            ctrl_c();
+            Some(Event::InternalStop)
         }
         KeyCode::Char('c') if options.has_selection => Some(Event::CopySelection),
         // Interactive branches


### PR DESCRIPTION
### Description

Previously we had used a `None` return from the input handler as a signal that the TUI should shut down. We no longer do this so we need to explicitly return `Event::InternalStop` to signal that we should shut down the TUI.

### Testing Instructions

Start up a dev task with 2.2.1 and observe that on Ctrl-C the terminal is left in raw mode:
<img width="1074" alt="Screenshot 2024-10-20 at 3 31 40 PM" src="https://github.com/user-attachments/assets/9b8abf85-20b6-4991-aa64-09a1edcc617b">


With the build from the PR you should note that the on Ctrl-C the terminal is returned to a cooked mode:
<img width="582" alt="Screenshot 2024-10-20 at 3 32 14 PM" src="https://github.com/user-attachments/assets/521381d6-6a28-4dbb-b56b-0d1cae7fbd27">
