### PR TITLE
chore: change use of `map_or` to `map` and `unwrap_or` in cli helper

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1161,14 +1161,12 @@ enum PrintVersionState {
 }
 
 fn get_print_version_state() -> PrintVersionState {
-    // map_or is used here because env::var returns Result<String, ...>
-    // and we want to compare against str
-    env::var("TURBO_PRINT_VERSION_DISABLED").map_or(PrintVersionState::Enabled, |var| {
-        match var.as_str() {
+    env::var("TURBO_PRINT_VERSION_DISABLED")
+        .map(|var| match var.as_str() {
             "1" | "true" => PrintVersionState::Disabled,
             _ => PrintVersionState::Enabled,
-        }
-    })
+        })
+        .unwrap_or(PrintVersionState::Enabled)
 }
 
 #[derive(PartialEq)]


### PR DESCRIPTION
### Description

Refactor to replace `map_or` with `map` and `unwrap_or`. The separation of these two steps makes it clear in the code that the `unwrap_or` case is the default, where it was obscured by the density and argument order of `map_or` before.