### PR TITLE
chore(turbo): include schema in turbo package

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -5,7 +5,7 @@ CLI_DIR = $(shell pwd)
 
 # This only builds JS packages
 build:
-	cd $(CLI_DIR)/../ && turbo build \
+	cd $(CLI_DIR)/../ && turbo build copy-schema \
 		--filter=create-turbo \
 		--filter=@turbo/codemod \
 		--filter=turbo-ignore \

--- a/packages/turbo-types/package.json
+++ b/packages/turbo-types/package.json
@@ -18,7 +18,8 @@
     "build": "tsc && pnpm generate-schema",
     "lint": "eslint src/",
     "lint:prettier": "prettier -c . --cache",
-    "generate-schema": "tsx scripts/generate-schema.ts"
+    "generate-schema": "tsx scripts/generate-schema.ts",
+    "copy-schema": "cp schemas/schema.json ../turbo/schema.json"
   },
   "devDependencies": {
     "@turbo/eslint-config": "workspace:*",

--- a/packages/turbo-types/turbo.json
+++ b/packages/turbo-types/turbo.json
@@ -7,6 +7,10 @@
     "build": {
       "outputs": ["schemas/**"],
       "dependsOn": ["^topo"]
+    },
+    "copy-schema": {
+      "dependsOn": ["build"],
+      "outputs": ["../turbo/schema.json"]
     }
   }
 }

--- a/packages/turbo/.gitignore
+++ b/packages/turbo/.gitignore
@@ -1,0 +1,1 @@
+schema.json

--- a/packages/turbo/package.json
+++ b/packages/turbo/package.json
@@ -14,7 +14,8 @@
     "turbo": "./bin/turbo"
   },
   "files": [
-    "bin"
+    "bin",
+    "schema.json"
   ],
   "optionalDependencies": {
     "turbo-darwin-64": "2.3.4-canary.8",


### PR DESCRIPTION
### Description

Add a new `@turbo/types#copy-schema` task which will copy the current schema into `packages/turbo`. We do this since we explicitly exclude the `turbo` package from our workspace so it's easier to have this hang off of `@turbo/types`.

We then add this task to the `build` target which is a dependency of the `publish-turbo` target which is what gets run on release: https://github.com/vercel/turborepo/actions/runs/12796720464/job/35678219119#step:11:2

Resolves #7466

### Testing Instructions

Do a test run of the release and make sure we end up running the new `copy-schema` task. [Started here](https://github.com/vercel/turborepo/actions/runs/12812613189), will take a sec to get to the point in the release where we hit this codepath.

You can see schema gets copied into the `turbo` package [here](https://github.com/vercel/turborepo/actions/runs/12812613189/job/35726384650#step:11:42)
