### PR TITLE
feat: Add globalInputsAsTaskInputs future flag

### DIFF
--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -613,10 +613,19 @@ impl Run {
         });
 
         let env_mode = self.opts.run_opts.env_mode;
+        let global_inputs_as_task_inputs = self.opts.future_flags.global_inputs_as_task_inputs;
 
         let mut file_hash_result = None;
         let mut internal_deps_result = None;
         let mut global_file_result = None;
+
+        // When the flag is enabled, global dep globs are prepended to each task's
+        // inputs in calculate_file_hashes instead of being folded into the global hash.
+        let global_input_globs: &[String] = if global_inputs_as_task_inputs {
+            &self.root_turbo_json.global_deps
+        } else {
+            &[]
+        };
 
         let _hash_scope_span = tracing::info_span!("hash_scope").entered();
         rayon::scope(|s| {
@@ -634,6 +643,7 @@ impl Run {
                     &self.run_telemetry,
                     repo_index,
                     needs_expanded,
+                    global_input_globs,
                 ));
             });
             s.spawn(|_| {
@@ -662,6 +672,7 @@ impl Run {
                     &self.env_at_execution_start,
                     &self.root_turbo_json.global_env,
                     &self.scm,
+                    global_inputs_as_task_inputs,
                 ));
             });
         });

--- a/crates/turborepo-schema-gen/src/main.rs
+++ b/crates/turborepo-schema-gen/src/main.rs
@@ -709,6 +709,15 @@ export interface FutureFlags {
    * @defaultValue `false`
    */
   longerSignatureKey?: boolean;
+  /**
+   * Treat `globalDependencies` as implicit task inputs prepended to every
+   * task's input globs instead of folding them into the global hash. This
+   * allows individual tasks to negate specific global inputs via
+   * `inputs: ["!$TURBO_ROOT$/some-global-file.txt"]`.
+   *
+   * @defaultValue `false`
+   */
+  globalInputsAsTaskInputs?: boolean;
 }
 
 "#

--- a/crates/turborepo-task-hash/src/global_hash.rs
+++ b/crates/turborepo-task-hash/src/global_hash.rs
@@ -73,6 +73,7 @@ pub fn get_global_hash_inputs<'a, L: ?Sized + Lockfile>(
     env_mode: EnvMode,
     framework_inference: bool,
     hasher: &SCM,
+    global_inputs_as_task_inputs: bool,
 ) -> Result<GlobalHashableInputs<'a>, Error> {
     let GlobalFileHashInputs {
         global_file_hash_map,
@@ -87,6 +88,7 @@ pub fn get_global_hash_inputs<'a, L: ?Sized + Lockfile>(
         env_at_execution_start,
         global_env,
         hasher,
+        global_inputs_as_task_inputs,
     )?;
 
     debug!(
@@ -123,6 +125,10 @@ pub struct GlobalFileHashInputs<'a> {
 /// This is the expensive I/O-bound portion of global hash computation and
 /// can be run concurrently with package file hashing and internal deps
 /// hashing since it has no dependencies on those results.
+///
+/// When `global_inputs_as_task_inputs` is true, global file dependencies are
+/// not resolved or hashed here — they will instead be prepended to each
+/// task's input globs in `PackageInputsHashes::calculate_file_hashes`.
 #[allow(clippy::too_many_arguments, clippy::result_large_err)]
 pub fn collect_global_file_hash_inputs<'a, L: ?Sized + Lockfile>(
     root_package: &'a PackageInfo,
@@ -133,6 +139,7 @@ pub fn collect_global_file_hash_inputs<'a, L: ?Sized + Lockfile>(
     env_at_execution_start: &'a EnvironmentVariableMap,
     global_env: &'a [String],
     hasher: &SCM,
+    global_inputs_as_task_inputs: bool,
 ) -> Result<GlobalFileHashInputs<'a>, Error> {
     let engines = root_package.package_json.engines();
 
@@ -144,8 +151,11 @@ pub fn collect_global_file_hash_inputs<'a, L: ?Sized + Lockfile>(
         global_hashable_env_vars.all.names()
     );
 
-    let mut global_deps =
-        collect_global_deps(package_manager, root_path, global_file_dependencies)?;
+    let mut global_deps = if global_inputs_as_task_inputs {
+        HashSet::new()
+    } else {
+        collect_global_deps(package_manager, root_path, global_file_dependencies)?
+    };
 
     if lockfile.is_none() {
         global_deps.insert(root_path.join_component("package.json"));
@@ -370,7 +380,7 @@ mod tests {
     use turborepo_scm::SCM;
     use turborepo_types::EnvMode;
 
-    use super::{collect_global_deps, get_global_hash_inputs};
+    use super::{collect_global_deps, collect_global_file_hash_inputs, get_global_hash_inputs};
 
     #[test]
     fn test_absolute_path() {
@@ -408,6 +418,7 @@ mod tests {
             EnvMode::Strict,
             false,
             &SCM::new(&root),
+            false,
         );
         assert!(result.is_ok());
     }
@@ -449,5 +460,91 @@ mod tests {
 
         // should not yield the root folder itself, src, or empty-folder
         assert_eq!(results.len(), 3, "{:?}", results);
+    }
+
+    #[test]
+    fn test_flag_off_includes_global_deps_in_hash() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPathBuf::try_from(tmp.path())
+            .unwrap()
+            .to_realpath()
+            .unwrap();
+
+        root.join_component("package.json")
+            .create_with_contents("{}")
+            .unwrap();
+        root.join_component("config.txt")
+            .create_with_contents("some config")
+            .unwrap();
+
+        let env_var_map = EnvironmentVariableMap::default();
+        let package_info = PackageInfo::default();
+        let lockfile: Option<&dyn Lockfile> = None;
+        let file_deps = ["config.txt".to_string()];
+
+        let result = collect_global_file_hash_inputs(
+            &package_info,
+            &root,
+            &PackageManager::Pnpm,
+            lockfile,
+            &file_deps,
+            &env_var_map,
+            &[],
+            &SCM::new(&root),
+            false,
+        )
+        .unwrap();
+
+        assert!(
+            !result.global_file_hash_map.is_empty(),
+            "flag off: global_file_hash_map should contain the global dep files"
+        );
+    }
+
+    #[test]
+    fn test_flag_on_excludes_global_deps_from_hash() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPathBuf::try_from(tmp.path())
+            .unwrap()
+            .to_realpath()
+            .unwrap();
+
+        root.join_component("package.json")
+            .create_with_contents("{}")
+            .unwrap();
+        root.join_component("config.txt")
+            .create_with_contents("some config")
+            .unwrap();
+
+        let env_var_map = EnvironmentVariableMap::default();
+        let package_info = PackageInfo::default();
+        let lockfile: Option<&dyn Lockfile> = None;
+        let file_deps = ["config.txt".to_string()];
+
+        let result = collect_global_file_hash_inputs(
+            &package_info,
+            &root,
+            &PackageManager::Pnpm,
+            lockfile,
+            &file_deps,
+            &env_var_map,
+            &[],
+            &SCM::new(&root),
+            true,
+        )
+        .unwrap();
+
+        // When the flag is on and there's no lockfile, package.json and
+        // the lockfile path may still be present, but the user-specified
+        // global dep (config.txt) should NOT be in the map.
+        let has_config = result
+            .global_file_hash_map
+            .keys()
+            .any(|k| k.as_str().contains("config.txt"));
+        assert!(
+            !has_config,
+            "flag on: config.txt should not appear in global_file_hash_map, got: {:?}",
+            result.global_file_hash_map.keys().collect::<Vec<_>>()
+        );
     }
 }

--- a/crates/turborepo-task-hash/src/lib.rs
+++ b/crates/turborepo-task-hash/src/lib.rs
@@ -33,7 +33,7 @@ use turborepo_task_id::TaskId;
 use turborepo_telemetry::events::{generic::GenericEventBuilder, task::PackageTaskEventBuilder};
 use turborepo_types::{
     EnvMode, HashTrackerCacheHitMetadata, HashTrackerDetailedMap, HashTrackerInfo, RunOptsHashInfo,
-    TaskDefinitionHashInfo, TaskInputs,
+    TaskDefinitionHashInfo,
 };
 
 #[derive(Debug, Error)]
@@ -75,6 +75,43 @@ pub struct PackageInputsHashes {
     expanded_hashes: HashMap<TaskId<'static>, Arc<FileHashes>>,
 }
 
+/// Translates root-relative global dep globs into package-relative globs.
+///
+/// For a package at `packages/foo`, the glob `config.json` becomes
+/// `../../config.json`. A negated glob `!config.json` becomes
+/// `!../../config.json`. For the root package (empty path), globs pass
+/// through unchanged.
+pub fn translate_global_globs_for_package(
+    global_globs: &[String],
+    package_path: &AnchoredSystemPath,
+) -> Vec<String> {
+    if global_globs.is_empty() {
+        return Vec::new();
+    }
+
+    let path_str = package_path.as_str();
+    if path_str.is_empty() {
+        return global_globs.to_vec();
+    }
+
+    // Count path components to build the "../.." prefix
+    let depth = path_str.split(std::path::MAIN_SEPARATOR).count();
+    let prefix: String = (0..depth)
+        .map(|i| if i == 0 { ".." } else { "/.." })
+        .collect();
+
+    global_globs
+        .iter()
+        .map(|glob| {
+            if let Some(without_neg) = glob.strip_prefix('!') {
+                format!("!{prefix}/{without_neg}")
+            } else {
+                format!("{prefix}/{glob}")
+            }
+        })
+        .collect()
+}
+
 impl PackageInputsHashes {
     #[tracing::instrument(skip(
         all_tasks,
@@ -94,6 +131,7 @@ impl PackageInputsHashes {
         _telemetry: &GenericEventBuilder,
         pre_built_index: Option<&RepoGitIndex>,
         needs_expanded_hashes: bool,
+        global_input_globs: &[String],
     ) -> Result<PackageInputsHashes, Error>
     where
         T: TaskDefinitionHashInfo + Sync,
@@ -116,7 +154,8 @@ impl PackageInputsHashes {
         struct TaskInfo<'b> {
             task_id: TaskId<'static>,
             package_path: &'b AnchoredSystemPath,
-            inputs: &'b TaskInputs,
+            globs: Vec<String>,
+            default: bool,
         }
 
         let mut task_infos = Vec::new();
@@ -136,10 +175,24 @@ impl PackageInputsHashes {
                 .parent()
                 .unwrap_or_else(|| AnchoredSystemPath::new("").unwrap());
             let inputs = task_definition.inputs();
+
+            // When globalInputsAsTaskInputs is enabled, prepend translated
+            // global dep globs to each task's input globs so that tasks can
+            // negate specific global inputs.
+            let globs = if global_input_globs.is_empty() {
+                inputs.globs.clone()
+            } else {
+                let mut translated =
+                    translate_global_globs_for_package(global_input_globs, package_path);
+                translated.extend(inputs.globs.iter().cloned());
+                translated
+            };
+
             task_infos.push(TaskInfo {
                 task_id: task_id.clone(),
                 package_path,
-                inputs,
+                globs,
+                default: inputs.default,
             });
         }
 
@@ -152,8 +205,8 @@ impl PackageInputsHashes {
         for info in &task_infos {
             let key: HashKey = (
                 info.package_path.to_owned(),
-                info.inputs.globs.clone(),
-                info.inputs.default,
+                info.globs.clone(),
+                info.default,
             );
             let idx = match key_indices.entry(key) {
                 std::collections::hash_map::Entry::Occupied(e) => *e.get(),
@@ -1075,5 +1128,55 @@ mod test {
         // But expanded inputs must return None, not panic
         assert!(tracker.get_expanded_inputs(&task_id).is_none());
         assert!(HashTrackerInfo::expanded_inputs(&tracker, &task_id).is_none());
+    }
+
+    #[test]
+    fn test_translate_global_globs_for_nested_package() {
+        let package_path = AnchoredSystemPath::new("packages/foo").unwrap();
+        let globs = vec!["config.json".to_string(), "!secret.txt".to_string()];
+
+        let result = translate_global_globs_for_package(&globs, package_path);
+
+        assert_eq!(result, vec!["../../config.json", "!../../secret.txt"]);
+    }
+
+    #[test]
+    fn test_translate_global_globs_for_root_package() {
+        let package_path = AnchoredSystemPath::new("").unwrap();
+        let globs = vec!["config.json".to_string(), "!secret.txt".to_string()];
+
+        let result = translate_global_globs_for_package(&globs, package_path);
+
+        assert_eq!(result, vec!["config.json", "!secret.txt"]);
+    }
+
+    #[test]
+    fn test_translate_global_globs_for_deeply_nested_package() {
+        let package_path = AnchoredSystemPath::new("packages/deeply/nested").unwrap();
+        let globs = vec!["dir/file.txt".to_string()];
+
+        let result = translate_global_globs_for_package(&globs, package_path);
+
+        assert_eq!(result, vec!["../../../dir/file.txt"]);
+    }
+
+    #[test]
+    fn test_translate_global_globs_with_wildcards() {
+        let package_path = AnchoredSystemPath::new("apps/web").unwrap();
+        let globs = vec!["config/**".to_string(), "!config/**/*.md".to_string()];
+
+        let result = translate_global_globs_for_package(&globs, package_path);
+
+        assert_eq!(result, vec!["../../config/**", "!../../config/**/*.md"]);
+    }
+
+    #[test]
+    fn test_translate_global_globs_empty() {
+        let package_path = AnchoredSystemPath::new("packages/foo").unwrap();
+        let globs: Vec<String> = vec![];
+
+        let result = translate_global_globs_for_package(&globs, package_path);
+
+        assert!(result.is_empty());
     }
 }

--- a/crates/turborepo-turbo-json/src/future_flags.rs
+++ b/crates/turborepo-turbo-json/src/future_flags.rs
@@ -53,6 +53,12 @@ pub struct FutureFlags {
     /// brute-force tag collision feasible.
     #[serde(default)]
     pub longer_signature_key: bool,
+    /// Treat `globalDependencies` as implicit task inputs prepended to every
+    /// task's input globs instead of folding them into the global hash.
+    /// This allows individual tasks to negate specific global inputs via
+    /// `inputs: ["!$TURBO_ROOT$/some-global-file.txt"]`.
+    #[serde(default)]
+    pub global_inputs_as_task_inputs: bool,
 }
 
 impl TS for FutureFlags {
@@ -65,25 +71,25 @@ impl TS for FutureFlags {
 
     fn inline() -> String {
         "{ errorsOnlyShowHash?: boolean, experimentalObservability?: boolean, longerSignatureKey?: \
-         boolean }"
+         boolean, globalInputsAsTaskInputs?: boolean }"
             .to_string()
     }
 
     fn inline_flattened() -> String {
         "{ errorsOnlyShowHash?: boolean, experimentalObservability?: boolean, longerSignatureKey?: \
-         boolean }"
+         boolean, globalInputsAsTaskInputs?: boolean }"
             .to_string()
     }
 
     fn decl() -> String {
         "type FutureFlags = { errorsOnlyShowHash?: boolean, experimentalObservability?: boolean, \
-         longerSignatureKey?: boolean };"
+         longerSignatureKey?: boolean, globalInputsAsTaskInputs?: boolean };"
             .to_string()
     }
 
     fn decl_concrete() -> String {
         "type FutureFlags = { errorsOnlyShowHash?: boolean, experimentalObservability?: boolean, \
-         longerSignatureKey?: boolean };"
+         longerSignatureKey?: boolean, globalInputsAsTaskInputs?: boolean };"
             .to_string()
     }
 

--- a/crates/turborepo-turbo-json/src/lib.rs
+++ b/crates/turborepo-turbo-json/src/lib.rs
@@ -737,6 +737,38 @@ mod tests {
     }
 
     #[test]
+    fn test_deserialize_future_flags_global_inputs_as_task_inputs() {
+        let json = r#"{
+            "tasks": {
+                "build": {}
+            },
+            "futureFlags": {
+                "globalInputsAsTaskInputs": true
+            }
+        }"#;
+
+        let deserialized_result = deserialize_from_json_str(
+            json,
+            JsonParserOptions::default().with_allow_comments(),
+            "turbo.json",
+        );
+        let raw_turbo_json: RawTurboJson = deserialized_result.into_deserialized().unwrap();
+
+        assert!(raw_turbo_json.future_flags.is_some());
+        let future_flags = raw_turbo_json.future_flags.as_ref().unwrap();
+        assert!(future_flags.as_inner().global_inputs_as_task_inputs);
+
+        let turbo_json = TurboJson::try_from(raw_turbo_json);
+        assert!(turbo_json.is_ok());
+        assert!(
+            turbo_json
+                .unwrap()
+                .future_flags
+                .global_inputs_as_task_inputs
+        );
+    }
+
+    #[test]
     fn test_is_root_config_with_root_path() {
         let turbo_json = TurboJson {
             path: Some("turbo.json".into()),

--- a/crates/turborepo/tests/global_deps_test.rs
+++ b/crates/turborepo/tests/global_deps_test.rs
@@ -2,7 +2,7 @@ mod common;
 
 use std::fs;
 
-use common::{run_turbo, setup};
+use common::{git, run_turbo, setup};
 
 #[test]
 fn test_global_deps_change_causes_cache_miss() {
@@ -49,5 +49,142 @@ fn test_global_deps_change_causes_cache_miss() {
     assert!(
         stdout3.contains("FULL TURBO"),
         "expected cache hit after non-global-dep change, got: {stdout3}"
+    );
+}
+
+/// Regression: with the globalInputsAsTaskInputs flag enabled, changing a
+/// global dep file still causes a cache miss for tasks that do NOT negate it.
+#[test]
+fn test_global_deps_with_flag_still_causes_cache_miss() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(tempdir.path(), "global_deps", "npm@10.5.0", true).unwrap();
+
+    // Enable the future flag by rewriting turbo.json
+    let turbo_json = r#"{
+  "globalDependencies": ["global_deps/**", "!global_deps/**/*.md"],
+  "globalEnv": ["SOME_ENV_VAR"],
+  "futureFlags": {
+    "globalInputsAsTaskInputs": true
+  },
+  "tasks": {
+    "build": {
+      "env": ["NODE_ENV"],
+      "outputs": []
+    },
+    "my-app#build": {
+      "outputs": ["banana.txt", "apple.json"],
+      "inputs": ["$TURBO_DEFAULT$", ".env.local"]
+    },
+    "something": {},
+    "//#something": {},
+    "maybefails": {}
+  }
+}"#;
+    fs::write(tempdir.path().join("turbo.json"), turbo_json).unwrap();
+    git(tempdir.path(), &["add", "."]);
+    git(
+        tempdir.path(),
+        &["commit", "-m", "enable flag", "--quiet", "--allow-empty"],
+    );
+
+    // First build: cache miss
+    let output1 = run_turbo(
+        tempdir.path(),
+        &["build", "-F", "my-app", "--output-logs=hash-only"],
+    );
+    assert!(output1.status.success());
+    let stdout1 = String::from_utf8_lossy(&output1.stdout);
+    assert!(
+        stdout1.contains("cache miss"),
+        "expected initial cache miss, got: {stdout1}"
+    );
+
+    // Change a global deps file
+    fs::write(tempdir.path().join("global_deps/foo.txt"), "new text").unwrap();
+
+    // Second build: cache miss because global dep changed (even with new flag)
+    let output2 = run_turbo(
+        tempdir.path(),
+        &["build", "-F", "my-app", "--output-logs=hash-only"],
+    );
+    assert!(output2.status.success());
+    let stdout2 = String::from_utf8_lossy(&output2.stdout);
+    assert!(
+        stdout2.contains("cache miss"),
+        "expected cache miss after global dep change with flag on, got: {stdout2}"
+    );
+}
+
+/// The key feature: with globalInputsAsTaskInputs enabled, a task that
+/// negates a global input is NOT invalidated when that file changes.
+/// A task that does NOT negate it IS still invalidated.
+#[test]
+fn test_global_deps_negation_with_flag() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(tempdir.path(), "global_deps", "npm@10.5.0", true).unwrap();
+
+    // Rewrite turbo.json: util#build negates foo.txt, my-app#build does not
+    let turbo_json = r#"{
+  "globalDependencies": ["global_deps/foo.txt"],
+  "futureFlags": {
+    "globalInputsAsTaskInputs": true
+  },
+  "tasks": {
+    "build": {
+      "outputs": []
+    },
+    "util#build": {
+      "outputs": [],
+      "inputs": ["$TURBO_DEFAULT$", "!$TURBO_ROOT$/global_deps/foo.txt"]
+    }
+  }
+}"#;
+    fs::write(tempdir.path().join("turbo.json"), turbo_json).unwrap();
+    git(tempdir.path(), &["add", "."]);
+    git(
+        tempdir.path(),
+        &["commit", "-m", "enable flag", "--quiet", "--allow-empty"],
+    );
+
+    // First build for both packages: cache miss
+    let output1 = run_turbo(tempdir.path(), &["build", "--output-logs=hash-only"]);
+    assert!(output1.status.success());
+    let stdout1 = String::from_utf8_lossy(&output1.stdout);
+    assert!(
+        stdout1.contains("cache miss"),
+        "expected initial cache miss, got: {stdout1}"
+    );
+
+    // Second build: cache hit (sanity check)
+    let output2 = run_turbo(tempdir.path(), &["build", "--output-logs=hash-only"]);
+    assert!(output2.status.success());
+    let stdout2 = String::from_utf8_lossy(&output2.stdout);
+    assert!(
+        stdout2.contains("FULL TURBO"),
+        "expected cache hit on second run, got: {stdout2}"
+    );
+
+    // Change the global dep file
+    fs::write(
+        tempdir.path().join("global_deps/foo.txt"),
+        "changed content",
+    )
+    .unwrap();
+
+    // Third build: util#build should be a cache HIT (it negated foo.txt),
+    // my-app#build should be a cache MISS (it did not negate foo.txt).
+    let output3 = run_turbo(tempdir.path(), &["build", "--output-logs=hash-only"]);
+    assert!(output3.status.success());
+    let stdout3 = String::from_utf8_lossy(&output3.stdout);
+
+    // my-app:build should miss
+    assert!(
+        stdout3.contains("my-app:build: cache miss"),
+        "expected my-app:build cache miss after global dep change, got: {stdout3}"
+    );
+    // util:build should hit because it negated the global dep
+    assert!(
+        stdout3.contains("util:build: cache hit"),
+        "expected util:build cache hit after negated global dep change, got: {stdout3}"
     );
 }


### PR DESCRIPTION
## Summary

Adds a `globalInputsAsTaskInputs` future flag that changes how `globalDependencies` affects task hashing. When enabled, global dependency globs are prepended to each task's input globs instead of being folded into a single global hash. This allows individual tasks to negate specific global inputs.

Closes TURBO-4284.

## Problem

`globalDependencies: ["my-file.txt"]` combined with `"foo#build": { "inputs": ["foo.txt", "!../my-file.txt"] }` still causes `my-file.txt` to change the `foo#build` hash. The negation has no effect because the global hash is computed once and baked into every task hash — tasks cannot opt out.

## Solution

Behind `futureFlags: { "globalInputsAsTaskInputs": true }`:

1. Global dep file hashes are **excluded from the global hash** (via `collect_global_file_hash_inputs`)
2. Global dep globs are **prepended to each task's input globs** in `PackageInputsHashes::calculate_file_hashes`, with path translation from root-relative to package-relative (e.g., `config.txt` becomes `../../config.txt` for a package at `packages/foo`)

This means `inputs: ["!$TURBO_ROOT$/my-file.txt"]` now actually excludes `my-file.txt` from the task's file hash.

## Testing

To test the negation behavior:
```json
{
  "globalDependencies": ["global_deps/foo.txt"],
  "futureFlags": { "globalInputsAsTaskInputs": true },
  "tasks": {
    "build": { "outputs": [] },
    "util#build": {
      "outputs": [],
      "inputs": ["$TURBO_DEFAULT$", "!$TURBO_ROOT$/global_deps/foo.txt"]
    }
  }
}
```

Changing `global_deps/foo.txt` will cause a cache miss for tasks that don't negate it, but a cache hit for `util#build` which explicitly negates it.

## Notes

- Enabling the flag will cause a one-time cache invalidation for all tasks (the global hash changes because global dep files are no longer in it)
- Scope/filter change detection is unchanged — `globalDependencies` file changes still mark all packages as changed for `--affected`
- The `globalDependencies` → `globalInputs` field rename is a separate follow-up