### PR TITLE
feat(turbo json): make `with` public

### DIFF
--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -218,6 +218,13 @@ pub enum Error {
         #[source_code]
         text: NamedSource<String>,
     },
+    #[error("`with` cannot use topological dependencies.")]
+    InvalidTaskWith {
+        #[label("Remove `^` from start of task name.")]
+        span: Option<SourceSpan>,
+        #[source_code]
+        text: NamedSource<String>,
+    },
 }
 
 const DEFAULT_API_URL: &str = "https://vercel.com/api";

--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -218,7 +218,7 @@ pub enum Error {
         #[source_code]
         text: NamedSource<String>,
     },
-    #[error("`with` cannot use topological dependencies.")]
+    #[error("`with` cannot use dependency relationships.")]
     InvalidTaskWith {
         #[label("Remove `^` from start of task name.")]
         span: Option<SourceSpan>,

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -447,7 +447,7 @@ impl<'a> EngineBuilder<'a> {
                 });
 
             for (sibling, span) in task_definition
-                .siblings
+                .with
                 .iter()
                 .flatten()
                 .map(|s| s.as_ref().split())
@@ -1443,7 +1443,7 @@ mod test {
     }
 
     #[test]
-    fn test_sibling_task() {
+    fn test_with_task() {
         let repo_root_dir = TempDir::with_prefix("repo").unwrap();
         let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
         let package_graph = mock_package_graph(
@@ -1461,7 +1461,7 @@ mod test {
                     "api#serve": { "persistent": true }
                 }
             }));
-            t_json.with_sibling(TaskName::from("web#dev"), &TaskName::from("api#serve"));
+            t_json.with_task(TaskName::from("web#dev"), &TaskName::from("api#serve"));
             t_json
         })]
         .into_iter()

--- a/crates/turborepo-lib/src/microfrontends.rs
+++ b/crates/turborepo-lib/src/microfrontends.rs
@@ -135,7 +135,7 @@ impl MicrofrontendsConfigs {
             if let Some(dev) = dev {
                 // If this package has a dev task that's part of the MFE, then we make sure the
                 // proxy gets included in the task graph.
-                turbo_json.with_sibling(
+                turbo_json.with_task(
                     TaskName::from(dev.task()).into_owned(),
                     &proxy.as_task_name(),
                 );

--- a/crates/turborepo-lib/src/run/summary/task.rs
+++ b/crates/turborepo-lib/src/run/summary/task.rs
@@ -285,7 +285,7 @@ impl From<TaskDefinition> for TaskSummaryTaskDefinition {
             interruptible,
             interactive,
             env_mode,
-            siblings: _,
+            with: _,
         } = value;
 
         let mut outputs = inclusions;

--- a/crates/turborepo-lib/src/task_graph/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/mod.rs
@@ -95,7 +95,7 @@ pub struct TaskDefinition {
     // It contains no guarantees regarding ordering, just that this will also get run.
     // It will also not affect the task's hash aside from the definition getting folded into the
     // hash.
-    pub siblings: Option<Vec<Spanned<TaskName<'static>>>>,
+    pub with: Option<Vec<Spanned<TaskName<'static>>>>,
 }
 
 impl Default for TaskDefinition {
@@ -113,7 +113,7 @@ impl Default for TaskDefinition {
             interruptible: Default::default(),
             interactive: Default::default(),
             env_mode: Default::default(),
-            siblings: Default::default(),
+            with: Default::default(),
         }
     }
 }

--- a/crates/turborepo-lib/src/turbo_json/loader.rs
+++ b/crates/turborepo-lib/src/turbo_json/loader.rs
@@ -844,7 +844,7 @@ mod test {
                     // Make sure proxy is in there
                     if task_name == "dev" {
                         assert_eq!(
-                            def.siblings.as_ref().unwrap().first().unwrap().as_inner(),
+                            def.with.as_ref().unwrap().first().unwrap().as_inner(),
                             &UnescapedString::from("web#proxy")
                         )
                     }
@@ -863,7 +863,7 @@ mod test {
                         Some(false)
                     );
                     assert_eq!(
-                        def.siblings.as_ref().unwrap().first().unwrap().as_inner(),
+                        def.with.as_ref().unwrap().first().unwrap().as_inner(),
                         &UnescapedString::from("web#proxy")
                     )
                 } else {

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -1362,7 +1362,7 @@ mod tests {
         let error = &errs[0];
         assert_eq!(
             error.to_string(),
-            "`with` cannot use topological dependencies."
+            "`with` cannot use dependency relationships."
         );
     }
 }

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -259,7 +259,7 @@ pub struct RawTaskDefinition {
     #[serde(skip)]
     env_mode: Option<EnvMode>,
     // This can currently only be set internally and isn't a part of turbo.json
-    #[serde(skip)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     with: Option<Vec<Spanned<UnescapedString>>>,
 }
 
@@ -443,8 +443,8 @@ impl TaskDefinition {
             })
             .transpose()?;
 
-        let siblings = raw_task.with.map(|siblings| {
-            siblings
+        let with = raw_task.with.map(|with_tasks| {
+            with_tasks
                 .into_iter()
                 .map(|sibling| {
                     let (sibling, span) = sibling.split();
@@ -466,7 +466,7 @@ impl TaskDefinition {
             interruptible: *interruptible,
             interactive,
             env_mode: raw_task.env_mode,
-            with: siblings,
+            with,
         })
     }
 }
@@ -743,6 +743,23 @@ pub fn validate_extends(turbo_json: &TurboJson) -> Vec<Error> {
     }
 }
 
+pub fn validate_with_has_no_topo(turbo_json: &TurboJson) -> Vec<Error> {
+    turbo_json
+        .tasks
+        .iter()
+        .flat_map(|(_, definition)| {
+            definition.with.iter().flatten().filter_map(|with_task| {
+                if with_task.starts_with(TOPOLOGICAL_PIPELINE_DELIMITER) {
+                    let (span, text) = with_task.span_and_text("turbo.json");
+                    Some(Error::InvalidTaskWith { span, text })
+                } else {
+                    None
+                }
+            })
+        })
+        .collect()
+}
+
 fn gather_env_vars(
     vars: Vec<Spanned<impl Into<String>>>,
     key: &str,
@@ -843,7 +860,8 @@ mod tests {
     use turborepo_unescape::UnescapedString;
 
     use super::{
-        replace_turbo_root_token_in_string, RawTurboJson, SpacesJson, Spanned, TurboJson, UIMode,
+        replace_turbo_root_token_in_string, validate_with_has_no_topo, Pipeline, RawTurboJson,
+        SpacesJson, Spanned, TurboJson, UIMode,
     };
     use crate::{
         boundaries::BoundariesConfig,
@@ -1045,6 +1063,22 @@ mod tests {
             ..TaskDefinition::default()
         }
     ; "turbo root"
+    )]
+    #[test_case(
+        r#"{
+            "with": ["proxy"]
+        }"#,
+        RawTaskDefinition {
+            with: Some(vec![
+                Spanned::new(UnescapedString::from("proxy")).with_range(23..30),
+            ]),
+            ..RawTaskDefinition::default()
+        },
+        TaskDefinition {
+            with: Some(vec![Spanned::new(TaskName::from("proxy")).with_range(23..30)]),
+            ..TaskDefinition::default()
+        }
+    ; "with task"
     )]
     fn test_deserialize_task_definition(
         task_definition_content: &str,
@@ -1304,5 +1338,31 @@ mod tests {
             Err(e) => Err(e.to_string()),
         };
         assert_eq!(actual, expected.map_err(|s| s.to_owned()));
+    }
+
+    #[test]
+    fn test_validate_with_has_no_topo() {
+        let turbo_json = TurboJson {
+            tasks: Pipeline(
+                vec![(
+                    TaskName::from("dev"),
+                    Spanned::new(RawTaskDefinition {
+                        with: Some(vec![Spanned::new(UnescapedString::from("^proxy"))]),
+                        ..Default::default()
+                    }),
+                )]
+                .into_iter()
+                .collect(),
+            ),
+            ..Default::default()
+        };
+
+        let errs = validate_with_has_no_topo(&turbo_json);
+        assert_eq!(errs.len(), 1);
+        let error = &errs[0];
+        assert_eq!(
+            error.to_string(),
+            "`with` cannot use topological dependencies."
+        );
     }
 }

--- a/crates/turborepo-lib/src/turbo_json/parser.rs
+++ b/crates/turborepo-lib/src/turbo_json/parser.rs
@@ -254,7 +254,8 @@ impl WithMetadata for RawTaskDefinition {
         self.interruptible.add_text(text.clone());
         self.outputs.add_text(text.clone());
         self.output_logs.add_text(text.clone());
-        self.interactive.add_text(text);
+        self.interactive.add_text(text.clone());
+        self.with.add_text(text);
     }
 
     fn add_path(&mut self, path: Arc<str>) {
@@ -269,7 +270,8 @@ impl WithMetadata for RawTaskDefinition {
         self.interruptible.add_path(path.clone());
         self.outputs.add_path(path.clone());
         self.output_logs.add_path(path.clone());
-        self.interactive.add_path(path);
+        self.interactive.add_path(path.clone());
+        self.with.add_path(path);
     }
 }
 

--- a/docs/site/content/repo-docs/reference/configuration.mdx
+++ b/docs/site/content/repo-docs/reference/configuration.mdx
@@ -527,9 +527,7 @@ To enable restarting persistent tasks, set `interruptible` to `true`.
 
 ### `with`
 
-A list of tasks that will be run along side this task.
-
-Unlike [`dependsOn`](#dependson), tasks listed here will not be run until completion before execution of this task starts.
+A list of tasks that will be ran alongside this task. This is most useful for long-running tasks that you want to ensure always run at the same time.
 
 ## Boundaries
 

--- a/docs/site/content/repo-docs/reference/configuration.mdx
+++ b/docs/site/content/repo-docs/reference/configuration.mdx
@@ -525,6 +525,12 @@ Label a `persistent` task as `interruptible` to allow it to be restarted by `tur
 that are affected. However, if a task is persistent, it will not be restarted by default.
 To enable restarting persistent tasks, set `interruptible` to `true`.
 
+### `with`
+
+A list of tasks that will be run along side this task.
+
+Unlike [`dependsOn`](#dependson), tasks listed here will not be run until completion before execution of this task starts.
+
 ## Boundaries
 
 The `boundaries` tag allows you to define rules for the [`boundaries` command](/repo/docs/reference/boundaries).

--- a/packages/turbo-types/schemas/schema.json
+++ b/packages/turbo-types/schemas/schema.json
@@ -173,6 +173,14 @@
           "type": "boolean",
           "description": "Label a persistent task as interruptible to allow it to be restarted by `turbo watch`. `turbo watch` watches for changes to your packages and automatically restarts tasks that are affected. However, if a task is persistent, it will not be restarted by default. To enable restarting persistent tasks, set `interruptible` to true.\n\nDocumentation: https://turbo.build/repo/docs/reference/configuration#interruptible",
           "default": false
+        },
+        "with": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of tasks that will run alongside this task.\n\nTasks in this list will not be run until completion before this task starts execution.\n\nDocumentation: https://turbo.build/repo/docs/reference/configuration#with",
+          "default": []
         }
       },
       "additionalProperties": false

--- a/packages/turbo-types/schemas/schema.v2.json
+++ b/packages/turbo-types/schemas/schema.v2.json
@@ -173,6 +173,14 @@
           "type": "boolean",
           "description": "Label a persistent task as interruptible to allow it to be restarted by `turbo watch`. `turbo watch` watches for changes to your packages and automatically restarts tasks that are affected. However, if a task is persistent, it will not be restarted by default. To enable restarting persistent tasks, set `interruptible` to true.\n\nDocumentation: https://turbo.build/repo/docs/reference/configuration#interruptible",
           "default": false
+        },
+        "with": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of tasks that will run alongside this task.\n\nTasks in this list will not be run until completion before this task starts execution.\n\nDocumentation: https://turbo.build/repo/docs/reference/configuration#with",
+          "default": []
         }
       },
       "additionalProperties": false

--- a/packages/turbo-types/src/types/config-v2.ts
+++ b/packages/turbo-types/src/types/config-v2.ts
@@ -309,6 +309,17 @@ export interface Pipeline {
    * @defaultValue `false`
    */
   interruptible?: boolean;
+
+  /**
+   * A list of tasks that will run alongside this task.
+   *
+   * Tasks in this list will not be run until completion before this task starts execution.
+   *
+   * Documentation: https://turbo.build/repo/docs/reference/configuration#with
+   *
+   * @defaultValue `[]`
+   */
+  with?: Array<string>;
 }
 
 export interface RemoteCache {


### PR DESCRIPTION
### Description

Make public the feature added in #9504 that allows for pulling in extra tasks into the graph without a `dependsOn` relationship.

Renamed to `with` as it is better than `sibling` since that indicates a shared parent, which isn't required.

### Testing Instructions

Added quick unit test for parsing and error validation.

Basic test:
```
[0 olszewski@macbookpro] /tmp/with-test $ git diff
diff --git a/turbo.json b/turbo.json
index d6a7fe0..35fa9cd 100644
--- a/turbo.json
+++ b/turbo.json
@@ -15,7 +15,8 @@
     },
     "dev": {
       "cache": false,
-      "persistent": true
+      "persistent": true,
+      "with": ["build"]
     }
   }
 }
# Verify web#build is in the graph
[0 olszewski@macbookpro] /tmp/with-test $ turbo_dev --skip-infer web#dev --graph
turbo 2.4.5-canary.4


digraph {
        compound = "true"
        newrank = "true"
        subgraph "root" {
                "[root] @repo/eslint-config#build" -> "[root] ___ROOT___"
                "[root] @repo/typescript-config#build" -> "[root] ___ROOT___"
                "[root] @repo/ui#build" -> "[root] @repo/eslint-config#build"
                "[root] @repo/ui#build" -> "[root] @repo/typescript-config#build"
                "[root] web#build" -> "[root] @repo/eslint-config#build"
                "[root] web#build" -> "[root] @repo/typescript-config#build"
                "[root] web#build" -> "[root] @repo/ui#build"
                "[root] web#dev" -> "[root] ___ROOT___"
        }
}
```

Error message for trying to use `^`
```
[0 olszewski@macbookpro] /tmp/with-test $ turbo_dev --skip-infer web#dev
turbo 2.4.5-canary.4

  × Invalid turbo.json configuration
  ╰─▶   × `with` cannot use topological dependencies.
          ╭─[turbo.json:19:16]
       18 │       "persistent": true,
       19 │       "with": ["^build"]
          ·                ────┬───
          ·                    ╰── Remove `^` from start of task name.
       20 │     }
          ╰────
```
