### PR TITLE
feat: Deprecate `--scope` flag for `turbo prune`

### DIFF
--- a/apps/docs/content/docs/support-policy.mdx
+++ b/apps/docs/content/docs/support-policy.mdx
@@ -118,3 +118,4 @@ Deprecated APIs are in the process of being removed. Any feature we intend to re
 **APIs that are currently deprecated:**
 
 - `TURBO_REMOTE_ONLY` and `--remote-only`: Use [`TURBO_CACHE`](/docs/reference/system-environment-variables) or [--cache](/docs/reference/run#--cache-options)
+- `--scope` for [`turbo prune`](/docs/reference/prune): Use positional arguments instead (e.g. `turbo prune web`)

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -425,6 +425,15 @@ impl Args {
             }
         }
 
+        if let Some(Command::Prune { ref scope, .. }) = clap_args.command {
+            if scope.is_some() {
+                warn!(
+                    "--scope is deprecated and will be removed in a future major version. Use \
+                     positional arguments instead (e.g. `turbo prune web`)"
+                );
+            }
+        }
+
         clap_args
     }
 
@@ -727,6 +736,8 @@ pub enum Command {
     Info,
     /// Prepare a subset of your monorepo.
     Prune {
+        /// DEPRECATED: Use positional arguments instead
+        /// (e.g. `turbo prune web`)
         #[clap(hide = true, long)]
         scope: Option<Vec<String>>,
         /// Workspaces that should be included in the subset


### PR DESCRIPTION
## Summary

- Adds a deprecation warning when `--scope` is used with `turbo prune`, guiding users toward positional arguments (e.g. `turbo prune web`)
- Documents the deprecation in the support policy page

The `--scope` flag was already hidden from help text. This adds the runtime warning to match other deprecation patterns in the CLI (like `--no-cache`, `--remote-only`, `--daemon`).

Closes TURBO-3988