### PR TITLE
fix: Prevent `$TURBO_DEFAULT$` from matching unrelated root files in affected detection

### DIFF
--- a/crates/turborepo-engine/src/affected.rs
+++ b/crates/turborepo-engine/src/affected.rs
@@ -284,4 +284,42 @@ mod tests {
             "lib-a#build should not match a root file with default inputs: {result:?}"
         );
     }
+
+    /// Regression test for https://github.com/vercel/turborepo/issues/12338
+    ///
+    /// Two tasks both use $TURBO_DEFAULT$ but reference different $TURBO_ROOT$
+    /// files. Changing only one root file should only affect the task that
+    /// declared it, not the other.
+    #[tokio::test]
+    async fn turbo_root_inputs_are_isolated_between_tasks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let pkg_graph = make_pkg_graph(root, &["lib-a"]).await;
+
+        let a_build = TaskId::new("lib-a", "build");
+        let a_test = TaskId::new("lib-a", "test");
+
+        let engine = make_engine(&[
+            (
+                a_build.clone(),
+                def_with_inputs(&["../../build-config.txt"], true),
+            ),
+            (
+                a_test.clone(),
+                def_with_inputs(&["../../test-config.txt"], true),
+            ),
+        ]);
+
+        // Only build-config.txt changes at the root.
+        let result =
+            match_tasks_against_changed_files(&engine, &pkg_graph, &changed(&["build-config.txt"]));
+        assert!(
+            result.contains_key(&a_build),
+            "lib-a#build should match its declared $TURBO_ROOT$ input: {result:?}"
+        );
+        assert!(
+            !result.contains_key(&a_test),
+            "lib-a#test should NOT match a root file it didn't declare: {result:?}"
+        );
+    }
 }

--- a/crates/turborepo-types/src/task_input_matching.rs
+++ b/crates/turborepo-types/src/task_input_matching.rs
@@ -143,12 +143,10 @@ pub fn file_matches_compiled_inputs(
         }
         relative.push_str(file_unix);
 
-        return check_compiled_globs(
-            &relative,
-            &compiled.inclusions,
-            &compiled.exclusions,
-            compiled.default,
-        );
+        // `default` (from $TURBO_DEFAULT$) only covers files *inside* the
+        // package. For traversal paths (files outside the package, typically
+        // from $TURBO_ROOT$), only explicit inclusion globs should match.
+        return check_compiled_globs(&relative, &compiled.inclusions, &compiled.exclusions, false);
     };
 
     check_compiled_globs(
@@ -410,6 +408,42 @@ mod tests {
             "apps/nested/deep/pkg",
             &TaskInputs {
                 globs: vec!["../../../../jest.config.js".to_string()],
+                default: true,
+            },
+            true,
+        );
+    }
+
+    /// Regression test for https://github.com/vercel/turborepo/issues/12338
+    ///
+    /// When two tasks both use $TURBO_DEFAULT$ but have different $TURBO_ROOT$
+    /// inputs, changing a root file that only one task references should NOT
+    /// mark the other task as affected. The `default` flag from $TURBO_DEFAULT$
+    /// must not apply to files outside the package directory.
+    #[test]
+    fn turbo_root_default_does_not_match_unrelated_root_file() {
+        // Task "test" declares $TURBO_DEFAULT$ + $TURBO_ROOT$/test-config.txt
+        // (resolved to ../../test-config.txt for packages/lib-a).
+        // Changing build-config.txt at the root should NOT match this task.
+        assert_match(
+            "build-config.txt",
+            "packages/lib-a",
+            &TaskInputs {
+                globs: vec!["../../test-config.txt".to_string()],
+                default: true,
+            },
+            false,
+        );
+    }
+
+    #[test]
+    fn turbo_root_default_matches_declared_root_file() {
+        // Same task shape, but this time the changed file IS the declared input.
+        assert_match(
+            "test-config.txt",
+            "packages/lib-a",
+            &TaskInputs {
+                globs: vec!["../../test-config.txt".to_string()],
                 default: true,
             },
             true,

--- a/crates/turborepo/tests/affected_test.rs
+++ b/crates/turborepo/tests/affected_test.rs
@@ -1100,6 +1100,87 @@ fn test_task_level_affected_turbo_root_input() {
     );
 }
 
+/// Regression test for https://github.com/vercel/turborepo/issues/12338
+///
+/// Two tasks both use $TURBO_DEFAULT$ but declare different $TURBO_ROOT$ files.
+/// Changing only one root file should mark only the task that declared it as
+/// affected, not the other. Previously, $TURBO_DEFAULT$ (which sets
+/// `default: true`) incorrectly matched ALL root-level files when the task
+/// had any traversal glob, causing cross-task contamination.
+#[test]
+fn test_task_level_affected_different_turbo_root_inputs_are_isolated() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let dir = tempdir.path();
+
+    setup::setup_integration_test(dir, "affected_tasks_inputs", "npm@10.5.0", true).unwrap();
+
+    // Create two distinct root-level config files.
+    fs::write(dir.join("build-config.txt"), "v1").unwrap();
+    fs::write(dir.join("test-config.txt"), "v1").unwrap();
+
+    // build references $TURBO_ROOT$/build-config.txt,
+    // test references $TURBO_ROOT$/test-config.txt.
+    let turbo_json = r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": [],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/build-config.txt"]
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/test-config.txt"]
+    }
+  },
+  "futureFlags": {
+    "affectedUsingTaskInputs": true
+  }
+}"#;
+    fs::write(dir.join("turbo.json"), turbo_json).unwrap();
+
+    git(dir, &["add", "."]);
+    git(dir, &["commit", "-m", "setup", "--quiet"]);
+    git(dir, &["checkout", "-b", "my-branch"]);
+
+    // Change ONLY build-config.txt. No package source files change.
+    fs::write(dir.join("build-config.txt"), "v2").unwrap();
+
+    let output = run_turbo(dir, &["run", "build", "test", "--affected", "--dry=json"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("failed to parse dry run JSON: {e}\nstdout: {stdout}"));
+
+    let tasks = json["tasks"].as_array().expect("tasks array");
+    let task_ids: Vec<&str> = tasks
+        .iter()
+        .map(|t| t["taskId"].as_str().unwrap())
+        .collect();
+
+    // build tasks should be affected (they declared build-config.txt).
+    assert!(
+        task_ids.contains(&"lib-a#build"),
+        "lib-a#build should be affected by its $TURBO_ROOT$ input: {task_ids:?}"
+    );
+    assert!(
+        task_ids.contains(&"app-a#build"),
+        "app-a#build should be affected by its $TURBO_ROOT$ input: {task_ids:?}"
+    );
+
+    // lib-a#test declared $TURBO_ROOT$/test-config.txt, NOT build-config.txt,
+    // and lib-a has no package dependencies so ^build adds nothing. It should
+    // NOT be affected.
+    assert!(
+        !task_ids.contains(&"lib-a#test"),
+        "lib-a#test should NOT be affected (its root input didn't change): {task_ids:?}"
+    );
+
+    // app-a#test IS correctly affected: it depends on lib-a#build via ^build,
+    // and lib-a#build is directly affected. That's transitive propagation,
+    // not the input-matching bug.
+}
+
 #[test]
 fn test_affected_with_nonexistent_task_errors() {
     let tempdir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

Fixes #12338

When two tasks both use `$TURBO_DEFAULT$` but declare different `$TURBO_ROOT$` inputs (e.g. `build` references `$TURBO_ROOT$/build-config.txt` and `test` references `$TURBO_ROOT$/test-config.txt`), changing only one root file incorrectly marked the other task as affected.

**Root cause**: `$TURBO_DEFAULT$` sets `default: true`, which means "all files in the package match." When a root-level file was checked against a task with any `$TURBO_ROOT$` input, the traversal code path passed `default: true` into `check_compiled_globs`, which short-circuited and returned `true` for *any* file — not just the declared `$TURBO_ROOT$` inputs.

**Fix**: Pass `false` for `default` when matching traversal paths (files outside the package directory). `$TURBO_DEFAULT$` semantically only covers in-package files; out-of-package files should only match against explicit inclusion globs.

## Testing

- 2 unit tests in `task_input_matching.rs` (file-level matching)
- 1 unit test in `affected.rs` (multi-task engine-level matching)
- 1 integration test in `affected_test.rs` (end-to-end with `turbo run --affected --dry=json`)

All existing affected tests continue to pass.