### PR TITLE
fix(cache): avoid warning if TURBO_FORCE, TURBO_REMOTE_ONLY, and TURBO_CACHE

### DIFF
--- a/crates/turborepo-lib/src/config/env.rs
+++ b/crates/turborepo-lib/src/config/env.rs
@@ -93,11 +93,6 @@ impl ResolvedConfigurationOptions for EnvVars {
             .map(|c| c.parse())
             .transpose()?;
 
-        // If TURBO_FORCE is set it wins out over TURBO_CACHE
-        if force.is_some_and(|t| t) {
-            cache = None;
-        }
-
         if remote_only.is_some_and(|t| t) {
             if let Some(cache) = cache {
                 // If TURBO_REMOTE_ONLY and TURBO_CACHE result in the same behavior, remove
@@ -117,6 +112,11 @@ impl ResolvedConfigurationOptions for EnvVars {
                     remote_cache_read_only = None;
                 }
             }
+        }
+
+        // If TURBO_FORCE is set it wins out over TURBO_CACHE
+        if force.is_some_and(|t| t) {
+            cache = None;
         }
 
         if remote_only.is_some() {


### PR DESCRIPTION
### Description

Previously we would erroneously warn users that `TURBO_REMOTE_ONLY` was being deprecated even if the correct `TURBO_CACHE` was also present. This happened because we have `TURBO_FORCE` erase caching behavior and this was happening before we checked if `TURBO_REMOTE_ONLY` had a matching `TURBO_CACHE` declaration. The fix is just doing that check before doing the force override.

### Testing Instructions
Before
```
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ TURBO_FORCE=1 TURBO_REMOTE_ONLY=1 TURBO_CACHE=remote:rw turbo_dev @turbo/t
ypes#build > /dev/null                                                                                                                      
 WARNING  No locally installed `turbo` found. Using version: 2.3.4-canary.6.                                                                
turbo 2.3.4-canary.6                                                                                                                        
                                                                                                                                            
 WARNING  TURBO_REMOTE_ONLY is deprecated and will be removed in a future major version. Use TURBO_CACHE=remote:rw
```

After:
```
[0 olszewski@chriss-mbp] /Users/olszewski/code/vercel/turborepo $ TURBO_FORCE=1 TURBO_REMOTE_ONLY=1 TURBO_CACHE=remote:rw turbo_dev @turbo/types#build > /dev/null
 WARNING  No locally installed `turbo` found. Using version: 2.3.4-canary.7.
turbo 2.3.4-canary.7
```
