### PR TITLE
fix: Pass `TURBO_*` env vars through to child processes in Strict Mode

### DIFF
--- a/crates/turborepo-env/src/lib.rs
+++ b/crates/turborepo-env/src/lib.rs
@@ -59,6 +59,8 @@ pub const BUILTIN_PASS_THROUGH_ENV: &[&str] = &[
     "JB_IDE_*",
     "JB_INTERPRETER",
     "_JETBRAINS_TEST_RUNNER_RUN_SCOPE_TYPE",
+    // Turborepo config (needed for nested turbo invocations)
+    "TURBO_*",
     // Vercel specific
     "VERCEL",
     "VERCEL_*",
@@ -671,6 +673,7 @@ mod tests {
                 ("DOCKER_HOST", "tcp://localhost"),
                 ("GITHUB_TOKEN", "ghp_xxx"),
                 ("NEXT_PUBLIC_API", "https://api"),
+                ("TURBO_TOKEN", "tkn_xxx"),
                 ("RANDOM_VAR", "value"),
                 ("CI", "true"),
                 ("VERCEL", "1"),


### PR DESCRIPTION
## Summary

- Adds `TURBO_*` to `BUILTIN_PASS_THROUGH_ENV` so turbo auth/config env vars survive strict env mode filtering into child processes

Fixes #12346

## Why

In strict env mode (the default), turbo clears the child process environment and only passes through declared vars. `TURBO_TOKEN`, `TURBO_TEAM`, `TURBO_TEAMID`, and `TURBO_API` were not in the builtin passthrough list.

When a task script invokes `turbo run` (a nested turbo invocation), the inner turbo process silently lost all auth credentials, causing `is_linked()` to return `false` and remote cache to be disabled without any warning.

The reporter's setup had `"main": "turbo run sub-task-1"` in their package.json, where `main` had `cache: false` and `sub-task-1` had `cache: true`. Running `turbo run main` would execute `sub-task-1` via a nested turbo process that couldn't authenticate with the remote cache.

## How to verify

The existing recursion detection only covers root package scripts (`visitor/mod.rs:379`), so non-root packages can invoke turbo without warning. With this change, the nested turbo process inherits `TURBO_TOKEN` and team config, allowing remote cache to work.

`TURBO_*` follows the same wildcard pattern used for `VERCEL_*`, `GITHUB_*`, `DOCKER_*`, etc. Passthrough vars are excluded from hash computation, so this won't change cache behavior for existing setups.