### PR TITLE
chore(with-docker/Dockerfile): Some improvements

### DIFF
--- a/docs/site/content/docs/guides/tools/docker.mdx
+++ b/docs/site/content/docs/guides/tools/docker.mdx
@@ -142,48 +142,51 @@ docker build -f apps/web/Dockerfile .
 
 ```docker title="./apps/web/Dockerfile"
 FROM node:18-alpine AS base
-
-FROM base AS builder
 RUN apk update
 RUN apk add --no-cache libc6-compat
 # Set working directory
 WORKDIR /app
+
+# ---
+FROM base AS prepare
 # Replace <your-major-version> with the major version installed in your repository. For example:
 # RUN yarn global add turbo@^2
 RUN yarn global add turbo@^<your-major-version>
 COPY . .
-
+# Add lockfile and package.json's of isolated subworkspace
 # Generate a partial monorepo with a pruned lockfile for a target workspace.
 # Assuming "web" is the name entered in the project's package.json: { name: "web" }
 RUN turbo prune web --docker
 
-# Add lockfile and package.json's of isolated subworkspace
-FROM base AS installer
-RUN apk update
-RUN apk add --no-cache libc6-compat
-WORKDIR /app
-
+# ---
+FROM base AS builder
 # First install the dependencies (as they change less often)
-COPY --from=builder /app/out/json/ .
-RUN yarn install --frozen-lockfile
-
+COPY --from=prepare /app/out/json/ .
+RUN yarn install
 # Build the project
-COPY --from=builder /app/out/full/ .
-RUN yarn turbo run build
+COPY --from=prepare /app/out/full/ .
 
+# Uncomment and use build args to enable remote caching
+# ARG TURBO_TEAM
+# ENV TURBO_TEAM=$TURBO_TEAM
+
+# ARG TURBO_TOKEN
+# ENV TURBO_TOKEN=$TURBO_TOKEN
+
+RUN yarn turbo build
+
+# ---
 FROM base AS runner
-WORKDIR /app
-
-# Don't run production as root
+# Don't run production as root for security reasons
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 USER nextjs
 
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=installer --chown=nextjs:nodejs /app/apps/web/.next/standalone ./
-COPY --from=installer --chown=nextjs:nodejs /app/apps/web/.next/static ./apps/web/.next/static
-COPY --from=installer --chown=nextjs:nodejs /app/apps/web/public ./apps/web/public
+COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/static ./apps/web/.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/apps/web/public ./apps/web/public
 
 CMD node apps/web/server.js
 ```

--- a/examples/with-docker/apps/web/Dockerfile
+++ b/examples/with-docker/apps/web/Dockerfile
@@ -1,4 +1,8 @@
 FROM node:18-alpine AS base
+
+# This Dockerfile is copy-pasted into our main docs at /docs/handbook/deploying-with-docker.
+# Make sure you update both files!
+
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk update
 RUN apk add --no-cache libc6-compat
@@ -6,7 +10,7 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # ---
-FROM base AS initiator
+FROM base AS prepare
 RUN yarn global add turbo
 COPY . .
 # Add lockfile and package.json's of isolated subworkspace
@@ -15,10 +19,10 @@ RUN turbo prune web --docker
 # ---
 FROM base AS builder
 # First install the dependencies (as they change less often)
-COPY --from=initiator /app/out/json/ .
+COPY --from=prepare /app/out/json/ .
 RUN yarn install
 # Build the project
-COPY --from=initiator /app/out/full/ .
+COPY --from=prepare /app/out/full/ .
 
 # Uncomment and use build args to enable remote caching
 # ARG TURBO_TEAM


### PR DESCRIPTION
### Description

I (think I) improved the Dockerfile of the web in the example "with-docker".

1. The "base" image install `libc6-compat` once only
2. The "base" image set the workspace to `/app` once only 
3. The "builder" image, which was doing the `prune` is renamed to "initiator" because, you know, **it doesn't build the app...**
4. The "installer" image, which was doing the `build` is renamed to "builder" because, you know, **it builds the app...**
5. A deprecated comment (I think) has been removed. But correct me, I am probably wrong

### Testing Instructions

```
docker build -f apps/web/Dockerfile -t "awesome" .
```
