### PR TITLE
docs: add workspace configuration example to package.json

### DIFF
--- a/docs/site/content/docs/crafting-your-repository/structuring-a-repository.mdx
+++ b/docs/site/content/docs/crafting-your-repository/structuring-a-repository.mdx
@@ -216,7 +216,7 @@ First, your package manager needs to describe the locations of your packages. We
   }
   ```
 
-  <LinkToDocumentation href="https://bun.sh/docs/install/workspaces">npm workspace documentation</LinkToDocumentation>
+  <LinkToDocumentation href="https://bun.sh/docs/install/workspaces">bun workspace documentation</LinkToDocumentation>
   </Tab>
 
 </PackageManagerTabs>

--- a/docs/site/content/docs/getting-started/add-to-existing-repository.mdx
+++ b/docs/site/content/docs/getting-started/add-to-existing-repository.mdx
@@ -3,9 +3,10 @@ title: Add to an existing repository
 description: Using Turborepo with your existing repository
 ---
 
-import { Tabs, Tab } from '#components/tabs';
+import { PackageManagerTabs, Tabs, Tab } from '#components/tabs';
 import { Callout } from '#components/callout';
 import { Step, Steps } from '#components/steps';
+import { LinkToDocumentation } from '#components/link-to-documentation';
 
 Turborepo can be incrementally adopted in **any repository, single or multi-package**, to speed up the developer and CI workflows of the repository.
 
@@ -186,11 +187,7 @@ Turborepo optimizes your repository using information from your package manager.
 
 ```diff title="package.json"
 {
-+  "packageManager": "npm@8.5.0",
-   "workspaces": [
-     "apps/*",
-     "packages/*"
-   ]
++  "packageManager": "npm@8.5.0"
 }
 ```
 
@@ -200,6 +197,86 @@ Turborepo optimizes your repository using information from your package manager.
   while migrating or in situations where you can't use the `packageManager` key
   yet.
 </Callout>
+
+</Step>
+<Step>
+### Set up package manager workspaces
+
+For multi-package repositories, you'll need to configure your package manager to recognize your workspace structure. This is done by adding a `workspaces` field to your root `package.json`.
+
+The `workspaces` field tells your package manager which directories contain your packages. Common patterns include `apps/*` for applications and `packages/*` for shared libraries.
+
+```diff title="package.json"
+{
+  "packageManager": "npm@8.5.0",
++  "workspaces": [
++    "apps/*",
++    "packages/*"
++  ]
+}
+```
+
+<Callout type="info">
+  If you're working with a single-package repository, you can skip this step as
+  workspaces aren't needed.
+</Callout>
+
+Different package managers may have alternative ways to configure workspaces:
+
+<PackageManagerTabs>
+
+  <Tab value="pnpm">
+  ```json title="pnpm-workspace.yaml"
+ packages:
+    - "apps/*"
+    - "packages/*"
+  ```
+  <LinkToDocumentation href="https://pnpm.io/pnpm-workspace_yaml">pnpm workspace documentation</LinkToDocumentation>
+
+  </Tab>
+
+  <Tab value="yarn">
+  ```json title="./package.json"
+  {
+    "workspaces": [
+      "apps/*",
+      "packages/*"
+    ]
+  }
+  ```
+
+  <LinkToDocumentation href="https://yarnpkg.com/features/workspaces#how-are-workspaces-declared">yarn workspace documentation</LinkToDocumentation>
+   </Tab>
+
+  <Tab value="npm">
+  ```json title="./package.json"
+  {
+    "workspaces": [
+      "apps/*",
+      "packages/*"
+    ]
+  }
+  ```
+
+  <LinkToDocumentation href="https://docs.npmjs.com/cli/v7/using-npm/workspaces#defining-workspaces">npm workspace documentation</LinkToDocumentation>
+  </Tab>
+
+  <Tab value="bun (Beta)">
+  ```json title="./package.json"
+  {
+    "workspaces": [
+      "apps/*",
+      "packages/*"
+    ]
+  }
+  ```
+
+  <LinkToDocumentation href="https://bun.sh/docs/install/workspaces">npm workspace documentation</LinkToDocumentation>
+  </Tab>
+
+</PackageManagerTabs>
+
+For more details on how to structure your repository, see [Structuring a Repository](/docs/crafting-your-repository/structuring-a-repository#declaring-directories-for-packages).
 
 </Step>
 <Step>

--- a/docs/site/content/docs/getting-started/add-to-existing-repository.mdx
+++ b/docs/site/content/docs/getting-started/add-to-existing-repository.mdx
@@ -186,7 +186,11 @@ Turborepo optimizes your repository using information from your package manager.
 
 ```diff title="package.json"
 {
-+  "packageManager": "npm@8.5.0"
++  "packageManager": "npm@8.5.0",
+   "workspaces": [
+     "apps/*",
+     "packages/*"
+   ]
 }
 ```
 

--- a/docs/site/content/docs/getting-started/add-to-existing-repository.mdx
+++ b/docs/site/content/docs/getting-started/add-to-existing-repository.mdx
@@ -202,26 +202,14 @@ Turborepo optimizes your repository using information from your package manager.
 <Step>
 ### Set up package manager workspaces
 
-For multi-package repositories, you'll need to configure your package manager to recognize your workspace structure. This is done by adding a `workspaces` field to your root `package.json`.
+For [multi-package workspaces](https://vercel.com/docs/glossary#multi-package-workspace), you'll need to configure your package manager to recognize your workspace structure.
 
 The `workspaces` field tells your package manager which directories contain your packages. Common patterns include `apps/*` for applications and `packages/*` for shared libraries.
 
-```diff title="package.json"
-{
-  "packageManager": "npm@8.5.0",
-+  "workspaces": [
-+    "apps/*",
-+    "packages/*"
-+  ]
-}
-```
-
-<Callout type="info">
+<Callout type="good-to-know">
   If you're working with a single-package repository, you can skip this step as
   workspaces aren't needed.
 </Callout>
-
-Different package managers may have alternative ways to configure workspaces:
 
 <PackageManagerTabs>
 
@@ -271,7 +259,7 @@ Different package managers may have alternative ways to configure workspaces:
   }
   ```
 
-  <LinkToDocumentation href="https://bun.sh/docs/install/workspaces">npm workspace documentation</LinkToDocumentation>
+  <LinkToDocumentation href="https://bun.sh/docs/install/workspaces">bun workspace documentation</LinkToDocumentation>
   </Tab>
 
 </PackageManagerTabs>


### PR DESCRIPTION
## Description
This PR updates the package.json configuration example in the documentation to include the `workspaces` field, which is necessary for multi-package repositories using Turborepo.

## Motivation
While following this documentation page, I noticed that the package.json example showed how to add the `packageManager` field, but omitted the `workspaces` field. Although this information is later explained at https://turborepo.com/docs/crafting-your-repository/structuring-a-repository#declaring-directories-for-packages, including it in this initial example would make the documentation more consistent and help prevent confusion for new users who are following the steps sequentially.

## Changes made
I've updated the diff example in the "Add a `packageManager` field to root `package.json`" section to show the `workspaces` field alongside the `packageManager` field, making the example complete and consistent with what's explained later in the documentation.