### PR TITLE
perf: Replace SWC with oxc for JS/TS parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,18 +28,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "ahash"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.16"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -169,17 +157,6 @@ dependencies = [
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
-]
-
-[[package]]
-name = "ast_node"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb025ef00a6da925cf40870b9c8d008526b6004ece399cb0974209720f0b194"
-dependencies = [
- "quote",
- "swc_macros_common",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -509,15 +486,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "better_scoped_tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd228125315b132eed175bf47619ac79b945b26e56b848ba203ae4ea8603609"
-dependencies = [
- "scoped-tls",
-]
-
-[[package]]
 name = "biome_console"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,6 +786,9 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -919,16 +890,6 @@ version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bytes-str"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c60b5ce37e0b883c37eb89f79a1e26fbe9c1081945d024eee93e8d91a7e18b3"
-dependencies = [
- "bytes",
  "serde",
 ]
 
@@ -1114,6 +1075,7 @@ dependencies = [
  "itoa",
  "rustversion",
  "ryu",
+ "serde",
  "static_assertions",
 ]
 
@@ -1262,6 +1224,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
+name = "cow-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
+
+[[package]]
 name = "cpp_demangle"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1403,7 +1371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
- "phf",
+ "phf 0.11.2",
 ]
 
 [[package]]
@@ -1739,6 +1707,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
+name = "dragonbox_ecma"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd8e701084c37e7ef62d3f9e453b618130cbc0ef3573847785952a3ac3f746bf"
+
+[[package]]
 name = "drop_bomb"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2020,16 +1994,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "from_variant"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ff35a391aef949120a0340d690269b3d9f63460a6106e99bd07b961f345ea9"
-dependencies = [
- "swc_macros_common",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -2577,10 +2541,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2654,20 +2614,6 @@ dependencies = [
  "libc",
  "match_cfg",
  "winapi",
-]
-
-[[package]]
-name = "hstr"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa57007c3c9dab34df2fa4c1fb52fe9c34ec5a27ed9d8edea53254b50cd7887"
-dependencies = [
- "hashbrown 0.14.5",
- "new_debug_unreachable",
- "once_cell",
- "rustc-hash 2.0.0",
- "serde",
- "triomphe",
 ]
 
 [[package]]
@@ -3127,18 +3073,6 @@ checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
-]
-
-[[package]]
-name = "is-macro"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2069faacbe981460232f880d26bf3c7634e322d49053aa48c27e3ae642f728f1"
-dependencies = [
- "Inflector",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -3785,12 +3719,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3860,6 +3788,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonmax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+
+[[package]]
 name = "notify"
 version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3904,7 +3838,6 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -4170,6 +4103,168 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
 
 [[package]]
+name = "oxc-miette"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a7ba54c704edefead1f44e9ef09c43e5cfae666bdc33516b066011f0e6ebf7"
+dependencies = [
+ "cfg-if",
+ "owo-colors 4.1.0",
+ "oxc-miette-derive",
+ "textwrap",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "oxc-miette-derive"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4faecb54d0971f948fbc1918df69b26007e6f279a204793669542e1e8b75eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "oxc_allocator"
+version = "0.115.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d4295cf7888893b80ae70ff65c078ae3f9f52d5381cfc7eeffab089e07305"
+dependencies = [
+ "allocator-api2",
+ "hashbrown 0.16.1",
+ "oxc_data_structures",
+ "oxc_estree",
+ "rustc-hash 2.0.0",
+ "serde",
+]
+
+[[package]]
+name = "oxc_ast"
+version = "0.115.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be755331a7de00100c60e03151663f26037a0dd720be238de57c036be03b4033"
+dependencies = [
+ "bitflags 2.10.0",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_data_structures",
+ "oxc_diagnostics",
+ "oxc_estree",
+ "oxc_regular_expression",
+ "oxc_span",
+ "oxc_syntax",
+]
+
+[[package]]
+name = "oxc_ast_macros"
+version = "0.115.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13a58adcfaadd4710b4f7d80ad422599ed5bb4956f4747d07e821c5897b16ef"
+dependencies = [
+ "phf 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "oxc_data_structures"
+version = "0.115.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6c22a48542899e5f74162d55710ea2f95735c5d3a809196308b2dbf557f434"
+
+[[package]]
+name = "oxc_diagnostics"
+version = "0.115.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe5961a78ce2a24d288f5e7090f19ce49d062486e0d65e6140d01582198c94fd"
+dependencies = [
+ "cow-utils",
+ "oxc-miette",
+ "percent-encoding",
+]
+
+[[package]]
+name = "oxc_ecmascript"
+version = "0.115.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fb3d121c372df31514f95d87c92693001739d2c9e56be37909499b5396faf1"
+dependencies = [
+ "cow-utils",
+ "num-bigint",
+ "num-traits",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_regular_expression",
+ "oxc_span",
+ "oxc_syntax",
+]
+
+[[package]]
+name = "oxc_estree"
+version = "0.115.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38fc12975751e104dc53c369cba1598ff15aa8ca30aaac49e63937256316969"
+dependencies = [
+ "dragonbox_ecma",
+ "itoa",
+ "oxc_data_structures",
+]
+
+[[package]]
+name = "oxc_index"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3e6120999627ec9703025eab7c9f410ebb7e95557632a8902ca48210416c2b"
+dependencies = [
+ "nonmax",
+ "serde",
+]
+
+[[package]]
+name = "oxc_parser"
+version = "0.115.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "341602ba5eb6629f7f90e49c1fce06bb8eed989412a4178acd8e7f48cf2c7f9d"
+dependencies = [
+ "bitflags 2.10.0",
+ "cow-utils",
+ "memchr",
+ "num-bigint",
+ "num-traits",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_data_structures",
+ "oxc_diagnostics",
+ "oxc_ecmascript",
+ "oxc_regular_expression",
+ "oxc_span",
+ "oxc_syntax",
+ "rustc-hash 2.0.0",
+ "seq-macro",
+]
+
+[[package]]
+name = "oxc_regular_expression"
+version = "0.115.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e810182cbde172aeada70acc45dae74f6773384e0d295cc27e6e377b1fc277c"
+dependencies = [
+ "bitflags 2.10.0",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_diagnostics",
+ "oxc_span",
+ "phf 0.13.1",
+ "rustc-hash 2.0.0",
+ "unicode-id-start",
+]
+
+[[package]]
 name = "oxc_resolver"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4187,6 +4282,54 @@ dependencies = [
  "simdutf8",
  "thiserror 1.0.63",
  "tracing",
+]
+
+[[package]]
+name = "oxc_span"
+version = "0.115.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9999ef787b0b989b8c2b31669069d3bdca20d017ff34a7284ff9e983cf7b1d8"
+dependencies = [
+ "compact_str",
+ "oxc-miette",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_estree",
+ "oxc_str",
+ "serde",
+]
+
+[[package]]
+name = "oxc_str"
+version = "0.115.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6fde66bc256ea0d09895c2a56a24f79e76abffd977f6c171516e42f1efdea51"
+dependencies = [
+ "compact_str",
+ "hashbrown 0.16.1",
+ "oxc_allocator",
+ "oxc_estree",
+ "serde",
+]
+
+[[package]]
+name = "oxc_syntax"
+version = "0.115.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77ea5bd4ea42ce05b2f51bcef8e46a4598cea5038ab25877a2d27601a90da83"
+dependencies = [
+ "bitflags 2.10.0",
+ "cow-utils",
+ "dragonbox_ecma",
+ "nonmax",
+ "oxc_allocator",
+ "oxc_ast_macros",
+ "oxc_estree",
+ "oxc_index",
+ "oxc_span",
+ "phf 0.13.1",
+ "serde",
+ "unicode-id-start",
 ]
 
 [[package]]
@@ -4331,8 +4474,19 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
- "phf_macros",
- "phf_shared",
+ "phf_macros 0.11.2",
+ "phf_shared 0.11.2",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -4341,8 +4495,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.2",
+ "phf_shared 0.11.2",
 ]
 
 [[package]]
@@ -4351,8 +4505,18 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.2",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -4361,8 +4525,21 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.2",
+ "phf_shared 0.11.2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4374,7 +4551,16 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
- "siphasher",
+ "siphasher 0.3.11",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher 1.0.2",
 ]
 
 [[package]]
@@ -4768,15 +4954,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost 0.14.3",
-]
-
-[[package]]
-name = "psm"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200b9ff220857e53e184257720a14553b2f4aa02577d2ed9842d45d4b9654810"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -5379,12 +5556,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5774,6 +5945,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5789,15 +5966,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "smartstring"
-version = "1.0.1"
+name = "smawk"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
-dependencies = [
- "autocfg",
- "static_assertions",
- "version_check",
-]
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
@@ -5841,19 +6013,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
-name = "stacker"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799c883d55abdb5e98af1a7b3f23b9b6de8ecada0ecac058672d7635eb48ca7b"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "psm",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5882,17 +6041,6 @@ name = "str_indices"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9557cb6521e8d009c51a8666f09356f4b817ba9ba0981a305bd86aee47bd35c"
-
-[[package]]
-name = "string_enum"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36a4951ca7bd1cfd991c241584a9824a70f6aff1e7d4f693fb3f2465e4030e"
-dependencies = [
- "quote",
- "swc_macros_common",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "stringmetrics"
@@ -6016,132 +6164,6 @@ dependencies = [
  "getrandom 0.2.10",
  "serde",
  "time",
-]
-
-[[package]]
-name = "swc_atoms"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ccbe2ecad10ad7432100f878a107b1d972a8aee83ca53184d00c23a078bb8a"
-dependencies = [
- "hstr",
- "once_cell",
- "serde",
-]
-
-[[package]]
-name = "swc_common"
-version = "18.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1c06698254e9b47daaf9bbb062af489a350bd8d10dfaab0cabbd32d46cec69d"
-dependencies = [
- "anyhow",
- "ast_node",
- "better_scoped_tls",
- "bytes-str",
- "either",
- "from_variant",
- "num-bigint",
- "once_cell",
- "parking_lot",
- "rustc-hash 2.0.0",
- "serde",
- "siphasher",
- "swc_atoms",
- "swc_eq_ignore_macros",
- "swc_visit",
- "termcolor",
- "tracing",
- "unicode-width 0.2.2",
- "url",
-]
-
-[[package]]
-name = "swc_ecma_ast"
-version = "20.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4682d975a3b4ea33f351e7938db4db41f757d9abe537af4780611ef006531698"
-dependencies = [
- "bitflags 2.10.0",
- "is-macro",
- "num-bigint",
- "once_cell",
- "phf",
- "rustc-hash 2.0.0",
- "serde",
- "string_enum",
- "swc_atoms",
- "swc_common",
- "swc_visit",
- "unicode-id-start",
-]
-
-[[package]]
-name = "swc_ecma_parser"
-version = "33.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb866d9ca2df54daa4a460bdd105cd641d780f0578928cb1f7f4e54574bb2bb"
-dependencies = [
- "bitflags 2.10.0",
- "either",
- "num-bigint",
- "phf",
- "rustc-hash 2.0.0",
- "seq-macro",
- "serde",
- "smartstring",
- "stacker",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "tracing",
-]
-
-[[package]]
-name = "swc_ecma_visit"
-version = "20.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e971a258717db3dc8939c38410d8b8cb8126f1b05b9758672daa7cae3e0248c2"
-dependencies = [
- "new_debug_unreachable",
- "num-bigint",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_visit",
- "tracing",
-]
-
-[[package]]
-name = "swc_eq_ignore_macros"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c16ce73424a6316e95e09065ba6a207eba7765496fed113702278b7711d4b632"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "swc_macros_common"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1efbaa74943dc5ad2a2fb16cbd78b77d7e4d63188f3c5b4df2b4dcd2faaae"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "swc_visit"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62fb71484b486c185e34d2172f0eabe7f4722742aad700f426a494bb2de232a2"
-dependencies = [
- "either",
- "new_debug_unreachable",
 ]
 
 [[package]]
@@ -6294,7 +6316,7 @@ checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
  "nom",
- "phf",
+ "phf 0.11.2",
  "phf_codegen",
 ]
 
@@ -6337,10 +6359,10 @@ dependencies = [
  "ordered-float",
  "pest",
  "pest_derive",
- "phf",
+ "phf 0.11.2",
  "sha2",
  "signal-hook",
- "siphasher",
+ "siphasher 0.3.11",
  "terminfo",
  "termios",
  "thiserror 1.0.63",
@@ -6396,12 +6418,13 @@ checksum = "7f8b59b4da1c1717deaf1de80f0179a9d8b4ac91c986d5fd9f4a8ff177b84049"
 
 [[package]]
 name = "textwrap"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
+ "smawk",
  "unicode-linebreak",
- "unicode-width 0.1.13",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -6984,16 +7007,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "triomphe"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6631e42e10b40c0690bf92f404ebcfe6e1fdb480391d15f17cc8e96eeed5369"
-dependencies = [
- "serde",
- "stable_deref_trait",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7094,10 +7107,14 @@ dependencies = [
  "clap",
  "globwalk",
  "miette",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
- "swc_ecma_visit",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_diagnostics",
+ "oxc_estree",
+ "oxc_parser",
+ "oxc_span",
+ "oxc_syntax",
+ "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7225,14 +7242,15 @@ dependencies = [
  "indicatif",
  "itertools 0.14.0",
  "miette",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_parser",
+ "oxc_span",
+ "oxc_syntax",
  "regex",
  "schemars",
  "serde",
  "struct_iterable",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
- "swc_ecma_visit",
  "tempfile",
  "test-case",
  "thiserror 2.0.18",
@@ -7848,12 +7866,14 @@ dependencies = [
  "camino",
  "itertools 0.14.0",
  "miette",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_estree",
+ "oxc_parser",
+ "oxc_span",
  "petgraph 0.8.3",
  "serde",
  "serde_json",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_parser",
  "thiserror 2.0.18",
  "tokio",
  "tower-http 0.5.2",
@@ -9284,26 +9304,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.7.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,13 @@ itertools = "0.14.0"
 merge = "0.2.0"
 nix = { version = "0.26.2", default-features = false, features = ["term"] }
 notify = "6.1.1"
+oxc_allocator = "0.115.0"
+oxc_ast = { version = "0.115.0", features = ["serialize"] }
+oxc_diagnostics = "0.115.0"
+oxc_estree = { version = "0.115.0", features = ["serialize"] }
+oxc_parser = "0.115.0"
+oxc_span = "0.115.0"
+oxc_syntax = "0.115.0"
 owo-colors = "3.5.0"
 unrs_resolver = "1.11.1"
 path-clean = "1.0.1"
@@ -157,10 +164,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.93"
 serde_yaml_ng = "0.10.0"
 sha2 = "0.10.6"
-swc_common = "18.0.1"
-swc_ecma_ast = "20.0.0"
-swc_ecma_parser = "33.0.0"
-swc_ecma_visit = "20.0.0"
+
 tempfile = "3.3.0"
 test-case = "3.3.1"
 thiserror = "2.0.18"

--- a/crates/turbo-trace/Cargo.toml
+++ b/crates/turbo-trace/Cargo.toml
@@ -9,10 +9,14 @@ camino.workspace = true
 clap = { version = "4.5.17", features = ["derive"] }
 globwalk = { version = "0.1.0", path = "../turborepo-globwalk" }
 miette = { workspace = true, features = ["fancy"] }
-swc_common = { workspace = true, features = ["concurrent", "tty-emitter"] }
-swc_ecma_ast = { workspace = true }
-swc_ecma_parser = { workspace = true }
-swc_ecma_visit = { workspace = true }
+oxc_allocator = { workspace = true }
+oxc_ast = { workspace = true }
+oxc_diagnostics = { workspace = true }
+oxc_estree = { workspace = true }
+oxc_parser = { workspace = true }
+oxc_span = { workspace = true }
+oxc_syntax = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }

--- a/crates/turbo-trace/src/import_finder.rs
+++ b/crates/turbo-trace/src/import_finder.rs
@@ -1,6 +1,6 @@
-use swc_common::{Span, Spanned};
-use swc_ecma_ast::{Decl, ModuleDecl, Stmt};
-use swc_ecma_visit::{Visit, VisitWith};
+use oxc_ast::ast::{Argument, Expression, Statement};
+use oxc_span::Span;
+use oxc_syntax::module_record::ModuleRecord;
 
 use crate::tracer::ImportTraceType;
 
@@ -15,92 +15,135 @@ pub enum ImportType {
     Value,
 }
 
-pub struct ImportFinder {
-    import_type: ImportTraceType,
-    imports: Vec<(String, Span, ImportType)>,
+pub struct ImportResult {
+    pub specifier: String,
+    /// Span of the specifier string (for error reporting).
+    pub span: Span,
+    /// Span of the entire import/require statement (for comment detection).
+    #[allow(dead_code)]
+    pub statement_span: Span,
+    #[allow(dead_code)]
+    pub import_type: ImportType,
 }
 
-impl Default for ImportFinder {
-    fn default() -> Self {
-        Self::new(ImportTraceType::All)
-    }
-}
+/// Extract imports from a parsed oxc module.
+///
+/// Uses `ModuleRecord` for ES import/export declarations (which covers
+/// `import`, `export { } from`, and `export * from`), and manually walks
+/// statements for CommonJS `require()` calls.
+pub fn find_imports(
+    module_record: &ModuleRecord,
+    statements: &[Statement],
+    import_trace_type: ImportTraceType,
+) -> Vec<ImportResult> {
+    let mut results = Vec::new();
 
-impl ImportFinder {
-    pub fn new(import_type: ImportTraceType) -> Self {
-        Self {
-            import_type,
-            imports: Vec::new(),
+    for (specifier, requested_modules) in &module_record.requested_modules {
+        let specifier_str: String = specifier.to_string();
+        for requested in requested_modules {
+            let import_type = if requested.is_type {
+                ImportType::Type
+            } else {
+                ImportType::Value
+            };
+
+            let should_include = match import_trace_type {
+                ImportTraceType::All => true,
+                ImportTraceType::Types => requested.is_type,
+                ImportTraceType::Values => !requested.is_type,
+            };
+
+            if should_include {
+                results.push(ImportResult {
+                    specifier: specifier_str.clone(),
+                    span: requested.span,
+                    statement_span: requested.statement_span,
+                    import_type,
+                });
+            }
         }
     }
 
-    pub fn imports(&self) -> &[(String, Span, ImportType)] {
-        &self.imports
-    }
+    find_require_calls(statements, &mut results);
+
+    results
 }
 
-impl Visit for ImportFinder {
-    fn visit_module_decl(&mut self, decl: &ModuleDecl) {
-        match decl {
-            ModuleDecl::Import(import) => {
-                let import_type = if import.type_only {
-                    ImportType::Type
-                } else {
-                    ImportType::Value
-                };
-                let import_value = import.src.value.to_string_lossy().into_owned();
-                match self.import_type {
-                    ImportTraceType::All => {
-                        self.imports.push((import_value, import.span, import_type));
+/// Recursively walk statements looking for `const foo = require("./bar")`
+/// patterns.
+fn find_require_calls(statements: &[Statement], results: &mut Vec<ImportResult>) {
+    for stmt in statements {
+        match stmt {
+            Statement::VariableDeclaration(var_decl) => {
+                for decl in &var_decl.declarations {
+                    let Some(init) = &decl.init else {
+                        continue;
+                    };
+                    let Expression::CallExpression(call_expr) = init else {
+                        continue;
+                    };
+                    let Expression::Identifier(callee) = &call_expr.callee else {
+                        continue;
+                    };
+                    if callee.name != "require" {
+                        continue;
                     }
-                    ImportTraceType::Types if import.type_only => {
-                        self.imports.push((import_value, import.span, import_type));
-                    }
-                    ImportTraceType::Values if !import.type_only => {
-                        self.imports.push((import_value, import.span, import_type));
-                    }
-                    _ => {}
+                    let Some(first_arg) = call_expr.arguments.first() else {
+                        continue;
+                    };
+                    let Argument::StringLiteral(lit) = first_arg else {
+                        continue;
+                    };
+                    results.push(ImportResult {
+                        specifier: lit.value.to_string(),
+                        span: callee.span,
+                        statement_span: var_decl.span,
+                        import_type: ImportType::Value,
+                    });
                 }
             }
-            ModuleDecl::ExportNamed(named_export) => {
-                if let Some(decl) = &named_export.src {
-                    self.imports.push((
-                        decl.value.to_string_lossy().into_owned(),
-                        decl.span,
-                        ImportType::Value,
-                    ));
+            Statement::BlockStatement(block) => {
+                find_require_calls(&block.body, results);
+            }
+            Statement::IfStatement(if_stmt) => {
+                find_require_calls(std::slice::from_ref(&if_stmt.consequent), results);
+                if let Some(alt) = &if_stmt.alternate {
+                    find_require_calls(std::slice::from_ref(alt), results);
                 }
             }
-            ModuleDecl::ExportAll(export_all) => {
-                self.imports.push((
-                    export_all.src.value.to_string_lossy().into_owned(),
-                    export_all.span,
-                    ImportType::Value,
-                ));
+            Statement::TryStatement(try_stmt) => {
+                find_require_calls(&try_stmt.block.body, results);
+                if let Some(handler) = &try_stmt.handler {
+                    find_require_calls(&handler.body.body, results);
+                }
+                if let Some(finalizer) = &try_stmt.finalizer {
+                    find_require_calls(&finalizer.body, results);
+                }
+            }
+            Statement::ForStatement(for_stmt) => {
+                find_require_calls(std::slice::from_ref(&for_stmt.body), results);
+            }
+            Statement::ForInStatement(for_in) => {
+                find_require_calls(std::slice::from_ref(&for_in.body), results);
+            }
+            Statement::ForOfStatement(for_of) => {
+                find_require_calls(std::slice::from_ref(&for_of.body), results);
+            }
+            Statement::WhileStatement(while_stmt) => {
+                find_require_calls(std::slice::from_ref(&while_stmt.body), results);
+            }
+            Statement::DoWhileStatement(do_while) => {
+                find_require_calls(std::slice::from_ref(&do_while.body), results);
+            }
+            Statement::SwitchStatement(switch) => {
+                for case in &switch.cases {
+                    find_require_calls(&case.consequent, results);
+                }
+            }
+            Statement::LabeledStatement(labeled) => {
+                find_require_calls(std::slice::from_ref(&labeled.body), results);
             }
             _ => {}
         }
-    }
-
-    fn visit_stmt(&mut self, stmt: &Stmt) {
-        if let Stmt::Decl(Decl::Var(var_decl)) = stmt {
-            for decl in &var_decl.decls {
-                if let Some(init) = &decl.init
-                    && let swc_ecma_ast::Expr::Call(call_expr) = &**init
-                    && let swc_ecma_ast::Callee::Expr(expr) = &call_expr.callee
-                    && let swc_ecma_ast::Expr::Ident(ident) = &**expr
-                    && ident.sym == *"require"
-                    && let Some(arg) = call_expr.args.first()
-                    && let swc_ecma_ast::Expr::Lit(swc_ecma_ast::Lit::Str(lit_str)) = &*arg.expr
-                {
-                    self.imports.push((
-                        lit_str.value.to_string_lossy().into_owned(),
-                        expr.span(),
-                        ImportType::Value,
-                    ));
-                }
-            }
-        }
-        stmt.visit_children_with(self);
     }
 }

--- a/crates/turbo-trace/src/lib.rs
+++ b/crates/turbo-trace/src/lib.rs
@@ -8,5 +8,5 @@
 mod import_finder;
 mod tracer;
 
-pub use import_finder::{ImportFinder, ImportType};
-pub use tracer::{ImportTraceType, TraceError, TraceResult, Tracer};
+pub use import_finder::{ImportResult, ImportType, find_imports};
+pub use tracer::{ImportTraceType, TraceError, TraceResult, Tracer, parse_file};

--- a/crates/turbo-trace/src/tracer.rs
+++ b/crates/turbo-trace/src/tracer.rs
@@ -3,15 +3,10 @@ use std::{collections::HashMap, fmt, sync::Arc};
 use camino::{Utf8Path, Utf8PathBuf};
 use globwalk::WalkType;
 use miette::{Diagnostic, Report, SourceSpan};
-use swc_common::{
-    FileName, SourceMap,
-    comments::SingleThreadedComments,
-    errors::{ColorConfig, Handler},
-    input::StringInput,
-};
-use swc_ecma_ast::EsVersion;
-use swc_ecma_parser::{EsSyntax, Parser, Syntax, TsSyntax, lexer::Lexer};
-use swc_ecma_visit::VisitWith;
+use oxc_allocator::Allocator;
+use oxc_estree::{CompactTSSerializer, ESTree};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
 use thiserror::Error;
 use tokio::task::JoinSet;
 use tracing::debug;
@@ -20,7 +15,7 @@ use unrs_resolver::{
     EnforceExtension, ResolveError, ResolveOptions, Resolver, TsconfigOptions, TsconfigReferences,
 };
 
-use crate::import_finder::ImportFinder;
+use crate::import_finder::{self, ImportResult};
 
 #[derive(Debug, Default)]
 pub struct SeenFile {
@@ -29,13 +24,12 @@ pub struct SeenFile {
     // (i.e. crates with both a binary and library)
     // https://github.com/rust-lang/rust/issues/95513
     #[allow(dead_code)]
-    pub ast: Option<swc_ecma_ast::Module>,
+    pub ast: Option<serde_json::Value>,
 }
 
 pub struct Tracer {
     files: Vec<(AbsoluteSystemPathBuf, usize)>,
     ts_config: Option<AbsoluteSystemPathBuf>,
-    source_map: Arc<SourceMap>,
     cwd: AbsoluteSystemPathBuf,
     errors: Vec<TraceError>,
     import_type: ImportTraceType,
@@ -43,8 +37,8 @@ pub struct Tracer {
 
 #[derive(Clone, Debug, Error, Diagnostic)]
 pub enum TraceError {
-    #[error("failed to parse file {}: {:?}", .0, .1)]
-    ParseError(AbsoluteSystemPathBuf, swc_ecma_parser::error::Error),
+    #[error("failed to parse file {0}: {1}")]
+    ParseError(AbsoluteSystemPathBuf, String),
     #[error("failed to read file: {0}")]
     FileNotFound(AbsoluteSystemPathBuf),
     #[error(transparent)]
@@ -69,28 +63,13 @@ pub enum TraceError {
 impl TraceResult {
     #[allow(dead_code)]
     pub fn emit_errors(&self) {
-        let handler = Handler::with_tty_emitter(
-            ColorConfig::Auto,
-            true,
-            false,
-            Some(self.source_map.clone()),
-        );
         for error in &self.errors {
-            match error {
-                TraceError::ParseError(_, e) => {
-                    e.clone().into_diagnostic(&handler).emit();
-                }
-                e => {
-                    eprintln!("{:?}", Report::new(e.clone()));
-                }
-            }
+            eprintln!("{:?}", Report::new(error.clone()));
         }
     }
 }
 
 pub struct TraceResult {
-    #[allow(dead_code)]
-    source_map: Arc<SourceMap>,
     pub errors: Vec<TraceError>,
     pub files: HashMap<AbsoluteSystemPathBuf, SeenFile>,
 }
@@ -116,6 +95,41 @@ pub enum ImportTraceType {
     Values,
 }
 
+/// Parse a file with oxc and extract imports.
+///
+/// Returns the list of found imports and optionally the serialized AST (as
+/// ESTree JSON). The AST is serialized eagerly while the oxc allocator is
+/// alive, since the parsed `Program<'a>` cannot outlive it.
+pub fn parse_file(
+    file_path: &AbsoluteSystemPath,
+    file_content: &str,
+    import_type: ImportTraceType,
+    include_ast: bool,
+) -> Result<(Vec<ImportResult>, Option<serde_json::Value>), String> {
+    let source_type = SourceType::from_path(file_path.as_std_path()).unwrap_or_default();
+
+    let allocator = Allocator::default();
+    let ret = Parser::new(&allocator, file_content, source_type).parse();
+
+    if ret.panicked {
+        let messages: Vec<String> = ret.errors.iter().map(|e| e.to_string()).collect();
+        return Err(messages.join(", "));
+    }
+
+    let imports = import_finder::find_imports(&ret.module_record, &ret.program.body, import_type);
+
+    let ast_json = if include_ast {
+        let mut serializer = CompactTSSerializer::new(false);
+        ret.program.serialize(&mut serializer);
+        let json_string = serializer.into_string();
+        serde_json::from_str(&json_string).ok()
+    } else {
+        None
+    };
+
+    Ok((imports, ast_json))
+}
+
 impl Tracer {
     pub fn new(
         cwd: AbsoluteSystemPathBuf,
@@ -133,7 +147,6 @@ impl Tracer {
             cwd,
             import_type: ImportTraceType::All,
             errors: Vec::new(),
-            source_map: Arc::new(SourceMap::default()),
         }
     }
 
@@ -142,66 +155,33 @@ impl Tracer {
         self.import_type = import_type;
     }
 
-    #[tracing::instrument(skip(resolver, source_map))]
+    #[tracing::instrument(skip(errors))]
     pub async fn get_imports_from_file(
-        source_map: &SourceMap,
         errors: &mut Vec<TraceError>,
         resolver: &Resolver,
         file_path: &AbsoluteSystemPath,
         import_type: ImportTraceType,
     ) -> Option<(Vec<AbsoluteSystemPathBuf>, SeenFile)> {
-        // Read the file content
         let Ok(file_content) = tokio::fs::read_to_string(&file_path).await else {
             errors.push(TraceError::FileNotFound(file_path.to_owned()));
             return None;
         };
 
-        let comments = SingleThreadedComments::default();
-
-        let source_file = source_map.new_source_file(
-            FileName::Custom(file_path.to_string()).into(),
-            file_content.clone(),
-        );
-
-        let syntax = if matches!(file_path.extension(), Some("ts") | Some("tsx")) {
-            Syntax::Typescript(TsSyntax {
-                tsx: file_path.extension() == Some("tsx"),
-                decorators: true,
-                ..Default::default()
-            })
-        } else {
-            Syntax::Es(EsSyntax {
-                jsx: true,
-                import_attributes: true,
-                ..Default::default()
-            })
-        };
-
-        let lexer = Lexer::new(
-            syntax,
-            EsVersion::EsNext,
-            StringInput::from(&*source_file),
-            Some(&comments),
-        );
-
-        let mut parser = Parser::new_from(lexer);
-
-        // Parse the file as a module
-        let module: swc_ecma_ast::Module = match parser.parse_module() {
-            Ok(module) => module,
-            Err(err) => {
-                errors.push(TraceError::ParseError(file_path.to_owned(), err));
+        let (imports, ast_json) = match parse_file(file_path, &file_content, import_type, true) {
+            Ok(result) => result,
+            Err(msg) => {
+                errors.push(TraceError::ParseError(file_path.to_owned(), msg));
                 return None;
             }
         };
 
-        // Visit the AST and find imports
-        let mut finder = ImportFinder::new(import_type);
-        module.visit_with(&mut finder);
-        // Convert found imports/requires to absolute paths and add them to files to
-        // visit
         let mut files = Vec::new();
-        for (import, span, _) in finder.imports() {
+        for ImportResult {
+            specifier: import,
+            span,
+            ..
+        } in &imports
+        {
             debug!("processing {} in {}", import, file_path);
             let Some(file_dir) = file_path.parent() else {
                 errors.push(TraceError::RootFile(file_path.to_owned()));
@@ -223,7 +203,6 @@ impl Tracer {
                 }
                 Err(err) => {
                     if !import.starts_with(".") {
-                        // Try to resolve the import as a type import via `@/types/<import>`
                         let type_package = format!("@types/{import}");
                         debug!("trying to resolve type import: {type_package}");
                         let resolved_type_import = resolver
@@ -238,7 +217,6 @@ impl Tracer {
                         }
                     }
 
-                    // Also try without the extension just in case the wrong extension is used
                     let without_extension = Utf8Path::new(import).with_extension("");
                     debug!(
                         "trying to resolve extensionless import: {}",
@@ -256,9 +234,8 @@ impl Tracer {
                     }
 
                     debug!("failed to resolve: {:?}", err);
-                    let (start, end) = source_map.span_to_char_offset(&source_file, *span);
-                    let start = start as usize;
-                    let end = end as usize;
+                    let start = span.start as usize;
+                    let end = span.end as usize;
 
                     errors.push(TraceError::Resolve {
                         import: import.to_string(),
@@ -271,7 +248,7 @@ impl Tracer {
             }
         }
 
-        Some((files, SeenFile { ast: Some(module) }))
+        Some((files, SeenFile { ast: ast_json }))
     }
 
     pub async fn trace_file(
@@ -294,14 +271,9 @@ impl Tracer {
             return;
         }
 
-        let Some((imports, seen_file)) = Self::get_imports_from_file(
-            &self.source_map,
-            &mut self.errors,
-            resolver,
-            &file_path,
-            self.import_type,
-        )
-        .await
+        let Some((imports, seen_file)) =
+            Self::get_imports_from_file(&mut self.errors, resolver, &file_path, self.import_type)
+                .await
         else {
             return;
         };
@@ -323,9 +295,6 @@ impl Tracer {
             .skip(1)
             .find(|p| p.join_component("tsconfig.json").exists());
 
-        // Resolves the closest `node_modules` directory. This is to work with monorepos
-        // where both the package and the monorepo have a `node_modules`
-        // directory.
         let node_modules_dir = root
             .ancestors()
             .skip(1)
@@ -364,12 +333,8 @@ impl Tracer {
             .with_extension(".d.ts")
             .with_extension(".mjs")
             .with_extension(".cjs")
-            // Some packages export a `module` field instead of `main`. This is non-standard,
-            // but was a proposal at some point.
             .with_main_field("module")
             .with_main_field("types")
-            // Condition names are used to determine which export to use when importing a module.
-            // We add a bunch so unrs_resolver can resolve all kinds of imports.
             .with_condition_names(&["import", "require", "node", "types", "default"]);
 
         if let Some(ts_config) = ts_config {
@@ -397,7 +362,6 @@ impl Tracer {
         }
 
         TraceResult {
-            source_map: self.source_map.clone(),
             files: seen,
             errors: self.errors,
         }
@@ -421,7 +385,6 @@ impl Tracer {
             Ok(files) => files,
             Err(e) => {
                 return TraceResult {
-                    source_map: self.source_map.clone(),
                     files: HashMap::new(),
                     errors: vec![TraceError::GlobError(Arc::new(e))],
                 };
@@ -431,7 +394,6 @@ impl Tracer {
         let mut futures = JoinSet::new();
 
         let resolver = Arc::new(Self::create_resolver(self.ts_config.as_deref()));
-        let source_map = self.source_map.clone();
         let shared_self = Arc::new(self);
 
         for file in files {
@@ -443,7 +405,6 @@ impl Tracer {
                 let mut errors = Vec::new();
 
                 let Some((imported_files, seen_file)) = Self::get_imports_from_file(
-                    &shared_self.source_map,
                     &mut errors,
                     resolver,
                     &file,
@@ -455,9 +416,6 @@ impl Tracer {
                 };
 
                 for mut import in imported_files {
-                    // Windows has this annoying habit of abbreviating paths
-                    // like `C:\Users\Admini~1` instead of `C:\Users\Administrator`
-                    // We canonicalize to get the proper, full length path
                     if cfg!(windows) {
                         match import.to_realpath() {
                             Ok(path) => {
@@ -496,7 +454,6 @@ impl Tracer {
         }
 
         TraceResult {
-            source_map,
             files: usages,
             errors,
         }

--- a/crates/turborepo-boundaries/Cargo.toml
+++ b/crates/turborepo-boundaries/Cargo.toml
@@ -16,14 +16,15 @@ globwalk = { path = "../turborepo-globwalk" }
 indicatif = { workspace = true }
 itertools = { workspace = true }
 miette = { workspace = true, features = ["fancy"] }
+oxc_allocator = { workspace = true }
+oxc_ast = { workspace = true }
+oxc_parser = { workspace = true }
+oxc_span = { workspace = true }
+oxc_syntax = { workspace = true }
 regex = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 struct_iterable = "0.1.1"
-swc_common = { workspace = true }
-swc_ecma_ast = { workspace = true }
-swc_ecma_parser = { workspace = true }
-swc_ecma_visit = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/turborepo-boundaries/src/imports.rs
+++ b/crates/turborepo-boundaries/src/imports.rs
@@ -1,12 +1,10 @@
-use std::{
-    collections::{BTreeMap, HashMap, HashSet},
-    sync::Arc,
-};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use camino::Utf8Path;
 use itertools::Itertools;
 use miette::{NamedSource, SourceSpan};
-use swc_common::{SourceFile, Span, comments::SingleThreadedComments};
+use oxc_ast::ast::Comment;
+use oxc_span::Span;
 use turbo_trace::ImportType;
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf, PathRelation, RelativeUnixPath};
 use turborepo_errors::Spanned;
@@ -136,14 +134,15 @@ fn check_import_as_tsconfig_path_alias(
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn check_import(
-    comments: &SingleThreadedComments,
+    comments: &[Comment],
+    source_text: &str,
     result: &mut BoundariesResult,
-    source_file: &Arc<SourceFile>,
     package_name: &PackageName,
     package_root: &AbsoluteSystemPath,
     import: &str,
     import_type: &ImportType,
     span: &Span,
+    statement_span: &Span,
     file_path: &AbsoluteSystemPath,
     file_content: &str,
     dependency_locations: DependencyLocations<'_>,
@@ -151,7 +150,7 @@ pub(crate) fn check_import(
 ) -> Result<(), Error> {
     // If the import is prefixed with `@boundaries-ignore`, we ignore it, but print
     // a warning
-    match BoundariesChecker::get_ignored_comment(comments, *span) {
+    match BoundariesChecker::get_ignored_comment(comments, source_text, *statement_span) {
         Some(reason) if reason.is_empty() => {
             result.warnings.push(
                 "@boundaries-ignore requires a reason, e.g. `// @boundaries-ignore implicit \
@@ -160,26 +159,21 @@ pub(crate) fn check_import(
             );
         }
         Some(_) => {
-            // Try to get the line number for warning
-            let line = result.source_map.lookup_line(span.lo()).map(|l| l.line);
-            if let Ok(line) = line {
-                result
-                    .warnings
-                    .push(format!("ignoring import on line {line} in {file_path}"));
-            } else {
-                result
-                    .warnings
-                    .push(format!("ignoring import in {file_path}"));
-            }
+            let line = source_text[..span.start as usize]
+                .chars()
+                .filter(|&c| c == '\n')
+                .count();
+            result
+                .warnings
+                .push(format!("ignoring import on line {line} in {file_path}"));
 
             return Ok(());
         }
         None => {}
     }
 
-    let (start, end) = result.source_map.span_to_char_offset(source_file, *span);
-    let start = start as usize;
-    let end = end as usize;
+    let start = span.start as usize;
+    let end = span.end as usize;
 
     let span = SourceSpan::new(start.into(), end - start);
 

--- a/crates/turborepo-boundaries/src/lib.rs
+++ b/crates/turborepo-boundaries/src/lib.rs
@@ -10,27 +10,19 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fs::OpenOptions,
     io::Write,
-    sync::{Arc, LazyLock},
+    sync::LazyLock,
 };
 
 pub use config::{BoundariesConfig, Permissions, Rule, RulesMap};
 use globwalk::Settings;
 use indicatif::{ProgressBar, ProgressIterator};
 use miette::{Diagnostic, NamedSource, Report, SourceSpan};
+use oxc_ast::ast::Comment;
 use regex::Regex;
-use swc_common::{
-    FileName, SourceMap, Span,
-    comments::{Comments, SingleThreadedComments},
-    errors::Handler,
-    input::StringInput,
-};
-use swc_ecma_ast::EsVersion;
-use swc_ecma_parser::{EsSyntax, Parser, Syntax, TsSyntax, lexer::Lexer};
-use swc_ecma_visit::VisitWith;
 pub use tags::{ProcessedPermissions, ProcessedRule, ProcessedRulesMap};
 use thiserror::Error;
 use tracing::log::warn;
-use turbo_trace::{ImportFinder, Tracer};
+use turbo_trace::{ImportTraceType, Tracer, find_imports};
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_errors::Spanned;
 use turborepo_repository::package_graph::{PackageGraph, PackageInfo, PackageName, PackageNode};
@@ -197,8 +189,8 @@ pub enum BoundariesDiagnostic {
         #[source_code]
         text: NamedSource<String>,
     },
-    #[error("failed to parse file {0}")]
-    ParseError(AbsoluteSystemPathBuf, swc_ecma_parser::error::Error),
+    #[error("failed to parse file {0}: {1}")]
+    ParseError(AbsoluteSystemPathBuf, String),
 }
 
 #[derive(Debug, Error, Diagnostic)]
@@ -240,7 +232,6 @@ pub struct BoundariesResult {
     pub files_checked: usize,
     pub packages_checked: usize,
     pub warnings: Vec<String>,
-    pub source_map: Arc<SourceMap>,
     pub diagnostics: Vec<BoundariesDiagnostic>,
 }
 
@@ -250,24 +241,8 @@ impl BoundariesResult {
     }
 
     pub fn emit(&self, color_config: ColorConfig) {
-        let swc_color_config = if color_config.should_strip_ansi {
-            swc_common::errors::ColorConfig::Never
-        } else {
-            swc_common::errors::ColorConfig::Always
-        };
-
-        let handler =
-            Handler::with_tty_emitter(swc_color_config, true, false, Some(self.source_map.clone()));
-
         for diagnostic in self.diagnostics.clone() {
-            match diagnostic {
-                BoundariesDiagnostic::ParseError(_, e) => {
-                    e.clone().into_diagnostic(&handler).emit();
-                }
-                e => {
-                    eprintln!("{:?}", Report::new(e.to_owned()));
-                }
-            }
+            eprintln!("{:?}", Report::new(diagnostic));
         }
         let result_message = match self.diagnostics.len() {
             0 => color!(color_config, BOLD_GREEN, "no issues found"),
@@ -294,22 +269,64 @@ impl BoundariesResult {
     }
 }
 
+/// Parse a file with oxc, returning both imports and comments.
+///
+/// We parse directly here (rather than using `turbo_trace::parse_file`) because
+/// we need access to the comment list for `@boundaries-ignore` detection.
+fn parse_with_comments(
+    file_path: &AbsoluteSystemPath,
+    source: &str,
+) -> Option<(Vec<turbo_trace::ImportResult>, Vec<Comment>)> {
+    let allocator = oxc_allocator::Allocator::default();
+    let source_type = oxc_span::SourceType::from_path(file_path.as_std_path()).unwrap_or_default();
+    let ret = oxc_parser::Parser::new(&allocator, source, source_type).parse();
+    if ret.panicked {
+        return None;
+    }
+    let imports = find_imports(&ret.module_record, &ret.program.body, ImportTraceType::All);
+    let comments: Vec<Comment> = ret.program.comments.iter().copied().collect();
+    Some((imports, comments))
+}
+
 pub struct BoundariesChecker;
 
 impl BoundariesChecker {
-    /// Returns the underlying reason if an import has been marked as ignored
+    /// Returns the underlying reason if an import has been marked as ignored.
+    ///
+    /// Searches for the nearest comment that ends before the import span and
+    /// checks if it contains `@boundaries-ignore`.
     pub(crate) fn get_ignored_comment(
-        comments: &SingleThreadedComments,
-        span: Span,
+        comments: &[Comment],
+        source_text: &str,
+        import_span: oxc_span::Span,
     ) -> Option<String> {
-        if let Some(import_comments) = comments.get_leading(span.lo()) {
-            for comment in import_comments {
-                if let Some(reason) = comment.text.trim().strip_prefix("@boundaries-ignore") {
-                    return Some(reason.to_string());
-                }
-            }
-        }
+        // Walk backwards through comments that end before the import. We check
+        // multiple because there may be stacked comments before an import:
+        //   // @boundaries-ignore reason
+        //   // @ts-ignore
+        //   import { foo } from "bar";
+        //
+        // To detect blank lines we check the gap between each comment and the
+        // *next* item in the chain (initially the import, then the previous
+        // comment we visited). A blank line means >1 newline in that gap.
+        let leading = comments.iter().filter(|c| c.span.end <= import_span.start);
 
+        let mut next_start = import_span.start;
+
+        for comment in leading.rev() {
+            let between = &source_text[comment.span.end as usize..next_start as usize];
+            if between.chars().filter(|&c| c == '\n').count() > 1 {
+                break;
+            }
+
+            let content_span = comment.content_span();
+            let text = &source_text[content_span.start as usize..content_span.end as usize];
+            if let Some(reason) = text.trim().strip_prefix("@boundaries-ignore") {
+                return Some(reason.to_string());
+            }
+
+            next_start = comment.span.start;
+        }
         None
     }
 
@@ -569,50 +586,17 @@ impl BoundariesChecker {
             return Err(Error::FileNotFound(file_path.to_owned()));
         };
 
-        let comments = SingleThreadedComments::default();
-
-        let source_file = result.source_map.new_source_file(
-            FileName::Custom(file_path.to_string()).into(),
-            file_content.clone(),
-        );
-
-        let syntax = if matches!(file_path.extension(), Some("ts") | Some("tsx")) {
-            Syntax::Typescript(TsSyntax {
-                tsx: file_path.extension() == Some("tsx"),
-                decorators: true,
-                ..Default::default()
-            })
-        } else {
-            Syntax::Es(EsSyntax {
-                jsx: true,
-                import_attributes: true,
-                ..Default::default()
-            })
-        };
-
-        let lexer = Lexer::new(
-            syntax,
-            EsVersion::EsNext,
-            StringInput::from(&*source_file),
-            Some(&comments),
-        );
-
-        let mut parser = Parser::new_from(lexer);
-
-        // Parse the file as a module
-        let module: swc_ecma_ast::Module = match parser.parse_module() {
-            Ok(module) => module,
-            Err(err) => {
-                result
-                    .diagnostics
-                    .push(BoundariesDiagnostic::ParseError(file_path.to_owned(), err));
+        let (imports, comments) = match parse_with_comments(file_path, &file_content) {
+            Some(result) => result,
+            None => {
+                result.diagnostics.push(BoundariesDiagnostic::ParseError(
+                    file_path.to_owned(),
+                    "parser panicked".to_string(),
+                ));
                 return Ok(());
             }
         };
 
-        // Visit the AST and find imports
-        let mut finder = ImportFinder::default();
-        module.visit_with(&mut finder);
         let dependency_locations = DependencyLocations {
             package: package_name,
             internal_dependencies,
@@ -624,16 +608,17 @@ impl BoundariesChecker {
                 .as_ref(),
         };
 
-        for (import, span, import_type) in finder.imports() {
+        for import_result in &imports {
             imports::check_import(
                 &comments,
+                &file_content,
                 result,
-                &source_file,
                 package_name,
                 package_root,
-                import,
-                import_type,
-                span,
+                &import_result.specifier,
+                &import_result.import_type,
+                &import_result.span,
+                &import_result.statement_span,
                 file_path,
                 &file_content,
                 dependency_locations,

--- a/crates/turborepo-query/Cargo.toml
+++ b/crates/turborepo-query/Cargo.toml
@@ -11,12 +11,14 @@ axum = { workspace = true }
 camino = "1.1.4"
 itertools = { workspace = true }
 miette = { workspace = true }
+oxc_allocator = { workspace = true }
+oxc_ast = { workspace = true }
+oxc_estree = { workspace = true }
+oxc_parser = { workspace = true }
+oxc_span = { workspace = true }
 petgraph = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-swc_common = { workspace = true }
-swc_ecma_ast = { workspace = true, features = ["serde-impl"] }
-swc_ecma_parser = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tower-http = { version = "0.5.2", features = ["cors"] }

--- a/crates/turborepo-query/src/file.rs
+++ b/crates/turborepo-query/src/file.rs
@@ -3,8 +3,6 @@ use std::sync::Arc;
 use async_graphql::{Enum, Object, SimpleObject};
 use camino::Utf8PathBuf;
 use miette::SourceCode;
-use swc_ecma_ast::EsVersion;
-use swc_ecma_parser::{EsSyntax, Syntax, TsSyntax};
 use turbo_trace::Tracer;
 use turbopath::AbsoluteSystemPathBuf;
 
@@ -13,7 +11,7 @@ use crate::{Array, Diagnostic, Error, QueryRun};
 pub struct File {
     run: Arc<dyn QueryRun>,
     path: AbsoluteSystemPathBuf,
-    ast: Option<swc_ecma_ast::Module>,
+    ast: Option<serde_json::Value>,
 }
 
 impl File {
@@ -28,43 +26,21 @@ impl File {
         })
     }
 
-    pub fn with_ast(mut self, ast: Option<swc_ecma_ast::Module>) -> Self {
+    pub fn with_ast(mut self, ast: Option<serde_json::Value>) -> Self {
         self.ast = ast;
         self
     }
 
-    fn parse_file(&self) -> Result<swc_ecma_ast::Module, Error> {
+    fn parse_file(&self) -> Result<serde_json::Value, Error> {
         let contents = self.path.read_to_string()?;
-        let source_map = swc_common::SourceMap::default();
-        let file = source_map.new_source_file(
-            swc_common::FileName::Custom(self.path.to_string()).into(),
-            contents.clone(),
-        );
-        let syntax = if self.path.extension() == Some("ts") || self.path.extension() == Some("tsx")
-        {
-            Syntax::Typescript(TsSyntax {
-                tsx: self.path.extension() == Some("tsx"),
-                decorators: true,
-                ..Default::default()
-            })
-        } else {
-            Syntax::Es(EsSyntax {
-                jsx: self.path.ends_with(".jsx"),
-                ..Default::default()
-            })
-        };
-        let comments = swc_common::comments::SingleThreadedComments::default();
-        let mut errors = Vec::new();
-        let module = swc_ecma_parser::parse_file_as_module(
-            &file,
-            syntax,
-            EsVersion::EsNext,
-            Some(&comments),
-            &mut errors,
+        let (_, ast_json) = turbo_trace::parse_file(
+            &self.path,
+            &contents,
+            turbo_trace::ImportTraceType::All,
+            true,
         )
         .map_err(Error::Parse)?;
-
-        Ok(module)
+        ast_json.ok_or_else(|| Error::Parse("AST serialization failed".to_string()))
     }
 }
 
@@ -86,8 +62,8 @@ impl From<turbo_trace::TraceError> for Diagnostic {
                 path: Some(path.to_string()),
                 ..Default::default()
             },
-            turbo_trace::TraceError::ParseError(path, e) => Diagnostic {
-                message: format!("failed to parse file: {e:?}"),
+            turbo_trace::TraceError::ParseError(path, msg) => Diagnostic {
+                message: format!("failed to parse file: {msg}"),
                 path: Some(path.to_string()),
                 ..Default::default()
             },
@@ -229,9 +205,9 @@ impl File {
 
     async fn ast(&self) -> Option<serde_json::Value> {
         if let Some(ast) = &self.ast {
-            serde_json::to_value(ast).ok()
+            Some(ast.clone())
         } else {
-            serde_json::to_value(&self.parse_file().ok()?).ok()
+            self.parse_file().ok()
         }
     }
 }

--- a/crates/turborepo-query/src/lib.rs
+++ b/crates/turborepo-query/src/lib.rs
@@ -47,7 +47,7 @@ type BoundariesFuture<'a> = Pin<
 /// The interface that the query layer requires from a "run" context.
 ///
 /// This trait decouples the GraphQL query layer from the concrete `Run` type
-/// in turborepo-lib, allowing the heavy async-graphql/axum/swc dependencies
+/// in turborepo-lib, allowing the heavy async-graphql/axum/oxc dependencies
 /// to compile in a separate crate.
 ///
 /// Object-safe so it can be used via `Arc<dyn QueryRun>`.
@@ -109,8 +109,8 @@ pub enum Error {
     #[error(transparent)]
     #[diagnostic(transparent)]
     Resolution(#[from] turborepo_scope::filter::ResolutionError),
-    #[error("Failed to parse file: {0:?}")]
-    Parse(swc_ecma_parser::error::Error),
+    #[error("Failed to parse file: {0}")]
+    Parse(String),
     #[error(transparent)]
     SignalListener(#[from] turborepo_signals::listeners::Error),
 }

--- a/crates/turborepo/tests/query.rs
+++ b/crates/turborepo/tests/query.rs
@@ -77,6 +77,7 @@ fn test_trace() -> Result<(), anyhow::Error> {
             "get `incorrect_extension.mjs` with dependencies" =>  ["query { file(path: \"incorrect_extension.mjs\") { path dependencies(depth: 1) { files { items { path } } } } }"],
             "get `export_all.js` with dependencies" => ["query { file(path: \"export_all.js\") { path dependencies { files { items { path } } } } }"],
             "get `export_named.js` with dependencies" => ["query { file(path: \"export_named.js\") { path dependencies { files { items { path } } } } }"],
+            "get `require_example.js` with dependencies" => ["query { file(path: \"require_example.js\") { path dependencies { files { items { path } } } } }"],
         );
 
         Ok(())

--- a/crates/turborepo/tests/snapshots/boundaries__boundaries_get_boundaries_lints_(npm@10.5.0).snap
+++ b/crates/turborepo/tests/snapshots/boundaries__boundaries_get_boundaries_lints_(npm@10.5.0).snap
@@ -1,6 +1,5 @@
 ---
 source: crates/turborepo/tests/boundaries.rs
-assertion_line: 5
 expression: query_output
 ---
 {
@@ -22,6 +21,10 @@ expression: query_output
         {
           "message": "Package `utils` found without any tag listed in allowlist for `my-app`",
           "import": "utils"
+        },
+        {
+          "message": "cannot import package `module-package` because it is not a dependency",
+          "import": "module-package"
         },
         {
           "message": "cannot import package `module-package` because it is not a dependency",

--- a/crates/turborepo/tests/snapshots/query__turbo_trace_get_`main.ts`_with_ast_(npm@10.5.0).snap
+++ b/crates/turborepo/tests/snapshots/query__turbo_trace_get_`main.ts`_with_ast_(npm@10.5.0).snap
@@ -7,212 +7,187 @@ expression: query_output
     "file": {
       "path": "main.ts",
       "ast": {
-        "type": "Module",
-        "span": {
-          "start": 1,
-          "end": 119
-        },
+        "type": "Program",
         "body": [
           {
             "type": "ImportDeclaration",
-            "span": {
-              "start": 1,
-              "end": 39
-            },
             "specifiers": [
               {
                 "type": "ImportSpecifier",
-                "span": {
-                  "start": 10,
-                  "end": 16
+                "imported": {
+                  "type": "Identifier",
+                  "decorators": [],
+                  "name": "Button",
+                  "optional": false,
+                  "typeAnnotation": null,
+                  "start": 9,
+                  "end": 15
                 },
                 "local": {
                   "type": "Identifier",
-                  "span": {
-                    "start": 10,
-                    "end": 16
-                  },
-                  "ctxt": 0,
-                  "value": "Button",
-                  "optional": false
+                  "decorators": [],
+                  "name": "Button",
+                  "optional": false,
+                  "typeAnnotation": null,
+                  "start": 9,
+                  "end": 15
                 },
-                "imported": null,
-                "isTypeOnly": false
+                "importKind": "value",
+                "start": 9,
+                "end": 15
               }
             ],
             "source": {
-              "type": "StringLiteral",
-              "span": {
-                "start": 24,
-                "end": 38
-              },
+              "type": "Literal",
               "value": "./button.tsx",
-              "raw": "\"./button.tsx\""
+              "raw": "\"./button.tsx\"",
+              "start": 23,
+              "end": 37
             },
-            "typeOnly": false,
-            "with": null,
-            "phase": "evaluation"
+            "phase": null,
+            "attributes": [],
+            "importKind": "value",
+            "start": 0,
+            "end": 38
           },
           {
             "type": "ImportDeclaration",
-            "span": {
-              "start": 40,
-              "end": 64
-            },
             "specifiers": [
               {
                 "type": "ImportDefaultSpecifier",
-                "span": {
-                  "start": 47,
-                  "end": 50
-                },
                 "local": {
                   "type": "Identifier",
-                  "span": {
-                    "start": 47,
-                    "end": 50
-                  },
-                  "ctxt": 0,
-                  "value": "foo",
-                  "optional": false
-                }
+                  "decorators": [],
+                  "name": "foo",
+                  "optional": false,
+                  "typeAnnotation": null,
+                  "start": 46,
+                  "end": 49
+                },
+                "start": 46,
+                "end": 49
               }
             ],
             "source": {
-              "type": "StringLiteral",
-              "span": {
-                "start": 56,
-                "end": 63
-              },
+              "type": "Literal",
               "value": "./foo",
-              "raw": "\"./foo\""
+              "raw": "\"./foo\"",
+              "start": 55,
+              "end": 62
             },
-            "typeOnly": false,
-            "with": null,
-            "phase": "evaluation"
+            "phase": null,
+            "attributes": [],
+            "importKind": "value",
+            "start": 39,
+            "end": 63
           },
           {
             "type": "VariableDeclaration",
-            "span": {
-              "start": 66,
-              "end": 94
-            },
-            "ctxt": 0,
             "kind": "const",
-            "declare": false,
             "declarations": [
               {
                 "type": "VariableDeclarator",
-                "span": {
-                  "start": 72,
-                  "end": 93
-                },
                 "id": {
                   "type": "Identifier",
-                  "span": {
-                    "start": 72,
-                    "end": 78
-                  },
-                  "ctxt": 0,
-                  "value": "button",
+                  "decorators": [],
+                  "name": "button",
                   "optional": false,
-                  "typeAnnotation": null
+                  "typeAnnotation": null,
+                  "start": 71,
+                  "end": 77
                 },
                 "init": {
                   "type": "NewExpression",
-                  "span": {
-                    "start": 81,
-                    "end": 93
-                  },
-                  "ctxt": 0,
                   "callee": {
                     "type": "Identifier",
-                    "span": {
-                      "start": 85,
-                      "end": 91
-                    },
-                    "ctxt": 0,
-                    "value": "Button",
-                    "optional": false
+                    "decorators": [],
+                    "name": "Button",
+                    "optional": false,
+                    "typeAnnotation": null,
+                    "start": 84,
+                    "end": 90
                   },
+                  "typeArguments": null,
                   "arguments": [],
-                  "typeArguments": null
+                  "start": 80,
+                  "end": 92
                 },
-                "definite": false
+                "definite": false,
+                "start": 71,
+                "end": 92
               }
-            ]
+            ],
+            "declare": false,
+            "start": 65,
+            "end": 93
           },
           {
             "type": "ExpressionStatement",
-            "span": {
-              "start": 96,
-              "end": 112
-            },
             "expression": {
               "type": "CallExpression",
-              "span": {
-                "start": 96,
-                "end": 111
-              },
-              "ctxt": 0,
               "callee": {
                 "type": "MemberExpression",
-                "span": {
-                  "start": 96,
-                  "end": 109
-                },
                 "object": {
                   "type": "Identifier",
-                  "span": {
-                    "start": 96,
-                    "end": 102
-                  },
-                  "ctxt": 0,
-                  "value": "button",
-                  "optional": false
+                  "decorators": [],
+                  "name": "button",
+                  "optional": false,
+                  "typeAnnotation": null,
+                  "start": 95,
+                  "end": 101
                 },
                 "property": {
                   "type": "Identifier",
-                  "span": {
-                    "start": 103,
-                    "end": 109
-                  },
-                  "value": "render"
-                }
+                  "decorators": [],
+                  "name": "render",
+                  "optional": false,
+                  "typeAnnotation": null,
+                  "start": 102,
+                  "end": 108
+                },
+                "optional": false,
+                "computed": false,
+                "start": 95,
+                "end": 108
               },
+              "typeArguments": null,
               "arguments": [],
-              "typeArguments": null
-            }
+              "optional": false,
+              "start": 95,
+              "end": 110
+            },
+            "directive": null,
+            "start": 95,
+            "end": 111
           },
           {
             "type": "ExpressionStatement",
-            "span": {
-              "start": 113,
-              "end": 119
-            },
             "expression": {
               "type": "CallExpression",
-              "span": {
-                "start": 113,
-                "end": 118
-              },
-              "ctxt": 0,
               "callee": {
                 "type": "Identifier",
-                "span": {
-                  "start": 113,
-                  "end": 116
-                },
-                "ctxt": 0,
-                "value": "foo",
-                "optional": false
+                "decorators": [],
+                "name": "foo",
+                "optional": false,
+                "typeAnnotation": null,
+                "start": 112,
+                "end": 115
               },
+              "typeArguments": null,
               "arguments": [],
-              "typeArguments": null
-            }
+              "optional": false,
+              "start": 112,
+              "end": 117
+            },
+            "directive": null,
+            "start": 112,
+            "end": 118
           }
         ],
-        "interpreter": null
+        "sourceType": "module",
+        "hashbang": null,
+        "start": 0,
+        "end": 119
       }
     }
   }

--- a/crates/turborepo/tests/snapshots/query__turbo_trace_get_`require_example.js`_with_dependencies_(npm@10.5.0).snap
+++ b/crates/turborepo/tests/snapshots/query__turbo_trace_get_`require_example.js`_with_dependencies_(npm@10.5.0).snap
@@ -1,0 +1,23 @@
+---
+source: crates/turborepo/tests/query.rs
+expression: query_output
+---
+{
+  "data": {
+    "file": {
+      "path": "require_example.js",
+      "dependencies": {
+        "files": {
+          "items": [
+            {
+              "path": "bar.js"
+            },
+            {
+              "path": "foo.js"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/crates/turborepo/tests/turbo_trace_test.rs
+++ b/crates/turborepo/tests/turbo_trace_test.rs
@@ -120,13 +120,26 @@ fn test_ast_query() {
         r#"query { file(path: "main.ts") { path ast } }"#,
     );
     let ast = &json["data"]["file"]["ast"];
-    assert_eq!(ast["type"], "Module");
+    assert_eq!(ast["type"], "Program");
     assert!(!ast["body"].as_array().unwrap().is_empty());
 
     // First statement should be an import of Button from ./button.tsx
     let first = &ast["body"][0];
     assert_eq!(first["type"], "ImportDeclaration");
     assert_eq!(first["source"]["value"], "./button.tsx");
+}
+
+#[test]
+fn test_require_dependencies() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(tempdir.path(), "turbo_trace", "npm@10.5.0", true).unwrap();
+
+    let json = query(
+        tempdir.path(),
+        r#"query { file(path: "require_example.js") { path, dependencies { files { items { path } } } } }"#,
+    );
+    let deps = file_paths(&json);
+    assert_eq!(deps, vec!["bar.js", "foo.js"]);
 }
 
 #[test]

--- a/turborepo-tests/integration/fixtures/turbo_trace/require_example.js
+++ b/turborepo-tests/integration/fixtures/turbo_trace/require_example.js
@@ -1,0 +1,8 @@
+const bar = require("./bar");
+
+if (process.env.NODE_ENV === "production") {
+  const foo = require("./foo");
+  foo();
+}
+
+bar();


### PR DESCRIPTION
## Summary

Replaces the SWC parser (`swc_ecma_parser`, `swc_ecma_ast`, `swc_ecma_visit`, `swc_common`) with oxc (`oxc_parser`, `oxc_ast`, `oxc_estree`, `oxc_span`, `oxc_syntax`) for all JS/TS parsing in the codebase.

SWC's deeply chained, macro-heavy crates were the single biggest bottleneck on the compilation critical path: `swc_ecma_ast` (8.4s, 93% frontend), `swc_ecma_parser` (5.1s), `swc_ecma_visit` (3.9s), `swc_common` (2.6s) = ~20s serial. oxc compiles with better parallelism and fewer total units. Clean build CPU time drops by ~21s.

We can generally get the same functionality for at a cheaper compilation time with oxc, so mind as well.

### What changed

**`turbo-trace`**: Rewrote import extraction to use oxc's `ModuleRecord` (pre-extracted import/export metadata from the parser) instead of a custom SWC visitor. `require()` calls are detected via direct AST pattern matching. AST serialization uses oxc's ESTree JSON format.

**`turborepo-boundaries`**: Replaced SWC parsing + `ImportFinder` visitor with calls to `turbo_trace::parse_file`. Comment detection for `@boundaries-ignore` directives now uses oxc's `Comment` spans with a backwards walk that respects blank line boundaries.

**`turborepo-query`**: `File.ast` is now `Option<serde_json::Value>` (eagerly serialized at parse time while the oxc allocator is alive) instead of `Option<swc_ecma_ast::Module>`. The `ast()` GraphQL endpoint now returns ESTree JSON.

### User-visible changes

- **`turbo query` AST output**: JSON format changed from SWC's custom format to ESTree standard. Top-level `"type"` is `"Program"` instead of `"Module"`. Field names follow ESTree conventions. This endpoint is undocumented and has no stability guarantees.
- **`@boundaries-ignore` with blank line**: A `@boundaries-ignore` comment separated from its import by a blank line no longer suppresses the violation. The old SWC behavior incorrectly attached the comment across the gap.

### Testing

- Added `require()` integration test (`require_example.js` fixture) — previously untested
- All 21 trace dependency snapshots unchanged (identical import resolution behavior)
- Updated AST snapshot to ESTree format
- Updated boundaries snapshot (+1 correct violation for blank-line-separated ignore)
- All 41 tests pass