### PR TITLE
fix: handle injected dependencies with link: and file: protocols

### DIFF
--- a/crates/turborepo-lockfiles/fixtures/pnpm-injected-file.yaml
+++ b/crates/turborepo-lockfiles/fixtures/pnpm-injected-file.yaml
@@ -1,0 +1,18 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+  services/application:
+    dependencies:
+      library:
+        specifier: workspace:^
+        version: file:../../../libraries/library
+    dependenciesMeta:
+      library:
+        injected: true
+
+packages: {}
+snapshots: {}

--- a/crates/turborepo-lockfiles/fixtures/pnpm-injected-link.yaml
+++ b/crates/turborepo-lockfiles/fixtures/pnpm-injected-link.yaml
@@ -1,0 +1,29 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+  .:
+    devDependencies:
+      turbo:
+        specifier: 2.0.0-canary.0
+        version: 2.0.0-canary.0
+
+  services/application:
+    dependencies:
+      library:
+        specifier: workspace:^
+        version: link:../../../libraries/library
+    dependenciesMeta:
+      library:
+        injected: true
+
+packages:
+  turbo@2.0.0-canary.0:
+    resolution: {integrity: sha512-test}
+    hasBin: true
+
+snapshots:
+  turbo@2.0.0-canary.0: {}


### PR DESCRIPTION
### Description

  Fixes issue where turbo prune fails with 'No lockfile entry found for link:...'
  when processing injected dependencies that use link: or file: protocols.

  These local workspace dependencies don't have entries in the packages section
  since they're just symlinks to local directories.

  Fixes #8243
 
### Testing Instructions

Issue contains reproduction repo