### PR TITLE
feat(tui): bump default scrollback length

### DIFF
--- a/crates/turborepo-ui/src/tui/term_output.rs
+++ b/crates/turborepo-ui/src/tui/term_output.rs
@@ -7,7 +7,7 @@ use super::{
     Error,
 };
 
-const SCROLLBACK_LEN: usize = 1024;
+const SCROLLBACK_LEN: usize = 2048;
 
 pub struct TerminalOutput<W> {
     output: Vec<u8>,


### PR DESCRIPTION
### Description

Breaking up https://github.com/vercel/turborepo/pull/10247 into PRs that only do one thing. This handles the bump for default scrollback length.

Performance was assessed here: https://github.com/vercel/turborepo/pull/10247#discussion_r2021313622

### Testing Instructions

👀
