### PR TITLE
feat(env): add proto version manager home to passthrough

### DIFF
--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -485,6 +485,7 @@ impl<'a> TaskHasher<'a> {
                     "HOMEPATH",
                     "PNPM_HOME",
                     "NPM_CONFIG_STORE_DIR",
+                    "PROTO_HOME",
                 ];
                 let pass_through_env_vars = self.env_at_execution_start.pass_through_env(
                     builtin_pass_through,


### PR DESCRIPTION
### Description

Added `PROTO_HOME` to environment pass-through to make the node and package manager shims work correctly in instances where [proto](https://moonrepo.dev/proto) is installed in a custom location

### Testing Instructions

1. Install proto in non-default location: https://moonrepo.dev/docs/proto/install#installing e.g. `export PROTO_HOME=$XDG_DATA_HOME/proto`
2. Follow the instructions to set up node/pnpm/other package manager or tools: https://moonrepo.dev/docs/proto/workflows
3. Run any turborepo project task on a shell with the shims set up, with this patch you won't have to add `PROTO_HOME` to `globalPassThroughEnv`/`passThroughEnv` which is problematic for 3rd party projects.
If `PROTO_HOME` is not passed through, you will get an error like: `× This project requires Node.js 24.7.0 (detected from ~/.prototools), but this version has not been installed. Install it with proto install node 24.7.0, or enable the auto-install setting to automatically install missing versions!`
