### PR TITLE
fix(docs): Exclude schema.json paths from middleware matcher

### DIFF
--- a/docs/site/proxy.ts
+++ b/docs/site/proxy.ts
@@ -40,9 +40,9 @@ const proxy = (request: NextRequest, context: NextFetchEvent) => {
 };
 
 export const config = {
-  // Matcher ignoring `/_next/`, `/api/`, static assets, favicon, feed.xml, sitemap.xml, etc.
+  // Matcher ignoring `/_next/`, `/api/`, static assets, favicon, feed.xml, sitemap.xml, schema JSON files, etc.
   matcher: [
-    "/((?!api|_next/static|_next/image|favicon.ico|feed.xml|sitemap.xml).*)"
+    "/((?!api|_next/static|_next/image|favicon.ico|feed.xml|sitemap.xml|schema\\.json|schema\\.v\\d+\\.json|microfrontends/schema\\.json).*)"
   ]
 };
 


### PR DESCRIPTION
## Summary

- Fixes schema.json files not being served at `https://turborepo.com/schema.json` and related paths
- The i18n middleware was intercepting these requests and rewriting them incorrectly
- Adds `schema.json`, `schema.v{N}.json`, and `microfrontends/schema.json` to the middleware matcher exclusion list

## Test Plan

Verified locally that all schema endpoints now return valid JSON:
- `/schema.json`
- `/schema.v1.json`  
- `/schema.v2.json`
- `/microfrontends/schema.json`