### PR TITLE
fix(turbo_json): avoid workspace validation errors

### DIFF
--- a/crates/turborepo-lib/src/config/turbo_json.rs
+++ b/crates/turborepo-lib/src/config/turbo_json.rs
@@ -53,15 +53,8 @@ impl<'a> ResolvedConfigurationOptions for TurboJsonReader<'a> {
         existing_config: &ConfigurationOptions,
     ) -> Result<ConfigurationOptions, Error> {
         let turbo_json_path = existing_config.root_turbo_json_path(self.repo_root)?;
-        let turbo_json = RawTurboJson::read(self.repo_root, &turbo_json_path).or_else(|e| {
-            if let Error::Io(e) = &e {
-                if matches!(e.kind(), std::io::ErrorKind::NotFound) {
-                    return Ok(Default::default());
-                }
-            }
-
-            Err(e)
-        })?;
+        let turbo_json = RawTurboJson::read(self.repo_root, &turbo_json_path)
+            .map(|turbo_json| turbo_json.unwrap_or_default())?;
         Self::turbo_json_to_config_options(turbo_json)
     }
 }

--- a/crates/turborepo-lib/src/turbo_json/loader.rs
+++ b/crates/turborepo-lib/src/turbo_json/loader.rs
@@ -288,27 +288,18 @@ fn load_from_file(
             let turbo_json = TurboJson::read(repo_root, &turbo_json_path);
             let turbo_jsonc = TurboJson::read(repo_root, &turbo_jsonc_path);
 
-            // If both are present, error as we don't know which to use
-            if turbo_json.is_ok() && turbo_jsonc.is_ok() {
-                return Err(Error::MultipleTurboConfigs {
-                    directory: turbo_json_dir_path.to_string(),
-                });
-            }
-
-            // Attempt to use the turbo.json that was successfully parsed
-            turbo_json.or(turbo_jsonc)
+            select_turbo_json(turbo_json_dir_path, turbo_json, turbo_jsonc)
         }
         LoadTurboJsonPath::File(turbo_json_path) => TurboJson::read(repo_root, turbo_json_path),
     };
 
     // Handle errors or success
     match result {
-        // If the file didn't exist, throw a custom error here instead of propagating
-        Err(Error::Io(_)) => Err(Error::NoTurboJSON),
         // There was an error, and we don't have any chance of recovering
         Err(e) => Err(e),
+        Ok(None) => Err(Error::NoTurboJSON),
         // We're not synthesizing anything and there was no error, we're done
-        Ok(turbo) => Ok(turbo),
+        Ok(Some(turbo)) => Ok(turbo),
     }
 }
 
@@ -322,7 +313,7 @@ fn load_from_root_package_json(
         // Note: this will have to change to support task inference in a monorepo
         // for now, we're going to error on any "root" tasks and turn non-root tasks into root
         // tasks
-        Ok(mut turbo_json) => {
+        Ok(Some(mut turbo_json)) => {
             let mut pipeline = Pipeline::default();
             for (task_name, task_definition) in turbo_json.tasks {
                 if task_name.is_package_task() {
@@ -343,7 +334,7 @@ fn load_from_root_package_json(
             turbo_json
         }
         // turbo.json doesn't exist, but we're going try to synthesize something
-        Err(Error::Io(_)) => TurboJson::default(),
+        Ok(None) => TurboJson::default(),
         // some other happened, we can't recover
         Err(e) => {
             return Err(e);
@@ -417,13 +408,45 @@ fn load_task_access_trace_turbo_json(
     let turbo_from_trace = TurboJson::read(repo_root, &trace_json_path);
 
     // check the zero config case (turbo trace file, but no turbo.json file)
-    if let Ok(turbo_from_trace) = turbo_from_trace {
+    if let Ok(Some(turbo_from_trace)) = turbo_from_trace {
         if !turbo_json_path.exists() {
             debug!("Using turbo.json synthesized from trace file");
             return Ok(turbo_from_trace);
         }
     }
     load_from_root_package_json(repo_root, turbo_json_path, root_package_json)
+}
+
+// Helper for selecting the correct turbo.json read result
+fn select_turbo_json(
+    turbo_json_dir_path: &AbsoluteSystemPath,
+    turbo_json: Result<Option<TurboJson>, Error>,
+    turbo_jsonc: Result<Option<TurboJson>, Error>,
+) -> Result<Option<TurboJson>, Error> {
+    debug!(
+        "path: {}, turbo_json: {:?}, turbo_jsonc: {:?}",
+        turbo_json_dir_path.as_str(),
+        turbo_json.as_ref().map(|v| v.as_ref().map(|_| ())),
+        turbo_jsonc.as_ref().map(|v| v.as_ref().map(|_| ()))
+    );
+    match (turbo_json, turbo_jsonc) {
+        // If both paths contain valid turbo.json error
+        (Ok(Some(_)), Ok(Some(_))) => Err(Error::MultipleTurboConfigs {
+            directory: turbo_json_dir_path.to_string(),
+        }),
+        // If turbo.json is valid and turbo.jsonc is missing or invalid, use turbo.json
+        (Ok(Some(turbo_json)), Ok(None)) | (Ok(Some(turbo_json)), Err(_)) => Ok(Some(turbo_json)),
+        // If turbo.jsonc is valid and turbo.json is missing or invalid, use turbo.jsonc
+        (Ok(None), Ok(Some(turbo_jsonc))) | (Err(_), Ok(Some(turbo_jsonc))) => {
+            Ok(Some(turbo_jsonc))
+        }
+        // If neither are present, then choose nothing
+        (Ok(None), Ok(None)) => Ok(None),
+        // If only one has an error return the failure
+        (Err(e), Ok(None)) | (Ok(None), Err(e)) => Err(e),
+        // If both fail then just return error for `turbo.json`
+        (Err(e), Err(_)) => Err(e),
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Description

#10083 introduced a bug where we swallow validation errors and end up silently ignoring these workspace `turbo.json` files. This PR fixes that by distinguishing a missing `turbo.json` from a failed read.

The bug stems from the fact that a missing file and a failed read were both errors so `turbo_json.or(turbo_jsonc)` could choose a missing turbo.json error (which is fine, not all workspaces need `turbo.json`s) over a validation error for the file that is present. We replace `.or` with an extremely explicit `match` that goes through all the possible combinations.

### Testing Instructions
Added unit test

Quick manual verification
```
[0 olszewski@macbookpro] /Users/olszewski/code/vercel/turborepo $ turbo_dev build   
 WARNING  No locally installed `turbo` found. Using version: 2.4.5-canary.6.
turbo 2.4.5-canary.6

turbo_json_parse_error

  × Failed to parse turbo.json.
  ╰─▶   × Found an unknown key `lol`.
          ╭─[cli/turbo.json:9:7]
        8 │     "rust-src": {
        9 │       "lol": true,
          ·       ─────
       10 │       "env": [
          ╰────
```
