### PR TITLE
ci(fix): Give read permissions to release workflows

### DIFF
--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   id-token: write # Required for npm Trusted Publishing using OIDC
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -19,6 +19,7 @@ env:
 
 permissions:
   id-token: write # Required for npm Trusted Publishing using OIDC
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
### Description

Forgot that you have to add read permissions when you add any `permissions`! This was added to release workflows in #11173.
