### PR TITLE
docs: fix correct package name from eslint-config-turbo to eslint-plugin-turbo

### DIFF
--- a/docs/site/content/docs/reference/eslint-plugin-turbo.mdx
+++ b/docs/site/content/docs/reference/eslint-plugin-turbo.mdx
@@ -9,14 +9,14 @@ import { PackageManagerTabs, Tab } from '#components/tabs';
 
 ## Installation
 
-Install `eslint-config-turbo` into the location where your ESLint configuration is held:
+Install `eslint-plugin-turbo` into the location where your ESLint configuration is held:
 
 <PackageManagerTabs>
 
   <Tab value="pnpm">
 
     ```bash title="Terminal"
-    pnpm add eslint-config-turbo --filter=@repo/eslint-config
+    pnpm add eslint-plugin-turbo --filter=@repo/eslint-config
     ```
 
   </Tab>
@@ -24,7 +24,7 @@ Install `eslint-config-turbo` into the location where your ESLint configuration 
   <Tab value="yarn">
 
     ```bash title="Terminal"
-    yarn workspace @acme/eslint-config add eslint-config-turbo --dev
+    yarn workspace @acme/eslint-config add eslint-plugin-turbo --dev
     ```
 
   </Tab>
@@ -32,7 +32,7 @@ Install `eslint-config-turbo` into the location where your ESLint configuration 
   <Tab value="npm">
 
     ```bash title="Terminal"
-    npm i --save-dev eslint-config-turbo -w @acme/eslint-config
+    npm i --save-dev eslint-plugin-turbo -w @acme/eslint-config
     ```
 
   </Tab>
@@ -40,7 +40,7 @@ Install `eslint-config-turbo` into the location where your ESLint configuration 
   <Tab value="bun (Beta)">
 
     ```bash title="Terminal"
-    bun install --dev eslint-config-turbo --filter=@acme/eslint-config
+    bun install --dev eslint-plugin-turbo --filter=@acme/eslint-config
     ```
 
   </Tab>


### PR DESCRIPTION
### Description

The Installation section in the eslint-plugin-turbo docs incorrectly referenced eslint-config-turbo. This PR updates it to eslint-plugin-turbo to match the Usage example.