### PR TITLE
docs: Add Git history requirements to `turbo query affected` docs

### DIFF
--- a/apps/docs/content/docs/crafting-your-repository/constructing-ci.mdx
+++ b/apps/docs/content/docs/crafting-your-repository/constructing-ci.mdx
@@ -93,7 +93,9 @@ As your codebase and CI grow, you may start to look for more ways to get even fa
 <Step>
 ### Checkout the repository
 
-Start by cloning your repository. A clone with sufficient history is necessary for comparisons. By default, `turbo query affected` compares against the merge-base with your default branch.
+Start by cloning your repository. A clone with sufficient history is necessary for comparisons — if the checkout is too shallow, all packages will be considered changed. For example, cloning with `--filter=blob:none --depth=0` will ensure the right history is available.
+
+By default, `turbo query affected` compares against the merge-base with your default branch.
 
 </Step>
 <Step>

--- a/apps/docs/content/docs/guides/skipping-tasks.mdx
+++ b/apps/docs/content/docs/guides/skipping-tasks.mdx
@@ -21,6 +21,15 @@ Ideally, you would do a quick check to see if any of that work needs to happen i
 
 ## Using `turbo query affected`
 
+<Callout type="warn">
+  The comparison requires everything between base and head to exist in the
+  checkout. If the checkout is too shallow, then all packages will be considered
+  changed.
+
+For example, setting up Git to check out with `--filter=blob:none --depth=0` will ensure `turbo query affected` has the right history to work correctly.
+
+</Callout>
+
 After you've checked out the repo, but **before** any other work, you can take a few seconds to check if your `web` workspace is affected by the changes in your branch:
 
 ```bash title="Terminal"

--- a/apps/docs/content/docs/reference/query.mdx
+++ b/apps/docs/content/docs/reference/query.mdx
@@ -109,6 +109,15 @@ Check which packages or tasks are affected by changes between two git refs.
 turbo query affected [flags]
 ```
 
+<Callout type="warn">
+  The comparison requires everything between base and head to exist in the
+  checkout. If the checkout is too shallow, then all packages will be considered
+  changed.
+
+For example, setting up Git to check out with `--filter=blob:none --depth=0` will ensure `turbo query affected` has the right history to work correctly.
+
+</Callout>
+
 With no flags, returns all affected tasks:
 
 ```bash title="Terminal"


### PR DESCRIPTION
## Summary

- `turbo query affected` has the same shallow-checkout pitfall as `--affected` but the docs didn't mention it. Without sufficient Git history, all packages are silently treated as changed — a confusing failure mode in CI.
- Adds the same `<Callout type="warn">` (with the `--filter=blob:none --depth=0` recommendation) to the `turbo query affected` reference and the skipping tasks guide, and strengthens the existing mention in the constructing CI guide.