### PR TITLE
examples(with-nestjs): Add missing eslint devDependency

### DIFF
--- a/examples/with-nestjs/apps/api/package.json
+++ b/examples/with-nestjs/apps/api/package.json
@@ -33,6 +33,7 @@
     "@types/express": "^4.17.17",
     "@types/node": "^22.10.7",
     "@types/supertest": "^6.0.0",
+    "eslint": "^9.31.0",
     "jest": "^29.7.0",
     "source-map-support": "^0.5.21",
     "supertest": "^7.0.0",

--- a/examples/with-nestjs/pnpm-lock.yaml
+++ b/examples/with-nestjs/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@types/supertest':
         specifier: ^6.0.0
         version: 6.0.3
+      eslint:
+        specifier: ^9.31.0
+        version: 9.39.1
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.19.0)(ts-node@10.9.2)


### PR DESCRIPTION
### Description

  Adds `eslint` as a devDependency to the `with-nestjs` example's API package.

  The API package in the with-nestjs example uses ESLint for linting but was missing it in `devDependencies`. This could cause issues for users trying to run
   the example, as ESLint-related scripts or configurations would fail without the dependency installed.

  **Changes:**
  - Added `eslint: ^9.31.0` to `devDependencies` in `examples/with-nestjs/apps/api/package.json`
  
  
  **AS-IS**
<img width="611" height="347" alt="스크린샷 2025-11-19 오후 12 25 08" src="https://github.com/user-attachments/assets/a5d2f638-0e41-42a1-aadb-7e09412d8faa" />
