### PR TITLE
fix(affected): consider both source and destination as changed

### DIFF
--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -302,8 +302,16 @@ impl Git {
         // comparison
         if include_uncommitted {
             // Add untracked files, i.e. files that are not in git at all
-            let output = self
-                .execute_git_command(&["ls-files", "--others", "--exclude-standard"], pathspec)?;
+            let output = self.execute_git_command(
+                &[
+                    "ls-files",
+                    "--others",
+                    "--modified",
+                    "--cached",
+                    "--exclude-standard",
+                ],
+                pathspec,
+            )?;
             self.add_files_from_stdout(&mut files, turbo_root, output);
         }
 

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -708,6 +708,17 @@ mod tests {
         index.add_path(Path::new("bar.js")).unwrap();
         index.write().unwrap();
 
+        // Test that uncommitted file in index is not marked as changed when not
+        // checking uncommitted
+        let files = changed_files(
+            repo_root.path().to_path_buf(),
+            turbo_root.to_path_buf(),
+            Some("HEAD"),
+            None,
+            false,
+        )?;
+        assert_eq!(files, HashSet::new());
+
         // Test that uncommitted file in index is still marked as changed
         let files = changed_files(
             repo_root.path().to_path_buf(),


### PR DESCRIPTION
### Description

Previously we would only consider the destination file moved as changed and not the source. We use `diff-tree` instead of `diff` to track these moves. 

This PR also fixes an issue where `include_uncommitted: false` was not respected if `to_commit` wasn't present i.e. we would always return uncommitted changes. This did not affect users since this API isn't exposed to users and there's no way to set `include_uncommitted: false` without setting a `to_commit`.

### Testing Instructions

Added unit test where a file is moved between packages. Also added additional checks for our `changed_files` tests
