### PR TITLE
fix(examples): add missing ESLint dependency

### DIFF
--- a/examples/basic/packages/eslint-config/package.json
+++ b/examples/basic/packages/eslint-config/package.json
@@ -9,6 +9,7 @@
     "./react-internal": "./react-internal.js"
   },
   "devDependencies": {
+    "@eslint/js": "^9.17.0",
     "@next/eslint-plugin-next": "^15.1.0",
     "@typescript-eslint/eslint-plugin": "^8.15.0",
     "@typescript-eslint/parser": "^8.15.0",

--- a/examples/basic/pnpm-lock.yaml
+++ b/examples/basic/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
 
   packages/eslint-config:
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.17.0
+        version: 9.17.0
       '@next/eslint-plugin-next':
         specifier: ^15.1.0
         version: 15.1.0
@@ -195,6 +198,10 @@ packages:
 
   '@eslint/js@9.15.0':
     resolution: {integrity: sha512-tMTqrY+EzbXmKJR5ToI8lxu7jaN5EdmrBFJpQk5JmSlyLsx6o4t27r883K5xsLuCYCpfKBCGswMSWXsM+jB7lg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.17.0':
+    resolution: {integrity: sha512-Sxc4hqcs1kTu0iID3kcZDW3JHq2a77HO9P8CP6YEA/FpH3Ll8UXE2r/86Rz9YJLKme39S9vU5OWNjC6Xl0Cr3w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/object-schema@2.1.4':
@@ -2106,6 +2113,8 @@ snapshots:
       - supports-color
 
   '@eslint/js@9.15.0': {}
+
+  '@eslint/js@9.17.0': {}
 
   '@eslint/object-schema@2.1.4': {}
 


### PR DESCRIPTION
### Description

It appears I missed adding this dependency when I worked through getting this example moved to ESLint v9. Getting it added in here.
