### PR TITLE
fix: Repair audit fixer log streaming and replace git push with patch upload

### DIFF
--- a/apps/agents/app/api/slack/actions/route.ts
+++ b/apps/agents/app/api/slack/actions/route.ts
@@ -1,6 +1,5 @@
 import { verifySlackRequest, updateMessage } from "@/lib/slack";
 import { addComment } from "@/lib/github";
-import { openFixPR, type AgentResults } from "@/lib/audit";
 import { REPRODUCTION_REQUEST } from "@/lib/templates";
 
 interface SlackAction {
@@ -60,46 +59,6 @@ export async function POST(request: Request) {
         channel,
         messageTs,
         `:heavy_minus_sign: ${mention} dismissed${issueRef} — no reproduction request needed`
-      );
-      break;
-    }
-
-    case "audit_open_pr": {
-      let parsed: { branch: string; agentResults: AgentResults };
-      try {
-        parsed = JSON.parse(action.value ?? "{}");
-      } catch {
-        await updateMessage(
-          channel,
-          messageTs,
-          `:x: Failed to parse action data`
-        );
-        break;
-      }
-
-      try {
-        const pr = await openFixPR(parsed.branch, parsed.agentResults);
-        await updateMessage(
-          channel,
-          messageTs,
-          `:white_check_mark: ${mention} opened <${pr.prUrl}|PR #${pr.prNumber}>`
-        );
-      } catch (error) {
-        const msg = error instanceof Error ? error.message : String(error);
-        await updateMessage(
-          channel,
-          messageTs,
-          `:x: ${mention} failed to open PR: ${msg}`
-        );
-      }
-      break;
-    }
-
-    case "audit_dismiss": {
-      await updateMessage(
-        channel,
-        messageTs,
-        `:heavy_minus_sign: ${mention} dismissed the audit results`
       );
       break;
     }

--- a/apps/agents/app/dashboard/page.tsx
+++ b/apps/agents/app/dashboard/page.tsx
@@ -8,7 +8,6 @@ const STATUS_LABELS: Record<string, { label: string; color: string }> = {
   queued: { label: "Queued", color: "text-neutral-400" },
   scanning: { label: "Scanning", color: "text-blue-400" },
   fixing: { label: "Fixing", color: "text-yellow-400" },
-  pushing: { label: "Pushing", color: "text-purple-400" },
   completed: { label: "Completed", color: "text-green-400" },
   failed: { label: "Failed", color: "text-red-400" }
 };
@@ -18,7 +17,7 @@ function StatusBadge({ status }: { status: string }) {
     label: status,
     color: "text-neutral-400"
   };
-  const isActive = ["queued", "scanning", "fixing", "pushing"].includes(status);
+  const isActive = ["queued", "scanning", "fixing"].includes(status);
 
   return (
     <span
@@ -96,7 +95,7 @@ export default function DashboardPage() {
   }, []);
 
   const activeRuns = runs.filter((r) =>
-    ["queued", "scanning", "fixing", "pushing"].includes(r.status)
+    ["queued", "scanning", "fixing"].includes(r.status)
   );
   const pastRuns = runs.filter(
     (r) => r.status === "completed" || r.status === "failed"

--- a/apps/agents/sandbox/audit-fix-agent.mjs
+++ b/apps/agents/sandbox/audit-fix-agent.mjs
@@ -220,7 +220,7 @@ async function main() {
       console.log("Results from reportResults tool call.");
       writeFileSync(
         RESULTS_PATH,
-        JSON.stringify(reportCall.args, null, 2),
+        JSON.stringify(reportCall.input, null, 2),
         "utf-8"
       );
     } else if (!existsSync(RESULTS_PATH)) {


### PR DESCRIPTION
## Summary

- Fixes multiple bugs preventing logs from streaming to the audit fixer dashboard
- Replaces `git push` in the audit pipeline with patch file generation + Vercel Blob upload
- Simplifies Slack notifications to short status lines with dashboard links