### PR TITLE
refactor: Migrate cache replay and status messages to `TaskHandle`, remove `CacheOutput` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8022,6 +8022,7 @@ dependencies = [
  "turbopath",
  "turborepo-cache",
  "turborepo-hash",
+ "turborepo-log",
  "turborepo-repository",
  "turborepo-scm",
  "turborepo-task-id",

--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -475,7 +475,16 @@ impl<'a> Visitor<'a> {
 
                     let task_id_str = info.to_string();
                     let task_prefix = self.prefix(&info);
-                    let task_handle = self.grouping_layer.task(task_id_str.clone());
+                    // The display label always includes the task name for
+                    // CI group markers, even when log_prefix is None.
+                    let display_label = if self.run_opts.single_package {
+                        info.task().to_string()
+                    } else {
+                        format!("{}:{}", info.package(), info.task())
+                    };
+                    let task_handle = self
+                        .grouping_layer
+                        .task_with_label(&task_id_str, display_label);
                     self.grouping_layer
                         .logger()
                         .register_task(&task_id_str, &task_prefix);

--- a/crates/turborepo-log/src/grouping.rs
+++ b/crates/turborepo-log/src/grouping.rs
@@ -56,13 +56,40 @@ impl GroupingLayer {
     ///
     /// In passthrough mode the handle forwards directly to the logger.
     /// In grouped mode it buffers until [`TaskHandle::finish`] is called.
+    /// Create a [`TaskHandle`] for a task.
+    ///
+    /// `task_id` is the canonical identifier (e.g., `"my-app#build"`).
+    /// `display_label` is used for CI group markers and other
+    /// human-facing contexts (e.g., `"my-app:build"`). If not
+    /// provided, `task_id` is used.
     pub fn task(self: &Arc<Self>, task_id: impl Into<String>) -> TaskHandle {
+        let id = task_id.into();
+        let buffer = match self.mode {
+            GroupingMode::Passthrough => None,
+            GroupingMode::Grouped => Some(Vec::new()),
+        };
+        TaskHandle {
+            display_label: id.clone(),
+            task_id: id,
+            layer: Arc::clone(self),
+            buffer,
+            accumulated_bytes: Vec::new(),
+        }
+    }
+
+    /// Create a [`TaskHandle`] with a separate display label.
+    pub fn task_with_label(
+        self: &Arc<Self>,
+        task_id: impl Into<String>,
+        display_label: impl Into<String>,
+    ) -> TaskHandle {
         let buffer = match self.mode {
             GroupingMode::Passthrough => None,
             GroupingMode::Grouped => Some(Vec::new()),
         };
         TaskHandle {
             task_id: task_id.into(),
+            display_label: display_label.into(),
             layer: Arc::clone(self),
             buffer,
             accumulated_bytes: Vec::new(),
@@ -90,6 +117,8 @@ enum TaskEvent {
 /// run summary use.
 pub struct TaskHandle {
     task_id: String,
+    /// Human-facing label for CI group markers. Defaults to `task_id`.
+    display_label: String,
     layer: Arc<GroupingLayer>,
     /// `None` in passthrough mode; `Some` in grouped mode.
     buffer: Option<Vec<TaskEvent>>,
@@ -144,7 +173,9 @@ impl TaskHandle {
                 .lock()
                 .unwrap_or_else(|e| e.into_inner());
 
-            self.layer.logger.begin_task_group(&self.task_id, is_error);
+            self.layer
+                .logger
+                .begin_task_group(&self.display_label, is_error);
 
             for event in buffer {
                 match event {
@@ -157,7 +188,9 @@ impl TaskHandle {
                 }
             }
 
-            self.layer.logger.end_task_group(&self.task_id, is_error);
+            self.layer
+                .logger
+                .end_task_group(&self.display_label, is_error);
         }
         self.accumulated_bytes
     }

--- a/crates/turborepo-run-cache/Cargo.toml
+++ b/crates/turborepo-run-cache/Cargo.toml
@@ -18,6 +18,7 @@ tracing = { workspace = true }
 turbopath = { workspace = true }
 turborepo-cache = { workspace = true }
 turborepo-hash = { workspace = true }
+turborepo-log = { workspace = true }
 turborepo-repository = { path = "../turborepo-repository" }
 turborepo-scm = { workspace = true }
 turborepo-task-id = { workspace = true }

--- a/crates/turborepo-run-cache/src/lib.rs
+++ b/crates/turborepo-run-cache/src/lib.rs
@@ -114,12 +114,6 @@ pub struct RunCache {
 }
 
 /// Trait used to output cache information to user
-pub trait CacheOutput {
-    fn status(&mut self, message: &str, result: CacheResult);
-    fn error(&mut self, message: &str);
-    fn replay_logs(&mut self, log_file: &AbsoluteSystemPath) -> Result<(), turborepo_ui::Error>;
-}
-
 impl RunCache {
     pub fn new(
         cache: AsyncCache,
@@ -233,20 +227,28 @@ impl TaskCache {
     }
 
     /// Will read log file and write to output a line at a time
-    pub fn replay_log_file(&self, output: &mut impl CacheOutput) -> Result<(), Error> {
+    fn replay_log_file(
+        &self,
+        task_handle: &mut turborepo_log::grouping::TaskHandle,
+    ) -> Result<(), Error> {
         if self.log_file_path.exists() {
-            output.replay_logs(&self.log_file_path)?;
+            let mut writer = task_handle.writer(turborepo_log::OutputChannel::Stdout);
+            turborepo_ui::replay_logs(&mut writer, &self.log_file_path)?;
         }
 
         Ok(())
     }
 
-    pub fn on_error(&self, terminal_output: &mut impl CacheOutput) -> Result<(), Error> {
+    pub fn on_error(
+        &self,
+        task_handle: &mut turborepo_log::grouping::TaskHandle,
+        tui_sender: Option<&turborepo_ui::sender::TaskSender>,
+    ) -> Result<(), Error> {
         if self.task_output_logs == OutputLogsMode::ErrorsOnly {
-            // If errors_only_show_hash is enabled, we already printed the hash when
-            // the task started, so we don't need to print it again. We just replay logs.
             if !self.errors_only_show_hash {
-                terminal_output.status(
+                self.write_status(
+                    task_handle,
+                    tui_sender,
                     &format!(
                         "cache miss, executing {}",
                         color!(self.ui, GREY, "{}", self.hash)
@@ -254,10 +256,31 @@ impl TaskCache {
                     CacheResult::Miss,
                 );
             }
-            self.replay_log_file(terminal_output)?;
+            self.replay_log_file(task_handle)?;
         }
 
         Ok(())
+    }
+
+    /// Write a cache status message to the task output stream.
+    ///
+    /// This renders as plain text with the task's prefix — matching
+    /// the old `PrefixedUI::output()` behavior. Empty messages are
+    /// silently ignored.
+    fn write_status(
+        &self,
+        task_handle: &mut turborepo_log::grouping::TaskHandle,
+        tui_sender: Option<&turborepo_ui::sender::TaskSender>,
+        message: &str,
+        result: turborepo_ui::tui::event::CacheResult,
+    ) {
+        if let Some(sender) = tui_sender {
+            sender.status(message, result);
+        }
+        if !message.is_empty() {
+            let line = format!("{message}\n");
+            task_handle.task_output(turborepo_log::OutputChannel::Stdout, line.as_bytes());
+        }
     }
 
     pub fn output_writer<W: Write>(&self, writer: W) -> Result<LogWriter<W>, Error> {
@@ -289,12 +312,11 @@ impl TaskCache {
 
     pub async fn restore_outputs(
         &mut self,
-        terminal_output: &mut impl CacheOutput,
+        task_handle: &mut turborepo_log::grouping::TaskHandle,
+        tui_sender: Option<&turborepo_ui::sender::TaskSender>,
         telemetry: &PackageTaskEventBuilder,
     ) -> Result<Option<CacheHitMetadata>, Error> {
         if self.caching_disabled || self.run_cache.reads_disabled {
-            // Always send the cache miss status so TUI knows to start rendering.
-            // The message is only shown based on output_logs setting.
             let message = if self.task_output_logs == OutputLogsMode::ErrorsOnly
                 && self.errors_only_show_hash
             {
@@ -314,7 +336,12 @@ impl TaskCache {
                     color!(self.ui, GREY, "{}", self.hash)
                 )
             };
-            terminal_output.status(&message, CacheResult::Miss);
+            self.write_status(
+                task_handle,
+                tui_sender,
+                &message,
+                turborepo_ui::tui::event::CacheResult::Miss,
+            );
 
             return Ok(None);
         }
@@ -363,8 +390,6 @@ impl TaskCache {
                 .await?;
 
             let Some((cache_hit_metadata, restored_files)) = cache_status else {
-                // Always send the cache miss status so TUI knows to start rendering.
-                // The message is only shown based on output_logs setting.
                 let message = if self.task_output_logs == OutputLogsMode::ErrorsOnly
                     && self.errors_only_show_hash
                 {
@@ -384,7 +409,7 @@ impl TaskCache {
                         color!(self.ui, GREY, "{}", self.hash)
                     )
                 };
-                terminal_output.status(&message, CacheResult::Miss);
+                self.write_status(task_handle, tui_sender, &message, CacheResult::Miss);
 
                 return Ok(None);
             };
@@ -431,7 +456,9 @@ impl TaskCache {
 
         match self.task_output_logs {
             OutputLogsMode::HashOnly | OutputLogsMode::NewOnly => {
-                terminal_output.status(
+                self.write_status(
+                    task_handle,
+                    tui_sender,
                     &format!(
                         "cache hit{}, suppressing logs {}",
                         more_context,
@@ -442,7 +469,9 @@ impl TaskCache {
             }
             OutputLogsMode::Full => {
                 debug!("log file path: {}", self.log_file_path);
-                terminal_output.status(
+                self.write_status(
+                    task_handle,
+                    tui_sender,
                     &format!(
                         "cache hit{}, replaying logs {}",
                         more_context,
@@ -450,11 +479,13 @@ impl TaskCache {
                     ),
                     CacheResult::Hit,
                 );
-                self.replay_log_file(terminal_output)?;
+                self.replay_log_file(task_handle)?;
             }
             OutputLogsMode::ErrorsOnly if self.errors_only_show_hash => {
                 debug!("log file path: {}", self.log_file_path);
-                terminal_output.status(
+                self.write_status(
+                    task_handle,
+                    tui_sender,
                     &format!(
                         "cache hit{}, replaying logs (no errors) {}",
                         more_context,
@@ -463,8 +494,6 @@ impl TaskCache {
                     CacheResult::Hit,
                 );
             }
-            // Note that if we're restoring from cache, the task succeeded
-            // so we know we don't need to print anything for errors
             OutputLogsMode::ErrorsOnly | OutputLogsMode::None => {}
         }
 

--- a/crates/turborepo-task-executor/src/exec.rs
+++ b/crates/turborepo-task-executor/src/exec.rs
@@ -12,7 +12,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use console::{Style, StyledObject};
+use console::StyledObject;
 use tokio::sync::oneshot;
 use tracing::{Instrument, error};
 use turbopath::AnchoredSystemPathBuf;
@@ -24,9 +24,9 @@ use turborepo_run_summary::TaskTracker;
 use turborepo_task_id::TaskId;
 use turborepo_telemetry::events::{TrackedErrors, task::PackageTaskEventBuilder};
 use turborepo_types::{ContinueMode, StopExecution, UIMode};
-use turborepo_ui::{ColorConfig, OutputWriter};
+use turborepo_ui::ColorConfig;
 
-use crate::{TaskAccessProvider, TaskCacheOutput, TaskOutput};
+use crate::{TaskAccessProvider, TaskOutput};
 
 /// Windows NT status codes that indicate out-of-memory conditions.
 /// These are the signed i32 representations of the unsigned NT status codes.
@@ -161,40 +161,6 @@ pub trait TaskWarningCollector: Clone + Send {
 }
 
 // =============================================================================
-// Helper Functions
-// =============================================================================
-
-/// Create a prefixed UI for task output.
-///
-/// This creates a `PrefixedUI` configured with appropriate prefixes for
-/// normal output, errors, and warnings.
-pub fn prefixed_ui<W: Write>(
-    color_config: ColorConfig,
-    is_github_actions: bool,
-    stdout: W,
-    stderr: W,
-    prefix: StyledObject<String>,
-    include_timestamps: bool,
-) -> turborepo_ui::PrefixedUI<W> {
-    let mut prefixed_ui = turborepo_ui::PrefixedUI::new(color_config, stdout, stderr)
-        .with_output_prefix(prefix.clone())
-        .with_error_prefix(
-            Style::new().apply_to(format!("{}ERROR: ", color_config.apply(prefix.clone()))),
-        )
-        .with_warn_prefix(prefix)
-        .with_timestamps(include_timestamps);
-    if is_github_actions {
-        prefixed_ui = prefixed_ui
-            .with_error_prefix(Style::new().apply_to("[ERROR] ".to_string()))
-            .with_warn_prefix(Style::new().apply_to("[WARN] ".to_string()));
-    }
-    prefixed_ui
-}
-
-// =============================================================================
-// TaskExecutor
-// =============================================================================
-
 /// Executes a single task.
 ///
 /// This struct encapsulates all the logic for executing a task, including:
@@ -379,31 +345,12 @@ where
         Ok(())
     }
 
-    fn prefixed_ui<'a, O: Write>(
-        &self,
-        output_client: &'a TaskOutput<O>,
-    ) -> TaskCacheOutput<OutputWriter<'a, O>> {
-        match output_client {
-            TaskOutput::Direct(client) => TaskCacheOutput::Direct(prefixed_ui(
-                self.color_config,
-                self.is_github_actions,
-                client.stdout(),
-                client.stderr(),
-                self.pretty_prefix.clone(),
-                self.ui_mode.should_include_timestamps(),
-            )),
-            TaskOutput::UI(task) => TaskCacheOutput::UI(task.clone()),
-        }
-    }
-
     async fn execute_inner<O: Write>(
         &mut self,
         output_client: &TaskOutput<O>,
         task_handle: &mut turborepo_log::grouping::TaskHandle,
         telemetry: &PackageTaskEventBuilder,
     ) -> Result<ExecOutcome, InternalError> {
-        let mut prefixed_ui = self.prefixed_ui(output_client);
-
         if self.ui_mode.has_sender()
             && let TaskOutput::UI(task) = output_client
         {
@@ -421,9 +368,13 @@ where
         }
 
         // Try to restore from cache
+        let tui_sender = match output_client {
+            TaskOutput::UI(sender) => Some(sender),
+            _ => None,
+        };
         let cache_result = self
             .task_cache
-            .restore_outputs(&mut prefixed_ui, telemetry)
+            .restore_outputs(task_handle, tui_sender, telemetry)
             .instrument(tracing::info_span!("cache_restore", task = %self.task_id))
             .await;
         match cache_result {
@@ -528,7 +479,7 @@ where
         match exit_status {
             ChildExit::Finished(Some(0)) => Ok(ExecOutcome::Success(SuccessOutcome::Run)),
             ChildExit::Finished(Some(code)) => {
-                if let Err(e) = self.task_cache.on_error(&mut prefixed_ui) {
+                if let Err(e) = self.task_cache.on_error(task_handle, tui_sender) {
                     error!("error reading logs: {e}");
                 }
                 // Check if this looks like an OOM-related exit code
@@ -559,7 +510,7 @@ where
                 })
             }
             ChildExit::Finished(None) | ChildExit::Failed => {
-                if let Err(e) = self.task_cache.on_error(&mut prefixed_ui) {
+                if let Err(e) = self.task_cache.on_error(task_handle, tui_sender) {
                     error!("error reading logs: {e}");
                 }
                 let message = format!("command {} exited unexpectedly", process.label());
@@ -581,7 +532,7 @@ where
             }
             ChildExit::KilledExternal => {
                 const SIGKILL_EXIT_CODE: i32 = 137;
-                if let Err(e) = self.task_cache.on_error(&mut prefixed_ui) {
+                if let Err(e) = self.task_cache.on_error(task_handle, tui_sender) {
                     error!("error reading logs: {e}");
                 }
                 let message = format!(

--- a/crates/turborepo-task-executor/src/lib.rs
+++ b/crates/turborepo-task-executor/src/lib.rs
@@ -30,9 +30,9 @@ pub use command::{
 };
 pub use exec::{
     DryRunExecutor, ExecOutcome, HashTrackerProvider, InternalError, SuccessOutcome,
-    TaskErrorCollector, TaskExecutor, TaskWarningCollector, prefixed_ui,
+    TaskErrorCollector, TaskExecutor, TaskWarningCollector,
 };
-pub use output::{StdWriter, TaskCacheOutput, TaskOutput};
+pub use output::{StdWriter, TaskOutput};
 use serde::Serialize;
 use turbopath::AbsoluteSystemPathBuf;
 use turborepo_task_id::TaskId;

--- a/crates/turborepo-task-executor/src/output.rs
+++ b/crates/turborepo-task-executor/src/output.rs
@@ -5,12 +5,7 @@
 
 use std::io::Write;
 
-use either::Either;
-use turbopath::AbsoluteSystemPath;
-use turborepo_run_cache::CacheOutput;
-use turborepo_ui::{
-    OutputClient, OutputWriter, PrefixedUI, sender::TaskSender, tui::event::CacheResult,
-};
+use turborepo_ui::{OutputClient, sender::TaskSender};
 
 /// Small wrapper over our two output types that defines a shared interface for
 /// interacting with them.
@@ -26,84 +21,6 @@ impl<W: Write> TaskOutput<W> {
             TaskOutput::Direct(client) => client.finish(use_error),
             TaskOutput::UI(client) if use_error => Ok(Some(client.failed())),
             TaskOutput::UI(client) => Ok(Some(client.succeeded(is_cache_hit))),
-        }
-    }
-
-    pub fn stdout(&self) -> Either<OutputWriter<'_, W>, TaskSender> {
-        match self {
-            TaskOutput::Direct(client) => Either::Left(client.stdout()),
-            TaskOutput::UI(client) => Either::Right(client.clone()),
-        }
-    }
-
-    pub fn stderr(&self) -> Either<OutputWriter<'_, W>, TaskSender> {
-        match self {
-            TaskOutput::Direct(client) => Either::Left(client.stderr()),
-            TaskOutput::UI(client) => Either::Right(client.clone()),
-        }
-    }
-
-    pub fn task_logs(&self) -> Either<OutputWriter<'_, W>, TaskSender> {
-        match self {
-            TaskOutput::Direct(client) => Either::Left(client.stdout()),
-            TaskOutput::UI(client) => Either::Right(client.clone()),
-        }
-    }
-}
-
-/// Struct for displaying information about task's cache
-pub enum TaskCacheOutput<W> {
-    Direct(PrefixedUI<W>),
-    UI(TaskSender),
-}
-
-impl<W: Write> TaskCacheOutput<W> {
-    pub fn task_writer(&mut self) -> Either<turborepo_ui::PrefixedWriter<&mut W>, TaskSender> {
-        match self {
-            TaskCacheOutput::Direct(prefixed) => Either::Left(prefixed.output_prefixed_writer()),
-            TaskCacheOutput::UI(task) => Either::Right(task.clone()),
-        }
-    }
-
-    pub fn warn(&mut self, message: impl std::fmt::Display) {
-        match self {
-            TaskCacheOutput::Direct(prefixed) => prefixed.warn(message),
-            TaskCacheOutput::UI(task) => {
-                let _ = write!(task, "\r\n{message}\r\n");
-            }
-        }
-    }
-}
-
-impl<W: Write> CacheOutput for TaskCacheOutput<W> {
-    fn status(&mut self, message: &str, result: CacheResult) {
-        match self {
-            TaskCacheOutput::Direct(direct) => {
-                // Only output if there's a message to display
-                if !message.is_empty() {
-                    direct.output(message);
-                }
-            }
-            TaskCacheOutput::UI(task) => task.status(message, result),
-        }
-    }
-
-    fn error(&mut self, message: &str) {
-        match self {
-            TaskCacheOutput::Direct(prefixed) => prefixed.error(message),
-            TaskCacheOutput::UI(task) => {
-                let _ = write!(task, "{message}\r\n");
-            }
-        }
-    }
-
-    fn replay_logs(&mut self, log_file: &AbsoluteSystemPath) -> Result<(), turborepo_ui::Error> {
-        match self {
-            TaskCacheOutput::Direct(direct) => {
-                let writer = direct.output_prefixed_writer();
-                turborepo_ui::replay_logs(writer, log_file)
-            }
-            TaskCacheOutput::UI(task) => turborepo_ui::replay_logs_with_crlf(task, log_file),
         }
     }
 }
@@ -151,87 +68,5 @@ impl std::io::Write for StdWriter {
 
     fn flush(&mut self) -> std::io::Result<()> {
         self.writer().flush()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use turborepo_run_cache::CacheOutput;
-    use turborepo_ui::{ColorConfig, PrefixedUI, tui::event::CacheResult};
-
-    use super::*;
-
-    fn create_test_prefixed_ui<'a>(
-        out: &'a mut Vec<u8>,
-        err: &'a mut Vec<u8>,
-    ) -> PrefixedUI<&'a mut Vec<u8>> {
-        PrefixedUI::new(ColorConfig::new(true), out, err)
-            .with_output_prefix(console::Style::new().apply_to("test: ".to_string()))
-    }
-
-    #[test]
-    fn test_direct_status_with_message_outputs() {
-        let mut out_buffer = Vec::new();
-        let mut err_buffer = Vec::new();
-        let prefixed_ui = create_test_prefixed_ui(&mut out_buffer, &mut err_buffer);
-        let mut output: TaskCacheOutput<&mut Vec<u8>> = TaskCacheOutput::Direct(prefixed_ui);
-
-        output.status("cache miss, executing abc123", CacheResult::Miss);
-
-        let output_str = String::from_utf8(out_buffer).unwrap();
-        assert!(
-            output_str.contains("cache miss"),
-            "expected output to contain 'cache miss', got: {output_str}"
-        );
-    }
-
-    #[test]
-    fn test_direct_status_with_empty_message_outputs_nothing() {
-        let mut out_buffer = Vec::new();
-        let mut err_buffer = Vec::new();
-        let prefixed_ui = create_test_prefixed_ui(&mut out_buffer, &mut err_buffer);
-        let mut output: TaskCacheOutput<&mut Vec<u8>> = TaskCacheOutput::Direct(prefixed_ui);
-
-        // Empty message should not produce any output
-        output.status("", CacheResult::Miss);
-
-        let output_str = String::from_utf8(out_buffer).unwrap();
-        assert!(
-            output_str.is_empty(),
-            "expected no output for empty message, got: {output_str:?}"
-        );
-    }
-
-    #[test]
-    fn test_direct_status_cache_hit_with_message() {
-        let mut out_buffer = Vec::new();
-        let mut err_buffer = Vec::new();
-        let prefixed_ui = create_test_prefixed_ui(&mut out_buffer, &mut err_buffer);
-        let mut output: TaskCacheOutput<&mut Vec<u8>> = TaskCacheOutput::Direct(prefixed_ui);
-
-        output.status("cache hit, replaying logs xyz789", CacheResult::Hit);
-
-        let output_str = String::from_utf8(out_buffer).unwrap();
-        assert!(
-            output_str.contains("cache hit"),
-            "expected output to contain 'cache hit', got: {output_str}"
-        );
-    }
-
-    #[test]
-    fn test_direct_status_cache_hit_empty_message() {
-        let mut out_buffer = Vec::new();
-        let mut err_buffer = Vec::new();
-        let prefixed_ui = create_test_prefixed_ui(&mut out_buffer, &mut err_buffer);
-        let mut output: TaskCacheOutput<&mut Vec<u8>> = TaskCacheOutput::Direct(prefixed_ui);
-
-        // Empty message with cache hit should also produce no output
-        output.status("", CacheResult::Hit);
-
-        let output_str = String::from_utf8(out_buffer).unwrap();
-        assert!(
-            output_str.is_empty(),
-            "expected no output for empty message, got: {output_str:?}"
-        );
     }
 }

--- a/crates/turborepo-ui/src/tui_sink.rs
+++ b/crates/turborepo-ui/src/tui_sink.rs
@@ -47,7 +47,10 @@ pub struct TuiSink {
 }
 
 enum SinkState {
-    Buffering(Vec<LogEvent>),
+    Buffering {
+        events: Vec<LogEvent>,
+        task_output: Vec<(String, Vec<u8>)>,
+    },
     Connected(TuiSender),
 }
 
@@ -60,17 +63,28 @@ impl Default for TuiSink {
 impl TuiSink {
     pub fn new() -> Self {
         Self {
-            state: Mutex::new(SinkState::Buffering(Vec::new())),
+            state: Mutex::new(SinkState::Buffering {
+                events: Vec::new(),
+                task_output: Vec::new(),
+            }),
         }
     }
 
     /// Transition from buffering to connected. Drains all buffered
-    /// events through the sender, then forwards directly from here on.
+    /// events and task output through the sender, then forwards
+    /// directly from here on.
     pub fn connect(&self, sender: TuiSender) {
         let mut state = self.state.lock().unwrap();
-        if let SinkState::Buffering(buffer) = &mut *state {
-            for event in buffer.drain(..) {
+        if let SinkState::Buffering {
+            events,
+            task_output,
+        } = &mut *state
+        {
+            for event in events.drain(..) {
                 sender.log_event(event);
+            }
+            for (task, bytes) in task_output.drain(..) {
+                let _ = sender.output(task, bytes);
             }
         }
         *state = SinkState::Connected(sender);
@@ -81,7 +95,7 @@ impl LogSink for TuiSink {
     fn emit(&self, event: &LogEvent) {
         let mut state = self.state.lock().unwrap();
         match &mut *state {
-            SinkState::Buffering(buffer) => buffer.push(event.clone()),
+            SinkState::Buffering { events, .. } => events.push(event.clone()),
             SinkState::Connected(sender) => {
                 // Task-scoped events go to the task's output pane so
                 // they appear inline with the task's process output.
@@ -97,11 +111,15 @@ impl LogSink for TuiSink {
     }
 
     fn task_output(&self, task: &str, _channel: OutputChannel, bytes: &[u8]) {
-        let state = self.state.lock().unwrap();
-        if let SinkState::Connected(sender) = &*state {
-            // Normalize \n to \r\n for the TUI's VT100 terminal emulator.
-            let normalized = normalize_newlines(bytes);
-            let _ = sender.output(task.to_string(), normalized);
+        let mut state = self.state.lock().unwrap();
+        let normalized = normalize_newlines(bytes);
+        match &mut *state {
+            SinkState::Buffering { task_output, .. } => {
+                task_output.push((task.to_string(), normalized));
+            }
+            SinkState::Connected(sender) => {
+                let _ = sender.output(task.to_string(), normalized);
+            }
         }
     }
 }
@@ -137,10 +155,10 @@ mod tests {
 
         let state = sink.state.lock().unwrap();
         match &*state {
-            SinkState::Buffering(buf) => {
-                assert_eq!(buf.len(), 2);
-                assert_eq!(buf[0].message(), "first");
-                assert_eq!(buf[1].message(), "second");
+            SinkState::Buffering { events, .. } => {
+                assert_eq!(events.len(), 2);
+                assert_eq!(events[0].message(), "first");
+                assert_eq!(events[1].message(), "second");
             }
             SinkState::Connected(_) => panic!("expected Buffering state"),
         }


### PR DESCRIPTION
## Summary

- Cache hit log replay and error-mode replay now flow through `TaskHandle` → `GroupingLayer` → sinks, replacing the `PrefixedUI`/`OutputClient` path
- Cache status messages ("cache miss, executing abc123", "cache hit, replaying logs") now flow as plain text through `task_handle.task_output()` for stream mode rendering, with `TaskSender::status()` called alongside for TUI cache status display
- Removes the `CacheOutput` trait, `TaskCacheOutput` enum, standalone `prefixed_ui()` function, and associated tests
- Fixes TUI task output: `TuiSink` now buffers task output bytes in pre-connect state (instead of dropping them), draining on `connect()`

## Why

This was the last code path using the old `PrefixedUI` → `OutputClient` pipeline. After this PR, ALL task output (child process bytes, cache status messages, cache log replay, and task errors/warnings) flows through the unified `turborepo-log` pipeline.

## What changed

| Before | After |
|--------|-------|
| `restore_outputs(&mut impl CacheOutput, ...)` | `restore_outputs(&mut TaskHandle, Option<&TaskSender>, ...)` |
| `on_error(&mut impl CacheOutput)` | `on_error(&mut TaskHandle, Option<&TaskSender>)` |
| `CacheOutput::status()` → `PrefixedUI::output()` → `OutputClient` → stdout | `task_handle.task_output()` for stream rendering + `TaskSender::status()` for TUI lifecycle |
| `CacheOutput::replay_logs()` → `PrefixedWriter` → `OutputClient` | `task_handle.writer()` → `replay_logs()` → sinks |
| `TuiSink::task_output()` drops bytes pre-connect | Buffers alongside `LogEvent`s, drains on `connect()` |

## Deleted

- `CacheOutput` trait (`turborepo-run-cache/src/lib.rs`)
- `TaskCacheOutput` enum + `CacheOutput` impl (`turborepo-task-executor/src/output.rs`)
- `prefixed_ui()` standalone function (`exec.rs`)
- 4 tests that tested the old `CacheOutput` impl
- `stdout()`, `stderr()` methods on `TaskOutput` (no longer used)

## How to test

Both stream and TUI modes:
```
turbo run build --force              # cache miss
turbo run build                      # cache hit with log replay
turbo run build --force --ui=stream  # stream mode explicitly
```
Verify: cache status messages render correctly, log replay works, TUI shows task output in panes.