### PR TITLE
docs: add missing shadcn/ui tile

### DIFF
--- a/docs/site/content/repo-docs/guides/tools/index.mdx
+++ b/docs/site/content/repo-docs/guides/tools/index.mdx
@@ -13,6 +13,7 @@ Turborepo works with **all of your favorite tooling**. Below, you'll find guides
   <Card title="ESLint" href="/repo/docs/guides/tools/eslint" />
   <Card title="Jest" href="/repo/docs/guides/tools/jest" />
   <Card title="Prisma" href="/repo/docs/guides/tools/prisma" />
+  <Card title="shadcn/ui" href="/repo/docs/guides/tools/shadcn-ui" />
   <Card title="Storybook" href="/repo/docs/guides/tools/storybook" />
   <Card title="TypeScript" href="/repo/docs/guides/tools/typescript" />
   <Card title="Vitest" href="/repo/docs/guides/tools/vitest" />


### PR DESCRIPTION
### Description

Add missing shadcn/ui tile to the section's index page.
