### PR TITLE
fix: Replace execSync with execFileSync for oxfmt

### DIFF
--- a/packages/prysk/index.mjs
+++ b/packages/prysk/index.mjs
@@ -15,7 +15,14 @@ const isWindows = process.platform === "win32";
 execFileSync("python3", ["-m", "venv", VENV_NAME]);
 
 // Upgrade pip
-execFileSync(getVenvBin("python3"), ["-m", "pip", "install", "--quiet", "--upgrade", "pip"]);
+execFileSync(getVenvBin("python3"), [
+  "-m",
+  "pip",
+  "install",
+  "--quiet",
+  "--upgrade",
+  "pip"
+]);
 
 // Install prysk
 execFileSync(getVenvBin("pip"), ["install", "prysk==0.15.2"]);

--- a/packages/turbo-types/scripts/generate-schema.ts
+++ b/packages/turbo-types/scripts/generate-schema.ts
@@ -55,10 +55,14 @@ create("schema.v2.json", "Schema");
 create("schema.json", "Schema");
 
 // Format generated schemas with oxfmt
-execFileSync("pnpm", [
-  "exec",
-  "oxfmt",
-  join(schemasDir, "schema.json"),
-  join(schemasDir, "schema.v1.json"),
-  join(schemasDir, "schema.v2.json")
-], { stdio: "inherit" });
+execFileSync(
+  "pnpm",
+  [
+    "exec",
+    "oxfmt",
+    join(schemasDir, "schema.json"),
+    join(schemasDir, "schema.v1.json"),
+    join(schemasDir, "schema.v2.json")
+  ],
+  { stdio: "inherit" }
+);

--- a/packages/turbo-utils/src/validateDirectory.ts
+++ b/packages/turbo-utils/src/validateDirectory.ts
@@ -33,13 +33,9 @@ export function validateDirectory(directory: string): {
 
   // Prevent resolved paths that could be misinterpreted as command-line options
   // when passed to tools like git, and ensure the project name is well-formed.
-  const unsafeRoot =
-    !root ||
-    root.startsWith("-") ||
-    root.includes("\0");
+  const unsafeRoot = !root || root.startsWith("-") || root.includes("\0");
   const invalidProjectName =
-    !projectName ||
-    !/^[a-zA-Z0-9._-]+$/.test(projectName);
+    !projectName || !/^[a-zA-Z0-9._-]+$/.test(projectName);
 
   if (unsafeRoot || invalidProjectName) {
     return {


### PR DESCRIPTION
### Description
fix is to avoid constructing a single shell command string that mixes a hard-coded command (`pnpm exec oxfmt`) with dynamic path arguments. Instead, invoke the command without a shell and pass each argument as a separate array element. This prevents spaces or metacharacters in the paths from being interpreted by a shell.

Concretely, in `packages/turbo-types/scripts/generate-schema.ts`, replace the `execSync` call on lines 58–61 with a call to `execFileSync` from `node:child_process`. Keep `pnpm` as the executable, and pass `"exec"`, `"oxfmt"`, and each schema file path as separate arguments. Also update the import on line 3 to import `execFileSync` instead of (or in addition to) `execSync`. No other logic needs to change.

You need:
- To adjust the child process import to include `execFileSync`.
- To change the command invocation to `execFileSync("pnpm", ["exec", "oxfmt", <paths>], { stdio: "inherit" });`.
- All changes are confined to the shown file and lines.