### PR TITLE
fix: Microfrontends merges `with` into root config instead of replacing it

### DIFF
--- a/crates/turborepo-lib/src/turbo_json/loader.rs
+++ b/crates/turborepo-lib/src/turbo_json/loader.rs
@@ -329,12 +329,13 @@ mod test {
                         def.cache.as_ref().map(|cache| *cache.as_inner()),
                         Some(false)
                     );
-                    // Make sure proxy is in there
                     if task_name == "dev" {
-                        assert_eq!(
-                            def.with.as_ref().unwrap().first().unwrap().as_inner(),
-                            &UnescapedString::from("web#proxy")
-                        )
+                        assert!(def
+                            .with
+                            .as_ref()
+                            .unwrap()
+                            .iter()
+                            .any(|t| { t.as_inner() == &UnescapedString::from("web#proxy") }));
                     }
                 } else {
                     panic!("didn't find {task_name}");
@@ -350,10 +351,12 @@ mod test {
                         def.cache.as_ref().map(|cache| *cache.as_inner()),
                         Some(false)
                     );
-                    assert_eq!(
-                        def.with.as_ref().unwrap().first().unwrap().as_inner(),
-                        &UnescapedString::from("web#proxy")
-                    )
+                    assert!(def
+                        .with
+                        .as_ref()
+                        .unwrap()
+                        .iter()
+                        .any(|t| { t.as_inner() == &UnescapedString::from("web#proxy") }));
                 } else {
                     panic!("didn't find {task_name}");
                 }

--- a/crates/turborepo-turbo-json/src/lib.rs
+++ b/crates/turborepo-turbo-json/src/lib.rs
@@ -517,7 +517,7 @@ mod tests {
     #[test]
     fn test_with_sibling_empty() {
         let mut json = TurboJson::default();
-        json.with_task(TaskName::from("dev"), &TaskName::from("api#server"));
+        json.with_task(TaskName::from("dev"), &TaskName::from("sibling-task"));
         let dev_task = json.tasks.get(&TaskName::from("dev"));
         assert!(dev_task.is_some());
         let dev_task = dev_task.unwrap().as_inner();
@@ -525,7 +525,7 @@ mod tests {
             dev_task.with.as_ref().unwrap().as_slice(),
             &[
                 Spanned::new(UnescapedString::from("$TURBO_EXTENDS$")),
-                Spanned::new(UnescapedString::from("api#server")),
+                Spanned::new(UnescapedString::from("sibling-task")),
             ]
         );
     }
@@ -540,7 +540,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        json.with_task(TaskName::from("dev"), &TaskName::from("api#server"));
+        json.with_task(TaskName::from("dev"), &TaskName::from("sibling-task"));
         let dev_task = json.tasks.get(&TaskName::from("dev"));
         assert!(dev_task.is_some());
         let dev_task = dev_task.unwrap().as_inner();
@@ -549,7 +549,7 @@ mod tests {
             dev_task.with.as_ref().unwrap().as_slice(),
             &[
                 Spanned::new(UnescapedString::from("$TURBO_EXTENDS$")),
-                Spanned::new(UnescapedString::from("api#server")),
+                Spanned::new(UnescapedString::from("sibling-task")),
             ]
         );
     }
@@ -557,16 +557,16 @@ mod tests {
     #[test]
     fn test_with_task_includes_turbo_extends_only_once() {
         let mut json = TurboJson::default();
-        json.with_task(TaskName::from("dev"), &TaskName::from("api#server"));
-        json.with_task(TaskName::from("dev"), &TaskName::from("web#proxy"));
+        json.with_task(TaskName::from("dev"), &TaskName::from("sibling-a"));
+        json.with_task(TaskName::from("dev"), &TaskName::from("sibling-b"));
         let dev_task = json.tasks.get(&TaskName::from("dev")).unwrap().as_inner();
         let with = dev_task.with.as_ref().unwrap();
         assert_eq!(
             with.as_slice(),
             &[
                 Spanned::new(UnescapedString::from("$TURBO_EXTENDS$")),
-                Spanned::new(UnescapedString::from("api#server")),
-                Spanned::new(UnescapedString::from("web#proxy")),
+                Spanned::new(UnescapedString::from("sibling-a")),
+                Spanned::new(UnescapedString::from("sibling-b")),
             ]
         );
     }
@@ -574,7 +574,6 @@ mod tests {
     #[test]
     fn test_with_task_preserves_user_configured_with() {
         let mut json = TurboJson::default();
-        // Simulate a workspace turbo.json that already has a user-configured `with`
         json.tasks.insert(
             TaskName::from("dev"),
             Spanned::new(RawTaskDefinition {
@@ -582,18 +581,15 @@ mod tests {
                 ..Default::default()
             }),
         );
-        // MFE injects its proxy
-        json.with_task(TaskName::from("dev"), &TaskName::from("web#proxy"));
+        json.with_task(TaskName::from("dev"), &TaskName::from("injected-task"));
         let dev_task = json.tasks.get(&TaskName::from("dev")).unwrap().as_inner();
         let with = dev_task.with.as_ref().unwrap();
-        // The user's existing task is preserved, $TURBO_EXTENDS$ is added, and the
-        // proxy is appended
         assert_eq!(
             with.as_slice(),
             &[
                 Spanned::new(UnescapedString::from("existing-task")),
                 Spanned::new(UnescapedString::from("$TURBO_EXTENDS$")),
-                Spanned::new(UnescapedString::from("web#proxy")),
+                Spanned::new(UnescapedString::from("injected-task")),
             ]
         );
     }
@@ -601,7 +597,6 @@ mod tests {
     #[test]
     fn test_with_task_respects_existing_turbo_extends() {
         let mut json = TurboJson::default();
-        // User already has $TURBO_EXTENDS$ in their with array
         json.tasks.insert(
             TaskName::from("dev"),
             Spanned::new(RawTaskDefinition {
@@ -612,8 +607,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        // MFE injects its proxy — should not add a duplicate $TURBO_EXTENDS$
-        json.with_task(TaskName::from("dev"), &TaskName::from("web#proxy"));
+        json.with_task(TaskName::from("dev"), &TaskName::from("injected-task"));
         let dev_task = json.tasks.get(&TaskName::from("dev")).unwrap().as_inner();
         let with = dev_task.with.as_ref().unwrap();
         assert_eq!(
@@ -621,7 +615,7 @@ mod tests {
             &[
                 Spanned::new(UnescapedString::from("existing-task")),
                 Spanned::new(UnescapedString::from("$TURBO_EXTENDS$")),
-                Spanned::new(UnescapedString::from("web#proxy")),
+                Spanned::new(UnescapedString::from("injected-task")),
             ]
         );
     }


### PR DESCRIPTION
## Summary

- Fixes a bug where microfrontends' proxy injection (`TurboJson::with_task()`) replaced the root turbo.json's `with` array instead of merging into it
- MFE apps that don't explicitly re-declare `with` in their own turbo.json lost any `with` entries configured at the root level

## Problem

`TurboJson::with_task()` pushes the task name into the raw `with` array without including the `$TURBO_EXTENDS$` sentinel. When the engine resolves the task definition chain (root -> workspace), `ProcessedWith::new()` sees no sentinel, sets `extends: false`, and the merge logic in `extend.rs` replaces the root's `with` values entirely.

## Fix

Add `$TURBO_EXTENDS$` to the `with` array in `with_task()` so the proxy entry merges into existing config rather than replacing it. The sentinel is only added once, even if `with_task()` is called multiple times.