### PR TITLE
fix: Upgrade semver to fix ReDoS vulnerability

### DIFF
--- a/packages/create-turbo/package.json
+++ b/packages/create-turbo/package.json
@@ -27,7 +27,7 @@
     "inquirer": "8.2.7",
     "picocolors": "1.0.1",
     "proxy-agent": "6.5.0",
-    "semver": "7.5.0",
+    "semver": "7.7.3",
     "update-check": "1.5.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,8 +333,8 @@ importers:
         specifier: 6.5.0
         version: 6.5.0
       semver:
-        specifier: 7.5.0
-        version: 7.5.0
+        specifier: 7.7.3
+        version: 7.7.3
       update-check:
         specifier: 1.5.4
         version: 1.5.4
@@ -8956,7 +8956,7 @@ snapshots:
       commander: 10.0.1
       marked: 9.1.6
       marked-terminal: 7.3.0(marked@9.1.6)
-      semver: 7.6.2
+      semver: 7.7.3
 
   '@arethetypeswrong/core@0.18.2':
     dependencies:
@@ -8965,7 +8965,7 @@ snapshots:
       cjs-module-lexer: 1.4.3
       fflate: 0.8.2
       lru-cache: 11.2.4
-      semver: 7.6.2
+      semver: 7.7.3
       typescript: 5.6.1-rc
       validate-npm-package-name: 5.0.0
 
@@ -12117,7 +12117,7 @@ snapshots:
 
   builtins@5.0.1:
     dependencies:
-      semver: 7.6.2
+      semver: 7.7.3
 
   bunchee@6.3.4(typescript@5.9.3):
     dependencies:
@@ -14284,7 +14284,7 @@ snapshots:
       '@babel/parser': 7.27.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
-      semver: 7.6.2
+      semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -14601,7 +14601,7 @@ snapshots:
       jest-util: 29.7.0
       natural-compare: 1.4.0
       pretty-format: 29.7.0
-      semver: 7.6.2
+      semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -17649,7 +17649,7 @@ snapshots:
   vscode-languageclient@9.0.1:
     dependencies:
       minimatch: 5.1.0
-      semver: 7.6.2
+      semver: 7.7.3
       vscode-languageserver-protocol: 3.17.5
 
   vscode-languageserver-protocol@3.17.5:


### PR DESCRIPTION
## Summary
- Upgrades `semver` from 7.5.0 to 7.7.3 in `packages/create-turbo` to fix a high-severity ReDoS vulnerability

## Details
The `semver` package versions `>=7.0.0 <7.5.2` are vulnerable to Regular Expression Denial of Service (ReDoS). This upgrade addresses [GHSA-c2qf-rxjj-qqgw](https://github.com/advisories/GHSA-c2qf-rxjj-qqgw).

Closes TURBO-5232