### PR TITLE
fix: Upgrade git2 to fix RUSTSEC-2026-0008

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2318,9 +2318,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git2"
-version = "0.20.0"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fda788993cc341f69012feba8bf45c0ba4f3291fcc08e214b4d5a7332d88aff"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
@@ -3192,9 +3192,9 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.0+1.9.0"
+version = "0.18.3+1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1a117465e7e1597e8febea8bb0c410f1c7fb93b1e1cddf34363f8390367ffec"
+checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ dialoguer = "0.11.0"
 dunce = "1.0.3"
 either = "1.9.0"
 futures = "0.3.30"
-git2 = { version = "0.20.0", default-features = false }
+git2 = { version = "0.20.4", default-features = false }
 hex = "0.4.3"
 httpmock = { version = "0.8.0", default-features = false }
 indicatif = "0.17.3"


### PR DESCRIPTION
## Summary
- Upgrades `git2` from 0.20.0 to 0.20.4 to fix RUSTSEC-2026-0008 (potential undefined behavior when dereferencing Buf struct)
- No source code changes needed — the upgrade is API-compatible

Resolves TURBO-5249