### PR TITLE
fix: Stop `add-package-names` codemod from silently renaming existing packages

### DIFF
--- a/packages/turbo-codemod/__tests__/__fixtures__/add-package-names/root-shares-name-with-workspace/package.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/add-package-names/root-shares-name-with-workspace/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "my-lib",
+  "version": "1.0.0",
+  "workspaces": [
+    "packages/*"
+  ],
+  "dependencies": {},
+  "devDependencies": {},
+  "packageManager": "npm@1.2.3"
+}

--- a/packages/turbo-codemod/__tests__/__fixtures__/add-package-names/root-shares-name-with-workspace/packages/lib/package.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/add-package-names/root-shares-name-with-workspace/packages/lib/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "my-lib",
+  "version": "1.0.0",
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/packages/turbo-codemod/__tests__/add-package-names.test.ts
+++ b/packages/turbo-codemod/__tests__/add-package-names.test.ts
@@ -50,7 +50,7 @@ describe("add-package-names", () => {
     }
   });
 
-  it("duplicate names", async () => {
+  it("duplicate names - aborts with error", async () => {
     // load the fixture for the test
     const { root, readJson } = useFixture({
       fixture: "duplicate-names"
@@ -62,28 +62,17 @@ describe("add-package-names", () => {
       options: { force: false, dryRun: false, print: false }
     });
 
-    // result should be correct
-    expect(result.fatalError).toBeUndefined();
-    expect(result.changes).toMatchInlineSnapshot(`
-      {
-        "packages/utils/package.json": {
-          "action": "modified",
-          "additions": 1,
-          "deletions": 1,
-        },
-      }
-    `);
+    // should abort with an error listing the duplicate names
+    expect(result.fatalError).toBeDefined();
+    expect(result.fatalError?.message).toContain("some-pkg");
+    expect(result.changes).toMatchInlineSnapshot(`{}`);
 
-    // validate unique names
-    const names = new Set();
-
+    // verify names are unchanged
     for (const pkg of ["ui", "utils"]) {
       const pkgJson = readJson<{ name: string }>(
         `packages/${pkg}/package.json`
       );
-      expect(pkgJson?.name).toBeDefined();
-      expect(names.has(pkgJson?.name)).toBe(false);
-      names.add(pkgJson?.name);
+      expect(pkgJson?.name).toBe("some-pkg");
     }
   });
 
@@ -114,6 +103,28 @@ describe("add-package-names", () => {
       expect(names.has(pkgJson?.name)).toBe(false);
       names.add(pkgJson?.name);
     }
+  });
+
+  it("aborts when workspace package shares name with root (#8312)", async () => {
+    // load the fixture for the test
+    const { root, readJson } = useFixture({
+      fixture: "root-shares-name-with-workspace"
+    });
+
+    // run the transformer
+    const result = await transformer({
+      root,
+      options: { force: false, dryRun: false, print: false }
+    });
+
+    // should abort with an error about the duplicate "my-lib" name
+    expect(result.fatalError).toBeDefined();
+    expect(result.fatalError?.message).toContain("my-lib");
+    expect(result.changes).toMatchInlineSnapshot(`{}`);
+
+    // the lib package must keep its original name — never renamed
+    const libPkg = readJson<{ name: string }>("packages/lib/package.json");
+    expect(libPkg?.name).toBe("my-lib");
   });
 
   it("ignored packages", async () => {

--- a/packages/turbo-codemod/src/transforms/add-package-names.ts
+++ b/packages/turbo-codemod/src/transforms/add-package-names.ts
@@ -87,29 +87,49 @@ export async function transformer({
     packagePaths.map((pkgJsonPath, idx) => [pkgJsonPath, packageContent[idx]])
   );
 
-  // wait for all package.json files to be read
-  const names = new Set();
+  // Collect existing names and detect duplicates.
+  const nameToPackages = new Map<string, Array<string>>();
   for (const [pkgJsonPath, pkgJsonContent] of Object.entries(
     packageToContent
   )) {
-    if (pkgJsonContent) {
-      // name is missing or isn't unique
-      if (!pkgJsonContent.name || names.has(pkgJsonContent.name)) {
-        const newName = getNewPkgName({
-          pkgPath: pkgJsonPath,
-          pkgName: pkgJsonContent.name
-        });
-        runner.modifyFile({
-          filePath: pkgJsonPath,
-          after: {
-            ...pkgJsonContent,
-            name: newName
-          }
-        });
-        names.add(newName);
-      } else {
-        names.add(pkgJsonContent.name);
-      }
+    if (pkgJsonContent?.name) {
+      const existing = nameToPackages.get(pkgJsonContent.name) || [];
+      existing.push(pkgJsonPath);
+      nameToPackages.set(pkgJsonContent.name, existing);
+    }
+  }
+
+  const duplicates = [...nameToPackages.entries()].filter(
+    ([, paths]) => paths.length > 1
+  );
+  if (duplicates.length > 0) {
+    const messages = duplicates.map(([name, paths]) => {
+      const relativePaths = paths.map((p) => path.relative(root, p));
+      return `  - "${name}" found in: ${relativePaths.join(", ")}`;
+    });
+    return runner.abortTransform({
+      reason: `Found packages with duplicate "name" fields:\n${messages.join("\n")}\nPlease resolve these duplicates manually and re-run the codemod.`
+    });
+  }
+
+  // Add names only to packages that are missing one.
+  const existingNames = new Set(nameToPackages.keys());
+  for (const [pkgJsonPath, pkgJsonContent] of Object.entries(
+    packageToContent
+  )) {
+    if (pkgJsonContent && !pkgJsonContent.name) {
+      const newName = getNewPkgName({
+        pkgPath: pkgJsonPath,
+        pkgName: undefined
+      });
+      runner.modifyFile({
+        filePath: pkgJsonPath,
+        after: {
+          ...pkgJsonContent,
+          name: newName
+        }
+      });
+      existingNames.add(newName);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #8312.

The `add-package-names` codemod was silently renaming workspace packages when it detected duplicate `name` fields. When a workspace package shared its name with the root `package.json` (common in monorepos where the root is named after the primary library), the codemod renamed the workspace package to `{dirName}-{originalName}`, breaking builds.

The codemod's job is to **add** names to packages that lack them — not to rename existing ones. It can't know which duplicate is the "right" one, so it shouldn't guess.

## What changed

- **Duplicate names now abort the transform** with an actionable error listing exactly which packages share which names, so the user can fix them manually.
- **Packages that already have names are never modified.**
- Missing names are still generated from the directory name, same as before.