### PR TITLE
feat(mfe): remove hyphen from microfrontends binary name

### DIFF
--- a/crates/turborepo-lib/src/task_graph/visitor/command.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/command.rs
@@ -230,7 +230,7 @@ impl<'a> CommandProvider for MicroFrontendProxyProvider<'a> {
         args.extend(local_apps);
 
         // TODO: leverage package manager to find the local proxy
-        let program = package_dir.join_components(&["node_modules", ".bin", "micro-frontends"]);
+        let program = package_dir.join_components(&["node_modules", ".bin", "microfrontends"]);
         let mut cmd = Command::new(program.as_std_path());
         cmd.current_dir(package_dir).args(args).open_stdin();
 


### PR DESCRIPTION
### Description

The standard naming for microfrontends does not have a hyphen. This updates Turborepo to look for the binary without the hyphen.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
