### PR TITLE
chore: Add generic `CommandProvider` trait to `turborepo-task-executor`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7497,6 +7497,8 @@ dependencies = [
  "serde",
  "tokio",
  "turbopath",
+ "turborepo-env",
+ "turborepo-process",
  "turborepo-run-cache",
  "turborepo-task-id",
  "turborepo-types",

--- a/crates/turborepo-task-executor/Cargo.toml
+++ b/crates/turborepo-task-executor/Cargo.toml
@@ -14,6 +14,10 @@ turborepo-types = { path = "../turborepo-types" }
 turborepo-run-cache = { path = "../turborepo-run-cache" }
 turborepo-ui = { path = "../turborepo-ui" }
 
+# Command execution
+turborepo-env = { workspace = true }
+turborepo-process = { workspace = true }
+
 # Used for output types
 either = { workspace = true }
 

--- a/crates/turborepo-task-executor/src/command.rs
+++ b/crates/turborepo-task-executor/src/command.rs
@@ -1,0 +1,181 @@
+//! Command provider infrastructure for task execution.
+//!
+//! This module provides the trait and factory for creating commands to execute
+//! tasks. The actual command provider implementations remain in turborepo-lib
+//! since they depend on package graph and microfrontends types.
+
+use turborepo_env::EnvironmentVariableMap;
+use turborepo_process::Command;
+use turborepo_task_id::TaskId;
+
+/// Trait for providing commands to execute tasks.
+///
+/// Implementors of this trait are responsible for determining how to execute
+/// a given task, including:
+/// - Finding the appropriate script/binary to run
+/// - Setting up the working directory
+/// - Configuring environment variables
+///
+/// # Type Parameters
+/// - `E`: The error type returned when command creation fails
+///
+/// # Implementors
+/// - `PackageGraphCommandProvider` in turborepo-lib (executes package.json
+///   scripts)
+/// - `MicroFrontendProxyProvider` in turborepo-lib (starts MFE proxy)
+pub trait CommandProvider<E> {
+    /// Create a command for the given task.
+    ///
+    /// Returns `Ok(Some(command))` if the provider can handle this task,
+    /// `Ok(None)` if this provider doesn't handle this task (allows
+    /// fallthrough), or `Err(e)` if an error occurred.
+    fn command(
+        &self,
+        task_id: &TaskId,
+        environment: EnvironmentVariableMap,
+    ) -> Result<Option<Command>, E>;
+}
+
+/// A collection of command providers.
+///
+/// Will attempt to find a command from any of the providers it contains.
+/// Ordering of the providers matters as the first present command will be
+/// returned. Any errors returned by the providers will be immediately returned.
+///
+/// # Type Parameters
+/// - `'a`: Lifetime of the providers
+/// - `E`: The error type returned by providers
+pub struct CommandFactory<'a, E> {
+    providers: Vec<Box<dyn CommandProvider<E> + 'a + Send>>,
+}
+
+impl<'a, E> CommandFactory<'a, E> {
+    /// Create a new empty command factory.
+    pub fn new() -> Self {
+        Self {
+            providers: Vec::new(),
+        }
+    }
+
+    /// Add a command provider to this factory.
+    ///
+    /// Providers are checked in the order they are added.
+    pub fn add_provider(&mut self, provider: impl CommandProvider<E> + 'a + Send) -> &mut Self {
+        self.providers.push(Box::new(provider));
+        self
+    }
+
+    /// Get a command for the given task.
+    ///
+    /// Iterates through providers in order until one returns a command.
+    /// Returns `Ok(None)` if no provider can handle the task.
+    pub fn command(
+        &self,
+        task_id: &TaskId,
+        environment: EnvironmentVariableMap,
+    ) -> Result<Option<Command>, E> {
+        for provider in self.providers.iter() {
+            let cmd = provider.command(task_id, environment.clone())?;
+            if cmd.is_some() {
+                return Ok(cmd);
+            }
+        }
+        Ok(None)
+    }
+}
+
+impl<'a, E> Default for CommandFactory<'a, E> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+
+    use super::*;
+
+    struct EchoProvider;
+
+    impl CommandProvider<String> for EchoProvider {
+        fn command(
+            &self,
+            _task_id: &TaskId,
+            _environment: EnvironmentVariableMap,
+        ) -> Result<Option<Command>, String> {
+            Ok(Some(Command::new("echo")))
+        }
+    }
+
+    struct NoneProvider;
+
+    impl CommandProvider<String> for NoneProvider {
+        fn command(
+            &self,
+            _task_id: &TaskId,
+            _environment: EnvironmentVariableMap,
+        ) -> Result<Option<Command>, String> {
+            Ok(None)
+        }
+    }
+
+    struct ErrProvider;
+
+    impl CommandProvider<String> for ErrProvider {
+        fn command(
+            &self,
+            _task_id: &TaskId,
+            _environment: EnvironmentVariableMap,
+        ) -> Result<Option<Command>, String> {
+            Err("error".to_string())
+        }
+    }
+
+    #[test]
+    fn test_first_present_cmd_returned() {
+        let mut factory = CommandFactory::new();
+        factory.add_provider(EchoProvider).add_provider(ErrProvider);
+        let task_id = TaskId::new("foo", "build");
+        let cmd = factory
+            .command(&task_id, EnvironmentVariableMap::default())
+            .unwrap()
+            .unwrap();
+        assert_eq!(cmd.program(), OsStr::new("echo"));
+    }
+
+    #[test]
+    fn test_error_short_circuits_factory() {
+        let mut factory = CommandFactory::new();
+        factory.add_provider(ErrProvider).add_provider(EchoProvider);
+        let task_id = TaskId::new("foo", "build");
+        let err = factory
+            .command(&task_id, EnvironmentVariableMap::default())
+            .unwrap_err();
+        assert_eq!(err, "error");
+    }
+
+    #[test]
+    fn test_none_values_filtered() {
+        let mut factory = CommandFactory::new();
+        factory
+            .add_provider(NoneProvider)
+            .add_provider(EchoProvider);
+        let task_id = TaskId::new("foo", "build");
+        let cmd = factory
+            .command(&task_id, EnvironmentVariableMap::default())
+            .unwrap()
+            .unwrap();
+        assert_eq!(cmd.program(), OsStr::new("echo"));
+    }
+
+    #[test]
+    fn test_none_returned_if_no_commands_found() {
+        let factory: CommandFactory<String> = CommandFactory::new();
+        let task_id = TaskId::new("foo", "build");
+        let cmd = factory
+            .command(&task_id, EnvironmentVariableMap::default())
+            .unwrap();
+        assert!(cmd.is_none(), "expected no cmd, got {cmd:?}");
+    }
+}

--- a/crates/turborepo-task-executor/src/lib.rs
+++ b/crates/turborepo-task-executor/src/lib.rs
@@ -17,10 +17,10 @@
 //! This allows the executor to be tested independently and reused in different
 //! contexts.
 
+mod command;
 mod output;
 
-use std::future::Future;
-
+pub use command::{CommandFactory, CommandProvider};
 pub use output::{StdWriter, TaskCacheOutput, TaskOutput};
 use serde::Serialize;
 use turbopath::AbsoluteSystemPathBuf;


### PR DESCRIPTION
## Summary

Extract the `CommandProvider` trait and `CommandFactory` to `turborepo-task-executor` as generic types parameterized by an error type. This allows the command infrastructure to be shared while letting `turborepo-lib` keep its specific error types and provider implementations.

### Changes

- Add `command.rs` to `turborepo-task-executor` with:
  - Generic `CommandProvider<E>` trait
  - Generic `CommandFactory<'a, E>` struct
  - Full test coverage
- Add `turborepo-env` and `turborepo-process` dependencies
- Update `turborepo-lib/command.rs` to use the generic trait via type alias:
  ```rust
  type CommandFactory<'a> = turborepo_task_executor::CommandFactory<'a, Error>
  ```
- Provider implementations (`PackageGraphCommandProvider`, `MicroFrontendProxyProvider`) remain in `turborepo-lib`

## Testing

- `cargo test -p turborepo-task-executor` - 7 tests pass
- `cargo test -p turborepo-lib --lib` - 253 tests pass