### PR TITLE
fix(examples): with-svelte example TypeScript

### DIFF
--- a/examples/with-svelte/packages/ui/package.json
+++ b/examples/with-svelte/packages/ui/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "svelte-package --watch --input=src",
-    "build": "svelte-package --input=src",
+    "dev": "svelte-kit sync && svelte-package --watch --input=src",
+    "build": "svelte-kit sync && svelte-package --input=src",
     "lint": "eslint .",
     "check-types": "svelte-check --tsconfig ./tsconfig.json"
   },
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
+    "@sveltejs/kit": "^2.20.0",
     "@sveltejs/package": "^2.0.0",
     "@sveltejs/vite-plugin-svelte": "^5.0.0",
     "eslint": "^9.25.0",

--- a/examples/with-svelte/packages/ui/svelte.config.js
+++ b/examples/with-svelte/packages/ui/svelte.config.js
@@ -1,0 +1,10 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+  // Consult https://kit.svelte.dev/docs/integrations#preprocessors
+  // for more information about preprocessors
+  preprocess: vitePreprocess()
+};
+
+export default config;

--- a/examples/with-svelte/packages/ui/tsconfig.json
+++ b/examples/with-svelte/packages/ui/tsconfig.json
@@ -1,12 +1,10 @@
 {
-  "extends": "@repo/typescript-config/svelte.json",
+  "extends": ["@repo/typescript-config/svelte.json", "./.svelte-kit/tsconfig.json"],
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true
+    "declarationMap": true,
+    "allowArbitraryExtensions": true
   },
-  "exclude": [
-    "node_modules",
-    "dist",
-    ".svelte-kit"
-  ]
+  "include": ["dist", "./src/**/*.svelte", "./src/**/*.ts"],
+  "exclude": ["node_modules", ".svelte-kit"]
 }

--- a/examples/with-svelte/packages/ui/tsconfig.json
+++ b/examples/with-svelte/packages/ui/tsconfig.json
@@ -1,6 +1,12 @@
 {
-  "extends": [
-    "@repo/typescript-config/svelte.json",
-    "./.svelte-kit/tsconfig.json"
+  "extends": "@repo/typescript-config/svelte.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    ".svelte-kit"
   ]
 }

--- a/examples/with-svelte/packages/ui/tsconfig.json
+++ b/examples/with-svelte/packages/ui/tsconfig.json
@@ -1,15 +1,6 @@
 {
-  "extends": "@repo/typescript-config/svelte.json",
-  "compilerOptions": {
-    "declaration": true,
-    "declarationMap": true,
-  },
-  "include": [
-    "src"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist",
-    ".svelte-kit"
+  "extends": [
+    "@repo/typescript-config/svelte.json",
+    "./.svelte-kit/tsconfig.json"
   ]
 }

--- a/examples/with-svelte/pnpm-lock.yaml
+++ b/examples/with-svelte/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
+      '@sveltejs/kit':
+        specifier: ^2.20.0
+        version: 2.20.0(@sveltejs/vite-plugin-svelte@5.0.3)(svelte@5.28.1)(vite@6.3.2)
       '@sveltejs/package':
         specifier: ^2.0.0
         version: 2.3.11(svelte@5.28.1)(typescript@5.8.2)


### PR DESCRIPTION
### Description

Inspired by @DoctorRyner in #10437, a set of changes to make TypeScript work better for the `with-svelte` example.

### Testing Instructions

This set of changes works correctly in my editor.
