### PR TITLE
chore: Extract task execution types and traits to turborepo-task-executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6915,6 +6915,7 @@ dependencies = [
  "turborepo-graph-utils",
  "turborepo-lockfiles",
  "turborepo-repository",
+ "turborepo-task-executor",
  "turborepo-task-id",
  "turborepo-turbo-json",
  "turborepo-types",
@@ -7493,16 +7494,25 @@ dependencies = [
 name = "turborepo-task-executor"
 version = "0.1.0"
 dependencies = [
+ "chrono",
+ "console",
  "either",
  "serde",
+ "thiserror 1.0.63",
  "tokio",
+ "tracing",
  "turbopath",
+ "turborepo-cache",
  "turborepo-env",
  "turborepo-process",
+ "turborepo-repository",
  "turborepo-run-cache",
+ "turborepo-run-summary",
  "turborepo-task-id",
+ "turborepo-telemetry",
  "turborepo-types",
  "turborepo-ui",
+ "which",
 ]
 
 [[package]]
@@ -7530,6 +7540,7 @@ dependencies = [
  "turborepo-repository",
  "turborepo-run-summary",
  "turborepo-scm",
+ "turborepo-task-executor",
  "turborepo-task-id",
  "turborepo-telemetry",
  "turborepo-types",

--- a/crates/turborepo-engine/Cargo.toml
+++ b/crates/turborepo-engine/Cargo.toml
@@ -22,6 +22,7 @@ turborepo-config = { path = "../turborepo-config" }
 turborepo-errors = { workspace = true }
 turborepo-graph-utils = { path = "../turborepo-graph-utils" }
 turborepo-repository = { path = "../turborepo-repository" }
+turborepo-task-executor = { path = "../turborepo-task-executor" }
 turborepo-task-id = { path = "../turborepo-task-id" }
 turborepo-turbo-json = { path = "../turborepo-turbo-json" }
 turborepo-types = { workspace = true }

--- a/crates/turborepo-engine/src/execute.rs
+++ b/crates/turborepo-engine/src/execute.rs
@@ -55,6 +55,16 @@ pub enum StopExecution {
     DependentTasks,
 }
 
+impl turborepo_task_executor::StopExecutionProvider for StopExecution {
+    fn dependent_tasks() -> Self {
+        StopExecution::DependentTasks
+    }
+
+    fn all_tasks() -> Self {
+        StopExecution::AllTasks
+    }
+}
+
 impl<T: TaskDefinitionInfo + Clone + Send + Sync + 'static> Engine<Built, T> {
     /// Execute a task graph by sending task ids to the visitor
     /// while respecting concurrency limits.

--- a/crates/turborepo-task-executor/Cargo.toml
+++ b/crates/turborepo-task-executor/Cargo.toml
@@ -11,6 +11,7 @@ turborepo-task-id = { path = "../turborepo-task-id" }
 turborepo-types = { path = "../turborepo-types" }
 
 # Cache output trait
+turborepo-cache = { path = "../turborepo-cache" }
 turborepo-run-cache = { path = "../turborepo-run-cache" }
 turborepo-ui = { path = "../turborepo-ui" }
 
@@ -18,11 +19,36 @@ turborepo-ui = { path = "../turborepo-ui" }
 turborepo-env = { workspace = true }
 turborepo-process = { workspace = true }
 
+# Run summary for task tracking
+turborepo-run-summary = { path = "../turborepo-run-summary" }
+
+# Telemetry
+turborepo-telemetry = { path = "../turborepo-telemetry" }
+
+# Repository types (for PackageManager)
+turborepo-repository = { path = "../turborepo-repository" }
+
 # Used for output types
 either = { workspace = true }
+
+# Console for styled output
+console = { workspace = true }
+
+# Error handling
+thiserror = { workspace = true }
+which = { workspace = true }
 
 # Async runtime
 tokio = { workspace = true }
 
+# Tracing
+tracing = { workspace = true }
+
+# Time
+chrono = { workspace = true }
+
 # Serialization (for config)
 serde = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/turborepo-task-executor/src/exec.rs
+++ b/crates/turborepo-task-executor/src/exec.rs
@@ -1,0 +1,210 @@
+//! Task execution context and related types.
+//!
+//! This module provides the core execution infrastructure for running tasks,
+//! including error types, outcome enums, and trait definitions for abstracting
+//! cache and hash tracking dependencies.
+//!
+//! The actual `ExecContext` implementation remains in turborepo-lib due to
+//! complex dependencies, but uses these types and traits.
+
+use std::time::Duration;
+
+use turbopath::AnchoredSystemPathBuf;
+use turborepo_cache::{CacheError, CacheHitMetadata};
+// Re-export CacheOutput for use by implementors
+pub use turborepo_run_cache::CacheOutput;
+use turborepo_task_id::TaskId;
+use turborepo_telemetry::events::task::PackageTaskEventBuilder;
+use turborepo_types::OutputLogsMode;
+
+// ============================================================================
+// Error Types
+// ============================================================================
+
+/// Internal errors that can occur during task execution.
+///
+/// These are errors that are not task failures (non-zero exit codes) but rather
+/// infrastructure errors that prevent task execution.
+#[derive(Debug, thiserror::Error)]
+pub enum InternalError {
+    /// IO error during execution
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    /// Unable to determine why task exited
+    #[error("unable to determine why task exited")]
+    UnknownChildExit,
+
+    /// Unable to find package manager binary
+    #[error("unable to find package manager binary: {0}")]
+    Which(#[from] which::Error),
+
+    /// External process killed a task
+    #[error("external process killed a task")]
+    ExternalKill,
+
+    /// Error writing logs
+    #[error("error writing logs: {0}")]
+    Logs(#[from] CacheError),
+}
+
+/// Outcome of task execution.
+#[derive(Debug)]
+pub enum ExecOutcome {
+    /// All operations during execution succeeded
+    Success(SuccessOutcome),
+    /// An error with the task execution (non-zero exit or spawn failure)
+    Task {
+        /// Exit code if the task ran
+        exit_code: Option<i32>,
+        /// Error message
+        message: String,
+    },
+    /// Task didn't execute normally due to a shutdown being initiated
+    Shutdown,
+    /// Task was stopped to be restarted
+    Restarted,
+}
+
+/// Type of successful execution.
+#[derive(Debug)]
+pub enum SuccessOutcome {
+    /// Task output was restored from cache
+    CacheHit,
+    /// Task was executed
+    Run,
+}
+
+// ============================================================================
+// Provider Traits
+// ============================================================================
+
+/// Trait for task hash tracking operations.
+///
+/// This trait abstracts the hash tracker to allow the executor to work with
+/// hash tracking without depending on the full TaskHashTracker implementation.
+pub trait TaskHashTrackerProvider: Clone + Send + Sync {
+    /// Insert the cache status for a task
+    fn insert_cache_status(&self, task_id: TaskId<'static>, status: CacheHitMetadata);
+
+    /// Insert the expanded outputs for a task
+    fn insert_expanded_outputs(
+        &self,
+        task_id: TaskId<'static>,
+        outputs: Vec<AnchoredSystemPathBuf>,
+    );
+}
+
+/// Trait for stop execution signaling.
+///
+/// This trait abstracts the mechanism for signaling task execution should stop.
+pub trait StopExecutionProvider: Clone + Send + Sync + 'static {
+    /// Signal that dependent tasks should stop
+    fn dependent_tasks() -> Self;
+
+    /// Signal that all tasks should stop
+    fn all_tasks() -> Self;
+}
+
+/// Trait for task error collection.
+pub trait TaskErrorProvider: Send + 'static {
+    /// Create an error from a spawn failure
+    fn from_spawn(task_id: String, error: std::io::Error) -> Self;
+
+    /// Create an error from a task execution failure
+    fn from_execution(task_id: String, command: String, exit_code: i32) -> Self;
+}
+
+/// Trait for task warning collection.
+pub trait TaskWarningProvider: Send + 'static {
+    /// Create a warning for missing platform environment variables
+    fn from_missing_platform_env(task_id: &str, missing_vars: Vec<String>) -> Option<Self>
+    where
+        Self: Sized;
+}
+
+/// Trait for task cache operations.
+///
+/// This trait abstracts the task cache to allow the executor to work with
+/// caching without depending on the full TaskCache implementation.
+///
+/// Note: This trait uses associated types and sync methods where possible
+/// to avoid complex async trait bounds. Implementors should handle async
+/// operations internally.
+pub trait TaskCacheProvider: Send {
+    /// The error type for cache operations
+    type Error: std::error::Error + Send + 'static;
+
+    /// Returns the output logs mode
+    fn output_logs(&self) -> OutputLogsMode;
+
+    /// Returns true if caching is disabled for this task
+    fn is_caching_disabled(&self) -> bool;
+
+    /// Returns the expanded outputs for this task
+    fn expanded_outputs(&self) -> &[AnchoredSystemPathBuf];
+
+    /// Check if cache entry exists (blocking)
+    fn exists_blocking(&self) -> Result<Option<CacheHitMetadata>, Self::Error>;
+
+    /// Restore outputs from cache (blocking)
+    fn restore_outputs_blocking<O: CacheOutput>(
+        &mut self,
+        output: &mut O,
+        telemetry: &PackageTaskEventBuilder,
+    ) -> Result<Option<CacheHitMetadata>, Self::Error>;
+
+    /// Save outputs to cache (blocking)
+    fn save_outputs_blocking(
+        &mut self,
+        duration: Duration,
+        telemetry: &PackageTaskEventBuilder,
+    ) -> Result<(), Self::Error>;
+
+    /// Handle error output
+    fn on_error<O: CacheOutput>(&self, output: &mut O) -> Result<(), Self::Error>;
+
+    /// Create an output writer for the task
+    fn output_writer<W: std::io::Write>(
+        &self,
+        writer: W,
+    ) -> Result<impl std::io::Write, Self::Error>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_internal_error_display() {
+        let err = InternalError::UnknownChildExit;
+        assert_eq!(err.to_string(), "unable to determine why task exited");
+
+        let err = InternalError::ExternalKill;
+        assert_eq!(err.to_string(), "external process killed a task");
+    }
+
+    #[test]
+    fn test_exec_outcome_variants() {
+        let success = ExecOutcome::Success(SuccessOutcome::Run);
+        assert!(matches!(success, ExecOutcome::Success(SuccessOutcome::Run)));
+
+        let cache_hit = ExecOutcome::Success(SuccessOutcome::CacheHit);
+        assert!(matches!(
+            cache_hit,
+            ExecOutcome::Success(SuccessOutcome::CacheHit)
+        ));
+
+        let task_error = ExecOutcome::Task {
+            exit_code: Some(1),
+            message: "failed".to_string(),
+        };
+        assert!(matches!(task_error, ExecOutcome::Task { .. }));
+
+        let shutdown = ExecOutcome::Shutdown;
+        assert!(matches!(shutdown, ExecOutcome::Shutdown));
+
+        let restarted = ExecOutcome::Restarted;
+        assert!(matches!(restarted, ExecOutcome::Restarted));
+    }
+}

--- a/crates/turborepo-task-executor/src/lib.rs
+++ b/crates/turborepo-task-executor/src/lib.rs
@@ -13,19 +13,28 @@
 //!   RunOpts)
 //! - [`MfeConfigProvider`]: Abstraction for microfrontends configuration
 //! - [`TaskAccessProvider`]: Abstraction for task access tracing
+//! - [`TaskCacheProvider`]: Abstraction for task caching operations
+//! - [`TaskHashTrackerProvider`]: Abstraction for hash tracking
 //!
 //! This allows the executor to be tested independently and reused in different
 //! contexts.
 
 mod command;
+mod exec;
 mod output;
 
 pub use command::{CommandFactory, CommandProvider};
+pub use exec::{
+    CacheOutput, ExecOutcome, InternalError, StopExecutionProvider, SuccessOutcome,
+    TaskCacheProvider, TaskErrorProvider, TaskHashTrackerProvider, TaskWarningProvider,
+};
 pub use output::{StdWriter, TaskCacheOutput, TaskOutput};
 use serde::Serialize;
 use turbopath::AbsoluteSystemPathBuf;
 use turborepo_task_id::TaskId;
-use turborepo_types::{ContinueMode, EnvMode, ResolvedLogOrder, ResolvedLogPrefix, UIMode};
+// Re-export UIMode for use in exec module and external users
+pub use turborepo_types::UIMode;
+use turborepo_types::{ContinueMode, EnvMode, ResolvedLogOrder, ResolvedLogPrefix};
 
 /// Configuration for task execution.
 ///

--- a/crates/turborepo-task-hash/Cargo.toml
+++ b/crates/turborepo-task-hash/Cargo.toml
@@ -26,6 +26,7 @@ turborepo-lockfiles = { workspace = true }
 turborepo-repository = { path = "../turborepo-repository" }
 turborepo-run-summary = { workspace = true }
 turborepo-scm = { workspace = true }
+turborepo-task-executor = { path = "../turborepo-task-executor" }
 turborepo-task-id = { workspace = true }
 turborepo-telemetry = { path = "../turborepo-telemetry" }
 turborepo-types = { workspace = true }

--- a/crates/turborepo-task-hash/src/lib.rs
+++ b/crates/turborepo-task-hash/src/lib.rs
@@ -749,6 +749,23 @@ impl HashTrackerInfo for TaskHashTracker {
     }
 }
 
+// Implement TaskHashTrackerProvider for TaskHashTracker to allow use with
+// turborepo-task-executor. The trait is defined in turborepo-task-executor
+// to enable proper dependency direction.
+impl turborepo_task_executor::TaskHashTrackerProvider for TaskHashTracker {
+    fn insert_cache_status(&self, task_id: TaskId<'static>, status: CacheHitMetadata) {
+        TaskHashTracker::insert_cache_status(self, task_id, status)
+    }
+
+    fn insert_expanded_outputs(
+        &self,
+        task_id: TaskId<'static>,
+        outputs: Vec<AnchoredSystemPathBuf>,
+    ) {
+        TaskHashTracker::insert_expanded_outputs(self, task_id, outputs)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
## Summary

Continues the turborepo-lib modularization by extracting task execution types and provider traits to `turborepo-task-executor`.

### Changes

- **New types in `turborepo-task-executor`:**
  - `ExecOutcome` - Task execution outcomes (Success, Task error, Shutdown, Restarted)
  - `SuccessOutcome` - Success types (CacheHit, Run)
  - `InternalError` - Errors during task execution

- **New provider traits:**
  - `TaskHashTrackerProvider` - Hash tracking abstraction
  - `StopExecutionProvider` - Stop execution signaling
  - `TaskErrorProvider` - Error collection
  - `TaskWarningProvider` - Warning collection
  - `TaskCacheProvider` - Cache operations

- **Trait implementations:**
  - `TaskHashTrackerProvider` for `TaskHashTracker` in turborepo-task-hash
  - `StopExecutionProvider` for `StopExecution` in turborepo-engine

- **turborepo-lib updates:**
  - Import `ExecOutcome` and `SuccessOutcome` from turborepo-task-executor
  - Keep local `InternalError` (depends on `turborepo_run_cache::Error` conversion)

### Part of
Phase 3 of turborepo-lib modularization - extracting task execution infrastructure.

### Related PRs
- #11356 - Shared types to turborepo-types
- #11357 - turborepo-task-executor crate skeleton
- #11358 - Generic CommandProvider trait
- #11359 - MfeConfigProvider and TaskAccessProvider traits
- #11360 - From<&RunOpts> for ExecutorConfig
- #11361 - TurboJsonReader moved to turborepo-turbo-json

### Testing
- `cargo test -p turborepo-task-executor --lib` - 9 tests pass
- `cargo test -p turborepo-lib --lib` - 253 tests pass
- `cargo clippy` - No warnings