### PR TITLE
feat: Always write log files when using the summarize flag

### DIFF
--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -216,6 +216,7 @@ impl<'a> From<OptsInputs<'a>> for RunCacheOpts {
         RunCacheOpts {
             task_output_logs_override: inputs.execution_args.output_logs,
             errors_only_show_hash: inputs.config.future_flags().errors_only_show_hash,
+            always_write_log_file: inputs.config.run_summary(),
         }
     }
 }

--- a/crates/turborepo-run-cache/src/lib.rs
+++ b/crates/turborepo-run-cache/src/lib.rs
@@ -111,6 +111,10 @@ pub struct RunCache {
     /// complete successfully. Controlled by the `errorsOnlyShowHash` future
     /// flag.
     errors_only_show_hash: bool,
+    /// When true, always write `.turbo/turbo-<task>.log` files even when
+    /// caching is disabled for a task. Set when `--summarize` is enabled so
+    /// that the run summary always has log files to reference.
+    always_write_log_file: bool,
 }
 
 /// Trait used to output cache information to user
@@ -145,6 +149,7 @@ impl RunCache {
             output_watcher,
             ui,
             errors_only_show_hash: run_cache_opts.errors_only_show_hash,
+            always_write_log_file: run_cache_opts.always_write_log_file,
         }
     }
 
@@ -263,7 +268,9 @@ impl TaskCache {
     pub fn output_writer<W: Write>(&self, writer: W) -> Result<LogWriter<W>, Error> {
         let mut log_writer = LogWriter::default();
 
-        if !self.caching_disabled && !self.run_cache.writes_disabled {
+        if (!self.caching_disabled && !self.run_cache.writes_disabled)
+            || self.run_cache.always_write_log_file
+        {
             log_writer.with_log_file(&self.log_file_path)?;
         }
 

--- a/crates/turborepo-types/src/lib.rs
+++ b/crates/turborepo-types/src/lib.rs
@@ -409,6 +409,10 @@ pub struct RunCacheOpts {
     /// complete successfully. Controlled by the `errorsOnlyShowHash` future
     /// flag.
     pub errors_only_show_hash: bool,
+    /// When true, always write `.turbo/turbo-<task>.log` files even when
+    /// caching is disabled for a task. Set when `--summarize` is enabled so
+    /// that the run summary always has log files to reference.
+    pub always_write_log_file: bool,
 }
 
 /// Options for scope resolution.


### PR DESCRIPTION
### Description

Always write a log file when using the `--summarize` flag when running a task, even if the task itself is not cached. Based on discussion here: https://github.com/vercel/turborepo/discussions/12217

### Testing Instructions

- [ ] Create a new task that is not cached and run it with `--summarize`
- [ ] Check for a log file output in `.turbo/turbo-*.log`
