### PR TITLE
docs: fix json title for Watch Mode docs

### DIFF
--- a/docs/repo-docs/crafting-your-repository/developing-applications.mdx
+++ b/docs/repo-docs/crafting-your-repository/developing-applications.mdx
@@ -130,7 +130,7 @@ For example, using a package structure like [`create-turbo`](/repo/docs/referenc
 
 <Tab value="packages/ui">
 
-```json title="turbo.json"
+```json title="package.json"
 {
   "name": "@repo/ui"
   "scripts": {
@@ -144,7 +144,7 @@ For example, using a package structure like [`create-turbo`](/repo/docs/referenc
 
 <Tab value="apps/web">
 
-```json title="turbo.json"
+```json title="package.json"
 {
   "name": "web"
   "scripts": {


### PR DESCRIPTION
### Description
Found a documentation error where a package.json code example was incorrectly labeled as turbo.json in the official Turborepo documentation:

- The example contains typical package.json fields like name and scripts section, which are not part of turbo.json schema
- turbo.json typically contains pipeline configurations, not npm package metadata
- This mislabeling could confuse users trying to set up their Turborepo projects

https://turbo.build/repo/docs/crafting-your-repository/developing-applications#watch-mode


