### PR TITLE
perf: Replace twox-hash with xxhash-rust and optimize file hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7391,7 +7391,7 @@ dependencies = [
  "turbopath",
  "turborepo-lockfiles",
  "turborepo-types",
- "twox-hash",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -8076,17 +8076,6 @@ dependencies = [
  "tui-term",
  "unicode-width 0.1.13",
  "vte",
-]
-
-[[package]]
-name = "twox-hash"
-version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "rand 0.8.5",
- "static_assertions",
 ]
 
 [[package]]
@@ -9008,6 +8997,12 @@ dependencies = [
  "linux-raw-sys 0.4.13",
  "rustix 0.38.31",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yansi"

--- a/crates/turborepo-hash/Cargo.toml
+++ b/crates/turborepo-hash/Cargo.toml
@@ -14,7 +14,7 @@ hex = "0.4.3"
 turbopath = { workspace = true }
 turborepo-lockfiles = { workspace = true }
 turborepo-types = { workspace = true }
-twox-hash = "1.6.3"
+xxhash-rust = { version = "0.8", features = ["xxh64"] }
 
 [dev-dependencies]
 test-case = { workspace = true }

--- a/crates/turborepo-hash/src/traits.rs
+++ b/crates/turborepo-hash/src/traits.rs
@@ -1,5 +1,3 @@
-use std::hash::Hasher;
-
 use capnp::message::{Allocator, Builder};
 
 pub trait Sealed<A> {}
@@ -31,9 +29,7 @@ where
 
         let buf = message.get_segments_for_output()[0];
 
-        let mut hasher = twox_hash::XxHash64::with_seed(0);
-        hasher.write(buf);
-        let out = hasher.finish();
+        let out = xxhash_rust::xxh64::xxh64(buf, 0);
 
         hex::encode(out.to_be_bytes())
     }


### PR DESCRIPTION
## Summary

- Replaces `twox-hash` with `xxhash-rust` for xxHash64 computation, using its one-shot `xxh64()` function instead of the streaming `Hasher` trait — avoids per-call setup overhead on a very hot path
- Pre-allocates file read buffers in `git_like_hash_file` using file metadata to avoid repeated reallocations during `read_to_end`
- Adds criterion benchmarks for both `turborepo-hash` and `turborepo-scm` crates

## Benchmarks

Tested end-to-end with `turbo run typecheck --dry --skip-infer --no-daemon` on an internal repo (10 runs, hyperfine):

| | Mean | Range |
|---|---|---|
| **This branch** | 8.881s ± 0.267s | 8.642s – 9.558s |
| **main** | 9.387s ± 0.192s | 9.146s – 9.860s |

**~6% faster** (1.06 ± 0.04x)

User-space CPU time dropped from 66.8s to 58.7s (~12% reduction), confirming the savings come from reduced hashing and allocation overhead.