### PR TITLE
feat(prune): add `--use-gitignore` flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1090,9 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1111,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -1123,9 +1123,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clipboard-win"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6353,6 +6353,7 @@ dependencies = [
  "fs-err",
  "ignore",
  "tempfile",
+ "test-case",
  "thiserror",
  "turbopath",
 ]

--- a/crates/turborepo-fs/Cargo.toml
+++ b/crates/turborepo-fs/Cargo.toml
@@ -17,3 +17,4 @@ turbopath = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+test-case = { workspace = true }

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -373,10 +373,10 @@ impl<'a> Prune<'a> {
             return Ok(());
         }
         let full_to = self.full_directory.resolve(path);
-        turborepo_fs::recursive_copy(&from_path, full_to)?;
+        turborepo_fs::recursive_copy(&from_path, full_to, true)?;
         if matches!(destination, Some(CopyDestination::All)) {
             let out_to = self.out_directory.resolve(path);
-            turborepo_fs::recursive_copy(&from_path, out_to)?;
+            turborepo_fs::recursive_copy(&from_path, out_to, true)?;
         }
         if self.docker
             && matches!(
@@ -385,7 +385,7 @@ impl<'a> Prune<'a> {
             )
         {
             let docker_to = self.docker_directory().resolve(path);
-            turborepo_fs::recursive_copy(&from_path, docker_to)?;
+            turborepo_fs::recursive_copy(&from_path, docker_to, true)?;
         }
         Ok(())
     }
@@ -400,7 +400,7 @@ impl<'a> Prune<'a> {
         let target_dir = self.full_directory.resolve(&relative_workspace_dir);
         target_dir.create_dir_all_with_permissions(metadata.permissions())?;
 
-        turborepo_fs::recursive_copy(original_dir, &target_dir)?;
+        turborepo_fs::recursive_copy(original_dir, &target_dir, true)?;
 
         if self.docker {
             let docker_workspace_dir = self.docker_directory().resolve(&relative_workspace_dir);

--- a/docs/repo-docs/reference/prune.mdx
+++ b/docs/repo-docs/reference/prune.mdx
@@ -201,3 +201,9 @@ Using the same example from above, running `turbo prune frontend --docker` will 
 Defaults to `./out`.
 
 Customize the directory the pruned output is generated in.
+
+#### `--use-gitignore[=<bool>]`
+
+Default: `true`
+
+Respect `.gitignore` file(s) when copying files to the output directory.


### PR DESCRIPTION
### Description

Closes #9789

Adds a flag for opting out of respecting `.gitignore`. If you want to copy over files that are ignored by `git` you can now pass `--use-gitignore=false` to `turbo prune`.

### Testing Instructions

Added unit tests. Quick manual test:
```
# A gitignored file in the app
[0 olszewski@chriss-mbp] /tmp/turborepo-gitignore-bug $ stat apps/web/.turbo       
16777234 160702923 drwxr-xr-x 6 olszewski wheel 0 192 "Jan 24 14:05:04 2025" "Jan 24 14:05:04 2025" "Jan 24 14:05:04 2025" "Jan 24 14:05:04 2025" 4096 0 0 .turbo
[0 olszewski@chriss-mbp] /tmp/turborepo-gitignore-bug $ turbo_dev --skip-infer prune web --use-gitignore=false
turbo 2.3.4

Generating pruned monorepo for web in /private/tmp/turborepo-gitignore-bug/out
 - Added @repo/eslint-config
 - Added @repo/typescript-config
 - Added @repo/ui
 - Added web
[0 olszewski@chriss-mbp] /tmp/turborepo-gitignore-bug $ stat out/apps/web/.turbo/                
16777234 160756779 drwxr-xr-x 3 olszewski wheel 0 96 "Jan 24 14:07:47 2025" "Jan 24 14:07:30 2025" "Jan 24 14:07:30 2025" "Jan 24 14:07:30 2025" 4096 0 0 out/apps/web/.turbo/
[0 olszewski@chriss-mbp] /tmp/turborepo-gitignore-bug $ rm -r out 
[0 olszewski@chriss-mbp] /tmp/turborepo-gitignore-bug $ turbo_dev --skip-infer prune web --use-gitignore      
turbo 2.3.4

Generating pruned monorepo for web in /private/tmp/turborepo-gitignore-bug/out
 - Added @repo/eslint-config
 - Added @repo/typescript-config
 - Added @repo/ui
 - Added web
[0 olszewski@chriss-mbp] /tmp/turborepo-gitignore-bug $ stat out/apps/web/.turbo/                       
stat: out/apps/web/.turbo/: stat: No such file or directory
```
