### PR TITLE
docs(repo): add JSON Schema to `turbo.json` ref in `single-package-workspaces.mdx`

### DIFF
--- a/docs/repo-docs/guides/single-package-workspaces.mdx
+++ b/docs/repo-docs/guides/single-package-workspaces.mdx
@@ -82,6 +82,7 @@ Then, create tasks in `turbo.json` to run these scripts in order:
 
 ```json title="./turbo.json"
 {
+  "$schema": "https://turbo.build/schema.json", 
   "tasks": {
     "dev": {
       "dependsOn": ["db:seed"],
@@ -123,6 +124,7 @@ You can create a configuration like this one:
 
 ```json title="turbo.json"
 {
+  "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "lint": {},
     "format": {},
@@ -145,6 +147,7 @@ For instance, a script for checking types using `tsc --noEmit` can be configured
 
 ```json title="./turbo.json"
 {
+  "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "check-types": {
       "inputs": ["**/*.{ts,tsx}"]


### PR DESCRIPTION
### Description

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

Add a JSON schema to the `turbo.json` reference in `single-package-workspaces.mdx`, found in the Guides section.

This is useful for newcomers who are setting up Turborepo and learning how to set that file up from this guide - they will fall into the pit of success and have the JSON schema set up.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->

N/A