### PR TITLE
perf: Extract query module into turborepo-query crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5212,7 +5212,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower 0.5.2",
- "tower-http",
+ "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -6848,6 +6848,22 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
@@ -7423,7 +7439,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "tower-http",
+ "tower-http 0.6.8",
  "tracing",
  "turbopath",
  "turborepo-filewatch",
@@ -7618,10 +7634,8 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "async-graphql",
- "async-graphql-axum",
  "async-io",
  "async-stream",
- "axum",
  "biome_deserialize 0.6.0",
  "biome_json_parser",
  "camino",
@@ -7668,9 +7682,6 @@ dependencies = [
  "serial_test",
  "sha2",
  "shared_child",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
  "sysinfo",
  "tempfile",
  "test-case",
@@ -7680,13 +7691,11 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
- "tower-http",
  "tracing",
  "tracing-appender",
  "tracing-chrome",
  "tracing-subscriber",
  "tracing-test",
- "turbo-trace",
  "turbo-updater",
  "turbopath",
  "turborepo-analytics",
@@ -7716,6 +7725,7 @@ dependencies = [
  "turborepo-microfrontends-proxy",
  "turborepo-process",
  "turborepo-profile-md",
+ "turborepo-query",
  "turborepo-repository",
  "turborepo-run-cache",
  "turborepo-run-summary",
@@ -7866,6 +7876,43 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "turborepo-query"
+version = "0.1.0"
+dependencies = [
+ "async-graphql",
+ "async-graphql-axum",
+ "axum",
+ "camino",
+ "itertools 0.14.0",
+ "miette",
+ "petgraph 0.6.5",
+ "serde",
+ "serde_json",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower-http 0.5.2",
+ "tracing",
+ "turbo-trace",
+ "turbopath",
+ "turborepo-boundaries",
+ "turborepo-engine",
+ "turborepo-errors",
+ "turborepo-lockfiles",
+ "turborepo-repository",
+ "turborepo-scm",
+ "turborepo-scope",
+ "turborepo-signals",
+ "turborepo-task-id",
+ "turborepo-turbo-json",
+ "turborepo-types",
+ "turborepo-ui",
+ "webbrowser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ turborepo-lockfiles = { path = "crates/turborepo-lockfiles" }
 turborepo-microfrontends = { path = "crates/turborepo-microfrontends" }
 turborepo-microfrontends-proxy = { path = "crates/turborepo-microfrontends-proxy" }
 turborepo-process = { path = "crates/turborepo-process" }
+turborepo-query = { path = "crates/turborepo-query" }
 turborepo-profile-md = { path = "crates/turborepo-profile-md" }
 turborepo-repository = { path = "crates/turborepo-repository" }
 turborepo-task-id = { path = "crates/turborepo-task-id" }

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -34,8 +34,6 @@ workspace = true
 
 [dependencies]
 async-graphql = { workspace = true }
-async-graphql-axum = { workspace = true }
-axum = { workspace = true }
 camino = "1.1.4"
 chrono = { workspace = true, features = ["serde"] }
 clap = { workspace = true, features = ["derive", "env"] }
@@ -79,9 +77,7 @@ serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }
 sha2 = { workspace = true }
 shared_child = "1.0.0"
-swc_common = { workspace = true }
-swc_ecma_ast = { workspace = true, features = ["serde-impl"] }
-swc_ecma_parser = { workspace = true }
+
 sysinfo = "0.27.7"
 thiserror = { workspace = true }
 time = "0.3.20"
@@ -89,12 +85,12 @@ tiny-gradient = { workspace = true }
 tokio = { workspace = true, features = ["full", "time"] }
 tokio-stream = { version = "0.1.12", features = ["net"] }
 tonic = { version = "0.14", features = ["transport"] }
-tower-http = { version = "0.6", features = ["cors"] }
+
 tracing-appender = "0.2.2"
 tracing-chrome = "0.7.1"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 tracing.workspace = true
-turbo-trace = { workspace = true }
+
 turbo-updater = { workspace = true }
 turbopath = { workspace = true }
 turborepo-analytics = { path = "../turborepo-analytics" }
@@ -124,6 +120,7 @@ turborepo-microfrontends = { workspace = true }
 turborepo-microfrontends-proxy = { workspace = true }
 turborepo-process = { workspace = true }
 turborepo-profile-md = { workspace = true }
+turborepo-query = { workspace = true }
 turborepo-repository = { path = "../turborepo-repository" }
 turborepo-run-cache = { path = "../turborepo-run-cache" }
 turborepo-run-summary = { workspace = true }

--- a/crates/turborepo-lib/src/boundaries/mod.rs
+++ b/crates/turborepo-lib/src/boundaries/mod.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 
 use turborepo_boundaries::{BoundariesChecker, BoundariesContext, TurboJsonProvider};
-pub use turborepo_boundaries::{BoundariesConfig, BoundariesDiagnostic, BoundariesResult, Error};
+pub use turborepo_boundaries::{BoundariesConfig, BoundariesResult, Error};
 use turborepo_errors::Spanned;
 use turborepo_repository::package_graph::PackageName;
 

--- a/crates/turborepo-lib/src/cli/error.rs
+++ b/crates/turborepo-lib/src/cli/error.rs
@@ -10,7 +10,7 @@ use turborepo_ui::{color, BOLD, GREY};
 
 use crate::{
     commands::{bin, docs, generate, get_mfe_port, link, login, ls, prune, CommandBase},
-    query, run,
+    run,
     run::{builder::RunBuilder, watch},
 };
 
@@ -63,7 +63,7 @@ pub enum Error {
     Run(#[from] run::Error),
     #[error(transparent)]
     #[diagnostic(transparent)]
-    Query(#[from] query::Error),
+    Query(#[from] turborepo_query::Error),
     #[error(transparent)]
     SerdeJson(#[from] serde_json::Error),
     #[error(transparent)]

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -25,7 +25,6 @@ mod microfrontends;
 mod opts;
 mod package_changes_watcher;
 mod panic_handler;
-mod query;
 mod run;
 mod shim;
 mod task_graph;

--- a/crates/turborepo-lib/src/run/scope/mod.rs
+++ b/crates/turborepo-lib/src/run/scope/mod.rs
@@ -12,7 +12,6 @@ use turborepo_repository::{
 };
 use turborepo_scm::SCM;
 // Re-export modules and types from turborepo-scope crate for backward compatibility
-pub use turborepo_scope::filter;
 pub use turborepo_scope::{filter::ResolutionError, target_selector, ScopeOpts};
 
 use crate::turbo_json::TurboJson;

--- a/crates/turborepo-lib/src/run/ui.rs
+++ b/crates/turborepo-lib/src/run/ui.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use turborepo_ui::wui::{event::WebUIEvent, query::SharedState};
 
-use crate::{query, run::Run};
+use crate::run::Run;
 
 pub async fn start_web_ui_server(
     rx: tokio::sync::mpsc::UnboundedReceiver<WebUIEvent>,
@@ -12,7 +12,8 @@ pub async fn start_web_ui_server(
     let subscriber = turborepo_ui::wui::subscriber::Subscriber::new(rx);
     tokio::spawn(subscriber.watch(state.clone()));
 
-    query::run_server(Some(state.clone()), run).await?;
+    let run: Arc<dyn turborepo_query::QueryRun> = run;
+    turborepo_query::run_server(Some(state.clone()), run).await?;
 
     Ok(())
 }

--- a/crates/turborepo-query/Cargo.toml
+++ b/crates/turborepo-query/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "turborepo-query"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+async-graphql = { workspace = true }
+async-graphql-axum = { workspace = true }
+axum = { workspace = true }
+camino = "1.1.4"
+itertools = { workspace = true }
+miette = { workspace = true }
+petgraph = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+swc_common = { workspace = true }
+swc_ecma_ast = { workspace = true, features = ["serde-impl"] }
+swc_ecma_parser = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tower-http = { version = "0.5.2", features = ["cors"] }
+tracing = { workspace = true }
+turbo-trace = { workspace = true }
+turbopath = { workspace = true }
+turborepo-boundaries = { workspace = true }
+turborepo-engine = { path = "../turborepo-engine" }
+turborepo-errors = { workspace = true }
+turborepo-lockfiles = { workspace = true }
+turborepo-repository = { path = "../turborepo-repository" }
+turborepo-scm = { workspace = true }
+turborepo-scope = { path = "../turborepo-scope" }
+turborepo-signals = { workspace = true }
+turborepo-task-id = { workspace = true }
+turborepo-turbo-json = { path = "../turborepo-turbo-json" }
+turborepo-types = { workspace = true }
+turborepo-ui = { workspace = true }
+webbrowser = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/turborepo-query/src/boundaries.rs
+++ b/crates/turborepo-query/src/boundaries.rs
@@ -1,5 +1,6 @@
-use super::Diagnostic;
-use crate::boundaries::BoundariesDiagnostic;
+use turborepo_boundaries::BoundariesDiagnostic;
+
+use crate::Diagnostic;
 
 impl From<BoundariesDiagnostic> for Diagnostic {
     fn from(diagnostic: BoundariesDiagnostic) -> Self {
@@ -53,7 +54,6 @@ impl From<BoundariesDiagnostic> for Diagnostic {
                 path: None,
                 reason: None,
             },
-
             BoundariesDiagnostic::NoTagInAllowlist {
                 source_package_name: _,
                 help: _,

--- a/crates/turborepo-query/src/external_package.rs
+++ b/crates/turborepo-query/src/external_package.rs
@@ -2,21 +2,19 @@ use std::sync::Arc;
 
 use async_graphql::Object;
 
-use super::{package::Package, Array, Error};
-use crate::run::Run;
+use crate::{package::Package, Array, Error, QueryRun};
 
 #[derive(Clone)]
 pub struct ExternalPackage {
-    run: Arc<Run>,
+    run: Arc<dyn QueryRun>,
     package: turborepo_lockfiles::Package,
 }
 
 impl ExternalPackage {
-    pub fn new(run: Arc<Run>, package: turborepo_lockfiles::Package) -> Self {
+    pub fn new(run: Arc<dyn QueryRun>, package: turborepo_lockfiles::Package) -> Self {
         Self { run, package }
     }
 
-    /// Converts the lockfile key to a human friendly name
     pub fn human_name(&self) -> String {
         self.run
             .pkg_dep_graph()

--- a/crates/turborepo-query/src/package_graph.rs
+++ b/crates/turborepo-query/src/package_graph.rs
@@ -2,22 +2,22 @@ use std::sync::Arc;
 
 use async_graphql::{Object, SimpleObject};
 use itertools::Itertools;
-use petgraph::graph::NodeIndex;
 use turborepo_repository::package_graph::{PackageName, PackageNode};
 
-use crate::{
-    query::{package::Package, Array, Error, PackagePredicate},
-    run::Run,
-};
+use crate::{package::Package, Array, Error, PackagePredicate, QueryRun};
 
 pub struct PackageGraph {
-    run: Arc<Run>,
+    run: Arc<dyn QueryRun>,
     center: Option<PackageNode>,
     filter: Option<PackagePredicate>,
 }
 
 impl PackageGraph {
-    pub fn new(run: Arc<Run>, center: Option<String>, filter: Option<PackagePredicate>) -> Self {
+    pub fn new(
+        run: Arc<dyn QueryRun>,
+        center: Option<String>,
+        filter: Option<PackagePredicate>,
+    ) -> Self {
         let center = center.map(|center| PackageNode::Workspace(PackageName::from(center)));
 
         Self {
@@ -26,12 +26,6 @@ impl PackageGraph {
             filter,
         }
     }
-}
-
-#[derive(Clone)]
-pub(crate) struct Node {
-    idx: NodeIndex,
-    run: Arc<Run>,
 }
 
 #[derive(Debug, Clone, SimpleObject, Hash, PartialEq, Eq)]

--- a/crates/turborepo-query/src/server.rs
+++ b/crates/turborepo-query/src/server.rs
@@ -7,24 +7,22 @@ use tokio::net::TcpListener;
 use tower_http::cors::{Any, CorsLayer};
 use turborepo_ui::wui::query::SharedState;
 
-use crate::{query, query::graphiql, run::Run};
+use crate::{graphiql, QueryRun, RepositoryQuery};
 
 #[derive(MergedObject)]
-struct Query(turborepo_ui::wui::RunQuery, query::RepositoryQuery);
+struct Query(turborepo_ui::wui::RunQuery, RepositoryQuery);
 
 pub async fn run_server(
     state: Option<SharedState>,
-    run: Arc<Run>,
+    run: Arc<dyn QueryRun>,
 ) -> Result<(), turborepo_ui::Error> {
     let cors = CorsLayer::new()
-        // allow `GET` and `POST` when accessing the resource
         .allow_methods([Method::GET, Method::POST])
         .allow_headers(Any)
-        // allow requests from any origin
         .allow_origin(Any);
 
     let web_ui_query = turborepo_ui::wui::RunQuery::new(state.clone());
-    let turbo_query = query::RepositoryQuery::new(run);
+    let turbo_query = RepositoryQuery::new(run);
     let combined_query = Query(web_ui_query, turbo_query);
 
     let schema = Schema::new(combined_query, EmptyMutation, EmptySubscription);

--- a/crates/turborepo-query/src/task.rs
+++ b/crates/turborepo-query/src/task.rs
@@ -1,14 +1,11 @@
 use std::sync::Arc;
 
 use async_graphql::Object;
+use turborepo_engine::TaskNode;
 use turborepo_errors::Spanned;
 use turborepo_task_id::TaskId;
 
-use crate::{
-    engine::TaskNode,
-    query::{package::Package, Array, Error},
-    run::Run,
-};
+use crate::{package::Package, Array, Error, QueryRun};
 
 pub struct RepositoryTask {
     pub name: String,
@@ -17,7 +14,7 @@ pub struct RepositoryTask {
 }
 
 impl RepositoryTask {
-    pub fn new(task_id: &TaskId, run: &Arc<Run>) -> Result<Self, Error> {
+    pub fn new(task_id: &TaskId, run: &Arc<dyn QueryRun>) -> Result<Self, Error> {
         let package = Package::new(run.clone(), task_id.package().into())?;
         let script = package.get_tasks().get(task_id.task()).cloned();
 


### PR DESCRIPTION
## Summary

- Extracts the GraphQL query layer (1,688 lines, 8 files) from `turborepo-lib` into a new `turborepo-query` crate
- Introduces a `QueryRun` trait that decouples the query layer from the concrete `Run` type
- Removes `swc_common`, `swc_ecma_ast`, `swc_ecma_parser`, `async-graphql-axum`, `axum`, `tower-http`, and `turbo-trace` from `turborepo-lib`'s direct dependencies

## Why

`turborepo-lib` is the bottleneck in the build graph — 42+ internal crates feed into it, and nothing downstream can compile until it finishes. The query module pulled in ~40s of CPU time in heavy dependencies (SWC, async-graphql, axum) that aren't needed by the rest of `turborepo-lib`.

After this change, those dependencies compile in the new `turborepo-query` crate **in parallel** with `turborepo-lib` instead of blocking it.

## Build time impact (clean build, macOS)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Wall clock | 74.2s | 57.4s | **-22.6%** |
| Total CPU | 761.2s | 521.8s | **-31.5%** |
| `turborepo-lib` compile | 7.20s | 5.06s | **-30%** |
| `turborepo-lib` start time | 62.3s | 47.3s | **15s earlier** |

## Approach

The `QueryRun` trait exposes the read-only accessors that the GraphQL resolvers need (`repo_root()`, `pkg_dep_graph()`, `engine()`, `scm()`, `root_turbo_json()`), plus two methods that encapsulate `turborepo-lib`-internal logic:

- `calculate_affected_packages(base, head)` — wraps the `Opts` mutation + `RunBuilder::calculate_filtered_packages` call, keeping `Opts` out of the query crate
- `check_boundaries(show_progress)` — delegates to the existing `impl Run` method

The query crate uses `Arc<dyn QueryRun>` (object-safe dynamic dispatch). The vtable cost is negligible for network-bound GraphQL resolvers.

No behavioral changes. All 192 `turborepo-lib` unit tests pass.

## For reviewers

`async-graphql` remains in `turborepo-lib` because `commands/query.rs` directly constructs a `Schema` to execute inline queries. A follow-up could push that behind a higher-level API in `turborepo-query` to drop async-graphql from `turborepo-lib` entirely.