### PR TITLE
fix(workspaces): Use `shell` option on Windows in `execa` call

### DIFF
--- a/packages/turbo-workspaces/src/install.ts
+++ b/packages/turbo-workspaces/src/install.ts
@@ -127,6 +127,8 @@ export async function install(args: InstallArgs) {
     try {
       await execa(packageManager.command, packageManager.installArgs, {
         cwd: args.project.paths.root,
+        preferLocal: true,
+        shell: process.platform === "win32",
       });
       if (spinner) {
         spinner.stop();

--- a/packages/turbo-workspaces/src/managers/pnpm.ts
+++ b/packages/turbo-workspaces/src/managers/pnpm.ts
@@ -240,6 +240,8 @@ async function convertLock(args: ConvertArgs): Promise<void> {
         await execa(PACKAGE_MANAGER_DETAILS.name, ["import"], {
           stdio: "ignore",
           cwd: project.paths.root,
+          preferLocal: true,
+          shell: process.platform === "win32",
         });
       } catch (err) {
         // do nothing

--- a/packages/turbo-workspaces/src/utils.ts
+++ b/packages/turbo-workspaces/src/utils.ts
@@ -276,6 +276,8 @@ async function bunLockToYarnLock({
       const { stdout } = await execa("bun", ["bun.lockb"], {
         stdin: "ignore",
         cwd: project.paths.root,
+        preferLocal: true,
+        shell: process.platform === "win32",
       });
       // write the yarn lockfile
       await writeFile(path.join(project.paths.root, "yarn.lock"), stdout);


### PR DESCRIPTION
## Summary

Addresses #11035 by adding `preferLocal` and `shell` options to `execa` calls for package manager commands. This resolves the "no package.json found" error that occurs when using Bun installed via bash installer on Windows.

When Bun is installed via `curl -fsSL https://bun.sh/install | bash`, it's placed in a Unix-style PATH that Node.js can't access without shell context. Using `shell: true` on Windows allows the shell to resolve these commands properly.

## Test Results

CI and canarying to be verified on Windows.