### PR TITLE
fix(examples): kitchen-sink package tests

### DIFF
--- a/examples/kitchen-sink/packages/jest-presets/browser/jest-preset.mjs
+++ b/examples/kitchen-sink/packages/jest-presets/browser/jest-preset.mjs
@@ -1,7 +1,7 @@
-import type { Config } from "jest";
-
+/** @type {import('jest').Config} */
 const config = {
   roots: ["<rootDir>"],
+  testEnvironment: "jsdom",
   transform: {
     "^.+\\.tsx?$": "ts-jest",
   },
@@ -12,6 +12,6 @@ const config = {
     "<rootDir>/dist",
   ],
   preset: "ts-jest",
-} as const satisfies Config;
+};
 
 export default config;

--- a/examples/kitchen-sink/packages/jest-presets/node/jest-preset.mjs
+++ b/examples/kitchen-sink/packages/jest-presets/node/jest-preset.mjs
@@ -1,8 +1,6 @@
-import type { Config } from "jest";
-
+/** @type {import('jest').Config} */
 const config = {
   roots: ["<rootDir>"],
-  testEnvironment: "jsdom",
   transform: {
     "^.+\\.tsx?$": "ts-jest",
   },
@@ -13,6 +11,6 @@ const config = {
     "<rootDir>/dist",
   ],
   preset: "ts-jest",
-} as const satisfies Config;
+};
 
 export default config;


### PR DESCRIPTION
### Description

Jest doesn't support `.ts` configs as shared presets. 

From https://jestjs.io/docs/configuration#preset-string
> A preset should point to an npm module that has a jest-preset.json, jest-preset.js, jest-preset.cjs or jest-preset.mjs file at the root.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
