### PR TITLE
docs: links for OpenAPI spec for both human-readable and JSON

### DIFF
--- a/docs/site/content/repo-docs/core-concepts/remote-caching.mdx
+++ b/docs/site/content/repo-docs/core-concepts/remote-caching.mdx
@@ -192,7 +192,10 @@ turbo login --manual
 
 #### OpenAPI specification
 
-You can [find the OpenAPI specification for the API here](/repo/docs/openapi). At this time, all versions of `turbo` are compatible with the `v8` endpoints.
+- [Human-readable viewer](/repo/docs/openapi)
+- [JSON](/api/remote-cache-spec)
+
+At this time, all versions of `turbo` are compatible with the `v8` endpoints.
 
 #### Community implementations
 


### PR DESCRIPTION
### Description

I realized I remove the link to the web-hosted JSON in https://github.com/vercel/turborepo/pull/10172/files#diff-24fd2507ec67403cc099bc4ebb6b0b8ffda016451400a1437548956bb33be770. This brings it back, with some slight reformatting now that we have a human-readable viewer, too.

### Testing Instructions

👀
