### PR TITLE
fix: Disable capnproto cache for container builds in library release

### DIFF
--- a/.github/actions/setup-capnproto/action.yml
+++ b/.github/actions/setup-capnproto/action.yml
@@ -1,39 +1,39 @@
 name: "Setup Capnproto"
 description: "Sets up capnproto for the current platform"
 
+inputs:
+  use-cache:
+    description: "Whether to cache the capnproto installation. Disable for container builds."
+    required: false
+    default: "true"
+
 runs:
   using: "composite"
   steps:
-    - name: "Detect container"
-      id: detect-container
-      shell: bash
-      run: |
-        if [ -f /.dockerenv ] || [ -f /run/.containerenv ] || grep -q 'docker\|lxc\|containerd' /proc/1/cgroup 2>/dev/null; then
-          echo "in-container=true" >> $GITHUB_OUTPUT
-        else
-          echo "in-container=false" >> $GITHUB_OUTPUT
-        fi
-
     - name: "Cache capnproto (Linux)"
-      if: runner.os == 'Linux' && steps.detect-container.outputs.in-container != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+      if: runner.os == 'Linux' && inputs.use-cache == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
       uses: actions/cache@v4
       id: cache-capnp-linux
       with:
         path: |
           /usr/bin/capnp
           /usr/bin/capnpc
-        key: ${{ runner.os }}-capnproto-0.11.2
+        key: ${{ runner.os }}-capnproto-1.1.0
 
     - name: "Setup capnproto for Linux"
       if: runner.os == 'Linux' && (steps.cache-capnp-linux.outcome == 'skipped' || steps.cache-capnp-linux.outputs.cache-hit != 'true')
       shell: bash
       run: |
+        if command -v capnp &> /dev/null; then
+          echo "capnp already available: $(capnp --version)"
+          exit 0
+        fi
+
         if command -v apt-get &> /dev/null; then
           sudo apt-get -y update && sudo apt-get install -y capnproto
         elif command -v apk &> /dev/null; then
           apk add capnproto
-        elif command -v microdnf &> /dev/null; then
-          microdnf install -y make automake autoconf libtool gcc-c++
+        else
           curl -sSL https://capnproto.org/capnproto-c++-1.1.0.tar.gz | tar -zxf -
           cd capnproto-c++-1.1.0 && ./configure --prefix=/usr && make -j$(nproc) && make install && cd .. && rm -rf capnproto-c++-1.1.0
         fi

--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -42,7 +42,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
             container: amazon/aws-lambda-nodejs:20
             install: |
-              microdnf install -y gcc gcc-c++ git tar xz
+              microdnf install -y gcc gcc-c++ git tar xz make
               curl https://sh.rustup.rs -sSf | bash -s -- -y
               npm i -g pnpm@10.28.0
               mkdir ../zig
@@ -118,6 +118,8 @@ jobs:
 
       - name: Setup capnproto
         uses: ./.github/actions/setup-capnproto
+        with:
+          use-cache: ${{ !matrix.settings.install }}
 
       - name: Setup toolchain
         run: ${{ matrix.settings.setup }}


### PR DESCRIPTION
## Summary

Follow-up to #12112. The container detection approach (`/.dockerenv`, `/proc/1/cgroup`) doesn't work reliably in GitHub Actions container jobs, so the Alpine musl builds still fail — the cache restores glibc binaries that can't run on musl.

This replaces the runtime container detection with an explicit `use-cache` input on the `setup-capnproto` action. The library release workflow passes `use-cache: false` for container matrix entries (keyed off the existing `matrix.settings.install` flag), ensuring the install step always runs fresh in containers.

### Changes

**`setup-capnproto` action:**
- Replaces unreliable container detection with `use-cache` input (defaults to `true`, backwards compatible)
- Adds early-exit if `capnp` is already available
- Simplifies the `else` fallback (source build) — removes `microdnf`-specific branch since `make`/`gcc-c++` are already installed by the workflow
- Bumps cache key to `1.1.0`

**Library release workflow:**
- Passes `use-cache: ${{ !matrix.settings.install }}` — container builds (which have `install`) skip cache, non-container builds use it
- Adds `make` to the Amazon Lambda container's package list (needed for source build)