### PR TITLE
feat(create-turbo): fix official examples

### DIFF
--- a/packages/create-turbo/src/transforms/official-starter.ts
+++ b/packages/create-turbo/src/transforms/official-starter.ts
@@ -5,6 +5,8 @@ import { isDefaultExample } from "../utils/isDefaultExample";
 import type { TransformInput, TransformResult, MetaJson } from "./types";
 import { TransformError } from "./errors";
 
+const REPO_NAMES = ["turbo", "turborepo"];
+
 const meta = {
   name: "official-starter",
 };
@@ -18,10 +20,10 @@ export async function transform(args: TransformInput): TransformResult {
   const { prompts, example, opts } = args;
 
   const defaultExample = isDefaultExample(example.name);
-  const isThisRepo =
-    example.repo &&
-    (example.repo.name === "turborepo" || example.repo.name === "turbo");
-  const isOfficialStarter = example.repo?.username === "vercel" && isThisRepo;
+  const isOfficialStarter =
+    !example.repo ||
+    (example.repo.username === "vercel" &&
+      REPO_NAMES.includes(example.repo.name));
 
   if (!isOfficialStarter) {
     return { result: "not-applicable", ...meta };
@@ -43,7 +45,7 @@ export async function transform(args: TransformInput): TransformResult {
   }
 
   if (hasPackageJson) {
-    let packageJsonContent;
+    let packageJsonContent: PackageJson | undefined;
     try {
       packageJsonContent = fs.readJsonSync(rootPackageJsonPath) as
         | PackageJson

--- a/packages/turbo-utils/src/createProject.ts
+++ b/packages/turbo-utils/src/createProject.ts
@@ -47,7 +47,7 @@ export async function createProject({
   if (isDefaultExample) {
     repoInfo = {
       username: "vercel",
-      name: "turbo",
+      name: "turborepo",
       branch: "main",
       filePath: "examples/basic",
     };

--- a/packages/turbo-utils/src/examples.ts
+++ b/packages/turbo-utils/src/examples.ts
@@ -91,7 +91,7 @@ export function existsInRepo(nameOrUrl: string): Promise<boolean> {
     return isUrlOk(url.href);
   } catch {
     return isUrlOk(
-      `https://api.github.com/repos/vercel/turbo/contents/examples/${encodeURIComponent(
+      `https://api.github.com/repos/vercel/turborepo/contents/examples/${encodeURIComponent(
         nameOrUrl
       )}`
     );


### PR DESCRIPTION
### Description

Fixes some logic that was introduced https://github.com/vercel/turborepo/pull/9708 that allows classifying official examples. 

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
