### PR TITLE
feat(boundaries): implicit dependencies

### DIFF
--- a/crates/turborepo-lib/src/boundaries/config.rs
+++ b/crates/turborepo-lib/src/boundaries/config.rs
@@ -7,7 +7,9 @@ use turborepo_errors::Spanned;
 
 #[derive(Serialize, Default, Debug, Clone, Iterable, Deserializable, PartialEq)]
 pub struct BoundariesConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<Spanned<RulesMap>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub implicit_dependencies: Option<Spanned<Vec<Spanned<String>>>>,
 }
 

--- a/crates/turborepo-lib/src/boundaries/config.rs
+++ b/crates/turborepo-lib/src/boundaries/config.rs
@@ -6,9 +6,11 @@ use struct_iterable::Iterable;
 use turborepo_errors::Spanned;
 
 #[derive(Serialize, Default, Debug, Clone, Iterable, Deserializable, PartialEq)]
-pub struct RootBoundariesConfig {
+pub struct BoundariesConfig {
     pub tags: Option<Spanned<RulesMap>>,
+    pub implicit_dependencies: Option<Spanned<Vec<Spanned<String>>>>,
 }
+
 pub type RulesMap = HashMap<String, Spanned<Rule>>;
 
 #[derive(Serialize, Default, Debug, Clone, Iterable, Deserializable, PartialEq)]

--- a/crates/turborepo-lib/src/boundaries/imports.rs
+++ b/crates/turborepo-lib/src/boundaries/imports.rs
@@ -12,7 +12,7 @@ use turbo_trace::ImportType;
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf, PathRelation, RelativeUnixPath};
 use turborepo_errors::Spanned;
 use turborepo_repository::{
-    package_graph::{PackageInfo, PackageName, PackageNode},
+    package_graph::{PackageName, PackageNode},
     package_json::PackageJson,
 };
 
@@ -20,6 +20,64 @@ use crate::{
     boundaries::{tsconfig::TsConfigLoader, BoundariesDiagnostic, BoundariesResult, Error},
     run::Run,
 };
+
+/// All the places a dependency can be declared
+#[derive(Clone, Copy)]
+pub struct DependencyLocations<'a> {
+    pub(crate) internal_dependencies: &'a HashSet<&'a PackageNode>,
+    pub(crate) package_json: &'a PackageJson,
+    pub(crate) unresolved_external_dependencies: Option<&'a BTreeMap<String, String>>,
+    pub(crate) implicit_dependencies: &'a HashMap<String, Spanned<()>>,
+    pub(crate) global_implicit_dependencies: &'a HashMap<String, Spanned<()>>,
+}
+
+impl<'a> DependencyLocations<'a> {
+    /// Go through all the possible places a package could be declared to see if
+    /// it's a valid import. We don't use `oxc_resolver` because there are some
+    /// cases where you can resolve a package that isn't declared properly.
+    fn is_dependency(&self, package_name: &PackageNode) -> bool {
+        self.internal_dependencies.contains(package_name)
+            || self
+                .unresolved_external_dependencies
+                .is_some_and(|external_dependencies| {
+                    external_dependencies.contains_key(package_name.as_package_name().as_str())
+                })
+            || self
+                .package_json
+                .dependencies
+                .as_ref()
+                .is_some_and(|dependencies| {
+                    dependencies.contains_key(package_name.as_package_name().as_str())
+                })
+            || self
+                .package_json
+                .dev_dependencies
+                .as_ref()
+                .is_some_and(|dev_dependencies| {
+                    dev_dependencies.contains_key(package_name.as_package_name().as_str())
+                })
+            || self
+                .package_json
+                .peer_dependencies
+                .as_ref()
+                .is_some_and(|peer_dependencies| {
+                    peer_dependencies.contains_key(package_name.as_package_name().as_str())
+                })
+            || self
+                .package_json
+                .optional_dependencies
+                .as_ref()
+                .is_some_and(|optional_dependencies| {
+                    optional_dependencies.contains_key(package_name.as_package_name().as_str())
+                })
+            || self
+                .implicit_dependencies
+                .contains_key(package_name.as_package_name().as_str())
+            || self
+                .global_implicit_dependencies
+                .contains_key(package_name.as_package_name().as_str())
+    }
+}
 
 impl Run {
     /// Checks if the given import can be resolved as a tsconfig path alias,
@@ -80,10 +138,7 @@ impl Run {
         span: &Span,
         file_path: &AbsoluteSystemPath,
         file_content: &str,
-        package_info: &PackageInfo,
-        internal_dependencies: &HashSet<&PackageNode>,
-        unresolved_external_dependencies: Option<&BTreeMap<String, String>>,
-        implicit_dependencies: &HashMap<String, Spanned<()>>,
+        dependency_locations: DependencyLocations<'_>,
         resolver: &Resolver,
     ) -> Result<(), Error> {
         // If the import is prefixed with `@boundaries-ignore`, we ignore it, but print
@@ -156,10 +211,7 @@ impl Run {
                 span,
                 file_path,
                 file_content,
-                &package_info.package_json,
-                internal_dependencies,
-                unresolved_external_dependencies,
-                implicit_dependencies,
+                dependency_locations,
                 resolver,
             )
         } else {
@@ -210,47 +262,6 @@ impl Run {
         }
     }
 
-    /// Go through all the possible places a package could be declared to see if
-    /// it's a valid import. We don't use `oxc_resolver` because there are some
-    /// cases where you can resolve a package that isn't declared properly.
-    fn is_dependency(
-        internal_dependencies: &HashSet<&PackageNode>,
-        package_json: &PackageJson,
-        unresolved_external_dependencies: Option<&BTreeMap<String, String>>,
-        implicit_dependencies: &HashMap<String, Spanned<()>>,
-        package_name: &PackageNode,
-    ) -> bool {
-        internal_dependencies.contains(&package_name)
-            || unresolved_external_dependencies.is_some_and(|external_dependencies| {
-                external_dependencies.contains_key(package_name.as_package_name().as_str())
-            })
-            || package_json
-                .dependencies
-                .as_ref()
-                .is_some_and(|dependencies| {
-                    dependencies.contains_key(package_name.as_package_name().as_str())
-                })
-            || package_json
-                .dev_dependencies
-                .as_ref()
-                .is_some_and(|dev_dependencies| {
-                    dev_dependencies.contains_key(package_name.as_package_name().as_str())
-                })
-            || package_json
-                .peer_dependencies
-                .as_ref()
-                .is_some_and(|peer_dependencies| {
-                    peer_dependencies.contains_key(package_name.as_package_name().as_str())
-                })
-            || package_json
-                .optional_dependencies
-                .as_ref()
-                .is_some_and(|optional_dependencies| {
-                    optional_dependencies.contains_key(package_name.as_package_name().as_str())
-                })
-            || implicit_dependencies.contains_key(package_name.as_package_name().as_str())
-    }
-
     fn get_package_name(import: &str) -> String {
         if import.starts_with("@") {
             import.split('/').take(2).join("/")
@@ -271,10 +282,7 @@ impl Run {
         span: SourceSpan,
         file_path: &AbsoluteSystemPath,
         file_content: &str,
-        package_json: &PackageJson,
-        internal_dependencies: &HashSet<&PackageNode>,
-        unresolved_external_dependencies: Option<&BTreeMap<String, String>>,
-        implicit_dependencies: &HashMap<String, Spanned<()>>,
+        dependency_locations: DependencyLocations<'_>,
         resolver: &Resolver,
     ) -> Option<BoundariesDiagnostic> {
         let package_name = Self::get_package_name(import);
@@ -288,13 +296,7 @@ impl Run {
         }
         let package_name = PackageNode::Workspace(PackageName::Other(package_name));
         let folder = file_path.parent().expect("file_path should have a parent");
-        let is_valid_dependency = Self::is_dependency(
-            internal_dependencies,
-            package_json,
-            unresolved_external_dependencies,
-            implicit_dependencies,
-            &package_name,
-        );
+        let is_valid_dependency = dependency_locations.is_dependency(&package_name);
 
         if !is_valid_dependency
             && !matches!(
@@ -307,13 +309,7 @@ impl Run {
                 "@types/{}",
                 package_name.as_package_name().as_str()
             )));
-            let is_types_dependency = Self::is_dependency(
-                internal_dependencies,
-                package_json,
-                unresolved_external_dependencies,
-                implicit_dependencies,
-                &types_package_name,
-            );
+            let is_types_dependency = dependency_locations.is_dependency(&types_package_name);
 
             if is_types_dependency {
                 return match import_type {

--- a/crates/turborepo-lib/src/boundaries/mod.rs
+++ b/crates/turborepo-lib/src/boundaries/mod.rs
@@ -8,7 +8,7 @@ use std::{
     sync::{Arc, LazyLock, Mutex},
 };
 
-pub use config::{Permissions, RootBoundariesConfig, Rule};
+pub use config::{BoundariesConfig, Permissions, Rule};
 use git2::Repository;
 use globwalk::Settings;
 use miette::{Diagnostic, NamedSource, Report, SourceSpan};

--- a/crates/turborepo-lib/src/turbo_json/parser.rs
+++ b/crates/turborepo-lib/src/turbo_json/parser.rs
@@ -16,7 +16,7 @@ use turborepo_errors::{ParseDiagnostic, WithMetadata};
 use turborepo_unescape::UnescapedString;
 
 use crate::{
-    boundaries::{Permissions, RootBoundariesConfig, Rule},
+    boundaries::{BoundariesConfig, Permissions, Rule},
     run::task_id::TaskName,
     turbo_json::{Pipeline, RawTaskDefinition, RawTurboJson, Spanned},
 };
@@ -155,13 +155,19 @@ impl WithMetadata for Pipeline {
     }
 }
 
-impl WithMetadata for RootBoundariesConfig {
+impl WithMetadata for BoundariesConfig {
     fn add_text(&mut self, text: Arc<str>) {
         self.tags.add_text(text.clone());
         if let Some(tags) = &mut self.tags {
             for rule in tags.as_inner_mut().values_mut() {
                 rule.add_text(text.clone());
                 rule.value.add_text(text.clone());
+            }
+        }
+        self.implicit_dependencies.add_text(text.clone());
+        if let Some(implicit_dependencies) = &mut self.implicit_dependencies {
+            for dep in implicit_dependencies.as_inner_mut() {
+                dep.add_text(text.clone());
             }
         }
     }
@@ -172,6 +178,12 @@ impl WithMetadata for RootBoundariesConfig {
             for rule in tags.as_inner_mut().values_mut() {
                 rule.add_path(path.clone());
                 rule.value.add_path(path.clone());
+            }
+        }
+        self.implicit_dependencies.add_path(path.clone());
+        if let Some(implicit_dependencies) = &mut self.implicit_dependencies {
+            for dep in implicit_dependencies.as_inner_mut() {
+                dep.add_path(path.clone());
             }
         }
     }

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__empty_boundaries.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__empty_boundaries.snap
@@ -2,7 +2,4 @@
 source: crates/turborepo-lib/src/turbo_json/mod.rs
 expression: raw_boundaries_config
 ---
-{
-  "tags": null,
-  "implicit_dependencies": null
-}
+{}

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__empty_tags.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__empty_tags.snap
@@ -3,6 +3,5 @@ source: crates/turborepo-lib/src/turbo_json/mod.rs
 expression: raw_boundaries_config
 ---
 {
-  "tags": {},
-  "implicit_dependencies": null
+  "tags": {}
 }

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__empty_tags.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__empty_tags.snap
@@ -1,7 +1,8 @@
 ---
 source: crates/turborepo-lib/src/turbo_json/mod.rs
-expression: raw_task_definition
+expression: raw_boundaries_config
 ---
 {
-  "tags": {}
+  "tags": {},
+  "implicit_dependencies": null
 }

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__implicit_dependencies.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__implicit_dependencies.snap
@@ -3,7 +3,6 @@ source: crates/turborepo-lib/src/turbo_json/mod.rs
 expression: raw_boundaries_config
 ---
 {
-  "tags": null,
   "implicit_dependencies": [
     "my-package"
   ]

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__implicit_dependencies.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__implicit_dependencies.snap
@@ -4,5 +4,7 @@ expression: raw_boundaries_config
 ---
 {
   "tags": null,
-  "implicit_dependencies": null
+  "implicit_dependencies": [
+    "my-package"
+  ]
 }

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__implicit_dependencies_and_tags.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__implicit_dependencies_and_tags.snap
@@ -16,5 +16,7 @@ expression: raw_boundaries_config
       }
     }
   },
-  "implicit_dependencies": null
+  "implicit_dependencies": [
+    "my-package"
+  ]
 }

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__tags_and_dependencies.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__tags_and_dependencies.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/turborepo-lib/src/turbo_json/mod.rs
-expression: raw_task_definition
+expression: raw_boundaries_config
 ---
 {
   "tags": {
@@ -13,5 +13,6 @@ expression: raw_task_definition
       },
       "dependents": null
     }
-  }
+  },
+  "implicit_dependencies": null
 }

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__tags_and_dependencies.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__tags_and_dependencies.snap
@@ -13,6 +13,5 @@ expression: raw_boundaries_config
       },
       "dependents": null
     }
-  },
-  "implicit_dependencies": null
+  }
 }

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__tags_and_dependencies_2.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__tags_and_dependencies_2.snap
@@ -15,6 +15,5 @@ expression: raw_boundaries_config
       },
       "dependents": null
     }
-  },
-  "implicit_dependencies": null
+  }
 }

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__tags_and_dependencies_2.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__tags_and_dependencies_2.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/turborepo-lib/src/turbo_json/mod.rs
-expression: raw_task_definition
+expression: raw_boundaries_config
 ---
 {
   "tags": {
@@ -15,5 +15,6 @@ expression: raw_task_definition
       },
       "dependents": null
     }
-  }
+  },
+  "implicit_dependencies": null
 }

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__tags_and_dependents.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__tags_and_dependents.snap
@@ -15,6 +15,5 @@ expression: raw_boundaries_config
         ]
       }
     }
-  },
-  "implicit_dependencies": null
+  }
 }

--- a/turborepo-tests/integration/fixtures/boundaries/packages/module-package/my-module.mjs
+++ b/turborepo-tests/integration/fixtures/boundaries/packages/module-package/my-module.mjs
@@ -1,1 +1,3 @@
+import { anotherImplicitDependency } from "another-implicit-dependency";
+
 export const walkThePlank = "walk the plank matey";

--- a/turborepo-tests/integration/fixtures/boundaries/packages/utils/index.jsx
+++ b/turborepo-tests/integration/fixtures/boundaries/packages/utils/index.jsx
@@ -1,1 +1,3 @@
+import { ui } from "ui";
+
 export const ship = "Queen Anne";

--- a/turborepo-tests/integration/fixtures/boundaries/packages/utils/turbo.json
+++ b/turborepo-tests/integration/fixtures/boundaries/packages/utils/turbo.json
@@ -1,0 +1,7 @@
+{
+  "boundaries": {
+    "implicitDependencies": [
+      "ui"
+    ]
+  }
+}

--- a/turborepo-tests/integration/fixtures/boundaries/turbo.json
+++ b/turborepo-tests/integration/fixtures/boundaries/turbo.json
@@ -11,6 +11,9 @@
           ]
         }
       }
-    }
+    },
+    "implicitDependencies": [
+      "another-implicit-dependency"
+    ]
   }
 }


### PR DESCRIPTION
### Description

Allow users to allowlist implicit dependencies for boundaries. This is useful in cases where testing libraries or frameworks can inject globals such as `server-only`

Can be reviewed commit by commit
### Testing Instructions

Added test to boundaries. Note the snapshots do *not* change since no errors are produced. To verify stuff is working as intended, try removing the `implicitDependencies` key and note that an error is produced.
