### PR TITLE
docs: more insightful leadin for Nx doc

### DIFF
--- a/docs/repo-docs/guides/migrating-from-nx.mdx
+++ b/docs/repo-docs/guides/migrating-from-nx.mdx
@@ -12,7 +12,7 @@ This guide will help you migrate an existing Nx repository to Turborepo.
 
 ## Why switch?
 
-There are several reasons why you might want to switch from from Nx to Turborepo.
+There are many reasons why you may be choosing to migrate from Nx to Turborepo. Below, we've listed the most common reasons that developers have referenced for their migrations.
 
 ### Ecosystem standards
 


### PR DESCRIPTION
### Description

@jamesHenry pointed out in https://github.com/vercel/turborepo/pull/10003 that the "Migrating from Nx" doc leaves room to make it sound like the "Why switch?" reasons sound like they come from the Turborepo team. Here, making sure that it's known on the page that that's not the case. These are reasons that come from Nx users looking to switch, brought together on their common themes.

Thanks, James!
