### PR TITLE
feat(docs): Add search icon to mobile header

### DIFF
--- a/docs/site/components/geistdocs/navbar.tsx
+++ b/docs/site/components/geistdocs/navbar.tsx
@@ -6,7 +6,7 @@ import { DesktopMenu } from "./desktop-menu";
 import { GitHubButton } from "./github-button";
 import { SlashIcon } from "./icons";
 import { MobileMenu } from "./mobile-menu";
-import { SearchButton } from "./search";
+import { MobileSearchButton, SearchButton } from "./search";
 
 export const Navbar = () => (
   <header className="sticky top-0 z-40 w-full gap-6 border-b bg-sidebar">
@@ -23,6 +23,7 @@ export const Navbar = () => (
       <DesktopMenu className="hidden md:flex" items={nav} />
       <div className="ml-auto flex flex-1 items-center justify-end gap-2">
         <SearchButton className="hidden md:flex" />
+        <MobileSearchButton className="md:hidden" />
         <Chat basePath={basePath} suggestions={suggestions} />
         <GitHubButton className="hidden md:flex" />
         <MobileMenu />

--- a/docs/site/components/geistdocs/search.tsx
+++ b/docs/site/components/geistdocs/search.tsx
@@ -14,6 +14,7 @@ import {
 } from "fumadocs-ui/components/dialog/search";
 import { useI18n } from "fumadocs-ui/contexts/i18n";
 import { useSearchContext } from "fumadocs-ui/contexts/search";
+import { SearchIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "../ui/button";
 import { Kbd } from "../ui/kbd";
@@ -73,6 +74,23 @@ export const SearchButton = ({ className, onClick }: SearchButtonProps) => {
     >
       <span>Search...</span>
       <Kbd className="border bg-background font-medium">⌘K</Kbd>
+    </Button>
+  );
+};
+
+export const MobileSearchButton = ({ className }: { className?: string }) => {
+  const { setOpenSearch } = useSearchContext();
+
+  return (
+    <Button
+      className={cn("size-8 text-muted-foreground", className)}
+      onClick={() => setOpenSearch(true)}
+      size="icon"
+      type="button"
+      variant="ghost"
+    >
+      <SearchIcon className="size-5" />
+      <span className="sr-only">Search</span>
     </Button>
   );
 };


### PR DESCRIPTION
## Summary
- Adds a search icon button to the mobile header so users can access search on mobile devices
- Creates `MobileSearchButton` component with icon-only display and screen reader support
- Shows on mobile (`md:hidden`), hidden on desktop where the full search button is displayed