### PR TITLE
feat(ui): remove gutter from persisted task output

### DIFF
--- a/crates/turborepo-ui/src/tui/term_output.rs
+++ b/crates/turborepo-ui/src/tui/term_output.rs
@@ -115,7 +115,6 @@ impl<W> TerminalOutput<W> {
                 stdout.write_all(title.as_bytes())?;
                 stdout.write_all(b"\r\n")?;
                 for row in screen.rows_formatted(0, cols) {
-                    stdout.write_all("│ ".as_bytes())?;
                     stdout.write_all(&row)?;
                     stdout.write_all(b"\r\n")?;
                 }

--- a/crates/turborepo-ui/src/tui/term_output.rs
+++ b/crates/turborepo-ui/src/tui/term_output.rs
@@ -111,14 +111,16 @@ impl<W> TerminalOutput<W> {
             LogBehavior::Full => {
                 let screen = self.parser.entire_screen();
                 let (_, cols) = screen.size();
-                stdout.write_all("┌".as_bytes())?;
+                stdout.write_all("┌─".as_bytes())?;
                 stdout.write_all(title.as_bytes())?;
                 stdout.write_all(b"\r\n")?;
                 for row in screen.rows_formatted(0, cols) {
                     stdout.write_all(&row)?;
                     stdout.write_all(b"\r\n")?;
                 }
-                stdout.write_all("└────>\r\n".as_bytes())?;
+                stdout.write_all("└─ ".as_bytes())?;
+                stdout.write_all(task_name.as_bytes())?;
+                stdout.write_all(" ──\r\n".as_bytes())?;
             }
             LogBehavior::Status => {
                 stdout.write_all(title.as_bytes())?;


### PR DESCRIPTION
### Description

@anthonyshew 

### Testing Instructions

```
[0 olszewski@macbookpro] /Users/olszewski/code/vercel/turborepo $ turbo_dev build -F @turbo/workspaces --ui=tui
 WARNING  No locally installed `turbo` found. Using version: 2.5.3-canary.0.
turbo 2.5.3-canary.0

• Packages in scope: @turbo/workspaces
• Running build in 1 packages
• Remote caching disabled
┌ @turbo/types#build > cache hit (outputs already on disk), replaying logs 77441397910de3fd 


> @turbo/types@2.5.3-canary.0 build /Users/olszewski/code/vercel/turborepo/packages/turbo
-types
> tsc && pnpm generate-schema


> @turbo/types@2.5.3-canary.0 generate-schema /Users/olszewski/code/vercel/turborepo/pack
ages/turbo-types
> tsx scripts/generate-schema.ts
└────>
┌ @turbo/workspaces#build > cache hit (outputs already on disk), replaying logs 5162f88d2ed536c3 


> @turbo/workspaces@2.5.3-canary.0 build /Users/olszewski/code/vercel/turborepo/packages/
turbo-workspaces
> tsup

CLI Building entry: src/index.ts, src/cli.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v5.12.9
CLI Using tsup config: /Users/olszewski/code/vercel/turborepo/packages/turbo-workspaces/t
sup.config.ts
CLI Target: node12
CLI Cleaning output folder
CJS Build start
ESM Build start
ESM ⚡️ Build success in 91ms
CJS ⚡️ Build success in 93ms
CJS dist/index.js 126.90 KB
CJS dist/cli.js   131.99 KB
ESM dist/index.mjs          412.00 B
ESM dist/cli.mjs            4.74 KB
ESM dist/chunk-OQ3Y4V4F.mjs 126.25 KB
DTS Build start
DTS ⚡️ Build success in 742ms
DTS dist/index.d.ts 4.32 KB
DTS dist/cli.d.ts   20.00 B
└────>

 Tasks:    2 successful, 2 total
Cached:    2 cached, 2 total
  Time:    230ms >>> FULL TURBO
```
