### PR TITLE
docs: add missing `apps` folder in `prune` command reference

### DIFF
--- a/docs/repo-docs/reference/prune.mdx
+++ b/docs/repo-docs/reference/prune.mdx
@@ -179,14 +179,16 @@ Using the same example from above, running `turbo prune frontend --docker` will 
   </Folder>
   <Folder name="json" defaultOpen>
     <File name="package.json (from repo root)" />
+    <Folder name="apps" defaultOpen>
+      <Folder name="frontend" defaultOpen>
+        <File name="package.json" />
+      </Folder>
+    </Folder>
     <Folder name="packages" defaultOpen>
       <Folder name="ui" defaultOpen>
         <File name="package.json" />
       </Folder>
       <Folder name="shared" defaultOpen>
-        <File name="package.json" />
-      </Folder>
-      <Folder name="frontend" defaultOpen>
         <File name="package.json" />
       </Folder>
     </Folder>


### PR DESCRIPTION
### Description

Hi everyone! I found that an example in the `prune` command reference shows an incorrect folder structure: `frontend` workspace is initially inside `apps` folder, but it's shown inside `packages` folder in the output example of `docker prune fronted --docker`

### Screenshots
After running `turbo prune docs --docker`, (think of `docs` as an equivalent of `frontend`) I get the following structure:
![image](https://github.com/user-attachments/assets/4b033881-6ab8-494a-9540-3455d203375d)


### Testing Instructions

To reproduce it, I created a new turborepo project, and the run `turbo prune docs --docker`.
