### PR TITLE
fix: Validate missing <cwd-path> argument in test-codemod server script

### DIFF
--- a/scripts/server.js
+++ b/scripts/server.js
@@ -5,6 +5,12 @@ const { platform } = require("process");
 
 const path = process.argv[2];
 
+if (!path) {
+  console.error("Error: Missing required argument <cwd-path>.");
+  console.error("Usage: node server.js <path-to-project>");
+  process.exit(1);
+}
+
 async function main() {
   let errored = false;
 


### PR DESCRIPTION
Adds a simple validation to scripts/test-codemod/server.js to handle the case where the required <cwd-path> argument is missing. This prevents unclear spawn() errors and provides a clear usage message instead.

Testing Instructions:

Run node scripts/test-codemod/server.js → should show a clear missing-argument error.
Run with a valid path → script should behave normally.

Fixes #11165