### PR TITLE
chore(test): add test for cyclic error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6279,6 +6279,7 @@ name = "turborepo-graph-utils"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "insta",
  "itertools 0.10.5",
  "log",
  "petgraph",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ httpmock = { version = "0.6.8", default-features = false }
 indexmap = "1.9.2"
 indicatif = "0.17.3"
 indoc = "2.0.0"
+insta = { version = "1.34.0", features = ["json"] }
 itertools = "0.10.5"
 lazy_static = "1.4.0"
 merge = "0.1.0"

--- a/crates/turborepo-graph-utils/Cargo.toml
+++ b/crates/turborepo-graph-utils/Cargo.toml
@@ -15,3 +15,6 @@ petgraph = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full", "time"] }
 tracing = { workspace = true, features = ["log"] }
+
+[dev-dependencies]
+insta = { workspace = true }

--- a/crates/turborepo-vercel-api/Cargo.toml
+++ b/crates/turborepo-vercel-api/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dev-dependencies]
-insta = { version = "1.34.0", features = ["json"] }
+insta = { workspace = true }
 serde_json = { workspace = true }
 test-case = { workspace = true }
 


### PR DESCRIPTION
### Description

As mentioned in https://github.com/vercel/turborepo/issues/9270 we currently output all strongly connected components. This PR just adds a test to display the current behavior where we show the set of nodes and not all cycles that might be contained in the SCC.

### Testing Instructions

Test runs and CI is green
