### PR TITLE
fix: Prevent `stdin` from being dropped for persistent tasks in stream mode

### DIFF
--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -1428,6 +1428,100 @@ mod test {
         assert_matches!(exit, Some(ChildExit::Finished(Some(0))));
     }
 
+    /// Regression test for #12393: proves that dropping stdin causes a
+    /// persistent-style child (one that exits on stdin EOF) to terminate.
+    ///
+    /// This documents the mechanism behind the bug: when the task executor
+    /// took stdin and passed it to `TaskOutput::set_stdin()` in stream mode,
+    /// the stdin was dropped immediately, sending EOF to the child.
+    #[test_case(false)]
+    #[test_case(TEST_PTY)]
+    #[tokio::test]
+    async fn test_dropping_stdin_terminates_persistent_child(use_pty: bool) {
+        let script = find_script_dir().join_component("persistent_server.js");
+        let mut cmd = Command::new("node");
+        cmd.args([script.as_std_path()]);
+        cmd.open_stdin();
+        let mut child =
+            Child::spawn(cmd, ShutdownStyle::Kill, use_pty.then(PtySize::default)).unwrap();
+
+        tokio::time::sleep(STARTUP_DELAY).await;
+
+        // Take stdin and immediately drop it — simulates the bug where
+        // TaskOutput::stream().set_stdin() dropped stdin in stream mode.
+        {
+            let _dropped = child.stdin();
+        }
+
+        // The child should exit because it received EOF on stdin.
+        let mut out = Vec::new();
+        let result = tokio::time::timeout(
+            Duration::from_secs(5),
+            child.wait_with_piped_outputs(&mut out),
+        )
+        .await;
+
+        let exit = result
+            .expect("child should have exited after stdin was dropped")
+            .unwrap();
+
+        let output = String::from_utf8(out).unwrap();
+        assert!(
+            output.contains("server ready"),
+            "expected 'server ready' in output, got: {output:?}"
+        );
+        assert_matches!(exit, Some(ChildExit::Finished(Some(0))));
+    }
+
+    /// Regression test for #12393: proves that holding stdin in a guard
+    /// keeps a persistent-style child alive.
+    ///
+    /// This is the correct behavior after the fix: in stream mode, stdin
+    /// is held by `_stdin_guard` instead of being passed to
+    /// `TaskOutput::set_stdin()` which would drop it.
+    ///
+    /// PTY-only: `child.stdin()` returns `None` for non-PTY children
+    /// (`ChildInput::Std` is filtered out), so the guard mechanism only
+    /// applies to PTY-spawned processes — which is the production path
+    /// for persistent tasks on Unix.
+    #[tokio::test]
+    async fn test_held_stdin_keeps_persistent_child_alive() {
+        if !TEST_PTY {
+            return;
+        }
+        let script = find_script_dir().join_component("persistent_server.js");
+        let mut cmd = Command::new("node");
+        cmd.args([script.as_std_path()]);
+        cmd.open_stdin();
+        let mut child = Child::spawn(cmd, ShutdownStyle::Kill, Some(PtySize::default())).unwrap();
+
+        tokio::time::sleep(STARTUP_DELAY).await;
+
+        // Hold stdin in a guard — simulates the correct persistent task flow.
+        let _stdin_guard = child.stdin();
+        assert!(
+            _stdin_guard.is_some(),
+            "PTY child should return Some from stdin()"
+        );
+
+        // The child should NOT exit while we hold stdin. Give it a moment
+        // and verify it's still alive by checking that wait times out.
+        let result = tokio::time::timeout(Duration::from_secs(2), child.wait()).await;
+        assert!(
+            result.is_err(),
+            "child should still be alive while stdin is held"
+        );
+
+        // Now drop the guard — child should exit.
+        drop(_stdin_guard);
+
+        let exit = tokio::time::timeout(Duration::from_secs(5), child.wait())
+            .await
+            .expect("child should exit after stdin guard is dropped");
+
+        assert_matches!(exit, Some(ChildExit::Finished(Some(0))));
+    }
+
     /// Verifies that stopping a parent process also kills its child processes.
     ///
     /// On Unix this works via process groups (setpgid + kill(-pgid)).

--- a/crates/turborepo-process/test/scripts/persistent_server.js
+++ b/crates/turborepo-process/test/scripts/persistent_server.js
@@ -1,0 +1,13 @@
+// Simulates a persistent dev server (like Vite) that:
+// 1. Prints a "ready" message to stdout
+// 2. Exits when stdin closes (receives EOF)
+//
+// This is the behavior that triggered the regression in #12393:
+// dropping stdin caused persistent tasks to terminate prematurely.
+
+process.stdout.write("server ready\n");
+
+process.stdin.resume();
+process.stdin.on("end", () => {
+  process.exit(0);
+});

--- a/crates/turborepo-task-executor/src/exec.rs
+++ b/crates/turborepo-task-executor/src/exec.rs
@@ -408,18 +408,27 @@ where
                 }
             };
 
-        if self.takes_input
-            && let Some(stdin) = process.stdin()
-        {
-            task_output.set_stdin(stdin);
-        }
-
-        // For persistent tasks not using TUI, take stdin and hold it so it
-        // stays alive until the process exits. Without this, the PTY read
-        // path in `wait_with_piped_outputs` would drop stdin immediately,
-        // sending EOF to tools like Vite that exit when stdin closes.
+        // For persistent/interactive tasks, keep stdin alive so tools like
+        // Vite that exit on EOF don't terminate prematurely.
+        //
+        // In TUI mode, forward stdin to the TaskSender for interactive display.
+        // In stream mode (no TUI sender), hold stdin in a guard that lives
+        // until the process exits — process.stdin() uses .take(), so only the
+        // first call returns Some.
         let _stdin_guard = if self.takes_input {
-            process.stdin()
+            let stdin = process.stdin();
+            if let Some(stdin) = stdin {
+                if task_output.sender().is_some() {
+                    task_output.set_stdin(stdin);
+                    // TUI sender now owns stdin, no guard needed.
+                    None
+                } else {
+                    // Stream mode: hold stdin open via the guard.
+                    Some(stdin)
+                }
+            } else {
+                None
+            }
         } else {
             None
         };

--- a/crates/turborepo-task-executor/src/output.rs
+++ b/crates/turborepo-task-executor/src/output.rs
@@ -98,3 +98,69 @@ impl std::io::Write for StdWriter {
         self.writer().flush()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+
+    use super::*;
+
+    /// A writer that tracks whether it has been dropped. Used to verify
+    /// that `set_stdin` in stream mode drops the stdin handle.
+    struct DropTracker {
+        dropped: Arc<AtomicBool>,
+    }
+
+    impl DropTracker {
+        fn new() -> (Self, Arc<AtomicBool>) {
+            let dropped = Arc::new(AtomicBool::new(false));
+            (
+                Self {
+                    dropped: dropped.clone(),
+                },
+                dropped,
+            )
+        }
+    }
+
+    impl std::io::Write for DropTracker {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl Drop for DropTracker {
+        fn drop(&mut self) {
+            self.dropped.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn stream_mode_has_no_sender() {
+        let output = TaskOutput::stream();
+        assert!(output.sender().is_none());
+    }
+
+    /// Regression test for #12393: in stream mode, `set_stdin` has no TUI
+    /// sender to forward stdin to, so the stdin handle is dropped. This is
+    /// why the task executor must NOT pass stdin through `set_stdin` in
+    /// stream mode — it must hold it in a guard instead.
+    #[test]
+    fn stream_mode_set_stdin_drops_handle() {
+        let output = TaskOutput::stream();
+        let (tracker, dropped) = DropTracker::new();
+
+        assert!(!dropped.load(Ordering::SeqCst));
+        output.set_stdin(Box::new(tracker));
+        assert!(
+            dropped.load(Ordering::SeqCst),
+            "stdin should be dropped when set_stdin is called in stream mode"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #12393 — persistent tasks (like Vite dev servers) terminate immediately in stream mode since v2.8.18.

The output pipeline refactor in #12343 simplified stdin forwarding to always pass through `TaskOutput::set_stdin()`. In stream mode (no TUI), `set_stdin` has no `TaskSender` to forward to, so the stdin handle is dropped immediately — sending EOF to tools that exit when stdin closes.

## What changed

- **`exec.rs`**: Unified stdin lifecycle into a single code path. When a TUI sender exists, forward stdin to it. Otherwise, hold stdin in a guard so it stays alive until the process exits.
- **`output.rs`**: Added unit tests proving `TaskOutput::stream().set_stdin()` drops the stdin handle (documenting why the executor must not use this path in stream mode).
- **`child.rs`** + **`persistent_server.js`**: Added process-level regression tests proving that dropping PTY stdin terminates a persistent child, and holding it in a guard keeps the child alive.

## How to test

```
# In a monorepo with a persistent task (e.g. Vite dev):
npx turbo dev          # TUI mode — should work (was already working)
npx turbo dev --ui=stream  # stream mode — was broken, now fixed
```