### PR TITLE
fix: Don't flash TUI on a >>> FULL TURBO

### DIFF
--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -754,20 +754,29 @@ pub async fn run_app(
     // Terminal is lazily initialized - only started when a non-cached task runs
     let mut terminal: Option<Terminal<CrosstermBackend<Stdout>>> = None;
 
-    let (result, callback) =
-        match run_app_inner(&mut terminal, &mut app, receiver, crossterm_rx, color_config).await {
-            Ok(callback) => (Ok(()), callback),
-            Err(err) => {
-                debug!("tui shutting down: {err}");
-                (Err(err), None)
-            }
-        };
+    let (result, callback) = match run_app_inner(
+        &mut terminal,
+        &mut app,
+        receiver,
+        crossterm_rx,
+        color_config,
+    )
+    .await
+    {
+        Ok(callback) => (Ok(()), callback),
+        Err(err) => {
+            debug!("tui shutting down: {err}");
+            (Err(err), None)
+        }
+    };
 
     // Only cleanup terminal if we actually started it
     if let Some(terminal) = terminal {
         cleanup(terminal, app, callback)?;
     } else {
-        // Even if TUI never started, flush preferences
+        // Even if TUI never started, still persist task output and flush preferences
+        let tasks_started = app.tasks_by_status.tasks_started();
+        app.persist_tasks(tasks_started)?;
         app.preferences.flush_to_disk().ok();
         if let Some(callback) = callback {
             // Signal completion even if we never started the terminal
@@ -779,7 +788,8 @@ pub async fn run_app(
 }
 
 /// Check if an event indicates we need to start rendering the TUI.
-/// We start rendering when we receive a cache miss, meaning a task will actually run.
+/// We start rendering when we receive a cache miss, meaning a task will
+/// actually run.
 fn should_start_terminal(event: &Event) -> bool {
     matches!(
         event,
@@ -2109,6 +2119,107 @@ mod test {
             app.preferences.is_task_list_visible(),
             "task list should be visible after entering search"
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_should_start_terminal_on_cache_miss() {
+        // Cache miss should trigger terminal start
+        let miss_event = Event::Status {
+            task: "task-a".to_string(),
+            status: "building".to_string(),
+            // This includes cache bypasses via `--force`
+            result: CacheResult::Miss,
+        };
+        assert!(
+            super::should_start_terminal(&miss_event),
+            "terminal should start on cache miss"
+        );
+    }
+
+    #[test]
+    fn test_should_not_start_terminal_on_cache_hit() {
+        // Cache hit should NOT trigger terminal start
+        let hit_event = Event::Status {
+            task: "task-a".to_string(),
+            status: "cached".to_string(),
+            result: CacheResult::Hit,
+        };
+        assert!(
+            !super::should_start_terminal(&hit_event),
+            "terminal should NOT start on cache hit"
+        );
+    }
+
+    #[test]
+    fn test_should_not_start_terminal_on_other_events() {
+        // Other events should NOT trigger terminal start
+        let start_event = Event::StartTask {
+            task: "task-a".to_string(),
+            output_logs: OutputLogs::Full,
+        };
+        assert!(
+            !super::should_start_terminal(&start_event),
+            "terminal should NOT start on StartTask event"
+        );
+
+        let end_event = Event::EndTask {
+            task: "task-a".to_string(),
+            result: TaskResult::Success,
+        };
+        assert!(
+            !super::should_start_terminal(&end_event),
+            "terminal should NOT start on EndTask event"
+        );
+
+        let tick_event = Event::Tick;
+        assert!(
+            !super::should_start_terminal(&tick_event),
+            "terminal should NOT start on Tick event"
+        );
+    }
+
+    #[test]
+    fn test_persist_tasks_called_on_cache_hit_only() -> Result<(), Error> {
+        // This test verifies that persist_tasks works correctly for cached tasks.
+        // When all tasks are cache hits, the TUI terminal is never started,
+        // but persist_tasks should still output the task logs.
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())
+            .expect("Failed to create AbsoluteSystemPathBuf");
+
+        let mut app: App<Vec<u8>> = App::new(
+            100,
+            100,
+            vec!["a".to_string(), "b".to_string()],
+            PreferenceLoader::new(&repo_root),
+            2048,
+        );
+
+        // Simulate a full cache hit scenario:
+        // 1. Set status as cache hit (this doesn't start the task in running state)
+        app.set_status("a".to_string(), "cached".to_string(), CacheResult::Hit)?;
+        app.set_status("b".to_string(), "cached".to_string(), CacheResult::Hit)?;
+
+        // 2. Start and finish tasks with CacheHit result
+        app.start_task("a", OutputLogs::Full)?;
+        app.start_task("b", OutputLogs::Full)?;
+        app.finish_task("a", TaskResult::CacheHit)?;
+        app.finish_task("b", TaskResult::CacheHit)?;
+
+        // 3. Get the list of started tasks - this should include both tasks
+        let tasks_started = app.tasks_by_status.tasks_started();
+        assert_eq!(
+            tasks_started.len(),
+            2,
+            "both tasks should be in started list"
+        );
+        assert!(tasks_started.contains(&"a".to_string()));
+        assert!(tasks_started.contains(&"b".to_string()));
+
+        // 4. Verify persist_tasks doesn't error (it writes to the task's output)
+        app.persist_tasks(tasks_started)?;
 
         Ok(())
     }

--- a/turborepo-tests/integration/tests/run-logging/full-cache-hit-output.t
+++ b/turborepo-tests/integration/tests/run-logging/full-cache-hit-output.t
@@ -1,0 +1,49 @@
+# Test that logs are printed on full cache hit
+# This test verifies that when all tasks are cached (FULL TURBO), 
+# the output logs are still printed correctly.
+#
+# Related to issue #9470 - TUI flicker fix should not break output on full cache hits
+
+Setup
+  $ . ${TESTDIR}/../../../helpers/setup_integration_test.sh
+
+Run build once to populate the cache
+  $ ${TURBO} run build --output-logs=none
+  \xe2\x80\xa2 Packages in scope: another, my-app, util (esc)
+  \xe2\x80\xa2 Running build in 3 packages (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
+  
+   Tasks:    2 successful, 2 total
+  Cached:    0 cached, 2 total
+    Time:\s*[\.0-9]+m?s  (re)
+  
+   WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
+
+
+Run build again with --output-logs=full - should be FULL TURBO (all cached) and still show output
+The output should contain cache hit messages and the echoed "building" from both tasks
+  $ ${TURBO} run build --output-logs=full 2>&1 | grep -c "cache hit, replaying logs"
+  2
+
+Verify the actual build output is shown (both tasks echo "building")
+  $ ${TURBO} run build --output-logs=full 2>&1 | grep -c "^.*:build: building$"
+  2
+
+Verify FULL TURBO is shown
+  $ ${TURBO} run build --output-logs=full 2>&1 | grep -c "FULL TURBO"
+  1
+
+Verify --output-logs=hash-only shows status on full cache hit (suppresses logs)
+  $ ${TURBO} run build --output-logs=hash-only 2>&1 | grep -c "cache hit, suppressing logs"
+  2
+
+Verify --output-logs=none shows minimal output on full cache hit  
+  $ ${TURBO} run build --output-logs=none
+  \xe2\x80\xa2 Packages in scope: another, my-app, util (esc)
+  \xe2\x80\xa2 Running build in 3 packages (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
+  
+   Tasks:    2 successful, 2 total
+  Cached:    2 cached, 2 total
+    Time:\s*[\.0-9]+m?s >>> FULL TURBO (re)
+  


### PR DESCRIPTION
### Description

Previously, our TUI would render when we started up tasks. However, this would cause a "flicker" in the case that all tasks hit cache. The flash was a bit annoying.

Now, we only render the TUI once we see that we won't hit cache for all tasks. This comes with a small delay in rendering the TUI, but the tradeoff seems to right in my UX testing. Also, when we consider that we're about to do a bunch of performance work, we're going to be faster at evaluating these states, so this side-effect will become much smaller.

### Testing Instructions

Added some tests and tested manually in both small and large Turborepos.

<sub>CLOSES https://github.com/vercel/turborepo/issues/9470</sub>