### PR TITLE
chore: remove experimental warning from ls command

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1464,7 +1464,6 @@ pub async fn run(
         Command::Ls {
             packages, output, ..
         } => {
-            warn!("ls command is experimental and may change in the future");
             let event = CommandEventBuilder::new("info").with_parent(&root_telemetry);
 
             event.track_call();

--- a/docs/repo-docs/crafting-your-repository/understanding-your-repository.mdx
+++ b/docs/repo-docs/crafting-your-repository/understanding-your-repository.mdx
@@ -11,10 +11,6 @@ To list your packages, you can run `turbo ls`. This will show the packages in yo
 
 ```bash title="Terminal"
 > turbo ls
-turbo 2.1.3
-
- WARNING  ls command is experimental and may change in the future
-5 packages (pnpm9)
 
   @repo/eslint-config packages/eslint-config
   @repo/typescript-config packages/typescript-config

--- a/turborepo-tests/integration/tests/affected.t
+++ b/turborepo-tests/integration/tests/affected.t
@@ -7,7 +7,6 @@ Create a new branch
 
 Ensure that nothing is affected
   $ ${TURBO} ls --affected
-   WARNING  ls command is experimental and may change in the future
   0 no packages (npm)
   
 
@@ -35,7 +34,6 @@ Validate that we only run `my-app#build` with change not committed
 
 Do the same thing with the `ls` command
   $ ${TURBO} ls --affected
-   WARNING  ls command is experimental and may change in the future
   1 package (npm)
   
     my-app apps[\/\\]my-app (re)
@@ -118,7 +116,6 @@ Validate that we only run `my-app#build` with change not committed
 
 Do the same thing with the `ls` command
   $ ${TURBO} ls --affected
-   WARNING  ls command is experimental and may change in the future
   1 package (npm)
   
     my-app apps[\/\\]my-app (re)
@@ -165,7 +162,6 @@ Validate that we only run `my-app#build` with change committed
 
 Do the same thing with the `ls` command
   $ ${TURBO} ls --affected
-   WARNING  ls command is experimental and may change in the future
   1 package (npm)
   
     my-app apps[\/\\]my-app (re)
@@ -201,7 +197,6 @@ Override the SCM base to be HEAD, so nothing runs
 
 Do the same thing with the `ls` command
   $ TURBO_SCM_BASE="HEAD" ${TURBO} ls --affected
-   WARNING  ls command is experimental and may change in the future
   0 no packages (npm)
   
 
@@ -232,7 +227,6 @@ Override the SCM head to be main, so nothing runs
 
 Do the same thing with the `ls` command
   $ TURBO_SCM_HEAD="main" ${TURBO} ls --affected
-   WARNING  ls command is experimental and may change in the future
   0 no packages (npm)
   
 
@@ -276,7 +270,6 @@ Run the build and expect only `my-app` to be affected, since between
 
 Do the same thing with the `ls` command
   $ ${TURBO} ls --affected
-   WARNING  ls command is experimental and may change in the future
   1 package (npm)
   
     my-app apps[\/\\]my-app (re)
@@ -316,7 +309,6 @@ Now try running `--affected` again, we should run all tasks
 
 Do the same thing with the `ls` command
   $ ${TURBO} ls --affected
-   WARNING  ls command is experimental and may change in the future
    WARNING  unable to detect git range, assuming all files have changed: Git error: fatal: no merge base found
   
   3 packages (npm)
@@ -371,7 +363,6 @@ Now try running `--affected` again, we should run all tasks
 
 Do the same thing with the `ls` command
   $ ${TURBO} ls --affected
-   WARNING  ls command is experimental and may change in the future
    WARNING  unable to detect git range, assuming all files have changed: Git error: fatal: no merge base found
   
   3 packages (npm)

--- a/turborepo-tests/integration/tests/command-ls.t
+++ b/turborepo-tests/integration/tests/command-ls.t
@@ -3,7 +3,6 @@ Setup
 
 Run info
   $ ${TURBO} ls
-   WARNING  ls command is experimental and may change in the future
   3 packages (npm)
   
     another packages[\/\\]another (re)
@@ -12,7 +11,6 @@ Run info
 
 Run ls with filter
   $ ${TURBO} ls -F my-app...
-   WARNING  ls command is experimental and may change in the future
   2 packages (npm)
   
     my-app apps[\/\\]my-app (re)
@@ -20,7 +18,6 @@ Run ls with filter
 
 Run ls on package `another`
   $ ${TURBO} ls another
-   WARNING  ls command is experimental and may change in the future
   packages[/\\]another  (re)
   another depends on: <no packages>
   
@@ -30,7 +27,6 @@ Run ls on package `another`
 
 Run ls on package `my-app`
   $ ${TURBO} ls my-app
-   WARNING  ls command is experimental and may change in the future
   apps[\/\\]my-app  (re)
   my-app depends on: util
   


### PR DESCRIPTION
### Description

This feature is no longer in experimental. We just forgot to remove the warning.
