### PR TITLE
fix(watch): fix output text when no tasks are provided

### DIFF
--- a/crates/turborepo-lib/src/cli/error.rs
+++ b/crates/turborepo-lib/src/cli/error.rs
@@ -82,7 +82,7 @@ pub async fn print_potential_tasks(
     let run = run_builder.build(&handler, telemetry).await?;
     let potential_tasks = run.get_potential_tasks()?;
 
-    println!("No tasks provided, here are some potential ones to run\n",);
+    println!("No tasks provided, here are some potential ones\n",);
 
     for (task, packages) in potential_tasks
         .into_iter()

--- a/docs/repo-docs/crafting-your-repository/understanding-your-repository.mdx
+++ b/docs/repo-docs/crafting-your-repository/understanding-your-repository.mdx
@@ -41,7 +41,7 @@ tasks and the packages in which they are defined:
 
 ```bash title="Terminal"
 > turbo run
-No tasks provided, here are some potential ones to run
+No tasks provided, here are some potential ones
 
   lint
     @repo/ui, docs, web

--- a/docs/repo-docs/reference/watch.mdx
+++ b/docs/repo-docs/reference/watch.mdx
@@ -11,6 +11,12 @@ turbo watch [tasks]
 
 `turbo watch` is dependency-aware, meaning tasks will re-run in the order [configured in `turbo.json`](/repo/docs/reference/configuration).
 
+If no tasks are provided, `turbo` will display what tasks are available for the packages in the repository.
+
+```bash title="Terminal"
+turbo watch
+```
+
 ## Using `turbo watch` with persistent tasks
 
 Persistent tasks are marked with [`"persistent": true`](/repo/docs/reference/configuration#persistent), meaning they won't exit. Because of this, they cannot be depended on in your task graph.

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -124,7 +124,7 @@ Make sure exit code is 2 when no args are passed
 
 Run without any tasks, get a list of potential tasks to run
   $ ${TURBO} run
-  No tasks provided, here are some potential ones to run
+  No tasks provided, here are some potential ones
   
     build
       my-app, util
@@ -136,7 +136,7 @@ Run without any tasks, get a list of potential tasks to run
 
 Run again with a filter and get only the packages that match
   $ ${TURBO} run --filter my-app
-  No tasks provided, here are some potential ones to run
+  No tasks provided, here are some potential ones
   
     build
       my-app
@@ -144,6 +144,17 @@ Run again with a filter and get only the packages that match
       my-app
   [1]
 
+Watch without any tasks, get a list of potential tasks to watch
+  $ ${TURBO} watch
+  No tasks provided, here are some potential ones
+  
+    build
+      my-app, util
+    maybefails
+      my-app, util
+    dev
+      another
+  [1]
 
 Run again with an environment variable that corresponds to a run argument and assert that
 we get the full help output.
@@ -156,7 +167,82 @@ Initialize a new monorepo
   $ . ${TESTDIR}/../../helpers/setup_integration_test.sh composable_config > /dev/null 2>&1
 
   $ ${TURBO} run
-  No tasks provided, here are some potential ones to run
+  No tasks provided, here are some potential ones
+  
+    build
+      invalid-config, my-app, util
+    maybefails
+      my-app, util
+    add-keys-task
+      add-keys
+    add-keys-underlying-task
+      add-keys
+    added-task
+      add-tasks
+    cached-task-1
+      cached
+    cached-task-2
+      cached
+    cached-task-3
+      cached
+    cached-task-4
+      missing-workspace-config
+    config-change-task
+      config-change
+    cross-workspace-task
+      cross-workspace
+    cross-workspace-underlying-task
+      blank-pkg
+    dev
+      another
+    missing-workspace-config-task
+      missing-workspace-config
+    missing-workspace-config-task-with-deps
+      missing-workspace-config
+    missing-workspace-config-underlying-task
+      missing-workspace-config
+    missing-workspace-config-underlying-topo-task
+      blank-pkg
+    omit-keys-task
+      omit-keys
+    omit-keys-task-with-deps
+      omit-keys
+    omit-keys-underlying-task
+      omit-keys
+    omit-keys-underlying-topo-task
+      blank-pkg
+    override-values-task
+      override-values
+    override-values-task-with-deps
+      override-values
+    override-values-task-with-deps-2
+      override-values
+    override-values-underlying-task
+      override-values
+    override-values-underlying-topo-task
+      blank-pkg
+    persistent-task-1
+      persistent
+    persistent-task-1-parent
+      persistent
+    persistent-task-2
+      persistent
+    persistent-task-2-parent
+      persistent
+    persistent-task-3
+      persistent
+    persistent-task-3-parent
+      persistent
+    persistent-task-4
+      persistent
+    persistent-task-4-parent
+      persistent
+    trailing-comma
+      bad-json
+  [1]
+
+  $ ${TURBO} watch
+  No tasks provided, here are some potential ones
   
     build
       invalid-config, my-app, util


### PR DESCRIPTION
Additional fixes for https://github.com/vercel/turborepo/pull/9598

### Description

- Unified output texts from `some potential ones to run` to `some potential ones` across both run and watch commands when no tasks are provided. Let me know if there is a better way!
- Added documentation and tests.

### Testing Instructions

Added integration tests.
