### PR TITLE
chore(bun): pretty print bun lockfile

### DIFF
--- a/crates/turborepo-lockfiles/src/bun/mod.rs
+++ b/crates/turborepo-lockfiles/src/bun/mod.rs
@@ -198,7 +198,7 @@ impl Lockfile for BunLockfile {
     }
 
     fn encode(&self) -> Result<Vec<u8>, crate::Error> {
-        Ok(serde_json::to_vec(&self.data)?)
+        Ok(serde_json::to_vec_pretty(&self.data)?)
     }
 
     fn global_change(&self, other: &dyn Lockfile) -> bool {


### PR DESCRIPTION
### Description

TSIA

### Testing Instructions

`turbo_dev prune` on a bun repo should produce a `bun.lock` that isn't a single line
