### PR TITLE
fix: correctly read execution args from watch command

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -495,10 +495,10 @@ impl Args {
 
     /// Fetch the execution args supplied to the command
     pub fn execution_args(&self) -> Option<&ExecutionArgs> {
-        if let Some(Command::Run { execution_args, .. }) = &self.command {
-            Some(execution_args)
-        } else {
-            self.execution_args.as_ref()
+        match &self.command {
+            Some(Command::Run { execution_args, .. }) => Some(execution_args),
+            Some(Command::Watch { execution_args, .. }) => Some(execution_args),
+            _ => self.execution_args.as_ref(),
         }
     }
 


### PR DESCRIPTION
### Description

This is a follow-up fix to: https://github.com/vercel/turborepo/pull/10236

As it turns out, this change presented a regression in how the `--concurrency` flag behaves in watch mode. Previously, since this flag was read from the `execution_args` directly, it worked as expected. After switching it to read from `config`, it no longer worked in `watch` mode, as `Args` would only extract correctly from the `Run` command.

This change lets the `Args::execution_args()` getter return the execution args from the watch command that has been run, if present. This _is_ a pretty significant change, as previously _none_ of the run mode execution args would be respected in watch mode. I'm not totally confident this is desired.

The alternative is to bring back the special case for `concurrency`, and try to read from execution_args directly when parsing it, and falling back to `config` otherwise.

### Testing Instructions

1. Clone `main` and `pnpm build:turbo`
2. Run `./path/to/turbo watch <some-cmd>` in a repository where more than 10 tasks (the default) are persistent
3. Observe that even specifying `--concurrency=<task-count>` does not override this setting
4. Checkout the v2.5.0 commit and rebuild
5. Run the same test, and observe that the concurrency flag works as expected
6. Finally, clone this branch and rebuild
7. Run the same test, and observe that the concurrency flag works as expected