### PR TITLE
chore: Add `turborepo-log` crate to improve our logging situation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7772,6 +7772,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "turborepo-log"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "turborepo-lsp"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ turborepo-hash = { path = "crates/turborepo-hash" }
 turborepo-json-rewrite = { path = "crates/turborepo-json-rewrite" }
 turborepo-lib = { path = "crates/turborepo-lib", default-features = false }
 turborepo-lockfiles = { path = "crates/turborepo-lockfiles" }
+turborepo-log = { path = "crates/turborepo-log" }
 turborepo-microfrontends = { path = "crates/turborepo-microfrontends" }
 turborepo-microfrontends-proxy = { path = "crates/turborepo-microfrontends-proxy" }
 turborepo-process = { path = "crates/turborepo-process" }

--- a/crates/turborepo-log/Cargo.toml
+++ b/crates/turborepo-log/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "turborepo-log"
+version = "0.1.0"
+edition = { workspace = true }
+license = "MIT"
+description = "User-facing logging interface for Turborepo"
+
+[lints]
+workspace = true
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }

--- a/crates/turborepo-log/src/event.rs
+++ b/crates/turborepo-log/src/event.rs
@@ -1,0 +1,1062 @@
+use std::{borrow::Cow, fmt, sync::Arc, time::SystemTime};
+
+use serde::{Serialize, Serializer, ser::SerializeMap};
+
+/// Strip control characters and ANSI escape sequences from a string.
+///
+/// ANSI escape sequences are consumed as complete units so that
+/// orphaned parameter bytes never appear in output. Handled:
+///
+/// - **CSI** (`ESC [` and C1 `U+009B`): parameter + final byte consumed
+/// - **OSC** (`ESC ]`): text consumed until BEL or ST
+/// - **Fe/Fp/Fs** (`ESC` + `0x30..=0x7E`): two-byte sequences
+///
+/// When `preserve_newlines` is true, `\n` is kept. When false, all
+/// control characters (ASCII C0, DEL, and Unicode C1) are removed.
+///
+/// Returns `Cow::Borrowed` when no changes are needed.
+fn strip_control_chars(input: &str, preserve_newlines: bool) -> Cow<'_, str> {
+    let needs_work = input
+        .chars()
+        .any(|c| c.is_control() && (!preserve_newlines || c != '\n'));
+
+    if !needs_work {
+        return Cow::Borrowed(input);
+    }
+
+    let mut result = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            // ESC — consume the full ANSI escape sequence.
+            match chars.peek().copied() {
+                Some('[') => {
+                    // CSI: ESC [ <params> <final byte 0x40..=0x7E per ECMA-48>
+                    chars.next();
+                    for c in chars.by_ref() {
+                        if ('@'..='~').contains(&c) {
+                            break;
+                        }
+                    }
+                }
+                Some(']') => {
+                    // OSC: ESC ] <text> <BEL | ST>
+                    chars.next();
+                    while let Some(c) = chars.next() {
+                        if c == '\x07' {
+                            break;
+                        }
+                        if c == '\x1b' && chars.peek().copied() == Some('\\') {
+                            chars.next();
+                            break;
+                        }
+                    }
+                }
+                // Fe (0x40-0x5F), Fp (0x30-0x3F), Fs (0x60-0x7E):
+                // two-character escape sequences. CSI '[' and OSC ']'
+                // are already matched above.
+                Some(c2) if ('0'..='~').contains(&c2) => {
+                    chars.next();
+                }
+                _ => {} // Standalone ESC
+            }
+            continue;
+        }
+
+        // C1 CSI (U+009B): single-byte equivalent of ESC [.
+        // Strip the introducer and consume parameter/final bytes
+        // the same way as the ESC [ branch above.
+        if c == '\u{009b}' {
+            for c in chars.by_ref() {
+                if ('@'..='~').contains(&c) {
+                    break;
+                }
+            }
+            continue;
+        }
+
+        // Strip ASCII C0, DEL, and Unicode C1 control characters.
+        if c.is_control() {
+            if preserve_newlines && c == '\n' {
+                result.push(c);
+            }
+            continue;
+        }
+
+        result.push(c);
+    }
+
+    Cow::Owned(result)
+}
+
+/// Sanitize a user-provided message string.
+///
+/// Strips control characters and ANSI escape sequences while
+/// preserving newlines (multi-line messages are common).
+fn sanitize_message(input: String) -> String {
+    match strip_control_chars(&input, true) {
+        Cow::Borrowed(_) => input,
+        Cow::Owned(sanitized) => sanitized,
+    }
+}
+
+/// Severity level for user-facing log events.
+///
+/// Ordered by severity: `Info < Warn < Error`. This matches the standard
+/// convention where `Error` is the most severe.
+///
+/// There is intentionally no `Debug` level. Debug-level output is
+/// developer-facing and should use the `tracing` crate instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[non_exhaustive]
+#[serde(rename_all = "UPPERCASE")]
+pub enum Level {
+    /// Informational messages.
+    Info,
+    /// Warnings that don't prevent progress.
+    Warn,
+    /// Errors that affect correctness or indicate failure.
+    Error,
+}
+
+impl fmt::Display for Level {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Level::Error => write!(f, "ERROR"),
+            Level::Warn => write!(f, "WARN"),
+            Level::Info => write!(f, "INFO"),
+        }
+    }
+}
+
+/// Origin of a log event.
+///
+/// # Relationship to `turborepo-task-id`
+///
+/// [`Source::Task`] deliberately uses `Arc<str>` rather than depending on
+/// `turborepo_task_id::TaskId` to keep this crate's dependency footprint
+/// minimal (it sits at the bottom of the dependency graph). Callers with
+/// a `TaskId` should pass `task_id.to_string()` to [`Source::task()`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Source {
+    /// Turborepo infrastructure (config, cache, scm, etc.).
+    ///
+    /// The string identifies the subsystem. Uses `&'static str` so that
+    /// only compile-time constants are accepted — no runtime sanitization
+    /// is needed for static strings.
+    ///
+    /// Convention: lowercase, e.g., `"config"`, `"cache"`, `"scm"`.
+    Turbo(&'static str),
+    /// A specific task, identified by its display string (e.g., `"web#build"`).
+    /// Uses `Arc<str>` so cloning a `LogHandle` for a task is cheap.
+    Task(Arc<str>),
+}
+
+// Manual Serialize impl to avoid requiring serde's "rc" feature for Arc<str>.
+impl Serialize for Source {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Source::Turbo(subsystem) => {
+                serializer.serialize_newtype_variant("Source", 0, "Turbo", subsystem)
+            }
+            Source::Task(id) => serializer.serialize_newtype_variant("Source", 1, "Task", &**id),
+        }
+    }
+}
+
+impl Source {
+    /// Create a source identifying a Turborepo subsystem.
+    ///
+    /// Convention: lowercase, e.g., `"config"`, `"cache"`, `"scm"`.
+    pub fn turbo(subsystem: &'static str) -> Self {
+        Source::Turbo(subsystem)
+    }
+
+    /// Create a source identifying a specific task.
+    ///
+    /// Accepts any string-like type. Task IDs typically follow the
+    /// `package#task` format (e.g., `"web#build"`).
+    ///
+    /// All control characters — including newlines — are stripped to
+    /// prevent terminal injection and ensure task IDs remain single-line.
+    /// Full ANSI escape sequences are consumed as units.
+    pub fn task(id: impl AsRef<str>) -> Self {
+        let cleaned = strip_control_chars(id.as_ref(), false);
+        Source::Task(Arc::from(cleaned.as_ref()))
+    }
+}
+
+impl fmt::Display for Source {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Source::Turbo(subsystem) => write!(f, "turbo:{subsystem}"),
+            Source::Task(id) => write!(f, "task:{id}"),
+        }
+    }
+}
+
+/// A string guaranteed to be free of control characters and ANSI escape
+/// sequences.
+///
+/// Construct via the [`From`] impls (which sanitize) or
+/// [`SanitizedString::from_trusted`] for strings that are already
+/// known-clean (e.g., numeric conversions).
+///
+/// Terminal-rendering sinks can trust `SanitizedString` content without
+/// re-sanitizing.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct SanitizedString(String);
+
+impl SanitizedString {
+    /// Create from a string that is already known to be clean.
+    ///
+    /// No sanitization is performed. Use this only for strings that
+    /// are guaranteed to contain no control characters or ANSI escape
+    /// sequences (e.g., numeric conversions, compile-time constants).
+    pub fn from_trusted(s: String) -> Self {
+        Self(s)
+    }
+
+    /// The inner string value.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consume and return the inner string.
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Display for SanitizedString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl PartialEq<str> for SanitizedString {
+    fn eq(&self, other: &str) -> bool {
+        self.0 == *other
+    }
+}
+
+/// Sanitize: control characters and ANSI escape sequences are stripped.
+/// Newlines are also removed (field values should be single-line).
+impl From<&str> for SanitizedString {
+    fn from(s: &str) -> Self {
+        match strip_control_chars(s, false) {
+            Cow::Borrowed(clean) => Self(clean.to_owned()),
+            Cow::Owned(sanitized) => Self(sanitized),
+        }
+    }
+}
+
+/// Sanitize: control characters and ANSI escape sequences are stripped.
+/// Newlines are also removed (field values should be single-line).
+impl From<String> for SanitizedString {
+    fn from(s: String) -> Self {
+        match strip_control_chars(&s, false) {
+            Cow::Borrowed(_) => Self(s),
+            Cow::Owned(sanitized) => Self(sanitized),
+        }
+    }
+}
+
+/// A non-recursive structured field value.
+///
+/// Used inside [`Value::List`] to enforce flat lists at the type level.
+/// All scalar variants of [`Value`] have a corresponding `Scalar` variant.
+///
+/// `Scalar` implements `PartialEq` but not `Eq` because `Float(f64)`
+/// does not satisfy IEEE 754 reflexivity (`NaN != NaN`).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[non_exhaustive]
+#[serde(untagged)]
+pub enum Scalar {
+    /// A sanitized UTF-8 string.
+    String(SanitizedString),
+    /// A signed 64-bit integer.
+    Int(i64),
+    /// A boolean.
+    Bool(bool),
+    /// A 64-bit float.
+    Float(f64),
+    /// A redacted value (serializes as JSON `null`).
+    #[serde(serialize_with = "serialize_redacted")]
+    Redacted,
+}
+
+impl fmt::Display for Scalar {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Scalar::String(s) => write!(f, "{s}"),
+            Scalar::Int(n) => write!(f, "{n}"),
+            Scalar::Bool(b) => write!(f, "{b}"),
+            Scalar::Float(n) => write!(f, "{n}"),
+            Scalar::Redacted => write!(f, "[REDACTED]"),
+        }
+    }
+}
+
+impl From<&str> for Scalar {
+    fn from(s: &str) -> Self {
+        Scalar::String(SanitizedString::from(s))
+    }
+}
+
+impl From<String> for Scalar {
+    fn from(s: String) -> Self {
+        Scalar::String(SanitizedString::from(s))
+    }
+}
+
+impl From<i64> for Scalar {
+    fn from(n: i64) -> Self {
+        Scalar::Int(n)
+    }
+}
+
+/// Values above `i64::MAX` are stored as `Scalar::String` to avoid
+/// silent truncation.
+impl From<u64> for Scalar {
+    fn from(n: u64) -> Self {
+        match i64::try_from(n) {
+            Ok(signed) => Scalar::Int(signed),
+            Err(_) => Scalar::String(SanitizedString::from_trusted(n.to_string())),
+        }
+    }
+}
+
+/// Values above `i64::MAX` are stored as `Scalar::String` to avoid
+/// silent truncation.
+impl From<usize> for Scalar {
+    fn from(n: usize) -> Self {
+        match i64::try_from(n) {
+            Ok(signed) => Scalar::Int(signed),
+            Err(_) => Scalar::String(SanitizedString::from_trusted(n.to_string())),
+        }
+    }
+}
+
+impl From<i32> for Scalar {
+    fn from(n: i32) -> Self {
+        Scalar::Int(n as i64)
+    }
+}
+
+impl From<u32> for Scalar {
+    fn from(n: u32) -> Self {
+        Scalar::Int(n as i64)
+    }
+}
+
+impl From<bool> for Scalar {
+    fn from(b: bool) -> Self {
+        Scalar::Bool(b)
+    }
+}
+
+impl From<f64> for Scalar {
+    fn from(n: f64) -> Self {
+        Scalar::Float(n)
+    }
+}
+
+/// A structured field value for log event metadata.
+///
+/// This is a restricted set of types suitable for structured logging fields.
+///
+/// # Sanitization
+///
+/// String values use [`SanitizedString`], which strips control characters
+/// and ANSI escape sequences. The [`From`] impls construct sanitized
+/// strings automatically. The sanitization invariant is enforced at the
+/// type level — terminal-rendering sinks can trust string content
+/// without re-sanitizing.
+///
+/// # `PartialEq` without `Eq`
+///
+/// `Value` implements `PartialEq` but not `Eq` because `Float(f64)`
+/// does not satisfy IEEE 754 reflexivity (`NaN != NaN`). This means
+/// `Value` cannot be used as a `HashMap` key or in contexts requiring
+/// `Eq`. If this is needed, encode floats as `Value::String`.
+///
+/// # Flat lists
+///
+/// `Value::List` holds [`Vec<Scalar>`] rather than `Vec<Value>`,
+/// enforcing flat lists at the type level. This prevents stack overflow
+/// during serialization from recursive nesting.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[non_exhaustive]
+#[serde(untagged)]
+pub enum Value {
+    /// A sanitized UTF-8 string.
+    String(SanitizedString),
+    /// A signed 64-bit integer.
+    Int(i64),
+    /// A boolean.
+    Bool(bool),
+    /// A 64-bit float.
+    Float(f64),
+    /// A flat list of scalar values. Holds [`Scalar`] rather than
+    /// `Value` to prevent recursive nesting.
+    List(Vec<Scalar>),
+    /// A redacted value. Serializes as JSON `null` (not the string
+    /// `"[REDACTED]"`) so that log consumers can distinguish redacted
+    /// fields from fields that literally contain that text.
+    ///
+    /// The `Display` impl still renders as `[REDACTED]` for
+    /// human-readable output.
+    #[serde(serialize_with = "serialize_redacted")]
+    Redacted,
+}
+
+fn serialize_redacted<S: Serializer>(s: S) -> Result<S::Ok, S::Error> {
+    s.serialize_none()
+}
+
+impl fmt::Display for Value {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Value::String(s) => write!(f, "{s}"),
+            Value::Int(n) => write!(f, "{n}"),
+            Value::Bool(b) => write!(f, "{b}"),
+            Value::Float(n) => write!(f, "{n}"),
+            Value::List(items) => {
+                for (i, v) in items.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{v}")?;
+                }
+                Ok(())
+            }
+            Value::Redacted => write!(f, "[REDACTED]"),
+        }
+    }
+}
+
+impl From<&str> for Value {
+    fn from(s: &str) -> Self {
+        Value::String(SanitizedString::from(s))
+    }
+}
+
+impl From<String> for Value {
+    fn from(s: String) -> Self {
+        Value::String(SanitizedString::from(s))
+    }
+}
+
+impl From<i64> for Value {
+    fn from(n: i64) -> Self {
+        Value::Int(n)
+    }
+}
+
+/// Values above `i64::MAX` are stored as `Value::String` to avoid
+/// silent truncation.
+impl From<u64> for Value {
+    fn from(n: u64) -> Self {
+        match i64::try_from(n) {
+            Ok(signed) => Value::Int(signed),
+            Err(_) => Value::String(SanitizedString::from_trusted(n.to_string())),
+        }
+    }
+}
+
+/// Values above `i64::MAX` are stored as `Value::String` to avoid
+/// silent truncation.
+impl From<usize> for Value {
+    fn from(n: usize) -> Self {
+        match i64::try_from(n) {
+            Ok(signed) => Value::Int(signed),
+            Err(_) => Value::String(SanitizedString::from_trusted(n.to_string())),
+        }
+    }
+}
+
+impl From<i32> for Value {
+    fn from(n: i32) -> Self {
+        Value::Int(n as i64)
+    }
+}
+
+impl From<u32> for Value {
+    fn from(n: u32) -> Self {
+        Value::Int(n as i64)
+    }
+}
+
+impl From<bool> for Value {
+    fn from(b: bool) -> Self {
+        Value::Bool(b)
+    }
+}
+
+impl From<f64> for Value {
+    fn from(n: f64) -> Self {
+        Value::Float(n)
+    }
+}
+
+impl From<Scalar> for Value {
+    fn from(s: Scalar) -> Self {
+        match s {
+            Scalar::String(s) => Value::String(s),
+            Scalar::Int(n) => Value::Int(n),
+            Scalar::Bool(b) => Value::Bool(b),
+            Scalar::Float(n) => Value::Float(n),
+            Scalar::Redacted => Value::Redacted,
+        }
+    }
+}
+
+impl<T: Into<Scalar>> From<Vec<T>> for Value {
+    fn from(items: Vec<T>) -> Self {
+        Value::List(items.into_iter().map(Into::into).collect())
+    }
+}
+
+/// Serialize fields as a JSON object rather than an array of tuples.
+///
+/// Duplicate keys are preserved in insertion order. Most JSON parsers
+/// use the last occurrence when duplicates are present, but behavior
+/// is parser-dependent per RFC 8259 §4.
+fn serialize_fields<S: Serializer>(
+    fields: &[(&'static str, Value)],
+    s: S,
+) -> Result<S::Ok, S::Error> {
+    let mut map = s.serialize_map(Some(fields.len()))?;
+    for (k, v) in fields {
+        map.serialize_entry(k, v)?;
+    }
+    map.end()
+}
+
+/// Serialize `SystemTime` as milliseconds since the Unix epoch.
+///
+/// Produces a single integer (e.g., `1710345600000`) rather than
+/// serde's default `{"secs_since_epoch": N, "nanos_since_epoch": N}`
+/// struct. This format is understood by virtually all log tooling.
+fn serialize_timestamp<S: Serializer>(ts: &SystemTime, s: S) -> Result<S::Ok, S::Error> {
+    let millis = ts
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    s.serialize_u64(u64::try_from(millis).unwrap_or(u64::MAX))
+}
+
+/// A structured log event for user-facing output.
+///
+/// Created via [`LogHandle`](crate::LogHandle) methods or the free functions
+/// [`warn`](crate::warn), [`info`](crate::info), [`error`](crate::error).
+/// Sink implementations receive these and decide how to render them.
+///
+/// # Field access
+///
+/// Sink implementations access event data via the public accessor
+/// methods ([`level()`](Self::level), [`message()`](Self::message),
+/// etc.). Fields are `pub(crate)` to enforce construction through
+/// [`LogEvent::new`] or the builder API, which sanitize the message.
+#[derive(Debug, Clone, Serialize)]
+pub struct LogEvent {
+    pub(crate) level: Level,
+    pub(crate) source: Source,
+    pub(crate) message: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(serialize_with = "serialize_fields")]
+    pub(crate) fields: Vec<(&'static str, Value)>,
+    #[serde(serialize_with = "serialize_timestamp")]
+    pub(crate) timestamp: SystemTime,
+}
+
+impl LogEvent {
+    /// Create a new event with the current timestamp and no fields.
+    ///
+    /// The message is sanitized: control characters (except newline) and
+    /// ANSI escape sequences are stripped.
+    pub fn new(level: Level, source: Source, message: impl Into<String>) -> Self {
+        Self {
+            level,
+            source,
+            message: sanitize_message(message.into()),
+            fields: Vec::new(),
+            timestamp: SystemTime::now(),
+        }
+    }
+
+    /// Create a new event with an explicit timestamp.
+    ///
+    /// Useful in tests where deterministic timestamps are needed.
+    pub fn with_timestamp(
+        level: Level,
+        source: Source,
+        message: impl Into<String>,
+        timestamp: SystemTime,
+    ) -> Self {
+        Self {
+            level,
+            source,
+            message: sanitize_message(message.into()),
+            fields: Vec::new(),
+            timestamp,
+        }
+    }
+
+    /// Severity of this event.
+    pub fn level(&self) -> Level {
+        self.level
+    }
+
+    /// Origin — which subsystem or task produced this.
+    pub fn source(&self) -> &Source {
+        &self.source
+    }
+
+    /// Human-readable message text. Sanitized on construction: control
+    /// characters (except newline) and ANSI escape sequences are stripped.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    /// Structured key-value metadata. Keys are `&'static str`, values are
+    /// [`Value`]. Insertion order is preserved. Serializes as a JSON object.
+    pub fn fields(&self) -> &[(&'static str, Value)] {
+        &self.fields
+    }
+
+    /// When this event was created. Serializes as milliseconds since the
+    /// Unix epoch.
+    pub fn timestamp(&self) -> SystemTime {
+        self.timestamp
+    }
+
+    /// Append a structured field.
+    pub(crate) fn push_field(&mut self, key: &'static str, value: Value) {
+        self.fields.push((key, value));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn level_ordering_matches_severity() {
+        assert!(Level::Error > Level::Warn);
+        assert!(Level::Warn > Level::Info);
+        assert!(Level::Error > Level::Info);
+    }
+
+    #[test]
+    fn level_display() {
+        assert_eq!(Level::Error.to_string(), "ERROR");
+        assert_eq!(Level::Warn.to_string(), "WARN");
+        assert_eq!(Level::Info.to_string(), "INFO");
+    }
+
+    #[test]
+    fn level_serializes_uppercase() {
+        assert_eq!(serde_json::to_string(&Level::Info).unwrap(), "\"INFO\"");
+        assert_eq!(serde_json::to_string(&Level::Warn).unwrap(), "\"WARN\"");
+        assert_eq!(serde_json::to_string(&Level::Error).unwrap(), "\"ERROR\"");
+    }
+
+    #[test]
+    fn source_display() {
+        assert_eq!(Source::turbo("config").to_string(), "turbo:config");
+        assert_eq!(Source::task("web#build").to_string(), "task:web#build");
+    }
+
+    #[test]
+    fn source_task_strips_full_ansi_escape_sequences() {
+        let source = Source::task("evil\x1b[31mtask\r\n");
+        match &source {
+            Source::Task(id) => assert_eq!(id.as_ref(), "eviltask"),
+            _ => panic!("expected Task variant"),
+        }
+    }
+
+    #[test]
+    fn source_task_strips_osc_sequences() {
+        let source = Source::task("before\x1b]0;title\x07after");
+        match &source {
+            Source::Task(id) => assert_eq!(id.as_ref(), "beforeafter"),
+            _ => panic!("expected Task variant"),
+        }
+    }
+
+    #[test]
+    fn source_task_strips_newlines() {
+        let source = Source::task("line1\nline2");
+        match &source {
+            Source::Task(id) => assert_eq!(id.as_ref(), "line1line2"),
+            _ => panic!("expected Task variant"),
+        }
+    }
+
+    #[test]
+    fn source_task_preserves_clean_strings() {
+        let source = Source::task("@scope/pkg#build");
+        assert_eq!(source.to_string(), "task:@scope/pkg#build");
+    }
+
+    #[test]
+    fn sanitized_string_strips_control_chars() {
+        let s = SanitizedString::from("\x1b[31mred\x1b[0m");
+        assert_eq!(s.as_str(), "red");
+
+        let s = SanitizedString::from("with\nnewline");
+        assert_eq!(s.as_str(), "withnewline");
+
+        let s = SanitizedString::from("clean string");
+        assert_eq!(s.as_str(), "clean string");
+    }
+
+    #[test]
+    fn sanitized_string_from_trusted_preserves_content() {
+        let raw = SanitizedString::from_trusted("\x1b[31mred\x1b[0m".to_string());
+        assert!(raw.as_str().contains("\x1b[31m"));
+    }
+
+    #[test]
+    fn sanitized_string_display() {
+        let s = SanitizedString::from("hello");
+        assert_eq!(s.to_string(), "hello");
+    }
+
+    #[test]
+    fn sanitized_string_partial_eq_str() {
+        let s = SanitizedString::from("hello");
+        assert!(s == *"hello");
+        assert!(!(s == *"world"));
+    }
+
+    #[test]
+    fn value_string_sanitizes_control_chars() {
+        assert_eq!(
+            Value::from("\x1b[31mred\x1b[0m"),
+            Value::String("red".into())
+        );
+        assert_eq!(
+            Value::from("with\nnewline"),
+            Value::String("withnewline".into())
+        );
+        assert_eq!(
+            Value::from("clean string"),
+            Value::String("clean string".into())
+        );
+    }
+
+    #[test]
+    fn value_from_conversions() {
+        assert_eq!(Value::from("hello"), Value::String("hello".into()));
+        assert_eq!(
+            Value::from(String::from("owned")),
+            Value::String("owned".into())
+        );
+        assert_eq!(Value::from(42i64), Value::Int(42));
+        assert_eq!(Value::from(42i32), Value::Int(42));
+        assert_eq!(Value::from(42u32), Value::Int(42));
+        assert_eq!(Value::from(true), Value::Bool(true));
+        assert_eq!(Value::from(2.72f64), Value::Float(2.72));
+    }
+
+    #[test]
+    fn value_from_u64_within_range() {
+        assert_eq!(Value::from(42u64), Value::Int(42));
+    }
+
+    #[test]
+    fn value_from_u64_overflow_becomes_string() {
+        let val = Value::from(u64::MAX);
+        assert_eq!(val, Value::String(u64::MAX.to_string().into()));
+    }
+
+    #[test]
+    fn value_from_usize_overflow_becomes_string() {
+        let val = Value::from(usize::MAX);
+        assert_eq!(val, Value::String(usize::MAX.to_string().into()));
+    }
+
+    #[test]
+    fn value_from_vec() {
+        let val = Value::from(vec!["a", "b", "c"]);
+        match val {
+            Value::List(items) => {
+                assert_eq!(items.len(), 3);
+                assert_eq!(items[0], Scalar::String("a".into()));
+            }
+            _ => panic!("expected List"),
+        }
+    }
+
+    #[test]
+    fn value_display() {
+        assert_eq!(Value::String("hello".into()).to_string(), "hello");
+        assert_eq!(Value::Int(42).to_string(), "42");
+        assert_eq!(Value::Bool(true).to_string(), "true");
+        assert_eq!(Value::Float(2.72).to_string(), "2.72");
+        assert_eq!(
+            Value::List(vec![Scalar::from("a"), Scalar::from("b")]).to_string(),
+            "a, b"
+        );
+        assert_eq!(Value::List(vec![]).to_string(), "");
+        assert_eq!(Value::Redacted.to_string(), "[REDACTED]");
+    }
+
+    #[test]
+    fn scalar_display() {
+        assert_eq!(Scalar::String("hello".into()).to_string(), "hello");
+        assert_eq!(Scalar::Int(42).to_string(), "42");
+        assert_eq!(Scalar::Bool(true).to_string(), "true");
+        assert_eq!(Scalar::Redacted.to_string(), "[REDACTED]");
+    }
+
+    #[test]
+    fn scalar_from_conversions() {
+        assert_eq!(Scalar::from("hello"), Scalar::String("hello".into()));
+        assert_eq!(Scalar::from(42i64), Scalar::Int(42));
+        assert_eq!(Scalar::from(true), Scalar::Bool(true));
+        assert_eq!(Scalar::from(2.72f64), Scalar::Float(2.72));
+    }
+
+    #[test]
+    fn value_list_holds_only_scalars() {
+        // Value::List(Vec<Scalar>) prevents nesting at the type level.
+        // This test verifies the flat-list contract at runtime.
+        let list = Value::from(vec!["a", "b"]);
+        match list {
+            Value::List(items) => {
+                assert_eq!(items.len(), 2);
+                assert!(matches!(&items[0], Scalar::String(s) if s == "a"));
+            }
+            _ => panic!("expected List"),
+        }
+    }
+
+    #[test]
+    fn message_strips_full_ansi_sequences() {
+        let event = LogEvent::new(
+            Level::Warn,
+            Source::turbo("test"),
+            "hello\x1b[31mworld\x00".to_string(),
+        );
+        assert_eq!(event.message, "helloworld");
+    }
+
+    #[test]
+    fn message_strips_clear_screen_sequence() {
+        let event = LogEvent::new(
+            Level::Warn,
+            Source::turbo("test"),
+            "before\x1b[2Jafter".to_string(),
+        );
+        assert_eq!(event.message, "beforeafter");
+    }
+
+    #[test]
+    fn message_preserves_newlines() {
+        let event = LogEvent::new(
+            Level::Info,
+            Source::turbo("test"),
+            "line 1\nline 2".to_string(),
+        );
+        assert_eq!(event.message, "line 1\nline 2");
+    }
+
+    #[test]
+    fn serialization_omits_empty_fields() {
+        let event = LogEvent::new(Level::Warn, Source::turbo("test"), "msg");
+        let json = serde_json::to_string(&event).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(parsed.get("fields").is_none());
+    }
+
+    #[test]
+    fn serialization_fields_as_map() {
+        let mut event = LogEvent::new(Level::Error, Source::task("web#build"), "failed");
+        event.fields.push(("code", Value::from(137i64)));
+        event.fields.push(("signal", Value::from("SIGKILL")));
+        let json = serde_json::to_string(&event).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["fields"]["code"], 137);
+        assert_eq!(parsed["fields"]["signal"], "SIGKILL");
+    }
+
+    #[test]
+    fn serialization_redacted_field_is_null() {
+        let mut event = LogEvent::new(Level::Info, Source::turbo("auth"), "token used");
+        event.fields.push(("token", Value::Redacted));
+        let json = serde_json::to_string(&event).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(parsed["fields"]["token"].is_null());
+    }
+
+    #[test]
+    fn serialization_timestamp_is_epoch_millis() {
+        let event = LogEvent::new(Level::Info, Source::turbo("test"), "msg");
+        let json = serde_json::to_string(&event).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(parsed["timestamp"].is_u64());
+    }
+
+    #[test]
+    fn serialization_level_is_uppercase() {
+        let event = LogEvent::new(Level::Warn, Source::turbo("test"), "msg");
+        let json = serde_json::to_string(&event).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["level"], "WARN");
+    }
+
+    #[test]
+    fn with_timestamp_uses_provided_time() {
+        let ts = SystemTime::UNIX_EPOCH;
+        let event = LogEvent::with_timestamp(Level::Info, Source::turbo("test"), "msg", ts);
+        assert_eq!(event.timestamp, ts);
+    }
+
+    #[test]
+    fn strip_control_chars_fast_path() {
+        let input = "no control chars here";
+        assert!(matches!(
+            strip_control_chars(input, false),
+            Cow::Borrowed(_)
+        ));
+    }
+
+    #[test]
+    fn strip_control_chars_preserves_newlines_when_requested() {
+        assert_eq!(strip_control_chars("a\nb", true).as_ref(), "a\nb");
+        assert_eq!(strip_control_chars("a\nb", false).as_ref(), "ab");
+    }
+
+    #[test]
+    fn strip_c1_csi_consumes_parameter_bytes() {
+        assert_eq!(
+            strip_control_chars("\u{9b}31mred\u{9b}0m", false).as_ref(),
+            "red"
+        );
+    }
+
+    #[test]
+    fn strip_c1_csi_clear_screen() {
+        assert_eq!(
+            strip_control_chars("before\u{9b}2Jafter", false).as_ref(),
+            "beforeafter"
+        );
+    }
+
+    #[test]
+    fn source_task_strips_c1_csi() {
+        let source = Source::task("evil\u{9b}31mtask");
+        match &source {
+            Source::Task(id) => assert_eq!(id.as_ref(), "eviltask"),
+            _ => panic!("expected Task"),
+        }
+    }
+
+    #[test]
+    fn message_strips_c1_csi() {
+        let event = LogEvent::new(
+            Level::Warn,
+            Source::turbo("test"),
+            "\u{9b}31mred\u{9b}0m text",
+        );
+        assert_eq!(event.message, "red text");
+    }
+
+    #[test]
+    fn value_string_strips_c1_csi() {
+        assert_eq!(
+            Value::from("\u{9b}31mred\u{9b}0m"),
+            Value::String("red".into())
+        );
+    }
+
+    #[test]
+    fn strip_csi_with_backtick_terminator() {
+        assert_eq!(
+            strip_control_chars("before\x1b[5`after", true).as_ref(),
+            "beforeafter"
+        );
+    }
+
+    #[test]
+    fn strip_csi_with_curly_brace_terminator() {
+        assert_eq!(
+            strip_control_chars("before\x1b[0{after", true).as_ref(),
+            "beforeafter"
+        );
+    }
+
+    #[test]
+    fn strip_csi_with_pipe_terminator() {
+        assert_eq!(
+            strip_control_chars("before\x1b[0|after", true).as_ref(),
+            "beforeafter"
+        );
+    }
+
+    #[test]
+    fn strip_fp_escape_cursor_save() {
+        // ESC 7 = DECSC (cursor save), Fp range 0x30-0x3F
+        assert_eq!(
+            strip_control_chars("before\x1b7after", true).as_ref(),
+            "beforeafter"
+        );
+    }
+
+    #[test]
+    fn strip_fs_escape_ris() {
+        // ESC c = RIS (Reset to Initial State), Fs range 0x60-0x7E
+        assert_eq!(
+            strip_control_chars("before\x1bcafter", true).as_ref(),
+            "beforeafter"
+        );
+    }
+
+    #[test]
+    fn sanitized_string_from_trusted_bypasses_sanitization() {
+        let raw = SanitizedString::from_trusted("\x1b[31mred\x1b[0m".to_string());
+        assert!(raw.as_str().contains("\x1b[31m"));
+        let sanitized = SanitizedString::from("\x1b[31mred\x1b[0m");
+        assert_eq!(sanitized.as_str(), "red");
+    }
+
+    #[test]
+    fn accessors_return_expected_values() {
+        let ts = SystemTime::UNIX_EPOCH;
+        let mut event = LogEvent::with_timestamp(Level::Warn, Source::turbo("test"), "msg", ts);
+        event.push_field("key", Value::from("val"));
+        assert_eq!(event.level(), Level::Warn);
+        assert_eq!(event.source(), &Source::turbo("test"));
+        assert_eq!(event.message(), "msg");
+        assert_eq!(event.fields().len(), 1);
+        assert_eq!(event.fields()[0].0, "key");
+        assert_eq!(event.timestamp(), ts);
+    }
+
+    #[test]
+    fn strip_del_character() {
+        assert_eq!(
+            strip_control_chars("hello\x7Fworld", true).as_ref(),
+            "helloworld"
+        );
+    }
+
+    #[test]
+    fn scalar_to_value_conversion() {
+        let scalar = Scalar::from("hello");
+        let value = Value::from(scalar);
+        assert_eq!(value, Value::String("hello".into()));
+
+        let scalar = Scalar::from(42i64);
+        let value = Value::from(scalar);
+        assert_eq!(value, Value::Int(42));
+    }
+}

--- a/crates/turborepo-log/src/lib.rs
+++ b/crates/turborepo-log/src/lib.rs
@@ -1,0 +1,101 @@
+#![warn(missing_docs)]
+//! User-facing logging interface for Turborepo.
+//!
+//! This crate provides a structured event system for messages intended for
+//! Turborepo's end users: warnings, errors, and informational output. It is
+//! separate from Rust's `tracing` crate, which remains for developer
+//! diagnostics.
+//!
+//! # When to use `turborepo-log` vs `tracing`
+//!
+//! | Audience     | Crate            | Example                              |
+//! |--------------|------------------|--------------------------------------|
+//! | End user     | `turborepo-log`  | `"cache miss for web#build"`         |
+//! | Developer    | `tracing`        | `"resolving lockfile at path={path}"`|
+//!
+//! **Rule of thumb**: If the message should appear in `turbo run` output
+//! that an end user sees, use `turborepo-log`. If it's for debug output
+//! or internal diagnostics, use `tracing`.
+//!
+//! # Architecture
+//!
+//! - **Handle**: [`LogHandle`] provides a source-scoped API for emitting
+//!   events. Create one via [`log()`] (global) or [`Logger::handle()`]
+//!   (specific logger).
+//! - **Sinks**: Implement [`LogSink`] to route events to different destinations
+//!   (terminal, TUI, file, collector, etc.).
+//! - **Logger**: [`Logger`] dispatches events to all registered sinks. Set a
+//!   global logger via [`init()`], or use a `Logger` directly for testing.
+//!
+//! # Usage
+//!
+//! ```no_run
+//! use std::sync::Arc;
+//! use turborepo_log::{init, log, Logger, Source};
+//! use turborepo_log::sinks::collector::CollectorSink;
+//!
+//! // Initialize the global logger (once, at startup).
+//! let collector = Arc::new(CollectorSink::new());
+//! init(Logger::new(vec![Box::new(collector.clone())])).ok();
+//!
+//! // Create a source-scoped handle and emit events.
+//! let handle = log(Source::turbo("config"));
+//! handle.warn("'daemon' config option is deprecated").emit();
+//!
+//! // With structured fields:
+//! handle.warn("deprecated field")
+//!     .field("name", "daemon")
+//!     .emit();
+//!
+//! // Task-scoped:
+//! let task_handle = log(Source::task("web#build"));
+//! task_handle.error("exited with non-zero code")
+//!     .field("code", 137)
+//!     .emit();
+//! ```
+//!
+//! # Testing
+//!
+//! The global logger can only be set once per process. For unit tests,
+//! create a [`Logger`] directly and use [`Logger::handle()`]:
+//!
+//! ```
+//! use std::sync::Arc;
+//! use turborepo_log::{Logger, Source};
+//! use turborepo_log::sinks::collector::CollectorSink;
+//!
+//! let (collector, logger) = CollectorSink::with_logger();
+//!
+//! let handle = logger.handle(Source::turbo("test"));
+//! handle.warn("test warning").emit();
+//!
+//! assert_eq!(collector.events().len(), 1);
+//! ```
+//!
+//! # Relationship to `turborepo-ui`
+//!
+//! `turborepo-ui` handles terminal rendering (TUI, console formatting,
+//! progress output). `turborepo-log` handles structured event capture
+//! and dispatch. They are complementary: a terminal sink in
+//! `turborepo-ui` can implement [`LogSink`] to bridge structured
+//! events into the existing rendering pipeline. This crate
+//! intentionally has no dependency on `turborepo-ui`.
+//!
+//! # Limitations
+//!
+//! The global logger uses [`OnceLock`](std::sync::OnceLock) and cannot
+//! be reconfigured after initialization. For long-running processes
+//! (e.g., `turbo daemon`), sink-level reconfiguration (such as file
+//! rotation) should be handled within the sink implementation rather
+//! than by replacing the logger.
+
+mod event;
+mod logger;
+mod sink;
+pub mod sinks;
+
+pub use event::{Level, LogEvent, SanitizedString, Scalar, Source, Value};
+pub use logger::{
+    InitError, LogEventBuilder, LogHandle, Logger, error, flush, info, init, log, warn,
+};
+pub use sink::LogSink;

--- a/crates/turborepo-log/src/logger.rs
+++ b/crates/turborepo-log/src/logger.rs
@@ -1,0 +1,523 @@
+use std::{
+    fmt,
+    sync::{Arc, OnceLock},
+};
+
+use crate::{
+    event::{Level, LogEvent, Source, Value},
+    sink::LogSink,
+};
+
+static GLOBAL_LOGGER: OnceLock<Arc<Logger>> = OnceLock::new();
+
+// Compile-time proof that Logger is Send + Sync (required by
+// OnceLock<Arc<Logger>>).
+#[allow(dead_code)]
+const _: () = {
+    fn assert_send_sync<T: Send + Sync>() {}
+    fn check() {
+        assert_send_sync::<Logger>();
+    }
+};
+
+/// Process-wide logger that dispatches events to registered sinks.
+///
+/// Create via [`Logger::new`], then either register globally with [`init`]
+/// or use directly via [`Logger::handle`] for testing.
+pub struct Logger {
+    sinks: Vec<Box<dyn LogSink>>,
+}
+
+impl fmt::Debug for Logger {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Logger")
+            .field("sinks", &self.sinks.len())
+            .finish()
+    }
+}
+
+impl Logger {
+    /// Create a logger that dispatches to the given sinks.
+    ///
+    /// An empty `sinks` list is valid — events will be silently dropped.
+    /// Sinks are called sequentially in registration order.
+    #[must_use]
+    pub fn new(sinks: Vec<Box<dyn LogSink>>) -> Self {
+        Self { sinks }
+    }
+
+    /// Dispatch an event to all registered sinks.
+    ///
+    /// Each sink's [`LogSink::enabled`] method is checked before dispatch.
+    pub fn emit(&self, event: &LogEvent) {
+        for sink in &self.sinks {
+            if sink.enabled(event.level) {
+                sink.emit(event);
+            }
+        }
+    }
+
+    /// Flush all sinks. Call during graceful shutdown.
+    pub fn flush(&self) {
+        for sink in &self.sinks {
+            sink.flush();
+        }
+    }
+
+    /// Create a source-scoped log handle bound to this logger.
+    ///
+    /// Use this in tests and when you need to bypass the global logger.
+    pub fn handle(self: &Arc<Self>, source: Source) -> LogHandle {
+        LogHandle {
+            source,
+            logger: LoggerRef::Direct(Arc::clone(self)),
+        }
+    }
+}
+
+/// Error returned by [`init`] when the global logger has already been set.
+#[derive(Debug, Clone, Copy)]
+pub struct InitError;
+
+impl fmt::Display for InitError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("global logger already initialized")
+    }
+}
+
+impl std::error::Error for InitError {}
+
+/// Set the global logger. Returns `Err` if already initialized.
+///
+/// Call this once during process startup, after sinks are configured.
+/// Events emitted before `init` are silently dropped.
+///
+/// # Errors
+///
+/// Returns [`InitError`] if the global logger was already set. The
+/// provided `Logger` (and its sinks) is dropped in that case — the
+/// existing global logger remains active.
+#[must_use = "returns Err(InitError) if the global logger was already initialized"]
+pub fn init(logger: Logger) -> Result<(), InitError> {
+    GLOBAL_LOGGER.set(Arc::new(logger)).map_err(|_| InitError)
+}
+
+/// Flush all sinks on the global logger. Call during graceful shutdown.
+pub fn flush() {
+    if let Some(logger) = GLOBAL_LOGGER.get() {
+        logger.flush();
+    }
+}
+
+/// How a [`LogHandle`] resolves its logger.
+#[derive(Clone)]
+enum LoggerRef {
+    /// Resolve the global logger at emit time (lazy). Handles created
+    /// before `init()` will start working once `init()` is called.
+    Global,
+    /// Bound to a specific logger (eager). Used by `Logger::handle()`.
+    Direct(Arc<Logger>),
+}
+
+/// A source-scoped handle for emitting user-facing log events.
+///
+/// Created via [`log()`] (global logger) or [`Logger::handle()`]
+/// (specific logger). Cheap to clone — carries the source and either
+/// a reference-counted logger pointer or a marker to use the global.
+///
+/// **Important**: Handles created via [`log()`] resolve the global
+/// logger at `.emit()` time, not at handle or builder creation time.
+/// This means handles — and builders created from them — will work
+/// once [`init()`] is called, even if both were created before
+/// initialization. Handles created via [`Logger::handle()`] are
+/// permanently bound to their logger.
+///
+/// ```no_run
+/// use turborepo_log::{log, Source};
+///
+/// let handle = log(Source::turbo("config"));
+/// handle.warn("'daemon' config option is deprecated").emit();
+/// handle.warn("deprecated field").field("name", "daemon").emit();
+/// ```
+#[derive(Clone)]
+pub struct LogHandle {
+    source: Source,
+    logger: LoggerRef,
+}
+
+impl fmt::Debug for LogHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LogHandle")
+            .field("source", &self.source)
+            .field(
+                "logger",
+                &match &self.logger {
+                    LoggerRef::Global => "Global",
+                    LoggerRef::Direct(_) => "Direct",
+                },
+            )
+            .finish()
+    }
+}
+
+impl LogHandle {
+    fn build<'a>(&'a self, level: Level, message: impl Into<String>) -> LogEventBuilder<'a> {
+        let resolver = match &self.logger {
+            LoggerRef::Global => LogResolver::Global,
+            LoggerRef::Direct(arc) => LogResolver::Direct(arc.as_ref()),
+        };
+        LogEventBuilder {
+            event: LogEvent::new(level, self.source.clone(), message),
+            resolver,
+        }
+    }
+
+    /// Create a warning-level event builder.
+    pub fn warn(&self, message: impl Into<String>) -> LogEventBuilder<'_> {
+        self.build(Level::Warn, message)
+    }
+
+    /// Create an info-level event builder.
+    pub fn info(&self, message: impl Into<String>) -> LogEventBuilder<'_> {
+        self.build(Level::Info, message)
+    }
+
+    /// Create an error-level event builder.
+    pub fn error(&self, message: impl Into<String>) -> LogEventBuilder<'_> {
+        self.build(Level::Error, message)
+    }
+}
+
+/// Create a source-scoped log handle using the global logger.
+///
+/// The handle resolves the global logger at emit time, not at creation
+/// time. This means handles created before [`init()`] will work once
+/// the global logger is set.
+///
+/// Prefer creating a handle and reusing it when emitting multiple events
+/// from the same source. For one-off events, the free functions
+/// [`warn()`], [`info()`], and [`error()`] are more concise.
+pub fn log(source: Source) -> LogHandle {
+    LogHandle {
+        source,
+        logger: LoggerRef::Global,
+    }
+}
+
+/// How a [`LogEventBuilder`] resolves its logger at emit time.
+enum LogResolver<'a> {
+    /// Resolve the global logger at emit time (lazy).
+    Global,
+    /// Bound to a specific logger (eager). Used by `Logger::handle()`.
+    Direct(&'a Logger),
+}
+
+/// Builder for a log event. Call `.emit()` to dispatch.
+///
+/// Chain `.field()` calls to attach structured metadata:
+///
+/// ```
+/// use std::sync::Arc;
+/// use turborepo_log::{Logger, Source};
+/// use turborepo_log::sinks::collector::CollectorSink;
+///
+/// let collector = Arc::new(CollectorSink::new());
+/// let logger = Arc::new(Logger::new(vec![Box::new(collector.clone())]));
+///
+/// logger.handle(Source::turbo("cache"))
+///     .warn("cache miss")
+///     .field("task", "web#build")
+///     .field("hash", "abc123")
+///     .emit();
+///
+/// assert_eq!(collector.events().len(), 1);
+/// ```
+///
+/// Events are **not** emitted automatically. You must call `.emit()`.
+///
+/// The global logger is resolved at `.emit()` time, not when the
+/// builder is created. This means a builder created before [`init()`]
+/// will dispatch correctly if `init()` is called before `.emit()`.
+#[must_use = "log events are not emitted until .emit() is called"]
+pub struct LogEventBuilder<'a> {
+    event: LogEvent,
+    resolver: LogResolver<'a>,
+}
+
+impl<'a> LogEventBuilder<'a> {
+    /// Attach a structured field to this event.
+    pub fn field(mut self, key: &'static str, value: impl Into<Value>) -> Self {
+        self.event.push_field(key, value.into());
+        self
+    }
+
+    /// Attach a redacted field. The value is recorded as `[REDACTED]`
+    /// and will never appear in log output.
+    pub fn field_redacted(mut self, key: &'static str) -> Self {
+        self.event.push_field(key, Value::Redacted);
+        self
+    }
+
+    /// Dispatch the event to all registered sinks.
+    ///
+    /// For global-logger builders, resolution happens now — not when
+    /// the builder was created. This is the lazy-resolution guarantee.
+    pub fn emit(self) {
+        let logger = match self.resolver {
+            LogResolver::Global => GLOBAL_LOGGER.get().map(|arc| arc.as_ref()),
+            LogResolver::Direct(l) => Some(l),
+        };
+        if let Some(logger) = logger {
+            logger.emit(&self.event);
+        }
+    }
+}
+
+/// Emit a warning without creating a handle.
+///
+/// Returns a [`LogEventBuilder`] — chain `.field()` calls to attach
+/// metadata, then call `.emit()`. The global logger is resolved at
+/// `.emit()` time; if it has not been initialized, `.emit()` is a
+/// no-op.
+///
+/// Prefer [`log()`] to create a reusable [`LogHandle`] when emitting
+/// multiple events from the same source.
+pub fn warn(source: Source, message: impl Into<String>) -> LogEventBuilder<'static> {
+    LogEventBuilder {
+        event: LogEvent::new(Level::Warn, source, message),
+        resolver: LogResolver::Global,
+    }
+}
+
+/// Emit an info message without creating a handle.
+///
+/// See [`warn()`] for full semantics — this function behaves
+/// identically except it creates an `Info`-level event.
+pub fn info(source: Source, message: impl Into<String>) -> LogEventBuilder<'static> {
+    LogEventBuilder {
+        event: LogEvent::new(Level::Info, source, message),
+        resolver: LogResolver::Global,
+    }
+}
+
+/// Emit an error without creating a handle.
+///
+/// See [`warn()`] for full semantics — this function behaves
+/// identically except it creates an `Error`-level event.
+pub fn error(source: Source, message: impl Into<String>) -> LogEventBuilder<'static> {
+    LogEventBuilder {
+        event: LogEvent::new(Level::Error, source, message),
+        resolver: LogResolver::Global,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::sinks::collector::CollectorSink;
+
+    #[test]
+    fn logger_dispatches_to_sinks() {
+        let (collector, logger) = CollectorSink::with_logger();
+
+        let event = LogEvent::new(Level::Warn, Source::turbo("test"), "test warning");
+        logger.emit(&event);
+
+        let events = collector.events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].message, "test warning");
+        assert_eq!(events[0].level, Level::Warn);
+    }
+
+    #[test]
+    fn logger_dispatches_to_multiple_sinks() {
+        let c1 = Arc::new(CollectorSink::new());
+        let c2 = Arc::new(CollectorSink::new());
+        let logger = Logger::new(vec![Box::new(c1.clone()), Box::new(c2.clone())]);
+
+        let event = LogEvent::new(Level::Error, Source::turbo("test"), "broadcast");
+        logger.emit(&event);
+
+        assert_eq!(c1.events().len(), 1);
+        assert_eq!(c2.events().len(), 1);
+        assert_eq!(c1.events()[0].message, "broadcast");
+    }
+
+    #[test]
+    fn log_handle_emits_via_builder() {
+        let (collector, logger) = CollectorSink::with_logger();
+
+        let handle = logger.handle(Source::turbo("config"));
+        handle
+            .warn("deprecated field")
+            .field("name", "daemon")
+            .emit();
+
+        let events = collector.events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].message, "deprecated field");
+        assert_eq!(events[0].level, Level::Warn);
+        assert_eq!(events[0].fields.len(), 1);
+        assert_eq!(events[0].fields[0].0, "name");
+    }
+
+    #[test]
+    fn builder_without_emit_does_not_dispatch() {
+        let (collector, logger) = CollectorSink::with_logger();
+
+        let handle = logger.handle(Source::turbo("test"));
+        let _builder = handle.warn("should not appear");
+        drop(_builder);
+        assert_eq!(collector.events().len(), 0);
+    }
+
+    #[test]
+    fn builder_field_chaining() {
+        let (collector, logger) = CollectorSink::with_logger();
+
+        logger
+            .handle(Source::turbo("cache"))
+            .warn("cache miss")
+            .field("hash", "abc123")
+            .field("task", "web#build")
+            .field_redacted("token")
+            .emit();
+
+        let events = collector.events();
+        assert_eq!(events[0].fields.len(), 3);
+        assert_eq!(events[0].fields[0].0, "hash");
+        assert_eq!(events[0].fields[2].1, Value::Redacted);
+    }
+
+    #[test]
+    fn logger_with_no_sinks_does_not_panic() {
+        let logger = Logger::new(vec![]);
+        let event = LogEvent::new(Level::Warn, Source::turbo("test"), "ignored");
+        logger.emit(&event);
+        logger.flush();
+    }
+
+    #[test]
+    fn log_event_with_fields() {
+        let (collector, logger) = CollectorSink::with_logger();
+
+        let mut event = LogEvent::new(Level::Warn, Source::turbo("cache"), "cache miss");
+        event.fields.push(("hash", Value::from("abc123")));
+        event.fields.push(("task", Value::from("web#build")));
+        logger.emit(&event);
+
+        let events = collector.events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].fields.len(), 2);
+        assert_eq!(events[0].fields[0].0, "hash");
+        assert!(matches!(&events[0].fields[0].1, Value::String(s) if s == "abc123"));
+    }
+
+    #[test]
+    fn log_handle_all_levels() {
+        let (collector, logger) = CollectorSink::with_logger();
+
+        let handle = logger.handle(Source::turbo("test"));
+        handle.info("info msg").emit();
+        handle.warn("warn msg").emit();
+        handle.error("error msg").emit();
+
+        let events = collector.events();
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0].level, Level::Info);
+        assert_eq!(events[1].level, Level::Warn);
+        assert_eq!(events[2].level, Level::Error);
+    }
+
+    #[test]
+    fn flush_propagates_to_sinks() {
+        let (_, logger) = CollectorSink::with_logger();
+        logger.flush();
+    }
+
+    #[test]
+    fn cloned_handle_emits_to_same_sinks() {
+        let (collector, logger) = CollectorSink::with_logger();
+        let handle = logger.handle(Source::turbo("test"));
+        let cloned = handle.clone();
+
+        handle.warn("from original").emit();
+        cloned.warn("from clone").emit();
+
+        assert_eq!(collector.events().len(), 2);
+    }
+
+    #[test]
+    fn logger_respects_sink_enabled_filter() {
+        use crate::sink::LogSink;
+
+        struct WarnAndAbove(Arc<CollectorSink>);
+
+        impl LogSink for WarnAndAbove {
+            fn emit(&self, event: &LogEvent) {
+                self.0.emit(event);
+            }
+
+            fn enabled(&self, level: Level) -> bool {
+                level >= Level::Warn
+            }
+        }
+
+        let inner = Arc::new(CollectorSink::new());
+        let sink = WarnAndAbove(inner.clone());
+        let logger = Arc::new(Logger::new(vec![Box::new(sink)]));
+
+        let handle = logger.handle(Source::turbo("test"));
+        handle.info("should be filtered").emit();
+        handle.warn("should pass").emit();
+        handle.error("should pass").emit();
+
+        assert_eq!(inner.events().len(), 2);
+        assert_eq!(inner.events()[0].level, Level::Warn);
+        assert_eq!(inner.events()[1].level, Level::Error);
+    }
+
+    #[test]
+    fn logger_selective_dispatch_with_multiple_sinks() {
+        use crate::sink::LogSink;
+
+        struct ErrorOnly(Arc<CollectorSink>);
+
+        impl LogSink for ErrorOnly {
+            fn emit(&self, event: &LogEvent) {
+                self.0.emit(event);
+            }
+
+            fn enabled(&self, level: Level) -> bool {
+                level >= Level::Error
+            }
+        }
+
+        let all_events = Arc::new(CollectorSink::new());
+        let errors_only_inner = Arc::new(CollectorSink::new());
+        let errors_only = ErrorOnly(errors_only_inner.clone());
+
+        let logger = Arc::new(Logger::new(vec![
+            Box::new(all_events.clone()),
+            Box::new(errors_only),
+        ]));
+
+        let handle = logger.handle(Source::turbo("test"));
+        handle.info("info").emit();
+        handle.warn("warn").emit();
+        handle.error("error").emit();
+
+        assert_eq!(all_events.events().len(), 3);
+        assert_eq!(errors_only_inner.events().len(), 1);
+        assert_eq!(errors_only_inner.events()[0].level, Level::Error);
+    }
+
+    #[test]
+    fn logger_debug_shows_sink_count() {
+        let logger = Logger::new(vec![]);
+        let debug = format!("{logger:?}");
+        assert!(debug.contains("sinks: 0"));
+    }
+}

--- a/crates/turborepo-log/src/sink.rs
+++ b/crates/turborepo-log/src/sink.rs
@@ -1,0 +1,58 @@
+use std::sync::Arc;
+
+use crate::{LogEvent, event::Level};
+
+/// A destination for user-facing log events.
+///
+/// Sinks receive structured events and decide how to present or store them.
+/// Multiple sinks can be active simultaneously (e.g., terminal output +
+/// collector for post-run summary).
+///
+/// # Threading contract
+///
+/// `emit` is called synchronously on the thread that triggered the log
+/// event (typically a task execution thread). Implementations **must not**
+/// perform unbounded blocking — a slow sink delays all subsequent sinks
+/// and the calling task. If your sink performs I/O that may block
+/// (network, unbuffered disk), buffer internally and flush asynchronously,
+/// or accept bounded latency.
+///
+/// Multiple threads may call `emit` concurrently on the same sink
+/// instance. The `Send + Sync` bound is required.
+///
+/// # Error handling
+///
+/// Sink implementations should be best-effort: failures to write or
+/// serialize an event should be handled silently. Logging must never
+/// cause the host process to panic.
+pub trait LogSink: Send + Sync + 'static {
+    /// Process a log event. Must not panic.
+    ///
+    /// Called inline on the emitting thread. Keep this fast — see the
+    /// threading contract above.
+    fn emit(&self, event: &LogEvent);
+
+    /// Flush any buffered output. Called during graceful shutdown.
+    fn flush(&self) {}
+
+    /// Whether this sink wants events at the given level.
+    /// Return `false` to skip dispatch entirely (avoids serialization cost).
+    /// Default: accept all levels.
+    fn enabled(&self, _level: Level) -> bool {
+        true
+    }
+}
+
+impl<T: LogSink> LogSink for Arc<T> {
+    fn emit(&self, event: &LogEvent) {
+        (**self).emit(event)
+    }
+
+    fn flush(&self) {
+        (**self).flush()
+    }
+
+    fn enabled(&self, level: Level) -> bool {
+        (**self).enabled(level)
+    }
+}

--- a/crates/turborepo-log/src/sinks/collector.rs
+++ b/crates/turborepo-log/src/sinks/collector.rs
@@ -1,0 +1,242 @@
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicU64, Ordering},
+};
+
+use crate::{
+    Logger,
+    event::{Level, LogEvent},
+    sink::LogSink,
+};
+
+const DEFAULT_MAX_EVENTS: usize = 10_000;
+
+/// Collects log events in memory for retrieval after a run.
+///
+/// Used for post-run warning/error summaries. Thread-safe via internal
+/// `Mutex`. Share across threads with `Arc<CollectorSink>`.
+///
+/// Events beyond the capacity limit are silently dropped and counted
+/// via [`dropped_count()`](Self::dropped_count). Use [`drain()`](Self::drain)
+/// to clear the buffer periodically for long-running processes.
+pub struct CollectorSink {
+    events: Mutex<Vec<LogEvent>>,
+    max_events: usize,
+    dropped: AtomicU64,
+}
+
+impl CollectorSink {
+    /// Create a collector with the default capacity (10,000 events).
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            events: Mutex::new(Vec::new()),
+            max_events: DEFAULT_MAX_EVENTS,
+            dropped: AtomicU64::new(0),
+        }
+    }
+
+    /// Create a collector with a specific capacity limit.
+    ///
+    /// Passing `0` creates a sink that drops all events (useful for
+    /// disabling collection without changing the sink plumbing).
+    /// Events beyond the capacity are silently dropped and counted.
+    #[must_use]
+    pub fn with_capacity(max_events: usize) -> Self {
+        Self {
+            events: Mutex::new(Vec::new()),
+            max_events,
+            dropped: AtomicU64::new(0),
+        }
+    }
+
+    /// Create a collector and a logger wired to it.
+    ///
+    /// Convenience for tests — avoids repeating the `Arc::new` +
+    /// `Box::new` boilerplate.
+    pub fn with_logger() -> (Arc<Self>, Arc<Logger>) {
+        let collector = Arc::new(Self::new());
+        let logger = Arc::new(Logger::new(vec![Box::new(collector.clone())]));
+        (collector, logger)
+    }
+
+    /// Return a clone of all collected events.
+    ///
+    /// This clones every event while holding the internal lock.
+    /// For large buffers, prefer [`with_events`](Self::with_events)
+    /// or [`drain`](Self::drain).
+    pub fn events(&self) -> Vec<LogEvent> {
+        self.lock().clone()
+    }
+
+    /// Access collected events without cloning.
+    pub fn with_events<R>(&self, f: impl FnOnce(&[LogEvent]) -> R) -> R {
+        f(&self.lock())
+    }
+
+    /// Return events at or above the given severity.
+    ///
+    /// For example, `events_at_severity(Level::Warn)` returns `Warn` and
+    /// `Error` events, excluding `Info`.
+    pub fn events_at_severity(&self, min_severity: Level) -> Vec<LogEvent> {
+        self.lock()
+            .iter()
+            .filter(|e| e.level >= min_severity)
+            .cloned()
+            .collect()
+    }
+
+    /// Drain all collected events, clearing the internal buffer.
+    pub fn drain(&self) -> Vec<LogEvent> {
+        std::mem::take(&mut *self.lock())
+    }
+
+    /// Number of events that were dropped because the buffer was full.
+    pub fn dropped_count(&self) -> u64 {
+        self.dropped.load(Ordering::Relaxed)
+    }
+
+    // Recover from poisoned mutex — logging must not propagate panics
+    // from other threads.
+    fn lock(&self) -> std::sync::MutexGuard<'_, Vec<LogEvent>> {
+        self.events.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+impl Default for CollectorSink {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LogSink for CollectorSink {
+    fn emit(&self, event: &LogEvent) {
+        let mut events = self.lock();
+        if events.len() < self.max_events {
+            events.push(event.clone());
+        } else {
+            self.dropped.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::Source;
+
+    #[test]
+    fn stores_events() {
+        let collector = CollectorSink::new();
+        collector.emit(&LogEvent::new(
+            Level::Warn,
+            Source::turbo("test"),
+            "warning 1",
+        ));
+        collector.emit(&LogEvent::new(
+            Level::Error,
+            Source::turbo("test"),
+            "error 1",
+        ));
+        assert_eq!(collector.events().len(), 2);
+    }
+
+    #[test]
+    fn filter_by_severity() {
+        let collector = CollectorSink::new();
+        collector.emit(&LogEvent::new(Level::Info, Source::turbo("t"), "info"));
+        collector.emit(&LogEvent::new(Level::Warn, Source::turbo("t"), "warn"));
+        collector.emit(&LogEvent::new(Level::Error, Source::turbo("t"), "error"));
+
+        let warnings_and_above = collector.events_at_severity(Level::Warn);
+        assert_eq!(warnings_and_above.len(), 2);
+        assert!(warnings_and_above.iter().all(|e| e.level >= Level::Warn));
+        assert!(warnings_and_above.iter().any(|e| e.level == Level::Warn));
+        assert!(warnings_and_above.iter().any(|e| e.level == Level::Error));
+
+        let errors_only = collector.events_at_severity(Level::Error);
+        assert_eq!(errors_only.len(), 1);
+        assert_eq!(errors_only[0].level, Level::Error);
+
+        let all = collector.events_at_severity(Level::Info);
+        assert_eq!(all.len(), 3);
+    }
+
+    #[test]
+    fn drain_clears_buffer() {
+        let collector = CollectorSink::new();
+        collector.emit(&LogEvent::new(Level::Warn, Source::turbo("test"), "msg"));
+        let drained = collector.drain();
+        assert_eq!(drained.len(), 1);
+        assert_eq!(collector.events().len(), 0);
+    }
+
+    #[test]
+    fn respects_capacity_limit() {
+        let collector = CollectorSink::with_capacity(3);
+        for i in 0..5 {
+            collector.emit(&LogEvent::new(
+                Level::Warn,
+                Source::turbo("test"),
+                format!("event {i}"),
+            ));
+        }
+        assert_eq!(collector.events().len(), 3);
+        assert_eq!(collector.dropped_count(), 2);
+    }
+
+    #[test]
+    fn with_capacity_zero_drops_all_events() {
+        let collector = CollectorSink::with_capacity(0);
+        collector.emit(&LogEvent::new(Level::Warn, Source::turbo("t"), "msg"));
+        assert_eq!(collector.events().len(), 0);
+        assert_eq!(collector.dropped_count(), 1);
+    }
+
+    #[test]
+    fn with_events_borrows_without_cloning() {
+        let collector = CollectorSink::new();
+        collector.emit(&LogEvent::new(Level::Info, Source::turbo("test"), "msg"));
+        collector.with_events(|events| {
+            assert_eq!(events.len(), 1);
+            assert_eq!(events[0].message, "msg");
+        });
+    }
+
+    #[test]
+    fn default_is_empty() {
+        let collector = CollectorSink::default();
+        assert_eq!(collector.events().len(), 0);
+        assert_eq!(collector.dropped_count(), 0);
+    }
+
+    #[test]
+    fn with_logger_creates_wired_pair() {
+        let (collector, logger) = CollectorSink::with_logger();
+        let handle = logger.handle(Source::turbo("test"));
+        handle.warn("via helper").emit();
+        assert_eq!(collector.events().len(), 1);
+    }
+
+    #[test]
+    fn concurrent_access() {
+        let collector = std::sync::Arc::new(CollectorSink::new());
+        let mut handles = vec![];
+        for i in 0..10 {
+            let c = std::sync::Arc::clone(&collector);
+            handles.push(std::thread::spawn(move || {
+                for j in 0..100 {
+                    c.emit(&LogEvent::new(
+                        Level::Warn,
+                        Source::turbo("test"),
+                        format!("thread {i} event {j}"),
+                    ));
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        assert_eq!(collector.events().len(), 1000);
+    }
+}

--- a/crates/turborepo-log/src/sinks/file.rs
+++ b/crates/turborepo-log/src/sinks/file.rs
@@ -1,0 +1,319 @@
+use std::{
+    io::{BufWriter, Write},
+    sync::{
+        Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+use crate::{event::LogEvent, sink::LogSink};
+
+/// Writes log events as newline-delimited JSON to a writer.
+///
+/// Each line is a complete JSON object representing one event. Suitable
+/// for daemon logs, `--log-file` output, and machine-readable log archives.
+///
+/// The writer is wrapped in a [`BufWriter`] internally — pass an
+/// unbuffered writer (e.g., `File`, `Vec<u8>`).
+///
+/// # Size limiting
+///
+/// Use [`with_max_bytes`](Self::with_max_bytes) to cap output size.
+/// Without a limit, the sink writes until the underlying writer fails.
+/// For long-running processes (e.g., `turbo daemon`), the caller is
+/// responsible for rotation — either by setting a max size, providing
+/// a writer that handles rotation, or by periodically recreating the
+/// sink.
+pub struct FileSink<W: Write + Send + 'static> {
+    writer: Mutex<BufWriter<W>>,
+    dropped: AtomicU64,
+    bytes_written: AtomicU64,
+    max_bytes: Option<u64>,
+}
+
+/// Convenience alias for the common case of writing to a file.
+pub type FileLogSink = FileSink<std::fs::File>;
+
+impl<W: Write + Send + 'static> FileSink<W> {
+    /// Create a new file sink writing to the given destination.
+    #[must_use]
+    pub fn new(writer: W) -> Self {
+        Self {
+            writer: Mutex::new(BufWriter::new(writer)),
+            dropped: AtomicU64::new(0),
+            bytes_written: AtomicU64::new(0),
+            max_bytes: None,
+        }
+    }
+
+    /// Create a file sink with a maximum output size in bytes.
+    ///
+    /// Once the limit is reached, subsequent events are dropped and
+    /// counted via [`dropped_count`](Self::dropped_count). The check
+    /// is performed under the internal lock so concurrent writers
+    /// cannot overshoot by more than one event.
+    #[must_use]
+    pub fn with_max_bytes(writer: W, max_bytes: u64) -> Self {
+        Self {
+            writer: Mutex::new(BufWriter::new(writer)),
+            dropped: AtomicU64::new(0),
+            bytes_written: AtomicU64::new(0),
+            max_bytes: Some(max_bytes),
+        }
+    }
+
+    /// Number of events that failed to write (serialization errors,
+    /// I/O errors, or size limit exceeded).
+    pub fn dropped_count(&self) -> u64 {
+        self.dropped.load(Ordering::Relaxed)
+    }
+
+    /// Approximate number of bytes written so far.
+    pub fn bytes_written(&self) -> u64 {
+        self.bytes_written.load(Ordering::Relaxed)
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, BufWriter<W>> {
+        self.writer.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+impl<W: Write + Send + 'static> LogSink for FileSink<W> {
+    fn emit(&self, event: &LogEvent) {
+        // Serialize outside the lock to reduce contention when many tasks
+        // emit concurrently. The tradeoff is one extra String allocation
+        // per event, but lock hold time drops to just the write + size check.
+        let json = match serde_json::to_string(event) {
+            Ok(j) => j,
+            Err(_) => {
+                self.dropped.fetch_add(1, Ordering::Relaxed);
+                return;
+            }
+        };
+
+        let event_bytes = json.len() as u64 + 1; // +1 for newline
+
+        // Size check is inside the lock so concurrent writers cannot
+        // overshoot max_bytes by more than one event.
+        let mut writer = self.lock();
+
+        if let Some(max) = self.max_bytes
+            && self.bytes_written.load(Ordering::Relaxed) + event_bytes > max
+        {
+            self.dropped.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+
+        if writeln!(writer, "{json}").is_err() {
+            self.dropped.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.bytes_written.fetch_add(event_bytes, Ordering::Relaxed);
+        }
+    }
+
+    fn flush(&self) {
+        let mut writer = self.lock();
+        let _ = writer.flush();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::event::{Level, Source, Value};
+
+    #[test]
+    fn writes_valid_jsonl() {
+        let sink = FileSink::new(Vec::new());
+        let event = LogEvent::new(Level::Warn, Source::turbo("cache"), "cache miss");
+        sink.emit(&event);
+        sink.flush();
+
+        let writer = sink.writer.lock().unwrap();
+        let output = String::from_utf8(writer.get_ref().clone()).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
+        assert_eq!(parsed["message"], "cache miss");
+        assert_eq!(parsed["level"], "WARN");
+    }
+
+    #[test]
+    fn writes_multiple_events_as_jsonl() {
+        let sink = FileSink::new(Vec::new());
+        sink.emit(&LogEvent::new(Level::Info, Source::turbo("a"), "first"));
+        sink.emit(&LogEvent::new(Level::Warn, Source::turbo("b"), "second"));
+        sink.emit(&LogEvent::new(Level::Error, Source::turbo("c"), "third"));
+        sink.flush();
+
+        let writer = sink.writer.lock().unwrap();
+        let output = String::from_utf8(writer.get_ref().clone()).unwrap();
+        let lines: Vec<&str> = output.trim().lines().collect();
+        assert_eq!(lines.len(), 3);
+        for line in &lines {
+            let parsed: serde_json::Value = serde_json::from_str(line).unwrap();
+            assert!(parsed["message"].is_string());
+        }
+    }
+
+    #[test]
+    fn serializes_fields_as_map() {
+        let sink = FileSink::new(Vec::new());
+        let mut event = LogEvent::new(Level::Info, Source::task("web#build"), "started");
+        event.fields.push(("hash", Value::from("abc123")));
+        event.fields.push(("duration_ms", Value::from(42i64)));
+        sink.emit(&event);
+        sink.flush();
+
+        let writer = sink.writer.lock().unwrap();
+        let output = String::from_utf8(writer.get_ref().clone()).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
+        assert_eq!(parsed["fields"]["hash"], "abc123");
+        assert_eq!(parsed["fields"]["duration_ms"], 42);
+    }
+
+    #[test]
+    fn omits_fields_when_empty() {
+        let sink = FileSink::new(Vec::new());
+        let event = LogEvent::new(Level::Warn, Source::turbo("test"), "no fields");
+        sink.emit(&event);
+        sink.flush();
+
+        let writer = sink.writer.lock().unwrap();
+        let output = String::from_utf8(writer.get_ref().clone()).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
+        assert!(parsed.get("fields").is_none());
+    }
+
+    #[test]
+    fn tracks_dropped_count_starts_at_zero() {
+        let sink = FileSink::new(Vec::new());
+        assert_eq!(sink.dropped_count(), 0);
+        sink.emit(&LogEvent::new(Level::Info, Source::turbo("t"), "ok"));
+        assert_eq!(sink.dropped_count(), 0);
+    }
+
+    #[test]
+    fn redacted_fields_serialize_as_null() {
+        let sink = FileSink::new(Vec::new());
+        let mut event = LogEvent::new(Level::Info, Source::turbo("auth"), "token used");
+        event.fields.push(("token", Value::Redacted));
+        sink.emit(&event);
+        sink.flush();
+
+        let writer = sink.writer.lock().unwrap();
+        let output = String::from_utf8(writer.get_ref().clone()).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
+        assert!(parsed["fields"]["token"].is_null());
+    }
+
+    #[test]
+    fn max_bytes_limits_output() {
+        // 200 bytes is enough for ~1 event but not 3
+        let sink = FileSink::with_max_bytes(Vec::new(), 400);
+        for _ in 0..10 {
+            sink.emit(&LogEvent::new(Level::Info, Source::turbo("t"), "msg"));
+        }
+        sink.flush();
+
+        assert!(sink.bytes_written() <= 400 + 200); // allow one event overshoot
+        assert!(sink.dropped_count() > 0);
+    }
+
+    #[test]
+    fn bytes_written_tracks_output_size() {
+        let sink = FileSink::new(Vec::new());
+        assert_eq!(sink.bytes_written(), 0);
+        sink.emit(&LogEvent::new(Level::Info, Source::turbo("t"), "msg"));
+        assert!(sink.bytes_written() > 0);
+    }
+
+    #[test]
+    fn io_error_increments_dropped_count() {
+        struct FailWriter;
+        impl Write for FailWriter {
+            fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::other("fail"))
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let sink = FileSink::new(FailWriter);
+        // The event must exceed BufWriter's 8KB buffer so the write
+        // reaches the underlying FailWriter (small writes are absorbed
+        // by the buffer and never hit the writer).
+        let big_msg = "x".repeat(10_000);
+        sink.emit(&LogEvent::new(Level::Info, Source::turbo("t"), big_msg));
+        assert_eq!(sink.dropped_count(), 1);
+    }
+
+    #[test]
+    fn concurrent_writes_produce_valid_jsonl() {
+        let sink = Arc::new(FileSink::new(Vec::new()));
+        let mut handles = vec![];
+        for i in 0..10 {
+            let s = Arc::clone(&sink);
+            handles.push(std::thread::spawn(move || {
+                for j in 0..100 {
+                    s.emit(&LogEvent::new(
+                        Level::Info,
+                        Source::turbo("test"),
+                        format!("t{i}e{j}"),
+                    ));
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        sink.flush();
+
+        let writer = sink.writer.lock().unwrap();
+        let output = String::from_utf8(writer.get_ref().clone()).unwrap();
+        let lines: Vec<&str> = output.trim().lines().collect();
+        assert_eq!(lines.len(), 1000);
+        for line in &lines {
+            assert!(serde_json::from_str::<serde_json::Value>(line).is_ok());
+        }
+    }
+
+    #[test]
+    fn concurrent_writes_with_max_bytes_bounded_overshoot() {
+        // Measure one event's serialized size.
+        let probe = FileSink::new(Vec::new());
+        probe.emit(&LogEvent::new(Level::Info, Source::turbo("t"), "msg"));
+        let one_event = probe.bytes_written();
+
+        let max = one_event * 5;
+        let sink = Arc::new(FileSink::with_max_bytes(Vec::new(), max));
+        let mut handles = vec![];
+        for i in 0..20 {
+            let s = Arc::clone(&sink);
+            handles.push(std::thread::spawn(move || {
+                for j in 0..50 {
+                    s.emit(&LogEvent::new(
+                        Level::Info,
+                        Source::turbo("t"),
+                        format!("t{i}e{j}"),
+                    ));
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        sink.flush();
+
+        // Size check is under the lock — overshoot is at most one event.
+        assert!(
+            sink.bytes_written() <= max + one_event + 50,
+            "bytes_written {} exceeded bound (max={}, one_event={})",
+            sink.bytes_written(),
+            max,
+            one_event
+        );
+        assert!(sink.dropped_count() > 0, "expected drops");
+    }
+}

--- a/crates/turborepo-log/src/sinks/mod.rs
+++ b/crates/turborepo-log/src/sinks/mod.rs
@@ -1,0 +1,13 @@
+//! Built-in [`LogSink`](crate::LogSink) implementations.
+//!
+//! - [`collector::CollectorSink`] — In-memory event buffer for post-run
+//!   summaries and testing
+//! - [`file::FileSink`] — Newline-delimited JSON file output with optional size
+//!   limiting
+//!
+//! To implement a custom sink, see the [`LogSink`](crate::LogSink) trait.
+
+/// In-memory event buffer for post-run summaries and testing.
+pub mod collector;
+/// Newline-delimited JSON file output with optional size limiting.
+pub mod file;

--- a/crates/turborepo-log/tests/global_init.rs
+++ b/crates/turborepo-log/tests/global_init.rs
@@ -1,0 +1,67 @@
+//! Integration tests for the global logger lifecycle.
+//!
+//! Each `tests/*.rs` file is compiled as a separate binary, so the
+//! `OnceLock`-based global logger can be tested without conflicting
+//! with other test files.
+
+use std::sync::Arc;
+
+use turborepo_log::{Logger, Source, flush, init, log, sinks::collector::CollectorSink};
+
+#[test]
+fn full_lifecycle() {
+    let collector = Arc::new(CollectorSink::new());
+
+    // Handle created before init — the global logger isn't set yet,
+    // so events emitted RIGHT NOW are dropped.
+    let early_handle = log(Source::turbo("early"));
+    early_handle.warn("before init").emit();
+    assert_eq!(collector.events().len(), 0);
+
+    // Builder created before init — holds LogResolver::Global, which
+    // defers resolution to emit() time.
+    let early_builder = early_handle.warn("built before init");
+
+    // Free function builder created before init — also defers.
+    let early_free = turborepo_log::warn(Source::turbo("free"), "free before init");
+
+    // Initialize the global logger.
+    assert!(init(Logger::new(vec![Box::new(collector.clone())])).is_ok());
+
+    // Handle created after init works immediately.
+    let handle = log(Source::turbo("test"));
+    handle.warn("test warning").field("key", "value").emit();
+    assert_eq!(collector.events().len(), 1);
+    assert_eq!(collector.events()[0].message(), "test warning");
+
+    // The early handle now works too — deferred resolution means it
+    // finds the global logger on the next emit() call.
+    early_handle.info("now works").emit();
+    assert_eq!(collector.events().len(), 2);
+
+    // Builders created before init also work — lazy resolution at
+    // emit() time finds the now-initialized global logger.
+    early_builder.emit();
+    assert_eq!(collector.events().len(), 3);
+    assert_eq!(collector.events()[2].message(), "built before init");
+
+    early_free.emit();
+    assert_eq!(collector.events().len(), 4);
+    assert_eq!(collector.events()[3].message(), "free before init");
+
+    // Double init fails with InitError.
+    let result = init(Logger::new(vec![]));
+    assert!(result.is_err());
+
+    // Free functions work.
+    turborepo_log::warn(Source::turbo("free"), "free warning").emit();
+    assert_eq!(collector.events().len(), 5);
+
+    // All levels work.
+    turborepo_log::info(Source::turbo("free"), "info").emit();
+    turborepo_log::error(Source::turbo("free"), "error").emit();
+    assert_eq!(collector.events().len(), 7);
+
+    // Flush doesn't panic.
+    flush();
+}

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -449,3 +449,44 @@ RunSummary.finish()
   └── observability::Handle.shutdown()
         └── Flush pending metrics to backend
 ```
+
+### 9. User-Facing Logging (`crates/turborepo-log/`)
+
+Structured event system for messages intended for end users (warnings,
+errors, informational output). Distinct from `tracing`, which remains
+for developer diagnostics.
+
+#### Key Types
+
+- `Logger` — Dispatches events to registered sinks. Set globally via
+  `init()` (once, at startup) or used directly via `Logger::handle()`
+  for testing.
+- `LogHandle` — Source-scoped handle for emitting events. Created via
+  `log()` (global) or `Logger::handle()` (specific logger). Resolves
+  the global logger at `.emit()` time, not at handle or builder
+  creation time — handles and builders created before `init()` work
+  once the global logger is set.
+- `LogSink` — Trait for event destinations. Built-in sinks:
+  `CollectorSink` (in-memory buffer for post-run summaries) and
+  `FileSink` (newline-delimited JSON with optional size limiting).
+- `LogEvent` — Structured event with level, source, message, typed
+  fields, and timestamp.
+
+#### Relationship to `turborepo-ui`
+
+`turborepo-ui` handles terminal rendering (TUI, console formatting).
+`turborepo-log` handles structured event capture and dispatch. A
+terminal sink in `turborepo-ui` can implement `LogSink` to bridge
+events into the rendering pipeline. `turborepo-log` intentionally has
+no dependency on `turborepo-ui` — it sits at the bottom of the
+dependency graph.
+
+#### Data Flow
+
+```
+Subsystem / Task Executor
+  └── LogHandle.warn("msg").field("k", v).emit()
+        └── Logger.emit(&event)
+              ├── CollectorSink → in-memory buffer → post-run summary
+              └── FileSink → JSONL file → external tooling
+```


### PR DESCRIPTION
## Summary

- Introduces `turborepo-log`, a new crate for structured user-facing log events (warnings, errors, informational output), deliberately separate from `tracing` which remains for developer diagnostics.
- The global `Logger` dispatches events to pluggable `LogSink` implementations. Ships with two built-in sinks: `CollectorSink` (in-memory buffer for post-run summaries) and `FileSink` (newline-delimited JSON with optional size limiting).
- All user-supplied strings are sanitized against ANSI escape sequences and control characters to prevent terminal injection.

## Why

Today, user-facing messages in `turbo run` are scattered across ad-hoc `println!`/`eprintln!` calls and tightly coupled to `turborepo-ui`'s terminal rendering. This makes it hard to capture warnings for post-run summaries, write them to structured log files, or route them to the TUI without touching rendering code.

`turborepo-log` sits at the bottom of the dependency graph (no dependency on `turborepo-ui`) and provides a clean boundary: subsystems emit structured events, sinks decide how to present or store them. A future terminal sink in `turborepo-ui` can implement `LogSink` to bridge into the existing rendering pipeline.

## Testing

```sh
cargo test -p turborepo-log
```

The crate includes unit tests for all public types and an integration test (`tests/global_init.rs`) that exercises the full global logger lifecycle including lazy handle resolution.