### PR TITLE
chore: Move MicroFrontendProxyProvider to turborepo-task-executor

### DIFF
--- a/crates/turborepo-lib/src/microfrontends.rs
+++ b/crates/turborepo-lib/src/microfrontends.rs
@@ -348,6 +348,23 @@ impl MfeConfigProvider for MicrofrontendsConfigs {
     fn should_use_turborepo_proxy(&self) -> bool {
         MicrofrontendsConfigs::should_use_turborepo_proxy(self)
     }
+
+    fn dev_tasks(&self, package_name: &str) -> Option<Vec<(TaskId<'static>, String)>> {
+        self.configs.get(package_name).map(|info| {
+            info.tasks
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect()
+        })
+    }
+
+    fn config_filename(&self, package_name: &str) -> Option<String> {
+        self.configs
+            .get(package_name)?
+            .path
+            .as_ref()
+            .map(|p| p.to_string())
+    }
 }
 
 // Internal struct used to capture the results of checking the package graph

--- a/crates/turborepo-lib/src/task_graph/visitor/command.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/command.rs
@@ -1,13 +1,3 @@
-use std::collections::{HashMap, HashSet};
-
-use turbopath::AbsoluteSystemPath;
-use turborepo_env::EnvironmentVariableMap;
-use turborepo_microfrontends::MICROFRONTENDS_PACKAGE;
-use turborepo_process::Command;
-use turborepo_repository::package_graph::{PackageInfo, PackageName};
-use turborepo_task_executor::CommandProvider;
-use turborepo_task_id::TaskId;
-
 use super::Error;
 use crate::microfrontends::MicrofrontendsConfigs;
 
@@ -19,162 +9,27 @@ pub type CommandFactory<'a> = turborepo_task_executor::CommandFactory<'a, Error>
 pub type PackageGraphCommandProvider<'a> =
     turborepo_task_executor::PackageGraphCommandProvider<'a, MicrofrontendsConfigs>;
 
-// Re-export PackageInfoProvider trait from turborepo-task-executor
-pub use turborepo_task_executor::PackageInfoProvider;
-
-#[derive(Debug)]
-pub struct MicroFrontendProxyProvider<'a, T> {
-    repo_root: &'a AbsoluteSystemPath,
-    package_graph: &'a T,
-    tasks_in_graph: HashSet<TaskId<'a>>,
-    mfe_configs: &'a MicrofrontendsConfigs,
-}
-
-impl<'a, T: PackageInfoProvider> MicroFrontendProxyProvider<'a, T> {
-    pub fn new<'b>(
-        repo_root: &'a AbsoluteSystemPath,
-        package_graph: &'a T,
-        tasks_in_graph: impl Iterator<Item = &'b TaskId<'static>>,
-        micro_frontends_configs: &'a MicrofrontendsConfigs,
-    ) -> Self {
-        Self {
-            repo_root,
-            package_graph,
-            tasks_in_graph: tasks_in_graph.cloned().collect(),
-            mfe_configs: micro_frontends_configs,
-        }
-    }
-
-    fn dev_tasks(&self, task_id: &TaskId) -> Option<&HashMap<TaskId<'static>, String>> {
-        (task_id.task() == "proxy")
-            .then(|| self.mfe_configs.get(task_id.package()))
-            .flatten()
-    }
-
-    fn package_info(&self, task_id: &TaskId) -> Result<&PackageInfo, Error> {
-        self.package_graph
-            .package_info(&PackageName::from(task_id.package()))
-            .ok_or_else(|| Error::MissingPackage {
-                package_name: task_id.package().into(),
-                task_id: task_id.clone().into_owned(),
-            })
-    }
-
-    fn has_custom_proxy(&self, task_id: &TaskId) -> Result<bool, Error> {
-        let package_info = self.package_info(task_id)?;
-        Ok(package_info.package_json.scripts.contains_key("proxy"))
-    }
-}
-
-impl<'a, T: PackageInfoProvider> CommandProvider<Error> for MicroFrontendProxyProvider<'a, T> {
-    fn command(
-        &self,
-        task_id: &TaskId,
-        _environment: EnvironmentVariableMap,
-    ) -> Result<Option<Command>, Error> {
-        tracing::debug!(
-            "MicroFrontendProxyProvider::command - called for task: {}",
-            task_id
-        );
-
-        let Some(dev_tasks) = self.dev_tasks(task_id) else {
-            tracing::debug!(
-                "MicroFrontendProxyProvider::command - no dev tasks found for {}",
-                task_id
-            );
-            return Ok(None);
-        };
-
-        tracing::debug!(
-            "MicroFrontendProxyProvider::command - found {} dev tasks for {}",
-            dev_tasks.len(),
-            task_id
-        );
-
-        let has_custom_proxy = self.has_custom_proxy(task_id)?;
-        let package_info = self.package_info(task_id)?;
-        let has_mfe_dependency = package_info
-            .package_json
-            .all_dependencies()
-            .any(|(package, _version)| package.as_str() == MICROFRONTENDS_PACKAGE);
-
-        tracing::debug!(
-            "MicroFrontendProxyProvider::command - has_custom_proxy: {}, has_mfe_dependency: {}",
-            has_custom_proxy,
-            has_mfe_dependency
-        );
-
-        let local_apps = dev_tasks.iter().filter_map(|(task, app_name)| {
-            self.tasks_in_graph
-                .contains(task)
-                .then_some(app_name.as_str())
-        });
-        let package_dir = self.repo_root.resolve(package_info.package_path());
-        let mfe_config_filename = self
-            .mfe_configs
-            .config_filename(task_id.package())
-            .expect("every microfrontends default application should have configuration path");
-        let mfe_path = self.repo_root.join_unix_path(mfe_config_filename);
-
-        let cmd = if has_custom_proxy {
-            tracing::debug!("MicroFrontendProxyProvider::command - using custom proxy script");
-            let package_manager = self.package_graph.package_manager();
-            let mut proxy_args = vec![mfe_path.as_str(), "--names"];
-            proxy_args.extend(local_apps);
-            let mut args = vec!["run", "proxy"];
-            if let Some(sep) = package_manager.arg_separator(&proxy_args) {
-                args.push(sep);
-            }
-            args.extend(proxy_args);
-
-            let program = which::which(package_manager.command())?;
-            let mut cmd = Command::new(&program);
-            cmd.current_dir(package_dir).args(args).open_stdin();
-            Some(cmd)
-        } else if has_mfe_dependency {
-            tracing::debug!(
-                "MicroFrontendProxyProvider::command - using @vercel/microfrontends proxy"
-            );
-            let mut args = vec!["proxy", mfe_path.as_str(), "--names"];
-            args.extend(local_apps);
-
-            // On Windows, a package manager will rework the binary to be a .cmd extension
-            // since that's what Windows needs
-            let bin_name = if cfg!(windows) {
-                "microfrontends.cmd"
-            } else {
-                "microfrontends"
-            };
-
-            // TODO: leverage package manager to find the local proxy
-            let program = package_dir.join_components(&["node_modules", ".bin", bin_name]);
-            let mut cmd = Command::new(program.as_std_path());
-            cmd.current_dir(package_dir).args(args).open_stdin();
-            Some(cmd)
-        } else {
-            tracing::debug!("MicroFrontendProxyProvider::command - using Turborepo built-in proxy");
-            // No custom proxy and no @vercel/microfrontends dependency.
-            // The Turborepo proxy will be started separately.
-            None
-        };
-
-        tracing::debug!(
-            "MicroFrontendProxyProvider::command - returning command: {}",
-            if cmd.is_some() { "Some" } else { "None" }
-        );
-
-        Ok(cmd)
-    }
-}
+// Re-export MicroFrontendProxyProvider from turborepo-task-executor with our
+// MicrofrontendsConfigs type
+pub type MicroFrontendProxyProvider<'a, T> =
+    turborepo_task_executor::MicroFrontendProxyProvider<'a, T, MicrofrontendsConfigs>;
 
 #[cfg(test)]
 mod test {
     use std::ffi::OsStr;
 
     use insta::assert_snapshot;
-    use turbopath::AnchoredSystemPath;
-    use turborepo_microfrontends::TurborepoMfeConfig as Config;
-    use turborepo_repository::{package_json::PackageJson, package_manager::PackageManager};
+    use turbopath::{AbsoluteSystemPath, AnchoredSystemPath};
+    use turborepo_env::EnvironmentVariableMap;
+    use turborepo_microfrontends::{TurborepoMfeConfig as Config, MICROFRONTENDS_PACKAGE};
+    use turborepo_process::Command;
+    use turborepo_repository::{
+        package_graph::{PackageInfo, PackageName},
+        package_json::PackageJson,
+        package_manager::PackageManager,
+    };
+    use turborepo_task_executor::{CommandProvider, PackageInfoProvider};
+    use turborepo_task_id::TaskId;
 
     use super::*;
 

--- a/crates/turborepo-task-executor/src/lib.rs
+++ b/crates/turborepo-task-executor/src/lib.rs
@@ -25,8 +25,8 @@ mod output;
 mod visitor;
 
 pub use command::{
-    CommandFactory, CommandProvider, CommandProviderError, PackageGraphCommandProvider,
-    PackageInfoProvider,
+    CommandFactory, CommandProvider, CommandProviderError, MicroFrontendProxyProvider,
+    PackageGraphCommandProvider, PackageInfoProvider,
 };
 pub use exec::{
     DryRunExecutor, ExecOutcome, HashTrackerProvider, InternalError, SuccessOutcome,
@@ -94,6 +94,13 @@ pub trait MfeConfigProvider: Send + Sync {
 
     /// Returns true if all configs should use the Turborepo proxy
     fn should_use_turborepo_proxy(&self) -> bool;
+
+    /// Returns the dev tasks for a package, as a map from task ID to
+    /// application name
+    fn dev_tasks(&self, package_name: &str) -> Option<Vec<(TaskId<'static>, String)>>;
+
+    /// Returns the config filename path for a package
+    fn config_filename(&self, package_name: &str) -> Option<String>;
 }
 
 /// Trait for task access tracing provider.
@@ -146,6 +153,14 @@ impl MfeConfigProvider for NoMfeConfig {
 
     fn should_use_turborepo_proxy(&self) -> bool {
         false
+    }
+
+    fn dev_tasks(&self, _package_name: &str) -> Option<Vec<(TaskId<'static>, String)>> {
+        None
+    }
+
+    fn config_filename(&self, _package_name: &str) -> Option<String> {
+        None
     }
 }
 


### PR DESCRIPTION
## Summary
- Move `MicroFrontendProxyProvider` struct to `turborepo-task-executor/src/command.rs`
- Make it generic over `MfeConfigProvider` trait instead of concrete `MicrofrontendsConfigs`
- Add `RecursiveTurboError` to new `error.rs` file in `turborepo-task-executor`
- Extend `MfeConfigProvider` trait with `dev_tasks()` and `config_filename()` methods
- Implement new trait methods on `MicrofrontendsConfigs` in `turborepo-lib`
- Simplify `turborepo-lib` `visitor/command.rs` to type aliases and tests

## Why
This continues the `turborepo-lib` modularization effort. The `MicroFrontendProxyProvider` is now fully decoupled from `turborepo-lib` types through trait abstractions.

## Testing
- All 175 tests in `turborepo-lib` pass
- All 8 tests in `turborepo-task-executor` pass