### PR TITLE
perf: Avoid Unconditional HTTP Client Warmup

### DIFF
--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -27,9 +27,11 @@ pub use crate::error::{Error, Result};
 pub mod analytics;
 mod error;
 mod retry;
+mod shared_http_client;
 pub mod telemetry;
 
 pub use bytes::Bytes;
+pub use shared_http_client::SharedHttpClient;
 pub use tokio_stream::Stream;
 
 static AUTHORIZATION_REGEX: LazyLock<Regex> =

--- a/crates/turborepo-api-client/src/shared_http_client.rs
+++ b/crates/turborepo-api-client/src/shared_http_client.rs
@@ -1,0 +1,62 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+
+use tokio::sync::OnceCell;
+
+use crate::{APIClient, Error};
+
+/// Shared reqwest client initialization for all run-time network consumers.
+///
+/// Call `activate()` as soon as a command knows it will need networking, then
+/// use `get_or_init()` at the actual point of use. This overlaps TLS/client
+/// setup with other startup work without constructing a client for commands
+/// that never touch the network.
+#[derive(Clone, Default)]
+pub struct SharedHttpClient {
+    cell: Arc<OnceCell<reqwest::Client>>,
+    warming: Arc<AtomicBool>,
+}
+
+impl SharedHttpClient {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn activate(&self) {
+        if self.cell.get().is_some() {
+            return;
+        }
+
+        if self
+            .warming
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+
+        let this = self.clone();
+        tokio::spawn(async move {
+            let _ = this.get_or_init().await;
+            this.warming.store(false, Ordering::Release);
+        });
+    }
+
+    pub async fn get_or_init(&self) -> Result<reqwest::Client, Error> {
+        let client = self
+            .cell
+            .get_or_try_init(|| async {
+                tokio::task::spawn_blocking(|| {
+                    let _span = tracing::info_span!("http_client_init").entered();
+                    APIClient::build_http_client(None)
+                })
+                .await
+                .map_err(|_| Error::HttpClientCancelled)?
+            })
+            .await?;
+
+        Ok(client.clone())
+    }
+}

--- a/crates/turborepo-api-client/src/telemetry.rs
+++ b/crates/turborepo-api-client/src/telemetry.rs
@@ -1,10 +1,9 @@
-use std::{future::Future, sync::Arc};
+use std::future::Future;
 
 use reqwest::Method;
-use tokio::sync::OnceCell;
 use turborepo_vercel_api::telemetry::TelemetryEvent;
 
-use crate::{APIClient, AnonAPIClient, Error, build_user_agent, retry};
+use crate::{AnonAPIClient, Error, SharedHttpClient, build_user_agent, retry};
 
 const TELEMETRY_ENDPOINT: &str = "/api/turborepo/v1/events";
 
@@ -43,24 +42,16 @@ impl TelemetryClient for AnonAPIClient {
     }
 }
 
-/// A telemetry client backed by an HTTP client that initializes on a
-/// background thread. TLS initialization (~100ms) starts as early as
-/// possible via `spawn_blocking`; this client shares the `OnceCell` that
-/// the background task writes to. By the time telemetry flushes its
-/// first batch, TLS init has almost certainly already completed.
+/// A telemetry client backed by the shared on-demand HTTP client.
 #[derive(Clone)]
 pub struct DeferredTelemetryClient {
-    http_client: Arc<OnceCell<reqwest::Client>>,
+    http_client: SharedHttpClient,
     base_url: String,
     user_agent: String,
 }
 
 impl DeferredTelemetryClient {
-    pub fn new(
-        http_client: Arc<OnceCell<reqwest::Client>>,
-        base_url: impl Into<String>,
-        version: &str,
-    ) -> Self {
+    pub fn new(http_client: SharedHttpClient, base_url: impl Into<String>, version: &str) -> Self {
         Self {
             http_client,
             base_url: base_url.into(),
@@ -76,20 +67,7 @@ impl TelemetryClient for DeferredTelemetryClient {
         telemetry_id: &str,
         session_id: &str,
     ) -> Result<(), Error> {
-        // Fast path: background TLS init already completed.
-        // Slow path: initialize inline, but if the runtime is shutting down
-        // the spawn_blocking task will be cancelled — return an error instead
-        // of panicking. Telemetry is never worth crashing over.
-        let maybe_client;
-        let client = match self.http_client.get() {
-            Some(client) => client,
-            None => {
-                maybe_client = tokio::task::spawn_blocking(|| APIClient::build_http_client(None))
-                    .await
-                    .map_err(|_| Error::HttpClientCancelled)??;
-                &maybe_client
-            }
-        };
+        let client = self.http_client.get_or_init().await?;
 
         let url = format!("{}{}", self.base_url, TELEMETRY_ENDPOINT);
         let telemetry_request = client

--- a/crates/turborepo-cache/src/async_cache.rs
+++ b/crates/turborepo-cache/src/async_cache.rs
@@ -37,7 +37,7 @@ impl AsyncCache {
     pub fn new(
         opts: &CacheOpts,
         repo_root: &AbsoluteSystemPath,
-        api_client: APIClient,
+        api_client: Option<APIClient>,
         api_auth: Option<APIAuth>,
         analytics_recorder: Option<AnalyticsSender>,
     ) -> Result<AsyncCache, CacheError> {
@@ -298,7 +298,8 @@ mod tests {
             token: SecretString::new("my-token".to_string()),
             team_slug: None,
         });
-        let async_cache = AsyncCache::new(&opts, &repo_root_path, api_client, api_auth, None)?;
+        let async_cache =
+            AsyncCache::new(&opts, &repo_root_path, Some(api_client), api_auth, None)?;
 
         // Ensure that the cache is empty
         let response = async_cache.exists(&hash).await;
@@ -376,21 +377,12 @@ mod tests {
             }),
         };
 
-        // Initialize client with invalid API url to ensure that we don't hit the
-        // network
-        let api_client = APIClient::new(
-            "http://example.com",
-            Some(Duration::from_secs(200)),
-            None,
-            "2.0.0",
-            true,
-        )?;
         let api_auth = Some(APIAuth {
             team_id: Some("my-team-id".to_string()),
             token: SecretString::new("my-token".to_string()),
             team_slug: None,
         });
-        let async_cache = AsyncCache::new(&opts, &repo_root_path, api_client, api_auth, None)?;
+        let async_cache = AsyncCache::new(&opts, &repo_root_path, None, api_auth, None)?;
 
         // Ensure that the cache is empty
         let response = async_cache.exists(&hash).await;
@@ -449,6 +441,71 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn test_local_only_cache_does_not_require_api_client() -> Result<()> {
+        let test_case = get_test_cases().into_iter().next().unwrap();
+        let repo_root = tempdir()?;
+        let repo_root_path = AbsoluteSystemPathBuf::try_from(repo_root.path())?;
+        test_case.initialize(&repo_root_path)?;
+
+        let hash = format!("{}-local-only", test_case.hash);
+        let opts = CacheOpts {
+            cache_dir: Utf8PathBuf::from(".turbo/cache"),
+            cache: CacheConfig {
+                local: CacheActions {
+                    read: true,
+                    write: true,
+                },
+                remote: CacheActions {
+                    read: false,
+                    write: false,
+                },
+            },
+            workers: 1,
+            remote_cache_opts: Some(RemoteCacheOpts {
+                unused_team_id: Some("my-team".to_string()),
+                signature: false,
+                enforce_signature_key_length: false,
+            }),
+        };
+
+        let api_auth = Some(APIAuth {
+            team_id: Some("my-team-id".to_string()),
+            token: SecretString::new("my-token".to_string()),
+            team_slug: None,
+        });
+        let async_cache = AsyncCache::new(&opts, &repo_root_path, None, api_auth, None)?;
+
+        assert_matches!(async_cache.exists(&hash).await, Ok(None));
+
+        async_cache
+            .put(
+                repo_root_path.clone(),
+                hash.clone(),
+                test_case
+                    .files
+                    .iter()
+                    .map(|f| f.path().to_owned())
+                    .collect(),
+                test_case.duration,
+            )
+            .await?;
+
+        async_cache.wait().await?;
+
+        assert_eq!(
+            async_cache.exists(&hash).await?,
+            Some(CacheHitMetadata {
+                source: CacheSource::Local,
+                time_saved: test_case.duration,
+            })
+        );
+
+        async_cache.shutdown().await?;
+
+        Ok(())
+    }
+
     async fn round_trip_test_with_both_caches(test_case: &TestCase, port: u16) -> Result<()> {
         let repo_root = tempdir()?;
         let repo_root_path = AbsoluteSystemPathBuf::try_from(repo_root.path())?;
@@ -488,7 +545,8 @@ mod tests {
             token: SecretString::new("my-token".to_string()),
             team_slug: None,
         });
-        let async_cache = AsyncCache::new(&opts, &repo_root_path, api_client, api_auth, None)?;
+        let async_cache =
+            AsyncCache::new(&opts, &repo_root_path, Some(api_client), api_auth, None)?;
 
         // Ensure that the cache is empty
         let response = async_cache.exists(&hash).await;

--- a/crates/turborepo-cache/src/multiplexer.rs
+++ b/crates/turborepo-cache/src/multiplexer.rs
@@ -33,7 +33,7 @@ impl CacheMultiplexer {
     pub fn new(
         opts: &CacheOpts,
         repo_root: &AbsoluteSystemPath,
-        api_client: APIClient,
+        api_client: Option<APIClient>,
         api_auth: Option<APIAuth>,
         analytics_recorder: Option<AnalyticsSender>,
     ) -> Result<Self, CacheError> {
@@ -55,19 +55,20 @@ impl CacheMultiplexer {
             .then(|| FSCache::new(&opts.cache_dir, repo_root, analytics_recorder.clone()))
             .transpose()?;
 
-        let http_cache = use_http_cache
-            .then_some(api_auth)
-            .flatten()
-            .map(|api_auth| {
-                HTTPCache::new(
+        let http_cache = if use_http_cache {
+            match (api_client, api_auth) {
+                (Some(api_client), Some(api_auth)) => Some(HTTPCache::new(
                     api_client,
                     opts,
                     repo_root.to_owned(),
                     api_auth,
                     analytics_recorder.clone(),
-                )
-            })
-            .transpose()?;
+                )?),
+                _ => None,
+            }
+        } else {
+            None
+        };
 
         Ok(CacheMultiplexer {
             should_print_skipping_remote_put: AtomicBool::new(true),

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -7,7 +7,7 @@ pub use error::Error;
 use serde::Serialize;
 use tracing::{debug, error, log::warn};
 use turbopath::AbsoluteSystemPathBuf;
-use turborepo_api_client::{APIClient, AnonAPIClient};
+use turborepo_api_client::SharedHttpClient;
 use turborepo_repository::inference::{RepoMode, RepoState};
 use turborepo_telemetry::{
     events::{command::CommandEventBuilder, generic::GenericEventBuilder, EventBuilder, EventType},
@@ -1142,38 +1142,23 @@ impl RunArgs {
     }
 }
 
-#[tracing::instrument(skip_all)]
-fn initialize_telemetry_client(
-    http_client: &reqwest::Client,
-    color_config: ColorConfig,
-    version: &str,
-) -> Option<TelemetryHandle> {
-    let anonymous_api_client = AnonAPIClient::new_with_client(
-        http_client.clone(),
-        "https://telemetry.vercel.com",
-        version,
-    );
-    match init_telemetry(anonymous_api_client, color_config) {
-        Ok(h) => Some(h),
-        Err(error) => {
-            debug!("failed to start telemetry: {:?}", error);
-            None
-        }
-    }
-}
-
 fn initialize_deferred_telemetry_client(
-    http_client_cell: std::sync::Arc<tokio::sync::OnceCell<reqwest::Client>>,
+    http_client: SharedHttpClient,
     color_config: ColorConfig,
     version: &str,
 ) -> Option<TelemetryHandle> {
     let deferred_client = turborepo_api_client::telemetry::DeferredTelemetryClient::new(
-        http_client_cell,
+        http_client.clone(),
         "https://telemetry.vercel.com",
         version,
     );
     match init_telemetry(deferred_client, color_config) {
-        Ok(h) => Some(h),
+        Ok((handle, enabled)) => {
+            if enabled {
+                http_client.activate();
+            }
+            Some(handle)
+        }
         Err(error) => {
             debug!("failed to start telemetry: {:?}", error);
             None
@@ -1323,26 +1308,7 @@ pub async fn run(
     query_server: Option<Arc<dyn turborepo_query_api::QueryServer>>,
 ) -> Result<i32, Error> {
     let _cli_run_span = tracing::info_span!("cli_run").entered();
-
-    // Spawn TLS initialization on a background thread immediately.
-    // This takes ~100ms (loading root certificates, TLS backend init)
-    // and runs fully in the background. Neither telemetry nor the run
-    // path block on it — the HTTP client is resolved lazily when the
-    // first network request is actually needed.
-    let http_client_cell = std::sync::Arc::new(tokio::sync::OnceCell::<reqwest::Client>::new());
-    {
-        let cell = http_client_cell.clone();
-        tokio::task::spawn(async move {
-            if let Ok(Ok(client)) = tokio::task::spawn_blocking(|| {
-                let _span = tracing::info_span!("http_client_init").entered();
-                APIClient::build_http_client(None)
-            })
-            .await
-            {
-                cell.set(client).ok();
-            }
-        });
-    }
+    let http_client = SharedHttpClient::new();
 
     let mut cli_args = {
         let _span = tracing::info_span!("cli_arg_parsing").entered();
@@ -1350,12 +1316,12 @@ pub async fn run(
     };
     let version = get_version();
 
-    // Initialize telemetry immediately with a deferred HTTP client.
-    // Events are queued to a channel from the start; the actual HTTP
-    // client is only resolved when the worker flushes its first batch.
+    // Initialize telemetry immediately so events are captured from startup.
+    // The shared HTTP client is only activated if telemetry is actually
+    // enabled for this invocation.
     let telemetry_handle = {
         let _span = tracing::info_span!("telemetry_init").entered();
-        initialize_deferred_telemetry_client(http_client_cell.clone(), color_config, version)
+        initialize_deferred_telemetry_client(http_client.clone(), color_config, version)
     };
 
     if should_print_version() {
@@ -1650,7 +1616,7 @@ pub async fn run(
             }
 
             run_args.track(&event);
-            let exit_code = run::run(base, event, http_client_cell, query_server.clone())
+            let exit_code = run::run(base, event, http_client, query_server.clone())
                 .await
                 .inspect(|code| {
                     if *code != 0 {

--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use tracing::error;
+use turborepo_api_client::SharedHttpClient;
 use turborepo_query_api::QueryServer;
 use turborepo_signals::{listeners::get_signal, SignalHandler};
 use turborepo_telemetry::events::command::CommandEventBuilder;
@@ -12,7 +13,7 @@ use crate::{commands::CommandBase, run, run::builder::RunBuilder};
 pub async fn run(
     base: CommandBase,
     telemetry: CommandEventBuilder,
-    http_client_cell: Arc<tokio::sync::OnceCell<reqwest::Client>>,
+    http_client: SharedHttpClient,
     query_server: Option<Arc<dyn QueryServer>>,
 ) -> Result<i32, run::Error> {
     let signal = get_signal()?;
@@ -20,7 +21,7 @@ pub async fn run(
 
     let mut run_builder = {
         let _span = tracing::info_span!("run_builder_new").entered();
-        RunBuilder::new(base, Some(http_client_cell))?
+        RunBuilder::new(base, Some(http_client))?
     };
     if let Some(qs) = query_server {
         run_builder = run_builder.with_query_server(qs);

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -2,14 +2,14 @@ use std::{
     collections::{HashMap, HashSet},
     io::{ErrorKind, IsTerminal},
     sync::Arc,
-    time::SystemTime,
+    time::{Duration, SystemTime},
 };
 
 use chrono::Local;
 use tracing::Instrument;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_analytics::{start_analytics, AnalyticsHandle};
-use turborepo_api_client::{APIAuth, APIClient};
+use turborepo_api_client::{APIAuth, APIClient, SharedHttpClient};
 use turborepo_cache::AsyncCache;
 use turborepo_env::EnvironmentVariableMap;
 use turborepo_errors::Spanned;
@@ -50,7 +50,7 @@ pub struct RunBuilder {
     repo_root: AbsoluteSystemPathBuf,
     color_config: ColorConfig,
     version: &'static str,
-    http_client_cell: Arc<tokio::sync::OnceCell<reqwest::Client>>,
+    http_client: SharedHttpClient,
     // In watch mode, we can have a changed package that we want to serve as an entrypoint.
     // We will then prune away any tasks that do not depend on tasks inside
     // this package.
@@ -70,12 +70,8 @@ pub struct RunBuilder {
 
 impl RunBuilder {
     #[tracing::instrument(skip_all)]
-    pub fn new(
-        base: CommandBase,
-        http_client_cell: Option<Arc<tokio::sync::OnceCell<reqwest::Client>>>,
-    ) -> Result<Self, Error> {
-        let http_client_cell =
-            http_client_cell.unwrap_or_else(|| Arc::new(tokio::sync::OnceCell::new()));
+    pub fn new(base: CommandBase, http_client: Option<SharedHttpClient>) -> Result<Self, Error> {
+        let http_client = http_client.unwrap_or_default();
         let opts = base.opts();
         let api_auth = base.api_auth()?;
 
@@ -98,7 +94,7 @@ impl RunBuilder {
         Ok(Self {
             processes,
             opts,
-            http_client_cell,
+            http_client,
             repo_root,
             color_config: ui,
             version,
@@ -147,6 +143,33 @@ impl RunBuilder {
 
     fn will_execute_tasks(&self) -> bool {
         self.opts.run_opts.dry_run.is_none() && self.opts.run_opts.graph.is_none()
+    }
+
+    fn should_initialize_http_client(&self) -> bool {
+        self.api_auth.as_ref().is_some_and(APIAuth::is_linked)
+            || (self.opts.cache_opts.cache.remote.should_use() && self.api_auth.is_some())
+    }
+
+    fn api_client_from_http(&self, http_client: reqwest::Client) -> APIClient {
+        let timeout = self.opts.api_client_opts.timeout;
+        let upload_timeout = self.opts.api_client_opts.upload_timeout;
+
+        APIClient::new_with_client(
+            http_client,
+            &self.opts.api_client_opts.api_url,
+            if timeout > 0 {
+                Some(Duration::from_secs(timeout))
+            } else {
+                None
+            },
+            if upload_timeout > 0 {
+                Some(Duration::from_secs(upload_timeout))
+            } else {
+                None
+            },
+            self.version,
+            self.opts.api_client_opts.preflight,
+        )
     }
 
     pub fn calculate_filtered_packages(
@@ -269,6 +292,10 @@ impl RunBuilder {
         // `turbo watch` which connects independently.
         run_telemetry.track_daemon_init(DaemonInitStatus::Disabled);
 
+        if self.should_initialize_http_client() {
+            self.http_client.activate();
+        }
+
         let mut pkg_dep_graph = {
             let builder = PackageGraph::builder(&self.repo_root, root_package_json.clone())
                 .with_single_package_mode(self.opts.run_opts.single_package)
@@ -318,42 +345,24 @@ impl RunBuilder {
         // inference, and turbo.json preloading overlap with git index
         // construction and untracked-file discovery.
 
-        // Resolve the HTTP client. TLS initialization has been running in the
-        // background since cli::run started, overlapping with arg parsing,
-        // config loading, package graph construction, and SCM indexing.
-        let api_client = {
+        let api_client = if self.should_initialize_http_client() {
             let _span = tracing::info_span!("resolve_api_client").entered();
-            let http_client = match self.http_client_cell.get() {
-                Some(client) => client.clone(),
-                None => tokio::task::spawn_blocking(|| APIClient::build_http_client(None))
-                    .await
-                    .map_err(|_| turborepo_api_client::Error::HttpClientCancelled)??,
-            };
-            let timeout = self.opts.api_client_opts.timeout;
-            let upload_timeout = self.opts.api_client_opts.upload_timeout;
-            APIClient::new_with_client(
-                http_client.clone(),
-                &self.opts.api_client_opts.api_url,
-                if timeout > 0 {
-                    Some(std::time::Duration::from_secs(timeout))
-                } else {
-                    None
-                },
-                if upload_timeout > 0 {
-                    Some(std::time::Duration::from_secs(upload_timeout))
-                } else {
-                    None
-                },
-                self.version,
-                self.opts.api_client_opts.preflight,
-            )
+            let http_client = self.http_client.get_or_init().await?;
+            Some(self.api_client_from_http(http_client))
+        } else {
+            None
         };
 
         let (analytics_sender, analytics_handle) = self
             .api_auth
             .as_ref()
             .filter(|auth| auth.is_linked())
-            .map(|auth| start_analytics(auth.clone(), api_client.clone()))
+            .map(|auth| {
+                let api_client = api_client
+                    .clone()
+                    .expect("linked analytics require a resolved API client");
+                start_analytics(auth.clone(), api_client)
+            })
             .unzip();
 
         let async_cache = {
@@ -523,7 +532,6 @@ impl RunBuilder {
                 task_access,
                 repo_root: self.repo_root,
                 opts: Arc::new(self.opts),
-                api_client,
                 api_auth: self.api_auth,
                 env_at_execution_start,
                 filtered_pkgs: filtered_pkgs.keys().cloned().collect(),

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -23,7 +23,7 @@ use shared_child::SharedChild;
 use tokio::{pin, select, task::JoinHandle};
 use tracing::{debug, error, info, instrument, warn};
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
-use turborepo_api_client::{APIAuth, APIClient};
+use turborepo_api_client::APIAuth;
 use turborepo_ci::Vendor;
 use turborepo_env::EnvironmentVariableMap;
 use turborepo_microfrontends_proxy::ProxyServer;
@@ -63,7 +63,6 @@ pub struct Run {
     run_telemetry: GenericEventBuilder,
     repo_root: AbsoluteSystemPathBuf,
     opts: Arc<Opts>,
-    api_client: APIClient,
     api_auth: Option<APIAuth>,
     env_at_execution_start: EnvironmentVariableMap,
     filtered_pkgs: HashSet<PackageName>,

--- a/crates/turborepo-telemetry/src/lib.rs
+++ b/crates/turborepo-telemetry/src/lib.rs
@@ -79,10 +79,11 @@ fn init(
     mut config: TelemetryConfig,
     client: impl telemetry::TelemetryClient + Clone + Send + Sync + 'static,
     color_config: ColorConfig,
-) -> Result<(TelemetryHandle, TelemetrySender), Box<dyn std::error::Error>> {
+) -> Result<(TelemetryHandle, TelemetrySender, bool), Box<dyn std::error::Error>> {
     let (tx, rx) = mpsc::unbounded_channel();
     let (cancel_tx, cancel_rx) = oneshot::channel();
     config.show_alert(color_config);
+    let enabled = config.is_enabled();
 
     let session_id = Uuid::new_v4();
     let worker = Worker {
@@ -92,7 +93,7 @@ fn init(
         client,
         session_id: session_id.to_string(),
         telemetry_id: config.get_id().to_string(),
-        enabled: config.is_enabled(),
+        enabled,
         color_config,
     };
     let handle = worker.start();
@@ -103,7 +104,7 @@ fn init(
     };
 
     // return
-    Ok((telemetry_handle, tx))
+    Ok((telemetry_handle, tx, enabled))
 }
 
 /// Starts the `Worker` on a separate tokio thread. Returns an `TelemetrySender`
@@ -115,16 +116,16 @@ fn init(
 pub fn init_telemetry(
     client: impl telemetry::TelemetryClient + Clone + Send + Sync + 'static,
     color_config: ColorConfig,
-) -> Result<TelemetryHandle, Box<dyn std::error::Error>> {
+) -> Result<(TelemetryHandle, bool), Box<dyn std::error::Error>> {
     // make sure we're not already initialized
     if SENDER_INSTANCE.get().is_some() {
         debug!("telemetry already initialized");
         return Err(Box::new(Error::AlreadyInitialized()));
     }
     let config = TelemetryConfig::with_default_config_path()?;
-    let (handle, sender) = init(config, client, color_config)?;
+    let (handle, sender, enabled) = init(config, client, color_config)?;
     SENDER_INSTANCE.set(sender).unwrap();
-    Ok(handle)
+    Ok((handle, enabled))
 }
 
 impl TelemetryHandle {
@@ -334,7 +335,7 @@ mod tests {
 
         let result = init(config, client.clone(), ColorConfig::new(false));
 
-        let (telemetry_handle, telemetry_sender) = result.unwrap();
+        let (telemetry_handle, telemetry_sender, _) = result.unwrap();
 
         for _ in 0..2 {
             telemetry_sender
@@ -374,7 +375,7 @@ mod tests {
 
         let result = init(config, client.clone(), ColorConfig::new(false));
 
-        let (telemetry_handle, telemetry_sender) = result.unwrap();
+        let (telemetry_handle, telemetry_sender, _) = result.unwrap();
 
         for _ in 0..12 {
             telemetry_sender
@@ -428,7 +429,7 @@ mod tests {
                 .unwrap();
 
         let result = init(config, SlowClient, ColorConfig::new(false));
-        let (telemetry_handle, telemetry_sender) = result.unwrap();
+        let (telemetry_handle, telemetry_sender, _) = result.unwrap();
 
         for _ in 0..2 {
             telemetry_sender
@@ -464,7 +465,7 @@ mod tests {
 
         let result = init(config, client.clone(), ColorConfig::new(false));
 
-        let (telemetry_handle, telemetry_sender) = result.unwrap();
+        let (telemetry_handle, telemetry_sender, _) = result.unwrap();
 
         for _ in 0..2 {
             telemetry_sender

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -31,6 +31,8 @@ A run consists of the following steps:
 - Task filtering based on arguments (task names and `--filter`)
 - Task graph construction and validation
 - Cache setup (local and remote)
+- Activating shared HTTP client initialization once telemetry, remote cache, or
+  linked analytics are known to be needed
 - Producing a final `Run` struct ready for execution
 
 ### 2. Package Graph (`crates/turborepo-repository/src/package_graph/`)
@@ -121,6 +123,23 @@ Multi-layered caching system:
 - `RunCache`: High-level cache coordination
 - `TaskCache`: Individual task cache management
 - `AsyncCache`: Handles async cache operations. Supports both local filesystem and remote HTTP caches
+- `SharedHttpClient`: Process-wide lazy/activatable `reqwest::Client`
+  initialization shared by telemetry and remote-cache consumers
+
+#### Shared HTTP Client Initialization
+
+Network consumers do not construct an HTTP client speculatively at process
+startup. Instead:
+
+1. The CLI and run builder determine whether telemetry, remote cache, or linked
+   analytics will actually need networking for the current invocation
+2. Once that need is known, they activate shared client initialization
+   immediately so TLS setup overlaps with other startup work
+3. Telemetry flushes and remote-cache operations both reuse the same initialized
+   `reqwest::Client`
+
+This avoids paying client/TLS setup on invocations with no network use while
+still warming the client before the first network request in the common case.
 
 #### Worktree Cache Sharing
 


### PR DESCRIPTION
## Summary
- Add a shared activatable HTTP client so telemetry and run/cache code reuse a single reqwest client
- Stop unconditionally warming the HTTP client at CLI startup and only activate it once a network capability is known to be needed
- Allow local-only cache setup to avoid constructing an API client and document the new startup behavior