### PR TITLE
perf: Disable unused zstd default features to reduce C compilation

### DIFF
--- a/crates/turborepo-cache/Cargo.toml
+++ b/crates/turborepo-cache/Cargo.toml
@@ -49,4 +49,4 @@ turbopath = { workspace = true }
 turborepo-analytics = { workspace = true }
 turborepo-api-client = { workspace = true }
 turborepo-auth = { workspace = true }
-zstd = "0.13.3"
+zstd = { version = "0.13.3", default-features = false }


### PR DESCRIPTION
## Summary

Disables the `legacy` and `zdict_builder` default features on the `zstd` crate in `turborepo-cache`. This eliminates 11 of 36 C files from the `zstd-sys` build script, which is the single most expensive unit on the compilation critical path at 12.6s.

- **`legacy`**: Compiles decoders for zstd formats v0.1-v0.7, deprecated years ago. Turborepo's cache only produces current-format zstd.
- **`zdict_builder`**: Compiles dictionary training code. Turborepo never trains dictionaries.

Zero runtime impact — the actual compress/decompress codepath is identical. Turborepo only uses `zstd::Encoder::new(writer, 0)` and `zstd::Decoder::new(reader)` for streaming cache archive compression.

`zstd-sys` sits on the critical path (`zstd-sys` → `zstd` → `turborepo-cache` → `turborepo-config` → ... → `turborepo-lib` → `turborepo-lsp`), so any reduction here translates directly to wall-time savings.