### PR TITLE
docs: use new community domain

### DIFF
--- a/docs/site/app/_components/footer.tsx
+++ b/docs/site/app/_components/footer.tsx
@@ -83,7 +83,7 @@ const navigation = {
     },
     {
       name: "Community",
-      href: "https://vercel.community/tag/turborepo",
+      href: "https://community.vercel.com/tag/turborepo",
     },
   ],
   company: [

--- a/docs/site/app/_components/not-found-template.tsx
+++ b/docs/site/app/_components/not-found-template.tsx
@@ -43,7 +43,7 @@ export function NotFoundTemplate({
             <li>
               <Link
                 className="text-center"
-                href="https://vercel.community/tag/turborepo"
+                href="https://community.vercel.com/tag/turborepo"
               >
                 Community
               </Link>

--- a/docs/site/components/nav/footer.tsx
+++ b/docs/site/components/nav/footer.tsx
@@ -25,7 +25,7 @@ const FOOTER_ITEMS = {
   ],
   community: [
     { href: "https://github.com/vercel/turborepo", label: "GitHub" },
-    { href: "https://vercel.community/tag/turborepo", label: "Community" },
+    { href: "https://community.vercel.com/tag/turborepo", label: "Community" },
     { href: "https://bsky.app/profile/turbo.build", label: "Bluesky" },
     { href: "https://x.com/turborepo", label: "X" },
   ],

--- a/docs/site/components/search-dialog.tsx
+++ b/docs/site/components/search-dialog.tsx
@@ -23,7 +23,7 @@ export function SearchDialog(props: SharedProps): JSX.Element {
         ["Blog", "/blog"],
         ["Changelog", `${gitHubRepoUrl}/releases`],
         ["Github", gitHubRepoUrl],
-        ["Community", "https://vercel.community/tag/turborepo"],
+        ["Community", "https://community.vercel.com/tag/turborepo"],
       ]}
     />
   );

--- a/docs/site/content/docs/community.mdx
+++ b/docs/site/content/docs/community.mdx
@@ -16,7 +16,7 @@ With over 2 million weekly downloads, Turborepo has a large and active community
 If you have a question about Turborepo or want to help others, join the conversation:
 
 - [GitHub Discussions](https://github.com/vercel/turborepo/discussions)
-- [Vercel Community](https://vercel.community/tag/turborepo)
+- [Vercel Community](https://community.vercel.com/tag/turborepo)
 
 ## Acknowledgements
 

--- a/docs/site/content/docs/index.mdx
+++ b/docs/site/content/docs/index.mdx
@@ -39,4 +39,4 @@ We will do our best to keep jargon to a minimum - but there are some need-to-kno
 
 ## Join the community
 
-If you have questions about anything related to Turborepo, you're always welcome to ask the community on [GitHub Discussions](https://github.com/vercel/turborepo/discussions), [Vercel Community](https://vercel.community/tag/turborepo), and [Twitter](https://twitter.com/turborepo).
+If you have questions about anything related to Turborepo, you're always welcome to ask the community on [GitHub Discussions](https://github.com/vercel/turborepo/discussions), [Vercel Community](https://community.vercel.com/tag/turborepo), and [Twitter](https://twitter.com/turborepo).

--- a/docs/site/content/extra/governance.mdx
+++ b/docs/site/content/extra/governance.mdx
@@ -28,7 +28,7 @@ This process is essential to ensure features are built together with the communi
 
 ## Turborepo Support
 
-For individual developers looking for free support on their Turborepo repositories, they can ask questions in [GitHub Discussions](https://github.com/vercel/turborepo/discussions) or in [Vercel Community's `#turborepo` tag](https://vercel.community/tag/turborepo).
+For individual developers looking for free support on their Turborepo repositories, they can ask questions in [GitHub Discussions](https://github.com/vercel/turborepo/discussions) or in [Vercel Community's `#turborepo` tag](https://community.vercel.com/tag/turborepo).
 
 For companies looking for paid support on their Turborepo repositories, they can [contact the Turborepo team at Vercel](https://vercel.com/contact) for more information.
 

--- a/docs/site/next.config.ts
+++ b/docs/site/next.config.ts
@@ -82,7 +82,7 @@ const config = {
       },
       {
         source: "/discord{/}?",
-        destination: "https://vercel.community/tag/turborepo",
+        destination: "https://community.vercel.com/tag/turborepo",
         permanent: true,
       },
       {


### PR DESCRIPTION
### Description

The Vercel Community team has moved from `vercel.community` to `community.vercel.com`. This PR moves our links over.

### Testing Instructions

👀
