### PR TITLE
fix: Fix library release workflow for Trusted Publishing OIDC

### DIFF
--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   id-token: write # Required for npm Trusted Publishing using OIDC
   contents: write
+  pull-requests: write
 
 jobs:
   build:
@@ -136,16 +137,45 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [build]
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      branch: ${{ steps.version.outputs.branch }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.14.0"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Ensure npm version
+        run: npm install -g npm@11.5.1
+
       - name: Configure git
         run: |
           git config --global user.name 'Turbobot'
           git config --global user.email 'turbobot@vercel.com'
+
+      - name: Bump version
+        id: version
+        run: |
+          CURRENT_VERSION=$(jq -r .version packages/turbo-repository/js/package.json)
+          NEXT_VERSION=$(cd packages/turbo-repository/js && npm version prerelease --preid canary --no-git-tag-version)
+          NEXT_VERSION="${NEXT_VERSION#v}"
+          echo "Bumping all packages from ${CURRENT_VERSION} to ${NEXT_VERSION}"
+          cd packages/turbo-repository && bash scripts/bump-version.sh "${NEXT_VERSION}"
+          cd "$GITHUB_WORKSPACE"
+          BRANCH="library-release/${NEXT_VERSION}"
+          git checkout -b "${BRANCH}"
+          git add -A
+          git commit -m "library release: ${NEXT_VERSION}"
+          git push origin "${BRANCH}"
+          echo "version=${NEXT_VERSION}" >> $GITHUB_OUTPUT
+          echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
 
       - name: Download Artifacts
         uses: actions/download-artifact@v4
@@ -204,3 +234,42 @@ jobs:
           npm publish -ddd --tag ${TAG} --access public turbo-repository-win32-arm64-msvc-${VERSION}.tgz
           npm publish -ddd --tag ${TAG} --access public turbo-repository-win32-x64-msvc-${VERSION}.tgz
           npm publish -ddd --tag ${TAG} --access public turbo-repository-${VERSION}.tgz
+
+  create-release-pr:
+    name: Create Release PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [package]
+    if: ${{ !inputs.dry_run }}
+    steps:
+      - name: Create PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ needs.package.outputs.version }}"
+          BRANCH="${{ needs.package.outputs.branch }}"
+          gh pr create \
+            --repo "${{ github.repository }}" \
+            --title "release(library): ${VERSION}" \
+            --body "Bumps \`@turbo/repository\` packages to \`${VERSION}\`." \
+            --head "${BRANCH}" \
+            --base main
+          PR_NUM=$(gh pr view "${BRANCH}" --repo "${{ github.repository }}" --json number --jq '.number')
+          gh pr merge "$PR_NUM" --repo "${{ github.repository }}" --auto --squash
+
+  cleanup-on-failure:
+    name: Cleanup Failed Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [package]
+    if: ${{ always() && needs.package.result == 'failure' }}
+    steps:
+      - name: Delete staging branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ needs.package.outputs.branch }}"
+          if [ -n "${BRANCH}" ]; then
+            echo "Cleaning up branch ${BRANCH}..."
+            gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/${BRANCH}" || echo "Branch may already be deleted"
+          fi


### PR DESCRIPTION
## Summary

The `@turbo/repository` library release workflow was failing because it lacked the setup needed for npm Trusted Publishing via OIDC.

Three issues fixed:

- **Missing Node/npm versions**: Trusted Publishing requires npm >=11.5.1 and Node >=22.14.0. The `package` job had no `setup-node` step and was using whatever shipped with `ubuntu-latest`, which is too old for OIDC auto-detection. Added `actions/setup-node@v4` with Node 22.14.0 and pinned npm to 11.5.1 (matching `turborepo-release.yml`).

- **No version bumping**: The workflow published whatever version was already committed in the `package.json` files. After the first successful publish, every subsequent run would fail with "already published." Added a version bump step that uses the existing `bump-version.sh` script to increment all 9 packages (8 platform + 1 meta) in lockstep to the next `0.0.1-canary.X` version.

- **No release PR**: The version bump wasn't being persisted back to `main`. Added a staging branch pattern (mirroring `turborepo-release.yml`) where the bump is committed to a `library-release/<version>` branch, and a `create-release-pr` job opens a PR with auto-merge back to `main`. Also added a `cleanup-on-failure` job to delete the staging branch if the publish fails.

## Testing

This is a CI workflow change. To verify: trigger the workflow with `dry_run: true` and confirm the version bump + staging branch are created correctly without publishing.