### PR TITLE
fix: Upgrade valibot to fix ReDoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "pnpm": {
     "overrides": {
-      "fast-xml-parser": ">=5.3.4"
+      "fast-xml-parser": ">=5.3.4",
+      "valibot": ">=1.2.0"
     }
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   fast-xml-parser: '>=5.3.4'
+  valibot: '>=1.2.0'
 
 importers:
 
@@ -3936,7 +3937,7 @@ packages:
   '@valibot/to-json-schema@1.0.0':
     resolution: {integrity: sha512-/9crJgPptVsGCL6X+JPDQyaJwkalSZ/52WuF8DiRUxJgcmpNdzYRfZ+gqMEP8W3CTVfuMWPqqvIgfwJ97f9Etw==}
     peerDependencies:
-      valibot: ^1.0.0
+      valibot: '>=1.2.0'
 
   '@vercel/analytics@1.6.1':
     resolution: {integrity: sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==}
@@ -8630,8 +8631,8 @@ packages:
     resolution: {integrity: sha512-83N0OkTbn6gOjJ2awNuzuK4czeGxwEwBoTqlhBZhnp8o0IJ72mXRQKphj/azwRf3acbDJZYZhbOPEJHd884ELg==}
     engines: {node: '>= 10.13.0'}
 
-  valibot@1.0.0:
-    resolution: {integrity: sha512-1Hc0ihzWxBar6NGeZv7fPLY0QuxFMyxwYR2sF1Blu7Wq7EnremwY2W02tit2ij2VJT8HcSkHAQqmFfl77f73Yw==}
+  valibot@1.2.0:
+    resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -11714,9 +11715,9 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@valibot/to-json-schema@1.0.0(valibot@1.0.0(typescript@5.5.4))':
+  '@valibot/to-json-schema@1.0.0(valibot@1.2.0(typescript@5.5.4))':
     dependencies:
-      valibot: 1.0.0(typescript@5.5.4)
+      valibot: 1.2.0(typescript@5.5.4)
 
   '@vercel/analytics@1.6.1(next@16.1.5(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     optionalDependencies:
@@ -16624,9 +16625,9 @@ snapshots:
   rolldown@1.0.0-beta.8-commit.d984417(typescript@5.5.4):
     dependencies:
       '@oxc-project/types': 0.65.0
-      '@valibot/to-json-schema': 1.0.0(valibot@1.0.0(typescript@5.5.4))
+      '@valibot/to-json-schema': 1.0.0(valibot@1.2.0(typescript@5.5.4))
       ansis: 3.17.0
-      valibot: 1.0.0(typescript@5.5.4)
+      valibot: 1.2.0(typescript@5.5.4)
     optionalDependencies:
       '@rolldown/binding-darwin-arm64': 1.0.0-beta.8-commit.d984417
       '@rolldown/binding-darwin-x64': 1.0.0-beta.8-commit.d984417
@@ -17504,7 +17505,7 @@ snapshots:
 
   v8flags@4.0.0: {}
 
-  valibot@1.0.0(typescript@5.5.4):
+  valibot@1.2.0(typescript@5.5.4):
     optionalDependencies:
       typescript: 5.5.4
 


### PR DESCRIPTION
## Summary

- Adds a `pnpm.overrides` entry for `valibot: ">=1.2.0"` to fix a ReDoS vulnerability in versions below 1.2.0
- The vulnerable `valibot` is a transitive dependency via `create-turbo > tsdown > rolldown > valibot`
- Override bumps the resolved version from 1.0.0 to 1.2.0, which contains the fix

Refs TURBO-5234