### PR TITLE
fix: Upgrade pest/pest_derive to resolve yanked version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4070,20 +4070,19 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.7.11"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
- "thiserror 1.0.63",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.7.9"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73541b156d32197eecda1a4014d7f868fd2bcb3c550d5386087cfba442bf69c"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
 dependencies = [
  "pest",
  "pest_generator",
@@ -4091,9 +4090,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.9"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35eeed0a3fab112f75165fdc026b3913f4183133f19b49be773ac9ea966e8bd"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
 dependencies = [
  "pest",
  "pest_meta",
@@ -4104,11 +4103,10 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.9"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adbf29bb9776f28caece835398781ab24435585fe0d4dc1374a61db5accedca"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
- "once_cell",
  "pest",
  "sha2",
 ]

--- a/crates/turborepo-lockfiles/Cargo.toml
+++ b/crates/turborepo-lockfiles/Cargo.toml
@@ -15,8 +15,8 @@ biome_json_formatter = { workspace = true }
 biome_json_parser = { workspace = true }
 itertools = { workspace = true }
 nom = "7"
-pest = "2.7.9"
-pest_derive = "2.7.9"
+pest = "2.8.6"
+pest_derive = "2.8.6"
 rayon = "1"
 regex = "1"
 semver = "1.0.17"


### PR DESCRIPTION
## Summary
- Upgrades `pest` and `pest_derive` from 2.7.9 (yanked) to 2.8.6
- No source code changes needed — the grammar file and parser code are compatible

Resolves TURBO-5254