### PR TITLE
fix: Commit lockfile updates in release PR job

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -620,6 +620,16 @@ jobs:
           git config --global user.name 'Turbobot'
           git config --global user.email 'turbobot@vercel.com'
 
+      - name: Commit lockfile if updated by install
+        run: |
+          if git diff --quiet pnpm-lock.yaml; then
+            echo "Lockfile already up to date."
+          else
+            git add pnpm-lock.yaml
+            git commit -m "Update lockfile for release"
+            git push origin "${{ needs.stage.outputs.stage-branch }}"
+          fi
+
       - name: Bump to next canary for stable releases
         run: |
           TAG=$(sed -n '2p' version.txt)


### PR DESCRIPTION
## Summary

The `stage-release` Makefile target bumps `@turbo/gen`'s optional dependencies (via its `postversion` script), but the `@turbo/gen-*` platform packages aren't published to npm yet at staging time, so the lockfile can't be updated then.

The `create-release-pr` job already runs `pnpm install --no-frozen-lockfile` via `setup-node`, which resolves the now-published packages and updates the lockfile on disk — but never commits it. This adds a step to commit the lockfile change before creating the PR.

This is what caused CI failures on #11846 and previous release PRs.