### PR TITLE
fix(docs): Fix mobile hamburger menu not opening

### DIFF
--- a/docs/site/components/geistdocs/sidebar.tsx
+++ b/docs/site/components/geistdocs/sidebar.tsx
@@ -49,12 +49,14 @@ export const Sidebar = () => {
     });
 
   return (
-    <div
-      className="pointer-events-none sticky top-(--fd-docs-row-1) z-20 h-[calc(var(--fd-docs-height)-var(--fd-docs-row-1))] [grid-area:sidebar] *:pointer-events-auto max-md:hidden md:layout:[--fd-sidebar-width:268px]"
-      data-sidebar-placeholder
-    >
-      <div className="px-4 pt-12 pb-4 h-full overflow-y-auto">
-        <Fragment key={root.$id}>{renderSidebarList(root.children)}</Fragment>
+    <>
+      <div
+        className="pointer-events-none sticky top-(--fd-docs-row-1) z-20 h-[calc(var(--fd-docs-height)-var(--fd-docs-row-1))] [grid-area:sidebar] *:pointer-events-auto max-md:hidden md:layout:[--fd-sidebar-width:268px]"
+        data-sidebar-placeholder
+      >
+        <div className="px-4 pt-12 pb-4 h-full overflow-y-auto">
+          <Fragment key={root.$id}>{renderSidebarList(root.children)}</Fragment>
+        </div>
       </div>
       <Sheet onOpenChange={setIsOpen} open={isOpen}>
         <SheetContent className="gap-0">
@@ -106,7 +108,7 @@ export const Sidebar = () => {
           </div>
         </SheetContent>
       </Sheet>
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- Fixes the mobile hamburger menu not opening on the docs site
- The `<Sheet>` component was nested inside a container with `max-md:hidden`, which prevented the mobile menu drawer from rendering on mobile screens
- Moved the Sheet outside the hidden container so it can render when triggered