### PR TITLE
refactor: Extract `turborepo-query-api` trait crate for compile-time decoupling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7097,6 +7097,10 @@ dependencies = [
  "serde_json",
  "tempfile",
  "turborepo-lib",
+ "turborepo-query",
+ "turborepo-query-api",
+ "turborepo-signals",
+ "turborepo-ui",
  "which",
 ]
 
@@ -7697,7 +7701,7 @@ dependencies = [
  "turborepo-otel",
  "turborepo-process",
  "turborepo-profile-md",
- "turborepo-query",
+ "turborepo-query-api",
  "turborepo-repository",
  "turborepo-run-cache",
  "turborepo-run-summary",
@@ -7893,6 +7897,7 @@ dependencies = [
  "turborepo-engine",
  "turborepo-errors",
  "turborepo-lockfiles",
+ "turborepo-query-api",
  "turborepo-repository",
  "turborepo-scm",
  "turborepo-scope",
@@ -7902,6 +7907,24 @@ dependencies = [
  "turborepo-types",
  "turborepo-ui",
  "webbrowser",
+]
+
+[[package]]
+name = "turborepo-query-api"
+version = "0.1.0"
+dependencies = [
+ "miette",
+ "thiserror 2.0.18",
+ "turbopath",
+ "turborepo-boundaries",
+ "turborepo-engine",
+ "turborepo-repository",
+ "turborepo-scm",
+ "turborepo-scope",
+ "turborepo-signals",
+ "turborepo-turbo-json",
+ "turborepo-types",
+ "turborepo-ui",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ turborepo-microfrontends = { path = "crates/turborepo-microfrontends" }
 turborepo-microfrontends-proxy = { path = "crates/turborepo-microfrontends-proxy" }
 turborepo-process = { path = "crates/turborepo-process" }
 turborepo-query = { path = "crates/turborepo-query" }
+turborepo-query-api = { path = "crates/turborepo-query-api" }
 turborepo-profile-md = { path = "crates/turborepo-profile-md" }
 turborepo-repository = { path = "crates/turborepo-repository" }
 turborepo-task-id = { path = "crates/turborepo-task-id" }

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -119,7 +119,7 @@ turborepo-microfrontends-proxy = { workspace = true }
 turborepo-otel = { workspace = true }
 turborepo-process = { workspace = true }
 turborepo-profile-md = { workspace = true }
-turborepo-query = { workspace = true }
+turborepo-query-api = { workspace = true }
 turborepo-repository = { path = "../turborepo-repository" }
 turborepo-run-cache = { path = "../turborepo-run-cache" }
 turborepo-run-summary = { workspace = true }

--- a/crates/turborepo-lib/src/cli/error.rs
+++ b/crates/turborepo-lib/src/cli/error.rs
@@ -18,6 +18,8 @@ use crate::{
 pub enum Error {
     #[error("No command specified.")]
     NoCommand,
+    #[error("Query server not available. The turbo query command requires the full turbo binary.")]
+    QueryNotAvailable,
     #[error("{0}")]
     Bin(#[from] bin::Error),
     #[error(transparent)]
@@ -63,7 +65,7 @@ pub enum Error {
     Run(#[from] run::Error),
     #[error(transparent)]
     #[diagnostic(transparent)]
-    Query(#[from] turborepo_query::Error),
+    Query(#[from] turborepo_query_api::Error),
     #[error(transparent)]
     SerdeJson(#[from] serde_json::Error),
     #[error(transparent)]

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1,4 +1,4 @@
-use std::{env, ffi::OsString, fmt, io, mem, process};
+use std::{env, ffi::OsString, fmt, io, mem, process, sync::Arc};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::{ArgAction, ArgGroup, CommandFactory, Parser, Subcommand, ValueEnum};
@@ -1320,6 +1320,7 @@ pub async fn run(
     repo_state: Option<RepoState>,
     #[allow(unused_variables)] logger: &TurboSubscriber,
     color_config: ColorConfig,
+    query_server: Option<Arc<dyn turborepo_query_api::QueryServer>>,
 ) -> Result<i32, Error> {
     let _cli_run_span = tracing::info_span!("cli_run").entered();
 
@@ -1649,7 +1650,7 @@ pub async fn run(
             }
 
             run_args.track(&event);
-            let exit_code = run::run(base, event, http_client_cell)
+            let exit_code = run::run(base, event, http_client_cell, query_server.clone())
                 .await
                 .inspect(|code| {
                     if *code != 0 {
@@ -1678,6 +1679,9 @@ pub async fn run(
             variables,
             schema,
         } => {
+            let Some(ref query_server) = query_server else {
+                return Err(error::Error::QueryNotAvailable);
+            };
             warn!("query command is experimental and may change in the future");
             let query = query.clone();
             let variables = variables.clone();
@@ -1688,7 +1692,15 @@ pub async fn run(
             let base = CommandBase::new(cli_args, repo_root, version, color_config)?;
             event.track_ui_mode(base.opts.run_opts.ui_mode);
 
-            let query = query::run(base, event, query, variables.as_deref(), schema).await?;
+            let query = query::run(
+                base,
+                event,
+                query,
+                variables.as_deref(),
+                schema,
+                query_server.as_ref(),
+            )
+            .await?;
 
             Ok(query)
         }
@@ -1706,7 +1718,9 @@ pub async fn run(
                 return Ok(1);
             }
 
-            let mut client = WatchClient::new(base, *experimental_write_cache, event).await?;
+            let mut client =
+                WatchClient::new(base, *experimental_write_cache, event, query_server.clone())
+                    .await?;
             if let Err(e) = client.start().await {
                 client.shutdown().await;
                 return Err(e.into());

--- a/crates/turborepo-lib/src/commands/query.rs
+++ b/crates/turborepo-lib/src/commands/query.rs
@@ -4,7 +4,7 @@ use camino::Utf8Path;
 use miette::{Diagnostic, Report, SourceSpan};
 use thiserror::Error;
 use turbopath::AbsoluteSystemPathBuf;
-use turborepo_query::QueryRun;
+use turborepo_query_api::{QueryRun, QueryServer};
 use turborepo_signals::{listeners::get_signal, SignalHandler};
 use turborepo_telemetry::events::command::CommandEventBuilder;
 
@@ -33,7 +33,7 @@ impl QueryError {
         index + column - 1
     }
 
-    fn from_query_error(error: turborepo_query::QueryErrorLocation, query: String) -> Self {
+    fn from_query_error(error: turborepo_query_api::QueryErrorLocation, query: String) -> Self {
         let idx = Self::get_index_from_row_column(&query, error.line, error.column);
         QueryError {
             message: error.message,
@@ -51,6 +51,7 @@ pub async fn run(
     query: Option<String>,
     variables_path: Option<&Utf8Path>,
     include_schema: bool,
+    query_server: &dyn QueryServer,
 ) -> Result<i32, cli::Error> {
     let signal = get_signal()?;
     let handler = SignalHandler::new(signal);
@@ -63,7 +64,7 @@ pub async fn run(
 
     let query = query
         .as_deref()
-        .or(include_schema.then_some(turborepo_query::SCHEMA_QUERY));
+        .or(include_schema.then_some(turborepo_query_api::SCHEMA_QUERY));
     if let Some(query) = query {
         let trimmed_query = query.trim();
         let query = if (trimmed_query.starts_with("query")
@@ -74,18 +75,20 @@ pub async fn run(
             query
         } else {
             &fs::read_to_string(AbsoluteSystemPathBuf::from_unknown(run.repo_root(), query))
-                .map_err(turborepo_query::Error::Server)?
+                .map_err(turborepo_query_api::Error::Server)?
         };
 
         let variables_json = variables_path
             .map(AbsoluteSystemPathBuf::from_cwd)
             .transpose()
-            .map_err(turborepo_query::Error::Path)?
+            .map_err(turborepo_query_api::Error::Path)?
             .map(|path| path.read_to_string())
             .transpose()
-            .map_err(turborepo_query::Error::Server)?;
+            .map_err(turborepo_query_api::Error::Server)?;
 
-        let result = turborepo_query::execute_query(run, query, variables_json.as_deref()).await?;
+        let result = query_server
+            .execute_query(run, query, variables_json.as_deref())
+            .await?;
 
         println!("{}", result.result_json);
         if !result.errors.is_empty() {
@@ -95,7 +98,7 @@ pub async fn run(
             }
         }
     } else {
-        turborepo_query::run_query_server(run, handler).await?;
+        query_server.run_query_server(run, handler).await?;
     }
 
     Ok(0)

--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use tracing::error;
+use turborepo_query_api::QueryServer;
 use turborepo_signals::{listeners::get_signal, SignalHandler};
 use turborepo_telemetry::events::command::CommandEventBuilder;
 use turborepo_ui::sender::UISender;
@@ -12,14 +13,18 @@ pub async fn run(
     base: CommandBase,
     telemetry: CommandEventBuilder,
     http_client_cell: Arc<tokio::sync::OnceCell<reqwest::Client>>,
+    query_server: Option<Arc<dyn QueryServer>>,
 ) -> Result<i32, run::Error> {
     let signal = get_signal()?;
     let handler = SignalHandler::new(signal);
 
-    let run_builder = {
+    let mut run_builder = {
         let _span = tracing::info_span!("run_builder_new").entered();
         RunBuilder::new(base, Some(http_client_cell))?
     };
+    if let Some(qs) = query_server {
+        run_builder = run_builder.with_query_server(qs);
+    }
 
     let run_fut = async {
         let (run, analytics_handle) = {

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -37,6 +37,7 @@ pub use run::package_discovery::DaemonPackageDiscovery;
 pub use turborepo_daemon::{
     DaemonClient, DaemonConnector, DaemonConnectorError, DaemonError, Paths as DaemonPaths,
 };
+pub use turborepo_query_api::QueryServer;
 
 pub use crate::{child::spawn_child, cli::Args, panic_handler::panic_handler};
 
@@ -49,8 +50,16 @@ pub fn get_version() -> &'static str {
         .trim_end()
 }
 
-pub fn main() -> Result<i32, shim::Error> {
-    shim::run()
+/// Main entry point for the turborepo CLI.
+///
+/// `query_server` provides the GraphQL query execution layer. When `None`,
+/// the `turbo query` command returns an error and the Web UI mode falls
+/// back silently. Pass `Some(...)` with a [`QueryServer`] implementation
+/// to enable the full query subsystem.
+pub fn main(
+    query_server: Option<std::sync::Arc<dyn turborepo_query_api::QueryServer>>,
+) -> Result<i32, shim::Error> {
+    shim::run(query_server)
 }
 
 #[cfg(all(feature = "native-tls", feature = "rustls-tls"))]

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -66,6 +66,7 @@ pub struct RunBuilder {
     // that are already on disk. Without this, cache restores write files
     // that trigger the file watcher, causing an infinite rebuild loop.
     daemon_client: Option<DaemonClient<DaemonConnector>>,
+    query_server: Option<Arc<dyn turborepo_query_api::QueryServer>>,
 }
 
 impl RunBuilder {
@@ -108,6 +109,7 @@ impl RunBuilder {
             should_validate_engine: true,
             add_all_tasks: false,
             daemon_client: None,
+            query_server: None,
         })
     }
 
@@ -118,6 +120,11 @@ impl RunBuilder {
 
     pub fn with_daemon_client(mut self, client: DaemonClient<DaemonConnector>) -> Self {
         self.daemon_client = Some(client);
+        self
+    }
+
+    pub fn with_query_server(mut self, server: Arc<dyn turborepo_query_api::QueryServer>) -> Self {
+        self.query_server = Some(server);
         self
     }
 
@@ -520,6 +527,7 @@ impl RunBuilder {
                 micro_frontend_configs,
                 repo_index,
                 observability_handle,
+                query_server: self.query_server,
             },
             analytics_handle,
         ))

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -79,6 +79,7 @@ pub struct Run {
     micro_frontend_configs: Option<MicrofrontendsConfigs>,
     repo_index: Arc<Option<RepoGitIndex>>,
     observability_handle: Option<ObservabilityHandle>,
+    pub(crate) query_server: Option<Arc<dyn turborepo_query_api::QueryServer>>,
 }
 
 type UIResult<T> = Result<Option<(T, JoinHandle<Result<(), turborepo_ui::Error>>)>, Error>;
@@ -265,9 +266,13 @@ impl Run {
         }
     }
     fn start_web_ui(self: &Arc<Self>) -> WuiResult {
+        let Some(query_server) = self.query_server.clone() else {
+            tracing::warn!("Web UI requires a query server implementation");
+            return Ok(None);
+        };
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 
-        let handle = tokio::spawn(ui::start_web_ui_server(rx, self.clone()));
+        let handle = tokio::spawn(ui::start_web_ui_server(rx, self.clone(), query_server));
 
         Ok(Some((WebUISender { tx }, handle)))
     }
@@ -869,7 +874,7 @@ impl turborepo_engine::ChildProcess for SharedChildWrapper {
     }
 }
 
-impl turborepo_query::QueryRun for Run {
+impl turborepo_query_api::QueryRun for Run {
     fn version(&self) -> &'static str {
         self.version
     }
@@ -905,7 +910,7 @@ impl turborepo_query::QueryRun for Run {
             turborepo_repository::package_graph::PackageName,
             turborepo_repository::change_mapper::PackageInclusionReason,
         >,
-        turborepo_query::AffectedPackagesError,
+        turborepo_query_api::AffectedPackagesError,
     > {
         let mut opts = self.opts.as_ref().clone();
         opts.scope_opts.affected_range = Some((base, head));
@@ -916,7 +921,7 @@ impl turborepo_query::QueryRun for Run {
             &self.scm,
             &self.root_turbo_json,
         )
-        .map_err(|e| turborepo_query::AffectedPackagesError::Other(Box::new(e)))
+        .map_err(|e| turborepo_query_api::AffectedPackagesError::Other(Box::new(e)))
     }
 
     fn check_boundaries(

--- a/crates/turborepo-lib/src/run/ui.rs
+++ b/crates/turborepo-lib/src/run/ui.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use turborepo_query_api::QueryServer;
 use turborepo_ui::wui::{event::WebUIEvent, query::SharedState};
 
 use crate::run::Run;
@@ -7,13 +8,20 @@ use crate::run::Run;
 pub async fn start_web_ui_server(
     rx: tokio::sync::mpsc::UnboundedReceiver<WebUIEvent>,
     run: Arc<Run>,
+    query_server: Arc<dyn QueryServer>,
 ) -> Result<(), turborepo_ui::Error> {
     let state = SharedState::default();
     let subscriber = turborepo_ui::wui::subscriber::Subscriber::new(rx);
     tokio::spawn(subscriber.watch(state.clone()));
 
-    let run: Arc<dyn turborepo_query::QueryRun> = run;
-    turborepo_query::run_server(Some(state.clone()), run).await?;
+    let run: Arc<dyn turborepo_query_api::QueryRun> = run;
+    query_server
+        .run_web_ui_server(state, run)
+        .await
+        .map_err(|e| {
+            let wui_err = turborepo_ui::wui::Error::Server(std::io::Error::other(e));
+            turborepo_ui::Error::Wui(wui_err)
+        })?;
 
     Ok(())
 }

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -75,6 +75,7 @@ pub struct WatchClient {
     ui_sender: Option<UISender>,
     ui_handle: Option<JoinHandle<Result<(), turborepo_ui::Error>>>,
     experimental_write_cache: bool,
+    query_server: Option<Arc<dyn turborepo_query_api::QueryServer>>,
 }
 
 struct RunHandle {
@@ -139,6 +140,7 @@ impl WatchClient {
         base: CommandBase,
         experimental_write_cache: bool,
         telemetry: CommandEventBuilder,
+        query_server: Option<Arc<dyn turborepo_query_api::QueryServer>>,
     ) -> Result<Self, Error> {
         let signal = get_signal()?;
         let handler = SignalHandler::new(signal);
@@ -172,10 +174,12 @@ impl WatchClient {
         let daemon_client = connector.clone().connect().await?;
 
         let new_base = base.clone();
-        let (run, _analytics) = RunBuilder::new(new_base, None)?
-            .with_daemon_client(daemon_client.clone())
-            .build(&handler, telemetry.clone())
-            .await?;
+        let mut run_builder =
+            RunBuilder::new(new_base, None)?.with_daemon_client(daemon_client.clone());
+        if let Some(ref qs) = query_server {
+            run_builder = run_builder.with_query_server(qs.clone());
+        }
+        let (run, _analytics) = run_builder.build(&handler, telemetry.clone()).await?;
         let run = Arc::new(run);
 
         let watched_packages = run.get_relevant_packages();
@@ -195,6 +199,7 @@ impl WatchClient {
             active_runs: Vec::new(),
             ui_sender,
             ui_handle,
+            query_server,
         })
     }
 
@@ -397,12 +402,14 @@ impl WatchClient {
                 let signal_handler = self.handler.clone();
                 let telemetry = self.telemetry.clone();
 
-                let (run, _analytics) = RunBuilder::new(new_base, None)?
+                let mut run_builder = RunBuilder::new(new_base, None)?
                     .with_daemon_client(self.daemon_client.clone())
                     .with_entrypoint_packages(packages)
-                    .hide_prelude()
-                    .build(&signal_handler, telemetry)
-                    .await?;
+                    .hide_prelude();
+                if let Some(ref qs) = self.query_server {
+                    run_builder = run_builder.with_query_server(qs.clone());
+                }
+                let (run, _analytics) = run_builder.build(&signal_handler, telemetry).await?;
 
                 if let Some(sender) = &self.ui_sender {
                     let task_names = run.engine.tasks_with_command(&run.pkg_dep_graph);
@@ -432,9 +439,13 @@ impl WatchClient {
                 );
 
                 // rebuild run struct
-                let (run, _analytics) = RunBuilder::new(base.clone(), None)?
+                let mut run_builder = RunBuilder::new(base.clone(), None)?
                     .with_daemon_client(self.daemon_client.clone())
-                    .hide_prelude()
+                    .hide_prelude();
+                if let Some(ref qs) = self.query_server {
+                    run_builder = run_builder.with_query_server(qs.clone());
+                }
+                let (run, _analytics) = run_builder
                     .build(&self.handler, self.telemetry.clone())
                     .await?;
                 self.run = run.into();

--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -40,11 +40,18 @@ pub enum Error {
 /// Implementation of `TurboRunner` that calls into `turborepo-lib`'s CLI.
 struct TurboCliRunner<'a> {
     subscriber: &'a TurboSubscriber,
+    query_server: Option<Arc<dyn turborepo_query_api::QueryServer>>,
 }
 
 impl<'a> TurboCliRunner<'a> {
-    fn new(subscriber: &'a TurboSubscriber) -> Self {
-        Self { subscriber }
+    fn new(
+        subscriber: &'a TurboSubscriber,
+        query_server: Option<Arc<dyn turborepo_query_api::QueryServer>>,
+    ) -> Self {
+        Self {
+            subscriber,
+            query_server,
+        }
     }
 }
 
@@ -52,7 +59,7 @@ impl TurboRunner for TurboCliRunner<'_> {
     type Error = cli::Error;
 
     fn run(&self, repo_state: Option<RepoState>, ui: ColorConfig) -> Result<i32, Self::Error> {
-        cli::run(repo_state, self.subscriber, ui)
+        cli::run(repo_state, self.subscriber, ui, self.query_server.clone())
     }
 }
 
@@ -199,7 +206,7 @@ fn normalize_config_dir_env_vars() {
 /// 3. Create TurboSubscriber with verbosity and color config
 /// 4. Create runtime with trait implementations
 /// 5. Execute shim logic (miette hook setup, repo inference, turbo execution)
-pub fn run() -> Result<i32, Error> {
+pub fn run(query_server: Option<Arc<dyn turborepo_query_api::QueryServer>>) -> Result<i32, Error> {
     // Normalize env vars first, before arg parsing (matches original behavior)
     normalize_config_dir_env_vars();
 
@@ -218,7 +225,7 @@ pub fn run() -> Result<i32, Error> {
 
     // Create the runtime with all implementations
     let runtime = ShimRuntime::new(
-        TurboCliRunner::new(&subscriber),
+        TurboCliRunner::new(&subscriber, query_server),
         TurboConfigProvider,
         TurboChildSpawner,
         TurboVersionProvider,

--- a/crates/turborepo-query-api/Cargo.toml
+++ b/crates/turborepo-query-api/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "turborepo-query-api"
+version = "0.1.0"
+edition = { workspace = true }
+license = "MIT"
+
+[dependencies]
+miette = { workspace = true }
+thiserror = { workspace = true }
+turbopath = { workspace = true }
+turborepo-boundaries = { workspace = true }
+turborepo-engine = { workspace = true }
+turborepo-repository = { workspace = true }
+turborepo-scm = { workspace = true }
+turborepo-scope = { workspace = true }
+turborepo-signals = { workspace = true }
+turborepo-turbo-json = { workspace = true }
+turborepo-types = { workspace = true }
+turborepo-ui = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/turborepo-query-api/src/lib.rs
+++ b/crates/turborepo-query-api/src/lib.rs
@@ -1,0 +1,149 @@
+#![allow(clippy::result_large_err)]
+//! Interface types for the turborepo query layer.
+//!
+//! This crate defines the traits that bridge `turborepo-lib` (the run
+//! orchestrator) and `turborepo-query` (the GraphQL implementation).
+//! By placing the interface here, `turborepo-lib` and `turborepo-query`
+//! can compile in parallel — neither depends on the other.
+//!
+//! ```text
+//! turborepo (binary)
+//!   ├── turborepo-lib ──────► turborepo-query-api (traits)
+//!   └── turborepo-query ────► turborepo-query-api (traits)
+//! ```
+//!
+//! The binary crate implements `QueryServer` and passes it to
+//! `turborepo_lib::main()`, connecting the two halves at runtime.
+//!
+//! Note: this crate's dependency list is larger than ideal for a pure
+//! interface crate because `QueryRun` methods expose types from crates
+//! like `turborepo-repository` and `turborepo-engine`. The benefit is
+//! still realized because the heavy async-graphql/axum/oxc stack in
+//! `turborepo-query` doesn't need to compile for `turborepo-lib`.
+
+use std::{collections::HashMap, future::Future, io, pin::Pin, sync::Arc};
+
+use thiserror::Error;
+use turborepo_boundaries::BoundariesResult;
+use turborepo_engine::Built;
+use turborepo_repository::{change_mapper::PackageInclusionReason, package_graph::PackageName};
+use turborepo_types::TaskDefinition;
+
+pub type BoundariesFuture<'a> = Pin<
+    Box<
+        dyn std::future::Future<Output = Result<BoundariesResult, turborepo_boundaries::Error>>
+            + Send
+            + 'a,
+    >,
+>;
+
+/// The interface that the query layer requires from a "run" context.
+///
+/// Decouples the GraphQL query layer from the concrete `Run` type in
+/// turborepo-lib, allowing the heavy async-graphql/axum/oxc dependencies
+/// to compile in a separate crate.
+pub trait QueryRun: Send + Sync + 'static {
+    fn version(&self) -> &'static str;
+    fn repo_root(&self) -> &turbopath::AbsoluteSystemPath;
+    fn pkg_dep_graph(&self) -> &turborepo_repository::package_graph::PackageGraph;
+    fn engine(&self) -> &turborepo_engine::Engine<Built, TaskDefinition>;
+    fn scm(&self) -> &turborepo_scm::SCM;
+    fn root_turbo_json(&self) -> &turborepo_turbo_json::TurboJson;
+
+    fn calculate_affected_packages(
+        &self,
+        base: Option<String>,
+        head: Option<String>,
+    ) -> Result<HashMap<PackageName, PackageInclusionReason>, AffectedPackagesError>;
+
+    fn check_boundaries(&self, show_progress: bool) -> BoundariesFuture<'_>;
+}
+
+#[derive(Debug, Error)]
+pub enum AffectedPackagesError {
+    #[error(transparent)]
+    Resolution(#[from] turborepo_scope::filter::ResolutionError),
+    #[error(transparent)]
+    Other(Box<dyn std::error::Error + Send + Sync>),
+}
+
+#[derive(Error, Debug, miette::Diagnostic)]
+pub enum Error {
+    #[error(transparent)]
+    Boundaries(#[from] turborepo_boundaries::Error),
+    #[error("Failed to start GraphQL server.")]
+    Server(#[from] io::Error),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Path(#[from] turbopath::PathError),
+    #[error(transparent)]
+    UI(#[from] turborepo_ui::Error),
+    #[error("Failed to calculate affected packages: {0}")]
+    AffectedPackages(#[from] AffectedPackagesError),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Resolution(#[from] turborepo_scope::filter::ResolutionError),
+    #[error(transparent)]
+    SignalListener(#[from] turborepo_signals::listeners::Error),
+    /// Opaque error from the query implementation crate.
+    #[error(transparent)]
+    Query(Box<dyn std::error::Error + Send + Sync>),
+}
+
+/// An error with source location information from a GraphQL query.
+pub struct QueryErrorLocation {
+    pub message: String,
+    pub line: usize,
+    pub column: usize,
+}
+
+/// The result of executing a GraphQL query.
+pub struct QueryResult {
+    pub result_json: String,
+    pub errors: Vec<QueryErrorLocation>,
+}
+
+/// The standard GraphQL introspection query used by `turbo query --schema`.
+pub const SCHEMA_QUERY: &str = include_str!("schema_query.graphql");
+
+/// Abstraction over the query execution layer.
+///
+/// `turborepo-lib` uses this trait to dispatch query operations without
+/// depending on `turborepo-query` directly. The concrete implementation
+/// lives in the binary crate, which depends on both `turborepo-lib` and
+/// `turborepo-query`.
+pub trait QueryServer: Send + Sync {
+    /// Execute a single GraphQL query and return the result as JSON.
+    ///
+    /// `variables_json` is an optional JSON string of query variables.
+    fn execute_query<'a>(
+        &'a self,
+        run: Arc<dyn QueryRun>,
+        query: &'a str,
+        variables_json: Option<&'a str>,
+    ) -> Pin<Box<dyn Future<Output = Result<QueryResult, Error>> + Send + 'a>>;
+
+    /// Start an interactive GraphiQL server on localhost.
+    ///
+    /// Blocks until the signal handler fires. Opens the browser automatically.
+    fn run_query_server(
+        &self,
+        run: Arc<dyn QueryRun>,
+        signal: turborepo_signals::SignalHandler,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + '_>>;
+
+    /// Start the Web UI server that serves the TUI-integrated query interface.
+    ///
+    /// The shared state is used to stream build events to the UI.
+    fn run_web_ui_server(
+        &self,
+        state: turborepo_ui::wui::query::SharedState,
+        run: Arc<dyn QueryRun>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + '_>>;
+}
+
+// Compile-time assertions that both traits remain object-safe.
+const _: () = {
+    fn _assert_query_run_object_safe(_: &dyn QueryRun) {}
+    fn _assert_query_server_object_safe(_: &dyn QueryServer) {}
+};

--- a/crates/turborepo-query-api/src/schema_query.graphql
+++ b/crates/turborepo-query-api/src/schema_query.graphql
@@ -1,0 +1,99 @@
+query IntrospectionQuery {
+  __schema {
+    queryType {
+      name
+    }
+    mutationType {
+      name
+    }
+    subscriptionType {
+      name
+    }
+    types {
+      ...FullType
+    }
+    directives {
+      name
+      description
+      locations
+      args {
+        ...InputValue
+      }
+    }
+  }
+}
+
+fragment FullType on __Type {
+  kind
+  name
+  description
+  fields(includeDeprecated: true) {
+    name
+    description
+    args {
+      ...InputValue
+    }
+    type {
+      ...TypeRef
+    }
+    isDeprecated
+    deprecationReason
+  }
+  inputFields {
+    ...InputValue
+  }
+  interfaces {
+    ...TypeRef
+  }
+  enumValues(includeDeprecated: true) {
+    name
+    description
+    isDeprecated
+    deprecationReason
+  }
+  possibleTypes {
+    ...TypeRef
+  }
+}
+
+fragment InputValue on __InputValue {
+  name
+  description
+  type {
+    ...TypeRef
+  }
+  defaultValue
+}
+
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/turborepo-query/Cargo.toml
+++ b/crates/turborepo-query/Cargo.toml
@@ -29,6 +29,7 @@ turborepo-boundaries = { workspace = true }
 turborepo-engine = { path = "../turborepo-engine" }
 turborepo-errors = { workspace = true }
 turborepo-lockfiles = { workspace = true }
+turborepo-query-api = { workspace = true }
 turborepo-repository = { path = "../turborepo-repository" }
 turborepo-scm = { workspace = true }
 turborepo-scope = { path = "../turborepo-scope" }

--- a/crates/turborepo-query/src/lib.rs
+++ b/crates/turborepo-query/src/lib.rs
@@ -9,10 +9,8 @@ mod server;
 mod task;
 
 use std::{
-    collections::HashMap,
     io,
     ops::{Deref, DerefMut},
-    pin::Pin,
     sync::Arc,
 };
 
@@ -23,96 +21,84 @@ use itertools::Itertools;
 use package::Package;
 use package_graph::{Edge, PackageGraph};
 pub use server::run_server;
-use thiserror::Error;
 use tokio::select;
 use turbo_trace::TraceError;
 use turbopath::AbsoluteSystemPathBuf;
-use turborepo_boundaries::BoundariesResult;
-use turborepo_engine::Built;
+pub use turborepo_query_api::{
+    AffectedPackagesError, BoundariesFuture, QueryErrorLocation, QueryResult, QueryRun,
+    SCHEMA_QUERY,
+};
 use turborepo_repository::{
     change_mapper::{AllPackageChangeReason, PackageInclusionReason},
     package_graph::PackageName,
 };
 use turborepo_signals::SignalHandler;
-use turborepo_types::TaskDefinition;
 
-type BoundariesFuture<'a> = Pin<
-    Box<
-        dyn std::future::Future<Output = Result<BoundariesResult, turborepo_boundaries::Error>>
-            + Send
-            + 'a,
-    >,
->;
-
-/// The interface that the query layer requires from a "run" context.
-///
-/// This trait decouples the GraphQL query layer from the concrete `Run` type
-/// in turborepo-lib, allowing the heavy async-graphql/axum/oxc dependencies
-/// to compile in a separate crate.
-///
-/// Object-safe so it can be used via `Arc<dyn QueryRun>`.
-pub trait QueryRun: Send + Sync + 'static {
-    fn version(&self) -> &'static str;
-    fn repo_root(&self) -> &turbopath::AbsoluteSystemPath;
-    fn pkg_dep_graph(&self) -> &turborepo_repository::package_graph::PackageGraph;
-    fn engine(&self) -> &turborepo_engine::Engine<Built, TaskDefinition>;
-    fn scm(&self) -> &turborepo_scm::SCM;
-    fn root_turbo_json(&self) -> &turborepo_turbo_json::TurboJson;
-
-    /// Calculate the set of affected packages given optional base/head git
-    /// refs.
-    ///
-    /// This encapsulates the scope resolution and filtering logic that lives
-    /// in the run builder, keeping `Opts` and `RunBuilder` out of the query
-    /// crate's dependency graph.
-    fn calculate_affected_packages(
-        &self,
-        base: Option<String>,
-        head: Option<String>,
-    ) -> Result<HashMap<PackageName, PackageInclusionReason>, AffectedPackagesError>;
-
-    /// Check package boundary rules across all filtered packages.
-    fn check_boundaries(&self, show_progress: bool) -> BoundariesFuture<'_>;
-}
-
-#[derive(Debug, Error)]
-pub enum AffectedPackagesError {
-    #[error(transparent)]
-    Resolution(#[from] turborepo_scope::filter::ResolutionError),
-    #[error("{0}")]
-    Other(Box<dyn std::error::Error + Send + Sync>),
-}
-
-#[derive(Error, Debug, miette::Diagnostic)]
+#[derive(thiserror::Error, Debug, miette::Diagnostic)]
 pub enum Error {
+    /// Errors that have a direct equivalent in `turborepo_query_api::Error`.
+    /// Using `#[from]` on the API error avoids duplicating variants.
     #[error(transparent)]
-    Boundaries(#[from] turborepo_boundaries::Error),
+    #[diagnostic(transparent)]
+    Api(#[from] turborepo_query_api::Error),
     #[error("Failed to get file dependencies")]
     Trace(#[related] Vec<TraceError>),
     #[error("No signal handler.")]
     NoSignalHandler,
     #[error("File `{0}` not found.")]
     FileNotFound(String),
-    #[error("Failed to start GraphQL server.")]
-    Server(#[from] io::Error),
     #[error("Package not found: {0}")]
     PackageNotFound(PackageName),
     #[error("Failed to serialize result: {0}")]
     Serde(#[from] serde_json::Error),
-    #[error("Failed to calculate affected packages: {0}")]
-    AffectedPackages(#[from] AffectedPackagesError),
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    Path(#[from] turbopath::PathError),
-    #[error(transparent)]
-    UI(#[from] turborepo_ui::Error),
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    Resolution(#[from] turborepo_scope::filter::ResolutionError),
     #[error("Failed to parse file: {0}")]
     Parse(String),
-    #[error(transparent)]
-    SignalListener(#[from] turborepo_signals::listeners::Error),
+}
+
+// Conversions from constituent error types into Error via the Api variant.
+impl From<turborepo_boundaries::Error> for Error {
+    fn from(e: turborepo_boundaries::Error) -> Self {
+        Error::Api(e.into())
+    }
+}
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Error::Api(e.into())
+    }
+}
+impl From<turbopath::PathError> for Error {
+    fn from(e: turbopath::PathError) -> Self {
+        Error::Api(e.into())
+    }
+}
+impl From<turborepo_ui::Error> for Error {
+    fn from(e: turborepo_ui::Error) -> Self {
+        Error::Api(e.into())
+    }
+}
+impl From<AffectedPackagesError> for Error {
+    fn from(e: AffectedPackagesError) -> Self {
+        Error::Api(e.into())
+    }
+}
+impl From<turborepo_scope::filter::ResolutionError> for Error {
+    fn from(e: turborepo_scope::filter::ResolutionError) -> Self {
+        Error::Api(e.into())
+    }
+}
+impl From<turborepo_signals::listeners::Error> for Error {
+    fn from(e: turborepo_signals::listeners::Error) -> Self {
+        Error::Api(e.into())
+    }
+}
+
+impl From<Error> for turborepo_query_api::Error {
+    fn from(err: Error) -> Self {
+        match err {
+            Error::Api(e) => e,
+            other => turborepo_query_api::Error::Query(Box::new(other)),
+        }
+    }
 }
 
 pub struct RepositoryQuery {
@@ -600,7 +586,7 @@ impl RepositoryQuery {
                         .then_with(|| a.import.cmp(&b.import))
                 })
                 .collect()),
-            Err(err) => Err(Error::Boundaries(err)),
+            Err(err) => Err(err.into()),
         }
     }
 
@@ -697,126 +683,6 @@ pub struct Diagnostic {
     pub end: Option<usize>,
 }
 
-/// An error with source location information from a GraphQL query.
-pub struct QueryErrorLocation {
-    pub message: String,
-    pub line: usize,
-    pub column: usize,
-}
-
-/// The result of executing a GraphQL query.
-pub struct QueryResult {
-    pub result_json: String,
-    pub errors: Vec<QueryErrorLocation>,
-}
-
-/// The standard GraphQL introspection query used by `turbo query --schema`.
-pub const SCHEMA_QUERY: &str = "query IntrospectionQuery {
-  __schema {
-    queryType {
-      name
-    }
-    mutationType {
-      name
-    }
-    subscriptionType {
-      name
-    }
-    types {
-      ...FullType
-    }
-    directives {
-      name
-      description
-      locations
-      args {
-        ...InputValue
-      }
-    }
-  }
-}
-
-fragment FullType on __Type {
-  kind
-  name
-  description
-  fields(includeDeprecated: true) {
-    name
-    description
-    args {
-      ...InputValue
-    }
-    type {
-      ...TypeRef
-    }
-    isDeprecated
-    deprecationReason
-  }
-  inputFields {
-    ...InputValue
-  }
-  interfaces {
-    ...TypeRef
-  }
-  enumValues(includeDeprecated: true) {
-    name
-    description
-    isDeprecated
-    deprecationReason
-  }
-  possibleTypes {
-    ...TypeRef
-  }
-}
-
-fragment InputValue on __InputValue {
-  name
-  description
-  type {
-    ...TypeRef
-  }
-  defaultValue
-}
-
-fragment TypeRef on __Type {
-  kind
-  name
-  ofType {
-    kind
-    name
-    ofType {
-      kind
-      name
-      ofType {
-        kind
-        name
-        ofType {
-          kind
-          name
-          ofType {
-            kind
-            name
-            ofType {
-              kind
-              name
-              ofType {
-                kind
-                name
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}";
-
-/// Execute a GraphQL query against the repository and return the result as
-/// JSON.
-///
-/// This is the high-level entry point that hides the `async-graphql` schema
-/// machinery from callers. `variables_json` is an optional raw JSON string
-/// for query variables.
 pub async fn execute_query(
     run: Arc<dyn QueryRun>,
     query: &str,

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -17,7 +17,7 @@ A run consists of the following steps:
 
 ## Entry Point
 
-- **CLI Entry**: `crates/turborepo/src/main.rs` - Thin wrapper that calls `turborepo_lib::main`
+- **CLI Entry**: `crates/turborepo/src/main.rs` - Constructs `TurboQueryServer` (the concrete `QueryServer` implementation) and passes it to `turborepo_lib::main`
 - **Command Handler**: `crates/turborepo-lib/src/commands/run.rs` - Entry point for the run command, sets up signal handling and UI
 - **Main Logic**: `crates/turborepo-lib/src/run/mod.rs` - Core run implementation
 
@@ -192,6 +192,27 @@ The summary module is responsible for any time of summary:
 
 - Stitches together result from visitor and the task tracker
 - Constructs final summary depending on user ask e.g. `--dry=json`/`--summarize`
+
+### 8. Query Subsystem
+
+The query subsystem powers `turbo query` (GraphQL introspection of the
+package/task graph) and the Web UI mode (`--ui=web`).
+
+**Crate layout:**
+
+- `turborepo-query-api` — Trait definitions (`QueryServer`, `QueryRun`) and
+  shared error/result types.  `turborepo-lib` depends on this thin interface
+  crate instead of the heavy implementation.
+- `turborepo-query` — GraphQL implementation using async-graphql, axum, and
+  oxc.  Implements the resolvers and HTTP server.
+- `turborepo/src/main.rs` — Wires the two halves together via `TurboQueryServer`,
+  which implements `QueryServer` by delegating to `turborepo-query`.
+
+**Data flow:** `main()` constructs `Arc<TurboQueryServer>` → passes to
+`turborepo_lib::main` → threaded through `shim` → `cli::run` →
+`commands::run` → `RunBuilder` → `Run`.  The `Run` struct stores the
+`query_server` and uses it in `start_web_ui()` and the `turbo query`
+command handler.
 
 ## Data Flow Overview
 

--- a/crates/turborepo/Cargo.toml
+++ b/crates/turborepo/Cargo.toml
@@ -40,3 +40,7 @@ workspace = true
 anyhow = { workspace = true, features = ["backtrace"] }
 miette.workspace = true
 turborepo-lib = { workspace = true, default-features = false }
+turborepo-query = { workspace = true }
+turborepo-query-api = { workspace = true }
+turborepo-signals = { workspace = true }
+turborepo-ui = { workspace = true }

--- a/crates/turborepo/src/main.rs
+++ b/crates/turborepo/src/main.rs
@@ -1,17 +1,72 @@
 // Bump all rust changes
 #![deny(clippy::all)]
 
-use std::process;
+use std::{future::Future, pin::Pin, process, sync::Arc};
 
 use anyhow::Result;
 use miette::Report;
+
+/// Concrete [`turborepo_query_api::QueryServer`] that delegates to
+/// `turborepo_query`.
+///
+/// Lives in the binary crate because it's the only place that depends on both
+/// `turborepo-lib` and `turborepo-query`, enabling the dependency inversion
+/// that allows them to compile in parallel.
+struct TurboQueryServer;
+
+impl turborepo_query_api::QueryServer for TurboQueryServer {
+    fn execute_query<'a>(
+        &'a self,
+        run: Arc<dyn turborepo_query_api::QueryRun>,
+        query: &'a str,
+        variables_json: Option<&'a str>,
+    ) -> Pin<
+        Box<
+            dyn Future<
+                    Output = Result<turborepo_query_api::QueryResult, turborepo_query_api::Error>,
+                > + Send
+                + 'a,
+        >,
+    > {
+        Box::pin(async move {
+            turborepo_query::execute_query(run, query, variables_json)
+                .await
+                .map_err(Into::into)
+        })
+    }
+
+    fn run_query_server(
+        &self,
+        run: Arc<dyn turborepo_query_api::QueryRun>,
+        signal: turborepo_signals::SignalHandler,
+    ) -> Pin<Box<dyn Future<Output = Result<(), turborepo_query_api::Error>> + Send + '_>> {
+        Box::pin(async move {
+            turborepo_query::run_query_server(run, signal)
+                .await
+                .map_err(Into::into)
+        })
+    }
+
+    fn run_web_ui_server(
+        &self,
+        state: turborepo_ui::wui::query::SharedState,
+        run: Arc<dyn turborepo_query_api::QueryRun>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), turborepo_query_api::Error>> + Send + '_>> {
+        Box::pin(async move {
+            turborepo_query::run_server(Some(state), run)
+                .await
+                .map_err(Into::into)
+        })
+    }
+}
 
 // This function should not expanded. Please add any logic to
 // `turborepo_lib::main` instead
 fn main() -> Result<()> {
     std::panic::set_hook(Box::new(turborepo_lib::panic_handler));
 
-    let exit_code = turborepo_lib::main().unwrap_or_else(|err| {
+    let query_server: Arc<dyn turborepo_lib::QueryServer> = Arc::new(TurboQueryServer);
+    let exit_code = turborepo_lib::main(Some(query_server)).unwrap_or_else(|err| {
         eprintln!("{:?}", Report::new(err));
         1
     });


### PR DESCRIPTION
## Summary

- Introduces `turborepo-query-api`, a trait crate defining `QueryServer` and `QueryRun` that decouples `turborepo-lib` from the heavy `turborepo-query` crate (async-graphql, axum, oxc), enabling parallel compilation
- The binary crate wires the two halves together via `TurboQueryServer`, implementing the dependency inversion pattern

## Key design decisions

**Error composition over duplication.** Rather than duplicating error variants between crates with a fragile manual `From` impl, `turborepo-query::Error` wraps `turborepo_query_api::Error` via an `Api(#[from] ...)` variant. Shared errors (Boundaries, Server, Path, UI, etc.) flow through automatically. Query-specific errors (Trace, FileNotFound, Serde, Parse) stay local and get boxed only when crossing the boundary.

**Resolution errors preserve diagnostics.** Added `Resolution` variant with `#[diagnostic(transparent)]` to the API error enum so miette source spans survive the full error chain from query → API → CLI.

**Watch mode threading.** `WatchClient` now accepts and forwards `query_server` to all 3 `RunBuilder` call sites, fixing a silent Web UI regression where `turbo watch --ui=web` would produce no UI and no error.

**Unified error type on `QueryServer`.** All three trait methods now return `Result<_, turborepo_query_api::Error>` instead of mixing in `turborepo_ui::Error`.

## How to test

1. `cargo check -p turbo --features rustls-tls` — verifies compilation
2. `cargo clippy -p turborepo-query-api -p turborepo-query -p turborepo-lib -p turbo --features rustls-tls` — zero warnings
3. Run `turbo query "{ packages { items { name } } }"` in any monorepo — should work as before
4. The `QueryNotAvailable` error can be verified by inspecting the code path (only reachable if someone uses `turborepo-lib` as a library without providing a query server)