### PR TITLE
chore(examples): remove unused typescript-eslint dependencies from ba…

### DIFF
--- a/examples/basic/packages/eslint-config/package.json
+++ b/examples/basic/packages/eslint-config/package.json
@@ -11,8 +11,6 @@
   "devDependencies": {
     "@eslint/js": "^9.17.0",
     "@next/eslint-plugin-next": "^15.1.0",
-    "@typescript-eslint/eslint-plugin": "^8.15.0",
-    "@typescript-eslint/parser": "^8.15.0",
     "eslint": "^9.15.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-only-warn": "^1.1.0",

--- a/examples/basic/pnpm-lock.yaml
+++ b/examples/basic/pnpm-lock.yaml
@@ -94,12 +94,6 @@ importers:
       '@next/eslint-plugin-next':
         specifier: ^15.1.0
         version: 15.1.0
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^8.15.0
-        version: 8.15.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0)(typescript@5.5.4))(eslint@9.15.0)(typescript@5.5.4)
-      '@typescript-eslint/parser':
-        specifier: ^8.15.0
-        version: 8.15.0(eslint@9.15.0)(typescript@5.5.4)
       eslint:
         specifier: ^9.15.0
         version: 9.15.0


### PR DESCRIPTION
### Description

Removed `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` from eslint-config package in the basic example.

These are already included within the `typescript-eslint` package, as outlined in the migration guide (https://typescript-eslint.io/packages/typescript-eslint/#migrating-from-legacy-config-setups). 