### PR TITLE
Fix noUpdateNotifier not suppressing updates

### DIFF
--- a/crates/turborepo-lib/src/shim/mod.rs
+++ b/crates/turborepo-lib/src/shim/mod.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 use tiny_gradient::{GradientStr, RGB};
 use tracing::{debug, warn};
 pub use turbo_state::TurboState;
-use turbo_updater::display_update_check;
+use turbo_updater::{display_update_check, should_skip_notification};
 use turbopath::AbsoluteSystemPathBuf;
 use turborepo_repository::{
     inference::{RepoMode, RepoState},
@@ -316,7 +316,7 @@ fn try_check_for_updates(
 ) {
     let package_manager = package_manager.unwrap_or(&PackageManager::Npm);
 
-    if args.should_check_for_update() && !config.no_update_notifier() {
+    if args.should_check_for_update() && !config.no_update_notifier() && !should_skip_notification() {
         // custom footer for update message
         let footer = format!(
             "Follow {username} for updates: {url}",

--- a/crates/turborepo-updater/src/lib.rs
+++ b/crates/turborepo-updater/src/lib.rs
@@ -83,7 +83,7 @@ fn get_tag_from_version(pre: &semver::Prerelease) -> VersionTag {
     }
 }
 
-fn should_skip_notification() -> bool {
+pub fn should_skip_notification() -> bool {
     NOTIFIER_DISABLE_VARS
         .iter()
         .chain(ENVIRONMENTAL_DISABLE_VARS.iter())
@@ -100,11 +100,6 @@ pub fn display_update_check(
     interval: Option<Duration>,
     package_manager: &PackageManager,
 ) -> Result<(), UpdateNotifierError> {
-    // bail early if the user has disabled update notifications
-    if should_skip_notification() {
-        return Ok(());
-    }
-
     let version = check_for_updates(package_name, current_version, timeout, interval);
 
     if let Ok(Some(version)) = version {


### PR DESCRIPTION
### Description

Fixes an issue where `noUpdateNotifier: true` in `turbo.json` did not suppress update notifications. The update notification logic was refactored to centralize all suppression checks (config and environment variables) in the caller, removing a redundant check that ignored the `turbo.json` setting.

### Testing Instructions

1.  Add `"noUpdateNotifier": true` to your `turbo.json`.
2.  Ensure your `turbo` CLI version is older than the latest available.
3.  Run any `turbo` command (e.g., `turbo run build`).
4.  Verify that no update notification is displayed.

---
Linear Issue: [TURBO-4878](https://linear.app/vercel/issue/TURBO-4878/noupdatenotifier-does-not-supress-update-notifications)

<a href="https://cursor.com/background-agent?bcId=bc-c44181b4-d2df-43d3-8a2f-44c93b3ed1f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c44181b4-d2df-43d3-8a2f-44c93b3ed1f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

