### PR TITLE
fix(docs): prefix environment variable for search dialog

### DIFF
--- a/docs/site/components/search-dialog.tsx
+++ b/docs/site/components/search-dialog.tsx
@@ -7,7 +7,7 @@ import FumaSearchDialog from "fumadocs-ui/components/dialog/search-algolia";
 import { usePathname } from "next/navigation";
 
 const client = algo(
-  process.env.ALGOLIA_APP_ID,
+  process.env.NEXT_PUBLIC_ALGOLIA_APP_ID,
   process.env.NEXT_PUBLIC_ALGOLIA_READ_KEY!
 );
 


### PR DESCRIPTION
### Description

Forgot that this variable gets used on the frontend, which means I need to prefix it with NEXT_PUBLIC.

### Testing Instructions

Try search on the preview.
