### PR TITLE
docs: Show 'Searching sources...' loading state in AI chat

### DIFF
--- a/docs/site/components/geistdocs/message-metadata.tsx
+++ b/docs/site/components/geistdocs/message-metadata.tsx
@@ -104,10 +104,16 @@ export const MessageMetadata = ({
   }
 
   if (tool && inProgress) {
+    // Show user-friendly message for search_docs tool
+    const isSearching = tool.type === "tool-search_docs";
     return (
       <div className="flex items-center gap-2">
         <Spinner />
-        <Shimmer>{tool.type}</Shimmer>
+        <Shimmer>
+          {isSearching
+            ? "Searching sources..."
+            : tool.type.replace("tool-", "")}
+        </Shimmer>
       </div>
     );
   }


### PR DESCRIPTION
## Summary

- Shows "Searching sources..." instead of "tool-invocation" when the AI chat is searching for documentation
- For other tools, displays the tool name (e.g., `get_doc_page`) instead of the generic type

Previously the loading state showed a non-descriptive `tool-invocation` text while sources were being fetched.