### PR TITLE
fix: Hardening for supporting private GitHub repos in `turbo gen workspace --copy`

### DIFF
--- a/packages/turbo-utils/__tests__/examples.test.ts
+++ b/packages/turbo-utils/__tests__/examples.test.ts
@@ -220,7 +220,7 @@ describe("examples", () => {
     });
 
     it("isUrlOk sends Authorization header when GITHUB_TOKEN is set", async () => {
-      process.env.GITHUB_TOKEN = "ghp_test_token_123";
+      process.env.GITHUB_TOKEN = "test_fake_token_123";
 
       global.fetch = jest.fn(() =>
         Promise.resolve({ ok: true } as Response)
@@ -235,14 +235,14 @@ describe("examples", () => {
         expect.objectContaining({
           method: "HEAD",
           headers: expect.objectContaining({
-            Authorization: "Bearer ghp_test_token_123"
+            Authorization: "Bearer test_fake_token_123"
           })
         })
       );
     });
 
     it("isUrlOk sends Authorization header when GH_TOKEN is set", async () => {
-      process.env.GH_TOKEN = "ghp_gh_token_456";
+      process.env.GH_TOKEN = "test_fake_gh_token_456";
 
       global.fetch = jest.fn(() =>
         Promise.resolve({ ok: true } as Response)
@@ -257,15 +257,15 @@ describe("examples", () => {
         expect.objectContaining({
           method: "HEAD",
           headers: expect.objectContaining({
-            Authorization: "Bearer ghp_gh_token_456"
+            Authorization: "Bearer test_fake_gh_token_456"
           })
         })
       );
     });
 
     it("GITHUB_TOKEN takes precedence over GH_TOKEN", async () => {
-      process.env.GITHUB_TOKEN = "ghp_primary";
-      process.env.GH_TOKEN = "ghp_secondary";
+      process.env.GITHUB_TOKEN = "test_fake_primary";
+      process.env.GH_TOKEN = "test_fake_secondary";
 
       global.fetch = jest.fn(() =>
         Promise.resolve({ ok: true } as Response)
@@ -278,7 +278,7 @@ describe("examples", () => {
         url,
         expect.objectContaining({
           headers: expect.objectContaining({
-            Authorization: "Bearer ghp_primary"
+            Authorization: "Bearer test_fake_primary"
           })
         })
       );
@@ -302,7 +302,7 @@ describe("examples", () => {
     });
 
     it("no Authorization header for non-GitHub URLs", async () => {
-      process.env.GITHUB_TOKEN = "ghp_test_token_123";
+      process.env.GITHUB_TOKEN = "test_fake_token_123";
 
       global.fetch = jest.fn(() =>
         Promise.resolve({ ok: true } as Response)
@@ -319,8 +319,30 @@ describe("examples", () => {
       expect(headers?.Authorization).toBeUndefined();
     });
 
+    it.each([
+      "https://api.github.com.evil.com/repos/user/repo",
+      "https://evil-api.github.com/repos/user/repo",
+      "https://codeload.github.com.attacker.io/user/repo/tar.gz/main",
+      "https://github.com/user/repo"
+    ])("no Authorization header for look-alike domain: %s", async (url) => {
+      process.env.GITHUB_TOKEN = "test_fake_token_bypass";
+
+      global.fetch = jest.fn(() =>
+        Promise.resolve({ ok: true } as Response)
+      ) as typeof fetch;
+
+      await isUrlOk(url);
+
+      const callArgs = (global.fetch as jest.Mock).mock.calls[0] as [
+        string,
+        RequestInit
+      ];
+      const headers = callArgs[1].headers as Record<string, string> | undefined;
+      expect(headers?.Authorization).toBeUndefined();
+    });
+
     it("getRepoInfo sends auth header when fetching default branch for private repo", async () => {
-      process.env.GITHUB_TOKEN = "ghp_test_token_123";
+      process.env.GITHUB_TOKEN = "test_fake_token_123";
 
       global.fetch = jest.fn(() =>
         Promise.resolve({
@@ -336,14 +358,14 @@ describe("examples", () => {
         "https://api.github.com/repos/private-user/private-repo",
         expect.objectContaining({
           headers: expect.objectContaining({
-            Authorization: "Bearer ghp_test_token_123"
+            Authorization: "Bearer test_fake_token_123"
           })
         })
       );
     });
 
     it("hasRepo sends auth header for private repo contents check", async () => {
-      process.env.GITHUB_TOKEN = "ghp_test_token_123";
+      process.env.GITHUB_TOKEN = "test_fake_token_123";
 
       global.fetch = jest.fn(() =>
         Promise.resolve({ ok: true } as Response)
@@ -360,14 +382,14 @@ describe("examples", () => {
         "https://api.github.com/repos/private-user/private-repo/contents/packages/my-app/package.json?ref=main",
         expect.objectContaining({
           headers: expect.objectContaining({
-            Authorization: "Bearer ghp_test_token_123"
+            Authorization: "Bearer test_fake_token_123"
           })
         })
       );
     });
 
     it("downloadAndExtractRepo sends auth header for private repo tarball", async () => {
-      process.env.GITHUB_TOKEN = "ghp_test_token_123";
+      process.env.GITHUB_TOKEN = "test_fake_token_123";
 
       global.fetch = jest.fn(() =>
         Promise.resolve({
@@ -380,21 +402,22 @@ describe("examples", () => {
       mkdirSync(root, { recursive: true });
 
       try {
-        await downloadAndExtractRepo(root, {
-          username: "private-user",
-          name: "private-repo",
-          branch: "main",
-          filePath: ""
-        }).catch(() => {
-          // Expected to fail on extraction since we returned empty data.
-          // We only care that auth headers were sent.
-        });
+        // Extraction fails because we returned an empty ArrayBuffer
+        await expect(
+          downloadAndExtractRepo(root, {
+            username: "private-user",
+            name: "private-repo",
+            branch: "main",
+            filePath: ""
+          })
+        ).rejects.toThrow();
 
+        expect(global.fetch).toHaveBeenCalledTimes(1);
         expect(global.fetch).toHaveBeenCalledWith(
           "https://codeload.github.com/private-user/private-repo/tar.gz/main",
           expect.objectContaining({
             headers: expect.objectContaining({
-              Authorization: "Bearer ghp_test_token_123"
+              Authorization: "Bearer test_fake_token_123"
             })
           })
         );
@@ -770,6 +793,46 @@ describe("examples", () => {
           process.env.https_proxy = originalHttpsProxyLower;
         if (originalHttpProxyLower !== undefined)
           process.env.http_proxy = originalHttpProxyLower;
+      }
+    });
+
+    it("sends auth header for GitHub URLs when GITHUB_TOKEN is set", async () => {
+      const savedToken = process.env.GITHUB_TOKEN;
+      process.env.GITHUB_TOKEN = "test_fake_token_streaming";
+
+      try {
+        const mockBody = await createMockTarballBody([
+          { path: "file.txt", content: "Hello" }
+        ]);
+
+        global.fetch = jest.fn(() =>
+          Promise.resolve({
+            ok: true,
+            body: mockBody
+          } as Response)
+        ) as typeof fetch;
+
+        await streamingExtract({
+          url: "https://codeload.github.com/private-user/private-repo/tar.gz/main",
+          root: testDir,
+          strip: 1,
+          filter: () => true
+        });
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          "https://codeload.github.com/private-user/private-repo/tar.gz/main",
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              Authorization: "Bearer test_fake_token_streaming"
+            })
+          })
+        );
+      } finally {
+        if (savedToken !== undefined) {
+          process.env.GITHUB_TOKEN = savedToken;
+        } else {
+          delete process.env.GITHUB_TOKEN;
+        }
       }
     });
   });

--- a/packages/turbo-utils/src/examples.ts
+++ b/packages/turbo-utils/src/examples.ts
@@ -14,12 +14,30 @@ import { error, warn } from "./logger";
 const REQUEST_TIMEOUT = 10000;
 const DOWNLOAD_TIMEOUT = 120000;
 
+// Hosts that receive Authorization headers when GITHUB_TOKEN / GH_TOKEN is set.
+// Limited to GitHub.com API hosts. GitHub Enterprise Server is not yet supported.
 const GITHUB_API_HOSTS = new Set(["api.github.com", "codeload.github.com"]);
 
+/**
+ * Reads a GitHub personal access token from the environment.
+ * GITHUB_TOKEN takes precedence over GH_TOKEN, matching the GitHub CLI convention.
+ * Requires `repo` scope (classic PAT) or `contents:read` (fine-grained PAT).
+ */
 function getGitHubToken(): string | undefined {
-  return process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  const token = (process.env.GITHUB_TOKEN || process.env.GH_TOKEN || "").trim();
+  if (!token) return undefined;
+  if (/[\r\n\0]/.test(token)) {
+    warn("GITHUB_TOKEN/GH_TOKEN contains invalid characters, ignoring.");
+    return undefined;
+  }
+  return token;
 }
 
+/**
+ * Returns an Authorization header for GitHub API requests when a token
+ * is available. Only sends tokens to hosts in GITHUB_API_HOSTS to
+ * prevent credential leakage to third-party domains.
+ */
 function getGitHubAuthHeaders(url: string): Record<string, string> {
   try {
     const { hostname } = new URL(url);
@@ -74,9 +92,50 @@ function getProxyAgent(proxyUrl: string): ProxyAgent {
 }
 
 /**
- * Performs a fetch request with an automatic timeout and proxy support.
+ * Builds common fetch options: proxy agent, GitHub auth headers, and
+ * undici dispatcher. Used by both fetchWithTimeout and streamingExtract
+ * to centralize proxy + auth logic.
+ */
+function buildFetchInit(url: string, options: RequestInit = {}): RequestInit {
+  const proxyUrl = getProxyForUrl(url);
+  const dispatcher: Dispatcher | undefined = proxyUrl
+    ? getProxyAgent(proxyUrl)
+    : undefined;
+
+  const authHeaders = getGitHubAuthHeaders(url);
+  let headers: HeadersInit | undefined = options.headers;
+  if (Object.keys(authHeaders).length > 0) {
+    let existing: Record<string, string> | undefined;
+    if (options.headers instanceof Headers) {
+      existing = {};
+      options.headers.forEach((value, key) => {
+        existing![key] = value;
+      });
+    } else if (Array.isArray(options.headers)) {
+      existing = {};
+      for (const [key, value] of options.headers) {
+        existing[key] = value;
+      }
+    } else {
+      existing = options.headers as Record<string, string> | undefined;
+    }
+    headers = { ...authHeaders, ...existing };
+  }
+
+  return {
+    ...options,
+    headers,
+    // @ts-expect-error - dispatcher is a valid option for undici's fetch
+    dispatcher
+  };
+}
+
+/**
+ * Performs a fetch request with an automatic timeout, proxy support,
+ * and GitHub authentication.
  * Centralizes the AbortController + setTimeout pattern to avoid repetition.
  * Automatically respects HTTP_PROXY/HTTPS_PROXY environment variables.
+ * Attaches a Bearer token from GITHUB_TOKEN/GH_TOKEN for known GitHub hosts.
  */
 async function fetchWithTimeout(
   url: string,
@@ -89,23 +148,9 @@ async function fetchWithTimeout(
   }, timeoutMs);
 
   try {
-    const proxyUrl = getProxyForUrl(url);
-    const dispatcher: Dispatcher | undefined = proxyUrl
-      ? getProxyAgent(proxyUrl)
-      : undefined;
-
-    const authHeaders = getGitHubAuthHeaders(url);
-    const headers =
-      Object.keys(authHeaders).length > 0
-        ? { ...authHeaders, ...(options.headers as Record<string, string>) }
-        : options.headers;
-
     return await fetch(url, {
-      ...options,
-      headers,
-      signal: controller.signal,
-      // @ts-expect-error - dispatcher is a valid option for undici's fetch
-      dispatcher
+      ...buildFetchInit(url, options),
+      signal: controller.signal
     });
   } finally {
     clearTimeout(timeoutId);
@@ -122,6 +167,15 @@ export interface RepoInfo {
 export async function isUrlOk(url: string): Promise<boolean> {
   try {
     const res = await fetchWithTimeout(url, { method: "HEAD" });
+    if (
+      !res.ok &&
+      getGitHubToken() &&
+      (res.status === 401 || res.status === 403)
+    ) {
+      warn(
+        `GitHub auth failed (HTTP ${res.status}). Check GITHUB_TOKEN/GH_TOKEN permissions.`
+      );
+    }
     return res.ok;
   } catch {
     return false;
@@ -281,20 +335,9 @@ export async function streamingExtract({
   const createdDirs = new Set<string>();
 
   try {
-    const proxyUrl = getProxyForUrl(url);
-    const dispatcher: Dispatcher | undefined = proxyUrl
-      ? getProxyAgent(proxyUrl)
-      : undefined;
-
-    const authHeaders = getGitHubAuthHeaders(url);
-    const headers =
-      Object.keys(authHeaders).length > 0 ? authHeaders : undefined;
-
     const response = await fetch(url, {
-      headers,
-      signal: controller.signal,
-      // @ts-expect-error - dispatcher is a valid option for undici's fetch
-      dispatcher
+      ...buildFetchInit(url),
+      signal: controller.signal
     });
     if (!response.ok || !response.body) {
       throw new Error(`Failed to download: ${response.status}`);


### PR DESCRIPTION
## Summary

Adds automatic GitHub authentication to `turbo gen workspace --copy` and `create-turbo --example <github-url>`, enabling private repository support. When `GITHUB_TOKEN` or `GH_TOKEN` is set in the environment, Bearer auth headers are sent to GitHub API hosts (`api.github.com`, `codeload.github.com`).

Closes #5945

## What changed

- **Auth header injection**: New `getGitHubToken()` and `getGitHubAuthHeaders()` functions read tokens from the environment and scope them to a GitHub host allowlist, preventing credential leakage to third-party domains.
- **Centralized fetch setup**: Extracted `buildFetchInit()` so both `fetchWithTimeout` and `streamingExtract` share proxy, auth, and dispatcher logic in one place.
- **Token validation**: Trims whitespace and rejects tokens containing CRLF or null bytes with a warning.
- **Auth failure observability**: `isUrlOk` now warns on 401/403 when a token is present, instead of silently returning `false`.
- **Safe `HeadersInit` handling**: Properly normalizes `Headers` instances and tuple arrays instead of an unsafe `as Record<string, string>` cast.

## Testing

- Auth header tests for `isUrlOk`, `getRepoInfo`, `hasRepo`, `downloadAndExtractRepo`, and `streamingExtract`
- Token precedence (`GITHUB_TOKEN` over `GH_TOKEN`) and no-token fallback
- Hostname allowlist bypass tests for look-alike domains (`api.github.com.evil.com`, etc.)
- All test tokens use `test_fake_*` prefixes to avoid triggering secret scanners

To test manually:
```bash
export GITHUB_TOKEN=ghp_your_pat_here
npx create-turbo --example https://github.com/your-org/private-repo
```