### PR TITLE
ci: Optimize Rust caching in CI pipelines

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: "Extra flags to pass to pnpm install"
     required: false
     default: ""
+  rust-cache:
+    description: "Whether to enable the Rust cache. Set to `false` for jobs that don't compile."
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -48,6 +52,7 @@ runs:
         shared-cache-key: turborepo-debug-build
         cache-key: ${{ inputs.target }}
         save-cache: true
+        cache: ${{ inputs.rust-cache }}
         github-token: ${{ inputs.github-token }}
 
     - name: "Setup capnproto"

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: "Determiners whether the cache should be saved. If `false`, the cache is only restored."
     required: false
     default: "false"
+  cache:
+    description: "Whether to enable the Rust cache. Set to `false` for jobs that don't compile."
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -41,7 +45,7 @@ runs:
       run: echo "::add-matcher::${{ github.action_path }}/matchers.json"
 
     - name: "Setup Rust Cache"
-      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+      if: inputs.cache == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
       uses: Swatinem/rust-cache@v2
       with:
         shared-key: ${{ inputs.shared-cache-key }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -77,6 +77,16 @@ jobs:
     if: ${{ needs.determine_changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      SCCACHE_BUCKET: turborepo-sccache
+      SCCACHE_REGION: us-east-2
+      RUSTC_WRAPPER: ${{ !github.event.pull_request.head.repo.fork && 'sccache' || '' }}
+      CARGO_INCREMENTAL: 0
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      SCCACHE_IDLE_TIMEOUT: 0
+      SCCACHE_REQUEST_TIMEOUT: 30
+      SCCACHE_ERROR_LOG: error
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -87,8 +97,15 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           node: "false"
 
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.6
+
       - name: Run cargo clippy
-        run: cargo lint
+        run: |
+          if [ -z "${RUSTC_WRAPPER}" ]; then
+            unset RUSTC_WRAPPER
+          fi
+          cargo lint
 
   rust_check:
     name: Rust check
@@ -96,6 +113,16 @@ jobs:
     if: ${{ needs.determine_changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      SCCACHE_BUCKET: turborepo-sccache
+      SCCACHE_REGION: us-east-2
+      RUSTC_WRAPPER: ${{ !github.event.pull_request.head.repo.fork && 'sccache' || '' }}
+      CARGO_INCREMENTAL: 0
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      SCCACHE_IDLE_TIMEOUT: 0
+      SCCACHE_REQUEST_TIMEOUT: 30
+      SCCACHE_ERROR_LOG: error
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -106,8 +133,15 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           node: "false"
 
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.6
+
       - name: Run cargo check
-        run: cargo check --workspace
+        run: |
+          if [ -z "${RUSTC_WRAPPER}" ]; then
+            unset RUSTC_WRAPPER
+          fi
+          cargo check --workspace
 
   rust_licenses:
     name: Rust licenses

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -317,6 +317,7 @@ jobs:
           node-version: "18.20.2"
           capnproto: ${{ github.event.pull_request.head.repo.fork && 'true' || 'false' }}
           package-install: "false"
+          rust-cache: "false"
 
       - name: Install Bun
         uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1


### PR DESCRIPTION
## Summary

- **Add sccache to `rust_clippy` and `rust_check` lint jobs.** These jobs compile the full workspace but were only using `Swatinem/rust-cache` (GitHub Actions cache). Adding sccache gives them S3-backed per-compilation-unit caching, which is especially useful on cold Swatinem cache runs. This matches how the test build jobs are already configured.
- **Skip Swatinem/rust-cache on `rust_test_windows` partition jobs.** These 10 parallel runners only restore a pre-built nextest archive and run tests from it — they never compile anything. Downloading/uploading the large `target/` cache tarball was pure overhead. A new `cache` input on `setup-rust` (threaded through `setup-environment` as `rust-cache`) allows disabling the Swatinem cache while keeping the toolchain install.