### PR TITLE
fix: Use `FilterMode` enum for root task scoping with exclude-only filters

### DIFF
--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -189,6 +189,22 @@ impl RunBuilder {
         prefixes
     }
 
+    /// Resolve the set of packages that should participate in this run.
+    ///
+    /// Starts with the result of scope resolution (which handles `--filter`
+    /// and `--affected`), then layers on root-task inclusion:
+    ///
+    /// - **No filter** (`AllPackages`): root tasks defined in `turbo.json` are
+    ///   included automatically.
+    /// - **Exclude-only** (`ExcludeOnly`): semantically "all packages minus
+    ///   excluded ones" — root tasks are still included unless the root package
+    ///   itself was explicitly excluded (e.g. `--filter=!//`).
+    /// - **Explicit selection** (`ExplicitSelection`): the user opted into
+    ///   specific packages — root tasks are not auto-injected.
+    ///
+    /// When `AllPackages` is active and every requested task uses
+    /// `package#task` syntax, the set is narrowed to only the referenced
+    /// packages.
     pub fn calculate_filtered_packages(
         repo_root: &AbsoluteSystemPath,
         opts: &Opts,
@@ -196,7 +212,7 @@ impl RunBuilder {
         scm: &SCM,
         root_turbo_json: &TurboJson,
     ) -> Result<HashMap<PackageName, PackageInclusionReason>, Error> {
-        let (mut filtered_pkgs, is_all_packages) = scope::resolve_packages(
+        let (mut filtered_pkgs, filter_mode) = scope::resolve_packages(
             &opts.scope_opts,
             repo_root,
             pkg_dep_graph,
@@ -204,30 +220,15 @@ impl RunBuilder {
             root_turbo_json,
         )?;
 
-        // When using exclude-only filters (e.g. --filter=!docs), the semantic is
-        // "all packages minus the excluded ones". Root tasks should still be
-        // included in this case, just as they are when no filter is specified.
-        let filters = opts.scope_opts.get_filters();
-        let has_exclude_only_filters = !filters.is_empty()
-            && filters.iter().all(|f| f.starts_with('!'));
-
-        // Include root tasks when either no filter is specified (is_all_packages)
-        // or when only exclude filters are used and the root is not explicitly
-        // excluded by the filter.
-        let should_include_root_tasks = is_all_packages
-            || (has_exclude_only_filters
-                && !filtered_pkgs.contains_key(&PackageName::Root)
-                && !filters.iter().any(|f| {
-                    // Check if any exclude filter explicitly targets the root
-                    // package (e.g. --filter=!//). The root package name is "//".
-                    let pattern = f.strip_prefix('!').unwrap_or(f);
-                    pattern == PackageName::Root.as_ref()
-                }));
+        let should_include_root_tasks = match filter_mode {
+            scope::FilterMode::AllPackages => true,
+            scope::FilterMode::ExcludeOnly { root_excluded } => !root_excluded,
+            scope::FilterMode::ExplicitSelection => false,
+        };
 
         if should_include_root_tasks {
             for target in opts.run_opts.tasks.iter() {
                 let mut task_name = TaskName::from(target.as_str());
-                // If it's not a package task, we convert to a root task
                 if !task_name.is_package_task() {
                     task_name = task_name.into_root_task()
                 }
@@ -244,7 +245,7 @@ impl RunBuilder {
             }
         }
 
-        if is_all_packages {
+        if matches!(filter_mode, scope::FilterMode::AllPackages) {
             // When all tasks use package#task syntax, we can narrow the package
             // set to only the referenced packages rather than the entire monorepo.
             let task_names: Vec<TaskName> = opts
@@ -262,7 +263,7 @@ impl RunBuilder {
                     .collect();
                 filtered_pkgs.retain(|pkg, _| target_packages.contains(pkg));
             }
-        };
+        }
 
         Ok(filtered_pkgs)
     }

--- a/crates/turborepo-lib/src/run/scope/mod.rs
+++ b/crates/turborepo-lib/src/run/scope/mod.rs
@@ -11,8 +11,7 @@ use turborepo_repository::{
     package_graph::{PackageGraph, PackageName},
 };
 use turborepo_scm::SCM;
-// Re-export modules and types from turborepo-scope crate for backward compatibility
-pub use turborepo_scope::{filter::ResolutionError, target_selector, ScopeOpts};
+pub use turborepo_scope::{filter::ResolutionError, target_selector, FilterMode, ScopeOpts};
 
 use crate::turbo_json::TurboJson;
 
@@ -26,8 +25,7 @@ pub fn resolve_packages(
     pkg_graph: &PackageGraph,
     scm: &SCM,
     root_turbo_json: &TurboJson,
-) -> Result<(HashMap<PackageName, PackageInclusionReason>, bool), ResolutionError> {
-    // Delegate to turborepo-scope, passing global_deps from turbo.json
+) -> Result<(HashMap<PackageName, PackageInclusionReason>, FilterMode), ResolutionError> {
     turborepo_scope::resolve_packages(
         opts,
         turbo_root,

--- a/crates/turborepo-scope/src/filter.rs
+++ b/crates/turborepo-scope/src/filter.rs
@@ -16,6 +16,7 @@ use turborepo_repository::{
     package_graph::{self, PackageGraph, PackageName},
 };
 use turborepo_scm::SCM;
+use turborepo_types::FilterMode;
 use wax::Program;
 
 use crate::{
@@ -199,24 +200,26 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
         }
     }
 
-    /// Resolves a set of filter patterns into a set of packages,
-    /// based on the current state of the workspace. The result is
-    /// guaranteed to be a subset of the packages in the workspace,
-    /// and non-empty. If the filter is empty, none of the packages
-    /// in the workspace will be returned.
+    /// Resolve the set of packages matching the given filter patterns.
     ///
-    /// It applies the following rules:
+    /// Returns the matched packages alongside a [`FilterMode`] that
+    /// describes the kind of filter that was applied. The caller uses
+    /// `FilterMode` to decide whether root tasks should be injected
+    /// without re-parsing raw filter strings.
+    ///
+    /// Root (`//`) is never included in the returned package set — the
+    /// caller is responsible for adding it when appropriate (see
+    /// `RunBuilder::calculate_filtered_packages`).
     pub fn resolve(
         &self,
         affected: &Option<(Option<String>, Option<String>)>,
         patterns: &[String],
-    ) -> Result<(HashMap<PackageName, PackageInclusionReason>, bool), ResolutionError> {
-        // inference is None only if we are in the root
+    ) -> Result<(HashMap<PackageName, PackageInclusionReason>, FilterMode), ResolutionError> {
         let is_all_packages = patterns.is_empty() && self.inference.is_none() && affected.is_none();
 
-        let filter_patterns = if is_all_packages {
-            // return all packages in the workspace
-            self.pkg_graph
+        if is_all_packages {
+            let packages = self
+                .pkg_graph
                 .packages()
                 .filter(|(name, _)| matches!(name, PackageName::Other(_)))
                 .map(|(name, _)| {
@@ -227,23 +230,17 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
                         },
                     )
                 })
-                .collect()
-        } else {
-            self.get_packages_from_patterns(affected, patterns)?
-        };
+                .collect();
+            return Ok((packages, FilterMode::AllPackages));
+        }
 
-        Ok((filter_patterns, is_all_packages))
-    }
-
-    fn get_packages_from_patterns(
-        &self,
-        affected: &Option<(Option<String>, Option<String>)>,
-        patterns: &[String],
-    ) -> Result<HashMap<PackageName, PackageInclusionReason>, ResolutionError> {
-        let mut selectors = patterns
+        // Parse selectors once — reused for both mode classification and resolution.
+        let mut selectors: Vec<TargetSelector> = patterns
             .iter()
             .map(|pattern| TargetSelector::from_str(pattern))
             .collect::<Result<Vec<_>, _>>()?;
+
+        let mode = self.classify_filter_mode(&selectors, affected);
 
         if let Some((from_ref, to_ref)) = affected {
             selectors.push(TargetSelector {
@@ -259,7 +256,54 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
             });
         }
 
-        self.get_filtered_packages(selectors)
+        let packages = self.get_filtered_packages(selectors)?;
+        Ok((packages, mode))
+    }
+
+    /// Classify the filter mode from parsed selectors.
+    ///
+    /// Only patterns from the CLI are considered — affected ranges and
+    /// package inference are separate selection mechanisms that always
+    /// produce an explicit selection.
+    fn classify_filter_mode(
+        &self,
+        pattern_selectors: &[TargetSelector],
+        affected: &Option<(Option<String>, Option<String>)>,
+    ) -> FilterMode {
+        if self.inference.is_some() || affected.is_some() || pattern_selectors.is_empty() {
+            return FilterMode::ExplicitSelection;
+        }
+
+        if pattern_selectors.iter().all(|s| s.exclude) {
+            let root_excluded = pattern_selectors
+                .iter()
+                .any(|s| Self::selector_matches_root(s));
+            FilterMode::ExcludeOnly { root_excluded }
+        } else {
+            FilterMode::ExplicitSelection
+        }
+    }
+
+    /// Check whether a selector would match the root package.
+    ///
+    /// Uses the same glob matching as `match_package_names` for name
+    /// patterns, and checks `parent_dir` for the repo root directory.
+    fn selector_matches_root(selector: &TargetSelector) -> bool {
+        if !selector.name_pattern.is_empty()
+            && let Ok(matcher) = SimpleGlob::new(&selector.name_pattern)
+            && matcher.is_match(PackageName::Root.as_ref())
+        {
+            return true;
+        }
+
+        if let Some(ref parent_dir) = selector.parent_dir {
+            let dir_str = parent_dir.as_str();
+            if dir_str == "." || dir_str.is_empty() {
+                return true;
+            }
+        }
+
+        false
     }
 
     fn get_filtered_packages(
@@ -783,6 +827,7 @@ mod test {
 
     use super::{FilterResolver, PackageInference};
     use crate::{
+        FilterMode,
         change_detector::GitChangeDetector,
         filter::ResolutionError,
         target_selector::{GitRange, TargetSelector},
@@ -1780,6 +1825,151 @@ mod test {
         assert!(
             !packages.contains_key(&PackageName::from("pkg-a")),
             "pkg-a should not match './*' filter from apps directory"
+        );
+    }
+
+    // -- FilterMode classification tests --------------------------------------
+    //
+    // These test `classify_filter_mode` (private) and `selector_matches_root`
+    // through the public `resolve()` method, asserting on the returned
+    // `FilterMode`. This validates the core decision logic for root task
+    // injection without needing expensive integration tests.
+
+    fn resolve_filter_mode(
+        patterns: &[&str],
+        affected: &Option<(Option<String>, Option<String>)>,
+        package_inference: Option<PackageInference>,
+    ) -> FilterMode {
+        resolve_filter_mode_with_changes(patterns, affected, package_inference, &[])
+    }
+
+    fn resolve_filter_mode_with_changes(
+        patterns: &[&str],
+        affected: &Option<(Option<String>, Option<String>)>,
+        package_inference: Option<PackageInference>,
+        changed: &[(&str, Option<&str>, &[&str])],
+    ) -> FilterMode {
+        let (_tempdir, resolver) = make_project(
+            &[
+                ("packages/project-0", "packages/project-1"),
+                ("packages/project-0", "project-5"),
+            ],
+            &["project-3"],
+            package_inference,
+            TestChangeDetector::new(changed),
+        );
+        let patterns: Vec<String> = patterns.iter().map(|s| s.to_string()).collect();
+        let (_, mode) = resolver.resolve(affected, &patterns).unwrap();
+        mode
+    }
+
+    #[test]
+    fn filter_mode_no_patterns_is_all_packages() {
+        let mode = resolve_filter_mode(&[], &None, None);
+        assert_eq!(mode, FilterMode::AllPackages);
+    }
+
+    #[test]
+    fn filter_mode_single_exclude_is_exclude_only() {
+        let mode = resolve_filter_mode(&["!project-3"], &None, None);
+        assert_eq!(
+            mode,
+            FilterMode::ExcludeOnly {
+                root_excluded: false
+            }
+        );
+    }
+
+    #[test]
+    fn filter_mode_multiple_excludes_is_exclude_only() {
+        let mode = resolve_filter_mode(&["!project-3", "!project-5"], &None, None);
+        assert_eq!(
+            mode,
+            FilterMode::ExcludeOnly {
+                root_excluded: false
+            }
+        );
+    }
+
+    #[test]
+    fn filter_mode_exclude_root_by_name() {
+        let mode = resolve_filter_mode(&["!//"], &None, None);
+        assert_eq!(
+            mode,
+            FilterMode::ExcludeOnly {
+                root_excluded: true
+            }
+        );
+    }
+
+    #[test]
+    fn filter_mode_exclude_root_by_directory() {
+        let mode = resolve_filter_mode(&["!{.}"], &None, None);
+        assert_eq!(
+            mode,
+            FilterMode::ExcludeOnly {
+                root_excluded: true
+            }
+        );
+    }
+
+    #[test]
+    fn filter_mode_wildcard_exclude_matches_root() {
+        // !* should match all packages including root (//).
+        let mode = resolve_filter_mode(&["!*"], &None, None);
+        assert_eq!(
+            mode,
+            FilterMode::ExcludeOnly {
+                root_excluded: true
+            }
+        );
+    }
+
+    #[test]
+    fn filter_mode_include_is_explicit_selection() {
+        let mode = resolve_filter_mode(&["project-3"], &None, None);
+        assert_eq!(mode, FilterMode::ExplicitSelection);
+    }
+
+    #[test]
+    fn filter_mode_mixed_include_exclude_is_explicit_selection() {
+        let mode = resolve_filter_mode(&["project-3", "!project-5"], &None, None);
+        assert_eq!(mode, FilterMode::ExplicitSelection);
+    }
+
+    #[test]
+    fn filter_mode_affected_forces_explicit_selection() {
+        // Even with exclude-only patterns, affected overrides to ExplicitSelection.
+        let affected = Some((Some("main".to_string()), None));
+        let mode = resolve_filter_mode_with_changes(
+            &["!project-3"],
+            &affected,
+            None,
+            &[("main", None, &["project-3"])],
+        );
+        assert_eq!(mode, FilterMode::ExplicitSelection);
+    }
+
+    #[test]
+    fn filter_mode_inference_forces_explicit_selection() {
+        let inference = Some(PackageInference {
+            package_name: Some("project-0".to_string()),
+            directory_root: AnchoredSystemPathBuf::try_from("packages/project-0").unwrap(),
+        });
+        // Exclude-only patterns with inference should still be ExplicitSelection.
+        let mode = resolve_filter_mode(&["!project-3"], &None, inference);
+        assert_eq!(mode, FilterMode::ExplicitSelection);
+    }
+
+    #[test]
+    fn filter_mode_exclude_root_among_multiple() {
+        // One of several excludes targets root — root_excluded should be true.
+        let mode = resolve_filter_mode(&["!project-3", "!//"], &None, None);
+        assert_eq!(
+            mode,
+            FilterMode::ExcludeOnly {
+                root_excluded: true
+            }
         );
     }
 }

--- a/crates/turborepo-scope/src/lib.rs
+++ b/crates/turborepo-scope/src/lib.rs
@@ -29,20 +29,14 @@ use turborepo_repository::{
     package_graph::{PackageGraph, PackageName},
 };
 use turborepo_scm::SCM;
-// Re-export ScopeOpts for backwards compatibility
-pub use turborepo_types::ScopeOpts;
+pub use turborepo_types::{FilterMode, ScopeOpts};
 
 /// Resolve which packages should be included in the run based on scope options.
 ///
-/// # Arguments
-/// * `opts` - Scope resolution options
-/// * `turbo_root` - The root of the turbo repository
-/// * `pkg_graph` - The package graph
-/// * `scm` - Source control manager for change detection
-/// * `global_deps` - Global dependencies from turbo.json
-///
-/// # Returns
-/// Tuple of (packages with inclusion reasons, is_all_packages flag)
+/// Returns the filtered package set alongside a [`FilterMode`] that
+/// describes how the filter was classified (all packages, exclude-only,
+/// or explicit selection). The caller uses `FilterMode` to decide
+/// whether root tasks should be injected.
 #[tracing::instrument(skip(opts, pkg_graph, scm))]
 pub fn resolve_packages(
     opts: &ScopeOpts,
@@ -50,11 +44,11 @@ pub fn resolve_packages(
     pkg_graph: &PackageGraph,
     scm: &SCM,
     global_deps: &[String],
-) -> Result<(HashMap<PackageName, PackageInclusionReason>, bool), ResolutionError> {
+) -> Result<(HashMap<PackageName, PackageInclusionReason>, FilterMode), ResolutionError> {
     let pkg_inference = opts.pkg_inference_root.as_ref().map(|pkg_inference_path| {
         PackageInference::calculate(turbo_root, pkg_inference_path, pkg_graph)
     });
 
     FilterResolver::new(opts, pkg_graph, turbo_root, pkg_inference, scm, global_deps)?
-        .resolve(&opts.affected_range, &opts.get_filters())
+        .resolve(&opts.affected_range, opts.get_filters())
 }

--- a/crates/turborepo-types/src/lib.rs
+++ b/crates/turborepo-types/src/lib.rs
@@ -425,10 +425,34 @@ pub struct ScopeOpts {
 }
 
 impl ScopeOpts {
-    /// Get the filter patterns.
-    pub fn get_filters(&self) -> Vec<String> {
-        self.filter_patterns.clone()
+    /// Returns the raw `--filter` patterns as provided on the CLI.
+    ///
+    /// Strings may include `!` prefixes for exclusion and other filter
+    /// microsyntax (e.g., `{dir}`, `[gitref]`, `...`). Use
+    /// `TargetSelector::from_str` for structured parsing.
+    pub fn get_filters(&self) -> &[String] {
+        &self.filter_patterns
     }
+}
+
+/// How packages were resolved by the scope filter.
+///
+/// Returned alongside the filtered package set from `resolve_packages`
+/// so the caller can decide whether to inject root tasks without
+/// re-parsing raw filter strings.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FilterMode {
+    /// No filter was specified — all workspace packages selected.
+    AllPackages,
+    /// Only exclude filters were used (e.g. `--filter=!docs`).
+    /// Semantically equivalent to "all packages minus the excluded ones".
+    ///
+    /// `root_excluded` is true when any exclude selector targets the root
+    /// package (e.g. `--filter=!//` or `--filter=!{.}`).
+    ExcludeOnly { root_excluded: bool },
+    /// Include filters were present (possibly with excludes too),
+    /// or package inference / --affected was active.
+    ExplicitSelection,
 }
 
 /// Projection of run options that only includes information necessary to

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -29,6 +29,10 @@ A run consists of the following steps:
 
 - Package discovery and lockfile analysis
 - Task filtering based on arguments (task names and `--filter`)
+- Root task scoping via `FilterMode` (from `turborepo-types`): when no filter
+  or only exclude filters are active, root tasks defined in `turbo.json` are
+  auto-included. Explicit include filters or `--affected` suppress root task
+  injection. See `calculate_filtered_packages` and `FilterMode`.
 - Task graph construction and validation
 - Cache setup (local and remote)
 - Activating shared HTTP client initialization once telemetry, remote cache, or

--- a/crates/turborepo/tests/filter_run_test.rs
+++ b/crates/turborepo/tests/filter_run_test.rs
@@ -1,8 +1,31 @@
 mod common;
 
-use std::fs;
+use std::{fs, path::Path};
 
 use common::{git, run_turbo, setup};
+
+/// Set up a basic_monorepo fixture with a non-recursive root `something`
+/// script. The default fixture's `something` calls `turbo run build`, which
+/// triggers recursion detection. This replaces it with a simple echo so we
+/// can test root task scoping via `--dry=json` without side effects.
+fn setup_root_task_fixture(dir: &Path) {
+    setup::setup_integration_test(dir, "basic_monorepo", "npm@10.5.0", true).unwrap();
+
+    let pkg_json = r#"{
+  "name": "monorepo",
+  "scripts": {
+    "something": "echo root-task-executed"
+  },
+  "packageManager": "npm@10.5.0",
+  "workspaces": [
+    "apps/**",
+    "packages/**"
+  ]
+}"#;
+    fs::write(dir.join("package.json"), pkg_json).unwrap();
+    git(dir, &["add", "."]);
+    git(dir, &["commit", "-m", "fix root script", "--quiet"]);
+}
 
 #[test]
 fn test_filter_git_range_no_changes() {
@@ -71,36 +94,36 @@ fn test_filter_nonexistent_package_errors() {
     );
 }
 
+// -- Root task scoping tests --------------------------------------------------
+//
+// These tests verify that root tasks (//#something defined in turbo.json)
+// are included or excluded from the run scope depending on the filter mode.
+// Fixture: basic_monorepo with packages my-app, util, another.
+
+#[test]
+fn test_no_filter_includes_root_tasks() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_root_task_fixture(tempdir.path());
+
+    let output = run_turbo(tempdir.path(), &["run", "something", "--dry=json"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "dry run failed: stdout={stdout}, stderr={stderr}"
+    );
+    assert!(
+        stdout.contains("//#something"),
+        "root task should be in scope without filter: {stdout}"
+    );
+}
+
 #[test]
 fn test_exclude_only_filter_includes_root_tasks() {
     // Regression test for https://github.com/vercel/turborepo/issues/8672
-    // When using an exclude-only filter like --filter=!my-app, root tasks
-    // defined with //#task syntax should still be included.
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup_root_task_fixture(tempdir.path());
 
-    // Replace root package.json "something" script with a non-recursive command
-    // (the default script calls "turbo run build" which triggers recursion detection)
-    let pkg_json_path = tempdir.path().join("package.json");
-    let pkg_json = r#"{
-  "name": "monorepo",
-  "scripts": {
-    "something": "echo root-task-executed"
-  },
-  "packageManager": "npm@10.5.0",
-  "workspaces": [
-    "apps/**",
-    "packages/**"
-  ]
-}"#;
-    fs::write(&pkg_json_path, pkg_json).unwrap();
-    git(tempdir.path(), &["add", "."]);
-    git(
-        tempdir.path(),
-        &["commit", "-m", "fix root script", "--quiet", "--allow-empty"],
-    );
-
-    // Use --dry=json to check which packages are in scope
     let output = run_turbo(
         tempdir.path(),
         &["run", "something", "--filter=!my-app", "--dry=json"],
@@ -111,43 +134,28 @@ fn test_exclude_only_filter_includes_root_tasks() {
         output.status.success(),
         "dry run failed: stdout={stdout}, stderr={stderr}"
     );
-    // The root task //#something should be in scope even with exclude-only filter
     assert!(
         stdout.contains("//#something"),
-        "root task //#something should be in scope with exclude-only filter: {stdout}"
+        "root task should be in scope with exclude-only filter: {stdout}"
     );
 }
 
 #[test]
-fn test_no_filter_includes_root_tasks() {
-    // Verify that root tasks work without any filter (baseline behavior)
+fn test_multiple_exclude_filters_include_root_tasks() {
+    // Multiple exclude filters are still "exclude-only" — root tasks should
+    // be included as long as none of them target the root package.
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup_root_task_fixture(tempdir.path());
 
-    // Replace root package.json "something" script with a non-recursive command
-    let pkg_json_path = tempdir.path().join("package.json");
-    let pkg_json = r#"{
-  "name": "monorepo",
-  "scripts": {
-    "something": "echo root-task-executed"
-  },
-  "packageManager": "npm@10.5.0",
-  "workspaces": [
-    "apps/**",
-    "packages/**"
-  ]
-}"#;
-    fs::write(&pkg_json_path, pkg_json).unwrap();
-    git(tempdir.path(), &["add", "."]);
-    git(
-        tempdir.path(),
-        &["commit", "-m", "fix root script", "--quiet", "--allow-empty"],
-    );
-
-    // Use --dry=json to check scope without executing tasks
     let output = run_turbo(
         tempdir.path(),
-        &["run", "something", "--dry=json"],
+        &[
+            "run",
+            "something",
+            "--filter=!my-app",
+            "--filter=!util",
+            "--dry=json",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -155,9 +163,82 @@ fn test_no_filter_includes_root_tasks() {
         output.status.success(),
         "dry run failed: stdout={stdout}, stderr={stderr}"
     );
-    // The root task //#something should appear in the dry run output
     assert!(
         stdout.contains("//#something"),
-        "root task //#something should be in scope without filter: {stdout}"
+        "root task should be in scope with multiple exclude-only filters: {stdout}"
+    );
+}
+
+#[test]
+fn test_exclude_root_filter_excludes_root_tasks() {
+    // Explicitly excluding root (--filter=!//) should prevent root task injection.
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_root_task_fixture(tempdir.path());
+
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "something", "--filter=!//", "--dry=json"],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "dry run failed: stdout={stdout}, stderr={stderr}"
+    );
+    assert!(
+        !stdout.contains("//#something"),
+        "root task should NOT be in scope when root is explicitly excluded: {stdout}"
+    );
+}
+
+#[test]
+fn test_include_filter_excludes_root_tasks() {
+    // An include filter (--filter=my-app) means the user opted into specific
+    // packages. Root tasks should not be auto-injected.
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_root_task_fixture(tempdir.path());
+
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "something", "--filter=my-app", "--dry=json"],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "dry run failed: stdout={stdout}, stderr={stderr}"
+    );
+    assert!(
+        !stdout.contains("//#something"),
+        "root task should NOT be in scope with include-only filter: {stdout}"
+    );
+}
+
+#[test]
+fn test_mixed_include_exclude_filter_excludes_root_tasks() {
+    // Mixed include+exclude (--filter=my-app --filter=!util) is an explicit
+    // selection, not "all packages minus some". Root tasks should not be injected.
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_root_task_fixture(tempdir.path());
+
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "run",
+            "something",
+            "--filter=my-app",
+            "--filter=!util",
+            "--dry=json",
+        ],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "dry run failed: stdout={stdout}, stderr={stderr}"
+    );
+    assert!(
+        !stdout.contains("//#something"),
+        "root task should NOT be in scope with mixed include+exclude filters: {stdout}"
     );
 }


### PR DESCRIPTION
## Summary

Fixes #8672

When using exclude-only filters like `--filter=!docs`, root tasks defined with `//#task` syntax in `turbo.json` were silently excluded from the task graph. The semantic of `--filter=!docs` is "all packages minus docs" — root tasks should still run.

## Approach

Introduces a `FilterMode` enum (`AllPackages | ExcludeOnly { root_excluded } | ExplicitSelection`) returned from scope resolution alongside the filtered package set. This pushes filter classification into the scope layer where `TargetSelector` is already parsed, rather than re-parsing raw filter strings in the builder.

The builder then matches on `FilterMode` to decide root task inclusion:

```rust
let should_include_root_tasks = match filter_mode {
    FilterMode::AllPackages => true,
    FilterMode::ExcludeOnly { root_excluded } => !root_excluded,
    FilterMode::ExplicitSelection => false,
};
```

### Changed crates

- **`turborepo-types`** — `FilterMode` enum, `get_filters()` returns `&[String]` instead of cloning
- **`turborepo-scope`** — `classify_filter_mode()` and `selector_matches_root()` in filter resolver, `resolve()` returns `FilterMode`
- **`turborepo-lib`** — `calculate_filtered_packages` matches on `FilterMode`

## Before/After

| Command | Before | After |
|---------|--------|-------|
| `turbo run dev` | Root `//#dev` runs | Unchanged |
| `turbo run dev --filter=!docs` | Root `//#dev` **skipped** | Root `//#dev` runs |
| `turbo run dev --filter=web` | Root `//#dev` skipped | Unchanged |
| `turbo run dev --filter=!//` | Root `//#dev` skipped | Unchanged |
| `turbo run dev --filter=!{.}` | Root `//#dev` skipped | Unchanged |

## Testing

- 11 new unit tests for `classify_filter_mode` covering all filter mode combinations (exclude-only, root exclusion by name/directory/wildcard, mixed filters, affected, inference)
- 6 integration tests for root task scoping through `turbo run --dry=json`
- ARCHITECTURE.md updated per repo policy
- All 79 `turborepo-scope` tests pass, all pre-existing tests unaffected