### PR TITLE
feat: Use task graph for `watch`

### DIFF
--- a/apps/docs/content/docs/reference/configuration.mdx
+++ b/apps/docs/content/docs/reference/configuration.mdx
@@ -256,7 +256,7 @@ When this flag is enabled and the key is too short, Turborepo will fail immediat
 }
 ```
 
-#### `affectedUsingTaskInputs`
+#### `affectedUsingTaskInputs` <ExperimentalBadge>Pre-release</ExperimentalBadge>
 
 Default: `false`
 
@@ -284,6 +284,36 @@ In this example, if only `README.md` changed in a package, `build` would not run
   `turbo.jsonc`), the package manager lockfile, or
   [`globalDependencies`](#globaldependencies) will always cause all tasks to be
   selected, regardless of individual task `inputs`.
+</Callout>
+
+#### `watchUsingTaskInputs` <ExperimentalBadge>Pre-release</ExperimentalBadge>
+
+Default: `false`
+
+Use task-level [`inputs`](#inputs) globs to determine which tasks to re-run when files change in `turbo watch`. When enabled, only tasks whose declared `inputs` match the changed files are re-executed, rather than re-running all tasks in changed packages.
+
+Without this flag, `turbo watch` operates at the **package level**: if any file in a package changes, all tasks in that package are re-run. With this flag, `turbo watch` operates at the **task level**: a task is only re-run if the changed files match its `inputs` configuration.
+
+```jsonc title="./turbo.json"
+{
+  "futureFlags": {
+    "watchUsingTaskInputs": true,
+  },
+  "tasks": {
+    "build": {
+      "inputs": ["$TURBO_DEFAULT$", "!README.md"],
+    },
+  },
+}
+```
+
+In this example, editing `README.md` in a package would not trigger a `build` re-run because it is excluded from the task's inputs. Editing `src/index.ts` would trigger it because it matches `$TURBO_DEFAULT$`.
+
+<Callout type="info">
+  Changes to root configuration files (`package.json`, `turbo.json`,
+  `turbo.jsonc`), the package manager lockfile, or
+  [`globalDependencies`](#globaldependencies) will always cause all tasks to be
+  re-run, regardless of individual task `inputs`.
 </Callout>
 
 ### `tags` <ExperimentalBadge>Experimental</ExperimentalBadge>

--- a/apps/docs/content/docs/reference/watch.mdx
+++ b/apps/docs/content/docs/reference/watch.mdx
@@ -18,6 +18,8 @@ turbo watch [tasks]
 
 `turbo watch` is dependency-aware, meaning tasks will re-run in the order [configured in `turbo.json`](/docs/reference/configuration).
 
+By default, `turbo watch` operates at the package level: if any file in a package changes, all tasks in that package are re-run. Enable [`futureFlags.watchUsingTaskInputs`](/docs/reference/configuration#watchusingtaskinputs) to filter at the task level using each task's [`inputs`](/docs/reference/configuration#inputs) globs instead.
+
 If no tasks are provided, `turbo` will display what tasks are available for the packages in the repository.
 
 ```bash title="Terminal"

--- a/crates/turborepo-daemon/src/lib.rs
+++ b/crates/turborepo-daemon/src/lib.rs
@@ -34,12 +34,14 @@ mod default_timeout_layer;
 pub mod endpoint;
 mod server;
 
+use std::{collections::HashSet, sync::Arc};
+
 pub use client::{DaemonClient, DaemonError};
 pub use connector::{DaemonConnector, DaemonConnectorError};
 pub use server::{CloseReason, FileWatching, TurboGrpcService};
 use sha2::{Digest, Sha256};
 use tokio::sync::broadcast;
-use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
 use turborepo_repository::package_graph::PackageName;
 
 /// Trait for watching package changes. Implemented by consumers who need
@@ -64,8 +66,16 @@ pub struct PackageChangesWatcherArgs {
 /// Events that indicate package changes in the repository.
 #[derive(Clone, Debug)]
 pub enum PackageChangeEvent {
-    /// A specific package has changed
-    Package { name: PackageName },
+    /// A specific package has changed.
+    ///
+    /// `changed_files` contains the repo-relative paths that triggered this
+    /// event. Shared via `Arc` so broadcast clones are cheap. When file-level
+    /// information is unavailable (e.g. daemon gRPC), this will be an empty
+    /// set.
+    Package {
+        name: PackageName,
+        changed_files: Arc<HashSet<AnchoredSystemPathBuf>>,
+    },
     /// All packages need to be rediscovered
     Rediscover,
 }

--- a/crates/turborepo-daemon/src/server.rs
+++ b/crates/turborepo-daemon/src/server.rs
@@ -719,7 +719,7 @@ impl<W: PackageChangesWatcher + 'static> proto::turbod_server::Turbod for TurboG
                         let _ = tx.send(Ok(event)).await;
                         break;
                     }
-                    Ok(PackageChangeEvent::Package { name }) => {
+                    Ok(PackageChangeEvent::Package { name, .. }) => {
                         let event = proto::PackageChangeEvent {
                             event: Some(proto::package_change_event::Event::PackageChanged(
                                 proto::PackageChanged {
@@ -1069,7 +1069,7 @@ mod test {
                         let _ = tx.send(Ok(event)).await;
                         break;
                     }
-                    Ok(PackageChangeEvent::Package { name }) => {
+                    Ok(PackageChangeEvent::Package { name, .. }) => {
                         let event = crate::proto::PackageChangeEvent {
                             event: Some(crate::proto::package_change_event::Event::PackageChanged(
                                 crate::proto::PackageChanged {

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -141,8 +141,10 @@ enum FileChangeAction {
     /// `ConfigChanged` so callers can log at the appropriate severity.
     MapperFailed,
     /// Files changed that map to specific packages (after gitignore
-    /// and .git filtering, before watched-package filtering)
-    PackagesChanged(PackageChanges),
+    /// and .git filtering, before watched-package filtering).
+    /// The second field carries the filtered file set for task-level
+    /// input matching in watch mode.
+    PackagesChanged(PackageChanges, HashSet<AnchoredSystemPathBuf>),
     /// All changed files were filtered out (gitignored, .git, etc.)
     NoRelevantChanges,
 }
@@ -194,8 +196,8 @@ fn classify_changed_files(
         return FileChangeAction::NoRelevantChanges;
     }
 
-    match change_mapper.changed_packages(changed_files, LockfileContents::Unchanged) {
-        Ok(changes) => FileChangeAction::PackagesChanged(changes),
+    match change_mapper.changed_packages(changed_files.clone(), LockfileContents::Unchanged) {
+        Ok(changes) => FileChangeAction::PackagesChanged(changes, changed_files),
         Err(err) => {
             tracing::warn!(
                 ?err,
@@ -543,10 +545,13 @@ impl Subscriber {
                     FileChangeAction::NoRelevantChanges => {
                         continue;
                     }
-                    FileChangeAction::PackagesChanged(PackageChanges::All(_)) => {
+                    FileChangeAction::PackagesChanged(PackageChanges::All(_), _) => {
                         rediscover!(self, repo_state, root_gitignore, change_mapper);
                     }
-                    FileChangeAction::PackagesChanged(PackageChanges::Some(filtered_pkgs)) => {
+                    FileChangeAction::PackagesChanged(
+                        PackageChanges::Some(filtered_pkgs),
+                        changed_files,
+                    ) => {
                         let mut filtered_pkgs: HashSet<WorkspacePackage> =
                             filtered_pkgs.into_keys().collect();
                         // Only propagate root package changes when the config defines
@@ -561,11 +566,13 @@ impl Subscriber {
                             }
                         }
 
+                        let changed_files = Arc::new(changed_files);
                         for pkg in filtered_pkgs {
                             if !self.is_same_hash(&pkg, &mut package_file_hashes).await {
                                 let _ = self.package_change_events_tx.send(
                                     PackageChangeEvent::Package {
                                         name: pkg.name.clone(),
+                                        changed_files: changed_files.clone(),
                                     },
                                 );
                             }
@@ -846,7 +853,7 @@ mod test {
         assert!(
             matches!(
                 action,
-                FileChangeAction::PackagesChanged(PackageChanges::Some(_))
+                FileChangeAction::PackagesChanged(PackageChanges::Some(_), _)
             ),
             "expected PackagesChanged(Some) for .gitignore in trie, got {action:?}"
         );
@@ -868,7 +875,7 @@ mod test {
 
         let action = f.classify(&trie, &["node_modules/"], None);
         match action {
-            FileChangeAction::PackagesChanged(PackageChanges::Some(pkgs)) => {
+            FileChangeAction::PackagesChanged(PackageChanges::Some(pkgs), _) => {
                 let pkg_names: HashSet<_> = pkgs.keys().map(|p| p.name.to_string()).collect();
                 assert!(
                     pkg_names.contains("a"),
@@ -943,7 +950,7 @@ mod test {
 
         let action = f.classify(&trie, &["node_modules/"], None);
         match action {
-            FileChangeAction::PackagesChanged(PackageChanges::Some(pkgs)) => {
+            FileChangeAction::PackagesChanged(PackageChanges::Some(pkgs), _) => {
                 let pkg_names: HashSet<_> = pkgs.keys().map(|p| p.name.to_string()).collect();
                 assert!(
                     pkg_names.contains("a"),
@@ -970,7 +977,7 @@ mod test {
         let action = f.classify(&trie, &[], None);
         assert!(matches!(
             action,
-            FileChangeAction::PackagesChanged(PackageChanges::Some(_))
+            FileChangeAction::PackagesChanged(PackageChanges::Some(_), _)
         ));
     }
 
@@ -990,7 +997,7 @@ mod test {
 
         let action = f.classify(&trie, &[], None);
         assert!(
-            matches!(action, FileChangeAction::PackagesChanged(_)),
+            matches!(action, FileChangeAction::PackagesChanged(_, _)),
             "expected PackagesChanged for lockfile change, got {action:?}"
         );
     }
@@ -1246,7 +1253,7 @@ mod test {
         let action = classify_changed_files(&trie, &repo_root, &gitignore, None, &change_mapper);
 
         match &action {
-            FileChangeAction::PackagesChanged(PackageChanges::Some(pkgs)) => {
+            FileChangeAction::PackagesChanged(PackageChanges::Some(pkgs), _) => {
                 let names: Vec<_> = pkgs.keys().map(|p| p.name.to_string()).collect();
                 assert!(names.contains(&"a".to_string()), "got {:?}", names);
             }

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -66,6 +66,10 @@ pub struct RunBuilder {
     // that trigger the file watcher, causing an infinite rebuild loop.
     output_watcher: Option<Arc<dyn turborepo_run_cache::OutputWatcher>>,
     query_server: Option<Arc<dyn turborepo_query_api::QueryServer>>,
+    // In watch mode with `watchUsingTaskInputs`, the file watcher provides
+    // the set of changed files that triggered the rebuild. Used to filter
+    // the engine down to only tasks whose declared inputs match.
+    changed_files_for_watch: Option<HashSet<turbopath::AnchoredSystemPathBuf>>,
 }
 
 impl RunBuilder {
@@ -105,6 +109,7 @@ impl RunBuilder {
             add_all_tasks: false,
             output_watcher: None,
             query_server: None,
+            changed_files_for_watch: None,
         })
     }
 
@@ -128,6 +133,11 @@ impl RunBuilder {
 
     pub fn hide_prelude(mut self) -> Self {
         self.should_print_prelude_override = Some(false);
+        self
+    }
+
+    pub fn with_changed_files(mut self, files: HashSet<turbopath::AnchoredSystemPathBuf>) -> Self {
+        self.changed_files_for_watch = Some(files);
         self
     }
 
@@ -719,10 +729,55 @@ impl RunBuilder {
 
         let mut engine = builder.build()?;
 
+        // In watch mode with the future flag, filter the engine to only tasks
+        // whose declared inputs match the changed files.
+        //
+        // When active, this REPLACES create_engine_for_subgraph because:
+        // 1. retain_affected_tasks already selects the correct tasks + dependents
+        // 2. The entrypoint packages (from file watcher events) may not overlap with
+        //    the affected tasks (e.g. a $TURBO_ROOT$ input in another package)
+        // 3. retain_affected_tasks requires the Root sentinel node, which
+        //    create_engine_for_subgraph removes
+        let watch_task_filtered = if let Some(ref changed_files) = self.changed_files_for_watch {
+            if self.opts.future_flags.watch_using_task_inputs && !changed_files.is_empty() {
+                // Only consider files that still exist on disk. Editor temp
+                // files (vim 4913, *~ backups, etc.) are created and deleted
+                // within the same watcher batch. The hash algorithm only sees
+                // files that exist, so input matching should too.
+                let existing_files: std::collections::HashSet<_> = changed_files
+                    .iter()
+                    .filter(|f| self.repo_root.resolve(f).exists())
+                    .cloned()
+                    .collect();
+
+                let total_tasks = engine.task_ids().count();
+                let affected_tasks = crate::task_change_detector::affected_task_ids(
+                    &engine,
+                    pkg_dep_graph,
+                    &existing_files,
+                    root_turbo_json.global_deps.as_slice(),
+                );
+                tracing::info!(
+                    total_tasks,
+                    affected_tasks = affected_tasks.len(),
+                    changed_files = existing_files.len(),
+                    "watch task-level input filtering complete"
+                );
+                engine = engine.retain_affected_tasks(&affected_tasks);
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+
         // If we have an initial task, we prune out the engine to only
         // tasks that are reachable from that initial task.
-        if let Some(entrypoint_packages) = &self.entrypoint_packages {
-            engine = engine.create_engine_for_subgraph(entrypoint_packages);
+        if !watch_task_filtered {
+            if let Some(entrypoint_packages) = &self.entrypoint_packages {
+                engine = engine.create_engine_for_subgraph(entrypoint_packages);
+            }
         }
 
         if !self.opts.run_opts.parallel && self.should_validate_engine {

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -13,6 +13,7 @@ use tokio::{
     task::JoinHandle,
 };
 use tracing::{instrument, trace};
+use turbopath::AnchoredSystemPathBuf;
 use turborepo_daemon::{PackageChangeEvent, PackageChangesWatcher as PackageChangesWatcherTrait};
 use turborepo_filewatch::{
     cookies::CookieWriter, globwatcher::GlobWatcher, hash_watcher::HashWatcher,
@@ -37,12 +38,18 @@ use crate::{
 #[derive(Debug)]
 enum ChangedPackages {
     All,
-    Some(HashSet<PackageName>),
+    Some {
+        packages: HashSet<PackageName>,
+        changed_files: HashSet<AnchoredSystemPathBuf>,
+    },
 }
 
 impl Default for ChangedPackages {
     fn default() -> Self {
-        ChangedPackages::Some(HashSet::new())
+        ChangedPackages::Some {
+            packages: HashSet::new(),
+            changed_files: HashSet::new(),
+        }
     }
 }
 
@@ -50,7 +57,7 @@ impl ChangedPackages {
     pub fn is_empty(&self) -> bool {
         match self {
             ChangedPackages::All => false,
-            ChangedPackages::Some(pkgs) => pkgs.is_empty(),
+            ChangedPackages::Some { packages, .. } => packages.is_empty(),
         }
     }
 
@@ -58,8 +65,8 @@ impl ChangedPackages {
     /// `All` is left unchanged because it triggers a full rebuild that
     /// recomputes the watched set from scratch.
     fn filter_to_watched(&mut self, watched_packages: &HashSet<PackageName>) {
-        if let ChangedPackages::Some(pkgs) = self {
-            pkgs.retain(|pkg| watched_packages.contains(pkg));
+        if let ChangedPackages::Some { packages, .. } = self {
+            packages.retain(|pkg| watched_packages.contains(pkg));
         }
     }
 }
@@ -359,9 +366,14 @@ impl WatchClient {
                     // - A cache-hit run incorrectly signaling persistent task readiness when the
                     //   real build failed
                     match changed_packages {
-                        ChangedPackages::Some(ref pkgs) => {
-                            let impacted = self.stop_impacted_tasks(pkgs).await;
-                            changed_packages = ChangedPackages::Some(impacted);
+                        ChangedPackages::Some { ref packages, .. } => {
+                            let impacted = self.stop_impacted_tasks(packages).await;
+                            if let ChangedPackages::Some {
+                                ref mut packages, ..
+                            } = changed_packages
+                            {
+                                *packages = impacted;
+                            }
                         }
                         ChangedPackages::All => {
                             for handle in self.active_runs.drain(..) {
@@ -406,16 +418,21 @@ impl WatchClient {
     #[instrument(skip(changed_packages))]
     fn handle_change_event(changed_packages: &Mutex<ChangedPackages>, event: PackageChangeEvent) {
         match event {
-            PackageChangeEvent::Package { name } => {
-                match changed_packages.lock().expect("poisoned lock").deref_mut() {
-                    ChangedPackages::All => {
-                        // Already rediscovering everything, ignore
-                    }
-                    ChangedPackages::Some(ref mut pkgs) => {
-                        pkgs.insert(name);
-                    }
+            PackageChangeEvent::Package {
+                name,
+                changed_files: files,
+            } => match changed_packages.lock().expect("poisoned lock").deref_mut() {
+                ChangedPackages::All => {
+                    // Already rediscovering everything, ignore
                 }
-            }
+                ChangedPackages::Some {
+                    ref mut packages,
+                    ref mut changed_files,
+                } => {
+                    packages.insert(name);
+                    changed_files.extend(files.iter().cloned());
+                }
+            },
             PackageChangeEvent::Rediscover => {
                 *changed_packages.lock().expect("poisoned lock") = ChangedPackages::All;
             }
@@ -475,7 +492,10 @@ impl WatchClient {
     async fn execute_run(&mut self, changed_packages: ChangedPackages) -> Result<RunHandle, Error> {
         trace!("handling run with changed packages: {changed_packages:?}");
         match changed_packages {
-            ChangedPackages::Some(packages) => {
+            ChangedPackages::Some {
+                packages,
+                changed_files,
+            } => {
                 let mut opts = self.base.opts().clone();
                 if !self.experimental_write_cache {
                     opts.cache_opts.cache.remote.write = false;
@@ -495,14 +515,23 @@ impl WatchClient {
                 let mut run_builder = RunBuilder::new(new_base, None)?
                     .with_output_watcher(self.output_watcher.clone())
                     .with_entrypoint_packages(packages)
+                    .with_changed_files(changed_files)
                     .hide_prelude();
                 if let Some(ref qs) = self.query_server {
                     run_builder = run_builder.with_query_server(qs.clone());
                 }
                 let (run, _analytics) = run_builder.build(&signal_handler, telemetry).await?;
 
+                let task_names = run.engine.tasks_with_command(&run.pkg_dep_graph);
+                if task_names.is_empty() {
+                    tracing::debug!("no executable tasks after filtering, skipping run");
+                    return Ok(RunHandle {
+                        stopper: run.stopper(),
+                        run_task: tokio::spawn(async { Ok(0) }),
+                    });
+                }
+
                 if let Some(sender) = &self.ui_sender {
-                    let task_names = run.engine.tasks_with_command(&run.pkg_dep_graph);
                     if let Err(err) = sender.restart_tasks(task_names) {
                         tracing::warn!("failed to notify UI of restarted tasks: {err}");
                     }
@@ -607,9 +636,13 @@ impl WatchClient {
 
 #[cfg(test)]
 mod test {
-    use std::{collections::HashSet, sync::Mutex};
+    use std::{
+        collections::HashSet,
+        sync::{Arc, Mutex},
+    };
 
     use tokio::sync::oneshot;
+    use turbopath::AnchoredSystemPathBuf;
     use turborepo_daemon::PackageChangeEvent;
     use turborepo_repository::package_graph::PackageName;
 
@@ -618,6 +651,19 @@ mod test {
     fn make_package_changed(name: &str) -> PackageChangeEvent {
         PackageChangeEvent::Package {
             name: PackageName::from(name),
+            changed_files: Arc::new(HashSet::new()),
+        }
+    }
+
+    fn make_package_changed_with_files(name: &str, files: &[&str]) -> PackageChangeEvent {
+        PackageChangeEvent::Package {
+            name: PackageName::from(name),
+            changed_files: Arc::new(
+                files
+                    .iter()
+                    .map(|f| AnchoredSystemPathBuf::from_raw(f).unwrap())
+                    .collect(),
+            ),
         }
     }
 
@@ -629,7 +675,7 @@ mod test {
     fn changed_packages_default_is_empty() {
         let cp = ChangedPackages::default();
         assert!(cp.is_empty());
-        assert!(matches!(cp, ChangedPackages::Some(ref s) if s.is_empty()));
+        assert!(matches!(cp, ChangedPackages::Some { ref packages, .. } if packages.is_empty()));
     }
 
     #[test]
@@ -639,9 +685,13 @@ mod test {
 
     #[test]
     fn changed_packages_some_with_items_is_not_empty() {
-        let mut set = HashSet::new();
-        set.insert(PackageName::from("a"));
-        assert!(!ChangedPackages::Some(set).is_empty());
+        let mut packages = HashSet::new();
+        packages.insert(PackageName::from("a"));
+        assert!(!ChangedPackages::Some {
+            packages,
+            changed_files: HashSet::new(),
+        }
+        .is_empty());
     }
 
     #[test]
@@ -651,9 +701,9 @@ mod test {
 
         let guard = changed.lock().unwrap();
         match &*guard {
-            ChangedPackages::Some(pkgs) => {
-                assert_eq!(pkgs.len(), 1);
-                assert!(pkgs.contains(&PackageName::from("web")));
+            ChangedPackages::Some { packages, .. } => {
+                assert_eq!(packages.len(), 1);
+                assert!(packages.contains(&PackageName::from("web")));
             }
             ChangedPackages::All => panic!("expected Some, got All"),
         }
@@ -668,11 +718,11 @@ mod test {
 
         let guard = changed.lock().unwrap();
         match &*guard {
-            ChangedPackages::Some(pkgs) => {
-                assert_eq!(pkgs.len(), 3);
-                assert!(pkgs.contains(&PackageName::from("web")));
-                assert!(pkgs.contains(&PackageName::from("ui")));
-                assert!(pkgs.contains(&PackageName::from("utils")));
+            ChangedPackages::Some { packages, .. } => {
+                assert_eq!(packages.len(), 3);
+                assert!(packages.contains(&PackageName::from("web")));
+                assert!(packages.contains(&PackageName::from("ui")));
+                assert!(packages.contains(&PackageName::from("utils")));
             }
             ChangedPackages::All => panic!("expected Some, got All"),
         }
@@ -686,7 +736,7 @@ mod test {
 
         let guard = changed.lock().unwrap();
         match &*guard {
-            ChangedPackages::Some(pkgs) => assert_eq!(pkgs.len(), 1),
+            ChangedPackages::Some { packages, .. } => assert_eq!(packages.len(), 1),
             ChangedPackages::All => panic!("expected Some, got All"),
         }
     }
@@ -721,26 +771,52 @@ mod test {
     }
 
     #[test]
+    fn handle_change_event_accumulates_changed_files() {
+        let changed = Mutex::new(ChangedPackages::default());
+        WatchClient::handle_change_event(
+            &changed,
+            make_package_changed_with_files("web", &["packages/web/src/index.ts"]),
+        );
+        WatchClient::handle_change_event(
+            &changed,
+            make_package_changed_with_files("ui", &["packages/ui/src/button.tsx"]),
+        );
+
+        let guard = changed.lock().unwrap();
+        match &*guard {
+            ChangedPackages::Some {
+                packages,
+                changed_files,
+            } => {
+                assert_eq!(packages.len(), 2);
+                assert_eq!(changed_files.len(), 2);
+            }
+            ChangedPackages::All => panic!("expected Some, got All"),
+        }
+    }
+
+    #[test]
     fn filter_to_watched_removes_unwatched_packages() {
         let watched: HashSet<_> = ["web", "ui"]
             .iter()
             .map(|s| PackageName::from(*s))
             .collect();
-        let mut changed = ChangedPackages::Some(
-            ["web", "api", "ui", "utils"]
+        let mut changed = ChangedPackages::Some {
+            packages: ["web", "api", "ui", "utils"]
                 .iter()
                 .map(|s| PackageName::from(*s))
                 .collect(),
-        );
+            changed_files: HashSet::new(),
+        };
 
         changed.filter_to_watched(&watched);
 
         match changed {
-            ChangedPackages::Some(pkgs) => {
-                assert_eq!(pkgs.len(), 2);
-                assert!(pkgs.contains(&PackageName::from("web")));
-                assert!(pkgs.contains(&PackageName::from("ui")));
-                assert!(!pkgs.contains(&PackageName::from("api")));
+            ChangedPackages::Some { packages, .. } => {
+                assert_eq!(packages.len(), 2);
+                assert!(packages.contains(&PackageName::from("web")));
+                assert!(packages.contains(&PackageName::from("ui")));
+                assert!(!packages.contains(&PackageName::from("api")));
             }
             ChangedPackages::All => panic!("expected Some"),
         }
@@ -758,17 +834,18 @@ mod test {
     #[test]
     fn filter_to_watched_empty_watched_set_clears_all() {
         let watched: HashSet<PackageName> = HashSet::new();
-        let mut changed = ChangedPackages::Some(
-            ["web", "ui"]
+        let mut changed = ChangedPackages::Some {
+            packages: ["web", "ui"]
                 .iter()
                 .map(|s| PackageName::from(*s))
                 .collect(),
-        );
+            changed_files: HashSet::new(),
+        };
 
         changed.filter_to_watched(&watched);
 
         match changed {
-            ChangedPackages::Some(pkgs) => assert!(pkgs.is_empty()),
+            ChangedPackages::Some { packages, .. } => assert!(packages.is_empty()),
             ChangedPackages::All => panic!("expected Some"),
         }
     }
@@ -776,17 +853,18 @@ mod test {
     #[test]
     fn filter_to_watched_no_overlap() {
         let watched: HashSet<_> = ["web"].iter().map(|s| PackageName::from(*s)).collect();
-        let mut changed = ChangedPackages::Some(
-            ["api", "utils"]
+        let mut changed = ChangedPackages::Some {
+            packages: ["api", "utils"]
                 .iter()
                 .map(|s| PackageName::from(*s))
                 .collect(),
-        );
+            changed_files: HashSet::new(),
+        };
 
         changed.filter_to_watched(&watched);
 
         match changed {
-            ChangedPackages::Some(pkgs) => assert!(pkgs.is_empty()),
+            ChangedPackages::Some { packages, .. } => assert!(packages.is_empty()),
             ChangedPackages::All => panic!("expected Some"),
         }
     }
@@ -806,8 +884,8 @@ mod test {
         assert!(guard.is_empty());
 
         match taken {
-            ChangedPackages::Some(pkgs) => {
-                assert!(pkgs.contains(&PackageName::from("web")));
+            ChangedPackages::Some { packages, .. } => {
+                assert!(packages.contains(&PackageName::from("web")));
             }
             ChangedPackages::All => panic!("expected Some"),
         }

--- a/crates/turborepo-turbo-json/src/future_flags.rs
+++ b/crates/turborepo-turbo-json/src/future_flags.rs
@@ -60,6 +60,12 @@ pub struct FutureFlags {
     /// selecting all tasks in changed packages.
     #[serde(default)]
     pub affected_using_task_inputs: bool,
+    /// Use task-level `inputs` globs to determine which tasks to re-run when
+    /// files change in `turbo watch`. When enabled, only tasks whose declared
+    /// inputs match the changed files are re-executed, rather than re-running
+    /// all tasks in changed packages.
+    #[serde(default)]
+    pub watch_using_task_inputs: bool,
 }
 
 // Manual TS impl because #[derive(TS)] conflicts with the Iterable and
@@ -75,25 +81,27 @@ impl TS for FutureFlags {
 
     fn inline() -> String {
         "{ errorsOnlyShowHash?: boolean, experimentalObservability?: boolean, longerSignatureKey?: \
-         boolean, affectedUsingTaskInputs?: boolean }"
+         boolean, affectedUsingTaskInputs?: boolean, watchUsingTaskInputs?: boolean }"
             .to_string()
     }
 
     fn inline_flattened() -> String {
         "{ errorsOnlyShowHash?: boolean, experimentalObservability?: boolean, longerSignatureKey?: \
-         boolean, affectedUsingTaskInputs?: boolean }"
+         boolean, affectedUsingTaskInputs?: boolean, watchUsingTaskInputs?: boolean }"
             .to_string()
     }
 
     fn decl() -> String {
         "type FutureFlags = { errorsOnlyShowHash?: boolean, experimentalObservability?: boolean, \
-         longerSignatureKey?: boolean, affectedUsingTaskInputs?: boolean };"
+         longerSignatureKey?: boolean, affectedUsingTaskInputs?: boolean, watchUsingTaskInputs?: \
+         boolean };"
             .to_string()
     }
 
     fn decl_concrete() -> String {
         "type FutureFlags = { errorsOnlyShowHash?: boolean, experimentalObservability?: boolean, \
-         longerSignatureKey?: boolean, affectedUsingTaskInputs?: boolean };"
+         longerSignatureKey?: boolean, affectedUsingTaskInputs?: boolean, watchUsingTaskInputs?: \
+         boolean };"
             .to_string()
     }
 

--- a/packages/turbo-types/schemas/schema.json
+++ b/packages/turbo-types/schemas/schema.json
@@ -276,6 +276,11 @@
           "description": "Enforce a minimum length of 32 bytes for `TURBO_REMOTE_CACHE_SIGNATURE_KEY` when `remoteCache.signature` is enabled. Short keys weaken the HMAC-SHA256 signature, making brute-force tag collision feasible.",
           "default": false,
           "type": "boolean"
+        },
+        "watchUsingTaskInputs": {
+          "description": "Use task-level `inputs` globs to determine which tasks to re-run when files change in `turbo watch`. When enabled, only tasks whose declared inputs match the changed files are re-executed, rather than re-running all tasks in changed packages.",
+          "default": false,
+          "type": "boolean"
         }
       }
     },

--- a/packages/turbo-types/schemas/schema.v2.json
+++ b/packages/turbo-types/schemas/schema.v2.json
@@ -276,6 +276,11 @@
           "description": "Enforce a minimum length of 32 bytes for `TURBO_REMOTE_CACHE_SIGNATURE_KEY` when `remoteCache.signature` is enabled. Short keys weaken the HMAC-SHA256 signature, making brute-force tag collision feasible.",
           "default": false,
           "type": "boolean"
+        },
+        "watchUsingTaskInputs": {
+          "description": "Use task-level `inputs` globs to determine which tasks to re-run when files change in `turbo watch`. When enabled, only tasks whose declared inputs match the changed files are re-executed, rather than re-running all tasks in changed packages.",
+          "default": false,
+          "type": "boolean"
         }
       }
     },


### PR DESCRIPTION
## Summary

- Adds `watchUsingTaskInputs` future flag that enables task-level `inputs` matching for `turbo watch`, matching the existing `affectedUsingTaskInputs` behavior for `--affected`
- When enabled, file changes are matched against each task's declared `inputs` globs — only tasks with matching inputs are re-run, rather than all tasks in the changed package
- Ephemeral editor temp files (vim `4913`, `*~` backups) are filtered out via an existence check before input matching, since they're gone by the time the debounced batch is processed

## How it works

1. `PackageChangeEvent::Package` now carries the changed file paths (via `Arc<HashSet>`) from the watcher through to the watch client
2. In `build_engine`, when the flag is enabled, `affected_task_ids()` + `retain_affected_tasks()` filter the engine — the same shared matching logic used by `--affected`
3. This replaces `create_engine_for_subgraph` (not stacked on top) because the two filters can conflict: entrypoint packages from the watcher may not overlap with affected tasks (e.g. `$TURBO_ROOT$` inputs)
4. When no tasks match, the run is skipped entirely — no TUI notification, no empty run

## Testing

- Edit `README.md` with `inputs: ["$TURBO_DEFAULT$", "!README.md"]` → no rebuild
- Edit `src/index.ts` → only matching tasks rebuild
- Edit a dependency package → transitive dependents rebuild correctly

Closes TURBO-5346