### PR TITLE
fix: Install bun in npm-publish release job

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -427,6 +427,11 @@ jobs:
         with:
           enable-corepack: false
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo
         with:


### PR DESCRIPTION
## Summary

- The `npm-publish` job runs `make publish-turbo`, which triggers `turbo build --filter=@turbo/gen`. That package's `build:embed` script requires `bun`, but `bun` was never installed in this job.
- Adds `oven-sh/setup-bun@v2` to the `npm-publish` job, matching the existing setup in `build-gen` and `js-smoke-test`.

`@turbo/gen` is the only JS package in the repo that uses `bun` for its build scripts.