### PR TITLE
ci(fix): ensure history is up to date

### DIFF
--- a/.github/workflows/update-examples-on-release.yml
+++ b/.github/workflows/update-examples-on-release.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Commit and push
         run: |
           git commit -am "release(turborepo): update examples to latest"
+          git pull origin main
           git push origin ${{ steps.branch.outputs.STAGE_BRANCH }}
 
       - name: Create pull request


### PR DESCRIPTION
### Description

[This workflow](https://github.com/vercel/turborepo/actions/runs/14248783731/job/39936314642)
 is complaining that it doesn't have all the history it needs, so hoping that fetching it will help it out?
 
 I don't totally get why this would be the case given that:
 1) I works when I do a manual workflow trigger.
 2) The first step is to checkout...
 
 🤷
