### PR TITLE
fix: correctly forward passthrough arguments when using pkg#task format

### DIFF
--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -13,7 +13,7 @@ use crate::{
         OutputLogsMode, RunArgs,
     },
     config::ConfigurationOptions,
-    run::task_id::TaskId,
+    run::task_id::{TaskId, TaskName},
     turbo_json::{UIMode, CONFIG_FILE},
     Args,
 };
@@ -258,7 +258,7 @@ impl<'a> TaskArgs<'a> {
             && self
                 .tasks
                 .iter()
-                .any(|task| task.as_str() == task_id.task())
+                .any(|task| TaskName::from(task.as_str()).task() == task_id.task())
         {
             Some(self.pass_through_args)
         } else {

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -550,12 +550,13 @@ mod test {
     use turborepo_cache::{CacheActions, CacheConfig, CacheOpts};
     use turborepo_ui::ColorConfig;
 
-    use super::{APIClientOpts, RepoOpts, RunOpts};
+    use super::{APIClientOpts, RepoOpts, RunOpts, TaskArgs};
     use crate::{
         cli::{Command, ContinueMode, DryRunMode, RunArgs},
         commands::CommandBase,
         config::ConfigurationOptions,
         opts::{Opts, RunCacheOpts, ScopeOpts},
+        run::task_id::TaskId,
         turbo_json::{UIMode, CONFIG_FILE},
         Args,
     };
@@ -872,6 +873,53 @@ mod test {
         insta::assert_json_snapshot!(
             args_str.iter().join("_"),
             json!({ "tasks": opts.run_opts.tasks, "filter_patterns": opts.scope_opts.filter_patterns  })
+        );
+
+        Ok(())
+    }
+
+    #[test_case(
+        vec!["build".to_string()],
+        vec!["passthrough".to_string()],
+        TaskId::new("web", "build"),
+        Some(vec!["passthrough".to_string()]);
+        "single task"
+    )]
+    #[test_case(
+        vec!["lint".to_string(), "build".to_string()],
+        vec!["passthrough".to_string()],
+        TaskId::new("web", "build"),
+        Some(vec!["passthrough".to_string()]);
+        "multiple tasks"
+    )]
+    #[test_case(
+        vec!["web#build".to_string()],
+        vec!["passthrough".to_string()],
+        TaskId::new("web", "build"),
+        Some(vec!["passthrough".to_string()]);
+        "task with package"
+    )]
+    #[test_case(
+        vec!["lint".to_string()],
+        vec![],
+        TaskId::new("ui", "lint"),
+        None;
+        "no passthrough args"
+    )]
+    fn test_get_args_for_tasks(
+        tasks: Vec<String>,
+        pass_through_args: Vec<String>,
+        expected_task: TaskId<'static>,
+        expected_args: Option<Vec<String>>,
+    ) -> Result<(), anyhow::Error> {
+        let task_opts = TaskArgs {
+            tasks: &tasks,
+            pass_through_args: &pass_through_args,
+        };
+
+        assert_eq!(
+            task_opts.args_for_task(&expected_task),
+            expected_args.as_deref()
         );
 
         Ok(())

--- a/turborepo-tests/integration/fixtures/passthrough/.gitignore
+++ b/turborepo-tests/integration/fixtures/passthrough/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.turbo
+.npmrc

--- a/turborepo-tests/integration/fixtures/passthrough/apps/my-app/package.json
+++ b/turborepo-tests/integration/fixtures/passthrough/apps/my-app/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "my-app",
+  "scripts": {
+    "echo": "echo $@"
+  },
+  "dependencies": {
+    "util": "*"
+  }
+}

--- a/turborepo-tests/integration/fixtures/passthrough/apps/my-app/package.json
+++ b/turborepo-tests/integration/fixtures/passthrough/apps/my-app/package.json
@@ -1,9 +1,6 @@
 {
   "name": "my-app",
   "scripts": {
-    "echo": "echo $@"
-  },
-  "dependencies": {
-    "util": "*"
+    "echo": "echo"
   }
 }

--- a/turborepo-tests/integration/fixtures/passthrough/package.json
+++ b/turborepo-tests/integration/fixtures/passthrough/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "monorepo",
+  "workspaces": [
+    "apps/**"
+  ]
+}

--- a/turborepo-tests/integration/fixtures/passthrough/turbo.json
+++ b/turborepo-tests/integration/fixtures/passthrough/turbo.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "echo": {}
+  }
+}

--- a/turborepo-tests/integration/tests/passthrough-args.t
+++ b/turborepo-tests/integration/tests/passthrough-args.t
@@ -1,0 +1,34 @@
+Setup
+  $ . ${TESTDIR}/../../helpers/setup_integration_test.sh passthrough
+
+  $ ${TURBO} -F my-app echo -- hello
+  \xe2\x80\xa2 Packages in scope: my-app (esc)
+  \xe2\x80\xa2 Running echo in 1 packages (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
+  my-app:echo: cache miss, executing 3706c931f8ac99c1
+  my-app:echo: 
+  my-app:echo: > echo
+  my-app:echo: > echo $@ hello
+  my-app:echo: 
+  my-app:echo: hello
+  
+   Tasks:    1 successful, 1 total
+  Cached:    0 cached, 1 total
+    Time:    .*s  (re)
+  
+
+  $ ${TURBO} my-app#echo -- goodbye
+  \xe2\x80\xa2 Packages in scope: my-app (esc)
+  \xe2\x80\xa2 Running my-app#echo in 1 packages (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
+  my-app:echo: cache miss, executing 81acd8845d88d1d1
+  my-app:echo: 
+  my-app:echo: > echo
+  my-app:echo: > echo $@ goodbye
+  my-app:echo: 
+  my-app:echo: goodbye
+  
+   Tasks:    1 successful, 1 total
+  Cached:    0 cached, 1 total
+    Time:    .*s  (re)
+  

--- a/turborepo-tests/integration/tests/passthrough-args.t
+++ b/turborepo-tests/integration/tests/passthrough-args.t
@@ -5,10 +5,10 @@ Setup
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running echo in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:echo: cache miss, executing 3706c931f8ac99c1
+  my-app:echo: cache miss, executing c0813f759149b8af
   my-app:echo: 
   my-app:echo: > echo
-  my-app:echo: > echo $@ hello
+  my-app:echo: > echo hello
   my-app:echo: 
   my-app:echo: hello
   
@@ -21,10 +21,10 @@ Setup
   \xe2\x80\xa2 Packages in scope: my-app (esc)
   \xe2\x80\xa2 Running my-app#echo in 1 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  my-app:echo: cache miss, executing 81acd8845d88d1d1
+  my-app:echo: cache miss, executing f4397252b3a3d780
   my-app:echo: 
   my-app:echo: > echo
-  my-app:echo: > echo $@ goodbye
+  my-app:echo: > echo goodbye
   my-app:echo: 
   my-app:echo: goodbye
   


### PR DESCRIPTION
### Description

Closes #10086. Parses the task as a `TaskName` before checking if task matches for passthrough args, to account for tasks being passed `pkg#task`.

### Testing Instructions
Added a test for passthrough args
