### PR TITLE
fix(examples): update vitest config paths for packages and apps in `with-vitest`

### DIFF
--- a/examples/with-vitest/vitest.config.ts
+++ b/examples/with-vitest/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   test: {
     projects: [
       {
-        root: "./packages/*",
+        root: "./packages",
         test: {
           ...sharedConfig.test,
           // Project-specific configuration for packages
@@ -14,7 +14,7 @@ export default defineConfig({
         },
       },
       {
-        root: "./apps/*",
+        root: "./apps",
         test: {
           ...sharedConfig.test,
           // Project-specific configuration for apps


### PR DESCRIPTION
### Description

The current `--with-vitest` example's root vitest.config.ts has `*` in the paths which seems to be invalid as shown below:

```
The project root contains the "*" character (/workspace/tmp/my-turborepo/packages/*), which may not work when running Vite. Consider renaming the directory / file to remove the characters.
The project root contains the "*" character (/workspace/tmp/my-turborepo/apps/*), which may not work when running Vite. Consider renaming the directory / file to remove the characters.

 DEV  v3.2.4 /workspace/tmp/my-turborepo

No test files found. You can change the file name pattern by pressing "p"


 0  

include: **/*.{test,spec}.?(c|m)[jt]s?(x)
exclude:  **/node_modules/**, **/dist/**, **/cypress/**, **/.{idea,git,cache,output,temp}/**, **/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*

 1  

include: **/*.{test,spec}.?(c|m)[jt]s?(x)
exclude:  **/node_modules/**, **/dist/**, **/cypress/**, **/.{idea,git,cache,output,temp}/**, **/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*
```

Removing `/*` sufix fixes this issue as show below:

```
› bun run test:projects:watch
$ vitest --watch

 DEV  v3.2.4 /workspace/tmp/my-turborepo

 ✓  0  math/tests/math.test.ts (2 tests) 2ms
 ✓  1  web/tests/math.test.ts (1 test) 1ms
 ✓  1  docs/tests/math.test.ts (1 test) 1ms

 Test Files  3 passed (3)
      Tests  4 passed (4)
   Start at  07:11:36
   Duration  515ms (transform 43ms, setup 0ms, collect 31ms, tests 4ms, environment 626ms, prepare 139ms)
```

This is related to https://github.com/vercel/turborepo/issues/10659#event-18621158590

### Testing Instructions

Just run:

`bun run test:projects:watch`
