### PR TITLE
docs: `turbo info`

### DIFF
--- a/docs/repo-docs/reference/info.mdx
+++ b/docs/repo-docs/reference/info.mdx
@@ -1,0 +1,34 @@
+---
+title: info
+description: API reference for the `turbo info` command
+---
+
+Print debugging information about your Turborepo.
+
+```bash title="Terminal"
+turbo info
+```
+
+Example output:
+
+```txt title="Terminal"
+CLI:
+   Version: 2.3.0
+   Path to executable: /path/to/turbo
+   Daemon status: Running
+   Package manager: pnpm
+
+Platform:
+   Architecture: aarch64
+   Operating system: macos
+   Available memory (MB): 12810
+   Available CPU cores: 10
+
+Environment:
+   CI: None
+   Terminal (TERM): xterm-256color
+   Terminal program (TERM_PROGRAM): tmux
+   Terminal program version (TERM_PROGRAM_VERSION): 3.4
+   Shell (SHELL): /bin/zsh
+   stdin: false
+```

--- a/docs/repo-docs/reference/meta.json
+++ b/docs/repo-docs/reference/meta.json
@@ -19,6 +19,7 @@
     "link",
     "unlink",
     "bin",
+    "info",
     "telemetry",
     "---Packages---",
     "create-turbo",


### PR DESCRIPTION
2.3 release

### Description

Adds https://github.com/vercel/turborepo/pull/9368 to the docs.

### Testing Instructions

👀 
