### PR TITLE
fix(scope): Don't inject package name when user provides directory filter

### DIFF
--- a/turborepo-tests/integration/tests/run/infer-pkg.t
+++ b/turborepo-tests/integration/tests/run/infer-pkg.t
@@ -58,7 +58,6 @@ Ensure we don't infer packages if --cwd is supplied
 Run a dry run in packages with a glob filter from directory
   $ ${TURBO} build --dry=json -F "../*" | jq .packages
   [
-    "another",
     "util"
   ]
 


### PR DESCRIPTION
## Summary

Fixes a bug where running `turbo run build -F ./*` from a directory that is both a workspace itself AND contains child workspaces would return no packages.

**Reproduction:** When `apps/` is a workspace (has its own `package.json`) and also contains `apps/app-a` and `apps/app-b` as child workspaces, running from `apps/` with filter `-F ./*` should match `app-a` and `app-b`, but instead matched nothing.

**Root cause:** `PackageInference` would inject the parent workspace's name (`apps`) into the selector's `name_pattern`, which then conflicted with the directory filter—packages had to match both the directory glob (`apps/*`) AND the injected name (`apps`), but child packages have different names.

**Fix:** Only inject the inferred package name when the user hasn't provided an explicit directory filter. If they specify a directory filter like `./*`, they're being explicit about what they want.

## Testing

Added a test case that reproduces the exact scenario. All 68 scope tests pass.