### PR TITLE
feat(tui): change binds for log scrolling and add UI hints

### DIFF
--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -110,10 +110,8 @@ fn translate_key_event(options: InputOptions, key_event: KeyEvent) -> Option<Eve
         }
         // Fall through if we aren't in interactive mode
         KeyCode::Char('h') => Some(Event::ToggleSidebar),
-        KeyCode::Char('p') if key_event.modifiers == KeyModifiers::CONTROL => Some(Event::ScrollUp),
-        KeyCode::Char('n') if key_event.modifiers == KeyModifiers::CONTROL => {
-            Some(Event::ScrollDown)
-        }
+        KeyCode::Char('u') => Some(Event::ScrollUp),
+        KeyCode::Char('d') => Some(Event::ScrollDown),
         KeyCode::Char('m') => Some(Event::ToggleHelpPopup),
         KeyCode::Up | KeyCode::Char('k') => Some(Event::Up),
         KeyCode::Down | KeyCode::Char('j') => Some(Event::Down),

--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -58,7 +58,7 @@ impl<'a, W> TerminalPane<'a, W> {
         };
 
         match self.section {
-            LayoutSections::Pane => build_message_vec(FOOTER_TEXT_ACTIVE),
+            LayoutSections::Pane => build_message_vec(EXIT_INTERACTIVE_HINT),
             LayoutSections::TaskList => {
                 // Spaces are used to pad the footer text for aesthetics
                 build_message_vec(format!("{}   {}", ENTER_INTERACTIVE_HINT, SCROLL_LOGS).as_str())

--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -36,8 +36,9 @@ impl<'a, W> TerminalPane<'a, W> {
     }
 
     fn footer(&self) -> Line {
-        let build_message_vec = |footer_text: &str| -> Line {
-            let mut messages = vec![footer_text];
+        let build_message_vec = |footer_text: &[&str]| -> Line {
+            let mut messages = Vec::new();
+            messages.extend_from_slice(footer_text);
 
             if !self.has_sidebar {
                 messages.push(TASK_LIST_HIDDEN);
@@ -58,11 +59,8 @@ impl<'a, W> TerminalPane<'a, W> {
         };
 
         match self.section {
-            LayoutSections::Pane => build_message_vec(EXIT_INTERACTIVE_HINT),
-            LayoutSections::TaskList => {
-                // Spaces are used to pad the footer text for aesthetics
-                build_message_vec(format!("{}   {}", ENTER_INTERACTIVE_HINT, SCROLL_LOGS).as_str())
-            }
+            LayoutSections::Pane => build_message_vec(&[EXIT_INTERACTIVE_HINT]),
+            LayoutSections::TaskList => build_message_vec(&[ENTER_INTERACTIVE_HINT, SCROLL_LOGS]),
             LayoutSections::Search { results, .. } => {
                 Line::from(format!("/ {}", results.query())).left_aligned()
             }

--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -7,10 +7,11 @@ use tui_term::widget::PseudoTerminal;
 
 use super::{app::LayoutSections, TerminalOutput};
 
-const FOOTER_TEXT_ACTIVE: &str = "Ctrl-z - Stop interacting";
-const FOOTER_TEXT_INACTIVE: &str = "i - Interact";
+const ENTER_INTERACTIVE_HINT: &str = "i - Interact";
 const HAS_SELECTION: &str = "c - Copy selection";
+const SCROLL_LOGS: &str = "u/d - Scroll logs";
 const TASK_LIST_HIDDEN: &str = "h - Show task list";
+const FOOTER_TEXT_ACTIVE: &str = "Ctrl-z - Stop interacting";
 
 pub struct TerminalPane<'a, W> {
     terminal_output: &'a TerminalOutput<W>,
@@ -47,7 +48,7 @@ impl<'a, W> TerminalPane<'a, W> {
             }
 
             // Spaces are used to pad the footer text for aesthetics
-            let formatted_messages = format!("   {}", messages.join(", "));
+            let formatted_messages = format!("   {}", messages.join("   "));
 
             Line::styled(
                 formatted_messages.to_string(),
@@ -58,7 +59,10 @@ impl<'a, W> TerminalPane<'a, W> {
 
         match self.section {
             LayoutSections::Pane => build_message_vec(FOOTER_TEXT_ACTIVE),
-            LayoutSections::TaskList => build_message_vec(FOOTER_TEXT_INACTIVE),
+            LayoutSections::TaskList => {
+                // Spaces are used to pad the footer text for aesthetics
+                build_message_vec(format!("{}   {}", ENTER_INTERACTIVE_HINT, SCROLL_LOGS).as_str())
+            }
             LayoutSections::Search { results, .. } => {
                 Line::from(format!("/ {}", results.query())).left_aligned()
             }

--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -7,11 +7,11 @@ use tui_term::widget::PseudoTerminal;
 
 use super::{app::LayoutSections, TerminalOutput};
 
+const FOOTER_TEXT_ACTIVE: &str = "Ctrl-z - Stop interacting";
 const ENTER_INTERACTIVE_HINT: &str = "i - Interact";
 const HAS_SELECTION: &str = "c - Copy selection";
 const SCROLL_LOGS: &str = "u/d - Scroll logs";
 const TASK_LIST_HIDDEN: &str = "h - Show task list";
-const FOOTER_TEXT_ACTIVE: &str = "Ctrl-z - Stop interacting";
 
 pub struct TerminalPane<'a, W> {
     terminal_output: &'a TerminalOutput<W>,

--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -7,7 +7,7 @@ use tui_term::widget::PseudoTerminal;
 
 use super::{app::LayoutSections, TerminalOutput};
 
-const FOOTER_TEXT_ACTIVE: &str = "Ctrl-z - Stop interacting";
+const EXIT_INTERACTIVE_HINT: &str = "Ctrl-z - Stop interacting";
 const ENTER_INTERACTIVE_HINT: &str = "i - Interact";
 const HAS_SELECTION: &str = "c - Copy selection";
 const SCROLL_LOGS: &str = "u/d - Scroll logs";

--- a/crates/turborepo-ui/src/tui/popup.rs
+++ b/crates/turborepo-ui/src/tui/popup.rs
@@ -16,8 +16,8 @@ const BIND_LIST: [&str; 11] = [
     "i      - Interact with task",
     "Ctrl+z - Stop interacting with task",
     "c      - Copy logs selection (Only when logs are selected)",
-    "Ctrl+n - Scroll logs up",
-    "Ctrl+p - Scroll logs down",
+    "d      - Scroll logs up",
+    "u      - Scroll logs down",
 ];
 
 pub fn popup_area(area: Rect) -> Rect {

--- a/crates/turborepo-ui/src/tui/popup.rs
+++ b/crates/turborepo-ui/src/tui/popup.rs
@@ -16,8 +16,8 @@ const BIND_LIST: [&str; 11] = [
     "i      - Interact with task",
     "Ctrl+z - Stop interacting with task",
     "c      - Copy logs selection (Only when logs are selected)",
-    "d      - Scroll logs up",
-    "u      - Scroll logs down",
+    "u      - Scroll logs up",
+    "d      - Scroll logs down",
 ];
 
 pub fn popup_area(area: Rect) -> Rect {


### PR DESCRIPTION
### Description

This PR changes the binds for scrolling logs from `CTRL+P` and `CTRL+N` to `u` and `d`. I'm learning into simple here, both by making the bind a simple one-tap instead of a chord and matching up with the mnemonic device of "**u**p and **d**own".

#### Minor hesitation

`CTRL+n` and `CTRL+p` are familiar to power users of a few terminal tools, but I personally don't see this as a great justification for our tool, which gets used by a much broader audience. I'm erring on the side of simplicity, but happy to hear dissent/pushback/other thoughts.

Additionally, I've updated our UI hints slightly:
- Added the hints for these binds to the logs pane
- Separating binds using spaces instead of commas

### Testing Instructions

Pick out your favorite Turborepo and try it out!
