### PR TITLE
fix(turbo): pass through pnpm store env vars by default

### DIFF
--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -479,6 +479,8 @@ impl<'a> TaskHasher<'a> {
                     "PROGRAMDATA",
                     "SYSTEMROOT",
                     "SYSTEMDRIVE",
+                    "PNPM_HOME",
+                    "NPM_CONFIG_STORE_DIR",
                 ];
                 let pass_through_env_vars = self.env_at_execution_start.pass_through_env(
                     builtin_pass_through,


### PR DESCRIPTION
### Description

If a task needs to access the pnpm store during execution and it is in a different spot than the default, it will be unable to find it.

### Testing Instructions

Merge + release. Then `with-svelte` example should start passing. Should remove need for https://github.com/vercel/turborepo/pull/10517
