### PR TITLE
perf: Parallelize package.json loading and reduce builder allocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7502,6 +7502,7 @@ dependencies = [
  "node-semver",
  "petgraph 0.6.5",
  "pretty_assertions",
+ "rayon",
  "regex",
  "rust-ini",
  "serde",

--- a/crates/turborepo-repository/Cargo.toml
+++ b/crates/turborepo-repository/Cargo.toml
@@ -23,6 +23,7 @@ lazy-regex = "2.5.0"
 miette = { workspace = true }
 node-semver = "2.2.0"
 petgraph = { workspace = true }
+rayon = "1"
 regex = { workspace = true }
 rust-ini = "0.20.0"
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
## Summary

Parallelize the package.json loading phase and reduce allocations in the package graph builder.

### Benchmarks (`--dry` runs, `--skip-infer`, 10 runs each, 5 warmup)

| Repo | Packages | Tasks | Before | After | Delta |
|------|----------|-------|--------|-------|-------|
| Large | ~1000 | 1690 | 2.107s ± 0.033s | 2.128s ± 0.203s | ~neutral (noisy) |
| Medium | ~120 | ~200 | 1.292s ± 0.071s | 1.230s ± 0.078s | **1.05x faster** |
| Small | ~5 | ~5 | 821.1ms ± 18.0ms | 812.7ms ± 15.6ms | **1.01x faster** |

The medium repo shows the clearest improvement — it has enough packages for rayon to help but isn't dominated by git subprocess overhead like the large repo.

### Changes

**Parallel package.json loading**: `parse_package_jsons` previously loaded and parsed each package.json file sequentially in a loop. Each `PackageJson::load` call does disk I/O (`read_to_string`) and CPU-bound JSON parsing (biome). These are independent per-package, so the loop is replaced with `rayon::par_iter` to parallelize across all available cores. The sequential `add_json` processing that mutates the builder is unchanged.

**Entry API in `add_json`**: The old code called `self.workspaces.insert(name.clone(), entry)` unconditionally, cloning the `PackageName` on every call. On the error path (duplicate workspace), it then did a second `get` + `clone` to retrieve the path. Now uses `HashMap::entry()` to avoid the clone on the success path (only clones once for `add_node`) and avoids the redundant lookup on the error path.

**Capacity pre-allocation**: `workspaces` and `node_lookup` HashMaps are now pre-allocated with `reserve(package_jsons.len())` before the `add_json` loop, avoiding rehashing as entries are inserted.