### PR TITLE
fix(mfe): multiple versions

### DIFF
--- a/crates/turborepo-lib/src/microfrontends.rs
+++ b/crates/turborepo-lib/src/microfrontends.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use itertools::Itertools;
 use tracing::warn;
-use turbopath::{AbsoluteSystemPath, RelativeUnixPathBuf};
+use turbopath::{AbsoluteSystemPath, RelativeUnixPath, RelativeUnixPathBuf};
 use turborepo_microfrontends::{Config as MFEConfig, Error, MICROFRONTENDS_PACKAGES};
 use turborepo_repository::package_graph::{PackageGraph, PackageName};
 
@@ -86,10 +86,10 @@ impl MicrofrontendsConfigs {
             .any(|info| info.tasks.contains(task_id))
     }
 
-    pub fn config_filename(&self, package_name: &str) -> Option<&str> {
+    pub fn config_filename(&self, package_name: &str) -> Option<&RelativeUnixPath> {
         let info = self.configs.get(package_name)?;
         let path = info.path.as_ref()?;
-        Some(path.as_str())
+        Some(path)
     }
 
     pub fn update_turbo_json(

--- a/crates/turborepo-lib/src/task_graph/visitor/command.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/command.rs
@@ -211,7 +211,9 @@ impl<'a> CommandProvider for MicroFrontendProxyProvider<'a> {
             let mfe_config_filename = self.mfe_configs.config_filename(task_id.package());
             return Err(Error::MissingMFEDependency {
                 package: task_id.package().into(),
-                mfe_config_filename: mfe_config_filename.unwrap_or_default().to_owned(),
+                mfe_config_filename: mfe_config_filename
+                    .map(|p| p.to_string())
+                    .unwrap_or_default(),
             });
         }
         let local_apps = dev_tasks
@@ -223,7 +225,7 @@ impl<'a> CommandProvider for MicroFrontendProxyProvider<'a> {
             .mfe_configs
             .config_filename(task_id.package())
             .expect("every microfrontends default application should have configuration path");
-        let mfe_path = package_dir.join_component(mfe_config_filename);
+        let mfe_path = self.repo_root.join_unix_path(mfe_config_filename);
         let mut args = vec!["proxy", mfe_path.as_str(), "--names"];
         args.extend(local_apps);
 

--- a/crates/turborepo-microfrontends/src/lib.rs
+++ b/crates/turborepo-microfrontends/src/lib.rs
@@ -126,6 +126,13 @@ impl Config {
         Some(path)
     }
 
+    pub fn version(&self) -> &'static str {
+        match &self.inner {
+            ConfigInner::V1(_) => "1",
+            ConfigInner::V2(_) => "2",
+        }
+    }
+
     fn load_v2_dir(dir: &AbsoluteSystemPath) -> Result<Option<Self>, Error> {
         let load_config =
             |filename: &str| -> Option<(Result<String, io::Error>, AbsoluteSystemPathBuf)> {

--- a/crates/turborepo-microfrontends/src/lib.rs
+++ b/crates/turborepo-microfrontends/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(assert_matches)]
 #![deny(clippy::all)]
 mod configv1;
 mod configv2;
@@ -187,8 +186,6 @@ impl Config {
 
 #[cfg(test)]
 mod test {
-    use std::assert_matches::assert_matches;
-
     use insta::assert_snapshot;
     use tempfile::TempDir;
     use test_case::test_case;


### PR DESCRIPTION
### Description

We had a bug where if there were multiple MFE configs that contained the same application we would defer to config name ordering for which config would get selected. This PR makes it so we now select the newest versioned configuration.

⚠️ Fix a bug I introduced in https://github.com/vercel/turborepo/pull/9582 where I cast the relative unix path to a basic `str` and I then misused it with `join_component`. 

### Testing Instructions

Updated and added unit tests. Tested on a repo with multiple overlapping configs with different versions.