### PR TITLE
fix: Fix AI chat not opening on home page

### DIFF
--- a/docs/site/components/geistdocs/chat.tsx
+++ b/docs/site/components/geistdocs/chat.tsx
@@ -387,12 +387,13 @@ export const Chat = ({ basePath, suggestions }: ChatProps) => {
         <span>Ask AI</span>
       </Button>
 
-      <Portal.Root className="hidden md:block">
+      <Portal.Root>
         <div
           className={cn(
             "fixed z-50 flex flex-col gap-4 bg-background transition-all",
             "inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
-            "translate-x-full data-[state=open]:translate-x-0"
+            "translate-x-full data-[state=open]:translate-x-0",
+            "hidden md:flex"
           )}
           data-state={isOpen ? "open" : "closed"}
         >


### PR DESCRIPTION
## Summary

- Moves responsive visibility classes from `Portal.Root` to inner `<div>` element
- `Portal.Root` from `radix-ui` doesn't support `className` prop, so the classes were being ignored

The AI chat wasn't opening because the `hidden md:block` classes on `Portal.Root` had no effect, causing the portal content to not render properly on desktop.