### PR TITLE
feat: Deprecate graphviz-dependent -`-graph` formats, add native SVG rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3271,6 +3271,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
+name = "layout-rs"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8b38bc67665e362eb770c6b6ae88b48d040d94a0a10c4904c37bc79d263b95"
+
+[[package]]
 name = "lazy-regex"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7476,6 +7482,7 @@ dependencies = [
  "futures",
  "insta",
  "itertools 0.14.0",
+ "layout-rs",
  "miette",
  "petgraph 0.8.3",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,7 @@ oxc_estree = { version = "0.115.0", features = ["serialize"] }
 oxc_parser = "0.115.0"
 oxc_span = "0.115.0"
 oxc_syntax = "0.115.0"
+layout-rs = "0.1.3"
 owo-colors = "3.5.0"
 unrs_resolver = "1.11.1"
 path-clean = "1.0.1"

--- a/apps/docs/content/docs/reference/run.mdx
+++ b/apps/docs/content/docs/reference/run.mdx
@@ -354,14 +354,23 @@ turbo run build --global-deps=".env.*" --global-deps=".eslintrc" --global-deps="
 
 Default: `dot`
 
-This command can output a graph file: `svg`, `png`, `jpg`, `pdf`, `json`, `html`, `mermaid`, or `dot`.
+This command can output a graph file: `svg`, `html`, `mermaid`, or `dot`.
 
-If [Graphviz](https://graphviz.org/) is not installed, or no filename is provided, this command prints the dot graph to `stdout`.
+If no filename is provided, this command prints the dot graph to `stdout`.
 
 ```bash title="Terminal"
 turbo run build --graph
 turbo run build test lint --graph=my-graph.svg
 ```
+
+<Callout type="warn" title="Deprecated formats">
+  The `.png`, `.jpg`, `.pdf`, and `.json` output formats for `--graph` are
+  deprecated and will be removed in version 3.0. These formats require an
+  external [Graphviz](https://graphviz.org/) installation.
+
+  Use `.svg`, `.html`, `.mermaid`, or `.dot` instead. For programmatic access to
+  the task graph, use [`turbo query`](/docs/reference/query).
+</Callout>
 
 <Callout type="info">
   **Known Bug**: All possible task nodes will be added to the graph at the

--- a/apps/docs/content/docs/support-policy.mdx
+++ b/apps/docs/content/docs/support-policy.mdx
@@ -119,3 +119,4 @@ Deprecated APIs are in the process of being removed. Any feature we intend to re
 
 - `TURBO_REMOTE_ONLY` and `--remote-only`: Use [`TURBO_CACHE`](/docs/reference/system-environment-variables) or [--cache](/docs/reference/run#--cache-options)
 - `--scope` for [`turbo prune`](/docs/reference/prune): Use positional arguments instead (e.g. `turbo prune web`)
+- `--graph` with `.png`, `.jpg`, `.pdf`, or `.json` output: These formats require an external Graphviz installation and will be removed in version 3.0. Use `.svg`, `.html`, `.mermaid`, or `.dot` instead. For programmatic access to the task graph, use [`turbo query`](/docs/reference/query).

--- a/crates/turborepo-engine/Cargo.toml
+++ b/crates/turborepo-engine/Cargo.toml
@@ -11,9 +11,11 @@ workspace = true
 convert_case = "0.6.0"
 futures = { workspace = true }
 itertools = { workspace = true }
+layout-rs = { workspace = true }
 miette = { workspace = true, features = ["fancy"] }
 petgraph = { workspace = true }
 rand = { workspace = true, features = ["small_rng"] }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
@@ -31,7 +33,6 @@ which = { workspace = true }
 [dev-dependencies]
 insta = { workspace = true }
 pretty_assertions = { workspace = true }
-serde_json = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }
 turborepo-lockfiles = { path = "../turborepo-lockfiles" }

--- a/crates/turborepo-engine/src/graph_visualizer.rs
+++ b/crates/turborepo-engine/src/graph_visualizer.rs
@@ -2,6 +2,7 @@
 //!
 //! This module provides functionality to render task graphs in various formats:
 //! - DOT format (Graphviz)
+//! - SVG (rendered natively via layout-rs)
 //! - Mermaid format
 //! - HTML with embedded Viz.js
 //!
@@ -14,12 +15,18 @@ use std::{
     process::{Command, Stdio},
 };
 
+use layout::{
+    backends::svg::SVGWriter,
+    core::{base::Orientation, geometry::Point, style::StyleAttr},
+    std_shapes::shapes::{Arrow, Element, ShapeKind},
+    topo::layout::VisualGraph,
+};
 use thiserror::Error;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_types::GraphOpts;
 use which::which;
 
-use crate::{Built, Engine, TaskDefinitionInfo};
+use crate::{Built, Engine, TaskDefinitionInfo, TaskNode};
 
 /// Errors that can occur during graph visualization.
 #[derive(Debug, Error)]
@@ -114,6 +121,8 @@ pub fn write_graph<T: TaskDefinitionInfo + Clone, S: ChildSpawner>(
                 render_mermaid_graph(&filename, engine, single_package)?;
             } else if extension == "html" {
                 render_html(&filename, engine, single_package)?;
+            } else if extension == "svg" {
+                render_svg(&filename, engine, single_package)?;
             } else if extension == "dot" {
                 let mut opts = OpenOptions::new();
                 opts.truncate(true).create(true).write(true);
@@ -211,6 +220,66 @@ fn render_html<T: TaskDefinitionInfo + Clone>(
     )
     .map_err(Error::GraphOutput)?;
     file.write_all(HTML_SUFFIX.as_bytes())
+        .map_err(Error::GraphOutput)?;
+    Ok(())
+}
+
+fn render_svg<T: TaskDefinitionInfo + Clone>(
+    filename: &AbsoluteSystemPath,
+    engine: &Engine<Built, T>,
+    single_package: bool,
+) -> Result<(), Error> {
+    use petgraph::visit::EdgeRef;
+
+    let task_graph = engine.task_graph();
+
+    let display_node = |node: &TaskNode| -> String {
+        match (single_package, node) {
+            (_, TaskNode::Root) => node.to_string(),
+            (true, TaskNode::Task(task)) => task.task().to_string(),
+            (false, TaskNode::Task(_)) => node.to_string(),
+        }
+    };
+
+    let mut vg = VisualGraph::new(Orientation::TopToBottom);
+
+    let default_look = StyleAttr::simple();
+
+    // Build nodes, mapping petgraph NodeIndex -> layout-rs NodeHandle
+    let mut handle_map = std::collections::HashMap::new();
+    for idx in task_graph.node_indices() {
+        let node = &task_graph[idx];
+        let label = display_node(node);
+        let shape = ShapeKind::new_box(&label);
+        let element = Element::create(
+            shape,
+            default_look.clone(),
+            Orientation::LeftToRight,
+            Point::zero(),
+        );
+        let handle = vg.add_node(element);
+        handle_map.insert(idx, handle);
+    }
+
+    // Build edges
+    for edge in task_graph.edge_references() {
+        let src = handle_map[&edge.source()];
+        let dst = handle_map[&edge.target()];
+        let arrow = Arrow::simple("");
+        vg.add_edge(arrow, src, dst);
+    }
+
+    // Compute layout and render to SVG
+    let mut backend = SVGWriter::new();
+    vg.do_it(false, false, false, &mut backend);
+    let svg_content = backend.finalize();
+
+    let mut opts = OpenOptions::new();
+    opts.truncate(true).create(true).write(true);
+    let mut file = filename
+        .open_with_options(opts)
+        .map_err(Error::GraphOutput)?;
+    file.write_all(svg_content.as_bytes())
         .map_err(Error::GraphOutput)?;
     Ok(())
 }

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -417,6 +417,25 @@ impl Args {
                      no longer used for `turbo run`."
                 );
             }
+            if let Some(graph) = &run_args.graph {
+                match Utf8Path::new(graph).extension() {
+                    Some("png" | "jpg" | "pdf") => {
+                        warn!(
+                            "--graph with .{ext} output is deprecated and will be removed in \
+                             version 3.0. Use .svg, .html, .mermaid, or .dot instead.",
+                            ext = Utf8Path::new(graph).extension().unwrap()
+                        );
+                    }
+                    Some("json") => {
+                        warn!(
+                            "--graph with .json output is deprecated and will be removed in \
+                             version 3.0. Use `turbo query` for programmatic access to the task \
+                             graph."
+                        );
+                    }
+                    _ => {}
+                }
+            }
         }
 
         if let Some(Command::Prune { ref scope, .. }) = clap_args.command {
@@ -1077,9 +1096,9 @@ pub struct RunArgs {
     #[clap(alias = "dry", long = "dry-run", num_args = 0..=1, default_missing_value = "text")]
     pub dry_run: Option<DryRunMode>,
     /// Generate a graph of the task execution and output to a file when a
-    /// filename is specified (.svg, .png, .jpg, .pdf, .json,
-    /// .html, .mermaid, .dot). Outputs dot graph to stdout when if no filename
-    /// is provided
+    /// filename is specified (.svg, .html, .mermaid, .dot). Outputs dot graph
+    /// to stdout when no filename is provided.
+    /// [DEPRECATED formats: .png, .jpg, .pdf, .json -- will be removed in 3.0]
     #[clap(long, num_args = 0..=1, default_missing_value = "", value_parser = validate_graph_extension)]
     pub graph: Option<String>,
     // clap does not have negation flags such as --daemon and --no-daemon

--- a/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__turbo_long_help.snap
+++ b/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__turbo_long_help.snap
@@ -162,7 +162,7 @@ Run Arguments:
           [possible values: text, json]
 
       --graph [<GRAPH>]
-          Generate a graph of the task execution and output to a file when a filename is specified (.svg, .png, .jpg, .pdf, .json, .html, .mermaid, .dot). Outputs dot graph to stdout when if no filename is provided
+          Generate a graph of the task execution and output to a file when a filename is specified (.svg, .html, .mermaid, .dot). Outputs dot graph to stdout when no filename is provided. [DEPRECATED formats: .png, .jpg, .pdf, .json -- will be removed in 3.0]
 
       --daemon
           [DEPRECATED] The daemon is no longer used for `turbo run`. This flag will be removed in version 3.0

--- a/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__turbo_short_help.snap
+++ b/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__turbo_short_help.snap
@@ -103,7 +103,7 @@ Run Arguments:
       --dry-run [<DRY_RUN>]
           [possible values: text, json]
       --graph [<GRAPH>]
-          Generate a graph of the task execution and output to a file when a filename is specified (.svg, .png, .jpg, .pdf, .json, .html, .mermaid, .dot). Outputs dot graph to stdout when if no filename is provided
+          Generate a graph of the task execution and output to a file when a filename is specified (.svg, .html, .mermaid, .dot). Outputs dot graph to stdout when no filename is provided. [DEPRECATED formats: .png, .jpg, .pdf, .json -- will be removed in 3.0]
       --daemon
           [DEPRECATED] The daemon is no longer used for `turbo run`. This flag will be removed in version 3.0
       --no-daemon

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -1047,7 +1047,8 @@ fn emit_graphviz_warning() -> Result<(), io::Error> {
     turborepo_log::warn(
         turborepo_log::Source::turbo(turborepo_log::Subsystem::Run),
         "`turbo` uses Graphviz to generate an image of your graph, but Graphviz isn't installed \
-         on this machine.\n\nYou can download Graphviz from https://graphviz.org/download.\n\nIn \
+         on this machine.\n\nNote: --graph output to .png, .jpg, .pdf, and .json is deprecated \
+         and will be removed in version 3.0. Use .svg, .html, .mermaid, or .dot instead.\n\nIn \
          the meantime, you can use this string output with an online Dot graph viewer.",
     )
     .emit();


### PR DESCRIPTION
## Summary

- Deprecate `.png`, `.jpg`, `.pdf`, and `.json` output formats for `--graph`, to be removed in 3.0
- Add native SVG rendering via `layout-rs`, eliminating the Graphviz dependency for `.svg` output
- Update docs and support policy

## Why

The `--graph` flag currently requires an external [Graphviz](https://graphviz.org/) `dot` binary for `.svg`, `.png`, `.jpg`, `.pdf`, and `.json` output. This is the only external binary dependency in Turborepo and creates friction for users who don't have it installed.

This PR takes the first step toward removing that dependency entirely:

1. **Native SVG**: `.svg` output now uses [`layout-rs`](https://github.com/nadavrot/layout), a pure-Rust graph layout engine. No external binary needed.
2. **Deprecation warnings**: `.png`, `.jpg`, `.pdf` emit a warning pointing users to `.svg`, `.html`, `.mermaid`, or `.dot`. `.json` emits a warning pointing users to `turbo query` for programmatic graph access.
3. The deprecated formats still work -- graphviz is still invoked when present.

## Changes

| File | What |
|------|------|
| `Cargo.toml` | Add `layout-rs` workspace dep |
| `turborepo-engine/Cargo.toml` | Add `layout-rs`, promote `serde_json` to regular dep |
| `turborepo-engine/src/graph_visualizer.rs` | Native SVG rendering via `layout-rs` (new `render_svg` function) |
| `turborepo-lib/src/cli/mod.rs` | Deprecation warnings + updated help text |
| `turborepo-lib/src/run/mod.rs` | Updated graphviz-not-installed warning to mention deprecation |
| `apps/docs/.../run.mdx` | Updated `--graph` docs with deprecation callout |
| `apps/docs/.../support-policy.mdx` | Added to deprecated APIs list |

## Testing

- `cargo check` passes for `turborepo-engine` and `turborepo-lib`
- All 108 CLI parsing tests pass (snapshots updated for new help text)
- All 5 engine graph tests pass

Closes TURBO-5130