### PR TITLE
refactor: Replace `tracing::log::` bridge imports with `tracing::` directly

### DIFF
--- a/crates/turborepo-engine/src/execute.rs
+++ b/crates/turborepo-engine/src/execute.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, Mutex};
 
 use futures::{StreamExt, stream::FuturesUnordered};
 use tokio::sync::{Semaphore, mpsc, oneshot};
-use tracing::log::debug;
+use tracing::debug;
 use turborepo_graph_utils::Walker;
 use turborepo_task_id::TaskId;
 // Re-export StopExecution from turborepo-types for backwards compatibility

--- a/crates/turborepo-graph-utils/src/walker.rs
+++ b/crates/turborepo-graph-utils/src/walker.rs
@@ -9,7 +9,7 @@ use tokio::{
     sync::{broadcast, mpsc, oneshot, watch},
     task::JoinHandle,
 };
-use tracing::log::trace;
+use tracing::trace;
 
 pub struct Walker<N, S> {
     marker: std::marker::PhantomData<S>,

--- a/crates/turborepo-run-summary/src/tracker.rs
+++ b/crates/turborepo-run-summary/src/tracker.rs
@@ -12,7 +12,6 @@ use serde::Serialize;
 use svix_ksuid::{Ksuid, KsuidLike};
 use tabwriter::TabWriter;
 use thiserror::Error;
-use tracing::log::warn;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPath};
 use turborepo_env::EnvironmentVariableMap;
 use turborepo_repository::package_graph::{PackageGraph, PackageName};

--- a/crates/turborepo-ui/src/wui/sender.rs
+++ b/crates/turborepo-ui/src/wui/sender.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-use tracing::log::warn;
+use tracing::warn;
 
 use crate::{
     sender::{TaskSender, UISender},


### PR DESCRIPTION
## Summary

- Replaces `tracing::log::{warn,debug,trace}` bridge imports with direct `tracing::{warn,debug,trace}` imports across 4 crates
- Removes a dead `use tracing::log::warn` import in `turborepo-run-summary` that was shadowed by `turborepo_log::warn`

## Why

The `tracing::log::*` bridge macros are a third logging pathway that sits ambiguously between `tracing` (developer diagnostics) and `turborepo-log` (user-facing structured output). All usages in this PR are developer diagnostics and should use `tracing` directly.

One remaining `tracing::log::warn` in `turborepo-boundaries` is intentionally excluded — it's user-facing and will migrate to `turborepo_log` in a follow-up PR that adds the `turborepo-log` dependency to that crate.

## Changed crates

- `turborepo-run-summary` — dead import removal
- `turborepo-ui` (wui/sender) — `tracing::log::warn` → `tracing::warn`
- `turborepo-graph-utils` — `tracing::log::trace` → `tracing::trace`
- `turborepo-engine` — `tracing::log::debug` → `tracing::debug`