### PR TITLE
fix: Strip JSX components from heading anchors and TOC entries

### DIFF
--- a/apps/docs/components/geistdocs/mdx-components.tsx
+++ b/apps/docs/components/geistdocs/mdx-components.tsx
@@ -4,6 +4,7 @@ import { TypeTable } from "fumadocs-ui/components/type-table";
 import { PackageManagerTabs, PlatformTabs, Tab, Tabs } from "./tabs";
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import type { MDXComponents } from "mdx/types";
+import type { SerializedBadge } from "@/lib/rehype-strip-heading-jsx";
 import { cn } from "@/lib/utils";
 import { Accordion, Accordions } from "./accordion";
 import {
@@ -31,6 +32,44 @@ import { Step, Steps } from "./steps";
 import { ThemeAwareImage } from "./theme-aware-image";
 import { Video } from "./video";
 
+const BADGE_COMPONENTS: Record<
+  string,
+  React.ComponentType<{ children?: string }>
+> = {
+  ExperimentalBadge,
+  PrereleaseBadge
+};
+
+function HeadingWithBadges({
+  as,
+  "data-heading-badges": badgeData,
+  children,
+  ...rest
+}: React.ComponentProps<"h1"> & {
+  as: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+  "data-heading-badges"?: string;
+}) {
+  let badges: SerializedBadge[] = [];
+  if (badgeData) {
+    try {
+      badges = JSON.parse(badgeData);
+    } catch {
+      // Ignore malformed data
+    }
+  }
+
+  return (
+    <Heading as={as} {...rest}>
+      {children}
+      {badges.map((badge, i) => {
+        const Component = BADGE_COMPONENTS[badge.component];
+        if (!Component) return null;
+        return <Component key={i}>{badge.text}</Component>;
+      })}
+    </Heading>
+  );
+}
+
 interface GetMDXComponentsOptions {
   components?: MDXComponents;
   /** Use the old site's typography styling for H1 elements (centered, semibold) */
@@ -45,11 +84,26 @@ export const getMDXComponents = (
   return {
     ...defaultMdxComponents,
     ...components,
+    h2: (props: React.ComponentProps<"h2">) => (
+      <HeadingWithBadges as="h2" {...props} />
+    ),
+    h3: (props: React.ComponentProps<"h3">) => (
+      <HeadingWithBadges as="h3" {...props} />
+    ),
+    h4: (props: React.ComponentProps<"h4">) => (
+      <HeadingWithBadges as="h4" {...props} />
+    ),
+    h5: (props: React.ComponentProps<"h5">) => (
+      <HeadingWithBadges as="h5" {...props} />
+    ),
+    h6: (props: React.ComponentProps<"h6">) => (
+      <HeadingWithBadges as="h6" {...props} />
+    ),
     ...(isBlog && {
       h1: (props: React.ComponentProps<"h1">) => {
         const { className, ...rest } = props;
         return (
-          <Heading
+          <HeadingWithBadges
             className={cn(
               "font-semibold text-center text-4xl tracking-wide!",
               className

--- a/apps/docs/content/blog/turbo-1-9-0.mdx
+++ b/apps/docs/content/blog/turbo-1-9-0.mdx
@@ -34,7 +34,7 @@ Turborepo 1.9 focuses on improving observability for your task runs to better un
 
 - [**Run Summaries**](#view-and-compare-task-runs): Use the `--summarize` flag to generate a summary of your task to compare against previous runs.
 - [**Easier Starters**](#bring-your-own-starter): Use the `--example` flag with `npx create-turbo` to start from official Turborepo examples or custom repositories.
-- [**Strict Environments** <ExperimentalBadge isLink={false} />](#strict-environments-experimental): Try enabling strict mode to restrict the environment variables your tasks have access to.
+- [**Strict Environments** <ExperimentalBadge isLink={false} />](#strict-environments): Try enabling strict mode to restrict the environment variables your tasks have access to.
 
 Update today by running `npx @turbo/codemod migrate`.
 

--- a/apps/docs/content/blog/turbo-2-2-0.mdx
+++ b/apps/docs/content/blog/turbo-2-2-0.mdx
@@ -29,7 +29,7 @@ import { ExperimentalBadge } from "@/components/geistdocs/experimental-badge";
 
 Turborepo 2.2 brings a new repository query command, along with other improvements, including:
 
-- [**Repository queries** <ExperimentalBadge isLink={false} />](#query-your-repository-experimental): Explore your repository like never before with `turbo query`
+- [**Repository queries** <ExperimentalBadge isLink={false} />](#query-your-repository): Explore your repository like never before with `turbo query`
 - [**Improved cache safety**](#improved-cache-safety): Easily diagnose and fix missing environment variable dependencies, and incorrect cache configurations
 - [**Zero-configuration comparisons for affected packages**](#zero-configuration-comparisons-with---affected): Automatically target packages with changes in GitHub workflows
 

--- a/apps/docs/content/blog/turbo-2-4.mdx
+++ b/apps/docs/content/blog/turbo-2-4.mdx
@@ -24,9 +24,9 @@ import { Callout } from "@/components/geistdocs/callout";
 
 Turborepo 2.4 includes a number of improvements to enhance your repository:
 
-- [**Boundaries <ExperimentalBadge>Experimental</ExperimentalBadge>**](#boundaries-experimental): A first look at Boundaries in Turborepo
+- [**Boundaries <ExperimentalBadge>Experimental</ExperimentalBadge>**](#boundaries): A first look at Boundaries in Turborepo
 - [**Terminal UI improvements**](#terminal-ui-improvements): Persistent preferences and new features
-- [**Watch Mode caching <ExperimentalBadge>Experimental</ExperimentalBadge>**](#watch-mode-caching-experimental): Develop faster in Watch Mode
+- [**Watch Mode caching <ExperimentalBadge>Experimental</ExperimentalBadge>**](#watch-mode-caching): Develop faster in Watch Mode
 - [**Circular dependency recommendations**](#circular-dependency-recommendations): Adopt Turborepo in large repos more easily
 - [**`schema.json` in `node_modules`**](#schemajson-in-node_modules): Versioned configuration validation from within your repository
 - [**ESLint Flat Config support**](#eslint-flat-config-support): `eslint-config-turbo` and `eslint-plugin-turbo` updated for ESLint v9

--- a/apps/docs/lib/rehype-strip-heading-jsx.ts
+++ b/apps/docs/lib/rehype-strip-heading-jsx.ts
@@ -1,0 +1,137 @@
+/**
+ * Rehype plugin that strips JSX components from heading IDs and TOC entries.
+ *
+ * When MDX headings contain inline JSX (e.g., badge components), fumadocs'
+ * remarkHeading plugin includes their text content in the generated slug,
+ * and rehypeToc includes them in the table of contents.
+ *
+ * This plugin runs after remarkHeading sets IDs but before rehypeToc reads
+ * them. It:
+ *  1. Rewrites the heading ID to exclude JSX text
+ *  2. Removes JSX elements from heading children (so rehypeToc produces clean titles)
+ *  3. Serializes the removed JSX info as a data-heading-badges attribute so
+ *     the heading component can re-render them inline
+ *
+ * Example:
+ *   ## Boundaries <ExperimentalBadge>Experimental</ExperimentalBadge>
+ *   Before: id="boundaries-experimental", TOC shows badge
+ *   After:  id="boundaries", TOC is clean, badge re-injected by component
+ */
+
+export interface SerializedBadge {
+  component: string;
+  text?: string;
+}
+
+const HEADING_TAGS = new Set(["h1", "h2", "h3", "h4", "h5", "h6"]);
+
+function flattenNode(node: any): string {
+  if ("children" in node && Array.isArray(node.children)) {
+    return node.children.map((child: any) => flattenNode(child)).join("");
+  }
+  if ("value" in node && typeof node.value === "string") {
+    return node.value;
+  }
+  return "";
+}
+
+function flattenNodeExcludingJsx(node: any): string {
+  if (
+    node.type === "mdxJsxTextElement" ||
+    node.type === "mdxJsxFlowElement"
+  ) {
+    return "";
+  }
+  if ("children" in node && Array.isArray(node.children)) {
+    return node.children
+      .map((child: any) => flattenNodeExcludingJsx(child))
+      .join("");
+  }
+  if ("value" in node && typeof node.value === "string") {
+    return node.value;
+  }
+  return "";
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^\p{L}\p{M}\p{N}\p{Pc}\s-]/gu, "")
+    .replace(/ /g, "-");
+}
+
+function isJsxElement(node: any): boolean {
+  return (
+    node.type === "mdxJsxTextElement" || node.type === "mdxJsxFlowElement"
+  );
+}
+
+function hasJsxChild(node: any): boolean {
+  return (
+    Array.isArray(node.children) &&
+    node.children.some((child: any) => isJsxElement(child))
+  );
+}
+
+function visitHeadings(tree: any, fn: (node: any) => void): void {
+  if (!tree || typeof tree !== "object") return;
+  if (tree.type === "element" && HEADING_TAGS.has(tree.tagName)) {
+    fn(tree);
+    return;
+  }
+  if (Array.isArray(tree.children)) {
+    for (const child of tree.children) {
+      visitHeadings(child, fn);
+    }
+  }
+}
+
+export default function rehypeStripHeadingJsx() {
+  return (tree: any) => {
+    const occurrences: Record<string, number> = Object.create(null);
+
+    function uniqueSlug(value: string): string {
+      let result = slugify(value);
+      const original = result;
+      while (Object.prototype.hasOwnProperty.call(occurrences, result)) {
+        occurrences[original]++;
+        result = `${original}-${occurrences[original]}`;
+      }
+      occurrences[result] = 0;
+      return result;
+    }
+
+    visitHeadings(tree, (node) => {
+      if (!node.properties?.id) return;
+
+      if (!hasJsxChild(node)) {
+        occurrences[node.properties.id] = 0;
+        return;
+      }
+
+      // Serialize JSX elements so the heading component can re-render them
+      const badges: SerializedBadge[] = [];
+      for (const child of node.children) {
+        if (isJsxElement(child)) {
+          const text = flattenNode(child).trim();
+          badges.push({
+            component: child.name,
+            ...(text ? { text } : {}),
+          });
+        }
+      }
+
+      // Remove JSX elements from children so rehypeToc produces clean titles
+      node.children = node.children.filter(
+        (child: any) => !isJsxElement(child)
+      );
+
+      // Store badge data for the heading component to reconstruct
+      node.properties["data-heading-badges"] = JSON.stringify(badges);
+
+      // Rewrite the heading ID without JSX text
+      const cleanText = flattenNodeExcludingJsx(node).trim();
+      node.properties.id = uniqueSlug(cleanText);
+    });
+  };
+}

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -5,6 +5,7 @@ import {
   transformerNotationWordHighlight
 } from "@shikijs/transformers";
 import remarkMermaid from "./components/diagram/remark-mermaid";
+import rehypeStripHeadingJsx from "./lib/rehype-strip-heading-jsx";
 import {
   defineConfig,
   defineDocs,
@@ -221,6 +222,7 @@ const theme = createCssVariablesTheme({
 export default defineConfig({
   mdxOptions: {
     remarkPlugins: [remarkMermaid],
+    rehypePlugins: [rehypeStripHeadingJsx],
     rehypeCodeOptions: {
       themes: {
         light: theme,

--- a/docs/link-checker/src/markdown.ts
+++ b/docs/link-checker/src/markdown.ts
@@ -56,6 +56,15 @@ const getAllMdxFilePaths = async (): Promise<string[]> => {
   );
 };
 
+// Strips JSX components from heading text so slugs match the rendered output.
+// The link checker parses raw markdown (not MDX), so JSX tags like
+// <ExperimentalBadge>Experimental</ExperimentalBadge> appear as text.
+const stripJsxComponents = (text: string): string =>
+  text
+    .replace(/<[A-Z]\w*(?:\s[^>]*)?>[\s\S]*?<\/[A-Z]\w*>/g, "")
+    .replace(/<[A-Z]\w*(?:\s[^>]*)?\/>/g, "")
+    .trim();
+
 // Returns the slugs of all headings in a tree
 const getHeadingsFromMarkdownTree = (
   tree: ReturnType<typeof markdownProcessor.parse>
@@ -65,13 +74,12 @@ const getHeadingsFromMarkdownTree = (
 
   visit(tree, "heading", (node) => {
     let headingText = "";
-    // Account for headings with inline code blocks by concatenating the
-    // text values of all children of a heading node.
     visit(node, (innerNode: any) => {
       if (innerNode.value) {
         headingText += innerNode.value;
       }
     });
+    headingText = stripJsxComponents(headingText);
     const slugified = slugger.slug(headingText);
     headings.push(slugified);
   });
@@ -148,32 +156,8 @@ const prepareDocumentMapEntry = async (
   }
 };
 
-/** Checks if the hash exists in a document's headings, accounting for ExperimentalBadge suffixes */
-const hashExistsInHeadings = (headings: string[], hash: string): boolean => {
-  if (headings.includes(hash)) {
-    return true;
-  }
-
-  // Handle experimental badge suffix: -experimental -> -experimentalbadgeexperimentalexperimentalbadge
-  const experimentalHeading = hash.replace(
-    "-experimental",
-    "-experimentalbadgeexperimentalexperimentalbadge"
-  );
-  if (headings.includes(experimentalHeading)) {
-    return true;
-  }
-
-  // Handle pre-release badge suffix: -pre-release -> -experimentalbadgepre-releaseexperimentalbadge
-  const preReleaseHeading = hash.replace(
-    "-pre-release",
-    "-experimentalbadgepre-releaseexperimentalbadge"
-  );
-  if (headings.includes(preReleaseHeading)) {
-    return true;
-  }
-
-  return false;
-};
+const hashExistsInHeadings = (headings: string[], hash: string): boolean =>
+  headings.includes(hash);
 
 /** Checks if the links point to existing documents */
 const validateInternalLink =
@@ -223,31 +207,6 @@ const validateHashLink = (doc: Document, href: string) => {
   }
 
   if (doc.headings.includes(hashLink)) {
-    return [];
-  }
-
-  // Handles when the link has the experimental badge in it.
-  // Because we're parsing the raw document (not the rendered output), the JSX declaration is still present.
-  const experimentalHeading = hashLink.replace(
-    "-experimental",
-    "-experimentalbadgeexperimentalexperimentalbadge"
-  );
-  const preReleaseHeading =
-    hashLink + "-experimentalbadgepre-releaseexperimentalbadge";
-
-  if (doc.headings.includes(experimentalHeading)) {
-    console.warn(
-      `The hash link "${hashLink}" passed when including the <ExperimentalBadge>Experimental</ExperimentalBadge> JSX declaration.`
-    );
-    console.log();
-    return [];
-  }
-
-  if (doc.headings.includes(preReleaseHeading)) {
-    console.warn(
-      `The hash link "${hashLink}" passed when including the <ExperimentalBadge>Pre-release</ExperimentalBadge> JSX declaration.`
-    );
-    console.log();
     return [];
   }
 


### PR DESCRIPTION
## Summary

- Heading anchor IDs and TOC entries included text from inline JSX components (like `<ExperimentalBadge>`), producing anchors like `#boundaries-experimental` and cluttered TOC sidebars
- Adds a rehype plugin (`rehype-strip-heading-jsx`) that runs between `remarkHeading` and `rehypeToc` in the fumadocs pipeline to strip JSX from heading IDs and TOC titles while preserving badge rendering in the heading itself
- Removes brittle badge-specific workarounds from the link checker

## How it works

The rehype plugin intercepts heading elements after `remarkHeading` sets IDs but before `rehypeToc` reads them:

1. Rewrites the heading `id` without JSX text content
2. Removes JSX elements from heading children (so `rehypeToc` produces clean TOC titles)
3. Serializes the removed JSX as a `data-heading-badges` attribute

The `HeadingWithBadges` component reads this attribute and re-injects the badge components inline at render time. Badges appear in the heading but never reach the TOC or anchor ID.

## Testing

Visit `/docs/reference/configuration` and verify:
- Heading anchors are clean (e.g., `#affectedusingtaskinputs` not `#affectedusingtaskinputs-pre-release`)
- TOC sidebar entries don't include badge text
- Badges still render inline in the heading content
- Blog posts with anchor links to badge headings still navigate correctly (`/blog/turbo-2-4`, `/blog/turbo-2-2-0`, `/blog/turbo-1-9-0`)