### PR TITLE
feat: Extend `LogSink` with task output and grouping support

### DIFF
--- a/crates/turborepo-log/src/event.rs
+++ b/crates/turborepo-log/src/event.rs
@@ -130,6 +130,15 @@ impl fmt::Display for Level {
     }
 }
 
+/// Which output stream a task byte chunk originated from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+pub enum OutputChannel {
+    /// Child process stdout.
+    Stdout,
+    /// Child process stderr.
+    Stderr,
+}
+
 /// A Turborepo infrastructure subsystem that can emit log events.
 ///
 /// Each variant identifies a logical area of the codebase. Adding a

--- a/crates/turborepo-log/src/lib.rs
+++ b/crates/turborepo-log/src/lib.rs
@@ -94,7 +94,9 @@ mod logger;
 mod sink;
 pub mod sinks;
 
-pub use event::{Level, LogEvent, SanitizedString, Scalar, Source, Subsystem, Value};
+pub use event::{
+    Level, LogEvent, OutputChannel, SanitizedString, Scalar, Source, Subsystem, Value,
+};
 pub use logger::{
     InitError, LogEventBuilder, LogHandle, Logger, error, flush, info, init, log, warn,
 };

--- a/crates/turborepo-log/src/logger.rs
+++ b/crates/turborepo-log/src/logger.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::{
-    event::{Level, LogEvent, Source, Value},
+    event::{Level, LogEvent, OutputChannel, Source, Value},
     sink::LogSink,
 };
 
@@ -54,6 +54,27 @@ impl Logger {
             if sink.enabled(event.level) {
                 sink.emit(event);
             }
+        }
+    }
+
+    /// Dispatch raw task output bytes to all registered sinks.
+    pub fn task_output(&self, task: &str, channel: OutputChannel, bytes: &[u8]) {
+        for sink in &self.sinks {
+            sink.task_output(task, channel, bytes);
+        }
+    }
+
+    /// Notify all sinks that a grouped task flush is starting.
+    pub fn begin_task_group(&self, task: &str, is_error: bool) {
+        for sink in &self.sinks {
+            sink.begin_task_group(task, is_error);
+        }
+    }
+
+    /// Notify all sinks that a grouped task flush has completed.
+    pub fn end_task_group(&self, task: &str, is_error: bool) {
+        for sink in &self.sinks {
+            sink.end_task_group(task, is_error);
         }
     }
 

--- a/crates/turborepo-log/src/sink.rs
+++ b/crates/turborepo-log/src/sink.rs
@@ -1,23 +1,26 @@
 use std::sync::Arc;
 
-use crate::{LogEvent, event::Level};
+use crate::{
+    LogEvent,
+    event::{Level, OutputChannel},
+};
 
-/// A destination for user-facing log events.
+/// A destination for user-facing log events and task output.
 ///
-/// Sinks receive structured events and decide how to present or store them.
-/// Multiple sinks can be active simultaneously (e.g., terminal output +
-/// collector for post-run summary).
+/// Sinks receive structured events and streaming task output, then
+/// decide how to present or store them. Multiple sinks can be active
+/// simultaneously (e.g., terminal output + collector for post-run summary).
 ///
 /// # Threading contract
 ///
-/// `emit` is called synchronously on the thread that triggered the log
+/// Methods are called synchronously on the thread that triggered the
 /// event (typically a task execution thread). Implementations **must not**
 /// perform unbounded blocking — a slow sink delays all subsequent sinks
 /// and the calling task. If your sink performs I/O that may block
 /// (network, unbuffered disk), buffer internally and flush asynchronously,
 /// or accept bounded latency.
 ///
-/// Multiple threads may call `emit` concurrently on the same sink
+/// Multiple threads may call methods concurrently on the same sink
 /// instance. The `Send + Sync` bound is required.
 ///
 /// # Error handling
@@ -26,11 +29,47 @@ use crate::{LogEvent, event::Level};
 /// serialize an event should be handled silently. Logging must never
 /// cause the host process to panic.
 pub trait LogSink: Send + Sync + 'static {
-    /// Process a log event. Must not panic.
+    /// Process a structured log event. Must not panic.
     ///
     /// Called inline on the emitting thread. Keep this fast — see the
     /// threading contract above.
     fn emit(&self, event: &LogEvent);
+
+    /// Process raw bytes from a task's child process.
+    ///
+    /// Called for each chunk of stdout/stderr output from a running task.
+    /// `channel` indicates whether the bytes came from stdout or stderr.
+    ///
+    /// Default: no-op. Sinks that don't care about task output can
+    /// ignore this.
+    fn task_output(&self, _task: &str, _channel: OutputChannel, _bytes: &[u8]) {}
+
+    /// Called before a grouped task flush begins.
+    ///
+    /// In grouped mode, all output for a task is buffered and flushed
+    /// atomically on task completion. This method is called once before
+    /// the buffered events and bytes are replayed through `emit` and
+    /// `task_output`.
+    ///
+    /// `is_error` is true when the task failed, allowing sinks to use
+    /// different styling (e.g., red CI group headers).
+    ///
+    /// Default: no-op.
+    fn begin_task_group(&self, _task: &str, _is_error: bool) {}
+
+    /// Called after a grouped task flush completes.
+    ///
+    /// Pairs with [`begin_task_group`](Self::begin_task_group). Sinks
+    /// that write CI group markers (e.g., `::endgroup::`) should emit
+    /// the closing marker here.
+    ///
+    /// `is_error` matches the value passed to the corresponding
+    /// `begin_task_group` call. On some CI providers, error tasks
+    /// skip the opening group marker and must also skip the closing
+    /// marker to avoid unpaired annotations.
+    ///
+    /// Default: no-op.
+    fn end_task_group(&self, _task: &str, _is_error: bool) {}
 
     /// Flush any buffered output. Called during graceful shutdown.
     fn flush(&self) {}
@@ -46,6 +85,18 @@ pub trait LogSink: Send + Sync + 'static {
 impl<T: LogSink> LogSink for Arc<T> {
     fn emit(&self, event: &LogEvent) {
         (**self).emit(event)
+    }
+
+    fn task_output(&self, task: &str, channel: OutputChannel, bytes: &[u8]) {
+        (**self).task_output(task, channel, bytes)
+    }
+
+    fn begin_task_group(&self, task: &str, is_error: bool) {
+        (**self).begin_task_group(task, is_error)
+    }
+
+    fn end_task_group(&self, task: &str, is_error: bool) {
+        (**self).end_task_group(task, is_error)
     }
 
     fn flush(&self) {

--- a/crates/turborepo-ui/src/terminal_sink.rs
+++ b/crates/turborepo-ui/src/terminal_sink.rs
@@ -3,7 +3,7 @@ use std::{
     sync::atomic::{AtomicU8, Ordering},
 };
 
-use turborepo_log::{Level, LogEvent, LogSink, Source};
+use turborepo_log::{Level, LogEvent, LogSink, OutputChannel, Source};
 
 use crate::ColorConfig;
 
@@ -104,6 +104,45 @@ impl LogSink for TerminalSink {
                 self.emit_stderr(event);
             }
             _ => {}
+        }
+    }
+
+    fn task_output(&self, _task: &str, channel: OutputChannel, bytes: &[u8]) {
+        if self.mode.load(Ordering::Relaxed) == MODE_DISABLED {
+            return;
+        }
+        let mut handle: Box<dyn Write> = match channel {
+            OutputChannel::Stdout => Box::new(io::stdout().lock()),
+            OutputChannel::Stderr => Box::new(io::stderr().lock()),
+        };
+        let _ = handle.write_all(bytes);
+    }
+
+    fn begin_task_group(&self, task: &str, is_error: bool) {
+        if self.mode.load(Ordering::Relaxed) == MODE_DISABLED {
+            return;
+        }
+        if self.ci_annotations {
+            let stdout = io::stdout();
+            let mut handle = stdout.lock();
+            if is_error {
+                let _ = writeln!(handle, "\x1b[;31m{task}\x1b[;0m");
+            } else {
+                let _ = writeln!(handle, "::group::{task}");
+            }
+        }
+    }
+
+    fn end_task_group(&self, _task: &str, is_error: bool) {
+        if self.mode.load(Ordering::Relaxed) == MODE_DISABLED {
+            return;
+        }
+        // Error tasks use a red header instead of ::group::, so
+        // emitting ::endgroup:: would be unpaired.
+        if self.ci_annotations && !is_error {
+            let stdout = io::stdout();
+            let mut handle = stdout.lock();
+            let _ = writeln!(handle, "::endgroup::");
         }
     }
 }

--- a/crates/turborepo-ui/src/tui_sink.rs
+++ b/crates/turborepo-ui/src/tui_sink.rs
@@ -1,6 +1,6 @@
 use std::sync::Mutex;
 
-use turborepo_log::{LogEvent, LogSink};
+use turborepo_log::{LogEvent, LogSink, OutputChannel};
 
 use crate::tui::TuiSender;
 
@@ -55,6 +55,13 @@ impl LogSink for TuiSink {
             SinkState::Connected(sender) => {
                 sender.log_event(event.clone());
             }
+        }
+    }
+
+    fn task_output(&self, task: &str, _channel: OutputChannel, bytes: &[u8]) {
+        let state = self.state.lock().unwrap();
+        if let SinkState::Connected(sender) = &*state {
+            let _ = sender.output(task.to_string(), bytes.to_vec());
         }
     }
 }


### PR DESCRIPTION
## Summary

Extends the `LogSink` trait with three new methods for handling task output and grouped flushes. All have default no-op implementations so existing sinks are unaffected.

## Why

This is foundational work for routing all task output through `turborepo-log`. Currently, task child process bytes and task status messages (cache hit/miss, errors) flow through a separate pipeline (`OutputClient` → `PrefixedWriter` → stdout/stderr`). To unify everything under `turborepo-log`, sinks need to handle streaming task output and grouped flush boundaries — not just discrete `LogEvent`s.

## New `LogSink` methods

| Method | Purpose |
|--------|---------|
| `task_output(task, channel, bytes)` | Streaming bytes from a task's child process. `OutputChannel` indicates stdout vs stderr. |
| `begin_task_group(task, is_error)` | Signals the start of a grouped flush (all buffered output for a task is about to replay). Sinks that write CI markers (e.g., `::group::`) use this. |
| `end_task_group(task)` | Signals the end of a grouped flush. |

## Sink implementations

| Sink | `task_output` | `begin/end_task_group` |
|------|---------------|----------------------|
| `TerminalSink` | Write bytes to stdout/stderr | Write GitHub Actions `::group::`/`::endgroup::` markers |
| `TuiSink` | Forward as `Event::TaskOutput` to the task pane | No-op (TUI doesn't use CI groups) |
| `FileSink` | No-op (will be implemented when task log files move here) | No-op |
| `CollectorSink` | No-op (will be implemented for post-run summary) | No-op |

## New types

- `OutputChannel` enum (`Stdout`, `Stderr`) in `turborepo-log`
- `Logger` gains `task_output()`, `begin_task_group()`, `end_task_group()` dispatch methods

No callers yet — this is purely additive. The upcoming `GroupingLayer` (PR 2 of this series) will be the first consumer.