### PR TITLE
feat: Include version, platform, and CPU count in Chrome trace profiles

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1661,6 +1661,12 @@ pub async fn run(
             if let Some(file_path) = logger.chrome_tracing_file() {
                 let _ = logger.flush_chrome_tracing();
 
+                if let Err(e) =
+                    crate::tracing::inject_trace_metadata(std::path::Path::new(&file_path), version)
+                {
+                    warn!("Failed to inject trace metadata: {e}");
+                }
+
                 let md_path = format!("{file_path}.md");
                 if let Err(e) = turborepo_profile_md::trace_to_markdown(
                     std::path::Path::new(&file_path),

--- a/crates/turborepo-lib/src/tracing.rs
+++ b/crates/turborepo-lib/src/tracing.rs
@@ -238,6 +238,44 @@ impl TurboSubscriber {
     }
 }
 
+/// Injects process-level metadata events (version, platform, CPU count) into
+/// a Chrome trace file. Call after `flush_chrome_tracing` and before any
+/// post-processing that reads the trace.
+pub fn inject_trace_metadata(trace_path: &Path, version: &str) -> std::io::Result<()> {
+    use std::io::Write;
+
+    let contents = std::fs::read(trace_path)?;
+
+    // The trace file is a JSON array: [\n{event},\n{event},\n...\n]
+    // Find the first newline after '[' to insert metadata events.
+    let insert_pos = contents
+        .iter()
+        .position(|&b| b == b'\n')
+        .map(|p| p + 1)
+        .unwrap_or(1);
+
+    let cpus = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+
+    let metadata = format!(
+        "{{\"ph\":\"M\",\"pid\":1,\"name\":\"process_name\",\"args\":{{\"name\":\"turbo \
+         {version}\"}}}},\n{{\"ph\":\"M\",\"pid\":1,\"name\":\"process_labels\",\"args\":{{\"\
+         labels\":\"{platform}, {cpus} CPUs\"}}}},\n",
+        version = version,
+        platform = std::env::consts::OS,
+        cpus = cpus,
+    );
+
+    let mut file = std::fs::File::create(trace_path)?;
+    file.write_all(&contents[..insert_pos])?;
+    file.write_all(metadata.as_bytes())?;
+    file.write_all(&contents[insert_pos..])?;
+    file.flush()?;
+
+    Ok(())
+}
+
 impl Drop for TurboSubscriber {
     fn drop(&mut self) {
         // drop the guard so that the non-blocking file writer stops


### PR DESCRIPTION
## Summary

- Adds `process_name` and `process_labels` metadata events to Chrome trace profiles
- Makes turbo version, OS, and CPU count immediately visible when opening a trace in `chrome://tracing` or Perfetto

## What it looks like

The trace file now starts with:
```json
{"ph":"M","pid":1,"name":"process_name","args":{"name":"turbo 2.8.14"}},
{"ph":"M","pid":1,"name":"process_labels","args":{"labels":"macos, 12 CPUs"}},
```

In Chrome's trace viewer, `process_name` shows up as the title in the process lane, and `process_labels` appears as a subtitle. This makes it trivial to identify which build produced a given trace without digging through individual events.

## How

Post-processes the trace file after `flush_chrome_tracing()` and before markdown generation. Reads the file, inserts metadata events at the start of the JSON array, writes it back. The `tracing-chrome` crate doesn't expose an API for custom metadata events, so post-processing is the simplest path.