### PR TITLE
feat: Allow `--affected` and `--filter` to be combined

### DIFF
--- a/apps/docs/content/docs/reference/ls.mdx
+++ b/apps/docs/content/docs/reference/ls.mdx
@@ -34,6 +34,13 @@ turbo ls web @repo/ui [package(s)]
 
 Automatically filter to only packages that are affected by changes on the current branch.
 
+When combined with `--filter`, returns the intersection: only packages that are both affected **and** match the filter.
+
+```bash title="Terminal"
+turbo ls --affected
+turbo ls --affected --filter=web
+```
+
 By default the changes considered are those between `main` and `HEAD`.
 
 - You can override `main` as the default base by setting `TURBO_SCM_BASE`.

--- a/apps/docs/content/docs/reference/query.mdx
+++ b/apps/docs/content/docs/reference/query.mdx
@@ -92,10 +92,13 @@ turbo query ls -F my-app...
 
 #### `--affected`
 
-Show only packages affected by changes between the current branch and `main`. Cannot be combined with `--filter`.
+Show only packages affected by changes between the current branch and `main`.
+
+When combined with `--filter`, returns the intersection: only packages that are both affected **and** match the filter.
 
 ```bash title="Terminal"
 turbo query ls --affected
+turbo query ls --affected --filter=web
 ```
 
 #### `--output`

--- a/apps/docs/content/docs/reference/run.mdx
+++ b/apps/docs/content/docs/reference/run.mdx
@@ -52,6 +52,16 @@ Filter to only packages that are affected by changes on the current branch.
 turbo run build lint test --affected
 ```
 
+When combined with `--filter`, only packages matching **both** constraints are selected. This is useful for narrowing a CI run to affected packages within a specific scope:
+
+```bash title="Terminal"
+# Only run build for "web" if it's affected by changes
+turbo run build --affected --filter=web
+
+# Run affected packages, excluding "docs"
+turbo run build --affected --filter=!docs
+```
+
 By default, the flag is equivalent to `--filter=...[main...HEAD]`. This considers changes between `main` and `HEAD` from Git's perspective.
 
 <Callout type="warn">

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -706,13 +706,13 @@ pub enum Command {
     Ls {
         /// Show only packages that are affected by changes between
         /// the current branch and `main`
-        #[clap(long, group = "scope-filter-group")]
+        #[clap(long)]
         affected: bool,
         /// Use the given selector to specify package(s) to act as
         /// entry points. The syntax mirrors pnpm's syntax, and
         /// additional documentation and examples can be found in
         /// turbo's documentation https://turborepo.dev/docs/reference/command-line-reference/run#--filter
-        #[clap(short = 'F', long, group = "scope-filter-group")]
+        #[clap(short = 'F', long)]
         filter: Vec<String>,
         /// Get insight into a specific package, such as
         /// its dependencies and tasks
@@ -900,13 +900,13 @@ pub enum QuerySubcommand {
 pub struct LsArgs {
     /// Show only packages that are affected by changes between
     /// the current branch and `main`
-    #[clap(long, group = "scope-filter-group")]
+    #[clap(long)]
     pub affected: bool,
     /// Use the given selector to specify package(s) to act as
     /// entry points. The syntax mirrors pnpm's syntax, and
     /// additional documentation and examples can be found in
     /// turbo's documentation https://turborepo.dev/docs/reference/command-line-reference/run#--filter
-    #[clap(short = 'F', long, group = "scope-filter-group")]
+    #[clap(short = 'F', long)]
     pub filter: Vec<String>,
     /// Get insight into a specific package, such as
     /// its dependencies and tasks
@@ -1010,7 +1010,7 @@ pub struct ExecutionArgs {
 
     /// Filter to only packages that are affected by changes between
     /// the current branch and `main`
-    #[clap(long, group = "scope-filter-group", conflicts_with = "filter")]
+    #[clap(long, group = "scope-filter-group")]
     pub affected: bool,
 
     /// Set type of process output logging. Use "full" to show
@@ -3533,14 +3533,14 @@ mod test {
     }
 
     #[test]
-    fn test_prevent_affected_and_filter() {
+    fn test_affected_and_filter_can_be_combined() {
         assert!(
             Args::try_parse_from(["turbo", "run", "build", "--affected", "--filter", "foo"])
-                .is_err(),
+                .is_ok(),
         );
-        assert!(Args::try_parse_from(["turbo", "build", "--affected", "--filter", "foo"]).is_err(),);
-        assert!(Args::try_parse_from(["turbo", "build", "--filter", "foo", "--affected"]).is_err(),);
-        assert!(Args::try_parse_from(["turbo", "ls", "--filter", "foo", "--affected"]).is_err(),);
+        assert!(Args::try_parse_from(["turbo", "build", "--affected", "--filter", "foo"]).is_ok(),);
+        assert!(Args::try_parse_from(["turbo", "build", "--filter", "foo", "--affected"]).is_ok(),);
+        assert!(Args::try_parse_from(["turbo", "ls", "--filter", "foo", "--affected"]).is_ok(),);
     }
 
     struct SinglePackageTestCase {

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -732,7 +732,7 @@ impl RunBuilder {
 
         // Task-level filter: resolve --filter and/or --affected against the task graph.
         if use_task_level_filter {
-            let mut selectors: Vec<turborepo_scope::TargetSelector> = self
+            let selectors: Vec<turborepo_scope::TargetSelector> = self
                 .opts
                 .scope_opts
                 .filter_patterns
@@ -741,26 +741,24 @@ impl RunBuilder {
                 .collect::<Result<_, _>>()
                 .map_err(turborepo_scope::ResolutionError::from)?;
 
-            // When --affected is used alongside filterUsingTasks, synthesize a
-            // selector equivalent to `...[base...HEAD]` so it flows through
-            // the same task-level filter instead of a separate codepath.
-            if let Some((from_ref, to_ref)) = &self.opts.scope_opts.affected_range {
-                selectors.push(turborepo_scope::TargetSelector {
-                    git_range: Some(turborepo_scope::GitRange {
-                        from_ref: from_ref.clone(),
-                        to_ref: to_ref.clone(),
-                        include_uncommitted: true,
-                        allow_unknown_objects: true,
-                        merge_base: true,
-                    }),
-                    include_dependents: true,
-                    ..Default::default()
-                });
-            }
+            let affected_constraint =
+                if let Some(affected_range) = &self.opts.scope_opts.affected_range {
+                    Some(super::task_filter::resolve_affected_tasks(
+                        &engine,
+                        affected_range,
+                        &pkg_dep_graph,
+                        &scm,
+                        &self.repo_root,
+                        &root_turbo_json.global_deps,
+                    )?)
+                } else {
+                    None
+                };
 
             engine = super::task_filter::filter_engine_to_tasks(
                 engine,
                 &selectors,
+                affected_constraint.as_ref(),
                 &pkg_dep_graph,
                 &scm,
                 &self.repo_root,

--- a/crates/turborepo-lib/src/run/task_filter.rs
+++ b/crates/turborepo-lib/src/run/task_filter.rs
@@ -26,16 +26,48 @@ use wax::Program;
 
 use crate::engine::Engine;
 
+/// Resolves an `--affected` range to the set of task IDs that are affected
+/// (changed + dependents). Used by the builder to compute an intersection
+/// constraint when both `--affected` and `--filter` are active.
+pub fn resolve_affected_tasks(
+    engine: &Engine,
+    affected_range: &(Option<String>, Option<String>),
+    pkg_dep_graph: &PackageGraph,
+    scm: &SCM,
+    repo_root: &AbsoluteSystemPath,
+    global_deps: &[String],
+) -> Result<HashSet<TaskId<'static>>, crate::run::error::Error> {
+    let selector = TargetSelector {
+        git_range: Some(GitRange {
+            from_ref: affected_range.0.clone(),
+            to_ref: affected_range.1.clone(),
+            include_uncommitted: true,
+            allow_unknown_objects: true,
+            merge_base: true,
+        }),
+        include_dependents: true,
+        ..Default::default()
+    };
+    resolve_selector_to_tasks(
+        engine,
+        &selector,
+        pkg_dep_graph,
+        scm,
+        repo_root,
+        global_deps,
+    )
+}
+
 /// Filters an engine down to only the tasks matching the given selectors.
 ///
 /// Each include selector contributes a set of tasks (unioned together).
-/// Exclude selectors remove tasks from the result. After all selectors
-/// are processed, the engine is pruned to the surviving tasks, their
-/// transitive dependents, and all transitive dependencies needed for
-/// execution.
+/// Exclude selectors remove tasks from the result. When
+/// `affected_constraint` is provided, the included tasks are intersected
+/// with it before excludes are applied.
 pub fn filter_engine_to_tasks(
     engine: Engine,
     selectors: &[TargetSelector],
+    affected_constraint: Option<&HashSet<TaskId<'static>>>,
     pkg_dep_graph: &PackageGraph,
     scm: &SCM,
     repo_root: &AbsoluteSystemPath,
@@ -60,6 +92,10 @@ pub fn filter_engine_to_tasks(
     // If there were no include selectors (only excludes), start with all tasks.
     if include.is_empty() {
         included_tasks = engine.task_ids().cloned().collect();
+    }
+
+    if let Some(affected) = affected_constraint {
+        included_tasks.retain(|t| affected.contains(t));
     }
 
     for selector in &exclude {
@@ -648,7 +684,7 @@ mod tests {
         };
 
         let result =
-            super::filter_engine_to_tasks(engine, &[selector], &pkg_graph, &scm, root, &[])
+            super::filter_engine_to_tasks(engine, &[selector], None, &pkg_graph, &scm, root, &[])
                 .unwrap();
 
         let remaining: HashSet<_> = result.task_ids().cloned().collect();
@@ -659,6 +695,172 @@ mod tests {
         assert!(
             !remaining.contains(&app_build),
             "app#build should NOT be pulled in as a dependent: {remaining:?}"
+        );
+    }
+
+    /// Include selector + affected constraint → only tasks matching both.
+    ///
+    /// Engine: ui#build, app#build (app depends on ui).
+    /// Selector: name=ui (selects ui#build, engine retains ui#build).
+    /// Affected: {app#build} (only app is affected).
+    /// Result: empty — ui#build is selected by filter but not affected.
+    #[tokio::test]
+    async fn affected_constraint_intersects_with_include() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let pkg_graph = make_pkg_graph(root, &["ui", "app"]).await;
+        let scm = turborepo_scm::SCM::new(root);
+
+        let ui_build = TaskId::new("ui", "build");
+        let app_build = TaskId::new("app", "build");
+
+        let engine = make_engine(
+            &[
+                (ui_build.clone(), TaskDefinition::default()),
+                (app_build.clone(), TaskDefinition::default()),
+            ],
+            &[(app_build.clone(), ui_build.clone())],
+        );
+
+        let selector = turborepo_scope::TargetSelector {
+            name_pattern: "ui".to_string(),
+            ..Default::default()
+        };
+
+        let affected: HashSet<TaskId<'static>> = [app_build.clone()].into_iter().collect();
+
+        let result = super::filter_engine_to_tasks(
+            engine,
+            &[selector],
+            Some(&affected),
+            &pkg_graph,
+            &scm,
+            root,
+            &[],
+        )
+        .unwrap();
+
+        let remaining: HashSet<_> = result.task_ids().cloned().collect();
+        assert!(
+            !remaining.contains(&ui_build),
+            "ui#build is not affected and should be excluded: {remaining:?}"
+        );
+    }
+
+    /// Exclude selector + affected constraint → affected minus excluded.
+    ///
+    /// Engine: ui#build, app#build, lib#build (no edges between them).
+    /// Selector: exclude ui.
+    /// Affected: {ui#build, app#build}.
+    /// Result: {app#build} — ui is excluded, lib is not affected.
+    #[tokio::test]
+    async fn affected_constraint_with_exclude_selector() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let pkg_graph = make_pkg_graph(root, &["ui", "app", "lib"]).await;
+        let scm = turborepo_scm::SCM::new(root);
+
+        let ui_build = TaskId::new("ui", "build");
+        let app_build = TaskId::new("app", "build");
+        let lib_build = TaskId::new("lib", "build");
+
+        // No dependency edges — tasks are independent
+        let engine = make_engine(
+            &[
+                (ui_build.clone(), TaskDefinition::default()),
+                (app_build.clone(), TaskDefinition::default()),
+                (lib_build.clone(), TaskDefinition::default()),
+            ],
+            &[],
+        );
+
+        let exclude_selector = turborepo_scope::TargetSelector {
+            name_pattern: "ui".to_string(),
+            exclude: true,
+            ..Default::default()
+        };
+
+        let affected: HashSet<TaskId<'static>> =
+            [ui_build.clone(), app_build.clone()].into_iter().collect();
+
+        let result = super::filter_engine_to_tasks(
+            engine,
+            &[exclude_selector],
+            Some(&affected),
+            &pkg_graph,
+            &scm,
+            root,
+            &[],
+        )
+        .unwrap();
+
+        let remaining: HashSet<_> = result.task_ids().cloned().collect();
+        assert!(
+            remaining.contains(&app_build),
+            "app#build is affected and not excluded: {remaining:?}"
+        );
+        assert!(
+            !remaining.contains(&ui_build),
+            "ui#build should be excluded: {remaining:?}"
+        );
+        assert!(
+            !remaining.contains(&lib_build),
+            "lib#build is not affected: {remaining:?}"
+        );
+    }
+
+    /// Empty selectors + affected constraint → only affected tasks survive.
+    ///
+    /// Engine: ui#build, app#build, lib#build.
+    /// Selectors: none.
+    /// Affected: {app#build}.
+    /// Result: {app#build} (plus ui#build as a transitive dep for execution).
+    #[tokio::test]
+    async fn affected_constraint_with_empty_selectors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let pkg_graph = make_pkg_graph(root, &["ui", "app", "lib"]).await;
+        let scm = turborepo_scm::SCM::new(root);
+
+        let ui_build = TaskId::new("ui", "build");
+        let app_build = TaskId::new("app", "build");
+        let lib_build = TaskId::new("lib", "build");
+
+        // app depends on ui
+        let engine = make_engine(
+            &[
+                (ui_build.clone(), TaskDefinition::default()),
+                (app_build.clone(), TaskDefinition::default()),
+                (lib_build.clone(), TaskDefinition::default()),
+            ],
+            &[(app_build.clone(), ui_build.clone())],
+        );
+
+        let affected: HashSet<TaskId<'static>> = [app_build.clone()].into_iter().collect();
+
+        let result = super::filter_engine_to_tasks(
+            engine,
+            &[],
+            Some(&affected),
+            &pkg_graph,
+            &scm,
+            root,
+            &[],
+        )
+        .unwrap();
+
+        let remaining: HashSet<_> = result.task_ids().cloned().collect();
+        assert!(
+            remaining.contains(&app_build),
+            "app#build is affected: {remaining:?}"
+        );
+        assert!(
+            remaining.contains(&ui_build),
+            "ui#build should be retained as a transitive dependency of app#build: {remaining:?}"
+        );
+        assert!(
+            !remaining.contains(&lib_build),
+            "lib#build is not affected and not a dependency: {remaining:?}"
         );
     }
 

--- a/crates/turborepo-scope/src/filter.rs
+++ b/crates/turborepo-scope/src/filter.rs
@@ -235,25 +235,75 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
         }
 
         // Parse selectors once — reused for both mode classification and resolution.
-        let mut selectors: Vec<TargetSelector> = patterns
+        let selectors: Vec<TargetSelector> = patterns
             .iter()
             .map(|pattern| TargetSelector::from_str(pattern))
             .collect::<Result<Vec<_>, _>>()?;
 
         let mode = self.classify_filter_mode(&selectors, affected);
 
-        if let Some((from_ref, to_ref)) = affected {
-            selectors.push(TargetSelector {
-                git_range: Some(GitRange {
-                    from_ref: from_ref.clone(),
-                    to_ref: to_ref.clone(),
-                    include_uncommitted: true,
-                    allow_unknown_objects: true,
-                    merge_base: true,
-                }),
-                include_dependents: true,
-                ..Default::default()
-            });
+        let affected_selector = affected.as_ref().map(|(from_ref, to_ref)| TargetSelector {
+            git_range: Some(GitRange {
+                from_ref: from_ref.clone(),
+                to_ref: to_ref.clone(),
+                include_uncommitted: true,
+                allow_unknown_objects: true,
+                merge_base: true,
+            }),
+            include_dependents: true,
+            ..Default::default()
+        });
+
+        if let Some(affected_sel) = affected_selector {
+            if selectors.is_empty() {
+                let packages = self.get_filtered_packages(vec![affected_sel])?;
+                return Ok((packages, mode));
+            }
+
+            let affected_pkgs = self.get_filtered_packages(vec![affected_sel])?;
+
+            // Explicit include/exclude ordering that mirrors task_filter.rs:
+            //   (filter_includes ∩ affected) - filter_excludes
+            let (include_sels, exclude_sels): (Vec<_>, Vec<_>) =
+                selectors.into_iter().partition(|s| !s.exclude);
+
+            let included = if include_sels.is_empty() {
+                // No include selectors → start from full affected set
+                affected_pkgs
+            } else {
+                let filter_pkgs = self.get_filtered_packages(include_sels)?;
+                filter_pkgs
+                    .into_iter()
+                    .filter(|(name, _)| affected_pkgs.contains_key(name))
+                    .collect()
+            };
+
+            if exclude_sels.is_empty() {
+                return Ok((included, mode));
+            }
+
+            // Resolve exclude selectors to the set of package names to subtract.
+            // Flip the exclude flag so filter_graph resolves them as normal
+            // includes — we just need the matching package names.
+            let exclude_names: HashSet<PackageName> = {
+                let as_includes: Vec<_> = exclude_sels
+                    .into_iter()
+                    .map(|mut s| {
+                        s.exclude = false;
+                        s
+                    })
+                    .collect();
+                self.get_filtered_packages(as_includes)?
+                    .into_keys()
+                    .collect()
+            };
+
+            let packages = included
+                .into_iter()
+                .filter(|(name, _)| !exclude_names.contains(name))
+                .collect();
+
+            return Ok((packages, mode));
         }
 
         let packages = self.get_filtered_packages(selectors)?;
@@ -1970,6 +2020,149 @@ mod test {
             FilterMode::ExcludeOnly {
                 root_excluded: true
             }
+        );
+    }
+
+    /// Helper that resolves with both affected and filter patterns and returns
+    /// the selected package names.
+    fn resolve_affected_with_filter(
+        patterns: &[&str],
+        changed: &[(&str, Option<&str>, &[&str])],
+    ) -> HashSet<PackageName> {
+        let (_tempdir, resolver) = make_project(
+            &[
+                ("packages/project-0", "packages/project-1"),
+                ("packages/project-0", "project-5"),
+            ],
+            &["project-3"],
+            None,
+            TestChangeDetector::new(changed),
+        );
+        let affected = Some((Some("main".to_string()), None));
+        let patterns: Vec<String> = patterns.iter().map(|s| s.to_string()).collect();
+        let (pkgs, _) = resolver.resolve(&affected, &patterns).unwrap();
+        pkgs.into_keys().collect()
+    }
+
+    #[test]
+    fn affected_with_include_filter_intersects() {
+        // project-5 changed → affected = {project-5, project-0}
+        // filter = project-0 → result = {project-0}
+        let pkgs = resolve_affected_with_filter(&["project-0"], &[("main", None, &["project-5"])]);
+        assert_eq!(pkgs, HashSet::from([PackageName::from("project-0")]));
+    }
+
+    #[test]
+    fn affected_with_exclude_filter_subtracts() {
+        // project-5 changed → affected = {project-5, project-0}
+        // filter = !project-0 → result = {project-5}
+        let pkgs = resolve_affected_with_filter(&["!project-0"], &[("main", None, &["project-5"])]);
+        assert_eq!(pkgs, HashSet::from([PackageName::from("project-5")]));
+    }
+
+    #[test]
+    fn affected_with_filter_no_overlap_is_empty() {
+        // project-5 changed → affected = {project-5, project-0}
+        // filter = project-3 → result = {} (project-3 not affected)
+        let pkgs = resolve_affected_with_filter(&["project-3"], &[("main", None, &["project-5"])]);
+        assert!(pkgs.is_empty(), "expected empty, got {pkgs:?}");
+    }
+
+    #[test]
+    fn affected_with_include_and_exclude_filter() {
+        // project-1 changed → affected = {project-1, project-0}
+        // filter = project-0, !project-1 → filter_result = {project-0}
+        // intersection = {project-0}
+        let pkgs = resolve_affected_with_filter(
+            &["project-0", "!project-1"],
+            &[("main", None, &["project-1"])],
+        );
+        assert_eq!(pkgs, HashSet::from([PackageName::from("project-0")]));
+    }
+
+    #[test]
+    fn affected_with_git_range_filter_different_ref() {
+        // affected("main") → project-5 changed → {project-5, project-0}
+        // filter `...[develop]` → project-1 changed + dependents → {project-1,
+        // project-0} intersection = {project-0}
+        let pkgs = resolve_affected_with_filter(
+            &["...[develop]"],
+            &[
+                ("main", None, &["project-5"]),
+                ("develop", None, &["project-1"]),
+            ],
+        );
+        assert_eq!(pkgs, HashSet::from([PackageName::from("project-0")]));
+    }
+
+    #[test]
+    fn affected_with_git_range_filter_same_ref() {
+        // Both affected and filter resolve against "main" with the same
+        // changed packages. Intersection should equal the full affected set.
+        let pkgs = resolve_affected_with_filter(&["...[main]"], &[("main", None, &["project-5"])]);
+        assert_eq!(
+            pkgs,
+            HashSet::from([
+                PackageName::from("project-5"),
+                PackageName::from("project-0"),
+            ])
+        );
+    }
+
+    #[test]
+    fn affected_with_dependents_filter() {
+        // project-5 changed → affected = {project-5, project-0}
+        // filter `...project-1` → {project-1, project-0} (project-1 + dependent
+        // project-0) intersection = {project-0}
+        let pkgs =
+            resolve_affected_with_filter(&["...project-1"], &[("main", None, &["project-5"])]);
+        assert_eq!(pkgs, HashSet::from([PackageName::from("project-0")]));
+    }
+
+    #[test]
+    fn affected_with_multiple_include_filters() {
+        // project-5 changed → affected = {project-5, project-0}
+        // filter = project-0 ∪ project-3 = {project-0, project-3}
+        // intersection = {project-0}
+        let pkgs = resolve_affected_with_filter(
+            &["project-0", "project-3"],
+            &[("main", None, &["project-5"])],
+        );
+        assert_eq!(pkgs, HashSet::from([PackageName::from("project-0")]));
+    }
+
+    #[test]
+    fn affected_with_multiple_exclude_filters() {
+        // project-5 changed → affected = {project-5, project-0}
+        // no includes → start from affected, exclude both → empty
+        let pkgs = resolve_affected_with_filter(
+            &["!project-0", "!project-5"],
+            &[("main", None, &["project-5"])],
+        );
+        assert!(pkgs.is_empty(), "expected empty, got {pkgs:?}");
+    }
+
+    #[test]
+    fn affected_alone_unchanged() {
+        // Verify that --affected without --filter still works as before.
+        let (_tempdir, resolver) = make_project(
+            &[
+                ("packages/project-0", "packages/project-1"),
+                ("packages/project-0", "project-5"),
+            ],
+            &["project-3"],
+            None,
+            TestChangeDetector::new(&[("main", None, &["project-5"])]),
+        );
+        let affected = Some((Some("main".to_string()), None));
+        let (pkgs, _) = resolver.resolve(&affected, &[]).unwrap();
+        let names: HashSet<PackageName> = pkgs.into_keys().collect();
+        assert_eq!(
+            names,
+            HashSet::from([
+                PackageName::from("project-5"),
+                PackageName::from("project-0"),
+            ])
         );
     }
 }

--- a/crates/turborepo/tests/affected_test.rs
+++ b/crates/turborepo/tests/affected_test.rs
@@ -1477,3 +1477,258 @@ fn test_query_affected_exit_code_error_returns_2() {
         "--exit-code should exit 2 on query errors, not 1"
     );
 }
+
+#[test]
+fn test_affected_with_filter_intersects() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_affected(tempdir.path());
+
+    // Change util → affected = {util, my-app} (my-app depends on util)
+    fs::write(tempdir.path().join("packages/util/new.js"), "hello").unwrap();
+
+    // --affected --filter=my-app should only run my-app (not util)
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "run",
+            "build",
+            "--affected",
+            "--filter=my-app",
+            "--log-order",
+            "grouped",
+        ],
+    );
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Packages in scope: my-app"),
+        "only my-app should be in scope: {stdout}"
+    );
+    assert!(stdout.contains("1 successful, 1 total"));
+}
+
+#[test]
+fn test_affected_with_exclude_filter() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_affected(tempdir.path());
+
+    // Change util → affected = {util, my-app}
+    fs::write(tempdir.path().join("packages/util/new.js"), "hello").unwrap();
+
+    // --affected --filter=!my-app should run util but not my-app
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "run",
+            "build",
+            "--affected",
+            "--filter=!my-app",
+            "--log-order",
+            "grouped",
+        ],
+    );
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Packages in scope: util"),
+        "only util should be in scope: {stdout}"
+    );
+    assert!(stdout.contains("1 successful, 1 total"));
+}
+
+#[test]
+fn test_affected_with_filter_no_overlap() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_affected(tempdir.path());
+
+    // Change my-app only → affected = {my-app}
+    fs::write(tempdir.path().join("apps/my-app/new.js"), "hello").unwrap();
+
+    // --affected --filter=another → empty intersection (another not affected)
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "run",
+            "build",
+            "--affected",
+            "--filter=another",
+            "--log-order",
+            "grouped",
+        ],
+    );
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("0 successful, 0 total"),
+        "no packages should run: {stdout}"
+    );
+}
+
+#[test]
+fn test_affected_with_filter_ls() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_affected(tempdir.path());
+
+    // Change util → affected = {util, my-app}
+    fs::write(tempdir.path().join("packages/util/new.js"), "hello").unwrap();
+
+    // turbo ls --affected --filter=my-app should list only my-app
+    let output = run_turbo(tempdir.path(), &["ls", "--affected", "--filter=my-app"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("1 package"), "expected 1 package: {stdout}");
+    assert!(
+        stdout.contains("my-app"),
+        "my-app should be listed: {stdout}"
+    );
+}
+
+#[test]
+fn test_affected_with_dependents_filter() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_affected(tempdir.path());
+
+    // Change my-app only → affected = {my-app}
+    fs::write(tempdir.path().join("apps/my-app/new.js"), "hello").unwrap();
+
+    // --affected --filter='...util' → filter selects util + dependents = {util,
+    // my-app} intersection with affected {my-app} = {my-app}
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "run",
+            "build",
+            "--affected",
+            "--filter=...util",
+            "--log-order",
+            "grouped",
+        ],
+    );
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Packages in scope: my-app"),
+        "only my-app should be in scope (affected ∩ dependents of util): {stdout}"
+    );
+    assert!(stdout.contains("1 successful, 1 total"));
+}
+
+#[test]
+fn test_affected_with_multiple_include_filters() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_affected(tempdir.path());
+
+    // Change util → affected = {util, my-app}
+    fs::write(tempdir.path().join("packages/util/new.js"), "hello").unwrap();
+
+    // --filter=my-app --filter=util → union = {my-app, util}
+    // intersection with affected {util, my-app} = {util, my-app}
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "run",
+            "build",
+            "--affected",
+            "--filter=my-app",
+            "--filter=util",
+            "--log-order",
+            "grouped",
+        ],
+    );
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("2 successful, 2 total"),
+        "both my-app and util should run: {stdout}"
+    );
+}
+
+#[test]
+fn test_affected_with_multiple_include_filters_partial_overlap() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_affected(tempdir.path());
+
+    // Change my-app only → affected = {my-app}
+    fs::write(tempdir.path().join("apps/my-app/new.js"), "hello").unwrap();
+
+    // --filter=my-app --filter=util → union = {my-app, util}
+    // intersection with affected {my-app} = {my-app} (util not affected)
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "run",
+            "build",
+            "--affected",
+            "--filter=my-app",
+            "--filter=util",
+            "--log-order",
+            "grouped",
+        ],
+    );
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Packages in scope: my-app"),
+        "only my-app should run (util not affected): {stdout}"
+    );
+    assert!(stdout.contains("1 successful, 1 total"));
+}
+
+#[test]
+fn test_affected_with_git_range_filter() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_affected(tempdir.path());
+
+    // Change util → affected = {util, my-app}
+    fs::write(tempdir.path().join("packages/util/new.js"), "hello").unwrap();
+
+    // --filter='[main]' is a git-range filter that resolves changed packages
+    // since main — same as --affected's default. The intersection should be
+    // the same as --affected alone.
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "run",
+            "build",
+            "--affected",
+            "--filter=...[main]",
+            "--log-order",
+            "grouped",
+        ],
+    );
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("2 successful, 2 total"),
+        "both util and my-app should run (both filters agree): {stdout}"
+    );
+}
+
+#[test]
+fn test_affected_with_multiple_excludes() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_affected(tempdir.path());
+
+    // Change util → affected = {util, my-app}
+    fs::write(tempdir.path().join("packages/util/new.js"), "hello").unwrap();
+
+    // --filter=!my-app --filter=!util → exclude both → empty
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "run",
+            "build",
+            "--affected",
+            "--filter=!my-app",
+            "--filter=!util",
+            "--log-order",
+            "grouped",
+        ],
+    );
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("0 successful, 0 total"),
+        "no packages should run (all excluded): {stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #10689

`--affected` and `--filter` were previously mutually exclusive. This PR makes them composable with intersection semantics — only packages/tasks matching **both** constraints are selected. For example:

```sh
turbo run build --affected --filter=web    # build web only if affected
turbo run build --affected --filter=!docs  # build affected packages except docs
turbo ls --affected --filter=my-app        # list my-app only if affected
```

## What changed

- **CLI**: Removed `conflicts_with` and `scope-filter-group` constraints that prevented combining the flags.
- **Package-level filter** (`filter.rs`): Affected and filter are now resolved independently with explicit `(includes ∩ affected) - excludes` ordering, matching the task-level path.
- **Task-level filter** (`task_filter.rs`): New `resolve_affected_tasks` function computes the affected task set separately. `filter_engine_to_tasks` accepts an optional `affected_constraint` for intersection.
- **Builder** (`builder.rs`): Orchestrates the two-phase resolution — affected constraint is computed first, then passed into the filter function.
- **Docs**: Updated `run.mdx`, `ls.mdx`, and `query.mdx` to document the combination behavior.

## How to test

```sh
# In a monorepo on a feature branch with changes:
turbo run build --affected --filter=<pkg>      # should only run if <pkg> is affected
turbo run build --affected --filter=!<pkg>     # affected minus <pkg>
turbo run build --affected --filter=...<pkg>   # affected ∩ dependents of <pkg>
turbo ls --affected --filter=<pkg>             # same intersection for ls
```

## Test coverage

- **15 new unit tests** across `filter.rs` and `task_filter.rs` covering: include/exclude intersection, git-range filters with different refs, dependents traversal, multiple includes/excludes, empty selectors with affected constraint
- **6 new integration tests** in `affected_test.rs` covering: dependents filter, multiple includes (full and partial overlap), git-range filter, multiple excludes, and the `ls` command