### PR TITLE
chore: Extract `turborepo-json-rewrite` crate from `turborepo-lib`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .store/
 .turbo/
 .hive/
+.claude/
 data/
 dist/
 node_modules/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6927,6 +6927,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "turborepo-json-rewrite"
+version = "0.1.0"
+dependencies = [
+ "jsonc-parser 0.21.0",
+ "pretty_assertions",
+ "thiserror 1.0.63",
+]
+
+[[package]]
 name = "turborepo-lib"
 version = "0.1.0"
 dependencies = [
@@ -7045,6 +7054,7 @@ dependencies = [
  "turborepo-fs",
  "turborepo-gitignore",
  "turborepo-graph-utils",
+ "turborepo-json-rewrite",
  "turborepo-lockfiles",
  "turborepo-microfrontends",
  "turborepo-microfrontends-proxy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ turborepo-fixed-map = { path = "crates/turborepo-fixed-map" }
 turborepo-frameworks = { path = "crates/turborepo-frameworks" }
 turborepo-fs = { path = "crates/turborepo-fs" }
 turborepo-gitignore = { path = "crates/turborepo-gitignore" }
+turborepo-json-rewrite = { path = "crates/turborepo-json-rewrite" }
 turborepo-lib = { path = "crates/turborepo-lib", default-features = false }
 turborepo-lockfiles = { path = "crates/turborepo-lockfiles" }
 turborepo-microfrontends = { path = "crates/turborepo-microfrontends" }

--- a/crates/turborepo-json-rewrite/Cargo.toml
+++ b/crates/turborepo-json-rewrite/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "turborepo-json-rewrite"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+jsonc-parser = "0.21.0"
+thiserror = "1.0.38"
+
+[dev-dependencies]
+pretty_assertions = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/turborepo-json-rewrite/src/lib.rs
+++ b/crates/turborepo-json-rewrite/src/lib.rs
@@ -352,7 +352,7 @@ fn find_all_paths<'a>(
 mod test {
     use pretty_assertions::assert_str_eq;
 
-    use crate::rewrite_json::{set_path, unset_path};
+    use crate::{set_path, unset_path};
 
     macro_rules! set_tests {
         ($($name:ident: $value:expr,)*) => {

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -139,6 +139,7 @@ turborepo-frameworks = { workspace = true }
 turborepo-fs = { path = "../turborepo-fs" }
 turborepo-gitignore = { workspace = true }
 turborepo-graph-utils = { path = "../turborepo-graph-utils" }
+turborepo-json-rewrite = { path = "../turborepo-json-rewrite" }
 turborepo-lockfiles = { workspace = true }
 turborepo-microfrontends = { workspace = true }
 turborepo-microfrontends-proxy = { workspace = true }

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -31,7 +31,7 @@ mod opts;
 mod package_changes_watcher;
 mod panic_handler;
 mod query;
-mod rewrite_json;
+pub use turborepo_json_rewrite as rewrite_json;
 mod run;
 mod shim;
 mod task_graph;


### PR DESCRIPTION
## Summary

Extract the self-contained `rewrite_json` module into its own crate as part of the ongoing `turborepo-lib` modularization effort.

- Create new `turborepo-json-rewrite` crate with `jsonc-parser` dependency
- Re-export from `turborepo-lib` to preserve existing internal usages
- All 14 existing tests pass

## Details

This module provides JSON document mutation utilities (`set_path`, `unset_path`) used for modifying `turbo.json` configuration files. It has **zero internal dependencies**, making it an ideal first extraction candidate.

The re-export pattern (`pub use turborepo_json_rewrite as rewrite_json;`) ensures all existing internal usages continue to work without modification.

## Test Plan

- `cargo check -p turborepo-json-rewrite -p turborepo-lib` ✅
- `cargo test -p turborepo-json-rewrite` ✅ (14 tests pass)