### PR TITLE
fix(packages): no longer match versionless packages

### DIFF
--- a/crates/turborepo-repository/src/package_graph/dep_splitter.rs
+++ b/crates/turborepo-repository/src/package_graph/dep_splitter.rs
@@ -170,6 +170,11 @@ impl<'a> DependencyVersion<'a> {
                 false
             }
             _ if self.version == "*" => true,
+            _ if package_version.is_empty() => {
+                // The workspace version of this package does not contain a version, no version
+                // based constraints will match it so it must be external.
+                false
+            }
             _ => {
                 // If we got this far, then we need to check the workspace package version to
                 // see it satisfies the dependencies range to determine whether


### PR DESCRIPTION
### Description

Previously we had matched version constraints on workspace packages that didn't have versions. This did not match actual package manager implementations.

To give a concrete example:
```
[0 olszewski@macbookpro] /tmp/pnpm-prune-test $ tree
.
├── node_modules
├── package.json
├── packages
│   ├── a
│   │   ├── node_modules
│   │   │   └── b -> ../../../node_modules/.pnpm/b@2.0.1/node_modules/b
│   │   └── package.json
│   └── b
│       └── package.json
├── pnpm-lock.yaml
└── pnpm-workspace.yaml
[0 olszewski@macbookpro] /tmp/pnpm-prune-test $ cat packages/a/package.json 
{"name": "a", "dependencies": {"b": "2.0.1"}}
[0 olszewski@macbookpro] /tmp/pnpm-prune-test $ cat packages/b/package.json
{"name": "b"}
[0 olszewski@macbookpro] /tmp/pnpm-prune-test $ cat pnpm-lock.yaml 
lockfileVersion: '6.0'

settings:
  autoInstallPeers: true
  excludeLinksFromLockfile: false

importers:

  .: {}

  packages/a:
    dependencies:
      b:
        specifier: 2.0.1
        version: 2.0.1

  packages/b: {}

packages:

  /b@2.0.1:
    resolution: {integrity: sha512-JBWAj6f91ocNLbdg1jCGrxHXSWbQDsxgqVmKeO0TellEcq9LCvJ97iWG6p3otCt/v08/hHrWwAB9vNYS9y70IQ==}
    engines: {node: '>= 0.8.0'}
    dev: false
```
As you can see `a` is using a `b` from the NPM registry and not the workspace package `b` that does not have a version.

### Testing Instructions

Added red -> green unit test

I spot checked and all of the following would not match a versionless workspace dependency when provided a constraint:
 - npm 8,9,10
 - yarn 1, 3, 4
 - pnpm 8, 9, 10