### PR TITLE
style: Fix oxfmt formatting in release workflow

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -634,14 +634,7 @@ jobs:
     name: "Cleanup Failed Release"
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs:
-      [
-        stage,
-        build-rust,
-        rust-smoke-test,
-        js-smoke-test,
-        npm-publish
-      ]
+    needs: [stage, build-rust, rust-smoke-test, js-smoke-test, npm-publish]
     if: ${{ always() && needs.stage.result == 'success' && (needs.build-rust.result == 'failure' || needs.rust-smoke-test.result == 'failure' || needs.js-smoke-test.result == 'failure' || needs.npm-publish.result == 'failure') }}
     steps:
       - name: Delete staging branch


### PR DESCRIPTION
## Summary

- Fixes `oxfmt --check` failure on `.github/workflows/turborepo-release.yml` by collapsing the multi-line `needs` array in the `cleanup-on-failure` job to a single line.