### PR TITLE
fix: Install capnproto on Windows for fork PRs that lack remote cache

### DIFF
--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -315,7 +315,7 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           node-version: "18.20.2"
-          capnproto: "false"
+          capnproto: ${{ github.event.pull_request.head.repo.fork && 'true' || 'false' }}
           package-install: "false"
 
       - name: Install Bun


### PR DESCRIPTION
## Summary

The `rust_test_windows` job had `capnproto: "false"` unconditionally, relying on turbo remote cache to restore the pre-built test archive. Fork PRs don't have access to `TURBO_TOKEN`/`TURBO_TEAM` secrets, so remote caching is unavailable and the job falls through to building from source — which panics because `capnp` isn't installed.

Now capnproto is conditionally installed: only on fork PRs where the remote cache won't be available.

## Test

Internal PRs: `capnproto: "false"` — no change in behavior, cache hit as before.
Fork PRs: `capnproto: "true"` — `choco install capnproto` runs, enabling the build to succeed on cache miss.