### PR TITLE
feat: allow Watch Mode with `--root-turbo-json`

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1442,7 +1442,9 @@ pub async fn run(
             event.track_ui_mode(base.opts.run_opts.ui_mode);
 
             match command {
-                Some(command) => daemon::daemon_client(command, &base).await,
+                Some(command) => {
+                    daemon::daemon_client(command, &base, turbo_json_path.as_deref()).await
+                }
                 None => {
                     daemon::daemon_server(&base, idle_time, turbo_json_path.as_deref(), logger)
                         .await

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1443,11 +1443,10 @@ pub async fn run(
 
             match command {
                 Some(command) => {
-                    daemon::daemon_client(command, &base, turbo_json_path.as_deref()).await
+                    daemon::daemon_client(command, &base, turbo_json_path.clone()).await
                 }
                 None => {
-                    daemon::daemon_server(&base, idle_time, turbo_json_path.as_deref(), logger)
-                        .await
+                    daemon::daemon_server(&base, idle_time, turbo_json_path.clone(), logger).await
                 }
             }?;
 

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -611,7 +611,7 @@ pub enum Command {
         /// Set the idle timeout for turbod
         #[clap(long, default_value_t = String::from("4h0m0s"))]
         idle_time: String,
-        /// Path to a custom turbo.json file to watch
+        /// Path to a custom turbo.json file to watch from --root-turbo-json
         #[clap(long)]
         turbo_json_path: Option<Utf8PathBuf>,
         #[clap(subcommand)]

--- a/crates/turborepo-lib/src/commands/daemon.rs
+++ b/crates/turborepo-lib/src/commands/daemon.rs
@@ -47,7 +47,7 @@ fn convert_turbo_json_path(
 pub async fn daemon_client(
     command: &DaemonCommand,
     base: &CommandBase,
-    custom_turbo_json_path: Option<&camino::Utf8Path>,
+    custom_turbo_json_path: Option<camino::Utf8PathBuf>,
 ) -> Result<(), DaemonError> {
     let (can_start_server, can_kill_server) = match command {
         DaemonCommand::Status { .. } | DaemonCommand::Logs => (false, false),
@@ -56,7 +56,7 @@ pub async fn daemon_client(
         DaemonCommand::Clean { .. } => (false, true),
     };
 
-    let custom_turbo_json_path = convert_turbo_json_path(custom_turbo_json_path)?;
+    let custom_turbo_json_path = convert_turbo_json_path(custom_turbo_json_path.as_deref())?;
 
     let connector = DaemonConnector::new(
         can_start_server,
@@ -305,7 +305,7 @@ fn log_filename(base_filename: &str) -> Result<String, time::Error> {
 pub async fn daemon_server(
     base: &CommandBase,
     idle_time: &String,
-    turbo_json_path: Option<&camino::Utf8Path>,
+    turbo_json_path: Option<camino::Utf8PathBuf>,
     logging: &TurboSubscriber,
 ) -> Result<(), DaemonError> {
     let paths = Paths::from_repo_root(&base.repo_root);
@@ -329,7 +329,7 @@ pub async fn daemon_server(
         }
         CloseReason::Interrupt
     });
-    let custom_turbo_json_path = convert_turbo_json_path(turbo_json_path)?;
+    let custom_turbo_json_path = convert_turbo_json_path(turbo_json_path.as_deref())?;
     let server = crate::daemon::TurboGrpcService::new(
         base.repo_root.clone(),
         paths,

--- a/crates/turborepo-lib/src/commands/daemon.rs
+++ b/crates/turborepo-lib/src/commands/daemon.rs
@@ -33,7 +33,7 @@ pub async fn daemon_client(command: &DaemonCommand, base: &CommandBase) -> Resul
         DaemonCommand::Clean { .. } => (false, true),
     };
 
-    let connector = DaemonConnector::new(can_start_server, can_kill_server, &base.repo_root, None);
+    let connector = DaemonConnector::new(can_start_server, can_kill_server, &base.repo_root);
 
     match command {
         DaemonCommand::Restart => {

--- a/crates/turborepo-lib/src/commands/daemon.rs
+++ b/crates/turborepo-lib/src/commands/daemon.rs
@@ -33,12 +33,7 @@ pub async fn daemon_client(command: &DaemonCommand, base: &CommandBase) -> Resul
         DaemonCommand::Clean { .. } => (false, true),
     };
 
-    let connector = DaemonConnector {
-        can_start_server,
-        can_kill_server,
-        paths: crate::daemon::Paths::from_repo_root(&base.repo_root),
-        custom_turbo_json_path: None,
-    };
+    let connector = DaemonConnector::new(can_start_server, can_kill_server, &base.repo_root, None);
 
     match command {
         DaemonCommand::Restart => {

--- a/crates/turborepo-lib/src/commands/info.rs
+++ b/crates/turborepo-lib/src/commands/info.rs
@@ -20,7 +20,12 @@ fn is_wsl() -> bool {
 
 pub async fn run(base: CommandBase) {
     let system = System::new_all();
-    let connector = DaemonConnector::new(false, false, &base.repo_root);
+    let connector = DaemonConnector {
+        can_start_server: false,
+        can_kill_server: false,
+        paths: crate::daemon::Paths::from_repo_root(&base.repo_root),
+        custom_turbo_json_path: None,
+    };
     let daemon_status = match connector.connect().await {
         Ok(_status) => "Running",
         Err(DaemonConnectorError::NotRunning) => "Not running",

--- a/crates/turborepo-lib/src/commands/info.rs
+++ b/crates/turborepo-lib/src/commands/info.rs
@@ -20,7 +20,7 @@ fn is_wsl() -> bool {
 
 pub async fn run(base: CommandBase) {
     let system = System::new_all();
-    let connector = DaemonConnector::new(false, false, &base.repo_root, None);
+    let connector = DaemonConnector::new(false, false, &base.repo_root);
     let daemon_status = match connector.connect().await {
         Ok(_status) => "Running",
         Err(DaemonConnectorError::NotRunning) => "Not running",

--- a/crates/turborepo-lib/src/commands/info.rs
+++ b/crates/turborepo-lib/src/commands/info.rs
@@ -20,12 +20,7 @@ fn is_wsl() -> bool {
 
 pub async fn run(base: CommandBase) {
     let system = System::new_all();
-    let connector = DaemonConnector {
-        can_start_server: false,
-        can_kill_server: false,
-        paths: crate::daemon::Paths::from_repo_root(&base.repo_root),
-        custom_turbo_json_path: None,
-    };
+    let connector = DaemonConnector::new(false, false, &base.repo_root, None);
     let daemon_status = match connector.connect().await {
         Ok(_status) => "Running",
         Err(DaemonConnectorError::NotRunning) => "Not running",

--- a/crates/turborepo-lib/src/commands/info.rs
+++ b/crates/turborepo-lib/src/commands/info.rs
@@ -20,7 +20,7 @@ fn is_wsl() -> bool {
 
 pub async fn run(base: CommandBase) {
     let system = System::new_all();
-    let connector = DaemonConnector::new(false, false, &base.repo_root);
+    let connector = DaemonConnector::new(false, false, &base.repo_root, None);
     let daemon_status = match connector.connect().await {
         Ok(_status) => "Running",
         Err(DaemonConnectorError::NotRunning) => "Not running",

--- a/crates/turborepo-lib/src/daemon/connector.rs
+++ b/crates/turborepo-lib/src/daemon/connector.rs
@@ -75,13 +75,14 @@ impl DaemonConnector {
         can_start_server: bool,
         can_kill_server: bool,
         repo_root: &AbsoluteSystemPath,
+        custom_turbo_json_path: Option<&turbopath::AbsoluteSystemPathBuf>,
     ) -> Self {
         let paths = Paths::from_repo_root(repo_root);
         Self {
             can_start_server,
             can_kill_server,
             paths,
-            custom_turbo_json_path: None,
+            custom_turbo_json_path: custom_turbo_json_path.cloned(),
         }
     }
 

--- a/crates/turborepo-lib/src/daemon/connector.rs
+++ b/crates/turborepo-lib/src/daemon/connector.rs
@@ -29,9 +29,6 @@ pub enum DaemonConnectorError {
     /// The daemon is not running and will not be started.
     #[error("daemon is not running")]
     NotRunning,
-    /// Cannot kill daemon (insufficient permissions).
-    #[error("cannot kill daemon")]
-    CannotKill,
     /// There was an issue connecting to the socket.
     #[error("unable to connect to socket: {0}")]
     Socket(#[from] tonic::transport::Error),

--- a/crates/turborepo-lib/src/daemon/connector.rs
+++ b/crates/turborepo-lib/src/daemon/connector.rs
@@ -75,14 +75,13 @@ impl DaemonConnector {
         can_start_server: bool,
         can_kill_server: bool,
         repo_root: &AbsoluteSystemPath,
-        custom_turbo_json_path: Option<&turbopath::AbsoluteSystemPathBuf>,
     ) -> Self {
         let paths = Paths::from_repo_root(repo_root);
         Self {
             can_start_server,
             can_kill_server,
             paths,
-            custom_turbo_json_path: custom_turbo_json_path.cloned(),
+            custom_turbo_json_path: None,
         }
     }
 
@@ -454,7 +453,7 @@ mod test {
         let tmp_dir = tempfile::tempdir().unwrap();
         let repo_root = AbsoluteSystemPathBuf::try_from(tmp_dir.path()).unwrap();
 
-        let connector = DaemonConnector::new(false, false, &repo_root, None);
+        let connector = DaemonConnector::new(false, false, &repo_root);
         connector.paths.pid_file.ensure_dir().unwrap();
         connector
             .paths
@@ -472,7 +471,7 @@ mod test {
     async fn handles_missing_server_connect() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let repo_root = AbsoluteSystemPathBuf::try_from(tmp_dir.path()).unwrap();
-        let connector = DaemonConnector::new(false, false, &repo_root, None);
+        let connector = DaemonConnector::new(false, false, &repo_root);
 
         assert_matches!(
             connector.connect().await,
@@ -484,7 +483,7 @@ mod test {
     async fn handles_kill_dead_server_missing_pid() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let repo_root = AbsoluteSystemPathBuf::try_from(tmp_dir.path()).unwrap();
-        let connector = DaemonConnector::new(false, false, &repo_root, None);
+        let connector = DaemonConnector::new(false, false, &repo_root);
 
         assert_matches!(
             connector.kill_dead_server(Pid::from(usize::MAX)).await,
@@ -496,7 +495,7 @@ mod test {
     async fn handles_kill_dead_server_missing_process() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let repo_root = AbsoluteSystemPathBuf::try_from(tmp_dir.path()).unwrap();
-        let connector = DaemonConnector::new(false, false, &repo_root, None);
+        let connector = DaemonConnector::new(false, false, &repo_root);
 
         connector.paths.pid_file.ensure_dir().unwrap();
         connector
@@ -522,7 +521,7 @@ mod test {
     async fn handles_kill_dead_server_wrong_process() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let repo_root = AbsoluteSystemPathBuf::try_from(tmp_dir.path()).unwrap();
-        let connector = DaemonConnector::new(false, false, &repo_root, None);
+        let connector = DaemonConnector::new(false, false, &repo_root);
 
         let proc = tokio::process::Command::new(NODE_EXE)
             .stdout(Stdio::null())
@@ -559,7 +558,7 @@ mod test {
     async fn handles_kill_dead_server() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let repo_root = AbsoluteSystemPathBuf::try_from(tmp_dir.path()).unwrap();
-        let connector = DaemonConnector::new(false, true, &repo_root, None);
+        let connector = DaemonConnector::new(false, true, &repo_root);
 
         let proc = tokio::process::Command::new(NODE_EXE)
             .stdout(Stdio::null())
@@ -699,7 +698,7 @@ mod test {
 
         let tmp_dir = tempfile::tempdir().unwrap();
         let repo_root = AbsoluteSystemPathBuf::try_from(tmp_dir.path()).unwrap();
-        let connector = DaemonConnector::new(false, false, &repo_root, None);
+        let connector = DaemonConnector::new(false, false, &repo_root);
 
         let mut client = Endpoint::try_from("http://[::]:50051")
             .expect("this is a valid uri")

--- a/crates/turborepo-lib/src/daemon/connector.rs
+++ b/crates/turborepo-lib/src/daemon/connector.rs
@@ -454,12 +454,7 @@ mod test {
         let tmp_dir = tempfile::tempdir().unwrap();
         let repo_root = AbsoluteSystemPathBuf::try_from(tmp_dir.path()).unwrap();
 
-        let connector = DaemonConnector {
-            can_start_server: false,
-            can_kill_server: false,
-            paths: Paths::from_repo_root(&repo_root),
-            custom_turbo_json_path: None,
-        };
+        let connector = DaemonConnector::new(false, false, &repo_root, None);
         connector.paths.pid_file.ensure_dir().unwrap();
         connector
             .paths
@@ -477,12 +472,7 @@ mod test {
     async fn handles_missing_server_connect() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let repo_root = AbsoluteSystemPathBuf::try_from(tmp_dir.path()).unwrap();
-        let connector = DaemonConnector {
-            can_start_server: false,
-            can_kill_server: false,
-            paths: Paths::from_repo_root(&repo_root),
-            custom_turbo_json_path: None,
-        };
+        let connector = DaemonConnector::new(false, false, &repo_root, None);
 
         assert_matches!(
             connector.connect().await,
@@ -494,12 +484,7 @@ mod test {
     async fn handles_kill_dead_server_missing_pid() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let repo_root = AbsoluteSystemPathBuf::try_from(tmp_dir.path()).unwrap();
-        let connector = DaemonConnector {
-            can_start_server: false,
-            can_kill_server: false,
-            paths: Paths::from_repo_root(&repo_root),
-            custom_turbo_json_path: None,
-        };
+        let connector = DaemonConnector::new(false, false, &repo_root, None);
 
         assert_matches!(
             connector.kill_dead_server(Pid::from(usize::MAX)).await,
@@ -511,12 +496,7 @@ mod test {
     async fn handles_kill_dead_server_missing_process() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let repo_root = AbsoluteSystemPathBuf::try_from(tmp_dir.path()).unwrap();
-        let connector = DaemonConnector {
-            can_start_server: false,
-            can_kill_server: false,
-            paths: Paths::from_repo_root(&repo_root),
-            custom_turbo_json_path: None,
-        };
+        let connector = DaemonConnector::new(false, false, &repo_root, None);
 
         connector.paths.pid_file.ensure_dir().unwrap();
         connector
@@ -542,12 +522,7 @@ mod test {
     async fn handles_kill_dead_server_wrong_process() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let repo_root = AbsoluteSystemPathBuf::try_from(tmp_dir.path()).unwrap();
-        let connector = DaemonConnector {
-            can_start_server: false,
-            can_kill_server: false,
-            paths: Paths::from_repo_root(&repo_root),
-            custom_turbo_json_path: None,
-        };
+        let connector = DaemonConnector::new(false, false, &repo_root, None);
 
         let proc = tokio::process::Command::new(NODE_EXE)
             .stdout(Stdio::null())
@@ -584,12 +559,7 @@ mod test {
     async fn handles_kill_dead_server() {
         let tmp_dir = tempfile::tempdir().unwrap();
         let repo_root = AbsoluteSystemPathBuf::try_from(tmp_dir.path()).unwrap();
-        let connector = DaemonConnector {
-            can_start_server: false,
-            can_kill_server: true,
-            paths: Paths::from_repo_root(&repo_root),
-            custom_turbo_json_path: None,
-        };
+        let connector = DaemonConnector::new(false, true, &repo_root, None);
 
         let proc = tokio::process::Command::new(NODE_EXE)
             .stdout(Stdio::null())
@@ -729,12 +699,7 @@ mod test {
 
         let tmp_dir = tempfile::tempdir().unwrap();
         let repo_root = AbsoluteSystemPathBuf::try_from(tmp_dir.path()).unwrap();
-        let connector = DaemonConnector {
-            can_start_server: false,
-            can_kill_server: false,
-            paths: Paths::from_repo_root(&repo_root),
-            custom_turbo_json_path: None,
-        };
+        let connector = DaemonConnector::new(false, false, &repo_root, None);
 
         let mut client = Endpoint::try_from("http://[::]:50051")
             .expect("this is a valid uri")

--- a/crates/turborepo-lib/src/daemon/connector.rs
+++ b/crates/turborepo-lib/src/daemon/connector.rs
@@ -148,7 +148,8 @@ impl DaemonConnector {
         ))
     }
 
-    /// Gets or starts a daemon process, returning its PID.
+    /// Gets the PID of the daemon process.
+    ///
     /// If a daemon is not running, it starts one.
     async fn get_or_start_daemon(&self) -> Result<sysinfo::Pid, DaemonConnectorError> {
         debug!("looking for pid in lockfile: {:?}", self.paths.pid_file);

--- a/crates/turborepo-lib/src/daemon/server.rs
+++ b/crates/turborepo-lib/src/daemon/server.rs
@@ -67,6 +67,7 @@ pub struct FileWatching {
     pub package_watcher: Arc<PackageWatcher>,
     pub package_changes_watcher: OnceLock<Arc<PackageChangesWatcher>>,
     pub hash_watcher: Arc<HashWatcher>,
+    custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
 }
 
 #[derive(Debug, Error)]
@@ -111,7 +112,10 @@ impl FileWatching {
     /// waiting for the filewatcher to be ready. Using `OptionalWatch`,
     /// dependent services can wait for resources they need to become
     /// available, and the server can start up without waiting for them.
-    pub fn new(repo_root: AbsoluteSystemPathBuf) -> Result<FileWatching, WatchError> {
+    pub fn new(
+        repo_root: AbsoluteSystemPathBuf,
+        custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
+    ) -> Result<FileWatching, WatchError> {
         let watcher = Arc::new(FileSystemWatcher::new_with_default_cookie_dir(&repo_root)?);
         let recv = watcher.watch();
 
@@ -144,6 +148,7 @@ impl FileWatching {
             package_watcher,
             package_changes_watcher: OnceLock::new(),
             hash_watcher,
+            custom_turbo_json_path,
         })
     }
 
@@ -155,6 +160,7 @@ impl FileWatching {
                     self.repo_root.clone(),
                     recv,
                     self.hash_watcher.clone(),
+                    self.custom_turbo_json_path.clone(),
                 ))
             })
             .clone()
@@ -169,6 +175,7 @@ pub struct TurboGrpcService<S> {
     paths: Paths,
     timeout: Duration,
     external_shutdown: S,
+    custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
 }
 
 impl<S> TurboGrpcService<S>
@@ -186,6 +193,7 @@ where
         paths: Paths,
         timeout: Duration,
         external_shutdown: S,
+        custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
     ) -> Self {
         // Run the actual service. It takes ownership of the struct given to it,
         // so we use a private struct with just the pieces of state needed to handle
@@ -195,6 +203,7 @@ where
             paths,
             timeout,
             external_shutdown,
+            custom_turbo_json_path,
         }
     }
 
@@ -204,6 +213,7 @@ where
             paths,
             repo_root,
             timeout,
+            custom_turbo_json_path,
         } = self;
 
         // A channel to trigger the shutdown of the gRPC server. This is handed out
@@ -211,8 +221,12 @@ where
         // well as available to the gRPC server itself to handle the shutdown RPC.
         let (trigger_shutdown, mut shutdown_signal) = mpsc::channel::<()>(1);
 
-        let (service, exit_root_watch, watch_root_handle) =
-            TurboGrpcServiceInner::new(repo_root.clone(), trigger_shutdown, paths.log_file);
+        let (service, exit_root_watch, watch_root_handle) = TurboGrpcServiceInner::new(
+            repo_root.clone(),
+            trigger_shutdown,
+            paths.log_file,
+            custom_turbo_json_path,
+        );
 
         let running = Arc::new(AtomicBool::new(true));
         let (_pid_lock, stream) =
@@ -290,12 +304,13 @@ impl TurboGrpcServiceInner {
         repo_root: AbsoluteSystemPathBuf,
         trigger_shutdown: mpsc::Sender<()>,
         log_file: AbsoluteSystemPathBuf,
+        custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
     ) -> (
         Self,
         oneshot::Sender<()>,
         JoinHandle<Result<(), WatchError>>,
     ) {
-        let file_watching = FileWatching::new(repo_root.clone()).unwrap();
+        let file_watching = FileWatching::new(repo_root.clone(), custom_turbo_json_path).unwrap();
 
         tracing::debug!("initing package discovery");
         // Note that we're cloning the Arc, not the package watcher itself
@@ -778,6 +793,7 @@ mod test {
             paths.clone(),
             Duration::from_secs(60 * 60),
             exit_signal,
+            None,
         );
 
         // the package watcher reads data from the package.json file
@@ -835,6 +851,7 @@ mod test {
             paths.clone(),
             Duration::from_millis(10),
             exit_signal,
+            None,
         );
 
         // the package watcher reads data from the package.json file
@@ -892,6 +909,7 @@ mod test {
             paths,
             Duration::from_secs(60 * 60),
             exit_signal,
+            None,
         );
 
         let handle = tokio::task::spawn(server.serve());

--- a/crates/turborepo-lib/src/diagnostics.rs
+++ b/crates/turborepo-lib/src/diagnostics.rs
@@ -317,6 +317,7 @@ impl Diagnostic for DaemonDiagnostic {
                 can_kill_server: false,
                 can_start_server: true,
                 paths,
+                custom_turbo_json_path: None,
             };
 
             let mut client = match connector.connect().await {

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -297,19 +297,8 @@ impl Subscriber {
                             self.changed_files.lock().await.borrow_mut().deref_mut()
                         {
                             for path in paths {
-                                if let Some(path_str) = path.to_str() {
-                                    if let Some(ref custom_path) = self.custom_turbo_json_path {
-                                        if path_str == custom_path.as_str()
-                                            || path_str.ends_with("turbo.json")
-                                            || path_str.ends_with("turbo.jsonc")
-                                        {
-                                            tracing::info!(
-                                                "File watcher detected change: {}",
-                                                path_str
-                                            );
-                                        }
-                                    }
-                                    trie.insert(path_str.to_string(), ());
+                                if let Some(path) = path.to_str() {
+                                    trie.insert(path.to_string(), ());
                                 }
                             }
                         }
@@ -409,21 +398,7 @@ impl Subscriber {
                     .as_ref()
                     .map(|path| {
                         let path_str = path.as_str();
-                        let found = trie.get(path_str).is_some();
-                        tracing::debug!(
-                            "Checking custom turbo.json path '{}' in trie, found: {}",
-                            path_str,
-                            found
-                        );
-                        if !found {
-                            // Also try with the path keys for debugging
-                            let trie_keys: Vec<_> = trie.keys().take(10).collect();
-                            tracing::debug!(
-                                "Trie contains these paths (first 10): {:?}",
-                                trie_keys
-                            );
-                        }
-                        found
+                        trie.get(path_str).is_some()
                     })
                     .unwrap_or(false);
 

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -217,9 +217,9 @@ impl Subscriber {
             match resolve_turbo_config_path(&self.repo_root) {
                 Ok(path) => path,
                 Err(_) => {
-                    // TODO: caIf both turbo.json and turbo.jsonc exist, log warning and default to
+                    // TODO: If both turbo.json and turbo.jsonc exist, log warning and default to
                     // turbo.json to preserve existing behavior for file
-                    // watching
+                    // watching prior to refactoring.
                     tracing::warn!(
                         "Found both turbo.json and turbo.jsonc in {}. Using turbo.json for \
                          watching.",

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -288,7 +288,6 @@ impl Subscriber {
                         {
                             for path in paths {
                                 if let Some(path_str) = path.to_str() {
-                                    // Log file changes for custom turbo.json debugging
                                     if let Some(ref custom_path) = self.custom_turbo_json_path {
                                         if path_str == custom_path.as_str()
                                             || path_str.ends_with("turbo.json")

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -159,7 +159,7 @@ impl Subscriber {
             if repo_root.anchor(&path).is_err() {
                 tracing::warn!(
                     "turbo.json is located outside of repository at {}. Changes to this file will \
-                     not be watched and may not trigger rebuilds in watch mode.",
+                     not be watched.",
                     path
                 );
             }

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -152,26 +152,25 @@ impl Subscriber {
         custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
     ) -> Self {
         // Try to canonicalize the custom path to match what the file watcher reports
-        let normalized_custom_path =
-            custom_turbo_json_path.and_then(|path| match path.to_realpath() {
-                Ok(real_path) => {
-                    tracing::info!(
-                        "PackageChangesWatcher: monitoring custom turbo.json at: {} \
-                         (canonicalized: {})",
-                        path,
-                        real_path
-                    );
-                    Some(real_path)
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "Failed to canonicalize custom turbo.json path {}: {}, using original path",
-                        path,
-                        e
-                    );
-                    Some(path)
-                }
-            });
+        let normalized_custom_path = custom_turbo_json_path.map(|path| match path.to_realpath() {
+            Ok(real_path) => {
+                tracing::info!(
+                    "PackageChangesWatcher: monitoring custom turbo.json at: {} (canonicalized: \
+                     {})",
+                    path,
+                    real_path
+                );
+                real_path
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to canonicalize custom turbo.json path {}: {}, using original path",
+                    path,
+                    e
+                );
+                path
+            }
+        });
 
         Subscriber {
             repo_root,

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -262,8 +262,12 @@ impl RunBuilder {
             (_, Some(true)) | (false, None) => {
                 let can_start_server = true;
                 let can_kill_server = true;
-                let connector =
-                    DaemonConnector::new(can_start_server, can_kill_server, &self.repo_root);
+                let connector = DaemonConnector {
+                    can_start_server,
+                    can_kill_server,
+                    paths: crate::daemon::Paths::from_repo_root(&self.repo_root),
+                    custom_turbo_json_path: None,
+                };
                 match (connector.connect().await, self.opts.run_opts.daemon) {
                     (Ok(client), _) => {
                         run_telemetry.track_daemon_init(DaemonInitStatus::Started);

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -262,8 +262,12 @@ impl RunBuilder {
             (_, Some(true)) | (false, None) => {
                 let can_start_server = true;
                 let can_kill_server = true;
-                let connector =
-                    DaemonConnector::new(can_start_server, can_kill_server, &self.repo_root);
+                let connector = DaemonConnector::new(
+                    can_start_server,
+                    can_kill_server,
+                    &self.repo_root,
+                    Some(self.opts.repo_opts.root_turbo_json_path.clone()),
+                );
                 match (connector.connect().await, self.opts.run_opts.daemon) {
                     (Ok(client), _) => {
                         run_telemetry.track_daemon_init(DaemonInitStatus::Started);

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -262,12 +262,8 @@ impl RunBuilder {
             (_, Some(true)) | (false, None) => {
                 let can_start_server = true;
                 let can_kill_server = true;
-                let connector = DaemonConnector {
-                    can_start_server,
-                    can_kill_server,
-                    paths: crate::daemon::Paths::from_repo_root(&self.repo_root),
-                    custom_turbo_json_path: None,
-                };
+                let connector =
+                    DaemonConnector::new(can_start_server, can_kill_server, &self.repo_root, None);
                 match (connector.connect().await, self.opts.run_opts.daemon) {
                     (Ok(client), _) => {
                         run_telemetry.track_daemon_init(DaemonInitStatus::Started);

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -263,7 +263,7 @@ impl RunBuilder {
                 let can_start_server = true;
                 let can_kill_server = true;
                 let connector =
-                    DaemonConnector::new(can_start_server, can_kill_server, &self.repo_root, None);
+                    DaemonConnector::new(can_start_server, can_kill_server, &self.repo_root);
                 match (connector.connect().await, self.opts.run_opts.daemon) {
                     (Ok(client), _) => {
                         run_telemetry.track_daemon_init(DaemonInitStatus::Started);

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -103,7 +103,6 @@ pub enum Error {
     UI(#[from] turborepo_ui::Error),
     #[error("Could not connect to UI thread: {0}")]
     UISend(String),
-
     #[error("Invalid config: {0}")]
     Config(#[from] crate::config::Error),
     #[error(transparent)]
@@ -120,9 +119,6 @@ impl WatchClient {
         let handler = SignalHandler::new(signal);
 
         let standard_config_path = resolve_turbo_config_path(&base.repo_root)?;
-
-        // Note: We now support watching custom turbo.json paths, so this check is
-        // removed
 
         if matches!(base.opts.run_opts.daemon, Some(false)) {
             warn!("daemon is required for watch, ignoring request to disable daemon");

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -135,26 +135,25 @@ impl WatchClient {
 
         let (ui_sender, ui_handle) = run.start_ui()?.unzip();
 
-        let mut connector = DaemonConnector {
+        // Determine if we're using a custom turbo.json path
+        let custom_turbo_json_path =
+            if base.opts.repo_opts.root_turbo_json_path != standard_config_path {
+                tracing::info!(
+                    "Using custom turbo.json path: {} (standard: {})",
+                    base.opts.repo_opts.root_turbo_json_path,
+                    standard_config_path
+                );
+                Some(base.opts.repo_opts.root_turbo_json_path.clone())
+            } else {
+                None
+            };
+
+        let connector = DaemonConnector {
             can_start_server: true,
             can_kill_server: true,
             paths: DaemonPaths::from_repo_root(&base.repo_root),
-            custom_turbo_json_path: None,
+            custom_turbo_json_path,
         };
-
-        // If using a non-standard turbo.json path, pass it to the daemon
-        if base.opts.repo_opts.root_turbo_json_path != standard_config_path {
-            tracing::info!(
-                "Using custom turbo.json path: {} (standard: {})",
-                base.opts.repo_opts.root_turbo_json_path,
-                standard_config_path
-            );
-            // The root_turbo_json_path is already an AbsoluteSystemPathBuf, so use it
-            // directly
-            let custom_path = base.opts.repo_opts.root_turbo_json_path.clone();
-            tracing::info!("Passing custom turbo.json path to daemon: {}", custom_path);
-            connector = connector.with_custom_turbo_json_path(custom_path);
-        }
 
         Ok(Self {
             base,

--- a/crates/turborepo-lsp/src/lib.rs
+++ b/crates/turborepo-lsp/src/lib.rs
@@ -85,8 +85,12 @@ impl LanguageServer for Backend {
                     || {
                         let can_start_server = true;
                         let can_kill_server = false;
-                        let connector =
-                            DaemonConnector::new(can_start_server, can_kill_server, &repo_root);
+                        let connector = DaemonConnector {
+                            can_start_server,
+                            can_kill_server,
+                            paths: DaemonPaths::from_repo_root(&repo_root),
+                            custom_turbo_json_path: None,
+                        };
                         connector.connect()
                     },
                 )

--- a/crates/turborepo-lsp/src/lib.rs
+++ b/crates/turborepo-lsp/src/lib.rs
@@ -85,12 +85,12 @@ impl LanguageServer for Backend {
                     || {
                         let can_start_server = true;
                         let can_kill_server = false;
-                        let connector = DaemonConnector {
+                        let connector = DaemonConnector::new(
                             can_start_server,
                             can_kill_server,
-                            paths: DaemonPaths::from_repo_root(&repo_root),
-                            custom_turbo_json_path: None,
-                        };
+                            &repo_root,
+                            None,
+                        );
                         connector.connect()
                     },
                 )

--- a/crates/turborepo-lsp/src/lib.rs
+++ b/crates/turborepo-lsp/src/lib.rs
@@ -85,8 +85,12 @@ impl LanguageServer for Backend {
                     || {
                         let can_start_server = true;
                         let can_kill_server = false;
-                        let connector =
-                            DaemonConnector::new(can_start_server, can_kill_server, &repo_root);
+                        let connector = DaemonConnector::new(
+                            can_start_server,
+                            can_kill_server,
+                            &repo_root,
+                            None,
+                        );
                         connector.connect()
                     },
                 )

--- a/crates/turborepo-lsp/src/lib.rs
+++ b/crates/turborepo-lsp/src/lib.rs
@@ -85,12 +85,8 @@ impl LanguageServer for Backend {
                     || {
                         let can_start_server = true;
                         let can_kill_server = false;
-                        let connector = DaemonConnector::new(
-                            can_start_server,
-                            can_kill_server,
-                            &repo_root,
-                            None,
-                        );
+                        let connector =
+                            DaemonConnector::new(can_start_server, can_kill_server, &repo_root);
                         connector.connect()
                     },
                 )


### PR DESCRIPTION
### Description

Unblock Watch Mode from being used with `--root-turbo-json`. 

### Testing Instructions

I tested this manually by using `turbo watch lint --root-turbo-json=./some-dir/turbo.json` in a `create-turbo` and changing that file. The tasks would be picked up and re-ran the same as if I omitted the `--root-turbo-json` and used a standard path.

I also tried it with a JSONC and it worked.
