### PR TITLE
docs: rework llms.txt and add .md responses

### DIFF
--- a/docs/site/app/lib/llms-utils.ts
+++ b/docs/site/app/lib/llms-utils.ts
@@ -1,0 +1,37 @@
+import * as fs from "node:fs/promises";
+import fg from "fast-glob";
+import matter from "gray-matter";
+import { remark } from "remark";
+import remarkStringify from "remark-stringify";
+import remarkMdx from "remark-mdx";
+
+export const DEFAULT_IGNORED_FILES = [
+  "!./content/docs/acknowledgments.mdx",
+  "!./content/docs/community.mdx",
+  "!./content/docs/telemetry.mdx",
+];
+
+export async function scanDocumentationFiles(
+  patterns: Array<string> = ["./content/docs/**/*.mdx"],
+  ignorePatterns: Array<string> = DEFAULT_IGNORED_FILES
+) {
+  return fg([...patterns, ...ignorePatterns]);
+}
+
+export async function parseFileContent(filePath: string) {
+  const fileContent = await fs.readFile(filePath);
+  return matter(fileContent.toString());
+}
+
+export async function processMarkdownContent(content: string): Promise<string> {
+  const file = await remark()
+    .use(remarkMdx)
+    .use(remarkStringify)
+    .process(content);
+
+  return String(file);
+}
+
+export function formatFilePath(filePath: string): string {
+  return filePath.replace("./content/docs", "").replace(/\.mdx$/, ".md");
+}

--- a/docs/site/app/llms-full.txt/route.ts
+++ b/docs/site/app/llms-full.txt/route.ts
@@ -19,7 +19,7 @@ export async function GET(): Promise<Response> {
     const processed = await processMarkdownContent(content);
     return `- [${data.title}](${formatFilePath(file)}): ${data.description}
 
-   ${processed}`;
+${processed}`;
   });
 
   const scanned = await Promise.all(scan);

--- a/docs/site/app/llms.md/[[...slug]]/route.ts
+++ b/docs/site/app/llms.md/[[...slug]]/route.ts
@@ -20,8 +20,7 @@ export async function GET(
   );
   const txt = await processMarkdownContent(content);
 
-  const header = `
-# ${data.title}
+  const header = `# ${data.title}
 Description: ${data.description}
 
 `;

--- a/docs/site/app/llms.md/[[...slug]]/route.ts
+++ b/docs/site/app/llms.md/[[...slug]]/route.ts
@@ -15,9 +15,18 @@ export async function GET(
   const page = repoDocsPages.getPage(slug);
   if (!page) notFound();
 
-  const { content } = await parseFileContent(page.data._file.absolutePath);
+  const { data, content } = await parseFileContent(
+    page.data._file.absolutePath
+  );
   const txt = await processMarkdownContent(content);
-  return new Response(txt);
+
+  const header = `
+# ${data.title}
+Description: ${data.description}
+
+`;
+
+  return new Response(header.concat(txt));
 }
 
 export function generateStaticParams() {

--- a/docs/site/app/llms.md/[[...slug]]/route.ts
+++ b/docs/site/app/llms.md/[[...slug]]/route.ts
@@ -1,9 +1,9 @@
 // This file is mostly a copy-paste from https://fumadocs.vercel.app/docs/ui/llms.
 
-import * as fs from "node:fs/promises";
 import { notFound } from "next/navigation";
 import { type NextRequest } from "next/server";
 import { repoDocsPages } from "../../source";
+import { parseFileContent, processMarkdownContent } from "../../lib/llms-utils";
 
 export const revalidate = false;
 
@@ -15,8 +15,9 @@ export async function GET(
   const page = repoDocsPages.getPage(slug);
   if (!page) notFound();
 
-  const fileContent = await fs.readFile(page.data._file.absolutePath);
-  return new Response(fileContent);
+  const { content } = await parseFileContent(page.data._file.absolutePath);
+  const txt = await processMarkdownContent(content);
+  return new Response(txt);
 }
 
 export function generateStaticParams() {

--- a/docs/site/app/llms.md/[[...slug]]/route.ts
+++ b/docs/site/app/llms.md/[[...slug]]/route.ts
@@ -2,7 +2,7 @@
 
 import * as fs from "node:fs/promises";
 import { notFound } from "next/navigation";
-import { type NextRequest, NextResponse } from "next/server";
+import { type NextRequest } from "next/server";
 import { repoDocsPages } from "../../source";
 
 export const revalidate = false;
@@ -16,7 +16,7 @@ export async function GET(
   if (!page) notFound();
 
   const fileContent = await fs.readFile(page.data._file.absolutePath);
-  return new NextResponse(fileContent);
+  return new Response(fileContent);
 }
 
 export function generateStaticParams() {

--- a/docs/site/app/llms.md/[[...slug]]/route.ts
+++ b/docs/site/app/llms.md/[[...slug]]/route.ts
@@ -1,0 +1,24 @@
+// This file is mostly a copy-paste from https://fumadocs.vercel.app/docs/ui/llms.
+
+import * as fs from "node:fs/promises";
+import { notFound } from "next/navigation";
+import { type NextRequest, NextResponse } from "next/server";
+import { repoDocsPages } from "../../source";
+
+export const revalidate = false;
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ slug?: Array<string> }> }
+) {
+  const { slug } = await params;
+  const page = repoDocsPages.getPage(slug);
+  if (!page) notFound();
+
+  const fileContent = await fs.readFile(page.data._file.absolutePath);
+  return new NextResponse(fileContent);
+}
+
+export function generateStaticParams() {
+  return repoDocsPages.generateParams();
+}

--- a/docs/site/app/llms.txt/route.ts
+++ b/docs/site/app/llms.txt/route.ts
@@ -1,28 +1,22 @@
 // This file is mostly a copy-paste from https://fumadocs.vercel.app/docs/ui/llms.
 
-import * as fs from "node:fs/promises";
-import fg from "fast-glob";
-import matter from "gray-matter";
+import {
+  scanDocumentationFiles,
+  parseFileContent,
+  formatFilePath,
+} from "../lib/llms-utils";
 import { PRODUCT_SLOGANS } from "../../lib/constants";
 
 export const revalidate = false;
 
 export async function GET(): Promise<Response> {
   // all scanned content
-  const files = await fg([
-    "./content/docs/**/*.mdx",
-    "!./content/docs/acknowledgments.mdx",
-    "!./content/docs/community.mdx",
-    "!./content/docs/telemetry.mdx",
-  ]);
+  const files = await scanDocumentationFiles();
 
   const scan = files.sort().map(async (file) => {
-    const fileContent = await fs.readFile(file);
-    const { data } = matter(fileContent.toString());
+    const { data } = await parseFileContent(file);
 
-    return `- [${data.title}](${file
-      .replace("./content/docs", "")
-      .replace(/\.mdx$/, ".md")}): ${data.description}`;
+    return `- [${data.title}](${formatFilePath(file)}): ${data.description}`;
   });
 
   const scanned = await Promise.all(scan);

--- a/docs/site/next.config.ts
+++ b/docs/site/next.config.ts
@@ -6,6 +6,11 @@ import { REDIRECTS_FOR_V2_DOCS } from "./lib/redirects/v2-docs.mjs";
 const withMDX = createMDX();
 const vercelToolbar = withVercelToolbar();
 
+const llmMarkdownRedirects = {
+  source: "/docs/:path*.md",
+  destination: "/llms.md/:path*",
+};
+
 const config: NextConfig = {
   reactStrictMode: true,
   images: {
@@ -40,17 +45,9 @@ const config: NextConfig = {
                 source: "/api/feedback",
                 destination: "https://vercel.com/api/feedback",
               },
-              {
-                source: "/docs/:path*.mdx",
-                destination: "/llms.mdx/:path*",
-              },
+              llmMarkdownRedirects,
             ]
-          : [
-              {
-                source: "/docs/:path*.md",
-                destination: "/llms.md/:path*",
-              },
-            ],
+          : [llmMarkdownRedirects],
     };
   },
   // Next.js still expects these to return Promises even without await

--- a/docs/site/next.config.ts
+++ b/docs/site/next.config.ts
@@ -40,8 +40,17 @@ const config: NextConfig = {
                 source: "/api/feedback",
                 destination: "https://vercel.com/api/feedback",
               },
+              {
+                source: "/docs/:path*.mdx",
+                destination: "/llms.mdx/:path*",
+              },
             ]
-          : undefined,
+          : [
+              {
+                source: "/docs/:path*.md",
+                destination: "/llms.md/:path*",
+              },
+            ],
     };
   },
   // Next.js still expects these to return Promises even without await


### PR DESCRIPTION
### Description

[Twitter dutifully informed me that I'm doing llms.txt wrong](https://x.com/mazeincoding/status/1959919330520428619).

Looking around at other implementations, it seems I fell behind. This PR:
- Makes `/llm.txt` a list of links
- Makes `/llms-full.txt` a full readout of all of our markdown
- Adds `.md` extension paths (e.g. `/docs/core-concepts.md`) to our usual docs paths so they're directly visitable

This is all in addition to our existing "Copy to markdown" button. More ways to access!

### Testing Instructions

Visit the paths mention for some sweet, sweet markdown.
