### PR TITLE
feat: optional `TURBO_SITE` environment variable at compilation time for development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,16 @@ There are many open-source Turborepos out in the community that you can test wit
 
 ## Debugging tips
 
+### Links in error messages
+
+Many of Turborepo's error messages include links to information or documentation to help end users.
+
+The base URL for the links can be set to a value of your choosing by providing a `TURBO_SITE` environment variable at compilation time.
+
+```bash
+TURBO_SITE="http://localhost:3000" cargo build
+```
+
 ### Verbose logging
 
 Verbose logging can be enabled by using the `-v`, `-vv`, or `-vvv` flag on your `turbo` command, depending on the level of logging you're looking for.

--- a/crates/turborepo-errors/src/lib.rs
+++ b/crates/turborepo-errors/src/lib.rs
@@ -9,7 +9,15 @@ use miette::{Diagnostic, NamedSource, SourceSpan};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-pub const TURBO_SITE: &str = "https://turbo.build";
+/// Base URL for links supplied in error messages. You can use the TURBO_SITE
+/// environment variable at compile time to set a base URL for easier debugging.
+///
+/// When TURBO_SITE is not provided at compile time, the production site will be
+/// used.
+pub const TURBO_SITE: &str = match option_env!("TURBO_SITE") {
+    Some(url) => url,
+    None => "https://turbo.build",
+};
 
 /// A little helper to convert from biome's syntax errors to miette.
 #[derive(Debug, Error, Diagnostic)]


### PR DESCRIPTION
### Description

To make it easier to test out the links we supply in our error messages, this PR lets us supply a base URL of our own choosing so you can point errors at places like `http://localhost:3000` or a preview build of `turbo.build`.

### Testing Instructions

You can try this out yourself with:
```bash
TURBO_SITE="http://localhost:3000" cargo build
```
