### PR TITLE
docs(run): fix --log-prefix options to match CLI (task, not prefix)

### DIFF
--- a/docs/site/content/docs/reference/run.mdx
+++ b/docs/site/content/docs/reference/run.mdx
@@ -388,11 +388,11 @@ Control the `<package>:<task>:` prefix for log lines produced when running tasks
 turbo run dev --log-prefix=none
 ```
 
-| Option   | Description                                 |
-| -------- | ------------------------------------------- |
-| `prefix` | Force prepending the prefix to logs         |
-| `none`   | No prefixes                                 |
-| `auto`   | `turbo` decides based on its own heuristics |
+| Option | Description                                             |
+| ------ | ------------------------------------------------------- |
+| `task` | Force prepending the `<package>:<task>:` prefix to logs |
+| `none` | No prefixes                                             |
+| `auto` | `turbo` decides based on its own heuristics             |
 
 ### `--no-cache`
 


### PR DESCRIPTION
## Summary
- Update docs for `--log-prefix` to match actual CLI enum values.
- Replace `prefix` with `task` and clarify description.

## Test plan
- Viewed `docs/site/content/docs/reference/run.mdx` and verified options table now lists `task`, `none`, `auto`.
- Cross-checked CLI enum in `crates/turborepo-lib/src/cli/mod.rs` (`LogPrefix::{Auto,None,Task}`).