### PR TITLE
feat: support task id entrypoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6361,6 +6361,7 @@ dependencies = [
  "human_format",
  "humantime",
  "ignore",
+ "insta",
  "itertools 0.10.5",
  "jsonc-parser 0.21.0",
  "lazy_static",

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -19,6 +19,7 @@ daemon-file-hashing = []
 anyhow = { workspace = true, features = ["backtrace"] }
 assert_cmd = { workspace = true }
 async-stream = "0.3.4"
+insta = { workspace = true }
 itertools = { workspace = true }
 port_scanner = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -561,7 +561,7 @@ fn validate_task_name(task: Spanned<&str>) -> Result<(), Error> {
 mod test {
     use std::assert_matches::assert_matches;
 
-    use insta::assert_snapshot;
+    use insta::assert_json_snapshot;
     use pretty_assertions::assert_eq;
     use serde_json::json;
     use tempfile::TempDir;
@@ -1353,21 +1353,23 @@ mod test {
             .with_workspaces(vec![PackageName::from("app1")])
             .build();
         assert!(engine.is_err());
-        assert_snapshot!(format!("{:?}", miette::Report::new(engine.unwrap_err())), @r###"
-          [31m×[0m missing tasks in project
-
-        Error:   [31m×[0m could not find task `app1#special` in project
-        "###);
+        let report = miette::Report::new(engine.unwrap_err());
+        let mut msg = String::new();
+        miette::JSONReportHandler::new()
+            .render_report(&mut msg, report.as_ref())
+            .unwrap();
+        assert_json_snapshot!(msg);
 
         let engine = EngineBuilder::new(&repo_root, &package_graph, loader, false)
             .with_tasks(vec![Spanned::new(TaskName::from("app1#another"))])
             .with_workspaces(vec![PackageName::from("libA")])
             .build();
         assert!(engine.is_err());
-        assert_snapshot!(format!("{:?}", miette::Report::new(engine.unwrap_err())), @r###"
-          [31m×[0m missing tasks in project
-
-        Error:   [31m×[0m could not find task `app1#another` in project
-        "###);
+        let report = miette::Report::new(engine.unwrap_err());
+        let mut msg = String::new();
+        miette::JSONReportHandler::new()
+            .render_report(&mut msg, report.as_ref())
+            .unwrap();
+        assert_json_snapshot!(msg);
     }
 }

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -561,6 +561,7 @@ fn validate_task_name(task: Spanned<&str>) -> Result<(), Error> {
 mod test {
     use std::assert_matches::assert_matches;
 
+    use insta::assert_snapshot;
     use pretty_assertions::assert_eq;
     use serde_json::json;
     use tempfile::TempDir;
@@ -1311,5 +1312,62 @@ mod test {
             "libA#build" => ["___ROOT___"]
         };
         assert_eq!(all_dependencies(&engine), expected);
+    }
+
+    #[test]
+    fn test_run_package_task_exact_error() {
+        let repo_root_dir = TempDir::with_prefix("repo").unwrap();
+        let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
+        let package_graph = mock_package_graph(
+            &repo_root,
+            package_jsons! {
+                repo_root,
+                "app1" => ["libA"],
+                "libA" => []
+            },
+        );
+        let turbo_jsons = vec![
+            (
+                PackageName::Root,
+                turbo_json(json!({
+                    "tasks": {
+                        "build": { "dependsOn": ["^build"] },
+                    }
+                })),
+            ),
+            (
+                PackageName::from("app1"),
+                turbo_json(json!({
+                    "extends": ["//"],
+                    "tasks": {
+                        "another": { "dependsOn": ["^build"] },
+                    }
+                })),
+            ),
+        ]
+        .into_iter()
+        .collect();
+        let loader = TurboJsonLoader::noop(turbo_jsons);
+        let engine = EngineBuilder::new(&repo_root, &package_graph, loader.clone(), false)
+            .with_tasks(vec![Spanned::new(TaskName::from("app1#special"))])
+            .with_workspaces(vec![PackageName::from("app1")])
+            .build();
+        assert!(engine.is_err());
+        assert_snapshot!(format!("{:?}", miette::Report::new(engine.unwrap_err())), @r###"
+          [31m×[0m missing tasks in project
+
+        Error:   [31m×[0m could not find task `app1#special` in project
+        "###);
+
+        let engine = EngineBuilder::new(&repo_root, &package_graph, loader, false)
+            .with_tasks(vec![Spanned::new(TaskName::from("app1#another"))])
+            .with_workspaces(vec![PackageName::from("libA")])
+            .build();
+        assert!(engine.is_err());
+        assert_snapshot!(format!("{:?}", miette::Report::new(engine.unwrap_err())), @r###"
+          [31m×[0m missing tasks in project
+
+        Error:   [31m×[0m could not find task `app1#another` in project
+        "###);
     }
 }

--- a/crates/turborepo-lib/src/engine/snapshots/turborepo_lib__engine__builder__test__run_package_task_exact_error-2.snap
+++ b/crates/turborepo-lib/src/engine/snapshots/turborepo_lib__engine__builder__test__run_package_task_exact_error-2.snap
@@ -1,0 +1,5 @@
+---
+source: crates/turborepo-lib/src/engine/builder.rs
+expression: msg
+---
+"{\"message\": \"missing tasks in project\",\"severity\": \"error\",\"causes\": [],\"labels\": [],\"related\": [{\"message\": \"could not find task `app1#another` in project\",\"severity\": \"error\",\"causes\": [],\"filename\": \"\",\"labels\": [],\"related\": []}]}"

--- a/crates/turborepo-lib/src/engine/snapshots/turborepo_lib__engine__builder__test__run_package_task_exact_error.snap
+++ b/crates/turborepo-lib/src/engine/snapshots/turborepo_lib__engine__builder__test__run_package_task_exact_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/turborepo-lib/src/engine/builder.rs
+expression: msg
+---
+"{\"message\": \"missing tasks in project\",\"severity\": \"error\",\"causes\": [],\"labels\": [],\"related\": [{\"message\": \"could not find task `app1#special` in project\",\"severity\": \"error\",\"causes\": [],\"filename\": \"\",\"labels\": [],\"related\": []}]}"

--- a/turborepo-tests/integration/tests/workspace-configs/cross-workspace.t
+++ b/turborepo-tests/integration/tests/workspace-configs/cross-workspace.t
@@ -21,3 +21,24 @@ Setup
   Cached:    0 cached, 2 total
     Time:\s*[\.0-9]+m?s  (re)
   
+  $ ${TURBO} run cross-workspace#cross-workspace-task
+  \xe2\x80\xa2 Packages in scope: add-keys, add-tasks, bad-json, blank-pkg, cached, config-change, cross-workspace, invalid-config, missing-workspace-config, omit-keys, override-values, persistent (esc)
+  \xe2\x80\xa2 Running cross-workspace#cross-workspace-task in 12 packages (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
+  blank-pkg:cross-workspace-underlying-task: cache hit, replaying logs 39566f6362976823
+  blank-pkg:cross-workspace-underlying-task: 
+  blank-pkg:cross-workspace-underlying-task: > cross-workspace-underlying-task
+  blank-pkg:cross-workspace-underlying-task: > echo cross-workspace-underlying-task from blank-pkg
+  blank-pkg:cross-workspace-underlying-task: 
+  blank-pkg:cross-workspace-underlying-task: cross-workspace-underlying-task from blank-pkg
+  cross-workspace:cross-workspace-task: cache hit, replaying logs bce507a110930f07
+  cross-workspace:cross-workspace-task: 
+  cross-workspace:cross-workspace-task: > cross-workspace-task
+  cross-workspace:cross-workspace-task: > echo cross-workspace-task
+  cross-workspace:cross-workspace-task: 
+  cross-workspace:cross-workspace-task: cross-workspace-task
+  
+   Tasks:    2 successful, 2 total
+  Cached:    2 cached, 2 total
+    Time:\s*[\.0-9]+m?s >>> FULL TURBO (re)
+  


### PR DESCRIPTION
### Description

Currently if you run `turbo cli#build` you will get the following failure*:
```
Error:   × could not find task `cli#build` in project
```
*It works if you had `"tasks": {"cli#build": {...}}` in your root level `turbo.json`

After this PR, passing a fully qualified task id to run will now work, regardless of how the task definition is defined:
 - In the root `turbo.json` as `build`
 - In the root `turbo.json` as `cli#build`
 - In the `cli` workspace's `turbo.json` as `build`

The usage of `#` is safe here as you already have been unable to use `#` in a unqualified task name. 
- If you attempt to use a `#` in a task name in a workspace level `turbo.json` you will get an error about using package task syntax in a workspace file.
- If you attempt to specify a task in the root `turbo.json` of the form `foo#bar` it will be read as the `bar` task in package `foo`
- If you attempt to use `foo#bar#baz` as a task name in root `turbo.json` it will work currently with `foo#bar#baz` and after this PR it will continue to work

### Testing Instructions

Added unit tests!

Manual verification by running `turbo cli#build`.
