### PR TITLE
fix(example): remove @expo/webpack-config from with-react-native-web

### DIFF
--- a/examples/with-react-native-web/apps/native/package.json
+++ b/examples/with-react-native-web/apps/native/package.json
@@ -27,7 +27,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.23.7",
-    "@expo/webpack-config": "19.0.1",
     "@types/react": "~18.3.12",
     "typescript": "5.8.3"
   },


### PR DESCRIPTION
The native Expo app failed to install with npm due to a peer dependency conflict
between Expo 52 and @expo/webpack-config@19.x.

Removing @expo/webpack-config allows npm install to succeed out of the box.

### Description

This PR fixes an npm install failure in the `with-react-native-web` example by
removing an outdated Expo Webpack dependency that is incompatible with Expo SDK 52.

This example is community-maintained, and this change ensures the example works
out of the box when installed with npm.

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.
-->

### Testing Instructions

1. Navigate to `examples/with-react-native-web`
2. Run `npm install`
3. Navigate to `apps/native`
4. Run `npm run web` or `npx expo start --web`
5. 
<!--
  Give a quick description of steps to test your changes.
-->
