### PR TITLE
docs: add explicit mention for capturing multiple .env files

### DIFF
--- a/docs/repo-docs/crafting-your-repository/using-environment-variables.mdx
+++ b/docs/repo-docs/crafting-your-repository/using-environment-variables.mdx
@@ -169,7 +169,22 @@ To do this, add the files to the [`inputs`](/repo/docs/reference/configuration#i
   "globalDependencies": [".env"], // All task hashes
   "tasks": {
     "build": {
-      "inputs": ["$TURBO_DEFAULT$", ".env", ".env.local"] // Only the `build` task hash
+      "inputs": ["$TURBO_DEFAULT$", ".env"] // Only the `build` task hash
+    }
+  }
+}
+```
+
+### Multiple `.env` files
+
+You can capture multiple `.env` files at once using a `*`.
+
+```json title="./turbo.json"
+{
+  "globalDependencies": [".env"], // All task hashes
+  "tasks": {
+    "build": {
+      "inputs": ["$TURBO_DEFAULT$", ".env*"] // Only the `build` task hash
     }
   }
 }


### PR DESCRIPTION
### Description

A user mentioned that it was annoying to write out all the various iterations of their `.env` files explicitly. Making sure to mention that you can capture them all at once with a `*`.