### PR TITLE
refactor(tui): cleanup where Vim binds were added.

### DIFF
--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -76,9 +76,6 @@ fn translate_key_event(options: InputOptions, key_event: KeyEvent) -> Option<Eve
         _ if matches!(options.focus, LayoutSections::Pane) => Some(Event::Input {
             bytes: encode_key(key_event),
         }),
-        // Vim keybinds
-        KeyCode::Char('j') => Some(Event::Down),
-        KeyCode::Char('k') => Some(Event::Up),
         // If we're on the list and user presses `/` enter search mode
         KeyCode::Char('/') if matches!(options.focus, LayoutSections::TaskList) => {
             Some(Event::SearchEnter)
@@ -115,8 +112,8 @@ fn translate_key_event(options: InputOptions, key_event: KeyEvent) -> Option<Eve
         KeyCode::Char('n') if key_event.modifiers == KeyModifiers::CONTROL => {
             Some(Event::ScrollDown)
         }
-        KeyCode::Up => Some(Event::Up),
-        KeyCode::Down => Some(Event::Down),
+        KeyCode::Up | KeyCode::Char('j') => Some(Event::Up),
+        KeyCode::Down | KeyCode::Char('k') => Some(Event::Down),
         KeyCode::Enter | KeyCode::Char('i') => Some(Event::EnterInteractive),
         _ => None,
     }


### PR DESCRIPTION
### Description

In #9243, we added these keybinds for Vim. This refactors to put them in an `|` OR and into the section that is for fallthroughs of interactive mode.

### Testing Instructions

Try it out!
