### PR TITLE
fix: Upgrade lodash to fix prototype pollution vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "pnpm": {
     "overrides": {
-      "fast-xml-parser": ">=5.3.4"
+      "fast-xml-parser": ">=5.3.4",
+      "lodash": ">=4.17.23",
+      "lodash-es": ">=4.17.23"
     }
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   fast-xml-parser: '>=5.3.4'
+  lodash: '>=4.17.23'
+  lodash-es: '>=4.17.23'
 
 importers:
 
@@ -148,7 +150,7 @@ importers:
         specifier: 0.18.12
         version: 0.18.12
       lodash-es:
-        specifier: 4.17.23
+        specifier: '>=4.17.23'
         version: 4.17.23
       lucide-react:
         specifier: ^0.555.0
@@ -6551,9 +6553,6 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
-  lodash-es@4.17.21:
-    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
-
   lodash-es@4.17.23:
     resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
 
@@ -6567,8 +6566,8 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
   log-symbols@3.0.0:
     resolution: {integrity: sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==}
@@ -9121,12 +9120,12 @@ snapshots:
     dependencies:
       '@chevrotain/gast': 11.0.3
       '@chevrotain/types': 11.0.3
-      lodash-es: 4.17.21
+      lodash-es: 4.17.23
 
   '@chevrotain/gast@11.0.3':
     dependencies:
       '@chevrotain/types': 11.0.3
-      lodash-es: 4.17.21
+      lodash-es: 4.17.23
 
   '@chevrotain/regexp-to-ast@11.0.3': {}
 
@@ -12235,7 +12234,7 @@ snapshots:
       '@chevrotain/regexp-to-ast': 11.0.3
       '@chevrotain/types': 11.0.3
       '@chevrotain/utils': 11.0.3
-      lodash-es: 4.17.21
+      lodash-es: 4.17.23
 
   chokidar@3.6.0:
     dependencies:
@@ -14039,7 +14038,7 @@ snapshots:
       chalk: 4.1.2
       cli-cursor: 3.1.0
       figures: 3.2.0
-      lodash: 4.17.21
+      lodash: 4.17.23
       rxjs: 7.8.1
 
   inquirer@7.3.3:
@@ -14050,7 +14049,7 @@ snapshots:
       cli-width: 3.0.0
       external-editor: 3.1.0
       figures: 3.2.0
-      lodash: 4.17.21
+      lodash: 4.17.23
       mute-stream: 0.0.8
       run-async: 2.4.1
       rxjs: 6.6.7
@@ -14066,7 +14065,7 @@ snapshots:
       cli-cursor: 3.1.0
       cli-width: 3.0.0
       figures: 3.2.0
-      lodash: 4.17.21
+      lodash: 4.17.23
       mute-stream: 0.0.8
       ora: 5.4.1
       run-async: 2.4.1
@@ -14809,8 +14808,6 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  lodash-es@4.17.21: {}
-
   lodash-es@4.17.23: {}
 
   lodash.get@4.4.2: {}
@@ -14819,7 +14816,7 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
-  lodash@4.17.21: {}
+  lodash@4.17.23: {}
 
   log-symbols@3.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds `pnpm.overrides` for `lodash` and `lodash-es` to `>=4.17.23`, resolving prototype pollution vulnerabilities (CVE-2021-23337, CVE-2020-28500) in transitive dependencies.

## Context (TURBO-5236)

`lodash@4.17.21` was pulled in transitively via `inquirer` (used by `create-turbo` and other packages). `lodash-es@4.17.21` was pulled in transitively via `mermaid > @mermaid-js/parser > langium > chevrotain` in `docs`. Both versions are vulnerable to prototype pollution; `4.17.23` is the fix.

The docs package already had a direct `lodash-es@4.17.23` dependency, but the transitive resolution from mermaid's sub-dependencies still resolved to `4.17.21`. The override forces all instances to the patched version.

## Verification

`pnpm why lodash --recursive` and `pnpm why lodash-es --recursive` confirm all instances now resolve to `4.17.23`.