### PR TITLE
chore(signals): prefactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6771,6 +6771,7 @@ name = "turborepo-signals"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "thiserror",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6613,6 +6613,7 @@ dependencies = [
  "turborepo-microfrontends",
  "turborepo-repository",
  "turborepo-scm",
+ "turborepo-signals",
  "turborepo-telemetry",
  "turborepo-ui",
  "turborepo-unescape",
@@ -6763,6 +6764,14 @@ dependencies = [
  "turborepo-telemetry",
  "wax",
  "which",
+]
+
+[[package]]
+name = "turborepo-signals"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ turborepo-repository = { path = "crates/turborepo-repository" }
 turborepo-ui = { path = "crates/turborepo-ui" }
 turborepo-unescape = { path = "crates/turborepo-unescape" }
 turborepo-scm = { path = "crates/turborepo-scm" }
+turborepo-signals = { path = "crates/turborepo-signals" }
 wax = { path = "crates/turborepo-wax" }
 turborepo-vercel-api = { path = "crates/turborepo-vercel-api" }
 turborepo-vercel-api-mock = { path = "crates/turborepo-vercel-api-mock" }

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -139,6 +139,7 @@ turborepo-lockfiles = { workspace = true }
 turborepo-microfrontends = { workspace = true }
 turborepo-repository = { path = "../turborepo-repository" }
 turborepo-scm = { workspace = true }
+turborepo-signals = { workspace = true }
 turborepo-telemetry = { path = "../turborepo-telemetry" }
 turborepo-ui = { workspace = true }
 turborepo-unescape = { workspace = true }

--- a/crates/turborepo-lib/src/cli/error.rs
+++ b/crates/turborepo-lib/src/cli/error.rs
@@ -4,6 +4,7 @@ use itertools::Itertools;
 use miette::Diagnostic;
 use thiserror::Error;
 use turborepo_repository::package_graph;
+use turborepo_signals::SignalHandler;
 use turborepo_telemetry::events::command::CommandEventBuilder;
 use turborepo_ui::{color, BOLD, GREY};
 
@@ -14,7 +15,6 @@ use crate::{
     rewrite_json::RewriteError,
     run,
     run::{builder::RunBuilder, watch},
-    signal::SignalHandler,
 };
 
 #[derive(Debug, Error, Diagnostic)]

--- a/crates/turborepo-lib/src/cli/error.rs
+++ b/crates/turborepo-lib/src/cli/error.rs
@@ -4,12 +4,12 @@ use itertools::Itertools;
 use miette::Diagnostic;
 use thiserror::Error;
 use turborepo_repository::package_graph;
-use turborepo_signals::SignalHandler;
+use turborepo_signals::{listeners::get_signal, SignalHandler};
 use turborepo_telemetry::events::command::CommandEventBuilder;
 use turborepo_ui::{color, BOLD, GREY};
 
 use crate::{
-    commands::{bin, generate, link, login, ls, prune, run::get_signal, CommandBase},
+    commands::{bin, generate, link, login, ls, prune, CommandBase},
     daemon::DaemonError,
     query,
     rewrite_json::RewriteError,
@@ -78,7 +78,7 @@ pub async fn print_potential_tasks(
     base: CommandBase,
     telemetry: CommandEventBuilder,
 ) -> Result<(), Error> {
-    let signal = get_signal()?;
+    let signal = get_signal().map_err(run::Error::SignalHandler)?;
     let handler = SignalHandler::new(signal);
     let color_config = base.color_config;
 

--- a/crates/turborepo-lib/src/cli/error.rs
+++ b/crates/turborepo-lib/src/cli/error.rs
@@ -78,7 +78,7 @@ pub async fn print_potential_tasks(
     base: CommandBase,
     telemetry: CommandEventBuilder,
 ) -> Result<(), Error> {
-    let signal = get_signal().map_err(run::Error::SignalHandler)?;
+    let signal = get_signal().map_err(run::Error::from)?;
     let handler = SignalHandler::new(signal);
     let color_config = base.color_config;
 

--- a/crates/turborepo-lib/src/commands/boundaries.rs
+++ b/crates/turborepo-lib/src/commands/boundaries.rs
@@ -1,14 +1,10 @@
-use turborepo_signals::SignalHandler;
+use turborepo_signals::{listeners::get_signal, SignalHandler};
 use turborepo_telemetry::events::command::CommandEventBuilder;
 
-use crate::{
-    cli,
-    commands::{run::get_signal, CommandBase},
-    run::builder::RunBuilder,
-};
+use crate::{cli, commands::CommandBase, run::builder::RunBuilder};
 
 pub async fn run(base: CommandBase, telemetry: CommandEventBuilder) -> Result<i32, cli::Error> {
-    let signal = get_signal()?;
+    let signal = get_signal().map_err(crate::run::Error::SignalHandler)?;
     let handler = SignalHandler::new(signal);
 
     let run = RunBuilder::new(base)?

--- a/crates/turborepo-lib/src/commands/boundaries.rs
+++ b/crates/turborepo-lib/src/commands/boundaries.rs
@@ -4,7 +4,7 @@ use turborepo_telemetry::events::command::CommandEventBuilder;
 use crate::{cli, commands::CommandBase, run::builder::RunBuilder};
 
 pub async fn run(base: CommandBase, telemetry: CommandEventBuilder) -> Result<i32, cli::Error> {
-    let signal = get_signal().map_err(crate::run::Error::SignalHandler)?;
+    let signal = get_signal().map_err(crate::run::Error::from)?;
     let handler = SignalHandler::new(signal);
 
     let run = RunBuilder::new(base)?

--- a/crates/turborepo-lib/src/commands/boundaries.rs
+++ b/crates/turborepo-lib/src/commands/boundaries.rs
@@ -1,10 +1,10 @@
+use turborepo_signals::SignalHandler;
 use turborepo_telemetry::events::command::CommandEventBuilder;
 
 use crate::{
     cli,
     commands::{run::get_signal, CommandBase},
     run::builder::RunBuilder,
-    signal::SignalHandler,
 };
 
 pub async fn run(base: CommandBase, telemetry: CommandEventBuilder) -> Result<i32, cli::Error> {

--- a/crates/turborepo-lib/src/commands/ls.rs
+++ b/crates/turborepo-lib/src/commands/ls.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 use thiserror::Error;
 use turbopath::AnchoredSystemPath;
 use turborepo_repository::package_graph::{PackageName, PackageNode};
+use turborepo_signals::SignalHandler;
 use turborepo_telemetry::events::command::CommandEventBuilder;
 use turborepo_ui::{color, cprint, cprintln, ColorConfig, BOLD, BOLD_GREEN, GREY};
 
@@ -13,7 +14,6 @@ use crate::{
     cli::OutputFormat,
     commands::{run::get_signal, CommandBase},
     run::{builder::RunBuilder, Run},
-    signal::SignalHandler,
 };
 
 #[derive(Debug, Error, Diagnostic)]

--- a/crates/turborepo-lib/src/commands/ls.rs
+++ b/crates/turborepo-lib/src/commands/ls.rs
@@ -115,7 +115,7 @@ pub async fn run(
     telemetry: CommandEventBuilder,
     output: Option<OutputFormat>,
 ) -> Result<(), cli::Error> {
-    let signal = get_signal().map_err(crate::run::Error::SignalHandler)?;
+    let signal = get_signal().map_err(crate::run::Error::from)?;
     let handler = SignalHandler::new(signal);
 
     let run_builder = RunBuilder::new(base)?;

--- a/crates/turborepo-lib/src/commands/ls.rs
+++ b/crates/turborepo-lib/src/commands/ls.rs
@@ -5,14 +5,14 @@ use serde::Serialize;
 use thiserror::Error;
 use turbopath::AnchoredSystemPath;
 use turborepo_repository::package_graph::{PackageName, PackageNode};
-use turborepo_signals::SignalHandler;
+use turborepo_signals::{listeners::get_signal, SignalHandler};
 use turborepo_telemetry::events::command::CommandEventBuilder;
 use turborepo_ui::{color, cprint, cprintln, ColorConfig, BOLD, BOLD_GREEN, GREY};
 
 use crate::{
     cli,
     cli::OutputFormat,
-    commands::{run::get_signal, CommandBase},
+    commands::CommandBase,
     run::{builder::RunBuilder, Run},
 };
 
@@ -115,7 +115,7 @@ pub async fn run(
     telemetry: CommandEventBuilder,
     output: Option<OutputFormat>,
 ) -> Result<(), cli::Error> {
-    let signal = get_signal()?;
+    let signal = get_signal().map_err(crate::run::Error::SignalHandler)?;
     let handler = SignalHandler::new(signal);
 
     let run_builder = RunBuilder::new(base)?;

--- a/crates/turborepo-lib/src/commands/query.rs
+++ b/crates/turborepo-lib/src/commands/query.rs
@@ -5,6 +5,7 @@ use camino::Utf8Path;
 use miette::{Diagnostic, Report, SourceSpan};
 use thiserror::Error;
 use turbopath::AbsoluteSystemPathBuf;
+use turborepo_signals::SignalHandler;
 use turborepo_telemetry::events::command::CommandEventBuilder;
 
 use crate::{
@@ -12,7 +13,6 @@ use crate::{
     query,
     query::{Error, RepositoryQuery},
     run::builder::RunBuilder,
-    signal::SignalHandler,
 };
 
 const SCHEMA_QUERY: &str = "query IntrospectionQuery {

--- a/crates/turborepo-lib/src/commands/query.rs
+++ b/crates/turborepo-lib/src/commands/query.rs
@@ -5,11 +5,11 @@ use camino::Utf8Path;
 use miette::{Diagnostic, Report, SourceSpan};
 use thiserror::Error;
 use turbopath::AbsoluteSystemPathBuf;
-use turborepo_signals::SignalHandler;
+use turborepo_signals::{listeners::get_signal, SignalHandler};
 use turborepo_telemetry::events::command::CommandEventBuilder;
 
 use crate::{
-    commands::{run::get_signal, CommandBase},
+    commands::CommandBase,
     query,
     query::{Error, RepositoryQuery},
     run::builder::RunBuilder,

--- a/crates/turborepo-lib/src/commands/query.rs
+++ b/crates/turborepo-lib/src/commands/query.rs
@@ -161,7 +161,7 @@ pub async fn run(
     variables_path: Option<&Utf8Path>,
     include_schema: bool,
 ) -> Result<i32, Error> {
-    let signal = get_signal()?;
+    let signal = get_signal().map_err(crate::run::Error::from)?;
     let handler = SignalHandler::new(signal);
 
     let run_builder = RunBuilder::new(base)?

--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -1,40 +1,14 @@
-use std::{future::Future, sync::Arc};
+use std::sync::Arc;
 
 use tracing::error;
-use turborepo_signals::SignalHandler;
+use turborepo_signals::{listeners::get_signal, SignalHandler};
 use turborepo_telemetry::events::command::CommandEventBuilder;
 use turborepo_ui::sender::UISender;
 
 use crate::{commands::CommandBase, run, run::builder::RunBuilder};
 
-#[cfg(windows)]
-pub fn get_signal() -> Result<impl Future<Output = Option<()>>, run::Error> {
-    let mut ctrl_c = tokio::signal::windows::ctrl_c().map_err(run::Error::SignalHandler)?;
-    Ok(async move { ctrl_c.recv().await })
-}
-
-#[cfg(not(windows))]
-pub fn get_signal() -> Result<impl Future<Output = Option<()>>, run::Error> {
-    use tokio::signal::unix;
-    let mut sigint =
-        unix::signal(unix::SignalKind::interrupt()).map_err(run::Error::SignalHandler)?;
-    let mut sigterm =
-        unix::signal(unix::SignalKind::terminate()).map_err(run::Error::SignalHandler)?;
-
-    Ok(async move {
-        tokio::select! {
-            res = sigint.recv() => {
-                res
-            }
-            res = sigterm.recv() => {
-                res
-            }
-        }
-    })
-}
-
 pub async fn run(base: CommandBase, telemetry: CommandEventBuilder) -> Result<i32, run::Error> {
-    let signal = get_signal()?;
+    let signal = get_signal().map_err(crate::run::Error::SignalHandler)?;
     let handler = SignalHandler::new(signal);
 
     let run_builder = RunBuilder::new(base)?;

--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -8,7 +8,7 @@ use turborepo_ui::sender::UISender;
 use crate::{commands::CommandBase, run, run::builder::RunBuilder};
 
 pub async fn run(base: CommandBase, telemetry: CommandEventBuilder) -> Result<i32, run::Error> {
-    let signal = get_signal().map_err(crate::run::Error::SignalHandler)?;
+    let signal = get_signal()?;
     let handler = SignalHandler::new(signal);
 
     let run_builder = RunBuilder::new(base)?;

--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -1,10 +1,11 @@
 use std::{future::Future, sync::Arc};
 
 use tracing::error;
+use turborepo_signals::SignalHandler;
 use turborepo_telemetry::events::command::CommandEventBuilder;
 use turborepo_ui::sender::UISender;
 
-use crate::{commands::CommandBase, run, run::builder::RunBuilder, signal::SignalHandler};
+use crate::{commands::CommandBase, run, run::builder::RunBuilder};
 
 #[cfg(windows)]
 pub fn get_signal() -> Result<impl Future<Output = Option<()>>, run::Error> {

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -34,7 +34,6 @@ mod query;
 mod rewrite_json;
 mod run;
 mod shim;
-mod signal;
 mod task_graph;
 mod task_hash;
 mod tracing;

--- a/crates/turborepo-lib/src/query/mod.rs
+++ b/crates/turborepo-lib/src/query/mod.rs
@@ -24,12 +24,12 @@ use tokio::select;
 use turbo_trace::TraceError;
 use turbopath::AbsoluteSystemPathBuf;
 use turborepo_repository::{change_mapper::AllPackageChangeReason, package_graph::PackageName};
+use turborepo_signals::SignalHandler;
 
 use crate::{
     get_version,
     query::{file::File, task::RepositoryTask},
     run::{builder::RunBuilder, Run},
-    signal::SignalHandler,
 };
 
 #[derive(Error, Debug, miette::Diagnostic)]

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -20,6 +20,7 @@ use turborepo_repository::{
     package_json::PackageJson,
 };
 use turborepo_scm::SCM;
+use turborepo_signals::{SignalHandler, SignalSubscriber};
 use turborepo_telemetry::events::{
     command::CommandEventBuilder,
     generic::{DaemonInitStatus, GenericEventBuilder},
@@ -46,7 +47,6 @@ use crate::{
     process::ProcessManager,
     run::{scope, task_access::TaskAccess, task_id::TaskName, Error, Run, RunCache},
     shim::TurboState,
-    signal::{SignalHandler, SignalSubscriber},
     turbo_json::{TurboJson, TurboJsonLoader, UIMode},
     DaemonConnector,
 };

--- a/crates/turborepo-lib/src/run/error.rs
+++ b/crates/turborepo-lib/src/run/error.rs
@@ -52,8 +52,8 @@ pub enum Error {
     #[error(transparent)]
     #[diagnostic(transparent)]
     Visitor(#[from] task_graph::VisitorError),
-    #[error("Failed to register signal handler: {0}")]
-    SignalHandler(std::io::Error),
+    #[error(transparent)]
+    SignalHandler(#[from] turborepo_signals::listeners::Error),
     #[error(transparent)]
     Daemon(#[from] daemon::DaemonError),
     #[error(transparent)]

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -31,7 +31,7 @@ use turborepo_ci::Vendor;
 use turborepo_env::EnvironmentVariableMap;
 use turborepo_repository::package_graph::{PackageGraph, PackageName, PackageNode};
 use turborepo_scm::SCM;
-use turborepo_signals::SignalHandler;
+use turborepo_signals::{listeners::get_signal, SignalHandler};
 use turborepo_telemetry::events::generic::GenericEventBuilder;
 use turborepo_ui::{
     cprint, cprintln, sender::UISender, tui, tui::TuiSender, wui::sender::WebUISender, ColorConfig,
@@ -336,7 +336,7 @@ impl Run {
                     };
 
                     let interrupt = async {
-                        if let Ok(fut) = crate::commands::run::get_signal() {
+                        if let Ok(fut) = get_signal() {
                             fut.await;
                         } else {
                             tracing::warn!("could not register ctrl-c handler");

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -31,6 +31,7 @@ use turborepo_ci::Vendor;
 use turborepo_env::EnvironmentVariableMap;
 use turborepo_repository::package_graph::{PackageGraph, PackageName, PackageNode};
 use turborepo_scm::SCM;
+use turborepo_signals::SignalHandler;
 use turborepo_telemetry::events::generic::GenericEventBuilder;
 use turborepo_ui::{
     cprint, cprintln, sender::UISender, tui, tui::TuiSender, wui::sender::WebUISender, ColorConfig,
@@ -45,7 +46,6 @@ use crate::{
     opts::Opts,
     process::ProcessManager,
     run::{global_hash::get_global_hash_inputs, summary::RunTracker, task_access::TaskAccess},
-    signal::SignalHandler,
     task_graph::Visitor,
     task_hash::{get_external_deps_hash, get_internal_deps_hash, PackageInputsHashes},
     turbo_json::{TurboJson, TurboJsonLoader, UIMode},

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -10,12 +10,12 @@ use thiserror::Error;
 use tokio::{select, sync::Notify, task::JoinHandle};
 use tracing::{instrument, trace, warn};
 use turborepo_repository::package_graph::PackageName;
-use turborepo_signals::SignalHandler;
+use turborepo_signals::{listeners::get_signal, SignalHandler};
 use turborepo_telemetry::events::command::CommandEventBuilder;
 use turborepo_ui::sender::UISender;
 
 use crate::{
-    commands::{self, CommandBase},
+    commands::CommandBase,
     daemon::{proto, DaemonConnectorError, DaemonError},
     get_version, opts,
     run::{self, builder::RunBuilder, scope::target_selector::InvalidSelectorError, Run},
@@ -115,7 +115,7 @@ impl WatchClient {
         experimental_write_cache: bool,
         telemetry: CommandEventBuilder,
     ) -> Result<Self, Error> {
-        let signal = commands::run::get_signal()?;
+        let signal = get_signal().map_err(crate::run::Error::SignalHandler)?;
         let handler = SignalHandler::new(signal);
 
         if base.opts.repo_opts.root_turbo_json_path != base.repo_root.join_component(CONFIG_FILE) {

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -115,7 +115,7 @@ impl WatchClient {
         experimental_write_cache: bool,
         telemetry: CommandEventBuilder,
     ) -> Result<Self, Error> {
-        let signal = get_signal().map_err(crate::run::Error::SignalHandler)?;
+        let signal = get_signal().map_err(crate::run::Error::from)?;
         let handler = SignalHandler::new(signal);
 
         if base.opts.repo_opts.root_turbo_json_path != base.repo_root.join_component(CONFIG_FILE) {

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -10,6 +10,7 @@ use thiserror::Error;
 use tokio::{select, sync::Notify, task::JoinHandle};
 use tracing::{instrument, trace, warn};
 use turborepo_repository::package_graph::PackageName;
+use turborepo_signals::SignalHandler;
 use turborepo_telemetry::events::command::CommandEventBuilder;
 use turborepo_ui::sender::UISender;
 
@@ -18,7 +19,6 @@ use crate::{
     daemon::{proto, DaemonConnectorError, DaemonError},
     get_version, opts,
     run::{self, builder::RunBuilder, scope::target_selector::InvalidSelectorError, Run},
-    signal::SignalHandler,
     turbo_json::CONFIG_FILE,
     DaemonConnector, DaemonPaths,
 };

--- a/crates/turborepo-signals/Cargo.toml
+++ b/crates/turborepo-signals/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "turborepo-signals"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+futures = "0.3.30"
+tokio = { workspace = true, features = ["full", "time"] }
+
+[dev-dependencies]
+
+[lints]
+workspace = true

--- a/crates/turborepo-signals/Cargo.toml
+++ b/crates/turborepo-signals/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 
 [dependencies]
 futures = "0.3.30"
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full", "time"] }
 
 [dev-dependencies]

--- a/crates/turborepo-signals/Cargo.toml
+++ b/crates/turborepo-signals/Cargo.toml
@@ -2,6 +2,7 @@
 name = "turborepo-signals"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
 
 [dependencies]
 futures = "0.3.30"

--- a/crates/turborepo-signals/src/lib.rs
+++ b/crates/turborepo-signals/src/lib.rs
@@ -1,3 +1,6 @@
+#![deny(clippy::all)]
+#![feature(assert_matches)]
+
 use std::{
     fmt::Debug,
     future::Future,

--- a/crates/turborepo-signals/src/lib.rs
+++ b/crates/turborepo-signals/src/lib.rs
@@ -1,6 +1,8 @@
 #![deny(clippy::all)]
 #![feature(assert_matches)]
 
+//! A crate for registering listeners for a given signal
+
 use std::{
     fmt::Debug,
     future::Future,
@@ -28,7 +30,9 @@ pub struct SignalSubscriber(oneshot::Receiver<oneshot::Sender<()>>);
 
 /// SubscriberGuard should be kept until a subscriber is done processing the
 /// signal
-pub struct SubscriberGuard(oneshot::Sender<()>);
+pub struct SubscriberGuard {
+    _guard: oneshot::Sender<()>,
+}
 
 impl SignalHandler {
     /// Construct a new SignalHandler that will alert any subscribers when
@@ -111,11 +115,11 @@ impl SignalHandler {
 impl SignalSubscriber {
     /// Wait until signal is received by the signal handler
     pub async fn listen(self) -> SubscriberGuard {
-        let callback = self
+        let _guard = self
             .0
             .await
             .expect("signal handler worker thread exited without alerting subscribers");
-        SubscriberGuard(callback)
+        SubscriberGuard { _guard }
     }
 }
 

--- a/crates/turborepo-signals/src/lib.rs
+++ b/crates/turborepo-signals/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! A crate for registering listeners for a given signal
 
+pub mod listeners;
+
 use std::{
     fmt::Debug,
     future::Future,

--- a/crates/turborepo-signals/src/lib.rs
+++ b/crates/turborepo-signals/src/lib.rs
@@ -162,7 +162,7 @@ mod test {
         }));
         let subscriber = handler.subscribe().unwrap();
         // Send mocked SIGINT
-        tx.send(Signal::Interrupt).unwrap();
+        tx.send(DEFAULT_SIGNAL).unwrap();
 
         let (done, mut is_done) = oneshot::channel();
         let handler2 = handler.clone();
@@ -229,7 +229,7 @@ mod test {
         let subscriber = handler.subscribe().unwrap();
 
         // Send SIGINT
-        tx.send(Signal::Interrupt).unwrap();
+        tx.send(DEFAULT_SIGNAL).unwrap();
         // Do a quick yield to give the worker a chance to read the sigint
         tokio::task::yield_now().await;
         assert!(

--- a/crates/turborepo-signals/src/listeners.rs
+++ b/crates/turborepo-signals/src/listeners.rs
@@ -1,17 +1,19 @@
 use std::future::Future;
 
+use crate::signals::Signal;
+
 #[cfg(windows)]
 /// A listener for Windows Console Ctrl-C events
-pub fn get_signal() -> Result<impl Future<Output = Option<()>>, std::io::Error> {
+pub fn get_signal() -> Result<impl Future<Output = Option<Signal>>, std::io::Error> {
     let mut ctrl_c = tokio::signal::windows::ctrl_c().map_err(run::Error::SignalHandler)?;
-    Ok(async move { ctrl_c.recv().await })
+    Ok(async move { ctrl_c.recv().await.map(|_| Signal::CtrlC) })
 }
 
 #[cfg(not(windows))]
 /// A listener for commong Unix signals that require special handling
 ///
 /// Currently listens for SIGINT and SIGTERM
-pub fn get_signal() -> Result<impl Future<Output = Option<()>>, std::io::Error> {
+pub fn get_signal() -> Result<impl Future<Output = Option<Signal>>, std::io::Error> {
     use tokio::signal::unix;
     let mut sigint = unix::signal(unix::SignalKind::interrupt())?;
     let mut sigterm = unix::signal(unix::SignalKind::terminate())?;
@@ -19,10 +21,10 @@ pub fn get_signal() -> Result<impl Future<Output = Option<()>>, std::io::Error> 
     Ok(async move {
         tokio::select! {
             res = sigint.recv() => {
-                res
+                res.map(|_| Signal::Interrupt)
             }
             res = sigterm.recv() => {
-                res
+                res.map(|_| Signal::Terminate)
             }
         }
     })

--- a/crates/turborepo-signals/src/listeners.rs
+++ b/crates/turborepo-signals/src/listeners.rs
@@ -5,7 +5,7 @@ use crate::signals::Signal;
 #[cfg(windows)]
 /// A listener for Windows Console Ctrl-C events
 pub fn get_signal() -> Result<impl Stream<Item = Option<Signal>>, std::io::Error> {
-    let mut ctrl_c = tokio::signal::windows::ctrl_c().map_err(run::Error::SignalHandler)?;
+    let mut ctrl_c = tokio::signal::windows::ctrl_c()?;
     Ok(stream::once(async move {
         ctrl_c.recv().await.map(|_| Signal::CtrlC)
     }))

--- a/crates/turborepo-signals/src/listeners.rs
+++ b/crates/turborepo-signals/src/listeners.rs
@@ -1,0 +1,29 @@
+use std::future::Future;
+
+#[cfg(windows)]
+/// A listener for Windows Console Ctrl-C events
+pub fn get_signal() -> Result<impl Future<Output = Option<()>>, std::io::Error> {
+    let mut ctrl_c = tokio::signal::windows::ctrl_c().map_err(run::Error::SignalHandler)?;
+    Ok(async move { ctrl_c.recv().await })
+}
+
+#[cfg(not(windows))]
+/// A listener for commong Unix signals that require special handling
+///
+/// Currently listens for SIGINT and SIGTERM
+pub fn get_signal() -> Result<impl Future<Output = Option<()>>, std::io::Error> {
+    use tokio::signal::unix;
+    let mut sigint = unix::signal(unix::SignalKind::interrupt())?;
+    let mut sigterm = unix::signal(unix::SignalKind::terminate())?;
+
+    Ok(async move {
+        tokio::select! {
+            res = sigint.recv() => {
+                res
+            }
+            res = sigterm.recv() => {
+                res
+            }
+        }
+    })
+}

--- a/crates/turborepo-signals/src/listeners.rs
+++ b/crates/turborepo-signals/src/listeners.rs
@@ -1,24 +1,26 @@
-use std::future::Future;
+use futures::{stream, Stream};
 
 use crate::signals::Signal;
 
 #[cfg(windows)]
 /// A listener for Windows Console Ctrl-C events
-pub fn get_signal() -> Result<impl Future<Output = Option<Signal>>, std::io::Error> {
+pub fn get_signal() -> Result<impl Stream<Item = Option<Signal>>, std::io::Error> {
     let mut ctrl_c = tokio::signal::windows::ctrl_c().map_err(run::Error::SignalHandler)?;
-    Ok(async move { ctrl_c.recv().await.map(|_| Signal::CtrlC) })
+    Ok(stream::once(async move {
+        ctrl_c.recv().await.map(|_| Signal::CtrlC)
+    }))
 }
 
 #[cfg(not(windows))]
 /// A listener for commong Unix signals that require special handling
 ///
 /// Currently listens for SIGINT and SIGTERM
-pub fn get_signal() -> Result<impl Future<Output = Option<Signal>>, std::io::Error> {
+pub fn get_signal() -> Result<impl Stream<Item = Option<Signal>>, std::io::Error> {
     use tokio::signal::unix;
     let mut sigint = unix::signal(unix::SignalKind::interrupt())?;
     let mut sigterm = unix::signal(unix::SignalKind::terminate())?;
 
-    Ok(async move {
+    Ok(stream::once(async move {
         tokio::select! {
             res = sigint.recv() => {
                 res.map(|_| Signal::Interrupt)
@@ -27,5 +29,5 @@ pub fn get_signal() -> Result<impl Future<Output = Option<Signal>>, std::io::Err
                 res.map(|_| Signal::Terminate)
             }
         }
-    })
+    }))
 }

--- a/crates/turborepo-signals/src/signals.rs
+++ b/crates/turborepo-signals/src/signals.rs
@@ -1,0 +1,10 @@
+/// A collection of signals that are caught by the listeners
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Signal {
+    #[cfg(windows)]
+    CtrlC,
+    #[cfg(not(windows))]
+    Interrupt,
+    #[cfg(not(windows))]
+    Terminate,
+}


### PR DESCRIPTION
### Description

Prefactors:
 - moved signal listening to own crate
 - return signal received to subscribers
 - support streams instead of single futures for signal sources

PR that prefactors the signals code to prepare for:
 - Subscribers getting all signals sent to `turbo`
 - Additional signal handlers to be sent transparently to children

There are no behavior changes in this PR. I highly suggest reviewing each commit on its own.

### Testing Instructions

Existing unit tests.


Quick manual verification that existing `SIGINT` behavior remains the same:
```
$ turbo_dev watch build
...
│    Finalizing page optimization  .   Collecting build traces  .
└────>
  × Watch interrupted due to signal
```