### PR TITLE
fix(deps): remove unused `winapi` for turborepo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6104,7 +6104,6 @@ dependencies = [
  "turbopath",
  "turborepo-lib",
  "which",
- "winapi",
 ]
 
 [[package]]

--- a/crates/turborepo/Cargo.toml
+++ b/crates/turborepo/Cargo.toml
@@ -37,6 +37,3 @@ workspace = true
 anyhow = { workspace = true, features = ["backtrace"] }
 miette.workspace = true
 turborepo-lib = { workspace = true, default-features = false }
-
-[target.'cfg(target_os = "windows")'.dependencies]
-winapi = "0.3.9"


### PR DESCRIPTION
### Description

it was added in #3671 but wasn't used
<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
