### PR TITLE
fix: --graph=foo.dot should not require graphviz installed

### DIFF
--- a/crates/turborepo-lib/src/run/graph_visualizer.rs
+++ b/crates/turborepo-lib/src/run/graph_visualizer.rs
@@ -42,7 +42,7 @@ pub(crate) fn write_graph(
             } else if extension == "dot" {
                 let mut opts = OpenOptions::new();
                 opts.truncate(true).create(true).write(true);
-                let mut file = filename
+                let file = filename
                     .open_with_options(opts)
                     .map_err(Error::GraphOutput)?;
                 render_dot_graph(file, engine, single_package)?;


### PR DESCRIPTION
### Description

I'm attempting to use `turbo ... --graph` in GHA to do some static analysis of a very large repository. It's easy enough to extract relevant patterns from a `.dot` file, but I wouldn't have expected to need graphviz installed if I'm not actually using it.

I guess it turns out we _are_ using it, to do `dot - -T dot > out.dot`, but this seems very odd when the `std::io::stdout()` case just outputs directly. Seems like a bug.

### Testing Instructions

Edit your `PATH` to remove where graphviz is installed, then

```bash
turbo run build --graph foo.dot
```

Prior to this PR, you should get the error ` WARNING  `turbo` uses Graphviz to generate an image of your graph, but Graphviz isn't installed on this machine.` and an empty `foo.dot`.
After this PR, you should end up with a populated dotfile and no warning.