### PR TITLE
perf: Replace subprocess repo index with in-process `gix-index`

### DIFF
--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -488,10 +488,11 @@ impl RunBuilder {
         repo_telemetry.track_size(pkg_dep_graph.len());
         run_telemetry.track_run_type(self.opts.run_opts.dry_run.is_some());
 
-        // Build the repo index using parallel git subprocesses for the tracked
-        // index (ls-tree + diff-index) and a race between walk_candidate_files
-        // and git ls-files for untracked discovery. The race ensures optimal
-        // performance: the walk wins on macOS, ls-files wins on Linux.
+        // Build the repo index by reading .git/index directly via gix-index
+        // (fast, in-process, no subprocess spawns) then running a scoped
+        // parallel walk for untracked file discovery. This replaces the
+        // subprocess approach (ls-tree + diff-index + ls-files race) which
+        // burned ~500ms of CPU on background threads.
         let all_prefixes = Self::all_package_prefixes(&pkg_dep_graph);
         let scm = scm_task
             .instrument(tracing::info_span!("scm_task_await"))
@@ -502,8 +503,12 @@ impl RunBuilder {
         } else {
             let scm = scm.clone();
             Some(tokio::task::spawn_blocking(move || {
-                let _span = tracing::info_span!("build_repo_index_subprocesses").entered();
-                scm.build_repo_index_from_subprocesses(&all_prefixes)
+                let _span = tracing::info_span!("build_repo_index_gix").entered();
+                let mut index = scm.build_tracked_repo_index_eager()?;
+                if let Err(e) = scm.populate_repo_index_untracked(&mut index, &all_prefixes) {
+                    tracing::debug!("failed to populate untracked files: {e}");
+                }
+                Some(index)
             }))
         };
         let micro_frontend_configs = {


### PR DESCRIPTION
## Summary

- Reverts the 2.8.15 SCM repo index construction from subprocess-based (`git ls-tree` + `git diff-index` + `git ls-files` race) back to the in-process gix-index path
- Profiling showed the subprocess approach burns ~500ms of CPU on background threads vs ~97ms for gix-index, stealing cycles from task execution

## Context

Comparing CPU profiles between 2.8.14 and 2.8.15 on `codegen:api` and `codegen:app` tasks revealed a regression in the SCM layer:

| Metric | Subprocess (2.8.15) | gix-index (this PR) |
|--------|---------------------|------------------------------|
| Tracked index | ~90ms (ls-tree + diff-index) | ~15ms (gix-index) |
| Untracked discovery | ~290-443ms wasted CPU (ls-files loses race on macOS) | ~82ms scoped walk |
| Subprocess spawns | 3-4 | 0 |
| Total SCM CPU | ~460-580ms | ~97ms |

The `git ls-files --others` subprocess (290-443ms) almost never wins the race against the parallel filesystem walk (~80ms) on macOS, making it pure waste. The gix-index code path was already present, well-tested, and produces identical results (verified by `git_index_regression_tests`).

## Testing

- `cargo check -p turborepo-lib` passes
- All 176 `turborepo-scm` tests pass, including the gix-vs-subprocess equivalence regression tests