### PR TITLE
feat: allow configuring custom includes for prune subcommand

### DIFF
--- a/crates/turborepo-lib/src/turbo_json/extend.rs
+++ b/crates/turborepo-lib/src/turbo_json/extend.rs
@@ -2,7 +2,7 @@
 
 use super::processed::{
     ProcessedDependsOn, ProcessedEnv, ProcessedInputs, ProcessedOutputs, ProcessedPassThroughEnv,
-    ProcessedTaskDefinition, ProcessedWith,
+    ProcessedPruneIncludes, ProcessedTaskDefinition, ProcessedWith,
 };
 
 /// Trait for types that can be merged with extends behavior
@@ -84,6 +84,14 @@ impl Extendable for ProcessedInputs {
     }
 }
 
+impl Extendable for ProcessedPruneIncludes {
+    fn extend(&mut self, other: Self) {
+        // Always extend (combine) prune includes, never replace
+        // This is different from other fields - we always want the union of patterns
+        self.globs.extend(other.globs);
+    }
+}
+
 impl FromIterator<ProcessedTaskDefinition> for ProcessedTaskDefinition {
     fn from_iter<T: IntoIterator<Item = ProcessedTaskDefinition>>(iter: T) -> Self {
         iter.into_iter()
@@ -158,8 +166,8 @@ mod test {
     use crate::{
         cli::OutputLogsMode,
         turbo_json::{
-            processed::{ProcessedEnv, ProcessedInputs, ProcessedOutputs},
             FutureFlags,
+            processed::{ProcessedEnv, ProcessedInputs, ProcessedOutputs},
         },
     };
 

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -31,7 +31,7 @@ pub mod validator;
 
 pub use future_flags::FutureFlags;
 pub use loader::{TurboJsonLoader, TurboJsonReader};
-pub use processed::ProcessedTaskDefinition;
+pub use processed::{ProcessedPruneIncludes, ProcessedTaskDefinition};
 pub use raw::{
     RawPackageTurboJson, RawRemoteCacheOptions, RawRootTurboJson, RawTaskDefinition, RawTurboJson,
 };
@@ -67,6 +67,7 @@ pub struct TurboJson {
     pub(crate) global_deps: Vec<String>,
     pub(crate) global_env: Vec<String>,
     pub(crate) global_pass_through_env: Option<Vec<String>>,
+    pub(crate) prune_includes: Option<processed::ProcessedPruneIncludes>,
     pub(crate) tasks: Pipeline,
     pub(crate) future_flags: FutureFlags,
 }
@@ -325,6 +326,13 @@ impl TryFrom<RawTurboJson> for TurboJson {
 
         let tasks = raw_turbo.tasks.clone().unwrap_or_default();
 
+        // Process prune includes
+        let prune_includes = raw_turbo
+            .prune
+            .and_then(|prune_config| prune_config.includes)
+            .map(processed::ProcessedPruneIncludes::new)
+            .transpose()?;
+
         Ok(TurboJson {
             text: raw_turbo.span.text,
             path: raw_turbo.span.path,
@@ -351,6 +359,7 @@ impl TryFrom<RawTurboJson> for TurboJson {
 
                 global_deps
             },
+            prune_includes,
             tasks,
             // copy these over, we don't need any changes here.
             extends: raw_turbo
@@ -1175,6 +1184,6 @@ mod tests {
         let deps = boundaries.dependencies.as_ref().unwrap();
         assert!(deps.allow.is_some());
         assert!(deps.deny.is_none()); // This should be None, not serialized as
-                                      // null
+        // null
     }
 }

--- a/crates/turborepo-lib/src/turbo_json/raw.rs
+++ b/crates/turborepo-lib/src/turbo_json/raw.rs
@@ -41,6 +41,14 @@ pub struct RawRemoteCacheOptions {
     pub upload_timeout: Option<Spanned<u64>>,
 }
 
+// Prune configuration
+#[derive(Serialize, Default, Debug, Clone, Iterable, Deserializable)]
+#[serde(rename_all = "camelCase")]
+pub struct RawPruneConfig {
+    #[serde(rename = "includes", skip_serializing_if = "Option::is_none")]
+    pub(crate) includes: Option<Vec<Spanned<UnescapedString>>>,
+}
+
 // Root turbo.json
 #[derive(Default, Debug, Clone, Iterable, Deserializable)]
 pub struct RawRootTurboJson {
@@ -54,6 +62,8 @@ pub struct RawRootTurboJson {
     pub(crate) global_dependencies: Option<Vec<Spanned<UnescapedString>>>,
     pub(crate) global_env: Option<Vec<Spanned<UnescapedString>>>,
     pub(crate) global_pass_through_env: Option<Vec<Spanned<UnescapedString>>>,
+    // Prune configuration
+    pub(crate) prune: Option<RawPruneConfig>,
     // Tasks is a map of task entries which define the task graph
     // and cache behavior on a per task or per package-task basis.
     pub(crate) tasks: Option<Pipeline>,
@@ -87,6 +97,7 @@ pub struct RawPackageTurboJson {
     pub(crate) pipeline: Option<Spanned<Pipeline>>,
     pub(crate) tags: Option<Spanned<Vec<Spanned<String>>>>,
     pub(crate) boundaries: Option<Spanned<BoundariesConfig>>,
+    pub(crate) prune: Option<RawPruneConfig>,
     #[deserializable(rename = "//")]
     pub(crate) _comment: Option<String>,
 }
@@ -110,6 +121,9 @@ pub struct RawTurboJson {
     pub(crate) global_env: Option<Vec<Spanned<UnescapedString>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) global_pass_through_env: Option<Vec<Spanned<UnescapedString>>>,
+    // Prune configuration
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) prune: Option<RawPruneConfig>,
     // Tasks is a map of task entries which define the task graph
     // and cache behavior on a per task or per package-task basis.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -189,6 +203,7 @@ impl From<RawRootTurboJson> for RawTurboJson {
             global_dependencies: root.global_dependencies,
             global_env: root.global_env,
             global_pass_through_env: root.global_pass_through_env,
+            prune: root.prune,
             tasks: root.tasks,
             pipeline: root.pipeline,
             remote_cache: root.remote_cache,
@@ -218,6 +233,7 @@ impl From<RawPackageTurboJson> for RawTurboJson {
             pipeline: pkg.pipeline,
             boundaries: pkg.boundaries,
             tags: pkg.tags,
+            prune: pkg.prune,
             _comment: pkg._comment,
             ..Default::default()
         }

--- a/packages/turbo-types/schemas/schema.json
+++ b/packages/turbo-types/schemas/schema.json
@@ -59,6 +59,11 @@
           "description": "An allowlist of environment variables that should be made to all tasks, but should not contribute to the task's cache key, e.g. `AWS_SECRET_KEY`.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#globalpassthroughenv",
           "default": null
         },
+        "prune": {
+          "$ref": "#/definitions/Prune",
+          "description": "Configuration for the `turbo prune` command.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#prune",
+          "default": {}
+        },
         "remoteCache": {
           "$ref": "#/definitions/RemoteCache",
           "description": "Configuration options that control how turbo interfaces with the remote cache.\n\nDocumentation: https://turborepo.com/docs/core-concepts/remote-caching",
@@ -213,6 +218,20 @@
         "errors-only",
         "none"
       ]
+    },
+    "Prune": {
+      "type": "object",
+      "properties": {
+        "includes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Additional files and directories to include in pruned output. Supports glob patterns with ! for exclusions and $TURBO_ROOT$/ for repo-relative paths. When specified in workspace configs, patterns are combined with root config patterns."
+        }
+      },
+      "additionalProperties": false,
+      "description": "Prune configuration"
     },
     "RemoteCache": {
       "type": "object",
@@ -371,6 +390,11 @@
         "boundaries": {
           "$ref": "#/definitions/BoundariesConfig",
           "description": "Configuration for `turbo boundaries` that is specific to this package"
+        },
+        "prune": {
+          "$ref": "#/definitions/Prune",
+          "description": "Configuration for the `turbo prune` command.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#prune",
+          "default": {}
         }
       },
       "required": [

--- a/packages/turbo-types/schemas/schema.v2.json
+++ b/packages/turbo-types/schemas/schema.v2.json
@@ -59,6 +59,11 @@
           "description": "An allowlist of environment variables that should be made to all tasks, but should not contribute to the task's cache key, e.g. `AWS_SECRET_KEY`.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#globalpassthroughenv",
           "default": null
         },
+        "prune": {
+          "$ref": "#/definitions/Prune",
+          "description": "Configuration for the `turbo prune` command.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#prune",
+          "default": {}
+        },
         "remoteCache": {
           "$ref": "#/definitions/RemoteCache",
           "description": "Configuration options that control how turbo interfaces with the remote cache.\n\nDocumentation: https://turborepo.com/docs/core-concepts/remote-caching",
@@ -213,6 +218,20 @@
         "errors-only",
         "none"
       ]
+    },
+    "Prune": {
+      "type": "object",
+      "properties": {
+        "includes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Additional files and directories to include in pruned output. Supports glob patterns with ! for exclusions and $TURBO_ROOT$/ for repo-relative paths. When specified in workspace configs, patterns are combined with root config patterns."
+        }
+      },
+      "additionalProperties": false,
+      "description": "Prune configuration"
     },
     "RemoteCache": {
       "type": "object",
@@ -371,6 +390,11 @@
         "boundaries": {
           "$ref": "#/definitions/BoundariesConfig",
           "description": "Configuration for `turbo boundaries` that is specific to this package"
+        },
+        "prune": {
+          "$ref": "#/definitions/Prune",
+          "description": "Configuration for the `turbo prune` command.\n\nDocumentation: https://turborepo.com/docs/reference/configuration#prune",
+          "default": {}
         }
       },
       "required": [

--- a/packages/turbo-types/src/types/config-v2.ts
+++ b/packages/turbo-types/src/types/config-v2.ts
@@ -61,6 +61,14 @@ export interface WorkspaceSchema extends BaseSchema {
    * Configuration for `turbo boundaries` that is specific to this package
    */
   boundaries?: BoundariesConfig;
+  /**
+   * Configuration for the `turbo prune` command.
+   *
+   * Documentation: https://turborepo.com/docs/reference/configuration#prune
+   *
+   * @defaultValue `{}`
+   */
+  prune?: Prune;
 }
 
 export interface RootSchema extends BaseSchema {
@@ -104,6 +112,15 @@ export interface RootSchema extends BaseSchema {
    * @defaultValue `null`
    */
   globalPassThroughEnv?: null | Array<EnvWildcard>;
+
+  /**
+   * Configuration for the `turbo prune` command.
+   *
+   * Documentation: https://turborepo.com/docs/reference/configuration#prune
+   *
+   * @defaultValue `{}`
+   */
+  prune?: Prune;
 
   /**
    * Configuration options that control how turbo interfaces with the remote cache.
@@ -464,6 +481,18 @@ export interface RootBoundariesConfig extends BoundariesConfig {
    * can import a tag and which packages a tag can import
    */
   tags?: BoundariesRulesMap;
+}
+
+/**
+ * Prune configuration
+ */
+export interface Prune {
+  /**
+   * Additional files and directories to include in pruned output.
+   * Supports glob patterns with ! for exclusions and $TURBO_ROOT$/ for repo-relative paths.
+   * When specified in workspace configs, patterns are combined with root config patterns.
+   */
+  includes?: string[];
 }
 
 export const isRootSchemaV2 = (schema: Schema): schema is RootSchema =>

--- a/turborepo-tests/integration/tests/prune/custom-includes.t
+++ b/turborepo-tests/integration/tests/prune/custom-includes.t
@@ -1,0 +1,245 @@
+Setup
+  $ . ${TESTDIR}/../../../helpers/setup_integration_test.sh monorepo_with_root_dep pnpm@7.25.1
+
+Create test files that should be included via prune.includes
+  $ echo "# Test README" > README.md
+  $ echo "MIT License" > LICENSE
+  $ mkdir -p docs
+  $ echo "# Documentation" > docs/guide.md
+  $ mkdir -p config
+  $ echo '{"env": "production"}' > config/prod.json
+  $ echo '{"env": "local"}' > config/local.json
+  $ mkdir -p shared-assets
+  $ echo "asset content" > shared-assets/logo.svg
+
+Test basic custom includes in root turbo.json
+  $ cat > turbo.json << EOF
+  > {
+  >   "\$schema": "https://turbo.build/schema.json",
+  >   "prune": {
+  >     "includes": ["README.md", "LICENSE"]
+  >   }
+  > }
+  > EOF
+
+  $ ${TURBO} prune web --docker
+  Generating pruned monorepo for web in .*out (re)
+   - Added shared
+   - Added util
+   - Added web
+
+Verify basic includes are copied to all destinations
+  $ test -f out/full/README.md
+  $ test -f out/full/LICENSE
+  $ test -f out/json/README.md
+  $ test -f out/json/LICENSE
+  $ test -f out/README.md
+  $ test -f out/LICENSE
+
+Test glob patterns with custom includes
+  $ cat > turbo.json << EOF
+  > {
+  >   "\$schema": "https://turbo.build/schema.json",
+  >   "prune": {
+  >     "includes": ["docs/**", "*.md"]
+  >   }
+  > }
+  > EOF
+
+  $ rm -rf out
+  $ ${TURBO} prune web --docker
+  Generating pruned monorepo for web in .*out (re)
+   - Added shared
+   - Added util
+   - Added web
+
+Verify glob patterns work
+  $ test -d out/full/docs
+  $ test -f out/full/docs/guide.md
+  $ test -f out/full/README.md
+
+Test exclusion patterns with negation at root level
+  $ cat > turbo.json << EOF
+  > {
+  >   "\$schema": "https://turbo.build/schema.json",
+  >   "prune": {
+  >     "includes": ["config/**", "!config/local.json"]
+  >   }
+  > }
+  > EOF
+
+  $ rm -rf out
+  $ ${TURBO} prune web --docker
+  Generating pruned monorepo for web in .*out (re)
+   - Added shared
+   - Added util
+   - Added web
+
+Verify included config files are copied
+  $ test -f out/full/config/prod.json
+
+Verify excluded config file is NOT copied
+  $ test ! -f out/full/config/local.json
+
+Verify config directory exists but excluded file is not in it
+  $ ls out/full/config
+  prod.json
+
+Verify exclusions work in all output directories
+  $ test -f out/config/prod.json
+  $ test ! -f out/config/local.json
+  $ test -f out/json/config/prod.json
+  $ test ! -f out/json/config/local.json
+
+Test multiple exclusion patterns
+  $ mkdir -p secrets
+  $ echo "secret1" > secrets/api-key.txt
+  $ echo "secret2" > secrets/password.txt
+  $ echo "not secret" > secrets/readme.txt
+  $ mkdir -p logs
+  $ echo "log data" > logs/debug.log
+  $ echo "more logs" > logs/error.log
+
+  $ cat > turbo.json << EOF
+  > {
+  >   "\$schema": "https://turbo.build/schema.json",
+  >   "prune": {
+  >     "includes": ["secrets/**", "logs/**", "!secrets/api-key.txt", "!secrets/password.txt", "!logs/*.log"]
+  >   }
+  > }
+  > EOF
+
+  $ rm -rf out
+  $ ${TURBO} prune web --docker
+  Generating pruned monorepo for web in .*out (re)
+   - Added shared
+   - Added util
+   - Added web
+
+Verify only non-excluded files are copied
+  $ test -f out/full/secrets/readme.txt
+  $ test ! -f out/full/secrets/api-key.txt
+  $ test ! -f out/full/secrets/password.txt
+  $ test ! -f out/full/logs/debug.log
+  $ test ! -f out/full/logs/error.log
+
+Test workspace-level custom includes with workspace-relative paths
+  $ mkdir -p apps/web/docs
+  $ echo "# Web App Docs" > apps/web/docs/README.md
+  $ echo "# Web README" > apps/web/README.md
+  $ echo "module.exports = {}" > apps/web/next.config.js
+  $ echo "module.exports = {}" > apps/web/tailwind.config.js
+
+Reset root turbo.json to have no custom includes
+  $ cat > turbo.json << EOF
+  > {
+  >   "\$schema": "https://turbo.build/schema.json"
+  > }
+  > EOF
+
+Add workspace-level turbo.json with custom includes
+  $ cat > apps/web/turbo.json << EOF
+  > {
+  >   "\$schema": "https://turbo.build/schema.json",
+  >   "prune": {
+  >     "includes": ["README.md", "docs/**", "*.config.js"]
+  >   }
+  > }
+  > EOF
+
+  $ rm -rf out
+  $ ${TURBO} prune web --docker
+  Generating pruned monorepo for web in .*out (re)
+   - Added shared
+   - Added util
+   - Added web
+
+Verify workspace-relative includes are properly prefixed and copied
+  $ test -f out/full/apps/web/README.md
+  $ test -d out/full/apps/web/docs
+  $ test -f out/full/apps/web/docs/README.md
+  $ test -f out/full/apps/web/next.config.js
+  $ test -f out/full/apps/web/tailwind.config.js
+  $ cat out/full/apps/web/README.md
+  # Web README
+
+Verify workspace files are also in docker output directories
+  $ test -f out/json/apps/web/README.md
+  $ test -f out/json/apps/web/next.config.js
+
+Verify workspace files are NOT copied to repo root (only in apps/web/)
+  $ test ! -f out/full/README.md
+  $ test ! -f out/full/next.config.js
+
+Test workspace-level includes with $TURBO_ROOT$ (repo-relative paths)
+  $ cat > apps/web/turbo.json << EOF
+  > {
+  >   "\$schema": "https://turbo.build/schema.json",
+  >   "prune": {
+  >     "includes": ["\$TURBO_ROOT\$/shared-assets/**"]
+  >   }
+  > }
+  > EOF
+
+  $ rm -rf out
+  $ ${TURBO} prune web --docker
+  Generating pruned monorepo for web in .*out (re)
+   - Added shared
+   - Added util
+   - Added web
+
+Verify $TURBO_ROOT$ patterns work from workspace configs
+  $ test -d out/full/shared-assets
+  $ test -f out/full/shared-assets/logo.svg
+
+Test mixed workspace and root includes
+  $ cat > turbo.json << EOF
+  > {
+  >   "\$schema": "https://turbo.build/schema.json",
+  >   "prune": {
+  >     "includes": ["LICENSE"]
+  >   }
+  > }
+  > EOF
+
+  $ cat > apps/web/turbo.json << EOF
+  > {
+  >   "\$schema": "https://turbo.build/schema.json",
+  >   "prune": {
+  >     "includes": ["README.md"]
+  >   }
+  > }
+  > EOF
+
+  $ rm -rf out
+  $ ${TURBO} prune web --docker
+  Generating pruned monorepo for web in .*out (re)
+   - Added shared
+   - Added util
+   - Added web
+
+Verify both root and workspace includes are applied
+  $ test -f out/full/LICENSE
+  $ test -f out/full/apps/web/README.md
+
+Test without docker mode
+  $ cat > turbo.json << EOF
+  > {
+  >   "\$schema": "https://turbo.build/schema.json",
+  >   "prune": {
+  >     "includes": ["README.md"]
+  >   }
+  > }
+  > EOF
+
+  $ rm -rf out
+  $ ${TURBO} prune web
+  Generating pruned monorepo for web in .*out (re)
+   - Added shared
+   - Added util
+   - Added web
+
+Verify files are copied when not in docker mode
+  $ test -f out/README.md
+  $ test ! -d out/json
+  $ test ! -d out/full


### PR DESCRIPTION
### Description

Extended `turbo prune` command and `turbo.json` config, so it's possible to specify additional fields that need to be copied during the prune operation. For example, it's possible to specify in the top-level `turbo.json`:
```json
"prune": {
  "includes": ["**/README.md", "$TURBO_ROOT$/lib/shared-library/example.file"]
}
```
so that `README.md` of all pruned workspaces should be copied and if `shared-library` is part of the prunned tree, `shared-library/example.file` will also be copied.


It should also be possible to specify prune includes in the workspace-level `turbo.json`:
```json
"prune": {
  "includes": ["example.file"]
}
```
Here the `includes` supports workspace-relative paths.

**Motivation for this change**
I have a use-case, where some of my workspaces have `postinstall` script performing some additional, required operations for a successful installation. By definition, `postinstall` is invoked directly after `yarn/npm/pnpm install`. I use `turbo prune --docker`, so before I can invoke install I need to manually copy relevant files first. While that works at a smaller scale, when this `postinstall` script is part of a shared library used by many apps/other libraries in the monorepo, every `Dockerfile` needs to manually copy these required files, which is annoying. Being able to configure that once in the `turbo.json` simplifies that use-case.

Related discussion: https://github.com/vercel/turborepo/discussions/7464

### Testing Instructions

- I've added new unit tests validating the expected behavior of individual functions
- I've added a couple of integration tests for this new option
