### PR TITLE
fix(docs): inconsistent turbo command with the illustration

### DIFF
--- a/docs/site/content/docs/crafting-your-repository/configuring-tasks.mdx
+++ b/docs/site/content/docs/crafting-your-repository/configuring-tasks.mdx
@@ -34,7 +34,7 @@ For example, <code style={{textWrap: "wrap"}}>yarn workspaces run lint && yarn w
   }}
 />
 
-But, to get the same work done **faster** with Turborepo, you can use `turbo run lint test build`:
+But, to get the same work done **faster** with Turborepo, you can use `turbo run lint build test`:
 
 <ThemeAwareImage
   dark={{


### PR DESCRIPTION
### Description

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

Relate to https://github.com/vercel/turborepo/pull/10596, I'm sorry I find this after the PR merged.

The original doc link: https://turborepo.com/docs/crafting-your-repository/configuring-tasks

The command sequence is inconsistent with the illustration.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
