### PR TITLE
docs: guide for shadcn/ui

### DIFF
--- a/docs/repo-docs/guides/tools/shadcn-ui.mdx
+++ b/docs/repo-docs/guides/tools/shadcn-ui.mdx
@@ -1,0 +1,70 @@
+---
+title: shadcn/ui
+description: Learn how to use shadcn/ui in a Turborepo.
+---
+
+import { PackageManagerTabs, Tab } from '#/components/tabs';
+
+shadcn/ui is an open-source set of beautifully designed components made with Tailwind CSS that you can copy and paste into your apps.
+
+To get started with shadcn/ui in a new monorepo, run:
+
+<PackageManagerTabs>
+<Tab>
+
+```bash title="Terminal"
+npx shadcn@canary init
+```
+
+</Tab>
+
+<Tab>
+
+```bash title="Terminal"
+npx shadcn@canary init
+```
+
+</Tab>
+
+<Tab>
+
+```bash title="Terminal"
+pnpm dlx shadcn@canary init
+```
+
+</Tab>
+</PackageManagerTabs>
+
+When prompted, select the option for monorepos.
+
+To add a component, run:
+
+<PackageManagerTabs>
+<Tab>
+
+```bash title="Terminal"
+npx shadcn@canary add [COMPONENT]
+```
+
+</Tab>
+
+<Tab>
+
+```bash title="Terminal"
+npx shadcn@canary add [COMPONENT]
+```
+
+</Tab>
+
+<Tab>
+
+```bash title="Terminal"
+pnpm dlx shadcn@canary add [COMPONENT]
+```
+
+</Tab>
+</PackageManagerTabs>
+
+## More information
+
+To learn more about using shadcn/ui in Turborepo, [visit the docs for shadcn/ui](https://ui.shadcn.com/docs/monorepo).


### PR DESCRIPTION
### Description

shadcn/ui recently added [experimental support for monorepos](https://ui.shadcn.com/docs/monorepo), so let's make a pointer for folks who come to Turborepo first.

### Testing Instructions

👀 
