### PR TITLE
fix: adjust binary call for microfrontends proxy on Windows

### DIFF
--- a/crates/turborepo-lib/src/task_graph/visitor/command.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/command.rs
@@ -256,12 +256,15 @@ impl<'a, T: PackageInfoProvider> CommandProvider for MicroFrontendProxyProvider<
             let mut args = vec!["proxy", mfe_path.as_str(), "--names"];
             args.extend(local_apps);
 
-            // TODO: leverage package manager to find the local proxy
+            // On Windows, a package manager will rework the binary to be a .cmd extension
+            // since that's what Windows needs
             let bin_name = if cfg!(windows) {
                 "microfrontends.cmd"
             } else {
                 "microfrontends"
             };
+
+            // TODO: leverage package manager to find the local proxy
             let program = package_dir.join_components(&["node_modules", ".bin", bin_name]);
             let mut cmd = Command::new(program.as_std_path());
             cmd.current_dir(package_dir).args(args).open_stdin();


### PR DESCRIPTION
### Description

The microfrontends local development proxy fails to start on Windows because it runs into: `%1 is not a valid Win32 application`. The issue is that Turborepo runs the `.js` script and relies on the shebang to be run correctly. That doesn't work on Windows. This PR changes the code to run `node` which will work on Windows.

### Testing Instructions

In a microfrontends repository, such as https://github.com/vercel-labs/microfrontends-nextjs-app-multi-zone, run `pnpm turbo run dev` on Windows and ensure that it starts up.