### PR TITLE
feat: add GitHub Actions environment variable as default passthru

### DIFF
--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -474,6 +474,9 @@ impl<'a> TaskHasher<'a> {
                     "NEXT_*",
                     "USE_OUTPUT_FOR_EDGE_FUNCTIONS",
                     "NOW_BUILDER",
+                    // GitHub Actions - https://docs.github.com/en/actions/reference/workflows-and-actions/variables
+                    "GITHUB_*",
+                    "RUNNER_*",
                     // Command Prompt casing of env variables
                     "APPDATA",
                     "PATH",


### PR DESCRIPTION
### Description

Allowing those variables to pass through by default would make using turborepo with GitHub Actions more seamless.

For example, NPM relies on `GITHUB_ACTIONS` for automatic provenance detection. (see https://github.com/npm/cli/blob/5d82d0b4a4bd1424031fb68b4df740c1bbe5b172/lib/utils/oidc.js#L11) By obfuscating the variable, it can be pretty confusing for users of both turborepo and npm as to why the provenance generation stopped working (don't ask me how I know).

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
