### PR TITLE
fix: Fall back to bundled certificates when system cert store is inaccessible

### DIFF
--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -626,17 +626,34 @@ impl APIClient {
         connect_timeout: Option<Duration>,
         #[allow(unused_variables)] native_roots: bool,
     ) -> Result<reqwest::Client> {
-        let mut builder = reqwest::Client::builder();
-        #[cfg(feature = "rustls-tls")]
-        {
-            builder = builder
-                .tls_built_in_webpki_certs(true)
-                .tls_built_in_native_certs(native_roots);
+        let build = |#[allow(unused_variables)] use_native: bool| {
+            let mut builder = reqwest::Client::builder();
+            #[cfg(feature = "rustls-tls")]
+            {
+                builder = builder
+                    .tls_built_in_webpki_certs(true)
+                    .tls_built_in_native_certs(use_native);
+            }
+            if let Some(dur) = connect_timeout {
+                builder = builder.connect_timeout(dur);
+            }
+            builder.build()
+        };
+
+        match build(native_roots) {
+            Ok(client) => Ok(client),
+            Err(e) if native_roots => {
+                // The system certificate store may be inaccessible (e.g.
+                // "Access is denied" on locked-down Windows machines).
+                // Fall back to the bundled Mozilla CA bundle which doesn't
+                // require any OS-level access.
+                tracing::warn!(
+                    "System certificate store is unavailable ({e}), using bundled certificates"
+                );
+                build(false).map_err(Error::TlsError)
+            }
+            Err(e) => Err(Error::TlsError(e)),
         }
-        if let Some(dur) = connect_timeout {
-            builder = builder.connect_timeout(dur);
-        }
-        builder.build().map_err(Error::TlsError)
     }
 
     pub fn base_url(&self) -> &str {

--- a/crates/turborepo-api-client/src/shared_http_client.rs
+++ b/crates/turborepo-api-client/src/shared_http_client.rs
@@ -62,15 +62,25 @@ impl SharedHttpClient {
 
         // Phase 2: build full client in background (native-roots, ~200ms on macOS).
         let native = self.native_client.clone();
+        let fast_fallback = self.fast_client.clone();
         let warming = self.warming.clone();
         tokio::task::spawn_blocking(move || {
             let _span = tracing::info_span!("http_client_init").entered();
-            let _ = native.get_or_init(|| {
-                let client =
-                    APIClient::build_http_client(None).expect("failed to build native HTTP client");
-                warming.store(false, Ordering::Release);
-                client
-            });
+            match APIClient::build_http_client(None) {
+                Ok(client) => {
+                    let _ = native.set(client);
+                }
+                Err(e) => {
+                    tracing::warn!("Native HTTP client init failed ({e}), using fast client");
+                    // Ensure the fast (webpki-only) client is available as fallback.
+                    if fast_fallback.get().is_none()
+                        && let Ok(client) = APIClient::build_http_client_webpki_only(None)
+                    {
+                        let _ = fast_fallback.set(client);
+                    }
+                }
+            }
+            warming.store(false, Ordering::Release);
         });
     }
 


### PR DESCRIPTION
## Summary

- When `rustls-native-certs` fails to access the system certificate store (e.g. "Access is denied" on locked-down Windows machines), turbo now falls back to the bundled Mozilla CA bundle (`webpki-roots`) instead of crashing
- Replaces a panicking `.expect()` in `SharedHttpClient` Phase 2 with graceful error handling

## Why

On certain Windows environments, the process cannot read the system certificate store at all, causing every turbo command (`run`, `login`, `link`, etc.) to fail with:

```
× Failed to create APIClient: Unable to set up TLS.
├─▶ builder error: Access is denied. (os error 5)
╰─▶ Access is denied. (os error 5)
```

The `SharedHttpClient` two-phase init (added in #12208) already mitigated this for `turbo run` by using a webpki-only fast client as fallback. But `turbo login`, `turbo link`, and `turbo logout` still called `APIClient::new()` directly and would crash.

This fix applies the fallback at the source (`build_http_client_with_native_roots`) so all callers are covered.

## Testing

The fallback only triggers when `reqwest::Client::builder().build()` fails with native certs enabled. On unaffected machines, behavior is unchanged — native certs are still preferred.

Closes https://github.com/vercel/turborepo/issues/8493