### PR TITLE
Fix clickable file paths in UI

### DIFF
--- a/crates/turbo-trace/src/main.rs
+++ b/crates/turbo-trace/src/main.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<(), PathError> {
 
     if !result.errors.is_empty() {
         for error in result.errors {
-            println!("{:?}", Report::new(error))
+            println!("{}", Report::new(error))
         }
         std::process::exit(1);
     } else {

--- a/crates/turbo-trace/src/tracer.rs
+++ b/crates/turbo-trace/src/tracer.rs
@@ -81,7 +81,7 @@ impl TraceResult {
                     e.clone().into_diagnostic(&handler).emit();
                 }
                 e => {
-                    eprintln!("{:?}", Report::new(e.clone()));
+                    eprintln!("{}", Report::new(e.clone()));
                 }
             }
         }

--- a/crates/turborepo-lib/src/boundaries/mod.rs
+++ b/crates/turborepo-lib/src/boundaries/mod.rs
@@ -227,7 +227,7 @@ impl BoundariesResult {
                     e.clone().into_diagnostic(&handler).emit();
                 }
                 e => {
-                    eprintln!("{:?}", Report::new(e.to_owned()));
+                    eprintln!("{}", Report::new(e.to_owned()));
                 }
             }
         }

--- a/crates/turborepo-lib/src/commands/boundaries.rs
+++ b/crates/turborepo-lib/src/commands/boundaries.rs
@@ -40,7 +40,7 @@ pub async fn run(
                     print!("{esc}c", esc = 27 as char);
                     println!();
                     println!();
-                    println!("{:?}", Report::new(diagnostic.clone()));
+                    println!("{}", Report::new(diagnostic.clone()));
                     let prompt = format!(
                         "Ignore this error by adding a {} comment?",
                         color!(run.color_config(), BOLD_GREEN, "@boundaries-ignore"),

--- a/crates/turborepo-lib/src/commands/query.rs
+++ b/crates/turborepo-lib/src/commands/query.rs
@@ -206,7 +206,7 @@ pub async fn run(
         if !result.errors.is_empty() {
             for error in result.errors {
                 let error = QueryError::new(error, query.to_string());
-                eprintln!("{:?}", Report::new(error));
+                eprintln!("{}", Report::new(error));
             }
         }
     } else {

--- a/crates/turborepo/src/main.rs
+++ b/crates/turborepo/src/main.rs
@@ -12,7 +12,7 @@ fn main() -> Result<()> {
     std::panic::set_hook(Box::new(turborepo_lib::panic_handler));
 
     let exit_code = turborepo_lib::main().unwrap_or_else(|err| {
-        eprintln!("{:?}", Report::new(err));
+        eprintln!("{}", Report::new(err));
         1
     });
 


### PR DESCRIPTION
Fix clickable file paths in VSCode by changing `miette::Report` formatting from debug to display.

VSCode mistakenly includes the `|` characters, which are part of `miette`'s debug output, in the file path, preventing it from being clickable. Switching to the display formatter removes these characters, making paths correctly recognized and clickable.

---
Linear Issue: [TURBO-4802](https://linear.app/vercel/issue/TURBO-4802/fix-clickable-file-paths-in-ui-formatting-for-vscode)

<a href="https://cursor.com/background-agent?bcId=bc-de95ebba-368c-4b6c-b92d-bac6c6359e5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-de95ebba-368c-4b6c-b92d-bac6c6359e5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

