### PR TITLE
fix: revert "chore: fix corepack wiring in integration tests"

### DIFF
--- a/turborepo-tests/helpers/setup_integration_test.sh
+++ b/turborepo-tests/helpers/setup_integration_test.sh
@@ -43,7 +43,7 @@ fi
 
 "${TURBOREPO_TESTS_DIR}/helpers/copy_fixture.sh" "${TARGET_DIR}" "${FIXTURE_NAME}" "${TURBOREPO_TESTS_DIR}/integration/fixtures"
 "${TURBOREPO_TESTS_DIR}/helpers/setup_git.sh" "${TARGET_DIR}"
-. "${TURBOREPO_TESTS_DIR}/helpers/setup_package_manager.sh" "${TARGET_DIR}" "$PACKAGE_MANAGER"
+"${TURBOREPO_TESTS_DIR}/helpers/setup_package_manager.sh" "${TARGET_DIR}" "$PACKAGE_MANAGER"
 if $INSTALL_DEPS; then
   "${TURBOREPO_TESTS_DIR}/helpers/install_deps.sh" "$PACKAGE_MANAGER"
 fi

--- a/turborepo-tests/helpers/setup_package_manager.sh
+++ b/turborepo-tests/helpers/setup_package_manager.sh
@@ -29,16 +29,15 @@ pkgManagerName="${pkgManager%%@*}"
 
 # Set the corepack install directory to a temp directory (either prysk temp or provided dir).
 # This will help isolate from the rest of the system, especially when running tests on a dev machine.
-COREPACK_INSTALL_DIR="${PRYSK_TEMP:-$dir}/corepack"
-if [[ "$OSTYPE" == "msys" ]]; then
-  # Ensure it's a POSIX path so that we can use it as a PATH entry (C:\... -> /c/...)
-  COREPACK_INSTALL_DIR="$(cygpath -au "$COREPACK_INSTALL_DIR")"
-  # Ensure corepack uses lowercase .cmd extensions, consistent with node's bundled npm
-  export PATHEXT="$(echo "$PATHEXT" | tr '[:upper:]' '[:lower:]')"
+if [ "$PRYSK_TEMP" == "" ]; then
+  COREPACK_INSTALL_DIR="$dir/corepack"
+  mkdir -p "${COREPACK_INSTALL_DIR}"
+  export PATH=${COREPACK_INSTALL_DIR}:$PATH
+else
+  COREPACK_INSTALL_DIR="${PRYSK_TEMP}/corepack"
+  mkdir -p "${COREPACK_INSTALL_DIR}"
+  export PATH=${COREPACK_INSTALL_DIR}:$PATH
 fi
-mkdir -p "${COREPACK_INSTALL_DIR}"
-export PATH=${COREPACK_INSTALL_DIR}:$PATH
-
 
 # Enable corepack so that the packageManager setting in package.json is respected.
 corepack enable $pkgManagerName "--install-directory=${COREPACK_INSTALL_DIR}"


### PR DESCRIPTION
Reverts vercel/turborepo#10044

This seems to be causing failures https://github.com/vercel/turborepo/actions/runs/13571078355/job/37935992392?pr=9995#step:9:1167

Failures seem to be flakey:
 [attempt 1](https://github.com/vercel/turborepo/actions/runs/13570184039/attempts/1)
 [attempt 2](https://github.com/vercel/turborepo/actions/runs/13570184039/attempts/2)