### PR TITLE
feat(tui): momentum-based scrolling

### DIFF
--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -218,7 +218,10 @@ impl<W> App<W> {
             self.scroll_momentum.reset();
             1
         };
-        self.get_full_task_mut()?.scroll_by(direction, lines)?;
+
+        if lines > 0 {
+            self.get_full_task_mut()?.scroll_by(direction, lines)?;
+        }
         Ok(())
     }
 

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -867,10 +867,12 @@ fn update(
         }
         Event::ScrollUp => {
             app.is_task_selection_pinned = true;
+            app.scroll_momentum.reset();
             app.scroll_terminal_output(Direction::Up, false)?
         }
         Event::ScrollDown => {
             app.is_task_selection_pinned = true;
+            app.scroll_momentum.reset();
             app.scroll_terminal_output(Direction::Down, false)?;
         }
         Event::ScrollWithMomentum(direction) => {
@@ -879,18 +881,22 @@ fn update(
         }
         Event::PageUp => {
             app.is_task_selection_pinned = true;
+            app.scroll_momentum.reset();
             app.scroll_terminal_output_by_page(Direction::Up)?;
         }
         Event::PageDown => {
             app.is_task_selection_pinned = true;
+            app.scroll_momentum.reset();
             app.scroll_terminal_output_by_page(Direction::Down)?;
         }
         Event::JumpToLogsTop => {
             app.is_task_selection_pinned = true;
+            app.scroll_momentum.reset();
             app.jump_to_logs_top()?;
         }
         Event::JumpToLogsBottom => {
             app.is_task_selection_pinned = true;
+            app.scroll_momentum.reset();
             app.jump_to_logs_bottom()?;
         }
         Event::EnterInteractive => {

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -32,6 +32,7 @@ use super::{
 };
 use crate::{
     tui::{
+        scroll::ScrollMomentum,
         task::{Task, TasksByStatus},
         term_output::TerminalOutput,
     },
@@ -60,6 +61,7 @@ pub struct App<W> {
     done: bool,
     preferences: PreferenceLoader,
     scrollback_len: u64,
+    scroll_momentum: ScrollMomentum,
 }
 
 impl<W> App<W> {
@@ -115,6 +117,7 @@ impl<W> App<W> {
             is_task_selection_pinned: preferences.active_task().is_some(),
             preferences,
             scrollback_len,
+            scroll_momentum: ScrollMomentum::new(),
         }
     }
 
@@ -204,8 +207,18 @@ impl<W> App<W> {
     }
 
     #[tracing::instrument(skip_all)]
-    pub fn scroll_terminal_output(&mut self, direction: Direction) -> Result<(), Error> {
-        self.get_full_task_mut()?.scroll(direction)?;
+    pub fn scroll_terminal_output(
+        &mut self,
+        direction: Direction,
+        use_momentum: bool,
+    ) -> Result<(), Error> {
+        let lines = if use_momentum {
+            self.scroll_momentum.on_scroll_event(direction)
+        } else {
+            self.scroll_momentum.reset();
+            1
+        };
+        self.get_full_task_mut()?.scroll_by(direction, lines)?;
         Ok(())
     }
 
@@ -851,11 +864,15 @@ fn update(
         }
         Event::ScrollUp => {
             app.is_task_selection_pinned = true;
-            app.scroll_terminal_output(Direction::Up)?;
+            app.scroll_terminal_output(Direction::Up, false)?
         }
         Event::ScrollDown => {
             app.is_task_selection_pinned = true;
-            app.scroll_terminal_output(Direction::Down)?;
+            app.scroll_terminal_output(Direction::Down, false)?;
+        }
+        Event::ScrollWithMomentum(direction) => {
+            app.is_task_selection_pinned = true;
+            app.scroll_terminal_output(direction, true)?;
         }
         Event::PageUp => {
             app.is_task_selection_pinned = true;

--- a/crates/turborepo-ui/src/tui/event.rs
+++ b/crates/turborepo-ui/src/tui/event.rs
@@ -29,6 +29,7 @@ pub enum Event {
     Down,
     ScrollUp,
     ScrollDown,
+    ScrollWithMomentum(Direction),
     PageUp,
     PageDown,
     JumpToLogsTop,
@@ -68,7 +69,7 @@ pub enum Event {
     SearchBackspace,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub enum Direction {
     Up,
     Down,

--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -37,8 +37,12 @@ impl InputOptions<'_> {
         match event {
             crossterm::event::Event::Key(k) => translate_key_event(self, k),
             crossterm::event::Event::Mouse(m) => match m.kind {
-                crossterm::event::MouseEventKind::ScrollDown => Some(Event::ScrollDown),
-                crossterm::event::MouseEventKind::ScrollUp => Some(Event::ScrollUp),
+                crossterm::event::MouseEventKind::ScrollDown => {
+                    Some(Event::ScrollWithMomentum(Direction::Down))
+                }
+                crossterm::event::MouseEventKind::ScrollUp => {
+                    Some(Event::ScrollWithMomentum(Direction::Up))
+                }
                 crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left)
                 | crossterm::event::MouseEventKind::Drag(crossterm::event::MouseButton::Left) => {
                     Some(Event::Mouse(m))

--- a/crates/turborepo-ui/src/tui/mod.rs
+++ b/crates/turborepo-ui/src/tui/mod.rs
@@ -7,6 +7,7 @@ mod input;
 mod pane;
 mod popup;
 mod preferences;
+pub mod scroll;
 mod search;
 mod size;
 mod spinner;

--- a/crates/turborepo-ui/src/tui/scroll.rs
+++ b/crates/turborepo-ui/src/tui/scroll.rs
@@ -14,18 +14,18 @@ const MIN_VELOCITY: f32 = 1.0;
 /// Increase for faster acceleration (reaches top speed quicker, feels
 /// snappier). Decrease for slower, smoother acceleration (takes longer to reach
 /// top speed).
-const ACCELERATION: f32 = 2.0;
+const ACCELERATION: f32 = 0.3;
 
 /// How long (in ms) between scrolls before momentum resets.
 /// Increase to allow longer pauses between scrolls while keeping momentum.
 /// Decrease to require faster, more continuous scrolling to maintain momentum.
-const DECAY_TIME: Duration = Duration::from_millis(200);
+const DECAY_TIME: Duration = Duration::from_millis(350);
 
 /// Only process 1 out of every N scroll events (throttling).
 /// Increase to make scrolling less sensitive to high-frequency mouse wheels
 /// (e.g. trackpads). Decrease to process more events (smoother, but may be
 /// too fast on some input devices).
-const THROTTLE_FACTOR: u8 = 1;
+const THROTTLE_FACTOR: u8 = 3;
 
 /// Tracks and computes momentum-based scrolling.
 pub struct ScrollMomentum {

--- a/crates/turborepo-ui/src/tui/scroll.rs
+++ b/crates/turborepo-ui/src/tui/scroll.rs
@@ -1,0 +1,77 @@
+use std::time::{Duration, Instant};
+
+use crate::tui::event::Direction;
+
+const MAX_VELOCITY: f32 = 12.0; // max lines per event
+const MIN_VELOCITY: f32 = 1.0; // min lines per event
+const ACCELERATION: f32 = 2.0; // lines per event per fast scroll
+const DECAY_TIME: Duration = Duration::from_millis(200); // ms to reset momentum
+
+/// Core struct to track and compute momentum-based scrolling.
+pub struct ScrollMomentum {
+    velocity: f32,
+    last_event: Option<Instant>,
+    phase: Phase,
+    last_direction: Option<Direction>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Phase {
+    Idle,
+    Accelerating,
+}
+
+impl ScrollMomentum {
+    pub fn new() -> Self {
+        Self {
+            velocity: 0.0,
+            last_event: None,
+            phase: Phase::Idle,
+            last_direction: None,
+        }
+    }
+
+    /// Call this on every scroll event (mouse wheel, key, etc).
+    /// Returns the number of lines to scroll for this event.
+    pub fn on_scroll_event(&mut self, direction: Direction) -> usize {
+        let now = Instant::now();
+
+        // Reset momentum if direction changes
+        let direction_changed = self.last_direction.map_or(false, |last| last != direction);
+        if direction_changed {
+            self.velocity = MIN_VELOCITY;
+            self.phase = Phase::Idle;
+            self.last_event = Some(now);
+        }
+
+        let lines_to_scroll = if let Some(last) = self.last_event {
+            let dt = now.duration_since(last);
+            if dt < DECAY_TIME && !direction_changed {
+                // User is scrolling fast, accelerate
+                self.phase = Phase::Accelerating;
+                self.velocity = (self.velocity + ACCELERATION).min(MAX_VELOCITY);
+                self.velocity.round() as usize
+            } else {
+                // Too slow, reset
+                self.phase = Phase::Idle;
+                self.velocity = MIN_VELOCITY;
+                MIN_VELOCITY as usize
+            }
+        } else {
+            self.phase = Phase::Accelerating;
+            self.velocity = MIN_VELOCITY;
+            MIN_VELOCITY as usize
+        };
+        self.last_event = Some(now);
+        self.last_direction = Some(direction);
+        lines_to_scroll
+    }
+
+    /// Call this to reset the momentum (e.g. on focus loss or scroll stop)
+    pub fn reset(&mut self) {
+        self.velocity = 0.0;
+        self.last_event = None;
+        self.phase = Phase::Idle;
+        self.last_direction = None;
+    }
+}

--- a/crates/turborepo-ui/src/tui/scroll.rs
+++ b/crates/turborepo-ui/src/tui/scroll.rs
@@ -14,7 +14,7 @@ const MIN_VELOCITY: f32 = 1.0;
 /// Increase for faster acceleration (reaches top speed quicker, feels
 /// snappier). Decrease for slower, smoother acceleration (takes longer to reach
 /// top speed).
-const ACCELERATION: f32 = 0.2;
+const ACCELERATION: f32 = 2.0;
 
 /// How long (in ms) between scrolls before momentum resets.
 /// Increase to allow longer pauses between scrolls while keeping momentum.
@@ -25,7 +25,7 @@ const DECAY_TIME: Duration = Duration::from_millis(200);
 /// Increase to make scrolling less sensitive to high-frequency mouse wheels
 /// (e.g. trackpads). Decrease to process more events (smoother, but may be
 /// too fast on some input devices).
-const THROTTLE_FACTOR: u8 = 3;
+const THROTTLE_FACTOR: u8 = 1;
 
 /// Tracks and computes momentum-based scrolling.
 pub struct ScrollMomentum {

--- a/crates/turborepo-ui/src/tui/scroll.rs
+++ b/crates/turborepo-ui/src/tui/scroll.rs
@@ -1,17 +1,31 @@
-use std::{
-    collections::VecDeque,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
 use crate::tui::event::Direction;
 
+/// The maximum number of lines that can be scrolled per event.
+/// Increase for a higher top speed; decrease for a lower top speed.
 const MAX_VELOCITY: f32 = 12.0; // max lines per event
-const MIN_VELOCITY: f32 = 1.0; // min lines per event
-const ACCELERATION: f32 = 2.0; // lines per event per fast scroll
-const DECAY_TIME: Duration = Duration::from_millis(200); // ms to reset momentum
-const THROTTLE_FACTOR: u8 = 3; // Only process 1 out of every 3 events
-const WINDOW_SIZE: usize = 3; // Number of scrolls to trigger acceleration
-const WINDOW_TIME: Duration = Duration::from_millis(250); // Time window for acceleration
+
+/// The minimum number of lines to scroll per event (when not accelerating).
+/// Usually leave at 1.0 for single-line scrolls.
+const MIN_VELOCITY: f32 = 1.0;
+
+/// How much the scroll velocity increases per qualifying event.
+/// Increase for faster acceleration (reaches top speed quicker, feels
+/// snappier). Decrease for slower, smoother acceleration (takes longer to reach
+/// top speed).
+const ACCELERATION: f32 = 0.2;
+
+/// How long (in ms) between scrolls before momentum resets.
+/// Increase to allow longer pauses between scrolls while keeping momentum.
+/// Decrease to require faster, more continuous scrolling to maintain momentum.
+const DECAY_TIME: Duration = Duration::from_millis(200);
+
+/// Only process 1 out of every N scroll events (throttling).
+/// Increase to make scrolling less sensitive to high-frequency mouse wheels
+/// (e.g. trackpads). Decrease to process more events (smoother, but may be
+/// too fast on some input devices).
+const THROTTLE_FACTOR: u8 = 3;
 
 /// Core struct to track and compute momentum-based scrolling.
 pub struct ScrollMomentum {
@@ -20,7 +34,6 @@ pub struct ScrollMomentum {
     phase: Phase,
     last_direction: Option<Direction>,
     throttle_counter: u8,
-    recent_events: VecDeque<Instant>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -37,7 +50,6 @@ impl ScrollMomentum {
             phase: Phase::Idle,
             last_direction: None,
             throttle_counter: 0,
-            recent_events: VecDeque::with_capacity(WINDOW_SIZE),
         }
     }
 
@@ -58,24 +70,6 @@ impl ScrollMomentum {
             self.velocity = MIN_VELOCITY;
             self.phase = Phase::Idle;
             self.last_event = Some(now);
-            self.recent_events.clear();
-        }
-
-        // Update moving window of recent scrolls
-        self.recent_events.push_back(now);
-        if self.recent_events.len() > WINDOW_SIZE {
-            self.recent_events.pop_front();
-        }
-
-        let reached_window_size = self.recent_events.len() == WINDOW_SIZE;
-        let within_window_time =
-            now.duration_since(self.recent_events.front().copied().unwrap()) <= WINDOW_TIME;
-        let should_accelerate = reached_window_size && within_window_time;
-
-        if !should_accelerate {
-            self.phase = Phase::Idle;
-            self.velocity = MIN_VELOCITY;
-            return 1;
         }
 
         let lines_to_scroll = if let Some(last) = self.last_event {
@@ -109,6 +103,5 @@ impl ScrollMomentum {
         self.phase = Phase::Idle;
         self.last_direction = None;
         self.throttle_counter = 0;
-        self.recent_events.clear();
     }
 }

--- a/crates/turborepo-ui/src/tui/scroll.rs
+++ b/crates/turborepo-ui/src/tui/scroll.rs
@@ -40,6 +40,12 @@ pub struct ScrollMomentum {
     throttle_counter: u8,
 }
 
+impl Default for ScrollMomentum {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ScrollMomentum {
     /// Create a new ScrollMomentum tracker.
     pub fn new() -> Self {

--- a/crates/turborepo-ui/src/tui/scroll.rs
+++ b/crates/turborepo-ui/src/tui/scroll.rs
@@ -1,4 +1,7 @@
-use std::time::{Duration, Instant};
+use std::{
+    collections::VecDeque,
+    time::{Duration, Instant},
+};
 
 use crate::tui::event::Direction;
 
@@ -6,6 +9,9 @@ const MAX_VELOCITY: f32 = 12.0; // max lines per event
 const MIN_VELOCITY: f32 = 1.0; // min lines per event
 const ACCELERATION: f32 = 2.0; // lines per event per fast scroll
 const DECAY_TIME: Duration = Duration::from_millis(200); // ms to reset momentum
+const THROTTLE_FACTOR: u8 = 3; // Only process 1 out of every 3 events
+const WINDOW_SIZE: usize = 3; // Number of scrolls to trigger acceleration
+const WINDOW_TIME: Duration = Duration::from_millis(250); // Time window for acceleration
 
 /// Core struct to track and compute momentum-based scrolling.
 pub struct ScrollMomentum {
@@ -13,6 +19,8 @@ pub struct ScrollMomentum {
     last_event: Option<Instant>,
     phase: Phase,
     last_direction: Option<Direction>,
+    throttle_counter: u8,
+    recent_events: VecDeque<Instant>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -28,12 +36,20 @@ impl ScrollMomentum {
             last_event: None,
             phase: Phase::Idle,
             last_direction: None,
+            throttle_counter: 0,
+            recent_events: VecDeque::with_capacity(WINDOW_SIZE),
         }
     }
 
     /// Call this on every scroll event (mouse wheel, key, etc).
     /// Returns the number of lines to scroll for this event.
     pub fn on_scroll_event(&mut self, direction: Direction) -> usize {
+        // Throttle: only process 1 out of every THROTTLE_FACTOR events
+        self.throttle_counter = (self.throttle_counter + 1) % THROTTLE_FACTOR;
+        if self.throttle_counter != 0 {
+            return 0;
+        }
+
         let now = Instant::now();
 
         // Reset momentum if direction changes
@@ -42,6 +58,24 @@ impl ScrollMomentum {
             self.velocity = MIN_VELOCITY;
             self.phase = Phase::Idle;
             self.last_event = Some(now);
+            self.recent_events.clear();
+        }
+
+        // Update moving window of recent scrolls
+        self.recent_events.push_back(now);
+        if self.recent_events.len() > WINDOW_SIZE {
+            self.recent_events.pop_front();
+        }
+
+        let reached_window_size = self.recent_events.len() == WINDOW_SIZE;
+        let within_window_time =
+            now.duration_since(self.recent_events.front().copied().unwrap()) <= WINDOW_TIME;
+        let should_accelerate = reached_window_size && within_window_time;
+
+        if !should_accelerate {
+            self.phase = Phase::Idle;
+            self.velocity = MIN_VELOCITY;
+            return 1;
         }
 
         let lines_to_scroll = if let Some(last) = self.last_event {
@@ -62,6 +96,7 @@ impl ScrollMomentum {
             self.velocity = MIN_VELOCITY;
             MIN_VELOCITY as usize
         };
+
         self.last_event = Some(now);
         self.last_direction = Some(direction);
         lines_to_scroll
@@ -73,5 +108,7 @@ impl ScrollMomentum {
         self.last_event = None;
         self.phase = Phase::Idle;
         self.last_direction = None;
+        self.throttle_counter = 0;
+        self.recent_events.clear();
     }
 }

--- a/docs/site/content/blog/turbo-2-5.mdx
+++ b/docs/site/content/blog/turbo-2-5.mdx
@@ -1,6 +1,6 @@
 ---
 title: Turborepo 2.5
-date: 2025/3/3
+date: 2025/4/3
 description: 'Sidecar tasks, `--continue` flexibility, turbo.jsonc, Bun pruning, `$TURBO_ROOT$`, OpenAPI viewer, and more.'
 tag: 'web development'
 ogImage: /images/blog/turbo-2-5/x-card.png
@@ -12,7 +12,7 @@ import { Accordion, Accordions } from '#components/accordion';
 
 # Turborepo 2.5
 
-<Date>Thursday, March 3rd, 2025</Date>
+<Date>Thursday, April 3rd, 2025</Date>
 
 <Authors authors={['nicholasyang', 'anthonyshew', 'chrisolszewski']} />
 


### PR DESCRIPTION
### Description
#10415 Adds momentum-based scrolling to the TUI for a smoother and more natural scroll experience.

### Testing Instructions
1. Run a long-running task that prints many lines, e.g.:
```bashs
perl -E '$i=1; for (1..1500) { say "[$i] " . "=" x int(rand(100) + 1); $i++ }' && read
```

2. Use the TUI to scroll through the output and observe the new scrolling behavior.