### PR TITLE
docs: fix typo in typescript.mdx of repo-docs

### DIFF
--- a/docs/repo-docs/guides/tools/typescript.mdx
+++ b/docs/repo-docs/guides/tools/typescript.mdx
@@ -81,7 +81,7 @@ The other `tsconfig` files in this package use the `extends` key to start with t
 
 Inside `package.json`, name the package so it can be referenced in the rest of the Workspace:
 
-```json title="packages/tsconfig/package.json"
+```json title="packages/typescript-config/package.json"
 {
   "name": "@repo/typescript-config"
 }


### PR DESCRIPTION
### Description

Corrected a minor typo in the docs/repo-docs/guides/tools/typescript.mdx file of the documentation. This update ensures better readability and accuracy for users.

### Testing Instructions

No specific testing is required, as this is a simple documentation update.
To verify the change:

Navigate to docs/repo-docs/guides/tools/typescript.mdx.
Confirm that the typo has been corrected and the updated text appears as expected.
