### PR TITLE
fix: Upgrade tsdown to fix valibot and diff vulnerabilities

### DIFF
--- a/packages/eslint-plugin-turbo/package.json
+++ b/packages/eslint-plugin-turbo/package.json
@@ -45,7 +45,7 @@
     "jest": "30.2.0",
     "json5": "2.2.3",
     "ts-jest": "29.4.6",
-    "tsdown": "0.9.3",
+    "tsdown": "0.12.0",
     "typescript": "5.5.4"
   },
   "peerDependencies": {

--- a/packages/turbo-codemod/package.json
+++ b/packages/turbo-codemod/package.json
@@ -53,7 +53,7 @@
     "plop": "3.1.1",
     "semver": "7.5.2",
     "ts-jest": "29.4.6",
-    "tsdown": "0.9.3",
+    "tsdown": "0.12.0",
     "typescript": "5.5.4"
   },
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,8 +456,8 @@ importers:
         specifier: 29.4.6
         version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.29.0))(jest-util@30.2.0)(jest@30.2.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(typescript@5.5.4)))(typescript@5.5.4)
       tsdown:
-        specifier: 0.9.3
-        version: 0.9.3(typescript@5.5.4)
+        specifier: 0.12.0
+        version: 0.12.0(typescript@5.5.4)
       typescript:
         specifier: 5.5.4
         version: 5.5.4
@@ -566,8 +566,8 @@ importers:
         specifier: 29.4.6
         version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.29.0))(jest-util@30.2.0)(jest@30.2.0(@types/node@18.17.4)(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@18.17.4)(typescript@5.5.4)))(typescript@5.5.4)
       tsdown:
-        specifier: 0.9.3
-        version: 0.9.3(typescript@5.5.4)
+        specifier: 0.12.0
+        version: 0.12.0(typescript@5.5.4)
       typescript:
         specifier: 5.5.4
         version: 5.5.4


### PR DESCRIPTION
## Summary

- Upgrades `tsdown` from 0.9.3 to 0.12.0 in `eslint-plugin-turbo` and `@turbo/codemod`
- Resolves GHSA-vqpr-j7v3-hqw9 (valibot ReDoS via rolldown's dependency on valibot@1.0.0, fixed in >=1.2.0)
- Resolves GHSA-73rr-hh4g-fpgx (diff DoS, fixed in >=8.0.3)

## Context

tsdown 0.9.3 pulls in rolldown which depends on vulnerable versions of `valibot` and `diff`. tsdown 0.12.0 uses rolldown@1.0.0-beta.9 which resolves these transitive vulnerabilities.

`create-turbo` already had tsdown 0.12.0 and is not changed in this PR.

Ref: TURBO-5265, TURBO-5269