### PR TITLE
release(turborepo): 2.8.9

### DIFF
--- a/packages/create-turbo/package.json
+++ b/packages/create-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-turbo",
-  "version": "2.8.9-canary.2",
+  "version": "2.8.9",
   "description": "Create a new Turborepo",
   "homepage": "https://turborepo.dev",
   "license": "MIT",

--- a/packages/eslint-config-turbo/package.json
+++ b/packages/eslint-config-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-turbo",
-  "version": "2.8.9-canary.2",
+  "version": "2.8.9",
   "type": "commonjs",
   "description": "ESLint config for Turborepo",
   "license": "MIT",

--- a/packages/eslint-plugin-turbo/package.json
+++ b/packages/eslint-plugin-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-turbo",
-  "version": "2.8.9-canary.2",
+  "version": "2.8.9",
   "description": "ESLint plugin for Turborepo",
   "keywords": [
     "turbo",

--- a/packages/turbo-codemod/package.json
+++ b/packages/turbo-codemod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/codemod",
-  "version": "2.8.9-canary.2",
+  "version": "2.8.9",
   "description": "Provides Codemod transformations to help upgrade your Turborepo codebase when a feature is deprecated.",
   "homepage": "https://turborepo.dev",
   "license": "MIT",

--- a/packages/turbo-gen/package.json
+++ b/packages/turbo-gen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/gen",
-  "version": "2.8.9-canary.2",
+  "version": "2.8.9",
   "description": "Extend a Turborepo",
   "homepage": "https://turborepo.dev",
   "license": "MIT",
@@ -58,10 +58,10 @@
     "access": "public"
   },
   "optionalDependencies": {
-    "@turbo/gen-darwin-64": "2.8.9-canary.2",
-    "@turbo/gen-darwin-arm64": "2.8.9-canary.2",
-    "@turbo/gen-linux-64": "2.8.9-canary.2",
-    "@turbo/gen-linux-arm64": "2.8.9-canary.2",
-    "@turbo/gen-windows-64": "2.8.9-canary.2"
+    "@turbo/gen-darwin-64": "2.8.9",
+    "@turbo/gen-darwin-arm64": "2.8.9",
+    "@turbo/gen-linux-64": "2.8.9",
+    "@turbo/gen-linux-arm64": "2.8.9",
+    "@turbo/gen-windows-64": "2.8.9"
   }
 }

--- a/packages/turbo-ignore/package.json
+++ b/packages/turbo-ignore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-ignore",
-  "version": "2.8.9-canary.2",
+  "version": "2.8.9",
   "description": "",
   "homepage": "https://turborepo.dev",
   "keywords": [],

--- a/packages/turbo-types/package.json
+++ b/packages/turbo-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/types",
-  "version": "2.8.9-canary.2",
+  "version": "2.8.9",
   "description": "Turborepo types",
   "type": "commonjs",
   "homepage": "https://turborepo.dev",

--- a/packages/turbo-workspaces/package.json
+++ b/packages/turbo-workspaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/workspaces",
-  "version": "2.8.9-canary.2",
+  "version": "2.8.9",
   "description": "Tools for working with package managers",
   "homepage": "https://turborepo.dev",
   "license": "MIT",

--- a/packages/turbo/package.json
+++ b/packages/turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo",
-  "version": "2.8.9-canary.2",
+  "version": "2.8.9",
   "description": "Turborepo is a high-performance build system for JavaScript and TypeScript codebases.",
   "repository": "https://github.com/vercel/turborepo",
   "bugs": "https://github.com/vercel/turborepo/issues",
@@ -18,11 +18,11 @@
     "schema.json"
   ],
   "optionalDependencies": {
-    "turbo-darwin-64": "2.8.9-canary.2",
-    "turbo-darwin-arm64": "2.8.9-canary.2",
-    "turbo-linux-64": "2.8.9-canary.2",
-    "turbo-linux-arm64": "2.8.9-canary.2",
-    "turbo-windows-64": "2.8.9-canary.2",
-    "turbo-windows-arm64": "2.8.9-canary.2"
+    "turbo-darwin-64": "2.8.9",
+    "turbo-darwin-arm64": "2.8.9",
+    "turbo-linux-64": "2.8.9",
+    "turbo-linux-arm64": "2.8.9",
+    "turbo-windows-64": "2.8.9",
+    "turbo-windows-arm64": "2.8.9"
   }
 }

--- a/skills/turborepo/SKILL.md
+++ b/skills/turborepo/SKILL.md
@@ -9,7 +9,7 @@ description: |
   monorepo, shares code between apps, runs changed/affected packages, debugs cache,
   or has apps/packages directories.
 metadata:
-  version: 2.8.9-canary.2
+  version: 2.8.9
 ---
 
 # Turborepo Skill

--- a/version.txt
+++ b/version.txt
@@ -1,2 +1,2 @@
-2.8.9-canary.2
-canary
+2.8.9
+latest


### PR DESCRIPTION
## Release v2.8.9

### Changes

- release(turborepo): 2.8.9-canary.2 (#11859) (`6e151bc`)
- fix: Handle premature tag creation by external release notes service (#11863) (`335200e`)