### PR TITLE
release(turborepo): 2.8.8-canary.5

### DIFF
--- a/packages/create-turbo/package.json
+++ b/packages/create-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-turbo",
-  "version": "2.8.8-canary.4",
+  "version": "2.8.8-canary.5",
   "description": "Create a new Turborepo",
   "homepage": "https://turborepo.dev",
   "license": "MIT",

--- a/packages/eslint-config-turbo/package.json
+++ b/packages/eslint-config-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-turbo",
-  "version": "2.8.8-canary.4",
+  "version": "2.8.8-canary.5",
   "type": "commonjs",
   "description": "ESLint config for Turborepo",
   "license": "MIT",

--- a/packages/eslint-plugin-turbo/package.json
+++ b/packages/eslint-plugin-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-turbo",
-  "version": "2.8.8-canary.4",
+  "version": "2.8.8-canary.5",
   "description": "ESLint plugin for Turborepo",
   "keywords": [
     "turbo",

--- a/packages/turbo-codemod/package.json
+++ b/packages/turbo-codemod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/codemod",
-  "version": "2.8.8-canary.4",
+  "version": "2.8.8-canary.5",
   "description": "Provides Codemod transformations to help upgrade your Turborepo codebase when a feature is deprecated.",
   "homepage": "https://turborepo.dev",
   "license": "MIT",

--- a/packages/turbo-gen/package.json
+++ b/packages/turbo-gen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/gen",
-  "version": "2.8.8-canary.4",
+  "version": "2.8.8-canary.5",
   "description": "Extend a Turborepo",
   "homepage": "https://turborepo.dev",
   "license": "MIT",

--- a/packages/turbo-ignore/package.json
+++ b/packages/turbo-ignore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-ignore",
-  "version": "2.8.8-canary.4",
+  "version": "2.8.8-canary.5",
   "description": "",
   "homepage": "https://turborepo.dev",
   "keywords": [],

--- a/packages/turbo-types/package.json
+++ b/packages/turbo-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/types",
-  "version": "2.8.8-canary.4",
+  "version": "2.8.8-canary.5",
   "description": "Turborepo types",
   "type": "commonjs",
   "homepage": "https://turborepo.dev",

--- a/packages/turbo-workspaces/package.json
+++ b/packages/turbo-workspaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/workspaces",
-  "version": "2.8.8-canary.4",
+  "version": "2.8.8-canary.5",
   "description": "Tools for working with package managers",
   "homepage": "https://turborepo.dev",
   "license": "MIT",

--- a/packages/turbo/package.json
+++ b/packages/turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo",
-  "version": "2.8.8-canary.4",
+  "version": "2.8.8-canary.5",
   "description": "Turborepo is a high-performance build system for JavaScript and TypeScript codebases.",
   "repository": "https://github.com/vercel/turborepo",
   "bugs": "https://github.com/vercel/turborepo/issues",
@@ -18,11 +18,11 @@
     "schema.json"
   ],
   "optionalDependencies": {
-    "turbo-darwin-64": "2.8.8-canary.4",
-    "turbo-darwin-arm64": "2.8.8-canary.4",
-    "turbo-linux-64": "2.8.8-canary.4",
-    "turbo-linux-arm64": "2.8.8-canary.4",
-    "turbo-windows-64": "2.8.8-canary.4",
-    "turbo-windows-arm64": "2.8.8-canary.4"
+    "turbo-darwin-64": "2.8.8-canary.5",
+    "turbo-darwin-arm64": "2.8.8-canary.5",
+    "turbo-linux-64": "2.8.8-canary.5",
+    "turbo-linux-arm64": "2.8.8-canary.5",
+    "turbo-windows-64": "2.8.8-canary.5",
+    "turbo-windows-arm64": "2.8.8-canary.5"
   }
 }

--- a/skills/turborepo/SKILL.md
+++ b/skills/turborepo/SKILL.md
@@ -9,7 +9,7 @@ description: |
   monorepo, shares code between apps, runs changed/affected packages, debugs cache,
   or has apps/packages directories.
 metadata:
-  version: 2.8.8-canary.4
+  version: 2.8.8-canary.5
 ---
 
 # Turborepo Skill

--- a/version.txt
+++ b/version.txt
@@ -1,2 +1,2 @@
-2.8.8-canary.4
+2.8.8-canary.5
 canary


### PR DESCRIPTION
## Release v2.8.8-canary.5

Versioned docs: https://v2-8-8-canary-5.turborepo.dev

Manual release PR — automated pipeline failed at "Publish To NPM" due to Trusted Publishing misconfiguration for `@turbo/gen` platform packages.

### Changes

- feat: Compile @turbo/gen to standalone binary via `bun build --compile` (#11825) (`4f5632cafd`)
- fix: Fix @turbo/gen release pipeline failures (#11836) (`16cbbbf666`)
- fix: Use pre-built turbo in build-gen release job (#11837) (`8a76848369`)
- fix: Install bun in npm-publish release job (#11838) (`0036398a24`)
- release(turborepo): 2.8.8-canary.4 (#11839) (`45fbbd08c7`)
- chore: Update lockfile for release (#11840) (`b13889821d`)
- fix: Unblock release pipeline for @turbo/gen optional dependencies (#11841) (`85d483dee9`)