### PR TITLE
fix: Command injection in turbo-ignore (#11154)

### DIFF
--- a/packages/turbo-ignore/__tests__/getComparison.test.ts
+++ b/packages/turbo-ignore/__tests__/getComparison.test.ts
@@ -83,7 +83,7 @@ describe("getComparison()", () => {
 
   it("uses previousDeploy when running in Vercel CI with VERCEL_GIT_PREVIOUS_SHA", () => {
     const mockExec = jest
-      .spyOn(child_process, "execFileSync")
+      .spyOn(child_process, "execSync")
       .mockReturnValue("commit");
 
     process.env.VERCEL = "1";
@@ -108,7 +108,7 @@ describe("getComparison()", () => {
 
   it("uses fallback when running in Vercel CI with unreachable VERCEL_GIT_PREVIOUS_SHA", () => {
     const mockExec = jest
-      .spyOn(child_process, "execFileSync")
+      .spyOn(child_process, "execSync")
       .mockImplementation(() => {
         throw new Error("fatal: Not a valid object name mygitsha");
       });
@@ -137,7 +137,7 @@ describe("getComparison()", () => {
 
   it("returns null running in Vercel CI with unreachable VERCEL_GIT_PREVIOUS_SHA and no fallback", () => {
     const mockExec = jest
-      .spyOn(child_process, "execFileSync")
+      .spyOn(child_process, "execSync")
       .mockImplementation(() => {
         throw new Error("fatal: Not a valid object name mygitsha");
       });
@@ -158,7 +158,7 @@ describe("getComparison()", () => {
 
   it("modifies output when running in Vercel CI with VERCEL_GIT_PREVIOUS_SHA but no VERCEL_GIT_COMMIT_REF", () => {
     const mockExec = jest
-      .spyOn(child_process, "execFileSync")
+      .spyOn(child_process, "execSync")
       .mockReturnValue("commit");
 
     process.env.VERCEL = "1";
@@ -182,7 +182,7 @@ describe("getComparison()", () => {
 
   it("modifies output when running in Vercel CI with unreachable VERCEL_GIT_PREVIOUS_SHA and no VERCEL_GIT_COMMIT_REF", () => {
     const mockExec = jest
-      .spyOn(child_process, "execFileSync")
+      .spyOn(child_process, "execSync")
       .mockImplementation(() => {
         throw new Error("fatal: Not a valid object name mygitsha");
       });

--- a/packages/turbo-ignore/__tests__/ignore.test.ts
+++ b/packages/turbo-ignore/__tests__/ignore.test.ts
@@ -45,8 +45,8 @@ describe("turboIgnore()", () => {
 
   it("throws error and allows build when exec fails", () => {
     const mockExec = jest
-      .spyOn(child_process, "execFile")
-      .mockImplementation((file, args, options, callback) => {
+      .spyOn(child_process, "exec")
+      .mockImplementation((command, options, callback) => {
         if (callback) {
           return callback(
             { message: "error details" } as unknown as ExecException,
@@ -60,15 +60,7 @@ describe("turboIgnore()", () => {
     turboIgnore("test-workspace", { telemetry });
 
     expect(mockExec).toHaveBeenCalledWith(
-      "npx",
-      [
-        "-y",
-        "turbo@^2",
-        "run",
-        "build",
-        "--filter=test-workspace...[HEAD^]",
-        "--dry=json",
-      ],
+      `npx -y turbo@^2 run build --filter="test-workspace...[HEAD^]" --dry=json`,
       expect.anything(),
       expect.anything()
     );
@@ -85,8 +77,8 @@ describe("turboIgnore()", () => {
 
   it("throws pretty error and allows build when exec fails", () => {
     const mockExec = jest
-      .spyOn(child_process, "execFile")
-      .mockImplementation((file, args, options, callback) => {
+      .spyOn(child_process, "exec")
+      .mockImplementation((command, options, callback) => {
         if (callback) {
           return callback(
             {
@@ -103,15 +95,7 @@ describe("turboIgnore()", () => {
     turboIgnore("test-workspace", {});
 
     expect(mockExec).toHaveBeenCalledWith(
-      "npx",
-      [
-        "-y",
-        "turbo@^2",
-        "run",
-        "build",
-        "--filter=test-workspace...[HEAD^]",
-        "--dry=json",
-      ],
+      `npx -y turbo@^2 run build --filter="test-workspace...[HEAD^]" --dry=json`,
       expect.anything(),
       expect.anything()
     );
@@ -132,12 +116,12 @@ describe("turboIgnore()", () => {
     process.env.VERCEL_GIT_COMMIT_REF = "my-branch";
 
     const mockExecSync = jest
-      .spyOn(child_process, "execFileSync")
+      .spyOn(child_process, "execSync")
       .mockReturnValue("commit");
 
     const mockExec = jest
-      .spyOn(child_process, "execFile")
-      .mockImplementation((file, args, options, callback) => {
+      .spyOn(child_process, "exec")
+      .mockImplementation((command, options, callback) => {
         if (callback) {
           return callback(
             {
@@ -154,15 +138,7 @@ describe("turboIgnore()", () => {
     turboIgnore("test-workspace", { telemetry });
 
     expect(mockExec).toHaveBeenCalledWith(
-      "npx",
-      [
-        "-y",
-        "turbo@^2",
-        "run",
-        "build",
-        "--filter=test-workspace...[too-far-back]",
-        "--dry=json",
-      ],
+      `npx -y turbo@^2 run build --filter="test-workspace...[too-far-back]" --dry=json`,
       expect.anything(),
       expect.anything()
     );
@@ -180,8 +156,8 @@ describe("turboIgnore()", () => {
 
   it("throws pretty error and allows build when fallback fails", () => {
     const mockExec = jest
-      .spyOn(child_process, "execFile")
-      .mockImplementation((file, args, options, callback) => {
+      .spyOn(child_process, "exec")
+      .mockImplementation((command, options, callback) => {
         if (callback) {
           return callback(
             {
@@ -198,15 +174,7 @@ describe("turboIgnore()", () => {
     turboIgnore("test-workspace", { fallback: "HEAD^" });
 
     expect(mockExec).toHaveBeenCalledWith(
-      "npx",
-      [
-        "-y",
-        "turbo@^2",
-        "run",
-        "build",
-        "--filter=test-workspace...[HEAD^]",
-        "--dry=json",
-      ],
+      `npx -y turbo@^2 run build --filter="test-workspace...[HEAD^]" --dry=json`,
       expect.anything(),
       expect.anything()
     );
@@ -284,12 +252,12 @@ describe("turboIgnore()", () => {
     process.env.VERCEL_GIT_COMMIT_REF = "my-branch";
 
     const mockExecSync = jest
-      .spyOn(child_process, "execFileSync")
+      .spyOn(child_process, "execSync")
       .mockReturnValue("commit");
 
     const mockExec = jest
-      .spyOn(child_process, "execFile")
-      .mockImplementation((file, args, options, callback) => {
+      .spyOn(child_process, "exec")
+      .mockImplementation((command, options, callback) => {
         if (callback) {
           return callback(
             null,
@@ -331,12 +299,12 @@ describe("turboIgnore()", () => {
     process.env.VERCEL_GIT_COMMIT_REF = "my-branch";
 
     const mockExecSync = jest
-      .spyOn(child_process, "execFileSync")
+      .spyOn(child_process, "execSync")
       .mockReturnValue("commit");
 
     const mockExec = jest
-      .spyOn(child_process, "execFile")
-      .mockImplementation((file, args, options, callback) => {
+      .spyOn(child_process, "exec")
+      .mockImplementation((command, options, callback) => {
         if (callback) {
           return callback(
             null,
@@ -381,12 +349,12 @@ describe("turboIgnore()", () => {
     process.env.VERCEL_GIT_COMMIT_REF = "my-branch";
 
     const mockExecSync = jest
-      .spyOn(child_process, "execFileSync")
+      .spyOn(child_process, "execSync")
       .mockReturnValue("commit");
 
     const mockExec = jest
-      .spyOn(child_process, "execFile")
-      .mockImplementation((file, args, options, callback) => {
+      .spyOn(child_process, "exec")
+      .mockImplementation((command, options, callback) => {
         if (callback) {
           return callback(
             null,
@@ -428,12 +396,12 @@ describe("turboIgnore()", () => {
     process.env.VERCEL_GIT_COMMIT_REF = "my-branch";
 
     const mockExecSync = jest
-      .spyOn(child_process, "execFileSync")
+      .spyOn(child_process, "execSync")
       .mockReturnValue("commit");
 
     const mockExec = jest
-      .spyOn(child_process, "execFile")
-      .mockImplementation((file, args, options, callback) => {
+      .spyOn(child_process, "exec")
+      .mockImplementation((command, options, callback) => {
         if (callback) {
           return callback(
             null,
@@ -478,17 +446,17 @@ describe("turboIgnore()", () => {
     process.env.VERCEL_GIT_COMMIT_REF = "my-branch";
 
     const mockExecSync = jest
-      .spyOn(child_process, "execFileSync")
-      .mockImplementation((file: string, args?: ReadonlyArray<string>) => {
-        if (file === "git" && args && args[0] === "cat-file") {
+      .spyOn(child_process, "execSync")
+      .mockImplementation((cmd: string) => {
+        if (cmd.includes("git cat-file")) {
           throw new Error("fatal: Not a valid object name last-deployed-sha");
         }
         return "";
       });
 
     const mockExec = jest
-      .spyOn(child_process, "execFile")
-      .mockImplementation((file, args, options, callback) => {
+      .spyOn(child_process, "exec")
+      .mockImplementation((command, options, callback) => {
         if (callback) {
           return callback(
             null,
@@ -531,8 +499,8 @@ describe("turboIgnore()", () => {
 
   it("throws error and allows build when json cannot be parsed", () => {
     const mockExec = jest
-      .spyOn(child_process, "execFile")
-      .mockImplementation((file, args, options, callback) => {
+      .spyOn(child_process, "exec")
+      .mockImplementation((command, options, callback) => {
         if (callback) {
           return callback(null, "stdout", "stderr") as unknown as ChildProcess;
         }
@@ -542,15 +510,7 @@ describe("turboIgnore()", () => {
     turboIgnore(undefined, { directory: "__fixtures__/app" });
 
     expect(mockExec).toHaveBeenCalledWith(
-      "npx",
-      [
-        "-y",
-        "turbo@^2",
-        "run",
-        "build",
-        "--filter=test-app...[HEAD^]",
-        "--dry=json",
-      ],
+      `npx -y turbo@^2 run build --filter="test-app...[HEAD^]" --dry=json`,
       expect.anything(),
       expect.anything()
     );
@@ -567,8 +527,8 @@ describe("turboIgnore()", () => {
 
   it("throws error and allows build when stdout is null", () => {
     const mockExec = jest
-      .spyOn(child_process, "execFile")
-      .mockImplementation((file, args, options, callback) => {
+      .spyOn(child_process, "exec")
+      .mockImplementation((command, options, callback) => {
         if (callback) {
           return callback(
             null,
@@ -582,15 +542,7 @@ describe("turboIgnore()", () => {
     turboIgnore(undefined, { directory: "__fixtures__/app" });
 
     expect(mockExec).toHaveBeenCalledWith(
-      "npx",
-      [
-        "-y",
-        "turbo@^2",
-        "run",
-        "build",
-        "--filter=test-app...[HEAD^]",
-        "--dry=json",
-      ],
+      `npx -y turbo@^2 run build --filter="test-app...[HEAD^]" --dry=json`,
       expect.anything(),
       expect.anything()
     );
@@ -654,12 +606,12 @@ describe("turboIgnore()", () => {
     process.env.VERCEL_GIT_COMMIT_REF = "my-branch";
 
     const mockExecSync = jest
-      .spyOn(child_process, "execFileSync")
+      .spyOn(child_process, "execSync")
       .mockReturnValue("commit");
 
     const mockExec = jest
-      .spyOn(child_process, "execFile")
-      .mockImplementation((file, args, options, callback) => {
+      .spyOn(child_process, "exec")
+      .mockImplementation((command, options, callback) => {
         if (callback) {
           return callback(
             null,
@@ -703,8 +655,8 @@ describe("turboIgnore()", () => {
 
   it("passes max buffer to turbo execution", () => {
     const mockExec = jest
-      .spyOn(child_process, "execFile")
-      .mockImplementation((file, args, options, callback) => {
+      .spyOn(child_process, "exec")
+      .mockImplementation((command, options, callback) => {
         if (callback) {
           return callback(
             null,
@@ -718,15 +670,7 @@ describe("turboIgnore()", () => {
     turboIgnore(undefined, { directory: "__fixtures__/app", maxBuffer: 1024 });
 
     expect(mockExec).toHaveBeenCalledWith(
-      "npx",
-      [
-        "-y",
-        "turbo@^2",
-        "run",
-        "build",
-        "--filter=test-app...[HEAD^]",
-        "--dry=json",
-      ],
+      `npx -y turbo@^2 run build --filter="test-app...[HEAD^]" --dry=json`,
       expect.objectContaining({ maxBuffer: 1024 }),
       expect.anything()
     );
@@ -736,8 +680,8 @@ describe("turboIgnore()", () => {
 
   it("runs with telemetry", () => {
     const mockExec = jest
-      .spyOn(child_process, "execFile")
-      .mockImplementation((file, args, options, callback) => {
+      .spyOn(child_process, "exec")
+      .mockImplementation((command, options, callback) => {
         if (callback) {
           return callback(
             null,
@@ -755,15 +699,7 @@ describe("turboIgnore()", () => {
     });
 
     expect(mockExec).toHaveBeenCalledWith(
-      "npx",
-      [
-        "-y",
-        "turbo@^2",
-        "run",
-        "build",
-        "--filter=test-app...[HEAD^]",
-        "--dry=json",
-      ],
+      `npx -y turbo@^2 run build --filter="test-app...[HEAD^]" --dry=json`,
       expect.objectContaining({ maxBuffer: 1024 }),
       expect.anything()
     );
@@ -773,8 +709,8 @@ describe("turboIgnore()", () => {
 
   it("allows build if packages is missing", () => {
     const mockExec = jest
-      .spyOn(child_process, "execFile")
-      .mockImplementation((file, args, options, callback) => {
+      .spyOn(child_process, "exec")
+      .mockImplementation((command, options, callback) => {
         if (callback) {
           return callback(
             null,
@@ -795,8 +731,8 @@ describe("turboIgnore()", () => {
 
   it("defaults to latest turbo if no hints for version", () => {
     const mockExec = jest
-      .spyOn(child_process, "execFile")
-      .mockImplementation((file, args, options, callback) => {
+      .spyOn(child_process, "exec")
+      .mockImplementation((command, options, callback) => {
         if (callback) {
           return callback(
             null,
@@ -810,15 +746,7 @@ describe("turboIgnore()", () => {
     turboIgnore(undefined, { directory: "__fixtures__/invalid_turbo_json" });
 
     expect(mockExec).toHaveBeenCalledWith(
-      "npx",
-      [
-        "-y",
-        "turbo",
-        "run",
-        "build",
-        "--filter=test-app...[HEAD^]",
-        "--dry=json",
-      ],
+      `npx -y turbo run build --filter="test-app...[HEAD^]" --dry=json`,
       expect.anything(),
       expect.anything()
     );

--- a/packages/turbo-ignore/src/getComparison.ts
+++ b/packages/turbo-ignore/src/getComparison.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execSync } from "node:child_process";
 import { info } from "./logger";
 import type { TurboIgnoreOptions } from "./types";
 
@@ -11,7 +11,7 @@ export interface GetComparisonArgs extends TurboIgnoreOptions {
 
 export function validateSHAExists(ref: string): boolean {
   try {
-    execFileSync("git", ["cat-file", "-t", ref], { stdio: "ignore" });
+    execSync(`git cat-file -t ${ref}`, { stdio: "ignore" });
     return true;
   } catch (e) {
     return false;

--- a/packages/turbo-ignore/src/ignore.ts
+++ b/packages/turbo-ignore/src/ignore.ts
@@ -1,4 +1,4 @@
-import { execFile } from "node:child_process";
+import { exec } from "node:child_process";
 import path from "node:path";
 import { existsSync } from "node:fs";
 import { getTurboRoot } from "@turbo/utils";
@@ -109,18 +109,8 @@ export function turboIgnore(
 
   // If we can't find a turbo version in package.json, don't specify a version
   const turbo = turboVersion ? `turbo@${turboVersion}` : "turbo";
-  // Build and execute the command
-  const filterArg = `${workspace}...[${comparison.ref}]`;
-  const args = [
-    "-y",
-    turbo,
-    "run",
-    task,
-    `--filter=${filterArg}`,
-    "--dry=json",
-  ];
-  // For logging, format with quotes around filter value to match expected format
-  const command = `npx -y ${turbo} run ${task} --filter="${filterArg}" --dry=json`;
+  // Build, and execute the command
+  const command = `npx -y ${turbo} run ${task} --filter="${workspace}...[${comparison.ref}]" --dry=json`;
   info(`Analyzing results of \`${command}\``);
 
   const execOptions: { cwd: string; maxBuffer?: number } = {
@@ -131,7 +121,7 @@ export function turboIgnore(
     execOptions.maxBuffer = opts.maxBuffer;
   }
 
-  execFile("npx", args, execOptions, (err, stdout) => {
+  exec(command, execOptions, (err, stdout) => {
     if (err) {
       const { level, code, message } = shouldWarn({ err: err.message });
       if (level === "warn") {


### PR DESCRIPTION
Description
Fixes a command injection vulnerability in turbo-ignore by replacing execSync with execFileSync when validating git refs. The old implementation used shell command strings. The fix ensures that user-controlled input (like git refs from environment variables) is passed as literal arguments rather than being interpreted by a shell.

Testing Instructions
Run the security test: pnpm test security.test.ts in packages/turbo-ignore