### PR TITLE
ci: Re-enable Rust unit tests in release workflow

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -245,32 +245,31 @@ jobs:
           cd cli && make stage-release
           echo "stage-branch=$(git branch --show-current)" >> $GITHUB_OUTPUT
 
-  # TODO: Re-enable Rust unit tests once flakiness is resolved.
-  # rust-smoke-test:
-  #   name: Rust Unit Tests
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 30
-  #   needs: [stage]
-  #   if: ${{ always() && needs.stage.result == 'success' }}
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ needs.stage.outputs.stage-branch }}
-  #
-  #     - name: Setup Environment
-  #       uses: ./.github/actions/setup-environment
-  #       with:
-  #         github-token: ${{ secrets.GITHUB_TOKEN }}
-  #         node: "false"
-  #
-  #     - name: Install cargo-nextest
-  #       uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532
-  #       with:
-  #         tool: nextest
-  #
-  #     - name: Run tests
-  #       timeout-minutes: 30
-  #       run: cargo nextest run --workspace
+  rust-smoke-test:
+    name: Rust Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: [stage]
+    if: ${{ always() && needs.stage.result == 'success' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.stage.outputs.stage-branch }}
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          node: "false"
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532
+        with:
+          tool: nextest
+
+      - name: Run tests
+        timeout-minutes: 30
+        run: cargo nextest run --workspace
 
   js-smoke-test:
     name: JS Package Tests
@@ -430,9 +429,8 @@ jobs:
     name: "Publish To NPM"
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # TODO: Add rust-smoke-test back to needs and if-condition when re-enabled.
-    needs: [stage, build-rust, build-gen, js-smoke-test]
-    if: ${{ always() && needs.stage.result == 'success' && needs.build-rust.result == 'success' && needs.build-gen.result == 'success' && needs.js-smoke-test.result == 'success' }}
+    needs: [stage, build-rust, build-gen, js-smoke-test, rust-smoke-test]
+    if: ${{ always() && needs.stage.result == 'success' && needs.build-rust.result == 'success' && needs.build-gen.result == 'success' && needs.js-smoke-test.result == 'success' && needs.rust-smoke-test.result == 'success' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -732,13 +730,13 @@ jobs:
     name: "Cleanup Failed Release"
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # TODO: Add rust-smoke-test back to needs and if-condition when re-enabled.
     needs:
       [
         stage,
         build-rust,
         build-gen,
         js-smoke-test,
+        rust-smoke-test,
         npm-publish,
         create-release-tag,
         create-release-pr
@@ -751,6 +749,7 @@ jobs:
           needs.build-rust.result == 'failure'
           || needs.build-gen.result == 'failure'
           || needs.js-smoke-test.result == 'failure'
+          || needs.rust-smoke-test.result == 'failure'
           || needs.npm-publish.result == 'failure'
           || needs.create-release-tag.result == 'failure'
           || needs.create-release-pr.result == 'failure'


### PR DESCRIPTION
## Summary

- Uncomments the `rust-smoke-test` job that was disabled due to flakiness
- Gates `npm-publish` on `rust-smoke-test` passing
- Triggers `cleanup-on-failure` when `rust-smoke-test` fails