### PR TITLE
fix: Upgrade axios to fix SSRF vulnerability

### DIFF
--- a/packages/turbo-codemod/package.json
+++ b/packages/turbo-codemod/package.json
@@ -21,7 +21,7 @@
     "lint:prettier": "prettier -c . --cache --ignore-path=../../.prettierignore"
   },
   "dependencies": {
-    "axios": "0.27.2",
+    "axios": "1.9.0",
     "commander": "9.5.0",
     "diff": "5.1.0",
     "find-up": "4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -469,8 +469,8 @@ importers:
   packages/turbo-codemod:
     dependencies:
       axios:
-        specifier: 0.27.2
-        version: 0.27.2
+        specifier: 1.9.0
+        version: 1.9.0
       commander:
         specifier: 9.5.0
         version: 9.5.0
@@ -4440,8 +4440,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios@0.27.2:
-    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
+  axios@1.9.0:
+    resolution: {integrity: sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==}
 
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
@@ -5874,8 +5874,8 @@ packages:
   flatted@3.2.7:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
 
-  follow-redirects@1.15.1:
-    resolution: {integrity: sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==}
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -12402,10 +12402,11 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@0.27.2:
+  axios@1.9.0:
     dependencies:
-      follow-redirects: 1.15.1
+      follow-redirects: 1.15.11
       form-data: 4.0.0
+      proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
 
@@ -14011,7 +14012,7 @@ snapshots:
 
   flatted@3.2.7: {}
 
-  follow-redirects@1.15.1: {}
+  follow-redirects@1.15.11: {}
 
   for-in@1.0.2: {}
 


### PR DESCRIPTION
## Summary

- Upgrades axios from 0.27.2 to 1.9.0 in `@turbo/codemod` to address a high severity SSRF and credential leakage vulnerability

## Details

**Vulnerability**: SSRF and Credential Leakage in axios <0.30.0
**Severity**: High
**Reference**: TURBO-5143

The affected code (`packages/turbo-codemod/src/commands/migrate/steps/getLatestVersion.ts`) uses `axios.get()` for simple HTTP requests, which is fully compatible with axios 1.x.

## Testing

- Type checking passes for the affected file
- No breaking API changes for the simple `axios.get()` usage pattern