### PR TITLE
fix(prune): support copying turbo.jsonc

### DIFF
--- a/turborepo-tests/integration/tests/prune/includes-root-deps.t
+++ b/turborepo-tests/integration/tests/prune/includes-root-deps.t
@@ -7,3 +7,20 @@ Make sure that the internal util package is part of the prune output
    - Added shared
    - Added util
    - Added web
+
+Make sure turbo.jsonc is copied over
+  $ mv turbo.json turbo.jsonc
+  $ rm -r out
+  $ ${TURBO} prune web
+  Generating pruned monorepo for web in .*(\/|\\)out (re)
+   - Added shared
+   - Added util
+   - Added web
+  $ ls out
+  apps
+  package.json
+  packages
+  patches
+  pnpm-lock.yaml
+  pnpm-workspace.yaml
+  turbo.jsonc


### PR DESCRIPTION
### Description

Realized we weren't considering `jsonc` as a possible source when copying files for `prune`.

Some future work is to make `prune` work with the now exposed `root_turbo_json()` method off of the configuration object, but didn't have time for that refactor at the moment.

### Testing Instructions

Added `turbo.jsonc` test to the prune e2e tests
