### PR TITLE
fix(frameworks): also check devDependencies when inferring framework in single-package mode

### DIFF
--- a/crates/turborepo-frameworks/src/lib.rs
+++ b/crates/turborepo-frameworks/src/lib.rs
@@ -86,23 +86,32 @@ fn get_frameworks() -> &'static Vec<Framework> {
 impl Matcher {
     pub fn test(&self, workspace: &PackageInfo, is_monorepo: bool) -> bool {
         // In the case where we're not in a monorepo, i.e. single package mode
-        // `unresolved_external_dependencies` is not populated. In which
-        // case we should check `dependencies` instead.
-        let deps = if is_monorepo {
-            workspace.unresolved_external_dependencies.as_ref()
-        } else {
-            workspace.package_json.dependencies.as_ref()
+        // `unresolved_external_dependencies` is not populated. In which case we
+        // should check `dependencies` and `dev_dependencies` instead, as frameworks
+        // (e.g. Vite, Astro, SvelteKit) are typically installed as devDependencies.
+        let contains = |dep: &str| -> bool {
+            if is_monorepo {
+                workspace
+                    .unresolved_external_dependencies
+                    .as_ref()
+                    .is_some_and(|deps| deps.contains_key(dep))
+            } else {
+                workspace
+                    .package_json
+                    .dependencies
+                    .as_ref()
+                    .is_some_and(|deps| deps.contains_key(dep))
+                    || workspace
+                        .package_json
+                        .dev_dependencies
+                        .as_ref()
+                        .is_some_and(|deps| deps.contains_key(dep))
+            }
         };
 
         match self.strategy {
-            Strategy::All => self
-                .dependencies
-                .iter()
-                .all(|dep| deps.is_some_and(|deps| deps.contains_key(dep))),
-            Strategy::Some => self
-                .dependencies
-                .iter()
-                .any(|dep| deps.is_some_and(|deps| deps.contains_key(dep))),
+            Strategy::All => self.dependencies.iter().all(|dep| contains(dep)),
+            Strategy::Some => self.dependencies.iter().any(|dep| contains(dep)),
         }
     }
 }
@@ -249,6 +258,23 @@ mod tests {
         Some(get_framework_by_slug("nextjs")),
         false;
         "Finds next in non-monorepo"
+    )]
+    #[test_case(
+        PackageInfo {
+            package_json: PackageJson {
+              dev_dependencies: Some(
+                vec![("vite", "*")]
+                    .into_iter()
+                    .map(|(s1, s2)| (s1.to_string(), s2.to_string()))
+                    .collect()
+              ),
+              ..Default::default()
+            },
+            ..Default::default()
+        },
+        Some(get_framework_by_slug("vite")),
+        false;
+        "Finds vite in devDependencies in non-monorepo"
     )]
     fn test_infer_framework(
         workspace_info: PackageInfo,


### PR DESCRIPTION
## Problem

In non-monorepo projects (single-package mode), framework inference silently fails for any framework installed as a `devDependency` (e.g. Vite, Astro, SvelteKit, Vue CLI).

```bash
# package.json has vite in devDependencies
turbo build --dry=json | jq '{framework, inferred}'
# => {"framework": "", "inferred": []}

# after moving vite to dependencies — works fine
```

Root cause: `Matcher::test` in `crates/turborepo-frameworks/src/lib.rs` only checks `package_json.dependencies` in single-package mode. `dev_dependencies` is not consulted.

The monorepo path was unaffected because `unresolved_external_dependencies` is populated from all dep fields during graph construction.

This was flagged in the original PR review (#5746) but never resolved:
> "I realize this is just a port of Go behavior, but do we want to also check the other places dependencies could appear? Primarily devDependencies and optionalDependencies"

## Fix

Replace the single `deps` map reference with a `contains` closure that checks both `dependencies` and `dev_dependencies` in single-package mode. The logic applies to both `Strategy::All` and `Strategy::Some` branches.

## Testing

Added a test case: `Finds vite in devDependencies in non-monorepo`. All 15 existing tests continue to pass.

Fixes #12023