### PR TITLE
chore: fix release notes ignore label

### DIFF
--- a/.github/turbo-orchestrator.yml
+++ b/.github/turbo-orchestrator.yml
@@ -37,7 +37,7 @@ labeler:
     # Removes the PR from release notes when its chore or ci
     - label: "release-notes-ignore"
       when:
-        isPRTitleMatch: "(\bchore\b|\bci\b).*?:"
+        isPRTitleMatch: "^(?:(\bchore\b|\bci\b)|.*?\\((\bchore\b|\bci\b)\\)).*?:"
 
     # areas
     - label: "area: ci"


### PR DESCRIPTION
### Description

It looks like I'd written this labeller regex wrong. We'll see if it works next time a chore PR rolls through.
