### PR TITLE
docs: update README.md in examples with-tailwind to correctly reference .ts config files instead of .js

### DIFF
--- a/examples/with-tailwind/README.md
+++ b/examples/with-tailwind/README.md
@@ -26,16 +26,16 @@ Each package/app is 100% [TypeScript](https://www.typescriptlang.org/).
 
 ### Building packages/ui
 
-This example is set up to produce compiled styles for `ui` components into the `dist` directory. The component `.tsx` files are consumed by the Next.js apps directly using `transpilePackages` in `next.config.js`. This was chosen for several reasons:
+This example is set up to produce compiled styles for `ui` components into the `dist` directory. The component `.tsx` files are consumed by the Next.js apps directly using `transpilePackages` in `next.config.ts`. This was chosen for several reasons:
 
-- Make sharing one `tailwind.config.js` to apps and packages as easy as possible.
+- Make sharing one `tailwind.config.ts` to apps and packages as easy as possible.
 - Make package compilation simple by only depending on the Next.js Compiler and `tailwindcss`.
 - Ensure Tailwind classes do not overwrite each other. The `ui` package uses a `ui-` prefix for it's classes.
 - Maintain clear package export boundaries.
 
-Another option is to consume `packages/ui` directly from source without building. If using this option, you will need to update the `tailwind.config.js` in your apps to be aware of your package locations, so it can find all usages of the `tailwindcss` class names for CSS compilation.
+Another option is to consume `packages/ui` directly from source without building. If using this option, you will need to update the `tailwind.config.ts` in your apps to be aware of your package locations, so it can find all usages of the `tailwindcss` class names for CSS compilation.
 
-For example, in [tailwind.config.js](packages/tailwind-config/tailwind.config.js):
+For example, in [tailwind.config.ts](packages/tailwind-config/tailwind.config.ts):
 
 ```js
   content: [


### PR DESCRIPTION
### Description

the next.config.js and tailwind.config.js are now next.config.ts and tailwind.config.ts in the tailwind repository I updated the readme of the repo to correct this




