### PR TITLE
fix: Add nextest retries for flaky tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -20,9 +20,28 @@ turborepo-dirs-serial = { max-threads = 1 }
 
 
 [[profile.default.overrides]]
-# Mark flaky prysk test for retries
+filter = 'package(turborepo-api-client) and test(retry::test::handles_too_many_failures)'
+retries = 5
+
+[[profile.default.overrides]]
+filter = 'package(turbo) and test(run/unnamed-packages)'
+retries = 5
+
+[[profile.default.overrides]]
 filter = 'package(turbo) and test(lockfile-aware-caching/bun)'
-retries = 3
+retries = 5
+
+[[profile.default.overrides]]
+filter = 'package(turbo) and test(lockfile-aware-caching/npm)'
+retries = 5
+
+[[profile.default.overrides]]
+filter = 'package(turbo) and test(lockfile-aware-caching/berry)'
+retries = 5
+
+[[profile.default.overrides]]
+filter = 'package(turbo) and test(lockfile-aware-caching/new-package)'
+retries = 5
 
 [[profile.default.overrides]]
 # Run all tests in the turborepo-process crate serially


### PR DESCRIPTION
## Summary

- Adds 5 retries for several flaky tests that have been intermittently failing in CI
- Bumps existing `lockfile-aware-caching/bun` retries from 3 to 5 for consistency

Tests covered:
- `turborepo-api-client::retry::test::handles_too_many_failures`
- `turbo::run/unnamed-packages`
- `turbo::lockfile-aware-caching/bun`
- `turbo::lockfile-aware-caching/npm`
- `turbo::lockfile-aware-caching/berry`
- `turbo::lockfile-aware-caching/new-package`