### PR TITLE
docs: update configuration reference to use correct turbo.json title

### DIFF
--- a/docs/site/content/docs/reference/configuration.mdx
+++ b/docs/site/content/docs/reference/configuration.mdx
@@ -85,7 +85,7 @@ Select a terminal UI for the repository.
 
 `"tui"` allows for viewing each log at once and interacting with the task. `"stream"` outputs logs as they come in and is not interactive.
 
-```jsonc title="./turbo.json"
+```json title="./turbo.json"
 {
   "ui": "tui" | "stream"
 }


### PR DESCRIPTION
Updates the json_title in configuration.mdx from "terminal" to "./turbo.json" to correctly reference the turbo.json configuration file in the documentation examples.