### PR TITLE
chore(ci): remove determine step

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,16 @@ on:
   push:
     branches: [main]
   pull_request:
+    paths:
+      - ".github/actions/**"
+      - .github/workflows/lint.yml
+      - "**/*.{yml,yaml,md,mdx,js,jsx,ts,tsx,json,toml,css}"
+      - pnpm-lock.yaml
+      - package.json
+      - "Cargo.**"
+      - "crates/**"
+      - ".cargo/**"
+      - rust-toolchain
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -14,54 +24,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  determine_jobs:
-    name: Determine jobs to run
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: CI related changes
-        id: ci
-        uses: technote-space/get-diff-action@v6
-        with:
-          PATTERNS: |
-            .github/actions/**
-            .github/workflows/lint.yml
-
-      - name: Rust related changes
-        id: rust
-        uses: technote-space/get-diff-action@v6
-        with:
-          PATTERNS: |
-            pnpm-lock.yaml
-            package.json
-            Cargo.**
-            crates/**
-            shim/**
-            xtask/**
-            .cargo/**
-            rust-toolchain
-            !**.md
-            !**.mdx
-
-      - name: Formatting related changes
-        id: format
-        uses: technote-space/get-diff-action@v6
-        with:
-          PATTERNS: |
-            **/*.{yml,yaml,md,mdx,js,jsx,ts,tsx,json,toml,css}
-
-    outputs:
-      rust: ${{ steps.ci.outputs.diff != '' || steps.rust.outputs.diff != '' }}
-      format: ${{ steps.ci.outputs.diff != '' || steps.format.outputs.diff != '' }}
-
   rust_lint:
-    needs: [determine_jobs]
-    if: needs.determine_jobs.outputs.rust == 'true'
     name: Rust lints
     runs-on:
       - "self-hosted"
@@ -96,8 +59,6 @@ jobs:
       - "linux"
       - "x64"
       - "metal"
-    needs: determine_jobs
-    if: needs.determine_jobs.outputs.format == 'true'
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches: [main]
   pull_request:
+    paths:
+      - "packages/**"
+      - ".github/actions/**"
+      - ".github/workflows/test-js-packages.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -14,40 +18,9 @@ permissions:
   pull-requests: read
 
 jobs:
-  determine_jobs:
-    name: Determine jobs to run
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: CI related changes
-        id: ci
-        uses: technote-space/get-diff-action@v6
-        with:
-          PATTERNS: |
-            .github/actions/**
-            .github/workflows/test-js-packages.yml
-
-      - name: /packages related changes
-        id: packages
-        uses: technote-space/get-diff-action@v6
-        with:
-          PATTERNS: |
-            packages/**
-
-    outputs:
-      ci: ${{ steps.ci.outputs.diff != ''}}
-      packages: ${{ steps.packages.outputs.diff != '' }}
-
   js_packages:
     name: "JS Package Tests (${{matrix.os.name}}, Node ${{matrix.node-version}})"
     timeout-minutes: 30
-    if: needs.determine_jobs.outputs.ci == 'true' || needs.determine_jobs.outputs.packages == 'true'
-    needs: [determine_jobs]
     runs-on: ${{ matrix.os.runner }}
     strategy:
       fail-fast: false
@@ -109,7 +82,6 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs:
-      - determine_jobs
       - js_packages
     steps:
       - name: Compute info
@@ -128,7 +100,6 @@ jobs:
             fi
           }
 
-          subjob ${{needs.determine_jobs.result}}
           subjob ${{needs.js_packages.result}}
 
           if [ "$cancelled" = "true" ]; then

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -14,101 +14,8 @@ permissions:
   pull-requests: read
 
 jobs:
-  determine_jobs:
-    name: Determine jobs to run
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: CI related changes
-        id: ci
-        uses: technote-space/get-diff-action@v6
-        with:
-          PATTERNS: |
-            .github/actions/**
-            .github/workflows/turborepo-test.yml
-
-      - name: Root cargo related changes
-        id: cargo
-        uses: technote-space/get-diff-action@v6
-        with:
-          PATTERNS: |
-            Cargo.*
-            rust-toolchain
-            cli/turbo.json
-
-      - name: Turborepo version changes
-        id: turborepo_version
-        uses: technote-space/get-diff-action@v6
-        with:
-          PATTERNS: |
-            version.txt
-
-      - name: Rust related changes
-        id: rust
-        uses: technote-space/get-diff-action@v6
-        with:
-          PATTERNS: |
-            pnpm-lock.yaml
-            package.json
-            Cargo.**
-            crates/**
-            shim/**
-            xtask/**
-            .cargo/**
-            rust-toolchain
-            !**.md
-            !**.mdx
-
-      - name: Turborepo Rust related changes
-        id: turborepo_rust
-        uses: technote-space/get-diff-action@v6
-        with:
-          PATTERNS: |
-            pnpm-lock.yaml
-            package.json
-            crates/turborepo*/**
-            .cargo/**
-            rust-toolchain
-            !**.md
-            !**.mdx
-
-      - name: Turborepo integration tests changes
-        id: turborepo_integration
-        uses: technote-space/get-diff-action@v6
-        with:
-          PATTERNS: |
-            turborepo-tests/integration/**
-            turborepo-tests/helpers/**
-
-      - name: Examples related changes
-        id: examples
-        uses: technote-space/get-diff-action@v6
-        with:
-          PATTERNS: |
-            examples/**
-            turborepo-tests/example-*/**
-            turborepo-tests/helpers/**
-            !**.md
-            !**.mdx
-
-    outputs:
-      rust: ${{ steps.ci.outputs.diff != '' || steps.rust.outputs.diff != '' }}
-      cargo_only: ${{ steps.ci.outputs.diff != '' || (steps.cargo.outputs.diff != '' && steps.turborepo_rust.outputs.diff == '') }}
-      # We only test workspace dependency changes on main, not on PRs to speed up CI
-      cargo_on_main: ${{ steps.ci.outputs.diff != '' || (steps.cargo.outputs.diff != '' && github.event_name == 'push' && github.ref == 'refs/heads/main') }}
-      turborepo_rust: ${{ steps.ci.outputs.diff != '' || steps.turborepo_rust.outputs.diff != '' }}
-      turborepo_integration: ${{ steps.ci.outputs.diff != '' || steps.turborepo_rust.outputs.diff != ''  || steps.turborepo_integration.outputs.diff != '' }}
-      examples: ${{ steps.ci.outputs.diff != '' || steps.examples.outputs.diff != '' || steps.turborepo_version.outputs.diff != '' }}
-
   integration:
     name: Turborepo Integration
-    needs: [determine_jobs]
-    if: needs.determine_jobs.outputs.turborepo_integration == 'true'
     runs-on: ${{ matrix.os.runner }}
     timeout-minutes: 45
     strategy:
@@ -159,8 +66,6 @@ jobs:
 
   examples:
     name: Turborepo Examples
-    needs: [determine_jobs]
-    if: needs.determine_jobs.outputs.examples == 'true'
     timeout-minutes: 40
 
     runs-on: ubuntu-latest
@@ -198,8 +103,6 @@ jobs:
         run: corepack disable
 
   rust_lint:
-    needs: [determine_jobs]
-    if: needs.determine_jobs.outputs.rust == 'true'
     name: Rust lints
     runs-on:
       - "self-hosted"
@@ -236,12 +139,7 @@ jobs:
           npx --package @ast-grep/cli -- ast-grep scan $(cargo groups list turborepo-libraries | awk '{ print $2 }' | tr '\n' ' ')
 
   rust_check:
-    needs: [determine_jobs]
     # We test dependency changes only on main
-    if: |
-      (needs.determine_jobs.outputs.rust == 'true' && needs.determine_jobs.outputs.turborepo_rust == 'true') ||
-      needs.determine_jobs.outputs.cargo_on_main == 'true' ||
-      needs.determine_jobs.outputs.cargo_only == 'true'
     name: Turborepo rust check
     runs-on:
       - "self-hosted"
@@ -263,7 +161,6 @@ jobs:
           cargo check --workspace
 
   rust_test:
-    needs: [rust_check]
     strategy:
       fail-fast: false
       matrix:
@@ -329,7 +226,6 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs:
-      - determine_jobs
       - integration
       - examples
       - rust_lint
@@ -352,7 +248,6 @@ jobs:
             fi
           }
 
-          subjob ${{needs.determine_jobs.result}}
           subjob ${{needs.integration.result}}
           subjob ${{needs.examples.result}}
           subjob ${{needs.rust_lint.result}}


### PR DESCRIPTION
### Description

Remove our usage of `technote-space/get-diff-action` which uses Node 16 and is deprecated. Node 16 jobs are getting shut off tomorrow!

In places where it made sense, I used the [paths](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore) syntax to limit when workflows get run. Reading the docs I think this only works at the workflow level?



### Testing Instructions

CI on this PR
