### PR TITLE
feat: Route child process bytes through TaskHandle with sink-owned prefix rendering

### DIFF
--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -473,7 +473,12 @@ impl<'a> Visitor<'a> {
                         continue;
                     };
 
-                    let task_handle = self.grouping_layer.task(info.to_string());
+                    let task_id_str = info.to_string();
+                    let task_prefix = self.prefix(&info);
+                    let task_handle = self.grouping_layer.task(task_id_str.clone());
+                    self.grouping_layer
+                        .logger()
+                        .register_task(&task_id_str, &task_prefix);
                     let tracker = self.run_tracker.track_task(info.into_owned());
                     let parent_span = Span::current();
 

--- a/crates/turborepo-log/src/grouping.rs
+++ b/crates/turborepo-log/src/grouping.rs
@@ -47,6 +47,11 @@ impl GroupingLayer {
         })
     }
 
+    /// Get a reference to the underlying logger.
+    pub fn logger(&self) -> &Logger {
+        &self.logger
+    }
+
     /// Create a [`TaskHandle`] for a task.
     ///
     /// In passthrough mode the handle forwards directly to the logger.
@@ -155,6 +160,36 @@ impl TaskHandle {
             self.layer.logger.end_task_group(&self.task_id, is_error);
         }
         self.accumulated_bytes
+    }
+
+    /// Create a writer that forwards to [`task_output`](Self::task_output).
+    ///
+    /// The returned writer implements [`std::io::Write`], making it
+    /// compatible with the child process output pipeline. Dropping
+    /// the writer releases the mutable borrow on the `TaskHandle`.
+    pub fn writer(&mut self, channel: OutputChannel) -> TaskHandleWriter<'_> {
+        TaskHandleWriter {
+            task_handle: self,
+            channel,
+        }
+    }
+}
+
+/// Adapter that implements [`std::io::Write`] by forwarding to
+/// [`TaskHandle::task_output`].
+pub struct TaskHandleWriter<'a> {
+    task_handle: &'a mut TaskHandle,
+    channel: OutputChannel,
+}
+
+impl std::io::Write for TaskHandleWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.task_handle.task_output(self.channel, buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
     }
 }
 

--- a/crates/turborepo-log/src/logger.rs
+++ b/crates/turborepo-log/src/logger.rs
@@ -78,6 +78,13 @@ impl Logger {
         }
     }
 
+    /// Register a task with all sinks.
+    pub fn register_task(&self, task: &str, prefix: &str) {
+        for sink in &self.sinks {
+            sink.register_task(task, prefix);
+        }
+    }
+
     /// Flush all sinks. Call during graceful shutdown.
     pub fn flush(&self) {
         for sink in &self.sinks {

--- a/crates/turborepo-log/src/sink.rs
+++ b/crates/turborepo-log/src/sink.rs
@@ -71,6 +71,19 @@ pub trait LogSink: Send + Sync + 'static {
     /// Default: no-op.
     fn end_task_group(&self, _task: &str, _is_error: bool) {}
 
+    /// Register a task with this sink.
+    ///
+    /// Called before a task starts producing output. Sinks that need
+    /// per-task render state (e.g., colored prefixes, line buffers)
+    /// should initialize it here.
+    ///
+    /// `task` is the task identifier used in `task_output()` calls.
+    /// `prefix` is the display prefix for terminal rendering
+    /// (e.g., `"my-app:build"` — the sink appends `": "`).
+    ///
+    /// Default: no-op.
+    fn register_task(&self, _task: &str, _prefix: &str) {}
+
     /// Flush any buffered output. Called during graceful shutdown.
     fn flush(&self) {}
 
@@ -97,6 +110,10 @@ impl<T: LogSink> LogSink for Arc<T> {
 
     fn end_task_group(&self, task: &str, is_error: bool) {
         (**self).end_task_group(task, is_error)
+    }
+
+    fn register_task(&self, task: &str, prefix: &str) {
+        (**self).register_task(task, prefix)
     }
 
     fn flush(&self) {

--- a/crates/turborepo-task-executor/src/exec.rs
+++ b/crates/turborepo-task-executor/src/exec.rs
@@ -498,42 +498,36 @@ where
             process.stdin();
         }
 
-        // Create output writer and pipe outputs
-        let mut stdout_writer = self
-            .task_cache
-            .output_writer(prefixed_ui.task_writer())
-            .inspect_err(|_| {
+        // Create output writer and pipe outputs.
+        // The stdout_writer is scoped so that TaskHandleWriter drops before
+        // the error handling section, which needs &mut task_handle for emit().
+        let exit_status = {
+            let writer = task_handle.writer(turborepo_log::OutputChannel::Stdout);
+            let mut stdout_writer = self.task_cache.output_writer(writer).inspect_err(|_| {
                 telemetry.track_error(TrackedErrors::FailedToCaptureOutputs);
             })?;
 
-        let exit_status = match process.wait_with_piped_outputs(&mut stdout_writer).await {
-            Ok(Some(exit_status)) => exit_status,
-            Err(e) => {
-                telemetry.track_error(TrackedErrors::FailedToPipeOutputs);
-                return Err(e.into());
+            let status = match process.wait_with_piped_outputs(&mut stdout_writer).await {
+                Ok(Some(exit_status)) => exit_status,
+                Err(e) => {
+                    telemetry.track_error(TrackedErrors::FailedToPipeOutputs);
+                    return Err(e.into());
+                }
+                Ok(None) => {
+                    telemetry.track_error(TrackedErrors::UnknownChildExit);
+                    error!("unable to determine why child exited");
+                    return Err(InternalError::UnknownChildExit);
+                }
+            };
+
+            if let Err(e) = stdout_writer.flush() {
+                error!("error flushing logs: {e}");
             }
-            Ok(None) => {
-                telemetry.track_error(TrackedErrors::UnknownChildExit);
-                error!("unable to determine why child exited");
-                return Err(InternalError::UnknownChildExit);
-            }
+            status
         };
         match exit_status {
-            ChildExit::Finished(Some(0)) => {
-                // Cache save is deferred to execute() so the callback can
-                // fire first, unblocking dependent tasks while the globwalk
-                // and cache write proceed in the background.
-                if let Err(e) = stdout_writer.flush() {
-                    error!("{e}");
-                    Ok(ExecOutcome::Success(SuccessOutcome::RunOutputError))
-                } else {
-                    Ok(ExecOutcome::Success(SuccessOutcome::Run))
-                }
-            }
+            ChildExit::Finished(Some(0)) => Ok(ExecOutcome::Success(SuccessOutcome::Run)),
             ChildExit::Finished(Some(code)) => {
-                if let Err(e) = stdout_writer.flush() {
-                    error!("error flushing logs: {e}");
-                }
                 if let Err(e) = self.task_cache.on_error(&mut prefixed_ui) {
                     error!("error reading logs: {e}");
                 }
@@ -565,11 +559,6 @@ where
                 })
             }
             ChildExit::Finished(None) | ChildExit::Failed => {
-                // Process exited without a code (e.g., killed by signal) or we failed to get
-                // status. Treat as a task failure with exit code 1.
-                if let Err(e) = stdout_writer.flush() {
-                    error!("error flushing logs: {e}");
-                }
                 if let Err(e) = self.task_cache.on_error(&mut prefixed_ui) {
                     error!("error reading logs: {e}");
                 }
@@ -591,12 +580,7 @@ where
                 })
             }
             ChildExit::KilledExternal => {
-                // Process was killed by an external signal (e.g., OOM killer sending SIGKILL).
-                // Use exit code 137 (128 + 9) which is the conventional code for SIGKILL.
                 const SIGKILL_EXIT_CODE: i32 = 137;
-                if let Err(e) = stdout_writer.flush() {
-                    error!("error flushing logs: {e}");
-                }
                 if let Err(e) = self.task_cache.on_error(&mut prefixed_ui) {
                     error!("error reading logs: {e}");
                 }
@@ -635,24 +619,19 @@ where
         task_handle: &mut turborepo_log::grouping::TaskHandle,
         task_id: &str,
         continue_on_error: ContinueMode,
-        message: &str,
+        _message: &str,
     ) {
-        let source = turborepo_log::Source::task(task_id);
-        match continue_on_error {
-            ContinueMode::Never => {
-                task_handle.emit(turborepo_log::LogEvent::new(
-                    turborepo_log::Level::Error,
-                    source,
-                    format!("command finished with error: {message}"),
-                ));
-            }
-            ContinueMode::Always | ContinueMode::DependenciesSuccessful => {
-                task_handle.emit(turborepo_log::LogEvent::new(
-                    turborepo_log::Level::Warn,
-                    source,
-                    "command finished with error, but continuing...",
-                ));
-            }
+        // In strict mode (Never), the run-level error summary already
+        // reports the failure — no need to duplicate it here.
+        if matches!(
+            continue_on_error,
+            ContinueMode::Always | ContinueMode::DependenciesSuccessful
+        ) {
+            task_handle.emit(turborepo_log::LogEvent::new(
+                turborepo_log::Level::Warn,
+                turborepo_log::Source::task(task_id),
+                "command finished with error, but continuing...",
+            ));
         }
     }
 }

--- a/crates/turborepo-ui/src/terminal_sink.rs
+++ b/crates/turborepo-ui/src/terminal_sink.rs
@@ -1,24 +1,42 @@
 use std::{
+    collections::HashMap,
     io::{self, Write},
-    sync::atomic::{AtomicU8, Ordering},
+    sync::{
+        Mutex,
+        atomic::{AtomicU8, Ordering},
+    },
 };
 
 use turborepo_log::{Level, LogEvent, LogSink, OutputChannel, Source};
 
-use crate::ColorConfig;
+use crate::{ColorConfig, ColorSelector};
 
 const MODE_DISABLED: u8 = 0;
 const MODE_STDERR_ONLY: u8 = 1;
 const MODE_ACTIVE: u8 = 2;
 
-/// Routes [`LogEvent`]s to the appropriate file descriptor with color
-/// styling:
+/// Per-task rendering state held by `TerminalSink`.
+struct TaskRenderState {
+    /// Pre-formatted ANSI-colored prefix (e.g., "\x1b[36mmy-app:build:
+    /// \x1b[0m").
+    prefix: String,
+    /// Partial line buffer — bytes accumulate until `\n` before being written
+    /// with the prefix prepended.
+    line_buffer: Vec<u8>,
+}
+
+/// Routes [`LogEvent`]s and task output to the appropriate file
+/// descriptor with color styling:
 ///
 /// | Level | Destination | Style |
 /// |-------|-------------|-------|
 /// | Info  | stdout      | grey, no badge |
 /// | Warn  | stderr      | yellow, `WARNING` badge |
 /// | Error | stderr      | red, `ERROR` badge |
+///
+/// Task output bytes are rendered with a per-task colored prefix.
+/// Call [`register_task`](LogSink::register_task) before a task
+/// starts producing output so the sink can assign a color.
 ///
 /// Operates in three modes controlled by an [`AtomicU8`]:
 ///
@@ -33,6 +51,9 @@ pub struct TerminalSink {
     color_config: ColorConfig,
     mode: AtomicU8,
     ci_annotations: bool,
+    color_selector: ColorSelector,
+    tasks: Mutex<HashMap<String, TaskRenderState>>,
+    include_timestamps: bool,
 }
 
 impl TerminalSink {
@@ -46,7 +67,16 @@ impl TerminalSink {
             color_config,
             mode: AtomicU8::new(MODE_ACTIVE),
             ci_annotations,
+            color_selector: ColorSelector::default(),
+            tasks: Mutex::new(HashMap::new()),
+            include_timestamps: false,
         }
+    }
+
+    /// Enable timestamp prefixes on task output lines.
+    pub fn with_timestamps(mut self, include: bool) -> Self {
+        self.include_timestamps = include;
+        self
     }
 
     /// Suppress all output. Called before the TUI takes ownership of
@@ -66,6 +96,67 @@ impl TerminalSink {
     /// carries machine-readable data.
     pub fn suppress_stdout(&self) {
         self.mode.store(MODE_STDERR_ONLY, Ordering::Relaxed);
+    }
+
+    /// Generate the current prefix string for a task, optionally with
+    /// timestamp.
+    fn task_prefix(&self, base_prefix: &str) -> String {
+        if self.include_timestamps {
+            let timestamp = chrono::Local::now().format("%H:%M:%S%.3f");
+            let grey_timestamp = self
+                .color_config
+                .apply(crate::GREY.apply_to(format!("[{timestamp}]")));
+            format!("{grey_timestamp} {base_prefix}")
+        } else {
+            base_prefix.to_string()
+        }
+    }
+
+    /// Write task output bytes to stdout with per-line prefix.
+    ///
+    /// Buffers partial lines. On each complete line (ending with `\n`),
+    /// writes `prefix + line` to stdout. Handles `\r` for progress
+    /// bars by rewriting the prefix at the start of the line.
+    fn write_task_output(&self, task: &str, bytes: &[u8]) {
+        let mut tasks = self.tasks.lock().unwrap();
+        let Some(state) = tasks.get_mut(task) else {
+            // Task not registered — write raw bytes as fallback
+            let stdout = io::stdout();
+            let mut handle = stdout.lock();
+            let _ = handle.write_all(bytes);
+            return;
+        };
+
+        let stdout = io::stdout();
+        let mut handle = stdout.lock();
+
+        // Split on newlines. For each complete line, write prefix + line.
+        for line in bytes.split_inclusive(|c| *c == b'\n') {
+            if line.ends_with(b"\n") {
+                if state.line_buffer.is_empty() {
+                    self.write_prefixed_line(&mut handle, &state.prefix, line);
+                } else {
+                    state.line_buffer.extend_from_slice(line);
+                    let buffered = std::mem::take(&mut state.line_buffer);
+                    self.write_prefixed_line(&mut handle, &state.prefix, &buffered);
+                }
+            } else {
+                state.line_buffer.extend_from_slice(line);
+            }
+        }
+    }
+
+    /// Write a complete line with per-chunk prefix handling for `\r`.
+    fn write_prefixed_line(&self, handle: &mut io::StdoutLock<'_>, base_prefix: &str, line: &[u8]) {
+        let mut is_first = true;
+        for chunk in line.split_inclusive(|c| *c == b'\r') {
+            if is_first || chunk != b"\n" {
+                let prefix = self.task_prefix(base_prefix);
+                let _ = handle.write_all(prefix.as_bytes());
+            }
+            let _ = handle.write_all(chunk);
+            is_first = false;
+        }
     }
 }
 
@@ -107,15 +198,21 @@ impl LogSink for TerminalSink {
         }
     }
 
-    fn task_output(&self, _task: &str, channel: OutputChannel, bytes: &[u8]) {
+    fn task_output(&self, task: &str, _channel: OutputChannel, bytes: &[u8]) {
         if self.mode.load(Ordering::Relaxed) == MODE_DISABLED {
             return;
         }
-        let mut handle: Box<dyn Write> = match channel {
-            OutputChannel::Stdout => Box::new(io::stdout().lock()),
-            OutputChannel::Stderr => Box::new(io::stderr().lock()),
-        };
-        let _ = handle.write_all(bytes);
+        self.write_task_output(task, bytes);
+    }
+
+    fn register_task(&self, task: &str, prefix: &str) {
+        let styled = self.color_selector.prefix_with_color(task, prefix);
+        let formatted = self.color_config.apply(styled).to_string();
+        let mut tasks = self.tasks.lock().unwrap();
+        tasks.entry(task.to_string()).or_insert(TaskRenderState {
+            prefix: formatted,
+            line_buffer: Vec::with_capacity(512),
+        });
     }
 
     fn begin_task_group(&self, task: &str, is_error: bool) {

--- a/crates/turborepo-ui/src/tui_sink.rs
+++ b/crates/turborepo-ui/src/tui_sink.rs
@@ -4,6 +4,22 @@ use turborepo_log::{Level, LogEvent, LogSink, OutputChannel, Source};
 
 use crate::tui::TuiSender;
 
+/// Normalize lone `\n` to `\r\n` for the TUI's VT100 terminal emulator.
+///
+/// Already-correct `\r\n` sequences are left as-is.
+fn normalize_newlines(bytes: &[u8]) -> Vec<u8> {
+    let mut result = Vec::with_capacity(bytes.len());
+    let mut prev_cr = false;
+    for &b in bytes {
+        if b == b'\n' && !prev_cr {
+            result.push(b'\r');
+        }
+        result.push(b);
+        prev_cr = b == b'\r';
+    }
+    result
+}
+
 /// Format a task-scoped log event as a string for the task output pane.
 ///
 /// Produces output like `ERROR: command finished with error: exit code 1\r\n`
@@ -83,7 +99,9 @@ impl LogSink for TuiSink {
     fn task_output(&self, task: &str, _channel: OutputChannel, bytes: &[u8]) {
         let state = self.state.lock().unwrap();
         if let SinkState::Connected(sender) = &*state {
-            let _ = sender.output(task.to_string(), bytes.to_vec());
+            // Normalize \n to \r\n for the TUI's VT100 terminal emulator.
+            let normalized = normalize_newlines(bytes);
+            let _ = sender.output(task.to_string(), normalized);
         }
     }
 }


### PR DESCRIPTION
## Summary

Routes child process stdout/stderr bytes through `TaskHandle` → `GroupingLayer` → `Logger` → sinks, replacing `PrefixedWriter` → `OutputWriter` → `OutputClient` as the display path for live task output.

`TerminalSink` now owns line prefixing: it maintains a per-task `ColorSelector`, generates colored prefixes, buffers partial lines, and writes `prefix + line` to stdout. This moves rendering responsibility into the sink where it belongs.

## What changed

| Component | Before | After |
|-----------|--------|-------|
| Child process display path | `LogWriter` → `PrefixedWriter` → `OutputWriter` → `OutputClient` → stdout | `LogWriter` → `TaskHandleWriter` → `TaskHandle` → `GroupingLayer` → `Logger` → `TerminalSink` → stdout |
| Line prefixing | `PrefixedWriter` (in the pipeline, before the sink) | `TerminalSink::task_output()` (in the sink) |
| Color assignment | `ColorSelector` in `Visitor` → `PrefixedUI` | `ColorSelector` in `TerminalSink` via `register_task()` |
| TUI task output | `TaskSender` implements `Write` | `TaskHandleWriter` → `TuiSink::task_output()` with `\n` → `\r\n` normalization |

## New types and methods

- **`TaskHandleWriter`** — `impl Write` adapter that forwards to `TaskHandle::task_output()`
- **`LogSink::register_task(task)`** — sinks initialize per-task render state (default no-op)
- **`TerminalSink`** gains `ColorSelector`, `HashMap<String, TaskRenderState>` for per-task prefix and line buffering, `\r` handling for progress bars

## What stays the same (transitional)

- **`LogWriter`** still multiplexes to log file + display writer. The display writer type changed but multiplexing logic is unchanged.
- **`PrefixedUI`** still exists for cache `restore_outputs()` and `on_error()` replay. These continue through the old `OutputClient` path. Migrating cache replay to the new path is a follow-up.
- **`OutputClient`/`OutputSink`** still exist but are only used by `PrefixedUI` for cache operations. Child process byte streaming no longer flows through them.

## How to test

```
cp -r turborepo-tests/integration/fixtures/basic_monorepo /tmp/test-grouping
cd /tmp/test-grouping
turbo run maybefails                    # stream mode, failing task
turbo run maybefails --log-order=grouped  # grouped mode
turbo run build                         # successful tasks
```

Verify: prefixed output lines use `package:task:` format with consistent colors, grouped mode flushes atomically, no duplicate error messages.