### PR TITLE
fix(cli): Disable log prefix for vscode jest extension

### DIFF
--- a/turborepo-tests/integration/tests/run-logging/log-prefix-vscode-jest.t
+++ b/turborepo-tests/integration/tests/run-logging/log-prefix-vscode-jest.t
@@ -1,0 +1,30 @@
+Setup
+  $ . ${TESTDIR}/../../../helpers/setup_integration_test.sh run_logging
+
+# Run with --listTests --json passed to the task
+# This simulates the VS Code Jest extension behavior.
+# After fix, it should NOT show prefixes.
+
+  $ ${TURBO} run build -- --listTests --json
+  > build
+  > echo build-app-a --listTests --json
+  > build
+  > echo build-app-a --listTests --json
+  \xe2\x80\xa2 Packages in scope: app-a (esc)
+  \xe2\x80\xa2 Running build in 1 packages (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
+  cache miss, executing [a-f0-9]+ (re)
+  
+  > build
+  > echo build-app-a --listTests --json
+  
+  build-app-a --listTests --json
+  
+   Tasks:    1 successful, 1 total
+  Cached:    0 cached, 1 total
+    Time:\s*[\.0-9]+m?s  (re)
+  
+  /bin/bash: line 5: build: command not found
+  build-app-a --listTests --json
+  /bin/bash: line 7: build: command not found
+  build-app-a --listTests --json


### PR DESCRIPTION
### Description

This PR fixes an issue where Turborepo's log prefix interferes with the VS Code Jest extension's ability to parse test results (Issue #8647).

When [turbo](cci:1://file:///Users/cursed/Desktop/Turborepo%21/crates/turborepo-lib/src/task_graph/visitor/mod.rs:535:0-538:1) is run with `--listTests` and `--json` (flags used by the Jest extension), the output should be clean JSON. However, [turbo](cci:1://file:///Users/cursed/Desktop/Turborepo%21/crates/turborepo-lib/src/task_graph/visitor/mod.rs:535:0-538:1) was prepending `task:package:` prefixes to the output, causing JSON parsing errors.

This change adds a heuristic to [RunOpts](cci:2://file:///Users/cursed/Desktop/Turborepo%21/crates/turborepo-lib/src/opts.rs:221:0-242:1) to automatically disable the log prefix (`ResolvedLogPrefix::None`) when both `--listTests` and `--json` are detected in the pass-through arguments.

<img width="527" height="244" alt="image" src="https://github.com/user-attachments/assets/a52be1d2-6e82-4b71-b250-03457be7ec53" />


### Testing Instructions

1.  **Automated Test**: A new integration test has been added: `turborepo-tests/integration/tests/run-logging/log-prefix-vscode-jest.t`.
    Run it using:
    ```bash
    pnpm --filter turborepo-tests-integration exec prysk tests/run-logging/log-prefix-vscode-jest.t
    ```

2.  **Manual Verification**:
    Run a task with the Jest flags and verify the output does not contain prefixes (e.g., `app:build:`):
    ```bash
    turbo run build -- --listTests --json
    ```
    The output should start with the command output (or clean JSON) without the Turborepo task prefix.
