### PR TITLE
fix: Use versioned schema URLs in Turborepo skill files

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -59,6 +59,16 @@ stage-release:
 	# Update turborepo skill version (in YAML frontmatter metadata block only)
 	node -e "const fs=require('fs'),p='$(CLI_DIR)/../skills/turborepo/SKILL.md',c=fs.readFileSync(p,'utf-8');fs.writeFileSync(p,c.replace(/^(---\n[\s\S]*?metadata:\n\s*version:\s*).+?(\n[\s\S]*?---)/,'\$$1$(TURBO_VERSION)\$$2'))"
 
+	# Update $schema URLs in turborepo skill files to use versioned subdomain
+	node -e "\
+	  const fs=require('fs'),path=require('path');\
+	  const sub='v'+'$(TURBO_VERSION)'.replace(/[\.\+]/g,'-');\
+	  const url='https://'+sub+'.turborepo.dev/schema.json';\
+	  const re=/https:\/\/(?:v[\w-]+\.)?turborepo\.(?:dev|com)\/schema(?:\.v2)?\.json|https:\/\/turbo\.build\/schema(?:\.v2)?\.json/g;\
+	  function walk(dir){for(const e of fs.readdirSync(dir,{withFileTypes:true})){const p=path.join(dir,e.name);if(e.isDirectory())walk(p);else if(e.name.endsWith('.md')){const c=fs.readFileSync(p,'utf-8');if(re.test(c)){re.lastIndex=0;fs.writeFileSync(p,c.replace(re,url))}}}}\
+	  walk('$(CLI_DIR)/../skills/turborepo');\
+	"
+
 	git checkout -b staging-$(TURBO_VERSION)
 	git commit -anm "publish $(TURBO_VERSION) to registry"
 	HUSKY=0 git push origin staging-$(TURBO_VERSION) --force

--- a/skills/turborepo/SKILL.md
+++ b/skills/turborepo/SKILL.md
@@ -722,7 +722,7 @@ import { Button } from "@repo/ui/button";
 
 ```json
 {
-  "$schema": "https://turborepo.dev/schema.v2.json",
+  "$schema": "https://v2-8-11-canary-28.turborepo.dev/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],

--- a/skills/turborepo/references/best-practices/structure.md
+++ b/skills/turborepo/references/best-practices/structure.md
@@ -95,7 +95,7 @@ Package tasks enable Turborepo to:
 
 ```json
 {
-  "$schema": "https://turborepo.dev/schema.v2.json",
+  "$schema": "https://v2-8-11-canary-28.turborepo.dev/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],

--- a/skills/turborepo/references/configuration/RULE.md
+++ b/skills/turborepo/references/configuration/RULE.md
@@ -73,7 +73,7 @@ When you run `turbo run lint`, Turborepo finds all packages with a `lint` script
 
 ```json
 {
-  "$schema": "https://turborepo.dev/schema.v2.json",
+  "$schema": "https://v2-8-11-canary-28.turborepo.dev/schema.json",
   "globalEnv": ["CI"],
   "globalDependencies": ["tsconfig.json"],
   "tasks": {

--- a/skills/turborepo/references/environment/RULE.md
+++ b/skills/turborepo/references/environment/RULE.md
@@ -80,7 +80,7 @@ Exclude variables (useful with framework inference):
 
 ```json
 {
-  "$schema": "https://turborepo.dev/schema.v2.json",
+  "$schema": "https://v2-8-11-canary-28.turborepo.dev/schema.json",
   "globalEnv": ["CI", "NODE_ENV"],
   "globalPassThroughEnv": ["GITHUB_TOKEN", "NPM_TOKEN"],
   "tasks": {

--- a/skills/turborepo/references/environment/gotchas.md
+++ b/skills/turborepo/references/environment/gotchas.md
@@ -112,7 +112,7 @@ If you use `.env.development` and `.env.production`, both should be in inputs.
 
 ```json
 {
-  "$schema": "https://turborepo.dev/schema.v2.json",
+  "$schema": "https://v2-8-11-canary-28.turborepo.dev/schema.json",
   "globalEnv": ["CI", "NODE_ENV", "VERCEL"],
   "globalPassThroughEnv": ["GITHUB_TOKEN", "VERCEL_URL"],
   "tasks": {


### PR DESCRIPTION
## Summary

- Updates `$schema` references in `skills/turborepo/` from the legacy `https://turborepo.dev/schema.v2.json` to the versioned subdomain format (`https://v2-8-11.turborepo.dev/schema.json`)
- Adds a step in the `stage-release` Makefile target to automatically update these URLs on every version bump, so they never go stale again

## Context

The versioned schema URL format (`https://v{X}-{Y}-{Z}.turborepo.dev/schema.json`) was introduced in 2.7.5 and is what the codemod (`update-versioned-schema-json`) migrates users to. The skill files were still using the old format, meaning the AI skill was teaching an outdated pattern.

The new `stage-release` step walks all `.md` files in `skills/turborepo/`, matches any legacy or outdated versioned schema URL, and replaces it with the URL for the current release version. The replacement is idempotent.