### PR TITLE
docs(fix): layout shift on home page

### DIFF
--- a/docs/site/app/(no-sidebar)/graphics/effortless.tsx
+++ b/docs/site/app/(no-sidebar)/graphics/effortless.tsx
@@ -13,7 +13,7 @@ export const EffortlessGraphic = () => {
     setMounted(true);
   }, []);
 
-  if (!mounted) return null;
+  if (!mounted) return <div className={sizingString}></div>;
 
   if (resolvedTheme === "dark") {
     return <EffortlessDark />;

--- a/docs/site/app/(no-sidebar)/graphics/providers.tsx
+++ b/docs/site/app/(no-sidebar)/graphics/providers.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
+import { cn } from "../../../components/cn";
 import { sizingString } from "./sizing-string";
 
 export const CiProviders = () => {
@@ -12,7 +13,7 @@ export const CiProviders = () => {
     setMounted(true);
   }, []);
 
-  if (!mounted) return null;
+  if (!mounted) return <div className={sizingString}></div>;
 
   if (resolvedTheme === "dark") {
     return <ProvidersDark />;

--- a/docs/site/app/(no-sidebar)/graphics/providers.tsx
+++ b/docs/site/app/(no-sidebar)/graphics/providers.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
-import { cn } from "../../../components/cn";
 import { sizingString } from "./sizing-string";
 
 export const CiProviders = () => {

--- a/docs/site/app/(no-sidebar)/graphics/remote-caching.tsx
+++ b/docs/site/app/(no-sidebar)/graphics/remote-caching.tsx
@@ -13,7 +13,7 @@ export const RemoteCachingGraphic = () => {
     setMounted(true);
   }, []);
 
-  if (!mounted) return null;
+  if (!mounted) return <div className={sizingString}></div>;
 
   if (resolvedTheme === "dark") {
     return <RemoteCachingDark />;
@@ -25,7 +25,7 @@ const RemoteCachingDark = () => {
   return (
     <div className={sizingString}>
       <svg
-        className="w-full h-auto"
+        className={sizingString}
         viewBox="0 0 307 200"
         fill="none"
         xmlns="http://www.w3.org/2000/svg"

--- a/docs/site/app/(no-sidebar)/graphics/sizing-string.ts
+++ b/docs/site/app/(no-sidebar)/graphics/sizing-string.ts
@@ -1,2 +1,2 @@
 export const sizingString =
-  "mx-auto w-[246px] xs:w-[326px] sm:w-[542px] md:w-[194px] lg:w-[255px] xl:w-[298px] xs:w-full";
+  "mx-auto h-[160px] xs:w-[326px] sm:w-[542px] md:w-[194px] lg:w-[255px] xl:w-[298px] xs:w-full";


### PR DESCRIPTION
### Description

The SVGs are client-rendered, so were creating layout shift. This PR puts a div with the same dimensions in their place on the server, preserving sizing.

### Testing Instructions

👀 
