### PR TITLE
fix: Handle subpath package imports in `turbo boundaries`

### DIFF
--- a/crates/turborepo-boundaries/src/imports.rs
+++ b/crates/turborepo-boundaries/src/imports.rs
@@ -270,7 +270,7 @@ pub(crate) fn check_file_import(
     }
 }
 
-fn get_package_name(import: &str) -> String {
+pub(crate) fn get_package_name(import: &str) -> String {
     if import.starts_with("@") {
         import.split('/').take(2).join("/")
     } else {
@@ -376,6 +376,9 @@ mod test {
     #[test_case("lodash" ; "bare package name lodash")]
     #[test_case("@scope/package" ; "scoped package name")]
     #[test_case("@types/node" ; "types package name")]
+    #[test_case("lodash/fp" ; "subpath import")]
+    #[test_case("@scope/package/sub" ; "scoped subpath import")]
+    #[test_case("@scope/package/deeply/nested" ; "scoped deeply nested subpath import")]
     fn tsconfig_alias_check_skips_bare_package_names(import: &str) {
         let (resolver, package_name, span, file_content, mut result) =
             make_tsconfig_alias_test_args(import);

--- a/crates/turborepo-boundaries/src/lib.rs
+++ b/crates/turborepo-boundaries/src/lib.rs
@@ -316,7 +316,8 @@ impl BoundariesChecker {
     }
 
     fn is_potential_package_name(import: &str) -> bool {
-        PACKAGE_NAME_REGEX.is_match(import)
+        let base = imports::get_package_name(import);
+        PACKAGE_NAME_REGEX.is_match(&base)
     }
 
     /// Patch a file with boundaries-ignore comments
@@ -790,6 +791,13 @@ mod tests {
             "@scope/package"
         ));
         assert!(BoundariesChecker::is_potential_package_name("my-package"));
+        assert!(BoundariesChecker::is_potential_package_name("lodash/fp"));
+        assert!(BoundariesChecker::is_potential_package_name(
+            "@scope/package/sub"
+        ));
+        assert!(BoundariesChecker::is_potential_package_name(
+            "@scope/package/deeply/nested"
+        ));
         assert!(!BoundariesChecker::is_potential_package_name("./relative"));
         assert!(!BoundariesChecker::is_potential_package_name("../parent"));
         assert!(!BoundariesChecker::is_potential_package_name("/absolute"));

--- a/crates/turborepo/tests/snapshots/boundaries__boundaries_get_boundaries_lints_(npm@10.5.0).snap
+++ b/crates/turborepo/tests/snapshots/boundaries__boundaries_get_boundaries_lints_(npm@10.5.0).snap
@@ -1,5 +1,6 @@
 ---
 source: crates/turborepo/tests/boundaries.rs
+assertion_line: 5
 expression: query_output
 ---
 {
@@ -11,12 +12,24 @@ expression: query_output
           "import": "@vercel/unsafe-package"
         },
         {
+          "message": "Package `another` found without any tag listed in allowlist for `my-app`",
+          "import": "another"
+        },
+        {
           "message": "Package `module-package` found without any tag listed in allowlist for `my-app`",
           "import": "module-package"
         },
         {
+          "message": "Package `utils` found without any tag listed in allowlist for `my-app`",
+          "import": "utils"
+        },
+        {
           "message": "cannot import package `module-package` because it is not a dependency",
           "import": "module-package"
+        },
+        {
+          "message": "cannot import package `utils` because it is not a dependency",
+          "import": "utils"
         },
         {
           "message": "import `!` leaves the package",

--- a/turborepo-tests/integration/fixtures/boundaries/apps/my-app/index.ts
+++ b/turborepo-tests/integration/fixtures/boundaries/apps/my-app/index.ts
@@ -25,3 +25,9 @@ import { walkThePlank } from "module-package";
 
 // Allow importing own package
 import { walkThePlank } from "my-app";
+
+// Subpath import from a declared dependency should be allowed
+import { anchor } from "another/helpers";
+
+// Subpath import from a package that is NOT a dependency should fail
+import { data } from "utils/data";

--- a/turborepo-tests/integration/fixtures/boundaries/apps/my-app/package.json
+++ b/turborepo-tests/integration/fixtures/boundaries/apps/my-app/package.json
@@ -6,6 +6,7 @@
   },
   "dependencies": {
     "@types/ship": "*",
-    "@vercel/unsafe-package": "*"
+    "@vercel/unsafe-package": "*",
+    "another": "*"
   }
 }

--- a/turborepo-tests/integration/fixtures/boundaries/packages/another/helpers.js
+++ b/turborepo-tests/integration/fixtures/boundaries/packages/another/helpers.js
@@ -1,0 +1,1 @@
+export const anchor = "dropped";

--- a/turborepo-tests/integration/fixtures/boundaries/packages/another/package.json
+++ b/turborepo-tests/integration/fixtures/boundaries/packages/another/package.json
@@ -1,5 +1,9 @@
 {
   "name": "another",
+  "exports": {
+    ".": "./index.jsx",
+    "./helpers": "./helpers.js"
+  },
   "scripts": {
     "dev": "echo building"
   },


### PR DESCRIPTION
## Summary

Fixes #11797

`turbo boundaries` incorrectly flagged subpath package imports (e.g. `import { x } from "pkg/test"` or `import { x } from "@scope/pkg/sub"`) as boundary violations since 2.8.4.

`is_potential_package_name` used a regex that only matched bare package names (`lodash`, `@scope/pkg`) — the `$` anchor rejected anything with additional path segments. This caused subpath imports to bypass the package-name guard in `check_import_as_tsconfig_path_alias`, where the full module resolver would resolve them to paths outside the importing package and emit false `ImportLeavesPackage` diagnostics.

The fix extracts the base package name (via the existing `get_package_name`) before checking against the regex, so `pkg-a/test` is recognized as a package import just like `pkg-a`.

## Test Plan

- Added integration test cases to the `boundaries` fixture: a subpath import from a declared dependency (should pass) and a subpath import from an undeclared dependency (should correctly report "not a dependency")
- Added unit test cases for `is_potential_package_name` and `tsconfig_alias_check_skips_bare_package_names` with subpath imports
- Verified against the exact reproduction repo from the issue