### PR TITLE
fix: Overly aggressive path checking in microfrontends loading

### DIFF
--- a/crates/turborepo-microfrontends/src/error.rs
+++ b/crates/turborepo-microfrontends/src/error.rs
@@ -32,8 +32,6 @@ pub enum Error {
         root_app: String,
         root_package: String,
     },
-    #[error("Invalid package path: {0}. Path traversal outside repository root is not allowed.")]
-    PathTraversal(String),
     #[error(
         "Invalid custom config file name: {0}. Must be a .json or .jsonc file directly in the \
          package root (no subdirectories or path traversal)."


### PR DESCRIPTION
### Description

Fixes https://github.com/vercel/turborepo/issues/11203.

The path checking in microfrontends was being too overzealous about protecting path traversals. The pattern shown in the original issue is fine.

### Testing Instructions

Tried the reproduction from the issue with the new codeset.

#### Before

```
▲ 👟 examples/application on turbo/path-traversal-error
  turbo build
turbo 2.6.3

  × Invalid package path: /Users/anthonyshew/projects/debugs/examples/application/../configuration/some-config. Path traversal outside repository root is not allowed.
```

#### After

```
▲ 👟 examples/application on turbo/path-traversal-error
  dt build --output-logs=errors-only
turbo 2.7.0

• Packages in scope: app-a, app-b, config-pkg, pkg-a, pkg-b, tooling-config
• Running build in 6 packages
• Remote caching disabled
 WARNING  IO error: paths in archives must not have `..` when setting path for

 Tasks:    6 successful, 6 total
Cached:    3 cached, 6 total
  Time:    534ms
```

The warning is an existing one prior to this bug, and needs its own handling. The reported problem in the issue is fixed in this change.