### PR TITLE
chore: Stop running unnecessary checks for docs-only changes.

### DIFF
--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -39,13 +39,6 @@ jobs:
           PATTERNS: |
             packages/**
 
-      - name: Docs related changes
-        id: docs
-        uses: technote-space/get-diff-action@v6
-        with:
-          PATTERNS: |
-            docs/**
-
     outputs:
       ci: ${{ steps.ci.outputs.diff != ''}}
       packages: ${{ steps.packages.outputs.diff != '' }}

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -42,12 +42,11 @@ jobs:
     outputs:
       ci: ${{ steps.ci.outputs.diff != ''}}
       packages: ${{ steps.packages.outputs.diff != '' }}
-      docs: ${{ steps.docs.outputs.diff != '' }}
 
   js_packages:
     name: "JS Package Tests (${{matrix.os.name}}, Node ${{matrix.node-version}})"
     timeout-minutes: 30
-    if: needs.determine_jobs.outputs.ci == 'true' || needs.determine_jobs.outputs.packages == 'true' || needs.determine_jobs.outputs.docs == 'true'
+    if: needs.determine_jobs.outputs.ci == 'true' || needs.determine_jobs.outputs.packages == 'true'
     needs: [determine_jobs]
     runs-on: ${{ matrix.os.runner }}
     strategy:

--- a/.github/workflows/turborepo-native-lib-test.yml
+++ b/.github/workflows/turborepo-native-lib-test.yml
@@ -2,8 +2,8 @@ name: Turborepo Native Library Tests
 on:
   push:
     branches: [main]
-    paths:
-      - "!docs/**"
+    paths-ignore:
+      - "docs/**"
   pull_request:
 
 permissions:

--- a/.github/workflows/turborepo-native-lib-test.yml
+++ b/.github/workflows/turborepo-native-lib-test.yml
@@ -2,6 +2,8 @@ name: Turborepo Native Library Tests
 on:
   push:
     branches: [main]
+    paths:
+      - "!docs/**"
   pull_request:
 
 permissions:


### PR DESCRIPTION
### Description

There were quite a few checks running when making docs changes that were unnecessary. They were slowing us down and quite noisy, so let's get them out of the way.
