### PR TITLE
chore(deps): update git2 to 0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2163,9 +2163,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git2"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+checksum = "3fda788993cc341f69012feba8bf45c0ba4f3291fcc08e214b4d5a7332d88aff"
 dependencies = [
  "bitflags 2.5.0",
  "libc",
@@ -2995,9 +2995,9 @@ checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.17.0+1.8.1"
+version = "0.18.0+1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+checksum = "e1a117465e7e1597e8febea8bb0c410f1c7fb93b1e1cddf34363f8390367ffec"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ dunce = "1.0.3"
 either = "1.9.0"
 futures = "0.3.26"
 futures-retry = "0.6.0"
-git2 = { version = "0.19.0", default-features = false }
+git2 = { version = "0.20.0", default-features = false }
 hex = "0.4.3"
 httpmock = { version = "0.6.8", default-features = false }
 indexmap = "1.9.2"


### PR DESCRIPTION
Reverts vercel/turborepo#10045

This was not the straw that broke the camel's back, the introduction of `turborepo-scm` to the [native library](https://github.com/vercel/turborepo/pull/9950/files#diff-74cfbd08b3cb8946fb49f42e0ec3b53a441952c2189730a2fb508026f6d23ec4R21) is what caused the native library release to fail.