### PR TITLE
docs: Send siteId as label on feedback GitHub issues

### DIFF
--- a/apps/docs/app/actions/feedback/index.ts
+++ b/apps/docs/app/actions/feedback/index.ts
@@ -2,6 +2,7 @@
 
 import { headers } from "next/headers";
 import type { Feedback } from "@/components/geistdocs/feedback";
+import { siteId } from "@/geistdocs";
 import { emotions } from "./emotions";
 
 const protocol = process.env.NODE_ENV === "production" ? "https" : "http";
@@ -26,7 +27,7 @@ export const sendFeedback = async (
       emotion: emoji,
       ua: headersList.get("user-agent") ?? undefined,
       ip: headersList.get("x-real-ip") || headersList.get("x-forwarded-for"),
-      label: "turbo-site"
+      label: siteId
     })
   });
 


### PR DESCRIPTION
## Summary
- Imports `siteId` from `geistdocs.tsx` config and passes it as the `label` field in the feedback POST body
- Issues created in `vercel/feedback` will now be labeled with the originating site
- Backward-compatible: if `siteId` is undefined, the platform falls back to `"vercel-site"`

See vercel/geistdocs#57 for the upstream template change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)