### PR TITLE
Fix sidebar scroll reset on language switch

### DIFF
--- a/docs/site/components/docs-layout/sidebar.tsx
+++ b/docs/site/components/docs-layout/sidebar.tsx
@@ -143,6 +143,9 @@ export function SidebarViewport(props: ScrollAreaProps) {
             "linear-gradient(to bottom, transparent, black 12px, black calc(100% - 12px), transparent 100%)",
           WebkitMaskImage:
             "linear-gradient(to bottom, transparent, black 12px, black calc(100% - 12px), transparent 100%)",
+          // Prevent scroll anchoring from affecting sidebar scroll position
+          // when main content height changes (e.g., switching code block tabs)
+          overflowAnchor: "none",
         }}
       >
         {props.children}


### PR DESCRIPTION
### Description

Fixes DOC-5503.
This PR resolves an issue where switching code block languages caused the left-hand sidebar's scroll position to unexpectedly reset. This behavior was due to the browser's scroll anchoring feature, which, when the main content's height changed, inadvertently adjusted the sidebar's scroll position.

The fix involves adding `overflowAnchor: "none"` to the `SidebarViewport` component. This CSS property prevents the sidebar from being considered a scroll anchor, ensuring its scroll position remains stable when other content on the page changes height.

### Testing Instructions

1.  Navigate to a documentation page that contains code blocks with multiple language tabs (e.g., a page showing `npm`, `pnpm`, `yarn` options).
2.  Scroll the left-hand sidebar to a specific position (e.g., halfway down).
3.  In the main content area, switch between the different language tabs within a code block.
4.  Verify that the sidebar's scroll position remains unchanged and does not reset.

---
Linear Issue: [DOC-5503](https://linear.app/vercel/issue/DOC-5503/code-block-language-switcher-resets-sidebar-scroll)

<a href="https://cursor.com/background-agent?bcId=bc-c218e29a-deea-4c0d-b2ee-c9d070d38b14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c218e29a-deea-4c0d-b2ee-c9d070d38b14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

