### PR TITLE
fix(docs): correct backticks causing broken links

### DIFF
--- a/docs/repo-docs/getting-started/add-to-existing-repository.mdx
+++ b/docs/repo-docs/getting-started/add-to-existing-repository.mdx
@@ -191,7 +191,7 @@ Turborepo optimizes your repository using information from your package manager.
 
 <Callout type="good-to-know">
   Depending on your repository, you may need to use the
-  [dangerouslyDisablePackageManagerCheck](`/repo/docs/reference/configuration#dangerouslydisablepackagemanagercheck`)
+  `[dangerouslyDisablePackageManagerCheck](/repo/docs/reference/configuration#dangerouslydisablepackagemanagercheck)`
   while migrating or in situations where you can't use the `packageManager` key
   yet.
 </Callout>


### PR DESCRIPTION
### Description

Fix misplaced backticks for link

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
