### PR TITLE
fix: Handle Yarn 2+ in @turbo/codemod install commands

### DIFF
--- a/packages/turbo-codemod/__tests__/get-turbo-upgrade-command.test.ts
+++ b/packages/turbo-codemod/__tests__/get-turbo-upgrade-command.test.ts
@@ -239,6 +239,36 @@ const LOCAL_INSTALL_COMMANDS: Array<TestCase> = [
     packageManagerVersion: "3.3.4",
     fixture: "single-package",
     expected: "yarn add turbo@latest"
+  },
+  // yarn 4.x - workspaces
+  {
+    version: "latest",
+    packageManager: "yarn",
+    packageManagerVersion: "4.1.0",
+    fixture: "normal-workspaces-dev-install",
+    expected: "yarn add turbo@latest --dev"
+  },
+  {
+    version: "latest",
+    packageManager: "yarn",
+    packageManagerVersion: "4.1.0",
+    fixture: "normal-workspaces",
+    expected: "yarn add turbo@latest"
+  },
+  // yarn 4.x - single package
+  {
+    version: "latest",
+    packageManager: "yarn",
+    packageManagerVersion: "4.1.0",
+    fixture: "single-package-dev-install",
+    expected: "yarn add turbo@latest --dev"
+  },
+  {
+    version: "latest",
+    packageManager: "yarn",
+    packageManagerVersion: "4.1.0",
+    fixture: "single-package",
+    expected: "yarn add turbo@latest"
   }
 ];
 
@@ -351,77 +381,106 @@ const GLOBAL_INSTALL_COMMANDS: Array<TestCase> = [
     fixture: "single-package-dev-install",
     expected: "yarn global add turbo@latest"
   },
-  // yarn 2.x
+  // yarn 2.x - falls through to local install (yarn 2+ has no `yarn global`)
   {
     version: "latest",
     packageManager: "yarn",
     packageManagerVersion: "2.3.4",
     fixture: "normal-workspaces-dev-install",
-    expected: "yarn global add turbo@latest"
+    expected: "yarn add turbo@latest --dev"
   },
   {
     version: "latest",
     packageManager: "yarn",
     packageManagerVersion: "2.3.4",
     fixture: "normal-workspaces",
-    expected: "yarn global add turbo@latest"
+    expected: "yarn add turbo@latest"
   },
   {
     version: "1.6.3",
     packageManager: "yarn",
     packageManagerVersion: "2.3.4",
     fixture: "normal-workspaces-dev-install",
-    expected: "yarn global add turbo@1.6.3"
+    expected: "yarn add turbo@1.6.3 --dev"
   },
   {
     version: "latest",
     packageManager: "yarn",
     packageManagerVersion: "2.3.4",
     fixture: "single-package",
-    expected: "yarn global add turbo@latest"
+    expected: "yarn add turbo@latest"
   },
   {
     version: "latest",
     packageManager: "yarn",
     packageManagerVersion: "2.3.4",
     fixture: "single-package-dev-install",
-    expected: "yarn global add turbo@latest"
+    expected: "yarn add turbo@latest --dev"
   },
-  // yarn 3.x
+  // yarn 3.x - falls through to local install (yarn 3+ has no `yarn global`)
   {
     version: "latest",
     packageManager: "yarn",
     packageManagerVersion: "3.3.3",
     fixture: "normal-workspaces-dev-install",
-    expected: "yarn global add turbo@latest"
+    expected: "yarn add turbo@latest --dev"
   },
   {
     version: "latest",
     packageManager: "yarn",
     packageManagerVersion: "3.3.3",
     fixture: "normal-workspaces",
-    expected: "yarn global add turbo@latest"
+    expected: "yarn add turbo@latest"
   },
   {
     version: "1.6.3",
     packageManager: "yarn",
     packageManagerVersion: "3.3.3",
     fixture: "normal-workspaces-dev-install",
-    expected: "yarn global add turbo@1.6.3"
+    expected: "yarn add turbo@1.6.3 --dev"
   },
   {
     version: "latest",
     packageManager: "yarn",
     packageManagerVersion: "3.3.4",
     fixture: "single-package",
-    expected: "yarn global add turbo@latest"
+    expected: "yarn add turbo@latest"
   },
   {
     version: "latest",
     packageManager: "yarn",
     packageManagerVersion: "3.3.4",
     fixture: "single-package-dev-install",
-    expected: "yarn global add turbo@latest"
+    expected: "yarn add turbo@latest --dev"
+  },
+  // yarn 4.x - falls through to local install (yarn 4+ has no `yarn global`)
+  {
+    version: "latest",
+    packageManager: "yarn",
+    packageManagerVersion: "4.1.0",
+    fixture: "normal-workspaces-dev-install",
+    expected: "yarn add turbo@latest --dev"
+  },
+  {
+    version: "latest",
+    packageManager: "yarn",
+    packageManagerVersion: "4.1.0",
+    fixture: "normal-workspaces",
+    expected: "yarn add turbo@latest"
+  },
+  {
+    version: "latest",
+    packageManager: "yarn",
+    packageManagerVersion: "4.1.0",
+    fixture: "single-package",
+    expected: "yarn add turbo@latest"
+  },
+  {
+    version: "latest",
+    packageManager: "yarn",
+    packageManagerVersion: "4.1.0",
+    fixture: "single-package-dev-install",
+    expected: "yarn add turbo@latest --dev"
   }
 ];
 

--- a/packages/turbo-codemod/src/cli.ts
+++ b/packages/turbo-codemod/src/cli.ts
@@ -1,8 +1,13 @@
 #!/usr/bin/env node
 
 import picocolors from "picocolors";
-import { logger, createNotifyUpdate } from "@turbo/utils";
+import {
+  logger,
+  createNotifyUpdate,
+  getAvailablePackageManagers
+} from "@turbo/utils";
 import { getWorkspaceDetails } from "@turbo/workspaces";
+import { gte } from "semver";
 import { Command } from "commander";
 import cliPkg from "../package.json";
 import { transform, migrate } from "./commands";
@@ -15,6 +20,11 @@ const notifyUpdate = createNotifyUpdate({
         root: process.cwd()
       });
       if (packageManager === "yarn") {
+        const available = await getAvailablePackageManagers();
+        const yarnVersion = available.yarn;
+        if (yarnVersion && gte(yarnVersion, "2.0.0")) {
+          return "yarn dlx @turbo/codemod";
+        }
         return "yarn global add @turbo/codemod";
       } else if (packageManager === "pnpm") {
         return "pnpm i -g @turbo/codemod";

--- a/packages/turbo-codemod/src/commands/migrate/steps/get-turbo-upgrade-command.ts
+++ b/packages/turbo-codemod/src/commands/migrate/steps/get-turbo-upgrade-command.ts
@@ -13,12 +13,22 @@ import { exec } from "../utils";
 
 type InstallType = "dependencies" | "devDependencies";
 
-function getGlobalUpgradeCommand(
-  packageManager: PackageManager,
+function getGlobalUpgradeCommand({
+  packageManager,
+  packageManagerVersion,
   to = "latest"
-) {
+}: {
+  packageManager: PackageManager;
+  packageManagerVersion?: string;
+  to?: string;
+}): string | undefined {
   switch (packageManager) {
     case "yarn": {
+      // Yarn 2+ (Berry) removed `yarn global`. There is no global install
+      // equivalent, so return undefined to fall through to local install.
+      if (packageManagerVersion && gte(packageManagerVersion, "2.0.0")) {
+        return undefined;
+      }
       return `yarn global add turbo@${to}`;
     }
     case "npm": {
@@ -134,6 +144,8 @@ export async function getTurboUpgradeCommand({
   project: Project;
   to?: string;
 }) {
+  const availablePackageManagers = await getAvailablePackageManagers();
+
   const turboBinaryPathFromGlobal = exec("turbo bin", {
     cwd: project.paths.root,
     stdio: "pipe"
@@ -152,14 +164,21 @@ export async function getTurboUpgradeCommand({
   }) as PackageManager | undefined;
 
   if (turboBinaryPathFromGlobal && globalPackageManager) {
-    // figure which package manager we need to upgrade
-    return getGlobalUpgradeCommand(globalPackageManager, to);
+    const globalCommand = getGlobalUpgradeCommand({
+      packageManager: globalPackageManager,
+      packageManagerVersion: availablePackageManagers[globalPackageManager],
+      to
+    });
+    if (globalCommand) {
+      return globalCommand;
+    }
+    // Package manager doesn't support global installs (e.g. Yarn 2+).
+    // Fall through to local install.
   }
+
   const { packageManager } = project;
-  // we didn't find a global install, so we'll try to find a local one
   const isUsingWorkspaces = project.workspaceData.globs.length > 0;
   const installType = getInstallType({ root: project.paths.root });
-  const availablePackageManagers = await getAvailablePackageManagers();
   const version = availablePackageManagers[packageManager];
 
   if (version && installType) {


### PR DESCRIPTION
## Summary

Closes #8567

- `getGlobalUpgradeCommand()` now returns `undefined` for Yarn 2+ (Berry removed `yarn global`), causing the orchestrator to fall through to the correct local install path
- The CLI notify-update suggestion now detects Yarn version and suggests `yarn dlx @turbo/codemod` for Berry users instead of the invalid `yarn global add`
- Added Yarn 4.x test coverage to both local and global install command tests

### Why

Yarn 2+ removed `yarn global` entirely. The codemod was generating invalid install commands for any Yarn Berry project, breaking the final migration step. The local install path already handled Berry correctly via an `gte("2.0.0")` semver check, so the fix lets Berry users naturally reach that path when global install isn't possible.

### Testing

`get-turbo-upgrade-command.test.ts` covers all combinations of Yarn 1.x, 2.x, 3.x, and 4.x for both local and global install scenarios. The Yarn 2+/3+ global test cases now verify the fallthrough-to-local behavior instead of asserting the broken `yarn global add` output.