### PR TITLE
Fix turbo prune pnpm lockfile issue

### DIFF
--- a/crates/turborepo-lockfiles/fixtures/pnpm-inject-workspace.yaml
+++ b/crates/turborepo-lockfiles/fixtures/pnpm-inject-workspace.yaml
@@ -1,0 +1,31 @@
+lockfileVersion: "9.0"
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+  injectWorkspacePackages: true
+
+importers:
+  .:
+    devDependencies:
+      prettier:
+        specifier: ^3.5.3
+        version: 3.5.3
+
+  apps/web:
+    dependencies:
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+
+packages:
+  /lodash@4.17.21:
+    resolution:
+      integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+  /prettier@3.5.3:
+    resolution:
+      integrity: sha512-e/BBvVnJaW3c/+vgULvKzeXo8LBbFhIF8MkHl1q2L6MvfjSXRIHW5xBM7U2m9GH9A+3keuLDolOgzL4u2p3Mw==
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: true


### PR DESCRIPTION
### Description

Fixes an issue where `turbo prune` would remove the `injectWorkspacePackages` option from `pnpm-lock.yml`, causing `pnpm install --frozen-lockfile` to fail with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`.

The root cause was the `LockfileSettings` struct in `crates/turborepo-lockfiles/src/pnpm/data.rs` was missing the `inject_workspace_packages` field. This led to the field being dropped during lockfile deserialization and not re-serialized.

This PR adds the missing `inject_workspace_packages: Option<bool>` field to the `LockfileSettings` struct to ensure its preservation.

### Testing Instructions

A new test fixture (`pnpm-inject-workspace.yaml`) and a comprehensive test (`test_inject_workspace_packages_preservation`) have been added to `crates/turborepo-lockfiles/src/pnpm/data.rs`. This test verifies:
1. The original lockfile contains `injectWorkspacePackages: true`.
2. The setting is preserved in the pruned lockfile.
3. The serialized YAML output of the pruned lockfile still contains `injectWorkspacePackages: true`.

Run `cargo test` in the `crates/turborepo-lockfiles` directory to confirm the new test passes and no regressions are introduced.

---
Linear Issue: [TURBO-4764](https://linear.app/vercel/issue/TURBO-4764/turbo-prune-will-remove-pnpm-injectworkspacepackages-option-from-pnpm)

<a href="https://cursor.com/background-agent?bcId=bc-2ab87d59-1c08-49a5-b6e1-979c0fbd3386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2ab87d59-1c08-49a5-b6e1-979c0fbd3386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

