### PR TITLE
fix(mfe): build either mfe package name

### DIFF
--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -12,7 +12,6 @@ use serde::{Deserialize, Serialize};
 use struct_iterable::Iterable;
 use turbopath::AbsoluteSystemPath;
 use turborepo_errors::Spanned;
-use turborepo_micro_frontend::MICRO_FRONTENDS_PACKAGE_INTERNAL;
 use turborepo_repository::package_graph::ROOT_PKG_NAME;
 use turborepo_unescape::UnescapedString;
 
@@ -611,7 +610,7 @@ impl TurboJson {
     }
 
     /// Adds a local proxy task to a workspace TurboJson
-    pub fn with_proxy(&mut self, needs_proxy_build: bool) {
+    pub fn with_proxy(&mut self, mfe_package_name: Option<&str>) {
         if self.extends.is_empty() {
             self.extends = Spanned::new(vec!["//".into()]);
         }
@@ -620,9 +619,9 @@ impl TurboJson {
             TaskName::from("proxy"),
             Spanned::new(RawTaskDefinition {
                 cache: Some(Spanned::new(false)),
-                depends_on: needs_proxy_build.then(|| {
+                depends_on: mfe_package_name.map(|mfe_package_name| {
                     Spanned::new(vec![Spanned::new(UnescapedString::from(format!(
-                        "{MICRO_FRONTENDS_PACKAGE_INTERNAL}#build"
+                        "{mfe_package_name}#build"
                     )))])
                 }),
                 ..Default::default()


### PR DESCRIPTION
### Description

Switch to no longer hardcode the MFE package name when making sure it is built before we attempt to start the proxy.

### Testing Instructions

Ran in repository with external MFE package name. Confirmed that it's build task was picked up.
