### PR TITLE
feat(sidebar): improve folder link accessibility and UX

### DIFF
--- a/docs/site/components/docs-layout/sidebar.tsx
+++ b/docs/site/components/docs-layout/sidebar.tsx
@@ -197,32 +197,30 @@ export const SidebarFolderLink = ({
   }, [active, setOpenFolder]);
 
   return (
-    <Link
-      href={href}
-      data-active={active}
-      className={itemClasses(className)}
-      prefetch={prefetch}
-      onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
-        if (
-          // clicking on icon
-          (e.target as HTMLElement).hasAttribute("data-icon") ||
-          active
-        ) {
-          setOpenFolder(!openFolder);
-          e.preventDefault();
-        }
-      }}
-      {...props}
-    >
-      {children}
-      <ChevronRight
-        data-icon
-        className={cn(
-          "ml-auto transition-transform h-3 w-3",
-          openFolder ? "rotate-90" : ""
-        )}
-      />
-    </Link>
+    <div className="flex items-center w-full">
+      <Link
+        href={href}
+        data-active={active}
+        className={itemClasses(className)}
+        prefetch={prefetch}
+        {...props}
+      >
+        {children}
+      </Link>
+      <button
+        onClick={() => setOpenFolder(!openFolder)}
+        className="ml-auto p-1 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-md transition-colors"
+        aria-label={openFolder ? "Collapse section" : "Expand section"}
+      >
+        <ChevronRight
+          data-icon
+          className={cn(
+            "transition-transform h-3 w-3",
+            openFolder ? "rotate-90" : ""
+          )}
+        />
+      </button>
+    </div>
   );
 };
 


### PR DESCRIPTION
### Description

```Refering the Discussion```: [#10328](https://github.com/vercel/turborepo/discussions/10328)

This PR improves the accessibility and user experience of the sidebar folder links by separating the navigation and toggle functionality into distinct interactive elements.

**Key Changes:**
- Separated the folder link and toggle button into distinct elements for clearer interaction patterns
- Added proper `aria-label` attributes for screen readers to indicate expand/collapse actions
- Improved visual feedback with hover states on the toggle button

### Testing Instructions

This is what it was earlier:
https://drive.google.com/file/d/1-XLu9N_nAoksvfLQQlQQndniZFstABaM/view?usp=sharing

And this is how it looks now:
https://drive.google.com/file/d/1YOqaRRn6L-cFq2cgZH5Lg7u5HSx-d6A9/view?usp=sharing

1. **Basic Functionality**
   - Navigate to any page with a sidebar containing folder links

2. **Accessibility Testing**
   - Use a screen reader to navigate the sidebar

4. **Edge Cases**
   - Test with long folder names to ensure proper text truncation
   - Verify behavior when a folder is both active and collapsed
