### PR TITLE
docs: clarify passthrough args comparison

### DIFF
--- a/docs/site/content/docs/crafting-your-repository/caching.mdx
+++ b/docs/site/content/docs/crafting-your-repository/caching.mdx
@@ -169,7 +169,7 @@ Under the hood, Turborepo creates two hashes: a global hash and a task hash. If 
 | [`globalDependencies`](/docs/reference/configuration#globaldependencies) file contents | Changing `./.env` when it is listed in `globalDependencies` will cause **all** tasks to miss cache                                                         |
 | Values of variables listed in [`globalEnv`](/docs/reference/configuration#globalenv)   | Changing the value of `GITHUB_TOKEN` when it is listed in `globalEnv`                                                                                      |
 | Flag values that affect task runtime                                                   | Using behavior-changing flags like `--cache-dir`, `--framework-inference`, or `--env-mode`                                                                 |
-| Arbitrary passthrough arguments                                                        | `turbo build -- --arg=value` will miss cache compared to either `turbo build` or `turbo build -- --arg=diff`                                                      |
+| Arbitrary passthrough arguments                                                        | `turbo build -- --arg=value` will miss cache when compared to either `turbo build` or `turbo build -- --arg=diff`                                                      |
 
 ### Package hash inputs
 


### PR DESCRIPTION
### Description

The current docs for global hash inputs made me think that _any_ passthrough arg would invalidate the cache when present. Stupid, I know. But I read it several times and just could not parse the meaning correctly.

The suggested fix would hopefully make it clear that the different examples are compared to the output of the first command.