### PR TITLE
docs: mention capnp in the dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ You will need to have these dependences installed on your machine to work on thi
 - [Rust](https://www.rust-lang.org/tools/install) ([Repository toolchain](https://github.com/vercel/turborepo/blob/main/rust-toolchain.toml))
 - [NodeJS](https://nodejs.org/en) v20
 - [pnpm](https://pnpm.io/) v8
+- [capnp](https://capnproto.org)
 
 ### Optional dependencies
 


### PR DESCRIPTION
### Description
When setting up the project, `cargo build` resulted in an error.

<img width="1136" alt="Screenshot 2024-12-20 at 21 35 26" src="https://github.com/user-attachments/assets/1a80a0da-c4c8-48c4-90c1-8781f0e44739" />

Perhaps this PR can clear some confusion for new devs in project.