### PR TITLE
docs: missing `migrate` word

### DIFF
--- a/apps/docs/content/docs/reference/turbo-codemod.mdx
+++ b/apps/docs/content/docs/reference/turbo-codemod.mdx
@@ -28,7 +28,7 @@ npx @turbo/codemod [transform] [path] [--dry] [--print]
 In most cases, you can run:
 
 ```bash title="Terminal"
-npx @turbo/codemod
+npx @turbo/codemod migrate
 ```
 
 All the codemods you need to upgrade will be run for you.


### PR DESCRIPTION
### Description

Was missing a word!
