### PR TITLE
release(turborepo): 2.8.2-canary.6

### DIFF
--- a/packages/create-turbo/package.json
+++ b/packages/create-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-turbo",
-  "version": "2.8.2-canary.5",
+  "version": "2.8.2-canary.6",
   "description": "Create a new Turborepo",
   "homepage": "https://turborepo.dev",
   "license": "MIT",

--- a/packages/eslint-config-turbo/package.json
+++ b/packages/eslint-config-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-turbo",
-  "version": "2.8.2-canary.5",
+  "version": "2.8.2-canary.6",
   "type": "commonjs",
   "description": "ESLint config for Turborepo",
   "license": "MIT",

--- a/packages/eslint-plugin-turbo/package.json
+++ b/packages/eslint-plugin-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-turbo",
-  "version": "2.8.2-canary.5",
+  "version": "2.8.2-canary.6",
   "description": "ESLint plugin for Turborepo",
   "keywords": [
     "turbo",

--- a/packages/turbo-codemod/package.json
+++ b/packages/turbo-codemod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/codemod",
-  "version": "2.8.2-canary.5",
+  "version": "2.8.2-canary.6",
   "description": "Provides Codemod transformations to help upgrade your Turborepo codebase when a feature is deprecated.",
   "homepage": "https://turborepo.dev",
   "license": "MIT",

--- a/packages/turbo-gen/package.json
+++ b/packages/turbo-gen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/gen",
-  "version": "2.8.2-canary.5",
+  "version": "2.8.2-canary.6",
   "description": "Extend a Turborepo",
   "type": "commonjs",
   "homepage": "https://turborepo.dev",

--- a/packages/turbo-ignore/package.json
+++ b/packages/turbo-ignore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-ignore",
-  "version": "2.8.2-canary.5",
+  "version": "2.8.2-canary.6",
   "description": "",
   "homepage": "https://turborepo.dev",
   "keywords": [],

--- a/packages/turbo-types/package.json
+++ b/packages/turbo-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/types",
-  "version": "2.8.2-canary.5",
+  "version": "2.8.2-canary.6",
   "description": "Turborepo types",
   "type": "commonjs",
   "homepage": "https://turborepo.dev",

--- a/packages/turbo-workspaces/package.json
+++ b/packages/turbo-workspaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/workspaces",
-  "version": "2.8.2-canary.5",
+  "version": "2.8.2-canary.6",
   "description": "Tools for working with package managers",
   "homepage": "https://turborepo.dev",
   "license": "MIT",

--- a/packages/turbo/package.json
+++ b/packages/turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo",
-  "version": "2.8.2-canary.5",
+  "version": "2.8.2-canary.6",
   "description": "Turborepo is a high-performance build system for JavaScript and TypeScript codebases.",
   "repository": "https://github.com/vercel/turborepo",
   "bugs": "https://github.com/vercel/turborepo/issues",
@@ -18,11 +18,11 @@
     "schema.json"
   ],
   "optionalDependencies": {
-    "turbo-darwin-64": "2.8.2-canary.5",
-    "turbo-darwin-arm64": "2.8.2-canary.5",
-    "turbo-linux-64": "2.8.2-canary.5",
-    "turbo-linux-arm64": "2.8.2-canary.5",
-    "turbo-windows-64": "2.8.2-canary.5",
-    "turbo-windows-arm64": "2.8.2-canary.5"
+    "turbo-darwin-64": "2.8.2-canary.6",
+    "turbo-darwin-arm64": "2.8.2-canary.6",
+    "turbo-linux-64": "2.8.2-canary.6",
+    "turbo-linux-arm64": "2.8.2-canary.6",
+    "turbo-windows-64": "2.8.2-canary.6",
+    "turbo-windows-arm64": "2.8.2-canary.6"
   }
 }

--- a/version.txt
+++ b/version.txt
@@ -1,2 +1,2 @@
-2.8.2-canary.5
+2.8.2-canary.6
 canary


### PR DESCRIPTION
## Canary Release

Versioned docs: https://v2-8-2-canary-6.turborepo.dev

This release PR was created manually after the original release's tag creation step needed to be re-run.

Release PR for turborepo v2.8.2-canary.6