### PR TITLE
fix(example): add missing Tailwind import to shared ui styles

### DIFF
--- a/examples/with-tailwind/packages/ui/src/styles.css
+++ b/examples/with-tailwind/packages/ui/src/styles.css
@@ -1,1 +1,2 @@
 /* Component-level styles for the UI package */
+@import "tailwindcss";


### PR DESCRIPTION
This PR fixes [vercel/turborepo#10566](https://github.com/vercel/turborepo/issues/10566) by adding the missing Tailwind import to `shared-styles.css` in the `packages/ui` directory of the `with-tailwind` example.

### What was the problem?

Shared components like `Card` or `Button` had Tailwind classes, but styles were not applied because Tailwind layers were never included.


![Screenshot 2025-06-18 165631](https://github.com/user-attachments/assets/05b4e5bf-7785-4808-a1bb-8278c71e8c13)

### What changed?
Added:

```css
@import "tailwindcss";
```
to packages/ui/shared-styles.css.

### Result
![Screenshot 2025-06-18 165704](https://github.com/user-attachments/assets/b74bc738-5320-493a-b11f-e2487ed8e151)

Tested locally using:

```
pnpm install
pnpm dev --filter=with-tailwind
```
 UI components are now styled correctly.

Closes #10566


