### PR TITLE
ci: Remove redundant rust_check job from lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -107,42 +107,6 @@ jobs:
           fi
           cargo lint
 
-  rust_check:
-    name: Rust check
-    needs: determine_changes
-    if: ${{ needs.determine_changes.outputs.rust == 'true' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    env:
-      SCCACHE_BUCKET: turborepo-sccache
-      SCCACHE_REGION: us-east-2
-      RUSTC_WRAPPER: ${{ !github.event.pull_request.head.repo.fork && 'sccache' || '' }}
-      CARGO_INCREMENTAL: 0
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SCCACHE_IDLE_TIMEOUT: 0
-      SCCACHE_REQUEST_TIMEOUT: 30
-      SCCACHE_ERROR_LOG: error
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Environment
-        uses: ./.github/actions/setup-environment
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          node: "false"
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
-
-      - name: Run cargo check
-        run: |
-          if [ -z "${RUSTC_WRAPPER}" ]; then
-            unset RUSTC_WRAPPER
-          fi
-          cargo check --workspace
-
   rust_licenses:
     name: Rust licenses
     needs: determine_changes
@@ -227,7 +191,6 @@ jobs:
       - determine_changes
       - rust_fmt
       - rust_clippy
-      - rust_check
       - rust_licenses
       - rust_audit
       - js_audit


### PR DESCRIPTION
## Summary

- Removes the `rust_check` job from the lint CI workflow

`rust_clippy` already executes `cargo check` internally as part of its analysis, with a strictly wider scope (`--all-targets` and `--features rustls-tls` vs. bare `--workspace`). Running both means two independent workspace compilations per PR for zero additional coverage.

Both jobs run in parallel off `determine_changes`, so `rust_check` doesn't provide an earlier signal either.