### PR TITLE
chore: move `create-turbo` community note and format it better

### DIFF
--- a/packages/create-turbo/src/commands/create/index.ts
+++ b/packages/create-turbo/src/commands/create/index.ts
@@ -252,6 +252,15 @@ export async function create(
     }
   }
 
+  if (!isMaintainedByCoreTeam) {
+    logger.log(
+      picocolors.dim(
+        "Note: This is a community-maintained example.\nIf you experience a problem, please submit a pull request with a fix.\nGitHub Issues will be closed."
+      )
+    );
+    logger.log();
+  }
+
   if (projectDirIsCurrentDir) {
     logger.log(
       `${picocolors.bold(
@@ -263,15 +272,6 @@ export async function create(
       `${picocolors.bold(
         turboGradient(">>> Success!")
       )} Created your Turborepo at ${picocolors.green(relativeProjectDir)}`
-    );
-  }
-
-  if (!isMaintainedByCoreTeam) {
-    logger.log();
-    logger.log(
-      picocolors.dim(
-        "Note: This is a community-maintained example. If you experience a problem, please submit a pull request with a fix. GitHub Issues will be closed."
-      )
     );
   }
 


### PR DESCRIPTION
### Description

The note was being printed after the success and it looked a little funny.

Additionally, it was the only thing being printed that was more than ~60 columns wide so it looked funny. Some `\n`'s clean that up nicely.