### PR TITLE
fix: Upgrade semver to fix ReDoS vulnerability

### DIFF
--- a/packages/turbo-codemod/package.json
+++ b/packages/turbo-codemod/package.json
@@ -31,7 +31,7 @@
     "is-git-clean": "1.1.0",
     "ora": "4.1.1",
     "picocolors": "1.0.1",
-    "semver": "7.5.0",
+    "semver": "7.5.2",
     "update-check": "1.5.4"
   },
   "devDependencies": {
@@ -51,7 +51,7 @@
     "deepmerge": "4.2.2",
     "jest": "30.2.0",
     "plop": "3.1.1",
-    "semver": "7.5.0",
+    "semver": "7.5.2",
     "ts-jest": "29.4.6",
     "tsdown": "0.9.3",
     "typescript": "5.5.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -508,8 +508,8 @@ importers:
         specifier: 1.0.1
         version: 1.0.1
       semver:
-        specifier: 7.5.0
-        version: 7.5.0
+        specifier: 7.5.2
+        version: 7.5.2
       update-check:
         specifier: 1.5.4
         version: 1.5.4
@@ -8031,11 +8031,6 @@ packages:
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
-
-  semver@7.5.0:
-    resolution: {integrity: sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==}
-    engines: {node: '>=10'}
     hasBin: true
 
   semver@7.5.2:
@@ -16728,10 +16723,6 @@ snapshots:
       kind-of: 6.0.3
 
   semver@6.3.1: {}
-
-  semver@7.5.0:
-    dependencies:
-      lru-cache: 6.0.0
 
   semver@7.5.2:
     dependencies:


### PR DESCRIPTION
## Summary

Upgrades `semver` from 7.5.0 to 7.5.2 in `packages/turbo-codemod` (both `dependencies` and `devDependencies`) to resolve [GHSA-c2qf-rxjj-qqgw](https://github.com/advisories/GHSA-c2qf-rxjj-qqgw), a Regular Expression Denial of Service (ReDoS) vulnerability affecting semver >=7.0.0 <7.5.2.

Ref: TURBO-5266

## Testing

- `pnpm build --filter=@turbo/codemod` passes
- All 217 tests pass across 19 test suites