### PR TITLE
fix: Validate turbo version from lockfile is a semver string

### DIFF
--- a/crates/turborepo-lockfiles/src/npm.rs
+++ b/crates/turborepo-lockfiles/src/npm.rs
@@ -152,8 +152,6 @@ impl Lockfile for NpmLockfile {
     fn turbo_version(&self) -> Option<String> {
         let turbo_entry = self.packages.get("node_modules/turbo")?;
         let version = turbo_entry.version.as_ref()?;
-        // Validate version is valid semver to prevent arbitrary package specifiers
-        // (e.g. URLs or file paths) from being passed to npx
         Version::parse(version).ok()?;
         Some(version.clone())
     }


### PR DESCRIPTION
## Description

When `TURBO_DOWNLOAD_LOCAL_ENABLED=1` is set, the turbo version extracted from `package-lock.json` is passed to `npx`. This adds validation to ensure the version is valid semver before using it.

## Credit

We'd like to thank HackerOne reporter hellnia for responsibly disclosing.