### PR TITLE
fix: Skip Unix domain sockets and other special files during file hashing

### DIFF
--- a/crates/turborepo-fs/src/lib.rs
+++ b/crates/turborepo-fs/src/lib.rs
@@ -69,9 +69,10 @@ pub fn recursive_copy(
                     if file_type.is_dir() {
                         let src_metadata = entry.metadata()?;
                         make_dir_copy(&target, &src_metadata)?;
-                    } else {
+                    } else if file_type.is_file() || file_type.is_symlink() {
                         copy_file_with_type(path, file_type, &target)?;
                     }
+                    // Skip special files (sockets, FIFOs, device nodes)
                 }
             }
         }

--- a/crates/turborepo-globwalk/src/lib.rs
+++ b/crates/turborepo-globwalk/src/lib.rs
@@ -659,7 +659,7 @@ fn walk_compiled_globs(
                 .symlink_metadata()
                 .ok()
                 .is_some_and(|m| match walk_type {
-                    WalkType::Files => !m.is_dir(),
+                    WalkType::Files => m.is_file() || m.is_symlink(),
                     WalkType::Folders => m.is_dir(),
                     WalkType::All => true,
                 });
@@ -695,7 +695,7 @@ fn walk_compiled_globs(
         .filter_map(|candidate| {
             let meta = candidate.symlink_metadata().ok()?;
             let dominated = match walk_type {
-                WalkType::Files => !meta.is_dir(),
+                WalkType::Files => meta.is_file() || meta.is_symlink(),
                 WalkType::Folders => meta.is_dir(),
                 WalkType::All => true,
             };
@@ -769,7 +769,13 @@ fn visit_file(
     entry: Result<wax::walk::GlobEntry, wax::walk::WalkError>,
 ) -> Option<Result<AbsoluteSystemPathBuf, WalkError>> {
     match entry {
-        Ok(entry) if walk_type == WalkType::Files && entry.file_type().is_dir() => None,
+        Ok(entry)
+            if walk_type == WalkType::Files
+                && !entry.file_type().is_file()
+                && !entry.file_type().is_symlink() =>
+        {
+            None
+        }
         Ok(entry) => Some(AbsoluteSystemPathBuf::try_from(entry.path()).map_err(|e| e.into())),
         Err(e) => {
             let io_err = std::io::Error::from(e);

--- a/crates/turborepo-scm/src/hash_object.rs
+++ b/crates/turborepo-scm/src/hash_object.rs
@@ -39,7 +39,17 @@ fn hash_file_with_retry(
 /// call is bounded by `BUF_SIZE` (~64KB) regardless of file size.
 fn hash_file(path: &AbsoluteSystemPath) -> Result<gix_index::hash::ObjectId, std::io::Error> {
     let file = std::fs::File::open(path)?;
-    let file_len = file.metadata()?.len();
+    let metadata = file.metadata()?;
+    // Reject exotic file types (sockets, FIFOs, device nodes) that cause
+    // EOPNOTSUPP on read(). Directories pass through to fail naturally
+    // with a descriptive IsADirectory error.
+    if !metadata.is_file() && !metadata.is_dir() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("{path}: not a regular file"),
+        ));
+    }
+    let file_len = metadata.len();
 
     // Build the hasher with the blob loose header pre-written, exactly as
     // gix_object::compute_hash does internally.
@@ -103,9 +113,11 @@ pub(crate) fn hash_objects(
                     )))
                 }
                 Err(e) => {
+                    // Gracefully skip non-regular files (symlinks, sockets,
+                    // FIFOs, device nodes) that can't be read as normal files.
                     if full_file_path
                         .symlink_metadata()
-                        .map(|md| md.is_symlink())
+                        .map(|md| !md.is_file())
                         .unwrap_or(false)
                     {
                         Ok(None)

--- a/crates/turborepo-scm/src/manual.rs
+++ b/crates/turborepo-scm/src/manual.rs
@@ -27,7 +27,18 @@ use crate::{Error, GitHashes, OidHash};
 fn git_like_hash_file(path: &AbsoluteSystemPath) -> Result<OidHash, Error> {
     let mut hasher = Sha1::new();
     let f = path.open()?;
-    let file_len = f.metadata()?.len();
+    let metadata = f.metadata()?;
+    // Reject exotic file types (sockets, FIFOs, device nodes) that cause
+    // EOPNOTSUPP on read(). Directories pass through to fail naturally
+    // with a descriptive IsADirectory error.
+    if !metadata.is_file() && !metadata.is_dir() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("{path}: not a regular file"),
+        )
+        .into());
+    }
+    let file_len = metadata.len();
 
     hasher.update(b"blob ");
     hasher.update(file_len.to_string().as_bytes());
@@ -208,9 +219,10 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
     for dirent in walker {
         let dirent = dirent?;
         let metadata = dirent.metadata()?;
-        // We need to do this here, rather than as a filter, because the root
-        // directory is always yielded and not subject to the supplied filter.
-        if metadata.is_dir() {
+        // Skip anything that isn't a regular file (directories, symlinks,
+        // sockets, FIFOs, device nodes). This must be here rather than as a
+        // walker filter because the root directory is always yielded.
+        if !metadata.is_file() {
             continue;
         }
 
@@ -232,10 +244,6 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
             continue;
         }
 
-        // FIXME: we don't hash symlinks...
-        if metadata.is_symlink() {
-            continue;
-        }
         let hash = git_like_hash_file(path)?;
         hashes.insert(relative_path, hash);
     }
@@ -253,9 +261,10 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
         for dirent in walker {
             let dirent = dirent?;
             let metadata = dirent.metadata()?;
-            // We need to do this here, rather than as a filter, because the root
-            // directory is always yielded and not subject to the supplied filter.
-            if metadata.is_dir() || metadata.is_symlink() {
+            // Skip anything that isn't a regular file. Must be here rather
+            // than as a walker filter because the root directory is always
+            // yielded.
+            if !metadata.is_file() {
                 continue;
             }
 

--- a/crates/turborepo-scm/src/repo_index.rs
+++ b/crates/turborepo-scm/src/repo_index.rs
@@ -597,10 +597,9 @@ pub fn walk_candidate_files(
                 Err(_) => return ignore::WalkState::Continue,
             };
 
-            if entry.file_type().is_some_and(|ft| ft.is_dir()) {
-                return ignore::WalkState::Continue;
-            }
-            if entry.file_type().is_some_and(|ft| ft.is_symlink()) {
+            // Skip anything that isn't a regular file (directories,
+            // symlinks, sockets, FIFOs, device nodes).
+            if !entry.file_type().is_some_and(|ft| ft.is_file()) {
                 return ignore::WalkState::Continue;
             }
 
@@ -834,10 +833,9 @@ fn find_untracked_files(
                 Err(_) => return ignore::WalkState::Continue,
             };
 
-            if entry.file_type().is_some_and(|ft| ft.is_dir()) {
-                return ignore::WalkState::Continue;
-            }
-            if entry.file_type().is_some_and(|ft| ft.is_symlink()) {
+            // Skip anything that isn't a regular file (directories,
+            // symlinks, sockets, FIFOs, device nodes).
+            if !entry.file_type().is_some_and(|ft| ft.is_file()) {
                 return ignore::WalkState::Continue;
             }
 


### PR DESCRIPTION
## Summary

Fixes #12437

- Unix domain sockets (and other special file types like FIFOs and device nodes) in the project directory crash turbo with `EOPNOTSUPP` (os error 102) because the file walkers filter by excluding known types (`is_dir`, `is_symlink`) rather than including the desired type (`is_file`), so sockets slip through and `read()` fails.
- Flips all walker filters from "exclude what's bad" to "include only what's good" (`is_file()`), and adds defense-in-depth guards in the hash functions themselves so a future walker that forgets to filter won't crash.

## Changes

**Walkers (outer layer):** Every file enumeration site now uses `is_file()` as a positive inclusion check. Sockets never enter the hashing pipeline.

- `turborepo-scm`: `manual.rs`, `repo_index.rs` (both `walk_candidate_files` and `find_untracked_files`)
- `turborepo-globwalk`: `walk_compiled_globs` literal, shallow, and general paths; `visit_file`
- `turborepo-fs`: `recursive_copy`

**Hash functions (inner layer):** Both `hash_file` and `git_like_hash_file` now check the file type from metadata they already fetch (zero extra I/O) and reject exotic types before attempting `read()`.

**Error handler:** `hash_objects` error recovery now skips any non-regular file, not just symlinks.

## Testing

To reproduce the original issue, any app that creates a Unix domain socket in its directory (e.g., Node IPC) will trigger the crash on a second `turbo run dev`. After this fix, the socket is silently skipped.