### PR TITLE
docs: Fix typo in Turbo 2.7 blog post

### DIFF
--- a/apps/docs/content/blog/turbo-2-7.mdx
+++ b/apps/docs/content/blog/turbo-2-7.mdx
@@ -315,7 +315,7 @@ We’ve updated our lockfile parser to work with this new Yarn feature, ensuring
     - examples(dev-deps): bump the with-svelte group in /examples/with-svelte with 2 updates ([#11152](https://github.com/vercel/turborepo/pull/11152))
     - examples(with-nestjs): Add missing eslint devDependency ([#11138](https://github.com/vercel/turborepo/pull/11138))
     - examples(dev-deps): bump @types/react from 19.2.2 to 19.2.5 in /examples/non-monorepo ([#11125](https://github.com/vercel/turborepo/pull/11125))
-    - examples: Remove uneeded microfrontends.json property ([#11101](https://github.com/vercel/turborepo/pull/11101))
+    - examples: Remove unneeded microfrontends.json property ([#11101](https://github.com/vercel/turborepo/pull/11101))
     - examples: Bump `turbo` to latest ([#11100](https://github.com/vercel/turborepo/pull/11100))
     - examples(deps): bump next from 16.0.0 to 16.0.1 in /examples/kitchen-sink ([#11088](https://github.com/vercel/turborepo/pull/11088))
     - examples(dev-deps): bump svelte from 5.43.3 to 5.43.5 in /examples/with-svelte ([#11087](https://github.com/vercel/turborepo/pull/11087))


### PR DESCRIPTION
### Description

- fix "uneeded" to "unneeded" in the Turbo 2.7 blog post
- related issue: N/A (trivial docs fix)
- guideline alignment: follows [CONTRIBUTING.md](https://github.com/vercel/turborepo/blob/main/CONTRIBUTING.md) as a single-file docs-only change

### Testing Instructions

- Not run (documentation-only change)
