### PR TITLE
chore: Extract types to turborepo-types and create turborepo-daemon crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7391,6 +7391,7 @@ dependencies = [
  "tui-term",
  "turbopath",
  "turborepo-ci",
+ "turborepo-types",
  "turborepo-vt100",
  "which",
  "windows-sys 0.59.0",

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -6,7 +6,6 @@ use std::{
     io, mem, process,
 };
 
-use biome_deserialize_macros::Deserializable;
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::{
     builder::NonEmptyStringValueParser, ArgAction, ArgGroup, CommandFactory, Parser, Subcommand,
@@ -48,44 +47,13 @@ const DEFAULT_NUM_WORKERS: u32 = 10;
 const SUPPORTED_GRAPH_FILE_EXTENSIONS: [&str; 8] =
     ["svg", "png", "jpg", "pdf", "json", "html", "mermaid", "dot"];
 
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum, Deserializable, Serialize)]
-pub enum OutputLogsMode {
-    #[serde(rename = "full")]
-    #[default]
-    Full,
-    #[serde(rename = "none")]
-    None,
-    #[serde(rename = "hash-only")]
-    HashOnly,
-    #[serde(rename = "new-only")]
-    NewOnly,
-    #[serde(rename = "errors-only")]
-    ErrorsOnly,
-}
-
-impl Display for OutputLogsMode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
-            OutputLogsMode::Full => "full",
-            OutputLogsMode::None => "none",
-            OutputLogsMode::HashOnly => "hash-only",
-            OutputLogsMode::NewOnly => "new-only",
-            OutputLogsMode::ErrorsOnly => "errors-only",
-        })
-    }
-}
-
-impl From<OutputLogsMode> for turborepo_ui::tui::event::OutputLogs {
-    fn from(value: OutputLogsMode) -> Self {
-        match value {
-            OutputLogsMode::Full => turborepo_ui::tui::event::OutputLogs::Full,
-            OutputLogsMode::None => turborepo_ui::tui::event::OutputLogs::None,
-            OutputLogsMode::HashOnly => turborepo_ui::tui::event::OutputLogs::HashOnly,
-            OutputLogsMode::NewOnly => turborepo_ui::tui::event::OutputLogs::NewOnly,
-            OutputLogsMode::ErrorsOnly => turborepo_ui::tui::event::OutputLogs::ErrorsOnly,
-        }
-    }
-}
+// Re-export OutputLogsMode from turborepo-types for backward compatibility.
+// New code should import directly from `turborepo_types::OutputLogsMode`.
+#[deprecated(
+    since = "2.4.0",
+    note = "Import `OutputLogsMode` directly from `turborepo_types` instead"
+)]
+pub use turborepo_types::OutputLogsMode;
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, ValueEnum, Deserialize, Eq)]
 pub enum LogOrder {

--- a/crates/turborepo-lib/src/task_graph/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/mod.rs
@@ -6,6 +6,14 @@ use globwalk::{GlobError, ValidatedGlob};
 use turbopath::{AnchoredSystemPath, AnchoredSystemPathBuf, RelativeUnixPathBuf};
 use turborepo_errors::Spanned;
 use turborepo_task_id::{TaskId, TaskName};
+use turborepo_types::EnvMode;
+// Re-export TaskInputs from turborepo-types for backward compatibility.
+// New code should import directly from `turborepo_types::TaskInputs`.
+#[deprecated(
+    since = "2.4.0",
+    note = "Import `TaskInputs` directly from `turborepo_types` instead"
+)]
+pub use turborepo_types::TaskInputs;
 // Re-export TaskOutputs from turborepo-types for backward compatibility.
 // New code should import directly from `turborepo_types::TaskOutputs`.
 #[deprecated(
@@ -15,7 +23,7 @@ use turborepo_task_id::{TaskId, TaskName};
 pub use turborepo_types::TaskOutputs;
 pub use visitor::{Error as VisitorError, Visitor};
 
-use crate::cli::{EnvMode, OutputLogsMode};
+use crate::cli::OutputLogsMode;
 
 // Constructed from a RawTaskDefinition
 #[derive(Debug, PartialEq, Clone, Eq)]
@@ -68,14 +76,6 @@ pub struct TaskDefinition {
     // It will also not affect the task's hash aside from the definition getting folded into the
     // hash.
     pub with: Option<Vec<Spanned<TaskName<'static>>>>,
-}
-
-// Structure for holding the inputs for a task
-#[derive(Debug, PartialEq, Clone, Eq, Default)]
-pub struct TaskInputs {
-    pub globs: Vec<String>,
-    // Set when $TURBO_DEFAULT$ is in inputs
-    pub default: bool,
 }
 
 impl Default for TaskDefinition {
@@ -157,20 +157,6 @@ impl TaskDefinition {
         }
 
         repo_relative_globs
-    }
-}
-
-impl TaskInputs {
-    pub fn new(globs: Vec<String>) -> Self {
-        Self {
-            globs,
-            default: false,
-        }
-    }
-
-    pub fn with_default(mut self, default: bool) -> Self {
-        self.default = default;
-        self
     }
 }
 

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -13,12 +13,12 @@ use turbopath::{AbsoluteSystemPath, RelativeUnixPath};
 use turborepo_errors::Spanned;
 use turborepo_repository::package_graph::ROOT_PKG_NAME;
 use turborepo_task_id::{TaskId, TaskName};
+use turborepo_types::{EnvMode, TaskInputs, TaskOutputs};
 use turborepo_unescape::UnescapedString;
 
 use crate::{
-    cli::EnvMode,
     config::{Error, InvalidEnvPrefixError},
-    task_graph::{TaskDefinition, TaskInputs, TaskOutputs},
+    task_graph::TaskDefinition,
 };
 
 mod extend;
@@ -172,12 +172,22 @@ fn task_outputs_from_processed(
     })
 }
 
-impl TaskInputs {
+/// Extension trait for creating TaskInputs from ProcessedInputs.
+/// This is defined here rather than on the type itself to allow TaskInputs
+/// to live in turborepo-types without depending on turbo_json types.
+trait TaskInputsFromProcessed {
     /// Creates TaskInputs from ProcessedInputs with resolved paths
     fn from_processed(
         inputs: processed::ProcessedInputs,
         turbo_root_path: &RelativeUnixPath,
-    ) -> Result<Self, Error> {
+    ) -> Result<TaskInputs, Error>;
+}
+
+impl TaskInputsFromProcessed for TaskInputs {
+    fn from_processed(
+        inputs: processed::ProcessedInputs,
+        turbo_root_path: &RelativeUnixPath,
+    ) -> Result<TaskInputs, Error> {
         // Resolve all globs with the turbo_root path
         // Absolute path validation was already done during ProcessedGlob creation
         Ok(TaskInputs {

--- a/crates/turborepo-types/src/lib.rs
+++ b/crates/turborepo-types/src/lib.rs
@@ -35,12 +35,75 @@ impl fmt::Display for EnvMode {
     }
 }
 
+/// Output log mode for task execution.
+///
+/// Controls how task output logs are displayed and persisted:
+/// - `Full`: Entire task output is persisted after run
+/// - `None`: None of a task output is persisted after run
+/// - `HashOnly`: Only the status line of a task is persisted
+/// - `NewOnly`: Output is only persisted if it is a cache miss
+/// - `ErrorsOnly`: Output is only persisted if the task failed
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum, Deserializable, Serialize)]
+pub enum OutputLogsMode {
+    #[serde(rename = "full")]
+    #[default]
+    Full,
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "hash-only")]
+    HashOnly,
+    #[serde(rename = "new-only")]
+    NewOnly,
+    #[serde(rename = "errors-only")]
+    ErrorsOnly,
+}
+
+impl fmt::Display for OutputLogsMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            OutputLogsMode::Full => "full",
+            OutputLogsMode::None => "none",
+            OutputLogsMode::HashOnly => "hash-only",
+            OutputLogsMode::NewOnly => "new-only",
+            OutputLogsMode::ErrorsOnly => "errors-only",
+        })
+    }
+}
+
 /// TaskOutputs represents the patterns for including and excluding files from
 /// outputs.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TaskOutputs {
     pub inclusions: Vec<String>,
     pub exclusions: Vec<String>,
+}
+
+/// TaskInputs represents the input file patterns for a task.
+///
+/// Contains glob patterns for files that the task depends on, and a flag
+/// indicating whether to include default inputs ($TURBO_DEFAULT$).
+#[derive(Debug, PartialEq, Clone, Eq, Default)]
+pub struct TaskInputs {
+    /// Glob patterns for input files
+    pub globs: Vec<String>,
+    /// Set when $TURBO_DEFAULT$ is in inputs
+    pub default: bool,
+}
+
+impl TaskInputs {
+    /// Creates a new TaskInputs with the given globs and default set to false
+    pub fn new(globs: Vec<String>) -> Self {
+        Self {
+            globs,
+            default: false,
+        }
+    }
+
+    /// Sets the default flag and returns self for method chaining
+    pub fn with_default(mut self, default: bool) -> Self {
+        self.default = default;
+        self
+    }
 }
 
 #[cfg(test)]
@@ -54,6 +117,20 @@ mod tests {
     }
 
     #[test]
+    fn output_logs_mode_display() {
+        assert_eq!(format!("{}", OutputLogsMode::Full), "full");
+        assert_eq!(format!("{}", OutputLogsMode::None), "none");
+        assert_eq!(format!("{}", OutputLogsMode::HashOnly), "hash-only");
+        assert_eq!(format!("{}", OutputLogsMode::NewOnly), "new-only");
+        assert_eq!(format!("{}", OutputLogsMode::ErrorsOnly), "errors-only");
+    }
+
+    #[test]
+    fn output_logs_mode_default() {
+        assert_eq!(OutputLogsMode::default(), OutputLogsMode::Full);
+    }
+
+    #[test]
     fn env_mode_default() {
         assert_eq!(EnvMode::default(), EnvMode::Strict);
     }
@@ -63,5 +140,26 @@ mod tests {
         let outputs = TaskOutputs::default();
         assert!(outputs.inclusions.is_empty());
         assert!(outputs.exclusions.is_empty());
+    }
+
+    #[test]
+    fn task_inputs_default() {
+        let inputs = TaskInputs::default();
+        assert!(inputs.globs.is_empty());
+        assert!(!inputs.default);
+    }
+
+    #[test]
+    fn task_inputs_new() {
+        let inputs = TaskInputs::new(vec!["src/**".to_string()]);
+        assert_eq!(inputs.globs, vec!["src/**".to_string()]);
+        assert!(!inputs.default);
+    }
+
+    #[test]
+    fn task_inputs_with_default() {
+        let inputs = TaskInputs::new(vec!["src/**".to_string()]).with_default(true);
+        assert_eq!(inputs.globs, vec!["src/**".to_string()]);
+        assert!(inputs.default);
     }
 }

--- a/crates/turborepo-ui/Cargo.toml
+++ b/crates/turborepo-ui/Cargo.toml
@@ -36,6 +36,7 @@ tracing = { workspace = true }
 tui-term = { workspace = true }
 turbopath = { workspace = true }
 turborepo-ci = { workspace = true }
+turborepo-types = { workspace = true }
 turborepo-vt100 = { workspace = true }
 which = { workspace = true }
 

--- a/crates/turborepo-ui/src/tui/event.rs
+++ b/crates/turborepo-ui/src/tui/event.rs
@@ -104,6 +104,18 @@ pub enum OutputLogs {
     ErrorsOnly,
 }
 
+impl From<turborepo_types::OutputLogsMode> for OutputLogs {
+    fn from(value: turborepo_types::OutputLogsMode) -> Self {
+        match value {
+            turborepo_types::OutputLogsMode::Full => OutputLogs::Full,
+            turborepo_types::OutputLogsMode::None => OutputLogs::None,
+            turborepo_types::OutputLogsMode::HashOnly => OutputLogs::HashOnly,
+            turborepo_types::OutputLogsMode::NewOnly => OutputLogs::NewOnly,
+            turborepo_types::OutputLogsMode::ErrorsOnly => OutputLogs::ErrorsOnly,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PaneSize {
     pub rows: u16,


### PR DESCRIPTION
## Summary

Two related extractions from turborepo-lib that enable further modularization:

### 1. Extract OutputLogsMode and TaskInputs to turborepo-types

Foundation types that are used across multiple modules. Their extraction breaks circular dependencies.

**Types Extracted:**
- `OutputLogsMode` - Controls task output logging behavior
- `TaskInputs` - Structure for holding task input globs

**Patterns Used:**
- `OutputLogsMode`: Moved `From<OutputLogsMode> for OutputLogs` impl to `turborepo-ui`
- `TaskInputs`: Converted `from_processed` to extension trait (`TaskInputsFromProcessed`) in `turbo_json`

### 2. Extract turborepo-daemon crate (~2,740 lines)

The daemon module is now a standalone crate with a clean trait-based interface.

**Key Design:**
- Defined `PackageChangesWatcher` trait in turborepo-daemon
- `TurboGrpcService` accepts a factory function for creating watchers
- turborepo-lib implements the trait and provides the factory

**New crate structure:**
```
crates/turborepo-daemon/
├── Cargo.toml
├── build.rs
└── src/
    ├── lib.rs (exports + PackageChangesWatcher trait)
    ├── client.rs
    ├── connector.rs
    ├── server.rs
    ├── endpoint.rs
    └── proto/turbod.proto
```

## Changes

**turborepo-types:**
- Added `OutputLogsMode` and `TaskInputs` with tests

**turborepo-ui:**
- Added `From<OutputLogsMode> for OutputLogs` impl
- Added `turborepo-types` dependency

**turborepo-daemon (new):**
- All daemon functionality (~2,740 lines)
- `PackageChangesWatcher` trait for DI
- 32 tests passing

**turborepo-lib:**
- Re-exports types with deprecation warnings
- Implements `PackageChangesWatcher` trait for `PackageChangesWatcher` struct
- Depends on `turborepo-daemon`

## Testing

- `cargo check --all` passes
- `cargo test -p turborepo-daemon` - 32 tests pass
- `cargo test -p turborepo-types` - 8 tests pass