### PR TITLE
feat: update `eslint-config-turbo` to support ESLint Flat Config.

### DIFF
--- a/packages/eslint-config-turbo/flat/index.js
+++ b/packages/eslint-config-turbo/flat/index.js
@@ -1,0 +1,12 @@
+const plugin = require("eslint-plugin-turbo");
+
+module.exports = [
+  {
+    plugins: {
+      turbo: plugin,
+    },
+    rules: {
+      "turbo/no-undeclared-env-vars": "error",
+    },
+  },
+];

--- a/packages/eslint-config-turbo/index.js
+++ b/packages/eslint-config-turbo/index.js
@@ -1,3 +1,13 @@
+const plugin = require("eslint-plugin-turbo");
+
 module.exports = {
+  flat: {
+    plugins: {
+      turbo: plugin,
+    },
+    rules: {
+      "turbo/no-undeclared-env-vars": "error",
+    },
+  },
   extends: ["plugin:turbo/recommended"],
 };

--- a/packages/eslint-config-turbo/index.js
+++ b/packages/eslint-config-turbo/index.js
@@ -1,13 +1,5 @@
 const plugin = require("eslint-plugin-turbo");
 
 module.exports = {
-  flat: {
-    plugins: {
-      turbo: plugin,
-    },
-    rules: {
-      "turbo/no-undeclared-env-vars": "error",
-    },
-  },
   extends: ["plugin:turbo/recommended"],
 };

--- a/packages/eslint-config-turbo/index.js
+++ b/packages/eslint-config-turbo/index.js
@@ -1,5 +1,3 @@
-const plugin = require("eslint-plugin-turbo");
-
 module.exports = {
   extends: ["plugin:turbo/recommended"],
 };

--- a/packages/eslint-config-turbo/package.json
+++ b/packages/eslint-config-turbo/package.json
@@ -22,6 +22,10 @@
     "eslint-config"
   ],
   "main": "index.js",
+  "exports": {
+    "./flat": "./flat/index.js",
+    ".": "./index.js"
+  },
   "author": "Vercel",
   "dependencies": {
     "eslint-plugin-turbo": "workspace:*"


### PR DESCRIPTION
### Description

Adds ESLint Flat Config Support to `eslint-config-turbo`. Users will be able to use:
```
import turboConfig from "eslint-config-turbo/flat"

export default [
  ...turboConfig
]
```

This is meant to be backwards compatible with ESLint v8, leaving the `extends` key in place for that purpose.

### Testing Instructions

Difficult to test this, so we'll be cutting a canary shortly after to make sure.