### PR TITLE
perf: Exclude network while doing getReport

### DIFF
--- a/packages/turbo-repository/js/index.js
+++ b/packages/turbo-repository/js/index.js
@@ -26,7 +26,10 @@ function isMusl() {
       return true;
     }
   } else {
+    const orig = process.report.excludeNetwork;
+    process.report.excludeNetwork = true;
     const { glibcVersionRuntime } = process.report.getReport().header;
+    process.report.excludeNetwork = orig;
     if (typeof glibcVersionRuntime === "string") {
       try {
         // We support glibc v2.26+


### PR DESCRIPTION
This will speed up the report generation and avoid unwanted DNS queries during the report

See https://github.com/lovell/detect-libc/pull/21