### PR TITLE
docs: fix JSDoc type for ESLint config in basic example

### DIFF
--- a/examples/basic/apps/web/eslint.config.js
+++ b/examples/basic/apps/web/eslint.config.js
@@ -1,4 +1,4 @@
 import { nextJsConfig } from "@repo/eslint-config/next-js";
 
-/** @type {import("eslint").Linter.Config} */
+/** @type {import("eslint").Linter.Config[]} */
 export default nextJsConfig;


### PR DESCRIPTION
This PR fixes a minor inaccuracy in the JSDoc type for the ESLint configuration, ensuring it correctly reflects that an array is exported.
