### PR TITLE
fix(test-utils): return promise from lifecycle

### DIFF
--- a/packages/turbo-test-utils/src/useFixtures.ts
+++ b/packages/turbo-test-utils/src/useFixtures.ts
@@ -28,7 +28,7 @@ export function setupTestFixtures({
   const parentDirectory = path.join(directory, test ? test : randomUUID());
 
   afterEach(async () => {
-    await Promise.all(
+    return Promise.all(
       fixtures.map((fixture) =>
         rm(fixture, {
           retryDelay: 50,
@@ -41,7 +41,7 @@ export function setupTestFixtures({
   });
 
   afterAll(async () => {
-    await rm(parentDirectory, {
+    return rm(parentDirectory, {
       retryDelay: 50,
       maxRetries: 5,
       recursive: true,


### PR DESCRIPTION
### Description

From Jest docs ([here](https://jestjs.io/docs/setup-teardown#repeating-setup))

> beforeEach and afterEach can handle asynchronous code in the same ways that [tests can handle asynchronous code](https://jestjs.io/docs/asynchronous) - they can either take a done parameter or return a promise

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
