### PR TITLE
fix(docs): fix broken anchor links to --graph option

### DIFF
--- a/docs/site/content/docs/guides/migrating-from-nx.mdx
+++ b/docs/site/content/docs/guides/migrating-from-nx.mdx
@@ -538,7 +538,7 @@ Configuration found in `nx.json` can be mapped to `turbo.json` using the tables 
 | `--parallel`     | [`--concurrency`](/docs/reference/run#--concurrency-number--percentage) |
 | `--nxBail`       | [`--continue`](/docs/reference/run#--continueoption)                    |
 | `--projects`     | [`--filter`](/docs/reference/run#--filter-string)                       |
-| `--graph`        | [`--graph`](/docs/reference/run#--graph-file-type)                      |
+| `--graph`        | [`--graph`](/docs/reference/run#--graph-file-name)                      |
 | `--output-style` | [`--log-order`](/docs/reference/run#--log-order-option)                 |
 | `--no-cloud`     | [`--cache`](/docs/reference/run#--cache-options)                        |
 | `--verbose`      | [`--verbosity`](/docs/reference/run#--verbosity)                        |

--- a/docs/site/content/docs/reference/options-overview.mdx
+++ b/docs/site/content/docs/reference/options-overview.mdx
@@ -88,7 +88,7 @@ The three strategies listed above are in order of precedence. Where a flag value
 | Behavior            | Flags                                              | Environment Variables                                                                 | turbo.json |
 | ------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------- | ---------- |
 | Run Summaries       | [`--summarize`](/docs/reference/run#--summarize)   | [`TURBO_RUN_SUMMARY`](/docs/reference/system-environment-variables#turbo_run_summary) | -          |
-| Graph visualization | [`--graph`](/docs/reference/run#--graph-file-type) | -                                                                                     | -          |
+| Graph visualization | [`--graph`](/docs/reference/run#--graph-file-name) | -                                                                                     | -          |
 | Dry run             | [`--dry`](/docs/reference/run#--dry----dry-run)    | -                                                                                     | -          |
 
 </div>


### PR DESCRIPTION
## Summary
Fixed broken documentation links that were pointing to non-existent anchors.

## Changes
- Updated links from `#--graph-file-type` to `#--graph-file-name` to match the actual anchor in run.mdx
- Fixed in 2 files:
  - `docs/reference/options-overview.mdx`
  - `docs/guides/migrating-from-nx.mdx`

## Test plan
Verified that the anchor `#--graph-file-name` exists in the target documentation page.

🤖 Generated with [Claude Code](https://claude.ai/code)