### PR TITLE
 feat: Detect WSL in `turbo info`.

### DIFF
--- a/crates/turborepo-lib/src/commands/info.rs
+++ b/crates/turborepo-lib/src/commands/info.rs
@@ -1,9 +1,4 @@
-use std::{
-    env,
-    fs::File,
-    io::{self, Read},
-    path::Path,
-};
+use std::{env, io, path::Path};
 
 use sysinfo::{System, SystemExt};
 use thiserror::Error;
@@ -16,15 +11,6 @@ use crate::{DaemonConnector, DaemonConnectorError};
 pub enum Error {
     #[error("could not get path to turbo binary: {0}")]
     NoCurrentExe(#[from] io::Error),
-}
-
-const OS: &str = std::env::consts::OS;
-
-fn os_release() -> Result<String, std::io::Error> {
-    let mut s = String::new();
-    File::open("/proc/sys/kernel/osrelease")?.read_to_string(&mut s)?;
-    s.pop(); // Remove trailing newline
-    Ok(s)
 }
 
 // https://superuser.com/questions/1749781/how-can-i-check-if-the-environment-is-wsl-from-a-shell-script/1749811#1749811
@@ -62,7 +48,7 @@ pub async fn run(base: CommandBase) {
 
     println!("Platform:");
     println!("   Architecture: {}", std::env::consts::ARCH);
-    println!("   Operating system: {}", OS);
+    println!("   Operating system: {}", std::env::consts::OS);
     println!("   WSL: {}", is_wsl());
     println!(
         "   Available memory (MB): {}",


### PR DESCRIPTION
### Description

We have had cases in the past where it would be nice to know if the user is using WSL. This adds best effort detection for printing out if you're using WSL.

Note that this isn't a 100% solution, according to [this superuser answer](https://superuser.com/questions/1749781/how-can-i-check-if-the-environment-is-wsl-from-a-shell-script/1749811#1749811). But, if you're doing something like is listed in the caveats...That's an extreme edge case.