### PR TITLE
fix(microfrontends): fix handling of unsupported version

### DIFF
--- a/crates/turborepo-microfrontends/src/configv1.rs
+++ b/crates/turborepo-microfrontends/src/configv1.rs
@@ -67,6 +67,7 @@ impl ConfigV1 {
                 Err(Error::InvalidVersion {
                     expected: "1",
                     actual: version,
+                    path: source.to_string(),
                 })
             }
         } else {

--- a/crates/turborepo-microfrontends/src/error.rs
+++ b/crates/turborepo-microfrontends/src/error.rs
@@ -15,10 +15,11 @@ pub enum Error {
     UnsupportedVersion(String),
     #[error("Configuration references config located in package {reference}.")]
     ChildConfig { reference: String },
-    #[error("Cannot parse config with version '{actual}' as version '{expected}'.")]
+    #[error("`{path}`: Cannot parse config with version '{actual}' as version '{expected}'.")]
     InvalidVersion {
         expected: &'static str,
         actual: String,
+        path: String,
     },
 }
 


### PR DESCRIPTION
### Description

Make it so any invalid MFE configs no longer fail the process. 

We had this behavior previously for unsupported versions, but it broke somewhere along the lines where we were throwing `InvalidVersions` instead.

### Testing Instructions

Added unit test. Quick manual verification:
```
[0 olszewski@chriss-mbp] /Users/olszewski/code/vapi $ turbo_dev --skip-infer build --dry > /dev/null
turbo 2.4.0

 WARNING  Ignoring control-plane-default: Unsupported microfrontends configuration version: 2. Supported versions: ["1"]
```
