### PR TITLE
fix: Avoid panic in sandboxed environments by removing system-configuration dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2782,11 +2782,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -6035,27 +6033,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags 2.10.0",
- "core-foundation 0.9.3",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tabwriter"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8658,44 +8635,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-registry"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
-dependencies = [
- "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
-]
 
 [[package]]
 name = "windows-sys"
@@ -8763,7 +8705,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -8818,7 +8760,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",

--- a/crates/turborepo-microfrontends-proxy/Cargo.toml
+++ b/crates/turborepo-microfrontends-proxy/Cargo.toml
@@ -14,7 +14,12 @@ hyper-rustls = { workspace = true, features = [
   "native-tokio",
   "ring",
 ] }
-hyper-util = { version = "0.1", features = ["full"] }
+hyper-util = { version = "0.1", features = [
+  "client-legacy",
+  "http1",
+  "http2",
+  "tokio",
+] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 tokio-tungstenite = "0.21"


### PR DESCRIPTION
## Summary

Fixes #11826

- Replace `hyper-util`'s `"full"` feature flag with only the features actually used (`client-legacy`, `http1`, `http2`, `tokio`) in `turborepo-microfrontends-proxy`
- This removes the `system-configuration` crate from the dependency tree entirely

## Why

The `"full"` feature on `hyper-util` includes `"client-proxy-system"`, which pulls in the [`system-configuration`](https://crates.io/crates/system-configuration) crate on macOS. Due to Cargo feature unification, this feature was activated for **all** `hyper-util` consumers in the workspace, including `reqwest`.

When `reqwest` builds a client, it calls `SCDynamicStoreCreateWithOptions()` to detect system proxy settings. In sandboxed environments (e.g. OpenAI Codex), this macOS API returns NULL, and the `system-configuration` crate panics with "Attempted to create a NULL object" — crashing turbo with exit code 101.

The microfrontends proxy never needed system proxy detection. It only uses `hyper-util` for its HTTP client (`Client::builder`), `TokioIo`, `TokioExecutor`, and HTTP/1+2 support.

## Testing

- `cargo check --workspace` passes
- All 13 `turborepo-microfrontends-proxy` tests pass
- `cargo tree --workspace | grep system-configuration` returns nothing — the dependency is fully removed