### PR TITLE
fix: unexpected top-level property `default` in `base.js` eslint config

### DIFF
--- a/examples/with-nestjs/packages/eslint-config/base.js
+++ b/examples/with-nestjs/packages/eslint-config/base.js
@@ -1,21 +1,25 @@
 /** @type {import("eslint").Linter.Config} */
+const turboConfig = require("eslint-config-turbo").default;
+
 module.exports = {
   root: true,
+  ...turboConfig,
   extends: [
-    'plugin:@typescript-eslint/recommended',
-    'plugin:prettier/recommended',
-    'prettier',
-    'turbo',
+    ...turboConfig.extends,
+    "plugin:@typescript-eslint/recommended",
+    "plugin:prettier/recommended",
+    "prettier",
   ],
-  plugins: ['@typescript-eslint/eslint-plugin'],
-  parser: '@typescript-eslint/parser',
+  plugins: [...(turboConfig.plugins || []), "@typescript-eslint/eslint-plugin"],
+  parser: "@typescript-eslint/parser",
   ignorePatterns: [
-    '.*.js',
-    '*.setup.js',
-    '*.config.js',
-    '.turbo/',
-    'dist/',
-    'coverage/',
-    'node_modules/',
+    ".*.js",
+    "*.setup.js",
+    "*.config.js",
+    ".turbo/",
+    "dist/",
+    "coverage/",
+    "node_modules/",
+    ".husky/",
   ],
 };


### PR DESCRIPTION
## Resolve issues with unexpected top-level property default in `base.js` eslint config

```
Error: ESLint configuration in .eslintrc.js » @repo/eslint-config/nest.js » ./base.js » eslint-config-turbo is invalid:
- Unexpected top-level property "default".
```

### Description

When I run this example application and use `npm run lint` it will retrun an error:

```
api:lint: Oops! Something went wrong! :(
api:lint: 
api:lint: ESLint: 8.57.1
api:lint: 
api:lint: Error: ESLint configuration in .eslintrc.js » @repo/eslint-config/nest.js » ./base.js » eslint-config-turbo is invalid:
api:lint:       - Unexpected top-level property "default".
api:lint: 
api:lint: Referenced from: /.../packages/eslint-config/base.js
```

My changes fixing issue and there is no more errors:

```
 Tasks:    4 successful, 4 total
Cached:    0 cached, 4 total
  Time:    1.821s 
```

### Testing Instructions

1. Clone repo
2. `npm i`
3. `npm run lint`
