### PR TITLE
ci: Run CodSpeed benchmarks only when Rust code changes

### DIFF
--- a/.github/actions/find-rust-changes/action.yml
+++ b/.github/actions/find-rust-changes/action.yml
@@ -1,0 +1,34 @@
+name: "Find Rust Changes"
+description: "Detects if Rust-related files have changed between base and head commits"
+outputs:
+  changed:
+    description: "Whether Rust files have changed ('true' or 'false')"
+    value: ${{ steps.check.outputs.changed }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check for Rust changes
+      id: check
+      shell: bash
+      run: |
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          git fetch origin ${{ github.base_ref }}
+          BASE_COMMIT="origin/${{ github.base_ref }}"
+          HEAD_COMMIT="HEAD"
+        else
+          BASE_COMMIT="${{ github.event.before }}"
+          HEAD_COMMIT="${{ github.event.after }}"
+        fi
+
+        echo "Comparing changes between $BASE_COMMIT and $HEAD_COMMIT"
+
+        RUST_PATHS="crates/ Cargo.toml Cargo.lock .cargo/ rust-toolchain.toml"
+
+        if git diff --name-only $BASE_COMMIT $HEAD_COMMIT -- $RUST_PATHS | grep -q .; then
+          echo "changed=true" >> $GITHUB_OUTPUT
+          echo "Changes detected in Rust paths"
+        else
+          echo "changed=false" >> $GITHUB_OUTPUT
+          echo "No changes in Rust paths"
+        fi

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -15,8 +15,23 @@ permissions:
   id-token: write # for OIDC authentication with CodSpeed
 
 jobs:
+  find-changes:
+    name: Find path changes
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.check.outputs.changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for Rust changes
+        id: check
+        uses: ./.github/actions/find-rust-changes
+
   benchmarks:
     name: Run benchmarks
+    needs: find-changes
+    if: ${{ needs.find-changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- CodSpeed benchmarks now only run when Rust-related files change, avoiding unnecessary CI runs on docs/examples/JS-only changes
- Adds a reusable `find-rust-changes` action that detects changes in `crates/`, `Cargo.toml`, `Cargo.lock`, `.cargo/`, and `rust-toolchain.toml`

## Test Plan

The `find-changes` job will output `rust=false` for PRs that don't touch Rust code, skipping the benchmarks job.