### PR TITLE
docs: Fix typo in tailwind set up guide

### DIFF
--- a/docs/site/content/docs/guides/tools/tailwind.mdx
+++ b/docs/site/content/docs/guides/tools/tailwind.mdx
@@ -11,7 +11,7 @@ import { Steps, Step } from '#components/steps';
 
 ## Quickstart
 
-If you'd rather use a template, this guide is walking throw how to build [this Tailwind CSS + Turborepo template](https://github.com/vercel/turborepo/tree/main/examples/with-tailwind).
+If you'd rather use a template, this guide is walking through how to build [this Tailwind CSS + Turborepo template](https://github.com/vercel/turborepo/tree/main/examples/with-tailwind).
 
 <PackageManagerTabs>
 


### PR DESCRIPTION
### Description

Fixed a small typo while reading the setup guide for tailwind turbo. I referred [the page for storybook](https://turborepo.com/docs/guides/tools/storybook#quickstart). Thank You! 
