### PR TITLE
fix(docs): Cancel active stream when clearing chat

### DIFF
--- a/docs/site/components/ai-elements/prompt-input.tsx
+++ b/docs/site/components/ai-elements/prompt-input.tsx
@@ -984,6 +984,7 @@ export const PromptInputActionMenuItem = ({
 
 export type PromptInputSubmitProps = ComponentProps<typeof InputGroupButton> & {
   status?: ChatStatus;
+  onStop?: () => void;
 };
 
 export const PromptInputSubmit = ({
@@ -991,6 +992,7 @@ export const PromptInputSubmit = ({
   variant = "default",
   size = "icon-sm",
   status,
+  onStop,
   children,
   ...props
 }: PromptInputSubmitProps) => {
@@ -1004,12 +1006,22 @@ export const PromptInputSubmit = ({
     Icon = <XIcon className="size-4" />;
   }
 
+  const isStreaming = status === "streaming" || status === "submitted";
+
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (isStreaming && onStop) {
+      e.preventDefault();
+      onStop();
+    }
+  };
+
   return (
     <InputGroupButton
-      aria-label="Submit"
+      aria-label={isStreaming ? "Stop" : "Submit"}
       className={cn(className)}
+      onClick={handleClick}
       size={size}
-      type="submit"
+      type={isStreaming ? "button" : "submit"}
       variant={variant}
       {...props}
     >

--- a/docs/site/components/geistdocs/chat.tsx
+++ b/docs/site/components/geistdocs/chat.tsx
@@ -129,7 +129,7 @@ const ChatInner = ({ basePath, suggestions }: ChatProps) => {
   const { initialMessages, isLoading, saveMessages, clearMessages } =
     useChatPersistence();
 
-  const { messages, sendMessage, status, setMessages } = useChat({
+  const { messages, sendMessage, status, setMessages, stop } = useChat({
     transport: new DefaultChatTransport({
       api: basePath ? `${basePath}/api/chat` : "/api/chat"
     }),
@@ -188,6 +188,8 @@ const ChatInner = ({ basePath, suggestions }: ChatProps) => {
 
   const handleClearChat = async () => {
     try {
+      // Cancel any active stream first
+      stop();
       await clearMessages();
       setMessages([]);
       toast.success("Chat history cleared");
@@ -342,7 +344,7 @@ const ChatInner = ({ basePath, suggestions }: ChatProps) => {
               <p className="text-muted-foreground text-xs">
                 {localPrompt.length} / 1000
               </p>
-              <PromptInputSubmit status={status} />
+              <PromptInputSubmit onStop={stop} status={status} />
             </PromptInputFooter>
           </PromptInput>
         </PromptInputProvider>


### PR DESCRIPTION
## Summary

- Clear chat button now cancels any active stream before clearing messages
- Fixes issue where stream chunks would continue appearing after clearing chat

Also adds `onStop` prop to `PromptInputSubmit` so the stop button properly cancels streams.