### PR TITLE
fix: Use correct pnpm version in library release workflow

### DIFF
--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -43,7 +43,7 @@ jobs:
             install: |
               microdnf install -y gcc gcc-c++ git tar xz
               curl https://sh.rustup.rs -sSf | bash -s -- -y
-              npm i -g pnpm@11.5.1
+              npm i -g pnpm@10.28.0
               mkdir ../zig
               curl --show-error --location https://ziglang.org/download/0.14.0/zig-linux-x86_64-0.14.0.tar.xz | tar -J -xf - -C ../zig --strip-components 1
               export PATH=$PATH:$(pwd)/../zig


### PR DESCRIPTION
## Summary

- The `x86_64-unknown-linux-gnu` build target in the library release workflow was installing `pnpm@11.5.1`, which doesn't exist on the npm registry (pnpm 11 is still in pre-release). This caused `npm i -g pnpm@11.5.1` to fail with `ETARGET`, breaking all `@turbo/repository` releases.
- Updated to `pnpm@10.28.0` to match the version in the root `package.json`.