### PR TITLE
docs: switch turbo run to turbo watch for --experimental-write-cache

### DIFF
--- a/docs/site/content/blog/turbo-2-4.mdx
+++ b/docs/site/content/blog/turbo-2-4.mdx
@@ -90,7 +90,7 @@ We've added more functionality to the terminal UI to make it easier to work with
 In this release, we're adding caching as an experimental feature in Watch Mode. To activate it, use the `--experimental-write-cache` flag:
 
 ```bash title="Terminal"
-turbo run dev --experimental-write-cache
+turbo watch dev --experimental-write-cache
 ```
 
 To learn more about Watch Mode, [visit the documentation](/repo/docs/reference/watch).

--- a/docs/site/content/repo-docs/reference/watch.mdx
+++ b/docs/site/content/repo-docs/reference/watch.mdx
@@ -40,7 +40,7 @@ restart the task when relevant changes are detected.
 Caching tasks with Watch Mode is currently experimental, under the `--experimental-write-cache` flag.
 
 ```bash title="Terminal"
-turbo run your-tasks --experimental-write-cache
+turbo watch your-tasks --experimental-write-cache
 ```
 
 ### Task outputs


### PR DESCRIPTION
### Description

The documentation incorrectly specifies that the `--experimental-write-cache` command is to be used with `turbo run`, while in reality it is supposed to be used in conjunction with `turbo watch`. This PR updates the documentation to reflect this.
