### PR TITLE
docs: Fix curl markdown Accept header syntax in 2.8 release blog

### DIFF
--- a/docs/site/content/blog/2-8.mdx
+++ b/docs/site/content/blog/2-8.mdx
@@ -126,7 +126,7 @@ We've retooled this site to enable agents and AI-assisted humans to work more ef
 
 We've improved your agents' ability to fetch docs from our site in a number of ways:
 
-- **Markdown responses for agents**: By responding with Markdown (instead of HTML), we help to preserve your context window. No configuration or special instructions are required. Run `curl -sL -H "Accept: text-markdown" https://turborepo.dev/repo/docs` in your terminal to see an example response.
+- **Markdown responses for agents**: By responding with Markdown (instead of HTML), we help to preserve your context window. No configuration or special instructions are required. Run `curl -sL -H "Accept: text/markdown" https://turborepo.dev/repo/docs` in your terminal to see an example response.
 - **.md routes**: You can also visit a markdown version of any documentation page by appending `.md` to a route. For example, try https://turborepo.dev/docs.md.
 - **/sitemap.md**: A machine-readable sitemap is available at https://turborepo.dev/sitemap.md, allowing agents to find out what docs exist.
 - **Versioned documentation**: Starting with version 2.7.6 of Turborepo, versioned docs are now available on subdomains of `turborepo.dev`. [Visit the 2.7.6 documentation here](https://v2-7-6.turborepo.dev/docs).


### PR DESCRIPTION
### Description

Reading 2.8 release post (https://turborepo.dev/blog/2-8) I decided to try the curl command used to show how Turborepo docs are now served as markdown when requested, but I noticed command was returning HTML instead of markdown.

This PR updates the docs to specify the header properly using `text/markdown` not `text-markdown`.

### Testing Instructions

Wrong command:
```bash
curl -sL -H "Accept: text-markdown" https://turborepo.dev/repo/docs
```

<img width="897" height="225" alt="image" src="https://github.com/user-attachments/assets/82b69323-aad9-45fe-b453-f7e842d43b9d" />

Correct command:
```bash
curl -sL -H "Accept: text/markdown" https://turborepo.dev/repo/docs
```

<img width="1025" height="251" alt="image" src="https://github.com/user-attachments/assets/cdd496b6-118f-4877-8c6c-e4f08c0a2070" />
