### PR TITLE
fix(deps): use windows-sys instead of winapi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6501,7 +6501,7 @@ dependencies = [
  "wax",
  "webbrowser",
  "which",
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6704,7 +6704,7 @@ dependencies = [
  "turborepo-ci",
  "turborepo-vt100",
  "which",
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7238,11 +7238,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -155,7 +155,7 @@ uds_windows = "1.0.2"
 async-io = "1.12.0"
 
 [target.'cfg(target_os = "windows")'.dev-dependencies]
-winapi = "0.3.9"
+windows-sys = { version = "0.59", features = ["Win32_System_Threading"] }
 
 [build-dependencies]
 capnpc = "0.18.0"

--- a/crates/turborepo-lib/src/process/child.rs
+++ b/crates/turborepo-lib/src/process/child.rs
@@ -1092,9 +1092,9 @@ mod test {
         if let Some(pid) = child.pid() {
             unsafe {
                 println!("killing");
-                winapi::um::processthreadsapi::TerminateProcess(
-                    winapi::um::processthreadsapi::OpenProcess(
-                        winapi::um::winnt::PROCESS_TERMINATE,
+                windows_sys::Win32::System::Threading::TerminateProcess(
+                    windows_sys::Win32::System::Threading::OpenProcess(
+                        windows_sys::Win32::System::Threading::PROCESS_TERMINATE,
                         0,
                         pid,
                     ),

--- a/crates/turborepo-ui/Cargo.toml
+++ b/crates/turborepo-ui/Cargo.toml
@@ -42,7 +42,7 @@ turbopath = { workspace = true }
 turborepo-ci = { workspace = true }
 turborepo-vt100 = { workspace = true }
 which = { workspace = true }
-winapi = "0.3.9"
 
 [target."cfg(windows)".dependencies]
 clipboard-win = "5.3.1"
+windows-sys = { version = "0.59", features = ["Win32_System_Console"] }

--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -136,19 +136,19 @@ fn ctrl_c() -> Option<Event> {
 
 #[cfg(windows)]
 fn ctrl_c() -> Option<Event> {
-    use winapi::{
-        shared::minwindef::{BOOL, DWORD, TRUE},
-        um::wincon,
+    use windows_sys::Win32::{
+        Foundation::{BOOL, TRUE},
+        System::Console::GenerateConsoleCtrlEvent,
     };
     // First parameter corresponds to what event to generate, 0 is a Ctrl-C
-    let ctrl_c_event: DWORD = 0x0;
+    let ctrl_c_event = 0x0;
     // Second parameter corresponds to which process group to send the event to.
     // If 0 is passed the event gets sent to every process connected to the current
     // Console.
-    let process_group_id: DWORD = 0x0;
+    let process_group_id = 0x0;
     let success: BOOL = unsafe {
         // See docs https://learn.microsoft.com/en-us/windows/console/generateconsolectrlevent
-        wincon::GenerateConsoleCtrlEvent(ctrl_c_event, process_group_id)
+        GenerateConsoleCtrlEvent(ctrl_c_event, process_group_id)
     };
     if success == TRUE {
         None


### PR DESCRIPTION
### Description

`winapi` is abandoned and had no updates since 2020, while `windows-sys` is supported by Microsoft. also updated `winapi-util` to use `windows-sys` too
<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
