### PR TITLE
chore(engine): error about missing package in package task

### DIFF
--- a/crates/turborepo-lib/src/engine/snapshots/turborepo_lib__engine__builder__test__run_package_task_invalid_package.snap
+++ b/crates/turborepo-lib/src/engine/snapshots/turborepo_lib__engine__builder__test__run_package_task_invalid_package.snap
@@ -1,0 +1,9 @@
+---
+source: crates/turborepo-lib/src/engine/builder.rs
+expression: msg
+---
+missing tasks in project
+    Diagnostic severity: error
+
+Error: could not find package `app2` in project
+    Diagnostic severity: error


### PR DESCRIPTION
### Description

With package tasks being accepted by `run` users can now bypass our package existence check in `--filter`. We add an additional check in the task graph builder where we verify that the `bad-package` in a `turbo run bad-package#task` command will error with a message explaining that `bad-package` doesn't exist.

### Testing Instructions

Added unit test that hits this error path along with snapshotting the error message
