### PR TITLE
chore(scm): gate git2 behind feature flag

### DIFF
--- a/crates/turborepo-filewatch/Cargo.toml
+++ b/crates/turborepo-filewatch/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { workspace = true, features = ["full", "time"] }
 tracing = "0.1.37"
 turbopath = { workspace = true }
 turborepo-repository = { version = "0.1.0", path = "../turborepo-repository" }
-turborepo-scm = { workspace = true }
+turborepo-scm = { workspace = true, features = ["git2"] }
 walkdir = "2.3.3"
 wax = { workspace = true }
 

--- a/crates/turborepo-filewatch/src/hash_watcher.rs
+++ b/crates/turborepo-filewatch/src/hash_watcher.rs
@@ -17,10 +17,7 @@ use tokio::{
 use tracing::{debug, trace};
 use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPath, AnchoredSystemPathBuf};
 use turborepo_repository::discovery::DiscoveryResponse;
-use turborepo_scm::{
-    package_deps::{GitHashes, INPUT_INCLUDE_DEFAULT_FILES},
-    Error as SCMError, SCM,
-};
+use turborepo_scm::{package_deps::INPUT_INCLUDE_DEFAULT_FILES, Error as SCMError, GitHashes, SCM};
 
 use crate::{
     debouncer::Debouncer,
@@ -691,7 +688,7 @@ mod tests {
     use turbopath::{
         AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf, RelativeUnixPathBuf,
     };
-    use turborepo_scm::{package_deps::GitHashes, SCM};
+    use turborepo_scm::{GitHashes, SCM};
 
     use super::{FileHashes, HashState};
     use crate::{

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -138,7 +138,7 @@ turborepo-graph-utils = { path = "../turborepo-graph-utils" }
 turborepo-lockfiles = { workspace = true }
 turborepo-microfrontends = { workspace = true }
 turborepo-repository = { path = "../turborepo-repository" }
-turborepo-scm = { workspace = true }
+turborepo-scm = { workspace = true, features = ["git2"] }
 turborepo-signals = { workspace = true }
 turborepo-telemetry = { path = "../turborepo-telemetry" }
 turborepo-ui = { workspace = true }

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -19,7 +19,7 @@ use turborepo_repository::{
     package_graph::{PackageGraph, PackageGraphBuilder, PackageName, WorkspacePackage},
     package_json::PackageJson,
 };
-use turborepo_scm::package_deps::GitHashes;
+use turborepo_scm::GitHashes;
 
 use crate::turbo_json::{TurboJson, TurboJsonLoader, CONFIG_FILE};
 

--- a/crates/turborepo-scm/Cargo.toml
+++ b/crates/turborepo-scm/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 bstr = "1.4.0"
-git2 = { workspace = true, default-features = false }
+git2 = { workspace = true, default-features = false, optional = true }
 globwalk = { path = "../turborepo-globwalk" }
 hex = { workspace = true }
 ignore = "0.4.20"
@@ -28,5 +28,9 @@ wax = { workspace = true }
 which = { workspace = true }
 
 [dev-dependencies]
+git2 = { workspace = true, default-features = false }
 tempfile = { workspace = true }
 test-case = "3.1.0"
+
+[features]
+git2 = ["dep:git2"]

--- a/crates/turborepo-scm/src/hash_object.rs
+++ b/crates/turborepo-scm/src/hash_object.rs
@@ -1,7 +1,8 @@
+#![cfg(feature = "git2")]
 use tracing::Span;
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf, RelativeUnixPathBuf};
 
-use crate::{package_deps::GitHashes, Error};
+use crate::{Error, GitHashes};
 
 #[tracing::instrument(skip(git_root, hashes, to_hash))]
 pub(crate) fn hash_objects(
@@ -49,7 +50,7 @@ mod test {
     use turbopath::{AbsoluteSystemPathBuf, RelativeUnixPathBuf, RelativeUnixPathBufTestExt};
 
     use super::hash_objects;
-    use crate::{find_git_root, package_deps::GitHashes};
+    use crate::{find_git_root, GitHashes};
 
     #[test]
     fn test_read_object_hashes() {

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -9,6 +9,7 @@
 
 use std::{
     backtrace::{self, Backtrace},
+    collections::HashMap,
     io::Read,
     process::{Child, Command},
 };
@@ -27,6 +28,7 @@ mod status;
 
 #[derive(Debug, Error)]
 pub enum Error {
+    #[cfg(feature = "git2")]
     #[error("Git error on {1}: {0}")]
     Git2(
         #[source] git2::Error,
@@ -65,6 +67,8 @@ pub enum Error {
     UnableToResolveRef,
 }
 
+pub type GitHashes = HashMap<RelativeUnixPathBuf, String>;
+
 impl From<wax::BuildError> for Error {
     fn from(value: wax::BuildError) -> Self {
         Error::Glob(Box::new(value), Backtrace::capture())
@@ -76,6 +80,7 @@ impl Error {
         Error::Git(s.into(), Backtrace::capture())
     }
 
+    #[cfg(feature = "git2")]
     pub(crate) fn git2_error_context(error: git2::Error, error_context: String) -> Self {
         Error::Git2(error, error_context, Backtrace::capture())
     }

--- a/crates/turborepo-scm/src/ls_tree.rs
+++ b/crates/turborepo-scm/src/ls_tree.rs
@@ -6,7 +6,7 @@ use std::{
 use nom::Finish;
 use turbopath::{AbsoluteSystemPathBuf, RelativeUnixPathBuf};
 
-use crate::{package_deps::GitHashes, wait_for_success, Error, Git};
+use crate::{wait_for_success, Error, Git, GitHashes};
 
 impl Git {
     #[tracing::instrument(skip(self))]
@@ -82,7 +82,7 @@ mod tests {
 
     use turbopath::RelativeUnixPathBuf;
 
-    use crate::{ls_tree::read_ls_tree, package_deps::GitHashes};
+    use crate::{ls_tree::read_ls_tree, GitHashes};
 
     fn to_hash_map(pairs: &[(&str, &str)]) -> GitHashes {
         HashMap::from_iter(

--- a/crates/turborepo-scm/src/manual.rs
+++ b/crates/turborepo-scm/src/manual.rs
@@ -7,7 +7,7 @@ use sha1::{Digest, Sha1};
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, IntoUnix};
 use wax::{any, Glob, Program};
 
-use crate::{package_deps::GitHashes, Error};
+use crate::{Error, GitHashes};
 
 fn git_like_hash_file(path: &AbsoluteSystemPath) -> Result<String, Error> {
     let mut hasher = Sha1::new();

--- a/crates/turborepo-scm/src/package_deps.rs
+++ b/crates/turborepo-scm/src/package_deps.rs
@@ -1,13 +1,14 @@
-use std::{collections::HashMap, str::FromStr};
+#![cfg(feature = "git2")]
+use std::str::FromStr;
 
 use globwalk::ValidatedGlob;
 use tracing::debug;
-use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, PathError, RelativeUnixPathBuf};
+use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, PathError};
 use turborepo_telemetry::events::task::{FileHashMethod, PackageTaskEventBuilder};
 
-use crate::{hash_object::hash_objects, Error, Git, SCM};
-
-pub type GitHashes = HashMap<RelativeUnixPathBuf, String>;
+#[cfg(feature = "git2")]
+use crate::hash_object::hash_objects;
+use crate::{Error, Git, GitHashes, SCM};
 
 pub const INPUT_INCLUDE_DEFAULT_FILES: &str = "$TURBO_DEFAULT$";
 
@@ -291,9 +292,9 @@ impl Git {
 
 #[cfg(test)]
 mod tests {
-    use std::{assert_matches::assert_matches, process::Command};
+    use std::{assert_matches::assert_matches, collections::HashMap, process::Command};
 
-    use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
+    use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPathBuf, RelativeUnixPathBuf};
 
     use super::*;
     use crate::manual::get_package_file_hashes_without_git;

--- a/crates/turborepo-scm/src/status.rs
+++ b/crates/turborepo-scm/src/status.rs
@@ -1,3 +1,6 @@
+// This module does not require git2, but is only used by modules that require
+// git2
+#![cfg(feature = "git2")]
 use std::{
     io::{BufRead, BufReader, Read},
     process::{Command, Stdio},
@@ -6,7 +9,7 @@ use std::{
 use nom::Finish;
 use turbopath::{AbsoluteSystemPath, RelativeUnixPathBuf};
 
-use crate::{package_deps::GitHashes, wait_for_success, Error, Git};
+use crate::{wait_for_success, Error, Git, GitHashes};
 
 impl Git {
     #[tracing::instrument(skip(self, root_path, hashes))]
@@ -111,7 +114,7 @@ mod tests {
     use turbopath::{AbsoluteSystemPathBuf, RelativeUnixPathBuf, RelativeUnixPathBufTestExt};
 
     use super::read_status;
-    use crate::package_deps::GitHashes;
+    use crate::GitHashes;
 
     #[test]
     fn test_status() {


### PR DESCRIPTION
### Description

We're having failures when trying to cross compile `git2` for the library. This PR gates the `turborepo-scm` functionality that requires `git2` behind a feature flag so the library can depend on the crate without building `git2`.

### Testing Instructions

Existing test suite passes. [Dry run](https://github.com/vercel/turborepo/actions/runs/13639486544/job/38125884886#step:7:347) of library release built
