### PR TITLE
fix: Upgrade futures/futures-util to resolve yanked futures-util 0.3.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2247,9 +2247,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2262,9 +2262,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2272,15 +2272,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2289,9 +2289,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -2305,9 +2305,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2316,15 +2316,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-timer"
@@ -2334,9 +2334,9 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ derive_setters = "0.1.6"
 dialoguer = "0.12.0"
 dunce = "1.0.3"
 either = "1.9.0"
-futures = "0.3.30"
+futures = "0.3.31"
 git2 = { version = "0.20.4", default-features = false }
 hex = "0.4.3"
 httpmock = { version = "0.8.0", default-features = false }

--- a/crates/turborepo-filewatch/Cargo.toml
+++ b/crates/turborepo-filewatch/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-futures = { version = "0.3.26" }
+futures = { workspace = true }
 notify = { workspace = true }
 radix_trie = { workspace = true }
 thiserror = "1.0.38"

--- a/crates/turborepo-globwatch/Cargo.toml
+++ b/crates/turborepo-globwatch/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 workspace = true
 
 [dependencies]
-futures = { version = "0.3.26" }
+futures = { workspace = true }
 itertools.workspace = true
 merge-streams = "0.1.2"
 notify = { workspace = true }

--- a/crates/turborepo-graph-utils/Cargo.toml
+++ b/crates/turborepo-graph-utils/Cargo.toml
@@ -9,7 +9,7 @@ workspace = true
 
 [dependencies]
 fixedbitset = "0.4.2"
-futures = "0.3.26"
+futures = { workspace = true }
 itertools = { workspace = true }
 petgraph = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/turborepo-microfrontends-proxy/Cargo.toml
+++ b/crates/turborepo-microfrontends-proxy/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 
 [dependencies]
 dashmap = "6.1"
-futures-util = "0.3"
+futures-util = "0.3.31"
 http-body-util = "0.1"
 hyper = { version = "1.0", features = ["full"] }
 hyper-rustls = { workspace = true, features = [

--- a/crates/turborepo-vercel-api-mock/Cargo.toml
+++ b/crates/turborepo-vercel-api-mock/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 axum = { workspace = true }
-futures-util = "0.3.28"
+futures-util = "0.3.31"
 port_scanner = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }


### PR DESCRIPTION
## Summary
- Upgrades `futures` from 0.3.30 to 0.3.31, resolving the yanked `futures-util` 0.3.30
- Normalizes 3 crates (turborepo-filewatch, turborepo-graph-utils, turborepo-globwatch) from local `"0.3.26"` to `workspace = true`
- Updates 2 direct `futures-util` declarations to 0.3.31

Resolves TURBO-5255