### PR TITLE
fix: unnecessary empty cache logs

### DIFF
--- a/crates/turborepo-lib/src/task_graph/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/mod.rs
@@ -23,9 +23,13 @@ pub struct TaskOutputs {
 }
 
 impl TaskOutputs {
+    // We consider an empty outputs to be a log output and nothing else
     pub fn is_empty(&self) -> bool {
-        self.inclusions.is_empty() && self.exclusions.is_empty()
+        self.inclusions.len() == 1
+            && self.inclusions[0].ends_with(".log")
+            && self.exclusions.is_empty()
     }
+
     pub fn validated_inclusions(&self) -> Result<Vec<ValidatedGlob>, GlobError> {
         self.inclusions
             .iter()

--- a/turborepo-tests/integration/tests/filter-run.t
+++ b/turborepo-tests/integration/tests/filter-run.t
@@ -41,7 +41,6 @@ Setup
     Time:\s*[\.0-9]+m?s  (re)
   
    WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
-   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
 
 Non existent package name should error
   $ ${TURBO} run build --filter="foo" --output-logs none

--- a/turborepo-tests/integration/tests/global-env.t
+++ b/turborepo-tests/integration/tests/global-env.t
@@ -14,7 +14,6 @@ Setup
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
 # run again and ensure there's a cache hit
   $ ${TURBO} run build --filter=util --output-logs=hash-only
   \xe2\x80\xa2 Packages in scope: util (esc)
@@ -37,7 +36,6 @@ Setup
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
 # set env var with "THASH" and ensure cache miss
   $ SOMETHING_THASH_YES=hi ${TURBO} run build --filter=util --output-logs=hash-only
   \xe2\x80\xa2 Packages in scope: util (esc)
@@ -60,7 +58,6 @@ Setup
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
 # THASH deprecation doesn't break --dry=json
   $ SOMETHING_THASH_YES=hi ${TURBO} run build --filter=util --dry=json | jq -r '.tasks[0].environmentVariables.global[0]'
   null

--- a/turborepo-tests/integration/tests/lockfile-aware-caching/berry.t
+++ b/turborepo-tests/integration/tests/lockfile-aware-caching/berry.t
@@ -14,7 +14,6 @@ Populate cache
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task a#build. Please check your `outputs` key in `turbo.json`
   $ ${TURBO} build --filter=b
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
@@ -26,7 +25,6 @@ Populate cache
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task b#build. Please check your `outputs` key in `turbo.json`
 
 Bump dependency for b and rebuild
 Only b should have a cache miss
@@ -55,7 +53,6 @@ Only b should have a cache miss
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task b#build. Please check your `outputs` key in `turbo.json`
 Add lockfile changes to a commit
   $ git add . && git commit -m "bump lockfile" --quiet
 Only root and b should be rebuilt since only the deps for b had a version bump
@@ -79,7 +76,6 @@ Bump of root workspace invalidates all packages
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task a#build. Please check your `outputs` key in `turbo.json`
   $ ${TURBO} build  --filter=b
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
@@ -91,7 +87,6 @@ Bump of root workspace invalidates all packages
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task b#build. Please check your `outputs` key in `turbo.json`
 Add lockfile changes to a commit
   $ git add . && git commit -m "global lockfile change" --quiet
 Everything should be rebuilt as a dependency of the root package got bumped

--- a/turborepo-tests/integration/tests/lockfile-aware-caching/npm.t
+++ b/turborepo-tests/integration/tests/lockfile-aware-caching/npm.t
@@ -18,7 +18,6 @@ Populate cache
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task a#build. Please check your `outputs` key in `turbo.json`
   $ ${TURBO} build --filter=b
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
@@ -34,7 +33,6 @@ Populate cache
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task b#build. Please check your `outputs` key in `turbo.json`
 
 Bump dependency for b and rebuild
 Only b should have a cache miss
@@ -71,7 +69,6 @@ Only b should have a cache miss
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task b#build. Please check your `outputs` key in `turbo.json`
 Add lockfile changes to a commit
   $ git add . && git commit -m "bump lockfile" --quiet
 Only root and b should be rebuilt since only the deps for b had a version bump
@@ -99,7 +96,6 @@ Bump of root workspace invalidates all packages
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task a#build. Please check your `outputs` key in `turbo.json`
   $ ${TURBO} build  --filter=b
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
@@ -115,7 +111,6 @@ Bump of root workspace invalidates all packages
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task b#build. Please check your `outputs` key in `turbo.json`
 Add lockfile changes to a commit
   $ git add . && git commit -m "global lockfile change" --quiet
 Everything should be rebuilt as a dependency of the root package got bumped

--- a/turborepo-tests/integration/tests/lockfile-aware-caching/pnpm.t
+++ b/turborepo-tests/integration/tests/lockfile-aware-caching/pnpm.t
@@ -18,7 +18,6 @@ Populate cache
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task a#build. Please check your `outputs` key in `turbo.json`
   $ ${TURBO} build --filter=b
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
@@ -34,7 +33,6 @@ Populate cache
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task b#build. Please check your `outputs` key in `turbo.json`
 
 Bump dependency for b and rebuild
 Only b should have a cache miss
@@ -71,7 +69,6 @@ Only b should have a cache miss
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task b#build. Please check your `outputs` key in `turbo.json`
 Add lockfile changes to a commit
   $ git add . && git commit -m "bump pnpm-lock" --quiet
 Only root and b should be rebuilt since only the deps for b had a version bump
@@ -124,7 +121,6 @@ Bump of root workspace invalidates all packages
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task a#build. Please check your `outputs` key in `turbo.json`
   $ ${TURBO} build  --filter=b
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
@@ -140,7 +136,6 @@ Bump of root workspace invalidates all packages
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task b#build. Please check your `outputs` key in `turbo.json`
 Add lockfile changes to a commit
   $ git add . && git commit -m "global lockfile change" --quiet
 Everything should be rebuilt as a dependency of the root package got bumped

--- a/turborepo-tests/integration/tests/lockfile-aware-caching/yarn.t
+++ b/turborepo-tests/integration/tests/lockfile-aware-caching/yarn.t
@@ -18,7 +18,6 @@ Populate cache
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task a#build. Please check your `outputs` key in `turbo.json`
   $ ${TURBO} build --filter=b
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
@@ -34,7 +33,6 @@ Populate cache
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task b#build. Please check your `outputs` key in `turbo.json`
 
 Bump dependency for b and rebuild
 Only b should have a cache miss
@@ -71,7 +69,6 @@ Only b should have a cache miss
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task b#build. Please check your `outputs` key in `turbo.json`
 Add lockfile changes to a commit
   $ git add . && git commit -m "bump lockfile" --quiet
 Only root and b should be rebuilt since only the deps for b had a version bump
@@ -124,7 +121,6 @@ Bump of root workspace invalidates all packages
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task a#build. Please check your `outputs` key in `turbo.json`
   $ ${TURBO} build  --filter=b
   \xe2\x80\xa2 Packages in scope: b (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
@@ -140,7 +136,6 @@ Bump of root workspace invalidates all packages
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task b#build. Please check your `outputs` key in `turbo.json`
 Add lockfile changes to a commit
   $ git add . && git commit -m "global lockfile change" --quiet
 Everything should be rebuilt as a dependency of the root package got bumped

--- a/turborepo-tests/integration/tests/persistent-dependencies/6-topological-unimplemented.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/6-topological-unimplemented.t
@@ -28,4 +28,3 @@
   Cached:    0 cached, 1 total
     Time:\s+[.0-9]+m?s  (re)
   
-   WARNING  no output files found for task app-a#dev. Please check your `outputs` key in `turbo.json`

--- a/turborepo-tests/integration/tests/pkg-inference.t
+++ b/turborepo-tests/integration/tests/pkg-inference.t
@@ -17,4 +17,3 @@ Setup
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`

--- a/turborepo-tests/integration/tests/prune/composable-config.t
+++ b/turborepo-tests/integration/tests/prune/composable-config.t
@@ -22,6 +22,5 @@ Make sure that the internal util package is part of the prune output
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task docs#new-task. Please check your `outputs` key in `turbo.json`
 
 

--- a/turborepo-tests/integration/tests/run-caching/cache-state.t
+++ b/turborepo-tests/integration/tests/run-caching/cache-state.t
@@ -12,7 +12,6 @@ Run a build to get a local cache.
     Time:\s+[.0-9]+m?s  (re)
   
    WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
-   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
 
 
 Do a dry run so we can see the state of the cache

--- a/turborepo-tests/integration/tests/run-logging/errors-only.t
+++ b/turborepo-tests/integration/tests/run-logging/errors-only.t
@@ -13,7 +13,6 @@ Setup
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task app-a#build. Please check your `outputs` key in `turbo.json`
 
 
 
@@ -29,7 +28,6 @@ Setup
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task app-a#buildsuccess. Please check your `outputs` key in `turbo.json`
 
 
 # [x] error exit

--- a/turborepo-tests/integration/tests/run-logging/log-order-github.t
+++ b/turborepo-tests/integration/tests/run-logging/log-order-github.t
@@ -31,8 +31,6 @@ because otherwise prysk interprets them as multiline commands
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
-   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
 # Build as if we are in Github Actions with a task log prefix.
   $ GITHUB_ACTIONS=1 ${TURBO} run build --force --log-prefix="task" --filter=util
   \xe2\x80\xa2 Packages in scope: util (esc)
@@ -52,7 +50,6 @@ because otherwise prysk interprets them as multiline commands
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
 
 Verify that errors are grouped properly
   $ GITHUB_ACTIONS=1 ${TURBO} run fail

--- a/turborepo-tests/integration/tests/run-logging/log-order-grouped.t
+++ b/turborepo-tests/integration/tests/run-logging/log-order-grouped.t
@@ -25,8 +25,6 @@
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
-   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
 
 
 # We can get the same behavior with an env var
@@ -53,8 +51,6 @@
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
-   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
 
 # The flag wins over the env var
   $ TURBO_LOG_ORDER=stream ${TURBO} run build --log-order grouped --force
@@ -80,6 +76,4 @@
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
-   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
 

--- a/turborepo-tests/integration/tests/run-logging/log-order-stream.t
+++ b/turborepo-tests/integration/tests/run-logging/log-order-stream.t
@@ -25,8 +25,6 @@
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
-   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
 
 The env var set to stream works (this is default, so this test doesn't guarantee the env var is "working"),
 it just guarantees setting this env var won't crash.
@@ -53,8 +51,6 @@ it just guarantees setting this env var won't crash.
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
-   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
 
 The flag wins over the env var
   $ TURBO_LOG_ORDER=grouped ${TURBO} run build --log-order stream --force
@@ -80,6 +76,4 @@ The flag wins over the env var
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
-   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
- 
+

--- a/turborepo-tests/integration/tests/run-logging/log-prefix.t
+++ b/turborepo-tests/integration/tests/run-logging/log-prefix.t
@@ -17,7 +17,6 @@ Setup
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task app-a#build. Please check your `outputs` key in `turbo.json`
 # Check that the cached logs don't have prefixes
   $ cat app-a/.turbo/turbo-build.log
   

--- a/turborepo-tests/integration/tests/run-logging/verbosity.t
+++ b/turborepo-tests/integration/tests/run-logging/verbosity.t
@@ -17,7 +17,6 @@ Verbosity level 1
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
   $ ${TURBO} build --verbosity=1 --filter=util --force
   \xe2\x80\xa2 Packages in scope: util (esc)
   \xe2\x80\xa2 Running build in 1 packages (esc)
@@ -33,7 +32,6 @@ Verbosity level 1
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
 
 Verbosity level 2
   $ ${TURBO} build -vv --filter=util --force 1> VERBOSEVV 2>&1

--- a/turborepo-tests/integration/tests/run-summary/enable.t
+++ b/turborepo-tests/integration/tests/run-summary/enable.t
@@ -27,7 +27,6 @@ Setup
   $ rm -rf .turbo/runs
   $ TURBO_RUN_SUMMARY=true ${TURBO} run build > /dev/null
    WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
-   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
   $ /bin/ls .turbo/runs/*.json | wc -l
   \s*1 (re)
 # env var=true, --flag=true: yes

--- a/turborepo-tests/integration/tests/run-summary/monorepo.t
+++ b/turborepo-tests/integration/tests/run-summary/monorepo.t
@@ -6,7 +6,6 @@ Setup
 
   $ ${TURBO} run build --summarize -- someargs > /dev/null # first run (should be cache miss)
    WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
-   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
 
 # HACK: Generated run summaries are named with a ksuid, which is a time-sorted ID. This _generally_ works
 # but we're seeing in this test that sometimes a summary file is not sorted (with /bin/ls) in the order we expect

--- a/turborepo-tests/integration/tests/run/continue.t
+++ b/turborepo-tests/integration/tests/run/continue.t
@@ -84,6 +84,5 @@ Run with --continue
     Time:\s*[\.0-9]+m?s  (re)
   Failed:    other-app#build, some-lib#build
   
-   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
    ERROR  run failed: command  exited (1)
   [1]

--- a/turborepo-tests/integration/tests/run/gitignored-inputs.t
+++ b/turborepo-tests/integration/tests/run/gitignored-inputs.t
@@ -16,7 +16,6 @@ Some helper functions to parse the summary file
 
 Just run the util package, it's simpler
   $ ${TURBO} run build --filter=util --output-logs=hash-only --summarize | grep "util:build: cache"
-   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
   util:build: cache miss, executing 11cff3dd389fdfed
 
   $ FIRST=$(/bin/ls .turbo/runs/*.json | head -n1)
@@ -31,7 +30,6 @@ Change the content of internal.txt
 
 Hash does not change, because it is gitignored
   $ ${TURBO} run build --filter=util --output-logs=hash-only --summarize | grep "util:build: cache"
-   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
   util:build: cache miss, executing a489883a3c7cd307
 
 The internal.txt hash should be different from the one before

--- a/turborepo-tests/integration/tests/run/one-script-error.t
+++ b/turborepo-tests/integration/tests/run/one-script-error.t
@@ -30,7 +30,6 @@ Note that npm reports any failed script as exit code 1, even though we "exit 2"
     Time:\s*[\.0-9]+m?s  (re)
   Failed:    my-app#error
   
-   WARNING  no output files found for task my-app#okay. Please check your `outputs` key in `turbo.json`
    ERROR  run failed: command  exited (1)
   [1]
 
@@ -99,6 +98,5 @@ Make sure error code isn't swallowed with continue
     Time:\s*[\.0-9]+m?s  (re)
   Failed:    my-app#error
   
-   WARNING  no output files found for task my-app#okay2. Please check your `outputs` key in `turbo.json`
    ERROR  run failed: command  exited (1)
   [1]

--- a/turborepo-tests/integration/tests/run/profile.t
+++ b/turborepo-tests/integration/tests/run/profile.t
@@ -5,6 +5,5 @@ Run build and record a trace
 Ignore output since we want to focus on testing the generated profile
   $ ${TURBO} build --profile=build.trace > turbo.log
    WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
-   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
 Make sure the resulting trace is valid JSON
   $ node -e "require('./build.trace')"

--- a/turborepo-tests/integration/tests/run/single-package/with-deps-run.t
+++ b/turborepo-tests/integration/tests/run/single-package/with-deps-run.t
@@ -21,7 +21,6 @@ Check
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task //#test. Please check your `outputs` key in `turbo.json`
 Run a second time, verify caching works because there is a config
   $ ${TURBO} run test
   \xe2\x80\xa2 Running test (esc)

--- a/turborepo-tests/integration/tests/run/unnamed-packages.t
+++ b/turborepo-tests/integration/tests/run/unnamed-packages.t
@@ -18,4 +18,3 @@ which does not have a name should be ignored. We should process it but filter.
   Cached:    0 cached, 1 total
     Time:    (.+)  (re)
   
-   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`

--- a/turborepo-tests/integration/tests/task-dependencies/overwriting.t
+++ b/turborepo-tests/integration/tests/task-dependencies/overwriting.t
@@ -4,9 +4,6 @@ Setup
 
 Test
   $ ${TURBO} run build > tmp.log
-   WARNING  no output files found for task workspace-a#build. Please check your `outputs` key in `turbo.json`
-   WARNING  no output files found for task workspace-a#generate. Please check your `outputs` key in `turbo.json`
-   WARNING  no output files found for task workspace-b#build. Please check your `outputs` key in `turbo.json`
   $ cat tmp.log | grep "Packages in scope" -A2
   \xe2\x80\xa2 Packages in scope: workspace-a, workspace-b (esc)
   \xe2\x80\xa2 Running build in 2 packages (esc)

--- a/turborepo-tests/integration/tests/task-dependencies/root-workspace.t
+++ b/turborepo-tests/integration/tests/task-dependencies/root-workspace.t
@@ -22,5 +22,3 @@ This tests asserts that root tasks can depend on workspace#task
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9ms]+  (re)
   
-   WARNING  no output files found for task //#mytask. Please check your `outputs` key in `turbo.json`
-   WARNING  no output files found for task lib-a#build. Please check your `outputs` key in `turbo.json`

--- a/turborepo-tests/integration/tests/task-dependencies/topological.t
+++ b/turborepo-tests/integration/tests/task-dependencies/topological.t
@@ -23,8 +23,6 @@ Check my-app#build output
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
-   WARNING  no output files found for task util#build. Please check your `outputs` key in `turbo.json`
 
 
 

--- a/turborepo-tests/integration/tests/workspace-configs/add-keys.t
+++ b/turborepo-tests/integration/tests/workspace-configs/add-keys.t
@@ -10,7 +10,6 @@ Setup
 
 # 1. First run, assert for `dependsOn` and `outputs` keys
   $ ${TURBO} run add-keys-task --filter=add-keys > tmp.log
-   WARNING  no output files found for task add-keys#add-keys-underlying-task. Please check your `outputs` key in `turbo.json`
   $ cat tmp.log
   \xe2\x80\xa2 Packages in scope: add-keys (esc)
   \xe2\x80\xa2 Running add-keys-task in 1 packages (esc)
@@ -77,7 +76,6 @@ Setup
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task add-keys#add-keys-underlying-task. Please check your `outputs` key in `turbo.json`
 # 4. Set env var and assert cache miss
   $ SOME_VAR=somevalue ${TURBO} run add-keys-task --filter=add-keys
   \xe2\x80\xa2 Packages in scope: add-keys (esc)

--- a/turborepo-tests/integration/tests/workspace-configs/cross-workspace.t
+++ b/turborepo-tests/integration/tests/workspace-configs/cross-workspace.t
@@ -21,5 +21,3 @@ Setup
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task blank-pkg#cross-workspace-underlying-task. Please check your `outputs` key in `turbo.json`
-   WARNING  no output files found for task cross-workspace#cross-workspace-task. Please check your `outputs` key in `turbo.json`

--- a/turborepo-tests/integration/tests/workspace-configs/missing-workspace-config-deps.t
+++ b/turborepo-tests/integration/tests/workspace-configs/missing-workspace-config-deps.t
@@ -7,8 +7,6 @@ Setup
 
 # 1. First run, assert that dependet tasks run `dependsOn`
   $ ${TURBO} run missing-workspace-config-task-with-deps --filter=missing-workspace-config > tmp.log
-   WARNING  no output files found for task blank-pkg#missing-workspace-config-underlying-topo-task. Please check your `outputs` key in `turbo.json`
-   WARNING  no output files found for task missing-workspace-config#missing-workspace-config-underlying-task. Please check your `outputs` key in `turbo.json`
 # Validate in pieces. `omit-key` task has two dependsOn values, and those tasks
 # can run in non-deterministic order. So we need to validate the logs in the pieces.
   $ cat tmp.log | grep "in scope" -A 2

--- a/turborepo-tests/integration/tests/workspace-configs/omit-keys-deps.t
+++ b/turborepo-tests/integration/tests/workspace-configs/omit-keys-deps.t
@@ -8,8 +8,6 @@ Setup
 
 # 1. First run, assert for `dependsOn` and `outputs` keys
   $ ${TURBO} run omit-keys-task-with-deps --filter=omit-keys > tmp.log
-   WARNING  no output files found for task blank-pkg#omit-keys-underlying-topo-task. Please check your `outputs` key in `turbo.json`
-   WARNING  no output files found for task omit-keys#omit-keys-underlying-task. Please check your `outputs` key in `turbo.json`
 # Validate in pieces. `omit-key` task has two dependsOn values, and those tasks
 # can run in non-deterministic order. So we need to validatte the logs in pieces.
   $ cat tmp.log | grep "in scope" -A 1

--- a/turborepo-tests/integration/tests/workspace-configs/override-values-deps.t
+++ b/turborepo-tests/integration/tests/workspace-configs/override-values-deps.t
@@ -22,7 +22,6 @@ Setup
   Cached:    0 cached, 1 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task override-values#override-values-task-with-deps. Please check your `outputs` key in `turbo.json`
 
 # This is the same test as above, but with --dry and testing the resolvedTaskDefinition has the same value for dependsOn
   $ ${TURBO} run override-values-task-with-deps --filter=override-values --dry=json | jq '.tasks | map(select(.taskId == "override-values#override-values-task-with-deps")) | .[0].resolvedTaskDefinition'

--- a/turborepo-tests/integration/tests/workspace-configs/persistent.t
+++ b/turborepo-tests/integration/tests/workspace-configs/persistent.t
@@ -47,8 +47,6 @@ This test covers:
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
-   WARNING  no output files found for task persistent#persistent-task-2-parent. Please check your `outputs` key in `turbo.json`
-   WARNING  no output files found for task persistent#persistent-task-2. Please check your `outputs` key in `turbo.json`
 # persistent-task-3-parent dependsOn persistent-task-3
 # persistent-task-3 is persistent:true in the root workspace
 # persistent-task-3 is defined in workspace, but does NOT have the persistent flag


### PR DESCRIPTION
### Description

In #9236 I added a check if the task output globs are empty. Turns out we need to check if the output globs only has a single entry for the log file.

Fixes #9291

### Testing Instructions

`basic_monorepo` has both a task that has globs and no outputs and a task that has empty globs and no outputs. Note that we warn for one and not the other.
