### PR TITLE
fix: Make release PR status checks pass for auto-merge

### DIFF
--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -102,7 +102,13 @@ jobs:
       - check-release-pr
       - js_packages
     steps:
+      - name: Skip for release PR
+        if: needs.check-release-pr.outputs.is-release-pr == 'true'
+        run: |
+          echo "Release PR detected - skipping tests (code already tested on main)"
+
       - name: Compute info
+        if: needs.check-release-pr.outputs.is-release-pr != 'true'
         run: |
           cancelled=false
           failure=false

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -685,9 +685,14 @@ jobs:
       - with-tailwind-example
       - js_native_packages
     steps:
+      - name: Skip for release PR
+        if: needs.find-changes.outputs.is-release-pr == 'true'
+        run: |
+          echo "Release PR detected - skipping tests (code already tested on main)"
+
       - name: Compute info
         id: info
-        if: always()
+        if: needs.find-changes.outputs.is-release-pr != 'true'
         run: |
           cancelled=false
           failure=false
@@ -722,11 +727,11 @@ jobs:
           fi
 
       - name: Failed
-        if: steps.info.outputs.failure == 'true'
+        if: needs.find-changes.outputs.is-release-pr != 'true' && steps.info.outputs.failure == 'true'
         run: exit 1
 
       - name: Succeeded
-        if: steps.info.outputs.success == 'true'
+        if: needs.find-changes.outputs.is-release-pr != 'true' && steps.info.outputs.success == 'true'
         run: echo Ok
 
   cleanup:


### PR DESCRIPTION
## Summary

Release PRs (created by the release workflow) were getting stuck because the required status checks `JS Test Summary` and `Test Summary` were never reported - the test jobs correctly skip for release PRs, but the summary jobs weren't explicitly succeeding.

This adds an early-exit step to both summary jobs that explicitly succeeds when a release PR is detected, allowing auto-merge to proceed.

Fixes the issue seen in #11628 where release PRs have auto-merge enabled but can't merge because required checks are "Waiting for status to be reported."