### PR TITLE
examples: Update NODE_VERSION to 24.13.1 in Dockerfile

### DIFF
--- a/examples/with-docker/apps/web/Dockerfile
+++ b/examples/with-docker/apps/web/Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=24.11.1
+ARG NODE_VERSION=24.13.1
 FROM node:${NODE_VERSION}-slim AS base
 
 # This Dockerfile is copy-pasted into our main docs at /docs/handbook/deploying-with-docker.


### PR DESCRIPTION
A flaw in Node.js's buffer allocation logic can expose uninitialized memory when allocations are interrupted, when using the vm module with the timeout option. Under specific timing conditions, buffers allocated with Buffer.alloc and other TypedArray instances like Uint8Array may contain leftover data from previous operations, allowing in-process secrets like tokens or passwords to leak or causing data corruption. While exploitation typically requires precise timing or in-process code execution, it can become remotely exploitable when untrusted input influences workload and timeouts, leading to potential confidentiality and integrity impact.

