### PR TITLE
fix: Validate task names when `--affected` yields empty package scope

### DIFF
--- a/crates/turborepo-engine/src/builder.rs
+++ b/crates/turborepo-engine/src/builder.rs
@@ -136,13 +136,6 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
     }
 
     pub fn build(mut self) -> Result<Engine<crate::Built, TaskDefinition>, BuilderError> {
-        // If there are no affected packages, we don't need to go through all this work
-        // we can just exit early.
-        // TODO(mehulkar): but we still need to validate bad task names?
-        if self.workspaces.is_empty() {
-            return Ok(Engine::default().seal());
-        }
-
         let turbo_json_loader = self
             .turbo_json_loader
             .take()
@@ -4682,5 +4675,75 @@ mod test {
             "//#rootlint" => ["___ROOT___"]
         };
         assert_eq!(all_dependencies(&engine), expected);
+    }
+
+    #[test]
+    fn test_empty_workspaces_with_invalid_task_errors() {
+        let repo_root_dir = TempDir::with_prefix("repo").unwrap();
+        let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
+        let package_graph = mock_package_graph(
+            &repo_root,
+            package_jsons! {
+                repo_root,
+                "a" => []
+            },
+        );
+        let turbo_jsons = vec![(
+            PackageName::Root,
+            turbo_json(json!({
+                "tasks": {
+                    "build": {},
+                }
+            })),
+        )]
+        .into_iter()
+        .collect();
+        let loader = TestTurboJsonLoader::new(turbo_jsons);
+
+        let result = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
+            .with_tasks(Some(Spanned::new(TaskName::from("foobarbaz"))))
+            .with_workspaces(vec![])
+            .build();
+
+        assert!(
+            matches!(result, Err(BuilderError::MissingTasks(_))),
+            "expected MissingTasks error for non-existent task with empty workspaces, got: \
+             {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_empty_workspaces_with_valid_task_succeeds() {
+        let repo_root_dir = TempDir::with_prefix("repo").unwrap();
+        let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
+        let package_graph = mock_package_graph(
+            &repo_root,
+            package_jsons! {
+                repo_root,
+                "a" => []
+            },
+        );
+        let turbo_jsons = vec![(
+            PackageName::Root,
+            turbo_json(json!({
+                "tasks": {
+                    "build": {},
+                }
+            })),
+        )]
+        .into_iter()
+        .collect();
+        let loader = TestTurboJsonLoader::new(turbo_jsons);
+
+        let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
+            .with_tasks(Some(Spanned::new(TaskName::from("build"))))
+            .with_workspaces(vec![])
+            .build()
+            .unwrap();
+
+        assert!(
+            engine.task_ids().count() == 0,
+            "expected empty engine when workspaces is empty but task is valid"
+        );
     }
 }

--- a/crates/turborepo/tests/affected_test.rs
+++ b/crates/turborepo/tests/affected_test.rs
@@ -2,7 +2,7 @@ mod common;
 
 use std::{fs, path::Path};
 
-use common::{git, run_turbo, run_turbo_with_env, setup};
+use common::{git, run_turbo, run_turbo_with_env, setup, turbo_output_filters};
 
 fn setup_affected(dir: &std::path::Path) {
     setup::setup_integration_test(dir, "basic_monorepo", "npm@10.5.0", true).unwrap();
@@ -962,4 +962,23 @@ fn test_task_level_affected_global_file_runs_everything() {
         "global change should affect many tasks, got {}: {task_ids:?}",
         task_ids.len()
     );
+}
+
+#[test]
+fn test_affected_with_nonexistent_task_errors() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_affected(tempdir.path());
+
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "foobarbaz", "--affected", "--log-order", "grouped"],
+    );
+    assert!(
+        !output.status.success(),
+        "expected failure for non-existent task with --affected"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    insta::with_settings!({ filters => turbo_output_filters() }, {
+        insta::assert_snapshot!("affected_nonexistent_task", stderr.to_string());
+    });
 }

--- a/crates/turborepo/tests/snapshots/affected_test__affected_nonexistent_task.snap
+++ b/crates/turborepo/tests/snapshots/affected_test__affected_nonexistent_task.snap
@@ -1,0 +1,7 @@
+---
+source: crates/turborepo/tests/affected_test.rs
+assertion_line: 982
+expression: stderr.to_string()
+---
+  x Missing tasks in project
+  `->   x Could not find task `foobarbaz` in project


### PR DESCRIPTION
## Summary

- `turbo run foobarbaz --affected` with no changed packages silently reports "no tasks ran" instead of erroring about the non-existent task
- `turbo run foobarbaz` (without `--affected`) correctly errors with "Could not find task 'foobarbaz' in project"

The root cause was an early return in `EngineBuilder::build()` that skipped all task name validation when `self.workspaces` was empty. There was already a TODO comment acknowledging this gap.

## Fix

Removed the early return. The existing validation logic handles empty workspaces naturally:
- The workspace × task cartesian product produces 0 iterations (no extra work)
- The `has_task_definition_in_repo` check still runs for each CLI task
- Invalid task names error as expected
- Valid tasks produce an empty engine (0 tasks) — correct behavior

## Testing

- Unit test: `test_empty_workspaces_with_invalid_task_errors` — `MissingTasks` error for non-existent task
- Unit test: `test_empty_workspaces_with_valid_task_succeeds` — valid task with empty workspaces produces an empty engine
- Snapshot integration test: `test_affected_with_nonexistent_task_errors` — end-to-end `turbo run foobarbaz --affected` errors correctly