### PR TITLE
fix: Upgrade mdast-util-to-hast to fix unsanitized class attribute vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "pnpm": {
     "overrides": {
-      "fast-xml-parser": ">=5.3.4"
+      "fast-xml-parser": ">=5.3.4",
+      "mdast-util-to-hast": ">=13.2.1"
     }
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   fast-xml-parser: '>=5.3.4'
+  mdast-util-to-hast: '>=13.2.1'
 
 importers:
 
@@ -6737,8 +6738,8 @@ packages:
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
 
-  mdast-util-to-hast@13.2.0:
-    resolution: {integrity: sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==}
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
 
   mdast-util-to-markdown@2.1.2:
     resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
@@ -13766,7 +13767,7 @@ snapshots:
       hast-util-from-parse5: 8.0.1
       hast-util-to-parse5: 8.0.0
       html-void-elements: 3.0.0
-      mdast-util-to-hast: 13.2.0
+      mdast-util-to-hast: 13.2.1
       parse5: 7.2.0
       unist-util-position: 5.0.0
       unist-util-visit: 5.0.0
@@ -13827,7 +13828,7 @@ snapshots:
       comma-separated-tokens: 2.0.3
       hast-util-whitespace: 3.0.0
       html-void-elements: 3.0.0
-      mdast-util-to-hast: 13.2.0
+      mdast-util-to-hast: 13.2.1
       property-information: 7.0.0
       space-separated-tokens: 2.0.2
       stringify-entities: 4.0.4
@@ -15086,7 +15087,7 @@ snapshots:
       '@types/mdast': 4.0.4
       unist-util-is: 6.0.0
 
-  mdast-util-to-hast@13.2.0:
+  mdast-util-to-hast@13.2.1:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
@@ -16524,7 +16525,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      mdast-util-to-hast: 13.2.0
+      mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
 


### PR DESCRIPTION
## Summary

- Fixes TURBO-5237: `mdast-util-to-hast` had an unsanitized class attribute vulnerability in versions `<13.2.1`
- Adds `pnpm.overrides` for `mdast-util-to-hast: ">=13.2.1"` in the root `package.json`, bumping the resolved version from `13.2.0` to `13.2.1` across all transitive dependency chains (`fumadocs-core` → `@shikijs/rehype` / `@shikijs/transformers` / `remark-rehype` → `mdast-util-to-hast`)

### Why an override?

`mdast-util-to-hast` is a transitive dependency pulled in by several packages in the `docs` app. None of the direct dependencies pin it below `13.2.1` — the lockfile simply resolved `13.2.0` before the fix was published. A `pnpm.overrides` entry is the idiomatic way to enforce a minimum version for transitive security fixes without unnecessarily upgrading direct dependencies.