### PR TITLE
fix: missing `bun.lock`

### DIFF
--- a/crates/turborepo-filewatch/src/package_watcher.rs
+++ b/crates/turborepo-filewatch/src/package_watcher.rs
@@ -177,10 +177,10 @@ enum State {
 const INVALIDATION_PATHS: &[&str] = &[
     "package.json",
     "pnpm-workspace.yaml",
-    "pnpm-lock.yaml",
-    "package-lock.json",
-    "yarn.lock",
-    "bun.lockb",
+    package_manager::pnpm::LOCKFILE,
+    package_manager::npm::LOCKFILE,
+    package_manager::yarn::LOCKFILE,
+    package_manager::bun::LOCKFILE_BINARY,
 ];
 
 impl Subscriber {

--- a/crates/turborepo-filewatch/src/package_watcher.rs
+++ b/crates/turborepo-filewatch/src/package_watcher.rs
@@ -181,6 +181,7 @@ const INVALIDATION_PATHS: &[&str] = &[
     package_manager::npm::LOCKFILE,
     package_manager::yarn::LOCKFILE,
     package_manager::bun::LOCKFILE_BINARY,
+    package_manager::bun::LOCKFILE,
 ];
 
 impl Subscriber {

--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -1,9 +1,9 @@
-mod bun;
-mod npm;
-mod npmrc;
-mod pnpm;
-mod yarn;
-mod yarnrc;
+pub mod bun;
+pub mod npm;
+pub mod npmrc;
+pub mod pnpm;
+pub mod yarn;
+pub mod yarnrc;
 
 use std::{
     backtrace,


### PR DESCRIPTION
### Description

In https://github.com/vercel/turborepo/pull/9950#discussion_r1954526537 it was observed that `bun.lock` is missing from this list.

I started by exposing and then consuming the constants right from the source (d9ea60fdc9c52dadd6462d0537ae305890950b88) and then added `bun.lock` to the list in (c5840dbb12a8ea9495f4eb7eaac1373adfbfbdfc)

### Testing Instructions

`bun.lock` should now invalidate.  With https://github.com/vercel/turborepo/pull/9783 being released, this is expected behavior.
