### PR TITLE
fix(docs): incorrect CSS filename in Tailwind CSS setup example

### DIFF
--- a/docs/site/content/docs/guides/tools/tailwind.mdx
+++ b/docs/site/content/docs/guides/tools/tailwind.mdx
@@ -257,7 +257,7 @@ This `styles.css` contains component-level styles for the shared UI library.
   application to avoid style duplication issues.
 </Callout>
 
-```css title="./packages/ui/src/index.css"
+```css title="./packages/ui/src/styles.css"
 /* Component-level styles for the UI package */
 ```
 


### PR DESCRIPTION
### Description

In the example for configuring Tailwind CSS in the UI package, the CSS file was incorrectly named `index.css`.

