### PR TITLE
fix: Improve determinism for graceful shutdown

### DIFF
--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -448,6 +448,7 @@ impl Child {
                 shutdown_initiated: false,
             };
             tokio::select! {
+                biased;
                 command = command_rx.recv() => {
                     manager.shutdown_initiated = true;
                     manager.handle_child_command(command, &mut child, controller).await;


### PR DESCRIPTION
### Description

My theory is we have a race condition when `child.stop()` is called and child process exist quickly. We process the SIGINT in this `tokio::select`. Depending on which branch of the select the branch goes down, you could get the wrong behavior (KilledExternal instead of Interrupted).

`biased;` gives us determinism for this situation.

### Testing Instructions

CI

<sub>CLOSES TURBO-4946</sub>