### PR TITLE
perf: Scope Repo Index Untracked Discovery

### DIFF
--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -7,7 +7,7 @@ use std::{
 
 use chrono::Local;
 use tracing::Instrument;
-use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, RelativeUnixPathBuf};
 use turborepo_analytics::{start_analytics, AnalyticsHandle};
 use turborepo_api_client::{APIAuth, APIClient, SharedHttpClient};
 use turborepo_cache::AsyncCache;
@@ -172,6 +172,26 @@ impl RunBuilder {
         )
     }
 
+    fn repo_index_untracked_prefixes(
+        pkg_dep_graph: &PackageGraph,
+        filtered_pkgs: &HashMap<PackageName, PackageInclusionReason>,
+    ) -> Vec<RelativeUnixPathBuf> {
+        let mut prefixes = filtered_pkgs
+            .keys()
+            .filter_map(|package| pkg_dep_graph.package_dir(package))
+            .map(|package_dir| package_dir.to_unix())
+            .collect::<Vec<_>>();
+
+        prefixes.extend(
+            pkg_dep_graph
+                .root_internal_package_dependencies_paths()
+                .into_iter()
+                .map(|package_dir| package_dir.to_unix()),
+        );
+
+        prefixes
+    }
+
     pub fn calculate_filtered_packages(
         repo_root: &AbsoluteSystemPath,
         opts: &Opts,
@@ -252,7 +272,7 @@ impl RunBuilder {
                     Some(root) => SCM::new_with_git_root(&repo_root, root),
                     None => SCM::new(&repo_root),
                 };
-                let repo_index = scm.build_repo_index_eager();
+                let repo_index = scm.build_tracked_repo_index_eager();
                 (scm, repo_index)
             })
         };
@@ -339,11 +359,10 @@ impl RunBuilder {
         };
 
         // SCM-independent work runs while the background scm_task continues.
-        // The await is deferred until just before the first consumer
-        // (task_access_setup / calculate_filtered_packages), letting API
-        // client resolution, cache init, turbo.json loading, validation, env
-        // inference, and turbo.json preloading overlap with git index
-        // construction and untracked-file discovery.
+        // The await is deferred until just before the first SCM consumer,
+        // letting API client resolution, cache init, turbo.json loading,
+        // validation, env inference, and turbo.json preloading overlap with
+        // tracked git-index construction.
 
         let api_client = if self.should_initialize_http_client() {
             let _span = tracing::info_span!("resolve_api_client").entered();
@@ -439,20 +458,12 @@ impl RunBuilder {
             turbo_json_loader.preload_all();
         }
 
-        // Await the SCM background task. Everything above ran while git index
-        // construction + untracked-file discovery continued in the background.
+        // Await the SCM background task. Everything above ran while tracked
+        // git-index construction continued in the background.
         let (scm, repo_index) = scm_task
             .instrument(tracing::info_span!("scm_task_await"))
             .await
             .expect("detecting scm panicked");
-        let repo_index = Arc::new(repo_index);
-
-        let task_access = {
-            let _span = tracing::info_span!("task_access_setup").entered();
-            let ta = TaskAccess::new(self.repo_root.clone(), async_cache.clone(), &scm);
-            ta.restore_config().await;
-            ta
-        };
 
         let filtered_pkgs = {
             let _span = tracing::info_span!("calculate_filtered_packages").entered();
@@ -463,6 +474,37 @@ impl RunBuilder {
                 &scm,
                 &root_turbo_json,
             )?
+        };
+        let repo_index_task = repo_index.and_then(|repo_index| {
+            let scoped_prefixes =
+                Self::repo_index_untracked_prefixes(&pkg_dep_graph, &filtered_pkgs);
+            if scoped_prefixes.is_empty() {
+                return None;
+            }
+
+            let scm = scm.clone();
+            Some(tokio::task::spawn_blocking(move || {
+                let _span = tracing::info_span!("repo_index_scope_untracked").entered();
+                let mut repo_index = repo_index;
+                match scm.populate_repo_index_untracked(&mut repo_index, &scoped_prefixes) {
+                    Ok(()) => Some(repo_index),
+                    Err(err) => {
+                        tracing::debug!(
+                            "failed to scope repo git index with untracked files: {}. Will hash \
+                             per-package.",
+                            err,
+                        );
+                        None
+                    }
+                }
+            }))
+        });
+
+        let task_access = {
+            let _span = tracing::info_span!("task_access_setup").entered();
+            let ta = TaskAccess::new(self.repo_root.clone(), async_cache.clone(), &scm);
+            ta.restore_config().await;
+            ta
         };
 
         let mut engine = self.build_engine(
@@ -522,6 +564,13 @@ impl RunBuilder {
                     .flatten();
                 observability::Handle::try_init(opts, token)
             });
+        let repo_index = Arc::new(match repo_index_task {
+            Some(repo_index_task) => repo_index_task
+                .instrument(tracing::info_span!("repo_index_untracked_await"))
+                .await
+                .expect("scoping repo index panicked"),
+            None => None,
+        });
         Ok((
             Run {
                 version: self.version,

--- a/crates/turborepo-scm/src/git_index_regression_tests.rs
+++ b/crates/turborepo-scm/src/git_index_regression_tests.rs
@@ -61,11 +61,32 @@ impl TestRepo {
             .expect("failed to build repo index")
     }
 
+    fn build_scoped_repo_index(&self, prefixes: &[&str]) -> RepoGitIndex {
+        let scm = self.scm();
+        let mut index = scm
+            .build_tracked_repo_index_eager()
+            .expect("failed to build tracked repo index");
+        let prefixes = prefixes
+            .iter()
+            .map(|prefix| path(prefix))
+            .collect::<Vec<_>>();
+        scm.populate_repo_index_untracked(&mut index, &prefixes)
+            .expect("failed to scope repo index");
+        index
+    }
+
     fn get_hashes(&self, package_path: &str) -> GitHashes {
         let scm = self.scm();
         let pkg = AnchoredSystemPathBuf::from_raw(package_path).unwrap();
         let index = self.build_repo_index();
         scm.get_package_file_hashes::<&str>(&self.root, &pkg, &[], false, None, Some(&index))
+            .unwrap()
+    }
+
+    fn get_hashes_with_index(&self, package_path: &str, index: &RepoGitIndex) -> GitHashes {
+        let scm = self.scm();
+        let pkg = AnchoredSystemPathBuf::from_raw(package_path).unwrap();
+        scm.get_package_file_hashes::<&str>(&self.root, &pkg, &[], false, None, Some(index))
             .unwrap()
     }
 
@@ -220,6 +241,59 @@ fn test_untracked_files_detected() {
     assert_eq!(hashes.len(), 3);
     assert!(hashes.contains_key(&path("untracked.ts")));
     assert!(hashes.contains_key(&path("committed.ts")));
+}
+
+#[test]
+fn test_scoped_untracked_files_only_include_selected_package() {
+    let repo = TestRepo::new();
+
+    repo.create_file("pkg-a/committed.ts", "committed a");
+    repo.create_file("pkg-a/package.json", "{}");
+    repo.create_file("pkg-b/committed.ts", "committed b");
+    repo.create_file("pkg-b/package.json", "{}");
+    repo.commit_all();
+
+    repo.create_file("pkg-a/untracked-a.ts", "new a");
+    repo.create_file("pkg-b/untracked-b.ts", "new b");
+
+    let index = repo.build_scoped_repo_index(&["pkg-a"]);
+
+    let pkg_a_hashes = repo.get_hashes_with_index("pkg-a", &index);
+    let pkg_a_no_index = repo.get_hashes_no_index("pkg-a");
+    assert_eq!(pkg_a_hashes, pkg_a_no_index);
+    assert!(pkg_a_hashes.contains_key(&path("untracked-a.ts")));
+
+    let pkg_b_hashes = repo.get_hashes_with_index("pkg-b", &index);
+    assert!(
+        !pkg_b_hashes.contains_key(&path("untracked-b.ts")),
+        "scoped repo index should not include untracked files for packages outside the selected \
+         scope"
+    );
+}
+
+#[test]
+fn test_scoped_untracked_files_respect_ancestor_gitignore() {
+    let repo = TestRepo::new();
+
+    repo.create_file("apps/web/src/index.ts", "code");
+    repo.create_file("apps/web/package.json", "{}");
+    repo.commit_all();
+
+    repo.create_file("apps/.gitignore", "ignored.ts\n");
+    repo.create_file("apps/web/keep.ts", "keep");
+    repo.create_file("apps/web/ignored.ts", "ignore");
+
+    let index = repo.build_scoped_repo_index(&["apps/web"]);
+
+    let hashes = repo.get_hashes_with_index("apps/web", &index);
+    assert!(hashes.contains_key(&path("keep.ts")));
+    assert!(
+        !hashes.contains_key(&path("ignored.ts")),
+        "ancestor .gitignore files discovered during the scoped walk should still apply"
+    );
+
+    let hashes_no_index = repo.get_hashes_no_index("apps/web");
+    assert_eq!(hashes, hashes_no_index);
 }
 
 #[test]

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -369,6 +369,42 @@ impl SCM {
             SCM::Manual => None,
         }
     }
+
+    /// Build only the tracked portion of the repo index.
+    ///
+    /// This is intended for speculative startup work on the `turbo run` path.
+    /// Untracked-file discovery can be layered on later once the selected
+    /// package set is known.
+    pub fn build_tracked_repo_index_eager(&self) -> Option<RepoGitIndex> {
+        match self {
+            SCM::Git(git) => match RepoGitIndex::new_tracked(git) {
+                Ok(index) => {
+                    debug!("tracked repo git index built eagerly");
+                    Some(index)
+                }
+                Err(e) => {
+                    debug!(
+                        "failed to build tracked repo git index eagerly: {}. Will hash \
+                         per-package.",
+                        e,
+                    );
+                    None
+                }
+            },
+            SCM::Manual => None,
+        }
+    }
+
+    pub fn populate_repo_index_untracked(
+        &self,
+        repo_index: &mut RepoGitIndex,
+        prefixes: &[RelativeUnixPathBuf],
+    ) -> Result<(), Error> {
+        match self {
+            SCM::Git(git) => repo_index.populate_untracked_for_prefixes(git, prefixes),
+            SCM::Manual => Ok(()),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/turborepo-scm/src/repo_index.rs
+++ b/crates/turborepo-scm/src/repo_index.rs
@@ -17,11 +17,19 @@ pub struct RepoGitIndex {
     /// Sorted by path so per-package filtering can use binary-search range
     /// queries instead of linear scans.
     status_entries: Vec<RepoStatusEntry>,
+    untracked_entries_populated: bool,
 }
 
 impl RepoGitIndex {
     #[tracing::instrument(skip(git))]
     pub fn new(git: &GitRepo) -> Result<Self, Error> {
+        let mut index = Self::new_tracked(git)?;
+        index.populate_all_untracked(git)?;
+        Ok(index)
+    }
+
+    #[tracing::instrument(skip(git))]
+    pub fn new_tracked(git: &GitRepo) -> Result<Self, Error> {
         Self::new_from_gix_index(git)
     }
 
@@ -30,8 +38,8 @@ impl RepoGitIndex {
     /// This replaces both `git ls-tree` and `git status` with a single
     /// operation: reading the index file gives us committed blob OIDs, and
     /// stat-comparing each entry against the filesystem tells us which files
-    /// are modified or deleted. Untracked files are detected by a parallel
-    /// walk of the working tree respecting .gitignore.
+    /// are modified or deleted. Untracked files can be layered on later once
+    /// the caller knows which package prefixes actually need them.
     ///
     /// Racy-git entries (where mtime >= index timestamp, so we can't trust
     /// the stat comparison) are deferred to per-package hashing rather than
@@ -153,18 +161,8 @@ impl RepoGitIndex {
         // directly on &[RepoStatusEntry] without cloning paths into Strings.
         status_entries.sort_by(|a, b| a.path.cmp(&b.path));
 
-        let untracked = find_untracked_files(git, &ls_tree_hashes, &status_entries)?;
-        for path in untracked {
-            status_entries.push(RepoStatusEntry {
-                path,
-                is_delete: false,
-            });
-        }
-
-        status_entries.sort_by(|a, b| a.path.cmp(&b.path));
-
         debug!(
-            "built repo git index (gix-index): clean_count={}, status_count={}",
+            "built tracked repo git index (gix-index): clean_count={}, status_count={}",
             ls_tree_hashes.len(),
             status_entries.len(),
         );
@@ -172,7 +170,59 @@ impl RepoGitIndex {
         Ok(Self {
             ls_tree_hashes,
             status_entries,
+            untracked_entries_populated: false,
         })
+    }
+
+    #[tracing::instrument(skip(self, git))]
+    pub fn populate_all_untracked(&mut self, git: &GitRepo) -> Result<(), Error> {
+        self.populate_untracked(git, None)
+    }
+
+    #[tracing::instrument(skip(self, git, prefixes))]
+    pub fn populate_untracked_for_prefixes(
+        &mut self,
+        git: &GitRepo,
+        prefixes: &[RelativeUnixPathBuf],
+    ) -> Result<(), Error> {
+        if prefixes.is_empty() {
+            return Ok(());
+        }
+
+        self.populate_untracked(git, Some(prefixes))
+    }
+
+    fn populate_untracked(
+        &mut self,
+        git: &GitRepo,
+        prefixes: Option<&[RelativeUnixPathBuf]>,
+    ) -> Result<(), Error> {
+        if self.untracked_entries_populated {
+            return Ok(());
+        }
+
+        let before_status_count = self.status_entries.len();
+        let untracked =
+            find_untracked_files(git, &self.ls_tree_hashes, &self.status_entries, prefixes)?;
+        for path in untracked {
+            self.status_entries.push(RepoStatusEntry {
+                path,
+                is_delete: false,
+            });
+        }
+
+        self.status_entries.sort_by(|a, b| a.path.cmp(&b.path));
+        self.untracked_entries_populated = true;
+
+        debug!(
+            "populated repo git index with untracked files: added_count={}, status_count={}",
+            self.status_entries
+                .len()
+                .saturating_sub(before_status_count),
+            self.status_entries.len(),
+        );
+
+        Ok(())
     }
 
     /// Extract hashes for a single package from the cached repo-wide data.
@@ -262,21 +312,27 @@ impl RepoGitIndex {
 /// `ls_tree_hashes` and `status_entries` slices — no intermediate
 /// allocations needed.
 ///
+/// When `prefixes` is provided, the walker prunes subtrees outside the
+/// requested package prefixes while still visiting ancestor `.gitignore`
+/// files that can affect those prefixes.
+///
 /// IMPORTANT: `status_entries` must be sorted by path before calling.
 ///
 /// Each walker thread accumulates results in a thread-local Vec and
 /// batch-sends them through a channel, avoiding per-file mutex contention.
-#[tracing::instrument(skip(git, ls_tree_hashes, status_entries))]
+#[tracing::instrument(skip(git, ls_tree_hashes, status_entries, prefixes))]
 fn find_untracked_files(
     git: &GitRepo,
     ls_tree_hashes: &SortedGitHashes,
     status_entries: &[RepoStatusEntry],
+    prefixes: Option<&[RelativeUnixPathBuf]>,
 ) -> Result<Vec<RelativeUnixPathBuf>, Error> {
     use std::sync::mpsc;
 
     use ignore::WalkBuilder;
 
-    let root = git.root.as_std_path();
+    let root = std::sync::Arc::new(git.root.as_std_path().to_path_buf());
+    let scope = std::sync::Arc::new(UntrackedScope::new(prefixes));
 
     // Pre-build gitignore matchers from all tracked .gitignore files.
     // Each .gitignore is built with a builder rooted at its containing
@@ -286,7 +342,7 @@ fn find_untracked_files(
         let mut matchers: Vec<ignore::gitignore::Gitignore> = Vec::new();
 
         // Global gitignore + .git/info/exclude are rooted at the repo root
-        let mut root_builder = ignore::gitignore::GitignoreBuilder::new(root);
+        let mut root_builder = ignore::gitignore::GitignoreBuilder::new(root.as_path());
         let mut has_root_rules = false;
         if let Some(global_path) = ignore::gitignore::gitconfig_excludes_path()
             && global_path.exists()
@@ -307,8 +363,8 @@ fn find_untracked_files(
                 if !abs_path.exists() {
                     continue;
                 }
-                let gi_dir = abs_path.parent().unwrap_or(root);
-                if gi_dir == root {
+                let gi_dir = abs_path.parent().unwrap_or(root.as_path());
+                if gi_dir == root.as_path() {
                     // Root .gitignore goes into the root builder alongside
                     // global and info/exclude rules
                     let _ = root_builder.add(&abs_path);
@@ -341,7 +397,7 @@ fn find_untracked_files(
 
     // Disable ALL per-directory probing. Gitignore rules are applied via
     // filter_entry using the pre-built matcher above.
-    let walker = WalkBuilder::new(root)
+    let walker = WalkBuilder::new(root.as_path())
         .follow_links(false)
         .git_ignore(false)
         .git_exclude(false)
@@ -351,12 +407,38 @@ fn find_untracked_files(
         .hidden(false)
         .filter_entry({
             let matchers = gitignore_matchers.clone();
+            let root = root.clone();
+            let scope = scope.clone();
             move |entry| {
                 if entry.file_name() == ".git" {
                     return false;
                 }
                 let is_dir = entry.file_type().is_some_and(|ft| ft.is_dir());
                 let path = entry.path();
+
+                let rel_path = match path.strip_prefix(root.as_path()) {
+                    Ok(rel) => rel,
+                    Err(_) => return false,
+                };
+                #[cfg(windows)]
+                let rel_path_owned = rel_path.to_string_lossy().replace('\\', "/");
+                #[cfg(windows)]
+                let rel_path = rel_path_owned.as_str();
+                #[cfg(not(windows))]
+                let rel_path = match rel_path.to_str() {
+                    Some(rel) => rel,
+                    None => return false,
+                };
+
+                let in_scope = if is_dir {
+                    scope.should_visit_dir(rel_path)
+                } else {
+                    scope.should_consider_file(rel_path, entry.file_name() == ".gitignore")
+                };
+                if !in_scope {
+                    return false;
+                }
+
                 // Check against all pre-built gitignore matchers. For
                 // directories, returning false prunes the entire subtree.
                 // Only check matchers whose root is a prefix of the entry
@@ -386,6 +468,7 @@ fn find_untracked_files(
     }
 
     walker.run(|| {
+        let root = root.clone();
         let mut guard = FlushOnDrop {
             buf: Vec::new(),
             tx: tx.clone(),
@@ -405,7 +488,7 @@ fn find_untracked_files(
             }
 
             let abs_path = entry.into_path();
-            let rel_path = match abs_path.strip_prefix(root) {
+            let rel_path = match abs_path.strip_prefix(root.as_path()) {
                 Ok(rel) => rel,
                 Err(_) => return ignore::WalkState::Continue,
             };
@@ -456,7 +539,7 @@ fn find_untracked_files(
         let mut extra_matchers: Vec<ignore::gitignore::Gitignore> = Vec::new();
         for gi_path in &untracked_gitignores {
             let abs = root.join(gi_path.as_str());
-            let gi_dir = abs.parent().unwrap_or(root);
+            let gi_dir = abs.parent().unwrap_or(root.as_path());
             let mut builder = ignore::gitignore::GitignoreBuilder::new(gi_dir);
             let _ = builder.add(&abs);
             if let Ok(gi) = builder.build()
@@ -480,6 +563,95 @@ fn find_untracked_files(
     }
 
     Ok(untracked)
+}
+
+#[derive(Debug, Clone)]
+struct UntrackedScope {
+    prefixes: Vec<String>,
+    is_full_walk: bool,
+}
+
+impl UntrackedScope {
+    fn new(prefixes: Option<&[RelativeUnixPathBuf]>) -> Self {
+        let Some(prefixes) = prefixes else {
+            return Self {
+                prefixes: Vec::new(),
+                is_full_walk: true,
+            };
+        };
+
+        if prefixes.iter().any(|prefix| prefix.as_str().is_empty()) {
+            return Self {
+                prefixes: Vec::new(),
+                is_full_walk: true,
+            };
+        }
+
+        let mut normalized = prefixes
+            .iter()
+            .map(|prefix| prefix.as_str().to_string())
+            .collect::<Vec<_>>();
+        normalized.sort_unstable();
+        normalized.dedup();
+
+        let mut scoped: Vec<String> = Vec::with_capacity(normalized.len());
+        for prefix in normalized {
+            if scoped
+                .iter()
+                .any(|existing| prefix == *existing || is_nested_path(&prefix, existing))
+            {
+                continue;
+            }
+            scoped.push(prefix);
+        }
+
+        Self {
+            prefixes: scoped,
+            is_full_walk: false,
+        }
+    }
+
+    fn should_visit_dir(&self, rel_path: &str) -> bool {
+        if self.is_full_walk || rel_path.is_empty() {
+            return true;
+        }
+
+        self.prefixes.iter().any(|prefix| {
+            rel_path == prefix
+                || is_nested_path(rel_path, prefix)
+                || is_nested_path(prefix, rel_path)
+        })
+    }
+
+    fn should_consider_file(&self, rel_path: &str, is_gitignore: bool) -> bool {
+        if self.is_full_walk || self.is_within_selected_prefix(rel_path) {
+            return true;
+        }
+
+        is_gitignore && self.should_visit_dir(parent_path(rel_path))
+    }
+
+    fn is_within_selected_prefix(&self, rel_path: &str) -> bool {
+        if self.is_full_walk {
+            return true;
+        }
+
+        self.prefixes
+            .iter()
+            .any(|prefix| rel_path == prefix || is_nested_path(rel_path, prefix))
+    }
+}
+
+fn is_nested_path(path: &str, prefix: &str) -> bool {
+    path.len() > prefix.len()
+        && path.starts_with(prefix)
+        && path.as_bytes().get(prefix.len()) == Some(&b'/')
+}
+
+fn parent_path(path: &str) -> &str {
+    path.rsplit_once('/')
+        .map(|(parent, _)| parent)
+        .unwrap_or("")
 }
 
 enum EntryClassification {
@@ -528,6 +700,7 @@ mod tests {
         RepoGitIndex {
             ls_tree_hashes,
             status_entries,
+            untracked_entries_populated: true,
         }
     }
 

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -33,6 +33,8 @@ A run consists of the following steps:
 - Cache setup (local and remote)
 - Activating shared HTTP client initialization once telemetry, remote cache, or
   linked analytics are known to be needed
+- Building a tracked repo index eagerly, then augmenting it with scoped
+  untracked-file discovery once the selected package set is known
 - Producing a final `Run` struct ready for execution
 
 ### 2. Package Graph (`crates/turborepo-repository/src/package_graph/`)
@@ -140,6 +142,20 @@ startup. Instead:
 
 This avoids paying client/TLS setup on invocations with no network use while
 still warming the client before the first network request in the common case.
+
+#### Two-Stage Repo Index Construction
+
+`turbo run` builds SCM state in two stages:
+
+1. A background startup task reads `.git/index` and records committed blob IDs
+   plus modified/deleted tracked files for the whole repo
+2. After package filtering finishes, Turborepo computes the package roots it
+   actually needs for hashing and augments that tracked index with untracked
+   files only for those prefixes
+
+This keeps the cheap tracked-index work overlapped with other startup work while
+avoiding a repo-wide untracked walk when only a subset of packages will be
+hashed.
 
 #### Worktree Cache Sharing
 


### PR DESCRIPTION
## Summary
- split repo index construction into a tracked phase and a scoped untracked augmentation phase
- build the tracked index eagerly during run startup, then scope untracked discovery to the filtered package roots plus root internal dependency packages
- prune the untracked walker outside selected prefixes while still honoring ancestor and nested `.gitignore` files, and document the two-stage SCM flow

Release profiles show `find_untracked_files` dropping:
| Before | After | % change |
|--------|--------|--------|
| 47.9ms | 38.5ms | 19.62% |

Note that this % change is only for this span in the profile.