### PR TITLE
fix: Remove stale build-gen references from release workflow

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -768,7 +768,6 @@ jobs:
       [
         stage,
         build-rust,
-        build-gen,
         js-smoke-test,
         npm-publish,
         create-release-tag,
@@ -780,7 +779,6 @@ jobs:
         && needs.stage.result == 'success'
         && (
           needs.build-rust.result == 'failure'
-          || needs.build-gen.result == 'failure'
           || needs.js-smoke-test.result == 'failure'
           || needs.npm-publish.result == 'failure'
           || needs.create-release-tag.result == 'failure'


### PR DESCRIPTION
## Summary

- The `build-gen` job was removed but `cleanup-on-failure` still referenced it in `needs` and the `if` condition, causing workflow validation to fail.