### PR TITLE
docs: Add `dependsOn` to lint task for proper cache invalidation

### DIFF
--- a/docs/site/content/docs/guides/tools/eslint.mdx
+++ b/docs/site/content/docs/guides/tools/eslint.mdx
@@ -282,13 +282,17 @@ The `package.json` for each package where you'd like to run ESLint should look l
 
 With your scripts prepared, you can then create your Turborepo task:
 
-```bash title="./turbo.json"
+```json title="./turbo.json"
 {
   "tasks": {
-    "lint": {}
+    "lint": {
+      "dependsOn": ["^lint"]
+    }
   }
 }
 ```
+
+Using `dependsOn` with `^lint` ensures that changes to dependencies like `@repo/eslint-config` will invalidate the cache for your `lint` task, even though the configuration package doesn't have a `lint` script itself.
 
 You can now run `turbo lint` with [global `turbo`](/docs/getting-started/installation#global-installation) or create a script in your root `package.json`:
 


### PR DESCRIPTION
## Summary
- Adds `dependsOn: ["^lint"]` to the ESLint lint task example
- Adds explanation of why this is needed for cache invalidation when config packages change

Fixes #11369