### PR TITLE
fix: update oxc-resolver and fix windows bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3729,21 +3729,30 @@ dependencies = [
 
 [[package]]
 name = "oxc_resolver"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da33ec82d0f4770f4b5c120d6a1d8e45de2d99ae2672a7ee6bd29092ada945f2"
+version = "4.2.0"
+source = "git+https://github.com/nicholaslyang/oxc-resolver?branch=symlink-hotfix-again#a9e3fa452ec43352dc7bc0ddc2ef19342dbd0574"
 dependencies = [
  "cfg-if",
- "dashmap 6.1.0",
  "indexmap 2.2.6",
  "json-strip-comments",
  "once_cell",
+ "papaya",
  "rustc-hash 2.0.0",
  "serde",
  "serde_json",
  "simdutf8",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "papaya"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aab21828b6b5952fdadd6c377728ffae53ec3a21b2febc47319ab65741f7e2fd"
+dependencies = [
+ "equivalent",
+ "seize",
 ]
 
 [[package]]
@@ -4762,6 +4771,16 @@ checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "seize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4b8d813387d566f627f3ea1b914c068aac94c40ae27ec43f5f33bde65abefe7"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6213,7 +6232,7 @@ dependencies = [
  "futures",
  "globwalk",
  "miette",
- "oxc_resolver 2.1.1",
+ "oxc_resolver 4.2.0",
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_parser",
@@ -6529,7 +6548,7 @@ dependencies = [
  "notify",
  "num_cpus",
  "owo-colors 3.5.0",
- "oxc_resolver 2.1.1",
+ "oxc_resolver 4.2.0",
  "path-clean",
  "petgraph",
  "pidlock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3730,7 +3730,8 @@ dependencies = [
 [[package]]
 name = "oxc_resolver"
 version = "4.2.0"
-source = "git+https://github.com/nicholaslyang/oxc-resolver?branch=symlink-hotfix-again#a9e3fa452ec43352dc7bc0ddc2ef19342dbd0574"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c4d9cffbd24c3a874bd44cce4384cb73bf732c4fe4aa99c4406b2e0c4027bb"
 dependencies = [
  "cfg-if",
  "indexmap 2.2.6",
@@ -3738,6 +3739,7 @@ dependencies = [
  "once_cell",
  "papaya",
  "rustc-hash 2.0.0",
+ "seize",
  "serde",
  "serde_json",
  "simdutf8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ notify = "6.1.1"
 num_cpus = "1.15.0"
 once_cell = "1.17.1"
 owo-colors = "3.5.0"
-oxc_resolver = { version = "2.1.0" }
+oxc_resolver = { version = "2.1.1" }
 parking_lot = "0.12.1"
 path-clean = "1.0.1"
 pathdiff = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ notify = "6.1.1"
 num_cpus = "1.15.0"
 once_cell = "1.17.1"
 owo-colors = "3.5.0"
-oxc_resolver = { git = "https://github.com/nicholaslyang/oxc-resolver", branch = "symlink-hotfix-again" }
+oxc_resolver = "4.2.0"
 parking_lot = "0.12.1"
 path-clean = "1.0.1"
 pathdiff = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ notify = "6.1.1"
 num_cpus = "1.15.0"
 once_cell = "1.17.1"
 owo-colors = "3.5.0"
-oxc_resolver = { version = "2.1.1" }
+oxc_resolver = { git = "https://github.com/nicholaslyang/oxc-resolver", branch = "symlink-hotfix-again" }
 parking_lot = "0.12.1"
 path-clean = "1.0.1"
 pathdiff = "0.2.1"

--- a/crates/turbo-trace/src/tracer.rs
+++ b/crates/turbo-trace/src/tracer.rs
@@ -439,6 +439,8 @@ impl Tracer {
             futures.spawn(async move {
                 let file_resolver = Self::infer_resolver_with_ts_config(&file, &resolver);
                 let resolver = file_resolver.as_ref().unwrap_or(&resolver);
+                eprintln!("file: {:?}", file);
+                eprintln!("resolver: {:?}", resolver);
                 let mut errors = Vec::new();
 
                 let Some((imported_files, seen_file)) = Self::get_imports_from_file(
@@ -450,10 +452,12 @@ impl Tracer {
                 )
                 .await
                 else {
+                    eprintln!("failed to get imports from file");
                     return (errors, None);
                 };
 
                 for import in imported_files {
+                    eprintln!("import: {:?}", import);
                     if shared_self
                         .files
                         .iter()

--- a/crates/turbo-trace/src/tracer.rs
+++ b/crates/turbo-trace/src/tracer.rs
@@ -439,8 +439,7 @@ impl Tracer {
             futures.spawn(async move {
                 let file_resolver = Self::infer_resolver_with_ts_config(&file, &resolver);
                 let resolver = file_resolver.as_ref().unwrap_or(&resolver);
-                eprintln!("file: {:?}", file);
-                eprintln!("resolver: {:?}", resolver);
+                eprintln!("file: {:?}", shared_self.cwd.anchor(&file));
                 let mut errors = Vec::new();
 
                 let Some((imported_files, seen_file)) = Self::get_imports_from_file(
@@ -456,8 +455,12 @@ impl Tracer {
                     return (errors, None);
                 };
 
+                if imported_files.is_empty() {
+                    eprintln!("no imports found for {}", file);
+                }
+
                 for import in imported_files {
-                    eprintln!("import: {:?}", import);
+                    eprintln!("import: {:?}", shared_self.cwd.anchor(&import));
                     if shared_self
                         .files
                         .iter()

--- a/crates/turbo-trace/src/tracer.rs
+++ b/crates/turbo-trace/src/tracer.rs
@@ -48,7 +48,7 @@ pub enum TraceError {
     #[error("failed to read file: {0}")]
     FileNotFound(AbsoluteSystemPathBuf),
     #[error(transparent)]
-    PathEncoding(Arc<PathError>),
+    PathError(Arc<PathError>),
     #[error("tracing a root file `{0}`, no parent found")]
     RootFile(AbsoluteSystemPathBuf),
     #[error("failed to resolve import to `{import}` in `{file_path}`")]
@@ -212,7 +212,7 @@ impl Tracer {
                     match resolved.into_path_buf().try_into().map_err(Arc::new) {
                         Ok(path) => files.push(path),
                         Err(err) => {
-                            errors.push(TraceError::PathEncoding(err));
+                            errors.push(TraceError::PathError(err));
                             continue;
                         }
                     }
@@ -459,8 +459,20 @@ impl Tracer {
                     eprintln!("no imports found for {}", file);
                 }
 
-                for import in imported_files {
-                    eprintln!("import: {:?}", shared_self.cwd.anchor(&import));
+                for mut import in imported_files {
+                    if cfg!(windows) {
+                        match import.to_realpath() {
+                            Ok(path) => {
+                                import = path;
+                            }
+                            Err(err) => {
+                                errors.push(TraceError::PathError(Arc::new(err)));
+                                eprintln!("failed to canonicalize import: {}", import);
+                                return (errors, None);
+                            }
+                        }
+                    }
+
                     if shared_self
                         .files
                         .iter()

--- a/crates/turbo-trace/src/tracer.rs
+++ b/crates/turbo-trace/src/tracer.rs
@@ -439,7 +439,6 @@ impl Tracer {
             futures.spawn(async move {
                 let file_resolver = Self::infer_resolver_with_ts_config(&file, &resolver);
                 let resolver = file_resolver.as_ref().unwrap_or(&resolver);
-                eprintln!("file: {:?}", shared_self.cwd.anchor(&file));
                 let mut errors = Vec::new();
 
                 let Some((imported_files, seen_file)) = Self::get_imports_from_file(
@@ -451,13 +450,8 @@ impl Tracer {
                 )
                 .await
                 else {
-                    eprintln!("failed to get imports from file");
                     return (errors, None);
                 };
-
-                if imported_files.is_empty() {
-                    eprintln!("no imports found for {}", file);
-                }
 
                 for mut import in imported_files {
                     if cfg!(windows) {
@@ -467,7 +461,6 @@ impl Tracer {
                             }
                             Err(err) => {
                                 errors.push(TraceError::PathError(Arc::new(err)));
-                                eprintln!("failed to canonicalize import: {}", import);
                                 return (errors, None);
                             }
                         }

--- a/crates/turborepo-lib/src/query/file.rs
+++ b/crates/turborepo-lib/src/query/file.rs
@@ -81,7 +81,7 @@ impl From<turbo_trace::TraceError> for Diagnostic {
                 path: Some(file.to_string()),
                 ..Default::default()
             },
-            turbo_trace::TraceError::PathEncoding(_) => Diagnostic {
+            turbo_trace::TraceError::PathError(_) => Diagnostic {
                 message,
                 ..Default::default()
             },


### PR DESCRIPTION
### Description

Upgrades oxc-resolver and fixes a bug that we found in Windows. We need to canonicalize paths manually since they may be the abbreviated version and that breaks our path equality logic.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
