### PR TITLE
feat(boundaries): package rules

### DIFF
--- a/crates/turborepo-lib/src/boundaries/config.rs
+++ b/crates/turborepo-lib/src/boundaries/config.rs
@@ -11,13 +11,20 @@ pub struct BoundariesConfig {
     pub tags: Option<Spanned<RulesMap>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub implicit_dependencies: Option<Spanned<Vec<Spanned<String>>>>,
+    /// Defines a rule for a package `turbo.json`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dependencies: Option<Spanned<Permissions>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dependents: Option<Spanned<Permissions>>,
 }
 
 pub type RulesMap = HashMap<String, Spanned<Rule>>;
 
 #[derive(Serialize, Default, Debug, Clone, Iterable, Deserializable, PartialEq)]
 pub struct Rule {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dependencies: Option<Spanned<Permissions>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dependents: Option<Spanned<Permissions>>,
 }
 

--- a/crates/turborepo-lib/src/boundaries/config.rs
+++ b/crates/turborepo-lib/src/boundaries/config.rs
@@ -11,7 +11,8 @@ pub struct BoundariesConfig {
     pub tags: Option<Spanned<RulesMap>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub implicit_dependencies: Option<Spanned<Vec<Spanned<String>>>>,
-    /// Defines a rule for a package `turbo.json`
+    /// If in a package `turbo.json`, the following two keys define
+    /// boundaries rules for that package
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dependencies: Option<Spanned<Permissions>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/turborepo-lib/src/boundaries/mod.rs
+++ b/crates/turborepo-lib/src/boundaries/mod.rs
@@ -67,6 +67,13 @@ pub enum SecondaryDiagnostic {
 
 #[derive(Clone, Debug, Error, Diagnostic)]
 pub enum BoundariesDiagnostic {
+    #[error("Package boundaries rules cannot have `tags` key")]
+    PackageBoundariesHasTags {
+        #[label("tags defined here")]
+        span: Option<SourceSpan>,
+        #[source_code]
+        text: NamedSource<String>,
+    },
     #[error("Tag `{tag}` cannot share the same name as package `{package}`")]
     TagSharesPackageName {
         tag: String,

--- a/crates/turborepo-lib/src/boundaries/mod.rs
+++ b/crates/turborepo-lib/src/boundaries/mod.rs
@@ -345,15 +345,6 @@ impl Run {
                 turbo_json.tags.as_ref(),
                 tag_rules.as_ref(),
             )?);
-
-            if turbo_json.tags.is_some() && tag_rules.is_none() {
-                // NOTE: if we use tags for something other than boundaries, we should remove
-                // this warning
-                warn!(
-                    "No boundaries rules found, but package {} has tags",
-                    package_name
-                );
-            }
         }
 
         result.packages_checked += 1;

--- a/crates/turborepo-lib/src/boundaries/tags.rs
+++ b/crates/turborepo-lib/src/boundaries/tags.rs
@@ -177,6 +177,53 @@ impl Run {
         Ok(None)
     }
 
+    pub(crate) fn check_tag(
+        &self,
+        diagnostics: &mut Vec<BoundariesDiagnostic>,
+        dependencies: Option<&ProcessedPermissions>,
+        dependents: Option<&ProcessedPermissions>,
+        pkg: &PackageNode,
+        package_json: &PackageJson,
+    ) -> Result<(), Error> {
+        if let Some(dependency_permissions) = dependencies {
+            for dependency in self.pkg_dep_graph().dependencies(&pkg) {
+                if matches!(dependency, PackageNode::Root) {
+                    continue;
+                }
+
+                let dependency_tags = self.load_package_tags(dependency.as_package_name());
+
+                diagnostics.extend(self.validate_relation(
+                    pkg.as_package_name(),
+                    package_json,
+                    dependency.as_package_name(),
+                    dependency_tags,
+                    dependency_permissions.allow.as_ref(),
+                    dependency_permissions.deny.as_ref(),
+                )?);
+            }
+        }
+
+        if let Some(dependent_permissions) = dependents {
+            for dependent in self.pkg_dep_graph().ancestors(&pkg) {
+                if matches!(dependent, PackageNode::Root) {
+                    continue;
+                }
+                let dependent_tags = self.load_package_tags(dependent.as_package_name());
+                diagnostics.extend(self.validate_relation(
+                    pkg.as_package_name(),
+                    package_json,
+                    dependent.as_package_name(),
+                    dependent_tags,
+                    dependent_permissions.allow.as_ref(),
+                    dependent_permissions.deny.as_ref(),
+                )?)
+            }
+        }
+
+        Ok(())
+    }
+
     pub(crate) fn check_package_tags(
         &self,
         pkg: PackageNode,
@@ -185,6 +232,34 @@ impl Run {
         tags_rules: &ProcessedRulesMap,
     ) -> Result<Vec<BoundariesDiagnostic>, Error> {
         let mut diagnostics = Vec::new();
+        let package_boundaries = self
+            .turbo_json_loader()
+            .load(pkg.as_package_name())
+            .ok()
+            .and_then(|turbo_json| turbo_json.boundaries.as_ref());
+
+        if let Some(boundaries) = package_boundaries {
+            if let Some(tags) = &boundaries.tags {
+                let (span, text) = tags.span_and_text("turbo.json");
+                diagnostics.push(BoundariesDiagnostic::PackageBoundariesHasTags { span, text });
+            }
+            let dependencies = boundaries
+                .dependencies
+                .clone()
+                .map(|deps| deps.into_inner().into());
+            let dependents = boundaries
+                .dependents
+                .clone()
+                .map(|deps| deps.into_inner().into());
+
+            self.check_tag(
+                &mut diagnostics,
+                dependencies.as_ref(),
+                dependents.as_ref(),
+                &pkg,
+                package_json,
+            )?;
+        }
 
         // We don't allow tags to share the same name as the package because
         // we allow package names to be used as a tag
@@ -210,41 +285,13 @@ impl Run {
 
         for tag in current_package_tags.iter() {
             if let Some(rule) = tags_rules.get(tag.as_inner()) {
-                if let Some(dependency_permissions) = &rule.dependencies {
-                    for dependency in self.pkg_dep_graph().dependencies(&pkg) {
-                        if matches!(dependency, PackageNode::Root) {
-                            continue;
-                        }
-
-                        let dependency_tags = self.load_package_tags(dependency.as_package_name());
-
-                        diagnostics.extend(self.validate_relation(
-                            pkg.as_package_name(),
-                            package_json,
-                            dependency.as_package_name(),
-                            dependency_tags,
-                            dependency_permissions.allow.as_ref(),
-                            dependency_permissions.deny.as_ref(),
-                        )?);
-                    }
-                }
-
-                if let Some(dependent_permissions) = &rule.dependents {
-                    for dependent in self.pkg_dep_graph().ancestors(&pkg) {
-                        if matches!(dependent, PackageNode::Root) {
-                            continue;
-                        }
-                        let dependent_tags = self.load_package_tags(dependent.as_package_name());
-                        diagnostics.extend(self.validate_relation(
-                            pkg.as_package_name(),
-                            package_json,
-                            dependent.as_package_name(),
-                            dependent_tags,
-                            dependent_permissions.allow.as_ref(),
-                            dependent_permissions.deny.as_ref(),
-                        )?)
-                    }
-                }
+                self.check_tag(
+                    &mut diagnostics,
+                    rule.dependencies.as_ref(),
+                    rule.dependents.as_ref(),
+                    &pkg,
+                    package_json,
+                )?;
             }
         }
 

--- a/crates/turborepo-lib/src/query/boundaries.rs
+++ b/crates/turborepo-lib/src/query/boundaries.rs
@@ -100,6 +100,14 @@ impl From<BoundariesDiagnostic> for Diagnostic {
                 import: None,
                 reason: Some(tag),
             },
+            BoundariesDiagnostic::PackageBoundariesHasTags { span, text: _ } => Diagnostic {
+                message,
+                path: None,
+                start: span.map(|span| span.offset()),
+                end: span.map(|span| span.offset() + span.len()),
+                import: None,
+                reason: None,
+            },
         }
     }
 }

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -908,6 +908,14 @@ mod tests {
         }"#,
         "implicit dependencies and tags"
     )]
+    #[test_case(
+        r#"{
+          "dependencies": {
+              "allow": ["my-package"]
+          }
+      }"#,
+        "package rule"
+    )]
     fn test_deserialize_boundaries(json: &str, name: &str) {
         let deserialized_result = deserialize_from_json_str(
             json,

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__implicit_dependencies_and_tags.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__implicit_dependencies_and_tags.snap
@@ -5,7 +5,6 @@ expression: raw_boundaries_config
 {
   "tags": {
     "my-tag": {
-      "dependencies": null,
       "dependents": {
         "allow": [
           "my-package"

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__package_rule.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__package_rule.snap
@@ -1,0 +1,12 @@
+---
+source: crates/turborepo-lib/src/turbo_json/mod.rs
+expression: raw_boundaries_config
+---
+{
+  "dependencies": {
+    "allow": [
+      "my-package"
+    ],
+    "deny": null
+  }
+}

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__tags_and_dependencies.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__tags_and_dependencies.snap
@@ -10,8 +10,7 @@ expression: raw_boundaries_config
           "my-package"
         ],
         "deny": null
-      },
-      "dependents": null
+      }
     }
   }
 }

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__tags_and_dependencies_2.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__tags_and_dependencies_2.snap
@@ -12,8 +12,7 @@ expression: raw_boundaries_config
         "deny": [
           "my-other-package"
         ]
-      },
-      "dependents": null
+      }
     }
   }
 }

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__tags_and_dependents.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__tags_and_dependents.snap
@@ -5,7 +5,6 @@ expression: raw_boundaries_config
 {
   "tags": {
     "my-tag": {
-      "dependencies": null,
       "dependents": {
         "allow": [
           "my-package"

--- a/crates/turborepo/tests/snapshots/boundaries__boundaries_tags_get_boundaries_lints_(npm@10.5.0).snap
+++ b/crates/turborepo/tests/snapshots/boundaries__boundaries_tags_get_boundaries_lints_(npm@10.5.0).snap
@@ -11,6 +11,10 @@ expression: query_output
           "import": "@vercel/allowed-and-denied-tag"
         },
         {
+          "message": "Package `@vercel/not-allowed-dependency` found with tag listed in denylist for `@vercel/package-with-boundaries-rules`: `@vercel/not-allowed-dependency`",
+          "import": "@vercel/not-allowed-dependency"
+        },
+        {
           "message": "Package `@vercel/not-allowed-dependent` found without any tag listed in allowlist for `@vercel/allowed-and-denied-tag`",
           "import": "@vercel/not-allowed-dependent"
         },

--- a/turborepo-tests/integration/fixtures/boundaries_tags/package-lock.json
+++ b/turborepo-tests/integration/fixtures/boundaries_tags/package-lock.json
@@ -1,0 +1,77 @@
+{
+  "name": "monorepo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "monorepo",
+      "workspaces": [
+        "apps/*",
+        "packages/*"
+      ]
+    },
+    "apps/my-app": {
+      "name": "@vercel/my-app",
+      "dependencies": {
+        "@vercel/allowed-and-denied-tag": "*",
+        "@vercel/allowed-tag": "*",
+        "@vercel/package-as-tag": "*"
+      }
+    },
+    "node_modules/@vercel/allowed-and-denied-tag": {
+      "resolved": "packages/allowed-and-denied-tag",
+      "link": true
+    },
+    "node_modules/@vercel/allowed-tag": {
+      "resolved": "packages/allowed-tag",
+      "link": true
+    },
+    "node_modules/@vercel/my-app": {
+      "resolved": "apps/my-app",
+      "link": true
+    },
+    "node_modules/@vercel/not-allowed-dependency": {
+      "resolved": "packages/not-allowed-dependency",
+      "link": true
+    },
+    "node_modules/@vercel/not-allowed-dependent": {
+      "resolved": "packages/not-allowed-dependent",
+      "link": true
+    },
+    "node_modules/@vercel/package-as-tag": {
+      "resolved": "packages/package-as-tag",
+      "link": true
+    },
+    "node_modules/@vercel/package-with-boundaries-rules": {
+      "resolved": "packages/package-with-boundaries-rules",
+      "link": true
+    },
+    "packages/allowed-and-denied-tag": {
+      "name": "@vercel/allowed-and-denied-tag"
+    },
+    "packages/allowed-tag": {
+      "name": "@vercel/allowed-tag",
+      "dependencies": {
+        "@vercel/package-as-tag": "*"
+      }
+    },
+    "packages/not-allowed-dependency": {
+      "name": "@vercel/not-allowed-dependency"
+    },
+    "packages/not-allowed-dependent": {
+      "name": "@vercel/not-allowed-dependent",
+      "dependencies": {
+        "@vercel/my-app": "*"
+      }
+    },
+    "packages/package-as-tag": {
+      "name": "@vercel/package-as-tag"
+    },
+    "packages/package-with-boundaries-rules": {
+      "name": "@vercel/package-with-boundaries-rules",
+      "dependencies": {
+        "@vercel/not-allowed-dependency": "*"
+      }
+    }
+  }
+}

--- a/turborepo-tests/integration/fixtures/boundaries_tags/package.json
+++ b/turborepo-tests/integration/fixtures/boundaries_tags/package.json
@@ -3,9 +3,6 @@
   "scripts": {
     "something": "turbo run build"
   },
-  "dependencies": {
-    "module-package": "*"
-  },
   "packageManager": "npm@10.5.0",
   "workspaces": [
     "apps/*",

--- a/turborepo-tests/integration/fixtures/boundaries_tags/packages/allowed-and-denied-tag/package.json
+++ b/turborepo-tests/integration/fixtures/boundaries_tags/packages/allowed-and-denied-tag/package.json
@@ -2,8 +2,5 @@
   "name": "@vercel/allowed-and-denied-tag",
   "scripts": {
     "dev": "echo building"
-  },
-  "dependencies": {
-    "utils": "*"
   }
 }

--- a/turborepo-tests/integration/fixtures/boundaries_tags/packages/allowed-tag/package.json
+++ b/turborepo-tests/integration/fixtures/boundaries_tags/packages/allowed-tag/package.json
@@ -2,7 +2,6 @@
   "name": "@vercel/allowed-tag",
   "module": "my-module.mjs",
   "dependencies": {
-    "@vercel/no-allowlist": "*",
     "@vercel/package-as-tag": "*"
   }
 }

--- a/turborepo-tests/integration/fixtures/boundaries_tags/packages/not-allowed-dependency/package.json
+++ b/turborepo-tests/integration/fixtures/boundaries_tags/packages/not-allowed-dependency/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@vercel/not-allowed-dependency"
+}

--- a/turborepo-tests/integration/fixtures/boundaries_tags/packages/package-with-boundaries-rules/package.json
+++ b/turborepo-tests/integration/fixtures/boundaries_tags/packages/package-with-boundaries-rules/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@vercel/package-with-boundaries-rules",
+  "dependencies": {
+    "@vercel/not-allowed-dependency": "*"
+  }
+}

--- a/turborepo-tests/integration/fixtures/boundaries_tags/packages/package-with-boundaries-rules/turbo.json
+++ b/turborepo-tests/integration/fixtures/boundaries_tags/packages/package-with-boundaries-rules/turbo.json
@@ -1,0 +1,9 @@
+{
+  "boundaries": {
+    "dependencies": {
+      "deny": [
+        "@vercel/not-allowed-dependency"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
### Description

Adds the ability for boundaries rules to be defined in the package `turbo.json`. These rules are specific to that package and are designed to work with code owners so that a package can restrict who imports it.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
