### PR TITLE
fix(create-turbo): correct repo name

### DIFF
--- a/packages/create-turbo/src/transforms/official-starter.ts
+++ b/packages/create-turbo/src/transforms/official-starter.ts
@@ -20,7 +20,7 @@ export async function transform(args: TransformInput): TransformResult {
   const defaultExample = isDefaultExample(example.name);
   const isOfficialStarter =
     !example.repo ||
-    (example.repo.username === "vercel" && example.repo.name === "turbo");
+    (example.repo.username === "vercel" && example.repo.name === "turborepo");
 
   if (!isOfficialStarter) {
     return { result: "not-applicable", ...meta };

--- a/packages/create-turbo/src/transforms/official-starter.ts
+++ b/packages/create-turbo/src/transforms/official-starter.ts
@@ -18,9 +18,10 @@ export async function transform(args: TransformInput): TransformResult {
   const { prompts, example, opts } = args;
 
   const defaultExample = isDefaultExample(example.name);
-  const isOfficialStarter =
-    !example.repo ||
-    (example.repo.username === "vercel" && example.repo.name === "turborepo");
+  const isThisRepo =
+    example.repo &&
+    (example.repo.name === "turborepo" || example.repo.name === "turbo");
+  const isOfficialStarter = example.repo?.username === "vercel" && isThisRepo;
 
   if (!isOfficialStarter) {
     return { result: "not-applicable", ...meta };


### PR DESCRIPTION
### Description

We have the repo name hardcoded to identify official examples, but we didn't update the name when we changed the name of the repository many moons ago.
