### PR TITLE
fix: Fix @turbo/gen release pipeline failures

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -276,6 +276,9 @@ jobs:
           rust: "false"
           capnproto: "false"
 
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo
         with:
@@ -392,7 +395,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build @turbo/gen binaries (all platforms)
+      - name: Build @turbo/gen (dependencies + embedded templates)
+        run: pnpm turbo run build --filter=@turbo/gen
+
+      - name: Cross-compile @turbo/gen for all platforms
         run: pnpm --filter @turbo/gen run build:all
 
       - name: Upload gen binaries
@@ -689,7 +695,15 @@ jobs:
     name: "Cleanup Failed Release"
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [stage, build-rust, build-gen, rust-smoke-test, js-smoke-test, npm-publish]
+    needs:
+      [
+        stage,
+        build-rust,
+        build-gen,
+        rust-smoke-test,
+        js-smoke-test,
+        npm-publish
+      ]
     if: ${{ always() && needs.stage.result == 'success' && (needs.build-rust.result == 'failure' || needs.build-gen.result == 'failure' || needs.rust-smoke-test.result == 'failure' || needs.js-smoke-test.result == 'failure' || needs.npm-publish.result == 'failure') }}
     steps:
       - name: Delete staging branch


### PR DESCRIPTION
## Summary

The release pipeline added in #11825 has two failures:

- **`js-smoke-test`**: `build:embed` (a prerequisite of `build` → `test`) runs `bun run scripts/embed-templates.ts`, but bun was never installed in this job. Fails with `sh: 1: bun: not found`.
- **`build-gen`**: Ran `pnpm --filter @turbo/gen run build:all` directly, bypassing turbo's task graph. This skipped `build:embed` (so `src/templates/embedded.ts` didn't exist) and `^build` (so `@turbo/workspaces` dist wasn't built), causing resolution failures during `bun build --compile`.

## Changes

- Add `oven-sh/setup-bun@v2` to the `js-smoke-test` job (matching `test-js-packages.yml`)
- Add `pnpm turbo run build --filter=@turbo/gen` before `build:all` in `build-gen` so turbo handles the dependency graph (`^build` + `build:embed`) before cross-compilation

## Testing

The `build-gen` job can be validated by running a canary release. The `js-smoke-test` fix can be verified by confirming bun is available during `turbo run check-types test`.