### PR TITLE
fix(cache): allow force to override any cache settings

### DIFF
--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -367,7 +367,6 @@ impl<'a> TryFrom<OptsInputs<'a>> for CacheOpts {
         let is_linked = turborepo_api_client::is_linked(inputs.api_auth);
         let cache = inputs.config.cache();
         let has_old_cache_config = inputs.config.remote_only()
-            || inputs.config.force()
             || inputs.run_args.no_cache
             || inputs.config.remote_cache_read_only();
 

--- a/crates/turborepo-lib/src/snapshots/turborepo_lib__opts__test__force_remote_r,local_r.snap
+++ b/crates/turborepo-lib/src/snapshots/turborepo_lib__opts__test__force_remote_r,local_r.snap
@@ -2,6 +2,15 @@
 source: crates/turborepo-lib/src/opts.rs
 expression: cache_opts
 ---
-Err(
-    OverlappingCacheOptions,
+Ok(
+    CacheConfig {
+        local: CacheActions {
+            read: false,
+            write: false,
+        },
+        remote: CacheActions {
+            read: false,
+            write: false,
+        },
+    },
 )


### PR DESCRIPTION
### Description

As mentioned in #9453 if a user sets `--force` when `TURBO_CACHE` is set we currently error. `--force` should be applicable in this case an just remove any reads from the `TURBO_CACHE` setting.

### Testing Instructions

Updated unit test, manual verification of behavior for other cases:
```
# Do not allow `--force` and `--cache`
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ turbo_dev @turbo/types#build --force --cache=local:rw 
 WARNING  No locally installed `turbo` found. Using version: 2.3.1-canary.0.
 ERROR  the argument '--force [<FORCE>]' cannot be used with '--cache <CACHE>'

Usage: turbo --force [<FORCE>]

For more information, try '--help'.

# Force should remove reads even if set from env var
[1 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ TURBO_FORCE=1 turbo_dev @turbo/types#build --cache=local:rw       
 WARNING  No locally installed `turbo` found. Using version: 2.3.1-canary.0.
turbo 2.3.1-canary.0

• Packages in scope: @turbo-internal/top-issues-gh-action, @turbo/benchmark, @turbo/codemod, @turbo/eslint-config, @turbo/exe-stub, @turbo/gen, @turbo/telemetry, @turbo/test-utils, @turbo/tsconfig, @turbo/types, @turbo/utils, @turbo/workspaces, @turborepo-examples-tests/basic, @turborepo-examples-tests/design-system, @turborepo-examples-tests/kitchen-sink, @turborepo-examples-tests/non-monorepo, @turborepo-examples-tests/with-berry, @turborepo-examples-tests/with-changesets, @turborepo-examples-tests/with-npm, @turborepo-examples-tests/with-react-native-web, @turborepo-examples-tests/with-rollup, @turborepo-examples-tests/with-svelte, @turborepo-examples-tests/with-tailwind, @turborepo-examples-tests/with-vite, @turborepo-examples-tests/with-yarn, cargo-sweep-action, cli, create-turbo, eslint-config-turbo, eslint-plugin-turbo, prysk, turbo-ignore, turbo-vsc, turborepo-examples, turborepo-repository, turborepo-tests-helpers, turborepo-tests-integration
• Running @turbo/types#build in 37 packages
• Remote caching disabled
┌ @turbo/types#build > cache bypass, force executing 378250748b4bc15b 
│ 
│ 
│ > @turbo/types@2.3.1-canary.0 build /Users/olszewski/code/vercel/turborepo/packages/turbo-types
│ > tsc && pnpm generate-schema
│ 
│ 
│ > @turbo/types@2.3.1-canary.0 generate-schema /Users/olszewski/code/vercel/turborepo/packages/turbo-types
│ > tsx scripts/generate-schema.ts
└────>

 Tasks:    1 successful, 1 total
Cached:    0 cached, 1 total
  Time:    3.045s 

# `--force` removes reads from `TURBO_CACHE` settings
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ TURBO_CACHE=local:rw turbo_dev @turbo/types#build --force         
 WARNING  No locally installed `turbo` found. Using version: 2.3.1-canary.0.
turbo 2.3.1-canary.0

• Packages in scope: @turbo-internal/top-issues-gh-action, @turbo/benchmark, @turbo/codemod, @turbo/eslint-config, @turbo/exe-stub, @turbo/gen, @turbo/telemetry, @turbo/test-utils, @turbo/tsconfig, @turbo/types, @turbo/utils, @turbo/workspaces, @turborepo-examples-tests/basic, @turborepo-examples-tests/design-system, @turborepo-examples-tests/kitchen-sink, @turborepo-examples-tests/non-monorepo, @turborepo-examples-tests/with-berry, @turborepo-examples-tests/with-changesets, @turborepo-examples-tests/with-npm, @turborepo-examples-tests/with-react-native-web, @turborepo-examples-tests/with-rollup, @turborepo-examples-tests/with-svelte, @turborepo-examples-tests/with-tailwind, @turborepo-examples-tests/with-vite, @turborepo-examples-tests/with-yarn, cargo-sweep-action, cli, create-turbo, eslint-config-turbo, eslint-plugin-turbo, prysk, turbo-ignore, turbo-vsc, turborepo-examples, turborepo-repository, turborepo-tests-helpers, turborepo-tests-integration
• Running @turbo/types#build in 37 packages
• Remote caching disabled
┌ @turbo/types#build > cache bypass, force executing 378250748b4bc15b 
│ 
│ 
│ > @turbo/types@2.3.1-canary.0 build /Users/olszewski/code/vercel/turborepo/packages/turbo-types
│ > tsc && pnpm generate-schema
│ 
│ 
│ > @turbo/types@2.3.1-canary.0 generate-schema /Users/olszewski/code/vercel/turborepo/packages/turbo-types
│ > tsx scripts/generate-schema.ts
└────>

 Tasks:    1 successful, 1 total
Cached:    0 cached, 1 total
  Time:    2.284s 
```
