### PR TITLE
feat: Add `turbo query affected` CLI shorthand

### DIFF
--- a/apps/docs/content/docs/reference/query.mdx
+++ b/apps/docs/content/docs/reference/query.mdx
@@ -4,6 +4,9 @@ description: API reference for the `turbo query` command
 product: turborepo
 type: reference
 summary: All flags and options for the `turbo query` command that runs GraphQL queries against your monorepo.
+related:
+  - /docs/crafting-your-repository/upgrading
+  - /docs/reference/system-environment-variables
 ---
 
 import { ExperimentalBadge } from "@/components/geistdocs/experimental-badge";
@@ -32,4 +35,119 @@ When passed a file path, the command will read the file and run the query.
 
 ```bash title="Terminal"
 turbo query query.gql
+```
+
+## Shorthands
+
+Shorthands generate GraphQL queries for common operations so you don't need to write them by hand. The JSON output is identical to what you'd get from a raw query.
+
+### `affected`
+
+Check which packages or tasks are affected by changes between two git refs.
+
+```bash title="Terminal"
+turbo query affected [flags]
+```
+
+With no flags, returns all affected tasks:
+
+```bash title="Terminal"
+turbo query affected
+```
+
+```json title="Output"
+{
+  "data": {
+    "affectedTasks": {
+      "items": [
+        {
+          "name": "build",
+          "fullName": "web#build",
+          "package": { "name": "web" },
+          "reason": { "__typename": "TaskFileChanged" }
+        }
+      ],
+      "length": 1
+    }
+  }
+}
+```
+
+Task-level detection is more precise than package-level. A task is only reported as affected if its configured [`inputs`](/docs/reference/configuration#inputs) match a changed file, or if an upstream task dependency is affected.
+
+#### `--tasks`
+
+Filter to specific task names. With no values, returns all affected tasks (same as bare `turbo query affected`).
+
+```bash title="Terminal"
+turbo query affected --tasks
+turbo query affected --tasks build
+turbo query affected --tasks build test
+```
+
+#### `--packages`
+
+Without `--tasks`, returns affected packages instead of tasks. With no values, returns all affected packages. With values, filters to the named packages.
+
+When combined with `--tasks`, both filters apply (intersection) — only tasks matching the task name **and** belonging to the named packages are returned. This lets you check whether a specific task in a specific package changed:
+
+```bash title="Terminal"
+turbo query affected --tasks build --packages web
+```
+
+```bash title="Terminal"
+turbo query affected --packages
+turbo query affected --packages web
+turbo query affected --packages web docs
+```
+
+```json title="Output"
+{
+  "data": {
+    "affectedPackages": {
+      "items": [
+        { "name": "web", "path": "apps/web", "reason": { "__typename": "FileChanged" } }
+      ],
+      "length": 1
+    }
+  }
+}
+```
+
+#### `--base`
+
+Base git ref for comparison. Defaults to the auto-detected base (e.g. `GITHUB_BASE_REF` on GitHub Actions, or the merge-base with `main`).
+
+Can also be set with the `TURBO_SCM_BASE` environment variable.
+
+```bash title="Terminal"
+turbo query affected --base main
+```
+
+#### `--head`
+
+Head git ref for comparison. Defaults to `HEAD`.
+
+Can also be set with the `TURBO_SCM_HEAD` environment variable.
+
+```bash title="Terminal"
+turbo query affected --head my-branch
+```
+
+## Flags
+
+### `--schema`
+
+Output the GraphQL introspection schema. Cannot be used with a query argument.
+
+```bash title="Terminal"
+turbo query --schema
+```
+
+### `--variables` (`-V`)
+
+Path to a JSON file containing query variables. Requires a query argument.
+
+```bash title="Terminal"
+turbo query query.gql --variables vars.json
 ```

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -773,7 +773,10 @@ pub enum Command {
     },
     /// Query your monorepo using GraphQL. If no query is provided, spins up a
     /// GraphQL server with GraphiQL.
+    #[command(args_conflicts_with_subcommands = true)]
     Query {
+        #[clap(subcommand)]
+        subcommand: Option<QuerySubcommand>,
         /// Pass variables to the query via a JSON file
         #[clap(short = 'V', long, requires = "query")]
         variables: Option<Utf8PathBuf>,
@@ -863,6 +866,33 @@ pub enum GenerateCommand {
     Workspace(GenerateWorkspaceArgs),
     #[clap(name = "run", alias = "r")]
     Run(GeneratorCustomArgs),
+}
+
+#[derive(Subcommand, Clone, Debug, PartialEq)]
+pub enum QuerySubcommand {
+    /// Check which packages or tasks are affected by changes between two git
+    /// refs
+    Affected(AffectedArgs),
+}
+
+#[derive(clap::Args, Clone, Debug, PartialEq)]
+pub struct AffectedArgs {
+    /// Return affected packages instead of tasks. Optionally filter by name.
+    /// When combined with --tasks, returns affected tasks that match both
+    /// the task name and package filters.
+    #[clap(long, num_args = 0..)]
+    pub packages: Option<Vec<String>>,
+    /// Filter to specific task names (e.g. build, test).
+    /// When combined with --packages, returns affected tasks that match both
+    /// the task name and package filters.
+    #[clap(long, num_args = 0..)]
+    pub tasks: Option<Vec<String>>,
+    /// Base git ref for comparison
+    #[clap(long)]
+    pub base: Option<String>,
+    /// Head git ref for comparison
+    #[clap(long)]
+    pub head: Option<String>,
 }
 
 fn validate_graph_extension(s: &str) -> Result<String, String> {
@@ -1725,6 +1755,7 @@ async fn run_main(
             Ok(exit_code)
         }
         Command::Query {
+            subcommand,
             query,
             variables,
             schema,
@@ -1733,6 +1764,7 @@ async fn run_main(
                 return Err(error::Error::QueryNotAvailable);
             };
             warn!("query command is experimental and may change in the future");
+            let subcommand = subcommand.clone();
             let query = query.clone();
             let variables = variables.clone();
             let schema = *schema;
@@ -1745,6 +1777,7 @@ async fn run_main(
             let query = query::run(
                 base,
                 event,
+                subcommand,
                 query,
                 variables.as_deref(),
                 schema,
@@ -3625,5 +3658,167 @@ mod test {
             let err = cli.unwrap_err();
             assert_snapshot!(args.join("-").as_str(), err);
         }
+    }
+
+    #[test]
+    fn test_query_affected_no_args() {
+        let args = Args::try_parse_from(["turbo", "query", "affected"]).unwrap();
+        assert_eq!(
+            args.command,
+            Some(Command::Query {
+                subcommand: Some(super::QuerySubcommand::Affected(super::AffectedArgs {
+                    packages: None,
+                    tasks: None,
+                    base: None,
+                    head: None,
+                })),
+                query: None,
+                variables: None,
+                schema: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_query_affected_bare_packages_flag() {
+        let args = Args::try_parse_from(["turbo", "query", "affected", "--packages"]).unwrap();
+        assert_matches!(
+            args.command,
+            Some(Command::Query {
+                subcommand: Some(super::QuerySubcommand::Affected(ref a)),
+                ..
+            }) if a.packages == Some(vec![])
+        );
+    }
+
+    #[test]
+    fn test_query_affected_with_packages() {
+        let args =
+            Args::try_parse_from(["turbo", "query", "affected", "--packages", "web"]).unwrap();
+        assert_matches!(
+            args.command,
+            Some(Command::Query {
+                subcommand: Some(super::QuerySubcommand::Affected(ref a)),
+                ..
+            }) if a.packages == Some(vec!["web".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_query_affected_with_multiple_packages() {
+        let args =
+            Args::try_parse_from(["turbo", "query", "affected", "--packages", "web", "docs"])
+                .unwrap();
+        assert_matches!(
+            args.command,
+            Some(Command::Query {
+                subcommand: Some(super::QuerySubcommand::Affected(ref a)),
+                ..
+            }) if a.packages == Some(vec!["web".to_string(), "docs".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_query_affected_bare_tasks_flag() {
+        let args = Args::try_parse_from(["turbo", "query", "affected", "--tasks"]).unwrap();
+        assert_matches!(
+            args.command,
+            Some(Command::Query {
+                subcommand: Some(super::QuerySubcommand::Affected(ref a)),
+                ..
+            }) if a.tasks == Some(vec![])
+        );
+    }
+
+    #[test]
+    fn test_query_affected_with_tasks() {
+        let args =
+            Args::try_parse_from(["turbo", "query", "affected", "--tasks", "build"]).unwrap();
+        assert_matches!(
+            args.command,
+            Some(Command::Query {
+                subcommand: Some(super::QuerySubcommand::Affected(ref a)),
+                ..
+            }) if a.tasks == Some(vec!["build".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_query_affected_with_base_head() {
+        let args = Args::try_parse_from([
+            "turbo", "query", "affected", "--base", "main", "--head", "HEAD",
+        ])
+        .unwrap();
+        assert_matches!(
+            args.command,
+            Some(Command::Query {
+                subcommand: Some(super::QuerySubcommand::Affected(ref a)),
+                ..
+            }) if a.base == Some("main".to_string()) && a.head == Some("HEAD".to_string())
+        );
+    }
+
+    #[test]
+    fn test_query_affected_combined_packages_and_tasks() {
+        let args = Args::try_parse_from([
+            "turbo",
+            "query",
+            "affected",
+            "--packages",
+            "web",
+            "--tasks",
+            "build",
+        ])
+        .unwrap();
+        assert_matches!(
+            args.command,
+            Some(Command::Query {
+                subcommand: Some(super::QuerySubcommand::Affected(ref a)),
+                ..
+            }) if a.packages == Some(vec!["web".to_string()])
+                && a.tasks == Some(vec!["build".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_query_affected_combined_bare_packages_and_bare_tasks() {
+        let args =
+            Args::try_parse_from(["turbo", "query", "affected", "--packages", "--tasks"]).unwrap();
+        assert_matches!(
+            args.command,
+            Some(Command::Query {
+                subcommand: Some(super::QuerySubcommand::Affected(ref a)),
+                ..
+            }) if a.packages == Some(vec![]) && a.tasks == Some(vec![])
+        );
+    }
+
+    #[test]
+    fn test_query_raw_graphql_still_works() {
+        let args =
+            Args::try_parse_from(["turbo", "query", "{ packages { items { name } } }"]).unwrap();
+        assert_eq!(
+            args.command,
+            Some(Command::Query {
+                subcommand: None,
+                query: Some("{ packages { items { name } } }".to_string()),
+                variables: None,
+                schema: false,
+            })
+        );
+    }
+
+    #[test]
+    fn test_query_schema_still_works() {
+        let args = Args::try_parse_from(["turbo", "query", "--schema"]).unwrap();
+        assert_eq!(
+            args.command,
+            Some(Command::Query {
+                subcommand: None,
+                query: None,
+                variables: None,
+                schema: true,
+            })
+        );
     }
 }

--- a/crates/turborepo-lib/src/commands/query.rs
+++ b/crates/turborepo-lib/src/commands/query.rs
@@ -1,4 +1,4 @@
-use std::{fs, sync::Arc};
+use std::{fmt::Write, fs, sync::Arc};
 
 use camino::Utf8Path;
 use miette::{Diagnostic, Report, SourceSpan};
@@ -8,7 +8,11 @@ use turborepo_query_api::{QueryRun, QueryServer};
 use turborepo_signals::{listeners::get_signal, SignalHandler};
 use turborepo_telemetry::events::command::CommandEventBuilder;
 
-use crate::{cli, commands::CommandBase, run::builder::RunBuilder};
+use crate::{
+    cli::{self, AffectedArgs, QuerySubcommand},
+    commands::CommandBase,
+    run::builder::RunBuilder,
+};
 
 #[derive(Debug, Diagnostic, Error)]
 #[error("{message}")]
@@ -45,9 +49,133 @@ impl QueryError {
     }
 }
 
+async fn execute_query_and_print(
+    run: Arc<dyn QueryRun>,
+    query_server: &dyn QueryServer,
+    query: &str,
+    variables_json: Option<&str>,
+) -> Result<i32, cli::Error> {
+    let result = query_server
+        .execute_query(run, query, variables_json)
+        .await?;
+
+    println!("{}", result.result_json);
+    if !result.errors.is_empty() {
+        for error in result.errors {
+            let error = QueryError::from_query_error(error, query.to_string());
+            eprintln!("{:?}", Report::new(error));
+        }
+        return Ok(1);
+    }
+    Ok(0)
+}
+
+fn escape_graphql_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\u{0008}' => out.push_str("\\b"),
+            '\u{000C}' => out.push_str("\\f"),
+            c if c.is_control() => {
+                write!(out, "\\u{:04X}", c as u32).unwrap();
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+impl AffectedArgs {
+    fn to_graphql_query(&self) -> String {
+        // --packages alone → affectedPackages
+        // Everything else (default, --tasks, --tasks + --packages) → affectedTasks
+        if self.packages.is_some() && self.tasks.is_none() {
+            self.build_affected_packages_query()
+        } else {
+            self.build_affected_tasks_query()
+        }
+    }
+
+    fn build_affected_packages_query(&self) -> String {
+        let mut query = String::from("{ affectedPackages");
+        let mut args = self.build_ref_args();
+        self.push_package_filter(&mut args);
+        if !args.is_empty() {
+            let joined = args.join(", ");
+            write!(query, "({joined})").unwrap();
+        }
+        query.push_str(" { items { name path reason { __typename } } length } }");
+        query
+    }
+
+    fn build_affected_tasks_query(&self) -> String {
+        let mut query = String::from("{ affectedTasks");
+        let mut args = self.build_ref_args();
+        let tasks = self.tasks.as_deref().unwrap_or_default();
+        if !tasks.is_empty() {
+            let task_values: Vec<String> = tasks
+                .iter()
+                .map(|t| format!("\"{}\"", escape_graphql_string(t)))
+                .collect();
+            args.push(format!("tasks: [{}]", task_values.join(", ")));
+        }
+        self.push_package_filter(&mut args);
+        if !args.is_empty() {
+            let joined = args.join(", ");
+            write!(query, "({joined})").unwrap();
+        }
+        query.push_str(
+            " { items { name fullName package { name } reason { __typename } } length } }",
+        );
+        query
+    }
+
+    fn build_ref_args(&self) -> Vec<String> {
+        let mut args = Vec::new();
+        if let Some(ref base) = self.base {
+            args.push(format!("base: \"{}\"", escape_graphql_string(base)));
+        }
+        if let Some(ref head) = self.head {
+            args.push(format!("head: \"{}\"", escape_graphql_string(head)));
+        }
+        args
+    }
+
+    fn push_package_filter(&self, args: &mut Vec<String>) {
+        let packages = self.packages.as_deref().unwrap_or_default();
+        if packages.is_empty() {
+            return;
+        }
+        let filter = if packages.len() == 1 {
+            format!(
+                "{{ equal: {{ field: NAME, value: \"{}\" }} }}",
+                escape_graphql_string(&packages[0])
+            )
+        } else {
+            let predicates: Vec<String> = packages
+                .iter()
+                .map(|p| {
+                    format!(
+                        "{{ equal: {{ field: NAME, value: \"{}\" }} }}",
+                        escape_graphql_string(p)
+                    )
+                })
+                .collect();
+            format!("{{ or: [{}] }}", predicates.join(", "))
+        };
+        args.push(format!("filter: {filter}"));
+    }
+}
+
 pub async fn run(
     base: CommandBase,
     telemetry: CommandEventBuilder,
+    subcommand: Option<QuerySubcommand>,
     query: Option<String>,
     variables_path: Option<&Utf8Path>,
     include_schema: bool,
@@ -61,6 +189,13 @@ pub async fn run(
         .do_not_validate_engine();
     let (run, _analytics) = run_builder.build(&handler, telemetry).await?;
     let run: Arc<dyn QueryRun> = Arc::new(run);
+
+    if let Some(subcommand) = subcommand {
+        let query = match &subcommand {
+            QuerySubcommand::Affected(args) => args.to_graphql_query(),
+        };
+        return execute_query_and_print(run, query_server, &query, None).await;
+    }
 
     let query = query
         .as_deref()
@@ -86,20 +221,238 @@ pub async fn run(
             .transpose()
             .map_err(turborepo_query_api::Error::Server)?;
 
-        let result = query_server
-            .execute_query(run, query, variables_json.as_deref())
-            .await?;
-
-        println!("{}", result.result_json);
-        if !result.errors.is_empty() {
-            for error in result.errors {
-                let error = QueryError::from_query_error(error, query.to_string());
-                eprintln!("{:?}", Report::new(error));
-            }
-        }
+        execute_query_and_print(run, query_server, query, variables_json.as_deref()).await
     } else {
         query_server.run_query_server(run, handler).await?;
+        Ok(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::escape_graphql_string;
+    use crate::cli::AffectedArgs;
+
+    fn affected(
+        packages: Option<Vec<&str>>,
+        tasks: Option<Vec<&str>>,
+        base: Option<&str>,
+        head: Option<&str>,
+    ) -> AffectedArgs {
+        AffectedArgs {
+            packages: packages.map(|v| v.into_iter().map(String::from).collect()),
+            tasks: tasks.map(|v| v.into_iter().map(String::from).collect()),
+            base: base.map(String::from),
+            head: head.map(String::from),
+        }
     }
 
-    Ok(0)
+    // -- escape tests --
+
+    #[test]
+    fn escape_noop_for_plain_strings() {
+        assert_eq!(escape_graphql_string("main"), "main");
+        assert_eq!(escape_graphql_string("my-app"), "my-app");
+    }
+
+    #[test]
+    fn escape_double_quotes() {
+        assert_eq!(escape_graphql_string(r#"a"b"#), r#"a\"b"#);
+    }
+
+    #[test]
+    fn escape_backslashes() {
+        assert_eq!(escape_graphql_string(r"a\b"), r"a\\b");
+    }
+
+    #[test]
+    fn escape_combined() {
+        assert_eq!(escape_graphql_string(r#"a\"b"#), r#"a\\\"b"#);
+    }
+
+    #[test]
+    fn escape_newline() {
+        assert_eq!(escape_graphql_string("a\nb"), "a\\nb");
+    }
+
+    #[test]
+    fn escape_carriage_return() {
+        assert_eq!(escape_graphql_string("a\rb"), "a\\rb");
+    }
+
+    #[test]
+    fn escape_tab() {
+        assert_eq!(escape_graphql_string("a\tb"), "a\\tb");
+    }
+
+    #[test]
+    fn escape_null_byte() {
+        assert_eq!(escape_graphql_string("a\x00b"), "a\\u0000b");
+    }
+
+    #[test]
+    fn escape_unicode_passthrough() {
+        assert_eq!(escape_graphql_string("日本語"), "日本語");
+    }
+
+    #[test]
+    fn escape_empty() {
+        assert_eq!(escape_graphql_string(""), "");
+    }
+
+    // -- default behavior: affected tasks --
+
+    #[test]
+    fn no_flags_defaults_to_affected_tasks() {
+        let q = affected(None, None, None, None).to_graphql_query();
+        assert_eq!(
+            q,
+            "{ affectedTasks { items { name fullName package { name } reason { __typename } } \
+             length } }"
+        );
+    }
+
+    #[test]
+    fn bare_tasks_flag_returns_all_affected_tasks() {
+        let q = affected(None, Some(vec![]), None, None).to_graphql_query();
+        assert_eq!(
+            q,
+            "{ affectedTasks { items { name fullName package { name } reason { __typename } } \
+             length } }"
+        );
+    }
+
+    #[test]
+    fn tasks_with_values_filters() {
+        let q = affected(None, Some(vec!["build"]), None, None).to_graphql_query();
+        assert!(q.starts_with("{ affectedTasks"), "{q}");
+        assert!(q.contains(r#"tasks: ["build"]"#), "{q}");
+    }
+
+    #[test]
+    fn multiple_tasks_all_appear() {
+        let q = affected(None, Some(vec!["build", "test"]), None, None).to_graphql_query();
+        assert!(q.contains(r#"tasks: ["build", "test"]"#), "{q}");
+    }
+
+    // -- --packages routes to affected packages --
+
+    #[test]
+    fn bare_packages_flag_returns_all_affected_packages() {
+        let q = affected(Some(vec![]), None, None, None).to_graphql_query();
+        assert_eq!(
+            q,
+            "{ affectedPackages { items { name path reason { __typename } } length } }"
+        );
+    }
+
+    #[test]
+    fn single_package_uses_equal_filter() {
+        let q = affected(Some(vec!["web"]), None, None, None).to_graphql_query();
+        assert!(q.starts_with("{ affectedPackages"), "{q}");
+        assert!(q.contains(r#"equal: { field: NAME, value: "web" }"#), "{q}");
+        assert!(!q.contains("or:"), "single package should not use or: {q}");
+    }
+
+    #[test]
+    fn multiple_packages_use_or_filter() {
+        let q = affected(Some(vec!["web", "docs"]), None, None, None).to_graphql_query();
+        assert!(q.contains("or: ["), "{q}");
+        assert!(q.contains(r#"value: "web""#), "{q}");
+        assert!(q.contains(r#"value: "docs""#), "{q}");
+    }
+
+    // -- ref args --
+
+    #[test]
+    fn base_and_head_appear_in_tasks_query() {
+        let q = affected(None, None, Some("main"), Some("HEAD")).to_graphql_query();
+        assert!(q.starts_with("{ affectedTasks"), "{q}");
+        assert!(q.contains(r#"base: "main""#), "{q}");
+        assert!(q.contains(r#"head: "HEAD""#), "{q}");
+    }
+
+    #[test]
+    fn base_and_head_appear_in_packages_query() {
+        let q = affected(Some(vec![]), None, Some("main"), Some("HEAD")).to_graphql_query();
+        assert!(q.starts_with("{ affectedPackages"), "{q}");
+        assert!(q.contains(r#"base: "main""#), "{q}");
+        assert!(q.contains(r#"head: "HEAD""#), "{q}");
+    }
+
+    // -- escaping in context --
+
+    #[test]
+    fn base_with_quotes_is_escaped() {
+        let q = affected(None, None, Some(r#"feat/"branch"#), None).to_graphql_query();
+        assert!(
+            q.contains(r#"base: "feat/\"branch""#),
+            "quotes should be escaped: {q}"
+        );
+    }
+
+    #[test]
+    fn package_with_quotes_is_escaped() {
+        let q = affected(Some(vec![r#"@scope/"pkg""#]), None, None, None).to_graphql_query();
+        assert!(
+            q.contains(r#"value: "@scope/\"pkg\""#),
+            "package quotes should be escaped: {q}"
+        );
+    }
+
+    #[test]
+    fn task_with_quotes_is_escaped() {
+        let q = affected(None, Some(vec![r#"build"inject"#]), None, None).to_graphql_query();
+        assert!(
+            q.contains(r#""build\"inject""#),
+            "task quotes should be escaped: {q}"
+        );
+    }
+
+    #[test]
+    fn head_with_backslash_is_escaped() {
+        let q = affected(None, None, None, Some(r"ref\path")).to_graphql_query();
+        assert!(
+            q.contains(r#"head: "ref\\path""#),
+            "backslash should be escaped: {q}"
+        );
+    }
+
+    // -- combined --packages + --tasks → affectedTasks with both filters
+    // (intersection) --
+
+    #[test]
+    fn combined_packages_and_tasks_routes_to_affected_tasks() {
+        let q = affected(Some(vec!["web"]), Some(vec!["build"]), None, None).to_graphql_query();
+        assert!(q.starts_with("{ affectedTasks"), "{q}");
+        assert!(q.contains(r#"tasks: ["build"]"#), "{q}");
+        assert!(
+            q.contains(r#"filter: { equal: { field: NAME, value: "web" } }"#),
+            "{q}"
+        );
+    }
+
+    #[test]
+    fn combined_bare_tasks_with_packages_filters_by_package_only() {
+        // --tasks (bare) + --packages web → affectedTasks with only package filter
+        let q = affected(Some(vec!["web"]), Some(vec![]), None, None).to_graphql_query();
+        assert!(q.starts_with("{ affectedTasks"), "{q}");
+        assert!(
+            !q.contains("tasks:"),
+            "bare --tasks should not add tasks arg: {q}"
+        );
+        assert!(q.contains("filter:"), "{q}");
+    }
+
+    #[test]
+    fn combined_tasks_with_bare_packages_filters_by_task_only() {
+        // --tasks build + --packages (bare) → affectedTasks with only task filter
+        let q = affected(Some(vec![]), Some(vec!["build"]), None, None).to_graphql_query();
+        assert!(q.starts_with("{ affectedTasks"), "{q}");
+        assert!(q.contains(r#"tasks: ["build"]"#), "{q}");
+        assert!(
+            !q.contains("filter:"),
+            "bare --packages should not add filter: {q}"
+        );
+    }
 }

--- a/crates/turborepo-query/src/lib.rs
+++ b/crates/turborepo-query/src/lib.rs
@@ -623,29 +623,36 @@ impl RepositoryQuery {
     /// or if an upstream task dependency is affected.
     ///
     /// Use the `tasks` parameter to filter to specific task names (e.g.
-    /// `["test", "typecheck"]`). When omitted, all affected tasks are returned.
+    /// `["test", "typecheck"]`). Use `filter` to filter by package (same
+    /// predicates as `affectedPackages`). When both are provided, a task
+    /// must match both filters to be included (intersection).
     async fn affected_tasks(
         &self,
         base: Option<String>,
         head: Option<String>,
         #[graphql(desc = "Filter to specific task names (e.g. [\"test\", \"typecheck\"])")]
         tasks: Option<Vec<String>>,
+        filter: Option<PackagePredicate>,
     ) -> Result<Array<ChangedTask>, Error> {
         let results = affected_tasks::calculate_affected_tasks(&self.run, base, head)?;
 
         let mut changed_tasks: Array<ChangedTask> = results
             .into_iter()
-            .filter(|at| {
-                tasks
-                    .as_ref()
-                    .is_none_or(|names| names.iter().any(|n| n == at.task_id.task()))
-            })
             .map(|at| {
                 let task = task::RepositoryTask::new(&at.task_id, &self.run)?;
                 let reason = convert_task_change_reason(at.reason);
                 Ok(ChangedTask { reason, task })
             })
-            .collect::<Result<Array<_>, Error>>()?;
+            .collect::<Result<Vec<_>, Error>>()?
+            .into_iter()
+            .filter(|ct| {
+                let task_ok = tasks.as_ref().is_none_or(|names| {
+                    names.is_empty() || names.iter().any(|n| n.as_str() == ct.task.name)
+                });
+                let package_ok = filter.as_ref().is_none_or(|f| f.check(&ct.task.package));
+                task_ok && package_ok
+            })
+            .collect();
 
         changed_tasks.sort_by(|a, b| {
             a.task

--- a/crates/turborepo/tests/affected_test.rs
+++ b/crates/turborepo/tests/affected_test.rs
@@ -982,3 +982,155 @@ fn test_affected_with_nonexistent_task_errors() {
         insta::assert_snapshot!("affected_nonexistent_task", stderr.to_string());
     });
 }
+
+// -- turbo query affected shorthand tests --
+
+#[test]
+fn test_query_affected_shorthand_no_args() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_affected(tempdir.path());
+
+    fs::write(tempdir.path().join("apps/my-app/new.js"), "foo").unwrap();
+
+    // Default (no flags) returns affected tasks
+    let output = run_turbo(tempdir.path(), &["query", "affected"]);
+    assert!(output.status.success(), "query affected should succeed");
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let items = json["data"]["affectedTasks"]["items"].as_array().unwrap();
+    assert!(!items.is_empty(), "should have affected tasks");
+    let names: Vec<&str> = items
+        .iter()
+        .map(|i| i["fullName"].as_str().unwrap())
+        .collect();
+    assert!(
+        names.iter().any(|n| n.contains("my-app")),
+        "my-app tasks should be affected: {names:?}"
+    );
+}
+
+#[test]
+fn test_query_affected_shorthand_bare_packages() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_affected(tempdir.path());
+
+    fs::write(tempdir.path().join("apps/my-app/new.js"), "foo").unwrap();
+
+    // --packages with no value returns all affected packages
+    let output = run_turbo(tempdir.path(), &["query", "affected", "--packages"]);
+    assert!(
+        output.status.success(),
+        "query affected --packages should succeed"
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let items = json["data"]["affectedPackages"]["items"]
+        .as_array()
+        .unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["name"], "my-app");
+    assert_eq!(items[0]["reason"]["__typename"], "FileChanged");
+    assert!(items[0]["path"].is_string(), "should include path field");
+}
+
+#[test]
+fn test_query_affected_shorthand_with_packages() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_affected(tempdir.path());
+
+    fs::write(tempdir.path().join("packages/util/new.js"), "foo").unwrap();
+
+    // Filter to only "util" — should exclude "my-app" (which is a dependent)
+    let output = run_turbo(tempdir.path(), &["query", "affected", "--packages", "util"]);
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let items = json["data"]["affectedPackages"]["items"]
+        .as_array()
+        .unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["name"], "util");
+}
+
+#[test]
+fn test_query_affected_shorthand_nothing_affected() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_affected(tempdir.path());
+
+    // No file changes — nothing should be affected
+    let output = run_turbo(tempdir.path(), &["query", "affected"]);
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let length = json["data"]["affectedTasks"]["length"].as_i64().unwrap();
+    assert_eq!(length, 0, "nothing should be affected on a clean branch");
+}
+
+#[test]
+fn test_query_affected_shorthand_with_tasks() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_affected(tempdir.path());
+
+    fs::write(tempdir.path().join("apps/my-app/new.js"), "foo").unwrap();
+
+    let output = run_turbo(tempdir.path(), &["query", "affected", "--tasks", "build"]);
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let items = json["data"]["affectedTasks"]["items"].as_array().unwrap();
+    assert!(!items.is_empty(), "build task should be affected");
+    let names: Vec<&str> = items
+        .iter()
+        .map(|i| i["fullName"].as_str().unwrap())
+        .collect();
+    assert!(
+        names.iter().any(|n| n.contains("my-app")),
+        "my-app#build should be in affected tasks: {names:?}"
+    );
+}
+
+#[test]
+fn test_query_affected_shorthand_with_base_head() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_affected(tempdir.path());
+
+    fs::write(tempdir.path().join("apps/my-app/new.js"), "foo").unwrap();
+    git(tempdir.path(), &["add", "."]);
+    git(tempdir.path(), &["commit", "-m", "add file", "--quiet"]);
+
+    // With --base=HEAD, no uncommitted changes → nothing affected
+    let output = run_turbo(tempdir.path(), &["query", "affected", "--base", "HEAD"]);
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let length = json["data"]["affectedTasks"]["length"].as_i64().unwrap();
+    assert_eq!(length, 0, "base=HEAD should show no changes: {}", json);
+}
+
+#[test]
+fn test_query_affected_shorthand_combined_packages_and_tasks() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_affected(tempdir.path());
+
+    fs::write(tempdir.path().join("apps/my-app/new.js"), "foo").unwrap();
+
+    // --tasks build --packages my-app → intersection: tasks named "build" AND in
+    // package "my-app"
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "query",
+            "affected",
+            "--tasks",
+            "build",
+            "--packages",
+            "my-app",
+        ],
+    );
+    assert!(output.status.success(), "combined query should succeed");
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let items = json["data"]["affectedTasks"]["items"].as_array().unwrap();
+    assert!(!items.is_empty(), "should have affected tasks: {json}");
+    let full_names: Vec<&str> = items
+        .iter()
+        .map(|i| i["fullName"].as_str().unwrap())
+        .collect();
+    assert!(
+        full_names.contains(&"my-app#build"),
+        "my-app#build should be in results: {full_names:?}"
+    );
+}

--- a/crates/turborepo/tests/snapshots/query__basic_monorepo_get_schema_(npm@10.5.0).snap
+++ b/crates/turborepo/tests/snapshots/query__basic_monorepo_get_schema_(npm@10.5.0).snap
@@ -2081,7 +2081,7 @@ expression: query_output
             },
             {
               "name": "affectedTasks",
-              "description": "Gets a list of tasks that are affected by changes between two git refs.\n\nUnlike `affectedPackages` which operates at the package level,\n`affectedTasks` checks each task's specific `inputs` configuration\nagainst the changed files and walks the task dependency graph.\nA task is only reported as affected if its inputs actually changed,\nor if an upstream task dependency is affected.\n\nUse the `tasks` parameter to filter to specific task names (e.g.\n`[\"test\", \"typecheck\"]`). When omitted, all affected tasks are returned.",
+              "description": "Gets a list of tasks that are affected by changes between two git refs.\n\nUnlike `affectedPackages` which operates at the package level,\n`affectedTasks` checks each task's specific `inputs` configuration\nagainst the changed files and walks the task dependency graph.\nA task is only reported as affected if its inputs actually changed,\nor if an upstream task dependency is affected.\n\nUse the `tasks` parameter to filter to specific task names (e.g.\n`[\"test\", \"typecheck\"]`). Use `filter` to filter by package (same\npredicates as `affectedPackages`). When both are provided, a task\nmust match both filters to be included (intersection).",
               "args": [
                 {
                   "name": "base",
@@ -2118,6 +2118,16 @@ expression: query_output
                         "ofType": null
                       }
                     }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filter",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "PackagePredicate",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }


### PR DESCRIPTION
## Summary

Adds `turbo query affected` as a CLI subcommand that generates and executes GraphQL queries for change detection, replacing the need to write raw GraphQL for common affected-packages/tasks checks.

This is the first PR toward deprecating `turbo-ignore` — it lands the `turbo query` feature that will serve as its replacement. The actual deprecation warning and migration guide will follow in a separate PR.

## What it does

- `turbo query affected` — returns all affected tasks (default)
- `turbo query affected --tasks build` — affected tasks filtered by name
- `turbo query affected --packages` — switches to affected packages
- `turbo query affected --packages web` — affected packages filtered by name
- `turbo query affected --tasks build --packages web` — intersection of both filters ("did web#build change?")
- `--base` / `--head` — control git ref comparison range

## Key implementation details

- The subcommand generates a GraphQL query string and runs it through the existing query infrastructure — no new execution paths
- `escape_graphql_string` handles the full GraphQL spec (control chars, unicode)
- `execute_query_and_print` returns exit code 1 on GraphQL errors so CI scripts can rely on it
- The `affectedTasks` GraphQL resolver now accepts an optional `filter: PackagePredicate` param (same type as `affectedPackages`). When combined with `tasks`, both filters must match (intersection)

## Testing

- 26 unit tests for query generation, escaping, and routing
- 11 CLI parsing tests for all flag combinations
- 7 integration tests covering default behavior, `--packages`, `--tasks`, `--base`/`--head`, combined filters, and the nothing-affected case

<sub>CLOSES TURBO-5350</sub>