### PR TITLE
chore: Add internal agents app for repo automation

### DIFF
--- a/apps/agents/app/api/github/route.ts
+++ b/apps/agents/app/api/github/route.ts
@@ -69,13 +69,6 @@ async function triageNewIssue(payload: GitHubIssuePayload) {
       }
     },
     {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: bodyPreview
-      }
-    },
-    {
       type: "context",
       elements: [
         {
@@ -97,7 +90,8 @@ async function triageNewIssue(payload: GitHubIssuePayload) {
         {
           type: "button",
           text: { type: "plain_text", text: "Dismiss" },
-          action_id: "repro_dismiss"
+          action_id: "repro_dismiss",
+          value: String(issue.number)
         }
       ]
     }

--- a/apps/agents/app/api/slack/actions/route.ts
+++ b/apps/agents/app/api/slack/actions/route.ts
@@ -40,7 +40,8 @@ export async function POST(request: Request) {
 
   const channel = payload.channel.id;
   const messageTs = payload.message.ts;
-  const user = payload.user.username;
+  const userId = payload.user.id;
+  const mention = `<@${userId}>`;
 
   switch (action.action_id) {
     // Issue triage: user approves posting a reproduction request comment
@@ -52,16 +53,20 @@ export async function POST(request: Request) {
       await updateMessage(
         channel,
         messageTs,
-        `:white_check_mark: @${user} posted reproduction request on #${issueNumber}`
+        `:white_check_mark: ${mention} posted reproduction request on <https://github.com/vercel/turborepo/issues/${issueNumber}|#${issueNumber}>`
       );
       break;
     }
 
     case "repro_dismiss": {
+      const issueNumber = parseInt(action.value ?? "0", 10);
+      const issueRef = issueNumber
+        ? ` for <https://github.com/vercel/turborepo/issues/${issueNumber}|#${issueNumber}>`
+        : "";
       await updateMessage(
         channel,
         messageTs,
-        `:heavy_minus_sign: @${user} dismissed — no reproduction request needed`
+        `:heavy_minus_sign: ${mention} dismissed${issueRef} — no reproduction request needed`
       );
       break;
     }
@@ -71,14 +76,14 @@ export async function POST(request: Request) {
       await updateMessage(
         channel,
         messageTs,
-        `:hourglass_flowing_sand: @${user} triggered the audit fix agent...`
+        `:hourglass_flowing_sand: ${mention} triggered the audit fix agent...`
       );
 
       const onProgress = async (message: string) => {
         await updateMessage(
           channel,
           messageTs,
-          `:hourglass_flowing_sand: @${user} — ${message}`
+          `:hourglass_flowing_sand: ${mention} — ${message}`
         );
       };
 
@@ -148,7 +153,7 @@ export async function POST(request: Request) {
             await updateMessage(
               channel,
               messageTs,
-              `:white_check_mark: @${user} — agent finished. Review posted above.`
+              `:white_check_mark: ${mention} — agent finished. Review posted above.`
             );
           })
           .catch(async (error: Error) => {
@@ -156,7 +161,7 @@ export async function POST(request: Request) {
             await updateMessage(
               channel,
               messageTs,
-              `:x: @${user} audit fix agent failed: ${error.message}`
+              `:x: ${mention} audit fix agent failed: ${error.message}`
             );
           })
       );
@@ -182,14 +187,14 @@ export async function POST(request: Request) {
         await updateMessage(
           channel,
           messageTs,
-          `:white_check_mark: @${user} opened <${pr.prUrl}|PR #${pr.prNumber}>`
+          `:white_check_mark: ${mention} opened <${pr.prUrl}|PR #${pr.prNumber}>`
         );
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         await updateMessage(
           channel,
           messageTs,
-          `:x: @${user} failed to open PR: ${msg}`
+          `:x: ${mention} failed to open PR: ${msg}`
         );
       }
       break;
@@ -199,7 +204,7 @@ export async function POST(request: Request) {
       await updateMessage(
         channel,
         messageTs,
-        `:heavy_minus_sign: @${user} dismissed the audit results`
+        `:heavy_minus_sign: ${mention} dismissed the audit results`
       );
       break;
     }


### PR DESCRIPTION
## Summary

- Adds `apps/agents`, a Next.js app deployed to Vercel that automates internal Turborepo maintenance via Slack
- Two workflows are implemented, both human-in-the-loop

## Issue triage (reproduction requests)

When a GitHub issue is opened, the AI (Sonnet 4.5 via AI Gateway) analyzes the issue body to determine if a reproduction was provided. If it suspects one is missing, it posts to Slack with the issue preview, the agent's reasoning, and approve/dismiss buttons. Approving posts a canned reproduction request comment on the issue.

## Security audit

A Vercel Cron runs `cargo audit` and `pnpm audit` weekly. If vulnerabilities are found, it posts to Slack with a "Fix vulnerabilities" button. Clicking it launches an Opus 4.6 coding agent inside a Vercel Sandbox VM (5 hour timeout) that:

1. Identifies vulnerabilities via audits
2. Updates dependency version constraints in manifest files (`Cargo.toml`, `package.json`)
3. Runs type checks and tests to verify nothing broke
4. Diagnoses and fixes source code if tests fail
5. Re-runs audits to confirm fixes
6. Pushes a branch and posts the diff back to Slack for review

You then approve or dismiss the PR from Slack. No PR is opened without explicit approval.

## Testing

To test the issue triage flow, open a test issue with no reproduction. To test the audit flow, manually trigger the cron endpoint. Setup details are in the `.env.example`.