### PR TITLE
fix: validation for root turbo.json vs. Package Configurations

### DIFF
--- a/crates/turborepo-lib/src/config/turbo_json.rs
+++ b/crates/turborepo-lib/src/config/turbo_json.rs
@@ -17,7 +17,7 @@ impl<'a> TurboJsonReader<'a> {
         turbo_json: RawTurboJson,
     ) -> Result<ConfigurationOptions, Error> {
         let mut opts = if let Some(remote_cache_options) = &turbo_json.remote_cache {
-            remote_cache_options.into()
+            remote_cache_options.as_inner().into()
         } else {
             ConfigurationOptions::default()
         };
@@ -38,12 +38,16 @@ impl<'a> TurboJsonReader<'a> {
 
         // Don't allow token to be set for shared config.
         opts.token = None;
-        opts.ui = turbo_json.ui;
-        opts.allow_no_package_manager = turbo_json.allow_no_package_manager;
+        opts.ui = turbo_json.ui.map(|ui| *ui.as_inner());
+        opts.allow_no_package_manager = turbo_json
+            .allow_no_package_manager
+            .map(|allow| *allow.as_inner());
         opts.daemon = turbo_json.daemon.map(|daemon| *daemon.as_inner());
-        opts.env_mode = turbo_json.env_mode;
+        opts.env_mode = turbo_json.env_mode.map(|env_mode| *env_mode.as_inner());
         opts.cache_dir = cache_dir;
-        opts.concurrency = turbo_json.concurrency;
+        opts.concurrency = turbo_json
+            .concurrency
+            .map(|concurrency| concurrency.into_inner());
         Ok(opts)
     }
 }

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -1459,4 +1459,57 @@ mod tests {
             "`with` cannot use dependency relationships."
         );
     }
+
+    #[test]
+    fn test_field_placement_validation_via_parser() {
+        // Test root-only field in package config
+        let json = r#"{
+            "extends": ["//"],
+            "globalEnv": ["NODE_ENV"],
+            "tasks": {
+                "build": {}
+            }
+        }"#;
+
+        let result = RawTurboJson::parse(json, "turbo.json");
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert!(error.to_string().contains("Failed to parse turbo.json"));
+
+        // Test package-only field in root config
+        let json = r#"{
+            "tags": ["utility"],
+            "tasks": {
+                "build": {}
+            }
+        }"#;
+
+        let result = RawTurboJson::parse(json, "turbo.json");
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert!(error.to_string().contains("Failed to parse turbo.json"));
+
+        // Test valid root config
+        let json = r#"{
+            "globalEnv": ["NODE_ENV"],
+            "tasks": {
+                "build": {}
+            }
+        }"#;
+
+        let result = RawTurboJson::parse(json, "turbo.json");
+        assert!(result.is_ok());
+
+        // Test valid package config
+        let json = r#"{
+            "extends": ["//"],
+            "tags": ["my-tag"],
+            "tasks": {
+                "build": {}
+            }
+        }"#;
+
+        let result = RawTurboJson::parse(json, "turbo.json");
+        assert!(result.is_ok());
+    }
 }

--- a/crates/turborepo-lib/src/turbo_json/parser.rs
+++ b/crates/turborepo-lib/src/turbo_json/parser.rs
@@ -428,33 +428,53 @@ impl RawTurboJson {
                 self.future_flags.as_ref().map(|f| f.range.clone()),
             ),
             ("pipeline", self.pipeline.as_ref().map(|f| f.range.clone())),
-            // TODO: These fields should be `Option<Spanned<Vec<T>>>` instead of
-            // `Option<Vec<Spanned<T>>>` for consistency with other fields. This would
-            // allow proper span information for the field itself. This is a breaking
-            // change that needs to be coordinated with the struct definition in mod.rs
             (
                 "globalDependencies",
-                if self.global_dependencies.is_some() {
-                    Some(None)
-                } else {
-                    None
-                },
+                self.global_dependencies.as_ref().and_then(|deps| {
+                    if deps.is_empty() {
+                        None // Skip validation for empty arrays
+                    } else {
+                        // Try to create a range from first to last element
+                        let first_range = deps.first().and_then(|elem| elem.range.as_ref());
+                        let last_range = deps.last().and_then(|elem| elem.range.as_ref());
+                        match (first_range, last_range) {
+                            (Some(first), Some(last)) => Some(Some(first.start..last.end)),
+                            _ => Some(None), // Present but no complete span info
+                        }
+                    }
+                }),
             ),
             (
                 "globalEnv",
-                if self.global_env.is_some() {
-                    Some(None)
-                } else {
-                    None
-                },
+                self.global_env.as_ref().and_then(|env| {
+                    if env.is_empty() {
+                        None // Skip validation for empty arrays
+                    } else {
+                        // Try to create a range from first to last element
+                        let first_range = env.first().and_then(|elem| elem.range.as_ref());
+                        let last_range = env.last().and_then(|elem| elem.range.as_ref());
+                        match (first_range, last_range) {
+                            (Some(first), Some(last)) => Some(Some(first.start..last.end)),
+                            _ => Some(None), // Present but no complete span info
+                        }
+                    }
+                }),
             ),
             (
                 "globalPassThroughEnv",
-                if self.global_pass_through_env.is_some() {
-                    Some(None)
-                } else {
-                    None
-                },
+                self.global_pass_through_env.as_ref().and_then(|env| {
+                    if env.is_empty() {
+                        None // Skip validation for empty arrays
+                    } else {
+                        // Try to create a range from first to last element
+                        let first_range = env.first().and_then(|elem| elem.range.as_ref());
+                        let last_range = env.last().and_then(|elem| elem.range.as_ref());
+                        match (first_range, last_range) {
+                            (Some(first), Some(last)) => Some(Some(first.start..last.end)),
+                            _ => Some(None), // Present but no complete span info
+                        }
+                    }
+                }),
             ),
         ];
 


### PR DESCRIPTION
### Description

We weren't checking fields that are root `turbo.json`-only aren't being used in Package Configurations - and vice versa. I did a check of this nature in https://github.com/vercel/turborepo/pull/10590 and have refactored that to a function that we can now use for other fields. Additionally, I've brought that idea along to the reverse situation.

### Testing Instructions

Added some tests ensuring the desired logic is what happens.
