### PR TITLE
feat(mfe): add env var indicating mfe proxy

### DIFF
--- a/crates/turborepo-lib/src/micro_frontends.rs
+++ b/crates/turborepo-lib/src/micro_frontends.rs
@@ -49,4 +49,10 @@ impl MicroFrontendsConfigs {
     pub fn get(&self, package_name: &str) -> Option<&HashSet<TaskId<'static>>> {
         self.configs.get(package_name)
     }
+
+    pub fn task_has_mfe_proxy(&self, task_id: &TaskId) -> bool {
+        self.configs
+            .values()
+            .any(|dev_tasks| dev_tasks.contains(task_id))
+    }
 }

--- a/crates/turborepo-lib/src/task_graph/visitor/exec.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/exec.rs
@@ -50,6 +50,7 @@ impl<'a> ExecContextFactory<'a> {
             visitor.repo_root,
             &visitor.package_graph,
             visitor.run_opts.task_args(),
+            visitor.micro_frontends_configs,
         );
         let mut command_factory = CommandFactory::new();
         if let Some(micro_frontends_configs) = visitor.micro_frontends_configs {


### PR DESCRIPTION
### Description

MFE development tasks may want to know if there's a corresponding proxy that is being run. Just checking if the proxy is running is error prone since they're both persistent tasks and there's no consistent way to prevent the check from running before the proxy server is listening on the port.

We avoid needing to perform this check by setting an environment variable for each development task if there's an associated proxy task in the configuration. It is then up to the underlying task to alter it's behavior depending on the presence of this variable.

### Testing Instructions

In a project with a MFE, run a development task and verify that `TURBO_TASK_HAS_MFE_PROXY` is set to `true`
