### PR TITLE
chore: Update undici dependency version to 6.24.0

### DIFF
--- a/packages/turbo-utils/package.json
+++ b/packages/turbo-utils/package.json
@@ -28,7 +28,7 @@
     "lint:prettier": "prettier -c . --cache --ignore-path=../../.prettierignore"
   },
   "dependencies": {
-    "undici": "^6.21.0"
+    "undici": "^6.24.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -848,8 +848,8 @@ importers:
   packages/turbo-utils:
     dependencies:
       undici:
-        specifier: ^6.21.0
-        version: 6.23.0
+        specifier: ^6.24.0
+        version: 6.24.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 0.18.2
@@ -8176,6 +8176,10 @@ packages:
     resolution: {integrity: sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==}
     engines: {node: '>=18.17'}
 
+  undici@6.24.1:
+    resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
+    engines: {node: '>=18.17'}
+
   undici@7.21.0:
     resolution: {integrity: sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg==}
     engines: {node: '>=20.18.1'}
@@ -8487,12 +8491,12 @@ snapshots:
   '@actions/http-client@3.0.2':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.23.0
+      undici: 6.24.1
 
   '@actions/http-client@4.0.0':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.23.0
+      undici: 6.24.1
 
   '@actions/io@3.0.2': {}
 
@@ -16220,6 +16224,8 @@ snapshots:
   undici-types@7.16.0: {}
 
   undici@6.23.0: {}
+
+  undici@6.24.1: {}
 
   undici@7.21.0: {}
 


### PR DESCRIPTION
The undici WebSocket client is vulnerable to a denial-of-service attack via unbounded memory consumption during permessage-deflate decompression. When a WebSocket connection negotiates the permessage-deflate extension, the client decompresses incoming compressed frames without enforcing any limit on the decompressed data size. A malicious WebSocket server can send a small compressed frame (a "decompression bomb") that expands to an extremely large size in memory, causing the Node.js process to exhaust available memory and crash or become unresponsive. The vulnerability exists in the PerMessageDeflate.decompress() method, which accumulates all decompressed chunks in memory and concatenates them into a single Buffer without checking whether the total size exceeds a safe threshold.

## Summary:
The turbo-utils package (part of the Turborepo monorepo) uses a vulnerable version of the undici library (@6.23.0). This version is susceptible to CVE-2026-1526, a Data Amplification vulnerability (CWE-409). An attacker can provide a specially crafted, highly compressed GZIP response that, when processed by the client, leads to massive memory consumption and an Out-of-Memory (OOM) crash. This results in a Denial of Service (DoS) for any process utilizing these utilities to fetch remote resources.

A remote attacker (e.g., via a compromised registry, proxy, or malicious API endpoint) can send a small compressed payload (~1MB) that expands to 1GB+ in the victim's memory. This will cause:

- **CI/CD Pipeline Failure**: Crashing build runners during task execution.
- **Developer Machine Instability**: Local development environments running turbo commands may become unresponsive or crash.
- **Service Interruption**: If turbo-utils is used in a server-side context, it leads to a complete service outage.
