### PR TITLE
docs: add more doc comments for working with the lockfile trait

### DIFF
--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -40,39 +40,72 @@ pub struct Package {
     pub version: String,
 }
 
-// This trait will only be used when migrating the Go lockfile implementations
-// to Rust. Once the migration is complete we will leverage petgraph for doing
-// our graph calculations.
+/// A trait for exposing common operations for lockfile parsing, analysis, and
+/// encoding.
+///
+/// External packages are identified by key strings which have no shared
+/// structure other than being able to uniquely identify a package in the
+/// corresponding lockfile. When programming against these keys they should be
+/// viewed as a black box and any logic for handling them should live in the
+/// specific lockfile implementation which might have additional understanding
+/// of them. Using `human_name` can provide a version of the key that is
+/// formatted for human viewing. The fact that keys are still represented as
+/// `String`s is a vestige of the translation from Go.
+///
+/// We cannot easily expose lockfiles as a standard
+/// graph due to overrides that various lockfile formats support. A dependency
+/// of `"package": "1.0.0"` might resolve to a different version depending on
+/// how it is imported. See
 pub trait Lockfile: Send + Sync + Any + std::fmt::Debug {
-    // Given a workspace, a package it imports and version returns the key, resolved
-    // version, and if it was found
+    /// Resolve a dependency declaration from a workspace package to a lockfile
+    /// key
     fn resolve_package(
         &self,
         workspace_path: &str,
         name: &str,
         version: &str,
     ) -> Result<Option<Package>, Error>;
-    // Given a lockfile key return all (prod/dev/optional) dependencies of that
-    // package
+
+    /// Given a lockfile key return all (prod/dev/optional) direct dependencies
+    /// of that package.
     fn all_dependencies(&self, key: &str) -> Result<Option<HashMap<String, String>>, Error>;
 
+    /// Given a list of workspace packages and external packages that are
+    /// dependencies of the workspace packages, produce a lockfile that only
+    /// references said packages.
+    ///
+    /// The caller is expected to have calculated the correct `packages` for the
+    /// provided `workspace_packages` using `resolve_package` and
+    /// `all_dependencies` as otherwise `subgraph` might fail or produce an
+    /// incorrect lockfile.
     fn subgraph(
         &self,
         workspace_packages: &[String],
         packages: &[String],
     ) -> Result<Box<dyn Lockfile>, Error>;
 
+    /// Encode the lockfile to a string of bytes that can be written to disk
     fn encode(&self) -> Result<Vec<u8>, Error>;
 
     /// All patch files referenced in the lockfile
+    ///
+    /// Useful for identifying any patch files that are referenced by the
+    /// lockfile
     fn patches(&self) -> Result<Vec<RelativeUnixPathBuf>, Error> {
         Ok(Vec::new())
     }
 
     /// Determine if there's a global change between two lockfiles
+    ///
+    /// This generally is only `true` across lockfile version changes or when a
+    /// setting changes where it is safer to view everything as changed rather
+    /// than try to understand the change.
     fn global_change(&self, other: &dyn Lockfile) -> bool;
 
     /// Return any turbo version found in the lockfile
+    ///
+    /// Used for identifying which version of `turbo` the lockfile references if
+    /// no local `turbo` binary is found.
     fn turbo_version(&self) -> Option<String>;
 
     /// A human friendly version of a lockfile key.
@@ -106,7 +139,6 @@ pub fn all_transitive_closures<L: Lockfile + ?Sized>(
         .collect()
 }
 
-// this should get replaced by petgraph in the future :)
 #[tracing::instrument(skip_all)]
 pub fn transitive_closure<L: Lockfile + ?Sized>(
     lockfile: &L,

--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -55,7 +55,7 @@ pub struct Package {
 /// We cannot easily expose lockfiles as a standard
 /// graph due to overrides that various lockfile formats support. A dependency
 /// of `"package": "1.0.0"` might resolve to a different version depending on
-/// how it is imported. See
+/// how it is imported. See https://pnpm.io/settings#overrides
 pub trait Lockfile: Send + Sync + Any + std::fmt::Debug {
     /// Resolve a dependency declaration from a workspace package to a lockfile
     /// key


### PR DESCRIPTION
### Description

Add/update doc comments for the titular `Lockfile` trait exposed by the `turborepo_lockfiles` crate.

### Testing Instructions

👀 
