### PR TITLE
chore(ci): install optional deps when testing JS packages

### DIFF
--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -58,7 +58,6 @@ jobs:
       - name: "Setup Node"
         uses: ./.github/actions/setup-node
         with:
-          extra-flags: --no-optional
           node-version: ${{ matrix.node-version }}
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1


### PR DESCRIPTION
### Description

See failure on #10168
```
Error: Cannot find module @rollup/rollup-linux-x64-gnu. npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828). Please try `npm i` again after removing both package-lock.json and node_modules directory.
```
[source](https://github.com/vercel/turborepo/actions/runs/13862424976/job/38794202787#step:6:461)

Rollup distributes binaries using the same strategy we do so skipping installing optional dependencies skips installing the actual binary.

### Testing Instructions

Will open PR against this one that triggers `eslint-config-turbo#build`: https://github.com/vercel/turborepo/actions/runs/13862902922?pr=10171
