### PR TITLE
fix: Replace `serde_yml` with `serde_yaml_ng` to fix RUSTSEC-2025-0067/0068

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3305,16 +3305,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
-
-[[package]]
 name = "libz-sys"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5478,18 +5468,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yml"
-version = "0.0.12"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap 2.2.6",
  "itoa",
- "libyml",
- "memchr",
  "ryu",
  "serde",
- "version_check",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -7525,7 +7513,7 @@ dependencies = [
  "semver 1.0.23",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_yaml_ng",
  "serial_test",
  "sha2",
  "shared_child",
@@ -7616,7 +7604,7 @@ dependencies = [
  "semver 1.0.23",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_yaml_ng",
  "test-case",
  "thiserror 1.0.63",
  "tracing",
@@ -7739,7 +7727,7 @@ dependencies = [
  "rust-ini",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_yaml_ng",
  "tempfile",
  "test-case",
  "thiserror 1.0.63",
@@ -7878,7 +7866,7 @@ dependencies = [
  "pretty_assertions",
  "semver 1.0.23",
  "serde",
- "serde_yml",
+ "serde_yaml_ng",
  "shared_child",
  "tempfile",
  "test-case",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,7 @@ regex = "1.7.0"
 semver = "1.0.16"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.93"
-serde_yml = "0.0.12"
+serde_yaml_ng = "0.10.0"
 sha2 = "0.10.6"
 swc_common = "18.0.1"
 swc_ecma_ast = "20.0.0"

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -80,7 +80,7 @@ reqwest = { workspace = true, default-features = false, features = ["json"] }
 semver = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-serde_yml = { workspace = true }
+serde_yaml_ng = { workspace = true }
 sha2 = { workspace = true }
 shared_child = "1.0.0"
 swc_common = { workspace = true }

--- a/crates/turborepo-lockfiles/Cargo.toml
+++ b/crates/turborepo-lockfiles/Cargo.toml
@@ -22,7 +22,7 @@ regex = "1"
 semver = "1.0.17"
 serde = { version = "1.0.228", features = ["derive", "rc"] }
 serde_json = "1.0.86"
-serde_yml = { workspace = true }
+serde_yaml_ng = { workspace = true }
 thiserror = "1.0.38"
 tracing.workspace = true
 turbopath = { path = "../turborepo-paths" }

--- a/crates/turborepo-lockfiles/src/berry/mod.rs
+++ b/crates/turborepo-lockfiles/src/berry/mod.rs
@@ -25,7 +25,7 @@ use super::Lockfile;
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("Unable to parse yaml: {0}")]
-    Parse(#[from] serde_yml::Error),
+    Parse(#[from] serde_yaml_ng::Error),
     #[error("Unable to parse identifier: {0}")]
     Identifiers(#[from] identifiers::Error),
     #[error("Unable to find original package in patch locator {0}")]
@@ -580,7 +580,7 @@ impl Lockfile for BerryLockfile {
 
 impl LockfileData {
     pub fn from_bytes(s: &[u8]) -> Result<Self, Error> {
-        serde_yml::from_slice(s).map_err(Error::from)
+        serde_yaml_ng::from_slice(s).map_err(Error::from)
     }
 }
 
@@ -706,7 +706,7 @@ mod test {
     #[test]
     fn test_resolve_package() {
         let data: LockfileData =
-            serde_yml::from_str(include_str!("../../fixtures/berry.lock")).unwrap();
+            serde_yaml_ng::from_str(include_str!("../../fixtures/berry.lock")).unwrap();
         let lockfile = BerryLockfile::new(data, None).unwrap();
 
         assert_eq!(
@@ -747,7 +747,7 @@ mod test {
     #[test]
     fn test_all_dependencies() {
         let data: LockfileData =
-            serde_yml::from_str(include_str!("../../fixtures/berry.lock")).unwrap();
+            serde_yaml_ng::from_str(include_str!("../../fixtures/berry.lock")).unwrap();
         let lockfile = BerryLockfile::new(data, None).unwrap();
 
         let pkg = lockfile
@@ -770,7 +770,7 @@ mod test {
     #[test]
     fn test_package_extension_detection() {
         let data: LockfileData =
-            serde_yml::from_str(include_str!("../../fixtures/berry.lock")).unwrap();
+            serde_yaml_ng::from_str(include_str!("../../fixtures/berry.lock")).unwrap();
         let lockfile = BerryLockfile::new(data, None).unwrap();
 
         assert_eq!(
@@ -785,7 +785,7 @@ mod test {
     #[test]
     fn test_patch_list() {
         let data: LockfileData =
-            serde_yml::from_str(include_str!("../../fixtures/berry.lock")).unwrap();
+            serde_yaml_ng::from_str(include_str!("../../fixtures/berry.lock")).unwrap();
         let lockfile = BerryLockfile::new(data, None).unwrap();
 
         let locator = Locator::try_from("resolve@npm:2.0.0-next.4").unwrap();
@@ -816,7 +816,7 @@ mod test {
     #[test]
     fn test_basic_descriptor_prune() {
         let data: LockfileData =
-            serde_yml::from_str(include_str!("../../fixtures/minimal-berry.lock")).unwrap();
+            serde_yaml_ng::from_str(include_str!("../../fixtures/minimal-berry.lock")).unwrap();
         let lockfile = BerryLockfile::new(data, None).unwrap();
 
         let pruned_lockfile = lockfile
@@ -870,7 +870,7 @@ mod test {
 
     #[test]
     fn test_basic_resolutions_dependencies() {
-        let data: LockfileData = serde_yml::from_str(include_str!(
+        let data: LockfileData = serde_yaml_ng::from_str(include_str!(
             "../../fixtures/minimal-berry-resolutions.lock"
         ))
         .unwrap();
@@ -901,7 +901,7 @@ mod test {
 
     #[test]
     fn test_targeted_resolutions_dependencies() {
-        let data: LockfileData = serde_yml::from_str(include_str!(
+        let data: LockfileData = serde_yaml_ng::from_str(include_str!(
             "../../fixtures/minimal-berry-resolutions.lock"
         ))
         .unwrap();
@@ -989,7 +989,7 @@ mod test {
     #[test]
     fn test_nonexistent_resolutions_dependencies() {
         let data: LockfileData =
-            serde_yml::from_str(include_str!("../../fixtures/yarn4-resolution.lock")).unwrap();
+            serde_yaml_ng::from_str(include_str!("../../fixtures/yarn4-resolution.lock")).unwrap();
         let manifest = BerryManifest {
             resolutions: Some(
                 [("react@^18.2.0".to_string(), "18.1.0".to_string())]

--- a/crates/turborepo-lockfiles/src/error.rs
+++ b/crates/turborepo-lockfiles/src/error.rs
@@ -13,7 +13,7 @@ pub enum Error {
     #[error("Unable to convert from json: {0}")]
     BiomeJsonError(String),
     #[error("Unable to convert to yaml: {0}")]
-    Yaml(#[from] serde_yml::Error),
+    Yaml(#[from] serde_yaml_ng::Error),
     #[error("Turborepo doesn't support npm lockfiles without a 'packages' field")]
     UnsupportedNpmVersion,
     #[error("Unsupported bun lockfile version: {0}")]

--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -117,7 +117,7 @@ pub struct PackageSnapshot {
     patched: Option<bool>,
 
     #[serde(flatten)]
-    other: Map<String, serde_yml::Value>,
+    other: Map<String, serde_yaml_ng::Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
@@ -180,7 +180,7 @@ struct LockfileSettings {
 
 impl PnpmLockfile {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, crate::Error> {
-        let this = serde_yml::from_slice(bytes)?;
+        let this = serde_yaml_ng::from_slice(bytes)?;
         Ok(this)
     }
 
@@ -510,7 +510,7 @@ impl crate::Lockfile for PnpmLockfile {
     }
 
     fn encode(&self) -> Result<Vec<u8>, crate::Error> {
-        Ok(serde_yml::to_string(&self)?.into_bytes())
+        Ok(serde_yaml_ng::to_string(&self)?.into_bytes())
     }
 
     fn patches(&self) -> Result<Vec<RelativeUnixPathBuf>, crate::Error> {
@@ -676,9 +676,9 @@ mod tests {
     #[test_case(PNPM10_PATCH)]
     fn test_roundtrip(fixture: &[u8]) {
         let lockfile = PnpmLockfile::from_bytes(fixture).unwrap();
-        let serialized_lockfile = serde_yml::to_string(&lockfile).unwrap();
+        let serialized_lockfile = serde_yaml_ng::to_string(&lockfile).unwrap();
         let lockfile_from_serialized =
-            serde_yml::from_slice(serialized_lockfile.as_bytes()).unwrap();
+            serde_yaml_ng::from_slice(serialized_lockfile.as_bytes()).unwrap();
         assert_eq!(lockfile, lockfile_from_serialized);
     }
 
@@ -1107,12 +1107,12 @@ c:
   dev: false
 ";
         let original_parsed: Map<String, PackageSnapshot> =
-            serde_yml::from_str(original_contents).unwrap();
-        let contents = serde_yml::to_string(&original_parsed).unwrap();
+            serde_yaml_ng::from_str(original_contents).unwrap();
+        let contents = serde_yaml_ng::to_string(&original_parsed).unwrap();
 
         // serde_yml quotes strings like "0.0.0" that could be ambiguous,
         // so we verify the round-trip by re-parsing instead of comparing raw strings
-        let reparsed: Map<String, PackageSnapshot> = serde_yml::from_str(&contents).unwrap();
+        let reparsed: Map<String, PackageSnapshot> = serde_yaml_ng::from_str(&contents).unwrap();
         assert_eq!(original_parsed, reparsed);
     }
 

--- a/crates/turborepo-repository/Cargo.toml
+++ b/crates/turborepo-repository/Cargo.toml
@@ -27,7 +27,7 @@ regex = { workspace = true }
 rust-ini = "0.20.0"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-serde_yml = { workspace = true }
+serde_yaml_ng = { workspace = true }
 thiserror = "1.0.38"
 tokio-stream = "0.1.14"
 tokio.workspace = true

--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -134,7 +134,10 @@ pub enum Error {
     #[error(transparent)]
     Workspace(#[from] MissingWorkspaceError),
     #[error("YAML parsing error: {0}")]
-    ParsingYaml(#[from] serde_yml::Error, #[backtrace] backtrace::Backtrace),
+    ParsingYaml(
+        #[from] serde_yaml_ng::Error,
+        #[backtrace] backtrace::Backtrace,
+    ),
     #[error("JSON parsing error: {0}")]
     ParsingJson(#[from] serde_json::Error, #[backtrace] backtrace::Backtrace),
     #[error("Globbing error: {0}")]

--- a/crates/turborepo-repository/src/package_manager/pnpm.rs
+++ b/crates/turborepo-repository/src/package_manager/pnpm.rs
@@ -155,7 +155,7 @@ impl PnpmWorkspace {
     pub fn from_file(repo_root: &AbsoluteSystemPath) -> Result<Self, Error> {
         let workspace_yaml_path = repo_root.join_component(WORKSPACE_CONFIGURATION_PATH);
         let workspace_yaml = workspace_yaml_path.read_to_string()?;
-        Ok(serde_yml::from_str(&workspace_yaml)?)
+        Ok(serde_yaml_ng::from_str(&workspace_yaml)?)
     }
 
     fn link_workspace_packages(&self) -> Option<bool> {
@@ -303,7 +303,7 @@ mod test {
     #[test]
     fn test_workspace_parsing() {
         let config: PnpmWorkspace =
-            serde_yml::from_str("linkWorkspacePackages: true\npackages:\n  - \"apps/*\"\n")
+            serde_yaml_ng::from_str("linkWorkspacePackages: true\npackages:\n  - \"apps/*\"\n")
                 .unwrap();
         assert_eq!(config.link_workspace_packages(), Some(true));
         assert_eq!(config.packages, vec!["apps/*".to_string()]);

--- a/crates/turborepo-repository/src/package_manager/yarnrc.rs
+++ b/crates/turborepo-repository/src/package_manager/yarnrc.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 use serde::Deserialize;
-use serde_yml;
+use serde_yaml_ng;
 use turbopath::AbsoluteSystemPath;
 
 pub const YARNRC_FILENAME: &str = ".yarnrc.yml";
@@ -11,7 +11,7 @@ pub enum Error {
     #[error("Encountered error opening yarnrc.yml: {0}")]
     Io(#[from] std::io::Error),
     #[error("Encountered error parsing yarnrc.yml: {0}")]
-    SerdeYaml(#[from] serde_yml::Error),
+    SerdeYaml(#[from] serde_yaml_ng::Error),
 }
 
 type Map<K, V> = std::collections::BTreeMap<K, V>;
@@ -50,7 +50,7 @@ impl Default for YarnRc {
 
 impl YarnRc {
     pub fn from_reader(mut reader: impl io::Read) -> Result<Self, Error> {
-        let config: YarnRc = serde_yml::from_reader(&mut reader)?;
+        let config: YarnRc = serde_yaml_ng::from_reader(&mut reader)?;
         Ok(config)
     }
 

--- a/crates/turborepo-shim/Cargo.toml
+++ b/crates/turborepo-shim/Cargo.toml
@@ -28,7 +28,7 @@ tracing = { workspace = true }
 # Serialization/Parsing
 semver = { workspace = true }
 serde = { workspace = true }
-serde_yml = { workspace = true }
+serde_yaml_ng = { workspace = true }
 
 # Path utilities
 camino = { workspace = true }

--- a/crates/turborepo-shim/src/local_turbo_state.rs
+++ b/crates/turborepo-shim/src/local_turbo_state.rs
@@ -104,7 +104,7 @@ impl LocalTurboState {
         let yarn_rc_filepath = root_path.as_path().join(yarn_rc_filename);
 
         let yarn_rc_yaml_string = fs::read_to_string(yarn_rc_filepath).unwrap_or_default();
-        let yarn_rc: YarnRc = serde_yml::from_str(&yarn_rc_yaml_string).unwrap_or_default();
+        let yarn_rc: YarnRc = serde_yaml_ng::from_str(&yarn_rc_yaml_string).unwrap_or_default();
 
         root_path.as_path().join(yarn_rc.pnp_unplugged_folder)
     }


### PR DESCRIPTION
## Summary

- Replaces the `serde_yml` (0.0.12) dependency with `serde_yaml_ng` (0.10.0) across the workspace
- Removes transitive dependency on `libyml` (0.0.5), which is flagged as unsound

## Why

`serde_yml` and its transitive dependency `libyml` are flagged by two RustSec advisories:
- **RUSTSEC-2025-0067**: `serde_yml` is unmaintained
- **RUSTSEC-2025-0068**: `libyml` contains unsound code

`serde_yaml_ng` is the maintained fork (by the original `serde_yaml` author's community) and provides an API-compatible replacement. It uses `unsafe-libyaml` instead of the unsound `libyml`.

## What changed

Workspace `Cargo.toml` and four crate `Cargo.toml` files (`turborepo-shim`, `turborepo-repository`, `turborepo-lockfiles`, `turborepo-lib`) updated to depend on `serde_yaml_ng` instead of `serde_yml`. Seven Rust source files updated to use `serde_yaml_ng::` paths. The API surface (`from_str`, `from_slice`, `from_reader`, `to_string`, `Value`, `Error`) is identical.

## Testing

- `cargo check` passes for all four affected crates
- `cargo test -p turborepo-lockfiles` — all 303 tests pass
- `cargo audit` confirms RUSTSEC-2025-0067 and RUSTSEC-2025-0068 are resolved

Resolves TURBO-5263