### PR TITLE
feat: Add `packagesFromLockfile()` NAPI binding to `@turbo/repository`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7842,6 +7842,7 @@ dependencies = [
  "tokio",
  "tracing",
  "turbopath",
+ "turborepo-lockfiles",
  "turborepo-repository",
  "turborepo-scm",
 ]

--- a/packages/turbo-repository/__tests__/lockfile-packages.test.ts
+++ b/packages/turbo-repository/__tests__/lockfile-packages.test.ts
@@ -1,0 +1,54 @@
+import { describe, it } from "node:test";
+import { strict as assert } from "node:assert";
+import * as path from "node:path";
+import { Workspace } from "../js/dist/index.js";
+
+const PNPM_MONOREPO_PATH = path.resolve(__dirname, "./fixtures/monorepo");
+const NPM_MONOREPO_PATH = path.resolve(__dirname, "./fixtures/npm-monorepo");
+
+describe("packagesFromLockfile", () => {
+  it("returns external packages from a pnpm lockfile", async () => {
+    const workspace = await Workspace.find(PNPM_MONOREPO_PATH);
+    const packages = await workspace.packagesFromLockfile();
+
+    assert.ok(Array.isArray(packages), "Expected an array");
+    assert.ok(packages.length > 0, "Expected at least one package");
+    assert.ok(
+      packages.includes("npm/microdiff@1.4.0"),
+      `Expected npm/microdiff@1.4.0, got: ${JSON.stringify(packages)}`
+    );
+  });
+
+  it("returns an empty array when there are no external dependencies", async () => {
+    const workspace = await Workspace.find(NPM_MONOREPO_PATH);
+    const packages = await workspace.packagesFromLockfile();
+
+    assert.ok(Array.isArray(packages), "Expected an array");
+    assert.equal(packages.length, 0, "Expected no packages");
+  });
+
+  it("returns sorted results with npm/ prefix", async () => {
+    const workspace = await Workspace.find(PNPM_MONOREPO_PATH);
+    const packages = await workspace.packagesFromLockfile();
+
+    for (const pkg of packages) {
+      assert.ok(pkg.startsWith("npm/"), `Expected npm/ prefix, got: ${pkg}`);
+      assert.match(
+        pkg,
+        /^npm\/.+@.+$/,
+        `Expected format npm/<name>@<version>, got: ${pkg}`
+      );
+    }
+
+    const sorted = [...packages].sort();
+    assert.deepEqual(packages, sorted, "Expected sorted output");
+  });
+
+  it("contains no duplicates", async () => {
+    const workspace = await Workspace.find(PNPM_MONOREPO_PATH);
+    const packages = await workspace.packagesFromLockfile();
+
+    const unique = new Set(packages);
+    assert.equal(packages.length, unique.size, "Expected no duplicate entries");
+  });
+});

--- a/packages/turbo-repository/js/index.d.ts
+++ b/packages/turbo-repository/js/index.d.ts
@@ -50,6 +50,12 @@ export class Workspace {
    */
   findPackagesWithGraph(): Promise<Record<string, PackageDetails>>;
   /**
+   * Returns all external packages from the lockfile as `npm/<name>@<version>` strings.
+   * Collects the transitive external dependencies of every workspace package
+   * and formats them using the lockfile's human-readable name.
+   */
+  packagesFromLockfile(): Promise<Array<string>>;
+  /**
    * Given a set of "changed" files, returns a set of packages that are
    * "affected" by the changes. The `files` argument is expected to be a list
    * of strings relative to the monorepo root and use the current system's

--- a/packages/turbo-repository/rust/Cargo.toml
+++ b/packages/turbo-repository/rust/Cargo.toml
@@ -17,6 +17,7 @@ napi-derive = "2.14.0"
 thiserror = { workspace = true }
 tokio = { workspace = true }
 turbopath = { workspace = true }
+turborepo-lockfiles = { workspace = true }
 turborepo-repository = { workspace = true }
 turborepo-scm = { workspace = true }
 tracing = "0.1.37"

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -1,9 +1,6 @@
 #![allow(clippy::result_large_err)]
 
-use std::{
-    collections::{HashMap, HashSet},
-    hash::Hash,
-};
+use std::collections::{HashMap, HashSet};
 
 use either::Either;
 use napi::Error;
@@ -188,6 +185,31 @@ impl Workspace {
             .collect();
 
         Ok(map)
+    }
+
+    /// Returns all external packages from the lockfile as
+    /// `npm/<name>@<version>` strings. Collects the transitive external
+    /// dependencies of every workspace package and formats them using the
+    /// lockfile's human-readable name.
+    #[napi]
+    pub async fn packages_from_lockfile(&self) -> Result<Vec<String>, napi::Error> {
+        let lockfile = self
+            .graph
+            .lockfile()
+            .ok_or_else(|| napi::Error::from_reason("No lockfile found"))?;
+
+        let mut seen = HashSet::new();
+        let mut result: Vec<String> = self
+            .graph
+            .packages()
+            .filter_map(|(_name, info)| info.transitive_dependencies.as_ref())
+            .flatten()
+            .filter(|pkg| seen.insert(&pkg.key))
+            .filter_map(|pkg| lockfile.human_name(pkg).map(|name| format!("npm/{name}")))
+            .collect();
+
+        result.sort();
+        Ok(result)
     }
 
     pub fn get_lockfile_contents(


### PR DESCRIPTION
## Summary

- Adds `workspace.packagesFromLockfile()` to `@turbo/repository`, returning all transitive external dependencies as `npm/<name>@<version>` strings
- Leverages the already-computed `transitive_dependencies` from `PackageGraph` and each lockfile's `human_name()` formatter -- no new Rust public API or lockfile parser changes

## Usage

```typescript
import { Workspace } from "@turbo/repository";

const workspace = await Workspace.find();
const packages: string[] = await workspace.packagesFromLockfile();
// ["npm/@types/react@18.2.0", "npm/react@18.2.0", ...]
```

Works with all supported lockfile formats (npm, pnpm, yarn classic, yarn berry, bun).

## Testing

New test file `__tests__/lockfile-packages.test.ts` covers:
- pnpm fixture returns expected `npm/microdiff@1.4.0`
- npm fixture with no external deps returns `[]`
- All entries match `npm/<name>@<version>` format
- Output is sorted and deduplicated