### PR TITLE
feat: Add `runAttributes` config to OTel metrics for cardinality control

### DIFF
--- a/apps/docs/content/docs/reference/configuration.mdx
+++ b/apps/docs/content/docs/reference/configuration.mdx
@@ -915,8 +915,12 @@ The `experimentalObservability` configuration requires `futureFlags.experimental
       "metrics": {
         "runSummary": true,
         "taskDetails": false,
+        "runAttributes": {
+          "id": false,
+          "scmRevision": false
+        },
         "taskAttributes": {
-          "id": true,
+          "id": false,
           "hashes": false
         }
       },
@@ -1013,6 +1017,14 @@ Optional resource attributes to attach to all exported metrics. These help ident
 
 Control which metric groups are exported.
 
+<Callout type="info">
+  Some metric attributes have **unbounded cardinality** — their unique values
+  grow without limit (e.g., a unique run ID per invocation, a unique hash per
+  input change). Backends like Datadog charge per unique metric series, so these
+  attributes are disabled by default and can be opted into via `runAttributes`
+  and `taskAttributes`.
+</Callout>
+
 ##### `metrics.runSummary`
 
 Default: `true`
@@ -1022,7 +1034,7 @@ Export run-level metrics:
 - Run duration
 - Tasks attempted, failed, and cached
 - Exit code
-- SCM branch and revision
+- SCM branch
 
 ##### `metrics.taskDetails`
 
@@ -1032,8 +1044,23 @@ Export per-task metrics:
 
 - Task execution duration
 - Cache hit/miss status and source
-- Cache time saved
 - Task identifiers (task ID, package, hash)
+
+##### `metrics.runAttributes`
+
+Control which run attributes are included in run-level metrics. These options only take effect when `runSummary` is enabled.
+
+###### `runAttributes.id`
+
+Default: `false`
+
+Include the `turbo.run.id` attribute on run-level metrics. Each Turborepo invocation generates a unique run ID, so enabling this increases metric cardinality.
+
+###### `runAttributes.scmRevision`
+
+Default: `false`
+
+Include the `turbo.scm.revision` attribute (full Git SHA) on run-level metrics. Each commit produces a unique value, so enabling this increases metric cardinality.
 
 ##### `metrics.taskAttributes`
 
@@ -1043,13 +1070,13 @@ Control which task attributes are included in per-task metrics. These options on
 
 Default: `false`
 
-Include the task ID attribute on per-task metrics.
+Include the `turbo.task.id` attribute (`package#task`) on per-task metrics.
 
 ###### `taskAttributes.hashes`
 
 Default: `false`
 
-Include task hash attributes on per-task metrics.
+Include the `turbo.task.hash` and `turbo.task.external_inputs_hash` attributes on per-task metrics. These are content hashes that change whenever task inputs change, so enabling this increases metric cardinality.
 
 #### `experimentalObservability.otel.useRemoteCacheToken`
 

--- a/crates/turborepo-config/src/env.rs
+++ b/crates/turborepo-config/src/env.rs
@@ -83,6 +83,14 @@ const TURBO_MAPPING: &[(&str, &str)] = [
         "experimental_otel_metrics_task_details",
     ),
     (
+        "turbo_experimental_otel_metrics_run_attributes_id",
+        "experimental_otel_metrics_run_attributes_id",
+    ),
+    (
+        "turbo_experimental_otel_metrics_run_attributes_scm_revision",
+        "experimental_otel_metrics_run_attributes_scm_revision",
+    ),
+    (
         "turbo_experimental_otel_metrics_task_attributes_id",
         "experimental_otel_metrics_task_attributes_id",
     ),

--- a/crates/turborepo-config/src/experimental_otel.rs
+++ b/crates/turborepo-config/src/experimental_otel.rs
@@ -10,6 +10,16 @@ use crate::Error;
 #[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq, Eq, Merge)]
 #[merge(strategy = merge::option::overwrite_none)]
 #[serde(rename_all = "camelCase")]
+pub struct ExperimentalOtelRunAttributesOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scm_revision: Option<bool>,
+}
+
+#[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq, Eq, Merge)]
+#[merge(strategy = merge::option::overwrite_none)]
+#[serde(rename_all = "camelCase")]
 pub struct ExperimentalOtelTaskAttributesOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<bool>,
@@ -25,6 +35,8 @@ pub struct ExperimentalOtelMetricsOptions {
     pub run_summary: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub task_details: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_attributes: Option<ExperimentalOtelRunAttributesOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub task_attributes: Option<ExperimentalOtelTaskAttributesOptions>,
 }
@@ -69,6 +81,10 @@ impl ExperimentalOtelOptions {
                 .map(|m| {
                     m.run_summary.is_none()
                         && m.task_details.is_none()
+                        && m.run_attributes
+                            .as_ref()
+                            .map(|a| a.id.is_none() && a.scm_revision.is_none())
+                            .unwrap_or(true)
                         && m.task_attributes
                             .as_ref()
                             .map(|a| a.id.is_none() && a.hashes.is_none())
@@ -155,6 +171,32 @@ impl ExperimentalOtelOptions {
             "experimental_otel_metrics_task_details",
             "TURBO_EXPERIMENTAL_OTEL_METRICS_TASK_DETAILS",
             |metrics, value| metrics.task_details = Some(value),
+            &mut options,
+        )?;
+
+        touched |= set_metric_flag(
+            map,
+            "experimental_otel_metrics_run_attributes_id",
+            "TURBO_EXPERIMENTAL_OTEL_METRICS_RUN_ATTRIBUTES_ID",
+            |metrics, value| {
+                metrics
+                    .run_attributes
+                    .get_or_insert_with(ExperimentalOtelRunAttributesOptions::default)
+                    .id = Some(value)
+            },
+            &mut options,
+        )?;
+
+        touched |= set_metric_flag(
+            map,
+            "experimental_otel_metrics_run_attributes_scm_revision",
+            "TURBO_EXPERIMENTAL_OTEL_METRICS_RUN_ATTRIBUTES_SCM_REVISION",
+            |metrics, value| {
+                metrics
+                    .run_attributes
+                    .get_or_insert_with(ExperimentalOtelRunAttributesOptions::default)
+                    .scm_revision = Some(value)
+            },
             &mut options,
         )?;
 
@@ -516,6 +558,26 @@ mod tests {
     }
 
     #[test]
+    fn test_from_env_map_metrics_run_attributes_id() {
+        let map = build_env_map(&[("experimental_otel_metrics_run_attributes_id", "0")]);
+        let result = ExperimentalOtelOptions::from_env_map(&map).unwrap();
+        assert!(result.is_some());
+        let metrics = result.unwrap().metrics.unwrap();
+        let attrs = metrics.run_attributes.unwrap();
+        assert_eq!(attrs.id, Some(false));
+    }
+
+    #[test]
+    fn test_from_env_map_metrics_run_attributes_scm_revision() {
+        let map = build_env_map(&[("experimental_otel_metrics_run_attributes_scm_revision", "1")]);
+        let result = ExperimentalOtelOptions::from_env_map(&map).unwrap();
+        assert!(result.is_some());
+        let metrics = result.unwrap().metrics.unwrap();
+        let attrs = metrics.run_attributes.unwrap();
+        assert_eq!(attrs.scm_revision, Some(true));
+    }
+
+    #[test]
     fn test_from_env_map_metrics_task_attributes_id() {
         let map = build_env_map(&[("experimental_otel_metrics_task_attributes_id", "1")]);
         let result = ExperimentalOtelOptions::from_env_map(&map).unwrap();
@@ -700,11 +762,29 @@ mod tests {
     }
 
     #[test]
+    fn test_is_empty_with_run_attributes() {
+        let opts = ExperimentalOtelOptions {
+            metrics: Some(ExperimentalOtelMetricsOptions {
+                run_summary: None,
+                task_details: None,
+                run_attributes: Some(ExperimentalOtelRunAttributesOptions {
+                    id: Some(false),
+                    scm_revision: None,
+                }),
+                task_attributes: None,
+            }),
+            ..Default::default()
+        };
+        assert!(!opts.is_empty());
+    }
+
+    #[test]
     fn test_is_empty_with_task_attributes() {
         let opts = ExperimentalOtelOptions {
             metrics: Some(ExperimentalOtelMetricsOptions {
                 run_summary: None,
                 task_details: None,
+                run_attributes: None,
                 task_attributes: Some(ExperimentalOtelTaskAttributesOptions {
                     id: Some(true),
                     hashes: None,

--- a/crates/turborepo-config/src/lib.rs
+++ b/crates/turborepo-config/src/lib.rs
@@ -50,7 +50,7 @@ pub const CONFIG_FILE_JSONC: &str = "turbo.jsonc";
 
 pub use experimental_otel::{
     ExperimentalOtelMetricsOptions, ExperimentalOtelOptions, ExperimentalOtelProtocol,
-    ExperimentalOtelTaskAttributesOptions,
+    ExperimentalOtelRunAttributesOptions, ExperimentalOtelTaskAttributesOptions,
 };
 
 #[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq, Eq, Merge)]
@@ -850,6 +850,7 @@ mod test {
                     metrics: Some(ExperimentalOtelMetricsOptions {
                         run_summary: Some(false),
                         task_details: Some(false),
+                        run_attributes: None,
                         task_attributes: None,
                     }),
                     ..Default::default()

--- a/crates/turborepo-config/src/turbo_json.rs
+++ b/crates/turborepo-config/src/turbo_json.rs
@@ -9,8 +9,8 @@ use turborepo_turbo_json::{
 
 use crate::{
     ConfigurationOptions, Error, ExperimentalObservabilityOptions, ExperimentalOtelMetricsOptions,
-    ExperimentalOtelOptions, ExperimentalOtelProtocol, ExperimentalOtelTaskAttributesOptions,
-    ResolvedConfigurationOptions,
+    ExperimentalOtelOptions, ExperimentalOtelProtocol, ExperimentalOtelRunAttributesOptions,
+    ExperimentalOtelTaskAttributesOptions, ResolvedConfigurationOptions,
 };
 
 pub struct TurboJsonReader<'a> {
@@ -152,6 +152,12 @@ fn convert_raw_observability_otel(
     let metrics = raw.metrics.map(|metrics| ExperimentalOtelMetricsOptions {
         run_summary: metrics.run_summary.map(|flag| *flag.as_inner()),
         task_details: metrics.task_details.map(|flag| *flag.as_inner()),
+        run_attributes: metrics
+            .run_attributes
+            .map(|attrs| ExperimentalOtelRunAttributesOptions {
+                id: attrs.id.map(|flag| *flag.as_inner()),
+                scm_revision: attrs.scm_revision.map(|flag| *flag.as_inner()),
+            }),
         task_attributes: metrics.task_attributes.map(|attrs| {
             ExperimentalOtelTaskAttributesOptions {
                 id: attrs.id.map(|flag| *flag.as_inner()),

--- a/crates/turborepo-otel/src/lib.rs
+++ b/crates/turborepo-otel/src/lib.rs
@@ -31,11 +31,9 @@
 //!     protocol: Protocol::Grpc,
 //!     headers: BTreeMap::new(),
 //!     timeout: Duration::from_secs(10),
+//!     interval: Duration::from_secs(15),
 //!     resource_attributes: BTreeMap::new(),
-//!     metrics: MetricsConfig {
-//!         run_summary: true,
-//!         task_details: false,
-//!     },
+//!     metrics: MetricsConfig::default(),
 //! };
 //!
 //! let handle = Handle::try_new(config)?;
@@ -64,6 +62,25 @@
 //! When `task_details` is enabled:
 //! - `turbo.task.duration_ms` - Histogram of individual task durations
 //! - `turbo.task.cache.events` - Counter of cache events with hit/miss status
+//!
+//! # Metric Attributes and Cardinality
+//!
+//! Attributes with unbounded cardinality (unique values grow without limit)
+//! are gated behind opt-in config flags to avoid creating excessive metric
+//! series in backends like Datadog that charge per unique series.
+//!
+//! **Always attached** (bounded cardinality):
+//! - `turbo.run.exit_code`, `turbo.version`, `turbo.scm.branch`
+//! - `turbo.task.name`, `turbo.task.package`, `turbo.task.command`
+//! - `turbo.task.cache_status`, `turbo.task.cache_source`,
+//!   `turbo.task.exit_code`
+//!
+//! **Gated by `run_attributes`** (unbounded — opt-in):
+//! - `turbo.run.id` — unique KSUID per invocation
+//! - `turbo.scm.revision` — full Git SHA, unique per commit
+//!
+//! **Gated by `task_attributes`** (unbounded — opt-in):
+//! - `turbo.task.id`, `turbo.task.hash`, `turbo.task.external_inputs_hash`
 
 use std::{
     collections::{BTreeMap, HashMap},
@@ -150,7 +167,14 @@ impl std::str::FromStr for Protocol {
     }
 }
 
-/// Metric toggle configuration.
+/// Controls which attributes are attached to run-level metrics.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct RunAttributesConfig {
+    pub id: bool,
+    pub scm_revision: bool,
+}
+
+/// Controls which attributes are attached to per-task metrics.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct TaskAttributesConfig {
     pub id: bool,
@@ -162,6 +186,7 @@ pub struct TaskAttributesConfig {
 pub struct MetricsConfig {
     pub run_summary: bool,
     pub task_details: bool,
+    pub run_attributes: RunAttributesConfig,
     pub task_attributes: TaskAttributesConfig,
 }
 
@@ -204,7 +229,6 @@ pub struct TaskMetricsPayload {
     pub duration_ms: Option<f64>,
     pub cache_status: TaskCacheStatus,
     pub cache_source: Option<String>,
-    pub cache_time_saved_ms: Option<u64>,
     pub exit_code: Option<i32>,
 }
 
@@ -302,7 +326,9 @@ impl Handle {
             payload.cached_tasks
         );
         if self.inner.metrics.run_summary {
-            self.inner.instruments.record_run_summary(payload);
+            self.inner
+                .instruments
+                .record_run_summary(payload, self.inner.metrics);
         }
         if self.inner.metrics.task_details {
             self.inner
@@ -336,7 +362,7 @@ impl Handle {
 }
 
 impl Instruments {
-    fn record_run_summary(&self, payload: &RunMetricsPayload) {
+    fn record_run_summary(&self, payload: &RunMetricsPayload, metrics: MetricsConfig) {
         tracing::debug!(
             target: "turborepo_otel",
             "record_run_summary run_id={} duration_ms={} attempted={}",
@@ -344,7 +370,7 @@ impl Instruments {
             payload.duration_ms,
             payload.attempted_tasks
         );
-        let attrs = build_run_attributes(payload);
+        let attrs = build_run_attributes(payload, metrics.run_attributes);
         self.run_duration.record(payload.duration_ms, &attrs);
         self.run_attempted.add(payload.attempted_tasks, &attrs);
         self.run_failed.add(payload.failed_tasks, &attrs);
@@ -358,7 +384,7 @@ impl Instruments {
             payload.run_id,
             payload.tasks.len()
         );
-        let base_attrs = build_run_attributes(payload);
+        let base_attrs = build_run_attributes(payload, metrics.run_attributes);
         for task in payload.tasks.iter() {
             let mut attrs = base_attrs.clone();
             attrs.push(KeyValue::new("turbo.task.name", task.task.clone()));
@@ -380,12 +406,6 @@ impl Instruments {
             ));
             if let Some(source) = &task.cache_source {
                 attrs.push(KeyValue::new("turbo.task.cache_source", source.clone()));
-            }
-            if let Some(time_saved) = task.cache_time_saved_ms {
-                attrs.push(KeyValue::new(
-                    "turbo.task.cache_time_saved_ms",
-                    time_saved as i64,
-                ));
             }
             if let Some(exit_code) = task.exit_code {
                 attrs.push(KeyValue::new("turbo.task.exit_code", exit_code as i64));
@@ -542,9 +562,14 @@ fn create_instruments(meter: &Meter) -> Instruments {
     }
 }
 
-fn build_run_attributes(payload: &RunMetricsPayload) -> Vec<KeyValue> {
+fn build_run_attributes(
+    payload: &RunMetricsPayload,
+    run_attributes: RunAttributesConfig,
+) -> Vec<KeyValue> {
     let mut attrs = Vec::with_capacity(6);
-    attrs.push(KeyValue::new("turbo.run.id", payload.run_id.clone()));
+    if run_attributes.id {
+        attrs.push(KeyValue::new("turbo.run.id", payload.run_id.clone()));
+    }
     attrs.push(KeyValue::new(
         "turbo.run.exit_code",
         payload.exit_code.to_string(),
@@ -556,7 +581,9 @@ fn build_run_attributes(payload: &RunMetricsPayload) -> Vec<KeyValue> {
     if let Some(branch) = &payload.scm_branch {
         attrs.push(KeyValue::new("turbo.scm.branch", branch.clone()));
     }
-    if let Some(revision) = &payload.scm_revision {
+    if run_attributes.scm_revision
+        && let Some(revision) = &payload.scm_revision
+    {
         attrs.push(KeyValue::new("turbo.scm.revision", revision.clone()));
     }
     attrs

--- a/crates/turborepo-run-summary/src/observability/otel.rs
+++ b/crates/turborepo-run-summary/src/observability/otel.rs
@@ -117,6 +117,13 @@ fn metrics_config(
 ) -> turborepo_otel::MetricsConfig {
     let run_summary = options.and_then(|opts| opts.run_summary).unwrap_or(true);
     let task_details = options.and_then(|opts| opts.task_details).unwrap_or(false);
+    let run_attributes = options
+        .and_then(|opts| opts.run_attributes.as_ref())
+        .map(|attrs| turborepo_otel::RunAttributesConfig {
+            id: attrs.id.unwrap_or(false),
+            scm_revision: attrs.scm_revision.unwrap_or(false),
+        })
+        .unwrap_or_default();
     let task_attributes = options
         .and_then(|opts| opts.task_attributes.as_ref())
         .map(|attrs| turborepo_otel::TaskAttributesConfig {
@@ -127,6 +134,7 @@ fn metrics_config(
     turborepo_otel::MetricsConfig {
         run_summary,
         task_details,
+        run_attributes,
         task_attributes,
     }
 }
@@ -180,13 +188,6 @@ fn build_task_payload(task: &TaskSummary) -> TaskMetricsPayload {
         .cache
         .cache_source_label()
         .map(|label| label.to_string());
-    let cache_time_saved_ms = match cache_status {
-        TaskCacheStatus::Hit => {
-            let saved = task.shared.cache.time_saved();
-            (saved > 0).then_some(saved)
-        }
-        TaskCacheStatus::Miss => None,
-    };
 
     TaskMetricsPayload {
         task_id: task.task_id.to_string(),
@@ -200,7 +201,6 @@ fn build_task_payload(task: &TaskSummary) -> TaskMetricsPayload {
         duration_ms,
         cache_status,
         cache_source,
-        cache_time_saved_ms,
         exit_code,
     }
 }
@@ -224,6 +224,7 @@ mod tests {
             metrics: turborepo_otel::MetricsConfig {
                 run_summary: true,
                 task_details: false,
+                run_attributes: turborepo_otel::RunAttributesConfig::default(),
                 task_attributes: turborepo_otel::TaskAttributesConfig::default(),
             },
         }
@@ -290,6 +291,8 @@ mod tests {
         assert!(config.resource_attributes.is_empty());
         assert!(config.metrics.run_summary);
         assert!(!config.metrics.task_details);
+        assert!(!config.metrics.run_attributes.id);
+        assert!(!config.metrics.run_attributes.scm_revision);
         assert!(!config.metrics.task_attributes.id);
         assert!(!config.metrics.task_attributes.hashes);
     }
@@ -311,6 +314,7 @@ mod tests {
             metrics: Some(ExperimentalOtelMetricsOptions {
                 run_summary: Some(false),
                 task_details: Some(true),
+                run_attributes: None,
                 task_attributes: None,
             }),
             ..Default::default()
@@ -342,12 +346,18 @@ mod tests {
         fn expected_metrics(
             run_summary: bool,
             task_details: bool,
+            run_id: bool,
+            run_scm_revision: bool,
             task_id: bool,
             task_hashes: bool,
         ) -> turborepo_otel::MetricsConfig {
             turborepo_otel::MetricsConfig {
                 run_summary,
                 task_details,
+                run_attributes: turborepo_otel::RunAttributesConfig {
+                    id: run_id,
+                    scm_revision: run_scm_revision,
+                },
                 task_attributes: turborepo_otel::TaskAttributesConfig {
                     id: task_id,
                     hashes: task_hashes,
@@ -359,40 +369,44 @@ mod tests {
             MetricsCase {
                 name: "defaults",
                 options: None,
-                expected: expected_metrics(true, false, false, false),
+                expected: expected_metrics(true, false, false, false, false, false),
             },
             MetricsCase {
                 name: "both overridden",
                 options: Some(ExperimentalOtelMetricsOptions {
                     run_summary: Some(false),
                     task_details: Some(true),
+                    run_attributes: None,
                     task_attributes: None,
                 }),
-                expected: expected_metrics(false, true, false, false),
+                expected: expected_metrics(false, true, false, false, false, false),
             },
             MetricsCase {
                 name: "only run_summary overridden",
                 options: Some(ExperimentalOtelMetricsOptions {
                     run_summary: Some(false),
                     task_details: None,
+                    run_attributes: None,
                     task_attributes: None,
                 }),
-                expected: expected_metrics(false, false, false, false),
+                expected: expected_metrics(false, false, false, false, false, false),
             },
             MetricsCase {
                 name: "only task_details overridden",
                 options: Some(ExperimentalOtelMetricsOptions {
                     run_summary: None,
                     task_details: Some(true),
+                    run_attributes: None,
                     task_attributes: None,
                 }),
-                expected: expected_metrics(true, true, false, false),
+                expected: expected_metrics(true, true, false, false, false, false),
             },
             MetricsCase {
                 name: "task_attributes overridden",
                 options: Some(ExperimentalOtelMetricsOptions {
                     run_summary: None,
                     task_details: None,
+                    run_attributes: None,
                     task_attributes: Some(
                         turborepo_config::ExperimentalOtelTaskAttributesOptions {
                             id: Some(true),
@@ -400,7 +414,33 @@ mod tests {
                         },
                     ),
                 }),
-                expected: expected_metrics(true, false, true, true),
+                expected: expected_metrics(true, false, false, false, true, true),
+            },
+            MetricsCase {
+                name: "run_attributes.id enabled",
+                options: Some(ExperimentalOtelMetricsOptions {
+                    run_summary: None,
+                    task_details: None,
+                    run_attributes: Some(turborepo_config::ExperimentalOtelRunAttributesOptions {
+                        id: Some(true),
+                        scm_revision: None,
+                    }),
+                    task_attributes: None,
+                }),
+                expected: expected_metrics(true, false, true, false, false, false),
+            },
+            MetricsCase {
+                name: "run_attributes fully enabled",
+                options: Some(ExperimentalOtelMetricsOptions {
+                    run_summary: None,
+                    task_details: None,
+                    run_attributes: Some(turborepo_config::ExperimentalOtelRunAttributesOptions {
+                        id: Some(true),
+                        scm_revision: Some(true),
+                    }),
+                    task_attributes: None,
+                }),
+                expected: expected_metrics(true, false, true, true, false, false),
             },
         ];
 

--- a/crates/turborepo-run-summary/src/task.rs
+++ b/crates/turborepo-run-summary/src/task.rs
@@ -151,12 +151,6 @@ impl TaskCacheSummary {
         self.status
     }
 
-    // Used in observability/otel.rs to populate
-    // TaskMetricsPayload.cache_time_saved_ms
-    pub(crate) fn time_saved(&self) -> u64 {
-        self.time_saved
-    }
-
     // Used in observability/otel.rs to populate TaskMetricsPayload.cache_source
     pub(crate) fn cache_source_label(&self) -> Option<&'static str> {
         self.source.map(|source| match source {

--- a/crates/turborepo-turbo-json/src/raw.rs
+++ b/crates/turborepo-turbo-json/src/raw.rs
@@ -244,7 +244,19 @@ pub struct RawObservabilityOtelMetrics {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub task_details: Option<Spanned<bool>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_attributes: Option<RawObservabilityOtelRunAttributes>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub task_attributes: Option<RawObservabilityOtelTaskAttributes>,
+}
+
+/// OTel run attribute configuration for run-level metrics.
+#[derive(Serialize, Default, Debug, Clone, Iterable, Deserializable)]
+#[serde(rename_all = "camelCase")]
+pub struct RawObservabilityOtelRunAttributes {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<Spanned<bool>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scm_revision: Option<Spanned<bool>>,
 }
 
 /// OTel task attribute configuration for task detail metrics.

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -314,7 +314,7 @@ The system uses a two-layer design:
 
 Observability is configured via `experimentalObservability.otel` in `turbo.json`:
 
-```json
+```jsonc
 {
   "futureFlags": {
     "experimentalObservability": true
@@ -329,7 +329,15 @@ Observability is configured via `experimentalObservability.otel` in `turbo.json`
       },
       "metrics": {
         "runSummary": true,
-        "taskDetails": true
+        "taskDetails": true,
+        "runAttributes": {
+          "id": false,        // turbo.run.id — unbounded cardinality
+          "scmRevision": false // turbo.scm.revision — unbounded cardinality
+        },
+        "taskAttributes": {
+          "id": false,    // turbo.task.id
+          "hashes": false // turbo.task.hash, turbo.task.external_inputs_hash — unbounded
+        }
       }
     }
   }
@@ -346,6 +354,8 @@ Configuration can also be set via environment variables (`TURBO_EXPERIMENTAL_OTE
 - `turbo.run.tasks.cached` - Cache hit counter
 - `turbo.task.duration_ms` - Per-task duration histogram (when `taskDetails` enabled)
 - `turbo.task.cache.events` - Per-task cache events (when `taskDetails` enabled)
+
+Attributes with unbounded cardinality (unique run IDs, Git SHAs, content hashes) are gated behind `runAttributes` and `taskAttributes` config flags, all defaulting to `false`. See the `Metric Attributes and Cardinality` section in `crates/turborepo-otel/src/lib.rs` for the full attribute inventory.
 
 #### Data Flow
 


### PR DESCRIPTION
## Summary

- Adds a `runAttributes` config section to `experimentalObservability.otel.metrics` that controls which run-level attributes are attached to exported metrics, following the same pattern as the existing `taskAttributes` config
- Gates high-cardinality metric attributes behind opt-in flags (all default to `false`) to prevent excessive metric series in observability backends
- Removes `turbo.task.cache_time_saved_ms` as a metric attribute since numeric values used as metric tags are a cardinality anti-pattern

### New config options

```jsonc
{
  "experimentalObservability": {
    "otel": {
      "metrics": {
        "runAttributes": {
          "id": false,          // turbo.run.id — unique per invocation
          "scmRevision": false  // turbo.scm.revision — unique per commit
        }
      }
    }
  }
}
```

Corresponding environment variables:
- `TURBO_EXPERIMENTAL_OTEL_METRICS_RUN_ATTRIBUTES_ID`
- `TURBO_EXPERIMENTAL_OTEL_METRICS_RUN_ATTRIBUTES_SCM_REVISION`

### Why

Some metric attributes have unbounded cardinality — their unique values grow without limit. When these are attached as tags/dimensions on metrics, each unique combination creates a new metric series. Observability backends often charge per unique series, so unbounded attributes can lead to unexpectedly high costs.

This change gates the following attributes behind opt-in config flags:

| Attribute | Risk | Config flag |
|---|---|---|
| `turbo.run.id` | Unique KSUID per `turbo` invocation | `runAttributes.id` |
| `turbo.scm.revision` | Full Git SHA, unique per commit | `runAttributes.scmRevision` |
| `turbo.task.id` | `package#task` combo per task | `taskAttributes.id` (existing) |
| `turbo.task.hash` | Content hash, changes with inputs | `taskAttributes.hashes` (existing) |
| `turbo.task.external_inputs_hash` | Content hash | `taskAttributes.hashes` (existing) |

Additionally, `turbo.task.cache_time_saved_ms` was removed as a metric attribute entirely — it's a numeric value being used as a tag dimension, creating a new series for every distinct millisecond value. The cache time saved data remains available in the run summary JSON output.

### Changes across layers

1. **Config schema** (`raw.rs`): Added `RawObservabilityOtelRunAttributes` struct
2. **Config options** (`experimental_otel.rs`): Added `ExperimentalOtelRunAttributesOptions` with `id` and `scm_revision` fields
3. **Config parsing** (`turbo_json.rs`): Conversion from raw to config options
4. **Runtime config** (`turborepo-otel/lib.rs`): Added `RunAttributesConfig` and gated `turbo.run.id` / `turbo.scm.revision` behind it
5. **Env vars** (`env.rs`): Registered `TURBO_EXPERIMENTAL_OTEL_METRICS_RUN_ATTRIBUTES_ID` and `_SCM_REVISION`
6. **Docs** (`configuration.mdx`, `ARCHITECTURE.md`): Documented new options with cardinality guidance

## Test plan

- [x] All existing tests pass (245 tests across 4 crates)
- [x] New test cases for `run_attributes.id` enabled, `run_attributes` fully enabled, env var parsing for both `id` and `scm_revision`
- [x] `is_empty` check updated to account for `run_attributes`
- [x] Serialization consistency verified — `skip_serializing_if = "Option::is_none"` on all fields across all layers
- [x] `cargo check` and `cargo clippy` pass cleanly