### PR TITLE
fix!: use stdin to infer colors instead of stdout

### DIFF
--- a/crates/turborepo-ui/src/lib.rs
+++ b/crates/turborepo-ui/src/lib.rs
@@ -153,7 +153,7 @@ impl ColorConfig {
         Self { should_strip_ansi }
     }
 
-    /// Infer the color choice from environment variables and checking if stdout
+    /// Infer the color choice from environment variables and checking if stdin
     /// is a tty
     pub fn infer() -> Self {
         let env_setting =
@@ -164,7 +164,7 @@ impl ColorConfig {
                     "true" | "1" | "2" | "3" => Some(false),
                     _ => None,
                 });
-        let should_strip_ansi = env_setting.unwrap_or_else(|| !atty::is(atty::Stream::Stdout));
+        let should_strip_ansi = env_setting.unwrap_or_else(|| !atty::is(atty::Stream::Stdin));
         Self { should_strip_ansi }
     }
 


### PR DESCRIPTION
### Description

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

Checking `stdin` would allow for cases where `stdout` is redirected but you still want colors to be maintained (which is rather common IME). Since it is relatively less common (and there are few workarounds other than setting `FORCE_COLORS` that I know of) to have `stdin` be a TTY but still want colors, it seems like this would be a good change for the next major. It is a breaking change, so totally understand if it would need to wait. 

### Testing Instructions

I didn't even test this, but happy to if you think this has a chance of landing.
