### PR TITLE
docs(skills): Standardize --dry flag usage

### DIFF
--- a/skills/turborepo/references/environment/modes.md
+++ b/skills/turborepo/references/environment/modes.md
@@ -94,8 +94,8 @@ Or exclude specific patterns in config:
 
 ## Checking Environment Mode
 
-Use `--dry-run` to see which vars affect each task:
+Use `--dry` to see which vars affect each task:
 
 ```bash
-turbo run build --dry-run=json | jq '.tasks[].environmentVariables'
+turbo run build --dry=json | jq '.tasks[].environmentVariables'
 ```


### PR DESCRIPTION
## Description

Fixes inconsistent flag usage in skills documentation.

The skills documentation uses `--dry` and `--dry=json` consistently across 5 files:
- `caching/gotchas.md`
- `cli/commands.md`
- `cli/README.md`
- `filtering/patterns.md`
- `SKILL.md`

However, `environment/modes.md` uses `--dry-run` and `--dry-run=json` instead.

While both flags are valid aliases, this PR standardizes on `--dry` for consistency.