### PR TITLE
fix: correct link to docs in platform-environment-variables warning

### DIFF
--- a/crates/turborepo-env/src/platform.rs
+++ b/crates/turborepo-env/src/platform.rs
@@ -64,7 +64,7 @@ impl PlatformEnv {
         let docs_message = color!(
             color_config,
             UNDERLINE,
-            "https://turborepo.com/docs/platform-environment-variables"
+            "https://turborepo.com/docs/crafting-your-repository/using-environment-variables#platform-environment-variables"
         );
 
         match ci {


### PR DESCRIPTION
### Description

This PR corrects the link used in a warning when building a project using environment variables without setting them up in `turbo.json`

Fixes #10461

### Testing Instructions

- [ ] Simply check if the link is correct (the previously used link was pointing to a 404 page)
