### PR TITLE
fix(create-turbo): Lowercase bun label for consistency

### DIFF
--- a/packages/create-turbo/src/commands/create/prompts.ts
+++ b/packages/create-turbo/src/commands/create/prompts.ts
@@ -56,7 +56,7 @@ export async function packageManager({
       { pm: "npm", label: "npm" },
       { pm: "pnpm", label: "pnpm" },
       { pm: "yarn", label: "yarn" },
-      { pm: "bun", label: "Bun" },
+      { pm: "bun", label: "bun" },
     ].map(({ pm, label }) => ({
       name: label,
       value: pm,


### PR DESCRIPTION
## Summary
- Lowercases the "Bun" label to "bun" in the package manager selection prompt for consistency with npm, pnpm, and yarn