### PR TITLE
feat: `turbo info` command for debugging

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1222,7 +1222,7 @@ pub async fn run(
 
             match info::run(base).await {
                 Ok(()) => {}
-                Err(e) => println!("Command failed. Please file a GitHub Issue.\n{}", e),
+                Err(_e) => panic!("`info` command failed."),
             }
             Ok(0)
         }

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1220,10 +1220,7 @@ pub async fn run(
                 .track_call();
             let base = CommandBase::new(cli_args.clone(), repo_root, version, color_config);
 
-            match info::run(base).await {
-                Ok(()) => {}
-                Err(_e) => panic!("`info` command failed."),
-            }
+            info::run(base).await;
             Ok(0)
         }
         Command::Telemetry { command } => {

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1218,8 +1218,8 @@ pub async fn run(
             CommandEventBuilder::new("info")
                 .with_parent(&root_telemetry)
                 .track_call();
-            let mut base = CommandBase::new(cli_args.clone(), repo_root, version, color_config);
-            info::run(base);
+            let base = CommandBase::new(cli_args.clone(), repo_root, version, color_config);
+            info::run(base).await;
 
             Ok(0)
         }

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -22,8 +22,8 @@ use turborepo_ui::{ColorConfig, GREY};
 use crate::{
     cli::error::print_potential_tasks,
     commands::{
-        bin, config, daemon, generate, link, login, logout, ls, prune, query, run, scan, telemetry,
-        unlink, CommandBase,
+        bin, config, daemon, generate, info, link, login, logout, ls, prune, query, run, scan,
+        telemetry, unlink, CommandBase,
     },
     get_version,
     run::watch::WatchClient,
@@ -475,9 +475,7 @@ impl Args {
     }
 }
 
-/// Defines the subcommands for CLI. NOTE: If we change the commands in Go,
-/// we must change these as well to avoid accidentally passing the
-/// --single-package flag into non-build commands.
+/// Defines the subcommands for CLI
 #[derive(Subcommand, Clone, Debug, PartialEq)]
 pub enum Command {
     /// Get the path to the Turbo binary
@@ -570,6 +568,8 @@ pub enum Command {
         #[clap(long)]
         invalidate: bool,
     },
+    /// Print debugging information
+    Info,
     /// Prepare a subset of your monorepo.
     Prune {
         #[clap(hide = true, long)]
@@ -1212,6 +1212,15 @@ pub async fn run(
             };
             let child_event = event.child();
             generate::run(tag, command, &args, child_event)?;
+            Ok(0)
+        }
+        Command::Info => {
+            CommandEventBuilder::new("info")
+                .with_parent(&root_telemetry)
+                .track_call();
+            let mut base = CommandBase::new(cli_args.clone(), repo_root, version, color_config);
+            info::run(base);
+
             Ok(0)
         }
         Command::Telemetry { command } => {

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1219,8 +1219,11 @@ pub async fn run(
                 .with_parent(&root_telemetry)
                 .track_call();
             let base = CommandBase::new(cli_args.clone(), repo_root, version, color_config);
-            info::run(base).await;
 
+            match info::run(base).await {
+                Ok(()) => {}
+                Err(e) => println!("Command failed. Please file a GitHub Issue.\n{}", e),
+            }
             Ok(0)
         }
         Command::Telemetry { command } => {

--- a/crates/turborepo-lib/src/commands/info.rs
+++ b/crates/turborepo-lib/src/commands/info.rs
@@ -1,0 +1,58 @@
+use std::{env, io};
+
+use thiserror::Error;
+
+use super::CommandBase;
+use crate::get_version;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("could not get path to turbo binary: {0}")]
+    NoCurrentExe(#[from] io::Error),
+}
+
+pub fn run(base: CommandBase) -> Result<(), Error> {
+    println!("CLI:");
+    println!("   Version: {}", base.version);
+    println!(
+        "   Location: {}",
+        std::env::current_exe()?.to_string_lossy()
+    );
+    println!("");
+
+    println!("Platform:");
+    println!("   Architecture: {}", std::env::consts::ARCH);
+    println!("   Operating System: {}", std::env::consts::OS);
+    println!("");
+
+    println!("Environment:");
+    println!("   CI: {:#?}", turborepo_ci::Vendor::get_name());
+    println!(
+        "   Terminal (TERM): {}",
+        env::var("TERM").unwrap_or_else(|_| "unknown".to_owned())
+    );
+
+    println!(
+        "   Terminal program (TERM_PROGRAM): {}",
+        env::var("TERM_PROGRAM").unwrap_or_else(|_| "unknown".to_owned())
+    );
+    println!(
+        "   Terminal program version (TERM_PROGRAM_VERSION): {}",
+        env::var("TERM_PROGRAM_VERSION").unwrap_or_else(|_| "unknown".to_owned())
+    );
+    println!(
+        "   Shell (SHELL): {}",
+        env::var("SHELL").unwrap_or_else(|_| "unknown".to_owned())
+    );
+    println!("   stdin: {}", turborepo_ci::is_ci());
+    println!("");
+
+    println!("Turborepo System Environment Variables:");
+    for (key, value) in env::vars().fil {
+        if key.starts_with("TURBO_") {
+            println!("   {}: {}", key, value);
+        }
+    }
+
+    Ok(())
+}

--- a/crates/turborepo-lib/src/commands/info.rs
+++ b/crates/turborepo-lib/src/commands/info.rs
@@ -32,10 +32,13 @@ pub async fn run(base: CommandBase) -> Result<(), Error> {
 
     println!("CLI:");
     println!("   Version: {}", base.version);
-    println!(
-        "   Location: {}",
-        std::env::current_exe()?.to_string_lossy()
+
+    let exe_path = std::env::current_exe().map_or_else(
+        |_| "Cannot be found".to_string(),
+        |path| path.to_string_lossy().into_owned(),
     );
+
+    println!("   Path to executable: {}", exe_path);
     println!("   Daemon status: {}", daemon_status);
     println!("   Package manager: {}", package_manager);
     println!();

--- a/crates/turborepo-lib/src/commands/info.rs
+++ b/crates/turborepo-lib/src/commands/info.rs
@@ -21,16 +21,14 @@ pub async fn run(base: CommandBase) -> Result<(), Error> {
         Err(DaemonConnectorError::NotRunning) => "Not running",
         Err(_e) => "Error getting status",
     };
-
-    let package_manager = match PackageJson::load(&base.repo_root.join_component("package.json")) {
-        Ok(package_json) => {
-            match PackageManager::read_or_detect_package_manager(&package_json, &base.repo_root) {
-                Ok(pm) => pm.to_string(),
-                Err(_) => "Not found".to_owned(),
-            }
-        }
-        Err(_) => "Not found".to_owned(),
-    };
+    let package_manager = PackageJson::load(&base.repo_root.join_component("package.json"))
+        .and_then(|package_json| {
+            Ok(PackageManager::read_or_detect_package_manager(
+                &package_json,
+                &base.repo_root,
+            ))
+        })
+        .map_or_else(|_| "Not found".to_owned(), |pm| pm.unwrap().to_string());
 
     println!("CLI:");
     println!("   Version: {}", base.version);

--- a/crates/turborepo-lib/src/commands/info.rs
+++ b/crates/turborepo-lib/src/commands/info.rs
@@ -74,20 +74,5 @@ pub async fn run(base: CommandBase) -> Result<(), Error> {
     println!("   stdin: {}", turborepo_ci::is_ci());
     println!();
 
-    println!("Turborepo System Environment Variables:");
-    for (key, value) in env::vars() {
-        // Don't print sensitive information
-        if key == "TURBO_TEAM"
-            || key == "TURBO_TEAMID"
-            || key == "TURBO_TOKEN"
-            || key == "TURBO_API"
-        {
-            continue;
-        }
-        if key.starts_with("TURBO_") {
-            println!("   {}: {}", key, value);
-        }
-    }
-
     Ok(())
 }

--- a/crates/turborepo-lib/src/commands/info.rs
+++ b/crates/turborepo-lib/src/commands/info.rs
@@ -1,9 +1,10 @@
 use std::{env, io};
 
+use sysinfo::{System, SystemExt};
 use thiserror::Error;
 
 use super::CommandBase;
-use crate::get_version;
+use crate::{DaemonConnector, DaemonConnectorError};
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -11,18 +12,39 @@ pub enum Error {
     NoCurrentExe(#[from] io::Error),
 }
 
-pub fn run(base: CommandBase) -> Result<(), Error> {
+pub async fn run(base: CommandBase) -> Result<(), Error> {
+    let system = System::new_all();
+    let connector = DaemonConnector::new(false, false, &base.repo_root);
+    let daemon_status = match connector.connect().await {
+        Ok(_status) => "Running",
+        Err(DaemonConnectorError::NotRunning) => "Not running",
+        Err(_e) => "Error getting status",
+    };
+
     println!("CLI:");
     println!("   Version: {}", base.version);
     println!(
         "   Location: {}",
         std::env::current_exe()?.to_string_lossy()
     );
+    println!("   Daemon status: {}", daemon_status);
+    println!("");
+
+    println!("Package managers:");
+    println!("   npm version: {}", "TODO");
+    println!("   yarn version: {}", "TODO");
+    println!("   pnpm version: {}", "TODO");
+    println!("   bun version: {}", "TODO");
     println!("");
 
     println!("Platform:");
     println!("   Architecture: {}", std::env::consts::ARCH);
-    println!("   Operating System: {}", std::env::consts::OS);
+    println!("   Operating system: {}", std::env::consts::OS);
+    println!(
+        "   Available memory (MB): {}",
+        system.available_memory() / 1024 / 1024
+    );
+    println!("   Available CPU cores: {}", num_cpus::get());
     println!("");
 
     println!("Environment:");
@@ -48,7 +70,15 @@ pub fn run(base: CommandBase) -> Result<(), Error> {
     println!("");
 
     println!("Turborepo System Environment Variables:");
-    for (key, value) in env::vars().fil {
+    for (key, value) in env::vars() {
+        // Don't print sensitive information
+        if key == "TURBO_TEAM".to_string()
+            || key == "TURBO_TEAMID".to_string()
+            || key == "TURBO_TOKEN".to_string()
+            || key == "TURBO_API".to_string()
+        {
+            continue;
+        }
         if key.starts_with("TURBO_") {
             println!("   {}: {}", key, value);
         }

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod bin;
 pub(crate) mod config;
 pub(crate) mod daemon;
 pub(crate) mod generate;
+pub(crate) mod info;
 pub(crate) mod link;
 pub(crate) mod login;
 pub(crate) mod logout;

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -18,6 +18,7 @@ Make sure exit code is 2 when no args are passed
     link        Link your local directory to a Vercel organization and enable remote caching
     login       Login to your Vercel account
     logout      Logout to your Vercel account
+    info        Print debugging information
     prune       Prepare a subset of your monorepo
     run         Run tasks across projects in your monorepo
     query       Query your monorepo using GraphQL. If no query is provided, spins up a GraphQL server with GraphiQL

--- a/turborepo-tests/integration/tests/turbo-help.t
+++ b/turborepo-tests/integration/tests/turbo-help.t
@@ -139,6 +139,7 @@ Test help flag
     link        Link your local directory to a Vercel organization and enable remote caching
     login       Login to your Vercel account
     logout      Logout to your Vercel account
+    info        Print debugging information
     prune       Prepare a subset of your monorepo
     run         Run tasks across projects in your monorepo
     query       Query your monorepo using GraphQL. If no query is provided, spins up a GraphQL server with GraphiQL

--- a/turborepo-tests/integration/tests/turbo-help.t
+++ b/turborepo-tests/integration/tests/turbo-help.t
@@ -18,6 +18,7 @@ Test help flag
     link        Link your local directory to a Vercel organization and enable remote caching
     login       Login to your Vercel account
     logout      Logout to your Vercel account
+    info        Print debugging information
     prune       Prepare a subset of your monorepo
     run         Run tasks across projects in your monorepo
     query       Query your monorepo using GraphQL. If no query is provided, spins up a GraphQL server with GraphiQL


### PR DESCRIPTION
### Description

A command to provide debugging information for reproductions or otherwise understand a machine better. Output will look something close to this.

```
CLI:
   Version: 2.2.4-canary.4
   Location: /Users/anthonyshew/projects/open/turbo/target/debug/turbo
   Daemon status: Running
   Package manager: pnpm

Platform:
   Architecture: aarch64
   Operating system: macos
   Available memory (MB): 13598
   Available CPU cores: 10

Environment:
   CI: None
   Terminal (TERM): xterm-256color
   Terminal program (TERM_PROGRAM): tmux
   Terminal program version (TERM_PROGRAM_VERSION): 3.4
   Shell (SHELL): /bin/zsh
   stdin: false

Turborepo System Environment Variables:
   TURBO_INVOCATION_DIR: /Users/anthonyshew/projects/open/turbo
```

### Testing Instructions

Try it out!
