### PR TITLE
fix: Unblock `watch` loop so interruptible persistent tasks restart on file changes

### DIFF
--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -13,7 +13,7 @@ use tokio::{
     sync::{broadcast, Notify},
     task::JoinHandle,
 };
-use tracing::{instrument, trace};
+use tracing::{debug, instrument, trace};
 use turbopath::AnchoredSystemPathBuf;
 use turborepo_daemon::{PackageChangeEvent, PackageChangesWatcher as PackageChangesWatcherTrait};
 use turborepo_filewatch::{
@@ -385,8 +385,9 @@ impl WatchClient {
         let event_fut = async {
             loop {
                 match events.recv().await {
-                    Ok(event) => {
-                        Self::handle_change_event(&pending_changes, event);
+                    Ok(ref event) => {
+                        debug!(?event, "received package change event");
+                        Self::handle_change_event(&pending_changes, event.clone());
                         notify_event.notify_one();
                     }
                     Err(broadcast::error::RecvError::Closed) => {
@@ -410,11 +411,9 @@ impl WatchClient {
 
                 if let Some(mut changed_packages) = some_changed_packages {
                     // Stop impacted tasks and wait for prior runs to finish
-                    // before starting new ones. This prevents:
-                    // - Concurrent builds of the same package (Next.js lock conflicts, duplicated
-                    //   output)
-                    // - A cache-hit run incorrectly signaling persistent task readiness when the
-                    //   real build failed
+                    // before starting new ones. This prevents concurrent
+                    // builds of the same package and stale cache-hit signals.
+                    debug!(?changed_packages, "processing changed packages");
                     match changed_packages {
                         ChangedPackages::Some { ref packages, .. } => {
                             let impacted = self.stop_impacted_tasks(packages).await;
@@ -445,9 +444,14 @@ impl WatchClient {
                     // In watch mode the visitor treats persistent tasks as
                     // fire-and-forget, so this only blocks on non-persistent
                     // tasks (builds).
+                    debug!(
+                        active_runs = self.active_runs.len(),
+                        "waiting for runs to complete"
+                    );
                     for handle in &mut self.active_runs {
                         let _ = (&mut handle.run_task).await;
                     }
+                    debug!("all runs completed, ready for next event");
                     // Save stoppers before retain drops them — their PMs may
                     // still track background persistent processes.
                     for handle in &self.active_runs {
@@ -530,6 +534,13 @@ impl WatchClient {
             .map(|task_id| PackageName::from(task_id.package()))
             .collect();
 
+        debug!(
+            ?pkgs,
+            ?impacted_packages,
+            impacted_tasks = ?task_ids,
+            "identified impacted tasks for changed packages"
+        );
+
         // Only stop tasks that are allowed to be restarted. Non-interruptible
         // persistent tasks survive file changes — they are only killed on a
         // full rebuild (ChangedPackages::All) or shutdown.
@@ -542,6 +553,7 @@ impl WatchClient {
             })
             .collect();
 
+        debug!(?stoppable_ids, "stopping interruptible tasks");
         for handle in &self.active_runs {
             handle.stopper.stop_tasks(&stoppable_ids).await;
         }

--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -21,7 +21,7 @@ use turborepo_errors::TURBO_SITE;
 use turborepo_log::grouping::{GroupingLayer, GroupingMode};
 use turborepo_process::ProcessManager;
 use turborepo_repository::package_graph::{PackageGraph, PackageName, ROOT_PKG_NAME};
-use turborepo_run_summary::{self as summary, GlobalHashSummary, RunTracker};
+use turborepo_run_summary::{self as summary, GlobalHashSummary, RunTracker, TaskTracker};
 use turborepo_scm::SCM;
 // Re-export output types and shared functions from turborepo-task-executor
 pub use turborepo_task_executor::{turbo_regex, TaskOutput};
@@ -477,7 +477,6 @@ impl<'a> Visitor<'a> {
                     self.grouping_layer
                         .logger()
                         .register_task(&task_id_str, &task_prefix);
-                    let tracker = self.run_tracker.track_task(info.into_owned());
                     let parent_span = Span::current();
 
                     if self.is_watch && task_definition.persistent {
@@ -487,12 +486,20 @@ impl<'a> Visitor<'a> {
                         // background task. The child process stays tracked by
                         // the ProcessManager for later stop_tasks() calls.
                         let _ = callback.send(Ok(()));
+                        // Use a no-op tracker for the detached task. The real
+                        // tracker (from run_tracker.track_task) must NOT be
+                        // passed to the spawn — its sender clone would keep
+                        // ExecutionTracker::finish() blocked forever since
+                        // the persistent process never exits. This caused
+                        // Run::run() to never return, preventing the watch
+                        // loop from processing file-change events.
+                        let bg_tracker = TaskTracker::noop(info.into_owned());
                         let (bg_callback, _) = tokio::sync::oneshot::channel();
                         tokio::spawn(async move {
                             exec_context
                                 .execute(
                                     parent_span.id(),
-                                    tracker,
+                                    bg_tracker,
                                     task_output,
                                     task_handle,
                                     bg_callback,
@@ -501,6 +508,7 @@ impl<'a> Visitor<'a> {
                                 .await
                         });
                     } else {
+                        let tracker = self.run_tracker.track_task(info.into_owned());
                         tasks.push(tokio::spawn(async move {
                             exec_context
                                 .execute(

--- a/crates/turborepo-run-summary/src/execution.rs
+++ b/crates/turborepo-run-summary/src/execution.rs
@@ -316,6 +316,19 @@ impl ExecutionTracker {
 }
 
 impl TaskTracker<()> {
+    /// Create a tracker whose events are silently discarded.
+    /// Used for fire-and-forget persistent tasks in watch mode where the
+    /// real tracker must be dropped to unblock `ExecutionTracker::finish()`.
+    pub fn noop(task_id: TaskId<'static>) -> Self {
+        // The receiver is dropped immediately; sends will silently fail.
+        let (sender, _) = mpsc::channel(1);
+        Self {
+            sender,
+            task_id,
+            started_at: (),
+        }
+    }
+
     // Start the tracker
     pub async fn start(self) -> TaskTracker<DateTime<Local>> {
         let TaskTracker {

--- a/crates/turborepo/tests/watch_test.rs
+++ b/crates/turborepo/tests/watch_test.rs
@@ -832,3 +832,64 @@ fn watch_mixed_persistent_tasks_all_start() {
         "app-b dev (non-interruptible) should have started, but ran {dev_b} times"
     );
 }
+
+/// Regression test for https://github.com/vercel/turborepo/issues/12505
+///
+/// When `turbo watch` is running an interruptible persistent task, editing
+/// a file in that package should kill and restart the task. This verifies
+/// the full file-change → stop → re-execute cycle works.
+#[test]
+#[cfg_attr(windows, ignore)]
+fn watch_interruptible_persistent_task_restarts_on_file_change() {
+    let (_tempdir, test_dir) = setup_watch_mixed_persistent_test();
+    let guard = WatchGuard::new(spawn_turbo_watch_with_tasks(&test_dir, &["dev"]));
+
+    // Wait for both tasks to start
+    wait_for_prefixed_markers(&test_dir, "app-a", "dev-", 1, Duration::from_secs(60));
+    wait_for_prefixed_markers(&test_dir, "app-b", "dev-", 1, Duration::from_secs(60));
+
+    // Let the watcher fully settle after the initial run.
+    std::thread::sleep(Duration::from_secs(2));
+
+    let a_before = prefixed_marker_count(&test_dir, "app-a", "dev-");
+
+    // Modify a file in app-a and commit. The hash watcher uses git-based
+    // hashing, so the change must be committed.
+    let src_file = test_dir.join("packages/app-a/src.js");
+    for attempt in 0..3 {
+        let value = 42 + attempt;
+        fs::write(&src_file, format!("module.exports = {{ a: {value} }};\n")).unwrap();
+
+        common::git(&test_dir, &["add", "."]);
+        common::git(
+            &test_dir,
+            &[
+                "commit",
+                "-m",
+                &format!("modify app-a (attempt {attempt})"),
+                "--quiet",
+            ],
+        );
+
+        let count = wait_for_prefixed_markers(
+            &test_dir,
+            "app-a",
+            "dev-",
+            a_before + 1,
+            Duration::from_secs(15),
+        );
+        if count > a_before {
+            break;
+        }
+    }
+
+    let a_after = prefixed_marker_count(&test_dir, "app-a", "dev-");
+
+    drop(guard);
+
+    assert!(
+        a_after > a_before,
+        "app-a dev (interruptible) should have restarted after file change. before: {a_before}, \
+         after: {a_after}"
+    );
+}

--- a/turborepo-tests/integration/fixtures/watch_mixed_persistent_test/packages/app-a/src.js
+++ b/turborepo-tests/integration/fixtures/watch_mixed_persistent_test/packages/app-a/src.js
@@ -1,0 +1,1 @@
+module.exports = { a: 1 };


### PR DESCRIPTION
## Summary

Fixes #12505

- **Cause**: The fire-and-forget change (PR #12449) moved a `TaskTracker` into a detached `tokio::spawn` for persistent tasks. Since persistent processes run forever, the tracker's `mpsc::Sender` clone is never dropped, which blocks `ExecutionTracker::finish()` indefinitely. This prevents `Run::run()` from returning, starving the watch loop of the ability to process any subsequent file-change events.
- **Fix**: Use a no-op `TaskTracker` (throwaway channel) for fire-and-forget persistent tasks so the real execution tracker can complete.
- **Observability**: Adds `debug!` traces at key decision points in the watch loop (event receipt, run processing, task stopping, run completion) to make future watch-mode issues diagnosable with `-vv`.