### PR TITLE
fix(docs): fix SVG attribute casing to remove React warnings

### DIFF
--- a/docs/site/components/icons/magnifying-glass.tsx
+++ b/docs/site/components/icons/magnifying-glass.tsx
@@ -3,13 +3,13 @@ export const MagnifyingGlass = ({ className }: { className?: string }) => {
     <svg
       className={className}
       height="16"
-      stroke-linejoin="round"
+      strokeLinejoin="round"
       viewBox="0 0 16 16"
       width="16"
     >
       <path
-        fill-rule="evenodd"
-        clip-rule="evenodd"
+        fillRule="evenodd"
+        clipRule="evenodd"
         d="M1.5 6.5C1.5 3.73858 3.73858 1.5 6.5 1.5C9.26142 1.5 11.5 3.73858 11.5 6.5C11.5 9.26142 9.26142 11.5 6.5 11.5C3.73858 11.5 1.5 9.26142 1.5 6.5ZM6.5 0C2.91015 0 0 2.91015 0 6.5C0 10.0899 2.91015 13 6.5 13C8.02469 13 9.42677 12.475 10.5353 11.596L13.9697 15.0303L14.5 15.5607L15.5607 14.5L15.0303 13.9697L11.596 10.5353C12.475 9.42677 13 8.02469 13 6.5C13 2.91015 10.0899 0 6.5 0Z"
         fill="currentColor"
       ></path>

--- a/docs/site/components/icons/turborepo-wordmark.tsx
+++ b/docs/site/components/icons/turborepo-wordmark.tsx
@@ -52,8 +52,8 @@ export const TurborepoWordmarkDark = ({
         fill="white"
       />
       <path
-        fill-rule="evenodd"
-        clip-rule="evenodd"
+        fillRule="evenodd"
+        clipRule="evenodd"
         d="M40.2115 14.744V7.125C56.7719 8.0104 69.9275 21.7208 69.9275 38.5016C69.9275 55.2824 56.7719 68.989 40.2115 69.8782V62.2592C52.5539 61.3776 62.3275 51.0644 62.3275 38.5016C62.3275 25.9388 52.5539 15.6256 40.2115 14.744ZM20.5048 54.0815C17.233 50.3043 15.124 45.4935 14.7478 40.2115H7.125C7.5202 47.6025 10.4766 54.3095 15.1088 59.4737L20.501 54.0815H20.5048ZM36.7916 69.8782V62.2592C31.5058 61.883 26.695 59.7778 22.9178 56.5022L17.5256 61.8944C22.6936 66.5304 29.4006 69.483 36.7878 69.8782H36.7916Z"
         fill="url(#paint0_linear_2028_477)"
       />
@@ -66,8 +66,8 @@ export const TurborepoWordmarkDark = ({
           y2="42.4236"
           gradientUnits="userSpaceOnUse"
         >
-          <stop stop-color="#0096FF" />
-          <stop offset="1" stop-color="#FF1E56" />
+          <stop stopColor="#0096FF" />
+          <stop offset="1" stopColor="#FF1E56" />
         </linearGradient>
       </defs>
     </svg>
@@ -128,8 +128,8 @@ export const TurborepoWordmarkLight = ({
         fill="black"
       />
       <path
-        fill-rule="evenodd"
-        clip-rule="evenodd"
+        fillRule="evenodd"
+        clipRule="evenodd"
         d="M40.2115 14.744V7.125C56.7719 8.0104 69.9275 21.7208 69.9275 38.5016C69.9275 55.2824 56.7719 68.989 40.2115 69.8782V62.2592C52.5539 61.3776 62.3275 51.0644 62.3275 38.5016C62.3275 25.9388 52.5539 15.6256 40.2115 14.744ZM20.5048 54.0815C17.233 50.3043 15.124 45.4935 14.7478 40.2115H7.125C7.5202 47.6025 10.4766 54.3095 15.1088 59.4737L20.501 54.0815H20.5048ZM36.7916 69.8782V62.2592C31.5058 61.883 26.695 59.7778 22.9178 56.5022L17.5256 61.8944C22.6936 66.5304 29.4006 69.483 36.7878 69.8782H36.7916Z"
         fill="url(#paint0_linear_2028_252)"
       />
@@ -142,8 +142,8 @@ export const TurborepoWordmarkLight = ({
           y2="42.4236"
           gradientUnits="userSpaceOnUse"
         >
-          <stop stop-color="#0096FF" />
-          <stop offset="1" stop-color="#FF1E56" />
+          <stop stopColor="#0096FF" />
+          <stop offset="1" stopColor="#FF1E56" />
         </linearGradient>
       </defs>
     </svg>


### PR DESCRIPTION
### Description
<table>
<tr>
<td>
<img width="1512" alt="Screenshot 2025-04-06 at 14 59 33" src="https://github.com/user-attachments/assets/544f47b3-6488-4b57-9077-3921735a7f06" />
</td>
<td>
<img width="1512" alt="Screenshot 2025-04-06 at 14 59 46" src="https://github.com/user-attachments/assets/ebee4f0c-2246-4f9d-8c17-638ad463c66d" />
</td>
</tr>
<tr>
<td align="center">
`turborepo-wordmark.tsx`
</td>
<td align="center">
`magnifying-glass.tsx`
</td>
</tr>
</table>

This PR fixes React warnings caused by incorrectly cased SVG attribute names in `turborepo-wordmark.tsx` and `magnifying-glass.tsx`.

The root cause is the use of non-camelCase attribute names in SVG elements, which is not compliant with React's expected syntax. 

To resolve this, the affected SVG attributes have been updated to use camelCase, eliminating the warnings during `next dev`.

### Testing Instructions

Clone the PR and run the project with `next dev`, or review the updated code to verify that the SVG attribute casing issues have been resolved.