### PR TITLE
fix: Align dry run cache status with normal run by checking caching guards

### DIFF
--- a/crates/turborepo-run-cache/src/lib.rs
+++ b/crates/turborepo-run-cache/src/lib.rs
@@ -306,7 +306,15 @@ impl TaskCache {
         Ok(log_writer)
     }
 
+    /// Check if a cache entry exists for this task.
+    ///
+    /// Used by dry runs to report cache status without restoring outputs.
+    /// Mirrors the guard checks in `restore_outputs()` so that dry runs
+    /// and real runs agree on cache status.
     pub async fn exists(&self) -> Result<Option<CacheHitMetadata>, CacheError> {
+        if self.caching_disabled || self.run_cache.reads_disabled {
+            return Ok(None);
+        }
         self.run_cache.cache.exists(&self.hash).await
     }
 

--- a/crates/turborepo/tests/dry_run_test.rs
+++ b/crates/turborepo/tests/dry_run_test.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{run_turbo, run_turbo_with_env, setup};
+use common::{git, run_turbo, run_turbo_with_env, setup};
 
 #[test]
 fn test_dry_run_packages_in_scope() {
@@ -67,4 +67,89 @@ fn test_dry_run_env_var_not_in_output() {
         !stdout.contains("Environment Variables"),
         "should not contain 'Environment Variables' header: {stdout}"
     );
+}
+
+#[test]
+fn test_dry_run_cache_hit_after_real_run() {
+    // Regression test for https://github.com/vercel/turborepo/issues/9044
+    // After a real run populates the cache, --dry=json should report HIT.
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+
+    // First: real run to populate cache
+    let output = run_turbo(tempdir.path(), &["run", "build"]);
+    assert!(output.status.success(), "real run should succeed");
+
+    // Second: dry run should see cache hits
+    let output = run_turbo(tempdir.path(), &["run", "build", "--dry=json"]);
+    assert!(output.status.success(), "dry run should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("failed to parse dry run JSON: {e}\nstdout: {stdout}"));
+
+    let tasks = json["tasks"].as_array().expect("tasks should be an array");
+    for task in tasks {
+        let task_id = task["taskId"].as_str().unwrap_or("<unknown>");
+        let command = task["command"].as_str().unwrap_or("");
+        // Skip tasks that don't have a real command (transit nodes, etc.)
+        if command == "<NONEXISTENT>" {
+            continue;
+        }
+        let status = task["cache"]["status"].as_str().unwrap_or("UNKNOWN");
+        assert_eq!(
+            status, "HIT",
+            "task {task_id} should be a cache HIT in dry run after a real run"
+        );
+    }
+}
+
+#[test]
+fn test_dry_run_respects_cache_false() {
+    // When a task has cache:false, --dry=json should report MISS,
+    // matching what a normal run would do (cache bypass).
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+
+    // Replace turbo.json with a config that disables caching for build
+    std::fs::write(
+        tempdir.path().join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "tasks": {
+    "build": {
+      "cache": false
+    }
+  }
+}"#,
+    )
+    .unwrap();
+    git(
+        tempdir.path(),
+        &["commit", "-am", "disable cache", "--quiet"],
+    );
+
+    // Real run (cache won't be written since cache:false)
+    let output = run_turbo(tempdir.path(), &["run", "build"]);
+    assert!(output.status.success());
+
+    // Dry run should also report MISS since caching is disabled
+    let output = run_turbo(tempdir.path(), &["run", "build", "--dry=json"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("failed to parse dry run JSON: {e}\nstdout: {stdout}"));
+
+    let tasks = json["tasks"].as_array().expect("tasks should be an array");
+    for task in tasks {
+        let command = task["command"].as_str().unwrap_or("");
+        if command == "<NONEXISTENT>" {
+            continue;
+        }
+        let task_id = task["taskId"].as_str().unwrap_or("<unknown>");
+        let status = task["cache"]["status"].as_str().unwrap_or("UNKNOWN");
+        assert_eq!(
+            status, "MISS",
+            "task {task_id} with cache:false should be MISS in dry run"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- `TaskCache::exists()` (used by `--dry`) was missing the `caching_disabled` and `reads_disabled` guard checks that `restore_outputs()` (used by normal runs) performs. This caused `--dry=json` to report incorrect cache status when `cache: false` was set on a task or when cache reads were globally disabled.
- Adds two integration tests: one verifying dry run reports HIT after a real run populates the cache, and one verifying dry run reports MISS when `cache: false` is configured.

Closes #9044