### PR TITLE
docs(run): fix passthrough arg behavior

### DIFF
--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -893,6 +893,13 @@ mod test {
         "multiple tasks"
     )]
     #[test_case(
+        vec!["test".to_string()],
+        vec!["passthrough".to_string()],
+        TaskId::new("web", "build"),
+        None;
+        "different task"
+    )]
+    #[test_case(
         vec!["web#build".to_string()],
         vec!["passthrough".to_string()],
         TaskId::new("web", "build"),

--- a/docs/site/content/repo-docs/reference/run.mdx
+++ b/docs/site/content/repo-docs/reference/run.mdx
@@ -13,7 +13,7 @@ turbo run [tasks] [options] [-- [args passed to tasks]]
 
 - **[tasks]**: Turborepo can run one or many tasks at the same time. To run a task through `turbo`, it must be specified in `turbo.json`.
 - **[options]**: Options are used to control the behavior of the `turbo run` command. Available flag options are described below.
-- **[-- [args passed to tasks]]**: You may also pass arguments to the underlying scripts. Note that all arguments will be passed to all tasks.
+- **[-- [args passed to tasks]]**: You may also pass arguments to the underlying scripts. Note that all arguments will be passed to all tasks that are named in the run command.
 
 <Callout type="good-to-know">
   `turbo run` is aliased to `turbo`. `turbo run build lint check-types` is the


### PR DESCRIPTION
### Description

Updating documentation around pass through args to address #8089.

This has been our behavior since 1.0 and I believe changing it would require a major semver bump.

We pass any pass through args to tasks that match the name of one of the tasks provided to the `turbo run` command. I believe this makes sense as your `test` tool probably accepts different arguments than your `build` tool so if `turbo test -- --coverage=true` passed `--coverage=true` to not just `jest`, but also `esbuild` which might error when given that argument. If you did want it to be passed to build you can achieve this by running `turbo build test -- --global-flag`.

### Testing Instructions

Added a unit test for this behavior. 

Also spot checked that this has been the behavior since 1.2.0 (earliest version I can get working without too much work). Tested by running `pnpm turbo run test --filter=@repo/ui  -- passthru`

1.2.0

```
• Packages in scope: @repo/ui
• Running test in 1 packages
@repo/ui:build: cache hit, replaying output 9509f6022cfb8b76
@repo/ui:build: 
@repo/ui:build: > @repo/ui@0.0.0 build /private/tmp/pass-thru/packages/ui
@repo/ui:build: > echo building: 
@repo/ui:build: 
@repo/ui:build: building:
@repo/ui:test: cache hit, replaying output 9b006b1111a435ab
@repo/ui:test: 
@repo/ui:test: > @repo/ui@0.0.0 test /private/tmp/pass-thru/packages/ui
@repo/ui:test: > echo testing:  "passthru"
@repo/ui:test: 
@repo/ui:test: testing: passthru

 Tasks:    2 successful, 2 total
Cached:    2 cached, 2 total
  Time:    40ms >>> FULL TURBO
```

1.6.0
```
• Packages in scope: @repo/ui
• Running test in 1 packages
• Remote caching disabled
@repo/ui:build: cache hit, replaying output 462fe8a87d3ab7c0
@repo/ui:build: 
@repo/ui:build: > @repo/ui@0.0.0 build /private/tmp/pass-thru/packages/ui
@repo/ui:build: > echo building: 
@repo/ui:build: 
@repo/ui:build: building:
@repo/ui:test: cache hit, replaying output 6fb610019c2f32a2
@repo/ui:test: 
@repo/ui:test: > @repo/ui@0.0.0 test /private/tmp/pass-thru/packages/ui
@repo/ui:test: > echo testing:  "passthru"
@repo/ui:test: 
@repo/ui:test: testing: passthru

 Tasks:    2 successful, 2 total
Cached:    2 cached, 2 total
  Time:    40ms >>> FULL TURBO
```

2.4.4
```
• Packages in scope: @repo/ui
• Running test in 1 packages
• Remote caching disabled
@repo/ui:build: cache hit, replaying logs 074103acac2242fe
@repo/ui:build: 
@repo/ui:build: 
@repo/ui:build: > @repo/ui@0.0.0 build /private/tmp/pass-thru/packages/ui
@repo/ui:build: > echo building: 
@repo/ui:build: 
@repo/ui:build: building:
@repo/ui:test: cache hit, replaying logs 0299610cfc01eeff
@repo/ui:test: 
@repo/ui:test: 
@repo/ui:test: > @repo/ui@0.0.0 test /private/tmp/pass-thru/packages/ui
@repo/ui:test: > echo testing:  "passthru"
@repo/ui:test: 
@repo/ui:test: testing: passthru

 Tasks:    2 successful, 2 total
Cached:    2 cached, 2 total
  Time:    42ms >>> FULL TURBO


```