### PR TITLE
fix: Use previous stable tag for stable release notes

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -164,15 +164,25 @@ jobs:
 
       - name: Get previous tag
         id: previous-tag
+        env:
+          INCREMENT: ${{ github.event_name == 'schedule' && 'prerelease' || inputs.increment }}
         run: |
-          # Use ls-remote to query tags without fetching objects
-          PREV_TAG=$(git ls-remote --tags origin 'refs/tags/v*-canary.*' \
-            | awk '{print $2}' | sed 's|refs/tags/||' | grep -v '\^{}$' \
-            | sort -V | tail -n 1)
-          if [ -z "$PREV_TAG" ]; then
+          # For stable releases, compare against the previous stable tag so
+          # release notes include everything since the last stable release.
+          # For canary releases, compare against the latest canary tag.
+          if [[ "$INCREMENT" == "patch" || "$INCREMENT" == "minor" || "$INCREMENT" == "major" ]]; then
             PREV_TAG=$(git ls-remote --tags origin 'refs/tags/v*' \
               | awk '{print $2}' | sed 's|refs/tags/||' | grep -v '\^{}$' \
               | grep -v canary | sort -V | tail -n 1)
+          else
+            PREV_TAG=$(git ls-remote --tags origin 'refs/tags/v*-canary.*' \
+              | awk '{print $2}' | sed 's|refs/tags/||' | grep -v '\^{}$' \
+              | sort -V | tail -n 1)
+            if [ -z "$PREV_TAG" ]; then
+              PREV_TAG=$(git ls-remote --tags origin 'refs/tags/v*' \
+                | awk '{print $2}' | sed 's|refs/tags/||' | grep -v '\^{}$' \
+                | grep -v canary | sort -V | tail -n 1)
+            fi
           fi
           echo "tag=$PREV_TAG" >> $GITHUB_OUTPUT
           echo "Previous tag: $PREV_TAG"


### PR DESCRIPTION
## Summary

- Stable releases (e.g. v2.8.18) were generating release notes by comparing against the last canary tag instead of the previous stable release, resulting in incomplete changelogs
- The `Get previous tag` step now branches on the `INCREMENT` input: stable releases (`patch`/`minor`/`major`) compare against the previous stable tag, canary releases keep the existing canary-first behavior
- Also updated the existing v2.8.18 release notes with the correct `v2.8.17...v2.8.18` comparison

## Context for reviewers

The v2.8.18 release notes only showed 2 PRs because `--notes-start-tag` was set to `v2.8.18-canary.26` rather than `v2.8.17`. The actual diff includes ~55 PRs. The root cause is the `Get previous tag` step unconditionally preferring canary tags — the `if [ -z "$PREV_TAG" ]` fallback to stable tags would never trigger since canary tags always exist.