### PR TITLE
fix(microfrontends): respect packageName field

### DIFF
--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -394,6 +394,13 @@ impl Engine<Built> {
         self.task_graph.node_weights()
     }
 
+    pub fn task_ids(&self) -> impl Iterator<Item = &TaskId<'static>> {
+        self.tasks().filter_map(|task| match task {
+            crate::engine::TaskNode::Task(task_id) => Some(task_id),
+            crate::engine::TaskNode::Root => None,
+        })
+    }
+
     /// Return all tasks that have a command to be run
     pub fn tasks_with_command(&self, pkg_graph: &PackageGraph) -> Vec<String> {
         self.tasks()

--- a/crates/turborepo-lib/src/microfrontends.rs
+++ b/crates/turborepo-lib/src/microfrontends.rs
@@ -68,10 +68,6 @@ impl MicrofrontendsConfigs {
         }))
     }
 
-    pub fn contains_package(&self, package_name: &str) -> bool {
-        self.configs.contains_key(package_name)
-    }
-
     pub fn configs(&self) -> impl Iterator<Item = (&String, &HashSet<TaskId<'static>>)> {
         self.configs.iter().map(|(pkg, info)| (pkg, &info.tasks))
     }

--- a/crates/turborepo-lib/src/task_graph/visitor/command.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/command.rs
@@ -1,16 +1,20 @@
-use std::{collections::HashSet, path::PathBuf};
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+};
 
 use tracing::debug;
 use turbopath::AbsoluteSystemPath;
 use turborepo_env::EnvironmentVariableMap;
 use turborepo_microfrontends::MICROFRONTENDS_PACKAGE;
 use turborepo_process::Command;
-use turborepo_repository::package_graph::{PackageGraph, PackageInfo, PackageName};
+use turborepo_repository::{
+    package_graph::{PackageGraph, PackageInfo, PackageName},
+    package_manager::PackageManager,
+};
 
 use super::Error;
-use crate::{
-    engine::Engine, microfrontends::MicrofrontendsConfigs, opts::TaskArgs, run::task_id::TaskId,
-};
+use crate::{microfrontends::MicrofrontendsConfigs, opts::TaskArgs, run::task_id::TaskId};
 
 pub trait CommandProvider {
     fn command(
@@ -155,37 +159,29 @@ impl<'a> CommandProvider for PackageGraphCommandProvider<'a> {
 }
 
 #[derive(Debug)]
-pub struct MicroFrontendProxyProvider<'a> {
+pub struct MicroFrontendProxyProvider<'a, T> {
     repo_root: &'a AbsoluteSystemPath,
-    package_graph: &'a PackageGraph,
+    package_graph: &'a T,
     tasks_in_graph: HashSet<TaskId<'a>>,
     mfe_configs: &'a MicrofrontendsConfigs,
 }
 
-impl<'a> MicroFrontendProxyProvider<'a> {
-    pub fn new(
+impl<'a, T: PackageInfoProvider> MicroFrontendProxyProvider<'a, T> {
+    pub fn new<'b>(
         repo_root: &'a AbsoluteSystemPath,
-        package_graph: &'a PackageGraph,
-        engine: &Engine,
+        package_graph: &'a T,
+        tasks_in_graph: impl Iterator<Item = &'b TaskId<'static>>,
         micro_frontends_configs: &'a MicrofrontendsConfigs,
     ) -> Self {
-        let tasks_in_graph = engine
-            .tasks()
-            .filter_map(|task| match task {
-                crate::engine::TaskNode::Task(task_id) => Some(task_id),
-                crate::engine::TaskNode::Root => None,
-            })
-            .cloned()
-            .collect();
         Self {
             repo_root,
             package_graph,
-            tasks_in_graph,
+            tasks_in_graph: tasks_in_graph.cloned().collect(),
             mfe_configs: micro_frontends_configs,
         }
     }
 
-    fn dev_tasks(&self, task_id: &TaskId) -> Option<&HashSet<TaskId<'static>>> {
+    fn dev_tasks(&self, task_id: &TaskId) -> Option<&HashMap<TaskId<'static>, String>> {
         (task_id.task() == "proxy")
             .then(|| self.mfe_configs.get(task_id.package()))
             .flatten()
@@ -206,7 +202,7 @@ impl<'a> MicroFrontendProxyProvider<'a> {
     }
 }
 
-impl<'a> CommandProvider for MicroFrontendProxyProvider<'a> {
+impl<'a, T: PackageInfoProvider> CommandProvider for MicroFrontendProxyProvider<'a, T> {
     fn command(
         &self,
         task_id: &TaskId,
@@ -230,10 +226,11 @@ impl<'a> CommandProvider for MicroFrontendProxyProvider<'a> {
                     .unwrap_or_default(),
             });
         }
-        let local_apps = dev_tasks
-            .iter()
-            .filter(|task| self.tasks_in_graph.contains(task))
-            .map(|task| task.package());
+        let local_apps = dev_tasks.iter().filter_map(|(task, app_name)| {
+            self.tasks_in_graph
+                .contains(task)
+                .then_some(app_name.as_str())
+        });
         let package_dir = self.repo_root.resolve(package_info.package_path());
         let mfe_config_filename = self
             .mfe_configs
@@ -269,11 +266,31 @@ impl<'a> CommandProvider for MicroFrontendProxyProvider<'a> {
     }
 }
 
+/// A trait for fetching package information required to execute commands
+pub trait PackageInfoProvider {
+    fn package_manager(&self) -> &PackageManager;
+
+    fn package_info(&self, name: &PackageName) -> Option<&PackageInfo>;
+}
+
+impl PackageInfoProvider for PackageGraph {
+    fn package_manager(&self) -> &PackageManager {
+        PackageGraph::package_manager(self)
+    }
+
+    fn package_info(&self, name: &PackageName) -> Option<&PackageInfo> {
+        PackageGraph::package_info(self, name)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::ffi::OsStr;
 
     use insta::assert_snapshot;
+    use turbopath::AnchoredSystemPath;
+    use turborepo_microfrontends::Config;
+    use turborepo_repository::package_json::PackageJson;
 
     use super::*;
 
@@ -362,5 +379,87 @@ mod test {
             .command(&task_id, EnvironmentVariableMap::default())
             .unwrap();
         assert!(cmd.is_none(), "expected no cmd, got {cmd:?}");
+    }
+
+    #[test]
+    fn test_mfe_application_passed() {
+        let repo_root = AbsoluteSystemPath::new(if cfg!(windows) {
+            "C:\\repo-root"
+        } else {
+            "/tmp/repo-root"
+        })
+        .unwrap();
+        struct MockPackageInfo(PackageInfo);
+        impl PackageInfoProvider for MockPackageInfo {
+            fn package_manager(&self) -> &PackageManager {
+                &PackageManager::Npm
+            }
+
+            fn package_info(&self, name: &PackageName) -> Option<&PackageInfo> {
+                match name {
+                    PackageName::Root => unimplemented!(),
+                    PackageName::Other(name) => match name.as_str() {
+                        "web" | "docs" => Some(&self.0),
+                        _ => None,
+                    },
+                }
+            }
+        }
+        let mut config = Config::from_str(
+            r#"
+        {
+            "applications": {
+                "web-app": {
+                    "packageName": "web"
+                },
+                "docs-app": {
+                    "packageName": "docs",
+                    "routes": []
+                }
+            }
+        }"#,
+            "microfrontends.json",
+        )
+        .unwrap();
+        config.set_path(AnchoredSystemPath::new("microfrontends.json").unwrap());
+        let microfrontends_configs = MicrofrontendsConfigs::from_configs(
+            ["web", "docs"].iter().copied().collect(),
+            std::iter::once(("web", Ok(Some(config)))),
+        )
+        .unwrap()
+        .unwrap();
+
+        let mock_package_info = MockPackageInfo(PackageInfo {
+            package_json: PackageJson {
+                dependencies: Some(
+                    vec![(MICROFRONTENDS_PACKAGE.to_owned(), "1.0.0".to_owned())]
+                        .into_iter()
+                        .collect(),
+                ),
+                ..Default::default()
+            },
+            package_json_path: AnchoredSystemPath::new("package.json").unwrap().to_owned(),
+            unresolved_external_dependencies: None,
+            transitive_dependencies: None,
+        });
+        let mut factory = CommandFactory::new();
+        factory.add_provider(MicroFrontendProxyProvider::new(
+            repo_root,
+            &mock_package_info,
+            [TaskId::new("docs", "dev"), TaskId::new("web", "proxy")].iter(),
+            &microfrontends_configs,
+        ));
+        let cmd = factory
+            .command(
+                &TaskId::new("web", "proxy"),
+                EnvironmentVariableMap::default(),
+            )
+            .unwrap()
+            .unwrap();
+        assert!(
+            cmd.label().ends_with("--names docs-app"),
+            "Expected command to use application name instead of package name: {}",
+            cmd.label(),
+        );
     }
 }

--- a/crates/turborepo-lib/src/task_graph/visitor/exec.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/exec.rs
@@ -52,8 +52,8 @@ impl<'a> ExecContextFactory<'a> {
         if let Some(micro_frontends_configs) = visitor.micro_frontends_configs {
             command_factory.add_provider(MicroFrontendProxyProvider::new(
                 visitor.repo_root,
-                &visitor.package_graph,
-                engine,
+                visitor.package_graph.as_ref(),
+                engine.task_ids(),
                 micro_frontends_configs,
             ));
         }

--- a/crates/turborepo-lib/src/turbo_json/loader.rs
+++ b/crates/turborepo-lib/src/turbo_json/loader.rs
@@ -451,7 +451,10 @@ fn select_turbo_json(
 
 #[cfg(test)]
 mod test {
-    use std::{collections::BTreeMap, fs};
+    use std::{
+        collections::{BTreeMap, HashSet},
+        fs,
+    };
 
     use anyhow::Result;
     use insta::assert_snapshot;
@@ -820,6 +823,7 @@ mod test {
         .collect();
 
         let microfrontends_configs = MicrofrontendsConfigs::from_configs(
+            HashSet::from_iter(["web", "docs"].iter().copied()),
             vec![
                 (
                     "web",

--- a/crates/turborepo-microfrontends/src/configv1.rs
+++ b/crates/turborepo-microfrontends/src/configv1.rs
@@ -11,29 +11,29 @@ pub enum ParseResult {
     Reference(String),
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default, Clone)]
 pub struct ConfigV1 {
     version: Option<String>,
     applications: BTreeMap<String, Application>,
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default, Clone)]
 struct ChildConfig {
     part_of: String,
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default, Clone)]
 struct Application {
     development: Option<Development>,
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default, Clone)]
 struct Development {
     task: Option<String>,
     local: Option<LocalHost>,
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserializable, Default, Clone, Copy)]
 struct LocalHost {
     port: Option<u16>,
 }

--- a/crates/turborepo-microfrontends/src/lib.rs
+++ b/crates/turborepo-microfrontends/src/lib.rs
@@ -30,6 +30,15 @@ pub struct Config {
     path: Option<AnchoredSystemPathBuf>,
 }
 
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+pub struct DevelopmentTask<'a> {
+    // The key in the applications object in microfrontends.json
+    // This will match package unless packageName is provided
+    pub application_name: &'a str,
+    pub package: &'a str,
+    pub task: Option<&'a str>,
+}
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 enum ConfigInner {
     V1(ConfigV1),
@@ -103,9 +112,7 @@ impl Config {
         })
     }
 
-    pub fn development_tasks<'a>(
-        &'a self,
-    ) -> Box<dyn Iterator<Item = (&'a str, Option<&'a str>)> + 'a> {
+    pub fn development_tasks<'a>(&'a self) -> Box<dyn Iterator<Item = DevelopmentTask<'a>> + 'a> {
         match &self.inner {
             ConfigInner::V1(config_v1) => Box::new(config_v1.development_tasks()),
         }

--- a/crates/turborepo-microfrontends/src/lib.rs
+++ b/crates/turborepo-microfrontends/src/lib.rs
@@ -23,14 +23,14 @@ pub const SUPPORTED_VERSIONS: &[&str] = ["1"].as_slice();
 
 /// The minimal amount of information Turborepo needs to correctly start a local
 /// proxy server for microfrontends
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Config {
     inner: ConfigInner,
     filename: String,
     path: Option<AnchoredSystemPathBuf>,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 enum ConfigInner {
     V1(ConfigV1),
 }


### PR DESCRIPTION
### Description

This PR does 2 things:
 - Adds a warning if a package is referenced in `microfrontends.json` that is not present in the monorepo
 - Uses `packageName` over the `applications` key if present

### Testing Instructions

Added unit tests.

Verified warnings now are present if you reference a package that isn't found in the monorepo:
```
[0 olszewski@macbookpro] /Users/olszewski/code/vercel/microfrontends $ turbo_dev --skip-infer dev -F nextjs-app-marketing -F nextjs-app-docs --dry=json > /dev/null
turbo 2.5.1

 WARNING  Unable to find packages referenced in 'microfrontends.json' in workspace.Local proxy will not route to the following applications if they are running locally: nextjs-app-marketing-test
```

Verified that proxy is now started if every application uses a `packageName` that differs from the key in `applications`.
