### PR TITLE
chore: upgrade turborepo-process and turborepo-filewatch to Rust 2024 edition

### DIFF
--- a/crates/turborepo-filewatch/Cargo.toml
+++ b/crates/turborepo-filewatch/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turborepo-filewatch"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/turborepo-filewatch/src/fsevent.rs
+++ b/crates/turborepo-filewatch/src/fsevent.rs
@@ -277,9 +277,9 @@ extern "C" fn release_context(info: *const libc::c_void) {
     }
 }
 
-extern "C" {
+unsafe extern "C" {
     /// Indicates whether the run loop is waiting for an event.
-    fn CFRunLoopIsWaiting(runloop: cf::CFRunLoopRef) -> cf::Boolean;
+    safe fn CFRunLoopIsWaiting(runloop: cf::CFRunLoopRef) -> cf::Boolean;
 }
 
 // CoreFoundation false value
@@ -515,10 +515,11 @@ impl FsEventWatcher {
 extern "C" fn callback(
     stream_ref: fs::FSEventStreamRef,
     info: *mut libc::c_void,
-    num_events: libc::size_t,                        // size_t numEvents
-    event_paths: *mut libc::c_void,                  // void *eventPaths
-    event_flags: *const fs::FSEventStreamEventFlags, // const FSEventStreamEventFlags eventFlags[]
-    event_ids: *const fs::FSEventStreamEventId,      // const FSEventStreamEventId eventIds[]
+    num_events: libc::size_t,       // size_t numEvents
+    event_paths: *mut libc::c_void, // void *eventPaths
+    event_flags: *const fs::FSEventStreamEventFlags, /* const FSEventStreamEventFlags
+                                     * eventFlags[] */
+    event_ids: *const fs::FSEventStreamEventId, // const FSEventStreamEventId eventIds[]
 ) {
     unsafe {
         callback_impl(
@@ -542,21 +543,21 @@ unsafe fn callback_impl(
 ) {
     let event_paths = event_paths as *const *const libc::c_char;
     let info = info as *const StreamContextInfo;
-    let event_handler = &(*info).event_handler;
+    let event_handler = unsafe { &(*info).event_handler };
 
     for p in 0..num_events {
-        let raw_path = CStr::from_ptr(*event_paths.add(p))
+        let raw_path = unsafe { CStr::from_ptr(*event_paths.add(p)) }
             .to_str()
             .expect("Invalid UTF8 string.");
         let path = PathBuf::from(format!("/{}", raw_path));
 
-        let flag = *event_flags.add(p);
+        let flag = unsafe { *event_flags.add(p) };
         let flag = StreamFlags::from_bits(flag).unwrap_or_else(|| {
             panic!("Unable to decode StreamFlags: {}", flag);
         });
 
         let mut handle_event = false;
-        for (p, r) in &(*info).recursive_info {
+        for (p, r) in unsafe { &(*info).recursive_info } {
             if path.starts_with(p) {
                 if *r || &path == p {
                     handle_event = true;

--- a/crates/turborepo-process/Cargo.toml
+++ b/crates/turborepo-process/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turborepo-process"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 
 [dev-dependencies]


### PR DESCRIPTION
### Description

in #10114 I tried to update turborepo-filewatch, but it failed due to functions being automatically marked as unsafe when using `unsafe extern "C"`. Rust provides a `safe` keyword to fall to previous behavior.

turborepo-process was added recently but it used edition 2021
<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

### Testing Instructions

CI. I don't have an Apple machine :(
<!--
  Give a quick description of steps to test your changes.
-->
