### PR TITLE
fix: add argument validation to server.js script (#11165)fix: add argument validation to server.js script

### DIFF
--- a/scripts/server.js
+++ b/scripts/server.js
@@ -6,6 +6,19 @@ const { platform } = require("process");
 const path = process.argv[2];
 
 async function main() {
+  // Validate that a path argument was provided
+  if (!path) {
+    console.error("Error: Missing required path argument.");
+    console.error("");
+    console.error("Usage: node scripts/server.js <path-to-project>");
+    console.error("");
+    console.error("Example: node scripts/server.js ./test-codemod");
+    console.error("");
+    console.error("The path should point to a directory containing a package.json");
+    console.error("with a 'start' script that can be run via 'pnpm run start'.");
+    process.exit(1);
+  }
+
   let errored = false;
 
   await new Promise((resolve) => {


### PR DESCRIPTION
## Description

This PR adds argument validation to `scripts/server.js` to prevent confusing spawn errors when the required path argument is missing.

Fixes #11165

## Problem

Previously, running the script without providing a path argument would result in `undefined` being passed to `spawn()`'s `cwd` option, causing unclear errors:
- `Error: spawn pnpm ENOENT`
- `Error: spawn ENOTDIR`

This made it difficult for new contributors to understand what went wrong.

## Solution

Added validation at the start of the `main()` function that:
- ✅ Checks if the path argument is provided
- ✅ Displays a clear error message with usage instructions
- ✅ Provides an example command
- ✅ Explains what the path should contain
- ✅ Exits gracefully with code 1

## Changes

- **Modified**: `scripts/server.js`
  - Added 13-line validation block
  - No changes to existing functionality when path is provided correctly

## Testing

Tested both scenarios:
1. ✅ Running without arguments - shows clear error message
2. ✅ Running with valid path - works as expected

## Comparison

### Before (confusing error):
```
Error: spawn pnpm ENOENT
    at Process.ChildProcess._handle.onexit ...
```

### After (helpful error):
```
Error: Missing required path argument.

Usage: node scripts/server.js <path-to-project>

Example: node scripts/server.js ./test-codemod

The path should point to a directory containing a package.json
with a 'start' script that can be run via 'pnpm run start'.
```

## Impact

- **Risk Level**: LOW ✅
- **Breaking Changes**: None
- **Files Changed**: 1
- **Lines Changed**: +13

New contributors will benefit from clearer error messages when running this internal development script.

- [ ] 