### PR TITLE
ci(fix): checkout before doing path filtering

### DIFF
--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -26,6 +26,9 @@ jobs:
       with-tailwind-example: ${{ steps.filter.outputs.with-tailwind-example }}
       rest: ${{ steps.filter.outputs.rest }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - uses: dorny/paths-filter@v3
         id: filter
         with:


### PR DESCRIPTION
### Description

We're seeing sporadic failures on the `dorny/paths-filter` part, and[ the recommended recourse](https://github.com/dorny/paths-filter/issues/24#issuecomment-841818275) from the workflow author is to add a checkout.

Failures:
- https://github.com/vercel/turborepo/actions/runs/13208878667/job/36878355246
- https://github.com/vercel/turborepo/actions/runs/13205111177/job/36866322671

However, it's notable that it looks like GHA just...does this sometimes?
- https://github.com/actions/checkout/issues/417
- https://github.com/actions/runner-images/issues/9632
- https://github.com/actions/runner-images/issues/9882

### Testing Instructions

CI
