### PR TITLE
fix: Normalize workspace globs with leading `./`

### DIFF
--- a/crates/turborepo-repository/src/inference.rs
+++ b/crates/turborepo-repository/src/inference.rs
@@ -351,8 +351,8 @@ mod test {
 
     #[test]
     fn test_gh_8599() {
-        // TODO: this test documents existing broken behavior, when we have time we
-        // should fix this and update the assertions
+        // Test that workspace globs with leading "./" are properly handled
+        // See https://github.com/vercel/turborepo/issues/8599
         let (_tmp, tmp_dir) = tmp_dir();
         let monorepo_root = tmp_dir.join_component("monorepo_root");
         let monorepo_pkg_json = monorepo_root.join_component("package.json");
@@ -366,11 +366,7 @@ mod test {
             .unwrap();
 
         let repo_state = RepoState::infer(&package_foo).unwrap();
-        // These assertions are the buggy behavior
-        assert_eq!(repo_state.root, package_foo);
-        assert_eq!(repo_state.mode, RepoMode::SinglePackage);
-        // TODO: the following assertions are the correct behavior
-        // assert_eq!(repo_state.root, monorepo_root);
-        // assert_eq!(repo_state.mode, RepoMode::MultiPackage);
+        assert_eq!(repo_state.root, monorepo_root);
+        assert_eq!(repo_state.mode, RepoMode::MultiPackage);
     }
 }

--- a/turborepo-tests/integration/fixtures/inference/has_workspaces_dot_prefix/apps/web/package.json
+++ b/turborepo-tests/integration/fixtures/inference/has_workspaces_dot_prefix/apps/web/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "web",
+  "scripts": {
+    "build": "echo building web"
+  }
+}

--- a/turborepo-tests/integration/fixtures/inference/has_workspaces_dot_prefix/package.json
+++ b/turborepo-tests/integration/fixtures/inference/has_workspaces_dot_prefix/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "inference-dot-prefix",
+  "workspaces": [
+    "./apps/*",
+    "./packages/*"
+  ],
+  "packageManager": "npm@8.0.0"
+}

--- a/turborepo-tests/integration/fixtures/inference/has_workspaces_dot_prefix/packages/ui/package.json
+++ b/turborepo-tests/integration/fixtures/inference/has_workspaces_dot_prefix/packages/ui/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "ui",
+  "scripts": {
+    "build": "echo building ui"
+  }
+}

--- a/turborepo-tests/integration/fixtures/inference/has_workspaces_dot_prefix/turbo.json
+++ b/turborepo-tests/integration/fixtures/inference/has_workspaces_dot_prefix/turbo.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "tasks": {
+    "build": {}
+  }
+}

--- a/turborepo-tests/integration/tests/inference/has-workspaces-dot-prefix.t
+++ b/turborepo-tests/integration/tests/inference/has-workspaces-dot-prefix.t
@@ -1,0 +1,73 @@
+Setup
+  $ . ${TESTDIR}/../../../helpers/setup_integration_test.sh inference/has_workspaces_dot_prefix
+
+Test that workspaces with "./" prefix in package.json work correctly (GH-8599)
+The fixture has: "workspaces": ["./apps/*", "./packages/*"]
+
+Running from within a workspace directory should detect the monorepo (not single-package mode)
+  $ cd $TARGET_DIR/apps/web && ${TURBO} run build
+  \xe2\x80\xa2 Packages in scope: web (esc)
+  \xe2\x80\xa2 Running build in 1 packages (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
+  web:build: cache miss, executing [0-9a-f]+ (re)
+  web:build: 
+  web:build: > build
+  web:build: > echo building web
+  web:build: 
+  web:build: building web
+  
+   Tasks:    1 successful, 1 total
+  Cached:    0 cached, 1 total
+    Time:\s+[\.0-9]+m?s.* (re)
+  
+
+Filter by package name should work
+  $ cd $TARGET_DIR && ${TURBO} run build --filter=ui
+  \xe2\x80\xa2 Packages in scope: ui (esc)
+  \xe2\x80\xa2 Running build in 1 packages (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
+  ui:build: cache miss, executing [0-9a-f]+ (re)
+  ui:build: 
+  ui:build: > build
+  ui:build: > echo building ui
+  ui:build: 
+  ui:build: building ui
+  
+   Tasks:    1 successful, 1 total
+  Cached:    0 cached, 1 total
+    Time:\s+[\.0-9]+m?s.* (re)
+  
+
+Filter with "./" prefix path should work
+  $ cd $TARGET_DIR && ${TURBO} run build --filter=./packages/ui
+  \xe2\x80\xa2 Packages in scope: ui (esc)
+  \xe2\x80\xa2 Running build in 1 packages (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
+  ui:build: cache (miss, executing|hit, replaying logs) [0-9a-f]+ (re)
+  ui:build: 
+  ui:build: > build
+  ui:build: > echo building ui
+  ui:build: 
+  ui:build: building ui
+  
+   Tasks:    1 successful, 1 total
+  Cached:    [01] cached, 1 total (re)
+    Time:\s+[\.0-9]+m?s.* (re)
+  
+
+Filter with "./" prefix path should work for another package
+  $ cd $TARGET_DIR && ${TURBO} run build --filter=./apps/web
+  \xe2\x80\xa2 Packages in scope: web (esc)
+  \xe2\x80\xa2 Running build in 1 packages (esc)
+  \xe2\x80\xa2 Remote caching disabled (esc)
+  web:build: cache (miss, executing|hit, replaying logs) [0-9a-f]+ (re)
+  web:build: 
+  web:build: > build
+  web:build: > echo building web
+  web:build: 
+  web:build: building web
+  
+   Tasks:    1 successful, 1 total
+  Cached:    [01] cached, 1 total (re)
+    Time:\s+[\.0-9]+m?s.* (re)
+  


### PR DESCRIPTION
## Summary

Fixes #8599

When workspace globs are declared with a leading `./` in `package.json` (e.g., `"workspaces": ["./packages/*"]`), package scoping and workspace inference would fail.

**Before (broken):**
```bash
# From within a workspace directory
$ cd packages/foo && turbo run build
x Could not resolve workspaces.
`-> Missing `packageManager` field in package.json
# Turbo incorrectly thinks it's in single-package mode
```

**After (fixed):**
```bash
$ cd packages/foo && turbo run build
• Packages in scope: foo
# Correctly detects the monorepo
```

## Root Cause

`wax::Glob` does not normalize `./` prefixes, so the pattern `./packages/*` doesn't match the path `packages/foo`. However, all paths in the codebase (from `root.anchor()`, filters after `path_clean`, etc.) are normalized without the `./` prefix. This mismatch caused workspace detection to fail.

## Solution

Normalize workspace globs at parse time by stripping the leading `./` from both inclusions and exclusions in `get_configured_workspace_globs()`. This ensures globs and paths use the same format.

## Testing

- Updated `test_gh_8599` unit test to verify correct behavior (previously documented the broken behavior)
- Added `test_workspace_globs_leading_dot_slash_normalized` unit test
- Added `has-workspaces-dot-prefix.t` integration test with a fixture that uses `./` prefixed workspace globs
- All existing inference and single-package tests continue to pass

## Notes

- Users with `./` in their workspace globs may experience a one-time cache invalidation since the normalized globs affect the global hash
- This fix applies to all package managers (npm, yarn, pnpm, bun, berry)