### PR TITLE
docs: remove `ls` from Experimental phase in Support Policy

### DIFF
--- a/docs/repo-docs/getting-started/support-policy.mdx
+++ b/docs/repo-docs/getting-started/support-policy.mdx
@@ -107,7 +107,6 @@ We encourage you to help us test experimental APIs in side projects, proof-of-co
 
 - [`turbo query`](/repo/docs/reference/query)
 - [`turbo boundaries`](/repo/docs/reference/boundaries) and [Tags](/repo/docs/reference/boundaries#tags)
-- [`turbo ls`](/repo/docs/reference/ls)
 - [`--experimental-write-cache` for `turbo watch`](/repo/docs/reference/watch#caching)
 - [`--output=json` for `turbo ls --affected` flag](/repo/docs/reference/ls)
 


### PR DESCRIPTION
### Description

Erroneously added this to the Experimental list when I did #10091.


