### PR TITLE
fix: Prevent lockfile-aware yarn test from hanging on corepack downloads

### DIFF
--- a/crates/turborepo-env/src/lib.rs
+++ b/crates/turborepo-env/src/lib.rs
@@ -29,7 +29,7 @@ pub const BUILTIN_PASS_THROUGH_ENV: &[&str] = &[
     "DBUS_SESSION_BUS_ADDRESS",
     "CI",
     "NODE_OPTIONS",
-    "COREPACK_HOME",
+    "COREPACK_*",
     "LD_LIBRARY_PATH",
     "DYLD_FALLBACK_LIBRARY_PATH",
     "LIBPATH",

--- a/crates/turborepo/tests/common/mod.rs
+++ b/crates/turborepo/tests/common/mod.rs
@@ -26,10 +26,15 @@ pub fn turbo_command(test_dir: &Path) -> assert_cmd::Command {
         .env("TURBO_PRINT_VERSION_DISABLED", "1")
         .env("DO_NOT_TRACK", "1")
         .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
-        // Allow corepack to download package managers without prompting.
-        // Without this, corepack can block waiting for stdin confirmation,
-        // causing tests to hang until they hit the >120s slow threshold.
+        // Corepack intercepts package manager calls (yarn, pnpm) and can
+        // either prompt for download confirmation or fetch an exact version
+        // from the network, both of which hang in non-interactive CI.
+        // COREPACK_ENABLE_DOWNLOAD_PROMPT=0 auto-approves downloads.
+        // COREPACK_ENABLE_STRICT=0 lets corepack fall back to whatever
+        // version is already installed instead of downloading the exact
+        // version from packageManager field.
         .env("COREPACK_ENABLE_DOWNLOAD_PROMPT", "0")
+        .env("COREPACK_ENABLE_STRICT", "0")
         .env_remove("CI")
         .env_remove("GITHUB_ACTIONS")
         .current_dir(test_dir);

--- a/crates/turborepo/tests/common/setup.rs
+++ b/crates/turborepo/tests/common/setup.rs
@@ -244,8 +244,9 @@ fn run_cmd(dir: &Path, program: &str, args: &[&str], path_env: &str) -> Result<(
     let output = cmd_with_path(program, path_env)
         .args(args)
         .current_dir(dir)
-        // Allow corepack to download package managers without prompting
+        // Prevent corepack from prompting or downloading exact versions
         .env("COREPACK_ENABLE_DOWNLOAD_PROMPT", "0")
+        .env("COREPACK_ENABLE_STRICT", "0")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::piped())
         .output()


### PR DESCRIPTION
## Summary

- Adds `COREPACK_ENABLE_STRICT=0` to test helpers alongside the existing `COREPACK_ENABLE_DOWNLOAD_PROMPT=0`, preventing corepack from downloading exact package manager versions during tests
- Widens `COREPACK_HOME` to `COREPACK_*` in `BUILTIN_PASS_THROUGH_ENV` so all corepack configuration vars pass through to tasks in strict env mode

## Context

The previous fix (#12090) set `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` on the turbo process to auto-approve corepack downloads. This prevents the stdin-prompt hang but still requires corepack to **download the exact version** from the network. On CI runners with slow or restricted network access, this download itself hangs — which is why `test_lockfile_aware_caching_yarn` was still hitting the >120s SLOW threshold.

`COREPACK_ENABLE_STRICT=0` tells corepack to fall back to whatever package manager version is already installed rather than insisting on downloading the exact version from the `packageManager` field. Since these tests only need `echo building` to run, the exact yarn version is irrelevant.

Additionally, `BUILTIN_PASS_THROUGH_ENV` only included `COREPACK_HOME`, meaning `COREPACK_ENABLE_DOWNLOAD_PROMPT` and `COREPACK_ENABLE_STRICT` were silently dropped from child task processes in strict env mode. Widening to `COREPACK_*` (consistent with `DOCKER_*`, `GITHUB_*`, `VERCEL_*`) ensures users who set these vars in their environment get them passed through to tasks.