### PR TITLE
ci: Skip check-examples on fork PRs

### DIFF
--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -520,7 +520,7 @@ jobs:
     timeout-minutes: 40
     needs:
       - find-changes
-    if: ${{ needs.find-changes.outputs.is-release-pr != 'true' }}
+    if: ${{ needs.find-changes.outputs.is-release-pr != 'true' && !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}


### PR DESCRIPTION
## Summary

- The `check-examples` job requires `VERCEL_TOKEN` to create Vercel Sandboxes, which isn't available on fork PRs due to GitHub's secret restrictions. This causes every external contributor PR to fail at the "Setup Vercel credentials" step ([example](https://github.com/vercel/turborepo/actions/runs/22626837277/job/65565872025)).
- Skip the job on fork PRs using the same `github.event.pull_request.head.repo.fork` pattern already used by other jobs in this workflow (e.g., `coverage_report`, `sccache` conditionals on `rust_test_*`).
- On `push` events (merge to main), the expression evaluates to falsy, so the job still runs as before.