### PR TITLE
fix(query): validate package name

### DIFF
--- a/crates/turborepo-lib/src/commands/query.rs
+++ b/crates/turborepo-lib/src/commands/query.rs
@@ -33,10 +33,10 @@ struct QueryError {
 impl QueryError {
     fn get_index_from_row_column(query: &str, row: usize, column: usize) -> usize {
         let mut index = 0;
-        for line in query.lines().take(row + 1) {
+        for line in query.lines().take(row.saturating_sub(1)) {
             index += line.len() + 1;
         }
-        index + column
+        index + column - 1
     }
     fn new(server_error: ServerError, query: String) -> Self {
         let span: Option<SourceSpan> = server_error.locations.first().map(|location| {
@@ -109,6 +109,7 @@ pub async fn run(
         if result.errors.is_empty() {
             println!("{}", serde_json::to_string_pretty(&result)?);
         } else {
+            println!("{}", serde_json::to_string_pretty(&result)?);
             for error in result.errors {
                 let error = QueryError::new(error, query.clone());
                 eprintln!("{:?}", Report::new(error));

--- a/crates/turborepo-lib/src/commands/query.rs
+++ b/crates/turborepo-lib/src/commands/query.rs
@@ -106,10 +106,8 @@ pub async fn run(
         let request = Request::new(&query).variables(variables);
 
         let result = schema.execute(request).await;
-        if result.errors.is_empty() {
-            println!("{}", serde_json::to_string_pretty(&result)?);
-        } else {
-            println!("{}", serde_json::to_string_pretty(&result)?);
+        println!("{}", serde_json::to_string_pretty(&result)?);
+        if !result.errors.is_empty() {
             for error in result.errors {
                 let error = QueryError::new(error, query.clone());
                 eprintln!("{:?}", Report::new(error));

--- a/crates/turborepo-lib/src/query/mod.rs
+++ b/crates/turborepo-lib/src/query/mod.rs
@@ -78,7 +78,7 @@ pub struct Array<T: OutputType> {
 }
 
 impl<T: OutputType> Deref for Array<T> {
-    type Target = Vec<T>;
+    type Target = [T];
     fn deref(&self) -> &Self::Target {
         &self.items
     }

--- a/crates/turborepo-lib/src/query/mod.rs
+++ b/crates/turborepo-lib/src/query/mod.rs
@@ -529,7 +529,7 @@ impl RepositoryQuery {
         })
         .collect::<Result<Array<_>, _>>()?;
 
-        packages.sort_by(|a, b| a.package.get_name().cmp(&b.package.get_name()));
+        packages.sort_by(|a, b| a.package.get_name().cmp(b.package.get_name()));
         Ok(packages)
     }
 

--- a/crates/turborepo-lib/src/query/package.rs
+++ b/crates/turborepo-lib/src/query/package.rs
@@ -12,11 +12,27 @@ use crate::{
 
 #[derive(Clone)]
 pub struct Package {
-    pub run: Arc<Run>,
-    pub name: PackageName,
+    run: Arc<Run>,
+    name: PackageName,
 }
 
 impl Package {
+    pub fn new(run: Arc<Run>, name: PackageName) -> Result<Self, Error> {
+        run.pkg_dep_graph()
+            .package_info(&name)
+            .ok_or_else(|| Error::PackageNotFound(name.clone()))?;
+
+        Ok(Self { run, name })
+    }
+
+    pub fn run(&self) -> &Arc<Run> {
+        &self.run
+    }
+
+    pub fn get_name(&self) -> &PackageName {
+        &self.name
+    }
+
     pub fn get_tasks(&self) -> HashMap<String, Spanned<String>> {
         self.run
             .pkg_dep_graph()

--- a/crates/turborepo-lib/src/query/package.rs
+++ b/crates/turborepo-lib/src/query/package.rs
@@ -29,6 +29,8 @@ impl Package {
         &self.run
     }
 
+    /// This uses a different naming convention because we already have a
+    /// `name` resolver defined for GraphQL
     pub fn get_name(&self) -> &PackageName {
         &self.name
     }

--- a/crates/turborepo-lib/src/query/task.rs
+++ b/crates/turborepo-lib/src/query/task.rs
@@ -37,13 +37,13 @@ impl RepositoryTask {
             .filter_map(|task| match task {
                 TaskNode::Root => None,
                 TaskNode::Task(task) if task == task_id => None,
-                TaskNode::Task(task) => Some(RepositoryTask::new(&task, &self.package.run())),
+                TaskNode::Task(task) => Some(RepositoryTask::new(task, self.package.run())),
             })
             .collect::<Result<Array<_>, _>>()?;
         tasks.sort_by(|a, b| {
             a.package
                 .get_name()
-                .cmp(&b.package.get_name())
+                .cmp(b.package.get_name())
                 .then_with(|| a.name.cmp(&b.name))
         });
         Ok(tasks)

--- a/crates/turborepo-lib/src/query/task.rs
+++ b/crates/turborepo-lib/src/query/task.rs
@@ -1,12 +1,11 @@
 use std::sync::Arc;
 
 use async_graphql::Object;
-use itertools::Itertools;
 use turborepo_errors::Spanned;
 
 use crate::{
     engine::TaskNode,
-    query::{package::Package, Array},
+    query::{package::Package, Array, Error},
     run::{task_id::TaskId, Run},
 };
 
@@ -17,18 +16,37 @@ pub struct RepositoryTask {
 }
 
 impl RepositoryTask {
-    pub fn new(task_id: &TaskId, run: &Arc<Run>) -> Self {
-        let package = Package {
-            name: task_id.package().into(),
-            run: run.clone(),
-        };
+    pub fn new(task_id: &TaskId, run: &Arc<Run>) -> Result<Self, Error> {
+        let package = Package::new(run.clone(), task_id.package().into())?;
         let script = package.get_tasks().get(task_id.task()).cloned();
 
-        RepositoryTask {
+        Ok(RepositoryTask {
             name: task_id.task().to_string(),
             package,
             script,
-        }
+        })
+    }
+
+    fn collect_and_sort<'a>(
+        &self,
+        task_id: &TaskId<'a>,
+        tasks: impl IntoIterator<Item = &'a TaskNode>,
+    ) -> Result<Array<RepositoryTask>, Error> {
+        let mut tasks = tasks
+            .into_iter()
+            .filter_map(|task| match task {
+                TaskNode::Root => None,
+                TaskNode::Task(task) if task == task_id => None,
+                TaskNode::Task(task) => Some(RepositoryTask::new(&task, &self.package.run())),
+            })
+            .collect::<Result<Array<_>, _>>()?;
+        tasks.sort_by(|a, b| {
+            a.package
+                .get_name()
+                .cmp(&b.package.get_name())
+                .then_with(|| a.name.cmp(&b.name))
+        });
+        Ok(tasks)
     }
 }
 
@@ -50,80 +68,55 @@ impl RepositoryTask {
         self.script.as_ref().map(|script| script.value.to_string())
     }
 
-    async fn direct_dependents(&self) -> Array<RepositoryTask> {
+    async fn direct_dependents(&self) -> Result<Array<RepositoryTask>, Error> {
         let task_id = TaskId::from_static(self.package.get_name().to_string(), self.name.clone());
-        self.package
-            .run()
-            .engine()
-            .dependents(&task_id)
-            .into_iter()
-            .flatten()
-            .filter_map(|task| match task {
-                TaskNode::Root => None,
-                TaskNode::Task(task) if task == &task_id => None,
-                TaskNode::Task(task) => Some(RepositoryTask::new(task, &self.package.run())),
-            })
-            .sorted_by(|a, b| {
-                a.package
-                    .get_name()
-                    .cmp(&b.package.get_name())
-                    .then_with(|| a.name.cmp(&b.name))
-            })
-            .collect()
+
+        self.collect_and_sort(
+            &task_id,
+            self.package
+                .run()
+                .engine()
+                .dependents(&task_id)
+                .into_iter()
+                .flatten(),
+        )
     }
 
-    async fn direct_dependencies(&self) -> Array<RepositoryTask> {
-        let task_id = TaskId::new(self.package.name.as_ref(), &self.name);
+    async fn direct_dependencies(&self) -> Result<Array<RepositoryTask>, Error> {
+        let task_id = TaskId::new(self.package.get_name().as_ref(), &self.name);
 
-        self.package
-            .run
-            .engine()
-            .dependencies(&task_id)
-            .into_iter()
-            .flatten()
-            .filter_map(|task| match task {
-                TaskNode::Root => None,
-                TaskNode::Task(task) if task == &task_id => None,
-                TaskNode::Task(task) => Some(RepositoryTask::new(task, &self.package.run)),
-            })
-            .sorted_by(|a, b| {
-                a.package
-                    .name
-                    .cmp(&b.package.name)
-                    .then_with(|| a.name.cmp(&b.name))
-            })
-            .collect()
+        self.collect_and_sort(
+            &task_id,
+            self.package
+                .run()
+                .engine()
+                .dependencies(&task_id)
+                .into_iter()
+                .flatten(),
+        )
     }
 
-    async fn indirect_dependents(&self) -> Array<RepositoryTask> {
-        let task_id = TaskId::from_static(self.package.name.to_string(), self.name.clone());
+    async fn indirect_dependents(&self) -> Result<Array<RepositoryTask>, Error> {
+        let task_id = TaskId::from_static(self.package.get_name().to_string(), self.name.clone());
         let direct_dependents = self
             .package
-            .run
+            .run()
             .engine()
             .dependencies(&task_id)
             .unwrap_or_default();
-        self.package
-            .run
-            .engine()
-            .transitive_dependents(&task_id)
-            .into_iter()
-            .filter(|node| !direct_dependents.contains(node))
-            .filter_map(|node| match node {
-                TaskNode::Root => None,
-                TaskNode::Task(task) if task == &task_id => None,
-                TaskNode::Task(task) => Some(RepositoryTask::new(task, &self.package.run)),
-            })
-            .sorted_by(|a, b| {
-                a.package
-                    .get_name()
-                    .cmp(&b.package.get_name())
-                    .then_with(|| a.name.cmp(&b.name))
-            })
-            .collect()
+
+        self.collect_and_sort(
+            &task_id,
+            self.package
+                .run()
+                .engine()
+                .transitive_dependents(&task_id)
+                .into_iter()
+                .filter(|node| !direct_dependents.contains(node)),
+        )
     }
 
-    async fn indirect_dependencies(&self) -> Array<RepositoryTask> {
+    async fn indirect_dependencies(&self) -> Result<Array<RepositoryTask>, Error> {
         let task_id = TaskId::from_static(self.package.get_name().to_string(), self.name.clone());
         let direct_dependencies = self
             .package
@@ -131,7 +124,8 @@ impl RepositoryTask {
             .engine()
             .dependencies(&task_id)
             .unwrap_or_default();
-        self.package
+        let mut dependencies = self
+            .package
             .run()
             .engine()
             .transitive_dependencies(&task_id)
@@ -140,56 +134,36 @@ impl RepositoryTask {
             .filter_map(|node| match node {
                 TaskNode::Root => None,
                 TaskNode::Task(task) if task == &task_id => None,
-                TaskNode::Task(task) => Some(RepositoryTask::new(task, &self.package.run)),
-            })
-            .sorted_by(|a, b| {
-                a.package
-                    .name
-                    .cmp(&b.package.name)
-                    .then_with(|| a.name.cmp(&b.name))
-            })
-            .collect()
-    }
-
-    async fn all_dependents(&self) -> Array<RepositoryTask> {
-        let task_id = TaskId::from_static(self.package.name.to_string(), self.name.clone());
-        self.package
-            .run
-            .engine()
-            .transitive_dependents(&task_id)
-            .into_iter()
-            .filter_map(|node| match node {
-                TaskNode::Root => None,
-                TaskNode::Task(task) if task == &task_id => None,
-                TaskNode::Task(task) => Some(RepositoryTask::new(task, &self.package.run)),
-            })
-            .sorted_by(|a, b| {
-                a.package
-                    .name
-                    .cmp(&b.package.name)
-                    .then_with(|| a.name.cmp(&b.name))
-            })
-            .collect()
-    }
-
-    async fn all_dependencies(&self) -> Array<RepositoryTask> {
-        let task_id = TaskId::from_static(self.package.get_name().to_string(), self.name.clone());
-        self.package
-            .run()
-            .engine()
-            .transitive_dependencies(&task_id)
-            .into_iter()
-            .filter_map(|node| match node {
-                TaskNode::Root => None,
-                TaskNode::Task(task) if task == &task_id => None,
                 TaskNode::Task(task) => Some(RepositoryTask::new(task, self.package.run())),
             })
-            .sorted_by(|a, b| {
-                a.package
-                    .get_name()
-                    .cmp(&b.package.get_name())
-                    .then_with(|| a.name.cmp(&b.name))
-            })
-            .collect()
+            .collect::<Result<Array<_>, _>>()?;
+
+        dependencies.sort_by(|a, b| {
+            a.package
+                .get_name()
+                .cmp(b.package.get_name())
+                .then_with(|| a.name.cmp(&b.name))
+        });
+
+        Ok(dependencies)
+    }
+
+    async fn all_dependents(&self) -> Result<Array<RepositoryTask>, Error> {
+        let task_id = TaskId::from_static(self.package.get_name().to_string(), self.name.clone());
+        self.collect_and_sort(
+            &task_id,
+            self.package.run().engine().transitive_dependents(&task_id),
+        )
+    }
+
+    async fn all_dependencies(&self) -> Result<Array<RepositoryTask>, Error> {
+        let task_id = TaskId::from_static(self.package.get_name().to_string(), self.name.clone());
+        self.collect_and_sort(
+            &task_id,
+            self.package
+                .run()
+                .engine()
+                .transitive_dependencies(&task_id),
+        )
     }
 }

--- a/crates/turborepo/tests/query.rs
+++ b/crates/turborepo/tests/query.rs
@@ -1,5 +1,17 @@
 mod common;
 
+#[test]
+fn test_query() -> Result<(), anyhow::Error> {
+    check_json!(
+        "basic_monorepo",
+        "npm@10.5.0",
+        "query",
+        "get package that doesn't exist" => "query { package(name: \"doesnotexist\") { path } }",
+    );
+
+    Ok(())
+}
+
 #[cfg(not(windows))]
 #[test]
 fn test_double_symlink() -> Result<(), anyhow::Error> {

--- a/crates/turborepo/tests/snapshots/query__basic_monorepo_get_package_that_doesn't_exist_(npm@10.5.0).snap
+++ b/crates/turborepo/tests/snapshots/query__basic_monorepo_get_package_that_doesn't_exist_(npm@10.5.0).snap
@@ -1,0 +1,21 @@
+---
+source: crates/turborepo/tests/query.rs
+expression: query_output
+---
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "package not found: doesnotexist",
+      "locations": [
+        {
+          "line": 1,
+          "column": 9
+        }
+      ],
+      "path": [
+        "package"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Description
Before we'd just trust that a package would exist with the name provided. This would lead to errors when using the package but not when constructing it. Now we actually validate it during construction.

### Testing Instructions

Added test for invalid package constructor
