### PR TITLE
chore: reformat code with 2024 edition

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -9,6 +9,3 @@ wrap_comments = true
 
 imports_granularity = "Crate"
 group_imports = "StdExternalCrate"
-
-# do not apply 2024 edition formatting
-style_edition = "2021"

--- a/crates/turbo-trace/src/tracer.rs
+++ b/crates/turbo-trace/src/tracer.rs
@@ -7,13 +7,13 @@ use oxc_resolver::{
     EnforceExtension, ResolveError, ResolveOptions, Resolver, TsconfigOptions, TsconfigReferences,
 };
 use swc_common::{
+    FileName, SourceMap,
     comments::SingleThreadedComments,
     errors::{ColorConfig, Handler},
     input::StringInput,
-    FileName, SourceMap,
 };
 use swc_ecma_ast::EsVersion;
-use swc_ecma_parser::{lexer::Lexer, Capturing, EsSyntax, Parser, Syntax, TsSyntax};
+use swc_ecma_parser::{Capturing, EsSyntax, Parser, Syntax, TsSyntax, lexer::Lexer};
 use swc_ecma_visit::VisitWith;
 use thiserror::Error;
 use tokio::task::JoinSet;
@@ -424,7 +424,7 @@ impl Tracer {
                     source_map: self.source_map.clone(),
                     files: HashMap::new(),
                     errors: vec![TraceError::GlobError(Arc::new(e))],
-                }
+                };
             }
         };
 

--- a/crates/turborepo-analytics/src/lib.rs
+++ b/crates/turborepo-analytics/src/lib.rs
@@ -7,7 +7,7 @@
 
 use std::time::Duration;
 
-use futures::{stream::FuturesUnordered, StreamExt};
+use futures::{StreamExt, stream::FuturesUnordered};
 use thiserror::Error;
 use tokio::{
     select,
@@ -15,7 +15,7 @@ use tokio::{
     task::{JoinError, JoinHandle},
 };
 use tracing::debug;
-use turborepo_api_client::{analytics::AnalyticsClient, APIAuth};
+use turborepo_api_client::{APIAuth, analytics::AnalyticsClient};
 pub use turborepo_vercel_api::AnalyticsEvent;
 use uuid::Uuid;
 
@@ -188,7 +188,7 @@ mod tests {
         select,
         sync::{mpsc, mpsc::UnboundedReceiver},
     };
-    use turborepo_api_client::{analytics::AnalyticsClient, APIAuth};
+    use turborepo_api_client::{APIAuth, analytics::AnalyticsClient};
     use turborepo_vercel_api::{AnalyticsEvent, CacheEvent, CacheSource};
     use uuid::Uuid;
 

--- a/crates/turborepo-api-client/src/analytics.rs
+++ b/crates/turborepo-api-client/src/analytics.rs
@@ -3,7 +3,7 @@ use std::future::Future;
 use reqwest::Method;
 pub use turborepo_vercel_api::{AnalyticsEvent, CacheEvent, CacheSource};
 
-use crate::{retry, APIAuth, APIClient, Error};
+use crate::{APIAuth, APIClient, Error, retry};
 
 pub trait AnalyticsClient {
     fn record_analytics(

--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -9,10 +9,10 @@ use regex::Regex;
 pub use reqwest::Response;
 use reqwest::{Body, Method, RequestBuilder, StatusCode};
 use serde::Deserialize;
-use turborepo_ci::{is_ci, Vendor};
+use turborepo_ci::{Vendor, is_ci};
 use turborepo_vercel_api::{
-    token::ResponseTokenMetadata, APIError, CachingStatus, CachingStatusResponse,
-    PreflightResponse, Team, TeamsResponse, UserResponse, VerificationResponse, VerifiedSsoUser,
+    APIError, CachingStatus, CachingStatusResponse, PreflightResponse, Team, TeamsResponse,
+    UserResponse, VerificationResponse, VerifiedSsoUser, token::ResponseTokenMetadata,
 };
 use url::Url;
 
@@ -228,7 +228,7 @@ impl Client for APIClient {
                 return Error::InvalidJson {
                     err,
                     text: body.clone(),
-                }
+                };
             }
         };
 
@@ -242,7 +242,7 @@ impl Client for APIClient {
                     return Error::UnknownCachingStatus(
                         status_string.to_string(),
                         Backtrace::capture(),
-                    )
+                    );
                 }
             };
 
@@ -641,7 +641,7 @@ impl APIClient {
                     return Err(Error::InvalidUrl {
                         url: location.to_string(),
                         err: e,
-                    })
+                    });
                 }
             }
         } else {
@@ -787,7 +787,7 @@ mod test {
     use turborepo_vercel_api_mock::start_test_server;
     use url::Url;
 
-    use crate::{telemetry::TelemetryClient, APIClient, AnonAPIClient, CacheClient, Client};
+    use crate::{APIClient, AnonAPIClient, CacheClient, Client, telemetry::TelemetryClient};
 
     #[tokio::test]
     async fn test_do_preflight() -> Result<()> {

--- a/crates/turborepo-api-client/src/retry.rs
+++ b/crates/turborepo-api-client/src/retry.rs
@@ -108,8 +108,8 @@ mod test {
     use std::{assert_matches::assert_matches, time::Duration};
 
     use crate::{
-        retry::{make_retryable_request, RetryStrategy},
         Error,
+        retry::{RetryStrategy, make_retryable_request},
     };
 
     #[tokio::test]

--- a/crates/turborepo-api-client/src/telemetry.rs
+++ b/crates/turborepo-api-client/src/telemetry.rs
@@ -3,7 +3,7 @@ use std::future::Future;
 use reqwest::Method;
 use turborepo_vercel_api::telemetry::TelemetryEvent;
 
-use crate::{retry, AnonAPIClient, Error};
+use crate::{AnonAPIClient, Error, retry};
 
 const TELEMETRY_ENDPOINT: &str = "/api/turborepo/v1/events";
 

--- a/crates/turborepo-auth/src/auth/login.rs
+++ b/crates/turborepo-auth/src/auth/login.rs
@@ -5,9 +5,9 @@ use reqwest::Url;
 use tokio::sync::OnceCell;
 use tracing::{debug, warn};
 use turborepo_api_client::{CacheClient, Client, TokenClient};
-use turborepo_ui::{start_spinner, ColorConfig, BOLD};
+use turborepo_ui::{BOLD, ColorConfig, start_spinner};
 
-use crate::{auth::extract_vercel_token, error, ui, LoginOptions, Token};
+use crate::{LoginOptions, Token, auth::extract_vercel_token, error, ui};
 
 const DEFAULT_HOST_NAME: &str = "127.0.0.1";
 const DEFAULT_PORT: u16 = 9789;
@@ -155,7 +155,7 @@ mod tests {
     use turborepo_vercel_api_mock::start_test_server;
 
     use super::*;
-    use crate::{login_server, LoginServer};
+    use crate::{LoginServer, login_server};
 
     struct MockLoginServer {
         hits: Arc<AtomicUsize>,
@@ -314,10 +314,10 @@ mod tests {
             &self,
             _hash: &str,
             _artifact_body: impl turborepo_api_client::Stream<
-                    Item = Result<turborepo_api_client::Bytes, turborepo_api_client::Error>,
-                > + Send
-                + Sync
-                + 'static,
+                Item = Result<turborepo_api_client::Bytes, turborepo_api_client::Error>,
+            > + Send
+            + Sync
+            + 'static,
             _body_len: usize,
             _duration: u64,
             _tag: Option<&str>,

--- a/crates/turborepo-auth/src/auth/logout.rs
+++ b/crates/turborepo-auth/src/auth/logout.rs
@@ -2,10 +2,10 @@ use tracing::error;
 use turbopath::AbsoluteSystemPath;
 use turborepo_api_client::TokenClient;
 use turborepo_dirs::{config_dir, vercel_config_dir};
-use turborepo_ui::{cprintln, GREY};
+use turborepo_ui::{GREY, cprintln};
 
 use crate::{
-    Error, LogoutOptions, Token, TURBO_TOKEN_DIR, TURBO_TOKEN_FILE, VERCEL_TOKEN_DIR,
+    Error, LogoutOptions, TURBO_TOKEN_DIR, TURBO_TOKEN_FILE, Token, VERCEL_TOKEN_DIR,
     VERCEL_TOKEN_FILE,
 };
 
@@ -88,7 +88,7 @@ mod tests {
     use turborepo_api_client::Client;
     use turborepo_ui::ColorConfig;
     use turborepo_vercel_api::{
-        token::ResponseTokenMetadata, Team, TeamsResponse, UserResponse, VerifiedSsoUser,
+        Team, TeamsResponse, UserResponse, VerifiedSsoUser, token::ResponseTokenMetadata,
     };
     use url::Url;
 

--- a/crates/turborepo-auth/src/auth/sso.rs
+++ b/crates/turborepo-auth/src/auth/sso.rs
@@ -4,9 +4,9 @@ use reqwest::Url;
 use tokio::sync::OnceCell;
 use tracing::warn;
 use turborepo_api_client::{CacheClient, Client, TokenClient};
-use turborepo_ui::{start_spinner, ColorConfig, BOLD};
+use turborepo_ui::{BOLD, ColorConfig, start_spinner};
 
-use crate::{auth::extract_vercel_token, error, ui, Error, LoginOptions, Token};
+use crate::{Error, LoginOptions, Token, auth::extract_vercel_token, error, ui};
 
 const DEFAULT_HOST_NAME: &str = "127.0.0.1";
 const DEFAULT_PORT: u16 = 9789;
@@ -149,14 +149,14 @@ mod tests {
     use async_trait::async_trait;
     use reqwest::{Method, RequestBuilder, Response};
     use turborepo_vercel_api::{
-        token::{ResponseTokenMetadata, Scope},
         CachingStatus, CachingStatusResponse, Membership, Role, Team, TeamsResponse, User,
         UserResponse, VerifiedSsoUser,
+        token::{ResponseTokenMetadata, Scope},
     };
     use turborepo_vercel_api_mock::start_test_server;
 
     use super::*;
-    use crate::{current_unix_time, LoginServer, LoginType};
+    use crate::{LoginServer, LoginType, current_unix_time};
     const EXPECTED_VERIFICATION_TOKEN: &str = "expected_verification_token";
 
     lazy_static::lazy_static! {
@@ -306,10 +306,10 @@ mod tests {
             &self,
             _hash: &str,
             _artifact_body: impl turborepo_api_client::Stream<
-                    Item = Result<turborepo_api_client::Bytes, turborepo_api_client::Error>,
-                > + Send
-                + Sync
-                + 'static,
+                Item = Result<turborepo_api_client::Bytes, turborepo_api_client::Error>,
+            > + Send
+            + Sync
+            + 'static,
             _body_len: usize,
             _duration: u64,
             _tag: Option<&str>,

--- a/crates/turborepo-auth/src/lib.rs
+++ b/crates/turborepo-auth/src/lib.rs
@@ -15,7 +15,7 @@ pub use login_server::*;
 use serde::Deserialize;
 use turbopath::AbsoluteSystemPath;
 use turborepo_api_client::{CacheClient, Client, TokenClient};
-use turborepo_vercel_api::{token::ResponseTokenMetadata, User};
+use turborepo_vercel_api::{User, token::ResponseTokenMetadata};
 
 pub struct TeamInfo<'a> {
     pub id: &'a str,
@@ -314,8 +314,8 @@ mod tests {
     use tempfile::tempdir;
     use turbopath::AbsoluteSystemPathBuf;
     use turborepo_vercel_api::{
-        token::Scope, CachingStatus, CachingStatusResponse, Team, TeamsResponse, User,
-        UserResponse, VerifiedSsoUser,
+        CachingStatus, CachingStatusResponse, Team, TeamsResponse, User, UserResponse,
+        VerifiedSsoUser, token::Scope,
     };
     use url::Url;
 
@@ -537,10 +537,10 @@ mod tests {
             &self,
             _hash: &str,
             _artifact_body: impl turborepo_api_client::Stream<
-                    Item = Result<turborepo_api_client::Bytes, turborepo_api_client::Error>,
-                > + Send
-                + Sync
-                + 'static,
+                Item = Result<turborepo_api_client::Bytes, turborepo_api_client::Error>,
+            > + Send
+            + Sync
+            + 'static,
             _body_len: usize,
             _duration: u64,
             _tag: Option<&str>,

--- a/crates/turborepo-auth/src/login_server.rs
+++ b/crates/turborepo-auth/src/login_server.rs
@@ -2,7 +2,7 @@ use std::{net::SocketAddr, sync::Arc};
 
 use anyhow::Result;
 use async_trait::async_trait;
-use axum::{extract::Query, response::Redirect, routing::get, Router};
+use axum::{Router, extract::Query, response::Redirect, routing::get};
 use serde::Deserialize;
 use tokio::sync::OnceCell;
 use url::Url;

--- a/crates/turborepo-auth/src/ui/messages.rs
+++ b/crates/turborepo-auth/src/ui/messages.rs
@@ -1,4 +1,4 @@
-use turborepo_ui::{ColorConfig, BOLD, CYAN};
+use turborepo_ui::{BOLD, CYAN, ColorConfig};
 
 pub fn print_cli_authorized(user: &str, color_config: &ColorConfig) {
     println!(

--- a/crates/turborepo-cache/src/async_cache.rs
+++ b/crates/turborepo-cache/src/async_cache.rs
@@ -1,14 +1,14 @@
-use std::sync::{atomic::AtomicU8, Arc, Mutex};
+use std::sync::{Arc, Mutex, atomic::AtomicU8};
 
-use futures::{stream::FuturesUnordered, StreamExt};
-use tokio::sync::{mpsc, oneshot, Semaphore};
-use tracing::{warn, Instrument, Level};
+use futures::{StreamExt, stream::FuturesUnordered};
+use tokio::sync::{Semaphore, mpsc, oneshot};
+use tracing::{Instrument, Level, warn};
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
 use turborepo_analytics::AnalyticsSender;
 use turborepo_api_client::{APIAuth, APIClient};
 
 use crate::{
-    http::UploadMap, multiplexer::CacheMultiplexer, CacheError, CacheHitMetadata, CacheOpts,
+    CacheError, CacheHitMetadata, CacheOpts, http::UploadMap, multiplexer::CacheMultiplexer,
 };
 
 const WARNING_CUTOFF: u8 = 4;
@@ -226,9 +226,9 @@ mod tests {
     use turborepo_vercel_api_mock::start_test_server;
 
     use crate::{
-        test_cases::{get_test_cases, TestCase},
         AsyncCache, CacheActions, CacheConfig, CacheHitMetadata, CacheOpts, CacheSource,
         RemoteCacheOpts,
+        test_cases::{TestCase, get_test_cases},
     };
 
     #[tokio::test]

--- a/crates/turborepo-cache/src/cache_archive/restore.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore.rs
@@ -6,14 +6,14 @@ use tar::Entry;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
 
 use crate::{
+    CacheError,
     cache_archive::{
-        restore_directory::{restore_directory, CachedDirTree},
+        restore_directory::{CachedDirTree, restore_directory},
         restore_regular::restore_regular,
         restore_symlink::{
             canonicalize_linkname, restore_symlink, restore_symlink_allow_missing_target,
         },
     },
-    CacheError,
 };
 
 pub struct CacheReader<'a> {
@@ -185,7 +185,7 @@ mod tests {
 
     use anyhow::Result;
     use tar::Header;
-    use tempfile::{tempdir, TempDir};
+    use tempfile::{TempDir, tempdir};
     use test_case::test_case;
     use tracing::debug;
     use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};

--- a/crates/turborepo-cache/src/cache_archive/restore_regular.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore_regular.rs
@@ -3,7 +3,7 @@ use std::{fs::OpenOptions, io, io::Read, path::Path};
 use tar::Entry;
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, AnchoredSystemPathBuf};
 
-use crate::{cache_archive::restore_directory::CachedDirTree, CacheError};
+use crate::{CacheError, cache_archive::restore_directory::CachedDirTree};
 
 pub fn restore_regular(
     dir_cache: &mut CachedDirTree,

--- a/crates/turborepo-cache/src/cache_archive/restore_symlink.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore_symlink.rs
@@ -6,7 +6,7 @@ use turbopath::{
     PathError, UnknownPathType,
 };
 
-use crate::{cache_archive::restore_directory::CachedDirTree, CacheError};
+use crate::{CacheError, cache_archive::restore_directory::CachedDirTree};
 
 pub fn restore_symlink(
     dir_cache: &mut CachedDirTree,

--- a/crates/turborepo-cache/src/config.rs
+++ b/crates/turborepo-cache/src/config.rs
@@ -144,7 +144,7 @@ impl FromStr for CacheConfig {
                         text: s.to_string(),
                         s: ty.to_string(),
                         span: Some(SourceSpan::new(idx.into(), ty.len())),
-                    })
+                    });
                 }
             }
 
@@ -190,7 +190,7 @@ impl FromStr for CacheActions {
                         c,
                         text: String::new(),
                         span: None,
-                    })
+                    });
                 }
             }
         }

--- a/crates/turborepo-cache/src/fs.rs
+++ b/crates/turborepo-cache/src/fs.rs
@@ -7,8 +7,8 @@ use turborepo_analytics::AnalyticsSender;
 use turborepo_api_client::{analytics, analytics::AnalyticsEvent};
 
 use crate::{
-    cache_archive::{CacheReader, CacheWriter},
     CacheError, CacheHitMetadata, CacheSource,
+    cache_archive::{CacheReader, CacheWriter},
 };
 
 pub struct FSCache {
@@ -185,7 +185,7 @@ mod test {
     use turborepo_vercel_api_mock::start_test_server;
 
     use super::*;
-    use crate::test_cases::{get_test_cases, validate_analytics, TestCase};
+    use crate::test_cases::{TestCase, get_test_cases, validate_analytics};
 
     #[tokio::test]
     async fn test_fs_cache() -> Result<()> {

--- a/crates/turborepo-cache/src/http.rs
+++ b/crates/turborepo-cache/src/http.rs
@@ -10,15 +10,15 @@ use tracing::debug;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
 use turborepo_analytics::AnalyticsSender;
 use turborepo_api_client::{
-    analytics::{self, AnalyticsEvent},
     APIAuth, APIClient, CacheClient, Response,
+    analytics::{self, AnalyticsEvent},
 };
 
 use crate::{
+    CacheError, CacheHitMetadata, CacheOpts, CacheSource,
     cache_archive::{CacheReader, CacheWriter},
     signature_authentication::ArtifactSignatureAuthenticator,
     upload_progress::{UploadProgress, UploadProgressQuery},
-    CacheError, CacheHitMetadata, CacheOpts, CacheSource,
 };
 
 pub type UploadMap = HashMap<String, UploadProgressQuery<10, 100>>;
@@ -294,13 +294,13 @@ mod test {
     use tempfile::tempdir;
     use turbopath::AbsoluteSystemPathBuf;
     use turborepo_analytics::start_analytics;
-    use turborepo_api_client::{analytics, APIClient};
+    use turborepo_api_client::{APIClient, analytics};
     use turborepo_vercel_api_mock::start_test_server;
 
     use crate::{
-        http::{APIAuth, HTTPCache},
-        test_cases::{get_test_cases, validate_analytics, TestCase},
         CacheOpts, CacheSource,
+        http::{APIAuth, HTTPCache},
+        test_cases::{TestCase, get_test_cases, validate_analytics},
     };
 
     #[tokio::test]

--- a/crates/turborepo-cache/src/multiplexer.rs
+++ b/crates/turborepo-cache/src/multiplexer.rs
@@ -1,6 +1,6 @@
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
     Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
 };
 
 use tracing::{debug, warn};
@@ -9,9 +9,9 @@ use turborepo_analytics::AnalyticsSender;
 use turborepo_api_client::{APIAuth, APIClient};
 
 use crate::{
+    CacheConfig, CacheError, CacheHitMetadata, CacheOpts,
     fs::FSCache,
     http::{HTTPCache, UploadMap},
-    CacheConfig, CacheError, CacheHitMetadata, CacheOpts,
 };
 
 pub struct CacheMultiplexer {

--- a/crates/turborepo-cache/src/signature_authentication.rs
+++ b/crates/turborepo-cache/src/signature_authentication.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use base64::{prelude::BASE64_STANDARD, Engine};
+use base64::{Engine, prelude::BASE64_STANDARD};
 use hmac::{Hmac, Mac};
 use os_str_bytes::OsStringBytes;
 use sha2::Sha256;

--- a/crates/turborepo-env/src/platform.rs
+++ b/crates/turborepo-env/src/platform.rs
@@ -1,5 +1,5 @@
 use turborepo_ci::Vendor;
-use turborepo_ui::{ceprint, ceprintln, color, ColorConfig, BOLD, GREY, UNDERLINE, YELLOW};
+use turborepo_ui::{BOLD, ColorConfig, GREY, UNDERLINE, YELLOW, ceprint, ceprintln, color};
 
 use crate::EnvironmentVariableMap;
 

--- a/crates/turborepo-filewatch/src/cookies.rs
+++ b/crates/turborepo-filewatch/src/cookies.rs
@@ -47,7 +47,7 @@ use tokio::{
 use tracing::trace;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, PathRelation};
 
-use crate::{optional_watch::SomeRef, NotifyError, OptionalWatch};
+use crate::{NotifyError, OptionalWatch, optional_watch::SomeRef};
 
 #[derive(Debug, Error)]
 pub enum CookieError {
@@ -516,7 +516,7 @@ impl CookieRegister {
 mod test {
     use std::time::Duration;
 
-    use notify::{event::CreateKind, Event, EventKind};
+    use notify::{Event, EventKind, event::CreateKind};
     use tokio::{
         sync::{broadcast, mpsc, oneshot},
         task::JoinSet,
@@ -524,7 +524,7 @@ mod test {
     use turbopath::AbsoluteSystemPathBuf;
 
     use super::{CookieWatcher, CookiedRequest};
-    use crate::{cookies::CookieWriter, NotifyError, OptionalWatch};
+    use crate::{NotifyError, OptionalWatch, cookies::CookieWriter};
 
     struct TestQuery {
         resp: oneshot::Sender<()>,

--- a/crates/turborepo-filewatch/src/fsevent.rs
+++ b/crates/turborepo-filewatch/src/fsevent.rs
@@ -34,8 +34,8 @@ use fs::core_foundation::Boolean;
 use fsevent_sys as fs;
 use fsevent_sys::core_foundation as cf;
 use notify::{
-    event::{CreateKind, DataChange, Flag, MetadataKind, ModifyKind, RemoveKind, RenameMode},
     Config, Error, Event, EventHandler, EventKind, RecursiveMode, Result, Watcher, WatcherKind,
+    event::{CreateKind, DataChange, Flag, MetadataKind, ModifyKind, RemoveKind, RenameMode},
 };
 
 //use crate::event::*;

--- a/crates/turborepo-filewatch/src/globwatcher.rs
+++ b/crates/turborepo-filewatch/src/globwatcher.rs
@@ -14,8 +14,8 @@ use turbopath::{AbsoluteSystemPathBuf, RelativeUnixPath};
 use wax::{Any, Glob, Program};
 
 use crate::{
-    cookies::{CookieError, CookieWatcher, CookieWriter, CookiedRequest},
     NotifyError, OptionalWatch,
+    cookies::{CookieError, CookieWatcher, CookieWriter, CookiedRequest},
 };
 
 type Hash = String;
@@ -489,12 +489,12 @@ mod test {
     };
 
     use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
-    use wax::{any, Glob};
+    use wax::{Glob, any};
 
     use crate::{
+        FileSystemWatcher,
         cookies::CookieWriter,
         globwatcher::{GlobSet, GlobWatcher},
-        FileSystemWatcher,
     };
 
     fn temp_dir() -> (AbsoluteSystemPathBuf, tempfile::TempDir) {

--- a/crates/turborepo-filewatch/src/hash_watcher.rs
+++ b/crates/turborepo-filewatch/src/hash_watcher.rs
@@ -1,8 +1,8 @@
 use std::{
     collections::{HashMap, HashSet},
     sync::{
-        atomic::{AtomicUsize, Ordering},
         Arc,
+        atomic::{AtomicUsize, Ordering},
     },
     time::Duration,
 };
@@ -20,11 +20,11 @@ use turborepo_repository::discovery::DiscoveryResponse;
 use turborepo_scm::{Error as SCMError, GitHashes, SCM};
 
 use crate::{
+    NotifyError, OptionalWatch,
     debouncer::Debouncer,
     globwatcher::{GlobError, GlobSet},
     package_watcher::DiscoveryData,
     scm_resource::SCMResource,
-    NotifyError, OptionalWatch,
 };
 
 pub struct HashWatcher {
@@ -689,7 +689,7 @@ mod tests {
     };
 
     use git2::Repository;
-    use tempfile::{tempdir, TempDir};
+    use tempfile::{TempDir, tempdir};
     use turbopath::{
         AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf, RelativeUnixPathBuf,
     };
@@ -697,11 +697,11 @@ mod tests {
 
     use super::{FileHashes, HashState};
     use crate::{
+        FileSystemWatcher,
         cookies::CookieWriter,
         globwatcher::GlobSet,
         hash_watcher::{HashSpec, HashWatcher, InputGlobs},
         package_watcher::PackageWatcher,
-        FileSystemWatcher,
     };
 
     fn commit_all(repo: &Repository) {

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -50,8 +50,8 @@ use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, PathRelation};
 #[cfg(feature = "manual_recursive_watch")]
 use {
     notify::{
-        event::{CreateKind, EventAttributes},
         ErrorKind,
+        event::{CreateKind, EventAttributes},
     },
     std::io,
     tracing::trace,
@@ -488,7 +488,7 @@ mod test {
 
     #[cfg(not(target_os = "windows"))]
     use notify::event::RenameMode;
-    use notify::{event::ModifyKind, Event, EventKind};
+    use notify::{Event, EventKind, event::ModifyKind};
     use tokio::sync::broadcast;
     use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 

--- a/crates/turborepo-filewatch/src/optional_watch.rs
+++ b/crates/turborepo-filewatch/src/optional_watch.rs
@@ -1,5 +1,5 @@
 use futures::FutureExt;
-use tokio::sync::watch::{self, error::RecvError, Ref};
+use tokio::sync::watch::{self, Ref, error::RecvError};
 
 #[derive(Debug)]
 pub struct OptionalWatch<T>(watch::Receiver<Option<T>>);

--- a/crates/turborepo-filewatch/src/package_watcher.rs
+++ b/crates/turborepo-filewatch/src/package_watcher.rs
@@ -5,8 +5,8 @@ use std::{
     collections::HashMap,
     path::Path,
     sync::{
-        atomic::{AtomicUsize, Ordering},
         Arc,
+        atomic::{AtomicUsize, Ordering},
     },
     time::Duration,
 };
@@ -32,10 +32,10 @@ use turborepo_repository::{
 };
 
 use crate::{
+    NotifyError,
     cookies::{CookieRegister, CookieWriter, CookiedOptionalWatch},
     debouncer::Debouncer,
     optional_watch::OptionalWatch,
-    NotifyError,
 };
 
 #[derive(Debug, Error)]
@@ -575,7 +575,7 @@ mod test {
     use turbopath::AbsoluteSystemPathBuf;
     use turborepo_repository::{discovery::WorkspaceData, package_manager::PackageManager};
 
-    use crate::{cookies::CookieWriter, package_watcher::PackageWatcher, FileSystemWatcher};
+    use crate::{FileSystemWatcher, cookies::CookieWriter, package_watcher::PackageWatcher};
 
     #[tokio::test]
     #[tracing_test::traced_test]

--- a/crates/turborepo-globwalk/src/lib.rs
+++ b/crates/turborepo-globwalk/src/lib.rs
@@ -17,7 +17,7 @@ use rayon::prelude::*;
 use regex::Regex;
 use tracing::debug;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, PathError, RelativeUnixPath};
-use wax::{walk::FileIterator, BuildError, Glob};
+use wax::{BuildError, Glob, walk::FileIterator};
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum WalkType {
@@ -481,8 +481,8 @@ mod test {
     use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 
     use crate::{
-        add_doublestar_to_dir, collapse_path, escape_glob_literals, fix_glob_pattern, globwalk,
-        Settings, ValidatedGlob, WalkError, WalkType,
+        Settings, ValidatedGlob, WalkError, WalkType, add_doublestar_to_dir, collapse_path,
+        escape_glob_literals, fix_glob_pattern, globwalk,
     };
 
     #[cfg(unix)]
@@ -1520,7 +1520,7 @@ mod test {
 
     #[test]
     #[cfg(not(windows))] // Windows doesn't support ':' at all, so just test not-Windows for correct
-                         // behavior
+    // behavior
     fn test_weird_filenames() {
         let files = &[
             "apps/foo",

--- a/crates/turborepo-globwatch/examples/cancel.rs
+++ b/crates/turborepo-globwatch/examples/cancel.rs
@@ -1,6 +1,6 @@
 use std::{path::PathBuf, time::Duration};
 
-use futures::{join, StreamExt};
+use futures::{StreamExt, join};
 use globwatch::GlobWatcher;
 use tracing::{info, info_span};
 use turbopath::AbsoluteSystemPathBuf;

--- a/crates/turborepo-graph-utils/src/lib.rs
+++ b/crates/turborepo-graph-utils/src/lib.rs
@@ -6,7 +6,7 @@ use fixedbitset::FixedBitSet;
 use itertools::Itertools;
 use petgraph::{
     prelude::*,
-    visit::{depth_first_search, EdgeFiltered, IntoNeighbors, Reversed, VisitMap, Visitable},
+    visit::{EdgeFiltered, IntoNeighbors, Reversed, VisitMap, Visitable, depth_first_search},
 };
 use thiserror::Error;
 

--- a/crates/turborepo-graph-utils/src/walker.rs
+++ b/crates/turborepo-graph-utils/src/walker.rs
@@ -1,9 +1,9 @@
 use std::{collections::HashMap, hash::Hash};
 
-use futures::{future::join_all, stream::FuturesUnordered, StreamExt};
+use futures::{StreamExt, future::join_all, stream::FuturesUnordered};
 use petgraph::{
-    visit::{IntoNeighborsDirected, IntoNodeIdentifiers},
     Direction,
+    visit::{IntoNeighborsDirected, IntoNodeIdentifiers},
 };
 use tokio::{
     sync::{broadcast, mpsc, oneshot, watch},

--- a/crates/turborepo-lockfiles/src/berry/mod.rs
+++ b/crates/turborepo-lockfiles/src/berry/mod.rs
@@ -17,7 +17,7 @@ use serde::Deserialize;
 use thiserror::Error;
 use turbopath::RelativeUnixPathBuf;
 
-use self::resolution::{parse_resolution, Resolution};
+use self::resolution::{Resolution, parse_resolution};
 use super::Lockfile;
 
 #[derive(Debug, Error)]
@@ -592,7 +592,7 @@ mod test {
     use pretty_assertions::assert_eq;
 
     use super::*;
-    use crate::{transitive_closure, Package};
+    use crate::{Package, transitive_closure};
 
     #[test]
     fn test_deserialize_lockfile() {
@@ -1115,11 +1115,9 @@ mod test {
             "is-odd@patch:is-odd@npm%3A3.0.1#~/.yarn/patches/is-odd-npm-3.0.1-93c3c3f41b.patch"
         ));
 
-        let patches =
-            vec![
-                RelativeUnixPathBuf::new(".yarn/patches/is-odd-npm-3.0.1-93c3c3f41b.patch")
-                    .unwrap(),
-            ];
+        let patches = vec![
+            RelativeUnixPathBuf::new(".yarn/patches/is-odd-npm-3.0.1-93c3c3f41b.patch").unwrap(),
+        ];
         assert_eq!(lockfile.patches().unwrap(), patches);
         assert_eq!(subgraph.patches().unwrap(), patches);
     }

--- a/crates/turborepo-lockfiles/src/berry/resolution.rs
+++ b/crates/turborepo-lockfiles/src/berry/resolution.rs
@@ -1,6 +1,6 @@
 use std::{fmt, sync::OnceLock};
 
-use pest::{iterators::Pair, Parser};
+use pest::{Parser, iterators::Pair};
 use pest_derive::Parser;
 use regex::Regex;
 use semver::Version;

--- a/crates/turborepo-lockfiles/src/bun/de.rs
+++ b/crates/turborepo-lockfiles/src/bun/de.rs
@@ -108,7 +108,7 @@ mod test {
     use test_case::test_case;
 
     use super::*;
-    use crate::{bun::WorkspaceEntry, BunLockfile};
+    use crate::{BunLockfile, bun::WorkspaceEntry};
 
     macro_rules! fixture {
         ($name:ident, $kind:ty, $cons:expr) => {

--- a/crates/turborepo-lockfiles/src/bun/ser.rs
+++ b/crates/turborepo-lockfiles/src/bun/ser.rs
@@ -1,4 +1,4 @@
-use serde::{ser::SerializeTuple, Serialize};
+use serde::{Serialize, ser::SerializeTuple};
 
 use super::PackageEntry;
 

--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -18,11 +18,11 @@ pub use berry::{Error as BerryError, *};
 pub use bun::BunLockfile;
 pub use error::Error;
 pub use npm::*;
-pub use pnpm::{pnpm_global_change, pnpm_subgraph, PnpmLockfile};
+pub use pnpm::{PnpmLockfile, pnpm_global_change, pnpm_subgraph};
 use rayon::prelude::*;
 use serde::Serialize;
 use turbopath::RelativeUnixPathBuf;
-pub use yarn1::{yarn_subgraph, Yarn1Lockfile};
+pub use yarn1::{Yarn1Lockfile, yarn_subgraph};
 
 #[derive(Debug, PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Serialize)]
 pub struct Package {

--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -7,7 +7,7 @@ use std::{
 use serde::{Deserialize, Serialize};
 use turbopath::RelativeUnixPathBuf;
 
-use super::{dep_path::DepPath, Error, LockfileVersion, SupportedLockfileVersion};
+use super::{Error, LockfileVersion, SupportedLockfileVersion, dep_path::DepPath};
 
 type Map<K, V> = std::collections::BTreeMap<K, V>;
 

--- a/crates/turborepo-lockfiles/src/pnpm/dep_path.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/dep_path.rs
@@ -1,9 +1,9 @@
 use nom::{
+    Finish, IResult,
     branch::alt,
     bytes::complete::{is_not, tag},
     combinator::{opt, recognize},
     sequence::tuple,
-    Finish, IResult,
 };
 
 use super::SupportedLockfileVersion;

--- a/crates/turborepo-lockfiles/src/pnpm/mod.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/mod.rs
@@ -3,7 +3,7 @@ mod de;
 mod dep_path;
 mod ser;
 
-pub use data::{pnpm_global_change, PnpmLockfile};
+pub use data::{PnpmLockfile, pnpm_global_change};
 
 use crate::Lockfile;
 

--- a/crates/turborepo-lockfiles/src/yarn1/de.rs
+++ b/crates/turborepo-lockfiles/src/yarn1/de.rs
@@ -1,13 +1,13 @@
 use std::sync::OnceLock;
 
 use nom::{
+    IResult,
     branch::alt,
     bytes::complete::{escaped_transform, is_not, tag, take_till},
     character::complete::{anychar, char as nom_char, crlf, newline, none_of, satisfy, space1},
     combinator::{all_consuming, map, not, opt, peek, recognize, value},
     multi::{count, many0, many1},
     sequence::{delimited, pair, preceded, separated_pair, terminated, tuple},
-    IResult,
 };
 use regex::Regex;
 use serde_json::Value;

--- a/crates/turborepo-lsp/src/lib.rs
+++ b/crates/turborepo-lsp/src/lib.rs
@@ -17,17 +17,17 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use itertools::{chain, Itertools};
+use itertools::{Itertools, chain};
 use jsonc_parser::{
-    ast::{ObjectPropName, StringLit},
     CollectOptions,
+    ast::{ObjectPropName, StringLit},
 };
 use serde_json::Value;
 use tokio::sync::watch::{Receiver, Sender};
 use tower_lsp::{
+    Client, LanguageServer,
     jsonrpc::{Error, Result as LspResult},
     lsp_types::*,
-    Client, LanguageServer,
 };
 use turbopath::AbsoluteSystemPathBuf;
 use turborepo_lib::{

--- a/crates/turborepo-paths/src/absolute_system_path.rs
+++ b/crates/turborepo-paths/src/absolute_system_path.rs
@@ -215,9 +215,11 @@ impl AbsoluteSystemPath {
 
     /// Intended for joining a path composed of literals
     pub fn join_components(&self, segments: &[&str]) -> AbsoluteSystemPathBuf {
-        debug_assert!(!segments
-            .iter()
-            .any(|segment| segment.contains(std::path::MAIN_SEPARATOR)));
+        debug_assert!(
+            !segments
+                .iter()
+                .any(|segment| segment.contains(std::path::MAIN_SEPARATOR))
+        );
         AbsoluteSystemPathBuf(
             self.0
                 .join(segments.join(std::path::MAIN_SEPARATOR_STR))
@@ -390,7 +392,7 @@ impl AbsoluteSystemPath {
                 (Some(self_component), Some(other_component))
                     if self_component != other_component =>
                 {
-                    return PathRelation::Divergent
+                    return PathRelation::Divergent;
                 }
                 // A matching component, continue iterating
                 (Some(_), Some(_)) => {}

--- a/crates/turborepo-paths/src/anchored_system_path.rs
+++ b/crates/turborepo-paths/src/anchored_system_path.rs
@@ -108,9 +108,11 @@ impl AnchoredSystemPath {
     }
 
     pub fn join_components(&self, segments: &[&str]) -> AnchoredSystemPathBuf {
-        debug_assert!(!segments
-            .iter()
-            .any(|segment| segment.contains(std::path::MAIN_SEPARATOR)));
+        debug_assert!(
+            !segments
+                .iter()
+                .any(|segment| segment.contains(std::path::MAIN_SEPARATOR))
+        );
         AnchoredSystemPathBuf(
             self.0
                 .join(segments.join(std::path::MAIN_SEPARATOR_STR))
@@ -138,7 +140,7 @@ impl AnchoredSystemPath {
                 (Some(self_component), Some(other_component))
                     if self_component != other_component =>
                 {
-                    return PathRelation::Divergent
+                    return PathRelation::Divergent;
                 }
                 // A matching component, continue iterating
                 (Some(_), Some(_)) => {}

--- a/crates/turborepo-paths/src/anchored_system_path_buf.rs
+++ b/crates/turborepo-paths/src/anchored_system_path_buf.rs
@@ -8,7 +8,7 @@ use std::{
 use camino::{Utf8Component, Utf8Components, Utf8Path, Utf8PathBuf};
 use serde::{Deserialize, Serialize};
 
-use crate::{check_path, AbsoluteSystemPath, AnchoredSystemPath, PathError, PathValidation};
+use crate::{AbsoluteSystemPath, AnchoredSystemPath, PathError, PathValidation, check_path};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize)]
 #[serde(transparent)]

--- a/crates/turborepo-paths/src/lib.rs
+++ b/crates/turborepo-paths/src/lib.rs
@@ -224,7 +224,7 @@ pub fn categorize(path: &Utf8Path) -> UnknownPathType {
 mod tests {
     use test_case::test_case;
 
-    use crate::{check_path, IntoUnix, PathValidation};
+    use crate::{IntoUnix, PathValidation, check_path};
 
     #[test]
     fn test_into_unix() {

--- a/crates/turborepo-pidlock/src/lib.rs
+++ b/crates/turborepo-pidlock/src/lib.rs
@@ -241,7 +241,7 @@ impl Drop for Pidlock {
 mod tests {
     use std::{assert_matches::assert_matches, fs, io::Write, path::PathBuf};
 
-    use rand::{distributions::Alphanumeric, thread_rng, Rng};
+    use rand::{Rng, distributions::Alphanumeric, thread_rng};
 
     use super::{PidFileError, Pidlock, PidlockError, PidlockState};
 

--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -24,7 +24,7 @@ use std::{
     time::Duration,
 };
 
-use portable_pty::{native_pty_system, Child as PtyChild, MasterPty as PtyController};
+use portable_pty::{Child as PtyChild, MasterPty as PtyController, native_pty_system};
 use tokio::{
     io::{AsyncBufRead, AsyncBufReadExt, BufReader},
     process::Command as TokioCommand,
@@ -757,7 +757,7 @@ impl Child {
 mod test {
     use std::{assert_matches::assert_matches, time::Duration};
 
-    use futures::{stream::FuturesUnordered, StreamExt};
+    use futures::{StreamExt, stream::FuturesUnordered};
     use test_case::test_case;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tracing_test::traced_test;
@@ -765,8 +765,8 @@ mod test {
 
     use super::{Child, ChildInput, ChildOutput, Command};
     use crate::{
-        child::{ChildExit, ShutdownStyle},
         PtySize,
+        child::{ChildExit, ShutdownStyle},
     };
 
     const STARTUP_DELAY: Duration = Duration::from_millis(500);

--- a/crates/turborepo-process/src/lib.rs
+++ b/crates/turborepo-process/src/lib.rs
@@ -206,7 +206,7 @@ impl Default for PtySize {
 mod test {
     use std::time::Instant;
 
-    use futures::{stream::FuturesUnordered, StreamExt};
+    use futures::{StreamExt, stream::FuturesUnordered};
     use test_case::test_case;
     use tokio::{join, time::sleep};
     use tracing_test::traced_test;
@@ -285,9 +285,11 @@ mod test {
         );
 
         // Verify that we can't start new child processes
-        assert!(manager
-            .spawn(get_command(), Duration::from_secs(2))
-            .is_none());
+        assert!(
+            manager
+                .spawn(get_command(), Duration::from_secs(2))
+                .is_none()
+        );
 
         manager.stop().await;
     }

--- a/crates/turborepo-repository/src/discovery.rs
+++ b/crates/turborepo-repository/src/discovery.rs
@@ -10,7 +10,7 @@
 //! we can track areas of run that are performing sub-optimally.
 
 use tokio::time::error::Elapsed;
-use tokio_stream::{iter, StreamExt};
+use tokio_stream::{StreamExt, iter};
 use turbopath::AbsoluteSystemPathBuf;
 
 use crate::{
@@ -149,7 +149,7 @@ impl PackageDiscovery for LocalPackageDiscovery {
                 return Ok(DiscoveryResponse {
                     workspaces: vec![],
                     package_manager: self.package_manager.clone(),
-                })
+                });
             }
             Err(e) => return Err(Error::Failed(Box::new(e))),
         };

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use miette::{Diagnostic, Report};
 use petgraph::graph::{Graph, NodeIndex};
-use tracing::{warn, Instrument};
+use tracing::{Instrument, warn};
 use turbopath::{
     AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPath, AnchoredSystemPathBuf,
 };
@@ -10,7 +10,7 @@ use turborepo_graph_utils as graph;
 use turborepo_lockfiles::Lockfile;
 
 use super::{
-    dep_splitter::DependencySplitter, PackageGraph, PackageInfo, PackageName, PackageNode,
+    PackageGraph, PackageInfo, PackageName, PackageNode, dep_splitter::DependencySplitter,
 };
 use crate::{
     discovery::{

--- a/crates/turborepo-repository/src/package_json.rs
+++ b/crates/turborepo-repository/src/package_json.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anyhow::Result;
-use biome_deserialize::{json::deserialize_from_json_str, Text};
+use biome_deserialize::{Text, json::deserialize_from_json_str};
 use biome_deserialize_macros::Deserializable;
 use biome_diagnostics::DiagnosticExt;
 use biome_json_parser::JsonParserOptions;

--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -14,7 +14,7 @@ use std::{
 
 use bun::BunDetector;
 use itertools::{Either, Itertools};
-use lazy_regex::{lazy_regex, Lazy};
+use lazy_regex::{Lazy, lazy_regex};
 use miette::{Diagnostic, NamedSource, SourceSpan};
 use node_semver::SemverError;
 use npm::NpmDetector;

--- a/crates/turborepo-repository/src/package_manager/yarn.rs
+++ b/crates/turborepo-repository/src/package_manager/yarn.rs
@@ -108,7 +108,7 @@ mod tests {
     use super::prune_patches;
     use crate::{
         package_json::PackageJson,
-        package_manager::{yarn::YarnDetector, PackageManager},
+        package_manager::{PackageManager, yarn::YarnDetector},
     };
 
     #[test]

--- a/crates/turborepo-repository/src/workspaces.rs
+++ b/crates/turborepo-repository/src/workspaces.rs
@@ -1,6 +1,6 @@
 use std::{fmt, str::FromStr as _};
 
-use globwalk::{fix_glob_pattern, ValidatedGlob};
+use globwalk::{ValidatedGlob, fix_glob_pattern};
 use itertools::Itertools as _;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, PathError};
 use wax::{Any, Glob, Program as _};

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -429,10 +429,10 @@ mod tests {
     use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, PathError};
     use which::which;
 
-    use super::{previous_content, CIEnv, InvalidRange};
+    use super::{CIEnv, InvalidRange, previous_content};
     use crate::{
-        git::{GitHubCommit, GitHubEvent},
         Error, GitRepo, SCM,
+        git::{GitHubCommit, GitHubEvent},
     };
 
     fn setup_repository(
@@ -560,23 +560,27 @@ mod tests {
             .output()?;
         assert!(output.status.success());
 
-        assert!(changed_files(
-            tmp_dir.path().to_owned(),
-            tmp_dir.path().to_owned(),
-            Some("HEAD~1"),
-            Some("HEAD"),
-            false,
-        )
-        .is_ok());
+        assert!(
+            changed_files(
+                tmp_dir.path().to_owned(),
+                tmp_dir.path().to_owned(),
+                Some("HEAD~1"),
+                Some("HEAD"),
+                false,
+            )
+            .is_ok()
+        );
 
-        assert!(changed_files(
-            tmp_dir.path().to_owned(),
-            tmp_dir.path().to_owned(),
-            Some("HEAD"),
-            None,
-            true,
-        )
-        .is_ok());
+        assert!(
+            changed_files(
+                tmp_dir.path().to_owned(),
+                tmp_dir.path().to_owned(),
+                Some("HEAD"),
+                None,
+                true,
+            )
+            .is_ok()
+        );
 
         Ok(())
     }

--- a/crates/turborepo-scm/src/hash_object.rs
+++ b/crates/turborepo-scm/src/hash_object.rs
@@ -50,7 +50,7 @@ mod test {
     use turbopath::{AbsoluteSystemPathBuf, RelativeUnixPathBuf, RelativeUnixPathBufTestExt};
 
     use super::hash_objects;
-    use crate::{find_git_root, GitHashes};
+    use crate::{GitHashes, find_git_root};
 
     #[test]
     fn test_read_object_hashes() {

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -267,7 +267,7 @@ mod tests {
     use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 
     use super::find_git_root;
-    use crate::{wait_for_success, Error};
+    use crate::{Error, wait_for_success};
 
     fn tmp_dir() -> (tempfile::TempDir, AbsoluteSystemPathBuf) {
         let tmp_dir = tempfile::tempdir().unwrap();

--- a/crates/turborepo-scm/src/ls_tree.rs
+++ b/crates/turborepo-scm/src/ls_tree.rs
@@ -6,7 +6,7 @@ use std::{
 use nom::Finish;
 use turbopath::{AbsoluteSystemPathBuf, RelativeUnixPathBuf};
 
-use crate::{wait_for_success, Error, GitHashes, GitRepo};
+use crate::{Error, GitHashes, GitRepo, wait_for_success};
 
 impl GitRepo {
     #[tracing::instrument(skip(self))]
@@ -82,7 +82,7 @@ mod tests {
 
     use turbopath::RelativeUnixPathBuf;
 
-    use crate::{ls_tree::read_ls_tree, GitHashes};
+    use crate::{GitHashes, ls_tree::read_ls_tree};
 
     fn to_hash_map(pairs: &[(&str, &str)]) -> GitHashes {
         HashMap::from_iter(

--- a/crates/turborepo-scm/src/manual.rs
+++ b/crates/turborepo-scm/src/manual.rs
@@ -8,7 +8,7 @@ use hex::ToHex;
 use ignore::WalkBuilder;
 use sha1::{Digest, Sha1};
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, IntoUnix};
-use wax::{any, Glob, Program};
+use wax::{Glob, Program, any};
 
 use crate::{Error, GitHashes};
 
@@ -51,7 +51,7 @@ pub(crate) fn hash_files(
             Err(Error::Io(ref io_error, _))
                 if allow_missing && io_error.kind() == ErrorKind::NotFound =>
             {
-                continue
+                continue;
             }
             Err(e) => return Err(e),
         };

--- a/crates/turborepo-scm/src/status.rs
+++ b/crates/turborepo-scm/src/status.rs
@@ -9,7 +9,7 @@ use std::{
 use nom::Finish;
 use turbopath::{AbsoluteSystemPath, RelativeUnixPathBuf};
 
-use crate::{wait_for_success, Error, GitHashes, GitRepo};
+use crate::{Error, GitHashes, GitRepo, wait_for_success};
 
 impl GitRepo {
     #[tracing::instrument(skip(self, root_path, hashes))]

--- a/crates/turborepo-signals/src/lib.rs
+++ b/crates/turborepo-signals/src/lib.rs
@@ -11,7 +11,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use futures::{stream::FuturesUnordered, Stream, StreamExt};
+use futures::{Stream, StreamExt, stream::FuturesUnordered};
 use signals::Signal;
 use tokio::{
     pin,

--- a/crates/turborepo-signals/src/listeners.rs
+++ b/crates/turborepo-signals/src/listeners.rs
@@ -1,4 +1,4 @@
-use futures::{stream, Stream};
+use futures::{Stream, stream};
 
 use crate::signals::Signal;
 

--- a/crates/turborepo-telemetry/src/config.rs
+++ b/crates/turborepo-telemetry/src/config.rs
@@ -16,7 +16,7 @@ use sha2::{Digest, Sha256};
 use tracing::{error, trace};
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_dirs::config_dir;
-use turborepo_ui::{color, ColorConfig, BOLD, GREY, UNDERLINE};
+use turborepo_ui::{BOLD, ColorConfig, GREY, UNDERLINE, color};
 use uuid::Uuid;
 
 static DEBUG_ENV_VAR: &str = "TURBO_TELEMETRY_DEBUG";

--- a/crates/turborepo-telemetry/src/lib.rs
+++ b/crates/turborepo-telemetry/src/lib.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 
 use config::{ConfigError, TelemetryConfig};
 use events::TelemetryEvent;
-use futures::{stream::FuturesUnordered, StreamExt};
+use futures::{StreamExt, stream::FuturesUnordered};
 use once_cell::sync::OnceCell;
 use thiserror::Error;
 use tokio::{
@@ -23,7 +23,7 @@ use tokio::{
 };
 use tracing::{debug, error, trace};
 use turborepo_api_client::telemetry;
-use turborepo_ui::{color, ColorConfig, BOLD, GREY};
+use turborepo_ui::{BOLD, ColorConfig, GREY, color};
 use uuid::Uuid;
 
 const BUFFER_THRESHOLD: usize = 10;

--- a/crates/turborepo-ui/src/lib.rs
+++ b/crates/turborepo-ui/src/lib.rs
@@ -23,7 +23,7 @@ use thiserror::Error;
 pub use crate::{
     color_selector::ColorSelector,
     line::LineWriter,
-    logs::{replay_logs, replay_logs_with_crlf, LogWriter},
+    logs::{LogWriter, replay_logs, replay_logs_with_crlf},
     output::{OutputClient, OutputClientBehavior, OutputSink, OutputWriter},
     prefixed::{PrefixedUI, PrefixedWriter},
     tui::{TaskTable, TerminalPane},

--- a/crates/turborepo-ui/src/logs.rs
+++ b/crates/turborepo-ui/src/logs.rs
@@ -170,8 +170,8 @@ mod tests {
     use turbopath::AbsoluteSystemPathBuf;
 
     use crate::{
-        logs::replay_logs, replay_logs_with_crlf, ColorConfig, LogWriter, PrefixedUI,
-        PrefixedWriter, BOLD, CYAN,
+        BOLD, CYAN, ColorConfig, LogWriter, PrefixedUI, PrefixedWriter, logs::replay_logs,
+        replay_logs_with_crlf,
     };
 
     #[test]

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -6,10 +6,10 @@ use std::{
 };
 
 use ratatui::{
+    Frame, Terminal,
     backend::{Backend, CrosstermBackend},
     layout::{Constraint, Layout},
     widgets::{Clear, TableState},
-    Frame, Terminal,
 };
 use tokio::{
     sync::{mpsc, oneshot},
@@ -24,19 +24,19 @@ pub const FRAMERATE: Duration = Duration::from_millis(3);
 const RESIZE_DEBOUNCE_DELAY: Duration = Duration::from_millis(10);
 
 use super::{
+    AppReceiver, Debouncer, Error, Event, InputOptions, SizeInfo, TaskTable, TerminalPane,
     event::{CacheResult, Direction, OutputLogs, PaneSize, TaskResult},
     input,
     preferences::PreferenceLoader,
     search::SearchResults,
-    AppReceiver, Debouncer, Error, Event, InputOptions, SizeInfo, TaskTable, TerminalPane,
 };
 use crate::{
+    ColorConfig,
     tui::{
         scroll::ScrollMomentum,
         task::{Task, TasksByStatus},
         term_output::TerminalOutput,
     },
-    ColorConfig,
 };
 
 #[derive(Debug, Clone)]

--- a/crates/turborepo-ui/src/tui/handle.rs
+++ b/crates/turborepo-ui/src/tui/handle.rs
@@ -1,9 +1,9 @@
 use tokio::sync::{mpsc, oneshot};
 
 use super::{
+    Error, Event, TaskResult,
     app::FRAMERATE,
     event::{CacheResult, OutputLogs, PaneSize},
-    Error, Event, TaskResult,
 };
 use crate::sender::{TaskSender, UISender};
 

--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -5,7 +5,7 @@ use ratatui::{
 };
 use tui_term::widget::PseudoTerminal;
 
-use super::{app::LayoutSections, TerminalOutput};
+use super::{TerminalOutput, app::LayoutSections};
 
 const EXIT_INTERACTIVE_HINT: &str = "Ctrl-z - Stop interacting";
 const ENTER_INTERACTIVE_HINT: &str = "i - Interact";

--- a/crates/turborepo-ui/src/tui/task.rs
+++ b/crates/turborepo-ui/src/tui/task.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 use std::{collections::HashSet, mem, time::Instant};
 
-use super::{event::TaskResult, Error};
+use super::{Error, event::TaskResult};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub struct Planned;

--- a/crates/turborepo-ui/src/tui/term_output.rs
+++ b/crates/turborepo-ui/src/tui/term_output.rs
@@ -3,8 +3,8 @@ use std::{io::Write, mem};
 use turborepo_vt100 as vt100;
 
 use super::{
-    event::{CacheResult, Direction, OutputLogs, TaskResult},
     Error,
+    event::{CacheResult, Direction, OutputLogs, TaskResult},
 };
 
 pub struct TerminalOutput<W> {

--- a/crates/turborepo-ui/src/wui/sender.rs
+++ b/crates/turborepo-ui/src/wui/sender.rs
@@ -5,7 +5,7 @@ use tracing::log::warn;
 use crate::{
     sender::{TaskSender, UISender},
     tui::event::{CacheResult, OutputLogs, TaskResult},
-    wui::{event::WebUIEvent, Error},
+    wui::{Error, event::WebUIEvent},
 };
 
 #[derive(Debug, Clone)]

--- a/crates/turborepo-updater/src/lib.rs
+++ b/crates/turborepo-updater/src/lib.rs
@@ -11,8 +11,8 @@ use serde::Deserialize;
 use thiserror::Error as ThisError;
 use turborepo_repository::package_manager::PackageManager;
 use update_informer::{
-    http_client::{GenericHttpClient, HttpClient},
     Check, Package, Registry, Result as UpdateResult, Version,
+    http_client::{GenericHttpClient, HttpClient},
 };
 
 mod ui;

--- a/crates/turborepo-updater/src/ui/mod.rs
+++ b/crates/turborepo-updater/src/ui/mod.rs
@@ -1,4 +1,4 @@
-use console::{measure_text_width, Term};
+use console::{Term, measure_text_width};
 
 use crate::UpdateNotifierError;
 pub mod utils;

--- a/crates/turborepo-vercel-api-mock/src/lib.rs
+++ b/crates/turborepo-vercel-api-mock/src/lib.rs
@@ -4,17 +4,17 @@ use std::{collections::HashMap, fs::OpenOptions, io::Write, net::SocketAddr, syn
 
 use anyhow::Result;
 use axum::{
+    Json, Router,
     body::Body,
     extract::Path,
-    http::{header::CONTENT_LENGTH, HeaderMap, HeaderValue, StatusCode},
+    http::{HeaderMap, HeaderValue, StatusCode, header::CONTENT_LENGTH},
     routing::{get, head, options, post, put},
-    Json, Router,
 };
 use futures_util::StreamExt;
 use tokio::{net::TcpListener, sync::Mutex};
 use turborepo_vercel_api::{
-    telemetry::TelemetryEvent, AnalyticsEvent, CachingStatus, CachingStatusResponse, Membership,
-    Role, Team, TeamsResponse, User, UserResponse, VerificationResponse,
+    AnalyticsEvent, CachingStatus, CachingStatusResponse, Membership, Role, Team, TeamsResponse,
+    User, UserResponse, VerificationResponse, telemetry::TelemetryEvent,
 };
 
 pub const EXPECTED_TOKEN: &str = "expected_token";

--- a/crates/turborepo-wax/src/diagnostics/miette.rs
+++ b/crates/turborepo-wax/src/diagnostics/miette.rs
@@ -9,10 +9,10 @@ use tardar::{
 use thiserror::Error;
 
 use crate::{
+    Checked, Glob,
     diagnostics::SpanExt as _,
     rule,
     token::{self, TokenKind, TokenTree, Tokenized},
-    Checked, Glob,
 };
 
 /// APIs for diagnosing globs.
@@ -150,9 +150,11 @@ mod tests {
         let glob = Glob::new("../foo").unwrap();
         let diagnostics: Vec<_> = glob.diagnose().collect();
 
-        assert!(diagnostics.iter().any(|diagnostic| diagnostic
-            .code()
-            .map_or(false, |code| code.to_string() == CODE_SEMANTIC_LITERAL)));
+        assert!(diagnostics.iter().any(|diagnostic| {
+            diagnostic
+                .code()
+                .map_or(false, |code| code.to_string() == CODE_SEMANTIC_LITERAL)
+        }));
     }
 
     #[test]
@@ -160,8 +162,10 @@ mod tests {
         let glob = Glob::new("**/foo/").unwrap();
         let diagnostics: Vec<_> = glob.diagnose().collect();
 
-        assert!(diagnostics.iter().any(|diagnostic| diagnostic
-            .code()
-            .map_or(false, |code| code.to_string() == CODE_TERMINATING_SEPARATOR)));
+        assert!(diagnostics.iter().any(|diagnostic| {
+            diagnostic
+                .code()
+                .map_or(false, |code| code.to_string() == CODE_TERMINATING_SEPARATOR)
+        }));
     }
 }

--- a/crates/turborepo-wax/src/lib.rs
+++ b/crates/turborepo-wax/src/lib.rs
@@ -1933,33 +1933,43 @@ mod tests {
     fn query_glob_variance() {
         assert!(Glob::new("").unwrap().variance().is_invariant());
         assert!(Glob::new("/a/file.ext").unwrap().variance().is_invariant());
-        assert!(Glob::new("/a/{file.ext}")
-            .unwrap()
-            .variance()
-            .is_invariant());
-        assert!(Glob::new("{a/b/file.ext}")
-            .unwrap()
-            .variance()
-            .is_invariant());
+        assert!(
+            Glob::new("/a/{file.ext}")
+                .unwrap()
+                .variance()
+                .is_invariant()
+        );
+        assert!(
+            Glob::new("{a/b/file.ext}")
+                .unwrap()
+                .variance()
+                .is_invariant()
+        );
         assert!(Glob::new("{a,a}").unwrap().variance().is_invariant());
         #[cfg(windows)]
         assert!(Glob::new("{a,A}").unwrap().variance().is_invariant());
         assert!(Glob::new("<a/b:2>").unwrap().variance().is_invariant());
         #[cfg(unix)]
-        assert!(Glob::new("/[a]/file.ext")
-            .unwrap()
-            .variance()
-            .is_invariant());
+        assert!(
+            Glob::new("/[a]/file.ext")
+                .unwrap()
+                .variance()
+                .is_invariant()
+        );
         #[cfg(unix)]
-        assert!(Glob::new("/[a-a]/file.ext")
-            .unwrap()
-            .variance()
-            .is_invariant());
+        assert!(
+            Glob::new("/[a-a]/file.ext")
+                .unwrap()
+                .variance()
+                .is_invariant()
+        );
         #[cfg(unix)]
-        assert!(Glob::new("/[a-aaa-a]/file.ext")
-            .unwrap()
-            .variance()
-            .is_invariant());
+        assert!(
+            Glob::new("/[a-aaa-a]/file.ext")
+                .unwrap()
+                .variance()
+                .is_invariant()
+        );
 
         assert!(Glob::new("/a/{b,c}").unwrap().variance().is_variant());
         assert!(Glob::new("<a/b:1,>").unwrap().variance().is_variant());
@@ -1968,14 +1978,18 @@ mod tests {
         assert!(Glob::new("/a/*.ext").unwrap().variance().is_variant());
         assert!(Glob::new("/a/b*").unwrap().variance().is_variant());
         #[cfg(unix)]
-        assert!(Glob::new("/a/(?i)file.ext")
-            .unwrap()
-            .variance()
-            .is_variant());
+        assert!(
+            Glob::new("/a/(?i)file.ext")
+                .unwrap()
+                .variance()
+                .is_variant()
+        );
         #[cfg(windows)]
-        assert!(Glob::new("/a/(?-i)file.ext")
-            .unwrap()
-            .variance()
-            .is_variant());
+        assert!(
+            Glob::new("/a/(?-i)file.ext")
+                .unwrap()
+                .variance()
+                .is_variant()
+        );
     }
 }

--- a/crates/turborepo-wax/src/rule.rs
+++ b/crates/turborepo-wax/src/rule.rs
@@ -23,9 +23,9 @@ use miette::{Diagnostic, LabeledSpan, SourceCode};
 use thiserror::Error;
 
 use crate::{
+    Any, BuildError, Glob, Pattern,
     diagnostics::{CompositeSpan, CorrelatedSpan, SpanExt as _},
     token::{self, InvariantSize, Token, TokenKind, TokenTree, Tokenized},
-    Any, BuildError, Glob, Pattern,
 };
 
 /// Maximum invariant size.

--- a/crates/turborepo-wax/src/token/mod.rs
+++ b/crates/turborepo-wax/src/token/mod.rs
@@ -7,24 +7,24 @@ use std::{
     collections::VecDeque,
     mem,
     ops::Deref,
-    path::{PathBuf, MAIN_SEPARATOR},
+    path::{MAIN_SEPARATOR, PathBuf},
     slice, str,
 };
 
 use itertools::Itertools as _;
 
 pub use crate::token::{
-    parse::{parse, Annotation, ParseError, ROOT_SEPARATOR_EXPRESSION},
+    parse::{Annotation, ParseError, ROOT_SEPARATOR_EXPRESSION, parse},
     variance::{
-        invariant_text_prefix, is_exhaustive, Boundedness, InvariantSize, InvariantText, Variance,
+        Boundedness, InvariantSize, InvariantText, Variance, invariant_text_prefix, is_exhaustive,
     },
 };
 use crate::{
+    PATHS_ARE_CASE_INSENSITIVE, StrExt as _,
     token::variance::{
         CompositeBreadth, CompositeDepth, ConjunctiveVariance, DisjunctiveVariance,
         IntoInvariantText, Invariance, UnitBreadth, UnitDepth, UnitVariance,
     },
-    StrExt as _, PATHS_ARE_CASE_INSENSITIVE,
 };
 
 pub trait TokenTree<'t>: Sized {

--- a/crates/turborepo-wax/src/token/parse.rs
+++ b/crates/turborepo-wax/src/token/parse.rs
@@ -11,12 +11,12 @@ use pori::{Located, Location, Stateful};
 use thiserror::Error;
 
 use crate::{
+    PATHS_ARE_CASE_INSENSITIVE,
     diagnostics::{LocatedError, Span},
     token::{
         Alternative, Archetype, Class, Evaluation, Literal, Repetition, Separator, Token,
         TokenKind, Tokenized, Wildcard,
     },
-    PATHS_ARE_CASE_INSENSITIVE,
 };
 
 pub type Annotation = Span;
@@ -180,8 +180,8 @@ enum FlagToggle {
 
 pub fn parse(expression: &str) -> Result<Tokenized<'_>, ParseError<'_>> {
     use nom::{
-        branch, bytes::complete as bytes, character::complete as character, combinator, error,
-        multi, sequence, IResult, Parser,
+        IResult, Parser, branch, bytes::complete as bytes, character::complete as character,
+        combinator, error, multi, sequence,
     };
 
     use crate::token::parse::FlagToggle::CaseInsensitive;

--- a/crates/turborepo-wax/src/token/variance.rs
+++ b/crates/turborepo-wax/src/token/variance.rs
@@ -7,9 +7,8 @@ use std::{
 use itertools::Itertools as _;
 
 use crate::{
-    encode,
+    PATHS_ARE_CASE_INSENSITIVE, encode,
     token::{self, Separator, Token},
-    PATHS_ARE_CASE_INSENSITIVE,
 };
 
 pub trait Invariance:
@@ -593,9 +592,8 @@ mod tests {
     use std::path::{Path, PathBuf};
 
     use crate::token::{
-        self,
+        self, TokenTree,
         variance::{self, Boundedness, InvariantSize, Variance},
-        TokenTree,
     };
 
     #[test]

--- a/crates/turborepo-wax/src/walk/glob.rs
+++ b/crates/turborepo-wax/src/walk/glob.rs
@@ -8,15 +8,15 @@ use regex::Regex;
 
 use super::SplitAtDepth;
 use crate::{
+    BuildError, CandidatePath, Glob, Pattern,
     capture::MatchedText,
     encode::CompileError,
     token::{self, Token, TokenTree},
     walk::{
-        filter::{HierarchicalIterator, Separation},
         Entry, EntryResidue, FileIterator, JoinAndGetDepth, TreeEntry, WalkBehavior, WalkError,
         WalkTree,
+        filter::{HierarchicalIterator, Separation},
     },
-    BuildError, CandidatePath, Glob, Pattern,
 };
 
 /// APIs for matching globs against directory trees.

--- a/crates/turborepo-wax/src/walk/mod.rs
+++ b/crates/turborepo-wax/src/walk/mod.rs
@@ -84,6 +84,7 @@ use walkdir::{DirEntry, Error, WalkDir};
 
 pub use crate::walk::glob::{GlobEntry, GlobWalker};
 use crate::{
+    BuildError, Pattern,
     walk::{
         filter::{
             CancelWalk, HierarchicalIterator, Isomeric, SeparatingFilter, SeparatingFilterInput,
@@ -91,7 +92,6 @@ use crate::{
         },
         glob::FilterAny,
     },
-    BuildError, Pattern,
 };
 
 type FileFiltrate<T> = Result<T, WalkError>;
@@ -1083,16 +1083,16 @@ impl From<EntryResidue> for TreeResidue<()> {
 mod tests {
     use std::{collections::HashSet, path::PathBuf};
 
-    use build_fs_tree::{dir, file, Build, FileSystemTree};
+    use build_fs_tree::{Build, FileSystemTree, dir, file};
     use path_slash::PathBufExt;
     use tempfile::TempDir;
 
     use crate::{
-        walk::{
-            filter::{HierarchicalIterator, Separation, TreeResidue},
-            Entry, FileIterator, LinkBehavior, PathExt, WalkBehavior,
-        },
         Glob,
+        walk::{
+            Entry, FileIterator, LinkBehavior, PathExt, WalkBehavior,
+            filter::{HierarchicalIterator, Separation, TreeResidue},
+        },
     };
 
     macro_rules! assert_set_eq {

--- a/crates/turborepo-wax/tests/walk.rs
+++ b/crates/turborepo-wax/tests/walk.rs
@@ -2,11 +2,11 @@
 
 use std::{collections::HashSet, path::PathBuf};
 
-use build_fs_tree::{dir, file, Build, FileSystemTree};
+use build_fs_tree::{Build, FileSystemTree, dir, file};
 use tempfile::TempDir;
 use wax::{
-    walk::{Entry, FileIterator, WalkBehavior},
     Glob,
+    walk::{Entry, FileIterator, WalkBehavior},
 };
 
 // TODO: Rust's testing framework does not provide a mechanism for maintaining

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -14,7 +14,7 @@ use turborepo_repository::{
         LockfileContents, PackageChangeMapper, PackageChanges,
     },
     inference::RepoState as WorkspaceState,
-    package_graph::{PackageGraph, PackageName, PackageNode, WorkspacePackage, ROOT_PKG_NAME},
+    package_graph::{PackageGraph, PackageName, PackageNode, ROOT_PKG_NAME, WorkspacePackage},
 };
 use turborepo_scm::SCM;
 mod internal;


### PR DESCRIPTION
### Description

mostly 2024 edition format is applied for import lines and extra semicolons, in some cases (macro or function arguments) more strict style is used
<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

### Testing Instructions

CI with its fmt check
<!--
  Give a quick description of steps to test your changes.
-->
