### PR TITLE
chore: change Discord links to Vercel Community

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for more information.
 
 The Turborepo community can be found on [GitHub Discussions](https://github.com/vercel/turborepo/discussions), where you can ask questions, voice ideas, and share your projects.
 
-To chat with other community members, you can join the [Turborepo Discord](https://turbo.build/discord).
+To chat with other community members, you can join [Vercel Community's `#turborepo` tag](https://vercel.community/tag/turborepo).
 
 Our [Code of Conduct](https://github.com/vercel/turborepo/blob/main/CODE_OF_CONDUCT.md) applies to all Turborepo community channels.
 

--- a/docs/repo-docs/community.mdx
+++ b/docs/repo-docs/community.mdx
@@ -16,7 +16,7 @@ With over 2 million weekly downloads, Turborepo has a large and active community
 If you have a question about Turborepo or want to help others, join the conversation:
 
 - [GitHub Discussions](https://github.com/vercel/turborepo/discussions)
-- [Discord](https://turbo.build/discord)
+- [Vercel Community](https://vercel.community/tag/turborepo)
 
 ## Acknowledgements
 

--- a/docs/repo-docs/index.mdx
+++ b/docs/repo-docs/index.mdx
@@ -39,4 +39,4 @@ We will do our best to keep jargon to a minimum - but there are some need-to-kno
 
 ## Join the community
 
-If you have questions about anything related to Turborepo, you're always welcome to ask the community on [GitHub Discussions](https://github.com/vercel/turborepo/discussions), [Discord](https://turbo.build/discord), and [Twitter](https://twitter.com/turborepo).
+If you have questions about anything related to Turborepo, you're always welcome to ask the community on [GitHub Discussions](https://github.com/vercel/turborepo/discussions), [Vercel Community](https://vercel.community/tag/turborepo), and [Twitter](https://twitter.com/turborepo).

--- a/packages/turbo/README.md
+++ b/packages/turbo/README.md
@@ -31,7 +31,7 @@ Visit https://turbo.build/repo/docs to get started with Turborepo and read the d
 
 The Turborepo community can be found on [GitHub Discussions](https://github.com/vercel/turborepo/discussions), where you can ask questions, voice ideas, and share your projects.
 
-To chat with other community members, you can join the [Turborepo Discord](https://turbo.build/discord)
+To chat with other community members, you can join [Vercel Community's `#turborepo` tag](https://vercel.community/tag/turborepo)
 
 Our [Code of Conduct](https://github.com/vercel/turborepo/blob/main/CODE_OF_CONDUCT.md) applies to all Turborepo community channels.
 


### PR DESCRIPTION
### Description

We're migrating from Discord to Vercel Community for a variety of reasons. This PR changes the links to go to the new target.
