### PR TITLE
fix: Replace unic-segment with unicode-segmentation in globwatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2379,7 +2379,7 @@ dependencies = [
  "tracing-subscriber",
  "tracing-test",
  "turbopath",
- "unic-segment",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -8064,56 +8064,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unic-char-property"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221"
-dependencies = [
- "unic-char-range",
-]
-
-[[package]]
-name = "unic-char-range"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc"
-
-[[package]]
-name = "unic-common"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc"
-
-[[package]]
-name = "unic-segment"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ed5d26be57f84f176157270c112ef57b86debac9cd21daaabbe56db0f88f23"
-dependencies = [
- "unic-ucd-segment",
-]
-
-[[package]]
-name = "unic-ucd-segment"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2079c122a62205b421f499da10f3ee0f7697f012f55b675e002483c73ea34700"
-dependencies = [
- "unic-char-property",
- "unic-char-range",
- "unic-ucd-version",
-]
-
-[[package]]
-name = "unic-ucd-version"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
-dependencies = [
- "unic-common",
-]
-
-[[package]]
 name = "unicode-bom"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8139,9 +8089,9 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-truncate"

--- a/crates/turborepo-globwatch/Cargo.toml
+++ b/crates/turborepo-globwatch/Cargo.toml
@@ -19,7 +19,7 @@ tokio = { version = "1.25.0", features = ["sync"] }
 tokio-stream = "0.1.12"
 tracing = "0.1.37"
 turbopath = { workspace = true }
-unic-segment = "0.9.0"
+unicode-segmentation = "1.12.0"
 
 [dev-dependencies]
 test-case = "3.0.0"

--- a/crates/turborepo-globwatch/src/lib.rs
+++ b/crates/turborepo-globwatch/src/lib.rs
@@ -520,7 +520,7 @@ fn symbols_to_combinations<'a, T: Iterator<Item = GlobSymbol<'a>>>(
 fn glob_to_symbols(glob: &str) -> impl Iterator<Item = GlobSymbol<'_>> {
     let glob_bytes = glob.as_bytes();
     let mut escaped = false;
-    let mut cursor = unic_segment::GraphemeCursor::new(0, glob.len());
+    let mut cursor = unicode_segmentation::GraphemeCursor::new(0, glob.len(), true);
 
     std::iter::from_fn(move || {
         loop {


### PR DESCRIPTION
## Summary
- Replaces unmaintained `unic-segment` 0.9.0 with `unicode-segmentation` 1.12.0 in globwatch
- This eliminates 6 RUSTSEC advisories (the entire unic-* family: RUSTSEC-2025-0074, 0075, 0080, 0081, 0098, 0104)
- Adapted `GraphemeCursor::new()` call to include the required `true` parameter for extended grapheme cluster mode

Resolves TURBO-5256