### PR TITLE
fix(bun): deserialize correctly and use optionalPeers

### DIFF
--- a/crates/turborepo-lockfiles/src/bun/de.rs
+++ b/crates/turborepo-lockfiles/src/bun/de.rs
@@ -153,6 +153,16 @@ mod test {
                 dependencies: Some(("is-number".into(), "^6.0.0".into()))
                     .into_iter()
                     .collect(),
+                dev_dependencies: Some(("is-bigint".into(), "1.1.0".into()))
+                    .into_iter()
+                    .collect(),
+                peer_dependencies: Some(("is-even".into(), "1.0.0".into()))
+                    .into_iter()
+                    .collect(),
+                optional_peers: Some("is-even".into()).into_iter().collect(),
+                optional_dependencies: Some(("is-regexp".into(), "1.0.0".into()))
+                    .into_iter()
+                    .collect(),
                 ..Default::default()
             }),
             checksum: Some("sha".into()),
@@ -193,7 +203,7 @@ mod test {
     );
     #[test_case(json!({"name": "bun-test", "devDependencies": {"turbo": "^2.3.3"}}), basic_workspace() ; "basic")]
     #[test_case(json!({"name": "docs", "version": "0.1.0"}), workspace_with_version() ; "with version")]
-    #[test_case(json!(["is-odd@3.0.1", "", {"dependencies": {"is-number": "^6.0.0"}}, "sha"]), registry_pkg() ; "registry package")]
+    #[test_case(json!(["is-odd@3.0.1", "", {"dependencies": {"is-number": "^6.0.0"}, "devDependencies": {"is-bigint": "1.1.0"}, "peerDependencies": {"is-even": "1.0.0"}, "optionalDependencies": {"is-regexp": "1.0.0"}, "optionalPeers": ["is-even"]}, "sha"]), registry_pkg() ; "registry package")]
     #[test_case(json!(["docs", {"dependencies": {"is-odd": "3.0.1"}}]), workspace_pkg() ; "workspace package")]
     #[test_case(json!(["some-package@root:", {"bin": "bin", "binDir": "binDir"}]), root_pkg() ; "root package")]
     fn test_deserialization<T: for<'a> Deserialize<'a> + PartialEq + std::fmt::Debug>(

--- a/crates/turborepo-lockfiles/src/bun/mod.rs
+++ b/crates/turborepo-lockfiles/src/bun/mod.rs
@@ -180,7 +180,7 @@ impl Lockfile for BunLockfile {
                     continue;
                 }
 
-                return Err(crate::Error::MissingPackage(parent_key));
+                return Err(crate::Error::MissingPackage(dependency.to_string()));
             };
             deps.insert(dep_key.to_string(), version.to_string());
         }

--- a/crates/turborepo-lockfiles/src/bun/ser.rs
+++ b/crates/turborepo-lockfiles/src/bun/ser.rs
@@ -103,6 +103,16 @@ mod test {
                 dependencies: Some(("is-number".into(), "^6.0.0".into()))
                     .into_iter()
                     .collect(),
+                dev_dependencies: Some(("is-bigint".into(), "1.1.0".into()))
+                    .into_iter()
+                    .collect(),
+                peer_dependencies: Some(("is-even".into(), "1.0.0".into()))
+                    .into_iter()
+                    .collect(),
+                optional_peers: Some("is-even".into()).into_iter().collect(),
+                optional_dependencies: Some(("is-regexp".into(), "1.0.0".into()))
+                    .into_iter()
+                    .collect(),
                 ..Default::default()
             }),
             checksum: Some("sha".into()),
@@ -143,7 +153,7 @@ mod test {
     );
     #[test_case(json!({"name": "bun-test", "devDependencies": {"turbo": "^2.3.3"}}), basic_workspace() ; "basic")]
     #[test_case(json!({"name": "docs", "version": "0.1.0"}), workspace_with_version() ; "with version")]
-    #[test_case(json!(["is-odd@3.0.1", "", {"dependencies": {"is-number": "^6.0.0"}}, "sha"]), registry_pkg() ; "registry package")]
+    #[test_case(json!(["is-odd@3.0.1", "", {"dependencies": {"is-number": "^6.0.0"}, "devDependencies": {"is-bigint": "1.1.0"}, "peerDependencies": {"is-even": "1.0.0"}, "optionalDependencies": {"is-regexp": "1.0.0"}, "optionalPeers": ["is-even"]}, "sha"]), registry_pkg() ; "registry package")]
     #[test_case(json!(["docs", {"dependencies": {"is-odd": "3.0.1"}}]), workspace_pkg() ; "workspace package")]
     #[test_case(json!(["some-package@root:", {"bin": "bin", "binDir": "binDir"}]), root_pkg() ; "root package")]
     fn test_serialization<T: Serialize + PartialEq + std::fmt::Debug>(


### PR DESCRIPTION
### Description
Resolves https://github.com/vercel/turborepo/issues/9058 and https://github.com/vercel/turborepo/discussions/7456 (again)

When I tested my previous PR (#10175) on another repo, I discovered an issue with a missing dep in the pruned lockfile

To reproduce this in the `with-yarn` example repo:
`cd apps/web && bun install dd-trace`
and
`cd apps/docs && bun install @opentelemtry/api`

Then run prune for `web` and try `bun install --frozen-lockfile` and you'll get this:
```
error: Failed to resolve peer dependency '@opentelemetry/api' for package '@opentelemetry/core'
    at bun.lock:1:16974
InvalidPackageInfo: failed to parse lockfile: 'bun.lock'
```

### Issue 1 -- Deserialization casing
The underlying error is rather straightforward -- it was deserializing most dependencies (`peerDependencies`, `devDependencies`, `optionalDependencies`) to `other` 😄 
![image](https://github.com/user-attachments/assets/0ca602de-c88a-4715-8db5-2f4cb620f95b)

This is because it just needed `#[serde(rename_all = "camelCase")]` since the rust names are snake case. This is why `dependencies` happened to work -- it's the same in snake and camel case.

By virtue of being in `other`, all non-`dependencies` packages were effectively ignored during the pruning process, and don't always end up in the resulting lockfile.

### Issue 2 -- optionalPeers
After fixing that, I also stumbled upon another issue:
```
WARNING  Unable to calculate transitive closures: No lockfile entry found for 'next/@playwright/test'
```

This is because we weren't accounting for the `optionalPeers` property. `next` doesn't actually require you have `@playwright/test`, it's an optional peer. I fixed this as well.