### PR TITLE
fix(repository): honour handleTransparentWorkspaces setting in Yarn/Berry

### DIFF
--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -10,8 +10,7 @@ use turborepo_graph_utils as graph;
 use turborepo_lockfiles::Lockfile;
 
 use super::{
-    dep_splitter::DependencySplitter, npmrc::NpmRc, yarnrc::YarnRc, PackageGraph, PackageInfo,
-    PackageName, PackageNode,
+    dep_splitter::DependencySplitter, PackageGraph, PackageInfo, PackageName, PackageNode,
 };
 use crate::{
     discovery::{
@@ -352,27 +351,6 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedWorkspaces, T> {
         &mut self,
         package_manager: &PackageManager,
     ) -> Result<(), Error> {
-        let npmrc = match package_manager {
-            PackageManager::Pnpm | PackageManager::Pnpm6 | PackageManager::Pnpm9 => {
-                let npmrc_path = self.repo_root.join_component(".npmrc");
-                match npmrc_path.read_existing_to_string().ok().flatten() {
-                    Some(contents) => NpmRc::from_reader(contents.as_bytes()).ok(),
-                    None => None,
-                }
-            }
-            _ => None,
-        };
-        let yarnrc_path = self.repo_root.join_component(".yarnrc.yml");
-        let yarnrc = match package_manager {
-            PackageManager::Berry => {
-                // HOME?
-                match yarnrc_path.read_existing_to_string().ok().flatten() {
-                    Some(contents) => YarnRc::from_reader(contents.as_bytes()).ok(),
-                    None => None,
-                }
-            }
-            _ => None,
-        };
         let split_deps = self
             .workspaces
             .iter()
@@ -385,8 +363,6 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedWorkspaces, T> {
                         &entry.package_json_path,
                         &self.workspaces,
                         package_manager,
-                        npmrc.as_ref(),
-                        yarnrc.as_ref(),
                         entry.package_json.all_dependencies(),
                     ),
                 )
@@ -578,8 +554,6 @@ impl Dependencies {
         workspace_json_path: &AnchoredSystemPathBuf,
         workspaces: &HashMap<PackageName, PackageInfo>,
         package_manager: &PackageManager,
-        npmrc: Option<&NpmRc>,
-        yarnrc: Option<&YarnRc>,
         dependencies: I,
     ) -> Self {
         let resolved_workspace_json_path = repo_root.resolve(workspace_json_path);
@@ -588,14 +562,8 @@ impl Dependencies {
             .expect("package.json path should have parent");
         let mut internal = HashSet::new();
         let mut external = BTreeMap::new();
-        let splitter = DependencySplitter::new(
-            repo_root,
-            workspace_dir,
-            workspaces,
-            package_manager,
-            npmrc,
-            yarnrc,
-        );
+        let splitter =
+            DependencySplitter::new(repo_root, workspace_dir, workspaces, package_manager);
         for (name, version) in dependencies.into_iter() {
             if let Some(workspace) = splitter.is_internal(name, version) {
                 internal.insert(workspace);

--- a/crates/turborepo-repository/src/package_graph/dep_splitter.rs
+++ b/crates/turborepo-repository/src/package_graph/dep_splitter.rs
@@ -5,7 +5,7 @@ use turbopath::{
     RelativeUnixPathBuf,
 };
 
-use super::{npmrc::NpmRc, PackageInfo, PackageName};
+use super::{npmrc::NpmRc, yarnrc::YarnRc, PackageInfo, PackageName};
 use crate::package_manager::PackageManager;
 
 pub struct DependencySplitter<'a> {
@@ -22,6 +22,7 @@ impl<'a> DependencySplitter<'a> {
         workspaces: &'a HashMap<PackageName, PackageInfo>,
         package_manager: &PackageManager,
         npmrc: Option<&'a NpmRc>,
+        yarnrc: Option<&'a YarnRc>,
     ) -> Self {
         Self {
             repo_root,
@@ -29,6 +30,7 @@ impl<'a> DependencySplitter<'a> {
             workspaces,
             link_workspace_packages: npmrc
                 .and_then(|npmrc| npmrc.link_workspace_packages)
+                .or_else(|| yarnrc.map(|yarnrc| yarnrc.enableTransparentWorkspaces))
                 .unwrap_or(!matches!(package_manager, PackageManager::Pnpm9)),
         }
     }

--- a/crates/turborepo-repository/src/package_graph/dep_splitter.rs
+++ b/crates/turborepo-repository/src/package_graph/dep_splitter.rs
@@ -30,7 +30,7 @@ impl<'a> DependencySplitter<'a> {
             workspaces,
             link_workspace_packages: npmrc
                 .and_then(|npmrc| npmrc.link_workspace_packages)
-                .or_else(|| yarnrc.map(|yarnrc| yarnrc.enableTransparentWorkspaces))
+                .or_else(|| yarnrc.map(|yarnrc| yarnrc.enable_transparent_workspaces))
                 .unwrap_or(!matches!(package_manager, PackageManager::Pnpm9)),
         }
     }

--- a/crates/turborepo-repository/src/package_graph/dep_splitter.rs
+++ b/crates/turborepo-repository/src/package_graph/dep_splitter.rs
@@ -5,7 +5,7 @@ use turbopath::{
     RelativeUnixPathBuf,
 };
 
-use super::{npmrc::NpmRc, yarnrc::YarnRc, PackageInfo, PackageName};
+use super::{PackageInfo, PackageName};
 use crate::package_manager::PackageManager;
 
 pub struct DependencySplitter<'a> {
@@ -21,17 +21,13 @@ impl<'a> DependencySplitter<'a> {
         workspace_dir: &'a AbsoluteSystemPath,
         workspaces: &'a HashMap<PackageName, PackageInfo>,
         package_manager: &PackageManager,
-        npmrc: Option<&'a NpmRc>,
-        yarnrc: Option<&'a YarnRc>,
     ) -> Self {
+        let link_workspace_packages = package_manager.link_workspace_packages(repo_root);
         Self {
             repo_root,
             workspace_dir,
             workspaces,
-            link_workspace_packages: npmrc
-                .and_then(|npmrc| npmrc.link_workspace_packages)
-                .or_else(|| yarnrc.map(|yarnrc| yarnrc.enable_transparent_workspaces))
-                .unwrap_or(!matches!(package_manager, PackageManager::Pnpm9)),
+            link_workspace_packages,
         }
     }
 

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -19,8 +19,6 @@ use crate::{
 
 pub mod builder;
 mod dep_splitter;
-mod npmrc;
-mod yarnrc;
 
 pub use builder::{Error, PackageGraphBuilder};
 

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -20,6 +20,7 @@ use crate::{
 pub mod builder;
 mod dep_splitter;
 mod npmrc;
+mod yarnrc;
 
 pub use builder::{Error, PackageGraphBuilder};
 

--- a/crates/turborepo-repository/src/package_graph/yarnrc.rs
+++ b/crates/turborepo-repository/src/package_graph/yarnrc.rs
@@ -10,20 +10,25 @@ pub enum Error {
 }
 
 /// A yarnrc.yaml file representing settings affecting the package graph.
-#[allow(non_snake_case)]
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct YarnRc {
     /// Used by Yarn(Berry) as `enableTransparentWorkspaces`.
     /// When true, treats local workspaces that match a package name
     /// and semver range as correct match resulting in turbo including
     /// the package in the dependency graph
-    pub enableTransparentWorkspaces: bool,
+    #[serde(default = "default_enable_transparent_workspaces")]
+    pub enable_transparent_workspaces: bool,
+}
+
+fn default_enable_transparent_workspaces() -> bool {
+    true
 }
 
 impl Default for YarnRc {
     fn default() -> YarnRc {
         YarnRc {
-            enableTransparentWorkspaces: true,
+            enable_transparent_workspaces: default_enable_transparent_workspaces(),
         }
     }
 }
@@ -45,7 +50,7 @@ mod test {
         assert_eq!(
             empty,
             YarnRc {
-                enableTransparentWorkspaces: true
+                enable_transparent_workspaces: true
             }
         );
     }
@@ -56,7 +61,18 @@ mod test {
         assert_eq!(
             empty,
             YarnRc {
-                enableTransparentWorkspaces: false
+                enable_transparent_workspaces: false
+            }
+        );
+    }
+
+    #[test]
+    fn test_parses_additional_settings() {
+        let empty = YarnRc::from_reader(b"httpProxy: \"http://my-proxy.com\"".as_slice()).unwrap();
+        assert_eq!(
+            empty,
+            YarnRc {
+                enable_transparent_workspaces: true
             }
         );
     }

--- a/crates/turborepo-repository/src/package_graph/yarnrc.rs
+++ b/crates/turborepo-repository/src/package_graph/yarnrc.rs
@@ -1,0 +1,63 @@
+use std::io;
+
+use serde::Deserialize;
+use serde_yaml;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("encountered error parsing yarnrc.yml: {0}")]
+    SerdeYaml(#[from] serde_yaml::Error),
+}
+
+/// A yarnrc.yaml file representing settings affecting the package graph.
+#[allow(non_snake_case)]
+#[derive(Debug, PartialEq, Eq, Clone, Deserialize)]
+pub struct YarnRc {
+    /// Used by Yarn(Berry) as `enableTransparentWorkspaces`.
+    /// When true, treats local workspaces that match a package name
+    /// and semver range as correct match resulting in turbo including
+    /// the package in the dependency graph
+    pub enableTransparentWorkspaces: bool,
+}
+
+impl Default for YarnRc {
+    fn default() -> YarnRc {
+        YarnRc {
+            enableTransparentWorkspaces: true,
+        }
+    }
+}
+
+impl YarnRc {
+    pub fn from_reader(mut reader: impl io::Read) -> Result<Self, Error> {
+        let config: YarnRc = serde_yaml::from_reader(&mut reader)?;
+        Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_parse_empty_yarnrc() {
+        let empty = YarnRc::from_reader(b"".as_slice()).unwrap();
+        assert_eq!(
+            empty,
+            YarnRc {
+                enableTransparentWorkspaces: true
+            }
+        );
+    }
+
+    #[test]
+    fn test_parses_transparent_workspaces() {
+        let empty = YarnRc::from_reader(b"enableTransparentWorkspaces: false".as_slice()).unwrap();
+        assert_eq!(
+            empty,
+            YarnRc {
+                enableTransparentWorkspaces: false
+            }
+        );
+    }
+}


### PR DESCRIPTION
### Description

This implements a fix for #8989 to honour `enableTransparentWorkspaces` in a yarn config. 

The patch folds the config setting into the existing `link_workspace_packages` npm settings as they're equivalent.

Massive Kudos to @me4502 as she helped throughout the implementation process with testing and figuring things out.

### Testing Instructions

* Use https://github.com/me4502/turborepo-reproduction reproducer
* Run compiled turbo build against workspace `a`: `turborepo/target/debug/turbo build --force --skip-infer --no-daemon --filter a`
