### PR TITLE
refactor(opts): remove config from opts

### DIFF
--- a/crates/turborepo-cache/src/http.rs
+++ b/crates/turborepo-cache/src/http.rs
@@ -337,7 +337,12 @@ mod test {
             "2.0.0",
             true,
         )?;
-        let opts = CacheOpts::default();
+        let opts = CacheOpts {
+            cache_dir: ".turbo/cache".into(),
+            cache: Default::default(),
+            workers: 0,
+            remote_cache_opts: None,
+        };
         let api_auth = APIAuth {
             team_id: Some("my-team".to_string()),
             token: "my-token".to_string(),

--- a/crates/turborepo-cache/src/lib.rs
+++ b/crates/turborepo-cache/src/lib.rs
@@ -182,7 +182,7 @@ pub struct CacheOpts {
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RemoteCacheOpts {
-    pub unused_team_id: Option<String>,
+    unused_team_id: Option<String>,
     signature: bool,
 }
 

--- a/crates/turborepo-cache/src/lib.rs
+++ b/crates/turborepo-cache/src/lib.rs
@@ -172,7 +172,7 @@ impl Default for CacheActions {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CacheOpts {
     pub cache_dir: Utf8PathBuf,
     pub cache: CacheConfig,
@@ -182,7 +182,7 @@ pub struct CacheOpts {
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RemoteCacheOpts {
-    unused_team_id: Option<String>,
+    pub unused_team_id: Option<String>,
     signature: bool,
 }
 

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1283,8 +1283,7 @@ pub async fn run(
             }
         }
         Command::Config => {
-            let base = CommandBase::new(cli_args.clone(), repo_root, version, color_config)?;
-            config::run(base).await?;
+            config::run(repo_root, cli_args).await?;
             Ok(0)
         }
         Command::Ls {

--- a/crates/turborepo-lib/src/commands/config.rs
+++ b/crates/turborepo-lib/src/commands/config.rs
@@ -28,7 +28,7 @@ struct ConfigOutput<'a> {
 }
 
 pub async fn run(repo_root: AbsoluteSystemPathBuf, args: Args) -> Result<(), cli::Error> {
-    let config = CommandBase::config_init(&repo_root, &args)?;
+    let config = CommandBase::load_config(&repo_root, &args)?;
     let root_package_json = PackageJson::load(&repo_root.join_component("package.json"))?;
 
     let package_graph = PackageGraph::builder(&repo_root, root_package_json)

--- a/crates/turborepo-lib/src/commands/config.rs
+++ b/crates/turborepo-lib/src/commands/config.rs
@@ -1,8 +1,9 @@
 use camino::Utf8Path;
 use serde::Serialize;
+use turbopath::AbsoluteSystemPathBuf;
 use turborepo_repository::{package_graph::PackageGraph, package_json::PackageJson};
 
-use crate::{cli, cli::EnvMode, commands::CommandBase, turbo_json::UIMode};
+use crate::{cli, cli::EnvMode, commands::CommandBase, turbo_json::UIMode, Args};
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -26,11 +27,11 @@ struct ConfigOutput<'a> {
     cache_dir: &'a Utf8Path,
 }
 
-pub async fn run(base: CommandBase) -> Result<(), cli::Error> {
-    let config = base.config();
-    let root_package_json = PackageJson::load(&base.repo_root.join_component("package.json"))?;
+pub async fn run(repo_root: AbsoluteSystemPathBuf, args: Args) -> Result<(), cli::Error> {
+    let config = CommandBase::config_init(&repo_root, &args)?;
+    let root_package_json = PackageJson::load(&repo_root.join_component("package.json"))?;
 
-    let package_graph = PackageGraph::builder(&base.repo_root, root_package_json)
+    let package_graph = PackageGraph::builder(&repo_root, root_package_json)
         .build()
         .await?;
 

--- a/crates/turborepo-lib/src/commands/link.rs
+++ b/crates/turborepo-lib/src/commands/link.rs
@@ -639,7 +639,7 @@ mod test {
             .build()?;
 
         let mut base = CommandBase::from_opts(
-            Opts::new(&Args::default(), config)?,
+            Opts::new(&repo_root, &Args::default(), config)?,
             repo_root.clone(),
             "1.0.0",
             ColorConfig::new(false),
@@ -701,7 +701,7 @@ mod test {
             .build()?;
 
         let mut base = CommandBase::from_opts(
-            Opts::new(&Args::default(), config)?,
+            Opts::new(&repo_root, &Args::default(), config)?,
             repo_root.clone(),
             "",
             ColorConfig::new(false),

--- a/crates/turborepo-lib/src/commands/link.rs
+++ b/crates/turborepo-lib/src/commands/link.rs
@@ -174,6 +174,7 @@ pub async fn link(
     let api_client = base.api_client()?;
     let token = base
         .opts()
+        .api_client_opts
         .token
         .as_deref()
         .ok_or_else(|| Error::TokenNotFound {

--- a/crates/turborepo-lib/src/commands/link.rs
+++ b/crates/turborepo-lib/src/commands/link.rs
@@ -174,8 +174,8 @@ pub async fn link(
     let api_client = base.api_client()?;
     let token = base
         .opts()
-        .config
-        .token()
+        .token
+        .as_deref()
         .ok_or_else(|| Error::TokenNotFound {
             command: base.color_config.apply(BOLD.apply_to("`npx turbo login`")),
         })?;

--- a/crates/turborepo-lib/src/commands/login.rs
+++ b/crates/turborepo-lib/src/commands/login.rs
@@ -15,9 +15,9 @@ pub async fn sso_login(
     telemetry.track_login_method(LoginMethod::SSO);
     let api_client: APIClient = base.api_client()?;
     let color_config = base.color_config;
-    let login_url_config = base.opts.login_url.to_string();
+    let login_url_config = base.opts.api_client_opts.login_url.to_string();
     let options = LoginOptions {
-        existing_token: base.opts.token.as_deref(),
+        existing_token: base.opts.api_client_opts.token.as_deref(),
         sso_team: Some(sso_team),
         force,
         ..LoginOptions::new(
@@ -72,8 +72,8 @@ pub async fn login(
 
     let api_client: APIClient = base.api_client()?;
     let color_config = base.color_config;
-    let login_url_config = base.opts.login_url.to_string();
-    let existing_token = base.opts.token.as_deref();
+    let login_url_config = base.opts.api_client_opts.login_url.to_string();
+    let existing_token = base.opts.api_client_opts.token.as_deref();
 
     let options = LoginOptions {
         existing_token,

--- a/crates/turborepo-lib/src/commands/login.rs
+++ b/crates/turborepo-lib/src/commands/login.rs
@@ -15,9 +15,9 @@ pub async fn sso_login(
     telemetry.track_login_method(LoginMethod::SSO);
     let api_client: APIClient = base.api_client()?;
     let color_config = base.color_config;
-    let login_url_config = base.config().login_url().to_string();
+    let login_url_config = base.opts.login_url.to_string();
     let options = LoginOptions {
-        existing_token: base.config().token(),
+        existing_token: base.opts.token.as_deref(),
         sso_team: Some(sso_team),
         force,
         ..LoginOptions::new(
@@ -72,9 +72,11 @@ pub async fn login(
 
     let api_client: APIClient = base.api_client()?;
     let color_config = base.color_config;
-    let login_url_config = base.config().login_url().to_string();
+    let login_url_config = base.opts.login_url.to_string();
+    let existing_token = base.opts.token.as_deref();
+
     let options = LoginOptions {
-        existing_token: base.config().token(),
+        existing_token,
         force,
         ..LoginOptions::new(
             &color_config,

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -143,10 +143,10 @@ impl CommandBase {
     }
 
     pub fn api_auth(&self) -> Result<Option<APIAuth>, ConfigError> {
-        let team_id = self.opts.team_id.as_ref();
-        let team_slug = self.opts.team_slug.as_ref();
+        let team_id = self.opts.api_client_opts.team_id.as_ref();
+        let team_slug = self.opts.api_client_opts.team_slug.as_ref();
 
-        let Some(token) = &self.opts.token else {
+        let Some(token) = &self.opts.api_client_opts.token else {
             return Ok(None);
         };
 
@@ -158,11 +158,11 @@ impl CommandBase {
     }
 
     pub fn api_client(&self) -> Result<APIClient, ConfigError> {
-        let timeout = self.opts.timeout;
-        let upload_timeout = self.opts.upload_timeout;
+        let timeout = self.opts.api_client_opts.timeout;
+        let upload_timeout = self.opts.api_client_opts.upload_timeout;
 
         APIClient::new(
-            &self.opts.api_url,
+            &self.opts.api_client_opts.api_url,
             if timeout > 0 {
                 Some(Duration::from_secs(timeout))
             } else {
@@ -174,7 +174,7 @@ impl CommandBase {
                 None
             },
             self.version,
-            self.opts.preflight,
+            self.opts.api_client_opts.preflight,
         )
         .map_err(ConfigError::ApiClient)
     }

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -44,7 +44,7 @@ impl CommandBase {
         version: &'static str,
         color_config: ColorConfig,
     ) -> Result<Self, cli::Error> {
-        let config = Self::config_init(&repo_root, &args)?;
+        let config = Self::load_config(&repo_root, &args)?;
         let opts = Opts::new(&repo_root, &args, config)?;
 
         Ok(Self {
@@ -69,7 +69,7 @@ impl CommandBase {
         }
     }
 
-    pub fn config_init(
+    pub fn load_config(
         repo_root: &AbsoluteSystemPath,
         args: &Args,
     ) -> Result<ConfigurationOptions, ConfigError> {

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -263,7 +263,7 @@ impl<'a> Prune<'a> {
         output_dir: &str,
         telemetry: CommandEventBuilder,
     ) -> Result<Self, Error> {
-        let allow_missing_package_manager = base.opts().config_opts.allow_no_package_manager;
+        let allow_missing_package_manager = base.opts().repo_opts.allow_no_package_manager;
         telemetry.track_arg_usage(
             "dangerously-allow-missing-package-manager",
             allow_missing_package_manager,

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -263,7 +263,7 @@ impl<'a> Prune<'a> {
         output_dir: &str,
         telemetry: CommandEventBuilder,
     ) -> Result<Self, Error> {
-        let allow_missing_package_manager = base.config().allow_no_package_manager();
+        let allow_missing_package_manager = base.opts().allow_no_package_manager;
         telemetry.track_arg_usage(
             "dangerously-allow-missing-package-manager",
             allow_missing_package_manager,

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -263,7 +263,7 @@ impl<'a> Prune<'a> {
         output_dir: &str,
         telemetry: CommandEventBuilder,
     ) -> Result<Self, Error> {
-        let allow_missing_package_manager = base.opts().allow_no_package_manager;
+        let allow_missing_package_manager = base.opts().config_opts.allow_no_package_manager;
         telemetry.track_arg_usage(
             "dangerously-allow-missing-package-manager",
             allow_missing_package_manager,

--- a/crates/turborepo-lib/src/commands/unlink.rs
+++ b/crates/turborepo-lib/src/commands/unlink.rs
@@ -16,7 +16,8 @@ enum UnlinkSpacesResult {
 }
 
 fn unlink_remote_caching(base: &mut CommandBase) -> Result<(), cli::Error> {
-    let needs_disabling = base.opts.team_id.is_some() || base.opts.team_slug.is_some();
+    let needs_disabling = base.opts.api_client_opts.team_id.is_some()
+        || base.opts.api_client_opts.team_slug.is_some();
 
     let output = if needs_disabling {
         let local_config_path = base.local_config_path();
@@ -56,7 +57,8 @@ fn unlink_remote_caching(base: &mut CommandBase) -> Result<(), cli::Error> {
 }
 
 fn unlink_spaces(base: &mut CommandBase) -> Result<(), cli::Error> {
-    let needs_disabling = base.opts().team_id.is_some() || base.opts().team_slug.is_some();
+    let needs_disabling = base.opts().api_client_opts.team_id.is_some()
+        || base.opts().api_client_opts.team_slug.is_some();
 
     if needs_disabling {
         let local_config_path = base.local_config_path();

--- a/crates/turborepo-lib/src/commands/unlink.rs
+++ b/crates/turborepo-lib/src/commands/unlink.rs
@@ -16,7 +16,7 @@ enum UnlinkSpacesResult {
 }
 
 fn unlink_remote_caching(base: &mut CommandBase) -> Result<(), cli::Error> {
-    let needs_disabling = base.config().team_id().is_some() || base.config().team_slug().is_some();
+    let needs_disabling = base.opts.team_id.is_some() || base.opts.team_slug.is_some();
 
     let output = if needs_disabling {
         let local_config_path = base.local_config_path();
@@ -56,7 +56,7 @@ fn unlink_remote_caching(base: &mut CommandBase) -> Result<(), cli::Error> {
 }
 
 fn unlink_spaces(base: &mut CommandBase) -> Result<(), cli::Error> {
-    let needs_disabling = base.config().team_id().is_some() || base.config().team_slug().is_some();
+    let needs_disabling = base.opts().team_id.is_some() || base.opts().team_slug.is_some();
 
     if needs_disabling {
         let local_config_path = base.local_config_path();

--- a/crates/turborepo-lib/src/diagnostics.rs
+++ b/crates/turborepo-lib/src/diagnostics.rs
@@ -406,8 +406,8 @@ impl Diagnostic for RemoteCacheDiagnostic {
             let (has_team_id, has_team_slug) = {
                 let base = base.lock().await;
                 (
-                    base.config().team_id().is_some(),
-                    base.config().team_slug().is_some(),
+                    base.opts().team_id.is_some(),
+                    base.opts().team_slug.is_some(),
                 )
             };
 

--- a/crates/turborepo-lib/src/diagnostics.rs
+++ b/crates/turborepo-lib/src/diagnostics.rs
@@ -406,8 +406,8 @@ impl Diagnostic for RemoteCacheDiagnostic {
             let (has_team_id, has_team_slug) = {
                 let base = base.lock().await;
                 (
-                    base.opts().team_id.is_some(),
-                    base.opts().team_slug.is_some(),
+                    base.opts().api_client_opts.team_id.is_some(),
+                    base.opts().api_client_opts.team_slug.is_some(),
                 )
             };
 

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -625,7 +625,12 @@ mod test {
             is_github_actions: false,
             daemon: None,
         };
-        let cache_opts = CacheOpts::default();
+        let cache_opts = CacheOpts {
+            cache_dir: ".turbo/cache".into(),
+            cache: Default::default(),
+            workers: 0,
+            remote_cache_opts: None,
+        };
         let runcache_opts = RunCacheOpts::default();
         let scope_opts = ScopeOpts {
             pkg_inference_root: None,
@@ -641,10 +646,21 @@ mod test {
         let opts = Opts {
             config,
             root_turbo_json_path,
+            api_url: "".to_string(),
+            timeout: 0,
+            upload_timeout: 0,
+            token: None,
+            team_id: None,
+            team_slug: None,
+            allow_no_package_manager: false,
+            allow_no_turbo_json: false,
             run_opts,
             cache_opts,
             scope_opts,
             runcache_opts,
+
+            login_url: "".to_string(),
+            preflight: false,
         };
         let synthesized = opts.synthesize_command();
         assert_eq!(synthesized, expected);

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -47,7 +47,6 @@ pub enum Error {
 /// including all the layers (env, args, etc.), and the command line arguments.
 #[derive(Debug, Clone)]
 pub struct Opts {
-    pub config: ConfigurationOptions,
     pub root_turbo_json_path: AbsoluteSystemPathBuf,
     pub api_url: String,
     pub timeout: u64,
@@ -162,7 +161,6 @@ impl Opts {
         let allow_no_turbo_json = config.allow_no_turbo_json();
 
         Ok(Self {
-            config,
             root_turbo_json_path,
             api_url,
             timeout,

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -56,7 +56,7 @@ pub struct APIClientOpts {
 }
 
 #[derive(Debug, Clone)]
-pub struct ConfigOpts {
+pub struct RepoOpts {
     pub root_turbo_json_path: AbsoluteSystemPathBuf,
     pub allow_no_package_manager: bool,
     pub allow_no_turbo_json: bool,
@@ -67,7 +67,7 @@ pub struct ConfigOpts {
 /// arguments.
 #[derive(Debug, Clone)]
 pub struct Opts {
-    pub config_opts: ConfigOpts,
+    pub repo_opts: RepoOpts,
     pub api_client_opts: APIClientOpts,
     pub cache_opts: CacheOpts,
     pub run_opts: RunOpts,
@@ -161,10 +161,10 @@ impl Opts {
         let scope_opts = ScopeOpts::try_from(inputs)?;
         let runcache_opts = RunCacheOpts::from(inputs);
         let api_client_opts = APIClientOpts::from(inputs);
-        let config_opts = ConfigOpts::from(inputs);
+        let repo_opts = RepoOpts::from(inputs);
 
         Ok(Self {
-            config_opts,
+            repo_opts,
             run_opts,
             cache_opts,
             scope_opts,
@@ -271,13 +271,13 @@ pub enum ResolvedLogPrefix {
     None,
 }
 
-impl<'a> From<OptsInputs<'a>> for ConfigOpts {
+impl<'a> From<OptsInputs<'a>> for RepoOpts {
     fn from(inputs: OptsInputs<'a>) -> Self {
         let root_turbo_json_path = inputs.config.root_turbo_json_path(inputs.repo_root);
         let allow_no_package_manager = inputs.config.allow_no_package_manager();
         let allow_no_turbo_json = inputs.config.allow_no_turbo_json();
 
-        ConfigOpts {
+        RepoOpts {
             root_turbo_json_path,
             allow_no_package_manager,
             allow_no_turbo_json,
@@ -534,7 +534,7 @@ mod test {
     use turborepo_cache::CacheOpts;
     use turborepo_ui::ColorConfig;
 
-    use super::{APIClientOpts, ConfigOpts, RunOpts};
+    use super::{APIClientOpts, RepoOpts, RunOpts};
     use crate::{
         cli::{Command, DryRunMode, RunArgs},
         commands::CommandBase,
@@ -675,7 +675,7 @@ mod test {
         let root_turbo_json_path = config.root_turbo_json_path(&AbsoluteSystemPathBuf::default());
 
         let opts = Opts {
-            config_opts: ConfigOpts {
+            repo_opts: RepoOpts {
                 root_turbo_json_path,
                 allow_no_package_manager: false,
                 allow_no_turbo_json: false,

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -56,7 +56,6 @@ pub struct RunBuilder {
     opts: Opts,
     api_auth: Option<APIAuth>,
     repo_root: AbsoluteSystemPathBuf,
-    root_turbo_json_path: AbsoluteSystemPathBuf,
     color_config: ColorConfig,
     version: &'static str,
     api_client: APIClient,
@@ -66,8 +65,6 @@ pub struct RunBuilder {
     // this package.
     entrypoint_packages: Option<HashSet<PackageName>>,
     should_print_prelude_override: Option<bool>,
-    allow_missing_package_manager: bool,
-    allow_no_turbo_json: bool,
     // In query, we don't want to validate the engine. Defaults to `true`
     should_validate_engine: bool,
     // If true, we will add all tasks to the graph, even if they are not specified
@@ -80,7 +77,6 @@ impl RunBuilder {
 
         let opts = base.opts();
         let api_auth = base.api_auth()?;
-        let allow_missing_package_manager = base.opts.allow_no_package_manager;
 
         let version = base.version();
         let processes = ProcessManager::new(
@@ -90,8 +86,6 @@ impl RunBuilder {
             // - if we're on windows, we're using the UI
             (!cfg!(windows) || matches!(opts.run_opts.ui_mode, UIMode::Tui)),
         );
-        let root_turbo_json_path = base.opts.root_turbo_json_path.clone();
-        let allow_no_turbo_json = base.opts.allow_no_turbo_json;
 
         let CommandBase {
             repo_root,
@@ -111,9 +105,6 @@ impl RunBuilder {
             analytics_sender: None,
             entrypoint_packages: None,
             should_print_prelude_override: None,
-            allow_missing_package_manager,
-            root_turbo_json_path,
-            allow_no_turbo_json,
             should_validate_engine: true,
             add_all_tasks: false,
         })
@@ -237,7 +228,7 @@ impl RunBuilder {
         run_telemetry.track_is_linked(is_linked);
         run_telemetry.track_arg_usage(
             "dangerously_allow_missing_package_manager",
-            self.allow_missing_package_manager,
+            self.opts.config_opts.allow_no_package_manager,
         );
         // we only track the remote cache if we're linked because this defaults to
         // Vercel
@@ -298,11 +289,11 @@ impl RunBuilder {
         let mut pkg_dep_graph = {
             let builder = PackageGraph::builder(&self.repo_root, root_package_json.clone())
                 .with_single_package_mode(self.opts.run_opts.single_package)
-                .with_allow_no_package_manager(self.allow_missing_package_manager);
+                .with_allow_no_package_manager(self.opts.config_opts.allow_no_package_manager);
 
             // Daemon package discovery depends on packageManager existing in package.json
             let graph = if cfg!(feature = "daemon-package-discovery")
-                && !self.allow_missing_package_manager
+                && !self.opts.config_opts.allow_no_package_manager
             {
                 match (&daemon, self.opts.run_opts.daemon) {
                     (None, Some(true)) => {
@@ -390,18 +381,18 @@ impl RunBuilder {
         let mut turbo_json_loader = if task_access.is_enabled() {
             TurboJsonLoader::task_access(
                 self.repo_root.clone(),
-                self.root_turbo_json_path.clone(),
+                self.opts.config_opts.root_turbo_json_path.clone(),
                 root_package_json.clone(),
             )
         } else if is_single_package {
             TurboJsonLoader::single_package(
                 self.repo_root.clone(),
-                self.root_turbo_json_path.clone(),
+                self.opts.config_opts.root_turbo_json_path.clone(),
                 root_package_json.clone(),
             )
-        } else if !self.root_turbo_json_path.exists() &&
+        } else if !self.opts.config_opts.root_turbo_json_path.exists() &&
         // Infer a turbo.json if allowing no turbo.json is explicitly allowed or if MFE configs are discovered
-        (self.allow_no_turbo_json || micro_frontend_configs.is_some())
+        (self.opts.config_opts.allow_no_turbo_json || micro_frontend_configs.is_some())
         {
             TurboJsonLoader::workspace_no_turbo_json(
                 self.repo_root.clone(),
@@ -411,14 +402,14 @@ impl RunBuilder {
         } else if let Some(micro_frontends) = &micro_frontend_configs {
             TurboJsonLoader::workspace_with_microfrontends(
                 self.repo_root.clone(),
-                self.root_turbo_json_path.clone(),
+                self.opts.config_opts.root_turbo_json_path.clone(),
                 pkg_dep_graph.packages(),
                 micro_frontends.clone(),
             )
         } else {
             TurboJsonLoader::workspace(
                 self.repo_root.clone(),
-                self.root_turbo_json_path.clone(),
+                self.opts.config_opts.root_turbo_json_path.clone(),
                 pkg_dep_graph.packages(),
             )
         };

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -80,8 +80,7 @@ impl RunBuilder {
 
         let opts = base.opts();
         let api_auth = base.api_auth()?;
-        let config = base.config();
-        let allow_missing_package_manager = config.allow_no_package_manager();
+        let allow_missing_package_manager = base.opts.allow_no_package_manager;
 
         let version = base.version();
         let processes = ProcessManager::new(
@@ -91,8 +90,8 @@ impl RunBuilder {
             // - if we're on windows, we're using the UI
             (!cfg!(windows) || matches!(opts.run_opts.ui_mode, UIMode::Tui)),
         );
-        let root_turbo_json_path = config.root_turbo_json_path(&base.repo_root);
-        let allow_no_turbo_json = config.allow_no_turbo_json();
+        let root_turbo_json_path = base.opts.root_turbo_json_path.clone();
+        let allow_no_turbo_json = base.opts.allow_no_turbo_json;
 
         let CommandBase {
             repo_root,

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -228,7 +228,7 @@ impl RunBuilder {
         run_telemetry.track_is_linked(is_linked);
         run_telemetry.track_arg_usage(
             "dangerously_allow_missing_package_manager",
-            self.opts.config_opts.allow_no_package_manager,
+            self.opts.repo_opts.allow_no_package_manager,
         );
         // we only track the remote cache if we're linked because this defaults to
         // Vercel
@@ -289,11 +289,11 @@ impl RunBuilder {
         let mut pkg_dep_graph = {
             let builder = PackageGraph::builder(&self.repo_root, root_package_json.clone())
                 .with_single_package_mode(self.opts.run_opts.single_package)
-                .with_allow_no_package_manager(self.opts.config_opts.allow_no_package_manager);
+                .with_allow_no_package_manager(self.opts.repo_opts.allow_no_package_manager);
 
             // Daemon package discovery depends on packageManager existing in package.json
             let graph = if cfg!(feature = "daemon-package-discovery")
-                && !self.opts.config_opts.allow_no_package_manager
+                && !self.opts.repo_opts.allow_no_package_manager
             {
                 match (&daemon, self.opts.run_opts.daemon) {
                     (None, Some(true)) => {
@@ -381,18 +381,18 @@ impl RunBuilder {
         let mut turbo_json_loader = if task_access.is_enabled() {
             TurboJsonLoader::task_access(
                 self.repo_root.clone(),
-                self.opts.config_opts.root_turbo_json_path.clone(),
+                self.opts.repo_opts.root_turbo_json_path.clone(),
                 root_package_json.clone(),
             )
         } else if is_single_package {
             TurboJsonLoader::single_package(
                 self.repo_root.clone(),
-                self.opts.config_opts.root_turbo_json_path.clone(),
+                self.opts.repo_opts.root_turbo_json_path.clone(),
                 root_package_json.clone(),
             )
-        } else if !self.opts.config_opts.root_turbo_json_path.exists() &&
+        } else if !self.opts.repo_opts.root_turbo_json_path.exists() &&
         // Infer a turbo.json if allowing no turbo.json is explicitly allowed or if MFE configs are discovered
-        (self.opts.config_opts.allow_no_turbo_json || micro_frontend_configs.is_some())
+        (self.opts.repo_opts.allow_no_turbo_json || micro_frontend_configs.is_some())
         {
             TurboJsonLoader::workspace_no_turbo_json(
                 self.repo_root.clone(),
@@ -402,14 +402,14 @@ impl RunBuilder {
         } else if let Some(micro_frontends) = &micro_frontend_configs {
             TurboJsonLoader::workspace_with_microfrontends(
                 self.repo_root.clone(),
-                self.opts.config_opts.root_turbo_json_path.clone(),
+                self.opts.repo_opts.root_turbo_json_path.clone(),
                 pkg_dep_graph.packages(),
                 micro_frontends.clone(),
             )
         } else {
             TurboJsonLoader::workspace(
                 self.repo_root.clone(),
-                self.opts.config_opts.root_turbo_json_path.clone(),
+                self.opts.repo_opts.root_turbo_json_path.clone(),
                 pkg_dep_graph.packages(),
             )
         };

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -113,10 +113,9 @@ impl WatchClient {
         let signal = commands::run::get_signal()?;
         let handler = SignalHandler::new(signal);
 
-        if base.opts.config_opts.root_turbo_json_path != base.repo_root.join_component(CONFIG_FILE)
-        {
+        if base.opts.repo_opts.root_turbo_json_path != base.repo_root.join_component(CONFIG_FILE) {
             return Err(Error::NonStandardTurboJsonPath(
-                base.opts.config_opts.root_turbo_json_path.to_string(),
+                base.opts.repo_opts.root_turbo_json_path.to_string(),
             ));
         }
 

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -112,14 +112,14 @@ impl WatchClient {
     pub async fn new(base: CommandBase, telemetry: CommandEventBuilder) -> Result<Self, Error> {
         let signal = commands::run::get_signal()?;
         let handler = SignalHandler::new(signal);
-        let config = &base.opts.config;
-        let root_turbo_json_path = config.root_turbo_json_path(&base.repo_root);
-        if root_turbo_json_path != base.repo_root.join_component(CONFIG_FILE) {
+
+        if base.opts.root_turbo_json_path != base.repo_root.join_component(CONFIG_FILE) {
             return Err(Error::NonStandardTurboJsonPath(
-                root_turbo_json_path.to_string(),
+                base.opts.root_turbo_json_path.to_string(),
             ));
         }
-        if matches!(config.daemon(), Some(false)) {
+
+        if matches!(base.opts.run_opts.daemon, Some(false)) {
             warn!("daemon is required for watch, ignoring request to disable daemon");
         }
 

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -113,9 +113,10 @@ impl WatchClient {
         let signal = commands::run::get_signal()?;
         let handler = SignalHandler::new(signal);
 
-        if base.opts.root_turbo_json_path != base.repo_root.join_component(CONFIG_FILE) {
+        if base.opts.config_opts.root_turbo_json_path != base.repo_root.join_component(CONFIG_FILE)
+        {
             return Err(Error::NonStandardTurboJsonPath(
-                base.opts.root_turbo_json_path.to_string(),
+                base.opts.config_opts.root_turbo_json_path.to_string(),
             ));
         }
 


### PR DESCRIPTION
### Description

Remove the config field from `Opts` entirely. I'm doing this because the config data already gets partially moved into `Opts`, so by keeping the config around, we have multiple sources for the same data. Now `Opts` is the fully transformed, normalized config for a run.

You can review this commit by commit if you like

### Testing Instructions

