### PR TITLE
docs: fix JSDoc annotation for ESLint flat configs of basic example

### DIFF
--- a/examples/basic/packages/eslint-config/base.js
+++ b/examples/basic/packages/eslint-config/base.js
@@ -7,7 +7,7 @@ import onlyWarn from "eslint-plugin-only-warn";
 /**
  * A shared ESLint configuration for the repository.
  *
- * @type {import("eslint").Linter.Config}
+ * @type {import("eslint").Linter.Config[]}
  * */
 export const config = [
   js.configs.recommended,

--- a/examples/basic/packages/eslint-config/next.js
+++ b/examples/basic/packages/eslint-config/next.js
@@ -10,7 +10,7 @@ import { config as baseConfig } from "./base.js";
 /**
  * A custom ESLint configuration for libraries that use Next.js.
  *
- * @type {import("eslint").Linter.Config}
+ * @type {import("eslint").Linter.Config[]}
  * */
 export const nextJsConfig = [
   ...baseConfig,

--- a/examples/basic/packages/eslint-config/react-internal.js
+++ b/examples/basic/packages/eslint-config/react-internal.js
@@ -9,7 +9,7 @@ import { config as baseConfig } from "./base.js";
 /**
  * A custom ESLint configuration for libraries that use React.
  *
- * @type {import("eslint").Linter.Config} */
+ * @type {import("eslint").Linter.Config[]} */
 export const config = [
   ...baseConfig,
   js.configs.recommended,


### PR DESCRIPTION
### Description

This is a very minor change I noticed when copying the basic example.
The JSDoc annotation for the ESLint flat configs is incorrect, indicating a config object instead of an array of config objects, which prevents the IDE from providing proper autocomplete.

### Testing Instructions

The IDE autocomplete feature allows to very quickly validate the change.
