### PR TITLE
fix: Use pre-built turbo in build-gen release job

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -392,11 +392,16 @@ jobs:
         with:
           bun-version: latest
 
+      - name: Install Global Turbo
+        uses: ./.github/actions/install-global-turbo
+        with:
+          turbo-version: ${{ inputs.ci-tag-override || '' }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Build @turbo/gen (dependencies + embedded templates)
-        run: pnpm turbo run build --filter=@turbo/gen
+        run: turbo run build --filter=@turbo/gen
 
       - name: Cross-compile @turbo/gen for all platforms
         run: pnpm --filter @turbo/gen run build:all


### PR DESCRIPTION
## Summary

- The `build-gen` release job was failing because `pnpm turbo` resolved to the root `package.json` script, which builds the entire Rust binary from source (`cargo build --package turbo`). This requires `capnp`, protobuf, and a full Rust toolchain — none of which `@turbo/gen` needs.
- Installs a pre-built `turbo` from npm (via `install-global-turbo`, same as the `js-smoke-test` job) and uses bare `turbo` instead of `pnpm turbo`.

## Testing

The `js-smoke-test` job in the same workflow already uses this exact pattern successfully.