### PR TITLE
chore: update to Rust 1.89.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ members = [
   "packages/turbo-repository/rust",
 ]
 
+[workspace.package]
+edition = "2024"
+
 [workspace.metadata.groups]
 # Only the libraries, does not include the turborepo binary.
 # That way we don't have to build the Go code

--- a/crates/coverage/Cargo.toml
+++ b/crates/coverage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "coverage"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
 license = "MIT"
 
 [[bin]]

--- a/crates/coverage/src/main.rs
+++ b/crates/coverage/src/main.rs
@@ -16,12 +16,12 @@ struct Args {
 /// Find the llvm-profdata binary using rustup
 fn find_llvm_profdata() -> Result<std::path::PathBuf> {
     // First try to find it in PATH
-    if let Ok(output) = Command::new("which").arg("llvm-profdata").output() {
-        if output.status.success() {
-            let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            if !path.is_empty() {
-                return Ok(std::path::PathBuf::from(path));
-            }
+    if let Ok(output) = Command::new("which").arg("llvm-profdata").output()
+        && output.status.success()
+    {
+        let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !path.is_empty() {
+            return Ok(std::path::PathBuf::from(path));
         }
     }
 
@@ -108,12 +108,12 @@ fn find_llvm_profdata() -> Result<std::path::PathBuf> {
 /// Find the llvm-cov binary using the same approach as llvm-profdata
 fn find_llvm_cov() -> Result<std::path::PathBuf> {
     // First try to find it in PATH
-    if let Ok(output) = Command::new("which").arg("llvm-cov").output() {
-        if output.status.success() {
-            let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            if !path.is_empty() {
-                return Ok(std::path::PathBuf::from(path));
-            }
+    if let Ok(output) = Command::new("which").arg("llvm-cov").output()
+        && output.status.success()
+    {
+        let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !path.is_empty() {
+            return Ok(std::path::PathBuf::from(path));
         }
     }
 
@@ -228,22 +228,18 @@ fn main() -> Result<()> {
 
     let mut object_args = Vec::new();
     for line in binaries_json.lines() {
-        if let Ok(json) = serde_json::from_str::<serde_json::Value>(line) {
-            if let Some(profile) = json.get("profile") {
-                if let Some(test) = profile.get("test") {
-                    if test.as_bool() == Some(true) {
-                        if let Some(filenames) = json.get("filenames") {
-                            if let Some(filenames_array) = filenames.as_array() {
-                                for filename in filenames_array {
-                                    if let Some(path) = filename.as_str() {
-                                        if !path.contains("dSYM") {
-                                            object_args.push(format!("--object={path}"));
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(line)
+            && let Some(profile) = json.get("profile")
+            && let Some(test) = profile.get("test")
+            && test.as_bool() == Some(true)
+            && let Some(filenames) = json.get("filenames")
+            && let Some(filenames_array) = filenames.as_array()
+        {
+            for filename in filenames_array {
+                if let Some(path) = filename.as_str()
+                    && !path.contains("dSYM")
+                {
+                    object_args.push(format!("--object={path}"));
                 }
             }
         }

--- a/crates/turbo-trace/Cargo.toml
+++ b/crates/turbo-trace/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turbo-trace"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 license = "MIT"
 
 [dependencies]

--- a/crates/turbo-trace/src/import_finder.rs
+++ b/crates/turbo-trace/src/import_finder.rs
@@ -84,27 +84,16 @@ impl Visit for ImportFinder {
     fn visit_stmt(&mut self, stmt: &Stmt) {
         if let Stmt::Decl(Decl::Var(var_decl)) = stmt {
             for decl in &var_decl.decls {
-                if let Some(init) = &decl.init {
-                    if let swc_ecma_ast::Expr::Call(call_expr) = &**init {
-                        if let swc_ecma_ast::Callee::Expr(expr) = &call_expr.callee {
-                            if let swc_ecma_ast::Expr::Ident(ident) = &**expr {
-                                if ident.sym == *"require" {
-                                    if let Some(arg) = call_expr.args.first() {
-                                        if let swc_ecma_ast::Expr::Lit(swc_ecma_ast::Lit::Str(
-                                            lit_str,
-                                        )) = &*arg.expr
-                                        {
-                                            self.imports.push((
-                                                lit_str.value.to_string(),
-                                                expr.span(),
-                                                ImportType::Value,
-                                            ));
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                if let Some(init) = &decl.init
+                    && let swc_ecma_ast::Expr::Call(call_expr) = &**init
+                    && let swc_ecma_ast::Callee::Expr(expr) = &call_expr.callee
+                    && let swc_ecma_ast::Expr::Ident(ident) = &**expr
+                    && ident.sym == *"require"
+                    && let Some(arg) = call_expr.args.first()
+                    && let swc_ecma_ast::Expr::Lit(swc_ecma_ast::Lit::Str(lit_str)) = &*arg.expr
+                {
+                    self.imports
+                        .push((lit_str.value.to_string(), expr.span(), ImportType::Value));
                 }
             }
         }

--- a/crates/turbo-trace/src/tracer.rs
+++ b/crates/turbo-trace/src/tracer.rs
@@ -387,10 +387,10 @@ impl Tracer {
         let resolver = Self::create_resolver(self.ts_config.as_deref());
 
         while let Some((file_path, file_depth)) = self.files.pop() {
-            if let Some(max_depth) = max_depth {
-                if file_depth > max_depth {
-                    continue;
-                }
+            if let Some(max_depth) = max_depth
+                && file_depth > max_depth
+            {
+                continue;
             }
             self.trace_file(&resolver, file_path, file_depth, &mut seen)
                 .await;

--- a/crates/turborepo-analytics/Cargo.toml
+++ b/crates/turborepo-analytics/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turborepo-analytics"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/turborepo-api-client/Cargo.toml
+++ b/crates/turborepo-api-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turborepo-api-client"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -182,10 +182,10 @@ impl Client for APIClient {
         Ok(response.json().await?)
     }
     fn add_ci_header(mut request_builder: RequestBuilder) -> RequestBuilder {
-        if is_ci() {
-            if let Some(vendor_constant) = Vendor::get_constant() {
-                request_builder = request_builder.header("x-artifact-client-ci", vendor_constant);
-            }
+        if is_ci()
+            && let Some(vendor_constant) = Vendor::get_constant()
+        {
+            request_builder = request_builder.header("x-artifact-client-ci", vendor_constant);
         }
 
         request_builder

--- a/crates/turborepo-auth/Cargo.toml
+++ b/crates/turborepo-auth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turborepo-auth"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 license = "MIT"
 
 [lints]

--- a/crates/turborepo-auth/src/auth/sso.rs
+++ b/crates/turborepo-auth/src/auth/sso.rs
@@ -71,22 +71,22 @@ pub async fn sso_login<T: Client + TokenClient + CacheClient>(
             }
         // No existing turbo token found. If the user is logging into Vercel,
         // check for an existing `vc` token with correct scope.
-        } else if login_url_configuration.contains("vercel.com") {
-            if let Ok(Some(token)) = extract_vercel_token() {
-                let token = Token::existing(token);
-                if token
-                    .is_valid_sso(
-                        api_client,
-                        sso_team,
-                        Some(valid_token_callback(
-                            &format!("Existing Vercel token for {sso_team} found!"),
-                            color_config,
-                        )),
-                    )
-                    .await?
-                {
-                    return Ok(token);
-                }
+        } else if login_url_configuration.contains("vercel.com")
+            && let Ok(Some(token)) = extract_vercel_token()
+        {
+            let token = Token::existing(token);
+            if token
+                .is_valid_sso(
+                    api_client,
+                    sso_team,
+                    Some(valid_token_callback(
+                        &format!("Existing Vercel token for {sso_team} found!"),
+                        color_config,
+                    )),
+                )
+                .await?
+            {
+                return Ok(token);
             }
         }
     }

--- a/crates/turborepo-cache/Cargo.toml
+++ b/crates/turborepo-cache/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turborepo-cache"
 version = "0.1.0"
 license = "MIT"
-edition = "2024"
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]

--- a/crates/turborepo-cache/src/multiplexer.rs
+++ b/crates/turborepo-cache/src/multiplexer.rs
@@ -146,32 +146,29 @@ impl CacheMultiplexer {
         anchor: &AbsoluteSystemPath,
         key: &str,
     ) -> Result<Option<(CacheHitMetadata, Vec<AnchoredSystemPathBuf>)>, CacheError> {
-        if self.cache_config.local.read {
-            if let Some(fs) = &self.fs {
-                if let response @ Ok(Some(_)) = fs.fetch(anchor, key) {
-                    return response;
-                }
-            }
+        if self.cache_config.local.read
+            && let Some(fs) = &self.fs
+            && let response @ Ok(Some(_)) = fs.fetch(anchor, key)
+        {
+            return response;
         }
 
-        if self.cache_config.remote.read {
-            if let Some(http) = self.get_http_cache() {
-                if let Ok(Some((CacheHitMetadata { source, time_saved }, files))) =
-                    http.fetch(key).await
-                {
-                    // Store this into fs cache. We can ignore errors here because we know
-                    // we have previously successfully stored in HTTP cache, and so the overall
-                    // result is a success at fetching. Storing in lower-priority caches is an
-                    // optimization.
-                    if self.cache_config.local.write {
-                        if let Some(fs) = &self.fs {
-                            let _ = fs.put(anchor, key, &files, time_saved);
-                        }
-                    }
-
-                    return Ok(Some((CacheHitMetadata { source, time_saved }, files)));
-                }
+        if self.cache_config.remote.read
+            && let Some(http) = self.get_http_cache()
+            && let Ok(Some((CacheHitMetadata { source, time_saved }, files))) =
+                http.fetch(key).await
+        {
+            // Store this into fs cache. We can ignore errors here because we know
+            // we have previously successfully stored in HTTP cache, and so the overall
+            // result is a success at fetching. Storing in lower-priority caches is an
+            // optimization.
+            if self.cache_config.local.write
+                && let Some(fs) = &self.fs
+            {
+                let _ = fs.put(anchor, key, &files, time_saved);
             }
+
+            return Ok(Some((CacheHitMetadata { source, time_saved }, files)));
         }
 
         Ok(None)
@@ -179,27 +176,27 @@ impl CacheMultiplexer {
 
     #[tracing::instrument(skip_all)]
     pub async fn exists(&self, key: &str) -> Result<Option<CacheHitMetadata>, CacheError> {
-        if self.cache_config.local.read {
-            if let Some(fs) = &self.fs {
-                match fs.exists(key) {
-                    cache_hit @ Ok(Some(_)) => {
-                        return cache_hit;
-                    }
-                    Ok(None) => {}
-                    Err(err) => debug!("failed to check fs cache: {:?}", err),
+        if self.cache_config.local.read
+            && let Some(fs) = &self.fs
+        {
+            match fs.exists(key) {
+                cache_hit @ Ok(Some(_)) => {
+                    return cache_hit;
                 }
+                Ok(None) => {}
+                Err(err) => debug!("failed to check fs cache: {:?}", err),
             }
         }
 
-        if self.cache_config.remote.read {
-            if let Some(http) = self.get_http_cache() {
-                match http.exists(key).await {
-                    cache_hit @ Ok(Some(_)) => {
-                        return cache_hit;
-                    }
-                    Ok(None) => {}
-                    Err(err) => debug!("failed to check http cache: {:?}", err),
+        if self.cache_config.remote.read
+            && let Some(http) = self.get_http_cache()
+        {
+            match http.exists(key).await {
+                cache_hit @ Ok(Some(_)) => {
+                    return cache_hit;
                 }
+                Ok(None) => {}
+                Err(err) => debug!("failed to check http cache: {:?}", err),
             }
         }
 

--- a/crates/turborepo-ci/Cargo.toml
+++ b/crates/turborepo-ci/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turborepo-ci"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/turborepo-dirs/Cargo.toml
+++ b/crates/turborepo-dirs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turborepo-dirs"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/turborepo-env/Cargo.toml
+++ b/crates/turborepo-env/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turborepo-env"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/turborepo-env/src/lib.rs
+++ b/crates/turborepo-env/src/lib.rs
@@ -309,10 +309,10 @@ fn wildcard_to_regex_pattern(pattern: &str) -> String {
                 regex_string.push(regex::escape(&pattern[previous_index..i]));
 
                 // Add a dynamic segment if it isn't adjacent to another dynamic segment.
-                if let Some(last_segment) = regex_string.last() {
-                    if last_segment != REGEX_WILDCARD_SEGMENT {
-                        regex_string.push(REGEX_WILDCARD_SEGMENT.to_string());
-                    }
+                if let Some(last_segment) = regex_string.last()
+                    && last_segment != REGEX_WILDCARD_SEGMENT
+                {
+                    regex_string.push(REGEX_WILDCARD_SEGMENT.to_string());
                 }
             }
 

--- a/crates/turborepo-errors/Cargo.toml
+++ b/crates/turborepo-errors/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turborepo-errors"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/turborepo-filewatch/Cargo.toml
+++ b/crates/turborepo-filewatch/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turborepo-filewatch"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/turborepo-filewatch/src/hash_watcher.rs
+++ b/crates/turborepo-filewatch/src/hash_watcher.rs
@@ -490,24 +490,24 @@ impl Subscriber {
             // We need mutable access to 'state' to update it, as well as being able to
             // extract the pending state, so we need two separate if statements
             // to pull the value apart.
-            if let HashState::Pending(existing_version, _, pending_queries) = state {
-                if *existing_version == version {
-                    match result {
-                        Ok(hashes) => {
-                            for pending_query in pending_queries.drain(..) {
-                                // We don't care if the client has gone away
-                                let _ = pending_query.send(Ok(hashes.clone()));
-                            }
-                            *state = HashState::Hashes(hashes);
+            if let HashState::Pending(existing_version, _, pending_queries) = state
+                && *existing_version == version
+            {
+                match result {
+                    Ok(hashes) => {
+                        for pending_query in pending_queries.drain(..) {
+                            // We don't care if the client has gone away
+                            let _ = pending_query.send(Ok(hashes.clone()));
                         }
-                        Err(e) => {
-                            let error = e.to_string();
-                            for pending_query in pending_queries.drain(..) {
-                                // We don't care if the client has gone away
-                                let _ = pending_query.send(Err(Error::HashingError(error.clone())));
-                            }
-                            *state = HashState::Unavailable(error);
+                        *state = HashState::Hashes(hashes);
+                    }
+                    Err(e) => {
+                        let error = e.to_string();
+                        for pending_query in pending_queries.drain(..) {
+                            // We don't care if the client has gone away
+                            let _ = pending_query.send(Err(Error::HashingError(error.clone())));
                         }
+                        *state = HashState::Unavailable(error);
                     }
                 }
             }

--- a/crates/turborepo-filewatch/src/package_watcher.rs
+++ b/crates/turborepo-filewatch/src/package_watcher.rs
@@ -367,12 +367,12 @@ impl Subscriber {
         state: &mut State,
         package_state_tx: &mpsc::Sender<DiscoveryResult>,
     ) {
-        if let State::Pending { debouncer, .. } = state {
-            if debouncer.bump() {
-                // We successfully bumped the debouncer, which was already pending,
-                // so a new discovery will happen shortly.
-                return;
-            }
+        if let State::Pending { debouncer, .. } = state
+            && debouncer.bump()
+        {
+            // We successfully bumped the debouncer, which was already pending,
+            // so a new discovery will happen shortly.
+            return;
         }
         // We either failed to bump the debouncer, or we don't have a rediscovery
         // queued, but we need one.

--- a/crates/turborepo-filewatch/src/scm_resource.rs
+++ b/crates/turborepo-filewatch/src/scm_resource.rs
@@ -28,7 +28,7 @@ impl SCMResource {
         Self { scm, semaphore }
     }
 
-    pub async fn acquire_scm(&self) -> SCMPermit {
+    pub async fn acquire_scm(&self) -> SCMPermit<'_> {
         let _permit = self
             .semaphore
             .acquire()

--- a/crates/turborepo-fixed-map/Cargo.toml
+++ b/crates/turborepo-fixed-map/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turborepo-fixed-map"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 license = "MIT"
 
 [dependencies]

--- a/crates/turborepo-frameworks/Cargo.toml
+++ b/crates/turborepo-frameworks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turborepo-frameworks"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 license = "MIT"
 
 [dependencies]

--- a/crates/turborepo-frameworks/src/lib.rs
+++ b/crates/turborepo-frameworks/src/lib.rs
@@ -56,10 +56,10 @@ impl Framework {
             for conditional in env_conditionals {
                 let (key, expected_value) = (&conditional.when.key, &conditional.when.value);
 
-                if let Some(actual_value) = env_at_execution_start.get(key) {
-                    if expected_value.is_none() || expected_value.as_ref() == Some(actual_value) {
-                        env_vars.extend(conditional.include.iter().cloned());
-                    }
+                if let Some(actual_value) = env_at_execution_start.get(key)
+                    && (expected_value.is_none() || expected_value.as_ref() == Some(actual_value))
+                {
+                    env_vars.extend(conditional.include.iter().cloned());
                 }
             }
         }

--- a/crates/turborepo-fs/Cargo.toml
+++ b/crates/turborepo-fs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turborepo-fs"
 version = "0.1.0"
 license = "MIT"
-edition = "2024"
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/turborepo-globwalk/Cargo.toml
+++ b/crates/turborepo-globwalk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "globwalk"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/turborepo-globwalk/src/lib.rs
+++ b/crates/turborepo-globwalk/src/lib.rs
@@ -57,7 +57,7 @@ fn glob_literals() -> &'static Regex {
     RE.get_or_init(|| Regex::new(r"(?<literal>[\?\*\$:<>\(\)\[\]{},])").unwrap())
 }
 
-fn escape_glob_literals(literal_glob: &str) -> Cow<str> {
+fn escape_glob_literals(literal_glob: &str) -> Cow<'_, str> {
     glob_literals().replace_all(literal_glob, "\\$literal")
 }
 
@@ -169,7 +169,7 @@ pub fn fix_glob_pattern(pattern: &str) -> String {
 ///
 /// also returns the position in the path of the first encountered collapse,
 /// for the purposes of calculating the new base path
-fn collapse_path(path: &str) -> Option<(Cow<str>, usize)> {
+fn collapse_path(path: &str) -> Option<(Cow<'_, str>, usize)> {
     let mut stack: Vec<&str> = vec![];
     let mut changed = false;
     let is_root = path.starts_with('/');

--- a/crates/turborepo-globwatch/Cargo.toml
+++ b/crates/turborepo-globwatch/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "globwatch"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 description = "Watch a set of globs efficiently"
 license = "MIT OR Apache-2.0"
 

--- a/crates/turborepo-globwatch/src/lib.rs
+++ b/crates/turborepo-globwatch/src/lib.rs
@@ -517,7 +517,7 @@ fn symbols_to_combinations<'a, T: Iterator<Item = GlobSymbol<'a>>>(
 }
 
 /// parses and escapes a glob, returning an iterator over the symbols
-fn glob_to_symbols(glob: &str) -> impl Iterator<Item = GlobSymbol> {
+fn glob_to_symbols(glob: &str) -> impl Iterator<Item = GlobSymbol<'_>> {
     let glob_bytes = glob.as_bytes();
     let mut escaped = false;
     let mut cursor = unic_segment::GraphemeCursor::new(0, glob.len());

--- a/crates/turborepo-graph-utils/Cargo.toml
+++ b/crates/turborepo-graph-utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turborepo-graph-utils"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 license = "MIT"
 
 [lints]

--- a/crates/turborepo-lib/src/microfrontends.rs
+++ b/crates/turborepo-lib/src/microfrontends.rs
@@ -359,7 +359,7 @@ mod test {
             PackageName::from(self.package_name)
         }
 
-        pub fn expected(&self) -> Option<FindResult> {
+        pub fn expected(&self) -> Option<FindResult<'_>> {
             match self.result {
                 Some(TestFindResult {
                     dev: Some(dev),

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -248,7 +248,7 @@ pub struct TaskArgs<'a> {
 }
 
 impl RunOpts {
-    pub fn task_args(&self) -> TaskArgs {
+    pub fn task_args(&self) -> TaskArgs<'_> {
         TaskArgs {
             pass_through_args: &self.pass_through_args,
             tasks: &self.tasks,

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -126,7 +126,7 @@ struct RepoState {
 }
 
 impl RepoState {
-    fn get_change_mapper(&self) -> Option<ChangeMapper<GlobalDepsPackageChangeMapper>> {
+    fn get_change_mapper(&self) -> Option<ChangeMapper<'_, GlobalDepsPackageChangeMapper<'_>>> {
         let Ok(package_change_mapper) = GlobalDepsPackageChangeMapper::new(
             &self.pkg_dep_graph,
             self.root_turbo_json

--- a/crates/turborepo-lib/src/rewrite_json.rs
+++ b/crates/turborepo-lib/src/rewrite_json.rs
@@ -114,7 +114,7 @@ pub fn set_path(
  * get_root returns the document root, or information on the error
  * encountered with the input json_document_string.
  */
-fn get_root(json_document_string: &str) -> Result<jsonc_parser::ast::Value, RewriteError> {
+fn get_root(json_document_string: &str) -> Result<jsonc_parser::ast::Value<'_>, RewriteError> {
     let parse_result_result = parse_to_ast(
         json_document_string,
         &Default::default(),

--- a/crates/turborepo-lib/src/task_graph/visitor/output.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/output.rs
@@ -25,21 +25,21 @@ impl<W: Write> TaskOutput<W> {
         }
     }
 
-    pub fn stdout(&self) -> Either<OutputWriter<W>, TaskSender> {
+    pub fn stdout(&self) -> Either<OutputWriter<'_, W>, TaskSender> {
         match self {
             TaskOutput::Direct(client) => Either::Left(client.stdout()),
             TaskOutput::UI(client) => Either::Right(client.clone()),
         }
     }
 
-    pub fn stderr(&self) -> Either<OutputWriter<W>, TaskSender> {
+    pub fn stderr(&self) -> Either<OutputWriter<'_, W>, TaskSender> {
         match self {
             TaskOutput::Direct(client) => Either::Left(client.stderr()),
             TaskOutput::UI(client) => Either::Right(client.clone()),
         }
     }
 
-    pub fn task_logs(&self) -> Either<OutputWriter<W>, TaskSender> {
+    pub fn task_logs(&self) -> Either<OutputWriter<'_, W>, TaskSender> {
         match self {
             TaskOutput::Direct(client) => Either::Left(client.stdout()),
             TaskOutput::UI(client) => Either::Right(client.clone()),

--- a/crates/turborepo-lockfiles/Cargo.toml
+++ b/crates/turborepo-lockfiles/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turborepo-lockfiles"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/turborepo-lockfiles/src/berry/identifiers.rs
+++ b/crates/turborepo-lockfiles/src/berry/identifiers.rs
@@ -250,7 +250,7 @@ impl<'a> Locator<'a> {
             })
     }
 
-    pub fn patched_locator(&self) -> Option<Locator> {
+    pub fn patched_locator(&self) -> Option<Locator<'_>> {
         // THis has an issue of cutting off the last char
         Locator::from_patch_reference(&self.reference)
     }

--- a/crates/turborepo-lockfiles/src/berry/mod.rs
+++ b/crates/turborepo-lockfiles/src/berry/mod.rs
@@ -177,10 +177,10 @@ impl BerryLockfile {
         for (locator, package) in &self.locator_package {
             for (name, range) in package.dependencies.iter().flatten() {
                 let mut descriptor = self.resolve_dependency(locator, name, range.as_ref())?;
-                if descriptor.protocol().is_none() {
-                    if let Some(range) = self.resolver.get(&descriptor) {
-                        descriptor.range = range.into();
-                    }
+                if descriptor.protocol().is_none()
+                    && let Some(range) = self.resolver.get(&descriptor)
+                {
+                    descriptor.range = range.into();
                 }
                 possible_extensions.remove(&descriptor);
             }
@@ -321,21 +321,20 @@ impl BerryLockfile {
             // Yarn 4 allows workspaces to depend directly on patched dependencies instead
             // of using resolutions. This results in the patched dependency appearing in the
             // closure instead of the original.
-            if locator.patch_file().is_some() {
-                if let Some((original, _)) =
+            if locator.patch_file().is_some()
+                && let Some((original, _)) =
                     self.patches.iter().find(|(_, patch)| patch == &&locator)
-                {
-                    patches.insert(original.as_owned(), locator.as_owned());
-                    // We include the patched dependency resolution
-                    let Locator { ident, reference } = original.as_owned();
-                    resolutions.insert(
-                        Descriptor {
-                            ident,
-                            range: reference,
-                        },
-                        original.as_owned(),
-                    );
-                }
+            {
+                patches.insert(original.as_owned(), locator.as_owned());
+                // We include the patched dependency resolution
+                let Locator { ident, reference } = original.as_owned();
+                resolutions.insert(
+                    Descriptor {
+                        ident,
+                        range: reference,
+                    },
+                    original.as_owned(),
+                );
             }
         }
 
@@ -391,10 +390,10 @@ impl BerryLockfile {
     ) -> Result<Descriptor<'static>, Error> {
         let mut dependency = Descriptor::new(name, range)?;
         // If there's no protocol we attempt to find a known one
-        if dependency.protocol().is_none() {
-            if let Some(range) = self.resolver.get(&dependency) {
-                dependency.range = range.to_string().into();
-            }
+        if dependency.protocol().is_none()
+            && let Some(range) = self.resolver.get(&dependency)
+        {
+            dependency.range = range.to_string().into();
         }
 
         for (resolution, reference) in &self.overrides {
@@ -410,7 +409,7 @@ impl BerryLockfile {
         Ok(dependency.into_owned())
     }
 
-    fn locator_for_workspace_path(&self, workspace_path: &str) -> Option<&Locator> {
+    fn locator_for_workspace_path(&self, workspace_path: &str) -> Option<&Locator<'_>> {
         self.workspace_path_to_locator
             .get(workspace_path)
             .or_else(|| {

--- a/crates/turborepo-lockfiles/src/berry/resolution.rs
+++ b/crates/turborepo-lockfiles/src/berry/resolution.rs
@@ -116,10 +116,10 @@ impl Resolution {
             // Since we have already checked the ident portion of the locator for equality
             // we can avoid an allocation caused by constructing a locator by just checking
             // the reference portion.
-            if let Some(desc) = &from.description {
-                if !Self::eq_with_protocol(&locator.reference, desc, "npm:") {
-                    return None;
-                }
+            if let Some(desc) = &from.description
+                && !Self::eq_with_protocol(&locator.reference, desc, "npm:")
+            {
+                return None;
             }
         }
 
@@ -129,14 +129,13 @@ impl Resolution {
             return None;
         }
 
-        if let Some(resolution_range) = &self.descriptor.description {
-            if resolution_range != &dependency.range
+        if let Some(resolution_range) = &self.descriptor.description
+            && resolution_range != &dependency.range
                 // Yarn4 encodes the default npm protocol in yarn.lock, but not in resolutions field of package.json
                 // We check if the ranges match when we add `npm:` to range coming from resolutions.
                 && !Self::eq_with_protocol(&dependency.range, resolution_range, "npm:")
-            {
-                return None;
-            }
+        {
+            return None;
         }
 
         // We have a match an we now override the dependency

--- a/crates/turborepo-lockfiles/src/berry/ser.rs
+++ b/crates/turborepo-lockfiles/src/berry/ser.rs
@@ -199,7 +199,7 @@ where
     builder.s
 }
 
-fn wrap_string(s: &str) -> Cow<str> {
+fn wrap_string(s: &str) -> Cow<'_, str> {
     match simple_string().is_match(s) {
         // Simple strings require no wrapping
         true => Cow::from(s),

--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -322,7 +322,7 @@ impl PnpmLockfile {
 
     // Create a projection of all fields in the lockfile that could affect all
     // workspaces
-    fn global_fields(&self) -> GlobalFields {
+    fn global_fields(&self) -> GlobalFields<'_> {
         GlobalFields {
             version: &self.lockfile_version.version,
             checksum: self.package_extensions_checksum.as_deref(),

--- a/crates/turborepo-lockfiles/src/pnpm/dep_path.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/dep_path.rs
@@ -79,7 +79,7 @@ impl<'a> DepPath<'a> {
 // order to parse 6+ it partially converts to the old format.
 // The conversion only replaces the '@' separator with '/', we avoid this
 // conversion by allowing for a '@' or a '/' to be used as a separator.
-fn parse_dep_path(i: &str) -> IResult<&str, DepPath> {
+fn parse_dep_path(i: &str) -> IResult<&str, DepPath<'_>> {
     let (i, host) = parse_host(i)?;
     let (i, _) = nom::character::complete::char('/')(i)?;
     let (i, name) = parse_name(i)?;
@@ -95,7 +95,7 @@ fn parse_dep_path(i: &str) -> IResult<&str, DepPath> {
     ))
 }
 
-fn parse_dep_path_v9(input: &str) -> Result<DepPath, Error> {
+fn parse_dep_path_v9(input: &str) -> Result<DepPath<'_>, Error> {
     if input.is_empty() {
         return Err(Error::MissingAt(input.to_owned()));
     }

--- a/crates/turborepo-lockfiles/src/yarn1/ser.rs
+++ b/crates/turborepo-lockfiles/src/yarn1/ser.rs
@@ -226,7 +226,7 @@ fn encode_map<'a, I: Iterator<Item = (&'a str, &'a str)>>(
     Ok(())
 }
 
-fn maybe_wrap(s: &str) -> Cow<str> {
+fn maybe_wrap(s: &str) -> Cow<'_, str> {
     match should_wrap_key(s) {
         // yarn uses JSON.stringify to escape strings
         // we approximate this behavior using serde_json

--- a/crates/turborepo-lsp/Cargo.toml
+++ b/crates/turborepo-lsp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turborepo-lsp"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 license = "MIT"
 
 [features]

--- a/crates/turborepo-lsp/src/lib.rs
+++ b/crates/turborepo-lsp/src/lib.rs
@@ -339,10 +339,10 @@ impl LanguageServer for Backend {
                 .map(|(p, t)| (Some(p), t))
                 .unwrap_or((None, &referenced_task));
 
-            if let (Some(package), Some(package_name)) = (package, package_json_name) {
-                if package_name != package {
-                    continue;
-                }
+            if let (Some(package), Some(package_name)) = (package, package_json_name)
+                && package_name != package
+            {
+                continue;
             };
 
             let Some(start) = data.find(&format!("\"{task}\"")) else {

--- a/crates/turborepo-microfrontends/Cargo.toml
+++ b/crates/turborepo-microfrontends/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turborepo-microfrontends"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 license = "MIT"
 
 [dependencies]

--- a/crates/turborepo-microfrontends/src/configv1.rs
+++ b/crates/turborepo-microfrontends/src/configv1.rs
@@ -76,7 +76,7 @@ impl ConfigV1 {
         }
     }
 
-    pub fn development_tasks(&self) -> impl Iterator<Item = DevelopmentTask> {
+    pub fn development_tasks(&self) -> impl Iterator<Item = DevelopmentTask<'_>> {
         self.applications
             .iter()
             .map(|(application, config)| DevelopmentTask {

--- a/crates/turborepo-paths/Cargo.toml
+++ b/crates/turborepo-paths/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbopath"
 version = "0.1.0"
 license = "MIT"
-edition = "2024"
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/turborepo-paths/src/anchored_system_path.rs
+++ b/crates/turborepo-paths/src/anchored_system_path.rs
@@ -80,7 +80,7 @@ impl AnchoredSystemPath {
             .map(|path| unsafe { AnchoredSystemPath::new_unchecked(path) })
     }
 
-    pub fn components(&self) -> impl Iterator<Item = Utf8Component> {
+    pub fn components(&self) -> impl Iterator<Item = Utf8Component<'_>> {
         self.0.components()
     }
 

--- a/crates/turborepo-paths/src/anchored_system_path_buf.rs
+++ b/crates/turborepo-paths/src/anchored_system_path_buf.rs
@@ -196,7 +196,7 @@ impl AnchoredSystemPathBuf {
         self.0.push(path.as_ref());
     }
 
-    pub fn components(&self) -> Utf8Components {
+    pub fn components(&self) -> Utf8Components<'_> {
         self.0.components()
     }
 

--- a/crates/turborepo-pidlock/Cargo.toml
+++ b/crates/turborepo-pidlock/Cargo.toml
@@ -3,7 +3,7 @@ name = "pidlock"
 version = "0.1.4"
 authors = ["Paul Hummer <paul@eventuallyanyway.com>"]
 license = "MIT"
-edition = "2024"
+edition = { workspace = true }
 description = "A library for using pidfiles as resource locks"
 repository = "https://github.com/rockstar/pidlock"
 keywords = ["pidfile", "file", "filelock", "server", "lock"]

--- a/crates/turborepo-process/Cargo.toml
+++ b/crates/turborepo-process/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turborepo-process"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 license = "MIT"
 
 [dev-dependencies]

--- a/crates/turborepo-repository/Cargo.toml
+++ b/crates/turborepo-repository/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turborepo-repository"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 license = "MIT"
 
 [lints]

--- a/crates/turborepo-repository/src/change_mapper/package.rs
+++ b/crates/turborepo-repository/src/change_mapper/package.rs
@@ -65,18 +65,18 @@ impl PackageChangeMapper for DefaultPackageChangeMapper<'_> {
             if name == &PackageName::Root {
                 continue;
             }
-            if let Some(package_path) = entry.package_json_path.parent() {
-                if Self::is_file_in_package(file, package_path) {
-                    return PackageMapping::Package((
-                        WorkspacePackage {
-                            name: name.clone(),
-                            path: package_path.to_owned(),
-                        },
-                        PackageInclusionReason::FileChanged {
-                            file: file.to_owned(),
-                        },
-                    ));
-                }
+            if let Some(package_path) = entry.package_json_path.parent()
+                && Self::is_file_in_package(file, package_path)
+            {
+                return PackageMapping::Package((
+                    WorkspacePackage {
+                        name: name.clone(),
+                        path: package_path.to_owned(),
+                    },
+                    PackageInclusionReason::FileChanged {
+                        file: file.to_owned(),
+                    },
+                ));
             }
         }
 

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -149,7 +149,7 @@ impl PackageGraph {
     pub fn builder(
         repo_root: &AbsoluteSystemPath,
         root_package_json: PackageJson,
-    ) -> PackageGraphBuilder<LocalPackageDiscoveryBuilder> {
+    ) -> PackageGraphBuilder<'_, LocalPackageDiscoveryBuilder> {
         PackageGraphBuilder::new(repo_root, root_package_json)
     }
 

--- a/crates/turborepo-scm/Cargo.toml
+++ b/crates/turborepo-scm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turborepo-scm"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -201,10 +201,10 @@ impl GitRepo {
          *
          * So environment variable is empty in a regular commit
          */
-        if let Ok(pr) = base_ref_env.github_base_ref {
-            if !pr.is_empty() {
-                return Some(pr);
-            }
+        if let Ok(pr) = base_ref_env.github_base_ref
+            && !pr.is_empty()
+        {
+            return Some(pr);
         }
 
         // we must be in a push event

--- a/crates/turborepo-scm/src/manual.rs
+++ b/crates/turborepo-scm/src/manual.rs
@@ -31,7 +31,7 @@ fn git_like_hash_file(path: &AbsoluteSystemPath) -> Result<String, Error> {
     Ok(result.encode_hex::<String>())
 }
 
-fn to_glob(input: &str) -> Result<Glob, Error> {
+fn to_glob(input: &str) -> Result<Glob<'_>, Error> {
     let glob = fix_glob_pattern(input).into_unix();
     let g = Glob::new(glob.as_str()).map(|g| g.into_owned())?;
 
@@ -132,17 +132,17 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
         let relative_path = relative_path.to_unix();
 
         // if we have includes, and this path doesn't match any of them, skip it
-        if let Some(include_pattern) = include_pattern.as_ref() {
-            if !include_pattern.is_match(relative_path.as_str()) {
-                continue;
-            }
+        if let Some(include_pattern) = include_pattern.as_ref()
+            && !include_pattern.is_match(relative_path.as_str())
+        {
+            continue;
         }
 
         // if we have excludes, and this path matches one of them, skip it
-        if let Some(exclude_pattern) = exclude_pattern.as_ref() {
-            if exclude_pattern.is_match(relative_path.as_str()) {
-                continue;
-            }
+        if let Some(exclude_pattern) = exclude_pattern.as_ref()
+            && exclude_pattern.is_match(relative_path.as_str())
+        {
+            continue;
         }
 
         // FIXME: we don't hash symlinks...
@@ -176,13 +176,13 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
             let relative_path = full_package_path.anchor(path)?;
             let relative_path = relative_path.to_unix();
 
-            if let Some(exclude_pattern) = exclude_pattern.as_ref() {
-                if exclude_pattern.is_match(relative_path.as_str()) {
-                    // track excludes so we can exclude them to the hash map later
-                    if !metadata.is_symlink() {
-                        let hash = git_like_hash_file(path)?;
-                        excluded_file_hashes.insert(relative_path.clone(), hash);
-                    }
+            if let Some(exclude_pattern) = exclude_pattern.as_ref()
+                && exclude_pattern.is_match(relative_path.as_str())
+            {
+                // track excludes so we can exclude them to the hash map later
+                if !metadata.is_symlink() {
+                    let hash = git_like_hash_file(path)?;
+                    excluded_file_hashes.insert(relative_path.clone(), hash);
                 }
             }
 

--- a/crates/turborepo-signals/Cargo.toml
+++ b/crates/turborepo-signals/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turborepo-signals"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 license = "MIT"
 
 [dependencies]

--- a/crates/turborepo-task-id/Cargo.toml
+++ b/crates/turborepo-task-id/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turborepo-task-id"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
 license = "MIT"
 
 [lints]

--- a/crates/turborepo-task-id/src/lib.rs
+++ b/crates/turborepo-task-id/src/lib.rs
@@ -104,7 +104,7 @@ impl<'a> TaskId<'a> {
         &self.task
     }
 
-    pub fn as_non_workspace_task_name(&self) -> TaskName {
+    pub fn as_non_workspace_task_name(&self) -> TaskName<'_> {
         let task: &str = &self.task;
         TaskName {
             package: None,
@@ -112,7 +112,7 @@ impl<'a> TaskId<'a> {
         }
     }
 
-    pub fn as_task_name(&self) -> TaskName {
+    pub fn as_task_name(&self) -> TaskName<'_> {
         let package: &str = &self.package;
         let task: &str = &self.task;
         TaskName {
@@ -130,7 +130,7 @@ impl<'a> TaskId<'a> {
     }
 
     /// Borrows a TaskId reference as a TaskId
-    pub fn as_borrowed(&self) -> TaskId {
+    pub fn as_borrowed(&self) -> TaskId<'_> {
         let TaskId { package, task } = self;
         let package = shorten_cow(package);
         let task = shorten_cow(task);

--- a/crates/turborepo-telemetry/Cargo.toml
+++ b/crates/turborepo-telemetry/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turborepo-telemetry"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/turborepo-ui/Cargo.toml
+++ b/crates/turborepo-ui/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turborepo-ui"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/turborepo-ui/src/output.rs
+++ b/crates/turborepo-ui/src/output.rs
@@ -115,7 +115,7 @@ impl<W: Write> OutputClient<W> {
 
     /// A writer that will write to the underlying sink's out writer according
     /// to this client's behavior.
-    pub fn stdout(&self) -> OutputWriter<W> {
+    pub fn stdout(&self) -> OutputWriter<'_, W> {
         OutputWriter {
             logger: self,
             destination: Destination::Stdout,
@@ -125,7 +125,7 @@ impl<W: Write> OutputClient<W> {
 
     /// A writer that will write to the underlying sink's err writer according
     /// to this client's behavior.
-    pub fn stderr(&self) -> OutputWriter<W> {
+    pub fn stderr(&self) -> OutputWriter<'_, W> {
         OutputWriter {
             logger: self,
             destination: Destination::Stderr,

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -133,7 +133,7 @@ impl<W> App<W> {
         self.tasks_by_status.task_name(self.selected_task_index)
     }
 
-    fn input_options(&self) -> Result<InputOptions, Error> {
+    fn input_options(&self) -> Result<InputOptions<'_>, Error> {
         let has_selection = self.get_full_task()?.has_selection();
         Ok(InputOptions {
             focus: &self.section_focus,
@@ -250,12 +250,12 @@ impl<W> App<W> {
         if let LayoutSections::Search {
             previous_selection, ..
         } = prev_focus
+            && restore_scroll
+            && self.select_task(&previous_selection).is_err()
         {
-            if restore_scroll && self.select_task(&previous_selection).is_err() {
-                // If the task that was selected is no longer in the task list we reset
-                // scrolling.
-                self.reset_scroll();
-            }
+            // If the task that was selected is no longer in the task list we reset
+            // scrolling.
+            self.reset_scroll();
         }
     }
 

--- a/crates/turborepo-ui/src/tui/clipboard.rs
+++ b/crates/turborepo-ui/src/tui/clipboard.rs
@@ -36,10 +36,10 @@ fn detect_copy_provider() -> Provider {
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
 fn detect_copy_provider() -> Provider {
     // Wayland
-    if std::env::var("WAYLAND_DISPLAY").is_ok() {
-        if let Some(provider) = check_prog("wl-copy", &["--type", "text/plain"]) {
-            return provider;
-        }
+    if std::env::var("WAYLAND_DISPLAY").is_ok()
+        && let Some(provider) = check_prog("wl-copy", &["--type", "text/plain"])
+    {
+        return provider;
     }
     // X11
     if std::env::var("DISPLAY").is_ok() {
@@ -55,10 +55,10 @@ fn detect_copy_provider() -> Provider {
         return provider;
     }
     // Tmux
-    if std::env::var("TMUX").is_ok() {
-        if let Some(provider) = check_prog("tmux", &["load-buffer", "-"]) {
-            return provider;
-        }
+    if std::env::var("TMUX").is_ok()
+        && let Some(provider) = check_prog("tmux", &["load-buffer", "-"])
+    {
+        return provider;
     }
 
     Provider::OSC52

--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -41,7 +41,7 @@ impl<'a, W> TerminalPane<'a, W> {
         self.terminal_output.stdin.is_some()
     }
 
-    fn footer(&self) -> Line {
+    fn footer(&self) -> Line<'_> {
         let build_message_vec = |footer_text: &[&str]| -> Line {
             let mut messages = Vec::new();
             messages.extend_from_slice(footer_text);

--- a/crates/turborepo-ui/src/tui/table.rs
+++ b/crates/turborepo-ui/src/tui/table.rs
@@ -51,7 +51,7 @@ impl<'b> TaskTable<'b> {
         self.spinner.update();
     }
 
-    fn finished_rows(&self) -> impl Iterator<Item = Row> + '_ {
+    fn finished_rows(&self) -> impl Iterator<Item = Row<'_>> + '_ {
         self.tasks_by_type.finished.iter().map(move |task| {
             let name = if matches!(task.result(), TaskResult::CacheHit) {
                 Cell::new(Text::styled(task.name(), Style::default().italic()))
@@ -77,7 +77,7 @@ impl<'b> TaskTable<'b> {
         })
     }
 
-    fn running_rows(&self) -> impl Iterator<Item = Row> + '_ {
+    fn running_rows(&self) -> impl Iterator<Item = Row<'_>> + '_ {
         let spinner = self.spinner.current();
         self.tasks_by_type
             .running
@@ -85,7 +85,7 @@ impl<'b> TaskTable<'b> {
             .map(move |task| Row::new(vec![Cell::new(task.name()), Cell::new(Text::raw(spinner))]))
     }
 
-    fn planned_rows(&self) -> impl Iterator<Item = Row> + '_ {
+    fn planned_rows(&self) -> impl Iterator<Item = Row<'_>> + '_ {
         self.tasks_by_type
             .planned
             .iter()

--- a/crates/turborepo-ui/src/wui/query.rs
+++ b/crates/turborepo-ui/src/wui/query.rs
@@ -54,7 +54,7 @@ impl RunQuery {
 
 #[Object]
 impl RunQuery {
-    async fn current_run(&self) -> Option<CurrentRun> {
+    async fn current_run(&self) -> Option<CurrentRun<'_>> {
         Some(CurrentRun {
             state: self.state.as_ref()?,
         })

--- a/crates/turborepo-unescape/Cargo.toml
+++ b/crates/turborepo-unescape/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turborepo-unescape"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 license = "MPL-2.0"
 
 [dependencies]

--- a/crates/turborepo-updater/Cargo.toml
+++ b/crates/turborepo-updater/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turbo-updater"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 description = "Minimal wrapper around update-informer to provide npm registry support and consistent UI"
 license = "MIT"
 publish = false

--- a/crates/turborepo-vercel-api-mock/Cargo.toml
+++ b/crates/turborepo-vercel-api-mock/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turborepo-vercel-api-mock"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/turborepo-vercel-api/Cargo.toml
+++ b/crates/turborepo-vercel-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turborepo-vercel-api"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/turborepo-vt100/Cargo.toml
+++ b/crates/turborepo-vt100/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turborepo-vt100"
 version = "0.15.2"
 authors = ["Jesse Luehrs <doy@tozt.net>"]
-edition = "2024"
+edition = { workspace = true }
 
 description = "Library for parsing terminal data"
 homepage = "https://github.com/doy/vt100-rust"

--- a/crates/turborepo-vt100/src/parser.rs
+++ b/crates/turborepo-vt100/src/parser.rs
@@ -61,7 +61,7 @@ impl Parser {
     /// Returns a reference to an `EntireScreen` object containing the
     /// terminal state where all contents including scrollback and displayed.
     #[must_use]
-    pub fn entire_screen(&self) -> crate::EntireScreen {
+    pub fn entire_screen(&self) -> crate::EntireScreen<'_> {
         crate::EntireScreen::new(self.screen())
     }
 }

--- a/crates/turborepo-vt100/src/row.rs
+++ b/crates/turborepo-vt100/src/row.rs
@@ -199,35 +199,34 @@ impl Row {
             let col: u16 = col.try_into().unwrap();
             let pos = crate::grid::Pos { row, col };
 
-            if let Some((prev_col, attrs)) = erase {
-                if cell.has_contents() || cell.attrs() != attrs {
-                    let new_pos = crate::grid::Pos { row, col: prev_col };
-                    if wrapping
-                        && prev_pos.row + 1 == new_pos.row
-                        && prev_pos.col >= self.cols()
-                    {
-                        if new_pos.col > 0 {
-                            contents.extend(
-                                " ".repeat(usize::from(new_pos.col))
-                                    .as_bytes(),
-                            );
-                        } else {
-                            contents.extend(b" ");
-                            crate::term::Backspace.write_buf(contents);
-                        }
+            if let Some((prev_col, attrs)) = erase
+                && (cell.has_contents() || cell.attrs() != attrs)
+            {
+                let new_pos = crate::grid::Pos { row, col: prev_col };
+                if wrapping
+                    && prev_pos.row + 1 == new_pos.row
+                    && prev_pos.col >= self.cols()
+                {
+                    if new_pos.col > 0 {
+                        contents.extend(
+                            " ".repeat(usize::from(new_pos.col)).as_bytes(),
+                        );
                     } else {
-                        crate::term::MoveFromTo::new(prev_pos, new_pos)
-                            .write_buf(contents);
+                        contents.extend(b" ");
+                        crate::term::Backspace.write_buf(contents);
                     }
-                    prev_pos = new_pos;
-                    if &prev_attrs != attrs {
-                        attrs.write_escape_code_diff(contents, &prev_attrs);
-                        prev_attrs = *attrs;
-                    }
-                    crate::term::EraseChar::new(pos.col - prev_col)
+                } else {
+                    crate::term::MoveFromTo::new(prev_pos, new_pos)
                         .write_buf(contents);
-                    erase = None;
                 }
+                prev_pos = new_pos;
+                if &prev_attrs != attrs {
+                    attrs.write_escape_code_diff(contents, &prev_attrs);
+                    prev_attrs = *attrs;
+                }
+                crate::term::EraseChar::new(pos.col - prev_col)
+                    .write_buf(contents);
+                erase = None;
             }
 
             if cell != &default_cell {
@@ -356,35 +355,34 @@ impl Row {
             let col: u16 = col.try_into().unwrap();
             let pos = crate::grid::Pos { row, col };
 
-            if let Some((prev_col, attrs)) = erase {
-                if cell.has_contents() || cell.attrs() != attrs {
-                    let new_pos = crate::grid::Pos { row, col: prev_col };
-                    if wrapping
-                        && prev_pos.row + 1 == new_pos.row
-                        && prev_pos.col >= self.cols()
-                    {
-                        if new_pos.col > 0 {
-                            contents.extend(
-                                " ".repeat(usize::from(new_pos.col))
-                                    .as_bytes(),
-                            );
-                        } else {
-                            contents.extend(b" ");
-                            crate::term::Backspace.write_buf(contents);
-                        }
+            if let Some((prev_col, attrs)) = erase
+                && (cell.has_contents() || cell.attrs() != attrs)
+            {
+                let new_pos = crate::grid::Pos { row, col: prev_col };
+                if wrapping
+                    && prev_pos.row + 1 == new_pos.row
+                    && prev_pos.col >= self.cols()
+                {
+                    if new_pos.col > 0 {
+                        contents.extend(
+                            " ".repeat(usize::from(new_pos.col)).as_bytes(),
+                        );
                     } else {
-                        crate::term::MoveFromTo::new(prev_pos, new_pos)
-                            .write_buf(contents);
+                        contents.extend(b" ");
+                        crate::term::Backspace.write_buf(contents);
                     }
-                    prev_pos = new_pos;
-                    if &prev_attrs != attrs {
-                        attrs.write_escape_code_diff(contents, &prev_attrs);
-                        prev_attrs = *attrs;
-                    }
-                    crate::term::EraseChar::new(pos.col - prev_col)
+                } else {
+                    crate::term::MoveFromTo::new(prev_pos, new_pos)
                         .write_buf(contents);
-                    erase = None;
                 }
+                prev_pos = new_pos;
+                if &prev_attrs != attrs {
+                    attrs.write_escape_code_diff(contents, &prev_attrs);
+                    prev_attrs = *attrs;
+                }
+                crate::term::EraseChar::new(pos.col - prev_col)
+                    .write_buf(contents);
+                erase = None;
             }
 
             if cell != prev_cell {

--- a/crates/turborepo-vt100/tests/split-escapes.rs
+++ b/crates/turborepo-vt100/tests/split-escapes.rs
@@ -25,10 +25,10 @@ fn test_splits(filename: &str, limit: Option<usize>) {
     let len = bytes.len();
     let expected = write_to_parser(&mut [bytes.clone()]);
     for i in 0..(len - 1) {
-        if let Some(limit) = limit {
-            if i > limit {
-                break;
-            }
+        if let Some(limit) = limit
+            && i > limit
+        {
+            break;
         }
         let bytes_copy = bytes.clone();
         let (start, end) = bytes_copy.split_at(i);

--- a/crates/turborepo-wax/Cargo.toml
+++ b/crates/turborepo-wax/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Sean Olson <olson.sean.k@gmail.com>"]
 description = "Opinionated and portable globs that can be matched against paths and directory trees."
 repository = "https://github.com/olson-sean-k/wax"
 readme = "README.md"
-edition = "2024"
+edition = { workspace = true }
 license = "MIT"
 keywords = ["glob", "pattern", "regex"]
 categories = ["filesystem"]

--- a/crates/turborepo-wax/src/capture.rs
+++ b/crates/turborepo-wax/src/capture.rs
@@ -176,7 +176,7 @@ impl<'t> MatchedText<'t> {
         }
     }
 
-    pub fn to_candidate_path(&self) -> CandidatePath {
+    pub fn to_candidate_path(&self) -> CandidatePath<'_> {
         CandidatePath::from(self.complete())
     }
 }

--- a/crates/turborepo-wax/src/lib.rs
+++ b/crates/turborepo-wax/src/lib.rs
@@ -1000,7 +1000,7 @@ where
 // It is possible to call this function using a mutable reference, which may appear to mutate the
 // parameter in place.
 #[must_use]
-pub fn escape(unescaped: &str) -> Cow<str> {
+pub fn escape(unescaped: &str) -> Cow<'_, str> {
     const ESCAPE: char = '\\';
 
     if unescaped.chars().any(is_meta_character) {
@@ -1045,7 +1045,7 @@ pub const fn is_contextual_meta_character(x: char) -> bool {
     matches!(x, '-')
 }
 
-fn parse_and_check(expression: &str) -> Result<Checked<Tokenized>, BuildError> {
+fn parse_and_check(expression: &str) -> Result<Checked<Tokenized<'_>>, BuildError> {
     let tokenized = token::parse(expression)?;
     let checked = rule::check(tokenized)?;
     Ok(checked)

--- a/crates/turborepo-wax/src/token/parse.rs
+++ b/crates/turborepo-wax/src/token/parse.rs
@@ -178,7 +178,7 @@ enum FlagToggle {
     CaseInsensitive(bool),
 }
 
-pub fn parse(expression: &str) -> Result<Tokenized, ParseError> {
+pub fn parse(expression: &str) -> Result<Tokenized<'_>, ParseError<'_>> {
     use nom::{
         branch, bytes::complete as bytes, character::complete as character, combinator, error,
         multi, sequence, IResult, Parser,

--- a/crates/turborepo/Cargo.toml
+++ b/crates/turborepo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turbo"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 license = "MIT"
 
 [features]

--- a/packages/turbo-repository/rust/Cargo.toml
+++ b/packages/turbo-repository/rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "turborepo-napi"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 license = "MIT"
 
 [lib]

--- a/packages/turbo-repository/scripts/build.sh
+++ b/packages/turbo-repository/scripts/build.sh
@@ -13,7 +13,7 @@ script_provided_flags="\
 for flag in $user_provided_flags; do
   if [[ $flag == --target=* ]]; then
     target=${flag#*=}
-    rustup toolchain install nightly-2025-05-09 --target "$target"
+    rustup toolchain install nightly-2025-06-20 --target "$target"
 
     # For we need to cross-compile some targets with Zig
     # Fortunately, napi comes with a `--zig` flag

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Needs to be copied to `packages/turbo-repository/scripts/build.sh`
-channel = "nightly-2025-05-09"
+channel = "nightly-2025-06-20"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
### Description

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->
- fix mismatched_lifetime_syntaxes lints
- let chains are now stable in edition 2024, so use them
- change workspace logic so "2024" edition is now applied for all package with `workspace = true`

### Testing Instructions

CI
<!--
  Give a quick description of steps to test your changes.
-->
