### PR TITLE
fix: update env variables supported by nitro

### DIFF
--- a/packages/turbo-types/src/json/frameworks.json
+++ b/packages/turbo-types/src/json/frameworks.json
@@ -53,7 +53,7 @@
   {
     "slug": "nitro",
     "name": "Nitro",
-    "envWildcards": ["NITRO_*"],
+    "envWildcards": ["NITRO_*", "SERVER_*", "AWS_APP_ID", "INPUT_AZURE_STATIC_WEB_APPS_API_TOKEN", "CLEAVR", "CF_PAGES", "FIREBASE_APP_HOSTING", "NETLIFY", "STORMKIT", "NOW_BUILDER", "ZEABUR", "RENDER"],
     "dependencyMatch": {
       "strategy": "some",
       "dependencies": [
@@ -67,7 +67,7 @@
   {
     "slug": "nuxtjs",
     "name": "Nuxt.js",
-    "envWildcards": ["NUXT_*", "NITRO_*"],
+    "envWildcards": ["NUXT_*", "NITRO_*", "SERVER_*", "AWS_APP_ID", "INPUT_AZURE_STATIC_WEB_APPS_API_TOKEN", "CLEAVR", "CF_PAGES", "FIREBASE_APP_HOSTING", "NETLIFY", "STORMKIT", "NOW_BUILDER", "ZEABUR", "RENDER"],
     "dependencyMatch": {
       "strategy": "some",
       "dependencies": ["nuxt", "nuxt-edge", "nuxt3", "nuxt3-edge"]


### PR DESCRIPTION
#9860

Deployment providers provide environmental variables to be detected.

[Nitro](https://nitro.build) uses this mechanism to auto-detect deployment providers when building.

I have made a handcrafted list of some common items to nuxt and nitro frameworks + `SERVER_*` (nitro supported env).

- aws_amplify: AWS_APP_ID
- azure_static: INPUT_AZURE_STATIC_WEB_APPS_API_TOKEN
- cleavr: CLEAVR
- cloudflare_pages: CF_PAGES
- firebase_app_hosting: FIREBASE_APP_HOSTING
- netlify: NETLIFY
- stormkit: STORMKIT
- vercel: NOW_BUILDER 
- zeabur: ZEABUR
- cleavr: CLEAVR
- render.com: RENDER



> [!IMPORTANT]
> This list will be most likely updated over time, meaning turborepo support will be broken from time to time and need to manually be updated. Nitro uses [std-env](https://github.com/unjs/std-env/blob/main/src/providers.ts) as source of this list.

> [!NOTE]
> Having list of provider envs under each framework, means that turborepo does not supports platform envs for frameworks not explicitly listed in this json (there are already few nitro based ones missing)