### PR TITLE
docs: Clarify `turbo-ignore`'s future

### DIFF
--- a/apps/docs/content/docs/reference/turbo-ignore.mdx
+++ b/apps/docs/content/docs/reference/turbo-ignore.mdx
@@ -11,7 +11,10 @@ related:
 ---
 
 <Callout type="warn" title="Deprecated">
-  `turbo-ignore` is deprecated and will be removed in a future major version. Use [`turbo query affected`](/docs/reference/query#affected) instead, which provides more precise task-level change detection. See the [migration guide](/docs/reference/query#migrating-from-turbo-ignore).
+  `turbo-ignore` is deprecated and will no longer receive updates. Use [`turbo
+  query affected`](/docs/reference/query#affected) instead, which provides more
+  precise task-level change detection. See the [migration
+  guide](/docs/reference/query#migrating-from-turbo-ignore).
 </Callout>
 
 Use `turbo` to determine if a package or its dependencies have changes. This can be useful for quickly skipping tasks in CI.


### PR DESCRIPTION
### Description

`turbo-ignore` won't be removed from the registry, but it will not receive new updates.
