### PR TITLE
fix: Disable pointer events on closed chat panel

### DIFF
--- a/docs/site/components/geistdocs/chat.tsx
+++ b/docs/site/components/geistdocs/chat.tsx
@@ -433,6 +433,7 @@ export const Chat = ({ basePath, suggestions }: ChatProps) => {
             "fixed z-50 flex flex-col gap-4 bg-background transition-all",
             "inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
             "translate-x-full data-[state=open]:translate-x-0",
+            "pointer-events-none data-[state=open]:pointer-events-auto",
             "hidden md:flex"
           )}
           data-state={isOpen ? "open" : "closed"}


### PR DESCRIPTION
## Summary
- Fix mobile header buttons (search, Ask AI, hamburger menu) being unclickable

The chat panel is a fixed-position element that slides off-screen when closed via `translate-x-full`. However, it still captured pointer events, blocking clicks on header buttons positioned underneath.

Adding `pointer-events-none` when closed and `pointer-events-auto` when open resolves this.

## Test
1. Resize browser to mobile width (< 768px)
2. Verify search, Ask AI, and hamburger menu buttons are clickable