### PR TITLE
perf: Pre-compile glob exclusion filter and cache path prefix in file hashing

### DIFF
--- a/crates/turborepo-wax/src/walk/mod.rs
+++ b/crates/turborepo-wax/src/walk/mod.rs
@@ -82,15 +82,12 @@ use std::{
 use thiserror::Error;
 use walkdir::{DirEntry, Error, WalkDir};
 
-pub use crate::walk::glob::{GlobEntry, GlobWalker};
+pub use crate::walk::glob::{FilterAny, GlobEntry, GlobWalker};
 use crate::{
     BuildError, Pattern,
-    walk::{
-        filter::{
-            CancelWalk, HierarchicalIterator, Isomeric, SeparatingFilter, SeparatingFilterInput,
-            Separation, TreeResidue, WalkCancellation,
-        },
-        glob::FilterAny,
+    walk::filter::{
+        CancelWalk, HierarchicalIterator, Isomeric, SeparatingFilter, SeparatingFilterInput,
+        Separation, TreeResidue, WalkCancellation,
     },
 };
 
@@ -902,6 +899,24 @@ pub trait FileIterator:
             input: self,
             filter,
         })
+    }
+
+    /// Filters file entries against a pre-compiled [`FilterAny`].
+    ///
+    /// This is the pre-compiled equivalent of [`not`]. Use this when the same
+    /// exclusion patterns are applied to multiple iterators to avoid
+    /// re-compiling the patterns each time.
+    ///
+    /// [`FilterAny`]: crate::walk::glob::FilterAny
+    /// [`not`]: crate::walk::FileIterator::not
+    fn not_any(self, filter: FilterAny) -> Not<Self>
+    where
+        Self: Sized,
+    {
+        Not {
+            input: self,
+            filter,
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- **Pre-compile glob exclusion patterns once** in `globwalk_internal` instead of cloning `Vec<Glob>` per include pattern and re-compiling each time. Adds `FileIterator::not_any` to wax to accept a pre-compiled `FilterAny` directly.
- **Cache the git-root-to-package path prefix** in `hash_objects` so each file does a cheap `strip_prefix` instead of full `relative_path_between` path component iteration.

## Why

CPU profiling showed `get_package_file_hashes` as the dominant hotspot (538% self time). Within that path, `globwalk_internal` was cloning and re-compiling exclusion `Glob` patterns (each containing a compiled `Regex`) for every include glob — O(N includes × M excludes) regex clones + N recompilations per globwalk call. In `hash_objects`, the path prefix computation was doing redundant component iteration for every file when the relationship between git root and package path is constant.

## Benchmarks

Measured with `hyperfine --warmup 5` across three monorepos of different sizes:

**~300 packages:**
```
Benchmark 1 (patched):  6.584s ± 0.144s
Benchmark 2 (baseline): 7.087s ± 0.141s
  → 1.08 ± 0.03 times faster
```

**~100 packages:**
```
Benchmark 1 (patched):  1.378s ± 0.104s
Benchmark 2 (baseline): 1.414s ± 0.059s
  → 1.03 ± 0.09 times faster
```

**~6 packages:**
```
Benchmark 1 (patched):  643.8ms ± 65.1ms
Benchmark 2 (baseline): 671.1ms ± 99.8ms
  → 1.04 ± 0.19 (within noise)
```

Improvements scale with package count as expected since both optimizations eliminate per-package redundant work.

## Testing

All existing tests pass across `wax`, `globwalk`, `turborepo-scm`, and `turborepo-task-hash`.