### PR TITLE
feat(mfe): inject local proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6505,6 +6505,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "turbopath",
+ "turborepo-errors",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6491,6 +6491,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "turborepo-micro-frontend"
+version = "0.1.0"
+dependencies = [
+ "biome_deserialize",
+ "biome_deserialize_macros",
+ "biome_diagnostics",
+ "biome_json_parser",
+ "biome_json_syntax",
+ "pretty_assertions",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "turbopath",
+]
+
+[[package]]
 name = "turborepo-napi"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6436,6 +6436,7 @@ dependencies = [
  "turborepo-fs",
  "turborepo-graph-utils",
  "turborepo-lockfiles",
+ "turborepo-micro-frontend",
  "turborepo-repository",
  "turborepo-scm",
  "turborepo-telemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ turborepo-errors = { path = "crates/turborepo-errors" }
 turborepo-fs = { path = "crates/turborepo-fs" }
 turborepo-lib = { path = "crates/turborepo-lib", default-features = false }
 turborepo-lockfiles = { path = "crates/turborepo-lockfiles" }
+turborepo-micro-frontend = { path = "crates/turborepo-micro-frontend" }
 turborepo-repository = { path = "crates/turborepo-repository" }
 turborepo-ui = { path = "crates/turborepo-ui" }
 turborepo-unescape = { path = "crates/turborepo-unescape" }

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -133,6 +133,7 @@ turborepo-filewatch = { path = "../turborepo-filewatch" }
 turborepo-fs = { path = "../turborepo-fs" }
 turborepo-graph-utils = { path = "../turborepo-graph-utils" }
 turborepo-lockfiles = { workspace = true }
+turborepo-micro-frontend = { workspace = true }
 turborepo-repository = { path = "../turborepo-repository" }
 turborepo-scm = { workspace = true }
 turborepo-telemetry = { path = "../turborepo-telemetry" }

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -234,7 +234,6 @@ impl<'a> EngineBuilder<'a> {
             let task_id = task
                 .task_id()
                 .unwrap_or_else(|| TaskId::new(workspace.as_ref(), task.task()));
-            eprintln!("{task_id:?}");
 
             if Self::has_task_definition(&mut turbo_json_loader, workspace, task, &task_id)? {
                 missing_tasks.remove(task.as_inner());

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -234,6 +234,7 @@ impl<'a> EngineBuilder<'a> {
             let task_id = task
                 .task_id()
                 .unwrap_or_else(|| TaskId::new(workspace.as_ref(), task.task()));
+            eprintln!("{task_id:?}");
 
             if Self::has_task_definition(&mut turbo_json_loader, workspace, task, &task_id)? {
                 missing_tasks.remove(task.as_inner());

--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -404,6 +404,8 @@ impl Engine<Built> {
             .filter_map(|task| {
                 let pkg_name = PackageName::from(task.package());
                 let json = pkg_graph.package_json(&pkg_name)?;
+                // TODO: delegate to command factory to filter down tasks to those that will
+                // have a runnable command.
                 (task.task() == "proxy" || json.command(task.task()).is_some())
                     .then(|| task.to_string())
             })

--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -404,7 +404,8 @@ impl Engine<Built> {
             .filter_map(|task| {
                 let pkg_name = PackageName::from(task.package());
                 let json = pkg_graph.package_json(&pkg_name)?;
-                json.command(task.task()).map(|_| task.to_string())
+                (task.task() == "proxy" || json.command(task.task()).is_some())
+                    .then(|| task.to_string())
             })
             .collect()
     }

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -23,6 +23,7 @@ mod framework;
 mod gitignore;
 pub(crate) mod globwatcher;
 mod hash;
+mod micro_frontends;
 mod opts;
 mod package_changes_watcher;
 mod panic_handler;

--- a/crates/turborepo-lib/src/micro_frontends.rs
+++ b/crates/turborepo-lib/src/micro_frontends.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use turbopath::AbsoluteSystemPath;
-use turborepo_micro_frontend::{Config as MFEConfig, Error, MICRO_FRONTENDS_CONFIG};
+use turborepo_micro_frontend::{Config as MFEConfig, Error, DEFAULT_MICRO_FRONTENDS_CONFIG};
 use turborepo_repository::package_graph::PackageGraph;
 
 use crate::run::task_id::TaskId;
@@ -20,7 +20,7 @@ impl MicroFrontendsConfigs {
         for (package_name, package_info) in package_graph.packages() {
             let config_path = repo_root
                 .resolve(package_info.package_path())
-                .join_component(MICRO_FRONTENDS_CONFIG);
+                .join_component(DEFAULT_MICRO_FRONTENDS_CONFIG);
             let Some(config) = MFEConfig::load(&config_path)? else {
                 continue;
             };

--- a/crates/turborepo-lib/src/micro_frontends.rs
+++ b/crates/turborepo-lib/src/micro_frontends.rs
@@ -1,0 +1,40 @@
+use std::collections::{HashMap, HashSet};
+
+use tracing::warn;
+use turbopath::AbsoluteSystemPath;
+use turborepo_micro_frontend::{Config as MFEConfig, Error, MICRO_FRONTENDS_CONFIG};
+use turborepo_repository::package_graph::PackageGraph;
+
+use crate::run::task_id::TaskId;
+
+pub fn find_micro_frontend_configs(
+    repo_root: &AbsoluteSystemPath,
+    package_graph: &PackageGraph,
+) -> Result<HashMap<String, HashSet<TaskId<'static>>>, Error> {
+    let mut configs = HashMap::new();
+    for (package_name, package_info) in package_graph.packages() {
+        let config_path = repo_root
+            .resolve(package_info.package_path())
+            .join_component(MICRO_FRONTENDS_CONFIG);
+        let Some(config) = MFEConfig::load(&config_path)? else {
+            continue;
+        };
+        let tasks = config
+            .applications
+            .iter()
+            .filter_map(|(application, options)| {
+                let Some(dev_task) = options.development.task.as_deref() else {
+                    warn!(
+                        "{application} does not have a dev task configured. Turborepo will be \
+                         unable to detect if traffic should be routed to local server"
+                    );
+                    return None;
+                };
+                Some(TaskId::new(application, dev_task).into_owned())
+            })
+            .collect();
+        configs.insert(package_name.to_string(), tasks);
+    }
+
+    Ok(configs)
+}

--- a/crates/turborepo-lib/src/micro_frontends.rs
+++ b/crates/turborepo-lib/src/micro_frontends.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, HashSet};
 
-use tracing::warn;
 use turbopath::AbsoluteSystemPath;
 use turborepo_micro_frontend::{Config as MFEConfig, Error, MICRO_FRONTENDS_CONFIG};
 use turborepo_repository::package_graph::PackageGraph;
@@ -22,15 +21,9 @@ pub fn find_micro_frontend_configs(
         let tasks = config
             .applications
             .iter()
-            .filter_map(|(application, options)| {
-                let Some(dev_task) = options.development.task.as_deref() else {
-                    warn!(
-                        "{application} does not have a dev task configured. Turborepo will be \
-                         unable to detect if traffic should be routed to local server"
-                    );
-                    return None;
-                };
-                Some(TaskId::new(application, dev_task).into_owned())
+            .map(|(application, options)| {
+                let dev_task = options.development.task.as_deref().unwrap_or("dev");
+                TaskId::new(application, dev_task).into_owned()
             })
             .collect();
         configs.insert(package_name.to_string(), tasks);

--- a/crates/turborepo-lib/src/micro_frontends.rs
+++ b/crates/turborepo-lib/src/micro_frontends.rs
@@ -6,28 +6,47 @@ use turborepo_repository::package_graph::PackageGraph;
 
 use crate::run::task_id::TaskId;
 
-pub fn find_micro_frontend_configs(
-    repo_root: &AbsoluteSystemPath,
-    package_graph: &PackageGraph,
-) -> Result<HashMap<String, HashSet<TaskId<'static>>>, Error> {
-    let mut configs = HashMap::new();
-    for (package_name, package_info) in package_graph.packages() {
-        let config_path = repo_root
-            .resolve(package_info.package_path())
-            .join_component(MICRO_FRONTENDS_CONFIG);
-        let Some(config) = MFEConfig::load(&config_path)? else {
-            continue;
-        };
-        let tasks = config
-            .applications
-            .iter()
-            .map(|(application, options)| {
-                let dev_task = options.development.task.as_deref().unwrap_or("dev");
-                TaskId::new(application, dev_task).into_owned()
-            })
-            .collect();
-        configs.insert(package_name.to_string(), tasks);
+#[derive(Debug, Clone)]
+pub struct MicroFrontendsConfigs {
+    configs: HashMap<String, HashSet<TaskId<'static>>>,
+}
+
+impl MicroFrontendsConfigs {
+    pub fn new(
+        repo_root: &AbsoluteSystemPath,
+        package_graph: &PackageGraph,
+    ) -> Result<Option<Self>, Error> {
+        let mut configs = HashMap::new();
+        for (package_name, package_info) in package_graph.packages() {
+            let config_path = repo_root
+                .resolve(package_info.package_path())
+                .join_component(MICRO_FRONTENDS_CONFIG);
+            let Some(config) = MFEConfig::load(&config_path)? else {
+                continue;
+            };
+            let tasks = config
+                .applications
+                .iter()
+                .map(|(application, options)| {
+                    let dev_task = options.development.task.as_deref().unwrap_or("dev");
+                    TaskId::new(application, dev_task).into_owned()
+                })
+                .collect();
+            configs.insert(package_name.to_string(), tasks);
+        }
+
+        Ok((!configs.is_empty()).then_some(Self { configs }))
     }
 
-    Ok(configs)
+    pub fn contains_package(&self, package_name: &str) -> bool {
+        self.configs.contains_key(package_name)
+    }
+
+    pub fn configs(&self) -> impl Iterator<Item = (&String, &HashSet<TaskId<'static>>)> {
+        self.configs.iter()
+    }
+
+    pub fn get(&self, package_name: &str) -> Option<&HashSet<TaskId<'static>>> {
+        self.configs.get(package_name)
+    }
 }

--- a/crates/turborepo-lib/src/process/command.rs
+++ b/crates/turborepo-lib/src/process/command.rs
@@ -101,6 +101,11 @@ impl Command {
     pub fn will_open_stdin(&self) -> bool {
         self.open_stdin
     }
+
+    /// Program for the command
+    pub fn program(&self) -> &OsStr {
+        &self.program
+    }
 }
 
 impl From<Command> for tokio::process::Command {

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -515,6 +515,9 @@ impl RunBuilder {
             tasks.push(Spanned::new(TaskName::from("proxy").into_owned()));
             // we need to add the MFE config packages into the scope here to make sure the
             // proxy gets run
+            // TODO(olszewski): We are relying on the fact that persistent tasks must be
+            // entry points to the task graph so we can get away with only
+            // checking the entrypoint tasks.
             for (mfe_config_package, dev_tasks) in micro_frontends_configs.iter() {
                 for dev_task in dev_tasks {
                     let package = PackageName::from(dev_task.package());

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -370,6 +370,8 @@ impl RunBuilder {
         repo_telemetry.track_package_manager(pkg_dep_graph.package_manager().to_string());
         repo_telemetry.track_size(pkg_dep_graph.len());
         run_telemetry.track_run_type(self.opts.run_opts.dry_run.is_some());
+        let micro_frontend_configs =
+            crate::micro_frontends::find_micro_frontend_configs(&self.repo_root, &pkg_dep_graph)?;
 
         let scm = scm.await.expect("detecting scm panicked");
         let async_cache = AsyncCache::new(
@@ -476,6 +478,7 @@ impl RunBuilder {
             signal_handler: signal_handler.clone(),
             daemon,
             should_print_prelude,
+            micro_frontend_configs,
         })
     }
 

--- a/crates/turborepo-lib/src/run/error.rs
+++ b/crates/turborepo-lib/src/run/error.rs
@@ -60,4 +60,6 @@ pub enum Error {
     UI(#[from] turborepo_ui::Error),
     #[error(transparent)]
     Tui(#[from] tui::Error),
+    #[error("Error reading micro frontends configuration: {0}")]
+    MicroFrontends(#[from] turborepo_micro_frontend::Error),
 }

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -14,7 +14,7 @@ mod ui;
 pub mod watch;
 
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashSet},
     io::Write,
     sync::Arc,
     time::Duration,
@@ -23,7 +23,6 @@ use std::{
 pub use cache::{CacheOutput, ConfigCache, Error as CacheError, RunCache, TaskCache};
 use chrono::{DateTime, Local};
 use rayon::iter::ParallelBridge;
-use task_id::TaskId;
 use tokio::{select, task::JoinHandle};
 use tracing::{debug, instrument};
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
@@ -42,6 +41,7 @@ pub use crate::run::error::Error;
 use crate::{
     cli::EnvMode,
     engine::Engine,
+    micro_frontends::MicroFrontendsConfigs,
     opts::Opts,
     process::ProcessManager,
     run::{global_hash::get_global_hash_inputs, summary::RunTracker, task_access::TaskAccess},
@@ -74,7 +74,7 @@ pub struct Run {
     task_access: TaskAccess,
     daemon: Option<DaemonClient<DaemonConnector>>,
     should_print_prelude: bool,
-    micro_frontend_configs: HashMap<String, HashSet<TaskId<'static>>>,
+    micro_frontend_configs: Option<MicroFrontendsConfigs>,
 }
 
 type UIResult<T> = Result<Option<(T, JoinHandle<Result<(), turborepo_ui::Error>>)>, Error>;
@@ -462,7 +462,7 @@ impl Run {
             global_env,
             ui_sender,
             is_watch,
-            &self.micro_frontend_configs,
+            self.micro_frontend_configs.as_ref(),
         )
         .await;
 

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -462,6 +462,7 @@ impl Run {
             global_env,
             ui_sender,
             is_watch,
+            &self.micro_frontend_configs,
         )
         .await;
 

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -14,7 +14,7 @@ mod ui;
 pub mod watch;
 
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     io::Write,
     sync::Arc,
     time::Duration,
@@ -23,6 +23,7 @@ use std::{
 pub use cache::{CacheOutput, ConfigCache, Error as CacheError, RunCache, TaskCache};
 use chrono::{DateTime, Local};
 use rayon::iter::ParallelBridge;
+use task_id::TaskId;
 use tokio::{select, task::JoinHandle};
 use tracing::{debug, instrument};
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
@@ -73,6 +74,7 @@ pub struct Run {
     task_access: TaskAccess,
     daemon: Option<DaemonClient<DaemonConnector>>,
     should_print_prelude: bool,
+    micro_frontend_configs: HashMap<String, HashSet<TaskId<'static>>>,
 }
 
 type UIResult<T> = Result<Option<(T, JoinHandle<Result<(), turborepo_ui::Error>>)>, Error>;

--- a/crates/turborepo-lib/src/task_graph/visitor/command.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/command.rs
@@ -202,7 +202,7 @@ impl<'a> CommandProvider for MicroFrontendProxyProvider<'a> {
         // TODO: leverage package manager to find the local proxy
         let program = package_dir.join_components(&["node_modules", ".bin", "micro-frontends"]);
         let mut cmd = Command::new(program.as_std_path());
-        cmd.current_dir(package_dir).args(args);
+        cmd.current_dir(package_dir).args(args).open_stdin();
         eprintln!("running proxy {}", cmd.label());
 
         Ok(Some(cmd))

--- a/crates/turborepo-lib/src/task_graph/visitor/command.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/command.rs
@@ -2,20 +2,64 @@ use std::path::PathBuf;
 
 use turbopath::AbsoluteSystemPath;
 use turborepo_env::EnvironmentVariableMap;
-use turborepo_repository::package_graph::{PackageGraph, PackageName};
+use turborepo_repository::package_graph::{PackageGraph, PackageInfo, PackageName};
 
 use super::Error;
 use crate::{opts::TaskArgs, process::Command, run::task_id::TaskId};
 
-#[derive(Debug)]
+pub trait CommandProvider {
+    fn command(
+        &self,
+        task_id: &TaskId,
+        environment: EnvironmentVariableMap,
+    ) -> Result<Option<Command>, Error>;
+}
+
+/// A collection of command providers.
+///
+/// Will attempt to find a command from any of the providers it contains.
+/// Ordering of the providers matters as the first present command will be
+/// returned. Any errors returned by the providers will be immediately returned.
 pub struct CommandFactory<'a> {
+    providers: Vec<Box<dyn CommandProvider + 'a + Send>>,
+}
+
+impl<'a> CommandFactory<'a> {
+    pub fn new() -> Self {
+        Self {
+            providers: Vec::new(),
+        }
+    }
+
+    pub fn add_provider(mut self, provider: impl CommandProvider + 'a + Send) -> Self {
+        self.providers.push(Box::new(provider));
+        self
+    }
+
+    pub fn command(
+        &self,
+        task_id: &TaskId,
+        environment: EnvironmentVariableMap,
+    ) -> Result<Option<Command>, Error> {
+        for provider in self.providers.iter() {
+            let cmd = provider.command(task_id, environment.clone())?;
+            if cmd.is_some() {
+                return Ok(cmd);
+            }
+        }
+        Ok(None)
+    }
+}
+
+#[derive(Debug)]
+pub struct PackageGraphCommandProvider<'a> {
     repo_root: &'a AbsoluteSystemPath,
     package_graph: &'a PackageGraph,
     package_manager_binary: Result<PathBuf, which::Error>,
     task_args: TaskArgs<'a>,
 }
 
-impl<'a> CommandFactory<'a> {
+impl<'a> PackageGraphCommandProvider<'a> {
     pub fn new(
         repo_root: &'a AbsoluteSystemPath,
         package_graph: &'a PackageGraph,
@@ -30,18 +74,23 @@ impl<'a> CommandFactory<'a> {
         }
     }
 
-    pub fn command(
-        &self,
-        task_id: &TaskId,
-        environment: EnvironmentVariableMap,
-    ) -> Result<Option<Command>, Error> {
-        let workspace_info = self
-            .package_graph
+    fn package_info(&self, task_id: &TaskId) -> Result<&PackageInfo, Error> {
+        self.package_graph
             .package_info(&PackageName::from(task_id.package()))
             .ok_or_else(|| Error::MissingPackage {
                 package_name: task_id.package().into(),
                 task_id: task_id.clone().into_owned(),
-            })?;
+            })
+    }
+}
+
+impl<'a> CommandProvider for PackageGraphCommandProvider<'a> {
+    fn command(
+        &self,
+        task_id: &TaskId,
+        environment: EnvironmentVariableMap,
+    ) -> Result<Option<Command>, Error> {
+        let workspace_info = self.package_info(task_id)?;
 
         // bail if the script doesn't exist or is empty
         if workspace_info
@@ -78,5 +127,98 @@ impl<'a> CommandFactory<'a> {
         cmd.open_stdin();
 
         Ok(Some(cmd))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::ffi::OsStr;
+
+    use insta::assert_snapshot;
+
+    use super::*;
+
+    struct EchoCmdFactory;
+
+    impl CommandProvider for EchoCmdFactory {
+        fn command(
+            &self,
+            _task_id: &TaskId,
+            _environment: EnvironmentVariableMap,
+        ) -> Result<Option<Command>, Error> {
+            Ok(Some(Command::new("echo")))
+        }
+    }
+
+    struct ErrProvider;
+
+    impl CommandProvider for ErrProvider {
+        fn command(
+            &self,
+            _task_id: &TaskId,
+            _environment: EnvironmentVariableMap,
+        ) -> Result<Option<Command>, Error> {
+            Err(Error::InternalErrors("oops!".into()))
+        }
+    }
+
+    struct NoneProvider;
+
+    impl CommandProvider for NoneProvider {
+        fn command(
+            &self,
+            _task_id: &TaskId,
+            _environment: EnvironmentVariableMap,
+        ) -> Result<Option<Command>, Error> {
+            Ok(None)
+        }
+    }
+
+    #[test]
+    fn test_first_present_cmd_returned() {
+        let factory = CommandFactory::new()
+            .add_provider(EchoCmdFactory)
+            .add_provider(ErrProvider);
+        let task_id = TaskId::new("foo", "build");
+        let cmd = factory
+            .command(&task_id, EnvironmentVariableMap::default())
+            .unwrap()
+            .unwrap();
+        assert_eq!(cmd.program(), OsStr::new("echo"));
+    }
+
+    #[test]
+    fn test_error_short_circuits_factory() {
+        let factory = CommandFactory::new()
+            .add_provider(ErrProvider)
+            .add_provider(EchoCmdFactory);
+        let task_id = TaskId::new("foo", "build");
+        let cmd = factory
+            .command(&task_id, EnvironmentVariableMap::default())
+            .unwrap_err();
+        assert_snapshot!(cmd.to_string(), @"internal errors encountered: oops!");
+    }
+
+    #[test]
+    fn test_none_values_filtered() {
+        let factory = CommandFactory::new()
+            .add_provider(EchoCmdFactory)
+            .add_provider(NoneProvider);
+        let task_id = TaskId::new("foo", "build");
+        let cmd = factory
+            .command(&task_id, EnvironmentVariableMap::default())
+            .unwrap()
+            .unwrap();
+        assert_eq!(cmd.program(), OsStr::new("echo"));
+    }
+
+    #[test]
+    fn test_none_returned_if_no_commands_found() {
+        let factory = CommandFactory::new();
+        let task_id = TaskId::new("foo", "build");
+        let cmd = factory
+            .command(&task_id, EnvironmentVariableMap::default())
+            .unwrap();
+        assert!(cmd.is_none(), "expected no cmd, got {cmd:?}");
     }
 }

--- a/crates/turborepo-lib/src/task_graph/visitor/exec.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/exec.rs
@@ -51,15 +51,17 @@ impl<'a> ExecContextFactory<'a> {
             &visitor.package_graph,
             visitor.run_opts.task_args(),
         );
-        let mfe_proxy_provider = MicroFrontendProxyProvider::new(
-            visitor.repo_root,
-            &visitor.package_graph,
-            engine,
-            visitor.micro_frontends_configs,
-        );
-        let command_factory = CommandFactory::new()
-            .add_provider(mfe_proxy_provider)
-            .add_provider(pkg_graph_provider);
+        let mut command_factory = CommandFactory::new();
+        if let Some(micro_frontends_configs) = visitor.micro_frontends_configs {
+            command_factory.add_provider(MicroFrontendProxyProvider::new(
+                visitor.repo_root,
+                &visitor.package_graph,
+                engine,
+                micro_frontends_configs,
+            ));
+        }
+        command_factory.add_provider(pkg_graph_provider);
+
         Ok(Self {
             visitor,
             errors,

--- a/crates/turborepo-lib/src/task_graph/visitor/exec.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/exec.rs
@@ -13,7 +13,7 @@ use turborepo_telemetry::events::{task::PackageTaskEventBuilder, TrackedErrors};
 use turborepo_ui::{ColorConfig, OutputWriter};
 
 use super::{
-    command::CommandFactory,
+    command::{CommandFactory, PackageGraphCommandProvider},
     error::{TaskError, TaskErrorCause, TaskWarning},
     output::TaskCacheOutput,
     TaskOutput, Visitor,
@@ -46,11 +46,12 @@ impl<'a> ExecContextFactory<'a> {
         manager: ProcessManager,
         engine: &'a Arc<Engine>,
     ) -> Result<Self, super::Error> {
-        let command_factory = CommandFactory::new(
+        let pkg_graph_provider = PackageGraphCommandProvider::new(
             visitor.repo_root,
             &visitor.package_graph,
             visitor.run_opts.task_args(),
         );
+        let command_factory = CommandFactory::new().add_provider(pkg_graph_provider);
         Ok(Self {
             visitor,
             errors,

--- a/crates/turborepo-lib/src/task_graph/visitor/exec.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/exec.rs
@@ -13,7 +13,7 @@ use turborepo_telemetry::events::{task::PackageTaskEventBuilder, TrackedErrors};
 use turborepo_ui::{ColorConfig, OutputWriter};
 
 use super::{
-    command::{CommandFactory, PackageGraphCommandProvider},
+    command::{CommandFactory, MicroFrontendProxyProvider, PackageGraphCommandProvider},
     error::{TaskError, TaskErrorCause, TaskWarning},
     output::TaskCacheOutput,
     TaskOutput, Visitor,
@@ -51,7 +51,15 @@ impl<'a> ExecContextFactory<'a> {
             &visitor.package_graph,
             visitor.run_opts.task_args(),
         );
-        let command_factory = CommandFactory::new().add_provider(pkg_graph_provider);
+        let mfe_proxy_provider = MicroFrontendProxyProvider::new(
+            visitor.repo_root,
+            &visitor.package_graph,
+            engine,
+            visitor.micro_frontends_configs,
+        );
+        let command_factory = CommandFactory::new()
+            .add_provider(mfe_proxy_provider)
+            .add_provider(pkg_graph_provider);
         Ok(Self {
             visitor,
             errors,

--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -98,6 +98,11 @@ pub enum Error {
     InternalErrors(String),
     #[error("unable to find package manager binary: {0}")]
     Which(#[from] which::Error),
+    #[error(
+        "'{package}' is configured with a microfrontend.jsonc, but doesn't have \
+         '@vercel/microfrontends' listed as a dependency"
+    )]
+    MissingMFEDependency { package: String },
 }
 
 impl<'a> Visitor<'a> {

--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -5,7 +5,7 @@ mod output;
 
 use std::{
     borrow::Cow,
-    collections::{HashMap, HashSet},
+    collections::HashSet,
     io::Write,
     sync::{Arc, Mutex, OnceLock},
 };
@@ -34,6 +34,7 @@ use turborepo_ui::{
 use crate::{
     cli::EnvMode,
     engine::{Engine, ExecutionOptions},
+    micro_frontends::MicroFrontendsConfigs,
     opts::RunOpts,
     process::ProcessManager,
     run::{
@@ -65,7 +66,7 @@ pub struct Visitor<'a> {
     is_watch: bool,
     ui_sender: Option<UISender>,
     warnings: Arc<Mutex<Vec<TaskWarning>>>,
-    micro_frontends_configs: &'a HashMap<String, HashSet<TaskId<'static>>>,
+    micro_frontends_configs: Option<&'a MicroFrontendsConfigs>,
 }
 
 #[derive(Debug, thiserror::Error, Diagnostic)]
@@ -125,7 +126,7 @@ impl<'a> Visitor<'a> {
         global_env: EnvironmentVariableMap,
         ui_sender: Option<UISender>,
         is_watch: bool,
-        micro_frontends_configs: &'a HashMap<String, HashSet<TaskId<'static>>>,
+        micro_frontends_configs: Option<&'a MicroFrontendsConfigs>,
     ) -> Self {
         let task_hasher = TaskHasher::new(
             package_inputs_hashes,

--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -5,7 +5,7 @@ mod output;
 
 use std::{
     borrow::Cow,
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     io::Write,
     sync::{Arc, Mutex, OnceLock},
 };
@@ -65,6 +65,7 @@ pub struct Visitor<'a> {
     is_watch: bool,
     ui_sender: Option<UISender>,
     warnings: Arc<Mutex<Vec<TaskWarning>>>,
+    micro_frontends_configs: &'a HashMap<String, HashSet<TaskId<'static>>>,
 }
 
 #[derive(Debug, thiserror::Error, Diagnostic)]
@@ -119,6 +120,7 @@ impl<'a> Visitor<'a> {
         global_env: EnvironmentVariableMap,
         ui_sender: Option<UISender>,
         is_watch: bool,
+        micro_frontends_configs: &'a HashMap<String, HashSet<TaskId<'static>>>,
     ) -> Self {
         let task_hasher = TaskHasher::new(
             package_inputs_hashes,
@@ -155,6 +157,7 @@ impl<'a> Visitor<'a> {
             ui_sender,
             is_watch,
             warnings: Default::default(),
+            micro_frontends_configs,
         }
     }
 

--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -23,6 +23,7 @@ use tracing::{debug, error, warn, Span};
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPath};
 use turborepo_ci::{Vendor, VendorBehavior};
 use turborepo_env::{platform::PlatformEnv, EnvironmentVariableMap};
+use turborepo_micro_frontend::DEFAULT_MICRO_FRONTENDS_CONFIG;
 use turborepo_repository::package_graph::{PackageGraph, PackageName, ROOT_PKG_NAME};
 use turborepo_telemetry::events::{
     generic::GenericEventBuilder, task::PackageTaskEventBuilder, EventBuilder, TrackedErrors,
@@ -100,7 +101,7 @@ pub enum Error {
     #[error("unable to find package manager binary: {0}")]
     Which(#[from] which::Error),
     #[error(
-        "'{package}' is configured with a microfrontend.jsonc, but doesn't have \
+        "'{package}' is configured with a {DEFAULT_MICRO_FRONTENDS_CONFIG}, but doesn't have \
          '@vercel/microfrontends' listed as a dependency"
     )]
     MissingMFEDependency { package: String },

--- a/crates/turborepo-lib/src/turbo_json/loader.rs
+++ b/crates/turborepo-lib/src/turbo_json/loader.rs
@@ -176,8 +176,6 @@ impl TurboJsonLoader {
                 packages,
                 micro_frontends_configs,
             } => {
-                eprint!("resolving {package:?}");
-                eprintln!("{micro_frontends_configs:?}");
                 let path = packages.get(package).ok_or_else(|| Error::NoTurboJSON)?;
                 let should_inject_proxy_task =
                     micro_frontends_configs.as_ref().map_or(false, |configs| {

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -608,6 +608,21 @@ impl TurboJson {
             .iter()
             .any(|(task_name, _)| task_name.package() == Some(ROOT_PKG_NAME))
     }
+
+    /// Adds a local proxy task to a workspace TurboJson
+    pub fn with_proxy(&mut self) {
+        if self.extends.is_empty() {
+            self.extends = Spanned::new(vec!["//".into()]);
+        }
+
+        self.tasks.insert(
+            TaskName::from("proxy"),
+            Spanned::new(RawTaskDefinition {
+                cache: Some(Spanned::new(false)),
+                ..Default::default()
+            }),
+        );
+    }
 }
 
 type TurboJSONValidation = fn(&TurboJson) -> Vec<Error>;

--- a/crates/turborepo-micro-frontend/Cargo.toml
+++ b/crates/turborepo-micro-frontend/Cargo.toml
@@ -14,6 +14,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 turbopath = { workspace = true }
+turborepo-errors = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/turborepo-micro-frontend/Cargo.toml
+++ b/crates/turborepo-micro-frontend/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "turborepo-micro-frontend"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+biome_deserialize = { workspace = true }
+biome_deserialize_macros = { workspace = true }
+biome_diagnostics = { workspace = true }
+biome_json_parser = { workspace = true }
+biome_json_syntax = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+turbopath = { workspace = true }
+
+[dev-dependencies]
+pretty_assertions = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/turborepo-micro-frontend/Cargo.toml
+++ b/crates/turborepo-micro-frontend/Cargo.toml
@@ -2,6 +2,7 @@
 name = "turborepo-micro-frontend"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
 
 [dependencies]
 biome_deserialize = { workspace = true }

--- a/crates/turborepo-micro-frontend/fixtures/sample.jsonc
+++ b/crates/turborepo-micro-frontend/fixtures/sample.jsonc
@@ -1,0 +1,133 @@
+{
+  "version": "1",
+  "applications": {
+    "main-site": {
+      "default": true,
+      "development": {
+        "local": {
+          "protocol": "http",
+          "host": "localhost",
+          "port": 3331
+        },
+        "fallback": {
+          "protocol": "https",
+          "host": "main-preview.sh"
+        }
+      },
+      "production": {
+        "protocol": "https",
+        "host": "main.com"
+      },
+      "vercel": {
+        "projectId": "id1",
+        "projectName": "main-site"
+      }
+    },
+    "vercel-marketing": {
+      "default": false,
+      "routing": {
+        "assetPrefix": "market-site",
+        "matches": [
+          {
+            "group": "blog",
+            "paths": [
+              "/blog",
+              "/blog/:slug*",
+              "/press",
+              "/changelog",
+              "/changelog/:slug*",
+              "/customers/:slug*"
+            ]
+          },
+          {
+            "group": "navbar",
+            "paths": [
+              "/",
+              "/contact",
+              "/pricing",
+              "/enterprise",
+              // Resources
+              "/customers",
+              "/solutions/composable-commerce"
+            ]
+          }
+        ]
+      },
+      "development": {
+        "local": {
+          "protocol": "http",
+          "host": "localhost",
+          "port": 3332
+        },
+        "fallback": {
+          "protocol": "https",
+          "host": "market-preview.sh"
+        }
+      },
+      "production": {
+        "protocol": "https",
+        "host": "market.main.com"
+      },
+      "vercel": {
+        "projectId": "id2",
+        "projectName": "market-site"
+      }
+    },
+    "foo-docs": {
+      "default": false,
+      "routing": {
+        "assetPrefix": "foo",
+        "matches": [
+          {
+            "paths": ["/foo/:path*"]
+          }
+        ]
+      },
+      "development": {
+        "fallback": {
+          "protocol": "https",
+          "host": "foo-preview.sh"
+        },
+        "local": {
+          "protocol": "http",
+          "host": "localhost",
+          "port": 3333
+        }
+      },
+      "production": {
+        "protocol": "https",
+        "host": "foo.main.com"
+      },
+      "vercel": {
+        "projectId": "id3",
+        "projectName": "foo-docs"
+      }
+    },
+    "docs": {
+      "default": false,
+      "routing": {
+        "assetPrefix": "docs",
+        "matches": []
+      },
+      "development": {
+        "fallback": {
+          "protocol": "https",
+          "host": "docs-preview.sh"
+        },
+        "local": {
+          "protocol": "http",
+          "host": "localhost",
+          "port": 3334
+        }
+      },
+      "production": {
+        "protocol": "https",
+        "host": "docs.main.com"
+      },
+      "vercel": {
+        "projectId": "id4",
+        "projectName": "docs-site"
+      }
+    }
+  }
+}

--- a/crates/turborepo-micro-frontend/src/error.rs
+++ b/crates/turborepo-micro-frontend/src/error.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use turborepo_errors::ParseDiagnostic;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -11,15 +11,9 @@ pub enum Error {
 impl Error {
     /// Constructs an error message from multiple biome diagnostic errors
     pub fn biome_error(errors: Vec<biome_diagnostics::Error>) -> Self {
-        struct DisplayDesc(biome_diagnostics::Error);
-        impl fmt::Display for DisplayDesc {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                self.0.description(f)
-            }
-        }
         let error_messages = errors
             .into_iter()
-            .map(|err| DisplayDesc(err).to_string())
+            .map(|err| ParseDiagnostic::from(err).to_string())
             .collect::<Vec<_>>();
         Self::JsonParse(error_messages.join("\n"))
     }

--- a/crates/turborepo-micro-frontend/src/error.rs
+++ b/crates/turborepo-micro-frontend/src/error.rs
@@ -1,0 +1,26 @@
+use std::fmt;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Unable to read configuration file: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Unable to parse JSON: {0}")]
+    JsonParse(String),
+}
+
+impl Error {
+    /// Constructs an error message from multiple biome diagnostic errors
+    pub fn biome_error(errors: Vec<biome_diagnostics::Error>) -> Self {
+        struct DisplayDesc(biome_diagnostics::Error);
+        impl fmt::Display for DisplayDesc {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                self.0.description(f)
+            }
+        }
+        let error_messages = errors
+            .into_iter()
+            .map(|err| DisplayDesc(err).to_string())
+            .collect::<Vec<_>>();
+        Self::JsonParse(error_messages.join("\n"))
+    }
+}

--- a/crates/turborepo-micro-frontend/src/lib.rs
+++ b/crates/turborepo-micro-frontend/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(clippy::all)]
 mod error;
 
 use std::collections::BTreeMap;

--- a/crates/turborepo-micro-frontend/src/lib.rs
+++ b/crates/turborepo-micro-frontend/src/lib.rs
@@ -9,7 +9,10 @@ pub use error::Error;
 use serde::Serialize;
 use turbopath::AbsoluteSystemPath;
 
-pub const MICRO_FRONTENDS_CONFIG: &str = "micro-frontends.jsonc";
+/// Currently the default path for a package that provides a configuration.
+///
+/// This is subject to change at any time.
+pub const DEFAULT_MICRO_FRONTENDS_CONFIG: &str = "micro-frontends.jsonc";
 pub const MICRO_FRONTENDS_PACKAGES: &[&str] = ["@vercel/micro-frontends-internal"].as_slice();
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]

--- a/crates/turborepo-micro-frontend/src/lib.rs
+++ b/crates/turborepo-micro-frontend/src/lib.rs
@@ -15,13 +15,12 @@ use turbopath::AbsoluteSystemPath;
 pub const DEFAULT_MICRO_FRONTENDS_CONFIG: &str = "micro-frontends.jsonc";
 pub const MICRO_FRONTENDS_PACKAGES: &[&str] = ["@vercel/micro-frontends-internal"].as_slice();
 
+/// The minimal amount of information Turborepo needs to correctly start a local
+/// proxy server for microfrontends
 #[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
 pub struct Config {
     pub version: String,
-    #[serde(rename = "$schema")]
-    pub schema: Option<String>,
     pub applications: BTreeMap<String, Application>,
-    pub options: Option<Options>,
 }
 
 impl Config {
@@ -51,115 +50,18 @@ impl Config {
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
-pub struct Options {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub vercel: Option<VercelOptions>,
-}
-
-#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct VercelOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub stitch_applications_in_preview: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub bypass_deployment_protection_in_production: Option<bool>,
-}
-
-#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
 pub struct Application {
-    // default = true -> no routing
-    // default = false -> requires routing
-    pub default: bool,
-    pub routing: Option<ZoneRouting>,
     pub development: Development,
-    pub production: Host,
-    pub metadata: Option<BTreeMap<String, String>>,
-    pub federation: Option<Federation>,
-    pub vercel: Option<Vercel>,
-}
-
-#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct Vercel {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub project_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub project_name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub deployment_protection_env_key: Option<String>,
-}
-
-#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
-pub struct Federation {
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub exposes: Vec<Module>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub uses: Vec<String>,
-}
-
-#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
-pub struct Module {
-    pub name: String,
-    pub path: String,
-}
-
-#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct ZoneRouting {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub asset_prefix: Option<String>,
-    pub matches: Vec<PathGroup>,
-}
-
-#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct PathGroup {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub group: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub options: Option<PathConfigurationOptions>,
-    pub paths: Vec<String>,
-}
-
-#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct PathConfigurationOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub flag: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub route_to_default_application: Option<bool>,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
 pub struct Development {
-    pub local: Host,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub fallback: Option<Host>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub task: Option<String>,
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
-pub struct Host {
-    pub protocol: Protocol,
-    pub host: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub port: Option<u16>,
-}
-
-#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
-#[serde(rename_all = "lowercase")]
-pub enum Protocol {
-    #[default]
-    Http,
-    Https,
-}
-
 #[cfg(test)]
 mod test {
-    use biome_deserialize::{json::deserialize_from_json_str, Deserializable};
-    use pretty_assertions::assert_eq;
-
     use super::*;
 
     #[test]
@@ -167,71 +69,5 @@ mod test {
         let input = include_str!("../fixtures/sample.jsonc");
         let example_config = Config::from_str(input, "something.json");
         assert!(example_config.is_ok());
-    }
-
-    fn assert_round_trip<T>(input: &str) -> Result<(), serde_json::Error>
-    where
-        for<'a> T: Serialize + Deserializable,
-    {
-        let (value, errs): (Option<T>, _) = deserialize_from_json_str(
-            input,
-            JsonParserOptions::default().with_allow_comments(),
-            "test.json",
-        )
-        .consume();
-        assert!(errs.is_empty());
-        let output = serde_json::to_string(&value.unwrap())?;
-        assert_eq!(
-            input,
-            output,
-            "roundtrip failed for {:?}",
-            std::any::type_name::<T>()
-        );
-        Ok(())
-    }
-
-    const EXAMPLE_HOST: &str = r#"{"protocol":"https","host":"example.com"}"#;
-    const EXAMPLE_PATH_GROUP: &str =
-        r#"{"group":"docs","options":{"routeToDefaultApplication":true},"paths":["docs/:path*"]}"#;
-
-    #[test]
-    fn test_round_trips() -> Result<(), serde_json::Error> {
-        assert_round_trip::<Protocol>(r#""http""#)?;
-        assert_round_trip::<Protocol>(r#""https""#)?;
-        assert_round_trip::<Host>(EXAMPLE_HOST)?;
-        assert_round_trip::<Host>(r#"{"protocol":"http","host":"example.com","port":3000}"#)?;
-        assert_round_trip::<Development>(&format!("{{\"local\":{EXAMPLE_HOST}}}"))?;
-        assert_round_trip::<Development>(&format!(
-            "{{\"local\":{EXAMPLE_HOST},\"task\":\"dev\"}}"
-        ))?;
-        assert_round_trip::<Development>(&format!(
-            "{{\"local\":{EXAMPLE_HOST},\"fallback\":{EXAMPLE_HOST}}}"
-        ))?;
-        assert_round_trip::<Vercel>(r#"{}"#)?;
-        assert_round_trip::<Vercel>(r#"{"projectId":"foobar"}"#)?;
-        assert_round_trip::<Vercel>(
-            r#"{"projectId":"foobar","projectName":"secret","deploymentProtectionEnvKey":"MY_VAR"}"#,
-        )?;
-        assert_round_trip::<PathConfigurationOptions>(r#"{}"#)?;
-        assert_round_trip::<PathConfigurationOptions>(r#"{"flag":"staging"}"#)?;
-        assert_round_trip::<PathConfigurationOptions>(r#"{"routeToDefaultApplication":true}"#)?;
-        assert_round_trip::<PathGroup>(r#"{"paths":["docs/:path*"]}"#)?;
-        assert_round_trip::<PathGroup>(EXAMPLE_PATH_GROUP)?;
-        assert_round_trip::<ZoneRouting>(&format!("{{\"matches\":[{EXAMPLE_PATH_GROUP}]}}"))?;
-        assert_round_trip::<ZoneRouting>(&format!(
-            "{{\"assetPrefix\":\"turbo\",\"matches\":[{EXAMPLE_PATH_GROUP}]}}"
-        ))?;
-        assert_round_trip::<Module>(r#"{"name":"lazy","path":"lazy.js"}"#)?;
-        assert_round_trip::<Federation>(r#"{}"#)?;
-        assert_round_trip::<Federation>(
-            r#"{"exposes":[{"name":"lazy","path":"lazy.js"}],"uses":["lazy"]}"#,
-        )?;
-        assert_round_trip::<VercelOptions>(r#"{}"#)?;
-        assert_round_trip::<VercelOptions>(
-            r#"{"stitchApplicationsInPreview":true,"bypassDeploymentProtectionInProduction":false}"#,
-        )?;
-        assert_round_trip::<Options>(r#"{}"#)?;
-        assert_round_trip::<Options>(r#"{"vercel":{}}"#)?;
-        Ok(())
     }
 }

--- a/crates/turborepo-micro-frontend/src/lib.rs
+++ b/crates/turborepo-micro-frontend/src/lib.rs
@@ -9,6 +9,7 @@ use serde::Serialize;
 use turbopath::AbsoluteSystemPath;
 
 pub const MICRO_FRONTENDS_CONFIG: &str = "micro-frontends.jsonc";
+pub const MICRO_FRONTENDS_PACKAGES: &[&str] = ["@vercel/micro-frontends-internal"].as_slice();
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
 pub struct Config {

--- a/crates/turborepo-micro-frontend/src/lib.rs
+++ b/crates/turborepo-micro-frontend/src/lib.rs
@@ -1,0 +1,232 @@
+mod error;
+
+use std::collections::BTreeMap;
+
+use biome_deserialize_macros::Deserializable;
+use biome_json_parser::JsonParserOptions;
+pub use error::Error;
+use serde::Serialize;
+use turbopath::AbsoluteSystemPath;
+
+pub const MICRO_FRONTENDS_CONFIG: &str = "micro-frontends.jsonc";
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
+pub struct Config {
+    pub version: String,
+    #[serde(rename = "$schema")]
+    pub schema: Option<String>,
+    pub applications: BTreeMap<String, Application>,
+    pub options: Option<Options>,
+}
+
+impl Config {
+    /// Reads config from given path.
+    /// Returns `Ok(None)` if the file does not exist
+    pub fn load(config_path: &AbsoluteSystemPath) -> Result<Option<Self>, Error> {
+        let Some(contents) = config_path.read_existing_to_string()? else {
+            return Ok(None);
+        };
+        let config = Self::from_str(&contents, config_path.as_str()).map_err(Error::biome_error)?;
+        Ok(Some(config))
+    }
+
+    pub fn from_str(input: &str, source: &str) -> Result<Self, Vec<biome_diagnostics::Error>> {
+        let (config, errs) = biome_deserialize::json::deserialize_from_json_str(
+            input,
+            JsonParserOptions::default().with_allow_comments(),
+            source,
+        )
+        .consume();
+        if let Some(config) = config {
+            Ok(config)
+        } else {
+            Err(errs)
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
+pub struct Options {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vercel: Option<VercelOptions>,
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct VercelOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stitch_applications_in_preview: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bypass_deployment_protection_in_production: Option<bool>,
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
+pub struct Application {
+    // default = true -> no routing
+    // default = false -> requires routing
+    pub default: bool,
+    pub routing: Option<ZoneRouting>,
+    pub development: Development,
+    pub production: Host,
+    pub metadata: Option<BTreeMap<String, String>>,
+    pub federation: Option<Federation>,
+    pub vercel: Option<Vercel>,
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct Vercel {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deployment_protection_env_key: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
+pub struct Federation {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub exposes: Vec<Module>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub uses: Vec<String>,
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
+pub struct Module {
+    pub name: String,
+    pub path: String,
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ZoneRouting {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub asset_prefix: Option<String>,
+    pub matches: Vec<PathGroup>,
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PathGroup {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<PathConfigurationOptions>,
+    pub paths: Vec<String>,
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PathConfigurationOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub flag: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub route_to_default_application: Option<bool>,
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
+pub struct Development {
+    pub local: Host,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fallback: Option<Host>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
+pub struct Host {
+    pub protocol: Protocol,
+    pub host: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub port: Option<u16>,
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Protocol {
+    #[default]
+    Http,
+    Https,
+}
+
+#[cfg(test)]
+mod test {
+    use biome_deserialize::{json::deserialize_from_json_str, Deserializable};
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn test_example_parses() {
+        let input = include_str!("../fixtures/sample.jsonc");
+        let example_config = Config::from_str(input, "something.json");
+        assert!(example_config.is_ok());
+    }
+
+    fn assert_round_trip<T>(input: &str) -> Result<(), serde_json::Error>
+    where
+        for<'a> T: Serialize + Deserializable,
+    {
+        let (value, errs): (Option<T>, _) = deserialize_from_json_str(
+            input,
+            JsonParserOptions::default().with_allow_comments(),
+            "test.json",
+        )
+        .consume();
+        assert!(errs.is_empty());
+        let output = serde_json::to_string(&value.unwrap())?;
+        assert_eq!(
+            input,
+            output,
+            "roundtrip failed for {:?}",
+            std::any::type_name::<T>()
+        );
+        Ok(())
+    }
+
+    const EXAMPLE_HOST: &str = r#"{"protocol":"https","host":"example.com"}"#;
+    const EXAMPLE_PATH_GROUP: &str =
+        r#"{"group":"docs","options":{"routeToDefaultApplication":true},"paths":["docs/:path*"]}"#;
+
+    #[test]
+    fn test_round_trips() -> Result<(), serde_json::Error> {
+        assert_round_trip::<Protocol>(r#""http""#)?;
+        assert_round_trip::<Protocol>(r#""https""#)?;
+        assert_round_trip::<Host>(EXAMPLE_HOST)?;
+        assert_round_trip::<Host>(r#"{"protocol":"http","host":"example.com","port":3000}"#)?;
+        assert_round_trip::<Development>(&format!("{{\"local\":{EXAMPLE_HOST}}}"))?;
+        assert_round_trip::<Development>(&format!(
+            "{{\"local\":{EXAMPLE_HOST},\"task\":\"dev\"}}"
+        ))?;
+        assert_round_trip::<Development>(&format!(
+            "{{\"local\":{EXAMPLE_HOST},\"fallback\":{EXAMPLE_HOST}}}"
+        ))?;
+        assert_round_trip::<Vercel>(r#"{}"#)?;
+        assert_round_trip::<Vercel>(r#"{"projectId":"foobar"}"#)?;
+        assert_round_trip::<Vercel>(
+            r#"{"projectId":"foobar","projectName":"secret","deploymentProtectionEnvKey":"MY_VAR"}"#,
+        )?;
+        assert_round_trip::<PathConfigurationOptions>(r#"{}"#)?;
+        assert_round_trip::<PathConfigurationOptions>(r#"{"flag":"staging"}"#)?;
+        assert_round_trip::<PathConfigurationOptions>(r#"{"routeToDefaultApplication":true}"#)?;
+        assert_round_trip::<PathGroup>(r#"{"paths":["docs/:path*"]}"#)?;
+        assert_round_trip::<PathGroup>(EXAMPLE_PATH_GROUP)?;
+        assert_round_trip::<ZoneRouting>(&format!("{{\"matches\":[{EXAMPLE_PATH_GROUP}]}}"))?;
+        assert_round_trip::<ZoneRouting>(&format!(
+            "{{\"assetPrefix\":\"turbo\",\"matches\":[{EXAMPLE_PATH_GROUP}]}}"
+        ))?;
+        assert_round_trip::<Module>(r#"{"name":"lazy","path":"lazy.js"}"#)?;
+        assert_round_trip::<Federation>(r#"{}"#)?;
+        assert_round_trip::<Federation>(
+            r#"{"exposes":[{"name":"lazy","path":"lazy.js"}],"uses":["lazy"]}"#,
+        )?;
+        assert_round_trip::<VercelOptions>(r#"{}"#)?;
+        assert_round_trip::<VercelOptions>(
+            r#"{"stitchApplicationsInPreview":true,"bypassDeploymentProtectionInProduction":false}"#,
+        )?;
+        assert_round_trip::<Options>(r#"{}"#)?;
+        assert_round_trip::<Options>(r#"{"vercel":{}}"#)?;
+        Ok(())
+    }
+}

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -109,6 +109,15 @@ impl Serialize for PackageName {
     }
 }
 
+impl PackageName {
+    pub fn as_str(&self) -> &str {
+        match self {
+            PackageName::Root => ROOT_PKG_NAME,
+            PackageName::Other(name) => name,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub enum PackageNode {
     Root,


### PR DESCRIPTION
### Description

This PR adds all support necessary for starting a MFE local proxy:
 - Adds new `CommandProvider` to allow for multiple strategies for constructing a command depending on the type
 - Adds parsing logic for `micro-frontends.jsonc`
 - Parses all `micro-frontends.jsonc` found in the package graph*
 - Adding a task definition for the generated `proxy` task if MFE configs are found
 - Explicitly include the `proxy` tasks in engine building step if a MFE dev task is found in the product of the package `--filter` and the tasks specified in `turbo run`
 - Adds a `CommandProvider` that construct a command that invokes the MFE local proxy

⚠️ This currently only support MFE configs that are located in shared packages and doesn't respect a loose MFE configs.

Follow up work:
 - [ ] Handle configurable MFE config location

### Testing Instructions

In a repository with MFE, run a dev task for one of the configured MFE. This should result in a `#proxy` task being injected for that MFE and correctly configured to route traffic to the dev tasks or a remote host.
