### PR TITLE
fix: Use repo setup-node action in library release package job

### DIFF
--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -147,13 +147,15 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: ./.github/actions/setup-node
         with:
-          node-version: "22.14.0"
-          registry-url: "https://registry.npmjs.org"
+          enable-corepack: false
+          package-install: false
 
-      - name: Ensure npm version
-        run: npm install -g npm@11.5.1
+      - name: Configure npm
+        run: |
+          npm install -g npm@11.5.1
+          npm config set registry https://registry.npmjs.org
 
       - name: Configure git
         run: |


### PR DESCRIPTION
## Summary

- The `package` job in the library release workflow used bare `actions/setup-node@v4`, which doesn't install pnpm. `bump-version.sh` calls `pnpm version`, causing exit code 127 (command not found).
- Switches to the repo's `.github/actions/setup-node` composite action (which includes `pnpm/action-setup@v4`), matching every other workflow in the repo.

Fixes https://github.com/vercel/turborepo/actions/runs/22355224749/job/64694921410