### PR TITLE
fix: Support private GitHub repos in `turbo gen workspace --copy`

### DIFF
--- a/packages/turbo-utils/__tests__/examples.test.ts
+++ b/packages/turbo-utils/__tests__/examples.test.ts
@@ -23,7 +23,8 @@ import {
   hasRepo,
   isPathSafe,
   isLinkEntry,
-  streamingExtract
+  streamingExtract,
+  downloadAndExtractRepo
 } from "../src/examples";
 
 describe("examples", () => {
@@ -192,6 +193,215 @@ describe("examples", () => {
         );
       }
     );
+  });
+
+  describe("private repository support (issue #5945)", () => {
+    let savedGitHubToken: string | undefined;
+    let savedGhToken: string | undefined;
+
+    beforeEach(() => {
+      savedGitHubToken = process.env.GITHUB_TOKEN;
+      savedGhToken = process.env.GH_TOKEN;
+      delete process.env.GITHUB_TOKEN;
+      delete process.env.GH_TOKEN;
+    });
+
+    afterEach(() => {
+      if (savedGitHubToken !== undefined) {
+        process.env.GITHUB_TOKEN = savedGitHubToken;
+      } else {
+        delete process.env.GITHUB_TOKEN;
+      }
+      if (savedGhToken !== undefined) {
+        process.env.GH_TOKEN = savedGhToken;
+      } else {
+        delete process.env.GH_TOKEN;
+      }
+    });
+
+    it("isUrlOk sends Authorization header when GITHUB_TOKEN is set", async () => {
+      process.env.GITHUB_TOKEN = "ghp_test_token_123";
+
+      global.fetch = jest.fn(() =>
+        Promise.resolve({ ok: true } as Response)
+      ) as typeof fetch;
+
+      const url =
+        "https://api.github.com/repos/private-user/repo/contents/package.json?ref=main";
+      await isUrlOk(url);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        url,
+        expect.objectContaining({
+          method: "HEAD",
+          headers: expect.objectContaining({
+            Authorization: "Bearer ghp_test_token_123"
+          })
+        })
+      );
+    });
+
+    it("isUrlOk sends Authorization header when GH_TOKEN is set", async () => {
+      process.env.GH_TOKEN = "ghp_gh_token_456";
+
+      global.fetch = jest.fn(() =>
+        Promise.resolve({ ok: true } as Response)
+      ) as typeof fetch;
+
+      const url =
+        "https://api.github.com/repos/private-user/repo/contents/package.json?ref=main";
+      await isUrlOk(url);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        url,
+        expect.objectContaining({
+          method: "HEAD",
+          headers: expect.objectContaining({
+            Authorization: "Bearer ghp_gh_token_456"
+          })
+        })
+      );
+    });
+
+    it("GITHUB_TOKEN takes precedence over GH_TOKEN", async () => {
+      process.env.GITHUB_TOKEN = "ghp_primary";
+      process.env.GH_TOKEN = "ghp_secondary";
+
+      global.fetch = jest.fn(() =>
+        Promise.resolve({ ok: true } as Response)
+      ) as typeof fetch;
+
+      const url = "https://api.github.com/repos/private-user/repo";
+      await isUrlOk(url);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        url,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: "Bearer ghp_primary"
+          })
+        })
+      );
+    });
+
+    it("no Authorization header when no token env vars are set", async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({ ok: true } as Response)
+      ) as typeof fetch;
+
+      const url =
+        "https://api.github.com/repos/vercel/turbo/contents/package.json?ref=main";
+      await isUrlOk(url);
+
+      const callArgs = (global.fetch as jest.Mock).mock.calls[0] as [
+        string,
+        RequestInit
+      ];
+      const headers = callArgs[1].headers as Record<string, string> | undefined;
+      expect(headers?.Authorization).toBeUndefined();
+    });
+
+    it("no Authorization header for non-GitHub URLs", async () => {
+      process.env.GITHUB_TOKEN = "ghp_test_token_123";
+
+      global.fetch = jest.fn(() =>
+        Promise.resolve({ ok: true } as Response)
+      ) as typeof fetch;
+
+      const url = "https://example.com/some-api";
+      await isUrlOk(url);
+
+      const callArgs = (global.fetch as jest.Mock).mock.calls[0] as [
+        string,
+        RequestInit
+      ];
+      const headers = callArgs[1].headers as Record<string, string> | undefined;
+      expect(headers?.Authorization).toBeUndefined();
+    });
+
+    it("getRepoInfo sends auth header when fetching default branch for private repo", async () => {
+      process.env.GITHUB_TOKEN = "ghp_test_token_123";
+
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ default_branch: "main" })
+        } as Response)
+      ) as typeof fetch;
+
+      const url = new URL("https://github.com/private-user/private-repo/");
+      await getRepoInfo(url);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://api.github.com/repos/private-user/private-repo",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: "Bearer ghp_test_token_123"
+          })
+        })
+      );
+    });
+
+    it("hasRepo sends auth header for private repo contents check", async () => {
+      process.env.GITHUB_TOKEN = "ghp_test_token_123";
+
+      global.fetch = jest.fn(() =>
+        Promise.resolve({ ok: true } as Response)
+      ) as typeof fetch;
+
+      await hasRepo({
+        username: "private-user",
+        name: "private-repo",
+        branch: "main",
+        filePath: "packages/my-app"
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://api.github.com/repos/private-user/private-repo/contents/packages/my-app/package.json?ref=main",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: "Bearer ghp_test_token_123"
+          })
+        })
+      );
+    });
+
+    it("downloadAndExtractRepo sends auth header for private repo tarball", async () => {
+      process.env.GITHUB_TOKEN = "ghp_test_token_123";
+
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          ok: true,
+          arrayBuffer: () => Promise.resolve(new ArrayBuffer(0))
+        } as Response)
+      ) as typeof fetch;
+
+      const root = join(tmpdir(), `turbo-test-download-${Date.now()}`);
+      mkdirSync(root, { recursive: true });
+
+      try {
+        await downloadAndExtractRepo(root, {
+          username: "private-user",
+          name: "private-repo",
+          branch: "main",
+          filePath: ""
+        }).catch(() => {
+          // Expected to fail on extraction since we returned empty data.
+          // We only care that auth headers were sent.
+        });
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          "https://codeload.github.com/private-user/private-repo/tar.gz/main",
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              Authorization: "Bearer ghp_test_token_123"
+            })
+          })
+        );
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
   });
 
   describe("isPathSafe (Zip Slip protection)", () => {

--- a/packages/turbo-utils/src/examples.ts
+++ b/packages/turbo-utils/src/examples.ts
@@ -14,6 +14,30 @@ import { error, warn } from "./logger";
 const REQUEST_TIMEOUT = 10000;
 const DOWNLOAD_TIMEOUT = 120000;
 
+const GITHUB_API_HOSTS = new Set(["api.github.com", "codeload.github.com"]);
+
+function getGitHubToken(): string | undefined {
+  return process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+}
+
+function getGitHubAuthHeaders(url: string): Record<string, string> {
+  try {
+    const { hostname } = new URL(url);
+    if (!GITHUB_API_HOSTS.has(hostname)) {
+      return {};
+    }
+  } catch {
+    return {};
+  }
+
+  const token = getGitHubToken();
+  if (!token) {
+    return {};
+  }
+
+  return { Authorization: `Bearer ${token}` };
+}
+
 /**
  * Gets proxy URL from environment variables.
  * Checks both lowercase and uppercase variants.
@@ -70,8 +94,15 @@ async function fetchWithTimeout(
       ? getProxyAgent(proxyUrl)
       : undefined;
 
+    const authHeaders = getGitHubAuthHeaders(url);
+    const headers =
+      Object.keys(authHeaders).length > 0
+        ? { ...authHeaders, ...(options.headers as Record<string, string>) }
+        : options.headers;
+
     return await fetch(url, {
       ...options,
+      headers,
       signal: controller.signal,
       // @ts-expect-error - dispatcher is a valid option for undici's fetch
       dispatcher
@@ -255,7 +286,12 @@ export async function streamingExtract({
       ? getProxyAgent(proxyUrl)
       : undefined;
 
+    const authHeaders = getGitHubAuthHeaders(url);
+    const headers =
+      Object.keys(authHeaders).length > 0 ? authHeaders : undefined;
+
     const response = await fetch(url, {
+      headers,
       signal: controller.signal,
       // @ts-expect-error - dispatcher is a valid option for undici's fetch
       dispatcher


### PR DESCRIPTION
## Summary

- `turbo gen workspace --copy <github-url>` now authenticates GitHub API requests when `GITHUB_TOKEN` or `GH_TOKEN` is set, fixing the "Could not locate the repository" error for private repos.

## Problem

All GitHub API calls (`api.github.com`) and tarball downloads (`codeload.github.com`) in `@turbo/utils` were unauthenticated. Private repos return 404 on unauthenticated requests, so `hasRepo()` returns false and the user gets an unhelpful error.

Affects: `turbo gen workspace --copy`, `create-turbo --example` (same code path).

## Fix

Added `getGitHubAuthHeaders(url)` in `examples.ts` that injects `Authorization: Bearer <token>` headers on requests to `api.github.com` and `codeload.github.com` when a token is available. This covers all four GitHub request paths: repo existence check (`hasRepo`), default branch lookup (`getRepoInfo`), contents check (`isUrlOk`), and tarball download (`downloadAndExtractRepo` / `streamingExtract`).

Token lookup order: `GITHUB_TOKEN` > `GH_TOKEN` (matches `gh` CLI conventions).

## How to test

```sh
# Without token — should fail for private repos (existing behavior)
turbo gen workspace --copy https://github.com/your-private/repo/tree/main/packages/foo

# With token — should succeed
GITHUB_TOKEN=ghp_xxx turbo gen workspace --copy https://github.com/your-private/repo/tree/main/packages/foo
```

Closes #5945