### PR TITLE
fix(examples): fix build in the freshly created project with vue/nuxt

### DIFF
--- a/examples/with-vue-nuxt/apps/web/env.d.ts
+++ b/examples/with-vue-nuxt/apps/web/env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+declare module "*.vue" {
+  import type { DefineComponent } from "vue";
+
+  const component: DefineComponent<{}, {}, any>;
+
+  export default component;
+}


### PR DESCRIPTION
Fixes the issue with build in the freshly created Turborepo project with vue-nuxt example

### Description

When you init a new project and try build command, there are errors in web app:
```
web:build: ../../packages/ui/index.ts(1,18): error TS7016: Could not find a declaration file for module './src/card.vue'. 'D:/Projekti/turborepo-vue-test/packages/ui/src/card.vue' implicitly has an 'any' type.
web:build: ../../packages/ui/index.ts(2,22): error TS7016: Could not find a declaration file for module './src/gradient.vue'. 'D:/Projekti/turborepo-vue-test/packages/ui/src/gradient.vue' implicitly has an 'any' type.
web:build: ../../packages/ui/index.ts(3,18): error TS7016: Could not find a declaration file for module './src/page.vue'. 'D:/Projekti/turborepo-vue-test/packages/ui/src/page.vue' implicitly has an 'any' type.
```

### Testing Instructions

Tried to run example from a branch but that didn't really work.
```bash
npx create-turbo@latest --example https://github.com/chameleonmind/turborepo/tree/fix/Fix_example_vue_nuxt_build
```
If necessary, I could provide a repo with these changes only
