### PR TITLE
fix: check-types in kitchen-sink example

### DIFF
--- a/examples/kitchen-sink/package.json
+++ b/examples/kitchen-sink/package.json
@@ -8,7 +8,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "lint": "turbo run lint",
     "test": "turbo run test",
-    "typecheck": "turbo run typecheck"
+    "check-types": "turbo run check-types"
   },
   "devDependencies": {
     "prettier": "^3.5.0",


### PR DESCRIPTION
### Description
The kitchen-sink example currently has its check types command set up as `"typecheck": "turbo run typecheck"` however none of its packages or apps have it set up that way instead utilizing `check-types`. This causes the following error where none of the type checking jobs run:

<img width="629" alt="Screenshot 2025-02-13 at 12 28 41 AM" src="https://github.com/user-attachments/assets/992fd4e7-4b7c-403d-96b4-3f43f90f3045" />

This pull request changes the root package.json's check types command to `check-types` so that all the packages and apps correctly run type checking. This also matches other examples such as `basic` and `with-tailwind`.

### Testing Instructions

To test open up the `examples/kitchen-sink` folder and run `yarn check-types` you will see the type checking jobs successfully run.

<img width="690" alt="Screenshot 2025-02-13 at 12 38 09 AM" src="https://github.com/user-attachments/assets/5e50cc86-ae71-4eb5-8875-b5c176e35fd0" />
