### PR TITLE
docs: fix typos

### DIFF
--- a/docs/site/content/blog/turbo-2-0.mdx
+++ b/docs/site/content/blog/turbo-2-0.mdx
@@ -87,7 +87,7 @@ Today, we're releasing Watch Mode to bring this functionality to all your toolin
 turbo watch dev lint test
 ```
 
-Using `turbo watch`, Turborepo will re-run tasks whenever you make changes to your source code. Tasks will be ran using your dependency graph and configuration from `turbo.json`, just like `turbo run`.
+Using `turbo watch`, Turborepo will re-run tasks whenever you make changes to your source code. Tasks will be run using your dependency graph and configuration from `turbo.json`, just like `turbo run`.
 
 [Learn more about Watch Mode in the documentation.](/repo/docs/crafting-your-repository/developing-applications#watch-mode)
 

--- a/docs/site/content/repo-docs/crafting-your-repository/configuring-tasks.mdx
+++ b/docs/site/content/repo-docs/crafting-your-repository/configuring-tasks.mdx
@@ -123,7 +123,7 @@ Sometimes, you may need to ensure that two tasks in the same package run in a sp
 
 #### Depending on a specific task in a specific package
 
-You can also specify an individual task in a specific package to depend on. In the example below, the `build` task in `utils` must be ran before any `lint` tasks.
+You can also specify an individual task in a specific package to depend on. In the example below, the `build` task in `utils` must be run before any `lint` tasks.
 
 ```json title="./turbo.json"
 {
@@ -147,7 +147,7 @@ You can also be more specific about the dependent task, limiting it to a certain
 }
 ```
 
-With this configuration, the `lint` task in your `web` package can only be ran after the `build` task in the `utils` package is complete.
+With this configuration, the `lint` task in your `web` package can only be run after the `build` task in the `utils` package is complete.
 
 #### No dependencies
 
@@ -306,7 +306,7 @@ In large monorepos with many teams, this allows teams greater control over their
 
 ### Performing side-effects
 
-Some tasks should always be ran no matter what, like a deployment script after a cached build. For these tasks, add `"cache": false` to your task definition.
+Some tasks should always be run no matter what, like a deployment script after a cached build. For these tasks, add `"cache": false` to your task definition.
 
 ```json title="./turbo.json"
 {
@@ -322,9 +322,9 @@ Some tasks should always be ran no matter what, like a deployment script after a
 }
 ```
 
-### Dependent tasks that can be ran in parallel
+### Dependent tasks that can be run in parallel
 
-Some tasks can be ran in parallel despite being dependent on other packages. An example of tasks that fit this description are linters, since a linter doesn't need to wait for outputs in dependencies to run successfully.
+Some tasks can be run in parallel despite being dependent on other packages. An example of tasks that fit this description are linters, since a linter doesn't need to wait for outputs in dependencies to run successfully.
 
 Because of this, you may be tempted to define your `check-types` task like this:
 

--- a/docs/site/content/repo-docs/guides/single-package-workspaces.mdx
+++ b/docs/site/content/repo-docs/guides/single-package-workspaces.mdx
@@ -104,7 +104,7 @@ Then, create tasks in `turbo.json` to run these scripts in order:
 }
 ```
 
-The `dependsOn` arrays in the tasks above create a sequential order for the tasks. When you run `turbo dev`, the scripts for `db:up`, then `db:push`, then `db:seed` will be ran first.
+The `dependsOn` arrays in the tasks above create a sequential order for the tasks. When you run `turbo dev`, the scripts for `db:up`, then `db:push`, then `db:seed` will be run first.
 
 ## Parallelizing tasks
 

--- a/docs/site/content/repo-docs/reference/turbo-codemod.mdx
+++ b/docs/site/content/repo-docs/reference/turbo-codemod.mdx
@@ -32,7 +32,7 @@ In most cases, you can run:
 npx @turbo/codemod
 ```
 
-All the codemods you need to upgrade will be ran for you.
+All the codemods you need to upgrade will be run for you.
 
 ### Turborepo 2.x
 


### PR DESCRIPTION
For the verb "run," the past participle is "run," not "ran." Hope it helps! :)