### PR TITLE
fix(turbo): graceful shutdown on sighup

### DIFF
--- a/crates/turborepo-signals/src/listeners.rs
+++ b/crates/turborepo-signals/src/listeners.rs
@@ -23,10 +23,14 @@ pub fn get_signal() -> Result<impl Stream<Item = Option<Signal>>, Error> {
     use tokio::signal::unix;
     let mut sigint = unix::signal(unix::SignalKind::interrupt())?;
     let mut sigterm = unix::signal(unix::SignalKind::terminate())?;
+    let mut sighup = unix::signal(unix::SignalKind::hangup())?;
 
     Ok(stream::once(async move {
         tokio::select! {
             res = sigint.recv() => {
+                res.map(|_| Signal::Interrupt)
+            }
+            res = sighup.recv() => {
                 res.map(|_| Signal::Interrupt)
             }
             res = sigterm.recv() => {


### PR DESCRIPTION
### Description

When trying to figure out why grouped logs don't get flushed on GitHub Actions timeouts I came across https://github.com/actions/runner/issues/1309

Seems promising, since I have verified that `SIGINT` results in logs getting flushed, but `SIGHUP` wouldn't trigger a flush.

### Testing Instructions

Send a `SIGHUP` to `turbo` and verify that everything gets shut down cleanly:
```
[130 olszewski@macbookpro] /tmp/grouped $ turbo_dev --skip-infer dev --log-order=grouped
turbo 2.5.6-canary.1

• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web
• Running dev in 5 packages
• Remote caching disabled
web:dev: cache bypass, force executing b1407803afdc4dc7
web:dev: 
web:dev: > web@0.1.0 dev /private/tmp/grouped/apps/web
web:dev: > next dev --turbopack --port 3000
web:dev: 
web:dev:    ▲ Next.js 15.4.2 (Turbopack)
web:dev:    - Local:        http://localhost:3000
web:dev:    - Network:      http://192.168.86.73:3000
web:dev: 
web:dev:  ✓ Starting...
web:dev:  ✓ Ready in 942ms
web:dev: 
docs:dev: cache bypass, force executing 9119eefc14447289
docs:dev: 
docs:dev: > docs@0.1.0 dev /private/tmp/grouped/apps/docs
docs:dev: > next dev --turbopack --port 3001
docs:dev: 
docs:dev:    ▲ Next.js 15.4.2 (Turbopack)
docs:dev:    - Local:        http://localhost:3001
docs:dev:    - Network:      http://192.168.86.73:3001
docs:dev: 
docs:dev:  ✓ Starting...
docs:dev:  ✓ Ready in 943ms
docs:dev: 
 ERROR  run failed: command  exited (1)
```
