### PR TITLE
chore(turbo_json): remove exterior mutability from loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6468,6 +6468,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "turborepo-fixed-map"
+version = "0.1.0"
+
+[[package]]
 name = "turborepo-fs"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6611,6 +6611,7 @@ dependencies = [
  "turborepo-env",
  "turborepo-errors",
  "turborepo-filewatch",
+ "turborepo-fixed-map",
  "turborepo-fs",
  "turborepo-graph-utils",
  "turborepo-lockfiles",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ turborepo-cache = { path = "crates/turborepo-cache" }
 turborepo-ci = { path = "crates/turborepo-ci" }
 turborepo-env = { path = "crates/turborepo-env" }
 turborepo-errors = { path = "crates/turborepo-errors" }
+turborepo-fixed-map = { path = "crates/turborepo-fixed-map" }
 turborepo-fs = { path = "crates/turborepo-fs" }
 turborepo-lib = { path = "crates/turborepo-lib", default-features = false }
 turborepo-lockfiles = { path = "crates/turborepo-lockfiles" }

--- a/crates/turborepo-fixed-map/Cargo.toml
+++ b/crates/turborepo-fixed-map/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "turborepo-fixed-map"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/turborepo-fixed-map/src/lib.rs
+++ b/crates/turborepo-fixed-map/src/lib.rs
@@ -34,7 +34,7 @@ impl<K: Ord, V> FixedMap<K, V> {
 
     /// Insert a value for a key.
     ///
-    /// There is not guarentee that the provided value will be the one returned.
+    /// There is no guarentee that the provided value will be the one returned.
     pub fn insert(&self, key: &K, value: V) -> Result<&V, UnknownKey> {
         let item_index = self
             .inner

--- a/crates/turborepo-fixed-map/src/lib.rs
+++ b/crates/turborepo-fixed-map/src/lib.rs
@@ -1,0 +1,117 @@
+#![deny(clippy::all)]
+
+use std::sync::OnceLock;
+
+/// An error indicating that the key wasn't given to the constructor.
+#[derive(Debug)]
+pub struct UnknownKey;
+
+/// A FixedMap is created with every key known at the start and cannot have
+/// value removed or written over.
+#[derive(Debug)]
+pub struct FixedMap<K, V> {
+    inner: Vec<(K, OnceLock<V>)>,
+}
+
+impl<K: Ord, V> FixedMap<K, V> {
+    pub fn new(keys: impl Iterator<Item = K>) -> Self {
+        let mut inner = keys.map(|key| (key, OnceLock::new())).collect::<Vec<_>>();
+        inner.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
+        Self { inner }
+    }
+
+    pub fn from_iter(entries: impl Iterator<Item = (K, Option<V>)>) -> Self {
+        let mut inner = entries
+            .map(|(key, value)| {
+                let value_slot = OnceLock::new();
+                if let Some(value) = value {
+                    value_slot
+                        .set(value)
+                        .map_err(|_| ())
+                        .expect("nobody else has access to this lock yet");
+                }
+                (key, value_slot)
+            })
+            .collect::<Vec<_>>();
+        inner.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
+        Self { inner }
+    }
+
+    /// Get a value for a key.
+    ///
+    /// Returns `None` if key hasn't had a value inserted yet.
+    pub fn get(&self, key: &K) -> Result<Option<&V>, UnknownKey> {
+        let item_index = self
+            .inner
+            .binary_search_by(|(k, _)| k.cmp(key))
+            .map_err(|_| UnknownKey)?;
+        let (_, value) = &self.inner[item_index];
+        Ok(value.get())
+    }
+
+    /// Insert a value for a key.
+    ///
+    /// There is not guarentee that the provided value will be the one returned.
+    pub fn insert(&self, key: &K, value: V) -> Result<&V, UnknownKey> {
+        let item_index = self
+            .inner
+            .binary_search_by(|(k, _)| k.cmp(key))
+            .map_err(|_| UnknownKey)?;
+        let (_, value_slot) = &self.inner[item_index];
+        // We do not care about if this set was successful or if another call won out.
+        // The end result is that we have a value for the key.
+        let _ = value_slot.set(value);
+        Ok(value_slot
+            .get()
+            .expect("OnceLock::set will always result in a value being present in the lock"))
+    }
+}
+
+impl<K: Clone, V: Clone> Clone for FixedMap<K, V> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_get() {
+        let map: FixedMap<i32, ()> = FixedMap::new([3, 2, 1].iter().copied());
+        assert_eq!(map.get(&2).unwrap(), None);
+        assert!(map.get(&4).is_err());
+    }
+
+    #[test]
+    fn test_set() {
+        let map: FixedMap<i32, bool> = FixedMap::new([3, 2, 1].iter().copied());
+        assert!(map.insert(&4, true).is_err());
+        assert_eq!(map.insert(&2, true).unwrap(), &true);
+        assert_eq!(map.insert(&2, false).unwrap(), &true);
+    }
+
+    #[test]
+    fn test_contention() {
+        let map: FixedMap<i32, bool> = FixedMap::new([3, 2, 1].iter().copied());
+        let results: Vec<_> = std::thread::scope(|scope| {
+            let mut handles = vec![];
+            let map = &map;
+            for i in 0..16 {
+                let is_even = i % 2 == 0;
+                handles.push(scope.spawn(move || {
+                    let val = map.insert(&1, is_even).unwrap();
+                    (val, *val)
+                }));
+            }
+            handles.into_iter().map(|h| h.join().unwrap()).collect()
+        });
+
+        for (val_ref, val) in results {
+            assert_eq!(*val_ref, val, "all values should remain the same");
+        }
+    }
+}

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -133,6 +133,7 @@ turborepo-dirs = { path = "../turborepo-dirs" }
 turborepo-env = { workspace = true }
 turborepo-errors = { workspace = true }
 turborepo-filewatch = { path = "../turborepo-filewatch" }
+turborepo-fixed-map = { workspace = true }
 turborepo-fs = { path = "../turborepo-fs" }
 turborepo-graph-utils = { path = "../turborepo-graph-utils" }
 turborepo-lockfiles = { workspace = true }

--- a/crates/turborepo-lib/src/boundaries/tags.rs
+++ b/crates/turborepo-lib/src/boundaries/tags.rs
@@ -51,7 +51,7 @@ impl From<Permissions> for ProcessedPermissions {
 impl Run {
     pub(crate) fn get_package_tags(&self) -> HashMap<PackageName, Spanned<Vec<Spanned<String>>>> {
         let mut package_tags = HashMap::new();
-        let mut turbo_json_loader = self.turbo_json_loader();
+        let turbo_json_loader = self.turbo_json_loader();
         for (package, _) in self.pkg_dep_graph().packages() {
             if let Ok(TurboJson {
                 tags: Some(tags),

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -118,7 +118,7 @@ pub enum Error {
 pub struct EngineBuilder<'a> {
     repo_root: &'a AbsoluteSystemPath,
     package_graph: &'a PackageGraph,
-    turbo_json_loader: Option<TurboJsonLoader>,
+    turbo_json_loader: Option<&'a TurboJsonLoader>,
     is_single: bool,
     workspaces: Vec<PackageName>,
     tasks: Vec<Spanned<TaskName<'static>>>,
@@ -132,7 +132,7 @@ impl<'a> EngineBuilder<'a> {
     pub fn new(
         repo_root: &'a AbsoluteSystemPath,
         package_graph: &'a PackageGraph,
-        turbo_json_loader: TurboJsonLoader,
+        turbo_json_loader: &'a TurboJsonLoader,
         is_single: bool,
     ) -> Self {
         Self {
@@ -259,7 +259,7 @@ impl<'a> EngineBuilder<'a> {
                 .task_id()
                 .unwrap_or_else(|| TaskId::new(workspace.as_ref(), task.task()));
 
-            if Self::has_task_definition(&turbo_json_loader, workspace, task, &task_id)? {
+            if Self::has_task_definition(turbo_json_loader, workspace, task, &task_id)? {
                 missing_tasks.remove(task.as_inner());
 
                 // Even if a task definition was found, we _only_ want to add it as an entry
@@ -359,7 +359,7 @@ impl<'a> EngineBuilder<'a> {
             }
 
             let task_definition = self.task_definition(
-                &turbo_json_loader,
+                turbo_json_loader,
                 &task_id,
                 &task_id.as_non_workspace_task_name(),
             )?;
@@ -783,12 +783,12 @@ mod test {
         ]
         .into_iter()
         .collect();
-        let mut loader = TurboJsonLoader::noop(turbo_jsons);
+        let loader = TurboJsonLoader::noop(turbo_jsons);
         let task_name = TaskName::from(task_name);
         let task_id = TaskId::try_from(task_id).unwrap();
 
         let has_def =
-            EngineBuilder::has_task_definition(&mut loader, &workspace, &task_name, &task_id)
+            EngineBuilder::has_task_definition(&loader, &workspace, &task_name, &task_id)
                 .unwrap();
         assert_eq!(has_def, expected);
     }
@@ -854,7 +854,7 @@ mod test {
         .into_iter()
         .collect();
         let loader = TurboJsonLoader::noop(turbo_jsons);
-        let engine = EngineBuilder::new(&repo_root, &package_graph, loader, false)
+        let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
             .with_tasks(Some(Spanned::new(TaskName::from("test"))))
             .with_workspaces(vec![
                 PackageName::from("a"),
@@ -911,7 +911,7 @@ mod test {
         .into_iter()
         .collect();
         let loader = TurboJsonLoader::noop(turbo_jsons);
-        let engine = EngineBuilder::new(&repo_root, &package_graph, loader, false)
+        let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
             .with_tasks(Some(Spanned::new(TaskName::from("test"))))
             .with_workspaces(vec![PackageName::from("app2")])
             .build()
@@ -950,7 +950,7 @@ mod test {
         .into_iter()
         .collect();
         let loader = TurboJsonLoader::noop(turbo_jsons);
-        let engine = EngineBuilder::new(&repo_root, &package_graph, loader, false)
+        let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
             .with_tasks(Some(Spanned::new(TaskName::from("special"))))
             .with_workspaces(vec![PackageName::from("app1"), PackageName::from("libA")])
             .build()
@@ -988,7 +988,7 @@ mod test {
         .into_iter()
         .collect();
         let loader = TurboJsonLoader::noop(turbo_jsons);
-        let engine = EngineBuilder::new(&repo_root, &package_graph, loader, false)
+        let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
             .with_tasks(vec![
                 Spanned::new(TaskName::from("build")),
                 Spanned::new(TaskName::from("test")),
@@ -1041,7 +1041,7 @@ mod test {
         .into_iter()
         .collect();
         let loader = TurboJsonLoader::noop(turbo_jsons);
-        let engine = EngineBuilder::new(&repo_root, &package_graph, loader, false)
+        let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
             .with_tasks(Some(Spanned::new(TaskName::from("build"))))
             .with_workspaces(vec![PackageName::from("app1")])
             .with_root_tasks(vec![
@@ -1084,7 +1084,7 @@ mod test {
         .into_iter()
         .collect();
         let loader = TurboJsonLoader::noop(turbo_jsons);
-        let engine = EngineBuilder::new(&repo_root, &package_graph, loader, false)
+        let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
             .with_tasks(Some(Spanned::new(TaskName::from("build"))))
             .with_workspaces(vec![PackageName::from("app1")])
             .with_root_tasks(vec![TaskName::from("libA#build"), TaskName::from("build")])
@@ -1119,7 +1119,7 @@ mod test {
         .into_iter()
         .collect();
         let loader = TurboJsonLoader::noop(turbo_jsons);
-        let engine = EngineBuilder::new(&repo_root, &package_graph, loader, false)
+        let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
             .with_tasks(Some(Spanned::new(TaskName::from("build"))))
             .with_workspaces(vec![PackageName::from("app1")])
             .with_root_tasks(vec![
@@ -1164,7 +1164,7 @@ mod test {
         .into_iter()
         .collect();
         let loader = TurboJsonLoader::noop(turbo_jsons);
-        let engine = EngineBuilder::new(&repo_root, &package_graph, loader, false)
+        let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
             .with_tasks(Some(Spanned::new(TaskName::from("build"))))
             .with_workspaces(vec![PackageName::from("app1")])
             .with_root_tasks(vec![
@@ -1203,7 +1203,7 @@ mod test {
         .into_iter()
         .collect();
         let loader = TurboJsonLoader::noop(turbo_jsons);
-        let engine = EngineBuilder::new(&repo_root, &package_graph, loader, false)
+        let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
             .with_tasks_only(true)
             .with_tasks(Some(Spanned::new(TaskName::from("test"))))
             .with_workspaces(vec![
@@ -1250,7 +1250,7 @@ mod test {
         .into_iter()
         .collect();
         let loader = TurboJsonLoader::noop(turbo_jsons);
-        let engine = EngineBuilder::new(&repo_root, &package_graph, loader, false)
+        let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
             .with_tasks_only(true)
             .with_tasks(Some(Spanned::new(TaskName::from("build"))))
             .with_workspaces(vec![PackageName::from("b")])
@@ -1289,7 +1289,7 @@ mod test {
         .into_iter()
         .collect();
         let loader = TurboJsonLoader::noop(turbo_jsons);
-        let engine = EngineBuilder::new(&repo_root, &package_graph, loader, false)
+        let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
             .with_tasks_only(true)
             .with_tasks(Some(Spanned::new(TaskName::from("build"))))
             .with_workspaces(vec![PackageName::from("b")])
@@ -1357,7 +1357,7 @@ mod test {
         .into_iter()
         .collect();
         let loader = TurboJsonLoader::noop(turbo_jsons);
-        let engine = EngineBuilder::new(&repo_root, &package_graph, loader, false)
+        let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
             .with_tasks(vec![
                 Spanned::new(TaskName::from("app1#special")),
                 Spanned::new(TaskName::from("app2#another")),
@@ -1399,7 +1399,7 @@ mod test {
         .into_iter()
         .collect();
         let loader = TurboJsonLoader::noop(turbo_jsons);
-        let engine = EngineBuilder::new(&repo_root, &package_graph, loader, false)
+        let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
             .with_tasks(Some(Spanned::new(TaskName::from("dev"))))
             .with_workspaces(vec![PackageName::from("web")])
             .build()
@@ -1446,7 +1446,7 @@ mod test {
         .into_iter()
         .collect();
         let loader = TurboJsonLoader::noop(turbo_jsons);
-        let engine = EngineBuilder::new(&repo_root, &package_graph, loader.clone(), false)
+        let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
             .with_tasks(vec![Spanned::new(TaskName::from("app1#special"))])
             .with_workspaces(vec![PackageName::from("app1")])
             .build();
@@ -1458,7 +1458,7 @@ mod test {
             .unwrap();
         assert_json_snapshot!(msg);
 
-        let engine = EngineBuilder::new(&repo_root, &package_graph, loader, false)
+        let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
             .with_tasks(vec![Spanned::new(TaskName::from("app1#another"))])
             .with_workspaces(vec![PackageName::from("libA")])
             .build();
@@ -1494,7 +1494,7 @@ mod test {
         .into_iter()
         .collect();
         let loader = TurboJsonLoader::noop(turbo_jsons);
-        let engine = EngineBuilder::new(&repo_root, &package_graph, loader.clone(), false)
+        let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
             .with_tasks(vec![Spanned::new(TaskName::from("app2#bad-task"))])
             .with_workspaces(vec![PackageName::from("app1"), PackageName::from("libA")])
             .build();

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -218,7 +218,7 @@ impl<'a> EngineBuilder<'a> {
             return Ok(Engine::default().seal());
         }
 
-        let mut turbo_json_loader = self
+        let turbo_json_loader = self
             .turbo_json_loader
             .take()
             .expect("engine builder cannot be constructed without TurboJsonLoader");
@@ -259,7 +259,7 @@ impl<'a> EngineBuilder<'a> {
                 .task_id()
                 .unwrap_or_else(|| TaskId::new(workspace.as_ref(), task.task()));
 
-            if Self::has_task_definition(&mut turbo_json_loader, workspace, task, &task_id)? {
+            if Self::has_task_definition(&turbo_json_loader, workspace, task, &task_id)? {
                 missing_tasks.remove(task.as_inner());
 
                 // Even if a task definition was found, we _only_ want to add it as an entry
@@ -359,7 +359,7 @@ impl<'a> EngineBuilder<'a> {
             }
 
             let task_definition = self.task_definition(
-                &mut turbo_json_loader,
+                &turbo_json_loader,
                 &task_id,
                 &task_id.as_non_workspace_task_name(),
             )?;
@@ -465,7 +465,7 @@ impl<'a> EngineBuilder<'a> {
     // Helper methods used when building the engine
 
     fn has_task_definition(
-        loader: &mut TurboJsonLoader,
+        loader: &TurboJsonLoader,
         workspace: &PackageName,
         task_name: &TaskName<'static>,
         task_id: &TaskId,
@@ -510,7 +510,7 @@ impl<'a> EngineBuilder<'a> {
 
     fn task_definition(
         &self,
-        turbo_json_loader: &mut TurboJsonLoader,
+        turbo_json_loader: &TurboJsonLoader,
         task_id: &Spanned<TaskId>,
         task_name: &TaskName,
     ) -> Result<TaskDefinition, Error> {
@@ -525,7 +525,7 @@ impl<'a> EngineBuilder<'a> {
 
     fn task_definition_chain(
         &self,
-        turbo_json_loader: &mut TurboJsonLoader,
+        turbo_json_loader: &TurboJsonLoader,
         task_id: &Spanned<TaskId>,
         task_name: &TaskName,
     ) -> Result<Vec<RawTaskDefinition>, Error> {

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -788,8 +788,7 @@ mod test {
         let task_id = TaskId::try_from(task_id).unwrap();
 
         let has_def =
-            EngineBuilder::has_task_definition(&loader, &workspace, &task_name, &task_id)
-                .unwrap();
+            EngineBuilder::has_task_definition(&loader, &workspace, &task_name, &task_id).unwrap();
         assert_eq!(has_def, expected);
     }
 

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -383,7 +383,7 @@ impl RunBuilder {
         let task_access = TaskAccess::new(self.repo_root.clone(), async_cache.clone(), &scm);
         task_access.restore_config().await;
 
-        let mut turbo_json_loader = if task_access.is_enabled() {
+        let turbo_json_loader = if task_access.is_enabled() {
             TurboJsonLoader::task_access(
                 self.repo_root.clone(),
                 self.opts.repo_opts.root_turbo_json_path.clone(),

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -436,7 +436,7 @@ impl RunBuilder {
             &pkg_dep_graph,
             &root_turbo_json,
             filtered_pkgs.keys(),
-            turbo_json_loader.clone(),
+            &turbo_json_loader,
         )?;
 
         if self.opts.run_opts.parallel {
@@ -445,7 +445,7 @@ impl RunBuilder {
                 &pkg_dep_graph,
                 &root_turbo_json,
                 filtered_pkgs.keys(),
-                turbo_json_loader.clone(),
+                &turbo_json_loader,
             )?;
         }
 
@@ -497,7 +497,7 @@ impl RunBuilder {
         pkg_dep_graph: &PackageGraph,
         root_turbo_json: &TurboJson,
         filtered_pkgs: impl Iterator<Item = &'a PackageName>,
-        turbo_json_loader: TurboJsonLoader,
+        turbo_json_loader: &TurboJsonLoader,
     ) -> Result<Engine, Error> {
         let tasks = self.opts.run_opts.tasks.iter().map(|task| {
             // TODO: Pull span info from command

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -124,8 +124,8 @@ impl Run {
         }
     }
 
-    pub fn turbo_json_loader(&self) -> TurboJsonLoader {
-        self.turbo_json_loader.clone()
+    pub fn turbo_json_loader(&self) -> &TurboJsonLoader {
+        &self.turbo_json_loader
     }
 
     pub fn opts(&self) -> &Opts {

--- a/crates/turborepo-lib/src/turbo_json/loader.rs
+++ b/crates/turborepo-lib/src/turbo_json/loader.rs
@@ -158,7 +158,7 @@ impl TurboJsonLoader {
     }
 
     /// Load a turbo.json for a given package
-    pub fn load<'a>(&'a mut self, package: &PackageName) -> Result<&'a TurboJson, Error> {
+    pub fn load<'a>(&'a self, package: &PackageName) -> Result<&'a TurboJson, Error> {
         if let Ok(Some(turbo_json)) = self.cache.get(package) {
             return Ok(turbo_json);
         }
@@ -428,7 +428,7 @@ mod test {
         let repo_root = AbsoluteSystemPath::from_std_path(root_dir.path())?;
         let root_turbo_json = repo_root.join_component("turbo.json");
         fs::write(&root_turbo_json, turbo_json_content)?;
-        let mut loader = TurboJsonLoader {
+        let loader = TurboJsonLoader {
             repo_root: repo_root.to_owned(),
             cache: FixedMap::new(Some(PackageName::Root).into_iter()),
             strategy: Strategy::Workspace {
@@ -509,7 +509,7 @@ mod test {
             fs::write(&root_turbo_json, content)?;
         }
 
-        let mut loader = TurboJsonLoader::single_package(
+        let loader = TurboJsonLoader::single_package(
             repo_root.to_owned(),
             root_turbo_json,
             root_package_json,
@@ -571,7 +571,7 @@ mod test {
             ..Default::default()
         };
 
-        let mut loader =
+        let loader =
             TurboJsonLoader::task_access(repo_root.to_owned(), root_turbo_json, root_package_json);
         let turbo_json = loader.load(&PackageName::Root)?;
         let root_build = turbo_json
@@ -608,7 +608,7 @@ mod test {
             PackageJson::default(),
         );
 
-        for mut loader in [single_loader, task_access_loader] {
+        for loader in [single_loader, task_access_loader] {
             let result = loader.load(&non_root);
             assert!(result.is_err());
             let err = result.unwrap_err();
@@ -629,7 +629,7 @@ mod test {
             .into_iter()
             .collect();
 
-        let mut loader = TurboJsonLoader {
+        let loader = TurboJsonLoader {
             repo_root: repo_root.to_owned(),
             cache: FixedMap::new(vec![PackageName::Root, PackageName::from("a")].into_iter()),
             strategy: Strategy::Workspace {
@@ -661,7 +661,7 @@ mod test {
             .into_iter()
             .collect();
 
-        let mut loader = TurboJsonLoader {
+        let loader = TurboJsonLoader {
             repo_root: repo_root.to_owned(),
             cache: FixedMap::new(vec![PackageName::Root, PackageName::from("a")].into_iter()),
             strategy: Strategy::Workspace {
@@ -696,7 +696,7 @@ mod test {
         .into_iter()
         .collect();
 
-        let mut loader = TurboJsonLoader {
+        let loader = TurboJsonLoader {
             repo_root: repo_root.to_owned(),
             cache: FixedMap::new(vec![PackageName::Root, PackageName::from("pkg-a")].into_iter()),
             strategy: Strategy::WorkspaceNoTurboJson {
@@ -776,7 +776,7 @@ mod test {
         )
         .unwrap();
 
-        let mut loader = TurboJsonLoader {
+        let loader = TurboJsonLoader {
             repo_root: repo_root.to_owned(),
             cache: FixedMap::new(
                 vec![

--- a/crates/turborepo-lib/src/turbo_json/loader.rs
+++ b/crates/turborepo-lib/src/turbo_json/loader.rs
@@ -168,7 +168,7 @@ impl TurboJsonLoader {
             .map_err(|_| Error::NoTurboJSON)
     }
 
-    pub fn uncached_load(&self, package: &PackageName) -> Result<TurboJson, Error> {
+    fn uncached_load(&self, package: &PackageName) -> Result<TurboJson, Error> {
         match &self.strategy {
             Strategy::SinglePackage {
                 package_json,


### PR DESCRIPTION
### Description

`TurboJsonLoader::load` only took a mutable self reference because we were using `HashMap` to cache the results. This PR changes the data type we use to cache results and removes the exterior mutability.

We move to use a `FixedMap` which has the following properties:
 - Only works with the keys provided at construction
 - Append only
 - Thread safe

I went with this just because the implementation is straightforward and matches our use case since we know all of the possible places a `turbo.json` will be before we start loading them.

Future work can be reworking boundaries code to no longer eagerly load all of the `turbo.json`s at the start of execution.

### Testing Instructions

Existing test suite. Additional unit tests for `FixedMap`