### PR TITLE
chore: update to Rust 1.90.0

### DIFF
--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -732,16 +732,18 @@ impl<'a> EngineBuilder<'a> {
                 .load(package_name)
                 .map(Some)
                 .or_else(|err| {
-                    if let Some((span, text)) = read_req.required()
-                        && matches!(err, config::Error::NoTurboJSON)
-                    {
-                        Err(Error::MissingTurboJsonExtends(Box::new(
-                            MissingTurboJsonExtends {
-                                package_name: read_req.package_name().to_string(),
-                                span,
-                                text,
-                            },
-                        )))
+                    if let Some((span, text)) = read_req.required() {
+                        if matches!(err, config::Error::NoTurboJSON) {
+                            Err(Error::MissingTurboJsonExtends(Box::new(
+                                MissingTurboJsonExtends {
+                                    package_name: read_req.package_name().to_string(),
+                                    span,
+                                    text,
+                                },
+                            )))
+                        } else {
+                            Err(err.into())
+                        }
                     } else if matches!(err, config::Error::NoTurboJSON) {
                         Ok(None)
                     } else {

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -4,7 +4,6 @@
 #![feature(once_cell_try)]
 #![feature(try_blocks)]
 #![feature(impl_trait_in_assoc_type)]
-#![feature(let_chains)]
 #![deny(clippy::all)]
 // Clippy's needless mut lint is buggy: https://github.com/rust-lang/rust-clippy/issues/11299
 #![allow(clippy::needless_pass_by_ref_mut)]

--- a/crates/turborepo-lib/src/turbo_json/validator.rs
+++ b/crates/turborepo-lib/src/turbo_json/validator.rs
@@ -98,28 +98,27 @@ pub fn validate_extends(validator: &Validator, turbo_json: &TurboJson) -> Vec<Er
             text: NamedSource::new(path, text),
         }];
     }
-    if let Some(package_name) = turbo_json.extends.first()
-        && package_name != ROOT_PKG_NAME
-        && validator.non_root_extends
-    {
-        let path = turbo_json
-            .path
-            .as_ref()
-            .map_or("turbo.json", |p| p.as_ref());
+    if let Some(package_name) = turbo_json.extends.first() {
+        if package_name != ROOT_PKG_NAME && validator.non_root_extends {
+            let path = turbo_json
+                .path
+                .as_ref()
+                .map_or("turbo.json", |p| p.as_ref());
 
-        let (span, text) = match turbo_json.text {
-            Some(ref text) => {
-                let len = text.len();
-                let span: SourceSpan = (0, len - 1).into();
-                (Some(span), text.to_string())
-            }
-            None => (None, String::new()),
-        };
-        // Root needs to be first
-        return vec![Error::ExtendsRootFirst {
-            span,
-            text: NamedSource::new(path, text),
-        }];
+            let (span, text) = match turbo_json.text {
+                Some(ref text) => {
+                    let len = text.len();
+                    let span: SourceSpan = (0, len - 1).into();
+                    (Some(span), text.to_string())
+                }
+                None => (None, String::new()),
+            };
+            // Root needs to be first
+            return vec![Error::ExtendsRootFirst {
+                span,
+                text: NamedSource::new(path, text),
+            }];
+        }
     }
     // If we allow for non-root extends we don't need to perform this check
     (!validator.non_root_extends

--- a/crates/turborepo-vt100/src/attrs.rs
+++ b/crates/turborepo-vt100/src/attrs.rs
@@ -1,9 +1,10 @@
 use crate::term::BufWrite as _;
 
 /// Represents a foreground or background color for cells.
-#[derive(Eq, PartialEq, Debug, Copy, Clone)]
+#[derive(Eq, PartialEq, Debug, Default, Copy, Clone)]
 pub enum Color {
     /// The default terminal color.
+    #[default]
     Default,
 
     /// An indexed terminal color.
@@ -11,12 +12,6 @@ pub enum Color {
 
     /// An RGB terminal color. The parameters are (red, green, blue).
     Rgb(u8, u8, u8),
-}
-
-impl Default for Color {
-    fn default() -> Self {
-        Self::Default
-    }
 }
 
 const TEXT_MODE_BOLD: u8 = 0b0000_0001;

--- a/crates/turborepo-vt100/src/screen.rs
+++ b/crates/turborepo-vt100/src/screen.rs
@@ -8,9 +8,10 @@ const MODE_ALTERNATE_SCREEN: u8 = 0b0000_1000;
 const MODE_BRACKETED_PASTE: u8 = 0b0001_0000;
 
 /// The xterm mouse handling mode currently in use.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub enum MouseProtocolMode {
     /// Mouse handling is disabled.
+    #[default]
     None,
 
     /// Mouse button events should be reported on button press. Also known as
@@ -34,16 +35,11 @@ pub enum MouseProtocolMode {
     // DecLocator,
 }
 
-impl Default for MouseProtocolMode {
-    fn default() -> Self {
-        Self::None
-    }
-}
-
 /// The encoding to use for the enabled `MouseProtocolMode`.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub enum MouseProtocolEncoding {
     /// Default single-printable-byte encoding.
+    #[default]
     Default,
 
     /// UTF-8-based encoding.
@@ -52,12 +48,6 @@ pub enum MouseProtocolEncoding {
     /// SGR-like encoding.
     Sgr,
     // Urxvt,
-}
-
-impl Default for MouseProtocolEncoding {
-    fn default() -> Self {
-        Self::Default
-    }
 }
 
 /// Represents the overall terminal state.

--- a/packages/turbo-repository/scripts/build.sh
+++ b/packages/turbo-repository/scripts/build.sh
@@ -13,7 +13,7 @@ script_provided_flags="\
 for flag in $user_provided_flags; do
   if [[ $flag == --target=* ]]; then
     target=${flag#*=}
-    rustup toolchain install nightly-2025-06-20 --target "$target"
+    rustup toolchain install nightly-2025-08-01 --target "$target"
 
     # For we need to cross-compile some targets with Zig
     # Fortunately, napi comes with a `--zig` flag

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Needs to be copied to `packages/turbo-repository/scripts/build.sh`
-channel = "nightly-2025-06-20"
+channel = "nightly-2025-08-01"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
### Description

Rust devs forbid using let-chains for non-2024 edition code (or it's a bug?) so `#![feature(let-chains)]` is ignored, and the code fails to compile. refactored a few pieces in turborepo-lib so it uses older behavior

the only clippy lint fixed is the Default deriving
<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

### Testing Instructions

CI
<!--
  Give a quick description of steps to test your changes.
-->
