### PR TITLE
fix: Add `allowComments` and `allowTrailingCommas` to turbo.json schema

### DIFF
--- a/crates/turborepo-schema-gen/src/main.rs
+++ b/crates/turborepo-schema-gen/src/main.rs
@@ -114,7 +114,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn generate_schema() -> RootSchema {
     // Generate schema for RawTurboJson which is the complete turbo.json structure
     // This includes both root-level and workspace-level configurations
-    schema_for!(RawTurboJson)
+    let mut schema = schema_for!(RawTurboJson);
+
+    // Add allowComments and allowTrailingCommas to the root schema
+    // These tell editors like VSCode that JSONC (JSON with comments) is supported
+    schema
+        .schema
+        .extensions
+        .insert("allowComments".to_string(), serde_json::json!(true));
+    schema
+        .schema
+        .extensions
+        .insert("allowTrailingCommas".to_string(), serde_json::json!(true));
+
+    schema
 }
 
 /// Generate TypeScript type definitions

--- a/packages/turbo-types/schemas/schema.json
+++ b/packages/turbo-types/schemas/schema.json
@@ -3,8 +3,6 @@
   "title": "RawTurboJson",
   "description": "Configuration schema for turbo.json.\n\nAn object representing the task dependency graph of your project. turbo interprets these conventions to schedule, execute, and cache the outputs of tasks in your project.\n\nDocumentation: https://turborepo.dev/docs/reference/configuration",
   "type": "object",
-  "allowComments": true,
-  "allowTrailingCommas": true,
   "properties": {
     "$schema": {
       "description": "JSON Schema URL for validation.",
@@ -178,6 +176,8 @@
       ]
     }
   },
+  "allowComments": true,
+  "allowTrailingCommas": true,
   "definitions": {
     "Array_of_String": {
       "type": "array",


### PR DESCRIPTION
## Summary
Adds `allowComments` and `allowTrailingCommas` properties to the turbo.json schema to prevent VSCode warnings when using JSONC features.

Fixes #11566

## Problem
When formatting `turbo.jsonc` with tools like `oxfmt` or `prettier` that add trailing commas, VSCode shows warnings like "Trailing comma jsonc(519)" because the schema doesn't declare support for JSONC features.

## Solution
Added two lines to `packages/turbo-types/schemas/schema.json`:
```json
"allowComments": true,
"allowTrailingCommas": true,
```

## Test plan
- [ ] Open a `turbo.jsonc` file with trailing commas in VSCode
- [ ] Verify no "Trailing comma" warnings appear

🤖 Generated with [Claude Code](https://claude.ai/code)