### PR TITLE
docs: Document `turbo.*` generator variables

### DIFF
--- a/apps/docs/content/docs/guides/generating-code.mdx
+++ b/apps/docs/content/docs/guides/generating-code.mdx
@@ -318,6 +318,42 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
 }
 ```
 
+### Turborepo variables
+
+When running actions, Turborepo automatically injects a `turbo` object into the answers data. This gives your templates and custom actions access to useful information about the repository without needing to discover it yourself.
+
+#### Using in templates
+
+In [Handlebars templates](https://plopjs.com/documentation/#built-in-actions), access the variables using double curly braces:
+
+```hbs title="turbo/generators/templates/component.hbs"
+// Generated at {{ turbo.paths.root }}/src/components
+```
+
+#### Using in custom actions
+
+In [custom action functions](https://plopjs.com/documentation/#functionsignature-custom-action), the `turbo` object is available on the `answers` parameter:
+
+```ts title="turbo/generators/config.ts"
+import type { PlopTypes } from "@turbo/gen";
+
+export default function generator(plop: PlopTypes.NodePlopAPI): void {
+  plop.setGenerator("example", {
+    description: "An example using turbo variables",
+    prompts: [],
+    actions: [
+      async (answers) => {
+        const { turbo } = answers;
+        console.log(`Monorepo root: ${turbo.paths.root}`);
+        return "Done!";
+      },
+    ],
+  });
+}
+```
+
+The available variables are documented in the [`@turbo/gen` reference](/docs/reference/turbo-gen#turborepo-variables).
+
 ### Running generators
 
 Once you have created your generator configuration file, you can skip the selection prompt and directly run a specified generator with:

--- a/apps/docs/content/docs/reference/turbo-gen.mdx
+++ b/apps/docs/content/docs/reference/turbo-gen.mdx
@@ -31,4 +31,29 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
 }
 ```
 
+## Turborepo variables
+
+When running generator actions, Turborepo injects a `turbo` object into the action answers data. This object provides information about the repository and the generator's context.
+
+### `turbo.paths`
+
+| Variable | Type | Description |
+| --- | --- | --- |
+| `turbo.paths.cwd` | `string` | The current working directory when the generator was invoked. |
+| `turbo.paths.root` | `string` | The root directory of the Turborepo project. |
+| `turbo.paths.workspace` | `string \| undefined` | The root directory of the workspace that contains the generator. `undefined` for root-level generators that are not within a workspace. |
+
+### `turbo.configs`
+
+An array of `TurboConfig` objects representing all `turbo.json` and `turbo.jsonc` files found in the repository.
+
+Each `TurboConfig` object has the following shape:
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `config` | `object` | The parsed contents of the Turbo configuration file. |
+| `turboConfigPath` | `string` | The absolute path to the Turbo configuration file. |
+| `workspacePath` | `string` | The absolute path to the workspace directory containing the configuration. |
+| `isRootConfig` | `boolean` | Whether the configuration is from the root of the monorepo. |
+
 For more information, [visit the Generating code guide](/docs/guides/generating-code).


### PR DESCRIPTION
## Summary

- Documents the `turbo` object that Turborepo injects into generator action answers (`turbo.paths` and `turbo.configs`), which was previously only discoverable by reading source code.
- Adds a guide-level section to the [Generating code](/docs/guides/generating-code) page showing usage in both Handlebars templates and custom actions.
- Adds a full reference table to the [`@turbo/gen`](/docs/reference/turbo-gen) page.

Closes #8708