### PR TITLE
fix: Upgrade cli package to fix arbitrary file write vulnerability

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cli",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "scripts": {
     "clean": "cargo clean --package turbo",
     "build": "cargo build --package turbo",


### PR DESCRIPTION
## Summary

- Bumps the `cli` workspace version from `0.0.0` to `1.0.0` to resolve a false-positive `pnpm audit` finding (CVE-2016-10538, GHSA-6cpc-mj5c-m9rq)

## Context

The `cli` workspace (`cli/package.json`) is the Rust CLI wrapper — it has nothing to do with the [npm `cli` package](https://www.npmjs.com/package/cli) from `node-js-libs/cli`. However, because our workspace is named `cli` and was at version `0.0.0`, `pnpm audit` matched it against the advisory for the npm `cli` package (vulnerable versions `<1.0.0`).

Bumping the workspace version to `1.0.0` puts it outside the vulnerable range, clearing the audit finding. This workspace is `private: true` so the version number has no publish implications.

Fixes TURBO-5242.