### PR TITLE
fix(tui): sort tasks in state not just view

### DIFF
--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -326,7 +326,8 @@ impl<W> App<W> {
             .ok_or_else(|| Error::TaskNotFound { name: task.into() })?;
 
         let running = self.tasks_by_status.running.remove(running_idx);
-        self.tasks_by_status.finished.push(running.finish(result));
+        self.tasks_by_status
+            .insert_finished_task(running.finish(result));
 
         self.tasks
             .get_mut(task)

--- a/crates/turborepo-ui/src/tui/table.rs
+++ b/crates/turborepo-ui/src/tui/table.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use ratatui::{
     layout::{Constraint, Rect},
     style::{Color, Modifier, Style, Stylize},
@@ -53,39 +52,29 @@ impl<'b> TaskTable<'b> {
     }
 
     fn finished_rows(&self) -> impl Iterator<Item = Row> + '_ {
-        self.tasks_by_type
-            .finished
-            .iter()
-            // note we can't use the default Ord impl because
-            // we want failed tasks first
-            .sorted_by_key(|task| match task.result() {
-                TaskResult::Failure => 0,
-                TaskResult::Success => 1,
-                TaskResult::CacheHit => 2,
-            })
-            .map(move |task| {
-                let name = if matches!(task.result(), TaskResult::CacheHit) {
-                    Cell::new(Text::styled(task.name(), Style::default().italic()))
-                } else {
-                    Cell::new(task.name())
-                };
+        self.tasks_by_type.finished.iter().map(move |task| {
+            let name = if matches!(task.result(), TaskResult::CacheHit) {
+                Cell::new(Text::styled(task.name(), Style::default().italic()))
+            } else {
+                Cell::new(task.name())
+            };
 
-                Row::new(vec![
-                    name,
-                    match task.result() {
-                        // matches Next.js (and many other CLI tools) https://github.com/vercel/next.js/blob/1a04d94aaec943d3cce93487fea3b8c8f8898f31/packages/next/src/build/output/log.ts
-                        TaskResult::Success => {
-                            Cell::new(Text::styled("✓", Style::default().green().bold()))
-                        }
-                        TaskResult::CacheHit => {
-                            Cell::new(Text::styled("⊙", Style::default().magenta()))
-                        }
-                        TaskResult::Failure => {
-                            Cell::new(Text::styled("⨯", Style::default().red().bold()))
-                        }
-                    },
-                ])
-            })
+            Row::new(vec![
+                name,
+                match task.result() {
+                    // matches Next.js (and many other CLI tools) https://github.com/vercel/next.js/blob/1a04d94aaec943d3cce93487fea3b8c8f8898f31/packages/next/src/build/output/log.ts
+                    TaskResult::Success => {
+                        Cell::new(Text::styled("✓", Style::default().green().bold()))
+                    }
+                    TaskResult::CacheHit => {
+                        Cell::new(Text::styled("⊙", Style::default().magenta()))
+                    }
+                    TaskResult::Failure => {
+                        Cell::new(Text::styled("⨯", Style::default().red().bold()))
+                    }
+                },
+            ])
+        })
     }
 
     fn running_rows(&self) -> impl Iterator<Item = Row> + '_ {


### PR DESCRIPTION
### Description

Move the new task ordering from just the view to the underlying state so that the task list syncs up with the pane.

### Testing Instructions

Added unit testing for new insertion order.
