### PR TITLE
fix(examples): correct 'test:projects' script to use vitest directly

### DIFF
--- a/docs/site/content/docs/guides/tools/vitest.mdx
+++ b/docs/site/content/docs/guides/tools/vitest.mdx
@@ -342,10 +342,10 @@ While your root `package.json` includes scripts for running tests globally:
 ```json title="./package.json"
 {
   "scripts": {
-    "test:projects": "turbo run test",
+    "test:projects": "vitest run",
     "test:projects:watch": "vitest --watch"
   }
 }
 ```
 
-This configuration allows developers to run `pnpm test:projects:watch` at the root for a seamless local development experience using Vitest projects, while CI continues to use `turbo run test` to leverage package-level caching. **You'll still need to handle merged coverage reports manually as described in the previous section**.
+This configuration allows developers to run `pnpm test:projects` or `pnpm test:projects:watch` at the root for a seamless local development experience using Vitest projects, while CI continues to use `turbo run test` to leverage package-level caching. **You'll still need to handle merged coverage reports manually as described in the previous section**.

--- a/examples/with-vitest/README.md
+++ b/examples/with-vitest/README.md
@@ -24,7 +24,7 @@ pnpm build --filter=@repo/vitest-config
 ## Available Commands
 
 - `pnpm test`: Runs tests in each package using Turborepo (leverages caching)
-- `pnpm test:projects`: Same as above, explicitly named for the package-level approach  
+- `pnpm test:projects`: Runs tests using Vitest's projects feature
 - `pnpm test:projects:watch`: Runs tests using Vitest's projects feature in watch mode
 - `pnpm view-report`: Collects coverage from each package and shows it in a merged report
 

--- a/examples/with-vitest/package.json
+++ b/examples/with-vitest/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "test": "turbo run test",
-    "test:projects": "turbo run test",
+    "test:projects": "vitest run",
     "test:projects:watch": "vitest --watch",
     "view-report": "turbo run view-report"
   },


### PR DESCRIPTION
### Description

Update the `test:projects` script in the `with-vitest` example to use Vitest's projects feature directly.

```diff
# examples/with-vitest/package.json
- "test:projects": "turbo run test",
+ "test:projects": "vitest run",
```

Currently, the `test:projects` script runs `turbo run test`, which leverages Turborepo's package-level caching. However, given the script name and the example's hybrid approach documentation, it seems more appropriate for this command to use `vitest run` directly to demonstrate Vitest's projects feature.

Changes made:

- Updated `package.json` to use `vitest run` for the `test:projects` script
- Updated README.md to accurately describe what `test:projects` does
- Updated the documentation in `docs/site/content/docs/guides/tools/vitest.mdx` to reflect the correct usage

### Testing Instructions

1. Clone the repository and navigate to the `examples/with-vitest` directory
2. Install dependencies: `pnpm install`
3. Build the shared config: `pnpm --filter @repo/vitest-config build`
4. Run the following commands to verify the fix:
   - `pnpm test` - Should run tests using Turborepo (with caching)
   - `pnpm test:projects` - Should run tests using Vitest's projects feature directly
   - `pnpm test:projects:watch` - Should run tests in watch mode using Vitest's projects feature
5. Verify that `test` and `test:projects` now have different behaviors as intended
