### PR TITLE
refactor(examples): remove duplicate Next.js plugin from app tsconfig files

### DIFF
--- a/examples/with-nestjs/apps/web/tsconfig.json
+++ b/examples/with-nestjs/apps/web/tsconfig.json
@@ -1,12 +1,5 @@
 {
   "extends": "@repo/typescript-config/nextjs.json",
-  "compilerOptions": {
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ]
-  },
   "include": [
     "next-env.d.ts",
     "next.config.js",


### PR DESCRIPTION
### Description

Removes duplicate Next.js TypeScript plugin configuration from `examples/with-nestjs/apps/web/tsconfig.json`.

The `"next"` plugin was configured in two places:
- ✅ `packages/typescript-config/nextjs.json` (shared config)
- ❌ `apps/web/tsconfig.json` (duplicate)

Since the app already extends the shared config, the duplicate plugin definition is unnecessary.

**File:** `examples/with-nestjs/apps/web/tsconfig.json`

**Removed:**
```json
"compilerOptions": {
  "plugins": [
    {
      "name": "next"
    }
  ]
}
```

The plugin is already inherited from `@repo/typescript-config/nextjs.json`.
