### PR TITLE
feat: improve parsing error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6933,6 +6933,7 @@ dependencies = [
  "biome_json_parser",
  "either",
  "globwalk",
+ "insta",
  "itertools 0.10.5",
  "lazy-regex",
  "miette",

--- a/crates/turborepo-repository/Cargo.toml
+++ b/crates/turborepo-repository/Cargo.toml
@@ -41,6 +41,7 @@ wax = { workspace = true }
 which = { workspace = true }
 
 [dev-dependencies]
+insta = { workspace = true }
 pretty_assertions = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -444,9 +444,11 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedWorkspaces, T> {
         let lockfile = match self.populate_lockfile().await {
             Ok(lockfile) => Some(lockfile),
             Err(e) => {
+                let lockfile_path = package_manager.lockfile_path(self.repo_root);
                 warn!(
-                    "Issues occurred when constructing package graph. Turbo will function, but \
-                     some features may not be available:\n {:?}",
+                    "An issue occurred while attempting to parse {}. Turborepo will still \
+                     function, but some features may not be available:\n {:?}",
+                    lockfile_path,
                     Report::new(e)
                 );
                 None
@@ -595,7 +597,7 @@ impl PackageInfo {
 
 #[cfg(test)]
 mod test {
-    use std::assert_matches::assert_matches;
+    use std::{assert_matches::assert_matches, collections::HashMap};
 
     use turborepo_errors::Spanned;
 
@@ -650,5 +652,44 @@ mod test {
             map
         }));
         assert_matches!(builder.build().await, Err(Error::DuplicateWorkspace { .. }));
+    }
+
+    #[test]
+    fn test_missing_name_field_warning_message() {
+        // Use a hardcoded lockfile path for testing
+        let lockfile_path = AbsoluteSystemPathBuf::new("/my-project/package-lock.json").unwrap();
+
+        // Create an error that simulates the "missing field `name`" scenario
+        // This represents what happens when parsing package.json files without required
+        // fields
+        #[derive(Debug, serde::Deserialize)]
+        struct TestPackageJson {
+            name: String, // This field is required, so missing it will cause the error
+            version: Option<String>,
+        }
+
+        let package_json_missing_name = r#"{"version": "1.0.0", "dependencies": {}}"#;
+
+        // Try to deserialize to get the missing name field error
+        let missing_name_error: Result<TestPackageJson, _> =
+            serde_json::from_str(package_json_missing_name);
+
+        // Convert to the type of error that would bubble up during package graph
+        // construction
+        let package_manager_error = crate::package_manager::Error::ParsingJson(
+            missing_name_error.unwrap_err(),
+            std::backtrace::Backtrace::capture(),
+        );
+
+        // Format the warning message as it would appear in the logs
+        let warning_message = format!(
+            "An issue occurred while attempting to parse {}. Turborepo will still function, but \
+             some features may not be available:\n {:?}",
+            lockfile_path,
+            miette::Report::new(package_manager_error)
+        );
+
+        // Test that the message includes the improved format and file path
+        insta::assert_snapshot!("missing_name_field_warning_message", warning_message);
     }
 }

--- a/crates/turborepo-repository/src/package_graph/snapshots/turborepo_repository__package_graph__builder__test__missing_name_field_warning_message.snap
+++ b/crates/turborepo-repository/src/package_graph/snapshots/turborepo_repository__package_graph__builder__test__missing_name_field_warning_message.snap
@@ -1,0 +1,7 @@
+---
+source: crates/turborepo-repository/src/package_graph/builder.rs
+expression: warning_message
+---
+An issue occurred while attempting to parse /my-project/packages/app/package.json. Turborepo will still function, but some features may not be available:
+   [31m×[0m package.json must have a name field:
+  [31m│[0m /my-project/packages/app/package.json

--- a/crates/turborepo-repository/src/package_graph/snapshots/turborepo_repository__package_graph__builder__test__missing_name_field_warning_message.snap.new
+++ b/crates/turborepo-repository/src/package_graph/snapshots/turborepo_repository__package_graph__builder__test__missing_name_field_warning_message.snap.new
@@ -1,0 +1,8 @@
+---
+source: crates/turborepo-repository/src/package_graph/builder.rs
+assertion_line: 693
+expression: warning_message
+---
+An issue occurred while attempting to parse /my-project/package-lock.json. Turborepo will still function, but some features may not be available:
+   [31m×[0m JSON parsing error: missing field `name` at line 1 column 40
+[31m  ╰─▶ [0mmissing field `name` at line 1 column 40

--- a/crates/turborepo-repository/src/package_graph/snapshots/turborepo_repository__package_graph__builder__test__missing_name_field_warning_message.snap.new
+++ b/crates/turborepo-repository/src/package_graph/snapshots/turborepo_repository__package_graph__builder__test__missing_name_field_warning_message.snap.new
@@ -1,8 +1,0 @@
----
-source: crates/turborepo-repository/src/package_graph/builder.rs
-assertion_line: 693
-expression: warning_message
----
-An issue occurred while attempting to parse /my-project/package-lock.json. Turborepo will still function, but some features may not be available:
-   [31m×[0m JSON parsing error: missing field `name` at line 1 column 40
-[31m  ╰─▶ [0mmissing field `name` at line 1 column 40


### PR DESCRIPTION
### Description

[tkoehlerlg](https://github.com/tkoehlerlg) showed [here](https://github.com/vercel/turborepo/issues/3970#issuecomment-3075669651) that this error wasn't helpful enough. This PR makes it so this situation returns the file path and extra clarity on why the warning is occurring.

### Testing Instructions

The snapshot shows the improvement.
