### PR TITLE
feat(tui): task list search with `/`

### DIFF
--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -47,6 +47,9 @@ pub enum LayoutSections {
         previous_selection: String,
         results: SearchResults,
     },
+    SearchLocked {
+        results: SearchResults,
+    },
 }
 
 pub struct App<W> {
@@ -125,7 +128,9 @@ impl<W> App<W> {
     fn is_focusing_pane(&self) -> bool {
         match self.section_focus {
             LayoutSections::Pane => true,
-            LayoutSections::TaskList | LayoutSections::Search { .. } => false,
+            LayoutSections::TaskList
+            | LayoutSections::Search { .. }
+            | LayoutSections::SearchLocked { .. } => false,
         }
     }
 
@@ -184,26 +189,71 @@ impl<W> App<W> {
     #[tracing::instrument(skip(self))]
     pub fn next(&mut self) {
         let num_rows = self.tasks_by_status.count_all();
-        if num_rows > 0 {
+        if num_rows == 0 {
+            return;
+        }
+
+        // If search is locked, jump to next matching task
+        if let LayoutSections::SearchLocked { results } = &self.section_focus {
+            let next_task = results
+                .first_match(
+                    self.tasks_by_status
+                        .task_names_in_displayed_order()
+                        .skip(self.selected_task_index + 1),
+                )
+                .or_else(|| {
+                    // Wrap around to first match
+                    results.first_match(self.tasks_by_status.task_names_in_displayed_order())
+                })
+                .map(|s| s.to_owned());
+
+            if let Some(task) = next_task {
+                let _ = self.select_task(&task);
+            }
+        } else {
             self.selected_task_index = (self.selected_task_index + 1) % num_rows;
             self.task_list_scroll.select(Some(self.selected_task_index));
-            self.is_task_selection_pinned = true;
-            self.persist_active_task().ok();
         }
+
+        self.is_task_selection_pinned = true;
+        self.persist_active_task().ok();
     }
 
     #[tracing::instrument(skip(self))]
     pub fn previous(&mut self) {
         let num_rows = self.tasks_by_status.count_all();
-        if num_rows > 0 {
+        if num_rows == 0 {
+            return;
+        }
+
+        // If search is locked, jump to previous matching task
+        if let LayoutSections::SearchLocked { results } = &self.section_focus {
+            let prev_task = results
+                .first_match(
+                    self.tasks_by_status
+                        .task_names_in_displayed_order()
+                        .rev()
+                        .skip(num_rows - self.selected_task_index),
+                )
+                .or_else(|| {
+                    // Wrap around to last match
+                    results.first_match(self.tasks_by_status.task_names_in_displayed_order().rev())
+                })
+                .map(|s| s.to_owned());
+
+            if let Some(task) = prev_task {
+                let _ = self.select_task(&task);
+            }
+        } else {
             self.selected_task_index = self
                 .selected_task_index
                 .checked_sub(1)
                 .unwrap_or(num_rows - 1);
             self.task_list_scroll.select(Some(self.selected_task_index));
-            self.is_task_selection_pinned = true;
-            self.persist_active_task().ok();
         }
+
+        self.is_task_selection_pinned = true;
+        self.persist_active_task().ok();
     }
 
     #[tracing::instrument(skip_all)]
@@ -247,15 +297,25 @@ impl<W> App<W> {
     pub fn exit_search(&mut self, restore_scroll: bool) {
         let mut prev_focus = LayoutSections::TaskList;
         mem::swap(&mut self.section_focus, &mut prev_focus);
-        if let LayoutSections::Search {
-            previous_selection, ..
-        } = prev_focus
-            && restore_scroll
-            && self.select_task(&previous_selection).is_err()
-        {
-            // If the task that was selected is no longer in the task list we reset
-            // scrolling.
-            self.reset_scroll();
+        match prev_focus {
+            LayoutSections::Search {
+                previous_selection, ..
+            } if restore_scroll => {
+                if self.select_task(&previous_selection).is_err() {
+                    // If the task that was selected is no longer in the task list we reset
+                    // scrolling.
+                    self.reset_scroll();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    pub fn lock_search(&mut self) {
+        if let LayoutSections::Search { results, .. } = &self.section_focus {
+            self.section_focus = LayoutSections::SearchLocked {
+                results: results.clone(),
+            };
         }
     }
 
@@ -264,19 +324,30 @@ impl<W> App<W> {
             debug!("scrolling search while not searching");
             return Ok(());
         };
+        let num_rows = self.tasks_by_status.count_all();
         let new_selection = match direction {
-            Direction::Up => results.first_match(
-                self.tasks_by_status
-                    .task_names_in_displayed_order()
-                    .rev()
-                    // We skip all of the tasks that are at or after the current selection
-                    .skip(self.tasks_by_status.count_all() - self.selected_task_index),
-            ),
-            Direction::Down => results.first_match(
-                self.tasks_by_status
-                    .task_names_in_displayed_order()
-                    .skip(self.selected_task_index + 1),
-            ),
+            Direction::Up => results
+                .first_match(
+                    self.tasks_by_status
+                        .task_names_in_displayed_order()
+                        .rev()
+                        // We skip all of the tasks that are at or after the current selection
+                        .skip(num_rows - self.selected_task_index),
+                )
+                .or_else(|| {
+                    // Wrap around to last match
+                    results.first_match(self.tasks_by_status.task_names_in_displayed_order().rev())
+                }),
+            Direction::Down => results
+                .first_match(
+                    self.tasks_by_status
+                        .task_names_in_displayed_order()
+                        .skip(self.selected_task_index + 1),
+                )
+                .or_else(|| {
+                    // Wrap around to first match
+                    results.first_match(self.tasks_by_status.task_names_in_displayed_order())
+                }),
         };
         if let Some(new_selection) = new_selection {
             let new_selection = new_selection.to_owned();
@@ -463,8 +534,12 @@ impl<W> App<W> {
             self.reset_scroll();
         }
 
-        if let LayoutSections::Search { results, .. } = &mut self.section_focus {
-            results.update_tasks(&self.tasks_by_status);
+        match &mut self.section_focus {
+            LayoutSections::Search { results, .. }
+            | LayoutSections::SearchLocked { results, .. } => {
+                results.update_tasks(&self.tasks_by_status);
+            }
+            _ => {}
         }
         self.update_search_results();
 
@@ -490,8 +565,12 @@ impl<W> App<W> {
         self.tasks_by_status
             .restart_tasks(tasks.iter().map(|s| s.as_str()));
 
-        if let LayoutSections::Search { results, .. } = &mut self.section_focus {
-            results.update_tasks(&self.tasks_by_status);
+        match &mut self.section_focus {
+            LayoutSections::Search { results, .. }
+            | LayoutSections::SearchLocked { results, .. } => {
+                results.update_tasks(&self.tasks_by_status);
+            }
+            _ => {}
         }
 
         if self.select_task(&highlighted_task).is_err() {
@@ -952,6 +1031,9 @@ fn update(
         Event::SearchExit { restore_scroll } => {
             app.exit_search(restore_scroll);
         }
+        Event::SearchLock => {
+            app.lock_search();
+        }
         Event::SearchScroll { direction } => {
             app.search_scroll(direction)?;
         }
@@ -993,7 +1075,7 @@ fn view<W>(app: &mut App<W>, f: &mut Frame) {
         app.preferences.is_task_list_visible(),
     );
 
-    let table_to_render = TaskTable::new(&app.tasks_by_status);
+    let table_to_render = TaskTable::new(&app.tasks_by_status, &app.section_focus);
 
     f.render_stateful_widget(&table_to_render, table, &mut app.task_list_scroll);
     f.render_widget(&pane_to_render, pane);
@@ -1553,9 +1635,9 @@ mod test {
         app.search_scroll(Direction::Down)?;
         assert_eq!(app.active_task()?, "abc");
         app.search_scroll(Direction::Down)?;
-        assert_eq!(app.active_task()?, "abc");
+        assert_eq!(app.active_task()?, "ab", "wraps around to first match");
         app.search_scroll(Direction::Up)?;
-        assert_eq!(app.active_task()?, "ab");
+        assert_eq!(app.active_task()?, "abc", "wraps around to last match");
         app.search_scroll(Direction::Up)?;
         assert_eq!(app.active_task()?, "ab");
         Ok(())
@@ -1654,6 +1736,310 @@ mod test {
         // Restart ab
         app.restart_tasks(vec!["ab".into()])?;
         assert_eq!(app.active_task()?, "ab");
+        Ok(())
+    }
+
+    #[test]
+    fn test_search_lock() -> Result<(), Error> {
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())
+            .expect("Failed to create AbsoluteSystemPathBuf");
+
+        let mut app: App<()> = App::new(
+            100,
+            100,
+            vec![
+                "app-a".to_string(),
+                "app-b".to_string(),
+                "pkg-a".to_string(),
+            ],
+            PreferenceLoader::new(&repo_root),
+            2048,
+        );
+
+        // Enter search mode and type query
+        app.enter_search()?;
+        assert!(matches!(app.section_focus, LayoutSections::Search { .. }));
+        app.search_enter_char('a')?;
+        app.search_enter_char('p')?;
+        app.search_enter_char('p')?;
+        assert_eq!(app.active_task()?, "app-a");
+
+        // Lock the search
+        app.lock_search();
+        assert!(
+            matches!(app.section_focus, LayoutSections::SearchLocked { .. }),
+            "search should be locked"
+        );
+
+        // Verify we're still on the same task
+        assert_eq!(app.active_task()?, "app-a");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_locked_search_navigation() -> Result<(), Error> {
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())
+            .expect("Failed to create AbsoluteSystemPathBuf");
+
+        let mut app: App<()> = App::new(
+            100,
+            100,
+            vec![
+                "app-a".to_string(),
+                "app-b".to_string(),
+                "pkg-a".to_string(),
+                "pkg-b".to_string(),
+            ],
+            PreferenceLoader::new(&repo_root),
+            2048,
+        );
+
+        // Enter search and lock with "app" query
+        app.enter_search()?;
+        app.search_enter_char('a')?;
+        app.search_enter_char('p')?;
+        app.search_enter_char('p')?;
+        assert_eq!(app.active_task()?, "app-a");
+        app.lock_search();
+
+        // Navigate down should only go to next matching task (app-b)
+        app.next();
+        assert_eq!(
+            app.active_task()?,
+            "app-b",
+            "should skip to next matching task"
+        );
+
+        // Navigate down again should wrap to first match
+        app.next();
+        assert_eq!(
+            app.active_task()?,
+            "app-a",
+            "should wrap around to first matching task"
+        );
+
+        // Navigate up should wrap to last match
+        app.previous();
+        assert_eq!(
+            app.active_task()?,
+            "app-b",
+            "should wrap to last matching task"
+        );
+
+        // Navigate up should go to previous match
+        app.previous();
+        assert_eq!(app.active_task()?, "app-a");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_locked_search_only_shows_matches() -> Result<(), Error> {
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())
+            .expect("Failed to create AbsoluteSystemPathBuf");
+
+        let mut app: App<()> = App::new(
+            100,
+            100,
+            vec![
+                "build-web".to_string(),
+                "build-api".to_string(),
+                "test-web".to_string(),
+                "test-api".to_string(),
+            ],
+            PreferenceLoader::new(&repo_root),
+            2048,
+        );
+
+        // Search for "build" - tasks are sorted alphabetically so build-api comes first
+        app.enter_search()?;
+        app.search_enter_char('b')?;
+        app.search_enter_char('u')?;
+        app.search_enter_char('i')?;
+        app.search_enter_char('l')?;
+        app.search_enter_char('d')?;
+        assert_eq!(app.active_task()?, "build-api");
+        app.lock_search();
+
+        // Navigate through all tasks - should only hit "build" tasks
+        let mut visited = vec![app.active_task()?.to_string()];
+        app.next();
+        visited.push(app.active_task()?.to_string());
+        app.next();
+        visited.push(app.active_task()?.to_string());
+
+        assert_eq!(visited, vec!["build-api", "build-web", "build-api"]);
+        assert!(
+            !visited.contains(&"test-web".to_string()),
+            "should not visit non-matching tasks"
+        );
+        assert!(
+            !visited.contains(&"test-api".to_string()),
+            "should not visit non-matching tasks"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_exit_locked_search() -> Result<(), Error> {
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())
+            .expect("Failed to create AbsoluteSystemPathBuf");
+
+        let mut app: App<()> = App::new(
+            100,
+            100,
+            vec![
+                "app-a".to_string(),
+                "app-b".to_string(),
+                "pkg-a".to_string(),
+            ],
+            PreferenceLoader::new(&repo_root),
+            2048,
+        );
+
+        // Enter search, lock it
+        app.enter_search()?;
+        app.search_enter_char('a')?;
+        app.search_enter_char('p')?;
+        app.search_enter_char('p')?;
+        app.lock_search();
+        assert!(matches!(
+            app.section_focus,
+            LayoutSections::SearchLocked { .. }
+        ));
+
+        // Exit should go back to normal task list
+        app.exit_search(false);
+        assert!(
+            matches!(app.section_focus, LayoutSections::TaskList),
+            "should exit to task list"
+        );
+
+        // Navigation should now go through all tasks
+        app.next();
+        app.next();
+        app.next();
+        // Starting from app-a, should cycle through app-b, pkg-a, back to app-a
+        assert_eq!(app.active_task()?, "app-a");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_locked_search_with_single_match() -> Result<(), Error> {
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())
+            .expect("Failed to create AbsoluteSystemPathBuf");
+
+        let mut app: App<()> = App::new(
+            100,
+            100,
+            vec![
+                "app-a".to_string(),
+                "app-b".to_string(),
+                "unique".to_string(),
+            ],
+            PreferenceLoader::new(&repo_root),
+            2048,
+        );
+
+        // Search for unique string
+        app.enter_search()?;
+        app.search_enter_char('u')?;
+        app.search_enter_char('n')?;
+        app.search_enter_char('i')?;
+        app.search_enter_char('q')?;
+        app.search_enter_char('u')?;
+        app.search_enter_char('e')?;
+        assert_eq!(app.active_task()?, "unique");
+        app.lock_search();
+
+        // Navigate should stay on the same task
+        app.next();
+        assert_eq!(app.active_task()?, "unique", "should stay on single match");
+        app.previous();
+        assert_eq!(app.active_task()?, "unique", "should stay on single match");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_locked_search_maintains_filter_after_task_changes() -> Result<(), Error> {
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())
+            .expect("Failed to create AbsoluteSystemPathBuf");
+
+        let mut app: App<()> = App::new(
+            100,
+            100,
+            vec![
+                "app-a".to_string(),
+                "app-b".to_string(),
+                "pkg-a".to_string(),
+            ],
+            PreferenceLoader::new(&repo_root),
+            2048,
+        );
+
+        // Lock search for "app"
+        app.enter_search()?;
+        app.search_enter_char('a')?;
+        app.search_enter_char('p')?;
+        app.search_enter_char('p')?;
+        app.lock_search();
+        assert_eq!(app.active_task()?, "app-a");
+
+        // Start a task
+        app.start_task("app-a", OutputLogs::Full)?;
+
+        // Navigation should still only show "app" tasks
+        app.next();
+        assert_eq!(
+            app.active_task()?,
+            "app-b",
+            "filter should persist after task changes"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_search_wrap_around_empty_results() -> Result<(), Error> {
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())
+            .expect("Failed to create AbsoluteSystemPathBuf");
+
+        let mut app: App<()> = App::new(
+            100,
+            100,
+            vec![
+                "app-a".to_string(),
+                "app-b".to_string(),
+                "pkg-a".to_string(),
+            ],
+            PreferenceLoader::new(&repo_root),
+            2048,
+        );
+
+        // Search for something that doesn't match anything
+        app.enter_search()?;
+        app.search_enter_char('x')?;
+        app.search_enter_char('y')?;
+        app.search_enter_char('z')?;
+
+        // Try to scroll - should not panic or change selection
+        let initial_task = app.active_task()?.to_string();
+        app.search_scroll(Direction::Down)?;
+        assert_eq!(app.active_task()?, initial_task);
+        app.search_scroll(Direction::Up)?;
+        assert_eq!(app.active_task()?, initial_task);
+
         Ok(())
     }
 }

--- a/crates/turborepo-ui/src/tui/event.rs
+++ b/crates/turborepo-ui/src/tui/event.rs
@@ -63,6 +63,7 @@ pub enum Event {
     SearchExit {
         restore_scroll: bool,
     },
+    SearchLock,
     SearchScroll {
         direction: Direction,
     },

--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -85,16 +85,25 @@ fn translate_key_event(options: InputOptions, key_event: KeyEvent) -> Option<Eve
         KeyCode::Char('/') if matches!(options.focus, LayoutSections::TaskList) => {
             Some(Event::SearchEnter)
         }
+        // If we're in locked search and user presses `/` clear the search
+        KeyCode::Char('/') if matches!(options.focus, LayoutSections::SearchLocked { .. }) => {
+            Some(Event::SearchExit {
+                restore_scroll: false,
+            })
+        }
         KeyCode::Esc if options.is_help_popup_open => Some(Event::ToggleHelpPopup),
         KeyCode::Esc if matches!(options.focus, LayoutSections::Search { .. }) => {
             Some(Event::SearchExit {
                 restore_scroll: true,
             })
         }
-        KeyCode::Enter if matches!(options.focus, LayoutSections::Search { .. }) => {
+        KeyCode::Esc if matches!(options.focus, LayoutSections::SearchLocked { .. }) => {
             Some(Event::SearchExit {
                 restore_scroll: false,
             })
+        }
+        KeyCode::Enter if matches!(options.focus, LayoutSections::Search { .. }) => {
+            Some(Event::SearchLock)
         }
         KeyCode::Up if matches!(options.focus, LayoutSections::Search { .. }) => {
             Some(Event::SearchScroll {

--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -70,8 +70,8 @@ impl<'a, W> TerminalPane<'a, W> {
                 build_message_vec(&[ENTER_INTERACTIVE_HINT, SCROLL_LOGS, PAGE_LOGS, JUMP_IN_LOGS])
             }
             LayoutSections::TaskList => build_message_vec(&[SCROLL_LOGS, PAGE_LOGS, JUMP_IN_LOGS]),
-            LayoutSections::Search { results, .. } => {
-                Line::from(format!("/ {}", results.query())).left_aligned()
+            LayoutSections::Search { .. } | LayoutSections::SearchLocked { .. } => {
+                build_message_vec(&[SCROLL_LOGS, PAGE_LOGS, JUMP_IN_LOGS])
             }
         }
     }

--- a/crates/turborepo-ui/src/tui/table.rs
+++ b/crates/turborepo-ui/src/tui/table.rs
@@ -57,7 +57,7 @@ impl<'b> TaskTable<'b> {
         match self.section {
             LayoutSections::Search { results, .. }
             | LayoutSections::SearchLocked { results, .. } => {
-                !results.first_match(std::iter::once(task_name)).is_some()
+                results.first_match(std::iter::once(task_name)).is_none()
             }
             _ => false,
         }


### PR DESCRIPTION
### Description

Add task list searching in terminal UI.

<img width="1898" height="1710" alt="CleanShot 2025-10-01 at 04 24 57@2x" src="https://github.com/user-attachments/assets/d7e2dba2-1d36-4891-86a7-234b4c9edc33" />


Features:
- UI hint for searching
- Locks query when the user presses ENTER
- Dims tasks in table list that don't match query

### Testing Instructions

Use the TUI and try:
- Searching by pressing the `/` key
- Cycling tasks with `↑`/`↓` while typing a query
- Pressing ENTER so you can cycle with `j`/`k`

CLOSES TURBO-4197
