### PR TITLE
fix(examples): add missing extension to with-react-native-web ui tsconfig

### DIFF
--- a/examples/with-react-native-web/packages/ui/tsconfig.json
+++ b/examples/with-react-native-web/packages/ui/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@repo/typescript-config/react-native-library",
+  "extends": "@repo/typescript-config/react-native-library.json",
   "include": ["."],
   "exclude": ["dist", "build", "node_modules"],
   "compilerOptions": {


### PR DESCRIPTION
### Description

- `examples/with-react-native-web/packages/ui/tsconfig.json` extends `react-native-library`.
- There was missing `.json`

### Testing Instructions

- Happy CI
- Run 
  - `pnpm dlx create-turbo@latest --example https://github.com/Franck-Fernandez-pro/turborepo/tree/main/examples/with-react-native-web`
  - `pnpm i`
  - `pnpm dev`
- Your app should run without errors