### PR TITLE
chore: add check-types to root package.json if available

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -5,7 +5,8 @@
     "build": "turbo build",
     "dev": "turbo dev",
     "lint": "turbo lint",
-    "format": "prettier --write \"**/*.{ts,tsx,md}\""
+    "format": "prettier --write \"**/*.{ts,tsx,md}\"",
+    "check-types": "turbo check-types"
   },
   "devDependencies": {
     "prettier": "^3.5.0",

--- a/examples/with-svelte/package.json
+++ b/examples/with-svelte/package.json
@@ -5,7 +5,8 @@
     "build": "turbo run build",
     "dev": "turbo run dev",
     "lint": "turbo run lint",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "check-types": "turbo run check-types"
   },
   "devDependencies": {
     "prettier": "^3.5.0",


### PR DESCRIPTION
### Description

There were a couple examples (basic, with-svelte) that have turbo tasks for type checking, but do not have them in the root package.json. There are other examples like (with-kitchen-sink, with-tailwind) that do include the type checking in the root package.json so this PR standardizes it across the board by adding it to the examples that are missing it. This change would be especially good for the basic package.json so beginners can easily run/find the task.

### Testing Instructions

Open up examples and run `pnpm type-check`
