### PR TITLE
docs: copy to markdown button

### DIFF
--- a/docs/site/app/(sidebar)/docs/[[...slug]]/layout.tsx
+++ b/docs/site/app/(sidebar)/docs/[[...slug]]/layout.tsx
@@ -17,7 +17,7 @@ export default async function SlugLayout(props: {
   }
 
   return (
-    <DocsPage>
+    <DocsPage breadcrumb={{ enabled: false }}>
       <DocsBody>{children}</DocsBody>
     </DocsPage>
   );

--- a/docs/site/app/(sidebar)/docs/[[...slug]]/page.tsx
+++ b/docs/site/app/(sidebar)/docs/[[...slug]]/page.tsx
@@ -1,9 +1,11 @@
 import { notFound } from "next/navigation";
+import { readFileSync } from "fs";
 import type { Metadata } from "next/types";
 import { repoDocsPages } from "@/app/source";
 import { createMetadata } from "@/lib/create-metadata";
 import { mdxComponents } from "@/mdx-components";
 import { SystemEnvironmentVariablesHashHighlighter } from "./system-environment-variables-hash-highlighter";
+import { CopyToMarkdown } from "@/components/copy-to-markdown";
 
 export async function generateMetadata(props: {
   params: Promise<{ slug?: string[] }>;
@@ -36,14 +38,28 @@ export default async function Page(props: {
     notFound();
   }
 
+  const rawMarkdown = readFileSync(page.data._file.absolutePath)
+    .toString()
+    // TODO: Make the regex capture all of the header metadata
+    .replace(/---/g, "")
+    // TODO: Regex to capture all import lines for real
+    .replace(/import { Step, Steps } from \'#\/components\/steps\';/g, "")
+    .replace(/import { Tabs, Tab } from \'#\/components\/tabs\';/g, "")
+    .replace(/import { Callout } from \'#\/components\/callout\';/g, "");
+
   const Mdx = page.data.body;
 
   return (
     <>
       <SystemEnvironmentVariablesHashHighlighter />
-      <h1 className="scroll-m-7 text-4xl font-semibold tracking-normal">
-        {page.data.title}
-      </h1>
+
+      <div className="flex justify-between gap-4">
+        <h1 className="scroll-m-7 text-4xl font-semibold tracking-normal">
+          {page.data.title}
+        </h1>
+
+        <CopyToMarkdown markdownContent={rawMarkdown} />
+      </div>
       <Mdx components={mdxComponents} />
     </>
   );

--- a/docs/site/app/(sidebar)/docs/[[...slug]]/page.tsx
+++ b/docs/site/app/(sidebar)/docs/[[...slug]]/page.tsx
@@ -40,19 +40,16 @@ export default async function Page(props: {
 
   const rawMarkdown = readFileSync(page.data._file.absolutePath)
     .toString()
-    // TODO: Make the regex capture all of the header metadata
-    .replace(/---/g, "")
-    // TODO: Regex to capture all import lines for real
-    .replace(/import { Step, Steps } from \'#\/components\/steps\';/g, "")
-    .replace(/import { Tabs, Tab } from \'#\/components\/tabs\';/g, "")
-    .replace(/import { Callout } from \'#\/components\/callout\';/g, "");
+    // Removes frontmatter
+    .replace(/^---\n(.*?\n)---\n/s, "")
+    // Removes import statements for components
+    .replace(/^import\s+{[^}]+}\s+from\s+['"]#\/[^'"]+['"];(\r?\n|$)/gm, "");
 
   const Mdx = page.data.body;
 
   return (
     <>
       <SystemEnvironmentVariablesHashHighlighter />
-
       <div className="flex justify-between gap-4">
         <h1 className="scroll-m-7 text-4xl font-semibold tracking-normal">
           {page.data.title}

--- a/docs/site/components/copy-to-markdown.tsx
+++ b/docs/site/components/copy-to-markdown.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { Button } from "./button";
+
+export const CopyToMarkdown = ({
+  markdownContent,
+}: {
+  markdownContent: string;
+}) => {
+  return (
+    <Button
+      variant="outline"
+      onClick={() => navigator.clipboard.writeText(markdownContent)}
+    >
+      Copy .mdx
+    </Button>
+  );
+};

--- a/docs/site/components/copy-to-markdown.tsx
+++ b/docs/site/components/copy-to-markdown.tsx
@@ -1,18 +1,40 @@
 "use client";
 
+import { useState } from "react";
+import { Copy, Check } from "lucide-react";
 import { Button } from "./button";
+import { cn } from "./cn";
 
 export const CopyToMarkdown = ({
   markdownContent,
 }: {
   markdownContent: string;
 }) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(markdownContent);
+    setCopied(true);
+
+    // Reset back to copy icon after 2 seconds
+    setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+  };
+
   return (
     <Button
       variant="outline"
-      onClick={() => navigator.clipboard.writeText(markdownContent)}
+      size="sm"
+      className={"text-xs hidden sm:flex"}
+      onClick={handleCopy}
     >
-      Copy .mdx
+      {copied ? (
+        <Check className="w-4 h-4 mr-1" />
+      ) : (
+        <Copy className="w-4 h-4 mr-1" />
+      )}
+      Copy as Markdown
     </Button>
   );
 };

--- a/docs/site/tsconfig.json
+++ b/docs/site/tsconfig.json
@@ -15,7 +15,7 @@
       "#/*": ["./*"]
     },
     "allowJs": true,
-    "target": "ES2017",
+    "target": "ESNext",
     "lib": ["dom", "dom.iterable", "esnext"],
     "noEmit": true,
     "incremental": true


### PR DESCRIPTION
### Description

Provides a button for a docs page to be copied to the user's clipboard as markdown, presumably to paste into an LLM.

### Testing Instructions

Try the button!
https://turbo-site-git-shew-454de.vercel.sh/docs/getting-started/examples
