### PR TITLE
fix: Use container queries for navbar to handle AI chat panel

### DIFF
--- a/docs/site/components/geistdocs/mobile-menu.tsx
+++ b/docs/site/components/geistdocs/mobile-menu.tsx
@@ -2,14 +2,19 @@
 
 import { MenuIcon } from "lucide-react";
 import { useSidebarContext } from "@/hooks/geistdocs/use-sidebar";
+import { cn } from "@/lib/utils";
 import { Button } from "../ui/button";
 
-export const MobileMenu = () => {
+type MobileMenuProps = {
+  className?: string;
+};
+
+export const MobileMenu = ({ className }: MobileMenuProps) => {
   const { isOpen, setIsOpen } = useSidebarContext();
 
   return (
     <Button
-      className="md:hidden"
+      className={cn(className)}
       onClick={() => setIsOpen(!isOpen)}
       size="icon-sm"
       variant="ghost"

--- a/docs/site/components/geistdocs/navbar.tsx
+++ b/docs/site/components/geistdocs/navbar.tsx
@@ -9,7 +9,7 @@ import { MobileMenu } from "./mobile-menu";
 import { MobileSearchButton, SearchButton } from "./search";
 
 export const Navbar = () => (
-  <header className="sticky top-0 z-40 w-full gap-6 border-b bg-sidebar">
+  <header className="sticky top-0 z-40 w-full gap-6 border-b bg-sidebar @container">
     <div className="mx-auto flex h-16 w-full max-w-(--fd-layout-width) items-center gap-4 px-4 py-3.5 md:px-6">
       <div className="flex shrink-0 items-center gap-2.5">
         <a href="https://vercel.com/" rel="noopener" target="_blank">
@@ -20,13 +20,13 @@ export const Navbar = () => (
           <Logo />
         </DynamicLink>
       </div>
-      <DesktopMenu className="hidden md:flex" items={nav} />
+      <DesktopMenu className="hidden @4xl:flex" items={nav} />
       <div className="ml-auto flex flex-1 items-center justify-end gap-2">
-        <SearchButton className="hidden md:flex" />
-        <MobileSearchButton className="md:hidden" />
+        <SearchButton className="hidden @3xl:flex" />
+        <MobileSearchButton className="@3xl:hidden" />
         <Chat basePath={basePath} suggestions={suggestions} />
-        <GitHubButton className="hidden md:flex" />
-        <MobileMenu />
+        <GitHubButton className="hidden @4xl:flex" />
+        <MobileMenu className="@4xl:hidden" />
       </div>
     </div>
   </header>


### PR DESCRIPTION
## Summary

- Navbar links overlap when the AI chat panel is opened because the layout uses media queries that don't respond to the reduced available space
- Switches navbar from media queries (`md:`) to container queries (`@container`, `@3xl:`, `@4xl:`) so elements hide/show based on actual container width
- When the chat panel opens and adds `pr-96` padding, the navbar now correctly collapses to mobile layout

## Testing

1. Open the docs site at a desktop width (~1200px)
2. Open the AI chat panel
3. Verify the nav links collapse to the mobile hamburger menu instead of overlapping