### PR TITLE
docs: adjust compute hours saved component initial value

### DIFF
--- a/docs/site/components/remote-cache-counter/client.tsx
+++ b/docs/site/components/remote-cache-counter/client.tsx
@@ -11,7 +11,7 @@ const counterFormatter = Intl.NumberFormat(undefined, {
 
 // A number to start the counter at that is lower than the actual time saved
 // to make the counter not start at 0
-const ARBITRARY_START_NUMBER = 240000000;
+const ARBITRARY_START_NUMBER = 240000000 / 60;
 
 export function RemoteCacheCounterClient({
   className,


### PR DESCRIPTION
Update the compute hours saved counter in the docs to start at 4,000,000 hours.

---
<a href="https://cursor.com/background-agent?bcId=bc-9876ff43-d7a2-41cf-a59b-c9e828cb2ec1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9876ff43-d7a2-41cf-a59b-c9e828cb2ec1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

