### PR TITLE
docs: replace incorrect generator links (#10344)

### DIFF
--- a/examples/basic/packages/ui/turbo/generators/config.ts
+++ b/examples/basic/packages/ui/turbo/generators/config.ts
@@ -1,6 +1,6 @@
 import type { PlopTypes } from "@turbo/gen";
 
-// Learn more about Turborepo Generators at https://turbo.build/docs/core-concepts/monorepos/code-generation
+// Learn more about Turborepo Generators at https://turbo.build/docs/guides/generating-code
 
 export default function generator(plop: PlopTypes.NodePlopAPI): void {
   // A simple generator to add a new React component to the internal UI library

--- a/examples/with-nestjs/packages/ui/turbo/generators/config.ts
+++ b/examples/with-nestjs/packages/ui/turbo/generators/config.ts
@@ -1,6 +1,6 @@
 import type { PlopTypes } from '@turbo/gen';
 
-// Learn more about Turborepo Generators at https://turbo.build/docs/core-concepts/monorepos/code-generation
+// Learn more about Turborepo Generators at https://turbo.build/docs/guides/generating-code
 
 export default function generator(plop: PlopTypes.NodePlopAPI): void {
   // A simple generator to add a new React component to the internal UI library

--- a/examples/with-npm/packages/ui/turbo/generators/config.ts
+++ b/examples/with-npm/packages/ui/turbo/generators/config.ts
@@ -1,6 +1,6 @@
 import type { PlopTypes } from "@turbo/gen";
 
-// Learn more about Turborepo Generators at https://turbo.build/docs/core-concepts/monorepos/code-generation
+// Learn more about Turborepo Generators at https://turbo.build/docs/guides/generating-code
 
 export default function generator(plop: PlopTypes.NodePlopAPI): void {
   // A simple generator to add a new React component to the internal UI library

--- a/examples/with-typeorm/packages/ui/turbo/generators/config.ts
+++ b/examples/with-typeorm/packages/ui/turbo/generators/config.ts
@@ -1,6 +1,6 @@
 import type { PlopTypes } from "@turbo/gen";
 
-// Learn more about Turborepo Generators at https://turbo.build/docs/core-concepts/monorepos/code-generation
+// Learn more about Turborepo Generators at https://turbo.build/docs/guides/generating-code
 
 export default function generator(plop: PlopTypes.NodePlopAPI): void {
   // A simple generator to add a new React component to the internal UI library

--- a/examples/with-vitest/packages/ui/turbo/generators/config.ts
+++ b/examples/with-vitest/packages/ui/turbo/generators/config.ts
@@ -1,6 +1,6 @@
 import type { PlopTypes } from "@turbo/gen";
 
-// Learn more about Turborepo Generators at https://turbo.build/docs/core-concepts/monorepos/code-generation
+// Learn more about Turborepo Generators at https://turbo.build/docs/guides/generating-code
 
 export default function generator(plop: PlopTypes.NodePlopAPI): void {
   // A simple generator to add a new React component to the internal UI library

--- a/examples/with-yarn/packages/ui/turbo/generators/config.ts
+++ b/examples/with-yarn/packages/ui/turbo/generators/config.ts
@@ -1,6 +1,6 @@
 import type { PlopTypes } from "@turbo/gen";
 
-// Learn more about Turborepo Generators at https://turbo.build/docs/core-concepts/monorepos/code-generation
+// Learn more about Turborepo Generators at https://turbo.build/docs/guides/generating-code
 
 export default function generator(plop: PlopTypes.NodePlopAPI): void {
   // A simple generator to add a new React component to the internal UI library

--- a/packages/turbo-gen/README.md
+++ b/packages/turbo-gen/README.md
@@ -1,6 +1,6 @@
-# `@turbo/gen`
+https://turbo.build/docs/guides/generating-code# `@turbo/gen`
 
-Types for working with [Turborepo Generators](https://turbo.build/docs/core-concepts/monorepos/code-generation).
+Types for working with [Turborepo Generators](https://turbo.build/docs/guides/generating-code).
 
 ## Usage
 
@@ -31,7 +31,7 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
 }
 ```
 
-Learn more about Turborepo Generators in the [docs](https://turbo.build/docs/core-concepts/monorepos/code-generation)
+Learn more about Turborepo Generators in the [docs](https://turbo.build/docs/guides/generating-code)
 
 ---
 

--- a/packages/turbo-gen/src/generators/custom.ts
+++ b/packages/turbo-gen/src/generators/custom.ts
@@ -1,4 +1,4 @@
-https://turbo.build/docs/guides/generating-codeimport { logger } from "@turbo/utils";
+import { logger } from "@turbo/utils";
 import { getCustomGenerators, runCustomGenerator } from "../utils/plop";
 import * as prompts from "../commands/run/prompts";
 import { GeneratorError } from "../utils/error";

--- a/packages/turbo-gen/src/generators/custom.ts
+++ b/packages/turbo-gen/src/generators/custom.ts
@@ -1,4 +1,4 @@
-import { logger } from "@turbo/utils";
+https://turbo.build/docs/guides/generating-codeimport { logger } from "@turbo/utils";
 import { getCustomGenerators, runCustomGenerator } from "../utils/plop";
 import * as prompts from "../commands/run/prompts";
 import { GeneratorError } from "../utils/error";
@@ -50,7 +50,7 @@ export async function generate({
     } else {
       logger.log();
       logger.dimmed(
-        "Learn more about custom Turborepo generators - https://turbo.build/docs/core-concepts/monorepos/code-generation#custom-generators"
+        "Learn more about custom Turborepo generators - https://turbo.build/docs/guides/generating-code#custom-generators"
       );
       return;
     }
@@ -87,7 +87,7 @@ export async function generate({
       logger.log();
       logger.info(`Congrats! You just ran your first Turborepo generator`);
       logger.dimmed(
-        "Learn more about custom Turborepo generators - https://turbo.build/docs/core-concepts/monorepos/code-generation#custom-generators"
+        "Learn more about custom Turborepo generators - https://turbo.build/docs/guides/generating-code#custom-generators"
       );
     }
   }

--- a/packages/turbo-gen/src/templates/simple-js/templates/turborepo-generators.hbs
+++ b/packages/turbo-gen/src/templates/simple-js/templates/turborepo-generators.hbs
@@ -2,4 +2,4 @@
 
 ### Created with Turborepo Generators
 
-Read the docs at [turbo.build](https://turbo.build/docs/core-concepts/monorepos/code-generation).
+Read the docs at [turbo.build](https://turbo.build/docs/guides/generating-code).

--- a/packages/turbo-gen/src/templates/simple-ts/templates/turborepo-generators.hbs
+++ b/packages/turbo-gen/src/templates/simple-ts/templates/turborepo-generators.hbs
@@ -2,4 +2,4 @@
 
 ### Created with Turborepo Generators
 
-Read the docs at [turbo.build](https://turbo.build/docs/core-concepts/monorepos/code-generation).
+Read the docs at [turbo.build](https://turbo.build/docs/guides/generating-code).


### PR DESCRIPTION
### Description

See: https://github.com/vercel/turborepo/issues/10344