### PR TITLE
feat: conditional update notifier message using package manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6256,7 +6256,6 @@ dependencies = [
  "semver 1.0.23",
  "serde",
  "thiserror",
- "turbopath",
  "turborepo-repository",
  "update-informer",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6256,6 +6256,8 @@ dependencies = [
  "semver 1.0.23",
  "serde",
  "thiserror",
+ "turbopath",
+ "turborepo-repository",
  "update-informer",
 ]
 

--- a/crates/turborepo-lib/src/shim/mod.rs
+++ b/crates/turborepo-lib/src/shim/mod.rs
@@ -88,7 +88,7 @@ fn run_correct_turbo(
     subscriber: &TurboSubscriber,
     ui: ColorConfig,
 ) -> Result<i32, Error> {
-    let package_manager = repo_state.package_manager;
+    let package_manager = repo_state.package_manager.as_ref();
 
     if let Some(turbo_state) = LocalTurboState::infer(&repo_state.root) {
         let mut builder = crate::config::TurborepoConfigBuilder::new(&repo_state.root);
@@ -282,12 +282,9 @@ fn try_check_for_updates(
     args: &ShimArgs,
     current_version: &str,
     config: &crate::config::ConfigurationOptions,
-    package_manager: Result<PackageManager, package_manager::Error>,
+    package_manager: Result<&PackageManager, &package_manager::Error>,
 ) {
-    let package_manager = package_manager
-        .as_ref()
-        .unwrap_or(&PackageManager::Npm)
-        .to_owned();
+    let package_manager = package_manager.unwrap_or(&PackageManager::Npm);
 
     if args.should_check_for_update() && !config.no_update_notifier() {
         // custom footer for update message

--- a/crates/turborepo-lib/src/shim/mod.rs
+++ b/crates/turborepo-lib/src/shim/mod.rs
@@ -18,6 +18,7 @@ use turbo_updater::display_update_check;
 use turbopath::AbsoluteSystemPathBuf;
 use turborepo_repository::{
     inference::{RepoMode, RepoState},
+    package_manager,
     package_manager::PackageManager,
 };
 use turborepo_ui::ColorConfig;
@@ -87,11 +88,7 @@ fn run_correct_turbo(
     subscriber: &TurboSubscriber,
     ui: ColorConfig,
 ) -> Result<i32, Error> {
-    let package_manager = repo_state
-        .package_manager
-        .as_ref()
-        .unwrap_or(&PackageManager::Npm)
-        .to_owned();
+    let package_manager = repo_state.package_manager;
 
     if let Some(turbo_state) = LocalTurboState::infer(&repo_state.root) {
         let mut builder = crate::config::TurborepoConfigBuilder::new(&repo_state.root);
@@ -285,8 +282,13 @@ fn try_check_for_updates(
     args: &ShimArgs,
     current_version: &str,
     config: &crate::config::ConfigurationOptions,
-    package_manager: PackageManager,
+    package_manager: Result<PackageManager, package_manager::Error>,
 ) {
+    let package_manager = package_manager
+        .as_ref()
+        .unwrap_or(&PackageManager::Npm)
+        .to_owned();
+
     if args.should_check_for_update() && !config.no_update_notifier() {
         // custom footer for update message
         let footer = format!(

--- a/crates/turborepo-updater/Cargo.toml
+++ b/crates/turborepo-updater/Cargo.toml
@@ -22,7 +22,6 @@ reqwest = { workspace = true, features = ["json", "blocking"] }
 semver = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
-turbopath = { workspace = true }
 turborepo-repository = { path = "../turborepo-repository" }
 update-informer = { git = "https://github.com/nicholaslyang/update-informer.git", default-features = false, features = [
   "reqwest",

--- a/crates/turborepo-updater/Cargo.toml
+++ b/crates/turborepo-updater/Cargo.toml
@@ -22,6 +22,8 @@ reqwest = { workspace = true, features = ["json", "blocking"] }
 semver = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
+turbopath = { workspace = true }
+turborepo-repository = { path = "../turborepo-repository" }
 update-informer = { git = "https://github.com/nicholaslyang/update-informer.git", default-features = false, features = [
   "reqwest",
 ] }

--- a/crates/turborepo-updater/src/lib.rs
+++ b/crates/turborepo-updater/src/lib.rs
@@ -104,7 +104,7 @@ pub fn display_update_check(
     current_version: &str,
     timeout: Option<Duration>,
     interval: Option<Duration>,
-    package_manager: PackageManager,
+    package_manager: &PackageManager,
 ) -> Result<(), UpdateNotifierError> {
     // bail early if the user has disabled update notifications
     if should_skip_notification() {


### PR DESCRIPTION
### Description

Small bit of polish to make our update notifier be package manager aware. Defaults to npm.

### Testing Instructions

Manually tested in a Bun repo.
```
▲ 👟 bun on main
  dt scan
╭───────────────────────────────────────────────────────────────────────────────────╮
│                                                                                   │
│                Update available v2.4.5-canary.5 ≫ v2.5.3-canary.1                 │
│    Changelog: https://github.com/vercel/turborepo/releases/tag/v2.5.3-canary.1    │
│                 Run "bunx @turbo/codemod@latest update" to update                 │
│                                                                                   │
│              Follow @turborepo for updates: https://x.com/turborepo               │
╰───────────────────────────────────────────────────────────────────────────────────╯
turbo 2.4.5-canary.5

...more logs...

```
