### PR TITLE
Update docs about env file handling

### DIFF
--- a/docs/site/content/docs/crafting-your-repository/using-environment-variables.mdx
+++ b/docs/site/content/docs/crafting-your-repository/using-environment-variables.mdx
@@ -241,7 +241,7 @@ Below are examples of proper environment variable configuration for a few popula
 The `turbo.json` below expresses:
 
 - The `build` and `dev` tasks will have different hashes for changes to `MY_API_URL` and `MY_API_KEY`.
-- The `build` and `dev` tasks use the same [file loading order as Next.js](https://nextjs.org/docs/app/building-your-application/configuring/environment-variables#environment-variable-load-order), with `.env` having the most precedence.
+- The `build` and `dev` tasks include the supported .env files for Next.js.
 - The `test` task does not use environment variables, so the `env` key is omitted. (Depending on your testing structure, your `test` task may need an `env` key.)
 
 ```json title="./turbo.json"
@@ -275,7 +275,7 @@ The `turbo.json` below expresses:
 <Accordion title="Vite">
 The `turbo.json` below expresses:
 - The `build` and `dev` tasks will have different hashes for changes to `MY_API_URL` and `MY_API_KEY`.
-- The `build` and `dev` tasks use the same [file loading order as Vite](https://vitejs.dev/guide/env-and-mode#env-files), with `.env` having the most precedence.
+- The `build` and `dev` tasks include the supported .env files for Vite.
 - The `test` task does not use environment variables, so the `env` key is omitted. (Depending on your testing structure, your `test` task may need an `env` key.)
 
 ```json title="./turbo.json"


### PR DESCRIPTION
### Description

Updated documentation regarding `.env` file handling for `build` and `dev` tasks in Next.js and Vite. The previous wording about "file loading order" and "precedence" was simplified to "include the supported .env files" for better clarity and conciseness.

### Testing Instructions

1.  Navigate to the "Using Environment Variables" documentation page.
2.  Verify the updated text under the "Next.js" and "Vite" sections.
    *   For Next.js, the line should now read: "The `build` and `dev` tasks include the supported .env files for Next.js."
    *   For Vite, the line should now read: "The `build` and `dev` tasks include the supported .env files for Vite."

---

[Open in Web](https://www.cursor.com/agents?id=bc-e1142347-a2fb-4796-a962-ca48ebe19ee1) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-e1142347-a2fb-4796-a962-ca48ebe19ee1)