### PR TITLE
fix: Align query affectedTasks with run `--affected` for `$TURBO_ROOT$` inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7906,6 +7906,7 @@ dependencies = [
  "petgraph 0.8.3",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tower-http 0.5.2",

--- a/crates/turborepo-engine/src/affected.rs
+++ b/crates/turborepo-engine/src/affected.rs
@@ -1,0 +1,287 @@
+//! Shared task-level affected detection for both `turbo run --affected`
+//! and `turbo query { affectedTasks }`.
+//!
+//! Iterates **all** engine tasks and checks each task's `inputs` globs
+//! against a set of changed files. This is the canonical implementation
+//! that both code paths must use to avoid divergence on which tasks are
+//! considered (e.g. tasks with `$TURBO_ROOT$` inputs in non-affected
+//! packages).
+
+use std::collections::{HashMap, HashSet};
+
+use turbopath::AnchoredSystemPathBuf;
+use turborepo_repository::package_graph::{PackageGraph, PackageName};
+use turborepo_task_id::TaskId;
+use turborepo_types::{
+    TaskDefinition, TaskInputs,
+    task_input_matching::{compile_globs, file_matches_compiled_inputs},
+};
+
+use crate::{Built, Engine};
+
+/// Fallback inputs when a task has no definition in the engine.
+/// `default: true` means all files in the package directory are considered
+/// inputs, matching turbo's default hashing behavior.
+static DEFAULT_TASK_INPUTS: TaskInputs = TaskInputs {
+    globs: Vec::new(),
+    default: true,
+};
+
+/// Returns the set of tasks whose input globs match at least one changed file.
+///
+/// Iterates every task in the engine regardless of which packages are
+/// "affected" at the package level. This is critical for correctness:
+/// a task in a non-affected package may declare `$TURBO_ROOT$` inputs
+/// (resolved to `../../` globs) that reference changed root-level files.
+///
+/// The returned map associates each affected task with the repo-relative
+/// path of the first file that matched its inputs. Callers that don't
+/// need the file path can discard the values.
+///
+/// Does NOT include transitive dependents. Callers should propagate
+/// through the task graph separately if needed.
+pub fn match_tasks_against_changed_files(
+    engine: &Engine<Built, TaskDefinition>,
+    pkg_dep_graph: &PackageGraph,
+    changed_files: &HashSet<AnchoredSystemPathBuf>,
+) -> HashMap<TaskId<'static>, String> {
+    let mut matched = HashMap::new();
+
+    // Pre-convert all file paths to Unix strings once, avoiding repeated
+    // allocation in the O(tasks × files) inner loop.
+    let changed_unix: Vec<String> = changed_files
+        .iter()
+        .map(|f| f.to_unix().to_string())
+        .collect();
+
+    // Compile globs once per unique (package_path, inputs) pair.
+    let mut compiled_cache: HashMap<(String, TaskInputs), _> = HashMap::new();
+
+    for task_id in engine.task_ids() {
+        let pkg_name = PackageName::from(task_id.package());
+        let Some(pkg_dir) = pkg_dep_graph.package_dir(&pkg_name) else {
+            continue;
+        };
+        let pkg_unix = pkg_dir.to_unix();
+        let pkg_str = pkg_unix.to_string();
+
+        let inputs = engine
+            .task_definition(task_id)
+            .map(|def| &def.inputs)
+            .unwrap_or(&DEFAULT_TASK_INPUTS);
+
+        let cache_key = (pkg_str.clone(), inputs.clone());
+        let compiled = compiled_cache
+            .entry(cache_key)
+            .or_insert_with(|| compile_globs(inputs));
+
+        let pkg_prefix_slash = if pkg_str.is_empty() {
+            String::new()
+        } else {
+            format!("{pkg_str}/")
+        };
+
+        for file_unix in &changed_unix {
+            if file_matches_compiled_inputs(file_unix, &pkg_str, &pkg_prefix_slash, compiled) {
+                matched.insert(task_id.clone(), file_unix.clone());
+                break;
+            }
+        }
+    }
+
+    matched
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+
+    use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf};
+    use turborepo_errors::Spanned;
+    use turborepo_repository::{
+        discovery::{DiscoveryResponse, PackageDiscovery},
+        package_graph::PackageGraph,
+        package_json::PackageJson,
+        package_manager::PackageManager,
+    };
+    use turborepo_task_id::TaskId;
+    use turborepo_types::{TaskDefinition, TaskInputs};
+
+    use super::*;
+    use crate::Building;
+
+    struct MockDiscovery;
+
+    impl PackageDiscovery for MockDiscovery {
+        async fn discover_packages(
+            &self,
+        ) -> Result<DiscoveryResponse, turborepo_repository::discovery::Error> {
+            Ok(DiscoveryResponse {
+                package_manager: PackageManager::Npm,
+                workspaces: vec![],
+            })
+        }
+
+        async fn discover_packages_blocking(
+            &self,
+        ) -> Result<DiscoveryResponse, turborepo_repository::discovery::Error> {
+            self.discover_packages().await
+        }
+    }
+
+    async fn make_pkg_graph(repo_root: &AbsoluteSystemPath, packages: &[&str]) -> PackageGraph {
+        let mut pkgs = HashMap::new();
+        for name in packages {
+            let path = repo_root.join_components(&["packages", name, "package.json"]);
+            let pkg = PackageJson {
+                name: Some(Spanned::new(name.to_string())),
+                ..Default::default()
+            };
+            pkgs.insert(path, pkg);
+        }
+        PackageGraph::builder(repo_root, PackageJson::default())
+            .with_package_discovery(MockDiscovery)
+            .with_package_jsons(Some(pkgs))
+            .build()
+            .await
+            .unwrap()
+    }
+
+    fn make_engine(
+        tasks: &[(TaskId<'static>, TaskDefinition)],
+    ) -> Engine<crate::Built, TaskDefinition> {
+        let mut engine: Engine<Building, TaskDefinition> = Engine::new();
+        for (task_id, def) in tasks {
+            engine.get_index(task_id);
+            engine.add_definition(task_id.clone(), def.clone());
+        }
+        engine.seal()
+    }
+
+    fn changed(files: &[&str]) -> HashSet<AnchoredSystemPathBuf> {
+        files
+            .iter()
+            .map(|f| AnchoredSystemPathBuf::from_raw(f).unwrap())
+            .collect()
+    }
+
+    fn def_with_inputs(globs: &[&str], default: bool) -> TaskDefinition {
+        TaskDefinition {
+            inputs: TaskInputs {
+                globs: globs.iter().map(|s| s.to_string()).collect(),
+                default,
+            },
+            ..Default::default()
+        }
+    }
+
+    // Single-file matching (default inputs, exclusions, explicit globs,
+    // $TURBO_ROOT$ traversal) is thoroughly tested in
+    // `turborepo_types::task_input_matching::tests`. The tests below only
+    // cover behavior unique to `match_tasks_against_changed_files`:
+    // multi-task iteration, the DEFAULT_TASK_INPUTS fallback, and the
+    // cross-package $TURBO_ROOT$ scenario that motivated this module.
+
+    #[tokio::test]
+    async fn multiple_tasks_selective_matching() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let pkg_graph = make_pkg_graph(root, &["lib-a"]).await;
+
+        let a_build = TaskId::new("lib-a", "build");
+        let a_test = TaskId::new("lib-a", "test");
+        let a_typecheck = TaskId::new("lib-a", "typecheck");
+
+        let engine = make_engine(&[
+            (a_build.clone(), TaskDefinition::default()),
+            (a_test.clone(), def_with_inputs(&["!**/*.md"], true)),
+            (
+                a_typecheck.clone(),
+                def_with_inputs(&["!**/*.md", "!**/*.test.ts"], true),
+            ),
+        ]);
+
+        // .md change: only build is affected
+        let result = match_tasks_against_changed_files(
+            &engine,
+            &pkg_graph,
+            &changed(&["packages/lib-a/README.md"]),
+        );
+        assert_eq!(result.len(), 1, "only build should match .md: {result:?}");
+        assert!(result.contains_key(&a_build));
+
+        // .test.ts change: build and test are affected, typecheck is not
+        let result = match_tasks_against_changed_files(
+            &engine,
+            &pkg_graph,
+            &changed(&["packages/lib-a/foo.test.ts"]),
+        );
+        assert_eq!(
+            result.len(),
+            2,
+            "build+test should match .test.ts: {result:?}"
+        );
+        assert!(result.contains_key(&a_build));
+        assert!(result.contains_key(&a_test));
+        assert!(!result.contains_key(&a_typecheck));
+    }
+
+    #[tokio::test]
+    async fn task_without_definition_uses_default_inputs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let pkg_graph = make_pkg_graph(root, &["lib-a"]).await;
+
+        // Register task in the graph but do NOT add a definition.
+        let mut engine: Engine<Building, TaskDefinition> = Engine::new();
+        let a_build = TaskId::new("lib-a", "build");
+        engine.get_index(&a_build);
+        let engine = engine.seal();
+
+        let result = match_tasks_against_changed_files(
+            &engine,
+            &pkg_graph,
+            &changed(&["packages/lib-a/src/index.ts"]),
+        );
+        assert_eq!(
+            result.len(),
+            1,
+            "task with no definition should use default inputs: {result:?}"
+        );
+    }
+
+    /// The key scenario: a task in package B has $TURBO_ROOT$ inputs
+    /// but package B itself has no source file changes. The function
+    /// must still detect it because it iterates ALL engine tasks.
+    #[tokio::test]
+    async fn turbo_root_input_in_non_affected_package() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let pkg_graph = make_pkg_graph(root, &["lib-a", "lib-b"]).await;
+
+        let a_build = TaskId::new("lib-a", "build");
+        let b_build = TaskId::new("lib-b", "build");
+
+        let engine = make_engine(&[
+            (a_build.clone(), TaskDefinition::default()),
+            (
+                b_build.clone(),
+                def_with_inputs(&["../../config.txt"], true),
+            ),
+        ]);
+
+        // Only a root-level file changed. lib-a has default inputs so its
+        // source dir didn't change. lib-b's $TURBO_ROOT$ input DID change.
+        let result =
+            match_tasks_against_changed_files(&engine, &pkg_graph, &changed(&["config.txt"]));
+        assert!(
+            result.contains_key(&b_build),
+            "lib-b#build should match via $TURBO_ROOT$ input: {result:?}"
+        );
+        // lib-a's default inputs only match files within packages/lib-a/
+        assert!(
+            !result.contains_key(&a_build),
+            "lib-a#build should not match a root file with default inputs: {result:?}"
+        );
+    }
+}

--- a/crates/turborepo-engine/src/lib.rs
+++ b/crates/turborepo-engine/src/lib.rs
@@ -8,6 +8,7 @@
 // errors are already established patterns in the codebase
 #![allow(clippy::result_large_err)]
 
+pub mod affected;
 mod builder;
 mod builder_error;
 mod builder_errors;
@@ -24,6 +25,7 @@ use std::{
     fmt,
 };
 
+pub use affected::match_tasks_against_changed_files;
 pub use builder::{EngineBuilder, TaskInheritanceResolver, ValidationMode};
 pub use builder_error::Error as BuilderError;
 pub use builder_errors::{

--- a/crates/turborepo-lib/src/task_change_detector.rs
+++ b/crates/turborepo-lib/src/task_change_detector.rs
@@ -1,19 +1,16 @@
 //! Task-level affected detection for `--affected` with the
 //! `affectedUsingTaskInputs` future flag.
 //!
-//! Glob matching logic is shared with `turborepo-query/src/affected_tasks.rs`
-//! via `turborepo_types::task_input_matching`. Changes to matching semantics
-//! apply to both `turbo run --affected` and `turbo query { affectedTasks }`.
+//! The core matching logic lives in `turborepo_engine::affected` and is
+//! shared with `turbo query { affectedTasks }`. This module adds the
+//! global-change fast path (root config files, lockfile, global deps)
+//! before delegating to the shared function.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use turbopath::AnchoredSystemPathBuf;
-use turborepo_repository::package_graph::{PackageGraph, PackageName};
+use turborepo_repository::package_graph::PackageGraph;
 use turborepo_task_id::TaskId;
-use turborepo_types::{
-    task_input_matching::{compile_globs, file_matches_compiled_inputs},
-    TaskInputs,
-};
 use wax::Program;
 
 use crate::engine::Engine;
@@ -60,62 +57,10 @@ pub fn affected_task_ids(
         return engine.task_ids().cloned().collect();
     }
 
-    let mut affected = HashSet::new();
-
-    // Pre-convert all file paths to Unix strings once, avoiding repeated
-    // allocation in the O(tasks × files) inner loop.
-    let changed_unix: Vec<String> = changed_files
-        .iter()
-        .map(|f| f.to_unix().to_string())
-        .collect();
-
-    // Compile globs once per unique (package_path, inputs) pair.
-    // Uses owned TaskInputs as key since it derives Hash.
-    let mut compiled_cache: HashMap<(String, TaskInputs), _> = HashMap::new();
-
-    for task_id in engine.task_ids() {
-        let pkg_name = PackageName::from(task_id.package());
-        let Some(pkg_dir) = pkg_dep_graph.package_dir(&pkg_name) else {
-            continue;
-        };
-        let pkg_unix = pkg_dir.to_unix();
-        let pkg_str = pkg_unix.to_string();
-
-        let default_inputs = DEFAULT_TASK_INPUTS;
-        let inputs = engine
-            .task_definition(task_id)
-            .map(|def| &def.inputs)
-            .unwrap_or(&default_inputs);
-
-        let cache_key = (pkg_str.clone(), inputs.clone());
-        let compiled = compiled_cache
-            .entry(cache_key)
-            .or_insert_with(|| compile_globs(inputs));
-
-        let pkg_prefix_slash = if pkg_str.is_empty() {
-            String::new()
-        } else {
-            format!("{pkg_str}/")
-        };
-
-        for file_unix in &changed_unix {
-            if file_matches_compiled_inputs(file_unix, &pkg_str, &pkg_prefix_slash, compiled) {
-                affected.insert(task_id.clone());
-                break;
-            }
-        }
-    }
-
-    affected
+    turborepo_engine::match_tasks_against_changed_files(engine, pkg_dep_graph, changed_files)
+        .into_keys()
+        .collect()
 }
-
-/// Fallback inputs when a task has no definition in the engine.
-/// `default: true` means all files in the package directory are considered
-/// inputs, matching turbo's default hashing behavior.
-const DEFAULT_TASK_INPUTS: TaskInputs = TaskInputs {
-    globs: Vec::new(),
-    default: true,
-};
 
 /// Returns `true` if any changed file is a global dependency, meaning all
 /// tasks should be considered affected regardless of their individual inputs.
@@ -180,7 +125,7 @@ mod tests {
         package_manager::PackageManager,
     };
     use turborepo_task_id::TaskId;
-    use turborepo_types::{TaskDefinition, TaskInputs};
+    use turborepo_types::TaskDefinition;
 
     use super::*;
     use crate::engine::Building;
@@ -255,28 +200,6 @@ mod tests {
         TaskDefinition::default()
     }
 
-    fn def_with_inputs(globs: &[&str], default: bool) -> TaskDefinition {
-        TaskDefinition {
-            inputs: TaskInputs {
-                globs: globs.iter().map(|s| s.to_string()).collect(),
-                default,
-            },
-            ..Default::default()
-        }
-    }
-
-    #[tokio::test]
-    async fn no_changed_files_returns_empty() {
-        let tmp = tempfile::tempdir().unwrap();
-        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
-        let pkg_graph = make_pkg_graph(root, &["lib-a"]).await;
-
-        let engine = make_engine(&[(TaskId::new("lib-a", "build"), default_def())], &[]);
-
-        let result = affected_task_ids(&engine, &pkg_graph, &HashSet::new(), &[]);
-        assert!(result.is_empty());
-    }
-
     #[tokio::test]
     async fn global_package_json_change_returns_all() {
         let tmp = tempfile::tempdir().unwrap();
@@ -329,72 +252,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn source_file_matches_default_inputs() {
-        let tmp = tempfile::tempdir().unwrap();
-        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
-        let pkg_graph = make_pkg_graph(root, &["lib-a"]).await;
-
-        let a_build = TaskId::new("lib-a", "build");
-        let engine = make_engine(&[(a_build.clone(), default_def())], &[]);
-
-        let result = affected_task_ids(
-            &engine,
-            &pkg_graph,
-            &changed(&["packages/lib-a/src/index.ts"]),
-            &[],
-        );
-        assert_eq!(result.len(), 1);
-        assert!(result.contains(&a_build));
-    }
-
-    #[tokio::test]
-    async fn excluded_file_not_matched() {
-        let tmp = tempfile::tempdir().unwrap();
-        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
-        let pkg_graph = make_pkg_graph(root, &["lib-a"]).await;
-
-        // Task excludes .md files from its inputs
-        let a_test = TaskId::new("lib-a", "test");
-        let engine = make_engine(
-            &[(a_test.clone(), def_with_inputs(&["!**/*.md"], true))],
-            &[],
-        );
-
-        let result = affected_task_ids(
-            &engine,
-            &pkg_graph,
-            &changed(&["packages/lib-a/README.md"]),
-            &[],
-        );
-        assert!(
-            result.is_empty(),
-            ".md change should not affect task that excludes *.md"
-        );
-    }
-
-    #[tokio::test]
-    async fn file_outside_package_not_matched() {
-        let tmp = tempfile::tempdir().unwrap();
-        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
-        let pkg_graph = make_pkg_graph(root, &["lib-a", "lib-b"]).await;
-
-        let a_build = TaskId::new("lib-a", "build");
-        let engine = make_engine(&[(a_build.clone(), default_def())], &[]);
-
-        // Changing a file in lib-b should not affect lib-a's build
-        let result = affected_task_ids(
-            &engine,
-            &pkg_graph,
-            &changed(&["packages/lib-b/src/index.ts"]),
-            &[],
-        );
-        assert!(
-            result.is_empty(),
-            "file in sibling package should not match: {result:?}"
-        );
-    }
-
-    #[tokio::test]
     async fn custom_global_deps_triggers_all() {
         let tmp = tempfile::tempdir().unwrap();
         let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
@@ -415,96 +272,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn non_matching_file_not_affected() {
-        let tmp = tempfile::tempdir().unwrap();
-        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
-        let pkg_graph = make_pkg_graph(root, &["lib-a"]).await;
-
-        // Task only includes .ts files explicitly (no $TURBO_DEFAULT$)
-        let a_build = TaskId::new("lib-a", "build");
-        let engine = make_engine(
-            &[(a_build.clone(), def_with_inputs(&["src/**/*.ts"], false))],
-            &[],
-        );
-
-        let result = affected_task_ids(
-            &engine,
-            &pkg_graph,
-            &changed(&["packages/lib-a/README.md"]),
-            &[],
-        );
-        assert!(
-            result.is_empty(),
-            ".md file should not match src/**/*.ts inputs"
-        );
-    }
-
-    #[tokio::test]
-    async fn multiple_tasks_selective_matching() {
-        let tmp = tempfile::tempdir().unwrap();
-        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
-        let pkg_graph = make_pkg_graph(root, &["lib-a"]).await;
-
-        let a_build = TaskId::new("lib-a", "build");
-        let a_test = TaskId::new("lib-a", "test");
-        let a_typecheck = TaskId::new("lib-a", "typecheck");
-
-        let engine = make_engine(
-            &[
-                // build: default inputs (matches everything in package)
-                (a_build.clone(), default_def()),
-                // test: excludes .md
-                (a_test.clone(), def_with_inputs(&["!**/*.md"], true)),
-                // typecheck: excludes .md and .test.ts
-                (
-                    a_typecheck.clone(),
-                    def_with_inputs(&["!**/*.md", "!**/*.test.ts"], true),
-                ),
-            ],
-            &[],
-        );
-
-        // .md change: only build is affected
-        let result = affected_task_ids(
-            &engine,
-            &pkg_graph,
-            &changed(&["packages/lib-a/README.md"]),
-            &[],
-        );
-        assert_eq!(result.len(), 1, "only build should match .md: {result:?}");
-        assert!(result.contains(&a_build));
-
-        // .test.ts change: build and test are affected, typecheck is not
-        let result = affected_task_ids(
-            &engine,
-            &pkg_graph,
-            &changed(&["packages/lib-a/foo.test.ts"]),
-            &[],
-        );
-        assert_eq!(
-            result.len(),
-            2,
-            "build+test should match .test.ts: {result:?}"
-        );
-        assert!(result.contains(&a_build));
-        assert!(result.contains(&a_test));
-        assert!(!result.contains(&a_typecheck));
-
-        // .ts source change: all three are affected
-        let result = affected_task_ids(
-            &engine,
-            &pkg_graph,
-            &changed(&["packages/lib-a/src/index.ts"]),
-            &[],
-        );
-        assert_eq!(
-            result.len(),
-            3,
-            "all tasks should match .ts source: {result:?}"
-        );
-    }
-
-    #[tokio::test]
     async fn global_turbo_jsonc_change_returns_all() {
         let tmp = tempfile::tempdir().unwrap();
         let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
@@ -516,32 +283,6 @@ mod tests {
         let result = affected_task_ids(&engine, &pkg_graph, &changed(&["turbo.jsonc"]), &[]);
         assert_eq!(result.len(), 1);
         assert!(result.contains(&a_build));
-    }
-
-    #[tokio::test]
-    async fn task_without_definition_uses_default_inputs() {
-        let tmp = tempfile::tempdir().unwrap();
-        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
-        let pkg_graph = make_pkg_graph(root, &["lib-a"]).await;
-
-        // Register the task in the graph but do NOT add a definition.
-        let mut engine: Engine<Building> = Engine::new();
-        let a_build = TaskId::new("lib-a", "build");
-        engine.get_index(&a_build);
-        let engine = engine.seal();
-
-        // A file in the package should match via DEFAULT_TASK_INPUTS.
-        let result = affected_task_ids(
-            &engine,
-            &pkg_graph,
-            &changed(&["packages/lib-a/src/index.ts"]),
-            &[],
-        );
-        assert_eq!(
-            result.len(),
-            1,
-            "task with no definition should use default inputs: {result:?}"
-        );
     }
 
     #[tokio::test]

--- a/crates/turborepo-query/Cargo.toml
+++ b/crates/turborepo-query/Cargo.toml
@@ -41,5 +41,8 @@ turborepo-ui = { workspace = true }
 wax = { workspace = true }
 webbrowser = { workspace = true }
 
+[dev-dependencies]
+tempfile = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/turborepo-query/src/affected_tasks.rs
+++ b/crates/turborepo-query/src/affected_tasks.rs
@@ -7,7 +7,6 @@ use petgraph::Direction;
 use turborepo_engine::TaskNode;
 use turborepo_repository::change_mapper::{AllPackageChangeReason, PackageInclusionReason};
 use turborepo_task_id::TaskId;
-use turborepo_types::task_input_matching::{compile_globs, file_matches_compiled_inputs_path};
 
 use crate::{Error, QueryRun};
 
@@ -129,55 +128,15 @@ pub fn calculate_affected_tasks(
     let pkg_dep_graph = run.pkg_dep_graph();
 
     // Phase 1: Direct task affectedness — check each task's inputs against
-    // changed files.
-    let mut affected: HashMap<TaskId<'static>, TaskChangeReason> = HashMap::new();
-
-    for (pkg_name, reason) in &affected_packages {
-        let Some(pkg_info) = pkg_dep_graph.package_info(pkg_name) else {
-            continue;
-        };
-        let pkg_path = pkg_info.package_path();
-        let pkg_unix_path = pkg_path.to_unix();
-
-        // Check all changed files against each task's inputs. We pass the
-        // full changed_files set (not pre-filtered to the package directory)
-        // so that cross-package inputs from $TURBO_ROOT$ expansion
-        // (e.g. "../../jest.config.js") are matched correctly, consistent
-        // with the `turbo run --affected` path in task_change_detector.rs.
-        //
-        // TODO: This outer loop only visits tasks in *affected packages*.
-        // A task in a non-affected package that has $TURBO_ROOT$ inputs
-        // pointing to a changed file will be missed here but caught by
-        // the `turbo run --affected` path (which checks all tasks).
-        // Unify by iterating all engine tasks regardless of package.
-        for task_id in engine.task_ids() {
-            if task_id.package() != pkg_name.as_str() {
-                continue;
-            }
-
-            if affected.contains_key(task_id) {
-                continue;
-            }
-
-            if let Some(def) = engine.task_definition(task_id) {
-                let compiled = compile_globs(&def.inputs);
-                for file in &changed_files {
-                    if file_matches_compiled_inputs_path(file, &pkg_unix_path, &compiled) {
-                        affected.insert(
-                            task_id.clone(),
-                            TaskChangeReason::FileChanged {
-                                file_path: file.to_string(),
-                            },
-                        );
-                        break;
-                    }
-                }
-            } else {
-                // No task definition — conservatively mark as affected
-                affected.insert(task_id.clone(), reason_from_package_reason(reason));
-            }
-        }
-    }
+    // changed files. Uses the shared matching function that iterates ALL
+    // engine tasks regardless of package, so tasks with $TURBO_ROOT$ inputs
+    // in non-affected packages are correctly detected.
+    let matched =
+        turborepo_engine::match_tasks_against_changed_files(engine, pkg_dep_graph, &changed_files);
+    let mut affected: HashMap<TaskId<'static>, TaskChangeReason> = matched
+        .into_iter()
+        .map(|(task_id, file_path)| (task_id, TaskChangeReason::FileChanged { file_path }))
+        .collect();
 
     // Phase 2: Propagate through the task dependency graph via BFS.
     // If task B depends on task A and A is affected, B is also affected.
@@ -225,42 +184,203 @@ pub fn calculate_affected_tasks(
         .collect())
 }
 
-fn reason_from_package_reason(reason: &PackageInclusionReason) -> TaskChangeReason {
-    match reason {
-        PackageInclusionReason::DependencyChanged { dependency } => {
-            TaskChangeReason::PackageDependencyChanged {
-                package_name: dependency.to_string(),
-            }
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{HashMap, HashSet},
+        sync::Arc,
+    };
+
+    use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
+    use turborepo_engine::Building;
+    use turborepo_query_api::{AffectedPackagesError, BoundariesFuture};
+    use turborepo_repository::{
+        change_mapper::PackageInclusionReason,
+        discovery::{DiscoveryResponse, PackageDiscovery},
+        package_graph::{PackageGraph, PackageName},
+        package_json::PackageJson,
+        package_manager::PackageManager,
+    };
+    use turborepo_scm::SCM;
+    use turborepo_task_id::TaskId;
+    use turborepo_turbo_json::TurboJson;
+    use turborepo_types::{TaskDefinition, TaskInputs};
+
+    use super::*;
+    use crate::QueryRun;
+
+    struct MockDiscovery;
+
+    impl PackageDiscovery for MockDiscovery {
+        async fn discover_packages(
+            &self,
+        ) -> Result<DiscoveryResponse, turborepo_repository::discovery::Error> {
+            Ok(DiscoveryResponse {
+                package_manager: PackageManager::Npm,
+                workspaces: vec![],
+            })
         }
-        PackageInclusionReason::DependentChanged { dependent } => {
-            TaskChangeReason::PackageDependencyChanged {
-                package_name: dependent.to_string(),
-            }
+
+        async fn discover_packages_blocking(
+            &self,
+        ) -> Result<DiscoveryResponse, turborepo_repository::discovery::Error> {
+            self.discover_packages().await
         }
-        PackageInclusionReason::LockfileChanged { .. } => TaskChangeReason::AllTasksChanged {
-            description: "lockfile changed".to_string(),
-        },
-        PackageInclusionReason::ConservativeRootLockfileChanged => {
-            TaskChangeReason::AllTasksChanged {
-                description: "root lockfile changed".to_string(),
-            }
+    }
+
+    async fn make_pkg_graph(repo_root: &AbsoluteSystemPath, packages: &[&str]) -> PackageGraph {
+        let mut pkgs = HashMap::new();
+        for name in packages {
+            let path = repo_root.join_components(&["packages", name, "package.json"]);
+            let pkg = PackageJson {
+                name: Some(turborepo_errors::Spanned::new(name.to_string())),
+                ..Default::default()
+            };
+            pkgs.insert(path, pkg);
         }
-        PackageInclusionReason::FileChanged { file } => TaskChangeReason::FileChanged {
-            file_path: file.to_string(),
-        },
-        PackageInclusionReason::InFilteredDirectory { directory } => {
-            TaskChangeReason::AllTasksChanged {
-                description: format!("in filtered directory: {directory}"),
-            }
+        PackageGraph::builder(repo_root, PackageJson::default())
+            .with_package_discovery(MockDiscovery)
+            .with_package_jsons(Some(pkgs))
+            .build()
+            .await
+            .unwrap()
+    }
+
+    fn make_engine(
+        tasks: &[(TaskId<'static>, TaskDefinition)],
+    ) -> turborepo_engine::Engine<turborepo_engine::Built, TaskDefinition> {
+        let mut engine: turborepo_engine::Engine<Building, TaskDefinition> =
+            turborepo_engine::Engine::new();
+        for (task_id, def) in tasks {
+            engine.get_index(task_id);
+            engine.add_definition(task_id.clone(), def.clone());
         }
-        PackageInclusionReason::IncludedByFilter { filters } => TaskChangeReason::AllTasksChanged {
-            description: format!("included by filter: {}", filters.join(", ")),
-        },
-        PackageInclusionReason::RootTask { task } => TaskChangeReason::AllTasksChanged {
-            description: format!("root task: {task}"),
-        },
-        PackageInclusionReason::All(_) => {
-            unreachable!("All case handled separately")
+        engine.seal()
+    }
+
+    struct MockQueryRun {
+        engine: turborepo_engine::Engine<turborepo_engine::Built, TaskDefinition>,
+        pkg_dep_graph: PackageGraph,
+        affected_packages: HashMap<PackageName, PackageInclusionReason>,
+        changed_files: HashSet<AnchoredSystemPathBuf>,
+        #[allow(dead_code)]
+        repo_root: AbsoluteSystemPathBuf,
+    }
+
+    impl QueryRun for MockQueryRun {
+        fn version(&self) -> &'static str {
+            "test"
         }
+
+        fn repo_root(&self) -> &AbsoluteSystemPath {
+            &self.repo_root
+        }
+
+        fn pkg_dep_graph(&self) -> &PackageGraph {
+            &self.pkg_dep_graph
+        }
+
+        fn engine(&self) -> &turborepo_engine::Engine<turborepo_engine::Built, TaskDefinition> {
+            &self.engine
+        }
+
+        fn scm(&self) -> &SCM {
+            unimplemented!("not needed for affected_tasks tests")
+        }
+
+        fn root_turbo_json(&self) -> &TurboJson {
+            unimplemented!("not needed for affected_tasks tests")
+        }
+
+        fn calculate_affected_packages(
+            &self,
+            _base: Option<String>,
+            _head: Option<String>,
+        ) -> Result<HashMap<PackageName, PackageInclusionReason>, AffectedPackagesError> {
+            Ok(self.affected_packages.clone())
+        }
+
+        fn changed_files(
+            &self,
+            _base: Option<&str>,
+            _head: Option<&str>,
+        ) -> Result<HashSet<AnchoredSystemPathBuf>, AffectedPackagesError> {
+            Ok(self.changed_files.clone())
+        }
+
+        fn check_boundaries(&self, _show_progress: bool) -> BoundariesFuture<'_> {
+            unimplemented!("not needed for affected_tasks tests")
+        }
+    }
+
+    /// Regression test: a task in a non-affected package that has
+    /// $TURBO_ROOT$ inputs (resolved to ../../ paths) pointing to a changed
+    /// root file should be detected as affected.
+    ///
+    /// The `turbo run --affected` path (task_change_detector.rs) iterates
+    /// ALL engine tasks and catches this. The query path must do the same.
+    #[tokio::test]
+    async fn turbo_root_input_in_non_affected_package_is_detected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let pkg_graph = make_pkg_graph(root, &["lib-a", "lib-b"]).await;
+
+        let a_build = TaskId::new("lib-a", "build");
+        let b_build = TaskId::new("lib-b", "build");
+
+        let engine = make_engine(&[
+            // lib-a: default inputs (matches files in packages/lib-a/**)
+            (a_build.clone(), TaskDefinition::default()),
+            // lib-b: has a $TURBO_ROOT$ input that resolved to ../../config.txt
+            (
+                b_build.clone(),
+                TaskDefinition {
+                    inputs: TaskInputs {
+                        globs: vec!["../../config.txt".to_string()],
+                        default: true,
+                    },
+                    ..Default::default()
+                },
+            ),
+        ]);
+
+        // Only lib-a is in the affected packages set (a source file changed).
+        // lib-b is NOT affected at the package level.
+        let mut affected_packages = HashMap::new();
+        affected_packages.insert(
+            PackageName::from("lib-a"),
+            PackageInclusionReason::FileChanged {
+                file: AnchoredSystemPathBuf::from_raw("packages/lib-a/src/index.ts").unwrap(),
+            },
+        );
+
+        // Changed files: a root-level config file AND a file in lib-a.
+        let changed_files: HashSet<AnchoredSystemPathBuf> =
+            ["config.txt", "packages/lib-a/src/index.ts"]
+                .iter()
+                .map(|f| AnchoredSystemPathBuf::from_raw(f).unwrap())
+                .collect();
+
+        let mock: Arc<dyn QueryRun> = Arc::new(MockQueryRun {
+            engine,
+            pkg_dep_graph: pkg_graph,
+            affected_packages,
+            changed_files,
+            repo_root: root.to_owned(),
+        });
+
+        let result = calculate_affected_tasks(&mock, None, None).unwrap();
+
+        let affected_ids: HashSet<_> = result.iter().map(|at| at.task_id.clone()).collect();
+
+        assert!(
+            affected_ids.contains(&a_build),
+            "lib-a#build should be affected (source file changed)"
+        );
+        assert!(
+            affected_ids.contains(&b_build),
+            "lib-b#build should be affected ($TURBO_ROOT$ input config.txt changed), but the \
+             query path only visited tasks in affected packages and missed it"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- `turbo query { affectedTasks }` only checked tasks in *affected packages*, missing tasks in non-affected packages that declare `$TURBO_ROOT$` inputs pointing to changed root-level files
- `turbo run --affected` already handled this correctly by iterating all engine tasks
- Extracted the shared matching loop into `turborepo_engine::affected::match_tasks_against_changed_files` so both code paths use identical logic

## How it works

When a task declares `inputs: ["$TURBO_ROOT$/config.txt"]`, this gets resolved to `../../config.txt` during turbo.json processing. The matching function needs to check **every** task in the engine against changed files, not just tasks in packages that the change mapper flagged as affected. The old query path scoped its loop to affected packages, so a non-affected package with root-level inputs was silently skipped.

## Testing

A regression test in `turborepo-query` mocks a `QueryRun` with two packages where only `lib-a` is in the affected set, but `lib-b` has a `$TURBO_ROOT$` input matching a changed root file. Before the fix, `lib-b#build` was missed. After: both tasks are correctly detected.

The shared function in `turborepo-engine` has 7 unit tests covering default inputs, exclusion globs, `$TURBO_ROOT$` traversal, and the key cross-package scenario.