### PR TITLE
docs: correct description of how `^` works

### DIFF
--- a/docs/site/content/docs/crafting-your-repository/configuring-tasks.mdx
+++ b/docs/site/content/docs/crafting-your-repository/configuring-tasks.mdx
@@ -105,7 +105,7 @@ You now have the build order you would expect, building _dependencies_ before _d
 
 #### Depending on tasks in dependencies with `^`
 
-The `^` microsyntax tells Turborepo to run the task starting at the bottom of the dependency graph. If your application depends on a library named `ui` and the library has a `build` task, the `build` script in `ui` will run **first**. Once it has successfully completed, the `build` task in your application will run.
+The `^` microsyntax tells Turborepo to run the task in direct dependencies before the target package. If your application depends on a library named `ui` and the library has a `build` task, the `build` script in `ui` will run **first**. Once it has successfully completed, the `build` task in your application will run.
 
 This is an important pattern as it ensures that your application's `build` task will have all of the necessary dependencies that it needs to compile. This concept also applies as your dependency graph grows to a more complex structure with many levels of task dependencies.
 


### PR DESCRIPTION
### Description

Closes #10109, which pointed out that we were describing the behavior of `^` incorrectly.

### Testing Instructions

👀
