### PR TITLE
feat: Instrument post-hashing setup phase for trace visibility

### DIFF
--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -663,6 +663,8 @@ impl Run {
 
         drop(_hash_scope_span);
 
+        let _setup_span = tracing::debug_span!("post_hashing_setup").entered();
+
         let package_inputs_hashes = file_hash_result.expect("file hash task did not complete")?;
         let root_internal_dependencies_hash =
             internal_deps_result.expect("internal deps task did not complete")?;
@@ -713,6 +715,8 @@ impl Run {
             Vendor::get_user(),
             self.observability_handle.clone(),
         );
+
+        drop(_setup_span);
 
         let mut visitor = Visitor::new(
             self.pkg_dep_graph.clone(),

--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -158,7 +158,11 @@ impl<'a> Visitor<'a> {
 
         // Set up correct size for underlying pty (requires .await, so outside span)
         if let Some(app) = ui_sender.as_ref() {
-            if let Some(pane_size) = app.pane_size().await {
+            if let Some(pane_size) = app
+                .pane_size()
+                .instrument(tracing::debug_span!("configure_pane_size"))
+                .await
+            {
                 manager.set_pty_size(pane_size.rows, pane_size.cols);
             }
         }

--- a/crates/turborepo-task-hash/src/global_hash.rs
+++ b/crates/turborepo-task-hash/src/global_hash.rs
@@ -235,6 +235,7 @@ fn collect_global_deps(
 }
 
 impl<'a> GlobalHashableInputs<'a> {
+    #[tracing::instrument(skip_all)]
     pub fn calculate_global_hash(&self) -> String {
         let global_hashable = GlobalHashable {
             global_cache_key: self.global_cache_key,

--- a/crates/turborepo-task-hash/src/lib.rs
+++ b/crates/turborepo-task-hash/src/lib.rs
@@ -297,6 +297,7 @@ impl<'a, R: RunOptsHashInfo> TaskHasher<'a, R> {
     /// Pre-compute and cache external dependency hashes for all packages.
     /// Many tasks share the same package, so this avoids re-sorting
     /// transitive dependencies for every task.
+    #[tracing::instrument(skip_all)]
     pub fn precompute_external_deps_hashes<'b>(
         &mut self,
         workspaces: impl Iterator<Item = (&'b PackageName, &'b PackageInfo)>,


### PR DESCRIPTION
## Summary

- Adds tracing spans to the previously untraced gap between `calculate_file_hashes` and `visit` in the `turbo run` critical path
- In production traces, this gap is 190ms for `codegen:app` and 33ms for `codegen:api` with zero visibility into what's consuming that time

## What's instrumented

| Span | Location | What it covers |
|---|---|---|
| `post_hashing_setup` | `run/mod.rs` | Global hash computation, env resolution, run tracker construction |
| `precompute_external_deps_hashes` | `task-hash/src/lib.rs` | Parallel rayon sort+hash of transitive lockfile deps for all packages |
| `calculate_global_hash` | `task-hash/src/global_hash.rs` | Deterministic global hash computation |
| `configure_pane_size` | `task_graph/visitor/mod.rs` | Async TUI pane size query (was outside the existing `visitor_new` span) |

## Testing

`cargo check` passes. No behavioral changes — this is tracing instrumentation only.