### PR TITLE
chore(ci): always use latest corepack version

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -31,7 +31,7 @@ runs:
         cache: pnpm
 
     - name: Upgrade corepack
-      if: ${{ inputs.enable-corepack == 'true' && inputs.node-version == '16' }}
+      if: ${{ inputs.enable-corepack == 'true' }}
       shell: bash
       # Forcibly upgrade our available version of corepack.
       # The bundled version in node 16 has known issues.


### PR DESCRIPTION
### Description

Always use latest corepack version regardless of Node version. Specifically unbreak CI as we pick up https://github.com/nodejs/corepack/pull/614



### Testing Instructions

CI passes
