### PR TITLE
Fix documentation as per GitHub issue

### DIFF
--- a/docs/site/content/docs/guides/tools/vitest.mdx
+++ b/docs/site/content/docs/guides/tools/vitest.mdx
@@ -10,12 +10,16 @@ import { Tab, Tabs } from '#components/tabs';
 
 [Vitest](https://vitest.dev/) is a test runner from the Vite ecosystem. Integrating it with Turborepo will lead to enormous speed-ups.
 
-[The Vitest documentation](https://vitest.dev/guide/workspace) shows how to create a "Vitest Workspace" that runs all tests in the monorepo from one root command, enabling behavior like merged coverage reports out-of-the-box. This feature doesn't follow modern best practices for monorepos, since its designed for compatibility with Jest (whose Workspace feature was built before [package manager Workspaces](/docs/crafting-your-repository/structuring-a-repository)).
+[The Vitest documentation](https://vitest.dev/guide/workspace) shows how to create a "Vitest Projects" configuration that runs all tests in the monorepo from one root command, enabling behavior like merged coverage reports out-of-the-box. This feature doesn't follow modern best practices for monorepos, since its designed for compatibility with Jest (whose Workspace feature was built before [package manager Workspaces](/docs/crafting-your-repository/structuring-a-repository)).
+
+<Callout type="warning">
+  Vitest has deprecated workspaces in favor of projects. When using projects, individual project vitest configs can't extend the root config anymore since they would inherit the projects configuration. Instead, a separate shared file like `vitest.shared.ts` is needed.
+</Callout>
 
 Because of this you have two options, each with their own tradeoffs:
 
 - [Leveraging Turborepo for caching](#leveraging-turborepo-for-caching)
-- [Using Vitest's Workspace feature](#using-vitests-workspace-feature)
+- [Using Vitest's Projects feature](#using-vitests-projects-feature)
 
 ### Leveraging Turborepo for caching
 
@@ -143,7 +147,7 @@ turbo run test:watch
 
 #### Creating merged coverage reports
 
-[Vitest's Workspace feature](#using-vitests-workspace-feature) creates an out-of-the-box coverage report that merges all of your packages' tests coverage reports. Following the Turborepo strategy, though, you'll have to merge the coverage reports yourself.
+[Vitest's Projects feature](#using-vitests-projects-feature) creates an out-of-the-box coverage report that merges all of your packages' tests coverage reports. Following the Turborepo strategy, though, you'll have to merge the coverage reports yourself.
 
 <Callout type="info">
   The [`with-vitest`
@@ -189,13 +193,13 @@ With this in place, run `turbo test && turbo report` to create a merged coverage
   started with it quickly using `npx create-turbo@latest --example with-vitest`.
 </Callout>
 
-### Using Vitest's Workspace feature
+### Using Vitest's Projects feature
 
-The Vitest Workspace feature doesn't follow the same model as a [package manager Workspace](/docs/crafting-your-repository/structuring-a-repository). Instead, it uses a root script that then reaches out into each package in the repository to handle the tests in that respective package.
+The Vitest Projects feature doesn't follow the same model as a [package manager Workspace](/docs/crafting-your-repository/structuring-a-repository). Instead, it uses a root script that then reaches out into each package in the repository to handle the tests in that respective package.
 
 In this model, there aren't package boundaries, from a modern JavaScript ecosystem perspective. This means you can't rely on Turborepo's caching, since Turborepo leans on those package boundaries.
 
-Because of this, you'll need to use [Root Tasks](/docs/crafting-your-repository/configuring-tasks#registering-root-tasks) if you want to run the tests using Turborepo. Once you've configured [a Vitest Workspace](https://vitest.dev/guide/workspace), create the Root Tasks for Turborepo:
+Because of this, you'll need to use [Root Tasks](/docs/crafting-your-repository/configuring-tasks#registering-root-tasks) if you want to run the tests using Turborepo. Once you've configured [a Vitest Projects setup](https://vitest.dev/guide/workspace), create the Root Tasks for Turborepo:
 
 ```json title="./turbo.json"
 {
@@ -215,15 +219,58 @@ Because of this, you'll need to use [Root Tasks](/docs/crafting-your-repository/
 
 ### Using a hybrid approach
 
-You can combine the benefits of both approaches by implementing a hybrid solution.This approach unifies local development using Vitest's Workspace approach while preserving Turborepo's caching in CI. This comes at the tradeoff of slightly more configuration and a mixed task running model in the repository.
+You can combine the benefits of both approaches by implementing a hybrid solution. This approach unifies local development using Vitest's Projects feature while preserving Turborepo's caching in CI. This comes at the tradeoff of slightly more configuration and a mixed task running model in the repository.
 
-```ts title="./vitest.workspace.ts"
-import { defineWorkspace } from 'vitest/config';
+First, create a shared configuration file since individual projects can't extend the root config when using projects:
 
-export default defineWorkspace(['packages/*']);
+```ts title="./vitest.shared.ts"
+export const sharedConfig = {
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.ts'],
+    // Other shared configuration
+  }
+};
 ```
 
-In this setup, your packages maintain their individual Vitest configurations and scripts:
+Then, create your root Vitest configuration using projects:
+
+```ts title="./vitest.config.ts"
+import { defineConfig } from 'vitest/config';
+import { sharedConfig } from './vitest.shared';
+
+export default defineConfig({
+  ...sharedConfig,
+  projects: [
+    {
+      name: 'packages',
+      root: './packages/*',
+      test: {
+        ...sharedConfig.test,
+        // Project-specific configuration
+      }
+    }
+  ]
+});
+```
+
+In this setup, your packages maintain their individual Vitest configurations that import the shared config:
+
+```ts title="./packages/ui/vitest.config.ts"
+import { defineConfig } from 'vitest/config';
+import { sharedConfig } from '../../vitest.shared';
+
+export default defineConfig({
+  ...sharedConfig,
+  test: {
+    ...sharedConfig.test,
+    // Package-specific overrides if needed
+  }
+});
+```
+
+And their package.json scripts:
 
 ```json title="./packages/ui/package.json"
 {
@@ -239,10 +286,10 @@ While your root `package.json` includes scripts for running tests globally:
 ```json title="./package.json"
 {
   "scripts": {
-    "test:workspace": "turbo run test",
-    "test:workspace:watch": "vitest --watch"
+    "test:projects": "turbo run test",
+    "test:projects:watch": "vitest --watch"
   }
 }
 ```
 
-This configuration allows developers to run `pnpm test:workspace:watch` at the root for a seamless local development experience, while CI continues to use `turbo run test` to leverage package-level caching. **You'll still need to handle merged coverage reports manually as described in the previous section**.
+This configuration allows developers to run `pnpm test:projects:watch` at the root for a seamless local development experience using Vitest projects, while CI continues to use `turbo run test` to leverage package-level caching. **You'll still need to handle merged coverage reports manually as described in the previous section**.

--- a/docs/site/content/docs/guides/tools/vitest.mdx
+++ b/docs/site/content/docs/guides/tools/vitest.mdx
@@ -221,9 +221,41 @@ Because of this, you'll need to use [Root Tasks](/docs/crafting-your-repository/
 
 You can combine the benefits of both approaches by implementing a hybrid solution. This approach unifies local development using Vitest's Projects feature while preserving Turborepo's caching in CI. This comes at the tradeoff of slightly more configuration and a mixed task running model in the repository.
 
-First, create a shared configuration file since individual projects can't extend the root config when using projects:
+First, create a shared configuration package since individual projects can't extend the root config when using projects. Create a new package for your shared Vitest configuration:
 
-```ts title="./vitest.shared.ts"
+```json title="./packages/vitest-config/package.json"
+{
+  "name": "@repo/vitest-config",
+  "version": "0.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  },
+  "dependencies": {
+    "vitest": "latest"
+  },
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*",
+    "typescript": "latest"
+  }
+}
+```
+
+```json title="./packages/vitest-config/tsconfig.json"
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}
+```
+
+```ts title="./packages/vitest-config/src/index.ts"
 export const sharedConfig = {
   test: {
     globals: true,
@@ -238,7 +270,7 @@ Then, create your root Vitest configuration using projects:
 
 ```ts title="./vitest.config.ts"
 import { defineConfig } from 'vitest/config';
-import { sharedConfig } from './vitest.shared';
+import { sharedConfig } from '@repo/vitest-config';
 
 export default defineConfig({
   ...sharedConfig,
@@ -255,11 +287,26 @@ export default defineConfig({
 });
 ```
 
-In this setup, your packages maintain their individual Vitest configurations that import the shared config:
+In this setup, your packages maintain their individual Vitest configurations that import the shared config. First, install the shared config package:
+
+```json title="./packages/ui/package.json"
+{
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest --watch"
+  },
+  "devDependencies": {
+    "@repo/vitest-config": "workspace:*",
+    "vitest": "latest"
+  }
+}
+```
+
+Then create the Vitest configuration:
 
 ```ts title="./packages/ui/vitest.config.ts"
 import { defineConfig } from 'vitest/config';
-import { sharedConfig } from '../../vitest.shared';
+import { sharedConfig } from '@repo/vitest-config';
 
 export default defineConfig({
   ...sharedConfig,
@@ -270,13 +317,22 @@ export default defineConfig({
 });
 ```
 
-And their package.json scripts:
+Make sure to update your `turbo.json` to include the new configuration package in the dependency graph:
 
-```json title="./packages/ui/package.json"
+```json title="./turbo.json"
 {
-  "scripts": {
-    "test": "vitest run",
-    "test:watch": "vitest --watch"
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
+    "test": {
+      "dependsOn": ["^test", "@repo/vitest-config#build"]
+    },
+    "test:watch": {
+      "cache": false,
+      "persistent": true
+    }
   }
 }
 ```


### PR DESCRIPTION
### Description

Updates the Vitest documentation to address GitHub Issue #10548. This PR:

*   Replaces deprecated Vitest "workspaces" with "projects" terminology and configuration.
*   Introduces a new `@repo/vitest-config` package for shared Vitest configuration, eliminating relative path traversals and promoting monorepo best practices.
*   Updates example code snippets and `turbo.json` to reflect the new package-based approach for improved cacheability and maintainability.

### Testing Instructions

Review the updated `docs/site/content/docs/guides/tools/vitest.mdx` file.

*   Verify that "workspaces" references are correctly replaced with "projects".
*   Ensure the new shared configuration package (`@repo/vitest-config`) is clearly explained and demonstrated.
*   Check the code snippets for accuracy and adherence to the recommended monorepo structure.