### PR TITLE
Update blog og image generation to use route handler

### DIFF
--- a/docs/site/app/(no-sidebar)/blog/[...slug]/page.tsx
+++ b/docs/site/app/(no-sidebar)/blog/[...slug]/page.tsx
@@ -21,6 +21,9 @@ export async function generateMetadata(props: {
 
   if (!page) notFound();
 
+  const version = params.slug?.[0] || "1.0.0";
+  const ogUrl = `/api/og/blog?version=${encodeURIComponent(version)}&title=${encodeURIComponent(page.data.title)}`;
+
   return {
     ...createMetadata({
       title: page.data.title,
@@ -30,7 +33,7 @@ export async function generateMetadata(props: {
     openGraph: {
       images: [
         {
-          url: `/images/blog/${params.slug?.[0]}/x-card.png`,
+          url: ogUrl,
         },
       ],
     },

--- a/docs/site/app/api/og/blog/route.tsx
+++ b/docs/site/app/api/og/blog/route.tsx
@@ -1,0 +1,137 @@
+import React from "react";
+import { ImageResponse } from "next/og";
+import type { NextApiRequest } from "next/index";
+import { RepoLogo } from "../../../_components/logos/og/repo-logo";
+import { VercelLogo } from "../../../_components/logos/og/vercel-logo";
+
+export const runtime = "edge";
+
+function _arrayBufferToBase64(buffer: ArrayBuffer): string {
+  let binary = "";
+  const bytes = new Uint8Array(buffer);
+  const len = bytes.byteLength;
+  for (let i = 0; i < len; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+export async function GET(req: NextApiRequest): Promise<Response> {
+  try {
+    const [geist, geistMono, bg] = await Promise.all([
+      fetch(new URL("../Geist-Regular.ttf", import.meta.url)).then((res) =>
+        res.arrayBuffer()
+      ),
+      fetch(new URL("../GeistMono-Regular.ttf", import.meta.url)).then((res) =>
+        res.arrayBuffer()
+      ),
+      _arrayBufferToBase64(
+        await fetch(new URL("../bg.jpeg", import.meta.url)).then((res) =>
+          res.arrayBuffer()
+        )
+      ),
+    ]);
+
+    const reqUrl = req.url || "";
+    const { searchParams } = new URL(reqUrl);
+
+    const version = searchParams.get("version") || "1.0.0";
+    const title = searchParams.get("title")?.slice(0, 100) || null;
+
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            width: "100%",
+            height: "100%",
+            fontFamily: "Geist Mono",
+            fontWeight: 700,
+            fontSize: 60,
+            backgroundImage: `url(data:image/jpeg;base64,${bg})`,
+            backgroundSize: "1200px 630px",
+            color: "#fff",
+          }}
+        >
+          <div
+            style={{ display: "flex", height: 97 * 1.1, alignItems: "center" }}
+          >
+            <RepoLogo />
+          </div>
+          {title ? (
+            <div
+              style={{
+                fontFamily: "Geist Mono",
+                fontSize: 36,
+                letterSpacing: -1.5,
+                padding: "40px 20px 30px",
+                textAlign: "center",
+                backgroundImage: "linear-gradient(to bottom, #fff, #aaa)",
+                backgroundClip: "text",
+                color: "transparent",
+              }}
+            >
+              {title}
+            </div>
+          ) : null}
+          <div
+            style={{
+              fontFamily: "Geist Mono",
+              fontSize: 24,
+              marginTop: 20,
+              color: "#fff",
+              opacity: 0.8,
+            }}
+          >
+            v{version}
+          </div>
+          <div
+            style={{
+              fontFamily: "Geist Mono",
+              fontSize: 18,
+              marginTop: 60,
+              display: "flex",
+              color: "#fff",
+              alignItems: "center",
+            }}
+          >
+            <div style={{ marginRight: 12 }}>by</div>
+            <VercelLogo fill="white" height={25} />
+          </div>
+        </div>
+      ),
+      {
+        fonts: [
+          {
+            name: "Geist Mono",
+            data: geistMono,
+            weight: 700 as const,
+            style: "normal" as const,
+          },
+          {
+            name: "Geist Sans",
+            data: geist,
+            weight: 400 as const,
+            style: "normal" as const,
+          },
+        ],
+      }
+    );
+  } catch (err: unknown) {
+    if (process.env.VERCEL_ENV === "production") {
+      return new Response(undefined, {
+        status: 302,
+        headers: {
+          Location: "https://turborepo.com/og-image.png",
+        },
+      });
+    }
+
+    return new Response(undefined, {
+      status: 500,
+    });
+  }
+}


### PR DESCRIPTION
### Description

This PR refactors blog post Open Graph (OG) image generation to use a dedicated Route Handler, aligning with existing `api/og` patterns.

-   A new Route Handler `docs/site/app/api/og/blog/route.tsx` has been created.
-   It accepts `version` and `title` as query parameters for dynamic content.
-   Blog post pages (`docs/site/app/(no-sidebar)/blog/[...slug]/page.tsx`) now dynamically generate the OG image URL using this new route.
-   Currently uses a placeholder background image, which can be updated later.

### Testing Instructions

1.  Navigate to any blog post page (e.g., `/blog/1.0.0/my-blog-post`).
2.  Inspect the page's HTML to verify the `<meta property="og:image" content="..." />` tag points to the new dynamic route (e.g., `/api/og/blog?version=...&title=...`).
3.  Optionally, directly visit the generated OG image URL in your browser to confirm the image renders correctly with the version and title.

---
<a href="https://cursor.com/background-agent?bcId=bc-419a6a6c-99df-48c8-8564-640fa45fa304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-419a6a6c-99df-48c8-8564-640fa45fa304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

