### PR TITLE
feat(query): add lockfile package changes to `affectedPackage`

### DIFF
--- a/crates/turborepo-lib/src/query/external_package.rs
+++ b/crates/turborepo-lib/src/query/external_package.rs
@@ -1,0 +1,33 @@
+use std::sync::Arc;
+
+use async_graphql::Object;
+
+use crate::run::Run;
+
+#[derive(Clone)]
+pub struct ExternalPackage {
+    run: Arc<Run>,
+    package: turborepo_lockfiles::Package,
+}
+
+impl ExternalPackage {
+    pub fn new(run: Arc<Run>, package: turborepo_lockfiles::Package) -> Self {
+        Self { run, package }
+    }
+
+    /// Converts the lockfile key to a human friendly name
+    pub fn human_name(&self) -> String {
+        self.run
+            .pkg_dep_graph()
+            .lockfile()
+            .and_then(|lockfile| lockfile.human_name(&self.package))
+            .unwrap_or_else(|| self.package.key.clone())
+    }
+}
+
+#[Object]
+impl ExternalPackage {
+    async fn name(&self) -> String {
+        self.human_name().to_string()
+    }
+}

--- a/crates/turborepo-lib/src/run/scope/change_detector.rs
+++ b/crates/turborepo-lib/src/run/scope/change_detector.rs
@@ -5,7 +5,7 @@ use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf};
 use turborepo_repository::{
     change_mapper::{
         AllPackageChangeReason, ChangeMapper, DefaultPackageChangeMapper, Error,
-        GlobalDepsPackageChangeMapper, LockfileChange, PackageChanges, PackageInclusionReason,
+        GlobalDepsPackageChangeMapper, PackageChanges, PackageInclusionReason,
     },
     package_graph::{PackageGraph, PackageName},
 };
@@ -53,12 +53,12 @@ impl<'a> ScopeChangeDetector<'a> {
 
     /// Gets the lockfile content from SCM if it has changed.
     /// Does *not* error if cannot get content, instead just
-    /// returns an empty lockfile change
+    /// returns a Some(None)
     fn get_lockfile_contents(
         &self,
         from_ref: Option<&str>,
         changed_files: &HashSet<AnchoredSystemPathBuf>,
-    ) -> Option<LockfileChange> {
+    ) -> Option<Option<Vec<u8>>> {
         let lockfile_path = self
             .pkg_graph
             .package_manager()
@@ -79,10 +79,10 @@ impl<'a> ScopeChangeDetector<'a> {
             .lockfile_path(self.turbo_root);
 
         let Ok(content) = self.scm.previous_content(from_ref, &lockfile_path) else {
-            return Some(LockfileChange::Empty);
+            return Some(None);
         };
 
-        Some(LockfileChange::WithContent(content))
+        Some(Some(content))
     }
 }
 

--- a/crates/turborepo-lockfiles/src/berry/mod.rs
+++ b/crates/turborepo-lockfiles/src/berry/mod.rs
@@ -531,6 +531,14 @@ impl Lockfile for BerryLockfile {
         let entry = self.locator_package.get(key)?;
         Some(entry.version.clone())
     }
+
+    fn human_name(&self, package: &crate::Package) -> Option<String> {
+        let locator = Locator::try_from(package.key.as_str()).ok()?;
+        let berry_package = self.locator_package.get(&locator)?;
+        let name = locator.ident.to_string();
+        let version = &berry_package.version;
+        Some(format!("{name}@{version}"))
+    }
 }
 
 impl LockfileData {

--- a/crates/turborepo-lockfiles/src/bun/mod.rs
+++ b/crates/turborepo-lockfiles/src/bun/mod.rs
@@ -122,6 +122,13 @@ impl Lockfile for BunLockfile {
     fn turbo_version(&self) -> Option<String> {
         None
     }
+
+    fn human_name(&self, package: &crate::Package) -> Option<String> {
+        let entry = self.inner.get(&package.key)?;
+        let name = entry.name.as_deref()?;
+        let version = &entry.version;
+        Some(format!("{name}@{version}"))
+    }
 }
 
 impl Entry {

--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -70,7 +70,10 @@ pub trait Lockfile: Send + Sync + Any + std::fmt::Debug {
     /// Usually of the form `package@version`, but version might include
     /// additional information to convey difference from other packages in
     /// the lockfile e.g. differing peer dependencies.
-    fn human_name(&self, package: &Package) -> Option<String>;
+    #[allow(unused)]
+    fn human_name(&self, package: &Package) -> Option<String> {
+        None
+    }
 }
 
 /// Takes a lockfile, and a map of workspace directory paths -> (package name,

--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -65,6 +65,12 @@ pub trait Lockfile: Send + Sync + Any + std::fmt::Debug {
 
     /// Return any turbo version found in the lockfile
     fn turbo_version(&self) -> Option<String>;
+
+    /// A human friendly version of a lockfile key.
+    /// Usually of the form `package@version`, but version might include
+    /// additional information to convey difference from other packages in
+    /// the lockfile e.g. differing peer dependencies.
+    fn human_name(&self, package: &Package) -> Option<String>;
 }
 
 /// Takes a lockfile, and a map of workspace directory paths -> (package name,

--- a/crates/turborepo-lockfiles/src/npm.rs
+++ b/crates/turborepo-lockfiles/src/npm.rs
@@ -152,6 +152,13 @@ impl Lockfile for NpmLockfile {
         let turbo_entry = self.packages.get("node_modules/turbo")?;
         turbo_entry.version.clone()
     }
+
+    fn human_name(&self, package: &Package) -> Option<String> {
+        let npm_package = self.packages.get(&package.key)?;
+        let version = npm_package.version.as_deref()?;
+        let name = package.key.split("node_modules/").last()?;
+        Some(format!("{name}@{version}"))
+    }
 }
 
 impl NpmLockfile {

--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -524,6 +524,16 @@ impl crate::Lockfile for PnpmLockfile {
             .find_map(|project| project.dependencies.turbo_version())?;
         Some(turbo_version.to_owned())
     }
+
+    fn human_name(&self, package: &crate::Package) -> Option<String> {
+        if matches!(self.version(), SupportedLockfileVersion::V7AndV9) {
+            Some(package.key.clone())
+        } else {
+            // TODO: this is really hacky and doesn't properly handle v5 as it uses `/` as
+            // the delimiter between name and version
+            Some(package.key.strip_prefix('/')?.to_owned())
+        }
+    }
 }
 
 impl DependencyInfo {

--- a/crates/turborepo-lockfiles/src/yarn1/mod.rs
+++ b/crates/turborepo-lockfiles/src/yarn1/mod.rs
@@ -127,6 +127,13 @@ impl Lockfile for Yarn1Lockfile {
         let entry = self.inner.get(key)?;
         Some(entry.version.clone())
     }
+
+    fn human_name(&self, package: &crate::Package) -> Option<String> {
+        let entry = self.inner.get(&package.key)?;
+        let name = entry.name.as_deref()?;
+        let version = &entry.version;
+        Some(format!("{name}@{version}"))
+    }
 }
 
 pub fn yarn_subgraph(contents: &[u8], packages: &[String]) -> Result<Vec<u8>, crate::Error> {

--- a/crates/turborepo-repository/src/change_mapper/mod.rs
+++ b/crates/turborepo-repository/src/change_mapper/mod.rs
@@ -14,7 +14,9 @@ use tracing::debug;
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf};
 use wax::Program;
 
-use crate::package_graph::{ChangedPackagesError, PackageGraph, PackageName, WorkspacePackage};
+use crate::package_graph::{
+    ChangedPackagesError, ExternalDependencyChange, PackageGraph, PackageName, WorkspacePackage,
+};
 
 mod package;
 
@@ -24,7 +26,7 @@ const DEFAULT_GLOBAL_DEPS: [&str; 2] = ["package.json", "turbo.json"];
 // still want to be able to express a generic change.
 pub enum LockfileChange {
     Empty,
-    WithContent(Vec<u8>),
+    ChangedPackages(HashSet<turborepo_lockfiles::Package>),
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
@@ -37,7 +39,10 @@ pub enum PackageInclusionReason {
     /// the lockfile changed.
     ConservativeRootLockfileChanged,
     /// The lockfile changed and caused this package to be invalidated
-    LockfileChanged,
+    LockfileChanged {
+        removed: Vec<turborepo_lockfiles::Package>,
+        added: Vec<turborepo_lockfiles::Package>,
+    },
     /// A transitive dependency of this package changed
     DependencyChanged { dependency: PackageName },
     /// A transitive dependent of this package changed
@@ -117,7 +122,7 @@ impl<'a, PD: PackageChangeMapper> ChangeMapper<'a, PD> {
     pub fn changed_packages(
         &self,
         changed_files: HashSet<AnchoredSystemPathBuf>,
-        lockfile_change: Option<LockfileChange>,
+        lockfile_change: Option<Option<Vec<u8>>>,
     ) -> Result<PackageChanges, ChangeMapError> {
         if let Some(file) = Self::default_global_file_changed(&changed_files) {
             debug!("global file changed");
@@ -136,7 +141,7 @@ impl<'a, PD: PackageChangeMapper> ChangeMapper<'a, PD> {
 
             PackageChanges::Some(mut changed_pkgs) => {
                 match lockfile_change {
-                    Some(LockfileChange::WithContent(content)) => {
+                    Some(Some(content)) => {
                         // if we run into issues, don't error, just assume all packages have changed
                         let Ok(lockfile_changes) =
                             self.get_changed_packages_from_lockfile(&content)
@@ -155,16 +160,24 @@ impl<'a, PD: PackageChangeMapper> ChangeMapper<'a, PD> {
                         );
                         merge_changed_packages(
                             &mut changed_pkgs,
-                            lockfile_changes
-                                .into_iter()
-                                .map(|pkg| (pkg, PackageInclusionReason::LockfileChanged)),
+                            lockfile_changes.into_iter().map(|change| {
+                                let ExternalDependencyChange {
+                                    package,
+                                    added,
+                                    removed,
+                                } = change;
+                                (
+                                    package,
+                                    PackageInclusionReason::LockfileChanged { added, removed },
+                                )
+                            }),
                         );
 
                         Ok(PackageChanges::Some(changed_pkgs))
                     }
 
                     // We don't have the actual contents, so just invalidate everything
-                    Some(LockfileChange::Empty) => {
+                    Some(None) => {
                         debug!("no previous lockfile available, assuming all packages changed");
                         Ok(PackageChanges::All(
                             AllPackageChangeReason::LockfileChangedWithoutDetails,
@@ -226,7 +239,7 @@ impl<'a, PD: PackageChangeMapper> ChangeMapper<'a, PD> {
     fn get_changed_packages_from_lockfile(
         &self,
         lockfile_content: &[u8],
-    ) -> Result<Vec<WorkspacePackage>, ChangeMapError> {
+    ) -> Result<Vec<ExternalDependencyChange>, ChangeMapError> {
         let previous_lockfile = self
             .pkg_graph
             .package_manager()

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -43,7 +43,7 @@ pub struct PackageGraph {
 /// There are other structs in this module that have "Workspace" in the name,
 /// but they do NOT follow the glossary, and instead mean "package" when they
 /// say Workspace. Some of these are labeled as such.
-#[derive(Debug, Eq, PartialEq, Hash)]
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
 pub struct WorkspacePackage {
     pub name: PackageName,
     pub path: AnchoredSystemPathBuf,
@@ -130,6 +130,15 @@ impl PackageNode {
             PackageNode::Root => &PackageName::Root,
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExternalDependencyChange {
+    pub package: WorkspacePackage,
+    /// Dependencies that were added to the package
+    pub added: Vec<turborepo_lockfiles::Package>,
+    /// Dependencies that were removed from the package
+    pub removed: Vec<turborepo_lockfiles::Package>,
 }
 
 impl PackageGraph {
@@ -427,7 +436,7 @@ impl PackageGraph {
     pub fn changed_packages_from_lockfile(
         &self,
         previous: &dyn Lockfile,
-    ) -> Result<Vec<WorkspacePackage>, ChangedPackagesError> {
+    ) -> Result<Vec<ExternalDependencyChange>, ChangedPackagesError> {
         let current = self.lockfile().ok_or(ChangedPackagesError::NoLockfile)?;
 
         let external_deps = self
@@ -458,7 +467,7 @@ impl PackageGraph {
         } else {
             self.packages
                 .iter()
-                .filter(|(name, info)| {
+                .filter_map(|(name, info)| {
                     let previous_closure = closures.get(info.package_path().to_unix().as_str());
                     let not_equal = previous_closure != info.transitive_dependencies.as_ref();
                     if not_equal {
@@ -470,30 +479,60 @@ impl PackageGraph {
                                 prev.symmetric_difference(curr)
                             );
                         }
+                        let empty_set = HashSet::default();
+                        let prev_deps = previous_closure.unwrap_or(&empty_set);
+                        let curr_deps = info.transitive_dependencies.as_ref().unwrap_or(&empty_set);
+                        // {a, b} -> {a, c}
+                        // b was removed
+                        // c was added
+                        let added = curr_deps
+                            .difference(prev_deps)
+                            .cloned()
+                            .sorted()
+                            .collect::<Vec<_>>();
+                        let removed = prev_deps
+                            .difference(curr_deps)
+                            .cloned()
+                            .sorted()
+                            .collect::<Vec<_>>();
+                        Some((name, info, added, removed))
+                    } else {
+                        None
                     }
-                    not_equal
                 })
-                .map(|(name, info)| match name {
+                .map(|(name, info, added, removed)| match name {
                     PackageName::Other(n) => {
                         let w_name = PackageName::Other(n.to_owned());
-                        Some(WorkspacePackage {
+                        let package = WorkspacePackage {
                             name: w_name.clone(),
                             path: info.package_path().to_owned(),
+                        };
+                        Some(ExternalDependencyChange {
+                            package,
+                            added,
+                            removed,
                         })
                     }
                     // if the root package has changed, then we should report `None`
                     // since all packages need to be revalidated
                     PackageName::Root => None,
                 })
-                .collect::<Option<Vec<WorkspacePackage>>>()
+                .collect::<Option<Vec<_>>>()
         };
 
         Ok(changed.unwrap_or_else(|| {
             self.packages
                 .iter()
-                .map(|(name, info)| WorkspacePackage {
-                    name: name.clone(),
-                    path: info.package_path().to_owned(),
+                .map(|(name, info)| {
+                    let package = WorkspacePackage {
+                        name: name.clone(),
+                        path: info.package_path().to_owned(),
+                    };
+                    ExternalDependencyChange {
+                        package,
+                        added: Vec::new(),
+                        removed: Vec::new(),
+                    }
                 })
                 .collect()
         }))


### PR DESCRIPTION
### Description

Add `added` and `removed` fields for lockfile changes to show exactly why a workspace package was marked as changed due to a lockfile change.

### Testing Instructions

```
query {
  affectedPackages() {
    length
    items {
      name
      reason {
        ... on LockfileChanged {
          added {
            items {
              name
            }
          }
          removed {
            items {
              name
            }
          }
          
        }
      }
    }
  }
}
```
Results:
```
...
      {
          "name": "@repo/package",
          "reason": {
            "added": {
              "items": []
            },
            "removed": {
              "items": [
                {
                  "name": "tslib@2.7.0"
                }
              ]
            }
          }
        },
```
