### PR TITLE
docs(fix): Add loading state after sources load in AI chat

### DIFF
--- a/docs/site/components/geistdocs/message-metadata.tsx
+++ b/docs/site/components/geistdocs/message-metadata.tsx
@@ -13,11 +13,13 @@ import { Spinner } from "../ui/spinner";
 type MessageMetadataProps = {
   parts: MyUIMessage["parts"];
   inProgress: boolean;
+  isStreaming?: boolean;
 };
 
 export const MessageMetadata = ({
   parts,
-  inProgress
+  inProgress,
+  isStreaming
 }: MessageMetadataProps) => {
   // Pull out last part that is either text or tool call
   const lastPart = parts
@@ -44,6 +46,40 @@ export const MessageMetadata = ({
         .map((part) => [part.url, part])
     ).values()
   );
+
+  // Check if there's any text content in the message
+  const hasTextContent = parts.some(
+    (part) => part.type === "text" && part.text.length > 0
+  );
+
+  // Show loading state when sources exist but text hasn't started streaming yet
+  if (sources.length > 0 && !hasTextContent && isStreaming) {
+    return (
+      <div className="flex flex-col gap-2">
+        <Sources>
+          <SourcesTrigger count={sources.length}>
+            <BookmarkIcon className="size-4" />
+            <p>Used {sources.length} sources</p>
+          </SourcesTrigger>
+          <SourcesContent>
+            <ul className="flex flex-col gap-2">
+              {sources.map((source) => (
+                <li className="ml-4.5 list-disc pl-1" key={source.url}>
+                  <Source href={source.url} title={source.url}>
+                    {source.title}
+                  </Source>
+                </li>
+              ))}
+            </ul>
+          </SourcesContent>
+        </Sources>
+        <div className="flex items-center gap-2">
+          <Spinner />
+          <Shimmer>Generating response...</Shimmer>
+        </div>
+      </div>
+    );
+  }
 
   if (sources.length > 0 && !(tool && inProgress)) {
     return (


### PR DESCRIPTION
## Summary

- Adds a loading state to the AI chat that appears after sources are pulled in but before the text response starts streaming
- Shows "Generating response..." with a spinner and shimmer animation when sources exist but no text content has been received yet

This improves the UX by providing visual feedback during the gap between source loading and response streaming.