### PR TITLE
docs(github-action): fix set team url to team id

### DIFF
--- a/docs/site/content/docs/guides/ci-vendors/github-actions.mdx
+++ b/docs/site/content/docs/guides/ci-vendors/github-actions.mdx
@@ -257,7 +257,7 @@ Go to your GitHub repository settings and click on the **Secrets** and then **Ac
 </Step>
 
 <Step>
-Create a new repository variable (click the **Variables** tab) called `TURBO_TEAM` and enter [your Team URL](https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fsettings&title=Find+Team+URL).
+Create a new repository variable (click the **Variables** tab) called `TURBO_TEAM` and enter [your Team ID](https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fsettings&title=Find+Team+ID).
 
 <Callout type="good-to-know">
   Using a repository variable rather than a secret will keep GitHub Actions from


### PR DESCRIPTION
### Description

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

Shoud use `TEAM ID` as `TURBO_TEAM` rather than `TEAM URL`

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->

Test on Github Action