### PR TITLE
feat: Handle package manager catalogs in migration codemod

### DIFF
--- a/packages/turbo-codemod/__tests__/__fixtures__/get-turbo-upgrade-command/pnpm-catalog-default/package.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/get-turbo-upgrade-command/pnpm-catalog-default/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "pnpm-catalog-default",
+  "version": "0.0.0",
+  "dependencies": {},
+  "devDependencies": {
+    "turbo": "catalog:"
+  }
+}

--- a/packages/turbo-codemod/__tests__/__fixtures__/get-turbo-upgrade-command/pnpm-catalog-default/pnpm-workspace.yaml
+++ b/packages/turbo-codemod/__tests__/__fixtures__/get-turbo-upgrade-command/pnpm-catalog-default/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+packages:
+  - "apps/*"
+  - "packages/*"
+
+catalog:
+  turbo: "^2.0.0"

--- a/packages/turbo-codemod/__tests__/__fixtures__/get-turbo-upgrade-command/pnpm-catalog-named/package.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/get-turbo-upgrade-command/pnpm-catalog-named/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "pnpm-catalog-named",
+  "version": "0.0.0",
+  "dependencies": {},
+  "devDependencies": {
+    "turbo": "catalog:build"
+  }
+}

--- a/packages/turbo-codemod/__tests__/__fixtures__/get-turbo-upgrade-command/pnpm-catalog-named/pnpm-workspace.yaml
+++ b/packages/turbo-codemod/__tests__/__fixtures__/get-turbo-upgrade-command/pnpm-catalog-named/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+packages:
+  - "apps/*"
+  - "packages/*"
+
+catalogs:
+  build:
+    turbo: "^2.0.0"

--- a/packages/turbo-codemod/__tests__/__fixtures__/get-turbo-upgrade-command/yarn-catalog-default/.yarnrc.yml
+++ b/packages/turbo-codemod/__tests__/__fixtures__/get-turbo-upgrade-command/yarn-catalog-default/.yarnrc.yml
@@ -1,0 +1,2 @@
+catalog:
+  turbo: "^2.0.0"

--- a/packages/turbo-codemod/__tests__/__fixtures__/get-turbo-upgrade-command/yarn-catalog-default/package.json
+++ b/packages/turbo-codemod/__tests__/__fixtures__/get-turbo-upgrade-command/yarn-catalog-default/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "yarn-catalog-default",
+  "version": "0.0.0",
+  "dependencies": {},
+  "devDependencies": {
+    "turbo": "catalog:"
+  }
+}

--- a/packages/turbo-codemod/__tests__/get-turbo-upgrade-command.test.ts
+++ b/packages/turbo-codemod/__tests__/get-turbo-upgrade-command.test.ts
@@ -1,8 +1,10 @@
+import path from "node:path";
 import * as turboWorkspaces from "@turbo/workspaces";
 import * as turboUtils from "@turbo/utils";
 import { setupTestFixtures } from "@turbo/test-utils";
 import { describe, it, expect, jest, afterEach } from "@jest/globals";
 import { getTurboUpgradeCommand } from "../src/commands/migrate/steps/get-turbo-upgrade-command";
+import type { CatalogInfo } from "../src/commands/migrate/steps/update-catalog";
 import * as utils from "../src/commands/migrate/utils";
 import { getWorkspaceDetailsMockReturnValue } from "./test-utils";
 
@@ -617,6 +619,74 @@ describe("get-turbo-upgrade-command", () => {
       mockGetWorkspaceDetails.mockRestore();
     }
   );
+
+  describe("catalog installs", () => {
+    it("returns pnpm install when catalog is used with pnpm workspaces", async () => {
+      const { root } = useFixture({ fixture: "pnpm-catalog-default" });
+
+      const project = getWorkspaceDetailsMockReturnValue({
+        root,
+        packageManager: "pnpm"
+      });
+
+      const catalogInfo: CatalogInfo = {
+        catalogName: null,
+        catalogFile: path.join(root, "pnpm-workspace.yaml"),
+        installType: "devDependencies"
+      };
+
+      const upgradeCommand = await getTurboUpgradeCommand({
+        project,
+        catalogInfo
+      });
+
+      expect(upgradeCommand).toEqual("pnpm install");
+    });
+
+    it("returns yarn install when catalog is used with yarn", async () => {
+      const { root } = useFixture({ fixture: "yarn-catalog-default" });
+
+      const project = getWorkspaceDetailsMockReturnValue({
+        root,
+        packageManager: "yarn"
+      });
+
+      const catalogInfo: CatalogInfo = {
+        catalogName: null,
+        catalogFile: path.join(root, ".yarnrc.yml"),
+        installType: "devDependencies"
+      };
+
+      const upgradeCommand = await getTurboUpgradeCommand({
+        project,
+        catalogInfo
+      });
+
+      expect(upgradeCommand).toEqual("yarn install");
+    });
+
+    it("returns npm install when catalog is used with npm", async () => {
+      const { root } = useFixture({ fixture: "pnpm-catalog-default" });
+
+      const project = getWorkspaceDetailsMockReturnValue({
+        root,
+        packageManager: "npm"
+      });
+
+      const catalogInfo: CatalogInfo = {
+        catalogName: null,
+        catalogFile: path.join(root, "pnpm-workspace.yaml"),
+        installType: "devDependencies"
+      };
+
+      const upgradeCommand = await getTurboUpgradeCommand({
+        project,
+        catalogInfo
+      });
+
+      expect(upgradeCommand).toEqual("npm install");
+    });
+  });
 
   describe("errors", () => {
     it("fails gracefully if no package.json exists", async () => {

--- a/packages/turbo-codemod/__tests__/update-catalog.test.ts
+++ b/packages/turbo-codemod/__tests__/update-catalog.test.ts
@@ -1,0 +1,215 @@
+import path from "node:path";
+import fs from "fs-extra";
+import { describe, it, expect } from "@jest/globals";
+import { setupTestFixtures } from "@turbo/test-utils";
+import {
+  detectCatalog,
+  updateCatalogVersion
+} from "../src/commands/migrate/steps/update-catalog";
+
+describe("detectCatalog", () => {
+  const { useFixture } = setupTestFixtures({
+    directory: __dirname,
+    test: "get-turbo-upgrade-command"
+  });
+
+  it("returns undefined for normal (non-catalog) pnpm devDependency", () => {
+    const { root } = useFixture({ fixture: "pnpm-workspaces-dev-install" });
+    const result = detectCatalog({ root, packageManager: "pnpm" });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined for normal (non-catalog) npm dependency", () => {
+    const { root } = useFixture({ fixture: "normal-workspaces" });
+    const result = detectCatalog({ root, packageManager: "npm" });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when turbo is not in package.json", () => {
+    const { root } = useFixture({ fixture: "no-turbo" });
+    const result = detectCatalog({ root, packageManager: "pnpm" });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when package.json does not exist", () => {
+    const { root } = useFixture({ fixture: "no-package" });
+    const result = detectCatalog({ root, packageManager: "pnpm" });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined for npm (catalogs not supported)", () => {
+    const { root } = useFixture({ fixture: "pnpm-catalog-default" });
+    const result = detectCatalog({ root, packageManager: "npm" });
+    expect(result).toBeUndefined();
+  });
+
+  it("detects pnpm default catalog reference", () => {
+    const { root } = useFixture({ fixture: "pnpm-catalog-default" });
+    const result = detectCatalog({ root, packageManager: "pnpm" });
+    expect(result).toEqual({
+      catalogName: null,
+      catalogFile: path.join(root, "pnpm-workspace.yaml"),
+      installType: "devDependencies"
+    });
+  });
+
+  it("detects pnpm named catalog reference", () => {
+    const { root } = useFixture({ fixture: "pnpm-catalog-named" });
+    const result = detectCatalog({ root, packageManager: "pnpm" });
+    expect(result).toEqual({
+      catalogName: "build",
+      catalogFile: path.join(root, "pnpm-workspace.yaml"),
+      installType: "devDependencies"
+    });
+  });
+
+  it("detects yarn default catalog reference", () => {
+    const { root } = useFixture({ fixture: "yarn-catalog-default" });
+    const result = detectCatalog({ root, packageManager: "yarn" });
+    expect(result).toEqual({
+      catalogName: null,
+      catalogFile: path.join(root, ".yarnrc.yml"),
+      installType: "devDependencies"
+    });
+  });
+});
+
+describe("updateCatalogVersion", () => {
+  const { useFixture } = setupTestFixtures({
+    directory: __dirname,
+    test: "get-turbo-upgrade-command"
+  });
+
+  it("updates the default catalog in pnpm-workspace.yaml", () => {
+    const { root } = useFixture({ fixture: "pnpm-catalog-default" });
+    const catalogFile = path.join(root, "pnpm-workspace.yaml");
+    const catalogInfo = {
+      catalogName: null,
+      catalogFile,
+      installType: "devDependencies" as const
+    };
+
+    const updated = updateCatalogVersion({
+      catalogInfo,
+      version: "2.9.0"
+    });
+
+    expect(updated).toBe(true);
+    const content = fs.readFileSync(catalogFile, "utf8");
+    expect(content).toContain('turbo: "^2.9.0"');
+    expect(content).not.toContain("^2.0.0");
+  });
+
+  it("updates a named catalog in pnpm-workspace.yaml", () => {
+    const { root } = useFixture({ fixture: "pnpm-catalog-named" });
+    const catalogFile = path.join(root, "pnpm-workspace.yaml");
+    const catalogInfo = {
+      catalogName: "build",
+      catalogFile,
+      installType: "devDependencies" as const
+    };
+
+    const updated = updateCatalogVersion({
+      catalogInfo,
+      version: "2.9.0"
+    });
+
+    expect(updated).toBe(true);
+    const content = fs.readFileSync(catalogFile, "utf8");
+    expect(content).toContain('turbo: "^2.9.0"');
+  });
+
+  it("updates the default catalog in .yarnrc.yml", () => {
+    const { root } = useFixture({ fixture: "yarn-catalog-default" });
+    const catalogFile = path.join(root, ".yarnrc.yml");
+    const catalogInfo = {
+      catalogName: null,
+      catalogFile,
+      installType: "devDependencies" as const
+    };
+
+    const updated = updateCatalogVersion({
+      catalogInfo,
+      version: "2.9.0"
+    });
+
+    expect(updated).toBe(true);
+    const content = fs.readFileSync(catalogFile, "utf8");
+    expect(content).toContain('turbo: "^2.9.0"');
+  });
+
+  it("preserves tilde (~) version prefix", () => {
+    const { root } = useFixture({ fixture: "pnpm-catalog-default" });
+    const catalogFile = path.join(root, "pnpm-workspace.yaml");
+
+    // Rewrite fixture with tilde prefix
+    const content = fs.readFileSync(catalogFile, "utf8");
+    fs.writeFileSync(catalogFile, content.replace("^2.0.0", "~2.0.0"));
+
+    const catalogInfo = {
+      catalogName: null,
+      catalogFile,
+      installType: "devDependencies" as const
+    };
+
+    updateCatalogVersion({ catalogInfo, version: "2.9.0" });
+
+    const updated = fs.readFileSync(catalogFile, "utf8");
+    expect(updated).toContain('turbo: "~2.9.0"');
+  });
+
+  it("preserves exact version (no prefix)", () => {
+    const { root } = useFixture({ fixture: "pnpm-catalog-default" });
+    const catalogFile = path.join(root, "pnpm-workspace.yaml");
+
+    // Rewrite fixture with no prefix
+    const content = fs.readFileSync(catalogFile, "utf8");
+    fs.writeFileSync(catalogFile, content.replace("^2.0.0", "2.0.0"));
+
+    const catalogInfo = {
+      catalogName: null,
+      catalogFile,
+      installType: "devDependencies" as const
+    };
+
+    updateCatalogVersion({ catalogInfo, version: "2.9.0" });
+
+    const updated = fs.readFileSync(catalogFile, "utf8");
+    expect(updated).toContain('turbo: "2.9.0"');
+    expect(updated).not.toMatch(/turbo: "\^2\.9\.0"/);
+  });
+
+  it("returns false when version is already up to date", () => {
+    const { root } = useFixture({ fixture: "pnpm-catalog-default" });
+    const catalogFile = path.join(root, "pnpm-workspace.yaml");
+    const catalogInfo = {
+      catalogName: null,
+      catalogFile,
+      installType: "devDependencies" as const
+    };
+
+    const updated = updateCatalogVersion({
+      catalogInfo,
+      version: "2.0.0"
+    });
+
+    expect(updated).toBe(false);
+  });
+
+  it("preserves other YAML content when updating", () => {
+    const { root } = useFixture({ fixture: "pnpm-catalog-default" });
+    const catalogFile = path.join(root, "pnpm-workspace.yaml");
+    const catalogInfo = {
+      catalogName: null,
+      catalogFile,
+      installType: "devDependencies" as const
+    };
+
+    updateCatalogVersion({ catalogInfo, version: "2.9.0" });
+
+    const content = fs.readFileSync(catalogFile, "utf8");
+    // packages section should still be intact
+    expect(content).toContain('- "apps/*"');
+    expect(content).toContain('- "packages/*"');
+  });
+});

--- a/packages/turbo-codemod/package.json
+++ b/packages/turbo-codemod/package.json
@@ -37,7 +37,8 @@
     "ora": "4.1.1",
     "picocolors": "1.0.1",
     "semver": "7.5.2",
-    "update-check": "1.5.4"
+    "update-check": "1.5.4",
+    "yaml": "2.7.1"
   },
   "devDependencies": {
     "@jest/globals": "30.2.0",

--- a/packages/turbo-codemod/src/commands/migrate/index.ts
+++ b/packages/turbo-codemod/src/commands/migrate/index.ts
@@ -13,6 +13,11 @@ import { getCurrentVersion } from "./steps/get-current-version";
 import { getLatestVersion } from "./steps/get-latest-version";
 import { getTransformsForMigration } from "./steps/get-transforms-for-migration";
 import { getTurboUpgradeCommand } from "./steps/get-turbo-upgrade-command";
+import {
+  detectCatalog,
+  updateCatalogVersion,
+  type CatalogInfo
+} from "./steps/update-catalog";
 import type { MigrateCommandArgument, MigrateCommandOptions } from "./types";
 import { shutdownDaemon } from "./steps/shutdown-daemon";
 
@@ -206,10 +211,46 @@ export async function migrate(
 
   // step 5
 
+  // Check if turbo uses a catalog reference (e.g. "turbo": "catalog:" in package.json).
+  // If so, update the version in the catalog file instead of letting the package
+  // manager overwrite the catalog reference with a literal version.
+  let catalogInfo: CatalogInfo | undefined;
+  if (project) {
+    catalogInfo = detectCatalog({
+      root: project.paths.root,
+      packageManager: project.packageManager
+    });
+  }
+
+  if (catalogInfo) {
+    if (options.dryRun) {
+      logger.log(
+        `Would update turbo version in catalog file ${picocolors.dim(
+          catalogInfo.catalogFile
+        )} ${picocolors.dim("(dry run)")}`,
+        os.EOL
+      );
+    } else {
+      const updated = updateCatalogVersion({
+        catalogInfo,
+        version: toVersion
+      });
+      if (updated) {
+        logger.log(
+          `Updated turbo version to ${picocolors.bold(
+            toVersion
+          )} in ${picocolors.dim(catalogInfo.catalogFile)}`,
+          os.EOL
+        );
+      }
+    }
+  }
+
   // find the upgrade command, and run it
   const upgradeCommand = await getTurboUpgradeCommand({
     project,
-    to: options.to
+    to: options.to,
+    catalogInfo
   });
 
   if (!upgradeCommand) {

--- a/packages/turbo-codemod/src/commands/migrate/steps/get-latest-version.ts
+++ b/packages/turbo-codemod/src/commands/migrate/steps/get-latest-version.ts
@@ -32,7 +32,11 @@ export async function getLatestVersion({
   const { "dist-tags": tags, versions } = packageDetails;
 
   if (to) {
-    if (tags[to] || to in versions) {
+    // If 'to' is a dist-tag (e.g. "latest", "canary"), resolve to the concrete version
+    if (tags[to]) {
+      return tags[to];
+    }
+    if (to in versions) {
       return to;
     }
     throw new Error(`turbo@${to} does not exist`);

--- a/packages/turbo-codemod/src/commands/migrate/steps/get-turbo-upgrade-command.ts
+++ b/packages/turbo-codemod/src/commands/migrate/steps/get-turbo-upgrade-command.ts
@@ -10,6 +10,7 @@ import {
 } from "@turbo/utils";
 import type { Project } from "@turbo/workspaces";
 import { exec } from "../utils";
+import type { CatalogInfo } from "./update-catalog";
 
 type InstallType = "dependencies" | "devDependencies";
 
@@ -109,6 +110,27 @@ function getLocalUpgradeCommand({
   }
 }
 
+function getInstallCommand({
+  packageManager
+}: {
+  packageManager: PackageManager;
+}): string {
+  switch (packageManager) {
+    case "yarn": {
+      return "yarn install";
+    }
+    case "npm": {
+      return "npm install";
+    }
+    case "pnpm": {
+      return "pnpm install";
+    }
+    case "bun": {
+      return "bun install";
+    }
+  }
+}
+
 function getInstallType({ root }: { root: string }): InstallType | undefined {
   // read package.json to make sure we have a reference to turbo
   const packageJsonPath = path.join(root, "package.json");
@@ -136,14 +158,29 @@ function getInstallType({ root }: { root: string }): InstallType | undefined {
   2. The install method (local or global)
 
   We try global first to let turbo handle the inference, then we try local.
+
+  When turbo uses a catalog reference (e.g. `"turbo": "catalog:"`), the version
+  lives in a catalog file (pnpm-workspace.yaml or .yarnrc.yml) rather than
+  package.json. In that case the caller is responsible for updating the catalog
+  file first, and we return a plain install command to sync the lockfile.
 **/
 export async function getTurboUpgradeCommand({
   project,
-  to
+  to,
+  catalogInfo
 }: {
   project: Project;
   to?: string;
+  catalogInfo?: CatalogInfo;
 }) {
+  // When the catalog file has already been updated, all we need is an install
+  // to sync the lockfile.
+  if (catalogInfo) {
+    return getInstallCommand({
+      packageManager: project.packageManager
+    });
+  }
+
   const availablePackageManagers = await getAvailablePackageManagers();
 
   const turboBinaryPathFromGlobal = exec("turbo bin", {

--- a/packages/turbo-codemod/src/commands/migrate/steps/update-catalog.ts
+++ b/packages/turbo-codemod/src/commands/migrate/steps/update-catalog.ts
@@ -1,0 +1,122 @@
+import path from "node:path";
+import fs from "fs-extra";
+import { parseDocument } from "yaml";
+import { logger, type PackageManager, type PackageJson } from "@turbo/utils";
+
+type InstallType = "dependencies" | "devDependencies";
+
+export interface CatalogInfo {
+  /** Which catalog the reference points to (null = default) */
+  catalogName: string | null;
+  /** Absolute path to the catalog file */
+  catalogFile: string;
+  /** Which dependency group turbo is in */
+  installType: InstallType;
+}
+
+const CATALOG_FILES: Partial<Record<PackageManager, string>> = {
+  pnpm: "pnpm-workspace.yaml",
+  yarn: ".yarnrc.yml"
+};
+
+/**
+ * Detect if turbo is installed via a `catalog:` protocol reference.
+ * Returns catalog metadata if so, undefined otherwise.
+ */
+export function detectCatalog({
+  root,
+  packageManager
+}: {
+  root: string;
+  packageManager: PackageManager;
+}): CatalogInfo | undefined {
+  const packageJsonPath = path.join(root, "package.json");
+  if (!fs.existsSync(packageJsonPath)) {
+    return undefined;
+  }
+
+  const packageJson = fs.readJsonSync(packageJsonPath) as PackageJson;
+
+  let turboSpecifier: string | undefined;
+  let installType: InstallType;
+
+  if (packageJson.devDependencies && "turbo" in packageJson.devDependencies) {
+    turboSpecifier = packageJson.devDependencies.turbo;
+    installType = "devDependencies";
+  } else if (packageJson.dependencies && "turbo" in packageJson.dependencies) {
+    turboSpecifier = packageJson.dependencies.turbo;
+    installType = "dependencies";
+  } else {
+    return undefined;
+  }
+
+  if (!turboSpecifier?.startsWith("catalog:")) {
+    return undefined;
+  }
+
+  const catalogFileName = CATALOG_FILES[packageManager];
+  if (!catalogFileName) {
+    return undefined;
+  }
+
+  const catalogFile = path.join(root, catalogFileName);
+  if (!fs.existsSync(catalogFile)) {
+    logger.warn(
+      `Found catalog reference but ${catalogFileName} does not exist`
+    );
+    return undefined;
+  }
+
+  const ref = turboSpecifier.slice("catalog:".length);
+  const catalogName = ref === "" || ref === "default" ? null : ref;
+
+  return { catalogName, catalogFile, installType };
+}
+
+/**
+ * Update the turbo version in a catalog file (pnpm-workspace.yaml or .yarnrc.yml).
+ * Preserves the existing version range prefix (^, ~, etc.) and YAML formatting.
+ *
+ * Returns true if the catalog was updated.
+ */
+export function updateCatalogVersion({
+  catalogInfo,
+  version
+}: {
+  catalogInfo: CatalogInfo;
+  version: string;
+}): boolean {
+  const { catalogFile, catalogName } = catalogInfo;
+  const content = fs.readFileSync(catalogFile, "utf8");
+  const doc = parseDocument(content);
+
+  // Path differs for default vs named catalogs:
+  //   default: catalog.turbo
+  //   named:   catalogs.<name>.turbo
+  const yamlPath =
+    catalogName === null
+      ? ["catalog", "turbo"]
+      : ["catalogs", catalogName, "turbo"];
+
+  const currentValue = doc.getIn(yamlPath) as string | undefined;
+  if (!currentValue) {
+    logger.warn(
+      `Could not find turbo in ${catalogName ? `catalog "${catalogName}"` : "default catalog"} in ${catalogFile}`
+    );
+    return false;
+  }
+
+  // Preserve the version range prefix (^, ~, >=, etc.)
+  const prefixMatch = currentValue.match(/^([^\d]*)/);
+  const prefix = prefixMatch ? prefixMatch[1] : "^";
+  const newValue = `${prefix}${version}`;
+
+  if (currentValue === newValue) {
+    return false;
+  }
+
+  doc.setIn(yamlPath, newValue);
+  fs.writeFileSync(catalogFile, doc.toString());
+
+  return true;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -532,6 +532,9 @@ importers:
       update-check:
         specifier: 1.5.4
         version: 1.5.4
+      yaml:
+        specifier: 2.7.1
+        version: 2.7.1
     devDependencies:
       '@jest/globals':
         specifier: 30.2.0
@@ -8408,6 +8411,11 @@ packages:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
 
+  yaml@2.7.1:
+    resolution: {integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==}
+    engines: {node: '>= 14'}
+    hasBin: true
+
   yaml@2.8.2:
     resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
     engines: {node: '>= 14.6'}
@@ -14080,7 +14088,7 @@ snapshots:
       object-inspect: 1.13.4
       pidtree: 0.6.0
       string-argv: 0.3.2
-      yaml: 2.8.2
+      yaml: 2.7.1
     transitivePeerDependencies:
       - enquirer
       - supports-color
@@ -16507,6 +16515,8 @@ snapshots:
   yallist@4.0.0: {}
 
   yallist@5.0.0: {}
+
+  yaml@2.7.1: {}
 
   yaml@2.8.2: {}
 


### PR DESCRIPTION
## Summary

When a project uses package manager catalogs (e.g. `"turbo": "catalog:"` in `package.json`), the migration codemod previously ran `pnpm add turbo@latest` which overwrote the `catalog:` reference with a literal version string — breaking the catalog setup.

Now the codemod detects `catalog:` protocol references, updates the version directly in the catalog file (`pnpm-workspace.yaml` or `.yarnrc.yml`), and runs a plain `install` to sync the lockfile instead.

Fixes the issue reported here: https://x.com/stanzillaz/status/1906367700218610076

## What changed

- **New step in migration flow**: Before building the upgrade command, the codemod checks if turbo uses a `catalog:` reference. If so, it updates the version in the catalog file (preserving the existing range prefix like `^` or `~`) and uses a plain install command instead of `add`.
- **Tag resolution fix in `getLatestVersion`**: `--to latest` now resolves to the concrete version (e.g. `"2.9.0"`) instead of returning the string `"latest"`. This also fixes the `fromVersion === toVersion` short-circuit that previously couldn't detect same-version with tag names.
- Supports pnpm default catalogs (`catalog:`), pnpm named catalogs (`catalog:<name>`), and Yarn Berry catalogs (`.yarnrc.yml`).

## Testing

18 new tests covering detection (pnpm default/named, yarn, npm, non-catalog, missing files) and YAML updates (version update, prefix preservation, no-op when already current). All 245 tests in the suite pass.