### PR TITLE
fix(ui): Fix text selection when TUI sidebar is hidden

### DIFF
--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -150,6 +150,12 @@ impl<W> App<W> {
     fn update_sidebar_toggle(&mut self) {
         let value = !self.preferences.is_task_list_visible();
         self.preferences.set_is_task_list_visible(Some(value));
+        // Resize terminal outputs to match new pane width
+        let pane_rows = self.size.pane_rows();
+        let pane_cols = self.size.pane_cols_with_sidebar(value);
+        self.tasks.values_mut().for_each(|term| {
+            term.resize(pane_rows, pane_cols);
+        });
     }
 
     fn update_task_selection_pinned_state(&mut self) -> Result<(), Error> {
@@ -502,14 +508,12 @@ impl<W> App<W> {
         debug!("updating task list: {tasks:?}");
         let highlighted_task = self.active_task()?.to_owned();
         // Make sure all tasks have a terminal output
+        let pane_cols = self
+            .size
+            .pane_cols_with_sidebar(self.preferences.is_task_list_visible());
         for task in &tasks {
             self.tasks.entry(task.clone()).or_insert_with(|| {
-                TerminalOutput::new(
-                    self.size.pane_rows(),
-                    self.size.pane_cols(),
-                    None,
-                    self.scrollback_len,
-                )
+                TerminalOutput::new(self.size.pane_rows(), pane_cols, None, self.scrollback_len)
             });
         }
         // Trim the terminal output to only tasks that exist in new list
@@ -547,14 +551,12 @@ impl<W> App<W> {
         debug!("tasks to reset: {tasks:?}");
         let highlighted_task = self.active_task()?.to_owned();
         // Make sure all tasks have a terminal output
+        let pane_cols = self
+            .size
+            .pane_cols_with_sidebar(self.preferences.is_task_list_visible());
         for task in &tasks {
             self.tasks.entry(task.clone()).or_insert_with(|| {
-                TerminalOutput::new(
-                    self.size.pane_rows(),
-                    self.size.pane_cols(),
-                    None,
-                    self.scrollback_len,
-                )
+                TerminalOutput::new(self.size.pane_rows(), pane_cols, None, self.scrollback_len)
             });
         }
 
@@ -606,7 +608,12 @@ impl<W> App<W> {
     }
 
     pub fn handle_mouse(&mut self, mut event: crossterm::event::MouseEvent) -> Result<(), Error> {
-        let table_width = self.size.task_list_width();
+        // Only offset by table width if the sidebar is visible
+        let table_width = if self.preferences.is_task_list_visible() {
+            self.size.task_list_width()
+        } else {
+            0
+        };
         debug!("original mouse event: {event:?}, table_width: {table_width}");
         // Only handle mouse event if it happens inside of pane
         // We give a 1 cell buffer to make it easier to select the first column of a row
@@ -663,7 +670,9 @@ impl<W> App<W> {
     pub fn resize(&mut self, rows: u16, cols: u16) {
         self.size.resize(rows, cols);
         let pane_rows = self.size.pane_rows();
-        let pane_cols = self.size.pane_cols();
+        let pane_cols = self
+            .size
+            .pane_cols_with_sidebar(self.preferences.is_task_list_visible());
         self.tasks.values_mut().for_each(|term| {
             term.resize(pane_rows, pane_cols);
         })
@@ -1094,7 +1103,9 @@ fn update(
             callback
                 .send(PaneSize {
                     rows: app.size.pane_rows(),
-                    cols: app.size.pane_cols(),
+                    cols: app
+                        .size
+                        .pane_cols_with_sidebar(app.preferences.is_task_list_visible()),
                 })
                 .ok();
         }
@@ -1107,7 +1118,8 @@ fn view<W>(app: &mut App<W>, f: &mut Frame) {
     let horizontal = if app.preferences.is_task_list_visible() {
         Layout::horizontal([Constraint::Fill(1), Constraint::Length(cols)])
     } else {
-        Layout::horizontal([Constraint::Max(0), Constraint::Length(cols)])
+        // When sidebar is hidden, let the pane fill the entire width
+        Layout::horizontal([Constraint::Max(0), Constraint::Fill(1)])
     };
     let [table, pane] = horizontal.areas(f.size());
 
@@ -2220,6 +2232,108 @@ mod test {
 
         // 4. Verify persist_tasks doesn't error (it writes to the task's output)
         app.persist_tasks(tasks_started)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_handle_mouse_with_hidden_sidebar() -> Result<(), Error> {
+        use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())
+            .expect("Failed to create AbsoluteSystemPathBuf");
+
+        let mut app: App<()> = App::new(
+            100,
+            100,
+            vec!["app-a".to_string(), "app-b".to_string()],
+            PreferenceLoader::new(&repo_root),
+            2048,
+        );
+
+        // Start a task so we have something to interact with
+        app.start_task("app-a", OutputLogs::Full)?;
+
+        // Get the task list width when visible
+        let table_width_visible = app.size.task_list_width();
+        assert!(
+            table_width_visible > 0,
+            "task list should have non-zero width"
+        );
+
+        // Test with sidebar visible - mouse at column 0 should be ignored
+        // because it's within the task list area
+        let mouse_event_col_0 = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 0,
+            row: 1,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        };
+        // This should not error, and should not crash
+        app.handle_mouse(mouse_event_col_0)?;
+
+        // Test with sidebar visible - mouse at column >= table_width should work
+        let mouse_event_in_pane = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: table_width_visible,
+            row: 1,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        };
+        app.handle_mouse(mouse_event_in_pane)?;
+
+        // Now hide the sidebar using the toggle function (which also resizes terminals)
+        app.update_sidebar_toggle();
+        assert!(!app.preferences.is_task_list_visible());
+
+        // Verify terminal outputs were resized to full width
+        let full_pane_cols = app.size.pane_cols_with_sidebar(false);
+        assert!(
+            full_pane_cols > table_width_visible as u16,
+            "pane should be wider when sidebar is hidden"
+        );
+        for (name, task) in app.tasks.iter() {
+            let (_, cols) = task.size();
+            assert_eq!(
+                cols, full_pane_cols,
+                "terminal output {name} should be resized to full width"
+            );
+        }
+
+        // With sidebar hidden, mouse at column 0 should now be processed
+        // (it's in the pane area, not the task list)
+        let mouse_event_col_0_hidden = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 0,
+            row: 1,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        };
+        // This should work without error - previously this would have been
+        // incorrectly ignored because the column check would fail
+        app.handle_mouse(mouse_event_col_0_hidden)?;
+
+        // Test dragging at column 5 with sidebar hidden
+        let mouse_event_drag_hidden = MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: 5,
+            row: 2,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        };
+        app.handle_mouse(mouse_event_drag_hidden)?;
+
+        // Toggle sidebar back to visible
+        app.update_sidebar_toggle();
+        assert!(app.preferences.is_task_list_visible());
+
+        // Verify terminal outputs were resized back
+        let sidebar_pane_cols = app.size.pane_cols_with_sidebar(true);
+        for (name, task) in app.tasks.iter() {
+            let (_, cols) = task.size();
+            assert_eq!(
+                cols, sidebar_pane_cols,
+                "terminal output {name} should be resized back when sidebar is shown"
+            );
+        }
 
         Ok(())
     }

--- a/crates/turborepo-ui/src/tui/size.rs
+++ b/crates/turborepo-ui/src/tui/size.rs
@@ -37,12 +37,21 @@ impl SizeInfo {
     }
 
     pub fn pane_cols(&self) -> u16 {
-        // Want to maximize pane width
-        let ratio_pane_width = (f32::from(self.cols) * PANE_SIZE_RATIO) as u16;
-        let full_task_width = self.cols.saturating_sub(self.task_width_hint);
-        full_task_width
-            .max(ratio_pane_width)
-            // We need to account for the left border of the pane
-            .saturating_sub(1)
+        self.pane_cols_with_sidebar(true)
+    }
+
+    pub fn pane_cols_with_sidebar(&self, has_sidebar: bool) -> u16 {
+        if has_sidebar {
+            // Want to maximize pane width
+            let ratio_pane_width = (f32::from(self.cols) * PANE_SIZE_RATIO) as u16;
+            let full_task_width = self.cols.saturating_sub(self.task_width_hint);
+            full_task_width
+                .max(ratio_pane_width)
+                // We need to account for the left border of the pane
+                .saturating_sub(1)
+        } else {
+            // When sidebar is hidden, pane takes full width minus border
+            self.cols.saturating_sub(1)
+        }
     }
 }

--- a/crates/turborepo-vt100/src/grid.rs
+++ b/crates/turborepo-vt100/src/grid.rs
@@ -347,9 +347,9 @@ impl Grid {
                         if row_index == start.row && row_index == end.row {
                             (start.col, end.col - start.col + 1)
                         } else if row_index == start.row {
-                            (start.col, cols)
+                            (start.col, cols - start.col)
                         } else if row_index == end.row {
-                            (0, end.col)
+                            (0, end.col + 1)
                         } else {
                             (0, cols)
                         };


### PR DESCRIPTION
## Summary

Fixes #11404

- Fix mouse coordinate translation when sidebar is hidden by checking sidebar visibility before calculating table width offset
- Resize terminal outputs when toggling sidebar visibility to match the new pane width
- Use `Constraint::Fill(1)` for pane layout when sidebar is hidden to use full terminal width
- Add `pane_cols_with_sidebar()` method to calculate correct pane width based on sidebar visibility state
- Fix text selection to not highlight on click-only, only on drag
- Fix selection to include first character by tracking click position and applying it on first drag event
- Fix upward drag selection to include the end column character

## Test Plan

I tested this manually with the following steps:

1. Run `turbo run build --ui=tui` in a monorepo
2. Press `h` to hide the sidebar
3. Try to select text by clicking and dragging - selection should work correctly and include the first character
4. Try dragging upward - selection should include all characters including at the click position
5. Click without dragging - no character should be highlighted
6. Press `h` to show the sidebar again
7. Verify text selection still works correctly with the sidebar visible