### PR TITLE
docs(prune): document how prune differs from pnpm deploy

### DIFF
--- a/docs/repo-docs/reference/prune.mdx
+++ b/docs/repo-docs/reference/prune.mdx
@@ -207,3 +207,13 @@ Customize the directory the pruned output is generated in.
 Default: `true`
 
 Respect `.gitignore` file(s) when copying files to the output directory.
+
+### Comparison to `pnpm deploy`
+
+While both `turbo prune` and [`pnpm deploy`](https://pnpm.io/cli/deploy) are used to isolate packages in a monorepo, they serve different purposes and produce different outputs.
+
+Where `turbo prune` generates a partial monorepo, `pnpm deploy` generates a directory that only contains the contents of the target package.
+
+The `pnpm deploy` generated directory has a self-contained `node_modules` with hard linked internal dependencies.
+This results in a portable package that can be directly copied to a server and used without additional steps.
+The repository structure is not retained, as the focus is on producing a standalone deployable package.


### PR DESCRIPTION
### Description

I received a question about how `pnpm deploy` and `turbo prune` differ and figured I would document my findings since they both server similar purposes.

### Testing Instructions

👀 
