### PR TITLE
docs: move CTA below TOC

### DIFF
--- a/docs/site/components/docs-layout/docs.client.tsx
+++ b/docs/site/components/docs-layout/docs.client.tsx
@@ -173,14 +173,13 @@ export const TableOfContents = () => {
 
   return (
     <>
-      <RemoteCacheCounter />
       <Base.AnchorProvider toc={data.toc}>
         <Base.ScrollProvider containerRef={ref}>
-          <div className="max-h-[calc(100vh-300px)]">
-            <span className="-ms-0.5 flex mb-2 items-center gap-x-1.5 text-sm font-medium text-gray-1000">
-              <AlignmentLeft className="w-3 h-3" />
-              On this page
-            </span>
+          <span className="-ms-0.5 flex mb-2 items-center gap-x-1.5 text-sm font-medium text-gray-1000">
+            <AlignmentLeft className="w-3 h-3" />
+            On this page
+          </span>
+          <div className="max-h-[calc(100vh-300px)] overflow-auto">
             <ul className="flex flex-col gap-y-2.5 text-sm text-gray-900">
               {data.toc.map((item) => {
                 return <TOCItem key={item.url} item={item} />;
@@ -189,6 +188,7 @@ export const TableOfContents = () => {
           </div>
         </Base.ScrollProvider>
       </Base.AnchorProvider>
+      <RemoteCacheCounter />
     </>
   );
 };


### PR DESCRIPTION
### Description

Moves the Remote Cache time saved counter below the Table of Contents. Users being able to find their content is more important.
