### PR TITLE
docs: Improve clarity on `--cache`.

### DIFF
--- a/docs/repo-docs/reference/run.mdx
+++ b/docs/repo-docs/reference/run.mdx
@@ -67,23 +67,27 @@ Specify caching sources for the run. Accepts a comma-separated list of options:
 - `local`: Use the local filesystem cache
 - `remote`: Use the Remote Cache
 
-When an option is omitted, reading and writing are both disabled
+When an a caching source is omitted, reading and writing are both disabled.
 
-Each option must be followed by one of:
+Cache sources use the following values:
 
 - `rw`: Read and write
 - `r`: Read only
 - `w`: Write only
+- None (`local:`) : Does not use cache. Equivalent to omitting the cache source option.
 
 ```bash title="Terminal"
-# Read and write to local cache, read only to Remote Cache
+# Read from and write to local cache. Only read from Remote Cache.
 turbo run build --cache=local:rw,remote:r
 
-# Read-only to local cache, read write to Remote Cache
+# Only read from local cache. Read from and write to Remote Cache.
 turbo run build --cache=local:r,remote:rw
 
-# Read and write to local cache, no Remote Cache activity
+# Read from and write to local cache. No Remote Cache activity.
 turbo run build --cache=local:rw
+
+# Do not use local cache. Only read from Remote Cache.
+turbo run build --cache=local:,remote:r
 ```
 
 ### `--cache-dir <path>`


### PR DESCRIPTION
### Description

Makes the documentation for `--cache` more clear.

### Testing Instructions

👀 
