### PR TITLE
chore: Update turborepo skill version during release

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -38,6 +38,9 @@ stage-release:
 	cd $(CLI_DIR)/../packages/eslint-config-turbo && pnpm version "$(TURBO_VERSION)" --allow-same-version
 	cd $(CLI_DIR)/../packages/turbo-types && pnpm version "$(TURBO_VERSION)" --allow-same-version
 
+	# Update turborepo skill version (in YAML frontmatter metadata block only)
+	node -e "const fs=require('fs'),p='$(CLI_DIR)/../skills/turborepo/SKILL.md',c=fs.readFileSync(p,'utf-8');fs.writeFileSync(p,c.replace(/^(---\n[\s\S]*?metadata:\n\s*version:\s*).+?(\n[\s\S]*?---)/,'\$$1$(TURBO_VERSION)\$$2'))"
+
 	git checkout -b staging-$(TURBO_VERSION)
 	git commit -anm "publish $(TURBO_VERSION) to registry"
 	git tag "v$(TURBO_VERSION)"

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -23,15 +23,3 @@ const parsed = semver.parse(newVersion);
 const tag = tagOverride || parsed?.prerelease[0] || "latest";
 
 fs.writeFileSync(versionFilePath, `${newVersion}\n${tag}\n`);
-
-// Update the turborepo skill version in YAML frontmatter
-const skillPath = path.join(__dirname, "..", "skills", "turborepo", "SKILL.md");
-if (fs.existsSync(skillPath)) {
-  const skillContent = fs.readFileSync(skillPath, "utf-8");
-  // Match frontmatter between --- delimiters, then replace version within metadata block
-  const updatedSkillContent = skillContent.replace(
-    /^(---\n[\s\S]*?metadata:\n\s*version:\s*).+?(\n[\s\S]*?---)/,
-    `$1${newVersion}$2`
-  );
-  fs.writeFileSync(skillPath, updatedSkillContent);
-}


### PR DESCRIPTION
## Summary

- Adds `metadata.version` field to the turborepo skill (`skills/turborepo/SKILL.md`)
- Updates `cli/Makefile` to bump the skill version alongside package versions during `make stage-release`

This ensures the skill version stays in sync with Turborepo releases automatically.