### PR TITLE
chore: Add tracing spans to uninstrumented hot path functions

### DIFF
--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -605,6 +605,7 @@ impl APIClient {
     /// Builds a shared HTTP client with optional connect timeout. This is
     /// the single TLS initialization point — all consumers should share the
     /// resulting client.
+    #[tracing::instrument(skip_all)]
     pub fn build_http_client(connect_timeout: Option<Duration>) -> Result<reqwest::Client> {
         let mut builder = reqwest::Client::builder();
         if let Some(dur) = connect_timeout {

--- a/crates/turborepo-engine/src/execute.rs
+++ b/crates/turborepo-engine/src/execute.rs
@@ -63,6 +63,7 @@ impl<T: TaskDefinitionInfo + Clone + Send + Sync + 'static> Engine<Built, T> {
     // finish even once a task sends back the stop signal. This is suboptimal
     // since it would mean the visitor would need to also track if
     // it is cancelled :)
+    #[tracing::instrument(skip_all)]
     pub async fn execute(
         self: Arc<Self>,
         options: ExecutionOptions,

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -614,6 +614,7 @@ impl Run {
 
         rayon::scope(|s| {
             s.spawn(|_| {
+                let _span = tracing::info_span!("calculate_file_hashes_task").entered();
                 file_hash_result = Some(PackageInputsHashes::calculate_file_hashes(
                     &self.scm,
                     self.engine.tasks(),
@@ -625,6 +626,7 @@ impl Run {
                 ));
             });
             s.spawn(|_| {
+                let _span = tracing::info_span!("get_internal_deps_hash_task").entered();
                 internal_deps_result = Some(
                     internal_dep_paths
                         .map(|dep_paths| {
@@ -639,6 +641,7 @@ impl Run {
                 );
             });
             s.spawn(|_| {
+                let _span = tracing::info_span!("collect_global_file_hash_inputs_task").entered();
                 global_file_result = Some(collect_global_file_hash_inputs(
                     root_workspace,
                     &self.repo_root,


### PR DESCRIPTION
## Summary

Adds `--profile` visibility to several functions that were previously invisible in profile output, making it easier to identify bottlenecks in `turbo run`.