### PR TITLE
fix(create-turbo): Prevent hang when using bun package manager

### DIFF
--- a/packages/turbo-workspaces/src/install.ts
+++ b/packages/turbo-workspaces/src/install.ts
@@ -129,6 +129,9 @@ export async function install(args: InstallArgs) {
         cwd: args.project.paths.root,
         preferLocal: true,
         shell: process.platform === "win32",
+        // Prevents the child process from inheriting stdin, which can cause
+        // hangs when running via bunx (e.g., `bunx create-turbo`)
+        stdin: "ignore",
       });
       if (spinner) {
         spinner.stop();


### PR DESCRIPTION
## Summary

Fixes #11343

When running `bunx create-turbo@latest` and selecting Bun as the package manager, the CLI would hang after creating the project directory and files successfully.

## Root Cause

The `install` function in `@turbo/workspaces` uses `execa` to run the package manager's install command. By default, `execa` inherits stdin from the parent process. When running via `bunx`, this causes `bun install` to hang waiting for stdin input that never comes.

## Solution

Added `stdin: "ignore"` to the `execa` call in the install function. This prevents the child process from inheriting stdin and waiting for input.

This pattern was already being used elsewhere in the codebase:
- `utils.ts` for `bunLockToYarnLock` 
- `pnpm.ts` for `pnpm import`

## Test Plan

- Added parameterized test to verify `stdin: "ignore"` is passed for all package managers (npm, pnpm, yarn, bun)
- All existing tests pass (909 total)