### PR TITLE
fix: Replace dns.lookup with https.get for create-turbo online check

### DIFF
--- a/packages/create-turbo/src/commands/create/index.ts
+++ b/packages/create-turbo/src/commands/create/index.ts
@@ -89,9 +89,7 @@ export async function create(
     error(
       "You appear to be offline. Please check your network connection and try again."
     );
-    for (const reason of onlineStatus.reasons) {
-      warn(reason);
-    }
+    warn(onlineStatus.reason);
     process.exit(1);
   }
   const { root, projectName } = await prompts.directory({ dir: directory });

--- a/packages/create-turbo/src/utils/is-online.ts
+++ b/packages/create-turbo/src/utils/is-online.ts
@@ -1,96 +1,29 @@
-import { execSync } from "node:child_process";
-import dns from "node:dns";
+import https from "node:https";
 
-const DNS_TIMEOUT = 5000;
-const DNS_HOST = "github.com";
+const TIMEOUT = 5000;
+const HOST = "https://github.com";
 
-type DnsResult = "resolved" | "timeout" | "error";
+type OnlineStatus = { online: true } | { online: false; reason: string };
 
-export type OnlineStatus =
-  | { online: true }
-  | { online: false; reasons: string[] };
-
-function getProxy(): string | undefined {
-  if (process.env.https_proxy || process.env.HTTPS_PROXY) {
-    return process.env.https_proxy || process.env.HTTPS_PROXY;
-  }
-
-  try {
-    const httpsProxy = execSync("npm config get https-proxy", {
-      timeout: 3000
-    })
-      .toString()
-      .trim();
-    return httpsProxy !== "null" ? httpsProxy : undefined;
-  } catch (_) {
-    // do nothing
-  }
-}
-
-function dnsLookupWithTimeout(
-  hostname: string,
-  timeout: number
-): Promise<DnsResult> {
+// Uses https.get which goes through the ProxyAgent
+// already configured as https.globalAgent in cli.ts.
+export function isOnline(): Promise<OnlineStatus> {
   return new Promise((resolve) => {
-    let settled = false;
+    const req = https.get(HOST, { timeout: TIMEOUT }, (res) => {
+      res.resume();
+      resolve({ online: true });
+    });
 
-    const timeoutId = setTimeout(() => {
-      if (!settled) {
-        settled = true;
-        resolve("timeout");
-      }
-    }, timeout);
+    req.on("error", (err) => {
+      resolve({ online: false, reason: err.message });
+    });
 
-    dns.lookup(hostname, (err) => {
-      if (!settled) {
-        settled = true;
-        clearTimeout(timeoutId);
-        resolve(err === null ? "resolved" : "error");
-      }
+    req.on("timeout", () => {
+      req.destroy();
+      resolve({
+        online: false,
+        reason: `Request to ${HOST} timed out after ${TIMEOUT / 1000}s`
+      });
     });
   });
-}
-
-function describeDnsFailure(hostname: string, result: DnsResult): string {
-  if (result === "timeout") {
-    return `DNS lookup for "${hostname}" timed out after ${DNS_TIMEOUT / 1000}s`;
-  }
-  return `DNS lookup for "${hostname}" failed`;
-}
-
-export async function isOnline(): Promise<OnlineStatus> {
-  const dnsResult = await dnsLookupWithTimeout(DNS_HOST, DNS_TIMEOUT);
-  if (dnsResult === "resolved") {
-    return { online: true };
-  }
-
-  const reasons: string[] = [describeDnsFailure(DNS_HOST, dnsResult)];
-
-  const proxy = getProxy();
-  if (!proxy) {
-    reasons.push("No HTTPS proxy was detected as a fallback.");
-    return { online: false, reasons };
-  }
-
-  let hostname: string | undefined;
-  try {
-    ({ hostname } = new URL(proxy));
-  } catch {
-    reasons.push(`HTTPS proxy "${proxy}" was detected but has an invalid URL.`);
-    return { online: false, reasons };
-  }
-  if (!hostname) {
-    reasons.push(`HTTPS proxy "${proxy}" was detected but has no hostname.`);
-    return { online: false, reasons };
-  }
-
-  const proxyResult = await dnsLookupWithTimeout(hostname, DNS_TIMEOUT);
-  if (proxyResult === "resolved") {
-    return { online: true };
-  }
-
-  reasons.push(
-    `HTTPS proxy "${proxy}" was detected but ${describeDnsFailure(hostname, proxyResult).toLowerCase()}.`
-  );
-  return { online: false, reasons };
 }


### PR DESCRIPTION
## Summary

Closes #12250

- Replace `dns.lookup()` with `https.get()` for the connectivity check in `create-turbo`

## Why

The previous code manually reimplemented proxy detection (`getProxy()` checking env vars + `npm config`) that the `ProxyAgent` — [already configured as `https.globalAgent` in `cli.ts`](https://github.com/vercel/turborepo/blob/5677b17120/packages/create-turbo/src/cli.ts#L24-L26) — handles automatically (env vars, npm config, PAC files, SOCKS, system settings).

`https.get()` goes through the global agent, so all proxy scenarios are covered without manual detection. It also tests actual HTTP connectivity rather than just DNS resolution, which is what actually matters.

## Testing

Ask the reporter to test with `bunx create-turbo` using this branch. Alternatively, confirm the change works by running:
- `npx create-turbo` (should work as before)
- `bunx create-turbo` (should no longer false-positive as offline)