### PR TITLE
chore(docs): correct syntax error in ESLint configuration example

### DIFF
--- a/docs/repo-docs/guides/tools/eslint.mdx
+++ b/docs/repo-docs/guides/tools/eslint.mdx
@@ -116,7 +116,7 @@ import { nextJsConfig } from "@repo/eslint-config/next-js";
 
 /** @type {import("eslint").Linter.Config} */
 export default [
-  ...nextJsConfig;
+  ...nextJsConfig,
   // Other configurations
 ]
 ```


### PR DESCRIPTION
### Description

Replace semicolon with comma in array spread syntax
