### PR TITLE
feat: Add TuiSink to route log events into the TUI

### DIFF
--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -6,7 +6,7 @@ use turborepo_log::{sinks::collector::CollectorSink, Logger};
 use turborepo_query_api::QueryServer;
 use turborepo_signals::{listeners::get_signal, SignalHandler};
 use turborepo_telemetry::events::command::CommandEventBuilder;
-use turborepo_ui::{sender::UISender, TerminalSink};
+use turborepo_ui::{sender::UISender, TerminalSink, TuiSink};
 
 use crate::{commands::CommandBase, run, run::builder::RunBuilder};
 
@@ -21,8 +21,13 @@ pub async fn run(
     let handler = SignalHandler::new(signal);
 
     let collector = Arc::new(CollectorSink::new());
-    let terminal = TerminalSink::new(base.color_config);
-    let _ = turborepo_log::init(Logger::new(vec![Box::new(collector), Box::new(terminal)]));
+    let terminal = Arc::new(TerminalSink::new(base.color_config));
+    let tui_sink = Arc::new(TuiSink::new());
+    let _ = turborepo_log::init(Logger::new(vec![
+        Box::new(collector),
+        Box::new(terminal.clone()),
+        Box::new(tui_sink.clone()),
+    ]));
 
     let mut run_builder = {
         let _span = tracing::info_span!("run_builder_new").entered();
@@ -42,6 +47,11 @@ pub async fn run(
             let _span = tracing::info_span!("start_ui").entered();
             run.start_ui()?.unzip()
         };
+
+        if let Some(UISender::Tui(ref tui_sender)) = sender {
+            tui_sink.connect(tui_sender.clone());
+            terminal.disable();
+        }
 
         let result = run.run(sender.clone(), false).await;
 

--- a/crates/turborepo-ui/src/lib.rs
+++ b/crates/turborepo-ui/src/lib.rs
@@ -12,6 +12,7 @@ mod prefixed;
 pub mod sender;
 mod terminal_sink;
 pub mod tui;
+mod tui_sink;
 pub mod wui;
 
 use std::{borrow::Cow, env, f64::consts::PI, io::IsTerminal, sync::LazyLock, time::Duration};
@@ -28,6 +29,7 @@ pub use crate::{
     prefixed::{PrefixedUI, PrefixedWriter},
     terminal_sink::TerminalSink,
     tui::{TaskTable, TerminalPane, panic_handler::restore_terminal_on_panic},
+    tui_sink::TuiSink,
 };
 
 // Re-export documentation for panic handler integration:

--- a/crates/turborepo-ui/src/terminal_sink.rs
+++ b/crates/turborepo-ui/src/terminal_sink.rs
@@ -1,4 +1,7 @@
-use std::io::{self, Write};
+use std::{
+    io::{self, Write},
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use turborepo_log::{Level, LogEvent, LogSink};
 
@@ -9,18 +12,35 @@ use crate::ColorConfig;
 /// This is the primary sink for user-facing messages during `turbo run`.
 /// It formats events to stderr using the same color conventions as the
 /// rest of turborepo's terminal output.
+///
+/// When the TUI is active it owns the terminal, so stderr writes would
+/// corrupt the display. Call [`disable()`](Self::disable) to suppress
+/// output once the TUI takes over.
 pub struct TerminalSink {
     color_config: ColorConfig,
+    active: AtomicBool,
 }
 
 impl TerminalSink {
     pub fn new(color_config: ColorConfig) -> Self {
-        Self { color_config }
+        Self {
+            color_config,
+            active: AtomicBool::new(true),
+        }
+    }
+
+    /// Stop emitting to stderr. Intended to be called when the TUI
+    /// connects and takes ownership of the terminal.
+    pub fn disable(&self) {
+        self.active.store(false, Ordering::Relaxed);
     }
 }
 
 impl LogSink for TerminalSink {
     fn emit(&self, event: &LogEvent) {
+        if !self.active.load(Ordering::Relaxed) {
+            return;
+        }
         let stderr = io::stderr();
         let mut handle = stderr.lock();
 
@@ -95,5 +115,28 @@ mod tests {
         let handle = logger.handle(Source::turbo("test"));
         handle.warn("no color here").emit();
         assert_eq!(collector.events().len(), 1);
+    }
+
+    #[test]
+    fn disable_suppresses_emit() {
+        // TerminalSink behind Arc so disable() and emit() share the same AtomicBool.
+        let sink = Arc::new(TerminalSink::new(ColorConfig::new(true)));
+        let collector = Arc::new(CollectorSink::new());
+        let logger = Arc::new(Logger::new(vec![
+            Box::new(sink.clone()),
+            Box::new(collector.clone()),
+        ]));
+
+        let handle = logger.handle(Source::turbo("test"));
+        handle.warn("before disable").emit();
+
+        sink.disable();
+        // This event still reaches the collector (it's a separate sink)
+        // but TerminalSink should skip its stderr write.
+        handle.warn("after disable").emit();
+
+        // Both events reached the collector, confirming the logger still
+        // dispatches. TerminalSink's disable only affects its own output.
+        assert_eq!(collector.events().len(), 2);
     }
 }

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -65,6 +65,7 @@ pub struct App<W> {
     preferences: PreferenceLoader,
     scrollback_len: u64,
     scroll_momentum: ScrollMomentum,
+    log_events: Vec<turborepo_log::LogEvent>,
 }
 
 impl<W> App<W> {
@@ -121,6 +122,7 @@ impl<W> App<W> {
             preferences,
             scrollback_len,
             scroll_momentum: ScrollMomentum::new(),
+            log_events: Vec::new(),
         }
     }
 
@@ -1042,6 +1044,9 @@ fn update(
     event: Event,
 ) -> Result<Option<oneshot::Sender<()>>, Error> {
     match event {
+        Event::LogEvent(log_event) => {
+            app.log_events.push(log_event);
+        }
         Event::StartTask { task, output_logs } => {
             app.start_task(&task, output_logs)?;
         }
@@ -2549,6 +2554,36 @@ mod test {
             !app.done,
             "app must not be done after a watch run completes — it waits for file changes"
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_log_event_reaches_app() -> Result<(), Error> {
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())
+            .expect("Failed to create AbsoluteSystemPathBuf");
+
+        let mut app: App<Box<dyn io::Write + Send>> = App::new(
+            100,
+            100,
+            vec!["a".to_string()],
+            PreferenceLoader::new(&repo_root),
+            2048,
+        );
+
+        assert!(app.log_events.is_empty());
+
+        let event = turborepo_log::LogEvent::new(
+            turborepo_log::Level::Warn,
+            turborepo_log::Source::turbo("scm"),
+            "something went wrong",
+        );
+        update(&mut app, Event::LogEvent(event))?;
+
+        assert_eq!(app.log_events.len(), 1);
+        assert_eq!(app.log_events[0].message(), "something went wrong");
+        assert_eq!(app.log_events[0].level(), turborepo_log::Level::Warn);
 
         Ok(())
     }

--- a/crates/turborepo-ui/src/tui/event.rs
+++ b/crates/turborepo-ui/src/tui/event.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 use tokio::sync::oneshot;
 
 pub enum Event {
+    LogEvent(turborepo_log::LogEvent),
     StartTask {
         task: String,
         output_logs: OutputLogs,

--- a/crates/turborepo-ui/src/tui/handle.rs
+++ b/crates/turborepo-ui/src/tui/handle.rs
@@ -47,6 +47,17 @@ impl TuiSender {
 }
 
 impl TuiSender {
+    /// Test-only constructor that wraps an existing channel sender
+    /// without spawning a tick task.
+    #[cfg(test)]
+    pub(crate) fn new_for_test(sender: mpsc::UnboundedSender<Event>) -> Self {
+        Self { primary: sender }
+    }
+
+    pub fn log_event(&self, event: turborepo_log::LogEvent) {
+        self.primary.send(Event::LogEvent(event)).ok();
+    }
+
     pub fn start_task(&self, task: String, output_logs: OutputLogs) {
         self.primary
             .send(Event::StartTask { task, output_logs })

--- a/crates/turborepo-ui/src/tui_sink.rs
+++ b/crates/turborepo-ui/src/tui_sink.rs
@@ -1,0 +1,142 @@
+use std::sync::Mutex;
+
+use turborepo_log::{LogEvent, LogSink};
+
+use crate::tui::TuiSender;
+
+/// Routes [`LogEvent`]s into the TUI's event channel.
+///
+/// Created before the TUI starts, so it buffers events until
+/// [`connect()`](Self::connect) is called with a live [`TuiSender`].
+/// Buffered events are drained through the sender on connect.
+///
+/// If the TUI never starts (stream mode, terminal too small), the
+/// buffer is simply unused.
+pub struct TuiSink {
+    state: Mutex<SinkState>,
+}
+
+enum SinkState {
+    Buffering(Vec<LogEvent>),
+    Connected(TuiSender),
+}
+
+impl Default for TuiSink {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TuiSink {
+    pub fn new() -> Self {
+        Self {
+            state: Mutex::new(SinkState::Buffering(Vec::new())),
+        }
+    }
+
+    /// Transition from buffering to connected. Drains all buffered
+    /// events through the sender, then forwards directly from here on.
+    pub fn connect(&self, sender: TuiSender) {
+        let mut state = self.state.lock().unwrap();
+        if let SinkState::Buffering(buffer) = &mut *state {
+            for event in buffer.drain(..) {
+                sender.log_event(event);
+            }
+        }
+        *state = SinkState::Connected(sender);
+    }
+}
+
+impl LogSink for TuiSink {
+    fn emit(&self, event: &LogEvent) {
+        let mut state = self.state.lock().unwrap();
+        match &mut *state {
+            SinkState::Buffering(buffer) => buffer.push(event.clone()),
+            SinkState::Connected(sender) => {
+                sender.log_event(event.clone());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tokio::sync::mpsc;
+    use turborepo_log::{Level, LogEvent, Source};
+
+    use super::*;
+    use crate::tui::event::Event;
+
+    fn make_event(msg: &str) -> LogEvent {
+        LogEvent::new(Level::Warn, Source::turbo("test"), msg)
+    }
+
+    fn make_tui_sender() -> (TuiSender, mpsc::UnboundedReceiver<Event>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (TuiSender::new_for_test(tx), rx)
+    }
+
+    #[test]
+    fn buffers_events_before_connect() {
+        let sink = TuiSink::new();
+        sink.emit(&make_event("first"));
+        sink.emit(&make_event("second"));
+
+        let state = sink.state.lock().unwrap();
+        match &*state {
+            SinkState::Buffering(buf) => {
+                assert_eq!(buf.len(), 2);
+                assert_eq!(buf[0].message(), "first");
+                assert_eq!(buf[1].message(), "second");
+            }
+            SinkState::Connected(_) => panic!("expected Buffering state"),
+        }
+    }
+
+    #[test]
+    fn connect_drains_buffer() {
+        let sink = TuiSink::new();
+        sink.emit(&make_event("buffered"));
+
+        let (sender, mut rx) = make_tui_sender();
+        sink.connect(sender);
+
+        let event = rx.try_recv().expect("should have drained buffered event");
+        match event {
+            Event::LogEvent(e) => assert_eq!(e.message(), "buffered"),
+            _ => panic!("expected LogEvent"),
+        }
+    }
+
+    #[test]
+    fn forwards_after_connect() {
+        let sink = TuiSink::new();
+        let (sender, mut rx) = make_tui_sender();
+        sink.connect(sender);
+
+        sink.emit(&make_event("live"));
+
+        let event = rx.try_recv().expect("should have forwarded event");
+        match event {
+            Event::LogEvent(e) => assert_eq!(e.message(), "live"),
+            _ => panic!("expected LogEvent"),
+        }
+    }
+
+    #[test]
+    fn works_behind_arc() {
+        let sink = Arc::new(TuiSink::new());
+        sink.emit(&make_event("arc event"));
+
+        let (sender, mut rx) = make_tui_sender();
+        sink.connect(sender);
+
+        let event = rx.try_recv().expect("should have drained");
+        match event {
+            Event::LogEvent(e) => assert_eq!(e.message(), "arc event"),
+            _ => panic!("expected LogEvent"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `TuiSink` — a log sink that buffers events before the TUI starts, then drains them into the TUI's event channel on connect
- Adds `TerminalSink::disable()` so stderr writes stop once the TUI owns the alternate screen
- Wires both up in `commands/run.rs`: after `start_ui()`, if TUI mode is active, connect the sink and disable the terminal

## Context

`TerminalSink` writes to stderr, but the TUI takes over the alternate screen — making those writes invisible. Events emitted *before* `start_ui()` (like the `--affected` SCM warning) also get hidden when the TUI starts.

`TuiSink` solves this with a two-phase approach: buffer events while the TUI channel doesn't exist, drain the buffer on connect, then forward directly. All three sinks (`CollectorSink`, `TerminalSink`, `TuiSink`) are always registered. If the TUI never starts (stream mode, terminal too small), `TerminalSink` stays active and `TuiSink`'s buffer is unused.

Log events land in `App.log_events` but aren't rendered yet — this PR is purely plumbing.

## Testing

- `TuiSink` unit tests: buffering, drain on connect, post-connect forwarding, `Arc` compatibility
- `TerminalSink::disable()` test: disabled sink stops writing while other sinks continue
- `App` integration test: `Event::LogEvent` flows through `update()` and lands in `app.log_events`
- Manual verification: temporarily emitted a test warning, confirmed `[TuiSink proof]` output after TUI exit