### PR TITLE
fix(prune): Add bunfig.toml to list of copied files

### DIFF
--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -66,6 +66,10 @@ lazy_static! {
             RelativeUnixPath::new(".yarnrc.yml").unwrap(),
             Some(CopyDestination::Docker)
         ),
+        (
+            RelativeUnixPath::new("bunfig.toml").unwrap(),
+            Some(CopyDestination::Docker)
+        ),
     ];
     static ref ADDITIONAL_DIRECTORIES: Vec<(&'static RelativeUnixPath, Option<CopyDestination>)> = vec![
         (


### PR DESCRIPTION
`bunfig.toml` can contain settings that control the package installation process under `install.*` https://bun.com/docs/runtime/bunfig#package-manager