### PR TITLE
fix(cache): suggest proper --cache flag for --remote-cache-read-only

### DIFF
--- a/crates/turborepo-cache/src/config.rs
+++ b/crates/turborepo-cache/src/config.rs
@@ -211,6 +211,10 @@ mod test {
     )]
     #[test_case("local:r", Ok(CacheConfig { local: CacheActions { read: true, write: false }, remote: CacheActions { read: false, write: false } }) ; "local:r"
     )]
+    #[test_case("remote:r", Ok(CacheConfig { local: CacheActions { read: false, write: false }, remote: CacheActions { read: true, write: false } }) ; "remote:r"
+    )]
+    #[test_case("local:rw,remote:r", Ok(CacheConfig { local: CacheActions { read: true, write: true }, remote: CacheActions { read: true, write: false } }) ; "local:rw,remote:r"
+    )]
     #[test_case("local:", Ok(CacheConfig { local: CacheActions { read: false, write: false }, remote: CacheActions { read: false, write: false } }) ; "empty action"
     )]
     #[test_case("local:,remote:", Ok(CacheConfig { local: CacheActions { read: false, write: false }, remote: CacheActions { read: false, write: false } }) ; "multiple empty actions"

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -391,7 +391,7 @@ impl Args {
             if run_args.remote_cache_read_only.is_some() {
                 warn!(
                     "--remote-cache-read-only is deprecated and will be removed in a future major \
-                     version. Use --cache=remote:r"
+                     version. Use --cache=local:rw,remote:r"
                 );
             }
         }


### PR DESCRIPTION
### Description

Fixes #9699

### Testing Instructions

Added some small unit tests to verify how the `--cache` flag gets parsed.
