### PR TITLE
refactor: Replace `Source::turbo` string literals with `Subsystem` enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7291,6 +7291,7 @@ dependencies = [
  "turbopath",
  "turborepo-errors",
  "turborepo-lockfiles",
+ "turborepo-log",
  "turborepo-repository",
  "turborepo-ui",
  "unrs_resolver",

--- a/crates/turborepo-boundaries/Cargo.toml
+++ b/crates/turborepo-boundaries/Cargo.toml
@@ -33,6 +33,7 @@ turbo-trace = { workspace = true }
 turbopath = { workspace = true }
 turborepo-errors = { workspace = true }
 turborepo-lockfiles = { workspace = true }
+turborepo-log = { workspace = true }
 turborepo-repository = { path = "../turborepo-repository" }
 turborepo-ui = { workspace = true }
 unrs_resolver = { workspace = true }

--- a/crates/turborepo-boundaries/src/lib.rs
+++ b/crates/turborepo-boundaries/src/lib.rs
@@ -21,10 +21,10 @@ use oxc_ast::ast::Comment;
 use regex::Regex;
 pub use tags::{ProcessedPermissions, ProcessedRule, ProcessedRulesMap};
 use thiserror::Error;
-use tracing::log::warn;
 use turbo_trace::{ImportTraceType, Tracer, find_imports};
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_errors::Spanned;
+use turborepo_log::Subsystem;
 use turborepo_repository::package_graph::{PackageGraph, PackageInfo, PackageName, PackageNode};
 use turborepo_ui::{BOLD_GREEN, BOLD_RED, ColorConfig, color};
 use unrs_resolver::Resolver;
@@ -256,7 +256,11 @@ impl BoundariesResult {
         };
 
         for warning in self.warnings.iter().take(MAX_WARNINGS) {
-            warn!("{}", warning);
+            turborepo_log::warn(
+                turborepo_log::Source::turbo(Subsystem::Boundaries),
+                warning.to_string(),
+            )
+            .emit();
         }
         if !self.warnings.is_empty() {
             eprintln!();

--- a/crates/turborepo-cache/src/async_cache.rs
+++ b/crates/turborepo-cache/src/async_cache.rs
@@ -91,7 +91,9 @@ impl AsyncCache {
                                             std::sync::atomic::Ordering::Release,
                                         );
                                         turborepo_log::warn(
-                                            turborepo_log::Source::turbo("cache"),
+                                            turborepo_log::Source::turbo(
+                                                turborepo_log::Subsystem::Cache,
+                                            ),
                                             format!("{err}"),
                                         )
                                         .emit();

--- a/crates/turborepo-cache/src/multiplexer.rs
+++ b/crates/turborepo-cache/src/multiplexer.rs
@@ -46,7 +46,7 @@ impl CacheMultiplexer {
         // but we shouldn't fail your build for that reason.
         if !use_fs_cache && !use_http_cache {
             turborepo_log::warn(
-                turborepo_log::Source::turbo("cache"),
+                turborepo_log::Source::turbo(turborepo_log::Subsystem::Cache),
                 "no caches are enabled",
             )
             .emit();
@@ -132,7 +132,7 @@ impl CacheMultiplexer {
                         .load(Ordering::Relaxed)
                     {
                         turborepo_log::warn(
-                            turborepo_log::Source::turbo("cache"),
+                            turborepo_log::Source::turbo(turborepo_log::Subsystem::Cache),
                             "Remote cache is read-only, skipping upload",
                         )
                         .emit();

--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -26,7 +26,11 @@ pub async fn run(
     sinks.init_logger();
 
     if let Ok(message) = env::var(turborepo_shim::GLOBAL_WARNING_ENV_VAR) {
-        turborepo_log::warn(turborepo_log::Source::turbo("shim"), message).emit();
+        turborepo_log::warn(
+            turborepo_log::Source::turbo(turborepo_log::Subsystem::Shim),
+            message,
+        )
+        .emit();
         unsafe { env::remove_var(turborepo_shim::GLOBAL_WARNING_ENV_VAR) };
     }
 
@@ -80,7 +84,7 @@ pub async fn run(
             sinks.tui.connect(tui_sender.clone());
             if let Some(path) = subscriber.stderr_redirect_path() {
                 turborepo_log::info(
-                    turborepo_log::Source::turbo("tracing"),
+                    turborepo_log::Source::turbo(turborepo_log::Subsystem::Tracing),
                     format!("Verbose logs redirected to {path}"),
                 )
                 .emit();

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -833,7 +833,7 @@ impl RunBuilder {
                     "SCM returned invalid change set; skipping task-level filtering"
                 );
                 turborepo_log::warn(
-                    turborepo_log::Source::turbo("scm"),
+                    turborepo_log::Source::turbo(turborepo_log::Subsystem::Scm),
                     "--affected could not determine changed files. All tasks will run. Check your \
                      git fetch depth.",
                 )

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -112,12 +112,16 @@ impl Run {
     /// captures them for the log panel.
     pub fn emit_run_prelude_logs(&self) {
         let pad = "   ";
-        turborepo_log::info(turborepo_log::Source::turbo("run"), "").emit();
+        turborepo_log::info(
+            turborepo_log::Source::turbo(turborepo_log::Subsystem::Run),
+            "",
+        )
+        .emit();
 
         let targets_list = self.opts.run_opts.tasks.join(", ");
         if self.opts.run_opts.single_package {
             turborepo_log::info(
-                turborepo_log::Source::turbo("run"),
+                turborepo_log::Source::turbo(turborepo_log::Subsystem::Run),
                 format!("{pad}• Running {targets_list}"),
             )
             .emit();
@@ -129,12 +133,12 @@ impl Run {
                 .collect::<Vec<String>>();
             packages.sort();
             turborepo_log::info(
-                turborepo_log::Source::turbo("run"),
+                turborepo_log::Source::turbo(turborepo_log::Subsystem::Run),
                 format!("{pad}• Packages in scope: {}", packages.join(", ")),
             )
             .emit();
             turborepo_log::info(
-                turborepo_log::Source::turbo("run"),
+                turborepo_log::Source::turbo(turborepo_log::Subsystem::Run),
                 format!(
                     "{pad}• Running {targets_list} in {} packages",
                     self.filtered_pkgs.len()
@@ -200,11 +204,23 @@ impl Run {
         };
 
         if is_warning {
-            turborepo_log::warn(turborepo_log::Source::turbo("run"), cache_status).emit();
+            turborepo_log::warn(
+                turborepo_log::Source::turbo(turborepo_log::Subsystem::Run),
+                cache_status,
+            )
+            .emit();
         } else {
-            turborepo_log::info(turborepo_log::Source::turbo("run"), cache_status).emit();
+            turborepo_log::info(
+                turborepo_log::Source::turbo(turborepo_log::Subsystem::Run),
+                cache_status,
+            )
+            .emit();
         }
-        turborepo_log::info(turborepo_log::Source::turbo("run"), "").emit();
+        turborepo_log::info(
+            turborepo_log::Source::turbo(turborepo_log::Subsystem::Run),
+            "",
+        )
+        .emit();
     }
 
     pub fn turbo_json_loader(&self) -> &UnifiedTurboJsonLoader {
@@ -824,7 +840,11 @@ impl Run {
             .unwrap_or(if errors.is_empty() { 0 } else { 1 });
 
         for err in &errors {
-            turborepo_log::error(turborepo_log::Source::turbo("run"), err.to_string()).emit();
+            turborepo_log::error(
+                turborepo_log::Source::turbo(turborepo_log::Subsystem::Run),
+                err.to_string(),
+            )
+            .emit();
         }
 
         self.cleanup_proxy(proxy_shutdown).await;
@@ -876,7 +896,7 @@ impl Run {
                 Some(graphviz_warning),
                 Some(&|filename: &AbsoluteSystemPath| {
                     turborepo_log::info(
-                        turborepo_log::Source::turbo("run"),
+                        turborepo_log::Source::turbo(turborepo_log::Subsystem::Run),
                         format!("\n✓ Generated task graph in {filename}"),
                     )
                     .emit();
@@ -1025,7 +1045,7 @@ impl turborepo_query_api::QueryRun for Run {
 
 fn emit_graphviz_warning() -> Result<(), io::Error> {
     turborepo_log::warn(
-        turborepo_log::Source::turbo("run"),
+        turborepo_log::Source::turbo(turborepo_log::Subsystem::Run),
         "`turbo` uses Graphviz to generate an image of your graph, but Graphviz isn't installed \
          on this machine.\n\nYou can download Graphviz from https://graphviz.org/download.\n\nIn \
          the meantime, you can use this string output with an online Dot graph viewer.",

--- a/crates/turborepo-lib/src/run/task_access.rs
+++ b/crates/turborepo-lib/src/run/task_access.rs
@@ -107,7 +107,7 @@ impl TaskAccessTraceFile {
         // network
         if self.accessed.network {
             turborepo_log::warn(
-                turborepo_log::Source::turbo("task-access"),
+                turborepo_log::Source::turbo(turborepo_log::Subsystem::TaskAccess),
                 "skipping automatic task caching - detected network access",
             )
             .emit();
@@ -122,7 +122,7 @@ impl TaskAccessTraceFile {
                     // only paths within the repo can be automatically cached
                     if relation == PathRelation::Parent || relation == PathRelation::Divergent {
                         turborepo_log::warn(
-                            turborepo_log::Source::turbo("task-access"),
+                            turborepo_log::Source::turbo(turborepo_log::Subsystem::TaskAccess),
                             format!(
                                 "skipping automatic task caching - file accessed outside of repo \
                                  root ({unescaped_str})"
@@ -164,7 +164,7 @@ impl TaskAccess {
                 Ok(_) => debug!("Automatically added .turbo to .gitignore"),
                 Err(e) => {
                     turborepo_log::error(
-                        turborepo_log::Source::turbo("task-access"),
+                        turborepo_log::Source::turbo(turborepo_log::Subsystem::TaskAccess),
                         format!(
                             "Failed to add .turbo to .gitignore. Caching will be disabled - {e}"
                         ),
@@ -231,7 +231,7 @@ impl TaskAccess {
             }
             Err(e) => {
                 turborepo_log::error(
-                    turborepo_log::Source::turbo("task-access"),
+                    turborepo_log::Source::turbo(turborepo_log::Subsystem::TaskAccess),
                     format!("Failed to save trace result - {e}"),
                 )
                 .emit();
@@ -249,7 +249,7 @@ impl TaskAccess {
             Ok(_) => (),
             Err(e) => {
                 turborepo_log::error(
-                    turborepo_log::Source::turbo("task-access"),
+                    turborepo_log::Source::turbo(turborepo_log::Subsystem::TaskAccess),
                     format!("Failed to write task access trace file - {e}"),
                 )
                 .emit();

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -287,7 +287,11 @@ impl WatchClient {
         sinks.init_logger();
 
         if let Ok(message) = env::var(turborepo_shim::GLOBAL_WARNING_ENV_VAR) {
-            turborepo_log::warn(turborepo_log::Source::turbo("shim"), message).emit();
+            turborepo_log::warn(
+                turborepo_log::Source::turbo(turborepo_log::Subsystem::Shim),
+                message,
+            )
+            .emit();
             unsafe { env::remove_var(turborepo_shim::GLOBAL_WARNING_ENV_VAR) };
         }
 
@@ -315,7 +319,7 @@ impl WatchClient {
             sinks.tui.connect(tui_sender.clone());
             if let Some(path) = subscriber.stderr_redirect_path() {
                 turborepo_log::info(
-                    turborepo_log::Source::turbo("tracing"),
+                    turborepo_log::Source::turbo(turborepo_log::Subsystem::Tracing),
                     format!("Verbose logs redirected to {path}"),
                 )
                 .emit();

--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -567,7 +567,7 @@ impl<'a> Visitor<'a> {
         if let Ok(warnings) = self.warnings.lock() {
             if !warnings.is_empty() {
                 turborepo_log::warn(
-                    turborepo_log::Source::turbo("run"),
+                    turborepo_log::Source::turbo(turborepo_log::Subsystem::Run),
                     "finished with warnings",
                 )
                 .emit();

--- a/crates/turborepo-log/src/event.rs
+++ b/crates/turborepo-log/src/event.rs
@@ -130,6 +130,51 @@ impl fmt::Display for Level {
     }
 }
 
+/// A Turborepo infrastructure subsystem that can emit log events.
+///
+/// Each variant identifies a logical area of the codebase. Adding a
+/// variant here is the only way to register a new subsystem — this
+/// keeps the set discoverable and typo-proof at compile time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[non_exhaustive]
+#[serde(rename_all = "kebab-case")]
+pub enum Subsystem {
+    /// Package boundary checks (`turbo boundaries`).
+    Boundaries,
+    /// Cache reads, writes, and configuration.
+    Cache,
+    /// Log file replay and related output.
+    Logs,
+    /// The `turbo run` orchestrator.
+    Run,
+    /// Source control (git) operations.
+    Scm,
+    /// Global shim version-mismatch warnings.
+    Shim,
+    /// Run summary generation and output.
+    Summary,
+    /// Task-access permission checks.
+    TaskAccess,
+    /// Tracing/logging infrastructure messages.
+    Tracing,
+}
+
+impl fmt::Display for Subsystem {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Subsystem::Boundaries => write!(f, "boundaries"),
+            Subsystem::Cache => write!(f, "cache"),
+            Subsystem::Logs => write!(f, "logs"),
+            Subsystem::Run => write!(f, "run"),
+            Subsystem::Scm => write!(f, "scm"),
+            Subsystem::Shim => write!(f, "shim"),
+            Subsystem::Summary => write!(f, "summary"),
+            Subsystem::TaskAccess => write!(f, "task-access"),
+            Subsystem::Tracing => write!(f, "tracing"),
+        }
+    }
+}
+
 /// Origin of a log event.
 ///
 /// # Relationship to `turborepo-task-id`
@@ -141,14 +186,8 @@ impl fmt::Display for Level {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Source {
-    /// Turborepo infrastructure (config, cache, scm, etc.).
-    ///
-    /// The string identifies the subsystem. Uses `&'static str` so that
-    /// only compile-time constants are accepted — no runtime sanitization
-    /// is needed for static strings.
-    ///
-    /// Convention: lowercase, e.g., `"config"`, `"cache"`, `"scm"`.
-    Turbo(&'static str),
+    /// Turborepo infrastructure (cache, scm, run, etc.).
+    Turbo(Subsystem),
     /// A specific task, identified by its display string (e.g., `"web#build"`).
     /// Uses `Arc<str>` so cloning a `LogHandle` for a task is cheap.
     Task(Arc<str>),
@@ -168,9 +207,7 @@ impl Serialize for Source {
 
 impl Source {
     /// Create a source identifying a Turborepo subsystem.
-    ///
-    /// Convention: lowercase, e.g., `"config"`, `"cache"`, `"scm"`.
-    pub fn turbo(subsystem: &'static str) -> Self {
+    pub fn turbo(subsystem: Subsystem) -> Self {
         Source::Turbo(subsystem)
     }
 
@@ -668,7 +705,7 @@ mod tests {
 
     #[test]
     fn source_display() {
-        assert_eq!(Source::turbo("config").to_string(), "turbo:config");
+        assert_eq!(Source::turbo(Subsystem::Cache).to_string(), "turbo:cache");
         assert_eq!(Source::task("web#build").to_string(), "task:web#build");
     }
 
@@ -843,7 +880,7 @@ mod tests {
     fn message_strips_full_ansi_sequences() {
         let event = LogEvent::new(
             Level::Warn,
-            Source::turbo("test"),
+            Source::turbo(Subsystem::Cache),
             "hello\x1b[31mworld\x00".to_string(),
         );
         assert_eq!(event.message, "helloworld");
@@ -853,7 +890,7 @@ mod tests {
     fn message_strips_clear_screen_sequence() {
         let event = LogEvent::new(
             Level::Warn,
-            Source::turbo("test"),
+            Source::turbo(Subsystem::Cache),
             "before\x1b[2Jafter".to_string(),
         );
         assert_eq!(event.message, "beforeafter");
@@ -863,7 +900,7 @@ mod tests {
     fn message_preserves_newlines() {
         let event = LogEvent::new(
             Level::Info,
-            Source::turbo("test"),
+            Source::turbo(Subsystem::Cache),
             "line 1\nline 2".to_string(),
         );
         assert_eq!(event.message, "line 1\nline 2");
@@ -871,7 +908,7 @@ mod tests {
 
     #[test]
     fn serialization_omits_empty_fields() {
-        let event = LogEvent::new(Level::Warn, Source::turbo("test"), "msg");
+        let event = LogEvent::new(Level::Warn, Source::turbo(Subsystem::Cache), "msg");
         let json = serde_json::to_string(&event).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert!(parsed.get("fields").is_none());
@@ -890,7 +927,7 @@ mod tests {
 
     #[test]
     fn serialization_redacted_field_is_null() {
-        let mut event = LogEvent::new(Level::Info, Source::turbo("auth"), "token used");
+        let mut event = LogEvent::new(Level::Info, Source::turbo(Subsystem::Cache), "token used");
         event.fields.push(("token", Value::Redacted));
         let json = serde_json::to_string(&event).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -899,7 +936,7 @@ mod tests {
 
     #[test]
     fn serialization_timestamp_is_epoch_millis() {
-        let event = LogEvent::new(Level::Info, Source::turbo("test"), "msg");
+        let event = LogEvent::new(Level::Info, Source::turbo(Subsystem::Cache), "msg");
         let json = serde_json::to_string(&event).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert!(parsed["timestamp"].is_u64());
@@ -907,7 +944,7 @@ mod tests {
 
     #[test]
     fn serialization_level_is_uppercase() {
-        let event = LogEvent::new(Level::Warn, Source::turbo("test"), "msg");
+        let event = LogEvent::new(Level::Warn, Source::turbo(Subsystem::Cache), "msg");
         let json = serde_json::to_string(&event).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed["level"], "WARN");
@@ -916,7 +953,8 @@ mod tests {
     #[test]
     fn with_timestamp_uses_provided_time() {
         let ts = SystemTime::UNIX_EPOCH;
-        let event = LogEvent::with_timestamp(Level::Info, Source::turbo("test"), "msg", ts);
+        let event =
+            LogEvent::with_timestamp(Level::Info, Source::turbo(Subsystem::Cache), "msg", ts);
         assert_eq!(event.timestamp, ts);
     }
 
@@ -964,7 +1002,7 @@ mod tests {
     fn message_strips_c1_csi() {
         let event = LogEvent::new(
             Level::Warn,
-            Source::turbo("test"),
+            Source::turbo(Subsystem::Cache),
             "\u{9b}31mred\u{9b}0m text",
         );
         assert_eq!(event.message, "red text");
@@ -1031,10 +1069,11 @@ mod tests {
     #[test]
     fn accessors_return_expected_values() {
         let ts = SystemTime::UNIX_EPOCH;
-        let mut event = LogEvent::with_timestamp(Level::Warn, Source::turbo("test"), "msg", ts);
+        let mut event =
+            LogEvent::with_timestamp(Level::Warn, Source::turbo(Subsystem::Cache), "msg", ts);
         event.push_field("key", Value::from("val"));
         assert_eq!(event.level(), Level::Warn);
-        assert_eq!(event.source(), &Source::turbo("test"));
+        assert_eq!(event.source(), &Source::turbo(Subsystem::Cache));
         assert_eq!(event.message(), "msg");
         assert_eq!(event.fields().len(), 1);
         assert_eq!(event.fields()[0].0, "key");

--- a/crates/turborepo-log/src/lib.rs
+++ b/crates/turborepo-log/src/lib.rs
@@ -31,7 +31,7 @@
 //!
 //! ```no_run
 //! use std::sync::Arc;
-//! use turborepo_log::{init, log, Logger, Source};
+//! use turborepo_log::{init, log, Logger, Source, Subsystem};
 //! use turborepo_log::sinks::collector::CollectorSink;
 //!
 //! // Initialize the global logger (once, at startup).
@@ -39,7 +39,7 @@
 //! init(Logger::new(vec![Box::new(collector.clone())])).ok();
 //!
 //! // Create a source-scoped handle and emit events.
-//! let handle = log(Source::turbo("config"));
+//! let handle = log(Source::turbo(Subsystem::Cache));
 //! handle.warn("'daemon' config option is deprecated").emit();
 //!
 //! // With structured fields:
@@ -66,7 +66,7 @@
 //!
 //! let (collector, logger) = CollectorSink::with_logger();
 //!
-//! let handle = logger.handle(Source::turbo("test"));
+//! let handle = logger.handle(Source::turbo(Subsystem::Cache));
 //! handle.warn("test warning").emit();
 //!
 //! assert_eq!(collector.events().len(), 1);
@@ -94,7 +94,7 @@ mod logger;
 mod sink;
 pub mod sinks;
 
-pub use event::{Level, LogEvent, SanitizedString, Scalar, Source, Value};
+pub use event::{Level, LogEvent, SanitizedString, Scalar, Source, Subsystem, Value};
 pub use logger::{
     InitError, LogEventBuilder, LogHandle, Logger, error, flush, info, init, log, warn,
 };

--- a/crates/turborepo-log/src/logger.rs
+++ b/crates/turborepo-log/src/logger.rs
@@ -133,9 +133,9 @@ enum LoggerRef {
 /// permanently bound to their logger.
 ///
 /// ```no_run
-/// use turborepo_log::{log, Source};
+/// use turborepo_log::{log, Source, Subsystem};
 ///
-/// let handle = log(Source::turbo("config"));
+/// let handle = log(Source::turbo(Subsystem::Cache));
 /// handle.warn("'daemon' config option is deprecated").emit();
 /// handle.warn("deprecated field").field("name", "daemon").emit();
 /// ```
@@ -218,13 +218,13 @@ enum LogResolver<'a> {
 ///
 /// ```
 /// use std::sync::Arc;
-/// use turborepo_log::{Logger, Source};
+/// use turborepo_log::{Logger, Source, Subsystem};
 /// use turborepo_log::sinks::collector::CollectorSink;
 ///
 /// let collector = Arc::new(CollectorSink::new());
 /// let logger = Arc::new(Logger::new(vec![Box::new(collector.clone())]));
 ///
-/// logger.handle(Source::turbo("cache"))
+/// logger.handle(Source::turbo(Subsystem::Cache))
 ///     .warn("cache miss")
 ///     .field("task", "web#build")
 ///     .field("hash", "abc123")
@@ -316,13 +316,13 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-    use crate::sinks::collector::CollectorSink;
+    use crate::{Subsystem, sinks::collector::CollectorSink};
 
     #[test]
     fn logger_dispatches_to_sinks() {
         let (collector, logger) = CollectorSink::with_logger();
 
-        let event = LogEvent::new(Level::Warn, Source::turbo("test"), "test warning");
+        let event = LogEvent::new(Level::Warn, Source::turbo(Subsystem::Cache), "test warning");
         logger.emit(&event);
 
         let events = collector.events();
@@ -337,7 +337,7 @@ mod tests {
         let c2 = Arc::new(CollectorSink::new());
         let logger = Logger::new(vec![Box::new(c1.clone()), Box::new(c2.clone())]);
 
-        let event = LogEvent::new(Level::Error, Source::turbo("test"), "broadcast");
+        let event = LogEvent::new(Level::Error, Source::turbo(Subsystem::Cache), "broadcast");
         logger.emit(&event);
 
         assert_eq!(c1.events().len(), 1);
@@ -349,7 +349,7 @@ mod tests {
     fn log_handle_emits_via_builder() {
         let (collector, logger) = CollectorSink::with_logger();
 
-        let handle = logger.handle(Source::turbo("config"));
+        let handle = logger.handle(Source::turbo(Subsystem::Cache));
         handle
             .warn("deprecated field")
             .field("name", "daemon")
@@ -367,7 +367,7 @@ mod tests {
     fn builder_without_emit_does_not_dispatch() {
         let (collector, logger) = CollectorSink::with_logger();
 
-        let handle = logger.handle(Source::turbo("test"));
+        let handle = logger.handle(Source::turbo(Subsystem::Cache));
         let _builder = handle.warn("should not appear");
         drop(_builder);
         assert_eq!(collector.events().len(), 0);
@@ -378,7 +378,7 @@ mod tests {
         let (collector, logger) = CollectorSink::with_logger();
 
         logger
-            .handle(Source::turbo("cache"))
+            .handle(Source::turbo(Subsystem::Cache))
             .warn("cache miss")
             .field("hash", "abc123")
             .field("task", "web#build")
@@ -394,7 +394,7 @@ mod tests {
     #[test]
     fn logger_with_no_sinks_does_not_panic() {
         let logger = Logger::new(vec![]);
-        let event = LogEvent::new(Level::Warn, Source::turbo("test"), "ignored");
+        let event = LogEvent::new(Level::Warn, Source::turbo(Subsystem::Cache), "ignored");
         logger.emit(&event);
         logger.flush();
     }
@@ -403,7 +403,7 @@ mod tests {
     fn log_event_with_fields() {
         let (collector, logger) = CollectorSink::with_logger();
 
-        let mut event = LogEvent::new(Level::Warn, Source::turbo("cache"), "cache miss");
+        let mut event = LogEvent::new(Level::Warn, Source::turbo(Subsystem::Cache), "cache miss");
         event.fields.push(("hash", Value::from("abc123")));
         event.fields.push(("task", Value::from("web#build")));
         logger.emit(&event);
@@ -419,7 +419,7 @@ mod tests {
     fn log_handle_all_levels() {
         let (collector, logger) = CollectorSink::with_logger();
 
-        let handle = logger.handle(Source::turbo("test"));
+        let handle = logger.handle(Source::turbo(Subsystem::Cache));
         handle.info("info msg").emit();
         handle.warn("warn msg").emit();
         handle.error("error msg").emit();
@@ -440,7 +440,7 @@ mod tests {
     #[test]
     fn cloned_handle_emits_to_same_sinks() {
         let (collector, logger) = CollectorSink::with_logger();
-        let handle = logger.handle(Source::turbo("test"));
+        let handle = logger.handle(Source::turbo(Subsystem::Cache));
         let cloned = handle.clone();
 
         handle.warn("from original").emit();
@@ -469,7 +469,7 @@ mod tests {
         let sink = WarnAndAbove(inner.clone());
         let logger = Arc::new(Logger::new(vec![Box::new(sink)]));
 
-        let handle = logger.handle(Source::turbo("test"));
+        let handle = logger.handle(Source::turbo(Subsystem::Cache));
         handle.info("should be filtered").emit();
         handle.warn("should pass").emit();
         handle.error("should pass").emit();
@@ -504,7 +504,7 @@ mod tests {
             Box::new(errors_only),
         ]));
 
-        let handle = logger.handle(Source::turbo("test"));
+        let handle = logger.handle(Source::turbo(Subsystem::Cache));
         handle.info("info").emit();
         handle.warn("warn").emit();
         handle.error("error").emit();

--- a/crates/turborepo-log/src/sinks/collector.rs
+++ b/crates/turborepo-log/src/sinks/collector.rs
@@ -123,19 +123,19 @@ impl LogSink for CollectorSink {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::event::Source;
+    use crate::event::{Source, Subsystem};
 
     #[test]
     fn stores_events() {
         let collector = CollectorSink::new();
         collector.emit(&LogEvent::new(
             Level::Warn,
-            Source::turbo("test"),
+            Source::turbo(Subsystem::Cache),
             "warning 1",
         ));
         collector.emit(&LogEvent::new(
             Level::Error,
-            Source::turbo("test"),
+            Source::turbo(Subsystem::Cache),
             "error 1",
         ));
         assert_eq!(collector.events().len(), 2);
@@ -144,9 +144,21 @@ mod tests {
     #[test]
     fn filter_by_severity() {
         let collector = CollectorSink::new();
-        collector.emit(&LogEvent::new(Level::Info, Source::turbo("t"), "info"));
-        collector.emit(&LogEvent::new(Level::Warn, Source::turbo("t"), "warn"));
-        collector.emit(&LogEvent::new(Level::Error, Source::turbo("t"), "error"));
+        collector.emit(&LogEvent::new(
+            Level::Info,
+            Source::turbo(Subsystem::Cache),
+            "info",
+        ));
+        collector.emit(&LogEvent::new(
+            Level::Warn,
+            Source::turbo(Subsystem::Cache),
+            "warn",
+        ));
+        collector.emit(&LogEvent::new(
+            Level::Error,
+            Source::turbo(Subsystem::Cache),
+            "error",
+        ));
 
         let warnings_and_above = collector.events_at_severity(Level::Warn);
         assert_eq!(warnings_and_above.len(), 2);
@@ -165,7 +177,11 @@ mod tests {
     #[test]
     fn drain_clears_buffer() {
         let collector = CollectorSink::new();
-        collector.emit(&LogEvent::new(Level::Warn, Source::turbo("test"), "msg"));
+        collector.emit(&LogEvent::new(
+            Level::Warn,
+            Source::turbo(Subsystem::Cache),
+            "msg",
+        ));
         let drained = collector.drain();
         assert_eq!(drained.len(), 1);
         assert_eq!(collector.events().len(), 0);
@@ -177,7 +193,7 @@ mod tests {
         for i in 0..5 {
             collector.emit(&LogEvent::new(
                 Level::Warn,
-                Source::turbo("test"),
+                Source::turbo(Subsystem::Cache),
                 format!("event {i}"),
             ));
         }
@@ -188,7 +204,11 @@ mod tests {
     #[test]
     fn with_capacity_zero_drops_all_events() {
         let collector = CollectorSink::with_capacity(0);
-        collector.emit(&LogEvent::new(Level::Warn, Source::turbo("t"), "msg"));
+        collector.emit(&LogEvent::new(
+            Level::Warn,
+            Source::turbo(Subsystem::Cache),
+            "msg",
+        ));
         assert_eq!(collector.events().len(), 0);
         assert_eq!(collector.dropped_count(), 1);
     }
@@ -196,7 +216,11 @@ mod tests {
     #[test]
     fn with_events_borrows_without_cloning() {
         let collector = CollectorSink::new();
-        collector.emit(&LogEvent::new(Level::Info, Source::turbo("test"), "msg"));
+        collector.emit(&LogEvent::new(
+            Level::Info,
+            Source::turbo(Subsystem::Cache),
+            "msg",
+        ));
         collector.with_events(|events| {
             assert_eq!(events.len(), 1);
             assert_eq!(events[0].message, "msg");
@@ -213,7 +237,7 @@ mod tests {
     #[test]
     fn with_logger_creates_wired_pair() {
         let (collector, logger) = CollectorSink::with_logger();
-        let handle = logger.handle(Source::turbo("test"));
+        let handle = logger.handle(Source::turbo(Subsystem::Cache));
         handle.warn("via helper").emit();
         assert_eq!(collector.events().len(), 1);
     }
@@ -228,7 +252,7 @@ mod tests {
                 for j in 0..100 {
                     c.emit(&LogEvent::new(
                         Level::Warn,
-                        Source::turbo("test"),
+                        Source::turbo(Subsystem::Cache),
                         format!("thread {i} event {j}"),
                     ));
                 }

--- a/crates/turborepo-log/src/sinks/file.rs
+++ b/crates/turborepo-log/src/sinks/file.rs
@@ -122,12 +122,12 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-    use crate::event::{Level, Source, Value};
+    use crate::event::{Level, Source, Subsystem, Value};
 
     #[test]
     fn writes_valid_jsonl() {
         let sink = FileSink::new(Vec::new());
-        let event = LogEvent::new(Level::Warn, Source::turbo("cache"), "cache miss");
+        let event = LogEvent::new(Level::Warn, Source::turbo(Subsystem::Cache), "cache miss");
         sink.emit(&event);
         sink.flush();
 
@@ -141,9 +141,21 @@ mod tests {
     #[test]
     fn writes_multiple_events_as_jsonl() {
         let sink = FileSink::new(Vec::new());
-        sink.emit(&LogEvent::new(Level::Info, Source::turbo("a"), "first"));
-        sink.emit(&LogEvent::new(Level::Warn, Source::turbo("b"), "second"));
-        sink.emit(&LogEvent::new(Level::Error, Source::turbo("c"), "third"));
+        sink.emit(&LogEvent::new(
+            Level::Info,
+            Source::turbo(Subsystem::Cache),
+            "first",
+        ));
+        sink.emit(&LogEvent::new(
+            Level::Warn,
+            Source::turbo(Subsystem::Run),
+            "second",
+        ));
+        sink.emit(&LogEvent::new(
+            Level::Error,
+            Source::turbo(Subsystem::Scm),
+            "third",
+        ));
         sink.flush();
 
         let writer = sink.writer.lock().unwrap();
@@ -175,7 +187,7 @@ mod tests {
     #[test]
     fn omits_fields_when_empty() {
         let sink = FileSink::new(Vec::new());
-        let event = LogEvent::new(Level::Warn, Source::turbo("test"), "no fields");
+        let event = LogEvent::new(Level::Warn, Source::turbo(Subsystem::Cache), "no fields");
         sink.emit(&event);
         sink.flush();
 
@@ -189,14 +201,18 @@ mod tests {
     fn tracks_dropped_count_starts_at_zero() {
         let sink = FileSink::new(Vec::new());
         assert_eq!(sink.dropped_count(), 0);
-        sink.emit(&LogEvent::new(Level::Info, Source::turbo("t"), "ok"));
+        sink.emit(&LogEvent::new(
+            Level::Info,
+            Source::turbo(Subsystem::Cache),
+            "ok",
+        ));
         assert_eq!(sink.dropped_count(), 0);
     }
 
     #[test]
     fn redacted_fields_serialize_as_null() {
         let sink = FileSink::new(Vec::new());
-        let mut event = LogEvent::new(Level::Info, Source::turbo("auth"), "token used");
+        let mut event = LogEvent::new(Level::Info, Source::turbo(Subsystem::Cache), "token used");
         event.fields.push(("token", Value::Redacted));
         sink.emit(&event);
         sink.flush();
@@ -212,7 +228,11 @@ mod tests {
         // 200 bytes is enough for ~1 event but not 3
         let sink = FileSink::with_max_bytes(Vec::new(), 400);
         for _ in 0..10 {
-            sink.emit(&LogEvent::new(Level::Info, Source::turbo("t"), "msg"));
+            sink.emit(&LogEvent::new(
+                Level::Info,
+                Source::turbo(Subsystem::Cache),
+                "msg",
+            ));
         }
         sink.flush();
 
@@ -224,7 +244,11 @@ mod tests {
     fn bytes_written_tracks_output_size() {
         let sink = FileSink::new(Vec::new());
         assert_eq!(sink.bytes_written(), 0);
-        sink.emit(&LogEvent::new(Level::Info, Source::turbo("t"), "msg"));
+        sink.emit(&LogEvent::new(
+            Level::Info,
+            Source::turbo(Subsystem::Cache),
+            "msg",
+        ));
         assert!(sink.bytes_written() > 0);
     }
 
@@ -245,7 +269,11 @@ mod tests {
         // reaches the underlying FailWriter (small writes are absorbed
         // by the buffer and never hit the writer).
         let big_msg = "x".repeat(10_000);
-        sink.emit(&LogEvent::new(Level::Info, Source::turbo("t"), big_msg));
+        sink.emit(&LogEvent::new(
+            Level::Info,
+            Source::turbo(Subsystem::Cache),
+            big_msg,
+        ));
         assert_eq!(sink.dropped_count(), 1);
     }
 
@@ -259,7 +287,7 @@ mod tests {
                 for j in 0..100 {
                     s.emit(&LogEvent::new(
                         Level::Info,
-                        Source::turbo("test"),
+                        Source::turbo(Subsystem::Cache),
                         format!("t{i}e{j}"),
                     ));
                 }
@@ -283,7 +311,11 @@ mod tests {
     fn concurrent_writes_with_max_bytes_bounded_overshoot() {
         // Measure one event's serialized size.
         let probe = FileSink::new(Vec::new());
-        probe.emit(&LogEvent::new(Level::Info, Source::turbo("t"), "msg"));
+        probe.emit(&LogEvent::new(
+            Level::Info,
+            Source::turbo(Subsystem::Cache),
+            "msg",
+        ));
         let one_event = probe.bytes_written();
 
         let max = one_event * 5;
@@ -295,7 +327,7 @@ mod tests {
                 for j in 0..50 {
                     s.emit(&LogEvent::new(
                         Level::Info,
-                        Source::turbo("t"),
+                        Source::turbo(Subsystem::Cache),
                         format!("t{i}e{j}"),
                     ));
                 }

--- a/crates/turborepo-log/tests/global_init.rs
+++ b/crates/turborepo-log/tests/global_init.rs
@@ -6,7 +6,7 @@
 
 use std::sync::Arc;
 
-use turborepo_log::{Logger, Source, flush, init, log, sinks::collector::CollectorSink};
+use turborepo_log::{Logger, Source, Subsystem, flush, init, log, sinks::collector::CollectorSink};
 
 #[test]
 fn full_lifecycle() {
@@ -14,7 +14,7 @@ fn full_lifecycle() {
 
     // Handle created before init — the global logger isn't set yet,
     // so events emitted RIGHT NOW are dropped.
-    let early_handle = log(Source::turbo("early"));
+    let early_handle = log(Source::turbo(Subsystem::Cache));
     early_handle.warn("before init").emit();
     assert_eq!(collector.events().len(), 0);
 
@@ -23,13 +23,13 @@ fn full_lifecycle() {
     let early_builder = early_handle.warn("built before init");
 
     // Free function builder created before init — also defers.
-    let early_free = turborepo_log::warn(Source::turbo("free"), "free before init");
+    let early_free = turborepo_log::warn(Source::turbo(Subsystem::Cache), "free before init");
 
     // Initialize the global logger.
     assert!(init(Logger::new(vec![Box::new(collector.clone())])).is_ok());
 
     // Handle created after init works immediately.
-    let handle = log(Source::turbo("test"));
+    let handle = log(Source::turbo(Subsystem::Cache));
     handle.warn("test warning").field("key", "value").emit();
     assert_eq!(collector.events().len(), 1);
     assert_eq!(collector.events()[0].message(), "test warning");
@@ -54,12 +54,12 @@ fn full_lifecycle() {
     assert!(result.is_err());
 
     // Free functions work.
-    turborepo_log::warn(Source::turbo("free"), "free warning").emit();
+    turborepo_log::warn(Source::turbo(Subsystem::Cache), "free warning").emit();
     assert_eq!(collector.events().len(), 5);
 
     // All levels work.
-    turborepo_log::info(Source::turbo("free"), "info").emit();
-    turborepo_log::error(Source::turbo("free"), "error").emit();
+    turborepo_log::info(Source::turbo(Subsystem::Cache), "info").emit();
+    turborepo_log::error(Source::turbo(Subsystem::Cache), "error").emit();
     assert_eq!(collector.events().len(), 7);
 
     // Flush doesn't panic.

--- a/crates/turborepo-run-summary/src/tracker.rs
+++ b/crates/turborepo-run-summary/src/tracker.rs
@@ -414,7 +414,7 @@ impl<'a> RunSummary<'a> {
             && let Err(err) = self.save().await
         {
             turborepo_log::warn(
-                turborepo_log::Source::turbo("summary"),
+                turborepo_log::Source::turbo(turborepo_log::Subsystem::Summary),
                 format!("Error writing run summary: {err}"),
             )
             .emit()
@@ -436,7 +436,11 @@ impl<'a> RunSummary<'a> {
         }
 
         for error in errors {
-            turborepo_log::warn(turborepo_log::Source::turbo("summary"), format!("{error}")).emit();
+            turborepo_log::warn(
+                turborepo_log::Source::turbo(turborepo_log::Subsystem::Summary),
+                format!("{error}"),
+            )
+            .emit();
         }
     }
 

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -224,7 +224,7 @@ impl GitRepo {
             Ok(output) => output,
             Err(e) => {
                 turborepo_log::warn(
-                    turborepo_log::Source::turbo("scm"),
+                    turborepo_log::Source::turbo(turborepo_log::Subsystem::Scm),
                     format!("failed to get git status for dirty hash: {e}"),
                 )
                 .emit();
@@ -251,7 +251,7 @@ impl GitRepo {
             &mut hasher,
         ) {
             turborepo_log::warn(
-                turborepo_log::Source::turbo("scm"),
+                turborepo_log::Source::turbo(turborepo_log::Subsystem::Scm),
                 "failed to run git diff for dirty hash",
             )
             .emit();

--- a/crates/turborepo-ui/src/logs.rs
+++ b/crates/turborepo-ui/src/logs.rs
@@ -30,7 +30,7 @@ impl<W: Write> LogWriter<W> {
     pub fn with_log_file(&mut self, log_file_path: &AbsoluteSystemPath) -> Result<(), Error> {
         log_file_path.ensure_dir().map_err(|err| {
             turborepo_log::warn(
-                turborepo_log::Source::turbo("logs"),
+                turborepo_log::Source::turbo(turborepo_log::Subsystem::Logs),
                 format!("error creating log file directory: {err:?}"),
             )
             .emit();
@@ -39,7 +39,7 @@ impl<W: Write> LogWriter<W> {
 
         let log_file = log_file_path.create().map_err(|err| {
             turborepo_log::warn(
-                turborepo_log::Source::turbo("logs"),
+                turborepo_log::Source::turbo(turborepo_log::Subsystem::Logs),
                 format!("error creating log file: {err:?}"),
             )
             .emit();
@@ -98,7 +98,7 @@ pub fn replay_logs<W: Write>(
 
     let log_file = File::open(log_file_name).map_err(|err| {
         turborepo_log::warn(
-            turborepo_log::Source::turbo("logs"),
+            turborepo_log::Source::turbo(turborepo_log::Subsystem::Logs),
             format!("error opening log file: {err:?}"),
         )
         .emit();
@@ -141,7 +141,7 @@ pub fn replay_logs_with_crlf<W: Write>(
 
     let log_file = File::open(log_file_name).map_err(|err| {
         turborepo_log::warn(
-            turborepo_log::Source::turbo("logs"),
+            turborepo_log::Source::turbo(turborepo_log::Subsystem::Logs),
             format!("error opening log file: {err:?}"),
         )
         .emit();

--- a/crates/turborepo-ui/src/terminal_sink.rs
+++ b/crates/turborepo-ui/src/terminal_sink.rs
@@ -170,7 +170,7 @@ mod tests {
             Box::new(collector.clone()),
         ]));
 
-        let handle = logger.handle(Source::turbo("test"));
+        let handle = logger.handle(Source::turbo(turborepo_log::Subsystem::Cache));
         handle.info("test info").emit();
         handle.warn("test warning").emit();
         handle.error("test error").field("code", 1).emit();
@@ -229,7 +229,7 @@ mod tests {
             Box::new(collector.clone()),
         ]));
 
-        let handle = logger.handle(Source::turbo("test"));
+        let handle = logger.handle(Source::turbo(turborepo_log::Subsystem::Cache));
         handle.warn("before disable").emit();
 
         sink.disable();

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -2602,7 +2602,7 @@ mod test {
 
         let event = turborepo_log::LogEvent::new(
             turborepo_log::Level::Warn,
-            turborepo_log::Source::turbo("scm"),
+            turborepo_log::Source::turbo(turborepo_log::Subsystem::Scm),
             "something went wrong",
         );
         update(&mut app, Event::LogEvent(event))?;

--- a/crates/turborepo-ui/src/tui_sink.rs
+++ b/crates/turborepo-ui/src/tui_sink.rs
@@ -70,7 +70,11 @@ mod tests {
     use crate::tui::event::Event;
 
     fn make_event(msg: &str) -> LogEvent {
-        LogEvent::new(Level::Warn, Source::turbo("test"), msg)
+        LogEvent::new(
+            Level::Warn,
+            Source::turbo(turborepo_log::Subsystem::Cache),
+            msg,
+        )
     }
 
     fn make_tui_sender() -> (TuiSender, mpsc::UnboundedReceiver<Event>) {


### PR DESCRIPTION
## Summary

- Introduces a `Subsystem` enum in `turborepo-log` to replace free `&'static str` arguments to `Source::turbo()`
- Migrates all ~36 production call sites and ~57 test call sites from `Source::turbo("cache")` to `Source::turbo(Subsystem::Cache)`
- Adds `turborepo-log` as a dependency of `turborepo-boundaries` and migrates its `tracing::log::warn` to `turborepo_log::warn`

## Why

`Source::turbo()` previously accepted any `&'static str`, which meant subsystem identifiers were undiscoverable and typo-prone (e.g., `"task-acces"` would silently compile). The new `Subsystem` enum makes the set of valid subsystems compiler-checked, discoverable in one place, and matchable for future sink-level filtering.

The boundaries migration also eliminates the last user-facing `tracing::log::warn` call, routing boundary check warnings through the structured `turborepo-log` sink system (so they render in TUI).

## Subsystem variants

`Boundaries`, `Cache`, `Logs`, `Run`, `Scm`, `Shim`, `Summary`, `TaskAccess`, `Tracing`

The enum is `#[non_exhaustive]` so new variants can be added without breaking downstream.

## Testing

`cargo check --workspace` and `cargo check -p turborepo-log --tests` pass. No behavioral changes — the `Display` impl for each variant produces the same string the old call site used.