### PR TITLE
fix: sanitize logging prefix for GitLab groups

### DIFF
--- a/crates/turborepo-ci/src/lib.rs
+++ b/crates/turborepo-ci/src/lib.rs
@@ -235,8 +235,8 @@ mod tests {
         let end_output = end_fn(end_time);
 
         // The section identifier should be sanitized (@ -> at, / -> -)
-        assert!(start_output.contains("section_start:1234567890:atorganisation-package:build"));
-        assert!(end_output.contains("section_end:1234567900:atorganisation-package:build"));
+        assert!(start_output.contains("section_start:1234567890:at-organisation-package:build"));
+        assert!(end_output.contains("section_end:1234567900:at-organisation-package:build"));
 
         // The description should contain the original group name
         assert!(start_output.contains("@organisation/package:build"));

--- a/crates/turborepo-ci/src/vendors.rs
+++ b/crates/turborepo-ci/src/vendors.rs
@@ -302,7 +302,7 @@ pub(crate) fn get_vendors() -> &'static [Vendor] {
                                 // GitLab CI section names only allow /a-zA-Z0-9._-/ characters
                                 // Replace @ with 'at' and / with '-' for section identifier
                                 let sanitized_group_name =
-                                    group_name.replace('@', "at").replace('/', "-");
+                                    group_name.replace('@', "at-").replace('/', "-");
                                 format!(
                                     "\\e[0Ksection_start:{timestamp}:{sanitized_group_name}\\r\\
                                      e[0K{group_name}"
@@ -314,7 +314,7 @@ pub(crate) fn get_vendors() -> &'static [Vendor] {
                                 let timestamp = end_time.timestamp();
                                 // Use the same sanitization for section end
                                 let sanitized_group_name =
-                                    group_name.replace('@', "at").replace('/', "-");
+                                    group_name.replace('@', "at-").replace('/', "-");
                                 format!(
                                     "\\e[0Ksection_end:{timestamp}:{sanitized_group_name}\\r\\e[0K"
                                 )


### PR DESCRIPTION
### Description

Closes #10663.

### Testing Instructions

Added a test to verify correctness.

Closes TURBO-4782