### PR TITLE
fix(tui): avoid zombie process on clipboard write failure

### DIFF
--- a/crates/turborepo-ui/src/tui/clipboard.rs
+++ b/crates/turborepo-ui/src/tui/clipboard.rs
@@ -86,8 +86,6 @@ fn copy_impl(s: &str, provider: &Provider) -> std::io::Result<()> {
         }
 
         Provider::Exec(prog, args) => {
-            // Child::wait is run after writing `s` into stdin
-            #[allow(clippy::zombie_processes)]
             let mut child = std::process::Command::new(prog)
                 .args(args)
                 .stdin(Stdio::piped())
@@ -95,8 +93,13 @@ fn copy_impl(s: &str, provider: &Provider) -> std::io::Result<()> {
                 .stderr(Stdio::null())
                 .spawn()
                 .unwrap();
-            std::io::Write::write_all(&mut child.stdin.as_ref().unwrap(), s.as_bytes())?;
-            child.wait()?;
+            // Do not exit early if we fail to write to the clipboard, make sure we attempt
+            // to wait on the clipboard to exit to avoid a zombie process.
+            let write_result =
+                std::io::Write::write_all(&mut child.stdin.as_ref().unwrap(), s.as_bytes());
+            let wait_result = child.wait();
+            write_result?;
+            wait_result?;
         }
 
         #[cfg(windows)]


### PR DESCRIPTION
### Description

As discovered in https://github.com/vercel/turborepo/pull/9652#discussion_r1918688510

We could create a zombie process if writing to the clipboard program failed as we handled the write failure without `wait`ing the clipboard process.

### Testing Instructions

We no longer get a lint warning when removing `allow(clippy::zombie_process)`
