### PR TITLE
fix(ci): Add project flag and show errors in versioned docs aliasing

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -301,7 +301,7 @@ jobs:
           SHA="${{ needs.stage.outputs.base-sha }}"
           echo "Searching for production deployment with SHA: ${SHA}"
 
-          DEPLOYMENT_URL=$(vercel ls -m githubCommitSha="${SHA}" --token="${VERCEL_TOKEN}" --scope=vercel 2>/dev/null | grep -E '^\S+\.vercel\.app' | head -n 1 | awk '{print $1}')
+          DEPLOYMENT_URL=$(vercel ls -m githubCommitSha="${SHA}" --token="${VERCEL_TOKEN}" --scope=vercel --project=turbo-site 2>&1 | tee /dev/stderr | grep -E '^\S+\.vercel\.app' | head -n 1 | awk '{print $1}')
 
           if [ -z "$DEPLOYMENT_URL" ]; then
             echo "::error::No deployment found for SHA ${SHA}. A production deployment is created when the release commit is merged to main. Ensure the merge to main has completed and the Vercel build has finished before running this workflow."


### PR DESCRIPTION
## Summary

- Added `--project=turbo-site` flag to `vercel ls` command so it queries the correct project
- Changed `2>/dev/null` to `2>&1 | tee /dev/stderr` so Vercel CLI errors are visible in CI logs instead of being swallowed

This fixes an issue where the versioned docs aliasing step would fail with a generic "No deployment found" error when the actual problem was that the Vercel CLI needed a project specified.