### PR TITLE
feat: respect gitignore during turbo prune

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6351,6 +6351,7 @@ name = "turborepo-fs"
 version = "0.1.0"
 dependencies = [
  "fs-err",
+ "ignore",
  "tempfile",
  "thiserror",
  "turbopath",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6355,7 +6355,6 @@ dependencies = [
  "tempfile",
  "thiserror",
  "turbopath",
- "walkdir",
 ]
 
 [[package]]

--- a/crates/turborepo-fs/Cargo.toml
+++ b/crates/turborepo-fs/Cargo.toml
@@ -11,9 +11,9 @@ workspace = true
 
 [dependencies]
 fs-err = "2.9.0"
+ignore = "0.4.22"
 thiserror = "1.0.38"
 turbopath = { workspace = true }
-ignore = "0.4.22"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/turborepo-fs/Cargo.toml
+++ b/crates/turborepo-fs/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 fs-err = "2.9.0"
 thiserror = "1.0.38"
 turbopath = { workspace = true }
-walkdir = "2.3.3"
 ignore = "0.4.22"
 
 [dev-dependencies]

--- a/crates/turborepo-fs/Cargo.toml
+++ b/crates/turborepo-fs/Cargo.toml
@@ -14,6 +14,7 @@ fs-err = "2.9.0"
 thiserror = "1.0.38"
 turbopath = { workspace = true }
 walkdir = "2.3.3"
+ignore = "0.4.22"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/turborepo-fs/src/lib.rs
+++ b/crates/turborepo-fs/src/lib.rs
@@ -61,7 +61,7 @@ pub fn recursive_copy(
                     let suffix = AnchoredSystemPathBuf::new(src, path)?;
                     let target = dst.resolve(&suffix);
                     if file_type.is_dir() {
-                        let src_metadata = path.symlink_metadata()?;
+                        let src_metadata = entry.metadata()?;
                         make_dir_copy(&target, &src_metadata)?;
                     } else {
                         copy_file_with_type(path, file_type, &target)?;

--- a/crates/turborepo-fs/src/lib.rs
+++ b/crates/turborepo-fs/src/lib.rs
@@ -50,9 +50,7 @@ pub fn recursive_copy(
                 Ok(entry) => {
                     let path = entry.path();
                     let path = AbsoluteSystemPath::from_std_path(path)?;
-                    let file_type = entry.file_type().ok_or_else(|| {
-                        io::Error::new(io::ErrorKind::Other, "Could not determine file type")
-                    })?;
+                    let file_type = entry.file_type().expect("all dir entries aside from stdin should have a file type");
 
                     // Note that we also don't currently copy broken symlinks
                     if file_type.is_symlink() && path.stat().is_err() {

--- a/packages/create-turbo/src/transforms/official-starter.ts
+++ b/packages/create-turbo/src/transforms/official-starter.ts
@@ -18,9 +18,10 @@ export async function transform(args: TransformInput): TransformResult {
   const { prompts, example, opts } = args;
 
   const defaultExample = isDefaultExample(example.name);
-  const isOfficialStarter =
-    !example.repo ||
-    (example.repo.username === "vercel" && example.repo.name === "turbo");
+  const isThisRepo =
+    example.repo &&
+    (example.repo.name === "turborepo" || example.repo.name === "turbo");
+  const isOfficialStarter = example.repo?.username === "vercel" && isThisRepo;
 
   if (!isOfficialStarter) {
     return { result: "not-applicable", ...meta };


### PR DESCRIPTION
### Description

This PR addresses https://github.com/vercel/turborepo/issues/1292 so that `turbo prune` now respects `.gitignore` patterns so that files excluded via `.gitignore` are properly omitted from the pruned output.

### Testing Instructions

You can test the built CLI against this repository confirming that secret.txt is not added to the output with turbo prune: https://github.com/thebrubaker/turbo-prune-test