### PR TITLE
fix(watch): stopping persistent tasks

### DIFF
--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -137,7 +137,12 @@ impl Run {
     }
 
     pub fn create_run_for_non_interruptible_tasks(&self) -> Self {
-        let mut new_run = self.clone();
+        let mut new_run = Self {
+            // ProcessManager is a singleton, so we want to explicitly recreate it
+            processes: ProcessManager::new(self.processes.use_pty()),
+            ..self.clone()
+        };
+
         let new_engine = new_run.engine.create_engine_for_non_interruptible_tasks();
         new_run.engine = Arc::new(new_engine);
 

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -138,7 +138,8 @@ impl Run {
 
     pub fn create_run_for_non_interruptible_tasks(&self) -> Self {
         let mut new_run = Self {
-            // ProcessManager is a singleton, so we want to explicitly recreate it
+            // ProcessManager is shared via an `Arc`,
+            // so we want to explicitly recreate it instead of cloning
             processes: ProcessManager::new(self.processes.use_pty()),
             ..self.clone()
         };

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -390,7 +390,6 @@ impl WatchClient {
                         ),
                     });
 
-                    // But we still run the regular tasks blocking
                     let non_persistent_run = self.run.create_run_for_interruptible_tasks();
                     let ui_sender = self.ui_sender.clone();
                     Ok(RunHandle {


### PR DESCRIPTION
### Description

We were accidentally stopping persistent tasks when we shouldn't have because we were reusing the same stopper.

### Testing Instructions

We need a way to test persistent stuff and also run construction stuff.