### PR TITLE
fix(microfrontends): ensure that local proxy is loose

### DIFF
--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -679,6 +679,7 @@ impl TurboJson {
                     )))])
                 }),
                 persistent: Some(Spanned::new(true)),
+                env_mode: Some(EnvMode::Loose),
                 ..Default::default()
             }),
         );


### PR DESCRIPTION
### Description

The MFE proxy is a persistent task that isn't cached. We don't need to get in user's way when they're trying to pass in an environment variable to be used by the local proxy.

### Testing Instructions

Test that a `proxy` script gets an env var.
- Setup a custom proxy script in `package.json`: `echo Starting with $PROXY_VAR && cat`
- Run `PROXY_VAR=foo turbo_dev --skip-infer dev -F nextjs-app-marketing`
- Verify that `Starting with foo` is in the proxy logs
