### PR TITLE
fix: Resolve generator name conflicts across workspaces

### DIFF
--- a/packages/turbo-gen/src/commands/run/prompts.ts
+++ b/packages/turbo-gen/src/commands/run/prompts.ts
@@ -4,7 +4,47 @@ import {
   Separator
 } from "@inquirer/prompts";
 import { logger } from "@turbo/utils";
-import type { Generator } from "../../utils/plop";
+import {
+  qualifiedName,
+  parseQualifiedName,
+  type Generator
+} from "../../utils/plop";
+
+function findGenerator(
+  generators: Array<Generator | Separator>,
+  name: string
+): Generator | undefined {
+  const parsed = parseQualifiedName(name);
+
+  if (parsed) {
+    return generators.find(
+      (g): g is Generator =>
+        !(g instanceof Separator) &&
+        g.name === parsed.generator &&
+        g.workspace === parsed.workspace
+    );
+  }
+
+  const matches = generators.filter(
+    (g): g is Generator => !(g instanceof Separator) && g.name === name
+  );
+
+  if (matches.length === 1) {
+    return matches[0];
+  }
+
+  if (matches.length > 1) {
+    logger.warn(
+      `Multiple generators named "${name}" found. Use a qualified name to disambiguate:`
+    );
+    for (const m of matches) {
+      logger.item(qualifiedName(m));
+    }
+    logger.log();
+  }
+
+  return undefined;
+}
 
 export async function customGenerators({
   generators,
@@ -12,31 +52,27 @@ export async function customGenerators({
 }: {
   generators: Array<Generator | Separator>;
   generator?: string;
-}) {
+}): Promise<{ selectedGenerator: Generator }> {
   if (generator) {
-    if (
-      generators.some((g) => !(g instanceof Separator) && g.name === generator)
-    ) {
-      return {
-        selectedGenerator: generator
-      };
+    const match = findGenerator(generators, generator);
+    if (match) {
+      return { selectedGenerator: match };
     }
 
     logger.warn(`Generator "${generator}" not found`);
     logger.log();
   }
 
-  const selectedGenerator = await select({
+  const selectedGenerator = await select<Generator>({
     message: `Select generator to run`,
     choices: generators.map((gen) => {
       if (gen instanceof Separator) {
         return gen;
       }
+      const qName = qualifiedName(gen);
       return {
-        name: gen.description
-          ? `  ${gen.name}: ${gen.description}`
-          : `  ${gen.name}`,
-        value: gen.name
+        name: gen.description ? `  ${qName}: ${gen.description}` : `  ${qName}`,
+        value: gen
       };
     })
   });

--- a/packages/turbo-gen/src/utils/plop.ts
+++ b/packages/turbo-gen/src/utils/plop.ts
@@ -24,81 +24,70 @@ const SUPPORTED_ROOT_GENERATOR_CONFIGS = [
 export type Generator = PlopGenerator & {
   basePath: string;
   name: string;
+  workspace: string;
+  configPath: string;
+  destBasePath: string;
 };
 
-export async function getPlop({
-  project,
-  configPath
-}: {
-  project: Project;
-  configPath?: string;
-}): Promise<NodePlopAPI | undefined> {
-  const workspaceConfigs = getWorkspaceGeneratorConfigs({ project });
-  let plop: NodePlopAPI | undefined;
+interface GeneratorConfig {
+  config: string;
+  root: string;
+  workspace: string;
+}
 
+async function createPlopFromConfig(
+  configPath: string,
+  destBasePath: string
+): Promise<NodePlopAPI | undefined> {
   try {
-    if (configPath) {
-      if (!fs.existsSync(configPath)) {
-        throw new GeneratorError(`No config at "${configPath}"`, {
-          type: "plop_no_config"
-        });
-      }
+    return await nodePlop(await bundleConfigForLoading(configPath), {
+      destBasePath,
+      force: false
+    });
+  } catch (e) {
+    logger.error(e);
+    return undefined;
+  }
+}
 
-      try {
-        plop = await nodePlop(await bundleConfigForLoading(configPath), {
-          destBasePath: configPath,
-          force: false
-        });
-      } catch (e) {
-        logger.error(e);
-      }
-    } else {
-      for (const possiblePath of SUPPORTED_ROOT_GENERATOR_CONFIGS) {
-        const plopFile = path.join(project.paths.root, possiblePath);
-        if (!fs.existsSync(plopFile)) {
-          continue;
-        }
-
-        try {
-          plop = await nodePlop(await bundleConfigForLoading(plopFile), {
-            destBasePath: project.paths.root,
-            force: false
-          });
-          break;
-        } catch (e) {
-          logger.error(e);
-        }
-      }
-
-      if (!plop && workspaceConfigs.length > 0) {
-        plop = await nodePlop(
-          await bundleConfigForLoading(workspaceConfigs[0].config),
-          {
-            destBasePath: workspaceConfigs[0].root,
-            force: false
-          }
-        );
-        workspaceConfigs.shift();
-      }
+function discoverGeneratorConfigs(
+  project: Project,
+  configPath?: string
+): Array<GeneratorConfig> {
+  if (configPath) {
+    if (!fs.existsSync(configPath)) {
+      throw new GeneratorError(`No config at "${configPath}"`, {
+        type: "plop_no_config"
+      });
     }
-
-    if (plop) {
-      for (const c of workspaceConfigs) {
-        try {
-          await plop.load(await bundleConfigForLoading(c.config), {
-            destBasePath: c.root,
-            force: false
-          });
-        } catch (e) {
-          logger.error(e);
-        }
-      }
-    }
-  } finally {
-    cleanupBundledConfigs();
+    return [{ config: configPath, root: configPath, workspace: "root" }];
   }
 
-  return plop;
+  const configs: Array<GeneratorConfig> = [];
+
+  for (const possiblePath of SUPPORTED_ROOT_GENERATOR_CONFIGS) {
+    const plopFile = path.join(project.paths.root, possiblePath);
+    if (fs.existsSync(plopFile)) {
+      configs.push({
+        config: plopFile,
+        root: project.paths.root,
+        workspace: "root"
+      });
+      break;
+    }
+  }
+
+  for (const entry of getWorkspaceGeneratorConfigs({ project })) {
+    const workspace = project.workspaceData.workspaces.find(
+      (w) => w.paths.root === entry.root
+    );
+    configs.push({
+      ...entry,
+      workspace: workspace?.name ?? path.basename(entry.root)
+    });
+  }
+
+  return configs;
 }
 
 export async function getCustomGenerators({
@@ -108,75 +97,55 @@ export async function getCustomGenerators({
   project: Project;
   configPath?: string;
 }): Promise<Array<Generator | InstanceType<typeof Separator>>> {
-  const plop = await getPlop({ project, configPath });
-
-  if (!plop) {
-    return [];
-  }
-
-  const gens = plop.getGeneratorList();
-  const gensWithDetails = gens.map((g) => plop.getGenerator(g.name));
+  const configs = discoverGeneratorConfigs(project, configPath);
 
   const gensByWorkspace: Record<string, Array<Generator>> = {};
-  for (const g of gensWithDetails) {
-    const generatorDetails = g as Generator;
-    const gensWorkspace = project.workspaceData.workspaces.find((w) => {
-      if (generatorDetails.basePath === project.paths.root) {
-        return false;
-      }
-      const parts = generatorDetails.basePath.split(path.sep);
-      parts.pop();
-      parts.pop();
-      const workspaceRoot = path.join("/", ...parts);
-      return workspaceRoot === w.paths.root;
-    });
-
-    if (gensWorkspace) {
-      if (!(gensWorkspace.name in gensByWorkspace)) {
-        gensByWorkspace[gensWorkspace.name] = [];
-      }
-      gensByWorkspace[gensWorkspace.name].push(generatorDetails);
-    } else {
-      if (!("root" in gensByWorkspace)) {
-        gensByWorkspace.root = [];
-      }
-      gensByWorkspace.root.push(generatorDetails);
-    }
-  }
-
-  const gensWithSeparators: Array<Generator | InstanceType<typeof Separator>> =
-    [];
-  for (const group of Object.keys(gensByWorkspace)) {
-    gensWithSeparators.push(new Separator(group));
-    gensWithSeparators.push(...gensByWorkspace[group]);
-  }
-
-  return gensWithSeparators;
-}
-
-export async function getCustomGenerator({
-  project,
-  generator,
-  configPath
-}: {
-  project: Project;
-  generator: string;
-  configPath?: string;
-}): Promise<string | undefined> {
-  const plop = await getPlop({ project, configPath });
-  if (!plop) {
-    return undefined;
-  }
 
   try {
-    const gen = plop.getGenerator(generator) as PlopGenerator | undefined;
-    if (gen) {
-      return generator;
+    for (const conf of configs) {
+      const plop = await createPlopFromConfig(conf.config, conf.root);
+      if (!plop) {
+        continue;
+      }
+
+      for (const g of plop.getGeneratorList()) {
+        const gen = plop.getGenerator(g.name) as Generator;
+        gen.workspace = conf.workspace;
+        gen.configPath = conf.config;
+        gen.destBasePath = conf.root;
+
+        gensByWorkspace[conf.workspace] ??= [];
+        gensByWorkspace[conf.workspace].push(gen);
+      }
     }
-    return undefined;
-  } catch (e) {
-    return undefined;
+  } finally {
+    cleanupBundledConfigs();
   }
+
+  const result: Array<Generator | InstanceType<typeof Separator>> = [];
+  for (const [workspace, gens] of Object.entries(gensByWorkspace)) {
+    result.push(new Separator(workspace));
+    result.push(...gens);
+  }
+  return result;
+}
+
+export function qualifiedName(gen: Generator): string {
+  return `${gen.workspace}/${gen.name}`;
+}
+
+export function parseQualifiedName(name: string): {
+  workspace: string;
+  generator: string;
+} | null {
+  const slashIndex = name.indexOf("/");
+  if (slashIndex === -1) {
+    return null;
+  }
+  return {
+    workspace: name.slice(0, slashIndex),
+    generator: name.slice(slashIndex + 1)
+  };
 }
 
 function injectTurborepoData({
@@ -380,22 +349,38 @@ export async function runCustomGenerator({
   configPath
 }: {
   project: Project;
-  generator: string;
+  generator: Generator;
   bypassArgs?: Array<string>;
   configPath?: string;
 }): Promise<void> {
-  const plop = await getPlop({ project, configPath });
+  const resolvedConfigPath = configPath ?? generator.configPath;
+  const destBasePath = configPath ?? generator.destBasePath;
+
+  let plop: NodePlopAPI | undefined;
+  try {
+    plop = await createPlopFromConfig(resolvedConfigPath, destBasePath);
+  } finally {
+    cleanupBundledConfigs();
+  }
+
   if (!plop) {
     throw new GeneratorError("Unable to load generators", {
       type: "plop_unable_to_load_config"
     });
   }
-  const gen = plop.getGenerator(generator) as PlopGenerator | undefined;
+
+  let gen: PlopGenerator | undefined;
+  try {
+    gen = plop.getGenerator(generator.name) as PlopGenerator | undefined;
+  } catch {
+    // plop throws when generator not found
+  }
 
   if (!gen) {
-    throw new GeneratorError(`Generator ${generator} not found`, {
-      type: "plop_generator_not_found"
-    });
+    throw new GeneratorError(
+      `Generator ${qualifiedName(generator)} not found`,
+      { type: "plop_generator_not_found" }
+    );
   }
 
   const answers = (await gen.runPrompts(bypassArgs)) as Array<unknown>;
@@ -416,9 +401,10 @@ export async function runCustomGenerator({
         logger.error(`Error - ${f.error}. Unable to ${f.type} to "${f.path}"`);
       }
     }
-    throw new GeneratorError(`Failed to run "${generator}" generator`, {
-      type: "plop_error_running_generator"
-    });
+    throw new GeneratorError(
+      `Failed to run "${qualifiedName(generator)}" generator`,
+      { type: "plop_error_running_generator" }
+    );
   }
 
   if (results.changes.length > 0) {


### PR DESCRIPTION
## Summary

Fixes #6215

- When multiple workspaces define a generator with the same name (e.g., `component`), only one would show up in `turbo gen` because all configs were loaded into a single `node-plop` instance — the last one silently overwrote earlier registrations.
- Each workspace config now gets its own plop instance during discovery, so same-named generators from different workspaces coexist correctly.
- Generators carry a qualified identifier (`workspace/name`) that's displayed in the selection prompt and used for unambiguous lookup. Unqualified names still work when there's only one match (backward compat).

## How to test

1. Create two workspaces with `turbo/generators/config.ts`, both registering a generator named `component`
2. Run `turbo gen`
3. **Before**: only one `component` generator visible
4. **After**: both visible as `ui-kit/component` and `webapp/component` under their workspace headers

Passing a generator name via CLI (`turbo gen run component`) still works when unambiguous. When ambiguous, you get a helpful message listing the qualified alternatives.