### PR TITLE
fix: Duplicate /signup? in Vercel URL

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -91,7 +91,7 @@ pnpm exec turbo dev --filter=web
 ### Remote Caching
 
 > [!TIP]
-> Vercel Remote Cache is free for all plans. Get started today at [vercel.com](https://vercel.com/signup?/signup?utm_source=remote-cache-sdk&utm_campaign=free_remote_cache).
+> Vercel Remote Cache is free for all plans. Get started today at [vercel.com](https://vercel.com/signup?utm_source=remote-cache-sdk&utm_campaign=free_remote_cache).
 
 Turborepo can use a technique known as [Remote Caching](https://turborepo.dev/docs/core-concepts/remote-caching) to share cache artifacts across machines, enabling you to share build caches with your team and CI/CD pipelines.
 


### PR DESCRIPTION
Fixes #11945. Corrects duplicate /signup? in Vercel signup URL in basic example README.