### PR TITLE
perf: Use stack-allocated OidHash in FileHashes and skip expanded hashes on normal runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8102,6 +8102,7 @@ dependencies = [
  "tracing",
  "turbopath",
  "turborepo-ci",
+ "turborepo-hash",
  "turborepo-telemetry",
  "wax",
  "which",

--- a/crates/turborepo-hash/src/oid_hash.rs
+++ b/crates/turborepo-hash/src/oid_hash.rs
@@ -1,0 +1,75 @@
+/// A fixed-size, stack-allocated git OID hex string (40 bytes, SHA-1).
+///
+/// Avoids heap allocation for the ~10K+ file hashes created during index
+/// building and per-package hash computation. Implements `Deref<Target=str>`
+/// so all existing `&str` consumers work unchanged.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct OidHash([u8; 40]);
+
+impl OidHash {
+    /// Create from a pre-filled 40-byte hex buffer.
+    /// Caller must ensure `buf` contains valid lowercase ASCII hex.
+    pub fn from_hex_buf(buf: [u8; 40]) -> Self {
+        Self(buf)
+    }
+
+    /// Create from a hex-encoded string slice.
+    pub fn from_hex_str(s: &str) -> Self {
+        debug_assert_eq!(s.len(), 40, "OID hex must be exactly 40 chars");
+        let mut buf = [0u8; 40];
+        buf.copy_from_slice(s.as_bytes());
+        Self(buf)
+    }
+}
+
+impl std::ops::Deref for OidHash {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        // SAFETY: OidHash is always constructed from valid ASCII hex bytes.
+        unsafe { std::str::from_utf8_unchecked(&self.0) }
+    }
+}
+
+impl AsRef<str> for OidHash {
+    fn as_ref(&self) -> &str {
+        self
+    }
+}
+
+impl std::borrow::Borrow<str> for OidHash {
+    fn borrow(&self) -> &str {
+        self
+    }
+}
+
+impl std::fmt::Debug for OidHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self)
+    }
+}
+
+impl std::fmt::Display for OidHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self)
+    }
+}
+
+impl PartialEq<str> for OidHash {
+    fn eq(&self, other: &str) -> bool {
+        self.0 == other.as_bytes()
+    }
+}
+
+impl PartialEq<&str> for OidHash {
+    fn eq(&self, other: &&str) -> bool {
+        self.0 == other.as_bytes()
+    }
+}
+
+impl From<OidHash> for String {
+    fn from(oid: OidHash) -> Self {
+        // SAFETY: OidHash is always valid ASCII hex.
+        unsafe { String::from_utf8_unchecked(oid.0.to_vec()) }
+    }
+}

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -617,6 +617,9 @@ impl Run {
         rayon::scope(|s| {
             s.spawn(|_| {
                 let _span = tracing::info_span!("calculate_file_hashes_task").entered();
+                let needs_expanded = self.opts.run_opts.dry_run.is_some()
+                    || self.opts.run_opts.summarize
+                    || self.observability_handle.is_some();
                 file_hash_result = Some(PackageInputsHashes::calculate_file_hashes(
                     &self.scm,
                     self.engine.tasks(),
@@ -625,6 +628,7 @@ impl Run {
                     &self.repo_root,
                     &self.run_telemetry,
                     repo_index,
+                    needs_expanded,
                 ));
             });
             s.spawn(|_| {

--- a/crates/turborepo-run-cache/src/lib.rs
+++ b/crates/turborepo-run-cache/src/lib.rs
@@ -579,10 +579,7 @@ impl ConfigCache {
                 Err(_) => return Err(CacheError::ConfigCacheError),
             };
 
-        let mut file_hashes: Vec<_> = hash_object
-            .into_iter()
-            .map(|(k, v)| (k, String::from(v)))
-            .collect();
+        let mut file_hashes: Vec<_> = hash_object.into_iter().collect();
         file_hashes.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
         Ok(FileHashes(file_hashes).hash())
     }

--- a/crates/turborepo-scm/Cargo.toml
+++ b/crates/turborepo-scm/Cargo.toml
@@ -26,6 +26,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 turbopath = { workspace = true }
 turborepo-ci = { workspace = true }
+turborepo-hash = { path = "../turborepo-hash" }
 turborepo-telemetry = { path = "../turborepo-telemetry" }
 wax = { workspace = true }
 which = { workspace = true }

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -35,6 +35,7 @@ mod git_index_regression_tests;
 mod test_utils;
 
 pub use repo_index::RepoGitIndex;
+pub use turborepo_hash::OidHash;
 pub use worktree::WorktreeInfo;
 
 #[derive(Debug, Error)]
@@ -69,82 +70,6 @@ pub enum Error {
     Walk(#[from] globwalk::WalkError),
     #[error("Unable to resolve base branch. Please set with `TURBO_SCM_BASE`.")]
     UnableToResolveRef,
-}
-
-/// A fixed-size, stack-allocated git OID hex string (40 bytes, SHA-1).
-///
-/// Avoids heap allocation for the ~10K+ file hashes created during index
-/// building and per-package hash computation. Implements `Deref<Target=str>`
-/// so all existing `&str` consumers work unchanged.
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
-pub struct OidHash([u8; 40]);
-
-impl OidHash {
-    /// Create from a pre-filled 40-byte hex buffer.
-    /// Caller must ensure `buf` contains valid lowercase ASCII hex.
-    pub fn from_hex_buf(buf: [u8; 40]) -> Self {
-        Self(buf)
-    }
-
-    /// Create from a hex-encoded string slice.
-    pub fn from_hex_str(s: &str) -> Self {
-        debug_assert_eq!(s.len(), 40, "OID hex must be exactly 40 chars");
-        let mut buf = [0u8; 40];
-        buf.copy_from_slice(s.as_bytes());
-        Self(buf)
-    }
-}
-
-impl std::ops::Deref for OidHash {
-    type Target = str;
-
-    fn deref(&self) -> &str {
-        // SAFETY: OidHash is always constructed from valid ASCII hex bytes.
-        unsafe { std::str::from_utf8_unchecked(&self.0) }
-    }
-}
-
-impl AsRef<str> for OidHash {
-    fn as_ref(&self) -> &str {
-        self
-    }
-}
-
-impl std::borrow::Borrow<str> for OidHash {
-    fn borrow(&self) -> &str {
-        self
-    }
-}
-
-impl std::fmt::Debug for OidHash {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self)
-    }
-}
-
-impl std::fmt::Display for OidHash {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self)
-    }
-}
-
-impl PartialEq<str> for OidHash {
-    fn eq(&self, other: &str) -> bool {
-        self.0 == other.as_bytes()
-    }
-}
-
-impl PartialEq<&str> for OidHash {
-    fn eq(&self, other: &&str) -> bool {
-        self.0 == other.as_bytes()
-    }
-}
-
-impl From<OidHash> for String {
-    fn from(oid: OidHash) -> Self {
-        // SAFETY: OidHash is always valid ASCII hex.
-        unsafe { String::from_utf8_unchecked(oid.0.to_vec()) }
-    }
 }
 
 pub type GitHashes = HashMap<RelativeUnixPathBuf, OidHash>;


### PR DESCRIPTION
## Summary

Two memory optimizations targeting large monorepos where per-file hash storage is a significant memory consumer.

- **`FileHashes` now stores `OidHash` instead of `String`** — eliminates one heap allocation (~80-96 bytes) per file across the entire repo. `OidHash` is a 40-byte stack-allocated `Copy` type. The `OidHash` → `String` conversion now only happens at the `expanded_inputs` trait boundary, which only runs for `--summarize`/`--dry` JSON output.

- **Expanded hashes are conditional** — `calculate_file_hashes` takes a `needs_expanded_hashes` flag. On normal `turbo run` (no `--dry`, `--summarize`, or observability), the per-file `Arc<FileHashes>` maps are computed for the collapsed task hash but not retained in `TaskHashTracker`. This skips `O(tasks × files)` of path+hash data that previously lived for the entire run.

## What changed

- **`crates/turborepo-hash/src/oid_hash.rs`** (new) — `OidHash` moved from `turborepo-scm` to `turborepo-hash`. It's a pure hash-value type, architecturally belonging with `FileHashes` and `TurboHash`.

- **`crates/turborepo-hash/src/lib.rs`** — `FileHashes` inner type changed from `String` to `OidHash`. Capnp serialization uses `&**value` (deref to `&str`).

- **`crates/turborepo-scm/src/lib.rs`** — Removed `OidHash` definition, re-exports from `turborepo_hash`.

- **`crates/turborepo-task-hash/src/lib.rs`** — Removed three `String::from(v)` conversions when constructing `FileHashes`. Added `needs_expanded_hashes` parameter to `calculate_file_hashes`. Added `OidHash` → `String` conversion in `expanded_inputs` trait impl (the single JSON boundary point).

- **`crates/turborepo-run-cache/src/lib.rs`** — Removed `String::from(v)` conversion.

- **`crates/turborepo-lib/src/run/mod.rs`** — Passes `needs_expanded_hashes` flag computed from `dry_run`, `summarize`, and `observability_handle`.

## Testing

- Added `test_expanded_inputs_none_when_not_collected` — verifies that when `TaskHashTracker` is constructed with an empty expanded hashes map (simulating `needs_expanded_hashes=false`), `get_expanded_inputs` returns `None` rather than panicking, even though the collapsed task hash exists.
- Updated all existing `FileHashes` test values to use valid 40-char hex strings for `OidHash`.
- All 365 tests across affected crates pass.