### PR TITLE
feat(boundaries): support tsconfig path aliases

### DIFF
--- a/crates/turborepo-lib/src/boundaries/imports.rs
+++ b/crates/turborepo-lib/src/boundaries/imports.rs
@@ -25,6 +25,7 @@ impl Run {
     /// e.g. `@/types/foo` -> `./src/foo`, and if so, checks the resolved paths.
     ///
     /// Returns true if the import was resolved as a tsconfig path alias.
+    #[allow(clippy::too_many_arguments)]
     fn check_import_as_tsconfig_path_alias(
         &self,
         tsconfig_loader: &mut TsConfigLoader,
@@ -57,7 +58,7 @@ impl Run {
                 import,
                 resolved_import_path,
                 span,
-                &file_content,
+                file_content,
             )?);
         }
 
@@ -85,7 +86,7 @@ impl Run {
     ) -> Result<(), Error> {
         // If the import is prefixed with `@boundaries-ignore`, we ignore it, but print
         // a warning
-        match Self::get_ignored_comment(&comments, *span) {
+        match Self::get_ignored_comment(comments, *span) {
             Some(reason) if reason.is_empty() => {
                 result.warnings.push(
                     "@boundaries-ignore requires a reason, e.g. `// @boundaries-ignore implicit \
@@ -111,7 +112,7 @@ impl Run {
             None => {}
         }
 
-        let (start, end) = result.source_map.span_to_char_offset(&source_file, *span);
+        let (start, end) = result.source_map.span_to_char_offset(source_file, *span);
         let start = start as usize;
         let end = end as usize;
 
@@ -139,12 +140,12 @@ impl Run {
             let resolved_import_path = dir_path.join_unix_path(import_path).clean()?;
             self.check_file_import(
                 file_path,
-                &package_root,
+                package_root,
                 package_name,
                 import,
                 &resolved_import_path,
                 span,
-                &file_content,
+                file_content,
             )?
         } else if Self::is_potential_package_name(import) {
             self.check_package_import(
@@ -154,9 +155,9 @@ impl Run {
                 file_path,
                 file_content,
                 &package_info.package_json,
-                &internal_dependencies,
+                internal_dependencies,
                 unresolved_external_dependencies,
-                &resolver,
+                resolver,
             )
         } else {
             None
@@ -167,6 +168,7 @@ impl Run {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn check_file_import(
         &self,
         file_path: &AbsoluteSystemPath,
@@ -186,11 +188,11 @@ impl Run {
         // We use `relation_to_path` and not `contains` because `contains`
         // panics on invalid paths with too many `..` components
         if !matches!(
-            package_path.relation_to_path(&resolved_import_path),
+            package_path.relation_to_path(resolved_import_path),
             PathRelation::Parent
         ) {
             let resolved_import_path =
-                AnchoredSystemPathBuf::relative_path_between(&package_path, &resolved_import_path)
+                AnchoredSystemPathBuf::relative_path_between(package_path, resolved_import_path)
                     .to_string();
 
             Ok(Some(BoundariesDiagnostic::ImportLeavesPackage {

--- a/crates/turborepo-lib/src/boundaries/imports.rs
+++ b/crates/turborepo-lib/src/boundaries/imports.rs
@@ -1,34 +1,176 @@
-use std::collections::{BTreeMap, HashSet};
+use std::{
+    collections::{BTreeMap, HashSet},
+    sync::Arc,
+};
 
+use camino::Utf8Path;
 use itertools::Itertools;
 use miette::{NamedSource, SourceSpan};
-use oxc_resolver::{ResolveError, Resolver};
+use oxc_resolver::{ResolveError, Resolver, TsConfig};
+use swc_common::{comments::SingleThreadedComments, SourceFile, Span};
 use turbo_trace::ImportType;
 use turbopath::{AbsoluteSystemPath, PathRelation, RelativeUnixPath};
 use turborepo_repository::{
-    package_graph::{PackageName, PackageNode},
+    package_graph::{PackageInfo, PackageKey, PackageName, PackageNode, PackageVersion},
     package_json::PackageJson,
 };
 
 use crate::{
-    boundaries::{BoundariesDiagnostic, Error},
+    boundaries::{tsconfig::TsConfigLoader, BoundariesDiagnostic, BoundariesResult, Error},
     run::Run,
 };
 
 impl Run {
+    /// Checks if the given import can be resolved as a tsconfig path alias,
+    /// e.g. `@/types/foo` -> `./src/foo`, and if so, checks the resolved paths.
+    ///
+    /// Returns true if the import was resolved as a tsconfig path alias.
+    fn check_import_as_tsconfig_path_alias(
+        &self,
+        tsconfig_loader: &mut TsConfigLoader,
+        package_root: &AbsoluteSystemPath,
+        span: SourceSpan,
+        file_path: &AbsoluteSystemPath,
+        file_content: &str,
+        import: &str,
+        result: &mut BoundariesResult,
+    ) -> Result<bool, Error> {
+        let dir = file_path.parent().expect("file_path must have a parent");
+        let Some(tsconfig) = tsconfig_loader.load(dir) else {
+            return Ok(false);
+        };
+
+        let resolved_paths = tsconfig.resolve(dir.as_std_path(), import);
+        for path in &resolved_paths {
+            let Some(utf8_path) = Utf8Path::from_path(path) else {
+                result.diagnostics.push(BoundariesDiagnostic::InvalidPath {
+                    path: path.to_string_lossy().to_string(),
+                });
+                continue;
+            };
+            let resolved_import_path = AbsoluteSystemPath::new(utf8_path)?;
+            result.diagnostics.extend(self.check_file_import(
+                file_path,
+                package_root,
+                import,
+                resolved_import_path,
+                span,
+                &file_content,
+            )?);
+        }
+
+        Ok(!resolved_paths.is_empty())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn check_import(
+        &self,
+        comments: &SingleThreadedComments,
+        tsconfig_loader: &mut TsConfigLoader,
+        result: &mut BoundariesResult,
+        source_file: &Arc<SourceFile>,
+        package_root: &AbsoluteSystemPath,
+        import: &str,
+        import_type: &ImportType,
+        span: &Span,
+        file_path: &AbsoluteSystemPath,
+        file_content: &str,
+        package_info: &PackageInfo,
+        internal_dependencies: &HashSet<&PackageNode>,
+        unresolved_external_dependencies: Option<&BTreeMap<PackageKey, PackageVersion>>,
+        resolver: &Resolver,
+    ) -> Result<(), Error> {
+        // If the import is prefixed with `@boundaries-ignore`, we ignore it, but print
+        // a warning
+        match Self::get_ignored_comment(&comments, *span) {
+            Some(reason) if reason.is_empty() => {
+                result.warnings.push(
+                    "@boundaries-ignore requires a reason, e.g. `// @boundaries-ignore implicit \
+                     dependency`"
+                        .to_string(),
+                );
+            }
+            Some(_) => {
+                // Try to get the line number for warning
+                let line = result.source_map.lookup_line(span.lo()).map(|l| l.line);
+                if let Ok(line) = line {
+                    result
+                        .warnings
+                        .push(format!("ignoring import on line {} in {}", line, file_path));
+                } else {
+                    result
+                        .warnings
+                        .push(format!("ignoring import in {}", file_path));
+                }
+
+                return Ok(());
+            }
+            None => {}
+        }
+
+        let (start, end) = result.source_map.span_to_char_offset(&source_file, *span);
+        let start = start as usize;
+        let end = end as usize;
+
+        let span = SourceSpan::new(start.into(), end - start);
+
+        if self.check_import_as_tsconfig_path_alias(
+            tsconfig_loader,
+            package_root,
+            span,
+            file_path,
+            file_content,
+            import,
+            result,
+        )? {
+            return Ok(());
+        }
+
+        // We have a file import
+        let check_result = if import.starts_with(".") {
+            let import_path = RelativeUnixPath::new(import)?;
+            let dir_path = file_path
+                .parent()
+                .ok_or_else(|| Error::NoParentDir(file_path.to_owned()))?;
+            let resolved_import_path = dir_path.join_unix_path(import_path).clean()?;
+            self.check_file_import(
+                file_path,
+                &package_root,
+                import,
+                &resolved_import_path,
+                span,
+                &file_content,
+            )?
+        } else if Self::is_potential_package_name(import) {
+            self.check_package_import(
+                import,
+                *import_type,
+                span,
+                file_path,
+                file_content,
+                &package_info.package_json,
+                &internal_dependencies,
+                unresolved_external_dependencies,
+                &resolver,
+            )
+        } else {
+            None
+        };
+
+        result.diagnostics.extend(check_result);
+
+        Ok(())
+    }
+
     pub(crate) fn check_file_import(
         &self,
         file_path: &AbsoluteSystemPath,
         package_path: &AbsoluteSystemPath,
         import: &str,
+        resolved_import_path: &AbsoluteSystemPath,
         source_span: SourceSpan,
         file_content: &str,
     ) -> Result<Option<BoundariesDiagnostic>, Error> {
-        let import_path = RelativeUnixPath::new(import)?;
-        let dir_path = file_path
-            .parent()
-            .ok_or_else(|| Error::NoParentDir(file_path.to_owned()))?;
-        let resolved_import_path = dir_path.join_unix_path(import_path).clean()?;
         // We have to check for this case because `relation_to_path` returns `Parent` if
         // the paths are equal and there's nothing wrong with importing the
         // package you're in.
@@ -43,6 +185,8 @@ impl Run {
         ) {
             Ok(Some(BoundariesDiagnostic::ImportLeavesPackage {
                 import: import.to_string(),
+                resolved_import_path: resolved_import_path.to_owned(),
+                package_root: package_path.to_owned(),
                 span: source_span,
                 text: NamedSource::new(file_path.as_str(), file_content.to_string()),
             }))

--- a/crates/turborepo-lib/src/boundaries/imports.rs
+++ b/crates/turborepo-lib/src/boundaries/imports.rs
@@ -11,7 +11,7 @@ use swc_common::{comments::SingleThreadedComments, SourceFile, Span};
 use turbo_trace::ImportType;
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf, PathRelation, RelativeUnixPath};
 use turborepo_repository::{
-    package_graph::{PackageInfo, PackageKey, PackageName, PackageNode, PackageVersion},
+    package_graph::{PackageInfo, PackageName, PackageNode},
     package_json::PackageJson,
 };
 
@@ -38,7 +38,7 @@ impl Run {
         result: &mut BoundariesResult,
     ) -> Result<bool, Error> {
         let dir = file_path.parent().expect("file_path must have a parent");
-        let Some(tsconfig) = tsconfig_loader.load(dir) else {
+        let Some(tsconfig) = tsconfig_loader.load(dir, result) else {
             return Ok(false);
         };
 
@@ -81,7 +81,7 @@ impl Run {
         file_content: &str,
         package_info: &PackageInfo,
         internal_dependencies: &HashSet<&PackageNode>,
-        unresolved_external_dependencies: Option<&BTreeMap<PackageKey, PackageVersion>>,
+        unresolved_external_dependencies: Option<&BTreeMap<String, String>>,
         resolver: &Resolver,
     ) -> Result<(), Error> {
         // If the import is prefixed with `@boundaries-ignore`, we ignore it, but print

--- a/crates/turborepo-lib/src/boundaries/mod.rs
+++ b/crates/turborepo-lib/src/boundaries/mod.rs
@@ -1,6 +1,7 @@
 mod config;
 mod imports;
 mod tags;
+mod tsconfig;
 
 use std::{
     collections::{HashMap, HashSet},

--- a/crates/turborepo-lib/src/boundaries/mod.rs
+++ b/crates/turborepo-lib/src/boundaries/mod.rs
@@ -406,7 +406,7 @@ impl Run {
                     span,
                     file_path,
                     &file_content,
-                    &package_info,
+                    package_info,
                     &internal_dependencies,
                     unresolved_external_dependencies,
                     &resolver,

--- a/crates/turborepo-lib/src/boundaries/mod.rs
+++ b/crates/turborepo-lib/src/boundaries/mod.rs
@@ -110,9 +110,14 @@ pub enum BoundariesDiagnostic {
         #[source_code]
         text: NamedSource<String>,
     },
-    #[error("cannot import file `{import}` because it leaves the package")]
+    #[error("import `{import}` leaves the package")]
+    #[diagnostic(help(
+        "`{import}` resolves to path `{resolved_import_path}` which is outside of `{package_name}`"
+    ))]
     ImportLeavesPackage {
         import: String,
+        resolved_import_path: String,
+        package_name: PackageName,
         #[label("file imported here")]
         span: SourceSpan,
         #[source_code]
@@ -394,6 +399,7 @@ impl Run {
                     &mut tsconfig_loader,
                     result,
                     &source_file,
+                    package_name,
                     &package_root,
                     import,
                     import_type,

--- a/crates/turborepo-lib/src/boundaries/mod.rs
+++ b/crates/turborepo-lib/src/boundaries/mod.rs
@@ -179,15 +179,15 @@ impl BoundariesResult {
                 }
             }
         }
-        let result_message = if self.diagnostics.is_empty() {
-            color!(color_config, BOLD_GREEN, "no issues found")
-        } else {
-            color!(
+        let result_message = match self.diagnostics.len() {
+            0 => color!(color_config, BOLD_GREEN, "no issues found"),
+            1 => color!(color_config, BOLD_RED, "1 issue found"),
+            _ => color!(
                 color_config,
                 BOLD_RED,
                 "{} issues found",
                 self.diagnostics.len()
-            )
+            ),
         };
 
         for warning in self.warnings.iter().take(MAX_WARNINGS) {

--- a/crates/turborepo-lib/src/boundaries/mod.rs
+++ b/crates/turborepo-lib/src/boundaries/mod.rs
@@ -30,7 +30,10 @@ use turborepo_errors::Spanned;
 use turborepo_repository::package_graph::{PackageInfo, PackageName, PackageNode};
 use turborepo_ui::{color, ColorConfig, BOLD_GREEN, BOLD_RED};
 
-use crate::{boundaries::tags::ProcessedRulesMap, run::Run};
+use crate::{
+    boundaries::{tags::ProcessedRulesMap, tsconfig::TsConfigLoader},
+    run::Run,
+};
 
 #[derive(Clone, Debug, Error, Diagnostic)]
 pub enum SecondaryDiagnostic {
@@ -52,6 +55,8 @@ pub enum SecondaryDiagnostic {
 
 #[derive(Clone, Debug, Error, Diagnostic)]
 pub enum BoundariesDiagnostic {
+    #[error("Path `{path}` is not valid UTF-8. Turborepo only supports UTF-8 paths.")]
+    InvalidPath { path: String },
     #[error(
         "Package `{package_name}` found without any tag listed in allowlist for \
          `{source_package_name}`"
@@ -321,6 +326,7 @@ impl Run {
             Tracer::create_resolver(tsconfig_path.exists().then(|| tsconfig_path.as_ref()));
 
         let mut not_supported_extensions = HashSet::new();
+        let mut tsconfig_loader = TsConfigLoader::new(&resolver);
 
         for file_path in &files {
             if let Some(ext @ ("svelte" | "vue")) = file_path.extension() {
@@ -383,61 +389,22 @@ impl Run {
             let mut finder = ImportFinder::default();
             module.visit_with(&mut finder);
             for (import, span, import_type) in finder.imports() {
-                // If the import is prefixed with `@boundaries-ignore`, we ignore it, but print
-                // a warning
-                match Self::get_ignored_comment(&comments, *span) {
-                    Some(reason) if reason.is_empty() => {
-                        result.warnings.push(
-                            "@boundaries-ignore requires a reason, e.g. `// @boundaries-ignore \
-                             implicit dependency`"
-                                .to_string(),
-                        );
-                    }
-                    Some(_) => {
-                        // Try to get the line number for warning
-                        let line = result.source_map.lookup_line(span.lo()).map(|l| l.line);
-                        if let Ok(line) = line {
-                            result
-                                .warnings
-                                .push(format!("ignoring import on line {} in {}", line, file_path));
-                        } else {
-                            result
-                                .warnings
-                                .push(format!("ignoring import in {}", file_path));
-                        }
-
-                        continue;
-                    }
-                    None => {}
-                }
-
-                let (start, end) = result.source_map.span_to_char_offset(&source_file, *span);
-                let start = start as usize;
-                let end = end as usize;
-                let span = SourceSpan::new(start.into(), end - start);
-
-                // We have a file import
-                let check_result = if import.starts_with(".") {
-                    self.check_file_import(file_path, &package_root, import, span, &file_content)?
-                } else if Self::is_potential_package_name(import) {
-                    self.check_package_import(
-                        import,
-                        *import_type,
-                        span,
-                        file_path,
-                        &file_content,
-                        &package_info.package_json,
-                        &internal_dependencies,
-                        unresolved_external_dependencies,
-                        &resolver,
-                    )
-                } else {
-                    None
-                };
-
-                if let Some(diagnostic) = check_result {
-                    result.diagnostics.push(diagnostic);
-                }
+                self.check_import(
+                    &comments,
+                    &mut tsconfig_loader,
+                    result,
+                    &source_file,
+                    &package_root,
+                    import,
+                    import_type,
+                    span,
+                    file_path,
+                    &file_content,
+                    &package_info,
+                    &internal_dependencies,
+                    unresolved_external_dependencies,
+                    &resolver,
+                )?;
             }
         }
 

--- a/crates/turborepo-lib/src/boundaries/tsconfig.rs
+++ b/crates/turborepo-lib/src/boundaries/tsconfig.rs
@@ -3,6 +3,8 @@ use std::{collections::HashMap, sync::Arc};
 use oxc_resolver::{Resolver, TsConfigSerde};
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 
+use crate::boundaries::BoundariesResult;
+
 pub struct TsConfigLoader<'a> {
     configs: HashMap<AbsoluteSystemPathBuf, Arc<TsConfigSerde>>,
     resolver: &'a Resolver,
@@ -16,14 +18,25 @@ impl<'a> TsConfigLoader<'a> {
         }
     }
 
-    pub fn load(&mut self, path: &AbsoluteSystemPath) -> Option<Arc<TsConfigSerde>> {
+    pub fn load(
+        &mut self,
+        path: &AbsoluteSystemPath,
+        result: &mut BoundariesResult,
+    ) -> Option<Arc<TsConfigSerde>> {
         for dir in path.ancestors() {
             if let Some(config) = self.configs.get(dir) {
                 return Some(config.clone());
             }
-            if let Ok(config) = self.resolver.resolve_tsconfig(dir) {
-                self.configs.insert(dir.to_owned(), config.clone());
-                return Some(config);
+            match self.resolver.resolve_tsconfig(dir) {
+                Ok(config) => {
+                    self.configs.insert(dir.to_owned(), config.clone());
+                    return Some(config);
+                }
+                Err(err) => {
+                    result
+                        .warnings
+                        .push(format!("Could not load tsconfig for {dir}: {err}"));
+                }
             }
         }
 

--- a/crates/turborepo-lib/src/boundaries/tsconfig.rs
+++ b/crates/turborepo-lib/src/boundaries/tsconfig.rs
@@ -1,0 +1,32 @@
+use std::{collections::HashMap, sync::Arc};
+
+use oxc_resolver::{Resolver, TsConfigSerde};
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
+
+pub struct TsConfigLoader<'a> {
+    configs: HashMap<AbsoluteSystemPathBuf, Arc<TsConfigSerde>>,
+    resolver: &'a Resolver,
+}
+
+impl<'a> TsConfigLoader<'a> {
+    pub fn new(resolver: &'a Resolver) -> Self {
+        Self {
+            configs: HashMap::new(),
+            resolver,
+        }
+    }
+
+    pub fn load(&mut self, path: &AbsoluteSystemPath) -> Option<Arc<TsConfigSerde>> {
+        for dir in path.ancestors() {
+            if let Some(config) = self.configs.get(dir) {
+                return Some(config.clone());
+            }
+            if let Some(config) = self.resolver.resolve_tsconfig(&dir).ok() {
+                self.configs.insert(dir.to_owned(), config.clone());
+                return Some(config);
+            }
+        }
+
+        None
+    }
+}

--- a/crates/turborepo-lib/src/boundaries/tsconfig.rs
+++ b/crates/turborepo-lib/src/boundaries/tsconfig.rs
@@ -21,7 +21,7 @@ impl<'a> TsConfigLoader<'a> {
             if let Some(config) = self.configs.get(dir) {
                 return Some(config.clone());
             }
-            if let Some(config) = self.resolver.resolve_tsconfig(&dir).ok() {
+            if let Ok(config) = self.resolver.resolve_tsconfig(dir) {
                 self.configs.insert(dir.to_owned(), config.clone());
                 return Some(config);
             }

--- a/crates/turborepo-lib/src/query/boundaries.rs
+++ b/crates/turborepo-lib/src/query/boundaries.rs
@@ -68,6 +68,14 @@ impl From<BoundariesDiagnostic> for Diagnostic {
                 import: Some(package_name.to_string()),
                 reason: Some(tag),
             },
+            BoundariesDiagnostic::InvalidPath { path } => Diagnostic {
+                message,
+                path: Some(path),
+                start: None,
+                end: None,
+                import: None,
+                reason: None,
+            },
         }
     }
 }

--- a/crates/turborepo-lib/src/query/boundaries.rs
+++ b/crates/turborepo-lib/src/query/boundaries.rs
@@ -21,7 +21,9 @@ impl From<BoundariesDiagnostic> for Diagnostic {
                 import: Some(name.to_string()),
                 reason: None,
             },
-            BoundariesDiagnostic::ImportLeavesPackage { import, span, text } => Diagnostic {
+            BoundariesDiagnostic::ImportLeavesPackage {
+                import, span, text, ..
+            } => Diagnostic {
                 message,
                 path: Some(text.name().to_string()),
                 start: Some(span.offset()),

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -88,8 +88,8 @@ impl PackageInfo {
     }
 }
 
-type PackageKey = String;
-type PackageVersion = String;
+pub type PackageKey = String;
+pub type PackageVersion = String;
 
 // PackageName refers to a real package's name or the root package.
 // It's not the best name, because root isn't a real package, but it's

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -88,8 +88,8 @@ impl PackageInfo {
     }
 }
 
-pub type PackageKey = String;
-pub type PackageVersion = String;
+type PackageKey = String;
+type PackageVersion = String;
 
 // PackageName refers to a real package's name or the root package.
 // It's not the best name, because root isn't a real package, but it's

--- a/crates/turborepo/tests/snapshots/boundaries__boundaries_get_boundaries_lints_(npm@10.5.0).snap
+++ b/crates/turborepo/tests/snapshots/boundaries__boundaries_get_boundaries_lints_(npm@10.5.0).snap
@@ -19,6 +19,10 @@ expression: query_output
           "import": "../../packages/another/index.jsx"
         },
         {
+          "message": "cannot import file `@/../../packages/another/index.jsx` because it leaves the package",
+          "import": "@/../../packages/another/index.jsx"
+        },
+        {
           "message": "cannot import package `module-package` because it is not a dependency",
           "import": "module-package"
         },

--- a/crates/turborepo/tests/snapshots/boundaries__boundaries_get_boundaries_lints_(npm@10.5.0).snap
+++ b/crates/turborepo/tests/snapshots/boundaries__boundaries_get_boundaries_lints_(npm@10.5.0).snap
@@ -15,16 +15,20 @@ expression: query_output
           "import": "module-package"
         },
         {
-          "message": "cannot import file `../../packages/another/index.jsx` because it leaves the package",
+          "message": "cannot import package `module-package` because it is not a dependency",
+          "import": "module-package"
+        },
+        {
+          "message": "import `!` leaves the package",
+          "import": "!"
+        },
+        {
+          "message": "import `../../packages/another/index.jsx` leaves the package",
           "import": "../../packages/another/index.jsx"
         },
         {
-          "message": "cannot import file `@/../../packages/another/index.jsx` because it leaves the package",
+          "message": "import `@/../../packages/another/index.jsx` leaves the package",
           "import": "@/../../packages/another/index.jsx"
-        },
-        {
-          "message": "cannot import package `module-package` because it is not a dependency",
-          "import": "module-package"
         },
         {
           "message": "importing from a type declaration package, but import is not declared as a type-only import",

--- a/turborepo-tests/integration/fixtures/boundaries/apps/my-app/tsconfig.json
+++ b/turborepo-tests/integration/fixtures/boundaries/apps/my-app/tsconfig.json
@@ -3,7 +3,8 @@
     "paths": {
       "@/*": [
         "./*"
-      ]
+      ],
+      "!": ["../../packages/another/index.jsx"]
     }
   }
 }

--- a/turborepo-tests/integration/fixtures/boundaries/apps/my-app/types.ts
+++ b/turborepo-tests/integration/fixtures/boundaries/apps/my-app/types.ts
@@ -1,4 +1,5 @@
 import { blackbeard } from "@/../../packages/another/index.jsx";
+import { blackbead } from "!";
 
 export interface Pirate {
   ship: string;


### PR DESCRIPTION
### Description
Support tsconfig path aliases such as:

```json
{
  "compilerOptions": {
    "paths": {
      "@/*": ["./*"]
    }
  }
}
```

We check if we can resolve the import as a path alias and if so, check the resolved path

Can be reviewed commit by commit

### Testing Instructions

Turns out we already had a test for this in `turborepo-tests/integration/fixtures/boundaries/apps/my-app/types.ts`. Added another import and updated snapshot
