### PR TITLE
feat: adds pnpm lockfile ignoredOptionalDependencies

### DIFF
--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -25,6 +25,8 @@ pub struct PnpmLockfile {
     #[serde(skip_serializing_if = "Option::is_none")]
     only_built_dependencies: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    ignored_optional_dependencies: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     overrides: Option<Map<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     package_extensions_checksum: Option<String>,
@@ -482,6 +484,7 @@ impl crate::Lockfile for PnpmLockfile {
             lockfile_version: self.lockfile_version.clone(),
             never_built_dependencies: self.never_built_dependencies.clone(),
             only_built_dependencies: self.only_built_dependencies.clone(),
+            ignored_optional_dependencies: self.ignored_optional_dependencies.clone(),
             overrides: self.overrides.clone(),
             package_extensions_checksum: self.package_extensions_checksum.clone(),
             patched_dependencies: patches,


### PR DESCRIPTION
### Description

Adds pnpm lockfile ignoredOptionalDependencies

I'm unaware if i need to make changes anywhere else, this works as expected in e.g copying lockfile during pruning

Fixes: https://github.com/vercel/turborepo/issues/8959