### PR TITLE
fix(docs): use `pnpm add <pkg>` instead of `pnpm install <pkg>`

### DIFF
--- a/docs/site/content/blog/turbo-1-6-0.mdx
+++ b/docs/site/content/blog/turbo-1-6-0.mdx
@@ -68,7 +68,7 @@ Try it out now by [starting from the example](https://github.com/vercel/turbo/tr
    </Tab>
   <Tab value="pnpm">
   ```bash title="Terminal"
-  pnpm install turbo --save-dev
+  pnpm add turbo --save-dev
    ```
 
   </Tab>

--- a/docs/site/content/blog/turbo-1-7-0.mdx
+++ b/docs/site/content/blog/turbo-1-7-0.mdx
@@ -79,7 +79,7 @@ yarn global add turbo
 </Tab>
 <Tab value="pnpm">
 ```bash title="Terminal"
-pnpm install turbo --global
+pnpm add turbo --global
 ```
 
 </Tab>

--- a/docs/site/content/docs/crafting-your-repository/managing-dependencies.mdx
+++ b/docs/site/content/docs/crafting-your-repository/managing-dependencies.mdx
@@ -75,7 +75,7 @@ To quickly install dependencies in multiple packages, you can use your package m
 <Tab value="pnpm">
 
 ```bash title="Terminal"
-pnpm install jest --save-dev --recursive --filter=web --filter=@repo/ui --filter=docs
+pnpm add jest --save-dev --recursive --filter=web --filter=@repo/ui --filter=docs
 ```
 
 <LinkToDocumentation href="https://pnpm.io/cli/recursive">pnpm documentation</LinkToDocumentation>

--- a/docs/site/content/docs/getting-started/index.mdx
+++ b/docs/site/content/docs/getting-started/index.mdx
@@ -30,7 +30,7 @@ Install `turbo` globally so you can conveniently run `turbo` commands in your te
   </Tab>
   <Tab value="pnpm">
   ```bash title="Terminal"
-  pnpm install turbo --global
+  pnpm add turbo --global
   ```
 
   </Tab>

--- a/docs/site/content/docs/getting-started/installation.mdx
+++ b/docs/site/content/docs/getting-started/installation.mdx
@@ -59,7 +59,7 @@ A global install of `turbo` brings flexibility and speed to your local workflows
 
   <Tab value="pnpm">
   ```bash title="Terminal"
-  pnpm install turbo --global
+  pnpm add turbo --global
   ```
 
   </Tab>

--- a/docs/site/content/docs/guides/migrating-from-nx.mdx
+++ b/docs/site/content/docs/guides/migrating-from-nx.mdx
@@ -330,7 +330,7 @@ Add Turborepo to the root `package.json` of the workspace.
 <Tab value="pnpm">
 
 ```bash title="Terminal"
-pnpm install turbo --save-dev --workspace-root
+pnpm add turbo --save-dev --workspace-root
 ```
 
 </Tab>
@@ -368,7 +368,7 @@ You can also optionally install `turbo` globally for added convenience when work
 <Tab value="pnpm">
 
 ```bash title="Terminal"
-pnpm install turbo --global
+pnpm add turbo --global
 ```
 
 </Tab>

--- a/docs/site/content/docs/guides/single-package-workspaces.mdx
+++ b/docs/site/content/docs/guides/single-package-workspaces.mdx
@@ -23,7 +23,7 @@ Install `turbo` into your application:
 
   <Tab value="pnpm">
     ```bash title="Terminal"
-    pnpm install turbo --save-dev
+    pnpm add turbo --save-dev
     ```
 
   </Tab>

--- a/docs/site/content/docs/guides/tools/jest.mdx
+++ b/docs/site/content/docs/guides/tools/jest.mdx
@@ -36,7 +36,7 @@ Install `jest` into the packages where you plan on having test suites. For this 
 <Tab value="pnpm">
 
 ```bash title="Terminal"
-pnpm install jest --save-dev --filter=@repo/ui --filter=web
+pnpm add jest --save-dev --filter=@repo/ui --filter=web
 ```
 
 </Tab>

--- a/docs/site/content/docs/guides/tools/storybook.mdx
+++ b/docs/site/content/docs/guides/tools/storybook.mdx
@@ -164,7 +164,7 @@ Now, install your UI package into Storybook.
 <Tab value="pnpm">
 
 ```bash title="Terminal"
-pnpm install @repo/ui --filter=storybook
+pnpm add @repo/ui --filter=storybook
 ```
 
 </Tab>
@@ -330,7 +330,7 @@ You'll also need to install any Storybook packages required for writing stories.
 <Tab value="pnpm">
 
 ```bash title="Terminal"
-pnpm install @storybook/react --filter=@repo/ui --save-dev
+pnpm add @storybook/react --filter=@repo/ui --save-dev
 ```
 
 </Tab>

--- a/docs/site/content/docs/guides/tools/tailwind.mdx
+++ b/docs/site/content/docs/guides/tools/tailwind.mdx
@@ -272,7 +272,7 @@ Install the packages you've created into your application.
 <Tab value="pnpm">
 
 ```bash title="Terminal"
-pnpm install @repo/ui @repo/tailwind-config --save-dev --filter=@repo/ui --filter=web
+pnpm add @repo/ui @repo/tailwind-config --save-dev --filter=@repo/ui --filter=web
 ```
 
 </Tab>


### PR DESCRIPTION
It should be `pnpm add <pkg>` instead of `pnpm install <pkg>`.

`pnpm install` is used to install all dependencies for a project while `pnpm add <pkg>` is used to install a package and any packages that it depends on.

More info (official source):

- https://pnpm.io/cli/add
- https://pnpm.io/cli/install

---

`pnpm install <pkg>` does the same as `pnpm add <pkg>` today, but it might stop functioning that way in future versions since the official docs clarify the difference between the two. It might be that `pnpm install <pkg>` was used in past versions, and the PNPM team didn't want to remove support for it right away after introducing `pnpm add <pkg>`.