### PR TITLE
fix(cli): error on out of place run args

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1,4 +1,10 @@
-use std::{backtrace::Backtrace, env, fmt, fmt::Display, io, mem, process};
+use std::{
+    backtrace::Backtrace,
+    env,
+    ffi::OsString,
+    fmt::{self, Display},
+    io, mem, process,
+};
 
 use biome_deserialize_macros::Deserializable;
 use camino::{Utf8Path, Utf8PathBuf};
@@ -329,32 +335,8 @@ pub enum LinkTarget {
 }
 
 impl Args {
-    pub fn new() -> Self {
-        // We always pass --single-package in from the shim.
-        // We need to omit it, and then add it in for run.
-        let arg_separator_position = env::args_os().position(|input_token| input_token == "--");
-
-        let single_package_position =
-            env::args_os().position(|input_token| input_token == "--single-package");
-
-        let is_single_package = match (arg_separator_position, single_package_position) {
-            (_, None) => false,
-            (None, Some(_)) => true,
-            (Some(arg_separator_position), Some(single_package_position)) => {
-                single_package_position < arg_separator_position
-            }
-        };
-
-        // Clap supports arbitrary iterators as input.
-        // We can remove all instances of --single-package
-        let single_package_free = std::env::args_os()
-            .enumerate()
-            .filter(|(index, input_token)| {
-                arg_separator_position
-                    .is_some_and(|arg_separator_position| index > &arg_separator_position)
-                    || input_token != "--single-package"
-            })
-            .map(|(_, input_token)| input_token);
+    pub fn new(os_args: Vec<OsString>) -> Self {
+        let (is_single_package, single_package_free) = Self::remove_single_package(os_args);
 
         let mut clap_args = match Args::try_parse_from(single_package_free) {
             Ok(mut args) => {
@@ -492,6 +474,38 @@ impl Args {
         } else {
             self.execution_args.as_ref()
         }
+    }
+
+    fn remove_single_package(args: Vec<OsString>) -> (bool, impl Iterator<Item = OsString>) {
+        // We always pass --single-package in from the shim.
+        // We need to omit it, and then add it in for run.
+        let arg_separator_position = args.iter().position(|input_token| input_token == "--");
+
+        let single_package_position = args
+            .iter()
+            .position(|input_token| input_token == "--single-package");
+
+        let is_single_package = match (arg_separator_position, single_package_position) {
+            (_, None) => false,
+            (None, Some(_)) => true,
+            (Some(arg_separator_position), Some(single_package_position)) => {
+                single_package_position < arg_separator_position
+            }
+        };
+
+        // Clap supports arbitrary iterators as input.
+        // We can remove all instances of --single-package
+        let single_package_free = args
+            .into_iter()
+            .enumerate()
+            .filter(move |(index, input_token)| {
+                arg_separator_position
+                    .is_some_and(|arg_separator_position| index > &arg_separator_position)
+                    || input_token != "--single-package"
+            })
+            .map(|(_, input_token)| input_token);
+
+        (is_single_package, single_package_free)
     }
 }
 
@@ -1071,7 +1085,7 @@ pub async fn run(
     color_config: ColorConfig,
 ) -> Result<i32, Error> {
     // TODO: remove mutability from this function
-    let mut cli_args = Args::new();
+    let mut cli_args = Args::new(env::args_os().collect());
     let version = get_version();
 
     // track telemetry handle to close at the end of the run
@@ -1462,7 +1476,7 @@ pub async fn run(
 
 #[cfg(test)]
 mod test {
-    use std::assert_matches::assert_matches;
+    use std::{assert_matches::assert_matches, ffi::OsString};
 
     use camino::Utf8PathBuf;
     use clap::Parser;
@@ -2724,5 +2738,73 @@ mod test {
         assert!(Args::try_parse_from(["turbo", "build", "--affected", "--filter", "foo"]).is_err(),);
         assert!(Args::try_parse_from(["turbo", "build", "--filter", "foo", "--affected"]).is_err(),);
         assert!(Args::try_parse_from(["turbo", "ls", "--filter", "foo", "--affected"]).is_err(),);
+    }
+
+    struct SinglePackageTestCase {
+        args: &'static [&'static str],
+        expected_is_single: bool,
+        expected: &'static [&'static str],
+    }
+
+    impl SinglePackageTestCase {
+        pub const fn new<const N: usize>(args: &'static [&'static str; N]) -> Self {
+            let args = args.as_slice();
+            Self {
+                args,
+                expected_is_single: false,
+                expected: args,
+            }
+        }
+
+        pub const fn expected<const N: usize>(
+            mut self,
+            expected: &'static [&'static str; N],
+        ) -> Self {
+            self.expected_is_single = true;
+            self.expected = expected.as_slice();
+            self
+        }
+
+        pub fn os_args(&self) -> Vec<OsString> {
+            self.args.iter().map(|s| OsString::from(*s)).collect()
+        }
+
+        pub fn assert_actual(&self, actual: (bool, impl Iterator<Item = OsString>)) {
+            let (is_single, args) = actual;
+            assert_eq!(is_single, self.expected_is_single);
+            assert_eq!(
+                args.map(|s| s.to_str().unwrap().to_string())
+                    .collect::<Vec<_>>()
+                    .as_slice(),
+                self.expected
+            );
+        }
+    }
+
+    const NO_SINGLE_PKG: SinglePackageTestCase =
+        SinglePackageTestCase::new(&["turbo", "--version"]);
+    const SINGLE_PKG_AFTER_PASS: SinglePackageTestCase =
+        SinglePackageTestCase::new(&["turbo", "--", "--single-package"]);
+    const SINGLE_PKG: SinglePackageTestCase =
+        SinglePackageTestCase::new(&["turbo", "--single-package", "run", "build"])
+            .expected(&["turbo", "run", "build"]);
+    const SINGLE_PKG_BEFORE_AFTER: SinglePackageTestCase = SinglePackageTestCase::new(&[
+        "turbo",
+        "--single-package",
+        "run",
+        "build",
+        "--",
+        "--single-package",
+    ])
+    .expected(&["turbo", "run", "build", "--", "--single-package"]);
+
+    #[test_case::test_case(NO_SINGLE_PKG)]
+    #[test_case::test_case(SINGLE_PKG_AFTER_PASS)]
+    #[test_case::test_case(SINGLE_PKG)]
+    #[test_case::test_case(SINGLE_PKG_BEFORE_AFTER)]
+    fn test_single_package_removal(test: SinglePackageTestCase) {
+        let os_args = test.os_args();
+        let actual = Args::remove_single_package(os_args);
+        test.assert_actual(actual);
     }
 }

--- a/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__turbo---filter=foo-run-build.snap
+++ b/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__turbo---filter=foo-run-build.snap
@@ -1,0 +1,9 @@
+---
+source: crates/turborepo-lib/src/cli/mod.rs
+expression: err
+---
+error: Cannot use run arguments before `run` subcommand
+
+Usage: turbo [OPTIONS] [COMMAND]
+
+For more information, try '--help'.

--- a/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__turbo---filter=web-watch-build.snap
+++ b/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__turbo---filter=web-watch-build.snap
@@ -1,0 +1,9 @@
+---
+source: crates/turborepo-lib/src/cli/mod.rs
+expression: err
+---
+error: Cannot use watch arguments before `watch` subcommand
+
+Usage: turbo [OPTIONS] [COMMAND]
+
+For more information, try '--help'.

--- a/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__turbo---no-daemon-run-build.snap
+++ b/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__turbo---no-daemon-run-build.snap
@@ -1,0 +1,9 @@
+---
+source: crates/turborepo-lib/src/cli/mod.rs
+expression: err
+---
+error: Cannot use run arguments before `run` subcommand
+
+Usage: turbo [OPTIONS] [COMMAND]
+
+For more information, try '--help'.

--- a/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__turbo---no-daemon-watch-build.snap
+++ b/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__turbo---no-daemon-watch-build.snap
@@ -1,0 +1,9 @@
+---
+source: crates/turborepo-lib/src/cli/mod.rs
+expression: err
+---
+error: Cannot use run arguments outside of run command
+
+Usage: turbo [OPTIONS] [COMMAND]
+
+For more information, try '--help'.

--- a/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__turbo-watch-build---no-daemon.snap
+++ b/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__turbo-watch-build---no-daemon.snap
@@ -1,0 +1,12 @@
+---
+source: crates/turborepo-lib/src/cli/mod.rs
+expression: err
+---
+error: unexpected argument '--no-daemon' found
+
+  tip: a similar argument exists: '--no-update-notifier'
+  tip: to pass '--no-daemon' as a value, use '-- --no-daemon'
+
+Usage: turbo watch --no-update-notifier <--cache-dir <CACHE_DIR>|--concurrency <CONCURRENCY>|--continue|--single-package|--framework-inference [<BOOL>]|--global-deps <GLOBAL_DEPS>|--env-mode [<ENV_MODE>]|--filter <FILTER>|--affected|--output-logs <OUTPUT_LOGS>|--log-order <LOG_ORDER>|--only|--pkg-inference-root <PKG_INFERENCE_ROOT>|--log-prefix <LOG_PREFIX>|TASKS|PASS_THROUGH_ARGS>
+
+For more information, try '--help'.


### PR DESCRIPTION
### Description

Currently we have a bug where run args can be specified incorrectly and we'll silently ignore them.
 - Specified for non-run commands e.g. `turbo --no-daemon watch`
 - Specified before a subcommand e.g. `turbo --filter=foo run build` `turbo --filter=foo watch build` which will silently ignore any arguments provided before the subcommand.

This PR makes these explicit failures instead of silently ignoring them. There is a solution where we attempt to "merge" args provided on either side of the subcommand, but that would require us to switch to `clap`'s builder interface which would make our 80 line top level CLI interface ~1k lines. I do not think this is worth the time to go about that refactor to allow for awkward syntax.

⚠️ This will very possibly break user workflows, but I think this is better than our current ignoring of user provided flags. We could warn here, but I'm afraid that those warnings would go unseen.

I suggest reviewing each commit individually as there was some required refactoring to unit test this behavior.

### Testing Instructions

Added unit tests
