### PR TITLE
fix: Flush stale mouse tracking events from stdin during TUI cleanup

### DIFF
--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -1031,6 +1031,22 @@ fn cleanup<B: Backend<Error = io::Error> + io::Write>(
     let tasks_started = app.tasks_by_status.tasks_started();
     app.persist_tasks(tasks_started)?;
     app.preferences.flush_to_disk().ok();
+
+    // Discard any stale mouse tracking events from stdin before re-enabling
+    // echo. There's a race between sending DisableMouseCapture to the terminal
+    // and the terminal actually stopping mouse event generation. Any events
+    // buffered in the kernel's input queue during that window would be echoed
+    // as raw escape sequences (e.g. ^[[<35;29;43M) once disable_raw_mode()
+    // restores canonical mode with echo.
+    #[cfg(unix)]
+    {
+        use std::os::unix::io::AsRawFd;
+        let _ = nix::sys::termios::tcflush(
+            std::io::stdin().as_raw_fd(),
+            nix::sys::termios::FlushArg::TCIFLUSH,
+        );
+    }
+
     crossterm::terminal::disable_raw_mode()?;
     terminal.show_cursor()?;
 

--- a/crates/turborepo-ui/src/tui/panic_handler.rs
+++ b/crates/turborepo-ui/src/tui/panic_handler.rs
@@ -91,6 +91,16 @@ pub fn restore_terminal_on_panic() -> bool {
 
     let _ = stdout.flush();
 
+    // Discard any stale mouse events from stdin before re-enabling echo.
+    #[cfg(unix)]
+    {
+        use std::os::unix::io::AsRawFd;
+        let _ = nix::sys::termios::tcflush(
+            std::io::stdin().as_raw_fd(),
+            nix::sys::termios::FlushArg::TCIFLUSH,
+        );
+    }
+
     // Disable raw mode - this is the one crossterm call we make, but it's
     // relatively safe as it just makes a tcsetattr syscall
     let _ = crossterm::terminal::disable_raw_mode();


### PR DESCRIPTION
## Summary

- Fixes raw SGR mouse escape sequences (`^[[<35;XX;YYM`) leaking to the terminal after the TUI exits

## Problem

When the TUI shuts down, there's a race between `DisableMouseCapture` (sent to stdout) and `disable_raw_mode()` (re-enables echo via `tcsetattr`). Mouse motion events generated in that window sit in the kernel's stdin buffer and get echoed as visible garbage once echo is restored. This is most noticeable when turbo runs inside git hooks (e.g. pre-push) where the user is likely moving the mouse during the run.

## Fix

Call `tcflush(stdin, TCIFLUSH)` right before `disable_raw_mode()` to discard any stale input. By this point, `DisableMouseCapture` was sent well before (during `persist_tasks`), so the terminal has had time to stop generating events.

Applied to both the normal `cleanup()` path and the `restore_terminal_on_panic()` path.