### PR TITLE
chore: Run pre-commit fmt on all files

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
       "taplo format"
     ],
     "*.rs": [
-      "cargo fmt --"
+      "cargo fmt"
     ]
   },
   "packageManager": "pnpm@10.25.0",


### PR DESCRIPTION
### Description

The pre-commit hook kept mis-formatting things, presumably because it doesn't have full file context when it tries to run. Seeing if this stops this.