### PR TITLE
docs: Update docker.mdx to Replace yarn install with yarn install --frozen-lockfile for consistent dependency installation

### DIFF
--- a/docs/repo-docs/guides/tools/docker.mdx
+++ b/docs/repo-docs/guides/tools/docker.mdx
@@ -165,7 +165,7 @@ WORKDIR /app
 
 # First install the dependencies (as they change less often)
 COPY --from=builder /app/out/json/ .
-RUN yarn install
+RUN yarn install --frozen-lockfile
 
 # Build the project
 COPY --from=builder /app/out/full/ .


### PR DESCRIPTION
### Description

- Updated the docker.mdx documentation to reflect the change from yarn install to yarn install --frozen-lockfile.

- This change ensures that the yarn.lock file remains unchanged during installation, promoting consistency across environments and preventing unintended updates to dependencies.

- Provides more predictable and reliable dependency management, especially in CI/CD pipelines and across development environments.
