### PR TITLE
feat: Surface cache SCM metadata in Run Summary

### DIFF
--- a/crates/turborepo-cache/src/async_cache.rs
+++ b/crates/turborepo-cache/src/async_cache.rs
@@ -346,7 +346,9 @@ mod tests {
             response,
             Some(CacheHitMetadata {
                 source: CacheSource::Remote,
-                time_saved: test_case.duration
+                time_saved: test_case.duration,
+                sha: None,
+                dirty_hash: None,
             })
         );
 
@@ -429,7 +431,9 @@ mod tests {
             response,
             Some(CacheHitMetadata {
                 source: CacheSource::Local,
-                time_saved: test_case.duration
+                time_saved: test_case.duration,
+                sha: None,
+                dirty_hash: None,
             })
         );
 
@@ -507,6 +511,8 @@ mod tests {
             Some(CacheHitMetadata {
                 source: CacheSource::Local,
                 time_saved: test_case.duration,
+                sha: None,
+                dirty_hash: None,
             })
         );
 
@@ -599,7 +605,9 @@ mod tests {
             response,
             Some(CacheHitMetadata {
                 source: CacheSource::Local,
-                time_saved: test_case.duration
+                time_saved: test_case.duration,
+                sha: None,
+                dirty_hash: None,
             })
         );
 
@@ -613,7 +621,9 @@ mod tests {
             response,
             Some(CacheHitMetadata {
                 source: CacheSource::Remote,
-                time_saved: test_case.duration
+                time_saved: test_case.duration,
+                sha: None,
+                dirty_hash: None,
             })
         );
 

--- a/crates/turborepo-cache/src/fs.rs
+++ b/crates/turborepo-cache/src/fs.rs
@@ -115,6 +115,8 @@ impl FSCache {
                 CacheHitMetadata {
                     time_saved: meta.duration,
                     source: CacheSource::Local,
+                    sha: meta.sha,
+                    dirty_hash: meta.dirty_hash,
                 },
                 file_list,
             )));
@@ -149,6 +151,8 @@ impl FSCache {
             CacheHitMetadata {
                 time_saved: meta.duration,
                 source: CacheSource::Local,
+                sha: meta.sha,
+                dirty_hash: meta.dirty_hash,
             },
             restored_files,
         )))
@@ -171,16 +175,21 @@ impl FSCache {
         buf.truncate(prefix_len);
         buf.push_str("-meta.json");
 
-        let duration = CacheMetadata::read(
+        let meta = CacheMetadata::read(
             &AbsoluteSystemPathBuf::try_from(buf.as_str())
                 .map_err(|_| CacheError::ConfigCacheInvalidBase)?,
-        )
-        .map(|meta| meta.duration)
-        .unwrap_or(0);
+        );
+
+        let (duration, sha, dirty_hash) = match meta {
+            Ok(m) => (m.duration, m.sha, m.dirty_hash),
+            Err(_) => (0, None, None),
+        };
 
         Ok(Some(CacheHitMetadata {
             time_saved: duration,
             source: CacheSource::Local,
+            sha,
+            dirty_hash,
         }))
     }
 
@@ -332,7 +341,9 @@ mod test {
             status,
             CacheHitMetadata {
                 time_saved: test_case.duration,
-                source: CacheSource::Local
+                source: CacheSource::Local,
+                sha: None,
+                dirty_hash: None,
             }
         );
 

--- a/crates/turborepo-cache/src/http.rs
+++ b/crates/turborepo-cache/src/http.rs
@@ -256,6 +256,8 @@ impl HTTPCache {
         Ok(Some(CacheHitMetadata {
             source: CacheSource::Remote,
             time_saved: duration,
+            sha: None,
+            dirty_hash: None,
         }))
     }
 
@@ -356,6 +358,8 @@ impl HTTPCache {
             CacheHitMetadata {
                 source: CacheSource::Remote,
                 time_saved: duration,
+                sha: None,
+                dirty_hash: None,
             },
             files,
         )))

--- a/crates/turborepo-cache/src/lib.rs
+++ b/crates/turborepo-cache/src/lib.rs
@@ -132,10 +132,12 @@ pub enum CacheSource {
     Remote,
 }
 
-#[derive(Debug, Clone, PartialEq, Copy)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CacheHitMetadata {
     pub source: CacheSource,
     pub time_saved: u64,
+    pub sha: Option<String>,
+    pub dirty_hash: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize)]

--- a/crates/turborepo-cache/src/multiplexer.rs
+++ b/crates/turborepo-cache/src/multiplexer.rs
@@ -169,8 +169,7 @@ impl CacheMultiplexer {
 
         if self.cache_config.remote.read
             && let Some(http) = self.get_http_cache()
-            && let Ok(Some((CacheHitMetadata { source, time_saved }, files))) =
-                http.fetch(key).await
+            && let Ok(Some((hit_metadata, files))) = http.fetch(key).await
         {
             // Store this into fs cache. We can ignore errors here because we know
             // we have previously successfully stored in HTTP cache, and so the overall
@@ -179,10 +178,10 @@ impl CacheMultiplexer {
             if self.cache_config.local.write
                 && let Some(fs) = &self.fs
             {
-                let _ = fs.put(anchor, key, &files, time_saved);
+                let _ = fs.put(anchor, key, &files, hit_metadata.time_saved);
             }
 
-            return Ok(Some((CacheHitMetadata { source, time_saved }, files)));
+            return Ok(Some((hit_metadata, files)));
         }
 
         Ok(None)

--- a/crates/turborepo-run-cache/src/lib.rs
+++ b/crates/turborepo-run-cache/src/lib.rs
@@ -418,6 +418,8 @@ impl TaskCache {
             Some(CacheHitMetadata {
                 source: CacheSource::Local,
                 time_saved: 0,
+                sha: None,
+                dirty_hash: None,
             })
         };
 

--- a/crates/turborepo-run-summary/src/task.rs
+++ b/crates/turborepo-run-summary/src/task.rs
@@ -43,6 +43,12 @@ pub struct TaskCacheSummary {
     source: Option<CacheSource>,
     // 0 if a cache miss
     time_saved: u64,
+    /// The HEAD commit SHA that produced the cache entry, if available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sha: Option<String>,
+    /// A hash of uncommitted changes when the cache entry was produced.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dirty_hash: Option<String>,
 }
 
 #[derive(Debug, Serialize, Copy, Clone)]
@@ -166,6 +172,8 @@ impl TaskCacheSummary {
             status: CacheStatus::Miss,
             time_saved: 0,
             source: None,
+            sha: None,
+            dirty_hash: None,
         }
     }
 }
@@ -173,8 +181,8 @@ impl TaskCacheSummary {
 impl From<Option<CacheHitMetadata>> for TaskCacheSummary {
     fn from(response: Option<CacheHitMetadata>) -> Self {
         match response {
-            Some(CacheHitMetadata { source, time_saved }) => {
-                let source = CacheSource::from(source);
+            Some(cache_hit) => {
+                let source = CacheSource::from(cache_hit.source);
                 // Assign these deprecated fields Local and Remote based on the information
                 // available in the itemStatus. Note that these fields are
                 // problematic, because an ItemStatus isn't always the composite
@@ -192,7 +200,9 @@ impl From<Option<CacheHitMetadata>> for TaskCacheSummary {
                     remote,
                     status: CacheStatus::Hit,
                     source: Some(source),
-                    time_saved,
+                    time_saved: cache_hit.time_saved,
+                    sha: cache_hit.sha,
+                    dirty_hash: cache_hit.dirty_hash,
                 }
             }
             None => Self::cache_miss(),
@@ -215,6 +225,8 @@ impl From<Option<HashTrackerCacheHitMetadata>> for TaskCacheSummary {
                     status: CacheStatus::Hit,
                     source: Some(source),
                     time_saved: metadata.time_saved,
+                    sha: metadata.sha,
+                    dirty_hash: metadata.dirty_hash,
                 }
             }
             None => Self::cache_miss(),
@@ -447,6 +459,8 @@ mod test {
             status: CacheStatus::Hit,
             source: Some(CacheSource::Local),
             time_saved: 6,
+            sha: None,
+            dirty_hash: None,
         },
         serde_json::json!({
                 "local": true,
@@ -456,6 +470,27 @@ mod test {
                 "timeSaved": 6,
             })
         ; "local cache hit"
+    )]
+    #[test_case(
+        TaskCacheSummary {
+            local: true,
+            remote: false,
+            status: CacheStatus::Hit,
+            source: Some(CacheSource::Local),
+            time_saved: 6,
+            sha: Some("abc123".to_string()),
+            dirty_hash: Some("def456".to_string()),
+        },
+        serde_json::json!({
+                "local": true,
+                "remote": false,
+                "status": "HIT",
+                "source": "LOCAL",
+                "timeSaved": 6,
+                "sha": "abc123",
+                "dirtyHash": "def456",
+            })
+        ; "local cache hit with scm state"
     )]
     #[test_case(
         TaskSummaryTaskDefinition {

--- a/crates/turborepo-task-hash/src/lib.rs
+++ b/crates/turborepo-task-hash/src/lib.rs
@@ -651,7 +651,7 @@ impl TaskHashTracker {
 
     pub fn cache_status(&self, task_id: &TaskId) -> Option<CacheHitMetadata> {
         let state = self.state.read().expect("hash tracker rwlock poisoned");
-        state.package_task_cache.get(task_id).copied()
+        state.package_task_cache.get(task_id).cloned()
     }
 
     pub fn insert_cache_status(&self, task_id: TaskId<'static>, cache_status: CacheHitMetadata) {
@@ -693,6 +693,8 @@ impl HashTrackerInfo for TaskHashTracker {
                 local,
                 remote,
                 time_saved: status.time_saved,
+                sha: status.sha,
+                dirty_hash: status.dirty_hash,
             }
         })
     }

--- a/crates/turborepo-types/src/lib.rs
+++ b/crates/turborepo-types/src/lib.rs
@@ -1096,6 +1096,10 @@ pub struct HashTrackerCacheHitMetadata {
     pub remote: bool,
     /// Time saved by the cache hit in milliseconds
     pub time_saved: u64,
+    /// The HEAD commit SHA that produced this cache entry
+    pub sha: Option<String>,
+    /// A hash of uncommitted changes when this cache entry was produced
+    pub dirty_hash: Option<String>,
 }
 
 /// Trait for types that provide task definition information needed for hashing.


### PR DESCRIPTION
## Summary
- Threads `sha` and `dirtyHash` from cache `-meta.json` sidecars through to the Run Summary output (`.turbo/runs/*.json`)
- On a cache hit, the task's `cache` object now includes `sha` and `dirtyHash` fields (omitted when null), enabling consumers to trace which commit produced a cached result
- Builds on #12288 which added these fields to the cache metadata sidecar

## Test plan
- [x] `cargo check` passes
- [x] Unit tests pass (`cargo test -p turborepo-run-summary -- task::test`)
- [x] New serialization test verifies `sha` and `dirtyHash` appear in JSON output
- [ ] Build turbo, run a task twice (miss then hit), inspect `.turbo/runs/*.json` to verify `sha`/`dirtyHash` appear in the `cache` object on the second run

🤖 Generated with [Claude Code](https://claude.com/claude-code)