### PR TITLE
docs(run): correct --graph formats; remove incorrect default mention

### DIFF
--- a/docs/site/content/docs/reference/run.mdx
+++ b/docs/site/content/docs/reference/run.mdx
@@ -342,9 +342,7 @@ turbo run build --global-deps=".env.*" --global-deps=".eslintrc" --global-deps="
 
 ### `--graph <file type>`
 
-Default: `jpg`
-
-This command will generate an `svg`, `png`, `jpg`, `pdf`, `json`, `html`, or [other supported output formats](https://graphviz.org/doc/info/output.html) of the current task graph.
+This command can output a graph file: `svg`, `png`, `jpg`, `pdf`, `json`, `html`, `mermaid`, or `dot`.
 
 If [Graphviz](https://graphviz.org/) is not installed, or no filename is provided, this command prints the dot graph to `stdout`.
 


### PR DESCRIPTION
## Summary
- Align `--graph` docs with actual supported formats in CLI: add `mermaid` and `dot` to the list, and drop outdated reference. Remove misleading default.

## Rationale
- CLI validates extensions against: svg, png, jpg, pdf, json, html, mermaid, dot (`SUPPORTED_GRAPH_FILE_EXTENSIONS`).
- Docs previously claimed a default of `jpg`, which is not enforced by the CLI (no default extension; empty value prints DOT to stdout).

## Test plan
- Confirmed enum in `crates/turborepo-lib/src/cli/mod.rs` and validation in `validate_graph_extension`.
- Built docs locally to verify formatting of the updated section.