### PR TITLE
fix: Handle capnproto installation across all container environments

### DIFF
--- a/.github/actions/setup-capnproto/action.yml
+++ b/.github/actions/setup-capnproto/action.yml
@@ -17,7 +17,16 @@ runs:
     - name: "Setup capnproto for Linux"
       if: runner.os == 'Linux' && (steps.cache-capnp-linux.outcome == 'skipped' || steps.cache-capnp-linux.outputs.cache-hit != 'true')
       shell: bash
-      run: sudo apt-get -y update && sudo apt-get install -y capnproto
+      run: |
+        if command -v apt-get &> /dev/null; then
+          sudo apt-get -y update && sudo apt-get install -y capnproto
+        elif command -v apk &> /dev/null; then
+          apk add capnproto
+        elif command -v microdnf &> /dev/null; then
+          microdnf install -y make automake autoconf libtool gcc-c++
+          curl -sSL https://capnproto.org/capnproto-c++-1.1.0.tar.gz | tar -zxf -
+          cd capnproto-c++-1.1.0 && ./configure --prefix=/usr && make -j$(nproc) && make install && cd .. && rm -rf capnproto-c++-1.1.0
+        fi
 
     - name: "Setup capnproto for macos"
       if: runner.os == 'macOS'

--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -42,7 +42,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
             container: amazon/aws-lambda-nodejs:20
             install: |
-              microdnf install -y gcc gcc-c++ git tar xz capnproto
+              microdnf install -y gcc gcc-c++ git tar xz
               curl https://sh.rustup.rs -sSf | bash -s -- -y
               npm i -g pnpm@10.28.0
               mkdir ../zig
@@ -57,7 +57,7 @@ jobs:
             container: ghcr.io/napi-rs/napi-rs/nodejs-rust:stable-2023-09-17-alpine
             install: |
               apk update && apk upgrade
-              apk add libc6-compat curl capnproto
+              apk add libc6-compat curl
               echo /root/.cargo/bin >> ${GITHUB_PATH}
               echo /usr/local/cargo/bin/rustup >> ${GITHUB_PATH}
             setup: |
@@ -71,7 +71,7 @@ jobs:
             container: ghcr.io/napi-rs/napi-rs/nodejs-rust:stable-2023-09-17-alpine
             install: |
               apk update && apk upgrade
-              apk add libc6-compat curl capnproto
+              apk add libc6-compat curl
               echo /root/.cargo/bin >> ${GITHUB_PATH}
               echo /usr/local/cargo/bin/rustup >> ${GITHUB_PATH}
               echo /aarch64-linux-musl-cross/bin >> ${GITHUB_PATH}
@@ -118,7 +118,6 @@ jobs:
 
       - name: Setup capnproto
         uses: ./.github/actions/setup-capnproto
-        if: ${{ !matrix.settings.install }}
 
       - name: Setup toolchain
         run: ${{ matrix.settings.setup }}


### PR DESCRIPTION
## Summary

- Updates the `setup-capnproto` action to detect the available package manager and install capnproto accordingly
  - `apt-get`: existing behavior (`sudo apt-get install -y capnproto`)
  - `apk`: Alpine containers (`apk add capnproto`)
  - `microdnf`: Amazon Lambda containers (builds from source since there's no pre-built package)
- Removes inline capnproto installs from the library release workflow in favor of the shared action
- Removes the `if: !matrix.settings.install` guard so the action runs for container builds too

Follow-up to #12110 — `capnproto` isn't available as a `microdnf` package in the Amazon Lambda container, so the previous inline approach failed.