### PR TITLE
fix: Remove smooth scrolling from docs

### DIFF
--- a/apps/docs/app/[lang]/layout.tsx
+++ b/apps/docs/app/[lang]/layout.tsx
@@ -21,7 +21,7 @@ const Layout = async ({ children, params }: LayoutProps<"/[lang]">) => {
 
   return (
     <html
-      className={cn(sans.variable, mono.variable, "scroll-smooth antialiased")}
+      className={cn(sans.variable, mono.variable, "antialiased")}
       lang={lang}
       suppressHydrationWarning
     >


### PR DESCRIPTION
## Summary

- Removes the global `scroll-smooth` class from the docs layout

Smooth scrolling can cause issues for users with motion sensitivity and interferes with browser find-in-page functionality.