### PR TITLE
refactor: Clean up test infrastructure and eliminate duplication

### DIFF
--- a/crates/turborepo/tests/affected_test.rs
+++ b/crates/turborepo/tests/affected_test.rs
@@ -2,17 +2,7 @@ mod common;
 
 use std::fs;
 
-use common::{run_turbo, run_turbo_with_env, setup};
-
-fn git(dir: &std::path::Path, args: &[&str]) {
-    std::process::Command::new("git")
-        .args(args)
-        .current_dir(dir)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .unwrap();
-}
+use common::{git, run_turbo, run_turbo_with_env, setup};
 
 fn setup_affected(dir: &std::path::Path) {
     setup::setup_integration_test(dir, "basic_monorepo", "npm@10.5.0", true).unwrap();
@@ -90,7 +80,6 @@ fn test_affected_dependency_changed() {
     let tempdir = tempfile::tempdir().unwrap();
     setup_affected(tempdir.path());
 
-    // Add file to util — should affect both util and my-app
     fs::write(tempdir.path().join("packages/util/new.js"), "hello world").unwrap();
 
     let output = run_turbo(
@@ -108,7 +97,6 @@ fn test_affected_dependency_changed() {
     assert!(names.contains(&"util"));
     assert!(names.contains(&"my-app"));
 
-    // Check reasons
     let util_item = items.iter().find(|i| i["name"] == "util").unwrap();
     assert_eq!(util_item["reason"]["__typename"], "FileChanged");
     let app_item = items.iter().find(|i| i["name"] == "my-app").unwrap();
@@ -120,7 +108,6 @@ fn test_affected_committed_change() {
     let tempdir = tempfile::tempdir().unwrap();
     setup_affected(tempdir.path());
 
-    // Add and commit a package.json change
     let pkg_path = tempdir.path().join("apps/my-app/package.json");
     let contents = fs::read_to_string(&pkg_path).unwrap();
     let mut pkg: serde_json::Value = serde_json::from_str(&contents).unwrap();
@@ -144,7 +131,6 @@ fn test_affected_scm_base_override() {
     git(tempdir.path(), &["add", "."]);
     git(tempdir.path(), &["commit", "-m", "add foo", "--quiet"]);
 
-    // Override SCM base to HEAD so nothing is affected
     let output = run_turbo_with_env(
         tempdir.path(),
         &["run", "build", "--affected", "--log-order", "grouped"],
@@ -166,7 +152,6 @@ fn test_affected_scm_head_override() {
     git(tempdir.path(), &["add", "."]);
     git(tempdir.path(), &["commit", "-m", "add foo", "--quiet"]);
 
-    // Override SCM head to main so nothing is affected
     let output = run_turbo_with_env(
         tempdir.path(),
         &["run", "build", "--affected", "--log-order", "grouped"],
@@ -184,7 +169,6 @@ fn test_affected_merge_base_diverged() {
     let tempdir = tempfile::tempdir().unwrap();
     setup_affected(tempdir.path());
 
-    // Add change on my-branch and commit
     let pkg_path = tempdir.path().join("apps/my-app/package.json");
     let contents = fs::read_to_string(&pkg_path).unwrap();
     let mut pkg: serde_json::Value = serde_json::from_str(&contents).unwrap();
@@ -193,7 +177,6 @@ fn test_affected_merge_base_diverged() {
     git(tempdir.path(), &["add", "."]);
     git(tempdir.path(), &["commit", "-m", "add foo", "--quiet"]);
 
-    // Add a commit to main so merge base diverges
     git(tempdir.path(), &["checkout", "main", "--quiet"]);
     let index_path = tempdir.path().join("packages/util/index.js");
     let mut idx = fs::read_to_string(&index_path).unwrap_or_default();
@@ -203,7 +186,6 @@ fn test_affected_merge_base_diverged() {
     git(tempdir.path(), &["commit", "-m", "add foo", "--quiet"]);
     git(tempdir.path(), &["checkout", "my-branch", "--quiet"]);
 
-    // Only my-app should be affected (between merge-base and my-branch)
     let output = run_turbo(tempdir.path(), &["ls", "--affected"]);
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("my-app"));

--- a/crates/turborepo/tests/command_logout_test.rs
+++ b/crates/turborepo/tests/command_logout_test.rs
@@ -2,20 +2,12 @@ mod common;
 
 use std::path::Path;
 
-use common::mock_turbo_config;
+use common::{mock_turbo_config, turbo_command};
 
 fn run_logout(config_dir: &Path) -> std::process::Output {
     let tempdir = tempfile::tempdir().unwrap();
-    let mut cmd = assert_cmd::Command::cargo_bin("turbo").expect("turbo binary not found");
-    cmd.env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
-        .env("TURBO_GLOBAL_WARNING_DISABLED", "1")
-        .env("TURBO_PRINT_VERSION_DISABLED", "1")
-        .env("TURBO_CONFIG_DIR_PATH", config_dir)
-        .env("DO_NOT_TRACK", "1")
-        .env_remove("CI")
-        .env_remove("GITHUB_ACTIONS")
-        .current_dir(tempdir.path())
-        .arg("logout");
+    let mut cmd = turbo_command(tempdir.path());
+    cmd.env("TURBO_CONFIG_DIR_PATH", config_dir).arg("logout");
     cmd.output().expect("failed to execute turbo")
 }
 
@@ -38,11 +30,9 @@ fn test_logout_while_logged_out() {
     let config_dir = tempfile::tempdir().unwrap();
     mock_turbo_config(config_dir.path());
 
-    // First logout removes the token
     let output1 = run_logout(config_dir.path());
     assert!(output1.status.success());
 
-    // Second logout against the same (now token-less) config dir
     let output2 = run_logout(config_dir.path());
     assert!(output2.status.success());
     let stdout = String::from_utf8_lossy(&output2.stdout);

--- a/crates/turborepo/tests/common/setup.rs
+++ b/crates/turborepo/tests/common/setup.rs
@@ -69,9 +69,7 @@ fn copy_symlink(src: &Path, dst: &Path) -> Result<(), anyhow::Error> {
 }
 
 /// Initialize a git repository in `target_dir` with a single commit.
-///
-/// Initialize a git repo in the test directory.
-///   git init, configure user, write .npmrc, git add ., git commit
+/// Configures user, writes .npmrc, adds all files, and commits.
 pub fn setup_git(target_dir: &Path) -> Result<(), anyhow::Error> {
     let git = |args: &[&str]| -> Result<(), anyhow::Error> {
         let status = cmd("git")
@@ -106,11 +104,8 @@ pub fn setup_git(target_dir: &Path) -> Result<(), anyhow::Error> {
 }
 
 /// Write the `packageManager` field into `package.json` and configure corepack.
-///
-/// Returns the path to the corepack install directory (outside `target_dir` so
-/// corepack shims don't appear as task inputs).
-///
-/// Set up the package manager (corepack enable + use).
+/// The corepack install directory is placed outside `target_dir` so corepack
+/// shims don't appear as task inputs.
 pub fn setup_package_manager(
     target_dir: &Path,
     package_manager: &str,
@@ -155,8 +150,6 @@ pub fn setup_package_manager(
 }
 
 /// Install dependencies using the specified package manager.
-///
-/// Install dependencies via the package manager.
 pub fn install_deps(
     target_dir: &Path,
     package_manager: &str,

--- a/crates/turborepo/tests/find_correct_turbo_test.rs
+++ b/crates/turborepo/tests/find_correct_turbo_test.rs
@@ -2,27 +2,21 @@ mod common;
 
 use std::path::Path;
 
+use common::turbo_command;
+
 #[test]
 fn test_bin_matches_running_binary() {
     let tempdir = tempfile::tempdir().unwrap();
-    // Point --cwd at the repo root so turbo can find turbo.json
     let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../");
 
-    let mut cmd = assert_cmd::Command::cargo_bin("turbo").expect("turbo binary not found");
-    cmd.env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
-        .env("TURBO_GLOBAL_WARNING_DISABLED", "1")
-        .env("TURBO_PRINT_VERSION_DISABLED", "1")
-        .env("DO_NOT_TRACK", "1")
-        .env_remove("CI")
-        .env_remove("GITHUB_ACTIONS")
-        .current_dir(tempdir.path())
-        .args(["--cwd", repo_root.to_str().unwrap(), "bin"]);
+    let output = turbo_command(tempdir.path())
+        .args(["--cwd", repo_root.to_str().unwrap(), "bin"])
+        .output()
+        .expect("failed to execute turbo");
 
-    let output = cmd.output().expect("failed to execute turbo");
     let stdout = String::from_utf8_lossy(&output.stdout);
     let bin_path = stdout.trim();
 
-    // The `turbo bin` output should resolve to the same binary we're testing
     assert!(!bin_path.is_empty(), "turbo bin should output a path");
 
     let expected = assert_cmd::cargo::cargo_bin("turbo");

--- a/crates/turborepo/tests/lockfile_new_package_test.rs
+++ b/crates/turborepo/tests/lockfile_new_package_test.rs
@@ -2,14 +2,13 @@ mod common;
 
 use std::fs;
 
-use common::setup_lockfile_test;
+use common::{setup_lockfile_test, turbo_command};
 
 #[test]
 fn test_new_package_in_lockfile_filter() {
     let tempdir = tempfile::tempdir().unwrap();
     setup_lockfile_test(tempdir.path(), "pnpm");
 
-    // Add new package with an external dependency
     fs::create_dir_all(tempdir.path().join("apps/c")).unwrap();
     fs::write(
         tempdir.path().join("apps/c/package.json"),
@@ -26,20 +25,12 @@ fn test_new_package_in_lockfile_filter() {
         .status()
         .ok();
 
-    // We need --skip-infer because pnpm install creates a local turbo in
-    // node_modules, and without it the shim would delegate to that binary.
-    // We also filter out the root package (//) since we only care about c.
+    // --skip-infer needed because pnpm install creates a local turbo in
+    // node_modules, and the shim would delegate to it otherwise.
     let config_dir = tempfile::tempdir().unwrap();
-    let output = std::process::Command::new(assert_cmd::cargo::cargo_bin("turbo"))
-        .env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
-        .env("TURBO_GLOBAL_WARNING_DISABLED", "1")
-        .env("TURBO_PRINT_VERSION_DISABLED", "1")
+    let output = turbo_command(tempdir.path())
         .env("TURBO_CONFIG_DIR_PATH", config_dir.path())
-        .env("DO_NOT_TRACK", "1")
         .env("MSYS_NO_PATHCONV", "1")
-        .env_remove("CI")
-        .env_remove("GITHUB_ACTIONS")
-        .current_dir(tempdir.path())
         .args([
             "--skip-infer",
             "build",
@@ -52,7 +43,6 @@ fn test_new_package_in_lockfile_filter() {
         .output()
         .expect("failed to execute turbo");
 
-    // Suppress stderr (warnings about experimental features, etc.)
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
         panic!(
             "expected valid JSON, got error {e}\nstdout: {}\nstderr: {}",

--- a/crates/turborepo/tests/recursive_turbo_test.rs
+++ b/crates/turborepo/tests/recursive_turbo_test.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{run_turbo, setup};
+use common::{combined_output, run_turbo, setup};
 
 #[test]
 fn test_recursive_turbo_invocation_detected() {
@@ -8,9 +8,7 @@ fn test_recursive_turbo_invocation_detected() {
     setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
 
     let output = run_turbo(tempdir.path(), &["something"]);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let combined = format!("{stdout}{stderr}");
+    let combined = combined_output(&output);
 
     assert!(
         combined.contains("recursive_turbo_invocations"),

--- a/crates/turborepo/tests/run_summary.rs
+++ b/crates/turborepo/tests/run_summary.rs
@@ -2,33 +2,7 @@ mod common;
 
 use std::{fs, path::Path};
 
-use common::{run_turbo, run_turbo_with_env, setup};
-
-fn replace_turbo_json(dir: &Path, config_name: &str) {
-    let workspace_root =
-        dunce::canonicalize(Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")).unwrap();
-    let src = workspace_root
-        .join("turborepo-tests/integration/fixtures/turbo-configs")
-        .join(config_name);
-    fs::copy(&src, dir.join("turbo.json")).unwrap();
-    let normalized = fs::read_to_string(dir.join("turbo.json"))
-        .unwrap()
-        .replace("\r\n", "\n");
-    fs::write(dir.join("turbo.json"), normalized).unwrap();
-    std::process::Command::new("git")
-        .args([
-            "commit",
-            "-am",
-            "replace turbo.json",
-            "--quiet",
-            "--allow-empty",
-        ])
-        .current_dir(dir)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .unwrap();
-}
+use common::{replace_turbo_json, run_turbo, run_turbo_with_env, setup};
 
 fn read_run_summaries(dir: &Path) -> Vec<serde_json::Value> {
     let runs_dir = dir.join(".turbo/runs");

--- a/crates/turborepo/tests/shim_errors_test.rs
+++ b/crates/turborepo/tests/shim_errors_test.rs
@@ -1,19 +1,14 @@
 mod common;
 
+use common::turbo_command;
+
 #[test]
 fn test_cwd_no_value() {
     let tempdir = tempfile::tempdir().unwrap();
-    let mut cmd = assert_cmd::Command::cargo_bin("turbo").expect("turbo binary not found");
-    cmd.env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
-        .env("TURBO_GLOBAL_WARNING_DISABLED", "1")
-        .env("TURBO_PRINT_VERSION_DISABLED", "1")
-        .env("DO_NOT_TRACK", "1")
-        .env_remove("CI")
-        .env_remove("GITHUB_ACTIONS")
-        .current_dir(tempdir.path())
-        .args(["foo", "bar", "--cwd"]);
-
-    let output = cmd.output().unwrap();
+    let output = turbo_command(tempdir.path())
+        .args(["foo", "bar", "--cwd"])
+        .output()
+        .unwrap();
     assert!(!output.status.success());
 
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -26,19 +21,12 @@ fn test_cwd_no_value() {
 #[test]
 fn test_multiple_cwd_flags() {
     let tempdir = tempfile::tempdir().unwrap();
-    let mut cmd = assert_cmd::Command::cargo_bin("turbo").expect("turbo binary not found");
-    cmd.env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
-        .env("TURBO_GLOBAL_WARNING_DISABLED", "1")
-        .env("TURBO_PRINT_VERSION_DISABLED", "1")
-        .env("DO_NOT_TRACK", "1")
-        .env_remove("CI")
-        .env_remove("GITHUB_ACTIONS")
-        .current_dir(tempdir.path())
+    let output = turbo_command(tempdir.path())
         .args([
             "--cwd", "foo", "--cwd", "--bar", "--cwd", "baz", "--cwd", "qux",
-        ]);
-
-    let output = cmd.output().unwrap();
+        ])
+        .output()
+        .unwrap();
     assert!(!output.status.success());
 
     let stderr = String::from_utf8_lossy(&output.stderr);

--- a/crates/turborepo/tests/strict_env_vars.rs
+++ b/crates/turborepo/tests/strict_env_vars.rs
@@ -2,35 +2,7 @@ mod common;
 
 use std::{fs, path::Path};
 
-use common::{run_turbo, run_turbo_with_env, setup};
-
-fn turbo_configs_dir() -> std::path::PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../../turborepo-tests/integration/fixtures/turbo-configs")
-}
-
-fn replace_turbo_json(dir: &Path, config_name: &str) {
-    let src = turbo_configs_dir().join(config_name);
-    fs::copy(&src, dir.join("turbo.json"))
-        .unwrap_or_else(|e| panic!("copy {} failed: {e}", src.display()));
-    let normalized = fs::read_to_string(dir.join("turbo.json"))
-        .unwrap()
-        .replace("\r\n", "\n");
-    fs::write(dir.join("turbo.json"), normalized).unwrap();
-    std::process::Command::new("git")
-        .args([
-            "commit",
-            "-am",
-            "replace turbo.json",
-            "--quiet",
-            "--allow-empty",
-        ])
-        .current_dir(dir)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .unwrap();
-}
+use common::{replace_turbo_json, run_turbo, run_turbo_with_env, setup};
 
 /// Get all task hashes as a sorted string. When the global hash (including
 /// env mode) changes, all task hashes change.


### PR DESCRIPTION
## Summary

Refactors the Rust integration test infrastructure to eliminate code duplication accumulated across the prysk porting effort.

**New shared helpers in `common/mod.rs`:**
- `turbo_command(test_dir)` — returns a pre-configured `Command` with all standard env var suppression. Tests chain `.arg()`, `.env()` as needed. Replaces 6+ local reimplementations.
- `git(dir, args)` — silent git command runner. Replaces 3 duplicate `fn git()` definitions and ~15 inline `Command::new("git")` blocks.
- `combined_output(output)` — merges stdout+stderr. Replaces 4 local definitions.
- `replace_turbo_json_from(dir, configs_dir, config_name)` — parameterized variant for different fixture directories.

**Files migrated to shared helpers:**
- `command_link_test.rs`, `command_logout_test.rs`, `command_telemetry_test.rs` — local `run_turbo_with_config` / `run_logout` / `run_telemetry` replaced with `turbo_command()`
- `shim_errors_test.rs`, `find_correct_turbo_test.rs`, `lockfile_new_package_test.rs` — inline command building replaced with `turbo_command()`
- `find_turbo_test.rs` — local `run_turbo_vv` and `combined_output` replaced with shared versions
- `affected_test.rs`, `affected_rdeps_test.rs`, `lockfile_aware_caching_test.rs`, `filter_run_test.rs`, `single_package_dry_run_test.rs`, `gitignored_inputs_test.rs` — local `git()` and inline git commands replaced with `common::git()`
- `strict_env_vars.rs`, `run_summary.rs` — duplicate `replace_turbo_json` + `turbo_configs_dir` deleted, using `common::replace_turbo_json`
- `recursive_turbo_test.rs` — inline `format!` replaced with `common::combined_output()`
- `check_json_output!` macro — now uses `turbo_command()` instead of duplicating env var setup

**Minor cleanups:**
- Renamed `walkdir` -> `find_files_by_name`
- Removed `set_find_turbo_version_inner` / `set_find_turbo_link_inner` (direct recursion)
- Fixed duplicate doc comments in `setup.rs`
- Added `#![allow(dead_code)]` at module level in `common/mod.rs` and `setup.rs`

~250 lines removed, 18 files touched. Zero behavioral changes.