### PR TITLE
docs: add missing `api` folder in `turbo prune api --docker` example

### DIFF
--- a/docs/repo-docs/guides/tools/docker.mdx
+++ b/docs/repo-docs/guides/tools/docker.mdx
@@ -96,7 +96,9 @@ First, we want to copy over only what we need to install the packages. When runn
   <Folder name="out" defaultOpen>
     <Folder name="json" defaultOpen>
       <Folder name="apps" defaultOpen>
-        <File name="package.json" />
+        <Folder name="api" defaultOpen>
+          <File name="package.json" />
+        </Folder>
       </Folder>
       <File name="package.json" />
     </Folder>


### PR DESCRIPTION
### Description

Hi everybody! I'm learning Turborepo and I think there's an incorrect example in the Docker guide.

### Testing Instructions

To reproduce the issue I just created a new repository and runned the `turbo prune` command. In this case, `docs` app is equivalent to `api` app.
```
npx create-turbo@latest
npm install turbo --global
turbo prune docs --docker
```

### Screenshots
![image](https://github.com/user-attachments/assets/3eae38f7-ceab-40ca-be2e-863667753cf0)

### Extra
It's my first time opening a PR here, please let me know if I should do something different! Thanks
