### PR TITLE
feat(tui): add shortcut for clearing task logs

### DIFF
--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -605,6 +605,12 @@ impl<W> App<W> {
         task.parser.screen_mut().set_scrollback(0);
         Ok(())
     }
+
+    pub fn clear_task_logs(&mut self) -> Result<(), Error> {
+        let task = self.get_full_task_mut()?;
+        task.clear_logs();
+        Ok(())
+    }
 }
 
 impl<W: Write> App<W> {
@@ -898,6 +904,9 @@ fn update(
             app.is_task_selection_pinned = true;
             app.scroll_momentum.reset();
             app.jump_to_logs_bottom()?;
+        }
+        Event::ClearLogs => {
+            app.clear_task_logs()?;
         }
         Event::EnterInteractive => {
             app.is_task_selection_pinned = true;

--- a/crates/turborepo-ui/src/tui/event.rs
+++ b/crates/turborepo-ui/src/tui/event.rs
@@ -34,6 +34,7 @@ pub enum Event {
     PageDown,
     JumpToLogsTop,
     JumpToLogsBottom,
+    ClearLogs,
     SetStdin {
         task: String,
         stdin: Box<dyn std::io::Write + Send>,

--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -120,6 +120,7 @@ fn translate_key_event(options: InputOptions, key_event: KeyEvent) -> Option<Eve
         KeyCode::PageDown | KeyCode::Char('D') => Some(Event::PageDown),
         KeyCode::Char('t') => Some(Event::JumpToLogsTop),
         KeyCode::Char('b') => Some(Event::JumpToLogsBottom),
+        KeyCode::Char('C') => Some(Event::ClearLogs),
         KeyCode::Char('m') => Some(Event::ToggleHelpPopup),
         KeyCode::Char('p') => Some(Event::TogglePinnedTask),
         KeyCode::Up | KeyCode::Char('k') => Some(Event::Up),

--- a/crates/turborepo-ui/src/tui/popup.rs
+++ b/crates/turborepo-ui/src/tui/popup.rs
@@ -21,6 +21,7 @@ const BIND_LIST: &[&str] = [
     "d       - Scroll logs down",
     "Shift+u - Page logs up",
     "Shift+d - Page logs down",
+    "Shift+c - Clear logs",
     "t       - Jump to top of logs",
     "b       - Jump to bottom of logs",
 ]

--- a/crates/turborepo-ui/src/tui/term_output.rs
+++ b/crates/turborepo-ui/src/tui/term_output.rs
@@ -170,4 +170,11 @@ impl<W> TerminalOutput<W> {
     pub fn copy_selection(&self) -> Option<String> {
         self.parser.screen().selected_text()
     }
+
+    pub fn clear_logs(&mut self) {
+        self.output.clear();
+
+        // clear screen and reset cursor
+        self.process(b"\x1bc");
+    }
 }


### PR DESCRIPTION
### Description
I use turborepo for long running `dev` tasks and sometimes I want to clear the output of just one pane, for example server logs before triggering a request. 

If I clear my terminal buffer it clears everything including the TUI, and the content is still there to be scrolled to. What I really want is to only clear the logs for a single task.

This PR introduces the "Clear logs" option, currently bound to `shift-c` (I tried to pick a shortcut inkeeping with the others). It clears the logs only for the current task

Example screencasts below

### Testing Instructions
- Run some tasks with the `--ui=tui`
- Press `shift-c` on a pane with output
- See that only that panes output is cleared, and new logs appear as normal

I attempted to write tests for this but I wasn't keen on all the hoops I had to jump through to try and test that it actually clears the buffer

**Examples**

Attempting and failing to clear with cmd+k:

https://github.com/user-attachments/assets/d72a304d-c4b8-467b-9c17-16422552610e

New behaviour with shift-c:

https://github.com/user-attachments/assets/00440758-aa16-402f-9119-086639f4fb62
