### PR TITLE
perf: Decouple filesystem walk from git index construction

### DIFF
--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -262,7 +262,9 @@ impl RunBuilder {
         let start_at = Local::now();
 
         let (tracked_index_tx, tracked_index_rx) =
-            tokio::sync::oneshot::channel::<(SCM, Option<turborepo_scm::RepoGitIndex>)>();
+            tokio::sync::oneshot::channel::<Option<turborepo_scm::RepoGitIndex>>();
+        let (git_root_tx, git_root_rx) =
+            tokio::sync::oneshot::channel::<Option<turbopath::AbsoluteSystemPathBuf>>();
         let scm_task = {
             let repo_root = self.repo_root.clone();
             let git_root = self.opts.git_root.clone();
@@ -271,8 +273,11 @@ impl RunBuilder {
                     Some(root) => SCM::new_with_git_root(&repo_root, root),
                     None => SCM::new(&repo_root),
                 };
+                // Send git root immediately so the filesystem walk can start
+                // while index construction continues.
+                let _ = git_root_tx.send(scm.git_root().map(|r| r.to_owned()));
                 let repo_index = scm.build_tracked_repo_index_eager();
-                let _ = tracked_index_tx.send((scm.clone(), repo_index));
+                let _ = tracked_index_tx.send(repo_index);
                 scm
             })
         };
@@ -349,40 +354,39 @@ impl RunBuilder {
         repo_telemetry.track_size(pkg_dep_graph.len());
         run_telemetry.track_run_type(self.opts.run_opts.dry_run.is_some());
 
-        // Spawn the untracked-file walk as soon as the package graph is ready.
-        // We use all-package prefixes (superset of any filtered selection) so
-        // the walk can start before filter resolution. Per-package hash queries
-        // use binary-search range scoping, so extra untracked files outside a
-        // queried package are never returned.
+        // Spawn the filesystem walk as soon as the git root is resolved.
+        // It only needs the git root and package prefixes, not the tracked
+        // index. The walk runs in parallel with new_from_gix_index (~267ms).
         let all_prefixes = Self::all_package_prefixes(&pkg_dep_graph);
-        let repo_index_task = if all_prefixes.is_empty() {
+        let walk_task = if all_prefixes.is_empty() {
             None
         } else {
             Some(tokio::task::spawn(async move {
-                let (scm, tracked_index) = match tracked_index_rx.await {
-                    Ok(pair) => pair,
-                    Err(_) => return None,
+                let git_root = match git_root_rx.await {
+                    Ok(Some(root)) => root,
+                    _ => return None,
                 };
-                let tracked_index = tracked_index?;
                 tokio::task::spawn_blocking(move || {
-                    let _span = tracing::info_span!("repo_index_scope_untracked").entered();
-                    let mut repo_index = tracked_index;
-                    match scm.populate_repo_index_untracked(&mut repo_index, &all_prefixes) {
-                        Ok(()) => Some(repo_index),
-                        Err(err) => {
-                            tracing::debug!(
-                                "failed to scope repo git index with untracked files: {}. Will \
-                                 hash per-package.",
-                                err,
-                            );
-                            None
-                        }
-                    }
+                    let _span = tracing::info_span!("walk_candidate_files").entered();
+                    turborepo_scm::walk_candidate_files(git_root.as_std_path(), Some(&all_prefixes))
+                        .ok()
                 })
                 .await
                 .ok()?
             }))
         };
+
+        // Combine the walk results with the tracked index once both are ready.
+        let repo_index_task = walk_task.map(|walk_task| {
+            tokio::task::spawn(async move {
+                let (candidates, tracked_index) = tokio::join!(walk_task, tracked_index_rx);
+                let candidates = candidates.ok()??;
+                let tracked_index = tracked_index.ok()??;
+                let mut repo_index = tracked_index;
+                repo_index.populate_untracked_from_candidates(candidates);
+                Some(repo_index)
+            })
+        });
         let micro_frontend_configs = {
             let _span = tracing::info_span!("micro_frontends_from_disk").entered();
             match MicrofrontendsConfigs::from_disk(&self.repo_root, &pkg_dep_graph) {

--- a/crates/turborepo-scm/src/git_index_regression_tests.rs
+++ b/crates/turborepo-scm/src/git_index_regression_tests.rs
@@ -12,7 +12,7 @@
 
 use turbopath::{AnchoredSystemPathBuf, RelativeUnixPathBuf};
 
-use crate::{GitHashes, RepoGitIndex, SCM, test_utils};
+use crate::{GitHashes, RepoGitIndex, SCM, test_utils, walk_candidate_files};
 
 fn path(s: &str) -> RelativeUnixPathBuf {
     RelativeUnixPathBuf::new(s).unwrap()
@@ -59,6 +59,23 @@ impl TestRepo {
         self.scm()
             .build_repo_index_eager()
             .expect("failed to build repo index")
+    }
+
+    fn build_split_repo_index(&self, prefixes: &[&str]) -> RepoGitIndex {
+        let scm = self.scm();
+        let prefix_paths = prefixes
+            .iter()
+            .map(|prefix| path(prefix))
+            .collect::<Vec<_>>();
+
+        let candidates = walk_candidate_files(self.root.as_std_path(), Some(&prefix_paths))
+            .expect("walk candidates failed");
+
+        let mut index = scm
+            .build_tracked_repo_index_eager()
+            .expect("failed to build tracked repo index");
+        index.populate_untracked_from_candidates(candidates);
+        index
     }
 
     fn build_scoped_repo_index(&self, prefixes: &[&str]) -> RepoGitIndex {
@@ -1419,6 +1436,157 @@ fn test_superset_walk_untracked_in_other_pkg_does_not_affect_queried_pkg() {
     let pkg_b_hashes = repo.get_hashes_with_index("pkg-b", &superset_v2);
     assert!(pkg_b_hashes.contains_key(&path("extra4.ts")));
     assert!(pkg_b_hashes.contains_key(&path("extra5.ts")));
+}
+
+// Category 6: Split walk/filter regression tests
+//
+// These tests validate that the two-phase approach (walk_candidate_files
+// followed by populate_untracked_from_candidates) produces identical
+// results to the original single-pass find_untracked_files.
+
+#[test]
+fn test_split_walk_matches_original_path() {
+    let repo = TestRepo::new();
+
+    repo.create_file("pkg-a/src/index.ts", "a code");
+    repo.create_file("pkg-a/package.json", "{}");
+    repo.create_file("pkg-b/src/index.ts", "b code");
+    repo.create_file("pkg-b/package.json", "{}");
+    repo.create_file("package.json", "{}");
+    repo.commit_all();
+
+    repo.create_file("pkg-a/untracked.ts", "new a");
+    repo.create_file("pkg-b/untracked.ts", "new b");
+
+    let original = repo.build_scoped_repo_index(&["pkg-a", "pkg-b"]);
+    let split = repo.build_split_repo_index(&["pkg-a", "pkg-b"]);
+
+    let orig_a = repo.get_hashes_with_index("pkg-a", &original);
+    let split_a = repo.get_hashes_with_index("pkg-a", &split);
+    assert_eq!(orig_a, split_a, "pkg-a: split walk must match original");
+
+    let orig_b = repo.get_hashes_with_index("pkg-b", &original);
+    let split_b = repo.get_hashes_with_index("pkg-b", &split);
+    assert_eq!(orig_b, split_b, "pkg-b: split walk must match original");
+
+    let no_idx_a = repo.get_hashes_no_index("pkg-a");
+    let no_idx_b = repo.get_hashes_no_index("pkg-b");
+    assert_eq!(split_a, no_idx_a, "pkg-a: split vs no-index");
+    assert_eq!(split_b, no_idx_b, "pkg-b: split vs no-index");
+}
+
+#[test]
+fn test_split_walk_respects_gitignore() {
+    let repo = TestRepo::new();
+
+    repo.create_gitignore(".gitignore", "*.log\nbuild/\nnode_modules/\n");
+    repo.create_gitignore("pkg-b/.gitignore", "tmp/\n");
+    repo.create_file("pkg-a/src/index.ts", "a");
+    repo.create_file("pkg-a/package.json", "{}");
+    repo.create_file("pkg-b/src/index.ts", "b");
+    repo.create_file("pkg-b/package.json", "{}");
+    repo.create_file("package.json", "{}");
+    repo.commit_all();
+
+    repo.create_file("pkg-a/debug.log", "log");
+    repo.create_file("pkg-a/build/out.js", "out");
+    repo.create_file("pkg-a/node_modules/dep/index.js", "dep");
+    repo.create_file("pkg-b/tmp/cache.dat", "cache");
+    repo.create_file("pkg-b/build/out.js", "out");
+    repo.create_file("pkg-a/new.ts", "new");
+    repo.create_file("pkg-b/new.ts", "new");
+
+    let original = repo.build_scoped_repo_index(&["pkg-a", "pkg-b"]);
+    let split = repo.build_split_repo_index(&["pkg-a", "pkg-b"]);
+
+    let orig_a = repo.get_hashes_with_index("pkg-a", &original);
+    let split_a = repo.get_hashes_with_index("pkg-a", &split);
+    assert_eq!(
+        orig_a, split_a,
+        "pkg-a: split must match original with gitignore"
+    );
+    assert!(split_a.contains_key(&path("new.ts")));
+    assert!(!split_a.contains_key(&path("debug.log")));
+    assert!(!split_a.contains_key(&path("build/out.js")));
+    assert!(!split_a.contains_key(&path("node_modules/dep/index.js")));
+
+    let orig_b = repo.get_hashes_with_index("pkg-b", &original);
+    let split_b = repo.get_hashes_with_index("pkg-b", &split);
+    assert_eq!(
+        orig_b, split_b,
+        "pkg-b: split must match original with gitignore"
+    );
+    assert!(split_b.contains_key(&path("new.ts")));
+    assert!(!split_b.contains_key(&path("tmp/cache.dat")));
+}
+
+#[test]
+fn test_split_walk_with_untracked_gitignore() {
+    let repo = TestRepo::new();
+
+    repo.create_file("pkg-a/src/index.ts", "a");
+    repo.create_file("pkg-a/package.json", "{}");
+    repo.create_file("package.json", "{}");
+    repo.commit_all();
+
+    repo.create_gitignore("pkg-a/.gitignore", "generated/\n");
+    repo.create_file("pkg-a/generated/output.js", "out");
+    repo.create_file("pkg-a/new.ts", "new");
+
+    let original = repo.build_scoped_repo_index(&["pkg-a"]);
+    let split = repo.build_split_repo_index(&["pkg-a"]);
+
+    let orig_a = repo.get_hashes_with_index("pkg-a", &original);
+    let split_a = repo.get_hashes_with_index("pkg-a", &split);
+
+    assert!(split_a.contains_key(&path("new.ts")));
+    assert!(orig_a.contains_key(&path("new.ts")));
+    assert!(
+        !split_a.contains_key(&path("generated/output.js")),
+        "split walk should respect untracked .gitignore"
+    );
+    assert!(
+        !orig_a.contains_key(&path("generated/output.js")),
+        "original walk should respect untracked .gitignore"
+    );
+    assert!(split_a.contains_key(&path(".gitignore")));
+    assert!(orig_a.contains_key(&path(".gitignore")));
+}
+
+#[test]
+fn test_split_walk_nested_gitignore_scoping() {
+    let repo = TestRepo::new();
+
+    repo.create_gitignore(".gitignore", "*.log\n");
+    repo.create_gitignore("pkg-a/.gitignore", "output/\n");
+    repo.create_file("pkg-a/src/index.ts", "a");
+    repo.create_file("pkg-a/package.json", "{}");
+    repo.create_file("pkg-b/src/index.ts", "b");
+    repo.create_file("pkg-b/package.json", "{}");
+    repo.create_file("package.json", "{}");
+    repo.commit_all();
+
+    repo.create_file("pkg-a/output/bundle.js", "a bundle");
+    repo.create_file("pkg-b/output/bundle.js", "b bundle");
+
+    let split = repo.build_split_repo_index(&["pkg-a", "pkg-b"]);
+
+    let split_a = repo.get_hashes_with_index("pkg-a", &split);
+    assert!(
+        !split_a.contains_key(&path("output/bundle.js")),
+        "pkg-a output/ should be ignored by pkg-a/.gitignore"
+    );
+
+    let split_b = repo.get_hashes_with_index("pkg-b", &split);
+    assert!(
+        split_b.contains_key(&path("output/bundle.js")),
+        "pkg-b output/ should NOT be ignored — the output/ rule is scoped to pkg-a"
+    );
+
+    let no_idx_a = repo.get_hashes_no_index("pkg-a");
+    let no_idx_b = repo.get_hashes_no_index("pkg-b");
+    assert_eq!(split_a, no_idx_a, "pkg-a split vs no-index");
+    assert_eq!(split_b, no_idx_b, "pkg-b split vs no-index");
 }
 
 #[test]

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -34,7 +34,7 @@ mod git_index_regression_tests;
 #[cfg(test)]
 mod test_utils;
 
-pub use repo_index::RepoGitIndex;
+pub use repo_index::{RepoGitIndex, walk_candidate_files};
 pub use turborepo_hash::OidHash;
 pub use worktree::WorktreeInfo;
 
@@ -309,6 +309,13 @@ impl SCM {
 
     pub fn is_manual(&self) -> bool {
         matches!(self, SCM::Manual)
+    }
+
+    pub fn git_root(&self) -> Option<&AbsoluteSystemPath> {
+        match self {
+            SCM::Git(git) => Some(&git.root),
+            SCM::Manual => None,
+        }
     }
 
     /// Build a repo-wide git index that caches `git ls-tree` and `git status`

--- a/crates/turborepo-scm/src/repo_index.rs
+++ b/crates/turborepo-scm/src/repo_index.rs
@@ -179,6 +179,41 @@ impl RepoGitIndex {
         self.populate_untracked(git, None)
     }
 
+    /// Populate untracked entries from pre-walked candidate files.
+    ///
+    /// This is the fast path used when the filesystem walk ran in parallel
+    /// with index construction. The candidates are filtered against the
+    /// tracked index to identify truly untracked files.
+    pub fn populate_untracked_from_candidates(&mut self, candidates: Vec<RelativeUnixPathBuf>) {
+        if self.untracked_entries_populated {
+            return;
+        }
+
+        let before_status_count = self.status_entries.len();
+        let untracked = filter_untracked_from_candidates(
+            candidates,
+            &self.ls_tree_hashes,
+            &self.status_entries,
+        );
+        for path in untracked {
+            self.status_entries.push(RepoStatusEntry {
+                path,
+                is_delete: false,
+            });
+        }
+
+        self.status_entries.sort_by(|a, b| a.path.cmp(&b.path));
+        self.untracked_entries_populated = true;
+
+        debug!(
+            "populated repo git index from pre-walked candidates: added_count={}, status_count={}",
+            self.status_entries
+                .len()
+                .saturating_sub(before_status_count),
+            self.status_entries.len(),
+        );
+    }
+
     #[tracing::instrument(skip(self, git, prefixes))]
     pub fn populate_untracked_for_prefixes(
         &mut self,
@@ -343,6 +378,163 @@ impl RepoGitIndex {
 
         (known_hashes, to_hash)
     }
+}
+
+/// Walk the working tree to collect candidate files (all non-gitignored
+/// files within scope). This is the I/O-bound phase that can run without
+/// the git index.
+///
+/// Uses the `ignore` crate's native gitignore support to read .gitignore
+/// files from disk as the walker descends. This matches standard git
+/// behavior and handles tracked, untracked, and nested .gitignore files.
+///
+/// Returns all candidate paths relative to `git_root`. The caller must
+/// filter these against the tracked index to identify truly untracked files.
+#[tracing::instrument(skip(git_root, prefixes))]
+pub fn walk_candidate_files(
+    git_root: &std::path::Path,
+    prefixes: Option<&[RelativeUnixPathBuf]>,
+) -> Result<Vec<RelativeUnixPathBuf>, Error> {
+    use std::sync::mpsc;
+
+    use ignore::WalkBuilder;
+
+    let root = std::sync::Arc::new(git_root.to_path_buf());
+    let scope = std::sync::Arc::new(UntrackedScope::new(prefixes));
+
+    let (tx, rx) = mpsc::channel::<Vec<RelativeUnixPathBuf>>();
+
+    let walker = WalkBuilder::new(root.as_path())
+        .follow_links(false)
+        .git_ignore(true)
+        .git_exclude(true)
+        .git_global(true)
+        .require_git(false)
+        .ignore(false)
+        .parents(false)
+        .hidden(false)
+        .filter_entry({
+            let root = root.clone();
+            let scope = scope.clone();
+            move |entry| {
+                if entry.file_name() == ".git" {
+                    return false;
+                }
+                let is_dir = entry.file_type().is_some_and(|ft| ft.is_dir());
+                let path = entry.path();
+
+                let rel_path = match path.strip_prefix(root.as_path()) {
+                    Ok(rel) => rel,
+                    Err(_) => return false,
+                };
+                #[cfg(windows)]
+                let rel_path_owned = rel_path.to_string_lossy().replace('\\', "/");
+                #[cfg(windows)]
+                let rel_path = rel_path_owned.as_str();
+                #[cfg(not(windows))]
+                let rel_path = match rel_path.to_str() {
+                    Some(rel) => rel,
+                    None => return false,
+                };
+
+                if is_dir {
+                    scope.should_visit_dir(rel_path)
+                } else {
+                    scope.should_consider_file(rel_path, entry.file_name() == ".gitignore")
+                }
+            }
+        })
+        .threads(rayon::current_num_threads().min(8))
+        .build_parallel();
+
+    struct FlushOnDrop {
+        buf: Vec<RelativeUnixPathBuf>,
+        tx: mpsc::Sender<Vec<RelativeUnixPathBuf>>,
+    }
+
+    impl Drop for FlushOnDrop {
+        fn drop(&mut self) {
+            if !self.buf.is_empty() {
+                let batch = std::mem::take(&mut self.buf);
+                let _ = self.tx.send(batch);
+            }
+        }
+    }
+
+    walker.run(|| {
+        let root = root.clone();
+        let mut guard = FlushOnDrop {
+            buf: Vec::new(),
+            tx: tx.clone(),
+        };
+
+        Box::new(move |entry| {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => return ignore::WalkState::Continue,
+            };
+
+            if entry.file_type().is_some_and(|ft| ft.is_dir()) {
+                return ignore::WalkState::Continue;
+            }
+            if entry.file_type().is_some_and(|ft| ft.is_symlink()) {
+                return ignore::WalkState::Continue;
+            }
+
+            let abs_path = entry.into_path();
+            let rel_path = match abs_path.strip_prefix(root.as_path()) {
+                Ok(rel) => rel,
+                Err(_) => return ignore::WalkState::Continue,
+            };
+
+            let unix_str = match rel_path.to_str() {
+                Some(s) => s,
+                None => return ignore::WalkState::Continue,
+            };
+
+            #[cfg(windows)]
+            let unix_str_owned = unix_str.replace('\\', "/");
+            #[cfg(windows)]
+            let unix_str: &str = &unix_str_owned;
+
+            if let Ok(path) = RelativeUnixPathBuf::new(unix_str) {
+                guard.buf.push(path);
+            }
+
+            ignore::WalkState::Continue
+        })
+    });
+    drop(tx);
+
+    let mut candidates: Vec<RelativeUnixPathBuf> = Vec::new();
+    for batch in rx.iter() {
+        candidates.extend(batch);
+    }
+
+    Ok(candidates)
+}
+
+/// Filter pre-walked candidate files against the git index to identify
+/// truly untracked files. This is the CPU-bound phase that runs after
+/// the tracked index is ready.
+fn filter_untracked_from_candidates(
+    candidates: Vec<RelativeUnixPathBuf>,
+    ls_tree_hashes: &SortedGitHashes,
+    status_entries: &[RepoStatusEntry],
+) -> Vec<RelativeUnixPathBuf> {
+    candidates
+        .into_iter()
+        .filter(|path| {
+            let s = path.as_str();
+            let in_ls_tree = ls_tree_hashes
+                .binary_search_by(|(p, _)| p.as_str().cmp(s))
+                .is_ok();
+            let in_status = status_entries
+                .binary_search_by(|e| e.path.as_str().cmp(s))
+                .is_ok();
+            !in_ls_tree && !in_status
+        })
+        .collect()
 }
 
 /// Walk the working tree to find untracked files (files on disk that are


### PR DESCRIPTION
## Summary

- Splits the untracked-file discovery into two parallel phases: an I/O-bound filesystem walk and a CPU-bound index filter
- The walk uses the `ignore` crate's native gitignore handling (reading `.gitignore` from disk), removing the dependency on the tracked git index
- Git root is forwarded via a oneshot channel as soon as `SCM::new()` resolves it (~5ms), letting the walk start while `new_from_gix_index` (~267ms) continues

## Why

After #12201, the critical path was `new_from_gix_index` (267ms) → `find_untracked_files` (509ms) = 776ms sequential. These two operations are now fully overlapped.

## Benchmark (110-package monorepo, 30 runs, sandboxed)

| | Mean | Min | Max |
|---|---|---|---|
| Baseline (main + #12201) | 853ms ± 19ms | 834ms | 928ms |
| This PR | **619ms ± 6ms** | 606ms | 635ms |

**1.38x faster** (234ms wall clock saved). `repo_index_untracked_await` dropped from 505ms to 89ms.

## Test Coverage

4 new regression tests validating the split walk produces identical results to the original single-pass approach:
- `test_split_walk_matches_original_path` — baseline equivalence verified against no-index subprocess path
- `test_split_walk_respects_gitignore` — root, nested, and package-level `.gitignore` rules
- `test_split_walk_with_untracked_gitignore` — untracked `.gitignore` files are applied during the walk
- `test_split_walk_nested_gitignore_scoping` — scoped ignore rules don't leak across packages

## How to Review

1. `repo_index.rs` — `walk_candidate_files` (I/O phase), `filter_untracked_from_candidates` (CPU phase), `populate_untracked_from_candidates` (integration into RepoGitIndex)
2. `builder.rs` — `git_root_tx`/`git_root_rx` channel, walk_task spawned from channel, `tokio::join!` to combine walk + index
3. `lib.rs` — `SCM::git_root()` accessor, re-export of `walk_candidate_files`
4. `git_index_regression_tests.rs` — `build_split_repo_index` helper and 4 new tests