### PR TITLE
feat: Add dashboard with run tracking and live logs for agent sandboxes

### DIFF
--- a/apps/agents/app/actions.ts
+++ b/apps/agents/app/actions.ts
@@ -4,5 +4,5 @@ import { waitUntil } from "@vercel/functions";
 import { runAuditAndFix } from "@/lib/audit";
 
 export async function triggerAudit() {
-  waitUntil(runAuditAndFix());
+  waitUntil(runAuditAndFix("manual"));
 }

--- a/apps/agents/app/api/cron/audit/route.ts
+++ b/apps/agents/app/api/cron/audit/route.ts
@@ -10,6 +10,6 @@ export async function GET(request: Request) {
     return new Response("Unauthorized", { status: 401 });
   }
 
-  waitUntil(runAuditAndFix());
+  waitUntil(runAuditAndFix("cron"));
   return Response.json({ ok: true, message: "Audit started" });
 }

--- a/apps/agents/app/api/runs/[id]/logs/route.ts
+++ b/apps/agents/app/api/runs/[id]/logs/route.ts
@@ -1,0 +1,14 @@
+import { getLogs } from "@/lib/runs";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const logs = await getLogs(id);
+  return new Response(logs, {
+    headers: { "Content-Type": "text/plain" }
+  });
+}

--- a/apps/agents/app/api/runs/[id]/route.ts
+++ b/apps/agents/app/api/runs/[id]/route.ts
@@ -1,0 +1,15 @@
+import { getRun } from "@/lib/runs";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const run = await getRun(id);
+  if (!run) {
+    return Response.json({ error: "Run not found" }, { status: 404 });
+  }
+  return Response.json(run);
+}

--- a/apps/agents/app/api/runs/route.ts
+++ b/apps/agents/app/api/runs/route.ts
@@ -1,0 +1,8 @@
+import { listRuns } from "@/lib/runs";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const runs = await listRuns();
+  return Response.json(runs);
+}

--- a/apps/agents/app/dashboard/[id]/page.tsx
+++ b/apps/agents/app/dashboard/[id]/page.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+import { useEffect, useRef, useState, use } from "react";
+import Link from "next/link";
+import type { RunMeta } from "@/lib/runs";
+
+const STATUS_LABELS: Record<string, { label: string; color: string }> = {
+  queued: { label: "Queued", color: "text-neutral-400" },
+  scanning: { label: "Scanning", color: "text-blue-400" },
+  fixing: { label: "Fixing", color: "text-yellow-400" },
+  pushing: { label: "Pushing", color: "text-purple-400" },
+  completed: { label: "Completed", color: "text-green-400" },
+  failed: { label: "Failed", color: "text-red-400" }
+};
+
+function StatusBadge({ status }: { status: string }) {
+  const config = STATUS_LABELS[status] ?? {
+    label: status,
+    color: "text-neutral-400"
+  };
+  const isActive = ["queued", "scanning", "fixing", "pushing"].includes(status);
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 text-sm font-medium ${config.color}`}
+    >
+      {isActive && (
+        <span className="relative flex h-2 w-2">
+          <span
+            className={`absolute inline-flex h-full w-full animate-ping rounded-full opacity-75 ${config.color.replace("text-", "bg-")}`}
+          />
+          <span
+            className={`relative inline-flex h-2 w-2 rounded-full ${config.color.replace("text-", "bg-")}`}
+          />
+        </span>
+      )}
+      {!isActive && (
+        <span
+          className={`inline-flex h-2 w-2 rounded-full ${config.color.replace("text-", "bg-")}`}
+        />
+      )}
+      {config.label}
+    </span>
+  );
+}
+
+function duration(start: string, end: string): string {
+  const ms = new Date(end).getTime() - new Date(start).getTime();
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  if (minutes < 60) return `${minutes}m ${remainingSeconds}s`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return `${hours}h ${remainingMinutes}m`;
+}
+
+export default function RunDetailPage({
+  params
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = use(params);
+  const [run, setRun] = useState<RunMeta | null>(null);
+  const [logs, setLogs] = useState("");
+  const [autoScroll, setAutoScroll] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const logEndRef = useRef<HTMLDivElement>(null);
+  const logContainerRef = useRef<HTMLPreElement>(null);
+
+  const isActive = run
+    ? ["queued", "scanning", "fixing", "pushing"].includes(run.status)
+    : false;
+
+  // Fetch run metadata
+  useEffect(() => {
+    let active = true;
+
+    async function fetchRun() {
+      try {
+        const res = await fetch(`/api/runs/${id}`);
+        if (res.ok && active) {
+          setRun(await res.json());
+        }
+      } catch {
+        // Retry on next interval
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+
+    fetchRun();
+    const interval = setInterval(fetchRun, 3_000);
+    return () => {
+      active = false;
+      clearInterval(interval);
+    };
+  }, [id]);
+
+  // Fetch logs (polls while run is active)
+  useEffect(() => {
+    let active = true;
+
+    async function fetchLogs() {
+      try {
+        const res = await fetch(`/api/runs/${id}/logs`);
+        if (res.ok && active) {
+          setLogs(await res.text());
+        }
+      } catch {
+        // Retry on next interval
+      }
+    }
+
+    fetchLogs();
+    // Poll faster while active, slower when done
+    const interval = setInterval(fetchLogs, isActive ? 3_000 : 10_000);
+    return () => {
+      active = false;
+      clearInterval(interval);
+    };
+  }, [id, isActive]);
+
+  // Auto-scroll to bottom when new logs arrive
+  useEffect(() => {
+    if (autoScroll && logEndRef.current) {
+      logEndRef.current.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [logs, autoScroll]);
+
+  // Detect manual scroll to pause auto-scroll
+  function handleScroll() {
+    const container = logContainerRef.current;
+    if (!container) return;
+    const isAtBottom =
+      container.scrollHeight - container.scrollTop - container.clientHeight <
+      50;
+    setAutoScroll(isAtBottom);
+  }
+
+  if (loading) {
+    return (
+      <main className="mx-auto max-w-5xl px-6 py-16 font-mono">
+        <div className="py-12 text-center text-neutral-500">Loading...</div>
+      </main>
+    );
+  }
+
+  if (!run) {
+    return (
+      <main className="mx-auto max-w-5xl px-6 py-16 font-mono">
+        <div className="py-12 text-center text-neutral-500">Run not found.</div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-5xl px-6 py-16 font-mono">
+      <div className="mb-6 flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <Link
+            href="/dashboard"
+            className="text-sm text-neutral-500 hover:text-white"
+          >
+            &larr; Dashboard
+          </Link>
+          <StatusBadge status={run.status} />
+        </div>
+      </div>
+
+      <h1 className="mb-6 text-xl font-bold">{run.id}</h1>
+
+      {/* Metadata grid */}
+      <div className="mb-8 grid grid-cols-2 gap-4 rounded border border-neutral-800 p-4 text-sm md:grid-cols-4">
+        <div>
+          <p className="text-xs text-neutral-500">Trigger</p>
+          <p>{run.trigger === "cron" ? "Scheduled" : "Manual"}</p>
+        </div>
+        <div>
+          <p className="text-xs text-neutral-500">Started</p>
+          <p>{new Date(run.createdAt).toLocaleString()}</p>
+        </div>
+        <div>
+          <p className="text-xs text-neutral-500">Duration</p>
+          <p>
+            {run.status === "completed" || run.status === "failed"
+              ? duration(run.createdAt, run.updatedAt)
+              : duration(run.createdAt, new Date().toISOString())}
+            {isActive && "..."}
+          </p>
+        </div>
+        <div>
+          <p className="text-xs text-neutral-500">Sandbox</p>
+          <p className="truncate" title={run.sandboxId}>
+            {run.sandboxId ?? "--"}
+          </p>
+        </div>
+
+        {run.vulnerabilities && (
+          <>
+            <div>
+              <p className="text-xs text-neutral-500">Cargo vulns</p>
+              <p>{run.vulnerabilities.cargo}</p>
+            </div>
+            <div>
+              <p className="text-xs text-neutral-500">pnpm vulns</p>
+              <p>{run.vulnerabilities.pnpm}</p>
+            </div>
+          </>
+        )}
+
+        {run.agentResults && (
+          <>
+            <div>
+              <p className="text-xs text-neutral-500">Fixed</p>
+              <p className="text-green-400">
+                {run.agentResults.vulnerabilitiesFixed}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-neutral-500">Remaining</p>
+              <p
+                className={
+                  run.agentResults.vulnerabilitiesRemaining > 0
+                    ? "text-yellow-400"
+                    : "text-green-400"
+                }
+              >
+                {run.agentResults.vulnerabilitiesRemaining}
+              </p>
+            </div>
+          </>
+        )}
+
+        {run.branch && (
+          <div className="col-span-2">
+            <p className="text-xs text-neutral-500">Branch</p>
+            <p className="truncate" title={run.branch}>
+              {run.branch}
+            </p>
+          </div>
+        )}
+
+        {run.error && (
+          <div className="col-span-full">
+            <p className="text-xs text-neutral-500">Error</p>
+            <p className="text-red-400">{run.error}</p>
+          </div>
+        )}
+
+        {run.agentResults?.summary && (
+          <div className="col-span-full">
+            <p className="text-xs text-neutral-500">Summary</p>
+            <p>{run.agentResults.summary}</p>
+          </div>
+        )}
+      </div>
+
+      {/* Links */}
+      <div className="mb-6 flex gap-3">
+        {run.diffUrl && (
+          <>
+            <Link
+              href={`/vuln-diffs/view?url=${encodeURIComponent(run.diffUrl)}`}
+              className="rounded border border-neutral-800 px-3 py-1.5 text-xs hover:bg-neutral-800"
+            >
+              View diff
+            </Link>
+            <a
+              href={run.diffUrl}
+              download
+              className="rounded border border-neutral-800 px-3 py-1.5 text-xs hover:bg-neutral-800"
+            >
+              Download .patch
+            </a>
+          </>
+        )}
+      </div>
+
+      {/* Logs */}
+      <div className="mb-2 flex items-center justify-between">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-neutral-500">
+          Logs
+        </h2>
+        <div className="flex items-center gap-3 text-xs text-neutral-500">
+          {isActive && <span className="text-blue-400">Streaming...</span>}
+          <button
+            onClick={() => setAutoScroll(!autoScroll)}
+            className={`rounded px-2 py-1 ${autoScroll ? "bg-neutral-800 text-white" : "text-neutral-500 hover:text-white"}`}
+          >
+            Auto-scroll {autoScroll ? "on" : "off"}
+          </button>
+        </div>
+      </div>
+      <pre
+        ref={logContainerRef}
+        onScroll={handleScroll}
+        className="h-[500px] overflow-auto rounded border border-neutral-800 bg-neutral-950 p-4 text-xs leading-5 text-neutral-300"
+      >
+        {logs || (
+          <span className="text-neutral-600">
+            {isActive
+              ? "Waiting for logs..."
+              : "No logs recorded for this run."}
+          </span>
+        )}
+        <div ref={logEndRef} />
+      </pre>
+    </main>
+  );
+}

--- a/apps/agents/app/dashboard/page.tsx
+++ b/apps/agents/app/dashboard/page.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import type { RunMeta } from "@/lib/runs";
+
+const STATUS_LABELS: Record<string, { label: string; color: string }> = {
+  queued: { label: "Queued", color: "text-neutral-400" },
+  scanning: { label: "Scanning", color: "text-blue-400" },
+  fixing: { label: "Fixing", color: "text-yellow-400" },
+  pushing: { label: "Pushing", color: "text-purple-400" },
+  completed: { label: "Completed", color: "text-green-400" },
+  failed: { label: "Failed", color: "text-red-400" }
+};
+
+function StatusBadge({ status }: { status: string }) {
+  const config = STATUS_LABELS[status] ?? {
+    label: status,
+    color: "text-neutral-400"
+  };
+  const isActive = ["queued", "scanning", "fixing", "pushing"].includes(status);
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 text-xs font-medium ${config.color}`}
+    >
+      {isActive && (
+        <span className="relative flex h-2 w-2">
+          <span
+            className={`absolute inline-flex h-full w-full animate-ping rounded-full opacity-75 ${config.color.replace("text-", "bg-")}`}
+          />
+          <span
+            className={`relative inline-flex h-2 w-2 rounded-full ${config.color.replace("text-", "bg-")}`}
+          />
+        </span>
+      )}
+      {!isActive && (
+        <span
+          className={`inline-flex h-2 w-2 rounded-full ${config.color.replace("text-", "bg-")}`}
+        />
+      )}
+      {config.label}
+    </span>
+  );
+}
+
+function timeAgo(dateStr: string): string {
+  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function duration(start: string, end: string): string {
+  const ms = new Date(end).getTime() - new Date(start).getTime();
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  if (minutes < 60) return `${minutes}m ${remainingSeconds}s`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return `${hours}h ${remainingMinutes}m`;
+}
+
+export default function DashboardPage() {
+  const [runs, setRuns] = useState<RunMeta[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+
+    async function fetchRuns() {
+      try {
+        const res = await fetch("/api/runs");
+        if (res.ok && active) {
+          setRuns(await res.json());
+        }
+      } catch {
+        // Silently retry on next interval
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+
+    fetchRuns();
+    const interval = setInterval(fetchRuns, 5_000);
+    return () => {
+      active = false;
+      clearInterval(interval);
+    };
+  }, []);
+
+  const activeRuns = runs.filter((r) =>
+    ["queued", "scanning", "fixing", "pushing"].includes(r.status)
+  );
+  const pastRuns = runs.filter(
+    (r) => r.status === "completed" || r.status === "failed"
+  );
+
+  return (
+    <main className="mx-auto max-w-4xl px-6 py-16 font-mono">
+      <div className="mb-8 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Dashboard</h1>
+          <p className="text-sm text-neutral-500">
+            Agent runs and sandbox logs
+          </p>
+        </div>
+        <Link
+          href="/"
+          className="rounded border border-neutral-800 px-3 py-1.5 text-sm hover:bg-neutral-800"
+        >
+          Home
+        </Link>
+      </div>
+
+      {loading && (
+        <div className="py-12 text-center text-neutral-500">
+          Loading runs...
+        </div>
+      )}
+
+      {!loading && runs.length === 0 && (
+        <div className="rounded border border-neutral-800 p-8 text-center text-neutral-500">
+          No runs yet. Trigger an audit from the{" "}
+          <Link href="/" className="underline hover:text-white">
+            home page
+          </Link>
+          .
+        </div>
+      )}
+
+      {activeRuns.length > 0 && (
+        <section className="mb-10">
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-neutral-500">
+            Active
+          </h2>
+          <div className="space-y-2">
+            {activeRuns.map((run) => (
+              <RunCard key={run.id} run={run} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {pastRuns.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-neutral-500">
+            History
+          </h2>
+          <div className="space-y-2">
+            {pastRuns.map((run) => (
+              <RunCard key={run.id} run={run} />
+            ))}
+          </div>
+        </section>
+      )}
+    </main>
+  );
+}
+
+function RunCard({ run }: { run: RunMeta }) {
+  const vulnCount = run.vulnerabilities
+    ? run.vulnerabilities.cargo + run.vulnerabilities.pnpm
+    : null;
+
+  return (
+    <Link
+      href={`/dashboard/${run.id}`}
+      className="flex items-center justify-between rounded border border-neutral-800 p-4 transition-colors hover:border-neutral-600 hover:bg-neutral-900/50"
+    >
+      <div className="flex items-center gap-4">
+        <StatusBadge status={run.status} />
+        <div>
+          <p className="text-sm font-medium">{run.id}</p>
+          <p className="text-xs text-neutral-500">
+            {run.trigger === "cron" ? "Scheduled" : "Manual"} ·{" "}
+            {timeAgo(run.createdAt)}
+            {run.status === "completed" || run.status === "failed"
+              ? ` · ${duration(run.createdAt, run.updatedAt)}`
+              : ""}
+          </p>
+        </div>
+      </div>
+      <div className="flex items-center gap-4 text-xs text-neutral-500">
+        {vulnCount !== null && <span>{vulnCount} vulns</span>}
+        {run.agentResults && (
+          <span>{run.agentResults.vulnerabilitiesFixed} fixed</span>
+        )}
+        {run.branch && (
+          <span className="max-w-[200px] truncate" title={run.branch}>
+            {run.branch}
+          </span>
+        )}
+        <span className="text-neutral-700">&rarr;</span>
+      </div>
+    </Link>
+  );
+}

--- a/apps/agents/app/page.tsx
+++ b/apps/agents/app/page.tsx
@@ -47,12 +47,23 @@ export default function Home() {
           </div>
           {auditStatus === "done" && (
             <p className="mt-3 text-sm text-green-500">
-              Audit triggered. Check Slack for progress.
+              Audit triggered. Track progress on the{" "}
+              <Link
+                href="/dashboard"
+                className="underline hover:text-green-400"
+              >
+                dashboard
+              </Link>
+              .
             </p>
           )}
           {auditStatus === "error" && (
             <p className="mt-3 text-sm text-red-500">
-              Failed to trigger audit. Check the logs.
+              Failed to trigger audit. Check the{" "}
+              <Link href="/dashboard" className="underline hover:text-red-400">
+                dashboard
+              </Link>{" "}
+              for details.
             </p>
           )}
         </div>
@@ -60,12 +71,20 @@ export default function Home() {
 
       <section>
         <h2 className="mb-4 text-lg font-semibold">History</h2>
-        <Link
-          href="/vuln-diffs"
-          className="inline-block rounded border border-neutral-800 px-4 py-2 text-sm hover:bg-neutral-800"
-        >
-          View saved diffs
-        </Link>
+        <div className="flex gap-3">
+          <Link
+            href="/dashboard"
+            className="inline-block rounded border border-neutral-800 px-4 py-2 text-sm hover:bg-neutral-800"
+          >
+            Dashboard
+          </Link>
+          <Link
+            href="/vuln-diffs"
+            className="inline-block rounded border border-neutral-800 px-4 py-2 text-sm hover:bg-neutral-800"
+          >
+            Saved diffs
+          </Link>
+        </div>
       </section>
     </main>
   );

--- a/apps/agents/lib/runs.ts
+++ b/apps/agents/lib/runs.ts
@@ -1,0 +1,156 @@
+import { put, list, head } from "@vercel/blob";
+
+export type RunStatus =
+  | "queued"
+  | "scanning"
+  | "fixing"
+  | "pushing"
+  | "completed"
+  | "failed";
+
+export interface RunMeta {
+  id: string;
+  status: RunStatus;
+  trigger: "cron" | "manual";
+  createdAt: string;
+  updatedAt: string;
+  sandboxId?: string;
+  branch?: string;
+  error?: string;
+  vulnerabilities?: { cargo: number; pnpm: number };
+  agentResults?: {
+    success: boolean;
+    summary: string;
+    vulnerabilitiesFixed: number;
+    vulnerabilitiesRemaining: number;
+  };
+  diffUrl?: string;
+}
+
+const RUNS_PREFIX = "runs/";
+const LOGS_PREFIX = "logs/";
+
+function metaPath(id: string): string {
+  return `${RUNS_PREFIX}${id}/meta.json`;
+}
+
+function logsPath(id: string): string {
+  return `${LOGS_PREFIX}${id}.log`;
+}
+
+export async function createRun(trigger: "cron" | "manual"): Promise<RunMeta> {
+  const id = `run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const now = new Date().toISOString();
+  const meta: RunMeta = {
+    id,
+    status: "queued",
+    trigger,
+    createdAt: now,
+    updatedAt: now
+  };
+
+  await put(metaPath(id), JSON.stringify(meta), {
+    access: "public",
+    contentType: "application/json"
+  });
+
+  // Initialize empty log file
+  await put(logsPath(id), "", {
+    access: "public",
+    contentType: "text/plain"
+  });
+
+  return meta;
+}
+
+export async function updateRun(
+  id: string,
+  updates: Partial<Omit<RunMeta, "id" | "createdAt">>
+): Promise<RunMeta> {
+  const current = await getRun(id);
+  if (!current) {
+    throw new Error(`Run ${id} not found`);
+  }
+
+  const updated: RunMeta = {
+    ...current,
+    ...updates,
+    updatedAt: new Date().toISOString()
+  };
+
+  await put(metaPath(id), JSON.stringify(updated), {
+    access: "public",
+    contentType: "application/json",
+    addRandomSuffix: false
+  });
+
+  return updated;
+}
+
+export async function getRun(id: string): Promise<RunMeta | null> {
+  const { blobs } = await list({ prefix: `${RUNS_PREFIX}${id}/meta` });
+  const blob = blobs[0];
+  if (!blob) return null;
+
+  const res = await fetch(blob.url);
+  if (!res.ok) return null;
+  return res.json() as Promise<RunMeta>;
+}
+
+export async function listRuns(limit = 20): Promise<RunMeta[]> {
+  const { blobs } = await list({ prefix: RUNS_PREFIX });
+
+  // Filter to only meta.json files
+  const metaBlobs = blobs.filter((b) => b.pathname.endsWith("meta.json"));
+
+  // Sort by upload date descending
+  metaBlobs.sort(
+    (a, b) =>
+      new Date(b.uploadedAt).getTime() - new Date(a.uploadedAt).getTime()
+  );
+
+  const runs: RunMeta[] = [];
+  for (const blob of metaBlobs.slice(0, limit)) {
+    try {
+      const res = await fetch(blob.url);
+      if (res.ok) {
+        runs.push((await res.json()) as RunMeta);
+      }
+    } catch {
+      // Skip corrupt entries
+    }
+  }
+
+  return runs;
+}
+
+export async function appendLogs(id: string, lines: string): Promise<void> {
+  // Vercel Blob is append-unfriendly, so we read + append + rewrite.
+  // For large logs this isn't ideal, but it's simple and works without a DB.
+  const { blobs } = await list({ prefix: `${LOGS_PREFIX}${id}` });
+  const blob = blobs[0];
+
+  let existing = "";
+  if (blob) {
+    const res = await fetch(blob.url);
+    if (res.ok) {
+      existing = await res.text();
+    }
+  }
+
+  await put(logsPath(id), existing + lines, {
+    access: "public",
+    contentType: "text/plain",
+    addRandomSuffix: false
+  });
+}
+
+export async function getLogs(id: string): Promise<string> {
+  const { blobs } = await list({ prefix: `${LOGS_PREFIX}${id}` });
+  const blob = blobs[0];
+  if (!blob) return "";
+
+  const res = await fetch(blob.url);
+  if (!res.ok) return "";
+  return res.text();
+}


### PR DESCRIPTION
## Summary

- Adds a `/dashboard` page to the agents app that shows all agent runs with live-updating status and a log viewer
- Every audit pipeline execution now creates a persistent run record so you can see what's happening (or what happened) without relying solely on Slack

## Why

There was no way to see if an agent sandbox was actually running, what it was doing, or why it failed. The only visibility was coarse Slack messages. This makes it possible to watch the agent work in real-time and debug failures after the fact.

## What changed

**`lib/runs.ts`** -- New run store backed by Vercel Blob (no database needed, consistent with existing patterns). Persists run metadata (status, sandbox ID, branch, vuln counts, agent results) and log output.

**`lib/audit.ts`** -- The agent command now runs in `detached: true` mode and streams sandbox stdout/stderr via `cmd.logs()` into the run's log file. Status transitions (`queued` -> `scanning` -> `fixing` -> `pushing` -> `completed`/`failed`) are tracked throughout the pipeline. Log writes are batched (3s / 50 lines) to avoid excessive blob writes.

**`/dashboard`** -- Run list split into Active and History sections. Active runs show a pulsing status indicator. Each card shows trigger type, time, duration, vuln counts, and branch.

**`/dashboard/[id]`** -- Full metadata grid + live log viewer. Polls every 3s while the run is active. Auto-scrolls to bottom, pauses when you scroll up to read.

**API routes** -- `GET /api/runs`, `GET /api/runs/[id]`, `GET /api/runs/[id]/logs`

## Testing

- `pnpm --filter=@turbo-internal/agents run check-types` passes
- `pnpm --filter=@turbo-internal/agents run build` passes, all routes registered correctly