### PR TITLE
fix: Restore daemon client in `RunCache` for `turbo watch`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7916,6 +7916,7 @@ dependencies = [
  "tracing",
  "turbopath",
  "turborepo-cache",
+ "turborepo-daemon",
  "turborepo-hash",
  "turborepo-repository",
  "turborepo-scm",

--- a/crates/turborepo-run-cache/Cargo.toml
+++ b/crates/turborepo-run-cache/Cargo.toml
@@ -17,6 +17,7 @@ tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 turbopath = { workspace = true }
 turborepo-cache = { workspace = true }
+turborepo-daemon = { workspace = true }
 turborepo-hash = { workspace = true }
 turborepo-repository = { path = "../turborepo-repository" }
 turborepo-scm = { workspace = true, features = ["git2"] }

--- a/crates/turborepo-run-cache/src/lib.rs
+++ b/crates/turborepo-run-cache/src/lib.rs
@@ -19,12 +19,15 @@ use tracing::{debug, log::warn};
 use turbopath::{
     AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPath, AnchoredSystemPathBuf,
 };
-use turborepo_cache::{AsyncCache, CacheError, CacheHitMetadata, CacheOpts, http::UploadMap};
+use turborepo_cache::{
+    AsyncCache, CacheError, CacheHitMetadata, CacheOpts, CacheSource, http::UploadMap,
+};
+use turborepo_daemon::{DaemonClient, DaemonConnector};
 use turborepo_hash::{FileHashes, TurboHash};
 use turborepo_repository::package_graph::PackageInfo;
 use turborepo_scm::SCM;
 use turborepo_task_id::TaskId;
-use turborepo_telemetry::events::task::PackageTaskEventBuilder;
+use turborepo_telemetry::events::{TrackedErrors, task::PackageTaskEventBuilder};
 // Re-export for backwards compatibility
 pub use turborepo_types::RunCacheOpts;
 use turborepo_types::{
@@ -43,10 +46,18 @@ pub enum Error {
     Globwalk(#[from] globwalk::WalkError),
     #[error("Invalid globwalk pattern: {0}")]
     Glob(#[from] globwalk::GlobError),
+    #[error("Error with daemon: {0}")]
+    Daemon(Box<turborepo_daemon::DaemonError>),
     #[error(transparent)]
     Scm(#[from] turborepo_scm::Error),
     #[error(transparent)]
     Path(#[from] turbopath::PathError),
+}
+
+impl From<turborepo_daemon::DaemonError> for Error {
+    fn from(err: turborepo_daemon::DaemonError) -> Self {
+        Error::Daemon(Box::new(err))
+    }
 }
 
 /// The run cache wraps an AsyncCache with task-aware semantics.
@@ -62,6 +73,7 @@ pub struct RunCache {
     reads_disabled: bool,
     writes_disabled: bool,
     repo_root: AbsoluteSystemPathBuf,
+    daemon_client: Option<DaemonClient<DaemonConnector>>,
     ui: ColorConfig,
     /// When using `outputLogs: "errors-only"`, show task hashes when tasks
     /// complete successfully. Controlled by the `errorsOnlyShowHash` future
@@ -82,6 +94,7 @@ impl RunCache {
         repo_root: &AbsoluteSystemPath,
         run_cache_opts: RunCacheOpts,
         cache_opts: &CacheOpts,
+        daemon_client: Option<DaemonClient<DaemonConnector>>,
         ui: ColorConfig,
         is_dry_run: bool,
     ) -> Self {
@@ -97,6 +110,7 @@ impl RunCache {
             reads_disabled: !cache_opts.cache.remote.read && !cache_opts.cache.local.read,
             writes_disabled: !cache_opts.cache.remote.write && !cache_opts.cache.local.write,
             repo_root: repo_root.to_owned(),
+            daemon_client,
             ui,
             errors_only_show_hash: run_cache_opts.errors_only_show_hash,
         }
@@ -133,6 +147,7 @@ impl RunCache {
             task_output_logs,
             caching_disabled,
             log_file_path,
+            daemon_client: self.daemon_client.clone(),
             ui: self.ui,
             warnings: self.warnings.clone(),
             errors_only_show_hash: self.errors_only_show_hash,
@@ -166,6 +181,7 @@ pub struct TaskCache {
     task_output_logs: OutputLogsMode,
     caching_disabled: bool,
     log_file_path: AbsoluteSystemPathBuf,
+    daemon_client: Option<DaemonClient<DaemonConnector>>,
     ui: ColorConfig,
     task_id: TaskId<'static>,
     warnings: Arc<Mutex<Vec<String>>>,
@@ -236,7 +252,7 @@ impl TaskCache {
     pub async fn restore_outputs(
         &mut self,
         terminal_output: &mut impl CacheOutput,
-        _telemetry: &PackageTaskEventBuilder,
+        telemetry: &PackageTaskEventBuilder,
     ) -> Result<Option<CacheHitMetadata>, Error> {
         if self.caching_disabled || self.run_cache.reads_disabled {
             // Always send the cache miss status so TUI knows to start rendering.
@@ -265,51 +281,111 @@ impl TaskCache {
             return Ok(None);
         }
 
-        // Note that we currently don't use the output globs when restoring, but we
-        // could in the future to avoid doing unnecessary file I/O. We also
-        // need to pass along the exclusion globs as well.
-        let cache_status = self
-            .run_cache
-            .cache
-            .fetch(&self.run_cache.repo_root, &self.hash)
-            .await?;
+        let validated_inclusions = self.repo_relative_globs.validated_inclusions()?;
 
-        let Some((cache_hit_metadata, restored_files)) = cache_status else {
-            // Always send the cache miss status so TUI knows to start rendering.
-            // The message is only shown based on output_logs setting.
-            let message = if self.task_output_logs == OutputLogsMode::ErrorsOnly
-                && self.errors_only_show_hash
+        // If the daemon is connected, check whether outputs have changed since
+        // they were last written. When outputs are already on disk and unchanged,
+        // we can skip the cache restore entirely — avoiding file writes that would
+        // otherwise trigger the file watcher and cause an infinite rebuild loop
+        // in `turbo watch`.
+        let changed_output_count = if let Some(daemon_client) = &mut self.daemon_client {
+            match daemon_client
+                .get_changed_outputs(self.hash.to_string(), &validated_inclusions)
+                .await
             {
-                format!(
-                    "cache miss, executing {} {}",
-                    color!(self.ui, GREY, "{}", self.hash),
-                    color!(self.ui, GREY, "(only logging errors)")
-                )
-            } else if matches!(
-                self.task_output_logs,
-                OutputLogsMode::None | OutputLogsMode::ErrorsOnly
-            ) {
-                String::new()
-            } else {
-                format!(
-                    "cache miss, executing {}",
-                    color!(self.ui, GREY, "{}", self.hash)
-                )
-            };
-            terminal_output.status(&message, CacheResult::Miss);
-
-            return Ok(None);
+                Ok(changed_output_globs) => changed_output_globs.len(),
+                Err(err) => {
+                    telemetry.track_error(TrackedErrors::DaemonSkipOutputRestoreCheckFailed);
+                    debug!(
+                        "Failed to check if we can skip restoring outputs for {}: {}. Proceeding \
+                         to check cache",
+                        self.task_id, err
+                    );
+                    self.repo_relative_globs.inclusions.len()
+                }
+            }
+        } else {
+            self.repo_relative_globs.inclusions.len()
         };
 
-        self.expanded_outputs = restored_files;
+        let has_changed_outputs = changed_output_count > 0;
 
-        let cache_status = Some(cache_hit_metadata);
+        let cache_status = if has_changed_outputs {
+            // Note that we currently don't use the output globs when restoring, but we
+            // could in the future to avoid doing unnecessary file I/O. We also
+            // need to pass along the exclusion globs as well.
+            let cache_status = self
+                .run_cache
+                .cache
+                .fetch(&self.run_cache.repo_root, &self.hash)
+                .await?;
+
+            let Some((cache_hit_metadata, restored_files)) = cache_status else {
+                // Always send the cache miss status so TUI knows to start rendering.
+                // The message is only shown based on output_logs setting.
+                let message = if self.task_output_logs == OutputLogsMode::ErrorsOnly
+                    && self.errors_only_show_hash
+                {
+                    format!(
+                        "cache miss, executing {} {}",
+                        color!(self.ui, GREY, "{}", self.hash),
+                        color!(self.ui, GREY, "(only logging errors)")
+                    )
+                } else if matches!(
+                    self.task_output_logs,
+                    OutputLogsMode::None | OutputLogsMode::ErrorsOnly
+                ) {
+                    String::new()
+                } else {
+                    format!(
+                        "cache miss, executing {}",
+                        color!(self.ui, GREY, "{}", self.hash)
+                    )
+                };
+                terminal_output.status(&message, CacheResult::Miss);
+
+                return Ok(None);
+            };
+
+            self.expanded_outputs = restored_files;
+
+            if let Some(daemon_client) = &mut self.daemon_client {
+                let validated_exclusions = self.repo_relative_globs.validated_exclusions()?;
+                if let Err(err) = daemon_client
+                    .notify_outputs_written(
+                        self.hash.clone(),
+                        &validated_inclusions,
+                        &validated_exclusions,
+                        cache_hit_metadata.time_saved,
+                    )
+                    .await
+                {
+                    telemetry.track_error(TrackedErrors::DaemonFailedToMarkOutputsAsCached);
+                    let task_id = &self.task_id;
+                    debug!("Failed to mark outputs as cached for {task_id}: {err}");
+                }
+            }
+
+            Some(cache_hit_metadata)
+        } else {
+            Some(CacheHitMetadata {
+                source: CacheSource::Local,
+                time_saved: 0,
+            })
+        };
+
+        let more_context = if has_changed_outputs {
+            ""
+        } else {
+            " (outputs already on disk)"
+        };
 
         match self.task_output_logs {
             OutputLogsMode::HashOnly | OutputLogsMode::NewOnly => {
                 terminal_output.status(
                     &format!(
-                        "cache hit, suppressing logs {}",
+                        "cache hit{}, suppressing logs {}",
+                        more_context,
                         color!(self.ui, GREY, "{}", self.hash)
                     ),
                     CacheResult::Hit,
@@ -319,7 +395,8 @@ impl TaskCache {
                 debug!("log file path: {}", self.log_file_path);
                 terminal_output.status(
                     &format!(
-                        "cache hit, replaying logs {}",
+                        "cache hit{}, replaying logs {}",
+                        more_context,
                         color!(self.ui, GREY, "{}", self.hash)
                     ),
                     CacheResult::Hit,
@@ -330,7 +407,8 @@ impl TaskCache {
                 debug!("log file path: {}", self.log_file_path);
                 terminal_output.status(
                     &format!(
-                        "cache hit, replaying logs (no errors) {}",
+                        "cache hit{}, replaying logs (no errors) {}",
+                        more_context,
                         color!(self.ui, GREY, "{}", self.hash)
                     ),
                     CacheResult::Hit,
@@ -347,7 +425,7 @@ impl TaskCache {
     pub async fn save_outputs(
         &mut self,
         duration: Duration,
-        _telemetry: &PackageTaskEventBuilder,
+        telemetry: &PackageTaskEventBuilder,
     ) -> Result<(), Error> {
         if self.caching_disabled || self.run_cache.writes_disabled {
             return Ok(());
@@ -392,6 +470,22 @@ impl TaskCache {
                 duration.as_millis() as u64,
             )
             .await?;
+
+        if let Some(daemon_client) = self.daemon_client.as_mut()
+            && let Err(err) = daemon_client
+                .notify_outputs_written(
+                    self.hash.to_string(),
+                    &validated_inclusions,
+                    &validated_exclusions,
+                    duration.as_millis() as u64,
+                )
+                .await
+                .map_err(Error::from)
+        {
+            telemetry.track_error(TrackedErrors::DaemonFailedToMarkOutputsAsCached);
+            let task_id = &self.task_id;
+            debug!("failed to mark outputs as cached for {task_id}: {err}");
+        }
 
         self.expanded_outputs = relative_paths;
 


### PR DESCRIPTION
## Summary

Fixes #11964 — `turbo watch` enters an infinite rebuild loop since `2.8.11-canary.19`.

When the daemon was removed from `turbo run` in #11910, the daemon client was also removed from `RunCache`/`TaskCache`. This broke `turbo watch`: without `get_changed_outputs` and `notify_outputs_written`, every cache hit unconditionally restores files to disk. The file watcher sees these writes as changes, triggers another rebuild, which hits cache again — infinite loop.

## What changed

- Restored the optional `daemon_client` field in `RunCache` and `TaskCache`
- `RunBuilder` accepts a daemon client via `with_daemon_client()` builder method
- `WatchClient` connects a daemon client and passes it to every `RunBuilder` it creates
- Normal `turbo run` passes `None`, keeping the daemon removal from #11910 fully intact

The daemon client allows the run cache to:
1. **Skip unnecessary cache restores** — `get_changed_outputs` checks if outputs are already on disk and unchanged, avoiding file writes that trigger the watcher
2. **Register output globs** — `notify_outputs_written` tells the daemon's `GlobWatcher` which outputs were just written, so future checks can skip them

## Testing

Verified by reproducing the original issue:

```sh
git clone https://github.com/remotion-dev/remotion
cd remotion
git checkout 41763f0290db417900551013a1bc8376a1f42103
bun i
bun run watch  # should stop after building, not loop forever
```