### PR TITLE
chore(spaces): remove spaces id

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -217,8 +217,5 @@
     "topo": {
       "dependsOn": ["^topo"]
     }
-  },
-  "experimentalSpaces": {
-    "id": "space_WTrAuWxqVUapGgZDX7KiZV1v"
   }
 }


### PR DESCRIPTION
### Description

After https://github.com/vercel/turborepo/pull/9961 this field is no longer used and produces a warning.

### Testing Instructions

No warning on CI about the spaces id
