### PR TITLE
feat(mfe): allow @vercel/microfrontends to be considered a MFE package dependency

### DIFF
--- a/crates/turborepo-micro-frontend/src/lib.rs
+++ b/crates/turborepo-micro-frontend/src/lib.rs
@@ -13,8 +13,13 @@ use turbopath::AbsoluteSystemPath;
 ///
 /// This is subject to change at any time.
 pub const DEFAULT_MICRO_FRONTENDS_CONFIG: &str = "micro-frontends.jsonc";
-pub const MICRO_FRONTENDS_PACKAGES: &[&str] = [MICRO_FRONTENDS_PACKAGE_INTERNAL].as_slice();
+pub const MICRO_FRONTENDS_PACKAGES: &[&str] = [
+    MICRO_FRONTENDS_PACKAGE_EXTERNAL,
+    MICRO_FRONTENDS_PACKAGE_INTERNAL,
+]
+.as_slice();
 pub const MICRO_FRONTENDS_PACKAGE_INTERNAL: &str = "@vercel/micro-frontends-internal";
+pub const MICRO_FRONTENDS_PACKAGE_EXTERNAL: &str = "@vercel/microfrontends";
 pub const SUPPORTED_VERSIONS: &[&str] = ["1"].as_slice();
 
 /// The minimal amount of information Turborepo needs to correctly start a local


### PR DESCRIPTION
### Description

This PR allows `@vercel/microfrontends` to be considered a MFE dependency in addition to `@vercel/micro-frontends-internal`.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
