### PR TITLE
fix: Prevent yarn integration tests from hanging on corepack prompts

### DIFF
--- a/crates/turborepo/tests/common/mod.rs
+++ b/crates/turborepo/tests/common/mod.rs
@@ -26,6 +26,10 @@ pub fn turbo_command(test_dir: &Path) -> assert_cmd::Command {
         .env("TURBO_PRINT_VERSION_DISABLED", "1")
         .env("DO_NOT_TRACK", "1")
         .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
+        // Allow corepack to download package managers without prompting.
+        // Without this, corepack can block waiting for stdin confirmation,
+        // causing tests to hang until they hit the >120s slow threshold.
+        .env("COREPACK_ENABLE_DOWNLOAD_PROMPT", "0")
         .env_remove("CI")
         .env_remove("GITHUB_ACTIONS")
         .current_dir(test_dir);

--- a/crates/turborepo/tests/common/setup.rs
+++ b/crates/turborepo/tests/common/setup.rs
@@ -174,7 +174,12 @@ pub fn install_deps(
             run_cmd(
                 target_dir,
                 "yarn",
-                &["install", &format!("--cache-folder={}", cache.display())],
+                &[
+                    "install",
+                    "--prefer-offline",
+                    "--frozen-lockfile",
+                    &format!("--cache-folder={}", cache.display()),
+                ],
                 &path_env,
             )?;
 
@@ -239,6 +244,8 @@ fn run_cmd(dir: &Path, program: &str, args: &[&str], path_env: &str) -> Result<(
     let output = cmd_with_path(program, path_env)
         .args(args)
         .current_dir(dir)
+        // Allow corepack to download package managers without prompting
+        .env("COREPACK_ENABLE_DOWNLOAD_PROMPT", "0")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::piped())
         .output()


### PR DESCRIPTION
## Summary

- Sets `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` in test helpers so corepack auto-downloads package managers without blocking on stdin confirmation, which caused tests to hang for >120s
- Adds `--prefer-offline` and `--frozen-lockfile` to `yarn install` in test setup for parity with npm's `--offline` flag

## Context

The `test_lockfile_aware_caching_yarn` and `test_single_package_build_yarn` tests were consistently slow (>120s, >180s) due to two issues:

1. When turbo executes `yarn run build`, corepack sees `packageManager: "yarn@1.22.19"` and either prompts for download confirmation (hanging on stdin) or downloads yarn from the network
2. `yarn install` in test setup had no offline/frozen flags and used a fresh empty cache folder, forcing network access every run

npm tests didn't have this problem because they already use `--offline`.