### PR TITLE
chore: ignore ci and chore PRs in release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -5,6 +5,7 @@ changelog:
     labels:
       - "area: ci"
       - "release: turborepo"
+      - "release-notes-ignore"
   categories:
     - title: Docs
       labels:

--- a/.github/turbo-orchestrator.yml
+++ b/.github/turbo-orchestrator.yml
@@ -34,6 +34,10 @@ labeler:
     - label: "needs: triage"
       when:
         isNotPRAuthorMatch: "^(padmaia|anthonyshew|dimitropoulos|tknickman|chris-olszewski|NicholasLYang)$"
+    # Removes the PR from release notes when its chore or ci
+    - label: "release-notes-ignore"
+      when:
+        isPrTitleMatch: "(\bchore\b|\bci\b).*?:"
 
     # areas
     - label: "area: ci"


### PR DESCRIPTION
### Description

Instruct the labeler to mark PRs with conventional commits that are `ci` or `chore`. Then, ignore it when generating release notes.
