### PR TITLE
examples(kitchen-sink): Use simpler eslint config for kitchen-sink

### DIFF
--- a/examples/kitchen-sink/packages/config-eslint/index.js
+++ b/examples/kitchen-sink/packages/config-eslint/index.js
@@ -1,4 +1,5 @@
 import js from "@eslint/js";
+import { defineConfig, globalIgnores } from "eslint/config";
 import eslintConfigPrettier from "eslint-config-prettier";
 import turboPlugin from "eslint-plugin-turbo";
 import tseslint from "typescript-eslint";
@@ -6,13 +7,12 @@ import onlyWarn from "eslint-plugin-only-warn";
 
 /**
  * A shared ESLint configuration for the repository.
- *
- * @type {import("eslint").Linter.Config}
- * */
-export const config = [
+ */
+export const config = defineConfig(
+  globalIgnores(["dist/**"]),
   js.configs.recommended,
   eslintConfigPrettier,
-  ...tseslint.configs.recommended,
+  tseslint.configs.recommended,
   {
     plugins: {
       turbo: turboPlugin,
@@ -25,8 +25,5 @@ export const config = [
     plugins: {
       onlyWarn,
     },
-  },
-  {
-    ignores: ["dist/**"],
-  },
-];
+  }
+);

--- a/examples/kitchen-sink/packages/config-eslint/next.js
+++ b/examples/kitchen-sink/packages/config-eslint/next.js
@@ -1,23 +1,12 @@
-import js from "@eslint/js";
-import { globalIgnores } from "eslint/config";
-import eslintConfigPrettier from "eslint-config-prettier";
-import tseslint from "typescript-eslint";
-import pluginReactHooks from "eslint-plugin-react-hooks";
-import pluginReact from "eslint-plugin-react";
-import globals from "globals";
+import { defineConfig, globalIgnores } from "eslint/config";
 import pluginNext from "@next/eslint-plugin-next";
-import { config as baseConfig } from "./index.js";
+import { config as reactConfig } from "./react.js";
 
 /**
  * A custom ESLint configuration for libraries that use Next.js.
- *
- * @type {import("eslint").Linter.Config}
- * */
-export const config = [
-  ...baseConfig,
-  js.configs.recommended,
-  eslintConfigPrettier,
-  ...tseslint.configs.recommended,
+ */
+export const config = defineConfig(
+  reactConfig,
   globalIgnores([
     // Default ignores of eslint-config-next:
     ".next/**",
@@ -25,33 +14,5 @@ export const config = [
     "build/**",
     "next-env.d.ts",
   ]),
-  {
-    ...pluginReact.configs.flat.recommended,
-    languageOptions: {
-      ...pluginReact.configs.flat.recommended.languageOptions,
-      globals: {
-        ...globals.serviceworker,
-      },
-    },
-  },
-  {
-    plugins: {
-      "@next/next": pluginNext,
-    },
-    rules: {
-      ...pluginNext.configs.recommended.rules,
-      ...pluginNext.configs["core-web-vitals"].rules,
-    },
-  },
-  {
-    plugins: {
-      "react-hooks": pluginReactHooks,
-    },
-    settings: { react: { version: "detect" } },
-    rules: {
-      ...pluginReactHooks.configs.recommended.rules,
-      // React scope no longer necessary with new JSX transform.
-      "react/react-in-jsx-scope": "off",
-    },
-  },
-];
+  pluginNext.flatConfig.coreWebVitals
+);

--- a/examples/kitchen-sink/packages/config-eslint/package.json
+++ b/examples/kitchen-sink/packages/config-eslint/package.json
@@ -17,7 +17,7 @@
     "eslint-config-prettier": "^10.1.1",
     "eslint-plugin-only-warn": "^1.1.0",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-turbo": "^2.6.0",
     "globals": "^16.5.0",
     "typescript": "^5.9.3",

--- a/examples/kitchen-sink/packages/config-eslint/react.js
+++ b/examples/kitchen-sink/packages/config-eslint/react.js
@@ -1,6 +1,3 @@
-import js from "@eslint/js";
-import eslintConfigPrettier from "eslint-config-prettier";
-import tseslint from "typescript-eslint";
 import pluginReactHooks from "eslint-plugin-react-hooks";
 import pluginReact from "eslint-plugin-react";
 import globals from "globals";
@@ -8,14 +5,11 @@ import { config as baseConfig } from "./index.js";
 
 /**
  * A custom ESLint configuration for libraries that use React.
- *
- * @type {import("eslint").Linter.Config} */
+ */
 export const config = [
   ...baseConfig,
-  js.configs.recommended,
-  eslintConfigPrettier,
-  ...tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
+  pluginReact.configs.flat["jsx-runtime"],
   {
     languageOptions: {
       ...pluginReact.configs.flat.recommended.languageOptions,
@@ -25,15 +19,5 @@ export const config = [
       },
     },
   },
-  {
-    plugins: {
-      "react-hooks": pluginReactHooks,
-    },
-    settings: { react: { version: "detect" } },
-    rules: {
-      ...pluginReactHooks.configs.recommended.rules,
-      // React scope no longer necessary with new JSX transform.
-      "react/react-in-jsx-scope": "off",
-    },
-  },
+  pluginReactHooks.configs.flat.recommended,
 ];


### PR DESCRIPTION
### Description

I've simplified the eslint config for next.js in the kitchen-sink example

### Testing Instructions

Personally, I just ran `pnpm install` within the kitchen-sink directory followed by `pnpm lint`
