### PR TITLE
fix: Prevent stale canary publishes after stable release

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -222,6 +222,18 @@ jobs:
             exit 1
           fi
 
+          # If this is a canary, check whether its stable version was already
+          # published to npm. This catches the window between a stable publish
+          # and the release PR merging back into main (which bumps version.txt).
+          if [[ "$VERSION" == *"-canary."* ]]; then
+            STABLE_VERSION="${VERSION%%-canary.*}"
+            if npm view "turbo@${STABLE_VERSION}" version >/dev/null 2>&1; then
+              echo "::error::turbo@${STABLE_VERSION} already exists on npm. Skipping stale canary ${VERSION}."
+              echo "::error::The release PR that bumps version.txt likely hasn't merged yet."
+              exit 1
+            fi
+          fi
+
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "New version: $VERSION"
           cat version.txt


### PR DESCRIPTION
## Summary

- Fixes a race condition where canary versions (e.g. `2.8.9-canary.3`) get published to npm after their stable counterpart (`2.8.9`) is already out.

## Problem

When a stable release publishes, the version bump to the next canary (e.g. `2.8.10-canary.0`) lives in the release PR. Until that PR merges, `version.txt` on `main` still has the old canary version (e.g. `2.8.9-canary.2`). If the hourly cron fires in that window, it increments to `2.8.9-canary.3` and publishes it — a canary that is semantically *older* than the stable release already on the registry.

## Fix

Before publishing a canary, the `stage` job now checks npm for the stable counterpart (`npm view turbo@X.Y.Z`). If it already exists, the release is aborted. The npm registry is the source of truth here rather than git tags, since `npm-publish` runs before `create-release-tag` in the pipeline.

## Testing

This only fires during the `stage` job in CI. To verify locally:

```bash
# This should succeed (version exists on npm)
npm view turbo@2.8.9 version

# This should fail (version doesn't exist)
npm view turbo@99.99.99 version
```