### PR TITLE
fix(dry): do not perform runtime validations on dry runs

### DIFF
--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -421,6 +421,7 @@ impl Engine<Built> {
         package_graph: &PackageGraph,
         concurrency: u32,
         ui_mode: UIMode,
+        will_execute_tasks: bool,
     ) -> Result<(), Vec<ValidateError>> {
         // TODO(olszewski) once this is hooked up to a real run, we should
         // see if using rayon to parallelize would provide a speedup
@@ -510,14 +511,16 @@ impl Engine<Built> {
 
         // there must always be at least one concurrency 'slot' available for
         // non-persistent tasks otherwise we get race conditions
-        if persistent_count >= concurrency {
+        if will_execute_tasks && persistent_count >= concurrency {
             validation_errors.push(ValidateError::PersistentTasksExceedConcurrency {
                 persistent_count,
                 concurrency,
             })
         }
 
-        validation_errors.extend(self.validate_interactive(ui_mode));
+        if will_execute_tasks {
+            validation_errors.extend(self.validate_interactive(ui_mode));
+        }
 
         validation_errors.sort();
 
@@ -706,20 +709,91 @@ mod test {
 
         // if our limit is less than, it should fail
         engine
-            .validate(&graph, 1, UIMode::Stream)
+            .validate(&graph, 1, UIMode::Stream, true)
             .expect_err("not enough");
 
         // if our limit is less than, it should fail
         engine
-            .validate(&graph, 2, UIMode::Stream)
+            .validate(&graph, 2, UIMode::Stream, true)
             .expect_err("not enough");
 
         // we have two persistent tasks, and a slot for all other tasks, so this should
         // pass
-        engine.validate(&graph, 3, UIMode::Stream).expect("ok");
+        engine
+            .validate(&graph, 3, UIMode::Stream, true)
+            .expect("ok");
 
         // if our limit is greater, then it should pass
-        engine.validate(&graph, 4, UIMode::Stream).expect("ok");
+        engine
+            .validate(&graph, 4, UIMode::Stream, true)
+            .expect("ok");
+    }
+
+    #[tokio::test]
+    async fn test_interactive_validation() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        let mut engine = Engine::new();
+
+        // add two packages with a persistent build task
+        for package in ["a", "b"] {
+            let task_id = TaskId::new(package, "build");
+            engine.get_index(&task_id);
+            engine.add_definition(
+                task_id,
+                TaskDefinition {
+                    persistent: true,
+                    interactive: true,
+                    ..Default::default()
+                },
+            );
+        }
+
+        let engine = engine.seal();
+
+        let graph_builder = PackageGraph::builder(
+            AbsoluteSystemPath::from_std_path(tmp.path()).unwrap(),
+            PackageJson::default(),
+        )
+        .with_package_discovery(DummyDiscovery(&tmp));
+
+        let graph = graph_builder.build().await.unwrap();
+
+        assert!(engine.validate(&graph, 3, UIMode::Stream, false).is_ok());
+        assert!(engine.validate(&graph, 3, UIMode::Stream, true).is_err());
+    }
+
+    #[tokio::test]
+    async fn test_dry_run_skips_concurrency_validation() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        let mut engine = Engine::new();
+
+        // add two packages with a persistent build task
+        for package in ["a", "b"] {
+            let task_id = TaskId::new(package, "build");
+            engine.get_index(&task_id);
+            engine.add_definition(
+                task_id,
+                TaskDefinition {
+                    persistent: true,
+                    ..Default::default()
+                },
+            );
+        }
+
+        let engine = engine.seal();
+
+        let graph_builder = PackageGraph::builder(
+            AbsoluteSystemPath::from_std_path(tmp.path()).unwrap(),
+            PackageJson::default(),
+        )
+        .with_package_discovery(DummyDiscovery(&tmp));
+
+        let graph = graph_builder.build().await.unwrap();
+
+        assert!(engine.validate(&graph, 1, UIMode::Stream, false).is_ok());
+        assert!(engine.validate(&graph, 1, UIMode::Stream, true).is_err());
     }
 
     #[tokio::test]

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -138,6 +138,10 @@ impl RunBuilder {
         });
     }
 
+    fn will_execute_tasks(&self) -> bool {
+        self.opts.run_opts.dry_run.is_none() && self.opts.run_opts.graph.is_none()
+    }
+
     pub fn with_analytics_sender(mut self, analytics_sender: Option<AnalyticsSender>) -> Self {
         self.analytics_sender = analytics_sender;
         self
@@ -464,9 +468,9 @@ impl RunBuilder {
             self.opts.run_opts.dry_run.is_some(),
         ));
 
-        let should_print_prelude = self.should_print_prelude_override.unwrap_or_else(|| {
-            self.opts.run_opts.dry_run.is_none() && self.opts.run_opts.graph.is_none()
-        });
+        let should_print_prelude = self
+            .should_print_prelude_override
+            .unwrap_or_else(|| self.will_execute_tasks());
 
         Ok(Run {
             version: self.version,
@@ -538,6 +542,7 @@ impl RunBuilder {
                     pkg_dep_graph,
                     self.opts.run_opts.concurrency,
                     self.opts.run_opts.ui_mode,
+                    self.will_execute_tasks(),
                 )
                 .map_err(Error::EngineValidation)?;
         }


### PR DESCRIPTION
### Description

I was poking around and hit a case where I couldn't use dry run if it included interactive tasks or too many persistent tasks for the concurrency.

These checks don't make sense for `--graph` or `--dry` since we're not actually executing the graph.

### Testing Instructions

Added unit tests making sure that these checks are skipped. 

Quick manual test:
```
[0 olszewski@macbookpro] $ turbo run dev --dry=json > /dev/null                
turbo 2.5.1-canary.1

  x Invalid task configuration
  |->   x You have 19 persistent tasks but `turbo` is configured for concurrency of 10. Set --concurrency to at least 20
  `->   x Cannot run interactive task "vercel-ship#dev" without Terminal UI. Set `"ui": true` in `turbo.json`, use the `--ui=tui` flag, or set `TURBO_UI=true` as
        | an environment variable.

[1 olszewski@macbookpro] $ turbo_dev --skip-infer dev --dry=json > /dev/null
turbo 2.5.1

[0 olszewski@macbookpro] $
```
