### PR TITLE
fix(mfe): factor in configs to hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6552,6 +6552,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "test-case",
  "thiserror",
  "turbopath",
  "turborepo-errors",

--- a/crates/turborepo-microfrontends/Cargo.toml
+++ b/crates/turborepo-microfrontends/Cargo.toml
@@ -20,6 +20,7 @@ turborepo-errors = { workspace = true }
 insta = { workspace = true }
 pretty_assertions = { workspace = true }
 tempfile = { workspace = true }
+test-case = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
### Description

Start factoring in any MFE configs found into task hashes so changes to the config will invalidate any applications that are a part of a MFE setup.

⚠️ We achieve this by adding this to the global cache. This is sub-optimal as it means tasks unrelated to MFEs get invalidated, but we make this temporary trade off in favor of correctness. See TODO for the planned path forward.

### Testing Instructions

Added unit tests, verified that changing a MFE config file will now invalidates all MFE apps:
```
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/front $ turbo_dev --skip-infer microfrontends-example-docs#build --output-logs=hash-only
turbo 2.3.4-canary.1

• Running microfrontends-example-docs#build in 84 packages
• Remote caching enabled
@vercel/microfrontends:build: cache hit (outputs already on disk), suppressing logs ea832ad348202d61
microfrontends-example-docs:build: cache hit (outputs already on disk), suppressing logs 2775f59cd3c9f808

 Tasks:    2 successful, 2 total
Cached:    2 cached, 2 total
  Time:    563ms >>> FULL TURBO

[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/front $ vim apps/microfrontends-example-web/microfrontends.json 
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/front $ git diff
diff --git a/apps/microfrontends-example-web/microfrontends.json b/apps/microfrontends-example-web/microfrontends.json
index 0a6883bfc62..13d73b0d47c 100644
--- a/apps/microfrontends-example-web/microfrontends.json
+++ b/apps/microfrontends-example-web/microfrontends.json
@@ -28,7 +28,7 @@
         },
         {
           "group": "docs",
-          "paths": ["/docs"]
+          "paths": ["/docs", "/other"]
         }
       ]
     }
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/front $ turbo_dev --skip-infer microfrontends-example-docs#build --output-logs=hash-only
turbo 2.3.4-canary.1

• Running microfrontends-example-docs#build in 84 packages
• Remote caching enabled
@vercel/microfrontends:build: cache hit, suppressing logs 51679cdd0650be9f
microfrontends-example-docs:build: cache miss, executing b0641267d9eb8cef

 Tasks:    2 successful, 2 total
Cached:    1 cached, 2 total
  Time:    8.936s 


```
