### PR TITLE
fix: Suppress noisy rustls TLS warning on stderr

### DIFF
--- a/crates/turborepo-lib/src/tracing.rs
+++ b/crates/turborepo-lib/src/tracing.rs
@@ -212,6 +212,7 @@ impl TurboSubscriber {
                 .with_env_var("TURBO_LOG_VERBOSITY")
                 .from_env_lossy()
                 .add_directive("reqwest=error".parse().unwrap())
+                .add_directive("rustls=error".parse().unwrap())
                 .add_directive("hyper=warn".parse().unwrap())
                 .add_directive("h2=warn".parse().unwrap());
 


### PR DESCRIPTION
## Summary

- Adds `rustls=error` tracing filter directive alongside the existing `reqwest`, `hyper`, and `h2` suppressions.

Closes #8626

## Context

Users with self-signed certificates see `WARNING Sending fatal alert BadCertificate` on every turbo command. This is a TLS protocol-level log message emitted by `rustls` at WARN level during handshake — it doesn't indicate a security problem that needs user attention. The TLS connection is still properly rejected by rustls; the warning is just narration.

Self-signed certs installed in the OS trust store already work correctly since the API client loads native roots via `rustls-native-certs`. The warning likely fires during the two-phase client initialization window (before native roots are loaded) or from background requests like update checks.

Users debugging TLS issues can still surface these logs with `TURBO_LOG_VERBOSITY=rustls=warn`.