### PR TITLE
feat: Show richer remote cache status in run prelude

### DIFF
--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -24,6 +24,24 @@ use crate::{
     Args,
 };
 
+/// Why remote caching was disabled by local configuration.
+/// Determined during opts resolution — no network call required.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum RemoteCacheDisabledReason {
+    /// User never opted in: no token, no team.
+    NotLinked,
+    /// TURBO_TOKEN env var is set but no team is configured.
+    /// The token gets effectively ignored because `is_linked` returns false.
+    TokenWithoutTeam,
+    /// `remoteCache.enabled: false` in turbo.json.
+    InConfig,
+    /// `TURBO_REMOTE_CACHE_ENABLED=0` env var.
+    InEnvVar,
+    /// CLI flags (e.g. `--cache=local:rw`, or `--no-cache` + `--force`)
+    /// disabled both remote read and write.
+    ByFlags,
+}
+
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("Expected `run` command.")]
@@ -68,6 +86,9 @@ pub struct Opts {
     /// Pre-resolved git root from worktree detection, if available.
     /// Allows `SCM::new` to skip its own `git rev-parse` subprocess.
     pub git_root: Option<AbsoluteSystemPathBuf>,
+    /// If remote caching is disabled, this captures the reason.
+    /// `None` means remote caching is enabled (by local config).
+    pub remote_cache_disabled_reason: Option<RemoteCacheDisabledReason>,
 }
 
 impl Opts {
@@ -183,6 +204,38 @@ impl Opts {
         let future_flags = config.future_flags();
         let experimental_observability = config.experimental_observability().cloned();
 
+        let remote_cache_disabled_reason = if !cache_opts.cache.remote.should_use() {
+            let is_linked = turborepo_api_client::is_linked(&api_auth);
+            if !is_linked {
+                let has_token_env = std::env::var("TURBO_TOKEN")
+                    .ok()
+                    .filter(|s| !s.is_empty())
+                    .is_some();
+                if has_token_env {
+                    Some(RemoteCacheDisabledReason::TokenWithoutTeam)
+                } else {
+                    Some(RemoteCacheDisabledReason::NotLinked)
+                }
+            } else if config.enabled == Some(false) {
+                let disabled_by_env = std::env::var("TURBO_REMOTE_CACHE_ENABLED")
+                    .ok()
+                    .filter(|v| v == "0")
+                    .is_some();
+                if disabled_by_env {
+                    Some(RemoteCacheDisabledReason::InEnvVar)
+                } else {
+                    Some(RemoteCacheDisabledReason::InConfig)
+                }
+            } else {
+                // Linked and enabled in config, but remote cache is still disabled.
+                // This means CLI flags (--no-cache + --force, or --cache=local:rw)
+                // disabled both remote read and write.
+                Some(RemoteCacheDisabledReason::ByFlags)
+            }
+        } else {
+            None
+        };
+
         Ok(Self {
             repo_opts,
             run_opts,
@@ -194,6 +247,7 @@ impl Opts {
             future_flags,
             git_root: cache_dir_result.git_root,
             experimental_observability,
+            remote_cache_disabled_reason,
         })
     }
 }
@@ -736,6 +790,7 @@ mod test {
             future_flags: Default::default(),
             experimental_observability: None,
             git_root: None,
+            remote_cache_disabled_reason: None,
         };
         let synthesized = opts.synthesize_command();
         assert_eq!(synthesized, expected);

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -9,7 +9,7 @@ use chrono::Local;
 use tracing::Instrument;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, RelativeUnixPathBuf};
 use turborepo_analytics::{start_analytics, AnalyticsHandle};
-use turborepo_api_client::{APIAuth, APIClient, SharedHttpClient};
+use turborepo_api_client::{APIAuth, APIClient, CacheClient, SharedHttpClient};
 use turborepo_cache::{AsyncCache, CacheScmState, LazyScmState};
 use turborepo_env::EnvironmentVariableMap;
 use turborepo_errors::Spanned;
@@ -32,13 +32,17 @@ use turborepo_telemetry::events::{
 };
 use turborepo_types::{DryRunMode, UIMode};
 use turborepo_ui::ColorConfig;
+use turborepo_vercel_api::CachingStatusResponse;
 
 use crate::{
     commands::CommandBase,
     engine::{Engine, EngineBuilder, EngineExt},
     microfrontends::MicrofrontendsConfigs,
     opts::Opts,
-    run::{scope, task_access::TaskAccess, Error, Run, RunCache},
+    run::{
+        scope, task_access::TaskAccess, Error, RemoteCacheStatus, RemoteCacheUnavailableReason,
+        Run, RunCache,
+    },
     shim::TurboState,
     turbo_json::{TurboJson, TurboJsonReader, UnifiedTurboJsonLoader},
 };
@@ -182,6 +186,109 @@ impl RunBuilder {
             self.version,
             self.opts.api_client_opts.preflight,
         )
+    }
+
+    async fn resolve_remote_cache_status(
+        &self,
+        preflight_handle: Option<
+            tokio::task::JoinHandle<turborepo_api_client::Result<CachingStatusResponse>>,
+        >,
+    ) -> RemoteCacheStatus {
+        use turborepo_vercel_api::CachingStatus;
+
+        if let Some(reason) = self.opts.remote_cache_disabled_reason {
+            return RemoteCacheStatus::Disabled(reason);
+        }
+
+        let Some(handle) = preflight_handle else {
+            return RemoteCacheStatus::Enabled;
+        };
+
+        // Wait at most 250ms for the preflight check. This runs concurrently
+        // with graph building so in practice it's almost always done by now.
+        // If it's not, fall back to "enabled" — the connection warmup still
+        // benefits later cache operations.
+        let result = tokio::time::timeout(Duration::from_millis(250), handle).await;
+        match result {
+            Ok(Ok(Ok(response))) => match response.status {
+                CachingStatus::Enabled => RemoteCacheStatus::Enabled,
+                CachingStatus::Disabled => {
+                    RemoteCacheStatus::Unavailable(RemoteCacheUnavailableReason::DisabledForTeam)
+                }
+                CachingStatus::OverLimit => {
+                    RemoteCacheStatus::Unavailable(RemoteCacheUnavailableReason::UsageLimitExceeded)
+                }
+                CachingStatus::Paused => {
+                    RemoteCacheStatus::Unavailable(RemoteCacheUnavailableReason::SpendingPaused)
+                }
+            },
+            Ok(Ok(Err(api_err))) => Self::map_api_error_to_status(api_err),
+            Ok(Err(_join_err)) => {
+                tracing::debug!("Remote cache preflight task panicked; assuming enabled");
+                RemoteCacheStatus::Enabled
+            }
+            Err(_timeout) => {
+                tracing::debug!("Remote cache preflight timed out after 250ms; assuming enabled");
+                RemoteCacheStatus::Enabled
+            }
+        }
+    }
+
+    fn map_api_error_to_status(err: turborepo_api_client::Error) -> RemoteCacheStatus {
+        match &err {
+            turborepo_api_client::Error::ReqwestError(e) if e.is_connect() || e.is_timeout() => {
+                RemoteCacheStatus::Unavailable(RemoteCacheUnavailableReason::CouldNotConnect)
+            }
+            turborepo_api_client::Error::ReqwestError(e) => {
+                if let Some(status) = e.status() {
+                    if status == reqwest::StatusCode::UNAUTHORIZED
+                        || status == reqwest::StatusCode::FORBIDDEN
+                    {
+                        return RemoteCacheStatus::Unavailable(
+                            RemoteCacheUnavailableReason::AuthenticationFailed,
+                        );
+                    }
+                    if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                        return RemoteCacheStatus::Unavailable(
+                            RemoteCacheUnavailableReason::UsageLimitExceeded,
+                        );
+                    }
+                    if status.is_server_error() {
+                        return RemoteCacheStatus::Unavailable(
+                            RemoteCacheUnavailableReason::UnexpectedServerError,
+                        );
+                    }
+                }
+                RemoteCacheStatus::Unavailable(RemoteCacheUnavailableReason::CouldNotConnect)
+            }
+            turborepo_api_client::Error::InvalidToken { .. } => {
+                RemoteCacheStatus::Unavailable(RemoteCacheUnavailableReason::AuthenticationFailed)
+            }
+            turborepo_api_client::Error::ForbiddenToken { .. } => {
+                RemoteCacheStatus::Unavailable(RemoteCacheUnavailableReason::AuthenticationFailed)
+            }
+            turborepo_api_client::Error::CacheDisabled { status, .. } => {
+                use turborepo_vercel_api::CachingStatus;
+                match status {
+                    CachingStatus::Disabled => RemoteCacheStatus::Unavailable(
+                        RemoteCacheUnavailableReason::DisabledForTeam,
+                    ),
+                    CachingStatus::OverLimit => RemoteCacheStatus::Unavailable(
+                        RemoteCacheUnavailableReason::UsageLimitExceeded,
+                    ),
+                    CachingStatus::Paused => {
+                        RemoteCacheStatus::Unavailable(RemoteCacheUnavailableReason::SpendingPaused)
+                    }
+                    CachingStatus::Enabled => RemoteCacheStatus::Enabled,
+                }
+            }
+            turborepo_api_client::Error::InvalidJson { .. }
+            | turborepo_api_client::Error::UnknownCachingStatus(..)
+            | turborepo_api_client::Error::UnknownStatus { .. } => {
+                RemoteCacheStatus::Unavailable(RemoteCacheUnavailableReason::UnexpectedServerError)
+            }
+            _ => RemoteCacheStatus::Unavailable(RemoteCacheUnavailableReason::CouldNotConnect),
+        }
     }
 
     fn all_package_prefixes(pkg_dep_graph: &PackageGraph) -> Vec<RelativeUnixPathBuf> {
@@ -433,6 +540,23 @@ impl RunBuilder {
             None
         };
 
+        let preflight_handle = if self.opts.remote_cache_disabled_reason.is_none() {
+            if let (Some(client), Some(auth)) = (api_client.clone(), self.api_auth.as_ref()) {
+                let token = auth.token.clone();
+                let team_id = auth.team_id.clone();
+                let team_slug = auth.team_slug.clone();
+                Some(tokio::spawn(async move {
+                    client
+                        .get_caching_status(&token, team_id.as_deref(), team_slug.as_deref())
+                        .await
+                }))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         let (analytics_sender, analytics_handle) = self
             .api_auth
             .as_ref()
@@ -588,6 +712,8 @@ impl RunBuilder {
             )?;
         }
 
+        let remote_cache_status = self.resolve_remote_cache_status(preflight_handle).await;
+
         let should_print_prelude = self
             .should_print_prelude_override
             .unwrap_or_else(|| self.will_execute_tasks());
@@ -656,6 +782,7 @@ impl RunBuilder {
                 run_cache,
                 signal_handler: signal_handler.clone(),
                 should_print_prelude,
+                remote_cache_status,
                 micro_frontend_configs,
                 repo_index,
                 observability_handle,

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -44,7 +44,7 @@ pub use crate::run::error::Error;
 use crate::{
     engine::{Engine, EngineExt},
     microfrontends::MicrofrontendsConfigs,
-    opts::Opts,
+    opts::{Opts, RemoteCacheDisabledReason},
     run::task_access::TaskAccess,
     task_graph::Visitor,
     task_hash::{
@@ -53,6 +53,26 @@ use crate::{
     },
     turbo_json::{TurboJson, UnifiedTurboJsonLoader},
 };
+
+/// Live status of the remote cache, determined by a preflight API check
+/// that runs concurrently with graph building.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum RemoteCacheUnavailableReason {
+    CouldNotConnect,
+    UsageLimitExceeded,
+    SpendingPaused,
+    DisabledForTeam,
+    AuthenticationFailed,
+    UnexpectedServerError,
+}
+
+/// Resolved remote cache status for the run prelude display.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum RemoteCacheStatus {
+    Disabled(RemoteCacheDisabledReason),
+    Enabled,
+    Unavailable(RemoteCacheUnavailableReason),
+}
 
 #[derive(Clone)]
 pub struct Run {
@@ -73,9 +93,9 @@ pub struct Run {
     run_cache: Arc<RunCache>,
     signal_handler: SignalHandler,
     should_print_prelude: bool,
+    remote_cache_status: RemoteCacheStatus,
     engine: Arc<Engine>,
     task_access: TaskAccess,
-
     micro_frontend_configs: Option<MicrofrontendsConfigs>,
     repo_index: Arc<Option<RepoGitIndex>>,
     observability_handle: Option<ObservabilityHandle>,
@@ -122,27 +142,68 @@ impl Run {
             );
         }
 
-        let use_http_cache = self.opts.cache_opts.cache.remote.should_use();
-        let remote_status = if use_http_cache {
-            "enabled"
-        } else {
-            "disabled"
+        let api_url = &self.opts.api_client_opts.api_url;
+        let (base_msg, use_warning_color) = match self.remote_cache_status {
+            RemoteCacheStatus::Disabled(reason) => {
+                let msg = match reason {
+                    RemoteCacheDisabledReason::NotLinked => "• Remote caching disabled".to_string(),
+                    RemoteCacheDisabledReason::TokenWithoutTeam => {
+                        "• Remote caching disabled (TURBO_TOKEN set without TURBO_TEAM)".to_string()
+                    }
+                    RemoteCacheDisabledReason::InConfig => {
+                        "• Remote caching disabled (in configuration)".to_string()
+                    }
+                    RemoteCacheDisabledReason::InEnvVar => {
+                        "• Remote caching disabled (by TURBO_REMOTE_CACHE_ENABLED)".to_string()
+                    }
+                    RemoteCacheDisabledReason::ByFlags => {
+                        "• Remote caching disabled (by flags)".to_string()
+                    }
+                };
+                (msg, false)
+            }
+            RemoteCacheStatus::Enabled => ("• Remote caching enabled".to_string(), false),
+            RemoteCacheStatus::Unavailable(reason) => {
+                let msg = match reason {
+                    RemoteCacheUnavailableReason::CouldNotConnect => {
+                        format!("• Remote caching unavailable (Could not connect to \"{api_url}\")")
+                    }
+                    RemoteCacheUnavailableReason::AuthenticationFailed => {
+                        "• Remote caching unavailable (Authentication failed \u{2014} check \
+                         TURBO_TOKEN or run \"turbo login\")"
+                            .to_string()
+                    }
+                    RemoteCacheUnavailableReason::UsageLimitExceeded => {
+                        "• Remote caching unavailable (Usage limit exceeded)".to_string()
+                    }
+                    RemoteCacheUnavailableReason::SpendingPaused => {
+                        "• Remote caching unavailable (Spending paused)".to_string()
+                    }
+                    RemoteCacheUnavailableReason::DisabledForTeam => {
+                        "• Remote caching unavailable (Disabled for this team)".to_string()
+                    }
+                    RemoteCacheUnavailableReason::UnexpectedServerError => {
+                        format!(
+                            "• Remote caching unavailable (Unexpected server error at \
+                             \"{api_url}\")"
+                        )
+                    }
+                };
+                (msg, true)
+            }
         };
 
         if self.opts.run_opts.is_shared_worktree_cache {
-            cprintln!(
-                self.color_config,
-                GREY,
-                "• Remote caching {}, using shared worktree cache",
-                remote_status
-            );
+            let msg = format!("{base_msg}, using shared worktree cache");
+            if use_warning_color {
+                cprintln!(self.color_config, YELLOW, "{}", msg);
+            } else {
+                cprintln!(self.color_config, GREY, "{}", msg);
+            }
+        } else if use_warning_color {
+            cprintln!(self.color_config, YELLOW, "{}", base_msg);
         } else {
-            cprintln!(
-                self.color_config,
-                GREY,
-                "• Remote caching {}",
-                remote_status
-            );
+            cprintln!(self.color_config, GREY, "{}", base_msg);
         }
     }
 

--- a/crates/turborepo/tests/run_caching.rs
+++ b/crates/turborepo/tests/run_caching.rs
@@ -169,7 +169,10 @@ fn test_remote_caching_enable() {
         ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("Remote caching enabled"));
+    // Config enables remote caching, but the preflight check may report
+    // "unavailable" because the test uses fake credentials.
+    // The key assertion is that it's NOT "disabled" (a local config state).
+    assert!(!stdout.contains("Remote caching disabled"));
 
     // Add empty remoteCache → still enabled
     let mut json: serde_json::Value = serde_json::from_str(&normalized).unwrap();
@@ -198,7 +201,7 @@ fn test_remote_caching_enable() {
         ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("Remote caching enabled"));
+    assert!(!stdout.contains("Remote caching disabled"));
 
     // Set remoteCache.enabled = false → disabled
     let mut json: serde_json::Value = serde_json::from_str(&new_normalized).unwrap();
@@ -222,7 +225,7 @@ fn test_remote_caching_enable() {
         ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("Remote caching disabled"));
+    assert!(stdout.contains("Remote caching disabled (in configuration)"));
 }
 
 // --- cache-state.t ---


### PR DESCRIPTION
## Summary

Replaces the binary "enabled"/"disabled" remote cache prelude message with context-aware status that tells users **why** remote caching is in its current state and **what to do about it**.

Closes #2081

## What changed

The `turbo run` prelude previously showed one of two messages:
```
• Remote caching enabled
• Remote caching disabled
```

It now shows one of 12 messages depending on the actual state:

| Message | When |
|---|---|
| `• Remote caching disabled` | Default — no token, no team, user never opted in |
| `• Remote caching disabled (TURBO_TOKEN set without TURBO_TEAM)` | Token env var set but no team configured |
| `• Remote caching disabled (in configuration)` | `remoteCache.enabled: false` in turbo.json |
| `• Remote caching disabled (by TURBO_REMOTE_CACHE_ENABLED)` | `TURBO_REMOTE_CACHE_ENABLED=0` |
| `• Remote caching disabled (by flags)` | CLI flags disabled both read+write |
| `• Remote caching enabled` | Preflight confirmed OK, or timed out |
| `• Remote caching unavailable (Could not connect to "<url>")` | Connection/timeout error (shows API URL) |
| `• Remote caching unavailable (Authentication failed — check TURBO_TOKEN or run "turbo login")` | 401/403 |
| `• Remote caching unavailable (Usage limit exceeded)` | API returns OverLimit or HTTP 429 |
| `• Remote caching unavailable (Spending paused)` | API returns Paused |
| `• Remote caching unavailable (Disabled for this team)` | Team admin disabled caching |
| `• Remote caching unavailable (Unexpected server error at "<url>")` | 5xx |