### PR TITLE
ci: Declare explicit token permissions for docs and maintenance workflows

### DIFF
--- a/.github/workflows/docs-alias-failure-notification.yml
+++ b/.github/workflows/docs-alias-failure-notification.yml
@@ -10,6 +10,9 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+
 jobs:
   notify-failure:
     name: "Notify Slack on Docs Alias Failure"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - "docs/**"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -8,6 +8,9 @@ name: LSP
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-rust:
     name: "Build Rust"

--- a/.github/workflows/turborepo-top-issues.yml
+++ b/.github/workflows/turborepo-top-issues.yml
@@ -5,6 +5,11 @@ on:
     - cron: "0 13 * * 1" # Every Monday at 1PM UTC (9AM EST)
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
 jobs:
   run:
     # if: github.repository_owner == 'vercel'

--- a/.github/workflows/update-examples-on-release.yml
+++ b/.github/workflows/update-examples-on-release.yml
@@ -3,6 +3,10 @@ name: Update examples to latest
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-examples-pr:
     name: "Update examples PR"


### PR DESCRIPTION
## Summary\n- add explicit `permissions` to five workflows currently relying on implicit defaults\n- set read-only scopes for docs/lsp/reporting workflows\n- set explicit write scopes for the release-time workflow that pushes a branch and opens a PR\n\n## Changed workflows\n- `.github/workflows/docs-alias-failure-notification.yml` (`contents: read`)\n- `.github/workflows/docs.yml` (`contents: read`)\n- `.github/workflows/lsp.yml` (`contents: read`)\n- `.github/workflows/turborepo-top-issues.yml` (`contents: read`, `issues: read`, `pull-requests: read`)\n- `.github/workflows/update-examples-on-release.yml` (`contents: write`, `pull-requests: write`)\n\n## Why\nExplicit permissions improve security posture by minimizing token scope and documenting intended access for each workflow.\n\n## Notes\n- configuration-only changes; no build/test/release logic changed\n