### PR TITLE
fix(examples): add private to with-shell-cmds

### DIFF
--- a/examples/with-shell-commands/package.json
+++ b/examples/with-shell-commands/package.json
@@ -1,6 +1,7 @@
 {
   "name": "my-turborepo",
   "description": "A barebones Turborepo example for working with Task Graphs.",
+  "private": true,
   "packageManager": "pnpm@8.15.6",
   "devDependencies": {
     "turbo": "^2.0.3"


### PR DESCRIPTION
### Description

Fixes https://github.com/vercel/turborepo/issues/9150

yarn classic errors when using workspaces without setting private to true

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
