### PR TITLE
fix: output valid turbo.json for prune with Boundaries definition

### DIFF
--- a/crates/turborepo-lib/src/boundaries/config.rs
+++ b/crates/turborepo-lib/src/boundaries/config.rs
@@ -31,6 +31,8 @@ pub struct Rule {
 
 #[derive(Serialize, Default, Debug, Clone, Iterable, Deserializable, PartialEq)]
 pub struct Permissions {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub allow: Option<Spanned<Vec<Spanned<String>>>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub deny: Option<Spanned<Vec<Spanned<String>>>>,
 }

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -1102,4 +1102,94 @@ mod tests {
             assert!(raw_config.future_flags.is_none());
         }
     }
+
+    #[test]
+    fn test_boundaries_permissions_serialization_skip_none() {
+        // Test that None values in Permissions struct are not serialized as null
+        let json_with_partial_permissions = r#"{
+            "boundaries": {
+                "dependencies": {
+                    "allow": ["package-a"]
+                }
+            }
+        }"#;
+
+        // Parse the JSON
+        let parsed: RawTurboJson =
+            RawRootTurboJson::parse(json_with_partial_permissions, "turbo.json")
+                .unwrap()
+                .into();
+
+        // Serialize it back to JSON
+        let serialized = serde_json::to_string(&parsed).unwrap();
+
+        // The serialized JSON should not contain "deny":null
+        assert!(!serialized.contains("\"deny\":null"));
+        assert!(!serialized.contains("\"deny\": null"));
+
+        // But it should contain the allow field
+        assert!(serialized.contains("\"allow\""));
+
+        // Test that we can parse the serialized JSON again without errors
+        let reparsed: RawTurboJson = RawRootTurboJson::parse(&serialized, "turbo.json")
+            .unwrap()
+            .into();
+
+        // Verify the structure is preserved
+        assert!(reparsed.boundaries.is_some());
+        let boundaries = reparsed.boundaries.as_ref().unwrap();
+        assert!(boundaries.dependencies.is_some());
+        let deps = boundaries.dependencies.as_ref().unwrap();
+        assert!(deps.allow.is_some());
+        assert!(deps.deny.is_none()); // This should be None, not null
+    }
+
+    #[test]
+    fn test_prune_tasks_preserves_boundaries_structure() {
+        // Test the specific scenario from the bug report
+        let json_with_boundaries = r#"{
+            "tasks": {
+                "build": {},
+                "app-a#build": {}
+            },
+            "boundaries": {
+                "dependencies": {
+                    "allow": []
+                }
+            }
+        }"#;
+
+        let parsed: RawTurboJson = RawRootTurboJson::parse(json_with_boundaries, "turbo.json")
+            .unwrap()
+            .into();
+
+        // Simulate the prune operation
+        let pruned = parsed.prune_tasks(&["app-a"]);
+
+        // Serialize the pruned config
+        let serialized = serde_json::to_string_pretty(&pruned).unwrap();
+
+        // The serialized JSON should not contain "deny":null
+        assert!(!serialized.contains("\"deny\":null"));
+        assert!(!serialized.contains("\"deny\": null"));
+
+        // Parse the serialized config to ensure it's valid
+        let reparsed_result = RawRootTurboJson::parse(&serialized, "turbo.json");
+        assert!(
+            reparsed_result.is_ok(),
+            "Failed to parse pruned config: {:?}",
+            reparsed_result.err()
+        );
+
+        let reparsed: RawTurboJson = reparsed_result.unwrap().into();
+
+        // Verify boundaries structure is preserved
+        assert!(reparsed.boundaries.is_some());
+        let boundaries = reparsed.boundaries.as_ref().unwrap();
+        assert!(boundaries.dependencies.is_some());
+        let deps = boundaries.dependencies.as_ref().unwrap();
+        assert!(deps.allow.is_some());
+        assert!(deps.deny.is_none()); // This should be None, not serialized as
+        // null
+    }
 }

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__package_rule.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__package_rule.snap
@@ -6,7 +6,6 @@ expression: raw_boundaries_config
   "dependencies": {
     "allow": [
       "my-package"
-    ],
-    "deny": null
+    ]
   }
 }

--- a/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__tags_and_dependencies.snap
+++ b/crates/turborepo-lib/src/turbo_json/snapshots/turborepo_lib__turbo_json__tests__tags_and_dependencies.snap
@@ -8,8 +8,7 @@ expression: raw_boundaries_config
       "dependencies": {
         "allow": [
           "my-package"
-        ],
-        "deny": null
+        ]
       }
     }
   }


### PR DESCRIPTION
### Description

Closes #10547 

A serde skip was missing.

### Testing Instructions

Corrected snapshots.
