### PR TITLE
release(turborepo): 2.8.21-canary.1

### DIFF
--- a/packages/create-turbo/package.json
+++ b/packages/create-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-turbo",
-  "version": "2.8.20",
+  "version": "2.8.21-canary.1",
   "description": "Create a new Turborepo",
   "homepage": "https://turborepo.dev",
   "bugs": {

--- a/packages/eslint-config-turbo/package.json
+++ b/packages/eslint-config-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-turbo",
-  "version": "2.8.20",
+  "version": "2.8.21-canary.1",
   "description": "ESLint config for Turborepo",
   "keywords": [
     "eslint",

--- a/packages/eslint-plugin-turbo/package.json
+++ b/packages/eslint-plugin-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-turbo",
-  "version": "2.8.20",
+  "version": "2.8.21-canary.1",
   "description": "ESLint plugin for Turborepo",
   "keywords": [
     "eslint",

--- a/packages/turbo-codemod/package.json
+++ b/packages/turbo-codemod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/codemod",
-  "version": "2.8.20",
+  "version": "2.8.21-canary.1",
   "description": "Provides Codemod transformations to help upgrade your Turborepo codebase when a feature is deprecated.",
   "homepage": "https://turborepo.dev",
   "bugs": {

--- a/packages/turbo-gen/package.json
+++ b/packages/turbo-gen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/gen",
-  "version": "2.8.20",
+  "version": "2.8.21-canary.1",
   "description": "Extend a Turborepo",
   "homepage": "https://turborepo.dev",
   "bugs": {

--- a/packages/turbo-ignore/package.json
+++ b/packages/turbo-ignore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-ignore",
-  "version": "2.8.20",
+  "version": "2.8.21-canary.1",
   "description": "",
   "keywords": [],
   "homepage": "https://turborepo.dev",

--- a/packages/turbo-types/package.json
+++ b/packages/turbo-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/types",
-  "version": "2.8.20",
+  "version": "2.8.21-canary.1",
   "description": "Turborepo types",
   "homepage": "https://turborepo.dev",
   "bugs": {

--- a/packages/turbo-workspaces/package.json
+++ b/packages/turbo-workspaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/workspaces",
-  "version": "2.8.20",
+  "version": "2.8.21-canary.1",
   "description": "Tools for working with package managers",
   "homepage": "https://turborepo.dev",
   "bugs": {

--- a/packages/turbo/package.json
+++ b/packages/turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo",
-  "version": "2.8.20",
+  "version": "2.8.21-canary.1",
   "description": "Turborepo is a high-performance build system for JavaScript and TypeScript codebases.",
   "homepage": "https://turborepo.dev",
   "bugs": "https://github.com/vercel/turborepo/issues",
@@ -18,11 +18,11 @@
     "postversion": "node bump-version.js"
   },
   "optionalDependencies": {
-    "@turbo/darwin-64": "2.8.20",
-    "@turbo/darwin-arm64": "2.8.20",
-    "@turbo/linux-64": "2.8.20",
-    "@turbo/linux-arm64": "2.8.20",
-    "@turbo/windows-64": "2.8.20",
-    "@turbo/windows-arm64": "2.8.20"
+    "@turbo/darwin-64": "2.8.21-canary.1",
+    "@turbo/darwin-arm64": "2.8.21-canary.1",
+    "@turbo/linux-64": "2.8.21-canary.1",
+    "@turbo/linux-arm64": "2.8.21-canary.1",
+    "@turbo/windows-64": "2.8.21-canary.1",
+    "@turbo/windows-arm64": "2.8.21-canary.1"
   }
 }

--- a/skills/turborepo/SKILL.md
+++ b/skills/turborepo/SKILL.md
@@ -9,7 +9,7 @@ description: |
   monorepo, shares code between apps, runs changed/affected packages, debugs cache,
   or has apps/packages directories.
 metadata:
-  version: 2.8.20
+  version: 2.8.21-canary.1
 ---
 
 # Turborepo Skill
@@ -740,7 +740,7 @@ import { Button } from "@repo/ui/button";
 
 ```json
 {
-  "$schema": "https://v2-8-20.turborepo.dev/schema.json",
+  "$schema": "https://v2-8-21-canary-1.turborepo.dev/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],

--- a/skills/turborepo/references/best-practices/structure.md
+++ b/skills/turborepo/references/best-practices/structure.md
@@ -95,7 +95,7 @@ Package tasks enable Turborepo to:
 
 ```json
 {
-  "$schema": "https://v2-8-20.turborepo.dev/schema.json",
+  "$schema": "https://v2-8-21-canary-1.turborepo.dev/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
@@ -117,7 +117,7 @@ With `futureFlags.globalConfiguration`, global settings move under a `global` ke
 
 ```json
 {
-  "$schema": "https://v2-8-20-canary-1.turborepo.dev/schema.json",
+  "$schema": "https://v2-8-21-canary-1.turborepo.dev/schema.json",
   "futureFlags": { "globalConfiguration": true },
   "global": {
     "inputs": ["tsconfig.json"],

--- a/skills/turborepo/references/configuration/RULE.md
+++ b/skills/turborepo/references/configuration/RULE.md
@@ -73,7 +73,7 @@ When you run `turbo run lint`, Turborepo finds all packages with a `lint` script
 
 ```json
 {
-  "$schema": "https://v2-8-20.turborepo.dev/schema.json",
+  "$schema": "https://v2-8-21-canary-1.turborepo.dev/schema.json",
   "globalEnv": ["CI"],
   "globalDependencies": ["tsconfig.json"],
   "tasks": {
@@ -97,7 +97,7 @@ When the `globalConfiguration` future flag is enabled, global options move under
 
 ```json
 {
-  "$schema": "https://turborepo.dev/schema.v2.json",
+  "$schema": "https://v2-8-21-canary-1.turborepo.dev/schema.json",
   "futureFlags": { "globalConfiguration": true },
   "global": {
     "inputs": ["tsconfig.json"],

--- a/skills/turborepo/references/environment/RULE.md
+++ b/skills/turborepo/references/environment/RULE.md
@@ -107,7 +107,7 @@ When the `globalConfiguration` future flag is enabled, global environment keys m
 
 ```json
 {
-  "$schema": "https://v2-8-20.turborepo.dev/schema.json",
+  "$schema": "https://v2-8-21-canary-1.turborepo.dev/schema.json",
   "globalEnv": ["CI", "NODE_ENV"],
   "globalPassThroughEnv": ["GITHUB_TOKEN", "NPM_TOKEN"],
   "tasks": {

--- a/skills/turborepo/references/environment/gotchas.md
+++ b/skills/turborepo/references/environment/gotchas.md
@@ -112,7 +112,7 @@ If you use `.env.development` and `.env.production`, both should be in inputs.
 
 ```json
 {
-  "$schema": "https://v2-8-20.turborepo.dev/schema.json",
+  "$schema": "https://v2-8-21-canary-1.turborepo.dev/schema.json",
   "globalEnv": ["CI", "NODE_ENV", "VERCEL"],
   "globalPassThroughEnv": ["GITHUB_TOKEN", "VERCEL_URL"],
   "tasks": {
@@ -146,7 +146,7 @@ The same config using the `global` key. The `.env` files move to `global.inputs`
 
 ```json
 {
-  "$schema": "https://v2-8-20-canary-1.turborepo.dev/schema.json",
+  "$schema": "https://v2-8-21-canary-1.turborepo.dev/schema.json",
   "futureFlags": { "globalConfiguration": true },
   "global": {
     "env": ["CI", "NODE_ENV", "VERCEL"],

--- a/version.txt
+++ b/version.txt
@@ -1,2 +1,2 @@
-2.8.21-canary.0
+2.8.21-canary.1
 canary


### PR DESCRIPTION
## Release v2.8.21-canary.1

Manual release PR to advance `main` past the partially-published `2.8.21-canary.1` canary.

The [automated release run](https://github.com/vercel/turborepo/actions/runs/23352060079/job/67935372332) failed during npm publish (`@turbo/types` was the only package that didn't make it). Since the release PR is created after publish, `main` was never updated to reflect the published version.

This PR applies the same changes the release workflow would have: bumps `version.txt` and all package versions to `2.8.21-canary.1` so the next scheduled canary publishes `2.8.21-canary.2`.