### PR TITLE
chore: Add oxfmt check to pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,7 +2,7 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 pnpm exec lint-staged
-pnpm exec oxfmt --check
+turbo run format
 
 export RUSTFLAGS="-D warnings"
 cargo fmt --check


### PR DESCRIPTION
## Summary

- Adds `turbo run format` to the pre-push hook so JS/TS formatting issues are caught locally before they fail in CI