### PR TITLE
fix: Install capnproto-dev on Alpine to get capnp compiler binary

### DIFF
--- a/.github/actions/setup-capnproto/action.yml
+++ b/.github/actions/setup-capnproto/action.yml
@@ -32,7 +32,7 @@ runs:
         if command -v apt-get &> /dev/null; then
           sudo apt-get -y update && sudo apt-get install -y capnproto
         elif command -v apk &> /dev/null; then
-          apk add capnproto
+          apk add capnproto-dev
         else
           curl -sSL https://capnproto.org/capnproto-c++-1.1.0.tar.gz | tar -zxf -
           cd capnproto-c++-1.1.0 && ./configure --prefix=/usr --disable-shared && make -j$(nproc) && make install && cd .. && rm -rf capnproto-c++-1.1.0


### PR DESCRIPTION
## Summary

On Alpine Linux, the `capnp` and `capnpc` binaries are in the `capnproto-dev` package, not `capnproto` (which only contains shared libraries). The musl container builds were installing the wrong package.