### PR TITLE
feat: makes `affectedPackages` lockfile aware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6569,6 +6569,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "pretty_assertions",
  "thiserror",
  "tokio",
  "turbopath",

--- a/crates/turborepo-paths/src/absolute_system_path.rs
+++ b/crates/turborepo-paths/src/absolute_system_path.rs
@@ -248,6 +248,8 @@ impl AbsoluteSystemPath {
         )
     }
 
+    /// Note: This does not handle resolutions, so `../` in a path won't
+    /// resolve.
     pub fn anchor(&self, path: &AbsoluteSystemPath) -> Result<AnchoredSystemPathBuf, PathError> {
         AnchoredSystemPathBuf::new(self, path)
     }

--- a/crates/turborepo-paths/src/anchored_system_path_buf.rs
+++ b/crates/turborepo-paths/src/anchored_system_path_buf.rs
@@ -73,6 +73,8 @@ impl<'a> From<&'a AnchoredSystemPathBuf> for wax::CandidatePath<'a> {
 }
 
 impl AnchoredSystemPathBuf {
+    /// Note: This does not handle resolutions, so `../` in a path won't
+    /// resolve.
     pub fn new(
         root: impl AsRef<AbsoluteSystemPath>,
         path: impl AsRef<AbsoluteSystemPath>,

--- a/crates/turborepo-repository/src/change_mapper/mod.rs
+++ b/crates/turborepo-repository/src/change_mapper/mod.rs
@@ -122,6 +122,12 @@ impl<'a, PD: PackageChangeMapper> ChangeMapper<'a, PD> {
     pub fn changed_packages(
         &self,
         changed_files: HashSet<AnchoredSystemPathBuf>,
+        // None - we don't know if the lockfile changed
+        //
+        // Some(None) - we know the lockfile changed, but don't know exactly why (i.e. `git status`
+        // and the lockfile is there)
+        //
+        // Some(Some(content)) - we know the lockfile changed and have the contents
         lockfile_change: Option<Option<Vec<u8>>>,
     ) -> Result<PackageChanges, ChangeMapError> {
         if let Some(file) = Self::default_global_file_changed(&changed_files) {

--- a/packages/turbo-repository/README.md
+++ b/packages/turbo-repository/README.md
@@ -11,6 +11,34 @@ for the JS API.
 
 This package contains scripts to build dev and release versions. `pnpm build && pnpm package` will build and package a dev version of the native library for `darwin-arm64`, or you can pass an additional argument for a specific target. `pnpm build:release` will build a release version of the library
 
-# Publishing
+## Setup
+
+Install JS dependencies:
+
+```sh
+pnpm install
+```
+
+## Build
+
+Build native library and TypeScript wrapper:
+
+```sh
+pnpm build
+cargo build
+```
+
+## Test
+
+```sh
+pnpm test
+```
+
+## Example Usage
+
+You can see examples in the `__tests__` directory, or see a simple script in `node scripts/test.mjs`.
+Note that this may fall out of date over time, but it's meant to be used during the early iterations.
+
+## Publishing
 
 There is now a version bump script in [bump-version.sh](./scripts/bump-version.sh). Passing it the new version will bump the meta package version, as well as the optional dependencies list and native packages.

--- a/packages/turbo-repository/__tests__/fixtures/monorepo/apps/app/package.json
+++ b/packages/turbo-repository/__tests__/fixtures/monorepo/apps/app/package.json
@@ -1,6 +1,7 @@
 {
   "name": "app-a",
   "dependencies": {
-    "ui": "*"
+    "microdiff": "^1.4.0",
+    "ui": "workspace:*"
   }
 }

--- a/packages/turbo-repository/__tests__/fixtures/monorepo/package.json
+++ b/packages/turbo-repository/__tests__/fixtures/monorepo/package.json
@@ -1,4 +1,4 @@
 {
   "name": "basic",
-  "packageManager": "pnpm@8.1.0"
+  "packageManager": "pnpm@8.14.0"
 }

--- a/packages/turbo-repository/__tests__/fixtures/monorepo/pnpm-lock.yaml
+++ b/packages/turbo-repository/__tests__/fixtures/monorepo/pnpm-lock.yaml
@@ -1,13 +1,28 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .: {}
 
-  app:
+  apps/app:
     dependencies:
+      microdiff:
+        specifier: ^1.4.0
+        version: 1.4.0
       ui:
-        specifier: '*'
-        version: link:../ui
+        specifier: workspace:*
+        version: link:../../packages/ui
 
-  ui: {}
+  packages/blank: {}
+
+  packages/ui: {}
+
+packages:
+
+  /microdiff@1.4.0:
+    resolution: {integrity: sha512-OBKBOa1VBznvLPb/3ljeJaENVe0fO0lnWl77lR4vhPlQD71UpjEoRV5P0KdQkcjbFlBu1Oy2mEUBMU3wxcBAGg==}
+    dev: false

--- a/packages/turbo-repository/js/index.d.ts
+++ b/packages/turbo-repository/js/index.d.ts
@@ -55,5 +55,8 @@ export class Workspace {
    * of strings relative to the monorepo root and use the current system's
    * path separator.
    */
-  affectedPackages(files: Array<string>): Promise<Array<Package>>;
+  affectedPackages(
+    files: Array<string>,
+    changedLockfile?: string | undefined | null
+  ): Promise<Array<Package>>;
 }

--- a/packages/turbo-repository/rust/Cargo.toml
+++ b/packages/turbo-repository/rust/Cargo.toml
@@ -18,5 +18,8 @@ tokio = { workspace = true }
 turbopath = { workspace = true }
 turborepo-repository = { workspace = true }
 
+[dev-dependencies]
+pretty_assertions = { workspace = true }
+
 [build-dependencies]
 napi-build = "2.0.1"

--- a/packages/turbo-repository/rust/README.md
+++ b/packages/turbo-repository/rust/README.md
@@ -1,20 +1,5 @@
-## Setup:
+# `turbo-repository`
 
-Install JS dependencies:
+This sub-crate provides repository helpers which are written in Rust and translated to TypeScript with [NAPI-RS](https://napi.rs).
 
-```
-pnpm i
-```
-
-## Build:
-
-Build native library and js wrapper
-
-```sh
-pnpm build
-```
-
-## Example Usage
-
-You can see examples in the `__tests__` directory, or see a simple script in `node scripts/test.mjs`.
-Note that this may fall out of date over time, but it's meant to be used during the early iterations.
+See the [root `README.md` for instructions](../README.md).


### PR DESCRIPTION
### Description

This PR passes lockfile change information to the `turbo-repository` NAPI interface.

### Testing Instructions

Run `pnpm test` from `packages/turbo-repository` to see the new test pass, which validates lockfile changes.