### PR TITLE
fix: Prevent horizontal overflow from long inline code on narrow viewports

### DIFF
--- a/apps/docs/app/styles/geistdocs.css
+++ b/apps/docs/app/styles/geistdocs.css
@@ -189,6 +189,13 @@
   --fd-page-width: 100%;
 }
 
+/* The global `* { min-w-0 }` reset lets tab triggers shrink below their
+   content width even though their text has `whitespace-nowrap`, causing labels
+   to overlap instead of triggering the TabsList's `overflow-x-auto` scroll. */
+[role="tablist"] > [role="tab"] {
+  flex-shrink: 0;
+}
+
 /* Prevent TOC from being clipped on tablet displays */
 #nd-docs-layout {
   overflow-x: visible;


### PR DESCRIPTION
## Summary

- Long unbreakable strings like `dangerouslyDisablePackageManagerCheck` and `TURBO_DANGEROUSLY_DISABLE_PACKAGE_MANAGER_CHECK` cause horizontal page overflow on the "Configuring turbo.json" docs page at narrow viewport widths.
- Adds `overflow-wrap: break-word` to prose headings and inline `<code>` elements (excluding code blocks, which already scroll via `overflow-x-auto`).