### PR TITLE
ci: Exclude turborepo-lsp and turborepo-schema-gen from test builds

### DIFF
--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -240,9 +240,9 @@ jobs:
             unset RUSTC_WRAPPER
           fi
           if [ "$RUNNER_OS" == "Windows" ]; then
-              cargo nextest run --workspace --exclude turborepo-napi --no-fail-fast --partition hash:${{ matrix.partition }}/10
+              cargo nextest run --workspace --exclude turborepo-napi --exclude turborepo-lsp --exclude turborepo-schema-gen --no-fail-fast --partition hash:${{ matrix.partition }}/10
           else
-              cargo nextest run --workspace --no-fail-fast --partition hash:${{ matrix.partition }}/10
+              cargo nextest run --workspace --exclude turborepo-lsp --exclude turborepo-schema-gen --no-fail-fast --partition hash:${{ matrix.partition }}/10
           fi
         shell: bash
 
@@ -316,6 +316,8 @@ jobs:
           cargo llvm-cov nextest \
             --workspace \
             --exclude turborepo-napi \
+            --exclude turborepo-lsp \
+            --exclude turborepo-schema-gen \
             --partition hash:${{ matrix.partition }}/10 \
             --no-fail-fast \
             --lcov \


### PR DESCRIPTION
## Summary

- Excludes `turborepo-lsp` and `turborepo-schema-gen` from all `cargo nextest` and `cargo llvm-cov nextest` runs in CI.

## Why

Both crates are leaf nodes with zero reverse dependencies — nothing in the workspace depends on them. They have no tests we care about exercising in the main test workflow, but they were being compiled on every run because the workspace `members` glob catches them.

`turborepo-lsp` is particularly expensive because it depends on `turborepo-lib`, which pulls in ~30 transitive workspace crates. It compiles dead last in the dependency graph and contributes nothing to test coverage.

Lint and `cargo check` still cover both crates.

## Testing

The change is purely additive `--exclude` flags on existing CI commands. Existing tests are unaffected since these crates had no meaningful test coverage being exercised.