### PR TITLE
chore: fix outdated docs issue template label

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-docs.yml
+++ b/.github/ISSUE_TEMPLATE/1-docs.yml
@@ -2,7 +2,7 @@ name: "Documentation update or improvement"
 description: A request to update or improve documentation
 title: "📚 Docs: "
 labels:
-  - "template: documentation"
+  - "area: docs"
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
### Description

The template was trying to apply a non-existent label. This makes it so the right label gets applied.
