### PR TITLE
chore: fix corepack wiring in integration tests

### DIFF
--- a/turborepo-tests/helpers/setup_integration_test.sh
+++ b/turborepo-tests/helpers/setup_integration_test.sh
@@ -43,7 +43,7 @@ fi
 
 "${TURBOREPO_TESTS_DIR}/helpers/copy_fixture.sh" "${TARGET_DIR}" "${FIXTURE_NAME}" "${TURBOREPO_TESTS_DIR}/integration/fixtures"
 "${TURBOREPO_TESTS_DIR}/helpers/setup_git.sh" "${TARGET_DIR}"
-"${TURBOREPO_TESTS_DIR}/helpers/setup_package_manager.sh" "${TARGET_DIR}" "$PACKAGE_MANAGER"
+. "${TURBOREPO_TESTS_DIR}/helpers/setup_package_manager.sh" "${TARGET_DIR}" "$PACKAGE_MANAGER"
 if $INSTALL_DEPS; then
   "${TURBOREPO_TESTS_DIR}/helpers/install_deps.sh" "$PACKAGE_MANAGER"
 fi

--- a/turborepo-tests/helpers/setup_package_manager.sh
+++ b/turborepo-tests/helpers/setup_package_manager.sh
@@ -29,15 +29,16 @@ pkgManagerName="${pkgManager%%@*}"
 
 # Set the corepack install directory to a temp directory (either prysk temp or provided dir).
 # This will help isolate from the rest of the system, especially when running tests on a dev machine.
-if [ "$PRYSK_TEMP" == "" ]; then
-  COREPACK_INSTALL_DIR="$dir/corepack"
-  mkdir -p "${COREPACK_INSTALL_DIR}"
-  export PATH=${COREPACK_INSTALL_DIR}:$PATH
-else
-  COREPACK_INSTALL_DIR="${PRYSK_TEMP}/corepack"
-  mkdir -p "${COREPACK_INSTALL_DIR}"
-  export PATH=${COREPACK_INSTALL_DIR}:$PATH
+COREPACK_INSTALL_DIR="${PRYSK_TEMP:-$dir}/corepack"
+if [[ "$OSTYPE" == "msys" ]]; then
+  # Ensure it's a POSIX path so that we can use it as a PATH entry (C:\... -> /c/...)
+  COREPACK_INSTALL_DIR="$(cygpath -au "$COREPACK_INSTALL_DIR")"
+  # Ensure corepack uses lowercase .cmd extensions, consistent with node's bundled npm
+  export PATHEXT="$(echo "$PATHEXT" | tr '[:upper:]' '[:lower:]')"
 fi
+mkdir -p "${COREPACK_INSTALL_DIR}"
+export PATH=${COREPACK_INSTALL_DIR}:$PATH
+
 
 # Enable corepack so that the packageManager setting in package.json is respected.
 corepack enable $pkgManagerName "--install-directory=${COREPACK_INSTALL_DIR}"


### PR DESCRIPTION
### Description

Spun out from https://github.com/vercel/turborepo/pull/10023#issuecomment-2679724673

setup_package_manager.sh exports `PATH`, so we need to source it for the isolated corepack shims to actually get used in tests. Otherwise certain npm integration tests can fail, depending on the global npm version and if corepack's npm shims haven't been explicitly enabled globally. This can lead to false positives and wasted time debugging integration tests locally.

This hasn't been an issue under GitHub Actions, since actions/setup-node is installing the same version of npm (10.5.0) that the tests expect, but could otherwise become problematic down the road.

Fixing this uncovers two new problems around testing under Windows, which this PR also addresses:

 - the corepack path needs to be POSIX-ified, since `C:\Users\RUNNER~1\...` contains backslashes and the name separator (:)
 - corepack uses `PATHEXT` (via [cmd-extension](https://www.npmjs.com/package/cmd-extension)) to determine the casing of its shims' file extension (e.g. npm.cmd vs npm.CMD), whereas node's bundled npm.cmd is always lowercase ... while we could update all the tests to accept both styles, the easiest thing to do is just to downcase `PATHEXT`.

### Testing Instructions

Integration tests 🥳 