### PR TITLE
fix: packages listed twice in watch mode

### DIFF
--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -159,10 +159,6 @@ impl WatchClient {
 
         let mut events = client.package_changes().await?;
 
-        if !self.run.has_tui() {
-            self.run.print_run_prelude();
-        }
-
         let signal_subscriber = self.handler.subscribe().ok_or(Error::NoSignalHandler)?;
 
         // We explicitly use a tokio::sync::Mutex here to avoid deadlocks.


### PR DESCRIPTION
### Description
Fixes: https://github.com/vercel/turborepo/issues/9538

The `WatchClient::new` already lists packages as a part of `start_ui`.
Therefore, an additional prelude print in `WatchClient::start` appears redundant.

### Testing Instructions
1. setup a [devturbo alias](https://github.com/vercel/turborepo/blob/main/CONTRIBUTING.md#manually-testing-turbo)
1. clone https://github.com/remotion-dev/remotion
1. run `devturbo watch make`