### PR TITLE
docs: migrate to `turborepo.com`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,7 +224,7 @@ Key characteristics of a great example include:
 - One technology added to the `basic` example
 - An updated README at the root of the example directory. Make sure to include any steps required to run the example
 - All tasks in `turbo.json` in the example run successfully without any code changes needed
-- Works with every package manager listed in our [Support Policy](https://turbo.build/docs/getting-started/support-policy#package-managers)
+- Works with every package manager listed in our [Support Policy](https://turborepo.com/docs/getting-started/support-policy#package-managers)
 
 Once you've created your example (with prior approval, as discussed above), you can submit a pull request to the repository.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://turbo.build">
+  <a href="https://turborepo.com">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/4060187/196936123-f6e1db90-784d-4174-b774-92502b718836.png">
       <img src="https://user-images.githubusercontent.com/4060187/196936104-5797972c-ab10-4834-bd61-0d1e5f442c9c.png" height="128">
@@ -19,7 +19,7 @@ Turborepo is a high-performance build system for JavaScript and TypeScript codeb
 
 ## Getting Started
 
-Visit https://turbo.build/repo to get started with Turborepo.
+Visit https://turborepo.com/repo to get started with Turborepo.
 
 ## Contributing
 
@@ -35,7 +35,7 @@ Our [Code of Conduct](https://github.com/vercel/turborepo/blob/main/CODE_OF_COND
 
 ## Who is using Turborepo?
 
-Turborepo is used by the world's leading companies. Check out the [Turborepo Showcase](https://turbo.build/showcase) to learn more.
+Turborepo is used by the world's leading companies. Check out the [Turborepo Showcase](https://turborepo.com/showcase) to learn more.
 
 ## Updates
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,3 +1,3 @@
 # `turbo` CLI
 
-Visit https://turbo.build/repo to view the full documentation.
+Visit https://turborepo.com/repo to view the full documentation.

--- a/crates/turborepo-env/src/platform.rs
+++ b/crates/turborepo-env/src/platform.rs
@@ -64,7 +64,7 @@ impl PlatformEnv {
         let docs_message = color!(
             color_config,
             UNDERLINE,
-            "https://turbo.build/docs/platform-environment-variables"
+            "https://turborepo.com/docs/platform-environment-variables"
         );
 
         match ci {

--- a/crates/turborepo-errors/src/lib.rs
+++ b/crates/turborepo-errors/src/lib.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 /// used.
 pub const TURBO_SITE: &str = match option_env!("TURBO_SITE") {
     Some(url) => url,
-    None => "https://turbo.build",
+    None => "https://turborepo.com",
 };
 
 /// A little helper to convert from biome's syntax errors to miette.

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -653,7 +653,7 @@ pub enum Command {
         /// Use the given selector to specify package(s) to act as
         /// entry points. The syntax mirrors pnpm's syntax, and
         /// additional documentation and examples can be found in
-        /// turbo's documentation https://turbo.build/docs/reference/command-line-reference/run#--filter
+        /// turbo's documentation https://turborepo.com/docs/reference/command-line-reference/run#--filter
         #[clap(short = 'F', long, group = "scope-filter-group")]
         filter: Vec<String>,
         /// Get insight into a specific package, such as
@@ -895,7 +895,7 @@ pub struct ExecutionArgs {
     /// Use the given selector to specify package(s) to act as
     /// entry points. The syntax mirrors pnpm's syntax, and
     /// additional documentation and examples can be found in
-    /// turbo's documentation https://turbo.build/docs/reference/command-line-reference/run#--filter
+    /// turbo's documentation https://turborepo.com/docs/reference/command-line-reference/run#--filter
     #[clap(short = 'F', long, group = "scope-filter-group")]
     pub filter: Vec<String>,
 

--- a/crates/turborepo-lib/src/commands/link.rs
+++ b/crates/turborepo-lib/src/commands/link.rs
@@ -75,7 +75,8 @@ pub(crate) enum SelectedTeam<'a> {
 pub(crate) const REMOTE_CACHING_INFO: &str =
     "Remote Caching makes your caching multiplayer,\nsharing build outputs and logs between \
      developers and CI/CD systems.\n\nBuild and deploy faster.";
-pub(crate) const REMOTE_CACHING_URL: &str = "https://turbo.build/docs/core-concepts/remote-caching";
+pub(crate) const REMOTE_CACHING_URL: &str =
+    "https://turborepo.com/docs/core-concepts/remote-caching";
 
 /// Verifies that caching status for a team is enabled, or prompts the user to
 /// enable it.

--- a/crates/turborepo-lib/src/commands/telemetry.rs
+++ b/crates/turborepo-lib/src/commands/telemetry.rs
@@ -25,7 +25,7 @@ fn log_status(config: TelemetryConfig, base: &CommandBase) {
             );
         }
     }
-    println!("Learn more: https://turbo.build/docs/telemetry");
+    println!("Learn more: https://turborepo.com/docs/telemetry");
 }
 
 fn log_error(message: &str, error: &str, base: &CommandBase) {

--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -74,7 +74,7 @@ pub enum Error {
     #[error(transparent)]
     PackageJson(#[from] turborepo_repository::package_json::Error),
     #[error(
-        "Could not find turbo.json or turbo.jsonc.\nFollow directions at https://turbo.build/docs \
+        "Could not find turbo.json or turbo.jsonc.\nFollow directions at https://turborepo.com/docs \
          to create one."
     )]
     NoTurboJSON,

--- a/crates/turborepo-lib/src/diagnostics.rs
+++ b/crates/turborepo-lib/src/diagnostics.rs
@@ -221,7 +221,7 @@ impl Diagnostic for GitDaemonDiagnostic {
                     if fsmonitor.trim() != "true" || untrackedcache.trim() != "true" {
                         chan.log_line("Git FS Monitor not configured".to_string())
                             .await;
-                        chan.log_line( "For more information, see https://turbo.build/docs/reference/command-line-reference/scan#fs-monitor".to_string()).await;
+                        chan.log_line( "For more information, see https://turborepo.com/docs/reference/command-line-reference/scan#fs-monitor".to_string()).await;
                         let Some(resp) = chan
                             .request(
                                 "Configure it for this repo now?".to_string(),
@@ -372,7 +372,7 @@ impl Diagnostic for LSPDiagnostic {
                 Ok(None) => {
                     chan.log_line("Unable to find LSP instance".to_string())
                         .await;
-                    chan.log_line( "For more information, see https://turbo.build/docs/reference/command-line-reference/scan#lsp".to_string()).await;
+                    chan.log_line( "For more information, see https://turborepo.com/docs/reference/command-line-reference/scan#lsp".to_string()).await;
                     chan.failed("Turborepo Extension is not running".to_string())
                         .await;
                 }

--- a/crates/turborepo-telemetry/README.md
+++ b/crates/turborepo-telemetry/README.md
@@ -7,7 +7,7 @@ Any changes made here should also be made to that package as well.
 ## Overview
 
 This crate provides a way to optionally record anonymous usage data.
-This information is used to shape the Turborepo roadmap and prioritize features. You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the [documentation](https://turbo.build/docs/telemetry):
+This information is used to shape the Turborepo roadmap and prioritize features. You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the [documentation](https://turborepo.com/docs/telemetry):
 
 ## Events
 

--- a/crates/turborepo-telemetry/src/config.rs
+++ b/crates/turborepo-telemetry/src/config.rs
@@ -167,7 +167,7 @@ impl TelemetryConfig {
                         color_config,
                         GREY,
                         "{}",
-                        "https://turbo.build/docs/telemetry"
+                        "https://turborepo.com/docs/telemetry"
                     )
                 ),
             );

--- a/crates/turborepo-telemetry/src/lib.rs
+++ b/crates/turborepo-telemetry/src/lib.rs
@@ -1,7 +1,7 @@
 //! Turborepo's telemetry library. Handles sending anonymous telemetry events to
 //! the Vercel API in the background.
 //!
-//! More detail is available at https://turbo.build/docs/telemetry.
+//! More detail is available at https://turborepo.com/docs/telemetry.
 
 #![feature(error_generic_member_access)]
 

--- a/crates/turborepo-updater/src/lib.rs
+++ b/crates/turborepo-updater/src/lib.rs
@@ -69,7 +69,7 @@ impl Registry for NPMRegistry {
         let split_name: Vec<&str> = full_name.split('/').collect();
         let name = split_name[1];
         let url = format!(
-            "https://turbo.build/api/binaries/version?name={name}&tag={tag}",
+            "https://turborepo.com/api/binaries/version?name={name}&tag={tag}",
             name = name,
             tag = tag
         );

--- a/docs/site/app/(no-sidebar)/page.tsx
+++ b/docs/site/app/(no-sidebar)/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import cn from "classnames";
+import { cn } from "@/components/cn";
 import Link from "next/link";
 import { motion } from "framer-motion";
 import { Clients } from "@/app/_clients/clients";

--- a/docs/site/app/(no-sidebar)/showcase/page.tsx
+++ b/docs/site/app/(no-sidebar)/showcase/page.tsx
@@ -16,16 +16,16 @@ function Showcase(): JSX.Element {
     <main className="container mx-auto pt-12">
       <div className="mx-auto">
         <div className="py-16 lg:text-center">
-          <h1 className="mt-2 text-3xl font-extrabold leading-8 tracking-tight text-gray-900 dark:text-white sm:text-4xl sm:leading-10 md:text-5xl">
+          <h1 className="mt-2 text-3xl font-extrabold leading-8 tracking-tight text-black dark:text-white sm:text-4xl sm:leading-10 md:text-5xl">
             Showcase
           </h1>
-          <p className="mt-4 max-w-3xl font-mono text-xl leading-7 text-gray-900 dark:text-gray-900 lg:mx-auto">
+          <p className="mt-4 max-w-3xl font-mono text-xl leading-7 text-black dark:text-white lg:mx-auto">
             Who is using Turborepo?
           </p>
         </div>
       </div>
 
-      <div className="mb-8 px-0 sm:px-8  grid grid-cols-3 items-center gap-16 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-7 ">
+      <div className="mb-8 px-0 min-h-screen sm:px-8 grid grid-cols-3 items-center gap-16 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-7 ">
         <Clients linked />
       </div>
     </main>

--- a/docs/site/app/_clients/client-logo.tsx
+++ b/docs/site/app/_clients/client-logo.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import cn from "classnames";
+import { cn } from "@/components/cn";
 import Image from "next/image";
 import type { TurboUser } from "./users";
 
@@ -12,10 +12,12 @@ export function Logo({
   user,
   theme,
   isLink,
+  className,
 }: {
   user: TurboUser;
   theme: "dark" | "light";
   isLink: boolean;
+  className?: string;
 }): JSX.Element {
   const styles = {
     ...DEFAULT_SIZE,
@@ -32,10 +34,7 @@ export function Logo({
   const logo = (
     <Image
       alt={`${user.caption}'s Logo`}
-      className={cn("mx-8", {
-        "hidden dark:inline": theme !== "dark",
-        "inline dark:hidden": theme === "dark",
-      })}
+      className={cn("mx-8", className)}
       // biome-ignore lint/style/noNonNullAssertion: Ignored using `--suppress`
       height={numericHeight!}
       priority
@@ -52,10 +51,7 @@ export function Logo({
   if (isLink) {
     return (
       <a
-        className={cn("item-center flex justify-center", {
-          "hidden dark:flex": theme !== "dark",
-          "flex dark:hidden": theme === "dark",
-        })}
+        className="item-center flex justify-center"
         href={user.infoLink}
         rel="noopener noreferrer"
         target="_blank"

--- a/docs/site/app/_clients/clients.tsx
+++ b/docs/site/app/_clients/clients.tsx
@@ -1,20 +1,19 @@
-import type { ReactElement, JSX } from "react";
-import React from "react";
-import cn from "classnames";
+"use client";
+
+import type { ReactElement } from "react";
+import React, { useEffect, useState } from "react";
+import { cn } from "@/components/cn";
 import { users } from "./users";
 import { Logo } from "./client-logo";
+import { useTheme } from "next-themes";
 
 interface LogoWrapperProps {
   className: string;
-  children: JSX.Element;
+  children: ReactElement;
   staticWidth?: boolean;
 }
 
-function LogoWrapper({
-  className,
-  children,
-  staticWidth,
-}: LogoWrapperProps): JSX.Element {
+function LogoWrapper({ className, children, staticWidth }: LogoWrapperProps) {
   if (!staticWidth) return children;
   return (
     <div
@@ -33,39 +32,36 @@ export function Clients({
   linked?: boolean;
   staticWidth?: boolean;
   companyList?: string[];
-}): JSX.Element {
-  const showcaseDark: ReactElement[] = [];
-  const showcaseLight: ReactElement[] = [];
+}) {
+  const [mounted, setMounted] = useState(false);
+  const { theme } = useTheme();
 
-  users
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // avoid hydration errors
+  if (!mounted) return null;
+
+  return users
     .filter((i) => (companyList ? companyList.includes(i.caption) : true))
-    .forEach((user) => {
-      if (user.pinned) {
-        showcaseDark.push(
-          <LogoWrapper
-            className="flex dark:hidden"
-            key={`${user.caption}-dark`}
-            staticWidth={staticWidth}
-          >
-            <Logo isLink={linked ?? false} theme="dark" user={user} />
-          </LogoWrapper>
-        );
-        showcaseLight.push(
-          <LogoWrapper
-            className="hidden dark:flex"
-            key={`${user.caption}-light`}
-            staticWidth={staticWidth}
-          >
-            <Logo isLink={linked ?? false} theme="light" user={user} />
-          </LogoWrapper>
-        );
-      }
-    });
+    .map((user) => {
+      const isDark = theme === "dark";
+      const imgTheme = isDark ? "light" : "dark";
 
-  return (
-    <>
-      {showcaseDark}
-      {showcaseLight}
-    </>
-  );
+      return (
+        <LogoWrapper
+          className={isDark ? "hidden dark:flex" : "dark:hidden flex"}
+          key={`${user.caption}-${imgTheme}`}
+          staticWidth={staticWidth}
+        >
+          <Logo
+            className={isDark ? "hidden dark:flex" : "dark:hidden flex"}
+            isLink={linked ?? false}
+            theme={imgTheme}
+            user={user}
+          />
+        </LogoWrapper>
+      );
+    });
 }

--- a/docs/site/app/_components/footer.tsx
+++ b/docs/site/app/_components/footer.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import type { ReactNode, ReactElement } from "react";
 import { useState } from "react";
-import cn from "classnames";
+import { cn } from "@/components/cn";
 import { VercelLogo } from "./logos";
 import { gitHubRepoUrl } from "@/lib/constants";
 

--- a/docs/site/app/_components/footer.tsx
+++ b/docs/site/app/_components/footer.tsx
@@ -90,11 +90,11 @@ const navigation = {
     { name: "Vercel", href: "https://vercel.com" },
     {
       name: "Open Source Software",
-      href: "https://vercel.com/oss?utm_source=turbo.build&utm_medium=referral&utm_campaign=footer-ossLink",
+      href: "https://vercel.com/oss?utm_source=turborepo.com&utm_medium=referral&utm_campaign=footer-ossLink",
     },
     {
       name: "Contact Sales",
-      href: "https://vercel.com/solutions/turborepo?utm_source=turbo.build&utm_medium=referral&utm_campaign=footer-enterpriseLink",
+      href: "https://vercel.com/solutions/turborepo?utm_source=turborepo.com&utm_medium=referral&utm_campaign=footer-enterpriseLink",
     },
     { name: "X", href: "https://x.com/vercel" },
   ],
@@ -183,7 +183,7 @@ function FooterContent(): JSX.Element {
           <div>
             <a
               className="text-current"
-              href="https://vercel.com?utm_source=turbo.build&utm_medium=referral&utm_campaign=footer-logoLink"
+              href="https://vercel.com?utm_source=turborepo.com&utm_medium=referral&utm_campaign=footer-logoLink"
               rel="noopener noreferrer"
               target="_blank"
               title="vercel.com homepage"

--- a/docs/site/app/_components/logo-context.tsx
+++ b/docs/site/app/_components/logo-context.tsx
@@ -3,7 +3,7 @@
 import type { MouseEvent } from "react";
 import { useEffect, useCallback, useState, useRef } from "react";
 import Link from "next/link";
-import classNames from "classnames";
+import { cn } from "@/components/cn";
 import { VercelLogo } from "./logos";
 import { PRODUCT_MENU_ITEMS, PLATFORM_MENU_ITEMS } from "./items";
 import type { MenuItemProps } from "./types";
@@ -17,9 +17,7 @@ function MenuDivider({
 }): JSX.Element {
   return (
     <h3
-      className={classNames(
-        "group flex items-center px-4 py-2 text-xs font-bold text-gray-500 dark:text-gray-600"
-      )}
+      className="group flex items-center px-4 py-2 text-xs font-bold text-gray-500 dark:text-gray-600"
       {...other}
     >
       {children}
@@ -63,7 +61,7 @@ function MenuItem({
     }
   }, [copied, closeMenu]);
 
-  const classes = classNames(
+  const classes = cn(
     className,
     "group flex items-center px-4 py-2 text-sm dark:hover:bg-gray-800 hover:bg-gray-200 w-full rounded-md"
   );
@@ -170,7 +168,7 @@ export function LogoContext(): JSX.Element {
               </MenuItem>
             ))}
             <MenuDivider>Products</MenuDivider>
-            {PRODUCT_MENU_ITEMS({ theme }).map((item) => (
+            {PRODUCT_MENU_ITEMS().map((item) => (
               <MenuItem
                 closeMenu={() => {
                   setOpen(false);

--- a/docs/site/app/_components/logos.tsx
+++ b/docs/site/app/_components/logos.tsx
@@ -1,9 +1,9 @@
-import classNames from "classnames";
+import { cn } from "@/components/cn";
 
 export function VercelLogo({ className }: { className?: string }): JSX.Element {
   return (
     <svg
-      className={classNames(className, "fill-black dark:fill-white")}
+      className={cn(className, "fill-black dark:fill-white")}
       fill="none"
       height={22}
       viewBox="0 0 235 203"

--- a/docs/site/app/_components/turbohero-background.tsx
+++ b/docs/site/app/_components/turbohero-background.tsx
@@ -1,4 +1,4 @@
-import cn from "classnames";
+import { cn } from "@/components/cn";
 import type { JSX } from "react";
 import styles from "./turbohero-background.module.css";
 

--- a/docs/site/app/api/og/route.tsx
+++ b/docs/site/app/api/og/route.tsx
@@ -118,7 +118,7 @@ export async function GET(req: NextApiRequest): Promise<Response> {
       return new Response(undefined, {
         status: 302,
         headers: {
-          Location: "https://turbo.build/og-image.png",
+          Location: "https://turborepo.com/og-image.png",
         },
       });
     }

--- a/docs/site/components/authors.tsx
+++ b/docs/site/components/authors.tsx
@@ -1,4 +1,4 @@
-import cn from "classnames";
+import { cn } from "@/components/cn";
 import { TURBO_TEAM } from "./team";
 import type { Author } from "./team";
 import { Avatar } from "./avatar";

--- a/docs/site/components/badge.tsx
+++ b/docs/site/components/badge.tsx
@@ -1,4 +1,4 @@
-import cn from "classnames";
+import { cn } from "@/components/cn";
 import type { ReactNode } from "react";
 
 export type BadgeProps = React.ComponentProps<"span"> & {

--- a/docs/site/components/feedback-widget.tsx
+++ b/docs/site/components/feedback-widget.tsx
@@ -35,7 +35,7 @@ export function FeedbackWidget() {
       body: JSON.stringify({
         url:
           window.location.hostname === "localhost"
-            ? `https://turbo.build/dev-mode${window.location.pathname}`
+            ? `https://turborepo.com/dev-mode${window.location.pathname}`
             : window.location.toString(),
         note: feedback,
         emotion: selectedEmoji,

--- a/docs/site/components/files.tsx
+++ b/docs/site/components/files.tsx
@@ -1,4 +1,4 @@
-import classNames from "classnames";
+import { cn } from "@/components/cn";
 import {
   File as FumaFile,
   Folder as FumaFolder,
@@ -18,9 +18,10 @@ export function File({
 }): JSX.Element {
   return (
     <FumaFile
-      className={`${classNames({
-        "text-green-700 dark:text-green-900": green,
-      })} ${className}`}
+      className={cn(
+        green ? "text-green-700 dark:text-green-900" : "",
+        className
+      )}
       name={name}
       {...props}
     />
@@ -39,9 +40,10 @@ export function Folder({
 }): JSX.Element {
   return (
     <FumaFolder
-      className={`${classNames({
-        "text-green-700 dark:text-green-900": green,
-      })} ${className}`}
+      className={cn(
+        green ? "text-green-700 dark:text-green-900" : "",
+        className
+      )}
       name={name}
       {...props}
     />

--- a/docs/site/components/image/themed-image-figure.tsx
+++ b/docs/site/components/image/themed-image-figure.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import cn from "classnames";
+import { cn } from "@/components/cn";
 import type { ImageFigureProps } from "./image-figure";
 import type { ThemedImageProps } from "./themed-image";
 import { ThemedImage } from "./themed-image";
@@ -27,10 +27,8 @@ export function ThemedImageFigure(
       <div
         className={cn(
           "border-box relative inline-block max-w-full overflow-hidden text-[0px]",
-          {
-            "rounded-md": borderRadius,
-            "shadow-lg": shadow,
-          }
+          borderRadius ? "rounded-md" : "",
+          shadow ? "shadow-lg" : ""
         )}
       >
         {}

--- a/docs/site/components/nav/footer.tsx
+++ b/docs/site/components/nav/footer.tsx
@@ -26,7 +26,7 @@ const FOOTER_ITEMS = {
   community: [
     { href: "https://github.com/vercel/turborepo", label: "GitHub" },
     { href: "https://community.vercel.com/tag/turborepo", label: "Community" },
-    { href: "https://bsky.app/profile/turbo.build", label: "Bluesky" },
+    { href: "https://bsky.app/profile/turborepo.com", label: "Bluesky" },
     { href: "https://x.com/turborepo", label: "X" },
   ],
 };

--- a/docs/site/components/nav/index.tsx
+++ b/docs/site/components/nav/index.tsx
@@ -40,7 +40,7 @@ export const PAGES = [
     name: "showcase",
   },
   {
-    href: "https://vercel.com/contact/sales?utm_source=turbo.build&utm_medium=referral&utm_campaign=header-enterpriseLink",
+    href: "https://vercel.com/contact/sales?utm_source=turborepo.com&utm_medium=referral&utm_campaign=header-enterpriseLink",
     tooltip: "Enterprise",
     name: "enterprise",
   },

--- a/docs/site/components/theme-aware-image.tsx
+++ b/docs/site/components/theme-aware-image.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import cn from "classnames";
+import { cn } from "@/components/cn";
 import type { ImageProps } from "next/image";
 import Image from "next/image";
 

--- a/docs/site/content/blog/joining-vercel.mdx
+++ b/docs/site/content/blog/joining-vercel.mdx
@@ -12,7 +12,7 @@ import { Authors } from '#/components/authors';
 
 <Authors authors={['jaredpalmer']} />
 
-Turborepo has been acquired by Vercel and the Turborepo CLI is now open-source! Also, Turborepo now provides zero-config remote caching through [Vercel](https://vercel.com/?utm_source=turbo.build&utm_medium=referral&utm_campaign=docs-link)!
+Turborepo has been acquired by Vercel and the Turborepo CLI is now open-source! Also, Turborepo now provides zero-config remote caching through [Vercel](https://vercel.com/?utm_source=turborepo.com&utm_medium=referral&utm_campaign=docs-link)!
 
 beta.turborepo.com and its remote caching service will be shut down on January 15th, 2022 and older versions of the `turbo` CLI will not be installable.
 

--- a/docs/site/content/blog/turbo-1-1-0.mdx
+++ b/docs/site/content/blog/turbo-1-1-0.mdx
@@ -18,7 +18,7 @@ Since releasing Turborepo v1.0 in mid-December, we've seen incredible adoption:
 - 70k+ weekly npm downloads
 - 65+ OSS contributors
 - In production at [Vercel](https://github.com/vercel/next.js), [AWS](https://github.com/aws-amplify/amplify-ui), [PayPal](https://x.com/jaredpalmer/status/1485617973477978121), [Twilio](https://github.com/twilio-labs/function-templates), [Contentful](https://github.com/contentful/forma-36), [Miro](https://github.com/miroapp/app-examples), [Framer](https://github.com/framer/motion), [Discord.js](https://github.com/discordjs/discord.js), [Rocket.chat](https://github.com/RocketChat/fuselage), [Astro.build](https://github.com/withastro/astro)
-- 585+ members of the [Turborepo Community Discord](https://turbo.build/discord)
+- 585+ members of the [Turborepo Community Discord](https://turborepo.com/discord)
 
 ![Weekly npm downloads of `turbo`](/images/blog/turbo-1-1-0/turborepo-weekly-npm-downloads.png)
 

--- a/docs/site/content/blog/turbo-1-10-0.mdx
+++ b/docs/site/content/blog/turbo-1-10-0.mdx
@@ -87,7 +87,7 @@ To ensure that Turborepo includes these variables in your hash, use the `dotEnv`
 
 ```json title="./turbo.json"
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDotEnv": [".env"],
   "pipeline": {
     "build": {
@@ -132,7 +132,7 @@ With wildcards, you can now specify patterns of variables to include in your has
 
 ```json title="./turbo.json"
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "pipeline": {
     "build": {
       "env": ["ACME_*"]

--- a/docs/site/content/blog/turbo-1-12-0.mdx
+++ b/docs/site/content/blog/turbo-1-12-0.mdx
@@ -113,11 +113,11 @@ This microsyntax allows you to use the Turborepo defaults you're used to while a
 
 Turborepo was released almost two years ago, and `turbo` has developed considerably over the past two years. As the community has grown, the value of your feedback is immeasurable in helping us stay focused on what matters most to Turborepo users.
 
-Until now, our feedback gathering process has been manual, slow, and error prone. While we will always highly appreciate users who file [GitHub Issues](https://github.com/vercel/turbo/issues), speak to us in [GitHub Discussions](https://github.com/vercel/turbo/discussions), and chat with the community in [Discord](https://turbo.build/discord), this feedback only captures the sentiment of a small corner of the Turboverse.
+Until now, our feedback gathering process has been manual, slow, and error prone. While we will always highly appreciate users who file [GitHub Issues](https://github.com/vercel/turbo/issues), speak to us in [GitHub Discussions](https://github.com/vercel/turbo/discussions), and chat with the community in [Discord](https://turborepo.com/discord), this feedback only captures the sentiment of a small corner of the Turboverse.
 
 Today, we're introducing a **completely anonymous**, automated approach to feedback to learn more about the ways that the community is using Turborepo. As we continue to iterate on `turbo`, this information will help us ensure performance, confirm stability, design new features, and drive the project's direction.
 
-We're creating the build system of the future and this information will be highly valuable to guide us in that effort. For more information, visit [turbo.build/docs/telemetry](https://turbo.build/docs/telemetry).
+We're creating the build system of the future and this information will be highly valuable to guide us in that effort. For more information, visit [turborepo.com/docs/telemetry](https://turborepo.com/docs/telemetry).
 
 If you'd like to opt out of telemetry, run:
 

--- a/docs/site/content/blog/turbo-1-2-0.mdx
+++ b/docs/site/content/blog/turbo-1-2-0.mdx
@@ -20,7 +20,7 @@ Since releasing Turborepo v1.1 in late January, we've seen incredible adoption a
 - **6.5k+** [GitHub Stars](https://github.com/vercel/turbo)
 - **140k+** weekly npm downloads (doubling since our [last blog post for v1.1](/blog/turbo-1-1-0))
 - **95+** OSS contributors
-- **900+** members of the [Turborepo Community Discord](https://turbo.build/discord)
+- **900+** members of the [Turborepo Community Discord](https://turborepo.com/discord)
 - **1.6 years** of Time Saved through Remote Caching on Vercel, saving more than 2.5 months every week
 
 We've further improved ergonomics, observability, and security with Turborepo v1.2 featuring:
@@ -91,7 +91,7 @@ To enable this feature, set the `remoteCache` options in your `turbo.json` confi
 
 ```jsonc title="./turbo.json"
 {
-  "$schema": "[https://turbo.build/schema.json](https://turbo.build/schema.json)",
+  "$schema": "[https://turborepo.com/schema.json](https://turborepo.com/schema.json)",
   "remoteCache": {
     // Indicates if signature verification is enabled.
     "signature": true

--- a/docs/site/content/blog/turbo-1-3-0.mdx
+++ b/docs/site/content/blog/turbo-1-3-0.mdx
@@ -72,7 +72,7 @@ Let's assume that the Next.js `docs-site` renders the markdown files from the `.
 
 ```jsonc title="./turbo.json"
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "pipeline": {
     // ... omitted for brevity
     "build": {
@@ -126,7 +126,7 @@ A sample pipeline that defines the root script `check-examples` and opts the roo
 
 ```jsonc title="./turbo.json" highlight="20"
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "pipeline": {
     "build": {
       "dependsOn": ["^build"]
@@ -190,7 +190,7 @@ Since releasing [Turborepo v1.2 in early April](/blog/turbo-1-2-0), we've seen i
 
 - [8.1k+ GitHub Stars](https://github.com/vercel/turbo)
 - 275k+ weekly NPM downloads (up ~2x)
-- 1,200+ members of the [Turborepo Community Discord](https://turbo.build/discord)
+- 1,200+ members of the [Turborepo Community Discord](https://turborepo.com/discord)
 - 5.8 years of compute time saved through Remote Caching on Vercel (up ~5x), saving +7 months per week now
 
 Turborepo is the result of the combined work of over 136 contributors including our core team.

--- a/docs/site/content/blog/turbo-1-4-0.mdx
+++ b/docs/site/content/blog/turbo-1-4-0.mdx
@@ -123,7 +123,7 @@ Based on your feedback and suggestions, we've created new examples to integrate 
 
 ## Community
 
-Since releasing [Turborepo v1.3 in June](https://turbo.build/blog/turbo-1-3-0), we've seen incredible adoption and community growth:
+Since releasing [Turborepo v1.3 in June](https://turborepo.com/blog/turbo-1-3-0), we've seen incredible adoption and community growth:
 
 - [8.65k+ GitHub Stars](https://github.com/vercel/turbo)
 - 365k weekly NPM downloads, up 2x since late April

--- a/docs/site/content/blog/turbo-1-7-0.mdx
+++ b/docs/site/content/blog/turbo-1-7-0.mdx
@@ -142,7 +142,7 @@ turbo build --output-logs=errors-only
 
 ## Community
 
-Since releasing [Turborepo v1.6](/blog/turbo-1-6-0) and merging with [Turbopack](https://turbo.build/pack), we've seen incredible adoption and community growth:
+Since releasing [Turborepo v1.6](/blog/turbo-1-6-0) and merging with [Turbopack](https://turborepo.com/pack), we've seen incredible adoption and community growth:
 
 - [18.7k+ GitHub Stars](https://github.com/vercel/turbo)
 - [750k weekly NPM downloads](https://www.npmjs.com/package/turbo)

--- a/docs/site/content/blog/turbo-2-0.mdx
+++ b/docs/site/content/blog/turbo-2-0.mdx
@@ -30,7 +30,7 @@ Visit [the upgrading guide](/docs/crafting-your-repository/upgrading#upgrading-t
 
 ## New terminal UI
 
-In [Turborepo 1.13](https://turbo.build/blog/turbo-1-13-0), we released an experimental interface to learn how a refined terminal UI could improve development velocity. Through [the RFC process](https://github.com/vercel/turbo/discussions/7802), we were able to work with the community on designing a revamped local experience, driven by your feedback. Thank you to those who participated.
+In [Turborepo 1.13](https://turborepo.com/blog/turbo-1-13-0), we released an experimental interface to learn how a refined terminal UI could improve development velocity. Through [the RFC process](https://github.com/vercel/turbo/discussions/7802), we were able to work with the community on designing a revamped local experience, driven by your feedback. Thank you to those who participated.
 
 Today, we’re releasing the new UI as stable, along with the highly requested features that it enables.
 

--- a/docs/site/content/blog/turbo-2-1-0.mdx
+++ b/docs/site/content/blog/turbo-2-1-0.mdx
@@ -107,7 +107,7 @@ turbo ls --affected
 
 ## Terminal UI Improvements
 
-In Turborepo 2.0, we released a [new terminal UI](https://turbo.build/blog/turbo-2-0#new-terminal-ui) to improve clarity for logs and allow for interactive tasks in local development. We heard your feedback, and prioritized polishing this UI, releasing improvements in patches to 2.0 and in this 2.1 release:
+In Turborepo 2.0, we released a [new terminal UI](https://turborepo.com/blog/turbo-2-0#new-terminal-ui) to improve clarity for logs and allow for interactive tasks in local development. We heard your feedback, and prioritized polishing this UI, releasing improvements in patches to 2.0 and in this 2.1 release:
 
 - Highlighting of logs for copying to clipboard ([PR](https://github.com/vercel/turborepo/pull/8713))
 - Search through task list ([PR](https://github.com/vercel/turborepo/pull/9042))

--- a/docs/site/content/blog/turbo-2-4.mdx
+++ b/docs/site/content/blog/turbo-2-4.mdx
@@ -138,7 +138,7 @@ Compare the before and after of the terminal printouts below:
 
 ## `schema.json` in `node_modules`
 
-A `schema.json` file provides auto-complete and validation in your editor for JSON files. We have a web-accessible version of the `schema.json` for `turbo.json` hosted at [`https://turbo.build/schema.json`](https://turbo.build/schema.json), but some developers prefer to get the file from `node_modules` to stay synced with the installed version of `turbo`.
+A `schema.json` file provides auto-complete and validation in your editor for JSON files. We have a web-accessible version of the `schema.json` for `turbo.json` hosted at [`https://turborepo.com/schema.json`](https://turborepo.com/schema.json), but some developers prefer to get the file from `node_modules` to stay synced with the installed version of `turbo`.
 
 Starting in this release, `schema.json` is available in `node_modules` once you've run your package manager's install command:
 

--- a/docs/site/content/blog/turbo-2-5.mdx
+++ b/docs/site/content/blog/turbo-2-5.mdx
@@ -137,7 +137,7 @@ Now, this file glob is guaranteed to always start at the root of your workspace.
 
 Turborepo is proudly open-source with a public specification for its Remote Caching protocol. While [Vercel Remote Cache is a free-to-use managed option](https://vercel.com/docs/monorepos/remote-caching), the OpenAPI spec allows the community to create implementations for Remote Caching of their own.
 
-We’ve published [the Remote Cache spec as JSON to the web](/api/remote-cache-spec) for some time, and have recently added a human-friendly version of the spec at [https://turbo.build/docs/openapi](https://turbo.build/docs/openapi).
+We’ve published [the Remote Cache spec as JSON to the web](/api/remote-cache-spec) for some time, and have recently added a human-friendly version of the spec at [https://turborepo.com/docs/openapi](https://turborepo.com/docs/openapi).
 
 [Visit the Remote Caching documentation](/docs/core-concepts/remote-caching#remote-cache-api) to learn more.
 

--- a/docs/site/content/blog/you-might-not-need-typescript-project-references.mdx
+++ b/docs/site/content/blog/you-might-not-need-typescript-project-references.mdx
@@ -97,4 +97,4 @@ As previously mentioned, this pattern actually has very little to do with Turbor
 
 ## Speaking of long build times...
 
-Shameless plug here. If you are reading this post, and you're struggling with slow build and test times, I'd love to show you how Turborepo can help. I guarantee that Turborepo will cut your monorepo's build time by 50% or more. [You can request a live demo right here.](https://vercel.com/contact/sales?utm_source=turbo.build&utm_medium=referral&utm_campaign=blog-project-references)
+Shameless plug here. If you are reading this post, and you're struggling with slow build and test times, I'd love to show you how Turborepo can help. I guarantee that Turborepo will cut your monorepo's build time by 50% or more. [You can request a live demo right here.](https://vercel.com/contact/sales?utm_source=turborepo.com&utm_medium=referral&utm_campaign=blog-project-references)

--- a/docs/site/content/docs/core-concepts/remote-caching.mdx
+++ b/docs/site/content/docs/core-concepts/remote-caching.mdx
@@ -63,7 +63,7 @@ What if you could share a single Turborepo cache across your entire team (and ev
 
 Turborepo can securely communicate with a remote cache - a cloud server that stores the results of your tasks. This can save enormous amounts of time by **preventing duplicated work across your entire organization**.
 
-Remote Caching is free and can be used with both [managed providers](https://turbo.build/docs/core-concepts/remote-caching#managed-remote-cache-with-vercel) or as a [self-hosted cache](https://turbo.build/docs/core-concepts/remote-caching#self-hosting).
+Remote Caching is free and can be used with both [managed providers](https://turborepo.com/docs/core-concepts/remote-caching#managed-remote-cache-with-vercel) or as a [self-hosted cache](https://turborepo.com/docs/core-concepts/remote-caching#self-hosting).
 
 <Callout>
   Remote Caching is a powerful feature of Turborepo, but, with great power,
@@ -161,7 +161,7 @@ Then, run the same build again. If things are working properly, `turbo` should n
 
 ### Remote Caching on Vercel
 
-If you are building and hosting your apps on Vercel, Remote Caching will be automatically set up on your behalf once you use `turbo`. Refer to the [Vercel documentation](https://vercel.com/docs/concepts/monorepos/remote-caching?utm_source=turbo.build&utm_medium=referral&utm_campaign=docs-link) for more information.
+If you are building and hosting your apps on Vercel, Remote Caching will be automatically set up on your behalf once you use `turbo`. Refer to the [Vercel documentation](https://vercel.com/docs/concepts/monorepos/remote-caching?utm_source=turborepo.com&utm_medium=referral&utm_campaign=docs-link) for more information.
 
 ### Artifact Integrity and Authenticity Verification
 

--- a/docs/site/content/docs/getting-started/add-to-existing-repository.mdx
+++ b/docs/site/content/docs/getting-started/add-to-existing-repository.mdx
@@ -91,7 +91,7 @@ We'll be using `build` and `check-types` tasks in this guide but you can replace
   <Tab value="Next.js">
 ```json title="./turbo.json"
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
@@ -124,7 +124,7 @@ In your Next.js application, make sure you have a `check-types` script for `turb
   <Tab value="Vite">
 ```json title="./turbo.json"
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "outputs": ["dist/**"]

--- a/docs/site/content/docs/getting-started/editor-integration.mdx
+++ b/docs/site/content/docs/getting-started/editor-integration.mdx
@@ -19,15 +19,15 @@ A `schema.json` is accessible at the URL shown below. This has the advantage of 
 
 ```json title="./turbo.json"
 {
-  "$schema": "https://turbo.build/schema.json"
+  "$schema": "https://turborepo.com/schema.json"
 }
 ```
 
-There is also a major versioned `schema.json` available, following the format of `https://turbo.build/schema.<version>.json`.
+There is also a major versioned `schema.json` available, following the format of `https://turborepo.com/schema.<version>.json`.
 
 ```json title="./turbo.json"
 {
-  "$schema": "https://turbo.build/schema.v1.json"
+  "$schema": "https://turborepo.com/schema.v1.json"
 }
 ```
 

--- a/docs/site/content/docs/guides/ci-vendors/circleci.mdx
+++ b/docs/site/content/docs/guides/ci-vendors/circleci.mdx
@@ -34,7 +34,7 @@ And a `turbo.json`:
 
 ```json title="./turbo.json"
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "outputs": [".next/**", "!.next/cache/**"],

--- a/docs/site/content/docs/guides/ci-vendors/github-actions.mdx
+++ b/docs/site/content/docs/guides/ci-vendors/github-actions.mdx
@@ -28,7 +28,7 @@ And a `turbo.json`:
 
 ```json title="./turbo.json"
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "outputs": [".next/**", "!.next/cache/**", "other-output-dirs/**"],

--- a/docs/site/content/docs/guides/ci-vendors/gitlab-ci.mdx
+++ b/docs/site/content/docs/guides/ci-vendors/gitlab-ci.mdx
@@ -26,7 +26,7 @@ And a `turbo.json`:
 
 ```json title="./turbo.json"
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "outputs": [".svelte-kit/**"],

--- a/docs/site/content/docs/guides/ci-vendors/travis-ci.mdx
+++ b/docs/site/content/docs/guides/ci-vendors/travis-ci.mdx
@@ -26,7 +26,7 @@ And a `turbo.json`:
 
 ```json title="./turbo.json"
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "outputs": [".svelte-kit/**"],

--- a/docs/site/content/docs/guides/single-package-workspaces.mdx
+++ b/docs/site/content/docs/guides/single-package-workspaces.mdx
@@ -92,7 +92,7 @@ Then, create tasks in `turbo.json` to run these scripts in order:
 
 ```json title="./turbo.json"
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "dev": {
       "dependsOn": ["db:seed"],
@@ -134,7 +134,7 @@ You can create a configuration like this one:
 
 ```json title="turbo.json"
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "lint": {},
     "format": {},
@@ -157,7 +157,7 @@ For instance, a script for checking types using `tsc --noEmit` can be configured
 
 ```json title="./turbo.json"
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "check-types": {
       "inputs": ["**/*.{ts,tsx}"]

--- a/docs/site/content/docs/guides/skipping-tasks.mdx
+++ b/docs/site/content/docs/guides/skipping-tasks.mdx
@@ -7,7 +7,7 @@ import { Callout } from '#/components/callout';
 
 [Caching](/docs/crafting-your-repository/caching) dramatically speeds up your tasks - but you may be able to go even faster by using `npx turbo-ignore`. If a workspace is unaffected by your code changes, you can completely skip executing a task altogether.
 
-Let's say you want to skip the unit tests for your `web` workspace when there aren't any changes to your `web` application (or its package dependencies). If you are already using [Remote Caching](https://turbo.build/docs/core-concepts/remote-caching), you will probably get a cache hit - but you would still spend time provisioning the CI container, installing `npm` dependencies, and other things that can take a while.
+Let's say you want to skip the unit tests for your `web` workspace when there aren't any changes to your `web` application (or its package dependencies). If you are already using [Remote Caching](https://turborepo.com/docs/core-concepts/remote-caching), you will probably get a cache hit - but you would still spend time provisioning the CI container, installing `npm` dependencies, and other things that can take a while.
 
 Ideally, you would do a quick check to see if any of that work needs to happen in the first place.
 

--- a/docs/site/content/docs/guides/tools/typescript.mdx
+++ b/docs/site/content/docs/guides/tools/typescript.mdx
@@ -269,11 +269,11 @@ With these two files in place, your editor will now navigate to the original sou
 
 ### Use Node.js subpath imports instead of TypeScript compiler `paths`
 
-It's possible to create absolute imports in your packages using [the TypeScript compiler's `paths` option](https://www.typescriptlang.org/tsconfig#paths), but these paths can cause failed compilation when using [Just-in-Time Packages](https://turbo.build/docs/core-concepts/internal-packages#just-in-time-packages). [As of TypeScript 5.4](https://devblogs.microsoft.com/typescript/announcing-typescript-5-4/#auto-import-support-for-subpath-imports), you can use [Node.js subpath imports](https://nodejs.org/api/packages.html#imports) instead for a more robust solution.
+It's possible to create absolute imports in your packages using [the TypeScript compiler's `paths` option](https://www.typescriptlang.org/tsconfig#paths), but these paths can cause failed compilation when using [Just-in-Time Packages](https://turborepo.com/docs/core-concepts/internal-packages#just-in-time-packages). [As of TypeScript 5.4](https://devblogs.microsoft.com/typescript/announcing-typescript-5-4/#auto-import-support-for-subpath-imports), you can use [Node.js subpath imports](https://nodejs.org/api/packages.html#imports) instead for a more robust solution.
 
 #### Just-in-Time Packages
 
-In [Just-in-Time packages](https://turbo.build/docs/core-concepts/internal-packages#just-in-time-packages), `imports` must target the source code in the package, since build outputs like `dist` won't be created.
+In [Just-in-Time packages](https://turborepo.com/docs/core-concepts/internal-packages#just-in-time-packages), `imports` must target the source code in the package, since build outputs like `dist` won't be created.
 
 <Tabs storageKey="ts-imports-jit" items={["package.json", "Source code"]}>
   <Tab value="package.json">
@@ -301,7 +301,7 @@ export const Button = () => {
 
 #### Compiled Packages
 
-In [Compiled packages](https://turbo.build/docs/core-concepts/internal-packages#compiled-packages), `imports` target the built outputs for the package.
+In [Compiled packages](https://turborepo.com/docs/core-concepts/internal-packages#compiled-packages), `imports` target the built outputs for the package.
 
 <Tabs storageKey="ts-imports-compiled" items={["package.json", "Source code"]}>
   <Tab value="package.json">

--- a/docs/site/content/docs/messages/recursive-turbo-invocations.mdx
+++ b/docs/site/content/docs/messages/recursive-turbo-invocations.mdx
@@ -5,7 +5,7 @@ description: Learn more about errors with recursive scripts and tasks in Turbore
 
 ## Why this error occurred
 
-When a cycle of `turbo` invocations is detected in a [single-package workspace](https://turbo.build/docs/guides/single-package-workspaces), Turborepo will error to prevent the recursive calls to itself. Typically, this situation occurs for one of two reasons:
+When a cycle of `turbo` invocations is detected in a [single-package workspace](https://turborepo.com/docs/guides/single-package-workspaces), Turborepo will error to prevent the recursive calls to itself. Typically, this situation occurs for one of two reasons:
 
 ### Recursion in scripts and tasks
 
@@ -35,6 +35,6 @@ To resolve this, ensure that the name of the script in `package.json` is not the
 
 A misconfigured workspace can make it appear that a [multi-package workspace](https://vercel.com/docs/vercel-platform/glossary#multi-package-workspace) is a single-package workspace. This causes Turborepo to infer that the repository is of the wrong type, causing it to see the script in `package.json` to be recursive.
 
-Your repo can end up in this state in a few ways, with the most common being that the [packages are not defined according to your package manager](https://turbo.build/docs/crafting-your-repository/structuring-a-repository#specifying-packages-in-a-monorepo). An npm workspace that is missing the `workspaces` field in `package.json` or a pnpm workspace that is missing a `pnpm-workspace.yaml` file can result in this error message.
+Your repo can end up in this state in a few ways, with the most common being that the [packages are not defined according to your package manager](https://turborepo.com/docs/crafting-your-repository/structuring-a-repository#specifying-packages-in-a-monorepo). An npm workspace that is missing the `workspaces` field in `package.json` or a pnpm workspace that is missing a `pnpm-workspace.yaml` file can result in this error message.
 
 Check that your repository is complying with standards for multi-package workspaces and correct any issues.

--- a/docs/site/content/docs/reference/configuration.mdx
+++ b/docs/site/content/docs/reference/configuration.mdx
@@ -111,7 +111,7 @@ Set/limit the maximum concurrency for task execution. Must be an integer greater
 
 Default: `false`
 
-Turborepo uses your repository's lockfile to determine caching behavior, [Package Graphs](https://turbo.build/docs/core-concepts/internal-packages), and more. Because of this, we use [the `packageManager` field](https://nodejs.org/api/packages.html#packagemanager) to help you stabilize your Turborepo.
+Turborepo uses your repository's lockfile to determine caching behavior, [Package Graphs](https://turborepo.com/docs/core-concepts/internal-packages), and more. Because of this, we use [the `packageManager` field](https://nodejs.org/api/packages.html#packagemanager) to help you stabilize your Turborepo.
 
 To help with incremental migration or in situations where you can't use the `packageManager` field, you may use `--dangerously-disable-package-manager-check` to opt out of this check and assume the risks of unstable lockfiles producing unpredictable behavior. When disabled, Turborepo will attempt a best-effort discovery of the intended package manager meant for the repository.
 
@@ -125,7 +125,7 @@ To help with incremental migration or in situations where you can't use the `pac
   You may also opt out of this check via
   [`flag`](/docs/reference/run#--dangerously-disable-package-manager-check) or
   the
-  [`TURBO_DANGEROUSLY_DISABLE_PACKAGE_MANAGER_CHECK`](https://turbo.build/docs/reference/system-environment-variables)
+  [`TURBO_DANGEROUSLY_DISABLE_PACKAGE_MANAGER_CHECK`](https://turborepo.com/docs/reference/system-environment-variables)
   environment variable.
 </Callout>
 
@@ -199,7 +199,7 @@ In the example below, we've defined three tasks under the `tasks` key: `build`, 
 
 ```jsonc title="./turbo.json"
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],

--- a/docs/site/content/docs/reference/run.mdx
+++ b/docs/site/content/docs/reference/run.mdx
@@ -153,7 +153,7 @@ turbo run build --cwd=./somewhere/else/in/your/repo
 
 ### `--dangerously-disable-package-manager-check`
 
-Turborepo uses your repository's lockfile to determine caching behavior, [Package Graphs](https://turbo.build/docs/core-concepts/internal-packages), and more. Because of this, we use [the `packageManager` field](https://nodejs.org/api/packages.html#packagemanager) to help you stabilize your Turborepo.
+Turborepo uses your repository's lockfile to determine caching behavior, [Package Graphs](https://turborepo.com/docs/core-concepts/internal-packages), and more. Because of this, we use [the `packageManager` field](https://nodejs.org/api/packages.html#packagemanager) to help you stabilize your Turborepo.
 
 To help with incremental migration or in situations where you cannot use the `packageManager` field, you may use `--dangerously-disable-package-manager-check` to opt out of this check and assume the risks of unstable lockfiles producing unpredictable behavior. When disabled, Turborepo will attempt a best-effort discovery of the intended package manager meant for the repository.
 
@@ -366,7 +366,7 @@ Default: `auto`
 
 Set the ordering for log output.
 
-By default, `turbo` will use `grouped` logs in CI environments and `stream` logs everywhere else. This flag is not applicable when using [the terminal UI](https://turbo.build/docs/reference/configuration#ui).
+By default, `turbo` will use `grouped` logs in CI environments and `stream` logs everywhere else. This flag is not applicable when using [the terminal UI](https://turborepo.com/docs/reference/configuration#ui).
 
 ```bash title="Terminal"
 turbo run build --log-order=stream
@@ -447,7 +447,7 @@ Given this `turbo.json`:
 
 ```json title="./turbo.json"
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"]

--- a/docs/site/content/docs/reference/turbo-codemod.mdx
+++ b/docs/site/content/docs/reference/turbo-codemod.mdx
@@ -52,8 +52,8 @@ npx @turbo/codemod update-schema-json-url
 
 ```diff title="./turbo.json"
 {
-- "$schema": "https://turbo.build/schema.v1.json",
-+ "$schema": "https://turbo.build/schema.v2.json",
+- "$schema": "https://turborepo.com/schema.v1.json",
++ "$schema": "https://turborepo.com/schema.v2.json",
 }
 ```
 
@@ -224,7 +224,7 @@ npx @turbo/codemod stabilize-env-mode
 
 ```diff title="./turbo.json"
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
 - "experimentalGlobalPassThroughEnv": ["CC"],
 + "globalPassThroughEnv": ["CC"],
   "pipeline": {
@@ -249,7 +249,7 @@ npx @turbo/codemod transform-env-literals-to-wildcards
 
 ```diff title="./turbo.json"
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
 - "globalEnv": ["THIS_*_IS_LITERAL"],
 - "globalPassThroughEnv": ["!LITERAL_LEADING_EXCLAMATION"],
 +  "globalEnv": ["THIS_\\*_IS_LITERAL"],
@@ -278,7 +278,7 @@ npx @turbo/codemod set-default-outputs
 
 ```diff title="turbo.json"
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": [".env"],
   "globalEnv": ["CI_ENV"],
   "pipeline": {
@@ -316,7 +316,7 @@ npx @turbo/codemod migrate-env-var-dependencies
 ```diff title="./turbo.json"
 // After, turbo.json
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
 - "globalDependencies": [".env", "$CI_ENV"],
 + "globalDependencies": [".env"],
 + "globalEnv": ["CI_ENV"],
@@ -390,7 +390,7 @@ npx @turbo/codemod create-turbo-config
 <Tab value="turbo.json">
 ```diff title="./turbo.json"
 + {
-+   "$schema": "https://turbo.build/schema.json",
++   "$schema": "https://turborepo.com/schema.json",
 +   "pipeline": {
 +     ...
 +   }

--- a/docs/site/lib/constants.ts
+++ b/docs/site/lib/constants.ts
@@ -5,5 +5,5 @@ export const PRODUCT_SLOGANS = {
 } as const;
 
 export const gitHubRepoUrl = "https://github.com/vercel/turborepo";
-export const PRODUCT_DOMAIN = "turbo.build";
+export const PRODUCT_DOMAIN = "turborepo.com";
 export const PREVIEW_DOMAIN_SUFFIX = "vercel.sh";

--- a/docs/site/lib/nav-links.tsx
+++ b/docs/site/lib/nav-links.tsx
@@ -10,7 +10,7 @@ export const navLinks: LinkItemType[] = [
   { url: "/blog", text: "Blog", icon: <BookOpenIcon /> },
   { url: "/showcase", text: "Showcase", icon: <StarIcon /> },
   {
-    url: "https://vercel.com/contact/sales?utm_source=turbo.build&utm_medium=referral&utm_campaign=header-enterpriseLink",
+    url: "https://vercel.com/contact/sales?utm_source=turborepo.com&utm_medium=referral&utm_campaign=header-enterpriseLink",
     text: "Enterprise",
     icon: <ExternalLinkIcon />,
   },

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -34,7 +34,6 @@
     "@vercel/speed-insights": "1.2.0",
     "algoliasearch": "^4.23.3",
     "class-variance-authority": "^0.7.1",
-    "classnames": "^2.5.1",
     "clsx": "^2.1.1",
     "copy-to-clipboard": "^3.3.3",
     "fast-glob": "^3.3.2",

--- a/docs/site/scripts/generate-docs.mjs
+++ b/docs/site/scripts/generate-docs.mjs
@@ -11,7 +11,7 @@
 //
 // You can verify differences for the specs by comparing:
 // Vercel Remote Cache: https://vercel.com/docs/rest-api/reference/endpoints/artifacts/record-an-artifacts-cache-usage-event
-// Self-hosted: https://turbo.build/api/remote-cache-spec
+// Self-hosted: https://turborepo.com/api/remote-cache-spec
 
 import { writeFileSync } from "node:fs";
 import { generateFiles } from "fumadocs-openapi";
@@ -126,7 +126,7 @@ const updateServerDescription = (spec) => {
   }
 };
 
-const thing = await fetch("https://turbo.build/api/remote-cache-spec")
+const thing = await fetch("https://turborepo.com/api/remote-cache-spec")
   .then((res) => res.json())
   .then((json) => removeExamples(json))
   .then((json) => removeBillingRelated403Responses(json))

--- a/docs/site/scripts/generate-rss.cjs
+++ b/docs/site/scripts/generate-rss.cjs
@@ -15,9 +15,9 @@ async function generate() {
   const feed = new RSS({
     title: "Turborepo Blog",
     description: "Turborepo news, updates, and announcements.",
-    site_url: "https://turbo.build",
-    feed_url: "https://turbo.build/feed.xml",
-    image_url: "https://turbo.build/api/og",
+    site_url: "https://turborepo.com",
+    feed_url: "https://turborepo.com/feed.xml",
+    image_url: "https://turborepo.com/api/og",
   });
 
   const posts = await fs.readdir(path.join(__dirname, "..", "content", "blog"));
@@ -45,11 +45,11 @@ async function generate() {
     );
     feed.item({
       title: frontmatter.data.title,
-      url: `https://turbo.build/blog/${frontmatter.slug}`, // intentionally including slash here
+      url: `https://turborepo.com/blog/${frontmatter.slug}`, // intentionally including slash here
       date: frontmatter.data.date,
       description: frontmatter.data.description,
       enclosure: {
-        url: `https://turbo.build${frontmatter.data.ogImage}`, // intentionally omitting slash here
+        url: `https://turborepo.com${frontmatter.data.ogImage}`, // intentionally omitting slash here
         type: "image/png",
         size: stat.size,
       },

--- a/docs/site/turbo.json
+++ b/docs/site/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "tasks": {
     "build": {

--- a/docs/site/turbo/generators/config.ts
+++ b/docs/site/turbo/generators/config.ts
@@ -10,7 +10,7 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
 
   // create generators
   plop.setGenerator("blog - release post", {
-    description: "Add a new release post to the turbo.build blog",
+    description: "Add a new release post to the turborepo.com blog",
     prompts: [
       {
         type: "input",

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -55,7 +55,7 @@ pnpm dev
 > [!TIP]
 > Vercel Remote Cache is free for all plans. Get started today at [vercel.com](https://vercel.com/signup?/signup?utm_source=remote-cache-sdk&utm_campaign=free_remote_cache).
 
-Turborepo can use a technique known as [Remote Caching](https://turbo.build/docs/core-concepts/remote-caching) to share cache artifacts across machines, enabling you to share build caches with your team and CI/CD pipelines.
+Turborepo can use a technique known as [Remote Caching](https://turborepo.com/docs/core-concepts/remote-caching) to share cache artifacts across machines, enabling you to share build caches with your team and CI/CD pipelines.
 
 By default, Turborepo will cache locally. To enable Remote Caching you will need an account with Vercel. If you don't have an account you can [create one](https://vercel.com/signup?utm_source=turborepo-examples), then enter the following commands:
 
@@ -76,9 +76,9 @@ npx turbo link
 
 Learn more about the power of Turborepo:
 
-- [Tasks](https://turbo.build/docs/core-concepts/monorepos/running-tasks)
-- [Caching](https://turbo.build/docs/core-concepts/caching)
-- [Remote Caching](https://turbo.build/docs/core-concepts/remote-caching)
-- [Filtering](https://turbo.build/docs/core-concepts/monorepos/filtering)
-- [Configuration Options](https://turbo.build/docs/reference/configuration)
-- [CLI Usage](https://turbo.build/docs/reference/command-line-reference)
+- [Tasks](https://turborepo.com/docs/core-concepts/monorepos/running-tasks)
+- [Caching](https://turborepo.com/docs/core-concepts/caching)
+- [Remote Caching](https://turborepo.com/docs/core-concepts/remote-caching)
+- [Filtering](https://turborepo.com/docs/core-concepts/monorepos/filtering)
+- [Configuration Options](https://turborepo.com/docs/reference/configuration)
+- [CLI Usage](https://turborepo.com/docs/reference/command-line-reference)

--- a/examples/basic/apps/docs/app/page.tsx
+++ b/examples/basic/apps/docs/app/page.tsx
@@ -55,7 +55,7 @@ export default function Home() {
             Deploy now
           </a>
           <a
-            href="https://turbo.build/docs?utm_source"
+            href="https://turborepo.com/docs?utm_source"
             target="_blank"
             rel="noopener noreferrer"
             className={styles.secondary}
@@ -83,7 +83,7 @@ export default function Home() {
           Examples
         </a>
         <a
-          href="https://turbo.build?utm_source=create-turbo"
+          href="https://turborepo.com?utm_source=create-turbo"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -94,7 +94,7 @@ export default function Home() {
             width={16}
             height={16}
           />
-          Go to turbo.build →
+          Go to turborepo.com →
         </a>
       </footer>
     </div>

--- a/examples/basic/apps/web/app/page.tsx
+++ b/examples/basic/apps/web/app/page.tsx
@@ -55,7 +55,7 @@ export default function Home() {
             Deploy now
           </a>
           <a
-            href="https://turbo.build/docs?utm_source"
+            href="https://turborepo.com/docs?utm_source"
             target="_blank"
             rel="noopener noreferrer"
             className={styles.secondary}
@@ -83,7 +83,7 @@ export default function Home() {
           Examples
         </a>
         <a
-          href="https://turbo.build?utm_source=create-turbo"
+          href="https://turborepo.com?utm_source=create-turbo"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -94,7 +94,7 @@ export default function Home() {
             width={16}
             height={16}
           />
-          Go to turbo.build →
+          Go to turborepo.com →
         </a>
       </footer>
     </div>

--- a/examples/basic/packages/ui/turbo/generators/config.ts
+++ b/examples/basic/packages/ui/turbo/generators/config.ts
@@ -1,6 +1,6 @@
 import type { PlopTypes } from "@turbo/gen";
 
-// Learn more about Turborepo Generators at https://turbo.build/docs/guides/generating-code
+// Learn more about Turborepo Generators at https://turborepo.com/docs/guides/generating-code
 
 export default function generator(plop: PlopTypes.NodePlopAPI): void {
   // A simple generator to add a new React component to the internal UI library

--- a/examples/basic/turbo.json
+++ b/examples/basic/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "ui": "tui",
   "tasks": {
     "build": {

--- a/examples/design-system/README.md
+++ b/examples/design-system/README.md
@@ -4,7 +4,7 @@ This is a community-maintained example. If you experience a problem, please subm
 
 This guide explains how to use a React design system starter powered by:
 
-- 🏎 [Turborepo](https://turbo.build/repo) — High-performance build system for Monorepos
+- 🏎 [Turborepo](https://turborepo.com/repo) — High-performance build system for Monorepos
 - 🚀 [React](https://reactjs.org/) — JavaScript library for user interfaces
 - 🛠 [Tsup](https://github.com/egoist/tsup) — TypeScript bundler powered by esbuild
 - 📖 [Storybook](https://storybook.js.org/) — UI component environment powered by Vite
@@ -35,7 +35,7 @@ npx create-turbo@latest -e design-system
 
 ## Turborepo
 
-[Turborepo](https://turbo.build/repo) is a high-performance build system for JavaScript and TypeScript codebases. It was designed after the workflows used by massive software engineering organizations to ship code at scale. Turborepo abstracts the complex configuration needed for monorepos and provides fast, incremental builds with zero-configuration remote caching.
+[Turborepo](https://turborepo.com/repo) is a high-performance build system for JavaScript and TypeScript codebases. It was designed after the workflows used by massive software engineering organizations to ship code at scale. Turborepo abstracts the complex configuration needed for monorepos and provides fast, incremental builds with zero-configuration remote caching.
 
 Using Turborepo simplifies managing your design system monorepo, as you can have a single lint, build, test, and release process for all packages. [Learn more](https://vercel.com/blog/monorepos-are-changing-how-teams-build-software) about how monorepos improve your development workflow.
 

--- a/examples/design-system/turbo.json
+++ b/examples/design-system/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "inputs": ["$TURBO_DEFAULT$", ".env*"],

--- a/examples/kitchen-sink/README.md
+++ b/examples/kitchen-sink/README.md
@@ -2,7 +2,7 @@
 
 This Turborepo starter is maintained by the Turborepo core team.
 
-This example also shows how to use [Workspace Configurations](https://turbo.build/docs/core-concepts/monorepos/configuring-workspaces).
+This example also shows how to use [Workspace Configurations](https://turborepo.com/docs/core-concepts/monorepos/configuring-workspaces).
 
 ## Using this example
 

--- a/examples/kitchen-sink/apps/admin/src/app/index.tsx
+++ b/examples/kitchen-sink/apps/admin/src/app/index.tsx
@@ -12,7 +12,7 @@ function App() {
       <CounterButton />
       <p className="description">
         Built With{" "}
-        <Link href="https://turbo.build/repo" newTab>
+        <Link href="https://turborepo.com/repo" newTab>
           Turborepo
         </Link>
         {" & "}

--- a/examples/kitchen-sink/apps/blog/app/routes/_index.tsx
+++ b/examples/kitchen-sink/apps/blog/app/routes/_index.tsx
@@ -10,7 +10,7 @@ export default function Index() {
       </h1>
       <CounterButton />
       <p className="description">
-        Built With <Link href="https://turbo.build/repo">Turborepo</Link>
+        Built With <Link href="https://turborepo.com/repo">Turborepo</Link>
         {" & "}
         <Link href="https://remix.run/">Remix</Link>
       </p>

--- a/examples/kitchen-sink/apps/storefront/src/app/page.tsx
+++ b/examples/kitchen-sink/apps/storefront/src/app/page.tsx
@@ -18,7 +18,7 @@ export default function Store() {
       <CounterButton />
       <p className="description">
         Built With{" "}
-        <Link href="https://turbo.build/repo" newTab>
+        <Link href="https://turborepo.com/repo" newTab>
           Turborepo
         </Link>
         {" & "}

--- a/examples/kitchen-sink/packages/ui/src/link/index.test.tsx
+++ b/examples/kitchen-sink/packages/ui/src/link/index.test.tsx
@@ -6,7 +6,7 @@ describe("Link", () => {
   it("renders without crashing", () => {
     const div = document.createElement("div");
     const root = createRoot(div);
-    root.render(<Link href="https://turbo.build/repo">Turborepo Docs</Link>);
+    root.render(<Link href="https://turborepo.com/repo">Turborepo Docs</Link>);
     root.unmount();
   });
 });

--- a/examples/kitchen-sink/turbo.json
+++ b/examples/kitchen-sink/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "ui": "tui",
   "tasks": {
     "build": {

--- a/examples/non-monorepo/README.md
+++ b/examples/non-monorepo/README.md
@@ -46,9 +46,9 @@ pnpm turbo dev
 
 Learn more about the power of Turborepo:
 
-- [Tasks](https://turbo.build/docs/core-concepts/monorepos/running-tasks)
-- [Caching](https://turbo.build/docs/core-concepts/caching)
-- [Remote Caching](https://turbo.build/docs/core-concepts/remote-caching)
-- [Filtering](https://turbo.build/docs/core-concepts/monorepos/filtering)
-- [Configuration Options](https://turbo.build/docs/reference/configuration)
-- [CLI Usage](https://turbo.build/docs/reference/command-line-reference)
+- [Tasks](https://turborepo.com/docs/core-concepts/monorepos/running-tasks)
+- [Caching](https://turborepo.com/docs/core-concepts/caching)
+- [Remote Caching](https://turborepo.com/docs/core-concepts/remote-caching)
+- [Filtering](https://turborepo.com/docs/core-concepts/monorepos/filtering)
+- [Configuration Options](https://turborepo.com/docs/reference/configuration)
+- [CLI Usage](https://turborepo.com/docs/reference/command-line-reference)

--- a/examples/non-monorepo/turbo.json
+++ b/examples/non-monorepo/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "ui": "tui",
   "tasks": {
     "build": {

--- a/examples/with-angular/turbo.json
+++ b/examples/with-angular/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["**/.env.*local"],
   "tasks": {
     "build": {

--- a/examples/with-berry/README.md
+++ b/examples/with-berry/README.md
@@ -55,7 +55,7 @@ yarn dev
 > [!TIP]
 > Vercel Remote Cache is free for all plans. Get started today at [vercel.com](https://vercel.com/signup?/signup?utm_source=remote-cache-sdk&utm_campaign=free_remote_cache).
 
-Turborepo can use a technique known as [Remote Caching](https://turbo.build/docs/core-concepts/remote-caching) to share cache artifacts across machines, enabling you to share build caches with your team and CI/CD pipelines.
+Turborepo can use a technique known as [Remote Caching](https://turborepo.com/docs/core-concepts/remote-caching) to share cache artifacts across machines, enabling you to share build caches with your team and CI/CD pipelines.
 
 By default, Turborepo will cache locally. To enable Remote Caching you will need an account with Vercel. If you don't have an account you can [create one](https://vercel.com/signup?utm_source=turborepo-examples), then enter the following commands:
 
@@ -76,9 +76,9 @@ npx turbo link
 
 Learn more about the power of Turborepo:
 
-- [Tasks](https://turbo.build/docs/core-concepts/monorepos/running-tasks)
-- [Caching](https://turbo.build/docs/core-concepts/caching)
-- [Remote Caching](https://turbo.build/docs/core-concepts/remote-caching)
-- [Filtering](https://turbo.build/docs/core-concepts/monorepos/filtering)
-- [Configuration Options](https://turbo.build/docs/reference/configuration)
-- [CLI Usage](https://turbo.build/docs/reference/command-line-reference)
+- [Tasks](https://turborepo.com/docs/core-concepts/monorepos/running-tasks)
+- [Caching](https://turborepo.com/docs/core-concepts/caching)
+- [Remote Caching](https://turborepo.com/docs/core-concepts/remote-caching)
+- [Filtering](https://turborepo.com/docs/core-concepts/monorepos/filtering)
+- [Configuration Options](https://turborepo.com/docs/reference/configuration)
+- [CLI Usage](https://turborepo.com/docs/reference/command-line-reference)

--- a/examples/with-berry/turbo.json
+++ b/examples/with-berry/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],

--- a/examples/with-changesets/turbo.json
+++ b/examples/with-changesets/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "inputs": ["$TURBO_DEFAULT$", ".env*"],

--- a/examples/with-docker/turbo.json
+++ b/examples/with-docker/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "inputs": ["$TURBO_DEFAULT$", ".env*"],

--- a/examples/with-gatsby/README.md
+++ b/examples/with-gatsby/README.md
@@ -55,7 +55,7 @@ pnpm dev
 > [!TIP]
 > Vercel Remote Cache is free for all plans. Get started today at [vercel.com](https://vercel.com/signup?/signup?utm_source=remote-cache-sdk&utm_campaign=free_remote_cache).
 
-Turborepo can use a technique known as [Remote Caching](https://turbo.build/docs/core-concepts/remote-caching) to share cache artifacts across machines, enabling you to share build caches with your team and CI/CD pipelines.
+Turborepo can use a technique known as [Remote Caching](https://turborepo.com/docs/core-concepts/remote-caching) to share cache artifacts across machines, enabling you to share build caches with your team and CI/CD pipelines.
 
 By default, Turborepo will cache locally. To enable Remote Caching you will need an account with Vercel. If you don't have an account you can [create one](https://vercel.com/signup?utm_source=turborepo-examples), then enter the following commands:
 
@@ -76,9 +76,9 @@ pnpm dlx turbo link
 
 Learn more about the power of Turborepo:
 
-- [Tasks](https://turbo.build/docs/core-concepts/monorepos/running-tasks)
-- [Caching](https://turbo.build/docs/core-concepts/caching)
-- [Remote Caching](https://turbo.build/docs/core-concepts/remote-caching)
-- [Filtering](https://turbo.build/docs/core-concepts/monorepos/filtering)
-- [Configuration Options](https://turbo.build/docs/reference/configuration)
-- [CLI Usage](https://turbo.build/docs/reference/command-line-reference)
+- [Tasks](https://turborepo.com/docs/core-concepts/monorepos/running-tasks)
+- [Caching](https://turborepo.com/docs/core-concepts/caching)
+- [Remote Caching](https://turborepo.com/docs/core-concepts/remote-caching)
+- [Filtering](https://turborepo.com/docs/core-concepts/monorepos/filtering)
+- [Configuration Options](https://turborepo.com/docs/reference/configuration)
+- [CLI Usage](https://turborepo.com/docs/reference/command-line-reference)

--- a/examples/with-gatsby/apps/docs/turbo.json
+++ b/examples/with-gatsby/apps/docs/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": [
     "//"
   ],

--- a/examples/with-gatsby/apps/web/turbo.json
+++ b/examples/with-gatsby/apps/web/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": [
     "//"
   ],

--- a/examples/with-gatsby/turbo.json
+++ b/examples/with-gatsby/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "inputs": ["$TURBO_DEFAULT$", ".env*"],

--- a/examples/with-nestjs/README.md
+++ b/examples/with-nestjs/README.md
@@ -92,7 +92,7 @@ pnpm format
 > [!TIP]
 > Vercel Remote Cache is free for all plans. Get started today at [vercel.com](https://vercel.com/signup?/signup?utm_source=remote-cache-sdk&utm_campaign=free_remote_cache).
 
-Turborepo can use a technique known as [Remote Caching](https://turbo.build/docs/core-concepts/remote-caching) to share cache artifacts across machines, enabling you to share build caches with your team and CI/CD pipelines.
+Turborepo can use a technique known as [Remote Caching](https://turborepo.com/docs/core-concepts/remote-caching) to share cache artifacts across machines, enabling you to share build caches with your team and CI/CD pipelines.
 
 By default, Turborepo will cache locally. To enable Remote Caching you will need an account with Vercel. If you don't have an account you can [create one](https://vercel.com/signup?utm_source=turborepo-examples), then enter the following commands:
 
@@ -112,9 +112,9 @@ npx turbo link
 
 Learn more about the power of Turborepo:
 
-- [Tasks](https://turbo.build/docs/core-concepts/monorepos/running-tasks)
-- [Caching](https://turbo.build/docs/core-concepts/caching)
-- [Remote Caching](https://turbo.build/docs/core-concepts/remote-caching)
-- [Filtering](https://turbo.build/docs/core-concepts/monorepos/filtering)
-- [Configuration Options](https://turbo.build/docs/reference/configuration)
-- [CLI Usage](https://turbo.build/docs/reference/command-line-reference)
+- [Tasks](https://turborepo.com/docs/core-concepts/monorepos/running-tasks)
+- [Caching](https://turborepo.com/docs/core-concepts/caching)
+- [Remote Caching](https://turborepo.com/docs/core-concepts/remote-caching)
+- [Filtering](https://turborepo.com/docs/core-concepts/monorepos/filtering)
+- [Configuration Options](https://turborepo.com/docs/reference/configuration)
+- [CLI Usage](https://turborepo.com/docs/reference/command-line-reference)

--- a/examples/with-nestjs/apps/api/src/links/links.service.ts
+++ b/examples/with-nestjs/apps/api/src/links/links.service.ts
@@ -11,20 +11,20 @@ export class LinksService {
     {
       id: 0,
       title: 'Docs',
-      url: 'https://turbo.build/docs',
+      url: 'https://turborepo.com/docs',
       description:
         'Find in-depth information about Turborepo features and API.',
     },
     {
       id: 1,
       title: 'Learn',
-      url: 'https://turbo.build/docs/handbook',
+      url: 'https://turborepo.com/docs/handbook',
       description: 'Learn more about monorepos with our handbook.',
     },
     {
       id: 2,
       title: 'Templates',
-      url: 'https://turbo.build/docs/getting-started/from-example',
+      url: 'https://turborepo.com/docs/getting-started/from-example',
       description:
         'Choose from over 15 examples and deploy with a single click.',
     },

--- a/examples/with-nestjs/packages/ui/turbo/generators/config.ts
+++ b/examples/with-nestjs/packages/ui/turbo/generators/config.ts
@@ -1,6 +1,6 @@
 import type { PlopTypes } from '@turbo/gen';
 
-// Learn more about Turborepo Generators at https://turbo.build/docs/guides/generating-code
+// Learn more about Turborepo Generators at https://turborepo.com/docs/guides/generating-code
 
 export default function generator(plop: PlopTypes.NodePlopAPI): void {
   // A simple generator to add a new React component to the internal UI library

--- a/examples/with-nestjs/turbo.json
+++ b/examples/with-nestjs/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": [
     "**/.env.*local"
   ],

--- a/examples/with-npm/README.md
+++ b/examples/with-npm/README.md
@@ -55,7 +55,7 @@ npm run dev
 > [!TIP]
 > Vercel Remote Cache is free for all plans. Get started today at [vercel.com](https://vercel.com/signup?/signup?utm_source=remote-cache-sdk&utm_campaign=free_remote_cache).
 
-Turborepo can use a technique known as [Remote Caching](https://turbo.build/docs/core-concepts/remote-caching) to share cache artifacts across machines, enabling you to share build caches with your team and CI/CD pipelines.
+Turborepo can use a technique known as [Remote Caching](https://turborepo.com/docs/core-concepts/remote-caching) to share cache artifacts across machines, enabling you to share build caches with your team and CI/CD pipelines.
 
 By default, Turborepo will cache locally. To enable Remote Caching you will need an account with Vercel. If you don't have an account you can [create one](https://vercel.com/signup?utm_source=turborepo-examples), then enter the following commands:
 
@@ -76,9 +76,9 @@ npx turbo link
 
 Learn more about the power of Turborepo:
 
-- [Tasks](https://turbo.build/docs/core-concepts/monorepos/running-tasks)
-- [Caching](https://turbo.build/docs/core-concepts/caching)
-- [Remote Caching](https://turbo.build/docs/core-concepts/remote-caching)
-- [Filtering](https://turbo.build/docs/core-concepts/monorepos/filtering)
-- [Configuration Options](https://turbo.build/docs/reference/configuration)
-- [CLI Usage](https://turbo.build/docs/reference/command-line-reference)
+- [Tasks](https://turborepo.com/docs/core-concepts/monorepos/running-tasks)
+- [Caching](https://turborepo.com/docs/core-concepts/caching)
+- [Remote Caching](https://turborepo.com/docs/core-concepts/remote-caching)
+- [Filtering](https://turborepo.com/docs/core-concepts/monorepos/filtering)
+- [Configuration Options](https://turborepo.com/docs/reference/configuration)
+- [CLI Usage](https://turborepo.com/docs/reference/command-line-reference)

--- a/examples/with-npm/apps/docs/app/page.tsx
+++ b/examples/with-npm/apps/docs/app/page.tsx
@@ -29,17 +29,17 @@ function Gradient({
 const LINKS = [
   {
     title: "Docs",
-    href: "https://turbo.build/docs",
+    href: "https://turborepo.com/docs",
     description: "Find in-depth information about Turborepo features and API.",
   },
   {
     title: "Learn",
-    href: "https://turbo.build/docs/handbook",
+    href: "https://turborepo.com/docs/handbook",
     description: "Learn more about monorepos with our handbook.",
   },
   {
     title: "Templates",
-    href: "https://turbo.build/docs/getting-started/from-example",
+    href: "https://turborepo.com/docs/getting-started/from-example",
     description: "Choose from over 15 examples and deploy with a single click.",
   },
   {

--- a/examples/with-npm/apps/web/app/page.tsx
+++ b/examples/with-npm/apps/web/app/page.tsx
@@ -29,17 +29,17 @@ function Gradient({
 const LINKS = [
   {
     title: "Docs",
-    href: "https://turbo.build/docs",
+    href: "https://turborepo.com/docs",
     description: "Find in-depth information about Turborepo features and API.",
   },
   {
     title: "Learn",
-    href: "https://turbo.build/docs/handbook",
+    href: "https://turborepo.com/docs/handbook",
     description: "Learn more about monorepos with our handbook.",
   },
   {
     title: "Templates",
-    href: "https://turbo.build/docs/getting-started/from-example",
+    href: "https://turborepo.com/docs/getting-started/from-example",
     description: "Choose from over 15 examples and deploy with a single click.",
   },
   {

--- a/examples/with-npm/packages/ui/turbo.json
+++ b/examples/with-npm/packages/ui/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": [
     "//"
   ],

--- a/examples/with-npm/packages/ui/turbo/generators/config.ts
+++ b/examples/with-npm/packages/ui/turbo/generators/config.ts
@@ -1,6 +1,6 @@
 import type { PlopTypes } from "@turbo/gen";
 
-// Learn more about Turborepo Generators at https://turbo.build/docs/guides/generating-code
+// Learn more about Turborepo Generators at https://turborepo.com/docs/guides/generating-code
 
 export default function generator(plop: PlopTypes.NodePlopAPI): void {
   // A simple generator to add a new React component to the internal UI library

--- a/examples/with-npm/turbo.json
+++ b/examples/with-npm/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],

--- a/examples/with-prisma/README.md
+++ b/examples/with-prisma/README.md
@@ -191,9 +191,9 @@ You can also read the official [detailed step-by-step guide from Prisma ORM](htt
 
 Learn more about the power of Turborepo:
 
-- [Tasks](https://turbo.build/docs/core-concepts/monorepos/running-tasks)
-- [Caching](https://turbo.build/docs/core-concepts/caching)
-- [Remote Caching](https://turbo.build/docs/core-concepts/remote-caching)
-- [Filtering](https://turbo.build/docs/core-concepts/monorepos/filtering)
-- [Configuration Options](https://turbo.build/docs/reference/configuration)
-- [CLI Usage](https://turbo.build/docs/reference/command-line-reference)
+- [Tasks](https://turborepo.com/docs/core-concepts/monorepos/running-tasks)
+- [Caching](https://turborepo.com/docs/core-concepts/caching)
+- [Remote Caching](https://turborepo.com/docs/core-concepts/remote-caching)
+- [Filtering](https://turborepo.com/docs/core-concepts/monorepos/filtering)
+- [Configuration Options](https://turborepo.com/docs/reference/configuration)
+- [CLI Usage](https://turborepo.com/docs/reference/command-line-reference)

--- a/examples/with-prisma/turbo.json
+++ b/examples/with-prisma/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],

--- a/examples/with-react-native-web/turbo.json
+++ b/examples/with-react-native-web/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "ui": "tui",
   "tasks": {
     "build": {

--- a/examples/with-shell-commands/README.md
+++ b/examples/with-shell-commands/README.md
@@ -34,7 +34,7 @@ This Turborepo includes the following packages:
 
 ### Some scripts to try
 
-If you haven't yet, [install global `turbo`](https://turbo.build/docs/installing#install-globally) to run tasks.
+If you haven't yet, [install global `turbo`](https://turborepo.com/docs/installing#install-globally) to run tasks.
 
 - `turbo build lint check-types`: Runs all tasks in the default graph.
 - `turbo build`: A basic command to build `app-a` and `app-b` in parallel.

--- a/examples/with-shell-commands/apps/app-a/README.md
+++ b/examples/with-shell-commands/apps/app-a/README.md
@@ -1,3 +1,3 @@
 # Top-level package
 
-We'll use this package as the final node of your [Task Graph](https://turbo.build/docs/core-concepts/task-graph). You may want to think of it as the final application you're building (the most common use case for a Turborepo build pipeline).
+We'll use this package as the final node of your [Task Graph](https://turborepo.com/docs/core-concepts/task-graph). You may want to think of it as the final application you're building (the most common use case for a Turborepo build pipeline).

--- a/examples/with-shell-commands/turbo.json
+++ b/examples/with-shell-commands/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "dependsOn": [

--- a/examples/with-solid/README.md
+++ b/examples/with-solid/README.md
@@ -64,7 +64,7 @@ pnpm run dev
 > [!TIP]
 > Vercel Remote Cache is free for all plans. Get started today at [vercel.com](https://vercel.com/signup?/signup?utm_source=remote-cache-sdk&utm_campaign=free_remote_cache).
 
-Turborepo can use a technique known as [Remote Caching](https://turbo.build/docs/core-concepts/remote-caching) to share cache artifacts across machines, enabling you to share build caches with your team and CI/CD pipelines.
+Turborepo can use a technique known as [Remote Caching](https://turborepo.com/docs/core-concepts/remote-caching) to share cache artifacts across machines, enabling you to share build caches with your team and CI/CD pipelines.
 
 By default, Turborepo will cache locally. To enable Remote Caching you will need an account with Vercel. If you don't have an account you can [create one](https://vercel.com/signup?utm_source=turborepo-examples), then enter the following commands:
 
@@ -85,12 +85,12 @@ npx turbo link
 
 Learn more about the power of Turborepo:
 
-- [Tasks](https://turbo.build/docs/core-concepts/monorepos/running-tasks)
-- [Caching](https://turbo.build/docs/core-concepts/caching)
-- [Remote Caching](https://turbo.build/docs/core-concepts/remote-caching)
-- [Filtering](https://turbo.build/docs/core-concepts/monorepos/filtering)
-- [Configuration Options](https://turbo.build/docs/reference/configuration)
-- [CLI Usage](https://turbo.build/docs/reference/command-line-reference)
+- [Tasks](https://turborepo.com/docs/core-concepts/monorepos/running-tasks)
+- [Caching](https://turborepo.com/docs/core-concepts/caching)
+- [Remote Caching](https://turborepo.com/docs/core-concepts/remote-caching)
+- [Filtering](https://turborepo.com/docs/core-concepts/monorepos/filtering)
+- [Configuration Options](https://turborepo.com/docs/reference/configuration)
+- [CLI Usage](https://turborepo.com/docs/reference/command-line-reference)
 
 ## License
 

--- a/examples/with-solid/turbo.json
+++ b/examples/with-solid/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "ui": "tui",
   "tasks": {
     "build": {

--- a/examples/with-svelte/turbo.json
+++ b/examples/with-svelte/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "ui": "tui",
   "tasks": {
     "build": {

--- a/examples/with-tailwind/apps/docs/app/page.tsx
+++ b/examples/with-tailwind/apps/docs/app/page.tsx
@@ -22,17 +22,17 @@ function Gradient({
 const LINKS = [
   {
     title: "Docs",
-    href: "https://turbo.build/docs",
+    href: "https://turborepo.com/docs",
     description: "Find in-depth information about Turborepo features and API.",
   },
   {
     title: "Learn",
-    href: "https://turbo.build/docs/handbook",
+    href: "https://turborepo.com/docs/handbook",
     description: "Learn more about monorepos with our handbook.",
   },
   {
     title: "Templates",
-    href: "https://turbo.build/docs/getting-started/from-example",
+    href: "https://turborepo.com/docs/getting-started/from-example",
     description: "Choose from over 15 examples and deploy with a single click.",
   },
   {

--- a/examples/with-tailwind/apps/web/app/page.tsx
+++ b/examples/with-tailwind/apps/web/app/page.tsx
@@ -22,17 +22,17 @@ function Gradient({
 const LINKS = [
   {
     title: "Docs",
-    href: "https://turbo.build/docs",
+    href: "https://turborepo.com/docs",
     description: "Find in-depth information about Turborepo features and API.",
   },
   {
     title: "Learn",
-    href: "https://turbo.build/docs/handbook",
+    href: "https://turborepo.com/docs/handbook",
     description: "Learn more about monorepos with our handbook.",
   },
   {
     title: "Templates",
-    href: "https://turbo.build/docs/getting-started/from-example",
+    href: "https://turborepo.com/docs/getting-started/from-example",
     description: "Choose from over 15 examples and deploy with a single click.",
   },
   {

--- a/examples/with-tailwind/turbo.json
+++ b/examples/with-tailwind/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "ui": "tui",
   "tasks": {
     "build": {

--- a/examples/with-typeorm/apps/docs/app/page.tsx
+++ b/examples/with-typeorm/apps/docs/app/page.tsx
@@ -31,17 +31,17 @@ function Gradient({
 const LINKS = [
   {
     title: "Docs",
-    href: "https://turbo.build/docs",
+    href: "https://turborepo.com/docs",
     description: "Find in-depth information about Turborepo features and API.",
   },
   {
     title: "Learn",
-    href: "https://turbo.build/docs/handbook",
+    href: "https://turborepo.com/docs/handbook",
     description: "Learn more about monorepos with our handbook.",
   },
   {
     title: "Templates",
-    href: "https://turbo.build/docs/getting-started/from-example",
+    href: "https://turborepo.com/docs/getting-started/from-example",
     description: "Choose from over 15 examples and deploy with a single click.",
   },
   {

--- a/examples/with-typeorm/apps/web/app/page.tsx
+++ b/examples/with-typeorm/apps/web/app/page.tsx
@@ -30,17 +30,17 @@ function Gradient({
 const LINKS = [
   {
     title: "Docs",
-    href: "https://turbo.build/docs",
+    href: "https://turborepo.com/docs",
     description: "Find in-depth information about Turborepo features and API.",
   },
   {
     title: "Learn",
-    href: "https://turbo.build/docs/handbook",
+    href: "https://turborepo.com/docs/handbook",
     description: "Learn more about monorepos with our handbook.",
   },
   {
     title: "Templates",
-    href: "https://turbo.build/docs/getting-started/from-example",
+    href: "https://turborepo.com/docs/getting-started/from-example",
     description: "Choose from over 15 examples and deploy with a single click.",
   },
   {

--- a/examples/with-typeorm/packages/ui/turbo/generators/config.ts
+++ b/examples/with-typeorm/packages/ui/turbo/generators/config.ts
@@ -1,6 +1,6 @@
 import type { PlopTypes } from "@turbo/gen";
 
-// Learn more about Turborepo Generators at https://turbo.build/docs/guides/generating-code
+// Learn more about Turborepo Generators at https://turborepo.com/docs/guides/generating-code
 
 export default function generator(plop: PlopTypes.NodePlopAPI): void {
   // A simple generator to add a new React component to the internal UI library

--- a/examples/with-typeorm/turbo.json
+++ b/examples/with-typeorm/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],

--- a/examples/with-vite-react/turbo.json
+++ b/examples/with-vite-react/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],

--- a/examples/with-vite/turbo.json
+++ b/examples/with-vite/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],

--- a/examples/with-vitest/README.md
+++ b/examples/with-vitest/README.md
@@ -16,7 +16,7 @@ For this reason, the only commands in the root package.json are `turbo run test`
 > [!TIP]
 > Vercel Remote Cache is free for all plans. Get started today at [vercel.com](https://vercel.com/signup?/signup?utm_source=remote-cache-sdk&utm_campaign=free_remote_cache).
 
-Turborepo can use a technique known as [Remote Caching](https://turbo.build/docs/core-concepts/remote-caching) to share cache artifacts across machines, enabling you to share build caches with your team and CI/CD pipelines.
+Turborepo can use a technique known as [Remote Caching](https://turborepo.com/docs/core-concepts/remote-caching) to share cache artifacts across machines, enabling you to share build caches with your team and CI/CD pipelines.
 
 By default, Turborepo will cache locally. To enable Remote Caching you will need an account with Vercel. If you don't have an account you can [create one](https://vercel.com/signup?utm_source=turborepo-examples), then enter the following commands:
 
@@ -37,9 +37,9 @@ npx turbo link
 
 Learn more about the power of Turborepo:
 
-- [Tasks](https://turbo.build/docs/core-concepts/monorepos/running-tasks)
-- [Caching](https://turbo.build/docs/core-concepts/caching)
-- [Remote Caching](https://turbo.build/docs/core-concepts/remote-caching)
-- [Filtering](https://turbo.build/docs/core-concepts/monorepos/filtering)
-- [Configuration Options](https://turbo.build/docs/reference/configuration)
-- [CLI Usage](https://turbo.build/docs/reference/command-line-reference)
+- [Tasks](https://turborepo.com/docs/core-concepts/monorepos/running-tasks)
+- [Caching](https://turborepo.com/docs/core-concepts/caching)
+- [Remote Caching](https://turborepo.com/docs/core-concepts/remote-caching)
+- [Filtering](https://turborepo.com/docs/core-concepts/monorepos/filtering)
+- [Configuration Options](https://turborepo.com/docs/reference/configuration)
+- [CLI Usage](https://turborepo.com/docs/reference/command-line-reference)

--- a/examples/with-vitest/apps/docs/app/page.tsx
+++ b/examples/with-vitest/apps/docs/app/page.tsx
@@ -55,7 +55,7 @@ export default function Home() {
             Deploy now
           </a>
           <a
-            href="https://turbo.build/docs?utm_source"
+            href="https://turborepo.com/docs?utm_source"
             target="_blank"
             rel="noopener noreferrer"
             className={styles.secondary}
@@ -83,7 +83,7 @@ export default function Home() {
           Examples
         </a>
         <a
-          href="https://turbo.build?utm_source=create-turbo"
+          href="https://turborepo.com?utm_source=create-turbo"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -94,7 +94,7 @@ export default function Home() {
             width={16}
             height={16}
           />
-          Go to turbo.build →
+          Go to turborepo.com →
         </a>
       </footer>
     </div>

--- a/examples/with-vitest/apps/web/app/page.tsx
+++ b/examples/with-vitest/apps/web/app/page.tsx
@@ -55,7 +55,7 @@ export default function Home() {
             Deploy now
           </a>
           <a
-            href="https://turbo.build/docs?utm_source"
+            href="https://turborepo.com/docs?utm_source"
             target="_blank"
             rel="noopener noreferrer"
             className={styles.secondary}
@@ -83,7 +83,7 @@ export default function Home() {
           Examples
         </a>
         <a
-          href="https://turbo.build?utm_source=create-turbo"
+          href="https://turborepo.com?utm_source=create-turbo"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -94,7 +94,7 @@ export default function Home() {
             width={16}
             height={16}
           />
-          Go to turbo.build →
+          Go to turborepo.com →
         </a>
       </footer>
     </div>

--- a/examples/with-vitest/packages/ui/turbo/generators/config.ts
+++ b/examples/with-vitest/packages/ui/turbo/generators/config.ts
@@ -1,6 +1,6 @@
 import type { PlopTypes } from "@turbo/gen";
 
-// Learn more about Turborepo Generators at https://turbo.build/docs/guides/generating-code
+// Learn more about Turborepo Generators at https://turborepo.com/docs/guides/generating-code
 
 export default function generator(plop: PlopTypes.NodePlopAPI): void {
   // A simple generator to add a new React component to the internal UI library

--- a/examples/with-vitest/turbo.json
+++ b/examples/with-vitest/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "ui": "tui",
   "tasks": {
     "build": {

--- a/examples/with-vue-nuxt/README.md
+++ b/examples/with-vue-nuxt/README.md
@@ -55,7 +55,7 @@ pnpm dev
 > [!TIP]
 > Vercel Remote Cache is free for all plans. Get started today at [vercel.com](https://vercel.com/signup?/signup?utm_source=remote-cache-sdk&utm_campaign=free_remote_cache).
 
-Turborepo can use a technique known as [Remote Caching](https://turbo.build/docs/core-concepts/remote-caching) to share cache artifacts across machines, enabling you to share build caches with your team and CI/CD pipelines.
+Turborepo can use a technique known as [Remote Caching](https://turborepo.com/docs/core-concepts/remote-caching) to share cache artifacts across machines, enabling you to share build caches with your team and CI/CD pipelines.
 
 By default, Turborepo will cache locally. To enable Remote Caching you will need an account with Vercel. If you don't have an account you can [create one](https://vercel.com/signup?utm_source=turborepo-examples), then enter the following commands:
 
@@ -76,9 +76,9 @@ npx turbo link
 
 Learn more about the power of Turborepo:
 
-- [Tasks](https://turbo.build/docs/core-concepts/monorepos/running-tasks)
-- [Caching](https://turbo.build/docs/core-concepts/caching)
-- [Remote Caching](https://turbo.build/docs/core-concepts/remote-caching)
-- [Filtering](https://turbo.build/docs/core-concepts/monorepos/filtering)
-- [Configuration Options](https://turbo.build/docs/reference/configuration)
-- [CLI Usage](https://turbo.build/docs/reference/command-line-reference)
+- [Tasks](https://turborepo.com/docs/core-concepts/monorepos/running-tasks)
+- [Caching](https://turborepo.com/docs/core-concepts/caching)
+- [Remote Caching](https://turborepo.com/docs/core-concepts/remote-caching)
+- [Filtering](https://turborepo.com/docs/core-concepts/monorepos/filtering)
+- [Configuration Options](https://turborepo.com/docs/reference/configuration)
+- [CLI Usage](https://turborepo.com/docs/reference/command-line-reference)

--- a/examples/with-vue-nuxt/packages/ui/src/page.vue
+++ b/examples/with-vue-nuxt/packages/ui/src/page.vue
@@ -5,17 +5,17 @@ import Gradient from "./gradient.vue";
 const LINKS = [
   {
     title: "Docs",
-    href: "https://turbo.build/docs",
+    href: "https://turborepo.com/docs",
     description: "Find in-depth information about Turborepo features and API.",
   },
   {
     title: "Learn",
-    href: "https://turbo.build/docs/handbook",
+    href: "https://turborepo.com/docs/handbook",
     description: "Learn more about monorepos with our handbook.",
   },
   {
     title: "Templates",
-    href: "https://turbo.build/docs/getting-started/from-example",
+    href: "https://turborepo.com/docs/getting-started/from-example",
     description: "Choose from over 15 examples and deploy with a single click.",
   },
   {

--- a/examples/with-vue-nuxt/turbo.json
+++ b/examples/with-vue-nuxt/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],

--- a/examples/with-yarn/README.md
+++ b/examples/with-yarn/README.md
@@ -55,7 +55,7 @@ yarn dev
 > [!TIP]
 > Vercel Remote Cache is free for all plans. Get started today at [vercel.com](https://vercel.com/signup?/signup?utm_source=remote-cache-sdk&utm_campaign=free_remote_cache).
 
-Turborepo can use a technique known as [Remote Caching](https://turbo.build/docs/core-concepts/remote-caching) to share cache artifacts across machines, enabling you to share build caches with your team and CI/CD pipelines.
+Turborepo can use a technique known as [Remote Caching](https://turborepo.com/docs/core-concepts/remote-caching) to share cache artifacts across machines, enabling you to share build caches with your team and CI/CD pipelines.
 
 By default, Turborepo will cache locally. To enable Remote Caching you will need an account with Vercel. If you don't have an account you can [create one](https://vercel.com/signup?utm_source=turborepo-examples), then enter the following commands:
 
@@ -76,9 +76,9 @@ npx turbo link
 
 Learn more about the power of Turborepo:
 
-- [Tasks](https://turbo.build/docs/core-concepts/monorepos/running-tasks)
-- [Caching](https://turbo.build/docs/core-concepts/caching)
-- [Remote Caching](https://turbo.build/docs/core-concepts/remote-caching)
-- [Filtering](https://turbo.build/docs/core-concepts/monorepos/filtering)
-- [Configuration Options](https://turbo.build/docs/reference/configuration)
-- [CLI Usage](https://turbo.build/docs/reference/command-line-reference)
+- [Tasks](https://turborepo.com/docs/core-concepts/monorepos/running-tasks)
+- [Caching](https://turborepo.com/docs/core-concepts/caching)
+- [Remote Caching](https://turborepo.com/docs/core-concepts/remote-caching)
+- [Filtering](https://turborepo.com/docs/core-concepts/monorepos/filtering)
+- [Configuration Options](https://turborepo.com/docs/reference/configuration)
+- [CLI Usage](https://turborepo.com/docs/reference/command-line-reference)

--- a/examples/with-yarn/apps/docs/app/page.tsx
+++ b/examples/with-yarn/apps/docs/app/page.tsx
@@ -29,17 +29,17 @@ function Gradient({
 const LINKS = [
   {
     title: "Docs",
-    href: "https://turbo.build/docs",
+    href: "https://turborepo.com/docs",
     description: "Find in-depth information about Turborepo features and API.",
   },
   {
     title: "Learn",
-    href: "https://turbo.build/docs/handbook",
+    href: "https://turborepo.com/docs/handbook",
     description: "Learn more about monorepos with our handbook.",
   },
   {
     title: "Templates",
-    href: "https://turbo.build/docs/getting-started/from-example",
+    href: "https://turborepo.com/docs/getting-started/from-example",
     description: "Choose from over 15 examples and deploy with a single click.",
   },
   {

--- a/examples/with-yarn/apps/web/app/page.tsx
+++ b/examples/with-yarn/apps/web/app/page.tsx
@@ -29,17 +29,17 @@ function Gradient({
 const LINKS = [
   {
     title: "Docs",
-    href: "https://turbo.build/docs",
+    href: "https://turborepo.com/docs",
     description: "Find in-depth information about Turborepo features and API.",
   },
   {
     title: "Learn",
-    href: "https://turbo.build/docs/handbook",
+    href: "https://turborepo.com/docs/handbook",
     description: "Learn more about monorepos with our handbook.",
   },
   {
     title: "Templates",
-    href: "https://turbo.build/docs/getting-started/from-example",
+    href: "https://turborepo.com/docs/getting-started/from-example",
     description: "Choose from over 15 examples and deploy with a single click.",
   },
   {

--- a/examples/with-yarn/packages/ui/turbo.json
+++ b/examples/with-yarn/packages/ui/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": [
     "//"
   ],

--- a/examples/with-yarn/packages/ui/turbo/generators/config.ts
+++ b/examples/with-yarn/packages/ui/turbo/generators/config.ts
@@ -1,6 +1,6 @@
 import type { PlopTypes } from "@turbo/gen";
 
-// Learn more about Turborepo Generators at https://turbo.build/docs/guides/generating-code
+// Learn more about Turborepo Generators at https://turborepo.com/docs/guides/generating-code
 
 export default function generator(plop: PlopTypes.NodePlopAPI): void {
   // A simple generator to add a new React component to the internal UI library

--- a/examples/with-yarn/turbo.json
+++ b/examples/with-yarn/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],

--- a/packages/create-turbo/README.md
+++ b/packages/create-turbo/README.md
@@ -1,6 +1,6 @@
 # Welcome to Turborepo
 
-[Turborepo](https://turbo.build/repo) is a high-performance monorepo build-system for modern JavaScript and TypeScript codebases.
+[Turborepo](https://turborepo.com/repo) is a high-performance monorepo build-system for modern JavaScript and TypeScript codebases.
 
 To get started, open a new shell and run:
 
@@ -10,7 +10,7 @@ npx create-turbo@latest
 
 Then follow the prompts you see in your terminal.
 
-For more information about Turborepo, [visit turbo.build/repo](https://turbo.build/repo) and follow us on X ([@turborepo](https://x.com/turborepo))!
+For more information about Turborepo, [visit turborepo.com/repo](https://turborepo.com/repo) and follow us on X ([@turborepo](https://x.com/turborepo))!
 
 ## Contributing
 

--- a/packages/create-turbo/package.json
+++ b/packages/create-turbo/package.json
@@ -2,7 +2,7 @@
   "name": "create-turbo",
   "version": "2.5.1-canary.1",
   "description": "Create a new Turborepo",
-  "homepage": "https://turbo.build/repo",
+  "homepage": "https://turborepo.com/repo",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/create-turbo/src/commands/create/index.ts
+++ b/packages/create-turbo/src/commands/create/index.ts
@@ -292,7 +292,7 @@ export async function create(
         `${packageManagerMeta.executable} turbo login`
       )}`
     );
-    logger.log("   - Learn more: https://turbo.build/repo/remote-cache");
+    logger.log("   - Learn more: https://turborepo.com/repo/remote-cache");
     logger.log();
     logger.log("- Run commands with Turborepo:");
     availableScripts

--- a/packages/create-turbo/src/transforms/official-starter.ts
+++ b/packages/create-turbo/src/transforms/official-starter.ts
@@ -36,7 +36,7 @@ export async function transform(args: TransformInput): TransformResult {
 
   let metaJson: MetaJson | undefined;
 
-  // 1. remove meta file (used for generating the examples page on turbo.build)
+  // 1. remove meta file (used for generating the examples page on turborepo.com)
   try {
     metaJson = fs.readJsonSync(rootMetaJsonPath) as MetaJson;
     fs.rmSync(rootMetaJsonPath, { force: true });

--- a/packages/eslint-plugin-turbo/__fixtures__/workspace-configs/apps/docs/turbo.json
+++ b/packages/eslint-plugin-turbo/__fixtures__/workspace-configs/apps/docs/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "pipeline": {
     "build": {

--- a/packages/eslint-plugin-turbo/__fixtures__/workspace-configs/apps/web/turbo.json
+++ b/packages/eslint-plugin-turbo/__fixtures__/workspace-configs/apps/web/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "pipeline": {
     "build": {

--- a/packages/eslint-plugin-turbo/__fixtures__/workspace-configs/packages/ui/turbo.json
+++ b/packages/eslint-plugin-turbo/__fixtures__/workspace-configs/packages/ui/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "pipeline": {
     "build": {

--- a/packages/eslint-plugin-turbo/__fixtures__/workspace-configs/turbo.json
+++ b/packages/eslint-plugin-turbo/__fixtures__/workspace-configs/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalEnv": ["CI"],
   "globalDotEnv": [".env", "missing.env"],
   "pipeline": {

--- a/packages/eslint-plugin-turbo/__fixtures__/workspace/turbo.json
+++ b/packages/eslint-plugin-turbo/__fixtures__/workspace/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalEnv": ["UNORDERED", "CI"],
   "globalDotEnv": [".env", "missing.env"],
   "pipeline": {

--- a/packages/eslint-plugin-turbo/docs/rules/no-undeclared-env-vars.md
+++ b/packages/eslint-plugin-turbo/docs/rules/no-undeclared-env-vars.md
@@ -71,4 +71,4 @@ Examples of **correct** code for this rule:
 
 ## Further Reading
 
-- [Environment Variable Inputs](https://turbo.build/docs/crafting-your-repository/using-environment-variables)
+- [Environment Variable Inputs](https://turborepo.com/docs/crafting-your-repository/using-environment-variables)

--- a/packages/turbo-benchmark/src/ttft/run.ts
+++ b/packages/turbo-benchmark/src/ttft/run.ts
@@ -10,7 +10,7 @@ export function run(profilePath: string) {
 
   const turboFlags = `--dry --skip-infer --profile=${profilePath}`;
 
-  console.log("Executing turbo build in child process", {
+  console.log("Executing turborepo.com in child process", {
     cwd: process.cwd(),
     bin: TURBO_BIN,
     execOpts: DEFAULT_EXEC_OPTS,
@@ -28,6 +28,6 @@ export function run(profilePath: string) {
     // catch errors and exit. the build command seems to be erroring out due to very large output?
     // need to chase it down, but the benchmark seems to still be working, and when the same turbo run build
     // is executed _without_ a child process, it works and has a 0 exit code.
-    console.error("Error running turbo build", e);
+    console.error("Error running turborepo.com", e);
   }
 }

--- a/packages/turbo-benchmark/src/ttft/slack.ts
+++ b/packages/turbo-benchmark/src/ttft/slack.ts
@@ -11,7 +11,7 @@ if (!runID) {
 
 const slackPayloadPath = path.join(process.cwd(), "slack-payload.json");
 
-console.log("Executing turbo build in child process", {
+console.log("Executing turborepo.com in child process", {
   cwd: process.cwd(),
   slackPayloadPath,
 });

--- a/packages/turbo-codemod/__tests__/__fixtures__/create-turbo-config/both-configs/package.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/create-turbo-config/both-configs/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {},
   "packageManager": "npm@1.2.3",
   "turbo": {
-    "$schema": "https://turbo.build/schema.json",
+    "$schema": "https://turborepo.com/schema.json",
     "pipeline": {
       "package-only": {
         "cache": false,

--- a/packages/turbo-codemod/__tests__/__fixtures__/create-turbo-config/both-configs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/create-turbo-config/both-configs/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "pipeline": {
     "turbo-only": {
       "cache": false,

--- a/packages/turbo-codemod/__tests__/__fixtures__/create-turbo-config/no-turbo-json-config/package.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/create-turbo-config/no-turbo-json-config/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {},
   "packageManager": "npm@1.2.3",
   "turbo": {
-    "$schema": "https://turbo.build/schema.json",
+    "$schema": "https://turborepo.com/schema.json",
     "pipeline": {
       "build": {
         "outputs": [

--- a/packages/turbo-codemod/__tests__/__fixtures__/create-turbo-config/turbo-json-config/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/create-turbo-config/turbo-json-config/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "pipeline": {
     "turbo-only": {
       "cache": false,

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/no-dot-env/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/no-dot-env/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build-one": {
       "dependsOn": ["build-two"]

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/no-pipeline/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/no-pipeline/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["$NEXT_PUBLIC_API_KEY", "$STRIPE_API_KEY", ".env"],
   "tasks": {}
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/with-dot-env/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/with-dot-env/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDotEnv": [".env"],
   "tasks": {
     "build-one": {

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/workspace-configs/apps/docs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/workspace-configs/apps/docs/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "tasks": {
     "build": {}

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/workspace-configs/apps/web/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/workspace-configs/apps/web/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "tasks": {
     "build": {

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/workspace-configs/packages/ui/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/workspace-configs/packages/ui/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "tasks": {
     "build-three": {

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/workspace-configs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-dot-env/workspace-configs/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build-one": {
       "dotEnv": ["build-one/.env"]

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/env-dependencies/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/env-dependencies/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["$NEXT_PUBLIC_API_KEY", "$STRIPE_API_KEY", ".env"],
   "pipeline": {
     "build": {

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/migrated-env-dependencies/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/migrated-env-dependencies/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": [],
   "globalEnv": ["NEXT_PUBLIC_API_KEY", "STRIPE_API_KEY"],
   "pipeline": {

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/old-config/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/old-config/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "pipeline": {
     "build-one": {
       "outputs": ["foo"]

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/workspace-configs/apps/docs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/workspace-configs/apps/docs/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "pipeline": {
     "build": {

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/workspace-configs/apps/web/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/workspace-configs/apps/web/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "pipeline": {
     "build": {

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/workspace-configs/packages/ui/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/workspace-configs/packages/ui/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "pipeline": {
     "build": {

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/workspace-configs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate-env-var-dependencies/workspace-configs/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["$NEXT_PUBLIC_API_KEY", "$STRIPE_API_KEY", ".env"],
   "pipeline": {
     "build": {

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate/old-turbo/package.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate/old-turbo/package.json
@@ -6,7 +6,7 @@
     "turbo": "1.0.0"
   },
   "turbo": {
-    "$schema": "https://turbo.build/schema.json",
+    "$schema": "https://turborepo.com/schema.json",
     "pipeline": {
       "build": {
         "outputs": [

--- a/packages/turbo-codemod/__tests__/__fixtures__/migrate/turbo-1/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/migrate/turbo-1/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   // A comment which we allow
   "pipeline": {
     "build": {

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/invalid-output-mode/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/invalid-output-mode/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "pipeline": {
     "build-one": {
       "outputMode": "errors-only"

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/no-output-mode/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/no-output-mode/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "pipeline": {
     "build-one": {
       "dependsOn": ["build-two"]

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/no-pipeline/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/no-pipeline/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["$NEXT_PUBLIC_API_KEY", "$STRIPE_API_KEY", ".env"],
   "pipeline": {}
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/old-config/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/old-config/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "pipeline": {
     "build-one": {
       "outputMode": "errors-only"

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/old-output-mode/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/old-output-mode/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "pipeline": {
     "build-one": {
       "outputMode": "hash-only"

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/workspace-configs/apps/docs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/workspace-configs/apps/docs/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "pipeline": {
     "build": {}

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/workspace-configs/apps/web/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/workspace-configs/apps/web/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "pipeline": {
     "build": {

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/workspace-configs/packages/ui/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/workspace-configs/packages/ui/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "pipeline": {
     "build-three": {

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/workspace-configs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-output-mode/workspace-configs/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "pipeline": {
     "build-one": {
       "outputMode": "new-only"

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-pipeline/root-only/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-pipeline/root-only/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["important.txt"],
   "pipeline": {
     "build": {

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-pipeline/with-tasks/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-pipeline/with-tasks/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "outputs": ["dist"]

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-pipeline/workspace-configs/apps/docs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-pipeline/workspace-configs/apps/docs/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "pipeline": {
     "build": {

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-pipeline/workspace-configs/apps/web/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-pipeline/workspace-configs/apps/web/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "pipeline": {
     "build": {

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-pipeline/workspace-configs/packages/ui/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-pipeline/workspace-configs/packages/ui/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "pipeline": {
     "test": {

--- a/packages/turbo-codemod/__tests__/__fixtures__/rename-pipeline/workspace-configs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/rename-pipeline/workspace-configs/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "pipeline": {
     "build": {
       "outputs": [".next/**", "!.next/cache/**"],

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/invalid-outputs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/invalid-outputs/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "pipeline": {
     "build-one": {
       "outputs": ["foo"]

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/no-outputs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/no-outputs/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "pipeline": {
     "build-one": {
       "dependsOn": ["build-two"]

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/no-pipeline/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/no-pipeline/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["$NEXT_PUBLIC_API_KEY", "$STRIPE_API_KEY", ".env"],
   "pipeline": {}
 }

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/old-config/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/old-config/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "pipeline": {
     "build-one": {
       "outputs": ["foo"]

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/old-outputs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/old-outputs/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "pipeline": {
     "build-one": {
       "outputs": ["foo"]

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/workspace-configs/apps/docs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/workspace-configs/apps/docs/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "pipeline": {
     "build": {}

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/workspace-configs/apps/web/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/workspace-configs/apps/web/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "pipeline": {
     "build": {

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/workspace-configs/packages/ui/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/workspace-configs/packages/ui/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "pipeline": {
     "build-three": {}

--- a/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/workspace-configs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/set-default-outputs/workspace-configs/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "pipeline": {
     "build-one": {
       "outputs": ["foo"]

--- a/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-both/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-both/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "experimentalGlobalPassThroughEnv": ["EXPERIMENTAL_GLOBAL_PASSTHROUGH"],
   "globalPassThroughEnv": ["GLOBAL_PASSTHROUGH"],
   "pipeline": {

--- a/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-duplicates/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-duplicates/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "experimentalGlobalPassThroughEnv": [
     "DUPLICATE_GLOBAL",
     "DUPLICATE_GLOBAL",

--- a/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-empty/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-empty/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "experimentalGlobalPassThroughEnv": [],
   "pipeline": {
     "build": {

--- a/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-neither/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-neither/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "pipeline": {
     "build": {}
   }

--- a/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-new/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-new/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalPassThroughEnv": ["GLOBAL_PASSTHROUGH"],
   "pipeline": {
     "build": {

--- a/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-old/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/has-old/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "experimentalGlobalPassThroughEnv": ["GLOBAL_PASSTHROUGH"],
   "pipeline": {
     "build": {

--- a/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/workspace-configs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/stabilize-env-mode/workspace-configs/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "experimentalGlobalPassThroughEnv": ["EXPERIMENTAL_GLOBAL_PASSTHROUGH"],
   "globalPassThroughEnv": ["GLOBAL_PASSTHROUGH"],
   "pipeline": {

--- a/packages/turbo-codemod/__tests__/__fixtures__/stabilize-ui/disabled/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/stabilize-ui/disabled/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "outputs": ["dist"]

--- a/packages/turbo-codemod/__tests__/__fixtures__/stabilize-ui/enabled/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/stabilize-ui/enabled/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "outputs": ["dist"]

--- a/packages/turbo-codemod/__tests__/__fixtures__/stabilize-ui/no-config/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/stabilize-ui/no-config/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "outputs": ["dist"]

--- a/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/has-empty/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/has-empty/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalEnv": [],
   "globalPassThroughEnv": [],
   "pipeline": {

--- a/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/has-nothing/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/has-nothing/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "pipeline": {
     "build": {}
   }

--- a/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/needs-rewriting/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/needs-rewriting/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalEnv": ["NO!", "!!!", "!!!"],
   "globalPassThroughEnv": ["DOES", "**BOLD**", "WORK"],
   "pipeline": {

--- a/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/workspace-configs/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/transform-env-literals-to-wildcards/workspace-configs/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalEnv": ["!*!*"],
   "globalPassThroughEnv": ["!*!*"],
   "pipeline": {

--- a/packages/turbo-codemod/__tests__/__fixtures__/update-schema-url/current-schema/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/update-schema-url/current-schema/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "outputs": ["dist/**"]

--- a/packages/turbo-codemod/__tests__/__fixtures__/update-schema-url/v1-schema/turbo.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/update-schema-url/v1-schema/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.v1.json",
+  "$schema": "https://turborepo.com/schema.v1.json",
   "tasks": {
     "build": {
       "outputs": ["dist/**"]

--- a/packages/turbo-codemod/__tests__/migrate-dot-env.test.ts
+++ b/packages/turbo-codemod/__tests__/migrate-dot-env.test.ts
@@ -21,7 +21,7 @@ describe("migrate-dot-env", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       globalDependencies: [".env"],
       tasks: {
         "build-one": {
@@ -59,7 +59,7 @@ describe("migrate-dot-env", () => {
     });
 
     expect(readJson("turbo.json") || "{}").toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       tasks: {
         "build-one": {
           inputs: ["$TURBO_DEFAULT$", "build-one/.env"],
@@ -72,7 +72,7 @@ describe("migrate-dot-env", () => {
     });
 
     expect(readJson("apps/docs/turbo.json") || "{}").toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       extends: ["//"],
       tasks: {
         build: {},
@@ -80,7 +80,7 @@ describe("migrate-dot-env", () => {
     });
 
     expect(readJson("apps/web/turbo.json") || "{}").toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       extends: ["//"],
       tasks: {
         build: {
@@ -90,7 +90,7 @@ describe("migrate-dot-env", () => {
     });
 
     expect(readJson("packages/ui/turbo.json") || "{}").toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       extends: ["//"],
       tasks: {
         "build-three": {
@@ -168,7 +168,7 @@ describe("migrate-dot-env", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       globalDependencies: [".env"],
       tasks: {
         "build-one": {
@@ -235,7 +235,7 @@ describe("migrate-dot-env", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       globalDependencies: ["$NEXT_PUBLIC_API_KEY", "$STRIPE_API_KEY", ".env"],
       tasks: {},
     });
@@ -265,7 +265,7 @@ describe("migrate-dot-env", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       tasks: {
         "build-one": {
           dependsOn: ["build-two"],

--- a/packages/turbo-codemod/__tests__/migrate-env-var-dependencies.test.ts
+++ b/packages/turbo-codemod/__tests__/migrate-env-var-dependencies.test.ts
@@ -423,7 +423,7 @@ describe("migrate-env-var-dependencies", () => {
       });
 
       expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-        $schema: "https://turbo.build/schema.json",
+        $schema: "https://turborepo.com/schema.json",
         globalDependencies: [".env"],
         globalEnv: ["NEXT_PUBLIC_API_KEY", "STRIPE_API_KEY"],
         pipeline: {
@@ -473,7 +473,7 @@ describe("migrate-env-var-dependencies", () => {
       });
 
       expect(readJson("turbo.json") || "{}").toStrictEqual({
-        $schema: "https://turbo.build/schema.json",
+        $schema: "https://turborepo.com/schema.json",
         globalDependencies: [".env"],
         globalEnv: ["NEXT_PUBLIC_API_KEY", "STRIPE_API_KEY"],
         pipeline: {
@@ -499,7 +499,7 @@ describe("migrate-env-var-dependencies", () => {
       });
 
       expect(readJson("apps/web/turbo.json") || "{}").toStrictEqual({
-        $schema: "https://turbo.build/schema.json",
+        $schema: "https://turborepo.com/schema.json",
         extends: ["//"],
         pipeline: {
           build: {
@@ -512,7 +512,7 @@ describe("migrate-env-var-dependencies", () => {
       });
 
       expect(readJson("packages/ui/turbo.json") || "{}").toStrictEqual({
-        $schema: "https://turbo.build/schema.json",
+        $schema: "https://turborepo.com/schema.json",
         extends: ["//"],
         pipeline: {
           build: {
@@ -557,7 +557,7 @@ describe("migrate-env-var-dependencies", () => {
       });
 
       expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-        $schema: "https://turbo.build/schema.json",
+        $schema: "https://turborepo.com/schema.json",
         globalDependencies: [".env"],
         globalEnv: ["NEXT_PUBLIC_API_KEY", "STRIPE_API_KEY"],
         pipeline: {
@@ -653,7 +653,7 @@ describe("migrate-env-var-dependencies", () => {
       });
 
       expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-        $schema: "https://turbo.build/schema.json",
+        $schema: "https://turborepo.com/schema.json",
         globalEnv: ["NEXT_PUBLIC_API_KEY", "STRIPE_API_KEY"],
         globalDependencies: [".env"],
         pipeline: {

--- a/packages/turbo-codemod/__tests__/migrate.test.ts
+++ b/packages/turbo-codemod/__tests__/migrate.test.ts
@@ -77,7 +77,7 @@ describe("migrate", () => {
       version: "1.0.0",
     });
     expect(readJson("turbo.json")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       pipeline: {
         build: {
           outputs: [".next/**", "!.next/cache/**"],
@@ -234,7 +234,7 @@ describe("migrate", () => {
       version: "1.0.0",
     });
     expect(readJson("turbo.json")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       pipeline: {
         build: {
           outputs: [".next/**", "!.next/cache/**"],
@@ -319,7 +319,7 @@ describe("migrate", () => {
       version: "1.0.0",
     });
     expect(readJson("turbo.json")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       pipeline: {
         build: {
           outputs: [".next/**", "!.next/cache/**"],
@@ -525,7 +525,7 @@ describe("migrate", () => {
       version: "1.0.0",
     });
     expect(readJson("turbo.json")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       pipeline: {
         build: {
           outputs: [".next/**", "!.next/cache/**"],
@@ -633,7 +633,7 @@ describe("migrate", () => {
       version: "1.0.0",
     });
     expect(readJson("turbo.json")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       pipeline: {
         build: {
           outputs: [".next/**", "!.next/cache/**"],
@@ -981,7 +981,7 @@ describe("migrate", () => {
       version: "1.0.0",
     });
     expect(readJson("turbo.json")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       tasks: {
         build: {
           outputs: [".next/**", "!.next/cache/**"],

--- a/packages/turbo-codemod/__tests__/rename-output-mode.test.ts
+++ b/packages/turbo-codemod/__tests__/rename-output-mode.test.ts
@@ -21,7 +21,7 @@ describe("rename-output-mode", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       pipeline: {
         "build-one": {
           outputLogs: "hash-only",
@@ -58,7 +58,7 @@ describe("rename-output-mode", () => {
     });
 
     expect(readJson("turbo.json") || "{}").toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       pipeline: {
         "build-one": {
           outputLogs: "new-only",
@@ -71,7 +71,7 @@ describe("rename-output-mode", () => {
     });
 
     expect(readJson("apps/docs/turbo.json") || "{}").toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       extends: ["//"],
       pipeline: {
         build: {},
@@ -79,7 +79,7 @@ describe("rename-output-mode", () => {
     });
 
     expect(readJson("apps/web/turbo.json") || "{}").toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       extends: ["//"],
       pipeline: {
         build: {
@@ -89,7 +89,7 @@ describe("rename-output-mode", () => {
     });
 
     expect(readJson("packages/ui/turbo.json") || "{}").toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       extends: ["//"],
       pipeline: {
         "build-three": {
@@ -167,7 +167,7 @@ describe("rename-output-mode", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       pipeline: {
         "build-one": {
           outputLogs: "hash-only",
@@ -233,7 +233,7 @@ describe("rename-output-mode", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       pipeline: {
         "build-one": {
           outputLogs: "errors-only",
@@ -294,7 +294,7 @@ describe("rename-output-mode", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       globalDependencies: ["$NEXT_PUBLIC_API_KEY", "$STRIPE_API_KEY", ".env"],
       pipeline: {},
     });
@@ -324,7 +324,7 @@ describe("rename-output-mode", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       pipeline: {
         "build-one": {
           dependsOn: ["build-two"],

--- a/packages/turbo-codemod/__tests__/rename-pipeline.ts
+++ b/packages/turbo-codemod/__tests__/rename-pipeline.ts
@@ -21,7 +21,7 @@ describe("rename-pipeline", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       globalDependencies: ["important.txt"],
       tasks: {
         build: {
@@ -55,7 +55,7 @@ describe("rename-pipeline", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       tasks: {
         build: {
           dependsOn: ["^build"],
@@ -74,7 +74,7 @@ describe("rename-pipeline", () => {
     });
 
     expect(JSON.parse(read("apps/web/turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       extends: ["//"],
       tasks: {
         build: {
@@ -84,7 +84,7 @@ describe("rename-pipeline", () => {
     });
 
     expect(JSON.parse(read("packages/ui/turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       extends: ["//"],
       tasks: {
         test: {
@@ -154,7 +154,7 @@ describe("rename-pipeline", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       tasks: {
         build: {
           outputs: ["dist"],

--- a/packages/turbo-codemod/__tests__/set-default-outputs.test.ts
+++ b/packages/turbo-codemod/__tests__/set-default-outputs.test.ts
@@ -53,7 +53,7 @@ describe("set-default-outputs", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       pipeline: {
         "build-one": {
           outputs: ["foo"],
@@ -90,7 +90,7 @@ describe("set-default-outputs", () => {
     });
 
     expect(readJson("turbo.json") || "{}").toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       pipeline: {
         "build-one": {
           outputs: ["foo"],
@@ -103,7 +103,7 @@ describe("set-default-outputs", () => {
     });
 
     expect(readJson("apps/docs/turbo.json") || "{}").toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       extends: ["//"],
       pipeline: {
         build: {
@@ -113,7 +113,7 @@ describe("set-default-outputs", () => {
     });
 
     expect(readJson("apps/web/turbo.json") || "{}").toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       extends: ["//"],
       pipeline: {
         build: {},
@@ -121,7 +121,7 @@ describe("set-default-outputs", () => {
     });
 
     expect(readJson("packages/ui/turbo.json") || "{}").toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       extends: ["//"],
       pipeline: {
         "build-three": {
@@ -199,7 +199,7 @@ describe("set-default-outputs", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       pipeline: {
         "build-one": {
           outputs: ["foo"],
@@ -265,7 +265,7 @@ describe("set-default-outputs", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       pipeline: {
         "build-one": {
           outputs: ["foo"],
@@ -326,7 +326,7 @@ describe("set-default-outputs", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       globalDependencies: ["$NEXT_PUBLIC_API_KEY", "$STRIPE_API_KEY", ".env"],
       pipeline: {},
     });
@@ -356,7 +356,7 @@ describe("set-default-outputs", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       pipeline: {
         "build-one": {
           dependsOn: ["build-two"],

--- a/packages/turbo-codemod/__tests__/stabilize-env-mode.test.ts
+++ b/packages/turbo-codemod/__tests__/stabilize-env-mode.test.ts
@@ -82,7 +82,7 @@ describe("stabilize-env-mode", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       globalPassThroughEnv: [
         "EXPERIMENTAL_GLOBAL_PASSTHROUGH",
         "GLOBAL_PASSTHROUGH",
@@ -119,7 +119,7 @@ describe("stabilize-env-mode", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       globalPassThroughEnv: [
         "DUPLICATE_GLOBAL",
         "EXPERIMENTAL_GLOBAL_PASSTHROUGH",
@@ -161,7 +161,7 @@ describe("stabilize-env-mode", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       globalPassThroughEnv: [],
       pipeline: {
         build: {
@@ -195,7 +195,7 @@ describe("stabilize-env-mode", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       pipeline: {
         build: {},
       },
@@ -226,7 +226,7 @@ describe("stabilize-env-mode", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       globalPassThroughEnv: ["GLOBAL_PASSTHROUGH"],
       pipeline: {
         build: {
@@ -260,7 +260,7 @@ describe("stabilize-env-mode", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       globalPassThroughEnv: ["GLOBAL_PASSTHROUGH"],
       pipeline: {
         build: {
@@ -294,7 +294,7 @@ describe("stabilize-env-mode", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       globalPassThroughEnv: [
         "EXPERIMENTAL_GLOBAL_PASSTHROUGH",
         "GLOBAL_PASSTHROUGH",

--- a/packages/turbo-codemod/__tests__/stabilize-ui.test.ts
+++ b/packages/turbo-codemod/__tests__/stabilize-ui.test.ts
@@ -21,7 +21,7 @@ describe("stabilize-ui", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       tasks: {
         build: {
           outputs: ["dist"],
@@ -54,7 +54,7 @@ describe("stabilize-ui", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       tasks: {
         build: {
           outputs: ["dist"],
@@ -87,7 +87,7 @@ describe("stabilize-ui", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       tasks: {
         build: {
           outputs: ["dist"],

--- a/packages/turbo-codemod/__tests__/transform-env-literals-to-wildcards.test.ts
+++ b/packages/turbo-codemod/__tests__/transform-env-literals-to-wildcards.test.ts
@@ -82,7 +82,7 @@ describe.only("transform-env-literals-to-wildcards", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       globalEnv: [],
       globalPassThroughEnv: [],
       pipeline: {
@@ -118,7 +118,7 @@ describe.only("transform-env-literals-to-wildcards", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       pipeline: {
         build: {},
       },
@@ -149,7 +149,7 @@ describe.only("transform-env-literals-to-wildcards", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       globalEnv: ["NO!", "\\!!!", "\\!!!"],
       globalPassThroughEnv: ["DOES", "\\*\\*BOLD\\*\\*", "WORK"],
       pipeline: {
@@ -185,7 +185,7 @@ describe.only("transform-env-literals-to-wildcards", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       globalEnv: ["\\!\\*!\\*"],
       globalPassThroughEnv: ["\\!\\*!\\*"],
       pipeline: {

--- a/packages/turbo-codemod/__tests__/update-schema-json-url.test.ts
+++ b/packages/turbo-codemod/__tests__/update-schema-json-url.test.ts
@@ -21,7 +21,7 @@ describe("update-schema-url", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.v2.json",
+      $schema: "https://turborepo.com/schema.v2.json",
       tasks: {
         build: {
           outputs: ["dist/**"],
@@ -54,7 +54,7 @@ describe("update-schema-url", () => {
     });
 
     expect(JSON.parse(read("turbo.json") || "{}")).toStrictEqual({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       tasks: {
         build: {
           outputs: ["dist/**"],

--- a/packages/turbo-codemod/package.json
+++ b/packages/turbo-codemod/package.json
@@ -2,7 +2,7 @@
   "name": "@turbo/codemod",
   "version": "2.5.1-canary.1",
   "description": "Provides Codemod transformations to help upgrade your Turborepo codebase when a feature is deprecated.",
-  "homepage": "https://turbo.build/repo",
+  "homepage": "https://turborepo.com/repo",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/turbo-codemod/src/transforms/update-schema-json-url.ts
+++ b/packages/turbo-codemod/src/transforms/update-schema-json-url.ts
@@ -7,7 +7,7 @@ import type { Transformer, TransformerArgs } from "../types";
 // transformer details
 const TRANSFORMER = "update-schema-json-url";
 const DESCRIPTION =
-  'Update the "$schema" property in turbo.json from "https://turbo.build/schema.v1.json" to "https://turbo.build/schema.v2.json"';
+  'Update the "$schema" property in turbo.json from "https://turborepo.com/schema.v1.json" to "https://turborepo.com/schema.v2.json"';
 const INTRODUCED_IN = "2.0.0";
 
 /**
@@ -15,8 +15,8 @@ const INTRODUCED_IN = "2.0.0";
  */
 function updateSchemaUrl(content: string): string {
   return content.replace(
-    "https://turbo.build/schema.v1.json",
-    "https://turbo.build/schema.v2.json"
+    "https://turborepo.com/schema.v1.json",
+    "https://turborepo.com/schema.v2.json"
   );
 }
 
@@ -44,7 +44,7 @@ export function transformer({
     const turboConfigContent = fs.readFileSync(turboConfigPath, "utf8");
 
     // Check if it has the v1 schema URL
-    if (turboConfigContent.includes("https://turbo.build/schema.v1.json")) {
+    if (turboConfigContent.includes("https://turborepo.com/schema.v1.json")) {
       // Replace the v1 schema URL with the current one
       const updatedContent = updateSchemaUrl(turboConfigContent);
 

--- a/packages/turbo-gen/README.md
+++ b/packages/turbo-gen/README.md
@@ -1,6 +1,6 @@
-https://turbo.build/docs/guides/generating-code# `@turbo/gen`
+https://turborepo.com/docs/guides/generating-code# `@turbo/gen`
 
-Types for working with [Turborepo Generators](https://turbo.build/docs/guides/generating-code).
+Types for working with [Turborepo Generators](https://turborepo.com/docs/guides/generating-code).
 
 ## Usage
 
@@ -31,8 +31,8 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
 }
 ```
 
-Learn more about Turborepo Generators in the [docs](https://turbo.build/docs/guides/generating-code)
+Learn more about Turborepo Generators in the [docs](https://turborepo.com/docs/guides/generating-code)
 
 ---
 
-For more information about Turborepo, visit [turbo.build](https://turbo.build) and follow us on X ([@turborepo](https://x.com/turborepo))!
+For more information about Turborepo, visit [turborepo.com](https://turborepo.com) and follow us on X ([@turborepo](https://x.com/turborepo))!

--- a/packages/turbo-gen/package.json
+++ b/packages/turbo-gen/package.json
@@ -2,7 +2,7 @@
   "name": "@turbo/gen",
   "version": "2.5.1-canary.1",
   "description": "Extend a Turborepo",
-  "homepage": "https://turbo.build/repo",
+  "homepage": "https://turborepo.com/repo",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/turbo-gen/src/generators/custom.ts
+++ b/packages/turbo-gen/src/generators/custom.ts
@@ -50,7 +50,7 @@ export async function generate({
     } else {
       logger.log();
       logger.dimmed(
-        "Learn more about custom Turborepo generators - https://turbo.build/docs/guides/generating-code#custom-generators"
+        "Learn more about custom Turborepo generators - https://turborepo.com/docs/guides/generating-code#custom-generators"
       );
       return;
     }
@@ -87,7 +87,7 @@ export async function generate({
       logger.log();
       logger.info(`Congrats! You just ran your first Turborepo generator`);
       logger.dimmed(
-        "Learn more about custom Turborepo generators - https://turbo.build/docs/guides/generating-code#custom-generators"
+        "Learn more about custom Turborepo generators - https://turborepo.com/docs/guides/generating-code#custom-generators"
       );
     }
   }

--- a/packages/turbo-gen/src/templates/simple-js/templates/turborepo-generators.hbs
+++ b/packages/turbo-gen/src/templates/simple-js/templates/turborepo-generators.hbs
@@ -2,4 +2,4 @@
 
 ### Created with Turborepo Generators
 
-Read the docs at [turbo.build](https://turbo.build/docs/guides/generating-code).
+Read the docs at [turborepo.com](https://turborepo.com/docs/guides/generating-code).

--- a/packages/turbo-gen/src/templates/simple-ts/templates/turborepo-generators.hbs
+++ b/packages/turbo-gen/src/templates/simple-ts/templates/turborepo-generators.hbs
@@ -2,4 +2,4 @@
 
 ### Created with Turborepo Generators
 
-Read the docs at [turbo.build](https://turbo.build/docs/guides/generating-code).
+Read the docs at [turborepo.com](https://turborepo.com/docs/guides/generating-code).

--- a/packages/turbo-ignore/README.md
+++ b/packages/turbo-ignore/README.md
@@ -100,4 +100,4 @@ When deploying on [Vercel](https://vercel.com), `turbo-ignore` can make a more a
 
 ---
 
-For more information about Turborepo, visit [turbo.build](https://turbo.build) and follow us on X ([@turborepo](https://x.com/turborepo))!
+For more information about Turborepo, visit [turborepo.com](https://turborepo.com) and follow us on X ([@turborepo](https://x.com/turborepo))!

--- a/packages/turbo-ignore/package.json
+++ b/packages/turbo-ignore/package.json
@@ -2,7 +2,7 @@
   "name": "turbo-ignore",
   "version": "2.5.1-canary.1",
   "description": "",
-  "homepage": "https://turbo.build/repo",
+  "homepage": "https://turborepo.com/repo",
   "keywords": [],
   "author": "Jared Palmer",
   "license": "MIT",

--- a/packages/turbo-releaser/src/native.ts
+++ b/packages/turbo-releaser/src/native.ts
@@ -59,7 +59,7 @@ async function generateNativePackage({
     description: `The ${os}-${arch} binary for turbo, a monorepo build system.`,
     repository: "https://github.com/vercel/turborepo",
     bugs: "https://github.com/vercel/turborepo/issues",
-    homepage: "https://turbo.build/repo",
+    homepage: "https://turborepo.com/repo",
     license: "MIT",
     os: [nodeOSLookup[os]],
     cpu: [arch],

--- a/packages/turbo-repository/js/package.json
+++ b/packages/turbo-repository/js/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1-canary.15",
   "description": "",
   "bugs": "https://github.com/vercel/turborepo/issues",
-  "homepage": "https://turbo.build/repo",
+  "homepage": "https://turborepo.com/repo",
   "license": "MIT",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/turbo-repository/package.json
+++ b/packages/turbo-repository/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "",
   "bugs": "https://github.com/vercel/turborepo/issues",
-  "homepage": "https://turbo.build/repo",
+  "homepage": "https://turborepo.com/repo",
   "scripts": {
     "build": "bash scripts/build.sh --dts ../js/index.d.ts",
     "build:release": "bash scripts/build.sh --release",

--- a/packages/turbo-telemetry/README.md
+++ b/packages/turbo-telemetry/README.md
@@ -7,7 +7,7 @@ Any changes made here should also be made to that crate as well.
 ## Overview
 
 This package provides a way to optionally record anonymous usage data that originates from the turborepo node packages.
-This information is used to shape the Turborepo roadmap and prioritize features. You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the [documentation](https://turbo.build/docs/telemetry):
+This information is used to shape the Turborepo roadmap and prioritize features. You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the [documentation](https://turborepo.com/docs/telemetry):
 
 ## Events
 

--- a/packages/turbo-telemetry/package.json
+++ b/packages/turbo-telemetry/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "description": "",
-  "homepage": "https://turbo.build/repo",
+  "homepage": "https://turborepo.com/repo",
   "keywords": [],
   "author": "Vercel",
   "license": "MIT",

--- a/packages/turbo-telemetry/src/cli.ts
+++ b/packages/turbo-telemetry/src/cli.ts
@@ -30,7 +30,7 @@ function status(options: TelemetryCLIOptions) {
       "You have opted-out of Turborepo anonymous telemetry. No data will be collected from your machine."
     );
   }
-  logger.log("Learn more: https://turbo.build/docs/telemetry");
+  logger.log("Learn more: https://turborepo.com/docs/telemetry");
 }
 
 function telemetry(action: TelemetryCLIAction, options: TelemetryCLIOptions) {

--- a/packages/turbo-telemetry/src/config.ts
+++ b/packages/turbo-telemetry/src/config.ts
@@ -167,7 +167,7 @@ export class TelemetryConfig {
       logger.grey(
         "You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:"
       );
-      logger.underline(picocolors.gray("https://turbo.build/docs/telemetry"));
+      logger.underline(picocolors.gray("https://turborepo.com/docs/telemetry"));
     }
 
     this.alertShown();

--- a/packages/turbo-test-utils/package.json
+++ b/packages/turbo-test-utils/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "description": "",
-  "homepage": "https://turbo.build/repo",
+  "homepage": "https://turborepo.com/repo",
   "keywords": [],
   "author": "Vercel",
   "main": "src/index.ts",

--- a/packages/turbo-types/README.md
+++ b/packages/turbo-types/README.md
@@ -4,4 +4,4 @@ TypeScript types for `turbo.json`
 
 ---
 
-For more information about Turborepo, visit [turbo.build/repo](https://turbo.build/repo) and follow us on X ([@turborepo](https://x.com/turborepo))!
+For more information about Turborepo, visit [turborepo.com/repo](https://turborepo.com/repo) and follow us on X ([@turborepo](https://x.com/turborepo))!

--- a/packages/turbo-types/package.json
+++ b/packages/turbo-types/package.json
@@ -2,7 +2,7 @@
   "name": "@turbo/types",
   "version": "2.5.1-canary.1",
   "description": "Turborepo types",
-  "homepage": "https://turbo.build/repo",
+  "homepage": "https://turborepo.com/repo",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/turbo-types/schemas/schema.json
+++ b/packages/turbo-types/schemas/schema.json
@@ -17,7 +17,7 @@
       "properties": {
         "$schema": {
           "type": "string",
-          "default": "https://turbo.build/schema.v2.json"
+          "default": "https://turborepo.com/schema.v2.json"
         },
         "tasks": {
           "type": "object",
@@ -25,7 +25,7 @@
             "$ref": "#/definitions/Pipeline",
             "description": "The name of a task that can be executed by turbo. If turbo finds a workspace package with a package.json scripts object with a matching key, it will apply the pipeline task configuration to that npm script during execution."
           },
-          "description": "An object representing the task dependency graph of your project. turbo interprets these conventions to schedule, execute, and cache the outputs of tasks in your project.\n\nDocumentation: https://turbo.build/docs/reference/configuration#tasks",
+          "description": "An object representing the task dependency graph of your project. turbo interprets these conventions to schedule, execute, and cache the outputs of tasks in your project.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#tasks",
           "default": {}
         },
         "globalDependencies": {
@@ -33,7 +33,7 @@
           "items": {
             "type": "string"
           },
-          "description": "A list of globs to include in the set of implicit global hash dependencies.\n\nThe contents of these files will be included in the global hashing algorithm and affect the hashes of all tasks.\n\nThis is useful for busting the cache based on:\n\n- .env files (not in Git)\n\n- any root level file that impacts package tasks that are not represented in the traditional dependency graph (e.g. a root tsconfig.json, jest.config.ts, .eslintrc, etc.)\n\nDocumentation: https://turbo.build/docs/reference/configuration#globaldependencies",
+          "description": "A list of globs to include in the set of implicit global hash dependencies.\n\nThe contents of these files will be included in the global hashing algorithm and affect the hashes of all tasks.\n\nThis is useful for busting the cache based on:\n\n- .env files (not in Git)\n\n- any root level file that impacts package tasks that are not represented in the traditional dependency graph (e.g. a root tsconfig.json, jest.config.ts, .eslintrc, etc.)\n\nDocumentation: https://turborepo.com/docs/reference/configuration#globaldependencies",
           "default": []
         },
         "globalEnv": {
@@ -41,7 +41,7 @@
           "items": {
             "$ref": "#/definitions/EnvWildcard"
           },
-          "description": "A list of environment variables for implicit global hash dependencies.\n\nThe variables included in this list will affect all task hashes.\n\nDocumentation: https://turbo.build/docs/reference/configuration#globalenv",
+          "description": "A list of environment variables for implicit global hash dependencies.\n\nThe variables included in this list will affect all task hashes.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#globalenv",
           "default": []
         },
         "globalPassThroughEnv": {
@@ -56,17 +56,17 @@
               }
             }
           ],
-          "description": "An allowlist of environment variables that should be made to all tasks, but should not contribute to the task's cache key, e.g. `AWS_SECRET_KEY`.\n\nDocumentation: https://turbo.build/docs/reference/configuration#globalpassthroughenv",
+          "description": "An allowlist of environment variables that should be made to all tasks, but should not contribute to the task's cache key, e.g. `AWS_SECRET_KEY`.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#globalpassthroughenv",
           "default": null
         },
         "remoteCache": {
           "$ref": "#/definitions/RemoteCache",
-          "description": "Configuration options that control how turbo interfaces with the remote cache.\n\nDocumentation: https://turbo.build/docs/core-concepts/remote-caching",
+          "description": "Configuration options that control how turbo interfaces with the remote cache.\n\nDocumentation: https://turborepo.com/docs/core-concepts/remote-caching",
           "default": {}
         },
         "ui": {
           "$ref": "#/definitions/UI",
-          "description": "Enable use of the UI for `turbo`.\n\nDocumentation: https://turbo.build/docs/reference/configuration#ui",
+          "description": "Enable use of the UI for `turbo`.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#ui",
           "default": "stream"
         },
         "dangerouslyDisablePackageManagerCheck": {
@@ -76,17 +76,17 @@
         },
         "cacheDir": {
           "$ref": "#/definitions/RelativeUnixPath",
-          "description": "Specify the filesystem cache directory.\n\nDocumentation: https://turbo.build/docs/reference/configuration#cachedir",
+          "description": "Specify the filesystem cache directory.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#cachedir",
           "default": ".turbo/cache"
         },
         "daemon": {
           "type": "boolean",
-          "description": "Turborepo runs a background process to pre-calculate some expensive operations. This standalone process (daemon) is a performance optimization, and not required for proper functioning of `turbo`.\n\nDocumentation: https://turbo.build/docs/reference/configuration#daemon",
+          "description": "Turborepo runs a background process to pre-calculate some expensive operations. This standalone process (daemon) is a performance optimization, and not required for proper functioning of `turbo`.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#daemon",
           "default": false
         },
         "envMode": {
           "$ref": "#/definitions/EnvMode",
-          "description": "Turborepo's Environment Modes allow you to control which environment variables are available to a task at runtime:\n\n- `\"strict\"`: Filter environment variables to only those that are specified in the `env` and `globalEnv` keys in `turbo.json`.\n- `\"loose\"`: Allow all environment variables for the process to be available.\n\nDocumentation: https://turbo.build/docs/reference/configuration#envmode",
+          "description": "Turborepo's Environment Modes allow you to control which environment variables are available to a task at runtime:\n\n- `\"strict\"`: Filter environment variables to only those that are specified in the `env` and `globalEnv` keys in `turbo.json`.\n- `\"loose\"`: Allow all environment variables for the process to be available.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#envmode",
           "default": "strict"
         },
         "boundaries": {
@@ -107,7 +107,7 @@
           "items": {
             "type": "string"
           },
-          "description": "The list of tasks that this task depends on.\n\nPrefixing an item in dependsOn with a ^ prefix tells turbo that this task depends on the package's topological dependencies completing the task first. (e.g. \"A package's build tasks should only run once all of its workspace dependencies have completed their own build commands.\")\n\nItems in dependsOn without a ^ prefix express the relationships between tasks within the same package (e.g. \"A package's test and lint commands depend on its own build being completed first.\")\n\nDocumentation: https://turbo.build/docs/reference/configuration#dependson",
+          "description": "The list of tasks that this task depends on.\n\nPrefixing an item in dependsOn with a ^ prefix tells turbo that this task depends on the package's topological dependencies completing the task first. (e.g. \"A package's build tasks should only run once all of its workspace dependencies have completed their own build commands.\")\n\nItems in dependsOn without a ^ prefix express the relationships between tasks within the same package (e.g. \"A package's test and lint commands depend on its own build being completed first.\")\n\nDocumentation: https://turborepo.com/docs/reference/configuration#dependson",
           "default": []
         },
         "env": {
@@ -115,7 +115,7 @@
           "items": {
             "$ref": "#/definitions/EnvWildcard"
           },
-          "description": "A list of environment variables that this task depends on.\n\nNote: If you are migrating from a turbo version 1.5 or below, you may be used to prefixing your variables with a $. You no longer need to use the $ prefix. (e.g. $GITHUB_TOKEN → GITHUB_TOKEN)\n\nDocumentation: https://turbo.build/docs/reference/configuration#env",
+          "description": "A list of environment variables that this task depends on.\n\nNote: If you are migrating from a turbo version 1.5 or below, you may be used to prefixing your variables with a $. You no longer need to use the $ prefix. (e.g. $GITHUB_TOKEN → GITHUB_TOKEN)\n\nDocumentation: https://turborepo.com/docs/reference/configuration#env",
           "default": []
         },
         "passThroughEnv": {
@@ -130,7 +130,7 @@
               }
             }
           ],
-          "description": "An allowlist of environment variables that should be made available in this task's environment, but should not contribute to the task's cache key, e.g. `AWS_SECRET_KEY`.\n\nDocumentation: https://turbo.build/docs/reference/configuration#passthroughenv",
+          "description": "An allowlist of environment variables that should be made available in this task's environment, but should not contribute to the task's cache key, e.g. `AWS_SECRET_KEY`.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#passthroughenv",
           "default": null
         },
         "outputs": {
@@ -138,12 +138,12 @@
           "items": {
             "type": "string"
           },
-          "description": "The set of glob patterns indicating a task's cacheable filesystem outputs.\n\nTurborepo captures task logs for all tasks. This enables us to cache tasks whose runs produce no artifacts other than logs (such as linters). Logs are always treated as a cacheable artifact and never need to be specified.\n\nDocumentation: https://turbo.build/docs/reference/configuration#outputs",
+          "description": "The set of glob patterns indicating a task's cacheable filesystem outputs.\n\nTurborepo captures task logs for all tasks. This enables us to cache tasks whose runs produce no artifacts other than logs (such as linters). Logs are always treated as a cacheable artifact and never need to be specified.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#outputs",
           "default": []
         },
         "cache": {
           "type": "boolean",
-          "description": "Whether or not to cache the outputs of the task.\n\nSetting cache to false is useful for long-running \"watch\" or development mode tasks.\n\nDocumentation: https://turbo.build/docs/reference/configuration#cache",
+          "description": "Whether or not to cache the outputs of the task.\n\nSetting cache to false is useful for long-running \"watch\" or development mode tasks.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#cache",
           "default": true
         },
         "inputs": {
@@ -151,27 +151,27 @@
           "items": {
             "type": "string"
           },
-          "description": "The set of glob patterns to consider as inputs to this task.\n\nChanges to files covered by these globs will cause a cache miss and the task will be rerun.\n\nIf a file has been changed that is **not** included in the set of globs, it will not cause a cache miss.\n\nIf omitted or empty, all files in the package are considered as inputs.\n\nDocumentation: https://turbo.build/docs/reference/configuration#inputs",
+          "description": "The set of glob patterns to consider as inputs to this task.\n\nChanges to files covered by these globs will cause a cache miss and the task will be rerun.\n\nIf a file has been changed that is **not** included in the set of globs, it will not cause a cache miss.\n\nIf omitted or empty, all files in the package are considered as inputs.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#inputs",
           "default": []
         },
         "outputLogs": {
           "$ref": "#/definitions/OutputLogs",
-          "description": "Output mode for the task.\n\n\"full\": Displays all output\n\n\"hash-only\": Show only the hashes of the tasks\n\n\"new-only\": Only show output from cache misses\n\n\"errors-only\": Only show output from task failures\n\n\"none\": Hides all task output\n\nDocumentation: https://turbo.build/docs/reference/run#--output-logs-option",
+          "description": "Output mode for the task.\n\n\"full\": Displays all output\n\n\"hash-only\": Show only the hashes of the tasks\n\n\"new-only\": Only show output from cache misses\n\n\"errors-only\": Only show output from task failures\n\n\"none\": Hides all task output\n\nDocumentation: https://turborepo.com/docs/reference/run#--output-logs-option",
           "default": "full"
         },
         "persistent": {
           "type": "boolean",
-          "description": "Indicates whether the task exits or not. Setting `persistent` to `true` tells turbo that this is a long-running task and will ensure that other tasks cannot depend on it.\n\nDocumentation: https://turbo.build/docs/reference/configuration#persistent",
+          "description": "Indicates whether the task exits or not. Setting `persistent` to `true` tells turbo that this is a long-running task and will ensure that other tasks cannot depend on it.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#persistent",
           "default": false
         },
         "interactive": {
           "type": "boolean",
-          "description": "Mark a task as interactive allowing it to receive input from stdin. Interactive tasks must be marked with \"cache\": false as the input they receive from stdin can change the outcome of the task.\n\nDocumentation: https://turbo.build/docs/reference/configuration#interactive",
+          "description": "Mark a task as interactive allowing it to receive input from stdin. Interactive tasks must be marked with \"cache\": false as the input they receive from stdin can change the outcome of the task.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#interactive",
           "default": false
         },
         "interruptible": {
           "type": "boolean",
-          "description": "Label a persistent task as interruptible to allow it to be restarted by `turbo watch`. `turbo watch` watches for changes to your packages and automatically restarts tasks that are affected. However, if a task is persistent, it will not be restarted by default. To enable restarting persistent tasks, set `interruptible` to true.\n\nDocumentation: https://turbo.build/docs/reference/configuration#interruptible",
+          "description": "Label a persistent task as interruptible to allow it to be restarted by `turbo watch`. `turbo watch` watches for changes to your packages and automatically restarts tasks that are affected. However, if a task is persistent, it will not be restarted by default. To enable restarting persistent tasks, set `interruptible` to true.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#interruptible",
           "default": false
         },
         "with": {
@@ -179,7 +179,7 @@
           "items": {
             "type": "string"
           },
-          "description": "A list of tasks that will run alongside this task.\n\nTasks in this list will not be run until completion before this task starts execution.\n\nDocumentation: https://turbo.build/docs/reference/configuration#with",
+          "description": "A list of tasks that will run alongside this task.\n\nTasks in this list will not be run until completion before this task starts execution.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#with",
           "default": []
         }
       },
@@ -208,7 +208,7 @@
         },
         "enabled": {
           "type": "boolean",
-          "description": "Indicates if the remote cache is enabled. When `false`, Turborepo will disable all remote cache operations, even if the repo has a valid token. If true, remote caching is enabled, but still requires the user to login and link their repo to a remote cache. Documentation: https://turbo.build/docs/core-concepts/remote-caching",
+          "description": "Indicates if the remote cache is enabled. When `false`, Turborepo will disable all remote cache operations, even if the repo has a valid token. If true, remote caching is enabled, but still requires the user to login and link their repo to a remote cache. Documentation: https://turborepo.com/docs/core-concepts/remote-caching",
           "default": true
         },
         "preflight": {
@@ -218,12 +218,12 @@
         },
         "apiUrl": {
           "type": "string",
-          "description": "Set endpoint for API calls to the remote cache. Documentation: https://turbo.build/docs/core-concepts/remote-caching#self-hosting",
+          "description": "Set endpoint for API calls to the remote cache. Documentation: https://turborepo.com/docs/core-concepts/remote-caching#self-hosting",
           "default": "https://vercel.com/api"
         },
         "loginUrl": {
           "type": "string",
-          "description": "Set endpoint for requesting tokens during `turbo login`. Documentation: https://turbo.build/docs/core-concepts/remote-caching#self-hosting",
+          "description": "Set endpoint for requesting tokens during `turbo login`. Documentation: https://turborepo.com/docs/core-concepts/remote-caching#self-hosting",
           "default": "https://vercel.com"
         },
         "timeout": {
@@ -324,7 +324,7 @@
       "properties": {
         "$schema": {
           "type": "string",
-          "default": "https://turbo.build/schema.v2.json"
+          "default": "https://turborepo.com/schema.v2.json"
         },
         "tasks": {
           "type": "object",
@@ -332,7 +332,7 @@
             "$ref": "#/definitions/Pipeline",
             "description": "The name of a task that can be executed by turbo. If turbo finds a workspace package with a package.json scripts object with a matching key, it will apply the pipeline task configuration to that npm script during execution."
           },
-          "description": "An object representing the task dependency graph of your project. turbo interprets these conventions to schedule, execute, and cache the outputs of tasks in your project.\n\nDocumentation: https://turbo.build/docs/reference/configuration#tasks",
+          "description": "An object representing the task dependency graph of your project. turbo interprets these conventions to schedule, execute, and cache the outputs of tasks in your project.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#tasks",
           "default": {}
         },
         "extends": {

--- a/packages/turbo-types/schemas/schema.v1.json
+++ b/packages/turbo-types/schemas/schema.v1.json
@@ -17,7 +17,7 @@
       "properties": {
         "$schema": {
           "type": "string",
-          "default": "https://turbo.build/schema.v1.json"
+          "default": "https://turborepo.com/schema.v1.json"
         },
         "pipeline": {
           "type": "object",
@@ -25,7 +25,7 @@
             "$ref": "#/definitions/PipelineV1",
             "description": "The name of a task that can be executed by turbo. If turbo finds a workspace package with a package.json scripts object with a matching key, it will apply the pipeline task configuration to that npm script during execution."
           },
-          "description": "An object representing the task dependency graph of your project. turbo interprets these conventions to schedule, execute, and cache the outputs of tasks in your project.\n\nDocumentation: https://turbo.build/docs/reference/configuration#tasks",
+          "description": "An object representing the task dependency graph of your project. turbo interprets these conventions to schedule, execute, and cache the outputs of tasks in your project.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#tasks",
           "default": {}
         },
         "extends": {
@@ -53,7 +53,7 @@
           "items": {
             "type": "string"
           },
-          "description": "The list of tasks that this task depends on.\n\nPrefixing an item in dependsOn with a ^ prefix tells turbo that this task depends on the package's topological dependencies completing the task first. (e.g. \"A package's build tasks should only run once all of its workspace dependencies have completed their own build commands.\")\n\nItems in dependsOn without a ^ prefix express the relationships between tasks within the same package (e.g. \"A package's test and lint commands depend on its own build being completed first.\")\n\nDocumentation: https://turbo.build/docs/reference/configuration#dependson",
+          "description": "The list of tasks that this task depends on.\n\nPrefixing an item in dependsOn with a ^ prefix tells turbo that this task depends on the package's topological dependencies completing the task first. (e.g. \"A package's build tasks should only run once all of its workspace dependencies have completed their own build commands.\")\n\nItems in dependsOn without a ^ prefix express the relationships between tasks within the same package (e.g. \"A package's test and lint commands depend on its own build being completed first.\")\n\nDocumentation: https://turborepo.com/docs/reference/configuration#dependson",
           "default": []
         },
         "env": {
@@ -61,7 +61,7 @@
           "items": {
             "$ref": "#/definitions/EnvWildcardV1"
           },
-          "description": "A list of environment variables that this task depends on.\n\nNote: If you are migrating from a turbo version 1.5 or below, you may be used to prefixing your variables with a $. You no longer need to use the $ prefix. (e.g. $GITHUB_TOKEN → GITHUB_TOKEN)\n\nDocumentation: https://turbo.build/docs/reference/configuration#env",
+          "description": "A list of environment variables that this task depends on.\n\nNote: If you are migrating from a turbo version 1.5 or below, you may be used to prefixing your variables with a $. You no longer need to use the $ prefix. (e.g. $GITHUB_TOKEN → GITHUB_TOKEN)\n\nDocumentation: https://turborepo.com/docs/reference/configuration#env",
           "default": []
         },
         "passThroughEnv": {
@@ -76,7 +76,7 @@
               }
             }
           ],
-          "description": "An allowlist of environment variables that should be made available in this task's environment, but should not contribute to the task's cache key, e.g. `AWS_SECRET_KEY`.\n\nDocumentation: https://turbo.build/docs/reference/configuration#passthroughenv",
+          "description": "An allowlist of environment variables that should be made available in this task's environment, but should not contribute to the task's cache key, e.g. `AWS_SECRET_KEY`.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#passthroughenv",
           "default": null
         },
         "dotEnv": {
@@ -99,12 +99,12 @@
           "items": {
             "type": "string"
           },
-          "description": "The set of glob patterns indicating a task's cacheable filesystem outputs.\n\nTurborepo captures task logs for all tasks. This enables us to cache tasks whose runs produce no artifacts other than logs (such as linters). Logs are always treated as a cacheable artifact and never need to be specified.\n\nDocumentation: https://turbo.build/docs/reference/configuration#outputs",
+          "description": "The set of glob patterns indicating a task's cacheable filesystem outputs.\n\nTurborepo captures task logs for all tasks. This enables us to cache tasks whose runs produce no artifacts other than logs (such as linters). Logs are always treated as a cacheable artifact and never need to be specified.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#outputs",
           "default": []
         },
         "cache": {
           "type": "boolean",
-          "description": "Whether or not to cache the outputs of the task.\n\nSetting cache to false is useful for long-running \"watch\" or development mode tasks.\n\nDocumentation: https://turbo.build/docs/reference/configuration#cache",
+          "description": "Whether or not to cache the outputs of the task.\n\nSetting cache to false is useful for long-running \"watch\" or development mode tasks.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#cache",
           "default": true
         },
         "inputs": {
@@ -112,22 +112,22 @@
           "items": {
             "type": "string"
           },
-          "description": "The set of glob patterns to consider as inputs to this task.\n\nChanges to files covered by these globs will cause a cache miss and the task will be rerun.\n\nIf a file has been changed that is **not** included in the set of globs, it will not cause a cache miss.\n\nIf omitted or empty, all files in the package are considered as inputs.\n\nDocumentation: https://turbo.build/docs/reference/configuration#inputs",
+          "description": "The set of glob patterns to consider as inputs to this task.\n\nChanges to files covered by these globs will cause a cache miss and the task will be rerun.\n\nIf a file has been changed that is **not** included in the set of globs, it will not cause a cache miss.\n\nIf omitted or empty, all files in the package are considered as inputs.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#inputs",
           "default": []
         },
         "outputMode": {
           "$ref": "#/definitions/OutputModeV1",
-          "description": "Output mode for the task.\n\n\"full\": Displays all output\n\n\"hash-only\": Show only the hashes of the tasks\n\n\"new-only\": Only show output from cache misses\n\n\"errors-only\": Only show output from task failures\n\n\"none\": Hides all task output\n\nDocumentation: https://turbo.build/docs/reference/run#--output-logs-option",
+          "description": "Output mode for the task.\n\n\"full\": Displays all output\n\n\"hash-only\": Show only the hashes of the tasks\n\n\"new-only\": Only show output from cache misses\n\n\"errors-only\": Only show output from task failures\n\n\"none\": Hides all task output\n\nDocumentation: https://turborepo.com/docs/reference/run#--output-logs-option",
           "default": "full"
         },
         "persistent": {
           "type": "boolean",
-          "description": "Indicates whether the task exits or not. Setting `persistent` to `true` tells turbo that this is a long-running task and will ensure that other tasks cannot depend on it.\n\nDocumentation: https://turbo.build/docs/reference/configuration#persistent",
+          "description": "Indicates whether the task exits or not. Setting `persistent` to `true` tells turbo that this is a long-running task and will ensure that other tasks cannot depend on it.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#persistent",
           "default": false
         },
         "interactive": {
           "type": "boolean",
-          "description": "Mark a task as interactive allowing it to receive input from stdin. Interactive tasks must be marked with \"cache\": false as the input they receive from stdin can change the outcome of the task.\n\nDocumentation: https://turbo.build/docs/reference/configuration#interactive",
+          "description": "Mark a task as interactive allowing it to receive input from stdin. Interactive tasks must be marked with \"cache\": false as the input they receive from stdin can change the outcome of the task.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#interactive",
           "default": false
         }
       },
@@ -154,7 +154,7 @@
       "properties": {
         "$schema": {
           "type": "string",
-          "default": "https://turbo.build/schema.v1.json"
+          "default": "https://turborepo.com/schema.v1.json"
         },
         "pipeline": {
           "type": "object",
@@ -162,7 +162,7 @@
             "$ref": "#/definitions/PipelineV1",
             "description": "The name of a task that can be executed by turbo. If turbo finds a workspace package with a package.json scripts object with a matching key, it will apply the pipeline task configuration to that npm script during execution."
           },
-          "description": "An object representing the task dependency graph of your project. turbo interprets these conventions to schedule, execute, and cache the outputs of tasks in your project.\n\nDocumentation: https://turbo.build/docs/reference/configuration#tasks",
+          "description": "An object representing the task dependency graph of your project. turbo interprets these conventions to schedule, execute, and cache the outputs of tasks in your project.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#tasks",
           "default": {}
         },
         "globalDependencies": {
@@ -170,7 +170,7 @@
           "items": {
             "type": "string"
           },
-          "description": "A list of globs to include in the set of implicit global hash dependencies.\n\nThe contents of these files will be included in the global hashing algorithm and affect the hashes of all tasks.\n\nThis is useful for busting the cache based on:\n\n- .env files (not in Git)\n\n- any root level file that impacts package tasks that are not represented in the traditional dependency graph (e.g. a root tsconfig.json, jest.config.ts, .eslintrc, etc.)\n\nDocumentation: https://turbo.build/docs/reference/configuration#globaldependencies",
+          "description": "A list of globs to include in the set of implicit global hash dependencies.\n\nThe contents of these files will be included in the global hashing algorithm and affect the hashes of all tasks.\n\nThis is useful for busting the cache based on:\n\n- .env files (not in Git)\n\n- any root level file that impacts package tasks that are not represented in the traditional dependency graph (e.g. a root tsconfig.json, jest.config.ts, .eslintrc, etc.)\n\nDocumentation: https://turborepo.com/docs/reference/configuration#globaldependencies",
           "default": []
         },
         "globalEnv": {
@@ -178,7 +178,7 @@
           "items": {
             "$ref": "#/definitions/EnvWildcardV1"
           },
-          "description": "A list of environment variables for implicit global hash dependencies.\n\nThe variables included in this list will affect all task hashes.\n\nDocumentation: https://turbo.build/docs/reference/configuration#globalenv",
+          "description": "A list of environment variables for implicit global hash dependencies.\n\nThe variables included in this list will affect all task hashes.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#globalenv",
           "default": []
         },
         "globalPassThroughEnv": {
@@ -193,7 +193,7 @@
               }
             }
           ],
-          "description": "An allowlist of environment variables that should be made to all tasks, but should not contribute to the task's cache key, e.g. `AWS_SECRET_KEY`.\n\nDocumentation: https://turbo.build/docs/reference/configuration#globalpassthroughenv",
+          "description": "An allowlist of environment variables that should be made to all tasks, but should not contribute to the task's cache key, e.g. `AWS_SECRET_KEY`.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#globalpassthroughenv",
           "default": null
         },
         "globalDotEnv": {
@@ -213,12 +213,12 @@
         },
         "remoteCache": {
           "$ref": "#/definitions/RemoteCacheV1",
-          "description": "Configuration options that control how turbo interfaces with the remote cache.\n\nDocumentation: https://turbo.build/docs/core-concepts/remote-caching",
+          "description": "Configuration options that control how turbo interfaces with the remote cache.\n\nDocumentation: https://turborepo.com/docs/core-concepts/remote-caching",
           "default": {}
         },
         "experimentalUI": {
           "type": "boolean",
-          "description": "Enable use of the new UI for `turbo`\n\nDocumentation: https://turbo.build/docs/reference/configuration#ui",
+          "description": "Enable use of the new UI for `turbo`\n\nDocumentation: https://turborepo.com/docs/reference/configuration#ui",
           "default": false
         }
       },
@@ -237,7 +237,7 @@
         },
         "enabled": {
           "type": "boolean",
-          "description": "Indicates if the remote cache is enabled. When `false`, Turborepo will disable all remote cache operations, even if the repo has a valid token. If true, remote caching is enabled, but still requires the user to login and link their repo to a remote cache. Documentation: https://turbo.build/docs/core-concepts/remote-caching",
+          "description": "Indicates if the remote cache is enabled. When `false`, Turborepo will disable all remote cache operations, even if the repo has a valid token. If true, remote caching is enabled, but still requires the user to login and link their repo to a remote cache. Documentation: https://turborepo.com/docs/core-concepts/remote-caching",
           "default": true
         }
       },

--- a/packages/turbo-types/schemas/schema.v2.json
+++ b/packages/turbo-types/schemas/schema.v2.json
@@ -17,7 +17,7 @@
       "properties": {
         "$schema": {
           "type": "string",
-          "default": "https://turbo.build/schema.v2.json"
+          "default": "https://turborepo.com/schema.v2.json"
         },
         "tasks": {
           "type": "object",
@@ -25,7 +25,7 @@
             "$ref": "#/definitions/Pipeline",
             "description": "The name of a task that can be executed by turbo. If turbo finds a workspace package with a package.json scripts object with a matching key, it will apply the pipeline task configuration to that npm script during execution."
           },
-          "description": "An object representing the task dependency graph of your project. turbo interprets these conventions to schedule, execute, and cache the outputs of tasks in your project.\n\nDocumentation: https://turbo.build/docs/reference/configuration#tasks",
+          "description": "An object representing the task dependency graph of your project. turbo interprets these conventions to schedule, execute, and cache the outputs of tasks in your project.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#tasks",
           "default": {}
         },
         "globalDependencies": {
@@ -33,7 +33,7 @@
           "items": {
             "type": "string"
           },
-          "description": "A list of globs to include in the set of implicit global hash dependencies.\n\nThe contents of these files will be included in the global hashing algorithm and affect the hashes of all tasks.\n\nThis is useful for busting the cache based on:\n\n- .env files (not in Git)\n\n- any root level file that impacts package tasks that are not represented in the traditional dependency graph (e.g. a root tsconfig.json, jest.config.ts, .eslintrc, etc.)\n\nDocumentation: https://turbo.build/docs/reference/configuration#globaldependencies",
+          "description": "A list of globs to include in the set of implicit global hash dependencies.\n\nThe contents of these files will be included in the global hashing algorithm and affect the hashes of all tasks.\n\nThis is useful for busting the cache based on:\n\n- .env files (not in Git)\n\n- any root level file that impacts package tasks that are not represented in the traditional dependency graph (e.g. a root tsconfig.json, jest.config.ts, .eslintrc, etc.)\n\nDocumentation: https://turborepo.com/docs/reference/configuration#globaldependencies",
           "default": []
         },
         "globalEnv": {
@@ -41,7 +41,7 @@
           "items": {
             "$ref": "#/definitions/EnvWildcard"
           },
-          "description": "A list of environment variables for implicit global hash dependencies.\n\nThe variables included in this list will affect all task hashes.\n\nDocumentation: https://turbo.build/docs/reference/configuration#globalenv",
+          "description": "A list of environment variables for implicit global hash dependencies.\n\nThe variables included in this list will affect all task hashes.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#globalenv",
           "default": []
         },
         "globalPassThroughEnv": {
@@ -56,17 +56,17 @@
               }
             }
           ],
-          "description": "An allowlist of environment variables that should be made to all tasks, but should not contribute to the task's cache key, e.g. `AWS_SECRET_KEY`.\n\nDocumentation: https://turbo.build/docs/reference/configuration#globalpassthroughenv",
+          "description": "An allowlist of environment variables that should be made to all tasks, but should not contribute to the task's cache key, e.g. `AWS_SECRET_KEY`.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#globalpassthroughenv",
           "default": null
         },
         "remoteCache": {
           "$ref": "#/definitions/RemoteCache",
-          "description": "Configuration options that control how turbo interfaces with the remote cache.\n\nDocumentation: https://turbo.build/docs/core-concepts/remote-caching",
+          "description": "Configuration options that control how turbo interfaces with the remote cache.\n\nDocumentation: https://turborepo.com/docs/core-concepts/remote-caching",
           "default": {}
         },
         "ui": {
           "$ref": "#/definitions/UI",
-          "description": "Enable use of the UI for `turbo`.\n\nDocumentation: https://turbo.build/docs/reference/configuration#ui",
+          "description": "Enable use of the UI for `turbo`.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#ui",
           "default": "stream"
         },
         "dangerouslyDisablePackageManagerCheck": {
@@ -76,17 +76,17 @@
         },
         "cacheDir": {
           "$ref": "#/definitions/RelativeUnixPath",
-          "description": "Specify the filesystem cache directory.\n\nDocumentation: https://turbo.build/docs/reference/configuration#cachedir",
+          "description": "Specify the filesystem cache directory.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#cachedir",
           "default": ".turbo/cache"
         },
         "daemon": {
           "type": "boolean",
-          "description": "Turborepo runs a background process to pre-calculate some expensive operations. This standalone process (daemon) is a performance optimization, and not required for proper functioning of `turbo`.\n\nDocumentation: https://turbo.build/docs/reference/configuration#daemon",
+          "description": "Turborepo runs a background process to pre-calculate some expensive operations. This standalone process (daemon) is a performance optimization, and not required for proper functioning of `turbo`.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#daemon",
           "default": false
         },
         "envMode": {
           "$ref": "#/definitions/EnvMode",
-          "description": "Turborepo's Environment Modes allow you to control which environment variables are available to a task at runtime:\n\n- `\"strict\"`: Filter environment variables to only those that are specified in the `env` and `globalEnv` keys in `turbo.json`.\n- `\"loose\"`: Allow all environment variables for the process to be available.\n\nDocumentation: https://turbo.build/docs/reference/configuration#envmode",
+          "description": "Turborepo's Environment Modes allow you to control which environment variables are available to a task at runtime:\n\n- `\"strict\"`: Filter environment variables to only those that are specified in the `env` and `globalEnv` keys in `turbo.json`.\n- `\"loose\"`: Allow all environment variables for the process to be available.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#envmode",
           "default": "strict"
         },
         "boundaries": {
@@ -107,7 +107,7 @@
           "items": {
             "type": "string"
           },
-          "description": "The list of tasks that this task depends on.\n\nPrefixing an item in dependsOn with a ^ prefix tells turbo that this task depends on the package's topological dependencies completing the task first. (e.g. \"A package's build tasks should only run once all of its workspace dependencies have completed their own build commands.\")\n\nItems in dependsOn without a ^ prefix express the relationships between tasks within the same package (e.g. \"A package's test and lint commands depend on its own build being completed first.\")\n\nDocumentation: https://turbo.build/docs/reference/configuration#dependson",
+          "description": "The list of tasks that this task depends on.\n\nPrefixing an item in dependsOn with a ^ prefix tells turbo that this task depends on the package's topological dependencies completing the task first. (e.g. \"A package's build tasks should only run once all of its workspace dependencies have completed their own build commands.\")\n\nItems in dependsOn without a ^ prefix express the relationships between tasks within the same package (e.g. \"A package's test and lint commands depend on its own build being completed first.\")\n\nDocumentation: https://turborepo.com/docs/reference/configuration#dependson",
           "default": []
         },
         "env": {
@@ -115,7 +115,7 @@
           "items": {
             "$ref": "#/definitions/EnvWildcard"
           },
-          "description": "A list of environment variables that this task depends on.\n\nNote: If you are migrating from a turbo version 1.5 or below, you may be used to prefixing your variables with a $. You no longer need to use the $ prefix. (e.g. $GITHUB_TOKEN → GITHUB_TOKEN)\n\nDocumentation: https://turbo.build/docs/reference/configuration#env",
+          "description": "A list of environment variables that this task depends on.\n\nNote: If you are migrating from a turbo version 1.5 or below, you may be used to prefixing your variables with a $. You no longer need to use the $ prefix. (e.g. $GITHUB_TOKEN → GITHUB_TOKEN)\n\nDocumentation: https://turborepo.com/docs/reference/configuration#env",
           "default": []
         },
         "passThroughEnv": {
@@ -130,7 +130,7 @@
               }
             }
           ],
-          "description": "An allowlist of environment variables that should be made available in this task's environment, but should not contribute to the task's cache key, e.g. `AWS_SECRET_KEY`.\n\nDocumentation: https://turbo.build/docs/reference/configuration#passthroughenv",
+          "description": "An allowlist of environment variables that should be made available in this task's environment, but should not contribute to the task's cache key, e.g. `AWS_SECRET_KEY`.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#passthroughenv",
           "default": null
         },
         "outputs": {
@@ -138,12 +138,12 @@
           "items": {
             "type": "string"
           },
-          "description": "The set of glob patterns indicating a task's cacheable filesystem outputs.\n\nTurborepo captures task logs for all tasks. This enables us to cache tasks whose runs produce no artifacts other than logs (such as linters). Logs are always treated as a cacheable artifact and never need to be specified.\n\nDocumentation: https://turbo.build/docs/reference/configuration#outputs",
+          "description": "The set of glob patterns indicating a task's cacheable filesystem outputs.\n\nTurborepo captures task logs for all tasks. This enables us to cache tasks whose runs produce no artifacts other than logs (such as linters). Logs are always treated as a cacheable artifact and never need to be specified.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#outputs",
           "default": []
         },
         "cache": {
           "type": "boolean",
-          "description": "Whether or not to cache the outputs of the task.\n\nSetting cache to false is useful for long-running \"watch\" or development mode tasks.\n\nDocumentation: https://turbo.build/docs/reference/configuration#cache",
+          "description": "Whether or not to cache the outputs of the task.\n\nSetting cache to false is useful for long-running \"watch\" or development mode tasks.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#cache",
           "default": true
         },
         "inputs": {
@@ -151,27 +151,27 @@
           "items": {
             "type": "string"
           },
-          "description": "The set of glob patterns to consider as inputs to this task.\n\nChanges to files covered by these globs will cause a cache miss and the task will be rerun.\n\nIf a file has been changed that is **not** included in the set of globs, it will not cause a cache miss.\n\nIf omitted or empty, all files in the package are considered as inputs.\n\nDocumentation: https://turbo.build/docs/reference/configuration#inputs",
+          "description": "The set of glob patterns to consider as inputs to this task.\n\nChanges to files covered by these globs will cause a cache miss and the task will be rerun.\n\nIf a file has been changed that is **not** included in the set of globs, it will not cause a cache miss.\n\nIf omitted or empty, all files in the package are considered as inputs.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#inputs",
           "default": []
         },
         "outputLogs": {
           "$ref": "#/definitions/OutputLogs",
-          "description": "Output mode for the task.\n\n\"full\": Displays all output\n\n\"hash-only\": Show only the hashes of the tasks\n\n\"new-only\": Only show output from cache misses\n\n\"errors-only\": Only show output from task failures\n\n\"none\": Hides all task output\n\nDocumentation: https://turbo.build/docs/reference/run#--output-logs-option",
+          "description": "Output mode for the task.\n\n\"full\": Displays all output\n\n\"hash-only\": Show only the hashes of the tasks\n\n\"new-only\": Only show output from cache misses\n\n\"errors-only\": Only show output from task failures\n\n\"none\": Hides all task output\n\nDocumentation: https://turborepo.com/docs/reference/run#--output-logs-option",
           "default": "full"
         },
         "persistent": {
           "type": "boolean",
-          "description": "Indicates whether the task exits or not. Setting `persistent` to `true` tells turbo that this is a long-running task and will ensure that other tasks cannot depend on it.\n\nDocumentation: https://turbo.build/docs/reference/configuration#persistent",
+          "description": "Indicates whether the task exits or not. Setting `persistent` to `true` tells turbo that this is a long-running task and will ensure that other tasks cannot depend on it.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#persistent",
           "default": false
         },
         "interactive": {
           "type": "boolean",
-          "description": "Mark a task as interactive allowing it to receive input from stdin. Interactive tasks must be marked with \"cache\": false as the input they receive from stdin can change the outcome of the task.\n\nDocumentation: https://turbo.build/docs/reference/configuration#interactive",
+          "description": "Mark a task as interactive allowing it to receive input from stdin. Interactive tasks must be marked with \"cache\": false as the input they receive from stdin can change the outcome of the task.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#interactive",
           "default": false
         },
         "interruptible": {
           "type": "boolean",
-          "description": "Label a persistent task as interruptible to allow it to be restarted by `turbo watch`. `turbo watch` watches for changes to your packages and automatically restarts tasks that are affected. However, if a task is persistent, it will not be restarted by default. To enable restarting persistent tasks, set `interruptible` to true.\n\nDocumentation: https://turbo.build/docs/reference/configuration#interruptible",
+          "description": "Label a persistent task as interruptible to allow it to be restarted by `turbo watch`. `turbo watch` watches for changes to your packages and automatically restarts tasks that are affected. However, if a task is persistent, it will not be restarted by default. To enable restarting persistent tasks, set `interruptible` to true.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#interruptible",
           "default": false
         },
         "with": {
@@ -179,7 +179,7 @@
           "items": {
             "type": "string"
           },
-          "description": "A list of tasks that will run alongside this task.\n\nTasks in this list will not be run until completion before this task starts execution.\n\nDocumentation: https://turbo.build/docs/reference/configuration#with",
+          "description": "A list of tasks that will run alongside this task.\n\nTasks in this list will not be run until completion before this task starts execution.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#with",
           "default": []
         }
       },
@@ -208,7 +208,7 @@
         },
         "enabled": {
           "type": "boolean",
-          "description": "Indicates if the remote cache is enabled. When `false`, Turborepo will disable all remote cache operations, even if the repo has a valid token. If true, remote caching is enabled, but still requires the user to login and link their repo to a remote cache. Documentation: https://turbo.build/docs/core-concepts/remote-caching",
+          "description": "Indicates if the remote cache is enabled. When `false`, Turborepo will disable all remote cache operations, even if the repo has a valid token. If true, remote caching is enabled, but still requires the user to login and link their repo to a remote cache. Documentation: https://turborepo.com/docs/core-concepts/remote-caching",
           "default": true
         },
         "preflight": {
@@ -218,12 +218,12 @@
         },
         "apiUrl": {
           "type": "string",
-          "description": "Set endpoint for API calls to the remote cache. Documentation: https://turbo.build/docs/core-concepts/remote-caching#self-hosting",
+          "description": "Set endpoint for API calls to the remote cache. Documentation: https://turborepo.com/docs/core-concepts/remote-caching#self-hosting",
           "default": "https://vercel.com/api"
         },
         "loginUrl": {
           "type": "string",
-          "description": "Set endpoint for requesting tokens during `turbo login`. Documentation: https://turbo.build/docs/core-concepts/remote-caching#self-hosting",
+          "description": "Set endpoint for requesting tokens during `turbo login`. Documentation: https://turborepo.com/docs/core-concepts/remote-caching#self-hosting",
           "default": "https://vercel.com"
         },
         "timeout": {
@@ -324,7 +324,7 @@
       "properties": {
         "$schema": {
           "type": "string",
-          "default": "https://turbo.build/schema.v2.json"
+          "default": "https://turborepo.com/schema.v2.json"
         },
         "tasks": {
           "type": "object",
@@ -332,7 +332,7 @@
             "$ref": "#/definitions/Pipeline",
             "description": "The name of a task that can be executed by turbo. If turbo finds a workspace package with a package.json scripts object with a matching key, it will apply the pipeline task configuration to that npm script during execution."
           },
-          "description": "An object representing the task dependency graph of your project. turbo interprets these conventions to schedule, execute, and cache the outputs of tasks in your project.\n\nDocumentation: https://turbo.build/docs/reference/configuration#tasks",
+          "description": "An object representing the task dependency graph of your project. turbo interprets these conventions to schedule, execute, and cache the outputs of tasks in your project.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#tasks",
           "default": {}
         },
         "extends": {

--- a/packages/turbo-types/src/types/config-v1.ts
+++ b/packages/turbo-types/src/types/config-v1.ts
@@ -25,7 +25,7 @@ export interface PipelineV1 {
    * same package (e.g. "A package's test and lint commands depend on its own build being
    * completed first.")
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#dependson
+   * Documentation: https://turborepo.com/docs/reference/configuration#dependson
    *
    * @defaultValue `[]`
    */
@@ -39,7 +39,7 @@ export interface PipelineV1 {
    * You no longer need to use the $ prefix.
    * (e.g. $GITHUB_TOKEN → GITHUB_TOKEN)
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#env
+   * Documentation: https://turborepo.com/docs/reference/configuration#env
    *
    * @defaultValue `[]`
    */
@@ -50,7 +50,7 @@ export interface PipelineV1 {
    * task's environment, but should not contribute to the task's cache key,
    * e.g. `AWS_SECRET_KEY`.
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#passthroughenv
+   * Documentation: https://turborepo.com/docs/reference/configuration#passthroughenv
    *
    * @defaultValue `null`
    */
@@ -71,7 +71,7 @@ export interface PipelineV1 {
    * produce no artifacts other than logs (such as linters). Logs are always treated as a
    * cacheable artifact and never need to be specified.
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#outputs
+   * Documentation: https://turborepo.com/docs/reference/configuration#outputs
    *
    * @defaultValue `[]`
    */
@@ -82,7 +82,7 @@ export interface PipelineV1 {
    *
    * Setting cache to false is useful for long-running "watch" or development mode tasks.
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#cache
+   * Documentation: https://turborepo.com/docs/reference/configuration#cache
    *
    * @defaultValue `true`
    */
@@ -99,7 +99,7 @@ export interface PipelineV1 {
    *
    * If omitted or empty, all files in the package are considered as inputs.
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#inputs
+   * Documentation: https://turborepo.com/docs/reference/configuration#inputs
    *
    * @defaultValue `[]`
    */
@@ -118,7 +118,7 @@ export interface PipelineV1 {
    *
    * "none": Hides all task output
    *
-   * Documentation: https://turbo.build/docs/reference/run#--output-logs-option
+   * Documentation: https://turborepo.com/docs/reference/run#--output-logs-option
    *
    * @defaultValue `"full"`
    */
@@ -129,7 +129,7 @@ export interface PipelineV1 {
    * turbo that this is a long-running task and will ensure that other tasks
    * cannot depend on it.
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#persistent
+   * Documentation: https://turborepo.com/docs/reference/configuration#persistent
    *
    * @defaultValue `false`
    */
@@ -140,7 +140,7 @@ export interface PipelineV1 {
    * Interactive tasks must be marked with "cache": false as the input
    * they receive from stdin can change the outcome of the task.
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#interactive
+   * Documentation: https://turborepo.com/docs/reference/configuration#interactive
    *
    * @defaultValue `false`
    */
@@ -148,14 +148,14 @@ export interface PipelineV1 {
 }
 
 export interface BaseSchemaV1 {
-  /** @defaultValue `https://turbo.build/schema.v1.json` */
+  /** @defaultValue `https://turborepo.com/schema.v1.json` */
   $schema?: string;
   /**
    * An object representing the task dependency graph of your project. turbo interprets
    * these conventions to schedule, execute, and cache the outputs of tasks in
    * your project.
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#tasks
+   * Documentation: https://turborepo.com/docs/reference/configuration#tasks
    *
    * @defaultValue `{}`
    */
@@ -201,7 +201,7 @@ export interface RemoteCacheV1 {
    * Indicates if the remote cache is enabled. When `false`, Turborepo will disable
    * all remote cache operations, even if the repo has a valid token. If true, remote caching
    * is enabled, but still requires the user to login and link their repo to a remote cache.
-   * Documentation: https://turbo.build/docs/core-concepts/remote-caching
+   * Documentation: https://turborepo.com/docs/core-concepts/remote-caching
    *
    * @defaultValue `true`
    */
@@ -223,7 +223,7 @@ export interface RootSchemaV1 extends BaseSchemaV1 {
    * that are not represented in the traditional dependency graph
    * (e.g. a root tsconfig.json, jest.config.ts, .eslintrc, etc.)
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#globaldependencies
+   * Documentation: https://turborepo.com/docs/reference/configuration#globaldependencies
    *
    * @defaultValue `[]`
    */
@@ -234,7 +234,7 @@ export interface RootSchemaV1 extends BaseSchemaV1 {
    *
    * The variables included in this list will affect all task hashes.
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#globalenv
+   * Documentation: https://turborepo.com/docs/reference/configuration#globalenv
    *
    * @defaultValue `[]`
    */
@@ -244,7 +244,7 @@ export interface RootSchemaV1 extends BaseSchemaV1 {
    * An allowlist of environment variables that should be made to all tasks, but
    * should not contribute to the task's cache key, e.g. `AWS_SECRET_KEY`.
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#globalpassthroughenv
+   * Documentation: https://turborepo.com/docs/reference/configuration#globalpassthroughenv
    *
    * @defaultValue `null`
    */
@@ -261,7 +261,7 @@ export interface RootSchemaV1 extends BaseSchemaV1 {
   /**
    * Configuration options that control how turbo interfaces with the remote cache.
    *
-   * Documentation: https://turbo.build/docs/core-concepts/remote-caching
+   * Documentation: https://turborepo.com/docs/core-concepts/remote-caching
    *
    * @defaultValue `{}`
    */
@@ -270,7 +270,7 @@ export interface RootSchemaV1 extends BaseSchemaV1 {
   /**
    * Enable use of the new UI for `turbo`
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#ui
+   * Documentation: https://turborepo.com/docs/reference/configuration#ui
    *
    * @defaultValue `false`
    */

--- a/packages/turbo-types/src/types/config-v2.ts
+++ b/packages/turbo-types/src/types/config-v2.ts
@@ -14,14 +14,14 @@ export type RelativeUnixPath = string;
 export type EnvWildcard = string;
 
 export interface BaseSchema {
-  /** @defaultValue `https://turbo.build/schema.v2.json` */
+  /** @defaultValue `https://turborepo.com/schema.v2.json` */
   $schema?: string;
   /**
    * An object representing the task dependency graph of your project. turbo interprets
    * these conventions to schedule, execute, and cache the outputs of tasks in
    * your project.
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#tasks
+   * Documentation: https://turborepo.com/docs/reference/configuration#tasks
    *
    * @defaultValue `{}`
    */
@@ -78,7 +78,7 @@ export interface RootSchema extends BaseSchema {
    * that are not represented in the traditional dependency graph
    * (e.g. a root tsconfig.json, jest.config.ts, .eslintrc, etc.)
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#globaldependencies
+   * Documentation: https://turborepo.com/docs/reference/configuration#globaldependencies
    *
    * @defaultValue `[]`
    */
@@ -89,7 +89,7 @@ export interface RootSchema extends BaseSchema {
    *
    * The variables included in this list will affect all task hashes.
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#globalenv
+   * Documentation: https://turborepo.com/docs/reference/configuration#globalenv
    *
    * @defaultValue `[]`
    */
@@ -99,7 +99,7 @@ export interface RootSchema extends BaseSchema {
    * An allowlist of environment variables that should be made to all tasks, but
    * should not contribute to the task's cache key, e.g. `AWS_SECRET_KEY`.
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#globalpassthroughenv
+   * Documentation: https://turborepo.com/docs/reference/configuration#globalpassthroughenv
    *
    * @defaultValue `null`
    */
@@ -108,7 +108,7 @@ export interface RootSchema extends BaseSchema {
   /**
    * Configuration options that control how turbo interfaces with the remote cache.
    *
-   * Documentation: https://turbo.build/docs/core-concepts/remote-caching
+   * Documentation: https://turborepo.com/docs/core-concepts/remote-caching
    *
    * @defaultValue `{}`
    */
@@ -117,7 +117,7 @@ export interface RootSchema extends BaseSchema {
   /**
    * Enable use of the UI for `turbo`.
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#ui
+   * Documentation: https://turborepo.com/docs/reference/configuration#ui
    *
    * @defaultValue `"stream"`
    */
@@ -138,7 +138,7 @@ export interface RootSchema extends BaseSchema {
   /**
    * Specify the filesystem cache directory.
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#cachedir
+   * Documentation: https://turborepo.com/docs/reference/configuration#cachedir
    *
    * @defaultValue `".turbo/cache"`
    */
@@ -147,7 +147,7 @@ export interface RootSchema extends BaseSchema {
   /**
    * Turborepo runs a background process to pre-calculate some expensive operations. This standalone process (daemon) is a performance optimization, and not required for proper functioning of `turbo`.
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#daemon
+   * Documentation: https://turborepo.com/docs/reference/configuration#daemon
    *
    * @defaultValue `false`
    */
@@ -159,7 +159,7 @@ export interface RootSchema extends BaseSchema {
    * - `"strict"`: Filter environment variables to only those that are specified in the `env` and `globalEnv` keys in `turbo.json`.
    * - `"loose"`: Allow all environment variables for the process to be available.
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#envmode
+   * Documentation: https://turborepo.com/docs/reference/configuration#envmode
    *
    * @defaultValue `"strict"`
    */
@@ -184,7 +184,7 @@ export interface Pipeline {
    * same package (e.g. "A package's test and lint commands depend on its own build being
    * completed first.")
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#dependson
+   * Documentation: https://turborepo.com/docs/reference/configuration#dependson
    *
    * @defaultValue `[]`
    */
@@ -198,7 +198,7 @@ export interface Pipeline {
    * You no longer need to use the $ prefix.
    * (e.g. $GITHUB_TOKEN → GITHUB_TOKEN)
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#env
+   * Documentation: https://turborepo.com/docs/reference/configuration#env
    *
    * @defaultValue `[]`
    */
@@ -209,7 +209,7 @@ export interface Pipeline {
    * task's environment, but should not contribute to the task's cache key,
    * e.g. `AWS_SECRET_KEY`.
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#passthroughenv
+   * Documentation: https://turborepo.com/docs/reference/configuration#passthroughenv
    *
    * @defaultValue `null`
    */
@@ -222,7 +222,7 @@ export interface Pipeline {
    * produce no artifacts other than logs (such as linters). Logs are always treated as a
    * cacheable artifact and never need to be specified.
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#outputs
+   * Documentation: https://turborepo.com/docs/reference/configuration#outputs
    *
    * @defaultValue `[]`
    */
@@ -233,7 +233,7 @@ export interface Pipeline {
    *
    * Setting cache to false is useful for long-running "watch" or development mode tasks.
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#cache
+   * Documentation: https://turborepo.com/docs/reference/configuration#cache
    *
    * @defaultValue `true`
    */
@@ -250,7 +250,7 @@ export interface Pipeline {
    *
    * If omitted or empty, all files in the package are considered as inputs.
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#inputs
+   * Documentation: https://turborepo.com/docs/reference/configuration#inputs
    *
    * @defaultValue `[]`
    */
@@ -269,7 +269,7 @@ export interface Pipeline {
    *
    * "none": Hides all task output
    *
-   * Documentation: https://turbo.build/docs/reference/run#--output-logs-option
+   * Documentation: https://turborepo.com/docs/reference/run#--output-logs-option
    *
    * @defaultValue `"full"`
    */
@@ -280,7 +280,7 @@ export interface Pipeline {
    * turbo that this is a long-running task and will ensure that other tasks
    * cannot depend on it.
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#persistent
+   * Documentation: https://turborepo.com/docs/reference/configuration#persistent
    *
    * @defaultValue `false`
    */
@@ -291,7 +291,7 @@ export interface Pipeline {
    * Interactive tasks must be marked with "cache": false as the input
    * they receive from stdin can change the outcome of the task.
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#interactive
+   * Documentation: https://turborepo.com/docs/reference/configuration#interactive
    *
    * @defaultValue `false`
    */
@@ -304,7 +304,7 @@ export interface Pipeline {
    * not be restarted by default. To enable restarting persistent tasks, set
    * `interruptible` to true.
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#interruptible
+   * Documentation: https://turborepo.com/docs/reference/configuration#interruptible
    *
    * @defaultValue `false`
    */
@@ -315,7 +315,7 @@ export interface Pipeline {
    *
    * Tasks in this list will not be run until completion before this task starts execution.
    *
-   * Documentation: https://turbo.build/docs/reference/configuration#with
+   * Documentation: https://turborepo.com/docs/reference/configuration#with
    *
    * @defaultValue `[]`
    */
@@ -337,7 +337,7 @@ export interface RemoteCache {
    * Indicates if the remote cache is enabled. When `false`, Turborepo will disable
    * all remote cache operations, even if the repo has a valid token. If true, remote caching
    * is enabled, but still requires the user to login and link their repo to a remote cache.
-   * Documentation: https://turbo.build/docs/core-concepts/remote-caching
+   * Documentation: https://turborepo.com/docs/core-concepts/remote-caching
    *
    * @defaultValue `true`
    */
@@ -354,14 +354,14 @@ export interface RemoteCache {
   preflight?: boolean;
   /**
    * Set endpoint for API calls to the remote cache.
-   * Documentation: https://turbo.build/docs/core-concepts/remote-caching#self-hosting
+   * Documentation: https://turborepo.com/docs/core-concepts/remote-caching#self-hosting
    *
    * @defaultValue `"https://vercel.com/api"`
    */
   apiUrl?: string;
   /**
    * Set endpoint for requesting tokens during `turbo login`.
-   * Documentation: https://turbo.build/docs/core-concepts/remote-caching#self-hosting
+   * Documentation: https://turborepo.com/docs/core-concepts/remote-caching#self-hosting
    *
    * @defaultValue `"https://vercel.com"`
    */

--- a/packages/turbo-utils/__fixtures__/common/both-configs/turbo.json
+++ b/packages/turbo-utils/__fixtures__/common/both-configs/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalEnv": ["UNORDERED", "CI"],
   "tasks": {
     "build": {

--- a/packages/turbo-utils/__fixtures__/common/both-configs/turbo.jsonc
+++ b/packages/turbo-utils/__fixtures__/common/both-configs/turbo.jsonc
@@ -1,6 +1,6 @@
 {
   // This is a comment in turbo.jsonc
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalEnv": ["UNORDERED", "CI"],
   "tasks": {
     "build": {

--- a/packages/turbo-utils/__fixtures__/common/jsonc-package/turbo.jsonc
+++ b/packages/turbo-utils/__fixtures__/common/jsonc-package/turbo.jsonc
@@ -1,6 +1,6 @@
 {
   // This is a comment in turbo.jsonc
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalEnv": ["UNORDERED", "CI"], // Another comment
   "tasks": {
     "build": {

--- a/packages/turbo-utils/__fixtures__/common/jsonc-workspace-configs/apps/web/turbo.jsonc
+++ b/packages/turbo-utils/__fixtures__/common/jsonc-workspace-configs/apps/web/turbo.jsonc
@@ -1,6 +1,6 @@
 {
   // Web app turbo.jsonc file
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "tasks": {
     "build": {

--- a/packages/turbo-utils/__fixtures__/common/jsonc-workspace-configs/turbo.jsonc
+++ b/packages/turbo-utils/__fixtures__/common/jsonc-workspace-configs/turbo.jsonc
@@ -1,6 +1,6 @@
 {
   // Root turbo.jsonc file
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalEnv": ["CI"],
   "tasks": {
     "build": {

--- a/packages/turbo-utils/__fixtures__/common/old-workspace-config/turbo.json
+++ b/packages/turbo-utils/__fixtures__/common/old-workspace-config/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["**/.env.*local"],
   "tasks": {
     "build": {

--- a/packages/turbo-utils/__fixtures__/common/single-package/turbo.json
+++ b/packages/turbo-utils/__fixtures__/common/single-package/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalEnv": ["UNORDERED", "CI"],
   "tasks": {
     "build": {

--- a/packages/turbo-utils/__fixtures__/common/workspace-configs/apps/web/turbo.json
+++ b/packages/turbo-utils/__fixtures__/common/workspace-configs/apps/web/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "tasks": {
     "build": {

--- a/packages/turbo-utils/__fixtures__/common/workspace-configs/packages/ui/turbo.json
+++ b/packages/turbo-utils/__fixtures__/common/workspace-configs/packages/ui/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "tasks": {
     "build": {

--- a/packages/turbo-utils/__fixtures__/common/workspace-configs/packages/utils/turbo.json
+++ b/packages/turbo-utils/__fixtures__/common/workspace-configs/packages/utils/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   // invalid config - missing extends
   "tasks": {
     "build": {

--- a/packages/turbo-utils/__fixtures__/common/workspace-configs/turbo.json
+++ b/packages/turbo-utils/__fixtures__/common/workspace-configs/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalEnv": ["CI"],
   "tasks": {
     "build": {

--- a/packages/turbo-utils/__tests__/getTurboConfigs.test.ts
+++ b/packages/turbo-utils/__tests__/getTurboConfigs.test.ts
@@ -19,7 +19,7 @@ describe("getTurboConfigs", () => {
     expect(configs[0].isRootConfig).toBe(true);
     expect(configs[0].config).toMatchInlineSnapshot(`
       {
-        "$schema": "https://turbo.build/schema.json",
+        "$schema": "https://turborepo.com/schema.json",
         "globalEnv": [
           "UNORDERED",
           "CI",
@@ -67,7 +67,7 @@ describe("getTurboConfigs", () => {
     expect(configs[0].isRootConfig).toBe(true);
     expect(configs[0].config).toMatchInlineSnapshot(`
       {
-        "$schema": "https://turbo.build/schema.json",
+        "$schema": "https://turborepo.com/schema.json",
         "globalEnv": [
           "CI",
         ],
@@ -83,7 +83,7 @@ describe("getTurboConfigs", () => {
     expect(configs[1].isRootConfig).toBe(false);
     expect(configs[1].config).toMatchInlineSnapshot(`
       {
-        "$schema": "https://turbo.build/schema.json",
+        "$schema": "https://turborepo.com/schema.json",
         "extends": [
           "//",
         ],
@@ -100,7 +100,7 @@ describe("getTurboConfigs", () => {
     expect(configs[2].isRootConfig).toBe(false);
     expect(configs[2].config).toMatchInlineSnapshot(`
       {
-        "$schema": "https://turbo.build/schema.json",
+        "$schema": "https://turborepo.com/schema.json",
         "extends": [
           "//",
         ],
@@ -124,7 +124,7 @@ describe("getTurboConfigs", () => {
     expect(configs[0].isRootConfig).toBe(true);
     expect(configs[0].config).toMatchInlineSnapshot(`
       {
-        "$schema": "https://turbo.build/schema.json",
+        "$schema": "https://turborepo.com/schema.json",
         "globalDependencies": [
           "**/.env.*local",
         ],
@@ -151,7 +151,7 @@ describe("JSON5 parsing for turbo.jsonc", () => {
   it("correctly parses turbo.jsonc with comments", () => {
     const turboJsoncContent = `{
       // This is a comment in turbo.jsonc
-      "$schema": "https://turbo.build/schema.json",
+      "$schema": "https://turborepo.com/schema.json",
       "globalEnv": ["UNORDERED", "CI"], // Another comment
       "tasks": {
         "build": {
@@ -176,7 +176,7 @@ describe("JSON5 parsing for turbo.jsonc", () => {
     const parsed: TurboConfigs = JSON5.parse(turboJsoncContent);
 
     expect(parsed).toMatchObject({
-      $schema: "https://turbo.build/schema.json",
+      $schema: "https://turborepo.com/schema.json",
       globalEnv: ["UNORDERED", "CI"],
       tasks: {
         build: {

--- a/packages/turbo-utils/package.json
+++ b/packages/turbo-utils/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "description": "",
-  "homepage": "https://turbo.build/repo",
+  "homepage": "https://turborepo.com/repo",
   "keywords": [],
   "author": "Vercel",
   "license": "MIT",

--- a/packages/turbo-vsc/src/extension.ts
+++ b/packages/turbo-vsc/src/extension.ts
@@ -367,11 +367,11 @@ async function promptGlobalTurbo(useLocalTurbo: boolean) {
       );
 
       if (message === "Open Docs") {
-        env.openExternal(Uri.parse("https://turbo.build/docs/installing"));
+        env.openExternal(Uri.parse("https://turborepo.com/docs/installing"));
       }
     }
   } else if (answer === "Open Docs") {
-    env.openExternal(Uri.parse("https://turbo.build/docs/installing"));
+    env.openExternal(Uri.parse("https://turborepo.com/docs/installing"));
   } else if (answer === "Open Settings") {
     commands.executeCommand("workbench.action.openSettings", "turbo.path");
   }

--- a/packages/turbo-workspaces/README.md
+++ b/packages/turbo-workspaces/README.md
@@ -46,4 +46,4 @@ if (project.packageManager !== "pnpm") {
 
 ---
 
-For more information about Turborepo, visit [turbo.build/repo](https://turbo.build/repo) and follow us on X ([@turborepo](https://x.com/turborepo))!
+For more information about Turborepo, visit [turborepo.com/repo](https://turborepo.com/repo) and follow us on X ([@turborepo](https://x.com/turborepo))!

--- a/packages/turbo-workspaces/package.json
+++ b/packages/turbo-workspaces/package.json
@@ -2,7 +2,7 @@
   "name": "@turbo/workspaces",
   "version": "2.5.1-canary.1",
   "description": "Tools for working with package managers",
-  "homepage": "https://turbo.build/repo",
+  "homepage": "https://turborepo.com/repo",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/turbo/README.md
+++ b/packages/turbo/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://turbo.build/repo">
+  <a href="https://turborepo.com/repo">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/4060187/196936123-f6e1db90-784d-4174-b774-92502b718836.png">
       <img src="https://user-images.githubusercontent.com/4060187/196936104-5797972c-ab10-4834-bd61-0d1e5f442c9c.png" height="128">
@@ -25,7 +25,7 @@
 
 ## Getting Started
 
-Visit https://turbo.build/docs to get started with Turborepo and read the documentation.
+Visit https://turborepo.com/docs to get started with Turborepo and read the documentation.
 
 ## Community
 
@@ -37,7 +37,7 @@ Our [Code of Conduct](https://github.com/vercel/turborepo/blob/main/CODE_OF_COND
 
 ## Who is using Turbo?
 
-Turbo is used by the world's leading companies. Check out the [Turbo Showcase](https://turbo.build/showcase) to learn more.
+Turbo is used by the world's leading companies. Check out the [Turbo Showcase](https://turborepo.com/showcase) to learn more.
 
 ## Updates
 

--- a/packages/turbo/package.json
+++ b/packages/turbo/package.json
@@ -4,7 +4,7 @@
   "description": "Turborepo is a high-performance build system for JavaScript and TypeScript codebases.",
   "repository": "https://github.com/vercel/turborepo",
   "bugs": "https://github.com/vercel/turborepo/issues",
-  "homepage": "https://turbo.build/repo",
+  "homepage": "https://turborepo.com/repo",
   "license": "MIT",
   "main": "./bin/turbo",
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,9 +139,6 @@ importers:
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
-      classnames:
-        specifier: ^2.5.1
-        version: 2.5.1
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -7141,10 +7138,6 @@ packages:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
     dependencies:
       clsx: 2.1.1
-    dev: false
-
-  /classnames@2.5.1:
-    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
     dev: false
 
   /clean-css@5.3.3:

--- a/test-codemod/turbo.json
+++ b/test-codemod/turbo.json
@@ -1,1 +1,1 @@
-{ "$schema": "https://turbo.build/schema.json", "tasks": {} }
+{ "$schema": "https://turborepo.com/schema.json", "tasks": {} }

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "ui": "tui",
   // The following are used by tools such as pnpm, gh actions to setup pnpm, etc.
   "globalPassThroughEnv": [

--- a/turborepo-tests/integration/fixtures/basic_monorepo/turbo.json
+++ b/turborepo-tests/integration/fixtures/basic_monorepo/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["foo.txt"],
   "globalEnv": ["SOME_ENV_VAR"],
   "tasks": {

--- a/turborepo-tests/integration/fixtures/composable_config/turbo.json
+++ b/turborepo-tests/integration/fixtures/composable_config/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "add-keys-task": {},
     "add-keys-underlying-task": {},

--- a/turborepo-tests/integration/fixtures/dir_globs/turbo.json
+++ b/turborepo-tests/integration/fixtures/dir_globs/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "inputs": ["src/"],

--- a/turborepo-tests/integration/fixtures/framework_inference/turbo.json
+++ b/turborepo-tests/integration/fixtures/framework_inference/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalPassThroughEnv": [],
   "tasks": {
     "build": {}

--- a/turborepo-tests/integration/fixtures/global_deps/turbo.json
+++ b/turborepo-tests/integration/fixtures/global_deps/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["global_deps/**", "!global_deps/**/*.md"],
   "globalEnv": ["SOME_ENV_VAR"],
   "tasks": {

--- a/turborepo-tests/integration/fixtures/inference/has_workspaces/packages/ui-library/turbo.json
+++ b/turborepo-tests/integration/fixtures/inference/has_workspaces/packages/ui-library/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "tasks": {}
 }

--- a/turborepo-tests/integration/fixtures/inference/has_workspaces/turbo.json
+++ b/turborepo-tests/integration/fixtures/inference/has_workspaces/turbo.json
@@ -1,6 +1,6 @@
 // Has a comment!
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {}
   }

--- a/turborepo-tests/integration/fixtures/inference/nested_workspaces/outer-no-turbo/inner/turbo.json
+++ b/turborepo-tests/integration/fixtures/inference/nested_workspaces/outer-no-turbo/inner/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {}
   }

--- a/turborepo-tests/integration/fixtures/inference/nested_workspaces/outer/inner/turbo.json
+++ b/turborepo-tests/integration/fixtures/inference/nested_workspaces/outer/inner/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {}
   }

--- a/turborepo-tests/integration/fixtures/inference/nested_workspaces/outer/turbo.json
+++ b/turborepo-tests/integration/fixtures/inference/nested_workspaces/outer/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {}
   }

--- a/turborepo-tests/integration/fixtures/lockfile_aware_caching/turbo.json
+++ b/turborepo-tests/integration/fixtures/lockfile_aware_caching/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "outputs": [],

--- a/turborepo-tests/integration/fixtures/monorepo_dependency_error/turbo.json
+++ b/turborepo-tests/integration/fixtures/monorepo_dependency_error/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],

--- a/turborepo-tests/integration/fixtures/monorepo_one_script_error/turbo.json
+++ b/turborepo-tests/integration/fixtures/monorepo_one_script_error/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "error": {
       "dependsOn": ["okay"],

--- a/turborepo-tests/integration/fixtures/monorepo_with_root_dep/turbo.json
+++ b/turborepo-tests/integration/fixtures/monorepo_with_root_dep/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "outputs": []

--- a/turborepo-tests/integration/fixtures/nested_packages/turbo.json
+++ b/turborepo-tests/integration/fixtures/nested_packages/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "outputs": []

--- a/turborepo-tests/integration/fixtures/ordered/turbo.json
+++ b/turborepo-tests/integration/fixtures/ordered/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {},
     "fail": {}

--- a/turborepo-tests/integration/fixtures/passthrough/turbo.json
+++ b/turborepo-tests/integration/fixtures/passthrough/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "echo": {}
   }

--- a/turborepo-tests/integration/fixtures/persistent_dependencies/1-topological/turbo.json
+++ b/turborepo-tests/integration/fixtures/persistent_dependencies/1-topological/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "dev": {
       "dependsOn": ["^dev"],

--- a/turborepo-tests/integration/fixtures/persistent_dependencies/10-too-many/turbo.json
+++ b/turborepo-tests/integration/fixtures/persistent_dependencies/10-too-many/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "persistent": true

--- a/turborepo-tests/integration/fixtures/persistent_dependencies/2-same-workspace/turbo.json
+++ b/turborepo-tests/integration/fixtures/persistent_dependencies/2-same-workspace/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["dev"]

--- a/turborepo-tests/integration/fixtures/persistent_dependencies/3-workspace-specific/turbo.json
+++ b/turborepo-tests/integration/fixtures/persistent_dependencies/3-workspace-specific/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["pkg-a#dev"]

--- a/turborepo-tests/integration/fixtures/persistent_dependencies/4-cross-workspace/turbo.json
+++ b/turborepo-tests/integration/fixtures/persistent_dependencies/4-cross-workspace/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "app-a#dev": {
       "dependsOn": ["pkg-a#dev"],

--- a/turborepo-tests/integration/fixtures/persistent_dependencies/5-root-workspace/turbo.json
+++ b/turborepo-tests/integration/fixtures/persistent_dependencies/5-root-workspace/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["//#dev"],

--- a/turborepo-tests/integration/fixtures/persistent_dependencies/6-topological-unimplemented/turbo.json
+++ b/turborepo-tests/integration/fixtures/persistent_dependencies/6-topological-unimplemented/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "dev": {
       "dependsOn": ["^dev"],

--- a/turborepo-tests/integration/fixtures/persistent_dependencies/7-topological-nested/turbo.json
+++ b/turborepo-tests/integration/fixtures/persistent_dependencies/7-topological-nested/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "dev": {
       "dependsOn": ["^dev"],

--- a/turborepo-tests/integration/fixtures/persistent_dependencies/8-topological-with-extra/turbo.json
+++ b/turborepo-tests/integration/fixtures/persistent_dependencies/8-topological-with-extra/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"]

--- a/turborepo-tests/integration/fixtures/persistent_dependencies/9-cross-workspace-nested/turbo.json
+++ b/turborepo-tests/integration/fixtures/persistent_dependencies/9-cross-workspace-nested/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "app-a#build": {
       "dependsOn": ["app-b#build"]

--- a/turborepo-tests/integration/fixtures/root_deps/turbo.json
+++ b/turborepo-tests/integration/fixtures/root_deps/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["foo.txt"],
   "globalEnv": ["SOME_ENV_VAR"],
   "tasks": {

--- a/turborepo-tests/integration/fixtures/single_package/turbo.json
+++ b/turborepo-tests/integration/fixtures/single_package/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["somefile.txt"],
   "tasks": {
     "build": {

--- a/turborepo-tests/integration/fixtures/strict_env_vars/turbo.json
+++ b/turborepo-tests/integration/fixtures/strict_env_vars/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "outputs": ["dist/**"]

--- a/turborepo-tests/integration/fixtures/task_dependencies/topological/turbo.json
+++ b/turborepo-tests/integration/fixtures/task_dependencies/topological/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"]

--- a/turborepo-tests/integration/fixtures/turbo-configs/abs-path-global-deps-win.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/abs-path-global-deps-win.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["C:\\an\\absolute\\path", "some\\file"]
 }

--- a/turborepo-tests/integration/fixtures/turbo-configs/abs-path-global-deps.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/abs-path-global-deps.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["/an/absolute/path", "some/file"]
 }

--- a/turborepo-tests/integration/fixtures/turbo-configs/abs-path-inputs-win.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/abs-path-inputs-win.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "inputs": ["C:\\another\\absolute\\path", "a\\relative\\path"]

--- a/turborepo-tests/integration/fixtures/turbo-configs/abs-path-inputs.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/abs-path-inputs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "inputs": ["/another/absolute/path", "a/relative/path"]

--- a/turborepo-tests/integration/fixtures/turbo-configs/abs-path-outputs-win.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/abs-path-outputs-win.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "outputs": ["C:\\another\\absolute\\path", "a\\relative\\path"]

--- a/turborepo-tests/integration/fixtures/turbo-configs/abs-path-outputs.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/abs-path-outputs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "outputs": ["/another/absolute/path", "a/relative/path"]

--- a/turborepo-tests/integration/fixtures/turbo-configs/basic-with-extends.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/basic-with-extends.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "extends": ["//"],
   "tasks": {
     "build": {

--- a/turborepo-tests/integration/fixtures/turbo-configs/gitignored-inputs.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/gitignored-inputs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "inputs": ["internal.txt"]

--- a/turborepo-tests/integration/fixtures/turbo-configs/interactive.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/interactive.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["foo.txt"],
   "globalEnv": ["SOME_ENV_VAR"],
   "tasks": {

--- a/turborepo-tests/integration/fixtures/turbo-configs/interruptible-but-not-persistent.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/interruptible-but-not-persistent.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": [
     "foo.txt"
   ],

--- a/turborepo-tests/integration/fixtures/turbo-configs/invalid-env-var.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/invalid-env-var.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["foo.txt"],
   "globalEnv": ["SOME_ENV_VAR"],
   "tasks": {

--- a/turborepo-tests/integration/fixtures/turbo-configs/package-task.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/package-task.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["foo.txt"],
   "globalEnv": ["SOME_ENV_VAR"],
   "extends": ["//"],

--- a/turborepo-tests/integration/fixtures/turbo-configs/parse-error.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/parse-error.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["foo.txt"],
   "globalEnv": ["SOME_ENV_VAR"],
   "tasks": {

--- a/turborepo-tests/integration/fixtures/turbo-configs/spaces-failure.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/spaces-failure.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["foo.txt"],
   "globalEnv": ["SOME_ENV_VAR"],
   "tasks": {

--- a/turborepo-tests/integration/fixtures/turbo-configs/strict_env_vars/all.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/strict_env_vars/all.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "outputs": ["dist/**"],

--- a/turborepo-tests/integration/fixtures/turbo-configs/strict_env_vars/global_pt-empty.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/strict_env_vars/global_pt-empty.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "outputs": ["dist/**"]

--- a/turborepo-tests/integration/fixtures/turbo-configs/strict_env_vars/global_pt.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/strict_env_vars/global_pt.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "outputs": ["dist/**"]

--- a/turborepo-tests/integration/fixtures/turbo-configs/strict_env_vars/task_pt-empty.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/strict_env_vars/task_pt-empty.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "outputs": ["dist/**"],

--- a/turborepo-tests/integration/fixtures/turbo-configs/strict_env_vars/task_pt.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/strict_env_vars/task_pt.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "outputs": ["dist/**"],

--- a/turborepo-tests/integration/fixtures/turbo-configs/syntax-error.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/syntax-error.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",,
+  "$schema": "https://turborepo.com/schema.json",,
   "globalDependencies": ["foo.txt"],
   "globalEnv": ["SOME_ENV_VAR"],
   "tasks": {

--- a/turborepo-tests/integration/fixtures/turbo_trace/README.md
+++ b/turborepo-tests/integration/fixtures/turbo_trace/README.md
@@ -52,7 +52,7 @@ pnpm dev
 
 ### Remote Caching
 
-Turborepo can use a technique known as [Remote Caching](https://turbo.build/docs/core-concepts/remote-caching) to share cache artifacts across machines, enabling you to share build caches with your team and CI/CD pipelines.
+Turborepo can use a technique known as [Remote Caching](https://turborepo.com/docs/core-concepts/remote-caching) to share cache artifacts across machines, enabling you to share build caches with your team and CI/CD pipelines.
 
 By default, Turborepo will cache locally. To enable Remote Caching you will need an account with Vercel. If you don't have an account you can [create one](https://vercel.com/signup), then enter the following commands:
 
@@ -73,9 +73,9 @@ npx turbo link
 
 Learn more about the power of Turborepo:
 
-- [Tasks](https://turbo.build/docs/core-concepts/monorepos/running-tasks)
-- [Caching](https://turbo.build/docs/core-concepts/caching)
-- [Remote Caching](https://turbo.build/docs/core-concepts/remote-caching)
-- [Filtering](https://turbo.build/docs/core-concepts/monorepos/filtering)
-- [Configuration Options](https://turbo.build/docs/reference/configuration)
-- [CLI Usage](https://turbo.build/docs/reference/command-line-reference)
+- [Tasks](https://turborepo.com/docs/core-concepts/monorepos/running-tasks)
+- [Caching](https://turborepo.com/docs/core-concepts/caching)
+- [Remote Caching](https://turborepo.com/docs/core-concepts/remote-caching)
+- [Filtering](https://turborepo.com/docs/core-concepts/monorepos/filtering)
+- [Configuration Options](https://turborepo.com/docs/reference/configuration)
+- [CLI Usage](https://turborepo.com/docs/reference/command-line-reference)

--- a/turborepo-tests/integration/fixtures/turbo_trace/turbo.json
+++ b/turborepo-tests/integration/fixtures/turbo_trace/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "ui": "tui",
   "tasks": {
     "build": {

--- a/turborepo-tests/integration/fixtures/with-pkg-deps/turbo.json
+++ b/turborepo-tests/integration/fixtures/with-pkg-deps/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"]

--- a/turborepo-tests/integration/tests/bad-turbo-json.t
+++ b/turborepo-tests/integration/tests/bad-turbo-json.t
@@ -94,10 +94,10 @@ Run build with syntax errors in turbo.json
   
     x Failed to parse turbo.json.
     |->   x Expected a property but instead found ','.
-    |      ,-[turbo.json:2:48]
+    |      ,-[turbo.json:2:50]
     |    1 | {
     |    2 |   "$schema": "https://turborepo.com/schema.json",,
-    |      :                                                ^
+    |      :                                                  ^
     |    3 |   "globalDependencies": ["foo.txt"],
     |      `----
     |->   x expected `,` but instead found `42`

--- a/turborepo-tests/integration/tests/bad-turbo-json.t
+++ b/turborepo-tests/integration/tests/bad-turbo-json.t
@@ -9,7 +9,7 @@ Run build with package task in non-root turbo.json
   [1]
   $ sed  's/\[\([^]]*\)\]/\(\1)/g' < error.txt
     x Invalid turbo.json configuration
-    `-> unnecessary_package_task_syntax (https://turbo.build/messages/
+    `-> unnecessary_package_task_syntax (https://turborepo.com/messages/
         unnecessary-package-task-syntax)
         
           x "my-app#build". Use "build" instead.
@@ -38,7 +38,7 @@ Run build with invalid env var
   $ ${TURBO} build 2> error.txt
   [1]
   $ sed  's/\[\([^]]*\)\]/\(\1)/g' < error.txt
-  invalid_env_prefix (https://turbo.build/messages/invalid-env-prefix)
+  invalid_env_prefix (https://turborepo.com/messages/invalid-env-prefix)
   
     x Environment variables should not be prefixed with "$"
      ,-(turbo.json:7:27)
@@ -56,7 +56,7 @@ Run in single package mode even though we have a task with package syntax
   $ ${TURBO} build --single-package 2> error.txt
   [1]
   $ sed  's/\[\([^]]*\)\]/\(\1)/g' < error.txt
-  package_task_in_single_package_mode (https://turbo.build/messages/package-task-in-single-package-mode)
+  package_task_in_single_package_mode (https://turborepo.com/messages/package-task-in-single-package-mode)
   
     x Package tasks (<package>#<task>) are not allowed in single-package
     | repositories: found //#something
@@ -96,7 +96,7 @@ Run build with syntax errors in turbo.json
     |->   x Expected a property but instead found ','.
     |      ,-[turbo.json:2:48]
     |    1 | {
-    |    2 |   "$schema": "https://turbo.build/schema.json",,
+    |    2 |   "$schema": "https://turborepo.com/schema.json",,
     |      :                                                ^
     |    3 |   "globalDependencies": ["foo.txt"],
     |      `----

--- a/turborepo-tests/integration/tests/command-telemetry.t
+++ b/turborepo-tests/integration/tests/command-telemetry.t
@@ -9,13 +9,13 @@ Run status (with first run message)
   Turborepo now collects completely anonymous telemetry regarding usage.
   This information is used to shape the Turborepo roadmap and prioritize features.
   You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
-  https://turbo.build/docs/telemetry
+  https://turborepo.com/docs/telemetry
   
   
   Status: Enabled
   
   Turborepo telemetry is completely anonymous. Thank you for participating!
-  Learn more: https://turbo.build/docs/telemetry
+  Learn more: https://turborepo.com/docs/telemetry
 
 Run without command
   $ ${TURBO} telemetry
@@ -23,7 +23,7 @@ Run without command
   Status: Enabled
   
   Turborepo telemetry is completely anonymous. Thank you for participating!
-  Learn more: https://turbo.build/docs/telemetry
+  Learn more: https://turborepo.com/docs/telemetry
 
 Disable
   $ ${TURBO} telemetry disable
@@ -32,7 +32,7 @@ Disable
   Status: Disabled
   
   You have opted-out of Turborepo anonymous telemetry. No data will be collected from your machine.
-  Learn more: https://turbo.build/docs/telemetry
+  Learn more: https://turborepo.com/docs/telemetry
 
 Enable
   $ ${TURBO} telemetry enable
@@ -41,6 +41,6 @@ Enable
   Status: Enabled
   
   Turborepo telemetry is completely anonymous. Thank you for participating!
-  Learn more: https://turbo.build/docs/telemetry
+  Learn more: https://turborepo.com/docs/telemetry
 
 

--- a/turborepo-tests/integration/tests/config.t
+++ b/turborepo-tests/integration/tests/config.t
@@ -48,7 +48,7 @@ Use our custom turbo config with an invalid env var
 
 Run build with invalid env var
   $ ${TURBO} build
-  invalid_env_prefix (https://turbo.build/messages/invalid-env-prefix)
+  invalid_env_prefix (https://turborepo.com/messages/invalid-env-prefix)
   
     x Environment variables should not be prefixed with "$"
      ,-[turbo.json:7:27]

--- a/turborepo-tests/integration/tests/dry-json/single-package-with-deps.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package-with-deps.t
@@ -33,13 +33,13 @@ Setup
       {
         "taskId": "build",
         "task": "build",
-        "hash": "7ece7b62aad25615",
+        "hash": "fe0059df5e6291b2",
         "inputs": {
           ".gitignore": "03b541460c1b836f96f9c0a941ceb48e91a9fd83",
           "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",
           "package.json": "8606ff4b95a5330740d8d9d0948faeada64f1f32",
           "somefile.txt": "45b983be36b73c0788dc9cbcb76cbb80fc7bb057",
-          "turbo.json": "ce5bdbed55601768de641f5d8d005a8f5be8d3f7"
+          "turbo.json": "3bc68ed1f2a5a308cb0166f9ed073c2fc7980ac7"
         },
         "hashOfExternalDependencies": "",
         "cache": {
@@ -89,13 +89,13 @@ Setup
       {
         "taskId": "test",
         "task": "test",
-        "hash": "cb5839f7284aa5f3",
+        "hash": "7cfbd8e30495d802",
         "inputs": {
           ".gitignore": "03b541460c1b836f96f9c0a941ceb48e91a9fd83",
           "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",
           "package.json": "8606ff4b95a5330740d8d9d0948faeada64f1f32",
           "somefile.txt": "45b983be36b73c0788dc9cbcb76cbb80fc7bb057",
-          "turbo.json": "ce5bdbed55601768de641f5d8d005a8f5be8d3f7"
+          "turbo.json": "3bc68ed1f2a5a308cb0166f9ed073c2fc7980ac7"
         },
         "hashOfExternalDependencies": "",
         "cache": {

--- a/turborepo-tests/integration/tests/dry-json/single-package.t
+++ b/turborepo-tests/integration/tests/dry-json/single-package.t
@@ -33,13 +33,13 @@ Setup
       {
         "taskId": "build",
         "task": "build",
-        "hash": "7ece7b62aad25615",
+        "hash": "fe0059df5e6291b2",
         "inputs": {
           ".gitignore": "03b541460c1b836f96f9c0a941ceb48e91a9fd83",
           "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",
           "package.json": "8606ff4b95a5330740d8d9d0948faeada64f1f32",
           "somefile.txt": "45b983be36b73c0788dc9cbcb76cbb80fc7bb057",
-          "turbo.json": "ce5bdbed55601768de641f5d8d005a8f5be8d3f7"
+          "turbo.json": "3bc68ed1f2a5a308cb0166f9ed073c2fc7980ac7"
         },
         "hashOfExternalDependencies": "",
         "cache": {

--- a/turborepo-tests/integration/tests/edit-turbo-json/fixture-configs/1-baseline.json
+++ b/turborepo-tests/integration/tests/edit-turbo-json/fixture-configs/1-baseline.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["foo.txt"],
   "globalEnv": ["SOME_ENV_VAR"],
   "tasks": {

--- a/turborepo-tests/integration/tests/edit-turbo-json/fixture-configs/2-update-pipeline.json
+++ b/turborepo-tests/integration/tests/edit-turbo-json/fixture-configs/2-update-pipeline.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["foo.txt"],
   "globalEnv": ["SOME_ENV_VAR"],
   "tasks": {

--- a/turborepo-tests/integration/tests/edit-turbo-json/fixture-configs/3-update-global-env.json
+++ b/turborepo-tests/integration/tests/edit-turbo-json/fixture-configs/3-update-global-env.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["foo.txt"],
   "globalEnv": ["SOME_ENV_VAR", "NEW_ENV"],
   "tasks": {

--- a/turborepo-tests/integration/tests/edit-turbo-json/fixture-configs/4-update-global-deps.json
+++ b/turborepo-tests/integration/tests/edit-turbo-json/fixture-configs/4-update-global-deps.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["foo*.txt"],
   "globalEnv": ["SOME_ENV_VAR"],
   "tasks": {

--- a/turborepo-tests/integration/tests/edit-turbo-json/fixture-configs/5-update-global-deps-materially.json
+++ b/turborepo-tests/integration/tests/edit-turbo-json/fixture-configs/5-update-global-deps-materially.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["foo.txt", "bar.txt"],
   "globalEnv": ["SOME_ENV_VAR"],
   "tasks": {

--- a/turborepo-tests/integration/tests/edit-turbo-json/fixture-configs/6-update-passthrough-env.json
+++ b/turborepo-tests/integration/tests/edit-turbo-json/fixture-configs/6-update-passthrough-env.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["foo.txt"],
   "globalEnv": ["SOME_ENV_VAR"],
   "globalPassThroughEnv": ["PASSTHROUGH"],

--- a/turborepo-tests/integration/tests/edit-turbo-json/fixture-configs/a-baseline.json
+++ b/turborepo-tests/integration/tests/edit-turbo-json/fixture-configs/a-baseline.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["foo.txt"],
   "globalEnv": ["SOME_ENV_VAR"],
   "tasks": {

--- a/turborepo-tests/integration/tests/edit-turbo-json/fixture-configs/b-change-only-my-app.json
+++ b/turborepo-tests/integration/tests/edit-turbo-json/fixture-configs/b-change-only-my-app.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["foo.txt"],
   "globalEnv": ["SOME_ENV_VAR"],
   "tasks": {

--- a/turborepo-tests/integration/tests/edit-turbo-json/fixture-configs/c-my-app-depends-on.json
+++ b/turborepo-tests/integration/tests/edit-turbo-json/fixture-configs/c-my-app-depends-on.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["foo.txt"],
   "globalEnv": ["SOME_ENV_VAR"],
   "tasks": {

--- a/turborepo-tests/integration/tests/edit-turbo-json/fixture-configs/d-depends-on-util.json
+++ b/turborepo-tests/integration/tests/edit-turbo-json/fixture-configs/d-depends-on-util.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["foo.txt"],
   "globalEnv": ["SOME_ENV_VAR"],
   "tasks": {

--- a/turborepo-tests/integration/tests/edit-turbo-json/fixture-configs/e-depends-on-util-but-modified.json
+++ b/turborepo-tests/integration/tests/edit-turbo-json/fixture-configs/e-depends-on-util-but-modified.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["foo.txt"],
   "globalEnv": ["SOME_ENV_VAR"],
   "tasks": {

--- a/turborepo-tests/integration/tests/inference/nested-workspaces.t
+++ b/turborepo-tests/integration/tests/inference/nested-workspaces.t
@@ -27,26 +27,26 @@ Locate a repository with no turbo.json. We'll get the right root, but there's no
   [1]
   $ grep --quiet -E "Repository Root: .*[\/\\]nested_workspaces[\/\\]outer[\/\\]inner-no-turbo" INNER_NO_TURBO
   $ grep --quiet "x Could not find turbo.json." INNER_NO_TURBO
-  $ grep --quiet "| Follow directions at https://turbo.build/docs to create one" INNER_NO_TURBO
+  $ grep --quiet "| Follow directions at https://turborepo.com/docs to create one" INNER_NO_TURBO
 
 Locate a repository with no turbo.json. We'll get the right root and inference directory, but there's nothing to run
   $ cd $TARGET_DIR/outer/inner-no-turbo/apps && ${TURBO} run build --filter=nothing -vv 1> INNER_NO_TURBO_APPS 2>&1
   [1]
   $ grep --quiet -E "Repository Root: .*[\/\\]nested_workspaces[\/\\]outer[\/\\]inner-no-turbo" INNER_NO_TURBO_APPS
   $ grep --quiet "x Could not find turbo.json." INNER_NO_TURBO_APPS
-  $ grep --quiet "| Follow directions at https://turbo.build/docs to create one" INNER_NO_TURBO_APPS
+  $ grep --quiet "| Follow directions at https://turborepo.com/docs to create one" INNER_NO_TURBO_APPS
 
   $ cd $TARGET_DIR/outer-no-turbo && ${TURBO} run build --filter=nothing -vv 1> OUTER_NO_TURBO 2>&1
   [1]
   $ grep --quiet -E "Repository Root: .*[\/\\]nested_workspaces[\/\\]outer-no-turbo" OUTER_NO_TURBO
   $ grep --quiet "x Could not find turbo.json." OUTER_NO_TURBO
-  $ grep --quiet "| Follow directions at https://turbo.build/docs to create one" OUTER_NO_TURBO
+  $ grep --quiet "| Follow directions at https://turborepo.com/docs to create one" OUTER_NO_TURBO
 
   $ cd $TARGET_DIR/outer-no-turbo/apps && ${TURBO} run build --filter=nothing -vv 1> OUTER_NO_TURBO_APPS 2>&1
   [1]
   $ grep --quiet -E "Repository Root: .*[\/\\]nested_workspaces[\/\\]outer-no-turbo" OUTER_NO_TURBO_APPS
   $ grep --quiet "x Could not find turbo.json." OUTER_NO_TURBO_APPS
-  $ grep --quiet "| Follow directions at https://turbo.build/docs to create one" OUTER_NO_TURBO_APPS
+  $ grep --quiet "| Follow directions at https://turborepo.com/docs to create one" OUTER_NO_TURBO_APPS
 
   $ cd $TARGET_DIR/outer-no-turbo/inner && ${TURBO} run build --filter=nothing -vv 1> OUTER_NO_TURBO_INNER 2>&1
   [1]
@@ -62,11 +62,11 @@ Locate a repository with no turbo.json. We'll get the right root and inference d
   [1]
   $ grep --quiet -E "Repository Root: .*[\/\\]nested_workspaces[\/\\]outer-no-turbo[\/\\]inner-no-turbo" INNER_NO_TURBO
   $ grep --quiet "x Could not find turbo.json." INNER_NO_TURBO
-  $ grep --quiet "| Follow directions at https://turbo.build/docs to create one" INNER_NO_TURBO
+  $ grep --quiet "| Follow directions at https://turborepo.com/docs to create one" INNER_NO_TURBO
 
   $ cd $TARGET_DIR/outer-no-turbo/inner-no-turbo/apps && ${TURBO} run build --filter=nothing -vv 1> INNER_NO_TURBO_APPS 2>&1
   [1]
   $ grep --quiet -E "Repository Root: .*[\/\\]nested_workspaces[\/\\]outer-no-turbo[\/\\]inner-no-turbo" INNER_NO_TURBO_APPS
   $ grep --quiet "x Could not find turbo.json." INNER_NO_TURBO_APPS
-  $ grep --quiet "| Follow directions at https://turbo.build/docs to create one" INNER_NO_TURBO_APPS
+  $ grep --quiet "| Follow directions at https://turborepo.com/docs to create one" INNER_NO_TURBO_APPS
 

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -109,7 +109,7 @@ Make sure exit code is 2 when no args are passed
         --env-mode [<ENV_MODE>]
             Environment variable mode. Use "loose" to pass the entire existing environment. Use "strict" to use an allowlist specified in turbo.json [possible values: loose, strict]
     -F, --filter <FILTER>
-            Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turbo.build/docs/reference/command-line-reference/run#--filter
+            Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turborepo.com/docs/reference/command-line-reference/run#--filter
         --affected
             Filter to only packages that are affected by changes between the current branch and `main`
         --output-logs <OUTPUT_LOGS>

--- a/turborepo-tests/integration/tests/prune/produces-valid-turbo-json.t
+++ b/turborepo-tests/integration/tests/prune/produces-valid-turbo-json.t
@@ -11,7 +11,7 @@ Make sure that the internal util package is part of the prune output
 Make sure we prune tasks that reference a pruned workspace
   $ cat out/turbo.json | jq
   {
-    "$schema": "https://turbo.build/schema.json",
+    "$schema": "https://turborepo.com/schema.json",
     "tasks": {
       "build": {
         "outputs": []

--- a/turborepo-tests/integration/tests/recursive-turbo.t
+++ b/turborepo-tests/integration/tests/recursive-turbo.t
@@ -6,7 +6,7 @@ sed replaces the square brackets with parentheses so prysk can parse the file pa
   \xe2\x80\xa2 Packages in scope: //, another, my-app, util (esc)
   \xe2\x80\xa2 Running something in 4 packages (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  recursive_turbo_invocations (https://turbo.build/messages/recursive-turbo-invocations)
+  recursive_turbo_invocations (https://turborepo.com/messages/recursive-turbo-invocations)
   
     x Your `package.json` script looks like it invokes a Root Task (//
     | #something), creating a loop of `turbo` invocations. You likely have

--- a/turborepo-tests/integration/tests/run-caching/excluded-inputs/turbo.json
+++ b/turborepo-tests/integration/tests/run-caching/excluded-inputs/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turborepo.com/schema.json",
   "tasks": {
     "build": {
       "inputs": ["*.txt", "!excluded.txt"],

--- a/turborepo-tests/integration/tests/run/allow-no-root-turbo.t
+++ b/turborepo-tests/integration/tests/run/allow-no-root-turbo.t
@@ -4,7 +4,7 @@ Setup
 Run fails if not configured to allow missing turbo.json
   $ ${TURBO} test
     x Could not find turbo.json or turbo.jsonc.
-    | Follow directions at https://turbo.build/docs to create one.
+    | Follow directions at https://turborepo.com/docs to create one.
   
   [1]
 Runs test tasks

--- a/turborepo-tests/integration/tests/run/no-root-turbo.t
+++ b/turborepo-tests/integration/tests/run/no-root-turbo.t
@@ -5,7 +5,7 @@ Setup
 Run without --root-turbo-json should fail
   $ ${TURBO} build
     x Could not find turbo.json or turbo.jsonc.
-    | Follow directions at https://turbo.build/docs to create one.
+    | Follow directions at https://turborepo.com/docs to create one.
   
   [1]
 

--- a/turborepo-tests/integration/tests/run/single-package/dry-run.t
+++ b/turborepo-tests/integration/tests/run/single-package/dry-run.t
@@ -18,7 +18,7 @@ Check
   Tasks to Run
   build
     Task                           = build\s* (re)
-    Hash                           = 7ece7b62aad25615
+    Hash                           = fe0059df5e6291b2
     Cached \(Local\)                 = false\s* (re)
     Cached \(Remote\)                = false\s* (re)
     Command                        = echo building > foo.txt\s* (re)

--- a/turborepo-tests/integration/tests/run/single-package/run-yarn.t
+++ b/turborepo-tests/integration/tests/run/single-package/run-yarn.t
@@ -5,7 +5,7 @@ Check
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache miss, executing a6fef17cc2efc81c
+  build: cache miss, executing 833244488b90f3b4
   build: yarn run v1.22.17
   build: warning package.json: No license field
   build: $ echo building > foo.txt
@@ -18,7 +18,7 @@ Check
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache hit, replaying logs a6fef17cc2efc81c
+  build: cache hit, replaying logs 833244488b90f3b4
   build: yarn run v1.22.17
   build: warning package.json: No license field
   build: $ echo building > foo.txt

--- a/turborepo-tests/integration/tests/run/single-package/run.t
+++ b/turborepo-tests/integration/tests/run/single-package/run.t
@@ -5,7 +5,7 @@ Check
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache miss, executing 7ece7b62aad25615
+  build: cache miss, executing fe0059df5e6291b2
   build: 
   build: > build
   build: > echo building > foo.txt
@@ -22,7 +22,7 @@ Run a second time, verify caching works because there is a config
   $ ${TURBO} run build
   \xe2\x80\xa2 Running build (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache hit, replaying logs 7ece7b62aad25615
+  build: cache hit, replaying logs fe0059df5e6291b2
   build: 
   build: > build
   build: > echo building > foo.txt

--- a/turborepo-tests/integration/tests/run/single-package/with-deps-dry-run.t
+++ b/turborepo-tests/integration/tests/run/single-package/with-deps-dry-run.t
@@ -18,7 +18,7 @@ Check
   Tasks to Run
   build
     Task                           = build\s* (re)
-    Hash                           = 7ece7b62aad25615
+    Hash                           = fe0059df5e6291b2
     Cached \(Local\)                 = false\s* (re)
     Cached \(Remote\)                = false\s* (re)
     Command                        = echo building > foo.txt\s* (re)
@@ -36,7 +36,7 @@ Check
     Framework                      = 
   test
     Task                           = test\s* (re)
-    Hash                           = cb5839f7284aa5f3
+    Hash                           = 7cfbd8e30495d802
     Cached \(Local\)                 = false\s* (re)
     Cached \(Remote\)                = false\s* (re)
     Command                        = cat foo.txt\s* (re)

--- a/turborepo-tests/integration/tests/run/single-package/with-deps-run.t
+++ b/turborepo-tests/integration/tests/run/single-package/with-deps-run.t
@@ -5,12 +5,12 @@ Check
   $ ${TURBO} run test
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache miss, executing 7ece7b62aad25615
+  build: cache miss, executing fe0059df5e6291b2
   build: 
   build: > build
   build: > echo building > foo.txt
   build: 
-  test: cache miss, executing cb5839f7284aa5f3
+  test: cache miss, executing 7cfbd8e30495d802
   test: 
   test: > test
   test: > cat foo.txt
@@ -25,12 +25,12 @@ Run a second time, verify caching works because there is a config
   $ ${TURBO} run test
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache hit, replaying logs 7ece7b62aad25615
+  build: cache hit, replaying logs fe0059df5e6291b2
   build: 
   build: > build
   build: > echo building > foo.txt
   build: 
-  test: cache hit, replaying logs cb5839f7284aa5f3
+  test: cache hit, replaying logs 7cfbd8e30495d802
   test: 
   test: > test
   test: > cat foo.txt
@@ -45,8 +45,8 @@ Run with --output-logs=hash-only
   $ ${TURBO} run test --output-logs=hash-only
   \xe2\x80\xa2 Running test (esc)
   \xe2\x80\xa2 Remote caching disabled (esc)
-  build: cache hit, suppressing logs 7ece7b62aad25615
-  test: cache hit, suppressing logs cb5839f7284aa5f3
+  build: cache hit, suppressing logs fe0059df5e6291b2
+  test: cache hit, suppressing logs 7cfbd8e30495d802
   
    Tasks:    2 successful, 2 total
   Cached:    2 cached, 2 total

--- a/turborepo-tests/integration/tests/turbo-help.t
+++ b/turborepo-tests/integration/tests/turbo-help.t
@@ -109,7 +109,7 @@ Test help flag
         --env-mode [<ENV_MODE>]
             Environment variable mode. Use "loose" to pass the entire existing environment. Use "strict" to use an allowlist specified in turbo.json [possible values: loose, strict]
     -F, --filter <FILTER>
-            Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turbo.build/docs/reference/command-line-reference/run#--filter
+            Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turborepo.com/docs/reference/command-line-reference/run#--filter
         --affected
             Filter to only packages that are affected by changes between the current branch and `main`
         --output-logs <OUTPUT_LOGS>
@@ -297,7 +297,7 @@ Test help flag
             [possible values: loose, strict]
   
     -F, --filter <FILTER>
-            Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turbo.build/docs/reference/command-line-reference/run#--filter
+            Use the given selector to specify package(s) to act as entry points. The syntax mirrors pnpm's syntax, and additional documentation and examples can be found in turbo's documentation https://turborepo.com/docs/reference/command-line-reference/run#--filter
   
         --affected
             Filter to only packages that are affected by changes between the current branch and `main`


### PR DESCRIPTION
### Description

We're changing `turbo.build` to `turborepo.com`. This PR changes the strings with a find and replace across the whole of the codebase.

### Testing Instructions

👀
