### PR TITLE
chore: Rename lint tasks and reduce CI duplication

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,4 +38,4 @@ jobs:
         uses: ./.github/actions/install-global-turbo
 
       - name: Run docs specific checks
-        run: turbo run check-types lint
+        run: turbo run check-types --filter=turborepo-docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Lint
         # Manually set TURBO_API to an empty string to override Hetzner env
         run: |
-          TURBO_API= turbo run lint --env-mode=strict
+          TURBO_API= turbo run quality --env-mode=strict
 
   cleanup:
     name: Cleanup

--- a/.github/workflows/turborepo-native-lib-test.yml
+++ b/.github/workflows/turborepo-native-lib-test.yml
@@ -2,9 +2,15 @@ name: Native Library Tests
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "docs/**"
+    paths:
+      - "packages/turbo-repository/**"
+      - "crates/**"
+      - ".github/workflows/turborepo-native-lib-test.yml"
   pull_request:
+    paths:
+      - "packages/turbo-repository/**"
+      - "crates/**"
+      - ".github/workflows/turborepo-native-lib-test.yml"
 
 permissions:
   actions: write

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "turbo run build",
     "build:turbo": "pnpm run --filter=cli build",
     "build:ts": "tsc -b tsconfig.project.json",
-    "lint:oxlint": "pnpm exec oxlint --ignore-path .oxlintignore --deny-warnings .",
+    "lint": "pnpm exec oxlint --ignore-path .oxlintignore --deny-warnings .",
     "format": "oxfmt --check",
     "check:toml": "taplo format --check",
     "docs:dev": "turbo run dev --filter=turborepo-docs",

--- a/turbo.json
+++ b/turbo.json
@@ -34,15 +34,15 @@
 
     // docs lint task runs fumadocs-mdx to generate types before oxlint
     "turborepo-docs#lint": {},
-    "//#lint": {
+    "//#quality": {
       "dependsOn": [
-        "//#lint:oxlint",
+        "//#lint",
         "//#format",
         "//#check:toml",
         "turborepo-docs#lint"
       ]
     },
-    "//#lint:oxlint": {},
+    "//#lint": {},
     "//#format": {},
     "//#check:toml": {},
     "check-types": {


### PR DESCRIPTION
## Summary

- Rename `lint:format` to `format` (formatters and linters are technically different)
- Rename `//#lint` to `//#quality` (aggregate task), `lint:oxlint` to `lint`
- Update `lint.yml` to use `turbo run quality`
- Remove duplicate `lint` from `docs.yml` (already runs as part of `//#quality`)
- Filter `docs.yml` `check-types` to `turborepo-docs` only (was running unfiltered on entire monorepo)
- Add path filtering to `turborepo-native-lib-test.yml` (was running on all PRs regardless of changes)

## Changes

| File | Change |
|------|--------|
| `package.json` | `lint:oxlint` → `lint`, `lint:format` → `format` |
| `turbo.json` | `//#lint` → `//#quality`, `//#lint:oxlint` → `//#lint`, `//#lint:format` → `//#format` |
| `.github/workflows/lint.yml` | `turbo run lint` → `turbo run quality` |
| `.github/workflows/docs.yml` | Remove `lint`, filter `check-types` to docs only |
| `.github/workflows/turborepo-native-lib-test.yml` | Add path filtering for `packages/turbo-repository/**`, `crates/**` |

## Why

1. **Naming clarity**: Linters analyze code for errors/style issues, formatters just reformat. These are different tools and should be named accordingly.

2. **Reduced CI duplication**: 
   - `docs.yml` was running `lint` which is already part of `lint.yml`'s `quality` task
   - `docs.yml` was running `check-types` on the entire monorepo when only docs changed
   - `turborepo-native-lib-test.yml` was running on ALL PRs instead of only when relevant files changed