### PR TITLE
chore(ci): fix remote caching for js lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -116,8 +116,9 @@ jobs:
         uses: ./.github/actions/install-global-turbo
 
       - name: Lint
+        # Manually set TURBO_API to an empty string to override Hetzner env
         run: |
-          turbo run lint --env-mode=strict
+          TURBO_API= turbo run lint --env-mode=strict
 
   cleanup:
     name: Cleanup


### PR DESCRIPTION
### Description

Hetzner for some reason sets `TURBO_API` to a different server. This causes [remote cache failures](https://github.com/vercel/turborepo/actions/runs/11468352625/job/31913289850?pr=9311#step:6:31).

In [other places](https://github.com/vercel/turborepo/blob/main/.github/workflows/test-js-packages.yml#L111) we use remote caching we unset `TURBO_API` we just weren't doing it here.


### Testing Instructions

JS Lint should no longer include `WARNING  failed to contact remote cache: unable to parse 'Forbidden' as JSON: expected value at line 1 column 1`
