### PR TITLE
ci: ensure turbo-types schemas are in sync

### DIFF
--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -131,11 +131,8 @@ jobs:
         run: git config --global core.autocrlf input
       - uses: actions/checkout@v4
 
-      - name: Setup Turborepo Environment
-        uses: ./.github/actions/setup-turborepo-environment
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          node-version: "18.20.2" # TODO: Update integration tests with changed log output in Node.js 22
+      - name: "Setup Node"
+        uses: ./.github/actions/setup-node
 
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -131,8 +131,11 @@ jobs:
         run: git config --global core.autocrlf input
       - uses: actions/checkout@v4
 
-      - name: "Setup Node"
-        uses: ./.github/actions/setup-node
+      - name: Setup Turborepo Environment
+        uses: ./.github/actions/setup-turborepo-environment
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          node-version: "18.20.2" # TODO: Update integration tests with changed log output in Node.js 22
 
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo
@@ -231,10 +234,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Turborepo Environment
-        uses: ./.github/actions/setup-turborepo-environment
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: "Setup Node"
+        uses: ./.github/actions/setup-node
 
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -224,6 +224,34 @@ jobs:
         run: |
           cargo check --workspace
 
+  turbo_types_check:
+    name: Turborepo types codegen check
+    needs:
+      - find-changes
+    if: ${{ needs.find-changes.outputs.rest == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Turborepo Environment
+        uses: ./.github/actions/setup-turborepo-environment
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Build turbo-types schemas
+        run: |
+          turbo build --filter=@turbo/types
+
+      - name: Check for uncommitted changes
+        run: |
+          if ! git diff --exit-code; then
+            echo "::error::Generated schema files are out of sync with TypeScript types"
+            echo "::error::Please run 'turbo build --filter=@turbo/types' and commit the changes"
+            git diff
+            exit 1
+          fi
+
   rust_test:
     strategy:
       fail-fast: false
@@ -384,6 +412,7 @@ jobs:
       - integration
       - rust_lint
       - rust_check
+      - turbo_types_check
       - rust_test
       - basic-example
       - kitchen-sink-example
@@ -410,6 +439,7 @@ jobs:
           subjob ${{needs.integration.result}}
           subjob ${{needs.rust_lint.result}}
           subjob ${{needs.rust_check.result}}
+          subjob ${{needs.turbo_types_check.result}}
           subjob ${{needs.rust_test.result}}
           subjob ${{needs.basic-example.result}}
           subjob ${{needs.kitchen-sink-example.result}}

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -239,6 +239,9 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
+      - name: Install Global Turbo
+        uses: ./.github/actions/install-global-turbo
+
       - name: Build turbo-types schemas
         run: |
           turbo build --filter=@turbo/types

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -225,7 +225,7 @@ jobs:
           cargo check --workspace
 
   turbo_types_check:
-    name: Turborepo types codegen check
+    name: "@turbo/types codegen check"
     needs:
       - find-changes
     if: ${{ needs.find-changes.outputs.rest == 'true' }}

--- a/packages/turbo-types/schemas/schema.v2.json
+++ b/packages/turbo-types/schemas/schema.v2.json
@@ -44,7 +44,6 @@
           "description": "A list of environment variables for implicit global hash dependencies.\n\nThe variables included in this list will affect all task hashes.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#globalenv",
           "default": []
         },
-        "test": "test",
         "globalPassThroughEnv": {
           "anyOf": [
             {
@@ -106,7 +105,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["tasks"]
+      "required": [
+        "tasks"
+      ]
     },
     "Pipeline": {
       "type": "object",
@@ -199,7 +200,13 @@
     },
     "OutputLogs": {
       "type": "string",
-      "enum": ["full", "hash-only", "new-only", "errors-only", "none"]
+      "enum": [
+        "full",
+        "hash-only",
+        "new-only",
+        "errors-only",
+        "none"
+      ]
     },
     "RemoteCache": {
       "type": "object",
@@ -252,7 +259,10 @@
     },
     "UI": {
       "type": "string",
-      "enum": ["tui", "stream"]
+      "enum": [
+        "tui",
+        "stream"
+      ]
     },
     "RelativeUnixPath": {
       "type": "string",
@@ -260,7 +270,10 @@
     },
     "EnvMode": {
       "type": "string",
-      "enum": ["strict", "loose"]
+      "enum": [
+        "strict",
+        "loose"
+      ]
     },
     "RootBoundariesConfig": {
       "type": "object",
@@ -338,7 +351,9 @@
             "type": "string"
           },
           "description": "This key is only available in Workspace Configs and cannot be used in your root turbo.json.\n\nTells turbo to extend your root `turbo.json` and overrides with the keys provided in your Workspace Configs.\n\nCurrently, only the \"//\" value is allowed.",
-          "default": ["//"]
+          "default": [
+            "//"
+          ]
         },
         "tags": {
           "type": "array",
@@ -352,7 +367,10 @@
           "description": "Configuration for `turbo boundaries` that is specific to this package"
         }
       },
-      "required": ["extends", "tasks"],
+      "required": [
+        "extends",
+        "tasks"
+      ],
       "additionalProperties": false,
       "description": "A `turbo.json` file in a package in the monorepo (not the root)"
     },
@@ -371,4 +389,3 @@
     }
   }
 }
-

--- a/packages/turbo-types/schemas/schema.v2.json
+++ b/packages/turbo-types/schemas/schema.v2.json
@@ -44,6 +44,7 @@
           "description": "A list of environment variables for implicit global hash dependencies.\n\nThe variables included in this list will affect all task hashes.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#globalenv",
           "default": []
         },
+        "test": "test",
         "globalPassThroughEnv": {
           "anyOf": [
             {
@@ -105,9 +106,7 @@
         }
       },
       "additionalProperties": false,
-      "required": [
-        "tasks"
-      ]
+      "required": ["tasks"]
     },
     "Pipeline": {
       "type": "object",
@@ -200,13 +199,7 @@
     },
     "OutputLogs": {
       "type": "string",
-      "enum": [
-        "full",
-        "hash-only",
-        "new-only",
-        "errors-only",
-        "none"
-      ]
+      "enum": ["full", "hash-only", "new-only", "errors-only", "none"]
     },
     "RemoteCache": {
       "type": "object",
@@ -259,10 +252,7 @@
     },
     "UI": {
       "type": "string",
-      "enum": [
-        "tui",
-        "stream"
-      ]
+      "enum": ["tui", "stream"]
     },
     "RelativeUnixPath": {
       "type": "string",
@@ -270,10 +260,7 @@
     },
     "EnvMode": {
       "type": "string",
-      "enum": [
-        "strict",
-        "loose"
-      ]
+      "enum": ["strict", "loose"]
     },
     "RootBoundariesConfig": {
       "type": "object",
@@ -351,9 +338,7 @@
             "type": "string"
           },
           "description": "This key is only available in Workspace Configs and cannot be used in your root turbo.json.\n\nTells turbo to extend your root `turbo.json` and overrides with the keys provided in your Workspace Configs.\n\nCurrently, only the \"//\" value is allowed.",
-          "default": [
-            "//"
-          ]
+          "default": ["//"]
         },
         "tags": {
           "type": "array",
@@ -367,10 +352,7 @@
           "description": "Configuration for `turbo boundaries` that is specific to this package"
         }
       },
-      "required": [
-        "extends",
-        "tasks"
-      ],
+      "required": ["extends", "tasks"],
       "additionalProperties": false,
       "description": "A `turbo.json` file in a package in the monorepo (not the root)"
     },
@@ -389,3 +371,4 @@
     }
   }
 }
+


### PR DESCRIPTION
### Description

In https://github.com/vercel/turborepo/pull/10590, I edited the JSON schema directly, which [isn't the right way](https://github.com/vercel/turborepo/pull/10590#discussion_r2171962005).

This PR introduces a CI check that I (and others) can't make this sort of mistake in the future.

### Testing Instructions

[This commit](https://github.com/vercel/turborepo/pull/10609/commits/3108ad0c57bfbeccfb60b87e7115b3398444e1de) shows a failure because I added a `test` key to the schema (and malformatted it in the process).