### PR TITLE
perf: Defer cache save to after callback to unblock dependents sooner

### DIFF
--- a/crates/turborepo-task-executor/src/exec.rs
+++ b/crates/turborepo-task-executor/src/exec.rs
@@ -107,8 +107,10 @@ pub enum ExecOutcome {
 pub enum SuccessOutcome {
     /// Task output was restored from cache
     CacheHit,
-    /// Task was executed
+    /// Task was executed and outputs are safe to cache
     Run,
+    /// Task was executed but log flush failed, so outputs should not be cached
+    RunOutputError,
 }
 
 /// Internal errors that can occur during task execution.
@@ -257,9 +259,10 @@ where
     ///
     /// This is the main entry point for task execution. It:
     /// 1. Starts tracking
-    /// 2. Executes the task (checking cache, running process, saving outputs)
+    /// 2. Executes the task (checking cache, running process)
     /// 3. Reports the outcome via the callback
-    /// 4. Updates the tracker
+    /// 4. Saves outputs to cache (off the critical path)
+    /// 5. Updates the tracker
     pub async fn execute<O: Write>(
         &mut self,
         parent_span_id: Option<tracing::Id>,
@@ -269,6 +272,7 @@ where
         telemetry: &PackageTaskEventBuilder,
     ) -> Result<(), InternalError> {
         let tracker: TaskTracker<chrono::DateTime<chrono::Local>> = tracker.start().await;
+        let task_start = Instant::now();
         let span = tracing::debug_span!("execute_task", task = %self.task_id.task());
         span.follows_from(parent_span_id);
 
@@ -276,6 +280,7 @@ where
             .execute_inner(&output_client, telemetry)
             .instrument(span)
             .await;
+        let task_duration = task_start.elapsed();
 
         // If the task resulted in an error, do not group in order to better highlight
         // the error.
@@ -311,13 +316,38 @@ where
             }
         }
 
+        // Cache save runs after the callback so dependent tasks can start
+        // while we walk the filesystem and write to cache.
+        if let Ok(ExecOutcome::Success(SuccessOutcome::Run)) = &result
+            && self
+                .task_access
+                .can_cache(&self.task_hash, &self.task_id_for_display)
+                .unwrap_or(true)
+        {
+            if let Err(e) = self
+                .task_cache
+                .save_outputs(task_duration, telemetry)
+                .instrument(tracing::info_span!("cache_save", task = %self.task_id))
+                .await
+            {
+                error!("error caching output: {e}");
+            } else {
+                self.hash_tracker.insert_expanded_outputs(
+                    self.task_id.clone(),
+                    self.task_cache.expanded_outputs().to_vec(),
+                );
+            }
+        }
+
         // Tracker bookkeeping happens after the callback so dependents
         // can start while we update summaries.
         match result {
             Ok(ExecOutcome::Success(outcome)) => {
                 match outcome {
                     SuccessOutcome::CacheHit => tracker.cached().await,
-                    SuccessOutcome::Run => tracker.build_succeeded(0).await,
+                    SuccessOutcome::Run | SuccessOutcome::RunOutputError => {
+                        tracker.build_succeeded(0).await
+                    }
                 };
             }
             Ok(ExecOutcome::Task { exit_code, message }) => {
@@ -366,7 +396,6 @@ where
         output_client: &TaskOutput<O>,
         telemetry: &PackageTaskEventBuilder,
     ) -> Result<ExecOutcome, InternalError> {
-        let task_start = Instant::now();
         let mut prefixed_ui = self.prefixed_ui(output_client);
 
         if self.ui_mode.has_sender()
@@ -475,35 +504,17 @@ where
                 return Err(InternalError::UnknownChildExit);
             }
         };
-        let task_duration = task_start.elapsed();
-
         match exit_status {
             ChildExit::Finished(Some(0)) => {
-                // Attempt to flush stdout_writer and log any errors encountered
+                // Cache save is deferred to execute() so the callback can
+                // fire first, unblocking dependent tasks while the globwalk
+                // and cache write proceed in the background.
                 if let Err(e) = stdout_writer.flush() {
                     error!("{e}");
-                } else if self
-                    .task_access
-                    .can_cache(&self.task_hash, &self.task_id_for_display)
-                    .unwrap_or(true)
-                {
-                    if let Err(e) = self
-                        .task_cache
-                        .save_outputs(task_duration, telemetry)
-                        .instrument(tracing::info_span!("cache_save", task = %self.task_id))
-                        .await
-                    {
-                        error!("error caching output: {e}");
-                        return Err(e.into());
-                    } else {
-                        self.hash_tracker.insert_expanded_outputs(
-                            self.task_id.clone(),
-                            self.task_cache.expanded_outputs().to_vec(),
-                        );
-                    }
+                    Ok(ExecOutcome::Success(SuccessOutcome::RunOutputError))
+                } else {
+                    Ok(ExecOutcome::Success(SuccessOutcome::Run))
                 }
-
-                Ok(ExecOutcome::Success(SuccessOutcome::Run))
             }
             ChildExit::Finished(Some(code)) => {
                 if let Err(e) = stdout_writer.flush() {


### PR DESCRIPTION
## Summary

Moves the `cache_save` step (filesystem globwalk + cache write) from inside `execute_inner` to after the callback in `execute`. Previously, the globwalk to discover output files ran before the callback that unblocks dependent tasks — putting it squarely on the critical path. Now dependent tasks start as soon as the process exits and output is flushed, while the cache save proceeds in parallel.

A customer trace showed `cache_save` appearing on the critical path for a code generation task with 543 output chunks. On deep dependency chains, this latency compounds across every non-cached task.

## Changes

- **`crates/turborepo-task-executor/src/exec.rs`**:
  - Removed `save_outputs`, `can_cache`, and `insert_expanded_outputs` from the `execute_inner` success path
  - Added them after the callback in `execute`, alongside the already-deferred tracker bookkeeping
  - Moved `task_start` from `execute_inner` to `execute` so `task_duration` is available for the deferred save
  - Cache save errors are now logged rather than failing the task (the task itself succeeded; caching is best-effort)

## How to review

The `execute` function now has three post-callback phases:
1. Cache save (new — globwalk + `cache.put()`)
2. Tracker bookkeeping (unchanged — summary updates)
3. Error handling (unchanged)

The key invariant is that `stdout_writer` (which writes the log file, one of the cached outputs) is a local in `execute_inner` — it's dropped and the file is closed before `save_outputs` runs, so the globwalk sees the complete log file.