### PR TITLE
fix(mfe): avoid crashing if unsupported mfe version found

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6541,6 +6541,7 @@ dependencies = [
  "biome_diagnostics",
  "biome_json_parser",
  "biome_json_syntax",
+ "insta",
  "pretty_assertions",
  "serde",
  "serde_json",

--- a/crates/turborepo-micro-frontend/Cargo.toml
+++ b/crates/turborepo-micro-frontend/Cargo.toml
@@ -17,6 +17,7 @@ turbopath = { workspace = true }
 turborepo-errors = { workspace = true }
 
 [dev-dependencies]
+insta = { workspace = true }
 pretty_assertions = { workspace = true }
 
 [lints]

--- a/crates/turborepo-micro-frontend/src/error.rs
+++ b/crates/turborepo-micro-frontend/src/error.rs
@@ -1,11 +1,18 @@
 use turborepo_errors::ParseDiagnostic;
 
+use crate::SUPPORTED_VERSIONS;
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("Unable to read configuration file: {0}")]
     Io(#[from] std::io::Error),
     #[error("Unable to parse JSON: {0}")]
     JsonParse(String),
+    #[error(
+        "Unsupported micro-frontends configuration version: {0}. Supported versions: \
+         {SUPPORTED_VERSIONS:?}"
+    )]
+    UnsupportedVersion(String),
 }
 
 impl Error {


### PR DESCRIPTION
### Description

We should avoid crashing if we encounter a version of MFE config that we don't currently support.

### Testing Instructions

Added unit test. Quick spot check by changing version in an example to an unsupported version:

```
[1 olszewski@chriss-mbp] /Users/olszewski/code/ $ turbo_dev --skip-infer micro-frontends-example-web#dev --dry=json > /dev/null
turbo 2.2.4-canary.10

 WARNING  Ignoring /Users/olszewski/code/packages/micro-frontends-example-site-config/micro-frontends.jsonc: Unsupported micro-frontends configuration version: 2. Supported versions: ["1"]
```
