### PR TITLE
Use entry instead of entryPoints

### DIFF
--- a/examples/kitchen-sink/apps/api/tsup.config.ts
+++ b/examples/kitchen-sink/apps/api/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig, type Options } from "tsup";
 
 export default defineConfig((options: Options) => ({
-  entryPoints: ["src/index.ts"],
+  entry: ['src/**/*'],
   clean: true,
   format: ["cjs"],
   ...options,


### PR DESCRIPTION
### Description

In tsup `entryPoints` is deprecated. You should use `entry` instead.

Also, I use src/**/*, so in case of projects using multiple directories in the `src` directory. That also keeps working.

### Testing Instructions


Try to run the example project again eg. `pnpm run dev`.