### PR TITLE
docs: Update managing-dependencies.mdx

### DIFF
--- a/docs/site/content/docs/crafting-your-repository/managing-dependencies.mdx
+++ b/docs/site/content/docs/crafting-your-repository/managing-dependencies.mdx
@@ -75,7 +75,7 @@ To quickly install dependencies in multiple packages, you can use your package m
 <Tab value="pnpm">
 
 ```bash title="Terminal"
-pnpm install jest --save-dev --recursive --filter=web --filter=@repo/ui --filter=@repo/web
+pnpm install jest --save-dev --recursive --filter=web --filter=@repo/ui --filter=docs
 ```
 
 <LinkToDocumentation href="https://pnpm.io/cli/recursive">pnpm documentation</LinkToDocumentation>


### PR DESCRIPTION
### Description

Hey,

In the "Best practices for dependency installation" section, the example command should be updated to align with the "Getting started" tutorial, where the default setup installs the docs/ and web/ apps.

Right now, it references @repo/web, but that package doesn't exist, what we actually have is @repo/ui.

The correct command should be:
```
pnpm install jest --save-dev --recursive --filter=web --filter=@repo/ui --filter=docs
```
<img width="830" alt="Screenshot 2025-05-12 at 10 17 52" src="https://github.com/user-attachments/assets/4a81baf3-cb72-4511-9ba0-a189f92aa671" />

Instead of:
```
pnpm install jest --save-dev --recursive --filter=web --filter=@repo/ui --filter=@repo/web
```

<img width="848" alt="Screenshot 2025-05-12 at 10 18 22" src="https://github.com/user-attachments/assets/7cdc1931-d9be-4c2c-9d5f-419911b34b75" />


<img width="1440" alt="Screenshot 2025-05-12 at 10 19 11" src="https://github.com/user-attachments/assets/6246bbbd-9974-4fea-9d49-a23df2a870aa" />


### Testing Instructions
(I'm reading the Turborepo docs and testing)

1. Follow the [Getting Started Tutorial](https://turborepo.com/docs/getting-started/installation)
2. Go to [[Best practices for dependency installation](https://turborepo.com/docs/crafting-your-repository/managing-dependencies#best-practices-for-dependency-installation)](https://turborepo.com/docs/crafting-your-repository/managing-dependencies#best-practices-for-dependency-installation)
3. Try to run: 
```
pnpm install jest --save-dev --recursive --filter=web --filter=@repo/ui --filter=@repo/web
```
<img width="740" alt="Screenshot 2025-05-12 at 10 20 50" src="https://github.com/user-attachments/assets/65380834-d7d3-4091-935d-f338cc329bb6" />



