### PR TITLE
release(turborepo): 2.8.8-canary.4

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -488,7 +488,7 @@ jobs:
           if [ "${{ inputs.dry_run }}" = "true" ]; then
             SKIP_FLAG="--skip-publish"
           fi
-          cd cli && turboreleaser gen --version-path ../version.txt $SKIP_FLAG
+          cd cli && pnpm exec turboreleaser gen --version-path ../version.txt $SKIP_FLAG
 
       # Upload published artifacts in case they are needed for debugging later
       - name: Upload Artifacts

--- a/packages/create-turbo/package.json
+++ b/packages/create-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-turbo",
-  "version": "2.8.8-canary.3",
+  "version": "2.8.8-canary.4",
   "description": "Create a new Turborepo",
   "homepage": "https://turborepo.dev",
   "license": "MIT",

--- a/packages/eslint-config-turbo/package.json
+++ b/packages/eslint-config-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-turbo",
-  "version": "2.8.8-canary.3",
+  "version": "2.8.8-canary.4",
   "type": "commonjs",
   "description": "ESLint config for Turborepo",
   "license": "MIT",

--- a/packages/eslint-plugin-turbo/package.json
+++ b/packages/eslint-plugin-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-turbo",
-  "version": "2.8.8-canary.3",
+  "version": "2.8.8-canary.4",
   "description": "ESLint plugin for Turborepo",
   "keywords": [
     "turbo",

--- a/packages/turbo-codemod/package.json
+++ b/packages/turbo-codemod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/codemod",
-  "version": "2.8.8-canary.3",
+  "version": "2.8.8-canary.4",
   "description": "Provides Codemod transformations to help upgrade your Turborepo codebase when a feature is deprecated.",
   "homepage": "https://turborepo.dev",
   "license": "MIT",

--- a/packages/turbo-gen/package.json
+++ b/packages/turbo-gen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/gen",
-  "version": "2.8.8-canary.3",
+  "version": "2.8.8-canary.4",
   "description": "Extend a Turborepo",
   "homepage": "https://turborepo.dev",
   "license": "MIT",
@@ -23,11 +23,11 @@
   },
   "dependencies": {},
   "optionalDependencies": {
-    "@turbo/gen-darwin-64": "2.8.8-canary.1",
-    "@turbo/gen-darwin-arm64": "2.8.8-canary.1",
-    "@turbo/gen-linux-64": "2.8.8-canary.1",
-    "@turbo/gen-linux-arm64": "2.8.8-canary.1",
-    "@turbo/gen-windows-64": "2.8.8-canary.1"
+    "@turbo/gen-darwin-64": "2.8.8-canary.4",
+    "@turbo/gen-darwin-arm64": "2.8.8-canary.4",
+    "@turbo/gen-linux-64": "2.8.8-canary.4",
+    "@turbo/gen-linux-arm64": "2.8.8-canary.4",
+    "@turbo/gen-windows-64": "2.8.8-canary.4"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.2",

--- a/packages/turbo-ignore/package.json
+++ b/packages/turbo-ignore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-ignore",
-  "version": "2.8.8-canary.3",
+  "version": "2.8.8-canary.4",
   "description": "",
   "homepage": "https://turborepo.dev",
   "keywords": [],

--- a/packages/turbo-types/package.json
+++ b/packages/turbo-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/types",
-  "version": "2.8.8-canary.3",
+  "version": "2.8.8-canary.4",
   "description": "Turborepo types",
   "type": "commonjs",
   "homepage": "https://turborepo.dev",

--- a/packages/turbo-workspaces/package.json
+++ b/packages/turbo-workspaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/workspaces",
-  "version": "2.8.8-canary.3",
+  "version": "2.8.8-canary.4",
   "description": "Tools for working with package managers",
   "homepage": "https://turborepo.dev",
   "license": "MIT",

--- a/packages/turbo/package.json
+++ b/packages/turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo",
-  "version": "2.8.8-canary.3",
+  "version": "2.8.8-canary.4",
   "description": "Turborepo is a high-performance build system for JavaScript and TypeScript codebases.",
   "repository": "https://github.com/vercel/turborepo",
   "bugs": "https://github.com/vercel/turborepo/issues",
@@ -18,11 +18,11 @@
     "schema.json"
   ],
   "optionalDependencies": {
-    "turbo-darwin-64": "2.8.8-canary.3",
-    "turbo-darwin-arm64": "2.8.8-canary.3",
-    "turbo-linux-64": "2.8.8-canary.3",
-    "turbo-linux-arm64": "2.8.8-canary.3",
-    "turbo-windows-64": "2.8.8-canary.3",
-    "turbo-windows-arm64": "2.8.8-canary.3"
+    "turbo-darwin-64": "2.8.8-canary.4",
+    "turbo-darwin-arm64": "2.8.8-canary.4",
+    "turbo-linux-64": "2.8.8-canary.4",
+    "turbo-linux-arm64": "2.8.8-canary.4",
+    "turbo-windows-64": "2.8.8-canary.4",
+    "turbo-windows-arm64": "2.8.8-canary.4"
   }
 }

--- a/skills/turborepo/SKILL.md
+++ b/skills/turborepo/SKILL.md
@@ -9,7 +9,7 @@ description: |
   monorepo, shares code between apps, runs changed/affected packages, debugs cache,
   or has apps/packages directories.
 metadata:
-  version: 2.8.8-canary.3
+  version: 2.8.8-canary.4
 ---
 
 # Turborepo Skill

--- a/version.txt
+++ b/version.txt
@@ -1,2 +1,2 @@
-2.8.8-canary.3
+2.8.8-canary.4
 canary


### PR DESCRIPTION
## Release v2.8.8-canary.4

Re-release after incomplete 2.8.8-canary.3 where `@turbo/gen` platform packages failed to publish.

### Changes

- Fix `turboreleaser: command not found` in the "Publish @turbo/gen platform packages" release step by adding `pnpm exec` prefix (the binary is workspace-linked, not on global PATH)
- Bump `@turbo/gen` optionalDependencies from `2.8.8-canary.1` to `2.8.8-canary.4` (were stale from prior failed publishes)
- Version bump all packages to `2.8.8-canary.4`