### PR TITLE
chore(release): add back gnu builds

### DIFF
--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -24,6 +24,30 @@ jobs:
             target: x86_64-apple-darwin
 
           - host: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            setup: |
+              sudo apt update
+              sudo apt install -y g++-aarch64-linux-gnu libc6-dev-arm64-cross xz-utils
+              mkdir zig
+              curl --show-error --location https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3028+cdc9d65b0.tar.xz | tar -J -xf - -C zig --strip-components 1
+              export PATH=$PATH:$(pwd)/zig
+              echo "$(pwd)/zig" >> $GITHUB_PATH
+
+          - host: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            container: amazon/aws-lambda-nodejs:20
+            install: |
+              microdnf install -y gcc gcc-c++ git tar xz
+              curl https://sh.rustup.rs -sSf | bash -s -- -y
+              npm i -g pnpm@8.9.0
+              mkdir ../zig
+              curl --show-error --location https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.3028+cdc9d65b0.tar.xz | tar -J -xf - -C ../zig --strip-components 1
+              export PATH=$PATH:$(pwd)/../zig
+              echo "$(pwd)/../zig" >> $GITHUB_PATH
+            setup: |
+              pnpm install
+
+          - host: ubuntu-latest
             target: x86_64-unknown-linux-musl
             container: ghcr.io/napi-rs/napi-rs/nodejs-rust:stable-2023-09-17-alpine
             install: |
@@ -126,7 +150,9 @@ jobs:
         run: |
           mv native-packages/turbo-library-aarch64-apple-darwin/@turbo/repository.darwin-arm64.node packages/turbo-repository/npm/darwin-arm64/
           mv native-packages/turbo-library-x86_64-apple-darwin/@turbo/repository.darwin-x64.node packages/turbo-repository/npm/darwin-x64/
+          mv native-packages/turbo-library-aarch64-unknown-linux-gnu/@turbo/repository.linux-arm64-gnu.node packages/turbo-repository/npm/linux-arm64-gnu/
           mv native-packages/turbo-library-aarch64-unknown-linux-musl/@turbo/repository.linux-arm64-musl.node packages/turbo-repository/npm/linux-arm64-musl/
+          mv native-packages/turbo-library-x86_64-unknown-linux-gnu/@turbo/repository.linux-x64-gnu.node packages/turbo-repository/npm/linux-x64-gnu/
           mv native-packages/turbo-library-x86_64-unknown-linux-musl/@turbo/repository.linux-x64-musl.node packages/turbo-repository/npm/linux-x64-musl/
           mv native-packages/turbo-library-aarch64-pc-windows-msvc/@turbo/repository.win32-arm64-msvc.node packages/turbo-repository/npm/win32-arm64-msvc/
           mv native-packages/turbo-library-x86_64-pc-windows-msvc/@turbo/repository.win32-x64-msvc.node packages/turbo-repository/npm/win32-x64-msvc/
@@ -141,7 +167,9 @@ jobs:
           mkdir tarballs
           npm pack packages/turbo-repository/npm/darwin-arm64
           npm pack packages/turbo-repository/npm/darwin-x64
+          npm pack packages/turbo-repository/npm/linux-arm64-gnu
           npm pack packages/turbo-repository/npm/linux-arm64-musl
+          npm pack packages/turbo-repository/npm/linux-x64-gnu
           npm pack packages/turbo-repository/npm/linux-x64-musl
           npm pack packages/turbo-repository/npm/win32-arm64-msvc
           npm pack packages/turbo-repository/npm/win32-x64-msvc
@@ -166,7 +194,9 @@ jobs:
           TAG="canary"
           npm publish -ddd --tag ${TAG} --access public turbo-repository-darwin-arm64-${VERSION}.tgz
           npm publish -ddd --tag ${TAG} --access public turbo-repository-darwin-x64-${VERSION}.tgz
+          npm publish -ddd --tag ${TAG} --access public turbo-repository-linux-arm64-gnu-${VERSION}.tgz
           npm publish -ddd --tag ${TAG} --access public turbo-repository-linux-arm64-musl-${VERSION}.tgz
+          npm publish -ddd --tag ${TAG} --access public turbo-repository-linux-x64-gnu-${VERSION}.tgz
           npm publish -ddd --tag ${TAG} --access public turbo-repository-linux-x64-musl-${VERSION}.tgz
           npm publish -ddd --tag ${TAG} --access public turbo-repository-win32-arm64-msvc-${VERSION}.tgz
           npm publish -ddd --tag ${TAG} --access public turbo-repository-win32-x64-msvc-${VERSION}.tgz

--- a/.github/workflows/turborepo-native-lib-test.yml
+++ b/.github/workflows/turborepo-native-lib-test.yml
@@ -22,7 +22,6 @@ jobs:
         os:
           - name: ubuntu
             runner: ubuntu-latest
-            target: x86_64-unknown-linux-musl
           - name: macos
             runner: macos-latest
         node-version:
@@ -51,31 +50,12 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           node-version: ${{ matrix.node-version }}
 
-      # If we're on Linux we need to force musl as that's what napi uses to decide the target
-      - name: Setup compile target
-        if: ${{ matrix.os.target != '' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential clang lldb llvm libclang-dev curl musl-tools
-          rustup show active-toolchain
-          rustup target add ${{ matrix.os.target }}
-
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo
 
       - name: Run tests
-        if: ${{ matrix.os.target == '' }}
         # Manually set TURBO_API to an empty string to override Hetzner env
         run: |
-          turbo run test --filter "turborepo-repository" --color
+          TURBO_API= turbo run test --filter "turborepo-repository" --color --env-mode=strict
         env:
           NODE_VERSION: ${{ matrix.node-version }}
-
-      - name: Run tests
-        if: ${{ matrix.os.target != '' }}
-        # Manually set TURBO_API to an empty string to override Hetzner env
-        run: |
-          turbo run test --filter "turborepo-repository" --color
-        env:
-          NODE_VERSION: ${{ matrix.node-version }}
-          CARGO_BUILD_TARGET: ${{ matrix.os.target }}

--- a/packages/turbo-repository/js/index.js
+++ b/packages/turbo-repository/js/index.js
@@ -10,6 +10,44 @@ const { join } = require("path");
 const { platform, arch } = process;
 
 let nativeBinding = null;
+let localFileExisted = false;
+let loadError = null;
+
+function isMusl() {
+  // For Node 10
+  if (!process.report || typeof process.report.getReport !== "function") {
+    try {
+      const lddPath = require("child_process")
+        .execSync("which ldd")
+        .toString()
+        .trim();
+      return readFileSync(lddPath, "utf8").includes("musl");
+    } catch (e) {
+      return true;
+    }
+  } else {
+    const orig = process.report.excludeNetwork;
+    process.report.excludeNetwork = true;
+    const { glibcVersionRuntime } = process.report.getReport().header;
+    process.report.excludeNetwork = orig;
+    if (typeof glibcVersionRuntime === "string") {
+      try {
+        // We support glibc v2.26+
+        let [major, minor] = glibcVersionRuntime.split(".", 2);
+        if (parseInt(major, 10) !== 2) {
+          return true;
+        }
+        if (parseInt(minor, 10) < 26) {
+          return true;
+        }
+        return false;
+      } catch (e) {
+        return true;
+      }
+    }
+    return !glibcVersionRuntime;
+  }
+}
 
 // TODO: find-up to turbo-repository? This currently only works from turbo-repository/js/dist
 const localPath = join(__dirname, "..", "..", "native", "@turbo");
@@ -50,15 +88,28 @@ switch (platform) {
     }
     break;
   case "linux":
-    switch (arch) {
-      case "x64":
-        suffix = "linux-x64-musl";
-        break;
-      case "arm64":
-        suffix = "linux-arm64-musl";
-        break;
-      default:
-        throw new Error(`Unsupported architecture on Linux: ${arch}`);
+    if (isMusl()) {
+      switch (arch) {
+        case "x64":
+          suffix = "linux-x64-musl";
+          break;
+        case "arm64":
+          suffix = "linux-arm64-musl";
+          break;
+        default:
+          throw new Error(`Unsupported architecture on Linux: ${arch}`);
+      }
+    } else {
+      switch (arch) {
+        case "x64":
+          suffix = "linux-x64-gnu";
+          break;
+        case "arm64":
+          suffix = "linux-arm64-gnu";
+          break;
+        default:
+          throw new Error(`Unsupported architecture on Linux: ${arch}`);
+      }
     }
     break;
   default:

--- a/packages/turbo-repository/js/package.json
+++ b/packages/turbo-repository/js/package.json
@@ -17,11 +17,11 @@
   "optionalDependencies": {
     "@turbo/repository-darwin-x64": "0.0.1-canary.12",
     "@turbo/repository-darwin-arm64": "0.0.1-canary.12",
+    "@turbo/repository-linux-x64-gnu": "0.0.1-canary.12",
+    "@turbo/repository-linux-arm64-gnu": "0.0.1-canary.12",
     "@turbo/repository-linux-x64-musl": "0.0.1-canary.12",
     "@turbo/repository-linux-arm64-musl": "0.0.1-canary.12",
     "@turbo/repository-win32-x64-msvc": "0.0.1-canary.12",
-    "@turbo/repository-win32-arm64-msvc": "0.0.1-canary.12",
-    "@turbo/repository-linux-arm64-gnu": "0.0.1-canary.12",
-    "@turbo/repository-linux-x64-gnu": "0.0.1-canary.12"
+    "@turbo/repository-win32-arm64-msvc": "0.0.1-canary.12"
   }
 }

--- a/packages/turbo-repository/js/package.json
+++ b/packages/turbo-repository/js/package.json
@@ -20,6 +20,8 @@
     "@turbo/repository-linux-x64-musl": "0.0.1-canary.12",
     "@turbo/repository-linux-arm64-musl": "0.0.1-canary.12",
     "@turbo/repository-win32-x64-msvc": "0.0.1-canary.12",
-    "@turbo/repository-win32-arm64-msvc": "0.0.1-canary.12"
+    "@turbo/repository-win32-arm64-msvc": "0.0.1-canary.12",
+    "@turbo/repository-linux-arm64-gnu": "0.0.1-canary.12",
+    "@turbo/repository-linux-x64-gnu": "0.0.1-canary.12"
   }
 }

--- a/packages/turbo-repository/npm/linux-arm64-gnu/package.json
+++ b/packages/turbo-repository/npm/linux-arm64-gnu/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@turbo/repository-linux-arm64-gnu",
+  "version": "0.0.1-canary.12",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/turborepo",
+    "directory": "packages/turbo-repository/npm/linux-arm64-gnu"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "main": "repository.linux-arm64-gnu.node",
+  "files": [
+    "repository.linux-arm64-gnu.node"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">= 10"
+  }
+}

--- a/packages/turbo-repository/npm/linux-x64-gnu/package.json
+++ b/packages/turbo-repository/npm/linux-x64-gnu/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@turbo/repository-linux-x64-gnu",
+  "version": "0.0.1-canary.12",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/turborepo",
+    "directory": "packages/turbo-repository/npm/linux-x64-gnu"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "main": "repository.linux-x64-gnu.node",
+  "files": [
+    "repository.linux-x64-gnu.node"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">= 10"
+  }
+}

--- a/packages/turbo-repository/package.json
+++ b/packages/turbo-repository/package.json
@@ -24,12 +24,12 @@
   "napi": {
     "name": "@turbo/repository",
     "triples": {
-      "defaults": false,
+      "defaults": true,
       "additional": [
         "x86_64-apple-darwin",
         "aarch64-apple-darwin",
-        "x86_64-unknown-linux-musl",
-        "aarch64-unknown-linux-musl",
+        "x86_64-unknown-linux-gnu",
+        "aarch64-unknown-linux-gnu",
         "x86_64-pc-windows-msvc",
         "aarch64-pc-windows-msvc"
       ]

--- a/packages/turbo-repository/turbo.json
+++ b/packages/turbo-repository/turbo.json
@@ -4,9 +4,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["cli#rust-src"],
-      "env": ["NODE_VERSION", "CARGO_BUILD_TARGET"],
-      // napi swallow compile errors so we cannot cache as we might save a failure
-      "cache": false
+      "env": ["NODE_VERSION"]
     },
     "test": {
       "dependsOn": ["build"]


### PR DESCRIPTION
### Description

Revert #10062 as we need them and now we avoid cross compiling `git2`

### Testing Instructions

[Test run](https://github.com/vercel/turborepo/actions/runs/13644965628)
