### PR TITLE
chore: Add `From<&RunOpts>` for `ExecutorConfig` conversion

### DIFF
--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -497,6 +497,24 @@ impl<'a> From<OptsInputs<'a>> for TuiOpts {
     }
 }
 
+// Convert RunOpts to ExecutorConfig for use with the generic task executor
+impl From<&RunOpts> for turborepo_task_executor::ExecutorConfig {
+    fn from(opts: &RunOpts) -> Self {
+        Self {
+            env_mode: opts.env_mode,
+            log_order: opts.log_order,
+            log_prefix: opts.log_prefix,
+            single_package: opts.single_package,
+            is_github_actions: opts.is_github_actions,
+            concurrency: opts.concurrency,
+            ui_mode: opts.ui_mode,
+            continue_on_error: opts.continue_on_error,
+            redirect_stderr_to_stdout: opts.should_redirect_stderr_to_stdout(),
+            framework_inference: opts.framework_inference,
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use clap::Parser;


### PR DESCRIPTION
## Summary

- Adds a `From<&RunOpts>` implementation for `ExecutorConfig` to bridge turborepo-lib's options to the generic task executor
- This allows `turborepo-task-executor` to be configured from run options without directly depending on turborepo-lib's internal types

## Testing

- `cargo check -p turborepo-lib` passes
- All existing tests continue to pass