### PR TITLE
fix: package name in with-changesets release job

### DIFF
--- a/examples/with-changesets/README.md
+++ b/examples/with-changesets/README.md
@@ -16,7 +16,7 @@ This Turborepo includes the following:
 
 ### Apps and Packages
 
-- `docs`: A placeholder documentation site powered by [Next.js](https://nextjs.org/)
+- `@acme/docs`: A placeholder documentation site powered by [Next.js](https://nextjs.org/)
 - `@acme/core`: core React components
 - `@acme/utils`: shared React utilities
 - `@acme/tsconfig`: shared `tsconfig.json`s used throughout the monorepo

--- a/examples/with-changesets/package.json
+++ b/examples/with-changesets/package.json
@@ -8,7 +8,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release": "turbo build --filter=docs^... && changeset publish"
+    "release": "turbo build --filter=@acme/docs^... && changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",


### PR DESCRIPTION
### Description

Currently the release job points to the `docs` package. This is incorrect as the package is actually called `@acme/docs` causing the following error:

![Screenshot 2025-02-14 at 11 15 42 AM](https://github.com/user-attachments/assets/bbc759a5-9901-4749-8f58-663fa7a222eb)

This pull request changes filter name to `@acme/docs` fixing the job.

![Screenshot 2025-02-14 at 11 30 45 AM](https://github.com/user-attachments/assets/375dc309-a0cd-4d11-9cc1-23a70ee93d24)

This pull request also updates the documentation to reflect the actual package name.

### Testing Instructions

Navigate to the `with-changesets` example and run `pnpm release`