### PR TITLE
chore(docs): enable hashlinking for System Environment Variables entries

### DIFF
--- a/docs/repo-docs/reference/system-environment-variables.mdx
+++ b/docs/repo-docs/reference/system-environment-variables.mdx
@@ -9,37 +9,320 @@ By setting certain environment variables, you can change Turborepo's behavior. T
 
 System environment variables are always overridden by flag values provided directly to your `turbo` commands.
 
-| Variable                                          | Description                                                                                                                                                                                                                                                                                          |
-| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `TURBO_API`                                       | Set the base URL for [Remote Cache](/repo/docs/core-concepts/remote-caching).                                                                                                                                                                                                                        |
-| `TURBO_BINARY_PATH`                               | Manually set the path to the `turbo` binary. By default, `turbo` will automatically discover the binary so you should only use this in rare circumstances.                                                                                                                                           |
-| `TURBO_CACHE`                                     | Control reading and writing for cache sources. Uses the same syntax as [`--cache`](/repo/docs/reference/run#--cache-options).                                                                                                                                                                        |
-| `TURBO_CACHE_DIR`                                 | Sets the cache directory, similar to using [`--cache-dir`](/repo/docs/reference/run#--cache-dir-path) flag                                                                                                                                                                                           |
-| `TURBO_CI_VENDOR_ENV_KEY`                         | Set a prefix for environment variables that you want **excluded** from [Framework Inference](/repo/docs/crafting-your-repository/using-environment-variables#framework-inference). **NOTE**: This does not need to be set by the user and should be configured automatically by supported platforms. |
-| `TURBO_DANGEROUSLY_DISABLE_PACKAGE_MANAGER_CHECK` | Disable checking the `packageManager` field in `package.json`. You may run into [errors and unexpected caching behavior](/repo/docs/reference/run#--dangerously-disable-package-manager-check) when disabling this check. Use `true` or `1` to disable.                                              |
-| `TURBO_DOWNLOAD_LOCAL_ENABLED`                    | Enables global `turbo` to install the correct local version if one is not found.                                                                                                                                                                                                                     |
-| `TURBO_FORCE`                                     | Set to `true` to force all tasks to run in full, opting out of all caching.                                                                                                                                                                                                                          |
-| `TURBO_GLOBAL_WARNING_DISABLED`                   | Disable warning when global `turbo` cannot find a local version to use.                                                                                                                                                                                                                              |
-| `TURBO_PRINT_VERSION_DISABLED`                    | Disable printing the version of `turbo` that is being executed.                                                                                                                                                                                                                                      |
-| `TURBO_LOG_ORDER`                                 | Set the [log order](/repo/docs/reference/run#--log-order-option). Allowed values are `grouped` and `default`.                                                                                                                                                                                        |
-| `TURBO_LOGIN`                                     | Set the URL used to log in to [Remote Cache](/repo/docs/core-concepts/remote-caching).                                                                                                                                                                                                               |
-| `TURBO_NO_UPDATE_NOTIFIER`                        | Remove the update notifier that appears when a new version of `turbo` is available. You can also use `NO_UPDATE_NOTIFIER` per ecosystem convention.                                                                                                                                                  |
-| `TURBO_PLATFORM_ENV`                              | A CSV of environment variable keys that are configured in a supported CI environment (Vercel). **NOTE**: This does not need to be set by the user and should be configured automatically by supported platforms.                                                                                     |
-| `TURBO_PLATFORM_ENV_DISABLED`                     | Disable checking environment variables configured in your `turbo.json` against those set on your supported platform                                                                                                                                                                                  |
-| `TURBO_PREFLIGHT`                                 | Enables sending a preflight request before every cache artifact and analytics request. The follow-up upload and download will follow redirects. Only applicable when [Remote Caching](/repo/docs/core-concepts/remote-caching) is configured.                                                        |
-| `TURBO_REMOTE_CACHE_READ_ONLY`                    | Prevent writing to the [Remote Cache](/repo/docs/core-concepts/remote-caching) - but still allow reading.                                                                                                                                                                                            |
-| `TURBO_REMOTE_CACHE_SIGNATURE_KEY`                | Sign artifacts with a secret key. For more information, visit [the Artifact Integrity section](/repo/docs/core-concepts/remote-caching#artifact-integrity-and-authenticity-verification).                                                                                                            |
-| `TURBO_REMOTE_CACHE_TIMEOUT`                      | Set a timeout in seconds for `turbo` to get artifacts from [Remote Cache](/repo/docs/core-concepts/remote-caching).                                                                                                                                                                                  |
-| `TURBO_REMOTE_CACHE_UPLOAD_TIMEOUT`               | Set a timeout in seconds for `turbo` to upload artifacts to [Remote Cache](/repo/docs/core-concepts/remote-caching).                                                                                                                                                                                 |
-| `TURBO_REMOTE_ONLY`                               | Always ignore the local filesystem cache for all tasks.                                                                                                                                                                                                                                              |
-| `TURBO_RUN_SUMMARY`                               | Generate a [Run Summary](/repo/docs/reference/run#--summarize) when you run tasks.                                                                                                                                                                                                                   |
-| `TURBO_SCM_BASE`                                  | Base used by `--affected` when calculating what has changed from `base...head`                                                                                                                                                                                                                       |
-| `TURBO_SCM_HEAD`                                  | Head used by `--affected` when calculating what has changed from `base...head`                                                                                                                                                                                                                       |
-| `TURBO_TEAM`                                      | The account name associated with your repository. When using [Vercel Remote Cache](https://vercel.com/docs/monorepos/remote-caching#vercel-remote-cache), this is your team's slug.                                                                                                                  |
-| `TURBO_TEAMID`                                    | The account identifier associated with your repository. When using [Vercel Remote Cache](https://vercel.com/docs/monorepos/remote-caching#vercel-remote-cache), this is your team's ID.                                                                                                              |
-| `TURBO_TELEMETRY_MESSAGE_DISABLED`                | Disable the message notifying you that [Telemetry](/repo/docs/telemetry) is enabled.                                                                                                                                                                                                                 |
-| `TURBO_TOKEN`                                     | The Bearer token for authentication to access [Remote Cache](/repo/docs/core-concepts/remote-caching).                                                                                                                                                                                               |
-| `TURBO_UI`                                        | Enables TUI when passed true or 1, disables when passed false or 0.                                                                                                                                                                                                                                  |
+<table id="system-environment-variables-table">
+  <thead>
+    <tr>
+      <th>Variable</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr id="turbo_api">
+      <td>
+        <code>TURBO_API</code>
+      </td>
+      <td>
+        Set the base URL for{' '}
+        <a href="/repo/docs/core-concepts/remote-caching">Remote Cache</a>.
+      </td>
+    </tr>
+    <tr id="turbo_binary_path">
+      <td>
+        <code>
+          <code>TURBO_BINARY_PATH</code>
+        </code>
+      </td>
+      <td>
+        Manually set the path to the <code>turbo</code> binary. By default,{' '}
+        <code>turbo</code> will automatically discover the binary so you should
+        only use this in rare circumstances.
+      </td>
+    </tr>
+    <tr id="turbo_cache">
+      <td>
+        <code>
+          <code>TURBO_CACHE</code>
+        </code>
+      </td>
+      <td>
+        Control reading and writing for cache sources. Uses the same syntax as{' '}
+        <a href="/repo/docs/reference/run#--cache-options">
+          <code>--cache</code>
+        </a>
+        .
+      </td>
+    </tr>
+    <tr id="turbo_cache_dir">
+      <td>
+        <code>TURBO_CACHE_DIR</code>
+      </td>
+      <td>
+        Sets the cache directory, similar to using{' '}
+        <a href="/repo/docs/reference/run#--cache-dir-path">
+          <code>--cache-dir</code>
+        </a>{' '}
+        flag
+      </td>
+    </tr>
+    <tr id="turbo_ci_vendor_env_key">
+      <td>
+        <code>TURBO_CI_VENDOR_ENV_KEY</code>
+      </td>
+      <td>
+        Set a prefix for environment variables that you want{' '}
+        <strong>excluded</strong> from{' '}
+        <a href="/repo/docs/crafting-your-repository/using-environment-variables#framework-inference">
+          Framework Inference
+        </a>
+        . <strong>NOTE</strong>: This does not need to be set by the user and should
+        be configured automatically by supported platforms.
+      </td>
+    </tr>
+    <tr id="turbo_dangerously_disable_package_manager_check">
+      <td>
+        <code>TURBO_DANGEROUSLY_DISABLE_PACKAGE_MANAGER_CHECK</code>
+      </td>
+      <td>
+        Disable checking the <code>packageManager</code> field in{' '}
+        <code>package.json</code>. You may run into{' '}
+        <a href="/repo/docs/reference/run#--dangerously-disable-package-manager-check">
+          errors and unexpected caching behavior
+        </a>{' '}
+        when disabling this check. Use <code>true</code> or <code>1</code> to
+        disable.
+      </td>
+    </tr>
+    <tr id="turbo_download_local_enabled">
+      <td>
+        <code>TURBO_DOWNLOAD_LOCAL_ENABLED</code>
+      </td>
+      <td>
+        Enables global <code>turbo</code> to install the correct local version
+        if one is not found.
+      </td>
+    </tr>
+    <tr id="turbo_force">
+      <td>
+        <code>TURBO_FORCE</code>
+      </td>
+      <td>
+        Set to <code>true</code> to force all tasks to run in full, opting out
+        of all caching.
+      </td>
+    </tr>
+    <tr id="turbo_global_warning_disabled">
+      <td>
+        <code>TURBO_GLOBAL_WARNING_DISABLED</code>
+      </td>
+      <td>
+        Disable warning when global <code>turbo</code> cannot find a local
+        version to use.
+      </td>
+    </tr>
+    <tr id="turbo_print_version_disabled">
+      <td>
+        <code>TURBO_PRINT_VERSION_DISABLED</code>
+      </td>
+      <td>
+        Disable printing the version of <code>turbo</code> that is being
+        executed.
+      </td>
+    </tr>
+    <tr id="turbo_log_order">
+      <td>
+        <code>TURBO_LOG_ORDER</code>
+      </td>
+      <td>
+        Set the{' '}
+        <a href="/repo/docs/reference/run#--log-order-option">log order</a>.
+        Allowed values are <code>grouped</code> and <code>default</code>.
+      </td>
+    </tr>
+    <tr id="turbo_login">
+      <td>
+        <code>TURBO_LOGIN</code>
+      </td>
+      <td>
+        Set the URL used to log in to{' '}
+        <a href="/repo/docs/core-concepts/remote-caching">Remote Cache</a>.
+      </td>
+    </tr>
+    <tr id="turbo_no_update_notifier">
+      <td>
+        <code>TURBO_NO_UPDATE_NOTIFIER</code>
+      </td>
+      <td>
+        Remove the update notifier that appears when a new version of{' '}
+        <code>turbo</code> is available. You can also use{' '}
+        <code>NO_UPDATE_NOTIFIER</code> per ecosystem convention.
+      </td>
+    </tr>
+    <tr id="turbo_platform_env">
+      <td>
+        <code>TURBO_PLATFORM_ENV</code>
+      </td>
+      <td>
+        A CSV of environment variable keys that are configured in a supported CI
+        environment (Vercel). <strong>NOTE</strong>: This variable is meant for
+        platforms looking to implement zero-configuration environment variables.
+        You are not meant to use this variable as an end user.{' '}
+      </td>
+    </tr>
+    <tr id="turbo_platform_env_disabled">
+      <td>
+        <code>TURBO_PLATFORM_ENV_DISABLED</code>
+      </td>
+      <td>
+        Disable checking environment variables configured in your{' '}
+        <code>turbo.json</code> against those set on your supported platform
+      </td>
+    </tr>
+    <tr id="turbo_preflight">
+      <td>
+        <code>TURBO_PREFLIGHT</code>
+      </td>
+      <td>
+        Enables sending a preflight request before every cache artifact and
+        analytics request. The follow-up upload and download will follow
+        redirects. Only applicable when{' '}
+        <a href="/repo/docs/core-concepts/remote-caching">Remote Caching</a> is
+        configured.
+      </td>
+    </tr>
+    <tr id="turbo_remote_cache_read_only">
+      <td>
+        <code>TURBO_REMOTE_CACHE_READ_ONLY</code>
+      </td>
+      <td>
+        Prevent writing to the{' '}
+        <a href="/repo/docs/core-concepts/remote-caching">Remote Cache</a> - but
+        still allow reading.
+      </td>
+    </tr>
+    <tr id="turbo_remote_cache_signature_key">
+      <td>
+        <code>TURBO_REMOTE_CACHE_SIGNATURE_KEY</code>
+      </td>
+      <td>
+        Sign artifacts with a secret key. For more information, visit{' '}
+        <a href="/repo/docs/core-concepts/remote-caching#artifact-integrity-and-authenticity-verification">
+          the Artifact Integrity section
+        </a>
+        .
+      </td>
+    </tr>
+    <tr id="turbo_remote_cache_timeout">
+      <td>
+        <code>TURBO_REMOTE_CACHE_TIMEOUT</code>
+      </td>
+      <td>
+        Set a timeout in seconds for <code>turbo</code> to get artifacts from{' '}
+        <a href="/repo/docs/core-concepts/remote-caching">Remote Cache</a>.
+      </td>
+    </tr>
+    <tr id="turbo_remote_cache_upload_timeout">
+      <td>
+        <code>TURBO_REMOTE_CACHE_UPLOAD_TIMEOUT</code>
+      </td>
+      <td>
+        Set a timeout in seconds for <code>turbo</code> to upload artifacts to{' '}
+        <a href="/repo/docs/core-concepts/remote-caching">Remote Cache</a>.
+      </td>
+    </tr>
+    <tr id="turbo_remote_only">
+      <td>
+        <code>TURBO_REMOTE_ONLY</code>
+      </td>
+      <td>Always ignore the local filesystem cache for all tasks.</td>
+    </tr>
+    <tr>
+      <td>
+        <code>TURBO_RUN_SUMMARY</code>
+      </td>
+      <td>
+        Generate a{' '}
+        <a href="/repo/docs/reference/run#--summarize">Run Summary</a> when you
+        run tasks.
+      </td>
+    </tr>
+    <tr id="turbo_scm_base">
+      <td>
+        <code>TURBO_SCM_BASE</code>
+      </td>
+      <td>
+        Base used by <code>--affected</code> when calculating what has changed
+        from <code>base...head</code>
+      </td>
+    </tr>
+    <tr id="turbo_scm_head">
+      <td>
+        <code>TURBO_SCM_HEAD</code>
+      </td>
+      <td>
+        Head used by <code>--affected</code> when calculating what has changed
+        from <code>base...head</code>
+      </td>
+    </tr>
+    <tr id="turbo_team">
+      <td>
+        <code>TURBO_TEAM</code>
+      </td>
+      <td>
+        The account name associated with your repository. When using{' '}
+        <a
+          href="https://vercel.com/docs/monorepos/remote-caching#vercel-remote-cache"
+          rel="noreferrer noopener"
+          target="_blank"
+        >
+          Vercel Remote Cache
+        </a>
+        , this is your team's slug.
+      </td>
+    </tr>
+    <tr id="turbo_teamid">
+      <td>
+        <code>TURBO_TEAMID</code>
+      </td>
+      <td>
+        The account identifier associated with your repository. When using{' '}
+        <a
+          href="https://vercel.com/docs/monorepos/remote-caching#vercel-remote-cache"
+          rel="noreferrer noopener"
+          target="_blank"
+        >
+          Vercel Remote Cache
+        </a>
+        , this is your team's ID.
+      </td>
+    </tr>
+    <tr id="turbo_telemetry_message_disabled">
+      <td>
+        <code>TURBO_TELEMETRY_MESSAGE_DISABLED</code>
+      </td>
+      <td>
+        Disable the message notifying you that{' '}
+        <a href="/repo/docs/telemetry">Telemetry</a> is enabled.
+      </td>
+    </tr>
+    <tr id="turbo_token">
+      <td>
+        <code>TURBO_TOKEN</code>
+      </td>
+      <td>
+        The Bearer token for authentication to access{' '}
+        <a href="/repo/docs/core-concepts/remote-caching">Remote Cache</a>.
+      </td>
+    </tr>
+    <tr id="turbo_ui">
+      <td>
+        <code>TURBO_UI</code>
+      </td>
+      <td>
+        Enables TUI when passed true or 1, disables when passed false or 0.
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 ## Environment variables in tasks
 


### PR DESCRIPTION
### Description

Before, we were only able to link people to the page itself, and having them find the variable in the table itself.

Instead, let's put an `id` tag on things so we can give hashlinks to users.

### Testing Instructions

This should be a no-op on the visual rendering of the page, as I've pasted the rendered HTML from the page directly into the Markdown file. The only change is the addition of the `id`s. 