### PR TITLE
fix: order tasks in order of interest, namely failed, successful, then cached

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6604,6 +6604,7 @@ dependencies = [
  "futures",
  "indicatif",
  "indoc",
+ "itertools 0.10.5",
  "lazy_static",
  "nix 0.26.2",
  "ratatui",

--- a/crates/turborepo-ui/Cargo.toml
+++ b/crates/turborepo-ui/Cargo.toml
@@ -28,6 +28,7 @@ crossterm = { version = "0.27.0", features = ["event-stream"] }
 dialoguer = { workspace = true }
 futures = { workspace = true }
 indicatif = { workspace = true }
+itertools.workspace = true
 lazy_static = { workspace = true }
 nix = { version = "0.26.2", features = ["signal"] }
 ratatui = { workspace = true }

--- a/crates/turborepo-ui/src/tui/table.rs
+++ b/crates/turborepo-ui/src/tui/table.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use ratatui::{
     layout::{Constraint, Rect},
     style::{Color, Style, Stylize},
@@ -9,8 +10,13 @@ use super::{event::TaskResult, spinner::SpinnerState, task::TasksByStatus};
 
 /// A widget that renders a table of their tasks and their current status
 ///
-/// The table contains finished tasks, running tasks, and planned tasks rendered
-/// in that order.
+/// The tasks are ordered as follows:
+/// - running tasks
+/// - planned tasks
+/// - finished tasks
+///   - failed tasks
+///   - successful tasks
+///   - cached tasks
 pub struct TaskTable<'b> {
     tasks_by_type: &'b TasksByStatus,
     spinner: SpinnerState,
@@ -46,29 +52,39 @@ impl<'b> TaskTable<'b> {
     }
 
     fn finished_rows(&self) -> impl Iterator<Item = Row> + '_ {
-        self.tasks_by_type.finished.iter().map(move |task| {
-            let name = if matches!(task.result(), TaskResult::CacheHit) {
-                Cell::new(Text::styled(task.name(), Style::default().italic()))
-            } else {
-                Cell::new(task.name())
-            };
+        self.tasks_by_type
+            .finished
+            .iter()
+            // note we can't use the default Ord impl because
+            // we want failed tasks first
+            .sorted_by_key(|task| match task.result() {
+                TaskResult::Failure => 0,
+                TaskResult::Success => 1,
+                TaskResult::CacheHit => 2,
+            })
+            .map(move |task| {
+                let name = if matches!(task.result(), TaskResult::CacheHit) {
+                    Cell::new(Text::styled(task.name(), Style::default().italic()))
+                } else {
+                    Cell::new(task.name())
+                };
 
-            Row::new(vec![
-                name,
-                match task.result() {
-                    // matches Next.js (and many other CLI tools) https://github.com/vercel/next.js/blob/1a04d94aaec943d3cce93487fea3b8c8f8898f31/packages/next/src/build/output/log.ts
-                    TaskResult::Success => {
-                        Cell::new(Text::styled("✓", Style::default().green().bold()))
-                    }
-                    TaskResult::CacheHit => {
-                        Cell::new(Text::styled("⊙", Style::default().magenta()))
-                    }
-                    TaskResult::Failure => {
-                        Cell::new(Text::styled("⨯", Style::default().red().bold()))
-                    }
-                },
-            ])
-        })
+                Row::new(vec![
+                    name,
+                    match task.result() {
+                        // matches Next.js (and many other CLI tools) https://github.com/vercel/next.js/blob/1a04d94aaec943d3cce93487fea3b8c8f8898f31/packages/next/src/build/output/log.ts
+                        TaskResult::Success => {
+                            Cell::new(Text::styled("✓", Style::default().green().bold()))
+                        }
+                        TaskResult::CacheHit => {
+                            Cell::new(Text::styled("⊙", Style::default().magenta()))
+                        }
+                        TaskResult::Failure => {
+                            Cell::new(Text::styled("⨯", Style::default().red().bold()))
+                        }
+                    },
+                ])
+            })
     }
 
     fn running_rows(&self) -> impl Iterator<Item = Row> + '_ {


### PR DESCRIPTION
Currently, when running tasks using the new UI, turbo inserts passed / failed tasks below cached tasks (in order of completion) meaning the stuff users probably want to see (failed things) end up at the bottom of the list or off screen. This change attempts to improve that by inserting those items in front of the list of cached tasks. That way cached tasks (likely the least interesting) end up last and preceded by successful tasks and then failed tasks. This assumes that users will more interested in failed tasks than successful ones but I am also open to ordering just the failed / successful task in order of completion instead.

In practice this means if running turbo in a large project with `--continue` where the majority of tasks are and will remain cached between runs, then the things that are 'interesting' will usually be close to the user's cursor.

It also 'fixes' the case where viewing a task that is completed jumps past the cached tasks and you have to traverse back through them all to get to the top again.