### PR TITLE
chore: use mocked package in test

### DIFF
--- a/crates/turborepo/tests/snapshots/query__turbo_trace_monorepo_get_`apps__my-app__index.ts`_with_dependencies_(npm@10.5.0).snap
+++ b/crates/turborepo/tests/snapshots/query__turbo_trace_monorepo_get_`apps__my-app__index.ts`_with_dependencies_(npm@10.5.0).snap
@@ -13,16 +13,13 @@ expression: query_output
               "path": "apps/my-app/types.ts"
             },
             {
-              "path": "node_modules/@types/d3-scale/index.d.ts"
-            },
-            {
-              "path": "node_modules/@types/d3-time/index.d.ts"
-            },
-            {
               "path": "packages/another/index.jsx"
             },
             {
               "path": "packages/module-package/my-module.mjs"
+            },
+            {
+              "path": "packages/ship-types/index.ts"
             },
             {
               "path": "packages/utils/index.ts"

--- a/turborepo-tests/integration/fixtures/turbo_trace_monorepo/apps/my-app/index.ts
+++ b/turborepo-tests/integration/fixtures/turbo_trace_monorepo/apps/my-app/index.ts
@@ -3,4 +3,4 @@ import ship from "utils";
 import { blackbeard } from "../../packages/another/index.jsx";
 import { Pirate } from "@/types.ts";
 import { walkThePlank } from "module-package";
-import type { ScalePoint } from "d3-scale";
+import type { Ship } from "ship";

--- a/turborepo-tests/integration/fixtures/turbo_trace_monorepo/apps/my-app/package.json
+++ b/turborepo-tests/integration/fixtures/turbo_trace_monorepo/apps/my-app/package.json
@@ -6,6 +6,6 @@
   },
   "dependencies": {
     "utils": "*",
-    "@types/d3-scale": "^4.0.2"
+    "@types/ship": "*"
   }
 }

--- a/turborepo-tests/integration/fixtures/turbo_trace_monorepo/packages/ship-types/index.ts
+++ b/turborepo-tests/integration/fixtures/turbo_trace_monorepo/packages/ship-types/index.ts
@@ -1,0 +1,1 @@
+export type Ship = "pirate" | "privateer" | "corvette";

--- a/turborepo-tests/integration/fixtures/turbo_trace_monorepo/packages/ship-types/package.json
+++ b/turborepo-tests/integration/fixtures/turbo_trace_monorepo/packages/ship-types/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@types/ship",
+  "types": "index.ts"
+}


### PR DESCRIPTION
### Description

Use a mocked `@types` package instead of a real one in test so we don't hit the npm registry.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
