### PR TITLE
fix(codemod): comment tmpdir for package managers

### DIFF
--- a/packages/turbo-utils/src/managers.ts
+++ b/packages/turbo-utils/src/managers.ts
@@ -8,7 +8,8 @@ async function exec(command: string, args: Array<string> = [], opts?: Options) {
   // this is no longer needed as of https://github.com/nodejs/corepack/pull/167
   // but we'll keep the behavior for those on older versions)
   const execOptions: Options = {
-    cwd: os.tmpdir(),
+    // Commented this line which causes local yarn version to not be used, uses global yarn instead.
+    // cwd: os.tmpdir(),
     env: { COREPACK_ENABLE_STRICT: "0" },
     ...opts,
   };


### PR DESCRIPTION
### Description

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

When using Yarn 4, the default is to use a local version to your repository. Codemod runs package managers from a tmp directory, which causes Yarn to think there's no local version and uses global version instead. This is fixed when removing the line to run from tmp dir, but needs to be tested if it works with other package managers/projects.

https://github.com/vercel/turborepo/pull/8076

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
