### PR TITLE
fix: Remove unnecessary git pull in update-examples workflow

### DIFF
--- a/.github/workflows/update-examples-on-release.yml
+++ b/.github/workflows/update-examples-on-release.yml
@@ -36,7 +36,6 @@ jobs:
       - name: Commit and push
         run: |
           git commit -am "release(turborepo): update examples to latest"
-          git pull origin main
           git push origin ${{ steps.branch.outputs.STAGE_BRANCH }}
 
       - name: Create pull request


### PR DESCRIPTION
## Summary
- The "Update Examples" release workflow fails because `git pull origin main` on a newly created branch causes a "divergent branches" error (exit code 128)
- The pull is redundant since the branch is created from a fresh checkout of `main`, so removing it fixes the push step