### PR TITLE
fix: Filter phantom tasks from `affectedTasks` query results

### DIFF
--- a/crates/turborepo-query/src/lib.rs
+++ b/crates/turborepo-query/src/lib.rs
@@ -646,11 +646,12 @@ impl RepositoryQuery {
             .collect::<Result<Vec<_>, Error>>()?
             .into_iter()
             .filter(|ct| {
+                let has_script = ct.task.script.is_some();
                 let task_ok = tasks.as_ref().is_none_or(|names| {
                     names.is_empty() || names.iter().any(|n| n.as_str() == ct.task.name)
                 });
                 let package_ok = filter.as_ref().is_none_or(|f| f.check(&ct.task.package));
-                task_ok && package_ok
+                has_script && task_ok && package_ok
             })
             .collect();
 

--- a/crates/turborepo/tests/affected_test.rs
+++ b/crates/turborepo/tests/affected_test.rs
@@ -452,6 +452,66 @@ fn test_affected_tasks_filter_by_task_name() {
 }
 
 #[test]
+fn test_affected_tasks_excludes_packages_without_script() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_affected_tasks_fixture(tempdir.path());
+
+    // Change a file in lib-no-test (which has build + typecheck but NOT test)
+    fs::write(
+        tempdir.path().join("packages/lib-no-test/index.ts"),
+        "export const changed = true;",
+    )
+    .unwrap();
+
+    // affectedTasks(tasks: ["test"]) should NOT include lib-no-test
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "query",
+            "query { affectedTasks(tasks: [\"test\"]) { items { name package { name } } } }",
+        ],
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let items = json["data"]["affectedTasks"]["items"].as_array().unwrap();
+    for item in items {
+        assert_ne!(
+            item["package"]["name"], "lib-no-test",
+            "lib-no-test has no test script and should not appear in affectedTasks(tasks: \
+             [\"test\"])"
+        );
+    }
+
+    // affectedTasks (no filter) should also not include phantom test task for
+    // lib-no-test
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "query",
+            "query { affectedTasks { items { name package { name } } } }",
+        ],
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let items = json["data"]["affectedTasks"]["items"].as_array().unwrap();
+    let phantom_test = items
+        .iter()
+        .any(|item| item["package"]["name"] == "lib-no-test" && item["name"] == "test");
+    assert!(
+        !phantom_test,
+        "lib-no-test#test should not appear — no test script in package.json"
+    );
+
+    // But lib-no-test's real tasks (build, typecheck) SHOULD still appear
+    let has_build = items
+        .iter()
+        .any(|item| item["package"]["name"] == "lib-no-test" && item["name"] == "build");
+    let has_typecheck = items
+        .iter()
+        .any(|item| item["package"]["name"] == "lib-no-test" && item["name"] == "typecheck");
+    assert!(has_build, "lib-no-test#build should be affected");
+    assert!(has_typecheck, "lib-no-test#typecheck should be affected");
+}
+
+#[test]
 fn test_affected_tasks_test_file_excluded_from_typecheck() {
     let tempdir = tempfile::tempdir().unwrap();
     setup_affected_tasks_fixture(tempdir.path());

--- a/turborepo-tests/integration/fixtures/affected_tasks_inputs/packages/lib-no-test/index.ts
+++ b/turborepo-tests/integration/fixtures/affected_tasks_inputs/packages/lib-no-test/index.ts
@@ -1,0 +1,1 @@
+export const placeholder = true;

--- a/turborepo-tests/integration/fixtures/affected_tasks_inputs/packages/lib-no-test/package.json
+++ b/turborepo-tests/integration/fixtures/affected_tasks_inputs/packages/lib-no-test/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "lib-no-test",
+  "scripts": {
+    "build": "echo building",
+    "typecheck": "echo typechecking"
+  }
+}


### PR DESCRIPTION
## Summary

- `affectedTasks` returned tasks for packages that don't have the corresponding script in `package.json` (e.g. `lib-no-test#test` when `lib-no-test` has no `test` script but root `turbo.json` defines `test`)
- Adds a `script.is_some()` check to the resolver filter, consistent with how `turbo run` and `packages { tasks }` already behave
- Adds integration test with a fixture package (`lib-no-test`) that has `build`/`typecheck` but no `test` script

## Background

`turbo query` builds its engine with `add_all_tasks()` + `do_not_validate_engine()`, creating entries for every `(workspace, task)` combination from `turbo.json` without checking `package.json` scripts. This means phantom tasks (where a package lacks the script) end up in engine iteration.

`RepositoryTask::new()` already correctly populates `script` from `package.json` — the field just wasn't being used for filtering. `turbo run` validates the engine and checks `package_has_task`, and `packages { tasks }` reads directly from `package.json` scripts — both correctly exclude phantom tasks. This change makes `affectedTasks` consistent with them.