### PR TITLE
fix(tui): make sure to open stdin for all tasks

### DIFF
--- a/crates/turborepo-lib/src/task_graph/visitor/command.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/command.rs
@@ -73,6 +73,10 @@ impl<'a> CommandFactory<'a> {
         cmd.env_clear();
         cmd.envs(environment.iter());
 
+        // We always open stdin and the visitor will close it depending on task
+        // configuration
+        cmd.open_stdin();
+
         Ok(Some(cmd))
     }
 }


### PR DESCRIPTION
### Description

In https://github.com/vercel/turborepo/pull/9306 I somehow dropped the `cmd.open_stdin()` call so we never started tasks hooked up to stdin.

I verified I copied the closing/forwarding stdin logic in my refactor [as seen here](https://github.com/vercel/turborepo/blob/main/crates/turborepo-lib/src/task_graph/visitor/exec.rs#L376), we were just never opening it in the first place.

### Testing Instructions

`turbo_dev dev` should now let you interact with `persistent` tasks
