### PR TITLE
feat(examples): add `dev` live reload task to `example-with-angular`

### DIFF
--- a/examples/with-angular/apps/web/package.json
+++ b/examples/with-angular/apps/web/package.json
@@ -7,7 +7,7 @@
     "start": "ng serve --host 0.0.0.0 --port 4201",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "dev": "ng build --watch --configuration development",
+    "dev": "sleep 5 && npm run start",
     "test": "ng test",
     "lint": "eslint . --max-warnings 0",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf .angular"

--- a/examples/with-angular/apps/web/package.json
+++ b/examples/with-angular/apps/web/package.json
@@ -7,6 +7,7 @@
     "start": "ng serve --host 0.0.0.0 --port 4201",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
+    "dev": "ng build --watch --configuration development",
     "test": "ng test",
     "lint": "eslint . --max-warnings 0",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf .angular"

--- a/examples/with-angular/apps/web/package.json
+++ b/examples/with-angular/apps/web/package.json
@@ -7,7 +7,7 @@
     "start": "ng serve --host 0.0.0.0 --port 4201",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "dev": "sleep 5 && npm run start",
+    "dev": "sleep 2 && npm run start",
     "test": "ng test",
     "lint": "eslint . --max-warnings 0",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf .angular"

--- a/examples/with-angular/packages/ui/package.json
+++ b/examples/with-angular/packages/ui/package.json
@@ -8,6 +8,7 @@
     "ng": "ng",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
+    "dev": "ng build --watch --configuration development",
     "test": "ng test",
     "lint": "eslint --max-warnings 0",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf .angular"


### PR DESCRIPTION
### Description

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

I think it's a conventional development workflow to launch both the Angular app (ie, `web` and `docs`) and watch for changes in the `ui` module. However, the current example's `watch` and `start` tasks (which front `ng build` and `ng serve`) don't seem to work "as expected".

By default, `persistant` tasks in Turborepo run at the same time; however, the `ng serve` in the web app will fail (and doesn't "self-heal"), because the `ng build` command in the ui package hasn't finished generating the `dist`.

I first tried all the various configurations I could find to try and get the web app `ng serve` to properly recognize changes in the `@repo/ui` package and "self-heal" after the first run, for example, using `path` configurations in `tsconfig.json`, etc, but nothing seemed to work (I may be not doing it properly, as I'm not super-familiar with Angular)

I then tried some turbo.json configs, trying to use `interruptible`, `turbo watch` etc. However, there was still a problem with the first run failing.

1. This pull-request is more of a convo starter about what the best way to provide this would be...
2. I found the most straight-forward method was to just add a sleep before the task; however, this is obviously inelegant
3. I wonder if there's just a simple config, perhaps in the `angular.json` to re-establish the "self-healing" of the `ng serve` that we'd see in a non-Turborepo setup
4. Or, perhaps some specific Turbo config would accomplish it, as long as it wasn't too complicated


### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->

Running `turbo run dev` or `turbo run dev --filter=...@repo/ui` will `ng build --watch` the `@repo/ui` library, and serve the `web` app at `localhost:4200`.

Make changes to the `@repo/ui` library and the app should rebuild and display the changes.