### PR TITLE
feat(auth): optional callback port

### DIFF
--- a/crates/turborepo-analytics/src/lib.rs
+++ b/crates/turborepo-analytics/src/lib.rs
@@ -190,9 +190,8 @@ mod tests {
     };
     use turborepo_api_client::{analytics::AnalyticsClient, APIAuth};
     use turborepo_vercel_api::{AnalyticsEvent, CacheEvent, CacheSource};
-    use uuid::Uuid;
 
-    use crate::{add_session_id, start_analytics};
+    use crate::start_analytics;
 
     #[derive(Clone)]
     struct DummyClient {
@@ -380,116 +379,5 @@ mod tests {
         assert_eq!(found.len(), 1);
         let payloads = &found[0];
         assert_eq!(payloads.len(), 2);
-    }
-
-    #[tokio::test]
-    async fn test_close_with_timeout() {
-        let (tx, _rx) = mpsc::unbounded_channel();
-
-        let client = DummyClient {
-            events: Default::default(),
-            tx,
-        };
-
-        let (analytics_sender, analytics_handle) = start_analytics(
-            APIAuth {
-                token: "foo".to_string(),
-                team_id: Some("bar".to_string()),
-                team_slug: None,
-            },
-            client.clone(),
-        );
-
-        // Send an event
-        analytics_sender
-            .send(AnalyticsEvent {
-                session_id: None,
-                source: CacheSource::Local,
-                event: CacheEvent::Hit,
-                hash: "".to_string(),
-                duration: 0,
-            })
-            .unwrap();
-
-        // Test close_with_timeout - should not panic
-        analytics_handle.close_with_timeout().await;
-    }
-
-    #[tokio::test]
-    async fn test_client_error_handling() {
-        let (tx, _rx) = mpsc::unbounded_channel();
-
-        let client = ErrorClient { tx };
-
-        let (analytics_sender, analytics_handle) = start_analytics(
-            APIAuth {
-                token: "foo".to_string(),
-                team_id: Some("bar".to_string()),
-                team_slug: None,
-            },
-            client,
-        );
-
-        // Send an event that will cause the client to error
-        analytics_sender
-            .send(AnalyticsEvent {
-                session_id: None,
-                source: CacheSource::Local,
-                event: CacheEvent::Hit,
-                hash: "".to_string(),
-                duration: 0,
-            })
-            .unwrap();
-
-        // Wait a bit for the error to be handled
-        tokio::time::sleep(Duration::from_millis(50)).await;
-
-        // Should not panic when closing
-        analytics_handle.close_with_timeout().await;
-    }
-
-    #[test]
-    fn test_add_session_id() {
-        let mut events = vec![
-            AnalyticsEvent {
-                session_id: None,
-                source: CacheSource::Local,
-                event: CacheEvent::Hit,
-                hash: "hash1".to_string(),
-                duration: 100,
-            },
-            AnalyticsEvent {
-                session_id: Some("existing".to_string()),
-                source: CacheSource::Remote,
-                event: CacheEvent::Miss,
-                hash: "hash2".to_string(),
-                duration: 200,
-            },
-        ];
-
-        let session_id = Uuid::new_v4();
-        add_session_id(session_id, &mut events);
-
-        assert_eq!(events[0].session_id, Some(session_id.to_string()));
-        assert_eq!(events[1].session_id, Some(session_id.to_string()));
-    }
-
-    #[derive(Clone)]
-    struct ErrorClient {
-        tx: mpsc::UnboundedSender<()>,
-    }
-
-    impl AnalyticsClient for ErrorClient {
-        async fn record_analytics(
-            &self,
-            _api_auth: &APIAuth,
-            _events: Vec<AnalyticsEvent>,
-        ) -> Result<(), turborepo_api_client::Error> {
-            // Simulate an error using a simple error type
-            Err(turborepo_api_client::Error::ReadError(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "test error",
-            )))
-        }
     }
 }

--- a/crates/turborepo-analytics/src/lib.rs
+++ b/crates/turborepo-analytics/src/lib.rs
@@ -190,8 +190,9 @@ mod tests {
     };
     use turborepo_api_client::{analytics::AnalyticsClient, APIAuth};
     use turborepo_vercel_api::{AnalyticsEvent, CacheEvent, CacheSource};
+    use uuid::Uuid;
 
-    use crate::start_analytics;
+    use crate::{add_session_id, start_analytics};
 
     #[derive(Clone)]
     struct DummyClient {
@@ -379,5 +380,116 @@ mod tests {
         assert_eq!(found.len(), 1);
         let payloads = &found[0];
         assert_eq!(payloads.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_close_with_timeout() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        let client = DummyClient {
+            events: Default::default(),
+            tx,
+        };
+
+        let (analytics_sender, analytics_handle) = start_analytics(
+            APIAuth {
+                token: "foo".to_string(),
+                team_id: Some("bar".to_string()),
+                team_slug: None,
+            },
+            client.clone(),
+        );
+
+        // Send an event
+        analytics_sender
+            .send(AnalyticsEvent {
+                session_id: None,
+                source: CacheSource::Local,
+                event: CacheEvent::Hit,
+                hash: "".to_string(),
+                duration: 0,
+            })
+            .unwrap();
+
+        // Test close_with_timeout - should not panic
+        analytics_handle.close_with_timeout().await;
+    }
+
+    #[tokio::test]
+    async fn test_client_error_handling() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        let client = ErrorClient { tx };
+
+        let (analytics_sender, analytics_handle) = start_analytics(
+            APIAuth {
+                token: "foo".to_string(),
+                team_id: Some("bar".to_string()),
+                team_slug: None,
+            },
+            client,
+        );
+
+        // Send an event that will cause the client to error
+        analytics_sender
+            .send(AnalyticsEvent {
+                session_id: None,
+                source: CacheSource::Local,
+                event: CacheEvent::Hit,
+                hash: "".to_string(),
+                duration: 0,
+            })
+            .unwrap();
+
+        // Wait a bit for the error to be handled
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Should not panic when closing
+        analytics_handle.close_with_timeout().await;
+    }
+
+    #[test]
+    fn test_add_session_id() {
+        let mut events = vec![
+            AnalyticsEvent {
+                session_id: None,
+                source: CacheSource::Local,
+                event: CacheEvent::Hit,
+                hash: "hash1".to_string(),
+                duration: 100,
+            },
+            AnalyticsEvent {
+                session_id: Some("existing".to_string()),
+                source: CacheSource::Remote,
+                event: CacheEvent::Miss,
+                hash: "hash2".to_string(),
+                duration: 200,
+            },
+        ];
+
+        let session_id = Uuid::new_v4();
+        add_session_id(session_id, &mut events);
+
+        assert_eq!(events[0].session_id, Some(session_id.to_string()));
+        assert_eq!(events[1].session_id, Some(session_id.to_string()));
+    }
+
+    #[derive(Clone)]
+    struct ErrorClient {
+        tx: mpsc::UnboundedSender<()>,
+    }
+
+    impl AnalyticsClient for ErrorClient {
+        async fn record_analytics(
+            &self,
+            _api_auth: &APIAuth,
+            _events: Vec<AnalyticsEvent>,
+        ) -> Result<(), turborepo_api_client::Error> {
+            // Simulate an error using a simple error type
+            Err(turborepo_api_client::Error::ReadError(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "test error",
+            )))
+        }
     }
 }

--- a/crates/turborepo-auth/src/auth/login.rs
+++ b/crates/turborepo-auth/src/auth/login.rs
@@ -12,10 +12,6 @@ use crate::{auth::extract_vercel_token, error, ui, LoginOptions, Token};
 const DEFAULT_HOST_NAME: &str = "127.0.0.1";
 const DEFAULT_PORT: u16 = 9789;
 
-fn get_callback_port(options: &LoginOptions<'_, impl Client + TokenClient + CacheClient>) -> u16 {
-    options.sso_login_callback_port.unwrap_or(DEFAULT_PORT)
-}
-
 /// Login returns a `Token` struct. If a token is already present,
 /// we do not overwrite it and instead log that we found an existing token,
 /// setting the `exists` field to `true`.
@@ -33,7 +29,7 @@ pub async fn login<T: Client + TokenClient + CacheClient>(
         existing_token,
         force,
         sso_team: _,
-        sso_login_callback_port: _,
+        sso_login_callback_port,
     } = *options; // Deref or we get double references for each of these
 
     // I created a closure that gives back a closure since the `is_valid` checks do
@@ -88,7 +84,7 @@ pub async fn login<T: Client + TokenClient + CacheClient>(
         }
     }
 
-    let port = get_callback_port(options);
+    let port = sso_login_callback_port.unwrap_or(DEFAULT_PORT);
     let redirect_url = format!("http://{DEFAULT_HOST_NAME}:{port}");
     let mut login_url = Url::parse(login_url_configuration)?;
     let mut success_url = login_url.clone();

--- a/crates/turborepo-auth/src/auth/login.rs
+++ b/crates/turborepo-auth/src/auth/login.rs
@@ -12,11 +12,8 @@ use crate::{auth::extract_vercel_token, error, ui, LoginOptions, Token};
 const DEFAULT_HOST_NAME: &str = "127.0.0.1";
 const DEFAULT_PORT: u16 = 9789;
 
-fn get_callback_port() -> u16 {
-    std::env::var("TURBO_SSO_LOGIN_CALLBACK_PORT")
-        .ok()
-        .and_then(|port_str| port_str.parse().ok())
-        .unwrap_or(DEFAULT_PORT)
+fn get_callback_port(options: &LoginOptions<'_, impl Client + TokenClient + CacheClient>) -> u16 {
+    options.sso_login_callback_port.unwrap_or(DEFAULT_PORT)
 }
 
 /// Login returns a `Token` struct. If a token is already present,
@@ -36,6 +33,7 @@ pub async fn login<T: Client + TokenClient + CacheClient>(
         existing_token,
         force,
         sso_team: _,
+        sso_login_callback_port: _,
     } = *options; // Deref or we get double references for each of these
 
     // I created a closure that gives back a closure since the `is_valid` checks do
@@ -90,7 +88,7 @@ pub async fn login<T: Client + TokenClient + CacheClient>(
         }
     }
 
-    let port = get_callback_port();
+    let port = get_callback_port(options);
     let redirect_url = format!("http://{DEFAULT_HOST_NAME}:{port}");
     let mut login_url = Url::parse(login_url_configuration)?;
     let mut success_url = login_url.clone();

--- a/crates/turborepo-auth/src/auth/mod.rs
+++ b/crates/turborepo-auth/src/auth/mod.rs
@@ -24,6 +24,7 @@ pub struct LoginOptions<'a, T: Client + TokenClient + CacheClient> {
     pub sso_team: Option<&'a str>,
     pub existing_token: Option<&'a str>,
     pub force: bool,
+    pub sso_login_callback_port: Option<u16>,
 }
 impl<'a, T: Client + TokenClient + CacheClient> LoginOptions<'a, T> {
     pub fn new(
@@ -40,6 +41,7 @@ impl<'a, T: Client + TokenClient + CacheClient> LoginOptions<'a, T> {
             sso_team: None,
             existing_token: None,
             force: false,
+            sso_login_callback_port: None,
         }
     }
 }

--- a/crates/turborepo-lib/src/commands/login/manual.rs
+++ b/crates/turborepo-lib/src/commands/login/manual.rs
@@ -189,6 +189,7 @@ mod test {
             upload_timeout: 0,
             login_url: "".into(),
             preflight: false,
+            sso_login_callback_port: None,
         };
         let login_opts = ManualLoginOptions::from(&api_opts);
         assert_eq!(
@@ -212,6 +213,7 @@ mod test {
             upload_timeout: 0,
             login_url: "".into(),
             preflight: false,
+            sso_login_callback_port: None,
         };
         let login_opts = ManualLoginOptions::from(&api_opts);
         assert_eq!(

--- a/crates/turborepo-lib/src/commands/login/mod.rs
+++ b/crates/turborepo-lib/src/commands/login/mod.rs
@@ -56,10 +56,12 @@ async fn sso_login(base: &mut CommandBase, sso_team: &str, force: bool) -> Resul
     let api_client: APIClient = base.api_client()?;
     let color_config = base.color_config;
     let login_url_config = base.opts.api_client_opts.login_url.to_string();
+    let sso_login_callback_port = base.opts.api_client_opts.sso_login_callback_port;
     let options = LoginOptions {
         existing_token: base.opts.api_client_opts.token.as_deref(),
         sso_team: Some(sso_team),
         force,
+        sso_login_callback_port,
         ..LoginOptions::new(
             &color_config,
             &login_url_config,
@@ -83,10 +85,12 @@ async fn login_no_sso(base: &mut CommandBase, force: bool) -> Result<(), Error> 
     let color_config = base.color_config;
     let login_url_config = base.opts.api_client_opts.login_url.to_string();
     let existing_token = base.opts.api_client_opts.token.as_deref();
+    let sso_login_callback_port = base.opts.api_client_opts.sso_login_callback_port;
 
     let options = LoginOptions {
         existing_token,
         force,
+        sso_login_callback_port,
         ..LoginOptions::new(
             &color_config,
             &login_url_config,

--- a/crates/turborepo-lib/src/config/env.rs
+++ b/crates/turborepo-lib/src/config/env.rs
@@ -45,6 +45,7 @@ const TURBO_MAPPING: &[(&str, &str)] = [
     ("turbo_tui_scrollback_length", "tui_scrollback_length"),
     ("turbo_concurrency", "concurrency"),
     ("turbo_no_update_notifier", "no_update_notifier"),
+    ("turbo_sso_login_callback_port", "sso_login_callback_port"),
 ]
 .as_slice();
 
@@ -212,6 +213,14 @@ impl ResolvedConfigurationOptions for EnvVars {
             .filter(|s| !s.is_empty())
             .cloned();
 
+        let sso_login_callback_port = self
+            .output_map
+            .get("sso_login_callback_port")
+            .filter(|s| !s.is_empty())
+            .map(|s| s.parse())
+            .transpose()
+            .map_err(Error::InvalidSsoLoginCallbackPort)?;
+
         let output = ConfigurationOptions {
             api_url: self.output_map.get("api_url").cloned(),
             login_url: self.output_map.get("login_url").cloned(),
@@ -245,6 +254,7 @@ impl ResolvedConfigurationOptions for EnvVars {
             cache_dir,
             root_turbo_json_path,
             log_order,
+            sso_login_callback_port,
         };
 
         Ok(output)
@@ -339,11 +349,13 @@ mod test {
         env.insert("turbo_remote_cache_upload_timeout".into(), "200".into());
         env.insert("turbo_tui_scrollback_length".into(), "2048".into());
         env.insert("turbo_concurrency".into(), "50%".into());
+        env.insert("turbo_sso_login_callback_port".into(), "3000".into());
 
         let config = EnvVars::new(&env)
             .unwrap()
             .get_configuration_options(&ConfigurationOptions::default())
             .unwrap();
+        assert_eq!(config.sso_login_callback_port(), Some(3000));
         assert!(config.preflight());
         assert!(config.force());
         assert_eq!(config.log_order(), LogOrder::Grouped);
@@ -393,6 +405,7 @@ mod test {
         env.insert("turbo_allow_no_turbo_json".into(), "".into());
         env.insert("turbo_tui_scrollback_length".into(), "".into());
         env.insert("turbo_concurrency".into(), "".into());
+        env.insert("turbo_sso_login_callback_port".into(), "".into());
 
         let config = EnvVars::new(&env)
             .unwrap()
@@ -421,5 +434,6 @@ mod test {
             DEFAULT_TUI_SCROLLBACK_LENGTH
         );
         assert_eq!(config.concurrency, None);
+        assert_eq!(config.sso_login_callback_port(), None);
     }
 }

--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -240,6 +240,8 @@ pub enum Error {
          scrollback."
     )]
     InvalidTuiScrollbackLength(#[source] std::num::ParseIntError),
+    #[error("TURBO_SSO_LOGIN_CALLBACK_PORT: Invalid value. Use a number for the callback port.")]
+    InvalidSsoLoginCallbackPort(#[source] std::num::ParseIntError),
 }
 
 const DEFAULT_API_URL: &str = "https://vercel.com/api";
@@ -309,6 +311,7 @@ pub struct ConfigurationOptions {
     pub(crate) tui_scrollback_length: Option<u64>,
     pub(crate) concurrency: Option<String>,
     pub(crate) no_update_notifier: Option<bool>,
+    pub(crate) sso_login_callback_port: Option<u16>,
 }
 
 #[derive(Default)]
@@ -463,6 +466,10 @@ impl ConfigurationOptions {
 
     pub fn no_update_notifier(&self) -> bool {
         self.no_update_notifier.unwrap_or_default()
+    }
+
+    pub fn sso_login_callback_port(&self) -> Option<u16> {
+        self.sso_login_callback_port
     }
 }
 

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -55,6 +55,7 @@ pub struct APIClientOpts {
     pub team_slug: Option<String>,
     pub login_url: String,
     pub preflight: bool,
+    pub sso_login_callback_port: Option<u16>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -449,6 +450,7 @@ impl<'a> From<OptsInputs<'a>> for APIClientOpts {
         let team_id = inputs.config.team_id().map(|s| s.to_string());
         let team_slug = inputs.config.team_slug().map(|s| s.to_string());
         let login_url = inputs.config.login_url().to_string();
+        let sso_login_callback_port = inputs.config.sso_login_callback_port();
 
         APIClientOpts {
             api_url,
@@ -459,6 +461,7 @@ impl<'a> From<OptsInputs<'a>> for APIClientOpts {
             team_slug,
             login_url,
             preflight,
+            sso_login_callback_port,
         }
     }
 }
@@ -737,6 +740,7 @@ mod test {
                 team_slug: None,
                 login_url: "".to_string(),
                 preflight: false,
+                sso_login_callback_port: None,
             },
             scope_opts,
             run_opts,

--- a/docs/site/content/docs/reference/system-environment-variables.mdx
+++ b/docs/site/content/docs/reference/system-environment-variables.mdx
@@ -340,6 +340,15 @@ System environment variables are always overridden by flag values provided direc
         settings in run or watch mode.
       </td>
     </tr>
+    <tr id="turbo_sso_login_callback_port">
+      <td>
+        <code>TURBO_SSO_LOGIN_CALLBACK_PORT</code>
+      </td>
+      <td>
+        Override the default port (9789) used for the SSO login callback server
+        during authentication.
+      </td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
### Description

In some situations, users might want to change the port for the callback when logging in. This PR allows such behavior through an ` environment variable.

### Testing Instructions

I manually tested that the port changes in the URL. Also added some tests.