### PR TITLE
docs: remove stale callout

### DIFF
--- a/docs/site/content/repo-docs/reference/configuration.mdx
+++ b/docs/site/content/repo-docs/reference/configuration.mdx
@@ -10,15 +10,6 @@ import Link from 'next/link';
 
 Configure the behavior of `turbo` by adding a `turbo.json` file in your Workspace's root directory.
 
-<Callout type="info">
-  Changing your root `turbo.json` file will invalidate the cache for all tasks
-  because it's considered in [the global
-  hash](/repo/docs/crafting-your-repository/caching#global-hash-inputs). If
-  you'd like the flexibility to change configuration without impacting the
-  global hash, use [Package
-  Configurations](/repo/docs/reference/package-configurations).
-</Callout>
-
 ## Global options
 
 ### `extends`


### PR DESCRIPTION
### Description

This used to be true, but is no longer true as of (at latest) 1.10.16.

More cache hits! Woohoo!
