### PR TITLE
Fix(filewatcher): handle removed directories #8800

### DIFF
--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -272,8 +272,9 @@ async fn watch_events(
                                 for new_path in &event.paths {
                                     if let Err(err) = manually_add_recursive_watches(new_path, &mut watcher, Some(&broadcast_sender)) {
                                         match err {
-                                            WatchError::WalkDir(_) => {
+                                            WatchError::WalkDir(err) => {
                                                 // Likely the path no longer exists
+                                                debug!("encountered error watching filesystem {}", err);
                                                 continue;
                                             },
                                             _ => {

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -271,8 +271,17 @@ async fn watch_events(
                             if event.kind == EventKind::Create(CreateKind::Folder) {
                                 for new_path in &event.paths {
                                     if let Err(err) = manually_add_recursive_watches(new_path, &mut watcher, Some(&broadcast_sender)) {
-                                        warn!("encountered error watching filesystem {}", err);
-                                        break 'outer;
+                                        match err {
+                                            WatchError::WalkDir(_) => {
+                                                // Likely the path no longer exists
+                                                continue;
+                                            },
+                                            _ => {
+                                                warn!("encountered error watching filesystem {}", err);
+                                                break 'outer;
+                                            }
+
+                                        }
                                     }
                                 }
                             }

--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -604,7 +604,7 @@ impl proto::turbod_server::Turbod for TurboGrpcServiceInner {
             .package_changes()
             .await;
 
-        let (tx, rx) = mpsc::channel(1024);
+        let (tx, rx) = mpsc::channel(4096);
 
         tx.send(Ok(proto::PackageChangeEvent {
             event: Some(proto::package_change_event::Event::RediscoverPackages(


### PR DESCRIPTION
### Description

When setting up manual recursive watching on folders (as is the case under Linux), the watching thread should not exit if a directory no longer exists. This is likely to occur within build output directories and it should not be the cause for interrupting the daemon.

Likely fixes https://github.com/vercel/turborepo/issues/8800 and https://github.com/vercel/turborepo/issues/8491

### Testing Instructions

#### Unit tests suite
`cargo test -p turborepo-filewatch`

#### Test building of [GitBulter](https://github.com/gitbutlerapp/gitbutler/)
(Within a Fedora Linux VM)

1. Prerequisites
```bash
sudo dnf check-update
sudo dnf install webkit2gtk4.1-devel \
  openssl-devel \
  curl \
  wget \
  file \
  libappindicator-gtk3-devel \
  librsvg2-devel
sudo dnf group install "C Development Tools and Libraries"
curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh
```
2. Obtain test project sources
```bash
git clone https://github.com/gitbutlerapp/gitbutler
cd gitbutler
```
3. Replace `turbo` with the turbo binary built from this branch, as an example:
```patch
diff --git a/package.json b/package.json
index 394d0f8e9..8f46a08e1 100644
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
                "dev:ui": "pnpm --filter @gitbutler/ui storybook",
                "dev:web": "turbo watch --filter @gitbutler/web dev",
                "dev:desktop": "pnpm tauri dev",
-               "dev:internal-tauri": "turbo watch --filter @gitbutler/desktop dev",
+               "dev:internal-tauri": "/home/parallels/src/turborepo/target/debug/turbo watch --filter @gitbutler/desktop dev",
                "package": "turbo run package",
                "test": "turbo run test --no-daemon",
                "test:watch": "pnpm --filter @gitbutler/desktop run test:watch",
```
4. Build project
```bash 
pnpm install
pnpm tauri dev
```
