### PR TITLE
fix: Prevent premature git tag push during release staging

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -46,15 +46,15 @@ stage-release:
 	fi
 
 	# Prepare the packages.
-	cd $(CLI_DIR)/../packages/turbo && pnpm version "$(TURBO_VERSION)" --allow-same-version
-	cd $(CLI_DIR)/../packages/create-turbo && pnpm version "$(TURBO_VERSION)" --allow-same-version
-	cd $(CLI_DIR)/../packages/turbo-codemod && pnpm version "$(TURBO_VERSION)" --allow-same-version
-	cd $(CLI_DIR)/../packages/turbo-ignore && pnpm version "$(TURBO_VERSION)" --allow-same-version
-	cd $(CLI_DIR)/../packages/turbo-workspaces && pnpm version "$(TURBO_VERSION)" --allow-same-version
-	cd $(CLI_DIR)/../packages/turbo-gen && pnpm version "$(TURBO_VERSION)" --allow-same-version
-	cd $(CLI_DIR)/../packages/eslint-plugin-turbo && pnpm version "$(TURBO_VERSION)" --allow-same-version
-	cd $(CLI_DIR)/../packages/eslint-config-turbo && pnpm version "$(TURBO_VERSION)" --allow-same-version
-	cd $(CLI_DIR)/../packages/turbo-types && pnpm version "$(TURBO_VERSION)" --allow-same-version
+	cd $(CLI_DIR)/../packages/turbo && pnpm version "$(TURBO_VERSION)" --allow-same-version --no-git-tag-version
+	cd $(CLI_DIR)/../packages/create-turbo && pnpm version "$(TURBO_VERSION)" --allow-same-version --no-git-tag-version
+	cd $(CLI_DIR)/../packages/turbo-codemod && pnpm version "$(TURBO_VERSION)" --allow-same-version --no-git-tag-version
+	cd $(CLI_DIR)/../packages/turbo-ignore && pnpm version "$(TURBO_VERSION)" --allow-same-version --no-git-tag-version
+	cd $(CLI_DIR)/../packages/turbo-workspaces && pnpm version "$(TURBO_VERSION)" --allow-same-version --no-git-tag-version
+	cd $(CLI_DIR)/../packages/turbo-gen && pnpm version "$(TURBO_VERSION)" --allow-same-version --no-git-tag-version
+	cd $(CLI_DIR)/../packages/eslint-plugin-turbo && pnpm version "$(TURBO_VERSION)" --allow-same-version --no-git-tag-version
+	cd $(CLI_DIR)/../packages/eslint-config-turbo && pnpm version "$(TURBO_VERSION)" --allow-same-version --no-git-tag-version
+	cd $(CLI_DIR)/../packages/turbo-types && pnpm version "$(TURBO_VERSION)" --allow-same-version --no-git-tag-version
 
 	# Update turborepo skill version (in YAML frontmatter metadata block only)
 	node -e "const fs=require('fs'),p='$(CLI_DIR)/../skills/turborepo/SKILL.md',c=fs.readFileSync(p,'utf-8');fs.writeFileSync(p,c.replace(/^(---\n[\s\S]*?metadata:\n\s*version:\s*).+?(\n[\s\S]*?---)/,'\$$1$(TURBO_VERSION)\$$2'))"
@@ -66,9 +66,21 @@ stage-release:
 .PHONY: create-release-tag
 create-release-tag:
 	@echo "Creating release tag v$(TURBO_VERSION)..."
-	git tag "v$(TURBO_VERSION)"
-	git push origin "v$(TURBO_VERSION)"
-	@echo "Release tag v$(TURBO_VERSION) created and pushed."
+	@REMOTE_TAG_SHA=$$(git ls-remote --tags origin "refs/tags/v$(TURBO_VERSION)" | awk '{print $$1}'); \
+	if [ -n "$$REMOTE_TAG_SHA" ]; then \
+		LOCAL_SHA=$$(git rev-parse HEAD); \
+		if [ "$$REMOTE_TAG_SHA" = "$$LOCAL_SHA" ]; then \
+			echo "Tag v$(TURBO_VERSION) already exists on remote at the correct commit. Skipping."; \
+		else \
+			echo "Error: Tag v$(TURBO_VERSION) exists on remote but points to $$REMOTE_TAG_SHA, expected $$LOCAL_SHA." && \
+			echo "This tag may have been pushed prematurely by a previous step." && \
+			exit 1; \
+		fi; \
+	else \
+		git tag "v$(TURBO_VERSION)" && \
+		git push origin "v$(TURBO_VERSION)" && \
+		echo "Release tag v$(TURBO_VERSION) created and pushed."; \
+	fi
 
 .PHONY: publish-turbo
 publish-turbo: build


### PR DESCRIPTION
## Summary

I *think* we're trying to double write git tags, but its hard to tell. This PR should make it more clear.