### PR TITLE
docs: account for Custom Environments

### DIFF
--- a/docs/site/scripts/sync-algolia.ts
+++ b/docs/site/scripts/sync-algolia.ts
@@ -35,6 +35,16 @@ const algoliaClient = algosearch(
   process.env.ALGOLIA_API_KEY
 );
 
+// Ensure a non-production target environment cannot sync to a production-looking Algolia index
+if (
+  process.env.VERCEL_TARGET_ENV !== "production" &&
+  process.env.NEXT_PUBLIC_ALGOLIA_INDEX?.includes("production")
+) {
+  throw new Error(
+    "Writing to the production Algolia index when building for an environment that is not production is not permitted."
+  );
+}
+
 const getDomain = () => {
   // Only "Production" environment
   if (process.env.VERCEL_TARGET_ENV === "production") {

--- a/docs/site/scripts/sync-algolia.ts
+++ b/docs/site/scripts/sync-algolia.ts
@@ -36,11 +36,13 @@ const algoliaClient = algosearch(
 );
 
 const getDomain = () => {
-  if (process.env.VERCEL_ENV === "production") {
+  // Only "Production" environment
+  if (process.env.VERCEL_TARGET_ENV === "production") {
     return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`;
   }
 
-  if (process.env.VERCEL_ENV === "preview") {
+  // All other environments on Vercel (Previews and Custom Environments)
+  if (process.env.VERCEL_ENV) {
     return `https://${process.env.VERCEL_URL}`;
   }
 


### PR DESCRIPTION
### Description

Our script allowed for a custom environment to write to production. Instead, we make sure only the `VERCEL_TARGET_ENV` that is "production" can do so.
