### PR TITLE
docs: Add AI guide to sidebar navigation

### DIFF
--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -1,5 +1,6 @@
 {
   "pages": [
+    "ai",
     "frameworks",
     "ci-vendors",
     "tools",


### PR DESCRIPTION
## Summary
- The AI guide page (`/docs/guides/ai`) existed but was missing from the sidebar `meta.json`, making it undiscoverable. Added it as the first entry in the Guides section.