### PR TITLE
feat(query): studio graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3819,12 +3819,12 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 1.9.3",
+ "indexmap 2.2.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ oxc_resolver = { version = "2.1.0" }
 parking_lot = "0.12.1"
 path-clean = "1.0.1"
 pathdiff = "0.2.1"
-petgraph = "0.6.3"
+petgraph = "0.6.5"
 pin-project-lite = "0.2.9"
 port_scanner = "0.1.5"
 predicates = "2.1.5"

--- a/crates/turborepo-lib/src/query/mod.rs
+++ b/crates/turborepo-lib/src/query/mod.rs
@@ -16,7 +16,7 @@ use async_graphql::{http::GraphiQLSource, *};
 use axum::{response, response::IntoResponse};
 use external_package::ExternalPackage;
 use package::Package;
-use package_graph::{Edge, Node, PackageGraph};
+use package_graph::{Edge, PackageGraph};
 pub use server::run_server;
 use thiserror::Error;
 use tokio::select;
@@ -155,7 +155,6 @@ impl RepositoryQuery {
 #[graphql(concrete(name = "Files", params(File)))]
 #[graphql(concrete(name = "ExternalPackages", params(ExternalPackage)))]
 #[graphql(concrete(name = "Diagnostics", params(Diagnostic)))]
-#[graphql(concrete(name = "Nodes", params(Node)))]
 #[graphql(concrete(name = "Edges", params(Edge)))]
 pub struct Array<T: OutputType> {
     items: Vec<T>,

--- a/crates/turborepo-lib/src/query/mod.rs
+++ b/crates/turborepo-lib/src/query/mod.rs
@@ -575,8 +575,8 @@ impl RepositoryQuery {
         }
     }
 
-    async fn package_graph(&self) -> PackageGraph {
-        PackageGraph::new(self.run.clone())
+    async fn package_graph(&self, center: String) -> PackageGraph {
+        PackageGraph::new(self.run.clone(), center)
     }
 
     async fn file(&self, path: String) -> Result<File, Error> {

--- a/crates/turborepo-lib/src/query/mod.rs
+++ b/crates/turborepo-lib/src/query/mod.rs
@@ -575,8 +575,12 @@ impl RepositoryQuery {
         }
     }
 
-    async fn package_graph(&self, center: String) -> PackageGraph {
-        PackageGraph::new(self.run.clone(), center)
+    async fn package_graph(
+        &self,
+        center: Option<String>,
+        filter: Option<PackagePredicate>,
+    ) -> PackageGraph {
+        PackageGraph::new(self.run.clone(), center, filter)
     }
 
     async fn file(&self, path: String) -> Result<File, Error> {

--- a/crates/turborepo-lib/src/query/package_graph.rs
+++ b/crates/turborepo-lib/src/query/package_graph.rs
@@ -1,1 +1,49 @@
+use std::sync::Arc;
 
+use async_graphql::{Object, SimpleObject};
+
+use crate::{query::Array, run::Run};
+
+pub struct PackageGraph {
+    run: Arc<Run>,
+}
+
+impl PackageGraph {
+    pub fn new(run: Arc<Run>) -> Self {
+        Self { run }
+    }
+}
+
+#[derive(Debug, Clone, SimpleObject)]
+pub(crate) struct Node {
+    idx: usize,
+}
+
+#[derive(Debug, Clone, SimpleObject)]
+pub(crate) struct Edge {
+    source: usize,
+    target: usize,
+}
+
+#[Object]
+impl PackageGraph {
+    async fn nodes(&self) -> Array<Node> {
+        self.run
+            .pkg_dep_graph()
+            .node_indices()
+            .map(|idx| Node { idx: idx.index() })
+            .collect()
+    }
+
+    async fn edges(&self) -> Array<Edge> {
+        self.run
+            .pkg_dep_graph()
+            .edges()
+            .iter()
+            .map(|edge| Edge {
+                source: edge.source().index(),
+                target: edge.target().index(),
+            })
+            .collect()
+    }
+}

--- a/crates/turborepo-lib/src/query/package_graph.rs
+++ b/crates/turborepo-lib/src/query/package_graph.rs
@@ -1,22 +1,42 @@
 use std::sync::Arc;
 
 use async_graphql::{Object, SimpleObject};
+use petgraph::graph::NodeIndex;
+use turborepo_repository::package_graph::{PackageName, PackageNode};
 
 use crate::{query::Array, run::Run};
 
 pub struct PackageGraph {
     run: Arc<Run>,
+    center: PackageNode,
 }
 
 impl PackageGraph {
-    pub fn new(run: Arc<Run>) -> Self {
-        Self { run }
+    pub fn new(run: Arc<Run>, center: String) -> Self {
+        let center = PackageNode::Workspace(PackageName::from(center));
+
+        Self { run, center }
     }
 }
 
-#[derive(Debug, Clone, SimpleObject)]
+#[derive(Clone)]
 pub(crate) struct Node {
-    idx: usize,
+    idx: NodeIndex,
+    run: Arc<Run>,
+}
+
+#[Object]
+impl Node {
+    async fn name(&self) -> Option<String> {
+        self.run
+            .pkg_dep_graph()
+            .get_package_by_index(self.idx)
+            .map(|pkg| pkg.to_string())
+    }
+
+    async fn idx(&self) -> usize {
+        self.idx.index()
+    }
 }
 
 #[derive(Debug, Clone, SimpleObject)]
@@ -28,21 +48,56 @@ pub(crate) struct Edge {
 #[Object]
 impl PackageGraph {
     async fn nodes(&self) -> Array<Node> {
+        let transitive_closure = self
+            .run
+            .pkg_dep_graph()
+            .transitive_closure(Some(&self.center));
         self.run
             .pkg_dep_graph()
             .node_indices()
-            .map(|idx| Node { idx: idx.index() })
+            .filter_map(|idx| {
+                let package_node = self.run.pkg_dep_graph().get_package_by_index(idx)?;
+                if !transitive_closure.contains(package_node) {
+                    return None;
+                }
+
+                Some(Node {
+                    idx: idx,
+                    run: self.run.clone(),
+                })
+            })
             .collect()
     }
 
     async fn edges(&self) -> Array<Edge> {
+        let transitive_closure = self
+            .run
+            .pkg_dep_graph()
+            .transitive_closure(Some(&self.center));
         self.run
             .pkg_dep_graph()
             .edges()
             .iter()
-            .map(|edge| Edge {
-                source: edge.source().index(),
-                target: edge.target().index(),
+            .filter_map(|edge| {
+                let source_node = self
+                    .run
+                    .pkg_dep_graph()
+                    .get_package_by_index(edge.source())?;
+                let target_node = self
+                    .run
+                    .pkg_dep_graph()
+                    .get_package_by_index(edge.target())?;
+
+                if !transitive_closure.contains(source_node)
+                    || !transitive_closure.contains(target_node)
+                {
+                    return None;
+                }
+
+                Some(Edge {
+                    source: edge.source().index(),
+                    target: edge.target().index(),
+                })
             })
             .collect()
     }

--- a/crates/turborepo-lib/src/query/package_graph.rs
+++ b/crates/turborepo-lib/src/query/package_graph.rs
@@ -52,6 +52,11 @@ impl PackageGraph {
             .node_indices()
             .filter_map(|idx| {
                 let package_node = self.run.pkg_dep_graph().get_package_by_index(idx)?;
+                if matches!(package_node, PackageNode::Root)
+                    || matches!(package_node, PackageNode::Workspace(PackageName::Root))
+                {
+                    return None;
+                }
                 if let Some(closure) = transitive_closure.as_ref() {
                     if !closure.contains(package_node) {
                         return None;
@@ -95,6 +100,16 @@ impl PackageGraph {
                     .run
                     .pkg_dep_graph()
                     .get_package_by_index(edge.target())?;
+
+                if matches!(
+                    source_node,
+                    PackageNode::Root | PackageNode::Workspace(PackageName::Root)
+                ) || matches!(
+                    target_node,
+                    PackageNode::Root | PackageNode::Workspace(PackageName::Root)
+                ) {
+                    return None;
+                }
 
                 if let Some(closure) = transitive_closure.as_ref() {
                     if !closure.contains(source_node) || !closure.contains(target_node) {

--- a/crates/turborepo-lib/src/query/package_graph.rs
+++ b/crates/turborepo-lib/src/query/package_graph.rs
@@ -48,7 +48,8 @@ impl PackageGraph {
             .as_ref()
             .and_then(|center| self.run.pkg_dep_graph().immediate_dependencies(center));
 
-        self.run
+        let mut nodes = self
+            .run
             .pkg_dep_graph()
             .node_indices()
             .filter_map(|idx| {
@@ -77,7 +78,7 @@ impl PackageGraph {
                     match Package::new(self.run.clone(), package_node.as_package_name().clone()) {
                         Ok(package) => package,
                         Err(err) => {
-                            return Some(Err(err.into()));
+                            return Some(Err(err));
                         }
                     };
 
@@ -89,7 +90,11 @@ impl PackageGraph {
 
                 Some(Ok(package))
             })
-            .collect::<Result<Array<_>, _>>()
+            .collect::<Result<Array<_>, _>>()?;
+
+        nodes.sort_by(|a, b| a.get_name().cmp(b.get_name()));
+
+        Ok(nodes)
     }
 
     async fn edges(&self) -> Array<Edge> {

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -224,6 +224,10 @@ impl PackageGraph {
         self.packages.get(package)
     }
 
+    pub fn get_package_by_index(&self, index: NodeIndex) -> Option<&PackageNode> {
+        self.graph.node_weight(index)
+    }
+
     pub fn node_indices(&self) -> impl Iterator<Item = NodeIndex> {
         self.graph.node_indices()
     }
@@ -234,6 +238,10 @@ impl PackageGraph {
 
     pub fn packages(&self) -> impl Iterator<Item = (&PackageName, &PackageInfo)> {
         self.packages.iter()
+    }
+
+    pub fn get_page_rank(&self) -> Vec<f64> {
+        petgraph::algo::page_rank::page_rank(&self.graph, 0.85, 1)
     }
 
     pub fn root_package_json(&self) -> &PackageJson {

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -4,6 +4,11 @@ use std::{
 };
 
 use itertools::Itertools;
+
+use petgraph::{
+    graph::{Edge, NodeIndex},
+    visit::{depth_first_search, Reversed},
+};
 use serde::Serialize;
 use tracing::debug;
 use turbopath::{
@@ -217,6 +222,14 @@ impl PackageGraph {
 
     pub fn package_info(&self, package: &PackageName) -> Option<&PackageInfo> {
         self.packages.get(package)
+    }
+
+    pub fn node_indices(&self) -> impl Iterator<Item = NodeIndex> {
+        self.graph.node_indices()
+    }
+
+    pub fn edges(&self) -> &[Edge<()>] {
+        self.graph.raw_edges()
     }
 
     pub fn packages(&self) -> impl Iterator<Item = (&PackageName, &PackageInfo)> {

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -4,11 +4,7 @@ use std::{
 };
 
 use itertools::Itertools;
-
-use petgraph::{
-    graph::{Edge, NodeIndex},
-    visit::{depth_first_search, Reversed},
-};
+use petgraph::graph::{Edge, NodeIndex};
 use serde::Serialize;
 use tracing::debug;
 use turbopath::{

--- a/crates/turborepo/tests/query.rs
+++ b/crates/turborepo/tests/query.rs
@@ -9,6 +9,7 @@ fn test_query() -> Result<(), anyhow::Error> {
         "get package that doesn't exist" => "query { package(name: \"doesnotexist\") { path } }",
         "get packages with less than 1 dependents" => "query { packages(filter: {lessThan: {field: DIRECT_DEPENDENT_COUNT, value: 1}}) { items { name directDependents { length } } } }",
         "get packages with more than 0 dependents" => "query { packages(filter: {greaterThan: {field: DIRECT_DEPENDENT_COUNT, value: 0}}) { items { name directDependents { length } } } }",
+        "get package graph" => "query { packageGraph { nodes { items { name } } edges { items { source target } } } }",
     );
 
     Ok(())

--- a/crates/turborepo/tests/snapshots/query__basic_monorepo_get_package_graph_(npm@10.5.0).snap
+++ b/crates/turborepo/tests/snapshots/query__basic_monorepo_get_package_graph_(npm@10.5.0).snap
@@ -1,0 +1,31 @@
+---
+source: crates/turborepo/tests/query.rs
+expression: query_output
+---
+{
+  "data": {
+    "packageGraph": {
+      "nodes": {
+        "items": [
+          {
+            "name": "my-app"
+          },
+          {
+            "name": "another"
+          },
+          {
+            "name": "util"
+          }
+        ]
+      },
+      "edges": {
+        "items": [
+          {
+            "source": "my-app",
+            "target": "util"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/crates/turborepo/tests/snapshots/query__basic_monorepo_get_package_graph_(npm@10.5.0).snap
+++ b/crates/turborepo/tests/snapshots/query__basic_monorepo_get_package_graph_(npm@10.5.0).snap
@@ -8,10 +8,10 @@ expression: query_output
       "nodes": {
         "items": [
           {
-            "name": "my-app"
+            "name": "another"
           },
           {
-            "name": "another"
+            "name": "my-app"
           },
           {
             "name": "util"


### PR DESCRIPTION
### Description

A very basic API for getting your package graph. You can query nodes and edges between those nodes:

```
{
  packageGraph {
    nodes {      
      items {
        name
      }
    }
    edges {
      items {
        source
        target
      }
    }
  }
}
```

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
