### PR TITLE
ci: Reduce Windows test partitions from 10 to 5

### DIFF
--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -284,14 +284,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        partition: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        partition: [1, 2, 3, 4, 5]
     runs-on: windows-latest-8-core-oss
     timeout-minutes: 45
     needs:
       - find-changes
       - build_rust_test_windows
     if: ${{ needs.find-changes.outputs.is-release-pr != 'true' && needs.find-changes.outputs.rust == 'true' }}
-    name: Rust testing on windows (partition ${{ matrix.partition }}/10)
+    name: Rust testing on windows (partition ${{ matrix.partition }}/5)
     steps:
       - name: Install git (Windows larger runners)
         shell: cmd
@@ -342,7 +342,7 @@ jobs:
       - name: Run tests
         timeout-minutes: 45
         run: |
-          cargo nextest run --archive-file cli/nextest-archive.tar.zst --no-fail-fast --partition hash:${{ matrix.partition }}/10
+          cargo nextest run --archive-file cli/nextest-archive.tar.zst --no-fail-fast --partition hash:${{ matrix.partition }}/5
         shell: bash
 
   rust_test_ubuntu:


### PR DESCRIPTION
## Summary

- Reduces Windows Rust test partitions from 10 to 5, halving the number of CI runners needed per push.

Windows test jobs have been consistently underutilizing their 45-minute timeout. Consolidating into fewer partitions reduces runner overhead and queue time while still providing meaningful parallelism.

## Testing

Watch this PR's CI run to confirm the 5 partitions complete within the 45-minute timeout.