### PR TITLE
ci: Update macOS runners to latest

### DIFF
--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -15,10 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-13
+          - host: macos-latest
             target: "x86_64-apple-darwin"
             container-options: "--rm"
-          - host: macos-13
+          - host: macos-latest
             target: "aarch64-apple-darwin"
             container-options: "--rm"
           - host: ubuntu-latest

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -32,7 +32,7 @@ jobs:
           - name: ubuntu
             runner: ubuntu-latest
           - name: macos
-            runner: macos-13
+            runner: macos-latest
         node-version:
           - 18
           - 20

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -116,7 +116,7 @@ jobs:
       matrix:
         os:
           - runner: ubuntu-latest
-          - runner: macos-13
+          - runner: macos-latest
           - runner: windows-latest
     steps:
       # On Windows, set autocrlf to input so that when the repo is cloned down
@@ -264,7 +264,7 @@ jobs:
           - name: ubuntu
             runner: ubuntu-latest
           - name: macos
-            runner: macos-13
+            runner: macos-latest
           - name: windows
             runner: windows-latest
     runs-on: ${{ matrix.os.runner }}


### PR DESCRIPTION
### Description

[macOS runners are soon to be deprecated](https://github.com/actions/runner-images/issues/13046), so updating them.

### Testing Instructions

CI
