### PR TITLE
chore(@turbo/repository): silence noop lint

### DIFF
--- a/packages/turbo-repository/rust/Cargo.toml
+++ b/packages/turbo-repository/rust/Cargo.toml
@@ -23,3 +23,8 @@ pretty_assertions = { workspace = true }
 
 [build-dependencies]
 napi-build = "2.0.1"
+
+[features]
+# The napi proc macro expands to include this feature, forward it correct feature
+# to avoid the lint warning.
+noop = ["napi-derive/noop"]


### PR DESCRIPTION
### Description

The recent Rust version bump started yielding these errors locally and on CI:

<img width="482" alt="Screenshot 2025-01-28 at 4 54 50 PM" src="https://github.com/user-attachments/assets/3862cc5a-a343-483f-b38c-1295b3b40aed" />


This is due to the `#[napi]` proc macro expanding to include a reference to a `noop` feature. To silence this lint we forward this feature to `napi-derive`: [src](https://github.com/napi-rs/napi-rs/blob/main/crates/macro/Cargo.toml#L20).

### Testing Instructions

`cargo clippy` should now produce no warnings
