### PR TITLE
fix: Resolve security vulnerabilities in `tar` and `rustls-webpki`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5504,9 +5504,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -6278,9 +6278,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.40"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",

--- a/crates/turborepo-cache/Cargo.toml
+++ b/crates/turborepo-cache/Cargo.toml
@@ -39,7 +39,7 @@ reqwest = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
-tar = "0.4.38"
+tar = "0.4.45"
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-stream = "0.1.15"


### PR DESCRIPTION
## Summary

- Bumps `tar` from 0.4.38 to 0.4.45 to fix two medium-severity vulnerabilities (RUSTSEC-2026-0067, RUSTSEC-2026-0068)
- Updates `rustls-webpki` from 0.103.9 to 0.103.10 to fix a CRL distribution point matching bug (RUSTSEC-2026-0049)

All three vulnerabilities were flagged by `cargo audit`. The `proc-macro-error` unmaintained warning (RUSTSEC-2024-0370) remains as it's an upstream biome dependency issue.