### PR TITLE
docs: Fix Typos

### DIFF
--- a/packages/turbo-vsc/README.md
+++ b/packages/turbo-vsc/README.md
@@ -16,7 +16,7 @@ Every task in your pipeline can be followed to find its references.
 
 Get instant feedback if you write incorrect globs, refer to non-existent packages or tasks, and more.
 
-![A screnshot of a VSCode editor notifying of an invalid glob syntax.](resources/globs.png)
+![A screenshot of a VSCode editor notifying of an invalid glob syntax.](resources/globs.png)
 
 #### Contextual codemods
 

--- a/turborepo-tests/integration/tests/workspace-configs/missing-workspace-config-deps.t
+++ b/turborepo-tests/integration/tests/workspace-configs/missing-workspace-config-deps.t
@@ -5,7 +5,7 @@ Setup
 # The workspace does not have a turbo.json config. This test checks that both regular dependencies
 # and Topological dependencies are retained from the root config.
 
-# 1. First run, assert that dependet tasks run `dependsOn`
+# 1. First run, assert that dependent tasks run `dependsOn`
   $ ${TURBO} run missing-workspace-config-task-with-deps --filter=missing-workspace-config > tmp.log
 # Validate in pieces. `omit-key` task has two dependsOn values, and those tasks
 # can run in non-deterministic order. So we need to validate the logs in the pieces.


### PR DESCRIPTION
### Description

Fix Typos: 
 - From `screnshot` to `screenshot`
 - From `dependet` to `dependent`
