### PR TITLE
perf: Remove a `serde(flatten)` and reorder untagged enum in pnpm lockfile parser

### DIFF
--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -108,6 +108,18 @@ pub struct ProjectSnapshot {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase", untagged)]
 pub enum DependencyInfo {
+    // V6 is listed first so serde tries it before PreV6. Since all modern
+    // lockfiles (v6, v7, v9) use the V6 format, this avoids a failed
+    // PreV6 parse attempt + backtrack for every importer entry.
+    #[serde(rename_all = "camelCase")]
+    V6 {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        dependencies: Option<Map<String, Dependency>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        optional_dependencies: Option<Map<String, Dependency>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        dev_dependencies: Option<Map<String, Dependency>>,
+    },
     #[serde(rename_all = "camelCase")]
     PreV6 {
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -118,15 +130,6 @@ pub enum DependencyInfo {
         optional_dependencies: Option<Map<String, String>>,
         #[serde(skip_serializing_if = "Option::is_none")]
         dev_dependencies: Option<Map<String, String>>,
-    },
-    #[serde(rename_all = "camelCase")]
-    V6 {
-        #[serde(skip_serializing_if = "Option::is_none")]
-        dependencies: Option<Map<String, Dependency>>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        optional_dependencies: Option<Map<String, Dependency>>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        dev_dependencies: Option<Map<String, Dependency>>,
     },
 }
 
@@ -148,16 +151,42 @@ pub struct PackageSnapshot {
     #[serde(skip_serializing_if = "Option::is_none")]
     version: Option<String>,
 
-    // In lockfile v7, this portion of package is stored in the top level
-    // `snapshots` map as opposed to being stored inline.
-    #[serde(flatten)]
-    snapshot: PackageSnapshotV7,
+    // In lockfile v7+, these fields move to the top-level `snapshots` map.
+    // In pre-v7, they're inline here. All fields from PackageSnapshotV7
+    // are inlined to avoid #[serde(flatten)] which forces serde into a
+    // slow buffered deserialization path for every package entry.
+    #[serde(skip_serializing_if = "is_false", default)]
+    optional: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dependencies: Option<Map<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    optional_dependencies: Option<Map<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    transitive_peer_dependencies: Option<Vec<String>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     patched: Option<bool>,
 
-    #[serde(flatten)]
-    other: Map<String, serde_yaml_ng::Value>,
+    // Fields that pnpm writes but turborepo doesn't use at runtime.
+    // Enumerated explicitly to avoid a #[serde(flatten)] catch-all map.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    engines: Option<serde_yaml_ng::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cpu: Option<serde_yaml_ng::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    os: Option<serde_yaml_ng::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    libc: Option<serde_yaml_ng::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    deprecated: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    has_bin: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bundled_dependencies: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    peer_dependencies: Option<Map<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    peer_dependencies_meta: Option<serde_yaml_ng::Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
@@ -238,7 +267,7 @@ impl PnpmLockfile {
             for (key, entry) in packages {
                 index
                     .entry(key.clone())
-                    .or_insert_with(|| entry.snapshot.dependencies());
+                    .or_insert_with(|| entry.dependencies());
             }
         }
         self.dependency_index = index;
@@ -693,6 +722,17 @@ impl Dependency {
     fn as_tuple(&self) -> (&str, &str) {
         let Dependency { specifier, version } = self;
         (specifier, version)
+    }
+}
+
+impl PackageSnapshot {
+    fn dependencies(&self) -> HashMap<String, String> {
+        self.dependencies
+            .iter()
+            .flatten()
+            .chain(self.optional_dependencies.iter().flatten())
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect()
     }
 }
 


### PR DESCRIPTION
## Summary

- Remove all `#[serde(flatten)]` from `PackageSnapshot`, replacing a catch-all `Map<String, Value>` and an inlined struct with explicit fields
- Reorder `DependencyInfo` enum variants so V6 is tried before PreV6 during `#[serde(untagged)]` deserialization

| Repo Size | Baseline (mean) | Improved (mean) | Change |
|-----------|----------------|-----------------|--------|
| ~1,000 packages | 1.541s ± 0.175s | 1.454s ± 0.049s | **87ms faster (5.6%), 72% less variance** |
| ~125 packages | 568.7ms ± 46.4ms | 575.1ms ± 61.9ms | noise |
| 5 packages | 73.9ms ± 24.3ms | 75.8ms ± 25.2ms | noise |

Benchmarks run on a Linux sandbox with hyperfine (15 runs, 2 warmup), all cache-hit scenarios.

Profile data for the large repo shows `parse_lockfile` self-time dropped from **362ms to 335ms (~7.4%)**. The improvement is concentrated in the large repo because it has the most package entries (~2,900) that benefit from the flatten removal. Smaller repos have fewer entries so the per-entry overhead reduction doesn't register above the noise floor.

## Why

`#[serde(flatten)]` forces serde into a slow buffered deserialization path where every field is first collected into an intermediate map, then matched against known fields, with leftovers going into the catch-all. For `PackageSnapshot`, this happened for every package entry in the lockfile (~2,900 in a large monorepo). The struct had two `flatten` attributes:

1. `other: Map<String, serde_yaml_ng::Value>` — a catch-all for unknown fields (used only for round-trip fidelity during `turbo prune`). Replaced with explicit `Option` fields for all known pnpm keys: `engines`, `cpu`, `os`, `libc`, `deprecated`, `hasBin`, `bundledDependencies`, `peerDependencies`, `peerDependenciesMeta`.

2. `snapshot: PackageSnapshotV7` — inlined the 4 fields (`optional`, `dependencies`, `optionalDependencies`, `transitivePeerDependencies`) directly into `PackageSnapshot`.

For `DependencyInfo`, the `#[serde(untagged)]` enum tried `PreV6` first. Since all modern lockfiles (v6, v7, v9) use the V6 format, every importer paid the cost of a failed PreV6 parse + backtrack before succeeding with V6. Swapping the order makes V6 match on the first try.