### PR TITLE
chore: Clear false positive unused warnings

### DIFF
--- a/crates/turbo-trace/src/lib.rs
+++ b/crates/turbo-trace/src/lib.rs
@@ -2,6 +2,8 @@
 //! TypeScript files. Provides functionality to discover and track module
 //! imports across a codebase. Used for `turbo boundaries`
 
+// miette's derive macro causes false positives for this lint
+#![allow(unused_assignments)]
 #![deny(clippy::all)]
 mod import_finder;
 mod tracer;

--- a/crates/turbo-trace/src/main.rs
+++ b/crates/turbo-trace/src/main.rs
@@ -1,3 +1,6 @@
+// miette's derive macro causes false positives for this lint
+#![allow(unused_assignments)]
+
 mod import_finder;
 mod tracer;
 

--- a/crates/turbo-trace/src/tracer.rs
+++ b/crates/turbo-trace/src/tracer.rs
@@ -17,7 +17,7 @@ use swc_ecma_parser::{Capturing, EsSyntax, Parser, Syntax, TsSyntax, lexer::Lexe
 use swc_ecma_visit::VisitWith;
 use thiserror::Error;
 use tokio::task::JoinSet;
-use tracing::{debug, error};
+use tracing::debug;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, PathError};
 
 use crate::import_finder::ImportFinder;

--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -4,6 +4,8 @@
 
 #![feature(error_generic_member_access)]
 #![feature(assert_matches)]
+// miette's derive macro causes false positives for this lint
+#![allow(unused_assignments)]
 #![deny(clippy::all)]
 
 use std::{backtrace::Backtrace, env, future::Future, time::Duration};

--- a/crates/turborepo-auth/src/lib.rs
+++ b/crates/turborepo-auth/src/lib.rs
@@ -1,5 +1,7 @@
 #![feature(cow_is_borrowed)]
 #![feature(assert_matches)]
+// miette's derive macro causes false positives for this lint
+#![allow(unused_assignments)]
 #![deny(clippy::all)]
 //! Turborepo's library for authenticating with the Vercel API.
 //! Handles logging into Vercel, verifying SSO, and storing the token.

--- a/crates/turborepo-cache/src/lib.rs
+++ b/crates/turborepo-cache/src/lib.rs
@@ -7,6 +7,8 @@
 #![feature(error_generic_member_access)]
 #![feature(assert_matches)]
 #![feature(box_patterns)]
+// miette's derive macro causes false positives for this lint
+#![allow(unused_assignments)]
 #![deny(clippy::all)]
 
 /// A wrapper for the cache that uses a worker pool to perform cache operations

--- a/crates/turborepo-errors/src/lib.rs
+++ b/crates/turborepo-errors/src/lib.rs
@@ -3,6 +3,9 @@
 //! Any parsing of files should attempt to produce value of `Spanned<T>` so if
 //! we need to reference where T came from the span is available.
 
+// miette's derive macro causes false positives for this lint
+#![allow(unused_assignments)]
+
 use std::{
     fmt::Display,
     iter,

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -4,6 +4,8 @@
 #![feature(once_cell_try)]
 #![feature(try_blocks)]
 #![feature(impl_trait_in_assoc_type)]
+// miette's derive macro causes false positives for this lint
+#![allow(unused_assignments)]
 #![deny(clippy::all)]
 // Clippy's needless mut lint is buggy: https://github.com/rust-lang/rust-clippy/issues/11299
 #![allow(clippy::needless_pass_by_ref_mut)]

--- a/crates/turborepo-lib/src/run/summary/mod.rs
+++ b/crates/turborepo-lib/src/run/summary/mod.rs
@@ -21,7 +21,7 @@ use serde::Serialize;
 use svix_ksuid::{Ksuid, KsuidLike};
 use tabwriter::TabWriter;
 use thiserror::Error;
-use tracing::{error, log::warn};
+use tracing::log::warn;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPath};
 use turborepo_env::EnvironmentVariableMap;
 use turborepo_repository::package_graph::{PackageGraph, PackageName};

--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -19,7 +19,7 @@ use miette::{Diagnostic, NamedSource, SourceSpan};
 use output::{StdWriter, TaskOutput};
 use regex::Regex;
 use tokio::sync::mpsc;
-use tracing::{debug, error, warn, Span};
+use tracing::{debug, warn, Span};
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPath};
 use turborepo_ci::{Vendor, VendorBehavior};
 use turborepo_env::{platform::PlatformEnv, EnvironmentVariableMap};

--- a/crates/turborepo-lsp/src/lib.rs
+++ b/crates/turborepo-lsp/src/lib.rs
@@ -7,6 +7,8 @@
 //! as well as the architecture documentation in `packages/turbo-vsc`.
 
 #![feature(box_patterns)]
+// miette's derive macro causes false positives for this lint
+#![allow(unused_assignments)]
 #![deny(clippy::all)]
 #![warn(clippy::unwrap_used)]
 

--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -63,6 +63,7 @@ pub enum ShutdownStyle {
 }
 
 /// Child process stopped.
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct ShutdownFailed;
 

--- a/crates/turborepo-repository/src/lib.rs
+++ b/crates/turborepo-repository/src/lib.rs
@@ -8,6 +8,8 @@
 
 #![feature(assert_matches)]
 #![feature(error_generic_member_access)]
+// miette's derive macro causes false positives for this lint
+#![allow(unused_assignments)]
 #![allow(clippy::result_large_err)]
 
 pub mod change_mapper;

--- a/crates/turborepo-telemetry/src/lib.rs
+++ b/crates/turborepo-telemetry/src/lib.rs
@@ -4,6 +4,8 @@
 //! More detail is available at https://turborepo.com/docs/telemetry.
 
 #![feature(error_generic_member_access)]
+// miette's derive macro causes false positives for this lint
+#![allow(unused_assignments)]
 
 pub mod config;
 pub mod errors;
@@ -21,7 +23,7 @@ use tokio::{
     sync::{mpsc, oneshot},
     task::{JoinError, JoinHandle},
 };
-use tracing::{debug, error, trace};
+use tracing::{debug, trace};
 use turborepo_api_client::telemetry;
 use turborepo_ui::{BOLD, ColorConfig, GREY, color};
 use uuid::Uuid;

--- a/crates/turborepo-ui/src/tui/table.rs
+++ b/crates/turborepo-ui/src/tui/table.rs
@@ -1,6 +1,6 @@
 use ratatui::{
     layout::{Constraint, Rect},
-    style::{Color, Modifier, Style, Stylize},
+    style::{Modifier, Style, Stylize},
     text::{Line, Span, Text},
     widgets::{Block, Borders, Cell, Row, StatefulWidget, Table, TableState},
 };

--- a/crates/turborepo-wax/src/lib.rs
+++ b/crates/turborepo-wax/src/lib.rs
@@ -13,6 +13,7 @@
     html_logo_url = "https://raw.githubusercontent.com/olson-sean-k/wax/master/doc/wax.svg?sanitize=true"
 )]
 #![allow(dead_code)]
+#![allow(unused_assignments)]
 #![allow(clippy::all)]
 #![deny(
     clippy::cast_lossless,


### PR DESCRIPTION
### Description

Clearing up warnings in our Rust code. Most of them come from a miette derive macro.

### Testing Instructions

Check CI logs to not have warnings.
