### PR TITLE
feat(turbo.json): allow for trailing commas

### DIFF
--- a/crates/turborepo-lib/src/turbo_json/parser.rs
+++ b/crates/turborepo-lib/src/turbo_json/parser.rs
@@ -295,7 +295,9 @@ impl RawTurboJson {
     pub fn parse(text: &str, file_path: &str) -> Result<RawTurboJson, Error> {
         let result = deserialize_from_json_str::<RawTurboJson>(
             text,
-            JsonParserOptions::default().with_allow_comments(),
+            JsonParserOptions::default()
+                .with_allow_comments()
+                .with_allow_trailing_commas(),
             file_path,
         );
 

--- a/turborepo-tests/integration/fixtures/turbo-configs/syntax-error.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/syntax-error.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turborepo.com/schema.json",,
+  "$schema": "https://turborepo.com/schema.json",
   "globalDependencies": ["foo.txt"],
   "globalEnv": ["SOME_ENV_VAR"],
   "tasks": {

--- a/turborepo-tests/integration/tests/bad-turbo-json.t
+++ b/turborepo-tests/integration/tests/bad-turbo-json.t
@@ -93,13 +93,6 @@ Run build with syntax errors in turbo.json
   turbo_json_parse_error
   
     x Failed to parse turbo.json.
-    |->   x Expected a property but instead found ','.
-    |      ,-[turbo.json:2:50]
-    |    1 | {
-    |    2 |   "$schema": "https://turborepo.com/schema.json",,
-    |      :                                                  ^
-    |    3 |   "globalDependencies": ["foo.txt"],
-    |      `----
     |->   x expected `,` but instead found `42`
     |       ,-[turbo.json:12:46]
     |    11 |     "my-app#build": {


### PR DESCRIPTION
### Description

Fixes #10499

### Testing Instructions


```
[0 olszewski@macbookpro] /tmp/trailing $ turbo build
turbo 2.5.4-canary.0

turbo_json_parse_error

  × Failed to parse turbo.json.
  ╰─▶   × Expected a property but instead found '}'.
          ╭─[turbo.json:9:5]
        8 │       "outputs": [".next/**", "!.next/cache/**"],
        9 │     },
          ·     ─
       10 │     "lint": {
          ╰────

[1 olszewski@macbookpro] /tmp/trailing $ turbo_dev --skip-infer build
turbo 2.5.4

• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web
• Running build in 5 packages
• Remote caching disabled
```