### PR TITLE
feat: better error when not enough scopes for SSO login

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6314,6 +6314,8 @@ dependencies = [
  "axum-server 0.7.1",
  "chrono",
  "hostname",
+ "http 1.1.0",
+ "httpmock",
  "lazy_static",
  "port_scanner",
  "reqwest",

--- a/crates/turborepo-auth/Cargo.toml
+++ b/crates/turborepo-auth/Cargo.toml
@@ -14,6 +14,8 @@ axum-server = { workspace = true }
 axum.workspace = true
 chrono.workspace = true
 hostname = "0.3.1"
+http = "1.1.0"
+httpmock = { workspace = true }
 lazy_static.workspace = true
 reqwest.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/crates/turborepo-auth/Cargo.toml
+++ b/crates/turborepo-auth/Cargo.toml
@@ -14,8 +14,6 @@ axum-server = { workspace = true }
 axum.workspace = true
 chrono.workspace = true
 hostname = "0.3.1"
-http = "1.1.0"
-httpmock = { workspace = true }
 lazy_static.workspace = true
 reqwest.workspace = true
 serde = { workspace = true, features = ["derive"] }
@@ -34,4 +32,6 @@ url = { workspace = true }
 webbrowser = { workspace = true }
 
 [dev-dependencies]
+http = "1.1.0"
+httpmock = { workspace = true }
 port_scanner = { workspace = true }

--- a/crates/turborepo-auth/src/lib.rs
+++ b/crates/turborepo-auth/src/lib.rs
@@ -707,4 +707,124 @@ mod tests {
         let result = Token::from_file(&file_path);
         assert!(matches!(result, Err(Error::TokenNotFound)));
     }
+
+    struct MockSSOTokenClient {
+        metadata_response: Option<ResponseTokenMetadata>,
+    }
+
+    impl TokenClient for MockSSOTokenClient {
+        async fn get_metadata(
+            &self,
+            _token: &str,
+        ) -> turborepo_api_client::Result<ResponseTokenMetadata> {
+            if let Some(metadata) = &self.metadata_response {
+                Ok(metadata.clone())
+            } else {
+                Ok(ResponseTokenMetadata {
+                    id: "test".to_string(),
+                    name: "test".to_string(),
+                    token_type: "".to_string(),
+                    origin: "test".to_string(),
+                    scopes: vec![],
+                    active_at: current_unix_time() - 100,
+                    created_at: 0,
+                })
+            }
+        }
+
+        async fn delete_token(&self, _token: &str) -> turborepo_api_client::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handle_sso_token_error_forbidden_with_invalid_token_error() {
+        let token = Token::new("test-token".to_string());
+        let client = MockSSOTokenClient {
+            metadata_response: Some(ResponseTokenMetadata {
+                id: "test".to_string(),
+                name: "test".to_string(),
+                token_type: "sso".to_string(),
+                origin: "test".to_string(),
+                scopes: vec![],
+                active_at: current_unix_time() - 100,
+                created_at: 0,
+            }),
+        };
+
+        let errorful_response = reqwest::Response::from(
+            http::Response::builder()
+                .status(reqwest::StatusCode::FORBIDDEN)
+                .body("")
+                .unwrap(),
+        );
+
+        let result = token
+            .handle_sso_token_error(&client, errorful_response.error_for_status().unwrap_err())
+            .await;
+        assert!(matches!(
+            result,
+            Err(Error::APIError(
+                turborepo_api_client::Error::InvalidToken { .. }
+            ))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_handle_sso_token_error_forbidden_without_token_type() {
+        let token = Token::new("test-token".to_string());
+        let client = MockSSOTokenClient {
+            metadata_response: Some(ResponseTokenMetadata {
+                id: "test".to_string(),
+                name: "test".to_string(),
+                token_type: "".to_string(),
+                origin: "test".to_string(),
+                scopes: vec![],
+                active_at: current_unix_time() - 100,
+                created_at: 0,
+            }),
+        };
+
+        let errorful_response = reqwest::Response::from(
+            http::Response::builder()
+                .status(reqwest::StatusCode::FORBIDDEN)
+                .body("")
+                .unwrap(),
+        );
+
+        let result = token
+            .handle_sso_token_error(&client, errorful_response.error_for_status().unwrap_err())
+            .await;
+        assert!(matches!(
+            result,
+            Err(Error::APIError(turborepo_api_client::Error::ReqwestError(
+                _
+            )))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_handle_sso_token_error_non_forbidden() {
+        let token = Token::new("test-token".to_string());
+        let client = MockSSOTokenClient {
+            metadata_response: None,
+        };
+
+        let errorful_response = reqwest::Response::from(
+            http::Response::builder()
+                .status(reqwest::StatusCode::INTERNAL_SERVER_ERROR)
+                .body("")
+                .unwrap(),
+        );
+
+        let result = token
+            .handle_sso_token_error(&client, errorful_response.error_for_status().unwrap_err())
+            .await;
+        assert!(matches!(
+            result,
+            Err(Error::APIError(turborepo_api_client::Error::ReqwestError(
+                _
+            )))
+        ));
+    }
 }

--- a/crates/turborepo-auth/src/lib.rs
+++ b/crates/turborepo-auth/src/lib.rs
@@ -158,7 +158,33 @@ impl Token {
 
                 Ok(true)
             }
-            (Err(e), _) | (_, Err(e)) => Err(Error::APIError(e)),
+            (Err(e), _) | (_, Err(e)) => match e {
+                turborepo_api_client::Error::ReqwestError(e) => {
+                    if e.status() == Some(reqwest::StatusCode::FORBIDDEN) {
+                        let metadata = self.fetch_metadata(client).await?;
+                        if !metadata.token_type.is_empty() {
+                            return Err(Error::APIError(
+                                turborepo_api_client::Error::InvalidToken {
+                                    status: e
+                                        .status()
+                                        .unwrap_or(reqwest::StatusCode::FORBIDDEN)
+                                        .as_u16(),
+                                    url: e
+                                        .url()
+                                        .map(|u| u.to_string())
+                                        .unwrap_or("Unknown url".to_string()),
+                                    message: e.to_string(),
+                                },
+                            ));
+                        }
+                    }
+
+                    Err(Error::APIError(turborepo_api_client::Error::ReqwestError(
+                        e,
+                    )))
+                }
+                e => Err(Error::APIError(e)),
+            },
         }
     }
 

--- a/crates/turborepo-auth/src/lib.rs
+++ b/crates/turborepo-auth/src/lib.rs
@@ -111,7 +111,7 @@ impl Token {
         Ok(true)
     }
 
-    async fn handle_sso_token_error<T: Client + TokenClient + CacheClient>(
+    async fn handle_sso_token_error<T: TokenClient>(
         &self,
         client: &T,
         error: reqwest::Error,


### PR DESCRIPTION
### Description

When you already have a token but don't have SSO scopes, we were throwing an error that didn't have much information. The error should be more clear now when you are in this state, informing you to use `--force`.

Specifically you could get into this state by doing:
```
turbo login
turbo login --sso-team=my-team
```

#### Note
I happy-pathed (error-pathed?) this for the specific case I wanted to solve for. I'm not sure if this is accidentally changing the error for other problematic states you can be in.

### Testing Instructions

I'm struggling to write a unit test. Help would be appreciate if you think one would be good for this (I do).

Additionally, here's a before and after:
Before:
```
▲ 👟 turbo on shew/6b0e1
  turbo login
turbo 2.4.0

>>> Opening browser to https://vercel.com/turborepo/token?redirect_uri=redacted

>>> Success! Turborepo CLI authorized for anthony.shew@vercel.com
To connect to your Remote Cache, run the following in any turborepo:
  npx turbo link


▲ 👟 turbo on shew/6b0e1 took 6s
  turbo login --sso-team=my-team
turbo 2.4.0

  × Error making HTTP request: HTTP status client error (403 Forbidden) for url (https://vercel.com/api/v2/teams/my-team)
  ╰─▶ HTTP status client error (403 Forbidden) for url (https://vercel.com/api/v2/teams/my-team)
```

After:
```
▲ 👟 turbo on shew/6b0e1
  dt login
turbo 2.4.2-canary.0

>>> Opening browser to https://vercel.com/turborepo/token?redirect_uri=redacted

>>> Success! Turborepo CLI authorized for anthony.shew@vercel.com
To connect to your Remote Cache, run the following in any turborepo:
  npx turbo link


▲ 👟 turbo on shew/6b0e1 took 2s
  dt login --sso-team=my-team
turbo 2.4.2-canary.0

  × [HTTP 403] request to https://vercel.com/api/v2/teams/my-team returned "HTTP status client error (403 Forbidden) for url (https://vercel.com/api/v2/teams/my-team)"
  │ Try logging in again, or force a refresh of your token (turbo login --sso-team=your-team --force).
  ```