### PR TITLE
refactor(turborepo-updater): chain environment variable iterators in should_skip_notification

### DIFF
--- a/crates/turborepo-updater/src/lib.rs
+++ b/crates/turborepo-updater/src/lib.rs
@@ -90,10 +90,8 @@ fn get_tag_from_version(pre: &semver::Prerelease) -> VersionTag {
 fn should_skip_notification() -> bool {
     NOTIFIER_DISABLE_VARS
         .iter()
+        .chain(ENVIRONMENTAL_DISABLE_VARS.iter())
         .any(|var| std::env::var(var).is_ok())
-        || ENVIRONMENTAL_DISABLE_VARS
-            .iter()
-            .any(|var| std::env::var(var).is_ok())
         || !atty::is(atty::Stream::Stdout)
 }
 


### PR DESCRIPTION
## Description
Optimizes the `should_skip_notification()` function by combining two separate environment variable checks into a single chained iterator operation.

### Changes
- **Before**: Two separate `.any()` calls on `NOTIFIER_DISABLE_VARS` and `ENVIRONMENTAL_DISABLE_VARS`
- **After**: Single chained iterator using `.chain()` method

### Benefits
- **Improved readability**: Cleaner, more idiomatic Rust code
- **Reduced redundancy**: Eliminates duplicate iteration logic
- **Better maintainability**: Follows Rust iterator best practices
- **Same functionality**: Zero behavioral changes