### PR TITLE
docs: clarify TURBO_TEAM slug usage

### DIFF
--- a/docs/repo-docs/crafting-your-repository/constructing-ci.mdx
+++ b/docs/repo-docs/crafting-your-repository/constructing-ci.mdx
@@ -15,10 +15,10 @@ For examples of how to connect your CI vendor to Remote Cache and run tasks, vis
 
 To enable Remote Caching for your CI, setup the environment variables for Turborepo to access your Remote Cache.
 
-| Environment Variable | Description                                                                                                                                                                                                                                    |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `TURBO_TOKEN`        | The Bearer token to access the Remote Cache                                                                                                                                                                                                    |
-| `TURBO_TEAM`         | The account name associated with your repository. When using{' '} <a href="https://vercel.com/docs/monorepos/remote-caching#vercel-remote-cache" rel="noreferrer noopener" target="_blank" >Vercel Remote Cache</a>, this is your team's slug. |
+| Environment Variable | Description                                                                                                                                                                                                                                                                                                                  |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TURBO_TOKEN`        | The Bearer token to access the Remote Cache                                                                                                                                                                                                                                                                                  |
+| `TURBO_TEAM`         | The account name associated with your repository. When using{' '} <a href="https://vercel.com/docs/monorepos/remote-caching#vercel-remote-cache" rel="noreferrer noopener" target="_blank" >Vercel Remote Cache</a>, this is [your team's slug](https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fsettings&title=Get+team+slug). |
 
 When you run tasks through `turbo`, your CI will be able to hit cache, speeding up your pipelines.
 

--- a/docs/repo-docs/crafting-your-repository/constructing-ci.mdx
+++ b/docs/repo-docs/crafting-your-repository/constructing-ci.mdx
@@ -15,10 +15,10 @@ For examples of how to connect your CI vendor to Remote Cache and run tasks, vis
 
 To enable Remote Caching for your CI, setup the environment variables for Turborepo to access your Remote Cache.
 
-| Environment Variable | Description                                      |
-| -------------------- | ------------------------------------------------ |
-| `TURBO_TOKEN`        | The Bearer token to access the Remote Cache      |
-| `TURBO_TEAM`         | The account name associated with your repository |
+| Environment Variable | Description                                                                                                                                                                                                                                    |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TURBO_TOKEN`        | The Bearer token to access the Remote Cache                                                                                                                                                                                                    |
+| `TURBO_TEAM`         | The account name associated with your repository. When using{' '} <a href="https://vercel.com/docs/monorepos/remote-caching#vercel-remote-cache" rel="noreferrer noopener" target="_blank" >Vercel Remote Cache</a>, this is your team's slug. |
 
 When you run tasks through `turbo`, your CI will be able to hit cache, speeding up your pipelines.
 

--- a/docs/repo-docs/guides/ci-vendors/index.mdx
+++ b/docs/repo-docs/guides/ci-vendors/index.mdx
@@ -35,7 +35,7 @@ To enable Remote Caching for your CI:
    | Variable | Description |
    | ----------- | ----------- |
    | `TURBO_TOKEN` | The Bearer token to access the Remote Cache |
-   | `TURBO_TEAM` | The account name associated with your repository. When using{' '} <a href="https://vercel.com/docs/monorepos/remote-caching#vercel-remote-cache" rel="noreferrer noopener" target="_blank" >Vercel Remote Cache</a>, this is your team's slug. |
+   | `TURBO_TEAM` | The account name associated with your repository. When using{' '} <a href="https://vercel.com/docs/monorepos/remote-caching#vercel-remote-cache" rel="noreferrer noopener" target="_blank" >Vercel Remote Cache</a>, this is [your team's slug](https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fsettings&title=Get+team+slug). |
 2. Clone your repository.
 3. Install your dependencies through your package manager.
 4. Run your tasks through `turbo`.

--- a/docs/repo-docs/guides/ci-vendors/index.mdx
+++ b/docs/repo-docs/guides/ci-vendors/index.mdx
@@ -35,8 +35,7 @@ To enable Remote Caching for your CI:
    | Variable | Description |
    | ----------- | ----------- |
    | `TURBO_TOKEN` | The Bearer token to access the Remote Cache |
-   | `TURBO_TEAM` | The account name associated with your repository |
-
+   | `TURBO_TEAM` | The account name associated with your repository. When using{' '} <a href="https://vercel.com/docs/monorepos/remote-caching#vercel-remote-cache" rel="noreferrer noopener" target="_blank" >Vercel Remote Cache</a>, this is your team's slug. |
 2. Clone your repository.
 3. Install your dependencies through your package manager.
 4. Run your tasks through `turbo`.

--- a/docs/repo-docs/reference/system-environment-variables.mdx
+++ b/docs/repo-docs/reference/system-environment-variables.mdx
@@ -145,7 +145,8 @@ System environment variables are always overridden by flag values provided direc
       <td>
         Set the URL used to log in to{' '}
         <a href="/repo/docs/core-concepts/remote-caching">Remote Cache</a>. Only
-        needed for self-hosted Remote Caches that implement an endpoint that dynamically creates tokens.
+        needed for self-hosted Remote Caches that implement an endpoint that
+        dynamically creates tokens.
       </td>
     </tr>
     <tr id="turbo_no_update_notifier">
@@ -277,7 +278,7 @@ System environment variables are always overridden by flag values provided direc
         >
           Vercel Remote Cache
         </a>
-        , this is your team's slug.
+        , this is [your team's slug](https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fsettings&title=Get+team+slug).
       </td>
     </tr>
     <tr id="turbo_teamid">


### PR DESCRIPTION
### Description

A user mentioned that its unclear what "The account name associated with your repository." means when using Vercel. I added a better description and a deep link to where the value can be found.

### Testing Instructions

👀
