### PR TITLE
ci: Increase Rust test partitions from 4 to 10

### DIFF
--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -109,7 +109,7 @@ jobs:
 
           # Detect if Rust/core code changed (requires Rust tests + integration tests)
           # This excludes JS-only changes like packages/*, lockfile, etc.
-          RUST_PATTERNS="^(crates/|cli/|Cargo\.|rust-toolchain|\.cargo/|turborepo-tests/)"
+          RUST_PATTERNS="^(crates/|cli/|Cargo\.|rust-toolchain|\.cargo/|\.github/|turborepo-tests/)"
           RUST_CHANGES=$(echo "$CHANGED_FILES" | grep -E "$RUST_PATTERNS" || true)
 
           if [ -n "$RUST_CHANGES" ]; then


### PR DESCRIPTION
## Summary

- Increases Rust test nextest partitions from 4 to 10 across all CI jobs (macOS, Windows, Ubuntu) to reduce per-partition test time
- Updates the coverage merge step to combine all 10 partition lcov files