### PR TITLE
ci: Remove redundant cargo build from coverage job

### DIFF
--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -298,15 +298,6 @@ jobs:
         with:
           tool: cargo-llvm-cov
 
-      - name: Build turbo binary
-        timeout-minutes: 15
-        run: |
-          if [ -z "${RUSTC_WRAPPER}" ]; then
-            unset RUSTC_WRAPPER
-          fi
-          cargo build -p turbo
-        shell: bash
-
       - name: Run tests with coverage
         timeout-minutes: 45
         run: |


### PR DESCRIPTION
## Summary

- Removes the "Build turbo binary" step from the Ubuntu coverage job (`rust_test_ubuntu`).

## Why

`cargo llvm-cov nextest --workspace` already builds all targets, including the `turbo` binary, with coverage instrumentation into `target/llvm-cov-target/debug/`. The separate `cargo build -p turbo` step was building an **uninstrumented** binary into `target/debug/` that was never used — `assert_cmd::cargo_bin("turbo")` resolves the binary path relative to the test executable's location, so it always finds the instrumented one.

This was a full compilation of `turbo` and its dependency tree happening 10 times (once per partition) for no reason. The macOS/Windows test jobs already work without a separate build step, confirming it's unnecessary.