### PR TITLE
perf: Improve transitive dependency resolution cache sharing across workspaces

### DIFF
--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -468,7 +468,6 @@ struct GlobalFields<'a> {
 }
 
 impl crate::Lockfile for PnpmLockfile {
-    #[tracing::instrument(skip(self))]
     fn resolve_package(
         &self,
         workspace_path: &str,
@@ -520,7 +519,6 @@ impl crate::Lockfile for PnpmLockfile {
         }
     }
 
-    #[tracing::instrument(skip(self))]
     fn all_dependencies(
         &self,
         key: &str,


### PR DESCRIPTION
## Summary

The `ResolveCache` used during pnpm lockfile transitive closure computation keyed entries by `(workspace_path, package_name, specifier)`. This meant two workspaces resolving the same transitive sub-dependency (e.g. `lodash@4.17.21`) would each miss the cache and resolve independently — the workspace path made the keys differ. For a monorepo with N workspaces sharing a common dependency tree, this caused O(N*D) resolution work instead of O(N+D).

The fix splits cache key strategy by resolution phase:
- **Direct workspace deps** (root level): include `workspace_path` in the key, since `resolve_specifier` needs the workspace's importer entry.
- **Transitive sub-deps** (recursive): omit `workspace_path`, since `resolve_package` resolves these by direct lockfile key lookup, independent of which workspace started the traversal.

Also removes `#[tracing::instrument]` from `resolve_package` (~332k calls) and `all_dependencies` (~329k calls). At this call volume, span creation/entry/exit overhead is significant — `all_dependencies` is a single HashMap lookup where the tracing cost exceeded the function body.

## Benchmarks

All benchmarks are `turbo run <task> --skip-infer --no-daemon --dry` with `--warmup 5`.

**Repo A — ~1000 packages (pnpm)**
| | Before | After | Speedup |
|---|---|---|---|
| Wall clock | 4.210s ± 0.087s | 2.165s ± 0.034s | **1.94x** |
| User time | 29.624s | 3.705s | **8.0x** (CPU work) |

**Repo B — ~100 packages (pnpm)**
| | Before | After | Speedup |
|---|---|---|---|
| Wall clock | 1.376s ± 0.116s | 1.323s ± 0.092s | 1.04x |
| User time | 3.522s | 0.801s | **4.4x** (CPU work) |

**Repo C — ~6 packages (pnpm)**
| | Before | After | Speedup |
|---|---|---|---|
| Wall clock | 694.6ms ± 85.4ms | 669.5ms ± 37.0ms | ~1.0x (within noise) |

The improvement scales with the number of workspaces sharing transitive dependencies, which is why the 1000-package repo sees the largest gain. Repo B shows a dramatic CPU reduction (4.4x) that translates to a modest wall-clock improvement because the old code hid redundant work behind rayon parallelism, and other costs (globwalk, git operations) now dominate.