### PR TITLE
docs: fix typo on continue docs

### DIFF
--- a/docs/repo-docs/reference/run.mdx
+++ b/docs/repo-docs/reference/run.mdx
@@ -123,7 +123,7 @@ turbo run test --concurrency=5
 
 ### `--continue <option>`
 
-Default: `none`
+Default: `never`
 
 Specify how `turbo` should handle current and pending tasks in the presence of an error (e.g. non-zero exit code from a task).
 


### PR DESCRIPTION
### Description

Fix minor oversight in #10023 when we reworded the options

### Testing Instructions

N/A