### PR TITLE
fix(env): allow `passThroughEnv` to negate built ins and `globalPassThroughEnv`

### DIFF
--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -52,7 +52,6 @@ use crate::{
 pub struct Visitor<'a> {
     color_cache: ColorSelector,
     dry: bool,
-    global_env: EnvironmentVariableMap,
     global_env_mode: EnvMode,
     manager: ProcessManager,
     run_opts: &'a RunOpts,
@@ -146,6 +145,7 @@ impl<'a> Visitor<'a> {
             run_opts,
             env_at_execution_start,
             global_hash,
+            global_env,
         );
 
         let sink = Self::sink(run_opts);
@@ -172,7 +172,6 @@ impl<'a> Visitor<'a> {
             sink,
             task_hasher,
             color_config,
-            global_env,
             ui_sender,
             is_watch,
             warnings: Default::default(),
@@ -259,9 +258,9 @@ impl<'a> Visitor<'a> {
             // We do this calculation earlier than we do in Go due to the `task_hasher`
             // being !Send. In the future we can look at doing this right before
             // task execution instead.
-            let execution_env =
-                self.task_hasher
-                    .env(&info, task_env_mode, task_definition, &self.global_env)?;
+            let execution_env = self
+                .task_hasher
+                .env(&info, task_env_mode, task_definition)?;
 
             let task_cache = self.run_cache.task_cache(
                 task_definition,

--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -289,17 +289,19 @@ impl<'a> TaskHasher<'a> {
         // See if we infer a framework
         let framework = do_framework_inference
             .then(|| infer_framework(workspace, is_monorepo))
-            .flatten();
+            .flatten()
+            .inspect(|framework| {
+                debug!("auto detected framework for {}", task_id.package());
+                debug!(
+                    "framework: {}, env_prefix: {:?}",
+                    framework.slug(),
+                    framework.env_wildcards()
+                );
+                telemetry.track_framework(framework.slug());
+            });
         let framework_slug = framework.map(|f| f.slug().to_string());
 
         if let Some(framework) = framework {
-            debug!("auto detected framework for {}", task_id.package());
-            debug!(
-                "framework: {}, env_prefix: {:?}",
-                framework.slug(),
-                framework.env_wildcards()
-            );
-            telemetry.track_framework(framework.slug());
             let mut computed_wildcards = framework
                 .env_wildcards()
                 .iter()

--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -433,70 +433,69 @@ impl<'a> TaskHasher<'a> {
     ) -> Result<EnvironmentVariableMap, Error> {
         match task_env_mode {
             EnvMode::Strict => {
-                let mut pass_through_env = EnvironmentVariableMap::default();
-                let default_env_var_pass_through_map =
-                    self.env_at_execution_start.from_wildcards(&[
-                        "HOME",
-                        "USER",
-                        "TZ",
-                        "LANG",
-                        "SHELL",
-                        "PWD",
-                        "CI",
-                        "NODE_OPTIONS",
-                        "COREPACK_HOME",
-                        "LD_LIBRARY_PATH",
-                        "DYLD_FALLBACK_LIBRARY_PATH",
-                        "LIBPATH",
-                        "COLORTERM",
-                        "TERM",
-                        "TERM_PROGRAM",
-                        "DISPLAY",
-                        "TMP",
-                        "TEMP",
-                        // VSCode IDE - https://github.com/microsoft/vscode-js-debug/blob/5b0f41dbe845d693a541c1fae30cec04c878216f/src/targets/node/nodeLauncherBase.ts#L320
-                        "VSCODE_*",
-                        "ELECTRON_RUN_AS_NODE",
-                        // Docker - https://docs.docker.com/engine/reference/commandline/cli/#environment-variables
-                        "DOCKER_*",
-                        "BUILDKIT_*",
-                        // Docker compose - https://docs.docker.com/compose/environment-variables/envvars/
-                        "COMPOSE_*",
-                        // Jetbrains IDE
-                        "JB_IDE_*",
-                        "JB_INTERPRETER",
-                        "_JETBRAINS_TEST_RUNNER_RUN_SCOPE_TYPE",
-                        // Vercel specific
-                        "VERCEL",
-                        "VERCEL_*",
-                        "NEXT_*",
-                        "USE_OUTPUT_FOR_EDGE_FUNCTIONS",
-                        "NOW_BUILDER",
-                        // Command Prompt casing of env variables
-                        "APPDATA",
-                        "PATH",
-                        "PROGRAMDATA",
-                        "SYSTEMROOT",
-                        "SYSTEMDRIVE",
-                    ])?;
-                let tracker_env = self
-                    .task_hash_tracker
-                    .env_vars(task_id)
-                    .ok_or_else(|| Error::MissingEnvVars(task_id.clone().into_owned()))?;
-
-                pass_through_env.union(&default_env_var_pass_through_map);
-                pass_through_env.union(global_env);
-                pass_through_env.union(&tracker_env.all);
-
-                let env_var_pass_through_map = self.env_at_execution_start.from_wildcards(
+                let mut full_task_env = EnvironmentVariableMap::default();
+                let builtin_pass_through = &[
+                    "HOME",
+                    "USER",
+                    "TZ",
+                    "LANG",
+                    "SHELL",
+                    "PWD",
+                    "CI",
+                    "NODE_OPTIONS",
+                    "COREPACK_HOME",
+                    "LD_LIBRARY_PATH",
+                    "DYLD_FALLBACK_LIBRARY_PATH",
+                    "LIBPATH",
+                    "COLORTERM",
+                    "TERM",
+                    "TERM_PROGRAM",
+                    "DISPLAY",
+                    "TMP",
+                    "TEMP",
+                    // VSCode IDE - https://github.com/microsoft/vscode-js-debug/blob/5b0f41dbe845d693a541c1fae30cec04c878216f/src/targets/node/nodeLauncherBase.ts#L320
+                    "VSCODE_*",
+                    "ELECTRON_RUN_AS_NODE",
+                    // Docker - https://docs.docker.com/engine/reference/commandline/cli/#environment-variables
+                    "DOCKER_*",
+                    "BUILDKIT_*",
+                    // Docker compose - https://docs.docker.com/compose/environment-variables/envvars/
+                    "COMPOSE_*",
+                    // Jetbrains IDE
+                    "JB_IDE_*",
+                    "JB_INTERPRETER",
+                    "_JETBRAINS_TEST_RUNNER_RUN_SCOPE_TYPE",
+                    // Vercel specific
+                    "VERCEL",
+                    "VERCEL_*",
+                    "NEXT_*",
+                    "USE_OUTPUT_FOR_EDGE_FUNCTIONS",
+                    "NOW_BUILDER",
+                    // Command Prompt casing of env variables
+                    "APPDATA",
+                    "PATH",
+                    "PROGRAMDATA",
+                    "SYSTEMROOT",
+                    "SYSTEMDRIVE",
+                ];
+                let pass_through_env_vars = self.env_at_execution_start.pass_through_env(
+                    builtin_pass_through,
+                    global_env,
                     task_definition
                         .pass_through_env
                         .as_deref()
                         .unwrap_or_default(),
                 )?;
-                pass_through_env.union(&env_var_pass_through_map);
 
-                Ok(pass_through_env)
+                let tracker_env = self
+                    .task_hash_tracker
+                    .env_vars(task_id)
+                    .ok_or_else(|| Error::MissingEnvVars(task_id.clone().into_owned()))?;
+
+                full_task_env.union(&pass_through_env_vars);
+                full_task_env.union(&tracker_env.all);
+
+                Ok(full_task_env)
             }
             EnvMode::Loose => Ok(self.env_at_execution_start.clone()),
         }

--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -242,6 +242,7 @@ pub struct TaskHasher<'a> {
     hashes: HashMap<TaskId<'static>, String>,
     run_opts: &'a RunOpts,
     env_at_execution_start: &'a EnvironmentVariableMap,
+    global_env: EnvironmentVariableMap,
     global_hash: &'a str,
     task_hash_tracker: TaskHashTracker,
 }
@@ -252,6 +253,7 @@ impl<'a> TaskHasher<'a> {
         run_opts: &'a RunOpts,
         env_at_execution_start: &'a EnvironmentVariableMap,
         global_hash: &'a str,
+        global_env: EnvironmentVariableMap,
     ) -> Self {
         let PackageInputsHashes {
             hashes,
@@ -262,6 +264,7 @@ impl<'a> TaskHasher<'a> {
             run_opts,
             env_at_execution_start,
             global_hash,
+            global_env,
             task_hash_tracker: TaskHashTracker::new(expanded_hashes),
         }
     }
@@ -429,7 +432,6 @@ impl<'a> TaskHasher<'a> {
         task_id: &TaskId,
         task_env_mode: EnvMode,
         task_definition: &TaskDefinition,
-        global_env: &EnvironmentVariableMap,
     ) -> Result<EnvironmentVariableMap, Error> {
         match task_env_mode {
             EnvMode::Strict => {
@@ -480,7 +482,7 @@ impl<'a> TaskHasher<'a> {
                 ];
                 let pass_through_env_vars = self.env_at_execution_start.pass_through_env(
                     builtin_pass_through,
-                    global_env,
+                    &self.global_env,
                     task_definition
                         .pass_through_env
                         .as_deref()

--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -302,22 +302,19 @@ impl<'a> TaskHasher<'a> {
         let framework_slug = framework.map(|f| f.slug().to_string());
 
         if let Some(framework) = framework {
-            let mut computed_wildcards = framework
-                .env_wildcards()
-                .iter()
-                .map(|s| s.to_string())
-                .collect::<Vec<_>>();
+            let mut computed_wildcards = framework.env_wildcards().to_vec();
 
-            if let Some(exclude_prefix) = self.env_at_execution_start.get("TURBO_CI_VENDOR_ENV_KEY")
+            if let Some(exclude_prefix) = self
+                .env_at_execution_start
+                .get("TURBO_CI_VENDOR_ENV_KEY")
+                .filter(|prefix| !prefix.is_empty())
             {
-                if !exclude_prefix.is_empty() {
-                    let computed_exclude = format!("!{}*", exclude_prefix);
-                    debug!(
-                        "excluding environment variables matching wildcard {}",
-                        computed_exclude
-                    );
-                    computed_wildcards.push(computed_exclude);
-                }
+                let computed_exclude = format!("!{}*", exclude_prefix);
+                debug!(
+                    "excluding environment variables matching wildcard {}",
+                    computed_exclude
+                );
+                computed_wildcards.push(computed_exclude);
             }
 
             let inference_env_var_map = self


### PR DESCRIPTION
### Description

Fixes https://github.com/vercel/turborepo/issues/9659

Fixing required a fair amount of code shuffling before it can be addressed. This PR is a collection of prework that I did before fixing the issue that will probably be easier to review in isolation. The final commit is the actual fix.

The important moves in the commit is moving some logic out of `TaskHasher` and into `turborepo-env` crate where we can easily test this logic without constructing a full `Run`.

Each commit is a small incremental change to this codepath that shouldn't have any behavioral changes until the final commit.

### Testing Instructions

Added unit tests for pass through env creation, existing integration tests that cover this behavior as well.

Quick manual test:
```
[0 olszewski@chriss-mbp] /tmp/signal2 $ NODE_ENV=foobar turbo_dev --skip-infer build --force
turbo 2.3.4-canary.6

• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web
• Running build in 5 packages
• Remote caching disabled
┌ docs#build > cache bypass, force executing 16782fcb8cc27a58 
│ 
│ 
│ > docs@0.1.0 build /private/tmp/signal2/apps/docs
│ > echo $NODE_ENV
│ 
│ foobar
└────>
┌ web#build > cache bypass, force executing e35cbd6e0f053fa7 
│ 
│ 
│ > web@0.1.0 build /private/tmp/signal2/apps/web
│ > echo $NODE_ENV
└────>

 Tasks:    2 successful, 2 total
Cached:    0 cached, 2 total
  Time:    295ms 

[0 olszewski@chriss-mbp] /tmp/signal2 $ bat apps/web/turbo.json 
───────┬────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
       │ File: apps/web/turbo.json
───────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1   │ {
   2   │ "extends": ["//"],
   3   │ "tasks": { "build": {"passThroughEnv": ["!NODE_ENV"] } }
   4   │ }
───────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```
