### PR TITLE
fix: Pass secrets explicitly in canary workflow

### DIFF
--- a/.github/workflows/turborepo-canary.yml
+++ b/.github/workflows/turborepo-canary.yml
@@ -56,7 +56,10 @@ jobs:
     with:
       increment: prerelease
       is-canary: true
-    secrets: inherit
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      DOCS_ALIAS_FAILURE_SLACK_WEBHOOK_URL: ${{ secrets.DOCS_ALIAS_FAILURE_SLACK_WEBHOOK_URL }}
 
   create-canary-pr:
     name: "Open Canary Release PR"


### PR DESCRIPTION
## Summary

Updates the canary workflow to pass secrets explicitly to the release workflow, fixing the validation error introduced by the explicit `secrets` declarations in #11619.

## Why

The release workflow now declares required secrets with `required: true`. Using `secrets: inherit` doesn't satisfy this validation - secrets must be passed explicitly.

This is also a security improvement: the canary workflow now only passes the 3 required secrets rather than inheriting all repository secrets.