### PR TITLE
fix: Add explicit secrets declarations to release workflow_call trigger

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -89,6 +89,13 @@ on:
         required: false
         type: boolean
         default: false
+    secrets:
+      NPM_TOKEN:
+        required: true
+      TURBO_TOKEN:
+        required: true
+      DOCS_ALIAS_FAILURE_SLACK_WEBHOOK_URL:
+        required: true
     outputs:
       stage-branch:
         description: "The staging branch name"


### PR DESCRIPTION
## Summary

- Adds explicit `secrets` declarations to the `workflow_call` trigger in the release workflow
- Documents the required secrets contract for callers: `NPM_TOKEN`, `TURBO_TOKEN`, `DOCS_ALIAS_FAILURE_SLACK_WEBHOOK_URL`

## Why

When the release workflow is called via `workflow_call` (e.g., from `turborepo-canary.yml`), secrets must be explicitly passed or inherited. Making these requirements explicit:

1. Enables early failure if required secrets are missing (fail-fast at workflow invocation rather than mid-pipeline)
2. Documents the contract for any workflow calling this one
3. Follows GitHub Actions best practices for reusable workflows

## Testing

- Verified all three secrets are actually used in the workflow
- No runtime behavior change - this is purely declarative