### PR TITLE
fix: Show run summary after TUI exits

### DIFF
--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -537,11 +537,10 @@ impl<'a> Visitor<'a> {
         }
         drop(factory);
 
-        if !self.is_watch {
-            if let Some(handle) = &self.ui_sender {
-                handle.stop().await;
-            }
-        }
+        // Don't send Event::Stop here. The caller (commands/run.rs) sends Stop
+        // after run.run() returns, which is after visitor.finish() has emitted
+        // the run summary through the logger. Stopping the TUI here would kill
+        // the event loop before the summary events reach app.log_events.
 
         // Propagate the dispatch error first — the engine error is an expected
         // consequence of us closing the channel early, not a root cause.

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -621,6 +621,23 @@ impl<W> App<W> {
         Ok(())
     }
 
+    /// Write the run summary (Tasks/Cached/Time) to stdout after TUI cleanup.
+    ///
+    /// These events were emitted by `ExecutionSummary::print()` while the TUI
+    /// owned the screen. They're already stored in `self.log_events` with ANSI
+    /// color codes baked in — we just need to replay the `Subsystem::Summary`
+    /// subset to the terminal now that we've left the alternate screen.
+    pub fn persist_summary(&self) -> std::io::Result<()> {
+        let mut stdout = std::io::stdout().lock();
+        for event in &self.log_events {
+            if event.source() == &turborepo_log::Source::turbo(turborepo_log::Subsystem::Summary) {
+                stdout.write_all(event.message().as_bytes())?;
+                stdout.write_all(b"\r\n")?;
+            }
+        }
+        Ok(())
+    }
+
     #[tracing::instrument(skip(self))]
     pub fn set_status(
         &mut self,
@@ -818,6 +835,7 @@ pub async fn run_app(
         // Even if TUI never started, still persist task output and flush preferences
         let tasks_started = app.tasks_by_status.tasks_started();
         app.persist_tasks(tasks_started)?;
+        app.persist_summary()?;
         app.preferences.flush_to_disk().ok();
         if let Some(callback) = callback {
             // Signal completion even if we never started the terminal
@@ -1030,6 +1048,7 @@ fn cleanup<B: Backend<Error = io::Error> + io::Write>(
 
     let tasks_started = app.tasks_by_status.tasks_started();
     app.persist_tasks(tasks_started)?;
+    app.persist_summary()?;
     app.preferences.flush_to_disk().ok();
     crossterm::terminal::disable_raw_mode()?;
     terminal.show_cursor()?;


### PR DESCRIPTION
## Summary

- The run summary (Tasks/Cached/Time) was never printed when using the TUI because `visitor.visit()` sent `Event::Stop` to the TUI before `visitor.finish()` had a chance to emit the summary log events via `ExecutionSummary::print()`. By the time the summary was emitted, the TUI event loop had already exited and the events were dropped.
- Removes the early Stop from `visitor.visit()` — `commands/run.rs` already sends Stop after `run.run()` returns, which is after the summary is emitted.
- Adds `persist_summary()` to replay `Subsystem::Summary` log events to stdout during TUI cleanup (both the terminal-started and all-cache-hits paths).

## How to test

1. Run `turbo run build` (or any task) with the TUI enabled
2. After the TUI exits, the summary should now appear below the task output:
   ```
    Tasks:    3 successful, 3 total
   Cached:    2 cached, 3 total
     Time:    1.5s
   ```
3. Verify it works for both cache-miss runs (TUI renders) and fully-cached runs (TUI never starts the alternate screen)