### PR TITLE
feat(turbo_json): add `$TURBO_EXTENDS$`

### DIFF
--- a/crates/turborepo-lib/src/config/env.rs
+++ b/crates/turborepo-lib/src/config/env.rs
@@ -255,6 +255,8 @@ impl ResolvedConfigurationOptions for EnvVars {
             root_turbo_json_path,
             log_order,
             sso_login_callback_port,
+            // Do not allow future flags to be set by env var
+            future_flags: None,
         };
 
         Ok(output)

--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -23,8 +23,11 @@ use turborepo_cache::CacheConfig;
 use turborepo_errors::TURBO_SITE;
 use turborepo_repository::package_graph::PackageName;
 
-use crate::cli::{EnvMode, LogOrder};
 pub use crate::turbo_json::{RawTurboJson, UIMode};
+use crate::{
+    cli::{EnvMode, LogOrder},
+    turbo_json::FutureFlags,
+};
 
 pub const CONFIG_FILE: &str = "turbo.json";
 pub const CONFIG_FILE_JSONC: &str = "turbo.jsonc";
@@ -312,6 +315,8 @@ pub struct ConfigurationOptions {
     pub(crate) concurrency: Option<String>,
     pub(crate) no_update_notifier: Option<bool>,
     pub(crate) sso_login_callback_port: Option<u16>,
+    #[serde(skip)]
+    future_flags: Option<FutureFlags>,
 }
 
 #[derive(Default)]
@@ -470,6 +475,10 @@ impl ConfigurationOptions {
 
     pub fn sso_login_callback_port(&self) -> Option<u16> {
         self.sso_login_callback_port
+    }
+
+    pub fn future_flags(&self) -> FutureFlags {
+        self.future_flags.unwrap_or_default()
     }
 }
 

--- a/crates/turborepo-lib/src/config/turbo_json.rs
+++ b/crates/turborepo-lib/src/config/turbo_json.rs
@@ -78,7 +78,7 @@ impl<'a> TurboJsonReader<'a> {
         opts.env_mode = turbo_json.env_mode.map(|mode| *mode.as_inner());
         opts.cache_dir = cache_dir;
         opts.concurrency = turbo_json.concurrency.map(|c| c.as_inner().clone());
-        opts.future_flags = turbo_json.future_flags.map(|f| f.as_inner().clone());
+        opts.future_flags = turbo_json.future_flags.map(|f| *f.as_inner());
         Ok(opts)
     }
 }

--- a/crates/turborepo-lib/src/config/turbo_json.rs
+++ b/crates/turborepo-lib/src/config/turbo_json.rs
@@ -78,6 +78,7 @@ impl<'a> TurboJsonReader<'a> {
         opts.env_mode = turbo_json.env_mode.map(|mode| *mode.as_inner());
         opts.cache_dir = cache_dir;
         opts.concurrency = turbo_json.concurrency.map(|c| c.as_inner().clone());
+        opts.future_flags = turbo_json.future_flags.map(|f| f.as_inner().clone());
         Ok(opts)
     }
 }

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -585,7 +585,7 @@ impl<'a> EngineBuilder<'a> {
         let root_turbo_json = turbo_json_loader.load(&PackageName::Root)?;
         Error::from_validation(root_turbo_json.validate(&[validate_with_has_no_topo]))?;
 
-        if let Some(root_definition) = root_turbo_json.task(task_id, task_name) {
+        if let Some(root_definition) = root_turbo_json.task(task_id, task_name)? {
             task_definitions.push(root_definition)
         }
 
@@ -614,7 +614,7 @@ impl<'a> EngineBuilder<'a> {
                         validate_with_has_no_topo,
                     ]))?;
 
-                    if let Some(workspace_def) = workspace_json.task(task_id, task_name) {
+                    if let Some(workspace_def) = workspace_json.task(task_id, task_name)? {
                         task_definitions.push(workspace_def);
                     }
                 }

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -14,7 +14,7 @@ use crate::{
         OutputLogsMode, RunArgs,
     },
     config::{ConfigurationOptions, CONFIG_FILE},
-    turbo_json::UIMode,
+    turbo_json::{FutureFlags, UIMode},
     Args,
 };
 
@@ -77,6 +77,7 @@ pub struct Opts {
     pub runcache_opts: RunCacheOpts,
     pub scope_opts: ScopeOpts,
     pub tui_opts: TuiOpts,
+    pub future_flags: FutureFlags,
 }
 
 impl Opts {
@@ -180,6 +181,7 @@ impl Opts {
         let api_client_opts = APIClientOpts::from(inputs);
         let repo_opts = RepoOpts::from(inputs);
         let tui_opts = TuiOpts::from(inputs);
+        let future_flags = config.future_flags();
 
         Ok(Self {
             repo_opts,
@@ -189,6 +191,7 @@ impl Opts {
             runcache_opts,
             api_client_opts,
             tui_opts,
+            future_flags,
         })
     }
 }
@@ -747,6 +750,7 @@ mod test {
             cache_opts,
             runcache_opts,
             tui_opts,
+            future_flags: Default::default(),
         };
         let synthesized = opts.synthesize_command();
         assert_eq!(synthesized, expected);

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -25,7 +25,7 @@ use turborepo_scm::GitHashes;
 
 use crate::{
     config::{resolve_turbo_config_path, CONFIG_FILE, CONFIG_FILE_JSONC},
-    turbo_json::{TurboJson, TurboJsonLoader},
+    turbo_json::{TurboJson, TurboJsonLoader, TurboJsonReader},
 };
 
 #[derive(Clone)]
@@ -232,7 +232,7 @@ impl Subscriber {
         };
 
         let root_turbo_json = TurboJsonLoader::workspace(
-            self.repo_root.clone(),
+            TurboJsonReader::new(self.repo_root.clone()),
             config_path,
             pkg_dep_graph.packages(),
         )

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -49,7 +49,7 @@ use crate::{
     opts::Opts,
     run::{scope, task_access::TaskAccess, Error, Run, RunCache},
     shim::TurboState,
-    turbo_json::{TurboJson, TurboJsonLoader, UIMode},
+    turbo_json::{TurboJson, TurboJsonLoader, TurboJsonReader, UIMode},
     DaemonConnector,
 };
 
@@ -408,16 +408,19 @@ impl RunBuilder {
         task_access.restore_config().await;
 
         let root_turbo_json_path = self.opts.repo_opts.root_turbo_json_path.clone();
+        let future_flags = self.opts.future_flags;
+
+        let reader = TurboJsonReader::new(self.repo_root.clone()).with_future_flags(future_flags);
 
         let turbo_json_loader = if task_access.is_enabled() {
             TurboJsonLoader::task_access(
-                self.repo_root.clone(),
+                reader,
                 root_turbo_json_path.clone(),
                 root_package_json.clone(),
             )
         } else if is_single_package {
             TurboJsonLoader::single_package(
-                self.repo_root.clone(),
+                reader,
                 root_turbo_json_path.clone(),
                 root_package_json.clone(),
             )
@@ -426,20 +429,20 @@ impl RunBuilder {
         (self.opts.repo_opts.allow_no_turbo_json || micro_frontend_configs.is_some())
         {
             TurboJsonLoader::workspace_no_turbo_json(
-                self.repo_root.clone(),
+                reader,
                 pkg_dep_graph.packages(),
                 micro_frontend_configs.clone(),
             )
         } else if let Some(micro_frontends) = &micro_frontend_configs {
             TurboJsonLoader::workspace_with_microfrontends(
-                self.repo_root.clone(),
+                reader,
                 root_turbo_json_path.clone(),
                 pkg_dep_graph.packages(),
                 micro_frontends.clone(),
             )
         } else {
             TurboJsonLoader::workspace(
-                self.repo_root.clone(),
+                reader,
                 root_turbo_json_path.clone(),
                 pkg_dep_graph.packages(),
             )

--- a/crates/turborepo-lib/src/turbo_json/ARCHITECTURE.md
+++ b/crates/turborepo-lib/src/turbo_json/ARCHITECTURE.md
@@ -9,9 +9,10 @@ The loading and resolving of task definitions is driven during task graph constr
 The configuration and task loading process follows this high-level flow:
 
 1. **Configuration Resolution**: Collect and merge configuration from multiple sources
-2. **TurboJson Loading**: Resolve `turbo.json` files, these are usually files on disk, but can be synthesized
-3. **Task Definition Resolution**: Convert raw task definitions into validated structures. `extends` is handled in this step
-4. **Task Graph Construction**: Build the executable task graph from resolved definitions
+2. **TurboJson Loading**: Parse `turbo.json` files into raw structures
+3. **Task Processing**: Convert raw definitions to processed intermediate representation with DSL token handling
+4. **Task Definition Resolution**: Transform processed definitions into final validated structures
+5. **Task Graph Construction**: Build the executable task graph from resolved definitions
 
 ## Phase 1: Configuration Resolution
 
@@ -39,30 +40,55 @@ Configuration is collected from multiple sources with the following priority (hi
 
 - **`TurboJsonLoader`** (`crates/turborepo-lib/src/turbo_json/loader.rs`): Loads and resolves turbo.json files
 - **`RawTurboJson`**: Raw deserialized structure from JSON files
-- **`TurboJson`**: Resolved and validated structure, all DSL magic strings have been handled
+- **`TurboJson`**: Validated structure containing raw task definitions
 
 ### Process
 
 1. **File Discovery**: Locate `turbo.json` or `turbo.jsonc` files
 2. **Parsing**: Deserialize JSON into `RawTurboJson` structures
-3. **Validation**: Convert to `TurboJson` with validation rules
+3. **Basic Validation**: Convert to `TurboJson` with structural validation
 4. **Workspace Resolution**: Apply workspace-specific overrides
 
-## Phase 3: Task Definition Resolution
+## Phase 3: Processed Task Definition (Intermediate Representation)
+
+### Key Components
+
+- **`ProcessedTaskDefinition`** (`crates/turborepo-lib/src/turbo_json/processed.rs`): Intermediate representation with DSL token processing
+- **`ProcessedGlob`**: Parsed glob patterns with separated components (base pattern, negation flag, turbo_root flag)
+- **`ProcessedInputs`/`ProcessedOutputs`**: Collections of processed globs with resolution methods
+
+### Processing Steps
+
+1. **DSL Token Detection**: Identify and separate `$TURBO_ROOT$` and `!` prefixes from glob patterns
+2. **Early Validation**: Validate absolute paths and invalid token usage at parse time with span information
+3. **Prefix Stripping**: Store clean glob patterns without DSL prefixes
+4. **Component Separation**: Track negation and turbo_root requirements as separate boolean flags
+
+## Phase 4: Task Definition Resolution
 
 ### Key Components
 
 - **`RawTaskDefinition`**: Raw task configuration from JSON
-- **`TaskDefinition`**: Validated and processed task configuration
+- **`ProcessedTaskDefinition`**: Intermediate representation with parsed DSL tokens
+- **`TaskDefinition`**: Final validated and resolved task configuration
 - **`TaskId`** and **`TaskName`** (from `turborepo-task-id` crate): Task identification types
 
 ### Transformation Process
 
-Raw task definitions undergo several transformations:
+The resolution now follows a three-stage pipeline:
 
-1. **Path Resolution**: Convert relative paths and handle `$TURBO_ROOT$` tokens
-2. **Dependency Parsing**: Parse `dependsOn` into topological and task dependencies
-3. **Environment Variable Collection**: Extract `env` and `passThroughEnv` variables
-4. **Output Processing**: Handle inclusion/exclusion patterns in outputs
-5. **Inheritance**: Handle merging multiple `RawTaskDefinition`s into a single usable task definition
-6. **Validation**: Ensure configuration consistency (e.g., interactive tasks can't be cached)
+1. **Raw → Processed** (`ProcessedTaskDefinition::from_raw`):
+
+   - Parse glob patterns and extract DSL tokens
+   - Validate absolute paths with span information
+   - Strip prefixes and store components separately
+
+2. **Processed → Resolved** (`TaskDefinition::from_processed`):
+
+   - Apply `$TURBO_ROOT$` token replacement using `resolve()` methods
+   - Parse `dependsOn` into topological and task dependencies
+   - Extract environment variables from `env` and `passThroughEnv`
+   - Transform outputs into inclusion/exclusion patterns
+   - Validate configuration consistency (e.g., interactive tasks can't be cached)
+
+3. **Inheritance**: The `extend` module handles merging multiple `ProcessedTaskDefinition`s before final resolution

--- a/crates/turborepo-lib/src/turbo_json/extend.rs
+++ b/crates/turborepo-lib/src/turbo_json/extend.rs
@@ -68,10 +68,9 @@ mod test {
                 Spanned::new(UnescapedString::from("dist/**")),
             )
             .unwrap()])),
-            inputs: Some(ProcessedInputs(vec![ProcessedGlob::from_spanned_input(
-                Spanned::new(UnescapedString::from("src/**")),
-            )
-            .unwrap()])),
+            inputs: Some(
+                ProcessedInputs::new(vec![Spanned::new(UnescapedString::from("src/**"))]).unwrap(),
+            ),
             env: Some(ProcessedEnv(vec![Spanned::new(UnescapedString::from(
                 "NODE_ENV",
             ))])),
@@ -93,10 +92,9 @@ mod test {
                 Spanned::new(UnescapedString::from("build/**")),
             )
             .unwrap()])),
-            inputs: Some(ProcessedInputs(vec![ProcessedGlob::from_spanned_input(
-                Spanned::new(UnescapedString::from("lib/**")),
-            )
-            .unwrap()])),
+            inputs: Some(
+                ProcessedInputs::new(vec![Spanned::new(UnescapedString::from("lib/**"))]).unwrap(),
+            ),
             env: Some(ProcessedEnv(vec![Spanned::new(UnescapedString::from(
                 "PROD_ENV",
             ))])),
@@ -220,10 +218,9 @@ mod test {
 
         let second = ProcessedTaskDefinition {
             persistent: Some(Spanned::new(false)),
-            inputs: Some(ProcessedInputs(vec![ProcessedGlob::from_spanned_input(
-                Spanned::new(UnescapedString::from("src/**")),
-            )
-            .unwrap()])),
+            inputs: Some(
+                ProcessedInputs::new(vec![Spanned::new(UnescapedString::from("src/**"))]).unwrap(),
+            ),
             ..Default::default()
         };
 

--- a/crates/turborepo-lib/src/turbo_json/extend.rs
+++ b/crates/turborepo-lib/src/turbo_json/extend.rs
@@ -56,7 +56,7 @@ mod test {
     use super::*;
     use crate::{
         cli::OutputLogsMode,
-        turbo_json::processed::{ProcessedEnv, ProcessedInputs, ProcessedOutputs},
+        turbo_json::processed::{ProcessedEnv, ProcessedGlob, ProcessedInputs, ProcessedOutputs},
     };
 
     // Shared test fixtures
@@ -64,12 +64,14 @@ mod test {
         ProcessedTaskDefinition {
             cache: Some(Spanned::new(true)),
             persistent: Some(Spanned::new(false)),
-            outputs: Some(ProcessedOutputs(vec![Spanned::new(UnescapedString::from(
-                "dist/**",
-            ))])),
-            inputs: Some(ProcessedInputs(vec![Spanned::new(UnescapedString::from(
-                "src/**",
-            ))])),
+            outputs: Some(ProcessedOutputs(vec![ProcessedGlob::from_spanned_output(
+                Spanned::new(UnescapedString::from("dist/**")),
+            )
+            .unwrap()])),
+            inputs: Some(ProcessedInputs(vec![ProcessedGlob::from_spanned_input(
+                Spanned::new(UnescapedString::from("src/**")),
+            )
+            .unwrap()])),
             env: Some(ProcessedEnv(vec![Spanned::new(UnescapedString::from(
                 "NODE_ENV",
             ))])),
@@ -87,12 +89,14 @@ mod test {
         ProcessedTaskDefinition {
             cache: Some(Spanned::new(false)),
             persistent: Some(Spanned::new(true)),
-            outputs: Some(ProcessedOutputs(vec![Spanned::new(UnescapedString::from(
-                "build/**",
-            ))])),
-            inputs: Some(ProcessedInputs(vec![Spanned::new(UnescapedString::from(
-                "lib/**",
-            ))])),
+            outputs: Some(ProcessedOutputs(vec![ProcessedGlob::from_spanned_output(
+                Spanned::new(UnescapedString::from("build/**")),
+            )
+            .unwrap()])),
+            inputs: Some(ProcessedInputs(vec![ProcessedGlob::from_spanned_input(
+                Spanned::new(UnescapedString::from("lib/**")),
+            )
+            .unwrap()])),
             env: Some(ProcessedEnv(vec![Spanned::new(UnescapedString::from(
                 "PROD_ENV",
             ))])),
@@ -207,17 +211,19 @@ mod test {
     fn test_from_iter_combines_across_multiple_tasks() {
         let first = ProcessedTaskDefinition {
             cache: Some(Spanned::new(true)),
-            outputs: Some(ProcessedOutputs(vec![Spanned::new(UnescapedString::from(
-                "dist/**",
-            ))])),
+            outputs: Some(ProcessedOutputs(vec![ProcessedGlob::from_spanned_output(
+                Spanned::new(UnescapedString::from("dist/**")),
+            )
+            .unwrap()])),
             ..Default::default()
         };
 
         let second = ProcessedTaskDefinition {
             persistent: Some(Spanned::new(false)),
-            inputs: Some(ProcessedInputs(vec![Spanned::new(UnescapedString::from(
-                "src/**",
-            ))])),
+            inputs: Some(ProcessedInputs(vec![ProcessedGlob::from_spanned_input(
+                Spanned::new(UnescapedString::from("src/**")),
+            )
+            .unwrap()])),
             ..Default::default()
         };
 

--- a/crates/turborepo-lib/src/turbo_json/extend.rs
+++ b/crates/turborepo-lib/src/turbo_json/extend.rs
@@ -71,9 +71,9 @@ mod test {
             inputs: Some(
                 ProcessedInputs::new(vec![Spanned::new(UnescapedString::from("src/**"))]).unwrap(),
             ),
-            env: Some(ProcessedEnv(vec![Spanned::new(UnescapedString::from(
-                "NODE_ENV",
-            ))])),
+            env: Some(
+                ProcessedEnv::new(vec![Spanned::new(UnescapedString::from("NODE_ENV"))]).unwrap(),
+            ),
             depends_on: None,
             pass_through_env: None,
             output_logs: None,
@@ -95,9 +95,9 @@ mod test {
             inputs: Some(
                 ProcessedInputs::new(vec![Spanned::new(UnescapedString::from("lib/**"))]).unwrap(),
             ),
-            env: Some(ProcessedEnv(vec![Spanned::new(UnescapedString::from(
-                "PROD_ENV",
-            ))])),
+            env: Some(
+                ProcessedEnv::new(vec![Spanned::new(UnescapedString::from("PROD_ENV"))]).unwrap(),
+            ),
             output_logs: Some(Spanned::new(OutputLogsMode::Full)),
             interruptible: Some(Spanned::new(true)),
             depends_on: None,
@@ -225,9 +225,9 @@ mod test {
         };
 
         let third = ProcessedTaskDefinition {
-            env: Some(ProcessedEnv(vec![Spanned::new(UnescapedString::from(
-                "NODE_ENV",
-            ))])),
+            env: Some(
+                ProcessedEnv::new(vec![Spanned::new(UnescapedString::from("NODE_ENV"))]).unwrap(),
+            ),
             output_logs: Some(Spanned::new(OutputLogsMode::Full)),
             // Override cache from first task
             cache: Some(Spanned::new(false)),

--- a/crates/turborepo-lib/src/turbo_json/extend.rs
+++ b/crates/turborepo-lib/src/turbo_json/extend.rs
@@ -1,6 +1,6 @@
 //! Module for code related to "extends" behavior for task definitions
 
-use super::ProcessedTaskDefinition;
+use super::processed::ProcessedTaskDefinition;
 
 impl FromIterator<ProcessedTaskDefinition> for ProcessedTaskDefinition {
     fn from_iter<T: IntoIterator<Item = ProcessedTaskDefinition>>(iter: T) -> Self {
@@ -56,7 +56,7 @@ mod test {
     use super::*;
     use crate::{
         cli::OutputLogsMode,
-        turbo_json::{ProcessedEnv, ProcessedInputs, ProcessedOutputs},
+        turbo_json::processed::{ProcessedEnv, ProcessedInputs, ProcessedOutputs},
     };
 
     // Shared test fixtures

--- a/crates/turborepo-lib/src/turbo_json/extend.rs
+++ b/crates/turborepo-lib/src/turbo_json/extend.rs
@@ -56,7 +56,7 @@ mod test {
     use super::*;
     use crate::{
         cli::OutputLogsMode,
-        turbo_json::processed::{ProcessedEnv, ProcessedGlob, ProcessedInputs, ProcessedOutputs},
+        turbo_json::processed::{ProcessedEnv, ProcessedInputs, ProcessedOutputs},
     };
 
     // Shared test fixtures
@@ -64,10 +64,10 @@ mod test {
         ProcessedTaskDefinition {
             cache: Some(Spanned::new(true)),
             persistent: Some(Spanned::new(false)),
-            outputs: Some(ProcessedOutputs(vec![ProcessedGlob::from_spanned_output(
-                Spanned::new(UnescapedString::from("dist/**")),
-            )
-            .unwrap()])),
+            outputs: Some(
+                ProcessedOutputs::new(vec![Spanned::new(UnescapedString::from("dist/**"))])
+                    .unwrap(),
+            ),
             inputs: Some(
                 ProcessedInputs::new(vec![Spanned::new(UnescapedString::from("src/**"))]).unwrap(),
             ),
@@ -88,10 +88,10 @@ mod test {
         ProcessedTaskDefinition {
             cache: Some(Spanned::new(false)),
             persistent: Some(Spanned::new(true)),
-            outputs: Some(ProcessedOutputs(vec![ProcessedGlob::from_spanned_output(
-                Spanned::new(UnescapedString::from("build/**")),
-            )
-            .unwrap()])),
+            outputs: Some(
+                ProcessedOutputs::new(vec![Spanned::new(UnescapedString::from("build/**"))])
+                    .unwrap(),
+            ),
             inputs: Some(
                 ProcessedInputs::new(vec![Spanned::new(UnescapedString::from("lib/**"))]).unwrap(),
             ),
@@ -209,10 +209,10 @@ mod test {
     fn test_from_iter_combines_across_multiple_tasks() {
         let first = ProcessedTaskDefinition {
             cache: Some(Spanned::new(true)),
-            outputs: Some(ProcessedOutputs(vec![ProcessedGlob::from_spanned_output(
-                Spanned::new(UnescapedString::from("dist/**")),
-            )
-            .unwrap()])),
+            outputs: Some(
+                ProcessedOutputs::new(vec![Spanned::new(UnescapedString::from("dist/**"))])
+                    .unwrap(),
+            ),
             ..Default::default()
         };
 

--- a/crates/turborepo-lib/src/turbo_json/future_flags.rs
+++ b/crates/turborepo-lib/src/turbo_json/future_flags.rs
@@ -34,7 +34,7 @@ pub struct FutureFlags {
     /// When enabled, allows using `$TURBO_EXTENDS$` in array fields.
     /// This will change the default behavior of overriding the field to instead
     /// append.
-    pub turbo_extends: bool,
+    pub turbo_extends_keyword: bool,
 }
 
 impl FutureFlags {

--- a/crates/turborepo-lib/src/turbo_json/future_flags.rs
+++ b/crates/turborepo-lib/src/turbo_json/future_flags.rs
@@ -1,0 +1,45 @@
+//! Future flags for enabling experimental or upcoming features
+//!
+//! This module contains the `FutureFlags` structure which allows users to
+//! opt-in to experimental features before they become the default behavior.
+//!
+//! ## Usage
+//!
+//! Future flags can be configured in the root `turbo.json`:
+//!
+//! ```json
+//! {
+//!   "futureFlags": {
+//!     "turboExtends": true
+//!   }
+//! }
+//! ```
+//!
+//! Note: Future flags are only allowed in the root `turbo.json` and will cause
+//! an error if specified in workspace packages.
+
+use biome_deserialize_macros::Deserializable;
+use serde::Serialize;
+use struct_iterable::Iterable;
+
+/// Future flags configuration for experimental features
+///
+/// Each flag represents an experimental feature that can be enabled
+/// before it becomes the default behavior in a future version.
+#[derive(Serialize, Default, Debug, Copy, Clone, Iterable, Deserializable, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct FutureFlags {
+    /// Enable `$TURBO_EXTENDS$`
+    ///
+    /// When enabled, allows using `$TURBO_EXTENDS$` in array fields.
+    /// This will change the default behavior of overriding the field to instead
+    /// append.
+    pub turbo_extends: bool,
+}
+
+impl FutureFlags {
+    /// Create a new FutureFlags with all features disabled
+    pub fn new() -> Self {
+        Self::default()
+    }
+}

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -1273,7 +1273,7 @@ mod tests {
                 "build": {}
             },
             "futureFlags": {
-                "turboExtends": true
+                "turboExtendsKeyword": true
             }
         }"#;
 
@@ -1290,7 +1290,7 @@ mod tests {
         assert_eq!(
             future_flags.as_inner(),
             &FutureFlags {
-                turbo_extends: true
+                turbo_extends_keyword: true
             }
         );
 

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -160,7 +160,10 @@ pub struct RawTurboJson {
 
 #[derive(Serialize, Default, Debug, Copy, Clone, Iterable, Deserializable, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub struct FutureFlags {}
+pub struct FutureFlags {
+    #[deserializable(rename = "turbo_extends")]
+    turbo_extends: bool,
+}
 
 #[derive(Serialize, Default, Debug, PartialEq, Clone)]
 #[serde(transparent)]
@@ -1380,7 +1383,7 @@ mod tests {
                 "build": {}
             },
             "futureFlags": {
-                "bestFeature": true
+                "turboExtends": true
             }
         }"#;
 
@@ -1394,7 +1397,12 @@ mod tests {
         // Verify that futureFlags is parsed correctly
         assert!(raw_turbo_json.future_flags.is_some());
         let future_flags = raw_turbo_json.future_flags.as_ref().unwrap();
-        assert_eq!(future_flags.as_inner(), &FutureFlags {});
+        assert_eq!(
+            future_flags.as_inner(),
+            &FutureFlags {
+                turbo_extends: true
+            }
+        );
 
         // Verify that the futureFlags field doesn't cause errors during conversion to
         // TurboJson

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -34,8 +34,6 @@ pub use processed::ProcessedTaskDefinition;
 
 use crate::{boundaries::BoundariesConfig, config::UnnecessaryPackageTaskSyntaxError};
 
-const TURBO_ROOT: &str = "$TURBO_ROOT$";
-const TURBO_ROOT_SLASH: &str = "$TURBO_ROOT$/";
 const TURBO_DEFAULT: &str = "$TURBO_DEFAULT$";
 
 const ENV_PIPELINE_DELIMITER: &str = "$";

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -36,7 +36,7 @@ use crate::{boundaries::BoundariesConfig, config::UnnecessaryPackageTaskSyntaxEr
 
 const TURBO_ROOT: &str = "$TURBO_ROOT$";
 const TURBO_ROOT_SLASH: &str = "$TURBO_ROOT$/";
-pub const TURBO_DEFAULT: &str = "$TURBO_DEFAULT$";
+const TURBO_DEFAULT: &str = "$TURBO_DEFAULT$";
 
 const ENV_PIPELINE_DELIMITER: &str = "$";
 const TOPOLOGICAL_PIPELINE_DELIMITER: &str = "^";

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -415,6 +415,7 @@ impl TaskDefinition {
 
         let with = processed.with.map(|with_tasks| {
             with_tasks
+                .0
                 .into_iter()
                 .map(|sibling| {
                     let (sibling, span) = sibling.split();

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -266,35 +266,24 @@ pub struct RawTaskDefinition {
     with: Option<Vec<Spanned<UnescapedString>>>,
 }
 
-impl TryFrom<Vec<Spanned<UnescapedString>>> for TaskOutputs {
-    type Error = Error;
-    fn try_from(outputs: Vec<Spanned<UnescapedString>>) -> Result<Self, Self::Error> {
+impl TaskOutputs {
+    /// Creates TaskOutputs from ProcessedOutputs with resolved paths
+    fn from_processed(
+        outputs: processed::ProcessedOutputs,
+        turbo_root_path: &str,
+    ) -> Result<Self, Error> {
         let mut inclusions = Vec::new();
         let mut exclusions = Vec::new();
 
-        for glob in outputs {
-            if let Some(stripped_glob) = glob.value.strip_prefix('!') {
-                if Utf8Path::new(stripped_glob).is_absolute() {
-                    let (span, text) = glob.span_and_text("turbo.json");
-                    return Err(Error::AbsolutePathInConfig {
-                        field: "outputs",
-                        span,
-                        text,
-                    });
-                }
+        // Resolve all globs with the turbo_root path
+        // Absolute path validation was already done during ProcessedGlob creation
+        let resolved = outputs.resolve(turbo_root_path);
 
+        for glob_str in resolved {
+            if let Some(stripped_glob) = glob_str.strip_prefix('!') {
                 exclusions.push(stripped_glob.to_string());
             } else {
-                if Utf8Path::new(&glob.value).is_absolute() {
-                    let (span, text) = glob.span_and_text("turbo.json");
-                    return Err(Error::AbsolutePathInConfig {
-                        field: "outputs",
-                        span,
-                        text,
-                    });
-                }
-
-                inclusions.push(glob.into_inner().into());
+                inclusions.push(glob_str);
             }
         }
 
@@ -308,30 +297,25 @@ impl TryFrom<Vec<Spanned<UnescapedString>>> for TaskOutputs {
     }
 }
 
-impl TryFrom<Option<Vec<Spanned<UnescapedString>>>> for TaskInputs {
-    type Error = Error;
-
-    fn try_from(inputs: Option<Vec<Spanned<UnescapedString>>>) -> Result<Self, Self::Error> {
-        let mut globs = Vec::with_capacity(inputs.as_ref().map_or(0, |inputs| inputs.len()));
-
+impl TaskInputs {
+    /// Creates TaskInputs from ProcessedInputs with resolved paths
+    fn from_processed(
+        inputs: processed::ProcessedInputs,
+        turbo_root_path: &str,
+    ) -> Result<Self, Error> {
+        let mut globs = Vec::new();
         let mut default = false;
-        for input in inputs.into_iter().flatten() {
-            // If the inputs contain "$TURBO_DEFAULT$", we need to include the "default"
-            // file hashes as well. NOTE: we intentionally don't remove
-            // "$TURBO_DEFAULT$" from the inputs if it exists in the off chance that
-            // the user has a file named "$TURBO_DEFAULT$" in their package (pls
-            // no).
-            if input.as_str() == TURBO_DEFAULT {
+
+        // Resolve all globs with the turbo_root path
+        // Absolute path validation was already done during ProcessedGlob creation
+        let resolved = inputs.resolve(turbo_root_path);
+
+        for glob_str in resolved {
+            // Check for $TURBO_DEFAULT$
+            if glob_str == TURBO_DEFAULT {
                 default = true;
-            } else if Utf8Path::new(input.as_str()).is_absolute() {
-                let (span, text) = input.span_and_text("turbo.json");
-                return Err(Error::AbsolutePathInConfig {
-                    field: "inputs",
-                    span,
-                    text,
-                });
             }
-            globs.push(input.to_string());
+            globs.push(glob_str);
         }
 
         Ok(TaskInputs { globs, default })
@@ -344,27 +328,29 @@ impl TaskDefinition {
         processed: ProcessedTaskDefinition,
         path_to_repo_root: &RelativeUnixPath,
     ) -> Result<Self, Error> {
-        // Convert back to raw and apply token replacement
-        let mut raw_task = processed.into_raw();
-        replace_turbo_root_token(&mut raw_task, path_to_repo_root)?;
-        let outputs = raw_task.outputs.unwrap_or_default().try_into()?;
+        // Convert outputs with turbo_root resolution
+        let outputs = processed
+            .outputs
+            .map(|outputs| TaskOutputs::from_processed(outputs, path_to_repo_root.as_str()))
+            .transpose()?
+            .unwrap_or_default();
 
-        let cache = raw_task.cache.is_none_or(|c| c.into_inner());
-        let interactive = raw_task
+        let cache = processed.cache.is_none_or(|c| c.into_inner());
+        let interactive = processed
             .interactive
             .as_ref()
             .map(|value| value.value)
             .unwrap_or_default();
 
-        if let Some(interactive) = raw_task.interactive {
+        if let Some(interactive) = &processed.interactive {
             let (span, text) = interactive.span_and_text("turbo.json");
             if cache && interactive.value {
                 return Err(Error::InteractiveNoCacheable { span, text });
             }
         }
 
-        let persistent = *raw_task.persistent.unwrap_or_default();
-        let interruptible = raw_task.interruptible.unwrap_or_default();
+        let persistent = *processed.persistent.unwrap_or_default();
+        let interruptible = processed.interruptible.unwrap_or_default();
         if *interruptible && !persistent {
             let (span, text) = interruptible.span_and_text("turbo.json");
             return Err(Error::InterruptibleButNotPersistent { span, text });
@@ -373,8 +359,8 @@ impl TaskDefinition {
         let mut env_var_dependencies = HashSet::new();
         let mut topological_dependencies: Vec<Spanned<TaskName>> = Vec::new();
         let mut task_dependencies: Vec<Spanned<TaskName>> = Vec::new();
-        if let Some(depends_on) = raw_task.depends_on {
-            for dependency in depends_on.into_inner() {
+        if let Some(depends_on) = processed.depends_on {
+            for dependency in depends_on.0.into_inner() {
                 let (span, text) = dependency.span_and_text("turbo.json");
                 let (dependency, depspan) = dependency.split();
                 let dependency: String = dependency.into();
@@ -397,10 +383,10 @@ impl TaskDefinition {
         task_dependencies.sort_by(|a, b| a.value.cmp(&b.value));
         topological_dependencies.sort_by(|a, b| a.value.cmp(&b.value));
 
-        let env = raw_task
+        let env = processed
             .env
             .map(|env| -> Result<Vec<String>, Error> {
-                gather_env_vars(env, "env", &mut env_var_dependencies)?;
+                gather_env_vars(env.0, "env", &mut env_var_dependencies)?;
                 let mut env_var_dependencies: Vec<String> =
                     env_var_dependencies.into_iter().collect();
                 env_var_dependencies.sort();
@@ -409,20 +395,25 @@ impl TaskDefinition {
             .transpose()?
             .unwrap_or_default();
 
-        let inputs = TaskInputs::try_from(raw_task.inputs)?;
+        // Convert inputs with turbo_root resolution
+        let inputs = processed
+            .inputs
+            .map(|inputs| TaskInputs::from_processed(inputs, path_to_repo_root.as_str()))
+            .transpose()?
+            .unwrap_or_default();
 
-        let pass_through_env = raw_task
+        let pass_through_env = processed
             .pass_through_env
             .map(|env| -> Result<Vec<String>, Error> {
                 let mut pass_through_env = HashSet::new();
-                gather_env_vars(env, "passThroughEnv", &mut pass_through_env)?;
+                gather_env_vars(env.0, "passThroughEnv", &mut pass_through_env)?;
                 let mut pass_through_env: Vec<String> = pass_through_env.into_iter().collect();
                 pass_through_env.sort();
                 Ok(pass_through_env)
             })
             .transpose()?;
 
-        let with = raw_task.with.map(|with_tasks| {
+        let with = processed.with.map(|with_tasks| {
             with_tasks
                 .into_iter()
                 .map(|sibling| {
@@ -440,11 +431,11 @@ impl TaskDefinition {
             env,
             inputs,
             pass_through_env,
-            output_logs: *raw_task.output_logs.unwrap_or_default(),
+            output_logs: *processed.output_logs.unwrap_or_default(),
             persistent,
             interruptible: *interruptible,
             interactive,
-            env_mode: raw_task.env_mode.map(|mode| *mode.as_inner()),
+            env_mode: processed.env_mode.map(|mode| *mode.as_inner()),
             with,
         })
     }
@@ -455,7 +446,7 @@ impl TaskDefinition {
         raw_task: RawTaskDefinition,
         path_to_repo_root: &RelativeUnixPath,
     ) -> Result<Self, Error> {
-        let processed = ProcessedTaskDefinition::from_raw(raw_task);
+        let processed = ProcessedTaskDefinition::from_raw(raw_task)?;
         Self::from_processed(processed, path_to_repo_root)
     }
 }
@@ -645,13 +636,18 @@ impl TurboJson {
         TurboJson::try_from(raw_turbo_json).map(Some)
     }
 
-    pub fn task(&self, task_id: &TaskId, task_name: &TaskName) -> Option<ProcessedTaskDefinition> {
+    pub fn task(
+        &self,
+        task_id: &TaskId,
+        task_name: &TaskName,
+    ) -> Result<Option<ProcessedTaskDefinition>, Error> {
         match self.tasks.get(&task_id.as_task_name()) {
-            Some(entry) => Some(ProcessedTaskDefinition::from_raw(entry.value.clone())),
+            Some(entry) => ProcessedTaskDefinition::from_raw(entry.value.clone()).map(Some),
             None => self
                 .tasks
                 .get(task_name)
-                .map(|entry| ProcessedTaskDefinition::from_raw(entry.value.clone())),
+                .map(|entry| ProcessedTaskDefinition::from_raw(entry.value.clone()))
+                .transpose(),
         }
     }
 
@@ -797,68 +793,9 @@ fn gather_env_vars(
 }
 
 // Takes an input/output glob that might start with TURBO_ROOT_PREFIX
-// and swap it with the relative path to the turbo root.
-fn replace_turbo_root_token_in_string(
-    input: &mut Spanned<UnescapedString>,
-    path_to_repo_root: &RelativeUnixPath,
-) -> Result<(), Error> {
-    let turbo_root_index = input.find(TURBO_ROOT);
-    if let Some(index) = turbo_root_index {
-        if !input.as_inner()[index..].starts_with(TURBO_ROOT_SLASH) {
-            let (span, text) = input.span_and_text("turbo.json");
-            return Err(Error::InvalidTurboRootNeedsSlash { span, text });
-        }
-    }
-    match turbo_root_index {
-        Some(0) => {
-            // Replace
-            input
-                .as_inner_mut()
-                .replace_range(..TURBO_ROOT.len(), path_to_repo_root.as_str());
-            Ok(())
-        }
-        // Handle negations
-        Some(1) if input.starts_with('!') => {
-            input
-                .as_inner_mut()
-                .replace_range(1..TURBO_ROOT.len() + 1, path_to_repo_root.as_str());
-            Ok(())
-        }
-        // We do not allow for TURBO_ROOT to be used in the middle of a glob
-        Some(_) => {
-            let (span, text) = input.span_and_text("turbo.json");
-            Err(Error::InvalidTurboRootUse { span, text })
-        }
-        None => Ok(()),
-    }
-}
-
-fn replace_turbo_root_token(
-    task_definition: &mut RawTaskDefinition,
-    path_to_repo_root: &RelativeUnixPath,
-) -> Result<(), Error> {
-    for input in task_definition
-        .inputs
-        .iter_mut()
-        .flat_map(|inputs| inputs.iter_mut())
-    {
-        replace_turbo_root_token_in_string(input, path_to_repo_root)?;
-    }
-
-    for output in task_definition
-        .outputs
-        .iter_mut()
-        .flat_map(|outputs| outputs.iter_mut())
-    {
-        replace_turbo_root_token_in_string(output, path_to_repo_root)?;
-    }
-
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
-    use std::{assert_matches::assert_matches, sync::Arc};
+    use std::assert_matches::assert_matches;
 
     use anyhow::Result;
     use biome_deserialize::json::deserialize_from_json_str;
@@ -870,10 +807,7 @@ mod tests {
     use turborepo_task_id::TaskName;
     use turborepo_unescape::UnescapedString;
 
-    use super::{
-        replace_turbo_root_token_in_string, validate_with_has_no_topo, FutureFlags, Pipeline,
-        RawTurboJson, SpacesJson, Spanned, TurboJson, UIMode, *,
-    };
+    use super::{processed::*, *};
     use crate::{
         boundaries::BoundariesConfig,
         cli::OutputLogsMode,
@@ -1142,11 +1076,15 @@ mod tests {
         expected_task_outputs: TaskOutputs,
     ) -> Result<()> {
         let raw_task_outputs: Vec<UnescapedString> = serde_json::from_str(task_outputs_str)?;
-        let raw_task_outputs = raw_task_outputs
-            .into_iter()
-            .map(Spanned::new)
-            .collect::<Vec<_>>();
-        let task_outputs: TaskOutputs = raw_task_outputs.try_into()?;
+        let processed_outputs = ProcessedOutputs(
+            raw_task_outputs
+                .into_iter()
+                .map(|s| ProcessedGlob::from_spanned_output(Spanned::new(s)))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| anyhow::anyhow!("{}", e))?,
+        );
+        // Use "../.." as a dummy turbo_root_path for tests
+        let task_outputs = TaskOutputs::from_processed(processed_outputs, "../..")?;
         assert_eq!(task_outputs, expected_task_outputs);
 
         Ok(())
@@ -1342,27 +1280,6 @@ mod tests {
         );
     }
 
-    #[test_case("index.ts", Ok("index.ts") ; "no token")]
-    #[test_case("$TURBO_ROOT$/config.txt", Ok("../../config.txt") ; "valid token")]
-    #[test_case("!$TURBO_ROOT$/README.md", Ok("!../../README.md") ; "negation")]
-    #[test_case("../$TURBO_ROOT$/config.txt", Err("\"$TURBO_ROOT$\" must be used at the start of glob.") ; "invalid token")]
-    #[test_case("$TURBO_ROOT$config.txt", Err("\"$TURBO_ROOT$\" must be followed by a '/'.") ; "trailing slash")]
-    fn test_replace_turbo_root(input: &'static str, expected: Result<&str, &str>) {
-        let mut spanned_string = Spanned::new(UnescapedString::from(input))
-            .with_path(Arc::from("turbo.json"))
-            .with_text(format!("\"{input}\""))
-            .with_range(1..(input.len()));
-        let result = replace_turbo_root_token_in_string(
-            &mut spanned_string,
-            RelativeUnixPath::new("../..").unwrap(),
-        );
-        let actual = match result {
-            Ok(()) => Ok(spanned_string.as_inner().as_ref()),
-            Err(e) => Err(e.to_string()),
-        };
-        assert_eq!(actual, expected.map_err(|s| s.to_owned()));
-    }
-
     #[test]
     fn test_future_flags_not_allowed_in_workspace() {
         let json = r#"{
@@ -1455,33 +1372,29 @@ mod tests {
 
     #[test]
     fn test_absolute_paths_error_in_inputs() {
-        assert_matches!(
-            TaskInputs::try_from(Some(vec![Spanned::new(UnescapedString::from(
-                if cfg!(windows) {
-                    "C:\\win32"
-                } else {
-                    "/dev/null"
-                }
-            ))])),
-            Err(Error::AbsolutePathInConfig { .. })
-        );
+        let absolute_path = if cfg!(windows) {
+            "C:\\win32"
+        } else {
+            "/dev/null"
+        };
+
+        // The error should be caught when creating the ProcessedGlob
+        let result =
+            ProcessedGlob::from_spanned_input(Spanned::new(UnescapedString::from(absolute_path)));
+
+        assert_matches!(result, Err(Error::AbsolutePathInConfig { .. }));
     }
 
     #[test]
     fn test_detects_turbo_default() {
-        let inputs = TaskInputs::try_from(Some(vec![Spanned::new(UnescapedString::from(
-            TURBO_DEFAULT,
-        ))]))
-        .unwrap();
-        assert!(inputs.default);
-    }
+        let processed_inputs = ProcessedInputs(vec![ProcessedGlob::from_spanned_input(
+            Spanned::new(UnescapedString::from(TURBO_DEFAULT)),
+        )
+        .unwrap()]);
 
-    #[test]
-    fn test_keeps_turbo_default() {
-        let inputs = TaskInputs::try_from(Some(vec![Spanned::new(UnescapedString::from(
-            TURBO_DEFAULT,
-        ))]))
-        .unwrap();
+        // Use "../.." as a dummy turbo_root_path for tests
+        let inputs = TaskInputs::from_processed(processed_inputs, "../..").unwrap();
+        assert!(inputs.default);
         assert_eq!(inputs.globs, vec![TURBO_DEFAULT.to_string()]);
     }
 }

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -27,8 +27,10 @@ use crate::{
 mod extend;
 mod loader;
 pub mod parser;
+mod processed;
 
 pub use loader::{TurboJsonLoader, TurboJsonReader};
+pub use processed::ProcessedTaskDefinition;
 
 use crate::{boundaries::BoundariesConfig, config::UnnecessaryPackageTaskSyntaxError};
 
@@ -333,81 +335,6 @@ impl TryFrom<Option<Vec<Spanned<UnescapedString>>>> for TaskInputs {
         }
 
         Ok(TaskInputs { globs, default })
-    }
-}
-
-/// Processed depends_on field with DSL detection
-#[derive(Debug, Clone, PartialEq)]
-pub struct ProcessedDependsOn(pub Spanned<Vec<Spanned<UnescapedString>>>);
-
-/// Processed env field with DSL detection
-#[derive(Debug, Clone, PartialEq)]
-pub struct ProcessedEnv(pub Vec<Spanned<UnescapedString>>);
-
-/// Processed inputs field with DSL detection
-#[derive(Debug, Clone, PartialEq)]
-pub struct ProcessedInputs(pub Vec<Spanned<UnescapedString>>);
-
-/// Processed pass_through_env field with DSL detection
-#[derive(Debug, Clone, PartialEq)]
-pub struct ProcessedPassThroughEnv(pub Vec<Spanned<UnescapedString>>);
-
-/// Processed outputs field with DSL detection
-#[derive(Debug, Clone, PartialEq)]
-pub struct ProcessedOutputs(pub Vec<Spanned<UnescapedString>>);
-
-/// Intermediate representation for task definitions with DSL processing
-#[derive(Debug, Clone, PartialEq, Default)]
-pub struct ProcessedTaskDefinition {
-    pub cache: Option<Spanned<bool>>,
-    pub depends_on: Option<ProcessedDependsOn>,
-    pub env: Option<ProcessedEnv>,
-    pub inputs: Option<ProcessedInputs>,
-    pub pass_through_env: Option<ProcessedPassThroughEnv>,
-    pub persistent: Option<Spanned<bool>>,
-    pub interruptible: Option<Spanned<bool>>,
-    pub outputs: Option<ProcessedOutputs>,
-    pub output_logs: Option<Spanned<OutputLogsMode>>,
-    pub interactive: Option<Spanned<bool>>,
-    pub env_mode: Option<Spanned<EnvMode>>,
-    pub with: Option<Vec<Spanned<UnescapedString>>>,
-}
-
-impl ProcessedTaskDefinition {
-    /// Creates a processed task definition from raw task
-    pub fn from_raw(raw_task: RawTaskDefinition) -> Self {
-        ProcessedTaskDefinition {
-            cache: raw_task.cache,
-            depends_on: raw_task.depends_on.map(ProcessedDependsOn),
-            env: raw_task.env.map(ProcessedEnv),
-            inputs: raw_task.inputs.map(ProcessedInputs),
-            pass_through_env: raw_task.pass_through_env.map(ProcessedPassThroughEnv),
-            persistent: raw_task.persistent,
-            interruptible: raw_task.interruptible,
-            outputs: raw_task.outputs.map(ProcessedOutputs),
-            output_logs: raw_task.output_logs,
-            interactive: raw_task.interactive,
-            env_mode: raw_task.env_mode,
-            with: raw_task.with,
-        }
-    }
-
-    /// Converts back to RawTaskDefinition
-    pub fn into_raw(self) -> RawTaskDefinition {
-        RawTaskDefinition {
-            cache: self.cache,
-            depends_on: self.depends_on.map(|d| d.0),
-            env: self.env.map(|e| e.0),
-            inputs: self.inputs.map(|i| i.0),
-            pass_through_env: self.pass_through_env.map(|p| p.0),
-            persistent: self.persistent,
-            interruptible: self.interruptible,
-            outputs: self.outputs.map(|o| o.0),
-            output_logs: self.output_logs,
-            interactive: self.interactive,
-            env_mode: self.env_mode,
-            with: self.with,
-        }
     }
 }
 

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -25,10 +25,12 @@ use crate::{
 };
 
 mod extend;
+pub mod future_flags;
 mod loader;
 pub mod parser;
 mod processed;
 
+pub use future_flags::FutureFlags;
 pub use loader::{TurboJsonLoader, TurboJsonReader};
 pub use processed::ProcessedTaskDefinition;
 
@@ -154,12 +156,6 @@ pub struct RawTurboJson {
     #[deserializable(rename = "//")]
     #[serde(skip)]
     _comment: Option<String>,
-}
-
-#[derive(Serialize, Default, Debug, Copy, Clone, Iterable, Deserializable, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
-pub struct FutureFlags {
-    turbo_extends: bool,
 }
 
 #[derive(Serialize, Default, Debug, PartialEq, Clone)]

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -28,7 +28,7 @@ mod extend;
 mod loader;
 pub mod parser;
 
-pub use loader::TurboJsonLoader;
+pub use loader::{TurboJsonLoader, TurboJsonReader};
 
 use crate::{boundaries::BoundariesConfig, config::UnnecessaryPackageTaskSyntaxError};
 
@@ -158,7 +158,7 @@ pub struct RawTurboJson {
     _comment: Option<String>,
 }
 
-#[derive(Serialize, Default, Debug, Clone, Iterable, Deserializable, PartialEq, Eq)]
+#[derive(Serialize, Default, Debug, Copy, Clone, Iterable, Deserializable, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct FutureFlags {}
 
@@ -614,9 +614,13 @@ impl TurboJson {
 
     /// Reads a `RawTurboJson` from the given path
     /// and then converts it into `TurboJson`
-    pub(crate) fn read(
+    ///
+    /// Should never be called directly outside of this module.
+    /// `TurboJsonReader` should be used instead.
+    fn read(
         repo_root: &AbsoluteSystemPath,
         path: &AbsoluteSystemPath,
+        _future_flags: FutureFlags,
     ) -> Result<Option<TurboJson>, Error> {
         let Some(raw_turbo_json) = RawTurboJson::read(repo_root, path)? else {
             return Ok(None);

--- a/crates/turborepo-lib/src/turbo_json/processed.rs
+++ b/crates/turborepo-lib/src/turbo_json/processed.rs
@@ -1,0 +1,82 @@
+//! Processed task definition types with DSL token handling
+
+use turborepo_errors::Spanned;
+use turborepo_unescape::UnescapedString;
+
+use super::RawTaskDefinition;
+use crate::cli::{EnvMode, OutputLogsMode};
+
+/// Processed depends_on field with DSL detection
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProcessedDependsOn(pub Spanned<Vec<Spanned<UnescapedString>>>);
+
+/// Processed env field with DSL detection
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProcessedEnv(pub Vec<Spanned<UnescapedString>>);
+
+/// Processed inputs field with DSL detection
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProcessedInputs(pub Vec<Spanned<UnescapedString>>);
+
+/// Processed pass_through_env field with DSL detection
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProcessedPassThroughEnv(pub Vec<Spanned<UnescapedString>>);
+
+/// Processed outputs field with DSL detection
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProcessedOutputs(pub Vec<Spanned<UnescapedString>>);
+
+/// Intermediate representation for task definitions with DSL processing
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct ProcessedTaskDefinition {
+    pub cache: Option<Spanned<bool>>,
+    pub depends_on: Option<ProcessedDependsOn>,
+    pub env: Option<ProcessedEnv>,
+    pub inputs: Option<ProcessedInputs>,
+    pub pass_through_env: Option<ProcessedPassThroughEnv>,
+    pub persistent: Option<Spanned<bool>>,
+    pub interruptible: Option<Spanned<bool>>,
+    pub outputs: Option<ProcessedOutputs>,
+    pub output_logs: Option<Spanned<OutputLogsMode>>,
+    pub interactive: Option<Spanned<bool>>,
+    pub env_mode: Option<Spanned<EnvMode>>,
+    pub with: Option<Vec<Spanned<UnescapedString>>>,
+}
+
+impl ProcessedTaskDefinition {
+    /// Creates a processed task definition from raw task
+    pub fn from_raw(raw_task: RawTaskDefinition) -> Self {
+        ProcessedTaskDefinition {
+            cache: raw_task.cache,
+            depends_on: raw_task.depends_on.map(ProcessedDependsOn),
+            env: raw_task.env.map(ProcessedEnv),
+            inputs: raw_task.inputs.map(ProcessedInputs),
+            pass_through_env: raw_task.pass_through_env.map(ProcessedPassThroughEnv),
+            persistent: raw_task.persistent,
+            interruptible: raw_task.interruptible,
+            outputs: raw_task.outputs.map(ProcessedOutputs),
+            output_logs: raw_task.output_logs,
+            interactive: raw_task.interactive,
+            env_mode: raw_task.env_mode,
+            with: raw_task.with,
+        }
+    }
+
+    /// Converts back to RawTaskDefinition
+    pub fn into_raw(self) -> RawTaskDefinition {
+        RawTaskDefinition {
+            cache: self.cache,
+            depends_on: self.depends_on.map(|d| d.0),
+            env: self.env.map(|e| e.0),
+            inputs: self.inputs.map(|i| i.0),
+            pass_through_env: self.pass_through_env.map(|p| p.0),
+            persistent: self.persistent,
+            interruptible: self.interruptible,
+            outputs: self.outputs.map(|o| o.0),
+            output_logs: self.output_logs,
+            interactive: self.interactive,
+            env_mode: self.env_mode,
+            with: self.with,
+        }
+    }
+}

--- a/crates/turborepo-lib/src/turbo_json/processed.rs
+++ b/crates/turborepo-lib/src/turbo_json/processed.rs
@@ -25,7 +25,7 @@ fn extract_turbo_extends(
     mut items: Vec<Spanned<UnescapedString>>,
     future_flags: &FutureFlags,
 ) -> (Vec<Spanned<UnescapedString>>, bool) {
-    if !future_flags.turbo_extends {
+    if !future_flags.turbo_extends_keyword {
         return (items, false);
     }
 
@@ -406,7 +406,7 @@ mod tests {
         let (processed, extends) = extract_turbo_extends(
             items,
             &FutureFlags {
-                turbo_extends: true,
+                turbo_extends_keyword: true,
             },
         );
 
@@ -427,7 +427,7 @@ mod tests {
         let (processed, extends) = extract_turbo_extends(
             items,
             &FutureFlags {
-                turbo_extends: false,
+                turbo_extends_keyword: false,
             },
         );
 
@@ -446,7 +446,7 @@ mod tests {
         let (processed, extends) = extract_turbo_extends(
             items,
             &FutureFlags {
-                turbo_extends: true,
+                turbo_extends_keyword: true,
             },
         );
 
@@ -591,7 +591,7 @@ mod tests {
         let inputs = ProcessedInputs::new(
             raw_globs,
             &FutureFlags {
-                turbo_extends: true,
+                turbo_extends_keyword: true,
             },
         )
         .unwrap();
@@ -614,7 +614,7 @@ mod tests {
         let result = ProcessedEnv::new(
             raw_env,
             &FutureFlags {
-                turbo_extends: false,
+                turbo_extends_keyword: false,
             },
         );
         assert!(result.is_err());
@@ -633,7 +633,7 @@ mod tests {
         let result = ProcessedDependsOn::new(
             Spanned::new(raw_deps),
             &FutureFlags {
-                turbo_extends: false,
+                turbo_extends_keyword: false,
             },
         );
         assert!(result.is_err());

--- a/crates/turborepo-lib/src/turbo_json/processed.rs
+++ b/crates/turborepo-lib/src/turbo_json/processed.rs
@@ -6,6 +6,109 @@ use turborepo_unescape::UnescapedString;
 use super::RawTaskDefinition;
 use crate::cli::{EnvMode, OutputLogsMode};
 
+const TURBO_ROOT: &str = "$TURBO_ROOT$";
+const TURBO_ROOT_SLASH: &str = "$TURBO_ROOT$/";
+
+/// A processed glob with separated components
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProcessedGlob {
+    /// The glob pattern without $TURBO_ROOT$ prefix
+    pub glob: Spanned<UnescapedString>,
+    /// Whether the glob was negated (started with !)
+    pub negated: bool,
+    /// Whether the glob needs turbo_root prefix (had $TURBO_ROOT$/)
+    pub turbo_root: bool,
+}
+
+impl ProcessedGlob {
+    /// Creates a ProcessedGlob from a raw glob string, stripping prefixes
+    fn from_spanned_internal(
+        mut value: Spanned<UnescapedString>,
+        field: &'static str,
+    ) -> Result<Self, crate::config::Error> {
+        use camino::Utf8Path;
+
+        use crate::config::Error;
+
+        let original_value = value.clone();
+        let mut negated = false;
+        let mut turbo_root = false;
+        let mut start_idx = 0;
+
+        // Check for negation
+        if value.as_str().starts_with("!") {
+            negated = true;
+            start_idx = 1;
+        }
+
+        // Check for TURBO_ROOT at the appropriate position
+        if value.as_str()[start_idx..].starts_with(TURBO_ROOT) {
+            // Validate it has the required slash
+            if !value.as_str()[start_idx..].starts_with(TURBO_ROOT_SLASH) {
+                let (span, text) = original_value.span_and_text("turbo.json");
+                return Err(Error::InvalidTurboRootNeedsSlash { span, text });
+            }
+            turbo_root = true;
+            // Strip the $TURBO_ROOT$/ prefix (keeping the content after it)
+            let new_value = value.as_str()[start_idx + TURBO_ROOT_SLASH.len()..].to_string();
+            *value.as_inner_mut() = UnescapedString::from(new_value);
+        } else if value.as_str().contains(TURBO_ROOT) {
+            // TURBO_ROOT found in the middle is not allowed
+            let (span, text) = original_value.span_and_text("turbo.json");
+            return Err(Error::InvalidTurboRootUse { span, text });
+        } else if negated {
+            // If negated but no TURBO_ROOT, strip the negation prefix
+            let new_value = value.as_str()[1..].to_string();
+            *value.as_inner_mut() = UnescapedString::from(new_value);
+        }
+
+        // Check for absolute paths (after stripping prefixes)
+        if Utf8Path::new(value.as_str()).is_absolute() {
+            let (span, text) = original_value.span_and_text("turbo.json");
+            return Err(Error::AbsolutePathInConfig { field, span, text });
+        }
+
+        Ok(ProcessedGlob {
+            glob: value,
+            negated,
+            turbo_root,
+        })
+    }
+
+    /// Creates a ProcessedGlob for outputs (validates as output field)
+    pub fn from_spanned_output(
+        value: Spanned<UnescapedString>,
+    ) -> Result<Self, crate::config::Error> {
+        Self::from_spanned_internal(value, "outputs")
+    }
+
+    /// Creates a ProcessedGlob for inputs (validates as input field)
+    pub fn from_spanned_input(
+        value: Spanned<UnescapedString>,
+    ) -> Result<Self, crate::config::Error> {
+        Self::from_spanned_internal(value, "inputs")
+    }
+
+    /// Creates a resolved glob string with the actual path
+    pub fn resolve(&self, turbo_root_path: &str) -> String {
+        let mut result = String::new();
+
+        if self.negated {
+            result.push('!');
+        }
+
+        if self.turbo_root {
+            result.push_str(turbo_root_path);
+            if !turbo_root_path.ends_with('/') && !self.glob.as_str().is_empty() {
+                result.push('/');
+            }
+        }
+
+        result.push_str(self.glob.as_str());
+        result
+    }
+}
+
 /// Processed depends_on field with DSL detection
 #[derive(Debug, Clone, PartialEq)]
 pub struct ProcessedDependsOn(pub Spanned<Vec<Spanned<UnescapedString>>>);
@@ -16,7 +119,17 @@ pub struct ProcessedEnv(pub Vec<Spanned<UnescapedString>>);
 
 /// Processed inputs field with DSL detection
 #[derive(Debug, Clone, PartialEq)]
-pub struct ProcessedInputs(pub Vec<Spanned<UnescapedString>>);
+pub struct ProcessedInputs(pub Vec<ProcessedGlob>);
+
+impl ProcessedInputs {
+    /// Resolves all globs with the given turbo_root path
+    pub fn resolve(&self, turbo_root_path: &str) -> Vec<String> {
+        self.0
+            .iter()
+            .map(|glob| glob.resolve(turbo_root_path))
+            .collect()
+    }
+}
 
 /// Processed pass_through_env field with DSL detection
 #[derive(Debug, Clone, PartialEq)]
@@ -24,7 +137,17 @@ pub struct ProcessedPassThroughEnv(pub Vec<Spanned<UnescapedString>>);
 
 /// Processed outputs field with DSL detection
 #[derive(Debug, Clone, PartialEq)]
-pub struct ProcessedOutputs(pub Vec<Spanned<UnescapedString>>);
+pub struct ProcessedOutputs(pub Vec<ProcessedGlob>);
+
+impl ProcessedOutputs {
+    /// Resolves all globs with the given turbo_root path
+    pub fn resolve(&self, turbo_root_path: &str) -> Vec<String> {
+        self.0
+            .iter()
+            .map(|glob| glob.resolve(turbo_root_path))
+            .collect()
+    }
+}
 
 /// Intermediate representation for task definitions with DSL processing
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -45,38 +168,145 @@ pub struct ProcessedTaskDefinition {
 
 impl ProcessedTaskDefinition {
     /// Creates a processed task definition from raw task
-    pub fn from_raw(raw_task: RawTaskDefinition) -> Self {
-        ProcessedTaskDefinition {
+    pub fn from_raw(raw_task: RawTaskDefinition) -> Result<Self, crate::config::Error> {
+        let inputs = raw_task
+            .inputs
+            .map(|inputs| -> Result<ProcessedInputs, crate::config::Error> {
+                let globs = inputs
+                    .into_iter()
+                    .map(ProcessedGlob::from_spanned_input)
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(ProcessedInputs(globs))
+            })
+            .transpose()?;
+
+        let outputs = raw_task
+            .outputs
+            .map(
+                |outputs| -> Result<ProcessedOutputs, crate::config::Error> {
+                    let globs = outputs
+                        .into_iter()
+                        .map(ProcessedGlob::from_spanned_output)
+                        .collect::<Result<Vec<_>, _>>()?;
+                    Ok(ProcessedOutputs(globs))
+                },
+            )
+            .transpose()?;
+
+        Ok(ProcessedTaskDefinition {
             cache: raw_task.cache,
             depends_on: raw_task.depends_on.map(ProcessedDependsOn),
             env: raw_task.env.map(ProcessedEnv),
-            inputs: raw_task.inputs.map(ProcessedInputs),
+            inputs,
             pass_through_env: raw_task.pass_through_env.map(ProcessedPassThroughEnv),
             persistent: raw_task.persistent,
             interruptible: raw_task.interruptible,
-            outputs: raw_task.outputs.map(ProcessedOutputs),
+            outputs,
             output_logs: raw_task.output_logs,
             interactive: raw_task.interactive,
             env_mode: raw_task.env_mode,
             with: raw_task.with,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use test_case::test_case;
+    use turborepo_errors::Spanned;
+    use turborepo_unescape::UnescapedString;
+
+    use super::*;
+
+    #[test_case("$TURBO_ROOT$/config.txt", Ok((true, false)) ; "detects turbo root")]
+    #[test_case("!$TURBO_ROOT$/README.md", Ok((true, true)) ; "detects negated turbo root")]
+    #[test_case("src/**/*.ts", Ok((false, false)) ; "no turbo root")]
+    fn test_processed_glob_detection(input: &str, expected: Result<(bool, bool), &str>) {
+        // Test with input variant
+        let result = ProcessedGlob::from_spanned_input(Spanned::new(UnescapedString::from(
+            input.to_string(),
+        )));
+
+        match expected {
+            Ok((turbo_root, negated)) => {
+                let glob = result.unwrap();
+                assert_eq!(glob.turbo_root, turbo_root);
+                assert_eq!(glob.negated, negated);
+            }
+            Err(_) => {
+                assert!(result.is_err());
+            }
         }
     }
 
-    /// Converts back to RawTaskDefinition
-    pub fn into_raw(self) -> RawTaskDefinition {
-        RawTaskDefinition {
-            cache: self.cache,
-            depends_on: self.depends_on.map(|d| d.0),
-            env: self.env.map(|e| e.0),
-            inputs: self.inputs.map(|i| i.0),
-            pass_through_env: self.pass_through_env.map(|p| p.0),
-            persistent: self.persistent,
-            interruptible: self.interruptible,
-            outputs: self.outputs.map(|o| o.0),
-            output_logs: self.output_logs,
-            interactive: self.interactive,
-            env_mode: self.env_mode,
-            with: self.with,
-        }
+    #[test_case("$TURBO_ROOT$config.txt", "must be followed by a '/'" ; "missing slash")]
+    #[test_case("../$TURBO_ROOT$/config.txt", "must be used at the start of glob" ; "middle turbo root")]
+    fn test_processed_glob_validation_errors(input: &str, expected_error: &str) {
+        // Test with input variant
+        let result = ProcessedGlob::from_spanned_input(
+            Spanned::new(UnescapedString::from(input.to_string()))
+                .with_path(Arc::from("turbo.json"))
+                .with_text(format!("\"{}\"", input))
+                .with_range(1..input.len() + 1),
+        );
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains(expected_error));
+    }
+
+    #[test_case("$TURBO_ROOT$/config.txt", "../..", "../../config.txt" ; "replace turbo root")]
+    #[test_case("!$TURBO_ROOT$/README.md", "../..", "!../../README.md" ; "replace negated turbo root")]
+    #[test_case("src/**/*.ts", "../..", "src/**/*.ts" ; "no replacement needed")]
+    fn test_processed_glob_resolution(input: &str, replacement: &str, expected: &str) {
+        // Test with output variant
+        let glob = ProcessedGlob::from_spanned_output(Spanned::new(UnescapedString::from(
+            input.to_string(),
+        )))
+        .unwrap();
+
+        let resolved = glob.resolve(replacement);
+        assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn test_processed_task_definition_resolve() {
+        // Create a raw task definition with TURBO_ROOT tokens
+        let raw_task = super::RawTaskDefinition {
+            inputs: Some(vec![
+                Spanned::new(UnescapedString::from("$TURBO_ROOT$/config.txt")),
+                Spanned::new(UnescapedString::from("src/**/*.ts")),
+            ]),
+            outputs: Some(vec![
+                Spanned::new(UnescapedString::from("!$TURBO_ROOT$/README.md")),
+                Spanned::new(UnescapedString::from("dist/**")),
+            ]),
+            ..Default::default()
+        };
+
+        // Convert to processed task definition
+        let processed = ProcessedTaskDefinition::from_raw(raw_task).unwrap();
+
+        // Verify TURBO_ROOT detection
+        let inputs = processed.inputs.as_ref().unwrap();
+        assert!(inputs.0[0].turbo_root);
+        assert!(!inputs.0[0].negated);
+        assert!(!inputs.0[1].turbo_root);
+
+        let outputs = processed.outputs.as_ref().unwrap();
+        assert!(outputs.0[0].turbo_root);
+        assert!(outputs.0[0].negated);
+        assert!(!outputs.0[1].turbo_root);
+
+        // Resolve with turbo_root path
+        let resolved_inputs = inputs.resolve("../..");
+        assert_eq!(resolved_inputs[0], "../../config.txt");
+        assert_eq!(resolved_inputs[1], "src/**/*.ts");
+
+        let resolved_outputs = outputs.resolve("../..");
+        assert_eq!(resolved_outputs[0], "!../../README.md");
+        assert_eq!(resolved_outputs[1], "dist/**");
     }
 }

--- a/crates/turborepo-lib/src/turbo_json/processed.rs
+++ b/crates/turborepo-lib/src/turbo_json/processed.rs
@@ -136,6 +136,10 @@ impl ProcessedOutputs {
     }
 }
 
+/// Processed with field with DSL detection
+#[derive(Debug, Clone, PartialEq)]
+pub struct ProcessedWith(pub Vec<Spanned<UnescapedString>>);
+
 /// Intermediate representation for task definitions with DSL processing
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct ProcessedTaskDefinition {
@@ -150,7 +154,7 @@ pub struct ProcessedTaskDefinition {
     pub output_logs: Option<Spanned<OutputLogsMode>>,
     pub interactive: Option<Spanned<bool>>,
     pub env_mode: Option<Spanned<EnvMode>>,
-    pub with: Option<Vec<Spanned<UnescapedString>>>,
+    pub with: Option<ProcessedWith>,
 }
 
 impl ProcessedTaskDefinition {
@@ -192,7 +196,7 @@ impl ProcessedTaskDefinition {
             output_logs: raw_task.output_logs,
             interactive: raw_task.interactive,
             env_mode: raw_task.env_mode,
-            with: raw_task.with,
+            with: raw_task.with.map(ProcessedWith),
         })
     }
 }

--- a/turborepo-tests/integration/fixtures/turbo-configs/interruptible-but-not-persistent.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/interruptible-but-not-persistent.json
@@ -10,7 +10,7 @@
     "build": {
       "env": [
         "NODE_ENV",
-        "$FOOBAR"
+        "FOOBAR"
       ],
       "interruptible": true,
       "outputs": []


### PR DESCRIPTION
### Description

This PR adds a new DSL keyword for array task definitions that alters the behavior when using `extends` in a package `turbo.json`. Usually a field from a package task definition will completely override the root field e.g.
Root: `{ "env": ["FOO"] }`
Package: `{ "env": ["BAR"] }`
Result: `{"env": ["BAR"] }`

If the package uses the new `$TURBO_EXTENDS$` the root field value will be extended from instead of overridden. e.g.
Root: `{ "env": ["FOO"] }`
Package: `{ "env": ["$TURBO_EXTENDS$", "BAR"] }`
Result: `{"env": ["FOO", "BAR"] }`

This functionality allows for greater flexibility when specializing package task definitions without needing to copy/paste the shared values and remembering to update them if the root changed.

It is currently gated by `turboExtends` feature flag in the root `turbo.json`.

Reviewing this each commit individually in this PR is *highly* suggested. The actual feature add is all done in the final commit, the rest are prefactors.

The primary prefactors are:
 - Plumbing through future flags to be read at config time, but usable at task resolution time. This is necessary since this is set at root and needs to be known when reading task definitions from package `turbo.json`s
 - Adding a new intermediate step for task definition creation named "processed". Removes a majority of the DSL concepts and validations that are exclusive to a single field. This paves the way for future extensions to the DSL.

Nerd note:
Technically, we could extend `$TURBO_EXTENDS$` to additional fields that are monoids. Extension behavior is really:
```
let a = if extends {
  base
} else {
  mempty
}
a mappend b
```
The only interesting addition we could make would be around boolean fields which has 2 different monoids: any and all. Which one to choose would depend on the default value of the flag. e.g. `cache` defaults to false so we would want an any (or) behavior. I am not suggesting we do this, it is more confusing than it is worthwhile.

### Testing Instructions

Added a fair amount of unit tests for the whole task definition resolution steps.
