### PR TITLE
Docs: improve readability of Turbo command examples

### DIFF
--- a/docs/site/content/docs/getting-started/installation.mdx
+++ b/docs/site/content/docs/getting-started/installation.mdx
@@ -90,7 +90,7 @@ Once installed globally, you can run your scripts through `turbo` from your term
 - `turbo build --filter=docs --dry` — Print the execution plan for the `build` task in the `docs` package without running it.
 - `turbo generate` — Run generators to scaffold new code in your repository.
 - `cd apps/docs && turbo build` — Run the `build` script in the `docs` package and its dependencies.
-Scoping section](/docs/crafting-your-repository/running-tasks#automatic-package-scoping).
+  For more, visit the [Automatic Package Scoping section](/docs/crafting-your-repository/running-tasks#automatic-package-scoping). 
 
 <Callout type="info">
   `turbo` is an alias for [`turbo run`](/docs/reference/run). For example,


### PR DESCRIPTION
Improves formatting of Turbo command examples to make the installation guide easier to read without changing behavior.