### PR TITLE
Remove experimental from affected output

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -648,7 +648,7 @@ pub enum Command {
     Scan,
     #[clap(hide = true)]
     Config,
-    /// EXPERIMENTAL: List packages in your monorepo.
+    /// List packages in your monorepo.
     Ls {
         /// Show only packages that are affected by changes between
         /// the current branch and `main`

--- a/docs/site/content/docs/reference/ls.mdx
+++ b/docs/site/content/docs/reference/ls.mdx
@@ -40,7 +40,7 @@ By default the changes considered are those between `main` and `HEAD`.
 TURBO_SCM_BASE=development turbo ls --affected
 ```
 
-### `--output <format>` <ExperimentalBadge />
+### `--output <format>`
 
 Format to output the results. `json` or `pretty` (default)
 

--- a/docs/site/content/docs/support-policy.mdx
+++ b/docs/site/content/docs/support-policy.mdx
@@ -108,7 +108,6 @@ We encourage you to help us test experimental APIs in side projects, proof-of-co
 - [`turbo query`](/docs/reference/query)
 - [`turbo boundaries`](/docs/reference/boundaries) and [Tags](/docs/reference/boundaries#tags)
 - [`--experimental-write-cache` for `turbo watch`](/docs/reference/watch#caching)
-- [`--output=json` for `turbo ls --affected` flag](/docs/reference/ls)
 
 ### Deprecated
 


### PR DESCRIPTION
### Description

This PR stabilizes the `turbo ls --affected --output=json` command by removing all "experimental" markers from the CLI, documentation, and support policy. This feature is now considered stable.

### Testing Instructions

1.  Run `turbo --help` and confirm that `ls` no longer shows an `EXPERIMENTAL` prefix.
2.  Run `turbo ls --affected --output=json` in a Turborepo project.
    *   Verify that the output is valid JSON.
    *   Confirm that no experimental warnings or badges are displayed.

---
Linear Issue: [TURBO-4009](https://linear.app/vercel/issue/TURBO-4009/remove-experimental-from-affected-output=json)

<a href="https://cursor.com/background-agent?bcId=bc-9cc15b66-92af-4e6e-b04f-d9b559df4546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9cc15b66-92af-4e6e-b04f-d9b559df4546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

