### PR TITLE
refactor(tui): Improve aesthetics for helper text.

### DIFF
--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -115,6 +115,7 @@ fn translate_key_event(options: InputOptions, key_event: KeyEvent) -> Option<Eve
         KeyCode::Up => Some(Event::Up),
         KeyCode::Down => Some(Event::Down),
         KeyCode::Enter => Some(Event::EnterInteractive),
+        KeyCode::Char('i') => Some(Event::EnterInteractive),
         _ => None,
     }
 }

--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -115,7 +115,6 @@ fn translate_key_event(options: InputOptions, key_event: KeyEvent) -> Option<Eve
         KeyCode::Up => Some(Event::Up),
         KeyCode::Down => Some(Event::Down),
         KeyCode::Enter => Some(Event::EnterInteractive),
-        KeyCode::Char('i') => Some(Event::EnterInteractive),
         _ => None,
     }
 }

--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -8,7 +8,7 @@ use tui_term::widget::PseudoTerminal;
 use super::{app::LayoutSections, TerminalOutput};
 
 const FOOTER_TEXT_ACTIVE: &str = "Ctrl-z - Stop interacting";
-const FOOTER_TEXT_INACTIVE: &str = "Enter - Interact";
+const FOOTER_TEXT_INACTIVE: &str = "i - Interact";
 const HAS_SELECTION: &str = "c - Copy selection";
 const TASK_LIST_HIDDEN: &str = "h - Show task list";
 

--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -51,7 +51,7 @@ impl<'a, W> TerminalPane<'a, W> {
             }
 
             // Spaces are used to pad the footer text for aesthetics
-            ["   ".into(), messages.join(", ")].join("")
+            format!("   {}", messages.join(", "))
         };
 
         match self.section {

--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -8,7 +8,7 @@ use tui_term::widget::PseudoTerminal;
 use super::{app::LayoutSections, TerminalOutput};
 
 const FOOTER_TEXT_ACTIVE: &str = "Ctrl-z - Stop interacting";
-const FOOTER_TEXT_INACTIVE: &str = "i - Interact";
+const FOOTER_TEXT_INACTIVE: &str = "Enter - Interact";
 const HAS_SELECTION: &str = "c - Copy selection";
 const TASK_LIST_HIDDEN: &str = "h - Show task list";
 


### PR DESCRIPTION
### Description

Just wanting to spruce things up a bit.

- Left-aligned the text so that it bounces around less when changing states. This is considered a generally good practice in UI design.
- Re-writing text chunks for simplicity

In the process of adjusting the text with a comma as a separator, I realized I could refactor the logic for which text to render to be a little easier to read. Isn't it great when the simplicity of the visual design is reflected in the code?!

### Testing Instructions

You'll want to put the TUI into different states to see them all. Matrix is:
- Task list open/closed
- Text selected/not selected
- Task being interacted with/ not interacted with

A sample of the spirit of the changes is below.

Before
![CleanShot 2024-11-20 at 23 05 58@2x](https://github.com/user-attachments/assets/e5ba1e5b-54e1-4cc6-9dee-20ac2e17d303)

After
![CleanShot 2024-11-20 at 23 06 38@2x](https://github.com/user-attachments/assets/50be8c06-fbfb-4e46-bce7-d50da8f83f9e)

