### PR TITLE
fix: Compose tasks when composing turbo.json

### DIFF
--- a/crates/turborepo-lib/src/engine/builder.rs
+++ b/crates/turborepo-lib/src/engine/builder.rs
@@ -14,7 +14,7 @@ use crate::{
     config,
     task_graph::TaskDefinition,
     turbo_json::{
-        FutureFlags, ProcessedTaskDefinition, TurboJson, TurboJsonLoader, validator::Validator,
+        validator::Validator, FutureFlags, ProcessedTaskDefinition, TurboJson, TurboJsonLoader,
     },
 };
 


### PR DESCRIPTION
### What
This PR fixes task discovery and resolution when Package Configurations use the `extends` field to inherit from non-root packages.

### Why
Previously, when a Package Configuration extended another non-root package (e.g., `"extends": ["//", "shared-config"]`), tasks defined in the extended package were not properly discovered or resolved.

### How
The fix modifies the engine builder to properly traverse the extends chain when:

1. Collecting tasks (`collect_tasks_from_extends_chain`): A new recursive function traverses the extends chain from any workspace, collecting all task names from each extended package. This ensures add_all_tasks discovers inherited tasks.
2. Checking task definitions (`has_task_definition_in_run_inner`): Updated to recursively check the extends chain for task definitions, not just the immediate workspace and root.

### Testing Instructions

I wrote tests covering these situations but you're encouraged to test yourself if you'd like:
- Basic extends inheritance
- Deep extends chains (A→B→C→D→root)
- Diamond inheritance patterns
- Cyclic extends handling
- Missing turbo.json fallback behavior
