### PR TITLE
fix(prune): preserve pnpmfileChecksum in lockfile

### DIFF
--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -21,6 +21,8 @@ pub struct PnpmLockfile {
     #[serde(skip_serializing_if = "Option::is_none")]
     settings: Option<LockfileSettings>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pnpmfile_checksum: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     never_built_dependencies: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     only_built_dependencies: Option<Vec<String>>,
@@ -491,6 +493,7 @@ impl crate::Lockfile for PnpmLockfile {
             snapshots: pruned_snapshots,
             time: None,
             settings: self.settings.clone(),
+            pnpmfile_checksum: self.pnpmfile_checksum.clone(),
         }))
     }
 


### PR DESCRIPTION
### Description

Closes #9947

### Testing Instructions

```
[0 olszewski@macbookpro] /tmp/pnpmcjs $ turbo_dev --skip-infer prune web
turbo 2.4.2

Generating pruned monorepo for web in /private/tmp/pnpmcjs/out
 - Added @repo/eslint-config
 - Added @repo/typescript-config
 - Added @repo/ui
 - Added web
[0 olszewski@macbookpro] /tmp/pnpmcjs $ cd out 
[0 olszewski@macbookpro] /tmp/pnpmcjs/out $ cp ../.pnpmfile.cjs ./
[0 olszewski@macbookpro] /tmp/pnpmcjs/out $ pnpm i --frozen-lockfile
Scope: all 5 workspace projects
Lockfile is up to date, resolution step is skipped
Packages: +452
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Progress: resolved 452, reused 452, downloaded 0, added 452, done

devDependencies:
+ prettier 3.5.0
+ turbo 2.4.2
+ typescript 5.7.3

Done in 3.4s
[0 olszewski@macbookpro] /tmp/pnpmcjs/out $ rg 'pnpmfileChecksum'
pnpm-lock.yaml
5:pnpmfileChecksum: kpphteni3rdug2puxczjfk5mle
```
