### PR TITLE
docs: Fix grammatical mistake on structuring-a-repository.mdx

### DIFF
--- a/docs/site/content/docs/crafting-your-repository/structuring-a-repository.mdx
+++ b/docs/site/content/docs/crafting-your-repository/structuring-a-repository.mdx
@@ -410,7 +410,7 @@ You may be more familiar with TypeScript's `compilerOptions#paths` option, which
 
 ### Source code
 
-Of course, you'll want some source code in your package. Packages commonly use an `src` directory to store their source code and compile to a `dist` directory (that should also be located within the package), although this is not a requirement.
+Of course, you'll want some source code in your package. Packages commonly use a `src` directory to store their source code and compile to a `dist` directory (that should also be located within the package), although this is not a requirement.
 
 ## Common pitfalls
 


### PR DESCRIPTION
### Description
Fixed a small typo in the documentation that I discovered while reading this morning. Sorry for annoyingly small typo correcting PR! Love this tool BTW <3