### PR TITLE
fix: Sync lockfile with @turbo/gen optionalDependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -698,6 +698,22 @@ importers:
       validate-npm-package-name:
         specifier: 5.0.0
         version: 5.0.0
+    optionalDependencies:
+      '@turbo/gen-darwin-64':
+        specifier: 2.8.8-canary.6
+        version: 2.8.8-canary.6
+      '@turbo/gen-darwin-arm64':
+        specifier: 2.8.8-canary.6
+        version: 2.8.8-canary.6
+      '@turbo/gen-linux-64':
+        specifier: 2.8.8-canary.6
+        version: 2.8.8-canary.6
+      '@turbo/gen-linux-arm64':
+        specifier: 2.8.8-canary.6
+        version: 2.8.8-canary.6
+      '@turbo/gen-windows-64':
+        specifier: 2.8.8-canary.6
+        version: 2.8.8-canary.6
 
   packages/turbo-ignore:
     dependencies:
@@ -3988,6 +4004,31 @@ packages:
 
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
+  '@turbo/gen-darwin-64@2.8.8-canary.6':
+    resolution: {integrity: sha512-+2cx2Z6u/wM6Pb629PscGLEzzzd3vS8HW3jqRMBZPt3HLdKC+2igUMepp0k5DGhwDyKLQE48OhcsUQwONFXR8w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@turbo/gen-darwin-arm64@2.8.8-canary.6':
+    resolution: {integrity: sha512-S2IbLeBJ4Vb39U7SfxvvpaiTxWOya43++6UdVYjT8JUNhEaFg6BColUnPiEkE666edJtkrHA9XQ6QrAGYZIM7g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@turbo/gen-linux-64@2.8.8-canary.6':
+    resolution: {integrity: sha512-I8oiij2tQBQUL98j8Ipyz0vSsvNDS7ccuIdua48+tVr98BouSqW5vEFeIURfIbyW4X19FdsabebL9spT7oirag==}
+    cpu: [x64]
+    os: [linux]
+
+  '@turbo/gen-linux-arm64@2.8.8-canary.6':
+    resolution: {integrity: sha512-qbve5m9qvlxE20ZAmSElVFWlp/aXa4nIY9O00h9k2DYLamg3NSfbdwKDJQathm3ILJ/Ty95+dmLLsHXh4vI7qw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@turbo/gen-windows-64@2.8.8-canary.6':
+    resolution: {integrity: sha512-qHKmdoLsKeXo2OYI0rB135XZvNsszAYEw5hJOkQPr7R5NW7ga2rGL98/RUZ/CQsGcc+hVt2SorxSG8mmL8kXpA==}
+    cpu: [x64]
+    os: [win32]
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -11713,6 +11754,21 @@ snapshots:
   '@tsconfig/node14@1.0.3': {}
 
   '@tsconfig/node16@1.0.4': {}
+
+  '@turbo/gen-darwin-64@2.8.8-canary.6':
+    optional: true
+
+  '@turbo/gen-darwin-arm64@2.8.8-canary.6':
+    optional: true
+
+  '@turbo/gen-linux-64@2.8.8-canary.6':
+    optional: true
+
+  '@turbo/gen-linux-arm64@2.8.8-canary.6':
+    optional: true
+
+  '@turbo/gen-windows-64@2.8.8-canary.6':
+    optional: true
 
   '@tybys/wasm-util@0.10.1':
     dependencies:


### PR DESCRIPTION
## Summary

The canary.6 manual release commit added `optionalDependencies` to `packages/turbo-gen/package.json` (via the `postversion` hook in `bump-version.js`) but didn't regenerate the lockfile. This leaves `pnpm-lock.yaml` out of sync — every `pnpm install` dirties the lockfile with 56 lines of missing `@turbo/gen-*` resolution entries.

Ran `pnpm install` and committed the resulting lockfile.