### PR TITLE
fix(ci): Prevent Test Summary job from hanging when integration tests are skipped

### DIFF
--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -140,7 +140,7 @@ jobs:
       - generate-integration-test-matrix
     runs-on: ${{ matrix.os.runner }}
     timeout-minutes: 30
-    if: ${{ needs.find-changes.outputs.rest == 'true' }}
+    if: ${{ needs.find-changes.outputs.rest == 'true' && needs.generate-integration-test-matrix.result == 'success' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Fixes the "Test Summary" job hanging by ensuring the integration job properly skips when the matrix generation job is skipped.