### PR TITLE
fix: use microdnf for ubuntu images

### DIFF
--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -35,7 +35,7 @@ jobs:
             target: "x86_64-unknown-linux-gnu"
             container: amazon/aws-lambda-nodejs:20
             install: |
-              yum install -y gcc gcc-c++ git
+              microdnf install -y gcc gcc-c++ git
               curl https://sh.rustup.rs -sSf | bash -s -- -y
               npm i -g pnpm@8.9.0
             setup: |


### PR DESCRIPTION
### Description

The pipeline using the `amazon/aws-lambda-nodejs:20` image [is failing](https://github.com/vercel/turborepo/actions/runs/13063935350/job/36452835658).

This is because:

> The Amazon Linux 2023 minimal image uses microdnf as package manager, symlinked as dnf, replacing yum in AL2-based images. Additionally, curl and gnupg2 are also included as their minimal versions curl-minimal and gnupg2-minimal.
> - https://aws.amazon.com/blogs/compute/node-js-20-x-runtime-now-available-in-aws-lambda

### Testing Instructions

```
docker pull amazon/aws-lambda-nodejs:20
docker run --interactive --tty --rm --entrypoint /bin/sh amazon/aws-lambda-nodejs:20
```

then run

```
microdnf install -y gcc gcc-c++ git
curl https://sh.rustup.rs -sSf | bash -s -- -y
npm i -g pnpm@8.9.0
```

