### PR TITLE
fix: Add nextest retries for flaky prysk tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -44,6 +44,14 @@ filter = 'package(turbo) and test(lockfile-aware-caching/new-package)'
 retries = 5
 
 [[profile.default.overrides]]
+filter = 'package(turbo) and test(other/affected)'
+retries = 5
+
+[[profile.default.overrides]]
+filter = 'package(turbo) and test(run/continue)'
+retries = 5
+
+[[profile.default.overrides]]
 # Run all tests in the turborepo-process crate serially
 filter = 'package(turborepo-process)'
 test-group = 'turborepo-process-serial'


### PR DESCRIPTION
## Summary

- Adds `retries = 5` for the `other/affected` and `run/continue` prysk tests that have been flaking in CI.