### PR TITLE
docs: Note that future flags affect global hash

### DIFF
--- a/apps/docs/content/docs/reference/configuration.mdx
+++ b/apps/docs/content/docs/reference/configuration.mdx
@@ -207,6 +207,12 @@ Enable experimental features that will become the default behavior in future ver
   Configuration](/docs/reference/package-configurations).
 </Callout>
 
+<Callout type="warn">
+  Changing any future flag will affect the [global
+  hash](/docs/crafting-your-repository/caching#global-hash-inputs), causing all
+  tasks to miss cache on the next run.
+</Callout>
+
 #### `errorsOnlyShowHash`
 
 Default: `false`


### PR DESCRIPTION
## Summary

- Adds a warning callout to the `futureFlags` configuration reference noting that toggling any future flag will change the global hash, causing all tasks to miss cache on the next run.