### PR TITLE
fix: Add retry logic to example update workflow push step

### DIFF
--- a/.github/workflows/update-examples-on-release.yml
+++ b/.github/workflows/update-examples-on-release.yml
@@ -41,7 +41,13 @@ jobs:
           HUSKY: "0"
         run: |
           git commit -am "release(turborepo): update examples to latest"
-          git push origin ${{ steps.branch.outputs.STAGE_BRANCH }}
+
+          for attempt in 1 2 3; do
+            git pull --rebase origin ${{ steps.branch.outputs.STAGE_BRANCH }} || true
+            git push origin ${{ steps.branch.outputs.STAGE_BRANCH }} && break
+            echo "Push attempt $attempt failed, retrying..."
+            sleep 5
+          done
 
       - name: Create pull request
         id: pr


### PR DESCRIPTION
## Summary

- The `update-examples-on-release` workflow fails when pushing to `post-release-bump-examples` because the remote branch already exists from a prior run
- Adds `git pull --rebase` before push to incorporate existing remote history, with a 3-attempt retry loop to handle transient failures