### PR TITLE
fix: Use newline for separator in misuse text

### DIFF
--- a/turborepo-tests/integration/tests/other/bad-flag.t
+++ b/turborepo-tests/integration/tests/other/bad-flag.t
@@ -38,6 +38,20 @@ Bad flag with an implied run command should display run flags
       --log-prefix <LOG_PREFIX>
       TASKS
       PASS_THROUGH_ARGS
+      --cache <CACHE>
+      --force \[<FORCE>\] (re)
+      --remote-only \[<REMOTE_ONLY>\] (re)
+      --remote-cache-read-only \[<REMOTE_CACHE_READ_ONLY>\] (re)
+      --no-cache <NO_CACHE>
+      --cache-workers <CACHE_WORKERS>
+      --dry-run \[<DRY_RUN>\] (re)
+      --graph \[<GRAPH>\] (re)
+      --daemon <DAEMON>
+      --no-daemon <NO_DAEMON>
+      --profile <PROFILE>
+      --anon-profile <ANON_PROFILE>
+      --summarize \[<SUMMARIZE>\] (re)
+      --parallel <PARALLEL>
   
   For more information, try '--help'.
   


### PR DESCRIPTION
### Description

#### Before
```
▲ 👟 turbo on shew/5a27b
  turbo build --bad-flag
 ERROR  unexpected argument '--bad-flag' found

  tip: to pass '--bad-flag' as a value, use '-- --bad-flag'

Usage: turbo --skip-infer <--cache-dir <CACHE_DIR>|--concurrency <CONCURRENCY>|--continue[=<CONTINUE>]|--single-package|--framework-inference [<BOOL>]|--global-deps <GLOBAL_DEPS>|--env-mode [<ENV_MODE>]|--filter <FILTER>|--affected|--output-logs <OUTPUT_LOGS>|--log-order <LOG_ORDER>|--only|--pkg-inference-root <PKG_INFERENCE_ROOT>|--log-prefix <LOG_PREFIX>|TASKS|PASS_THROUGH_ARGS>

For more information, try '--help'.
```

#### After
```
▲ 👟 turbo on shew/5a27b
  dt build --bad-flag
 ERROR  unexpected argument '--bad-flag' found

  tip: to pass '--bad-flag' as a value, use '-- --bad-flag'

Usage: turbo [OPTIONS] [TASKS]... [-- <PASS_THROUGH_ARGS>...]

Options:
    --cache-dir <CACHE_DIR>
    --concurrency <CONCURRENCY>
    --continue[=<CONTINUE>]
    --single-package
    --framework-inference [<BOOL>]
    --global-deps <GLOBAL_DEPS>
    --env-mode [<ENV_MODE>]
    --filter <FILTER>
    --affected
    --output-logs <OUTPUT_LOGS>
    --log-order <LOG_ORDER>
    --only
    --pkg-inference-root <PKG_INFERENCE_ROOT>
    --log-prefix <LOG_PREFIX>
    TASKS
    PASS_THROUGH_ARGS

For more information, try '--help'.
```

### Testing Instructions

Updated tests.
