### PR TITLE
fix(env): add DISPLAY to default pass through

### DIFF
--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -480,6 +480,7 @@ impl<'a> TaskHasher<'a> {
                         "COLORTERM",
                         "TERM",
                         "TERM_PROGRAM",
+                        "DISPLAY",
                         "TMP",
                         "TEMP",
                         // VSCode IDE - https://github.com/microsoft/vscode-js-debug/blob/5b0f41dbe845d693a541c1fae30cec04c878216f/src/targets/node/nodeLauncherBase.ts#L320


### PR DESCRIPTION
### Description

Closes #9402 by adding `DISPLAY` to the default pass through map. TL;DR `xdg-open` uses `DISPLAY` to decide which display it should open a new window on.

### Testing Instructions

👀 
