### PR TITLE
fix: Remove root package.json from `--affected` global triggers

### DIFF
--- a/crates/turborepo-lib/src/task_change_detector.rs
+++ b/crates/turborepo-lib/src/task_change_detector.rs
@@ -21,7 +21,7 @@ use crate::engine::Engine;
 /// - `turbo.json`/`turbo.jsonc`: task definitions, global deps, pipelines
 ///
 /// Lockfile changes are detected separately via the package manager.
-const DEFAULT_GLOBAL_DEPS: &[&str] = &["package.json", "turbo.json", "turbo.jsonc"];
+const DEFAULT_GLOBAL_DEPS: &[&str] = &["turbo.json", "turbo.jsonc"];
 
 /// Determines which tasks are directly affected by the given set of changed
 /// files. Does NOT include transitive dependents — use
@@ -201,7 +201,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn global_package_json_change_returns_all() {
+    async fn root_package_json_change_is_not_global() {
         let tmp = tempfile::tempdir().unwrap();
         let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
         let pkg_graph = make_pkg_graph(root, &["lib-a"]).await;
@@ -216,10 +216,13 @@ mod tests {
             &[],
         );
 
+        // root package.json is not in the global hash (when a lockfile exists),
+        // so changing it should not affect all tasks.
         let result = affected_task_ids(&engine, &pkg_graph, &changed(&["package.json"]), &[]);
-        assert_eq!(result.len(), 2);
-        assert!(result.contains(&a_build));
-        assert!(result.contains(&a_test));
+        assert!(
+            result.is_empty(),
+            "root package.json should not globally affect tasks: {result:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/turborepo-repository/src/change_mapper/mod.rs
+++ b/crates/turborepo-repository/src/change_mapper/mod.rs
@@ -20,7 +20,7 @@ use crate::package_graph::{
 
 mod package;
 
-const DEFAULT_GLOBAL_DEPS: &[&str] = ["package.json", "turbo.json", "turbo.jsonc"].as_slice();
+const DEFAULT_GLOBAL_DEPS: &[&str] = ["turbo.json", "turbo.jsonc"].as_slice();
 
 // We may not be able to load the lockfile contents, but we
 // still want to be able to express a generic change.

--- a/crates/turborepo-repository/src/change_mapper/package.rs
+++ b/crates/turborepo-repository/src/change_mapper/package.rs
@@ -283,4 +283,110 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn root_package_json_not_global_with_global_deps_mapper() -> Result<(), anyhow::Error> {
+        let repo_root = tempdir()?;
+        let pkg_graph = PackageGraphBuilder::new(
+            AbsoluteSystemPath::from_std_path(repo_root.path())?,
+            PackageJson::default(),
+        )
+        .with_package_discovery(MockDiscovery)
+        .build()
+        .await?;
+
+        let detector = GlobalDepsPackageChangeMapper::new(&pkg_graph, std::iter::empty::<&str>())?;
+        let change_mapper = ChangeMapper::new(&pkg_graph, vec![], detector);
+
+        // root package.json is not in the global hash when a lockfile exists,
+        // so it should only affect the root workspace — not all packages.
+        let result = change_mapper.changed_packages(
+            [AnchoredSystemPathBuf::from_raw("package.json")?]
+                .into_iter()
+                .collect(),
+            LockfileContents::Unchanged,
+        )?;
+
+        assert_eq!(
+            result,
+            PackageChanges::Some(
+                [(
+                    WorkspacePackage::root(),
+                    PackageInclusionReason::FileChanged {
+                        file: AnchoredSystemPathBuf::from_raw("package.json")?,
+                    }
+                )]
+                .into_iter()
+                .collect()
+            )
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn turbo_json_still_global() -> Result<(), anyhow::Error> {
+        let repo_root = tempdir()?;
+        let pkg_graph = PackageGraphBuilder::new(
+            AbsoluteSystemPath::from_std_path(repo_root.path())?,
+            PackageJson::default(),
+        )
+        .with_package_discovery(MockDiscovery)
+        .build()
+        .await?;
+
+        let detector = GlobalDepsPackageChangeMapper::new(&pkg_graph, std::iter::empty::<&str>())?;
+        let change_mapper = ChangeMapper::new(&pkg_graph, vec![], detector);
+
+        // turbo.json task definitions are part of every task hash,
+        // so it must remain a global trigger.
+        let result = change_mapper.changed_packages(
+            [AnchoredSystemPathBuf::from_raw("turbo.json")?]
+                .into_iter()
+                .collect(),
+            LockfileContents::Unchanged,
+        )?;
+
+        assert_eq!(
+            result,
+            PackageChanges::All(AllPackageChangeReason::DefaultGlobalFileChanged {
+                file: AnchoredSystemPathBuf::from_raw("turbo.json")?,
+            })
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn package_json_in_global_deps_triggers_all() -> Result<(), anyhow::Error> {
+        let repo_root = tempdir()?;
+        let pkg_graph = PackageGraphBuilder::new(
+            AbsoluteSystemPath::from_std_path(repo_root.path())?,
+            PackageJson::default(),
+        )
+        .with_package_discovery(MockDiscovery)
+        .build()
+        .await?;
+
+        // Users can opt-in to the old behavior via globalDependencies.
+        let detector =
+            GlobalDepsPackageChangeMapper::new(&pkg_graph, ["package.json"].into_iter())?;
+        let change_mapper = ChangeMapper::new(&pkg_graph, vec![], detector);
+
+        let result = change_mapper.changed_packages(
+            [AnchoredSystemPathBuf::from_raw("package.json")?]
+                .into_iter()
+                .collect(),
+            LockfileContents::Unchanged,
+        )?;
+
+        assert_eq!(
+            result,
+            PackageChanges::All(AllPackageChangeReason::GlobalDepsChanged {
+                file: AnchoredSystemPathBuf::from_raw("package.json")?,
+            })
+        );
+
+        Ok(())
+    }
 }

--- a/crates/turborepo/tests/affected_test.rs
+++ b/crates/turborepo/tests/affected_test.rs
@@ -676,11 +676,12 @@ fn test_affected_tasks_md_change_no_propagation() {
 }
 
 #[test]
-fn test_affected_tasks_default_global_file_change() {
+fn test_root_package_json_change_does_not_globally_affect_tasks() {
     let tempdir = tempfile::tempdir().unwrap();
     setup_affected_tasks_fixture(tempdir.path());
 
-    // package.json is a default global file — changing it marks everything affected
+    // root package.json is not in the global hash (when a lockfile exists),
+    // so changing it should not mark all tasks as affected.
     let root_pkg = tempdir.path().join("package.json");
     let contents = fs::read_to_string(&root_pkg).unwrap();
     let mut pkg: serde_json::Value = serde_json::from_str(&contents).unwrap();
@@ -689,22 +690,14 @@ fn test_affected_tasks_default_global_file_change() {
 
     let output = run_turbo(
         tempdir.path(),
-        &[
-            "query",
-            "query { affectedTasks { length items { reason { __typename } } } }",
-        ],
+        &["query", "query { affectedTasks { length } }"],
     );
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     let length = json["data"]["affectedTasks"]["length"].as_i64().unwrap();
-    assert!(length > 0, "all tasks should be affected");
-
-    let items = json["data"]["affectedTasks"]["items"].as_array().unwrap();
-    for item in items {
-        assert_eq!(
-            item["reason"]["__typename"], "TaskGlobalFileChanged",
-            "default global file change should produce TaskGlobalFileChanged: {item:?}"
-        );
-    }
+    assert_eq!(
+        length, 0,
+        "root package.json change should not globally affect tasks"
+    );
 }
 
 #[test]
@@ -971,11 +964,12 @@ fn test_task_level_affected_test_file_excludes_typecheck() {
 }
 
 #[test]
-fn test_task_level_affected_global_file_runs_everything() {
+fn test_task_level_affected_root_package_json_not_global() {
     let tempdir = tempfile::tempdir().unwrap();
     setup_task_level_affected(tempdir.path());
 
-    // Change root package.json — a default global dependency.
+    // root package.json is not in the global hash when a lockfile exists,
+    // so changing it should not cause all tasks to be affected.
     let root_pkg = tempdir.path().join("package.json");
     let contents = fs::read_to_string(&root_pkg).unwrap();
     let mut pkg: serde_json::Value = serde_json::from_str(&contents).unwrap();
@@ -999,28 +993,9 @@ fn test_task_level_affected_global_file_runs_everything() {
         .unwrap_or_else(|e| panic!("failed to parse dry run JSON: {e}\nstdout: {stdout}"));
 
     let tasks = json["tasks"].as_array().expect("tasks array");
-    let task_ids: Vec<&str> = tasks
-        .iter()
-        .map(|t| t["taskId"].as_str().unwrap())
-        .collect();
-
-    // All tasks in both packages should be affected when a global file changes.
     assert!(
-        task_ids.contains(&"lib-a#build"),
-        "global change should affect all tasks: {task_ids:?}"
-    );
-    assert!(
-        task_ids.contains(&"lib-a#test"),
-        "global change should affect all tasks: {task_ids:?}"
-    );
-    assert!(
-        task_ids.contains(&"app-a#build"),
-        "global change should affect all tasks: {task_ids:?}"
-    );
-    assert!(
-        task_ids.len() >= 4,
-        "global change should affect many tasks, got {}: {task_ids:?}",
-        task_ids.len()
+        tasks.is_empty(),
+        "root package.json change should not globally affect tasks: {tasks:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes #10869

- Removes `package.json` from the hardcoded `DEFAULT_GLOBAL_DEPS` list that triggers all-packages-affected

## Why

Root `package.json` is not part of the global hash when a lockfile exists (the normal case). Changing it was incorrectly marking all packages as affected via `--affected`, while `--dry=json` correctly showed cache HITs. This caused `turbo ls --affected` and `turbo run --affected` to over-select packages on any root `package.json` change, including whitespace-only edits.

Dependency changes that actually matter (adding/removing deps) also modify the lockfile, which `--affected` already detects separately.

## What stays the same

- `turbo.json` / `turbo.jsonc` remain global triggers — their parsed task definitions are part of every `TaskHashable`, so changes can cause cache misses
- Lockfile changes remain global triggers
- User-configured `globalDependencies` still work — users can add `package.json` there to restore the old behavior

## Testing

To verify: create a turborepo, run `turbo build` to populate cache, make a whitespace change to root `package.json`, then compare `turbo ls --affected` with `turbo build --dry=json`. They should now agree (no affected packages, all cache HITs).