### PR TITLE
fix: Normalize ANSI escape codes in insta snapshots

### DIFF
--- a/.config/insta.yaml
+++ b/.config/insta.yaml
@@ -1,0 +1,9 @@
+# Insta snapshot testing configuration
+# https://insta.rs/docs/advanced/#configuration-file
+
+# Strip ANSI escape codes from snapshots to ensure consistent results
+# across different terminal environments. Some environments output ANSI
+# color codes while others output plain Unicode characters.
+filters:
+  - regex: "\\x1b\\[[0-9;]*m"
+    replacement: ""


### PR DESCRIPTION
## Summary

- Add global `insta.yaml` config to strip ANSI color codes from all snapshot tests automatically

The `test_missing_name_field_warning_message` test was producing different snapshots depending on the terminal environment. When miette detects a TTY or color-capable terminal, it outputs ANSI color codes (`[31m×[0m`). On other environments, it outputs plain Unicode characters (`×`).

The global config at `.config/insta.yaml` applies the ANSI filter to all snapshots, preventing this class of issues from affecting any current or future snapshot tests.

<sub>CLOSES TURBO-5043</sub>