### PR TITLE
fix: Infer monorepo root in LSP instead of trusting editor `root_uri`

### DIFF
--- a/crates/turborepo-lsp/src/lib.rs
+++ b/crates/turborepo-lsp/src/lib.rs
@@ -38,6 +38,7 @@ use turborepo_lib::{
 };
 use turborepo_repository::{
     discovery::{self, DiscoveryResponse, PackageDiscovery, WorkspaceData},
+    inference::RepoState,
     package_json::PackageJson,
 };
 
@@ -71,6 +72,15 @@ impl LanguageServer for Backend {
             // convert uri file:///absolute-path to AbsoluteSystemPathBuf
             let repo_root =
                 AbsoluteSystemPathBuf::new(repo_root).expect("file is always an absolute path");
+
+            // Walk up from the editor's root_uri to find the actual monorepo
+            // root. In multi-root VSCode workspaces the editor can send a
+            // subdirectory, which would cause the daemon to start with the
+            // wrong root and write cookie files in the wrong location.
+            let repo_root = match RepoState::infer(&repo_root) {
+                Ok(state) => state.root,
+                Err(_) => repo_root,
+            };
 
             self.repo_root
                 .lock()


### PR DESCRIPTION
## Summary

- Use `RepoState::infer` in the LSP's `initialize()` to walk up from the editor's `root_uri` and find the actual monorepo root, with a fallback to the raw path if inference fails

## Context

Closes #9126

The LSP blindly trusted the editor's `root_uri` as the repo root. In multi-root VSCode workspaces, the editor can send a subdirectory or the wrong project folder. The LSP then starts a daemon at that incorrect path, which writes cookie files (used for file watcher synchronization) to `<wrong_path>/.turbo/cookies/` — exactly the behavior reported in the issue.

The CLI already solves this with `RepoState::infer` (`turborepo-repository/src/inference.rs`), which walks up from a given directory looking for `package.json` + workspace configuration to find the monorepo root. The LSP simply wasn't using it.

## Testing

Open a multi-root VSCode workspace where the turborepo project is not the first folder. The daemon should now start with the correct repo root and cookie files should appear in `<monorepo_root>/.turbo/cookies/` instead of in a sibling project's directory.