### PR TITLE
ci: make working on docs faster

### DIFF
--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -56,7 +56,7 @@ jobs:
               - "turborepo-tests/example-with-svelte-*/**"
               - "turborepo-tests/helpers/**"
             rest:
-              - "!(docs/**|examples/**)**"
+              - "!(examples/**|docs/**)**"
 
   integration:
     name: Turborepo Integration


### PR DESCRIPTION
### Description

This globbing syntax refuses to work how I want it to, no matter how hard I try. I'm just going to swap the order for now so I can work on docs fast without running all our 20 minute checks.

(This will make working on examples slow again, but that's a tradeoff I'm willing to make at this time.)
