### PR TITLE
feat(boundaries): ignore svelte and vue files (but warn)

### DIFF
--- a/crates/turborepo-lib/src/boundaries.rs
+++ b/crates/turborepo-lib/src/boundaries.rs
@@ -219,12 +219,9 @@ impl Run {
 
         let mut not_supported_extensions = HashSet::new();
         for file_path in files {
-            match file_path.extension() {
-                Some(ext @ ("svelte" | "vue")) => {
-                    not_supported_extensions.insert(ext.to_string());
-                    continue;
-                }
-                _ => {}
+            if let Some(ext @ ("svelte" | "vue")) = file_path.extension() {
+                not_supported_extensions.insert(ext.to_string());
+                continue;
             }
 
             if let Some(repo) = repo {

--- a/crates/turborepo-lib/src/boundaries.rs
+++ b/crates/turborepo-lib/src/boundaries.rs
@@ -197,8 +197,6 @@ impl Run {
                 "**/*.jsx".parse().unwrap(),
                 "**/*.ts".parse().unwrap(),
                 "**/*.tsx".parse().unwrap(),
-                "**/*.vue".parse().unwrap(),
-                "**/*.svelte".parse().unwrap(),
             ],
             &["**/node_modules/**".parse().unwrap()],
             globwalk::WalkType::Files,

--- a/crates/turborepo-lib/src/boundaries.rs
+++ b/crates/turborepo-lib/src/boundaries.rs
@@ -16,6 +16,7 @@ use swc_ecma_ast::EsVersion;
 use swc_ecma_parser::{lexer::Lexer, Capturing, EsSyntax, Parser, Syntax, TsSyntax};
 use swc_ecma_visit::VisitWith;
 use thiserror::Error;
+use tracing::log::warn;
 use turbo_trace::{ImportFinder, ImportType, Tracer};
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, PathRelation, RelativeUnixPath};
 use turborepo_repository::{
@@ -197,6 +198,10 @@ impl Run {
                 "**/*.jsx".parse().unwrap(),
                 "**/*.ts".parse().unwrap(),
                 "**/*.tsx".parse().unwrap(),
+                "**/*.cjs".parse().unwrap(),
+                "**/*.mjs".parse().unwrap(),
+                "**/*.svelte".parse().unwrap(),
+                "**/*.vue".parse().unwrap(),
             ],
             &["**/node_modules/**".parse().unwrap()],
             globwalk::WalkType::Files,
@@ -212,7 +217,16 @@ impl Run {
         let resolver =
             Tracer::create_resolver(tsconfig_path.exists().then(|| tsconfig_path.as_ref()));
 
+        let mut not_supported_extensions = HashSet::new();
         for file_path in files {
+            match file_path.extension() {
+                Some(ext @ ("svelte" | "vue")) => {
+                    not_supported_extensions.insert(ext.to_string());
+                    continue;
+                }
+                _ => {}
+            }
+
             if let Some(repo) = repo {
                 let repo = repo.lock().expect("lock poisoned");
                 if matches!(repo.status_should_ignore(file_path.as_std_path()), Ok(true)) {
@@ -294,6 +308,16 @@ impl Run {
                     diagnostics.push(diagnostic);
                 }
             }
+        }
+
+        for ext in &not_supported_extensions {
+            warn!(
+                "{} files are currently not supported, boundaries checks will not apply to them",
+                ext
+            );
+        }
+        if !not_supported_extensions.is_empty() {
+            println!();
         }
 
         Ok((files_checked, diagnostics))


### PR DESCRIPTION
### Description

SWC currently cannot parse svelte or vue. Therefore we ignore them when it comes to boundaries, but we do emit a warning for users. Note that we specifically do *not* emit a warning per file, since that could be a lot of warnings. We do however emit per package, but that should hopefully not be too excessive

closes #9874 

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
