### PR TITLE
fix: Build capnproto statically in source build fallback

### DIFF
--- a/.github/actions/setup-capnproto/action.yml
+++ b/.github/actions/setup-capnproto/action.yml
@@ -35,7 +35,7 @@ runs:
           apk add capnproto
         else
           curl -sSL https://capnproto.org/capnproto-c++-1.1.0.tar.gz | tar -zxf -
-          cd capnproto-c++-1.1.0 && ./configure --prefix=/usr && make -j$(nproc) && make install && cd .. && rm -rf capnproto-c++-1.1.0
+          cd capnproto-c++-1.1.0 && ./configure --prefix=/usr --disable-shared && make -j$(nproc) && make install && cd .. && rm -rf capnproto-c++-1.1.0
         fi
 
     - name: "Setup capnproto for macos"


### PR DESCRIPTION
## Summary

The Amazon Lambda container build (`x86_64-unknown-linux-gnu`) fails because the source-built `capnp` binary links against shared libraries that aren't in the container's library path (exit status 32512 = dynamic linker failure).

Adds `--disable-shared` to the `./configure` step so the `capnp` binary is statically linked and runs in any environment.