### PR TITLE
ci: Disable flaky Rust unit tests from release pipeline

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -245,31 +245,32 @@ jobs:
           cd cli && make stage-release
           echo "stage-branch=$(git branch --show-current)" >> $GITHUB_OUTPUT
 
-  rust-smoke-test:
-    name: Rust Unit Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    needs: [stage]
-    if: ${{ always() && needs.stage.result == 'success' }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.stage.outputs.stage-branch }}
-
-      - name: Setup Environment
-        uses: ./.github/actions/setup-environment
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          node: "false"
-
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532
-        with:
-          tool: nextest
-
-      - name: Run tests
-        timeout-minutes: 30
-        run: cargo nextest run --workspace
+  # TODO: Re-enable Rust unit tests once flakiness is resolved.
+  # rust-smoke-test:
+  #   name: Rust Unit Tests
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 30
+  #   needs: [stage]
+  #   if: ${{ always() && needs.stage.result == 'success' }}
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ needs.stage.outputs.stage-branch }}
+  #
+  #     - name: Setup Environment
+  #       uses: ./.github/actions/setup-environment
+  #       with:
+  #         github-token: ${{ secrets.GITHUB_TOKEN }}
+  #         node: "false"
+  #
+  #     - name: Install cargo-nextest
+  #       uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532
+  #       with:
+  #         tool: nextest
+  #
+  #     - name: Run tests
+  #       timeout-minutes: 30
+  #       run: cargo nextest run --workspace
 
   js-smoke-test:
     name: JS Package Tests
@@ -429,8 +430,9 @@ jobs:
     name: "Publish To NPM"
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: [stage, build-rust, build-gen, rust-smoke-test, js-smoke-test]
-    if: ${{ always() && needs.stage.result == 'success' && needs.build-rust.result == 'success' && needs.build-gen.result == 'success' && needs.rust-smoke-test.result == 'success' && needs.js-smoke-test.result == 'success' }}
+    # TODO: Add rust-smoke-test back to needs and if-condition when re-enabled.
+    needs: [stage, build-rust, build-gen, js-smoke-test]
+    if: ${{ always() && needs.stage.result == 'success' && needs.build-rust.result == 'success' && needs.build-gen.result == 'success' && needs.js-smoke-test.result == 'success' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -730,12 +732,12 @@ jobs:
     name: "Cleanup Failed Release"
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # TODO: Add rust-smoke-test back to needs and if-condition when re-enabled.
     needs:
       [
         stage,
         build-rust,
         build-gen,
-        rust-smoke-test,
         js-smoke-test,
         npm-publish,
         create-release-tag,
@@ -748,7 +750,6 @@ jobs:
         && (
           needs.build-rust.result == 'failure'
           || needs.build-gen.result == 'failure'
-          || needs.rust-smoke-test.result == 'failure'
           || needs.js-smoke-test.result == 'failure'
           || needs.npm-publish.result == 'failure'
           || needs.create-release-tag.result == 'failure'


### PR DESCRIPTION
## Summary

- Comments out the `rust-smoke-test` job from the release pipeline due to persistent flakiness
- Removes `rust-smoke-test` as a blocking dependency from `npm-publish` and `cleanup-on-failure`
- TODO comments mark each location where `rust-smoke-test` needs to be re-added once stabilized