### PR TITLE
chore(release): run tests as we build binary

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -119,7 +119,7 @@ jobs:
 
   build-rust:
     name: "Build Rust"
-    needs: [stage, rust-smoke-test, js-smoke-test]
+    needs: [stage]
     strategy:
       fail-fast: false
       matrix:
@@ -201,7 +201,7 @@ jobs:
   npm-publish:
     name: "Publish To NPM"
     runs-on: ubuntu-latest
-    needs: [stage, build-rust]
+    needs: [stage, build-rust, rust-smoke-test, js-smoke-test]
     steps:
       - name: Show Stage Commit
         run: echo "${{ needs.stage.outputs.stage-branch }}"


### PR DESCRIPTION
### Description

We can cut down on the time it takes to cut a release by starting to build the binary before tests have run.

For example in [this run](https://github.com/vercel/turborepo/actions/runs/13246084115):
 - Rust tests took 8m48s
 - Slowest binary build took 15m38s

### Testing Instructions

[Test run](https://github.com/vercel/turborepo/actions/runs/13271787502)
