### PR TITLE
chore(ci): enable sccache for integration tests

### DIFF
--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -61,8 +61,29 @@ jobs:
           path: cli/.cram_env
           key: prysk-venv-${{ matrix.os.runner }}
 
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.6
+
       - name: Integration Tests
-        run: turbo run test --filter=turborepo-tests-integration --color --env-mode=strict --token=${{ secrets.TURBO_TOKEN }} --team=${{ vars.TURBO_TEAM }}
+        run: |
+          if [ -z "${RUSTC_WRAPPER}" ]; then
+            unset RUSTC_WRAPPER
+          fi
+          if [ "$RUNNER_OS" == "Windows" ]; then
+              cargo test --workspace --exclude turborepo-napi
+          else
+              cargo test --workspace
+          fi
+          turbo run test --filter=turborepo-tests-integration --color --env-mode=strict --token=${{ secrets.TURBO_TOKEN }} --team=${{ vars.TURBO_TEAM }}
+        shell: bash
+        env:
+          SCCACHE_BUCKET: turborepo-sccache
+          SCCACHE_REGION: us-east-2
+          # Only use sccache if we're in the Vercel repo.
+          RUSTC_WRAPPER: ${{ !github.event.pull_request.head.repo.fork && 'sccache' || '' }}
+          CARGO_INCREMENTAL: 0
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   examples:
     name: Turborepo Examples

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -69,11 +69,6 @@ jobs:
           if [ -z "${RUSTC_WRAPPER}" ]; then
             unset RUSTC_WRAPPER
           fi
-          if [ "$RUNNER_OS" == "Windows" ]; then
-              cargo test --workspace --exclude turborepo-napi
-          else
-              cargo test --workspace
-          fi
           turbo run test --filter=turborepo-tests-integration --color --env-mode=strict --token=${{ secrets.TURBO_TOKEN }} --team=${{ vars.TURBO_TEAM }}
         shell: bash
         env:

--- a/cli/turbo.json
+++ b/cli/turbo.json
@@ -30,7 +30,14 @@
         "rust-src"
       ],
       "passThroughEnv": [
-        "ProgramData"
+        "ProgramData",
+        // sccache related flags
+        "SCCACHE_BUCKET",
+        "SCCACHE_REGION",
+        "RUSTC_WRAPPER",
+        "CARGO_INCREMENTAL",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY"
       ]
     }
   }

--- a/crates/turbo-trace/src/tracer.rs
+++ b/crates/turbo-trace/src/tracer.rs
@@ -67,6 +67,7 @@ pub enum TraceError {
 }
 
 impl TraceResult {
+    #[allow(dead_code)]
     pub fn emit_errors(&self) {
         let handler = Handler::with_tty_emitter(
             ColorConfig::Auto,


### PR DESCRIPTION
### Description

Enable sccache for building the turbo binary in integration tests.

### Testing Instructions

This should provide a speedup for our integration tests:
 - [Normal run](https://github.com/vercel/turborepo/actions/runs/12209798573?pr=9545):
   - Ubuntu: 12m 17s
   - macOs: 25m 45s
   - Windows: 26m 13s
 - [Run with sccache](https://github.com/vercel/turborepo/actions/runs/12245380679?pr=9597)
   - Ubuntu: 7m 8s 
   - macOs: 18m 44s 
   - Windows:  23m 31s 

(I quick double checked that none of these were `turbo` cached, but they did have a warmed `sccache` so external dep changes will degrade speed)