### PR TITLE
fix: Upgrade diff to fix DoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "pnpm": {
     "overrides": {
+      "diff@^4": "4.0.4",
+      "diff@>=6 <9": "8.0.3",
       "fast-xml-parser": ">=5.3.4"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  diff@^4: 4.0.4
+  diff@>=6 <9: 8.0.3
   fast-xml-parser: '>=5.3.4'
 
 importers:
@@ -4992,16 +4994,16 @@ packages:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  diff@4.0.2:
-    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+  diff@4.0.4:
+    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
     engines: {node: '>=0.3.1'}
 
   diff@5.2.2:
     resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
     engines: {node: '>=0.3.1'}
 
-  diff@7.0.0:
-    resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
+  diff@8.0.3:
+    resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
 
   dir-glob@3.0.1:
@@ -12807,11 +12809,11 @@ snapshots:
 
   diff-sequences@29.6.3: {}
 
-  diff@4.0.2: {}
+  diff@4.0.4: {}
 
   diff@5.2.2: {}
 
-  diff@7.0.0: {}
+  diff@8.0.3: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -17250,7 +17252,7 @@ snapshots:
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1
-      diff: 4.0.2
+      diff: 4.0.4
       make-error: 1.3.6
       typescript: 5.5.4
       v8-compile-cache-lib: 3.0.1
@@ -17265,7 +17267,7 @@ snapshots:
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.3
-      diff: 7.0.0
+      diff: 8.0.3
       find-up-simple: 1.0.1
       rolldown: 1.0.0-beta.8-commit.d984417(typescript@5.5.4)
       rolldown-plugin-dts: 0.8.6(rolldown@1.0.0-beta.8-commit.d984417(typescript@5.5.4))(typescript@5.5.4)


### PR DESCRIPTION
## Summary

- Fixes TURBO-5241: `diff` (jsdiff) has a DoS vulnerability in `parsePatch` and `applyPatch` ([GHSA-73rr-hh4g-fpgx](https://github.com/advisories/GHSA-73rr-hh4g-fpgx))
- Adds `pnpm.overrides` to upgrade `diff@^4` to `4.0.4` (fixes `ts-node > diff`) and `diff@>=6 <9` to `8.0.3` (fixes `tsdown > diff`)
- `turbo-codemod`'s direct dependency on `diff@5.2.2` is unaffected (v5 is not in either vulnerable range)