### PR TITLE
chore: Format version printing similar to rest of prelude

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1353,7 +1353,7 @@ pub async fn run(
     let telemetry_handle = initialize_telemetry_client(color_config, version);
 
     if should_print_version() {
-        eprintln!("{}\n", GREY.apply_to(format!("turbo {}", get_version())));
+        eprintln!("{}", GREY.apply_to(format!("• turbo {}", get_version())));
     }
 
     let mut command = get_command(&mut cli_args)?;


### PR DESCRIPTION
### Description

Just a cosmetic change.

### Testing Instructions

#### Before
```
▲ 👟 my-turborepo on main
  turbo build
turbo 2.7.0

• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web
• Running build in 5 packages
• Remote caching disabled
```

#### After
```
▲ 👟 my-turborepo on main
  dt build
• turbo 2.7.1-canary.0
• Packages in scope: @repo/eslint-config, @repo/typescript-config, @repo/ui, docs, web
• Running build in 5 packages
• Remote caching disabled
```