### PR TITLE
fix(examples): remove `--filter` from `with-docker` example.

### DIFF
--- a/docs/repo-docs/guides/tools/docker.mdx
+++ b/docs/repo-docs/guides/tools/docker.mdx
@@ -167,7 +167,7 @@ RUN yarn install
 
 # Build the project
 COPY --from=builder /app/out/full/ .
-RUN yarn turbo run build --filter=web...
+RUN yarn turbo run build
 
 FROM base AS runner
 WORKDIR /app
@@ -201,7 +201,7 @@ ENV TURBO_TEAM=$TURBO_TEAM
 ARG TURBO_TOKEN
 ENV TURBO_TOKEN=$TURBO_TOKEN
 
-RUN yarn turbo run build --filter=web...
+RUN yarn turbo run build
 ```
 
 `turbo` will now be able to hit your Remote Cache. To see a Turborepo cache hit for a non-cached Docker build image, run a command like this one from your project root:

--- a/examples/with-docker/apps/api/Dockerfile
+++ b/examples/with-docker/apps/api/Dockerfile
@@ -33,7 +33,7 @@ COPY --from=builder /app/out/full/ .
 # ARG TURBO_TOKEN
 # ENV TURBO_TOKEN=$TURBO_TOKEN
 
-RUN yarn turbo build --filter=api...
+RUN yarn turbo build
 
 FROM base AS runner
 WORKDIR /app

--- a/examples/with-docker/apps/web/Dockerfile
+++ b/examples/with-docker/apps/web/Dockerfile
@@ -33,7 +33,7 @@ COPY --from=builder /app/out/full/ .
 # ARG TURBO_TOKEN
 # ENV TURBO_TOKEN=$TURBO_TOKEN
 
-RUN yarn turbo build --filter=web...
+RUN yarn turbo build
 
 FROM base AS runner
 WORKDIR /app


### PR DESCRIPTION
### Description

`--filter` isn't needed after running `prune` since the target from the prune is the only application in the pruned workspace. This was confusing someone in https://github.com/vercel/turborepo/discussions/9496.
