### PR TITLE
chore: Remove obsolete GitHub labels.

### DIFF
--- a/.github/turbo-orchestrator.yml
+++ b/.github/turbo-orchestrator.yml
@@ -30,16 +30,11 @@
 
 labeler:
   labels:
-    # owned-by
-    - label: "owned-by: turborepo"
-      when:
-        isAnyFileOwnedByMatch: '@vercel\/turbo-oss'
-
     - label: "created-by: turborepo"
       when:
         isPRAuthorMatch: "^(anthonyshew|dimitropoulos|tknickman|chris-olszewski|NicholasLYang)$"
 
-    # needs: triage when not any of the turbopack or turborepo team
+    # needs: triage when not any of the turborepo team
     - label: "needs: triage"
       when:
         isNotPRAuthorMatch: "^(padmaia|anthonyshew|dimitropoulos|tknickman|chris-olszewski|NicholasLYang)$"

--- a/.github/turbo-orchestrator.yml
+++ b/.github/turbo-orchestrator.yml
@@ -30,10 +30,6 @@
 
 labeler:
   labels:
-    - label: "created-by: turborepo"
-      when:
-        isPRAuthorMatch: "^(anthonyshew|dimitropoulos|tknickman|chris-olszewski|NicholasLYang)$"
-
     # needs: triage when not any of the turborepo team
     - label: "needs: triage"
       when:

--- a/.github/turborepo-release.yml
+++ b/.github/turborepo-release.yml
@@ -3,7 +3,6 @@
 changelog:
   exclude:
     labels:
-      - "owned-by: turbopack"
       - "area: ci"
       - "release: turborepo"
   categories:


### PR DESCRIPTION
### Description

We used to need these labels when Turbopack was in this repository as well but its not anymore. No need for the cruft!
