### PR TITLE
fix: adds callout for installation instructions for PNPM

### DIFF
--- a/docs/repo-docs/getting-started/add-to-existing-repository.mdx
+++ b/docs/repo-docs/getting-started/add-to-existing-repository.mdx
@@ -40,10 +40,6 @@ familiar with Turborepo.
 <Step>
 ### Install `turbo`
 
-<Callout type="good-to-know">
-  Ensure you have created a `pnpm-workspace.yaml` file before you begin the installation. Failure to have this file will result in an error that says: ` --workspace-root may only be used inside a workspace`.
-</Callout>
-
 We recommend you install `turbo` both globally and into your repository's root for the best developer experience.
 
 <Tabs items={['npm', 'yarn', 'pnpm']} storageKey="selected-pkg-manager">
@@ -68,6 +64,9 @@ We recommend you install `turbo` both globally and into your repository's root f
 
   </Tab>
   <Tab value="pnpm">
+    <Callout type="good-to-know">
+      Ensure you have created a `pnpm-workspace.yaml` file before you begin the installation. Failure to have this file will result in an error that says: ` --workspace-root may only be used inside a workspace`.
+    </Callout>
 
     ```bash title="Terminal"
     # Global install
@@ -223,9 +222,9 @@ turbo check-types build
 You should see terminal output like this:
 
 ```bash title="Terminal"
- Tasks:    2 successful, 2 total
+Tasks:    2 successful, 2 total
 Cached:    2 cached, 2 total
-  Time:    185ms >>> FULL TURBO
+Time:    185ms >>> FULL TURBO
 ```
 
 Congratulations! **You just built and type checked your code in milliseconds**.

--- a/docs/repo-docs/getting-started/add-to-existing-repository.mdx
+++ b/docs/repo-docs/getting-started/add-to-existing-repository.mdx
@@ -40,6 +40,10 @@ familiar with Turborepo.
 <Step>
 ### Install `turbo`
 
+<Callout type="good-to-know">
+  Ensure you have created a `pnpm-workspace.yaml` file before you begin the installation. Failure to have this file will result in an error that says: ` --workspace-root may only be used inside a workspace`.
+</Callout>
+
 We recommend you install `turbo` both globally and into your repository's root for the best developer experience.
 
 <Tabs items={['npm', 'yarn', 'pnpm']} storageKey="selected-pkg-manager">

--- a/docs/repo-docs/getting-started/add-to-existing-repository.mdx
+++ b/docs/repo-docs/getting-started/add-to-existing-repository.mdx
@@ -64,9 +64,7 @@ We recommend you install `turbo` both globally and into your repository's root f
 
   </Tab>
   <Tab value="pnpm">
-    <Callout type="good-to-know">
       Ensure you have created a `pnpm-workspace.yaml` file before you begin the installation. Failure to have this file will result in an error that says: ` --workspace-root may only be used inside a workspace`.
-    </Callout>
 
     ```bash title="Terminal"
     # Global install


### PR DESCRIPTION
Refs: [10099](https://github.com/vercel/turborepo/issues/10099)

### Description

Adds callout for installation instructions in documentation page.