### PR TITLE
refactor: compile args + config to opts

### DIFF
--- a/crates/turborepo-lib/src/cli/error.rs
+++ b/crates/turborepo-lib/src/cli/error.rs
@@ -64,6 +64,8 @@ pub enum Error {
     #[error(transparent)]
     #[diagnostic(transparent)]
     Watch(#[from] watch::Error),
+    #[error(transparent)]
+    Opts(#[from] crate::opts::Error),
 }
 
 const MAX_CHARS_PER_TASK_LINE: usize = 100;

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -154,6 +154,9 @@ impl fmt::Display for EnvMode {
     }
 }
 
+/// The parsed arguments from the command line. In general we should avoid using
+/// or mutating this directly, and instead use the fully canonicalized `Opts`
+/// struct.
 #[derive(Parser, Clone, Default, Debug, PartialEq)]
 #[clap(author, about = "The build system that makes ship happen", long_about = None)]
 #[clap(disable_help_subcommand = true)]

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1224,7 +1224,7 @@ pub async fn run(
             CommandEventBuilder::new("daemon")
                 .with_parent(&root_telemetry)
                 .track_call();
-            let base = CommandBase::new(cli_args.clone(), repo_root, version, color_config);
+            let base = CommandBase::new(cli_args.clone(), repo_root, version, color_config)?;
 
             match command {
                 Some(command) => daemon::daemon_client(command, &base).await,
@@ -1258,7 +1258,7 @@ pub async fn run(
             CommandEventBuilder::new("info")
                 .with_parent(&root_telemetry)
                 .track_call();
-            let base = CommandBase::new(cli_args.clone(), repo_root, version, color_config);
+            let base = CommandBase::new(cli_args.clone(), repo_root, version, color_config)?;
 
             info::run(base).await;
             Ok(0)
@@ -1266,13 +1266,13 @@ pub async fn run(
         Command::Telemetry { command } => {
             let event = CommandEventBuilder::new("telemetry").with_parent(&root_telemetry);
             event.track_call();
-            let mut base = CommandBase::new(cli_args.clone(), repo_root, version, color_config);
+            let mut base = CommandBase::new(cli_args.clone(), repo_root, version, color_config)?;
             let child_event = event.child();
             telemetry::configure(command, &mut base, child_event);
             Ok(0)
         }
         Command::Scan {} => {
-            let base = CommandBase::new(cli_args.clone(), repo_root, version, color_config);
+            let base = CommandBase::new(cli_args.clone(), repo_root, version, color_config)?;
             if scan::run(base).await {
                 Ok(0)
             } else {
@@ -1280,27 +1280,22 @@ pub async fn run(
             }
         }
         Command::Config => {
-            let base = CommandBase::new(cli_args.clone(), repo_root, version, color_config);
+            let base = CommandBase::new(cli_args.clone(), repo_root, version, color_config)?;
             config::run(base).await?;
             Ok(0)
         }
         Command::Ls {
-            affected,
-            filter,
-            packages,
-            output,
+            packages, output, ..
         } => {
             warn!("ls command is experimental and may change in the future");
             let event = CommandEventBuilder::new("info").with_parent(&root_telemetry);
 
             event.track_call();
-            let affected = *affected;
             let output = *output;
-            let filter = filter.clone();
             let packages = packages.clone();
-            let base = CommandBase::new(cli_args, repo_root, version, color_config);
+            let base = CommandBase::new(cli_args, repo_root, version, color_config)?;
 
-            ls::run(base, packages, event, filter, affected, output).await?;
+            ls::run(base, packages, event, output).await?;
 
             Ok(0)
         }
@@ -1327,7 +1322,7 @@ pub async fn run(
             let to = *target;
             let yes = *yes;
             let scope = scope.clone();
-            let mut base = CommandBase::new(cli_args, repo_root, version, color_config);
+            let mut base = CommandBase::new(cli_args, repo_root, version, color_config)?;
 
             link::link(&mut base, scope, modify_gitignore, yes, to).await?;
 
@@ -1338,7 +1333,7 @@ pub async fn run(
             event.track_call();
             let invalidate = *invalidate;
 
-            let mut base = CommandBase::new(cli_args, repo_root, version, color_config);
+            let mut base = CommandBase::new(cli_args, repo_root, version, color_config)?;
             let event_child = event.child();
 
             logout::logout(&mut base, invalidate, event_child).await?;
@@ -1356,7 +1351,7 @@ pub async fn run(
             let sso_team = sso_team.clone();
             let force = *force;
 
-            let mut base = CommandBase::new(cli_args, repo_root, version, color_config);
+            let mut base = CommandBase::new(cli_args, repo_root, version, color_config)?;
             let event_child = event.child();
 
             if let Some(sso_team) = sso_team {
@@ -1377,7 +1372,7 @@ pub async fn run(
             }
 
             let from = *target;
-            let mut base = CommandBase::new(cli_args, repo_root, version, color_config);
+            let mut base = CommandBase::new(cli_args, repo_root, version, color_config)?;
 
             unlink::unlink(&mut base, from)?;
 
@@ -1390,7 +1385,7 @@ pub async fn run(
             let event = CommandEventBuilder::new("run").with_parent(&root_telemetry);
             event.track_call();
 
-            let base = CommandBase::new(cli_args.clone(), repo_root, version, color_config);
+            let base = CommandBase::new(cli_args.clone(), repo_root, version, color_config)?;
 
             if execution_args.tasks.is_empty() {
                 print_potential_tasks(base, event).await?;
@@ -1417,7 +1412,7 @@ pub async fn run(
             let event = CommandEventBuilder::new("query").with_parent(&root_telemetry);
             event.track_call();
 
-            let base = CommandBase::new(cli_args, repo_root, version, color_config);
+            let base = CommandBase::new(cli_args, repo_root, version, color_config)?;
 
             let query = query::run(base, event, query, variables.as_deref()).await?;
 
@@ -1426,7 +1421,7 @@ pub async fn run(
         Command::Watch(_) => {
             let event = CommandEventBuilder::new("watch").with_parent(&root_telemetry);
             event.track_call();
-            let base = CommandBase::new(cli_args, repo_root, version, color_config);
+            let base = CommandBase::new(cli_args, repo_root, version, color_config)?;
 
             let mut client = WatchClient::new(base, event).await?;
             if let Err(e) = client.start().await {
@@ -1451,7 +1446,7 @@ pub async fn run(
                 .unwrap_or_default();
             let docker = *docker;
             let output_dir = output_dir.clone();
-            let base = CommandBase::new(cli_args, repo_root, version, color_config);
+            let base = CommandBase::new(cli_args, repo_root, version, color_config)?;
             let event_child = event.child();
             prune::prune(&base, &scope, docker, &output_dir, event_child).await?;
             Ok(0)

--- a/crates/turborepo-lib/src/commands/config.rs
+++ b/crates/turborepo-lib/src/commands/config.rs
@@ -29,7 +29,7 @@ struct ConfigOutput<'a> {
 }
 
 pub async fn run(base: CommandBase) -> Result<(), cli::Error> {
-    let config = base.config()?;
+    let config = base.config();
     let root_package_json = PackageJson::load(&base.repo_root.join_component("package.json"))?;
 
     let package_graph = PackageGraph::builder(&base.repo_root, root_package_json)

--- a/crates/turborepo-lib/src/commands/link.rs
+++ b/crates/turborepo-lib/src/commands/link.rs
@@ -631,12 +631,12 @@ mod test {
         let override_global_config_path =
             AbsoluteSystemPathBuf::try_from(user_config_file.path().to_path_buf())?;
 
-        let config =
-            TurborepoConfigBuilder::new(&repo_root, Some(override_global_config_path.clone()))
-                .with_api_url(Some(format!("http://localhost:{}", port)))
-                .with_login_url(Some(format!("http://localhost:{}", port)))
-                .with_token(Some("token".to_string()))
-                .build()?;
+        let config = TurborepoConfigBuilder::new(&repo_root)
+            .with_global_config_path(override_global_config_path.clone())
+            .with_api_url(Some(format!("http://localhost:{}", port)))
+            .with_login_url(Some(format!("http://localhost:{}", port)))
+            .with_token(Some("token".to_string()))
+            .build()?;
 
         let mut base = CommandBase::from_opts(
             Opts::new(&Args::default(), config)?,
@@ -650,9 +650,9 @@ mod test {
         handle.abort();
 
         // read the config
-        let updated_config =
-            TurborepoConfigBuilder::new(&base.repo_root, Some(override_global_config_path))
-                .build()?;
+        let updated_config = TurborepoConfigBuilder::new(&base.repo_root)
+            .with_global_config_path(override_global_config_path)
+            .build()?;
         let team_id = updated_config.team_id();
 
         assert!(
@@ -693,12 +693,12 @@ mod test {
         let override_global_config_path =
             AbsoluteSystemPathBuf::try_from(user_config_file.path().to_path_buf())?;
 
-        let config =
-            TurborepoConfigBuilder::new(&repo_root, Some(override_global_config_path.clone()))
-                .with_api_url(Some(format!("http://localhost:{}", port)))
-                .with_login_url(Some(format!("http://localhost:{}", port)))
-                .with_token(Some("token".to_string()))
-                .build()?;
+        let config = TurborepoConfigBuilder::new(&repo_root)
+            .with_global_config_path(override_global_config_path.clone())
+            .with_api_url(Some(format!("http://localhost:{}", port)))
+            .with_login_url(Some(format!("http://localhost:{}", port)))
+            .with_token(Some("token".to_string()))
+            .build()?;
 
         let mut base = CommandBase::from_opts(
             Opts::new(&Args::default(), config)?,

--- a/crates/turborepo-lib/src/commands/login.rs
+++ b/crates/turborepo-lib/src/commands/login.rs
@@ -15,9 +15,9 @@ pub async fn sso_login(
     telemetry.track_login_method(LoginMethod::SSO);
     let api_client: APIClient = base.api_client()?;
     let color_config = base.color_config;
-    let login_url_config = base.config()?.login_url().to_string();
+    let login_url_config = base.config().login_url().to_string();
     let options = LoginOptions {
-        existing_token: base.config()?.token(),
+        existing_token: base.config().token(),
         sso_team: Some(sso_team),
         force,
         ..LoginOptions::new(
@@ -72,9 +72,9 @@ pub async fn login(
 
     let api_client: APIClient = base.api_client()?;
     let color_config = base.color_config;
-    let login_url_config = base.config()?.login_url().to_string();
+    let login_url_config = base.config().login_url().to_string();
     let options = LoginOptions {
-        existing_token: base.config()?.token(),
+        existing_token: base.config().token(),
         force,
         ..LoginOptions::new(
             &color_config,

--- a/crates/turborepo-lib/src/commands/ls.rs
+++ b/crates/turborepo-lib/src/commands/ls.rs
@@ -13,7 +13,7 @@ use turborepo_ui::{color, cprint, cprintln, ColorConfig, BOLD, BOLD_GREEN, GREY}
 
 use crate::{
     cli,
-    cli::{Command, ExecutionArgs, OutputFormat},
+    cli::OutputFormat,
     commands::{run::get_signal, CommandBase},
     run::{builder::RunBuilder, Run},
     signal::SignalHandler,
@@ -113,25 +113,13 @@ impl<'a> From<PackageDetails<'a>> for PackageDetailsDisplay<'a> {
 }
 
 pub async fn run(
-    mut base: CommandBase,
+    base: CommandBase,
     packages: Vec<String>,
     telemetry: CommandEventBuilder,
-    filter: Vec<String>,
-    affected: bool,
     output: Option<OutputFormat>,
 ) -> Result<(), cli::Error> {
     let signal = get_signal()?;
     let handler = SignalHandler::new(signal);
-
-    // We fake a run command, so we can construct a `Run` type
-    base.args_mut().command = Some(Command::Run {
-        run_args: Box::default(),
-        execution_args: Box::new(ExecutionArgs {
-            filter,
-            affected,
-            ..Default::default()
-        }),
-    });
 
     let run_builder = RunBuilder::new(base)?;
     let run = run_builder.build(&handler, telemetry).await?;

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -73,7 +73,7 @@ impl CommandBase {
         repo_root: &AbsoluteSystemPath,
         args: &Args,
     ) -> Result<ConfigurationOptions, ConfigError> {
-        TurborepoConfigBuilder::new(&repo_root)
+        TurborepoConfigBuilder::new(repo_root)
             // The below should be deprecated and removed.
             .with_api_url(args.api.clone())
             .with_login_url(args.login.clone())

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -1,4 +1,4 @@
-use std::{cell::OnceCell, time::Duration};
+use std::time::Duration;
 
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_api_client::{APIAuth, APIClient};
@@ -7,7 +7,9 @@ use turborepo_dirs::config_dir;
 use turborepo_ui::ColorConfig;
 
 use crate::{
+    cli,
     config::{ConfigurationOptions, Error as ConfigError, TurborepoConfigBuilder},
+    opts::Opts,
     Args,
 };
 
@@ -32,8 +34,7 @@ pub struct CommandBase {
     pub repo_root: AbsoluteSystemPathBuf,
     pub color_config: ColorConfig,
     pub override_global_config_path: Option<AbsoluteSystemPathBuf>,
-    config: OnceCell<ConfigurationOptions>,
-    args: Args,
+    pub opts: Opts,
     version: &'static str,
 }
 
@@ -43,15 +44,43 @@ impl CommandBase {
         repo_root: AbsoluteSystemPathBuf,
         version: &'static str,
         color_config: ColorConfig,
+    ) -> Result<Self, cli::Error> {
+        Self::new_with_override_global_config_path(args, repo_root, version, None, color_config)
+    }
+
+    pub fn from_opts(
+        opts: Opts,
+        repo_root: AbsoluteSystemPathBuf,
+        version: &'static str,
+        color_config: ColorConfig,
     ) -> Self {
         Self {
             repo_root,
             color_config,
-            args,
-            override_global_config_path: None,
-            config: OnceCell::new(),
             version,
+            opts,
+            override_global_config_path: None,
         }
+    }
+
+    /// `override_global_config_path` is only used for testing
+    fn new_with_override_global_config_path(
+        args: Args,
+        repo_root: AbsoluteSystemPathBuf,
+        version: &'static str,
+        override_global_config_path: Option<AbsoluteSystemPathBuf>,
+        color_config: ColorConfig,
+    ) -> Result<Self, cli::Error> {
+        let config = Self::config_init(&repo_root, override_global_config_path, &args)?;
+        let opts = Opts::new(&args, config)?;
+
+        Ok(Self {
+            repo_root,
+            color_config,
+            override_global_config_path: None,
+            opts,
+            version,
+        })
     }
 
     pub fn with_override_global_config_path(mut self, path: AbsoluteSystemPathBuf) -> Self {
@@ -59,65 +88,62 @@ impl CommandBase {
         self
     }
 
-    fn config_init(&self) -> Result<ConfigurationOptions, ConfigError> {
-        TurborepoConfigBuilder::new(self)
+    fn config_init(
+        repo_root: &AbsoluteSystemPath,
+        override_global_config_path: Option<AbsoluteSystemPathBuf>,
+        args: &Args,
+    ) -> Result<ConfigurationOptions, ConfigError> {
+        TurborepoConfigBuilder::new(&repo_root, override_global_config_path)
             // The below should be deprecated and removed.
-            .with_api_url(self.args.api.clone())
-            .with_login_url(self.args.login.clone())
-            .with_team_slug(self.args.team.clone())
-            .with_token(self.args.token.clone())
-            .with_timeout(self.args.remote_cache_timeout)
-            .with_preflight(self.args.preflight.then_some(true))
-            .with_ui(self.args.ui)
+            .with_api_url(args.api.clone())
+            .with_login_url(args.login.clone())
+            .with_team_slug(args.team.clone())
+            .with_token(args.token.clone())
+            .with_timeout(args.remote_cache_timeout)
+            .with_preflight(args.preflight.then_some(true))
+            .with_ui(args.ui)
             .with_allow_no_package_manager(
-                self.args
-                    .dangerously_disable_package_manager_check
+                args.dangerously_disable_package_manager_check
                     .then_some(true),
             )
-            .with_daemon(self.args.run_args().and_then(|args| args.daemon()))
+            .with_daemon(args.run_args().and_then(|args| args.daemon()))
             .with_env_mode(
-                self.args
-                    .execution_args()
+                args.execution_args()
                     .and_then(|execution_args| execution_args.env_mode),
             )
             .with_cache_dir(
-                self.args
-                    .execution_args()
+                args.execution_args()
                     .and_then(|execution_args| execution_args.cache_dir.clone()),
             )
             .with_root_turbo_json_path(
-                self.args
-                    .root_turbo_json
+                args.root_turbo_json
                     .clone()
                     .map(AbsoluteSystemPathBuf::from_cwd)
                     .transpose()?,
             )
             .with_force(
-                self.args
-                    .run_args()
+                args.run_args()
                     .and_then(|args| args.force.map(|value| value.unwrap_or(true))),
             )
-            .with_log_order(self.args.execution_args().and_then(|args| args.log_order))
-            .with_remote_only(self.args.run_args().and_then(|args| args.remote_only()))
+            .with_log_order(args.execution_args().and_then(|args| args.log_order))
+            .with_remote_only(args.run_args().and_then(|args| args.remote_only()))
             .with_remote_cache_read_only(
-                self.args
-                    .run_args()
+                args.run_args()
                     .and_then(|args| args.remote_cache_read_only()),
             )
             .with_cache(
-                self.args
-                    .run_args()
+                args.run_args()
                     .and_then(|args| args.cache.as_deref())
                     .map(|cache| cache.parse())
                     .transpose()?,
             )
-            .with_run_summary(self.args.run_args().and_then(|args| args.summarize()))
-            .with_allow_no_turbo_json(self.args.allow_no_turbo_json.then_some(true))
+            .with_run_summary(args.run_args().and_then(|args| args.summarize()))
+            .with_allow_no_turbo_json(args.allow_no_turbo_json.then_some(true))
             .build()
     }
 
-    pub fn config(&self) -> Result<&ConfigurationOptions, ConfigError> {
-        self.config.get_or_try_init(|| self.config_init())
+    pub fn opts(&self) -> &Opts {
+        &self.opts
     }
 
     // Getting all of the paths.
@@ -142,7 +168,7 @@ impl CommandBase {
     }
 
     pub fn api_auth(&self) -> Result<Option<APIAuth>, ConfigError> {
-        let config = self.config()?;
+        let config = self.config();
         let team_id = config.team_id();
         let team_slug = config.team_slug();
 
@@ -157,16 +183,12 @@ impl CommandBase {
         }))
     }
 
-    pub fn args(&self) -> &Args {
-        &self.args
-    }
-
-    pub fn args_mut(&mut self) -> &mut Args {
-        &mut self.args
+    pub fn config(&self) -> &ConfigurationOptions {
+        &self.opts.config
     }
 
     pub fn api_client(&self) -> Result<APIClient, ConfigError> {
-        let config = self.config()?;
+        let config = &self.opts.config;
         let api_url = config.api_url();
         let timeout = config.timeout();
         let upload_timeout = config.upload_timeout();

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -263,7 +263,7 @@ impl<'a> Prune<'a> {
         output_dir: &str,
         telemetry: CommandEventBuilder,
     ) -> Result<Self, Error> {
-        let allow_missing_package_manager = base.config()?.allow_no_package_manager();
+        let allow_missing_package_manager = base.config().allow_no_package_manager();
         telemetry.track_arg_usage(
             "dangerously-allow-missing-package-manager",
             allow_missing_package_manager,

--- a/crates/turborepo-lib/src/commands/query.rs
+++ b/crates/turborepo-lib/src/commands/query.rs
@@ -8,7 +8,6 @@ use turbopath::AbsoluteSystemPathBuf;
 use turborepo_telemetry::events::command::CommandEventBuilder;
 
 use crate::{
-    cli::Command,
     commands::{run::get_signal, CommandBase},
     query,
     query::{Error, RepositoryQuery},
@@ -56,19 +55,13 @@ impl QueryError {
 }
 
 pub async fn run(
-    mut base: CommandBase,
+    base: CommandBase,
     telemetry: CommandEventBuilder,
     query: Option<String>,
     variables_path: Option<&Utf8Path>,
 ) -> Result<i32, Error> {
     let signal = get_signal()?;
     let handler = SignalHandler::new(signal);
-
-    // We fake a run command, so we can construct a `Run` type
-    base.args_mut().command = Some(Command::Run {
-        run_args: Box::default(),
-        execution_args: Box::default(),
-    });
 
     let run_builder = RunBuilder::new(base)?
         .add_all_tasks()

--- a/crates/turborepo-lib/src/commands/unlink.rs
+++ b/crates/turborepo-lib/src/commands/unlink.rs
@@ -16,8 +16,7 @@ enum UnlinkSpacesResult {
 }
 
 fn unlink_remote_caching(base: &mut CommandBase) -> Result<(), cli::Error> {
-    let needs_disabling =
-        base.config()?.team_id().is_some() || base.config()?.team_slug().is_some();
+    let needs_disabling = base.config().team_id().is_some() || base.config().team_slug().is_some();
 
     let output = if needs_disabling {
         let local_config_path = base.local_config_path();
@@ -57,8 +56,7 @@ fn unlink_remote_caching(base: &mut CommandBase) -> Result<(), cli::Error> {
 }
 
 fn unlink_spaces(base: &mut CommandBase) -> Result<(), cli::Error> {
-    let needs_disabling =
-        base.config()?.team_id().is_some() || base.config()?.team_slug().is_some();
+    let needs_disabling = base.config().team_id().is_some() || base.config().team_slug().is_some();
 
     if needs_disabling {
         let local_config_path = base.local_config_path();

--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -26,7 +26,6 @@ use turborepo_repository::package_graph::PackageName;
 pub use crate::turbo_json::{RawTurboJson, UIMode};
 use crate::{
     cli::{EnvMode, LogOrder},
-    commands::CommandBase,
     turbo_json::CONFIG_FILE,
 };
 
@@ -437,11 +436,14 @@ fn get_lowercased_env_vars() -> HashMap<OsString, OsString> {
 }
 
 impl TurborepoConfigBuilder {
-    pub fn new(base: &CommandBase) -> Self {
+    pub fn new(
+        repo_root: &AbsoluteSystemPath,
+        override_global_config_path: Option<AbsoluteSystemPathBuf>,
+    ) -> Self {
         Self {
-            repo_root: base.repo_root.to_owned(),
+            repo_root: repo_root.to_owned(),
             override_config: Default::default(),
-            global_config_path: base.override_global_config_path.clone(),
+            global_config_path: override_global_config_path,
             environment: None,
         }
     }

--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -436,16 +436,18 @@ fn get_lowercased_env_vars() -> HashMap<OsString, OsString> {
 }
 
 impl TurborepoConfigBuilder {
-    pub fn new(
-        repo_root: &AbsoluteSystemPath,
-        override_global_config_path: Option<AbsoluteSystemPathBuf>,
-    ) -> Self {
+    pub fn new(repo_root: &AbsoluteSystemPath) -> Self {
         Self {
             repo_root: repo_root.to_owned(),
             override_config: Default::default(),
-            global_config_path: override_global_config_path,
+            global_config_path: None,
             environment: None,
         }
+    }
+
+    pub fn with_global_config_path(mut self, path: AbsoluteSystemPathBuf) -> Self {
+        self.global_config_path = Some(path);
+        self
     }
 
     // Getting all of the paths.

--- a/crates/turborepo-lib/src/diagnostics.rs
+++ b/crates/turborepo-lib/src/diagnostics.rs
@@ -403,15 +403,12 @@ impl Diagnostic for RemoteCacheDiagnostic {
         tokio::task::spawn(async move {
             chan.started("Remote Cache".to_string()).await;
 
-            let result = {
+            let (has_team_id, has_team_slug) = {
                 let base = base.lock().await;
-                base.config()
-                    .map(|c| (c.team_id().is_some(), c.team_slug().is_some()))
-            };
-
-            let Ok((has_team_id, has_team_slug)) = result else {
-                chan.failed("Malformed config file".to_string()).await;
-                return;
+                (
+                    base.config().team_id().is_some(),
+                    base.config().team_slug().is_some(),
+                )
             };
 
             chan.log_line("Checking credentials".to_string()).await;

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -43,6 +43,8 @@ pub enum Error {
     Config(#[from] crate::config::Error),
 }
 
+/// The fully resolved options for Turborepo. This is the combination of config,
+/// including all the layers (env, args, etc.), and the command line arguments.
 #[derive(Debug, Clone)]
 pub struct Opts {
     pub config: ConfigurationOptions,

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -1,4 +1,4 @@
-use std::{backtrace, backtrace::Backtrace};
+use std::backtrace;
 
 use camino::Utf8PathBuf;
 use thiserror::Error;
@@ -10,10 +10,10 @@ use crate::{
     cli::{
         Command, DryRunMode, EnvMode, ExecutionArgs, LogOrder, LogPrefix, OutputLogsMode, RunArgs,
     },
-    commands::CommandBase,
     config::ConfigurationOptions,
     run::task_id::TaskId,
     turbo_json::UIMode,
+    Args,
 };
 
 #[derive(Debug, Error)]
@@ -45,6 +45,7 @@ pub enum Error {
 
 #[derive(Debug, Clone)]
 pub struct Opts {
+    pub config: ConfigurationOptions,
     pub cache_opts: CacheOpts,
     pub run_opts: RunOpts,
     pub runcache_opts: RunCacheOpts,
@@ -92,23 +93,36 @@ impl Opts {
 }
 
 impl Opts {
-    pub fn new(base: &CommandBase) -> Result<Self, Error> {
-        let args = base.args();
-        let config = base.config()?;
-        let api_auth = base.api_auth()?;
+    pub fn new(args: &Args, config: ConfigurationOptions) -> Result<Self, Error> {
+        let team_id = config.team_id();
+        let team_slug = config.team_slug();
 
-        let Some(Command::Run {
-            run_args,
-            execution_args,
-        }) = &args.command
-        else {
-            return Err(Error::ExpectedRun(Backtrace::capture()));
+        let api_auth = config.token().map(|token| APIAuth {
+            team_id: team_id.map(|s| s.to_string()),
+            token: token.to_string(),
+            team_slug: team_slug.map(|s| s.to_string()),
+        });
+
+        let (execution_args, run_args) = match &args.command {
+            Some(Command::Run {
+                run_args,
+                execution_args,
+            }) => (execution_args, run_args),
+            Some(Command::Ls {
+                affected, filter, ..
+            }) => {
+                let mut execution_args = ExecutionArgs::default();
+                execution_args.affected = *affected;
+                execution_args.filter = filter.clone();
+                (&Box::new(execution_args), &Box::default())
+            }
+            _ => (&Box::default(), &Box::default()),
         };
 
         let inputs = OptsInputs {
             run_args: run_args.as_ref(),
             execution_args: execution_args.as_ref(),
-            config,
+            config: &config,
             api_auth: &api_auth,
         };
         let run_opts = RunOpts::try_from(inputs)?;
@@ -117,6 +131,7 @@ impl Opts {
         let runcache_opts = RunCacheOpts::from(inputs);
 
         Ok(Self {
+            config,
             run_opts,
             cache_opts,
             scope_opts,
@@ -441,17 +456,16 @@ impl ScopeOpts {
 
 #[cfg(test)]
 mod test {
-
     use test_case::test_case;
     use turbopath::AbsoluteSystemPathBuf;
-    use turborepo_api_client::APIAuth;
     use turborepo_cache::CacheOpts;
     use turborepo_ui::ColorConfig;
 
-    use super::{OptsInputs, RunOpts};
+    use super::RunOpts;
     use crate::{
         cli::{Command, DryRunMode, RunArgs},
         commands::CommandBase,
+        config::ConfigurationOptions,
         opts::{Opts, RunCacheOpts, ScopeOpts},
         turbo_json::UIMode,
         Args,
@@ -469,81 +483,81 @@ mod test {
         affected: Option<(String, String)>,
     }
 
-    #[test_case(TestCaseOpts {
+    #[test_case(TestCaseOpts{
         filter_patterns: vec!["my-app".to_string()],
         tasks: vec!["build".to_string()],
         ..Default::default()
-    },
-    "turbo run build --filter=my-app")]
+        },
+        "turbo run build --filter=my-app")]
     #[test_case(
-        TestCaseOpts {
+        TestCaseOpts{
             tasks: vec!["build".to_string()],
             only: true,
             ..Default::default()
-        },
+            },
         "turbo run build --only"
     )]
     #[test_case(
-        TestCaseOpts {
+        TestCaseOpts{
             filter_patterns: vec!["my-app".to_string()],
             tasks: vec!["build".to_string()],
             pass_through_args: vec!["-v".to_string(), "--foo=bar".to_string()],
             ..Default::default()
-        },
+            },
         "turbo run build --filter=my-app -- -v --foo=bar"
     )]
     #[test_case(
-        TestCaseOpts {
+        TestCaseOpts{
             filter_patterns: vec!["other-app".to_string(), "my-app".to_string()],
             tasks: vec!["build".to_string()],
             pass_through_args: vec!["-v".to_string(), "--foo=bar".to_string()],
             ..Default::default()
-        },
+            },
         "turbo run build --filter=other-app --filter=my-app -- -v --foo=bar"
     )]
-    #[test_case    (
-        TestCaseOpts {
+    #[test_case(
+        TestCaseOpts{
             filter_patterns: vec!["my-app".to_string()],
             tasks: vec!["build".to_string()],
             parallel: true,
             continue_on_error: true,
             ..Default::default()
-        },
+            },
         "turbo run build --filter=my-app --parallel --continue"
     )]
-    #[test_case    (
-        TestCaseOpts {
+    #[test_case(
+        TestCaseOpts{
             filter_patterns: vec!["my-app".to_string()],
             tasks: vec!["build".to_string()],
             dry_run: Some(DryRunMode::Text),
             ..Default::default()
-        },
+            },
         "turbo run build --filter=my-app --dry"
     )]
-    #[test_case    (
-        TestCaseOpts {
+    #[test_case(
+        TestCaseOpts{
             filter_patterns: vec!["my-app".to_string()],
             tasks: vec!["build".to_string()],
             dry_run: Some(DryRunMode::Json),
             ..Default::default()
-        },
+            },
         "turbo run build --filter=my-app --dry=json"
     )]
-    #[test_case    (
-        TestCaseOpts {
+    #[test_case(
+        TestCaseOpts{
             filter_patterns: vec!["my-app".to_string()],
             tasks: vec!["build".to_string()],
             affected: Some(("HEAD".to_string(), "my-branch".to_string())),
             ..Default::default()
-        },
+            },
         "turbo run build --filter=my-app --affected"
     )]
-    #[test_case    (
-        TestCaseOpts {
+    #[test_case(
+        TestCaseOpts{
             tasks: vec!["build".to_string()],
             affected: Some(("HEAD".to_string(), "my-branch".to_string())),
             ..Default::default()
-        },
+            },
         "turbo run build --affected"
     )]
     fn test_synthesize_command(opts_input: TestCaseOpts, expected: &str) {
@@ -580,6 +594,7 @@ mod test {
                 .map(|(base, head)| (Some(base), Some(head))),
         };
         let opts = Opts {
+            config: ConfigurationOptions::default(),
             run_opts,
             cache_opts,
             scope_opts,
@@ -594,52 +609,52 @@ mod test {
              no_cache: true,
              ..Default::default()
          }, "no-cache"
-    )]
+     ; "no-cache" )]
     #[test_case(
          RunArgs {
              force: Some(Some(true)),
              ..Default::default()
          }, "force"
-    )]
+     ; "force")]
     #[test_case(
-         RunArgs {
+        RunArgs{
              remote_only: Some(Some(true)),
              ..Default::default()
-         }, "remote-only"
+            }, "remote-only"
     )]
     #[test_case(
-         RunArgs {
+        RunArgs{
              remote_cache_read_only: Some(Some(true)),
              ..Default::default()
-         }, "remote-cache-read-only"
+            }, "remote-cache-read-only"
     )]
     #[test_case(
-         RunArgs {
+        RunArgs{
              no_cache: true,
              cache: Some("remote:w,local:rw".to_string()),
              ..Default::default()
-         }, "no-cache_remote_w,local_rw"
+            }, "no-cache_remote_w,local_rw"
     )]
     #[test_case(
-         RunArgs {
+        RunArgs{
              remote_only: Some(Some(true)),
              cache: Some("remote:r,local:rw".to_string()),
              ..Default::default()
-         }, "remote-only_remote_r,local_rw"
+            }, "remote-only_remote_r,local_rw"
     )]
     #[test_case(
-         RunArgs {
+        RunArgs{
              force: Some(Some(true)),
              cache: Some("remote:r,local:r".to_string()),
              ..Default::default()
-         }, "force_remote_r,local_r"
+            }, "force_remote_r,local_r"
     )]
     #[test_case(
-          RunArgs {
+        RunArgs{
               remote_cache_read_only: Some(Some(true)),
               cache: Some("remote:rw,local:r".to_string()),
               ..Default::default()
-          }, "remote-cache-read-only_remote_rw,local_r"
+            }, "remote-cache-read-only_remote_rw,local_r"
     )]
     fn test_resolve_cache_config(run_args: RunArgs, name: &str) -> Result<(), anyhow::Error> {
         let mut args = Args::default();
@@ -647,26 +662,19 @@ mod test {
             execution_args: Box::default(),
             run_args: Box::new(run_args),
         });
-        let base = CommandBase::new(
+        // set token and team to simulate a logged in/linked user
+        args.token = Some("token".to_string());
+        args.team = Some("team".to_string());
+
+        let cache_config = CommandBase::new(
             args,
             AbsoluteSystemPathBuf::default(),
             "1.0.0",
             ColorConfig::new(true),
-        );
+        )
+        .map(|base| base.opts().cache_opts.cache);
 
-        let cache_opts = CacheOpts::try_from(OptsInputs {
-            run_args: base.args().run_args().unwrap(),
-            execution_args: base.args().execution_args().unwrap(),
-            config: base.config()?,
-            api_auth: &Some(APIAuth {
-                team_id: Some("my-team".to_string()),
-                token: "my-token".to_string(),
-                team_slug: None,
-            }),
-        })
-        .map(|cache_opts| cache_opts.cache);
-
-        insta::assert_debug_snapshot!(name, cache_opts);
+        insta::assert_debug_snapshot!(name, cache_config);
 
         Ok(())
     }

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -113,9 +113,12 @@ impl Opts {
             Some(Command::Ls {
                 affected, filter, ..
             }) => {
-                let mut execution_args = ExecutionArgs::default();
-                execution_args.affected = *affected;
-                execution_args.filter = filter.clone();
+                let execution_args = ExecutionArgs {
+                    filter: filter.clone(),
+                    affected: *affected,
+                    ..Default::default()
+                };
+
                 (&Box::new(execution_args), &Box::default())
             }
             _ => (&Box::default(), &Box::default()),

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -78,9 +78,9 @@ impl RunBuilder {
     pub fn new(base: CommandBase) -> Result<Self, Error> {
         let api_client = base.api_client()?;
 
-        let opts = Opts::new(&base)?;
+        let opts = base.opts();
         let api_auth = base.api_auth()?;
-        let config = base.config()?;
+        let config = base.config();
         let allow_missing_package_manager = config.allow_no_package_manager();
 
         let version = base.version();
@@ -97,6 +97,7 @@ impl RunBuilder {
         let CommandBase {
             repo_root,
             color_config: ui,
+            opts,
             ..
         } = base;
 

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -14,7 +14,6 @@ use turborepo_telemetry::events::command::CommandEventBuilder;
 use turborepo_ui::sender::UISender;
 
 use crate::{
-    cli::{Command, RunArgs},
     commands::{self, CommandBase},
     daemon::{proto, DaemonConnectorError, DaemonError},
     get_version, opts,
@@ -113,7 +112,7 @@ impl WatchClient {
     pub async fn new(base: CommandBase, telemetry: CommandEventBuilder) -> Result<Self, Error> {
         let signal = commands::run::get_signal()?;
         let handler = SignalHandler::new(signal);
-        let config = base.config()?;
+        let config = &base.opts.config;
         let root_turbo_json_path = config.root_turbo_json_path(&base.repo_root);
         if root_turbo_json_path != base.repo_root.join_component(CONFIG_FILE) {
             return Err(Error::NonStandardTurboJsonPath(
@@ -124,16 +123,7 @@ impl WatchClient {
             warn!("daemon is required for watch, ignoring request to disable daemon");
         }
 
-        let Some(Command::Watch(execution_args)) = &base.args().command else {
-            unreachable!()
-        };
-
-        let mut new_base = base.clone();
-        new_base.args_mut().command = Some(Command::Run {
-            run_args: Box::default(),
-            execution_args: execution_args.clone(),
-        });
-
+        let new_base = base.clone();
         let run = Arc::new(
             RunBuilder::new(new_base)?
                 .build(&handler, telemetry.clone())
@@ -298,24 +288,12 @@ impl WatchClient {
                     })
                     .collect();
 
-                let mut args = self.base.args().clone();
-                args.command = args.command.map(|c| {
-                    if let Command::Watch(execution_args) = c {
-                        Command::Run {
-                            execution_args,
-                            run_args: Box::new(RunArgs {
-                                no_cache: true,
-                                daemon: true,
-                                ..Default::default()
-                            }),
-                        }
-                    } else {
-                        unreachable!()
-                    }
-                });
+                let mut opts = self.base.opts().clone();
+                opts.cache_opts.cache.remote.write = false;
+                opts.cache_opts.cache.local.write = false;
 
-                let new_base = CommandBase::new(
-                    args,
+                let new_base = CommandBase::from_opts(
+                    opts,
                     self.base.repo_root.clone(),
                     get_version(),
                     self.base.color_config,
@@ -344,24 +322,12 @@ impl WatchClient {
                 })
             }
             ChangedPackages::All => {
-                let mut args = self.base.args().clone();
-                args.command = args.command.map(|c| {
-                    if let Command::Watch(execution_args) = c {
-                        Command::Run {
-                            run_args: Box::new(RunArgs {
-                                no_cache: true,
-                                daemon: true,
-                                ..Default::default()
-                            }),
-                            execution_args,
-                        }
-                    } else {
-                        unreachable!()
-                    }
-                });
+                let mut opts = self.base.opts().clone();
+                opts.cache_opts.cache.remote.write = false;
+                opts.cache_opts.cache.local.write = false;
 
-                let base = CommandBase::new(
-                    args,
+                let base = CommandBase::from_opts(
+                    opts,
                     self.base.repo_root.clone(),
                     get_version(),
                     self.base.color_config,

--- a/crates/turborepo-lib/src/snapshots/turborepo_lib__opts__test__force.snap
+++ b/crates/turborepo-lib/src/snapshots/turborepo_lib__opts__test__force.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/turborepo-lib/src/opts.rs
-expression: cache_opts
+expression: cache_config
 ---
 Ok(
     CacheConfig {

--- a/crates/turborepo-lib/src/snapshots/turborepo_lib__opts__test__force_remote_r,local_r.snap
+++ b/crates/turborepo-lib/src/snapshots/turborepo_lib__opts__test__force_remote_r,local_r.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/turborepo-lib/src/opts.rs
-expression: cache_opts
+expression: cache_config
 ---
 Ok(
     CacheConfig {

--- a/crates/turborepo-lib/src/snapshots/turborepo_lib__opts__test__no-cache.snap
+++ b/crates/turborepo-lib/src/snapshots/turborepo_lib__opts__test__no-cache.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/turborepo-lib/src/opts.rs
-expression: cache_opts
+expression: cache_config
 ---
 Ok(
     CacheConfig {

--- a/crates/turborepo-lib/src/snapshots/turborepo_lib__opts__test__no-cache_remote_w,local_rw.snap
+++ b/crates/turborepo-lib/src/snapshots/turborepo_lib__opts__test__no-cache_remote_w,local_rw.snap
@@ -1,7 +1,9 @@
 ---
 source: crates/turborepo-lib/src/opts.rs
-expression: cache_opts
+expression: cache_config
 ---
 Err(
-    OverlappingCacheOptions,
+    Opts(
+        OverlappingCacheOptions,
+    ),
 )

--- a/crates/turborepo-lib/src/snapshots/turborepo_lib__opts__test__remote-cache-read-only.snap
+++ b/crates/turborepo-lib/src/snapshots/turborepo_lib__opts__test__remote-cache-read-only.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/turborepo-lib/src/opts.rs
-expression: cache_opts
+expression: cache_config
 ---
 Ok(
     CacheConfig {

--- a/crates/turborepo-lib/src/snapshots/turborepo_lib__opts__test__remote-cache-read-only_remote_rw,local_r.snap
+++ b/crates/turborepo-lib/src/snapshots/turborepo_lib__opts__test__remote-cache-read-only_remote_rw,local_r.snap
@@ -1,7 +1,9 @@
 ---
 source: crates/turborepo-lib/src/opts.rs
-expression: cache_opts
+expression: cache_config
 ---
 Err(
-    OverlappingCacheOptions,
+    Opts(
+        OverlappingCacheOptions,
+    ),
 )

--- a/crates/turborepo-lib/src/snapshots/turborepo_lib__opts__test__remote-only.snap
+++ b/crates/turborepo-lib/src/snapshots/turborepo_lib__opts__test__remote-only.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/turborepo-lib/src/opts.rs
-expression: cache_opts
+expression: cache_config
 ---
 Ok(
     CacheConfig {

--- a/crates/turborepo-lib/src/snapshots/turborepo_lib__opts__test__remote-only_remote_r,local_rw.snap
+++ b/crates/turborepo-lib/src/snapshots/turborepo_lib__opts__test__remote-only_remote_r,local_rw.snap
@@ -1,7 +1,9 @@
 ---
 source: crates/turborepo-lib/src/opts.rs
-expression: cache_opts
+expression: cache_config
 ---
 Err(
-    OverlappingCacheOptions,
+    Opts(
+        OverlappingCacheOptions,
+    ),
 )


### PR DESCRIPTION
### Description

Refactors our config setup to explicitly transform the `Args` and `Config` to `Opts` in the `CommandBase` constructor. This accomplishes a few things:

- Limits our usage of args beyond `cli`. Args are structured according to the CLI parsing logic, so there are multiple fields that do the same thing (args.command.run_args and args.run_args). By compiling down to `Opts`, we can use a more normalized structure.
- Remove the requirement that we have a `Command::Run` to create a `Run` struct. This requires us to mock out a `Command::Run` in places like `query` or `ls`, which is unnecessary.
- Fix a potential nasty bug where we change the `Args` struct via `CommandBase::args_mut` but that change is not propagated to the config because it's cached via a `OnceCell`.
- Finally, and most importantly, allow us to construct a `Run` without `Args`. This is very important for `query`.

However, this does create a change where `CommandBase::new` is now fallible. Overall this is fine, but it does mean that we sometimes error earlier than before. I couldn't figure out an alternative without making `Config` reactive on any `Args` change

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
