### PR TITLE
feat(trace): filtering by import type

### DIFF
--- a/crates/turbo-trace/src/lib.rs
+++ b/crates/turbo-trace/src/lib.rs
@@ -2,4 +2,4 @@
 mod import_finder;
 mod tracer;
 
-pub use tracer::{TraceError, TraceResult, Tracer};
+pub use tracer::{ImportType, TraceError, TraceResult, Tracer};

--- a/crates/turborepo/tests/query.rs
+++ b/crates/turborepo/tests/query.rs
@@ -47,6 +47,12 @@ fn test_trace() -> Result<(), anyhow::Error> {
             "get `invalid.ts` with dependencies" => "query { file(path: \"invalid.ts\") { path dependencies { files { items { path } } errors { items { message } } } } }",
             "get `main.ts` with depth = 0" => "query { file(path: \"main.ts\") { path dependencies(depth: 1) { files { items { path } } } } }",
             "get `with_prefix.ts` with dependencies" => "query { file(path: \"with_prefix.ts\") { path dependencies { files { items { path } } } } }",
+            "get `import_value_and_type.ts` with all dependencies" => "query { file(path: \"import_value_and_type.ts\") { path dependencies(importType: ALL) { files { items { path } } } } }",
+            "get `import_value_and_type.ts` with type dependencies" => "query { file(path: \"import_value_and_type.ts\") { path dependencies(importType: TYPES) { files { items { path } } } } }",
+            "get `import_value_and_type.ts` with value dependencies" => "query { file(path: \"import_value_and_type.ts\") { path dependencies(importType: VALUES) { files { items { path } } } } }",
+            "get `link.tsx` with all dependents" => "query { file(path: \"link.tsx\") { path dependents(importType: ALL) { files { items { path } } } } }",
+            "get `link.tsx` with type dependents" => "query { file(path: \"link.tsx\") { path dependents(importType: TYPES) { files { items { path } } } } }",
+            "get `link.tsx` with value dependents" => "query { file(path: \"link.tsx\") { path dependents(importType: VALUES) { files { items { path } } } } }",
         );
 
         Ok(())

--- a/crates/turborepo/tests/snapshots/query__turbo_trace_get_`import_value_and_type.ts`_with_all_dependencies_(npm@10.5.0).snap
+++ b/crates/turborepo/tests/snapshots/query__turbo_trace_get_`import_value_and_type.ts`_with_all_dependencies_(npm@10.5.0).snap
@@ -1,0 +1,23 @@
+---
+source: crates/turborepo/tests/query.rs
+expression: query_output
+---
+{
+  "data": {
+    "file": {
+      "path": "import_value_and_type.ts",
+      "dependencies": {
+        "files": {
+          "items": [
+            {
+              "path": "link.tsx"
+            },
+            {
+              "path": "types.ts"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/crates/turborepo/tests/snapshots/query__turbo_trace_get_`import_value_and_type.ts`_with_type_dependencies_(npm@10.5.0).snap
+++ b/crates/turborepo/tests/snapshots/query__turbo_trace_get_`import_value_and_type.ts`_with_type_dependencies_(npm@10.5.0).snap
@@ -1,0 +1,20 @@
+---
+source: crates/turborepo/tests/query.rs
+expression: query_output
+---
+{
+  "data": {
+    "file": {
+      "path": "import_value_and_type.ts",
+      "dependencies": {
+        "files": {
+          "items": [
+            {
+              "path": "types.ts"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/crates/turborepo/tests/snapshots/query__turbo_trace_get_`import_value_and_type.ts`_with_value_dependencies_(npm@10.5.0).snap
+++ b/crates/turborepo/tests/snapshots/query__turbo_trace_get_`import_value_and_type.ts`_with_value_dependencies_(npm@10.5.0).snap
@@ -1,0 +1,20 @@
+---
+source: crates/turborepo/tests/query.rs
+expression: query_output
+---
+{
+  "data": {
+    "file": {
+      "path": "import_value_and_type.ts",
+      "dependencies": {
+        "files": {
+          "items": [
+            {
+              "path": "link.tsx"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/crates/turborepo/tests/snapshots/query__turbo_trace_get_`link.tsx`_with_all_dependents_(npm@10.5.0).snap
+++ b/crates/turborepo/tests/snapshots/query__turbo_trace_get_`link.tsx`_with_all_dependents_(npm@10.5.0).snap
@@ -1,0 +1,26 @@
+---
+source: crates/turborepo/tests/query.rs
+expression: query_output
+---
+{
+  "data": {
+    "file": {
+      "path": "link.tsx",
+      "dependents": {
+        "files": {
+          "items": [
+            {
+              "path": "import_just_type.ts"
+            },
+            {
+              "path": "import_just_value.ts"
+            },
+            {
+              "path": "import_value_and_type.ts"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/crates/turborepo/tests/snapshots/query__turbo_trace_get_`link.tsx`_with_type_dependents_(npm@10.5.0).snap
+++ b/crates/turborepo/tests/snapshots/query__turbo_trace_get_`link.tsx`_with_type_dependents_(npm@10.5.0).snap
@@ -1,0 +1,20 @@
+---
+source: crates/turborepo/tests/query.rs
+expression: query_output
+---
+{
+  "data": {
+    "file": {
+      "path": "link.tsx",
+      "dependents": {
+        "files": {
+          "items": [
+            {
+              "path": "import_just_type.ts"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/crates/turborepo/tests/snapshots/query__turbo_trace_get_`link.tsx`_with_value_dependents_(npm@10.5.0).snap
+++ b/crates/turborepo/tests/snapshots/query__turbo_trace_get_`link.tsx`_with_value_dependents_(npm@10.5.0).snap
@@ -1,0 +1,23 @@
+---
+source: crates/turborepo/tests/query.rs
+expression: query_output
+---
+{
+  "data": {
+    "file": {
+      "path": "link.tsx",
+      "dependents": {
+        "files": {
+          "items": [
+            {
+              "path": "import_just_value.ts"
+            },
+            {
+              "path": "import_value_and_type.ts"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/turborepo-tests/integration/fixtures/turbo_trace/import_just_type.ts
+++ b/turborepo-tests/integration/fixtures/turbo_trace/import_just_type.ts
@@ -1,0 +1,1 @@
+import type { LinkProps } from "./link";

--- a/turborepo-tests/integration/fixtures/turbo_trace/import_just_value.ts
+++ b/turborepo-tests/integration/fixtures/turbo_trace/import_just_value.ts
@@ -1,0 +1,1 @@
+import { Link } from "./link";

--- a/turborepo-tests/integration/fixtures/turbo_trace/import_value_and_type.ts
+++ b/turborepo-tests/integration/fixtures/turbo_trace/import_value_and_type.ts
@@ -1,0 +1,2 @@
+import type { LinkProps } from "./types";
+import { Link } from "./link";

--- a/turborepo-tests/integration/fixtures/turbo_trace/link.tsx
+++ b/turborepo-tests/integration/fixtures/turbo_trace/link.tsx
@@ -1,0 +1,8 @@
+export interface LinkProps {
+  children: React.ReactNode;
+  href: string;
+}
+
+export const Link = ({ children, href }: LinkProps) => {
+  return <a href={href}>{children}</a>;
+};

--- a/turborepo-tests/integration/fixtures/turbo_trace/types.ts
+++ b/turborepo-tests/integration/fixtures/turbo_trace/types.ts
@@ -1,0 +1,1 @@
+export type LinkProps = string;


### PR DESCRIPTION
### Description

Allow for turbo trace to filter by import type so you can get just the type imports. Note, this just checks syntactically, so it's possible it will miss type imports that are not labeled as such. However, this is a pretty common lint rule to split out type imports.

### Testing Instructions

Added tests in `turborepo-lib/tests/query.rs` including both dependencies and dependents with import type filtering