### PR TITLE
fix(docs): Clean up markdown output for LLM content negotiation

### DIFF
--- a/docs/site/lib/geistdocs/source.ts
+++ b/docs/site/lib/geistdocs/source.ts
@@ -76,9 +76,17 @@ export const getPageImage = (page: InferPageType<typeof source>) => {
 export const getLLMText = async (page: InferPageType<typeof source>) => {
   const processed = await page.data.getText("processed");
 
+  // Clean up the markdown for LLM consumption
+  const cleaned = processed
+    // Remove import statements
+    .replace(/^import\s+.*?from\s+["'].*?["'];?\s*$/gm, "")
+    // Collapse multiple consecutive blank lines into a single blank line
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+
   return `# ${page.data.title}
 
-${processed}`;
+${cleaned}`;
 };
 
 // Blog loaders


### PR DESCRIPTION
## Summary

- Removes `import` statements from markdown output served via `Accept: text/markdown`
- Collapses multiple consecutive blank lines into a single blank line

These cleanups make the markdown output cleaner for AI agents consuming the docs.