### PR TITLE
chore(examples): mark core supported examples

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,6 +1,6 @@
 # Turborepo starter
 
-This is Turborepo starter is maintained by the Turborepo core team.
+This Turborepo starter is maintained by the Turborepo core team.
 
 ## Using this example
 

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,6 +1,6 @@
 # Turborepo starter
 
-This is an official starter Turborepo.
+This is Turborepo starter is maintained by the Turborepo core team.
 
 ## Using this example
 

--- a/examples/basic/meta.json
+++ b/examples/basic/meta.json
@@ -1,0 +1,3 @@
+{
+  "maintainedByCoreTeam": true
+}

--- a/examples/design-system/README.md
+++ b/examples/design-system/README.md
@@ -1,5 +1,7 @@
 # Turborepo Design System Starter
 
+This is a community-maintained example. If you experience a problem, please submit a pull request with a fix. GitHub Issues will be closed.
+
 This guide explains how to use a React design system starter powered by:
 
 - 🏎 [Turborepo](https://turbo.build/repo) — High-performance build system for Monorepos

--- a/examples/kitchen-sink/README.md
+++ b/examples/kitchen-sink/README.md
@@ -1,6 +1,6 @@
 # Turborepo kitchen sink starter
 
-This is Turborepo starter is maintained by the Turborepo core team.
+This Turborepo starter is maintained by the Turborepo core team.
 
 This example also shows how to use [Workspace Configurations](https://turbo.build/repo/docs/core-concepts/monorepos/configuring-workspaces).
 

--- a/examples/kitchen-sink/README.md
+++ b/examples/kitchen-sink/README.md
@@ -1,6 +1,6 @@
 # Turborepo kitchen sink starter
 
-This is an official starter Turborepo with multiple meta-frameworks all working in harmony and sharing packages.
+This is Turborepo starter is maintained by the Turborepo core team.
 
 This example also shows how to use [Workspace Configurations](https://turbo.build/repo/docs/core-concepts/monorepos/configuring-workspaces).
 

--- a/examples/kitchen-sink/meta.json
+++ b/examples/kitchen-sink/meta.json
@@ -2,5 +2,6 @@
   "name": "Kitchen Sink",
   "description": "Want to see a more in-depth example? Includes multiple frameworks, both frontend and backend.",
   "template": "https://vercel.com/templates/remix/turborepo-kitchensink",
-  "featured": true
+  "featured": true,
+  "maintainedByCoreTeam": true
 }

--- a/examples/non-monorepo/README.md
+++ b/examples/non-monorepo/README.md
@@ -1,6 +1,6 @@
 # Turborepo non-monorepo starter
 
-This is an official starter Turborepo.
+This is Turborepo starter is maintained by the Turborepo core team.
 
 ## Using this example
 

--- a/examples/non-monorepo/README.md
+++ b/examples/non-monorepo/README.md
@@ -1,6 +1,6 @@
 # Turborepo non-monorepo starter
 
-This is Turborepo starter is maintained by the Turborepo core team.
+This Turborepo starter is maintained by the Turborepo core team.
 
 ## Using this example
 

--- a/examples/non-monorepo/meta.json
+++ b/examples/non-monorepo/meta.json
@@ -1,4 +1,5 @@
 {
   "name": "Non-Monorepo",
-  "description": "Example of using Turborepo in a single project without workspaces"
+  "description": "Example of using Turborepo in a single project without workspaces",
+  "maintainedByCoreTeam": true
 }

--- a/examples/with-angular/README.md
+++ b/examples/with-angular/README.md
@@ -1,6 +1,6 @@
 # Turborepo starter
 
-This is an official starter Turborepo.
+This is a community-maintained example. If you experience a problem, please submit a pull request with a fix. GitHub Issues will be closed.
 
 ## Using this example
 

--- a/examples/with-berry/README.md
+++ b/examples/with-berry/README.md
@@ -1,6 +1,6 @@
 # Turborepo starter with berry (yarn v2+)
 
-This is an official starter Turborepo.
+This is a community-maintained example. If you experience a problem, please submit a pull request with a fix. GitHub Issues will be closed.
 
 ## Using this example
 

--- a/examples/with-changesets/README.md
+++ b/examples/with-changesets/README.md
@@ -1,6 +1,6 @@
 # Turborepo Design System starter with Changesets
 
-This is an official React design system starter powered by Turborepo. Versioning and package publishing is handled by [Changesets](https://github.com/changesets/changesets) and fully automated with GitHub Actions.
+This is a community-maintained example. If you experience a problem, please submit a pull request with a fix. GitHub Issues will be closed.
 
 ## Using this example
 

--- a/examples/with-docker/README.md
+++ b/examples/with-docker/README.md
@@ -1,6 +1,6 @@
 # Turborepo Docker starter
 
-This is an official Docker starter Turborepo.
+This is a community-maintained example. If you experience a problem, please submit a pull request with a fix. GitHub Issues will be closed.
 
 ## Using this example
 

--- a/examples/with-gatsby/README.md
+++ b/examples/with-gatsby/README.md
@@ -1,6 +1,6 @@
 # Turborepo Gatsby.js starter
 
-This is an official starter turborepo.
+This is a community-maintained example. If you experience a problem, please submit a pull request with a fix. GitHub Issues will be closed.
 
 ## Using this example
 

--- a/examples/with-nestjs/README.md
+++ b/examples/with-nestjs/README.md
@@ -1,6 +1,6 @@
 # Turborepo starter
 
-This is an official starter Turborepo.
+This is a community-maintained example. If you experience a problem, please submit a pull request with a fix. GitHub Issues will be closed.
 
 ## Using this example
 

--- a/examples/with-npm/README.md
+++ b/examples/with-npm/README.md
@@ -1,6 +1,6 @@
 # Turborepo starter
 
-This is an official starter Turborepo.
+This is a community-maintained example. If you experience a problem, please submit a pull request with a fix. GitHub Issues will be closed.
 
 ## Using this example
 

--- a/examples/with-prisma/README.md
+++ b/examples/with-prisma/README.md
@@ -1,6 +1,6 @@
 # Turborepo starter
 
-This is an official starter turborepo.
+This is a community-maintained example. If you experience a problem, please submit a pull request with a fix. GitHub Issues will be closed.
 
 ## Using this example
 

--- a/examples/with-react-native-web/README.md
+++ b/examples/with-react-native-web/README.md
@@ -1,6 +1,6 @@
 # Turborepo react-native starter
 
-This is an official starter Turborepo.
+This is a community-maintained example. If you experience a problem, please submit a pull request with a fix. GitHub Issues will be closed.
 
 ## Using this example
 

--- a/examples/with-rollup/README.md
+++ b/examples/with-rollup/README.md
@@ -1,6 +1,6 @@
 # Turborepo starter with Rollup
 
-This is an official starter Turborepo, showing how Turborepo can be used with Rollup for bundling a `ui` package.
+This is a community-maintained example. If you experience a problem, please submit a pull request with a fix. GitHub Issues will be closed.
 
 ## Using this example
 

--- a/examples/with-shell-commands/README.md
+++ b/examples/with-shell-commands/README.md
@@ -1,6 +1,6 @@
 # Turborepo starter with shell commands
 
-This is Turborepo starter is maintained by the Turborepo core team. This template is great for issue reproductions and exploring building task graphs without frameworks.
+This Turborepo starter is maintained by the Turborepo core team. This template is great for issue reproductions and exploring building task graphs without frameworks.
 
 ## Using this example
 

--- a/examples/with-shell-commands/README.md
+++ b/examples/with-shell-commands/README.md
@@ -1,6 +1,6 @@
 # Turborepo starter with shell commands
 
-This is an official starter Turborepo meant for debugging, learning, and exploring.
+This is Turborepo starter is maintained by the Turborepo core team. This template is great for issue reproductions and exploring building task graphs without frameworks.
 
 ## Using this example
 

--- a/examples/with-shell-commands/meta.json
+++ b/examples/with-shell-commands/meta.json
@@ -1,0 +1,3 @@
+{
+  "maintainedByCoreTeam": true
+}

--- a/examples/with-svelte/README.md
+++ b/examples/with-svelte/README.md
@@ -1,6 +1,6 @@
 # Turborepo Svelte starter
 
-This is Turborepo starter is maintained by the Turborepo core team.
+This Turborepo starter is maintained by the Turborepo core team.
 
 ## Using this example
 

--- a/examples/with-svelte/README.md
+++ b/examples/with-svelte/README.md
@@ -1,6 +1,6 @@
 # Turborepo Svelte starter
 
-This is an official starter Turborepo.
+This is Turborepo starter is maintained by the Turborepo core team.
 
 ## Using this example
 

--- a/examples/with-svelte/meta.json
+++ b/examples/with-svelte/meta.json
@@ -3,5 +3,6 @@
   "description": "Monorepo with multiple SvelteKit apps sharing a UI Library",
   "featured": true,
   "template": "https://vercel.com/templates/svelte/turborepo-sveltekit-starter",
-  "boost": true
+  "boost": true,
+  "maintainedByCoreTeam": true
 }

--- a/examples/with-tailwind/README.md
+++ b/examples/with-tailwind/README.md
@@ -1,6 +1,6 @@
 # Turborepo Tailwind CSS starter
 
-This is Turborepo starter is maintained by the Turborepo core team.
+This Turborepo starter is maintained by the Turborepo core team.
 
 ## Using this example
 

--- a/examples/with-tailwind/README.md
+++ b/examples/with-tailwind/README.md
@@ -1,6 +1,6 @@
 # Turborepo Tailwind CSS starter
 
-This is an official starter Turborepo.
+This is Turborepo starter is maintained by the Turborepo core team.
 
 ## Using this example
 

--- a/examples/with-tailwind/meta.json
+++ b/examples/with-tailwind/meta.json
@@ -1,5 +1,6 @@
 {
   "name": "Tailwind CSS",
   "description": "Monorepo with multiple Next.js apps sharing a UI Library all using Tailwind CSS with a shared config",
-  "featured": true
+  "featured": true,
+  "maintainedByCoreTeam": true
 }

--- a/examples/with-typeorm/README.md
+++ b/examples/with-typeorm/README.md
@@ -1,6 +1,6 @@
 # Turborepo with TypeORM
 
-This is an official starter Turborepo configured with TypeORM to manage the service layer in a monorepo setup.
+This is a community-maintained example. If you experience a problem, please submit a pull request with a fix. GitHub Issues will be closed.
 
 ## What's inside?
 

--- a/examples/with-vite/README.md
+++ b/examples/with-vite/README.md
@@ -1,6 +1,6 @@
 # `Turborepo` Vite starter
 
-This is an official starter Turborepo.
+This is a community-maintained example. If you experience a problem, please submit a pull request with a fix. GitHub Issues will be closed.
 
 ## Using this example
 

--- a/examples/with-vue-nuxt/README.md
+++ b/examples/with-vue-nuxt/README.md
@@ -1,6 +1,6 @@
 # Turborepo VueJS/NuxtJS starter
 
-This is an official starter Turborepo.
+This is a community-maintained example. If you experience a problem, please submit a pull request with a fix. GitHub Issues will be closed.
 
 ## Using this example
 

--- a/examples/with-yarn/README.md
+++ b/examples/with-yarn/README.md
@@ -1,6 +1,6 @@
 # Turborepo starter
 
-This is an official starter Turborepo.
+This is a community-maintained example. If you experience a problem, please submit a pull request with a fix. GitHub Issues will be closed.
 
 ## Using this example
 

--- a/packages/create-turbo/src/commands/create/index.ts
+++ b/packages/create-turbo/src/commands/create/index.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { bold, red, cyan, green } from "picocolors";
+import { bold, red, cyan, green, dim } from "picocolors";
 import type { Project } from "@turbo/workspaces";
 import {
   getWorkspaceDetails,
@@ -262,6 +262,15 @@ export async function create(
     );
   }
 
+  if (!isMaintainedByCoreTeam) {
+    logger.log();
+    logger.log(
+      dim(
+        "Note: This is a community-maintained example. If you experience a problem, please submit a pull request with a fix. GitHub Issues will be closed."
+      )
+    );
+  }
+
   // get the package manager details so we display the right commands to the user in log messages
   const packageManagerMeta = getPackageManagerMeta(projectPackageManager);
   if (packageManagerMeta && hasPackageJson) {
@@ -292,11 +301,5 @@ export async function create(
     logger.log("- Run a command twice to hit cache");
   }
 
-  if (!isMaintainedByCoreTeam) {
-    logger.log();
-    logger.log(
-      "Note: This example is maintained by the community. If you experience an issue, please submit a pull request with a fix. GitHub Issues created for community-supported examples will be closed."
-    );
-  }
   opts.telemetry?.trackCommandStatus({ command: "create", status: "end" });
 }

--- a/packages/create-turbo/src/commands/create/index.ts
+++ b/packages/create-turbo/src/commands/create/index.ts
@@ -285,5 +285,8 @@ export async function create(
       });
     logger.log("- Run a command twice to hit cache");
   }
+
+  logger.log();
+  logger.log("Note: ");
   opts.telemetry?.trackCommandStatus({ command: "create", status: "end" });
 }

--- a/packages/create-turbo/src/commands/create/index.ts
+++ b/packages/create-turbo/src/commands/create/index.ts
@@ -76,6 +76,8 @@ export async function create(
   opts.telemetry?.trackArgumentDirectory(Boolean(directory));
   trackOptions(opts);
 
+  let isMaintainedByCoreTeam = false;
+
   const { packageManager, skipInstall, skipTransforms } = opts;
 
   const [online, availablePackageManagers] = await Promise.all([
@@ -158,6 +160,10 @@ export async function create(
           tryGitCommit(
             `feat(create-turbo): apply ${transformResult.name} transform`
           );
+        }
+
+        if (transformResult.metaJson?.maintainedByCoreTeam) {
+          isMaintainedByCoreTeam = true;
         }
       } catch (err) {
         handleErrors(err, opts.telemetry);
@@ -286,7 +292,11 @@ export async function create(
     logger.log("- Run a command twice to hit cache");
   }
 
-  logger.log();
-  logger.log("Note: ");
+  if (!isMaintainedByCoreTeam) {
+    logger.log();
+    logger.log(
+      "Note: This example is maintained by the community. If you experience an issue, please submit a pull request with a fix. Issues created for community-supported examples will be closed."
+    );
+  }
   opts.telemetry?.trackCommandStatus({ command: "create", status: "end" });
 }

--- a/packages/create-turbo/src/commands/create/index.ts
+++ b/packages/create-turbo/src/commands/create/index.ts
@@ -295,7 +295,7 @@ export async function create(
   if (!isMaintainedByCoreTeam) {
     logger.log();
     logger.log(
-      "Note: This example is maintained by the community. If you experience an issue, please submit a pull request with a fix. Issues created for community-supported examples will be closed."
+      "Note: This example is maintained by the community. If you experience an issue, please submit a pull request with a fix. GitHub Issues created for community-supported examples will be closed."
     );
   }
   opts.telemetry?.trackCommandStatus({ command: "create", status: "end" });

--- a/packages/create-turbo/src/transforms/official-starter.ts
+++ b/packages/create-turbo/src/transforms/official-starter.ts
@@ -18,9 +18,10 @@ export async function transform(args: TransformInput): TransformResult {
   const { prompts, example, opts } = args;
 
   const defaultExample = isDefaultExample(example.name);
-  const isOfficialStarter =
-    !example.repo ||
-    (example.repo.username === "vercel" && example.repo.name === "turborepo");
+  const isThisRepo =
+    example.repo &&
+    (example.repo.name === "turborepo" || example.repo.name === "turbo");
+  const isOfficialStarter = example.repo?.username === "vercel" && isThisRepo;
 
   if (!isOfficialStarter) {
     return { result: "not-applicable", ...meta };
@@ -40,8 +41,6 @@ export async function transform(args: TransformInput): TransformResult {
   } catch (_err) {
     // do nothing
   }
-
-  console.log("meta.json", metaJson);
 
   if (hasPackageJson) {
     let packageJsonContent;

--- a/packages/create-turbo/src/transforms/official-starter.ts
+++ b/packages/create-turbo/src/transforms/official-starter.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { readJsonSync, writeJsonSync, rmSync, existsSync } from "fs-extra";
 import type { PackageJson } from "@turbo/utils";
 import { isDefaultExample } from "../utils/isDefaultExample";
-import type { TransformInput, TransformResult } from "./types";
+import type { TransformInput, TransformResult, MetaJson } from "./types";
 import { TransformError } from "./errors";
 
 const meta = {
@@ -20,7 +20,7 @@ export async function transform(args: TransformInput): TransformResult {
   const defaultExample = isDefaultExample(example.name);
   const isOfficialStarter =
     !example.repo ||
-    (example.repo.username === "vercel" && example.repo.name === "turbo");
+    (example.repo.username === "vercel" && example.repo.name === "turborepo");
 
   if (!isOfficialStarter) {
     return { result: "not-applicable", ...meta };
@@ -31,12 +31,17 @@ export async function transform(args: TransformInput): TransformResult {
   const rootMetaJsonPath = path.join(prompts.root, "meta.json");
   const hasPackageJson = existsSync(rootPackageJsonPath);
 
+  let metaJson: MetaJson | undefined;
+
   // 1. remove meta file (used for generating the examples page on turbo.build)
   try {
+    metaJson = readJsonSync(rootMetaJsonPath) as MetaJson;
     rmSync(rootMetaJsonPath, { force: true });
   } catch (_err) {
     // do nothing
   }
+
+  console.log("meta.json", metaJson);
 
   if (hasPackageJson) {
     let packageJsonContent;
@@ -83,5 +88,5 @@ export async function transform(args: TransformInput): TransformResult {
     }
   }
 
-  return { result: "success", ...meta };
+  return { result: "success", metaJson, ...meta };
 }

--- a/packages/create-turbo/src/transforms/types.ts
+++ b/packages/create-turbo/src/transforms/types.ts
@@ -21,10 +21,15 @@ export interface TransformInput {
   opts: CreateCommandOptions;
 }
 
+export interface MetaJson {
+  maintainedByCoreTeam: string;
+}
+
 export interface TransformResponse {
   // errors should be thrown as instances of TransformError
   result: "not-applicable" | "success";
   name: string;
+  metaJson?: MetaJson;
 }
 
 export type TransformResult = Promise<TransformResponse>;

--- a/packages/create-turbo/src/transforms/types.ts
+++ b/packages/create-turbo/src/transforms/types.ts
@@ -22,7 +22,12 @@ export interface TransformInput {
 }
 
 export interface MetaJson {
-  maintainedByCoreTeam: string;
+  maintainedByCoreTeam?: string;
+  name?: string;
+  description?: string;
+  featured?: boolean;
+  boost?: boolean;
+  template?: boolean;
 }
 
 export interface TransformResponse {


### PR DESCRIPTION
### Description

The community has been contributing more and more examples as Turborepo usage has grown. This is _so exciting_ for those of us on the core team, but we've had a hard time maintaining so many examples. It's a lot of work to keep up with the breadth of tools that work great with Turborepo, and the JavaScript ecosystem moves fast.

Because of this, we've come up with a strategy so that we can set expectations correctly with the community. We're picking out ~5 examples that we're committing to maintaining as shining representatives of JavaScript monorepo greatness, leaving the rest to be maintained by the community.

We will communicate this directly in `create-turbo` invocations, leaving a note for users when they pick out a community-supported example.
 
### Testing Instructions
Should not show a `Note` log: `devcreateturbo --example https://github.com/vercel/turborepo/tree/shew-0f97e/examples/basic`
Should show a `Note` log: `devcreateturbo --example https://github.com/vercel/turborepo/tree/shew-0f97e/examples/with-docker`
 
 
