### PR TITLE
docs: Clean up `futureFlags` description

### DIFF
--- a/crates/turborepo-turbo-json/src/future_flags.rs
+++ b/crates/turborepo-turbo-json/src/future_flags.rs
@@ -26,9 +26,6 @@ use ts_rs::TS;
 
 /// Opt into breaking changes prior to major releases, experimental features,
 /// and beta features.
-///
-/// Note: Currently all previous future flags (turboExtendsKeyword,
-/// nonRootExtends) have been graduated and are now enabled by default.
 #[derive(
     Serialize, Default, Debug, Copy, Clone, Iterable, Deserializable, PartialEq, Eq, JsonSchema,
 )]

--- a/packages/turbo-types/schemas/schema.json
+++ b/packages/turbo-types/schemas/schema.json
@@ -254,7 +254,7 @@
       ]
     },
     "FutureFlags": {
-      "description": "Opt into breaking changes prior to major releases, experimental features, and beta features.\n\nNote: Currently all previous future flags (turboExtendsKeyword, nonRootExtends) have been graduated and are now enabled by default.",
+      "description": "Opt into breaking changes prior to major releases, experimental features, and beta features.",
       "type": "object",
       "properties": {
         "affectedUsingTaskInputs": {


### PR DESCRIPTION
## Summary

- Removes outdated note about graduated future flags (`turboExtendsKeyword`, `nonRootExtends`) from the `FutureFlags` doc comment since these are no longer relevant
- Regenerates JSON schema to reflect the updated description