### PR TITLE
ci: Bump dev profile to opt-level 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ too_many_arguments = "allow"
 
 [profile.dev]
 debug = 0
-opt-level = 0
+opt-level = 1
 
 [profile.release]
 lto = "off"


### PR DESCRIPTION
## Summary

- Changes `[profile.dev] opt-level` from `0` to `1` in the workspace `Cargo.toml`.

## Why

`opt-level = 1` enables basic optimizations, producing a faster turbo binary at the cost of slightly slower compilation. Since integration tests spawn hundreds of turbo processes, faster runtime may offset the compilation cost.

## How to evaluate

Compare the **total wall-clock time** of the slowest partition across macOS and Ubuntu jobs against a recent main run. The compile phase will be slower; the test execution phase should be faster. If net time is worse, close this PR.