### PR TITLE
docs: Clarification in oxc guide

### DIFF
--- a/apps/docs/content/docs/guides/tools/oxc.mdx
+++ b/apps/docs/content/docs/guides/tools/oxc.mdx
@@ -103,7 +103,7 @@ You can now run `turbo run lint` to lint your entire repository.
 <Callout type="warn" title="Type-aware linting">
   If you enable [type-aware linting rules](https://oxc.rs/docs/guide/usage/linter/config#type-aware-linting) in oxlint, the linter needs TypeScript type information to work correctly. This means any dependencies that must be built before type-checking (such as [Compiled Packages](/docs/core-concepts/internal-packages#compiled-packages) in your monorepo) also need to be built before linting.
 
-For example, to build Compiled Packages before linting in CI:
+For example, to build Compiled Packages before running formatting and linting:
 
 ```bash title="Terminal"
 turbo run build --filter=./packages/* && turbo run lint


### PR DESCRIPTION
### Description

Clarify that packages that need building are the ones that need building.