### PR TITLE
refactor: Wire `GroupingLayer` into `Visitor` and migrate task error/warn to `turborepo-log`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8185,6 +8185,7 @@ dependencies = [
  "turborepo-ci",
  "turborepo-env",
  "turborepo-errors",
+ "turborepo-log",
  "turborepo-process",
  "turborepo-repository",
  "turborepo-run-cache",

--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -21,6 +21,7 @@ use turborepo_ci::{Vendor, VendorBehavior};
 use turborepo_engine::{TaskError, TaskWarning};
 use turborepo_env::{platform::PlatformEnv, EnvironmentVariableMap};
 use turborepo_errors::TURBO_SITE;
+use turborepo_log::grouping::{GroupingLayer, GroupingMode};
 use turborepo_process::ProcessManager;
 use turborepo_repository::package_graph::{PackageGraph, PackageName, ROOT_PKG_NAME};
 use turborepo_run_summary::{self as summary, GlobalHashSummary, RunTracker};
@@ -51,6 +52,7 @@ pub struct Visitor<'a> {
     color_cache: ColorSelector,
     dry: bool,
     global_env_mode: EnvMode,
+    grouping_layer: Arc<GroupingLayer>,
     manager: ProcessManager,
     run_opts: &'a RunOpts,
     package_graph: Arc<PackageGraph>,
@@ -138,7 +140,7 @@ impl<'a> Visitor<'a> {
         is_watch: bool,
         micro_frontends_configs: Option<&'a MicrofrontendsConfigs>,
     ) -> Self {
-        let (task_hasher, sink, color_cache) = {
+        let (task_hasher, sink, color_cache, grouping_layer) = {
             let _span = tracing::info_span!("visitor_new").entered();
             let mut task_hasher = TaskHasher::new(
                 package_inputs_hashes,
@@ -155,7 +157,16 @@ impl<'a> Visitor<'a> {
 
             let sink = Self::sink(run_opts);
             let color_cache = ColorSelector::default();
-            (task_hasher, sink, color_cache)
+
+            let grouping_mode = match run_opts.log_order {
+                ResolvedLogOrder::Stream => GroupingMode::Passthrough,
+                ResolvedLogOrder::Grouped => GroupingMode::Grouped,
+            };
+            let logger = turborepo_log::global_logger()
+                .unwrap_or_else(|| Arc::new(turborepo_log::Logger::new(vec![])));
+            let grouping_layer = GroupingLayer::new(logger, grouping_mode);
+
+            (task_hasher, sink, color_cache, grouping_layer)
         };
 
         // Set up correct size for underlying pty (requires .await, so outside span)
@@ -173,6 +184,7 @@ impl<'a> Visitor<'a> {
             color_cache,
             dry: false,
             global_env_mode: run_opts.env_mode,
+            grouping_layer,
             manager,
             run_opts,
             package_graph,
@@ -461,6 +473,7 @@ impl<'a> Visitor<'a> {
                         continue;
                     };
 
+                    let task_handle = self.grouping_layer.task(info.to_string());
                     let tracker = self.run_tracker.track_task(info.into_owned());
                     let parent_span = Span::current();
 
@@ -470,6 +483,7 @@ impl<'a> Visitor<'a> {
                                 parent_span.id(),
                                 tracker,
                                 output_client,
+                                task_handle,
                                 callback,
                                 &execution_telemetry,
                             )

--- a/crates/turborepo-log/src/lib.rs
+++ b/crates/turborepo-log/src/lib.rs
@@ -99,6 +99,7 @@ pub use event::{
     Level, LogEvent, OutputChannel, SanitizedString, Scalar, Source, Subsystem, Value,
 };
 pub use logger::{
-    InitError, LogEventBuilder, LogHandle, Logger, error, flush, info, init, log, warn,
+    InitError, LogEventBuilder, LogHandle, Logger, error, flush, global_logger, info, init, log,
+    warn,
 };
 pub use sink::LogSink;

--- a/crates/turborepo-log/src/logger.rs
+++ b/crates/turborepo-log/src/logger.rs
@@ -123,6 +123,13 @@ pub fn init(logger: Logger) -> Result<(), InitError> {
     GLOBAL_LOGGER.set(Arc::new(logger)).map_err(|_| InitError)
 }
 
+/// Get a reference to the global logger, if initialized.
+///
+/// Returns `None` if [`init`] has not been called yet.
+pub fn global_logger() -> Option<Arc<Logger>> {
+    GLOBAL_LOGGER.get().cloned()
+}
+
 /// Flush all sinks on the global logger. Call during graceful shutdown.
 pub fn flush() {
     if let Some(logger) = GLOBAL_LOGGER.get() {

--- a/crates/turborepo-task-executor/Cargo.toml
+++ b/crates/turborepo-task-executor/Cargo.toml
@@ -55,6 +55,7 @@ thiserror = { workspace = true }
 
 # Logging
 tracing = { workspace = true }
+turborepo-log = { workspace = true }
 
 # Time
 chrono = { workspace = true }

--- a/crates/turborepo-task-executor/src/exec.rs
+++ b/crates/turborepo-task-executor/src/exec.rs
@@ -19,7 +19,7 @@ use turbopath::AnchoredSystemPathBuf;
 use turborepo_cache::CacheHitMetadata;
 use turborepo_env::{EnvironmentVariableMap, platform::PlatformEnv};
 use turborepo_process::{ChildExit, Command, ProcessManager};
-use turborepo_run_cache::{CacheOutput, TaskCache};
+use turborepo_run_cache::TaskCache;
 use turborepo_run_summary::TaskTracker;
 use turborepo_task_id::TaskId;
 use turborepo_telemetry::events::{TrackedErrors, task::PackageTaskEventBuilder};
@@ -268,6 +268,7 @@ where
         parent_span_id: Option<tracing::Id>,
         tracker: TaskTracker<()>,
         output_client: TaskOutput<O>,
+        mut task_handle: turborepo_log::grouping::TaskHandle,
         callback: oneshot::Sender<Result<(), StopExecution>>,
         telemetry: &PackageTaskEventBuilder,
     ) -> Result<(), InternalError> {
@@ -277,7 +278,7 @@ where
         span.follows_from(parent_span_id);
 
         let mut result = self
-            .execute_inner(&output_client, telemetry)
+            .execute_inner(&output_client, &mut task_handle, telemetry)
             .instrument(span)
             .await;
         let task_duration = task_start.elapsed();
@@ -291,6 +292,10 @@ where
             error!("unable to flush output client: {e}");
             result = Err(InternalError::Io(e));
         }
+        // Flush any structured events buffered by the grouping layer.
+        // This must happen after output_client.finish() so the grouped
+        // block includes both child process output and structured events.
+        task_handle.finish(is_error);
 
         // Send the callback as early as possible after output is flushed.
         // For cache hits, this unblocks dependent tasks before the tracker
@@ -394,6 +399,7 @@ where
     async fn execute_inner<O: Write>(
         &mut self,
         output_client: &TaskOutput<O>,
+        task_handle: &mut turborepo_log::grouping::TaskHandle,
         telemetry: &PackageTaskEventBuilder,
     ) -> Result<ExecOutcome, InternalError> {
         let mut prefixed_ui = self.prefixed_ui(output_client);
@@ -433,7 +439,11 @@ where
             Ok(None) => (),
             Err(e) => {
                 telemetry.track_error(TrackedErrors::ErrorFetchingFromCache);
-                prefixed_ui.error(&format!("error fetching from cache: {e}"));
+                task_handle.emit(turborepo_log::LogEvent::new(
+                    turborepo_log::Level::Error,
+                    turborepo_log::Source::task(&self.task_id_for_display),
+                    format!("error fetching from cache: {e}"),
+                ));
             }
         }
 
@@ -446,7 +456,11 @@ where
             {
                 Some(Ok(child)) => child,
                 Some(Err(e)) => {
-                    prefixed_ui.error(&format!("command finished with error: {e}"));
+                    task_handle.emit(turborepo_log::LogEvent::new(
+                        turborepo_log::Level::Error,
+                        turborepo_log::Source::task(&self.task_id_for_display),
+                        format!("command finished with error: {e}"),
+                    ));
                     let error_string = e.to_string();
                     self.errors
                         .push_spawn_error(self.task_id_for_display.clone(), e);
@@ -534,14 +548,12 @@ where
                 } else {
                     format!("command {} exited ({})", process.label(), code)
                 };
-                match self.continue_on_error {
-                    ContinueMode::Never => {
-                        prefixed_ui.error(&format!("command finished with error: {}", message))
-                    }
-                    ContinueMode::Always | ContinueMode::DependenciesSuccessful => {
-                        prefixed_ui.warn("command finished with error, but continuing...")
-                    }
-                }
+                Self::emit_task_error(
+                    task_handle,
+                    &self.task_id_for_display,
+                    self.continue_on_error,
+                    &message,
+                );
                 self.errors.push_execution_error(
                     self.task_id_for_display.clone(),
                     process.label().to_string(),
@@ -562,14 +574,12 @@ where
                     error!("error reading logs: {e}");
                 }
                 let message = format!("command {} exited unexpectedly", process.label());
-                match self.continue_on_error {
-                    ContinueMode::Never => {
-                        prefixed_ui.error(&format!("command finished with error: {}", message))
-                    }
-                    ContinueMode::Always | ContinueMode::DependenciesSuccessful => {
-                        prefixed_ui.warn("command finished with error, but continuing...")
-                    }
-                }
+                Self::emit_task_error(
+                    task_handle,
+                    &self.task_id_for_display,
+                    self.continue_on_error,
+                    &message,
+                );
                 self.errors.push_execution_error(
                     self.task_id_for_display.clone(),
                     process.label().to_string(),
@@ -595,14 +605,12 @@ where
                     process.label(),
                     SIGKILL_EXIT_CODE
                 );
-                match self.continue_on_error {
-                    ContinueMode::Never => {
-                        prefixed_ui.error(&format!("command finished with error: {}", message))
-                    }
-                    ContinueMode::Always | ContinueMode::DependenciesSuccessful => {
-                        prefixed_ui.warn("command finished with error, but continuing...")
-                    }
-                }
+                Self::emit_task_error(
+                    task_handle,
+                    &self.task_id_for_display,
+                    self.continue_on_error,
+                    &message,
+                );
                 self.errors.push_execution_error(
                     self.task_id_for_display.clone(),
                     process.label().to_string(),
@@ -619,6 +627,31 @@ where
                 } else {
                     Ok(ExecOutcome::Restarted)
                 }
+            }
+        }
+    }
+
+    fn emit_task_error(
+        task_handle: &mut turborepo_log::grouping::TaskHandle,
+        task_id: &str,
+        continue_on_error: ContinueMode,
+        message: &str,
+    ) {
+        let source = turborepo_log::Source::task(task_id);
+        match continue_on_error {
+            ContinueMode::Never => {
+                task_handle.emit(turborepo_log::LogEvent::new(
+                    turborepo_log::Level::Error,
+                    source,
+                    format!("command finished with error: {message}"),
+                ));
+            }
+            ContinueMode::Always | ContinueMode::DependenciesSuccessful => {
+                task_handle.emit(turborepo_log::LogEvent::new(
+                    turborepo_log::Level::Warn,
+                    source,
+                    "command finished with error, but continuing...",
+                ));
             }
         }
     }

--- a/crates/turborepo-ui/src/tui_sink.rs
+++ b/crates/turborepo-ui/src/tui_sink.rs
@@ -1,8 +1,22 @@
 use std::sync::Mutex;
 
-use turborepo_log::{LogEvent, LogSink, OutputChannel};
+use turborepo_log::{Level, LogEvent, LogSink, OutputChannel, Source};
 
 use crate::tui::TuiSender;
+
+/// Format a task-scoped log event as a string for the task output pane.
+///
+/// Produces output like `ERROR: command finished with error: exit code 1\r\n`
+/// that will be rendered by the TUI's VT100 parser in the task pane.
+fn format_task_event(event: &LogEvent) -> String {
+    let badge = match event.level() {
+        Level::Error => "ERROR: ",
+        Level::Warn => "WARNING: ",
+        Level::Info => "",
+        _ => "",
+    };
+    format!("{badge}{}\r\n", event.message())
+}
 
 /// Routes [`LogEvent`]s into the TUI's event channel.
 ///
@@ -53,7 +67,15 @@ impl LogSink for TuiSink {
         match &mut *state {
             SinkState::Buffering(buffer) => buffer.push(event.clone()),
             SinkState::Connected(sender) => {
-                sender.log_event(event.clone());
+                // Task-scoped events go to the task's output pane so
+                // they appear inline with the task's process output.
+                // Non-task events go to the global log panel.
+                if let Source::Task(id) = event.source() {
+                    let formatted = format_task_event(event);
+                    let _ = sender.output(id.to_string(), formatted.into_bytes());
+                } else {
+                    sender.log_event(event.clone());
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Wires the `GroupingLayer` into the `Visitor` → `TaskExecutor` pipeline
- Migrates 8 `PrefixedUI::error/warn` calls in `exec.rs` to structured `turborepo_log` events flowing through the `GroupingLayer`
- Updates `TuiSink` to route `Source::Task` events to the task output pane instead of the log panel

## Why

This is the first PR that actually changes task error/warn behavior. Previously, `PrefixedUI::error("command finished with error: ...")` wrote directly into the task's output stream via `OutputClient`. Now these messages flow through `turborepo-log`:

```
TaskExecutor → task_handle.emit(LogEvent) → GroupingLayer → Logger → Sinks
```

In grouped mode, the `GroupingLayer` buffers these events and flushes them atomically when the task completes — preserving the grouping semantics. In passthrough mode, events flow immediately.

## What changed

| File | Change |
|------|--------|
| `visitor/mod.rs` | Creates `GroupingLayer` in `Visitor::new()`, creates `TaskHandle` per task in `visit()`, passes it to `execute()` |
| `exec.rs` | `execute()` accepts `TaskHandle`, passes to `execute_inner()`. 8 `prefixed_ui.error/warn` calls replaced with `task_handle.emit(LogEvent)`. New `emit_task_error()` helper deduplicates the 3 identical `match continue_on_error` blocks. |
| `tui_sink.rs` | `emit()` checks `Source::Task` — formats the event as `"ERROR: message\r\n"` and routes via `sender.output()` to the task pane. Non-task events continue to `sender.log_event()` (log panel). |
| `logger.rs` | Added `global_logger()` public accessor for `Arc<Logger>` |
| `Cargo.toml` | Added `turborepo-log` dep to `turborepo-task-executor` |

## What didn't change

- Child process bytes still flow through the old `LogWriter` → `PrefixedWriter` → `OutputClient` pipeline
- Cache status messages (`CacheOutput::status()`) still use `PrefixedUI::output()` (separate follow-up)
- `PrefixedUI` still exists — it's used as a `PrefixedWriter` factory and for `task_cache.restore_outputs/on_error`

## How to test

Run `turbo run <task>` with a failing task in both stream and grouped modes. The error message format changes from `{task}: ERROR: {message}` (PrefixedUI) to the sink's rendering. In TUI mode, the error still appears in the task's output pane.