### PR TITLE
fix: Prevent infinite loop in `pnpm turbo` script and update docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,9 @@ Thank you for your interest in contributing to Turborepo!
 
 You will need to have these dependencies installed on your machine to work on this repository:
 
-- [Rust](https://www.rust-lang.org/tools/install) ([Repository toolchain](https://github.com/vercel/turborepo/blob/main/rust-toolchain.toml))
-- [NodeJS](https://nodejs.org/en) v20
-- [pnpm](https://pnpm.io/) v8
+- [Rust](https://www.rust-lang.org/tools/install) (via [rustup](https://rustup.rs/), which will automatically use the [repository toolchain](https://github.com/vercel/turborepo/blob/main/rust-toolchain.toml))
+- [Node.js](https://nodejs.org/en) v22
+- [pnpm](https://pnpm.io/) v10
 - [protoc](https://grpc.io/docs/protoc-installation/)
 - [capnp](https://capnproto.org)
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "fix:toml": "taplo format",
     "quality:fix": "turbo run quality:fix",
     "docs:dev": "turbo run dev --filter=turborepo-docs",
-    "turbo": "pnpm run build:turbo && pnpm -- turbo",
+    "turbo": "pnpm run build:turbo && ./target/debug/turbo",
     "turbo-prebuilt": "pnpm -- turbo",
     "prepare": "husky install",
     "test": "turbo run test",


### PR DESCRIPTION
## Summary

- Fix infinite loop when running `pnpm turbo` in the development repo by directly executing the built binary instead of recursing through pnpm
- Update CONTRIBUTING.md with current dependency requirements (Node.js 22, pnpm 10, rustup for automatic toolchain management)

Fixes #11394