### PR TITLE
chore(change_detector): improve log message on invalid ref range

### DIFF
--- a/crates/turborepo-lib/src/run/scope/change_detector.rs
+++ b/crates/turborepo-lib/src/run/scope/change_detector.rs
@@ -104,7 +104,7 @@ impl<'a> GitChangeDetector for ScopeChangeDetector<'a> {
             merge_base,
         )? {
             Err(InvalidRange { from_ref, to_ref }) => {
-                debug!("all packages changed");
+                debug!("invalid ref range, defaulting to all packages changed");
                 return Ok(self
                     .pkg_graph
                     .packages()


### PR DESCRIPTION
I was getting confused about why I was seeing this log in a PR and the issue was that I wasn't cloning my repo with enough depth in CI. It would have saved me a little time to have a better log message here.