### PR TITLE
add vim keybindings for cycling up and down

### DIFF
--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -113,7 +113,9 @@ fn translate_key_event(options: InputOptions, key_event: KeyEvent) -> Option<Eve
             Some(Event::ScrollDown)
         }
         KeyCode::Up => Some(Event::Up),
+        KeyCode::Char('k') => Some(Event::Up),
         KeyCode::Down => Some(Event::Down),
+        KeyCode::Char('j') => Some(Event::Down),
         KeyCode::Enter => Some(Event::EnterInteractive),
         _ => None,
     }


### PR DESCRIPTION
### Description

I updated the inputs for the tui to allow for using the 'j'  key to cycle down in tasks and 'k' for cycling up in tasks.

### Testing Instructions

Run a turbo repo job and try using 'j' and 'k' to cycle between running tasks.
