### PR TITLE
fix: Tailored `turbo-ignore` deprecation notice for Vercel users

### DIFF
--- a/packages/turbo-ignore/src/ignore.ts
+++ b/packages/turbo-ignore/src/ignore.ts
@@ -42,12 +42,21 @@ export function turboIgnore(
     ...opts
   };
 
-  warn(
-    `\x1b[33m"turbo-ignore" is deprecated and will be removed in a future major version. Use "turbo query affected" instead.\x1b[39m`
-  );
-  warn(
-    `\x1b[33mLearn more: https://turborepo.dev/docs/reference/query#migrating-from-turbo-ignore\x1b[39m\n`
-  );
+  if (process.env.VERCEL === "1") {
+    warn(
+      `\u001B[33m"turbo-ignore" is deprecated. Use Vercel's built-in project skipping instead.\u001B[39m`
+    );
+    warn(
+      `\u001B[33mLearn more: https://vercel.com/docs/monorepos#skipping-unaffected-projects\u001B[39m\n`
+    );
+  } else {
+    warn(
+      `\u001B[33m"turbo-ignore" is deprecated. Use "turbo query affected" instead.\u001B[39m`
+    );
+    warn(
+      `\u001B[33mLearn more: https://turborepo.dev/docs/reference/query#migrating-from-turbo-ignore\u001B[39m\n`
+    );
+  }
 
   info(
     `Using Turborepo to determine if this project is affected by the commit...\n`


### PR DESCRIPTION
## Summary

- When `turbo-ignore` runs on Vercel (`VERCEL=1`), the deprecation notice now points users to [Vercel's built-in project skipping](https://vercel.com/docs/monorepos#skipping-unaffected-projects) instead of `turbo query affected`
- Non-Vercel environments continue to see the existing `turbo query affected` guidance

Vercel users don't need to adopt `turbo query affected` as a migration path since Vercel already has first-class support for skipping unaffected projects. Sending them to the right docs reduces friction.