### PR TITLE
fix: Disable husky hooks in `update-examples` workflow

### DIFF
--- a/.github/workflows/update-examples-on-release.yml
+++ b/.github/workflows/update-examples-on-release.yml
@@ -37,6 +37,8 @@ jobs:
         run: bash scripts/update-examples-dep.sh
 
       - name: Commit and push
+        env:
+          HUSKY: "0"
         run: |
           git commit -am "release(turborepo): update examples to latest"
           git push origin ${{ steps.branch.outputs.STAGE_BRANCH }}


### PR DESCRIPTION
## Summary

- The `update-examples-on-release` workflow fails on `git push` because the husky pre-push hook tries to run `turbo`, `cargo`, etc. which aren't installed in the CI runner
- Sets `HUSKY=0` on the commit-and-push step to skip hooks, since they're meant for local development and not relevant for an automated dependency bump