### PR TITLE
fix: Source cargo env in pre-push hook for Rust toolchain resolution

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,6 +1,9 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+# Ensure rustup-managed cargo is in PATH (not inherited in hook's sh environment)
+[ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
+
 pnpm exec lint-staged
 turbo run format
 


### PR DESCRIPTION
## Summary

- The pre-push hook runs in a bare `sh` environment that doesn't inherit the user's shell profile, so `~/.cargo/bin` may not be in `PATH`. When this happens, `cargo fmt` either isn't found or isn't the rustup proxy, meaning `rust-toolchain.toml` is ignored and the nightly-only `.rustfmt.toml` options (`imports_granularity`, `group_imports`, etc.) don't apply. This causes formatting to diverge from CI.
- Sources `$HOME/.cargo/env` (the standard file rustup creates on install) at the top of the hook so the rustup-managed `cargo` is always used and `rust-toolchain.toml` is respected.