### PR TITLE
fix: Emit space for empty vt100 cells to fix TUI repaint on task switch

### DIFF
--- a/crates/turborepo-vt100/src/tui_term.rs
+++ b/crates/turborepo-vt100/src/tui_term.rs
@@ -258,7 +258,7 @@ mod test {
             for col in 0..cols {
                 let cell = &buf[ratatui::layout::Position::new(col, row)];
                 let sym = cell.symbol();
-                let is_text = row == 0 && (col as usize) < 5;
+                let is_text = row == 0 && col < 5;
                 let is_cursor = row == 0 && col == cursor_col;
                 assert!(
                     sym == " " || is_text || is_cursor,


### PR DESCRIPTION
## Summary

Fixes #11779

The ratatui 0.30 upgrade (PR #11723) introduced a TUI rendering glitch where characters from a previous task's output "bleed through" when switching to a task with shorter output.

The `tui-term` upgrade from 0.1.9 to 0.3.1 changed `state::handle` to apply **all** vt100 screen cells to the ratatui buffer — including empty ones. Previously, empty cells were skipped. Our `fill_buf_cell` bridge function was calling `set_symbol("")` for these empty cells, producing a zero-width symbol that ratatui's diff algorithm correctly detects as "changed" but writes nothing to the terminal, leaving the previous frame's characters visible.

The fix writes `" "` (space) instead of `""` for empty cells, which properly overwrites stale content from the previous frame.

### To test

1. Use the reproduction at https://github.com/jeremybanka/turbo-tui-buffer-fails-to-clear-repro (or any monorepo with tasks producing different output lengths)
2. `turbo dev` (or `turbo run` with `--ui=tui`)
3. Arrow up/down between tasks — the pane should fully repaint with no leftover characters