### PR TITLE
docs: clarify default inputs behavior

### DIFF
--- a/docs/site/content/docs/reference/configuration.mdx
+++ b/docs/site/content/docs/reference/configuration.mdx
@@ -419,7 +419,7 @@ Defines if task outputs should be cached. Setting `cache` to false is useful for
 
 Default: `[]`, all files in the package that are checked into source control
 
-A list of file glob patterns relative to the package's `package.json` to consider when determining if a package has changed. `turbo.json` is **always** considered an input.
+A list of file glob patterns relative to the package's `package.json` to consider when determining if a package has changed. `turbo.json` and `package.json` are **always** considered inputs, even if you try to explicitly ignore them.
 
 Visit the [file glob specification](/docs/reference/globs) for more information on globbing syntax.
 


### PR DESCRIPTION
### Description

https://github.com/vercel/turborepo/discussions/10606 pointed out a minor clarification that we needed about `inputs`.
