### PR TITLE
refactor(examples): remove duplicate Next.js plugin in examples

### DIFF
--- a/examples/basic/apps/docs/tsconfig.json
+++ b/examples/basic/apps/docs/tsconfig.json
@@ -1,12 +1,5 @@
 {
   "extends": "@repo/typescript-config/nextjs.json",
-  "compilerOptions": {
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ]
-  },
   "include": [
     "**/*.ts",
     "**/*.tsx",

--- a/examples/basic/apps/web/tsconfig.json
+++ b/examples/basic/apps/web/tsconfig.json
@@ -1,12 +1,5 @@
 {
   "extends": "@repo/typescript-config/nextjs.json",
-  "compilerOptions": {
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ]
-  },
   "include": [
     "**/*.ts",
     "**/*.tsx",

--- a/examples/kitchen-sink/apps/storefront/tsconfig.json
+++ b/examples/kitchen-sink/apps/storefront/tsconfig.json
@@ -3,11 +3,6 @@
   "extends": "@repo/typescript-config/nextjs.json",
   "compilerOptions": {
     "outDir": "dist",
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ]
   },
   "include": ["src", "next.config.ts", "next-env.d.ts", ".next/types/**/*.ts"]
 }

--- a/examples/with-berry/apps/docs/tsconfig.json
+++ b/examples/with-berry/apps/docs/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "@repo/typescript-config/nextjs.json",
-  "compilerOptions": {
-    "plugins": [{ "name": "next" }]
-  },
   "include": [
     "next-env.d.ts",
     "next.config.js",

--- a/examples/with-berry/apps/web/tsconfig.json
+++ b/examples/with-berry/apps/web/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "@repo/typescript-config/nextjs.json",
-  "compilerOptions": {
-    "plugins": [{ "name": "next" }]
-  },
   "include": [
     "next-env.d.ts",
     "next.config.js",

--- a/examples/with-docker/apps/web/tsconfig.json
+++ b/examples/with-docker/apps/web/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "@repo/typescript-config/nextjs.json",
-  "compilerOptions": {
-    "plugins": [{ "name": "next" }]
-  },
   "include": ["next-env.d.ts", "next.config.js", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/examples/with-npm/apps/docs/tsconfig.json
+++ b/examples/with-npm/apps/docs/tsconfig.json
@@ -1,12 +1,5 @@
 {
   "extends": "@repo/typescript-config/nextjs.json",
-  "compilerOptions": {
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ]
-  },
   "include": [
     "next-env.d.ts",
     "next.config.js",

--- a/examples/with-npm/apps/web/tsconfig.json
+++ b/examples/with-npm/apps/web/tsconfig.json
@@ -1,12 +1,5 @@
 {
   "extends": "@repo/typescript-config/nextjs.json",
-  "compilerOptions": {
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ]
-  },
   "include": [
     "next-env.d.ts",
     "next.config.js",

--- a/examples/with-prisma/apps/web/tsconfig.json
+++ b/examples/with-prisma/apps/web/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "extends": "@repo/typescript-config/nextjs.json",
-  "compilerOptions": { "plugins": [{ "name": "next" }] },
   "include": [
     "next-env.d.ts",
     "next.config.js",

--- a/examples/with-react-native-web/apps/web/tsconfig.json
+++ b/examples/with-react-native-web/apps/web/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "@repo/typescript-config/nextjs.json",
-  "compilerOptions": {
-    "plugins": [{ "name": "next" }]
-  },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/examples/with-rollup/apps/web/tsconfig.json
+++ b/examples/with-rollup/apps/web/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "@repo/typescript-config/nextjs.json",
-  "compilerOptions": {
-    "plugins": [{ "name": "next" }]
-  },
   "include": [
     "next-env.d.ts",
     "**/*.ts",

--- a/examples/with-tailwind/apps/docs/tsconfig.json
+++ b/examples/with-tailwind/apps/docs/tsconfig.json
@@ -1,12 +1,5 @@
 {
   "extends": "@repo/typescript-config/nextjs.json",
-  "compilerOptions": {
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ]
-  },
   "include": [
     "**/*.ts",
     "**/*.tsx",

--- a/examples/with-tailwind/apps/web/tsconfig.json
+++ b/examples/with-tailwind/apps/web/tsconfig.json
@@ -1,12 +1,5 @@
 {
   "extends": "@repo/typescript-config/nextjs.json",
-  "compilerOptions": {
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ]
-  },
   "include": [
     "**/*.ts",
     "**/*.tsx",

--- a/examples/with-typeorm/apps/docs/tsconfig.json
+++ b/examples/with-typeorm/apps/docs/tsconfig.json
@@ -1,12 +1,5 @@
 {
   "extends": "@repo/typescript-config/nextjs.json",
-  "compilerOptions": {
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ]
-  },
   "include": [
     "next-env.d.ts",
     "next.config.js",

--- a/examples/with-typeorm/apps/web/tsconfig.json
+++ b/examples/with-typeorm/apps/web/tsconfig.json
@@ -1,12 +1,5 @@
 {
   "extends": "@repo/typescript-config/nextjs.json",
-  "compilerOptions": {
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ]
-  },
   "include": [
     "next-env.d.ts",
     "next.config.js",

--- a/examples/with-vitest/apps/docs/tsconfig.json
+++ b/examples/with-vitest/apps/docs/tsconfig.json
@@ -1,12 +1,5 @@
 {
   "extends": "@repo/typescript-config/nextjs.json",
-  "compilerOptions": {
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ]
-  },
   "include": [
     "**/*.ts",
     "**/*.tsx",

--- a/examples/with-vitest/apps/web/tsconfig.json
+++ b/examples/with-vitest/apps/web/tsconfig.json
@@ -1,12 +1,5 @@
 {
   "extends": "@repo/typescript-config/nextjs.json",
-  "compilerOptions": {
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ]
-  },
   "include": [
     "**/*.ts",
     "**/*.tsx",

--- a/examples/with-yarn/apps/docs/tsconfig.json
+++ b/examples/with-yarn/apps/docs/tsconfig.json
@@ -1,12 +1,5 @@
 {
   "extends": "@repo/typescript-config/nextjs.json",
-  "compilerOptions": {
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ]
-  },
   "include": [
     "next-env.d.ts",
     "next.config.js",

--- a/examples/with-yarn/apps/web/tsconfig.json
+++ b/examples/with-yarn/apps/web/tsconfig.json
@@ -1,12 +1,5 @@
 {
   "extends": "@repo/typescript-config/nextjs.json",
-  "compilerOptions": {
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ]
-  },
   "include": [
     "next-env.d.ts",
     "next.config.js",


### PR DESCRIPTION
### Description

Removes duplicate Next.js TypeScript plugin configuration from `examples/.../apps/web/tsconfig.json`.

The `"next"` plugin was configured in two places:
- ✅ `packages/typescript-config/nextjs.json` (shared config)
- ❌ `apps/web/tsconfig.json` (duplicate)

Since the app already extends the shared config, the duplicate plugin definition is unnecessary.

**File:** `examples/.../apps/web/tsconfig.json`

**Removed:**
```json
"compilerOptions": {
  "plugins": [
    {
      "name": "next"
    }
  ]
}
```

The plugin is already inherited from `@repo/typescript-config/nextjs.json`.