### PR TITLE
feat: opt into breaking changes and pre-stable features early with `turbo.json` configuration

### DIFF
--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -226,6 +226,16 @@ pub enum Error {
         text: NamedSource<String>,
     },
     #[error(
+        "The \"futureFlags\" key can only be used in the root turbo.json. Please remove it from \
+         Package Configurations."
+    )]
+    FutureFlagsInWorkspace {
+        #[label("futureFlags key found here")]
+        span: Option<SourceSpan>,
+        #[source_code]
+        text: NamedSource<String>,
+    },
+    #[error(
         "TURBO_TUI_SCROLLBACK_LENGTH: Invalid value. Use a number for how many lines to keep in \
          scrollback."
     )]

--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -229,7 +229,7 @@ pub enum Error {
         "The \"futureFlags\" key can only be used in the root turbo.json. Please remove it from \
          Package Configurations."
     )]
-    FutureFlagsInWorkspace {
+    FutureFlagsInPackage {
         #[label("futureFlags key found here")]
         span: Option<SourceSpan>,
         #[source_code]

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -562,7 +562,7 @@ impl TryFrom<RawTurboJson> for TurboJson {
             return Err(Error::PipelineField { span, text });
         }
 
-        // Check if futureFlags is used in a workspace config (which has extends field)
+        // `futureFlags` key is only allowed in root turbo.json
         let is_workspace_config = raw_turbo.extends.is_some();
         if is_workspace_config {
             if let Some(future_flags) = raw_turbo.future_flags {

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -567,7 +567,7 @@ impl TryFrom<RawTurboJson> for TurboJson {
         if is_workspace_config {
             if let Some(future_flags) = raw_turbo.future_flags {
                 let (span, text) = future_flags.span_and_text("turbo.json");
-                return Err(Error::FutureFlagsInWorkspace { span, text });
+                return Err(Error::FutureFlagsInPackage { span, text });
             }
         }
         let mut global_env = HashSet::new();

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -164,13 +164,17 @@ pub struct RawTurboJson {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub concurrency: Option<String>,
 
-    #[serde(skip_serializing_if = "Option::is_none", rename = "futureFlags")]
-    pub future_flags: Option<Spanned<serde_json::Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub future_flags: Option<Spanned<FutureFlags>>,
 
     #[deserializable(rename = "//")]
     #[serde(skip)]
     _comment: Option<String>,
 }
+
+#[derive(Serialize, Default, Debug, Clone, Iterable, Deserializable, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct FutureFlags {}
 
 #[derive(Serialize, Default, Debug, PartialEq, Clone)]
 #[serde(transparent)]
@@ -883,8 +887,8 @@ mod tests {
     use turborepo_unescape::UnescapedString;
 
     use super::{
-        replace_turbo_root_token_in_string, validate_with_has_no_topo, Pipeline, RawTurboJson,
-        SpacesJson, Spanned, TurboJson, UIMode,
+        replace_turbo_root_token_in_string, validate_with_has_no_topo, FutureFlags, Pipeline,
+        RawTurboJson, SpacesJson, Spanned, TurboJson, UIMode,
     };
     use crate::{
         boundaries::BoundariesConfig,
@@ -1408,8 +1412,7 @@ mod tests {
                 "build": {}
             },
             "futureFlags": {
-                "newFeature": true,
-                "experimentalOption": "value"
+                "bestFeature": true
             }
         }"#;
 
@@ -1423,11 +1426,7 @@ mod tests {
         // Verify that futureFlags is parsed correctly
         assert!(raw_turbo_json.future_flags.is_some());
         let future_flags = raw_turbo_json.future_flags.as_ref().unwrap();
-        assert_eq!(future_flags.as_inner()["newFeature"], json!(true));
-        assert_eq!(
-            future_flags.as_inner()["experimentalOption"],
-            json!("value")
-        );
+        assert_eq!(future_flags.as_inner(), &FutureFlags {});
 
         // Verify that the futureFlags field doesn't cause errors during conversion to
         // TurboJson

--- a/packages/turbo-types/schemas/schema.json
+++ b/packages/turbo-types/schemas/schema.json
@@ -102,12 +102,16 @@
           "type": "boolean",
           "description": "When set to `true`, disables the update notification that appears when a new version of `turbo` is available.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#noupdatenotifier",
           "default": false
+        },
+        "futureFlags": {
+          "type": "object",
+          "description": "Configuration for future flags that enable experimental or upcoming features.",
+          "additionalProperties": false,
+          "default": {}
         }
       },
       "additionalProperties": false,
-      "required": [
-        "tasks"
-      ]
+      "required": ["tasks"]
     },
     "Pipeline": {
       "type": "object",
@@ -200,13 +204,7 @@
     },
     "OutputLogs": {
       "type": "string",
-      "enum": [
-        "full",
-        "hash-only",
-        "new-only",
-        "errors-only",
-        "none"
-      ]
+      "enum": ["full", "hash-only", "new-only", "errors-only", "none"]
     },
     "RemoteCache": {
       "type": "object",
@@ -259,10 +257,7 @@
     },
     "UI": {
       "type": "string",
-      "enum": [
-        "tui",
-        "stream"
-      ]
+      "enum": ["tui", "stream"]
     },
     "RelativeUnixPath": {
       "type": "string",
@@ -270,10 +265,7 @@
     },
     "EnvMode": {
       "type": "string",
-      "enum": [
-        "strict",
-        "loose"
-      ]
+      "enum": ["strict", "loose"]
     },
     "RootBoundariesConfig": {
       "type": "object",
@@ -351,9 +343,7 @@
             "type": "string"
           },
           "description": "This key is only available in Workspace Configs and cannot be used in your root turbo.json.\n\nTells turbo to extend your root `turbo.json` and overrides with the keys provided in your Workspace Configs.\n\nCurrently, only the \"//\" value is allowed.",
-          "default": [
-            "//"
-          ]
+          "default": ["//"]
         },
         "tags": {
           "type": "array",
@@ -367,10 +357,7 @@
           "description": "Configuration for `turbo boundaries` that is specific to this package"
         }
       },
-      "required": [
-        "extends",
-        "tasks"
-      ],
+      "required": ["extends", "tasks"],
       "additionalProperties": false,
       "description": "A `turbo.json` file in a package in the monorepo (not the root)"
     },

--- a/packages/turbo-types/schemas/schema.json
+++ b/packages/turbo-types/schemas/schema.json
@@ -105,8 +105,8 @@
         },
         "futureFlags": {
           "type": "object",
+          "additionalProperties": {},
           "description": "Opt into breaking changes prior to major releases, experimental features, and beta features.",
-          "additionalProperties": false,
           "default": {}
         }
       },

--- a/packages/turbo-types/schemas/schema.json
+++ b/packages/turbo-types/schemas/schema.json
@@ -105,13 +105,15 @@
         },
         "futureFlags": {
           "type": "object",
-          "description": "Configuration for future flags that enable experimental or upcoming features.",
+          "description": "Opt into breaking changes prior to major releases, experimental features, and beta features.",
           "additionalProperties": false,
           "default": {}
         }
       },
       "additionalProperties": false,
-      "required": ["tasks"]
+      "required": [
+        "tasks"
+      ]
     },
     "Pipeline": {
       "type": "object",
@@ -204,7 +206,13 @@
     },
     "OutputLogs": {
       "type": "string",
-      "enum": ["full", "hash-only", "new-only", "errors-only", "none"]
+      "enum": [
+        "full",
+        "hash-only",
+        "new-only",
+        "errors-only",
+        "none"
+      ]
     },
     "RemoteCache": {
       "type": "object",
@@ -257,7 +265,10 @@
     },
     "UI": {
       "type": "string",
-      "enum": ["tui", "stream"]
+      "enum": [
+        "tui",
+        "stream"
+      ]
     },
     "RelativeUnixPath": {
       "type": "string",
@@ -265,7 +276,10 @@
     },
     "EnvMode": {
       "type": "string",
-      "enum": ["strict", "loose"]
+      "enum": [
+        "strict",
+        "loose"
+      ]
     },
     "RootBoundariesConfig": {
       "type": "object",
@@ -343,7 +357,9 @@
             "type": "string"
           },
           "description": "This key is only available in Workspace Configs and cannot be used in your root turbo.json.\n\nTells turbo to extend your root `turbo.json` and overrides with the keys provided in your Workspace Configs.\n\nCurrently, only the \"//\" value is allowed.",
-          "default": ["//"]
+          "default": [
+            "//"
+          ]
         },
         "tags": {
           "type": "array",
@@ -357,7 +373,10 @@
           "description": "Configuration for `turbo boundaries` that is specific to this package"
         }
       },
-      "required": ["extends", "tasks"],
+      "required": [
+        "extends",
+        "tasks"
+      ],
       "additionalProperties": false,
       "description": "A `turbo.json` file in a package in the monorepo (not the root)"
     },

--- a/packages/turbo-types/schemas/schema.v1.json
+++ b/packages/turbo-types/schemas/schema.v1.json
@@ -34,15 +34,10 @@
             "type": "string"
           },
           "description": "This key is only available in Workspace Configs and cannot be used in your root turbo.json.\n\nTells turbo to extend your root `turbo.json` and overrides with the keys provided in your Workspace Configs.\n\nCurrently, only the \"//\" value is allowed.",
-          "default": [
-            "//"
-          ]
+          "default": ["//"]
         }
       },
-      "required": [
-        "extends",
-        "pipeline"
-      ],
+      "required": ["extends", "pipeline"],
       "additionalProperties": false
     },
     "PipelineV1": {
@@ -141,13 +136,7 @@
     },
     "OutputModeV1": {
       "type": "string",
-      "enum": [
-        "full",
-        "hash-only",
-        "new-only",
-        "errors-only",
-        "none"
-      ]
+      "enum": ["full", "hash-only", "new-only", "errors-only", "none"]
     },
     "RootSchemaV1": {
       "type": "object",
@@ -223,9 +212,7 @@
         }
       },
       "additionalProperties": false,
-      "required": [
-        "pipeline"
-      ]
+      "required": ["pipeline"]
     },
     "RemoteCacheV1": {
       "type": "object",

--- a/packages/turbo-types/schemas/schema.v1.json
+++ b/packages/turbo-types/schemas/schema.v1.json
@@ -34,10 +34,15 @@
             "type": "string"
           },
           "description": "This key is only available in Workspace Configs and cannot be used in your root turbo.json.\n\nTells turbo to extend your root `turbo.json` and overrides with the keys provided in your Workspace Configs.\n\nCurrently, only the \"//\" value is allowed.",
-          "default": ["//"]
+          "default": [
+            "//"
+          ]
         }
       },
-      "required": ["extends", "pipeline"],
+      "required": [
+        "extends",
+        "pipeline"
+      ],
       "additionalProperties": false
     },
     "PipelineV1": {
@@ -136,7 +141,13 @@
     },
     "OutputModeV1": {
       "type": "string",
-      "enum": ["full", "hash-only", "new-only", "errors-only", "none"]
+      "enum": [
+        "full",
+        "hash-only",
+        "new-only",
+        "errors-only",
+        "none"
+      ]
     },
     "RootSchemaV1": {
       "type": "object",
@@ -212,7 +223,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["pipeline"]
+      "required": [
+        "pipeline"
+      ]
     },
     "RemoteCacheV1": {
       "type": "object",

--- a/packages/turbo-types/schemas/schema.v2.json
+++ b/packages/turbo-types/schemas/schema.v2.json
@@ -105,7 +105,7 @@
         },
         "futureFlags": {
           "type": "object",
-          "description": "Configuration for future flags that enable experimental or upcoming features.",
+          "description": "Opt into breaking changes prior to major releases, experimental features, and beta features.",
           "additionalProperties": false,
           "default": {}
         }

--- a/packages/turbo-types/schemas/schema.v2.json
+++ b/packages/turbo-types/schemas/schema.v2.json
@@ -111,7 +111,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["tasks"]
+      "required": [
+        "tasks"
+      ]
     },
     "Pipeline": {
       "type": "object",
@@ -204,7 +206,13 @@
     },
     "OutputLogs": {
       "type": "string",
-      "enum": ["full", "hash-only", "new-only", "errors-only", "none"]
+      "enum": [
+        "full",
+        "hash-only",
+        "new-only",
+        "errors-only",
+        "none"
+      ]
     },
     "RemoteCache": {
       "type": "object",
@@ -257,7 +265,10 @@
     },
     "UI": {
       "type": "string",
-      "enum": ["tui", "stream"]
+      "enum": [
+        "tui",
+        "stream"
+      ]
     },
     "RelativeUnixPath": {
       "type": "string",
@@ -265,7 +276,10 @@
     },
     "EnvMode": {
       "type": "string",
-      "enum": ["strict", "loose"]
+      "enum": [
+        "strict",
+        "loose"
+      ]
     },
     "RootBoundariesConfig": {
       "type": "object",
@@ -343,7 +357,9 @@
             "type": "string"
           },
           "description": "This key is only available in Workspace Configs and cannot be used in your root turbo.json.\n\nTells turbo to extend your root `turbo.json` and overrides with the keys provided in your Workspace Configs.\n\nCurrently, only the \"//\" value is allowed.",
-          "default": ["//"]
+          "default": [
+            "//"
+          ]
         },
         "tags": {
           "type": "array",
@@ -357,7 +373,10 @@
           "description": "Configuration for `turbo boundaries` that is specific to this package"
         }
       },
-      "required": ["extends", "tasks"],
+      "required": [
+        "extends",
+        "tasks"
+      ],
       "additionalProperties": false,
       "description": "A `turbo.json` file in a package in the monorepo (not the root)"
     },

--- a/packages/turbo-types/schemas/schema.v2.json
+++ b/packages/turbo-types/schemas/schema.v2.json
@@ -102,12 +102,16 @@
           "type": "boolean",
           "description": "When set to `true`, disables the update notification that appears when a new version of `turbo` is available.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#noupdatenotifier",
           "default": false
+        },
+        "futureFlags": {
+          "type": "object",
+          "description": "Configuration for future flags that enable experimental or upcoming features.",
+          "additionalProperties": false,
+          "default": {}
         }
       },
       "additionalProperties": false,
-      "required": [
-        "tasks"
-      ]
+      "required": ["tasks"]
     },
     "Pipeline": {
       "type": "object",
@@ -200,13 +204,7 @@
     },
     "OutputLogs": {
       "type": "string",
-      "enum": [
-        "full",
-        "hash-only",
-        "new-only",
-        "errors-only",
-        "none"
-      ]
+      "enum": ["full", "hash-only", "new-only", "errors-only", "none"]
     },
     "RemoteCache": {
       "type": "object",
@@ -259,10 +257,7 @@
     },
     "UI": {
       "type": "string",
-      "enum": [
-        "tui",
-        "stream"
-      ]
+      "enum": ["tui", "stream"]
     },
     "RelativeUnixPath": {
       "type": "string",
@@ -270,10 +265,7 @@
     },
     "EnvMode": {
       "type": "string",
-      "enum": [
-        "strict",
-        "loose"
-      ]
+      "enum": ["strict", "loose"]
     },
     "RootBoundariesConfig": {
       "type": "object",
@@ -351,9 +343,7 @@
             "type": "string"
           },
           "description": "This key is only available in Workspace Configs and cannot be used in your root turbo.json.\n\nTells turbo to extend your root `turbo.json` and overrides with the keys provided in your Workspace Configs.\n\nCurrently, only the \"//\" value is allowed.",
-          "default": [
-            "//"
-          ]
+          "default": ["//"]
         },
         "tags": {
           "type": "array",
@@ -367,10 +357,7 @@
           "description": "Configuration for `turbo boundaries` that is specific to this package"
         }
       },
-      "required": [
-        "extends",
-        "tasks"
-      ],
+      "required": ["extends", "tasks"],
       "additionalProperties": false,
       "description": "A `turbo.json` file in a package in the monorepo (not the root)"
     },

--- a/packages/turbo-types/schemas/schema.v2.json
+++ b/packages/turbo-types/schemas/schema.v2.json
@@ -105,8 +105,8 @@
         },
         "futureFlags": {
           "type": "object",
+          "additionalProperties": {},
           "description": "Opt into breaking changes prior to major releases, experimental features, and beta features.",
-          "additionalProperties": false,
           "default": {}
         }
       },

--- a/packages/turbo-types/src/types/config-v2.ts
+++ b/packages/turbo-types/src/types/config-v2.ts
@@ -190,6 +190,13 @@ export interface RootSchema extends BaseSchema {
    * @defaultValue `false`
    */
   noUpdateNotifier?: boolean;
+
+  /**
+   * Opt into breaking changes prior to major releases, experimental features, and beta features.
+   *
+   * @defaultValue `{}`
+   */
+  futureFlags?: Record<string, unknown>;
 }
 
 export interface Pipeline {


### PR DESCRIPTION
### Description

We want to smooth migration paths for users when we introduce functionality with breaking changes. This can be difficult with point-in-time majors that might force a user to make many breaking changes at once.

Instead, we can introduce the concept of "future flags" to allow you to opt into breaking changes early. As a user, you get to have more control over when you adopt breaking changes. As a core team, we get more freedom to iterate, resulting in faster feedback cycles with users.

This PR only introduces the flag to the parser, not adding any flags quite yet. This key is only allowed in root `turbo.json`s.

### Testing Instructions

Added some tests. I also tried it out manually (and trivially). It worked how I'd hoped.
