### PR TITLE
chore(ci): support custom turbo version for ci

### DIFF
--- a/.github/actions/install-global-turbo/action.yml
+++ b/.github/actions/install-global-turbo/action.yml
@@ -1,12 +1,29 @@
 name: "Install Global Turbo"
 description: "Installs turbo globally. Expects Node and npm to already be installed"
 
+inputs:
+  turbo-version:
+    description: "Specify a Turbo version or tag (e.g., 2.0.5, latest, beta, canary)"
+    required: false
+    default: ""
+
 runs:
   using: "composite"
   steps:
+    - name: Determine Turbo Version
+      id: determine-version
+      shell: bash
+      run: |
+        if [[ -n "${{ inputs.turbo-version }}" ]]; then
+          VERSION="${{ inputs.turbo-version }}"
+        else
+          VERSION=$(npm view turbo --json | jq -r '.versions | map(select(test("^2\\."))) | last')
+          echo "No version provided, using latest 2.x version: $VERSION"
+        fi
+        echo "TURBO_VERSION=$VERSION" >> $GITHUB_ENV
+
     - name: Install Turbo globally
       shell: bash
       run: |
-        VERSION=$(npm view turbo --json | jq -r '.versions | map(select(test("2."))) | last')
-        echo "Latest published version: $VERSION"
-        npm i -g turbo@$VERSION
+        echo "Installing turbo@$TURBO_VERSION..."
+        npm i -g turbo@$TURBO_VERSION

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -47,6 +47,11 @@ on:
         description: "Override default npm dist-tag for the release. Should only be used for backporting"
         required: false
         type: string
+      ci-tag-override:
+        description: "Override default npm dist-tag to use for running tests. Should only be used when the most recent release was faulty"
+        required: false
+        type: string
+        default: ""
 
 jobs:
   stage:
@@ -107,6 +112,8 @@ jobs:
           node-version: "20"
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo
+        with:
+          turbo-version: "${{ github.event.inputs.ci-tag-override }}"
       - name: Run JS Package Tests
         run: turbo run check-types test --filter="./packages/*" --color
 
@@ -207,7 +214,9 @@ jobs:
           enable-corepack: false
 
       - name: Install Global Turbo
-        uses: ./.github/actions/install-global-turbo
+        uses: ./.github/actions/
+        with:
+          turbo-version: "${{ github.event.inputs.ci-tag-override }}"
 
       - name: Configure git
         run: |


### PR DESCRIPTION
### Description

Our release flow installs the most recent version of turbo to run tests even if it's deprecated. This allows that to be overriden so we can still release forward after a bad release. 

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
