### PR TITLE
ci: Fix flaky test (hopefully)

### DIFF
--- a/crates/turborepo/tests/common/mod.rs
+++ b/crates/turborepo/tests/common/mod.rs
@@ -49,7 +49,15 @@ macro_rules! check_json_output {
                 let mut command = assert_cmd::Command::cargo_bin("turbo")?;
 
                 command
-                    .arg($command);
+                    .arg($command)
+                    // Ensure telemetry can initialize by providing a writable config directory.
+                    // This prevents debug builds from printing errors to stdout when telemetry
+                    // init fails due to missing config directories.
+                    .env("TURBO_CONFIG_DIR_PATH", tempdir.path())
+                    // Disable telemetry and various warnings to ensure clean JSON output
+                    .env("DO_NOT_TRACK", "1")
+                    .env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
+                    .env("TURBO_GLOBAL_WARNING_DISABLED", "1");
 
                 $(
                     command.arg($query);


### PR DESCRIPTION
### Description

This test has been flaky for awhile and I think I just figured out that it has to do with the telemetry client not being set up yet when the call to the implementation code gets made. When that happens, a log gets sent into stdout, which the test is attempting to parse JSON from. When that happens, stdout has a warning printed by the telemetry crate instead of the JSON its expecting.

### Testing Instructions

CI over the next week or so.

<sub>CLOSES TURBO-5012</sub>