### PR TITLE
Update docker.mdx

### DIFF
--- a/docs/site/content/docs/guides/tools/docker.mdx
+++ b/docs/site/content/docs/guides/tools/docker.mdx
@@ -140,7 +140,7 @@ docker build -f apps/web/Dockerfile .
   mode](https://nextjs.org/docs/pages/api-reference/next-config-js/output).
 </Callout>
 
-```docker title="./apps/api/Dockerfile"
+```docker title="./apps/web/Dockerfile"
 FROM node:18-alpine AS base
 
 FROM base AS builder


### PR DESCRIPTION
Fix file path in docs

### Description

While I was reading https://turborepo.com/docs/guides/tools/docker i have noticed that file path `./apps/api/Dockerfile` does not match the content of the file. I think it should be `./apps/web/Dockerfile`

### Testing Instructions

Nothing to test just docs update.