### PR TITLE
perf: Replace O(V³) Floyd-Warshall with O(V+E) DFS in watch mode subgraph creation

### DIFF
--- a/crates/turborepo-engine/src/lib.rs
+++ b/crates/turborepo-engine/src/lib.rs
@@ -250,15 +250,11 @@ impl<T: TaskDefinitionInfo + Clone> Engine<Built, T> {
         // reversed). Uses a multi-source DFS which is O(V+E), replacing the
         // previous O(V^3) Floyd-Warshall approach.
         let mut reachable = HashSet::new();
-        depth_first_search(
-            Reversed(&self.task_graph),
-            entrypoint_indices,
-            |event| {
-                if let DfsEvent::Discover(n, _) = event {
-                    reachable.insert(n);
-                }
-            },
-        );
+        depth_first_search(Reversed(&self.task_graph), entrypoint_indices, |event| {
+            if let DfsEvent::Discover(n, _) = event {
+                reachable.insert(n);
+            }
+        });
 
         let new_graph = self.task_graph.filter_map(
             |node_idx, node| {


### PR DESCRIPTION
## Summary

- Replaces the O(V³) Floyd-Warshall all-pairs shortest path algorithm in `create_engine_for_subgraph` with an O(V+E) multi-source DFS, making watch mode re-runs significantly faster in large monorepos.
- Uses `petgraph::visit::Reversed` for a zero-copy reversed graph view, eliminating the previous `.clone()` + `.reverse()` of the entire task graph.

## Context

`create_engine_for_subgraph` is called on every file change in `turbo watch` to compute the subgraph of tasks affected by changed packages. The old Floyd-Warshall approach computed distances between *all* pairs of nodes — unnecessary since we only need to know which nodes are reachable from the changed entrypoints. The new DFS approach traverses only the relevant portion of the graph.

The improvement is most noticeable in monorepos with 100+ packages where the cubic cost of Floyd-Warshall becomes a real bottleneck on each file save.

## Testing

Existing tests for `create_engine_for_subgraph` continue to pass and validate correctness.