### PR TITLE
chore(scm): gate manual file hash behind git2

### DIFF
--- a/crates/turborepo-scm/src/manual.rs
+++ b/crates/turborepo-scm/src/manual.rs
@@ -1,3 +1,6 @@
+// This module doesn't require git2, but it is only used by modules that require
+// git2.
+#![cfg(feature = "git2")]
 use std::io::{ErrorKind, Read};
 
 use globwalk::fix_glob_pattern;


### PR DESCRIPTION
### Description

We're getting some dead code warning when building `@turbo/repository`:
```
warning: function `git_like_hash_file` is never used
Warning:   --> crates/turborepo-scm/src/manual.rs:12:4
   |
12 | fn git_like_hash_file(path: &AbsoluteSystemPath) -> Result<String, Error> {
   |    ^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: function `to_glob` is never used
Warning:   --> crates/turborepo-scm/src/manual.rs:31:4
   |
31 | fn to_glob(input: &str) -> Result<Glob, Error> {
   |    ^^^^^^^

warning: function `hash_files` is never used
Warning:   --> crates/turborepo-scm/src/manual.rs:38:15
   |
38 | pub(crate) fn hash_files(
   |               ^^^^^^^^^^

warning: function `get_package_file_hashes_without_git` is never used
Warning:   --> crates/turborepo-scm/src/manual.rs:59:15
   |
59 | pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
```

Gate this module behind `git2` to silence it.

### Testing Instructions

`cargo build -p turborepo-napi` should not produce any errors
