### PR TITLE
fix: use an image that supports glibc for @turbo/repository ubuntu

### DIFF
--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -33,10 +33,9 @@ jobs:
 
           - host: ubuntu-latest
             target: "x86_64-unknown-linux-gnu"
-            container: node:18-bullseye
+            container: amazon/aws-lambda-nodejs:20
             install: |
-              apt-get update
-              apt-get install -y gcc g++ git
+              yum install -y gcc gcc-c++ git
               curl https://sh.rustup.rs -sSf | bash -s -- -y
               npm i -g pnpm@8.9.0
             setup: |

--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -33,9 +33,10 @@ jobs:
 
           - host: ubuntu-latest
             target: "x86_64-unknown-linux-gnu"
-            container: amazon/aws-lambda-nodejs:18
+            container: node:18-bullseye
             install: |
-              yum install -y gcc gcc-c++ git
+              apt-get update
+              apt-get install -y gcc g++ git
               curl https://sh.rustup.rs -sSf | bash -s -- -y
               npm i -g pnpm@8.9.0
             setup: |


### PR DESCRIPTION
### Description

In a [recent release](https://github.com/vercel/turborepo/actions/runs/13038773591/job/36375503780) of `@turbo/repository` I noticed that on `x86_64-unknown-linux-gnu` is failing checkout with:

```text
/__e/node20/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
```

### Testing Instructions

#### Verify the old version

```bash
docker pull amazon/aws-lambda-nodejs:18
docker run --rm -it --entrypoint /bin/sh amazon/aws-lambda-nodejs:18
```

then run

```bash
ldd --version
```

To verify that the version was indeed 2.26:

```text
ldd (GNU libc) 2.26
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Written by Roland McGrath and Ulrich Drepper.
```

#### Verify the new version

```bash
docker pull node:18-bullseye
docker run --rm -it --entrypoint /bin/sh amazon/aws-lambda-nodejs:20
```

then run

```bash
ldd --version
```

and expect an output like

```
sh-5.2# ldd --version
ldd (GNU libc) 2.34
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Written by Roland McGrath and Ulrich Drepper.
```



