### PR TITLE
chore(tui): move `h` bind to correct section

### DIFF
--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -85,7 +85,6 @@ fn translate_key_event(options: InputOptions, key_event: KeyEvent) -> Option<Eve
                 restore_scroll: true,
             })
         }
-        KeyCode::Char('h') => Some(Event::ToggleSidebar),
         KeyCode::Enter if matches!(options.focus, LayoutSections::Search { .. }) => {
             Some(Event::SearchExit {
                 restore_scroll: false,
@@ -108,6 +107,7 @@ fn translate_key_event(options: InputOptions, key_event: KeyEvent) -> Option<Eve
             Some(Event::SearchEnterChar(c))
         }
         // Fall through if we aren't in interactive mode
+        KeyCode::Char('h') => Some(Event::ToggleSidebar),
         KeyCode::Char('p') if key_event.modifiers == KeyModifiers::CONTROL => Some(Event::ScrollUp),
         KeyCode::Char('n') if key_event.modifiers == KeyModifiers::CONTROL => {
             Some(Event::ScrollDown)


### PR DESCRIPTION
### Description

I hadn't realized that the list was separated such that the fallthrough binds were at the end of the list. Putting `h` at the bottom so its in the right spot now.

### Testing Instructions

👀 
