### PR TITLE
examples: Use slim image (debian) for prepare and builder stage, use latest no…

### DIFF
--- a/examples/with-docker/apps/api/Dockerfile
+++ b/examples/with-docker/apps/api/Dockerfile
@@ -6,8 +6,6 @@ FROM node:${NODE_VERSION}-slim AS base
 
 FROM base AS prepare
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk update
-RUN apk add --no-cache libc6-compat
 # Set working directory
 WORKDIR /app
 RUN yarn global add turbo
@@ -16,8 +14,6 @@ RUN turbo prune api --docker
 
 # Add lockfile and package.json's of isolated subworkspace
 FROM base AS builder
-RUN apk update
-RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # First install dependencies (as they change less often)

--- a/examples/with-docker/apps/web/Dockerfile
+++ b/examples/with-docker/apps/web/Dockerfile
@@ -5,8 +5,6 @@ FROM node:${NODE_VERSION}-slim AS base
 # Make sure you update both files!
 
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk update
-RUN apk add --no-cache libc6-compat
 # Set working directory
 WORKDIR /app
 


### PR DESCRIPTION
## Description

This PR changes the following things in the with-docker example:

- Use a Debian base image for the prepare and builder stages
- Set the latest Node version
- Used the same naming for docker stages from `apps/web` in `apps/api`

In a project I worked on, I switched from using Alpine Linux to a Debian-based image for the prepare and builder stages. This resulted in a significant speed-up in my builds.
In my project, it reduced the compile time of Next.js from ~120s to ~30s — a reduction of about 75%.

The reason is that Debian (slim image) uses glibc as the standard library, whereas Alpine uses musl as the standard library.
glibc has faster runtime performance. [Here](https://edu.chainguard.dev/chainguard/chainguard-images/about/images-compiled-programs/glibc-vs-musl/#high-level-differences-between-glibc-and-musl) is a good read on that.

## Testing Instructions

I ran the Docker builds of the with-docker example web app and the api app on my machine.
From examples/with-docker, I ran:
docker build -f apps/web/Dockerfile -t web . --no-cache --progress=plain
(and the same for apps/api, respectively)

These are very small apps, so the absolute change isn’t that big. The results:

`apps/api` before, with Alpine build stage:
`api:build: Done in 0.49s.`

`apps/api` after, with Debian (slim) for the build stage:
`api:build: Done in 0.32s.`

`apps/web` before, with Alpine for the build stage:
`web:buil\`: Done in 10.27s.`

`apps/web` after, with Debian (slim) for the build stage:
`web:build: Done in 8.74s.`

The Next.js app is using v14, so the compile time isn’t logged explicitly there. Instead, I used the total build time.