### PR TITLE
fix(summary): no longer display non existent logfile

### DIFF
--- a/crates/turborepo-lib/src/run/summary/mod.rs
+++ b/crates/turborepo-lib/src/run/summary/mod.rs
@@ -629,7 +629,7 @@ impl<'a> RunSummary<'a> {
                 ui,
                 GREY,
                 "  Log File\t=\t{}",
-                task.shared.log_file
+                task.shared.log_file.as_deref().unwrap_or_default()
             )?;
 
             let dependencies = if !self.monorepo {

--- a/crates/turborepo-lib/src/run/summary/task.rs
+++ b/crates/turborepo-lib/src/run/summary/task.rs
@@ -71,7 +71,8 @@ pub(crate) struct SharedTaskSummary<T> {
     pub cli_arguments: Vec<String>,
     pub outputs: Option<Vec<String>>,
     pub excluded_outputs: Option<Vec<String>>,
-    pub log_file: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub log_file: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub directory: Option<String>,
     pub dependencies: Vec<T>,

--- a/crates/turborepo-lib/src/run/summary/task_factory.rs
+++ b/crates/turborepo-lib/src/run/summary/task_factory.rs
@@ -146,11 +146,11 @@ impl<'a> TaskSummaryFactory<'a> {
 
         let (dependencies, dependents) = self.dependencies_and_dependents(task_id, display_task);
 
-        let log_file = {
+        let log_file = task_definition.cache.then(|| {
             let path = workspace_info.package_path().to_owned();
             let relative_log_file = TaskDefinition::workspace_relative_log_file(task_id.task());
             path.join(&relative_log_file).to_string()
-        };
+        });
 
         Ok(SharedTaskSummary {
             hash,

--- a/turborepo-tests/integration/tests/dry-json/single-package-no-config.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package-no-config.t
@@ -52,7 +52,6 @@ Setup
         "cliArguments": [],
         "outputs": null,
         "excludedOutputs": null,
-        "logFile": "\.turbo(\/|\\\\)turbo-build\.log", (re)
         "dependencies": [],
         "dependents": [],
         "resolvedTaskDefinition": {

--- a/turborepo-tests/integration/tests/run/single-package/no-config.t
+++ b/turborepo-tests/integration/tests/run/single-package/no-config.t
@@ -25,7 +25,7 @@ Check
     Cached \(Remote\)                = false\s* (re)
     Command                        = echo building > foo.txt\s* (re)
     Outputs                        =\s* (re)
-    Log File                       = .turbo(\/|\\)turbo-build.log\s* (re)
+    Log File                       = 
     Dependencies                   =\s* (re)
     Dependents                     =\s* (re)
     Inputs Files Considered        = 4\s* (re)


### PR DESCRIPTION
### Description

Closes #9903

If caching is disabled, then we don't cache the task logs. We shouldn't display a path to a log file that doesn't exist.

### Testing Instructions

Run a task that doesn't get cached with `--summarize` and make sure that `logFile` isn't present:
```
[0 olszewski@macbookpro] /tmp/summarize-colon-missing-logfile $ turbo_dev --skip-infer colon:command --summarize
turbo 2.4.1-canary.0

• Packages in scope: app-a, app-b, pkg-a, pkg-b, tooling-config
• Running colon:command in 5 packages
• Remote caching disabled
pkg-a:colon:command: cache bypass, force executing 71e88464fc594d21
pkg-a:colon:command: 
pkg-a:colon:command: 
pkg-a:colon:command: > colon:command
pkg-a:colon:command: > echo "Colon command!"
pkg-a:colon:command: 
Colon command!


  Tasks:    1 successful, 1 total
 Cached:    0 cached, 1 total
   Time:    230ms 
Summary:    /private/tmp/summarize-colon-missing-logfile/.turbo/runs/2sfbsk4LTfEuhw4VWPU60jJMmdi.json

[0 olszewski@macbookpro] /tmp/summarize-colon-missing-logfile $ rg -F 'logFile' .turbo/runs/2sfbsk4LTfEuhw4VWPU60jJMmdi.json
[1 olszewski@macbookpro] /tmp/summarize-colon-missing-logfile $ 
```
