### PR TITLE
feat: workspace root microsyntax

### DIFF
--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -204,6 +204,13 @@ pub enum Error {
     },
     #[error("Cannot load turbo.json for {0} in single package mode.")]
     InvalidTurboJsonLoad(PackageName),
+    #[error("Cannot use '$TURBO_ROOT$' anywhere besides start of string.")]
+    InvalidTurboRootUse {
+        #[label("must be at start")]
+        span: Option<SourceSpan>,
+        #[source_code]
+        text: NamedSource<String>,
+    },
 }
 
 const DEFAULT_API_URL: &str = "https://vercel.com/api";

--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -206,7 +206,7 @@ pub enum Error {
     InvalidTurboJsonLoad(PackageName),
     #[error("\"$TURBO_ROOT$\" must be used at the start of glob.")]
     InvalidTurboRootUse {
-        #[label("must be at start")]
+        #[label("\"$TURBO_ROOT$\" must be used at the start of glob.")]
         span: Option<SourceSpan>,
         #[source_code]
         text: NamedSource<String>,

--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -211,6 +211,13 @@ pub enum Error {
         #[source_code]
         text: NamedSource<String>,
     },
+    #[error("\"$TURBO_ROOT$\" must be followed by a '/'.")]
+    InvalidTurboRootNeedsSlash {
+        #[label("\"$TURBO_ROOT$\" must be followed by a '/'.")]
+        span: Option<SourceSpan>,
+        #[source_code]
+        text: NamedSource<String>,
+    },
 }
 
 const DEFAULT_API_URL: &str = "https://vercel.com/api";

--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -204,7 +204,7 @@ pub enum Error {
     },
     #[error("Cannot load turbo.json for {0} in single package mode.")]
     InvalidTurboJsonLoad(PackageName),
-    #[error("Cannot use '$TURBO_ROOT$' anywhere besides start of string.")]
+    #[error("\"$TURBO_ROOT$\" must be used at the start of glob.")]
     InvalidTurboRootUse {
         #[label("must be at start")]
         span: Option<SourceSpan>,

--- a/crates/turborepo-lib/src/turbo_json/loader.rs
+++ b/crates/turborepo-lib/src/turbo_json/loader.rs
@@ -434,6 +434,7 @@ mod test {
     use insta::assert_snapshot;
     use tempfile::tempdir;
     use test_case::test_case;
+    use turbopath::RelativeUnixPath;
     use turborepo_unescape::UnescapedString;
 
     use super::*;
@@ -616,7 +617,7 @@ mod test {
 
         assert_eq!(
             expected_root_build,
-            TaskDefinition::try_from(root_build.clone())?
+            TaskDefinition::from_raw(root_build.clone(), RelativeUnixPath::new(".").unwrap())?
         );
 
         Ok(())

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -11,7 +11,7 @@ use clap::ValueEnum;
 use miette::{NamedSource, SourceSpan};
 use serde::{Deserialize, Serialize};
 use struct_iterable::Iterable;
-use turbopath::AbsoluteSystemPath;
+use turbopath::{AbsoluteSystemPath, RelativeUnixPath};
 use turborepo_errors::Spanned;
 use turborepo_repository::package_graph::ROOT_PKG_NAME;
 use turborepo_unescape::UnescapedString;
@@ -32,6 +32,8 @@ pub mod parser;
 pub use loader::TurboJsonLoader;
 
 use crate::{boundaries::BoundariesConfig, config::UnnecessaryPackageTaskSyntaxError};
+
+const TURBO_ROOT: &str = "$TURBO_ROOT$";
 
 #[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone, Deserializable)]
 #[serde(rename_all = "camelCase")]
@@ -343,10 +345,12 @@ impl TryFrom<Vec<Spanned<UnescapedString>>> for TaskOutputs {
     }
 }
 
-impl TryFrom<RawTaskDefinition> for TaskDefinition {
-    type Error = Error;
-
-    fn try_from(raw_task: RawTaskDefinition) -> Result<Self, Error> {
+impl TaskDefinition {
+    pub fn from_raw(
+        mut raw_task: RawTaskDefinition,
+        path_to_repo_root: &RelativeUnixPath,
+    ) -> Result<Self, Error> {
+        replace_turbo_root_token(&mut raw_task, path_to_repo_root)?;
         let outputs = raw_task.outputs.unwrap_or_default().try_into()?;
 
         let cache = raw_task.cache.is_none_or(|c| c.into_inner());
@@ -572,6 +576,8 @@ impl TryFrom<RawTurboJson> for TurboJson {
             }
         }
 
+        let tasks = raw_turbo.tasks.clone().unwrap_or_default();
+
         Ok(TurboJson {
             text: raw_turbo.span.text,
             path: raw_turbo.span.path,
@@ -598,7 +604,7 @@ impl TryFrom<RawTurboJson> for TurboJson {
 
                 global_deps
             },
-            tasks: raw_turbo.tasks.unwrap_or_default(),
+            tasks,
             // copy these over, we don't need any changes here.
             extends: raw_turbo
                 .extends
@@ -629,7 +635,7 @@ impl TurboJson {
         path: &AbsoluteSystemPath,
     ) -> Result<TurboJson, Error> {
         let raw_turbo_json = RawTurboJson::read(repo_root, path)?;
-        raw_turbo_json.try_into()
+        TurboJson::try_from(raw_turbo_json)
     }
 
     pub fn task(&self, task_id: &TaskId, task_name: &TaskName) -> Option<RawTaskDefinition> {
@@ -765,17 +771,75 @@ fn gather_env_vars(
     Ok(())
 }
 
+// Takes an input/output glob that might start with TURBO_ROOT_PREFIX
+// and swap it with the relative path to the turbo root.
+fn replace_turbo_root_token_in_string(
+    input: &mut Spanned<UnescapedString>,
+    path_to_repo_root: &RelativeUnixPath,
+) -> Result<(), Error> {
+    match input.find(TURBO_ROOT) {
+        Some(0) => {
+            // Replace
+            input
+                .as_inner_mut()
+                .replace_range(..TURBO_ROOT.len(), path_to_repo_root.as_str());
+            Ok(())
+        }
+        // Handle negations
+        Some(1) if input.starts_with('!') => {
+            input
+                .as_inner_mut()
+                .replace_range(1..TURBO_ROOT.len() + 1, path_to_repo_root.as_str());
+            Ok(())
+        }
+        // We do not allow for TURBO_ROOT to be used in the middle of a glob
+        Some(_) => {
+            let (span, text) = input.span_and_text("turbo.json");
+            Err(Error::InvalidTurboRootUse { span, text })
+        }
+        None => Ok(()),
+    }
+}
+
+fn replace_turbo_root_token(
+    task_definition: &mut RawTaskDefinition,
+    path_to_repo_root: &RelativeUnixPath,
+) -> Result<(), Error> {
+    for input in task_definition
+        .inputs
+        .iter_mut()
+        .flat_map(|inputs| inputs.iter_mut())
+    {
+        replace_turbo_root_token_in_string(input, path_to_repo_root)?;
+    }
+
+    for output in task_definition
+        .outputs
+        .iter_mut()
+        .flat_map(|outputs| outputs.iter_mut())
+    {
+        replace_turbo_root_token_in_string(output, path_to_repo_root)?;
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use anyhow::Result;
     use biome_deserialize::json::deserialize_from_json_str;
     use biome_json_parser::JsonParserOptions;
     use pretty_assertions::assert_eq;
     use serde_json::json;
     use test_case::test_case;
+    use turbopath::RelativeUnixPath;
     use turborepo_unescape::UnescapedString;
 
-    use super::{RawTurboJson, SpacesJson, Spanned, TurboJson, UIMode};
+    use super::{
+        replace_turbo_root_token_in_string, RawTurboJson, SpacesJson, Spanned, TurboJson, UIMode,
+    };
     use crate::{
         boundaries::BoundariesConfig,
         cli::OutputLogsMode,
@@ -787,7 +851,7 @@ mod tests {
     #[test_case("{}", "empty boundaries")]
     #[test_case(r#"{"tags": {} }"#, "empty tags")]
     #[test_case(
-        r#"{"tags": { "my-tag": { "dependencies": { "allow": ["my-package"] } } } }"#,
+        r#"{"tags": { "my-tag": { "dependencies": { "allow": ["my-package"] } } }"#,
         "tags and dependencies"
     )]
     #[test_case(
@@ -954,6 +1018,29 @@ mod tests {
         }
       ; "full (windows)"
     )]
+    #[test_case(
+        r#"{
+            "inputs": ["$TURBO_ROOT$/config.txt"],
+            "outputs": ["$TURBO_ROOT$/coverage/**", "!$TURBO_ROOT$/coverage/index.html"]
+        }"#,
+        RawTaskDefinition {
+            inputs: Some(vec![Spanned::new(UnescapedString::from("$TURBO_ROOT$/config.txt")).with_range(25..50)]),
+            outputs: Some(vec![
+                Spanned::new(UnescapedString::from("$TURBO_ROOT$/coverage/**")).with_range(77..103),
+                Spanned::new(UnescapedString::from("!$TURBO_ROOT$/coverage/index.html")).with_range(105..140),
+            ]),
+            ..RawTaskDefinition::default()
+        },
+        TaskDefinition {
+            inputs: vec!["../../config.txt".to_owned()],
+            outputs: TaskOutputs {
+                inclusions: vec!["../../coverage/**".to_owned()],
+                exclusions: vec!["../../coverage/index.html".to_owned()],
+            },
+            ..TaskDefinition::default()
+        }
+    ; "turbo root"
+    )]
     fn test_deserialize_task_definition(
         task_definition_content: &str,
         expected_raw_task_definition: RawTaskDefinition,
@@ -968,7 +1055,8 @@ mod tests {
             deserialized_result.into_deserialized().unwrap();
         assert_eq!(raw_task_definition, expected_raw_task_definition);
 
-        let task_definition: TaskDefinition = raw_task_definition.try_into()?;
+        let task_definition =
+            TaskDefinition::from_raw(raw_task_definition, RelativeUnixPath::new("../..").unwrap())?;
         assert_eq!(task_definition, expected_task_definition);
 
         Ok(())
@@ -1190,5 +1278,25 @@ mod tests {
             dev_task.siblings.as_ref().unwrap().as_slice(),
             &[Spanned::new(UnescapedString::from("api#server"))]
         );
+    }
+
+    #[test_case("index.ts", Ok("index.ts") ; "no token")]
+    #[test_case("$TURBO_ROOT$/config.txt", Ok("../../config.txt") ; "valid token")]
+    #[test_case("!$TURBO_ROOT$/README.md", Ok("!../../README.md") ; "negation")]
+    #[test_case("../$TURBO_ROOT$/config.txt", Err("Cannot use '$TURBO_ROOT$' anywhere besides start of string.") ; "invalid token")]
+    fn test_replace_turbo_root(input: &'static str, expected: Result<&str, &str>) {
+        let mut spanned_string = Spanned::new(UnescapedString::from(input))
+            .with_path(Arc::from("turbo.json"))
+            .with_text(format!("\"{input}\""))
+            .with_range(1..(input.len()));
+        let result = replace_turbo_root_token_in_string(
+            &mut spanned_string,
+            RelativeUnixPath::new("../..").unwrap(),
+        );
+        let actual = match result {
+            Ok(()) => Ok(spanned_string.as_inner().as_ref()),
+            Err(e) => Err(e.to_string()),
+        };
+        assert_eq!(actual, expected.map_err(|s| s.to_owned()));
     }
 }

--- a/crates/turborepo-unescape/src/lib.rs
+++ b/crates/turborepo-unescape/src/lib.rs
@@ -1,4 +1,7 @@
-use std::{fmt, fmt::Display, ops::Deref};
+use std::{
+    fmt::{self, Display},
+    ops::{Deref, DerefMut},
+};
 
 use biome_deserialize::{Deserializable, DeserializableValue, DeserializationDiagnostic};
 
@@ -21,12 +24,19 @@ impl AsRef<str> for UnescapedString {
 }
 
 impl Deref for UnescapedString {
-    type Target = str;
+    type Target = String;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
+
+impl DerefMut for UnescapedString {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
 fn unescape_str(s: String) -> Result<String, serde_json::Error> {
     let wrapped_s = format!("\"{}\"", s);
 

--- a/docs/site/content/repo-docs/reference/configuration.mdx
+++ b/docs/site/content/repo-docs/reference/configuration.mdx
@@ -358,6 +358,8 @@ An allowlist of environment variables that should be made available to this task
 
 A list of file glob patterns relative to the package's `package.json` to cache when the task is successfully completed.
 
+See [`$TURBO_ROOT$`](#turbo_root) if output paths need to be relative to the repository root.
+
 ```jsonc title="./turbo.json"
 {
   "tasks": {
@@ -426,6 +428,23 @@ the special string `$TURBO_DEFAULT$` within the `inputs` array to restore `turbo
     "check-types": {
       // Consider all default inputs except the package's README
       "inputs": ["$TURBO_DEFAULT$", "!README.md"]
+    }
+  }
+}
+```
+
+#### `$TURBO_ROOT$`
+
+Tasks might reference a file that lies outside of their directory.
+
+Starting a file glob with `$TURBO_ROOT$` will change the glob to be relative to the root of the repository instead of the package directory.
+
+```jsonc title="./turbo.json"
+{
+  "tasks": {
+    "check-types": {
+      // Consider all Typescript files in `src/` and the root tsconfig.json as inputs
+      "inputs": ["$TURBO_ROOT$/tsconfig.json", "src/**/*.ts"]
     }
   }
 }


### PR DESCRIPTION
### Description

Microsyntax for file globbing from the workspace root. Our file globs are anchored to packages, but there are use cases where anchoring at the root is more preferable.

Adds `$TURBO_ROOT$` which can be used in task `inputs` and `outputs`. It can only be used at the start of an inclusion/exclusion so `../$TURBO_ROOT$/config.txt` isn't valid usage.

We achieve this by swapping out `$TURBO_ROOT$` as we convert a raw task definition to a usable one. This allows us to not handle this at any later steps since all inputs/outpus are expected to be relative to the package directory.

### Testing Instructions

Added unit tests for:
 - Replacing of `$TURBO_ROOT$` with the relative path to the repo root
 - Calculation of the relative path to repo root for packages

```
[0 olszewski@macbookpro] /tmp/watch-time $ bat turbo.json 
───────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
       │ File: turbo.json
───────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1   │ {
   2   │   "$schema": "https://turbo.build/schema.json",
   3   │   "ui": "tui",
   4   │   "tasks": {
   5   │     "build": {
   6   │       "dependsOn": ["^build"],
   7 ~ │       "inputs": ["$TURBO_DEFAULT$", ".env*", "$TURBO_ROOT$/my-configs/*"],
   8   │       "outputs": [".next/**", "!.next/cache/**"]
   9   │     },
  10   │     "lint": {
  11   │       "dependsOn": ["^lint"]
  12   │     },
  13   │     "check-types": {
  14   │       "dependsOn": ["^check-types"]
  15   │     },
  16   │     "dev": {
  17   │       "cache": false,
  18   │       "persistent": true
  19   │     }
  20   │   }
  21   │ }

[0 olszewski@macbookpro] /tmp/watch-time $ turbo_dev --skip-infer build --output-logs=hash-only                     
turbo 2.4.5-canary.2

• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web
• Running build in 5 packages
• Remote caching disabled
 web#build > cache hit, suppressing logs cf5b7818b9c2c383 
 docs#build > cache hit, suppressing logs 9306af3d3750177a 

 Tasks:    2 successful, 2 total
Cached:    2 cached, 2 total
  Time:    110ms >>> FULL TURBO

[0 olszewski@macbookpro] /tmp/watch-time $ echo 'a change' > my-configs/config.txt 
[0 olszewski@macbookpro] /tmp/watch-time $ turbo_dev --skip-infer build --output-logs=hash-only
turbo 2.4.5-canary.2

• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web
• Running build in 5 packages
• Remote caching disabled
 web#build > cache miss, executing 0acfce06b3b2069d 
 docs#build > cache miss, executing cfb4227df7dfd1fc 

 Tasks:    2 successful, 2 total
Cached:    0 cached, 2 total
  Time:    7.97s 

[0 olszewski@macbookpro] /tmp/watch-time $ vim turbo.json 
[0 olszewski@macbookpro] /tmp/watch-time $ turbo_dev --skip-infer build --output-logs=hash-only
turbo 2.4.5-canary.2

  × Cannot use '$TURBO_ROOT$' anywhere besides start of string.
   ╭─[turbo.json:7:46]
 6 │       "dependsOn": ["^build"],
 7 │       "inputs": ["$TURBO_DEFAULT$", ".env*", "../$TURBO_ROOT$/my-configs/*"],
   ·                                              ───────────────┬──────────────
   ·                                                             ╰── must be at start
 8 │       "outputs": [".next/**", "!.next/cache/**"]
   ╰────
```
