### PR TITLE
feat: Add `filterUsingTasks` future flag for task-level `--filter` resolution

### DIFF
--- a/crates/turborepo-engine/src/lib.rs
+++ b/crates/turborepo-engine/src/lib.rs
@@ -547,6 +547,70 @@ impl<T: TaskDefinitionInfo + Clone> Engine<Built, T> {
         )
     }
 
+    /// Returns all task IDs belonging to the given packages.
+    pub fn task_ids_for_packages(
+        &self,
+        packages: &HashSet<PackageName>,
+    ) -> HashSet<TaskId<'static>> {
+        packages
+            .iter()
+            .filter_map(|pkg| self.package_tasks.get(pkg))
+            .flatten()
+            .filter_map(|&idx| match self.task_graph.node_weight(idx)? {
+                TaskNode::Task(id) => Some(id.clone()),
+                TaskNode::Root => None,
+            })
+            .collect()
+    }
+
+    /// Returns the transitive task-graph dependencies of the given task set.
+    /// Forward DFS: all tasks that must run before any task in `task_ids`.
+    pub fn collect_task_dependencies(
+        &self,
+        task_ids: &HashSet<TaskId<'static>>,
+    ) -> HashSet<TaskId<'static>> {
+        let indices = task_ids
+            .iter()
+            .filter_map(|id| self.task_lookup.get(id))
+            .copied();
+        let nodes = turborepo_graph_utils::transitive_closure(
+            &self.task_graph,
+            indices,
+            petgraph::Direction::Outgoing,
+        );
+        nodes
+            .into_iter()
+            .filter_map(|node| match node {
+                TaskNode::Task(id) => Some(id.clone()),
+                TaskNode::Root => None,
+            })
+            .collect()
+    }
+
+    /// Returns the transitive task-graph dependents of the given task set.
+    /// Reverse DFS: all tasks that depend on any task in `task_ids`.
+    pub fn collect_task_dependents(
+        &self,
+        task_ids: &HashSet<TaskId<'static>>,
+    ) -> HashSet<TaskId<'static>> {
+        let indices = task_ids
+            .iter()
+            .filter_map(|id| self.task_lookup.get(id))
+            .copied();
+        let nodes = turborepo_graph_utils::transitive_closure(
+            &self.task_graph,
+            indices,
+            petgraph::Direction::Incoming,
+        );
+        nodes
+            .into_iter()
+            .filter_map(|node| match node {
+                TaskNode::Task(id) => Some(id.clone()),
+                TaskNode::Root => None,
+            })
+            .collect()
+    }
+
     fn neighbors(
         &self,
         task_id: &TaskId,

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -668,14 +668,23 @@ impl RunBuilder {
             )?
         };
 
-        let use_task_level_affected = self.opts.scope_opts.affected_range.is_some()
+        // When filterUsingTasks is active, --affected is handled by the
+        // same task-level filter rather than a separate codepath.
+        let use_task_level_filter = self.opts.future_flags.filter_using_tasks
+            && (!self.opts.scope_opts.filter_patterns.is_empty()
+                || self.opts.scope_opts.affected_range.is_some());
+
+        let use_task_level_affected = !use_task_level_filter
+            && self.opts.scope_opts.affected_range.is_some()
             && self.opts.future_flags.affected_using_task_inputs;
 
-        // When task-level affected filtering is active, the engine must
-        // contain tasks for ALL packages so that $TURBO_ROOT$ inputs in
-        // packages not flagged by the package-level scope resolution are
-        // still matched. The task-level filter (below) does the pruning.
-        let all_pkgs: Vec<PackageName> = if use_task_level_affected {
+        let needs_all_packages = use_task_level_affected || use_task_level_filter;
+
+        // When task-level filtering is active, the engine must contain tasks
+        // for ALL packages so that $TURBO_ROOT$ inputs in packages not flagged
+        // by the package-level scope resolution are still matched.
+        // The task-level filter (below) does the pruning.
+        let all_pkgs: Vec<PackageName> = if needs_all_packages {
             pkg_dep_graph
                 .packages()
                 .map(|(name, _)| name.clone())
@@ -683,7 +692,7 @@ impl RunBuilder {
         } else {
             Vec::new()
         };
-        let engine_pkgs: Box<dyn Iterator<Item = &PackageName>> = if use_task_level_affected {
+        let engine_pkgs: Box<dyn Iterator<Item = &PackageName>> = if needs_all_packages {
             Box::new(all_pkgs.iter())
         } else {
             Box::new(filtered_pkgs.keys())
@@ -708,7 +717,7 @@ impl RunBuilder {
         // rather than on both engines to avoid a redundant SCM query.
         if self.opts.run_opts.parallel {
             pkg_dep_graph.remove_package_dependencies();
-            let engine_pkgs: Box<dyn Iterator<Item = &PackageName>> = if use_task_level_affected {
+            let engine_pkgs: Box<dyn Iterator<Item = &PackageName>> = if needs_all_packages {
                 Box::new(all_pkgs.iter())
             } else {
                 Box::new(filtered_pkgs.keys())
@@ -721,6 +730,45 @@ impl RunBuilder {
             )?;
         }
 
+        // Task-level filter: resolve --filter and/or --affected against the task graph.
+        if use_task_level_filter {
+            let mut selectors: Vec<turborepo_scope::TargetSelector> = self
+                .opts
+                .scope_opts
+                .filter_patterns
+                .iter()
+                .map(|p| p.parse())
+                .collect::<Result<_, _>>()
+                .map_err(turborepo_scope::ResolutionError::from)?;
+
+            // When --affected is used alongside filterUsingTasks, synthesize a
+            // selector equivalent to `...[base...HEAD]` so it flows through
+            // the same task-level filter instead of a separate codepath.
+            if let Some((from_ref, to_ref)) = &self.opts.scope_opts.affected_range {
+                selectors.push(turborepo_scope::TargetSelector {
+                    git_range: Some(turborepo_scope::GitRange {
+                        from_ref: from_ref.clone(),
+                        to_ref: to_ref.clone(),
+                        include_uncommitted: true,
+                        allow_unknown_objects: true,
+                        merge_base: true,
+                    }),
+                    include_dependents: true,
+                    ..Default::default()
+                });
+            }
+
+            engine = super::task_filter::filter_engine_to_tasks(
+                engine,
+                &selectors,
+                &pkg_dep_graph,
+                &scm,
+                &self.repo_root,
+                &root_turbo_json.global_deps,
+            )?;
+        }
+
+        // Task-level --affected detection (separate from --filter).
         if use_task_level_affected {
             engine = self.filter_engine_to_affected_tasks(
                 engine,

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -5,6 +5,7 @@ mod error;
 pub(crate) mod package_discovery;
 pub(crate) mod scope;
 pub mod task_access;
+pub(crate) mod task_filter;
 mod ui;
 pub mod watch;
 

--- a/crates/turborepo-lib/src/run/task_filter.rs
+++ b/crates/turborepo-lib/src/run/task_filter.rs
@@ -1,0 +1,706 @@
+//! Task-level filter resolution for `--filter` with the `filterUsingTasks`
+//! future flag.
+//!
+//! When active, `--filter` patterns are resolved against the task graph
+//! rather than the package graph:
+//!
+//! - Git-range selectors (`[main]`) match changed files against each task's
+//!   `inputs` globs, catching out-of-package inputs like `$TURBO_ROOT$`.
+//! - The `...` dependency/dependent syntax traverses the task graph, picking up
+//!   cross-package task dependencies (e.g. `web#build -> schema#gen` where
+//!   `web` has no package-level dependency on `schema`).
+//!
+//! The core matching logic reuses
+//! `turborepo_engine::match_tasks_against_changed_files`
+//! and `crate::task_change_detector::affected_task_ids`, sharing code with
+//! `--affected` + `affectedUsingTaskInputs`.
+
+use std::collections::HashSet;
+
+use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf};
+use turborepo_repository::package_graph::{PackageGraph, PackageName};
+use turborepo_scm::SCM;
+use turborepo_scope::{target_selector::GitRange, TargetSelector};
+use turborepo_task_id::TaskId;
+use wax::Program;
+
+use crate::engine::Engine;
+
+/// Filters an engine down to only the tasks matching the given selectors.
+///
+/// Each include selector contributes a set of tasks (unioned together).
+/// Exclude selectors remove tasks from the result. After all selectors
+/// are processed, the engine is pruned to the surviving tasks plus their
+/// transitive dependents (so downstream tasks still run).
+pub fn filter_engine_to_tasks(
+    engine: Engine,
+    selectors: &[TargetSelector],
+    pkg_dep_graph: &PackageGraph,
+    scm: &SCM,
+    repo_root: &AbsoluteSystemPath,
+    global_deps: &[String],
+) -> Result<Engine, crate::run::error::Error> {
+    let (include, exclude): (Vec<_>, Vec<_>) = selectors.iter().partition(|s| !s.exclude);
+
+    let mut included_tasks: HashSet<TaskId<'static>> = HashSet::new();
+
+    for selector in &include {
+        let matched = resolve_selector_to_tasks(
+            &engine,
+            selector,
+            pkg_dep_graph,
+            scm,
+            repo_root,
+            global_deps,
+        )?;
+        included_tasks.extend(matched);
+    }
+
+    // If there were no include selectors (only excludes), start with all tasks.
+    if include.is_empty() {
+        included_tasks = engine.task_ids().cloned().collect();
+    }
+
+    for selector in &exclude {
+        let to_exclude = resolve_selector_to_tasks(
+            &engine,
+            selector,
+            pkg_dep_graph,
+            scm,
+            repo_root,
+            global_deps,
+        )?;
+        included_tasks.retain(|t| !to_exclude.contains(t));
+    }
+
+    if included_tasks.is_empty() {
+        return Ok(engine.retain_affected_tasks(&included_tasks));
+    }
+
+    // retain_affected_tasks expands to transitive dependents and prunes the
+    // rest, which is exactly what we want — downstream tasks of matched tasks
+    // still need to run.
+    Ok(engine.retain_affected_tasks(&included_tasks))
+}
+
+/// Resolves a single selector to the set of matching task IDs.
+///
+/// Steps:
+/// 1. Find the "base" task set from name/directory/git-range
+/// 2. Expand via `...` (dependencies/dependents) in the task graph
+fn resolve_selector_to_tasks(
+    engine: &Engine,
+    selector: &TargetSelector,
+    pkg_dep_graph: &PackageGraph,
+    scm: &SCM,
+    repo_root: &AbsoluteSystemPath,
+    global_deps: &[String],
+) -> Result<HashSet<TaskId<'static>>, crate::run::error::Error> {
+    if selector.match_dependencies {
+        return resolve_match_dependencies(
+            engine,
+            selector,
+            pkg_dep_graph,
+            scm,
+            repo_root,
+            global_deps,
+        );
+    }
+
+    let base_tasks =
+        resolve_base_tasks(engine, selector, pkg_dep_graph, scm, repo_root, global_deps)?;
+
+    let mut result = HashSet::new();
+
+    if selector.include_dependencies {
+        let deps = engine.collect_task_dependencies(&base_tasks);
+        result.extend(deps);
+    }
+
+    if selector.include_dependents {
+        let dependents = engine.collect_task_dependents(&base_tasks);
+        result.extend(dependents);
+    }
+
+    if selector.include_dependencies || selector.include_dependents {
+        if selector.exclude_self {
+            // Remove the originally matched tasks, keeping only the
+            // traversed deps/dependents.
+            for t in &base_tasks {
+                result.remove(t);
+            }
+        } else {
+            result.extend(base_tasks);
+        }
+    } else {
+        result.extend(base_tasks);
+    }
+
+    Ok(result)
+}
+
+/// The base task set before `...` expansion.
+///
+/// Combines name/directory matching (package-level) with git-range matching
+/// (task-level via inputs). When both are present, the result is their
+/// intersection (same semantics as the package-level filter).
+fn resolve_base_tasks(
+    engine: &Engine,
+    selector: &TargetSelector,
+    pkg_dep_graph: &PackageGraph,
+    scm: &SCM,
+    repo_root: &AbsoluteSystemPath,
+    global_deps: &[String],
+) -> Result<HashSet<TaskId<'static>>, crate::run::error::Error> {
+    let tasks_from_packages = resolve_name_and_dir(engine, selector, pkg_dep_graph);
+    let tasks_from_git_range =
+        resolve_git_range(engine, selector, pkg_dep_graph, scm, repo_root, global_deps)?;
+
+    match (tasks_from_packages, tasks_from_git_range) {
+        (Some(pkg_tasks), Some(git_tasks)) => {
+            // Intersection: task must match both name/dir AND git range.
+            Ok(pkg_tasks.intersection(&git_tasks).cloned().collect())
+        }
+        (Some(tasks), None) | (None, Some(tasks)) => Ok(tasks),
+        (None, None) => Ok(HashSet::new()),
+    }
+}
+
+/// Matches tasks by package name pattern and/or directory.
+/// Returns None if the selector has no name/directory constraints.
+fn resolve_name_and_dir(
+    engine: &Engine,
+    selector: &TargetSelector,
+    pkg_dep_graph: &PackageGraph,
+) -> Option<HashSet<TaskId<'static>>> {
+    let has_name = !selector.name_pattern.is_empty();
+    let has_dir = selector.parent_dir.is_some();
+
+    if !has_name && !has_dir {
+        return None;
+    }
+
+    let matching_packages = find_matching_packages(selector, pkg_dep_graph);
+    Some(engine.task_ids_for_packages(&matching_packages))
+}
+
+/// Finds packages matching a selector's name pattern and/or directory.
+fn find_matching_packages(
+    selector: &TargetSelector,
+    pkg_dep_graph: &PackageGraph,
+) -> HashSet<PackageName> {
+    let mut packages: HashSet<PackageName> = HashSet::new();
+
+    // Directory matching
+    if let Some(parent_dir) = &selector.parent_dir {
+        let parent_dir_unix = parent_dir.to_unix();
+        if let Ok(globber) = wax::Glob::new(parent_dir_unix.as_str()) {
+            let root_anchor = AnchoredSystemPathBuf::from_raw(".").expect("valid anchored");
+            if parent_dir == &root_anchor {
+                packages.insert(PackageName::Root);
+            } else {
+                for (name, info) in pkg_dep_graph.packages() {
+                    if globber.is_match(info.package_path().as_path()) {
+                        packages.insert(name.clone());
+                    }
+                }
+            }
+        }
+    } else {
+        // Start with all packages when only name pattern is used
+        packages = pkg_dep_graph
+            .packages()
+            .map(|(name, _)| name.clone())
+            .collect();
+    }
+
+    // Name pattern matching
+    if !selector.name_pattern.is_empty() {
+        if let Ok(matcher) = turborepo_scope::simple_glob::SimpleGlob::new(&selector.name_pattern) {
+            use turborepo_scope::simple_glob::Match;
+            packages.retain(|name| matcher.is_match(name.as_ref()));
+        }
+    }
+
+    packages
+}
+
+/// Matches tasks by git range using task-level input matching.
+/// Returns None if the selector has no git range.
+fn resolve_git_range(
+    engine: &Engine,
+    selector: &TargetSelector,
+    pkg_dep_graph: &PackageGraph,
+    scm: &SCM,
+    repo_root: &AbsoluteSystemPath,
+    global_deps: &[String],
+) -> Result<Option<HashSet<TaskId<'static>>>, crate::run::error::Error> {
+    let git_range = match &selector.git_range {
+        Some(range) => range,
+        None => return Ok(None),
+    };
+
+    let changed_files = get_changed_files(scm, repo_root, git_range)?;
+
+    match changed_files {
+        Ok(files) => {
+            let affected = crate::task_change_detector::affected_task_ids(
+                engine,
+                pkg_dep_graph,
+                &files,
+                global_deps,
+            );
+            Ok(Some(affected))
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = ?e,
+                "SCM returned invalid change set for filter git range; including all tasks"
+            );
+            // If we can't determine changes, include all tasks (safe fallback).
+            Ok(Some(engine.task_ids().cloned().collect()))
+        }
+    }
+}
+
+/// Resolves `match_dependencies` selectors (e.g. `web...[main]`).
+///
+/// Finds tasks in the named packages (or their task-graph dependencies)
+/// whose inputs match the changed files.
+fn resolve_match_dependencies(
+    engine: &Engine,
+    selector: &TargetSelector,
+    pkg_dep_graph: &PackageGraph,
+    scm: &SCM,
+    repo_root: &AbsoluteSystemPath,
+    global_deps: &[String],
+) -> Result<HashSet<TaskId<'static>>, crate::run::error::Error> {
+    let git_range = match &selector.git_range {
+        Some(range) => range,
+        None => return Ok(HashSet::new()),
+    };
+
+    // Find all tasks in the named packages
+    let matching_packages = find_matching_packages(selector, pkg_dep_graph);
+    let package_tasks = engine.task_ids_for_packages(&matching_packages);
+
+    // Expand to include all task-graph dependencies
+    let mut candidate_tasks = engine.collect_task_dependencies(&package_tasks);
+    if !selector.exclude_self {
+        candidate_tasks.extend(package_tasks);
+    }
+
+    // Now check which of these candidates are affected by the git range
+    let changed_files = get_changed_files(scm, repo_root, git_range)?;
+
+    match changed_files {
+        Ok(files) => {
+            let affected = crate::task_change_detector::affected_task_ids(
+                engine,
+                pkg_dep_graph,
+                &files,
+                global_deps,
+            );
+            // Intersection: task must be in the candidate set AND affected
+            Ok(candidate_tasks.intersection(&affected).cloned().collect())
+        }
+        Err(_) => {
+            // Can't determine changes → return all candidates
+            Ok(candidate_tasks)
+        }
+    }
+}
+
+fn get_changed_files(
+    scm: &SCM,
+    repo_root: &AbsoluteSystemPath,
+    git_range: &GitRange,
+) -> Result<
+    Result<HashSet<AnchoredSystemPathBuf>, turborepo_scm::git::InvalidRange>,
+    crate::run::error::Error,
+> {
+    let result = scm.changed_files(
+        repo_root,
+        git_range.from_ref.as_deref(),
+        git_range.to_ref.as_deref(),
+        git_range.include_uncommitted,
+        git_range.merge_base,
+        git_range.allow_unknown_objects,
+    )?;
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+
+    use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf};
+    use turborepo_repository::{
+        discovery::{DiscoveryResponse, PackageDiscovery},
+        package_graph::{PackageGraph, PackageName},
+        package_json::PackageJson,
+        package_manager::PackageManager,
+    };
+    use turborepo_task_id::TaskId;
+    use turborepo_types::{TaskDefinition, TaskInputs};
+
+    use crate::engine::{Building, Engine};
+
+    struct MockDiscovery;
+
+    impl PackageDiscovery for MockDiscovery {
+        async fn discover_packages(
+            &self,
+        ) -> Result<DiscoveryResponse, turborepo_repository::discovery::Error> {
+            Ok(DiscoveryResponse {
+                package_manager: PackageManager::Npm,
+                workspaces: vec![],
+            })
+        }
+
+        async fn discover_packages_blocking(
+            &self,
+        ) -> Result<DiscoveryResponse, turborepo_repository::discovery::Error> {
+            self.discover_packages().await
+        }
+    }
+
+    async fn make_pkg_graph(repo_root: &AbsoluteSystemPath, packages: &[&str]) -> PackageGraph {
+        let mut pkgs = HashMap::new();
+        for name in packages {
+            let path = repo_root.join_components(&["packages", name, "package.json"]);
+            let pkg = PackageJson {
+                name: Some(turborepo_errors::Spanned::new(name.to_string())),
+                ..Default::default()
+            };
+            pkgs.insert(path, pkg);
+        }
+        PackageGraph::builder(repo_root, PackageJson::default())
+            .with_package_discovery(MockDiscovery)
+            .with_package_jsons(Some(pkgs))
+            .build()
+            .await
+            .unwrap()
+    }
+
+    fn make_engine(
+        tasks: &[(TaskId<'static>, TaskDefinition)],
+        edges: &[(TaskId<'static>, TaskId<'static>)],
+    ) -> Engine {
+        let mut engine: Engine<Building> = Engine::new();
+        for (task_id, def) in tasks {
+            engine.get_index(task_id);
+            engine.add_definition(task_id.clone(), def.clone());
+        }
+        for (from, to) in edges {
+            let from_idx = engine.get_index(from);
+            let to_idx = engine.get_index(to);
+            engine.task_graph_mut().add_edge(from_idx, to_idx, ());
+        }
+        engine.seal()
+    }
+
+    fn def_with_inputs(globs: &[&str], default: bool) -> TaskDefinition {
+        TaskDefinition {
+            inputs: TaskInputs {
+                globs: globs.iter().map(|s| s.to_string()).collect(),
+                default,
+            },
+            ..Default::default()
+        }
+    }
+
+    /// `--filter=web...` should pick up cross-package task deps.
+    ///
+    /// web#build -> schema#gen is a task dependency but web has no
+    /// package-level dep on schema. The filter should include schema#gen.
+    #[tokio::test]
+    async fn include_dependencies_traverses_task_graph() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let _pkg_graph = make_pkg_graph(root, &["web", "schema"]).await;
+
+        let web_build = TaskId::new("web", "build");
+        let schema_gen = TaskId::new("schema", "gen");
+
+        let engine = make_engine(
+            &[
+                (web_build.clone(), TaskDefinition::default()),
+                (schema_gen.clone(), TaskDefinition::default()),
+            ],
+            // web#build depends on schema#gen (task dep, not package dep)
+            &[(web_build.clone(), schema_gen.clone())],
+        );
+
+        let matching_packages: HashSet<_> = ["web"].iter().map(|s| PackageName::from(*s)).collect();
+        let web_tasks = engine.task_ids_for_packages(&matching_packages);
+        assert!(web_tasks.contains(&web_build));
+        assert!(!web_tasks.contains(&schema_gen));
+
+        // include_dependencies should traverse the task graph
+        let mut all_tasks = engine.collect_task_dependencies(&web_tasks);
+        all_tasks.extend(web_tasks);
+        assert!(all_tasks.contains(&web_build));
+        assert!(all_tasks.contains(&schema_gen));
+    }
+
+    /// `--filter=...schema` should pick up task-graph dependents.
+    #[tokio::test]
+    async fn include_dependents_traverses_task_graph() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let _pkg_graph = make_pkg_graph(root, &["web", "schema"]).await;
+
+        let web_build = TaskId::new("web", "build");
+        let schema_gen = TaskId::new("schema", "gen");
+
+        let engine = make_engine(
+            &[
+                (web_build.clone(), TaskDefinition::default()),
+                (schema_gen.clone(), TaskDefinition::default()),
+            ],
+            &[(web_build.clone(), schema_gen.clone())],
+        );
+
+        let matching_packages: HashSet<_> =
+            ["schema"].iter().map(|s| PackageName::from(*s)).collect();
+        let schema_tasks = engine.task_ids_for_packages(&matching_packages);
+
+        let mut all_tasks = engine.collect_task_dependents(&schema_tasks);
+        all_tasks.extend(schema_tasks);
+        assert!(all_tasks.contains(&web_build));
+        assert!(all_tasks.contains(&schema_gen));
+    }
+
+    /// Task input matching: a task with $TURBO_ROOT$ inputs should be
+    /// detectable through engine-level matching.
+    #[tokio::test]
+    async fn task_inputs_matching_via_engine() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let pkg_graph = make_pkg_graph(root, &["lib-a"]).await;
+
+        let a_build = TaskId::new("lib-a", "build");
+        // ../../config.txt is the $TURBO_ROOT$ expansion for packages/lib-a
+        let engine = make_engine(
+            &[(
+                a_build.clone(),
+                def_with_inputs(&["../../config.txt"], true),
+            )],
+            &[],
+        );
+
+        let changed: HashSet<AnchoredSystemPathBuf> = ["config.txt"]
+            .iter()
+            .map(|f| AnchoredSystemPathBuf::from_raw(f).unwrap())
+            .collect();
+
+        let affected =
+            turborepo_engine::match_tasks_against_changed_files(&engine, &pkg_graph, &changed);
+        assert!(
+            affected.contains_key(&a_build),
+            "task with $TURBO_ROOT$ input should match root file change"
+        );
+    }
+
+    /// resolve_selector_to_tasks with a name-only selector returns
+    /// only the matching package's tasks.
+    #[tokio::test]
+    async fn selector_name_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let pkg_graph = make_pkg_graph(root, &["web", "api"]).await;
+        let scm = turborepo_scm::SCM::new(root);
+
+        let web_build = TaskId::new("web", "build");
+        let api_build = TaskId::new("api", "build");
+
+        let engine = make_engine(
+            &[
+                (web_build.clone(), TaskDefinition::default()),
+                (api_build.clone(), TaskDefinition::default()),
+            ],
+            &[],
+        );
+
+        let selector = turborepo_scope::TargetSelector {
+            name_pattern: "web".to_string(),
+            ..Default::default()
+        };
+
+        let tasks =
+            super::resolve_selector_to_tasks(&engine, &selector, &pkg_graph, &scm, root, &[])
+                .unwrap();
+
+        assert!(tasks.contains(&web_build));
+        assert!(!tasks.contains(&api_build));
+    }
+
+    /// resolve_selector_to_tasks with include_dependencies traverses
+    /// the task graph, not the package graph.
+    #[tokio::test]
+    async fn selector_include_dependencies_uses_task_graph() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        // web has no package dep on schema
+        let pkg_graph = make_pkg_graph(root, &["web", "schema"]).await;
+        let scm = turborepo_scm::SCM::new(root);
+
+        let web_build = TaskId::new("web", "build");
+        let schema_gen = TaskId::new("schema", "gen");
+
+        let engine = make_engine(
+            &[
+                (web_build.clone(), TaskDefinition::default()),
+                (schema_gen.clone(), TaskDefinition::default()),
+            ],
+            // Task dep: web#build -> schema#gen
+            &[(web_build.clone(), schema_gen.clone())],
+        );
+
+        let selector = turborepo_scope::TargetSelector {
+            name_pattern: "web".to_string(),
+            include_dependencies: true,
+            ..Default::default()
+        };
+
+        let tasks =
+            super::resolve_selector_to_tasks(&engine, &selector, &pkg_graph, &scm, root, &[])
+                .unwrap();
+
+        assert!(
+            tasks.contains(&web_build),
+            "web#build should be included: {tasks:?}"
+        );
+        assert!(
+            tasks.contains(&schema_gen),
+            "schema#gen should be included via task graph traversal: {tasks:?}"
+        );
+    }
+
+    /// resolve_selector_to_tasks with include_dependents traverses
+    /// the task graph backwards.
+    #[tokio::test]
+    async fn selector_include_dependents_uses_task_graph() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let pkg_graph = make_pkg_graph(root, &["web", "schema"]).await;
+        let scm = turborepo_scm::SCM::new(root);
+
+        let web_build = TaskId::new("web", "build");
+        let schema_gen = TaskId::new("schema", "gen");
+
+        let engine = make_engine(
+            &[
+                (web_build.clone(), TaskDefinition::default()),
+                (schema_gen.clone(), TaskDefinition::default()),
+            ],
+            &[(web_build.clone(), schema_gen.clone())],
+        );
+
+        let selector = turborepo_scope::TargetSelector {
+            name_pattern: "schema".to_string(),
+            include_dependents: true,
+            ..Default::default()
+        };
+
+        let tasks =
+            super::resolve_selector_to_tasks(&engine, &selector, &pkg_graph, &scm, root, &[])
+                .unwrap();
+
+        assert!(
+            tasks.contains(&schema_gen),
+            "schema#gen should be included: {tasks:?}"
+        );
+        assert!(
+            tasks.contains(&web_build),
+            "web#build should be included as a task-level dependent: {tasks:?}"
+        );
+    }
+
+    /// exclude_self with include_dependencies should include deps but
+    /// not the matched package's own tasks.
+    #[tokio::test]
+    async fn selector_exclude_self_with_dependencies() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let pkg_graph = make_pkg_graph(root, &["web", "schema"]).await;
+        let scm = turborepo_scm::SCM::new(root);
+
+        let web_build = TaskId::new("web", "build");
+        let schema_gen = TaskId::new("schema", "gen");
+
+        let engine = make_engine(
+            &[
+                (web_build.clone(), TaskDefinition::default()),
+                (schema_gen.clone(), TaskDefinition::default()),
+            ],
+            &[(web_build.clone(), schema_gen.clone())],
+        );
+
+        // ^web... — web's deps but not web itself
+        let selector = turborepo_scope::TargetSelector {
+            name_pattern: "web".to_string(),
+            include_dependencies: true,
+            exclude_self: true,
+            ..Default::default()
+        };
+
+        let tasks =
+            super::resolve_selector_to_tasks(&engine, &selector, &pkg_graph, &scm, root, &[])
+                .unwrap();
+
+        assert!(
+            !tasks.contains(&web_build),
+            "web#build should be excluded by exclude_self: {tasks:?}"
+        );
+        assert!(
+            tasks.contains(&schema_gen),
+            "schema#gen should still be included as a dep: {tasks:?}"
+        );
+    }
+
+    /// Glob name pattern should match multiple packages.
+    #[tokio::test]
+    async fn selector_glob_name_pattern() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let pkg_graph = make_pkg_graph(root, &["lib-a", "lib-b", "app"]).await;
+        let scm = turborepo_scm::SCM::new(root);
+
+        let a_build = TaskId::new("lib-a", "build");
+        let b_build = TaskId::new("lib-b", "build");
+        let app_build = TaskId::new("app", "build");
+
+        let engine = make_engine(
+            &[
+                (a_build.clone(), TaskDefinition::default()),
+                (b_build.clone(), TaskDefinition::default()),
+                (app_build.clone(), TaskDefinition::default()),
+            ],
+            &[],
+        );
+
+        let selector = turborepo_scope::TargetSelector {
+            name_pattern: "lib-*".to_string(),
+            ..Default::default()
+        };
+
+        let tasks =
+            super::resolve_selector_to_tasks(&engine, &selector, &pkg_graph, &scm, root, &[])
+                .unwrap();
+
+        assert!(
+            tasks.contains(&a_build),
+            "lib-a#build should match: {tasks:?}"
+        );
+        assert!(
+            tasks.contains(&b_build),
+            "lib-b#build should match: {tasks:?}"
+        );
+        assert!(
+            !tasks.contains(&app_build),
+            "app#build should not match lib-* glob: {tasks:?}"
+        );
+    }
+}

--- a/crates/turborepo-schema-gen/src/main.rs
+++ b/crates/turborepo-schema-gen/src/main.rs
@@ -719,6 +719,15 @@ export interface FutureFlags {
    */
   affectedUsingTaskInputs?: boolean;
   /**
+   * Use task-level `inputs` globs to determine which tasks to re-run when
+   * files change in `turbo watch`. When enabled, only tasks whose declared
+   * inputs match the changed files are re-executed, rather than re-running
+   * all tasks in changed packages.
+   *
+   * @defaultValue `false`
+   */
+  watchUsingTaskInputs?: boolean;
+  /**
    * Include files matching `globalDependencies` globs in the `turbo prune`
    * output. Without this flag, `globalDependencies` entries are preserved in
    * the pruned `turbo.json` but the actual files are not copied.
@@ -726,6 +735,15 @@ export interface FutureFlags {
    * @defaultValue `false`
    */
   pruneIncludesGlobalFiles?: boolean;
+  /**
+   * Resolve `--filter` at the task level instead of the package level.
+   * Git-range filters (e.g. `--filter=[main]`) will match against task
+   * `inputs` globs, and the `...` dependency/dependent syntax will
+   * traverse the task graph in addition to the package graph.
+   *
+   * @defaultValue `false`
+   */
+  filterUsingTasks?: boolean;
 }
 
 "#

--- a/crates/turborepo-scope/src/lib.rs
+++ b/crates/turborepo-scope/src/lib.rs
@@ -15,7 +15,7 @@
 // Module declarations
 mod change_detector;
 pub mod filter;
-mod simple_glob;
+pub mod simple_glob;
 pub mod target_selector;
 
 use std::collections::HashMap;

--- a/crates/turborepo-turbo-json/src/future_flags.rs
+++ b/crates/turborepo-turbo-json/src/future_flags.rs
@@ -68,6 +68,12 @@ pub struct FutureFlags {
     /// the pruned `turbo.json` but the actual files are not copied.
     #[serde(default)]
     pub prune_includes_global_files: bool,
+    /// Resolve `--filter` at the task level instead of the package level.
+    /// Git-range filters (e.g. `--filter=[main]`) will match against task
+    /// `inputs` globs, and the `...` dependency/dependent syntax will
+    /// traverse the task graph in addition to the package graph.
+    #[serde(default)]
+    pub filter_using_tasks: bool,
 }
 
 // Manual TS impl because #[derive(TS)] conflicts with the Iterable and
@@ -84,28 +90,28 @@ impl TS for FutureFlags {
     fn inline() -> String {
         "{ errorsOnlyShowHash?: boolean, experimentalObservability?: boolean, longerSignatureKey?: \
          boolean, affectedUsingTaskInputs?: boolean, watchUsingTaskInputs?: boolean, \
-         pruneIncludesGlobalFiles?: boolean }"
+         pruneIncludesGlobalFiles?: boolean, filterUsingTasks?: boolean }"
             .to_string()
     }
 
     fn inline_flattened() -> String {
         "{ errorsOnlyShowHash?: boolean, experimentalObservability?: boolean, longerSignatureKey?: \
          boolean, affectedUsingTaskInputs?: boolean, watchUsingTaskInputs?: boolean, \
-         pruneIncludesGlobalFiles?: boolean }"
+         pruneIncludesGlobalFiles?: boolean, filterUsingTasks?: boolean }"
             .to_string()
     }
 
     fn decl() -> String {
         "type FutureFlags = { errorsOnlyShowHash?: boolean, experimentalObservability?: boolean, \
          longerSignatureKey?: boolean, affectedUsingTaskInputs?: boolean, watchUsingTaskInputs?: \
-         boolean, pruneIncludesGlobalFiles?: boolean };"
+         boolean, pruneIncludesGlobalFiles?: boolean, filterUsingTasks?: boolean };"
             .to_string()
     }
 
     fn decl_concrete() -> String {
         "type FutureFlags = { errorsOnlyShowHash?: boolean, experimentalObservability?: boolean, \
          longerSignatureKey?: boolean, affectedUsingTaskInputs?: boolean, watchUsingTaskInputs?: \
-         boolean, pruneIncludesGlobalFiles?: boolean };"
+         boolean, pruneIncludesGlobalFiles?: boolean, filterUsingTasks?: boolean };"
             .to_string()
     }
 

--- a/packages/turbo-types/schemas/schema.json
+++ b/packages/turbo-types/schemas/schema.json
@@ -272,6 +272,11 @@
           "default": false,
           "type": "boolean"
         },
+        "filterUsingTasks": {
+          "description": "Resolve `--filter` at the task level instead of the package level. Git-range filters (e.g. `--filter=[main]`) will match against task `inputs` globs, and the `...` dependency/dependent syntax will traverse the task graph in addition to the package graph.",
+          "default": false,
+          "type": "boolean"
+        },
         "longerSignatureKey": {
           "description": "Enforce a minimum length of 32 bytes for `TURBO_REMOTE_CACHE_SIGNATURE_KEY` when `remoteCache.signature` is enabled. Short keys weaken the HMAC-SHA256 signature, making brute-force tag collision feasible.",
           "default": false,

--- a/packages/turbo-types/schemas/schema.v2.json
+++ b/packages/turbo-types/schemas/schema.v2.json
@@ -281,6 +281,11 @@
           "description": "Use task-level `inputs` globs to determine which tasks to re-run when files change in `turbo watch`. When enabled, only tasks whose declared inputs match the changed files are re-executed, rather than re-running all tasks in changed packages.",
           "default": false,
           "type": "boolean"
+        },
+        "filterUsingTasks": {
+          "description": "Resolve `--filter` at the task level instead of the package level. Git-range filters (e.g. `--filter=[main]`) will match against task `inputs` globs, and the `...` dependency/dependent syntax will traverse the task graph in addition to the package graph.",
+          "default": false,
+          "type": "boolean"
         }
       }
     },

--- a/packages/turbo-types/src/types/config-v2.ts
+++ b/packages/turbo-types/src/types/config-v2.ts
@@ -236,6 +236,15 @@ export interface FutureFlags {
    */
   affectedUsingTaskInputs?: boolean;
   /**
+   * Use task-level `inputs` globs to determine which tasks to re-run when
+   * files change in `turbo watch`. When enabled, only tasks whose declared
+   * inputs match the changed files are re-executed, rather than re-running
+   * all tasks in changed packages.
+   *
+   * @defaultValue `false`
+   */
+  watchUsingTaskInputs?: boolean;
+  /**
    * Include files matching `globalDependencies` globs in the `turbo prune`
    * output. Without this flag, `globalDependencies` entries are preserved in
    * the pruned `turbo.json` but the actual files are not copied.
@@ -243,6 +252,15 @@ export interface FutureFlags {
    * @defaultValue `false`
    */
   pruneIncludesGlobalFiles?: boolean;
+  /**
+   * Resolve `--filter` at the task level instead of the package level.
+   * Git-range filters (e.g. `--filter=[main]`) will match against task
+   * `inputs` globs, and the `...` dependency/dependent syntax will
+   * traverse the task graph in addition to the package graph.
+   *
+   * @defaultValue `false`
+   */
+  filterUsingTasks?: boolean;
 }
 
 export interface Pipeline {


### PR DESCRIPTION
## Summary

Implements TURBO-3956. `--filter` currently resolves at the package graph level, which has two gaps:

- **`--filter=[main]` misses out-of-package task inputs**: If a task declares `inputs: ["$TURBO_ROOT$/config.txt"]` and that file changes, the filter won't detect it because the file is outside every package directory.
- **`--filter=web...` only traverses package dependencies**: If `web#build` depends on `schema#gen` via turbo.json `dependsOn` but `web` has no package-level dep on `schema`, then `schema#gen` is excluded.

This PR adds a `filterUsingTasks` future flag that shifts `--filter` resolution to the task graph level. When enabled:

1. The engine is built with ALL packages (so `$TURBO_ROOT$` inputs anywhere can be matched)
2. Git-range selectors (`[main]`) match changed files against each task's `inputs` globs via `match_tasks_against_changed_files()`
3. The `...` dependency/dependent syntax traverses the task graph (not just the package graph), picking up cross-package task deps
4. `--affected` flows through the same unified codepath

Gated behind `futureFlags.filterUsingTasks` in `turbo.json`. Zero behavior change when flag is off.

## How to test

Enable in turbo.json:
```json
{
  "futureFlags": {
    "filterUsingTasks": true
  }
}
```

Then test the two scenarios from the issue:
1. Add a task with `$TURBO_ROOT$` inputs, change the root file, run `turbo run build --filter=[main]` — the task should now be included
2. Create a cross-package task dependency (e.g. `web#build -> schema#gen` without a package dep), run `turbo run build --filter=web...` — `schema#gen` should now be included