### PR TITLE
fix: Align experimentalObservability on object maps rather than arrays

### DIFF
--- a/apps/docs/content/docs/reference/configuration.mdx
+++ b/apps/docs/content/docs/reference/configuration.mdx
@@ -886,9 +886,9 @@ The `experimentalObservability` configuration requires `futureFlags.experimental
       },
       "timeoutMs": 10000,
       "intervalMs": 15000,
-      "resource": [
-        { "key": "service.name", "value": "turborepo" }
-      ],
+      "resource": {
+        "service.name": "turborepo"
+      },
       "metrics": {
         "runSummary": true,
         "taskDetails": false,
@@ -970,17 +970,17 @@ Interval in milliseconds between periodic exports to the collector. This control
 
 #### `experimentalObservability.otel.resource`
 
-Optional resource attributes to attach to all exported metrics. Each entry is an object with `key` and `value` fields. These help identify the source of metrics in your observability platform.
+Optional resource attributes to attach to all exported metrics. These help identify the source of metrics in your observability platform.
 
 ```jsonc title="./turbo.json"
 {
   "experimentalObservability": {
     "otel": {
-      "resource": [
-        { "key": "service.name", "value": "turborepo" },
-        { "key": "service.namespace", "value": "ci" },
-        { "key": "deployment.environment", "value": "production" }
-      ]
+      "resource": {
+        "service.name": "turborepo",
+        "service.namespace": "ci",
+        "deployment.environment": "production"
+      }
     }
   }
 }

--- a/crates/turborepo-config/src/turbo_json.rs
+++ b/crates/turborepo-config/src/turbo_json.rs
@@ -1,10 +1,10 @@
-use std::{collections::BTreeMap, str::FromStr};
+use std::str::FromStr;
 
 use camino::Utf8PathBuf;
 use turbopath::{AbsoluteSystemPath, RelativeUnixPath};
 use turborepo_turbo_json::{
-    RawExperimentalObservability, RawKeyValue, RawObservabilityOtel, RawRemoteCacheOptions,
-    RawRootTurboJson, RawTurboJson,
+    RawExperimentalObservability, RawObservabilityOtel, RawRemoteCacheOptions, RawRootTurboJson,
+    RawTurboJson,
 };
 
 use crate::{
@@ -160,27 +160,17 @@ fn convert_raw_observability_otel(
         }),
     });
 
-    let headers = raw.headers.map(convert_key_values);
-
-    let resource = raw.resource.map(convert_key_values);
-
     Ok(ExperimentalOtelOptions {
         enabled: raw.enabled.map(|flag| *flag.as_inner()),
         protocol,
         endpoint: raw.endpoint.map(|endpoint| endpoint.into_inner().into()),
-        headers,
+        headers: raw.headers,
         timeout_ms: raw.timeout_ms.map(|timeout| *timeout.as_inner()),
         interval_ms: raw.interval_ms.map(|interval| *interval.as_inner()),
-        resource,
+        resource: raw.resource,
         metrics,
         use_remote_cache_token: raw.use_remote_cache_token.map(|flag| *flag.as_inner()),
     })
-}
-
-fn convert_key_values(raw: Vec<RawKeyValue>) -> BTreeMap<String, String> {
-    raw.into_iter()
-        .map(|kv| (kv.key.into_inner().into(), kv.value.into_inner().into()))
-        .collect()
 }
 
 #[cfg(test)]
@@ -429,14 +419,14 @@ mod test {
                     "otel": {
                         "enabled": true,
                         "endpoint": "https://example.com/otel",
-                        "headers": [
-                            { "key": "Authorization", "value": "Bearer token123" },
-                            { "key": "X-Custom-Header", "value": "custom-value" }
-                        ],
-                        "resource": [
-                            { "key": "service.name", "value": "turborepo" },
-                            { "key": "service.version", "value": "1.0.0" }
-                        ]
+                        "headers": {
+                            "Authorization": "Bearer token123",
+                            "X-Custom-Header": "custom-value"
+                        },
+                        "resource": {
+                            "service.name": "turborepo",
+                            "service.version": "1.0.0"
+                        }
                     }
                 }
             }))

--- a/crates/turborepo-turbo-json/src/lib.rs
+++ b/crates/turborepo-turbo-json/src/lib.rs
@@ -46,9 +46,9 @@ pub use processed::{
     ProcessedPassThroughEnv, ProcessedTaskDefinition, ProcessedWith,
 };
 pub use raw::{
-    HasConfigBeyondExtends, Pipeline, RawExperimentalObservability, RawKeyValue,
-    RawObservabilityOtel, RawObservabilityOtelMetrics, RawPackageTurboJson, RawRemoteCacheOptions,
-    RawRootTurboJson, RawTaskDefinition, RawTurboJson, SpacesJson,
+    HasConfigBeyondExtends, Pipeline, RawExperimentalObservability, RawObservabilityOtel,
+    RawObservabilityOtelMetrics, RawPackageTurboJson, RawRemoteCacheOptions, RawRootTurboJson,
+    RawTaskDefinition, RawTurboJson, SpacesJson,
 };
 pub use validator::{TOPOLOGICAL_PIPELINE_DELIMITER, Validator};
 

--- a/crates/turborepo-turbo-json/src/raw.rs
+++ b/crates/turborepo-turbo-json/src/raw.rs
@@ -210,10 +210,10 @@ pub struct RawObservabilityOtel {
     pub enabled: Option<Spanned<bool>>,
     pub protocol: Option<Spanned<UnescapedString>>,
     pub endpoint: Option<Spanned<UnescapedString>>,
-    pub headers: Option<Vec<RawKeyValue>>,
+    pub headers: Option<BTreeMap<String, String>>,
     pub timeout_ms: Option<Spanned<u64>>,
     pub interval_ms: Option<Spanned<u64>>,
-    pub resource: Option<Vec<RawKeyValue>>,
+    pub resource: Option<BTreeMap<String, String>>,
     pub metrics: Option<RawObservabilityOtelMetrics>,
     pub use_remote_cache_token: Option<Spanned<bool>>,
 }
@@ -223,13 +223,6 @@ pub struct RawObservabilityOtel {
 #[serde(rename_all = "camelCase")]
 pub struct RawExperimentalObservability {
     pub otel: Option<RawObservabilityOtel>,
-}
-
-/// A key-value pair for OTel configuration
-#[derive(Serialize, Debug, Clone, Iterable, Deserializable)]
-pub struct RawKeyValue {
-    pub key: Spanned<UnescapedString>,
-    pub value: Spanned<UnescapedString>,
 }
 
 /// OTel metrics configuration
@@ -247,15 +240,6 @@ pub struct RawObservabilityOtelMetrics {
 pub struct RawObservabilityOtelTaskAttributes {
     pub id: Option<Spanned<bool>>,
     pub hashes: Option<Spanned<bool>>,
-}
-
-impl Default for RawKeyValue {
-    fn default() -> Self {
-        Self {
-            key: Spanned::new(UnescapedString::from(String::new())),
-            value: Spanned::new(UnescapedString::from(String::new())),
-        }
-    }
 }
 
 // Root turbo.json


### PR DESCRIPTION
## Summary

- Changes `experimentalObservability.otel.headers` and `experimentalObservability.otel.resource` in `turbo.json` from array-of-key-value format to plain JSON object format
- Updates documentation to consistently use the new object format

## Details

The OTel configuration previously required an awkward array syntax:

```json
"headers": [
  { "key": "Authorization", "value": "Bearer token" },
  { "key": "X-Custom", "value": "value" }
],
"resource": [
  { "key": "service.name", "value": "turborepo" }
]
```

This PR changes both fields to accept a simpler object format:

```json
"headers": {
  "Authorization": "Bearer token",
  "X-Custom": "value"
},
"resource": {
  "service.name": "turborepo"
}
```

This is a safe breaking change because:
- The `experimentalObservability` config is gated behind `futureFlags.experimentalObservability`
- The types are excluded from the JSON schema (`#[schemars(skip)]`) and TS exports (`#[ts(skip)]`)
- The downstream `ExperimentalOtelOptions` struct already uses `BTreeMap<String, String>`
- `biome_deserialize` 0.6.0 has built-in `Deserializable` support for `BTreeMap`

## Test plan

- [x] Existing unit tests updated and passing
- [x] `cargo check` passes without errors
- [x] All `experimental_observability` tests pass