### PR TITLE
fix: Skip writing unchanged files during slow-path cache restore

### DIFF
--- a/crates/turborepo-cache/src/cache_archive/restore.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore.rs
@@ -102,11 +102,20 @@ impl<'a> CacheReader<'a> {
                     symlinks.push(entry);
                 }
                 Err(e) => return Err(e),
-                Ok(restored_path) => {
+                Ok((restored_path, skipped)) => {
                     if entry_type == tar::EntryType::Regular {
-                        let resolved = anchor.resolve(&restored_path);
-                        let _ =
-                            new_manifest.record_file(restored_path.as_str().to_owned(), &resolved);
+                        let key = restored_path.as_str().to_owned();
+                        if skipped {
+                            if let Some(existing) =
+                                previous_manifest.and_then(|m| m.files.get(&key))
+                            {
+                                new_manifest.order.push(key.clone());
+                                new_manifest.files.insert(key, *existing);
+                            }
+                        } else {
+                            let resolved = anchor.resolve(&restored_path);
+                            let _ = new_manifest.record_file(key, &resolved);
+                        }
                     }
                     restored.push(restored_path);
                 }
@@ -167,18 +176,22 @@ impl<'a> CacheReader<'a> {
     }
 }
 
+/// Returns `(path, skipped)` where `skipped` is true only for regular
+/// files that matched the manifest and were not rewritten.
 fn restore_entry<T: Read>(
     dir_cache: &mut CachedDirTree,
     anchor: &AbsoluteSystemPath,
     entry: &mut Entry<T>,
     manifest: Option<&RestoreManifest>,
-) -> Result<AnchoredSystemPathBuf, CacheError> {
+) -> Result<(AnchoredSystemPathBuf, bool), CacheError> {
     let header = entry.header();
 
     match header.entry_type() {
-        tar::EntryType::Directory => restore_directory(dir_cache, anchor, entry),
+        tar::EntryType::Directory => {
+            restore_directory(dir_cache, anchor, entry).map(|p| (p, false))
+        }
         tar::EntryType::Regular => restore_regular(dir_cache, anchor, entry, manifest),
-        tar::EntryType::Symlink => restore_symlink(dir_cache, anchor, entry),
+        tar::EntryType::Symlink => restore_symlink(dir_cache, anchor, entry).map(|p| (p, false)),
         ty => Err(CacheError::RestoreUnsupportedFileType(
             ty,
             Backtrace::capture(),

--- a/crates/turborepo-cache/src/cache_archive/restore_regular.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore_regular.rs
@@ -5,12 +5,14 @@ use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, AnchoredSystemPathBuf};
 
 use crate::{CacheError, cache_archive::restore_directory::CachedDirTree};
 
+/// Returns `(path, true)` when the file was skipped (matched manifest),
+/// or `(path, false)` when it was written to disk.
 pub fn restore_regular(
     dir_cache: &mut CachedDirTree,
     anchor: &AbsoluteSystemPath,
     entry: &mut Entry<impl Read>,
     manifest: Option<&super::restore_manifest::RestoreManifest>,
-) -> Result<AnchoredSystemPathBuf, CacheError> {
+) -> Result<(AnchoredSystemPathBuf, bool), CacheError> {
     let processed_name = AnchoredSystemPathBuf::from_system_path(&entry.path()?)?;
     let resolved_path = anchor.resolve(&processed_name);
 
@@ -20,7 +22,7 @@ pub fn restore_regular(
         && manifest.file_matches(processed_name.as_str(), &resolved_path)
     {
         io::copy(entry, &mut io::sink())?;
-        return Ok(processed_name);
+        return Ok((processed_name, true));
     }
 
     dir_cache.safe_mkdir_file(anchor, &processed_name)?;
@@ -38,7 +40,7 @@ pub fn restore_regular(
     let mut file = open_options.open(resolved_path.as_path())?;
     io::copy(entry, &mut file)?;
 
-    Ok(processed_name)
+    Ok((processed_name, false))
 }
 
 impl CachedDirTree {

--- a/crates/turborepo-cache/src/fs.rs
+++ b/crates/turborepo-cache/src/fs.rs
@@ -100,9 +100,11 @@ impl FSCache {
             .cache_directory
             .join_component(&format!("{hash}-manifest.json"));
 
+        let previous_manifest = crate::cache_archive::RestoreManifest::read(&manifest_path);
+
         // Fast path: if a manifest exists and ALL files on disk still match,
         // skip opening/decompressing the tar entirely.
-        if let Some(manifest) = crate::cache_archive::RestoreManifest::read(&manifest_path)
+        if let Some(ref manifest) = previous_manifest
             && let Some(file_list) = manifest.validate_all(anchor)
         {
             let meta = CacheMetadata::read(
@@ -122,7 +124,9 @@ impl FSCache {
             )));
         }
 
-        // Slow path: decompress and extract the archive.
+        // Slow path: decompress and extract the archive. Pass any existing
+        // manifest so that individual files still matching on disk can be
+        // skipped, avoiding unnecessary writes and filesystem notifications.
         let mut cache_reader = match CacheReader::open(&cache_path) {
             Ok(reader) => reader,
             Err(CacheError::IO(ref e, _)) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -132,7 +136,8 @@ impl FSCache {
             Err(e) => return Err(e),
         };
 
-        let (restored_files, new_manifest) = cache_reader.restore(anchor, None)?;
+        let (restored_files, new_manifest) =
+            cache_reader.restore(anchor, previous_manifest.as_ref())?;
 
         let manifest_path_owned = manifest_path.to_owned();
         std::thread::spawn(move || {
@@ -719,5 +724,62 @@ mod test {
         assert_eq!(deserialized.dirty_hash, Some("cafebabe".to_string()));
         assert_eq!(deserialized.hash, "abc");
         assert_eq!(deserialized.duration, 99);
+    }
+
+    /// When the manifest fast path fails because one file changed, the slow
+    /// path should still skip writing files that haven't changed. This
+    /// prevents unnecessary filesystem notifications (inotify/fsevents) for
+    /// unchanged outputs. See https://github.com/vercel/turborepo/issues/10875
+    #[tokio::test]
+    async fn test_slow_path_skips_unchanged_files() -> Result<()> {
+        let repo_root = tempdir()?;
+        let repo_root_path = AbsoluteSystemPath::from_std_path(repo_root.path())?;
+
+        let stable_file = repo_root_path.join_component("stable.txt");
+        stable_file.create_with_contents("unchanged content")?;
+
+        let changing_file = repo_root_path.join_component("changing.txt");
+        changing_file.create_with_contents("original")?;
+
+        let files = vec![
+            AnchoredSystemPathBuf::from_raw("stable.txt")?,
+            AnchoredSystemPathBuf::from_raw("changing.txt")?,
+        ];
+        let hash = "partial_change_test";
+
+        let cache = FSCache::new(
+            Utf8Path::new("cache"),
+            repo_root_path,
+            None,
+            LazyScmState::resolved(None),
+        )?;
+        cache.put(repo_root_path, hash, &files, 50)?;
+
+        let stable_mtime_before = stable_file.symlink_metadata()?.modified()?;
+
+        // Ensure a measurable mtime gap so the overwrite (if any) is detectable.
+        std::thread::sleep(Duration::from_millis(50));
+
+        // Modify the changing file so the manifest fast-path fails.
+        changing_file.create_with_contents("modified")?;
+
+        // Fetch should hit the slow path (manifest validation fails because
+        // changing.txt has a different mtime) but pass the manifest through
+        // so stable.txt is skipped.
+        let result = cache.fetch(repo_root_path, hash)?;
+        assert!(result.is_some(), "Cache should still hit");
+
+        // stable.txt should NOT have been rewritten — its mtime must be
+        // identical to what it was before the fetch.
+        let stable_mtime_after = stable_file.symlink_metadata()?.modified()?;
+        assert_eq!(
+            stable_mtime_before, stable_mtime_after,
+            "Unchanged file should not be rewritten during slow-path restore"
+        );
+
+        // changing.txt should be restored to its original cached content.
+        assert_eq!(changing_file.read_to_string()?, "original");
+
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

When the manifest fast-path validation fails (e.g., 1 of 100 output files changed), the slow path previously rewrote **every** file from the tar archive. This triggered unnecessary filesystem notifications (inotify/fsevents) for unchanged outputs.

Now the slow path receives the previous manifest and checks each file before writing. Unchanged files are skipped — their tar bytes are drained without touching disk.

## What changed

- `FSCache::fetch` reads the manifest once and shares it between the fast path and slow path (previously it was consumed by the fast path and discarded)
- `restore_regular` returns a `(path, skipped)` tuple so the caller knows whether the file was written or skipped
- For skipped files, the existing manifest entry is carried forward directly into the new manifest, avoiding a redundant `stat()` syscall per file

## How to test

The new `test_slow_path_skips_unchanged_files` test validates the core behavior:
1. Cache two files via `put()`
2. Modify one file so the fast path fails
3. `fetch()` hits the slow path
4. Assert the unchanged file's mtime is identical (proving no write occurred)
5. Assert the changed file's content is restored from cache

```
cargo test -p turborepo-cache test_slow_path_skips_unchanged_files
```

Closes #10875