### PR TITLE
fix(pnpm): read linkWorkspacePackages from pnpm-workspace.yaml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Lint
         # Manually set TURBO_API to an empty string to override Hetzner env
         run: |
-          TURBO_API= turbo run lint knip --env-mode=strict
+          TURBO_API= turbo run lint --env-mode=strict
 
   cleanup:
     name: Cleanup

--- a/crates/turborepo-repository/src/package_manager/berry.rs
+++ b/crates/turborepo-repository/src/package_manager/berry.rs
@@ -1,0 +1,34 @@
+use tracing::debug;
+use turbopath::AbsoluteSystemPath;
+
+use super::yarnrc;
+
+pub fn link_workspace_packages(repo_root: &AbsoluteSystemPath) -> bool {
+    let yarnrc_config = yarnrc::YarnRc::from_file(repo_root)
+        .inspect_err(|e| debug!("unable to read yarnrc: {e}"))
+        .unwrap_or_default();
+    yarnrc_config.enable_transparent_workspaces
+}
+
+#[cfg(test)]
+mod test {
+    use test_case::test_case;
+
+    use super::*;
+
+    #[test_case(None, true)]
+    #[test_case(Some(false), false)]
+    #[test_case(Some(true), true)]
+    fn test_link_workspace_packages(enabled: Option<bool>, expected: bool) {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let repo_root = AbsoluteSystemPath::from_std_path(tmpdir.path()).unwrap();
+        if let Some(enabled) = enabled {
+            repo_root
+                .join_component(yarnrc::YARNRC_FILENAME)
+                .create_with_contents(format!("enableTransparentWorkspaces: {enabled}"))
+                .unwrap();
+        }
+        let actual = link_workspace_packages(repo_root);
+        assert_eq!(actual, expected);
+    }
+}

--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -273,6 +273,8 @@ impl PackageManager {
     ) -> Result<(Vec<String>, Vec<String>), Error> {
         let globs = match self {
             PackageManager::Pnpm | PackageManager::Pnpm6 | PackageManager::Pnpm9 => {
+                // Make sure to convert this to a missing workspace error
+                // so we can catch it in the case of single package mode.
                 pnpm::get_configured_workspace_globs(root_path)
                     .ok_or_else(|| Error::Workspace(MissingWorkspaceError::from(self.clone())))?
             }

--- a/crates/turborepo-repository/src/package_manager/pnpm.rs
+++ b/crates/turborepo-repository/src/package_manager/pnpm.rs
@@ -89,8 +89,16 @@ pub fn link_workspace_packages(pnpm_version: PnpmVersion, repo_root: &AbsoluteSy
     let npmrc_config = npmrc::NpmRc::from_file(repo_root)
         .inspect_err(|e| debug!("unable to read npmrc: {e}"))
         .unwrap_or_default();
-    npmrc_config
-        .link_workspace_packages
+    let workspace_config = matches!(pnpm_version, PnpmVersion::Pnpm9)
+        .then(|| {
+            PnpmWorkspace::from_file(repo_root)
+                .inspect_err(|e| debug!("unable to read {WORKSPACE_CONFIGURATION_PATH}: {e}"))
+                .ok()
+        })
+        .flatten()
+        .and_then(|config| config.link_workspace_packages);
+    workspace_config
+        .or(npmrc_config.link_workspace_packages)
         // The default for pnpm 9 is false if not explicitly set
         // All previous versions had a default of true
         .unwrap_or(match pnpm_version {
@@ -102,9 +110,7 @@ pub fn link_workspace_packages(pnpm_version: PnpmVersion, repo_root: &AbsoluteSy
 pub fn get_configured_workspace_globs(repo_root: &AbsoluteSystemPath) -> Option<Vec<String>> {
     // Make sure to convert this to a missing workspace error
     // so we can catch it in the case of single package mode.
-    let workspace_yaml_path = repo_root.join_component(WORKSPACE_CONFIGURATION_PATH);
-    let workspace_yaml = workspace_yaml_path.read_to_string().ok()?;
-    let pnpm_workspace: PnpmWorkspace = serde_yaml::from_str(&workspace_yaml).ok()?;
+    let pnpm_workspace = PnpmWorkspace::from_file(repo_root).ok()?;
     if pnpm_workspace.packages.is_empty() {
         None
     } else {
@@ -117,8 +123,18 @@ pub fn get_default_exclusions() -> &'static [&'static str] {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct PnpmWorkspace {
     pub packages: Vec<String>,
+    link_workspace_packages: Option<bool>,
+}
+
+impl PnpmWorkspace {
+    pub fn from_file(repo_root: &AbsoluteSystemPath) -> Result<Self, Error> {
+        let workspace_yaml_path = repo_root.join_component(WORKSPACE_CONFIGURATION_PATH);
+        let workspace_yaml = workspace_yaml_path.read_to_string()?;
+        Ok(serde_yaml::from_str(&workspace_yaml)?)
+    }
 }
 
 #[derive(Debug)]
@@ -218,6 +234,15 @@ mod test {
         );
     }
 
+    #[test]
+    fn test_workspace_parsing() {
+        let config: PnpmWorkspace =
+            serde_yaml::from_str("linkWorkspacePackages: true\npackages:\n  - \"apps/*\"\n")
+                .unwrap();
+        assert_eq!(config.link_workspace_packages, Some(true));
+        assert_eq!(config.packages, vec!["apps/*".to_string()]);
+    }
+
     #[test_case(PnpmVersion::Pnpm6, None, true)]
     #[test_case(PnpmVersion::Pnpm7And8, None, true)]
     #[test_case(PnpmVersion::Pnpm7And8, Some(false), false)]
@@ -236,5 +261,48 @@ mod test {
         }
         let actual = link_workspace_packages(version, repo_root);
         assert_eq!(actual, expected);
+    }
+
+    #[test_case(PnpmVersion::Pnpm6, None, true)]
+    #[test_case(PnpmVersion::Pnpm7And8, None, true)]
+    // Pnpm <9 doesn't use workspace config
+    #[test_case(PnpmVersion::Pnpm7And8, Some(false), true)]
+    #[test_case(PnpmVersion::Pnpm7And8, Some(true), true)]
+    #[test_case(PnpmVersion::Pnpm9, None, false)]
+    #[test_case(PnpmVersion::Pnpm9, Some(true), true)]
+    #[test_case(PnpmVersion::Pnpm9, Some(false), false)]
+    fn test_link_workspace_packages_via_workspace(
+        version: PnpmVersion,
+        enabled: Option<bool>,
+        expected: bool,
+    ) {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let repo_root = AbsoluteSystemPath::from_std_path(tmpdir.path()).unwrap();
+        if let Some(enabled) = enabled {
+            repo_root
+                .join_component(WORKSPACE_CONFIGURATION_PATH)
+                .create_with_contents(format!(
+                    "linkWorkspacePackages: {enabled}\npackages:\n  - \"apps/*\"\n"
+                ))
+                .unwrap();
+        }
+        let actual = link_workspace_packages(version, repo_root);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_workspace_yaml_wins_over_npmrc() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let repo_root = AbsoluteSystemPath::from_std_path(tmpdir.path()).unwrap();
+        repo_root
+            .join_component(WORKSPACE_CONFIGURATION_PATH)
+            .create_with_contents("linkWorkspacePackages: true\npackages:\n  - \"apps/*\"\n")
+            .unwrap();
+        repo_root
+            .join_component(npmrc::NPMRC_FILENAME)
+            .create_with_contents("link-workspace-packages=false")
+            .unwrap();
+        let actual = link_workspace_packages(PnpmVersion::Pnpm9, repo_root);
+        assert!(actual);
     }
 }

--- a/crates/turborepo-repository/src/package_manager/pnpm.rs
+++ b/crates/turborepo-repository/src/package_manager/pnpm.rs
@@ -108,8 +108,6 @@ pub fn link_workspace_packages(pnpm_version: PnpmVersion, repo_root: &AbsoluteSy
 }
 
 pub fn get_configured_workspace_globs(repo_root: &AbsoluteSystemPath) -> Option<Vec<String>> {
-    // Make sure to convert this to a missing workspace error
-    // so we can catch it in the case of single package mode.
     let pnpm_workspace = PnpmWorkspace::from_file(repo_root).ok()?;
     if pnpm_workspace.packages.is_empty() {
         None

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -15,7 +15,10 @@
         "@next/env",
         "@next/eslint-plugin-next",
         "rss",
-        "@radix-ui/react-dropdown-menu"
+        "@radix-ui/react-dropdown-menu",
+        "semver",
+        "@turbo/types",
+        "@types/semver"
       ]
     }
   }

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -15,10 +15,7 @@
         "@next/env",
         "@next/eslint-plugin-next",
         "rss",
-        "@radix-ui/react-dropdown-menu",
-        "semver",
-        "@turbo/types",
-        "@types/semver"
+        "@radix-ui/react-dropdown-menu"
       ]
     }
   }


### PR DESCRIPTION
### Description

Fixes #10387 by adding partial support for the new configuration location added in https://github.com/pnpm/pnpm/pull/9121. There will be future work to add additional configuration options that lived in `.npmrc` and `package.json` to the YAML definition.

I highly suggest reviewing the first 2 commits on their own as they are prefactors. They both get a slightly smaller to slimming down the `impl PackageManager` so we can move to an interface instead of a single struct with `match`s for every package manager x version.

### Testing Instructions

Added new unit tests for this behavior, also manually verified behavior change in repro provided in #10387. Note that after this PR the topological `^lint` dependency is correctly applied so the application lints to not start until `@repo/lint` completes.

Before
```
[0 olszewski@macbookpro] /tmp/turbo-respect-pnpm-configs $ turbo lint                         
turbo 2.5.2

• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web
• Running lint in 5 packages
• Remote caching disabled
┌ web#lint > cache miss, executing b9dab19525365b14 
│ 
│ 
│ > web@0.1.0 lint /private/tmp/turbo-respect-pnpm-configs/apps/web
│ > next lint --max-warnings 0
└────>
┌ docs#lint > cache miss, executing 72e63e1338f32778 
│ 
│ 
│ > docs@0.1.0 lint /private/tmp/turbo-respect-pnpm-configs/apps/docs
│ > next lint --max-warnings 0
└────>
┌ @repo/ui#lint > cache miss, executing 1e7e4e418db8cf29 
│ 
│ 
│ > @repo/ui@0.0.0 lint /private/tmp/turbo-respect-pnpm-configs/packages/ui
│ > echo 'failing lint' && exit 1
│ 
│ failing lint
│  ELIFECYCLE  Command failed with exit code 1.
│ command finished with error: command (/private/tmp/turbo-respect-pnpm-configs/packages/ui) /User
│ s/olszewski/.nvm/versions/node/v22.13.0/bin/pnpm run lint exited (1)
└────>
@repo/ui#lint: command (/private/tmp/turbo-respect-pnpm-configs/packages/ui) /Users/olszewski/.nvm/versions/node/v22.13.0/bin/pnpm run lint exited (1)

 Tasks:    0 successful, 3 total
Cached:    0 cached, 3 total
  Time:    1.096s 
Failed:    @repo/ui#lint

 ERROR  run failed: command  exited (1)
```

After
```
[1 olszewski@macbookpro] /tmp/turbo-respect-pnpm-configs $ turbo_dev --skip-infer lint            
turbo 2.5.2

• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web
• Running lint in 5 packages
• Remote caching disabled
┌ @repo/ui#lint > cache miss, executing 5e80cac629794173 
│ 
│ 
│ > @repo/ui@0.0.0 lint /private/tmp/turbo-respect-pnpm-configs/packages/ui
│ > echo 'failing lint' && exit 1
│ 
│ failing lint
│  ELIFECYCLE  Command failed with exit code 1.
│ command finished with error: command (/private/tmp/turbo-respect-pnpm-configs/packages/ui) /User
│ s/olszewski/.nvm/versions/node/v22.13.0/bin/pnpm run lint exited (1)
└────>
@repo/ui#lint: command (/private/tmp/turbo-respect-pnpm-configs/packages/ui) /Users/olszewski/.nvm/versions/node/v22.13.0/bin/pnpm run lint exited (1)

 Tasks:    0 successful, 1 total
Cached:    0 cached, 1 total
  Time:    363ms 
Failed:    @repo/ui#lint

 ERROR  run failed: command  exited (1)
```
