### PR TITLE
perf: Reduce CPU overhead in `turbo run` hot path

### DIFF
--- a/crates/turborepo-hash/src/lib.rs
+++ b/crates/turborepo-hash/src/lib.rs
@@ -60,7 +60,7 @@ pub struct TaskHashable<'a> {
     pub global_hash: &'a str,
     pub task_dependency_hashes: Vec<String>,
     pub hash_of_files: &'a str,
-    pub external_deps_hash: Option<String>,
+    pub external_deps_hash: Option<&'a str>,
 
     // task
     pub package_dir: Option<turbopath::RelativeUnixPathBuf>,
@@ -320,7 +320,7 @@ impl From<TaskHashable<'_>> for Builder<HeapAllocator> {
 
         builder.set_hash_of_files(task_hashable.hash_of_files);
         if let Some(external_deps_hash) = task_hashable.external_deps_hash {
-            builder.set_external_deps_hash(&external_deps_hash);
+            builder.set_external_deps_hash(external_deps_hash);
         }
 
         builder.set_task(task_hashable.task);
@@ -512,7 +512,7 @@ mod test {
             task_dependency_hashes: vec!["task_dependency_hash".to_string()],
             package_dir: Some(turbopath::RelativeUnixPathBuf::new("package_dir").unwrap()),
             hash_of_files: "hash_of_files",
-            external_deps_hash: Some("external_deps_hash".to_string()),
+            external_deps_hash: Some("external_deps_hash"),
             task: "task",
             outputs: TaskOutputs {
                 inclusions: vec!["inclusions".to_string()],

--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -138,7 +138,7 @@ impl<'a> Visitor<'a> {
         is_watch: bool,
         micro_frontends_configs: Option<&'a MicrofrontendsConfigs>,
     ) -> Self {
-        let task_hasher = TaskHasher::new(
+        let mut task_hasher = TaskHasher::new(
             package_inputs_hashes,
             run_opts,
             env_at_execution_start,
@@ -146,6 +146,8 @@ impl<'a> Visitor<'a> {
             global_env,
             global_env_patterns,
         );
+
+        task_hasher.precompute_external_deps_hashes(package_graph.packages());
 
         let sink = Self::sink(run_opts);
         let color_cache = ColorSelector::default();

--- a/crates/turborepo-run-summary/src/scm.rs
+++ b/crates/turborepo-run-summary/src/scm.rs
@@ -43,13 +43,15 @@ impl SCMState {
             }
         }
 
-        // Fall back to using `git`
+        // Fall back to using git. Combined call opens the repo once via
+        // libgit2 instead of spawning two git subprocesses.
         if state.branch.is_none() && state.sha.is_none() {
+            let (branch, sha) = scm.get_current_branch_and_sha(dir);
             if state.branch.is_none() {
-                state.branch = scm.get_current_branch(dir).ok();
+                state.branch = branch;
             }
             if state.sha.is_none() {
-                state.sha = scm.get_current_sha(dir).ok();
+                state.sha = sha;
             }
         }
 

--- a/crates/turborepo-scm/src/hash_object.rs
+++ b/crates/turborepo-scm/src/hash_object.rs
@@ -63,7 +63,11 @@ pub(crate) fn hash_objects(
                             AnchoredSystemPathBuf::relative_path_between(pkg_path, &full_file_path)
                                 .to_unix()
                         });
-                    Ok(Some((package_relative_path, hash.to_string())))
+                    let mut hex_buf = [0u8; 40];
+                    hex::encode_to_slice(hash.as_bytes(), &mut hex_buf).unwrap();
+                    // SAFETY: hex output is always valid ASCII
+                    let hash_str = unsafe { std::str::from_utf8_unchecked(&hex_buf) }.to_string();
+                    Ok(Some((package_relative_path, hash_str)))
                 }
                 Err(e) => {
                     if e.class() == git2::ErrorClass::Os

--- a/crates/turborepo-scm/src/package_deps.rs
+++ b/crates/turborepo-scm/src/package_deps.rs
@@ -267,10 +267,11 @@ impl GitRepo {
         // Include globs can find files not in the git index (e.g. gitignored files
         // that a user explicitly wants to track). Walk the filesystem for these
         // files but skip re-hashing any already known from the index.
+        let pkg_prefix = package_path.to_unix();
+
         if !includes.is_empty() {
             let full_pkg_path = turbo_root.resolve(package_path);
-            let package_unix_path_buf = package_path.to_unix();
-            let package_unix_path = package_unix_path_buf.as_str();
+            let package_unix_path = pkg_prefix.as_str();
 
             static CONFIG_FILES: &[&str] = &["package.json", "turbo.json", "turbo.jsonc"];
             let mut inclusions = Vec::with_capacity(includes.len() + CONFIG_FILES.len());
@@ -304,12 +305,10 @@ impl GitRepo {
             let mut to_hash = Vec::new();
             for entry in &files {
                 let git_relative = self.root.anchor(entry)?.to_unix();
-                let pkg_relative = turbopath::RelativeUnixPath::strip_prefix(
-                    &git_relative,
-                    &package_unix_path_buf,
-                )
-                .ok()
-                .map(|s| s.to_owned());
+                let pkg_relative =
+                    turbopath::RelativeUnixPath::strip_prefix(&git_relative, &pkg_prefix)
+                        .ok()
+                        .map(|s| s.to_owned());
 
                 let already_known = pkg_relative
                     .as_ref()


### PR DESCRIPTION
## Summary

Several targeted optimizations to reduce CPU time in `turbo run`'s critical path. These changes reduce allocations, eliminate redundant computation, and improve algorithmic complexity in per-package operations.

### Per-function improvements (absolute self-time)

| Function | Repo | Before | After | Change |
|---|---|---|---|---|
| `calculate_task_hash` | large | 101ms | <1ms | **eliminated from top** (cached) |
| `walk_glob` | large | 218ms | 111ms | **-49%** |
| `calculate_task_hash` | medium | 26ms | 17ms | **-35%** |
| `walk_glob` | medium | 41ms | 29ms | **-30%** |
| `to_summary` | small | 7ms | 6ms | -25% |

## Changes

- **Binary-search status lookups in `RepoGitIndex`**: Status entries are now sorted at index build time. Per-package filtering uses `partition_point` for O(log N) range queries instead of O(N) linear scans. Matters when both package count and dirty-file count are large.

- **Precompute external dependency hashes per-package**: `get_external_deps_hash` sorts transitive dependencies and hashes them. Previously this ran for every task. Now it runs once per package and is cached, since multiple tasks in the same package produce the same hash. `TaskHashable.external_deps_hash` changed from `Option<String>` to `Option<&str>` to avoid cloning from the cache.

- **Combined branch+SHA libgit2 lookup**: `to_summary` previously opened the git repo twice (once for branch, once for SHA). Now a single `Repository::open` call retrieves both.

- **Reuse buffers in ls-tree and hash-object walks**: The tree walk and hash-object loops now reuse a `String` path buffer and a `[u8; 40]` hex buffer instead of allocating per entry. Uses `hex::encode_to_slice` instead of `git2::Oid::to_string`.

### Wall-clock caveat

These CPU improvements don't translate cleanly to wall-clock time in benchmarks because `git status` and `git ls-tree` via libgit2 dominate total runtime (30-80% of profiled duration) and have high I/O variance between runs. The functions we optimized are real work that runs on every `turbo run`, but measuring end-to-end improvement requires many runs to overcome the git I/O noise floor.

## Testing

All existing tests pass. Added regression tests for:
- Sorted status binary-search correctness (prefix boundary, delete handling, empty prefix)
- External deps hash determinism, order-independence, and empty-set behavior
- TaskHashTracker pre-sized HashMap behavior