### PR TITLE
fix: Add Windows-specific env var to default passthroughs

### DIFF
--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -6,25 +6,25 @@ use std::{
 use rayon::prelude::*;
 use serde::Serialize;
 use thiserror::Error;
-use tracing::{Span, debug};
+use tracing::{debug, Span};
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, AnchoredSystemPathBuf};
 use turborepo_cache::CacheHitMetadata;
 use turborepo_env::{BySource, DetailedMap, EnvironmentVariableMap};
-use turborepo_frameworks::{Slug as FrameworkSlug, infer_framework};
+use turborepo_frameworks::{infer_framework, Slug as FrameworkSlug};
 use turborepo_repository::package_graph::{PackageInfo, PackageName};
 use turborepo_scm::SCM;
 use turborepo_task_id::TaskId;
 use turborepo_telemetry::events::{
-    EventBuilder, generic::GenericEventBuilder, task::PackageTaskEventBuilder,
+    generic::GenericEventBuilder, task::PackageTaskEventBuilder, EventBuilder,
 };
 
 use crate::{
-    DaemonClient, DaemonConnector,
     cli::EnvMode,
     engine::TaskNode,
     hash::{FileHashes, LockFilePackages, TaskHashable, TurboHash},
     opts::RunOpts,
     task_graph::TaskDefinition,
+    DaemonClient, DaemonConnector,
 };
 
 #[derive(Debug, Error)]
@@ -149,9 +149,9 @@ impl PackageInputsHashes {
                                     );
                                 })
                                 .ok() // If we timed out, we don't need to
-                            // error,
-                            // just return None so we can move on to
-                            // local
+                                      // error,
+                                      // just return None so we can move on to
+                                      // local
                         })
                         .and_then(|result| {
                             match result {


### PR DESCRIPTION
### Description

CLOSES https://github.com/vercel/turborepo/issues/8653
