### PR TITLE
docs: document MSVC requirement

### DIFF
--- a/docs/repo-docs/getting-started/support-policy.mdx
+++ b/docs/repo-docs/getting-started/support-policy.mdx
@@ -33,8 +33,10 @@ the following binaries via npm:
 - `turbo-darwin-arm64` (macOS with Apple Silicon)
 - `turbo-linux-64`
 - `turbo-linux-arm64`
-- `turbo-windows-64`
-- `turbo-windows-arm64`
+- `turbo-windows-64` [^1]
+- `turbo-windows-arm64` [^1]
+
+[^1]: Requires [Windows C Runtime Libraries](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist)
 
 ## Node.js
 


### PR DESCRIPTION
### Description

Closes https://github.com/vercel/turborepo/issues/8878 by documenting that `turbo` requires the Microsoft C Runtime Libraries.

### Testing Instructions

Tested out docs site and made sure the footnote links and back reference links worked.

![Screenshot 2024-10-22 at 10 49 23 AM](https://github.com/user-attachments/assets/ea6cb6a9-d2bd-48ba-9c37-c9e3caed0e28)
![Screenshot 2024-10-22 at 10 50 50 AM](https://github.com/user-attachments/assets/7cb9aa5c-3405-4205-9fb5-dd37924782b5)


