### PR TITLE
fix: documentation for type-check in with-shell-commands example

### DIFF
--- a/examples/with-shell-commands/README.md
+++ b/examples/with-shell-commands/README.md
@@ -36,7 +36,7 @@ This Turborepo includes the following packages:
 
 If you haven't yet, [install global `turbo`](https://turbo.build/repo/docs/installing#install-globally) to run tasks.
 
-- `turbo build lint typecheck`: Runs all tasks in the default graph.
+- `turbo build lint type-check`: Runs all tasks in the default graph.
 - `turbo build`: A basic command to build `app-a` and `app-b` in parallel.
 - `turbo build --filter=app-a`: Building only `app-a` and its dependencies.
 - `turbo lint`: A basic command for running lints in all packages in parallel.


### PR DESCRIPTION
### Description

If you run `turbo typecheck` which the documentation currently suggests you get an error that it could not find `typecheck` in project.

<img width="649" alt="Screenshot 2025-02-13 at 12 57 27 AM" src="https://github.com/user-attachments/assets/7c7fcc3d-d68a-4c43-b03d-a9d7a8922ec9" />

This pull request updates the documentation to `type-check` which aligns with what is in the packages and apps.

<img width="699" alt="Screenshot 2025-02-13 at 12 57 46 AM" src="https://github.com/user-attachments/assets/2e25b7c2-db5e-4418-8646-a5201f2fc148" />

### Testing Instructions

Go into `examples/with-shell-commands` and run `turbo type-check`
