### PR TITLE
ci: correctly ignoring in turborepo-test.yml

### DIFF
--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -53,7 +53,7 @@ jobs:
               - "turborepo-tests/example-with-svelte-*/**"
               - "turborepo-tests/helpers/**"
             rest:
-              - "!(examples/**|docs/**)**"
+              - "!(docs/**|examples/**)**"
 
   integration:
     name: Turborepo Integration


### PR DESCRIPTION
### Description

I can't explain why, but switching the ordering of these globs finally does what I want. Previously, the right behavior would only happen for `docs/**` but not `examples/**`. It appears switching the order does what I'm looking for.

### Testing Instructions

On my fork, you can see this change [here](https://github.com/anthonyshew/turborepo/blob/anthonyshew-patch-14/.github/workflows/turborepo-test.yml#L56C1-L56C43).

I've tested with a hand-rolled matrix of file changes on separate PRs:
- https://github.com/anthonyshew/turborepo/pulls

These should match our expectations of what should run when. Please gut check me!