### PR TITLE
fix: Auto-bump to next canary after stable releases

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -511,6 +511,30 @@ jobs:
           ref: ${{ needs.stage.outputs.stage-branch }}
           fetch-depth: 0
 
+      - uses: ./.github/actions/setup-node
+        with:
+          enable-corepack: false
+
+      - name: Configure git
+        run: |
+          git config --global user.name 'Turbobot'
+          git config --global user.email 'turbobot@vercel.com'
+
+      - name: Bump to next canary for stable releases
+        run: |
+          TAG=$(sed -n '2p' version.txt)
+
+          if [ "$TAG" = "latest" ]; then
+            VERSION="${{ needs.stage.outputs.version }}"
+            echo "Stable release detected (${VERSION}). Bumping to next prepatch canary..."
+            ./scripts/version.js prepatch
+            cat version.txt
+            git commit -anm "bump to next canary after ${VERSION}"
+            git push origin "${{ needs.stage.outputs.stage-branch }}"
+          else
+            echo "Pre-release ($TAG), skipping canary bump."
+          fi
+
       - name: Fetch main and tags
         run: git fetch origin main --tags
 


### PR DESCRIPTION
## Summary

- After a stable release (major/minor/patch), the release PR now automatically bumps `version.txt` to the next prepatch canary before merging to main.
- This prevents the hourly cron from continuing to produce canaries for the already-released version (e.g. `2.8.3-canary.5` after `2.8.3` was already shipped).

## How it works

The `create-release-pr` job reads the tag from line 2 of `version.txt`. If it's `latest` (stable release), it runs `./scripts/version.js prepatch` and commits the result to the staging branch before creating the PR. When the PR squash-merges to main, `version.txt` lands with the next canary baseline (e.g. `2.8.4-canary.0`), and the hourly cron correctly produces `2.8.4-canary.1` on its next run.

For canary releases, the step is a no-op.

## Context

After `2.8.3` shipped, nobody manually ran `prepatch` to start the `2.8.4` canary cycle. The cron kept producing `2.8.3-canary.X` releases instead of `2.8.4-canary.X`.