### PR TITLE
fix(affected): consider turbo.jsonc as a default global dependency

### DIFF
--- a/crates/turborepo-repository/src/change_mapper/mod.rs
+++ b/crates/turborepo-repository/src/change_mapper/mod.rs
@@ -20,7 +20,7 @@ use crate::package_graph::{
 
 mod package;
 
-const DEFAULT_GLOBAL_DEPS: [&str; 2] = ["package.json", "turbo.json"];
+const DEFAULT_GLOBAL_DEPS: &[&str] = ["package.json", "turbo.json", "turbo.jsonc"].as_slice();
 
 // We may not be able to load the lockfile contents, but we
 // still want to be able to express a generic change.


### PR DESCRIPTION
### Description

#10083 missed including `turbo.jsonc` as a global dependency when doing SCM based filters

### Testing Instructions

👀 
