### PR TITLE
fix: Mark lockfile-aware-caching/bun prysk test as flaky

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -20,6 +20,11 @@ turborepo-dirs-serial = { max-threads = 1 }
 
 
 [[profile.default.overrides]]
+# Mark flaky prysk test for retries
+filter = 'package(turbo) and test(lockfile-aware-caching/bun)'
+retries = 3
+
+[[profile.default.overrides]]
 # Run all tests in the turborepo-process crate serially
 filter = 'package(turborepo-process)'
 test-group = 'turborepo-process-serial'


### PR DESCRIPTION
## Summary

- Adds nextest retry configuration (3 retries) for the `lockfile-aware-caching/bun` prysk test, which has been failing intermittently in CI.