### PR TITLE
fix: add types node to fix minimatch issue

### DIFF
--- a/examples/with-nestjs/packages/api/tsconfig.json
+++ b/examples/with-nestjs/packages/api/tsconfig.json
@@ -5,7 +5,8 @@
     "baseUrl": "src",
     "esModuleInterop": true,
     "incremental": false,
-    "outDir": "dist"
+    "outDir": "dist",
+    "types": ["node"]
   },
   "include": ["src"],
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]


### PR DESCRIPTION
### Description

After using the with-nestjs example and I started facing this issue: 
<img width="824" height="129" alt="image" src="https://github.com/user-attachments/assets/1a726727-2a8b-4a3c-ae6a-7fd92cdb320c" />


### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
