### PR TITLE
perf: Share HTTP client and improve profile instrumentation

### DIFF
--- a/crates/turborepo-lib/src/commands/mod.rs
+++ b/crates/turborepo-lib/src/commands/mod.rs
@@ -45,6 +45,7 @@ pub struct CommandBase {
 }
 
 impl CommandBase {
+    #[tracing::instrument(skip_all)]
     pub fn new(
         args: Args,
         repo_root: AbsoluteSystemPathBuf,
@@ -76,6 +77,7 @@ impl CommandBase {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     pub fn load_config(
         repo_root: &AbsoluteSystemPath,
         args: &Args,

--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -7,6 +7,7 @@ use turborepo_ui::sender::UISender;
 
 use crate::{commands::CommandBase, run, run::builder::RunBuilder};
 
+#[tracing::instrument(skip_all)]
 pub async fn run(base: CommandBase, telemetry: CommandEventBuilder) -> Result<i32, run::Error> {
     let signal = get_signal()?;
     let handler = SignalHandler::new(signal);

--- a/crates/turborepo-lib/src/microfrontends.rs
+++ b/crates/turborepo-lib/src/microfrontends.rs
@@ -30,6 +30,7 @@ struct ConfigInfo {
 
 impl MicrofrontendsConfigs {
     /// Constructs a collection of configurations from disk
+    #[tracing::instrument(skip_all)]
     pub fn from_disk(
         repo_root: &AbsoluteSystemPath,
         package_graph: &PackageGraph,

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -63,6 +63,7 @@ pub struct RunBuilder {
 }
 
 impl RunBuilder {
+    #[tracing::instrument(skip_all)]
     pub fn new(base: CommandBase) -> Result<Self, Error> {
         let api_client = base.api_client()?;
 
@@ -405,6 +406,7 @@ impl RunBuilder {
         })
     }
 
+    #[tracing::instrument(skip_all)]
     fn build_engine<'a>(
         &self,
         pkg_dep_graph: &PackageGraph,

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -573,6 +573,7 @@ impl Run {
         info!("Proxy shutdown complete, proceeding with visitor cleanup");
     }
 
+    #[instrument(skip_all)]
     async fn execute_visitor(
         &self,
         ui_sender: Option<UISender>,
@@ -735,6 +736,7 @@ impl Run {
         Ok(exit_code)
     }
 
+    #[instrument(skip_all)]
     pub async fn run(&self, ui_sender: Option<UISender>, is_watch: bool) -> Result<i32, Error> {
         let proxy_shutdown = self.start_proxy_if_needed().await?;
         self.setup_cache_shutdown_handler();

--- a/crates/turborepo-repository/src/inference.rs
+++ b/crates/turborepo-repository/src/inference.rs
@@ -73,6 +73,7 @@ impl RepoState {
     /// * `reference_dir`: Turbo's invocation directory
     ///
     /// returns: Result<RepoState, Error>
+    #[tracing::instrument(skip_all)]
     pub fn infer(reference_dir: &AbsoluteSystemPath) -> Result<Self, Error> {
         reference_dir
             .ancestors()

--- a/crates/turborepo-run-summary/src/tracker.rs
+++ b/crates/turborepo-run-summary/src/tracker.rs
@@ -343,6 +343,7 @@ impl<'a> RunSummary<'a> {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     fn close_dry_run(
         &mut self,
         pkg_dep_graph: &PackageGraph,
@@ -358,6 +359,7 @@ impl<'a> RunSummary<'a> {
         self.format_and_print_text(pkg_dep_graph, ui)
     }
 
+    #[tracing::instrument(skip_all)]
     fn format_and_print_text(
         &mut self,
         pkg_dep_graph: &PackageGraph,

--- a/crates/turborepo-task-executor/src/exec.rs
+++ b/crates/turborepo-task-executor/src/exec.rs
@@ -603,6 +603,7 @@ pub struct DryRunExecutor<H> {
 }
 
 impl<H: HashTrackerProvider> DryRunExecutor<H> {
+    #[tracing::instrument(skip_all, fields(task = %self.task_id))]
     pub async fn execute_dry_run(&self, tracker: TaskTracker<()>) -> Result<(), InternalError> {
         if let Ok(Some(status)) = self.task_cache.exists().await {
             self.hash_tracker


### PR DESCRIPTION
## Summary

Two changes to improve turbo startup performance and profiling accuracy:

1. **Share a single `reqwest::Client`** across telemetry, API, and cache operations — eliminates redundant TLS initialization that was costing ~260ms on startup
2. **Improve `--profile` instrumentation coverage** — moves chrome tracing enablement earlier and instruments key functions so profiles capture the full wall-clock time

## Why the shared client matters

Previously, three separate `reqwest::Client` instances were built during startup, each independently initializing a TLS backend (loading system certs, creating crypto context):

- `initialize_telemetry_client` → `AnonAPIClient::new()` (~100ms)
- `RunBuilder::new` → `APIClient::new()` with 2 clients (~160ms)

That's ~260ms of sequential TLS initialization before any real work begins. Now a single client is built once in `cli::run()` and shared via `new_with_client()` constructors. Per-request timeouts replace per-client timeouts, preserving the existing timeout semantics.

## Benchmarks

Measured with `hyperfine --warmup 5` across three differently-sized monorepos:

| Repo | Before | After | Speedup |
|---|---|---|---|
| Small (1 package) | 1.037s ± 0.079s | 868ms ± 27ms | **1.16x** |
| Medium (~10 packages) | 1.348s ± 0.065s | 1.299s ± 0.052s | **1.04x** |
| Large (~50 packages) | 2.022s ± 0.152s | 1.933s ± 0.136s | **1.05x** |

The small repo shows the largest relative improvement because TLS init is a larger fraction of total runtime. In larger repos, git subprocess and package graph work dominate.

## Profiling improvements

The `--profile` flag previously captured only ~50% of wall-clock time. This was caused by:

1. Chrome tracing was enabled too late — after clap parsing, config resolution, and repo inference
2. Many key functions in the startup and run paths lacked `#[tracing::instrument]`

Now the shim's argument parser extracts `--profile`/`--anon-profile` early and enables chrome tracing before any repo inference or CLI work begins. Profiles now capture the full run duration.

## Testing

- 7 new regression tests for API client operations (get_user, get_teams, get_caching_status, put/fetch/exists artifact, timeout configurations)
- All 18 `turborepo-api-client` tests pass
- All 46 `turborepo-shim` tests pass
- Zero-cost instrumentation when `--profile` is not passed