### PR TITLE
fix: Cap rayon thread pool and `block_in_place` in tokio to prevent deadlock potential

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7718,6 +7718,7 @@ dependencies = [
  "turborepo-process",
  "turborepo-profile-md",
  "turborepo-query-api",
+ "turborepo-rayon-compat",
  "turborepo-repository",
  "turborepo-run-cache",
  "turborepo-run-summary",
@@ -7945,6 +7946,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "turborepo-rayon-compat"
+version = "0.1.0"
+dependencies = [
+ "rayon",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "turborepo-repository"
 version = "0.1.0"
 dependencies = [
@@ -7979,6 +7989,7 @@ dependencies = [
  "turborepo-errors",
  "turborepo-graph-utils",
  "turborepo-lockfiles",
+ "turborepo-rayon-compat",
  "turborepo-unescape",
  "wax",
  "which",
@@ -8029,6 +8040,7 @@ dependencies = [
  "turborepo-hash",
  "turborepo-lockfiles",
  "turborepo-otel",
+ "turborepo-rayon-compat",
  "turborepo-repository",
  "turborepo-scm",
  "turborepo-task-id",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ turborepo-task-executor = { path = "crates/turborepo-task-executor" }
 turborepo-task-hash = { path = "crates/turborepo-task-hash" }
 turborepo-turbo-json = { path = "crates/turborepo-turbo-json" }
 turborepo-otel = { path = "crates/turborepo-otel" }
+turborepo-rayon-compat = { path = "crates/turborepo-rayon-compat" }
 wax = { path = "crates/turborepo-wax" }
 turborepo-shim = { path = "crates/turborepo-shim" }
 turborepo-vercel-api = { path = "crates/turborepo-vercel-api" }

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -120,6 +120,7 @@ turborepo-otel = { workspace = true }
 turborepo-process = { workspace = true }
 turborepo-profile-md = { workspace = true }
 turborepo-query-api = { workspace = true }
+turborepo-rayon-compat = { workspace = true }
 turborepo-repository = { path = "../turborepo-repository" }
 turborepo-run-cache = { path = "../turborepo-run-cache" }
 turborepo-run-summary = { workspace = true }

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -39,6 +39,56 @@ pub const INVOCATION_DIR_ENV_VAR: &str = "TURBO_INVOCATION_DIR";
 
 // Default value for the --cache-workers argument
 const DEFAULT_NUM_WORKERS: u32 = 10;
+
+/// Returns a scaled thread count for rayon's global pool based on
+/// available CPU cores, capped at
+/// [`crate::rayon_compat::MAX_RAYON_THREADS`].
+///
+/// See [`init_rayon_pool`] and <https://github.com/vercel/turborepo/issues/12251>
+fn rayon_pool_size() -> usize {
+    let cpus = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+    crate::rayon_compat::scale_thread_count(cpus)
+}
+
+/// Explicitly initialize rayon's global thread pool early so we control
+/// its size and initialization timing.
+///
+/// If `RAYON_NUM_THREADS` is set, its value is still clamped to
+/// [`crate::rayon_compat::MAX_RAYON_THREADS`] to prevent the known
+/// deadlock on high-core-count machines.
+fn init_rayon_pool() {
+    let pool_size = match std::env::var("RAYON_NUM_THREADS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+    {
+        Some(user_val) => {
+            let clamped = crate::rayon_compat::scale_thread_count(user_val);
+            if clamped < user_val {
+                tracing::debug!(
+                    requested = user_val,
+                    clamped,
+                    max = crate::rayon_compat::MAX_RAYON_THREADS,
+                    "RAYON_NUM_THREADS exceeds safe limit, clamping"
+                );
+            }
+            clamped
+        }
+        None => rayon_pool_size(),
+    };
+
+    tracing::info!(
+        rayon_pool_size = pool_size,
+        "initializing rayon global pool"
+    );
+
+    let builder = rayon::ThreadPoolBuilder::new().num_threads(pool_size);
+    if let Err(e) = builder.build_global() {
+        tracing::warn!("rayon global pool already initialized: {e}");
+    }
+}
+
 const SUPPORTED_GRAPH_FILE_EXTENSIONS: [&str; 8] =
     ["svg", "png", "jpg", "pdf", "json", "html", "mermaid", "dot"];
 
@@ -1291,17 +1341,34 @@ fn get_command(cli_args: &mut Args) -> Result<Command, Error> {
 ///
 /// # Arguments
 ///
-/// * `repo_state`: If we have done repository inference and NOT executed
-/// local turbo, such as in the case where `TURBO_BINARY_PATH` is set,
-/// we use it here to modify clap's arguments.
+/// * `repo_state`: If we have done repository inference and NOT executed local
+///   turbo, such as in the case where `TURBO_BINARY_PATH` is set, we use it
+///   here to modify clap's arguments.
 /// * `logger`: The logger to use for the run.
 /// * `color_config`: The color configuration to use for the run, i.e. whether
 ///   we should colorize output.
 ///
-/// returns: Result<Payload, Error>
-#[tokio::main]
+/// returns: Result<i32, Error>
+pub fn run(
+    repo_state: Option<RepoState>,
+    logger: &TurboSubscriber,
+    color_config: ColorConfig,
+    query_server: Option<Arc<dyn turborepo_query_api::QueryServer>>,
+) -> Result<i32, Error> {
+    // Initialize rayon's global pool before the tokio runtime so we
+    // control thread count and avoid lazy initialization during a hot path.
+    init_rayon_pool();
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("failed to build tokio runtime");
+
+    runtime.block_on(run_main(repo_state, logger, color_config, query_server))
+}
+
 #[tracing::instrument(skip_all)]
-pub async fn run(
+async fn run_main(
     repo_state: Option<RepoState>,
     #[allow(unused_variables)] logger: &TurboSubscriber,
     color_config: ColorConfig,

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -25,6 +25,7 @@ mod microfrontends;
 mod opts;
 mod package_changes_watcher;
 mod panic_handler;
+mod rayon_compat;
 mod run;
 mod shim;
 mod task_graph;

--- a/crates/turborepo-lib/src/rayon_compat.rs
+++ b/crates/turborepo-lib/src/rayon_compat.rs
@@ -1,0 +1,1 @@
+pub(crate) use turborepo_rayon_compat::{block_in_place, scale_thread_count, MAX_RAYON_THREADS};

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -488,10 +488,10 @@ impl RunBuilder {
             let _span = tracing::info_span!("env_infer").entered();
             EnvironmentVariableMap::infer()
         };
-        {
+        crate::rayon_compat::block_in_place(|| {
             let _span = tracing::info_span!("turbo_json_preload").entered();
             turbo_json_loader.preload_all();
-        }
+        });
 
         let filtered_pkgs = {
             let _span = tracing::info_span!("calculate_filtered_packages").entered();

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -618,50 +618,53 @@ impl Run {
         let mut global_file_result = None;
 
         let _hash_scope_span = tracing::info_span!("hash_scope").entered();
-        rayon::scope(|s| {
-            s.spawn(|_| {
-                let _span = tracing::info_span!("calculate_file_hashes_task").entered();
-                let needs_expanded = self.opts.run_opts.dry_run.is_some()
-                    || self.opts.run_opts.summarize
-                    || self.observability_handle.is_some();
-                file_hash_result = Some(PackageInputsHashes::calculate_file_hashes(
-                    &self.scm,
-                    self.engine.tasks(),
-                    workspaces,
-                    self.engine.task_definitions(),
-                    &self.repo_root,
-                    &self.run_telemetry,
-                    repo_index,
-                    needs_expanded,
-                ));
-            });
-            s.spawn(|_| {
-                let _span = tracing::info_span!("get_internal_deps_hash_task").entered();
-                internal_deps_result = Some(
-                    internal_dep_paths
-                        .map(|dep_paths| {
-                            get_internal_deps_hash(
-                                &self.scm,
-                                &self.repo_root,
-                                dep_paths,
-                                repo_index,
-                            )
-                        })
-                        .transpose(),
-                );
-            });
-            s.spawn(|_| {
-                let _span = tracing::info_span!("collect_global_file_hash_inputs_task").entered();
-                global_file_result = Some(collect_global_file_hash_inputs(
-                    root_workspace,
-                    &self.repo_root,
-                    self.pkg_dep_graph.package_manager(),
-                    self.pkg_dep_graph.lockfile(),
-                    &self.root_turbo_json.global_deps,
-                    &self.env_at_execution_start,
-                    &self.root_turbo_json.global_env,
-                    &self.scm,
-                ));
+        crate::rayon_compat::block_in_place(|| {
+            rayon::scope(|s| {
+                s.spawn(|_| {
+                    let _span = tracing::info_span!("calculate_file_hashes_task").entered();
+                    let needs_expanded = self.opts.run_opts.dry_run.is_some()
+                        || self.opts.run_opts.summarize
+                        || self.observability_handle.is_some();
+                    file_hash_result = Some(PackageInputsHashes::calculate_file_hashes(
+                        &self.scm,
+                        self.engine.tasks(),
+                        workspaces,
+                        self.engine.task_definitions(),
+                        &self.repo_root,
+                        &self.run_telemetry,
+                        repo_index,
+                        needs_expanded,
+                    ));
+                });
+                s.spawn(|_| {
+                    let _span = tracing::info_span!("get_internal_deps_hash_task").entered();
+                    internal_deps_result = Some(
+                        internal_dep_paths
+                            .map(|dep_paths| {
+                                get_internal_deps_hash(
+                                    &self.scm,
+                                    &self.repo_root,
+                                    dep_paths,
+                                    repo_index,
+                                )
+                            })
+                            .transpose(),
+                    );
+                });
+                s.spawn(|_| {
+                    let _span =
+                        tracing::info_span!("collect_global_file_hash_inputs_task").entered();
+                    global_file_result = Some(collect_global_file_hash_inputs(
+                        root_workspace,
+                        &self.repo_root,
+                        self.pkg_dep_graph.package_manager(),
+                        self.pkg_dep_graph.lockfile(),
+                        &self.root_turbo_json.global_deps,
+                        &self.env_at_execution_start,
+                        &self.root_turbo_json.global_env,
+                        &self.scm,
+                    ));
+                });
             });
         });
 

--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -149,7 +149,9 @@ impl<'a> Visitor<'a> {
                 global_env_patterns,
             );
 
-            task_hasher.precompute_external_deps_hashes(package_graph.packages());
+            crate::rayon_compat::block_in_place(|| {
+                task_hasher.precompute_external_deps_hashes(package_graph.packages());
+            });
 
             let sink = Self::sink(run_opts);
             let color_cache = ColorSelector::default();
@@ -321,10 +323,10 @@ impl<'a> Visitor<'a> {
         // task's dependency hashes are available before it is hashed.
         // This replaces the per-task serial hashing that was inside the
         // dispatch loop.
-        let mut precomputed = {
+        let mut precomputed = crate::rayon_compat::block_in_place(|| {
             let _span = tracing::info_span!("precompute_task_hashes").entered();
-            self.precompute_task_hashes(&engine, telemetry)?
-        };
+            self.precompute_task_hashes(&engine, telemetry)
+        })?;
 
         let concurrency = self.run_opts.concurrency as usize;
         let (node_sender, mut node_stream) = mpsc::channel(concurrency);

--- a/crates/turborepo-rayon-compat/Cargo.toml
+++ b/crates/turborepo-rayon-compat/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "turborepo-rayon-compat"
+version = "0.1.0"
+edition = { workspace = true }
+license = "MIT"
+
+[lints]
+workspace = true
+
+[dependencies]
+rayon = "1"
+tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }

--- a/crates/turborepo-rayon-compat/src/lib.rs
+++ b/crates/turborepo-rayon-compat/src/lib.rs
@@ -1,0 +1,88 @@
+/// Safe ceiling for rayon's global thread pool.
+///
+/// Rayon has a known initialization race condition that can deadlock
+/// above ~90 threads on Linux. In [testing][issue], 96 cores always
+/// deadlocked while 60 cores never did. 72 is a conservative cap — the
+/// highest multiple of 8 below the observed failure threshold — giving
+/// headroom against variance across kernel versions and schedulers.
+///
+/// [issue]: https://github.com/vercel/turborepo/issues/12251
+pub const MAX_RAYON_THREADS: usize = 72;
+
+/// Scale a CPU count to a safe rayon thread pool size.
+///
+/// Uses all available cores up to [`MAX_RAYON_THREADS`], then caps.
+/// Always returns at least 1.
+pub fn scale_thread_count(cpus: usize) -> usize {
+    cpus.clamp(1, MAX_RAYON_THREADS)
+}
+
+/// Run a blocking closure, notifying the tokio runtime when possible.
+///
+/// On a multi-threaded tokio runtime this calls `tokio::task::block_in_place`
+/// so the runtime can spawn a replacement worker. On current-thread runtimes
+/// (common in tests) or outside of tokio the closure runs directly.
+pub fn block_in_place<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    use tokio::runtime::{Handle, RuntimeFlavor};
+    match Handle::try_current().map(|h| h.runtime_flavor()) {
+        Ok(RuntimeFlavor::MultiThread) => tokio::task::block_in_place(f),
+        _ => f(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scale_thread_count_always_at_least_one() {
+        assert_eq!(scale_thread_count(0), 1);
+        assert_eq!(scale_thread_count(1), 1);
+    }
+
+    #[test]
+    fn scale_thread_count_preserves_small_values() {
+        assert_eq!(scale_thread_count(2), 2);
+        assert_eq!(scale_thread_count(4), 4);
+        assert_eq!(scale_thread_count(8), 8);
+        assert_eq!(scale_thread_count(16), 16);
+    }
+
+    #[test]
+    fn scale_thread_count_caps_at_max() {
+        assert_eq!(scale_thread_count(72), MAX_RAYON_THREADS);
+        assert_eq!(scale_thread_count(96), MAX_RAYON_THREADS);
+        assert_eq!(scale_thread_count(128), MAX_RAYON_THREADS);
+        assert_eq!(scale_thread_count(256), MAX_RAYON_THREADS);
+    }
+
+    #[test]
+    fn block_in_place_works_outside_runtime() {
+        let result = block_in_place(|| 42);
+        assert_eq!(result, 42);
+    }
+
+    #[tokio::test]
+    async fn block_in_place_works_on_current_thread_runtime() {
+        let result = block_in_place(|| 42);
+        assert_eq!(result, 42);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn block_in_place_works_on_multi_thread_runtime() {
+        let result = block_in_place(|| 42);
+        assert_eq!(result, 42);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn block_in_place_with_rayon_completes() {
+        let result = block_in_place(|| {
+            use rayon::prelude::*;
+            (0..1000).into_par_iter().map(|i| i * 2).sum::<i64>()
+        });
+        assert_eq!(result, 999_000);
+    }
+}

--- a/crates/turborepo-repository/Cargo.toml
+++ b/crates/turborepo-repository/Cargo.toml
@@ -37,6 +37,7 @@ turbopath = { workspace = true, features = ["biome"] }
 turborepo-errors = { workspace = true }
 turborepo-graph-utils = { path = "../turborepo-graph-utils" }
 turborepo-lockfiles = { workspace = true }
+turborepo-rayon-compat = { workspace = true }
 turborepo-unescape = { workspace = true }
 wax = { workspace = true }
 which = { workspace = true }

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -326,7 +326,7 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedPackageManager, T> {
                 let workspace_paths: Vec<_> =
                     self.package_discovery.discover_packages().await?.workspaces;
 
-                let results: Vec<_> = {
+                let results: Vec<_> = turborepo_rayon_compat::block_in_place(|| {
                     use rayon::prelude::*;
                     workspace_paths
                         .into_par_iter()
@@ -334,8 +334,8 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedPackageManager, T> {
                             let json = PackageJson::load(&path.package_json)?;
                             Ok((path.package_json, json))
                         })
-                        .collect::<Result<Vec<_>, Error>>()?
-                };
+                        .collect::<Result<Vec<_>, Error>>()
+                })?;
 
                 let mut jsons = HashMap::with_capacity(results.len());
                 for (path, json) in results {
@@ -516,7 +516,9 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedWorkspaces, T> {
             .discover_packages()
             .await?
             .package_manager;
-        self.connect_internal_dependencies(&package_manager)?;
+        turborepo_rayon_compat::block_in_place(|| {
+            self.connect_internal_dependencies(&package_manager)
+        })?;
 
         if let Some(handle) = lockfile_future
             && let Ok(Some(lockfile)) = handle.await
@@ -609,7 +611,9 @@ impl<T: PackageDiscovery> BuildState<'_, ResolvedLockfile, T> {
 
     #[tracing::instrument(skip(self))]
     async fn build_inner(mut self) -> Result<PackageGraph, discovery::Error> {
-        if let Err(e) = self.populate_transitive_dependencies() {
+        if let Err(e) =
+            turborepo_rayon_compat::block_in_place(|| self.populate_transitive_dependencies())
+        {
             warn!("Unable to calculate transitive closures: {}", e);
         }
         let package_manager = self

--- a/crates/turborepo-run-summary/Cargo.toml
+++ b/crates/turborepo-run-summary/Cargo.toml
@@ -23,6 +23,7 @@ turborepo-env = { workspace = true }
 turborepo-hash = { workspace = true }
 turborepo-lockfiles = { workspace = true }
 turborepo-otel = { workspace = true }
+turborepo-rayon-compat = { workspace = true }
 turborepo-repository = { workspace = true }
 turborepo-scm = { workspace = true }
 turborepo-task-id = { workspace = true }

--- a/crates/turborepo-run-summary/src/tracker.rs
+++ b/crates/turborepo-run-summary/src/tracker.rs
@@ -160,7 +160,7 @@ impl RunTracker {
 
         // Build task summaries in parallel — each task_summary call is read-only
         // on the engine, hash tracker, and package graph.
-        let tasks = {
+        let tasks = turborepo_rayon_compat::block_in_place(|| {
             use rayon::prelude::*;
             let results: Vec<Result<TaskSummary, crate::task_factory::Error>> = summary_state
                 .tasks
@@ -172,8 +172,8 @@ impl RunTracker {
                 .collect();
             results
                 .into_iter()
-                .collect::<Result<Vec<_>, crate::task_factory::Error>>()?
-        };
+                .collect::<Result<Vec<_>, crate::task_factory::Error>>()
+        })?;
         let execution_summary = ExecutionSummary::new(
             self.synthesized_command.clone(),
             summary_state,


### PR DESCRIPTION
## Summary

- Fixes a deadlock where `turbo run` hangs indefinitely on 96+ core Linux machines due to a rayon global thread pool initialization race condition
- Caps the rayon pool at 72 threads, initializes it explicitly before the tokio runtime, and wraps rayon blocking operations in `block_in_place()` so tokio can compensate

Addresses #12251 but won't mark as closed until reporter confirms the issue is no longer observed.

## What changed

**New crate: `turborepo-rayon-compat`** — shared leaf crate providing:
- `MAX_RAYON_THREADS` (72) — conservative cap below the observed ~90-thread failure threshold
- `scale_thread_count()` — clamps a CPU count to the safe range
- `block_in_place()` — bridges rayon blocking work from tokio async contexts by detecting the runtime flavor and calling `tokio::task::block_in_place` only on multi-thread runtimes

**`cli/mod.rs`** — `run()` is now synchronous. It initializes the rayon pool, then manually constructs the tokio runtime. The previous async body lives in `run_main()`. `RAYON_NUM_THREADS` is respected but clamped to the safe maximum so it can't re-enable the deadlock.

**Call sites** — Six rayon entry points across `turborepo-lib`, `turborepo-repository`, and `turborepo-run-summary` are wrapped in `block_in_place()` so tokio workers aren't starved during parallel file hashing, package graph construction, or summary generation.