### PR TITLE
chore(ci): bump macOS runner to 13

### DIFF
--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -15,10 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-12
+          - host: macos-13
             target: "x86_64-apple-darwin"
             container-options: "--rm"
-          - host: macos-12
+          - host: macos-13
             target: "aarch64-apple-darwin"
             container-options: "--rm"
           - host: ubuntu-latest

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -68,7 +68,7 @@ jobs:
               - "x64"
               - "metal"
           - name: macos
-            runner: macos-12
+            runner: macos-13
         node-version:
           - 18
           - 20

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -116,7 +116,7 @@ jobs:
       matrix:
         os:
           - runner: ubuntu-latest
-          - runner: macos-12
+          - runner: macos-13
           - runner: windows-latest
     steps:
       # On Windows, set autocrlf to input so that when the repo is cloned down
@@ -276,7 +276,7 @@ jobs:
               - "metal"
             nextest: linux
           - name: macos
-            runner: macos-12
+            runner: macos-13
             nextest: mac
           - name: windows
             runner: windows-latest


### PR DESCRIPTION
### Description

We need to do this because macOS 12 runners are getting deprecated. 

### Testing Instructions

CI should pass
