### PR TITLE
feat(env): add Windows user profile variables to pass-through

### DIFF
--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -479,6 +479,9 @@ impl<'a> TaskHasher<'a> {
                     "PROGRAMDATA",
                     "SYSTEMROOT",
                     "SYSTEMDRIVE",
+                    "USERPROFILE",
+                    "HOMEDRIVE",
+                    "HOMEPATH",
                     "PNPM_HOME",
                     "NPM_CONFIG_STORE_DIR",
                 ];


### PR DESCRIPTION
Add USERPROFILE, HOMEDRIVE, and HOMEPATH to the built-in environment variables pass-through list to ensure proper path resolution in Windows environments.

### Description

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

Resolves #10587 

When running AWS SAM CLI from tasks, the following error occurs because profiles cannot be referenced:

```
Error: The config profile (default) could not be found
```

This happens because Python's `os.path` module references environment variables such as `USERPROFILE`, `HOMEDRIVE`, and `HOMEPATH` to obtain user paths in Windows environments, but these variables are not included in the default pass-through list, making them inaccessible within tasks.

https://github.com/python/cpython/blob/f4911258a80409cb641f13578137475204ab43b5/Lib/ntpath.py#L360-L366

Since these are standard Windows environment variables, I propose adding them to the default pass-through list.


### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
Add an AWS SAM project to a Turborepo child project, configure a script with the `--profile` option, and run it as a task.
