### PR TITLE
docs: added pnpm catalogs

### DIFF
--- a/docs/site/content/docs/crafting-your-repository/managing-dependencies.mdx
+++ b/docs/site/content/docs/crafting-your-repository/managing-dependencies.mdx
@@ -185,6 +185,10 @@ pnpm up --recursive typescript@latest
 ```
   <small>[→ pnpm documentation](https://pnpm.io/cli/update#--recursive--r)</small>
 
+Catalogs:
+Reference constants for version ranges across `package.json` files. 
+  <small>[→ pnpm catalogs](https://pnpm.io/catalogs)</small>
+
 </Tab>
 
 <Tab value="yarn">

--- a/docs/site/content/docs/crafting-your-repository/managing-dependencies.mdx
+++ b/docs/site/content/docs/crafting-your-repository/managing-dependencies.mdx
@@ -182,7 +182,7 @@ You can use your package manager to update dependency versions in one command.
 <Tab value="pnpm">
 
 ```bash title="Terminal"
-  pnpm up --recursive typescript@latest
+pnpm up --recursive typescript@latest
 ```
 
 <small>[→ pnpm documentation](https://pnpm.io/cli/update#--recursive--r)</small>

--- a/docs/site/content/docs/crafting-your-repository/managing-dependencies.mdx
+++ b/docs/site/content/docs/crafting-your-repository/managing-dependencies.mdx
@@ -180,14 +180,12 @@ You can use your package manager to update dependency versions in one command.
 <PackageManagerTabs>
 
 <Tab value="pnpm">
-```bash title="Terminal"
-pnpm up --recursive typescript@latest
-```
-  <small>[→ pnpm documentation](https://pnpm.io/cli/update#--recursive--r)</small>
 
-Catalogs:
-Reference constants for version ranges across `package.json` files. 
-  <small>[→ pnpm catalogs](https://pnpm.io/catalogs)</small>
+```bash title="Terminal"
+  pnpm up --recursive typescript@latest
+```
+
+<small>[→ pnpm documentation](https://pnpm.io/cli/update#--recursive--r)</small>
 
 </Tab>
 
@@ -223,6 +221,12 @@ No equivalent
 
 </Tab>
 </PackageManagerTabs>
+
+#### pnpm catalogs
+
+In pnpm v9.5+, you can use catalogs to define dependency version ranges as reusable constants. This will keep dependencies on the same version since you're referencing the same value across the workspace.
+
+To learn more, [visit the pnpm catalogs documentation](https://pnpm.io/catalogs).
 
 #### Using an IDE
 


### PR DESCRIPTION
### Description

Added [pnpm catalogs](https://pnpm.io/catalogs) as another option to keep dependency versions in sync across packages.

### Testing Instructions

None, just docs.
<!--
  Give a quick description of steps to test your changes.
-->
