### PR TITLE
fix: Quoting in turbo-ignore commands

### DIFF
--- a/packages/turbo-ignore/__tests__/getTask.test.ts
+++ b/packages/turbo-ignore/__tests__/getTask.test.ts
@@ -13,12 +13,12 @@ describe("getWorkspace()", () => {
     );
   });
 
-  it("getTask returns a quoted task if user-supplied", () => {
+  it("getTask returns the task unquoted if user-supplied", () => {
     expect(
       getTask({
         task: "workspace#task",
       })
-    ).toEqual(`"workspace#task"`);
+    ).toEqual("workspace#task");
 
     expect(mockConsole.log).toHaveBeenNthCalledWith(
       1,

--- a/packages/turbo-ignore/src/getTask.ts
+++ b/packages/turbo-ignore/src/getTask.ts
@@ -4,7 +4,7 @@ import type { TurboIgnoreOptions } from "./types";
 export function getTask(args: TurboIgnoreOptions): string {
   if (args.task) {
     info(`Using "${args.task}" as the task from the arguments`);
-    return `"${args.task}"`;
+    return args.task;
   }
 
   info('Using "build" as the task as it was unspecified');

--- a/packages/turbo-ignore/src/ignore.ts
+++ b/packages/turbo-ignore/src/ignore.ts
@@ -119,8 +119,9 @@ export function turboIgnore(
     `--filter=${filterArg}`,
     "--dry=json",
   ];
-  // For logging, format with quotes around filter value to match expected format
-  const command = `npx -y ${turbo} run ${task} --filter="${filterArg}" --dry=json`;
+  // For logging, format task with quotes if it contains special characters (like #)
+  const displayTask = task.includes("#") ? `"${task}"` : task;
+  const command = `npx -y ${turbo} run ${displayTask} --filter="${filterArg}" --dry=json`;
   info(`Analyzing results of \`${command}\``);
 
   const execOptions: { cwd: string; maxBuffer?: number } = {


### PR DESCRIPTION
### Description

 #11154 changed `turbo-ignore` from exec() to execFile() for security, but getTask() still wrapped task names in quotes ("build"). With execFile(), these quotes are passed literally, causing turbo to fail finding a task named "build" (with quotes).

### Testing Instructions

Updated test and hand-tested it.
