### PR TITLE
docs: fix typo in design-system.css comment

### DIFF
--- a/docs/site/app/design-system.css
+++ b/docs/site/app/design-system.css
@@ -3,7 +3,7 @@
 [data-theme="dark"] .invert-theme,
 .dark-theme .invert-theme,
 .dark .invert-theme {
-  /* Seperate HSL values from opacity, so opacity can be dynamic for TailwindCSS  */
+  /* Separate HSL values from opacity, so opacity can be dynamic for TailwindCSS  */
   /* Gray */
   --ds-gray-100-value: 0, 0%, 95%;
   --ds-gray-200-value: 0, 0%, 92%;


### PR DESCRIPTION
Description
This PR fixes a spelling typo in the CSS comment within the design system stylesheet.

Changes
- Fixed typo: "Seperate" → "Separate" in `docs/site/app/design-system.css` (line 6)
- The comment explains how HSL values are separated from opacity for dynamic TailwindCSS usage

Motivation
While reviewing the codebase, I noticed this small typo in the documentation comment. Fixing it improves code readability and maintains professional documentation standards.

Type of Change
- [x] Documentation improvement
- [x] Non-breaking change
- [x] Typo correction

 Testing
- No functional changes - this is a comment-only modification
- Verified CSS file has no syntax errors
- No impact on build or runtime behavior

Checklist
- [x] The change is focused and atomic
- [x] Commit message follows conventional commits format
- [x] No breaking changes introduced