### PR TITLE
feat(bun): bun prune support

### DIFF
--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -47,8 +47,6 @@ pub enum Error {
     MissingWorkspace(PackageName),
     #[error("Cannot prune without parsed lockfile.")]
     MissingLockfile,
-    #[error("`prune` is not supported for Bun.")]
-    BunUnsupported,
     #[error("Unable to read config: {0}")]
     Config(#[from] crate::config::Error),
 }
@@ -105,13 +103,6 @@ pub async fn prune(
     telemetry.track_arg_usage("out-dir", output_dir != DEFAULT_OUTPUT_DIR);
 
     let prune = Prune::new(base, scope, docker, output_dir, use_gitignore, telemetry).await?;
-
-    if matches!(
-        prune.package_graph.package_manager(),
-        turborepo_repository::package_manager::PackageManager::Bun
-    ) {
-        return Err(Error::BunUnsupported);
-    }
 
     println!(
         "Generating pruned monorepo for {} in {}",

--- a/crates/turborepo-lockfiles/src/bun/de.rs
+++ b/crates/turborepo-lockfiles/src/bun/de.rs
@@ -3,6 +3,7 @@ use std::collections::VecDeque;
 use serde::Deserialize;
 
 use super::{PackageEntry, PackageInfo};
+use crate::bun::RootInfo;
 // Comment explaining entry schemas taken from bun.lock.zig
 // first index is resolution for each type of package
 // npm         -> [
@@ -25,7 +26,7 @@ impl<'de> Deserialize<'de> for PackageEntry {
         D: serde::Deserializer<'de>,
     {
         use serde::de;
-        #[derive(Deserialize)]
+        #[derive(Deserialize, Debug)]
         #[serde(untagged)]
         enum Vals {
             Str(String),
@@ -46,20 +47,50 @@ impl<'de> Deserialize<'de> for PackageEntry {
         };
         // For workspace packages deps are second element, rest have them as third
         // element
-        let info = vals
-            .pop_front()
-            .and_then(val_to_info)
-            .or_else(|| vals.pop_front().and_then(val_to_info));
+
+        let mut registry = None;
+        let mut info = None;
+
+        if key.ends_with("@root:") {
+            let root = vals.pop_front().and_then(|val| {
+                serde_json::from_value::<RootInfo>(match val {
+                    Vals::Info(info) => {
+                        serde_json::to_value(info.other).expect("failed to convert info to value")
+                    }
+                    _ => return None,
+                })
+                .ok()
+            });
+            return Ok(Self {
+                ident: key,
+                info,
+                registry,
+                checksum: None,
+                root,
+            });
+        }
+
+        // The second value can be either registry (string) or info (object)
+        vals.pop_front().map(|val| match val {
+            Vals::Str(reg) => registry = Some(reg),
+            Vals::Info(package_info) => info = Some(*package_info),
+        });
+
+        // Info will be next if we haven't already found it
+        if info.is_none() {
+            info = vals.pop_front().and_then(val_to_info);
+        }
+
+        // Checksum is last
         let checksum = vals.pop_front().and_then(|val| match val {
             Vals::Str(sha) => Some(sha),
             Vals::Info(_) => None,
         });
+
         Ok(Self {
             ident: key,
             info,
-            // The rest are only necessary for serializing a lockfile and aren't needed until adding
-            // `prune` support
-            registry: None,
+            registry,
             checksum,
             root: None,
         })
@@ -114,7 +145,7 @@ mod test {
         PackageEntry,
         PackageEntry {
             ident: "is-odd@3.0.1".into(),
-            registry: None,
+            registry: Some("".into()),
             info: Some(PackageInfo {
                 dependencies: Some(("is-number".into(), "^6.0.0".into()))
                     .into_iter()
@@ -142,10 +173,26 @@ mod test {
             root: None,
         }
     );
+
+    fixture!(
+        root_pkg,
+        PackageEntry,
+        PackageEntry {
+            ident: "some-package@root:".into(),
+            root: Some(RootInfo {
+                bin: Some("bin".into()),
+                bin_dir: Some("binDir".into()),
+            }),
+            info: None,
+            registry: None,
+            checksum: None,
+        }
+    );
     #[test_case(json!({"name": "bun-test", "devDependencies": {"turbo": "^2.3.3"}}), basic_workspace() ; "basic")]
     #[test_case(json!({"name": "docs", "version": "0.1.0"}), workspace_with_version() ; "with version")]
     #[test_case(json!(["is-odd@3.0.1", "", {"dependencies": {"is-number": "^6.0.0"}}, "sha"]), registry_pkg() ; "registry package")]
     #[test_case(json!(["docs", {"dependencies": {"is-odd": "3.0.1"}}]), workspace_pkg() ; "workspace package")]
+    #[test_case(json!(["some-package@root:", {"bin": "bin", "binDir": "binDir"}]), root_pkg() ; "root package")]
     fn test_deserialization<T: for<'a> Deserialize<'a> + PartialEq + std::fmt::Debug>(
         input: serde_json::Value,
         expected: &T,

--- a/crates/turborepo-lockfiles/src/bun/de.rs
+++ b/crates/turborepo-lockfiles/src/bun/de.rs
@@ -72,9 +72,11 @@ impl<'de> Deserialize<'de> for PackageEntry {
         }
 
         // The second value can be either registry (string) or info (object)
-        vals.pop_front().map(|val| match val {
-            Vals::Str(reg) => registry = Some(reg),
-            Vals::Info(package_info) => info = Some(*package_info),
+        let Some(val) = vals.pop_front() {
+            match val {
+                Vals::Str(reg) => registry = Some(reg),
+                Vals::Info(package_info) => info = Some(*package_info),
+            }
         });
 
         // Info will be next if we haven't already found it

--- a/crates/turborepo-lockfiles/src/bun/de.rs
+++ b/crates/turborepo-lockfiles/src/bun/de.rs
@@ -72,7 +72,7 @@ impl<'de> Deserialize<'de> for PackageEntry {
         }
 
         // The second value can be either registry (string) or info (object)
-        let Some(val) = vals.pop_front() {
+        if let Some(val) = vals.pop_front() {
             match val {
                 Vals::Str(reg) => registry = Some(reg),
                 Vals::Info(package_info) => info = Some(*package_info),

--- a/crates/turborepo-lockfiles/src/bun/de.rs
+++ b/crates/turborepo-lockfiles/src/bun/de.rs
@@ -77,7 +77,7 @@ impl<'de> Deserialize<'de> for PackageEntry {
                 Vals::Str(reg) => registry = Some(reg),
                 Vals::Info(package_info) => info = Some(*package_info),
             }
-        });
+        };
 
         // Info will be next if we haven't already found it
         if info.is_none() {

--- a/crates/turborepo-lockfiles/src/bun/mod.rs
+++ b/crates/turborepo-lockfiles/src/bun/mod.rs
@@ -23,8 +23,6 @@ pub enum Error {
     Format(#[from] biome_formatter::FormatError),
     #[error("Failed to strip commas: {0}")]
     Print(#[from] biome_formatter::PrintError),
-    #[error("Turborepo cannot serialize Bun lockfiles.")]
-    NotImplemented,
     #[error("{ident} had two entries with differing checksums: {sha1}, {sha2}")]
     MismatchedShas {
         ident: String,
@@ -33,13 +31,13 @@ pub enum Error {
     },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct BunLockfile {
     data: BunLockfileData,
     key_to_entry: HashMap<String, String>,
 }
 
-#[derive(Debug, Deserialize, Clone, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BunLockfileData {
     #[allow(unused)]
@@ -263,7 +261,11 @@ impl BunLockfile {
         }
 
         // Add root workspace
-        let root_workspace = self.data.workspaces.get("").expect("root workspace");
+        let root_workspace = self
+            .data
+            .workspaces
+            .get("")
+            .expect("root workspace should exist");
         new_workspaces.insert("".to_string(), root_workspace.clone());
 
         for workspace in workspace_packages {

--- a/crates/turborepo-lockfiles/src/bun/mod.rs
+++ b/crates/turborepo-lockfiles/src/bun/mod.rs
@@ -234,7 +234,7 @@ impl BunLockfile {
             .iter()
             .filter_map(|(key, entry)| {
                 // Ensure the root workspace package is included, which is always indexed by ""
-                if key == "" || workspace_packages.contains(&key) {
+                if key.is_empty() || workspace_packages.contains(key) {
                     Some((key.clone(), entry.clone()))
                 } else {
                     None

--- a/crates/turborepo-lockfiles/src/bun/mod.rs
+++ b/crates/turborepo-lockfiles/src/bun/mod.rs
@@ -393,6 +393,35 @@ mod test {
         );
     }
 
+    // There are multiple aliases that resolve to the same ident, here we test that
+    // we output them all
+    #[test]
+    fn test_deduplicated_idents() {
+        // chalk@2.4.2
+        let lockfile = BunLockfile::from_str(BASIC_LOCKFILE).unwrap();
+        let subgraph = lockfile
+            .subgraph(&["apps/docs".into()], &["chalk@2.4.2".into()])
+            .unwrap();
+        let subgraph_data = subgraph.lockfile().unwrap();
+
+        assert_eq!(
+            subgraph_data
+                .packages
+                .iter()
+                .map(|(key, pkg)| (key.as_str(), pkg.ident.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("@turbo/gen/chalk", "chalk@2.4.2"),
+                ("@turbo/workspaces/chalk", "chalk@2.4.2"),
+                ("log-symbols/chalk", "chalk@2.4.2")
+            ]
+        );
+        assert_eq!(
+            subgraph_data.workspaces.keys().collect::<Vec<_>>(),
+            vec!["", "apps/docs"]
+        );
+    }
+
     #[test]
     fn test_patch_subgraph() {
         let lockfile = BunLockfile::from_str(PATCH_LOCKFILE).unwrap();

--- a/crates/turborepo-lockfiles/src/bun/ser.rs
+++ b/crates/turborepo-lockfiles/src/bun/ser.rs
@@ -1,0 +1,82 @@
+use serde::{ser::SerializeTuple, Serialize};
+
+use super::PackageEntry;
+
+impl Serialize for PackageEntry {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut tuple = serializer.serialize_tuple(4)?;
+        tuple.serialize_element(&self.ident)?;
+
+        if let Some(info) = &self.info {
+            tuple.serialize_element(&self.registry.as_deref().unwrap_or(""))?;
+            tuple.serialize_element(info)?;
+            tuple.serialize_element(&self.checksum)?;
+            if let Some(root) = &self.root {
+                tuple.serialize_element(root)?;
+            }
+        };
+
+        tuple.end()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use serde_json::json;
+
+    use super::*;
+    use crate::bun::PackageInfo;
+
+    #[test]
+    fn test_serialize_registry_package() {
+        let package = PackageEntry {
+            ident: "is-odd@3.0.1".into(),
+            registry: Some("registry".into()),
+            info: Some(PackageInfo {
+                dependencies: [("is-number".into(), "^6.0.0".into())]
+                    .into_iter()
+                    .collect(),
+                ..Default::default()
+            }),
+            checksum: Some("sha".into()),
+            root: None,
+        };
+
+        let expected =
+            json!(["is-odd@3.0.1", "registry", {"dependencies": {"is-number": "^6.0.0"}}, "sha"]);
+        let actual = serde_json::to_value(&package).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_serialize_registry_package_no_deps() {
+        let package = PackageEntry {
+            ident: "is-odd@3.0.1".into(),
+            registry: Some("registry".into()),
+            info: Some(PackageInfo {
+                ..Default::default()
+            }),
+            checksum: Some("sha".into()),
+            root: None,
+        };
+
+        let expected = json!(["is-odd@3.0.1", "registry", {}, "sha"]);
+        let actual = serde_json::to_value(&package).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_serialize_workspace_package() {
+        let package = PackageEntry {
+            ident: "@workspace/package".into(),
+            registry: None,
+            info: None,
+            checksum: None,
+            root: None,
+        };
+
+        let expected = json!(["@workspace/package"]);
+        let actual = serde_json::to_value(&package).unwrap();
+        assert_eq!(actual, expected);
+    }
+}

--- a/crates/turborepo-lockfiles/src/bun/ser.rs
+++ b/crates/turborepo-lockfiles/src/bun/ser.rs
@@ -4,7 +4,7 @@ use super::PackageEntry;
 
 impl Serialize for PackageEntry {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut tuple = serializer.serialize_tuple(4)?;
+        let mut tuple = serializer.serialize_tuple(5)?;
         tuple.serialize_element(&self.ident)?;
 
         if let Some(info) = &self.info {

--- a/crates/turborepo-lockfiles/src/bun/ser.rs
+++ b/crates/turborepo-lockfiles/src/bun/ser.rs
@@ -21,6 +21,8 @@ use super::PackageEntry;
 impl Serialize for PackageEntry {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut tuple = serializer.serialize_tuple(4)?;
+
+        // First value is always the package key
         tuple.serialize_element(&self.ident)?;
 
         // For root packages, only thing left to serialize is the root info
@@ -50,16 +52,13 @@ impl Serialize for PackageEntry {
 
 #[cfg(test)]
 mod test {
-    use std::{str::FromStr, sync::OnceLock};
+    use std::sync::OnceLock;
 
     use serde_json::json;
     use test_case::test_case;
 
     use super::*;
-    use crate::{
-        bun::{PackageInfo, RootInfo, WorkspaceEntry},
-        BunLockfile,
-    };
+    use crate::bun::{PackageInfo, RootInfo, WorkspaceEntry};
 
     macro_rules! fixture {
         ($name:ident, $kind:ty, $cons:expr) => {
@@ -147,7 +146,7 @@ mod test {
     #[test_case(json!(["is-odd@3.0.1", "", {"dependencies": {"is-number": "^6.0.0"}}, "sha"]), registry_pkg() ; "registry package")]
     #[test_case(json!(["docs", {"dependencies": {"is-odd": "3.0.1"}}]), workspace_pkg() ; "workspace package")]
     #[test_case(json!(["some-package@root:", {"bin": "bin", "binDir": "binDir"}]), root_pkg() ; "root package")]
-    fn test_serialization<T: for<'a> Serialize + PartialEq + std::fmt::Debug>(
+    fn test_serialization<T: Serialize + PartialEq + std::fmt::Debug>(
         expected: serde_json::Value,
         input: &T,
     ) {

--- a/crates/turborepo-lockfiles/src/bun/ser.rs
+++ b/crates/turborepo-lockfiles/src/bun/ser.rs
@@ -2,19 +2,47 @@ use serde::{ser::SerializeTuple, Serialize};
 
 use super::PackageEntry;
 
+// Comment explaining entry schemas taken from bun.lock.zig
+// first index is resolution for each type of package
+// npm         -> [
+//                "name@version",
+//                registry (TODO: remove if default),
+//                INFO,
+//                integrity
+//                ]
+// symlink     -> [ "name@link:path", INFO ]
+// folder      -> [ "name@file:path", INFO ]
+// workspace   -> [ "name@workspace:path", INFO ]
+// tarball     -> [ "name@tarball", INFO ]
+// root        -> [ "name@root:", { bin, binDir } ]
+// git         -> [ "name@git+repo", INFO, .bun-tag string (TODO: remove this) ]
+// github      -> [ "name@github:user/repo", INFO, .bun-tag string (TODO: remove
+// this) ]
 impl Serialize for PackageEntry {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut tuple = serializer.serialize_tuple(5)?;
+        let mut tuple = serializer.serialize_tuple(4)?;
         tuple.serialize_element(&self.ident)?;
 
+        // For root packages, only thing left to serialize is the root info
+        if let Some(root) = &self.root {
+            tuple.serialize_element(root)?;
+            return tuple.end();
+        }
+
+        // npm packages have a registry
+        if let Some(registry) = &self.registry {
+            tuple.serialize_element(registry)?;
+        }
+
+        // All packages have info in the next slot
         if let Some(info) = &self.info {
-            tuple.serialize_element(&self.registry.as_deref().unwrap_or(""))?;
             tuple.serialize_element(info)?;
-            tuple.serialize_element(&self.checksum)?;
-            if let Some(root) = &self.root {
-                tuple.serialize_element(root)?;
-            }
         };
+
+        // npm packages, git, and github have a checksum/integrity
+        if let Some(checksum) = &self.checksum {
+            tuple.serialize_element(checksum)?;
+        }
 
         tuple.end()
     }
@@ -22,61 +50,108 @@ impl Serialize for PackageEntry {
 
 #[cfg(test)]
 mod test {
+    use std::{str::FromStr, sync::OnceLock};
+
     use serde_json::json;
+    use test_case::test_case;
 
     use super::*;
-    use crate::bun::PackageInfo;
+    use crate::{
+        bun::{PackageInfo, RootInfo, WorkspaceEntry},
+        BunLockfile,
+    };
 
-    #[test]
-    fn test_serialize_registry_package() {
-        let package = PackageEntry {
+    macro_rules! fixture {
+        ($name:ident, $kind:ty, $cons:expr) => {
+            fn $name() -> &'static $kind {
+                static ONCE: OnceLock<$kind> = OnceLock::new();
+                ONCE.get_or_init(|| $cons)
+            }
+        };
+    }
+
+    fixture!(
+        basic_workspace,
+        WorkspaceEntry,
+        WorkspaceEntry {
+            name: "bun-test".into(),
+            dev_dependencies: Some(
+                Some(("turbo".to_string(), "^2.3.3".to_string()))
+                    .into_iter()
+                    .collect()
+            ),
+            ..Default::default()
+        }
+    );
+
+    fixture!(
+        workspace_with_version,
+        WorkspaceEntry,
+        WorkspaceEntry {
+            name: "docs".into(),
+            version: Some("0.1.0".into()),
+            ..Default::default()
+        }
+    );
+
+    fixture!(
+        registry_pkg,
+        PackageEntry,
+        PackageEntry {
             ident: "is-odd@3.0.1".into(),
-            registry: Some("registry".into()),
+            registry: Some("".into()),
             info: Some(PackageInfo {
-                dependencies: [("is-number".into(), "^6.0.0".into())]
+                dependencies: Some(("is-number".into(), "^6.0.0".into()))
                     .into_iter()
                     .collect(),
                 ..Default::default()
             }),
             checksum: Some("sha".into()),
             root: None,
-        };
+        }
+    );
 
-        let expected =
-            json!(["is-odd@3.0.1", "registry", {"dependencies": {"is-number": "^6.0.0"}}, "sha"]);
-        let actual = serde_json::to_value(&package).unwrap();
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn test_serialize_registry_package_no_deps() {
-        let package = PackageEntry {
-            ident: "is-odd@3.0.1".into(),
-            registry: Some("registry".into()),
+    fixture!(
+        workspace_pkg,
+        PackageEntry,
+        PackageEntry {
+            ident: "docs".into(),
             info: Some(PackageInfo {
+                dependencies: Some(("is-odd".into(), "3.0.1".into()))
+                    .into_iter()
+                    .collect(),
                 ..Default::default()
             }),
-            checksum: Some("sha".into()),
-            root: None,
-        };
-
-        let expected = json!(["is-odd@3.0.1", "registry", {}, "sha"]);
-        let actual = serde_json::to_value(&package).unwrap();
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn test_serialize_workspace_package() {
-        let package = PackageEntry {
-            ident: "@workspace/package".into(),
             registry: None,
-            info: None,
             checksum: None,
             root: None,
-        };
+        }
+    );
 
-        let expected = json!(["@workspace/package"]);
-        let actual = serde_json::to_value(&package).unwrap();
+    fixture!(
+        root_pkg,
+        PackageEntry,
+        PackageEntry {
+            ident: "some-package@root:".into(),
+            root: Some(RootInfo {
+                bin: Some("bin".into()),
+                bin_dir: Some("binDir".into()),
+            }),
+            info: None,
+            registry: None,
+            checksum: None,
+        }
+    );
+    #[test_case(json!({"name": "bun-test", "devDependencies": {"turbo": "^2.3.3"}}), basic_workspace() ; "basic")]
+    #[test_case(json!({"name": "docs", "version": "0.1.0"}), workspace_with_version() ; "with version")]
+    #[test_case(json!(["is-odd@3.0.1", "", {"dependencies": {"is-number": "^6.0.0"}}, "sha"]), registry_pkg() ; "registry package")]
+    #[test_case(json!(["docs", {"dependencies": {"is-odd": "3.0.1"}}]), workspace_pkg() ; "workspace package")]
+    #[test_case(json!(["some-package@root:", {"bin": "bin", "binDir": "binDir"}]), root_pkg() ; "root package")]
+    fn test_serialization<T: for<'a> Serialize + PartialEq + std::fmt::Debug>(
+        expected: serde_json::Value,
+        input: &T,
+    ) {
+        let actual = serde_json::to_value(input).unwrap();
         assert_eq!(actual, expected);
     }
 }


### PR DESCRIPTION
### Description
Resolves https://github.com/vercel/turborepo/issues/9058 and https://github.com/vercel/turborepo/discussions/7456

Building on https://github.com/vercel/turborepo/pull/9783 to add `prune` support for bun. This is a simple implementation that allow turbo to properly prune a `bun.lock` file

Basically, it just creates a new `BunLockfileData` with the filtered dependencies/workspaces and serializes it to `bun.lock` via `serde_json`. This is made simple since the internal layout matches the bun.lock format, so the only special serialization case I had to do was `PackageEntry`. This also required updating the _deserialization_, since it skipped parsing some parts that we need to write back out.
 
### Testing Instructions
1. Clone https://github.com/mugencraft/turbobun (or any other turbo + bun repo)
2. `bun install --save-text-lockfile` (we need the new `.lock` version and not `.lockb`)
3. I then do 
    ```sh
    rm -rf ./out && cp ../turborepo/target/debug/turbo ./node_modules/.bin/turbo # Copy debug build of turbo
    bunx turbo prune @turbobun/backend --docker --skip-infer # turbo prune 🚀
    ```
4. Open the generated `out/bun.lock`. It's currently outputted in an unformatted json, so I format it.
5. Observe that the dependencies include backend (`elysia`) and root workspace (`commitizen`) dependencies, but not e.g. `@turbobun/website` dependencies (like `next`)
6. `cd ./out/json && bun install` -> Bun install can read the lockfile and works!
7. You can also patch a random package using `bun patch` and test that the patches are propagated correctly

### Screenshots
![image](https://github.com/user-attachments/assets/8e059425-8e87-4d6e-9360-d49fbf65d105)
