### PR TITLE
release(turborepo): 2.8.3-canary.12

### DIFF
--- a/packages/create-turbo/package.json
+++ b/packages/create-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-turbo",
-  "version": "2.8.3-canary.11",
+  "version": "2.8.3-canary.12",
   "description": "Create a new Turborepo",
   "homepage": "https://turborepo.dev",
   "license": "MIT",

--- a/packages/eslint-config-turbo/package.json
+++ b/packages/eslint-config-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-turbo",
-  "version": "2.8.3-canary.11",
+  "version": "2.8.3-canary.12",
   "type": "commonjs",
   "description": "ESLint config for Turborepo",
   "license": "MIT",

--- a/packages/eslint-plugin-turbo/package.json
+++ b/packages/eslint-plugin-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-turbo",
-  "version": "2.8.3-canary.11",
+  "version": "2.8.3-canary.12",
   "description": "ESLint plugin for Turborepo",
   "keywords": [
     "turbo",

--- a/packages/turbo-codemod/package.json
+++ b/packages/turbo-codemod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/codemod",
-  "version": "2.8.3-canary.11",
+  "version": "2.8.3-canary.12",
   "description": "Provides Codemod transformations to help upgrade your Turborepo codebase when a feature is deprecated.",
   "homepage": "https://turborepo.dev",
   "license": "MIT",

--- a/packages/turbo-gen/package.json
+++ b/packages/turbo-gen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/gen",
-  "version": "2.8.3-canary.11",
+  "version": "2.8.3-canary.12",
   "description": "Extend a Turborepo",
   "type": "commonjs",
   "homepage": "https://turborepo.dev",

--- a/packages/turbo-ignore/package.json
+++ b/packages/turbo-ignore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-ignore",
-  "version": "2.8.3-canary.11",
+  "version": "2.8.3-canary.12",
   "description": "",
   "homepage": "https://turborepo.dev",
   "keywords": [],

--- a/packages/turbo-types/package.json
+++ b/packages/turbo-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/types",
-  "version": "2.8.3-canary.11",
+  "version": "2.8.3-canary.12",
   "description": "Turborepo types",
   "type": "commonjs",
   "homepage": "https://turborepo.dev",

--- a/packages/turbo-workspaces/package.json
+++ b/packages/turbo-workspaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/workspaces",
-  "version": "2.8.3-canary.11",
+  "version": "2.8.3-canary.12",
   "description": "Tools for working with package managers",
   "homepage": "https://turborepo.dev",
   "license": "MIT",

--- a/packages/turbo/package.json
+++ b/packages/turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo",
-  "version": "2.8.3-canary.11",
+  "version": "2.8.3-canary.12",
   "description": "Turborepo is a high-performance build system for JavaScript and TypeScript codebases.",
   "repository": "https://github.com/vercel/turborepo",
   "bugs": "https://github.com/vercel/turborepo/issues",
@@ -18,11 +18,11 @@
     "schema.json"
   ],
   "optionalDependencies": {
-    "turbo-darwin-64": "2.8.3-canary.11",
-    "turbo-darwin-arm64": "2.8.3-canary.11",
-    "turbo-linux-64": "2.8.3-canary.11",
-    "turbo-linux-arm64": "2.8.3-canary.11",
-    "turbo-windows-64": "2.8.3-canary.11",
-    "turbo-windows-arm64": "2.8.3-canary.11"
+    "turbo-darwin-64": "2.8.3-canary.12",
+    "turbo-darwin-arm64": "2.8.3-canary.12",
+    "turbo-linux-64": "2.8.3-canary.12",
+    "turbo-linux-arm64": "2.8.3-canary.12",
+    "turbo-windows-64": "2.8.3-canary.12",
+    "turbo-windows-arm64": "2.8.3-canary.12"
   }
 }

--- a/skills/turborepo/SKILL.md
+++ b/skills/turborepo/SKILL.md
@@ -9,7 +9,7 @@ description: |
   monorepo, shares code between apps, runs changed/affected packages, debugs cache,
   or has apps/packages directories.
 metadata:
-  version: 2.8.3-canary.11
+  version: 2.8.3-canary.12
 ---
 
 # Turborepo Skill

--- a/version.txt
+++ b/version.txt
@@ -1,2 +1,2 @@
-2.8.3-canary.11
+2.8.3-canary.12
 canary


### PR DESCRIPTION
## Release v2.8.3-canary.12

### Changes

- fix: Upgrade futures/futures-util to resolve yanked futures-util 0.3.30 (#11735) (`9c2c84ac84`)
- fix: Upgrade oxc_resolver to resolve yanked papaya dependency (#11733) (`250e8a45b3`)
- fix: Upgrade portable-pty to resolve RUSTSEC-2017-0008 (#11732) (`136a658917`)
- fix: Upgrade pprof to fix RUSTSEC-2024-0408 (#11730) (`c2937e7aa0`)
- fix: Upgrade git2 to fix RUSTSEC-2026-0008 (#11729) (`6422f1d0ba`)
- fix: Upgrade pest/pest_derive to resolve yanked version (#11734) (`9be27e67e1`)
- fix: Upgrade test-case to resolve transitive proc-macro-error (#11737) (`095b81969e`)
- fix: Upgrade rustls chain to resolve RUSTSEC-2025-0134 (#11739) (`3fa43fd818`)
- refactor: Centralize configuration resolution funnel (#11727) (`4021bb7758`)
- fix: Upgrade indicatif to 0.18.3 to drop unmaintained number_prefix (#11716) (`a7d8427ef8`)
- fix: Upgrade test-case and merge to drop unmaintained proc-macro-error (#11721) (`3b43995a2c`)
- fix: Migrate from unmaintained serde_yaml to serde_yml (#11720) (`9760bd2341`)
- fix: Upgrade async-io to 2.x to drop unmaintained instant crate (#11719) (`e588b670f8`)
- fix(docs): Fix code syntax highlighting by using correct Shiki CSS variable names (#11726) (`e5bbd0982e`)
- release(turborepo): 2.8.3-canary.11 (#11725) (`21b2777399`)