### PR TITLE
fix: Use `secret_key_override` in tests to eliminate env var race condition

### DIFF
--- a/crates/turborepo-cache/src/signature_authentication.rs
+++ b/crates/turborepo-cache/src/signature_authentication.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use base64::{prelude::BASE64_STANDARD, Engine};
+use base64::{Engine, prelude::BASE64_STANDARD};
 use hmac::{Hmac, Mac};
 use os_str_bytes::OsStringBytes;
 use sha2::Sha256;


### PR DESCRIPTION
## Summary

- Refactors `signature_authentication` tests to use the existing `secret_key_override` field instead of `unsafe { env::set_var(...) }`, eliminating a race condition when tests run in parallel.

## Details

The `ArtifactSignatureAuthenticator` already has a `secret_key_override` field specifically designed to avoid env var race conditions, but the tests weren't using it. Instead, they were setting `TURBO_REMOTE_CACHE_SIGNATURE_KEY` via `env::set_var` (which is `unsafe` in Rust 2024 edition for exactly this reason).

The "change the key" portion of the test now creates a second authenticator instance with a different `secret_key_override` rather than mutating the global environment.

Closes TURBO-5218