### PR TITLE
ci: Use larger runners for macOS Rust tests

### DIFF
--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -109,7 +109,7 @@ jobs:
 
           # Detect if Rust/core code changed (requires Rust tests + integration tests)
           # This excludes JS-only changes like packages/*, lockfile, etc.
-          RUST_PATTERNS="^(crates/|cli/|Cargo\.|rust-toolchain|\.cargo/|turborepo-tests/)"
+          RUST_PATTERNS="^(crates/|cli/|Cargo\.|rust-toolchain|\.cargo/|\.github/|turborepo-tests/)"
           RUST_CHANGES=$(echo "$CHANGED_FILES" | grep -E "$RUST_PATTERNS" || true)
 
           if [ -n "$RUST_CHANGES" ]; then
@@ -161,7 +161,7 @@ jobs:
       matrix:
         os:
           - name: macos
-            runner: macos-latest
+            runner: macos-latest-xlarge
           - name: windows
             runner: windows-latest
         partition: [1, 2, 3, 4]


### PR DESCRIPTION
## Summary

- Upgrade macOS test runner from `macos-latest` (3 vCPU M1) to `macos-latest-xlarge` (6 vCPU M2)
- Add `.github/` to the Rust change detection pattern so CI workflow changes trigger Rust test jobs

## Expected impact

macOS larger runners are available by just changing the label — no org setup needed. The M2 runner has 6 vCPUs vs 3, so the parallel Rust compilation phase should roughly halve.

## Results from this PR's CI run

Compare macOS partition times against [this baseline run](https://github.com/vercel/turborepo/actions/runs/22464281795).