### PR TITLE
fix(config): Deep-merge nested OTEL config across priority sources

### DIFF
--- a/apps/docs/content/docs/reference/configuration.mdx
+++ b/apps/docs/content/docs/reference/configuration.mdx
@@ -1246,6 +1246,16 @@ Optional HTTP headers to include with export requests. Useful for authentication
   manager for sensitive header values.
 </Callout>
 
+<Callout type="warn">
+  `headers` is tied to `endpoint` for security. If you override the endpoint
+  from a higher-priority source (e.g., setting `TURBO_EXPERIMENTAL_OTEL_ENDPOINT`
+  in your environment), headers from lower-priority sources like `turbo.json` are
+  **not inherited**. You must re-provide headers alongside the new endpoint.
+
+  This prevents authentication credentials configured for one collector from
+  being sent to a different collector.
+</Callout>
+
 #### `experimentalObservability.otel.timeoutMs`
 
 Default: `10000` (10 seconds)
@@ -1349,6 +1359,13 @@ When enabled, automatically adds an `Authorization: Bearer <token>` header to OT
 
 This is useful when your OTLP collector uses the same authentication as your remote cache.
 
+<Callout type="warn">
+  Like `headers`, `useRemoteCacheToken` is tied to `endpoint`. If the endpoint
+  is overridden from a higher-priority source, this flag is not inherited from
+  lower-priority sources. Set it alongside the endpoint to ensure the token is
+  sent to the intended collector.
+</Callout>
+
 <Callout type="info">
   Exporter failures are logged but do not cause the run to fail. If the
   collector is unavailable or misconfigured, Turborepo will continue executing
@@ -1362,6 +1379,26 @@ This is useful when your OTLP collector uses the same authentication as your rem
   protocol) results in metrics being disabled rather than causing runs to fail.
   Turborepo will continue executing tasks normally even if the exporter cannot
   be initialized.
+</Callout>
+
+### Multi-source configuration
+
+When OTEL settings come from multiple sources (e.g., `turbo.json` and environment variables), Turborepo deep-merges them per-field. Higher-priority sources win for each field they set, and unset fields fall through from lower-priority sources.
+
+Priority order (highest to lowest):
+
+1. CLI flags
+2. Environment variables
+3. `turbo.json`
+
+For example, if `turbo.json` configures `endpoint`, `enabled`, and `metrics`, and an environment variable overrides just `endpoint`, the `enabled` and `metrics` values from `turbo.json` are preserved.
+
+<Callout type="warn">
+  **Changing the endpoint resets credentials.** `headers` and
+  `useRemoteCacheToken` are security-sensitive and tied to `endpoint`. If a
+  higher-priority source sets the endpoint, credentials from lower-priority
+  sources are discarded to prevent authentication tokens from being sent to
+  unintended collectors. Re-provide credentials alongside the new endpoint.
 </Callout>
 
 ### Environment variables

--- a/crates/turborepo-config/src/experimental_otel.rs
+++ b/crates/turborepo-config/src/experimental_otel.rs
@@ -36,15 +36,14 @@ pub struct ExperimentalOtelMetricsOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub task_details: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[merge(strategy = crate::merge_option_deep)]
+    #[merge(strategy = merge::option::recurse)]
     pub run_attributes: Option<ExperimentalOtelRunAttributesOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[merge(strategy = crate::merge_option_deep)]
+    #[merge(strategy = merge::option::recurse)]
     pub task_attributes: Option<ExperimentalOtelTaskAttributesOptions>,
 }
 
-#[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq, Eq, Merge)]
-#[merge(strategy = merge::option::overwrite_none)]
+#[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ExperimentalOtelOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -62,10 +61,43 @@ pub struct ExperimentalOtelOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resource: Option<BTreeMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[merge(strategy = crate::merge_option_deep)]
     pub metrics: Option<ExperimentalOtelMetricsOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_remote_cache_token: Option<bool>,
+}
+
+/// Credential locking: `headers` and `use_remote_cache_token` are security-
+/// coupled to `endpoint`. Changing the endpoint resets credentials — you must
+/// re-provide them alongside the new endpoint.
+///
+/// Config sources are merged highest-priority first. Once a source provides
+/// an endpoint, all subsequent (lower-priority) sources' credential fields
+/// are ignored, even if the higher-priority source left them unset. This
+/// prevents auth headers configured for one endpoint from leaking to a
+/// different endpoint set by a higher-priority source.
+///
+/// Non-credential fields (`enabled`, `protocol`, `timeout_ms`, `interval_ms`,
+/// `resource`, `metrics`) always merge independently across all sources.
+impl Merge for ExperimentalOtelOptions {
+    fn merge(&mut self, other: Self) {
+        let endpoint_locked = self.endpoint.is_some();
+        merge::option::overwrite_none(&mut self.endpoint, other.endpoint);
+
+        if !endpoint_locked {
+            merge::option::overwrite_none(&mut self.headers, other.headers);
+            merge::option::overwrite_none(
+                &mut self.use_remote_cache_token,
+                other.use_remote_cache_token,
+            );
+        }
+
+        merge::option::overwrite_none(&mut self.enabled, other.enabled);
+        merge::option::overwrite_none(&mut self.protocol, other.protocol);
+        merge::option::overwrite_none(&mut self.timeout_ms, other.timeout_ms);
+        merge::option::overwrite_none(&mut self.interval_ms, other.interval_ms);
+        merge::option::overwrite_none(&mut self.resource, other.resource);
+        merge::option::recurse(&mut self.metrics, other.metrics);
+    }
 }
 
 impl ExperimentalOtelOptions {
@@ -821,5 +853,272 @@ mod tests {
     fn test_parse_key_value_pairs_empty_string() {
         let result = parse_key_value_pairs("", "TEST").unwrap();
         assert!(result.is_empty());
+    }
+
+    // -- Credential-locking merge tests --
+    //
+    // Config sources are merged highest-priority first. The custom Merge impl
+    // on ExperimentalOtelOptions ensures that once a higher-priority source
+    // provides an endpoint, credentials (headers, use_remote_cache_token) from
+    // lower-priority sources are discarded.
+
+    fn make_headers(pairs: &[(&str, &str)]) -> Option<BTreeMap<String, String>> {
+        Some(
+            pairs
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn merge_endpoint_override_blocks_lower_priority_headers() {
+        // Higher-priority source sets endpoint only.
+        let mut high = ExperimentalOtelOptions {
+            endpoint: Some("https://staging.example/otel".into()),
+            ..Default::default()
+        };
+        // Lower-priority source sets endpoint + auth headers.
+        let low = ExperimentalOtelOptions {
+            endpoint: Some("https://internal.corp/otel".into()),
+            headers: make_headers(&[("Authorization", "Bearer secret")]),
+            use_remote_cache_token: Some(true),
+            ..Default::default()
+        };
+
+        high.merge(low);
+
+        assert_eq!(
+            high.endpoint.as_deref(),
+            Some("https://staging.example/otel")
+        );
+        assert_eq!(
+            high.headers, None,
+            "headers from lower-priority source must not leak to overridden endpoint"
+        );
+        assert_eq!(
+            high.use_remote_cache_token, None,
+            "use_remote_cache_token must not leak"
+        );
+    }
+
+    #[test]
+    fn merge_endpoint_override_still_merges_non_credential_fields() {
+        let mut high = ExperimentalOtelOptions {
+            endpoint: Some("https://staging.example/otel".into()),
+            ..Default::default()
+        };
+        let low = ExperimentalOtelOptions {
+            endpoint: Some("https://internal.corp/otel".into()),
+            enabled: Some(true),
+            protocol: Some(ExperimentalOtelProtocol::Grpc),
+            timeout_ms: Some(5000),
+            interval_ms: Some(30000),
+            resource: Some([("service.name".into(), "turbo".into())].into()),
+            metrics: Some(ExperimentalOtelMetricsOptions {
+                run_summary: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        high.merge(low);
+
+        assert_eq!(
+            high.enabled,
+            Some(true),
+            "non-credential fields merge independently"
+        );
+        assert_eq!(high.protocol, Some(ExperimentalOtelProtocol::Grpc));
+        assert_eq!(high.timeout_ms, Some(5000));
+        assert_eq!(high.interval_ms, Some(30000));
+        assert!(high.resource.is_some());
+        assert_eq!(
+            high.metrics.as_ref().and_then(|m| m.run_summary),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn merge_headers_without_endpoint_are_inherited() {
+        // Higher-priority source sets only headers (no endpoint).
+        let mut high = ExperimentalOtelOptions {
+            headers: make_headers(&[("X-Custom", "value")]),
+            ..Default::default()
+        };
+        // Lower-priority source provides the endpoint.
+        let low = ExperimentalOtelOptions {
+            endpoint: Some("https://internal.corp/otel".into()),
+            headers: make_headers(&[("Authorization", "Bearer secret")]),
+            ..Default::default()
+        };
+
+        high.merge(low);
+
+        assert_eq!(high.endpoint.as_deref(), Some("https://internal.corp/otel"));
+        assert_eq!(
+            high.headers
+                .as_ref()
+                .and_then(|h| h.get("X-Custom"))
+                .map(|s| s.as_str()),
+            Some("value"),
+            "higher-priority headers win"
+        );
+        assert_eq!(
+            high.headers.as_ref().and_then(|h| h.get("Authorization")),
+            None,
+            "headers use atomic overwrite_none, not key-level merge"
+        );
+    }
+
+    #[test]
+    fn merge_same_source_endpoint_and_headers() {
+        let mut high = ExperimentalOtelOptions {
+            endpoint: Some("https://prod.example/otel".into()),
+            headers: make_headers(&[("Authorization", "Bearer prod")]),
+            use_remote_cache_token: Some(true),
+            ..Default::default()
+        };
+        let low = ExperimentalOtelOptions {
+            endpoint: Some("https://fallback.example/otel".into()),
+            headers: make_headers(&[("Authorization", "Bearer fallback")]),
+            ..Default::default()
+        };
+
+        high.merge(low);
+
+        assert_eq!(high.endpoint.as_deref(), Some("https://prod.example/otel"));
+        assert_eq!(
+            high.headers
+                .as_ref()
+                .and_then(|h| h.get("Authorization"))
+                .map(|s| s.as_str()),
+            Some("Bearer prod"),
+        );
+        assert_eq!(high.use_remote_cache_token, Some(true));
+    }
+
+    #[test]
+    fn merge_three_layers_credential_locking() {
+        // Simulates: override → env → turbo.json (highest to lowest priority)
+        let mut acc = ExperimentalOtelOptions::default();
+
+        // Highest priority: override sets endpoint + protocol
+        let override_source = ExperimentalOtelOptions {
+            endpoint: Some("https://override.example/otel".into()),
+            protocol: Some(ExperimentalOtelProtocol::HttpProtobuf),
+            ..Default::default()
+        };
+        acc.merge(override_source);
+
+        // Mid priority: env sets headers + timeout
+        let env_source = ExperimentalOtelOptions {
+            headers: make_headers(&[("X-Env", "from-env")]),
+            timeout_ms: Some(9999),
+            ..Default::default()
+        };
+        acc.merge(env_source);
+
+        // Lowest priority: turbo.json sets everything
+        let turbo_json = ExperimentalOtelOptions {
+            endpoint: Some("https://turbo-json.example/otel".into()),
+            headers: make_headers(&[("Authorization", "Bearer turbo-json-secret")]),
+            use_remote_cache_token: Some(true),
+            enabled: Some(true),
+            interval_ms: Some(60000),
+            metrics: Some(ExperimentalOtelMetricsOptions {
+                run_summary: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        acc.merge(turbo_json);
+
+        // Override's endpoint wins.
+        assert_eq!(
+            acc.endpoint.as_deref(),
+            Some("https://override.example/otel")
+        );
+        assert_eq!(acc.protocol, Some(ExperimentalOtelProtocol::HttpProtobuf));
+
+        // Endpoint was locked after the override merge, so BOTH env and
+        // turbo.json credentials are blocked.
+        assert_eq!(
+            acc.headers, None,
+            "env headers blocked — endpoint already locked"
+        );
+        assert_eq!(acc.use_remote_cache_token, None, "turbo.json token blocked");
+
+        // Non-credential fields still fill in from lower-priority sources.
+        assert_eq!(acc.timeout_ms, Some(9999), "env timeout fills in");
+        assert_eq!(acc.enabled, Some(true), "turbo.json enabled fills in");
+        assert_eq!(acc.interval_ms, Some(60000), "turbo.json interval fills in");
+        assert_eq!(acc.metrics.as_ref().and_then(|m| m.run_summary), Some(true));
+    }
+
+    #[test]
+    fn merge_no_endpoint_anywhere_credentials_merge_normally() {
+        let mut high = ExperimentalOtelOptions {
+            headers: make_headers(&[("X-High", "1")]),
+            ..Default::default()
+        };
+        let low = ExperimentalOtelOptions {
+            use_remote_cache_token: Some(true),
+            enabled: Some(true),
+            ..Default::default()
+        };
+
+        high.merge(low);
+
+        assert!(high.headers.is_some(), "headers preserved");
+        assert_eq!(
+            high.use_remote_cache_token,
+            Some(true),
+            "token fills in when no endpoint set"
+        );
+        assert_eq!(high.enabled, Some(true));
+    }
+
+    #[test]
+    fn merge_metrics_deep_merge_unaffected_by_credential_locking() {
+        let mut high = ExperimentalOtelOptions {
+            endpoint: Some("https://high.example/otel".into()),
+            metrics: Some(ExperimentalOtelMetricsOptions {
+                run_summary: Some(false),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let low = ExperimentalOtelOptions {
+            endpoint: Some("https://low.example/otel".into()),
+            metrics: Some(ExperimentalOtelMetricsOptions {
+                task_details: Some(true),
+                task_attributes: Some(ExperimentalOtelTaskAttributesOptions {
+                    id: Some(true),
+                    hashes: None,
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        high.merge(low);
+
+        let metrics = high.metrics.as_ref().unwrap();
+        assert_eq!(
+            metrics.run_summary,
+            Some(false),
+            "high's run_summary preserved"
+        );
+        assert_eq!(
+            metrics.task_details,
+            Some(true),
+            "low's task_details fills in"
+        );
+        assert_eq!(
+            metrics.task_attributes.as_ref().and_then(|ta| ta.id),
+            Some(true),
+            "low's nested task_attributes fills in via recurse"
+        );
     }
 }

--- a/crates/turborepo-config/src/lib.rs
+++ b/crates/turborepo-config/src/lib.rs
@@ -7,8 +7,15 @@
 //! - Environment variables
 //! - CLI arguments
 //!
-//! Configuration is merged with a priority order where later sources
-//! override earlier ones.
+//! Configuration is merged with a priority order where higher-priority sources
+//! override lower-priority ones on a per-field basis. Scalar fields use
+//! first-writer-wins (`overwrite_none`). Nested config objects like OTEL
+//! options are deep-merged so that a higher-priority source overriding a
+//! single field does not shadow unrelated fields from lower-priority sources.
+//!
+//! Security-sensitive fields (`headers`, `use_remote_cache_token`) are coupled
+//! to `endpoint`: once an endpoint is set by a source, credentials from
+//! lower-priority sources are discarded. See `ExperimentalOtelOptions::merge`.
 
 // Match the lint settings from turborepo-lib
 #![allow(clippy::needless_lifetimes)]
@@ -53,37 +60,15 @@ pub use experimental_otel::{
     ExperimentalOtelRunAttributesOptions, ExperimentalOtelTaskAttributesOptions,
 };
 
-/// Merge strategy for `Option<T: Merge>` that performs a field-level deep
-/// merge when both sides are `Some`, rather than treating the option value as
-/// an atomic unit.
-///
-/// The standard `merge::option::overwrite_none` strategy keeps the existing
-/// value untouched when it is already `Some`. This is correct for scalar
-/// fields (e.g. `TURBO_TOKEN` overrides `token` in turbo.json and nothing
-/// more), but wrong for nested config objects: setting a single env-var like
-/// `TURBO_EXPERIMENTAL_OTEL_HEADERS` creates a partial
-/// `ExperimentalOtelOptions` with only `headers` populated, which then
-/// silently shadows the `endpoint`, `protocol`, and other fields that were
-/// configured in `turbo.json`.
-///
-/// With this strategy each `Some/Some` pair is resolved by recursively merging
-/// the inner value (calling its own `Merge` impl), so that higher-priority
-/// sources override individual fields while lower-priority sources fill in
-/// whatever was left unset.
-pub(crate) fn merge_option_deep<T: Merge>(left: &mut Option<T>, right: Option<T>) {
-    match (left.as_mut(), right) {
-        (None, Some(r)) => *left = Some(r),
-        (Some(l), Some(r)) => l.merge(r),
-        _ => {}
-    }
-}
-
+/// Wrapper for observability-related config. Uses `recurse` on `otel` so that
+/// a partial `ExperimentalOtelOptions` from one source (e.g. a single env var)
+/// does not shadow the entire block from a lower-priority source.
 #[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq, Eq, Merge)]
 #[merge(strategy = merge::option::overwrite_none)]
 #[serde(rename_all = "camelCase")]
 pub struct ExperimentalObservabilityOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[merge(strategy = crate::merge_option_deep)]
+    #[merge(strategy = merge::option::recurse)]
     pub otel: Option<ExperimentalOtelOptions>,
 }
 
@@ -337,8 +322,11 @@ pub struct ConfigurationOptions {
     pub sso_login_callback_port: Option<u16>,
     #[serde(skip)]
     pub future_flags: Option<FutureFlags>,
+    /// Deep-merged so that setting a single OTEL env var does not shadow the
+    /// entire observability block from turbo.json. See
+    /// `ExperimentalOtelOptions::merge` for credential-locking semantics.
     #[serde(rename = "experimentalObservability")]
-    #[merge(strategy = merge_option_deep)]
+    #[merge(strategy = merge::option::recurse)]
     pub experimental_observability: Option<ExperimentalObservabilityOptions>,
     /// Structured log file destination, configured via `logFile` in
     /// turbo.json or `TURBO_LOG_FILE` env var.
@@ -676,13 +664,19 @@ impl TurborepoConfigBuilder {
     }
 
     pub fn build(&self) -> Result<ConfigurationOptions, Error> {
-        // Priority, from least significant to most significant:
-        // - shared configuration (turbo.json)
-        // - global configuration (~/.turbo/config.json)
-        // - local configuration (<REPO_ROOT>/.turbo/config.json)
-        // - environment variables
-        // - CLI arguments
-        // - builder pattern overrides.
+        // Sources are listed highest-to-lowest priority. The fold merges each
+        // source into the accumulator; `overwrite_none` keeps the first `Some`
+        // it sees, so processing highest-priority first gives it precedence.
+        //
+        // Priority order:
+        //   1. builder pattern overrides (CLI arguments)
+        //   2. environment variables (TURBO_*)
+        //   3. override env vars (VERCEL_ARTIFACTS_*)
+        //   4. local configuration (<REPO_ROOT>/.turbo/config.json)
+        //   5. global auth (~/.turbo/auth.json)
+        //   6. global configuration (~/.turbo/config.json)
+        //   7. shared configuration (turbo.json)
+        //
         // See `test_experimental_observability_otel_precedence` for coverage.
 
         let turbo_json = TurboJsonReader::new(&self.repo_root);
@@ -693,7 +687,6 @@ impl TurborepoConfigBuilder {
         let env_var_config = EnvVars::new(&env_vars)?;
         let override_env_var_config = OverrideEnvVars::new(&env_vars)?;
 
-        // These are ordered from highest to lowest priority
         let sources: [Box<dyn ResolvedConfigurationOptions>; 7] = [
             Box::new(&self.override_config),
             Box::new(env_var_config),

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -807,13 +807,22 @@ impl RunBuilder {
             .experimental_observability
             .as_ref()
             .and_then(|opts| {
-                let token = opts
-                    .otel
-                    .as_ref()
-                    .and_then(|otel| otel.use_remote_cache_token)
-                    .unwrap_or(false)
-                    .then(|| self.api_auth.as_ref().map(|auth| auth.token.expose()))
-                    .flatten();
+                let token = opts.otel.as_ref().and_then(|otel| {
+                    if !otel.use_remote_cache_token.unwrap_or(false) {
+                        return None;
+                    }
+                    let endpoint = otel.endpoint.as_deref().unwrap_or("");
+                    let api_url = &self.opts.api_client_opts.api_url;
+                    if !hosts_match(endpoint, api_url) {
+                        tracing::warn!(
+                            "use_remote_cache_token is enabled but the OTEL endpoint ({endpoint}) \
+                             does not match the API URL ({api_url}). Skipping cache token \
+                             injection to prevent sending credentials to an unrelated endpoint."
+                        );
+                        return None;
+                    }
+                    self.api_auth.as_ref().map(|auth| auth.token.expose())
+                });
                 observability::Handle::try_init(opts, token)
             });
         let repo_index = Arc::new(match repo_index_task {
@@ -1025,5 +1034,75 @@ impl RunBuilder {
         }
 
         Ok(engine)
+    }
+}
+
+fn extract_host(url: &str) -> Option<&str> {
+    let after_scheme = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))?;
+    let host_and_port = after_scheme.split('/').next()?;
+    Some(host_and_port.split(':').next().unwrap_or(host_and_port))
+}
+
+fn hosts_match(url1: &str, url2: &str) -> bool {
+    match (extract_host(url1), extract_host(url2)) {
+        (Some(h1), Some(h2)) => h1.eq_ignore_ascii_case(h2),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod hosts_match_tests {
+    use super::*;
+
+    #[test]
+    fn same_host_different_paths() {
+        assert!(hosts_match(
+            "https://vercel.com/otel",
+            "https://vercel.com/api"
+        ));
+    }
+
+    #[test]
+    fn different_hosts() {
+        assert!(!hosts_match(
+            "https://third-party.com/otel",
+            "https://vercel.com/api"
+        ));
+    }
+
+    #[test]
+    fn case_insensitive() {
+        assert!(hosts_match(
+            "https://Vercel.COM/otel",
+            "https://vercel.com/api"
+        ));
+    }
+
+    #[test]
+    fn with_port() {
+        assert!(hosts_match(
+            "https://vercel.com:443/otel",
+            "https://vercel.com/api"
+        ));
+    }
+
+    #[test]
+    fn different_subdomains_do_not_match() {
+        assert!(!hosts_match(
+            "https://otel.vercel.com/v1",
+            "https://vercel.com/api"
+        ));
+    }
+
+    #[test]
+    fn missing_scheme_returns_false() {
+        assert!(!hosts_match("vercel.com/otel", "https://vercel.com/api"));
+    }
+
+    #[test]
+    fn empty_url_returns_false() {
+        assert!(!hosts_match("", "https://vercel.com/api"));
     }
 }


### PR DESCRIPTION
## Problem

tl;dr it seems that you can only configure OTEL through turbo.json OR env vars, and not a mix. I had a use-case where I wanted to keep the secret/auth token out of turbo.json and only set that on CI or on developers machines, but keep the config in turbo.json. A few reasons is that then I don't have to many tooo many env vars, and also, it's easier to share 1 env var rather than the 4 to 5 needed if we went all in on env vars.

Another way to explain it is that setting any single `TURBO_EXPERIMENTAL_OTEL_*` env var will opt turbo out of reading from turbo.json, even if fields are set. For example, adding the env var `TURBO_EXPERIMENTAL_OTEL_HEADERS` creates a partial `ExperimentalOtelOptions` with only `headers` set. Because the outer `Option<ExperimentalOtelOptions>` is now `Some`, the entire block from lower-priority sources, including `endpoint` and `protocol` from `turbo.json`, is discarded by `merge::option::overwrite_none`. The OTEL exporter is then "misconfigured" from turbo's POV and doesn't work.

The same issue affects `metrics`, `run_attributes`, and `task_attributes`: a single env-var flag (e.g. `TURBO_EXPERIMENTAL_OTEL_METRICS_TASK_DETAILS`) would shadow all sibling flags configured in `turbo.json`. These are maybe.. not as popular edge cases compared to mine where I just wanted to set a token. Although I think having a protected/authed endpoint and only exposing _that_ secret/token in CI is a nice way to manage things.

So, for example, a typical working setup that hits this bug:

```jsonc
"experimentalObservability": {
  "otel": {
    "endpoint": "https://endpoint-that-is-not-really-a-secret.com",
    "protocol": "grpc"
  }
}
```

```sh
# .. then in the CI, you set any header.. let's say the secrets
TURBO_EXPERIMENTAL_OTEL_HEADERS=authorization=Bearer <token>
```

**Expected:** headers env var is merged in alongside things inside turbo.json, and then then OTEL exports successfully
**Actual:** env var preempts turbo.json entirely, no endpoint, and now OTEL is skipped entirely since it doesn't have any info

(well I would say it's Expected ☺️)

## Fix

Introduce `merge_option_deep<T: Merge>`, a small `pub(crate)` helper that recurses into `Some(T)` rather than treating the option as an atomic unit. Apply it at four nesting levels where `overwrite_none` causes the problem:

- `ConfigurationOptions.experimental_observability`
- `ExperimentalObservabilityOptions.otel`
- `ExperimentalOtelOptions.metrics`
- `ExperimentalOtelMetricsOptions.{run_attributes, task_attributes}`

Higher-priority sources still win for every field they explicitly set. The change only allows lower-priority sources to fill in fields left as `None` by higher-priority sources.. consistent with how every other flat config field (`TURBO_TOKEN`, `TURBO_TEAM`, etc.) already behaves.

I was not sure what kind of pattern you follow, so I inlined merge_option_deep. I tried to peek around the codebase to see if this pattern was common elsewhere.

## Test changes

`test_experimental_observability_otel_precedence` is updated to assert the correct post-fix behaviour:

- `enabled` (set only in turbo.json) is now `Some(true)` instead of `None`
- `task_attributes.id` (set only via env var) is now `Some(true)` even though
  the builder override provided a partial `otel` object that left it unset

## Checklist

What I considered:

- [x] `cargo test -p turborepo-config --lib` passes (83/83)
- [x] No behaviour change for users who configure OTEL entirely from one source

Again let me know if the rust code needs tweaking, Opus helped again. 

Also, I am not sure if it is intentional that you cannot have a mix. In my experience, I am used to be able to mix env vars and inlined config. If that is an **intentional** API design, then please do feel free to close this PR. Totally understand!