### PR TITLE
feat(turbo_json): allow for extending form non-root `turbo.json`

### DIFF
--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -18,7 +18,7 @@ use turborepo_ui::BOLD;
 use super::CommandBase;
 use crate::{
     config::{CONFIG_FILE, CONFIG_FILE_JSONC},
-    turbo_json::RawTurboJson,
+    turbo_json::{RawRootTurboJson, RawTurboJson},
 };
 
 pub const DEFAULT_OUTPUT_DIR: &str = "out";
@@ -473,7 +473,8 @@ impl<'a> Prune<'a> {
             return Ok(None);
         };
 
-        let turbo_json = RawTurboJson::parse(&turbo_json_contents, turbo_json_name.as_str())?;
+        let turbo_json =
+            RawRootTurboJson::parse(&turbo_json_contents, turbo_json_name.as_str())?.into();
         Ok(Some((turbo_json, turbo_json_name)))
     }
 }

--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -140,6 +140,13 @@ pub enum Error {
         #[source_code]
         text: NamedSource<String>,
     },
+    #[error("You must extend from the root of the workspace first.")]
+    ExtendsRootFirst {
+        #[label("'//' should be first")]
+        span: Option<SourceSpan>,
+        #[source_code]
+        text: NamedSource<String>,
+    },
     #[error("`{field}` cannot contain an environment variable.")]
     InvalidDependsOnValue {
         field: &'static str,

--- a/crates/turborepo-lib/src/config/mod.rs
+++ b/crates/turborepo-lib/src/config/mod.rs
@@ -23,7 +23,7 @@ use turborepo_cache::CacheConfig;
 use turborepo_errors::TURBO_SITE;
 use turborepo_repository::package_graph::PackageName;
 
-pub use crate::turbo_json::{RawTurboJson, UIMode};
+pub use crate::turbo_json::UIMode;
 use crate::{
     cli::{EnvMode, LogOrder},
     turbo_json::FutureFlags,

--- a/crates/turborepo-lib/src/config/turbo_json.rs
+++ b/crates/turborepo-lib/src/config/turbo_json.rs
@@ -2,7 +2,7 @@ use camino::Utf8PathBuf;
 use turbopath::{AbsoluteSystemPath, RelativeUnixPath};
 
 use super::{ConfigurationOptions, Error, ResolvedConfigurationOptions};
-use crate::turbo_json::{RawRemoteCacheOptions, RawTurboJson};
+use crate::turbo_json::{RawRemoteCacheOptions, RawRootTurboJson, RawTurboJson};
 
 pub struct TurboJsonReader<'a> {
     repo_root: &'a AbsoluteSystemPath,
@@ -89,8 +89,16 @@ impl<'a> ResolvedConfigurationOptions for TurboJsonReader<'a> {
         existing_config: &ConfigurationOptions,
     ) -> Result<ConfigurationOptions, Error> {
         let turbo_json_path = existing_config.root_turbo_json_path(self.repo_root)?;
-        let turbo_json = RawTurboJson::read(self.repo_root, &turbo_json_path)
-            .map(|turbo_json| turbo_json.unwrap_or_default())?;
+        let root_relative_turbo_json_path = self.repo_root.anchor(&turbo_json_path).map_or_else(
+            |_| turbo_json_path.as_str().to_owned(),
+            |relative| relative.to_string(),
+        );
+        let turbo_json = match turbo_json_path.read_existing_to_string()? {
+            Some(contents) => {
+                RawRootTurboJson::parse(&contents, &root_relative_turbo_json_path)?.into()
+            }
+            None => RawTurboJson::default(),
+        };
         Self::turbo_json_to_config_options(turbo_json)
     }
 }
@@ -166,7 +174,7 @@ mod test {
         let login_url = "localhost:3001";
         let team_slug = "acme-packers";
         let team_id = "id-123";
-        let turbo_json = RawTurboJson::parse(
+        let turbo_json = RawRootTurboJson::parse(
             &serde_json::to_string_pretty(&json!({
                 "remoteCache": {
                     "enabled": true,
@@ -183,7 +191,8 @@ mod test {
             .unwrap(),
             "junk",
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let config = TurboJsonReader::turbo_json_to_config_options(turbo_json).unwrap();
         assert!(config.enabled());
         assert_eq!(config.timeout(), timeout);
@@ -200,7 +209,7 @@ mod test {
     #[test_case(Some(false), false)]
     #[test_case(Some(true), true)]
     fn test_dangerously_disable_package_manager_check(value: Option<bool>, expected: bool) {
-        let turbo_json = RawTurboJson::parse(
+        let turbo_json = RawRootTurboJson::parse(
             &serde_json::to_string_pretty(
                 &(if let Some(value) = value {
                     json!({
@@ -213,7 +222,8 @@ mod test {
             .unwrap(),
             "turbo.json",
         )
-        .unwrap();
+        .unwrap()
+        .into();
         let config = TurboJsonReader::turbo_json_to_config_options(turbo_json).unwrap();
         assert_eq!(config.allow_no_package_manager(), expected);
     }

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -13,7 +13,7 @@ use super::Engine;
 use crate::{
     config,
     task_graph::TaskDefinition,
-    turbo_json::{ProcessedTaskDefinition, TurboJson, TurboJsonLoader, validator::Validator},
+    turbo_json::{validator::Validator, ProcessedTaskDefinition, TurboJson, TurboJsonLoader},
 };
 
 #[derive(Debug, thiserror::Error, Diagnostic)]

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -14,7 +14,7 @@ use crate::{
     config,
     task_graph::TaskDefinition,
     turbo_json::{
-        validate_extends, validate_no_package_task_syntax, validate_with_has_no_topo,
+        validator::{validate_extends, validate_no_package_task_syntax, validate_with_has_no_topo},
         ProcessedTaskDefinition, TurboJsonLoader,
     },
 };

--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -709,7 +709,7 @@ mod test {
     use super::*;
     use crate::{
         engine::TaskNode,
-        turbo_json::{RawTurboJson, TurboJson},
+        turbo_json::{RawPackageTurboJson, RawRootTurboJson, RawTurboJson, TurboJson},
     };
 
     // Only used to prevent package graph construction from attempting to read
@@ -813,8 +813,13 @@ mod test {
     }
 
     fn turbo_json(value: serde_json::Value) -> TurboJson {
+        let is_package = value.as_object().unwrap().contains_key("extends");
         let json_text = serde_json::to_string(&value).unwrap();
-        let raw = RawTurboJson::parse(&json_text, "").unwrap();
+        let raw: RawTurboJson = if is_package {
+            RawPackageTurboJson::parse(&json_text, "").unwrap().into()
+        } else {
+            RawRootTurboJson::parse(&json_text, "").unwrap().into()
+        };
         TurboJson::try_from(raw).unwrap()
     }
 

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(once_cell_try)]
 #![feature(try_blocks)]
 #![feature(impl_trait_in_assoc_type)]
+#![feature(let_chains)]
 #![deny(clippy::all)]
 // Clippy's needless mut lint is buggy: https://github.com/rust-lang/rust-clippy/issues/11299
 #![allow(clippy::needless_pass_by_ref_mut)]

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -541,6 +541,7 @@ impl RunBuilder {
         .with_root_tasks(root_turbo_json.tasks.keys().cloned())
         .with_tasks_only(self.opts.run_opts.only)
         .with_workspaces(filtered_pkgs.cloned().collect())
+        .with_future_flags(self.opts.future_flags)
         .with_tasks(tasks);
 
         if self.add_all_tasks {

--- a/crates/turborepo-lib/src/run/task_access.rs
+++ b/crates/turborepo-lib/src/run/task_access.rs
@@ -13,7 +13,7 @@ use turborepo_scm::SCM;
 use turborepo_unescape::UnescapedString;
 
 use super::ConfigCache;
-use crate::{config::RawTurboJson, gitignore::ensure_turbo_is_gitignored};
+use crate::{gitignore::ensure_turbo_is_gitignored, turbo_json::RawTurboJson};
 
 // Environment variable key that will be used to enable, and set the expected
 // trace location

--- a/crates/turborepo-lib/src/turbo_json/future_flags.rs
+++ b/crates/turborepo-lib/src/turbo_json/future_flags.rs
@@ -28,6 +28,7 @@ use struct_iterable::Iterable;
 /// before it becomes the default behavior in a future version.
 #[derive(Serialize, Default, Debug, Copy, Clone, Iterable, Deserializable, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+#[deserializable()]
 pub struct FutureFlags {
     /// Enable `$TURBO_EXTENDS$`
     ///
@@ -35,6 +36,12 @@ pub struct FutureFlags {
     /// This will change the default behavior of overriding the field to instead
     /// append.
     pub turbo_extends_keyword: bool,
+    /// Enable extending from a non-root `turbo.json`
+    ///
+    /// When enabled, allows using extends targeting `turbo.json`s other than
+    /// root. All `turbo.json` must still extend from the root `turbo.json`
+    /// first.
+    pub non_root_extends: bool,
 }
 
 impl FutureFlags {

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -387,9 +387,10 @@ impl TurboJson {
     fn read(
         repo_root: &AbsoluteSystemPath,
         path: &AbsoluteSystemPath,
+        is_root: bool,
         future_flags: FutureFlags,
     ) -> Result<Option<TurboJson>, Error> {
-        let Some(raw_turbo_json) = RawTurboJson::read(repo_root, path)? else {
+        let Some(raw_turbo_json) = RawTurboJson::read(repo_root, path, is_root)? else {
             return Ok(None);
         };
 

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -35,7 +35,6 @@ pub use processed::ProcessedTaskDefinition;
 pub use raw::{
     RawPackageTurboJson, RawRemoteCacheOptions, RawRootTurboJson, RawTaskDefinition, RawTurboJson,
 };
-use validator::TurboJSONValidation;
 
 use crate::boundaries::BoundariesConfig;
 
@@ -418,13 +417,6 @@ impl TurboJson {
                 })
                 .transpose(),
         }
-    }
-
-    pub fn validate(&self, validations: &[TurboJSONValidation]) -> Vec<Error> {
-        validations
-            .iter()
-            .flat_map(|validation| validation(self))
-            .collect()
     }
 
     pub fn has_root_tasks(&self) -> bool {

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -1023,7 +1023,8 @@ mod tests {
         assert_eq!(
             future_flags.as_inner(),
             &FutureFlags {
-                turbo_extends_keyword: true
+                turbo_extends_keyword: true,
+                non_root_extends: false,
             }
         );
 

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -8,7 +8,6 @@ use std::{
 use biome_deserialize_macros::Deserializable;
 use camino::Utf8Path;
 use clap::ValueEnum;
-use miette::{NamedSource, SourceSpan};
 use serde::{Deserialize, Serialize};
 use turbopath::{AbsoluteSystemPath, RelativeUnixPath};
 use turborepo_errors::Spanned;
@@ -28,6 +27,7 @@ mod loader;
 pub mod parser;
 mod processed;
 mod raw;
+pub mod validator;
 
 pub use future_flags::FutureFlags;
 pub use loader::{TurboJsonLoader, TurboJsonReader};
@@ -35,8 +35,9 @@ pub use processed::ProcessedTaskDefinition;
 pub use raw::{
     RawPackageTurboJson, RawRemoteCacheOptions, RawRootTurboJson, RawTaskDefinition, RawTurboJson,
 };
+use validator::TurboJSONValidation;
 
-use crate::{boundaries::BoundariesConfig, config::UnnecessaryPackageTaskSyntaxError};
+use crate::boundaries::BoundariesConfig;
 
 const ENV_PIPELINE_DELIMITER: &str = "$";
 const TOPOLOGICAL_PIPELINE_DELIMITER: &str = "^";
@@ -466,72 +467,6 @@ impl TurboJson {
 
         with_tasks.push(Spanned::new(UnescapedString::from(with.to_string())))
     }
-}
-
-type TurboJSONValidation = fn(&TurboJson) -> Vec<Error>;
-
-pub fn validate_no_package_task_syntax(turbo_json: &TurboJson) -> Vec<Error> {
-    turbo_json
-        .tasks
-        .iter()
-        .filter(|(task_name, _)| task_name.is_package_task())
-        .map(|(task_name, entry)| {
-            let (span, text) = entry.span_and_text("turbo.json");
-            Error::UnnecessaryPackageTaskSyntax(Box::new(UnnecessaryPackageTaskSyntaxError {
-                actual: task_name.to_string(),
-                wanted: task_name.task().to_string(),
-                span,
-                text,
-            }))
-        })
-        .collect()
-}
-
-pub fn validate_extends(turbo_json: &TurboJson) -> Vec<Error> {
-    match turbo_json.extends.first() {
-        Some(package_name) if package_name != ROOT_PKG_NAME || turbo_json.extends.len() > 1 => {
-            let (span, text) = turbo_json.extends.span_and_text("turbo.json");
-            vec![Error::ExtendFromNonRoot { span, text }]
-        }
-        None => {
-            let path = turbo_json
-                .path
-                .as_ref()
-                .map_or("turbo.json", |p| p.as_ref());
-
-            let (span, text) = match turbo_json.text {
-                Some(ref text) => {
-                    let len = text.len();
-                    let span: SourceSpan = (0, len - 1).into();
-                    (Some(span), text.to_string())
-                }
-                None => (None, String::new()),
-            };
-
-            vec![Error::NoExtends {
-                span,
-                text: NamedSource::new(path, text),
-            }]
-        }
-        _ => vec![],
-    }
-}
-
-pub fn validate_with_has_no_topo(turbo_json: &TurboJson) -> Vec<Error> {
-    turbo_json
-        .tasks
-        .iter()
-        .flat_map(|(_, definition)| {
-            definition.with.iter().flatten().filter_map(|with_task| {
-                if with_task.starts_with(TOPOLOGICAL_PIPELINE_DELIMITER) {
-                    let (span, text) = with_task.span_and_text("turbo.json");
-                    Some(Error::InvalidTaskWith { span, text })
-                } else {
-                    None
-                }
-            })
-        })
-        .collect()
 }
 
 fn gather_env_vars(
@@ -1173,31 +1108,5 @@ mod tests {
             assert!(raw_config.global_dependencies.is_none());
             assert!(raw_config.future_flags.is_none());
         }
-    }
-
-    #[test]
-    fn test_validate_with_has_no_topo() {
-        let turbo_json = TurboJson {
-            tasks: Pipeline(
-                vec![(
-                    TaskName::from("dev"),
-                    Spanned::new(RawTaskDefinition {
-                        with: Some(vec![Spanned::new(UnescapedString::from("^proxy"))]),
-                        ..Default::default()
-                    }),
-                )]
-                .into_iter()
-                .collect(),
-            ),
-            ..Default::default()
-        };
-
-        let errs = validate_with_has_no_topo(&turbo_json);
-        assert_eq!(errs.len(), 1);
-        let error = &errs[0];
-        assert_eq!(
-            error.to_string(),
-            "`with` cannot use dependency relationships."
-        );
     }
 }

--- a/crates/turborepo-lib/src/turbo_json/parser.rs
+++ b/crates/turborepo-lib/src/turbo_json/parser.rs
@@ -343,7 +343,6 @@ impl WithMetadata for RawPackageTurboJson {
 }
 
 impl RawRootTurboJson {
-    /// Parse a root turbo.json file
     pub fn parse(text: &str, file_path: &str) -> Result<Self, Error> {
         let turbo_json = parse_turbo_json::<RawRootTurboJson>(text, file_path)?;
 
@@ -369,16 +368,6 @@ impl RawTurboJson {
         let raw_root = RawRootTurboJson::parse(&json_string, "turbo.json")?;
         Ok(Self::from(raw_root))
     }
-}
-
-fn parse_root_turbo_json(text: &str, file_path: &str) -> Result<RawRootTurboJson, Error> {
-    let turbo_json = parse_turbo_json::<RawRootTurboJson>(text, file_path)?;
-
-    if turbo_json.experimental_spaces.is_some() {
-        warn!("`experimentalSpaces` key in turbo.json is deprecated and does not do anything")
-    }
-
-    Ok(turbo_json)
 }
 
 fn parse_turbo_json<T: Deserializable + WithMetadata>(

--- a/crates/turborepo-lib/src/turbo_json/parser.rs
+++ b/crates/turborepo-lib/src/turbo_json/parser.rs
@@ -316,6 +316,7 @@ impl RawTurboJson {
         let json_string = serde_json::to_string(&value).expect("should be able to serialize");
         Self::parse(&json_string, "turbo.json")
     }
+
     /// Parses a turbo.json file into the raw representation with span info
     /// attached.
     ///

--- a/crates/turborepo-lib/src/turbo_json/parser.rs
+++ b/crates/turborepo-lib/src/turbo_json/parser.rs
@@ -18,7 +18,10 @@ use turborepo_unescape::UnescapedString;
 
 use crate::{
     boundaries::{BoundariesConfig, Permissions, Rule},
-    turbo_json::{Pipeline, RawRemoteCacheOptions, RawTaskDefinition, RawTurboJson, Spanned},
+    turbo_json::{
+        Pipeline, RawPackageTurboJson, RawRemoteCacheOptions, RawRootTurboJson, RawTaskDefinition,
+        RawTurboJson, Spanned,
+    },
 };
 
 #[derive(Debug, Error, Diagnostic)]
@@ -87,63 +90,6 @@ impl DeserializationVisitor for PipelineVisitor {
         }
 
         Some(Pipeline(result))
-    }
-}
-
-impl WithMetadata for RawTurboJson {
-    fn add_text(&mut self, text: Arc<str>) {
-        self.span.add_text(text.clone());
-        self.extends.add_text(text.clone());
-        self.tags.add_text(text.clone());
-        if let Some(tags) = &mut self.tags {
-            tags.value.add_text(text.clone());
-        }
-        self.global_dependencies.add_text(text.clone());
-        self.global_env.add_text(text.clone());
-        self.global_pass_through_env.add_text(text.clone());
-        self.boundaries.add_text(text.clone());
-        if let Some(boundaries) = &mut self.boundaries {
-            boundaries.value.add_text(text.clone());
-        }
-
-        self.tasks.add_text(text.clone());
-        self.cache_dir.add_text(text.clone());
-        self.pipeline.add_text(text.clone());
-        self.remote_cache.add_text(text.clone());
-        self.ui.add_text(text.clone());
-        self.allow_no_package_manager.add_text(text.clone());
-        self.daemon.add_text(text.clone());
-        self.env_mode.add_text(text.clone());
-        self.no_update_notifier.add_text(text.clone());
-        self.concurrency.add_text(text.clone());
-        self.future_flags.add_text(text);
-    }
-
-    fn add_path(&mut self, path: Arc<str>) {
-        self.span.add_path(path.clone());
-        self.extends.add_path(path.clone());
-        self.tags.add_path(path.clone());
-        if let Some(tags) = &mut self.tags {
-            tags.value.add_path(path.clone());
-        }
-        self.global_dependencies.add_path(path.clone());
-        self.global_env.add_path(path.clone());
-        self.global_pass_through_env.add_path(path.clone());
-        self.boundaries.add_path(path.clone());
-        if let Some(boundaries) = &mut self.boundaries {
-            boundaries.value.add_path(path.clone());
-        }
-        self.tasks.add_path(path.clone());
-        self.cache_dir.add_path(path.clone());
-        self.pipeline.add_path(path.clone());
-        self.remote_cache.add_path(path.clone());
-        self.ui.add_path(path.clone());
-        self.allow_no_package_manager.add_path(path.clone());
-        self.daemon.add_path(path.clone());
-        self.env_mode.add_path(path.clone());
-        self.no_update_notifier.add_path(path.clone());
-        self.concurrency.add_path(path.clone());
-        self.future_flags.add_path(path);
     }
 }
 
@@ -309,66 +255,189 @@ impl WithMetadata for RawRemoteCacheOptions {
     }
 }
 
-impl RawTurboJson {
-    // A simple helper for tests
-    #[cfg(test)]
-    pub fn parse_from_serde(value: serde_json::Value) -> Result<RawTurboJson, Error> {
-        let json_string = serde_json::to_string(&value).expect("should be able to serialize");
-        Self::parse(&json_string, "turbo.json")
-    }
-
-    /// Parses a turbo.json file into the raw representation with span info
-    /// attached.
-    ///
-    /// # Arguments
-    ///
-    /// * `text`: The text contents of the turbo.json file
-    /// * `file_path`: The path to the turbo.json file. Just used for error
-    ///   display, so doesn't need to actually be a correct path.
-    ///
-    /// returns: Result<RawTurboJson, Error>
-    pub fn parse(text: &str, file_path: &str) -> Result<RawTurboJson, Error> {
-        let result = deserialize_from_json_str::<RawTurboJson>(
-            text,
-            JsonParserOptions::default()
-                .with_allow_comments()
-                .with_allow_trailing_commas(),
-            file_path,
-        );
-
-        if !result.diagnostics().is_empty() {
-            let diagnostics = result
-                .into_diagnostics()
-                .into_iter()
-                .map(|d| {
-                    d.with_file_source_code(text)
-                        .with_file_path(file_path)
-                        .as_ref()
-                        .into()
-                })
-                .collect();
-
-            return Err(Error {
-                diagnostics,
-                backtrace: backtrace::Backtrace::capture(),
-            });
+impl WithMetadata for RawRootTurboJson {
+    fn add_text(&mut self, text: Arc<str>) {
+        self.span.add_text(text.clone());
+        self.tags.add_text(text.clone());
+        if let Some(tags) = &mut self.tags {
+            tags.value.add_text(text.clone());
+        }
+        self.global_dependencies.add_text(text.clone());
+        self.global_env.add_text(text.clone());
+        self.global_pass_through_env.add_text(text.clone());
+        self.boundaries.add_text(text.clone());
+        if let Some(boundaries) = &mut self.boundaries {
+            boundaries.value.add_text(text.clone());
         }
 
-        // It's highly unlikely that biome would fail to produce a deserialized value
-        // *and* not return any errors, but it's still possible. In that case, we
-        // just print that there is an error and return.
-        let mut turbo_json = result.into_deserialized().ok_or_else(|| Error {
-            diagnostics: vec![],
-            backtrace: backtrace::Backtrace::capture(),
-        })?;
+        self.tasks.add_text(text.clone());
+        self.cache_dir.add_text(text.clone());
+        self.pipeline.add_text(text.clone());
+        self.remote_cache.add_text(text.clone());
+        self.ui.add_text(text.clone());
+        self.allow_no_package_manager.add_text(text.clone());
+        self.daemon.add_text(text.clone());
+        self.env_mode.add_text(text.clone());
+        self.no_update_notifier.add_text(text.clone());
+        self.concurrency.add_text(text.clone());
+        self.future_flags.add_text(text);
+    }
+
+    fn add_path(&mut self, path: Arc<str>) {
+        self.span.add_path(path.clone());
+        self.tags.add_path(path.clone());
+        if let Some(tags) = &mut self.tags {
+            tags.value.add_path(path.clone());
+        }
+        self.global_dependencies.add_path(path.clone());
+        self.global_env.add_path(path.clone());
+        self.global_pass_through_env.add_path(path.clone());
+        self.boundaries.add_path(path.clone());
+        if let Some(boundaries) = &mut self.boundaries {
+            boundaries.value.add_path(path.clone());
+        }
+        self.tasks.add_path(path.clone());
+        self.cache_dir.add_path(path.clone());
+        self.pipeline.add_path(path.clone());
+        self.remote_cache.add_path(path.clone());
+        self.ui.add_path(path.clone());
+        self.allow_no_package_manager.add_path(path.clone());
+        self.daemon.add_path(path.clone());
+        self.env_mode.add_path(path.clone());
+        self.no_update_notifier.add_path(path.clone());
+        self.concurrency.add_path(path.clone());
+        self.future_flags.add_path(path);
+    }
+}
+
+impl WithMetadata for RawPackageTurboJson {
+    fn add_text(&mut self, text: Arc<str>) {
+        self.span.add_text(text.clone());
+        self.extends.add_text(text.clone());
+        self.tags.add_text(text.clone());
+        if let Some(tags) = &mut self.tags {
+            tags.value.add_text(text.clone());
+        }
+        self.boundaries.add_text(text.clone());
+        if let Some(boundaries) = &mut self.boundaries {
+            boundaries.value.add_text(text.clone());
+        }
+        self.tasks.add_text(text.clone());
+        self.pipeline.add_text(text);
+    }
+
+    fn add_path(&mut self, path: Arc<str>) {
+        self.span.add_path(path.clone());
+        self.extends.add_path(path.clone());
+        self.tags.add_path(path.clone());
+        if let Some(tags) = &mut self.tags {
+            tags.value.add_path(path.clone());
+        }
+        self.boundaries.add_path(path.clone());
+        if let Some(boundaries) = &mut self.boundaries {
+            boundaries.value.add_path(path.clone());
+        }
+        self.tasks.add_path(path.clone());
+        self.pipeline.add_path(path);
+    }
+}
+
+impl RawRootTurboJson {
+    /// Parse a root turbo.json file
+    pub fn parse(text: &str, file_path: &str) -> Result<Self, Error> {
+        let turbo_json = parse_turbo_json::<RawRootTurboJson>(text, file_path)?;
 
         if turbo_json.experimental_spaces.is_some() {
             warn!("`experimentalSpaces` key in turbo.json is deprecated and does not do anything")
         }
 
-        turbo_json.add_text(Arc::from(text));
-        turbo_json.add_path(Arc::from(file_path));
-
         Ok(turbo_json)
+    }
+}
+
+impl RawPackageTurboJson {
+    pub fn parse(text: &str, file_path: &str) -> Result<Self, Error> {
+        parse_turbo_json::<RawPackageTurboJson>(text, file_path)
+    }
+}
+
+impl RawTurboJson {
+    // A simple helper for tests
+    #[cfg(test)]
+    pub fn parse_from_serde(value: serde_json::Value) -> Result<RawTurboJson, Error> {
+        let json_string = serde_json::to_string(&value).expect("should be able to serialize");
+        let raw_root = RawRootTurboJson::parse(&json_string, "turbo.json")?;
+        Ok(Self::from(raw_root))
+    }
+}
+
+fn parse_root_turbo_json(text: &str, file_path: &str) -> Result<RawRootTurboJson, Error> {
+    let turbo_json = parse_turbo_json::<RawRootTurboJson>(text, file_path)?;
+
+    if turbo_json.experimental_spaces.is_some() {
+        warn!("`experimentalSpaces` key in turbo.json is deprecated and does not do anything")
+    }
+
+    Ok(turbo_json)
+}
+
+fn parse_turbo_json<T: Deserializable + WithMetadata>(
+    text: &str,
+    file_path: &str,
+) -> Result<T, Error> {
+    let result = deserialize_from_json_str::<T>(
+        text,
+        JsonParserOptions::default()
+            .with_allow_comments()
+            .with_allow_trailing_commas(),
+        file_path,
+    );
+
+    if !result.diagnostics().is_empty() {
+        let diagnostics = result
+            .into_diagnostics()
+            .into_iter()
+            .map(|d| {
+                d.with_file_source_code(text)
+                    .with_file_path(file_path)
+                    .as_ref()
+                    .into()
+            })
+            .collect();
+
+        return Err(Error {
+            diagnostics,
+            backtrace: backtrace::Backtrace::capture(),
+        });
+    }
+
+    let mut turbo_json = result.into_deserialized().ok_or_else(|| Error {
+        diagnostics: vec![],
+        backtrace: backtrace::Backtrace::capture(),
+    })?;
+    turbo_json.add_text(Arc::from(text));
+    turbo_json.add_path(Arc::from(file_path));
+
+    Ok(turbo_json)
+}
+
+#[cfg(test)]
+mod tests {
+    use insta::assert_snapshot;
+    use test_case::test_case;
+
+    use super::*;
+
+    #[test_case(r#"{"daemon": true}"#; "daemon in package turbo.json")]
+    fn test_root_only_fields_in_package_turbo_json(json: &str) {
+        let result = RawPackageTurboJson::parse(json, "packages/foo/turbo.json");
+        assert!(result.is_err());
+
+        let report = miette::Report::new(result.unwrap_err());
+        let mut msg = String::new();
+        miette::NarratableReportHandler::new()
+            .render_report(&mut msg, report.as_ref())
+            .unwrap();
+        assert_snapshot!(msg);
     }
 }

--- a/crates/turborepo-lib/src/turbo_json/processed.rs
+++ b/crates/turborepo-lib/src/turbo_json/processed.rs
@@ -407,6 +407,7 @@ mod tests {
             items,
             &FutureFlags {
                 turbo_extends_keyword: true,
+                non_root_extends: false,
             },
         );
 
@@ -428,6 +429,7 @@ mod tests {
             items,
             &FutureFlags {
                 turbo_extends_keyword: false,
+                non_root_extends: false,
             },
         );
 
@@ -447,6 +449,7 @@ mod tests {
             items,
             &FutureFlags {
                 turbo_extends_keyword: true,
+                non_root_extends: false,
             },
         );
 
@@ -592,6 +595,7 @@ mod tests {
             raw_globs,
             &FutureFlags {
                 turbo_extends_keyword: true,
+                non_root_extends: false,
             },
         )
         .unwrap();
@@ -615,6 +619,7 @@ mod tests {
             raw_env,
             &FutureFlags {
                 turbo_extends_keyword: false,
+                non_root_extends: false,
             },
         );
         assert!(result.is_err());
@@ -634,6 +639,7 @@ mod tests {
             Spanned::new(raw_deps),
             &FutureFlags {
                 turbo_extends_keyword: false,
+                non_root_extends: false,
             },
         );
         assert!(result.is_err());

--- a/crates/turborepo-lib/src/turbo_json/raw.rs
+++ b/crates/turborepo-lib/src/turbo_json/raw.rs
@@ -228,14 +228,12 @@ impl RawTurboJson {
     pub(super) fn read(
         repo_root: &AbsoluteSystemPath,
         path: &AbsoluteSystemPath,
+        is_root: bool,
     ) -> Result<Option<RawTurboJson>, Error> {
         let Some(contents) = path.read_existing_to_string()? else {
             return Ok(None);
         };
 
-        // Determine if this is a root turbo.json by checking if its parent is the repo
-        // root
-        let is_root = repo_root.is_parent(path);
         // Anchoring the path can fail if the path resides outside of the repository
         // Just display absolute path in that case.
         let root_relative_path = repo_root.anchor(path).map_or_else(

--- a/crates/turborepo-lib/src/turbo_json/raw.rs
+++ b/crates/turborepo-lib/src/turbo_json/raw.rs
@@ -1,0 +1,305 @@
+use std::collections::HashMap;
+
+use biome_deserialize_macros::Deserializable;
+use serde::Serialize;
+use struct_iterable::Iterable;
+use turbopath::AbsoluteSystemPath;
+use turborepo_errors::Spanned;
+use turborepo_repository::package_graph::ROOT_PKG_NAME;
+use turborepo_task_id::TaskName;
+use turborepo_unescape::UnescapedString;
+
+use super::{FutureFlags, Pipeline, SpacesJson, UIMode};
+use crate::{
+    boundaries::BoundariesConfig,
+    cli::{EnvMode, OutputLogsMode},
+    config::Error,
+    run::task_access::TaskAccessTraceFile,
+};
+
+// Iterable is required to enumerate allowed keys
+#[derive(Clone, Debug, Default, Iterable, Serialize, Deserializable)]
+#[serde(rename_all = "camelCase")]
+pub struct RawRemoteCacheOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_url: Option<Spanned<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub login_url: Option<Spanned<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub team_slug: Option<Spanned<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub team_id: Option<Spanned<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signature: Option<Spanned<bool>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preflight: Option<Spanned<bool>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout: Option<Spanned<u64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<Spanned<bool>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub upload_timeout: Option<Spanned<u64>>,
+}
+
+// Root turbo.json
+#[derive(Default, Debug, Clone, Iterable, Deserializable)]
+pub struct RawRootTurboJson {
+    pub(crate) span: Spanned<()>,
+
+    #[deserializable(rename = "$schema")]
+    pub(crate) schema: Option<UnescapedString>,
+    pub(crate) experimental_spaces: Option<SpacesJson>,
+
+    // Global root filesystem dependencies
+    pub(crate) global_dependencies: Option<Vec<Spanned<UnescapedString>>>,
+    pub(crate) global_env: Option<Vec<Spanned<UnescapedString>>>,
+    pub(crate) global_pass_through_env: Option<Vec<Spanned<UnescapedString>>>,
+    // Tasks is a map of task entries which define the task graph
+    // and cache behavior on a per task or per package-task basis.
+    pub(crate) tasks: Option<Pipeline>,
+    pub(crate) pipeline: Option<Spanned<Pipeline>>,
+    // Configuration options when interfacing with the remote cache
+    pub(crate) remote_cache: Option<RawRemoteCacheOptions>,
+    pub(crate) ui: Option<Spanned<UIMode>>,
+    #[deserializable(rename = "dangerouslyDisablePackageManagerCheck")]
+    pub(crate) allow_no_package_manager: Option<Spanned<bool>>,
+    pub(crate) daemon: Option<Spanned<bool>>,
+    pub(crate) env_mode: Option<Spanned<EnvMode>>,
+    pub(crate) no_update_notifier: Option<Spanned<bool>>,
+    pub(crate) cache_dir: Option<Spanned<UnescapedString>>,
+    pub(crate) concurrency: Option<Spanned<String>>,
+    pub(crate) tags: Option<Spanned<Vec<Spanned<String>>>>,
+    pub(crate) boundaries: Option<Spanned<BoundariesConfig>>,
+
+    pub(crate) future_flags: Option<Spanned<FutureFlags>>,
+    #[deserializable(rename = "//")]
+    pub(crate) _comment: Option<String>,
+}
+
+// Package turbo.json
+#[derive(Default, Debug, Clone, Iterable, Deserializable)]
+pub struct RawPackageTurboJson {
+    pub(crate) span: Spanned<()>,
+    #[deserializable(rename = "$schema")]
+    pub(crate) schema: Option<UnescapedString>,
+    pub(crate) extends: Option<Spanned<Vec<UnescapedString>>>,
+    pub(crate) tasks: Option<Pipeline>,
+    pub(crate) pipeline: Option<Spanned<Pipeline>>,
+    pub(crate) tags: Option<Spanned<Vec<Spanned<String>>>>,
+    pub(crate) boundaries: Option<Spanned<BoundariesConfig>>,
+    #[deserializable(rename = "//")]
+    pub(crate) _comment: Option<String>,
+}
+
+// Unified structure that represents either root or package turbo.json
+#[derive(Serialize, Default, Debug, Clone, Iterable, Deserializable)]
+#[serde(rename_all = "camelCase")]
+pub struct RawTurboJson {
+    #[serde(skip)]
+    pub(crate) span: Spanned<()>,
+    #[serde(rename = "$schema", skip_serializing_if = "Option::is_none")]
+    pub(crate) schema: Option<UnescapedString>,
+    #[serde(skip_serializing)]
+    pub experimental_spaces: Option<SpacesJson>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) extends: Option<Spanned<Vec<UnescapedString>>>,
+    // Global root filesystem dependencies
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) global_dependencies: Option<Vec<Spanned<UnescapedString>>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) global_env: Option<Vec<Spanned<UnescapedString>>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) global_pass_through_env: Option<Vec<Spanned<UnescapedString>>>,
+    // Tasks is a map of task entries which define the task graph
+    // and cache behavior on a per task or per package-task basis.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tasks: Option<Pipeline>,
+    #[serde(skip_serializing)]
+    pub pipeline: Option<Spanned<Pipeline>>,
+    // Configuration options when interfacing with the remote cache
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote_cache: Option<RawRemoteCacheOptions>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "ui")]
+    pub ui: Option<Spanned<UIMode>>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        rename = "dangerouslyDisablePackageManagerCheck"
+    )]
+    pub allow_no_package_manager: Option<Spanned<bool>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub daemon: Option<Spanned<bool>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub env_mode: Option<Spanned<EnvMode>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_dir: Option<Spanned<UnescapedString>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub no_update_notifier: Option<Spanned<bool>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Spanned<Vec<Spanned<String>>>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub boundaries: Option<Spanned<BoundariesConfig>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub concurrency: Option<Spanned<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub future_flags: Option<Spanned<FutureFlags>>,
+    #[deserializable(rename = "//")]
+    #[serde(skip)]
+    pub(crate) _comment: Option<String>,
+}
+
+#[derive(Serialize, Default, Debug, PartialEq, Clone, Iterable, Deserializable)]
+#[serde(rename_all = "camelCase")]
+#[deserializable(unknown_fields = "deny")]
+pub struct RawTaskDefinition {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) cache: Option<Spanned<bool>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) depends_on: Option<Spanned<Vec<Spanned<UnescapedString>>>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) env: Option<Vec<Spanned<UnescapedString>>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) inputs: Option<Vec<Spanned<UnescapedString>>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) pass_through_env: Option<Vec<Spanned<UnescapedString>>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) persistent: Option<Spanned<bool>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) interruptible: Option<Spanned<bool>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) outputs: Option<Vec<Spanned<UnescapedString>>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) output_logs: Option<Spanned<OutputLogsMode>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) interactive: Option<Spanned<bool>>,
+    // TODO: Remove this once we have the ability to load task definitions directly
+    // instead of deriving them from a TurboJson
+    #[serde(skip)]
+    pub(crate) env_mode: Option<Spanned<EnvMode>>,
+    // This can currently only be set internally and isn't a part of turbo.json
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) with: Option<Vec<Spanned<UnescapedString>>>,
+}
+
+impl From<RawRootTurboJson> for RawTurboJson {
+    fn from(root: RawRootTurboJson) -> Self {
+        RawTurboJson {
+            span: root.span,
+            schema: root.schema,
+            experimental_spaces: root.experimental_spaces,
+            global_dependencies: root.global_dependencies,
+            global_env: root.global_env,
+            global_pass_through_env: root.global_pass_through_env,
+            tasks: root.tasks,
+            pipeline: root.pipeline,
+            remote_cache: root.remote_cache,
+            ui: root.ui,
+            allow_no_package_manager: root.allow_no_package_manager,
+            daemon: root.daemon,
+            env_mode: root.env_mode,
+            cache_dir: root.cache_dir,
+            no_update_notifier: root.no_update_notifier,
+            tags: root.tags,
+            boundaries: root.boundaries,
+            concurrency: root.concurrency,
+            future_flags: root.future_flags,
+            _comment: root._comment,
+            extends: None, // Root configs never have extends
+        }
+    }
+}
+
+impl From<RawPackageTurboJson> for RawTurboJson {
+    fn from(pkg: RawPackageTurboJson) -> Self {
+        RawTurboJson {
+            span: pkg.span,
+            schema: pkg.schema,
+            extends: pkg.extends,
+            tasks: pkg.tasks,
+            pipeline: pkg.pipeline,
+            boundaries: pkg.boundaries,
+            tags: pkg.tags,
+            _comment: pkg._comment,
+            ..Default::default()
+        }
+    }
+}
+
+impl RawTurboJson {
+    pub(super) fn read(
+        repo_root: &AbsoluteSystemPath,
+        path: &AbsoluteSystemPath,
+    ) -> Result<Option<RawTurboJson>, Error> {
+        let Some(contents) = path.read_existing_to_string()? else {
+            return Ok(None);
+        };
+
+        // Determine if this is a root turbo.json by checking if its parent is the repo
+        // root
+        let is_root = repo_root.is_parent(path);
+        // Anchoring the path can fail if the path resides outside of the repository
+        // Just display absolute path in that case.
+        let root_relative_path = repo_root.anchor(path).map_or_else(
+            |_| path.as_str().to_owned(),
+            |relative| relative.to_string(),
+        );
+
+        Ok(Some(if is_root {
+            RawTurboJson::from(RawRootTurboJson::parse(&contents, &root_relative_path)?)
+        } else {
+            RawTurboJson::from(RawPackageTurboJson::parse(&contents, &root_relative_path)?)
+        }))
+    }
+
+    /// Produces a new turbo.json without any tasks that reference non-existent
+    /// workspaces
+    pub fn prune_tasks<S: AsRef<str>>(&self, workspaces: &[S]) -> Self {
+        let mut this = self.clone();
+        if let Some(pipeline) = &mut this.tasks {
+            pipeline.0.retain(|task_name, _| {
+                task_name.in_workspace(ROOT_PKG_NAME)
+                    || workspaces
+                        .iter()
+                        .any(|workspace| task_name.in_workspace(workspace.as_ref()))
+            })
+        }
+
+        this
+    }
+
+    pub fn from_task_access_trace(trace: &HashMap<String, TaskAccessTraceFile>) -> Option<Self> {
+        if trace.is_empty() {
+            return None;
+        }
+
+        let mut pipeline = Pipeline::default();
+
+        for (task_name, trace_file) in trace {
+            let spanned_outputs: Vec<Spanned<UnescapedString>> = trace_file
+                .outputs
+                .iter()
+                .map(|output| Spanned::new(output.clone()))
+                .collect();
+            let task_definition = RawTaskDefinition {
+                outputs: Some(spanned_outputs),
+                env: Some(
+                    trace_file
+                        .accessed
+                        .env_var_keys
+                        .iter()
+                        .map(|unescaped_string| Spanned::new(unescaped_string.clone()))
+                        .collect(),
+                ),
+                ..Default::default()
+            };
+
+            let name = TaskName::from(task_name.as_str());
+            let root_task = name.into_root_task();
+            pipeline.insert(root_task, Spanned::new(task_definition.clone()));
+        }
+
+        Some(RawTurboJson {
+            tasks: Some(pipeline),
+            ..RawTurboJson::default()
+        })
+    }
+}

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__parser__tests__root_only_fields_in_package_turbo_json.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__parser__tests__root_only_fields_in_package_turbo_json.snap
@@ -1,0 +1,15 @@
+---
+source: crates/turborepo-lib/src/turbo_json/parser.rs
+expression: msg
+---
+Failed to parse turbo.json.
+    Diagnostic severity: error
+diagnostic code: turbo_json_parse_error
+
+Error: Found an unknown key `daemon`.
+    Diagnostic severity: error
+
+Begin snippet for packages/foo/turbo.json starting at line 1, column 1
+
+snippet line 1: {"daemon": true}
+    label at line 1, columns 2 to 9

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_extends_extends_from_non_root_package.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_extends_extends_from_non_root_package.snap
@@ -1,0 +1,7 @@
+---
+source: crates/turborepo-lib/src/turbo_json/validator.rs
+expression: error_messages
+---
+[
+    "You can only extend from the root of the workspace.",
+]

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_extends_extends_from_non_root_package_then_root.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_extends_extends_from_non_root_package_then_root.snap
@@ -1,0 +1,7 @@
+---
+source: crates/turborepo-lib/src/turbo_json/validator.rs
+expression: error_messages
+---
+[
+    "You can only extend from the root of the workspace.",
+]

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_extends_extends_from_non_root_package_then_root_true.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_extends_extends_from_non_root_package_then_root_true.snap
@@ -1,0 +1,7 @@
+---
+source: crates/turborepo-lib/src/turbo_json/validator.rs
+expression: error_messages
+---
+[
+    "You must extend from the root of the workspace first.",
+]

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_extends_extends_from_non_root_package_true.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_extends_extends_from_non_root_package_true.snap
@@ -1,0 +1,7 @@
+---
+source: crates/turborepo-lib/src/turbo_json/validator.rs
+expression: error_messages
+---
+[
+    "You must extend from the root of the workspace first.",
+]

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_extends_multiple_extends_including_root.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_extends_multiple_extends_including_root.snap
@@ -1,0 +1,7 @@
+---
+source: crates/turborepo-lib/src/turbo_json/validator.rs
+expression: error_messages
+---
+[
+    "You can only extend from the root of the workspace.",
+]

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_extends_multiple_extends_including_root_true.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_extends_multiple_extends_including_root_true.snap
@@ -1,0 +1,5 @@
+---
+source: crates/turborepo-lib/src/turbo_json/validator.rs
+expression: error_messages
+---
+[]

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_extends_multiple_extends_not_including_root.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_extends_multiple_extends_not_including_root.snap
@@ -1,0 +1,7 @@
+---
+source: crates/turborepo-lib/src/turbo_json/validator.rs
+expression: error_messages
+---
+[
+    "You can only extend from the root of the workspace.",
+]

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_extends_multiple_extends_not_including_root_true.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_extends_multiple_extends_not_including_root_true.snap
@@ -1,0 +1,7 @@
+---
+source: crates/turborepo-lib/src/turbo_json/validator.rs
+expression: error_messages
+---
+[
+    "You must extend from the root of the workspace first.",
+]

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_extends_no_extends.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_extends_no_extends.snap
@@ -1,0 +1,7 @@
+---
+source: crates/turborepo-lib/src/turbo_json/validator.rs
+expression: error_messages
+---
+[
+    "No \"extends\" key found.",
+]

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_extends_no_extends_true.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_extends_no_extends_true.snap
@@ -1,0 +1,7 @@
+---
+source: crates/turborepo-lib/src/turbo_json/validator.rs
+expression: error_messages
+---
+[
+    "No \"extends\" key found.",
+]

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_extends_valid_extends_from_root.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_extends_valid_extends_from_root.snap
@@ -1,0 +1,5 @@
+---
+source: crates/turborepo-lib/src/turbo_json/validator.rs
+expression: error_messages
+---
+[]

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_extends_valid_extends_from_root_true.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_extends_valid_extends_from_root_true.snap
@@ -1,0 +1,5 @@
+---
+source: crates/turborepo-lib/src/turbo_json/validator.rs
+expression: error_messages
+---
+[]

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_no_package_task_syntax_multiple_mixed_tasks.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_no_package_task_syntax_multiple_mixed_tasks.snap
@@ -1,0 +1,8 @@
+---
+source: crates/turborepo-lib/src/turbo_json/validator.rs
+expression: error_messages
+---
+[
+    "\"pkg-a#test\". Use \"test\" instead.",
+    "\"pkg-b#lint\". Use \"lint\" instead.",
+]

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_no_package_task_syntax_non_package_task.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_no_package_task_syntax_non_package_task.snap
@@ -1,0 +1,5 @@
+---
+source: crates/turborepo-lib/src/turbo_json/validator.rs
+expression: error_messages
+---
+[]

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_no_package_task_syntax_single_package_task.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_no_package_task_syntax_single_package_task.snap
@@ -1,0 +1,7 @@
+---
+source: crates/turborepo-lib/src/turbo_json/validator.rs
+expression: error_messages
+---
+[
+    "\"my-package#build\". Use \"build\" instead.",
+]

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_with_has_no_topo.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__validator__test__validate_with_has_no_topo.snap
@@ -1,0 +1,7 @@
+---
+source: crates/turborepo-lib/src/turbo_json/validator.rs
+expression: error_messages
+---
+[
+    "`with` cannot use dependency relationships.",
+]

--- a/crates/turborepo-lib/src/turbo_json/validator.rs
+++ b/crates/turborepo-lib/src/turbo_json/validator.rs
@@ -1,7 +1,7 @@
 use miette::{NamedSource, SourceSpan};
 use turborepo_repository::package_graph::{PackageName, ROOT_PKG_NAME};
 
-use super::{Error, TOPOLOGICAL_PIPELINE_DELIMITER, TurboJson};
+use super::{Error, TurboJson, TOPOLOGICAL_PIPELINE_DELIMITER};
 use crate::config::UnnecessaryPackageTaskSyntaxError;
 
 pub type TurboJSONValidation = fn(&Validator, &TurboJson) -> Vec<Error>;

--- a/crates/turborepo-lib/src/turbo_json/validator.rs
+++ b/crates/turborepo-lib/src/turbo_json/validator.rs
@@ -1,0 +1,107 @@
+use miette::{NamedSource, SourceSpan};
+use turborepo_repository::package_graph::ROOT_PKG_NAME;
+
+use super::{Error, TurboJson, TOPOLOGICAL_PIPELINE_DELIMITER};
+use crate::config::UnnecessaryPackageTaskSyntaxError;
+
+pub type TurboJSONValidation = fn(&TurboJson) -> Vec<Error>;
+
+pub fn validate_no_package_task_syntax(turbo_json: &TurboJson) -> Vec<Error> {
+    turbo_json
+        .tasks
+        .iter()
+        .filter(|(task_name, _)| task_name.is_package_task())
+        .map(|(task_name, entry)| {
+            let (span, text) = entry.span_and_text("turbo.json");
+            Error::UnnecessaryPackageTaskSyntax(Box::new(UnnecessaryPackageTaskSyntaxError {
+                actual: task_name.to_string(),
+                wanted: task_name.task().to_string(),
+                span,
+                text,
+            }))
+        })
+        .collect()
+}
+
+pub fn validate_extends(turbo_json: &TurboJson) -> Vec<Error> {
+    match turbo_json.extends.first() {
+        Some(package_name) if package_name != ROOT_PKG_NAME || turbo_json.extends.len() > 1 => {
+            let (span, text) = turbo_json.extends.span_and_text("turbo.json");
+            vec![Error::ExtendFromNonRoot { span, text }]
+        }
+        None => {
+            let path = turbo_json
+                .path
+                .as_ref()
+                .map_or("turbo.json", |p| p.as_ref());
+
+            let (span, text) = match turbo_json.text {
+                Some(ref text) => {
+                    let len = text.len();
+                    let span: SourceSpan = (0, len - 1).into();
+                    (Some(span), text.to_string())
+                }
+                None => (None, String::new()),
+            };
+
+            vec![Error::NoExtends {
+                span,
+                text: NamedSource::new(path, text),
+            }]
+        }
+        _ => vec![],
+    }
+}
+
+pub fn validate_with_has_no_topo(turbo_json: &TurboJson) -> Vec<Error> {
+    turbo_json
+        .tasks
+        .iter()
+        .flat_map(|(_, definition)| {
+            definition.with.iter().flatten().filter_map(|with_task| {
+                if with_task.starts_with(TOPOLOGICAL_PIPELINE_DELIMITER) {
+                    let (span, text) = with_task.span_and_text("turbo.json");
+                    Some(Error::InvalidTaskWith { span, text })
+                } else {
+                    None
+                }
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod test {
+    use turborepo_errors::Spanned;
+    use turborepo_task_id::TaskName;
+    use turborepo_unescape::UnescapedString;
+
+    use super::*;
+    use crate::turbo_json::{Pipeline, RawTaskDefinition};
+
+    #[test]
+    fn test_validate_with_has_no_topo() {
+        let turbo_json = TurboJson {
+            tasks: Pipeline(
+                vec![(
+                    TaskName::from("dev"),
+                    Spanned::new(RawTaskDefinition {
+                        with: Some(vec![Spanned::new(UnescapedString::from("^proxy"))]),
+                        ..Default::default()
+                    }),
+                )]
+                .into_iter()
+                .collect(),
+            ),
+            ..Default::default()
+        };
+
+        let errs = validate_with_has_no_topo(&turbo_json);
+        assert_eq!(errs.len(), 1);
+        let error = &errs[0];
+        assert_eq!(
+            error.to_string(),
+            "`with` cannot use dependency relationships."
+        );
+    }
+}

--- a/crates/turborepo-lib/src/turbo_json/validator.rs
+++ b/crates/turborepo-lib/src/turbo_json/validator.rs
@@ -72,6 +72,7 @@ pub fn validate_with_has_no_topo(turbo_json: &TurboJson) -> Vec<Error> {
 
 #[cfg(test)]
 mod test {
+    use test_case::test_case;
     use turborepo_errors::Spanned;
     use turborepo_task_id::TaskName;
     use turborepo_unescape::UnescapedString;
@@ -97,11 +98,73 @@ mod test {
         };
 
         let errs = validate_with_has_no_topo(&turbo_json);
-        assert_eq!(errs.len(), 1);
-        let error = &errs[0];
-        assert_eq!(
-            error.to_string(),
-            "`with` cannot use dependency relationships."
-        );
+        let error_messages: Vec<String> = errs.iter().map(|e| e.to_string()).collect();
+        insta::assert_debug_snapshot!("validate_with_has_no_topo", error_messages);
+    }
+
+    #[test_case(
+        vec!["my-package#build"],
+        "single_package_task"
+    )]
+    #[test_case(
+        vec!["build"],
+        "non_package_task"
+    )]
+    #[test_case(
+        vec!["pkg-a#test", "pkg-b#lint", "build"],
+        "multiple_mixed_tasks"
+    )]
+    fn test_validate_no_package_task_syntax(tasks: Vec<&str>, name: &str) {
+        let turbo_json = TurboJson {
+            tasks: Pipeline(
+                tasks
+                    .into_iter()
+                    .map(|task_name| {
+                        (
+                            TaskName::from(task_name.to_string()),
+                            Spanned::new(RawTaskDefinition::default()),
+                        )
+                    })
+                    .collect(),
+            ),
+            ..Default::default()
+        };
+
+        let errs = validate_no_package_task_syntax(&turbo_json);
+        let error_messages: Vec<String> = errs.iter().map(|e| e.to_string()).collect();
+        let snapshot_name = format!("validate_no_package_task_syntax_{}", name);
+        insta::assert_debug_snapshot!(snapshot_name, error_messages);
+    }
+
+    #[test_case(
+        vec![],
+        "no_extends"
+    )]
+    #[test_case(
+        vec!["//"],
+        "valid_extends_from_root"
+    )]
+    #[test_case(
+        vec!["some-package"],
+        "extends_from_non_root_package"
+    )]
+    #[test_case(
+        vec!["//", "other-package"],
+        "multiple_extends_including_root"
+    )]
+    #[test_case(
+        vec!["package-a", "package-b"],
+        "multiple_extends_not_including_root"
+    )]
+    fn test_validate_extends(extends: Vec<&str>, name: &str) {
+        let turbo_json = TurboJson {
+            extends: Spanned::new(extends.into_iter().map(String::from).collect()),
+            ..Default::default()
+        };
+
+        let errs = validate_extends(&turbo_json);
+        let error_messages: Vec<String> = errs.iter().map(|e| e.to_string()).collect();
+        let snapshot_name = format!("validate_extends_{}", name);
+        insta::assert_debug_snapshot!(snapshot_name, error_messages);
     }
 }

--- a/turborepo-tests/integration/fixtures/turbo-configs/package-task.json
+++ b/turborepo-tests/integration/fixtures/turbo-configs/package-task.json
@@ -1,7 +1,5 @@
 {
   "$schema": "https://turborepo.com/schema.json",
-  "globalDependencies": ["foo.txt"],
-  "globalEnv": ["SOME_ENV_VAR"],
   "extends": ["//"],
   "tasks": {
     // this comment verifies that turbo can read .json files with comments

--- a/turborepo-tests/integration/tests/bad-turbo-json.t
+++ b/turborepo-tests/integration/tests/bad-turbo-json.t
@@ -13,15 +13,15 @@ Run build with package task in non-root turbo.json
         unnecessary-package-task-syntax)
         
           x "my-app#build". Use "build" instead.
-            ,-\(apps(\/|\\)my-app(\/|\\)turbo.json:8:21\) (re)
-          7 |         // this comment verifies that turbo can read .json files
+            ,-\(apps(\/|\\)my-app(\/|\\)turbo.json:6:21\) (re)
+          5 |         // this comment verifies that turbo can read .json files
         with comments
-          8 | ,->     "my-app#build": {
-          9 | |         "outputs": ("banana.txt", "apple.json"),
-         10 | |         "inputs": ("$TURBO_DEFAULT$", ".env.local")
-         11 | |->     }
+          6 | ,->     "my-app#build": {
+          7 | |         "outputs": ("banana.txt", "apple.json"),
+          8 | |         "inputs": ("$TURBO_DEFAULT$", ".env.local")
+          9 | |->     }
             : `---- unnecessary package syntax found here
-         12 |       }
+         10 |       }
             `----
   
 


### PR DESCRIPTION
### Description

TL;DR Allow for `"extends": ["//", "@acem/my-pkg"]` to allow for shared task configuration outside of the root.

This PR adds non-root extensions of `turbo.json` files. We still require all `turbo.json` files to extend from root first, but now you can extend from an additional package `turbo.json` files. The task definitions are collapsed left to right with the right fields taking precedence. (This can be more powerful when using `$TURBO_EXTENDS$` added in https://github.com/vercel/turborepo/pull/10763)

We do have to check for cycles in `turbo.json` extends statements to ensure we can resolve the `extends` chain.

Prefactor steps taken:
 - Splitting of the `RawTurboJson` schema into a root schema and a package schema. This removes the need for our ad-hoc checks of all fields in a package `turbo.json` that are invalid. (We were missing quite a few, for example you could put `globalEnv` in a package `turbo.json` and it would be silently ignored)
 - Changed ordering of task definition chain construction to first load all necessary `turbo.json` before fetching task definitions
 - Created a `Validator` struct which is used to share context which affect validation outcomes. This is necessary to feature flag this behavior

I highly suggest reviewing each commit by itself as there is a lot of prefactor work that muddies the feature addition.

### Testing Instructions


