### PR TITLE
fix(watch): only stop relevant tasks while watching for changes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6912,6 +6912,7 @@ dependencies = [
  "tracing",
  "tracing-test",
  "turbopath",
+ "turborepo-repository",
  "windows-sys 0.59.0",
 ]
 

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -531,4 +531,8 @@ impl RunStopper {
     pub async fn stop(&self) {
         self.manager.stop().await;
     }
+
+    pub async fn stop_tasks(&self, tasks: &HashSet<(PackageName, String)>) {
+        self.manager.stop_tasks(tasks).await;
+    }
 }

--- a/crates/turborepo-process/Cargo.toml
+++ b/crates/turborepo-process/Cargo.toml
@@ -19,6 +19,7 @@ portable-pty = "0.8.1"
 tokio = { workspace = true, features = ["full", "time"] }
 tracing.workspace = true
 turbopath = { workspace = true }
+turborepo-repository = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -381,6 +381,7 @@ pub struct Child {
     stdin: Arc<Mutex<Option<ChildInput>>>,
     output: Arc<Mutex<Option<ChildOutput>>>,
     label: String,
+    command: Command,
 }
 
 #[derive(Clone, Debug)]
@@ -416,6 +417,7 @@ impl Child {
         pty_size: Option<PtySize>,
     ) -> io::Result<Self> {
         let label = command.label();
+        let command_clone = command.clone();
         let SpawnResult {
             handle: mut child,
             io: ChildIO { stdin, output },
@@ -468,6 +470,7 @@ impl Child {
             stdin: Arc::new(Mutex::new(stdin)),
             output: Arc::new(Mutex::new(output)),
             label,
+            command: command_clone,
         })
     }
 
@@ -687,6 +690,10 @@ impl Child {
 
     pub fn label(&self) -> &str {
         &self.label
+    }
+
+    pub fn command(&self) -> &Command {
+        &self.command
     }
 }
 

--- a/crates/turborepo-process/src/command.rs
+++ b/crates/turborepo-process/src/command.rs
@@ -106,6 +106,20 @@ impl Command {
     pub fn program(&self) -> &OsStr {
         &self.program
     }
+
+    pub fn task_name(&self) -> Option<(String, String)> {
+        let package = self
+            .env
+            .get(&OsString::from("TURBO_PACKAGE_NAME"))?
+            .to_str()?
+            .to_string();
+        let task = self
+            .env
+            .get(&OsString::from("TURBO_TASK_NAME"))?
+            .to_str()?
+            .to_string();
+        Some((package, task))
+    }
 }
 
 impl From<Command> for tokio::process::Command {


### PR DESCRIPTION
### Description

Fixed a bug in watch mode that caused unrelated interruptible tasks to be killed when a dependency changed. 
The fix makes watch mode more granular by identifying the specific tasks affected by a file change and only restarting them. 

This fixes the issue in #9421 