### PR TITLE
docs: mention module resolution differences for package managers

### DIFF
--- a/docs/repo-docs/crafting-your-repository/managing-dependencies.mdx
+++ b/docs/repo-docs/crafting-your-repository/managing-dependencies.mdx
@@ -120,6 +120,14 @@ Note that Turborepo does not play a role in managing your dependencies, leaving 
 
 It's up to the package manager to handle things like downloading the right external dependency version, symlinking, and resolving modules. The recommendations on this page are best practices for managing dependencies in a Workspace, and are not enforced by Turborepo.
 
+### Module resolution differs amongst package managers
+
+Package managers have different module resolution algorithms, which leads to differences in behavior that can be difficult to predict.
+
+In the Turborepo documentation, we make many recommendations according to the expected behaviors of the package managers. Our coverage of how to handle dependencies is best effort and you may need to adapt the documented behavior for your package manager or repository's needs.
+
+However, if you find an issue with the documentation that appears to be universally incorrect for all package managers or a specific one, please let us know with a GitHub Issue so we can improve.
+
 ### node_modules locations
 
 Depending on your choice of package manager, version, settings, and where your dependencies are installed in your Workspace, you may see `node_modules` and the dependencies inside it in various locations within the Workspace. Dependencies could be found in the root `node_modules`, in packages' `node_modules`, or both.


### PR DESCRIPTION
### Description

We've gotten reports before about the documentation being wrong when it's actually an issue with a package manager behaving in a bizarre way or a specific setting for a package manager not working with the strategy proposed in the documentation.

We won't be able to document every edge case or odd behavior of every package manager's module resolution algorithm, so I'd prefer to make mention of this in the docs.

We do our best. 😬

### Testing Instructions

👀
