### PR TITLE
perf: Generate cache restore manifest at save time to eliminate first-hit penalty

### DIFF
--- a/crates/turborepo-cache/src/cache_archive/restore_manifest.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore_manifest.rs
@@ -12,6 +12,10 @@ use crate::CacheError;
 pub struct RestoreManifest {
     /// path (relative to anchor) -> (size_bytes, mtime_nanos, mode)
     pub files: HashMap<String, FileEntry>,
+    /// Insertion-order list of paths so validate_all can return files in
+    /// the same order the archive was originally built.
+    #[serde(default)]
+    pub order: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -19,6 +23,8 @@ pub struct FileEntry {
     pub size: u64,
     pub mtime_nanos: i128,
     pub mode: u32,
+    #[serde(default)]
+    pub is_dir: bool,
 }
 
 impl RestoreManifest {
@@ -38,6 +44,10 @@ impl RestoreManifest {
         let Ok(meta) = disk_path.symlink_metadata() else {
             return false;
         };
+
+        if expected.is_dir {
+            return meta.is_dir();
+        }
 
         if !meta.is_file() {
             return false;
@@ -86,15 +96,31 @@ impl RestoreManifest {
         #[cfg(not(unix))]
         let mode = 0o644;
 
+        self.order.push(path.clone());
         self.files.insert(
             path,
             FileEntry {
                 size: meta.len(),
                 mtime_nanos,
                 mode,
+                is_dir: false,
             },
         );
         Ok(())
+    }
+
+    /// Record a directory entry in the manifest.
+    pub fn record_dir(&mut self, path: String) {
+        self.order.push(path.clone());
+        self.files.insert(
+            path,
+            FileEntry {
+                size: 0,
+                mtime_nanos: 0,
+                mode: 0,
+                is_dir: true,
+            },
+        );
     }
 
     /// Check every file in the manifest against disk. If ALL match,
@@ -104,8 +130,17 @@ impl RestoreManifest {
         &self,
         anchor: &AbsoluteSystemPath,
     ) -> Option<Vec<turbopath::AnchoredSystemPathBuf>> {
-        let mut paths = Vec::with_capacity(self.files.len());
-        for rel_path in self.files.keys() {
+        // Use the order vec when present so the returned list matches
+        // the original archive order. Fall back to HashMap keys for
+        // manifests written before order tracking was added.
+        let keys: Vec<&str> = if self.order.len() == self.files.len() {
+            self.order.iter().map(|s| s.as_str()).collect()
+        } else {
+            self.files.keys().map(|s| s.as_str()).collect()
+        };
+
+        let mut paths = Vec::with_capacity(keys.len());
+        for rel_path in keys {
             let Ok(anchored) = turbopath::AnchoredSystemPathBuf::from_raw(rel_path) else {
                 return None;
             };

--- a/crates/turborepo-cache/src/fs.rs
+++ b/crates/turborepo-cache/src/fs.rs
@@ -196,14 +196,13 @@ impl FSCache {
             cache_item.add_file(anchor, file)?;
 
             let source_path = anchor.resolve(file);
-            // Only record regular files in the manifest (not dirs/symlinks)
-            if source_path
-                .symlink_metadata()
-                .map(|m| m.is_file())
-                .unwrap_or(false)
-            {
-                let unix_path = file.to_unix();
-                let _ = manifest.record_file(unix_path.as_str().to_owned(), &source_path);
+            let unix_path = file.to_unix();
+            if let Ok(m) = source_path.symlink_metadata() {
+                if m.is_file() {
+                    let _ = manifest.record_file(unix_path.as_str().to_owned(), &source_path);
+                } else if m.is_dir() {
+                    manifest.record_dir(unix_path.as_str().to_owned());
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

The manifest system from #12209 skips redundant file writes on cache restore, but the manifest only existed after the first restore. This meant the first cache hit always decompressed and wrote all files — a 7.6s penalty in large-monorepo that used to be sub-second.

Two changes fix this:

1. **Generate the manifest during `put()`** — stat files as they're archived, write `{hash}-manifest.json` alongside the tar.zst. Since outputs are still on disk from the build that just ran, the manifest is immediately usable.

2. **Fast path in `fetch()`** — before opening the tar.zst, validate the manifest against disk. If all files match (size, mtime, mode), return the file list immediately with zero decompression.

## How to test

```sh
# Clean cache and outputs, run cold build
rm -rf .turbo/cache apps/*/.next
turbo build --output-logs=none

# First cache hit — should be fast (manifest from put())
turbo build --output-logs=none

# Second cache hit — should be same speed
turbo build --output-logs=none
```

All three cache hit runs should report similar times. Previously the first was 10-15x slower than the second.