### PR TITLE
chore: remove leader from bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/0-turborepo-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/0-turborepo-bug-report.yml
@@ -1,7 +1,6 @@
 name: Turborepo bug report
 description: Create a bug report
 labels: ["kind: bug", "needs: triage"]
-title: "🐛 Bug: "
 
 body:
   - type: markdown


### PR DESCRIPTION
### Description

I thought this would be good vibes but it just looks like noise since we keep our Issues scoped to bugs and only bugs. We'll keep the title for the docs requests but this was noisy for the bugs template.
