### PR TITLE
fix: Resolve git diff warning in fresh repos and make SCM state lazy

### DIFF
--- a/crates/turborepo-cache/src/async_cache.rs
+++ b/crates/turborepo-cache/src/async_cache.rs
@@ -8,7 +8,7 @@ use turborepo_analytics::AnalyticsSender;
 use turborepo_api_client::{APIAuth, APIClient};
 
 use crate::{
-    CacheError, CacheHitMetadata, CacheOpts, CacheScmState, http::UploadMap,
+    CacheError, CacheHitMetadata, CacheOpts, LazyScmState, http::UploadMap,
     multiplexer::CacheMultiplexer,
 };
 
@@ -41,7 +41,7 @@ impl AsyncCache {
         api_client: Option<APIClient>,
         api_auth: Option<APIAuth>,
         analytics_recorder: Option<AnalyticsSender>,
-        scm_state: Option<CacheScmState>,
+        scm_state: LazyScmState,
     ) -> Result<AsyncCache, CacheError> {
         let max_workers = opts.workers.try_into().expect("usize is smaller than u32");
         let real_cache = Arc::new(CacheMultiplexer::new(
@@ -236,7 +236,7 @@ mod tests {
 
     use crate::{
         AsyncCache, CacheActions, CacheConfig, CacheHitMetadata, CacheOpts, CacheSource,
-        RemoteCacheOpts,
+        LazyScmState, RemoteCacheOpts,
         test_cases::{TestCase, get_test_cases},
     };
 
@@ -307,7 +307,7 @@ mod tests {
             Some(api_client),
             api_auth,
             None,
-            None,
+            LazyScmState::new(),
         )?;
 
         // Ensure that the cache is empty
@@ -393,7 +393,14 @@ mod tests {
             token: SecretString::new("my-token".to_string()),
             team_slug: None,
         });
-        let async_cache = AsyncCache::new(&opts, &repo_root_path, None, api_auth, None, None)?;
+        let async_cache = AsyncCache::new(
+            &opts,
+            &repo_root_path,
+            None,
+            api_auth,
+            None,
+            LazyScmState::new(),
+        )?;
 
         // Ensure that the cache is empty
         let response = async_cache.exists(&hash).await;
@@ -487,7 +494,14 @@ mod tests {
             token: SecretString::new("my-token".to_string()),
             team_slug: None,
         });
-        let async_cache = AsyncCache::new(&opts, &repo_root_path, None, api_auth, None, None)?;
+        let async_cache = AsyncCache::new(
+            &opts,
+            &repo_root_path,
+            None,
+            api_auth,
+            None,
+            LazyScmState::new(),
+        )?;
 
         assert_matches!(async_cache.exists(&hash).await, Ok(None));
 
@@ -566,7 +580,7 @@ mod tests {
             Some(api_client),
             api_auth,
             None,
-            None,
+            LazyScmState::new(),
         )?;
 
         // Ensure that the cache is empty

--- a/crates/turborepo-cache/src/fs.rs
+++ b/crates/turborepo-cache/src/fs.rs
@@ -8,14 +8,14 @@ use turborepo_analytics::AnalyticsSender;
 use turborepo_api_client::{analytics, analytics::AnalyticsEvent};
 
 use crate::{
-    CacheError, CacheHitMetadata, CacheScmState, CacheSource,
+    CacheError, CacheHitMetadata, CacheSource, LazyScmState,
     cache_archive::{CacheReader, CacheWriter},
 };
 
 pub struct FSCache {
     cache_directory: AbsoluteSystemPathBuf,
     analytics_recorder: Option<AnalyticsSender>,
-    scm_state: Option<CacheScmState>,
+    scm_state: LazyScmState,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -48,7 +48,7 @@ impl FSCache {
         cache_dir: &Utf8Path,
         repo_root: &AbsoluteSystemPath,
         analytics_recorder: Option<AnalyticsSender>,
-        scm_state: Option<CacheScmState>,
+        scm_state: LazyScmState,
     ) -> Result<Self, CacheError> {
         debug!(
             "FSCache::new called with cache_dir={}, repo_root={}",
@@ -237,11 +237,12 @@ impl FSCache {
             .cache_directory
             .join_component(&format!("{hash}-meta.json"));
 
+        let resolved = self.scm_state.get();
         let meta = CacheMetadata {
             hash: hash.to_string(),
             duration,
-            sha: self.scm_state.as_ref().and_then(|s| s.sha.clone()),
-            dirty_hash: self.scm_state.as_ref().and_then(|s| s.dirty_hash.clone()),
+            sha: resolved.and_then(|s| s.sha.clone()),
+            dirty_hash: resolved.and_then(|s| s.dirty_hash.clone()),
         };
 
         let meta_json = serde_json::to_string(&meta)
@@ -272,7 +273,10 @@ mod test {
     use turborepo_vercel_api_mock::start_test_server;
 
     use super::*;
-    use crate::test_cases::{TestCase, get_test_cases, validate_analytics};
+    use crate::{
+        CacheScmState,
+        test_cases::{TestCase, get_test_cases, validate_analytics},
+    };
 
     #[tokio::test]
     async fn test_fs_cache() -> Result<()> {
@@ -322,7 +326,7 @@ mod test {
             Utf8Path::new(""),
             repo_root_path,
             Some(analytics_sender.clone()),
-            None,
+            LazyScmState::new(),
         )?;
 
         let expected_miss = cache.fetch(repo_root_path, test_case.hash)?;
@@ -380,9 +384,24 @@ mod test {
         let duration = 100;
 
         // Create multiple caches pointing to the same directory
-        let cache1 = FSCache::new(Utf8Path::new("cache"), repo_root_path, None, None)?;
-        let cache2 = FSCache::new(Utf8Path::new("cache"), repo_root_path, None, None)?;
-        let cache3 = FSCache::new(Utf8Path::new("cache"), repo_root_path, None, None)?;
+        let cache1 = FSCache::new(
+            Utf8Path::new("cache"),
+            repo_root_path,
+            None,
+            LazyScmState::new(),
+        )?;
+        let cache2 = FSCache::new(
+            Utf8Path::new("cache"),
+            repo_root_path,
+            None,
+            LazyScmState::new(),
+        )?;
+        let cache3 = FSCache::new(
+            Utf8Path::new("cache"),
+            repo_root_path,
+            None,
+            LazyScmState::new(),
+        )?;
 
         // Perform concurrent writes
         let handle1 = {
@@ -407,7 +426,12 @@ mod test {
         let _ = handle3.await?;
 
         // The cache should be readable
-        let cache = FSCache::new(Utf8Path::new("cache"), repo_root_path, None, None)?;
+        let cache = FSCache::new(
+            Utf8Path::new("cache"),
+            repo_root_path,
+            None,
+            LazyScmState::new(),
+        )?;
         let result = cache.fetch(repo_root_path, hash)?;
         assert!(
             result.is_some(),
@@ -434,15 +458,30 @@ mod test {
         let duration = 100;
 
         // First write to establish the cache
-        let cache = FSCache::new(Utf8Path::new("cache"), repo_root_path, None, None)?;
+        let cache = FSCache::new(
+            Utf8Path::new("cache"),
+            repo_root_path,
+            None,
+            LazyScmState::new(),
+        )?;
         cache.put(repo_root_path, hash, &files, duration)?;
 
         // Update the source file
         test_file.create_with_contents("updated content")?;
 
         // Perform concurrent read and write
-        let cache_write = FSCache::new(Utf8Path::new("cache"), repo_root_path, None, None)?;
-        let cache_read = FSCache::new(Utf8Path::new("cache"), repo_root_path, None, None)?;
+        let cache_write = FSCache::new(
+            Utf8Path::new("cache"),
+            repo_root_path,
+            None,
+            LazyScmState::new(),
+        )?;
+        let cache_read = FSCache::new(
+            Utf8Path::new("cache"),
+            repo_root_path,
+            None,
+            LazyScmState::new(),
+        )?;
 
         let write_handle = {
             let files = files.clone();
@@ -484,13 +523,23 @@ mod test {
         let duration = 100;
 
         // Write to cache first
-        let cache = FSCache::new(Utf8Path::new("cache"), repo_root_path, None, None)?;
+        let cache = FSCache::new(
+            Utf8Path::new("cache"),
+            repo_root_path,
+            None,
+            LazyScmState::new(),
+        )?;
         cache.put(repo_root_path, hash, &files, duration)?;
 
         // Perform concurrent reads
         let mut handles = Vec::new();
         for _ in 0..10 {
-            let cache = FSCache::new(Utf8Path::new("cache"), repo_root_path, None, None)?;
+            let cache = FSCache::new(
+                Utf8Path::new("cache"),
+                repo_root_path,
+                None,
+                LazyScmState::new(),
+            )?;
             let repo_root = repo_root_path.to_owned();
             handles.push(tokio::spawn(async move { cache.fetch(&repo_root, hash) }));
         }
@@ -521,9 +570,24 @@ mod test {
         let duration = 100;
 
         // Perform concurrent writes
-        let cache1 = FSCache::new(Utf8Path::new("cache"), repo_root_path, None, None)?;
-        let cache2 = FSCache::new(Utf8Path::new("cache"), repo_root_path, None, None)?;
-        let cache3 = FSCache::new(Utf8Path::new("cache"), repo_root_path, None, None)?;
+        let cache1 = FSCache::new(
+            Utf8Path::new("cache"),
+            repo_root_path,
+            None,
+            LazyScmState::new(),
+        )?;
+        let cache2 = FSCache::new(
+            Utf8Path::new("cache"),
+            repo_root_path,
+            None,
+            LazyScmState::new(),
+        )?;
+        let cache3 = FSCache::new(
+            Utf8Path::new("cache"),
+            repo_root_path,
+            None,
+            LazyScmState::new(),
+        )?;
 
         let handle1 = {
             let files = files.clone();
@@ -584,10 +648,10 @@ mod test {
         let test_file = repo_root_path.join_component("test.txt");
         test_file.create_with_contents("content")?;
 
-        let scm_state = Some(CacheScmState {
+        let scm_state = LazyScmState::resolved(Some(CacheScmState {
             sha: Some("abc123def456".to_string()),
             dirty_hash: Some("fedcba654321".to_string()),
-        });
+        }));
         let cache = FSCache::new(Utf8Path::new("cache"), repo_root_path, None, scm_state)?;
         let files = vec![AnchoredSystemPathBuf::from_raw("test.txt")?];
         cache.put(repo_root_path, "scm-test-hash", &files, 42)?;
@@ -612,7 +676,12 @@ mod test {
         let test_file = repo_root_path.join_component("test.txt");
         test_file.create_with_contents("content")?;
 
-        let cache = FSCache::new(Utf8Path::new("cache"), repo_root_path, None, None)?;
+        let cache = FSCache::new(
+            Utf8Path::new("cache"),
+            repo_root_path,
+            None,
+            LazyScmState::new(),
+        )?;
         let files = vec![AnchoredSystemPathBuf::from_raw("test.txt")?];
         cache.put(repo_root_path, "no-scm-hash", &files, 10)?;
 

--- a/crates/turborepo-cache/src/lib.rs
+++ b/crates/turborepo-cache/src/lib.rs
@@ -30,7 +30,11 @@ pub mod signature_authentication;
 mod test_cases;
 mod upload_progress;
 
-use std::{backtrace, backtrace::Backtrace};
+use std::{
+    backtrace,
+    backtrace::Backtrace,
+    sync::{Arc, OnceLock},
+};
 
 pub use async_cache::AsyncCache;
 use camino::Utf8PathBuf;
@@ -111,9 +115,6 @@ impl From<turborepo_api_client::Error> for CacheError {
 /// can be traced back to the commit (and working-tree state) that
 /// produced them.
 ///
-/// Because this is a snapshot from run start, it may become stale for
-/// tasks that execute later in a long-running build.
-///
 /// Currently only written to the local filesystem cache's `-meta.json`
 /// sidecar. Remote cache entries do not include SCM state.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -124,6 +125,46 @@ pub struct CacheScmState {
     /// and untracked files). `None` when the working tree is clean or
     /// when git is unavailable.
     pub dirty_hash: Option<String>,
+}
+
+/// SCM state that is computed in the background and resolved lazily.
+///
+/// Git operations (rev-parse, status, diff) are spawned at run start but
+/// the cache no longer blocks on them. `get()` returns the resolved state
+/// if the background work has finished, or `None` if it hasn't yet. This
+/// keeps git subprocesses off the critical startup path.
+#[derive(Debug, Clone)]
+pub struct LazyScmState(Arc<OnceLock<Option<CacheScmState>>>);
+
+impl LazyScmState {
+    pub fn new() -> Self {
+        Self(Arc::new(OnceLock::new()))
+    }
+
+    /// Create an already-resolved instance (useful in tests).
+    pub fn resolved(state: Option<CacheScmState>) -> Self {
+        let lock = OnceLock::new();
+        let _ = lock.set(state);
+        Self(Arc::new(lock))
+    }
+
+    /// Set the resolved value. No-op if already set.
+    pub fn resolve(&self, state: Option<CacheScmState>) {
+        let _ = self.0.set(state);
+    }
+
+    /// Returns the SCM state if the background computation has finished
+    /// and produced a value. Returns `None` if still pending or if git
+    /// was unavailable.
+    pub fn get(&self) -> Option<&CacheScmState> {
+        self.0.get().and_then(|s| s.as_ref())
+    }
+}
+
+impl Default for LazyScmState {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Copy)]

--- a/crates/turborepo-cache/src/multiplexer.rs
+++ b/crates/turborepo-cache/src/multiplexer.rs
@@ -9,7 +9,7 @@ use turborepo_analytics::AnalyticsSender;
 use turborepo_api_client::{APIAuth, APIClient};
 
 use crate::{
-    CacheConfig, CacheError, CacheHitMetadata, CacheOpts, CacheScmState,
+    CacheConfig, CacheError, CacheHitMetadata, CacheOpts, LazyScmState,
     fs::FSCache,
     http::{HTTPCache, UploadMap},
 };
@@ -36,7 +36,7 @@ impl CacheMultiplexer {
         api_client: Option<APIClient>,
         api_auth: Option<APIAuth>,
         analytics_recorder: Option<AnalyticsSender>,
-        scm_state: Option<CacheScmState>,
+        scm_state: LazyScmState,
     ) -> Result<Self, CacheError> {
         let use_fs_cache = opts.cache.local.should_use();
         let use_http_cache = opts.cache.remote.should_use();

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -10,7 +10,7 @@ use tracing::Instrument;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, RelativeUnixPathBuf};
 use turborepo_analytics::{start_analytics, AnalyticsHandle};
 use turborepo_api_client::{APIAuth, APIClient, SharedHttpClient};
-use turborepo_cache::{AsyncCache, CacheScmState};
+use turborepo_cache::{AsyncCache, CacheScmState, LazyScmState};
 use turborepo_env::EnvironmentVariableMap;
 use turborepo_errors::Spanned;
 use turborepo_process::ProcessManager;
@@ -443,24 +443,26 @@ impl RunBuilder {
             })
             .unzip();
 
-        let scm_state_task = {
+        let scm_state = LazyScmState::new();
+        {
+            let scm_state = scm_state.clone();
             let scm = scm.clone();
             let repo_root = self.repo_root.clone();
             tokio::task::spawn_blocking(move || {
                 let _span = tracing::info_span!("capture_scm_state").entered();
                 let sha = scm.get_current_sha(&repo_root).ok();
                 let dirty_hash = scm.get_dirty_hash();
-                if sha.is_some() || dirty_hash.is_some() {
+                let state = if sha.is_some() || dirty_hash.is_some() {
                     Some(CacheScmState { sha, dirty_hash })
                 } else {
                     None
-                }
-            })
-        };
+                };
+                scm_state.resolve(state);
+            });
+        }
 
         let async_cache = {
             let _span = tracing::info_span!("async_cache_new").entered();
-            let scm_state = scm_state_task.await.expect("scm state capture panicked");
             AsyncCache::new(
                 &self.opts.cache_opts,
                 &self.repo_root,

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -218,8 +218,6 @@ impl GitRepo {
     /// Note: content of untracked files (not yet `git add`ed) is not included
     /// in the diff — only their filenames from `git status` contribute.
     fn get_dirty_hash(&self) -> Option<String> {
-        use std::{io::Read, process::Stdio};
-
         use sha2::{Digest, Sha256};
 
         let status_output = match self.execute_git_command(&["status", "--porcelain", "-z"], "") {
@@ -237,45 +235,55 @@ impl GitRepo {
         let mut hasher = Sha256::new();
         hasher.update(&status_output);
 
-        // Stream `git diff HEAD` through the hasher instead of buffering the
-        // entire output. --no-ext-diff prevents external diff drivers from
-        // producing non-deterministic output, --no-color ensures consistent
-        // formatting regardless of git config.
-        match Command::new(self.bin.as_std_path())
-            .args(["diff", "HEAD", "--no-ext-diff", "--no-color"])
+        // Try `git diff HEAD` first. In a freshly initialized repo with no
+        // commits, HEAD doesn't exist and git exits with code 128. Fall back
+        // to `git diff --cached` which diffs the index against an empty tree,
+        // correctly capturing staged file content without needing HEAD.
+        if !self.stream_diff_into_hasher(
+            &["diff", "HEAD", "--no-ext-diff", "--no-color"],
+            &mut hasher,
+        ) && !self.stream_diff_into_hasher(
+            &["diff", "--cached", "--no-ext-diff", "--no-color"],
+            &mut hasher,
+        ) {
+            warn!("failed to run git diff for dirty hash");
+        }
+
+        Some(hex::encode(hasher.finalize()))
+    }
+
+    /// Spawn a git diff subprocess, streaming its stdout into `hasher`.
+    /// Returns `true` if the command exited successfully.
+    fn stream_diff_into_hasher(&self, args: &[&str], hasher: &mut sha2::Sha256) -> bool {
+        use std::{io::Read, process::Stdio};
+
+        use sha2::Digest;
+
+        let mut child = match Command::new(self.bin.as_std_path())
+            .args(args)
             .current_dir(&self.root)
             .env("GIT_OPTIONAL_LOCKS", "0")
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
             .spawn()
         {
-            Ok(mut child) => {
-                if let Some(stdout) = child.stdout.take() {
-                    let mut reader = std::io::BufReader::new(stdout);
-                    let mut buf = [0u8; 65536];
-                    loop {
-                        match reader.read(&mut buf) {
-                            Ok(0) => break,
-                            Ok(n) => hasher.update(&buf[..n]),
-                            Err(e) => {
-                                warn!("error reading git diff output: {e}");
-                                break;
-                            }
-                        }
-                    }
+            Ok(child) => child,
+            Err(_) => return false,
+        };
+
+        if let Some(stdout) = child.stdout.take() {
+            let mut reader = std::io::BufReader::new(stdout);
+            let mut buf = [0u8; 65536];
+            loop {
+                match reader.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => hasher.update(&buf[..n]),
+                    Err(_) => break,
                 }
-                if let Ok(status) = child.wait()
-                    && !status.success()
-                {
-                    warn!("git diff exited with non-zero status: {status}");
-                }
-            }
-            Err(e) => {
-                warn!("failed to spawn git diff for dirty hash: {e}");
             }
         }
 
-        Some(hex::encode(hasher.finalize()))
+        child.wait().is_ok_and(|s| s.success())
     }
 
     /// for GitHub Actions environment variables, see: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
@@ -1587,5 +1595,39 @@ mod tests {
     #[test]
     fn test_dirty_hash_manual_scm_returns_none() {
         assert_eq!(SCM::Manual.get_dirty_hash(), None);
+    }
+
+    #[test]
+    fn test_dirty_hash_no_commits_untracked_file() {
+        let (repo_root, _repo_path) = setup_repository(None).unwrap();
+        fs::write(repo_root.path().join("new.txt"), "hello").unwrap();
+
+        let git_root = AbsoluteSystemPathBuf::try_from(repo_root.path()).unwrap();
+        let scm = SCM::new(&git_root);
+        assert!(
+            scm.get_dirty_hash().is_some(),
+            "fresh repo with untracked files should produce a dirty hash"
+        );
+    }
+
+    #[test]
+    fn test_dirty_hash_no_commits_staged_content_affects_hash() {
+        let (repo_root, _repo_path) = setup_repository(None).unwrap();
+        let file = repo_root.path().join("foo.txt");
+
+        fs::write(&file, "content A").unwrap();
+        run_git(repo_root.path(), &["add", "foo.txt"]);
+        let git_root = AbsoluteSystemPathBuf::try_from(repo_root.path()).unwrap();
+        let scm = SCM::new(&git_root);
+        let hash_a = scm.get_dirty_hash();
+
+        fs::write(&file, "content B").unwrap();
+        run_git(repo_root.path(), &["add", "foo.txt"]);
+        let hash_b = scm.get_dirty_hash();
+
+        assert_ne!(
+            hash_a, hash_b,
+            "different staged content in a fresh repo should produce different hashes"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Fixes the `WARNING  git diff exited with non-zero status: exit status: 128` that appears during `turbo watch` in freshly initialized Git repos (no commits yet)
- Moves git subprocess work off the critical run startup path by making `CacheScmState` lazy

## Problem

In a freshly initialized Git repo (zero commits), `git diff HEAD` fails with exit code 128 because HEAD doesn't exist yet. `get_dirty_hash()` was calling this unconditionally, producing a noisy warning on every watch cycle. The warning was harmless but alarming.

Separately, the `CacheScmState` (which is purely cache metadata, never affects cache keys or hit/miss logic) was blocking `AsyncCache` construction because the builder `.await`ed the git subprocess before proceeding.

## Changes

**`crates/turborepo-scm/src/git.rs`**
- `get_dirty_hash()` now tries `git diff HEAD` first and falls back to `git diff --cached` on failure. Zero overhead in the common case (HEAD exists), correct behavior in fresh repos.
- Extracted `stream_diff_into_hasher()` helper to avoid duplicating the spawn/pipe/read logic.
- Added tests for the fresh-repo edge case.

**`crates/turborepo-cache/src/lib.rs`**
- Added `LazyScmState` newtype wrapping `Arc<OnceLock<Option<CacheScmState>>>`. Git work starts eagerly in the background but the result is resolved non-blockingly at `FSCache::put()` time.

**`crates/turborepo-cache/src/{fs,multiplexer,async_cache}.rs`**
- Plumbed `LazyScmState` through the cache constructor chain.

**`crates/turborepo-lib/src/run/builder.rs`**
- The `spawn_blocking` git task now writes to a `LazyScmState` via `.resolve()` instead of being `.await`ed. `AsyncCache` construction proceeds immediately.

## Testing

- `cargo test --package turborepo-scm -- dirty_hash` (9 tests, including 2 new fresh-repo tests)
- `cargo test --package turborepo-cache -- fs::test` (9 tests)
- `cargo test --package turborepo-cache -- async_cache` (2 tests)