### PR TITLE
chore(pm): reduce PackageManager surface area

### DIFF
--- a/crates/turborepo-filewatch/src/package_watcher.rs
+++ b/crates/turborepo-filewatch/src/package_watcher.rs
@@ -27,7 +27,8 @@ use turborepo_repository::{
         DiscoveryResponse, LocalPackageDiscoveryBuilder, PackageDiscovery, PackageDiscoveryBuilder,
         WorkspaceData,
     },
-    package_manager::{self, PackageManager, WorkspaceGlobs},
+    package_manager::{self, PackageManager},
+    workspaces::WorkspaceGlobs,
 };
 
 use crate::{

--- a/crates/turborepo-filewatch/src/package_watcher.rs
+++ b/crates/turborepo-filewatch/src/package_watcher.rs
@@ -508,7 +508,7 @@ impl Subscriber {
                 ..
             } => {
                 let resp = DiscoveryResponse {
-                    package_manager: *package_manager,
+                    package_manager: package_manager.clone(),
                     workspaces: workspaces.values().cloned().collect(),
                 };
                 // Note that we could implement PartialEq for DiscoveryResponse, but we

--- a/crates/turborepo-lib/src/commands/config.rs
+++ b/crates/turborepo-lib/src/commands/config.rs
@@ -1,8 +1,6 @@
 use camino::Utf8Path;
 use serde::Serialize;
-use turborepo_repository::{
-    package_graph::PackageGraph, package_json::PackageJson, package_manager::PackageManager,
-};
+use turborepo_repository::{package_graph::PackageGraph, package_json::PackageJson};
 
 use crate::{cli, cli::EnvMode, commands::CommandBase, turbo_json::UIMode};
 
@@ -20,7 +18,7 @@ struct ConfigOutput<'a> {
     enabled: bool,
     spaces_id: Option<&'a str>,
     ui: UIMode,
-    package_manager: PackageManager,
+    package_manager: &'static str,
     daemon: Option<bool>,
     env_mode: EnvMode,
     scm_base: Option<&'a str>,
@@ -36,7 +34,7 @@ pub async fn run(base: CommandBase) -> Result<(), cli::Error> {
         .build()
         .await?;
 
-    let package_manager = package_graph.package_manager();
+    let package_manager = package_graph.package_manager().name();
 
     println!(
         "{}",
@@ -52,7 +50,7 @@ pub async fn run(base: CommandBase) -> Result<(), cli::Error> {
             enabled: config.enabled(),
             spaces_id: config.spaces_id(),
             ui: config.ui(),
-            package_manager: *package_manager,
+            package_manager,
             daemon: config.daemon,
             env_mode: config.env_mode(),
             scm_base: config.scm_base(),

--- a/crates/turborepo-lib/src/commands/info.rs
+++ b/crates/turborepo-lib/src/commands/info.rs
@@ -31,7 +31,7 @@ pub async fn run(base: CommandBase) {
         .and_then(|package_json| {
             PackageManager::read_or_detect_package_manager(&package_json, &base.repo_root).ok()
         })
-        .map_or_else(|| "Not found".to_owned(), |pm| pm.to_string());
+        .map_or_else(|| "Not found".to_owned(), |pm| pm.name().to_string());
 
     println!("CLI:");
     println!("   Version: {}", base.version);

--- a/crates/turborepo-lib/src/commands/ls.rs
+++ b/crates/turborepo-lib/src/commands/ls.rs
@@ -4,10 +4,7 @@ use miette::Diagnostic;
 use serde::Serialize;
 use thiserror::Error;
 use turbopath::AnchoredSystemPath;
-use turborepo_repository::{
-    package_graph::{PackageName, PackageNode},
-    package_manager::PackageManager,
-};
+use turborepo_repository::package_graph::{PackageName, PackageNode};
 use turborepo_telemetry::events::command::CommandEventBuilder;
 use turborepo_ui::{color, cprint, cprintln, ColorConfig, BOLD, BOLD_GREEN, GREY};
 
@@ -32,17 +29,17 @@ struct ItemsWithCount<T> {
 }
 
 #[derive(Clone, Serialize)]
-#[serde(into = "RepositoryDetailsDisplay<'a>")]
+#[serde(into = "RepositoryDetailsDisplay")]
 struct RepositoryDetails<'a> {
     color_config: ColorConfig,
-    package_manager: &'a PackageManager,
+    package_manager: &'static str,
     packages: Vec<(&'a PackageName, &'a AnchoredSystemPath)>,
 }
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-struct RepositoryDetailsDisplay<'a> {
-    package_manager: &'a PackageManager,
+struct RepositoryDetailsDisplay {
+    package_manager: &'static str,
     packages: ItemsWithCount<PackageDetailDisplay>,
 }
 
@@ -52,8 +49,8 @@ struct PackageDetailDisplay {
     path: String,
 }
 
-impl<'a> From<RepositoryDetails<'a>> for RepositoryDetailsDisplay<'a> {
-    fn from(val: RepositoryDetails<'a>) -> Self {
+impl<'a> From<RepositoryDetails<'a>> for RepositoryDetailsDisplay {
+    fn from(val: RepositoryDetails) -> Self {
         RepositoryDetailsDisplay {
             package_manager: val.package_manager,
             packages: ItemsWithCount {
@@ -186,7 +183,7 @@ impl<'a> RepositoryDetails<'a> {
 
         Self {
             color_config,
-            package_manager: package_graph.package_manager(),
+            package_manager: package_graph.package_manager().name(),
             packages,
         }
     }

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -368,7 +368,7 @@ impl RunBuilder {
             }
         };
 
-        repo_telemetry.track_package_manager(pkg_dep_graph.package_manager().to_string());
+        repo_telemetry.track_package_manager(pkg_dep_graph.package_manager().name().to_string());
         repo_telemetry.track_size(pkg_dep_graph.len());
         run_telemetry.track_run_type(self.opts.run_opts.dry_run.is_some());
         let micro_frontend_configs = MicroFrontendsConfigs::new(&self.repo_root, &pkg_dep_graph)?;

--- a/crates/turborepo-lib/src/task_graph/visitor/exec.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/exec.rs
@@ -104,7 +104,7 @@ impl<'a> ExecContextFactory<'a> {
             task_id_for_display,
             task_cache,
             hash_tracker: self.visitor.task_hasher.task_hash_tracker(),
-            package_manager: *self.visitor.package_graph.package_manager(),
+            package_manager: self.visitor.package_graph.package_manager().clone(),
             manager: self.manager.clone(),
             task_hash,
             execution_env,

--- a/crates/turborepo-repository/src/discovery.rs
+++ b/crates/turborepo-repository/src/discovery.rs
@@ -143,7 +143,7 @@ impl PackageDiscovery for LocalPackageDiscovery {
             Err(package_manager::Error::Workspace(_)) => {
                 return Ok(DiscoveryResponse {
                     workspaces: vec![],
-                    package_manager: self.package_manager,
+                    package_manager: self.package_manager.clone(),
                 })
             }
             Err(e) => return Err(Error::Failed(Box::new(e))),
@@ -168,7 +168,7 @@ impl PackageDiscovery for LocalPackageDiscovery {
             .await
             .map(|workspaces| DiscoveryResponse {
                 workspaces,
-                package_manager: self.package_manager,
+                package_manager: self.package_manager.clone(),
             })
     }
 

--- a/crates/turborepo-repository/src/inference.rs
+++ b/crates/turborepo-repository/src/inference.rs
@@ -226,7 +226,7 @@ mod test {
                 Some(RepoState {
                     root: monorepo_root.clone(),
                     mode: RepoMode::MultiPackage,
-                    package_manager: Ok(pnpm),
+                    package_manager: Ok(pnpm.clone()),
                     root_package_json: PackageJson::load(&monorepo_pkg_json).unwrap(),
                 }),
             ),
@@ -235,7 +235,7 @@ mod test {
                 Some(RepoState {
                     root: monorepo_root.clone(),
                     mode: RepoMode::MultiPackage,
-                    package_manager: Ok(pnpm),
+                    package_manager: Ok(pnpm.clone()),
                     root_package_json: PackageJson::load(&monorepo_pkg_json).unwrap(),
                 }),
             ),
@@ -244,7 +244,7 @@ mod test {
                 Some(RepoState {
                     root: monorepo_root.clone(),
                     mode: RepoMode::MultiPackage,
-                    package_manager: Ok(pnpm),
+                    package_manager: Ok(pnpm.clone()),
                     root_package_json: PackageJson::load(&monorepo_pkg_json).unwrap(),
                 }),
             ),
@@ -253,7 +253,7 @@ mod test {
                 Some(RepoState {
                     root: single_root.clone(),
                     mode: RepoMode::SinglePackage,
-                    package_manager: Ok(pnpm),
+                    package_manager: Ok(pnpm.clone()),
                     root_package_json: PackageJson::load(&single_root_package_json).unwrap(),
                 }),
             ),
@@ -262,7 +262,7 @@ mod test {
                 Some(RepoState {
                     root: single_root.clone(),
                     mode: RepoMode::SinglePackage,
-                    package_manager: Ok(pnpm),
+                    package_manager: Ok(pnpm.clone()),
                     root_package_json: PackageJson::load(&single_root_package_json).unwrap(),
                 }),
             ),
@@ -272,7 +272,7 @@ mod test {
                 Some(RepoState {
                     root: standalone.clone(),
                     mode: RepoMode::SinglePackage,
-                    package_manager: Ok(pnpm),
+                    package_manager: Ok(pnpm.clone()),
                     root_package_json: PackageJson::load(&standalone_pkg_json).unwrap(),
                 }),
             ),
@@ -281,7 +281,7 @@ mod test {
                 Some(RepoState {
                     root: standalone_monorepo.clone(),
                     mode: RepoMode::MultiPackage,
-                    package_manager: Ok(pnpm),
+                    package_manager: Ok(pnpm.clone()),
                     root_package_json: PackageJson::load(&standalone_monorepo_package_json)
                         .unwrap(),
                 }),

--- a/crates/turborepo-repository/src/inference.rs
+++ b/crates/turborepo-repository/src/inference.rs
@@ -3,7 +3,8 @@ use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 
 use crate::{
     package_json::PackageJson,
-    package_manager::{self, PackageManager, WorkspaceGlobs},
+    package_manager::{self, PackageManager},
+    workspaces::WorkspaceGlobs,
 };
 
 #[derive(Debug, PartialEq)]

--- a/crates/turborepo-repository/src/lib.rs
+++ b/crates/turborepo-repository/src/lib.rs
@@ -7,3 +7,4 @@ pub mod inference;
 pub mod package_graph;
 pub mod package_json;
 pub mod package_manager;
+pub mod workspaces;

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -350,7 +350,7 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedWorkspaces, T> {
     #[tracing::instrument(skip(self))]
     fn connect_internal_dependencies(
         &mut self,
-        package_manager: PackageManager,
+        package_manager: &PackageManager,
     ) -> Result<(), Error> {
         let npmrc = match package_manager {
             PackageManager::Pnpm | PackageManager::Pnpm6 | PackageManager::Pnpm9 => {
@@ -444,7 +444,7 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedWorkspaces, T> {
             .discover_packages()
             .await?
             .package_manager;
-        self.connect_internal_dependencies(package_manager)?;
+        self.connect_internal_dependencies(&package_manager)?;
 
         let lockfile = match self.populate_lockfile().await {
             Ok(lockfile) => Some(lockfile),
@@ -565,7 +565,7 @@ impl Dependencies {
         repo_root: &AbsoluteSystemPath,
         workspace_json_path: &AnchoredSystemPathBuf,
         workspaces: &HashMap<PackageName, PackageInfo>,
-        package_manager: PackageManager,
+        package_manager: &PackageManager,
         npmrc: Option<&NpmRc>,
         dependencies: I,
     ) -> Self {

--- a/crates/turborepo-repository/src/package_graph/dep_splitter.rs
+++ b/crates/turborepo-repository/src/package_graph/dep_splitter.rs
@@ -20,7 +20,7 @@ impl<'a> DependencySplitter<'a> {
         repo_root: &'a AbsoluteSystemPath,
         workspace_dir: &'a AbsoluteSystemPath,
         workspaces: &'a HashMap<PackageName, PackageInfo>,
-        package_manager: PackageManager,
+        package_manager: &PackageManager,
         npmrc: Option<&'a NpmRc>,
     ) -> Self {
         Self {

--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -19,7 +19,7 @@ use miette::{Diagnostic, NamedSource, SourceSpan};
 use node_semver::SemverError;
 use npm::NpmDetector;
 use regex::Regex;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use thiserror::Error;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, PathError, RelativeUnixPath};
 use turborepo_errors::Spanned;
@@ -68,8 +68,7 @@ impl From<Workspaces> for Vec<String> {
     }
 }
 
-#[derive(Debug, Serialize, PartialEq, Eq, Clone, Copy)]
-#[serde(rename_all = "lowercase")]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum PackageManager {
     Berry,
     Npm,
@@ -82,15 +81,7 @@ pub enum PackageManager {
 
 impl Display for PackageManager {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            PackageManager::Berry => write!(f, "berry"),
-            PackageManager::Npm => write!(f, "npm"),
-            PackageManager::Pnpm => write!(f, "pnpm"),
-            PackageManager::Pnpm6 => write!(f, "pnpm6"),
-            PackageManager::Pnpm9 => write!(f, "pnpm9"),
-            PackageManager::Yarn => write!(f, "yarn"),
-            PackageManager::Bun => write!(f, "bun"),
-        }
+        write!(f, "{}", self.name())
     }
 }
 
@@ -351,6 +342,18 @@ impl PackageManager {
             Self::Bun,
         ]
         .as_slice()
+    }
+
+    pub fn name(&self) -> &'static str {
+        match self {
+            PackageManager::Berry => "berry",
+            PackageManager::Npm => "npm",
+            PackageManager::Pnpm => "pnpm",
+            PackageManager::Pnpm6 => "pnpm6",
+            PackageManager::Pnpm9 => "pnpm9",
+            PackageManager::Yarn => "yarn",
+            PackageManager::Bun => "bun",
+        }
     }
 
     pub fn command(&self) -> &'static str {

--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -8,11 +8,9 @@ use std::{
     fmt::{self, Display},
     fs,
     process::Command,
-    str::FromStr,
 };
 
 use bun::BunDetector;
-use globwalk::{fix_glob_pattern, ValidatedGlob};
 use itertools::{Either, Itertools};
 use lazy_regex::{lazy_regex, Lazy};
 use miette::{Diagnostic, NamedSource, SourceSpan};
@@ -21,16 +19,16 @@ use npm::NpmDetector;
 use regex::Regex;
 use serde::Deserialize;
 use thiserror::Error;
-use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, PathError, RelativeUnixPath};
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, RelativeUnixPath};
 use turborepo_errors::Spanned;
 use turborepo_lockfiles::Lockfile;
-use wax::{Any, Glob, Program};
 use which::which;
 
 use crate::{
     discovery,
     package_json::{self, PackageJson},
     package_manager::{pnpm::PnpmDetector, yarn::YarnDetector},
+    workspaces::WorkspaceGlobs,
 };
 
 #[derive(Debug, Deserialize)]
@@ -77,123 +75,6 @@ pub enum PackageManager {
     Pnpm6,
     Yarn,
     Bun,
-}
-
-// WorkspaceGlobs is suitable for finding package.json files via globwalk
-#[derive(Clone)]
-pub struct WorkspaceGlobs {
-    directory_inclusions: Any<'static>,
-    directory_exclusions: Any<'static>,
-    package_json_inclusions: Vec<ValidatedGlob>,
-    pub raw_inclusions: Vec<String>,
-    pub raw_exclusions: Vec<String>,
-    validated_exclusions: Vec<ValidatedGlob>,
-}
-
-impl fmt::Debug for WorkspaceGlobs {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("WorkspaceGlobs")
-            .field("inclusions", &self.raw_inclusions)
-            .field("exclusions", &self.raw_exclusions)
-            .finish()
-    }
-}
-
-impl PartialEq for WorkspaceGlobs {
-    fn eq(&self, other: &Self) -> bool {
-        // Use the literals for comparison, not the compiled globs
-        self.raw_inclusions == other.raw_inclusions && self.raw_exclusions == other.raw_exclusions
-    }
-}
-
-impl Eq for WorkspaceGlobs {}
-
-fn glob_with_contextual_error<S: AsRef<str>>(raw: S) -> Result<Glob<'static>, Error> {
-    let raw = raw.as_ref();
-    let fixed = fix_glob_pattern(raw);
-    Glob::new(&fixed)
-        .map(|g| g.into_owned())
-        .map_err(|e| Error::Glob(fixed, Box::new(e)))
-}
-
-fn any_with_contextual_error(
-    precompiled: Vec<Glob<'static>>,
-    text: Vec<String>,
-) -> Result<wax::Any<'static>, Error> {
-    wax::any(precompiled).map_err(|e| {
-        let text = text.iter().join(",");
-        Error::Glob(text, Box::new(e))
-    })
-}
-
-impl WorkspaceGlobs {
-    pub fn new<S: Into<String>>(inclusions: Vec<S>, exclusions: Vec<S>) -> Result<Self, Error> {
-        // take ownership of the inputs
-        let raw_inclusions: Vec<String> = inclusions
-            .into_iter()
-            .map(|s| s.into())
-            .collect::<Vec<String>>();
-        let package_json_inclusions = raw_inclusions
-            .iter()
-            .map(|s| {
-                let mut s: String = s.clone();
-                if s.ends_with('/') {
-                    s.push_str("package.json");
-                } else {
-                    s.push_str("/package.json");
-                }
-                ValidatedGlob::from_str(&s)
-            })
-            .collect::<Result<Vec<ValidatedGlob>, _>>()?;
-        let raw_exclusions: Vec<String> = exclusions
-            .into_iter()
-            .map(|s| s.into())
-            .collect::<Vec<String>>();
-        let inclusion_globs = raw_inclusions
-            .iter()
-            .map(glob_with_contextual_error)
-            .collect::<Result<Vec<_>, _>>()?;
-        let exclusion_globs = raw_exclusions
-            .iter()
-            .map(glob_with_contextual_error)
-            .collect::<Result<Vec<_>, _>>()?;
-        let validated_exclusions = raw_exclusions
-            .iter()
-            .map(|e| ValidatedGlob::from_str(e))
-            .collect::<Result<Vec<_>, _>>()?;
-        Ok(Self {
-            directory_inclusions: any_with_contextual_error(
-                inclusion_globs,
-                raw_inclusions.clone(),
-            )?,
-            directory_exclusions: any_with_contextual_error(
-                exclusion_globs,
-                raw_exclusions.clone(),
-            )?,
-            package_json_inclusions,
-            validated_exclusions,
-            raw_exclusions,
-            raw_inclusions,
-        })
-    }
-
-    /// Checks if the given `target` matches this `WorkspaceGlobs`.
-    ///
-    /// Errors:
-    /// This function returns an Err if `root` is not a valid anchor for
-    /// `target`
-    pub fn target_is_workspace(
-        &self,
-        root: &AbsoluteSystemPath,
-        target: &AbsoluteSystemPath,
-    ) -> Result<bool, PathError> {
-        let search_value = root.anchor(target)?;
-
-        let includes = self.directory_inclusions.is_match(&search_value);
-        let excludes = self.directory_exclusions.is_match(&search_value);
-
-        Ok(includes && !excludes)
-    }
 }
 
 #[derive(Debug, Error)]
@@ -300,11 +181,7 @@ pub enum Error {
         text: NamedSource,
     },
     #[error(transparent)]
-    WalkError(#[from] globwalk::WalkError),
-    #[error("invalid workspace glob {0}: {1}")]
-    Glob(String, #[source] Box<wax::BuildError>),
-    #[error("invalid globwalk pattern {0}")]
-    Globwalk(#[from] globwalk::GlobError),
+    WorkspaceGlob(#[from] crate::workspaces::Error),
     #[error(transparent)]
     Lockfile(#[from] turborepo_lockfiles::Error),
     #[error("lockfile not found at {0}")]
@@ -528,14 +405,7 @@ impl PackageManager {
         repo_root: &AbsoluteSystemPath,
     ) -> Result<impl Iterator<Item = AbsoluteSystemPathBuf>, Error> {
         let globs = self.get_workspace_globs(repo_root)?;
-
-        let files = globwalk::globwalk(
-            repo_root,
-            &globs.package_json_inclusions,
-            &globs.validated_exclusions,
-            globwalk::WalkType::Files,
-        )?;
-        Ok(files.into_iter())
+        Ok(globs.get_package_jsons(repo_root)?)
     }
 
     pub fn lockfile_name(&self) -> &'static str {
@@ -916,19 +786,5 @@ mod tests {
             serde_json::from_str("{ \"workspaces\": {\"packages\": [\"packages/**\"]}}")?;
         assert_eq!(nested.workspaces.as_ref(), vec!["packages/**"]);
         Ok(())
-    }
-
-    #[test]
-    fn test_workspace_globs_trailing_slash() {
-        let globs =
-            WorkspaceGlobs::new(vec!["scripts/", "packages/**"], vec!["package/template"]).unwrap();
-        assert_eq!(
-            &globs
-                .package_json_inclusions
-                .iter()
-                .map(|i| i.as_str())
-                .collect::<Vec<_>>(),
-            &["scripts/package.json", "packages/**/package.json"]
-        );
     }
 }

--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -79,12 +79,6 @@ pub enum PackageManager {
     Bun,
 }
 
-impl Display for PackageManager {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.name())
-    }
-}
-
 // WorkspaceGlobs is suitable for finding package.json files via globwalk
 #[derive(Clone)]
 pub struct WorkspaceGlobs {
@@ -496,7 +490,7 @@ impl PackageManager {
             _ => {
                 let managers = detected_package_managers
                     .iter()
-                    .map(|mgr| mgr.to_string())
+                    .map(|mgr| mgr.name().to_string())
                     .collect();
                 Err(Error::MultiplePackageManagers { managers })
             }
@@ -720,7 +714,7 @@ mod tests {
             let found = mgr.get_package_jsons(&basic).unwrap();
             let mut found = Vec::from_iter(found);
             found.sort();
-            assert_eq!(found, basic_expected, "{}", mgr);
+            assert_eq!(found, basic_expected, "{}", mgr.name());
         }
     }
 

--- a/crates/turborepo-repository/src/workspaces.rs
+++ b/crates/turborepo-repository/src/workspaces.rs
@@ -1,0 +1,178 @@
+use std::{fmt, str::FromStr as _};
+
+use globwalk::{fix_glob_pattern, ValidatedGlob};
+use itertools::Itertools as _;
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, PathError};
+use wax::{Any, Glob, Program as _};
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("invalid workspace glob {fixed}: {err}")]
+    Glob {
+        fixed: String,
+        #[source]
+        err: Box<wax::BuildError>,
+    },
+    #[error("invalid globwalk pattern {0}")]
+    Globwalk(#[from] globwalk::GlobError),
+    #[error(transparent)]
+    WalkError(#[from] globwalk::WalkError),
+}
+
+// WorkspaceGlobs is suitable for finding package.json files via globwalk
+#[derive(Clone)]
+pub struct WorkspaceGlobs {
+    directory_inclusions: Any<'static>,
+    directory_exclusions: Any<'static>,
+    package_json_inclusions: Vec<ValidatedGlob>,
+    pub raw_inclusions: Vec<String>,
+    pub raw_exclusions: Vec<String>,
+    validated_exclusions: Vec<ValidatedGlob>,
+}
+
+impl Error {
+    pub fn invalid_glob(fixed: String, err: wax::BuildError) -> Self {
+        Self::Glob {
+            fixed,
+            err: Box::new(err),
+        }
+    }
+}
+
+impl fmt::Debug for WorkspaceGlobs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WorkspaceGlobs")
+            .field("inclusions", &self.raw_inclusions)
+            .field("exclusions", &self.raw_exclusions)
+            .finish()
+    }
+}
+
+impl PartialEq for WorkspaceGlobs {
+    fn eq(&self, other: &Self) -> bool {
+        // Use the literals for comparison, not the compiled globs
+        self.raw_inclusions == other.raw_inclusions && self.raw_exclusions == other.raw_exclusions
+    }
+}
+
+impl Eq for WorkspaceGlobs {}
+
+fn glob_with_contextual_error<S: AsRef<str>>(raw: S) -> Result<Glob<'static>, Error> {
+    let raw = raw.as_ref();
+    let fixed = fix_glob_pattern(raw);
+    Glob::new(&fixed)
+        .map(|g| g.into_owned())
+        .map_err(|e| Error::invalid_glob(fixed, e))
+}
+
+fn any_with_contextual_error(
+    precompiled: Vec<Glob<'static>>,
+    text: Vec<String>,
+) -> Result<wax::Any<'static>, Error> {
+    wax::any(precompiled).map_err(|e| {
+        let text = text.iter().join(",");
+        Error::invalid_glob(text, e)
+    })
+}
+
+impl WorkspaceGlobs {
+    pub fn new<S: Into<String>>(inclusions: Vec<S>, exclusions: Vec<S>) -> Result<Self, Error> {
+        // take ownership of the inputs
+        let raw_inclusions: Vec<String> = inclusions
+            .into_iter()
+            .map(|s| s.into())
+            .collect::<Vec<String>>();
+        let package_json_inclusions = raw_inclusions
+            .iter()
+            .map(|s| {
+                let mut s: String = s.clone();
+                if s.ends_with('/') {
+                    s.push_str("package.json");
+                } else {
+                    s.push_str("/package.json");
+                }
+                ValidatedGlob::from_str(&s)
+            })
+            .collect::<Result<Vec<ValidatedGlob>, _>>()?;
+        let raw_exclusions: Vec<String> = exclusions
+            .into_iter()
+            .map(|s| s.into())
+            .collect::<Vec<String>>();
+        let inclusion_globs = raw_inclusions
+            .iter()
+            .map(glob_with_contextual_error)
+            .collect::<Result<Vec<_>, _>>()?;
+        let exclusion_globs = raw_exclusions
+            .iter()
+            .map(glob_with_contextual_error)
+            .collect::<Result<Vec<_>, _>>()?;
+        let validated_exclusions = raw_exclusions
+            .iter()
+            .map(|e| ValidatedGlob::from_str(e))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            directory_inclusions: any_with_contextual_error(
+                inclusion_globs,
+                raw_inclusions.clone(),
+            )?,
+            directory_exclusions: any_with_contextual_error(
+                exclusion_globs,
+                raw_exclusions.clone(),
+            )?,
+            package_json_inclusions,
+            validated_exclusions,
+            raw_exclusions,
+            raw_inclusions,
+        })
+    }
+
+    /// Checks if the given `target` matches this `WorkspaceGlobs`.
+    ///
+    /// Errors:
+    /// This function returns an Err if `root` is not a valid anchor for
+    /// `target`
+    pub fn target_is_workspace(
+        &self,
+        root: &AbsoluteSystemPath,
+        target: &AbsoluteSystemPath,
+    ) -> Result<bool, PathError> {
+        let search_value = root.anchor(target)?;
+
+        let includes = self.directory_inclusions.is_match(&search_value);
+        let excludes = self.directory_exclusions.is_match(&search_value);
+
+        Ok(includes && !excludes)
+    }
+
+    pub fn get_package_jsons(
+        &self,
+        repo_root: &AbsoluteSystemPath,
+    ) -> Result<impl Iterator<Item = AbsoluteSystemPathBuf>, Error> {
+        let files = globwalk::globwalk(
+            repo_root,
+            &self.package_json_inclusions,
+            &self.validated_exclusions,
+            globwalk::WalkType::Files,
+        )?;
+        Ok(files.into_iter())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_workspace_globs_trailing_slash() {
+        let globs =
+            WorkspaceGlobs::new(vec!["scripts/", "packages/**"], vec!["package/template"]).unwrap();
+        assert_eq!(
+            &globs
+                .package_json_inclusions
+                .iter()
+                .map(|i| i.as_str())
+                .collect::<Vec<_>>(),
+            &["scripts/package.json", "packages/**/package.json"]
+        );
+    }
+}

--- a/packages/turbo-repository/rust/src/internal.rs
+++ b/packages/turbo-repository/rust/src/internal.rs
@@ -63,14 +63,14 @@ impl Workspace {
             })?;
         let workspace_state = WorkspaceState::infer(&reference_dir)?;
         let is_multi_package = workspace_state.mode == WorkspaceType::MultiPackage;
-        let package_manager_name =
-            *workspace_state
-                .package_manager
-                .as_ref()
-                .map_err(|error| Error::PackageManager {
-                    error: error.to_string(),
-                    path: workspace_state.root.clone(),
-                })?;
+        let package_manager_name = workspace_state
+            .package_manager
+            .as_ref()
+            .map_err(|error| Error::PackageManager {
+                error: error.to_string(),
+                path: workspace_state.root.clone(),
+            })?
+            .name();
 
         let workspace_root = &workspace_state.root;
         let root_package_json = PackageJson::load(&workspace_root.join_component("package.json"))?;

--- a/packages/turbo-repository/rust/src/internal.rs
+++ b/packages/turbo-repository/rust/src/internal.rs
@@ -104,7 +104,7 @@ impl Workspace {
                 path: self.workspace_state.root.clone(),
             })?;
 
-        let package_manager = *package_manager;
+        let package_manager = package_manager.clone();
         let workspace_root = self.workspace_state.root.clone();
 
         let package_json_paths =


### PR DESCRIPTION
### Description

A prefactor for cleaning up the `PackageManager` enum. If we want to make this a richer data structure we need to remove some behaviors that other crates might be depending on. This is just a small PR, the far larger one will be removing direct pattern matching on `PackageManager` variants.

### Testing Instructions

This is purely removal of code and moving of code. Relying on existing unit tests
