### PR TITLE
docs: mention --graph on graphs page

### DIFF
--- a/docs/repo-docs/core-concepts/package-and-task-graph.mdx
+++ b/docs/repo-docs/core-concepts/package-and-task-graph.mdx
@@ -4,6 +4,7 @@ description: Turborepo builds a Task Graph based on your configuration and repos
 ---
 
 import { File, Folder, Files } from '#/components/files';
+import { Callout } from '#/components/callout';
 
 ## Package Graph
 
@@ -14,8 +15,12 @@ This sets the groundwork for the Task Graph, where you'll define how **tasks** r
 ## Task Graph
 
 In `turbo.json`, you express how tasks relate to each other. You can think of these relationships as
-dependencies between tasks, but we have a more formal name for them: the Task
-Graph.
+dependencies between tasks, but we have a more formal name for them: the Task Graph.
+
+<Callout type="good-to-know">
+  You can generate a visualization of the task graph for your tasks using [the
+  `--graph` flag](/repo/docs/reference/run#--graph-file-type).
+</Callout>
 
 Turborepo uses a data structure called a [directed acyclic graph (DAG)](https://en.wikipedia.org/wiki/Directed_acyclic_graph) to
 understand your repository and its tasks. A graph is made up of "nodes" and


### PR DESCRIPTION
### Description

In https://github.com/vercel/turborepo/issues/8806, it was mentioned that we should mention `--graph` on the page where we talk about graphs - so let's do that!
