### PR TITLE
fix: Replace flaky pnpx symlink-dir with native NTFS junctions in find-turbo test

### DIFF
--- a/turborepo-tests/integration/tests/find-turbo/setup.sh
+++ b/turborepo-tests/integration/tests/find-turbo/setup.sh
@@ -7,23 +7,36 @@ FIXTURE_DIR=$2
 
 cp -a ${SCRIPT_DIR}/../../fixtures/find_turbo/$FIXTURE_DIR/. ${TARGET_DIR}/
 
-# We need to symlink: turbo -> .pnpm/turbo@1.0.0/node_modules/turbo
-# where `turbo` is the symlink
-# and `.pnpm/turbo@1.0.0/node_modules/turbo` is the path to symlink to
-# Note: using a nested if so it's easy to find the Windows checks in scripts around the codebase.
+# On Windows, git may check out symlinks (mode 120000) as plain text files
+# containing the target path instead of actual symlinks/junctions. The linked
+# fixture relies on two layers of symlinks that must be real junctions for
+# turbo's local binary discovery to work:
+#   Level 1: node_modules/turbo -> .pnpm/turbo@1.0.0/node_modules/turbo
+#   Level 2: .pnpm/turbo@1.0.0/node_modules/turbo-<platform> -> ../../turbo-<platform>@1.0.0/...
+#
+# We recreate all of them as NTFS junctions (mklink /J), which work without
+# Developer Mode or elevated privileges. Junction targets are resolved relative
+# to CWD (not the link's parent), so we use paths from the working directory.
 if [[ "$OSTYPE" == "msys" ]]; then
-   if [[ $FIXTURE_DIR == "linked" ]]; then
-    # Delete the existing turbo directory or file, whatever exists there
+  if [[ $FIXTURE_DIR == "linked" ]]; then
+    PNPM_STORE="node_modules/.pnpm"
+    PNPM_TURBO_NM="${PNPM_STORE}/turbo@1.0.0/node_modules"
+
+    # Level 1: node_modules/turbo -> .pnpm/turbo@1.0.0/node_modules/turbo
     rm -rf node_modules/turbo
+    cmd //c mklink //J \
+      "node_modules\\turbo" \
+      "${PNPM_TURBO_NM//\//\\}\\turbo" \
+      > /dev/null || exit 1
 
-    # Let's enter the node_modules directory
-    # echo "entering node_modules directory"
-    pushd node_modules > /dev/null || exit 1
-
-    # Use pnpx to run symlnk-dir because installing globally doesn't work with pnpm.
-    pnpx symlink-dir .pnpm/turbo@1.0.0/node_modules/turbo turbo > /dev/null 2>&1
-
-    # Get outta there
-    popd > /dev/null || exit 1
+    # Level 2: platform package symlinks inside the pnpm virtual store.
+    # Junction targets must be relative to CWD, not the link's parent.
+    for platform in darwin-64 darwin-arm64 linux-64 linux-arm64 windows-64 windows-arm64; do
+      rm -rf "${PNPM_TURBO_NM}/turbo-${platform}"
+      cmd //c mklink //J \
+        "${PNPM_TURBO_NM//\//\\}\\turbo-${platform}" \
+        "${PNPM_STORE//\//\\}\\turbo-${platform}@1.0.0\\node_modules\\turbo-${platform}" \
+        > /dev/null || exit 1
+    done
   fi
 fi


### PR DESCRIPTION
## Summary

- Fixes the flaky `find-turbo/linked.t` prysk test on Windows by replacing `pnpx symlink-dir` with native NTFS junctions (`mklink /J`)

## Problem

The `linked` fixture simulates a pnpm-style `node_modules` layout using git symlinks (mode `120000`). On Windows, these may be checked out as plain text files instead of real symlinks, depending on `core.symlinks` and Developer Mode availability.

The old `setup.sh` only recreated the **Level 1** symlink (`node_modules/turbo`) using `pnpx symlink-dir`, which:
- Is an external npm package that can silently fail (network, cache, pnpm issues)
- Has no error checking (output silenced with `> /dev/null 2>&1`)
- Never recreated the **Level 2** platform-specific symlinks (e.g. `turbo-windows-64 -> ../../turbo-windows-64@1.0.0/...`)

When either layer is broken, `LocalTurboState::infer()` fails to find the local binary, turbo falls back to global mode, and the test fails with exit code 1.

## Fix

- Remove `pnpx symlink-dir` dependency entirely (no network dependency in test setup)
- Create both Level 1 and Level 2 junctions via `cmd /c mklink /J` with error checking (`|| exit 1`)
- NTFS junctions work without Developer Mode or elevated privileges

## Testing

Verified the non-Windows code path is unaffected — `linked.t` passes on macOS. The Windows fix can only be validated in Windows CI.