### PR TITLE
fix: Ensure JS Test Summary always reports status

### DIFF
--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -1,14 +1,6 @@
 name: JS Package Tests
 on:
   pull_request:
-    paths:
-      - package.json
-      - pnpm-workspace.yaml
-      - pnpm-lock.yaml
-      - version.txt
-      - "packages/**"
-      - ".github/actions/**"
-      - ".github/workflows/test-js-packages.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -20,14 +12,12 @@ permissions:
   pull-requests: read
 
 jobs:
-  # Detect automated release PRs which only contain version bumps.
-  # These PRs are created by the release workflow after code has already
-  # been tested on main. Skipping tests on version-only changes saves CI time.
-  check-release-pr:
-    name: Check Release PR
+  find-changes:
+    name: Find path changes
     runs-on: ubuntu-latest
     outputs:
       is-release-pr: ${{ steps.check.outputs.is-release-pr }}
+      js-packages: ${{ steps.filter.outputs.js-packages }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -36,10 +26,35 @@ jobs:
         id: check
         uses: ./.github/actions/check-release-pr
 
+      - name: Check path changes
+        if: steps.check.outputs.is-release-pr != 'true'
+        id: filter
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            git fetch origin ${{ github.base_ref }}
+            BASE_COMMIT="origin/${{ github.base_ref }}"
+            HEAD_COMMIT="HEAD"
+          else
+            BASE_COMMIT="${{ github.event.before }}"
+            HEAD_COMMIT="${{ github.event.after }}"
+          fi
+
+          JS_PATTERNS="^(package\.json|pnpm-workspace\.yaml|pnpm-lock\.yaml|version\.txt|packages/|\.github/actions/|\.github/workflows/test-js-packages\.yml)"
+          CHANGED_FILES=$(git diff --name-only $BASE_COMMIT $HEAD_COMMIT)
+          JS_CHANGES=$(echo "$CHANGED_FILES" | grep -E "$JS_PATTERNS" || true)
+
+          if [ -n "$JS_CHANGES" ]; then
+            echo "js-packages=true" >> $GITHUB_OUTPUT
+            echo "JS package changes detected"
+          else
+            echo "js-packages=false" >> $GITHUB_OUTPUT
+            echo "No JS package changes"
+          fi
+
   js_packages:
     name: "(${{matrix.os.name}}, Node ${{matrix.node-version}})"
-    needs: check-release-pr
-    if: needs.check-release-pr.outputs.is-release-pr != 'true'
+    needs: find-changes
+    if: needs.find-changes.outputs.is-release-pr != 'true' && needs.find-changes.outputs.js-packages == 'true'
     timeout-minutes: 30
     runs-on: ${{ matrix.os.runner }}
     strategy:
@@ -99,16 +114,19 @@ jobs:
     timeout-minutes: 30
     if: always()
     needs:
-      - check-release-pr
+      - find-changes
       - js_packages
     steps:
       - name: Skip for release PR
-        if: needs.check-release-pr.outputs.is-release-pr == 'true'
-        run: |
-          echo "Release PR detected - skipping tests (code already tested on main)"
+        if: needs.find-changes.outputs.is-release-pr == 'true'
+        run: echo "Release PR detected - skipping tests (code already tested on main)"
+
+      - name: Skip - no JS changes
+        if: needs.find-changes.outputs.is-release-pr != 'true' && needs.find-changes.outputs.js-packages != 'true'
+        run: echo "No JS package changes detected - skipping tests"
 
       - name: Compute info
-        if: needs.check-release-pr.outputs.is-release-pr != 'true'
+        if: needs.find-changes.outputs.is-release-pr != 'true' && needs.find-changes.outputs.js-packages == 'true'
         run: |
           cancelled=false
           failure=false


### PR DESCRIPTION
## Summary

- Move path filtering from workflow-level trigger to job-level conditions
- Ensures the summary job always runs and posts a status to GitHub

When path filters are at the workflow level and paths don't match, the workflow never runs, so required status checks never receive a status and hang indefinitely as "Waiting for status to be reported."

By moving the filtering inside the workflow, the `find-changes` job always runs and the summary job can report success/skip appropriately.

## Testing

This PR itself will validate the fix - the "JS Test Summary" check should complete (likely with a skip message since no JS packages are modified).