### PR TITLE
fix: check-types in kitchen-sink example

### DIFF
--- a/examples/kitchen-sink/package.json
+++ b/examples/kitchen-sink/package.json
@@ -8,7 +8,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "lint": "turbo run lint",
     "test": "turbo run test",
-    "typecheck": "turbo run typecheck"
+    "check-types": "turbo run check-types"
   },
   "devDependencies": {
     "prettier": "^3.5.0",


### PR DESCRIPTION
### Description

The kitchen-sink example currently has its check types command set up as "typecheck": "turbo run typecheck" however none of its packages or apps have it set up that way instead utilizing check-types. This causes the following error where none of the type checking jobs run:

![image](https://github.com/user-attachments/assets/e38cc1cf-8144-435d-a2b3-55e4cd0425c0)

This pull request changes the root package.json's check types command to check-types so that all the packages and apps correctly run type checking. This also matches other examples such as basic and with-tailwind.

### Testing Instructions
To test open up the examples/kitchen-sink folder and run yarn check-types you will see the type checking jobs successfully run.
![image](https://github.com/user-attachments/assets/ceb42d4e-8e85-4aa5-8a66-de357eac42f7)
