### PR TITLE
fix(mfe): build internal package if present in graph

### DIFF
--- a/crates/turborepo-lib/src/turbo_json/loader.rs
+++ b/crates/turborepo-lib/src/turbo_json/loader.rs
@@ -1,8 +1,10 @@
 use std::collections::HashMap;
 
+use itertools::Itertools;
 use tracing::debug;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_errors::Spanned;
+use turborepo_micro_frontend::MICRO_FRONTENDS_PACKAGE_INTERNAL;
 use turborepo_repository::{
     package_graph::{PackageInfo, PackageName},
     package_json::PackageJson,
@@ -184,7 +186,10 @@ impl TurboJsonLoader {
                         Error::NoTurboJSON => Ok(TurboJson::default()),
                         err => Err(err),
                     })?;
-                    turbo_json.with_proxy();
+                    let needs_proxy_build = packages
+                        .keys()
+                        .contains(&PackageName::from(MICRO_FRONTENDS_PACKAGE_INTERNAL));
+                    turbo_json.with_proxy(needs_proxy_build);
                     Ok(turbo_json)
                 } else {
                     turbo_json

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use struct_iterable::Iterable;
 use turbopath::AbsoluteSystemPath;
 use turborepo_errors::Spanned;
+use turborepo_micro_frontend::MICRO_FRONTENDS_PACKAGE_INTERNAL;
 use turborepo_repository::package_graph::ROOT_PKG_NAME;
 use turborepo_unescape::UnescapedString;
 
@@ -610,7 +611,7 @@ impl TurboJson {
     }
 
     /// Adds a local proxy task to a workspace TurboJson
-    pub fn with_proxy(&mut self) {
+    pub fn with_proxy(&mut self, needs_proxy_build: bool) {
         if self.extends.is_empty() {
             self.extends = Spanned::new(vec!["//".into()]);
         }
@@ -619,6 +620,11 @@ impl TurboJson {
             TaskName::from("proxy"),
             Spanned::new(RawTaskDefinition {
                 cache: Some(Spanned::new(false)),
+                depends_on: needs_proxy_build.then(|| {
+                    Spanned::new(vec![Spanned::new(UnescapedString::from(format!(
+                        "{MICRO_FRONTENDS_PACKAGE_INTERNAL}#build"
+                    )))])
+                }),
                 ..Default::default()
             }),
         );

--- a/crates/turborepo-micro-frontend/src/lib.rs
+++ b/crates/turborepo-micro-frontend/src/lib.rs
@@ -13,7 +13,8 @@ use turbopath::AbsoluteSystemPath;
 ///
 /// This is subject to change at any time.
 pub const DEFAULT_MICRO_FRONTENDS_CONFIG: &str = "micro-frontends.jsonc";
-pub const MICRO_FRONTENDS_PACKAGES: &[&str] = ["@vercel/micro-frontends-internal"].as_slice();
+pub const MICRO_FRONTENDS_PACKAGES: &[&str] = [MICRO_FRONTENDS_PACKAGE_INTERNAL].as_slice();
+pub const MICRO_FRONTENDS_PACKAGE_INTERNAL: &str = "@vercel/micro-frontends-internal";
 
 /// The minimal amount of information Turborepo needs to correctly start a local
 /// proxy server for microfrontends

--- a/crates/turborepo-unescape/src/lib.rs
+++ b/crates/turborepo-unescape/src/lib.rs
@@ -57,6 +57,11 @@ impl From<UnescapedString> for String {
     }
 }
 
+impl From<String> for UnescapedString {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
 // For testing purposes
 impl From<&'static str> for UnescapedString {
     fn from(value: &'static str) -> Self {


### PR DESCRIPTION
### Description

Previously we were relying on the proxy already being built, for non-internal use cases this will be true, but for the internal case we need to make sure it is built before we try to start the proxy.

### Testing Instructions

- Edit `packages/micro-frontends/dist/bin/cli.cjs` and add a `throw new Error("oops")` to the top
- `turbo vercel-docs#dev` should fail due to the proxy script failing
- Now try with the PR `turbo`: `turbo_dev --skip-infer vercel-docs#dev`, you will see the MFE package being built before the proxy is started.
