### PR TITLE
docs: add `name` field mention to migration page

### DIFF
--- a/docs/site/content/docs/crafting-your-repository/creating-an-internal-package.mdx
+++ b/docs/site/content/docs/crafting-your-repository/creating-an-internal-package.mdx
@@ -45,7 +45,7 @@ You'll need a directory to put the package in. Let's create one at `./packages/m
 Next, create the `package.json` for the package. By adding this file, you'll fulfill [the two requirements for an Internal Package](/docs/crafting-your-repository/structuring-a-repository#specifying-packages-in-a-monorepo), making it discoverable to Turborepo and the rest of your Workspace.
 
 <Callout type="warn">
-  **Critical**: The `name` field in your `package.json` determines how your package can be imported throughout your workspace. The name you choose here (e.g., `@repo/math`) is exactly how other packages will import it (e.g., `import { add } from '@repo/math/add'`). Simply adding a `package.json` file is not enough - the `name` field must be correctly set for your package to be discoverable.
+The `name` field in your `package.json` determines how your package can be imported throughout your workspace. The name you choose here (e.g. `@repo/math`) is exactly how other packages will import it (e.g. `import { add } from '@repo/math/add'`).
 </Callout>
 
 <PackageManagerTabs>

--- a/docs/site/content/docs/crafting-your-repository/creating-an-internal-package.mdx
+++ b/docs/site/content/docs/crafting-your-repository/creating-an-internal-package.mdx
@@ -42,7 +42,11 @@ You'll need a directory to put the package in. Let's create one at `./packages/m
 <Step>
 ### Add a package.json
 
-Next, create the `package.json` for the package. By adding this file, you'll fulfill [the two requirements for an Internal Package](/docs/crafting-your-repository/structuring-a-repository#specifying-packages-in-a-monorepo), making it discoverable to Turborepo and the rest of your Workspace:
+Next, create the `package.json` for the package. By adding this file, you'll fulfill [the two requirements for an Internal Package](/docs/crafting-your-repository/structuring-a-repository#specifying-packages-in-a-monorepo), making it discoverable to Turborepo and the rest of your Workspace.
+
+<Callout type="warn">
+  **Critical**: The `name` field in your `package.json` determines how your package can be imported throughout your workspace. The name you choose here (e.g., `@repo/math`) is exactly how other packages will import it (e.g., `import { add } from '@repo/math/add'`). Simply adding a `package.json` file is not enough - the `name` field must be correctly set for your package to be discoverable.
+</Callout>
 
 <PackageManagerTabs>
 
@@ -159,9 +163,10 @@ Next, create the `package.json` for the package. By adding this file, you'll ful
 
 Let's break down this `package.json` piece-by-piece:
 
+- **`name`**: This is the most critical field for package discoverability. The value `@repo/math` becomes the exact identifier used in import statements throughout your workspace. If you change this name, you must update all import statements accordingly.
 - **`scripts`**: The `dev` and `build` script compile the package using [the TypeScript compiler](https://www.typescriptlang.org/docs/handbook/compiler-options.html). The `dev` script will watch for changes to source code and automatically recompile the package.
 - **`devDependencies`**: `typescript` and `@repo/typescript-config` are `devDependencies` so you can use those packages in the `@repo/math` package. In a real-world package, you will likely have more `devDependencies` and `dependencies` - but we can keep it simple for now.
-- **`exports`**: Defines multiple entrypoints for the package so it can be used in other packages (`import { add } from '@repo/math'`).
+- **`exports`**: Defines multiple entrypoints for the package so it can be used in other packages (`import { add } from '@repo/math/add'`).
 
 Notably, this `package.json` declares an Internal Package, `@repo/typescript-config`, as a dependency. Turborepo will recognize `@repo/math` as a dependent of `@repo/typescript-config` for ordering your tasks.
 
@@ -331,6 +336,17 @@ The `@repo/math` package built before the `web` application built so that the ru
 
 </Step>
 </Steps>
+
+## Troubleshooting
+
+### Package not found or import errors
+
+If you're encountering import errors or your package isn't being discovered, check these common issues:
+
+- **Verify the `name` field**: Ensure the `name` in your `package.json` matches exactly how you're trying to import it. For example, if your package.json has `"name": "@repo/math"`, you must import it as `import { add } from '@repo/math/add'`.
+- **Check workspace configuration**: Make sure your package is located in a directory that's included in your workspace configuration (e.g., `pnpm-workspace.yaml`, `lerna.json`, or Yarn workspaces).
+- **Run package manager install**: After creating a new package or changing dependencies, run your package manager's install command (`pnpm install`, `npm install`, etc.) to update the workspace's lockfile.
+- **Verify the package location**: Ensure your package directory is in the correct location according to your workspace configuration (typically `packages/*` or `apps/*`).
 
 ## Best practices for Internal Packages
 

--- a/docs/site/content/docs/crafting-your-repository/creating-an-internal-package.mdx
+++ b/docs/site/content/docs/crafting-your-repository/creating-an-internal-package.mdx
@@ -337,17 +337,6 @@ The `@repo/math` package built before the `web` application built so that the ru
 </Step>
 </Steps>
 
-## Troubleshooting
-
-### Package not found or import errors
-
-If you're encountering import errors or your package isn't being discovered, check these common issues:
-
-- **Verify the `name` field**: Ensure the `name` in your `package.json` matches exactly how you're trying to import it. For example, if your package.json has `"name": "@repo/math"`, you must import it as `import { add } from '@repo/math/add'`.
-- **Check workspace configuration**: Make sure your package is located in a directory that's included in your workspace configuration (e.g., `pnpm-workspace.yaml`, `lerna.json`, or Yarn workspaces).
-- **Run package manager install**: After creating a new package or changing dependencies, run your package manager's install command (`pnpm install`, `npm install`, etc.) to update the workspace's lockfile.
-- **Verify the package location**: Ensure your package directory is in the correct location according to your workspace configuration (typically `packages/*` or `apps/*`).
-
 ## Best practices for Internal Packages
 
 ### One "purpose" per package


### PR DESCRIPTION
### Description

A user mentioned that this page didn't make mention of how you need a `main` field in package.json

### Testing Instructions

👀