### PR TITLE
fix: Override lodash-es to resolve prototype pollution vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "pnpm": {
     "overrides": {
-      "fast-xml-parser": ">=5.3.4"
+      "fast-xml-parser": ">=5.3.4",
+      "lodash-es": ">=4.17.23"
     }
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   fast-xml-parser: '>=5.3.4'
+  lodash-es: '>=4.17.23'
 
 importers:
 
@@ -151,7 +152,7 @@ importers:
         specifier: 0.18.12
         version: 0.18.12
       lodash-es:
-        specifier: 4.17.23
+        specifier: '>=4.17.23'
         version: 4.17.23
       lucide-react:
         specifier: ^0.555.0
@@ -6699,9 +6700,6 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
-  lodash-es@4.17.21:
-    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
-
   lodash-es@4.17.23:
     resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
 
@@ -9188,12 +9186,12 @@ snapshots:
     dependencies:
       '@chevrotain/gast': 11.0.3
       '@chevrotain/types': 11.0.3
-      lodash-es: 4.17.21
+      lodash-es: 4.17.23
 
   '@chevrotain/gast@11.0.3':
     dependencies:
       '@chevrotain/types': 11.0.3
-      lodash-es: 4.17.21
+      lodash-es: 4.17.23
 
   '@chevrotain/regexp-to-ast@11.0.3': {}
 
@@ -12491,7 +12489,7 @@ snapshots:
       '@chevrotain/regexp-to-ast': 11.0.3
       '@chevrotain/types': 11.0.3
       '@chevrotain/utils': 11.0.3
-      lodash-es: 4.17.21
+      lodash-es: 4.17.23
 
   chokidar@3.6.0:
     dependencies:
@@ -14830,8 +14828,6 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
-
-  lodash-es@4.17.21: {}
 
   lodash-es@4.17.23: {}
 


### PR DESCRIPTION
## Summary

- Add pnpm override for `lodash-es` to `>=4.17.23` to resolve a prototype pollution vulnerability (GHSA-xxjr-mmjv-4gpg, moderate severity)

## Why

`chevrotain@11.0.3`, a transitive dependency via `mermaid > @mermaid-js/parser > langium`, pulls in `lodash-es@4.17.21` which is vulnerable to prototype pollution. While `apps/docs` already has `lodash-es@4.17.23` as a direct dependency, the transitive copy through chevrotain remains at the vulnerable version without an override.

The latest chevrotain (11.1.1) ships with `lodash-es@4.17.23`, but upgrading it directly would require upstream changes in langium/mermaid. A pnpm override is the least invasive fix.

Verified: `pnpm install` succeeds and `pnpm build --filter=docs` builds cleanly.

Refs: TURBO-5267