### PR TITLE
ci(fix): Fix flaky macOS tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,7 +6,17 @@
 # and timing issues, especially on macOS where PTY devices are limited
 turborepo-process-serial = { max-threads = 1 }
 
+# Integration tests that spawn turbo binaries should run serially to avoid
+# race conditions with binary detection and stdout/stderr capture
+turborepo-integration-serial = { max-threads = 1 }
+
 [[profile.default.overrides]]
 # Run all tests in the turborepo-process crate serially
 filter = 'package(turborepo-process)'
 test-group = 'turborepo-process-serial'
+
+[[profile.default.overrides]]
+# Run integration tests that use check_json_output! serially
+# These tests spawn turbo processes and parse JSON from stdout
+filter = 'package(turbo) and (test(boundaries) or test(query) or test(ls))'
+test-group = 'turborepo-integration-serial'


### PR DESCRIPTION
### Description

Some tests are flaky on macOS. Choosing to run them serially to see if they stop flaking.

This likely only masks a root cause(s) that we should investigate further in the future.

### Testing Instructions

CI

<sub>CLOSES TURBO-4963</sub>