### PR TITLE
 docs: Small stylistic change for footnote.

### DIFF
--- a/docs/repo-docs/getting-started/support-policy.mdx
+++ b/docs/repo-docs/getting-started/support-policy.mdx
@@ -33,10 +33,13 @@ the following binaries via npm:
 - `turbo-darwin-arm64` (macOS with Apple Silicon)
 - `turbo-linux-64`
 - `turbo-linux-arm64`
-- `turbo-windows-64` [^1]
-- `turbo-windows-arm64` [^1]
+- `turbo-windows-64`\*
+- `turbo-windows-arm64`\*
 
-[^1]: Requires [Windows C Runtime Libraries](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist)
+<small>
+  \*: Requires [Windows C Runtime
+  Libraries](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist)
+</small>
 
 ## Node.js
 


### PR DESCRIPTION
### Description

The way the Markdown footnote attribution looked just felt a little out of place. Simplifying and localizing here.

### Testing Instructions

Before
![CleanShot 2024-11-16 at 21 27 34@2x](https://github.com/user-attachments/assets/85ee00ee-c260-4850-8659-516be7ead949)
![CleanShot 2024-11-16 at 21 27 43@2x](https://github.com/user-attachments/assets/86a3c1e6-cffa-4b4f-a8bf-b9d7337fd1cd)


After
![CleanShot 2024-11-16 at 21 27 13@2x](https://github.com/user-attachments/assets/2d63174a-d86a-4549-b7ca-0d0f0e2d2da5)
