### PR TITLE
feat: Generate LLM-friendly markdown alongside --profile trace output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7330,6 +7330,7 @@ dependencies = [
  "turborepo-microfrontends",
  "turborepo-microfrontends-proxy",
  "turborepo-process",
+ "turborepo-profile-md",
  "turborepo-repository",
  "turborepo-run-cache",
  "turborepo-run-summary",
@@ -7469,6 +7470,16 @@ dependencies = [
  "turbopath",
  "turborepo-task-id",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "turborepo-profile-md"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 1.0.63",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ turborepo-lockfiles = { path = "crates/turborepo-lockfiles" }
 turborepo-microfrontends = { path = "crates/turborepo-microfrontends" }
 turborepo-microfrontends-proxy = { path = "crates/turborepo-microfrontends-proxy" }
 turborepo-process = { path = "crates/turborepo-process" }
+turborepo-profile-md = { path = "crates/turborepo-profile-md" }
 turborepo-repository = { path = "crates/turborepo-repository" }
 turborepo-task-id = { path = "crates/turborepo-task-id" }
 turborepo-types = { path = "crates/turborepo-types" }

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -126,6 +126,7 @@ turborepo-lockfiles = { workspace = true }
 turborepo-microfrontends = { workspace = true }
 turborepo-microfrontends-proxy = { workspace = true }
 turborepo-process = { workspace = true }
+turborepo-profile-md = { workspace = true }
 turborepo-repository = { path = "../turborepo-repository" }
 turborepo-run-cache = { path = "../turborepo-run-cache" }
 turborepo-run-summary = { workspace = true }

--- a/crates/turborepo-lib/src/tracing.rs
+++ b/crates/turborepo-lib/src/tracing.rs
@@ -206,6 +206,17 @@ impl TurboSubscriber {
 
         Ok(())
     }
+
+    /// Flushes and closes the chrome tracing layer so the trace file is
+    /// fully written. This must be called before reading the trace file
+    /// for post-processing (e.g., markdown generation).
+    pub fn flush_chrome_tracing(&self) -> Result<(), Error> {
+        // Disable the layer by replacing it with None
+        self.chrome_update.reload(None)?;
+        // Drop the flush guard to finalize the file
+        self.chrome_guard.lock().expect("not poisoned").take();
+        Ok(())
+    }
 }
 
 impl Drop for TurboSubscriber {

--- a/crates/turborepo-profile-md/Cargo.toml
+++ b/crates/turborepo-profile-md/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "turborepo-profile-md"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = "1.0.38"
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/turborepo-profile-md/src/analyze.rs
+++ b/crates/turborepo-profile-md/src/analyze.rs
@@ -1,0 +1,310 @@
+use std::collections::HashMap;
+
+use crate::parse::TraceEvent;
+
+/// Uniquely identifies a function by its name and source location.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FunctionId {
+    pub name: String,
+    pub category: String,
+    pub file: String,
+    pub line: u64,
+}
+
+impl FunctionId {
+    pub fn location(&self) -> String {
+        if self.file.is_empty() {
+            self.category.clone()
+        } else if self.line > 0 {
+            format!("{}:{}", self.file, self.line)
+        } else {
+            self.file.clone()
+        }
+    }
+}
+
+/// Aggregated timing data for a single function.
+#[derive(Debug, Clone)]
+pub struct FunctionStats {
+    pub id: FunctionId,
+    /// Total wall time spent in this function (including children).
+    pub total_time_us: f64,
+    /// Self time (total minus time in child spans).
+    pub self_time_us: f64,
+    /// Number of times this function was entered.
+    pub call_count: u64,
+}
+
+/// A resolved span with begin/end timestamps and parent relationship.
+#[derive(Debug, Clone)]
+struct ResolvedSpan {
+    func_id: FunctionId,
+    start_us: f64,
+    end_us: f64,
+    tid: u64,
+    parent_idx: Option<usize>,
+}
+
+/// Full analysis result.
+#[derive(Debug)]
+pub struct ProfileAnalysis {
+    pub total_duration_us: f64,
+    pub span_count: u64,
+    pub functions: Vec<FunctionStats>,
+    /// caller -> callee -> count
+    pub call_edges: HashMap<(FunctionId, FunctionId), u64>,
+}
+
+pub fn analyze(events: &[TraceEvent]) -> ProfileAnalysis {
+    let spans = resolve_spans(events);
+    let total_duration_us = compute_total_duration(&spans);
+    let span_count = spans.len() as u64;
+
+    let spans_with_parents = assign_parents(&spans);
+    let (functions, call_edges) = compute_function_stats(&spans_with_parents);
+
+    ProfileAnalysis {
+        total_duration_us,
+        span_count,
+        functions,
+        call_edges,
+    }
+}
+
+/// Match async "b"/"e" pairs into resolved spans.
+fn resolve_spans(events: &[TraceEvent]) -> Vec<ResolvedSpan> {
+    // Group begin events by (tid, id, name) to match with end events.
+    // For async spans, the `id` field is the correlation key.
+    let mut pending: HashMap<(u64, u64, String), PendingSpan> = HashMap::new();
+    let mut resolved = Vec::new();
+
+    for event in events {
+        let name = match &event.name {
+            Some(n) => n.clone(),
+            None => continue,
+        };
+
+        match event.ph.as_str() {
+            "b" | "B" => {
+                let tid = event.tid.unwrap_or(0);
+                let id = event.id.unwrap_or(0);
+                let ts = match event.ts {
+                    Some(ts) => ts,
+                    None => continue,
+                };
+
+                let func_id = FunctionId {
+                    name: name.clone(),
+                    category: event.cat.clone().unwrap_or_default(),
+                    file: event.file.clone().unwrap_or_default(),
+                    line: event.line.unwrap_or(0),
+                };
+
+                pending.insert(
+                    (tid, id, name),
+                    PendingSpan {
+                        func_id,
+                        start_us: ts,
+                        tid,
+                    },
+                );
+            }
+            "e" | "E" => {
+                let tid = event.tid.unwrap_or(0);
+                let id = event.id.unwrap_or(0);
+                let ts = match event.ts {
+                    Some(ts) => ts,
+                    None => continue,
+                };
+
+                let key = (tid, id, name);
+                if let Some(begin) = pending.remove(&key) {
+                    resolved.push(ResolvedSpan {
+                        func_id: begin.func_id,
+                        start_us: begin.start_us,
+                        end_us: ts,
+                        tid: begin.tid,
+                        parent_idx: None,
+                    });
+                }
+            }
+            // "i" (instant), "M" (metadata) -- skip for span analysis
+            _ => {}
+        }
+    }
+
+    // Sort by start time for parent assignment
+    resolved.sort_by(|a, b| {
+        a.start_us
+            .partial_cmp(&b.start_us)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    resolved
+}
+
+struct PendingSpan {
+    func_id: FunctionId,
+    start_us: f64,
+    tid: u64,
+}
+
+fn compute_total_duration(spans: &[ResolvedSpan]) -> f64 {
+    if spans.is_empty() {
+        return 0.0;
+    }
+    let min_start = spans
+        .iter()
+        .map(|s| s.start_us)
+        .fold(f64::INFINITY, f64::min);
+    let max_end = spans
+        .iter()
+        .map(|s| s.end_us)
+        .fold(f64::NEG_INFINITY, f64::max);
+    max_end - min_start
+}
+
+/// Assign parent spans using a stack-based approach per thread.
+/// For async traces, we use timestamp containment: a span is a child of
+/// the most recent span on the same thread that fully contains it.
+fn assign_parents(spans: &[ResolvedSpan]) -> Vec<ResolvedSpan> {
+    let mut result = spans.to_vec();
+
+    // Group spans by tid
+    let mut by_tid: HashMap<u64, Vec<usize>> = HashMap::new();
+    for (i, span) in result.iter().enumerate() {
+        by_tid.entry(span.tid).or_default().push(i);
+    }
+
+    for indices in by_tid.values() {
+        // Within each thread, use a stack to track nesting.
+        // Spans are already sorted by start time globally.
+        let mut stack: Vec<usize> = Vec::new();
+
+        for &idx in indices {
+            // Pop spans from the stack that have ended before this span starts
+            while let Some(&top_idx) = stack.last() {
+                if result[top_idx].end_us <= result[idx].start_us {
+                    stack.pop();
+                } else {
+                    break;
+                }
+            }
+
+            // The top of the stack (if any) is our parent
+            if let Some(&parent_idx) = stack.last() {
+                // Only set parent if this span is fully contained
+                if result[parent_idx].start_us <= result[idx].start_us
+                    && result[idx].end_us <= result[parent_idx].end_us
+                {
+                    result[idx].parent_idx = Some(parent_idx);
+                }
+            }
+
+            stack.push(idx);
+        }
+    }
+
+    result
+}
+
+fn compute_function_stats(
+    spans: &[ResolvedSpan],
+) -> (Vec<FunctionStats>, HashMap<(FunctionId, FunctionId), u64>) {
+    let mut stats_map: HashMap<FunctionId, (f64, f64, u64)> = HashMap::new();
+    let mut call_edges: HashMap<(FunctionId, FunctionId), u64> = HashMap::new();
+
+    // First pass: accumulate total time and call count
+    for span in spans {
+        let duration = span.end_us - span.start_us;
+        let entry = stats_map
+            .entry(span.func_id.clone())
+            .or_insert((0.0, 0.0, 0));
+        entry.0 += duration; // total_time
+        entry.1 += duration; // self_time (will subtract children below)
+        entry.2 += 1; // call_count
+    }
+
+    // Second pass: subtract child time from parent's self time, record call edges
+    for span in spans {
+        if let Some(parent_idx) = span.parent_idx {
+            let parent = &spans[parent_idx];
+            let child_duration = span.end_us - span.start_us;
+
+            if let Some(parent_stats) = stats_map.get_mut(&parent.func_id) {
+                parent_stats.1 -= child_duration;
+            }
+
+            *call_edges
+                .entry((parent.func_id.clone(), span.func_id.clone()))
+                .or_insert(0) += 1;
+        }
+    }
+
+    // Clamp negative self-times (can happen with overlapping async spans)
+    for stats in stats_map.values_mut() {
+        if stats.1 < 0.0 {
+            stats.1 = 0.0;
+        }
+    }
+
+    let mut functions: Vec<FunctionStats> = stats_map
+        .into_iter()
+        .map(|(id, (total, self_time, count))| FunctionStats {
+            id,
+            total_time_us: total,
+            self_time_us: self_time,
+            call_count: count,
+        })
+        .collect();
+
+    // Sort by self time descending
+    functions.sort_by(|a, b| {
+        b.self_time_us
+            .partial_cmp(&a.self_time_us)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    (functions, call_edges)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse::parse_trace;
+
+    #[test]
+    fn basic_analysis() {
+        let json = r#"[
+            {"ph":"M","pid":1,"name":"thread_name","tid":0,"args":{"name":"main"}},
+            {"ph":"b","pid":1,"ts":0.0,"name":"run","cat":"turborepo_lib::run","tid":0,"id":1,".file":"src/run.rs",".line":10},
+            {"ph":"b","pid":1,"ts":100.0,"name":"hash","cat":"turborepo_task_hash","tid":0,"id":2,".file":"src/hash.rs",".line":20},
+            {"ph":"e","pid":1,"ts":300.0,"name":"hash","cat":"turborepo_task_hash","tid":0,"id":2},
+            {"ph":"e","pid":1,"ts":500.0,"name":"run","cat":"turborepo_lib::run","tid":0,"id":1}
+        ]"#;
+
+        let events = parse_trace(json).unwrap();
+        let analysis = analyze(&events);
+
+        assert_eq!(analysis.span_count, 2);
+        assert!((analysis.total_duration_us - 500.0).abs() < 0.01);
+
+        // "run" has total=500, self=500-200=300
+        let run = analysis
+            .functions
+            .iter()
+            .find(|f| f.id.name == "run")
+            .unwrap();
+        assert!((run.total_time_us - 500.0).abs() < 0.01);
+        assert!((run.self_time_us - 300.0).abs() < 0.01);
+
+        // "hash" has total=200, self=200
+        let hash = analysis
+            .functions
+            .iter()
+            .find(|f| f.id.name == "hash")
+            .unwrap();
+        assert!((hash.total_time_us - 200.0).abs() < 0.01);
+        assert!((hash.self_time_us - 200.0).abs() < 0.01);
+    }
+}

--- a/crates/turborepo-profile-md/src/format.rs
+++ b/crates/turborepo-profile-md/src/format.rs
@@ -1,0 +1,252 @@
+use std::fmt::Write;
+
+use crate::analyze::{FunctionId, ProfileAnalysis};
+
+/// Minimum self-time percentage to appear in the Hot Functions table.
+const HOT_FUNCTION_THRESHOLD_PERCENT: f64 = 0.4;
+/// Maximum number of functions in the "Top N" summary line.
+const TOP_N: usize = 10;
+/// Minimum total-time percentage to appear in the Call Tree table.
+const CALL_TREE_THRESHOLD_PERCENT: f64 = 0.4;
+/// Minimum self-time percentage to get a Function Details section.
+const DETAIL_THRESHOLD_PERCENT: f64 = 0.5;
+
+pub fn format_markdown(analysis: &ProfileAnalysis) -> String {
+    let mut out = String::with_capacity(8192);
+
+    write_header(&mut out, analysis);
+    write_top_n(&mut out, analysis);
+    write_hot_functions(&mut out, analysis);
+    write_call_tree(&mut out, analysis);
+    write_function_details(&mut out, analysis);
+
+    out
+}
+
+fn write_header(out: &mut String, analysis: &ProfileAnalysis) {
+    let duration = format_duration_us(analysis.total_duration_us);
+    let unique_fns = analysis.functions.len();
+
+    let _ = writeln!(out, "# CPU Profile");
+    let _ = writeln!(out);
+    let _ = writeln!(out, "| Duration | Spans | Functions |");
+    let _ = writeln!(out, "|----------|-------|-----------|");
+    let _ = writeln!(
+        out,
+        "| {} | {} | {} |",
+        duration, analysis.span_count, unique_fns
+    );
+    let _ = writeln!(out);
+}
+
+fn write_top_n(out: &mut String, analysis: &ProfileAnalysis) {
+    if analysis.functions.is_empty() {
+        return;
+    }
+
+    let total = analysis.total_duration_us;
+    if total <= 0.0 {
+        return;
+    }
+
+    let entries: Vec<String> = analysis
+        .functions
+        .iter()
+        .take(TOP_N)
+        .filter(|f| f.self_time_us > 0.0)
+        .map(|f| {
+            let pct = (f.self_time_us / total) * 100.0;
+            format!("`{}` {:.1}%", f.id.name, pct)
+        })
+        .collect();
+
+    let _ = writeln!(out, "**Top {}:** {}", entries.len(), entries.join(", "));
+    let _ = writeln!(out);
+}
+
+fn write_hot_functions(out: &mut String, analysis: &ProfileAnalysis) {
+    let total = analysis.total_duration_us;
+    if total <= 0.0 {
+        return;
+    }
+
+    let _ = writeln!(out, "## Hot Functions (Self Time)");
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "| Self% | Self | Total% | Total | Function | Location |"
+    );
+    let _ = writeln!(
+        out,
+        "|------:|-----:|-------:|------:|----------|----------|"
+    );
+
+    for func in &analysis.functions {
+        let self_pct = (func.self_time_us / total) * 100.0;
+        if self_pct < HOT_FUNCTION_THRESHOLD_PERCENT {
+            break;
+        }
+        let total_pct = (func.total_time_us / total) * 100.0;
+
+        let _ = writeln!(
+            out,
+            "| {:.1}% | {} | {:.1}% | {} | `{}` | `{}` |",
+            self_pct,
+            format_duration_us(func.self_time_us),
+            total_pct,
+            format_duration_us(func.total_time_us),
+            func.id.name,
+            func.id.location(),
+        );
+    }
+
+    let _ = writeln!(out);
+}
+
+fn write_call_tree(out: &mut String, analysis: &ProfileAnalysis) {
+    let total = analysis.total_duration_us;
+    if total <= 0.0 {
+        return;
+    }
+
+    // Sort by total time descending for call tree view
+    let mut by_total: Vec<_> = analysis.functions.iter().collect();
+    by_total.sort_by(|a, b| {
+        b.total_time_us
+            .partial_cmp(&a.total_time_us)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    let _ = writeln!(out, "## Call Tree (Total Time)");
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "| Total% | Total | Self% | Self | Function | Location |"
+    );
+    let _ = writeln!(
+        out,
+        "|-------:|------:|------:|-----:|----------|----------|"
+    );
+
+    for func in &by_total {
+        let total_pct = (func.total_time_us / total) * 100.0;
+        if total_pct < CALL_TREE_THRESHOLD_PERCENT {
+            break;
+        }
+        let self_pct = (func.self_time_us / total) * 100.0;
+
+        let _ = writeln!(
+            out,
+            "| {:.1}% | {} | {:.1}% | {} | `{}` | `{}` |",
+            total_pct,
+            format_duration_us(func.total_time_us),
+            self_pct,
+            format_duration_us(func.self_time_us),
+            func.id.name,
+            func.id.location(),
+        );
+    }
+
+    let _ = writeln!(out);
+}
+
+fn write_function_details(out: &mut String, analysis: &ProfileAnalysis) {
+    let total = analysis.total_duration_us;
+    if total <= 0.0 {
+        return;
+    }
+
+    let _ = writeln!(out, "## Function Details");
+    let _ = writeln!(out);
+
+    for func in &analysis.functions {
+        let self_pct = (func.self_time_us / total) * 100.0;
+        if self_pct < DETAIL_THRESHOLD_PERCENT {
+            continue;
+        }
+
+        let _ = writeln!(out, "### `{}`", func.id.name);
+        let _ = writeln!(
+            out,
+            "`{}` | Self: {:.1}% ({}) | Total: {:.1}% ({}) | Calls: {}",
+            func.id.location(),
+            self_pct,
+            format_duration_us(func.self_time_us),
+            (func.total_time_us / total) * 100.0,
+            format_duration_us(func.total_time_us),
+            func.call_count,
+        );
+        let _ = writeln!(out);
+
+        // Callers (who calls this function)
+        let callers: Vec<(&FunctionId, u64)> = analysis
+            .call_edges
+            .iter()
+            .filter(|((_, callee), _)| callee == &func.id)
+            .map(|((caller, _), count)| (caller, *count))
+            .collect();
+
+        if !callers.is_empty() {
+            let _ = writeln!(out, "**Called by:**");
+            for (caller, count) in &callers {
+                let _ = writeln!(out, "- `{}` ({})", caller.name, count);
+            }
+            let _ = writeln!(out);
+        }
+
+        // Callees (what this function calls)
+        let callees: Vec<(&FunctionId, u64)> = analysis
+            .call_edges
+            .iter()
+            .filter(|((caller, _), _)| caller == &func.id)
+            .map(|((_, callee), count)| (callee, *count))
+            .collect();
+
+        if !callees.is_empty() {
+            let _ = writeln!(out, "**Calls:**");
+            for (callee, count) in &callees {
+                let _ = writeln!(out, "- `{}` ({})", callee.name, count);
+            }
+            let _ = writeln!(out);
+        }
+    }
+}
+
+fn format_duration_us(us: f64) -> String {
+    if us >= 1_000_000.0 {
+        format!("{:.1}s", us / 1_000_000.0)
+    } else if us >= 1_000.0 {
+        format!("{:.1}ms", us / 1_000.0)
+    } else {
+        format!("{:.0}us", us)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{analyze::analyze, parse::parse_trace};
+
+    #[test]
+    fn format_basic_profile() {
+        let json = r#"[
+            {"ph":"b","pid":1,"ts":0.0,"name":"run","cat":"turborepo_lib::run","tid":0,"id":1,".file":"src/run.rs",".line":10},
+            {"ph":"b","pid":1,"ts":100.0,"name":"hash","cat":"turborepo_task_hash","tid":0,"id":2,".file":"src/hash.rs",".line":20},
+            {"ph":"e","pid":1,"ts":300.0,"name":"hash","cat":"turborepo_task_hash","tid":0,"id":2},
+            {"ph":"b","pid":1,"ts":310.0,"name":"execute","cat":"turborepo_task_executor","tid":0,"id":3,".file":"src/exec.rs",".line":30},
+            {"ph":"e","pid":1,"ts":490.0,"name":"execute","cat":"turborepo_task_executor","tid":0,"id":3},
+            {"ph":"e","pid":1,"ts":500.0,"name":"run","cat":"turborepo_lib::run","tid":0,"id":1}
+        ]"#;
+
+        let events = parse_trace(json).unwrap();
+        let analysis = analyze(&events);
+        let md = format_markdown(&analysis);
+
+        assert!(md.contains("# CPU Profile"));
+        assert!(md.contains("## Hot Functions (Self Time)"));
+        assert!(md.contains("## Call Tree (Total Time)"));
+        assert!(md.contains("`hash`"));
+        assert!(md.contains("`run`"));
+        assert!(md.contains("`execute`"));
+    }
+}

--- a/crates/turborepo-profile-md/src/lib.rs
+++ b/crates/turborepo-profile-md/src/lib.rs
@@ -1,0 +1,89 @@
+mod analyze;
+mod format;
+mod parse;
+
+use std::path::Path;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("failed to read trace file: {0}")]
+    ReadFile(#[from] std::io::Error),
+    #[error("failed to parse trace JSON: {0}")]
+    ParseJson(#[from] serde_json::Error),
+}
+
+/// Reads a Chromium Trace Event Format JSON file produced by `turbo run
+/// --profile` and writes an LLM-friendly markdown summary alongside it.
+///
+/// The output markdown contains:
+/// - Summary table (duration, span count, unique functions)
+/// - Top N hottest functions
+/// - Hot Functions table sorted by self-time
+/// - Call Tree table sorted by total-time
+/// - Function Details with caller/callee relationships
+pub fn trace_to_markdown(trace_path: &Path, output_path: &Path) -> Result<(), Error> {
+    let contents = std::fs::read_to_string(trace_path)?;
+    let md = trace_contents_to_markdown(&contents)?;
+    std::fs::write(output_path, md)?;
+    Ok(())
+}
+
+/// Same as `trace_to_markdown` but operates on the trace file contents
+/// directly, returning the markdown string rather than writing to a file.
+pub fn trace_contents_to_markdown(contents: &str) -> Result<String, Error> {
+    let events = parse::parse_trace(contents)?;
+    let analysis = analyze::analyze(&events);
+    Ok(format::format_markdown(&analysis))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn end_to_end() {
+        let json = r#"[
+            {"ph":"M","pid":1,"name":"thread_name","tid":0,"args":{"name":"main"}},
+            {"ph":"b","pid":1,"ts":0.0,"name":"build","cat":"turborepo_lib::run","tid":0,"id":1,".file":"crates/turborepo-lib/src/run/builder.rs",".line":194},
+            {"ph":"b","pid":1,"ts":50.0,"name":"resolve_packages","cat":"turborepo_lib::run","tid":0,"id":2,".file":"crates/turborepo-lib/src/run/mod.rs",".line":189},
+            {"ph":"e","pid":1,"ts":150.0,"name":"resolve_packages","cat":"turborepo_lib::run","tid":0,"id":2},
+            {"ph":"b","pid":1,"ts":200.0,"name":"calculate_hashes","cat":"turborepo_task_hash","tid":0,"id":3,".file":"crates/turborepo-task-hash/src/lib.rs",".line":104},
+            {"ph":"b","pid":1,"ts":220.0,"name":"calculate_file_hash","cat":"turborepo_task_hash","tid":0,"id":4,".file":"crates/turborepo-task-hash/src/lib.rs",".line":320},
+            {"ph":"e","pid":1,"ts":350.0,"name":"calculate_file_hash","cat":"turborepo_task_hash","tid":0,"id":4},
+            {"ph":"e","pid":1,"ts":400.0,"name":"calculate_hashes","cat":"turborepo_task_hash","tid":0,"id":3},
+            {"ph":"b","pid":1,"ts":410.0,"name":"execute_task","cat":"turborepo_task_executor::exec","tid":0,"id":5,".file":"crates/turborepo-task-executor/src/exec.rs",".line":272,"args":{"task":"web#build"}},
+            {"ph":"e","pid":1,"ts":900.0,"name":"execute_task","cat":"turborepo_task_executor::exec","tid":0,"id":5},
+            {"ph":"e","pid":1,"ts":1000.0,"name":"build","cat":"turborepo_lib::run","tid":0,"id":1}
+        ]"#;
+
+        let md = trace_contents_to_markdown(json).unwrap();
+
+        // Verify structure
+        assert!(md.contains("# CPU Profile"));
+        assert!(md.contains("| Duration | Spans | Functions |"));
+        assert!(md.contains("1.0ms")); // total duration ~1000us
+        assert!(md.contains("## Hot Functions (Self Time)"));
+        assert!(md.contains("## Call Tree (Total Time)"));
+        assert!(md.contains("`execute_task`"));
+        assert!(md.contains("`build`"));
+    }
+
+    #[test]
+    fn file_round_trip() {
+        let json = r#"[
+            {"ph":"b","pid":1,"ts":0.0,"name":"run","cat":"test","tid":0,"id":1},
+            {"ph":"e","pid":1,"ts":1000.0,"name":"run","cat":"test","tid":0,"id":1}
+        ]"#;
+
+        let dir = tempfile::tempdir().unwrap();
+        let trace_path = dir.path().join("test.trace");
+        let md_path = dir.path().join("test.trace.md");
+
+        std::fs::write(&trace_path, json).unwrap();
+        trace_to_markdown(&trace_path, &md_path).unwrap();
+
+        let md = std::fs::read_to_string(&md_path).unwrap();
+        assert!(md.contains("# CPU Profile"));
+        assert!(md.contains("`run`"));
+    }
+}

--- a/crates/turborepo-profile-md/src/parse.rs
+++ b/crates/turborepo-profile-md/src/parse.rs
@@ -1,0 +1,68 @@
+use serde::Deserialize;
+use serde_json::Value;
+
+/// A single event from a Chromium Trace Event Format JSON array.
+///
+/// The tracing-chrome crate outputs these with:
+/// - `ph`: phase type ("b"/"e" for async begin/end, "i" for instant, "M" for
+///   metadata)
+/// - `ts`: timestamp in microseconds
+/// - `name`: span or event name
+/// - `cat`: category (tracing target, e.g. "turborepo_lib::run")
+/// - `tid`: thread ID
+/// - `id`: async span correlation ID (only for "b"/"e" phases)
+/// - `.file` / `.line`: source location (when include_locations is true)
+/// - `args`: recorded span fields (when include_args is true)
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct TraceEvent {
+    pub ph: String,
+    #[serde(default)]
+    pub pid: Option<u64>,
+    #[serde(default)]
+    pub ts: Option<f64>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub cat: Option<String>,
+    #[serde(default)]
+    pub tid: Option<u64>,
+    #[serde(default)]
+    pub id: Option<u64>,
+    #[serde(default, rename = ".file")]
+    pub file: Option<String>,
+    #[serde(default, rename = ".line")]
+    pub line: Option<u64>,
+    #[serde(default)]
+    pub args: Option<Value>,
+    #[serde(default)]
+    pub s: Option<String>,
+}
+
+pub fn parse_trace(contents: &str) -> Result<Vec<TraceEvent>, serde_json::Error> {
+    serde_json::from_str(contents)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_async_trace() {
+        let json = r#"[
+            {"ph":"M","pid":1,"name":"thread_name","tid":0,"args":{"name":"main"}},
+            {"ph":"b","pid":1,"ts":100.0,"name":"run","cat":"turborepo_lib::run","tid":0,"id":1,".file":"src/run/mod.rs",".line":42},
+            {"ph":"b","pid":1,"ts":200.0,"name":"hash","cat":"turborepo_task_hash","tid":0,"id":2,".file":"src/lib.rs",".line":10},
+            {"ph":"e","pid":1,"ts":350.0,"name":"hash","cat":"turborepo_task_hash","tid":0,"id":2},
+            {"ph":"e","pid":1,"ts":500.0,"name":"run","cat":"turborepo_lib::run","tid":0,"id":1}
+        ]"#;
+
+        let events = parse_trace(json).unwrap();
+        assert_eq!(events.len(), 5);
+        assert_eq!(events[0].ph, "M");
+        assert_eq!(events[1].ph, "b");
+        assert_eq!(events[1].name.as_deref(), Some("run"));
+        assert_eq!(events[1].file.as_deref(), Some("src/run/mod.rs"));
+        assert_eq!(events[1].line, Some(42));
+    }
+}

--- a/turborepo-tests/integration/tests/run/profile.t
+++ b/turborepo-tests/integration/tests/run/profile.t
@@ -7,3 +7,12 @@ Ignore output since we want to focus on testing the generated profile
    WARNING  no output files found for task my-app#build. Please check your `outputs` key in `turbo.json`
 Make sure the resulting trace is valid JSON
   $ node -e "require('./build.trace')"
+
+Make sure the markdown profile summary was generated
+  $ test -f build.trace.md
+  $ head -1 build.trace.md
+  # CPU Profile
+  $ grep -c "Hot Functions" build.trace.md
+  1
+  $ grep -c "Call Tree" build.trace.md
+  1


### PR DESCRIPTION
## Summary

- When `--profile` or `--anon-profile` is used, Turborepo now automatically generates a companion `.md` file alongside the `.trace` file (e.g., `build.trace` → `build.trace.md`)
- The markdown contains hot functions sorted by self-time, a call tree sorted by total-time, and function detail sections with caller/callee relationships — all in a highly greppable format designed for LLM analysis
- Adds a new `turborepo-profile-md` crate that parses Chrome Trace Event Format JSON and renders the analysis as markdown

## Why

Chrome trace JSON is great for `chrome://tracing` but useless for quick analysis or LLM consumption. This is inspired by Bun's `--cpu-prof-md` flag which outputs profiles in a markdown format optimized for grep and LLM tools. Having a `.md` alongside the `.trace` means you can immediately feed it to an AI assistant and get actionable optimization suggestions without needing to open a browser tool.

## How it works

1. After `run::run()` completes, `flush_chrome_tracing()` is called on the `TurboSubscriber` to finalize the trace file (disables the chrome layer and drops the `FlushGuard`)
2. The trace JSON is parsed, async `b`/`e` span pairs are matched, and self/total time is computed per function
3. A markdown file is written with summary tables, top-N hottest functions, and caller/callee graphs

## Testing

- 5 unit tests in the new crate covering parsing, analysis, formatting, and end-to-end file round-trips
- Integration test updated to verify the `.md` file is generated with expected sections
- To test manually: `cargo run -p turborepo -- run build --profile=build.trace` then inspect `build.trace.md`