### PR TITLE
fix: Prevent run summary `SendError` panic on shutdown

### DIFF
--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -340,6 +340,13 @@ impl<'a> Visitor<'a> {
         let factory = ExecContextFactory::new(self, errors.clone(), self.manager.clone(), &engine)?;
         let cached_vendor_behavior = Vendor::infer().and_then(|vendor| vendor.behavior.as_ref());
 
+        // Errors from the dispatch loop are captured here rather than returned
+        // immediately. This ensures we always drain the FuturesUnordered below,
+        // so that every spawned task's TaskTracker is consumed before the
+        // ExecutionTracker is dropped. Without this, orphaned TaskTrackers can
+        // panic with SendError during shutdown.
+        let mut dispatch_error: Option<Error> = None;
+
         loop {
             let message = node_stream
                 .recv()
@@ -353,13 +360,13 @@ impl<'a> Visitor<'a> {
             let crate::engine::Message { info, callback } = message;
             let package_name = PackageName::from(info.package());
 
-            let workspace_info =
-                self.package_graph
-                    .package_info(&package_name)
-                    .ok_or_else(|| Error::MissingPackage {
-                        package_name: package_name.clone(),
-                        task_id: info.clone(),
-                    })?;
+            let Some(workspace_info) = self.package_graph.package_info(&package_name) else {
+                dispatch_error = Some(Error::MissingPackage {
+                    package_name: package_name.clone(),
+                    task_id: info.clone(),
+                });
+                break;
+            };
 
             let command = workspace_info.package_json.scripts.get(info.task());
 
@@ -371,24 +378,28 @@ impl<'a> Visitor<'a> {
                     package_task_event.track_error(TrackedErrors::RecursiveError);
                     let (span, text) = cmd.span_and_text("package.json");
 
-                    return Err(Error::RecursiveTurbo(Box::new(RecursiveTurboError {
+                    dispatch_error = Some(Error::RecursiveTurbo(Box::new(RecursiveTurboError {
                         task_name: info.to_string(),
                         command: cmd.to_string(),
                         span,
                         text,
                     })));
+                    break;
                 }
                 _ => (),
             }
 
-            let task_definition = engine
-                .task_definition(&info)
-                .ok_or(Error::MissingDefinition)?;
+            let Some(task_definition) = engine.task_definition(&info) else {
+                dispatch_error = Some(Error::MissingDefinition);
+                break;
+            };
 
             // Move pre-computed hash and env out of the map — each task is
             // dispatched exactly once, so remove avoids cloning the env map.
-            let (task_hash, execution_env) =
-                precomputed.remove(&info).ok_or(Error::MissingDefinition)?;
+            let Some((task_hash, execution_env)) = precomputed.remove(&info) else {
+                dispatch_error = Some(Error::MissingDefinition);
+                break;
+            };
 
             debug!("task {} hash is {}", info, task_hash);
 
@@ -429,14 +440,20 @@ impl<'a> Visitor<'a> {
 
                     let exec_context = {
                         let _span = tracing::info_span!("exec_context_new").entered();
-                        factory.exec_context(
+                        match factory.exec_context(
                             info.clone(),
                             task_hash,
                             task_cache,
                             execution_env,
                             takes_input,
                             self.task_access.clone(),
-                        )?
+                        ) {
+                            Ok(ctx) => ctx,
+                            Err(e) => {
+                                dispatch_error = Some(e);
+                                break;
+                            }
+                        }
                     };
                     let Some(mut exec_context) = exec_context else {
                         continue;
@@ -460,9 +477,17 @@ impl<'a> Visitor<'a> {
             }
         }
 
-        // Wait for the engine task to finish and for all of our tasks to finish
-        engine_handle.await.expect("engine execution panicked")?;
-        // This will poll the futures until they are all completed
+        // Close the receiver so the engine can finish if we broke out early.
+        // Without this, the engine would block trying to send the next task.
+        drop(node_stream);
+
+        // Always wait for the engine, even after a dispatch error. If we broke
+        // early the engine will see the closed channel and return
+        // Err(ExecuteError::Visitor), which is expected — not a real error.
+        let engine_result = engine_handle.await.expect("engine execution panicked");
+
+        // Always drain spawned tasks so every TaskTracker is consumed before
+        // the ExecutionTracker is dropped.
         let mut internal_errors = Vec::new();
         while let Some(result) = tasks.next().await {
             if let Err(e) = result.unwrap_or_else(|e| panic!("task executor panicked: {e}")) {
@@ -476,6 +501,14 @@ impl<'a> Visitor<'a> {
                 handle.stop().await;
             }
         }
+
+        // Propagate the dispatch error first — the engine error is an expected
+        // consequence of us closing the channel early, not a root cause.
+        if let Some(err) = dispatch_error {
+            return Err(err);
+        }
+
+        engine_result?;
 
         if !internal_errors.is_empty() {
             return Err(Error::InternalErrors(

--- a/crates/turborepo-run-summary/src/execution.rs
+++ b/crates/turborepo-run-summary/src/execution.rs
@@ -316,7 +316,7 @@ impl TaskTracker<()> {
                 state: None,
             })
             .await
-            .expect("execution summary state thread finished");
+            .ok();
         TaskTracker {
             sender,
             started_at,
@@ -339,7 +339,7 @@ impl TaskTracker<()> {
                 }),
             })
             .await
-            .expect("execution summary state thread finished")
+            .ok();
     }
 }
 
@@ -374,7 +374,7 @@ impl TaskTracker<chrono::DateTime<Local>> {
                 state: Some(state),
             })
             .await
-            .expect("summary state thread finished");
+            .ok();
         execution
     }
 
@@ -403,7 +403,7 @@ impl TaskTracker<chrono::DateTime<Local>> {
                 state: Some(state),
             })
             .await
-            .expect("summary state thread finished");
+            .ok();
         execution
     }
 
@@ -436,7 +436,7 @@ impl TaskTracker<chrono::DateTime<Local>> {
                 state: Some(state),
             })
             .await
-            .expect("summary state thread finished");
+            .ok();
         execution
     }
 }
@@ -637,5 +637,78 @@ mod test {
         assert_eq!(summary.failed, 2);
         assert_eq!(summary.cached, 5);
         assert_eq!(summary.exit_code, 1);
+    }
+
+    // Regression tests for https://github.com/vercel/turborepo/issues/11527
+    //
+    // The crash occurs when a TaskTracker tries to send to the state thread
+    // after its receiver has been dropped (e.g. during tokio runtime shutdown).
+    // These tests verify that every send site handles a dead receiver
+    // gracefully instead of panicking.
+    //
+    // We construct trackers with an already-closed channel to guarantee the
+    // send path hits Err(SendError) — the exact condition from the bug.
+
+    fn tracker_with_dead_channel() -> TaskTracker<()> {
+        let (sender, receiver) = mpsc::channel::<Message>(1);
+        drop(receiver);
+        TaskTracker {
+            sender,
+            started_at: (),
+            task_id: TaskId::new("pkg", "build"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_start_with_dead_receiver() {
+        let tracker = tracker_with_dead_channel();
+        // start() sends Event::Building — must not panic
+        tracker.start().await;
+    }
+
+    #[tokio::test]
+    async fn test_dry_run_with_dead_receiver() {
+        let tracker = tracker_with_dead_channel();
+        // dry_run() sends Event::Canceled — must not panic
+        tracker.dry_run().await;
+    }
+
+    #[tokio::test]
+    async fn test_cached_with_dead_receiver() {
+        let (sender, receiver) = mpsc::channel::<Message>(1);
+        drop(receiver);
+        let tracker: TaskTracker<DateTime<Local>> = TaskTracker {
+            sender,
+            started_at: Local::now(),
+            task_id: TaskId::new("pkg", "build"),
+        };
+        // cached() sends Event::Cached — must not panic
+        tracker.cached().await;
+    }
+
+    #[tokio::test]
+    async fn test_build_succeeded_with_dead_receiver() {
+        let (sender, receiver) = mpsc::channel::<Message>(1);
+        drop(receiver);
+        let tracker: TaskTracker<DateTime<Local>> = TaskTracker {
+            sender,
+            started_at: Local::now(),
+            task_id: TaskId::new("pkg", "build"),
+        };
+        // build_succeeded() sends Event::Built — must not panic
+        tracker.build_succeeded(0).await;
+    }
+
+    #[tokio::test]
+    async fn test_build_failed_with_dead_receiver() {
+        let (sender, receiver) = mpsc::channel::<Message>(1);
+        drop(receiver);
+        let tracker: TaskTracker<DateTime<Local>> = TaskTracker {
+            sender,
+            started_at: Local::now(),
+            task_id: TaskId::new("pkg", "build"),
+        };
+        // build_failed() sends Event::BuildFailed — must not panic
+        tracker.build_failed(Some(1), "error").await;
     }
 }


### PR DESCRIPTION
## Summary

Fixes #11527 — turbo crashes with a `SendError` panic in `turborepo-run-summary` after a successful build.

The crash occurs when a `TaskTracker` tries to send to the `ExecutionTracker`'s state thread after its receiver has been dropped during error recovery or tokio runtime shutdown. The root cause is that `Visitor::visit()` has early-return error paths in its dispatch loop that skip draining the `FuturesUnordered`, leaving spawned tasks with live `TaskTracker` senders orphaned.

## Changes

**`visitor/mod.rs`**: Restructure the dispatch loop so errors are captured into a local `Option<Error>` and `break` instead of returning early. After the loop, we always:
1. `drop(node_stream)` — close the receiver so the engine can finish
2. Await the engine handle
3. Drain all spawned task futures (ensuring every `TaskTracker` is consumed)
4. Only then propagate the captured error

**`execution.rs`**: Replace all 5 `.expect()` calls on `sender.send()` with `.ok()` as defense-in-depth. Even with the drain fix, edge cases during tokio runtime shutdown can race. A lost summary message is harmless compared to a process crash.

**Tests**: 5 regression tests that construct a `TaskTracker` with an already-dead channel receiver (guaranteeing `Err(SendError)`) and verify every send site handles it gracefully — one test per `.ok()` site.

## How to verify

```
cargo test -p turborepo-run-summary --lib
cargo clippy -p turborepo-run-summary -p turborepo-lib --lib
```