### PR TITLE
docs: fixing --no-cache alert

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -399,7 +399,7 @@ impl Args {
             if run_args.no_cache {
                 warn!(
                     "--no-cache is deprecated and will be removed in a future major version. Use \
-                     --cache=local:r,remote:r"
+                     --cache=local:,remote:"
                 );
             }
             if run_args.remote_only.is_some() {

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -399,7 +399,7 @@ impl Args {
             if run_args.no_cache {
                 warn!(
                     "--no-cache is deprecated and will be removed in a future major version. Use \
-                     --cache=local:,remote:"
+                     --cache=local:r,remote:r"
                 );
             }
             if run_args.remote_only.is_some() {

--- a/docs/site/content/docs/crafting-your-repository/caching.mdx
+++ b/docs/site/content/docs/crafting-your-repository/caching.mdx
@@ -204,7 +204,7 @@ Turborepo has a [`--summarize` flag](/docs/reference/run#--summarize) that can b
 
 ### Turning off caching
 
-Sometimes, you may not want to write the output of tasks to the cache. This can be set permanently for a task using [`"cache": false`](/docs/reference/configuration#cache) or for a whole run using [ the `--no-cache` flag](/docs/reference/run#--no-cache).
+Sometimes, you may not want to write the output of tasks to the cache. This can be set permanently for a task using [`"cache": false`](/docs/reference/configuration#cache) or for a whole run using [ the `--cache <options>` flag](/docs/reference/run#--no-cache).
 
 ### Overwriting a cache
 


### PR DESCRIPTION
### Description

Minimal contribution because the alert of --no-cache deprecation gave a wrong command to use now with newer versions

### Testing Instructions

In a project with a recent enough version of turbo such as 2.5.4 :
turbo run build --no-cache

--> You'll receive the alert on the use of --no-cache