### PR TITLE
 fix: Don't require a name for the root package.json.

### DIFF
--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -914,4 +914,17 @@ mod test {
             ))
         );
     }
+
+    #[tokio::test]
+    async fn test_does_not_require_name_for_root_package_json() {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+        let pkg_graph = PackageGraph::builder(&root, PackageJson::from_value(json!({})).unwrap())
+            .with_package_discovery(MockDiscovery)
+            .build()
+            .await
+            .unwrap();
+
+        assert!(pkg_graph.validate().is_ok());
+    }
 }

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -156,7 +156,6 @@ impl PackageGraph {
                         continue;
                     }
 
-                    let package_json_path = self.repo_root.resolve(info.package_json_path());
                     return Err(Error::PackageJsonMissingName(package_json_path));
                 }
                 Some(_) => continue,

--- a/docs/repo-docs/getting-started/add-to-existing-repository.mdx
+++ b/docs/repo-docs/getting-started/add-to-existing-repository.mdx
@@ -179,6 +179,12 @@ Add `.turbo` to your `.gitignore` file. The `turbo` CLI uses these folders for p
 
 </Step>
 <Step>
+### Add a `name` and `packageManager` field to root `package.json`
+
+Turborepo optimizes your repository using information from your package manager.
+
+</Step>
+<Step>
 ### Run the `build` and `check-types` tasks with `turbo`
 
 ```bash title="Terminal"

--- a/docs/repo-docs/getting-started/add-to-existing-repository.mdx
+++ b/docs/repo-docs/getting-started/add-to-existing-repository.mdx
@@ -179,12 +179,6 @@ Add `.turbo` to your `.gitignore` file. The `turbo` CLI uses these folders for p
 
 </Step>
 <Step>
-### Add a `name` and `packageManager` field to root `package.json`
-
-Turborepo optimizes your repository using information from your package manager.
-
-</Step>
-<Step>
 ### Run the `build` and `check-types` tasks with `turbo`
 
 ```bash title="Terminal"


### PR DESCRIPTION
### Description

There doesn't necessarily need to be a `name` field in the root package.json, since it won't get used for other work throughout the graph.

### Testing Instructions

I wrote a test and tested against `create-turbo` by removing the `name` field from the root package.json
