### PR TITLE
chore(ci): run js package tests on lockfile changes

### DIFF
--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -4,6 +4,9 @@ on:
     branches: [main]
   pull_request:
     paths:
+      - package.json
+      - pnpm-workspace.yaml
+      - pnpm-lock.yaml
       - "packages/**"
       - ".github/actions/**"
       - ".github/workflows/test-js-packages.yml"


### PR DESCRIPTION
### Description

https://github.com/vercel/turborepo/pull/9533 displayed that we weren't running JS tests when global JS artifacts were getting changed

### Testing Instructions

👀 
