### PR TITLE
ci: Stop failing cargo audit on unmaintained crates

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Run cargo audit
         run: |
           cargo install cargo-audit --locked --quiet
-          cargo audit --deny warnings
+          cargo audit --deny unsound --deny yanked
 
   js_audit:
     name: JS security audit

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -381,7 +381,7 @@ jobs:
       - name: Rust dependency audit
         run: |
           cargo install cargo-audit --locked --quiet
-          cargo audit --deny warnings
+          cargo audit --deny unsound --deny yanked
 
       - name: JS dependency audit
         run: pnpm audit --prod --audit-level low


### PR DESCRIPTION
## Summary

- Replace `cargo audit --deny warnings` with `--deny unsound --deny yanked` so unmaintained crate advisories don't fail CI while actual vulnerabilities, unsound code, and yanked versions still do.