### PR TITLE
chore: Update docs:dev script filter to point to the correct documentation site path

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format:fix": "oxfmt .",
     "check:toml": "taplo format --check",
     "fix:toml": "taplo format",
-    "docs:dev": "turbo run dev --filter=turborepo-docs",
+    "docs:dev": "turbo run dev --filter=./docs/site",
     "turbo": "pnpm run build:turbo && ./target/debug/turbo",
     "turbo-prebuilt": "pnpm -- turbo",
     "prepare": "husky install",


### PR DESCRIPTION

### Description

<!--
  ✍️ Write a short summary of your work.
  If necessary, include relevant screenshots.

-->
Hello Turborepo team,

I am a frequent user of your project and really appreciate your work. I found an error in the docs execution script within package.json and have submitted a fix.

<img width="644" height="141" alt="Screenshot 2026-01-25 at 10 03 40 PM" src="https://github.com/user-attachments/assets/fb0f8065-da3f-491c-842f-ba2fb4cb638a" />


