### PR TITLE
fix: Improve behavior for OOM-killed tasks

### DIFF
--- a/crates/turborepo-task-executor/src/exec.rs
+++ b/crates/turborepo-task-executor/src/exec.rs
@@ -28,7 +28,6 @@ use turborepo_ui::{ColorConfig, OutputWriter};
 
 use crate::{TaskAccessProvider, TaskCacheOutput, TaskOutput};
 
-
 /// Windows NT status codes that indicate out-of-memory conditions.
 /// These are the signed i32 representations of the unsigned NT status codes.
 #[cfg(windows)]


### PR DESCRIPTION
## Summary

**Behavioral change:** Previously `ChildExit::KilledExternal`, `ChildExit::Finished(None)`, and `ChildExit::Failed` returned internal errors (`InternalError::ExternalKill`, `InternalError::UnknownChildExit`). Now they're handled as normal task failures with proper exit codes, error logging, and respect for `--continue` flags.

Changes:
- `KilledExternal` → task failure with exit code 137 (SIGKILL convention)
- `Finished(None)` / `Failed` → task failure with exit code 1
- Add OOM detection hints for Windows NT status codes and Unix exit code 137
- Remove `InternalError::ExternalKill` variant

This means externally-killed tasks now behave consistently with tasks that exit non-zero rather than causing internal errors.