### PR TITLE
release(turborepo): 2.8.11-canary.28

### DIFF
--- a/packages/create-turbo/package.json
+++ b/packages/create-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-turbo",
-  "version": "2.8.11-canary.27",
+  "version": "2.8.11-canary.28",
   "description": "Create a new Turborepo",
   "homepage": "https://turborepo.dev",
   "bugs": {

--- a/packages/eslint-config-turbo/package.json
+++ b/packages/eslint-config-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-turbo",
-  "version": "2.8.11-canary.27",
+  "version": "2.8.11-canary.28",
   "description": "ESLint config for Turborepo",
   "keywords": [
     "eslint",

--- a/packages/eslint-plugin-turbo/package.json
+++ b/packages/eslint-plugin-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-turbo",
-  "version": "2.8.11-canary.27",
+  "version": "2.8.11-canary.28",
   "description": "ESLint plugin for Turborepo",
   "keywords": [
     "eslint",

--- a/packages/turbo-codemod/package.json
+++ b/packages/turbo-codemod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/codemod",
-  "version": "2.8.11-canary.27",
+  "version": "2.8.11-canary.28",
   "description": "Provides Codemod transformations to help upgrade your Turborepo codebase when a feature is deprecated.",
   "homepage": "https://turborepo.dev",
   "bugs": {

--- a/packages/turbo-gen/package.json
+++ b/packages/turbo-gen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/gen",
-  "version": "2.8.11-canary.27",
+  "version": "2.8.11-canary.28",
   "description": "Extend a Turborepo",
   "homepage": "https://turborepo.dev",
   "bugs": {
@@ -58,10 +58,10 @@
     "validate-npm-package-name": "5.0.0"
   },
   "optionalDependencies": {
-    "@turbo/gen-darwin-64": "2.8.11-canary.27",
-    "@turbo/gen-darwin-arm64": "2.8.11-canary.27",
-    "@turbo/gen-linux-64": "2.8.11-canary.27",
-    "@turbo/gen-linux-arm64": "2.8.11-canary.27",
-    "@turbo/gen-windows-64": "2.8.11-canary.27"
+    "@turbo/gen-darwin-64": "2.8.11-canary.28",
+    "@turbo/gen-darwin-arm64": "2.8.11-canary.28",
+    "@turbo/gen-linux-64": "2.8.11-canary.28",
+    "@turbo/gen-linux-arm64": "2.8.11-canary.28",
+    "@turbo/gen-windows-64": "2.8.11-canary.28"
   }
 }

--- a/packages/turbo-ignore/package.json
+++ b/packages/turbo-ignore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-ignore",
-  "version": "2.8.11-canary.27",
+  "version": "2.8.11-canary.28",
   "description": "",
   "keywords": [],
   "homepage": "https://turborepo.dev",

--- a/packages/turbo-types/package.json
+++ b/packages/turbo-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/types",
-  "version": "2.8.11-canary.27",
+  "version": "2.8.11-canary.28",
   "description": "Turborepo types",
   "homepage": "https://turborepo.dev",
   "bugs": {

--- a/packages/turbo-workspaces/package.json
+++ b/packages/turbo-workspaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/workspaces",
-  "version": "2.8.11-canary.27",
+  "version": "2.8.11-canary.28",
   "description": "Tools for working with package managers",
   "homepage": "https://turborepo.dev",
   "bugs": {

--- a/packages/turbo/package.json
+++ b/packages/turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo",
-  "version": "2.8.11-canary.27",
+  "version": "2.8.11-canary.28",
   "description": "Turborepo is a high-performance build system for JavaScript and TypeScript codebases.",
   "homepage": "https://turborepo.dev",
   "bugs": "https://github.com/vercel/turborepo/issues",
@@ -18,11 +18,11 @@
     "postversion": "node bump-version.js"
   },
   "optionalDependencies": {
-    "turbo-darwin-64": "2.8.11-canary.27",
-    "turbo-darwin-arm64": "2.8.11-canary.27",
-    "turbo-linux-64": "2.8.11-canary.27",
-    "turbo-linux-arm64": "2.8.11-canary.27",
-    "turbo-windows-64": "2.8.11-canary.27",
-    "turbo-windows-arm64": "2.8.11-canary.27"
+    "turbo-darwin-64": "2.8.11-canary.28",
+    "turbo-darwin-arm64": "2.8.11-canary.28",
+    "turbo-linux-64": "2.8.11-canary.28",
+    "turbo-linux-arm64": "2.8.11-canary.28",
+    "turbo-windows-64": "2.8.11-canary.28",
+    "turbo-windows-arm64": "2.8.11-canary.28"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -710,20 +710,20 @@ importers:
         version: 5.0.0
     optionalDependencies:
       '@turbo/gen-darwin-64':
-        specifier: 2.8.11-canary.27
-        version: 2.8.11-canary.27
+        specifier: 2.8.11-canary.28
+        version: 2.8.11-canary.28
       '@turbo/gen-darwin-arm64':
-        specifier: 2.8.11-canary.27
-        version: 2.8.11-canary.27
+        specifier: 2.8.11-canary.28
+        version: 2.8.11-canary.28
       '@turbo/gen-linux-64':
-        specifier: 2.8.11-canary.27
-        version: 2.8.11-canary.27
+        specifier: 2.8.11-canary.28
+        version: 2.8.11-canary.28
       '@turbo/gen-linux-arm64':
-        specifier: 2.8.11-canary.27
-        version: 2.8.11-canary.27
+        specifier: 2.8.11-canary.28
+        version: 2.8.11-canary.28
       '@turbo/gen-windows-64':
-        specifier: 2.8.11-canary.27
-        version: 2.8.11-canary.27
+        specifier: 2.8.11-canary.28
+        version: 2.8.11-canary.28
 
   packages/turbo-ignore:
     dependencies:
@@ -4169,28 +4169,28 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
-  '@turbo/gen-darwin-64@2.8.11-canary.27':
-    resolution: {integrity: sha512-ZheuA7L6BP1Ptx0iQPFG9A7RkANSpaEiMbVZwrpQxgotvcIQL6i/aEztGA/dwZrtKlkAvh8mLzcA3QA0oF2j4A==}
+  '@turbo/gen-darwin-64@2.8.11-canary.28':
+    resolution: {integrity: sha512-aZ+VwwoQn7oiqFKtsQiFtFGkY1AHPhKzZx+W8u5rLZjcRhpv/Ii/Kkbrxm8qvyDhMzf3hG172HEJ9r3g9ftaag==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/gen-darwin-arm64@2.8.11-canary.27':
-    resolution: {integrity: sha512-1oOeTqUkmaMH5GzqFjWa8dlyxmJBy1RU2MSYWce06hg63dDxXUPO+QVMMD1lxNVz+kfhRNif1bN0qQ47tKBB8w==}
+  '@turbo/gen-darwin-arm64@2.8.11-canary.28':
+    resolution: {integrity: sha512-k38UmHYV3BKnRyfQLS50nc0r2MfwkmJmLRBRBUDHBLopnqIzJT0ZJ/N9SWRqXXWZQom1yfE+WwJwPVzfNa3Wbw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/gen-linux-64@2.8.11-canary.27':
-    resolution: {integrity: sha512-t3vzGeZVl2ormAFOVoFDdNBcwaLZBZCfHDY4LlJ5ETdyZc59vT2rVVP9uhZyOT/rOQwKUI0lTEnIK72I5jPK6w==}
+  '@turbo/gen-linux-64@2.8.11-canary.28':
+    resolution: {integrity: sha512-66fJUQHSZlfXLaKwWcED9HRmc31otXFUykJPBPrfl/bT9YeUc7nHnEQDjx0Tq3i9EZGL2vWb+DWxZQW16psEIw==}
     cpu: [x64]
     os: [linux]
 
-  '@turbo/gen-linux-arm64@2.8.11-canary.27':
-    resolution: {integrity: sha512-I9EZXWqqXdAW00vBsg99BhYi3/IuAzJI346w9bU3d7xjZy3NHAyVgXH+hdm6F83mtca6da5ospRGs/os1DWMGw==}
+  '@turbo/gen-linux-arm64@2.8.11-canary.28':
+    resolution: {integrity: sha512-/lNKlkEMNsZq5G6bsKRnshbd0+Cedfy0zQjsExm/5ookA+hi29PmL2SeRUtlZVmnKjYZsFbnbPivvjewHzO52g==}
     cpu: [arm64]
     os: [linux]
 
-  '@turbo/gen-windows-64@2.8.11-canary.27':
-    resolution: {integrity: sha512-5YDlWCmHxyx27FYpoJkYAzRZV8C6jSHbc9E5PiZL9gIftsQj+VM1aWFnnb/EXDC+vHP8U85X2JPNir4gKCVDJw==}
+  '@turbo/gen-windows-64@2.8.11-canary.28':
+    resolution: {integrity: sha512-PpRnLc1iXfwcGxrMs+JBmg5ys4y6chJUqkZrBzdaHxa0F8goFBzxdTwwdMXfQDEeuwZFczxWLjjomIlfT8M1sg==}
     cpu: [x64]
     os: [win32]
 
@@ -12043,19 +12043,19 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
-  '@turbo/gen-darwin-64@2.8.11-canary.27':
+  '@turbo/gen-darwin-64@2.8.11-canary.28':
     optional: true
 
-  '@turbo/gen-darwin-arm64@2.8.11-canary.27':
+  '@turbo/gen-darwin-arm64@2.8.11-canary.28':
     optional: true
 
-  '@turbo/gen-linux-64@2.8.11-canary.27':
+  '@turbo/gen-linux-64@2.8.11-canary.28':
     optional: true
 
-  '@turbo/gen-linux-arm64@2.8.11-canary.27':
+  '@turbo/gen-linux-arm64@2.8.11-canary.28':
     optional: true
 
-  '@turbo/gen-windows-64@2.8.11-canary.27':
+  '@turbo/gen-windows-64@2.8.11-canary.28':
     optional: true
 
   '@tybys/wasm-util@0.10.1':

--- a/skills/turborepo/SKILL.md
+++ b/skills/turborepo/SKILL.md
@@ -9,7 +9,7 @@ description: |
   monorepo, shares code between apps, runs changed/affected packages, debugs cache,
   or has apps/packages directories.
 metadata:
-  version: 2.8.11-canary.27
+  version: 2.8.11-canary.28
 ---
 
 # Turborepo Skill

--- a/version.txt
+++ b/version.txt
@@ -1,2 +1,2 @@
-2.8.11-canary.27
+2.8.11-canary.28
 canary


### PR DESCRIPTION
## Release v2.8.11-canary.28

> [!NOTE]
> This release PR was created manually because the [automated release workflow failed](https://github.com/vercel/turborepo/actions/runs/22396672874/job/64834751381) during the "Create Release PR" step. The npm packages were already published successfully.

### Changes

- release(turborepo): 2.8.11-canary.27 (#11975) (`09e2557`)
- chore: Move git hooks from pre-commit to pre-push and match CI lint checks (#11977) (`68928c0`)
- chore: Update AGENTS.md (#11978) (`3887e0d`)
- fix: Use correct pnpm version in library release workflow (#11979) (`716229d`)
- fix: Fix library release workflow for Trusted Publishing OIDC (#11980) (`f2b57af`)
- fix: Use repo setup-node action in library release package job (#11981) (`c8d6fd8`)
- fix: Add repository field to @turbo/repository package.json (#11982) (`2865110`)
- perf: Replace heap-allocated String with stack-allocated OidHash for git OIDs (#11984) (`24e1937`)
- perf: Eliminate redundant syscalls in FSCache fetch and exists (#11985) (`ba1e3bb`)
- release(library): 0.0.1-canary.19 (#11983) (`a5bc714`)
- perf: Reduce per-task allocations in visitor dispatch loop (#11986) (`53b2b4f`)
- docs: Fix same-page anchor links that don't scroll to target (#11989) (`b1d5ec2`)
- docs: Mention inputs key in package hash inputs table (#11990) (`6bc216b`)
- fix(docs): update sitemap.md to single-line pipe-delimited format (#11976) (`fd15d24`)
- fix: Disable husky pre-push hook during release staging (#11991) (`2365307`)
- fix: Disable husky pre-push hook in release workflow (#11992) (`71ca25c`)