### PR TITLE
examples: Remove skipLibCheck from nestjs.json in nestJS example

### DIFF
--- a/examples/with-nestjs/packages/typescript-config/nestjs.json
+++ b/examples/with-nestjs/packages/typescript-config/nestjs.json
@@ -12,7 +12,6 @@
     "noFallthroughCasesInSwitch": false,
     "noImplicitAny": false,
     "removeComments": true,
-    "skipLibCheck": true,
     "sourceMap": true,
     "strictNullChecks": false,
     "strictBindCallApply": false


### PR DESCRIPTION
Removed 'skipLibCheck' from `nestjs.json`

### Description

`skipLibCheck` is already set to `true` in `base.json`. Having it here as well is duplicative.

### Testing Instructions

`pnpm run build`