### PR TITLE
fix: Detect affected tasks with `$TURBO_ROOT$` inputs when using `affectedUsingTaskInputs`

### DIFF
--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -663,15 +663,33 @@ impl RunBuilder {
             )?
         };
 
+        let use_task_level_affected = self.opts.scope_opts.affected_range.is_some()
+            && self.opts.future_flags.affected_using_task_inputs;
+
+        // When task-level affected filtering is active, the engine must
+        // contain tasks for ALL packages so that $TURBO_ROOT$ inputs in
+        // packages not flagged by the package-level scope resolution are
+        // still matched. The task-level filter (below) does the pruning.
+        let all_pkgs: Vec<PackageName> = if use_task_level_affected {
+            pkg_dep_graph
+                .packages()
+                .map(|(name, _)| name.clone())
+                .collect()
+        } else {
+            Vec::new()
+        };
+        let engine_pkgs: Box<dyn Iterator<Item = &PackageName>> = if use_task_level_affected {
+            Box::new(all_pkgs.iter())
+        } else {
+            Box::new(filtered_pkgs.keys())
+        };
+
         let mut engine = self.build_engine(
             &pkg_dep_graph,
             &root_turbo_json,
-            filtered_pkgs.keys(),
+            engine_pkgs,
             &turbo_json_loader,
         )?;
-
-        let use_task_level_affected = self.opts.scope_opts.affected_range.is_some()
-            && self.opts.future_flags.affected_using_task_inputs;
 
         let task_access = {
             let _span = tracing::info_span!("task_access_setup").entered();
@@ -685,10 +703,15 @@ impl RunBuilder {
         // rather than on both engines to avoid a redundant SCM query.
         if self.opts.run_opts.parallel {
             pkg_dep_graph.remove_package_dependencies();
+            let engine_pkgs: Box<dyn Iterator<Item = &PackageName>> = if use_task_level_affected {
+                Box::new(all_pkgs.iter())
+            } else {
+                Box::new(filtered_pkgs.keys())
+            };
             engine = self.build_engine(
                 &pkg_dep_graph,
                 &root_turbo_json,
-                filtered_pkgs.keys(),
+                engine_pkgs,
                 &turbo_json_loader,
             )?;
         }

--- a/crates/turborepo/tests/affected_test.rs
+++ b/crates/turborepo/tests/affected_test.rs
@@ -1024,6 +1024,82 @@ fn test_task_level_affected_global_file_runs_everything() {
     );
 }
 
+/// Regression test for https://github.com/vercel/turborepo/issues/12329
+///
+/// When a task declares a `$TURBO_ROOT$` input, changing that root-level file
+/// should mark the task as affected. Previously, the package-level scope
+/// resolution excluded non-root packages (since the file isn't inside them),
+/// so the engine never contained their tasks and the task-level filter couldn't
+/// match them.
+#[test]
+fn test_task_level_affected_turbo_root_input() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let dir = tempdir.path();
+
+    setup::setup_integration_test(dir, "affected_tasks_inputs", "npm@10.5.0", true).unwrap();
+
+    // Create a root-level config file that tasks will reference.
+    fs::write(dir.join("rootconfig.txt"), "v1").unwrap();
+
+    // turbo.json: build uses $TURBO_ROOT$/rootconfig.txt as an input.
+    // This means every package's build task depends on that root file.
+    let turbo_json = r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": [],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/rootconfig.txt"]
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "!**/*.md"]
+    }
+  },
+  "futureFlags": {
+    "affectedUsingTaskInputs": true
+  }
+}"#;
+    fs::write(dir.join("turbo.json"), turbo_json).unwrap();
+
+    git(dir, &["add", "."]);
+    git(dir, &["commit", "-m", "setup", "--quiet"]);
+    git(dir, &["checkout", "-b", "my-branch"]);
+
+    // Change ONLY the root-level file. No package source files change.
+    fs::write(dir.join("rootconfig.txt"), "v2").unwrap();
+
+    let output = run_turbo(dir, &["run", "build", "test", "--affected", "--dry=json"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("failed to parse dry run JSON: {e}\nstdout: {stdout}"));
+
+    let tasks = json["tasks"].as_array().expect("tasks array");
+    let task_ids: Vec<&str> = tasks
+        .iter()
+        .map(|t| t["taskId"].as_str().unwrap())
+        .collect();
+
+    // Both packages have a build task with $TURBO_ROOT$/rootconfig.txt input.
+    // Changing rootconfig.txt should mark both as affected.
+    assert!(
+        task_ids.contains(&"lib-a#build"),
+        "lib-a#build should be affected by $TURBO_ROOT$ input change: {task_ids:?}"
+    );
+    assert!(
+        task_ids.contains(&"app-a#build"),
+        "app-a#build should be affected by $TURBO_ROOT$ input change: {task_ids:?}"
+    );
+
+    // test tasks don't reference $TURBO_ROOT$/rootconfig.txt and no package
+    // source files changed, so they should NOT be directly affected.
+    assert!(
+        !task_ids.contains(&"lib-a#test"),
+        "lib-a#test should NOT be affected (no source changes, no root input): {task_ids:?}"
+    );
+}
+
 #[test]
 fn test_affected_with_nonexistent_task_errors() {
     let tempdir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- Fixes `--affected` + `affectedUsingTaskInputs` not detecting tasks whose only changed input is a `$TURBO_ROOT$` file

Closes #12329

## Problem

When `affectedUsingTaskInputs` is enabled, affected detection runs in two phases:

1. **Package-level scope resolution** determines which packages have changed files
2. **Task-level filtering** checks each engine task's `inputs` globs against the changed files

The bug: phase 1 uses `GlobalDepsPackageChangeMapper` which, for a root-level file not in `globalDependencies`, only marks the root package as changed. Non-root packages are excluded from `filtered_pkgs`, so `build_engine()` never creates their tasks. When phase 2 runs, it iterates an engine that's already missing the tasks it needs to match.

## Fix

When `affectedUsingTaskInputs` is active, the engine is now built with **all** packages instead of only the package-level filtered set. This lets `match_tasks_against_changed_files()` see every task — including those in packages whose own source files didn't change but whose `$TURBO_ROOT$` inputs did. The task-level filter then prunes down to only the truly affected tasks.

## Testing

New integration test `test_task_level_affected_turbo_root_input`:
- Sets up a monorepo where `build` tasks declare `$TURBO_ROOT$/rootconfig.txt` as an input
- Changes only the root file (no package source changes)
- Asserts both `lib-a#build` and `app-a#build` are detected as affected
- Asserts `test` tasks (which don't reference the root file) are NOT affected

This test fails without the fix (`task_ids` is empty) and passes with it.