### PR TITLE
chore(signals): lift error conversion to each command that sets up signal handler

### DIFF
--- a/crates/turborepo-lib/src/cli/error.rs
+++ b/crates/turborepo-lib/src/cli/error.rs
@@ -70,6 +70,8 @@ pub enum Error {
     Watch(#[from] watch::Error),
     #[error(transparent)]
     Opts(#[from] crate::opts::Error),
+    #[error(transparent)]
+    SignalListener(#[from] turborepo_signals::listeners::Error),
 }
 
 const MAX_CHARS_PER_TASK_LINE: usize = 100;
@@ -78,7 +80,7 @@ pub async fn print_potential_tasks(
     base: CommandBase,
     telemetry: CommandEventBuilder,
 ) -> Result<(), Error> {
-    let signal = get_signal().map_err(run::Error::from)?;
+    let signal = get_signal()?;
     let handler = SignalHandler::new(signal);
     let color_config = base.color_config;
 

--- a/crates/turborepo-lib/src/commands/boundaries.rs
+++ b/crates/turborepo-lib/src/commands/boundaries.rs
@@ -4,7 +4,7 @@ use turborepo_telemetry::events::command::CommandEventBuilder;
 use crate::{cli, commands::CommandBase, run::builder::RunBuilder};
 
 pub async fn run(base: CommandBase, telemetry: CommandEventBuilder) -> Result<i32, cli::Error> {
-    let signal = get_signal().map_err(crate::run::Error::from)?;
+    let signal = get_signal()?;
     let handler = SignalHandler::new(signal);
 
     let run = RunBuilder::new(base)?

--- a/crates/turborepo-lib/src/commands/ls.rs
+++ b/crates/turborepo-lib/src/commands/ls.rs
@@ -115,7 +115,7 @@ pub async fn run(
     telemetry: CommandEventBuilder,
     output: Option<OutputFormat>,
 ) -> Result<(), cli::Error> {
-    let signal = get_signal().map_err(crate::run::Error::from)?;
+    let signal = get_signal()?;
     let handler = SignalHandler::new(signal);
 
     let run_builder = RunBuilder::new(base)?;

--- a/crates/turborepo-lib/src/commands/query.rs
+++ b/crates/turborepo-lib/src/commands/query.rs
@@ -161,7 +161,7 @@ pub async fn run(
     variables_path: Option<&Utf8Path>,
     include_schema: bool,
 ) -> Result<i32, Error> {
-    let signal = get_signal().map_err(crate::run::Error::from)?;
+    let signal = get_signal()?;
     let handler = SignalHandler::new(signal);
 
     let run_builder = RunBuilder::new(base)?

--- a/crates/turborepo-lib/src/query/mod.rs
+++ b/crates/turborepo-lib/src/query/mod.rs
@@ -61,6 +61,8 @@ pub enum Error {
     Resolution(#[from] crate::run::scope::filter::ResolutionError),
     #[error("Failed to parse file: {0:?}")]
     Parse(swc_ecma_parser::error::Error),
+    #[error(transparent)]
+    SignalListener(#[from] turborepo_signals::listeners::Error),
 }
 
 pub struct RepositoryQuery {

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -107,6 +107,8 @@ pub enum Error {
     NonStandardTurboJsonPath(String),
     #[error("Invalid config: {0}")]
     Config(#[from] crate::config::Error),
+    #[error(transparent)]
+    SignalListener(#[from] turborepo_signals::listeners::Error),
 }
 
 impl WatchClient {
@@ -115,7 +117,7 @@ impl WatchClient {
         experimental_write_cache: bool,
         telemetry: CommandEventBuilder,
     ) -> Result<Self, Error> {
-        let signal = get_signal().map_err(crate::run::Error::from)?;
+        let signal = get_signal()?;
         let handler = SignalHandler::new(signal);
 
         if base.opts.repo_opts.root_turbo_json_path != base.repo_root.join_component(CONFIG_FILE) {


### PR DESCRIPTION
### Description

TSIA

### Testing Instructions

👀 All of these error types had existing transparent conversions from `run::Error` so this should match the current behavior if we fail to register a listener.
