### PR TITLE
fix: Use previous minor/major tag for release notes on minor/major releases

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -168,10 +168,15 @@ jobs:
         env:
           INCREMENT: ${{ github.event_name == 'schedule' && 'prerelease' || inputs.increment }}
         run: |
-          # For stable releases, compare against the previous stable tag so
-          # release notes include everything since the last stable release.
+          # For minor/major releases, compare against the previous minor/major
+          # release (vX.Y.0) so notes include all patches since then.
+          # For patch releases, compare against the latest stable tag.
           # For canary releases, compare against the latest canary tag.
-          if [[ "$INCREMENT" == "patch" || "$INCREMENT" == "minor" || "$INCREMENT" == "major" ]]; then
+          if [[ "$INCREMENT" == "minor" || "$INCREMENT" == "major" ]]; then
+            PREV_TAG=$(git ls-remote --tags origin 'refs/tags/v*' \
+              | awk '{print $2}' | sed 's|refs/tags/||' | grep -v '\^{}$' \
+              | grep -v canary | grep -E 'v[0-9]+\.[0-9]+\.0$' | sort -V | tail -n 1)
+          elif [[ "$INCREMENT" == "patch" ]]; then
             PREV_TAG=$(git ls-remote --tags origin 'refs/tags/v*' \
               | awk '{print $2}' | sed 's|refs/tags/||' | grep -v '\^{}$' \
               | grep -v canary | sort -V | tail -n 1)


### PR DESCRIPTION
## Summary

- The "Get previous tag" step in the release workflow treated all stable releases the same, picking the latest non-canary tag as `--notes-start-tag`. For minor/major releases like v2.9.0, this meant comparing against v2.8.21 (a patch) instead of v2.8.0 (the last minor), so the generated notes missed everything shipped in patches between the two minors.
- Now, minor/major releases filter to `vX.Y.0` tags so the full delta is captured. Patch releases keep the existing behavior.
- Already fixed the live v2.9.0 release notes via `gh release edit`.