### PR TITLE
chore(docs): convert 'Turbo' into 'Turborepo'

### DIFF
--- a/docs/site/app/(no-sidebar)/blog/not-found.tsx
+++ b/docs/site/app/(no-sidebar)/blog/not-found.tsx
@@ -14,7 +14,7 @@ export default function NotFound(): JSX.Element {
       content={
         <div className="flex flex-col gap-12 mx-auto">
           <p className="text-center text-gray-500 dark:text-gray-400">
-            The latest updates and releases from the Turbo team at Vercel.
+            The latest updates and releases from the Turborepo team at Vercel.
           </p>
           {posts.map((post) => {
             if ("isExternal" in post.data) {

--- a/docs/site/app/(no-sidebar)/confirm/page.tsx
+++ b/docs/site/app/(no-sidebar)/confirm/page.tsx
@@ -8,12 +8,12 @@ export function Confirm(): JSX.Element {
               <h2 className="text-xl font-bold">Thanks so much!</h2>
               <p>
                 Keep an eye on your inbox for product updates and announcements
-                from Turbo and Vercel.
+                from Turborepo and Vercel.
               </p>{" "}
               <p>
                 Thanks,
                 <br />
-                The Turbo Team
+                The Turborepo Team
               </p>
             </div>
           </div>

--- a/docs/site/app/_components/footer.tsx
+++ b/docs/site/app/_components/footer.tsx
@@ -172,8 +172,8 @@ function FooterContent(): JSX.Element {
           <div className="mt-12 xl:!mt-0">
             <FooterHeader>Subscribe to our newsletter</FooterHeader>
             <p className="mt-4 text-sm text-gray-600 dark:text-[#888888]">
-              Subscribe to the Turbo newsletter and stay updated on new releases
-              and features, guides, and case studies.
+              Subscribe to the Turborepo newsletter and stay updated on new
+              releases and features, guides, and case studies.
             </p>
             <SubmitForm />
           </div>

--- a/docs/site/app/_components/logos.tsx
+++ b/docs/site/app/_components/logos.tsx
@@ -134,7 +134,7 @@ export function TurborepoLogo({
   return (
     <svg
       className={className}
-      aria-label="Turbo logomark"
+      aria-label="Turborepo logomark"
       height="80"
       role="img"
       viewBox="0 0 40 40"

--- a/docs/site/components/search-dialog.tsx
+++ b/docs/site/components/search-dialog.tsx
@@ -4,7 +4,6 @@ import { gitHubRepoUrl } from "@/lib/constants";
 import algo from "algoliasearch/lite";
 import type { SharedProps } from "fumadocs-ui/components/dialog/search";
 import FumaSearchDialog from "fumadocs-ui/components/dialog/search-algolia";
-import { usePathname } from "next/navigation";
 
 const client = algo(
   process.env.NEXT_PUBLIC_ALGOLIA_APP_ID,
@@ -14,8 +13,6 @@ const client = algo(
 const index = client.initIndex(process.env.NEXT_PUBLIC_ALGOLIA_INDEX!);
 
 export function SearchDialog(props: SharedProps): JSX.Element {
-  const path = usePathname();
-
   return (
     <FumaSearchDialog
       index={index}
@@ -23,7 +20,6 @@ export function SearchDialog(props: SharedProps): JSX.Element {
       links={[
         ["Home", "/"],
         ["Turborepo documentation", "/repo/docs"],
-        ["Turbopack documentation", "/pack/docs"],
         ["Blog", "/blog"],
         ["Changelog", `${gitHubRepoUrl}/releases`],
         ["Github", gitHubRepoUrl],

--- a/docs/site/content/extra/governance.mdx
+++ b/docs/site/content/extra/governance.mdx
@@ -1,37 +1,37 @@
 ---
 title: Governance
-description: Turbo by Vercel is the next-generation build system for the web.
+description: Turborepo by Vercel is the next-generation build system for the web.
 ---
 
 - Turborepo was created by the team at [Vercel](https://vercel.com) in 2020.
 - Turbopack was created by the team at [Vercel](https://vercel.com) in 2022.
 
-The research and development of Turbo is led by the core team working full-time at Vercel. Turbo is a collaborative open-source effort to build tools for web developers.
+The research and development of Turborepo is led by the core team working full-time at Vercel. Turborepo is a collaborative open-source effort to build tools for web developers.
 
 ## Teams
 
-**Core Team**: Turborepo and Turbopack teams at [Vercel](https://vercel.com) manage the direction of Turbo and leadership of the project.
+**Core Team**: Turborepo and Turbopack teams at [Vercel](https://vercel.com) manage the direction of Turborepo and leadership of the project.
 
 **Documentation**: DevRel teams at [Vercel](https://vercel.com) manage documentation and learning platforms.
 
 ## Roadmap and RFC Process
 
-Large architecture decisions and features start as a [Request for Comments (RFC)](https://github.com/vercel/turbo/discussions/categories/rfc) inside GitHub Discussions. The entire Turbo community is invited to be involved in the process and discuss the tradeoffs of proposed work.
+Large architecture decisions and features start as a [Request for Comments (RFC)](https://github.com/vercel/turbo/discussions/categories/rfc) inside GitHub Discussions. The entire Turborepo community is invited to be involved in the process and discuss the tradeoffs of proposed work.
 
 This process is essential to ensure features are built together with the community and our collaborators. More minor changes including bug fixes and documentation improvements are still implemented through GitHub pull requests. However, for larger initiatives, we believe it's essential to follow the RFC process.
 
 ## Stability and release phases
 
 - **Experimental**: Experimental features lack essential capabilities required to be ready for stability. The feature is considered to be under active development and is being built to transition into Beta.
-- **Beta**: Beta means the feature does not yet meet our quality standards for a stable release. There is also usually a need for more information or feedback from Turbo developers to validate this feature works as expected in a variety of environments.
+- **Beta**: Beta means the feature does not yet meet our quality standards for a stable release. There is also usually a need for more information or feedback from Turborepo developers to validate this feature works as expected in a variety of environments.
 - **Stable**: When the features reach stability, it is considered ready for use in production. APIs marked as stable will only change in a backward-compatible way unless there is a major release.
 - **Deprecated**: A feature is in the process of being removed. Deprecated features include documentation for existing users with the next steps and information on when to expect the feature to be removed.
 
-## Turbo Support
+## Turborepo Support
 
-For individual developers looking for free support on their Turbo repositories, they can ask questions in [GitHub Discussions](https://github.com/vercel/turbo/discussions) or in [Vercel Community's `#turborepo` tag](https://vercel.community/tag/turborepo).
+For individual developers looking for free support on their Turborepo repositories, they can ask questions in [GitHub Discussions](https://github.com/vercel/turbo/discussions) or in [Vercel Community's `#turborepo` tag](https://vercel.community/tag/turborepo).
 
-For companies looking for paid support on their Turbo repositories, they can [contact the Turbo team at Vercel](https://vercel.com/contact) for more information.
+For companies looking for paid support on their Turborepo repositories, they can [contact the Turborepo team at Vercel](https://vercel.com/contact) for more information.
 
 ## Additional Resources
 

--- a/docs/site/content/repo-docs/community.mdx
+++ b/docs/site/content/repo-docs/community.mdx
@@ -1,6 +1,6 @@
 ---
 title: Community
-description: Learn about the Turbo community.
+description: Learn about the Turborepo community.
 ---
 
 With over 2 million weekly downloads, Turborepo has a large and active community of developers across the world. Here's how you can get involved.

--- a/docs/site/content/repo-docs/crafting-your-repository/understanding-your-repository.mdx
+++ b/docs/site/content/repo-docs/crafting-your-repository/understanding-your-repository.mdx
@@ -53,7 +53,7 @@ No tasks provided, here are some potential ones
 
 ## `turbo query`
 
-If you wish to dig into your repository structure, since `2.2.0`, Turbo provides a GraphQL interface into your repository
+If you wish to dig into your repository structure, since `2.2.0`, Turborepo provides a GraphQL interface into your repository
 via `turbo query`. You can execute queries such as finding all packages that have a `test` task:
 
 ```bash title="Terminal"

--- a/docs/site/content/repo-docs/guides/ci-vendors/github-actions.mdx
+++ b/docs/site/content/repo-docs/guides/ci-vendors/github-actions.mdx
@@ -252,7 +252,7 @@ The following steps exemplify how you could use [actions/cache](https://github.c
 
 <Steps>
 <Step>
-Supply a package.json script that will run tasks using Turbo.
+Supply a package.json script that will run tasks using Turborepo.
 
 Example `package.json` with a `build` script:
 

--- a/docs/site/content/repo-docs/messages/invalid-env-prefix.mdx
+++ b/docs/site/content/repo-docs/messages/invalid-env-prefix.mdx
@@ -6,7 +6,7 @@ description: Learn more about errors with invalid environment variable prefixes 
 ## Why this error occurred
 
 When declaring environment variables in your `turbo.json`, you cannot prefix them with `$`. This
-was an old syntax for declaring a dependency on an environment variable that was deprecated in Turbo 1.5.
+was an old syntax for declaring a dependency on an environment variable that was deprecated in Turborepo 1.5.
 
 ```json title="./turbo.json"
 {

--- a/docs/site/content/repo-docs/reference/run.mdx
+++ b/docs/site/content/repo-docs/reference/run.mdx
@@ -369,11 +369,11 @@ By default, `turbo` will use `grouped` logs in CI environments and `stream` logs
 turbo run build --log-order=stream
 ```
 
-| Option    | Description                                   |
-| --------- | --------------------------------------------- |
-| `stream`  | Show output as soon as it is available        |
-| `grouped` | Group output by task                          |
-| `auto`    | Turborepo decides based on its own heuristics |
+| Option    | Description                                 |
+| --------- | ------------------------------------------- |
+| `stream`  | Show output as soon as it is available      |
+| `grouped` | Group output by task                        |
+| `auto`    | `turbo` decides based on its own heuristics |
 
 ### `--log-prefix <option>`
 

--- a/docs/site/content/repo-docs/reference/run.mdx
+++ b/docs/site/content/repo-docs/reference/run.mdx
@@ -369,11 +369,11 @@ By default, `turbo` will use `grouped` logs in CI environments and `stream` logs
 turbo run build --log-order=stream
 ```
 
-| Option    | Description                               |
-| --------- | ----------------------------------------- |
-| `stream`  | Show output as soon as it is available    |
-| `grouped` | Group output by task                      |
-| `auto`    | Turbo decides based on its own heuristics |
+| Option    | Description                                   |
+| --------- | --------------------------------------------- |
+| `stream`  | Show output as soon as it is available        |
+| `grouped` | Group output by task                          |
+| `auto`    | Turborepo decides based on its own heuristics |
 
 ### `--log-prefix <option>`
 

--- a/docs/site/content/repo-docs/reference/scan.mdx
+++ b/docs/site/content/repo-docs/reference/scan.mdx
@@ -8,7 +8,7 @@ Enable faster tooling for your Turborepo locally with one, interactive command.
 You'll be taken through a short series of steps to enable the fastest settings for your Turborepo. These optimizations include:
 
 - **Git FS Monitor**: `turbo` leans on Git to do file change discovery. Since we have to wait for `git` to tell us about changes, we can use [Git's built-in filesystem monitor](https://git-scm.com/docs/git-fsmonitor--daemon) to get those notifications sooner.
-- **Turbo Daemon**: Turborepo's daemon optimistically understands your repository in the background. By doing shared, common work that `turbo` will need to do when running tasks beforehand, `turbo` will run your tasks faster.
+- **Turborepo Daemon**: Turborepo's daemon optimistically understands your repository in the background. By doing shared, common work that `turbo` will need to do when running tasks beforehand, `turbo` will run your tasks faster.
 - **Remote Caching**: While Turborepo can cache your work locally, it can also share a cache across all of your machines. Enabling [Remote Caching](/repo/docs/core-concepts/remote-caching) makes your caching **multiplayer**, ensuring that you, your teammates, and your CI machines, never do the same work twice.
 - **Check `turbo` version**: We're always working towards making `turbo` better. To ensure you are using the latest version of Turborepo, we'll check your version and remind you to install `latest` if you aren't using it yet.
 - **Check for Turborepo LSP**:

--- a/docs/site/lib/constants.ts
+++ b/docs/site/lib/constants.ts
@@ -1,6 +1,6 @@
 export const PRODUCT_SLOGANS = {
   turbo:
-    "Turbo is an incremental bundler and build system optimized for JavaScript and TypeScript, written in Rust.",
+    "Turborepo is a build system optimized for JavaScript and TypeScript, written in Rust.",
   repo: "The build system that makes ship happen.",
 } as const;
 

--- a/docs/site/lib/create-metadata.ts
+++ b/docs/site/lib/create-metadata.ts
@@ -57,15 +57,9 @@ export const createMetadata = ({
     console.warn(`Warning: ${canonicalPath} does not have a description.`);
   }
 
-  const formatTitle = (): string => {
-    return title ?? "Turborepo";
-  };
-
-  const formattedTitle = formatTitle();
-
   return {
     metadataBase: getBaseURL(),
-    title: formattedTitle,
+    title: title ? `${title} | Turborepo` : "Turborepo",
     description,
     openGraph: {
       siteName: "Turborepo",

--- a/docs/site/lib/create-metadata.ts
+++ b/docs/site/lib/create-metadata.ts
@@ -46,9 +46,7 @@ export const createMetadata = ({
   title,
   description,
   canonicalPath,
-  product,
 }: {
-  product?: Products;
   title?: string;
   description?: string;
   /** You do not need to supply the domain! `metadataBase` already does that for you. */
@@ -60,15 +58,7 @@ export const createMetadata = ({
   }
 
   const formatTitle = (): string => {
-    if (canonicalPath === "/repo") {
-      return "Turborepo";
-    }
-
-    if (product === "repo") {
-      return `${title} | Turborepo`;
-    }
-
-    return title ?? "Turbo";
+    return title ?? "Turborepo";
   };
 
   const formattedTitle = formatTitle();
@@ -78,11 +68,10 @@ export const createMetadata = ({
     title: formattedTitle,
     description,
     openGraph: {
-      siteName: "Turbo",
+      siteName: "Turborepo",
       images: [
         createOgImagePath({
           title: canonicalPath === "/" ? "" : title,
-          product,
           canonicalPath,
         }),
       ],

--- a/docs/site/scripts/generate-rss.cjs
+++ b/docs/site/scripts/generate-rss.cjs
@@ -1,7 +1,7 @@
-const { promises: fs, statSync } = require('node:fs');
-const path = require('node:path');
-const RSS = require('rss');
-const matter = require('gray-matter');
+const { promises: fs, statSync } = require("node:fs");
+const path = require("node:path");
+const RSS = require("rss");
+const matter = require("gray-matter");
 
 function dateSortDesc(a, b) {
   const date1 = new Date(a.data.date);
@@ -13,23 +13,23 @@ function dateSortDesc(a, b) {
 
 async function generate() {
   const feed = new RSS({
-    title: 'Turbo Blog',
-    description: 'Turbo news, updates, and announcements.',
-    site_url: 'https://turbo.build',
-    feed_url: 'https://turbo.build/feed.xml',
-    image_url: 'https://turbo.build/api/og',
+    title: "Turborepo Blog",
+    description: "Turborepo news, updates, and announcements.",
+    site_url: "https://turbo.build",
+    feed_url: "https://turbo.build/feed.xml",
+    image_url: "https://turbo.build/api/og",
   });
 
-  const posts = await fs.readdir(path.join(__dirname, '..', 'content', 'blog'));
+  const posts = await fs.readdir(path.join(__dirname, "..", "content", "blog"));
 
   const promises = posts.map(async (post) => {
-    if (post.startsWith('index.') || post.startsWith('_meta.json')) return;
+    if (post.startsWith("index.") || post.startsWith("_meta.json")) return;
     const file = await fs.readFile(
-      path.join(__dirname, '..', 'content', 'blog', post),
+      path.join(__dirname, "..", "content", "blog", post)
     );
     const frontmatter = matter(file);
     if (frontmatter.data.href) return;
-    return { ...frontmatter, slug: post.replace('.mdx', '') };
+    return { ...frontmatter, slug: post.replace(".mdx", "") };
   });
 
   const results = await Promise.all(promises);
@@ -41,7 +41,7 @@ async function generate() {
   for (const frontmatter of sortedData) {
     // get the og image size
     const stat = statSync(
-      path.join(__dirname, '..', 'public', frontmatter.data.ogImage),
+      path.join(__dirname, "..", "public", frontmatter.data.ogImage)
     );
     feed.item({
       title: frontmatter.data.title,
@@ -50,13 +50,13 @@ async function generate() {
       description: frontmatter.data.description,
       enclosure: {
         url: `https://turbo.build${frontmatter.data.ogImage}`, // intentionally omitting slash here
-        type: 'image/png',
+        type: "image/png",
         size: stat.size,
       },
     });
   }
 
-  await fs.writeFile('./public/feed.xml', feed.xml({ indent: true }));
+  await fs.writeFile("./public/feed.xml", feed.xml({ indent: true }));
 }
 
 generate();


### PR DESCRIPTION
### Description

Swapping out places where things say "Turbo" to be "Turborepo" as we convert the site. When we say "Turbo", we mean `turbo` or "Turborepo".