### PR TITLE
chore: fix lints in tests

### DIFF
--- a/crates/turborepo-analytics/src/lib.rs
+++ b/crates/turborepo-analytics/src/lib.rs
@@ -456,10 +456,9 @@ mod tests {
             _events: Vec<AnalyticsEvent>,
         ) -> Result<(), turborepo_api_client::Error> {
             // Simulate an error using a simple error type
-            Err(turborepo_api_client::Error::ReadError(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "test error",
-            )))
+            Err(turborepo_api_client::Error::ReadError(
+                std::io::Error::other("test error"),
+            ))
         }
     }
 }

--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -793,7 +793,7 @@ mod test {
     async fn test_do_preflight() -> Result<()> {
         let port = port_scanner::request_open_port().unwrap();
         let handle = tokio::spawn(start_test_server(port));
-        let base_url = format!("http://localhost:{}", port);
+        let base_url = format!("http://localhost:{port}");
 
         let client = APIClient::new(
             &base_url,
@@ -806,7 +806,7 @@ mod test {
         let response = client
             .do_preflight(
                 "",
-                Url::parse(&format!("{}/preflight/absolute-location", base_url)).unwrap(),
+                Url::parse(&format!("{base_url}/preflight/absolute-location")).unwrap(),
                 "GET",
                 "Authorization, User-Agent",
             )
@@ -817,7 +817,7 @@ mod test {
         let response = client
             .do_preflight(
                 "",
-                Url::parse(&format!("{}/preflight/relative-location", base_url)).unwrap(),
+                Url::parse(&format!("{base_url}/preflight/relative-location")).unwrap(),
                 "GET",
                 "Authorization, User-Agent",
             )
@@ -830,7 +830,7 @@ mod test {
         let response = client
             .do_preflight(
                 "",
-                Url::parse(&format!("{}/preflight/allow-auth", base_url)).unwrap(),
+                Url::parse(&format!("{base_url}/preflight/allow-auth")).unwrap(),
                 "GET",
                 "Authorization, User-Agent",
             )
@@ -841,7 +841,7 @@ mod test {
         let response = client
             .do_preflight(
                 "",
-                Url::parse(&format!("{}/preflight/no-allow-auth", base_url)).unwrap(),
+                Url::parse(&format!("{base_url}/preflight/no-allow-auth")).unwrap(),
                 "GET",
                 "Authorization, User-Agent",
             )
@@ -882,7 +882,7 @@ mod test {
     async fn test_content_length() -> Result<()> {
         let port = port_scanner::request_open_port().unwrap();
         let handle = tokio::spawn(start_test_server(port));
-        let base_url = format!("http://localhost:{}", port);
+        let base_url = format!("http://localhost:{port}");
 
         let client = APIClient::new(
             &base_url,
@@ -917,7 +917,7 @@ mod test {
     async fn test_record_telemetry_success() -> Result<()> {
         let port = port_scanner::request_open_port().unwrap();
         let handle = tokio::spawn(start_test_server(port));
-        let base_url = format!("http://localhost:{}", port);
+        let base_url = format!("http://localhost:{port}");
 
         let client = AnonAPIClient::new(&base_url, 10, "2.0.0")?;
 
@@ -952,7 +952,7 @@ mod test {
     async fn test_record_telemetry_empty_events() -> Result<()> {
         let port = port_scanner::request_open_port().unwrap();
         let handle = tokio::spawn(start_test_server(port));
-        let base_url = format!("http://localhost:{}", port);
+        let base_url = format!("http://localhost:{port}");
 
         let client = AnonAPIClient::new(&base_url, 10, "2.0.0")?;
 
@@ -974,7 +974,7 @@ mod test {
     async fn test_record_telemetry_with_different_event_types() -> Result<()> {
         let port = port_scanner::request_open_port().unwrap();
         let handle = tokio::spawn(start_test_server(port));
-        let base_url = format!("http://localhost:{}", port);
+        let base_url = format!("http://localhost:{port}");
 
         let client = AnonAPIClient::new(&base_url, 10, "2.0.0")?;
 

--- a/crates/turborepo-auth/src/lib.rs
+++ b/crates/turborepo-auth/src/lib.rs
@@ -377,8 +377,7 @@ mod tests {
             assert_eq!(
                 is_token_active(&metadata, current_time),
                 expected,
-                "Test failed for active_at: {}",
-                active_at
+                "Test failed for active_at: {active_at}"
             );
         }
     }

--- a/crates/turborepo-cache/src/async_cache.rs
+++ b/crates/turborepo-cache/src/async_cache.rs
@@ -274,7 +274,7 @@ mod tests {
         };
 
         let api_client = APIClient::new(
-            format!("http://localhost:{}", port),
+            format!("http://localhost:{port}"),
             Some(Duration::from_secs(200)),
             None,
             "2.0.0",
@@ -311,7 +311,7 @@ mod tests {
         async_cache.wait().await.unwrap();
 
         let fs_cache_path =
-            repo_root_path.join_components(&[".turbo", "cache", &format!("{}.tar.zst", hash)]);
+            repo_root_path.join_components(&[".turbo", "cache", &format!("{hash}.tar.zst")]);
 
         // Confirm that fs cache file does *not* exist
         assert!(!fs_cache_path.exists());
@@ -402,7 +402,7 @@ mod tests {
         async_cache.wait().await.unwrap();
 
         let fs_cache_path =
-            repo_root_path.join_components(&[".turbo", "cache", &format!("{}.tar.zst", hash)]);
+            repo_root_path.join_components(&[".turbo", "cache", &format!("{hash}.tar.zst")]);
 
         // Confirm that fs cache file exists
         assert!(fs_cache_path.exists());
@@ -462,7 +462,7 @@ mod tests {
         };
 
         let api_client = APIClient::new(
-            format!("http://localhost:{}", port),
+            format!("http://localhost:{port}"),
             Some(Duration::from_secs(200)),
             None,
             "2.0.0",
@@ -499,7 +499,7 @@ mod tests {
         async_cache.wait().await.unwrap();
 
         let fs_cache_path =
-            repo_root_path.join_components(&[".turbo", "cache", &format!("{}.tar.zst", hash)]);
+            repo_root_path.join_components(&[".turbo", "cache", &format!("{hash}.tar.zst")]);
 
         // Confirm that fs cache file exists
         assert!(fs_cache_path.exists());

--- a/crates/turborepo-cache/src/cache_archive/restore.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore.rs
@@ -283,7 +283,7 @@ mod tests {
     fn compress_tar(archive_path: &AbsoluteSystemPathBuf) -> Result<AbsoluteSystemPathBuf> {
         let mut input_file = File::open(archive_path)?;
 
-        let output_file_path = format!("{}.zst", archive_path);
+        let output_file_path = format!("{archive_path}.zst");
         let output_file = File::create(&output_file_path)?;
 
         let mut zw = zstd::stream::Encoder::new(output_file, 0)?;
@@ -883,10 +883,7 @@ mod tests {
 
                 match (cache_reader.restore(anchor), &test.expected_output) {
                     (Ok(restored_files), Err(expected_error)) => {
-                        panic!(
-                            "expected error: {:?}, received {:?}",
-                            expected_error, restored_files
-                        );
+                        panic!("expected error: {expected_error:?}, received {restored_files:?}");
                     }
                     (Ok(restored_files), Ok(expected_files)) => {
                         assert_eq!(&restored_files, expected_files);
@@ -896,7 +893,7 @@ mod tests {
                         continue;
                     }
                     (Err(err), Ok(_)) => {
-                        panic!("unexpected error: {:?}", err);
+                        panic!("unexpected error: {err:?}");
                     }
                 };
 

--- a/crates/turborepo-cache/src/fs.rs
+++ b/crates/turborepo-cache/src/fs.rs
@@ -211,7 +211,7 @@ mod test {
         test_case.initialize(repo_root_path)?;
 
         let api_client = APIClient::new(
-            format!("http://localhost:{}", port),
+            format!("http://localhost:{port}"),
             Some(Duration::from_secs(200)),
             None,
             "2.0.0",

--- a/crates/turborepo-cache/src/http.rs
+++ b/crates/turborepo-cache/src/http.rs
@@ -331,7 +331,7 @@ mod test {
         let duration = test_case.duration;
 
         let api_client = APIClient::new(
-            format!("http://localhost:{}", port),
+            format!("http://localhost:{port}"),
             Some(Duration::from_secs(200)),
             None,
             "2.0.0",

--- a/crates/turborepo-cache/src/test_cases.rs
+++ b/crates/turborepo-cache/src/test_cases.rs
@@ -68,13 +68,13 @@ pub(crate) async fn validate_analytics(
     source: analytics::CacheSource,
     port: u16,
 ) -> Result<()> {
-    let response = reqwest::get(format!("http://localhost:{}/v8/artifacts/events", port)).await?;
+    let response = reqwest::get(format!("http://localhost:{port}/v8/artifacts/events")).await?;
     assert_eq!(response.status(), 200);
     let analytics_events: Vec<AnalyticsEvent> = response.json().await?;
 
     assert_eq!(analytics_events.len(), test_cases.len() * 2);
 
-    println!("{:#?}", analytics_events);
+    println!("{analytics_events:#?}");
     for test_case in test_cases {
         println!("finding {}", test_case.hash);
         // We should have a hit and a miss event for both test cases

--- a/crates/turborepo-filewatch/src/fsevent.rs
+++ b/crates/turborepo-filewatch/src/fsevent.rs
@@ -549,11 +549,11 @@ unsafe fn callback_impl(
         let raw_path = unsafe { CStr::from_ptr(*event_paths.add(p)) }
             .to_str()
             .expect("Invalid UTF8 string.");
-        let path = PathBuf::from(format!("/{}", raw_path));
+        let path = PathBuf::from(format!("/{raw_path}"));
 
         let flag = unsafe { *event_flags.add(p) };
         let flag = StreamFlags::from_bits(flag).unwrap_or_else(|| {
-            panic!("Unable to decode StreamFlags: {}", flag);
+            panic!("Unable to decode StreamFlags: {flag}");
         });
 
         let mut handle_event = false;
@@ -602,7 +602,7 @@ impl Watcher for FsEventWatcher {
         let (tx, rx) = std::sync::mpsc::channel();
         self.configure_raw_mode(config, tx);
         rx.recv()
-            .map_err(|err| Error::generic(&format!("internal channel disconnect: {:?}", err)))?
+            .map_err(|err| Error::generic(&format!("internal channel disconnect: {err:?}")))?
     }
 
     fn kind() -> WatcherKind {

--- a/crates/turborepo-filewatch/src/hash_watcher.rs
+++ b/crates/turborepo-filewatch/src/hash_watcher.rs
@@ -714,11 +714,7 @@ mod tests {
             &repo.signature().unwrap(),
             "Commit",
             &tree,
-            previous_commit
-                .as_ref()
-                .as_ref()
-                .map(std::slice::from_ref)
-                .unwrap_or_default(),
+            previous_commit.as_ref().as_slice(),
         )
         .unwrap();
     }
@@ -1037,10 +1033,7 @@ mod tests {
             }
             tokio::time::sleep(Duration::from_millis(200)).await;
         }
-        panic!(
-            "failed to get expected hashes. Error {:?}, last hashes: {:?}",
-            error, last_value
-        );
+        panic!("failed to get expected hashes. Error {error:?}, last hashes: {last_value:?}");
     }
 
     fn make_expected(expected: Vec<(&str, &str)>) -> GitHashes {

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -527,7 +527,7 @@ mod test {
     ) {
         for dir in dirs {
             let count = WATCH_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            let filename = dir.join_component(format!("test-{}", count).as_str());
+            let filename = dir.join_component(format!("test-{count}").as_str());
             filename.create_with_contents("hello").unwrap();
 
             expect_filesystem_event!(recv, filename, EventKind::Create(_));

--- a/crates/turborepo-globwalk/src/lib.rs
+++ b/crates/turborepo-globwalk/src/lib.rs
@@ -548,7 +548,7 @@ mod test {
         include_exp: Option<&[&str]>,
         exclude_exp: Option<&[&str]>,
     ) {
-        let raw_path = format!("{}{}", ROOT, base_path);
+        let raw_path = format!("{ROOT}{base_path}");
         let base_path = AbsoluteSystemPathBuf::new(raw_path).unwrap();
         let include = include.iter().map(|s| s.to_string()).collect_vec();
         let exclude = exclude.iter().map(|s| s.to_string()).collect_vec();
@@ -568,7 +568,7 @@ mod test {
                 include,
                 include_exp
                     .iter()
-                    .map(|s| format!("{}{}", GLOB_ROOT, s))
+                    .map(|s| format!("{GLOB_ROOT}{s}"))
                     .collect_vec()
                     .as_slice()
             );
@@ -579,7 +579,7 @@ mod test {
                 exclude,
                 exclude_exp
                     .iter()
-                    .map(|s| format!("{}{}", GLOB_ROOT, s))
+                    .map(|s| format!("{GLOB_ROOT}{s}"))
                     .collect_vec()
                     .as_slice()
             );
@@ -751,10 +751,7 @@ mod test {
         assert_eq!(
             success.len(),
             result_count,
-            "{}: expected {} matches, but got {:#?}",
-            pattern,
-            result_count,
-            success
+            "{pattern}: expected {result_count} matches, but got {success:#?}"
         );
 
         None
@@ -1395,8 +1392,7 @@ mod test {
 
             assert_eq!(
                 success, expected,
-                "\n\n{:?}: expected \n{:#?} but got \n{:#?}",
-                walk_type, expected, success
+                "\n\n{walk_type:?}: expected \n{expected:#?} but got \n{success:#?}"
             );
         }
     }
@@ -1453,7 +1449,7 @@ mod test {
             let path = tmp.path().join(file);
             let parent = path.parent().unwrap();
             std::fs::create_dir_all(parent)
-                .unwrap_or_else(|_| panic!("failed to create {:?}", parent));
+                .unwrap_or_else(|_| panic!("failed to create {parent:?}"));
             std::fs::File::create(path).unwrap();
         }
         tmp

--- a/crates/turborepo-graph-utils/src/lib.rs
+++ b/crates/turborepo-graph-utils/src/lib.rs
@@ -262,7 +262,7 @@ mod test {
         g.add_edge(c, a, ());
 
         let breaks = edges_to_break_cycle(&g);
-        assert_eq!(breaks.len(), 3, "{:?}", breaks);
+        assert_eq!(breaks.len(), 3, "{breaks:?}");
         let mut edges_that_break = HashSet::new();
         for brk in breaks {
             assert_eq!(brk.len(), 1);
@@ -296,7 +296,7 @@ mod test {
         g.add_edge(d, a, ());
 
         let breaks = edges_to_break_cycle(&g);
-        assert_eq!(breaks.len(), 1, "{:?}", breaks);
+        assert_eq!(breaks.len(), 1, "{breaks:?}");
         assert_eq!(
             breaks.into_iter().flatten().exactly_one().unwrap(),
             ("a", "b")
@@ -320,7 +320,7 @@ mod test {
         g.add_edge(c, b, ());
 
         let breaks = edges_to_break_cycle(&g);
-        assert_eq!(breaks.len(), 3, "{:?}", breaks);
+        assert_eq!(breaks.len(), 3, "{breaks:?}");
         let expected_1: HashSet<_> = [("b", "c"), ("a", "c")].iter().copied().collect();
         let expected_2: HashSet<_> = [("b", "c"), ("c", "a")].iter().copied().collect();
         let expected_3: HashSet<_> = [("c", "b"), ("c", "a")].iter().copied().collect();

--- a/crates/turborepo-lib/src/microfrontends.rs
+++ b/crates/turborepo-lib/src/microfrontends.rs
@@ -441,13 +441,7 @@ mod test {
         let result = PackageGraphResult::new(
             HashSet::default(),
             vec![
-                (
-                    "a",
-                    Err(Error::Io(std::io::Error::new(
-                        std::io::ErrorKind::Other,
-                        "something",
-                    ))),
-                ),
+                ("a", Err(Error::Io(std::io::Error::other("something")))),
                 (
                     "b",
                     Err(Error::ChildConfig {

--- a/crates/turborepo-lib/src/shim/parser.rs
+++ b/crates/turborepo-lib/src/shim/parser.rs
@@ -375,7 +375,7 @@ mod test {
                 color,
                 no_color,
                 root_turbo_json: relative_root_turbo_json
-                    .map(|path| AbsoluteSystemPathBuf::from_unknown(&invocation_dir, path)),
+                    .map(|path| AbsoluteSystemPathBuf::from_unknown(invocation_dir, path)),
             }
         }
     }

--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -806,12 +806,10 @@ mod tests {
             (Ok(actual), Ok(expected)) => assert_eq!(actual, expected),
             (Err(actual), Err(expected_msg)) => assert!(
                 actual.to_string().contains(expected_msg),
-                "Expected '{}' to appear in error message: '{}'",
-                expected_msg,
-                actual,
+                "Expected '{expected_msg}' to appear in error message: '{actual}'",
             ),
             (actual, expected) => {
-                panic!("Mismatched result variants: {:?} {:?}", actual, expected)
+                panic!("Mismatched result variants: {actual:?} {expected:?}")
             }
         }
     }
@@ -939,12 +937,10 @@ mod tests {
             (Ok(actual), Ok(expected)) => assert_eq!(actual, expected),
             (Err(actual), Err(expected_msg)) => assert!(
                 actual.to_string().contains(expected_msg),
-                "Expected '{}' to appear in error message: '{}'",
-                expected_msg,
-                actual,
+                "Expected '{expected_msg}' to appear in error message: '{actual}'",
             ),
             (actual, expected) => {
-                panic!("Mismatched result variants: {:?} {:?}", actual, expected)
+                panic!("Mismatched result variants: {actual:?} {expected:?}")
             }
         }
     }

--- a/crates/turborepo-lockfiles/src/yarn1/mod.rs
+++ b/crates/turborepo-lockfiles/src/yarn1/mod.rs
@@ -190,8 +190,7 @@ mod test {
         ] {
             assert!(
                 lockfile.inner.contains_key(key),
-                "missing {} in lockfile",
-                key
+                "missing {key} in lockfile"
             );
         }
     }

--- a/crates/turborepo-paths/src/anchored_system_path_buf.rs
+++ b/crates/turborepo-paths/src/anchored_system_path_buf.rs
@@ -281,7 +281,7 @@ mod tests {
                 assert_eq!(result.as_str(), expected)
             }
             (Err(result), Err(expected)) => assert_eq!(result, expected),
-            (result, expected) => panic!("Expected {:?}, got {:?}", expected, result),
+            (result, expected) => panic!("Expected {expected:?}, got {result:?}"),
         }
     }
 }

--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -912,7 +912,7 @@ mod test {
         let trimmed_out = output_str.trim();
         let trimmed_out = trimmed_out.strip_prefix(EOT).unwrap_or(trimmed_out);
 
-        assert!(trimmed_out.contains(input), "got: {}", trimmed_out);
+        assert!(trimmed_out.contains(input), "got: {trimmed_out}");
 
         let exit = child.wait().await;
         assert_matches!(exit, Some(ChildExit::Finished(Some(0))));
@@ -1089,8 +1089,8 @@ mod test {
         // There are no ordering guarantees so we just check that both logs made it
         let expected_stdout = "hello world";
         let expected_stderr = "hello moon";
-        assert!(output.contains(expected_stdout), "got: {}", output);
-        assert!(output.contains(expected_stderr), "got: {}", output);
+        assert!(output.contains(expected_stdout), "got: {output}");
+        assert!(output.contains(expected_stderr), "got: {output}");
         assert_matches!(exit, Some(ChildExit::Finished(Some(0))));
     }
 
@@ -1136,8 +1136,7 @@ mod test {
         let trimmed_out = trimmed_out.strip_prefix(EOT).unwrap_or(trimmed_out);
         assert!(
             output.ends_with('\n'),
-            "expected newline to be added: {}",
-            output
+            "expected newline to be added: {output}"
         );
         assert_eq!(trimmed_out, "look ma, no newline!");
         assert_matches!(exit, Some(ChildExit::Finished(Some(0))));

--- a/crates/turborepo-process/src/lib.rs
+++ b/crates/turborepo-process/src/lib.rs
@@ -384,8 +384,7 @@ mod test {
         // tasks return proper exit code
         assert!(
             tasks.all(|v| async { v.unwrap() == expected }).await,
-            "not all tasks returned the correct code: {:?}",
-            expected
+            "not all tasks returned the correct code: {expected:?}"
         );
     }
 

--- a/crates/turborepo-repository/src/discovery.rs
+++ b/crates/turborepo-repository/src/discovery.rs
@@ -327,10 +327,7 @@ mod fallback_tests {
     impl PackageDiscovery for MockDiscovery {
         async fn discover_packages(&self) -> Result<DiscoveryResponse, Error> {
             if self.should_fail {
-                Err(Error::Failed(Box::new(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "mock error",
-                ))))
+                Err(Error::Failed(Box::new(std::io::Error::other("mock error"))))
             } else {
                 tokio::time::sleep(Duration::from_millis(100)).await;
                 self.calls.fetch_add(1, Ordering::SeqCst);

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -667,7 +667,7 @@ mod test {
             pkg_graph.transitive_closure(Some(&PackageNode::Workspace(PackageName::Root)));
         assert!(closure.contains(&PackageNode::Root));
         let result = pkg_graph.validate();
-        assert!(result.is_ok(), "expected ok {:?}", result);
+        assert!(result.is_ok(), "expected ok {result:?}");
     }
 
     #[tokio::test]

--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -573,7 +573,7 @@ mod tests {
                 return ancestor.to_owned();
             }
         }
-        panic!("Couldn't find Turborepo root from {}", cwd);
+        panic!("Couldn't find Turborepo root from {cwd}");
     }
 
     #[test]

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -500,11 +500,7 @@ mod tests {
             &repo.signature().unwrap(),
             "Commit",
             &tree,
-            previous_commit
-                .as_ref()
-                .as_ref()
-                .map(std::slice::from_ref)
-                .unwrap_or_default(),
+            previous_commit.as_ref().as_slice(),
         )
         .unwrap()
     }

--- a/crates/turborepo-scm/src/manual.rs
+++ b/crates/turborepo-scm/src/manual.rs
@@ -249,7 +249,7 @@ mod tests {
             .iter()
             .map(|s| AnchoredSystemPathBuf::from_raw(s).unwrap());
         match hash_files(&turbo_root, files, allow_missing) {
-            Err(e) => assert!(want_err, "unexpected error {}", e),
+            Err(e) => assert!(want_err, "unexpected error {e}"),
             Ok(hashes) => assert_eq!(hashes, expected),
         }
     }
@@ -402,10 +402,10 @@ mod tests {
             file_path.ensure_dir().unwrap();
             file_path.create_with_contents(contents).unwrap();
             if let Some(hash) = expected_hash {
-                println!("unix_path: {}", unix_path);
-                println!("unix_pkg_path: {}", unix_pkg_path);
+                println!("unix_path: {unix_path}");
+                println!("unix_pkg_path: {unix_pkg_path}");
                 let unix_pkg_file_path = unix_path.strip_prefix(&unix_pkg_path).unwrap();
-                println!("unix_pkg_file_path: {}", unix_pkg_file_path);
+                println!("unix_pkg_file_path: {unix_pkg_file_path}");
                 expected.insert(unix_pkg_file_path.to_owned(), (*hash).to_owned());
             }
         }

--- a/crates/turborepo-scm/src/package_deps.rs
+++ b/crates/turborepo-scm/src/package_deps.rs
@@ -451,7 +451,7 @@ mod tests {
         commit_all(&repo_root);
         let git = SCM::new(&repo_root);
         let SCM::Git(git) = git else {
-            panic!("expected git, found {:?}", git);
+            panic!("expected git, found {git:?}");
         };
 
         // remove a file

--- a/crates/turborepo-scm/src/status.rs
+++ b/crates/turborepo-scm/src/status.rs
@@ -139,9 +139,9 @@ mod tests {
             let mut hashes = to_hash_map(&[(expected_filename, "some-hash")]);
             let to_hash = read_status(input.as_bytes(), &root_path, &prefix, &mut hashes).unwrap();
             if *expect_delete {
-                assert_eq!(hashes.len(), 0, "input: {}", input);
+                assert_eq!(hashes.len(), 0, "input: {input}");
             } else {
-                assert_eq!(to_hash.len(), 1, "input: {}", input);
+                assert_eq!(to_hash.len(), 1, "input: {input}");
                 let expected = prefix.join(&RelativeUnixPathBuf::new(*expected_filename).unwrap());
                 assert_eq!(to_hash[0], expected);
             }

--- a/crates/turborepo/tests/common/mod.rs
+++ b/crates/turborepo/tests/common/mod.rs
@@ -26,10 +26,7 @@ pub fn setup_fixture(
 
     Command::new(bash)
         .arg("-c")
-        .arg(format!(
-            "{} {} {}",
-            unix_script_path, fixture, package_manager
-        ))
+        .arg(format!("{unix_script_path} {fixture} {package_manager}"))
         .current_dir(test_dir)
         .spawn()?
         .wait()?;


### PR DESCRIPTION
### Description

A bunch of lints failures got into tests. This PR fixes them with `cargo clippy --fix`

### Testing Instructions

👀 
