### PR TITLE
fix: Upgrade indicatif to 0.18.3 to drop unmaintained number_prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1301,15 +1301,27 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.7"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
- "unicode-width 0.1.13",
- "windows-sys 0.45.0",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width 0.2.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1748,15 +1760,14 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
 dependencies = [
- "console",
+ "console 0.16.2",
  "fuzzy-matcher",
  "shell-words",
  "tempfile",
- "thiserror 1.0.63",
  "zeroize",
 ]
 
@@ -1918,9 +1929,9 @@ checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
 
 [[package]]
 name = "encode_unicode"
-version = "0.3.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -2900,14 +2911,15 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.3"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef509aa9bc73864d6756f0d34d35504af3cf0844373afe9b8669a5b8005a729"
+checksum = "9375e112e4b463ec1b1c6c011953545c65a30164fbab5b581df32b3abf0dcb88"
 dependencies = [
- "console",
- "number_prefix",
- "portable-atomic 0.3.19",
- "unicode-width 0.1.13",
+ "console 0.16.2",
+ "portable-atomic",
+ "unicode-width 0.2.2",
+ "unit-prefix",
+ "web-time",
 ]
 
 [[package]]
@@ -2942,7 +2954,7 @@ version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6593a41c7a73841868772495db7dc1e8ecab43bb5c0b6da2059246c4b506ab60"
 dependencies = [
- "console",
+ "console 0.15.11",
  "lazy_static",
  "linked-hash-map",
  "regex",
@@ -3125,7 +3137,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fe90c1150662e858c7d5f945089b7517b0a80d8bf7ba4b1b5ffc984e7230a5b"
 dependencies = [
  "hashbrown 0.16.1",
- "portable-atomic 1.13.1",
+ "portable-atomic",
  "thiserror 2.0.18",
 ]
 
@@ -3830,12 +3842,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4297,12 +4303,6 @@ name = "port_scanner"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "325a6d2ac5dee293c3b2612d4993b98aec1dff096b0a2dae70ed7d95784a05da"
-
-[[package]]
-name = "portable-atomic"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
 
 [[package]]
 name = "portable-atomic"
@@ -6941,7 +6941,7 @@ dependencies = [
 name = "turbo-updater"
 version = "0.1.0"
 dependencies = [
- "console",
+ "console 0.16.2",
  "reqwest",
  "semver 1.0.23",
  "serde",
@@ -7419,7 +7419,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
- "console",
+ "console 0.16.2",
  "convert_case 0.6.0",
  "ctrlc",
  "dialoguer",
@@ -7632,7 +7632,7 @@ dependencies = [
 name = "turborepo-process"
 version = "0.1.0"
 dependencies = [
- "console",
+ "console 0.16.2",
  "futures",
  "itertools 0.10.5",
  "libc",
@@ -7838,7 +7838,7 @@ name = "turborepo-task-executor"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "console",
+ "console 0.16.2",
  "convert_case 0.6.0",
  "either",
  "futures",
@@ -7995,7 +7995,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "clipboard-win",
- "console",
+ "console 0.16.2",
  "crossterm 0.29.0",
  "dialoguer",
  "futures",
@@ -8215,6 +8215,12 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -8488,6 +8494,16 @@ name = "web-sys"
 version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,18 +112,18 @@ camino = { version = "1.1.4", features = ["serde1"] }
 chrono = "0.4.23"
 clap = "4.5.16"
 clap_complete = "4.5.24"
-console = "0.15.5"
+console = "0.16.0"
 crossbeam-channel = "0.5.15"
 dashmap = "5.4.0"
 derive_setters = "0.1.6"
-dialoguer = "0.11.0"
+dialoguer = "0.12.0"
 dunce = "1.0.3"
 either = "1.9.0"
 futures = "0.3.30"
 git2 = { version = "0.20.0", default-features = false }
 hex = "0.4.3"
 httpmock = { version = "0.8.0", default-features = false }
-indicatif = "0.17.3"
+indicatif = "0.18.3"
 indoc = "2.0.0"
 insta = { version = "1.34.0", features = ["json"] }
 itertools = "0.10.5"

--- a/crates/turborepo-lib/src/commands/login/manual.rs
+++ b/crates/turborepo-lib/src/commands/login/manual.rs
@@ -98,7 +98,7 @@ impl ManualLoginOptions<'_> {
                 // figure out
                 let ask_for_team_id = dialoguer::Select::new()
                     .with_prompt("How do you want to specify your team?")
-                    .items(&["id", "slug"])
+                    .items(["id", "slug"])
                     .default(0)
                     .interact()?
                     == 0;


### PR DESCRIPTION
## Summary
- Upgrades `indicatif` from 0.17.3 to 0.18.3, fully dropping the unmaintained `number_prefix` crate (RUSTSEC-2025-0119)
- Upgrades `console` from 0.15.5 to 0.16.0 (required by indicatif 0.18.x)
- Upgrades `dialoguer` from 0.11.0 to 0.12.0 (required to align on console 0.16.x — dialoguer 0.11 used console 0.15, causing type mismatches)

No source code changes were needed — the indicatif, console, and dialoguer APIs we use are compatible across these versions.

CLOSES TURBO-5225