### PR TITLE
docs: fix formatting on `/repo/docs/getting-started/installation`

### DIFF
--- a/docs/repo-docs/getting-started/installation.mdx
+++ b/docs/repo-docs/getting-started/installation.mdx
@@ -135,7 +135,7 @@ npx create-turbo@latest --example [example-name]
 
 npx create-turbo@latest --example [github-url]
 
-````
+```
 
 </Tab>
 
@@ -146,7 +146,7 @@ yarn dlx create-turbo@latest --example [example-name]
 
 # Use a GitHub repository from the community
 yarn dlx create-turbo@latest --example [github-url]
-````
+```
 
 </Tab>
 


### PR DESCRIPTION
Fixes https://vercel.com/vercel/turbo-site/7YWCRzojaypxXMLNjRcpqWzWUSP1?filter=errors