### PR TITLE
fix: Add NixOS environment variables to default passthroughs

### DIFF
--- a/crates/turborepo-env/src/lib.rs
+++ b/crates/turborepo-env/src/lib.rs
@@ -71,6 +71,9 @@ pub const BUILTIN_PASS_THROUGH_ENV: &[&str] = &[
     // GitHub Actions
     "GITHUB_*",
     "RUNNER_*",
+    // NixOS
+    "__NIXOS_*",
+    "NIX_*",
     // Command Prompt casing of env variables
     "APPDATA",
     "PATH",


### PR DESCRIPTION
## Summary

- Adds `__NIXOS_*` and `NIX_*` to `BUILTIN_PASS_THROUGH_ENV`

On NixOS, when `__NIXOS_SET_ENVIRONMENT_DONE` is stripped from the environment, spawning a non-interactive shell resets `PATH` via `/etc/zshenv` (or equivalent). This silently breaks task execution since the shell loses most of its `PATH` entries.

These variables have no effect on non-NixOS systems.

Closes #11688