### PR TITLE
fix(proxy): make proxy task persistent

### DIFF
--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -666,6 +666,7 @@ impl TurboJson {
                         "{mfe_package_name}#build"
                     )))])
                 }),
+                persistent: Some(Spanned::new(true)),
                 ..Default::default()
             }),
         );


### PR DESCRIPTION
### Description

`turbo watch dev` wasn't working properly with local proxies if they were marked as `persistent` as they would be in a different run than the proxy task.

This isn't a perfect fix as we're introducing the same failure to find locally running dev tasks that *aren't* marked as persistent. 

A few possible follow ups:
 - Error on any dev tasks that aren't marked as persistent to ensure the proxy ends up in the same run as the dev tasks.
 - (Stretch): Lift requirement to have dev tasks marked as persistent, this would probably require an overhaul of either `watch` or our `Run` abstraction to "share" parts of one run with another.

### Testing Instructions

`turbo watch dev` with a microfrontend should no longer fail to find which locally running apps dev tasks
