### PR TITLE
feat: Allow cyclic package graphs, validate only at task graph level

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -40,3 +40,9 @@ test-group = 'turborepo-dirs-serial'
 filter = 'package(turbo) and test(/^watch_/)'
 test-group = 'turbo-watch-serial'
 slow-timeout = { period = "60s", terminate-after = 2 }
+
+[[profile.default.overrides]]
+# Cyclic package graph tests could deadlock if the validate_graph guard
+# ever regresses, so cap them to prevent 45-min CI hangs.
+filter = 'test(/cyclic/) or test(/cycle/)'
+slow-timeout = { period = "30s", terminate-after = 2 }

--- a/crates/turborepo-engine/src/builder.rs
+++ b/crates/turborepo-engine/src/builder.rs
@@ -5,6 +5,11 @@
 //! - Resolving task dependencies through the extends chain
 //! - Validating task definitions and dependencies
 //! - Building the final execution engine
+//!
+//! The engine builder is the sole layer that validates the task graph for
+//! cycles and self-dependencies. Package graph cycles are intentionally allowed
+//! — only task graph cycles (e.g. from topological `^` dependencies through a
+//! package cycle) prevent execution.
 
 use std::collections::{HashMap, HashSet, VecDeque};
 
@@ -430,6 +435,9 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
             }
         }
 
+        // This is the sole cycle/self-dependency check in the pipeline. Package
+        // graph cycles are intentionally allowed; only task graph cycles prevent
+        // execution. See #2559.
         graph::validate_graph(engine.task_graph_mut())?;
 
         Ok(engine.seal())
@@ -4709,6 +4717,194 @@ mod test {
             matches!(result, Err(BuilderError::MissingTasks(_))),
             "expected MissingTasks error for non-existent task with empty workspaces, got: \
              {result:?}"
+        );
+    }
+
+    // --- Cyclic package graph tests (see #2559) ---
+
+    #[test]
+    fn test_cyclic_package_graph_without_task_cycle_succeeds() {
+        let repo_root_dir = TempDir::with_prefix("repo").unwrap();
+        let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
+        let package_graph = mock_package_graph(
+            &repo_root,
+            package_jsons! {
+                repo_root,
+                "a" => ["b"],
+                "b" => ["a"]
+            },
+        );
+        let turbo_jsons = vec![(
+            PackageName::Root,
+            turbo_json(json!({
+                "tasks": {
+                    "lint": {},
+                    "build": { "dependsOn": ["lint"] },
+                }
+            })),
+        )]
+        .into_iter()
+        .collect();
+        let loader = TestTurboJsonLoader::new(turbo_jsons);
+        let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
+            .with_tasks(Some(Spanned::new(TaskName::from("build"))))
+            .with_workspaces(vec![PackageName::from("a"), PackageName::from("b")])
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            all_dependencies(&engine),
+            deps! {
+                "a#build" => ["a#lint"],
+                "a#lint" => ["___ROOT___"],
+                "b#build" => ["b#lint"],
+                "b#lint" => ["___ROOT___"]
+            }
+        );
+    }
+
+    #[test]
+    fn test_cyclic_package_graph_with_topo_deps_produces_task_cycle_error() {
+        let repo_root_dir = TempDir::with_prefix("repo").unwrap();
+        let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
+        let package_graph = mock_package_graph(
+            &repo_root,
+            package_jsons! {
+                repo_root,
+                "a" => ["b"],
+                "b" => ["a"]
+            },
+        );
+        let turbo_jsons = vec![(
+            PackageName::Root,
+            turbo_json(json!({
+                "tasks": {
+                    "build": { "dependsOn": ["^build"] },
+                }
+            })),
+        )]
+        .into_iter()
+        .collect();
+        let loader = TestTurboJsonLoader::new(turbo_jsons);
+        let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
+            .with_tasks(Some(Spanned::new(TaskName::from("build"))))
+            .with_workspaces(vec![PackageName::from("a"), PackageName::from("b")])
+            .build();
+
+        assert!(
+            matches!(engine, Err(BuilderError::Graph(..))),
+            "topological deps on cyclic package graph should produce task graph cycle error: \
+             {engine:?}"
+        );
+    }
+
+    #[test]
+    fn test_three_node_cycle_with_topo_deps_produces_task_cycle_error() {
+        let repo_root_dir = TempDir::with_prefix("repo").unwrap();
+        let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
+        let package_graph = mock_package_graph(
+            &repo_root,
+            package_jsons! {
+                repo_root,
+                "a" => ["b"],
+                "b" => ["c"],
+                "c" => ["a"]
+            },
+        );
+        let turbo_jsons = vec![(
+            PackageName::Root,
+            turbo_json(json!({
+                "tasks": {
+                    "build": { "dependsOn": ["^build"] },
+                }
+            })),
+        )]
+        .into_iter()
+        .collect();
+        let loader = TestTurboJsonLoader::new(turbo_jsons);
+        let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
+            .with_tasks(Some(Spanned::new(TaskName::from("build"))))
+            .with_workspaces(vec![
+                PackageName::from("a"),
+                PackageName::from("b"),
+                PackageName::from("c"),
+            ])
+            .build();
+
+        assert!(
+            matches!(engine, Err(BuilderError::Graph(..))),
+            "3-node cycle with topological deps should produce task graph cycle error: {engine:?}"
+        );
+    }
+
+    #[test]
+    fn test_self_dependency_without_topo_deps_succeeds() {
+        let repo_root_dir = TempDir::with_prefix("repo").unwrap();
+        let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
+        let package_graph = mock_package_graph(
+            &repo_root,
+            package_jsons! {
+                repo_root,
+                "a" => ["a"]
+            },
+        );
+        let turbo_jsons = vec![(
+            PackageName::Root,
+            turbo_json(json!({
+                "tasks": {
+                    "lint": {},
+                    "build": { "dependsOn": ["lint"] },
+                }
+            })),
+        )]
+        .into_iter()
+        .collect();
+        let loader = TestTurboJsonLoader::new(turbo_jsons);
+        let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
+            .with_tasks(Some(Spanned::new(TaskName::from("build"))))
+            .with_workspaces(vec![PackageName::from("a")])
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            all_dependencies(&engine),
+            deps! {
+                "a#build" => ["a#lint"],
+                "a#lint" => ["___ROOT___"]
+            }
+        );
+    }
+
+    #[test]
+    fn test_self_dependency_with_topo_deps_produces_error() {
+        let repo_root_dir = TempDir::with_prefix("repo").unwrap();
+        let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
+        let package_graph = mock_package_graph(
+            &repo_root,
+            package_jsons! {
+                repo_root,
+                "a" => ["a"]
+            },
+        );
+        let turbo_jsons = vec![(
+            PackageName::Root,
+            turbo_json(json!({
+                "tasks": {
+                    "build": { "dependsOn": ["^build"] },
+                }
+            })),
+        )]
+        .into_iter()
+        .collect();
+        let loader = TestTurboJsonLoader::new(turbo_jsons);
+        let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
+            .with_tasks(Some(Spanned::new(TaskName::from("build"))))
+            .with_workspaces(vec![PackageName::from("a")])
+            .build();
+
+        assert!(
+            matches!(engine, Err(BuilderError::Graph(..))),
+            "self-dependency with topological deps should produce task graph error: {engine:?}"
         );
     }
 

--- a/crates/turborepo-engine/src/execute.rs
+++ b/crates/turborepo-engine/src/execute.rs
@@ -41,6 +41,10 @@ pub enum ExecuteError {
     Semaphore(#[from] tokio::sync::AcquireError),
     #[error("Engine visitor closed channel before walk finished")]
     Visitor,
+    #[error(
+        "Task graph contains a cycle — validate_graph should have rejected it before execution"
+    )]
+    CyclicTaskGraph,
 }
 
 impl From<mpsc::error::SendError<Message<VisitorData, VisitorResult>>> for ExecuteError {
@@ -77,6 +81,9 @@ impl<T: TaskDefinitionInfo + Clone + Send + Sync + 'static> Engine<Built, T> {
         let mut tasks: FuturesUnordered<tokio::task::JoinHandle<Result<(), ExecuteError>>> =
             FuturesUnordered::new();
 
+        if petgraph::algo::is_cyclic_directed(&self.task_graph) {
+            return Err(ExecuteError::CyclicTaskGraph);
+        }
         let (walker, mut nodes) = Walker::new(&self.task_graph).walk();
         let walker = Arc::new(Mutex::new(walker));
 

--- a/crates/turborepo-graph-utils/src/lib.rs
+++ b/crates/turborepo-graph-utils/src/lib.rs
@@ -78,9 +78,20 @@ pub fn cycles_and_cut_candidates<N: Clone + Hash + Eq, E: Clone>(
 /// in a cycle no longer being present.
 /// Minimal here means that if the cycle can be broken by only removing n edges,
 /// then only sets containing n edges will be returned.
+///
+/// For large SCCs the powerset enumeration is O(2^E) which becomes infeasible.
+/// When the edge count exceeds `MAX_EDGES_FOR_CUT_ANALYSIS` we skip the
+/// cut-candidate computation and return an empty `cuts` vec so callers still
+/// get the cycle members without hanging.
+const MAX_EDGES_FOR_CUT_ANALYSIS: usize = 15;
+
 fn edges_to_break_cycle<N: Clone + Hash + Eq, E: Clone>(
     graph: &Graph<N, E>,
 ) -> Vec<HashSet<(N, N)>> {
+    if graph.edge_count() > MAX_EDGES_FOR_CUT_ANALYSIS {
+        return Vec::new();
+    }
+
     let edge_sets = graph.edge_indices().powerset();
     let mut breaking_edge_sets = Vec::new();
 
@@ -123,12 +134,21 @@ pub fn validate_graph<N: Display + Clone + Hash + Eq>(graph: &Graph<N, ()>) -> R
         .into_iter()
         .map(|Cycle { nodes, cuts }| {
             let workspaces = nodes.into_iter().map(|id| graph.node_weight(id).unwrap());
-            let cuts = cuts.into_iter().map(format_cut).format("\n\t");
-            format!(
-                "\t{}\n\nThe cycle can be broken by removing any of these sets of \
-                 dependencies:\n\t{cuts}",
-                workspaces.format(", ")
-            )
+            if cuts.is_empty() {
+                format!(
+                    "\t{}\n\nCheck the `dependsOn` configuration for these tasks in turbo.json. \
+                     Cycles can be caused by topological (^) dependencies flowing through a \
+                     package dependency cycle, or by explicit task references that form a loop.",
+                    workspaces.format(", ")
+                )
+            } else {
+                let cuts = cuts.into_iter().map(format_cut).format("\n\t");
+                format!(
+                    "\t{}\n\nThe cycle can be broken by removing any of these sets of \
+                     dependencies:\n\t{cuts}",
+                    workspaces.format(", ")
+                )
+            }
         })
         .join("\n");
 
@@ -155,7 +175,7 @@ fn format_cut<N: Display>(edges: impl IntoIterator<Item = (N, N)>) -> String {
         .sorted()
         .format(", ");
 
-    format!("{{ {edges} }}")
+    edges.to_string()
 }
 
 struct CycleDetector {
@@ -249,7 +269,7 @@ mod test {
         	d, c, b, a
 
         The cycle can be broken by removing any of these sets of dependencies:
-        	{ b -> c }
+        	b -> c
         "###);
     }
 

--- a/crates/turborepo-graph-utils/src/walker.rs
+++ b/crates/turborepo-graph-utils/src/walker.rs
@@ -29,6 +29,12 @@ pub type WalkMessage<N> = (N, oneshot::Sender<bool>);
 impl<N: Eq + Hash + Copy + Send + 'static> Walker<N, Start> {
     /// Create a new graph walker for a DAG that emits nodes only once all of
     /// their dependencies have been processed.
+    ///
+    /// The graph **must** be a DAG. If the graph contains cycles, the walker
+    /// will deadlock: nodes in a cycle each wait indefinitely for their
+    /// dependency's completion signal. Cycle detection is the caller's
+    /// responsibility — see `validate_graph` in this crate.
+    ///
     /// The graph should not be modified after a walker is created as the nodes
     /// emitted might no longer exist or might miss newly added edges.
     pub fn new<G: IntoNodeIdentifiers<NodeId = N> + IntoNeighborsDirected>(graph: G) -> Self {

--- a/crates/turborepo-query/src/package.rs
+++ b/crates/turborepo-query/src/package.rs
@@ -65,12 +65,20 @@ impl Package {
 
     pub fn indirect_dependents_count(&self) -> usize {
         let node: PackageNode = PackageNode::Workspace(self.name.clone());
-        self.run.pkg_dep_graph().ancestors(&node).len() - self.direct_dependents_count()
+        self.run
+            .pkg_dep_graph()
+            .ancestors(&node)
+            .len()
+            .saturating_sub(self.direct_dependents_count())
     }
 
     pub fn indirect_dependencies_count(&self) -> usize {
         let node: PackageNode = PackageNode::Workspace(self.name.clone());
-        self.run.pkg_dep_graph().dependencies(&node).len() - self.direct_dependencies_count()
+        self.run
+            .pkg_dep_graph()
+            .dependencies(&node)
+            .len()
+            .saturating_sub(self.direct_dependencies_count())
     }
 
     pub fn all_dependents_count(&self) -> usize {

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -6,7 +6,6 @@ use tracing::{Instrument, warn};
 use turbopath::{
     AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPath, AnchoredSystemPathBuf,
 };
-use turborepo_graph_utils as graph;
 use turborepo_lockfiles::Lockfile;
 
 use super::{
@@ -53,8 +52,6 @@ pub enum Error {
     PackageJson(#[from] crate::package_json::Error),
     #[error("package.json must have a name field:\n{0}")]
     PackageJsonMissingName(AbsoluteSystemPathBuf),
-    #[error("Invalid package dependency graph:")]
-    InvalidPackageGraph(#[source] graph::Error),
     #[error(transparent)]
     Lockfile(#[from] turborepo_lockfiles::Error),
     #[error(transparent)]

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -5,13 +5,15 @@ use std::{
 };
 
 use itertools::Itertools;
-use petgraph::graph::{Edge, NodeIndex};
+use petgraph::{
+    graph::{Edge, NodeIndex},
+    visit::EdgeRef,
+};
 use serde::Serialize;
 use tracing::debug;
 use turbopath::{
     AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPath, AnchoredSystemPathBuf,
 };
-use turborepo_graph_utils as graph;
 use turborepo_lockfiles::Lockfile;
 
 use crate::{
@@ -156,6 +158,20 @@ impl PackageGraph {
         PackageGraphBuilder::new(repo_root, root_package_json)
     }
 
+    /// Validates that every non-root package has a `name` field in its
+    /// package.json.
+    ///
+    /// Structural invariants (cycles, self-dependencies) are intentionally not
+    /// checked here — those are caught at the task graph level by the engine
+    /// builder, since package-level cycles don't necessarily produce invalid
+    /// task execution orders. A warning is logged when cycles or
+    /// self-dependencies are detected so users have visibility into the graph
+    /// structure.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::PackageJsonMissingName` if any non-root package is
+    /// missing a `name` field in its package.json.
     #[tracing::instrument(skip(self))]
     pub fn validate(&self) -> Result<(), Error> {
         for (package_name, info) in self.packages.iter() {
@@ -171,7 +187,38 @@ impl PackageGraph {
                 Some(_) => continue,
             }
         }
-        graph::validate_graph(&self.graph).map_err(Error::InvalidPackageGraph)?;
+
+        for edge in self.graph.edge_references() {
+            if edge.source() == edge.target()
+                && let Some(PackageNode::Workspace(PackageName::Other(name))) =
+                    self.graph.node_weight(edge.source())
+            {
+                tracing::warn!("Package \"{name}\" depends on itself");
+            }
+        }
+
+        if petgraph::algo::is_cyclic_directed(&self.graph) {
+            let sccs = petgraph::algo::tarjan_scc(&self.graph);
+            let cycle_members: Vec<String> = sccs
+                .into_iter()
+                .filter(|scc| scc.len() > 1)
+                .flat_map(|scc| {
+                    scc.into_iter()
+                        .filter_map(|idx| match self.graph.node_weight(idx)? {
+                            PackageNode::Workspace(PackageName::Other(name)) => {
+                                Some(name.to_string())
+                            }
+                            _ => None,
+                        })
+                })
+                .collect();
+            if !cycle_members.is_empty() {
+                tracing::warn!(
+                    "Circular package dependency detected: {}",
+                    cycle_members.join(", ")
+                );
+            }
+        }
 
         Ok(())
     }
@@ -304,6 +351,9 @@ impl PackageGraph {
     /// a -> b -> c (external)
     ///
     /// dependencies(a) = {b, c}
+    ///
+    /// If the package graph contains cycles, the returned set will include
+    /// all members of any cycle reachable from `node`.
     #[allow(dead_code)]
     pub fn dependencies<'a>(&'a self, node: &PackageNode) -> HashSet<&'a PackageNode> {
         let mut dependencies = turborepo_graph_utils::transitive_closure(
@@ -326,6 +376,9 @@ impl PackageGraph {
     /// a -> b -> c (external)
     ///
     /// ancestors(c) = {a, b}
+    ///
+    /// If the package graph contains cycles, the returned set will include
+    /// all members of any cycle reachable from `node`.
     pub fn ancestors(&self, node: &PackageNode) -> HashSet<&PackageNode> {
         // If node is a root dep, then *every* package is an ancestor of this one
         let mut dependents = if self.root_internal_dependencies().contains(node) {
@@ -375,10 +428,11 @@ impl PackageGraph {
             .collect()
     }
 
-    /// Provides a path from the root package to package
+    /// Provides a path from the root package to package.
     ///
     /// Currently only provides the shortest path as calculating all paths can
-    /// be O(n!)
+    /// be O(n!). If the package graph contains cycles, the shortest path may
+    /// traverse through cycle members.
     pub fn root_internal_dependency_explanation(
         &self,
         package: &WorkspacePackage,
@@ -428,6 +482,9 @@ impl PackageGraph {
     /// the dependencies, or the dependents, use `dependencies` or `ancestors`.
     /// Alternatively, if you need just direct dependents, use
     /// `immediate_dependents`.
+    ///
+    /// If the package graph contains cycles, the returned set will include
+    /// all members of any cycle reachable from the starting nodes.
     pub fn transitive_closure<'a, 'b, I: IntoIterator<Item = &'b PackageNode>>(
         &'a self,
         nodes: I,
@@ -678,8 +735,6 @@ impl AsRef<str> for PackageName {
 
 #[cfg(test)]
 mod test {
-    use std::assert_matches::assert_matches;
-
     use serde_json::json;
     use turborepo_errors::Spanned;
 
@@ -984,11 +1039,35 @@ mod test {
         .await
         .unwrap();
 
-        assert_matches!(
-            pkg_graph.validate(),
-            Err(builder::Error::InvalidPackageGraph(
-                graph::Error::CyclicDependencies { .. }
-            ))
+        // Package graph cycles are intentionally allowed (#2559) — only task
+        // graph cycles block execution (checked in the engine builder).
+        assert!(pkg_graph.validate().is_ok());
+
+        let foo_node = PackageNode::Workspace("foo".into());
+        let bar_node = PackageNode::Workspace("bar".into());
+        let baz_node = PackageNode::Workspace("baz".into());
+
+        // transitive_closure starting from any cycle member includes all members
+        let closure = pkg_graph.transitive_closure(Some(&foo_node));
+        assert!(
+            closure.contains(&foo_node)
+                && closure.contains(&bar_node)
+                && closure.contains(&baz_node),
+            "transitive_closure on a cycle member should include all cycle members: {closure:?}"
+        );
+
+        // dependencies of a cycle member includes the other cycle members
+        let deps = pkg_graph.dependencies(&foo_node);
+        assert!(
+            deps.contains(&bar_node) && deps.contains(&baz_node),
+            "dependencies on a cycle member should include other cycle members: {deps:?}"
+        );
+
+        // ancestors of a cycle member includes the other cycle members
+        let anc = pkg_graph.ancestors(&foo_node);
+        assert!(
+            anc.contains(&bar_node) && anc.contains(&baz_node),
+            "ancestors on a cycle member should include other cycle members: {anc:?}"
         );
     }
 
@@ -1020,11 +1099,30 @@ mod test {
         .await
         .unwrap();
 
-        assert_matches!(
-            pkg_graph.validate(),
-            Err(builder::Error::InvalidPackageGraph(
-                graph::Error::SelfDependency(_)
-            ))
+        // Package graph self-dependencies are intentionally allowed (#2559) —
+        // if this causes a task-level cycle it will be caught by the engine
+        // builder.
+        assert!(pkg_graph.validate().is_ok());
+
+        let foo_node = PackageNode::Workspace("foo".into());
+
+        // Self-dep doesn't cause infinite loops in traversal methods
+        let closure = pkg_graph.transitive_closure(Some(&foo_node));
+        assert!(
+            closure.contains(&foo_node),
+            "transitive_closure on self-dep should include the package itself: {closure:?}"
+        );
+
+        let deps = pkg_graph.dependencies(&foo_node);
+        assert!(
+            !deps.contains(&foo_node),
+            "dependencies() excludes the node itself: {deps:?}"
+        );
+
+        let anc = pkg_graph.ancestors(&foo_node);
+        assert!(
+            !anc.contains(&foo_node),
+            "ancestors() excludes the node itself: {anc:?}"
         );
     }
 

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -68,6 +68,14 @@ Represents the workspace structure and package dependencies:
 - Discovers packages in workspace
 - Performs lockfile analysis
 - Builds dependency relationships between workspace packages
+- Validates that all non-root packages have a `name` field
+  (`PackageGraph::validate()`)
+
+The package graph intentionally allows cyclic dependencies between packages —
+this aligns with how npm, pnpm, and yarn handle cyclic workspace deps. Cycle
+detection is deferred to the task graph layer (engine builder), since
+package-level cycles only matter when they produce task-level cycles via
+topological (`^`) dependencies.
 
 ### 3. Task Graph (`crates/turborepo-lib/src/engine/`)
 
@@ -82,7 +90,8 @@ The core task graph consists of:
 - Parses `turbo.json` and other configuration sources to determine task definitions
 - Resolves task dependencies (topological `^build` and direct `build`)
 - Creates task nodes and dependency edges
-- Validates task definitions and checks for circular dependencies
+- Validates task definitions and is the sole layer that checks for circular
+  dependencies (both cycles and self-dependencies in the task graph)
 
 #### Engine Execution (`crates/turborepo-lib/src/engine/execute.rs`)
 
@@ -281,10 +290,10 @@ command handler.
 
 ```
 RunBuilder
-  ├── Package Discovery → PackageGraph
+  ├── Package Discovery → PackageGraph (validates package names)
   ├── Task Discovery → EngineBuilder
   ├── Task Graph Construction → Engine (built)
-  └── Validation → Ready Engine
+  └── Task Graph Validation (cycles, missing deps) → Ready Engine
 ```
 
 **Process:**
@@ -293,7 +302,7 @@ RunBuilder
 2. Load turbo.json configurations for tasks
 3. Create task nodes for each package × task combination
 4. Build dependency edges based on `dependsOn` configurations
-5. Validate graph for cycles and missing dependencies
+5. Validate task graph for cycles and missing dependencies
 
 ### 2. Task Graph Traversal
 

--- a/crates/turborepo/tests/task_dependencies.rs
+++ b/crates/turborepo/tests/task_dependencies.rs
@@ -1,5 +1,7 @@
 mod common;
 
+use std::fs;
+
 use common::{run_turbo, setup, turbo_output_filters};
 
 fn setup_task_deps(fixture_suffix: &str) -> tempfile::TempDir {
@@ -210,4 +212,92 @@ fn test_workspace_tasks_special_graph() {
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     insta::assert_snapshot!("workspace_tasks_special_graph", stdout.to_string());
+}
+
+// === cyclic.t (see #2559) ===
+
+#[test]
+fn test_cyclic_packages_with_topo_deps_errors() {
+    let tempdir = setup_task_deps("cyclic");
+    let output = run_turbo(tempdir.path(), &["run", "build"]);
+    assert!(
+        !output.status.success(),
+        "cyclic packages with ^build should fail"
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        combined.contains("Cyclic dependency detected"),
+        "expected cycle error, got:\n{combined}"
+    );
+}
+
+#[test]
+fn test_cyclic_packages_without_topo_deps_succeeds() {
+    let tempdir = setup_task_deps("cyclic");
+    let output = run_turbo(tempdir.path(), &["run", "lint"]);
+    assert!(
+        output.status.success(),
+        "cyclic packages with non-topo task should succeed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("pkg-a:lint") && stdout.contains("pkg-b:lint"),
+        "expected both packages to run lint, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_cyclic_packages_filter_scopes_correctly() {
+    let tempdir = setup_task_deps("cyclic");
+    let output = run_turbo(tempdir.path(), &["run", "lint", "--filter=pkg-a"]);
+    assert!(
+        output.status.success(),
+        "--filter on cyclic package should succeed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("pkg-a:lint"),
+        "expected pkg-a:lint to run, got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("pkg-b:lint"),
+        "--filter=pkg-a should not run pkg-b:lint, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_cyclic_packages_prune_includes_all_cycle_members() {
+    let tempdir = setup_task_deps("cyclic");
+    let output = run_turbo(tempdir.path(), &["prune", "pkg-a"]);
+    assert!(
+        output.status.success(),
+        "prune on cyclic package should succeed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // transitive_closure includes all reachable cycle members, so pruning
+    // pkg-a in a pkg-a ↔ pkg-b cycle should include both.
+    assert!(
+        stdout.contains("pkg-b"),
+        "prune should include the other cycle member (pkg-b), got:\n{stdout}"
+    );
+
+    // Verify the pruned output directory actually contains both packages.
+    let out_packages = tempdir.path().join("out").join("packages");
+    assert!(
+        out_packages.join("pkg-a").exists() && out_packages.join("pkg-b").exists(),
+        "pruned output should contain both cycle members, entries: {:?}",
+        fs::read_dir(&out_packages)
+            .map(|rd| rd
+                .filter_map(|e| e.ok())
+                .map(|e| e.file_name().to_string_lossy().to_string())
+                .collect::<Vec<_>>())
+            .unwrap_or_default()
+    );
 }

--- a/turborepo-tests/integration/fixtures/task_dependencies/cyclic/.gitignore
+++ b/turborepo-tests/integration/fixtures/task_dependencies/cyclic/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.turbo
+.npmrc

--- a/turborepo-tests/integration/fixtures/task_dependencies/cyclic/package.json
+++ b/turborepo-tests/integration/fixtures/task_dependencies/cyclic/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "monorepo",
+  "workspaces": [
+    "packages/**"
+  ]
+}

--- a/turborepo-tests/integration/fixtures/task_dependencies/cyclic/packages/pkg-a/package.json
+++ b/turborepo-tests/integration/fixtures/task_dependencies/cyclic/packages/pkg-a/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pkg-a",
+  "scripts": {
+    "build": "echo building-a",
+    "lint": "echo linting-a"
+  },
+  "dependencies": {
+    "pkg-b": "*"
+  }
+}

--- a/turborepo-tests/integration/fixtures/task_dependencies/cyclic/packages/pkg-b/package.json
+++ b/turborepo-tests/integration/fixtures/task_dependencies/cyclic/packages/pkg-b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pkg-b",
+  "scripts": {
+    "build": "echo building-b",
+    "lint": "echo linting-b"
+  },
+  "dependencies": {
+    "pkg-a": "*"
+  }
+}

--- a/turborepo-tests/integration/fixtures/task_dependencies/cyclic/turbo.json
+++ b/turborepo-tests/integration/fixtures/task_dependencies/cyclic/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turborepo.dev/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"]
+    },
+    "lint": {}
+  }
+}


### PR DESCRIPTION
## Summary

Closes #2559

- Package dependency cycles and self-dependencies no longer produce hard errors at the package graph level. Cycles only block execution when they produce a **task graph cycle** (e.g. `^build` through a package cycle, or explicit `pkg-a#build → pkg-b#build → pkg-a#build` references).
- Moves cycle/self-dependency validation from `PackageGraph::validate()` to the engine builder's `validate_graph()` call on the task graph — the sole place cycles are now rejected.
- Adds a pre-walk cycle check in `Engine::execute()` as a safety net to prevent the `Walker` from deadlocking if a cycle somehow reaches execution.
- Guards the `O(2^E)` powerset cut-candidate analysis with `MAX_EDGES_FOR_CUT_ANALYSIS = 15` and provides a `dependsOn`-focused hint for large cycles that skip it.
- Removes curly brackets from cut-candidate formatting.
- Emits terse warnings for package-level cycles/self-deps (e.g. `Circular package dependency detected: pkg-a, pkg-b`) to flag the architectural smell without duplicating the task-level error.
- Uses `saturating_sub` in query indirect counts to prevent underflow when cycles inflate transitive counts.

## Testing

- 5 new unit tests in `engine/builder.rs` covering cyclic packages with and without topo deps, 3-node cycles, and self-dependencies.
- 4 new integration tests in `task_dependencies.rs` using a `cyclic` fixture: topo deps error, non-topo success, `--filter` scoping, and `prune` behavior.
- Existing `package_graph` cycle/self-dep tests updated to assert `Ok` with traversal correctness through cycles.

To manually test error output, create a monorepo with circular package deps and run `turbo run build` where `build` uses `dependsOn: ["^build"]`.

<sub>CLOSES TURBO-5024</sub>