### PR TITLE
fix: Bump cli workspace version to clear false-positive audit finding

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cli",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "scripts": {
     "clean": "cargo clean --package turbo",
     "build": "cargo build --package turbo",


### PR DESCRIPTION
## Summary

- Bumps `cli/package.json` version from `0.0.0` to `1.0.0` to clear a false-positive `pnpm audit` finding (CVE-2016-10538, "Arbitrary File Write in cli").

The `cli` workspace shares its name with a vulnerable npm package (`cli <1.0.0`). Since `pnpm audit` matches on workspace names, it incorrectly flags our private workspace. Bumping the version to `1.0.0` puts it outside the vulnerable range. The package is `"private": true`, so the version number has no publish implications.

Refs TURBO-5242