### PR TITLE
fix(docs): missing commas in package.json files of jest docs

### DIFF
--- a/docs/site/content/docs/guides/tools/jest.mdx
+++ b/docs/site/content/docs/guides/tools/jest.mdx
@@ -73,7 +73,7 @@ Both the `apps/web` and `packages/ui` have their own test suites, so we'll add a
 <Tab value="web">
 ```json title="./apps/web/package.json"
 {
-  "name": "web"
+  "name": "web",
   "scripts": {
     "test": "jest"
   },
@@ -86,7 +86,7 @@ Both the `apps/web` and `packages/ui` have their own test suites, so we'll add a
 <Tab value="@repo/ui">
 ```json title="./packages/ui/package.json"
 {
-  "name": "@repo/ui"
+  "name": "@repo/ui",
   "scripts": {
     "test": "jest"
   },
@@ -122,11 +122,11 @@ Because of this difference, we recommend specifying **two separate Turborepo tas
 <Tab value="web">
 ```json title="./apps/web/package.json"
 {
-  "name": "web"
+  "name": "web",
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch" // [!code highlight]
-  }
+  },
   "devDependencies": {
     "jest": "latest"
   }
@@ -136,7 +136,7 @@ Because of this difference, we recommend specifying **two separate Turborepo tas
 <Tab value="@repo/ui">
 ```json title="./packages/ui/package.json"
 {
-  "name": "@repo/ui"
+  "name": "@repo/ui",
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch" // [!code highlight]


### PR DESCRIPTION
### Description

Fixes #10542

Fixed this small issue which I found when I copy pasted the package.json examples from the Jest docs page. The missing commas caused JSON parsing errors when trying to use the files.
