### PR TITLE
fix: typescript-config export form react-native-web

### DIFF
--- a/examples/with-react-native-web/packages/typescript-config/package.json
+++ b/examples/with-react-native-web/packages/typescript-config/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "publishConfig": {
     "access": "public"
-  }
+  },
   "exports": {
     "./base.json": "./base.json",
     "./nextjs.json": "./nextjs.json",

--- a/examples/with-react-native-web/packages/typescript-config/package.json
+++ b/examples/with-react-native-web/packages/typescript-config/package.json
@@ -5,4 +5,9 @@
   "publishConfig": {
     "access": "public"
   }
+  "exports": {
+    "./base.json": "./base.json",
+    "./nextjs.json": "./nextjs.json",
+    "./react-native-library.json": "./react-native-library.json"
+  }
 }


### PR DESCRIPTION
### Description

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->
When setting up the react native web template, you get hit with `File '@repo/typescript-config/nextjs.json' not found.` in `apps/web/tsconfig..json`.

Properly exporting the config files from `packages/typescript-config` so it works out the box.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
Clone the template, notice no more `no found` errors.
