### PR TITLE
chore: standardize how turbo is ran in example packages

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -2,11 +2,11 @@
   "name": "my-turborepo",
   "private": true,
   "scripts": {
-    "build": "turbo build",
-    "dev": "turbo dev",
-    "lint": "turbo lint",
+    "build": "turbo run build",
+    "dev": "turbo run dev",
+    "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
-    "check-types": "turbo check-types"
+    "check-types": "turbo run check-types"
   },
   "devDependencies": {
     "prettier": "^3.5.0",

--- a/examples/design-system/package.json
+++ b/examples/design-system/package.json
@@ -9,7 +9,7 @@
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "turbo run build --filter=docs^... && changeset publish",
-    "preview-storybook": "turbo preview-storybook"
+    "preview-storybook": "turbo run preview-storybook"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",

--- a/examples/with-changesets/package.json
+++ b/examples/with-changesets/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "scripts": {
-    "build": "turbo build",
-    "dev": "turbo dev",
-    "lint": "turbo lint",
-    "clean": "turbo clean && rm -rf node_modules",
+    "build": "turbo run build",
+    "dev": "turbo run dev",
+    "lint": "turbo run lint",
+    "clean": "turbo run clean && rm -rf node_modules",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release": "turbo build --filter=docs^... && changeset publish"
+    "release": "turbo run build --filter=docs^... && changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",

--- a/examples/with-gatsby/package.json
+++ b/examples/with-gatsby/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "build": "turbo build",
-    "dev": "turbo dev",
-    "lint": "turbo lint",
+    "build": "turbo run build",
+    "dev": "turbo run dev",
+    "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\""
   },
   "devDependencies": {

--- a/examples/with-nestjs/package.json
+++ b/examples/with-nestjs/package.json
@@ -6,11 +6,11 @@
   "author": "",
   "license": "UNLICENSED",
   "scripts": {
-    "dev": "turbo dev",
-    "build": "turbo build",
-    "test": "turbo test",
-    "test:e2e": "turbo test:e2e",
-    "lint": "turbo lint",
+    "dev": "turbo run dev",
+    "build": "turbo run build",
+    "test": "turbo run test",
+    "test:e2e": "turbo run test:e2e",
+    "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\""
   },
   "devDependencies": {

--- a/examples/with-tailwind/package.json
+++ b/examples/with-tailwind/package.json
@@ -2,10 +2,10 @@
   "name": "with-tailwind",
   "private": true,
   "scripts": {
-    "build": "turbo build",
+    "build": "turbo run build",
     "dev": "turbo run dev",
     "lint": "turbo run lint",
-    "check-types": "turbo check-types",
+    "check-types": "turbo run check-types",
     "format": "prettier --write \"**/*.{ts,tsx,md}\""
   },
   "devDependencies": {

--- a/examples/with-typeorm/package.json
+++ b/examples/with-typeorm/package.json
@@ -1,10 +1,10 @@
 {
   "private": true,
   "scripts": {
-    "build": "turbo build",
-    "dev": "turbo dev",
-    "lint": "turbo lint",
-    "type-check": "turbo type-check",
+    "build": "turbo run build",
+    "dev": "turbo run dev",
+    "lint": "turbo run lint",
+    "type-check": "turbo run type-check",
     "format": "prettier --write \"**/*.{ts,tsx,md}\""
   },
   "devDependencies": {

--- a/examples/with-vite-react/package.json
+++ b/examples/with-vite-react/package.json
@@ -1,9 +1,9 @@
 {
   "private": true,
   "scripts": {
-    "build": "turbo build",
-    "dev": "turbo dev",
-    "lint": "turbo lint",
+    "build": "turbo run build",
+    "dev": "turbo run dev",
+    "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\""
   },
   "devDependencies": {

--- a/examples/with-vite/package.json
+++ b/examples/with-vite/package.json
@@ -1,9 +1,9 @@
 {
   "private": true,
   "scripts": {
-    "build": "turbo build",
-    "dev": "turbo dev",
-    "lint": "turbo lint",
+    "build": "turbo run build",
+    "dev": "turbo run dev",
+    "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\""
   },
   "devDependencies": {


### PR DESCRIPTION
### Description

This pull request goes through and makes sure each example uses "turbo run _x_" instead of "turbo _x_". I did this as [in the docs](https://turbo.build/repo/docs/reference/run) it says "We recommend using `turbo run` in CI pipelines and `turbo` with global turbo locally for ease of use". In the examples some packages were one way, others the opposite, some mixed. Since these command will be run by proxy by pipelines it would be good to standardize across the board to `turbo run`.

### Testing Instructions

I went through each package where there were changes and ran every command.
