### PR TITLE
chore: unify futures versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ derive_setters = "0.1.6"
 dialoguer = "0.11.0"
 dunce = "1.0.3"
 either = "1.9.0"
-futures = "0.3.26"
+futures = "0.3.30"
 futures-retry = "0.6.0"
 git2 = { version = "0.20.0", default-features = false }
 hex = "0.4.3"

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -58,7 +58,7 @@ dialoguer = { workspace = true, features = ["fuzzy-select", "password"] }
 dirs-next = "2.0.0"
 dunce = { workspace = true }
 either = { workspace = true }
-futures = "0.3.30"
+futures = { workspace = true }
 futures-core = "0.3.30"
 git2 = { workspace = true, default-features = false }
 globwalk = { version = "0.1.0", path = "../turborepo-globwalk" }

--- a/crates/turborepo-signals/Cargo.toml
+++ b/crates/turborepo-signals/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
-futures = "0.3.30"
+futures = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full", "time"] }
 


### PR DESCRIPTION
### Description

Bump `futures` version to match that of `turborepo-lib`

### Testing Instructions

Existing tests