### PR TITLE
fix: Use BTreeMap for deterministic lockfile dependency ordering

### DIFF
--- a/crates/turborepo-engine/src/builder.rs
+++ b/crates/turborepo-engine/src/builder.rs
@@ -1233,8 +1233,10 @@ mod test {
         fn all_dependencies(
             &self,
             _key: &str,
-        ) -> Result<Option<std::borrow::Cow<'_, HashMap<String, String>>>, turborepo_lockfiles::Error>
-        {
+        ) -> Result<
+            Option<std::borrow::Cow<'_, std::collections::BTreeMap<String, String>>>,
+            turborepo_lockfiles::Error,
+        > {
             unreachable!()
         }
 

--- a/crates/turborepo-lockfiles/src/berry/mod.rs
+++ b/crates/turborepo-lockfiles/src/berry/mod.rs
@@ -558,15 +558,17 @@ impl Lockfile for BerryLockfile {
     fn all_dependencies(
         &self,
         key: &str,
-    ) -> Result<Option<std::borrow::Cow<'_, std::collections::HashMap<String, String>>>, crate::Error>
-    {
+    ) -> Result<
+        Option<std::borrow::Cow<'_, std::collections::BTreeMap<String, String>>>,
+        crate::Error,
+    > {
         let locator = Locator::try_from(key).map_err(Error::from)?;
 
         let Some(package) = self.locator_package.get(&locator) else {
             return Ok(None);
         };
 
-        let mut map = HashMap::new();
+        let mut map = std::collections::BTreeMap::new();
         for (name, version) in package.dependencies.iter().flatten() {
             let mut dependency = Descriptor::new(name, version.as_ref()).unwrap();
             for (resolution, reference) in &self.overrides {

--- a/crates/turborepo-lockfiles/src/bun/mod.rs
+++ b/crates/turborepo-lockfiles/src/bun/mod.rs
@@ -88,7 +88,12 @@
 //! - [`PackageEntry`]: External package representation
 //! - [`LockfileVersion`]: Version enum for format compatibility
 
-use std::{any::Any, collections::HashMap, str::FromStr, sync::OnceLock};
+use std::{
+    any::Any,
+    collections::{BTreeMap, HashMap},
+    str::FromStr,
+    sync::OnceLock,
+};
 
 use biome_json_formatter::context::JsonFormatOptions;
 use biome_json_parser::JsonParserOptions;
@@ -588,8 +593,10 @@ impl Lockfile for BunLockfile {
     fn all_dependencies(
         &self,
         key: &str,
-    ) -> Result<Option<std::borrow::Cow<'_, std::collections::HashMap<String, String>>>, crate::Error>
-    {
+    ) -> Result<
+        Option<std::borrow::Cow<'_, std::collections::BTreeMap<String, String>>>,
+        crate::Error,
+    > {
         let entry_key = self
             .key_to_entry
             .get(key)
@@ -600,7 +607,7 @@ impl Lockfile for BunLockfile {
             .get(entry_key)
             .ok_or_else(|| crate::Error::MissingPackage(key.into()))?;
 
-        let mut deps = HashMap::new();
+        let mut deps = std::collections::BTreeMap::new();
 
         let Some(info) = &entry.info else {
             return Ok(Some(std::borrow::Cow::Owned(deps)));
@@ -1612,11 +1619,11 @@ impl BunLockfile {
         };
 
         // Collect workspace dependencies
-        let workspace_deps: HashMap<String, HashMap<String, String>> = pruned_data
+        let workspace_deps: HashMap<String, BTreeMap<String, String>> = pruned_data
             .workspaces
             .iter()
             .map(|(ws_path, ws_entry)| {
-                let mut deps = HashMap::new();
+                let mut deps = BTreeMap::new();
                 if let Some(d) = &ws_entry.dependencies {
                     deps.extend(d.clone());
                 }
@@ -2534,7 +2541,7 @@ mod test {
         let lockfile = BunLockfile::from_str(&contents).unwrap();
 
         // Simulate what turbo prune would call: Get transitive closure first
-        let unresolved_deps: std::collections::HashMap<String, String> =
+        let unresolved_deps: std::collections::BTreeMap<String, String> =
             [("@hookform/resolvers".to_string(), "^5.0.1".to_string())]
                 .into_iter()
                 .collect();
@@ -3094,7 +3101,7 @@ mod test {
         let lockfile = BunLockfile::from_str(&contents).unwrap();
 
         // Compute transitive closure for app1 (simulating turbo prune --scope=app1)
-        let mut app1_deps = std::collections::HashMap::new();
+        let mut app1_deps = std::collections::BTreeMap::new();
         app1_deps.insert("color".to_string(), "^5.0.3".to_string());
         app1_deps.insert("express-winston".to_string(), "4.2.0".to_string());
 
@@ -3229,7 +3236,7 @@ mod test {
         // Prune for apps/web only. The transitive closure includes
         // negotiator@0.6.3 (via accepts) but NOT negotiator@0.6.4 (only
         // needed by compression, which is in apps/admin).
-        let mut web_deps = std::collections::HashMap::new();
+        let mut web_deps = std::collections::BTreeMap::new();
         web_deps.insert("express".to_string(), "^4.18.0".to_string());
         let closure = crate::transitive_closure(&lockfile, "apps/web", web_deps, false).unwrap();
         let package_idents: Vec<String> = closure.iter().map(|pkg| pkg.key.clone()).collect();
@@ -3306,7 +3313,7 @@ mod test {
         // chalk/ansi-styles -> chalk/ansi-styles/color-convert ->
         // chalk/ansi-styles/color-convert/color-name but NOT the hoisted
         // ansi-styles@4.3.0, color-convert@2.0.1, or color-name@2.1.0.
-        let mut web_deps = std::collections::HashMap::new();
+        let mut web_deps = std::collections::BTreeMap::new();
         web_deps.insert("express-winston".to_string(), "4.2.0".to_string());
         let closure = crate::transitive_closure(&lockfile, "apps/web", web_deps, false).unwrap();
         let package_idents: Vec<String> = closure.iter().map(|pkg| pkg.key.clone()).collect();
@@ -3406,7 +3413,7 @@ mod test {
         );
 
         // Prune to just the api workspace
-        let mut api_deps = std::collections::HashMap::new();
+        let mut api_deps = std::collections::BTreeMap::new();
         api_deps.insert(
             "@api/sdk".to_string(),
             "file:apps/api/.api/apis/sdk".to_string(),

--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -22,7 +22,7 @@ mod yarn1;
 use std::{
     any::Any,
     borrow::Cow,
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
 };
 
 pub use berry::{Error as BerryError, *};
@@ -37,7 +37,7 @@ use turbopath::RelativeUnixPathBuf;
 pub use yarn1::{Yarn1Lockfile, yarn_subgraph};
 
 type ResolveCache = DashMap<String, Option<Package>>;
-type DepsCache = DashMap<String, Option<HashMap<String, String>>>;
+type DepsCache = DashMap<String, Option<BTreeMap<String, String>>>;
 
 #[derive(Debug, PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Serialize)]
 pub struct Package {
@@ -76,7 +76,7 @@ pub trait Lockfile: Send + Sync + Any + std::fmt::Debug {
     fn all_dependencies(
         &self,
         key: &str,
-    ) -> Result<Option<Cow<'_, HashMap<String, String>>>, Error>;
+    ) -> Result<Option<Cow<'_, BTreeMap<String, String>>>, Error>;
 
     /// Given a list of workspace packages and external packages that are
     /// dependencies of the workspace packages, produce a lockfile that only
@@ -130,7 +130,7 @@ pub trait Lockfile: Send + Sync + Any + std::fmt::Debug {
 /// version) and calculates the transitive closures for all of them
 pub fn all_transitive_closures<L: Lockfile + ?Sized>(
     lockfile: &L,
-    workspaces: HashMap<String, HashMap<String, String>>,
+    workspaces: HashMap<String, BTreeMap<String, String>>,
     ignore_missing_packages: bool,
 ) -> Result<HashMap<String, HashSet<Package>>, Error> {
     let resolve_cache: ResolveCache = DashMap::new();
@@ -155,7 +155,7 @@ pub fn all_transitive_closures<L: Lockfile + ?Sized>(
 pub fn transitive_closure<L: Lockfile + ?Sized>(
     lockfile: &L,
     workspace_path: &str,
-    unresolved_deps: HashMap<String, String>,
+    unresolved_deps: BTreeMap<String, String>,
     ignore_missing_packages: bool,
 ) -> Result<HashSet<Package>, Error> {
     let resolve_cache: ResolveCache = DashMap::new();
@@ -173,7 +173,7 @@ pub fn transitive_closure<L: Lockfile + ?Sized>(
 fn transitive_closure_cached<L: Lockfile + ?Sized>(
     lockfile: &L,
     workspace_path: &str,
-    unresolved_deps: HashMap<String, String>,
+    unresolved_deps: BTreeMap<String, String>,
     ignore_missing_packages: bool,
     resolve_cache: &ResolveCache,
     deps_cache: &DepsCache,
@@ -221,7 +221,7 @@ impl<L: Lockfile + ?Sized> ClosureContext<'_, L> {
 
     fn resolve_deps(
         &mut self,
-        unresolved_deps: &HashMap<String, String>,
+        unresolved_deps: &BTreeMap<String, String>,
         ignore_missing_packages: bool,
         is_workspace_root_deps: bool,
     ) -> Result<Vec<Package>, Error> {
@@ -267,7 +267,7 @@ impl<L: Lockfile + ?Sized> ClosureContext<'_, L> {
 
     fn walk(
         &mut self,
-        unresolved_deps: &HashMap<String, String>,
+        unresolved_deps: &BTreeMap<String, String>,
         resolved_deps: &mut HashSet<Package>,
         ignore_missing_packages: bool,
         is_workspace_root_deps: bool,

--- a/crates/turborepo-lockfiles/src/npm.rs
+++ b/crates/turborepo-lockfiles/src/npm.rs
@@ -153,12 +153,13 @@ impl Lockfile for NpmLockfile {
     fn all_dependencies(
         &self,
         key: &str,
-    ) -> Result<Option<std::borrow::Cow<'_, HashMap<String, String>>>, Error> {
+    ) -> Result<Option<std::borrow::Cow<'_, std::collections::BTreeMap<String, String>>>, Error>
+    {
         let Some(pkg) = self.packages.get(key) else {
             return Ok(None);
         };
 
-        let mut deps = HashMap::new();
+        let mut deps = std::collections::BTreeMap::new();
         let mut buf = String::new();
         for name in pkg.dep_keys() {
             if let Some((resolved_key, version)) = self.find_dep_in_lockfile(key, name, &mut buf)? {

--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -1,48 +1,15 @@
-use std::{
-    any::Any,
-    borrow::Cow,
-    collections::{BTreeMap, HashMap},
-};
+use std::{any::Any, borrow::Cow, collections::BTreeMap};
 
 use semver::Version;
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 use turbopath::RelativeUnixPathBuf;
 
 use super::{Error, LockfileVersion, SupportedLockfileVersion, dep_path::DepPath};
 
 type Map<K, V> = std::collections::BTreeMap<K, V>;
 
-type Packages = HashMap<String, PackageSnapshot>;
-type Snapshots = HashMap<String, PackageSnapshotV7>;
-
-fn serialize_optional_hashmap_as_sorted<S, V>(
-    value: &Option<HashMap<String, V>>,
-    serializer: S,
-) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-    V: Serialize,
-{
-    match value {
-        Some(map) => {
-            let sorted: BTreeMap<_, _> = map.iter().collect();
-            sorted.serialize(serializer)
-        }
-        None => serializer.serialize_none(),
-    }
-}
-
-fn serialize_hashmap_as_sorted<S, V>(
-    value: &HashMap<String, V>,
-    serializer: S,
-) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-    V: Serialize,
-{
-    let sorted: BTreeMap<_, _> = value.iter().collect();
-    sorted.serialize(serializer)
-}
+type Packages = BTreeMap<String, PackageSnapshot>;
+type Snapshots = BTreeMap<String, PackageSnapshotV7>;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -68,20 +35,13 @@ pub struct PnpmLockfile {
     package_extensions_checksum: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     patched_dependencies: Option<Map<String, PatchFile>>,
-    #[serde(serialize_with = "serialize_hashmap_as_sorted")]
-    importers: HashMap<String, ProjectSnapshot>,
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "serialize_optional_hashmap_as_sorted"
-    )]
+    importers: BTreeMap<String, ProjectSnapshot>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     packages: Option<Packages>,
-    #[serde(
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "serialize_optional_hashmap_as_sorted"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     snapshots: Option<Snapshots>,
     #[serde(skip)]
-    dependency_index: HashMap<String, HashMap<String, String>>,
+    dependency_index: BTreeMap<String, BTreeMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     time: Option<Map<String, String>>,
 }
@@ -257,7 +217,7 @@ impl PnpmLockfile {
 
             // Merge packages
             if let Some(ws_packages) = ws_lockfile.packages {
-                let packages = self.packages.get_or_insert_with(HashMap::new);
+                let packages = self.packages.get_or_insert_with(BTreeMap::new);
                 for (key, pkg) in ws_packages {
                     packages.entry(key).or_insert(pkg);
                 }
@@ -265,7 +225,7 @@ impl PnpmLockfile {
 
             // Merge snapshots
             if let Some(ws_snapshots) = ws_lockfile.snapshots {
-                let snapshots = self.snapshots.get_or_insert_with(HashMap::new);
+                let snapshots = self.snapshots.get_or_insert_with(BTreeMap::new);
                 for (key, snap) in ws_snapshots {
                     snapshots.entry(key).or_insert(snap);
                 }
@@ -279,9 +239,7 @@ impl PnpmLockfile {
     }
 
     fn build_dependency_index(&mut self) {
-        let snapshot_count = self.snapshots.as_ref().map_or(0, HashMap::len);
-        let package_count = self.packages.as_ref().map_or(0, HashMap::len);
-        let mut index = HashMap::with_capacity(snapshot_count + package_count);
+        let mut index = BTreeMap::new();
         if let Some(snapshots) = &self.snapshots {
             for (key, snapshot) in snapshots {
                 index.insert(key.clone(), snapshot.dependencies());
@@ -480,9 +438,9 @@ impl PnpmLockfile {
         &self,
         packages: &[String],
     ) -> Result<(Packages, Option<Snapshots>), crate::Error> {
-        let mut pruned_packages = HashMap::new();
+        let mut pruned_packages = BTreeMap::new();
         if let Some(snapshots) = self.snapshots.as_ref() {
-            let mut pruned_snapshots = HashMap::new();
+            let mut pruned_snapshots = BTreeMap::new();
             for package in packages {
                 let entry = snapshots
                     .get(package.as_str())
@@ -575,8 +533,10 @@ impl crate::Lockfile for PnpmLockfile {
     fn all_dependencies(
         &self,
         key: &str,
-    ) -> Result<Option<std::borrow::Cow<'_, std::collections::HashMap<String, String>>>, crate::Error>
-    {
+    ) -> Result<
+        Option<std::borrow::Cow<'_, std::collections::BTreeMap<String, String>>>,
+        crate::Error,
+    > {
         Ok(self
             .dependency_index
             .get(key)
@@ -588,7 +548,7 @@ impl crate::Lockfile for PnpmLockfile {
         workspace_packages: &[String],
         packages: &[String],
     ) -> Result<Box<dyn crate::Lockfile>, crate::Error> {
-        let importers: HashMap<_, _> = self
+        let importers: BTreeMap<_, _> = self
             .importers
             .iter()
             .filter(|(key, _)| key.as_str() == "." || workspace_packages.contains(key))
@@ -691,7 +651,7 @@ impl crate::Lockfile for PnpmLockfile {
             package_extensions_checksum: self.package_extensions_checksum.clone(),
             patched_dependencies: patches,
             snapshots: pruned_snapshots,
-            dependency_index: HashMap::new(),
+            dependency_index: BTreeMap::new(),
             time: None,
             settings: self.settings.clone(),
             pnpmfile_checksum: self.pnpmfile_checksum.clone(),
@@ -828,10 +788,8 @@ impl Dependency {
 }
 
 impl PackageSnapshotV7 {
-    pub fn dependencies(&self) -> HashMap<String, String> {
-        let dependency_count = self.dependencies.as_ref().map_or(0, Map::len)
-            + self.optional_dependencies.as_ref().map_or(0, Map::len);
-        let mut combined = HashMap::with_capacity(dependency_count);
+    pub fn dependencies(&self) -> BTreeMap<String, String> {
+        let mut combined = BTreeMap::new();
 
         if let Some(dependencies) = &self.dependencies {
             combined.extend(
@@ -868,6 +826,8 @@ pub fn pnpm_global_change(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use pretty_assertions::assert_eq;
 
     use super::*;
@@ -1418,5 +1378,470 @@ snapshots:
         // The importer for apps/my-app should retain dependenciesMeta
         let importer = pruned_lockfile.importers.get("apps/my-app").unwrap();
         assert!(importer.dependencies_meta.is_some());
+    }
+
+    /// Regression test for https://github.com/vercel/turborepo/issues/12252
+    ///
+    /// The Lockfile trait returns `HashMap<String, String>` from
+    /// `all_dependencies`, and `PackageSnapshotV7::dependencies()` converts
+    /// deterministic BTreeMap data into a HashMap. This test asserts that the
+    /// dependency maps used in the transitive closure walk are
+    /// deterministically ordered (i.e. BTreeMap), so that the walk and
+    /// hashing are reproducible across process invocations regardless of
+    /// HashMap's per-process random seed.
+    ///
+    /// With HashMap, the `dependency_index` values have random iteration
+    /// order. When these feed into `resolve_deps` → `resolve_package` via the
+    /// shared `DashMap` resolve cache in `all_transitive_closures`, different
+    /// iteration orders in parallel threads can race to populate cache entries,
+    /// producing different `Package` values and thus different hashes.
+    #[test]
+    fn test_dependency_index_is_deterministically_ordered() {
+        let yaml = r#"lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      express:
+        specifier: 4.18.2
+        version: 4.18.2
+
+packages:
+
+  express@4.18.2:
+    resolution: {integrity: sha512-aaa}
+
+  body-parser@1.20.1:
+    resolution: {integrity: sha512-bbb}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-ccc}
+
+  cookie@0.5.0:
+    resolution: {integrity: sha512-ddd}
+
+  debug@4.3.4:
+    resolution: {integrity: sha512-eee}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-fff}
+
+  finalhandler@1.2.0:
+    resolution: {integrity: sha512-ggg}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-hhh}
+
+  qs@6.11.0:
+    resolution: {integrity: sha512-iii}
+
+  raw-body@2.5.1:
+    resolution: {integrity: sha512-jjj}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-kkk}
+
+  type-is@1.6.18:
+    resolution: {integrity: sha512-lll}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-mmm}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-nnn}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-ooo}
+
+  destroy@1.2.0:
+    resolution: {integrity: sha512-ppp}
+
+snapshots:
+
+  express@4.18.2:
+    dependencies:
+      body-parser: 1.20.1
+      content-type: 1.0.5
+      cookie: 0.5.0
+      debug: 4.3.4
+      etag: 1.8.1
+      finalhandler: 1.2.0
+      qs: 6.11.0
+      type-is: 1.6.18
+    optionalDependencies:
+      safe-buffer: 5.2.1
+      depd: 2.0.0
+      destroy: 1.2.0
+
+  body-parser@1.20.1:
+    dependencies:
+      content-type: 1.0.5
+      debug: 4.3.4
+      raw-body: 2.5.1
+      type-is: 1.6.18
+      qs: 6.11.0
+
+  content-type@1.0.5: {}
+  cookie@0.5.0: {}
+
+  debug@4.3.4:
+    dependencies:
+      ms: 2.1.3
+
+  etag@1.8.1: {}
+  finalhandler@1.2.0:
+    dependencies:
+      debug: 4.3.4
+
+  ms@2.1.3: {}
+  qs@6.11.0: {}
+
+  raw-body@2.5.1:
+    dependencies:
+      depd: 2.0.0
+
+  safe-buffer@5.2.1: {}
+
+  type-is@1.6.18:
+    dependencies:
+      mime-types: 2.1.35
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mime-db@1.52.0: {}
+  depd@2.0.0: {}
+  destroy@1.2.0: {}
+"#;
+
+        // Parse the lockfile multiple times — each parse creates HashMaps
+        // with fresh RandomState seeds. Collect the iteration order of the
+        // dependency_index entries to verify determinism.
+        let mut seen_orders = std::collections::HashSet::new();
+        for _ in 0..50 {
+            let lockfile = PnpmLockfile::from_bytes(yaml.as_bytes()).unwrap();
+
+            // express@4.18.2 merges 8 dependencies + 3 optionalDependencies
+            // into a single map via PackageSnapshotV7::dependencies().
+            // If this map is a HashMap, its iteration order varies per instance.
+            let deps = lockfile
+                .all_dependencies("express@4.18.2")
+                .unwrap()
+                .expect("express should have dependencies");
+            let order: Vec<String> = deps.keys().cloned().collect();
+            seen_orders.insert(order);
+        }
+
+        // With BTreeMap the iteration order is always sorted, so there is
+        // exactly 1 distinct order. With HashMap there are typically many.
+        assert_eq!(
+            seen_orders.len(),
+            1,
+            "dependency iteration order must be deterministic (found {} distinct orderings). This \
+             causes non-deterministic hashOfExternalDependencies across turbo invocations.",
+            seen_orders.len()
+        );
+    }
+
+    /// Regression test for https://github.com/vercel/turborepo/issues/12252
+    ///
+    /// End-to-end: parse the same lockfile bytes multiple times and assert
+    /// that all_transitive_closures produces identical results every time.
+    #[test]
+    fn test_transitive_closure_deterministic_across_parses() {
+        let yaml = r#"lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  apps/web:
+    dependencies:
+      react:
+        specifier: 18.2.0
+        version: 18.2.0
+      react-dom:
+        specifier: 18.2.0
+        version: 18.2.0(react@18.2.0)
+      lodash:
+        specifier: 4.17.21
+        version: 4.17.21
+      express:
+        specifier: 4.18.2
+        version: 4.18.2
+      axios:
+        specifier: 1.6.0
+        version: 1.6.0
+      zod:
+        specifier: 3.22.0
+        version: 3.22.0
+      dayjs:
+        specifier: 1.11.10
+        version: 1.11.10
+      uuid:
+        specifier: 9.0.0
+        version: 9.0.0
+      chalk:
+        specifier: 5.3.0
+        version: 5.3.0
+      commander:
+        specifier: 11.1.0
+        version: 11.1.0
+
+  packages/ui:
+    dependencies:
+      react:
+        specifier: 18.2.0
+        version: 18.2.0
+      classnames:
+        specifier: 2.3.2
+        version: 2.3.2
+      lodash:
+        specifier: 4.17.21
+        version: 4.17.21
+      tslib:
+        specifier: 2.6.2
+        version: 2.6.2
+      prop-types:
+        specifier: 15.8.1
+        version: 15.8.1
+      csstype:
+        specifier: 3.1.2
+        version: 3.1.2
+
+packages:
+
+  react@18.2.0:
+    resolution: {integrity: sha512-aaa}
+
+  react-dom@18.2.0:
+    resolution: {integrity: sha512-bbb}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-ccc}
+
+  express@4.18.2:
+    resolution: {integrity: sha512-ddd}
+
+  axios@1.6.0:
+    resolution: {integrity: sha512-eee}
+
+  zod@3.22.0:
+    resolution: {integrity: sha512-fff}
+
+  dayjs@1.11.10:
+    resolution: {integrity: sha512-ggg}
+
+  uuid@9.0.0:
+    resolution: {integrity: sha512-hhh}
+
+  chalk@5.3.0:
+    resolution: {integrity: sha512-iii}
+
+  commander@11.1.0:
+    resolution: {integrity: sha512-jjj}
+
+  classnames@2.3.2:
+    resolution: {integrity: sha512-kkk}
+
+  tslib@2.6.2:
+    resolution: {integrity: sha512-lll}
+
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-mmm}
+
+  csstype@3.1.2:
+    resolution: {integrity: sha512-nnn}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-ooo}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-ppp}
+
+  scheduler@0.23.0:
+    resolution: {integrity: sha512-qqq}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rrr}
+
+  react-is@16.13.1:
+    resolution: {integrity: sha512-sss}
+
+  follow-redirects@1.15.3:
+    resolution: {integrity: sha512-ttt}
+
+  body-parser@1.20.1:
+    resolution: {integrity: sha512-uuu}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-vvv}
+
+  cookie@0.5.0:
+    resolution: {integrity: sha512-www}
+
+  debug@4.3.4:
+    resolution: {integrity: sha512-xxx}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-yyy}
+
+  form-data@4.0.0:
+    resolution: {integrity: sha512-zzz}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-aab}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-aac}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-aad}
+
+snapshots:
+
+  react@18.2.0: {}
+
+  react-dom@18.2.0(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      loose-envify: 1.4.0
+      scheduler: 0.23.0
+
+  lodash@4.17.21: {}
+
+  express@4.18.2:
+    dependencies:
+      body-parser: 1.20.1
+      content-type: 1.0.5
+      cookie: 0.5.0
+      debug: 4.3.4
+
+  axios@1.6.0:
+    dependencies:
+      follow-redirects: 1.15.3
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+
+  zod@3.22.0: {}
+
+  dayjs@1.11.10: {}
+
+  uuid@9.0.0: {}
+
+  chalk@5.3.0: {}
+
+  commander@11.1.0: {}
+
+  classnames@2.3.2: {}
+
+  tslib@2.6.2: {}
+
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
+  csstype@3.1.2: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  js-tokens@4.0.0: {}
+
+  scheduler@0.23.0:
+    dependencies:
+      loose-envify: 1.4.0
+
+  object-assign@4.1.1: {}
+
+  react-is@16.13.1: {}
+
+  follow-redirects@1.15.3: {}
+
+  body-parser@1.20.1:
+    dependencies:
+      content-type: 1.0.5
+      debug: 4.3.4
+
+  content-type@1.0.5: {}
+
+  cookie@0.5.0: {}
+
+  debug@4.3.4:
+    dependencies:
+      ms: 2.1.3
+
+  ms@2.1.3: {}
+
+  form-data@4.0.0:
+    dependencies:
+      mime-types: 2.1.35
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mime-db@1.52.0: {}
+
+  proxy-from-env@1.1.0: {}
+"#;
+
+        let iterations = 20;
+        let mut all_closures = Vec::with_capacity(iterations);
+
+        for _ in 0..iterations {
+            let lockfile = PnpmLockfile::from_bytes(yaml.as_bytes()).unwrap();
+
+            let mut workspaces = HashMap::new();
+            let web_deps: BTreeMap<String, String> = [
+                ("react", "18.2.0"),
+                ("react-dom", "18.2.0"),
+                ("lodash", "4.17.21"),
+                ("express", "4.18.2"),
+                ("axios", "1.6.0"),
+                ("zod", "3.22.0"),
+                ("dayjs", "1.11.10"),
+                ("uuid", "9.0.0"),
+                ("chalk", "5.3.0"),
+                ("commander", "11.1.0"),
+            ]
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+
+            let ui_deps: BTreeMap<String, String> = [
+                ("react", "18.2.0"),
+                ("classnames", "2.3.2"),
+                ("lodash", "4.17.21"),
+                ("tslib", "2.6.2"),
+                ("prop-types", "15.8.1"),
+                ("csstype", "3.1.2"),
+            ]
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+
+            workspaces.insert("apps/web".to_string(), web_deps);
+            workspaces.insert("packages/ui".to_string(), ui_deps);
+
+            let closures = crate::all_transitive_closures(&lockfile, workspaces, false).unwrap();
+            all_closures.push(closures);
+        }
+
+        let first = &all_closures[0];
+        for (i, closure) in all_closures.iter().enumerate().skip(1) {
+            assert_eq!(
+                first, closure,
+                "transitive closure differed between parse 0 and parse {i} (non-deterministic \
+                 HashMap iteration order)"
+            );
+        }
     }
 }

--- a/crates/turborepo-lockfiles/src/yarn1/mod.rs
+++ b/crates/turborepo-lockfiles/src/yarn1/mod.rs
@@ -79,13 +79,15 @@ impl Lockfile for Yarn1Lockfile {
     fn all_dependencies(
         &self,
         key: &str,
-    ) -> Result<Option<std::borrow::Cow<'_, std::collections::HashMap<String, String>>>, crate::Error>
-    {
+    ) -> Result<
+        Option<std::borrow::Cow<'_, std::collections::BTreeMap<String, String>>>,
+        crate::Error,
+    > {
         let Some(entry) = self.inner.get(key) else {
             return Ok(None);
         };
 
-        let all_deps: std::collections::HashMap<_, _> = entry.dependency_entries().collect();
+        let all_deps: std::collections::BTreeMap<_, _> = entry.dependency_entries().collect();
         Ok(match all_deps.is_empty() {
             false => Some(std::borrow::Cow::Owned(all_deps)),
             true => None,

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -564,7 +564,9 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedWorkspaces, T> {
 }
 
 impl<T: PackageDiscovery> BuildState<'_, ResolvedLockfile, T> {
-    fn all_external_dependencies(&self) -> Result<HashMap<String, HashMap<String, String>>, Error> {
+    fn all_external_dependencies(
+        &self,
+    ) -> Result<HashMap<String, BTreeMap<String, String>>, Error> {
         self.workspaces
             .values()
             .map(|entry| {

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -474,7 +474,7 @@ impl PackageGraph {
                     )
                 })
             })
-            .collect::<HashMap<_, HashMap<_, _>>>();
+            .collect::<HashMap<_, BTreeMap<_, _>>>();
 
         // We're comparing to a previous lockfile, it's possible that a package was
         // added and thus won't exist in the previous lockfile. In that case,
@@ -827,7 +827,7 @@ mod test {
             &self,
             key: &str,
         ) -> std::result::Result<
-            Option<std::borrow::Cow<'_, HashMap<String, String>>>,
+            Option<std::borrow::Cow<'_, BTreeMap<String, String>>>,
             turborepo_lockfiles::Error,
         > {
             match key {


### PR DESCRIPTION
## Summary

- Fixes non-deterministic `hashOfExternalDependencies` across `turbo` invocations (#12252)
- Replaces `HashMap` with `BTreeMap` throughout the lockfile dependency resolution pipeline (trait + all 5 implementations + callers)
- Adds regression tests that verify dependency iteration order determinism

## Why

`HashMap` uses per-process random hash seeds (`RandomState`), so each `turbo` invocation iterates lockfile dependency entries in a different order. This propagated through the transitive closure computation and parallel `DashMap` caching in `all_transitive_closures`, producing different external dependency hashes for the same unchanged lockfile.

The `PackageSnapshotV7::dependencies()` method was particularly ironic: the internal data was already stored as `BTreeMap` (via `type Map<K, V> = BTreeMap<K, V>`), but the method converted it into a `HashMap` before returning, needlessly discarding the deterministic ordering.

## Testing

The `test_dependency_index_is_deterministically_ordered` test parses the same lockfile 50 times and asserts that `all_dependencies()` always returns entries in the same order. Before this change, it found **50 distinct iteration orders** from 50 parses. This tests goes out of its way to force non-determinism into these codepaths.

### How did we not have coverage over this before?

We have many places where we ensure our hashes are deterministic, but this slipped through for a tricky reason. Tests are single-process, and HashMap happens to use seeds from the same thread-local RNG. The `DashMap`s there were introduced for performance interleave non-determinstically, but the _inputs_ were always deterministic because of the thread scheduling.

Outside of the testing environment, there are, of course, more threads that vary across process invocations, so this bug shows up. We were testing that the inputs into hashes were deterministic, but not the ordering of those inputs.

Closes #12252