### PR TITLE
docs(fix): correct line highlighting by removing extra comma

### DIFF
--- a/docs/repo-docs/core-concepts/internal-packages.mdx
+++ b/docs/repo-docs/core-concepts/internal-packages.mdx
@@ -109,11 +109,11 @@ A Compiled Package is a package that handles its own compilation using a build t
   "exports": {
     "./button": {
       "types": "./src/button.tsx", // [!code highlight]
-      "default": "./dist/button.js" // [!code highlight],
+      "default": "./dist/button.js" // [!code highlight]
     },
     "./card": {
       "types": "./src/card.tsx", // [!code highlight]
-      "default": "./dist/card.js" // [!code highlight],
+      "default": "./dist/card.js" // [!code highlight]
     }
   },
   "scripts": {


### PR DESCRIPTION
### Description

The comma was preventing the actual highlighting and causing it to print to the content.
