### PR TITLE
fix(release): manually install target toolchain

### DIFF
--- a/packages/turbo-repository/scripts/build.sh
+++ b/packages/turbo-repository/scripts/build.sh
@@ -13,7 +13,7 @@ script_provided_flags="\
 for flag in $user_provided_flags; do
   if [[ $flag == --target=* ]]; then
     target=${flag#*=}
-    rustup target add "$target"
+    rustup toolchain install stable --target "$target"
 
     # For we need to cross-compile some targets with Zig
     # Fortunately, napi comes with a `--zig` flag
@@ -23,7 +23,7 @@ for flag in $user_provided_flags; do
   fi
 done
 
-node_modules/.bin/napi build $script_provided_flags $user_provided_flags
+node_modules/.bin/napi build "$script_provided_flags" "$user_provided_flags"
 
 # Unfortunately, when napi generates a .d.ts file, it doesn't match our formatting rules (it doesn't have semicolons).
 # Since there's now way to configure this from napi itself, so we need to run prettier on it after generating it.

--- a/packages/turbo-repository/scripts/build.sh
+++ b/packages/turbo-repository/scripts/build.sh
@@ -13,7 +13,7 @@ script_provided_flags="\
 for flag in $user_provided_flags; do
   if [[ $flag == --target=* ]]; then
     target=${flag#*=}
-    rustup toolchain install stable --target "$target"
+    rustup toolchain install nightly-2024-11-22 --target "$target"
 
     # For we need to cross-compile some targets with Zig
     # Fortunately, napi comes with a `--zig` flag
@@ -23,7 +23,7 @@ for flag in $user_provided_flags; do
   fi
 done
 
-node_modules/.bin/napi build "$script_provided_flags" "$user_provided_flags"
+node_modules/.bin/napi build $script_provided_flags $user_provided_flags
 
 # Unfortunately, when napi generates a .d.ts file, it doesn't match our formatting rules (it doesn't have semicolons).
 # Since there's now way to configure this from napi itself, so we need to run prettier on it after generating it.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,5 @@
 [toolchain]
+# Needs to be copied to `packages/turbo-repository/scripts/build.sh`
 channel = "nightly-2024-11-22"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
### Description

We discovered that Rust 1.28 release requires us to manually install the toolchain, not just the target.  This command should install both and ensure compatibility.

### Testing Instructions

Running the Turbo Repository Library Release workflow.