### PR TITLE
fix: Sort uninstalled package managers to bottom of `create-turbo` selection

### DIFF
--- a/packages/create-turbo/src/commands/create/prompts.ts
+++ b/packages/create-turbo/src/commands/create/prompts.ts
@@ -52,13 +52,23 @@ export async function packageManager({
       { pm: "pnpm", label: "pnpm" },
       { pm: "yarn", label: "yarn" },
       { pm: "bun", label: "bun" }
-    ].map(({ pm, label }) => ({
-      name: label,
-      value: pm as PackageManager,
-      disabled: availablePackageManagers[pm as PackageManager]
-        ? false
-        : `not installed`
-    }))
+    ]
+      .sort((a, b) => {
+        const aInstalled = Boolean(
+          availablePackageManagers[a.pm as PackageManager]
+        );
+        const bInstalled = Boolean(
+          availablePackageManagers[b.pm as PackageManager]
+        );
+        return Number(bInstalled) - Number(aInstalled);
+      })
+      .map(({ pm, label }) => ({
+        name: label,
+        value: pm as PackageManager,
+        disabled: availablePackageManagers[pm as PackageManager]
+          ? false
+          : `not installed`
+      }))
   });
 
   return {


### PR DESCRIPTION
## Summary

- Uninstalled package managers in the `create-turbo` prompt now sort to the bottom of the list, keeping installed options front and center.
- Relative order within each group (installed/uninstalled) is preserved via stable sort.