### PR TITLE
fix(turbo-trace): check exports

### DIFF
--- a/crates/turborepo/tests/query.rs
+++ b/crates/turborepo/tests/query.rs
@@ -63,6 +63,8 @@ fn test_trace() -> Result<(), anyhow::Error> {
             "get `import_value_and_type.ts` with type dependencies" => "query { file(path: \"import_value_and_type.ts\") { path dependencies(importType: TYPES) { files { items { path } } } } }",
             "get `import_value_and_type.ts` with value dependencies" => "query { file(path: \"import_value_and_type.ts\") { path dependencies(importType: VALUES) { files { items { path } } } } }",
             "get `incorrect_extension.mjs` with dependencies" =>  "query { file(path: \"incorrect_extension.mjs\") { path dependencies(depth: 1) { files { items { path } } } } }",
+            "get `export_all.js` with dependencies" => "query { file(path: \"export_all.js\") { path dependencies { files { items { path } } } } }",
+            "get `export_named.js` with dependencies" => "query { file(path: \"export_named.js\") { path dependencies { files { items { path } } } } }",
         );
 
         Ok(())

--- a/crates/turborepo/tests/snapshots/query__turbo_trace_get_`export_all.js`_with_dependencies_(npm@10.5.0).snap
+++ b/crates/turborepo/tests/snapshots/query__turbo_trace_get_`export_all.js`_with_dependencies_(npm@10.5.0).snap
@@ -1,0 +1,23 @@
+---
+source: crates/turborepo/tests/query.rs
+expression: query_output
+---
+{
+  "data": {
+    "file": {
+      "path": "export_all.js",
+      "dependencies": {
+        "files": {
+          "items": [
+            {
+              "path": "bar.js"
+            },
+            {
+              "path": "foo.js"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/crates/turborepo/tests/snapshots/query__turbo_trace_get_`export_named.js`_with_dependencies_(npm@10.5.0).snap
+++ b/crates/turborepo/tests/snapshots/query__turbo_trace_get_`export_named.js`_with_dependencies_(npm@10.5.0).snap
@@ -1,0 +1,23 @@
+---
+source: crates/turborepo/tests/query.rs
+expression: query_output
+---
+{
+  "data": {
+    "file": {
+      "path": "export_named.js",
+      "dependencies": {
+        "files": {
+          "items": [
+            {
+              "path": "bar.js"
+            },
+            {
+              "path": "foo.js"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/turborepo-tests/integration/fixtures/turbo_trace/export_all.js
+++ b/turborepo-tests/integration/fixtures/turbo_trace/export_all.js
@@ -1,0 +1,1 @@
+export * from "./foo.js";

--- a/turborepo-tests/integration/fixtures/turbo_trace/export_named.js
+++ b/turborepo-tests/integration/fixtures/turbo_trace/export_named.js
@@ -1,0 +1,1 @@
+export { foo } from "./foo.js";


### PR DESCRIPTION
### Description

Closes #9828. We now check export statements since they can import from other modules, e.g. `export * from "./foo"`

### Testing Instructions

Added a test for both `export * from "./foo"` and `export { foo } from "./foo"`