### PR TITLE
feat: Add incremental caching for Rust CI builds

### DIFF
--- a/cli/turbo.json
+++ b/cli/turbo.json
@@ -41,17 +41,10 @@
             "$TURBO_ROOT$/rust-toolchain.toml"
           ],
           "outputs": [
-            "$TURBO_ROOT$/target/**/*.d",
-            "$TURBO_ROOT$/target/**/*.rlib",
-            "$TURBO_ROOT$/target/**/*.rmeta",
-            "$TURBO_ROOT$/target/**/*.dylib",
-            "$TURBO_ROOT$/target/**/*.so",
-            "$TURBO_ROOT$/target/**/*.a",
-            "$TURBO_ROOT$/target/**/*.dll",
-            "$TURBO_ROOT$/target/**/*.lib",
-            "$TURBO_ROOT$/target/**/*.exe",
-            "$TURBO_ROOT$/target/**/build_*",
-            "$TURBO_ROOT$/target/**/.fingerprint/**"
+            "$TURBO_ROOT$/target/**/deps/**",
+            "!$TURBO_ROOT$/target/**/deps/*.rlib",
+            "$TURBO_ROOT$/target/**/.fingerprint/**",
+            "$TURBO_ROOT$/target/**/build/**"
           ]
         }
       ]

--- a/cli/turbo.json
+++ b/cli/turbo.json
@@ -32,6 +32,28 @@
         "CARGO_INCREMENTAL",
         "AWS_ACCESS_KEY_ID",
         "AWS_SECRET_ACCESS_KEY"
+      ],
+      "incremental": [
+        {
+          "inputs": [
+            "$TURBO_ROOT$/Cargo.lock",
+            "$TURBO_ROOT$/.cargo/**",
+            "$TURBO_ROOT$/rust-toolchain.toml"
+          ],
+          "outputs": [
+            "$TURBO_ROOT$/target/**/*.d",
+            "$TURBO_ROOT$/target/**/*.rlib",
+            "$TURBO_ROOT$/target/**/*.rmeta",
+            "$TURBO_ROOT$/target/**/*.dylib",
+            "$TURBO_ROOT$/target/**/*.so",
+            "$TURBO_ROOT$/target/**/*.a",
+            "$TURBO_ROOT$/target/**/*.dll",
+            "$TURBO_ROOT$/target/**/*.lib",
+            "$TURBO_ROOT$/target/**/*.exe",
+            "$TURBO_ROOT$/target/**/build_*",
+            "$TURBO_ROOT$/target/**/.fingerprint/**"
+          ]
+        }
       ]
     },
     "build:test-archive": {
@@ -45,6 +67,21 @@
         "CARGO_INCREMENTAL",
         "AWS_ACCESS_KEY_ID",
         "AWS_SECRET_ACCESS_KEY"
+      ],
+      "incremental": [
+        {
+          "inputs": [
+            "$TURBO_ROOT$/Cargo.lock",
+            "$TURBO_ROOT$/.cargo/**",
+            "$TURBO_ROOT$/rust-toolchain.toml"
+          ],
+          "outputs": [
+            "$TURBO_ROOT$/target/**/deps/**",
+            "!$TURBO_ROOT$/target/**/deps/*.rlib",
+            "$TURBO_ROOT$/target/**/.fingerprint/**",
+            "$TURBO_ROOT$/target/**/build/**"
+          ]
+        }
       ]
     },
     "release-native": {

--- a/crates/turborepo-run-cache/README.md
+++ b/crates/turborepo-run-cache/README.md
@@ -4,6 +4,8 @@
 
 Task-aware caching layer that wraps `turborepo-cache` with task-specific semantics. Handles log files, output modes, and task output tracking.
 
+Also hanadles incremental artifacts.
+
 ## Architecture
 
 ```

--- a/crates/turborepo-run-cache/src/incremental.rs
+++ b/crates/turborepo-run-cache/src/incremental.rs
@@ -7,7 +7,7 @@ use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
 use turborepo_cache::AsyncCache;
 use turborepo_types::{IncrementalPartition, TaskOutputs, TaskOutputsExt};
 
-// Test comment
+// Test comment 1
 
 /// Per-partition result of an incremental fetch attempt.
 #[derive(Debug, Clone)]

--- a/crates/turborepo-run-cache/src/incremental.rs
+++ b/crates/turborepo-run-cache/src/incremental.rs
@@ -59,6 +59,7 @@ pub struct IncrementalTaskCache {
     partitions: Vec<IncrementalPartition>,
     package_name: String,
     task_name: String,
+    task_hash: String,
     cache: AsyncCache,
     repo_root: AbsoluteSystemPathBuf,
     package_dir: AbsoluteSystemPathBuf,
@@ -71,6 +72,7 @@ impl IncrementalTaskCache {
         partitions: Vec<IncrementalPartition>,
         package_name: String,
         task_name: String,
+        task_hash: String,
         cache: AsyncCache,
         repo_root: AbsoluteSystemPathBuf,
         package_dir: AbsoluteSystemPathBuf,
@@ -80,6 +82,7 @@ impl IncrementalTaskCache {
             partitions,
             package_name,
             task_name,
+            task_hash,
             cache,
             repo_root,
             package_dir,
@@ -102,6 +105,7 @@ impl IncrementalTaskCache {
                         let package_dir = self.package_dir.clone();
                         let pkg = self.package_name.clone();
                         let task = self.task_name.clone();
+                        let task_hash = self.task_hash.clone();
                         let inputs = partition.inputs.clone();
                         let outputs = partition.outputs.clone();
                         async move {
@@ -110,6 +114,7 @@ impl IncrementalTaskCache {
                                     &package_dir,
                                     &pkg,
                                     &task,
+                                    &task_hash,
                                     idx,
                                     &inputs,
                                     &outputs,
@@ -303,6 +308,7 @@ fn compute_partition_key(
     package_dir: &AbsoluteSystemPathBuf,
     package_name: &str,
     task_name: &str,
+    task_hash: &str,
     idx: usize,
     inputs: &[String],
     outputs: &TaskOutputs,
@@ -317,6 +323,12 @@ fn compute_partition_key(
 
     let mut hasher = Sha256::new();
     hasher.update(b"incremental:v1:");
+
+    // The task hash already incorporates globalEnv, env, passThroughEnv, and
+    // other task-level configuration. Including it here ensures the
+    // incremental partition is segmented by everything the task cares about
+    // (e.g. OS, RUNNER_OS) without hardcoding platform logic.
+    hasher.update(task_hash.as_bytes());
 
     // Length-prefixed encoding prevents separator collisions
     hasher.update((package_name.len() as u32).to_le_bytes());
@@ -600,8 +612,8 @@ mod tests {
             exclusions: vec![],
         };
 
-        let key_a = compute_partition_key(&dir, "pkg", "task", 0, &[], &outputs_a);
-        let key_b = compute_partition_key(&dir, "pkg", "task", 0, &[], &outputs_b);
+        let key_a = compute_partition_key(&dir, "pkg", "task", "hash123", 0, &[], &outputs_a);
+        let key_b = compute_partition_key(&dir, "pkg", "task", "hash123", 0, &[], &outputs_b);
         assert_ne!(
             key_a, key_b,
             "different output globs must produce different keys"
@@ -617,8 +629,8 @@ mod tests {
             exclusions: vec![],
         };
 
-        let key_ab_c = compute_partition_key(&dir, "a:b", "c", 0, &[], &outputs);
-        let key_a_bc = compute_partition_key(&dir, "a", "b:c", 0, &[], &outputs);
+        let key_ab_c = compute_partition_key(&dir, "a:b", "c", "hash123", 0, &[], &outputs);
+        let key_a_bc = compute_partition_key(&dir, "a", "b:c", "hash123", 0, &[], &outputs);
         assert_ne!(
             key_ab_c, key_a_bc,
             "length-prefixed encoding must prevent separator collisions"
@@ -632,7 +644,8 @@ mod tests {
             inclusions: vec!["dist/**".into()],
             exclusions: vec![],
         };
-        let result = compute_partition_key(&dir, "pkg", "task", 0, &["[invalid".into()], &outputs);
+        let result =
+            compute_partition_key(&dir, "pkg", "task", "hash123", 0, &["[invalid".into()], &outputs);
         assert!(
             result.is_none(),
             "invalid input glob should produce None, not a fallback key"
@@ -647,7 +660,7 @@ mod tests {
             inclusions: vec!["dist/**".into()],
             exclusions: vec![],
         };
-        let key = compute_partition_key(&dir, "pkg", "task", 0, &[], &outputs).unwrap();
+        let key = compute_partition_key(&dir, "pkg", "task", "hash123", 0, &[], &outputs).unwrap();
         assert!(
             key.ends_with("incremental"),
             "key must end with 'incremental'"
@@ -856,8 +869,10 @@ mod tests {
             exclusions: vec![],
         };
 
-        let k1 = compute_partition_key(&dir, "pkg", "build", 0, &["input.txt".into()], &outputs);
-        let k2 = compute_partition_key(&dir, "pkg", "build", 0, &["input.txt".into()], &outputs);
+        let k1 =
+            compute_partition_key(&dir, "pkg", "build", "hash123", 0, &["input.txt".into()], &outputs);
+        let k2 =
+            compute_partition_key(&dir, "pkg", "build", "hash123", 0, &["input.txt".into()], &outputs);
         assert_eq!(k1, k2);
     }
 

--- a/crates/turborepo-run-cache/src/incremental.rs
+++ b/crates/turborepo-run-cache/src/incremental.rs
@@ -642,8 +642,15 @@ mod tests {
             inclusions: vec!["dist/**".into()],
             exclusions: vec![],
         };
-        let result =
-            compute_partition_key(&dir, "pkg", "task", "hash123", 0, &["[invalid".into()], &outputs);
+        let result = compute_partition_key(
+            &dir,
+            "pkg",
+            "task",
+            "hash123",
+            0,
+            &["[invalid".into()],
+            &outputs,
+        );
         assert!(
             result.is_none(),
             "invalid input glob should produce None, not a fallback key"
@@ -867,10 +874,24 @@ mod tests {
             exclusions: vec![],
         };
 
-        let k1 =
-            compute_partition_key(&dir, "pkg", "build", "hash123", 0, &["input.txt".into()], &outputs);
-        let k2 =
-            compute_partition_key(&dir, "pkg", "build", "hash123", 0, &["input.txt".into()], &outputs);
+        let k1 = compute_partition_key(
+            &dir,
+            "pkg",
+            "build",
+            "hash123",
+            0,
+            &["input.txt".into()],
+            &outputs,
+        );
+        let k2 = compute_partition_key(
+            &dir,
+            "pkg",
+            "build",
+            "hash123",
+            0,
+            &["input.txt".into()],
+            &outputs,
+        );
         assert_eq!(k1, k2);
     }
 

--- a/crates/turborepo-run-cache/src/incremental.rs
+++ b/crates/turborepo-run-cache/src/incremental.rs
@@ -7,8 +7,6 @@ use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
 use turborepo_cache::AsyncCache;
 use turborepo_types::{IncrementalPartition, TaskOutputs, TaskOutputsExt};
 
-// Testing 6
-
 /// Per-partition result of an incremental fetch attempt.
 #[derive(Debug, Clone)]
 pub enum IncrementalFetchResult {

--- a/crates/turborepo-run-cache/src/incremental.rs
+++ b/crates/turborepo-run-cache/src/incremental.rs
@@ -7,6 +7,8 @@ use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
 use turborepo_cache::AsyncCache;
 use turborepo_types::{IncrementalPartition, TaskOutputs, TaskOutputsExt};
 
+// Testing 6
+
 /// Per-partition result of an incremental fetch attempt.
 #[derive(Debug, Clone)]
 pub enum IncrementalFetchResult {
@@ -344,7 +346,7 @@ fn compute_partition_key(
     }
 
     let hash = hex::encode(hasher.finalize());
-    Some(format!("incremental-{hash}"))
+    Some(format!("{hash}incremental"))
 }
 
 /// Compute a hash of the partition's input files.
@@ -647,11 +649,11 @@ mod tests {
         };
         let key = compute_partition_key(&dir, "pkg", "task", 0, &[], &outputs).unwrap();
         assert!(
-            key.starts_with("incremental-"),
-            "key must start with 'incremental-'"
+            key.ends_with("incremental"),
+            "key must end with 'incremental'"
         );
-        // 'incremental-' (12 chars) + 64 hex chars (sha256)
-        assert_eq!(key.len(), 12 + 64);
+        // 64 hex chars (sha256) + 'incremental' (11 chars)
+        assert_eq!(key.len(), 64 + 11);
     }
 
     #[test]

--- a/crates/turborepo-run-cache/src/incremental.rs
+++ b/crates/turborepo-run-cache/src/incremental.rs
@@ -7,6 +7,8 @@ use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
 use turborepo_cache::AsyncCache;
 use turborepo_types::{IncrementalPartition, TaskOutputs, TaskOutputsExt};
 
+// Test comment
+
 /// Per-partition result of an incremental fetch attempt.
 #[derive(Debug, Clone)]
 pub enum IncrementalFetchResult {

--- a/crates/turborepo-run-cache/src/lib.rs
+++ b/crates/turborepo-run-cache/src/lib.rs
@@ -181,6 +181,7 @@ impl RunCache {
                 partitions.clone(),
                 task_id.package().to_string(),
                 task_id.task().to_string(),
+                hash.to_owned(),
                 self.cache.clone(),
                 self.repo_root.clone(),
                 package_dir,

--- a/turbo.json
+++ b/turbo.json
@@ -2,6 +2,9 @@
   "$schema": "https://turborepo.dev/schema.json",
   "ui": "tui",
   "noUpdateNotifier": true,
+  "futureFlags": {
+    "incrementalTasks": true
+  },
   // The following are used by tools such as pnpm, gh actions to setup pnpm, etc.
   "globalPassThroughEnv": [
     "Path",


### PR DESCRIPTION
## Summary

- Enables `incrementalTasks` future flag and adds incremental partitions to the `build` and `build:test-archive` tasks in `cli/turbo.json`
- Cargo intermediate artifacts (deps, fingerprints, build script outputs) are cached via remote cache, excluding `.rlib` files to keep upload size manageable (~250MB vs ~450MB)
- Fixes incremental partition key to incorporate the task hash, so partitions inherit all task-level configuration (`globalEnv`, `env`, etc.) and are properly segmented across platforms
- Moves the `incremental` suffix from prepend to append in the partition key format

## Testing

To verify locally:

```bash
# Seed the incremental cache
turbo run build --filter=@turbo/cli

# Control (no incremental restore)
cargo clean
time turbo run build --filter=@turbo/cli --force

# Experiment (with incremental restore)
cargo clean
time turbo run build --filter=@turbo/cli
```

`--force` disables incremental reads, so the control build starts cold. The experiment should be significantly faster as Cargo finds warm `.fingerprint`/`.rmeta`/`.d` artifacts and skips recompilation of unchanged crates.