### PR TITLE
fix: Exclude turborepo-repository from JS smoke test in release workflow

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -300,7 +300,7 @@ jobs:
           turbo-version: ${{ inputs.ci-tag-override || '' }}
 
       - name: Run JS Package Tests
-        run: turbo run check-types test --filter="./packages/*" --color
+        run: turbo run check-types test --filter="./packages/*" --filter="!turborepo-repository" --color
 
   build-rust:
     name: "Build Rust"


### PR DESCRIPTION
## Summary

- Excludes `turborepo-repository` from the JS smoke test filter in the release workflow since its `build` task compiles Rust via napi but the job has no Rust toolchain (`rust: "false"`)

`turborepo-repository` has its own dedicated release workflow (`turborepo-library-release.yml`) that properly sets up Rust for each target.