### PR TITLE
refactor: Route 'no tasks executed' warning through `turborepo-log` and add task prefix to `TerminalSink`

### DIFF
--- a/crates/turborepo-run-summary/src/execution.rs
+++ b/crates/turborepo-run-summary/src/execution.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use tokio::sync::mpsc;
 use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPath};
 use turborepo_task_id::TaskId;
-use turborepo_ui::{BOLD, BOLD_GREEN, BOLD_RED, ColorConfig, MAGENTA, YELLOW, color, cprintln};
+use turborepo_ui::{BOLD, BOLD_GREEN, BOLD_RED, ColorConfig, MAGENTA, color};
 
 use crate::{TurboDuration, task::TaskExecutionSummary};
 
@@ -149,8 +149,11 @@ impl<'a> ExecutionSummary<'a> {
             .collect();
 
         if self.attempted == 0 {
-            println!();
-            cprintln!(ui, YELLOW, "No tasks were executed as part of this run.");
+            turborepo_log::warn(
+                turborepo_log::Source::turbo(turborepo_log::Subsystem::Summary),
+                "No tasks were executed as part of this run.",
+            )
+            .emit();
         }
 
         println!();

--- a/crates/turborepo-ui/src/terminal_sink.rs
+++ b/crates/turborepo-ui/src/terminal_sink.rs
@@ -3,7 +3,7 @@ use std::{
     sync::atomic::{AtomicU8, Ordering},
 };
 
-use turborepo_log::{Level, LogEvent, LogSink};
+use turborepo_log::{Level, LogEvent, LogSink, Source};
 
 use crate::ColorConfig;
 
@@ -117,6 +117,17 @@ impl TerminalSink {
         // the runner to parse it as a workflow command.
         if self.ci_annotations && event.level() == Level::Error {
             let _ = writeln!(handle, "::error::{}", event.message());
+        }
+
+        // Task-scoped events get the task ID prefix so the user
+        // knows which task produced the warning/error.
+        if let Source::Task(id) = event.source() {
+            let _ = write!(
+                handle,
+                "{}",
+                self.color_config
+                    .apply(crate::BOLD.apply_to(format!("{id}: ")))
+            );
         }
 
         let badge = match event.level() {


### PR DESCRIPTION
## Summary

- Migrates the "No tasks were executed as part of this run" warning from `cprintln!(YELLOW, ...)` to `turborepo_log::warn`
- Adds task ID prefix rendering to `TerminalSink` for `Source::Task` events (e.g., `web#build:  ERROR  ...`)

## Why

This is incremental progress toward routing all user-facing output through `turborepo-log`. The "no tasks" warning is turbo-scoped and maps cleanly to a structured warn event.

The `TerminalSink` task prefix is groundwork for future task-scoped event rendering. Task error/warn messages (e.g., "command finished with error") currently flow through `PrefixedUI` into the task output stream. Migrating those requires `turborepo-log` to support routing task-scoped events into the task output pane (not just the log panel), which is a separate effort.