### PR TITLE
fix: Upgrade tokio to 1.47.1+ to fix pidfd_reaper panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6576,27 +6576,26 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
- "backtrace",
  "bytes",
  "libc",
  "mio 1.0.1",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.6",
+ "socket2 0.6.2",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,7 +173,7 @@ tempfile = "3.3.0"
 test-case = "3.3.1"
 thiserror = "2.0.18"
 tiny-gradient = "0.1.0"
-tokio = "1.25.0"
+tokio = "1.47.1"
 tokio-util = { version = "0.7.7", features = ["io"] }
 tracing = "0.1.37"
 tracing-appender = "0.2.2"

--- a/crates/turborepo-globwatch/Cargo.toml
+++ b/crates/turborepo-globwatch/Cargo.toml
@@ -15,7 +15,7 @@ merge-streams = "0.1.2"
 notify = { workspace = true }
 stop-token = "0.7.0"
 thiserror = { workspace = true }
-tokio = { version = "1.25.0", features = ["sync"] }
+tokio = { workspace = true, features = ["sync"] }
 tokio-stream = "0.1.12"
 tracing = "0.1.37"
 turbopath = { workspace = true }
@@ -23,7 +23,7 @@ unicode-segmentation = "1.12.0"
 
 [dev-dependencies]
 test-case = { workspace = true }
-tokio = { version = "1.25.0", features = [
+tokio = { workspace = true, features = [
   "rt",
   "rt-multi-thread",
   "time",


### PR DESCRIPTION
## Summary

- Bumps the workspace `tokio` minimum from `1.25.0` to `1.47.1` to pick up the pidfd_reaper spurious-wakeup fix ([tokio-rs/tokio#7494](https://github.com/tokio-rs/tokio/pull/7494))
- Switches `turborepo-globwatch` from a hardcoded tokio version to `workspace = true` for consistency

tokio 1.42.0 introduced pidfd-based child process reaping on Linux. When a ptracer (e.g. CrowdStrike Falcon) is attached, pidfds receive spurious wakeups that falsely signal process exit, causing a panic at `pidfd_reaper.rs:130`. This was fixed in tokio 1.47.1.

Closes #12430