### PR TITLE
chore(release): fix release by avoiding old glibc version

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -118,7 +118,7 @@ jobs:
           - host: ubuntu-latest
             container-options: "--platform=linux/amd64 --rm"
             target: "x86_64-unknown-linux-musl"
-            setup: "sudo apt-get && sudo apt-get install -y build-essential clang lldb llvm libclang curl musl-tools sudo unzip"
+            setup: "sudo apt-get update && sudo apt-get install -y build-essential clang lldb llvm libclang curl musl-tools sudo unzip"
           - host: ubuntu-latest
             container-options: "--rm"
             target: "aarch64-unknown-linux-musl"

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -117,9 +117,8 @@ jobs:
             container-options: "--rm"
           - host: ubuntu-latest
             container-options: "--platform=linux/amd64 --rm"
-            container-setup: "apt-get update && apt-get install -y curl musl-tools sudo unzip"
             target: "x86_64-unknown-linux-musl"
-            setup: "apt-get install -y build-essential clang-5.0 lldb-5.0 llvm-5.0-dev libclang-5.0-dev"
+            setup: "sudo apt-get && sudo apt-get install -y build-essential clang lldb llvm libclang curl musl-tools sudo unzip"
           - host: ubuntu-latest
             container-options: "--rm"
             target: "aarch64-unknown-linux-musl"

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -116,7 +116,6 @@ jobs:
             target: "aarch64-apple-darwin"
             container-options: "--rm"
           - host: ubuntu-latest
-            container: ubuntu:xenial
             container-options: "--platform=linux/amd64 --rm"
             container-setup: "apt-get update && apt-get install -y curl musl-tools sudo unzip"
             target: "x86_64-unknown-linux-musl"

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -118,7 +118,7 @@ jobs:
           - host: ubuntu-latest
             container-options: "--platform=linux/amd64 --rm"
             target: "x86_64-unknown-linux-musl"
-            setup: "sudo apt-get update && sudo apt-get install -y build-essential clang lldb llvm libclang curl musl-tools sudo unzip"
+            setup: "sudo apt-get update && sudo apt-get install -y build-essential clang lldb llvm libclang-dev curl musl-tools sudo unzip"
           - host: ubuntu-latest
             container-options: "--rm"
             target: "aarch64-unknown-linux-musl"


### PR DESCRIPTION
### Description

https://github.com/vercel/turborepo/pull/9447 bumped us to `upload-artifact` to v4 which uses Node 20. Node 20 required a newer glibc version than was available on our build that targeted AWS's Lambda2's glibc version. See [this job](https://github.com/vercel/turborepo/actions/runs/11897321603/job/33151832964#step:12:21) for an example failure.

Requiring this glibc version isn't necessary for the musl builds since it uses musl instead of glibc for libc.

I do not think this was intentional to have the musl binary building in this container as we changed this back when we were cross compiling: https://github.com/vercel/turborepo/commit/8ca67c3c0cd9601909730953b9d03699a01b1da8

Future work: This does not fix the `@turbo/repository` release.

### Testing Instructions

Ran test release and x86 msul build now passes: [job](https://github.com/vercel/turborepo/actions/runs/11917567457/job/33214049836)
