### PR TITLE
ci: allow passing specific sha in release action

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -52,12 +52,18 @@ on:
         required: false
         type: string
         default: ""
-
+      sha:
+        description: "Override the SHA to use for the release. Should rarely be used, usually only for debugging."
+        required: false
+        type: string
+        default: ""
 jobs:
   stage:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha || github.sha }}
       - uses: ./.github/actions/setup-node
         with:
           enable-corepack: false


### PR DESCRIPTION
### Description

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->
Allows for passing in a commit sha to the release action to run a point-in-time release.

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->
