### PR TITLE
docs: align tailwindcss 4 guide to the with-tailwind example 

### DIFF
--- a/docs/site/content/docs/guides/tools/tailwind.mdx
+++ b/docs/site/content/docs/guides/tools/tailwind.mdx
@@ -258,7 +258,7 @@ This `styles.css` contains component-level styles for the shared UI library.
 ```
 
 <Callout type="info">
-  Tailwind classes used in this package should be prefixed with `ui-` to avoid style specificity issues.
+  Tailwind classes used in this package should be prefixed with `ui:` to avoid style specificity issues.
 </Callout>
 
 </Tab>


### PR DESCRIPTION
### Description
Update the Tailwind v4 Guide to detect the classes used in the shared UI package.

By default Tailwind detects classes in the current working directory.

To detect classes used in the `@repo/ui` packages we need to **either** include add `@import 'tailwindcss';` in that package's `style.css` **or** add the ui package as a source.

While the former was done in the [with-tailwind example](https://github.com/vercel/turborepo/pull/10579), it can lead to duplicate classes and [conflicts](https://github.com/vercel/turborepo/pull/10657).

You can find Tailwind's documentation about this here: https://tailwindcss.com/docs/detecting-classes-in-source-files#explicitly-registering-sources.

In order for Tailwind to pick up the classes used in the `@repo/ui` package the web styles need 