### PR TITLE
fix: Add `FORCE_COLOR` and `NO_COLOR` to builtin passthrough env vars

### DIFF
--- a/crates/turborepo-env/src/lib.rs
+++ b/crates/turborepo-env/src/lib.rs
@@ -36,6 +36,8 @@ pub const BUILTIN_PASS_THROUGH_ENV: &[&str] = &[
     "LD_PRELOAD",
     "DYLD_INSERT_LIBRARIES",
     "COLORTERM",
+    "FORCE_COLOR",
+    "NO_COLOR",
     "TERM",
     "TERM_PROGRAM",
     "DISPLAY",


### PR DESCRIPTION
## Summary

- Adds `FORCE_COLOR` and `NO_COLOR` to `BUILTIN_PASS_THROUGH_ENV` so they are passed through to child tasks in strict mode.
- Without this, tasks running in strict mode don't receive these env vars, meaning user color preferences are silently ignored by child processes.

These are standard conventions ([force-color.org](https://force-color.org/), [no-color.org](https://no-color.org/)) and belong alongside the existing terminal vars (`COLORTERM`, `TERM`, `TERM_PROGRAM`).

## Testing

`cargo test -p turborepo-env` — all 25 tests pass.