### PR TITLE
docs: Update Prisma integration guide link

### DIFF
--- a/docs/site/content/docs/guides/tools/prisma.mdx
+++ b/docs/site/content/docs/guides/tools/prisma.mdx
@@ -10,7 +10,7 @@ import { CreateTurboCallout } from './create-turbo-callout.tsx';
 
 [Prisma](https://www.prisma.io/) unlocks a new level of developer experience when working with databases thanks to its intuitive data model, automated migrations, type-safety & auto-completion.
 
-[Their official guide](https://www.prisma.io/docs/guides/using-prisma-orm-with-turborepo#1-create-your-monorepo-using-turborepo) describes how to integrate Prisma into a Turborepo, including:
+[Their official guide](https://www.prisma.io/docs/guides/turborepo) describes how to integrate Prisma into a Turborepo, including:
 
 - Prisma client initialization
 - Packaging the client as an [Internal Package](/docs/core-concepts/internal-packages)


### PR DESCRIPTION
Fixes outdated Prisma link

### Description

This PR Implements a small fix to an anchor where it redirects to an outdated [prisma doc](https://www.prisma.io/docs/guides/using-prisma-orm-with-turborepo#1-create-your-monorepo-using-turborepo). Now it uses the correct [url](https://www.prisma.io/docs/guides/turborepo)
Attached img of current broken redirect
<img width="766" height="483" alt="image" src="https://github.com/user-attachments/assets/c599bb53-2d1c-4394-89fb-20675379a1a7" />

