### PR TITLE
fix: Stop running unnecessary npm install in engines tests

### DIFF
--- a/crates/turborepo/tests/engines_test.rs
+++ b/crates/turborepo/tests/engines_test.rs
@@ -19,7 +19,7 @@ fn set_engines(dir: &std::path::Path, node_version: &str) {
 #[test]
 fn test_engines_affect_hash() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     // Set engines to >=12
     set_engines(tempdir.path(), ">=12");
@@ -47,7 +47,7 @@ fn test_engines_affect_hash() {
 #[test]
 fn test_engines_in_global_cache_inputs() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     set_engines(tempdir.path(), ">=16");
 


### PR DESCRIPTION
## Summary

- Engines tests (`test_engines_affect_hash`, `test_engines_in_global_cache_inputs`) were flaking on Windows because `npm install --offline` intermittently fails on Windows CI (corepack download races, junction creation issues in temp directories)
- These tests only run `turbo build --dry=json` which plans the task graph without executing — it only needs `package.json` files and the lockfile, not `node_modules`. Changed `install: true` → `install: false`, matching how `dry_json.rs` already tests the same fixture
- Also changed `run_cmd` in the test setup to capture stderr instead of discarding it, so future install failures include diagnostic output

## Testing

The failing CI run: https://github.com/vercel/turborepo/actions/runs/22534605085/job/65279608254