### PR TITLE
fix: Upgrade diff to fix DoS vulnerabilities

### DIFF
--- a/packages/turbo-codemod/package.json
+++ b/packages/turbo-codemod/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "commander": "9.5.0",
-    "diff": "5.1.0",
+    "diff": "5.2.2",
     "find-up": "4.1.0",
     "fs-extra": "10.1.0",
     "gradient-string": "2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -472,8 +472,8 @@ importers:
         specifier: 9.5.0
         version: 9.5.0
       diff:
-        specifier: 5.1.0
-        version: 5.1.0
+        specifier: 5.2.2
+        version: 5.2.2
       find-up:
         specifier: 4.1.0
         version: 4.1.0
@@ -5309,12 +5309,12 @@ packages:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  diff@4.0.2:
-    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+  diff@4.0.4:
+    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
     engines: {node: '>=0.3.1'}
 
-  diff@5.1.0:
-    resolution: {integrity: sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==}
+  diff@5.2.2:
+    resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
     engines: {node: '>=0.3.1'}
 
   dir-glob@3.0.1:
@@ -13643,9 +13643,9 @@ snapshots:
 
   diff-sequences@29.6.3: {}
 
-  diff@4.0.2: {}
+  diff@4.0.4: {}
 
-  diff@5.1.0: {}
+  diff@5.2.2: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -18550,7 +18550,7 @@ snapshots:
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1
-      diff: 4.0.2
+      diff: 4.0.4
       make-error: 1.3.6
       typescript: 5.5.4
       v8-compile-cache-lib: 3.0.1


### PR DESCRIPTION
## Summary

- Upgrades `diff` from 5.1.0 to 5.2.2 in `@turbo/codemod` (fixes TURBO-5178)
- Updates lockfile to resolve `diff@4.0.4` for ts-node's transitive dependency (fixes TURBO-5177)

Both versions patch a Regular Expression Denial of Service (ReDoS) vulnerability.

## Testing

- `@turbo/codemod`: 217 tests passing
- `@turbo/gen`: 9 tests passing
- Both packages build successfully