### PR TITLE
ci: Only run coverage workflow for Rust code changes

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,8 +2,18 @@ name: Coverage
 
 on:
   pull_request:
+    paths:
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
   push:
     branches: [main]
+    paths:
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
## Summary

- Adds path filters to the coverage workflow so it only runs when Rust code is modified
- Reduces unnecessary CI runs for PRs that only touch JS/docs/config files

Filtered paths: `crates/**`, `Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`