### PR TITLE
perf: Optimize pnpm lockfile transitive closure resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7361,6 +7361,7 @@ dependencies = [
  "biome_formatter",
  "biome_json_formatter",
  "biome_json_parser",
+ "dashmap 5.5.3",
  "insta",
  "itertools 0.10.5",
  "nom",

--- a/crates/turborepo-lockfiles/Cargo.toml
+++ b/crates/turborepo-lockfiles/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 biome_formatter = { workspace = true }
 biome_json_formatter = { workspace = true }
 biome_json_parser = { workspace = true }
+dashmap = { workspace = true }
 itertools = { workspace = true }
 nom = "7"
 pest = "2.8.6"

--- a/crates/turborepo-lockfiles/src/pnpm/mod.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/mod.rs
@@ -29,9 +29,10 @@ enum VersionFormat {
     Float,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 enum SupportedLockfileVersion {
     V5,
+    #[default]
     V6,
     // As of pnpm@9.0.0-rc.0 the lockfile version will now match the pnpm version
     // Lockfile version 7.0 and 9.0 are both the same version


### PR DESCRIPTION
## Summary

- Optimizes lockfile dependency resolution for pnpm repositories, reducing `transitive_closure` wall time by ~20%
- Five targeted changes to `turborepo-lockfiles` that eliminate redundant work in the hot path

## Benchmarks

**Large pnpm monorepo (~1000 packages):**
```
Benchmark 1 (this branch):   5.924s ± 0.231s
Benchmark 2 (main):          7.117s ± 0.147s

Summary: 1.20 ± 0.05 times faster
```

**Medium pnpm monorepo:**
```
Benchmark 1 (this branch):   1.326s ± 0.059s
Benchmark 2 (main):          1.548s ± 0.227s

Summary: 1.17 ± 0.18 times faster
```

User-space CPU time dropped from ~45s to ~25s on the large repo, confirming the reduction is in compute, not I/O.

## What changed

All changes are in `crates/turborepo-lockfiles`.

**Cross-workspace resolve cache** (`src/lib.rs`): `all_transitive_closures` runs workspace closures in parallel via rayon, but each workspace independently resolves the same transitive packages. A shared `DashMap` cache now deduplicates `resolve_package` calls across workspaces, reducing 726k calls to the number of unique `(workspace, name, specifier)` triples.

**HashMap for package/snapshot lookups** (`src/pnpm/data.rs`): Switched the `packages` and `snapshots` maps from `BTreeMap` to `HashMap` for O(1) lookups on the hot path. A custom serde serializer converts back to `BTreeMap` for deterministic YAML output.

**Pre-built dependency index** (`src/pnpm/data.rs`): The `all_dependencies` method was called 329k times, each time chaining iterators across dependency maps and cloning every key/value. A `HashMap<String, HashMap<String, String>>` is now built once at parse time and lookups just clone from the cache.

**Reusable key buffer** (`src/pnpm/data.rs`): `format_key` allocated a new `String` via `format!()` on every call (~2M allocations). `resolve_package` and `resolve_specifier` now share a single `String` buffer across all their internal lookups.

**Cached lockfile version** (`src/pnpm/data.rs`, `src/pnpm/mod.rs`): `version()` was recomputed via string matching on every call. Now computed once at parse time and stored.