### PR TITLE
chore: Reduce compile times by deduplicating thiserror and itertools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2564,7 +2564,7 @@ name = "globwalk"
 version = "0.1.0"
 dependencies = [
  "camino",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "path-clean",
  "path-slash",
  "rayon",
@@ -2583,7 +2583,7 @@ name = "globwatch"
 version = "0.1.0"
 dependencies = [
  "futures",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "merge-streams",
  "notify",
  "stop-token",
@@ -7109,7 +7109,7 @@ dependencies = [
  "build-target",
  "camino",
  "insta",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "miette",
  "pretty_assertions",
  "serde_json",
@@ -7233,7 +7233,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 1.0.63",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "turbopath",
@@ -7257,7 +7257,7 @@ dependencies = [
  "git2",
  "globwalk",
  "indicatif",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "miette",
  "regex",
  "schemars",
@@ -7337,7 +7337,7 @@ dependencies = [
  "camino",
  "clap",
  "derive_setters",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "merge",
  "miette",
  "reqwest",
@@ -7458,7 +7458,7 @@ dependencies = [
  "convert_case 0.6.0",
  "futures",
  "insta",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "miette",
  "petgraph 0.6.5",
  "pretty_assertions",
@@ -7523,7 +7523,7 @@ dependencies = [
  "notify",
  "radix_trie",
  "tempfile",
- "thiserror 1.0.63",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-scoped",
  "tracing",
@@ -7557,7 +7557,7 @@ dependencies = [
  "ignore",
  "tempfile",
  "test-case",
- "thiserror 1.0.63",
+ "thiserror 2.0.18",
  "turbopath",
 ]
 
@@ -7577,7 +7577,7 @@ dependencies = [
  "fixedbitset 0.4.2",
  "futures",
  "insta",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "petgraph 0.6.5",
  "thiserror 2.0.18",
  "tokio",
@@ -7604,7 +7604,7 @@ version = "0.1.0"
 dependencies = [
  "jsonc-parser 0.21.0",
  "pretty_assertions",
- "thiserror 1.0.63",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7640,7 +7640,7 @@ dependencies = [
  "ignore",
  "indicatif",
  "insta",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "libc",
  "merge",
  "miette",
@@ -7670,7 +7670,7 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "test-case",
- "thiserror 1.0.63",
+ "thiserror 2.0.18",
  "time",
  "tiny-gradient",
  "tokio",
@@ -7744,7 +7744,7 @@ dependencies = [
  "biome_json_parser",
  "dashmap 5.5.3",
  "insta",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "nom",
  "pest",
  "pest_derive",
@@ -7756,7 +7756,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "test-case",
- "thiserror 1.0.63",
+ "thiserror 2.0.18",
  "tracing",
  "turbopath",
  "turborepo-errors",
@@ -7767,7 +7767,7 @@ name = "turborepo-lsp"
 version = "0.1.0"
 dependencies = [
  "crop",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "jsonc-parser 0.23.0",
  "pidlock",
  "serde_json",
@@ -7841,7 +7841,7 @@ version = "0.1.0"
 dependencies = [
  "console 0.16.2",
  "futures",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "libc",
  "nix 0.26.2",
  "portable-pty",
@@ -7861,7 +7861,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 1.0.63",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7877,7 +7877,7 @@ dependencies = [
  "either",
  "globwalk",
  "insta",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "lazy-regex",
  "miette",
  "node-semver",
@@ -7891,7 +7891,7 @@ dependencies = [
  "serde_yaml_ng",
  "tempfile",
  "test-case",
- "thiserror 1.0.63",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -7909,9 +7909,9 @@ name = "turborepo-run-cache"
 version = "0.1.0"
 dependencies = [
  "globwalk",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "serde",
- "thiserror 1.0.63",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "turbopath",
@@ -7931,7 +7931,7 @@ name = "turborepo-run-summary"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "pretty_assertions",
  "rayon",
  "serde",
@@ -8025,7 +8025,7 @@ dependencies = [
  "const_format",
  "crossterm 0.27.0",
  "dunce",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "miette",
  "pretty_assertions",
  "semver 1.0.23",
@@ -8091,12 +8091,12 @@ version = "0.1.0"
 dependencies = [
  "either",
  "globwalk",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "rayon",
  "regex",
  "serde",
  "tempfile",
- "thiserror 1.0.63",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "turbopath",
@@ -8676,7 +8676,7 @@ dependencies = [
  "build-fs-tree",
  "const_format",
  "dunce",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "miette",
  "nom",
  "path-slash",
@@ -8684,7 +8684,7 @@ dependencies = [
  "regex",
  "tardar",
  "tempfile",
- "thiserror 1.0.63",
+ "thiserror 2.0.18",
  "walkdir",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ httpmock = { version = "0.8.0", default-features = false }
 indicatif = "0.18.3"
 indoc = "2.0.0"
 insta = { version = "1.34.0", features = ["json"] }
-itertools = "0.10.5"
+itertools = "0.14.0"
 merge = "0.2.0"
 notify = "6.1.1"
 owo-colors = "3.5.0"

--- a/crates/turborepo-auth/Cargo.toml
+++ b/crates/turborepo-auth/Cargo.toml
@@ -17,7 +17,7 @@ hostname = "0.3.1"
 reqwest.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-thiserror = "1.0.38"
+thiserror = { workspace = true }
 tokio.workspace = true
 tracing.workspace = true
 turbopath.workspace = true

--- a/crates/turborepo-boundaries/bindings/BoundariesConfig.ts
+++ b/crates/turborepo-boundaries/bindings/BoundariesConfig.ts
@@ -5,32 +5,31 @@
  *
  * Allows users to restrict a package's dependencies and dependents.
  */
-export type BoundariesConfig = {
-  /**
-   * The boundaries rules for tags.
-   *
-   * Restricts which packages can import a tag and which packages a tag can
-   * import.
-   */
-  tags: { [key in string]?: TagRules } | null;
-  /**
-   * Declares any implicit dependencies, i.e. any dependency not declared in
-   * a `package.json`.
-   *
-   * These can include dependencies automatically injected by a framework or
-   * a testing library.
-   */
-  implicitDependencies: Array<string> | null;
-  /**
-   * Rules for a package's dependencies.
-   *
-   * Restricts which packages this package can import.
-   */
-  dependencies: Permissions | null;
-  /**
-   * Rules for a package's dependents.
-   *
-   * Restricts which packages can import this package.
-   */
-  dependents: Permissions | null;
-};
+export type BoundariesConfig = { 
+/**
+ * The boundaries rules for tags.
+ *
+ * Restricts which packages can import a tag and which packages a tag can
+ * import.
+ */
+tags?: { [key in string]?: TagRules }, 
+/**
+ * Declares any implicit dependencies, i.e. any dependency not declared in
+ * a `package.json`.
+ *
+ * These can include dependencies automatically injected by a framework or
+ * a testing library.
+ */
+implicitDependencies?: Array<string>, 
+/**
+ * Rules for a package's dependencies.
+ *
+ * Restricts which packages this package can import.
+ */
+dependencies?: Permissions, 
+/**
+ * Rules for a package's dependents.
+ *
+ * Restricts which packages can import this package.
+ */
+dependents?: Permissions, };

--- a/crates/turborepo-boundaries/bindings/Permissions.ts
+++ b/crates/turborepo-boundaries/bindings/Permissions.ts
@@ -3,15 +3,14 @@
 /**
  * Permission rules for boundaries.
  */
-export type Permissions = {
-  /**
-   * Lists which tags are allowed.
-   *
-   * Any tag not included will be banned. If omitted, all tags are permitted.
-   */
-  allow: Array<string> | null;
-  /**
-   * Lists which tags are banned.
-   */
-  deny: Array<string> | null;
-};
+export type Permissions = { 
+/**
+ * Lists which tags are allowed.
+ *
+ * Any tag not included will be banned. If omitted, all tags are permitted.
+ */
+allow?: Array<string>, 
+/**
+ * Lists which tags are banned.
+ */
+deny?: Array<string>, };

--- a/crates/turborepo-boundaries/bindings/TagRules.ts
+++ b/crates/turborepo-boundaries/bindings/TagRules.ts
@@ -6,17 +6,16 @@
  * Restricts which packages a tag can import and which packages can import this
  * tag.
  */
-export type TagRules = {
-  /**
-   * Rules for a tag's dependencies.
-   *
-   * Restricts which packages a tag can import.
-   */
-  dependencies: Permissions | null;
-  /**
-   * Rules for a tag's dependents.
-   *
-   * Restricts which packages can import this tag.
-   */
-  dependents: Permissions | null;
-};
+export type TagRules = { 
+/**
+ * Rules for a tag's dependencies.
+ *
+ * Restricts which packages a tag can import.
+ */
+dependencies?: Permissions, 
+/**
+ * Rules for a tag's dependents.
+ *
+ * Restricts which packages can import this tag.
+ */
+dependents?: Permissions, };

--- a/crates/turborepo-cache/Cargo.toml
+++ b/crates/turborepo-cache/Cargo.toml
@@ -33,7 +33,7 @@ hmac = "0.12.1"
 miette = { workspace = true }
 os_str_bytes = "6.5.0"
 path-clean = { workspace = true }
-petgraph = "0.6.3"
+petgraph = { workspace = true }
 pin-project = "1.1.5"
 reqwest = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/turborepo-filewatch/Cargo.toml
+++ b/crates/turborepo-filewatch/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 futures = { workspace = true }
 notify = { workspace = true }
 radix_trie = { workspace = true }
-thiserror = "1.0.38"
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full", "time"] }
 tracing = "0.1.37"
 turbopath = { workspace = true }

--- a/crates/turborepo-filewatch/src/globwatcher.rs
+++ b/crates/turborepo-filewatch/src/globwatcher.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
-    fmt::Display,
     future::IntoFuture,
     str::FromStr,
     time::Duration,
@@ -66,16 +65,11 @@ impl std::hash::Hash for GlobSet {
 }
 
 #[derive(Debug, Error)]
+#[error("{underlying}: {raw_glob}")]
 pub struct GlobError {
     // Boxed to minimize error size
     underlying: Box<wax::BuildError>,
     raw_glob: String,
-}
-
-impl Display for GlobError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}: {}", self.underlying, self.raw_glob)
-    }
 }
 
 fn compile_glob(raw: &str) -> Result<Glob<'static>, GlobError> {

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -25,13 +25,7 @@
 #![allow(clippy::result_large_err)]
 #![feature(assert_matches)]
 
-use std::{
-    fmt::{Debug, Display},
-    future::IntoFuture,
-    path::Path,
-    sync::Arc,
-    time::Duration,
-};
+use std::{fmt::Debug, future::IntoFuture, path::Path, sync::Arc, time::Duration};
 
 // windows -> no recursive watch, watch ancestors
 // linux -> recursive watch, watch ancestors
@@ -93,17 +87,12 @@ pub enum WatchError {
 // Clone. We provide a wrapper that uses an Arc to implement Clone so that we
 // can send errors on a broadcast channel.
 #[derive(Clone, Debug, Error)]
+#[error("{0}")]
 pub struct NotifyError(Arc<notify::Error>);
 
 impl From<notify::Error> for NotifyError {
     fn from(value: notify::Error) -> Self {
         Self(Arc::new(value))
-    }
-}
-
-impl Display for NotifyError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
     }
 }
 

--- a/crates/turborepo-fs/Cargo.toml
+++ b/crates/turborepo-fs/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 fs-err = "2.9.0"
 ignore = "0.4.22"
-thiserror = "1.0.38"
+thiserror = { workspace = true }
 turbopath = { workspace = true }
 
 [dev-dependencies]

--- a/crates/turborepo-globwatch/src/lib.rs
+++ b/crates/turborepo-globwatch/src/lib.rs
@@ -456,7 +456,7 @@ enum GlobSymbol<'a> {
 /// and `?`. any other case watches the entire directory.
 fn glob_to_paths(glob: &str) -> Vec<PathBuf> {
     // get all the symbols and chunk them by path separator
-    let chunks = glob_to_symbols(glob).group_by(|s| s != &GlobSymbol::PathSeparator);
+    let chunks = glob_to_symbols(glob).chunk_by(|s| s != &GlobSymbol::PathSeparator);
     let chunks = chunks
         .into_iter()
         .filter_map(|(not_sep, chunk)| (not_sep).then_some(chunk));

--- a/crates/turborepo-json-rewrite/Cargo.toml
+++ b/crates/turborepo-json-rewrite/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 
 [dependencies]
 jsonc-parser = "0.21.0"
-thiserror = "1.0.38"
+thiserror = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -83,7 +83,7 @@ swc_common = { workspace = true }
 swc_ecma_ast = { workspace = true, features = ["serde-impl"] }
 swc_ecma_parser = { workspace = true }
 sysinfo = "0.27.7"
-thiserror = "1.0.38"
+thiserror = { workspace = true }
 time = "0.3.20"
 tiny-gradient = { workspace = true }
 tokio = { workspace = true, features = ["full", "time"] }

--- a/crates/turborepo-lib/src/cli/error.rs
+++ b/crates/turborepo-lib/src/cli/error.rs
@@ -1,5 +1,3 @@
-use std::backtrace;
-
 use itertools::Itertools;
 use miette::Diagnostic;
 use thiserror::Error;
@@ -19,9 +17,9 @@ use crate::{
 #[derive(Debug, Error, Diagnostic)]
 pub enum Error {
     #[error("No command specified.")]
-    NoCommand(#[backtrace] backtrace::Backtrace),
+    NoCommand,
     #[error("{0}")]
-    Bin(#[from] bin::Error, #[backtrace] backtrace::Backtrace),
+    Bin(#[from] bin::Error),
     #[error(transparent)]
     Boundaries(#[from] crate::boundaries::Error),
     #[error(transparent)]

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1,4 +1,4 @@
-use std::{backtrace::Backtrace, env, ffi::OsString, fmt, io, mem, process};
+use std::{env, ffi::OsString, fmt, io, mem, process};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::{ArgAction, ArgGroup, CommandFactory, Parser, Subcommand, ValueEnum};
@@ -1266,7 +1266,7 @@ fn default_to_run_command(cli_args: &Args) -> Result<Command, Error> {
         // We clone instead of take as take would leave the command base a copy of cli_args
         // missing any execution args.
         .clone()
-        .ok_or_else(|| Error::NoCommand(Backtrace::capture()))?;
+        .ok_or_else(|| Error::NoCommand)?;
 
     if execution_args.tasks.is_empty() {
         let mut cmd = <Args as CommandFactory>::command();

--- a/crates/turborepo-lockfiles/Cargo.toml
+++ b/crates/turborepo-lockfiles/Cargo.toml
@@ -24,7 +24,7 @@ semver = "1.0.17"
 serde = { version = "1.0.228", features = ["derive", "rc"] }
 serde_json = "1.0.86"
 serde_yaml_ng = { workspace = true }
-thiserror = "1.0.38"
+thiserror = { workspace = true }
 tracing.workspace = true
 turbopath = { path = "../turborepo-paths" }
 turborepo-errors = { workspace = true }

--- a/crates/turborepo-profile-md/Cargo.toml
+++ b/crates/turborepo-profile-md/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-thiserror = "1.0.38"
+thiserror = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/turborepo-repository/Cargo.toml
+++ b/crates/turborepo-repository/Cargo.toml
@@ -29,7 +29,7 @@ rust-ini = "0.20.0"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }
-thiserror = "1.0.38"
+thiserror = { workspace = true }
 tokio-stream = "0.1.14"
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -7,7 +7,6 @@ pub mod yarn;
 pub mod yarnrc;
 
 use std::{
-    backtrace,
     fmt::{self, Display},
     fs,
 };
@@ -73,13 +72,17 @@ pub enum PackageManager {
     Bun,
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub struct MissingWorkspaceError {
     package_manager: PackageManager,
 }
 
-#[derive(Debug, Error)]
+impl std::error::Error for MissingWorkspaceError {}
+
+#[derive(Debug)]
 pub struct NoPackageManager;
+
+impl std::error::Error for NoPackageManager {}
 
 impl Display for NoPackageManager {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -123,25 +126,22 @@ impl From<PackageManager> for MissingWorkspaceError {
 
 impl From<wax::BuildError> for Error {
     fn from(value: wax::BuildError) -> Self {
-        Self::Wax(Box::new(value), backtrace::Backtrace::capture())
+        Self::Wax(Box::new(value))
     }
 }
 
 #[derive(Debug, Error, Diagnostic)]
 pub enum Error {
     #[error("I/O error: {0}")]
-    Io(#[from] std::io::Error, #[backtrace] backtrace::Backtrace),
+    Io(#[from] std::io::Error),
     #[error(transparent)]
     Workspace(#[from] MissingWorkspaceError),
     #[error("YAML parsing error: {0}")]
-    ParsingYaml(
-        #[from] serde_yaml_ng::Error,
-        #[backtrace] backtrace::Backtrace,
-    ),
+    ParsingYaml(#[from] serde_yaml_ng::Error),
     #[error("JSON parsing error: {0}")]
-    ParsingJson(#[from] serde_json::Error, #[backtrace] backtrace::Backtrace),
+    ParsingJson(#[from] serde_json::Error),
     #[error("Globbing error: {0}")]
-    Wax(Box<wax::BuildError>, #[backtrace] backtrace::Backtrace),
+    Wax(Box<wax::BuildError>),
     #[error(transparent)]
     PackageJson(#[from] package_json::Error),
     #[error(transparent)]

--- a/crates/turborepo-run-cache/Cargo.toml
+++ b/crates/turborepo-run-cache/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 globwalk = { version = "0.1.0", path = "../turborepo-globwalk" }
 itertools = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-thiserror = "1.0.38"
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 turbopath = { workspace = true }

--- a/crates/turborepo-task-hash/Cargo.toml
+++ b/crates/turborepo-task-hash/Cargo.toml
@@ -12,7 +12,7 @@ itertools = { workspace = true }
 rayon = "1.7.0"
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
-thiserror = "1.0.38"
+thiserror = { workspace = true }
 tracing = { workspace = true }
 
 turbopath = { workspace = true }

--- a/crates/turborepo-turbo-json/bindings/Pipeline.ts
+++ b/crates/turborepo-turbo-json/bindings/Pipeline.ts
@@ -8,118 +8,117 @@
  * key, it will apply the pipeline task configuration to that npm script
  * during execution.
  */
-export type Pipeline = {
-  /**
-   * A human-readable description of what this task does.
-   *
-   * This field is for documentation purposes only and does not affect
-   * task execution or caching behavior.
-   */
-  description: string | null;
-  /**
-   * Whether or not to cache the outputs of the task.
-   *
-   * Setting cache to false is useful for long-running "watch" or
-   * development mode tasks.
-   *
-   * Documentation: https://turborepo.dev/docs/reference/configuration#cache
-   */
-  cache: boolean | null;
-  /**
-   * The list of tasks that this task depends on.
-   *
-   * Prefixing an item in `dependsOn` with a `^` prefix tells turbo that
-   * this task depends on the package's topological dependencies completing
-   * the task first. Items without a `^` prefix express the relationships
-   * between tasks within the same package.
-   *
-   * Documentation: https://turborepo.dev/docs/reference/configuration#dependson
-   */
-  dependsOn: Array<string> | null;
-  /**
-   * A list of environment variables that this task depends on.
-   *
-   * Note: If you are migrating from a turbo version 1.5 or below, you may
-   * be used to prefixing your variables with a `$`. You no longer need to
-   * use the `$` prefix.
-   *
-   * Documentation: https://turborepo.dev/docs/reference/configuration#env
-   */
-  env: Array<string> | null;
-  /**
-   * The set of glob patterns to consider as inputs to this task.
-   *
-   * Changes to files covered by these globs will cause a cache miss and
-   * the task will be rerun. If a file has been changed that is **not**
-   * included in the set of globs, it will not cause a cache miss.
-   * If omitted or empty, all files in the package are considered as inputs.
-   *
-   * Documentation: https://turborepo.dev/docs/reference/configuration#inputs
-   */
-  inputs: Array<string> | null;
-  /**
-   * An allowlist of environment variables that should be made available
-   * in this task's environment, but should not contribute to the task's
-   * cache key, e.g. `AWS_SECRET_KEY`.
-   *
-   * Documentation: https://turborepo.dev/docs/reference/configuration#passthroughenv
-   */
-  passThroughEnv: Array<string> | null;
-  /**
-   * Indicates whether the task exits or not.
-   *
-   * Setting `persistent` to `true` tells turbo that this is a long-running
-   * task and will ensure that other tasks cannot depend on it.
-   *
-   * Documentation: https://turborepo.dev/docs/reference/configuration#persistent
-   */
-  persistent: boolean | null;
-  /**
-   * Label a persistent task as interruptible to allow it to be restarted
-   * by `turbo watch`.
-   *
-   * `turbo watch` watches for changes to your packages and automatically
-   * restarts tasks that are affected. However, if a task is persistent,
-   * it will not be restarted by default. To enable restarting persistent
-   * tasks, set `interruptible` to `true`.
-   *
-   * Documentation: https://turborepo.dev/docs/reference/configuration#interruptible
-   */
-  interruptible: boolean | null;
-  /**
-   * The set of glob patterns indicating a task's cacheable filesystem
-   * outputs.
-   *
-   * Turborepo captures task logs for all tasks. This enables us to cache
-   * tasks whose runs produce no artifacts other than logs (such as linters).
-   * Logs are always treated as a cacheable artifact and never need to be
-   * specified.
-   *
-   * Documentation: https://turborepo.dev/docs/reference/configuration#outputs
-   */
-  outputs: Array<string> | null;
-  /**
-   * Output mode for the task.
-   *
-   * Documentation: https://turborepo.dev/docs/reference/run#--output-logs-option
-   */
-  outputLogs: OutputLogs | null;
-  /**
-   * Mark a task as interactive allowing it to receive input from stdin.
-   *
-   * Interactive tasks must be marked with `"cache": false` as the input
-   * they receive from stdin can change the outcome of the task.
-   *
-   * Documentation: https://turborepo.dev/docs/reference/configuration#interactive
-   */
-  interactive: boolean | null;
-  /**
-   * A list of tasks that will run alongside this task.
-   *
-   * Tasks in this list will not be run until completion before this task
-   * starts execution.
-   *
-   * Documentation: https://turborepo.dev/docs/reference/configuration#with
-   */
-  with: Array<string> | null;
-};
+export type Pipeline = { 
+/**
+ * A human-readable description of what this task does.
+ *
+ * This field is for documentation purposes only and does not affect
+ * task execution or caching behavior.
+ */
+description?: string, 
+/**
+ * Whether or not to cache the outputs of the task.
+ *
+ * Setting cache to false is useful for long-running "watch" or
+ * development mode tasks.
+ *
+ * Documentation: https://turborepo.dev/docs/reference/configuration#cache
+ */
+cache?: boolean, 
+/**
+ * The list of tasks that this task depends on.
+ *
+ * Prefixing an item in `dependsOn` with a `^` prefix tells turbo that
+ * this task depends on the package's topological dependencies completing
+ * the task first. Items without a `^` prefix express the relationships
+ * between tasks within the same package.
+ *
+ * Documentation: https://turborepo.dev/docs/reference/configuration#dependson
+ */
+dependsOn?: Array<string>, 
+/**
+ * A list of environment variables that this task depends on.
+ *
+ * Note: If you are migrating from a turbo version 1.5 or below, you may
+ * be used to prefixing your variables with a `$`. You no longer need to
+ * use the `$` prefix.
+ *
+ * Documentation: https://turborepo.dev/docs/reference/configuration#env
+ */
+env?: Array<string>, 
+/**
+ * The set of glob patterns to consider as inputs to this task.
+ *
+ * Changes to files covered by these globs will cause a cache miss and
+ * the task will be rerun. If a file has been changed that is **not**
+ * included in the set of globs, it will not cause a cache miss.
+ * If omitted or empty, all files in the package are considered as inputs.
+ *
+ * Documentation: https://turborepo.dev/docs/reference/configuration#inputs
+ */
+inputs?: Array<string>, 
+/**
+ * An allowlist of environment variables that should be made available
+ * in this task's environment, but should not contribute to the task's
+ * cache key, e.g. `AWS_SECRET_KEY`.
+ *
+ * Documentation: https://turborepo.dev/docs/reference/configuration#passthroughenv
+ */
+passThroughEnv?: Array<string>, 
+/**
+ * Indicates whether the task exits or not.
+ *
+ * Setting `persistent` to `true` tells turbo that this is a long-running
+ * task and will ensure that other tasks cannot depend on it.
+ *
+ * Documentation: https://turborepo.dev/docs/reference/configuration#persistent
+ */
+persistent?: boolean, 
+/**
+ * Label a persistent task as interruptible to allow it to be restarted
+ * by `turbo watch`.
+ *
+ * `turbo watch` watches for changes to your packages and automatically
+ * restarts tasks that are affected. However, if a task is persistent,
+ * it will not be restarted by default. To enable restarting persistent
+ * tasks, set `interruptible` to `true`.
+ *
+ * Documentation: https://turborepo.dev/docs/reference/configuration#interruptible
+ */
+interruptible?: boolean, 
+/**
+ * The set of glob patterns indicating a task's cacheable filesystem
+ * outputs.
+ *
+ * Turborepo captures task logs for all tasks. This enables us to cache
+ * tasks whose runs produce no artifacts other than logs (such as linters).
+ * Logs are always treated as a cacheable artifact and never need to be
+ * specified.
+ *
+ * Documentation: https://turborepo.dev/docs/reference/configuration#outputs
+ */
+outputs?: Array<string>, 
+/**
+ * Output mode for the task.
+ *
+ * Documentation: https://turborepo.dev/docs/reference/run#--output-logs-option
+ */
+outputLogs?: OutputLogs, 
+/**
+ * Mark a task as interactive allowing it to receive input from stdin.
+ *
+ * Interactive tasks must be marked with `"cache": false` as the input
+ * they receive from stdin can change the outcome of the task.
+ *
+ * Documentation: https://turborepo.dev/docs/reference/configuration#interactive
+ */
+interactive?: boolean, 
+/**
+ * A list of tasks that will run alongside this task.
+ *
+ * Tasks in this list will not be run until completion before this task
+ * starts execution.
+ *
+ * Documentation: https://turborepo.dev/docs/reference/configuration#with
+ */
+with?: Array<string>, };

--- a/crates/turborepo-turbo-json/bindings/RawTurboJson.ts
+++ b/crates/turborepo-turbo-json/bindings/RawTurboJson.ts
@@ -10,135 +10,133 @@ import type { RemoteCache } from "./RemoteCache";
  *
  * Documentation: https://turborepo.dev/docs/reference/configuration
  */
-export type RawTurboJson = {
-  /**
-   * JSON Schema URL for validation.
-   */
-  $schema: string | null;
-  /**
-   * This key is only available in Workspace Configs and cannot be used in
-   * your root turbo.json.
-   *
-   * Tells turbo to extend your root `turbo.json` and overrides with the
-   * keys provided in your Workspace Configs. Currently, only the `["//"]`
-   * value is allowed.
-   */
-  extends: Array<string> | null;
-  /**
-   * A list of globs to include in the set of implicit global hash
-   * dependencies.
-   *
-   * The contents of these files will be included in the global hashing
-   * algorithm and affect the hashes of all tasks.
-   *
-   * This is useful for busting the cache based on:
-   * - `.env` files (not in Git)
-   * - Any root level file that impacts package tasks that are not
-   *   represented in the traditional dependency graph (e.g. a root
-   *   `tsconfig.json`, `jest.config.ts`, `.eslintrc`, etc.)
-   *
-   * Documentation: https://turborepo.dev/docs/reference/configuration#globaldependencies
-   */
-  globalDependencies: Array<string> | null;
-  /**
-   * A list of environment variables for implicit global hash dependencies.
-   *
-   * The variables included in this list will affect all task hashes.
-   *
-   * Documentation: https://turborepo.dev/docs/reference/configuration#globalenv
-   */
-  globalEnv: Array<string> | null;
-  /**
-   * An allowlist of environment variables that should be made to all tasks,
-   * but should not contribute to the task's cache key, e.g.
-   * `AWS_SECRET_KEY`.
-   *
-   * Documentation: https://turborepo.dev/docs/reference/configuration#globalpassthroughenv
-   */
-  globalPassThroughEnv: Array<string> | null;
-  /**
-   * An object representing the task dependency graph of your project.
-   *
-   * turbo interprets these conventions to schedule, execute, and cache the
-   * outputs of tasks in your project.
-   *
-   * Documentation: https://turborepo.dev/docs/reference/configuration#tasks
-   */
-  tasks: null;
-  /**
-   * Configuration options when interfacing with the remote cache.
-   *
-   * Documentation: https://turborepo.dev/docs/core-concepts/remote-caching
-   */
-  remoteCache: RemoteCache | null;
-  /**
-   * Enable use of the UI for `turbo`.
-   *
-   * Documentation: https://turborepo.dev/docs/reference/configuration#ui
-   */
-  ui: UI | null;
-  /**
-   * Disable check for `packageManager` in root `package.json`.
-   *
-   * This is highly discouraged as it leaves `turbo` dependent on system
-   * configuration to infer the correct package manager. Some turbo features
-   * are disabled if this is set to true.
-   */
-  dangerouslyDisablePackageManagerCheck: boolean | null;
-  /**
-   * Turborepo runs a background process to pre-calculate some expensive
-   * operations. This standalone process (daemon) is a performance
-   * optimization, and not required for proper functioning of `turbo`.
-   *
-   * Documentation: https://turborepo.dev/docs/reference/configuration#daemon
-   */
-  daemon: boolean | null;
-  /**
-   * Turborepo's Environment Modes allow you to control which environment
-   * variables are available to a task at runtime.
-   *
-   * Documentation: https://turborepo.dev/docs/reference/configuration#envmode
-   */
-  envMode: EnvMode | null;
-  /**
-   * Specify the filesystem cache directory.
-   *
-   * Documentation: https://turborepo.dev/docs/reference/configuration#cachedir
-   */
-  cacheDir: string | null;
-  /**
-   * When set to `true`, disables the update notification that appears when
-   * a new version of `turbo` is available.
-   *
-   * Documentation: https://turborepo.dev/docs/reference/configuration#noupdatenotifier
-   */
-  noUpdateNotifier: boolean | null;
-  /**
-   * Used to tag a package for boundaries rules.
-   *
-   * Boundaries rules can restrict which packages a tag group can import
-   * or be imported by.
-   */
-  tags: Array<string> | null;
-  /**
-   * Configuration for `turbo boundaries`.
-   *
-   * Allows users to restrict a package's dependencies and dependents.
-   */
-  boundaries: BoundariesConfig | null;
-  /**
-   * Set/limit the maximum concurrency for task execution.
-   *
-   * Must be an integer greater than or equal to `1` or a percentage value
-   * like `50%`. Use `1` to force serial execution (one task at a time).
-   * Use `100%` to use all available logical processors.
-   *
-   * Documentation: https://turborepo.dev/docs/reference/configuration#concurrency
-   */
-  concurrency: string | null;
-  /**
-   * Opt into breaking changes prior to major releases, experimental
-   * features, and beta features.
-   */
-  futureFlags: FutureFlags | null;
-};
+export type RawTurboJson = { 
+/**
+ * JSON Schema URL for validation.
+ */
+$schema?: string, 
+/**
+ * This key is only available in Workspace Configs and cannot be used in
+ * your root turbo.json.
+ *
+ * Tells turbo to extend your root `turbo.json` and overrides with the
+ * keys provided in your Workspace Configs. Currently, only the `["//"]`
+ * value is allowed.
+ */
+extends?: Array<string>, 
+/**
+ * A list of globs to include in the set of implicit global hash
+ * dependencies.
+ *
+ * The contents of these files will be included in the global hashing
+ * algorithm and affect the hashes of all tasks.
+ *
+ * This is useful for busting the cache based on:
+ * - `.env` files (not in Git)
+ * - Any root level file that impacts package tasks that are not
+ *   represented in the traditional dependency graph (e.g. a root
+ *   `tsconfig.json`, `jest.config.ts`, `.eslintrc`, etc.)
+ *
+ * Documentation: https://turborepo.dev/docs/reference/configuration#globaldependencies
+ */
+globalDependencies?: Array<string>, 
+/**
+ * A list of environment variables for implicit global hash dependencies.
+ *
+ * The variables included in this list will affect all task hashes.
+ *
+ * Documentation: https://turborepo.dev/docs/reference/configuration#globalenv
+ */
+globalEnv?: Array<string>, 
+/**
+ * An allowlist of environment variables that should be made to all tasks,
+ * but should not contribute to the task's cache key, e.g.
+ * `AWS_SECRET_KEY`.
+ *
+ * Documentation: https://turborepo.dev/docs/reference/configuration#globalpassthroughenv
+ */
+globalPassThroughEnv?: Array<string>, 
+/**
+ * An object representing the task dependency graph of your project.
+ *
+ * turbo interprets these conventions to schedule, execute, and cache the
+ * outputs of tasks in your project.
+ *
+ * Documentation: https://turborepo.dev/docs/reference/configuration#tasks
+ */
+tasks?: , 
+/**
+ * Configuration options when interfacing with the remote cache.
+ *
+ * Documentation: https://turborepo.dev/docs/core-concepts/remote-caching
+ */
+remoteCache?: RemoteCache, 
+/**
+ * Enable use of the UI for `turbo`.
+ *
+ * Documentation: https://turborepo.dev/docs/reference/configuration#ui
+ */
+ui?: UI, 
+/**
+ * Disable check for `packageManager` in root `package.json`.
+ *
+ * This is highly discouraged as it leaves `turbo` dependent on system
+ * configuration to infer the correct package manager. Some turbo features
+ * are disabled if this is set to true.
+ */
+dangerouslyDisablePackageManagerCheck?: boolean, 
+/**
+ * Deprecated: The daemon is no longer used for `turbo run` and this
+ * option will be removed in version 3.0.
+ *
+ * Documentation: https://turborepo.dev/docs/reference/configuration#daemon
+ */
+daemon?: boolean, 
+/**
+ * Turborepo's Environment Modes allow you to control which environment
+ * variables are available to a task at runtime.
+ *
+ * Documentation: https://turborepo.dev/docs/reference/configuration#envmode
+ */
+envMode?: EnvMode, 
+/**
+ * Specify the filesystem cache directory.
+ *
+ * Documentation: https://turborepo.dev/docs/reference/configuration#cachedir
+ */
+cacheDir?: string, 
+/**
+ * When set to `true`, disables the update notification that appears when
+ * a new version of `turbo` is available.
+ *
+ * Documentation: https://turborepo.dev/docs/reference/configuration#noupdatenotifier
+ */
+noUpdateNotifier?: boolean, 
+/**
+ * Used to tag a package for boundaries rules.
+ *
+ * Boundaries rules can restrict which packages a tag group can import
+ * or be imported by.
+ */
+tags?: Array<string>, 
+/**
+ * Configuration for `turbo boundaries`.
+ *
+ * Allows users to restrict a package's dependencies and dependents.
+ */
+boundaries?: BoundariesConfig, 
+/**
+ * Set/limit the maximum concurrency for task execution.
+ *
+ * Must be an integer greater than or equal to `1` or a percentage value
+ * like `50%`. Use `1` to force serial execution (one task at a time).
+ * Use `100%` to use all available logical processors.
+ *
+ * Documentation: https://turborepo.dev/docs/reference/configuration#concurrency
+ */
+concurrency?: string, 
+/**
+ * Opt into breaking changes prior to major releases, experimental
+ * features, and beta features.
+ */
+futureFlags?: FutureFlags, };

--- a/crates/turborepo-turbo-json/bindings/RemoteCache.ts
+++ b/crates/turborepo-turbo-json/bindings/RemoteCache.ts
@@ -6,73 +6,72 @@
  *
  * Documentation: https://turborepo.dev/docs/core-concepts/remote-caching
  */
-export type RemoteCache = {
-  /**
-   * Set endpoint for API calls to the remote cache.
-   *
-   * Documentation: https://turborepo.dev/docs/core-concepts/remote-caching#self-hosting
-   */
-  apiUrl: string | null;
-  /**
-   * Set endpoint for requesting tokens during `turbo login`.
-   *
-   * Documentation: https://turborepo.dev/docs/core-concepts/remote-caching#self-hosting
-   */
-  loginUrl: string | null;
-  /**
-   * The slug of the Remote Cache team.
-   *
-   * Value will be passed as `slug` in the querystring for all Remote
-   * Cache HTTP calls.
-   */
-  teamSlug: string | null;
-  /**
-   * The ID of the Remote Cache team.
-   *
-   * Value will be passed as `teamId` in the querystring for all Remote
-   * Cache HTTP calls. Must start with `team_` or it will not be used.
-   */
-  teamId: string | null;
-  /**
-   * Indicates if signature verification is enabled for requests to the
-   * remote cache.
-   *
-   * When `true`, Turborepo will sign every uploaded artifact using the
-   * value of the environment variable `TURBO_REMOTE_CACHE_SIGNATURE_KEY`.
-   * Turborepo will reject any downloaded artifacts that have an invalid
-   * signature or are missing a signature.
-   */
-  signature: boolean | null;
-  /**
-   * When enabled, any HTTP request will be preceded by an OPTIONS request
-   * to determine if the request is supported by the endpoint.
-   *
-   * Documentation: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#preflighted_requests
-   */
-  preflight: boolean | null;
-  /**
-   * Sets a timeout for remote cache operations.
-   *
-   * Value is given in seconds and only whole values are accepted.
-   * If `0` is passed, then there is no timeout for any cache operations.
-   */
-  timeout: number | null;
-  /**
-   * Indicates if the remote cache is enabled.
-   *
-   * When `false`, Turborepo will disable all remote cache operations,
-   * even if the repo has a valid token. If `true`, remote caching is
-   * enabled, but still requires the user to login and link their repo
-   * to a remote cache.
-   *
-   * Documentation: https://turborepo.dev/docs/core-concepts/remote-caching
-   */
-  enabled: boolean | null;
-  /**
-   * Sets a timeout for remote cache uploads.
-   *
-   * Value is given in seconds and only whole values are accepted.
-   * If `0` is passed, then there is no timeout for any remote cache uploads.
-   */
-  uploadTimeout: number | null;
-};
+export type RemoteCache = { 
+/**
+ * Set endpoint for API calls to the remote cache.
+ *
+ * Documentation: https://turborepo.dev/docs/core-concepts/remote-caching#self-hosting
+ */
+apiUrl?: string, 
+/**
+ * Set endpoint for requesting tokens during `turbo login`.
+ *
+ * Documentation: https://turborepo.dev/docs/core-concepts/remote-caching#self-hosting
+ */
+loginUrl?: string, 
+/**
+ * The slug of the Remote Cache team.
+ *
+ * Value will be passed as `slug` in the querystring for all Remote
+ * Cache HTTP calls.
+ */
+teamSlug?: string, 
+/**
+ * The ID of the Remote Cache team.
+ *
+ * Value will be passed as `teamId` in the querystring for all Remote
+ * Cache HTTP calls. Must start with `team_` or it will not be used.
+ */
+teamId?: string, 
+/**
+ * Indicates if signature verification is enabled for requests to the
+ * remote cache.
+ *
+ * When `true`, Turborepo will sign every uploaded artifact using the
+ * value of the environment variable `TURBO_REMOTE_CACHE_SIGNATURE_KEY`.
+ * Turborepo will reject any downloaded artifacts that have an invalid
+ * signature or are missing a signature.
+ */
+signature?: boolean, 
+/**
+ * When enabled, any HTTP request will be preceded by an OPTIONS request
+ * to determine if the request is supported by the endpoint.
+ *
+ * Documentation: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#preflighted_requests
+ */
+preflight?: boolean, 
+/**
+ * Sets a timeout for remote cache operations.
+ *
+ * Value is given in seconds and only whole values are accepted.
+ * If `0` is passed, then there is no timeout for any cache operations.
+ */
+timeout?: number | null, 
+/**
+ * Indicates if the remote cache is enabled.
+ *
+ * When `false`, Turborepo will disable all remote cache operations,
+ * even if the repo has a valid token. If `true`, remote caching is
+ * enabled, but still requires the user to login and link their repo
+ * to a remote cache.
+ *
+ * Documentation: https://turborepo.dev/docs/core-concepts/remote-caching
+ */
+enabled?: boolean, 
+/**
+ * Sets a timeout for remote cache uploads.
+ *
+ * Value is given in seconds and only whole values are accepted.
+ * If `0` is passed, then there is no timeout for any remote cache uploads.
+ */
+uploadTimeout?: number | null, };

--- a/crates/turborepo-wax/Cargo.toml
+++ b/crates/turborepo-wax/Cargo.toml
@@ -26,10 +26,10 @@ workspace = true
 
 [dependencies]
 const_format = "^0.2.0"
-itertools = "^0.11.0"
+itertools = { workspace = true }
 nom = "^7.0.0"
 pori = "=0.0.0"
-thiserror = "^1.0.0"
+thiserror = { workspace = true }
 
   [dependencies.miette]
   default-features = false

--- a/crates/turborepo-wax/src/rule.rs
+++ b/crates/turborepo-wax/src/rule.rs
@@ -374,7 +374,7 @@ pub fn check(tokenized: Tokenized) -> Result<Checked<Tokenized>, RuleError> {
 fn boundary<'t>(tokenized: &Tokenized<'t>) -> Result<(), RuleError<'t>> {
     if let Some((left, right)) = tokenized
         .walk()
-        .group_by(|(position, _)| *position)
+        .chunk_by(|(position, _)| *position)
         .into_iter()
         .flat_map(|(_, group)| {
             group


### PR DESCRIPTION
## Summary

- Migrate all 11 workspace crates from thiserror v1 to v2, eliminating duplicate `thiserror-impl` proc-macro compilation
- Bump itertools from 0.10 to 0.14, reducing from 4 compiled versions down to 2
- Fix `turborepo-cache` petgraph pin to use workspace dependency

## Why

The workspace was compiling both thiserror v1 and v2 (plus both `thiserror-impl` proc-macro crates) because 11 crates pinned `thiserror = "1.0.38"` instead of using `{ workspace = true }`. Similarly, itertools had 4 versions in the dependency tree (0.10, 0.11, 0.13, 0.14) due to the workspace pinning 0.10 while transitive deps pulled newer versions.

Duplicate proc-macro crates are especially expensive because they must be compiled to native code for the host, and each version is compiled independently.

## Migration Details

**thiserror v2 breaking changes addressed:**

- **Removed `#[backtrace]` fields** from error enums in `turborepo-lib` (5 sites) and `turborepo-repository` (4 sites). In thiserror v2, backtraces are captured automatically via `std::error::Error::provide()`.
- **Fixed structs that derived `Error` without `#[error(...)]`**: `NotifyError` and `GlobError` in `turborepo-filewatch` now use `#[error("...")]` instead of manual `Display` impls. `MissingWorkspaceError` and `NoPackageManager` in `turborepo-repository` now use manual `impl std::error::Error` since their `Display` impls are complex.
- **turborepo-wax** migrated cleanly — all error types already had explicit `#[error(...)]` attributes.

**itertools 0.14 breaking changes addressed:**

- Renamed `group_by` → `chunk_by` in `turborepo-wax` and `turborepo-globwatch`.

## Testing

`cargo check --workspace` and `cargo test --workspace` pass. The `.ts` binding file changes are auto-generated by `ts-rs` from the dependency update.