### PR TITLE
Improve GH action caching docs in github-actions.mdx

### DIFF
--- a/docs/repo-docs/guides/ci-vendors/github-actions.mdx
+++ b/docs/repo-docs/guides/ci-vendors/github-actions.mdx
@@ -290,7 +290,7 @@ Example `ci` yaml with `.turbo` as chosen cache folder:
           uses: actions/cache@v4 // [!code highlight]
           with: // [!code highlight]
             path: .turbo // [!code highlight]
-            key: ${{ runner.os }}-turbo-${{ github.sha }} // [!code highlight]
+            key: ${{ runner.os }}-turbo-${{ github.ref_name }} // [!code highlight]
             restore-keys: | // [!code highlight]
               ${{ runner.os }}-turbo- // [!code highlight]
 


### PR DESCRIPTION
### Description

The local caching in GH actions can be improved by using `ref_name` instead of the commit SHA as the latter would be different on every push & hence a cache-miss. While the restore-key may help, caching across branches will allow for cache-hit & branch-based cache isolation.