### PR TITLE
fix(vercel-api): Add `VIEWER_FOR_PLUS` and `SECURITY` role variants

### DIFF
--- a/crates/turborepo-vercel-api/src/lib.rs
+++ b/crates/turborepo-vercel-api/src/lib.rs
@@ -67,6 +67,7 @@ pub enum Role {
     Viewer,
     #[serde(rename = "VIEWER_FOR_PLUS")]
     ViewerForPlus,
+    Security,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
### Description

Adds support for the `VIEWER_FOR_PLUS` role variant returned by the Vercel API.

**Problem**: The `turbo link` command fails with a deserialization error when the Vercel API returns `VIEWER_FOR_PLUS` role:

```
error decoding response body
unknown variant `VIEWER_FOR_PLUS`, expected one of `OWNER`, `ADMIN`, `MEMBER`, `DEVELOPER`, `CONTRIBUTOR`, `BILLING`, `VIEWER`
```

**Solution**: Add `ViewerForPlus` variant to the `Role` enum with explicit `#[serde(rename = "VIEWER_FOR_PLUS")]` attribute to handle the underscore format from the API.

**Reference**: https://vercel.com/docs/rest-api/reference/endpoints/teams/list-team-members

### Testing Instructions

1. Build the crate: `cargo build -p turborepo-vercel-api`
2. Run tests: `cargo test -p turborepo-vercel-api`
3. Manual verification: Run `turbo link` with a Vercel account that has `VIEWER_FOR_PLUS` role