### PR TITLE
docs: [correction] nx remote caching is free like Turborepo

### DIFF
--- a/docs/site/content/docs/guides/migrating-from-nx.mdx
+++ b/docs/site/content/docs/guides/migrating-from-nx.mdx
@@ -145,7 +145,7 @@ Migrating to Turborepo will likely require deleting previous configuration that 
 
 Turborepo’s [Remote Caching](/docs/core-concepts/remote-caching) stores the results of your task on a cloud server. This saves enormous amounts of time by **preventing duplicated work across your entire organization**. [Vercel Remote Cache](https://vercel.com/docs/monorepos/remote-caching) has saved teams over 500 years of compute so far.
 
-Since Nx 19.7, similar functionality is a paid-for feature, even when self-hosting. Remote Caching with Turborepo is free when [self-hosting](/docs/core-concepts/remote-caching#self-hosting) or using [Vercel Remote Cache](https://vercel.com/docs/monorepos/remote-caching).
+Nx offers multiple forms of Free Remote Caching: Nx Cloud, Free Self-Hosted via plugins, or via OpenAPI spec like Turborepo.
 
 ## Migration steps
 

--- a/docs/site/content/docs/guides/migrating-from-nx.mdx
+++ b/docs/site/content/docs/guides/migrating-from-nx.mdx
@@ -141,12 +141,6 @@ Migrating to Turborepo will likely require deleting previous configuration that 
 
 </Tabs>
 
-### Free Remote Caching
-
-Turborepo’s [Remote Caching](/docs/core-concepts/remote-caching) stores the results of your task on a cloud server. This saves enormous amounts of time by **preventing duplicated work across your entire organization**. [Vercel Remote Cache](https://vercel.com/docs/monorepos/remote-caching) has saved teams over 500 years of compute so far.
-
-Nx offers multiple forms of Free Remote Caching: Nx Cloud, Free Self-Hosted via plugins, or via OpenAPI spec like Turborepo.
-
 ## Migration steps
 
 Our goal for this migration is to get a working Turborepo task as quickly as possible, so that you can adopt Turborepo features incrementally. We’ll start by using the Nx scaffolder to create a repository with a Next.js app.
@@ -473,7 +467,7 @@ turbo login
 turbo link
 ```
 
-You may also configure a self-hosted Remote Cache, which does not require a license or any other fees.
+You may also configure a self-hosted Remote Cache.
 
 ## Advanced migration considerations
 


### PR DESCRIPTION
The deleted statement was **never** accurate in Nx. We briefly openly explored some alternative solutions and pricing structures for self-hosted caching but this _never_ landed as a requirement in Nx. We took on the feedback loud and clear that our initial thinking was misguided and we changed course _before_ it landed.

We offer a broader array of free cache hosting options than Turborepo, with the OpenAPI spec being the exact equivalent of how Turborepo chooses to approach the problem, you can learn more here:

https://nx.dev/recipes/running-tasks/self-hosted-caching

For this change, I went for the most generous correction I could, but you may decide the overall section is redundant without this key incorrect point.

While I'm here, I'd suggest you run through this guide yourself again because it doesn't really make sense currently. If you run the command you have listed Nx generates package manager workspaces, no `project.json` files, and `package.json` files for each project, but then you tell people to add these things because that's "only how Turborepo does things" (not quoting but that's the inaccurate gist)...

Finally, as pointed out last time your `nx.json` to `turbo.json` comparison is very, very far from apples to apples. On the nx side you are demonstrating the configuration of a bunch of capabilities that Turborepo simply does not have and then saying "see, look, nx _requires_ more config", which doesn't seem fair 🤷

Nx can work _exactly_ how Turborepo works, and it can _also_ work with optional plugins, users have complete freedom of choice. If you'd like to collaborate on further rewrites I'm totally open to that, but I thought I would keep this PR very focused on this critical correction for now.