### PR TITLE
fix: Labels for k + j backwards in binds list

### DIFF
--- a/crates/turborepo-ui/src/tui/popup.rs
+++ b/crates/turborepo-ui/src/tui/popup.rs
@@ -8,8 +8,8 @@ use ratatui::{
 
 const BIND_LIST: &[&str] = [
     "m       - Toggle this help popup",
-    "↑ or j  - Select previous task",
-    "↓ or k  - Select next task",
+    "↑ or k  - Select previous task",
+    "↓ or j  - Select next task",
     "h       - Toggle task list",
     "p       - Toggle pinned task selection",
     "/       - Filter tasks to search term",


### PR DESCRIPTION
### Description
Fixed `k` and `j` being around the wrong way in binds list for popup.

### Testing Instructions

Check binds list for correct labels.
