### PR TITLE
fix: Respect dirty .gitignore patterns during task input hashing

### DIFF
--- a/crates/turborepo-scm/src/git_index_regression_tests.rs
+++ b/crates/turborepo-scm/src/git_index_regression_tests.rs
@@ -497,6 +497,54 @@ fn test_nested_gitignore_respected() {
     assert!(hashes.contains_key(&path(".gitignore")));
 }
 
+// Regression: vercel/turborepo#12554
+// When .gitignore is modified but not committed, its patterns must still be
+// respected. A dirty .gitignore ends up in status_entries (not ls_tree_hashes),
+// so the gitignore matcher construction must check both.
+#[test]
+fn test_dirty_gitignore_still_excludes_ignored_files() {
+    let repo = TestRepo::new();
+
+    repo.create_gitignore(".gitignore", "node_modules/\n");
+    repo.create_file("my-pkg/src/index.ts", "code");
+    repo.create_file("my-pkg/package.json", "{}");
+    repo.commit_all();
+
+    // Create an ignored file and then dirty the .gitignore without committing
+    repo.create_file("my-pkg/node_modules/.bin/foo", "stub");
+    repo.create_gitignore(".gitignore", "node_modules/\n# added comment\n");
+
+    let hashes = repo.get_hashes("my-pkg");
+    assert!(
+        !hashes.contains_key(&path("node_modules/.bin/foo")),
+        "dirty .gitignore must still exclude node_modules"
+    );
+    assert!(hashes.contains_key(&path("src/index.ts")));
+}
+
+// Regression: vercel/turborepo#12554 (nested variant)
+// Same as above but with a nested .gitignore inside a package directory.
+#[test]
+fn test_dirty_nested_gitignore_still_excludes_ignored_files() {
+    let repo = TestRepo::new();
+
+    repo.create_gitignore("my-pkg/.gitignore", "dist/\n");
+    repo.create_file("my-pkg/src/index.ts", "code");
+    repo.create_file("my-pkg/package.json", "{}");
+    repo.commit_all();
+
+    repo.create_file("my-pkg/dist/bundle.js", "compiled");
+    repo.create_gitignore("my-pkg/.gitignore", "dist/\n# added comment\n");
+
+    let hashes = repo.get_hashes("my-pkg");
+    assert!(
+        !hashes.contains_key(&path("dist/bundle.js")),
+        "dirty nested .gitignore must still exclude dist/"
+    );
+    assert!(hashes.contains_key(&path("src/index.ts")));
+    assert!(hashes.contains_key(&path(".gitignore")));
+}
+
 #[test]
 fn test_empty_package_returns_empty_hashes() {
     let repo = TestRepo::new();

--- a/crates/turborepo-scm/src/repo_index.rs
+++ b/crates/turborepo-scm/src/repo_index.rs
@@ -709,28 +709,41 @@ fn find_untracked_files(
             has_root_rules = true;
         }
 
-        for (path, _) in ls_tree_hashes.iter() {
-            let s = path.as_str();
-            if s.ends_with(".gitignore") {
-                let abs_path = root.join(s);
-                if !abs_path.exists() {
-                    continue;
-                }
-                let gi_dir = abs_path.parent().unwrap_or(root.as_path());
-                if gi_dir == root.as_path() {
-                    // Root .gitignore goes into the root builder alongside
-                    // global and info/exclude rules
-                    let _ = root_builder.add(&abs_path);
-                    has_root_rules = true;
-                } else {
-                    // Nested .gitignore gets its own matcher scoped to its dir
-                    let mut builder = ignore::gitignore::GitignoreBuilder::new(gi_dir);
-                    let _ = builder.add(&abs_path);
-                    if let Ok(gi) = builder.build()
-                        && !gi.is_empty()
-                    {
-                        matchers.push(gi);
-                    }
+        // Collect .gitignore paths from both clean tracked files and
+        // dirty (modified-but-tracked) files. A modified .gitignore
+        // lands in status_entries instead of ls_tree_hashes, but its
+        // on-disk patterns must still be respected.
+        let gitignore_paths: Vec<&str> = ls_tree_hashes
+            .iter()
+            .map(|(p, _)| p.as_str())
+            .chain(
+                status_entries
+                    .iter()
+                    .filter(|e| !e.is_delete)
+                    .map(|e| e.path.as_str()),
+            )
+            .filter(|s| s.ends_with(".gitignore"))
+            .collect();
+
+        for s in gitignore_paths {
+            let abs_path = root.join(s);
+            if !abs_path.exists() {
+                continue;
+            }
+            let gi_dir = abs_path.parent().unwrap_or(root.as_path());
+            if gi_dir == root.as_path() {
+                // Root .gitignore goes into the root builder alongside
+                // global and info/exclude rules
+                let _ = root_builder.add(&abs_path);
+                has_root_rules = true;
+            } else {
+                // Nested .gitignore gets its own matcher scoped to its dir
+                let mut builder = ignore::gitignore::GitignoreBuilder::new(gi_dir);
+                let _ = builder.add(&abs_path);
+                if let Ok(gi) = builder.build()
+                    && !gi.is_empty()
+                {
+                    matchers.push(gi);
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fixes #12554

When `.gitignore` is modified but not yet committed, its ignore patterns are silently dropped during untracked file discovery, causing gitignored paths (like `node_modules/`) to leak into task input hashes, which breaks caching.

## Reason

PR #12339 replaced subprocess-based `git ls-files` with in-process `gix-index` for file discovery. The new `find_untracked_files()` function pre-builds gitignore matchers by scanning `ls_tree_hashes` — the set of **clean** tracked files whose stat matches the git index. When `.gitignore` is dirty (modified on disk), its stat no longer matches the index entry, so it gets classified as `Modified` and placed in `status_entries` instead. The matcher construction loop never looks there, so no ignore rules from that file are applied.

The old `git ls-files --others --exclude-standard` approach didn't have this problem because git reads `.gitignore` from the working tree, not from the index.

## Fix

The gitignore matcher construction now scans both `ls_tree_hashes` and non-deleted entries in `status_entries` for `.gitignore` files. Since the code already reads `.gitignore` content from the filesystem (not from the index), the only change needed was expanding the iteration to include dirty tracked files.

## Testing

Two regression tests added covering root-level and nested dirty `.gitignore` files. Both fail before the fix and pass after.