### PR TITLE
chore(cache): add deprecation warnings to old cache flags

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -413,6 +413,27 @@ impl Args {
             clap_args.test_run = true;
         }
 
+        if let Some(run_args) = clap_args.run_args() {
+            if run_args.no_cache {
+                warn!(
+                    "--no-cache is deprecated and will be removed in a future major version. Use \
+                     --cache=local:r,remote:r"
+                );
+            }
+            if run_args.remote_only.is_some() {
+                warn!(
+                    "--remote-only is deprecated and will be removed in a future major version. \
+                     Use --cache=remote:rw"
+                );
+            }
+            if run_args.remote_cache_read_only.is_some() {
+                warn!(
+                    "--remote-cache-read-only is deprecated and will be removed in a future major \
+                     version. Use --cache=remote:r"
+                );
+            }
+        }
+
         clap_args
     }
 

--- a/crates/turborepo-lib/src/config/env.rs
+++ b/crates/turborepo-lib/src/config/env.rs
@@ -5,6 +5,7 @@ use std::{
 
 use clap::ValueEnum;
 use itertools::Itertools;
+use tracing::warn;
 use turbopath::AbsoluteSystemPathBuf;
 
 use super::{ConfigurationOptions, Error, ResolvedConfigurationOptions};
@@ -80,7 +81,19 @@ impl ResolvedConfigurationOptions for EnvVars {
 
         let force = self.truthy_value("force").flatten();
         let remote_only = self.truthy_value("remote_only").flatten();
+        if remote_only.is_some() {
+            warn!(
+                "TURBO_REMOTE_ONLY is deprecated and will be removed in a future major version. \
+                 Use TURBO_CACHE=remote:rw"
+            );
+        }
         let remote_cache_read_only = self.truthy_value("remote_cache_read_only").flatten();
+        if remote_cache_read_only.is_some() {
+            warn!(
+                "TURBO_REMOTE_CACHE_READ_ONLY is deprecated and will be removed in a future major \
+                 version. Use TURBO_CACHE=remote:r"
+            );
+        }
         let run_summary = self.truthy_value("run_summary").flatten();
         let allow_no_turbo_json = self.truthy_value("allow_no_turbo_json").flatten();
 


### PR DESCRIPTION
### Description

With introduction of `--cache` and `TURBO_CACHE` add deprecation flags to the "old" cache config options.

### Testing Instructions

```
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ TURBO_REMOTE_ONLY=1 turbo_dev @turbo/types#lint > /dev/null           
 WARNING  No locally installed `turbo` found. Using version: 2.2.4-canary.9.
turbo 2.2.4-canary.9

 WARNING  TURBO_REMOTE_ONLY is deprecated and will be removed in a future major version. Use TURBO_CACHE=remote:rw
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ TURBO_REMOTE_CACHE_READ_ONLY=1 turbo_dev @turbo/types#lint > /dev/null
 WARNING  No locally installed `turbo` found. Using version: 2.2.4-canary.9.
turbo 2.2.4-canary.9

 WARNING  TURBO_REMOTE_CACHE_READ_ONLY is deprecated and will be removed in a future major version. Use TURBO_CACHE=remote:r
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ turbo_dev @turbo/types#lint --no-cache > /dev/null           
 WARNING  No locally installed `turbo` found. Using version: 2.2.4-canary.9.
 WARNING  --no-cache is deprecated and will be removed in a future major version. Use --cache=local:r,remote:r
turbo 2.2.4-canary.9

[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ turbo_dev @turbo/types#lint --remote-only > /dev/null           
 WARNING  No locally installed `turbo` found. Using version: 2.2.4-canary.9.
 WARNING  --remote-only is deprecated and will be removed in a future major version. Use --cache=remote:rw
turbo 2.2.4-canary.9

[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ turbo_dev @turbo/types#lint --remote-cache-read-only > /dev/null      
 WARNING  No locally installed `turbo` found. Using version: 2.2.4-canary.9.
 WARNING  --remote-cache-read-only is deprecated and will be removed in a future major version. Use --cache=remote:r
turbo 2.2.4-canary.9
```
