### PR TITLE
ci: more usable separator

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     labels:
       - "area: examples"
     open-pull-requests-limit: 1
+    pull-request-branch-name:
+      separator: "-"
     versioning-strategy: "increase"
     allow:
       - dependency-type: "direct"
@@ -30,6 +32,8 @@ updates:
     labels:
       - "area: examples"
     open-pull-requests-limit: 1
+    pull-request-branch-name:
+      separator: "-"
     versioning-strategy: "increase"
     allow:
       - dependency-type: "direct"
@@ -59,6 +63,8 @@ updates:
     labels:
       - "area: examples"
     open-pull-requests-limit: 1
+    pull-request-branch-name:
+      separator: "-"
     versioning-strategy: "increase"
     allow:
       - dependency-type: "direct"
@@ -78,6 +84,8 @@ updates:
     labels:
       - "area: examples"
     open-pull-requests-limit: 1
+    pull-request-branch-name:
+      separator: "-"
     versioning-strategy: "increase"
     allow:
       - dependency-type: "direct"
@@ -97,6 +105,8 @@ updates:
     labels:
       - "area: examples"
     open-pull-requests-limit: 1
+    pull-request-branch-name:
+      separator: "-"
     versioning-strategy: "increase"
     allow:
       - dependency-type: "direct"
@@ -116,6 +126,8 @@ updates:
     labels:
       - "area: examples"
     open-pull-requests-limit: 1
+    pull-request-branch-name:
+      separator: "-"
     versioning-strategy: "increase"
     allow:
       - dependency-type: "direct"


### PR DESCRIPTION
### Description

The `/`s in the branch names make it a little annoying to run `create-turbo` on the branches for the Dependabot upgrades. It's easy to forget to have to use `create-turbo --example-path` rather than just `--example`.

Using `-` for separators is just a slight bit simpler.
