### PR TITLE
fix(docs): correct grammar in turborepo setup message

### DIFF
--- a/docs/repo-docs/getting-started/add-to-existing-repository.mdx
+++ b/docs/repo-docs/getting-started/add-to-existing-repository.mdx
@@ -255,7 +255,7 @@ Note that this step doesn't provide much value in a single-package workspace sin
 
 ## Next steps
 
-You now up and running with Turborepo! To learn about more ways you can improve your workflow and get the most out of `turbo`, we recommend checking out the following pages:
+You're now up and running with Turborepo! To learn about more ways you can improve your workflow and get the most out of `turbo`, we recommend checking out the following pages:
 
 - [Enabling Remote Caching for development machines](/repo/docs/crafting-your-repository/constructing-ci#enabling-remote-caching)
 - [Enabling Remote Caching in CI](/repo/docs/crafting-your-repository/constructing-ci)


### PR DESCRIPTION
### Description

Fixed a grammatical error in the setup message:  
"You now up and running with Turborepo" -> "You're now up and running with Turborepo."  

