### PR TITLE
fix(docs): Fix markdown content negotation matcher

### DIFF
--- a/docs/site/proxy.ts
+++ b/docs/site/proxy.ts
@@ -7,7 +7,10 @@ import {
 } from "next/server";
 import { i18n } from "@/lib/geistdocs/i18n";
 
-const { rewrite: rewriteLLM } = rewritePath("/docs/*path", "/llms.md/*path");
+const { rewrite: rewriteLLM } = rewritePath(
+  "/docs{/*path}",
+  "/en/llms.md{/*path}"
+);
 
 const internationalizer = createI18nMiddleware(i18n);
 


### PR DESCRIPTION
## Summary

- Fixed the rewrite path for `Accept: text/markdown` requests which was missing the `/en` language prefix, causing requests to not reach the `llms.md` route handler
- Added handling for the root `/docs` path which wasn't matched by the `/*path` pattern

## Testing

```bash
curl -L -H "Accept: text/markdown" http://localhost:3000/docs
```

Now correctly returns markdown content instead of HTML.