### PR TITLE
fix: Restrict credential file permissions to owner-only

### DIFF
--- a/crates/turborepo-auth/src/auth/logout.rs
+++ b/crates/turborepo-auth/src/auth/logout.rs
@@ -51,7 +51,7 @@ impl<T: TokenClient> LogoutOptions<T> {
         let new_content = serde_json::to_string_pretty(&data)?;
 
         // Write the updated content back to the file
-        path.create_with_contents(new_content)?;
+        path.create_with_contents_secret(new_content)?;
 
         Ok(())
     }

--- a/crates/turborepo-lib/src/commands/login/mod.rs
+++ b/crates/turborepo-lib/src/commands/login/mod.rs
@@ -160,7 +160,7 @@ fn write_token(base: &CommandBase, token: Token) -> Result<(), Error> {
         })?;
 
     global_config_path
-        .create_with_contents(after)
+        .create_with_contents_secret(after)
         .map_err(|e| config::Error::FailedToSetConfig {
             config_path: global_config_path.clone(),
             error: e,


### PR DESCRIPTION
## Summary

Credential files (`config.json`, `auth.json`) were created with `fs::File::create()` which inherits the process umask — typically `0o644` (world-readable) on Unix. On shared multi-user systems, this allowed any local user to read another user's Vercel API tokens.

- Adds `create_with_contents_secret()` to `AbsoluteSystemPath` that sets `0o600` atomically at creation time via `OpenOptions::mode()`, and explicitly tightens permissions on pre-existing files
- Applies it to all credential write paths: `turbo login`, auth token refresh (`write_to_auth_file`), and logout config rewrite
- On Windows, delegates to `create_with_contents` (no POSIX permission semantics)

## Testing

New tests verify:
- Fresh files are created with `0o600`
- Pre-existing `0o644` files are tightened to `0o600` on overwrite
- `write_to_auth_file` produces `0o600` end-to-end

All existing tests in `turbopath`, `turborepo-auth`, and `turborepo-lib` pass.