### PR TITLE
docs: correct typo in test file path

### DIFF
--- a/crates/turborepo-lib/src/run/scope/filter.rs
+++ b/crates/turborepo-lib/src/run/scope/filter.rs
@@ -1213,7 +1213,7 @@ mod test {
             TestChangeDetector::new(&[]),
         );
         let packages = resolver.get_filtered_packages(vec![TargetSelector {
-            parent_dir: Some(AnchoredSystemPathBuf::try_from("pakcages/*").unwrap()),
+            parent_dir: Some(AnchoredSystemPathBuf::try_from("packages/*").unwrap()),
             ..Default::default()
         }]);
 

--- a/packages/turbo-vsc/README.md
+++ b/packages/turbo-vsc/README.md
@@ -16,7 +16,7 @@ Every task in your pipeline can be followed to find its references.
 
 Get instant feedback if you write incorrect globs, refer to non-existent packages or tasks, and more.
 
-![A screenshot of a VSCode editor notifying of an invalid glob syntax.](resources/globs.png)
+![A screnshot of a VSCode editor notifying of an invalid glob syntax.](resources/globs.png)
 
 #### Contextual codemods
 

--- a/packages/turbo-vsc/README.md
+++ b/packages/turbo-vsc/README.md
@@ -16,7 +16,7 @@ Every task in your pipeline can be followed to find its references.
 
 Get instant feedback if you write incorrect globs, refer to non-existent packages or tasks, and more.
 
-![A screnshot of a VSCode editor notifying of an invalid glob syntax.](resources/globs.png)
+![A screenshot of a VSCode editor notifying of an invalid glob syntax.](resources/globs.png)
 
 #### Contextual codemods
 


### PR DESCRIPTION


### **Description:**

This pull request addresses a minor typo found in a test file.

**Changes:**

*   Corrected a path in `crates/turborepo-lib/src/run/scope/filter.rs` from `pakcages/*` to `packages/*`.
*   Includes a minor formatting update to `packages/turbo-vsc/README.md`.

This ensures the test setup points to the correct directory, preventing potential issues.
