### PR TITLE
docs(repo): add section on filtering to include dependencies

### DIFF
--- a/docs/repo-docs/crafting-your-repository/running-tasks.mdx
+++ b/docs/repo-docs/crafting-your-repository/running-tasks.mdx
@@ -157,6 +157,13 @@ When you're working on a specific package, you might want to run tasks for the p
 turbo build --filter=...ui
 ```
 
+### Filtering to include dependencies
+If you want to narrow the scope down to only an app and its dependencies, you can use the ... microsyntax in reverse. This ensures that only the specified package and the dependencies it relies on are included in the task.
+
+```bash title="Terminal"
+turbo dev --filter=web...
+```
+
 ### Filtering by source control changes
 
 Using filters to run tasks based on changes in source control is a great way to run only the tasks for packages that are affected by your changes. **Source control filters must be wrapped in `[]`**.

--- a/docs/repo-docs/crafting-your-repository/running-tasks.mdx
+++ b/docs/repo-docs/crafting-your-repository/running-tasks.mdx
@@ -158,7 +158,7 @@ turbo build --filter=...ui
 ```
 
 ### Filtering to include dependencies
-If you want to narrow the scope down to only an app and its dependencies, you can use the ... microsyntax in reverse. This ensures that only the specified package and the dependencies it relies on are included in the task.
+To limit the scope to a package and its dependencies, append `...` to the package name. This runs the task for the specified package and all packages it depends on.
 
 ```bash title="Terminal"
 turbo dev --filter=web...


### PR DESCRIPTION
### Description

Add a section in [crafting-your-repository/running-tasks](https://turbo.build/repo/docs/crafting-your-repository/running-tasks) on filtering to include dependencies.

Clarifies the use of `turbo dev --filter=web...` to limit the scope to an app and its dependencies.

### Testing Instructions

N/A
