### PR TITLE
docs: Clarify how to use values for self-hosted Remote Cache.

### DIFF
--- a/docs/repo-docs/core-concepts/remote-caching.mdx
+++ b/docs/repo-docs/core-concepts/remote-caching.mdx
@@ -190,4 +190,6 @@ turbo link --api="https://my-server-example.com"
 turbo run build --api="https://my-server.example.com" --token="xxxxxxxxxxxxxxxxx"
 ```
 
+Alternatively, [the `TURBO_API` and `TURBO_TOKEN` System Environment Variables](/repo/docs/reference/system-environment-variables) can be used to set the respective values for the Remote Cache once you've logged in.
+
 You can [find the OpenAPI specification for the API here](/api/remote-cache-spec). At this time, all versions of `turbo` are compatible with the `v8` endpoints.


### PR DESCRIPTION
### Description

Clarify that use can use environment variables. You don't have to use the flags all the time. 😄

### Testing Instructions

👀 
