### PR TITLE
docs: Add link to Docker guide in prune --docker flag section

### DIFF
--- a/apps/docs/content/docs/reference/prune.mdx
+++ b/apps/docs/content/docs/reference/prune.mdx
@@ -133,7 +133,7 @@ Run `turbo prune frontend` to generate a pruned workspace for the `frontend` app
 
 Defaults to `false`.
 
-Alter the output directory to make it easier to use with [Docker best practices and layer caching](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/). The directory will contain:
+Alter the output directory to make it easier to use with [Docker best practices and layer caching](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/). For an example Dockerfile using this flag, see the [Docker guide](/docs/guides/tools/docker). The directory will contain:
 
 - A folder named `json` with the pruned workspace's `package.json` files.
 - A folder named `full` with the pruned workspace's full source code for the internal packages needed to build the target.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

The `--docker` flag section in the [prune reference docs](/docs/reference/prune#options) describes the Docker-optimized output format but doesn't link to the Turborepo [Docker guide](/docs/guides/tools/docker), which contains an example Dockerfile demonstrating how to use it.

This adds a sentence linking to the Docker guide so users can easily find the example Dockerfile.

### Testing Instructions

Visit the prune reference page at `/docs/reference/prune` and verify the `--docker` section now includes a link to the Docker guide at `/docs/guides/tools/docker`.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://vercel.slack.com/archives/C03LMQZL205/p1773971828225739?thread_ts=1773971828.225739&cid=C03LMQZL205)

<div><a href="https://cursor.com/agents/bc-63800317-e20a-5fce-9567-3cd6e65322c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63800317-e20a-5fce-9567-3cd6e65322c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

