### PR TITLE
fix: Make release PRs auto-mergeable

### DIFF
--- a/.github/actions/check-release-pr/action.yml
+++ b/.github/actions/check-release-pr/action.yml
@@ -1,0 +1,77 @@
+name: Check Release PR
+description: |
+  Detects automated release PRs created by github-actions[bot] with title
+  matching "release(turborepo):*". These PRs only contain version bumps and
+  can skip full test suites.
+
+  This action also validates that release PRs only modify expected files
+  (version.txt, package.json, Cargo.toml, Cargo.lock, CHANGELOG).
+
+outputs:
+  is-release-pr:
+    description: "Whether this is an automated release PR (true/false)"
+    value: ${{ steps.check.outputs.is-release-pr }}
+
+runs:
+  using: composite
+  steps:
+    - name: Check if automated release PR
+      id: check
+      shell: bash
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        PR_TITLE: ${{ github.event.pull_request.title }}
+        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: |
+        # Only check on pull_request events
+        if [[ "$EVENT_NAME" != "pull_request" ]]; then
+          echo "is-release-pr=false" >> $GITHUB_OUTPUT
+          echo "Not a pull_request event, skipping release PR check"
+          exit 0
+        fi
+
+        # Check if PR is from github-actions[bot] with release title
+        if [[ "$PR_AUTHOR" == "github-actions[bot]" && "$PR_TITLE" =~ ^release\(turborepo\): ]]; then
+          echo "Detected automated release PR from $PR_AUTHOR"
+          echo "Title: $PR_TITLE"
+          echo "is-release-pr=true" >> $GITHUB_OUTPUT
+        else
+          echo "is-release-pr=false" >> $GITHUB_OUTPUT
+          echo "Not a release PR (author: $PR_AUTHOR, title: $PR_TITLE)"
+        fi
+
+    - name: Validate release PR contents
+      if: steps.check.outputs.is-release-pr == 'true'
+      shell: bash
+      env:
+        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      run: |
+        # Fetch the base branch to compare
+        git fetch origin $PR_BASE_SHA --depth=1 2>/dev/null || true
+
+        # Get list of changed files
+        CHANGED_FILES=$(git diff --name-only $PR_BASE_SHA...HEAD 2>/dev/null || git diff --name-only HEAD~1)
+
+        echo "Changed files in release PR:"
+        echo "$CHANGED_FILES"
+
+        # Validate each file matches expected release patterns
+        ALLOWED_PATTERN="^(version\.txt|.*/package\.json|package\.json|Cargo\.toml|Cargo\.lock|.*/Cargo\.toml|CHANGELOG.*|pnpm-lock\.yaml)$"
+
+        INVALID_FILES=""
+        while IFS= read -r file; do
+          if [[ -n "$file" ]] && ! echo "$file" | grep -qE "$ALLOWED_PATTERN"; then
+            INVALID_FILES="$INVALID_FILES$file"$'\n'
+          fi
+        done <<< "$CHANGED_FILES"
+
+        if [[ -n "$INVALID_FILES" ]]; then
+          echo "::error::Release PR contains unexpected files that are not version-related:"
+          echo "$INVALID_FILES"
+          echo "::error::Release PRs should only modify version.txt, package.json, Cargo.toml, Cargo.lock, CHANGELOG, or pnpm-lock.yaml"
+          exit 1
+        fi
+
+        echo "Release PR content validation passed - only version-related files changed"

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -21,23 +21,20 @@ permissions:
 
 jobs:
   # Detect automated release PRs which only contain version bumps.
-  # These don't need full test suites - we skip to the summary.
+  # These PRs are created by the release workflow after code has already
+  # been tested on main. Skipping tests on version-only changes saves CI time.
   check-release-pr:
     name: Check Release PR
     runs-on: ubuntu-latest
     outputs:
       is-release-pr: ${{ steps.check.outputs.is-release-pr }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Check if automated release PR
         id: check
-        run: |
-          if [[ "${{ github.event.pull_request.user.login }}" == "github-actions[bot]" && \
-                "${{ github.event.pull_request.title }}" == release\(turborepo\):* ]]; then
-            echo "is-release-pr=true" >> $GITHUB_OUTPUT
-            echo "Detected automated release PR - will skip tests"
-          else
-            echo "is-release-pr=false" >> $GITHUB_OUTPUT
-          fi
+        uses: ./.github/actions/check-release-pr
 
   js_packages:
     name: "(${{matrix.os.name}}, Node ${{matrix.node-version}})"

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -31,22 +31,14 @@ jobs:
       native-lib: ${{ steps.filter.outputs.native-lib }}
     steps:
       # Detect automated release PRs which only contain version bumps.
-      # These don't need full test suites - we skip to the summary.
-      - name: Check if automated release PR
-        id: check-release
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request" && \
-                "${{ github.event.pull_request.user.login }}" == "github-actions[bot]" && \
-                "${{ github.event.pull_request.title }}" == release\(turborepo\):* ]]; then
-            echo "is-release-pr=true" >> $GITHUB_OUTPUT
-            echo "Detected automated release PR - will skip tests"
-          else
-            echo "is-release-pr=false" >> $GITHUB_OUTPUT
-          fi
-
+      # These PRs are created by the release workflow after code has already
+      # been tested on main. Skipping tests on version-only changes saves CI time.
       - name: Checkout
         uses: actions/checkout@v4
-        if: steps.check-release.outputs.is-release-pr != 'true'
+
+      - name: Check if automated release PR
+        id: check-release
+        uses: ./.github/actions/check-release-pr
 
       - name: Check path changes
         if: steps.check-release.outputs.is-release-pr != 'true'


### PR DESCRIPTION
## Summary

Automated release PRs (created by `github-actions[bot]` with title `release(turborepo):*`) were stuck waiting for required checks that never completed because test jobs were skipped due to path filters or change detection.

This modifies both test workflows to detect release PRs and skip directly to reporting success:

- **test-js-packages.yml**: Added `version.txt` to path filters so the workflow triggers, plus a `check-release-pr` job that skips tests for release PRs
- **turborepo-test.yml**: Added `is-release-pr` output to the existing `find-changes` job, used to skip all test jobs

Release PRs only contain version bumps, so full test suites aren't needed. The author check (`github-actions[bot]`) prevents humans from bypassing tests with a matching title.

Fixes the auto-merge blocking issue seen in #11625.