### PR TITLE
fix: Disable husky pre-push hook during release staging

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -61,7 +61,7 @@ stage-release:
 
 	git checkout -b staging-$(TURBO_VERSION)
 	git commit -anm "publish $(TURBO_VERSION) to registry"
-	git push origin staging-$(TURBO_VERSION) --force
+	HUSKY=0 git push origin staging-$(TURBO_VERSION) --force
 
 .PHONY: create-release-tag
 create-release-tag:


### PR DESCRIPTION
## Summary

- Hourly canary releases are failing because `make stage-release`'s `git push` triggers the `.husky/pre-push` hook, which runs `cargo check --workspace`. The `stage` job runner only has Node installed — no Rust toolchain or `capnp` binary — so `turborepo-hash`'s build script panics and the push fails.
- Sets `HUSKY=0` on the push so the hook is skipped. The Rust checks already run in dedicated downstream jobs (`rust-smoke-test`, `build-rust`).

Example failure: https://github.com/vercel/turborepo/actions/runs/22357171812/job/64699998825