### PR TITLE
refactor(examples): update CSS variable names to use consistent --color- prefix in tailwind examples

### DIFF
--- a/examples/with-tailwind/packages/tailwind-config/shared-styles.css
+++ b/examples/with-tailwind/packages/tailwind-config/shared-styles.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 @theme {
-  --blue-1000: #2a8af6;
-  --purple-1000: #a853ba;
-  --red-1000: #e92a67;
+  --color-blue-1000: #2a8af6;
+  --color-purple-1000: #a853ba;
+  --color-red-1000: #e92a67;
 }


### PR DESCRIPTION
### Description

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->
Tailwind CSS v4 uses the `--color-*` convention for custom properties.

In the current example file at  
[`examples/with-tailwind/packages/tailwind-config/shared-styles.css`](https://github.com/vercel/turborepo/blob/main/examples/with-tailwind/packages/tailwind-config/shared-styles.css),  
the custom color variables do **not** use the `--color-` prefix, which causes them not to work correctly with Tailwind v4.

This PR updates the variable names to follow the correct naming convention, allowing them to be used properly with Tailwind's color system.

#### Before:
```css
@theme {
  --blue-1000: #2a8af6;
  --purple-1000: #a853ba;
  --red-1000: #e92a67;
}
```
#### After:
```css
@theme {
  --color-blue-1000: #2a8af6;
  --color-purple-1000: #a853ba;
  --color-red-1000: #e92a67;
}
```



<!--
  Give a quick description of steps to test your changes.
-->
