### PR TITLE
feat: specific error message for potential debugging flags

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -278,7 +278,7 @@ pub struct Verbosity {
         value_name = "COUNT"
     )]
     /// Verbosity level. Useful when debugging Turborepo or creating logs for
-    /// issue reports.
+    /// issue reports
     pub verbosity: Option<u8>,
     #[clap(
         short = 'v',

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -277,7 +277,8 @@ pub struct Verbosity {
         conflicts_with = "v",
         value_name = "COUNT"
     )]
-    /// Verbosity level
+    /// Verbosity level. Useful when debugging Turborepo or creating logs for
+    /// issue reports.
     pub verbosity: Option<u8>,
     #[clap(
         short = 'v',

--- a/crates/turborepo-lib/src/shim/mod.rs
+++ b/crates/turborepo-lib/src/shim/mod.rs
@@ -53,6 +53,8 @@ pub enum Error {
         #[label = "Requires a path to be passed after it"]
         flag_range: SourceSpan,
     },
+    #[error("The {flag} flag is not supported. {suggestion}")]
+    UnsupportedFlag { flag: String, suggestion: String },
     #[error(transparent)]
     #[diagnostic(transparent)]
     Cli(#[from] cli::Error),

--- a/crates/turborepo-lib/src/shim/parser.rs
+++ b/crates/turborepo-lib/src/shim/parser.rs
@@ -2,8 +2,9 @@ use std::{backtrace::Backtrace, env};
 
 use itertools::Itertools;
 use miette::{Diagnostic, SourceSpan};
+use tracing::warn;
 use turbopath::AbsoluteSystemPathBuf;
-use turborepo_ui::ColorConfig;
+use turborepo_ui::{ceprintln, ColorConfig, YELLOW};
 
 use super::Error;
 
@@ -142,6 +143,16 @@ impl ShimArgs {
                 // `--root-turbo-json=./path/to/turbo.json`, that entire chunk
                 // is a single arg, so we need to split it up.
                 root_turbo_json = Some(AbsoluteSystemPathBuf::from_unknown(&invocation_dir, path));
+            } else if arg == "--debug" {
+                return Err(Error::UnsupportedFlag {
+                    flag: "--debug".to_string(),
+                    suggestion: "Please use --verbosity instead.".to_string(),
+                });
+            } else if arg == "--verbose" {
+                return Err(Error::UnsupportedFlag {
+                    flag: "--verbose".to_string(),
+                    suggestion: "Please use --verbosity instead.".to_string(),
+                });
             } else {
                 remaining_turbo_args.push(arg);
             }

--- a/crates/turborepo-lib/src/shim/parser.rs
+++ b/crates/turborepo-lib/src/shim/parser.rs
@@ -146,12 +146,12 @@ impl ShimArgs {
             } else if arg == "--debug" {
                 return Err(Error::UnsupportedFlag {
                     flag: "--debug".to_string(),
-                    suggestion: "Please use --verbosity instead.".to_string(),
+                    suggestion: "Use --verbosity instead.".to_string(),
                 });
             } else if arg == "--verbose" {
                 return Err(Error::UnsupportedFlag {
                     flag: "--verbose".to_string(),
-                    suggestion: "Please use --verbosity instead.".to_string(),
+                    suggestion: "Use --verbosity instead.".to_string(),
                 });
             } else {
                 remaining_turbo_args.push(arg);

--- a/crates/turborepo-lib/src/shim/parser.rs
+++ b/crates/turborepo-lib/src/shim/parser.rs
@@ -2,9 +2,8 @@ use std::{backtrace::Backtrace, env};
 
 use itertools::Itertools;
 use miette::{Diagnostic, SourceSpan};
-use tracing::warn;
 use turbopath::AbsoluteSystemPathBuf;
-use turborepo_ui::{ceprintln, ColorConfig, YELLOW};
+use turborepo_ui::ColorConfig;
 
 use super::Error;
 
@@ -146,12 +145,16 @@ impl ShimArgs {
             } else if arg == "--debug" {
                 return Err(Error::UnsupportedFlag {
                     flag: "--debug".to_string(),
-                    suggestion: "Use --verbosity instead.".to_string(),
+                    suggestion: "Please use --verbosity instead.\n if you are trying to pass \
+                                 `--debug` as a value, use `-- --debug`."
+                        .to_string(),
                 });
             } else if arg == "--verbose" {
                 return Err(Error::UnsupportedFlag {
                     flag: "--verbose".to_string(),
-                    suggestion: "Use --verbosity instead.".to_string(),
+                    suggestion: "Please use --verbosity instead.\n if you are trying to pass \
+                                 `--verbose` as a value, use `-- --verbose`."
+                        .to_string(),
                 });
             } else {
                 remaining_turbo_args.push(arg);

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -57,7 +57,7 @@ Make sure exit code is 2 when no args are passed
         --trace <TRACE>
             Specify a file to save a pprof trace
         --verbosity <COUNT>
-            Verbosity level
+            Verbosity level. Useful when debugging Turborepo or creating logs for reports
         --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`
         --root-turbo-json <ROOT_TURBO_JSON>

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -57,7 +57,7 @@ Make sure exit code is 2 when no args are passed
         --trace <TRACE>
             Specify a file to save a pprof trace
         --verbosity <COUNT>
-            Verbosity level. Useful when debugging Turborepo or creating logs for reports.
+            Verbosity level. Useful when debugging Turborepo or creating logs for reports
         --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`
         --root-turbo-json <ROOT_TURBO_JSON>

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -57,7 +57,7 @@ Make sure exit code is 2 when no args are passed
         --trace <TRACE>
             Specify a file to save a pprof trace
         --verbosity <COUNT>
-            Verbosity level. Useful when debugging Turborepo or creating logs for reports
+            Verbosity level. Useful when debugging Turborepo or creating logs for reports.
         --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`
         --root-turbo-json <ROOT_TURBO_JSON>

--- a/turborepo-tests/integration/tests/no-args.t
+++ b/turborepo-tests/integration/tests/no-args.t
@@ -57,7 +57,7 @@ Make sure exit code is 2 when no args are passed
         --trace <TRACE>
             Specify a file to save a pprof trace
         --verbosity <COUNT>
-            Verbosity level. Useful when debugging Turborepo or creating logs for reports
+            Verbosity level. Useful when debugging Turborepo or creating logs for issue reports
         --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`
         --root-turbo-json <ROOT_TURBO_JSON>

--- a/turborepo-tests/integration/tests/turbo-help.t
+++ b/turborepo-tests/integration/tests/turbo-help.t
@@ -57,7 +57,7 @@ Test help flag
         --trace <TRACE>
             Specify a file to save a pprof trace
         --verbosity <COUNT>
-            Verbosity level. Useful when debugging Turborepo or creating logs for issue reports.
+            Verbosity level. Useful when debugging Turborepo or creating logs for issue reports
         --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`
         --root-turbo-json <ROOT_TURBO_JSON>
@@ -201,7 +201,7 @@ Test help flag
             Specify a file to save a pprof trace
   
         --verbosity <COUNT>
-            Verbosity level. Useful when debugging Turborepo or creating logs for issue reports.
+            Verbosity level. Useful when debugging Turborepo or creating logs for issue reports
   
         --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`.
@@ -368,7 +368,7 @@ Test help flag for link command
         --trace <TRACE>
             Specify a file to save a pprof trace
         --verbosity <COUNT>
-            Verbosity level. Useful when debugging Turborepo or creating logs for issue reports.
+            Verbosity level. Useful when debugging Turborepo or creating logs for issue reports
         --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`
         --root-turbo-json <ROOT_TURBO_JSON>
@@ -416,7 +416,7 @@ Test help flag for unlink command
         --trace <TRACE>
             Specify a file to save a pprof trace
         --verbosity <COUNT>
-            Verbosity level. Useful when debugging Turborepo or creating logs for issue reports.
+            Verbosity level. Useful when debugging Turborepo or creating logs for issue reports
         --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`
         --root-turbo-json <ROOT_TURBO_JSON>
@@ -468,7 +468,7 @@ Test help flag for login command
         --trace <TRACE>
             Specify a file to save a pprof trace
         --verbosity <COUNT>
-            Verbosity level. Useful when debugging Turborepo or creating logs for issue reports.
+            Verbosity level. Useful when debugging Turborepo or creating logs for issue reports
         --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`
         --root-turbo-json <ROOT_TURBO_JSON>
@@ -516,7 +516,7 @@ Test help flag for logout command
         --trace <TRACE>
             Specify a file to save a pprof trace
         --verbosity <COUNT>
-            Verbosity level. Useful when debugging Turborepo or creating logs for issue reports.
+            Verbosity level. Useful when debugging Turborepo or creating logs for issue reports
         --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`
         --root-turbo-json <ROOT_TURBO_JSON>

--- a/turborepo-tests/integration/tests/turbo-help.t
+++ b/turborepo-tests/integration/tests/turbo-help.t
@@ -57,7 +57,7 @@ Test help flag
         --trace <TRACE>
             Specify a file to save a pprof trace
         --verbosity <COUNT>
-            Verbosity level
+            Verbosity level. Useful when debugging Turborepo or creating logs for reports.
         --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`
         --root-turbo-json <ROOT_TURBO_JSON>
@@ -201,7 +201,7 @@ Test help flag
             Specify a file to save a pprof trace
   
         --verbosity <COUNT>
-            Verbosity level
+            Verbosity level. Useful when debugging Turborepo or creating logs for reports.
   
         --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`.
@@ -368,7 +368,7 @@ Test help flag for link command
         --trace <TRACE>
             Specify a file to save a pprof trace
         --verbosity <COUNT>
-            Verbosity level
+            Verbosity level. Useful when debugging Turborepo or creating logs for reports.
         --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`
         --root-turbo-json <ROOT_TURBO_JSON>
@@ -416,7 +416,7 @@ Test help flag for unlink command
         --trace <TRACE>
             Specify a file to save a pprof trace
         --verbosity <COUNT>
-            Verbosity level
+            Verbosity level. Useful when debugging Turborepo or creating logs for reports.
         --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`
         --root-turbo-json <ROOT_TURBO_JSON>
@@ -468,7 +468,7 @@ Test help flag for login command
         --trace <TRACE>
             Specify a file to save a pprof trace
         --verbosity <COUNT>
-            Verbosity level
+            Verbosity level. Useful when debugging Turborepo or creating logs for reports.
         --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`
         --root-turbo-json <ROOT_TURBO_JSON>
@@ -516,7 +516,7 @@ Test help flag for logout command
         --trace <TRACE>
             Specify a file to save a pprof trace
         --verbosity <COUNT>
-            Verbosity level
+            Verbosity level. Useful when debugging Turborepo or creating logs for reports.
         --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`
         --root-turbo-json <ROOT_TURBO_JSON>

--- a/turborepo-tests/integration/tests/turbo-help.t
+++ b/turborepo-tests/integration/tests/turbo-help.t
@@ -57,7 +57,7 @@ Test help flag
         --trace <TRACE>
             Specify a file to save a pprof trace
         --verbosity <COUNT>
-            Verbosity level. Useful when debugging Turborepo or creating logs for reports.
+            Verbosity level. Useful when debugging Turborepo or creating logs for issue reports.
         --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`
         --root-turbo-json <ROOT_TURBO_JSON>
@@ -201,7 +201,7 @@ Test help flag
             Specify a file to save a pprof trace
   
         --verbosity <COUNT>
-            Verbosity level. Useful when debugging Turborepo or creating logs for reports.
+            Verbosity level. Useful when debugging Turborepo or creating logs for issue reports.
   
         --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`.
@@ -368,7 +368,7 @@ Test help flag for link command
         --trace <TRACE>
             Specify a file to save a pprof trace
         --verbosity <COUNT>
-            Verbosity level. Useful when debugging Turborepo or creating logs for reports.
+            Verbosity level. Useful when debugging Turborepo or creating logs for issue reports.
         --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`
         --root-turbo-json <ROOT_TURBO_JSON>
@@ -416,7 +416,7 @@ Test help flag for unlink command
         --trace <TRACE>
             Specify a file to save a pprof trace
         --verbosity <COUNT>
-            Verbosity level. Useful when debugging Turborepo or creating logs for reports.
+            Verbosity level. Useful when debugging Turborepo or creating logs for issue reports.
         --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`
         --root-turbo-json <ROOT_TURBO_JSON>
@@ -468,7 +468,7 @@ Test help flag for login command
         --trace <TRACE>
             Specify a file to save a pprof trace
         --verbosity <COUNT>
-            Verbosity level. Useful when debugging Turborepo or creating logs for reports.
+            Verbosity level. Useful when debugging Turborepo or creating logs for issue reports.
         --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`
         --root-turbo-json <ROOT_TURBO_JSON>
@@ -516,7 +516,7 @@ Test help flag for logout command
         --trace <TRACE>
             Specify a file to save a pprof trace
         --verbosity <COUNT>
-            Verbosity level. Useful when debugging Turborepo or creating logs for reports.
+            Verbosity level. Useful when debugging Turborepo or creating logs for issue reports.
         --dangerously-disable-package-manager-check
             Allow for missing `packageManager` in `package.json`
         --root-turbo-json <ROOT_TURBO_JSON>


### PR DESCRIPTION
### Description

When a user tries to use `--debug` or `--verbose` as flags, we can make a pretty strong bet that they're trying to get some debug logging from us. In this case, we can supply better direction to the developer.

### Testing Instructions

Before:
```
▲ 👟 turbo on shew/8d2a6
  dt anything --debug
  × The --debug flag is not supported. Please use --verbosity instead.
  │  if you are trying to pass `--debug` as a value, use `-- --debug`.
```

AFTER:
```
▲ 👟 turbo on shew/8d2a6
  turbo anything --debug
 ERROR  unexpected argument '--debug' found

  tip: to pass '--debug' as a value, use '-- --debug'

Usage: turbo <--cache-dir <CACHE_DIR>|--concurrency <CONCURRENCY>|--continue[=<CONTINUE>]|--single-package|--framework-inference [<BOOL>]|--global-deps <GLOBAL_DEPS>|--env-mode [<ENV_MODE>]|--filter <FILTER>|--affected|--output-logs <OUTPUT_LOGS>|--log-order <LOG_ORDER>|--only|--pkg-inference-root <PKG_INFERENCE_ROOT>|--log-prefix <LOG_PREFIX>|TASKS|PASS_THROUGH_ARGS>

For more information, try '--help'.
```
