### PR TITLE
docs: new page for examples

### DIFF
--- a/docs/repo-docs/getting-started/examples.mdx
+++ b/docs/repo-docs/getting-started/examples.mdx
@@ -1,0 +1,65 @@
+---
+title: Start with an example
+description: Start with an example Turborepo.
+---
+
+import { PackageManagerTabs, Tabs, Tab } from '#/components/tabs';
+import { ExamplesTable } from '#/components/examples-table';
+import { Callout } from '#/components/callout';
+
+Use `create-turbo` to bootstrap an example with your favorite tooling.
+
+<PackageManagerTabs>
+<Tab>
+
+```bash title="Terminal"
+# Use an example listed below
+npx create-turbo@latest --example [example-name]
+
+# Use a GitHub repository from the community
+npx create-turbo@latest --example [github-url]
+```
+
+</Tab>
+
+<Tab>
+
+```bash title="Terminal"
+# Use an example listed below
+yarn dlx create-turbo@latest --example [example-name]
+
+# Use a GitHub repository from the community
+yarn dlx create-turbo@latest --example [github-url]
+```
+
+</Tab>
+
+<Tab>
+
+```bash title="Terminal"
+# Use an example listed below
+pnpm dlx create-turbo@latest --example [example-name]
+
+# Use a GitHub repository from the community
+pnpm dlx create-turbo@latest --example [github-url]
+```
+
+</Tab>
+</PackageManagerTabs>
+
+## Core-maintained examples
+
+This list is maintained by the Turborepo core team. Dependencies are kept as up-to-date as possible and GitHub Issues are accepted and addressed for these examples.
+
+<ExamplesTable coreMaintained />
+
+## Community-maintained examples
+
+The community curates a set of examples to showcase ways to use common tools and libraries with Turborepo. To bootstrap your monorepo with one of the examples, use the `--example` flag:
+
+<Callout type="good-to-know">
+  GitHub Issues for these examples will be closed. If you find problems, please
+  submit a pull request with fixes.
+</Callout>
+
+<ExamplesTable />

--- a/docs/repo-docs/getting-started/index.mdx
+++ b/docs/repo-docs/getting-started/index.mdx
@@ -50,7 +50,7 @@ To learn more about installing `turbo`, see the [installation guide](/repo/docs/
     description="Start with a template"
   />
   <Card
-    href="/repo/docs/getting-started/installation#start-with-an-example"
+    href="/repo/docs/getting-started/examples"
     title="Use an example"
     description="Start with a framework-specific example"
   />

--- a/docs/repo-docs/getting-started/installation.mdx
+++ b/docs/repo-docs/getting-started/installation.mdx
@@ -5,7 +5,6 @@ description: Learn how to get started with Turborepo.
 
 import { Callout } from '#/components/callout';
 import { PackageManagerTabs, Tabs, Tab } from '#/components/tabs';
-import { ExamplesTable } from '#/components/examples-table';
 
 Get started with Turborepo in a few moments using:
 
@@ -38,7 +37,7 @@ The starter repository will have:
 - Two deployable applications
 - Three shared libraries for use in the rest of the monorepo
 
-For more details on the starter, [visit the README for the basic starter on GitHub](https://github.com/vercel/turborepo/tree/main/examples/basic). You can also [use an example](/repo/docs/getting-started/installation#start-with-an-example) that more closely fits your tooling interests.
+For more details on the starter, [visit the README for the basic starter on GitHub](https://github.com/vercel/turborepo/tree/main/examples/basic). You can also [use an example](/repo/docs/getting-started/examples) that more closely fits your tooling interests.
 
 ## Installing `turbo`
 
@@ -120,51 +119,3 @@ When collaborating with other developers in a repository, it's a good idea to pi
 You can continue to use your global installation of `turbo` to run commands. Global `turbo` will defer to the local version of your repository if it exists.
 
 This lets you to get the best of both installations: easily run commands in your terminal while maintaining a pinned version for consistent usage for all developers in the repository.
-
-## Start with an example
-
-The community curates a set of examples to showcase ways to use common tools and libraries with Turborepo. To bootstrap your monorepo with one of the examples, use the `--example` flag:
-
-<PackageManagerTabs>
-<Tab>
-```bash title="Terminal"
-# Use an example listed below
-npx create-turbo@latest --example [example-name]
-
-# Use a GitHub repository from the community
-
-npx create-turbo@latest --example [github-url]
-
-```
-
-</Tab>
-
-<Tab>
-```bash title="Terminal"
-# Use an example listed below
-yarn dlx create-turbo@latest --example [example-name]
-
-# Use a GitHub repository from the community
-yarn dlx create-turbo@latest --example [github-url]
-```
-
-</Tab>
-
-<Tab>
-```bash title="Terminal"
-# Use an example listed below
-pnpm dlx create-turbo@latest --example [example-name]
-
-# Use a GitHub repository from the community
-
-pnpm dlx create-turbo@latest --example [github-url]
-
-```
-
-</Tab>
-
-</PackageManagerTabs>
-
-Use any of the example's names below:
-
-<ExamplesTable />

--- a/docs/repo-docs/getting-started/meta.json
+++ b/docs/repo-docs/getting-started/meta.json
@@ -2,6 +2,7 @@
   "defaultOpen": true,
   "pages": [
     "installation",
+    "examples",
     "add-to-existing-repository",
     "editor-integration",
     "support-policy",

--- a/docs/repo-docs/getting-started/support-policy.mdx
+++ b/docs/repo-docs/getting-started/support-policy.mdx
@@ -48,7 +48,7 @@ active Node.js version on your system, but [some packages in the Turborepo ecosy
 such as [`create-turbo`](/repo/docs/reference/create-turbo), [`turbo-ignore`](/repo/docs/reference/turbo-ignore), and [`eslint-config-turbo`](/repo/docs/reference/eslint-config-turbo) do. For these features,
 we intend to support the [Active and Maintenance LTS versions of Node.js](https://nodejs.org/en/about/previous-releases).
 
-Turborepo's [examples](/repo/docs/getting-started/installation#start-with-an-example) are also expected to work with these Node.js versions.
+Turborepo's [examples](/repo/docs/getting-started/examples) are also expected to work with these Node.js versions.
 
 ## Version control
 


### PR DESCRIPTION
### Description

 Sprucing up the way we're handling examples in the docs.

- Dedicated page for starting with an example
- Splits the tables so that we can have a core-maintained section and a community-maintained section

### Testing Instructions

👀