### PR TITLE
Consolidate configuration file checks

### DIFF
--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -146,26 +146,7 @@ impl CommandBase {
         self.repo_root.join_component("package.json")
     }
     fn root_turbo_json_path(&self) -> Result<AbsoluteSystemPathBuf, ConfigError> {
-        let turbo_json_path = self.repo_root.join_component(CONFIG_FILE);
-        let turbo_jsonc_path = self.repo_root.join_component(CONFIG_FILE_JSONC);
-
-        let turbo_json_exists = turbo_json_path.exists();
-        let turbo_jsonc_exists = turbo_jsonc_path.exists();
-
-        if turbo_json_exists && turbo_jsonc_exists {
-            return Err(ConfigError::MultipleTurboConfigs {
-                directory: self.repo_root.to_string(),
-            });
-        }
-
-        if turbo_json_exists {
-            Ok(turbo_json_path)
-        } else if turbo_jsonc_exists {
-            Ok(turbo_jsonc_path)
-        } else {
-            Ok(turbo_json_path) // Default to turbo.json path even if it doesn't
-                                // exist
-        }
+        crate::turbo_json::resolve_turbo_config_path(&self.repo_root)
     }
 
     pub fn api_auth(&self) -> Result<Option<APIAuth>, ConfigError> {

--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -454,21 +454,7 @@ impl ConfigurationOptions {
             return Ok(path.clone());
         }
 
-        // Check if both files exist
-        let turbo_json_path = repo_root.join_component(CONFIG_FILE);
-        let turbo_jsonc_path = repo_root.join_component(CONFIG_FILE_JSONC);
-        let turbo_json_exists = turbo_json_path.try_exists()?;
-        let turbo_jsonc_exists = turbo_jsonc_path.try_exists()?;
-
-        match (turbo_json_exists, turbo_jsonc_exists) {
-            (true, true) => Err(Error::MultipleTurboConfigs {
-                directory: repo_root.to_string(),
-            }),
-            (true, false) => Ok(turbo_json_path),
-            (false, true) => Ok(turbo_jsonc_path),
-            // Default to turbo.json if neither exists
-            (false, false) => Ok(turbo_json_path),
-        }
+        crate::turbo_json::resolve_turbo_config_path(repo_root)
     }
 
     pub fn allow_no_turbo_json(&self) -> bool {

--- a/packages/turbo-utils/src/getTurboConfigs.ts
+++ b/packages/turbo-utils/src/getTurboConfigs.ts
@@ -17,6 +17,38 @@ import type { PackageJson, PNPMWorkspaceConfig } from "./types";
 const ROOT_GLOB = "{turbo.json,turbo.jsonc}";
 const ROOT_WORKSPACE_GLOB = "package.json";
 
+/**
+ * Given a directory path, determines which turbo config file to use.
+ * Throws an error if both turbo.json and turbo.jsonc exist in the same directory.
+ * Returns the path to the config file to use, or null if neither exists.
+ */
+function resolveTurboConfigPath(dirPath: string): {
+  configPath: string | null;
+  configExists: boolean;
+} {
+  const turboJsonPath = path.join(dirPath, "turbo.json");
+  const turboJsoncPath = path.join(dirPath, "turbo.jsonc");
+
+  const turboJsonExists = fs.existsSync(turboJsonPath);
+  const turboJsoncExists = fs.existsSync(turboJsoncPath);
+
+  if (turboJsonExists && turboJsoncExists) {
+    const errorMessage = `Found both turbo.json and turbo.jsonc in the same directory: ${dirPath}\nPlease use either turbo.json or turbo.jsonc, but not both.`;
+    logger.error(errorMessage);
+    throw new Error(errorMessage);
+  }
+
+  if (turboJsonExists) {
+    return { configPath: turboJsonPath, configExists: true };
+  }
+
+  if (turboJsoncExists) {
+    return { configPath: turboJsoncPath, configExists: true };
+  }
+
+  return { configPath: null, configExists: false };
+}
+
 export interface WorkspaceConfig {
   workspaceName: string;
   workspacePath: string;
@@ -189,27 +221,14 @@ export function getWorkspaceConfigs(
         const isWorkspaceRoot = workspacePath === turboRoot;
 
         // Try and get turbo.json or turbo.jsonc
-        const turboJsonPath = path.join(workspacePath, "turbo.json");
-        const turboJsoncPath = path.join(workspacePath, "turbo.jsonc");
-
-        // Check if both files exist
-        const turboJsonExists = fs.existsSync(turboJsonPath);
-        const turboJsoncExists = fs.existsSync(turboJsoncPath);
-
-        if (turboJsonExists && turboJsoncExists) {
-          const errorMessage = `Found both turbo.json and turbo.jsonc in the same directory: ${workspacePath}\nPlease use either turbo.json or turbo.jsonc, but not both.`;
-          logger.error(errorMessage);
-          throw new Error(errorMessage);
-        }
+        const { configPath: turboConfigPath, configExists } = resolveTurboConfigPath(workspacePath);
 
         let rawTurboJson = null;
         let turboConfig: SchemaV1 | undefined;
 
         try {
-          if (turboJsonExists) {
-            rawTurboJson = fs.readFileSync(turboJsonPath, "utf8");
-          } else if (turboJsoncExists) {
-            rawTurboJson = fs.readFileSync(turboJsoncPath, "utf8");
+          if (configExists && turboConfigPath) {
+            rawTurboJson = fs.readFileSync(turboConfigPath, "utf8");
           }
 
           if (rawTurboJson) {


### PR DESCRIPTION
### Description

This PR refactors the codebase to deduplicate the logic for resolving `turbo.json` and `turbo.jsonc` configuration files.

-   Introduced `resolve_turbo_config_path` in Rust (`crates/turborepo-lib/src/turbo_json/mod.rs`) and `resolveTurboConfigPath` in TypeScript (`packages/turbo-utils/src/getTurboConfigs.ts`).
-   Replaced duplicated file existence checks and conflict resolution with calls to these new utility functions.
-   Ensures that the behavior for handling `turbo.json` and `turbo.jsonc` (precedence, error on both existing) remains unchanged.

### Testing Instructions

-   The refactor is purely internal, and existing tests cover the behavior.
-   Run `cargo test` in the Rust workspace.
-   Run `pnpm check-types` in the root to verify TypeScript changes.