### PR TITLE
feat(trace): add export conditions `import` and `require` to trace resolver

### DIFF
--- a/crates/turborepo-lib/src/query/file.rs
+++ b/crates/turborepo-lib/src/query/file.rs
@@ -99,8 +99,9 @@ impl From<turbo_trace::TraceError> for TraceError {
                 path: Some(path.to_string()),
                 ..Default::default()
             },
-            turbo_trace::TraceError::ParseError(e) => TraceError {
+            turbo_trace::TraceError::ParseError(path, e) => TraceError {
                 message: format!("failed to parse file: {:?}", e),
+                path: Some(path.to_string()),
                 ..Default::default()
             },
             turbo_trace::TraceError::GlobError(err) => TraceError {

--- a/crates/turborepo/tests/query.rs
+++ b/crates/turborepo/tests/query.rs
@@ -50,9 +50,7 @@ fn test_trace() -> Result<(), anyhow::Error> {
             "get `import_value_and_type.ts` with all dependencies" => "query { file(path: \"import_value_and_type.ts\") { path dependencies(importType: ALL) { files { items { path } } } } }",
             "get `import_value_and_type.ts` with type dependencies" => "query { file(path: \"import_value_and_type.ts\") { path dependencies(importType: TYPES) { files { items { path } } } } }",
             "get `import_value_and_type.ts` with value dependencies" => "query { file(path: \"import_value_and_type.ts\") { path dependencies(importType: VALUES) { files { items { path } } } } }",
-            "get `link.tsx` with all dependents" => "query { file(path: \"link.tsx\") { path dependents(importType: ALL) { files { items { path } } } } }",
-            "get `link.tsx` with type dependents" => "query { file(path: \"link.tsx\") { path dependents(importType: TYPES) { files { items { path } } } } }",
-            "get `link.tsx` with value dependents" => "query { file(path: \"link.tsx\") { path dependents(importType: VALUES) { files { items { path } } } } }",
+            "get `export_conditions` with dependencies" => "query { file(path: \"export_conditions.js\") { path dependencies(depth: 1) { files { items { path } } } } }",
         );
 
         Ok(())
@@ -82,6 +80,9 @@ fn test_reverse_trace() -> Result<(), anyhow::Error> {
         "npm@10.5.0",
         "query",
         "get `button.tsx` with dependents" => "query { file(path: \"button.tsx\") { path dependents { files { items { path } } } } }",
+        "get `link.tsx` with all dependents" => "query { file(path: \"link.tsx\") { path dependents(importType: ALL) { files { items { path } } } } }",
+        "get `link.tsx` with type dependents" => "query { file(path: \"link.tsx\") { path dependents(importType: TYPES) { files { items { path } } } } }",
+        "get `link.tsx` with value dependents" => "query { file(path: \"link.tsx\") { path dependents(importType: VALUES) { files { items { path } } } } }",
     );
 
     Ok(())

--- a/crates/turborepo/tests/snapshots/query__turbo_trace_get_`export_conditions`_with_dependencies_(npm@10.5.0).snap
+++ b/crates/turborepo/tests/snapshots/query__turbo_trace_get_`export_conditions`_with_dependencies_(npm@10.5.0).snap
@@ -1,0 +1,20 @@
+---
+source: crates/turborepo/tests/query.rs
+expression: query_output
+---
+{
+  "data": {
+    "file": {
+      "path": "export_conditions.js",
+      "dependencies": {
+        "files": {
+          "items": [
+            {
+              "path": "node_modules/swr/dist/core/index.mjs"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/turborepo-tests/integration/fixtures/turbo_trace/export_conditions.js
+++ b/turborepo-tests/integration/fixtures/turbo_trace/export_conditions.js
@@ -1,0 +1,1 @@
+import useSWR from "swr";

--- a/turborepo-tests/integration/fixtures/turbo_trace/package.json
+++ b/turborepo-tests/integration/fixtures/turbo_trace/package.json
@@ -5,7 +5,8 @@
     "node": ">=18"
   },
   "dependencies": {
-    "repeat-string": "^1.6.1"
+    "repeat-string": "^1.6.1",
+    "swr": "^2.2.5"
   },
   "workspaces": [
     "apps/*",


### PR DESCRIPTION
### Description

`package.json` exports can be selected based on conditions such as whether the package is being imported as an esm `import` or a `require`. We added `import` and `require` as default conditions for the resolver so packages that define these conditions trace properly.

### Testing Instructions

Added a test with `swr` which uses these package export conditions
