### PR TITLE
fix: windows symlinking bug

### DIFF
--- a/crates/turborepo-lib/src/shim/local_turbo_state.rs
+++ b/crates/turborepo-lib/src/shim/local_turbo_state.rs
@@ -178,6 +178,8 @@ impl LocalTurboState {
                         PackageJson::load(&resolved_package_json_path).ok()?;
                     let local_version = platform_package_json.version?;
 
+                    debug!("Local turbo path: {}", bin_path.display());
+                    debug!("Local turbo version: {}", &local_version);
                     return Some(Self {
                         bin_path,
                         version: local_version,


### PR DESCRIPTION
## Description

This fixes a symlinking bug that can happen on Windows. `fs_canonicalize` can fail, even when the symlink is valid, due to permissions errors. That means we have to retry to find the path an extra time, to see if the symlink target really is there for us to use.

We do this by handling the error that `canonical_path.parent()` can produce and, in the case that we're on Windows, using `fs::read_link()`, which doesn't run into the same permissions errors. From there, we know where the symlink target is, so we use it to construct the desired path.

Therefore, the only behavioral change should be:
1. On Windows
2. No longer error on a symlink when the target is actually present

In any other case, the original `None` value is returned, like we would have gotten before this PR.

## Testing

Windows CI started failing (still haven't figured out why) because of this issue. You can see me trying to debug with extensive logging until I finally found the permissions issue that was being bubbled up in some logs.