### PR TITLE
fix(examples): css specificity in Tailwind example

### DIFF
--- a/crates/turborepo-analytics/src/lib.rs
+++ b/crates/turborepo-analytics/src/lib.rs
@@ -190,9 +190,8 @@ mod tests {
     };
     use turborepo_api_client::{analytics::AnalyticsClient, APIAuth};
     use turborepo_vercel_api::{AnalyticsEvent, CacheEvent, CacheSource};
-    use uuid::Uuid;
 
-    use crate::{add_session_id, start_analytics};
+    use crate::start_analytics;
 
     #[derive(Clone)]
     struct DummyClient {
@@ -380,116 +379,5 @@ mod tests {
         assert_eq!(found.len(), 1);
         let payloads = &found[0];
         assert_eq!(payloads.len(), 2);
-    }
-
-    #[tokio::test]
-    async fn test_close_with_timeout() {
-        let (tx, _rx) = mpsc::unbounded_channel();
-
-        let client = DummyClient {
-            events: Default::default(),
-            tx,
-        };
-
-        let (analytics_sender, analytics_handle) = start_analytics(
-            APIAuth {
-                token: "foo".to_string(),
-                team_id: Some("bar".to_string()),
-                team_slug: None,
-            },
-            client.clone(),
-        );
-
-        // Send an event
-        analytics_sender
-            .send(AnalyticsEvent {
-                session_id: None,
-                source: CacheSource::Local,
-                event: CacheEvent::Hit,
-                hash: "".to_string(),
-                duration: 0,
-            })
-            .unwrap();
-
-        // Test close_with_timeout - should not panic
-        analytics_handle.close_with_timeout().await;
-    }
-
-    #[tokio::test]
-    async fn test_client_error_handling() {
-        let (tx, _rx) = mpsc::unbounded_channel();
-
-        let client = ErrorClient { tx };
-
-        let (analytics_sender, analytics_handle) = start_analytics(
-            APIAuth {
-                token: "foo".to_string(),
-                team_id: Some("bar".to_string()),
-                team_slug: None,
-            },
-            client,
-        );
-
-        // Send an event that will cause the client to error
-        analytics_sender
-            .send(AnalyticsEvent {
-                session_id: None,
-                source: CacheSource::Local,
-                event: CacheEvent::Hit,
-                hash: "".to_string(),
-                duration: 0,
-            })
-            .unwrap();
-
-        // Wait a bit for the error to be handled
-        tokio::time::sleep(Duration::from_millis(50)).await;
-
-        // Should not panic when closing
-        analytics_handle.close_with_timeout().await;
-    }
-
-    #[test]
-    fn test_add_session_id() {
-        let mut events = vec![
-            AnalyticsEvent {
-                session_id: None,
-                source: CacheSource::Local,
-                event: CacheEvent::Hit,
-                hash: "hash1".to_string(),
-                duration: 100,
-            },
-            AnalyticsEvent {
-                session_id: Some("existing".to_string()),
-                source: CacheSource::Remote,
-                event: CacheEvent::Miss,
-                hash: "hash2".to_string(),
-                duration: 200,
-            },
-        ];
-
-        let session_id = Uuid::new_v4();
-        add_session_id(session_id, &mut events);
-
-        assert_eq!(events[0].session_id, Some(session_id.to_string()));
-        assert_eq!(events[1].session_id, Some(session_id.to_string()));
-    }
-
-    #[derive(Clone)]
-    struct ErrorClient {
-        tx: mpsc::UnboundedSender<()>,
-    }
-
-    impl AnalyticsClient for ErrorClient {
-        async fn record_analytics(
-            &self,
-            _api_auth: &APIAuth,
-            _events: Vec<AnalyticsEvent>,
-        ) -> Result<(), turborepo_api_client::Error> {
-            // Simulate an error using a simple error type
-            Err(turborepo_api_client::Error::ReadError(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "test error",
-            )))
-        }
     }
 }

--- a/crates/turborepo-analytics/src/lib.rs
+++ b/crates/turborepo-analytics/src/lib.rs
@@ -190,8 +190,9 @@ mod tests {
     };
     use turborepo_api_client::{analytics::AnalyticsClient, APIAuth};
     use turborepo_vercel_api::{AnalyticsEvent, CacheEvent, CacheSource};
+    use uuid::Uuid;
 
-    use crate::start_analytics;
+    use crate::{add_session_id, start_analytics};
 
     #[derive(Clone)]
     struct DummyClient {
@@ -379,5 +380,116 @@ mod tests {
         assert_eq!(found.len(), 1);
         let payloads = &found[0];
         assert_eq!(payloads.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_close_with_timeout() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        let client = DummyClient {
+            events: Default::default(),
+            tx,
+        };
+
+        let (analytics_sender, analytics_handle) = start_analytics(
+            APIAuth {
+                token: "foo".to_string(),
+                team_id: Some("bar".to_string()),
+                team_slug: None,
+            },
+            client.clone(),
+        );
+
+        // Send an event
+        analytics_sender
+            .send(AnalyticsEvent {
+                session_id: None,
+                source: CacheSource::Local,
+                event: CacheEvent::Hit,
+                hash: "".to_string(),
+                duration: 0,
+            })
+            .unwrap();
+
+        // Test close_with_timeout - should not panic
+        analytics_handle.close_with_timeout().await;
+    }
+
+    #[tokio::test]
+    async fn test_client_error_handling() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        let client = ErrorClient { tx };
+
+        let (analytics_sender, analytics_handle) = start_analytics(
+            APIAuth {
+                token: "foo".to_string(),
+                team_id: Some("bar".to_string()),
+                team_slug: None,
+            },
+            client,
+        );
+
+        // Send an event that will cause the client to error
+        analytics_sender
+            .send(AnalyticsEvent {
+                session_id: None,
+                source: CacheSource::Local,
+                event: CacheEvent::Hit,
+                hash: "".to_string(),
+                duration: 0,
+            })
+            .unwrap();
+
+        // Wait a bit for the error to be handled
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Should not panic when closing
+        analytics_handle.close_with_timeout().await;
+    }
+
+    #[test]
+    fn test_add_session_id() {
+        let mut events = vec![
+            AnalyticsEvent {
+                session_id: None,
+                source: CacheSource::Local,
+                event: CacheEvent::Hit,
+                hash: "hash1".to_string(),
+                duration: 100,
+            },
+            AnalyticsEvent {
+                session_id: Some("existing".to_string()),
+                source: CacheSource::Remote,
+                event: CacheEvent::Miss,
+                hash: "hash2".to_string(),
+                duration: 200,
+            },
+        ];
+
+        let session_id = Uuid::new_v4();
+        add_session_id(session_id, &mut events);
+
+        assert_eq!(events[0].session_id, Some(session_id.to_string()));
+        assert_eq!(events[1].session_id, Some(session_id.to_string()));
+    }
+
+    #[derive(Clone)]
+    struct ErrorClient {
+        tx: mpsc::UnboundedSender<()>,
+    }
+
+    impl AnalyticsClient for ErrorClient {
+        async fn record_analytics(
+            &self,
+            _api_auth: &APIAuth,
+            _events: Vec<AnalyticsEvent>,
+        ) -> Result<(), turborepo_api_client::Error> {
+            // Simulate an error using a simple error type
+            Err(turborepo_api_client::Error::ReadError(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "test error",
+            )))
+        }
     }
 }

--- a/examples/with-tailwind/apps/docs/app/globals.css
+++ b/examples/with-tailwind/apps/docs/app/globals.css
@@ -1,6 +1,5 @@
 @import "tailwindcss";
 @import "@repo/tailwind-config";
-@import "@repo/ui/styles.css";
 
 :root {
   --foreground-rgb: 0, 0, 0;

--- a/examples/with-tailwind/apps/docs/app/layout.tsx
+++ b/examples/with-tailwind/apps/docs/app/layout.tsx
@@ -1,4 +1,3 @@
-// Stylesheet from components must come first for correct CSS specifity
 import "@repo/ui/styles.css";
 import "./globals.css";
 import type { Metadata } from "next";

--- a/examples/with-tailwind/apps/docs/app/layout.tsx
+++ b/examples/with-tailwind/apps/docs/app/layout.tsx
@@ -1,3 +1,5 @@
+// Stylesheet from components must come first for correct CSS specifity
+import "@repo/ui/styles.css";
 import "./globals.css";
 import type { Metadata } from "next";
 import { Geist } from "next/font/google";

--- a/examples/with-tailwind/apps/web/app/globals.css
+++ b/examples/with-tailwind/apps/web/app/globals.css
@@ -1,6 +1,5 @@
 @import "tailwindcss";
 @import "@repo/tailwind-config";
-@import "@repo/ui/styles.css";
 
 :root {
   --foreground-rgb: 0, 0, 0;

--- a/examples/with-tailwind/apps/web/app/layout.tsx
+++ b/examples/with-tailwind/apps/web/app/layout.tsx
@@ -1,4 +1,3 @@
-// Stylesheet from components must come first for correct CSS specifity
 import "@repo/ui/styles.css";
 import "./globals.css";
 import type { Metadata } from "next";

--- a/examples/with-tailwind/apps/web/app/layout.tsx
+++ b/examples/with-tailwind/apps/web/app/layout.tsx
@@ -1,3 +1,5 @@
+// Stylesheet from components must come first for correct CSS specifity
+import "@repo/ui/styles.css";
 import "./globals.css";
 import type { Metadata } from "next";
 import { Geist } from "next/font/google";

--- a/examples/with-tailwind/packages/ui/src/card.tsx
+++ b/examples/with-tailwind/packages/ui/src/card.tsx
@@ -11,18 +11,20 @@ export function Card({
 }) {
   return (
     <a
-      className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-neutral-700 hover:bg-neutral-800/30"
+      className="ui:group ui:rounded-lg ui:bg-red-300 ui:border ui:border-transparent ui:px-5 ui:py-4 ui:transition-colors hover:ui:border-neutral-700 hover:ui:bg-neutral-800/30"
       href={`${href}?utm_source=create-turbo&utm_medium=with-tailwind&utm_campaign=create-turbo"`}
       rel="noopener noreferrer"
       target="_blank"
     >
-      <h2 className="mb-3 text-2xl font-semibold">
+      <h2 className="ui:mb-3 ui:text-2xl ui:font-semibold">
         {title}{" "}
-        <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
+        <span className="ui:inline-block ui:transition-transform group-hover:ui:translate-x-1 motion-reduce:ui:transform-none">
           -&gt;
         </span>
       </h2>
-      <p className="m-0 max-w-[30ch] text-sm opacity-50">{children}</p>
+      <p className="ui:m-0 ui:max-w-[30ch] ui:text-sm ui:opacity-50">
+        {children}
+      </p>
     </a>
   );
 }

--- a/examples/with-tailwind/packages/ui/src/card.tsx
+++ b/examples/with-tailwind/packages/ui/src/card.tsx
@@ -11,7 +11,7 @@ export function Card({
 }) {
   return (
     <a
-      className="ui:group ui:rounded-lg ui:bg-red-300 ui:border ui:border-transparent ui:px-5 ui:py-4 ui:transition-colors hover:ui:border-neutral-700 hover:ui:bg-neutral-800/30"
+      className="ui:group ui:rounded-lg ui:border ui:border-transparent ui:px-5 ui:py-4 ui:transition-colors hover:ui:border-neutral-700 hover:ui:bg-neutral-800/30"
       href={`${href}?utm_source=create-turbo&utm_medium=with-tailwind&utm_campaign=create-turbo"`}
       rel="noopener noreferrer"
       target="_blank"

--- a/examples/with-tailwind/packages/ui/src/gradient.tsx
+++ b/examples/with-tailwind/packages/ui/src/gradient.tsx
@@ -9,11 +9,11 @@ export function Gradient({
 }) {
   return (
     <span
-      className={`absolute mix-blend-normal will-change-[filter] rounded-[100%] ${
-        small ? "blur-[32px]" : "blur-[75px]"
+      className={`ui:absolute ui:mix-blend-normal ui:will-change-[filter] ui:rounded-[100%] ${
+        small ? "ui:blur-[32px]" : "ui:blur-[75px]"
       } ${
         conic
-          ? "bg-[conic-gradient(from_180deg_at_50%_50%,var(--red-1000)_0deg,_var(--purple-1000)_180deg,_var(--blue-1000)_360deg)]"
+          ? "ui:bg-[conic-gradient(from_180deg_at_50%_50%,var(--red-1000)_0deg,_var(--purple-1000)_180deg,_var(--blue-1000)_360deg)]"
           : ""
       } ${className ?? ""}`}
     />

--- a/examples/with-tailwind/packages/ui/src/styles.css
+++ b/examples/with-tailwind/packages/ui/src/styles.css
@@ -1,2 +1,2 @@
 /* Component-level styles for the UI package */
-@import "tailwindcss";
+@import "tailwindcss" prefix(ui);


### PR DESCRIPTION
### Description

As described in #10642, CSS specificity wasn't being handled correctly in the example. This PR fixes it by ensuring the compiled stylesheet from the package:
- Uses a prefix. This fixes all specificity issues by itself, but also...
- Is used directly in the app instead of trying to go through the app's Tailwind compilation process
- Is applied _before_ the app's stylesheet, so that things can be properly overridden by the app (since they're later in the CSS evaluation)

### Testing Instructions

Try it out!
