### PR TITLE
fix: Ensure `pkg#task` CLI args are always included in filtered packages

### DIFF
--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -275,6 +275,20 @@ impl RunBuilder {
             }
         }
 
+        // Packages referenced by `pkg#task` CLI args are direct task graph
+        // entry points regardless of --filter. Add them to filtered_pkgs so
+        // the engine builder iterates their workspace.
+        for task_str in &opts.run_opts.tasks {
+            let task_name = TaskName::from(task_str.as_str());
+            if let Some(pkg) = task_name.package() {
+                filtered_pkgs.entry(PackageName::from(pkg)).or_insert(
+                    PackageInclusionReason::IncludedByFilter {
+                        filters: vec![task_str.clone()],
+                    },
+                );
+            }
+        }
+
         Ok(filtered_pkgs)
     }
 

--- a/crates/turborepo/tests/pkg_task_entry_test.rs
+++ b/crates/turborepo/tests/pkg_task_entry_test.rs
@@ -1,0 +1,109 @@
+mod common;
+
+use common::{combined_output, run_turbo, setup};
+
+fn setup_fixture(dir: &std::path::Path) {
+    setup::setup_integration_test(dir, "pkg_task_entry", "npm@10.5.0", true).unwrap();
+}
+
+fn dry_run_tasks(dir: &std::path::Path, args: &[&str]) -> Vec<String> {
+    let mut full_args = vec!["run"];
+    full_args.extend_from_slice(args);
+    full_args.push("--dry=json");
+    let output = run_turbo(dir, &full_args);
+    assert!(
+        output.status.success(),
+        "turbo failed: {}",
+        combined_output(&output)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("expected valid JSON from --dry=json");
+    let mut tasks: Vec<String> = json["tasks"]
+        .as_array()
+        .expect("expected tasks array")
+        .iter()
+        .map(|t| t["taskId"].as_str().unwrap().to_string())
+        .collect();
+    tasks.sort();
+    tasks
+}
+
+#[test]
+fn pkg_task_syntax_as_sole_entry_point() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_fixture(tempdir.path());
+
+    // `turbo run web#build` should only run web#build (+ dependency lib#build)
+    let tasks = dry_run_tasks(tempdir.path(), &["web#build"]);
+    assert_eq!(tasks, vec!["lib#build", "web#build"]);
+}
+
+#[test]
+fn pkg_task_syntax_union_with_filter() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_fixture(tempdir.path());
+
+    // `turbo run build --filter=docs web#build` should run:
+    // - docs#build (from --filter + bare task)
+    // - web#build (from pkg#task entry)
+    // - lib#build (dependency of web)
+    let tasks = dry_run_tasks(tempdir.path(), &["build", "--filter=docs", "web#build"]);
+    assert_eq!(tasks, vec!["docs#build", "lib#build", "web#build"]);
+}
+
+#[test]
+fn pkg_task_syntax_union_with_filter_cross_product() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_fixture(tempdir.path());
+
+    // `turbo run build --filter=docs web#lint` should run:
+    // - docs#build (from --filter + bare task `build`)
+    // - web#build (cross-product: web brought in by web#lint + bare task build)
+    // - web#lint (from pkg#task entry)
+    // - lib#build (dependency of web via ^build)
+    let tasks = dry_run_tasks(tempdir.path(), &["build", "--filter=docs", "web#lint"]);
+    assert_eq!(
+        tasks,
+        vec!["docs#build", "lib#build", "web#build", "web#lint"]
+    );
+}
+
+#[test]
+fn pkg_task_syntax_multiple_qualified_tasks() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_fixture(tempdir.path());
+
+    // `turbo run web#build docs#lint` should only run those specific entries
+    // plus web's dependency
+    let tasks = dry_run_tasks(tempdir.path(), &["web#build", "docs#lint"]);
+    assert_eq!(tasks, vec!["docs#lint", "lib#build", "web#build"]);
+}
+
+#[test]
+fn pkg_task_syntax_nonexistent_package_errors() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_fixture(tempdir.path());
+
+    let output = run_turbo(tempdir.path(), &["run", "nonexistent#build"]);
+    assert!(
+        !output.status.success(),
+        "expected failure for nonexistent package"
+    );
+    let combined = combined_output(&output);
+    assert!(
+        combined.contains("nonexistent") && combined.contains("Could not find package"),
+        "expected error about missing package, got: {combined}"
+    );
+}
+
+#[test]
+fn pkg_task_syntax_filter_exclusion_overridden() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_fixture(tempdir.path());
+
+    // `turbo run web#build --filter=!web` should still run web#build
+    // because pkg#task always adds its package regardless of filter exclusions
+    let tasks = dry_run_tasks(tempdir.path(), &["web#build", "--filter=!web"]);
+    assert_eq!(tasks, vec!["lib#build", "web#build"]);
+}

--- a/turborepo-tests/integration/fixtures/pkg_task_entry/package.json
+++ b/turborepo-tests/integration/fixtures/pkg_task_entry/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "monorepo",
+  "workspaces": [
+    "packages/**"
+  ]
+}

--- a/turborepo-tests/integration/fixtures/pkg_task_entry/packages/docs/package.json
+++ b/turborepo-tests/integration/fixtures/pkg_task_entry/packages/docs/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "docs",
+  "scripts": {
+    "build": "echo building-docs",
+    "lint": "echo linting-docs"
+  }
+}

--- a/turborepo-tests/integration/fixtures/pkg_task_entry/packages/lib/package.json
+++ b/turborepo-tests/integration/fixtures/pkg_task_entry/packages/lib/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "lib",
+  "scripts": {
+    "build": "echo building-lib",
+    "lint": "echo linting-lib"
+  }
+}

--- a/turborepo-tests/integration/fixtures/pkg_task_entry/packages/web/package.json
+++ b/turborepo-tests/integration/fixtures/pkg_task_entry/packages/web/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "web",
+  "scripts": {
+    "build": "echo building-web",
+    "lint": "echo linting-web"
+  },
+  "dependencies": {
+    "lib": "*"
+  }
+}

--- a/turborepo-tests/integration/fixtures/pkg_task_entry/turbo.json
+++ b/turborepo-tests/integration/fixtures/pkg_task_entry/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turborepo.dev/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"]
+    },
+    "lint": {}
+  }
+}


### PR DESCRIPTION
## Summary

- `turbo run build --filter=docs web#build` previously dropped `web#build` silently because `web` wasn't in the filter-resolved package set
- `pkg#task` CLI arguments now always add their package to `filtered_pkgs`, regardless of `--filter`
- This is strictly additive — no existing invocation runs fewer tasks

## Why

`--filter` and `pkg#task` syntax should form a union of entry points. The filter narrows which packages bare task names apply to, while `pkg#task` is a direct entry into the task graph. Previously, `--filter` could accidentally exclude the package referenced by `pkg#task`, causing it to vanish from the run.

## Testing

New integration tests cover:
- `pkg#task` as sole entry point (no filter)
- `pkg#task` + `--filter` union (different packages)
- Cross-product: adding `web#lint` brings `web` into scope for bare tasks too
- Multiple qualified tasks targeting different packages
- Nonexistent package produces a clear error
- `--filter=!web web#build` — exclusion overridden by explicit `pkg#task`

```
cargo test --package turbo --test pkg_task_entry_test
```