### PR TITLE
fix: Prevent corepack download prompt from hanging prysk tests on Windows

### DIFF
--- a/crates/turborepo/tests/prysk.rs
+++ b/crates/turborepo/tests/prysk.rs
@@ -202,6 +202,11 @@ fn run_prysk_test(path: &Path) -> datatest_stable::Result<()> {
     cmd.env("NO_UPDATE_NOTIFIER", "1");
     cmd.env("NPM_CONFIG_UPDATE_NOTIFIER", "false");
 
+    // Prevent corepack from prompting to download package managers. Without
+    // this, corepack blocks on stdin in non-TTY environments (causing hangs
+    // on Windows CI).
+    cmd.env("COREPACK_ENABLE_DOWNLOAD_PROMPT", "0");
+
     // macOS tmp dirs set by prysk can fail — use /tmp directly.
     if cfg!(target_os = "macos") {
         cmd.env("TMPDIR", "/tmp");

--- a/turborepo-tests/helpers/setup_integration_test.sh
+++ b/turborepo-tests/helpers/setup_integration_test.sh
@@ -58,6 +58,7 @@ fi
 export TURBO_TELEMETRY_MESSAGE_DISABLED=1
 export TURBO_GLOBAL_WARNING_DISABLED=1
 export TURBO_PRINT_VERSION_DISABLED=1
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 export TURBO=${MONOREPO_ROOT_DIR}/target/debug/turbo${EXT}
 
 # Undo the set -eo pipefail at the top of this script


### PR DESCRIPTION
## Summary

- Sets `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` in both the Rust prysk test harness and the shell-based integration test setup to prevent indefinite hangs on Windows CI

## Problem

`run/single-package/run-yarn.t` hangs forever on Windows CI. The test uses `yarn@1.22.17` via corepack, which needs to download yarn on first invocation. Corepack (v0.20+) prompts on stdin before downloading — in a non-TTY environment like CI, this blocks indefinitely.

The prysk harness (`prysk.rs`) already strips `CI` and `GITHUB_*` env vars and sets other suppression flags, but was missing `COREPACK_ENABLE_DOWNLOAD_PROMPT=0`. The `setup_integration_test.sh` helper (used by run tests) also didn't set it, unlike the separate `setup.sh` helper (used by find-turbo tests) which already had it.

## Changes

| File | Change |
|------|--------|
| `crates/turborepo/tests/prysk.rs` | Add `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` to prysk env |
| `turborepo-tests/helpers/setup_integration_test.sh` | Export `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` alongside other suppression vars |

## Testing

`run-yarn.t` passes locally on macOS. The Windows hang can only be reproduced in Windows CI where corepack hasn't cached yarn yet.