### PR TITLE
ci: conventional commits adjustment

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -16,18 +16,34 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          # Configure which types are allowed (newline-delimited).
+          types: |
+            fix
+            feat
+            chore
+            ci
+            docs
+            refactor
+            perf
+            test
+            style
+            examples
           # Configure that a scope must always be provided.
           requireScope: false
+          # Configure which scopes are disallowed in PR titles (newline-delimited).
+          disallowScopes: |
+            examples
+            example
           # Configure additional validation for the subject based on a regex.
-          # Ensures that the subject doesn't start with an uppercase character.
-          subjectPattern: ^[^A-Z].*$
+          # Ensures that the subject starts with an uppercase character.
+          subjectPattern: ^[A-Z].*$
           # If `subjectPattern` is configured, you can use this property to override
           # the default error message that is shown when the pattern doesn't match.
           # The variables `subject` and `title` can be used within the message.
           subjectPatternError: |
             The subject "{subject}" found in the pull request title "{title}" doesn't match the configured pattern.
-            Please ensure that the subject doesn't start with an uppercase character.
+            Please ensure that the subject starts with an uppercase character.


### PR DESCRIPTION
### Description

Updating our conventional commits strategy to make things slightly more strict. This helps with things like generating blog post details, readability of changelog notes, and a few more chore-like tasks.
