### PR TITLE
examples: Remove redundant border declaration

### DIFF
--- a/examples/basic/apps/docs/app/page.module.css
+++ b/examples/basic/apps/docs/app/page.module.css
@@ -66,7 +66,6 @@
   border-radius: 128px;
   height: 48px;
   padding: 0 20px;
-  border: none;
   font-family: var(--font-geist-sans);
   border: 1px solid transparent;
   transition: background 0.2s, color 0.2s, border-color 0.2s;
@@ -95,7 +94,6 @@ button.secondary {
   border-radius: 128px;
   height: 48px;
   padding: 0 20px;
-  border: none;
   font-family: var(--font-geist-sans);
   border: 1px solid transparent;
   transition: background 0.2s, color 0.2s, border-color 0.2s;

--- a/examples/basic/apps/web/app/page.module.css
+++ b/examples/basic/apps/web/app/page.module.css
@@ -66,7 +66,6 @@
   border-radius: 128px;
   height: 48px;
   padding: 0 20px;
-  border: none;
   font-family: var(--font-geist-sans);
   border: 1px solid transparent;
   transition: background 0.2s, color 0.2s, border-color 0.2s;
@@ -95,7 +94,6 @@ button.secondary {
   border-radius: 128px;
   height: 48px;
   padding: 0 20px;
-  border: none;
   font-family: var(--font-geist-sans);
   border: 1px solid transparent;
   transition: background 0.2s, color 0.2s, border-color 0.2s;

--- a/examples/with-microfrontends/apps/docs/app/page.module.css
+++ b/examples/with-microfrontends/apps/docs/app/page.module.css
@@ -66,7 +66,6 @@
   border-radius: 128px;
   height: 48px;
   padding: 0 20px;
-  border: none;
   font-family: var(--font-geist-sans);
   border: 1px solid transparent;
   transition: background 0.2s, color 0.2s, border-color 0.2s;
@@ -95,7 +94,6 @@ button.secondary {
   border-radius: 128px;
   height: 48px;
   padding: 0 20px;
-  border: none;
   font-family: var(--font-geist-sans);
   border: 1px solid transparent;
   transition: background 0.2s, color 0.2s, border-color 0.2s;

--- a/examples/with-microfrontends/apps/web/app/page.module.css
+++ b/examples/with-microfrontends/apps/web/app/page.module.css
@@ -66,7 +66,6 @@
   border-radius: 128px;
   height: 48px;
   padding: 0 20px;
-  border: none;
   font-family: var(--font-geist-sans);
   border: 1px solid transparent;
   transition: background 0.2s, color 0.2s, border-color 0.2s;
@@ -95,7 +94,6 @@ button.secondary {
   border-radius: 128px;
   height: 48px;
   padding: 0 20px;
-  border: none;
   font-family: var(--font-geist-sans);
   border: 1px solid transparent;
   transition: background 0.2s, color 0.2s, border-color 0.2s;

--- a/examples/with-nestjs/apps/web/app/page.module.css
+++ b/examples/with-nestjs/apps/web/app/page.module.css
@@ -66,7 +66,6 @@
   border-radius: 128px;
   height: 48px;
   padding: 0 20px;
-  border: none;
   font-family: var(--font-geist-sans);
   border: 1px solid transparent;
   transition: background 0.2s, color 0.2s, border-color 0.2s;
@@ -95,7 +94,6 @@ button.secondary {
   border-radius: 128px;
   height: 48px;
   padding: 0 20px;
-  border: none;
   font-family: var(--font-geist-sans);
   border: 1px solid transparent;
   transition: background 0.2s, color 0.2s, border-color 0.2s;

--- a/examples/with-vitest/apps/docs/app/page.module.css
+++ b/examples/with-vitest/apps/docs/app/page.module.css
@@ -66,7 +66,6 @@
   border-radius: 128px;
   height: 48px;
   padding: 0 20px;
-  border: none;
   font-family: var(--font-geist-sans);
   border: 1px solid transparent;
   transition: background 0.2s, color 0.2s, border-color 0.2s;
@@ -95,7 +94,6 @@ button.secondary {
   border-radius: 128px;
   height: 48px;
   padding: 0 20px;
-  border: none;
   font-family: var(--font-geist-sans);
   border: 1px solid transparent;
   transition: background 0.2s, color 0.2s, border-color 0.2s;

--- a/examples/with-vitest/apps/web/app/page.module.css
+++ b/examples/with-vitest/apps/web/app/page.module.css
@@ -66,7 +66,6 @@
   border-radius: 128px;
   height: 48px;
   padding: 0 20px;
-  border: none;
   font-family: var(--font-geist-sans);
   border: 1px solid transparent;
   transition: background 0.2s, color 0.2s, border-color 0.2s;
@@ -95,7 +94,6 @@ button.secondary {
   border-radius: 128px;
   height: 48px;
   padding: 0 20px;
-  border: none;
   font-family: var(--font-geist-sans);
   border: 1px solid transparent;
   transition: background 0.2s, color 0.2s, border-color 0.2s;


### PR DESCRIPTION
This PR removes a **redundant CSS border declaration**

Previously, both `border: none;` and `border: 1px solid transparent;` were declared in sequence.  
Since the second declaration fully overrides the first, the `border: none;` rule was unnecessary and triggered Biome's `noDuplicateDeclarations` lint warning.

By keeping only `border: 1px solid transparent;`, we ensure:

- clean and intentional styling
- preserved layout stability for hover/focus states
- improved lint compliance and maintainability

---

### Changes

- Removed duplicate `border: none;` rule
- Retained `border: 1px solid transparent;` for layout consistency
- Ensured alignment with Biome linting rules

---

### Motivation

The first border declaration provided no functional benefit, as it was immediately overridden.  
This cleanup improves clarity, prevents false-positive lint issues, and aligns with best practices for CSS resets and UI consistency.

---

### Breaking Changes

None — visual and functional behavior remains identical.
