### PR TITLE
fix(bun): properly handle bun lockfile keys

### DIFF
--- a/crates/turborepo-lockfiles/src/bun/de.rs
+++ b/crates/turborepo-lockfiles/src/bun/de.rs
@@ -50,13 +50,17 @@ impl<'de> Deserialize<'de> for PackageEntry {
             .pop_front()
             .and_then(val_to_info)
             .or_else(|| vals.pop_front().and_then(val_to_info));
+        let checksum = vals.pop_front().and_then(|val| match val {
+            Vals::Str(sha) => Some(sha),
+            Vals::Info(_) => None,
+        });
         Ok(Self {
             ident: key,
             info,
             // The rest are only necessary for serializing a lockfile and aren't needed until adding
             // `prune` support
             registry: None,
-            checksum: None,
+            checksum,
             root: None,
         })
     }
@@ -117,7 +121,7 @@ mod test {
                     .collect(),
                 ..Default::default()
             }),
-            checksum: None,
+            checksum: Some("sha".into()),
             root: None,
         }
     );

--- a/crates/turborepo-lockfiles/src/bun/mod.rs
+++ b/crates/turborepo-lockfiles/src/bun/mod.rs
@@ -290,9 +290,9 @@ mod test {
     .as_slice();
     const CHALK_DEPS: &[&str] = ["ansi-styles", "supports-color"].as_slice();
 
-    #[test_case("@turbo/gen", TURBO_GEN_DEPS)]
-    #[test_case("@turbo/gen/chalk", TURBO_GEN_CHALK_DEPS)]
-    #[test_case("chalk", CHALK_DEPS)]
+    #[test_case("@turbo/gen@1.13.4", TURBO_GEN_DEPS)]
+    #[test_case("chalk@2.4.2", TURBO_GEN_CHALK_DEPS)]
+    #[test_case("chalk@4.1.2", CHALK_DEPS)]
     fn test_all_dependencies(key: &str, expected: &[&str]) {
         let lockfile = BunLockfile::from_str(BASIC_LOCKFILE).unwrap();
         let mut expected = expected.to_vec();


### PR DESCRIPTION
### Description

We were not properly handling recursing when traversing the lockfile. Resolving a package would give a `package@version` key instead of the key into the `packages` array. Our `all_dependencies` implementation assumed that we were given the key into `packages`.

This is a little odd as the keys can have different "paths" (keys to the packages object) that map to identical entries. This PR adds a check to verify that the entries are in fact the same package by comparing checksums.

### Testing Instructions

Fixed unit tests and added one with mismatched checksums.
`create-turbo` using bun should no longer display ` WARNING  Unable to calculate transitive closures: No lockfile entry found for '@types/react@19.0.10'`
