### PR TITLE
chore: Move `ContinueMode` and `LogPrefix` to `turborepo-types`

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1,10 +1,4 @@
-use std::{
-    backtrace::Backtrace,
-    env,
-    ffi::OsString,
-    fmt::{self, Display},
-    io, mem, process,
-};
+use std::{backtrace::Backtrace, env, ffi::OsString, fmt, io, mem, process};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::{
@@ -22,7 +16,7 @@ use turborepo_telemetry::{
     events::{command::CommandEventBuilder, generic::GenericEventBuilder, EventBuilder, EventType},
     init_telemetry, track_usage, TelemetryHandle,
 };
-use turborepo_types::{DryRunMode, LogOrder, UIMode};
+use turborepo_types::{ContinueMode, DryRunMode, LogOrder, LogPrefix, UIMode};
 use turborepo_ui::{ColorConfig, GREY};
 
 use crate::{
@@ -61,25 +55,6 @@ pub use turborepo_types::EnvMode;
     note = "Import `OutputLogsMode` directly from `turborepo_types` instead"
 )]
 pub use turborepo_types::OutputLogsMode;
-
-#[derive(Copy, Clone, Debug, Default, PartialEq, ValueEnum, Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum ContinueMode {
-    #[default]
-    Never,
-    DependenciesSuccessful,
-    Always,
-}
-
-impl fmt::Display for ContinueMode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
-            ContinueMode::Never => "never",
-            ContinueMode::DependenciesSuccessful => "dependencies-successful",
-            ContinueMode::Always => "always",
-        })
-    }
-}
 
 /// The parsed arguments from the command line. In general we should avoid using
 /// or mutating this directly, and instead use the fully canonicalized `Opts`
@@ -1153,27 +1128,6 @@ impl RunArgs {
             // track the extension used only
             let extension = Utf8Path::new(graph).extension().unwrap_or("stdout");
             telemetry.track_arg_value("graph", extension, EventType::NonSensitive);
-        }
-    }
-}
-
-#[derive(ValueEnum, Clone, Copy, Debug, Default, PartialEq, Serialize)]
-pub enum LogPrefix {
-    #[serde(rename = "auto")]
-    #[default]
-    Auto,
-    #[serde(rename = "none")]
-    None,
-    #[serde(rename = "task")]
-    Task,
-}
-
-impl Display for LogPrefix {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            LogPrefix::Auto => write!(f, "auto"),
-            LogPrefix::None => write!(f, "none"),
-            LogPrefix::Task => write!(f, "task"),
         }
     }
 }

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -9,10 +9,12 @@ use turborepo_cache::{CacheOpts, RemoteCacheOpts};
 // Re-export ScopeOpts from turborepo-scope to avoid duplication
 pub use turborepo_scope::ScopeOpts;
 use turborepo_task_id::{TaskId, TaskName};
-use turborepo_types::{DryRunMode, EnvMode, LogOrder, OutputLogsMode, UIMode};
+use turborepo_types::{
+    ContinueMode, DryRunMode, EnvMode, LogOrder, LogPrefix, OutputLogsMode, UIMode,
+};
 
 use crate::{
-    cli::{Command, ContinueMode, ExecutionArgs, LogPrefix, RunArgs},
+    cli::{Command, ExecutionArgs, RunArgs},
     config::{ConfigurationOptions, CONFIG_FILE},
     turbo_json::FutureFlags,
     Args,
@@ -557,12 +559,12 @@ mod test {
     use turbopath::AbsoluteSystemPathBuf;
     use turborepo_cache::{CacheActions, CacheConfig, CacheOpts};
     use turborepo_task_id::TaskId;
-    use turborepo_types::{DryRunMode, UIMode};
+    use turborepo_types::{ContinueMode, DryRunMode, UIMode};
     use turborepo_ui::ColorConfig;
 
     use super::{APIClientOpts, RepoOpts, RunOpts, TaskArgs};
     use crate::{
-        cli::{Command, ContinueMode, RunArgs},
+        cli::{Command, RunArgs},
         commands::CommandBase,
         config::{ConfigurationOptions, CONFIG_FILE},
         opts::{Opts, RunCacheOpts, ScopeOpts, TuiOpts},

--- a/crates/turborepo-lib/src/task_graph/visitor/exec.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/exec.rs
@@ -12,6 +12,7 @@ use turborepo_process::{ChildExit, Command, ProcessManager};
 use turborepo_repository::package_manager::PackageManager;
 use turborepo_task_id::TaskId;
 use turborepo_telemetry::events::{task::PackageTaskEventBuilder, TrackedErrors};
+use turborepo_types::ContinueMode;
 use turborepo_ui::{ColorConfig, OutputWriter};
 
 use super::{
@@ -21,7 +22,6 @@ use super::{
     TaskOutput, Visitor,
 };
 use crate::{
-    cli::ContinueMode,
     config::UIMode,
     engine::{Engine, StopExecution},
     run::{summary::TaskTracker, task_access::TaskAccess, CacheOutput, TaskCache},

--- a/crates/turborepo-types/src/lib.rs
+++ b/crates/turborepo-types/src/lib.rs
@@ -170,6 +170,58 @@ impl LogOrder {
     }
 }
 
+/// Continue mode for task execution.
+///
+/// Controls how task execution continues after failures:
+/// - `Never`: Stop on first failure
+/// - `DependenciesSuccessful`: Continue if dependencies succeeded
+/// - `Always`: Always continue regardless of failures
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ContinueMode {
+    #[default]
+    Never,
+    DependenciesSuccessful,
+    Always,
+}
+
+impl fmt::Display for ContinueMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            ContinueMode::Never => "never",
+            ContinueMode::DependenciesSuccessful => "dependencies-successful",
+            ContinueMode::Always => "always",
+        })
+    }
+}
+
+/// Log prefix mode for task output.
+///
+/// Controls how task output lines are prefixed:
+/// - `Auto`: System decides based on context
+/// - `None`: No prefix
+/// - `Task`: Prefix with task name
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum, Serialize)]
+pub enum LogPrefix {
+    #[serde(rename = "auto")]
+    #[default]
+    Auto,
+    #[serde(rename = "none")]
+    None,
+    #[serde(rename = "task")]
+    Task,
+}
+
+impl fmt::Display for LogPrefix {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            LogPrefix::Auto => "auto",
+            LogPrefix::None => "none",
+            LogPrefix::Task => "task",
+        })
+    }
+}
+
 /// TaskOutputs represents the patterns for including and excluding files from
 /// outputs.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

- Moves `ContinueMode` enum from `turborepo-lib/src/cli/mod.rs` to `turborepo-types`
- Moves `LogPrefix` enum from `turborepo-lib/src/cli/mod.rs` to `turborepo-types`
- Updates all imports across turborepo-lib to use `turborepo_types::` directly

This continues the modularization effort to extract types from the monolithic `turborepo-lib` crate into smaller, focused crates.

## Test Plan

- `cargo build -p turborepo-lib` passes with no errors or warnings