### PR TITLE
docs: fix formatting on `/repo/docs/getting-started/installation`

### DIFF
--- a/docs/repo-docs/getting-started/installation.mdx
+++ b/docs/repo-docs/getting-started/installation.mdx
@@ -168,4 +168,3 @@ pnpm dlx create-turbo@latest --example [github-url]
 Use any of the example's names below:
 
 <ExamplesTable />
-```


### PR DESCRIPTION
Missed to fix https://github.com/vercel/turborepo/pull/9507/files#diff-3f884df65d3c1a26abe6957ac9f5a6adc0ca987eda48efb9a78ebcc931b846e0R171 in  https://github.com/vercel/turborepo/pull/9509/