### PR TITLE
feat: update `create-turbo` Bun prompt text

### DIFF
--- a/packages/create-turbo/src/commands/create/prompts.ts
+++ b/packages/create-turbo/src/commands/create/prompts.ts
@@ -56,7 +56,7 @@ export async function packageManager({
       { pm: "npm", label: "npm" },
       { pm: "pnpm", label: "pnpm" },
       { pm: "yarn", label: "yarn" },
-      { pm: "bun", label: "Bun (beta)" },
+      { pm: "bun", label: "Bun" },
     ].map(({ pm, label }) => ({
       name: label,
       value: pm,


### PR DESCRIPTION
### Description

Updates the `create-turbo` prompt to display "Bun" instead of "Bun (beta)" when selecting a package manager. This change reflects Bun's stable status.

### Testing Instructions

Run `pnpm create-turbo` and observe the package manager selection prompt to confirm "Bun" is displayed without "(beta)".

---
Linear Issue: [TURBO-4592](https://linear.app/vercel/issue/TURBO-4592/update-create-turbo-bun-beta-tag-in-create-turbo)

<a href="https://cursor.com/background-agent?bcId=bc-dc8d532b-5bc4-4e7d-a76d-a1b321dd2801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dc8d532b-5bc4-4e7d-a76d-a1b321dd2801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

