### PR TITLE
fix(docs): Allow search engine indexing on production domain

### DIFF
--- a/docs/site/app/robots.ts
+++ b/docs/site/app/robots.ts
@@ -1,22 +1,20 @@
 import type { MetadataRoute } from "next";
 
-/**
- * Check if the host is a subdomain (has more than 2 parts, e.g., v1.example.com)
- */
-function isSubdomain(host: string): boolean {
-  const parts = host.split(".");
-  return parts.length > 2;
-}
+const PRODUCTION_DOMAIN = "turborepo.dev";
 
 /**
  * Dynamic robots.txt generation.
  *
- * All subdomains are blocked from search engine indexing.
+ * Only the production domain (turborepo.dev) is allowed to be indexed.
+ * Subdomains (e.g., v1.turborepo.dev) and preview deployments are blocked.
  */
 export default function robots(): MetadataRoute.Robots {
-  const host = process.env.VERCEL_URL ?? "";
+  // VERCEL_PROJECT_PRODUCTION_URL is the production domain assigned to the project
+  // For the main site, this will be "turborepo.dev"
+  // For subdomains, this will be "v1.turborepo.dev", etc.
+  const productionUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL ?? "";
 
-  if (isSubdomain(host)) {
+  if (productionUrl !== PRODUCTION_DOMAIN) {
     return {
       rules: {
         userAgent: "*",
@@ -29,6 +27,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: "*",
       allow: "/"
-    }
+    },
+    sitemap: `https://${PRODUCTION_DOMAIN}/sitemap.xml`
   };
 }


### PR DESCRIPTION
## Summary

- Fixes robots.txt blocking all search engines on turborepo.dev
- Uses `VERCEL_PROJECT_PRODUCTION_URL` to determine if we're on the main production domain
- Only allows indexing on `turborepo.dev`, blocks subdomains and preview deployments
- Adds sitemap reference for production

## Problem

The previous logic used `VERCEL_URL` which returns values like `turborepo-git-main-vercel.vercel.app` even in production. This has more than 2 domain parts, so it was incorrectly triggering the subdomain blocking logic and serving `Disallow: /` on the main site.