### PR TITLE
feat: Accept `experimentalCI` key in turbo.json task config

### DIFF
--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -134,6 +134,7 @@ mod tests {
             interruptible: Some(Spanned::new(true).with_range(342..346)),
             env_mode: None,
             with: None,
+            experimental_ci: None,
         },
         TaskDefinition {
           env: vec!["OS".to_string()],
@@ -182,6 +183,7 @@ mod tests {
             interactive: None,
             env_mode: None,
             with: None,
+            experimental_ci: None,
         },
         TaskDefinition {
             env: vec!["OS".to_string()],

--- a/crates/turborepo-turbo-json/src/raw.rs
+++ b/crates/turborepo-turbo-json/src/raw.rs
@@ -759,6 +759,13 @@ pub struct RawTaskDefinition {
     #[serde(rename = "with")]
     #[ts(optional)]
     pub with: Option<Vec<Spanned<UnescapedString>>>,
+
+    #[serde(rename = "experimentalCI")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[deserializable(rename = "experimentalCI")]
+    #[schemars(skip)]
+    #[ts(skip)]
+    pub experimental_ci: Option<Spanned<bool>>,
 }
 
 impl HasConfigBeyondExtends for RawTaskDefinition {


### PR DESCRIPTION
## Summary

- Adds `experimentalCI` as an accepted boolean field on `tasks.<task>` in turbo.json so the parser doesn't reject it
- The field is excluded from JSON schema, TypeScript types, and docs — it's intentionally undocumented
- Turborepo does not propagate or act on this value; it exists for external CI systems to read directly from turbo.json