### PR TITLE
fix(watch): ensure TUI is shutdown regardless of exit path

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1391,7 +1391,10 @@ pub async fn run(
             let base = CommandBase::new(cli_args, repo_root, version, color_config);
 
             let mut client = WatchClient::new(base, event).await?;
-            client.start().await?;
+            if let Err(e) = client.start().await {
+                client.shutdown().await;
+                return Err(e.into());
+            }
             // We only exit if we get a signal, so we return a non-zero exit code
             return Ok(1);
         }

--- a/crates/turborepo-lib/src/process/child.rs
+++ b/crates/turborepo-lib/src/process/child.rs
@@ -464,7 +464,7 @@ impl Child {
             // On Windows it is important that this gets dropped once the child process
             // exits
             let controller = controller;
-            debug!("waiting for task");
+            debug!("waiting for task: {pid:?}");
             let manager = ChildStateManager {
                 shutdown_style,
                 task_state,


### PR DESCRIPTION
### Description

I noticed in https://github.com/vercel/turborepo/issues/9389 that the TUI wasn't exiting if `watch` exited from anything other than a `Ctrl-C` (including a direct SIGINT to the process). This PR ensures that we shut down the TUI and the persistent task handle regardless of how `watch.start()` exits.

### Testing Instructions

- Start up a watch task `turbo_dev watch dev`
- Find the pid file via `turbo_dev daemon status`
- Kill the daemon `kill $(cat /path/to/pid/file)`

Before
<img width="1365" alt="Screenshot 2024-11-07 at 5 42 22 PM" src="https://github.com/user-attachments/assets/141831b4-8a82-485e-ac14-c0d72802cf81">


After
<img width="1286" alt="Screenshot 2024-11-07 at 5 39 08 PM" src="https://github.com/user-attachments/assets/21acddb9-ae6a-4b78-b38d-1cbe0e0d3309">

