### PR TITLE
fix(docs): Update "Edit this page on GitHub" link to new content path

### DIFF
--- a/docs/site/components/geistdocs/edit-source.tsx
+++ b/docs/site/components/geistdocs/edit-source.tsx
@@ -9,7 +9,7 @@ export const EditSource = ({ path }: EditSourceProps) => {
   let url: string | undefined;
 
   if (github.owner && github.repo && path) {
-    url = `https://github.com/${github.owner}/${github.repo}/edit/main/content/docs/${path}`;
+    url = `https://github.com/${github.owner}/${github.repo}/edit/main/docs/site/content/docs/${path}`;
   }
 
   if (!url) {


### PR DESCRIPTION
## Summary

This hotfix resolves a bug showing up on the production documentaton
site in the form of  86 broken links "Edit this page on GitHub."

Root cause: work in progress – however, the fix is ready now. It is
better IMO to deploy a fix now and RCA later.

## Recommended Actions

- root cause: changes were likely tested and working somewhere 
before release. i suggest start there and work backwards. 
- ci: post-deployment monitoring + automated rollback mechanism --
are they setup and working?
- ci: site status checks for outbound links --  are they setup 
and running?

## Testing

1. Clone this PR then
2. Execute
`
cd turborepo/docs/site
pnpm run build
pnpm run start
`
3. Open `http://localhost:3000/docs`
4. Click "Edit this page on GitHub"