### PR TITLE
feat: add Expo to common frameworks

### DIFF
--- a/packages/turbo-types/src/json/frameworks.json
+++ b/packages/turbo-types/src/json/frameworks.json
@@ -27,6 +27,15 @@
     }
   },
   {
+    "slug": "expo",
+    "name": "Expo",
+    "envWildcards": ["EXPO_PUBLIC_*"],
+    "dependencyMatch": {
+      "strategy": "all",
+      "dependencies": ["expo"]
+    }
+  },
+  {
     "slug": "gatsby",
     "name": "Gatsby",
     "envWildcards": ["GATSBY_*"],


### PR DESCRIPTION
### Description

Added Expo to turborepo common frameworks and EXPO_PUBLIC_ env wildcard to work with Framework Inference

### Testing Instructions