### PR TITLE
feat: allow specifying concurrency in config / environment

### DIFF
--- a/crates/turborepo-lib/src/commands/config.rs
+++ b/crates/turborepo-lib/src/commands/config.rs
@@ -24,6 +24,7 @@ struct ConfigOutput<'a> {
     scm_base: Option<&'a str>,
     scm_head: Option<&'a str>,
     cache_dir: &'a Utf8Path,
+    concurrency: Option<&'a str>,
 }
 
 pub async fn run(repo_root: AbsoluteSystemPathBuf, args: Args) -> Result<(), cli::Error> {
@@ -55,6 +56,7 @@ pub async fn run(repo_root: AbsoluteSystemPathBuf, args: Args) -> Result<(), cli
             scm_base: config.scm_base(),
             scm_head: config.scm_head(),
             cache_dir: config.cache_dir(),
+            concurrency: config.concurrency.as_deref()
         })?
     );
     Ok(())

--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -122,6 +122,10 @@ impl CommandBase {
             )
             .with_run_summary(args.run_args().and_then(|args| args.summarize()))
             .with_allow_no_turbo_json(args.allow_no_turbo_json.then_some(true))
+            .with_concurrency(
+                args.execution_args()
+                    .and_then(|args| args.concurrency.clone()),
+            )
             .build()
     }
 

--- a/crates/turborepo-lib/src/config/env.rs
+++ b/crates/turborepo-lib/src/config/env.rs
@@ -43,6 +43,7 @@ const TURBO_MAPPING: &[(&str, &str)] = [
     ("turbo_allow_no_turbo_json", "allow_no_turbo_json"),
     ("turbo_cache", "cache"),
     ("turbo_tui_scrollback_length", "tui_scrollback_length"),
+    ("turbo_concurrency", "concurrency"),
 ]
 .as_slice();
 
@@ -202,6 +203,12 @@ impl ResolvedConfigurationOptions for EnvVars {
                 )
             })?;
 
+        let concurrency = self
+            .output_map
+            .get("concurrency")
+            .filter(|s| !s.is_empty())
+            .cloned();
+
         let output = ConfigurationOptions {
             api_url: self.output_map.get("api_url").cloned(),
             login_url: self.output_map.get("login_url").cloned(),
@@ -210,6 +217,7 @@ impl ResolvedConfigurationOptions for EnvVars {
             token: self.output_map.get("token").cloned(),
             scm_base: self.output_map.get("scm_base").cloned(),
             scm_head: self.output_map.get("scm_head").cloned(),
+            concurrency,
             cache,
             // Processed booleans
             signature,
@@ -326,6 +334,7 @@ mod test {
         env.insert("turbo_allow_no_turbo_json".into(), "true".into());
         env.insert("turbo_remote_cache_upload_timeout".into(), "200".into());
         env.insert("turbo_tui_scrollback_length".into(), "2048".into());
+        env.insert("turbo_concurrency".into(), "50%".into());
 
         let config = EnvVars::new(&env)
             .unwrap()
@@ -354,6 +363,7 @@ mod test {
             config.root_turbo_json_path,
             Some(AbsoluteSystemPathBuf::new(root_turbo_json).unwrap())
         );
+        assert_eq!(config.concurrency, Some("50%".to_owned()));
     }
 
     #[test]
@@ -378,6 +388,7 @@ mod test {
         env.insert("turbo_run_summary".into(), "".into());
         env.insert("turbo_allow_no_turbo_json".into(), "".into());
         env.insert("turbo_tui_scrollback_length".into(), "".into());
+        env.insert("turbo_concurrency".into(), "".into());
 
         let config = EnvVars::new(&env)
             .unwrap()
@@ -405,5 +416,6 @@ mod test {
             config.tui_scrollback_length(),
             DEFAULT_TUI_SCROLLBACK_LENGTH
         );
+        assert_eq!(config.concurrency, None);
     }
 }

--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -297,6 +297,7 @@ pub struct ConfigurationOptions {
     pub(crate) run_summary: Option<bool>,
     pub(crate) allow_no_turbo_json: Option<bool>,
     pub(crate) tui_scrollback_length: Option<u64>,
+    pub(crate) concurrency: Option<String>,
 }
 
 #[derive(Default)]

--- a/crates/turborepo-lib/src/config/turbo_json.rs
+++ b/crates/turborepo-lib/src/config/turbo_json.rs
@@ -43,6 +43,7 @@ impl<'a> TurboJsonReader<'a> {
         opts.daemon = turbo_json.daemon.map(|daemon| *daemon.as_inner());
         opts.env_mode = turbo_json.env_mode;
         opts.cache_dir = cache_dir;
+        opts.concurrency = turbo_json.concurrency;
         Ok(opts)
     }
 }

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -312,7 +312,7 @@ impl<'a> TryFrom<OptsInputs<'a>> for RunOpts {
 
     fn try_from(inputs: OptsInputs) -> Result<Self, Self::Error> {
         let concurrency = inputs
-            .execution_args
+            .config
             .concurrency
             .as_deref()
             .map(parse_concurrency)

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -158,6 +158,9 @@ pub struct RawTurboJson {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub boundaries: Option<Spanned<BoundariesConfig>>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub concurrency: Option<String>,
+
     #[deserializable(rename = "//")]
     #[serde(skip)]
     _comment: Option<String>,

--- a/docs/site/content/docs/reference/configuration.mdx
+++ b/docs/site/content/docs/reference/configuration.mdx
@@ -91,6 +91,22 @@ Select a terminal UI for the repository.
 }
 ```
 
+### `concurrency`
+
+Default: `"10"`
+
+Set/limit the maximum concurrency for task execution. Must be an integer greater than or equal to `1` or a percentage value like `50%`.
+
+- Use `1` to force serial execution (one task at a time).
+- Use `100%` to use all available logical processors.
+- This option is ignored if the [`--parallel`](#--parallel) flag is also passed.
+
+```jsonc title="./turbo.json"
+{
+  "concurrency": "1"
+}
+```
+
 ### `dangerouslyDisablePackageManagerCheck`
 
 Default: `false`

--- a/docs/site/content/docs/reference/system-environment-variables.mdx
+++ b/docs/site/content/docs/reference/system-environment-variables.mdx
@@ -328,6 +328,16 @@ System environment variables are always overridden by flag values provided direc
         Enables TUI when passed true or 1, disables when passed false or 0.
       </td>
     </tr>
+    <tr id="turbo_concurrency">
+      <td>
+        <code>TURBO_CONCURRENCY</code>
+      </td>
+      <td>
+        Controls{' '}
+        <a href="/repo/docs/reference/run#--concurrency-number--percentage">concurrency</a>{' '}
+        settings in run or watch mode.
+      </td>
+    </tr>
   </tbody>
 </table>
 

--- a/turborepo-tests/integration/tests/config.t
+++ b/turborepo-tests/integration/tests/config.t
@@ -19,7 +19,8 @@ Run test run
     "envMode": "strict",
     "scmBase": null,
     "scmHead": null,
-    "cacheDir": ".turbo[\\/]+cache" (re)
+    "cacheDir": ".turbo[\\/]+cache", (re)
+    "concurrency": null
   }
 
 Run test run with api overloaded
@@ -111,3 +112,15 @@ Add env var: `TURBO_CACHE_DIR`
 Add flag: `--cache-dir`
   $ ${TURBO} --cache-dir FifthDimension/Nebulo9 config | jq -r .cacheDir
   FifthDimension[\\/]Nebulo9 (re)
+
+No concurrency by default
+  $ ${TURBO} config | jq -r .concurrency
+  null
+
+Add env var: `TURBO_CONCURRENCY`
+  $ TURBO_CONCURRENCY=5 ${TURBO} config | jq -r .concurrency
+  5
+
+Add flag: `--concurrency`
+  $ ${TURBO} --concurrency=5 config | jq -r .concurrency
+  5

--- a/turborepo-tests/integration/tests/persistent-dependencies/10-too-many.t
+++ b/turborepo-tests/integration/tests/persistent-dependencies/10-too-many.t
@@ -8,7 +8,21 @@
   
   [1]
 
+  $ TURBO_CONCURRENCY=1 ${TURBO} run build
+    x Invalid task configuration
+    `->   x You have 2 persistent tasks but `turbo` is configured for
+          | concurrency of 1. Set --concurrency to at least 3
+  
+  [1]
+
   $ ${TURBO} run build --concurrency=2
+    x Invalid task configuration
+    `->   x You have 2 persistent tasks but `turbo` is configured for
+          | concurrency of 2. Set --concurrency to at least 3
+  
+  [1]
+
+  $ TURBO_CONCURRENCY=2 ${TURBO} run build
     x Invalid task configuration
     `->   x You have 2 persistent tasks but `turbo` is configured for
           | concurrency of 2. Set --concurrency to at least 3
@@ -17,5 +31,9 @@
 
   $ ${TURBO} run build --concurrency=3 > tmp.log 2>&1
   $ grep -E "2 successful, 2 total" tmp.log
+   Tasks:    2 successful, 2 total
+
+  $ TURBO_CONCURRENCY=3 ${TURBO} run build > tmp-env.log 2>&1
+  $ grep -E "2 successful, 2 total" tmp-env.log
    Tasks:    2 successful, 2 total
 


### PR DESCRIPTION
### Description

This adds a couple new ways to configure task run concurrency: 

- A `TURBO_CONCURRENCY` environment variable
- A `concurrency` configuration value in `turbo.json`

These options should follow the same precedence rules for other options which are made available in multiple locations. I think the environment variable is the most valuable to me (IMO), as this would make it a lot easier to turn off or drastically reduce concurrency in CI scenarios with restricted performance, where running multiple test suites at the same time could cause flaky results due to timeouts, or too much resource contention in general scenarios. Being able to specify this in the configuration file is maybe less valuable, but there are situations where it might be desirable.

The `--concurrency` option is obviously already available and certainly usable in combination with other changes (enforcing the use of an alias, or setting up different `package.json` scripts for CI and local development), but enabling this to be enforced via the config or an environment variable makes it a lot easier to turn off concurrency in CI, for example.

There is some active desire for this feature to exist:
- https://github.com/vercel/turborepo/discussions/7263
- https://github.com/vercel/turborepo/discussions/7493

Notably, this does _not_ enable configuring concurrency per task, which was part of one of the discussions here. That seemed like a much larger lift vs. just adding an environment variable and config option that behaved exactly like the CLI argument already does. There is still some demand for this "simple" option.

### Testing Instructions

1. Build `turbo`
2. Check that you can now specify a top-level "concurrency" property in your `turbo.json`, with the same behaviour as the CLI argument.
3. Check that you can now specify a `TURBO_CONCURRENCY` environment variable, with the same behaviour as the CLI argument.
4. Check that this settings maintains expected preference (i.e. CLI arg > env var > turbo.json)

I've done this checks (with some print debugging) on repos where I use `turbo` and it seems to work as expected. I've added some unit and integration tests where it seemed to make the most sense, but there were some spots where it was unclear if I should add something. If I've missed a spot or need some additional checks, let me know!
