### PR TITLE
docs: list pnpm as first package manager

### DIFF
--- a/docs/site/components/icons/magnifying-glass.tsx
+++ b/docs/site/components/icons/magnifying-glass.tsx
@@ -3,13 +3,13 @@ export const MagnifyingGlass = ({ className }: { className?: string }) => {
     <svg
       className={className}
       height="16"
-      stroke-linejoin="round"
+      strokeLinejoin="round"
       viewBox="0 0 16 16"
       width="16"
     >
       <path
-        fill-rule="evenodd"
-        clip-rule="evenodd"
+        fillRule="evenodd"
+        clipRule="evenodd"
         d="M1.5 6.5C1.5 3.73858 3.73858 1.5 6.5 1.5C9.26142 1.5 11.5 3.73858 11.5 6.5C11.5 9.26142 9.26142 11.5 6.5 11.5C3.73858 11.5 1.5 9.26142 1.5 6.5ZM6.5 0C2.91015 0 0 2.91015 0 6.5C0 10.0899 2.91015 13 6.5 13C8.02469 13 9.42677 12.475 10.5353 11.596L13.9697 15.0303L14.5 15.5607L15.5607 14.5L15.0303 13.9697L11.596 10.5353C12.475 9.42677 13 8.02469 13 6.5C13 2.91015 10.0899 0 6.5 0Z"
         fill="currentColor"
       ></path>

--- a/docs/site/components/icons/magnifying-glass.tsx
+++ b/docs/site/components/icons/magnifying-glass.tsx
@@ -3,13 +3,13 @@ export const MagnifyingGlass = ({ className }: { className?: string }) => {
     <svg
       className={className}
       height="16"
-      strokeLinejoin="round"
+      stroke-linejoin="round"
       viewBox="0 0 16 16"
       width="16"
     >
       <path
-        fillRule="evenodd"
-        clipRule="evenodd"
+        fill-rule="evenodd"
+        clip-rule="evenodd"
         d="M1.5 6.5C1.5 3.73858 3.73858 1.5 6.5 1.5C9.26142 1.5 11.5 3.73858 11.5 6.5C11.5 9.26142 9.26142 11.5 6.5 11.5C3.73858 11.5 1.5 9.26142 1.5 6.5ZM6.5 0C2.91015 0 0 2.91015 0 6.5C0 10.0899 2.91015 13 6.5 13C8.02469 13 9.42677 12.475 10.5353 11.596L13.9697 15.0303L14.5 15.5607L15.5607 14.5L15.0303 13.9697L11.596 10.5353C12.475 9.42677 13 8.02469 13 6.5C13 2.91015 10.0899 0 6.5 0Z"
         fill="currentColor"
       ></path>

--- a/docs/site/components/icons/turborepo-wordmark.tsx
+++ b/docs/site/components/icons/turborepo-wordmark.tsx
@@ -52,8 +52,8 @@ export const TurborepoWordmarkDark = ({
         fill="white"
       />
       <path
-        fill-rule="evenodd"
-        clip-rule="evenodd"
+        fillRule="evenodd"
+        clipRule="evenodd"
         d="M40.2115 14.744V7.125C56.7719 8.0104 69.9275 21.7208 69.9275 38.5016C69.9275 55.2824 56.7719 68.989 40.2115 69.8782V62.2592C52.5539 61.3776 62.3275 51.0644 62.3275 38.5016C62.3275 25.9388 52.5539 15.6256 40.2115 14.744ZM20.5048 54.0815C17.233 50.3043 15.124 45.4935 14.7478 40.2115H7.125C7.5202 47.6025 10.4766 54.3095 15.1088 59.4737L20.501 54.0815H20.5048ZM36.7916 69.8782V62.2592C31.5058 61.883 26.695 59.7778 22.9178 56.5022L17.5256 61.8944C22.6936 66.5304 29.4006 69.483 36.7878 69.8782H36.7916Z"
         fill="url(#paint0_linear_2028_477)"
       />
@@ -66,8 +66,8 @@ export const TurborepoWordmarkDark = ({
           y2="42.4236"
           gradientUnits="userSpaceOnUse"
         >
-          <stop stop-color="#0096FF" />
-          <stop offset="1" stop-color="#FF1E56" />
+          <stop stopColor="#0096FF" />
+          <stop offset="1" stopColor="#FF1E56" />
         </linearGradient>
       </defs>
     </svg>
@@ -128,8 +128,8 @@ export const TurborepoWordmarkLight = ({
         fill="black"
       />
       <path
-        fill-rule="evenodd"
-        clip-rule="evenodd"
+        fillRule="evenodd"
+        clipRule="evenodd"
         d="M40.2115 14.744V7.125C56.7719 8.0104 69.9275 21.7208 69.9275 38.5016C69.9275 55.2824 56.7719 68.989 40.2115 69.8782V62.2592C52.5539 61.3776 62.3275 51.0644 62.3275 38.5016C62.3275 25.9388 52.5539 15.6256 40.2115 14.744ZM20.5048 54.0815C17.233 50.3043 15.124 45.4935 14.7478 40.2115H7.125C7.5202 47.6025 10.4766 54.3095 15.1088 59.4737L20.501 54.0815H20.5048ZM36.7916 69.8782V62.2592C31.5058 61.883 26.695 59.7778 22.9178 56.5022L17.5256 61.8944C22.6936 66.5304 29.4006 69.483 36.7878 69.8782H36.7916Z"
         fill="url(#paint0_linear_2028_252)"
       />
@@ -142,8 +142,8 @@ export const TurborepoWordmarkLight = ({
           y2="42.4236"
           gradientUnits="userSpaceOnUse"
         >
-          <stop stop-color="#0096FF" />
-          <stop offset="1" stop-color="#FF1E56" />
+          <stop stopColor="#0096FF" />
+          <stop offset="1" stopColor="#FF1E56" />
         </linearGradient>
       </defs>
     </svg>

--- a/docs/site/components/icons/turborepo-wordmark.tsx
+++ b/docs/site/components/icons/turborepo-wordmark.tsx
@@ -52,8 +52,8 @@ export const TurborepoWordmarkDark = ({
         fill="white"
       />
       <path
-        fillRule="evenodd"
-        clipRule="evenodd"
+        fill-rule="evenodd"
+        clip-rule="evenodd"
         d="M40.2115 14.744V7.125C56.7719 8.0104 69.9275 21.7208 69.9275 38.5016C69.9275 55.2824 56.7719 68.989 40.2115 69.8782V62.2592C52.5539 61.3776 62.3275 51.0644 62.3275 38.5016C62.3275 25.9388 52.5539 15.6256 40.2115 14.744ZM20.5048 54.0815C17.233 50.3043 15.124 45.4935 14.7478 40.2115H7.125C7.5202 47.6025 10.4766 54.3095 15.1088 59.4737L20.501 54.0815H20.5048ZM36.7916 69.8782V62.2592C31.5058 61.883 26.695 59.7778 22.9178 56.5022L17.5256 61.8944C22.6936 66.5304 29.4006 69.483 36.7878 69.8782H36.7916Z"
         fill="url(#paint0_linear_2028_477)"
       />
@@ -66,8 +66,8 @@ export const TurborepoWordmarkDark = ({
           y2="42.4236"
           gradientUnits="userSpaceOnUse"
         >
-          <stop stopColor="#0096FF" />
-          <stop offset="1" stopColor="#FF1E56" />
+          <stop stop-color="#0096FF" />
+          <stop offset="1" stop-color="#FF1E56" />
         </linearGradient>
       </defs>
     </svg>
@@ -128,8 +128,8 @@ export const TurborepoWordmarkLight = ({
         fill="black"
       />
       <path
-        fillRule="evenodd"
-        clipRule="evenodd"
+        fill-rule="evenodd"
+        clip-rule="evenodd"
         d="M40.2115 14.744V7.125C56.7719 8.0104 69.9275 21.7208 69.9275 38.5016C69.9275 55.2824 56.7719 68.989 40.2115 69.8782V62.2592C52.5539 61.3776 62.3275 51.0644 62.3275 38.5016C62.3275 25.9388 52.5539 15.6256 40.2115 14.744ZM20.5048 54.0815C17.233 50.3043 15.124 45.4935 14.7478 40.2115H7.125C7.5202 47.6025 10.4766 54.3095 15.1088 59.4737L20.501 54.0815H20.5048ZM36.7916 69.8782V62.2592C31.5058 61.883 26.695 59.7778 22.9178 56.5022L17.5256 61.8944C22.6936 66.5304 29.4006 69.483 36.7878 69.8782H36.7916Z"
         fill="url(#paint0_linear_2028_252)"
       />
@@ -142,8 +142,8 @@ export const TurborepoWordmarkLight = ({
           y2="42.4236"
           gradientUnits="userSpaceOnUse"
         >
-          <stop stopColor="#0096FF" />
-          <stop offset="1" stopColor="#FF1E56" />
+          <stop stop-color="#0096FF" />
+          <stop offset="1" stop-color="#FF1E56" />
         </linearGradient>
       </defs>
     </svg>

--- a/docs/site/components/tabs.tsx
+++ b/docs/site/components/tabs.tsx
@@ -22,12 +22,12 @@ export function Tabs({
   );
 }
 
-const checkPackageManagerIndex = (index: number, provided: string) => {
-  const expectedValues = ["pnpm", "yarn", "npm"];
+const packageManagers = ["pnpm", "yarn", "npm"];
 
-  if (provided !== expectedValues[index]) {
+const checkPackageManagerIndex = (index: number, provided: string) => {
+  if (provided !== packageManagers[index]) {
     throw new Error(
-      `Package manager at index ${index} must be ${expectedValues[index]}.`
+      `Package manager at index ${index} must be ${packageManagers[index]}.`
     );
   }
 };
@@ -41,8 +41,6 @@ export function PackageManagerTabs({
   storageKey?: string;
   children: ReactNode;
 }): JSX.Element {
-  const items = ["pnpm", "yarn", "npm"];
-
   if (!Array.isArray(children)) {
     throw new Error("Children must be an array.");
   }
@@ -56,10 +54,13 @@ export function PackageManagerTabs({
   });
 
   return (
-    <FumaTabs id={storageKey} items={items} {...props}>
+    <FumaTabs id={storageKey} items={packageManagers} {...props}>
       {children.map((child, index) => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-assignment
-        return { ...child, props: { ...child.props, value: items[index] } };
+        return {
+          ...child,
+          props: { ...child.props, value: packageManagers[index] },
+        };
       })}
     </FumaTabs>
   );

--- a/docs/site/components/tabs.tsx
+++ b/docs/site/components/tabs.tsx
@@ -22,6 +22,16 @@ export function Tabs({
   );
 }
 
+const checkPackageManagerIndex = (index: number, provided: string) => {
+  const expectedValues = ["pnpm", "yarn", "npm"];
+
+  if (provided !== expectedValues[index]) {
+    throw new Error(
+      `Package manager at index ${index} must be ${expectedValues[index]}.`
+    );
+  }
+};
+
 /** Use <Tab /> component to create the tabs. They will automatically be assigned their values in the order ["npm", "yarn", "pnpm"]. */
 export function PackageManagerTabs({
   storageKey = "package-manager-tabs",
@@ -31,11 +41,19 @@ export function PackageManagerTabs({
   storageKey?: string;
   children: ReactNode;
 }): JSX.Element {
-  const items = ["npm", "yarn", "pnpm"];
+  const items = ["pnpm", "yarn", "npm"];
 
   if (!Array.isArray(children)) {
     throw new Error("Children must be an array.");
   }
+
+  children.forEach((packageManager, index) => {
+    if (!packageManager.props.value) {
+      throw new Error(`Package manager tab is missing a value.`);
+    }
+
+    checkPackageManagerIndex(index, packageManager.props.value);
+  });
 
   return (
     <FumaTabs id={storageKey} items={items} {...props}>

--- a/docs/site/content/repo-docs/core-concepts/internal-packages.mdx
+++ b/docs/site/content/repo-docs/core-concepts/internal-packages.mdx
@@ -10,31 +10,32 @@ Internal Packages are libraries whose source code is inside your Workspace. You 
 Internal Packages are used in your repository by installing them in `package.json` similar to an external package coming from the npm registry. However, instead of marking a version to install, you can reference the package using your package manager's workspace installation syntax:
 
 <PackageManagerTabs>
-<Tab>
-```json title="./apps/web/package.json"
-{
-  "dependencies": {
-    "@repo/ui": "*" // [!code highlight]
-  }
-}
-```
-</Tab>
 
-<Tab>
-```json title="./apps/web/package.json"
-{
-  "dependencies": {
-    "@repo/ui": "*" // [!code highlight]
-  }
-}
-```
-</Tab>
-
-<Tab>
+<Tab value="pnpm">
 ```json title="./apps/web/package.json"
 {
   "dependencies": {
     "@repo/ui": "workspace:*" // [!code highlight]
+  }
+}
+```
+</Tab>
+
+<Tab value="yarn">
+```json title="./apps/web/package.json"
+{
+  "dependencies": {
+    "@repo/ui": "*" // [!code highlight]
+  }
+}
+```
+</Tab>
+
+<Tab value="npm">
+```json title="./apps/web/package.json"
+{
+  "dependencies": {
+    "@repo/ui": "*" // [!code highlight]
   }
 }
 ```

--- a/docs/site/content/repo-docs/core-concepts/remote-caching.mdx
+++ b/docs/site/content/repo-docs/core-concepts/remote-caching.mdx
@@ -89,15 +89,16 @@ turbo login
 You can also use your package manager if you do not have [global `turbo`](/docs/getting-started/installation#global-installation) installed:
 
 <PackageManagerTabs>
-<Tab>
+
+<Tab value="pnpm">
 
 ```bash title="Terminal"
-npx turbo login
+pnpm dlx turbo login
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 
 ```bash title="Terminal"
 yarn dlx turbo login
@@ -105,10 +106,10 @@ yarn dlx turbo login
 
 </Tab>
 
-<Tab>
+<Tab value="npm">
 
 ```bash title="Terminal"
-pnpm dlx turbo login
+npx turbo login
 ```
 
 </Tab>

--- a/docs/site/content/repo-docs/crafting-your-repository/caching.mdx
+++ b/docs/site/content/repo-docs/crafting-your-repository/caching.mdx
@@ -49,23 +49,27 @@ If you have [`turbo` installed globally](/docs/getting-started/installation#glob
 Alternatively, you can run the `build` script in `package.json` using your package manager.
 
 <PackageManagerTabs>
-<Tab>
 
+<Tab value="pnpm">
 ```bash title="Terminal"
-npm run build
+pnpm run build
 ```
 
 </Tab>
-<Tab>
+
+<Tab value="yarn">
 ```bash title="Terminal"
 yarn build
 ```
 
 </Tab>
-<Tab>
+
+<Tab value="npm">
+
 ```bash title="Terminal"
-pnpm run build
+npm run build
 ```
+
 </Tab>
 </PackageManagerTabs>
 

--- a/docs/site/content/repo-docs/crafting-your-repository/creating-an-internal-package.mdx
+++ b/docs/site/content/repo-docs/crafting-your-repository/creating-an-internal-package.mdx
@@ -45,7 +45,62 @@ You'll need a directory to put the package in. Let's create one at `./packages/m
 Next, create the `package.json` for the package. By adding this file, you'll fulfill [the two requirements for an Internal Package](/docs/crafting-your-repository/structuring-a-repository#specifying-packages-in-a-monorepo), making it discoverable to Turborepo and the rest of your Workspace:
 
 <PackageManagerTabs>
-<Tab>
+
+<Tab value="pnpm">
+```json title="./packages/math/package.json"
+{
+  "name": "@repo/math",
+  "type": "module",
+  "scripts": {
+    "dev": "tsc --watch",
+    "build": "tsc"
+  },
+  "exports": {
+    "./add": {
+      "types": "./src/add.ts",
+      "default": "./dist/add.js"
+    },
+    "./subtract": {
+      "types": "./src/subtract.ts",
+      "default": "./dist/subtract.js"
+    }
+  },
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*",
+    "typescript": "latest"
+  }
+}
+```
+</Tab>
+
+<Tab value="yarn">
+```json title="./packages/math/package.json"
+{
+  "name": "@repo/math",
+  "type": "module",
+  "scripts": {
+    "dev": "tsc --watch",
+    "build": "tsc"
+  },
+  "exports": {
+    "./add": {
+      "types": "./src/add.ts",
+      "default": "./dist/add.js"
+    },
+    "./subtract": {
+      "types": "./src/subtract.ts",
+      "default": "./dist/subtract.js"
+    }
+  },
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*",
+    "typescript": "latest"
+  }
+}
+```
+</Tab>
+
+<Tab value="npm">
 ```json title="./packages/math/package.json"
 {
   "name": "@repo/math",
@@ -71,58 +126,6 @@ Next, create the `package.json` for the package. By adding this file, you'll ful
 }
 ````
 
-</Tab>
-<Tab>
-```json title="./packages/math/package.json"
-{
-  "name": "@repo/math",
-  "type": "module",
-  "scripts": {
-    "dev": "tsc --watch",
-    "build": "tsc"
-  },
-  "exports": {
-    "./add": {
-      "types": "./src/add.ts",
-      "default": "./dist/add.js"
-    },
-    "./subtract": {
-      "types": "./src/subtract.ts",
-      "default": "./dist/subtract.js"
-    }
-  },
-  "devDependencies": {
-    "@repo/typescript-config": "workspace:*",
-    "typescript": "latest"
-  }
-}
-```
-</Tab>
-<Tab>
-```json title="./packages/math/package.json"
-{
-  "name": "@repo/math",
-  "type": "module",
-  "scripts": {
-    "dev": "tsc --watch",
-    "build": "tsc"
-  },
-  "exports": {
-    "./add": {
-      "types": "./src/add.ts",
-      "default": "./dist/add.js"
-    },
-    "./subtract": {
-      "types": "./src/subtract.ts",
-      "default": "./dist/subtract.js"
-    }
-  },
-  "devDependencies": {
-    "@repo/typescript-config": "workspace:*",
-    "typescript": "latest"
-  }
-}
-```
 </Tab>
 </PackageManagerTabs>
 
@@ -201,30 +204,33 @@ These files map to the outputs that will be created by `tsc` when you run `turbo
 You're ready to use your new package in an application. Let's add it to the `web` application.
 
 <PackageManagerTabs>
-<Tab>
-```diff title="apps/web/package.json"
-  "dependencies": {
-+   "@repo/math": "*",
-    "next": "latest",
-    "react": "latest",
-    "react-dom": "latest"
-  },
-```
-</Tab>
-<Tab>
-```diff title="apps/web/package.json"
-  "dependencies": {
-+   "@repo/math": "*",
-    "next": "latest",
-    "react": "latest",
-    "react-dom": "latest"
-  },
-```
-</Tab>
-<Tab>
+
+<Tab value="pnpm">
 ```diff title="apps/web/package.json"
   "dependencies": {
 +   "@repo/math": "workspace:*",
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  },
+```
+</Tab>
+
+<Tab value="yarn">
+```diff title="apps/web/package.json"
+  "dependencies": {
++   "@repo/math": "*",
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  },
+```
+</Tab>
+
+<Tab value="npm">
+```diff title="apps/web/package.json"
+  "dependencies": {
++   "@repo/math": "*",
     "next": "latest",
     "react": "latest",
     "react-dom": "latest"

--- a/docs/site/content/repo-docs/crafting-your-repository/managing-dependencies.mdx
+++ b/docs/site/content/repo-docs/crafting-your-repository/managing-dependencies.mdx
@@ -11,32 +11,35 @@ import { LinkToDocumentation } from '#/components/link-to-documentation';
 - **Internal dependencies** let you share functionality within your repository, dramatically improving discoverability and usability of shared code. We will discuss how to build an Internal Package in [the next guide](/docs/crafting-your-repository/creating-an-internal-package).
 
 <PackageManagerTabs>
-<Tab>
-```json title="./apps/web/package.json"
-{
-  "dependencies": {
-    "next": "latest", // External dependency
-    "@repo/ui": "*" // Internal dependency
-  }
-}
-```
-</Tab>
-<Tab>
-```json title="./apps/web/package.json"
-{
-  "dependencies": {
-    "next": "latest", // External dependency
-    "@repo/ui": "*" // Internal dependency
-  }
-}
-```
-</Tab>
-<Tab>
+
+<Tab value="pnpm">
 ```json title="./apps/web/package.json"
 {
   "dependencies": {
     "next": "latest", // External dependency
     "@repo/ui": "workspace:*" // Internal dependency
+  }
+}
+```
+</Tab>
+
+<Tab value="yarn">
+```json title="./apps/web/package.json"
+{
+  "dependencies": {
+    "next": "latest", // External dependency
+    "@repo/ui": "*" // Internal dependency
+  }
+}
+```
+</Tab>
+
+<Tab value="npm">
+```json title="./apps/web/package.json"
+{
+  "dependencies": {
+    "next": "latest", // External dependency
+    "@repo/ui": "*" // Internal dependency
   }
 }
 ```
@@ -57,16 +60,17 @@ When you install a dependency in your repository, you should install it directly
 To quickly install dependencies in multiple packages, you can use your package manager:
 
 <PackageManagerTabs>
-<Tab>
+
+<Tab value="pnpm">
 
 ```bash title="Terminal"
-npm install jest --workspace=web --workspace=@repo/ui --save-dev
+pnpm install jest --save-dev --recursive --filter=web --filter=@repo/ui --filter=@repo/web
 ```
 
-<LinkToDocumentation href="https://docs.npmjs.com/cli/v7/using-npm/config#workspace">npm documentation</LinkToDocumentation>
+<LinkToDocumentation href="https://pnpm.io/cli/recursive">pnpm documentation</LinkToDocumentation>
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 Yarn 1:
 
 ```bash title="Terminal"
@@ -89,13 +93,13 @@ yarn workspaces foreach -R --from '{web,@repo/ui}' add jest --dev
 </LinkToDocumentation>
 </Tab>
 
-<Tab>
+<Tab value="npm">
 
 ```bash title="Terminal"
-pnpm install jest --save-dev --recursive --filter=web --filter=@repo/ui --filter=@repo/web
+npm install jest --workspace=web --workspace=@repo/ui --save-dev
 ```
 
-<LinkToDocumentation href="https://pnpm.io/cli/recursive">pnpm documentation</LinkToDocumentation>
+<LinkToDocumentation href="https://docs.npmjs.com/cli/v7/using-npm/config#workspace">npm documentation</LinkToDocumentation>
 </Tab>
 </PackageManagerTabs>
 
@@ -154,15 +158,16 @@ Tools like [`syncpack`](https://www.npmjs.com/package/syncpack), [`manypkg`](htt
 You can use your package manager to update dependency versions in one command.
 
 <PackageManagerTabs>
-<Tab>
+
+<Tab value="pnpm">
 ```bash title="Terminal"
-npm install typescript@latest --workspaces
+pnpm up --recursive typescript@latest
 ```
-  <small>[→ npm documentation](https://docs.npmjs.com/cli/v7/using-npm/config#workspaces)</small>
+  <small>[→ pnpm documentation](https://pnpm.io/cli/update#--recursive--r)</small>
 
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 Yarn 1:
 ```bash title="Terminal"
 yarn upgrade-interactive --latest
@@ -179,11 +184,11 @@ yarn upgrade typescript@latest --upgrade
 
 </Tab>
 
-<Tab>
+<Tab value="npm">
 ```bash title="Terminal"
-pnpm up --recursive typescript@latest
+npm install typescript@latest --workspaces
 ```
-  <small>[→ pnpm documentation](https://pnpm.io/cli/update#--recursive--r)</small>
+  <small>[→ npm documentation](https://docs.npmjs.com/cli/v7/using-npm/config#workspaces)</small>
 
 </Tab>
 </PackageManagerTabs>

--- a/docs/site/content/repo-docs/crafting-your-repository/running-tasks.mdx
+++ b/docs/site/content/repo-docs/crafting-your-repository/running-tasks.mdx
@@ -40,24 +40,28 @@ For tasks that you run frequently, you can write your `turbo` commands directly 
 These scripts can then be run using your package manager.
 
 <PackageManagerTabs>
-  <Tab>
 
-```bash title="Terminal"
-npm run dev
-```
+  <Tab value="pnpm">
+  ```bash title="Terminal"
+  pnpm dev
+  ```
 
   </Tab>
-  <Tab>
+
+  <Tab value="yarn">
 
 ```bash title="Terminal"
 yarn dev
 ```
 
   </Tab>
-  <Tab>
-  ```bash title="Terminal"
-  pnpm dev
-  ```
+
+  <Tab value="npm">
+
+```bash title="Terminal"
+npm run dev
+```
+
   </Tab>
 </PackageManagerTabs>
 

--- a/docs/site/content/repo-docs/crafting-your-repository/structuring-a-repository.mdx
+++ b/docs/site/content/repo-docs/crafting-your-repository/structuring-a-repository.mdx
@@ -22,9 +22,30 @@ In this guide, we'll walk through setting up a multi-package workspace (monorepo
 
 Setting up a workspace's structure can be tedious to do by hand. If you're new to monorepos, we recommend [using `create-turbo` to get started](/docs/getting-started/installation) with a valid workspace structure right away.
 
+<PackageManagerTabs>
+
+<Tab value="pnpm">
+```bash title="Terminal"
+pnpm dlx create-turbo@latest
+```
+
+</Tab>
+
+<Tab value="yarn">
+```bash title="Terminal"
+yarn dlx create-turbo@latest
+```
+
+</Tab>
+
+<Tab value="npm">
 ```bash title="Terminal"
 npx create-turbo@latest
 ```
+
+</Tab>
+
+</PackageManagerTabs>
 
 You can then review the repository for the characteristics described in this guide.
 
@@ -35,28 +56,29 @@ In JavaScript, a workspace can either be [a single package](/docs/guides/single-
 Below, the structural elements of `create-turbo` that make it a valid workspace are highlighted.
 
 <PackageManagerTabs>
-<Tab>
-<Files>
-  <File name="package.json" green />
-  <File name="package-lock.json" green />
-  <File name="turbo.json" />
-  <Folder name="apps" defaultOpen>
-    <Folder name="docs" className="text-foreground" defaultOpen>
-     <File name="package.json" green />
+
+<Tab value="pnpm">
+  <Files>
+    <File name="package.json" green />
+    <File name="pnpm-lock.yaml" green />
+    <File name="turbo.json" />
+    <Folder name="apps" defaultOpen>
+      <Folder name="docs" className="text-foreground" defaultOpen>
+        <File name="package.json" green />
+      </Folder>
+      <Folder name="web">
+        <File name="package.json" green />
+      </Folder>
     </Folder>
-    <Folder name="web">
-      <File name="package.json" green />
+    <Folder name="packages">
+      <Folder name="ui">
+        <File name="package.json" green />
+      </Folder>
     </Folder>
-  </Folder>
-  <Folder name="packages">
-    <Folder name="ui">
-      <File name="package.json" green />
-    </Folder>
-  </Folder>
-</Files>
+  </Files>
 </Tab>
 
-<Tab>
+<Tab value="yarn">
   <Files>
     <File name="package.json" green />
     <File name="yarn.lock" green />
@@ -77,26 +99,27 @@ Below, the structural elements of `create-turbo` that make it a valid workspace 
   </Files>
 </Tab>
 
-<Tab>
-<Files>
-  <File name="package.json" green />
-  <File name="pnpm-lock.yaml" green />
-  <File name="turbo.json" />
-  <Folder name="apps" defaultOpen>
-    <Folder name="docs" className="text-foreground" defaultOpen>
-     <File name="package.json" green />
+<Tab value="npm">
+  <Files>
+    <File name="package.json" green />
+    <File name="package-lock.json" green />
+    <File name="turbo.json" />
+    <Folder name="apps" defaultOpen>
+      <Folder name="docs" className="text-foreground" defaultOpen>
+        <File name="package.json" green />
+      </Folder>
+      <Folder name="web">
+        <File name="package.json" green />
+      </Folder>
     </Folder>
-    <Folder name="web">
-      <File name="package.json" green />
+    <Folder name="packages">
+      <Folder name="ui">
+        <File name="package.json" green />
+      </Folder>
     </Folder>
-  </Folder>
-  <Folder name="packages">
-    <Folder name="ui">
-      <File name="package.json" green />
-    </Folder>
-  </Folder>
-</Files>
+  </Files>
 </Tab>
+
 </PackageManagerTabs>
 
 ### Minimum requirements
@@ -117,19 +140,18 @@ Below, the structural elements of `create-turbo` that make it a valid workspace 
 First, your package manager needs to describe the locations of your packages. We recommend starting with splitting your packages into `apps/` for applications and services and `packages/` for everything else, like libraries and tooling.
 
 <PackageManagerTabs>
-  <Tab>
-  ```json title="./package.json"
-  {
-    "workspaces": [
-      "apps/*",
-      "packages/*"
-    ]
-  }
-  ```
 
-  <LinkToDocumentation href="https://docs.npmjs.com/cli/v7/using-npm/workspaces#defining-workspaces">npm workspace documentation</LinkToDocumentation>
+  <Tab value="pnpm">
+  ```json title="pnpm-workspace.yaml"
+ packages:
+    - "apps/*"
+    - "packages/*"
+  ```
+  <LinkToDocumentation href="https://pnpm.io/pnpm-workspace_yaml">pnpm workspace documentation</LinkToDocumentation>
+
   </Tab>
-  <Tab >
+
+  <Tab value="yarn">
   ```json title="./package.json"
   {
     "workspaces": [
@@ -141,14 +163,18 @@ First, your package manager needs to describe the locations of your packages. We
 
   <LinkToDocumentation href="https://yarnpkg.com/features/workspaces#how-are-workspaces-declared">yarn workspace documentation</LinkToDocumentation>
    </Tab>
-  <Tab>
-  ```json title="pnpm-workspace.yaml"
- packages:
-    - "apps/*"
-    - "packages/*"
-  ```
-  <LinkToDocumentation href="https://pnpm.io/pnpm-workspace_yaml">pnpm workspace documentation</LinkToDocumentation>
 
+  <Tab value="npm">
+  ```json title="./package.json"
+  {
+    "workspaces": [
+      "apps/*",
+      "packages/*"
+    ]
+  }
+  ```
+
+  <LinkToDocumentation href="https://docs.npmjs.com/cli/v7/using-npm/workspaces#defining-workspaces">npm workspace documentation</LinkToDocumentation>
   </Tab>
 </PackageManagerTabs>
 
@@ -176,45 +202,8 @@ In the directory of the package, there must be a `package.json` to make the pack
 The root `package.json` is the base for your workspace. Below is a common example of what you would find in a root `package.json`:
 
 <PackageManagerTabs>
-<Tab>
 
-```json title="./package.json"
-{
-  "private": true,
-  "scripts": {
-    "build": "turbo run build",
-    "dev": "turbo run dev",
-    "lint": "turbo run lint"
-  },
-  "devDependencies": {
-    "turbo": "latest"
-  },
-  "packageManager": "npm@10.0.0"
-}
-```
-
-</Tab>
-
-<Tab>
-
-```json title="./package.json"
-{
-  "private": true,
-  "scripts": {
-    "build": "turbo run build",
-    "dev": "turbo run dev",
-    "lint": "turbo run lint"
-  },
-  "devDependencies": {
-    "turbo": "latest"
-  },
-  "packageManager": "yarn@1.22.19"
-}
-```
-
-</Tab>
-
-<Tab>
+<Tab value="pnpm">
 
 ```json title="./package.json"
 {
@@ -233,6 +222,43 @@ The root `package.json` is the base for your workspace. Below is a common exampl
 
 </Tab>
 
+<Tab value="yarn">
+
+```json title="./package.json"
+{
+  "private": true,
+  "scripts": {
+    "build": "turbo run build",
+    "dev": "turbo run dev",
+    "lint": "turbo run lint"
+  },
+  "devDependencies": {
+    "turbo": "latest"
+  },
+  "packageManager": "yarn@1.22.19"
+}
+```
+
+</Tab>
+
+<Tab value="npm">
+
+```json title="./package.json"
+{
+  "private": true,
+  "scripts": {
+    "build": "turbo run build",
+    "dev": "turbo run dev",
+    "lint": "turbo run lint"
+  },
+  "devDependencies": {
+    "turbo": "latest"
+  },
+  "packageManager": "npm@10.0.0"
+}
+```
+
+</Tab>
 </PackageManagerTabs>
 
 ### Root `turbo.json`

--- a/docs/site/content/repo-docs/crafting-your-repository/upgrading.mdx
+++ b/docs/site/content/repo-docs/crafting-your-repository/upgrading.mdx
@@ -18,15 +18,15 @@ Get started upgrading from 1.x to 2.0 by running:
 
 <PackageManagerTabs>
 
-<Tab>
+<Tab value="pnpm">
 
 ```bash title="Terminal"
-npx @turbo/codemod migrate
+pnpm dlx @turbo/codemod migrate
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 
 ```bash title="Terminal"
 yarn dlx @turbo/codemod migrate
@@ -34,10 +34,10 @@ yarn dlx @turbo/codemod migrate
 
 </Tab>
 
-<Tab>
+<Tab value="npm">
 
 ```bash title="Terminal"
-pnpm dlx @turbo/codemod migrate
+npx @turbo/codemod migrate
 ```
 
 </Tab>
@@ -64,17 +64,18 @@ Additionally, a `name` field will be added to any `package.json` in the Workspac
 Turborepo 2.0 requires that your Workspace define this field as a way to improve the stability and behavioral predictability of your codebase. If you do not have one already, add this field to your root `package.json`:
 
 <PackageManagerTabs>
-<Tab>
+
+<Tab value="pnpm">
 
 ```diff title="./package.json"
 {
-+ "packageManager": "npm@10.8.1"
++ "packageManager": "pnpm@9.2.0"
 }
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 
 ```diff title="./package.json"
 {
@@ -84,11 +85,11 @@ Turborepo 2.0 requires that your Workspace define this field as a way to improve
 
 </Tab>
 
-<Tab>
+<Tab value="npm">
 
 ```diff title="./package.json"
 {
-+ "packageManager": "pnpm@9.2.0"
++ "packageManager": "npm@10.8.1"
 }
 ```
 

--- a/docs/site/content/repo-docs/getting-started/examples.mdx
+++ b/docs/site/content/repo-docs/getting-started/examples.mdx
@@ -10,19 +10,20 @@ import { Callout } from '#/components/callout';
 Use `create-turbo` to bootstrap an example with your favorite tooling.
 
 <PackageManagerTabs>
-<Tab>
+
+<Tab value="pnpm">
 
 ```bash title="Terminal"
 # Use an example listed below
-npx create-turbo@latest --example [example-name]
+pnpm dlx create-turbo@latest --example [example-name]
 
 # Use a GitHub repository from the community
-npx create-turbo@latest --example [github-url]
+pnpm dlx create-turbo@latest --example [github-url]
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 
 ```bash title="Terminal"
 # Use an example listed below
@@ -34,17 +35,18 @@ yarn dlx create-turbo@latest --example [github-url]
 
 </Tab>
 
-<Tab>
+<Tab value="npm">
 
 ```bash title="Terminal"
 # Use an example listed below
-pnpm dlx create-turbo@latest --example [example-name]
+npx create-turbo@latest --example [example-name]
 
 # Use a GitHub repository from the community
-pnpm dlx create-turbo@latest --example [github-url]
+npx create-turbo@latest --example [github-url]
 ```
 
 </Tab>
+
 </PackageManagerTabs>
 
 ## Core-maintained examples

--- a/docs/site/content/repo-docs/getting-started/installation.mdx
+++ b/docs/site/content/repo-docs/getting-started/installation.mdx
@@ -9,23 +9,24 @@ import { PackageManagerTabs, Tabs, Tab } from '#/components/tabs';
 Get started with Turborepo in a few moments using:
 
 <PackageManagerTabs>
-<Tab value="npm">
+
+<Tab value="pnpm">
 ```bash title="Terminal"
-npx create-turbo@latest
+pnpm dlx create-turbo@latest
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 ```bash title="Terminal"
 yarn dlx create-turbo@latest
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="npm">
 ```bash title="Terminal"
-pnpm dlx create-turbo@latest
+npx create-turbo@latest
 ```
 
 </Tab>
@@ -47,26 +48,30 @@ For more details on the starter, [visit the README for the basic starter on GitH
 
 A global install of `turbo` brings flexibility and speed to your local workflows.
 
-<Tabs items={["npm", "yarn", "pnpm"]} storageKey="selected-pkg-manager">
-  <Tab value="npm">
-  ```bash title="Terminal"
-  npm install turbo --global
-  ```
+<PackageManagerTabs>
 
-  </Tab>
-  <Tab value="yarn">
-  ```bash title="Terminal"
-  yarn global add turbo
-  ```
-
-  </Tab>
   <Tab value="pnpm">
   ```bash title="Terminal"
   pnpm install turbo --global
   ```
 
   </Tab>
-</Tabs>
+
+  <Tab value="yarn">
+  ```bash title="Terminal"
+  yarn global add turbo
+  ```
+
+  </Tab>
+
+  <Tab value="npm">
+  ```bash title="Terminal"
+  npm install turbo --global
+  ```
+
+  </Tab>
+
+</PackageManagerTabs>
 
 Once installed globally, you can run your scripts through `turbo` from your terminal, quickly running one-off commands to use within your repository. For example:
 
@@ -95,26 +100,30 @@ You can also take advantage of global `turbo` when creating your CI pipelines. V
 
 When collaborating with other developers in a repository, it's a good idea to pin versions of dependencies. You can do this with `turbo` by adding it as a `devDependency` in the root of your repository:
 
-<Tabs items={["npm", "yarn", "pnpm"]} storageKey="selected-pkg-manager">
-  <Tab value="npm">
-  ```bash title="Terminal"
-  npm install turbo --save-dev
-  ```
+<PackageManagerTabs>
 
-  </Tab>
-  <Tab value="yarn">
-    ```bash title="Terminal"
-    yarn add turbo --dev --ignore-workspace-root-check
-    ```
-
-  </Tab>
   <Tab value="pnpm">
     ```bash title="Terminal"
     pnpm add turbo --save-dev --ignore-workspace-root-check
     ```
 
   </Tab>
-</Tabs>
+
+  <Tab value="yarn">
+    ```bash title="Terminal"
+    yarn add turbo --dev --ignore-workspace-root-check
+    ```
+
+  </Tab>
+
+  <Tab value="npm">
+  ```bash title="Terminal"
+  npm install turbo --save-dev
+  ```
+
+  </Tab>
+
+  </PackageManagerTabs>
 
 You can continue to use your global installation of `turbo` to run commands. Global `turbo` will defer to the local version of your repository if it exists.
 

--- a/docs/site/content/repo-docs/guides/ci-vendors/circleci.mdx
+++ b/docs/site/content/repo-docs/guides/ci-vendors/circleci.mdx
@@ -50,7 +50,8 @@ And a `turbo.json`:
 Create a file called `.circleci/config.yml` in your repository with the following contents:
 
 <PackageManagerTabs>
-<Tab>
+
+  <Tab value="pnpm">
 
     ```yaml title=".circleci/config.yml"
     version: 2.1
@@ -68,18 +69,21 @@ Create a file called `.circleci/config.yml` in your repository with the followin
           - checkout
           - node/install-packages
           - run:
-            command: npm run build
+            command: npm i -g pnpm
             environment:
               TURBO_UI: "false"
-
           - run:
-            command: npm run test
+            command: pnpm build
+            environment:
+              TURBO_UI: "false"
+          - run:
+            command: pnpm test
             environment:
               TURBO_UI: "false"
     ```
 
   </Tab>
-  <Tab>
+  <Tab value="yarn">
 
     ```yaml title=".circleci/config.yml"
     version: 2.1
@@ -108,7 +112,8 @@ Create a file called `.circleci/config.yml` in your repository with the followin
     ```
 
   </Tab>
-  <Tab>
+
+<Tab value="npm">
 
     ```yaml title=".circleci/config.yml"
     version: 2.1
@@ -126,15 +131,12 @@ Create a file called `.circleci/config.yml` in your repository with the followin
           - checkout
           - node/install-packages
           - run:
-            command: npm i -g pnpm
+            command: npm run build
             environment:
               TURBO_UI: "false"
+
           - run:
-            command: pnpm build
-            environment:
-              TURBO_UI: "false"
-          - run:
-            command: pnpm test
+            command: npm run test
             environment:
               TURBO_UI: "false"
     ```

--- a/docs/site/content/repo-docs/guides/ci-vendors/github-actions.mdx
+++ b/docs/site/content/repo-docs/guides/ci-vendors/github-actions.mdx
@@ -43,96 +43,7 @@ And a `turbo.json`:
 Create a file called `.github/workflows/ci.yml` in your repository with the following contents:
 
 <PackageManagerTabs>
-  <Tab>
-
-    ```yaml title=".github/workflows/ci.yml"
-    name: CI
-
-    on:
-      push:
-        branches: ["main"]
-      pull_request:
-        types: [opened, synchronize]
-
-    jobs:
-      build:
-        name: Build and Test
-        timeout-minutes: 15
-        runs-on: ubuntu-latest
-        # To use Remote Caching, uncomment the next lines and follow the steps below.
-        # env:
-        #  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-        #  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-        #  TURBO_REMOTE_ONLY: true
-
-        steps:
-          - name: Check out code
-            uses: actions/checkout@v4
-            with:
-              fetch-depth: 2
-
-          - name: Setup Node.js environment
-            uses: actions/setup-node@v4
-            with:
-              node-version: 20
-              cache: 'npm'
-
-          - name: Install dependencies
-            run: npm install
-
-          - name: Build
-            run: npm run build
-
-          - name: Test
-            run: npm run test
-    ```
-
-  </Tab>
-  <Tab>
-
-    ```yaml title=".github/workflows/ci.yml"
-    name: CI
-
-    on:
-      push:
-        branches: ["main"]
-      pull_request:
-        types: [opened, synchronize]
-
-    jobs:
-      build:
-        name: Build and Test
-        timeout-minutes: 15
-        runs-on: ubuntu-latest
-        # To use Remote Caching, uncomment the next lines and follow the steps below.
-        # env:
-        #  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-        #  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-
-        steps:
-          - name: Check out code
-            uses: actions/checkout@v4
-            with:
-              fetch-depth: 2
-
-          - name: Setup Node.js environment
-            uses: actions/setup-node@v4
-            with:
-              node-version: 20
-              cache: 'yarn'
-
-          - name: Install dependencies
-            run: yarn
-
-          - name: Build
-            run: yarn build
-
-          - name: Test
-            run: yarn test
-    ```
-
-  </Tab>
-  <Tab>
+  <Tab value="pnpm">
     ```yaml title=".github/workflows/ci.yml"
     name: CI
 
@@ -176,6 +87,96 @@ Create a file called `.github/workflows/ci.yml` in your repository with the foll
 
           - name: Test
             run: pnpm test
+    ```
+
+  </Tab>
+
+  <Tab value="yarn">
+
+    ```yaml title=".github/workflows/ci.yml"
+    name: CI
+
+    on:
+      push:
+        branches: ["main"]
+      pull_request:
+        types: [opened, synchronize]
+
+    jobs:
+      build:
+        name: Build and Test
+        timeout-minutes: 15
+        runs-on: ubuntu-latest
+        # To use Remote Caching, uncomment the next lines and follow the steps below.
+        # env:
+        #  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+        #  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
+        steps:
+          - name: Check out code
+            uses: actions/checkout@v4
+            with:
+              fetch-depth: 2
+
+          - name: Setup Node.js environment
+            uses: actions/setup-node@v4
+            with:
+              node-version: 20
+              cache: 'yarn'
+
+          - name: Install dependencies
+            run: yarn
+
+          - name: Build
+            run: yarn build
+
+          - name: Test
+            run: yarn test
+    ```
+
+  </Tab>
+  <Tab value="npm">
+
+    ```yaml title=".github/workflows/ci.yml"
+    name: CI
+
+    on:
+      push:
+        branches: ["main"]
+      pull_request:
+        types: [opened, synchronize]
+
+    jobs:
+      build:
+        name: Build and Test
+        timeout-minutes: 15
+        runs-on: ubuntu-latest
+        # To use Remote Caching, uncomment the next lines and follow the steps below.
+        # env:
+        #  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+        #  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+        #  TURBO_REMOTE_ONLY: true
+
+        steps:
+          - name: Check out code
+            uses: actions/checkout@v4
+            with:
+              fetch-depth: 2
+
+          - name: Setup Node.js environment
+            uses: actions/setup-node@v4
+            with:
+              node-version: 20
+              cache: 'npm'
+
+          - name: Install dependencies
+            run: npm install
+
+          - name: Build
+            run: npm run build
+
+          - name: Test
+            run: npm run test
     ```
 
   </Tab>

--- a/docs/site/content/repo-docs/guides/ci-vendors/gitlab-ci.mdx
+++ b/docs/site/content/repo-docs/guides/ci-vendors/gitlab-ci.mdx
@@ -42,41 +42,7 @@ And a `turbo.json`:
 Create a file called `.gitlab-ci.yml` in your repository with the following contents:
 
 <PackageManagerTabs>
-<Tab>
-
-        ```yaml title=".gitlab-ci.yml"
-        image: node:latest
-        stages:
-          - build
-        build:
-          stage: build
-          script:
-            - npm install
-            - npm run build
-            - npm run test
-        ```
-
-    </Tab>
-    <Tab>
-
-        ```yaml title=".gitlab-ci.yml"
-        image: node:latest
-        stages:
-          - build
-        build:
-          stage: build
-          script:
-            - yarn install
-            - yarn build
-            - yarn test
-          cache:
-            paths:
-              - node_modules/
-              - .yarn
-        ```
-
-    </Tab>
-    <Tab>
+    <Tab value="pnpm">
 
         ```yaml title=".gitlab-ci.yml"
         image: node:latest
@@ -100,6 +66,42 @@ Create a file called `.gitlab-ci.yml` in your repository with the following cont
         ```
 
         > For more information visit the pnpm documentation section on GitLab CI integration, view it [here](https://pnpm.io/continuous-integration#gitlab)
+    </Tab>
+
+    <Tab value="yarn">
+
+        ```yaml title=".gitlab-ci.yml"
+        image: node:latest
+        stages:
+          - build
+        build:
+          stage: build
+          script:
+            - yarn install
+            - yarn build
+            - yarn test
+          cache:
+            paths:
+              - node_modules/
+              - .yarn
+        ```
+
+    </Tab>
+
+<Tab value="npm">
+
+        ```yaml title=".gitlab-ci.yml"
+        image: node:latest
+        stages:
+          - build
+        build:
+          stage: build
+          script:
+            - npm install
+            - npm run build
+            - npm run test
+        ```
+
     </Tab>
 
 </PackageManagerTabs>

--- a/docs/site/content/repo-docs/guides/ci-vendors/travis-ci.mdx
+++ b/docs/site/content/repo-docs/guides/ci-vendors/travis-ci.mdx
@@ -42,38 +42,7 @@ And a `turbo.json`:
 Create a file called `.travis.yml` in your repository with the following contents:
 
 <PackageManagerTabs>
-<Tab>
-
-    ```yaml title=".travis.yml"
-    language: node_js
-    node_js:
-      - lts/*
-    install:
-      - npm install
-    script:
-      - npm run build
-    script:
-      - npm run test
-    ```
-
-  </Tab>
-    <Tab>
-      Travis CI detects the use of Yarn by the presence of `yarn.lock`. It will automatically ensure it is installed.
-
-      ```yaml title=".travis.yml"
-      language: node_js
-      node_js:
-        - lts/*
-      install:
-        - yarn
-      script:
-        - yarn build
-      script:
-        - yarn test
-      ```
-
-  </Tab>
-    <Tab>
+    <Tab value="pnpm">
 
       ```yaml title=".travis.yml"
       language: node_js
@@ -95,6 +64,38 @@ Create a file called `.travis.yml` in your repository with the following content
       ```
 
       > For more information visit the pnpm documentation section on Travis CI integration, view it [here](https://pnpm.io/continuous-integration#travis)
+
+  </Tab>
+    <Tab value="yarn">
+      Travis CI detects the use of Yarn by the presence of `yarn.lock`. It will automatically ensure it is installed.
+
+      ```yaml title=".travis.yml"
+      language: node_js
+      node_js:
+        - lts/*
+      install:
+        - yarn
+      script:
+        - yarn build
+      script:
+        - yarn test
+      ```
+
+  </Tab>
+
+<Tab value="npm">
+
+    ```yaml title=".travis.yml"
+    language: node_js
+    node_js:
+      - lts/*
+    install:
+      - npm install
+    script:
+      - npm run build
+    script:
+      - npm run test
+    ```
 
   </Tab>
 </PackageManagerTabs>

--- a/docs/site/content/repo-docs/guides/frameworks/nextjs.mdx
+++ b/docs/site/content/repo-docs/guides/frameworks/nextjs.mdx
@@ -13,15 +13,16 @@ import { Callout } from '#/components/callout';
 To get started with Next.js in a Turborepo quickly, follow the [quickstart](/docs/getting-started/installation) to create a repository with two Next.js applications:
 
 <PackageManagerTabs>
-<Tab>
+
+<Tab value="pnpm">
 
 ```bash title="Terminal"
-npx create-turbo@latest
+pnpm dlx create-turbo@latest
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 
 ```bash title="Terminal"
 yarn dlx create-turbo@latest
@@ -29,10 +30,10 @@ yarn dlx create-turbo@latest
 
 </Tab>
 
-<Tab>
+<Tab value="npm">
 
 ```bash title="Terminal"
-pnpm dlx create-turbo@latest
+npx create-turbo@latest
 ```
 
 </Tab>
@@ -43,15 +44,16 @@ pnpm dlx create-turbo@latest
 Use [`create-next-app`](https://nextjs.org/docs/app/api-reference/create-next-app) to set up a new Next.js application in a package. From the root of your repository, run:
 
 <PackageManagerTabs>
-<Tab>
+
+<Tab value="pnpm">
 
 ```bash title="Terminal"
-npx create-next-app@latest apps/my-app
+pnpm dlx create-next-app@latest apps/my-app
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 
 ```bash title="Terminal"
 yarn dlx create-next-app@latest apps/my-app
@@ -59,10 +61,10 @@ yarn dlx create-next-app@latest apps/my-app
 
 </Tab>
 
-<Tab>
+<Tab value="npm">
 
 ```bash title="Terminal"
-pnpm dlx create-next-app@latest apps/my-app
+npx create-next-app@latest apps/my-app
 ```
 
 </Tab>
@@ -73,39 +75,40 @@ pnpm dlx create-next-app@latest apps/my-app
 To add [Internal Packages](/docs/core-concepts/internal-packages) to your new application, install them into the app with your package manager:
 
 <PackageManagerTabs>
-<Tab>
 
-```diff title="./apps/my-app/package.json"
-{
- "name": "my-app",
-  "dependencies": {
-+   "@repo/ui": "*"
-  }
-}
-```
-
-</Tab>
-
-<Tab>
-
-```diff title="./apps/my-app/package.json"
-{
-  "name": "my-app",
-  "dependencies": {
-+   "@repo/ui": "*"
-  }
-}
-```
-
-</Tab>
-
-<Tab>
+<Tab value="pnpm">
 
 ```diff title="./apps/my-app/package.json"
 {
   "name": "my-app",
   "dependencies": {
 +   "@repo/ui": "workspace:*"
+  }
+}
+```
+
+</Tab>
+
+<Tab value="yarn">
+
+```diff title="./apps/my-app/package.json"
+{
+  "name": "my-app",
+  "dependencies": {
++   "@repo/ui": "*"
+  }
+}
+```
+
+</Tab>
+
+<Tab value="npm">
+
+```diff title="./apps/my-app/package.json"
+{
+ "name": "my-app",
+  "dependencies": {
++   "@repo/ui": "*"
   }
 }
 ```

--- a/docs/site/content/repo-docs/guides/frameworks/nuxt.mdx
+++ b/docs/site/content/repo-docs/guides/frameworks/nuxt.mdx
@@ -13,15 +13,16 @@ import { Callout } from '#/components/callout';
 To get started with Nuxt in a Turborepo quickly, use [the `with-vue-nuxt` example](https://github.com/vercel/turborepo/tree/main/examples/with-vue-nuxt):
 
 <PackageManagerTabs>
-<Tab>
+
+<Tab value="pnpm">
 
 ```bash title="Terminal"
-npx create-turbo@latest -e with-vue-nuxt
+pnpm dlx create-turbo@latest -e with-vue-nuxt
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 
 ```bash title="Terminal"
 yarn dlx create-turbo@latest -e with-vue-nuxt
@@ -29,10 +30,10 @@ yarn dlx create-turbo@latest -e with-vue-nuxt
 
 </Tab>
 
-<Tab>
+<Tab value="npm">
 
 ```bash title="Terminal"
-pnpm dlx create-turbo@latest -e with-vue-nuxt
+npx create-turbo@latest -e with-vue-nuxt
 ```
 
 </Tab>
@@ -43,15 +44,16 @@ pnpm dlx create-turbo@latest -e with-vue-nuxt
 Use [Nuxi](https://www.npmjs.com/package/nuxi), Nuxt's CLI, to set up a new Nuxt application in a package. From the root of your repository, run:
 
 <PackageManagerTabs>
-<Tab>
+
+<Tab value="pnpm">
 
 ```bash title="Terminal"
-npx nuxi@latest init apps/my-app
+pnpm dlx nuxi@latest init apps/my-app
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 
 ```bash title="Terminal"
 yarn dlx nuxi@latest init apps/my-app
@@ -59,10 +61,10 @@ yarn dlx nuxi@latest init apps/my-app
 
 </Tab>
 
-<Tab>
+<Tab value="npm">
 
 ```bash title="Terminal"
-pnpm dlx nuxi@latest init apps/my-app
+npx nuxi@latest init apps/my-app
 ```
 
 </Tab>
@@ -73,39 +75,40 @@ pnpm dlx nuxi@latest init apps/my-app
 To add [Internal Packages](/docs/core-concepts/internal-packages) to your new application, install them into the app with your package manager:
 
 <PackageManagerTabs>
-<Tab>
 
-```diff title="./apps/my-app/package.json"
-{
- "name": "my-app",
-  "dependencies": {
-+   "@repo/ui": "*"
-  }
-}
-```
-
-</Tab>
-
-<Tab>
-
-```diff title="./apps/my-app/package.json"
-{
-  "name": "my-app",
-  "dependencies": {
-+   "@repo/ui": "*"
-  }
-}
-```
-
-</Tab>
-
-<Tab>
+<Tab value="pnpm">
 
 ```diff title="./apps/my-app/package.json"
 {
   "name": "my-app",
   "dependencies": {
 +   "@repo/ui": "workspace:*"
+  }
+}
+```
+
+</Tab>
+
+<Tab value="yarn">
+
+```diff title="./apps/my-app/package.json"
+{
+  "name": "my-app",
+  "dependencies": {
++   "@repo/ui": "*"
+  }
+}
+```
+
+</Tab>
+
+<Tab value="npm">
+
+```diff title="./apps/my-app/package.json"
+{
+ "name": "my-app",
+  "dependencies": {
++   "@repo/ui": "*"
   }
 }
 ```

--- a/docs/site/content/repo-docs/guides/frameworks/sveltekit.mdx
+++ b/docs/site/content/repo-docs/guides/frameworks/sveltekit.mdx
@@ -13,15 +13,16 @@ import { Callout } from '#/components/callout';
 To get started with SvelteKit in a Turborepo quickly, use [the `with-svelte` example](https://github.com/vercel/turborepo/tree/main/examples/with-svelte):
 
 <PackageManagerTabs>
-<Tab>
+
+<Tab value="pnpm">
 
 ```bash title="Terminal"
-npx create-turbo@latest -e with-svelte
+pnpm dlx create-turbo@latest -e with-svelte
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 
 ```bash title="Terminal"
 yarn dlx create-turbo@latest -e with-svelte
@@ -29,10 +30,10 @@ yarn dlx create-turbo@latest -e with-svelte
 
 </Tab>
 
-<Tab>
+<Tab value="npm">
 
 ```bash title="Terminal"
-pnpm dlx create-turbo@latest -e with-svelte
+npx create-turbo@latest -e with-svelte
 ```
 
 </Tab>
@@ -43,15 +44,16 @@ pnpm dlx create-turbo@latest -e with-svelte
 Use [`npm create svelte`](https://kit.svelte.dev/docs/creating-a-project) to set up a new SvelteKit application in a package. From the root of your repository, run:
 
 <PackageManagerTabs>
-<Tab>
+
+<Tab value="pnpm">
 
 ```bash title="Terminal"
-npm create svelte@latest apps/my-app
+pnpm create svelte@latest apps/my-app
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 
 ```bash title="Terminal"
 yarn create svelte@latest apps/my-app
@@ -59,10 +61,10 @@ yarn create svelte@latest apps/my-app
 
 </Tab>
 
-<Tab>
+<Tab value="npm">
 
 ```bash title="Terminal"
-pnpm create svelte@latest apps/my-app
+npm create svelte@latest apps/my-app
 ```
 
 </Tab>
@@ -73,39 +75,40 @@ pnpm create svelte@latest apps/my-app
 To add [Internal Packages](/docs/core-concepts/internal-packages) to your new application, install them into the app with your package manager:
 
 <PackageManagerTabs>
-<Tab>
 
-```diff title="./apps/my-app/package.json"
-{
- "name": "my-app",
-  "dependencies": {
-+   "@repo/ui": "*"
-  }
-}
-```
-
-</Tab>
-
-<Tab>
-
-```diff title="./apps/my-app/package.json"
-{
-  "name": "my-app",
-  "dependencies": {
-+   "@repo/ui": "*"
-  }
-}
-```
-
-</Tab>
-
-<Tab>
+<Tab value="pnpm">
 
 ```diff title="./apps/my-app/package.json"
 {
   "name": "my-app",
   "dependencies": {
 +   "@repo/ui": "workspace:*"
+  }
+}
+```
+
+</Tab>
+
+<Tab value="yarn">
+
+```diff title="./apps/my-app/package.json"
+{
+  "name": "my-app",
+  "dependencies": {
++   "@repo/ui": "*"
+  }
+}
+```
+
+</Tab>
+
+<Tab value="npm">
+
+```diff title="./apps/my-app/package.json"
+{
+ "name": "my-app",
+  "dependencies": {
++   "@repo/ui": "*"
   }
 }
 ```

--- a/docs/site/content/repo-docs/guides/frameworks/vite.mdx
+++ b/docs/site/content/repo-docs/guides/frameworks/vite.mdx
@@ -13,15 +13,16 @@ import { Callout } from '#/components/callout';
 To get started with Vite in a Turborepo quickly, use [the `with-vite` example](https://github.com/vercel/turborepo/tree/main/examples/with-vite):
 
 <PackageManagerTabs>
-<Tab>
+
+<Tab value="pnpm">
 
 ```bash title="Terminal"
-npx create-turbo@latest -e with-vite
+pnpm dlx create-turbo@latest -e with-vite
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 
 ```bash title="Terminal"
 yarn dlx create-turbo@latest -e with-vite
@@ -29,10 +30,10 @@ yarn dlx create-turbo@latest -e with-vite
 
 </Tab>
 
-<Tab>
+<Tab value="npm">
 
 ```bash title="Terminal"
-pnpm dlx create-turbo@latest -e with-vite
+npx create-turbo@latest -e with-vite
 ```
 
 </Tab>
@@ -43,15 +44,16 @@ pnpm dlx create-turbo@latest -e with-vite
 Use [`npm create vite`](https://vitejs.dev/guide/#scaffolding-your-first-vite-project) to set up a new Vite application in a package. From the root of your repository, run:
 
 <PackageManagerTabs>
-<Tab>
+
+<Tab value="pnpm">
 
 ```bash title="Terminal"
-npm create vite@latest apps/my-app
+pnpm create vite@latest apps/my-app
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 
 ```bash title="Terminal"
 yarn create vite@latest apps/my-app
@@ -59,10 +61,10 @@ yarn create vite@latest apps/my-app
 
 </Tab>
 
-<Tab>
+<Tab value="npm">
 
 ```bash title="Terminal"
-pnpm create vite@latest apps/my-app
+npm create vite@latest apps/my-app
 ```
 
 </Tab>
@@ -73,39 +75,40 @@ pnpm create vite@latest apps/my-app
 To add [Internal Packages](/docs/core-concepts/internal-packages) to your new application, install them into the app with your package manager:
 
 <PackageManagerTabs>
-<Tab>
 
-```diff title="./apps/my-app/package.json"
-{
- "name": "my-app",
-  "dependencies": {
-+   "@repo/ui": "*"
-  }
-}
-```
-
-</Tab>
-
-<Tab>
-
-```diff title="./apps/my-app/package.json"
-{
-  "name": "my-app",
-  "dependencies": {
-+   "@repo/ui": "*"
-  }
-}
-```
-
-</Tab>
-
-<Tab>
+<Tab value="pnpm">
 
 ```diff title="./apps/my-app/package.json"
 {
   "name": "my-app",
   "dependencies": {
 +   "@repo/ui": "workspace:*"
+  }
+}
+```
+
+</Tab>
+
+<Tab value="yarn">
+
+```diff title="./apps/my-app/package.json"
+{
+  "name": "my-app",
+  "dependencies": {
++   "@repo/ui": "*"
+  }
+}
+```
+
+</Tab>
+
+<Tab value="npm">
+
+```diff title="./apps/my-app/package.json"
+{
+ "name": "my-app",
+  "dependencies": {
++   "@repo/ui": "*"
   }
 }
 ```

--- a/docs/site/content/repo-docs/guides/generating-code.mdx
+++ b/docs/site/content/repo-docs/guides/generating-code.mdx
@@ -90,46 +90,47 @@ manually at `turbo/generators/config.ts` (or `config.js`) at the root of your re
 For example, the following illustrates a monorepo with three locations for generators:
 
 <PackageManagerTabs>
-<Tab>
-<Files>
-  <Folder name="apps" defaultOpen>
-    <Folder name="docs">
-     <File name="package.json"  />
+
+<Tab value="pnpm">
+  <Files>
+    <Folder name="apps" defaultOpen>
+      <Folder name="docs">
+        <File name="package.json" />
+      </Folder>
+      <Folder name="web" defaultOpen>
+        <File name="package.json" />
+        <Folder name="turbo" green defaultOpen>
+          <Folder name="generators">
+            <File name="config.ts" />
+            <File name="templates" />
+          </Folder>
+        </Folder>
+      </Folder>
     </Folder>
-    <Folder name="web" defaultOpen>
-      <File name="package.json"  />
-  <Folder name="turbo" green defaultOpen>
-    <Folder name="generators">
-      <File name="config.ts" />
-      <File name="templates" />
+    <Folder name="packages" defaultOpen>
+      <Folder name="ui" defaultOpen>
+        <File name="package.json" />
+        <Folder name="turbo" green defaultOpen>
+          <Folder name="generators">
+            <File name="config.ts" />
+            <File name="templates" />
+          </Folder>
+        </Folder>
+      </Folder>
     </Folder>
-  </Folder>
-  </Folder>
-  </Folder>
-  <Folder name="packages" defaultOpen>
-    <Folder name="ui" defaultOpen>
-      <File name="package.json" />
-  <Folder name="turbo" green defaultOpen>
-    <Folder name="generators">
-      <File name="config.ts" />
-      <File name="templates" />
+    <Folder name="turbo" green defaultOpen>
+      <Folder name="generators">
+        <File name="config.ts" />
+        <File name="templates" />
+      </Folder>
     </Folder>
-  </Folder>
-    </Folder>
-  </Folder>
-  <Folder name="turbo" green defaultOpen>
-    <Folder name="generators">
-      <File name="config.ts" />
-      <File name="templates" />
-    </Folder>
-  </Folder>
-  <File name="package.json"  />
-  <File name="package-lock.json"  />
-  <File name="turbo.json"  />
-</Files>
+    <File name="package.json" />
+    <File name="package-lock.yaml" />
+    <File name="turbo.json" />
+  </Files>
 </Tab>
 
-<Tab>
+<Tab value="yarn">
   <Files>
     <Folder name="apps" defaultOpen>
       <Folder name="docs">
@@ -168,7 +169,7 @@ For example, the following illustrates a monorepo with three locations for gener
   </Files>
 </Tab>
 
-<Tab>
+<Tab value="npm">
 <Files>
   <Folder name="apps" defaultOpen>
     <Folder name="docs">
@@ -202,7 +203,7 @@ For example, the following illustrates a monorepo with three locations for gener
     </Folder>
   </Folder>
   <File name="package.json"  />
-  <File name="package-lock.yaml"  />
+  <File name="package-lock.json"  />
   <File name="turbo.json"  />
 </Files>
 </Tab>

--- a/docs/site/content/repo-docs/guides/migrating-from-nx.mdx
+++ b/docs/site/content/repo-docs/guides/migrating-from-nx.mdx
@@ -169,31 +169,31 @@ Turborepo is built on top of package manager workspaces, a JavaScript ecosystem 
 
 <PackageManagerTabs>
 
-<Tab>
-
-```json title="package.json"
-{
-  "workspaces": ["apps/*"]
-}
-```
-
-</Tab>
-
-<Tab>
-
-```json title="package.json"
-{
-  "workspaces": ["apps/*"]
-}
-```
-
-</Tab>
-
-<Tab>
+<Tab value="pnpm">
 
 ```yml title="pnpm-workspace.yaml"
 packages:
   - apps/*
+```
+
+</Tab>
+
+<Tab value="yarn">
+
+```json title="package.json"
+{
+  "workspaces": ["apps/*"]
+}
+```
+
+</Tab>
+
+<Tab value="npm">
+
+```json title="package.json"
+{
+  "workspaces": ["apps/*"]
+}
 ```
 
 </Tab>
@@ -233,17 +233,17 @@ The root package.json needs to have the `packageManager` field. This ensures dev
 
 <PackageManagerTabs>
 
-<Tab>
+<Tab value="pnpm">
 
 ```json title="./package.json"
 {
-  "packageManager": "npm@10.0.0"
+  "packageManager": "pnpm@9.0.0"
 }
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 
 ```json title="./package.json"
 {
@@ -253,11 +253,11 @@ The root package.json needs to have the `packageManager` field. This ensures dev
 
 </Tab>
 
-<Tab>
+<Tab value="npm">
 
 ```json title="./package.json"
 {
-  "packageManager": "pnpm@9.0.0"
+  "packageManager": "npm@10.0.0"
 }
 ```
 
@@ -271,15 +271,15 @@ Update your lockfile by running your installation command.
 
 <PackageManagerTabs>
 
-<Tab>
+<Tab value="pnpm">
 
 ```bash title="Terminal"
-npm install
+pnpm install
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 
 ```bash title="Terminal"
 yarn install
@@ -287,10 +287,10 @@ yarn install
 
 </Tab>
 
-<Tab>
+<Tab value="npm">
 
 ```bash title="Terminal"
-pnpm install
+npm install
 ```
 
 </Tab>
@@ -305,15 +305,15 @@ Add Turborepo to the root `package.json` of the workspace.
 
 <PackageManagerTabs>
 
-<Tab>
+<Tab value="pnpm">
 
 ```bash title="Terminal"
-npm install turbo --save-dev
+pnpm install turbo --save-dev --workspace-root
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 
 ```bash title="Terminal"
  yarn add turbo --save-dev --ignore-workspace-root-check
@@ -321,10 +321,10 @@ npm install turbo --save-dev
 
 </Tab>
 
-<Tab>
+<Tab value="npm">
 
 ```bash title="Terminal"
-pnpm install turbo --save-dev --workspace-root
+npm install turbo --save-dev
 ```
 
 </Tab>
@@ -335,15 +335,15 @@ You can also optionally install `turbo` globally for added convenience when work
 
 <PackageManagerTabs>
 
-<Tab>
+<Tab value="pnpm">
 
 ```bash title="Terminal"
-npm install turbo --global
+pnpm install turbo --global
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 
 ```bash title="Terminal"
 yarn global add turbo
@@ -351,10 +351,10 @@ yarn global add turbo
 
 </Tab>
 
-<Tab>
+<Tab value="npm">
 
 ```bash title="Terminal"
-pnpm install turbo --global
+npm install turbo --global
 ```
 
 </Tab>
@@ -386,15 +386,15 @@ Build the application with Turborepo. Using global `turbo`, this would be `turbo
 
 <PackageManagerTabs>
 
-<Tab>
+<Tab value="pnpm">
 
 ```bash title="Terminal"
-npx turbo run build
+pnpm exec turbo build
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 
 ```bash title="Terminal"
  yarn dlx turbo build
@@ -402,10 +402,10 @@ npx turbo run build
 
 </Tab>
 
-<Tab>
+<Tab value="npm">
 
 ```bash title="Terminal"
-pnpm exec turbo build
+npx turbo run build
 ```
 
 </Tab>

--- a/docs/site/content/repo-docs/guides/multi-language.mdx
+++ b/docs/site/content/repo-docs/guides/multi-language.mdx
@@ -11,20 +11,19 @@ Turborepo is built on the conventions of the JavaScript ecosystem to find script
 As an example, you may have a Rust project in the `./cli` directory in your repository. To add this directory as a package to your JavaScript package manager's workspace, add the directory to the workspace definition:
 
 <PackageManagerTabs>
-  <Tab>
-  ```json title="./package.json"
-  {
-    "workspaces": [
-      "apps/*"
-      "packages/*",
-      "cli" // [!code highlight]
-    ]
-  }
-  ```
 
-  <LinkToDocumentation href="https://docs.npmjs.com/cli/v7/using-npm/workspaces#defining-workspaces">npm workspace documentation</LinkToDocumentation>
+  <Tab value="pnpm">
+  ```json title="pnpm-workspace.yaml"
+ packages:
+    - "apps/*"
+    - "packages/*"
+    - "cli" // [!code highlight]
+  ```
+  <LinkToDocumentation href="https://pnpm.io/pnpm-workspace_yaml">pnpm workspace documentation</LinkToDocumentation>
+
   </Tab>
-  <Tab >
+
+  <Tab value="yarn">
   ```json title="./package.json"
   {
     "workspaces": [
@@ -37,15 +36,19 @@ As an example, you may have a Rust project in the `./cli` directory in your repo
 
   <LinkToDocumentation href="https://yarnpkg.com/features/workspaces#how-are-workspaces-declared">yarn workspace documentation</LinkToDocumentation>
    </Tab>
-  <Tab>
-  ```json title="pnpm-workspace.yaml"
- packages:
-    - "apps/*"
-    - "packages/*"
-    - "cli" // [!code highlight]
-  ```
-  <LinkToDocumentation href="https://pnpm.io/pnpm-workspace_yaml">pnpm workspace documentation</LinkToDocumentation>
 
+  <Tab value="npm">
+  ```json title="./package.json"
+  {
+    "workspaces": [
+      "apps/*"
+      "packages/*",
+      "cli" // [!code highlight]
+    ]
+  }
+  ```
+
+  <LinkToDocumentation href="https://docs.npmjs.com/cli/v7/using-npm/workspaces#defining-workspaces">npm workspace documentation</LinkToDocumentation>
   </Tab>
 </PackageManagerTabs>
 
@@ -83,34 +86,36 @@ Because the directory is now a part of the package manager's workspace, you can 
 For instance, if you wanted to make sure that the `rust-cli` "package" from above is built before your `web` application, install it into the dependencies for the `web` application:
 
 <PackageManagerTabs>
-  <Tab>
-
-```diff title="./web/package.json"
-{
-  "devDependencies": {
-+   "@repo/rust-cli": "*"
-  }
-}
-```
-
-  </Tab>
-  <Tab>
-
-```diff title="./web/package.json"
-{
-  "devDependencies": {
-+   "@repo/rust-cli": "*"
-  }
-}
-```
-
-  </Tab>
-  <Tab>
+  <Tab value="pnpm">
 
 ```diff title="./web/package.json"
 {
   "devDependencies": {
 +   "@repo/rust-cli": "workspace:*"
+  }
+}
+```
+
+  </Tab>
+
+  <Tab value="yarn">
+
+```diff title="./web/package.json"
+{
+  "devDependencies": {
++   "@repo/rust-cli": "*"
+  }
+}
+```
+
+  </Tab>
+
+  <Tab value="npm">
+
+```diff title="./web/package.json"
+{
+  "devDependencies": {
++   "@repo/rust-cli": "*"
   }
 }
 ```

--- a/docs/site/content/repo-docs/guides/single-package-workspaces.mdx
+++ b/docs/site/content/repo-docs/guides/single-package-workspaces.mdx
@@ -20,22 +20,25 @@ Turborepo's most important features work in single-package workspaces including 
 Install `turbo` into your application:
 
 <PackageManagerTabs>
-  <Tab>
-  ```bash title="Terminal"
-  npm install turbo --save-dev
-  ```
+
+  <Tab value="pnpm">
+    ```bash title="Terminal"
+    pnpm install turbo --save-dev
+    ```
 
   </Tab>
-  <Tab>
+
+  <Tab value="yarn">
     ```bash title="Terminal"
     yarn add turbo --dev
     ```
 
   </Tab>
-  <Tab>
-    ```bash title="Terminal"
-    pnpm install turbo --save-dev
-    ```
+
+  <Tab value="npm">
+  ```bash title="Terminal"
+  npm install turbo --save-dev
+  ```
 
   </Tab>
 </PackageManagerTabs>

--- a/docs/site/content/repo-docs/guides/tools/eslint.mdx
+++ b/docs/site/content/repo-docs/guides/tools/eslint.mdx
@@ -71,29 +71,32 @@ Notably, the `next.js` and `react-internal.js` configurations use the `base.js` 
 In our `web` app, we first need to add `@repo/eslint-config` as a dependency.
 
 <PackageManagerTabs>
-  <Tab>
-```jsonc title="./apps/web/package.json"
-{
-  "devDependencies": {
-    "@repo/eslint-config": "*"
-  }
-}
-```
-  </Tab>
-  <Tab>
-```jsonc title="./apps/web/package.json"
-{
-  "devDependencies": {
-    "@repo/eslint-config": "*"
-  }
-}
-```
-  </Tab>
-  <Tab>
+
+  <Tab value="pnpm">
 ```jsonc title="./apps/web/package.json"
 {
   "devDependencies": {
     "@repo/eslint-config": "workspace:*"
+  }
+}
+```
+  </Tab>
+
+  <Tab value="yarn">
+```jsonc title="./apps/web/package.json"
+{
+  "devDependencies": {
+    "@repo/eslint-config": "*"
+  }
+}
+```
+  </Tab>
+
+  <Tab value="npm">
+```jsonc title="./apps/web/package.json"
+{
+  "devDependencies": {
+    "@repo/eslint-config": "*"
   }
 }
 ```
@@ -203,29 +206,31 @@ Note that the ESLint dependencies are all listed here. This is useful, since it 
 In our `web` app, we first need to add `@repo/eslint-config` as a dependency.
 
 <PackageManagerTabs>
-  <Tab>
-```jsonc title="./apps/web/package.json"
-{
-  "dependencies": {
-    "@repo/eslint-config": "*"
-  }
-}
-```
-  </Tab>
-  <Tab>
-```jsonc title="./apps/web/package.json"
-{
-  "dependencies": {
-    "@repo/eslint-config": "*"
-  }
-}
-```
-  </Tab>
-  <Tab>
+
+  <Tab value="pnpm">
 ```jsonc title="./apps/web/package.json"
 {
   "dependencies": {
     "@repo/eslint-config": "workspace:*"
+  }
+}
+```
+  </Tab>
+  <Tab value="yarn">
+```jsonc title="./apps/web/package.json"
+{
+  "dependencies": {
+    "@repo/eslint-config": "*"
+  }
+}
+```
+  </Tab>
+
+  <Tab value="npm">
+```jsonc title="./apps/web/package.json"
+{
+  "dependencies": {
+    "@repo/eslint-config": "*"
   }
 }
 ```

--- a/docs/site/content/repo-docs/guides/tools/jest.mdx
+++ b/docs/site/content/repo-docs/guides/tools/jest.mdx
@@ -32,15 +32,16 @@ Let's say we have a monorepo that looks like this:
 Install `jest` into the packages where you plan on having test suites. For this example, we will have tests in `web` and `@repo/ui`:
 
 <PackageManagerTabs>
-<Tab>
+
+<Tab value="pnpm">
 
 ```bash title="Terminal"
-npm install jest --workspace=web --workspace=@repo/ui --save-dev
+pnpm install jest --save-dev --filter=@repo/ui --filter=web
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 
 ```bash title="Terminal"
 yarn workspace web add jest --dev
@@ -49,10 +50,10 @@ yarn workspace @repo/ui add jest --dev
 
 </Tab>
 
-<Tab>
+<Tab value="npm">
 
 ```bash title="Terminal"
-pnpm install jest --save-dev --filter=@repo/ui --filter=web
+npm install jest --workspace=web --workspace=@repo/ui --save-dev
 ```
 
 </Tab>

--- a/docs/site/content/repo-docs/guides/tools/playwright.mdx
+++ b/docs/site/content/repo-docs/guides/tools/playwright.mdx
@@ -99,19 +99,18 @@ You can also create a common package for shared utilities that you need in your 
 
 <PackageManagerTabs>
 
-<Tab>
+<Tab value="pnpm">
 ```json title="./packages/playwright-utilities/package.json"
 {
- "name": "@repo/playwright-utilities",
- "peerDependencies": {
-   "playwright": "*"
+  "name": "@repo/playwright-utilities",
+  "peerDependencies": {
+    "playwright": "workspace:*"
 }
 }
 ```
-
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 ```json title="./packages/playwright-utilities/package.json"
 {
   "name": "@repo/playwright-utilities",
@@ -122,15 +121,16 @@ You can also create a common package for shared utilities that you need in your 
 ```
 </Tab>
 
-<Tab>
+<Tab value="npm">
 ```json title="./packages/playwright-utilities/package.json"
 {
-  "name": "@repo/playwright-utilities",
-  "peerDependencies": {
-    "playwright": "workspace:*"
+ "name": "@repo/playwright-utilities",
+ "peerDependencies": {
+   "playwright": "*"
 }
 }
 ```
+
 </Tab>
 
 </PackageManagerTabs>

--- a/docs/site/content/repo-docs/guides/tools/shadcn-ui.mdx
+++ b/docs/site/content/repo-docs/guides/tools/shadcn-ui.mdx
@@ -10,26 +10,27 @@ import { PackageManagerTabs, Tab } from '#/components/tabs';
 To get started with shadcn/ui in a new monorepo, run:
 
 <PackageManagerTabs>
-<Tab>
 
-```bash title="Terminal"
-npx shadcn@canary init
-```
-
-</Tab>
-
-<Tab>
-
-```bash title="Terminal"
-npx shadcn@canary init
-```
-
-</Tab>
-
-<Tab>
+<Tab value="pnpm">
 
 ```bash title="Terminal"
 pnpm dlx shadcn@canary init
+```
+
+</Tab>
+
+<Tab value="yarn">
+
+```bash title="Terminal"
+npx shadcn@canary init
+```
+
+</Tab>
+
+<Tab value="npm">
+
+```bash title="Terminal"
+npx shadcn@canary init
 ```
 
 </Tab>
@@ -40,26 +41,27 @@ When prompted, select the option for monorepos.
 To add a component, run:
 
 <PackageManagerTabs>
-<Tab>
 
-```bash title="Terminal"
-npx shadcn@canary add [COMPONENT]
-```
-
-</Tab>
-
-<Tab>
-
-```bash title="Terminal"
-npx shadcn@canary add [COMPONENT]
-```
-
-</Tab>
-
-<Tab>
+<Tab value="pnpm">
 
 ```bash title="Terminal"
 pnpm dlx shadcn@canary add [COMPONENT]
+```
+
+</Tab>
+
+<Tab value="yarn">
+
+```bash title="Terminal"
+npx shadcn@canary add [COMPONENT]
+```
+
+</Tab>
+
+<Tab value="npm">
+
+```bash title="Terminal"
+npx shadcn@canary add [COMPONENT]
 ```
 
 </Tab>

--- a/docs/site/content/repo-docs/guides/tools/storybook.mdx
+++ b/docs/site/content/repo-docs/guides/tools/storybook.mdx
@@ -14,15 +14,16 @@ import { Steps, Step } from '#/components/steps';
 If you'd rather use a template, this guide is walking through how to build [this Storybook/Turborepo template](https://vercel.com/templates/react/turborepo-design-system) on Vercel.
 
 <PackageManagerTabs>
-<Tab>
+
+<Tab value="pnpm">
 
 ```bash title="Terminal"
-npx create-turbo@latest -e design-system
+pnpm dlx create-turbo@latest -e design-system
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 
 ```bash title="Terminal"
 yarn dlx create-turbo@latest -e design-system
@@ -30,10 +31,10 @@ yarn dlx create-turbo@latest -e design-system
 
 </Tab>
 
-<Tab>
+<Tab value="npm">
 
 ```bash title="Terminal"
-pnpm dlx create-turbo@latest -e design-system
+npx create-turbo@latest -e design-system
 ```
 
 </Tab>
@@ -49,15 +50,16 @@ pnpm dlx create-turbo@latest -e design-system
 If you don't have an existing project, use [create-turbo](/docs/getting-started/installation) to create a new monorepo:
 
 <PackageManagerTabs>
-<Tab>
+
+<Tab value="pnpm">
 
 ```bash title="Terminal"
-npx create-turbo@latest
+pnpm dlx create-turbo@latest
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 
 ```bash title="Terminal"
 yarn dlx create-turbo@latest
@@ -65,10 +67,10 @@ yarn dlx create-turbo@latest
 
 </Tab>
 
-<Tab>
+<Tab value="npm">
 
 ```bash title="Terminal"
-pnpm dlx create-turbo@latest
+npx create-turbo@latest
 ```
 
 </Tab>
@@ -94,24 +96,26 @@ cd apps/storybook
 In the `apps/storybook` directory, initialize a new Storybook application:
 
 <PackageManagerTabs>
-  <Tab>
+
+  <Tab value="pnpm">
 
 ```bash title="Terminal"
-npm create storybook@latest
+pnpm create storybook@latest
 ```
 
   </Tab>
-  <Tab>
+  <Tab value="yarn">
 
 ```bash title="Terminal"
 yarn create storybook@latest
 ```
 
   </Tab>
-  <Tab>
+
+  <Tab value="npm">
 
 ```bash title="Terminal"
-pnpm create storybook@latest
+npm create storybook@latest
 ```
 
   </Tab>
@@ -132,15 +136,16 @@ Follow the prompts to create an application. For the rest of this guide, we'll a
 Now, install your UI package into Storybook.
 
 <PackageManagerTabs>
-<Tab>
+
+<Tab value="pnpm">
 
 ```bash title="Terminal"
-npm install @repo/ui --workspace=storybook
+pnpm install @repo/ui --filter=storybook
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 
 ```bash title="Terminal"
 yarn workspace storybook add @repo/ui
@@ -148,10 +153,10 @@ yarn workspace storybook add @repo/ui
 
 </Tab>
 
-<Tab>
+<Tab value="npm">
 
 ```bash title="Terminal"
-pnpm install @repo/ui --filter=storybook
+npm install @repo/ui --workspace=storybook
 ```
 
 </Tab>
@@ -289,15 +294,16 @@ Update components imports so that they reference the now co-located modules. For
 You'll also need to install any Storybook packages required for writing stories. For example, moving the story from above would require that you install `@storybook/react` into your `@repo/ui` package.
 
 <PackageManagerTabs>
-<Tab>
+
+<Tab value="pnpm">
 
 ```bash title="Terminal"
-npm install @storybook/react --workspace=@repo/ui --save-dev
+pnpm install @storybook/react --filter=@repo/ui --save-dev
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 
 ```bash title="Terminal"
 yarn workspace @repo/ui add @storybook/react --dev
@@ -305,10 +311,10 @@ yarn workspace @repo/ui add @storybook/react --dev
 
 </Tab>
 
-<Tab>
+<Tab value="npm">
 
 ```bash title="Terminal"
-pnpm install @storybook/react --filter=@repo/ui --save-dev
+npm install @storybook/react --workspace=@repo/ui --save-dev
 ```
 
 </Tab>

--- a/docs/site/content/repo-docs/guides/tools/typescript.mdx
+++ b/docs/site/content/repo-docs/guides/tools/typescript.mdx
@@ -29,15 +29,16 @@ TypeScript's `tsconfig.json` sets the configuration for the TypeScript compiler 
 This guide will use [`create-turbo`](/docs/reference/create-turbo) as an example.
 
 <PackageManagerTabs>
-<Tab>
+
+<Tab value="pnpm">
 
 ```bash title="Terminal"
-npx create-turbo@latest
+pnpm dlx create-turbo@latest
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 
 ```bash title="Terminal"
 yarn dlx create-turbo@latest
@@ -45,10 +46,10 @@ yarn dlx create-turbo@latest
 
 </Tab>
 
-<Tab>
+<Tab value="npm">
 
 ```bash title="Terminal"
-pnpm dlx create-turbo@latest
+npx create-turbo@latest
 ```
 
 </Tab>
@@ -98,31 +99,34 @@ Inside `package.json`, name the package so it can be referenced in the rest of t
 First, install the `@repo/typescript-config` package into your package:
 
 <PackageManagerTabs>
-<Tab>
-```json title="./apps/web/package.json"
-{
-  "devDependencies": {
-     "@repo/typescript-config": "*",
-     "typescript": "latest",
-  }
-}
-```
-</Tab>
-<Tab>
-```json title="./apps/web/package.json"
-{
-  "devDependencies": {
-     "@repo/typescript-config": "*",
-     "typescript": "latest",
-  }
-}
-```
-</Tab>
-<Tab>
+
+<Tab value="pnpm">
 ```json title="./apps/web/package.json"
 {
   "devDependencies": {
      "@repo/typescript-config": "workspace:*",
+     "typescript": "latest",
+  }
+}
+```
+</Tab>
+
+<Tab value="yarn">
+```json title="./apps/web/package.json"
+{
+  "devDependencies": {
+     "@repo/typescript-config": "*",
+     "typescript": "latest",
+  }
+}
+```
+</Tab>
+
+<Tab value="npm">
+```json title="./apps/web/package.json"
+{
+  "devDependencies": {
+     "@repo/typescript-config": "*",
      "typescript": "latest",
   }
 }

--- a/docs/site/content/repo-docs/reference/create-turbo.mdx
+++ b/docs/site/content/repo-docs/reference/create-turbo.mdx
@@ -9,20 +9,26 @@ import { ExamplesTable } from '#/components/examples-table';
 The easiest way to get started with Turborepo is by using `create-turbo`. Use this CLI tool to quickly start building a new monorepo, with everything set up for you.
 
 <PackageManagerTabs>
-<Tab>
-```bash title="Terminal"
-npx create-turbo@latest
-```
-</Tab>
-<Tab>
-```bash title="Terminal"
-yarn dlx create-turbo@latest
-```
-</Tab>
-<Tab>
+
+<Tab value="pnpm">
 ```bash title="Terminal"
 pnpm dlx create-turbo@latest
 ```
+
+</Tab>
+
+<Tab value="yarn">
+```bash title="Terminal"
+yarn dlx create-turbo@latest
+```
+
+</Tab>
+
+<Tab value="npm">
+```bash title="Terminal"
+npx create-turbo@latest
+```
+
 </Tab>
 
 </PackageManagerTabs>
@@ -32,23 +38,24 @@ pnpm dlx create-turbo@latest
 The community curates a set of examples to showcase ways to use common tools and libraries with Turborepo. To bootstrap your monorepo with one of the examples, use the `--example` flag:
 
 <PackageManagerTabs>
-<Tab>
+
+<Tab value="pnpm">
 ```bash title="Terminal"
-npx create-turbo@latest --example [example-name]
+pnpm dlx create-turbo@latest --example [example-name]
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 ```bash title="Terminal"
 yarn dlx create-turbo@latest --example [example-name]
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="npm">
 ```bash title="Terminal"
-pnpm dlx create-turbo@latest --example [example-name]
+npx create-turbo@latest --example [example-name]
 ```
 
 </Tab>
@@ -74,23 +81,24 @@ The community curates a set of examples to showcase ways to use common tools and
 You can also use a custom starter or example by using a GitHub URL. This is useful for using your own custom starters or examples from the community.
 
 <PackageManagerTabs>
-<Tab>
+
+<Tab value="pnpm">
 ```bash title="Terminal"
-npx create-turbo@latest --example [github-url]
+pnpm dlx create-turbo@latest --example [github-url]
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="yarn">
 ```bash title="Terminal"
 yarn dlx create-turbo@latest --example [github-url]
 ```
 
 </Tab>
 
-<Tab>
+<Tab value="npm">
 ```bash title="Terminal"
-pnpm dlx create-turbo@latest --example [github-url]
+npx create-turbo@latest --example [github-url]
 ```
 
 </Tab>

--- a/docs/site/content/repo-docs/reference/eslint-config-turbo.mdx
+++ b/docs/site/content/repo-docs/reference/eslint-config-turbo.mdx
@@ -12,24 +12,27 @@ import { PackageManagerTabs, Tab } from '#/components/tabs';
 Install `eslint-config-turbo` into the location where your ESLint configuration is held:
 
 <PackageManagerTabs>
-  <Tab>
+
+  <Tab value="pnpm">
 
     ```bash title="Terminal"
-    npm i --save-dev eslint-config-turbo -w @acme/eslint-config
+    pnpm add eslint-config-turbo --filter=@repo/eslint-config
     ```
 
   </Tab>
-  <Tab>
+
+  <Tab value="yarn">
 
     ```bash title="Terminal"
     yarn workspace @acme/eslint-config add eslint-config-turbo --dev
     ```
 
   </Tab>
-  <Tab>
+
+  <Tab value="npm">
 
     ```bash title="Terminal"
-    pnpm add eslint-config-turbo --filter=@repo/eslint-config
+    npm i --save-dev eslint-config-turbo -w @acme/eslint-config
     ```
 
   </Tab>

--- a/docs/site/content/repo-docs/reference/eslint-plugin-turbo.mdx
+++ b/docs/site/content/repo-docs/reference/eslint-plugin-turbo.mdx
@@ -12,24 +12,27 @@ import { PackageManagerTabs, Tab } from '#/components/tabs';
 Install `eslint-config-turbo` into the location where your ESLint configuration is held:
 
 <PackageManagerTabs>
-  <Tab>
+
+  <Tab value="pnpm">
 
     ```bash title="Terminal"
-    npm i --save-dev eslint-config-turbo -w @acme/eslint-config
+    pnpm add eslint-config-turbo --filter=@repo/eslint-config
     ```
 
   </Tab>
-  <Tab>
+
+  <Tab value="yarn">
 
     ```bash title="Terminal"
     yarn workspace @acme/eslint-config add eslint-config-turbo --dev
     ```
 
   </Tab>
-  <Tab>
+
+  <Tab value="npm">
 
     ```bash title="Terminal"
-    pnpm add eslint-config-turbo --filter=@repo/eslint-config
+    npm i --save-dev eslint-config-turbo -w @acme/eslint-config
     ```
 
   </Tab>


### PR DESCRIPTION
### Description

After spending enough time with monorepo users, we've developed the opinion that pnpm should be the preferred package manager that we point people to.

We're nudging pnpm to the top of the tabs where we list package managers to lean on this preference.

> [!NOTE]
> While working on this, I found out that these tabs aren't syncing with each other. Changing to pnpm only changes for the one you clicked, not all `<PackageManagerTabs />`. The bug is not introduced by this PR, and I'll fix it separately. 

### Testing Instructions

👀 
