### PR TITLE
fix(cli): no longer attempt to parse task name as continue value

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1946,6 +1946,21 @@ mod test {
         "continue option with no value"
 	)]
     #[test_case::test_case(
+		&["turbo", "run", "--continue", "build"],
+        Args {
+            command: Some(Command::Run {
+                execution_args: Box::new(ExecutionArgs {
+                    tasks: vec!["build".to_string()],
+                    continue_execution: ContinueMode::Always,
+                    ..get_default_execution_args()
+                }),
+                run_args: Box::new(get_default_run_args())
+            }),
+            ..Args::default()
+        } ;
+        "continue option with no value before task"
+	)]
+    #[test_case::test_case(
 		&["turbo", "run", "build", "--continue=dependencies-successful"],
         Args {
             command: Some(Command::Run {

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -851,7 +851,7 @@ pub struct ExecutionArgs {
     /// continue running tasks whose dependencies have succeeded. Use "always"
     /// to continue running all tasks, even those whose dependencies have
     /// failed.
-    #[clap(long = "continue", value_name = "CONTINUE", num_args = 0..=1, default_value = "never", default_missing_value = "always")]
+    #[clap(long = "continue", value_name = "CONTINUE", num_args = 0..=1, default_value = "never", default_missing_value = "always", require_equals = true)]
     pub continue_execution: ContinueMode,
     /// Run turbo in single-package mode
     #[clap(long)]

--- a/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__turbo-watch-build---no-daemon.snap
+++ b/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__turbo-watch-build---no-daemon.snap
@@ -7,6 +7,6 @@ error: unexpected argument '--no-daemon' found
   tip: a similar argument exists: '--no-update-notifier'
   tip: to pass '--no-daemon' as a value, use '-- --no-daemon'
 
-Usage: turbo watch --no-update-notifier <--cache-dir <CACHE_DIR>|--concurrency <CONCURRENCY>|--continue [<CONTINUE>]|--single-package|--framework-inference [<BOOL>]|--global-deps <GLOBAL_DEPS>|--env-mode [<ENV_MODE>]|--filter <FILTER>|--affected|--output-logs <OUTPUT_LOGS>|--log-order <LOG_ORDER>|--only|--pkg-inference-root <PKG_INFERENCE_ROOT>|--log-prefix <LOG_PREFIX>|TASKS|PASS_THROUGH_ARGS>
+Usage: turbo watch --no-update-notifier <--cache-dir <CACHE_DIR>|--concurrency <CONCURRENCY>|--continue[=<CONTINUE>]|--single-package|--framework-inference [<BOOL>]|--global-deps <GLOBAL_DEPS>|--env-mode [<ENV_MODE>]|--filter <FILTER>|--affected|--output-logs <OUTPUT_LOGS>|--log-order <LOG_ORDER>|--only|--pkg-inference-root <PKG_INFERENCE_ROOT>|--log-prefix <LOG_PREFIX>|TASKS|PASS_THROUGH_ARGS>
 
 For more information, try '--help'.

--- a/docs/repo-docs/guides/migrating-from-nx.mdx
+++ b/docs/repo-docs/guides/migrating-from-nx.mdx
@@ -490,7 +490,7 @@ Configuration found in `nx.json` can be mapped to `turbo.json` using the tables 
 | `nx run-many`    | [`turbo run`](/repo/docs/reference/run)                                      |
 | `nx reset`       | [`--force`](/repo/docs/reference/run#--force)                                |
 | `--parallel`     | [`--concurrency`](/repo/docs/reference/run#--concurrency-number--percentage) |
-| `--nxBail`       | [`--continue`](/repo/docs/reference/run#--continue-option)                   |
+| `--nxBail`       | [`--continue`](/repo/docs/reference/run#--continueoption)                    |
 | `--projects`     | [`--filter`](/repo/docs/reference/run#--filter-string)                       |
 | `--graph`        | [`--graph`](/repo/docs/reference/run#--graph-file-type)                      |
 | `--output-style` | [`--log-order`](/repo/docs/reference/run#--log-order-option)                 |

--- a/docs/repo-docs/reference/run.mdx
+++ b/docs/repo-docs/reference/run.mdx
@@ -121,15 +121,15 @@ turbo run build --concurrency=50%
 turbo run test --concurrency=5
 ```
 
-### `--continue <option>`
+### `--continue[=<option>]`
 
 Default: `never`
 
 Specify how `turbo` should handle current and pending tasks in the presence of an error (e.g. non-zero exit code from a task).
 
-- When `--continue` is `never` and an error occurs, `turbo` will cancel all tasks.
-- When `--continue` is `dependencies-successful` and an error occurs, `turbo` will cancel dependent tasks. Tasks whose dependencies have succeeded will continue to run.
-- When `--continue` is `always` and an error occurs, `turbo` will continue running all tasks, even those whose dependencies have failed.
+- When `--continue=never` and an error occurs, `turbo` will cancel all tasks.
+- When `--continue=dependencies-successful` and an error occurs, `turbo` will cancel dependent tasks. Tasks whose dependencies have succeeded will continue to run.
+- When `--continue=always` and an error occurs, `turbo` will continue running all tasks, even those whose dependencies have failed.
 - When `--continue` is specified without a value, it will default to `always`.
 
 In all cases, `turbo` will exit with the highest exit code value encountered during execution.

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -98,7 +98,7 @@ Make sure exit code is 2 when no args are passed
             Override the filesystem cache directory
         --concurrency <CONCURRENCY>
             Limit the concurrency of task execution. Use 1 for serial (i.e. one-at-a-time) execution
-        --continue [<CONTINUE>]
+        --continue[=<CONTINUE>]
             Specify how task execution should proceed when an error occurs. Use "never" to cancel all tasks. Use "dependencies-successful" to continue running tasks whose dependencies have succeeded. Use "always" to continue running all tasks, even those whose dependencies have failed [default: never] [possible values: never, dependencies-successful, always]
         --single-package
             Run turbo in single-package mode

--- a/turborepo-tests/integration/tests/turbo-help.t
+++ b/turborepo-tests/integration/tests/turbo-help.t
@@ -98,7 +98,7 @@ Test help flag
             Override the filesystem cache directory
         --concurrency <CONCURRENCY>
             Limit the concurrency of task execution. Use 1 for serial (i.e. one-at-a-time) execution
-        --continue [<CONTINUE>]
+        --continue[=<CONTINUE>]
             Specify how task execution should proceed when an error occurs. Use "never" to cancel all tasks. Use "dependencies-successful" to continue running tasks whose dependencies have succeeded. Use "always" to continue running all tasks, even those whose dependencies have failed [default: never] [possible values: never, dependencies-successful, always]
         --single-package
             Run turbo in single-package mode
@@ -273,7 +273,7 @@ Test help flag
         --concurrency <CONCURRENCY>
             Limit the concurrency of task execution. Use 1 for serial (i.e. one-at-a-time) execution
   
-        --continue [<CONTINUE>]
+        --continue[=<CONTINUE>]
             Specify how task execution should proceed when an error occurs. Use "never" to cancel all tasks. Use "dependencies-successful" to continue running tasks whose dependencies have succeeded. Use "always" to continue running all tasks, even those whose dependencies have failed
             
             [default: never]


### PR DESCRIPTION
### Description

#10023 added values for the `--continue` flag, but this unintentionally broke commands such as `turbo --continue build` as `build` would be interpreted as a `continue` value

### Testing Instructions

Added failing test for the previous breakage and updated snapshots.
