### PR TITLE
feat(trace): resolve incorrect extension

### DIFF
--- a/crates/turborepo/tests/query.rs
+++ b/crates/turborepo/tests/query.rs
@@ -63,6 +63,7 @@ fn test_trace() -> Result<(), anyhow::Error> {
             "get `import_value_and_type.ts` with type dependencies" => "query { file(path: \"import_value_and_type.ts\") { path dependencies(importType: TYPES) { files { items { path } } } } }",
             "get `import_value_and_type.ts` with value dependencies" => "query { file(path: \"import_value_and_type.ts\") { path dependencies(importType: VALUES) { files { items { path } } } } }",
             "get `export_conditions` with dependencies" => "query { file(path: \"export_conditions.js\") { path dependencies(depth: 1) { files { items { path } } } } }",
+            "get `incorrect_extension.mjs` with dependencies" =>  "query { file(path: \"incorrect_extension.mjs\") { path dependencies(depth: 1) { files { items { path } } } } }",
         );
 
         Ok(())

--- a/crates/turborepo/tests/snapshots/query__turbo_trace_get_`incorrect_extension.mjs`_with_dependencies_(npm@10.5.0).snap
+++ b/crates/turborepo/tests/snapshots/query__turbo_trace_get_`incorrect_extension.mjs`_with_dependencies_(npm@10.5.0).snap
@@ -1,0 +1,20 @@
+---
+source: crates/turborepo/tests/query.rs
+expression: query_output
+---
+{
+  "data": {
+    "file": {
+      "path": "incorrect_extension.mjs",
+      "dependencies": {
+        "files": {
+          "items": [
+            {
+              "path": "bar.js"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/turborepo-tests/integration/fixtures/turbo_trace/incorrect_extension.mjs
+++ b/turborepo-tests/integration/fixtures/turbo_trace/incorrect_extension.mjs
@@ -1,0 +1,1 @@
+import { bar } from "./bar.cjs";


### PR DESCRIPTION
### Description

Invalid extensions are unfortunately too common in imports. Therefore if we can't resolve with the extension, we strip it and try again.

### Testing Instructions

Added a test where we try to import with the wrong extension
