### PR TITLE
docs(chore): remove `/repo` references from a few places

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Turborepo is a high-performance build system for JavaScript and TypeScript codeb
 
 ## Getting Started
 
-Visit https://turborepo.com/repo to get started with Turborepo.
+Visit https://turborepo.com to get started with Turborepo.
 
 ## Contributing
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,3 +1,3 @@
 # `turbo` CLI
 
-Visit https://turborepo.com/repo to view the full documentation.
+Visit https://turborepo.com to view the full documentation.

--- a/examples/design-system/README.md
+++ b/examples/design-system/README.md
@@ -4,7 +4,7 @@ This is a community-maintained example. If you experience a problem, please subm
 
 This guide explains how to use a React design system starter powered by:
 
-- 🏎 [Turborepo](https://turborepo.com/repo) — High-performance build system for Monorepos
+- 🏎 [Turborepo](https://turborepo.com) — High-performance build system for Monorepos
 - 🚀 [React](https://reactjs.org/) — JavaScript library for user interfaces
 - 🛠 [Tsup](https://github.com/egoist/tsup) — TypeScript bundler powered by esbuild
 - 📖 [Storybook](https://storybook.js.org/) — UI component environment powered by Vite
@@ -35,7 +35,7 @@ npx create-turbo@latest -e design-system
 
 ## Turborepo
 
-[Turborepo](https://turborepo.com/repo) is a high-performance build system for JavaScript and TypeScript codebases. It was designed after the workflows used by massive software engineering organizations to ship code at scale. Turborepo abstracts the complex configuration needed for monorepos and provides fast, incremental builds with zero-configuration remote caching.
+[Turborepo](https://turborepo.com) is a high-performance build system for JavaScript and TypeScript codebases. It was designed after the workflows used by massive software engineering organizations to ship code at scale. Turborepo abstracts the complex configuration needed for monorepos and provides fast, incremental builds with zero-configuration remote caching.
 
 Using Turborepo simplifies managing your design system monorepo, as you can have a single lint, build, test, and release process for all packages. [Learn more](https://vercel.com/blog/monorepos-are-changing-how-teams-build-software) about how monorepos improve your development workflow.
 

--- a/examples/kitchen-sink/apps/admin/src/app/index.tsx
+++ b/examples/kitchen-sink/apps/admin/src/app/index.tsx
@@ -12,7 +12,7 @@ function App() {
       <CounterButton />
       <p className="description">
         Built With{" "}
-        <Link href="https://turborepo.com/repo" newTab>
+        <Link href="https://turborepo.com" newTab>
           Turborepo
         </Link>
         {" & "}

--- a/examples/kitchen-sink/apps/blog/app/routes/_index.tsx
+++ b/examples/kitchen-sink/apps/blog/app/routes/_index.tsx
@@ -10,7 +10,7 @@ export default function Index() {
       </h1>
       <CounterButton />
       <p className="description">
-        Built With <Link href="https://turborepo.com/repo">Turborepo</Link>
+        Built With <Link href="https://turborepo.com">Turborepo</Link>
         {" & "}
         <Link href="https://remix.run/">Remix</Link>
       </p>

--- a/examples/kitchen-sink/apps/storefront/src/app/page.tsx
+++ b/examples/kitchen-sink/apps/storefront/src/app/page.tsx
@@ -18,7 +18,7 @@ export default function Store() {
       <CounterButton />
       <p className="description">
         Built With{" "}
-        <Link href="https://turborepo.com/repo" newTab>
+        <Link href="https://turborepo.com" newTab>
           Turborepo
         </Link>
         {" & "}

--- a/examples/kitchen-sink/packages/ui/src/link/index.test.tsx
+++ b/examples/kitchen-sink/packages/ui/src/link/index.test.tsx
@@ -6,7 +6,7 @@ describe("Link", () => {
   it("renders without crashing", () => {
     const div = document.createElement("div");
     const root = createRoot(div);
-    root.render(<Link href="https://turborepo.com/repo">Turborepo Docs</Link>);
+    root.render(<Link href="https://turborepo.com">Turborepo Docs</Link>);
     root.unmount();
   });
 });

--- a/packages/create-turbo/README.md
+++ b/packages/create-turbo/README.md
@@ -1,6 +1,6 @@
 # Welcome to Turborepo
 
-[Turborepo](https://turborepo.com/repo) is a high-performance monorepo build-system for modern JavaScript and TypeScript codebases.
+[Turborepo](https://turborepo.com) is a high-performance monorepo build-system for modern JavaScript and TypeScript codebases.
 
 To get started, open a new shell and run:
 
@@ -10,7 +10,7 @@ npx create-turbo@latest
 
 Then follow the prompts you see in your terminal.
 
-For more information about Turborepo, [visit turborepo.com/repo](https://turborepo.com/repo) and follow us on X ([@turborepo](https://x.com/turborepo))!
+For more information about Turborepo, [visit turborepo.com](https://turborepo.com) and follow us on X ([@turborepo](https://x.com/turborepo))!
 
 ## Contributing
 

--- a/packages/create-turbo/package.json
+++ b/packages/create-turbo/package.json
@@ -2,7 +2,7 @@
   "name": "create-turbo",
   "version": "2.5.1-canary.2",
   "description": "Create a new Turborepo",
-  "homepage": "https://turborepo.com/repo",
+  "homepage": "https://turborepo.com",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/create-turbo/src/commands/create/index.ts
+++ b/packages/create-turbo/src/commands/create/index.ts
@@ -292,7 +292,7 @@ export async function create(
         `${packageManagerMeta.executable} turbo login`
       )}`
     );
-    logger.log("   - Learn more: https://turborepo.com/repo/remote-cache");
+    logger.log("   - Learn more: https://turborepo.com/remote-cache");
     logger.log();
     logger.log("- Run commands with Turborepo:");
     availableScripts

--- a/packages/turbo-codemod/package.json
+++ b/packages/turbo-codemod/package.json
@@ -2,7 +2,7 @@
   "name": "@turbo/codemod",
   "version": "2.5.1-canary.2",
   "description": "Provides Codemod transformations to help upgrade your Turborepo codebase when a feature is deprecated.",
-  "homepage": "https://turborepo.com/repo",
+  "homepage": "https://turborepo.com",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/turbo-gen/package.json
+++ b/packages/turbo-gen/package.json
@@ -2,7 +2,7 @@
   "name": "@turbo/gen",
   "version": "2.5.1-canary.2",
   "description": "Extend a Turborepo",
-  "homepage": "https://turborepo.com/repo",
+  "homepage": "https://turborepo.com",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/turbo-ignore/package.json
+++ b/packages/turbo-ignore/package.json
@@ -2,7 +2,7 @@
   "name": "turbo-ignore",
   "version": "2.5.1-canary.2",
   "description": "",
-  "homepage": "https://turborepo.com/repo",
+  "homepage": "https://turborepo.com",
   "keywords": [],
   "author": "Jared Palmer",
   "license": "MIT",

--- a/packages/turbo-releaser/src/native.ts
+++ b/packages/turbo-releaser/src/native.ts
@@ -59,7 +59,7 @@ async function generateNativePackage({
     description: `The ${os}-${arch} binary for turbo, a monorepo build system.`,
     repository: "https://github.com/vercel/turborepo",
     bugs: "https://github.com/vercel/turborepo/issues",
-    homepage: "https://turborepo.com/repo",
+    homepage: "https://turborepo.com",
     license: "MIT",
     os: [nodeOSLookup[os]],
     cpu: [arch],

--- a/packages/turbo-repository/js/package.json
+++ b/packages/turbo-repository/js/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1-canary.15",
   "description": "",
   "bugs": "https://github.com/vercel/turborepo/issues",
-  "homepage": "https://turborepo.com/repo",
+  "homepage": "https://turborepo.com",
   "license": "MIT",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/turbo-repository/package.json
+++ b/packages/turbo-repository/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "",
   "bugs": "https://github.com/vercel/turborepo/issues",
-  "homepage": "https://turborepo.com/repo",
+  "homepage": "https://turborepo.com",
   "scripts": {
     "build": "bash scripts/build.sh --dts ../js/index.d.ts",
     "build:release": "bash scripts/build.sh --release",

--- a/packages/turbo-telemetry/package.json
+++ b/packages/turbo-telemetry/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "description": "",
-  "homepage": "https://turborepo.com/repo",
+  "homepage": "https://turborepo.com",
   "keywords": [],
   "author": "Vercel",
   "license": "MIT",

--- a/packages/turbo-test-utils/package.json
+++ b/packages/turbo-test-utils/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "description": "",
-  "homepage": "https://turborepo.com/repo",
+  "homepage": "https://turborepo.com",
   "keywords": [],
   "author": "Vercel",
   "main": "src/index.ts",

--- a/packages/turbo-types/README.md
+++ b/packages/turbo-types/README.md
@@ -4,4 +4,4 @@ TypeScript types for `turbo.json`
 
 ---
 
-For more information about Turborepo, visit [turborepo.com/repo](https://turborepo.com/repo) and follow us on X ([@turborepo](https://x.com/turborepo))!
+For more information about Turborepo, visit [turborepo.com](https://turborepo.com) and follow us on X ([@turborepo](https://x.com/turborepo))!

--- a/packages/turbo-types/package.json
+++ b/packages/turbo-types/package.json
@@ -2,7 +2,7 @@
   "name": "@turbo/types",
   "version": "2.5.1-canary.2",
   "description": "Turborepo types",
-  "homepage": "https://turborepo.com/repo",
+  "homepage": "https://turborepo.com",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/turbo-utils/package.json
+++ b/packages/turbo-utils/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "description": "",
-  "homepage": "https://turborepo.com/repo",
+  "homepage": "https://turborepo.com",
   "keywords": [],
   "author": "Vercel",
   "license": "MIT",

--- a/packages/turbo-workspaces/README.md
+++ b/packages/turbo-workspaces/README.md
@@ -46,4 +46,4 @@ if (project.packageManager !== "pnpm") {
 
 ---
 
-For more information about Turborepo, visit [turborepo.com/repo](https://turborepo.com/repo) and follow us on X ([@turborepo](https://x.com/turborepo))!
+For more information about Turborepo, visit [turborepo.com](https://turborepo.com) and follow us on X ([@turborepo](https://x.com/turborepo))!

--- a/packages/turbo-workspaces/package.json
+++ b/packages/turbo-workspaces/package.json
@@ -2,7 +2,7 @@
   "name": "@turbo/workspaces",
   "version": "2.5.1-canary.2",
   "description": "Tools for working with package managers",
-  "homepage": "https://turborepo.com/repo",
+  "homepage": "https://turborepo.com",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/turbo/README.md
+++ b/packages/turbo/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://turborepo.com/repo">
+  <a href="https://turborepo.com">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/4060187/196936123-f6e1db90-784d-4174-b774-92502b718836.png">
       <img src="https://user-images.githubusercontent.com/4060187/196936104-5797972c-ab10-4834-bd61-0d1e5f442c9c.png" height="128">

--- a/packages/turbo/package.json
+++ b/packages/turbo/package.json
@@ -4,7 +4,7 @@
   "description": "Turborepo is a high-performance build system for JavaScript and TypeScript codebases.",
   "repository": "https://github.com/vercel/turborepo",
   "bugs": "https://github.com/vercel/turborepo/issues",
-  "homepage": "https://turborepo.com/repo",
+  "homepage": "https://turborepo.com",
   "license": "MIT",
   "main": "./bin/turbo",
   "scripts": {


### PR DESCRIPTION
### Description

In #10368, I swapped out the links for the domain, but forgot to get rid of `turborepo.com/repo`, which is a vestigial from when Turbopack was in the repo. Fixing that here.

### Testing Instructions

👀
