### PR TITLE
fix: Upgrade Next.js to 15.5.7 (CVE-2025-55182)

### DIFF
--- a/packages/eslint-plugin-turbo/__fixtures__/framework-inference/apps/kitchen-sink/package.json
+++ b/packages/eslint-plugin-turbo/__fixtures__/framework-inference/apps/kitchen-sink/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextjs",
   "dependencies": {
-    "next": "*",
+    "next": "15.5.7",
     "blitz": "*",
     "react": "*",
     "left-pad": "*",

--- a/packages/eslint-plugin-turbo/__fixtures__/framework-inference/apps/nextjs/package.json
+++ b/packages/eslint-plugin-turbo/__fixtures__/framework-inference/apps/nextjs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextjs",
   "dependencies": {
-    "next": "*"
+    "next": "15.5.7"
   },
   "devDependencies": {
     "eslint": "8.57.0",

--- a/turborepo-tests/integration/fixtures/framework_inference/apps/docs/package.json
+++ b/turborepo-tests/integration/fixtures/framework_inference/apps/docs/package.json
@@ -4,6 +4,6 @@
     "build": "next build"
   },
   "dependencies": {
-    "next": "latest"
+    "next": "15.5.7"
   }
 }


### PR DESCRIPTION
This upgrade fixes CVE-2025-55182, a React Server Components RCE vulnerability.