### PR TITLE
fix(docs): fix commas in package exports example

### DIFF
--- a/docs/site/content/repo-docs/guides/tools/typescript.mdx
+++ b/docs/site/content/repo-docs/guides/tools/typescript.mdx
@@ -162,8 +162,8 @@ Then, set up the entrypoints for your package in `package.json` so that other pa
 {
   "exports": {
     "./*": {
-      "types": "./src/*.ts"
-      "default": "./dist/*.js",
+      "types": "./src/*.ts",
+      "default": "./dist/*.js"
     }
   }
 }


### PR DESCRIPTION
### Description

Fixed commas order.

### Testing Instructions

Use a JSON schema tester.

