### PR TITLE
feat(tui): Add padding to task names and icons

### DIFF
--- a/crates/turborepo-ui/src/tui/table.rs
+++ b/crates/turborepo-ui/src/tui/table.rs
@@ -44,7 +44,8 @@ impl<'b> TaskTable<'b> {
             .max()
             .unwrap_or_default()
             .clamp(min_width, 40) as u16;
-        // Add space for leading space, status emoji, trailing space, and space before task name
+        // Add space for leading space, status emoji, trailing space, and space before
+        // task name
         task_name_width + 4
     }
 


### PR DESCRIPTION
### Description

Rework spacing now that #10726 gave us a full background highlight.

### Testing Instructions

<img width="720" height="684" alt="CleanShot 2025-11-11 at 14 04 19@2x" src="https://github.com/user-attachments/assets/4ca48c2d-a219-4a1c-83ff-d2ce99e334d3" />

