### PR TITLE
feat: sibling tasks

### DIFF
--- a/crates/turborepo-errors/src/lib.rs
+++ b/crates/turborepo-errors/src/lib.rs
@@ -177,7 +177,8 @@ impl<T> Spanned<T> {
         }
     }
 
-    pub fn inner_mut(&mut self) -> &mut T {
+    /// Gets a mutable ref to the inner value
+    pub fn as_inner_mut(&mut self) -> &mut T {
         &mut self.value
     }
 }

--- a/crates/turborepo-errors/src/lib.rs
+++ b/crates/turborepo-errors/src/lib.rs
@@ -176,6 +176,10 @@ impl<T> Spanned<T> {
             text: self.text,
         }
     }
+
+    pub fn inner_mut(&mut self) -> &mut T {
+        &mut self.value
+    }
 }
 
 impl<T> Spanned<Option<T>> {

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -395,6 +395,19 @@ impl<'a> EngineBuilder<'a> {
                     }
                 });
 
+            for (sibling, span) in task_definition
+                .siblings
+                .iter()
+                .flatten()
+                .map(|s| s.as_ref().split())
+            {
+                let sibling_task_id = sibling
+                    .task_id()
+                    .unwrap_or_else(|| TaskId::new(to_task_id.package(), sibling.task()))
+                    .into_owned();
+                traversal_queue.push_back(span.to(sibling_task_id));
+            }
+
             for (dep, span) in deps {
                 let from_task_id = dep
                     .task_id()
@@ -1329,6 +1342,45 @@ mod test {
             "app1#special" => ["libA#build"],
             "app2#another" => ["libA#build"],
             "libA#build" => ["___ROOT___"]
+        };
+        assert_eq!(all_dependencies(&engine), expected);
+    }
+
+    #[test]
+    fn test_sibling_task() {
+        let repo_root_dir = TempDir::with_prefix("repo").unwrap();
+        let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
+        let package_graph = mock_package_graph(
+            &repo_root,
+            package_jsons! {
+                repo_root,
+                "web" => [],
+                "api" => []
+            },
+        );
+        let turbo_jsons = vec![(PackageName::Root, {
+            let mut t_json = turbo_json(json!({
+                "tasks": {
+                    "web#dev": { "persistent": true },
+                    "api#serve": { "persistent": true }
+                }
+            }));
+            let a_dev = t_json.tasks.get_mut(&TaskName::from("web#dev")).unwrap();
+            a_dev.inner_mut().with_sibling("api#serve");
+            t_json
+        })]
+        .into_iter()
+        .collect();
+        let loader = TurboJsonLoader::noop(turbo_jsons);
+        let engine = EngineBuilder::new(&repo_root, &package_graph, loader, false)
+            .with_tasks(Some(Spanned::new(TaskName::from("dev"))))
+            .with_workspaces(vec![PackageName::from("web")])
+            .build()
+            .unwrap();
+
+        let expected = deps! {
+            "web#dev" => ["___ROOT___"],
+            "api#serve" => ["___ROOT___"]
         };
         assert_eq!(all_dependencies(&engine), expected);
     }

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -1365,8 +1365,7 @@ mod test {
                     "api#serve": { "persistent": true }
                 }
             }));
-            let a_dev = t_json.tasks.get_mut(&TaskName::from("web#dev")).unwrap();
-            a_dev.as_inner_mut().with_sibling("api#serve");
+            t_json.with_sibling(TaskName::from("web#dev"), &TaskName::from("api#serve"));
             t_json
         })]
         .into_iter()

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -1366,7 +1366,7 @@ mod test {
                 }
             }));
             let a_dev = t_json.tasks.get_mut(&TaskName::from("web#dev")).unwrap();
-            a_dev.inner_mut().with_sibling("api#serve");
+            a_dev.as_inner_mut().with_sibling("api#serve");
             t_json
         })]
         .into_iter()

--- a/crates/turborepo-lib/src/micro_frontends.rs
+++ b/crates/turborepo-lib/src/micro_frontends.rs
@@ -3,14 +3,21 @@ use std::collections::{HashMap, HashSet};
 use itertools::Itertools;
 use tracing::warn;
 use turbopath::AbsoluteSystemPath;
-use turborepo_micro_frontend::{Config as MFEConfig, Error, DEFAULT_MICRO_FRONTENDS_CONFIG};
+use turborepo_micro_frontend::{
+    Config as MFEConfig, Error, DEFAULT_MICRO_FRONTENDS_CONFIG, MICRO_FRONTENDS_PACKAGES,
+};
 use turborepo_repository::package_graph::{PackageGraph, PackageName};
 
-use crate::run::task_id::TaskId;
+use crate::{
+    config,
+    run::task_id::{TaskId, TaskName},
+    turbo_json::TurboJson,
+};
 
 #[derive(Debug, Clone)]
 pub struct MicroFrontendsConfigs {
     configs: HashMap<String, HashSet<TaskId<'static>>>,
+    mfe_package: Option<&'static str>,
 }
 
 impl MicroFrontendsConfigs {
@@ -45,7 +52,23 @@ impl MicroFrontendsConfigs {
             configs.insert(package_name.to_string(), tasks);
         }
 
-        Ok((!configs.is_empty()).then_some(Self { configs }))
+        let mfe_package = package_graph
+            .packages()
+            .map(|(pkg, _)| pkg.as_str())
+            .sorted()
+            // We use `find_map` here instead of a simple `find` so we get the &'static str
+            // instead of the &str tied to the lifetime of the package graph.
+            .find_map(|pkg| {
+                MICRO_FRONTENDS_PACKAGES
+                    .iter()
+                    .find(|static_pkg| pkg == **static_pkg)
+            })
+            .copied();
+
+        Ok((!configs.is_empty()).then_some(Self {
+            configs,
+            mfe_package,
+        }))
     }
 
     pub fn contains_package(&self, package_name: &str) -> bool {
@@ -66,26 +89,177 @@ impl MicroFrontendsConfigs {
             .any(|dev_tasks| dev_tasks.contains(task_id))
     }
 
-    /// Returns the proxy task for a given package in a MFE
-    pub fn package_mfe_proxy(&self, package_name: &PackageName) -> Option<DevTaskAndProxy> {
-        self.configs
-            .iter()
-            // Find the MFE this package belongs to
-            .find_map(|(pkg_with_proxy, dev_tasks)| {
-                dev_tasks.iter().find_map(|dev_task| {
-                    (dev_task.package() == package_name.as_str())
-                        .then_some((pkg_with_proxy, dev_task))
+    pub fn update_turbo_json(
+        &self,
+        package_name: &PackageName,
+        turbo_json: Result<TurboJson, config::Error>,
+    ) -> Result<TurboJson, config::Error> {
+        // If package either
+        // - contains the proxy task
+        // - a member of one of the microfrontends
+        // then we need to modify it's task definitions
+        if let Some(FindResult { dev, proxy }) = self.package_turbo_json_update(package_name) {
+            // We need to modify turbo.json, use default one if there isn't one present
+            let mut turbo_json = turbo_json.or_else(|err| match err {
+                config::Error::NoTurboJSON => Ok(TurboJson::default()),
+                err => Err(err),
+            })?;
+
+            // If the current package contains the proxy task, then add that definition
+            if proxy.package() == package_name.as_str() {
+                turbo_json.with_proxy(self.mfe_package);
+            }
+
+            if let Some(dev) = dev {
+                // If this package has a dev task that's part of the MFE, then we make sure the
+                // proxy gets included in the task graph.
+                turbo_json.with_sibling(
+                    TaskName::from(dev.task()).into_owned(),
+                    &proxy.as_task_name(),
+                );
+            }
+
+            Ok(turbo_json)
+        } else {
+            turbo_json
+        }
+    }
+
+    fn package_turbo_json_update<'a>(
+        &'a self,
+        package_name: &PackageName,
+    ) -> Option<FindResult<'a>> {
+        self.configs().find_map(|(config, tasks)| {
+            let dev_task = tasks.iter().find_map(|task| {
+                (task.package() == package_name.as_str()).then(|| FindResult {
+                    dev: Some(task.as_borrowed()),
+                    proxy: TaskId::new(config, "proxy"),
                 })
-            })
-            // Return package's dev task with it's proxy task
-            .map(|(pkg_with_proxy, dev_task)| DevTaskAndProxy {
-                dev: dev_task.as_borrowed(),
-                proxy: TaskId::new(pkg_with_proxy, "proxy"),
-            })
+            });
+            let proxy_owner = (config.as_str() == package_name.as_str()).then(|| FindResult {
+                dev: None,
+                proxy: TaskId::new(config, "proxy"),
+            });
+            dev_task.or(proxy_owner)
+        })
     }
 }
 
-pub struct DevTaskAndProxy<'a> {
-    pub dev: TaskId<'a>,
-    pub proxy: TaskId<'a>,
+#[derive(Debug, PartialEq, Eq)]
+struct FindResult<'a> {
+    dev: Option<TaskId<'a>>,
+    proxy: TaskId<'a>,
+}
+
+#[cfg(test)]
+mod test {
+    use test_case::test_case;
+
+    use super::*;
+
+    macro_rules! mfe_configs {
+        {$($config_owner:expr => $dev_tasks:expr),+} => {
+            {
+                let mut _map = std::collections::HashMap::new();
+                $(
+                    let mut _dev_tasks = std::collections::HashSet::new();
+                    for _dev_task in $dev_tasks.as_slice() {
+                        _dev_tasks.insert(crate::run::task_id::TaskName::from(*_dev_task).task_id().unwrap().into_owned());
+                    }
+                    _map.insert($config_owner.to_string(), _dev_tasks);
+                )+
+                _map
+            }
+        };
+    }
+
+    struct PackageUpdateTest {
+        package_name: &'static str,
+        result: Option<TestFindResult>,
+    }
+
+    struct TestFindResult {
+        dev: Option<&'static str>,
+        proxy: &'static str,
+    }
+
+    impl PackageUpdateTest {
+        pub const fn new(package_name: &'static str) -> Self {
+            Self {
+                package_name,
+                result: None,
+            }
+        }
+
+        pub const fn dev(mut self, dev: &'static str, proxy: &'static str) -> Self {
+            self.result = Some(TestFindResult {
+                dev: Some(dev),
+                proxy,
+            });
+            self
+        }
+
+        pub const fn proxy_only(mut self, proxy: &'static str) -> Self {
+            self.result = Some(TestFindResult { dev: None, proxy });
+            self
+        }
+
+        pub fn package_name(&self) -> PackageName {
+            PackageName::from(self.package_name)
+        }
+
+        pub fn expected(&self) -> Option<FindResult> {
+            match self.result {
+                Some(TestFindResult {
+                    dev: Some(dev),
+                    proxy,
+                }) => Some(FindResult {
+                    dev: Some(Self::str_to_task(dev)),
+                    proxy: Self::str_to_task(proxy),
+                }),
+                Some(TestFindResult { dev: None, proxy }) => Some(FindResult {
+                    dev: None,
+                    proxy: Self::str_to_task(proxy),
+                }),
+                None => None,
+            }
+        }
+
+        fn str_to_task(s: &str) -> TaskId<'static> {
+            crate::run::task_id::TaskName::from(s)
+                .task_id()
+                .unwrap()
+                .into_owned()
+        }
+    }
+
+    const NON_MFE_PKG: PackageUpdateTest = PackageUpdateTest::new("other-pkg");
+    const MFE_CONFIG_PKG: PackageUpdateTest =
+        PackageUpdateTest::new("mfe-config-pkg").proxy_only("mfe-config-pkg#proxy");
+    const MFE_CONFIG_PKG_DEV_TASK: PackageUpdateTest =
+        PackageUpdateTest::new("web").dev("web#dev", "mfe-config-pkg#proxy");
+    const DEFAULT_APP_PROXY: PackageUpdateTest =
+        PackageUpdateTest::new("mfe-docs").dev("mfe-docs#serve", "mfe-web#proxy");
+    const DEFAULT_APP_PROXY_AND_DEV: PackageUpdateTest =
+        PackageUpdateTest::new("mfe-web").dev("mfe-web#dev", "mfe-web#proxy");
+
+    #[test_case(NON_MFE_PKG)]
+    #[test_case(MFE_CONFIG_PKG)]
+    #[test_case(MFE_CONFIG_PKG_DEV_TASK)]
+    #[test_case(DEFAULT_APP_PROXY)]
+    #[test_case(DEFAULT_APP_PROXY_AND_DEV)]
+    fn test_package_turbo_json_update(test: PackageUpdateTest) {
+        let configs = mfe_configs!(
+            "mfe-config-pkg" => ["web#dev", "docs#dev"],
+            "mfe-web" => ["mfe-web#dev", "mfe-docs#serve"]
+        );
+        let mfe = MicroFrontendsConfigs {
+            configs,
+            mfe_package: None,
+        };
+        assert_eq!(
+            mfe.package_turbo_json_update(&test.package_name()),
+            test.expected()
+        );
+    }
 }

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -6,7 +6,6 @@ use std::{
 };
 
 use chrono::Local;
-use itertools::Itertools;
 use tracing::debug;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_analytics::{start_analytics, AnalyticsHandle, AnalyticsSender};
@@ -38,7 +37,6 @@ use {
     },
 };
 
-use super::task_id::TaskId;
 use crate::{
     cli::DryRunMode,
     commands::CommandBase,

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -438,7 +438,6 @@ impl RunBuilder {
             &root_turbo_json,
             filtered_pkgs.keys(),
             turbo_json_loader.clone(),
-            micro_frontend_configs.as_ref(),
         )?;
 
         if self.opts.run_opts.parallel {
@@ -448,7 +447,6 @@ impl RunBuilder {
                 &root_turbo_json,
                 filtered_pkgs.keys(),
                 turbo_json_loader,
-                micro_frontend_configs.as_ref(),
             )?;
         }
 
@@ -500,52 +498,11 @@ impl RunBuilder {
         root_turbo_json: &TurboJson,
         filtered_pkgs: impl Iterator<Item = &'a PackageName>,
         turbo_json_loader: TurboJsonLoader,
-        micro_frontends_configs: Option<&MicroFrontendsConfigs>,
     ) -> Result<Engine, Error> {
-        let mut tasks = self
-            .opts
-            .run_opts
-            .tasks
-            .iter()
-            .map(|task| {
-                // TODO: Pull span info from command
-                Spanned::new(TaskName::from(task.as_str()).into_owned())
-            })
-            .collect::<Vec<_>>();
-        let mut workspace_packages = filtered_pkgs.cloned().collect::<Vec<_>>();
-        if let Some(micro_frontends_configs) = micro_frontends_configs {
-            // TODO: this logic is very similar to what happens inside engine builder and
-            // could probably be exposed
-            let tasks_from_filter = workspace_packages
-                .iter()
-                .map(|package| package.as_str())
-                .cartesian_product(tasks.iter())
-                .map(|(package, task)| {
-                    task.task_id().map_or_else(
-                        || TaskId::new(package, task.task()).into_owned(),
-                        |task_id| task_id.into_owned(),
-                    )
-                })
-                .collect::<HashSet<_>>();
-            // we need to add the MFE config packages into the scope here to make sure the
-            // proxy gets run
-            // TODO(olszewski): We are relying on the fact that persistent tasks must be
-            // entry points to the task graph so we can get away with only
-            // checking the entrypoint tasks.
-            for (mfe_config_package, dev_tasks) in micro_frontends_configs.configs() {
-                for dev_task in dev_tasks {
-                    if tasks_from_filter.contains(dev_task) {
-                        workspace_packages.push(PackageName::from(mfe_config_package.as_str()));
-                        tasks.push(Spanned::new(
-                            TaskId::new(mfe_config_package, "proxy")
-                                .as_task_name()
-                                .into_owned(),
-                        ));
-                        break;
-                    }
-                }
-            }
-        }
+        let tasks = self.opts.run_opts.tasks.iter().map(|task| {
+            // TODO: Pull span info from command
+            Spanned::new(TaskName::from(task.as_str()).into_owned())
+        });
         let mut builder = EngineBuilder::new(
             &self.repo_root,
             pkg_dep_graph,
@@ -554,7 +511,7 @@ impl RunBuilder {
         )
         .with_root_tasks(root_turbo_json.tasks.keys().cloned())
         .with_tasks_only(self.opts.run_opts.only)
-        .with_workspaces(workspace_packages)
+        .with_workspaces(filtered_pkgs.cloned().collect())
         .with_tasks(tasks);
 
         if self.add_all_tasks {

--- a/crates/turborepo-lib/src/run/summary/task.rs
+++ b/crates/turborepo-lib/src/run/summary/task.rs
@@ -284,6 +284,7 @@ impl From<TaskDefinition> for TaskSummaryTaskDefinition {
             interruptible,
             interactive,
             env_mode,
+            siblings: _,
         } = value;
 
         let mut outputs = inclusions;

--- a/crates/turborepo-lib/src/run/task_id.rs
+++ b/crates/turborepo-lib/src/run/task_id.rs
@@ -1,4 +1,7 @@
-use std::{borrow::Cow, fmt};
+use std::{
+    borrow::{Borrow, Cow},
+    fmt,
+};
 
 use serde::{Deserialize, Serialize};
 use turborepo_repository::package_graph::{PackageName, ROOT_PKG_NAME};
@@ -125,6 +128,14 @@ impl<'a> TaskId<'a> {
             task: static_cow(task),
         }
     }
+
+    /// Borrows a TaskId reference as a TaskId
+    pub fn as_borrowed(&self) -> TaskId {
+        let TaskId { package, task } = self;
+        let package = shorten_cow(package);
+        let task = shorten_cow(task);
+        TaskId { package, task }
+    }
 }
 
 impl<'a> TryFrom<&'a str> for TaskId<'a> {
@@ -168,6 +179,16 @@ fn static_cow<'a, T: 'a + ToOwned + ?Sized>(cow: Cow<'a, T>) -> Cow<'static, T> 
     match cow {
         Cow::Borrowed(x) => Cow::Owned(x.to_owned()),
         Cow::Owned(x) => Cow::Owned(x),
+    }
+}
+
+// Utility method for changing &'a Cow<'b, T> to Cow<'a, T>
+// 'b must outlive 'a
+#[allow(clippy::ptr_arg)]
+fn shorten_cow<'a, 'b: 'a, T: ToOwned + ?Sized>(cow: &'a Cow<'b, T>) -> Cow<'a, T> {
+    match cow {
+        Cow::Borrowed(x) => Cow::Borrowed(x),
+        Cow::Owned(x) => Cow::Borrowed(x.borrow()),
     }
 }
 

--- a/crates/turborepo-lib/src/task_graph/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/mod.rs
@@ -90,6 +90,12 @@ pub struct TaskDefinition {
 
     // Override for global env mode setting
     pub env_mode: Option<EnvMode>,
+
+    // Tasks that will get added to the graph if this one is
+    // It contains no guarantees regarding ordering, just that this will also get run.
+    // It will also not affect the task's hash aside from the definition getting folded into the
+    // hash.
+    pub siblings: Option<Vec<Spanned<TaskName<'static>>>>,
 }
 
 impl Default for TaskDefinition {
@@ -107,6 +113,7 @@ impl Default for TaskDefinition {
             interruptible: Default::default(),
             interactive: Default::default(),
             env_mode: Default::default(),
+            siblings: Default::default(),
         }
     }
 }

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -652,6 +652,22 @@ impl TurboJson {
             }),
         );
     }
+
+    /// Adds a sibling relationship from task to sibling
+    pub fn with_sibling(&mut self, task: TaskName<'static>, sibling: &TaskName) {
+        if self.extends.is_empty() {
+            self.extends = Spanned::new(vec!["//".into()]);
+        }
+
+        let task_definition = self.tasks.entry(task).or_default();
+
+        let siblings = task_definition
+            .as_inner_mut()
+            .siblings
+            .get_or_insert_default();
+
+        siblings.push(Spanned::new(UnescapedString::from(sibling.to_string())))
+    }
 }
 
 type TurboJSONValidation = fn(&TurboJson) -> Vec<Error>;


### PR DESCRIPTION
### Description

This PR does 2 things:
 - Adds a `sibling` attribute for task definitions that has the ability to bring another task into the graph without depending on it. This is currently only an attribute that can be set by us inside Rust, but I hope this use case proves useful enough to eventually make this a public API.
 - Switches MFE proxy injection over to use `siblings` where each dev task gets a `"siblings": ["mfe-pkg#proxy"]` to ensure the proxy gets run.

A sibling relationship acts similar to `dependsOn` except that it will not wait for the task to exit before starting and the sibling's task hash will not affect the current task's hash.

Currently it's very hard to get `web#proxy` to run if the user runs a command like `turbo dev --filter=docs` as just adding `web` to the filter will mean `web#dev` gets picked up which isn't what we desire. As you can see in `run/builder.rs` this also removes the need of microfrontend knowledge from building the task graph.

### Testing Instructions

Added unit tests for sibling behavior as well as unit tests for MFE task injection.

Manual testing for the MFE behavior to make sure proxy still gets picked up.
