### PR TITLE
docs: update readme with pnpm, yarn, and npm

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -38,7 +38,15 @@ To build all apps and packages, run the following command:
 
 ```
 cd my-turborepo
+
+```
+
+```
 pnpm build
+or
+npm run build
+or
+yarn build
 ```
 
 ### Develop
@@ -47,7 +55,15 @@ To develop all apps and packages, run the following command:
 
 ```
 cd my-turborepo
+
+```
+
+```
 pnpm dev
+or
+npm run dev
+or
+yarn dev
 ```
 
 ### Remote Caching

--- a/examples/non-monorepo/README.md
+++ b/examples/non-monorepo/README.md
@@ -20,6 +20,11 @@ To build all apps and packages, run the following command:
 
 ```
 pnpm turbo build
+or
+yarn turbo run build
+or
+npx turbo run build
+
 ```
 
 ### Develop

--- a/examples/with-docker/README.md
+++ b/examples/with-docker/README.md
@@ -33,6 +33,10 @@ This repo is configured to be built with Docker, and Docker compose. To build al
 ```
 # Install dependencies
 yarn install
+or
+npm install
+or
+pnpm install
 
 # Create a network, which allows containers to communicate
 # with each other, by using their container name as a hostname

--- a/examples/with-gatsby/README.md
+++ b/examples/with-gatsby/README.md
@@ -58,7 +58,15 @@ By default, Turborepo will cache locally. To enable Remote Caching you will need
 
 ```
 cd my-turborepo
+
+```
+
+```
 pnpm dlx turbo login
+or
+npx turbo login
+or
+yarn dlx turbo login
 ```
 
 This will authenticate the Turborepo CLI with your [Vercel account](https://vercel.com/docs/concepts/personal-accounts/overview).
@@ -67,6 +75,11 @@ Next, you can link your Turborepo to your Remote Cache by running the following 
 
 ```
 pnpm dlx turbo link
+or
+npx turbo link
+or
+yarn dlx turbo link
+
 ```
 
 ## Useful Links

--- a/examples/with-prisma/README.md
+++ b/examples/with-prisma/README.md
@@ -88,6 +88,10 @@ To build all apps and packages, run the following command:
 
 ```bash
 yarn run build
+or
+pnpm run build
+or
+npm run build
 ```
 
 ### Develop
@@ -96,6 +100,10 @@ To develop all apps and packages, run the following command:
 
 ```bash
 yarn run dev
+or
+npm run dev
+or
+pnpm dev
 ```
 
 ## Useful Links

--- a/examples/with-rollup/README.md
+++ b/examples/with-rollup/README.md
@@ -37,7 +37,15 @@ To build all apps and packages, run the following command:
 
 ```
 cd my-turborepo
+
+```
+
+```
 pnpm run build
+or
+npm run build
+or
+yarn run build
 ```
 
 ### Develop
@@ -46,7 +54,15 @@ To develop all apps and packages, run the following command:
 
 ```
 cd my-turborepo
+
+```
+
+```
 pnpm run dev
+or
+yarn run dev
+or
+npm run dev
 ```
 
 ### Remote Caching

--- a/examples/with-vue-nuxt/README.md
+++ b/examples/with-vue-nuxt/README.md
@@ -38,7 +38,15 @@ To build all apps and packages, run the following command:
 
 ```
 cd my-turborepo
+
+```
+
+```
 pnpm build
+or
+npm run build
+or
+yarn build
 ```
 
 ### Develop
@@ -47,7 +55,15 @@ To develop all apps and packages, run the following command:
 
 ```
 cd my-turborepo
+
+```
+
+```
 pnpm dev
+or
+npm run dev
+or
+yarn dev
 ```
 
 ### Remote Caching


### PR DESCRIPTION
### Description

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->
Updated the **README** file in the Turborepo basic example to replace the **pnpm commands** with commands for **yarn, npm, and pnpm.** This resolves the issue where only pnpm commands were shown, providing more flexibility based on the user's package manager selection.

