### PR TITLE
ci: Add Node.js 24 to JS test matrices

### DIFF
--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -69,6 +69,7 @@ jobs:
           - 18
           - 20
           - 22
+          - 24
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -572,6 +572,7 @@ jobs:
           - 18
           - 20
           - 22
+          - 24
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}


### PR DESCRIPTION
## Summary

- Adds Node.js 24 to the `node-version` matrix in `test-js-packages.yml` and `turborepo-test.yml` so our JS package tests and `@turbo/repository` native binding tests run against it in CI.