### PR TITLE
chore: fix error message when PR title does not conform to pattern

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -30,4 +30,4 @@ jobs:
           # The variables `subject` and `title` can be used within the message.
           subjectPatternError: |
             The subject "{subject}" found in the pull request title "{title}" doesn't match the configured pattern.
-            Please ensure that the subject doesn't start with a lowercase character.
+            Please ensure that the subject doesn't start with an uppercase character.


### PR DESCRIPTION
Pattern is `^[^A-Z].*$ ` which means the string can't start with uppercase. The message was saying the opposite ("doesn't start with a lowercase character).

