### PR TITLE
feat: Add experimental structured logging with `--json` and `--log-file` flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7787,6 +7787,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/apps/docs/content/docs/reference/run.mdx
+++ b/apps/docs/content/docs/reference/run.mdx
@@ -11,6 +11,8 @@ related:
   - /docs/reference/options-overview
 ---
 
+import { ExperimentalBadge } from "@/components/geistdocs/experimental-badge";
+
 Run tasks specified in `turbo.json`.
 
 ```bash title="Terminal"
@@ -378,6 +380,49 @@ turbo run build test lint --graph=my-graph.svg
   has no impact on execution, but the graph may overstate the number of packages
   and tasks involved.
 </Callout>
+
+### `--json` <ExperimentalBadge />
+
+Output machine-readable [NDJSON](https://github.com/ndjson/ndjson-spec) to stdout instead of human-readable text. Disables the TUI and forces stream mode.
+
+```bash title="Terminal"
+turbo run build --json
+```
+
+Each line is a JSON object with the following shape:
+
+```json
+{"timestamp":1710000000000,"source":"web#build","level":"stdout","text":"Compiled successfully"}
+```
+
+| Field | Description |
+| --- | --- |
+| `timestamp` | Unix epoch milliseconds |
+| `source` | `"turbo"` for Turborepo messages, or `"<package>#<task>"` for task output |
+| `level` | `"info"`, `"warn"`, `"error"` for Turborepo messages; `"stdout"`, `"stderr"` for task output |
+| `text` | The message content, with ANSI escape sequences stripped |
+
+Can be combined with `--log-file` to write to both stdout and a file simultaneously.
+
+<Callout type="warn">
+  Structured output captures **all** task output verbatim. If your build scripts echo secrets to stdout, those values will appear in the output.
+</Callout>
+
+### `--log-file [path]` <ExperimentalBadge />
+
+Write structured JSON logs to a file. If no path is given, writes to `.turbo/logs/<timestamp>.json`.
+
+```bash title="Terminal"
+# Default location
+turbo run build --log-file
+
+# Custom path
+turbo run build --log-file=build-log.json
+```
+
+The file is a valid JSON array at all times, even if the process is interrupted. Log files are created with owner-only permissions (`0600`) on Unix, and the path is restricted to the repository root.
+
+Can also be set with the [`TURBO_LOG_FILE`](/docs/reference/system-environment-variables#turbo_log_file) environment variable. The CLI flag takes precedence.
 
 ### `--log-order <option>`
 

--- a/apps/docs/content/docs/reference/system-environment-variables.mdx
+++ b/apps/docs/content/docs/reference/system-environment-variables.mdx
@@ -128,6 +128,18 @@ System environment variables are always overridden by flag values provided direc
         executed.
       </td>
     </tr>
+    <tr id="turbo_log_file">
+      <td>
+        <code>TURBO_LOG_FILE</code>
+      </td>
+      <td>
+        Write structured JSON logs to a file. Set to <code>1</code> or{" "}
+        <code>true</code> for the default location (
+        <code>.turbo/logs/&lt;timestamp&gt;.json</code>), or provide a custom
+        file path. Equivalent to the{" "}
+        <a href="/docs/reference/run#--log-file-path">--log-file</a> flag.
+      </td>
+    </tr>
     <tr id="turbo_log_order">
       <td>
         <code>TURBO_LOG_ORDER</code>

--- a/crates/turborepo-config/src/env.rs
+++ b/crates/turborepo-config/src/env.rs
@@ -12,7 +12,7 @@ use turborepo_types::{EnvMode, LogOrder, UIMode};
 
 use crate::{
     ConfigurationOptions, Error, ExperimentalObservabilityOptions, ExperimentalOtelOptions,
-    ResolvedConfigurationOptions,
+    LogFileConfig, ResolvedConfigurationOptions,
 };
 
 const TURBO_MAPPING: &[(&str, &str)] = [
@@ -46,6 +46,7 @@ const TURBO_MAPPING: &[(&str, &str)] = [
     ("turbo_concurrency", "concurrency"),
     ("turbo_no_update_notifier", "no_update_notifier"),
     ("turbo_sso_login_callback_port", "sso_login_callback_port"),
+    ("turbo_log_file", "structured_log_file"),
     (
         "turbo_experimental_otel_enabled",
         "experimental_otel_enabled",
@@ -278,6 +279,20 @@ impl ResolvedConfigurationOptions for EnvVars {
             .map_err(Error::InvalidSsoLoginCallbackPort)?;
 
         let experimental_otel = ExperimentalOtelOptions::from_env_map(&self.output_map)?;
+
+        // TURBO_LOG_FILE: "1"/"true" → default location, path string → custom path
+        let log_file = self
+            .output_map
+            .get("structured_log_file")
+            .filter(|s| !s.is_empty())
+            .map(|s| {
+                if s == "1" || s == "true" {
+                    LogFileConfig::Enabled
+                } else {
+                    LogFileConfig::Path(s.clone())
+                }
+            });
+
         let experimental_observability =
             experimental_otel.map(|otel| ExperimentalObservabilityOptions { otel: Some(otel) });
 
@@ -318,6 +333,7 @@ impl ResolvedConfigurationOptions for EnvVars {
             // Do not allow future flags to be set by env var
             future_flags: None,
             experimental_observability,
+            log_file,
         };
 
         Ok(output)

--- a/crates/turborepo-config/src/lib.rs
+++ b/crates/turborepo-config/src/lib.rs
@@ -61,6 +61,39 @@ pub struct ExperimentalObservabilityOptions {
     pub otel: Option<ExperimentalOtelOptions>,
 }
 
+/// Configuration for structured log file output.
+///
+/// - `LogFileConfig::Enabled` — write to default location
+///   (`.turbo/logs/<epoch_millis>.json`)
+/// - `LogFileConfig::Path(p)` — write to a custom file path
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub enum LogFileConfig {
+    Enabled,
+    Path(String),
+}
+
+impl<'de> Deserialize<'de> for LogFileConfig {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let value = serde_json::Value::deserialize(d)?;
+        match value {
+            serde_json::Value::Bool(true) => Ok(LogFileConfig::Enabled),
+            serde_json::Value::Bool(false) => Err(serde::de::Error::custom(
+                "use null/absent instead of false to disable log file",
+            )),
+            serde_json::Value::String(path) => Ok(LogFileConfig::Path(path)),
+            _ => Err(serde::de::Error::custom(
+                "expected true or a file path string",
+            )),
+        }
+    }
+}
+
+impl Merge for LogFileConfig {
+    fn merge(&mut self, _other: Self) {
+        // CLI/env takes precedence, no merging needed
+    }
+}
+
 // Re-export default constants for tests and external use
 pub const DEFAULT_API_URL: &str = "https://vercel.com/api";
 pub const DEFAULT_LOGIN_URL: &str = "https://vercel.com";
@@ -276,6 +309,10 @@ pub struct ConfigurationOptions {
     pub future_flags: Option<FutureFlags>,
     #[serde(rename = "experimentalObservability")]
     pub experimental_observability: Option<ExperimentalObservabilityOptions>,
+    /// Structured log file destination, configured via `logFile` in
+    /// turbo.json or `TURBO_LOG_FILE` env var.
+    #[serde(rename = "logFile")]
+    pub log_file: Option<LogFileConfig>,
 }
 
 #[derive(Default)]
@@ -537,6 +574,10 @@ impl ConfigurationOptions {
 
     pub fn experimental_observability(&self) -> Option<&ExperimentalObservabilityOptions> {
         self.experimental_observability.as_ref()
+    }
+
+    pub fn log_file(&self) -> Option<&LogFileConfig> {
+        self.log_file.as_ref()
     }
 }
 

--- a/crates/turborepo-config/src/turbo_json.rs
+++ b/crates/turborepo-config/src/turbo_json.rs
@@ -95,16 +95,23 @@ impl<'a> TurboJsonReader<'a> {
 
         opts.future_flags = turbo_json.future_flags.map(|f| *f.as_inner());
 
-        // Only read observability config if futureFlags.experimentalObservability is
-        // enabled
-        if opts
-            .future_flags
-            .map(|f| f.experimental_observability)
-            .unwrap_or(false)
-            && let Some(raw_observability) = turbo_json.experimental_observability
-        {
-            opts.experimental_observability = Some(convert_raw_observability(raw_observability)?);
+        if let Some(raw_observability) = turbo_json.experimental_observability {
+            let otel_enabled = opts
+                .future_flags
+                .map(|f| f.experimental_observability)
+                .unwrap_or(false);
+
+            let converted = convert_raw_observability(raw_observability)?;
+
+            let effective = ExperimentalObservabilityOptions {
+                otel: if otel_enabled { converted.otel } else { None },
+            };
+
+            if effective.otel.is_some() {
+                opts.experimental_observability = Some(effective);
+            }
         }
+
         Ok(opts)
     }
 }

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -997,6 +997,14 @@ pub struct ExecutionArgs {
     /// turbo decide based on its own heuristics. (default auto)
     #[clap(long, value_enum)]
     pub log_order: Option<LogOrder>,
+    /// Output machine-readable NDJSON to stdout instead of human-readable
+    /// text. Disables the TUI and forces stream mode.
+    #[clap(long)]
+    pub json: bool,
+    /// Write structured JSON logs to a file. If no path is given, writes to
+    /// `.turbo/logs/<epoch_millis>.json`.
+    #[clap(long)]
+    pub log_file: Option<Option<String>>,
     /// Only executes the tasks specified, does not execute parent tasks.
     #[clap(long)]
     pub only: bool,
@@ -1452,7 +1460,14 @@ async fn run_main(
 
     let mut command = get_command(&mut cli_args)?;
 
-    if should_print_version() {
+    // Suppress the version banner in --json mode — all output on stdout
+    // must be machine-readable NDJSON.
+    let is_json_mode = matches!(
+        &command,
+        Command::Run { execution_args, .. } | Command::Watch { execution_args, .. }
+            if execution_args.json
+    );
+    if should_print_version() && !is_json_mode {
         eprintln!("{}", GREY.apply_to(format!("• turbo {}", get_version())));
     }
 

--- a/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__turbo-watch-build---no-daemon.snap
+++ b/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__turbo-watch-build---no-daemon.snap
@@ -7,6 +7,6 @@ error: unexpected argument '--no-daemon' found
   tip: a similar argument exists: '--no-update-notifier'
   tip: to pass '--no-daemon' as a value, use '-- --no-daemon'
 
-Usage: turbo watch --no-update-notifier <--cache-dir <CACHE_DIR>|--concurrency <CONCURRENCY>|--continue[=<CONTINUE>]|--single-package|--framework-inference [<BOOL>]|--global-deps <GLOBAL_DEPS>|--env-mode [<ENV_MODE>]|--filter <FILTER>|--affected|--output-logs <OUTPUT_LOGS>|--log-order <LOG_ORDER>|--only|--pkg-inference-root <PKG_INFERENCE_ROOT>|--log-prefix <LOG_PREFIX>|TASKS|PASS_THROUGH_ARGS>
+Usage: turbo watch --no-update-notifier <--cache-dir <CACHE_DIR>|--concurrency <CONCURRENCY>|--continue[=<CONTINUE>]|--single-package|--framework-inference [<BOOL>]|--global-deps <GLOBAL_DEPS>|--env-mode [<ENV_MODE>]|--filter <FILTER>|--affected|--output-logs <OUTPUT_LOGS>|--log-order <LOG_ORDER>|--json|--log-file [<LOG_FILE>]|--only|--pkg-inference-root <PKG_INFERENCE_ROOT>|--log-prefix <LOG_PREFIX>|TASKS|PASS_THROUGH_ARGS>
 
 For more information, try '--help'.

--- a/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__turbo_long_help.snap
+++ b/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__turbo_long_help.snap
@@ -236,6 +236,12 @@ Run Arguments:
           
           [possible values: auto, stream, grouped]
 
+      --json
+          Output machine-readable NDJSON to stdout instead of human-readable text. Disables the TUI and forces stream mode
+
+      --log-file [<LOG_FILE>]
+          Write structured JSON logs to a file. If no path is given, writes to `.turbo/logs/<epoch_millis>.json`
+
       --only
           Only executes the tasks specified, does not execute parent tasks
 

--- a/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__turbo_short_help.snap
+++ b/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__turbo_short_help.snap
@@ -138,6 +138,10 @@ Run Arguments:
           Set type of process output logging. Use "full" to show all output. Use "hash-only" to show only turbo-computed task hashes. Use "new-only" to show only new output with only hashes for cached tasks. Use "none" to hide process output. (default full) [possible values: full, none, hash-only, new-only, errors-only]
       --log-order <LOG_ORDER>
           Set type of task output order. Use "stream" to show output as soon as it is available. Use "grouped" to show output when a command has finished execution. Use "auto" to let turbo decide based on its own heuristics. (default auto) [possible values: auto, stream, grouped]
+      --json
+          Output machine-readable NDJSON to stdout instead of human-readable text. Disables the TUI and forces stream mode
+      --log-file [<LOG_FILE>]
+          Write structured JSON logs to a file. If no path is given, writes to `.turbo/logs/<epoch_millis>.json`
       --only
           Only executes the tasks specified, does not execute parent tasks
       --log-prefix <LOG_PREFIX>

--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -2,6 +2,7 @@ use std::{env, sync::Arc};
 
 use tracing::error;
 use turborepo_api_client::SharedHttpClient;
+use turborepo_log::StructuredLogSink;
 use turborepo_query_api::QueryServer;
 use turborepo_signals::{listeners::get_signal, SignalHandler};
 use turborepo_telemetry::events::command::CommandEventBuilder;
@@ -22,7 +23,22 @@ pub async fn run(
     let signal = get_signal()?;
     let handler = SignalHandler::new(signal);
 
-    let sinks = LogSinks::new(base.color_config);
+    let mut sinks = LogSinks::new(base.color_config);
+
+    // Set up structured logging before initializing the global logger so
+    // turbo messages during build() are also captured.
+    let structured_sink = create_structured_sink(base.opts.log_file_path.as_ref(), base.opts.json);
+    if let Some(ref sink) = structured_sink {
+        sinks.with_structured_sink(sink.clone());
+    }
+
+    // In --json mode, disable the TerminalSink before init_logger so ALL
+    // messages (including the shim warning below) go exclusively through
+    // the StructuredLogSink.
+    if base.opts.json {
+        sinks.terminal.disable();
+    }
+
     sinks.init_logger();
 
     if let Ok(message) = env::var(turborepo_shim::GLOBAL_WARNING_ENV_VAR) {
@@ -61,11 +77,21 @@ pub async fn run(
             (Arc::new(run), analytics_handle)
         };
 
-        // Structured output modes own stdout for machine-readable data.
+        let json_mode = run.opts().json;
+
+        // JSON and other machine-readable modes own stdout.
         if run.opts().run_opts.graph.is_some()
             || matches!(run.opts().run_opts.dry_run, Some(DryRunMode::Json))
+            || json_mode
         {
             sinks.suppress_stdout();
+        }
+
+        // In --json mode, disable the TerminalSink entirely before the
+        // prelude so nothing leaks to the terminal. The StructuredLogSink
+        // captures everything via the Logger.
+        if json_mode {
+            sinks.terminal.disable();
         }
 
         // Emit the prelude while TerminalSink is still active so it
@@ -73,7 +99,9 @@ pub async fn run(
         // screen). TuiSink buffers these events and flushes on connect().
         run.emit_run_prelude_logs();
 
-        sinks.disable_for_tui();
+        if !json_mode {
+            sinks.disable_for_tui();
+        }
 
         let (sender, handle) = {
             let _span = tracing::info_span!("start_ui").entered();
@@ -91,7 +119,10 @@ pub async fn run(
             } else {
                 subscriber.suppress_stderr();
             }
-        } else {
+        } else if !json_mode {
+            // Only re-enable the TerminalSink when NOT in --json mode.
+            // In --json mode it stays disabled — all output goes through
+            // the StructuredLogSink.
             sinks.enable_for_stream();
             if subscriber.stderr_redirect_path().is_some() {
                 subscriber.restore_stderr();
@@ -140,4 +171,39 @@ pub async fn run(
 
     turborepo_log::flush();
     result
+}
+
+fn create_structured_sink(
+    file_path: Option<&turbopath::AbsoluteSystemPathBuf>,
+    terminal: bool,
+) -> Option<Arc<StructuredLogSink>> {
+    if file_path.is_none() && !terminal {
+        return None;
+    }
+
+    let mut builder = StructuredLogSink::builder();
+
+    if let Some(path) = file_path {
+        builder = builder.file_path(path.as_std_path());
+        // Warn that structured logs capture ALL output including potential secrets.
+        // This fires before the logger is initialized so we use eprintln.
+        eprintln!(
+            "turbo: structured logs will capture all output (including potential secrets) to {}",
+            path
+        );
+    }
+
+    if terminal {
+        builder = builder.terminal(true);
+    }
+
+    match builder.build() {
+        Ok(sink) => Some(Arc::new(sink)),
+        Err(e) => {
+            // Structured logging is best-effort. This fires before the
+            // global logger is initialized, so use eprintln directly.
+            eprintln!("turbo: failed to set up structured logging: {e}");
+            None
+        }
+    }
 }

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -89,6 +89,12 @@ pub struct Opts {
     /// If remote caching is disabled, this captures the reason.
     /// `None` means remote caching is enabled (by local config).
     pub remote_cache_disabled_reason: Option<RemoteCacheDisabledReason>,
+    /// Resolved log file path, if enabled via `--log-file`, `logFile` in
+    /// turbo.json, or `TURBO_LOG_FILE` env var.
+    #[serde(skip)]
+    pub log_file_path: Option<AbsoluteSystemPathBuf>,
+    /// Whether JSON output mode is enabled (`--json`).
+    pub json: bool,
 }
 
 impl Opts {
@@ -236,6 +242,14 @@ impl Opts {
             None
         };
 
+        let json = execution_args.json;
+
+        let log_file_path = resolve_log_file_path(
+            repo_root,
+            execution_args.log_file.as_ref(),
+            inputs.config.log_file(),
+        );
+
         Ok(Self {
             repo_opts,
             run_opts,
@@ -248,8 +262,94 @@ impl Opts {
             git_root: cache_dir_result.git_root,
             experimental_observability,
             remote_cache_disabled_reason,
+            log_file_path,
+            json,
         })
     }
+}
+
+/// Resolve the log file path from the config layers.
+///
+/// Priority: CLI flag (`--log-file`) > turbo.json/env (`logFile` /
+/// `TURBO_LOG_FILE`).
+fn resolve_log_file_path(
+    repo_root: &AbsoluteSystemPath,
+    cli_flag: Option<&Option<String>>,
+    config_value: Option<&crate::config::LogFileConfig>,
+) -> Option<AbsoluteSystemPathBuf> {
+    // CLI: --log-file (present with no value → default, with value → custom)
+    if let Some(maybe_path) = cli_flag {
+        return Some(match maybe_path {
+            Some(path) => resolve_path_relative_to_root(repo_root, path),
+            None => default_log_file_path(repo_root),
+        });
+    }
+
+    // turbo.json / env var (merged by the config layer)
+    match config_value {
+        Some(crate::config::LogFileConfig::Enabled) => Some(default_log_file_path(repo_root)),
+        Some(crate::config::LogFileConfig::Path(path)) => {
+            Some(resolve_path_relative_to_root(repo_root, path))
+        }
+        None => None,
+    }
+}
+
+fn resolve_path_relative_to_root(
+    repo_root: &AbsoluteSystemPath,
+    path: &str,
+) -> AbsoluteSystemPathBuf {
+    let joined = repo_root.as_std_path().join(path);
+
+    let resolved = match AbsoluteSystemPathBuf::new(joined.to_string_lossy().to_string()) {
+        Ok(p) => p,
+        Err(_) => {
+            tracing::warn!(
+                "Invalid structured log path '{}', using default location",
+                path
+            );
+            return default_log_file_path(repo_root);
+        }
+    };
+
+    // Prevent path traversal outside the repo root. Canonicalization
+    // resolves `..` segments so we can compare prefixes reliably.
+    let repo_canonical = repo_root
+        .as_std_path()
+        .canonicalize()
+        .unwrap_or_else(|_| repo_root.as_std_path().to_path_buf());
+    let resolved_canonical = resolved
+        .as_std_path()
+        .canonicalize()
+        // If the file doesn't exist yet, canonicalize the parent.
+        .or_else(|_| {
+            resolved
+                .as_std_path()
+                .parent()
+                .and_then(|p| p.canonicalize().ok())
+                .ok_or(std::io::ErrorKind::NotFound)
+                .map(|parent| parent.join(resolved.as_std_path().file_name().unwrap_or_default()))
+        })
+        // Last resort: use the raw joined path for the prefix check.
+        .unwrap_or_else(|_| resolved.as_std_path().to_path_buf());
+
+    if !resolved_canonical.starts_with(&repo_canonical) {
+        tracing::warn!(
+            "Structured log path '{}' escapes the repository root, using default location",
+            path
+        );
+        return default_log_file_path(repo_root);
+    }
+
+    resolved
+}
+
+fn default_log_file_path(repo_root: &AbsoluteSystemPath) -> AbsoluteSystemPathBuf {
+    let millis = std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    repo_root.join_components(&[".turbo", "logs", &format!("{millis}.json")])
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -365,6 +465,13 @@ impl<'a> TryFrom<OptsInputs<'a>> for RunOpts {
             ),
         };
 
+        // --json forces stream order — no grouping.
+        let log_order = if inputs.execution_args.json {
+            ResolvedLogOrder::Stream
+        } else {
+            log_order
+        };
+
         Ok(Self {
             tasks: inputs.execution_args.tasks.clone(),
             log_prefix,
@@ -386,7 +493,12 @@ impl<'a> TryFrom<OptsInputs<'a>> for RunOpts {
             cache_dir: inputs.cache_dir_result.path.clone(),
             is_shared_worktree_cache: inputs.cache_dir_result.is_shared_worktree,
             is_github_actions,
-            ui_mode: inputs.config.ui(),
+            // --json disables the TUI and forces stream mode.
+            ui_mode: if inputs.execution_args.json {
+                UIMode::Stream
+            } else {
+                inputs.config.ui()
+            },
         })
     }
 }
@@ -791,6 +903,8 @@ mod test {
             experimental_observability: None,
             git_root: None,
             remote_cache_disabled_reason: None,
+            log_file_path: None,
+            json: false,
         };
         let synthesized = opts.synthesize_command();
         assert_eq!(synthesized, expected);

--- a/crates/turborepo-log/Cargo.toml
+++ b/crates/turborepo-log/Cargo.toml
@@ -11,3 +11,6 @@ workspace = true
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/turborepo-log/src/event.rs
+++ b/crates/turborepo-log/src/event.rs
@@ -15,7 +15,7 @@ use serde::{Serialize, Serializer, ser::SerializeMap};
 /// control characters (ASCII C0, DEL, and Unicode C1) are removed.
 ///
 /// Returns `Cow::Borrowed` when no changes are needed.
-fn strip_control_chars(input: &str, preserve_newlines: bool) -> Cow<'_, str> {
+pub(crate) fn strip_control_chars(input: &str, preserve_newlines: bool) -> Cow<'_, str> {
     let needs_work = input
         .chars()
         .any(|c| c.is_control() && (!preserve_newlines || c != '\n'));
@@ -94,11 +94,29 @@ fn strip_control_chars(input: &str, preserve_newlines: bool) -> Cow<'_, str> {
 ///
 /// Strips control characters and ANSI escape sequences while
 /// preserving newlines (multi-line messages are common).
+/// Strip control characters but preserve ANSI escape sequences.
+///
+/// ANSI codes are kept so that the TerminalSink can render colors.
+/// Sinks that produce machine-readable output (StructuredLogSink,
+/// FileSink) strip ANSI at write time.
 fn sanitize_message(input: String) -> String {
-    match strip_control_chars(&input, true) {
-        Cow::Borrowed(_) => input,
-        Cow::Owned(sanitized) => sanitized,
+    // Only strip non-ANSI control characters (NUL, BEL, etc.)
+    // while preserving ANSI escape sequences and newlines.
+    let needs_strip = input.bytes().any(|b| {
+        // Control chars excluding \n (0x0A) and ESC (0x1B)
+        b < 0x20 && b != b'\n' && b != 0x1B
+    });
+    if !needs_strip {
+        return input;
     }
+    input
+        .chars()
+        .filter(|&c| {
+            let b = c as u32;
+            // Keep printable, newline, ESC, and everything >= 0x20
+            b >= 0x20 || c == '\n' || c == '\x1B'
+        })
+        .collect()
 }
 
 /// Severity level for user-facing log events.
@@ -886,23 +904,25 @@ mod tests {
     }
 
     #[test]
-    fn message_strips_full_ansi_sequences() {
+    fn message_preserves_ansi_strips_nul() {
         let event = LogEvent::new(
             Level::Warn,
             Source::turbo(Subsystem::Cache),
             "hello\x1b[31mworld\x00".to_string(),
         );
-        assert_eq!(event.message, "helloworld");
+        // ANSI preserved for terminal rendering, NUL stripped
+        assert_eq!(event.message, "hello\x1b[31mworld");
     }
 
     #[test]
-    fn message_strips_clear_screen_sequence() {
+    fn message_preserves_ansi_clear_screen() {
         let event = LogEvent::new(
             Level::Warn,
             Source::turbo(Subsystem::Cache),
             "before\x1b[2Jafter".to_string(),
         );
-        assert_eq!(event.message, "beforeafter");
+        // ANSI escape sequences preserved
+        assert_eq!(event.message, "before\x1b[2Jafter");
     }
 
     #[test]
@@ -1008,13 +1028,15 @@ mod tests {
     }
 
     #[test]
-    fn message_strips_c1_csi() {
+    fn message_preserves_c1_csi() {
+        // C1 CSI (0x9B) is a control character but part of ANSI escape
+        // sequences. The message preserves it for terminal rendering.
         let event = LogEvent::new(
             Level::Warn,
             Source::turbo(Subsystem::Cache),
             "\u{9b}31mred\u{9b}0m text",
         );
-        assert_eq!(event.message, "red text");
+        assert_eq!(event.message, "\u{9b}31mred\u{9b}0m text");
     }
 
     #[test]

--- a/crates/turborepo-log/src/lib.rs
+++ b/crates/turborepo-log/src/lib.rs
@@ -111,3 +111,4 @@ pub use logger::{
     warn,
 };
 pub use sink::LogSink;
+pub use sinks::structured::{StructuredLogSink, StructuredTaskWriter, TeeWriter};

--- a/crates/turborepo-log/src/sinks/file.rs
+++ b/crates/turborepo-log/src/sinks/file.rs
@@ -6,7 +6,10 @@ use std::{
     },
 };
 
-use crate::{event::LogEvent, sink::LogSink};
+use crate::{
+    event::{LogEvent, strip_control_chars},
+    sink::LogSink,
+};
 
 /// Writes log events as newline-delimited JSON to a writer.
 ///
@@ -80,6 +83,18 @@ impl<W: Write + Send + 'static> FileSink<W> {
 
 impl<W: Write + Send + 'static> LogSink for FileSink<W> {
     fn emit(&self, event: &LogEvent) {
+        // Strip ANSI from the message for machine-readable output.
+        let clean_event;
+        let event = if event.message().bytes().any(|b| b == 0x1B) {
+            let mut cloned = event.clone();
+            let stripped = strip_control_chars(&cloned.message, true);
+            cloned.message = stripped.into_owned();
+            clean_event = cloned;
+            &clean_event
+        } else {
+            event
+        };
+
         // Serialize outside the lock to reduce contention when many tasks
         // emit concurrently. The tradeoff is one extra String allocation
         // per event, but lock hold time drops to just the write + size check.

--- a/crates/turborepo-log/src/sinks/mod.rs
+++ b/crates/turborepo-log/src/sinks/mod.rs
@@ -4,6 +4,8 @@
 //!   summaries and testing
 //! - [`file::FileSink`] — Newline-delimited JSON file output with optional size
 //!   limiting
+//! - [`structured::StructuredLogSink`] — Machine-readable structured log output
+//!   (JSON array file and/or NDJSON terminal)
 //!
 //! To implement a custom sink, see the [`LogSink`](crate::LogSink) trait.
 
@@ -11,3 +13,5 @@
 pub mod collector;
 /// Newline-delimited JSON file output with optional size limiting.
 pub mod file;
+/// Machine-readable structured log output for observability.
+pub mod structured;

--- a/crates/turborepo-log/src/sinks/structured.rs
+++ b/crates/turborepo-log/src/sinks/structured.rs
@@ -1,0 +1,756 @@
+use std::{
+    borrow::Cow,
+    fs::{File, OpenOptions},
+    io::{Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
+    sync::{
+        Mutex,
+        mpsc::{self, Receiver, SyncSender},
+    },
+    thread::JoinHandle,
+    time::SystemTime,
+};
+
+use serde::Serialize;
+
+use crate::{
+    LogEvent,
+    event::{Level, OutputChannel, strip_control_chars},
+    sink::LogSink,
+};
+
+/// A structured log entry matching the spec's JSON schema.
+///
+/// Every entry has the same shape regardless of whether it originated
+/// from turbo itself or a child process.
+#[derive(Debug, Clone, Serialize)]
+pub struct StructuredLogEntry {
+    source: String,
+    level: String,
+    timestamp: u64,
+    text: String,
+}
+
+fn epoch_millis_now() -> u64 {
+    let millis = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    u64::try_from(millis).unwrap_or(u64::MAX)
+}
+
+impl StructuredLogEntry {
+    fn from_log_event(event: &LogEvent) -> Self {
+        let source = "turbo".to_owned();
+        let level = match event.level() {
+            Level::Info => "info",
+            Level::Warn => "warn",
+            Level::Error => "error",
+        }
+        .to_owned();
+        let millis = event
+            .timestamp()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis();
+        let timestamp = u64::try_from(millis).unwrap_or(u64::MAX);
+        // Strip ANSI escape sequences — structured output must be plain text.
+        let raw = event.message();
+        let text = match strip_control_chars(raw, true) {
+            Cow::Borrowed(s) => s.to_owned(),
+            Cow::Owned(s) => s,
+        };
+
+        Self {
+            source,
+            level,
+            timestamp,
+            text,
+        }
+    }
+
+    fn from_task_output(task: &str, channel: OutputChannel, text: String) -> Self {
+        let level = match channel {
+            OutputChannel::Stdout => "stdout",
+            OutputChannel::Stderr => "stderr",
+        }
+        .to_owned();
+
+        Self {
+            source: task.to_owned(),
+            level,
+            timestamp: epoch_millis_now(),
+            text,
+        }
+    }
+}
+
+/// Writes a valid JSON array to a file, kept valid at all times.
+///
+/// Uses a raw `File` (no BufWriter) because we batch writes in memory
+/// before issuing a single `write_all` per batch. The file always ends
+/// with `\n]\n` so it is parseable JSON even if the process is killed.
+#[derive(Debug)]
+struct JsonArrayFile {
+    file: File,
+    has_entries: bool,
+}
+
+impl JsonArrayFile {
+    fn create(path: &Path) -> std::io::Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        // Reject symlinks to prevent symlink-following attacks.
+        if path.exists() {
+            let meta = path.symlink_metadata()?;
+            if meta.file_type().is_symlink() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::AlreadyExists,
+                    format!(
+                        "refusing to write structured log to symlink: {}",
+                        path.display()
+                    ),
+                ));
+            }
+        }
+
+        let mut opts = OpenOptions::new();
+        opts.write(true).create(true).truncate(true);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.mode(0o600);
+        }
+
+        let mut file = opts.open(path)?;
+        file.write_all(b"[\n]\n")?;
+
+        Ok(Self {
+            file,
+            has_entries: false,
+        })
+    }
+
+    /// Write a batch of pre-serialized JSON strings to the file.
+    ///
+    /// Performs one seek and one `write_all` per batch instead of
+    /// per-entry, reducing syscalls under high concurrency.
+    fn write_batch(&mut self, entries: &[String]) -> std::io::Result<()> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+
+        // Build the entire batch payload in memory.
+        let mut buf = Vec::with_capacity(entries.iter().map(|e| e.len() + 2).sum());
+        for json in entries {
+            if self.has_entries {
+                buf.extend_from_slice(b",\n");
+            }
+            buf.extend_from_slice(json.as_bytes());
+            self.has_entries = true;
+        }
+        buf.extend_from_slice(b"\n]\n");
+
+        // The file always ends with `]\n` (2 bytes). Seek there and
+        // overwrite with the new entries + fresh closing bracket.
+        self.file.seek(SeekFrom::End(-2))?;
+        self.file.write_all(&buf)?;
+
+        Ok(())
+    }
+}
+
+// Messages sent from emit/task_output threads to the writer thread.
+enum WriterMsg {
+    Entry(String),
+    Flush(SyncSender<()>),
+    Shutdown,
+}
+
+/// Background thread that owns all I/O resources and processes
+/// entries in batches.
+struct WriterThread {
+    file: Option<JsonArrayFile>,
+    terminal_writer: Option<Box<dyn Write + Send>>,
+    receiver: Receiver<WriterMsg>,
+    first_file_error_logged: bool,
+}
+
+impl WriterThread {
+    fn run(mut self) {
+        loop {
+            match self.receiver.recv() {
+                Ok(WriterMsg::Entry(json)) => {
+                    let mut batch = vec![json];
+                    // Drain queued entries without blocking to form a batch.
+                    loop {
+                        match self.receiver.try_recv() {
+                            Ok(WriterMsg::Entry(j)) => batch.push(j),
+                            Ok(WriterMsg::Flush(resp)) => {
+                                self.write_batch(&batch);
+                                batch.clear();
+                                let _ = resp.send(());
+                            }
+                            Ok(WriterMsg::Shutdown) => {
+                                self.write_batch(&batch);
+                                return;
+                            }
+                            Err(mpsc::TryRecvError::Empty) => break,
+                            Err(mpsc::TryRecvError::Disconnected) => {
+                                self.write_batch(&batch);
+                                return;
+                            }
+                        }
+                    }
+                    self.write_batch(&batch);
+                }
+                Ok(WriterMsg::Flush(resp)) => {
+                    let _ = resp.send(());
+                }
+                Ok(WriterMsg::Shutdown) | Err(_) => return,
+            }
+        }
+    }
+
+    fn write_batch(&mut self, batch: &[String]) {
+        if batch.is_empty() {
+            return;
+        }
+
+        if let Some(ref mut file) = self.file
+            && let Err(e) = file.write_batch(batch)
+            && !self.first_file_error_logged
+        {
+            eprintln!(
+                "turbo: structured log file write failed ({} entries dropped): {e}",
+                batch.len()
+            );
+            self.first_file_error_logged = true;
+        }
+
+        if let Some(ref mut writer) = self.terminal_writer {
+            for json in batch {
+                if writeln!(writer, "{json}").is_err() {
+                    break;
+                }
+            }
+            let _ = writer.flush();
+        }
+    }
+}
+
+/// Strips ANSI codes from task output bytes and returns clean text.
+///
+/// Handles non-UTF-8 gracefully via lossy conversion.
+fn clean_task_text(bytes: &[u8]) -> String {
+    let lossy = String::from_utf8_lossy(bytes);
+    match strip_control_chars(&lossy, true) {
+        Cow::Borrowed(s) => s.to_owned(),
+        Cow::Owned(s) => s,
+    }
+}
+
+/// Converts raw task output bytes into pre-serialized JSON strings,
+/// one per non-empty line.
+fn serialize_task_lines(task: &str, channel: OutputChannel, bytes: &[u8]) -> Vec<String> {
+    let text = clean_task_text(bytes);
+    if text.is_empty() {
+        return Vec::new();
+    }
+    text.split('\n')
+        .filter(|line| !line.is_empty())
+        .filter_map(|line| {
+            let entry = StructuredLogEntry::from_task_output(task, channel, line.to_owned());
+            serde_json::to_string(&entry).ok()
+        })
+        .collect()
+}
+
+/// `LogSink` implementation for structured logging.
+///
+/// Serializes entries on the calling thread and sends the pre-serialized
+/// JSON through a bounded channel to a dedicated writer thread. This
+/// decouples task execution latency from file/terminal I/O latency.
+pub struct StructuredLogSink {
+    sender: SyncSender<WriterMsg>,
+    writer_handle: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl StructuredLogSink {
+    /// Create a builder to configure the sink.
+    pub fn builder() -> StructuredLogSinkBuilder {
+        StructuredLogSinkBuilder {
+            file_path: None,
+            terminal: false,
+        }
+    }
+
+    /// Create a [`StructuredTaskWriter`] for piping raw task output
+    /// into the structured log.
+    pub fn task_writer(
+        &self,
+        task_name: impl Into<String>,
+        channel: OutputChannel,
+    ) -> StructuredTaskWriter {
+        StructuredTaskWriter {
+            sender: self.sender.clone(),
+            task_name: task_name.into(),
+            channel,
+        }
+    }
+}
+
+impl LogSink for StructuredLogSink {
+    fn emit(&self, event: &LogEvent) {
+        let entry = StructuredLogEntry::from_log_event(event);
+        if let Ok(json) = serde_json::to_string(&entry) {
+            let _ = self.sender.send(WriterMsg::Entry(json));
+        }
+    }
+
+    fn task_output(&self, task: &str, channel: OutputChannel, bytes: &[u8]) {
+        for json in serialize_task_lines(task, channel, bytes) {
+            let _ = self.sender.send(WriterMsg::Entry(json));
+        }
+    }
+
+    fn flush(&self) {
+        let (tx, rx) = mpsc::sync_channel(1);
+        if self.sender.send(WriterMsg::Flush(tx)).is_ok() {
+            // Wait up to 5 seconds for the writer to drain.
+            let _ = rx.recv_timeout(std::time::Duration::from_secs(5));
+        }
+    }
+}
+
+impl Drop for StructuredLogSink {
+    fn drop(&mut self) {
+        let _ = self.sender.send(WriterMsg::Shutdown);
+        if let Ok(mut guard) = self.writer_handle.lock()
+            && let Some(handle) = guard.take()
+        {
+            let _ = handle.join();
+        }
+    }
+}
+
+/// Builder for [`StructuredLogSink`].
+pub struct StructuredLogSinkBuilder {
+    file_path: Option<PathBuf>,
+    terminal: bool,
+}
+
+impl StructuredLogSinkBuilder {
+    /// Enable JSON array file output at the given path.
+    pub fn file_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.file_path = Some(path.into());
+        self
+    }
+
+    /// Enable NDJSON output on stdout.
+    pub fn terminal(mut self, enabled: bool) -> Self {
+        self.terminal = enabled;
+        self
+    }
+
+    /// Build the sink. Returns `Err` if the file path is set but
+    /// cannot be created.
+    pub fn build(self) -> std::io::Result<StructuredLogSink> {
+        self.build_internal(Box::new(std::io::stdout()))
+    }
+
+    /// Build the sink using a custom writer for terminal output
+    /// (useful for testing).
+    pub fn build_with_writer<W: Write + Send + 'static>(
+        self,
+        writer: W,
+    ) -> std::io::Result<StructuredLogSink> {
+        self.build_internal(Box::new(writer))
+    }
+
+    fn build_internal(self, stdout: Box<dyn Write + Send>) -> std::io::Result<StructuredLogSink> {
+        let file = match self.file_path {
+            Some(path) => Some(JsonArrayFile::create(&path)?),
+            None => None,
+        };
+
+        let terminal_writer = if self.terminal { Some(stdout) } else { None };
+
+        // Bounded channel provides natural backpressure: if the writer
+        // thread falls behind by this many entries, senders block.
+        let (sender, receiver) = mpsc::sync_channel(4096);
+
+        let writer = WriterThread {
+            file,
+            terminal_writer,
+            receiver,
+            first_file_error_logged: false,
+        };
+
+        let handle = std::thread::Builder::new()
+            .name("structured-log-writer".into())
+            .spawn(move || writer.run())
+            .map_err(std::io::Error::other)?;
+
+        Ok(StructuredLogSink {
+            sender,
+            writer_handle: Mutex::new(Some(handle)),
+        })
+    }
+}
+
+/// A `Write` adapter that converts raw task output bytes into structured
+/// log entries and sends them through the channel.
+///
+/// Used as a tee alongside the normal output pipeline so the structured
+/// log receives all task output regardless of per-task `outputLogs`.
+pub struct StructuredTaskWriter {
+    sender: SyncSender<WriterMsg>,
+    task_name: String,
+    channel: OutputChannel,
+}
+
+impl Write for StructuredTaskWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        for json in serialize_task_lines(&self.task_name, self.channel, buf) {
+            let _ = self.sender.send(WriterMsg::Entry(json));
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// A writer that duplicates all writes to two underlying writers.
+pub struct TeeWriter<A, B> {
+    primary: A,
+    secondary: B,
+}
+
+impl<A, B> TeeWriter<A, B> {
+    /// Create a tee that writes to both `primary` and `secondary`.
+    pub fn new(primary: A, secondary: B) -> Self {
+        Self { primary, secondary }
+    }
+}
+
+impl<A: Write, B: Write> Write for TeeWriter<A, B> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let n = self.primary.write(buf)?;
+        // Write all bytes that the primary accepted to the secondary.
+        // Errors on the secondary are ignored — structured logging is
+        // best-effort and must not kill the run.
+        let _ = self.secondary.write_all(&buf[..n]);
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.primary.flush()?;
+        let _ = self.secondary.flush();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::{Source, Subsystem};
+
+    #[test]
+    fn entry_from_log_event() {
+        let event = LogEvent::new(Level::Warn, Source::turbo(Subsystem::Cache), "cache miss");
+        let entry = StructuredLogEntry::from_log_event(&event);
+        assert_eq!(entry.source, "turbo");
+        assert_eq!(entry.level, "warn");
+        assert_eq!(entry.text, "cache miss");
+        assert!(entry.timestamp > 0);
+    }
+
+    #[test]
+    fn entry_from_task_output_stdout() {
+        let entry = StructuredLogEntry::from_task_output(
+            "web#build",
+            OutputChannel::Stdout,
+            "built".into(),
+        );
+        assert_eq!(entry.source, "web#build");
+        assert_eq!(entry.level, "stdout");
+        assert_eq!(entry.text, "built");
+    }
+
+    #[test]
+    fn entry_from_task_output_stderr() {
+        let entry = StructuredLogEntry::from_task_output(
+            "api#lint",
+            OutputChannel::Stderr,
+            "warning".into(),
+        );
+        assert_eq!(entry.source, "api#lint");
+        assert_eq!(entry.level, "stderr");
+    }
+
+    #[test]
+    fn entry_serializes_to_spec_shape() {
+        let entry = StructuredLogEntry {
+            source: "turbo".into(),
+            level: "info".into(),
+            timestamp: 1710345600000,
+            text: "hello".into(),
+        };
+        let json = serde_json::to_value(&entry).unwrap();
+        assert_eq!(json["source"], "turbo");
+        assert_eq!(json["level"], "info");
+        assert_eq!(json["timestamp"], 1710345600000u64);
+        assert_eq!(json["text"], "hello");
+        // Exactly four fields, no extras
+        assert_eq!(json.as_object().unwrap().len(), 4);
+    }
+
+    #[test]
+    fn json_array_file_is_always_valid() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.json");
+
+        let mut file = JsonArrayFile::create(&path).unwrap();
+
+        // Empty — valid JSON
+        let content = std::fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert!(parsed.is_array());
+        assert_eq!(parsed.as_array().unwrap().len(), 0);
+
+        // One entry via batch
+        file.write_batch(&[
+            r#"{"source":"turbo","level":"info","timestamp":1,"text":"first"}"#.to_string(),
+        ])
+        .unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(parsed.as_array().unwrap().len(), 1);
+
+        // Two more entries in one batch — valid JSON
+        file.write_batch(&[
+            r#"{"source":"web#build","level":"stdout","timestamp":2,"text":"second"}"#.to_string(),
+            r#"{"source":"web#build","level":"stdout","timestamp":3,"text":"third"}"#.to_string(),
+        ])
+        .unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0]["text"], "first");
+        assert_eq!(arr[1]["text"], "second");
+        assert_eq!(arr[2]["text"], "third");
+    }
+
+    #[test]
+    fn json_array_file_creates_parent_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested").join("dir").join("test.json");
+        let _file = JsonArrayFile::create(&path).unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn json_array_file_rejects_symlinks() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("real.json");
+        std::fs::write(&target, "").unwrap();
+        let link = dir.path().join("link.json");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_file(&target, &link).unwrap();
+
+        let result = JsonArrayFile::create(&link);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("symlink"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn json_array_file_permissions_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secure.json");
+        let _file = JsonArrayFile::create(&path).unwrap();
+        let perms = std::fs::metadata(&path).unwrap().permissions();
+        assert_eq!(perms.mode() & 0o777, 0o600);
+    }
+
+    #[test]
+    fn ndjson_terminal_output() {
+        let output = Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
+        let sink = StructuredLogSink::builder()
+            .terminal(true)
+            .build_with_writer(VecWriter(output.clone()))
+            .unwrap();
+
+        sink.emit(&LogEvent::new(
+            Level::Info,
+            Source::turbo(Subsystem::Run),
+            "starting",
+        ));
+        sink.emit(&LogEvent::new(
+            Level::Warn,
+            Source::turbo(Subsystem::Cache),
+            "miss",
+        ));
+        sink.flush();
+
+        let bytes = output.lock().unwrap().clone();
+        let text = String::from_utf8(bytes).unwrap();
+        let lines: Vec<&str> = text.trim().lines().collect();
+        assert_eq!(lines.len(), 2);
+        for line in &lines {
+            let parsed: serde_json::Value = serde_json::from_str(line).unwrap();
+            assert!(parsed["source"].is_string());
+            assert!(parsed["timestamp"].is_u64());
+        }
+    }
+
+    #[test]
+    fn task_output_strips_ansi() {
+        let output = Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
+        let sink = StructuredLogSink::builder()
+            .terminal(true)
+            .build_with_writer(VecWriter(output.clone()))
+            .unwrap();
+
+        sink.task_output(
+            "web#build",
+            OutputChannel::Stdout,
+            b"\x1b[32mSuccess\x1b[0m\n",
+        );
+        sink.flush();
+
+        let bytes = output.lock().unwrap().clone();
+        let text = String::from_utf8(bytes).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(text.trim()).unwrap();
+        assert_eq!(parsed["text"], "Success");
+        assert_eq!(parsed["source"], "web#build");
+        assert_eq!(parsed["level"], "stdout");
+    }
+
+    #[test]
+    fn task_output_skips_empty() {
+        let output = Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
+        let sink = StructuredLogSink::builder()
+            .terminal(true)
+            .build_with_writer(VecWriter(output.clone()))
+            .unwrap();
+
+        sink.task_output("web#build", OutputChannel::Stdout, b"");
+        sink.task_output("web#build", OutputChannel::Stdout, b"\n");
+        sink.flush();
+
+        let bytes = output.lock().unwrap().clone();
+        assert!(bytes.is_empty());
+    }
+
+    #[test]
+    fn task_output_splits_lines() {
+        let output = Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
+        let sink = StructuredLogSink::builder()
+            .terminal(true)
+            .build_with_writer(VecWriter(output.clone()))
+            .unwrap();
+
+        sink.task_output("web#build", OutputChannel::Stdout, b"line one\nline two\n");
+        sink.flush();
+
+        let bytes = output.lock().unwrap().clone();
+        let text = String::from_utf8(bytes).unwrap();
+        let lines: Vec<&str> = text.trim().lines().collect();
+        assert_eq!(lines.len(), 2);
+        let p1: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        let p2: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(p1["text"], "line one");
+        assert_eq!(p2["text"], "line two");
+    }
+
+    #[test]
+    fn tee_writer_duplicates_output() {
+        let mut a = Vec::new();
+        let mut b = Vec::new();
+        {
+            let mut tee = TeeWriter::new(&mut a, &mut b);
+            tee.write_all(b"hello").unwrap();
+        }
+        assert_eq!(a, b"hello");
+        assert_eq!(b, b"hello");
+    }
+
+    #[test]
+    fn combined_file_and_terminal() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("combined.json");
+        let term_output = Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
+
+        let sink = StructuredLogSink::builder()
+            .file_path(&path)
+            .terminal(true)
+            .build_with_writer(VecWriter(term_output.clone()))
+            .unwrap();
+
+        sink.emit(&LogEvent::new(
+            Level::Info,
+            Source::turbo(Subsystem::Run),
+            "msg",
+        ));
+        sink.task_output("web#build", OutputChannel::Stdout, b"output\n");
+        sink.flush();
+
+        // File has valid JSON array
+        let file_content = std::fs::read_to_string(&path).unwrap();
+        let file_parsed: serde_json::Value = serde_json::from_str(&file_content).unwrap();
+        assert_eq!(file_parsed.as_array().unwrap().len(), 2);
+
+        // Terminal has NDJSON
+        let term_bytes = term_output.lock().unwrap().clone();
+        let term_text = String::from_utf8(term_bytes).unwrap();
+        assert_eq!(term_text.trim().lines().count(), 2);
+    }
+
+    #[test]
+    fn structured_task_writer_works() {
+        let term_output = Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
+        let sink = StructuredLogSink::builder()
+            .terminal(true)
+            .build_with_writer(VecWriter(term_output.clone()))
+            .unwrap();
+
+        let mut writer = sink.task_writer("api#test", OutputChannel::Stderr);
+        writer.write_all(b"FAIL: test_foo\n").unwrap();
+        sink.flush();
+
+        let bytes = term_output.lock().unwrap().clone();
+        let text = String::from_utf8(bytes).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(text.trim()).unwrap();
+        assert_eq!(parsed["source"], "api#test");
+        assert_eq!(parsed["level"], "stderr");
+        assert_eq!(parsed["text"], "FAIL: test_foo");
+    }
+
+    /// Helper writer that appends to a shared Vec.
+    #[derive(Clone)]
+    struct VecWriter(Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl Write for VecWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+}

--- a/crates/turborepo-run-summary/src/execution.rs
+++ b/crates/turborepo-run-summary/src/execution.rs
@@ -134,20 +134,6 @@ impl<'a> ExecutionSummary<'a> {
             .max()
             .unwrap_or_default();
 
-        let lines: Vec<_> = line_data
-            .into_iter()
-            .map(|(header, trailer)| {
-                color!(
-                    ui,
-                    BOLD,
-                    "{}{}:    {}",
-                    " ".repeat(max_length - header.len()),
-                    header,
-                    trailer
-                )
-            })
-            .collect();
-
         if self.attempted == 0 {
             turborepo_log::warn(
                 turborepo_log::Source::turbo(turborepo_log::Subsystem::Summary),
@@ -156,12 +142,35 @@ impl<'a> ExecutionSummary<'a> {
             .emit();
         }
 
-        println!();
-        for line in lines {
-            println!("{line}");
+        // All output goes through the Logger. The TerminalSink renders
+        // ANSI codes for color; the StructuredLogSink strips them.
+        turborepo_log::info(
+            turborepo_log::Source::turbo(turborepo_log::Subsystem::Summary),
+            "",
+        )
+        .emit();
+        for (header, trailer) in &line_data {
+            turborepo_log::info(
+                turborepo_log::Source::turbo(turborepo_log::Subsystem::Summary),
+                format!(
+                    "{}",
+                    color!(
+                        ui,
+                        BOLD,
+                        "{}{}:    {}",
+                        " ".repeat(max_length - header.len()),
+                        header,
+                        trailer
+                    )
+                ),
+            )
+            .emit();
         }
-
-        println!();
+        turborepo_log::info(
+            turborepo_log::Source::turbo(turborepo_log::Subsystem::Summary),
+            "",
+        )
+        .emit();
     }
 
     fn successful(&self) -> usize {

--- a/crates/turborepo-ui/src/log_sinks.rs
+++ b/crates/turborepo-ui/src/log_sinks.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use turborepo_log::{Logger, sinks::collector::CollectorSink};
+use turborepo_log::{Logger, StructuredLogSink, sinks::collector::CollectorSink};
 
 use crate::{ColorConfig, TerminalSink, TuiSink};
 
@@ -14,15 +14,17 @@ use crate::{ColorConfig, TerminalSink, TuiSink};
 /// # Lifecycle
 ///
 /// 1. `LogSinks::new()` — all sinks start in Active mode
-/// 2. `init_logger()` — registers sinks with the global `turborepo_log` logger
-/// 3. For `--graph` / `--dry=json`: `suppress_stdout()` before emitting prelude
-/// 4. Emit prelude logs (Info→stdout, unless suppressed)
-/// 5. `disable_for_tui()` — suppress all terminal output before TUI startup
-/// 6. If TUI starts: `tui.connect(sender)` to forward buffered events If TUI
+/// 2. Optionally call `with_structured_sink()` to enable structured logging
+/// 3. `init_logger()` — registers sinks with the global `turborepo_log` logger
+/// 4. For `--graph` / `--dry=json`: `suppress_stdout()` before emitting prelude
+/// 5. Emit prelude logs (Info→stdout, unless suppressed)
+/// 6. `disable_for_tui()` — suppress all terminal output before TUI startup
+/// 7. If TUI starts: `tui.connect(sender)` to forward buffered events If TUI
 ///    doesn't start: `enable_for_stream()` to re-enable output
 pub struct LogSinks {
     pub terminal: Arc<TerminalSink>,
     pub tui: Arc<TuiSink>,
+    pub structured: Option<Arc<StructuredLogSink>>,
 }
 
 impl LogSinks {
@@ -30,7 +32,13 @@ impl LogSinks {
         Self {
             terminal: Arc::new(TerminalSink::new(color_config)),
             tui: Arc::new(TuiSink::new()),
+            structured: None,
         }
+    }
+
+    /// Set the structured log sink. Must be called before `init_logger()`.
+    pub fn with_structured_sink(&mut self, sink: Arc<StructuredLogSink>) {
+        self.structured = Some(sink);
     }
 
     /// Initialize the global logger with these sinks plus a fresh
@@ -38,11 +46,15 @@ impl LogSinks {
     /// return `Err` but the original sinks remain active via `Arc`.
     pub fn init_logger(&self) {
         let collector = Arc::new(CollectorSink::new());
-        let _ = turborepo_log::init(Logger::new(vec![
+        let mut sinks: Vec<Box<dyn turborepo_log::LogSink>> = vec![
             Box::new(collector),
             Box::new(self.terminal.clone()),
             Box::new(self.tui.clone()),
-        ]));
+        ];
+        if let Some(ref structured) = self.structured {
+            sinks.push(Box::new(structured.clone()));
+        }
+        let _ = turborepo_log::init(Logger::new(sinks));
     }
 
     /// Suppress Info→stdout while keeping Warn/Error→stderr. Used for

--- a/crates/turborepo-ui/src/terminal_sink.rs
+++ b/crates/turborepo-ui/src/terminal_sink.rs
@@ -184,12 +184,9 @@ impl LogSink for TerminalSink {
                 }
                 let stdout = io::stdout();
                 let mut handle = stdout.lock();
-                let _ = writeln!(
-                    handle,
-                    "{}",
-                    self.color_config
-                        .apply(crate::GREY.apply_to(event.message()))
-                );
+                // Print the raw message — it may carry its own ANSI
+                // formatting (e.g., summary colors). Don't wrap in GREY.
+                let _ = writeln!(handle, "{}", event.message());
             }
             Level::Warn | Level::Error => {
                 self.emit_stderr(event);

--- a/crates/turborepo/tests/snapshots/command_test__bad_flag_implied_run.snap
+++ b/crates/turborepo/tests/snapshots/command_test__bad_flag_implied_run.snap
@@ -20,6 +20,8 @@ Options:
     --affected
     --output-logs <OUTPUT_LOGS>
     --log-order <LOG_ORDER>
+    --json
+    --log-file [<LOG_FILE>]
     --only
     --pkg-inference-root <PKG_INFERENCE_ROOT>
     --log-prefix <LOG_PREFIX>

--- a/crates/turborepo/tests/structured_logging.rs
+++ b/crates/turborepo/tests/structured_logging.rs
@@ -1,0 +1,145 @@
+mod common;
+
+use common::{run_turbo, setup};
+
+/// Verify `--log-file` produces a valid JSON array file
+/// containing task output entries.
+#[test]
+fn log_file_produces_valid_json() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", true).unwrap();
+
+    let log_path = tempdir.path().join("structured.json");
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "run",
+            "build",
+            "--force",
+            &format!("--log-file={}", log_path.display()),
+        ],
+    );
+
+    assert!(output.status.success(), "turbo run should succeed");
+    assert!(log_path.exists(), "structured log file should be created");
+
+    let content = std::fs::read_to_string(&log_path).unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&content).expect("structured log file should be valid JSON");
+    let entries = parsed.as_array().expect("top-level should be an array");
+
+    assert!(!entries.is_empty(), "should contain at least one entry");
+
+    // Every entry must have the spec-required fields.
+    for entry in entries {
+        assert!(entry["source"].is_string(), "entry missing 'source'");
+        assert!(entry["level"].is_string(), "entry missing 'level'");
+        assert!(entry["timestamp"].is_u64(), "entry missing 'timestamp'");
+        assert!(entry["text"].is_string(), "entry missing 'text'");
+    }
+
+    // At least one entry should be task output from app-a's build script.
+    let has_task_output = entries.iter().any(|e| {
+        e["source"].as_str().is_some_and(|s| s.contains("build"))
+            && e["text"]
+                .as_str()
+                .is_some_and(|t| t.contains("build-app-a"))
+    });
+    assert!(has_task_output, "should capture task stdout");
+}
+
+/// Verify `--json` produces NDJSON on stdout.
+#[test]
+fn json_flag_produces_ndjson() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", true).unwrap();
+
+    let output = run_turbo(tempdir.path(), &["run", "build", "--force", "--json"]);
+
+    assert!(output.status.success(), "turbo run should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    assert!(!lines.is_empty(), "should produce output on stdout");
+
+    // Every line must be valid JSON with the spec-required fields.
+    for line in &lines {
+        let parsed: serde_json::Value =
+            serde_json::from_str(line).unwrap_or_else(|_| panic!("invalid JSON line: {line}"));
+        assert!(parsed["source"].is_string());
+        assert!(parsed["level"].is_string());
+        assert!(parsed["timestamp"].is_u64());
+        assert!(parsed["text"].is_string());
+    }
+}
+
+/// Verify structured log file has no ANSI escape codes in text fields.
+#[test]
+fn structured_log_strips_ansi() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", true).unwrap();
+
+    let log_path = tempdir.path().join("ansi_test.json");
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "run",
+            "build",
+            "--force",
+            &format!("--log-file={}", log_path.display()),
+        ],
+    );
+
+    assert!(output.status.success());
+
+    let content = std::fs::read_to_string(&log_path).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+    for entry in parsed.as_array().unwrap() {
+        let text = entry["text"].as_str().unwrap();
+        assert!(
+            !text.contains('\x1b'),
+            "structured log text should not contain ANSI escape codes: {text:?}"
+        );
+    }
+}
+
+/// Verify path traversal is rejected (path escaping repo root falls back to
+/// default).
+#[test]
+fn log_file_rejects_path_traversal() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", true).unwrap();
+
+    // Attempt to write outside the repo root.
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "run",
+            "build",
+            "--force",
+            "--log-file=../../../tmp/evil.json",
+        ],
+    );
+
+    assert!(output.status.success(), "run should still succeed");
+
+    // The traversal path should NOT have been created.
+    assert!(
+        !std::path::Path::new("/tmp/evil.json").exists(),
+        "path traversal should be rejected"
+    );
+
+    // Instead, a log should exist under .turbo/logs/ (the default fallback).
+    let turbo_logs = tempdir.path().join(".turbo").join("logs");
+    if turbo_logs.exists() {
+        let json_files: Vec<_> = std::fs::read_dir(&turbo_logs)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
+            .collect();
+        assert!(
+            !json_files.is_empty(),
+            "should fall back to default .turbo/logs/ location"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `--json` flag to stream NDJSON to stdout and `--log-file [path]` flag to write structured JSON logs to a file, both behind an experimental marker
- Supports `TURBO_LOG_FILE` environment variable as an alternative to the CLI flag
- Deliberately omits `logFile` from `turbo.json` — structured logging is a per-invocation concern better suited to CLI flags and env vars than checked-in config

## How to test

```bash
# NDJSON to stdout
turbo run build --json 2>/dev/null | head -5

# File output (default path)
turbo run build --log-file
cat .turbo/logs/*.json | python3 -m json.tool | head -20

# File output (custom path)
turbo run build --log-file=my-log.json

# Env var
TURBO_LOG_FILE=1 turbo run build

# Both modes simultaneously
turbo run build --json --log-file=build.json
```

Each JSON entry has `timestamp`, `source`, `level`, and `text` fields. ANSI escape sequences are stripped in file output.