### PR TITLE
fix: Support legacy unscoped binary package names in Node.js shim

### DIFF
--- a/packages/turbo/bin/turbo
+++ b/packages/turbo/bin/turbo
@@ -36,6 +36,34 @@ function hasPackage(sourceObject, packageName) {
   return !!sourceObject[packageName] || !!sourceObject[`node_modules/${packageName}`];
 }
 
+// Binary packages were renamed from `turbo-<os>-<arch>` to `@turbo/<os>-<arch>`.
+// We try the scoped name first, then fall back to the legacy unscoped name so
+// that upgrades across the rename boundary still work without re-installing.
+function binaryPaths(platform, arch) {
+  const ext = platform === 'windows' ? '.exe' : '';
+  return [
+    `@turbo/${platform}-${arch}/bin/turbo${ext}`,
+    `turbo-${platform}-${arch}/bin/turbo${ext}`,
+  ];
+}
+
+function packageNames(platform, arch) {
+  return [
+    `@turbo/${platform}-${arch}`,
+    `turbo-${platform}-${arch}`,
+  ];
+}
+
+// Try require.resolve on each candidate, return the first that succeeds.
+function tryResolve(candidates) {
+  for (const candidate of candidates) {
+    try {
+      return require.resolve(candidate);
+    } catch (e) {}
+  }
+  return null;
+}
+
 // This provides logging messages as it progresses towards calculating the binary path.
 function getBinaryPath() {
   // First we see if the user has configured a particular binary path.
@@ -68,49 +96,53 @@ function getBinaryPath() {
 
   let { platform, arch } = process;
   // Node uses `win32` but we want to use `windows` for consistency with
-  // our package naming conventions (i.e. `turbo-windows-64`).
+  // our package naming conventions (i.e. `@turbo/windows-64`).
   if (platform === "win32") {
     platform = "windows";
   }
   const resolvedArch = arch === 'x64' ? '64' : arch;
-  const ext = platform === 'windows' ? '.exe' : '';
 
   // Try all places in order until we get a hit.
 
+  const isSupported = availablePlatforms.includes(platform) && availableArchs.includes(resolvedArch);
+
   // 1. The package which contains the binary we _should_ be running.
-  const correctBinary = availablePlatforms.includes(platform) && availableArchs.includes(resolvedArch) ? `@turbo/${platform}-${resolvedArch}/bin/turbo${ext}` : null;
-  if (correctBinary !== null) {
-    try {
-      return require.resolve(`${correctBinary}`);
-    } catch (e) {}
+  //    Try the scoped name (@turbo/<os>-<arch>) first, then the legacy name (turbo-<os>-<arch>).
+  const correctCandidates = isSupported ? binaryPaths(platform, resolvedArch) : [];
+  const resolved = tryResolve(correctCandidates);
+  if (resolved !== null) {
+    return resolved;
   }
 
   // 2. Install the binary that they need just in time.
-  if (SHOULD_INSTALL && correctBinary !== null) {
+  if (SHOULD_INSTALL && correctCandidates.length > 0) {
     console.warn('Turborepo did not find the correct binary for your platform.');
     console.warn('We will attempt to install it now.');
 
     try {
       installUsingNPM();
-      const resolvedPath = require.resolve(`${correctBinary}`);
-      console.warn('Installation has succeeded.');
-      return resolvedPath;
-    } catch (e) {
-      console.warn('Installation has failed.');
-    }
+      const resolvedPath = tryResolve(correctCandidates);
+      if (resolvedPath !== null) {
+        console.warn('Installation has succeeded.');
+        return resolvedPath;
+      }
+    } catch (e) {}
+    console.warn('Installation has failed.');
   }
 
   // 3. Both Windows and macOS ARM boxes can run x64 binaries. Attempt to run under emulation.
-  const alternateBinary = (arch === "arm64" && ['darwin', 'windows'].includes(platform)) ? `@turbo/${platform}-64/bin/turbo${ext}` : null;
-  if (SHOULD_ATTEMPT_EMULATED && alternateBinary !== null) {
-    try {
-      const resolvedPath = require.resolve(`${alternateBinary}`);
+  const alternateCandidates = (arch === "arm64" && ['darwin', 'windows'].includes(platform))
+    ? binaryPaths(platform, '64')
+    : [];
+  if (SHOULD_ATTEMPT_EMULATED && alternateCandidates.length > 0) {
+    const resolvedPath = tryResolve(alternateCandidates);
+    if (resolvedPath !== null) {
       console.warn(`Turborepo detected that you're running:\n${platform} ${resolvedArch}.`);
-      console.warn(`We were not able to find the binary at:\n${correctBinary}`);
-      console.warn(`We found a possibly-compatible binary at:\n${alternateBinary}`);
+      console.warn(`We were not able to find the binary at:\n${correctCandidates[0]}`);
+      console.warn(`We found a possibly-compatible binary at:\n${resolvedPath}`);
       console.warn(`We will attempt to run that binary.`);
       return resolvedPath;
-    } catch (e) {}
+    }
   }
 
   // We are not going to run `turbo` this invocation.
@@ -118,7 +150,7 @@ function getBinaryPath() {
 
   // Possible error scenarios:
   // - The user is on a platform/arch combination we do not support.
-  // - We somehow got detection wrong and never attempted to run the _actual_ `correctBinary` or `alternateBinary`.
+  // - We somehow got detection wrong and never attempted to run the _actual_ correct binary or alternate binary.
   // - The user doesn't have the correct packages installed for their platform.
 
   // Explain our detection attempt:
@@ -146,32 +178,33 @@ function getBinaryPath() {
     }
   }
 
-  if (correctBinary !== null) {
+  if (correctCandidates.length > 0) {
     console.error();
     console.error('***');
     console.error();
-    console.error(`We were not able to find the binary at:\n${correctBinary}`);
+    console.error(`We were not able to find the binary at:\n${correctCandidates.join('\nor: ')}`);
     console.error();
     console.error(`We looked for it at:`);
-    console.error(require.resolve.paths(correctBinary).join('\n'));
+    console.error(require.resolve.paths(correctCandidates[0]).join('\n'));
   }
-  if (alternateBinary !== null) {
+  if (alternateCandidates.length > 0) {
     console.error();
     console.error('***');
     console.error();
     console.error(`Your platform (${platform}) can sometimes run x86 under emulation.`);
-    console.error(`We did not find a possibly-compatible binary at:\n${alternateBinary}`);
+    console.error(`We did not find a possibly-compatible binary at:\n${alternateCandidates.join('\nor: ')}`);
     console.error();
     console.error(`We looked for it at:`);
-    console.error(require.resolve.paths(alternateBinary).join('\n'));
+    console.error(require.resolve.paths(alternateCandidates[0]).join('\n'));
   }
 
   // Investigate other failure modes.
 
   // Has the wrong platform's binaries available.
-  const availableBinaries = availablePlatforms.map(platform => availableArchs.map(arch => `@turbo/${platform}-${arch}/bin/turbo${platform === 'windows' ? '.exe' : ''}`)).flat();
-  const definitelyWrongBinaries = availableBinaries.filter(binary => binary !== correctBinary && binary !== alternateBinary);
-  const otherInstalled = definitelyWrongBinaries.filter(binaryPath => {
+  const ownCandidates = new Set([...correctCandidates, ...alternateCandidates]);
+  const allBinaries = availablePlatforms.flatMap(p => availableArchs.flatMap(a => binaryPaths(p, a)));
+  const wrongPlatformBinaries = allBinaries.filter(b => !ownCandidates.has(b));
+  const otherInstalled = wrongPlatformBinaries.filter(binaryPath => {
     try {
       return require.resolve(binaryPath);
     } catch (e) {}
@@ -195,7 +228,6 @@ function getBinaryPath() {
 
   // Check to see if we have partially-populated dependencies in the npm lockfile.
   const MAX_LOOKUPS = 10;
-  const availablePackages = availablePlatforms.map(platform => availableArchs.map(arch => `@turbo/${platform}-${arch}`)).flat();
 
   try {
     // Attempt to find project root.
@@ -213,9 +245,13 @@ function getBinaryPath() {
 
         // If we don't show up in the lockfile it's the wrong lockfile.
         if (hasPackage(sourceObject, 'turbo')) {
-          // Check to see if all of `turbo-<PLATFORM>-<ARCH>` is included.
-          const hasAllPackages = availablePackages.every(package => hasPackage(sourceObject, package));
-          if (!hasAllPackages) {
+          // A platform is covered if either the scoped or legacy package name is in the lockfile.
+          const hasAllPlatforms = availablePlatforms.every(p =>
+            availableArchs.every(a =>
+              packageNames(p, a).some(name => hasPackage(sourceObject, name))
+            )
+          );
+          if (!hasAllPlatforms) {
             console.error();
             console.error('***');
             console.error();


### PR DESCRIPTION
## Summary

- The Node shim (`packages/turbo/bin/turbo`) only resolves `@turbo/<platform>` packages. Users upgrading across the 2.8.17 → 2.8.18 scope rename boundary can have legacy `turbo-<platform>` binaries in `node_modules` that the shim silently ignores, falling through to a slow JIT `npm install` or failing entirely.
- Add `binaryPaths`/`packageNames`/`tryResolve` helpers so every resolution step (direct, JIT install, emulated, diagnostics, lockfile check) tries the scoped name first then falls back to the legacy unscoped name.

This is the Node-side counterpart to #12386, which fixed the same gap in the Rust shim.

## How to test

```bash
mkdir /tmp/turbo-test && cd /tmp/turbo-test && npm init -y

# Install last version with unscoped names
npm install turbo@2.8.17

# Swap in the patched shim
cp <repo>/packages/turbo/bin/turbo node_modules/turbo/bin/turbo

# Should resolve the legacy binary without JIT install
npx turbo --version
```

Closes #10618