### PR TITLE
feat(release): allow for overriding npm dist tag

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -43,6 +43,10 @@ on:
       dry_run:
         description: "Do a dry run, skipping the final publish step."
         type: boolean
+      tag-override:
+        description: "Override default npm dist-tag for the release. Should only be used for backporting"
+        required: false
+        type: string
 
 jobs:
   stage:
@@ -58,7 +62,7 @@ jobs:
           git config --global user.email 'turbobot@vercel.com'
       - name: Version
         run: |
-          ./scripts/version.js ${{ inputs.increment }}
+          ./scripts/version.js ${{ inputs.increment }} ${{ inputs.tag-override }}
           cat version.txt
       - name: Stage Commit
         id: stage

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -6,6 +6,7 @@ const semver = require("semver");
 
 // These values come from the invocation of release.
 const increment = process.argv[2];
+const tagOverride = process.argv[3];
 
 // Now we get the current version of the package.
 const versionFilePath = path.join(__dirname, "..", "version.txt");
@@ -19,6 +20,6 @@ const newVersion = semver.inc(currentVersion, increment, identifier);
 
 // Parse the output semver identifier to identify which npm tag to publish to.
 const parsed = semver.parse(newVersion);
-const tag = parsed?.prerelease[0] || "latest";
+const tag = tagOverride || parsed?.prerelease[0] || "latest";
 
 fs.writeFileSync(versionFilePath, `${newVersion}\n${tag}\n`);


### PR DESCRIPTION
### Description

Npm requires all published versions to have a dist tag. If we want to backport a fix we don't want to release this under the `latest` or `canary` tag. Instead we should release it under a `v${SPECIFIC_MINOR}` tag if we want to cut another patch under an old version (or `v${SPECIFIC_MAJOR}` for a minor release for a previous major)

This updates what we write to `version.txt` which is what gets used for our [NPM publish](https://github.com/vercel/turborepo/blob/main/cli/Makefile#L2).

### Testing Instructions

[`prepatch` release without an override](https://github.com/vercel/turborepo/actions/runs/13144407776/job/36679014437#step:5:12)
[`prepatch` release with an override](https://github.com/vercel/turborepo/actions/runs/13144412891/job/36679032662#step:5:12)
