### PR TITLE
fix: Exclude coverage-reporter from Node.js 18 CI tests

### DIFF
--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -69,7 +69,6 @@ jobs:
         # We filter out turborepo-repository because it's a native package and needs
         # to run when turbo core changes. This job (`js_packages`) does not run on turborpeo core
         # changes, and we don't want to enable that beahvior for _all_ our JS packages.
-        # We filter out @turbo/coverage-reporter because it uses Next.js 16+ which requires Node.js >= 20.
         run: |
           TURBO_API= turbo run check-types test build package-checks --filter="!turborepo-repository" --filter="!@turbo/coverage-reporter" --filter={./packages/*}...[${{ github.event.pull_request.base.sha || 'HEAD^1' }}] --color --env-mode=strict
         env:


### PR DESCRIPTION
## Summary

- Excludes `@turbo/coverage-reporter` from the JS package test workflow

The coverage-reporter app uses Next.js 16+ which requires Node.js >= 20. This causes CI failures in the Node.js 18 test matrix since the `build` task attempts to run `next build`.