### PR TITLE
feat: hot-reloading for `no-undeclared-env-vars` ESLint rule

### DIFF
--- a/packages/eslint-plugin-turbo/__tests__/lib/no-undeclared-env-vars/workspace-configs/reload.test.ts
+++ b/packages/eslint-plugin-turbo/__tests__/lib/no-undeclared-env-vars/workspace-configs/reload.test.ts
@@ -1,0 +1,72 @@
+import path from "node:path";
+import { RuleTester } from "eslint";
+import { describe, expect, it } from "@jest/globals";
+import { RULES } from "../../../../lib/constants";
+import rule from "../../../../lib/rules/no-undeclared-env-vars";
+import { Project } from "../../../../lib/utils/calculate-inputs";
+
+const ruleTester = new RuleTester({
+  parserOptions: { ecmaVersion: 2020, sourceType: "module" },
+});
+
+const cwd = path.join(__dirname, "../../../../__fixtures__/workspace-configs");
+const webFilename = path.join(cwd, "/apps/web/index.js");
+
+describe("Project reload functionality", () => {
+  it("should reload workspace configurations when called", () => {
+    const project = new Project(cwd);
+    const initialConfigs = [...project.allConfigs];
+
+    // Call reload
+    project.reload();
+
+    // Verify that configurations were reloaded
+    expect(project.allConfigs).not.toBe(initialConfigs);
+    expect(project.allConfigs.length).toBe(initialConfigs.length);
+
+    // Verify that project root and workspaces were updated
+    expect(project.projectRoot).toBeDefined();
+    expect(project.projectWorkspaces.length).toBeGreaterThan(0);
+  });
+
+  it("should regenerate key and test configurations after reload", () => {
+    const project = new Project(cwd);
+    const initialKey = project._key;
+    const initialTest = project._test;
+
+    // Call reload
+    project.reload();
+
+    // Verify that key and test configurations were regenerated
+    expect(project._key).not.toBe(initialKey);
+    expect(project._test).not.toBe(initialTest);
+  });
+});
+
+// Test that the reload functionality works with the ESLint rule
+ruleTester.run(RULES.noUndeclaredEnvVars, rule, {
+  valid: [
+    {
+      code: `
+        const { ENV_2 } = import.meta.env;
+      `,
+      options: [{ cwd }],
+      filename: webFilename,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        const { ENV_3 } = import.meta.env;
+      `,
+      options: [{ cwd }],
+      filename: webFilename,
+      errors: [
+        {
+          message:
+            "ENV_3 is not listed as a dependency in the root turbo.json or workspace (apps/web) turbo.json",
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin-turbo/__tests__/lib/no-undeclared-env-vars/workspace-configs/reload.test.ts
+++ b/packages/eslint-plugin-turbo/__tests__/lib/no-undeclared-env-vars/workspace-configs/reload.test.ts
@@ -1,6 +1,8 @@
 import path from "node:path";
+import fs from "node:fs";
 import { RuleTester } from "eslint";
-import { describe, expect, it } from "@jest/globals";
+import { describe, expect, it, beforeEach, afterEach } from "@jest/globals";
+import type { SchemaV1 } from "@turbo/types";
 import { RULES } from "../../../../lib/constants";
 import rule from "../../../../lib/rules/no-undeclared-env-vars";
 import { Project } from "../../../../lib/utils/calculate-inputs";
@@ -13,8 +15,23 @@ const cwd = path.join(__dirname, "../../../../__fixtures__/workspace-configs");
 const webFilename = path.join(cwd, "/apps/web/index.js");
 
 describe("Project reload functionality", () => {
+  let project: Project;
+  let originalTurboJson: string;
+
+  beforeEach(() => {
+    project = new Project(cwd);
+    // Store original turbo.json content for restoration
+    const turboJsonPath = path.join(cwd, "turbo.json");
+    originalTurboJson = fs.readFileSync(turboJsonPath, "utf8");
+  });
+
+  afterEach(() => {
+    // Restore original turbo.json content
+    const turboJsonPath = path.join(cwd, "turbo.json");
+    fs.writeFileSync(turboJsonPath, originalTurboJson);
+  });
+
   it("should reload workspace configurations when called", () => {
-    const project = new Project(cwd);
     const initialConfigs = [...project.allConfigs];
 
     // Call reload
@@ -30,7 +47,6 @@ describe("Project reload functionality", () => {
   });
 
   it("should regenerate key and test configurations after reload", () => {
-    const project = new Project(cwd);
     const initialKey = project._key;
     const initialTest = project._test;
 
@@ -40,6 +56,60 @@ describe("Project reload functionality", () => {
     // Verify that key and test configurations were regenerated
     expect(project._key).not.toBe(initialKey);
     expect(project._test).not.toBe(initialTest);
+  });
+
+  it("should detect changes in turbo.json after reload", () => {
+    const turboJsonPath = path.join(cwd, "turbo.json");
+    const initialConfig = project.projectRoot?.turboConfig;
+
+    // Modify turbo.json
+    const modifiedConfig: SchemaV1 = {
+      ...(JSON.parse(originalTurboJson) as SchemaV1),
+      pipeline: {
+        ...(JSON.parse(originalTurboJson) as SchemaV1).pipeline,
+        newTask: {
+          outputs: [],
+        },
+      },
+    };
+    fs.writeFileSync(turboJsonPath, JSON.stringify(modifiedConfig, null, 2));
+
+    // Call reload
+    project.reload();
+
+    // Verify that the new configuration is loaded
+    expect(project.projectRoot?.turboConfig).not.toEqual(initialConfig);
+    expect(project.projectRoot?.turboConfig).toEqual(modifiedConfig);
+  });
+
+  it("should handle invalid turbo.json gracefully", () => {
+    const turboJsonPath = path.join(cwd, "turbo.json");
+
+    // Write invalid JSON
+    fs.writeFileSync(turboJsonPath, "invalid json");
+
+    // Call reload - should not throw
+    expect(() => {
+      project.reload();
+    }).not.toThrow();
+
+    // Verify that the project still has a valid state
+    expect(project.projectRoot).toBeDefined();
+    expect(project.projectWorkspaces.length).toBeGreaterThan(0);
+  });
+
+  it("should maintain consistent state after multiple reloads", () => {
+    const initialConfigs = [...project.allConfigs];
+
+    // Perform multiple reloads
+    project.reload();
+    project.reload();
+    project.reload();
+
+    // Verify that the final state is consistent
+    expect(project.allConfigs.length).toBe(initialConfigs.length);
+    expect(project.projectRoot).toBeDefined();
+    expect(project.projectWorkspaces.length).toBeGreaterThan(0);
   });
 });
 

--- a/packages/eslint-plugin-turbo/lib/rules/no-undeclared-env-vars.ts
+++ b/packages/eslint-plugin-turbo/lib/rules/no-undeclared-env-vars.ts
@@ -264,7 +264,7 @@ function create(context: RuleContextWithOptions): Rule.RuleListener {
 
   return {
     MemberExpression(node) {
-      // Reload project configuration so that changes show in the users editor
+      // Reload project configuration so that changes show in the user's editor
       project.reload();
 
       // we only care about complete process env declarations and non-computed keys

--- a/packages/eslint-plugin-turbo/lib/rules/no-undeclared-env-vars.ts
+++ b/packages/eslint-plugin-turbo/lib/rules/no-undeclared-env-vars.ts
@@ -264,11 +264,10 @@ function create(context: RuleContextWithOptions): Rule.RuleListener {
 
   return {
     Program() {
+      // Reload project configuration so that changes show in the user's editor
       project.reload();
     },
     MemberExpression(node) {
-      // Reload project configuration so that changes show in the user's editor
-
       // we only care about complete process env declarations and non-computed keys
       if (isProcessEnv(node) || isImportMetaEnv(node)) {
         // we're doing something with process.env

--- a/packages/eslint-plugin-turbo/lib/rules/no-undeclared-env-vars.ts
+++ b/packages/eslint-plugin-turbo/lib/rules/no-undeclared-env-vars.ts
@@ -264,6 +264,44 @@ function create(context: RuleContextWithOptions): Rule.RuleListener {
 
   return {
     MemberExpression(node) {
+      // Log current configuration state
+      debug("Current configuration state:");
+      debug(
+        `- Root config: ${JSON.stringify(project.projectRoot?.turboConfig)}`
+      );
+      debug(
+        `- Workspace configs: ${project.projectWorkspaces
+          .map((w) => w.workspaceName)
+          .join(", ")}`
+      );
+
+      // Reload project configuration
+      project.reload();
+
+      // Log new configuration state
+      debug("Configuration state after reload:");
+      debug(
+        `- Root config: ${JSON.stringify(project.projectRoot?.turboConfig)}`
+      );
+      debug(
+        `- Workspace configs: ${project.projectWorkspaces
+          .map((w) => w.workspaceName)
+          .join(", ")}`
+      );
+
+      // Verify that the configuration was actually reloaded
+      const rootConfigPath = path.join(cwd || process.cwd(), "turbo.json");
+      try {
+        const rootConfigContent = readFileSync(rootConfigPath, "utf-8");
+        debug(`- Current turbo.json content: ${rootConfigContent}`);
+      } catch (err) {
+        debug(
+          `Could not read turbo.json: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      }
+
       // we only care about complete process env declarations and non-computed keys
       if (isProcessEnv(node) || isImportMetaEnv(node)) {
         // we're doing something with process.env

--- a/packages/eslint-plugin-turbo/lib/rules/no-undeclared-env-vars.ts
+++ b/packages/eslint-plugin-turbo/lib/rules/no-undeclared-env-vars.ts
@@ -264,30 +264,8 @@ function create(context: RuleContextWithOptions): Rule.RuleListener {
 
   return {
     MemberExpression(node) {
-      // Log current configuration state
-      debug("Current configuration state:");
-      debug(
-        `- Root config: ${JSON.stringify(project.projectRoot?.turboConfig)}`
-      );
-      debug(
-        `- Workspace configs: ${project.projectWorkspaces
-          .map((w) => w.workspaceName)
-          .join(", ")}`
-      );
-
-      // Reload project configuration
+      // Reload project configuration so that changes show in the users editor
       project.reload();
-
-      // Log new configuration state
-      debug("Configuration state after reload:");
-      debug(
-        `- Root config: ${JSON.stringify(project.projectRoot?.turboConfig)}`
-      );
-      debug(
-        `- Workspace configs: ${project.projectWorkspaces
-          .map((w) => w.workspaceName)
-          .join(", ")}`
-      );
 
       // Verify that the configuration was actually reloaded
       const rootConfigPath = path.join(cwd || process.cwd(), "turbo.json");

--- a/packages/eslint-plugin-turbo/lib/rules/no-undeclared-env-vars.ts
+++ b/packages/eslint-plugin-turbo/lib/rules/no-undeclared-env-vars.ts
@@ -263,9 +263,11 @@ function create(context: RuleContextWithOptions): Rule.RuleListener {
   };
 
   return {
+    Program() {
+      project.reload();
+    },
     MemberExpression(node) {
       // Reload project configuration so that changes show in the user's editor
-      project.reload();
 
       // we only care about complete process env declarations and non-computed keys
       if (isProcessEnv(node) || isImportMetaEnv(node)) {

--- a/packages/eslint-plugin-turbo/lib/rules/no-undeclared-env-vars.ts
+++ b/packages/eslint-plugin-turbo/lib/rules/no-undeclared-env-vars.ts
@@ -267,19 +267,6 @@ function create(context: RuleContextWithOptions): Rule.RuleListener {
       // Reload project configuration so that changes show in the users editor
       project.reload();
 
-      // Verify that the configuration was actually reloaded
-      const rootConfigPath = path.join(cwd || process.cwd(), "turbo.json");
-      try {
-        const rootConfigContent = readFileSync(rootConfigPath, "utf-8");
-        debug(`- Current turbo.json content: ${rootConfigContent}`);
-      } catch (err) {
-        debug(
-          `Could not read turbo.json: ${
-            err instanceof Error ? err.message : String(err)
-          }`
-        );
-      }
-
       // we only care about complete process env declarations and non-computed keys
       if (isProcessEnv(node) || isImportMetaEnv(node)) {
         // we're doing something with process.env

--- a/packages/eslint-plugin-turbo/lib/utils/calculate-inputs.ts
+++ b/packages/eslint-plugin-turbo/lib/utils/calculate-inputs.ts
@@ -284,13 +284,10 @@ export class Project {
   constructor(cwd: string | undefined) {
     this.cwd = cwd;
     this.allConfigs = getWorkspaceConfigs(cwd);
-    this.projectRoot = this.allConfigs.find(
-      (workspaceConfig) => workspaceConfig.isWorkspaceRoot
-    );
+    this.projectRoot = this.allConfigs.find((config) => config.isWorkspaceRoot);
     this.projectWorkspaces = this.allConfigs.filter(
-      (workspaceConfig) => !workspaceConfig.isWorkspaceRoot
+      (config) => !config.isWorkspaceRoot
     );
-
     this._key = this.generateKey();
     this._test = this.generateTestConfig();
   }
@@ -441,5 +438,18 @@ export class Project {
     }
 
     return tests.flat().some((test) => test(envVar));
+  }
+
+  reload() {
+    // Reload workspace configurations with caching disabled
+    this.allConfigs = getWorkspaceConfigs(this.cwd, { cache: false });
+    this.projectRoot = this.allConfigs.find((config) => config.isWorkspaceRoot);
+    this.projectWorkspaces = this.allConfigs.filter(
+      (config) => !config.isWorkspaceRoot
+    );
+
+    // Regenerate key and test configurations
+    this._key = this.generateKey();
+    this._test = this.generateTestConfig();
   }
 }


### PR DESCRIPTION
### Description

Fixes #10140 so that updating the `env` key in `turbo.json` is reflected in ESLint in your editor.

### Testing Instructions

TODO
