### PR TITLE
feat(tui): bind to toggle task selection pinning

### DIFF
--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -798,6 +798,9 @@ fn update(
         Event::ToggleHelpPopup => {
             app.showing_help_popup = !app.showing_help_popup;
         }
+        Event::TogglePinnedTask => {
+            app.is_task_selection_pinned = !app.is_task_selection_pinned;
+        }
         Event::Input { bytes } => {
             app.forward_input(&bytes)?;
         }

--- a/crates/turborepo-ui/src/tui/event.rs
+++ b/crates/turborepo-ui/src/tui/event.rs
@@ -52,6 +52,7 @@ pub enum Event {
     },
     ToggleSidebar,
     ToggleHelpPopup,
+    TogglePinnedTask,
     SearchEnter,
     SearchExit {
         restore_scroll: bool,

--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -115,6 +115,7 @@ fn translate_key_event(options: InputOptions, key_event: KeyEvent) -> Option<Eve
             Some(Event::ScrollDown)
         }
         KeyCode::Char('m') => Some(Event::ToggleHelpPopup),
+        KeyCode::Char('p') => Some(Event::TogglePinnedTask),
         KeyCode::Up | KeyCode::Char('k') => Some(Event::Up),
         KeyCode::Down | KeyCode::Char('j') => Some(Event::Down),
         KeyCode::Enter | KeyCode::Char('i') => Some(Event::EnterInteractive),

--- a/crates/turborepo-ui/src/tui/popup.rs
+++ b/crates/turborepo-ui/src/tui/popup.rs
@@ -6,11 +6,12 @@ use ratatui::{
     widgets::{Block, List, ListItem, Padding},
 };
 
-const BIND_LIST: [&str; 11] = [
+const BIND_LIST: [&str; 12] = [
     "m      - Toggle this help popup",
     "↑ or j - Select previous task",
     "↓ or k - Select next task",
     "h      - Toggle task list",
+    "p      - Toggle pinned task selection",
     "/      - Filter tasks to search term",
     "ESC    - Clear filter",
     "i      - Interact with task",


### PR DESCRIPTION
### Description

While task selection pinning is convenient when tasks are changing order and status, it can sometimes get in the way. 

When you haven't selected a task yet (e.g. pressed one of ↑/↓/j/k), you are in an _unpinned_ state. You'll always be looking at the first task in the list, even as they shuffle around in order. When you do press one of those keys, you end up in a _pinned_ state such that the task you selected continues to be selected.

This feels good until you select a task, and then want to "exit" that pinned state and let tasks flow around beneath your cursor again. In this PR, we solve this problem, adding a keybind for `p` that toggles the pinned/unpinned state of your selection.

### Testing Instructions

Pick out your favorite Turborepo, run tasks with the TUI, and try out this new feature.
