### PR TITLE
ci: Remove push-to-main triggers from CI workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,5 @@
 name: Lint
 on:
-  push:
-    branches: [main]
   pull_request:
 
 concurrency:

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -1,7 +1,5 @@
 name: JS Package Tests
 on:
-  push:
-    branches: [main]
   pull_request:
     paths:
       - package.json

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -1,7 +1,5 @@
 name: Test
 on:
-  push:
-    branches: [main]
   pull_request:
 
 concurrency:


### PR DESCRIPTION
## Summary

- Removes `push: branches: [main]` triggers from `lint.yml`, `test-js-packages.yml`, and `turborepo-test.yml`
- These workflows now only run on pull requests, avoiding redundant CI runs after PRs are merged
- The `pr-clean-caches.yml` workflow retains its push trigger for cache cleanup