### PR TITLE
docs: update storybook initiation instructions

### DIFF
--- a/docs/site/content/repo-docs/guides/tools/storybook.mdx
+++ b/docs/site/content/repo-docs/guides/tools/storybook.mdx
@@ -97,21 +97,21 @@ In the `apps/storybook` directory, initialize a new Storybook application:
   <Tab>
 
 ```bash title="Terminal"
-npx storybook@latest init
+npm create storybook@latest
 ```
 
   </Tab>
   <Tab>
 
 ```bash title="Terminal"
-yarn dlx storybook@latest init
+yarn create storybook@latest
 ```
 
   </Tab>
   <Tab>
 
 ```bash title="Terminal"
-pnpm dlx storybook@latest init
+pnpm create storybook@latest
 ```
 
   </Tab>


### PR DESCRIPTION
### Description

Follow latest Storybook instructions and conventions for setup. Using yarn or pnpm dlx otherwise will only install versions of storybook older than 8.3. Very simple change that uses the `create` command instead

### Testing Instructions

For testing, you could try the two different initiation options:
`pnpx dlx storybook@latest init`

Then verify your installed version, which will show a version older than 8.3. Delete the directory and create a new storybook directory, then run:

`pnpm create storybook@latest` 

Afterwards, the version should show the latest version, either 8.3 or older.

Also just a note, I think it is on storybooks side, but the most recent version of nextjs that they use in their examples is 8.
