### PR TITLE
refactor: upgrade miette

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.20.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
@@ -26,6 +26,12 @@ name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
@@ -608,17 +614,17 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.68"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.8.3",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1953,7 +1959,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.7.1",
 ]
 
 [[package]]
@@ -2148,9 +2154,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.3"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git2"
@@ -2782,21 +2788,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
-dependencies = [
- "hermit-abi 0.3.9",
- "rustix 0.38.31",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "is_ci"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "isahc"
@@ -3214,16 +3209,27 @@ version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
 dependencies = [
+ "miette-derive 5.10.0",
+ "once_cell",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette"
+version = "7.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a955165f87b37fd1862df2a59547ac542c77ef6d17c666f619d1ad22dd89484"
+dependencies = [
  "backtrace",
  "backtrace-ext",
- "is-terminal",
- "miette-derive",
- "once_cell",
- "owo-colors",
+ "cfg-if",
+ "miette-derive 7.5.0",
+ "owo-colors 4.1.0",
  "supports-color",
  "supports-hyperlinks",
  "supports-unicode",
- "terminal_size 0.1.17",
+ "terminal_size 0.4.1",
  "textwrap",
  "thiserror",
  "unicode-width",
@@ -3234,6 +3240,17 @@ name = "miette-derive"
 version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf45bf44ab49be92fd1227a3be6fc6f617f1a337c06af54981048574d8783147"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3259,6 +3276,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+dependencies = [
+ "adler2",
 ]
 
 [[package]]
@@ -3452,7 +3478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84f390c1756333538f2aed01cf280a56bc683e199b9804a504df6e7320d40116"
 dependencies = [
  "bytecount",
- "miette",
+ "miette 5.10.0",
  "nom",
  "serde",
  "thiserror",
@@ -3568,9 +3594,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.31.1"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -3673,6 +3699,12 @@ name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "owo-colors"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
 
 [[package]]
 name = "oxc_resolver"
@@ -4517,9 +4549,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
@@ -5055,12 +5087,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "smawk"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
-
-[[package]]
 name = "socket2"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5222,31 +5248,24 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "supports-color"
-version = "2.1.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
 dependencies = [
- "is-terminal",
  "is_ci",
 ]
 
 [[package]]
 name = "supports-hyperlinks"
-version = "2.1.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84231692eb0d4d41e4cdd0cabfdd2e6cd9e255e65f80c9aa7c98dd502b4233d"
-dependencies = [
- "is-terminal",
-]
+checksum = "804f44ed3c63152de6a9f90acbea1a110441de43006ea51bcce8f436196a288b"
 
 [[package]]
 name = "supports-unicode"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6c2cb240ab5dd21ed4906895ee23fe5a48acdbd15a3ce388e7b62a9b66baf7"
-dependencies = [
- "is-terminal",
-]
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "svix-ksuid"
@@ -5502,7 +5521,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900c942f83b6a8b9998cc8f74ad3ffa24b7ff3c4279ea1c1c52d95dced9f3516"
 dependencies = [
- "miette",
+ "miette 5.10.0",
  "vec1",
 ]
 
@@ -5530,22 +5549,22 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "terminal_size"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
 dependencies = [
  "rustix 0.37.23",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
+dependencies = [
+ "rustix 0.38.31",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5606,11 +5625,10 @@ checksum = "7f8b59b4da1c1717deaf1de80f0179a9d8b4ac91c986d5fd9f4a8ff177b84049"
 
 [[package]]
 name = "textwrap"
-version = "0.15.2"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 dependencies = [
- "smawk",
  "unicode-linebreak",
  "unicode-width",
 ]
@@ -6176,7 +6194,7 @@ dependencies = [
  "camino",
  "insta",
  "itertools 0.10.5",
- "miette",
+ "miette 7.5.0",
  "pretty_assertions",
  "serde_json",
  "tempfile",
@@ -6193,7 +6211,7 @@ dependencies = [
  "clap",
  "futures",
  "globwalk",
- "miette",
+ "miette 7.5.0",
  "oxc_resolver 2.1.1",
  "swc_common",
  "swc_ecma_ast",
@@ -6231,7 +6249,7 @@ dependencies = [
  "camino",
  "dunce",
  "fs-err",
- "miette",
+ "miette 7.5.0",
  "path-clean",
  "serde",
  "serde_json",
@@ -6326,7 +6344,7 @@ dependencies = [
  "hmac",
  "insta",
  "libc",
- "miette",
+ "miette 7.5.0",
  "os_str_bytes",
  "path-clean",
  "petgraph",
@@ -6391,7 +6409,7 @@ dependencies = [
  "biome_deserialize 0.6.0",
  "biome_diagnostics",
  "biome_json_parser",
- "miette",
+ "miette 7.5.0",
  "serde",
  "serde_json",
  "test-case",
@@ -6503,11 +6521,11 @@ dependencies = [
  "lazy_static",
  "libc",
  "merge",
- "miette",
+ "miette 7.5.0",
  "nix 0.26.2",
  "notify",
  "num_cpus",
- "owo-colors",
+ "owo-colors 3.5.0",
  "oxc_resolver 2.1.1",
  "path-clean",
  "petgraph",
@@ -6675,7 +6693,7 @@ dependencies = [
  "globwalk",
  "itertools 0.10.5",
  "lazy-regex",
- "miette",
+ "miette 7.5.0",
  "node-semver",
  "petgraph",
  "pretty_assertions",
@@ -7246,7 +7264,7 @@ dependencies = [
  "const_format",
  "dunce",
  "itertools 0.11.0",
- "miette",
+ "miette 5.10.0",
  "nom",
  "path-slash",
  "pori",
@@ -7326,7 +7344,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,9 @@ name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "ascii_utils"
@@ -2848,6 +2851,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3309,6 +3321,18 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "mitsein"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3270bb79f678415dd22d6c619ba7654cb400cb56f8b5dc65c78253d3fb7fa7"
+dependencies = [
+ "arrayvec",
+ "itertools 0.13.0",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -5517,12 +5541,12 @@ dependencies = [
 
 [[package]]
 name = "tardar"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900c942f83b6a8b9998cc8f74ad3ffa24b7ff3c4279ea1c1c52d95dced9f3516"
+checksum = "23441d4791e5f309275356b69aacd760208ea2ce07d85930768fab187bb93d15"
 dependencies = [
- "miette 5.10.0",
- "vec1",
+ "miette 7.5.0",
+ "mitsein",
 ]
 
 [[package]]
@@ -7104,12 +7128,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "vec1"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bda7c41ca331fe9a1c278a9e7ee055f4be7f5eb1c2b72f079b4ff8b5fce9d5c"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7264,7 +7282,7 @@ dependencies = [
  "const_format",
  "dunce",
  "itertools 0.11.0",
- "miette 5.10.0",
+ "miette 7.5.0",
  "nom",
  "path-slash",
  "pori",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ strip = true
 # ref: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace
 [workspace.dependencies]
 async-recursion = "1.0.2"
-miette = { version = "5.10.0", features = ["fancy"] }
+miette = { version = "7.4.0", features = ["fancy"] }
 markdown = "1.0.0-alpha.18"
 
 turbo-trace = { path = "crates/turbo-trace" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ strip = true
 # ref: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace
 [workspace.dependencies]
 async-recursion = "1.0.2"
-miette = { version = "7.4.0", features = ["fancy"] }
+miette = { version = "7.5.0", features = ["fancy"] }
 markdown = "1.0.0-alpha.18"
 
 turbo-trace = { path = "crates/turbo-trace" }

--- a/crates/turborepo-cache/src/config.rs
+++ b/crates/turborepo-cache/src/config.rs
@@ -225,12 +225,12 @@ mod test {
     )]
     #[test_case("", Ok(CacheConfig { local: CacheActions { read: false, write: false }, remote: CacheActions { read: false, write: false } }) ; "empty"
     )]
-    #[test_case("local:r,local:w", Err(Error::DuplicateKeys { text: "local:r,local:w".to_string(), key: "local", span: Some(SourceSpan::new(8.into(), 5.into())) }) ; "duplicate local key"
+    #[test_case("local:r,local:w", Err(Error::DuplicateKeys { text: "local:r,local:w".to_string(), key: "local", span: Some(SourceSpan::new(8_usize.into(), 5_usize.into())) }) ; "duplicate local key"
     )]
-    #[test_case("local:rr", Err(Error::DuplicateActions { text: "local:rr".to_string(), action: "r (read)", span: Some(SourceSpan::new(6.into(), 5.into())) }) ; "duplicate action")]
-    #[test_case("remote:r,local=rx", Err(Error::InvalidCacheTypeAndAction { text: "remote:r,local=rx".to_string(), pair: "local=rx".to_string(), span: Some(SourceSpan::new(9.into(), 8.into())) }) ; "invalid key action pair")]
-    #[test_case("local:rx", Err(Error::InvalidCacheAction { c: 'x', text: "local:rx".to_string(), span: Some(SourceSpan::new(6.into(), 5.into())) }) ; "invalid action")]
-    #[test_case("file:r", Err(Error::InvalidCacheType { s: "file".to_string(), text: "file:r".to_string(), span: Some(SourceSpan::new(0.into(), 4.into())) }) ; "invalid cache type")]
+    #[test_case("local:rr", Err(Error::DuplicateActions { text: "local:rr".to_string(), action: "r (read)", span: Some(SourceSpan::new(6_usize.into(), 5_usize.into())) }) ; "duplicate action")]
+    #[test_case("remote:r,local=rx", Err(Error::InvalidCacheTypeAndAction { text: "remote:r,local=rx".to_string(), pair: "local=rx".to_string(), span: Some(SourceSpan::new(9_usize.into(), 8_usize.into())) }) ; "invalid key action pair")]
+    #[test_case("local:rx", Err(Error::InvalidCacheAction { c: 'x', text: "local:rx".to_string(), span: Some(SourceSpan::new(6_usize.into(), 5_usize.into())) }) ; "invalid action")]
+    #[test_case("file:r", Err(Error::InvalidCacheType { s: "file".to_string(), text: "file:r".to_string(), span: Some(SourceSpan::new(0_usize.into(), 4_usize.into())) }) ; "invalid cache type")]
     fn test_cache_config(s: &str, expected: Result<CacheConfig, Error>) {
         assert_eq!(CacheConfig::from_str(s), expected);
     }

--- a/crates/turborepo-errors/src/lib.rs
+++ b/crates/turborepo-errors/src/lib.rs
@@ -25,7 +25,7 @@ pub const TURBO_SITE: &str = match option_env!("TURBO_SITE") {
 pub struct ParseDiagnostic {
     message: String,
     #[source_code]
-    source_code: NamedSource,
+    source_code: NamedSource<String>,
     #[label]
     label: Option<SourceSpan>,
 }
@@ -168,7 +168,7 @@ impl<T> Spanned<T> {
     /// Gets the span and the text if both exist. If either doesn't exist, we
     /// return `None` for the span and an empty string for the text, since
     /// miette doesn't accept an `Option<String>` for `#[source_code]`
-    pub fn span_and_text(&self, default_path: &str) -> (Option<SourceSpan>, NamedSource) {
+    pub fn span_and_text(&self, default_path: &str) -> (Option<SourceSpan>, NamedSource<String>) {
         let path = self.path.as_ref().map_or(default_path, |p| p.as_ref());
         match self.range.clone().zip(self.text.as_ref()) {
             Some((range, text)) => (Some(range.into()), NamedSource::new(path, text.to_string())),

--- a/crates/turborepo-lib/src/boundaries.rs
+++ b/crates/turborepo-lib/src/boundaries.rs
@@ -39,7 +39,7 @@ pub enum BoundariesDiagnostic {
         #[label("package imported here")]
         span: SourceSpan,
         #[source_code]
-        text: Arc<NamedSource>,
+        text: NamedSource<String>,
     },
     #[error("cannot import package `{name}` because it is not a dependency")]
     PackageNotFound {
@@ -47,7 +47,7 @@ pub enum BoundariesDiagnostic {
         #[label("package imported here")]
         span: SourceSpan,
         #[source_code]
-        text: Arc<NamedSource>,
+        text: NamedSource<String>,
     },
     #[error("cannot import file `{import}` because it leaves the package")]
     ImportLeavesPackage {
@@ -55,7 +55,7 @@ pub enum BoundariesDiagnostic {
         #[label("file imported here")]
         span: SourceSpan,
         #[source_code]
-        text: Arc<NamedSource>,
+        text: NamedSource<String>,
     },
     #[error("failed to parse file {0}")]
     ParseError(AbsoluteSystemPathBuf, swc_ecma_parser::error::Error),
@@ -348,10 +348,7 @@ impl Run {
             Ok(Some(BoundariesDiagnostic::ImportLeavesPackage {
                 import: import.to_string(),
                 span: source_span,
-                text: Arc::new(NamedSource::new(
-                    file_path.as_str(),
-                    file_content.to_string(),
-                )),
+                text: NamedSource::new(file_path.as_str(), file_content.to_string()),
             }))
         } else {
             Ok(None)
@@ -428,10 +425,7 @@ impl Run {
             return Some(BoundariesDiagnostic::NotTypeOnlyImport {
                 import: import.to_string(),
                 span,
-                text: Arc::new(NamedSource::new(
-                    file_path.as_str(),
-                    file_content.to_string(),
-                )),
+                text: NamedSource::new(file_path.as_str(), file_content.to_string()),
             });
         }
         let package_name = PackageNode::Workspace(PackageName::Other(package_name));
@@ -467,10 +461,7 @@ impl Run {
                     ImportType::Value => Some(BoundariesDiagnostic::NotTypeOnlyImport {
                         import: import.to_string(),
                         span,
-                        text: Arc::new(NamedSource::new(
-                            file_path.as_str(),
-                            file_content.to_string(),
-                        )),
+                        text: NamedSource::new(file_path.as_str(), file_content.to_string()),
                     }),
                 };
             }
@@ -478,10 +469,7 @@ impl Run {
             return Some(BoundariesDiagnostic::PackageNotFound {
                 name: package_name.to_string(),
                 span,
-                text: Arc::new(NamedSource::new(
-                    file_path.as_str(),
-                    file_content.to_string(),
-                )),
+                text: NamedSource::new(file_path.as_str(), file_content.to_string()),
             });
         }
 

--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -39,7 +39,7 @@ pub struct InvalidEnvPrefixError {
     pub value: String,
     pub key: String,
     #[source_code]
-    pub text: NamedSource,
+    pub text: NamedSource<String>,
     #[label("variable with invalid prefix declared here")]
     pub span: Option<SourceSpan>,
     pub env_pipeline_delimiter: &'static str,
@@ -91,14 +91,14 @@ pub enum Error {
     PackageTaskInSinglePackageMode {
         task_id: String,
         #[source_code]
-        text: NamedSource,
+        text: NamedSource<String>,
         #[label("package task found here")]
         span: Option<SourceSpan>,
     },
     #[error("Interruptible tasks must be persistent.")]
     InterruptibleButNotPersistent {
         #[source_code]
-        text: NamedSource,
+        text: NamedSource<String>,
         #[label("`interruptible` set here")]
         span: Option<SourceSpan>,
     },
@@ -118,14 +118,14 @@ pub enum Error {
         #[label("unnecessary package syntax found here")]
         span: Option<SourceSpan>,
         #[source_code]
-        text: NamedSource,
+        text: NamedSource<String>,
     },
     #[error("You can only extend from the root of the workspace.")]
     ExtendFromNonRoot {
         #[label("non-root workspace found here")]
         span: Option<SourceSpan>,
         #[source_code]
-        text: NamedSource,
+        text: NamedSource<String>,
     },
     #[error("`{field}` cannot contain an environment variable.")]
     InvalidDependsOnValue {
@@ -133,7 +133,7 @@ pub enum Error {
         #[label("environment variable found here")]
         span: Option<SourceSpan>,
         #[source_code]
-        text: NamedSource,
+        text: NamedSource<String>,
     },
     #[error("`{field}` cannot contain an absolute path.")]
     AbsolutePathInConfig {
@@ -141,21 +141,21 @@ pub enum Error {
         #[label("absolute path found here")]
         span: Option<SourceSpan>,
         #[source_code]
-        text: NamedSource,
+        text: NamedSource<String>,
     },
     #[error("No \"extends\" key found.")]
     NoExtends {
         #[label("add extends key here")]
         span: Option<SourceSpan>,
         #[source_code]
-        text: NamedSource,
+        text: NamedSource<String>,
     },
     #[error("Tasks cannot be marked as interactive and cacheable.")]
     InteractiveNoCacheable {
         #[label("marked interactive here")]
         span: Option<SourceSpan>,
         #[source_code]
-        text: NamedSource,
+        text: NamedSource<String>,
     },
     #[error("Found `pipeline` field instead of `tasks`.")]
     #[diagnostic(help("Changed in 2.0: `pipeline` has been renamed to `tasks`."))]
@@ -163,7 +163,7 @@ pub enum Error {
         #[label("Rename `pipeline` field to `tasks`")]
         span: Option<SourceSpan>,
         #[source_code]
-        text: NamedSource,
+        text: NamedSource<String>,
     },
     #[error("Failed to create APIClient: {0}")]
     ApiClient(#[source] turborepo_api_client::Error),
@@ -190,7 +190,7 @@ pub enum Error {
         #[label("Make `cacheDir` value a relative unix path.")]
         span: Option<SourceSpan>,
         #[source_code]
-        text: NamedSource,
+        text: NamedSource<String>,
     },
     #[error("Cannot load turbo.json for {0} in single package mode.")]
     InvalidTurboJsonLoad(PackageName),

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -26,7 +26,7 @@ pub enum MissingTaskError {
         #[label]
         span: Option<SourceSpan>,
         #[source_code]
-        text: NamedSource,
+        text: NamedSource<String>,
     },
     #[error("Could not find package `{name}` in project")]
     MissingPackage { name: String },
@@ -54,14 +54,14 @@ pub enum Error {
         #[label("Add an entry in turbo.json for this task")]
         span: Option<SourceSpan>,
         #[source_code]
-        text: NamedSource,
+        text: NamedSource<String>,
     },
     #[error("Could not find package \"{package}\" referenced by task \"{task_id}\" in project")]
     MissingPackageFromTask {
         #[label]
         span: Option<SourceSpan>,
         #[source_code]
-        text: NamedSource,
+        text: NamedSource<String>,
         package: String,
         task_id: String,
     },
@@ -70,7 +70,7 @@ pub enum Error {
         #[label]
         span: Option<SourceSpan>,
         #[source_code]
-        text: NamedSource,
+        text: NamedSource<String>,
         task_id: String,
         task_name: String,
     },
@@ -89,7 +89,7 @@ pub enum Error {
         #[label]
         span: Option<SourceSpan>,
         #[source_code]
-        text: NamedSource,
+        text: NamedSource<String>,
         task_name: String,
         reason: String,
     },

--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -469,7 +469,7 @@ impl Engine<Built> {
                             .task_locations
                             .get(dep_id)
                             .map(|spanned| spanned.span_and_text("turbo.json"))
-                            .unwrap_or((None, NamedSource::new("", "")));
+                            .unwrap_or((None, NamedSource::new("", String::new())));
 
                         return Err(ValidateError::DependencyOnPersistentTask {
                             span,
@@ -561,7 +561,7 @@ pub enum ValidateError {
         #[label("persistent task")]
         span: Option<SourceSpan>,
         #[source_code]
-        text: NamedSource,
+        text: NamedSource<String>,
         persistent_task: String,
         dependant: String,
     },

--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -94,7 +94,7 @@ pub enum Error {
         #[label("This script calls `turbo`, which calls the script, which calls `turbo`...")]
         span: Option<SourceSpan>,
         #[source_code]
-        text: NamedSource,
+        text: NamedSource<String>,
     },
     #[error("Could not find definition for task")]
     MissingDefinition,

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -735,15 +735,11 @@ fn gather_env_vars(
             let (span, text) = value.span_and_text("turbo.json");
             // Hard error to help people specify this correctly during migration.
             // TODO: Remove this error after we have run summary.
-            let path = value
-                .path
-                .as_ref()
-                .map_or_else(|| "turbo.json".to_string(), |p| p.to_string());
             return Err(Error::InvalidEnvPrefix(Box::new(InvalidEnvPrefixError {
                 key: key.to_string(),
                 value: value.into_inner(),
                 span,
-                text: NamedSource::new(path, text),
+                text,
                 env_pipeline_delimiter: ENV_PIPELINE_DELIMITER,
             })));
         }

--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -161,7 +161,7 @@ pub enum Error {
         #[label("version found here")]
         span: Option<SourceSpan>,
         #[source_code]
-        text: NamedSource,
+        text: NamedSource<String>,
     },
     #[error("{0}: {1}")]
     // this will be something like "cannot find binary: <thing we tried to find>"
@@ -180,7 +180,7 @@ pub enum Error {
         #[label("Invalid `packageManager` field")]
         span: Option<SourceSpan>,
         #[source_code]
-        text: NamedSource,
+        text: NamedSource<String>,
     },
     #[error(transparent)]
     WorkspaceGlob(#[from] crate::workspaces::Error),

--- a/crates/turborepo-wax/Cargo.toml
+++ b/crates/turborepo-wax/Cargo.toml
@@ -35,7 +35,7 @@ thiserror = "^1.0.0"
   [dependencies.miette]
   default-features = false
   optional = true
-  version = "^5.10.0"
+  version = "7.5.0"
 
   [dependencies.regex]
   default-features = false
@@ -44,7 +44,7 @@ thiserror = "^1.0.0"
 
   [dependencies.tardar]
   optional = true
-  version = "^0.1.0"
+  version = "^0.2.0"
 
   [dependencies.walkdir]
   optional = true

--- a/turborepo-tests/integration/tests/bad-turbo-json.t
+++ b/turborepo-tests/integration/tests/bad-turbo-json.t
@@ -13,7 +13,7 @@ Run build with package task in non-root turbo.json
   Error: unnecessary_package_task_syntax (https://turbo.build/messages/unnecessary-package-task-syntax)
   
     x "my-app#build". Use "build" instead.
-      ,-\(apps[\\/]my-app[\\/]turbo.json:7:1\) (re)
+      ,-(apps/my-app/turbo.json:8:21)
     7 |         // this comment verifies that turbo can read .json files with comments
     8 | ,->     "my-app#build": {
     9 | |         "outputs": ("banana.txt", "apple.json"),
@@ -40,7 +40,7 @@ Run build with invalid env var
   invalid_env_prefix (https://turbo.build/messages/invalid-env-prefix)
   
     x Environment variables should not be prefixed with "$"
-     ,-\(turbo.json:6:1\) (re)
+     ,-(turbo.json:7:27)
    6 |     "build": {
    7 |       "env": ("NODE_ENV", "$FOOBAR"),
      :                           ^^^^|^^^^
@@ -59,7 +59,7 @@ Run in single package mode even though we have a task with package syntax
   
     x Package tasks (<package>#<task>) are not allowed in single-package
     | repositories: found //#something
-      ,-(turbo.json:16:1)
+      ,-(turbo.json:17:21)
    16 |     "something": {},
    17 |     "//#something": {},
       :                     ^|
@@ -74,7 +74,7 @@ Use our custom turbo config which has interruptible: true
 Build should fail
   $ ${TURBO} run build
     x Interruptible tasks must be persistent.
-      ,-[turbo.json:14:1]
+      ,-[turbo.json:15:24]
    14 |       ],
    15 |       "interruptible": true,
       :                        ^^|^
@@ -93,22 +93,27 @@ Run build with syntax errors in turbo.json
   
     x Failed to parse turbo.json.
   
-  Error:   x Expected a property but instead found ','.
-     ,-[turbo.json:1:1]
+  Error: 
+    x Expected a property but instead found ','.
+     ,-[turbo.json:2:48]
    1 | {
    2 |   "$schema": "https://turbo.build/schema.json",,
      :                                                ^
    3 |   "globalDependencies": ["foo.txt"],
      `----
-  Error:   x expected `,` but instead found `42`
-      ,-[turbo.json:11:1]
+  
+  Error: 
+    x expected `,` but instead found `42`
+      ,-[turbo.json:12:46]
    11 |     "my-app#build": {
    12 |       "outputs": ["banana.txt", "apple.json"]42,
       :                                              ^^
    13 |       "inputs": [".env.local"
       `----
-  Error:   x expected `,` but instead found `}`
-      ,-[turbo.json:13:1]
+  
+  Error: 
+    x expected `,` but instead found `}`
+      ,-[turbo.json:14:5]
    13 |       "inputs": [".env.local"
    14 |     },
       :     ^

--- a/turborepo-tests/integration/tests/config.t
+++ b/turborepo-tests/integration/tests/config.t
@@ -51,7 +51,7 @@ Run build with invalid env var
   invalid_env_prefix (https://turbo.build/messages/invalid-env-prefix)
   
     x Environment variables should not be prefixed with "$"
-     ,-[turbo.json:6:1]
+     ,-[turbo.json:7:27]
    6 |     "build": {
    7 |       "env": ["NODE_ENV", "$FOOBAR"],
      :                           ^^^^|^^^^

--- a/turborepo-tests/integration/tests/dry-json/monorepo.t
+++ b/turborepo-tests/integration/tests/dry-json/monorepo.t
@@ -181,6 +181,7 @@ Tasks that don't exist throw an error
   $ ${TURBO} run doesnotexist --dry=json
     x Missing tasks in project
   
-  Error:   x Could not find task `doesnotexist` in project
+  Error: 
+    x Could not find task `doesnotexist` in project
   
   [1]

--- a/turborepo-tests/integration/tests/interactive.t
+++ b/turborepo-tests/integration/tests/interactive.t
@@ -4,7 +4,7 @@ Setup
 Verify we error on interactive task that hasn't been marked as cache: false
   $ ${TURBO} build
     x Tasks cannot be marked as interactive and cacheable.
-     ,-[turbo.json:6:1]
+     ,-[turbo.json:7:22]
    6 |     "build": {
    7 |       "interactive": true
      :                      ^^|^

--- a/turborepo-tests/integration/tests/invalid-package-json.t
+++ b/turborepo-tests/integration/tests/invalid-package-json.t
@@ -47,7 +47,7 @@ Add invalid packageManager field that passes the regex.
     x Could not resolve workspaces.
     `-> Invalid semantic version: Failed to parse an integer component of a
         semver string: number too large to fit in target type
-     ,-\(.*package.json:5:1\) (re)
+     ,-\(.*package.json:6:21\) (re)
    5 |   },
    6 |   "packageManager": "npm@0.3.211111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
      :                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^|^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -70,8 +70,9 @@ Build should fail due to trailing comma (sed replaces square brackets with paren
   
     x Unable to parse package.json.
   
-  Error:   x Expected a property but instead found '}'.
-     ,-\(.*package.json:1:1\) (re)
+  Error: 
+    x Expected a property but instead found '}'.
+     ,-\(.*package.json:1:21\) (re)
    1 | { "name": "foobar", }
      :                     ^
      `----

--- a/turborepo-tests/integration/tests/persistent-dependencies/1-topological.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/1-topological.t
@@ -15,8 +15,9 @@
   $ ${TURBO} run dev
     x Invalid task configuration
   
-  Error:   x "pkg-a#dev" is a persistent task, "app-a#dev" cannot depend on it
-     ,-[turbo.json:4:1]
+  Error: 
+    x "pkg-a#dev" is a persistent task, "app-a#dev" cannot depend on it
+     ,-[turbo.json:5:21]
    4 |     "dev": {
    5 |       "dependsOn": ["^dev"],
      :                     ^^^|^^

--- a/turborepo-tests/integration/tests/persistent-dependencies/10-too-many.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/10-too-many.t
@@ -4,7 +4,8 @@
   $ ${TURBO} run build --concurrency=1
     x Invalid task configuration
   
-  Error:   x You have 2 persistent tasks but `turbo` is configured for concurrency of
+  Error: 
+    x You have 2 persistent tasks but `turbo` is configured for concurrency of
     | 1. Set --concurrency to at least 3
   
   [1]
@@ -12,7 +13,8 @@
   $ ${TURBO} run build --concurrency=2
     x Invalid task configuration
   
-  Error:   x You have 2 persistent tasks but `turbo` is configured for concurrency of
+  Error: 
+    x You have 2 persistent tasks but `turbo` is configured for concurrency of
     | 2. Set --concurrency to at least 3
   
   [1]

--- a/turborepo-tests/integration/tests/persistent-dependencies/2-same-workspace.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/2-same-workspace.t
@@ -15,8 +15,9 @@
   $ ${TURBO} run build
     x Invalid task configuration
   
-  Error:   x "app-a#dev" is a persistent task, "app-a#build" cannot depend on it
-     ,-[turbo.json:4:1]
+  Error: 
+    x "app-a#dev" is a persistent task, "app-a#build" cannot depend on it
+     ,-[turbo.json:5:21]
    4 |     "build": {
    5 |       "dependsOn": ["dev"]
      :                     ^^|^^

--- a/turborepo-tests/integration/tests/persistent-dependencies/3-workspace-specific.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/3-workspace-specific.t
@@ -19,16 +19,19 @@
   $ ${TURBO} run build
     x Invalid task configuration
   
-  Error:   x "pkg-a#dev" is a persistent task, "((pkg-a)|(app-a))#build" cannot depend on it (re)
-     ,-[turbo.json:4:1]
+  Error: 
+    x "pkg-a#dev" is a persistent task, "app-a#build" cannot depend on it
+     ,-[turbo.json:5:21]
    4 |     "build": {
    5 |       "dependsOn": ["pkg-a#dev"]
      :                     ^^^^^|^^^^^
      :                          `-- persistent task
    6 |     },
      `----
-  Error:   x "pkg-a#dev" is a persistent task, "((pkg-a)|(app-a))#build" cannot depend on it (re)
-     ,-[turbo.json:4:1]
+  
+  Error: 
+    x "pkg-a#dev" is a persistent task, "pkg-a#build" cannot depend on it
+     ,-[turbo.json:5:21]
    4 |     "build": {
    5 |       "dependsOn": ["pkg-a#dev"]
      :                     ^^^^^|^^^^^

--- a/turborepo-tests/integration/tests/persistent-dependencies/4-cross-workspace.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/4-cross-workspace.t
@@ -9,8 +9,9 @@
   $ ${TURBO} run dev
     x Invalid task configuration
   
-  Error:   x "pkg-a#dev" is a persistent task, "app-a#dev" cannot depend on it
-     ,-[turbo.json:4:1]
+  Error: 
+    x "pkg-a#dev" is a persistent task, "app-a#dev" cannot depend on it
+     ,-[turbo.json:5:21]
    4 |     "app-a#dev": {
    5 |       "dependsOn": ["pkg-a#dev"],
      :                     ^^^^^|^^^^^

--- a/turborepo-tests/integration/tests/persistent-dependencies/5-root-workspace.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/5-root-workspace.t
@@ -15,8 +15,9 @@
   $ ${TURBO} run build
     x Invalid task configuration
   
-  Error:   x "//#dev" is a persistent task, "app-a#build" cannot depend on it
-     ,-[turbo.json:4:1]
+  Error: 
+    x "//#dev" is a persistent task, "app-a#build" cannot depend on it
+     ,-[turbo.json:5:21]
    4 |     "build": {
    5 |       "dependsOn": ["//#dev"],
      :                     ^^^^|^^^

--- a/turborepo-tests/integration/tests/persistent-dependencies/7-topological-nested.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/7-topological-nested.t
@@ -22,8 +22,9 @@
   $ ${TURBO} run dev
     x Invalid task configuration
   
-  Error:   x "pkg-b#dev" is a persistent task, "pkg-a#dev" cannot depend on it
-     ,-[turbo.json:4:1]
+  Error: 
+    x "pkg-b#dev" is a persistent task, "pkg-a#dev" cannot depend on it
+     ,-[turbo.json:5:21]
    4 |     "dev": {
    5 |       "dependsOn": ["^dev"],
      :                     ^^^|^^

--- a/turborepo-tests/integration/tests/persistent-dependencies/8-topological-with-extra.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/8-topological-with-extra.t
@@ -21,8 +21,9 @@
   $ ${TURBO} run build
     x Invalid task configuration
   
-  Error:   x "pkg-z#dev" is a persistent task, "pkg-b#build" cannot depend on it
-     ,-[turbo.json:7:1]
+  Error: 
+    x "pkg-z#dev" is a persistent task, "pkg-b#build" cannot depend on it
+     ,-[turbo.json:8:21]
    7 |     "pkg-b#build": {
    8 |       "dependsOn": ["pkg-z#dev"]
      :                     ^^^^^|^^^^^

--- a/turborepo-tests/integration/tests/persistent-dependencies/9-cross-workspace-nested.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/9-cross-workspace-nested.t
@@ -14,8 +14,9 @@
   $ ${TURBO} run build
     x Invalid task configuration
   
-  Error:   x "app-z#dev" is a persistent task, "app-c#build" cannot depend on it
-      ,-[turbo.json:12:1]
+  Error: 
+    x "app-z#dev" is a persistent task, "app-c#build" cannot depend on it
+      ,-[turbo.json:13:21]
    12 |     "app-c#build": {
    13 |       "dependsOn": ["app-z#dev"]
       :                     ^^^^^|^^^^^

--- a/turborepo-tests/integration/tests/query/validation.t
+++ b/turborepo-tests/integration/tests/query/validation.t
@@ -5,7 +5,8 @@ Validate that we get an error when we try to run multiple persistent tasks with 
   $ ${TURBO} run build --concurrency=1
     x Invalid task configuration
   
-  Error:   x You have 2 persistent tasks but `turbo` is configured for concurrency of
+  Error: 
+    x You have 2 persistent tasks but `turbo` is configured for concurrency of
     | 1. Set --concurrency to at least 3
   
   [1]
@@ -52,7 +53,7 @@ Setup
 Validate that we get an error when trying to depend on a task that doesn't exist
   $ ${TURBO} run build2
     x Could not find "app-a#custom" in root turbo.json or "custom" in package
-      ,-[turbo.json:27:1]
+      ,-[turbo.json:28:9]
    27 |       "dependsOn": [
    28 |         "app-a#custom"
       :         ^^^^^^^^^^^^^^

--- a/turborepo-tests/integration/tests/recursive-turbo.t
+++ b/turborepo-tests/integration/tests/recursive-turbo.t
@@ -12,7 +12,7 @@ sed replaces the square brackets with parentheses so prysk can parse the file pa
     | #something), creating a loop of `turbo` invocations. You likely have
     | misconfigured your scripts and tasks or your package manager's Workspace
     | structure.
-     ,-\(.*package.json:3:1\) (re)
+     ,-\(.*package.json:4:18\) (re)
    3 |   "scripts": {
    4 |     "something": "turbo run build"
      :                  ^^^^^^^^|^^^^^^^^

--- a/turborepo-tests/integration/tests/run/missing-tasks.t
+++ b/turborepo-tests/integration/tests/run/missing-tasks.t
@@ -5,7 +5,8 @@ Setup
   $ ${TURBO} run doesnotexist
     x Missing tasks in project
   
-  Error:   x Could not find task `doesnotexist` in project
+  Error: 
+    x Could not find task `doesnotexist` in project
   
   [1]
 
@@ -13,8 +14,11 @@ Setup
   $ ${TURBO} run doesnotexist alsono
     x Missing tasks in project
   
-  Error:   x Could not find task `alsono` in project
-  Error:   x Could not find task `doesnotexist` in project
+  Error: 
+    x Could not find task `alsono` in project
+  
+  Error: 
+    x Could not find task `doesnotexist` in project
   
   [1]
 
@@ -22,7 +26,8 @@ Setup
   $ ${TURBO} run build doesnotexist
     x Missing tasks in project
   
-  Error:   x Could not find task `doesnotexist` in project
+  Error: 
+    x Could not find task `doesnotexist` in project
   
   [1]
 

--- a/turborepo-tests/integration/tests/workspace-configs/persistent.t
+++ b/turborepo-tests/integration/tests/workspace-configs/persistent.t
@@ -12,9 +12,10 @@ This test covers:
   $ ${TURBO} run persistent-task-1-parent --filter=persistent
     x Invalid task configuration
   
-  Error:   x "persistent#persistent-task-1" is a persistent task,
+  Error: 
+    x "persistent#persistent-task-1" is a persistent task,
     | "persistent#persistent-task-1-parent" cannot depend on it
-      ,-[turbo.json:88:1]
+      ,-[turbo.json:89:9]
    88 |       "dependsOn": [
    89 |         "persistent-task-1"
       :         ^^^^^^^^^|^^^^^^^^^
@@ -53,9 +54,10 @@ This test covers:
   $ ${TURBO} run persistent-task-3-parent --filter=persistent
     x Invalid task configuration
   
-  Error:   x "persistent#persistent-task-3" is a persistent task,
+  Error: 
+    x "persistent#persistent-task-3" is a persistent task,
     | "persistent#persistent-task-3-parent" cannot depend on it
-       ,-[turbo.json:98:1]
+       ,-[turbo.json:99:9]
     98 |       "dependsOn": [
     99 |         "persistent-task-3"
        :         ^^^^^^^^^|^^^^^^^^^
@@ -70,9 +72,10 @@ This test covers:
   $ ${TURBO} run persistent-task-4-parent --filter=persistent
     x Invalid task configuration
   
-  Error:   x "persistent#persistent-task-4" is a persistent task,
+  Error: 
+    x "persistent#persistent-task-4" is a persistent task,
     | "persistent#persistent-task-4-parent" cannot depend on it
-       ,-[turbo.json:103:1]
+       ,-[turbo.json:104:9]
    103 |       "dependsOn": [
    104 |         "persistent-task-4"
        :         ^^^^^^^^^|^^^^^^^^^


### PR DESCRIPTION
### Description

Upgrade miette to 7.5.0. This bring some nice changes like `NamedSource` now being generic so you can get the underlying source instead of a dynamic trait object.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
