### PR TITLE
fix: Simplify VersionWarning to show on all versioned subdomains

### DIFF
--- a/docs/site/components/version-warning.tsx
+++ b/docs/site/components/version-warning.tsx
@@ -1,40 +1,21 @@
 "use client";
 
-import { TriangleAlert } from "lucide-react";
+import { InfoIcon } from "lucide-react";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
 const PRODUCTION_DOMAIN = "turborepo.dev";
-const NPM_REGISTRY_URL = "https://registry.npmjs.org/turbo/latest";
 
 /**
- * Convert subdomain format to semver for comparison.
+ * Convert subdomain format to display version.
  * Subdomain format: "v2-3-1" -> "2.3.1"
  */
-function subdomainToSemver(subdomain: string): string {
+function subdomainToVersion(subdomain: string): string {
   return subdomain.replace(/^v/, "").replace(/-/g, ".");
 }
 
-/**
- * Compare two semver strings.
- * Returns true if `a` is older than `b`.
- */
-function isOlderVersion(a: string, b: string): boolean {
-  const aParts = a.split(".").map(Number);
-  const bParts = b.split(".").map(Number);
-
-  for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
-    const aVal = aParts[i] || 0;
-    const bVal = bParts[i] || 0;
-    if (aVal < bVal) return true;
-    if (aVal > bVal) return false;
-  }
-  return false;
-}
-
 export function VersionWarning() {
-  const [isOldVersion, setIsOldVersion] = useState(false);
-  const [subdomainVersion, setSubdomainVersion] = useState("");
+  const [version, setVersion] = useState<string | null>(null);
 
   useEffect(() => {
     const host = window.location.host;
@@ -46,43 +27,25 @@ export function VersionWarning() {
 
     // Extract version from subdomain (e.g., "v2-3-1" from "v2-3-1.turborepo.dev")
     const subdomain = host.replace(`.${PRODUCTION_DOMAIN}`, "");
-    setSubdomainVersion(subdomain);
-
-    const currentSemver = subdomainToSemver(subdomain);
-
-    // Fetch latest version from npm to compare
-    fetch(NPM_REGISTRY_URL)
-      .then((res) => res.json())
-      .then((data) => {
-        const latestVersion = data.version as string;
-
-        if (isOlderVersion(currentSemver, latestVersion)) {
-          setIsOldVersion(true);
-        }
-      })
-      .catch(() => {
-        // If we can't fetch npm, assume it's old to be safe
-        setIsOldVersion(true);
-      });
+    setVersion(subdomainToVersion(subdomain));
   }, []);
 
-  if (!isOldVersion) {
+  if (!version) {
     return null;
   }
 
   return (
-    <div className="mb-4 rounded-lg border border-amber-500/50 bg-amber-500/10 p-3 text-sm">
-      <div className="flex items-center gap-2 font-medium text-amber-600 dark:text-amber-500">
-        <TriangleAlert className="size-4" />
-        <span>Old Version ({subdomainVersion})</span>
+    <div className="mb-4 rounded-lg border border-blue-500/50 bg-blue-500/10 p-3 text-sm">
+      <div className="flex items-center gap-2 font-medium text-blue-600 dark:text-blue-500">
+        <InfoIcon className="size-4" />
+        <span>Version: {version}</span>
       </div>
       <p className="mt-2 text-muted-foreground">
-        You&apos;re viewing docs for an out-of-date version of Turborepo.{" "}
         <Link
           href={`https://${PRODUCTION_DOMAIN}`}
-          className="block mt-2 font-medium text-amber-600 underline underline-offset-2 hover:text-amber-500 dark:text-amber-500 dark:hover:text-amber-400"
+          className="font-medium text-blue-600 underline underline-offset-2 hover:text-blue-500 dark:text-blue-500 dark:hover:text-blue-400"
         >
-          View latest docs →
+          Visit the latest documentation.
         </Link>
       </p>
     </div>


### PR DESCRIPTION
## Summary

- Simplifies `VersionWarning` component to show a version notice on any versioned subdomain (e.g., `v2-3-1.turborepo.dev`)
- Removes npm registry fetch and version comparison logic that was never working as intended

## Context

The previous implementation tried to fetch the latest version from npm and compare it to the subdomain version to determine if the docs were "old." However, versioned subdomains don't serve archived documentation - they all serve the same latest deployment. The subdomains exist primarily for serving versioned `schema.json` files.

The new behavior simply shows an informational notice with the version number and a link to the main docs site whenever a user is on any versioned subdomain.