### PR TITLE
ci: Use blobless clones for release workflow checkouts

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -148,6 +148,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.sha || github.sha }}
+          filter: blob:none
 
       - uses: ./.github/actions/setup-node
         with:
@@ -282,6 +283,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.stage.outputs.stage-branch }}
+          filter: blob:none
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
@@ -330,6 +332,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.stage.outputs.stage-branch }}
+          filter: blob:none
 
       - name: Setup Protoc
         uses: ./.github/actions/setup-protoc
@@ -373,6 +376,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.stage.outputs.stage-branch }}
+          filter: blob:none
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
@@ -400,6 +404,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.stage.outputs.stage-branch }}
+          filter: blob:none
 
       - uses: ./.github/actions/setup-node
         with:
@@ -458,6 +463,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.stage.outputs.stage-branch }}
+          filter: blob:none
 
       - name: Configure git
         run: |
@@ -505,6 +511,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.stage.outputs.stage-branch }}
+          filter: blob:none
 
       - name: Get version and compute subdomain
         id: version
@@ -588,6 +595,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.stage.outputs.stage-branch }}
+          filter: blob:none
 
       - uses: ./.github/actions/setup-node
         with:

--- a/.github/workflows/update-examples-on-release.yml
+++ b/.github/workflows/update-examples-on-release.yml
@@ -11,6 +11,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          filter: blob:none
+
       - uses: ./.github/actions/setup-node
 
       - name: Upgrade corepack


### PR DESCRIPTION
## Summary

- Adds `filter: blob:none` to all 9 checkout steps in the release pipeline and the update-examples workflow
- This makes `actions/checkout` perform a blobless partial clone: git fetches tree metadata (directory structure) immediately but defers downloading file contents until they're actually accessed by subsequent steps
- Should meaningfully reduce checkout times across all release jobs (stage, build-rust, npm-publish, etc.) since not every job reads every file in the repo