### PR TITLE
fix(repository): still assume files not belonging to a package result in a global change

### DIFF
--- a/crates/turborepo-repository/src/change_mapper/mod.rs
+++ b/crates/turborepo-repository/src/change_mapper/mod.rs
@@ -7,8 +7,8 @@ use std::{
 };
 
 pub use package::{
-    DefaultPackageChangeMapper, Error, GlobalDepsPackageChangeMapper, PackageChangeMapper,
-    PackageMapping,
+    DefaultPackageChangeMapper, DefaultPackageChangeMapperWithLockfile, Error,
+    GlobalDepsPackageChangeMapper, PackageChangeMapper, PackageMapping,
 };
 use tracing::debug;
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf};

--- a/packages/turbo-repository/__tests__/affected-packages.test.ts
+++ b/packages/turbo-repository/__tests__/affected-packages.test.ts
@@ -68,5 +68,28 @@ describe("affectedPackages", () => {
         workspace.affectedPackages(["pnpm-lock.yaml"], null, true)
       );
     });
+
+    it("still considers root file changes as global", async () => {
+      const dir = path.resolve(__dirname, "./fixtures/monorepo");
+      const workspace = await Workspace.find(dir);
+
+      const reduced: PackageReduced[] = (
+        await workspace.affectedPackages(
+          ["file-we-do-not-understand.txt"],
+          "HEAD",
+          true
+        )
+      ).map((pkg) => {
+        return {
+          name: pkg.name,
+          relativePath: pkg.relativePath,
+        };
+      });
+
+      assert.deepEqual(reduced, [
+        { name: "app-a", relativePath: "apps/app" },
+        { name: "ui", relativePath: "packages/ui" },
+      ]);
+    });
   });
 });

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -10,8 +10,8 @@ use tracing::debug;
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, AnchoredSystemPathBuf};
 use turborepo_repository::{
     change_mapper::{
-        ChangeMapper, DefaultPackageChangeMapper, GlobalDepsPackageChangeMapper, LockfileContents,
-        PackageChanges,
+        ChangeMapper, DefaultPackageChangeMapper, DefaultPackageChangeMapperWithLockfile,
+        LockfileContents, PackageChanges,
     },
     inference::RepoState as WorkspaceState,
     package_graph::{PackageGraph, PackageName, PackageNode, WorkspacePackage, ROOT_PKG_NAME},
@@ -246,12 +246,7 @@ impl Workspace {
         // Create a ChangeMapper with no ignore patterns
         let change_detector = comparison
             .is_some()
-            .then(|| {
-                Either::Left(
-                    GlobalDepsPackageChangeMapper::new(&self.graph, std::iter::empty::<&str>())
-                        .unwrap(),
-                )
-            })
+            .then(|| Either::Left(DefaultPackageChangeMapperWithLockfile::new(&self.graph)))
             .unwrap_or_else(|| Either::Right(DefaultPackageChangeMapper::new(&self.graph)));
         let mapper = ChangeMapper::new(&self.graph, vec![], change_detector);
 


### PR DESCRIPTION
### Description

Make sure we keep as much of the default behavior as possible.

We now have a nesting doll sorta structure for change mappers:
```
Most conservative > Least Conservative
Default > DefaultWLockfile > Global
```
