### PR TITLE
fix: Normalize CRLF line endings in file hashing to match git

### DIFF
--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -186,6 +186,11 @@ jobs:
           echo %ProgramFiles%\Git\cmd>> "%GITHUB_PATH%"
 
       - name: Set git to use LF line endings
+        # Ensures the turborepo source code is checked out with LF endings
+        # so the Rust build and test fixtures work correctly. Turbo's CRLF
+        # normalization is driven by .gitattributes (not core.autocrlf).
+        # Tests create CRLF content directly and configure repos per-test —
+        # see turborepo-scm's crlf.rs and package_deps.rs CRLF tests.
         run: |
           git config --global core.autocrlf false
           git config --global core.eol lf
@@ -332,6 +337,11 @@ jobs:
     name: Rust testing on windows (partition ${{ matrix.partition }}/10)
     steps:
       - name: Set git to use LF line endings
+        # Ensures the turborepo source code is checked out with LF endings
+        # so the Rust build and test fixtures work correctly. Turbo's CRLF
+        # normalization is driven by .gitattributes (not core.autocrlf).
+        # Tests create CRLF content directly and configure repos per-test —
+        # see turborepo-scm's crlf.rs and package_deps.rs CRLF tests.
         run: |
           git config --global core.autocrlf false
           git config --global core.eol lf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,8 +2186,25 @@ checksum = "0c44f13049925e8dc3955c20ecec5391cedfb041e0952416b583ecc57bc68325"
 dependencies = [
  "bstr 1.12.1",
  "gix-date",
- "gix-error",
+ "gix-error 0.1.0",
  "winnow 0.7.14",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c233d6eaa098c0ca5ce03236fd7a96e27f1abe72fad74b46003fbd11fe49563c"
+dependencies = [
+ "bstr 1.12.1",
+ "gix-glob",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "kstring",
+ "smallvec",
+ "thiserror 2.0.18",
+ "unicode-bom",
 ]
 
 [[package]]
@@ -2205,7 +2222,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d14ee09ab454481a91fe969ca5afbd41c8a9b05680197b6554ebb69bdcf7d571"
 dependencies = [
- "gix-error",
+ "gix-error 0.1.0",
 ]
 
 [[package]]
@@ -2216,7 +2233,7 @@ checksum = "f9dc2a550978b510b4e58b0bf5a15481433c3b21981330f3898d93f25b07d9a5"
 dependencies = [
  "bstr 1.12.1",
  "gix-chunk",
- "gix-error",
+ "gix-error 0.1.0",
  "gix-hash",
  "memmap2 0.9.10",
 ]
@@ -2228,7 +2245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e66a5117b22495fe7cb4b443777cf3f024a1b1db0009771db440fc8b38a0a6fd"
 dependencies = [
  "bstr 1.12.1",
- "gix-error",
+ "gix-error 0.1.0",
  "itoa",
  "jiff",
  "smallvec",
@@ -2239,6 +2256,15 @@ name = "gix-error"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e37b10e97c822fc17550fc1a187283ad3ce79617e920bf179f301ee12abcbc"
+dependencies = [
+ "bstr 1.12.1",
+]
+
+[[package]]
+name = "gix-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e86d01da904d4a9265def43bd42a18c5e6dc7000a73af512946ba14579c9fbd"
 dependencies = [
  "bstr 1.12.1",
 ]
@@ -2267,6 +2293,18 @@ dependencies = [
  "gix-path",
  "gix-utils",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03e6cd88cc0dc1eafa1fddac0fb719e4e74b6ea58dd016e71125fde4a326bee"
+dependencies = [
+ "bitflags 2.10.0",
+ "bstr 1.12.1",
+ "gix-features",
+ "gix-path",
 ]
 
 [[package]]
@@ -2365,6 +2403,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-quote"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68533db71259c8776dd4e770d2b7b98696213ecdc1f5c9e3507119e274e0c578"
+dependencies = [
+ "bstr 1.12.1",
+ "gix-error 0.2.1",
+ "gix-utils",
+]
+
+[[package]]
 name = "gix-revwalk"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2372,7 +2421,7 @@ checksum = "07efcad1d064abdac3e79dfc6e23e05accb579559d015e944c9dcf64be95eb49"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
- "gix-error",
+ "gix-error 0.1.0",
  "gix-hash",
  "gix-hashtable",
  "gix-object",
@@ -3262,6 +3311,15 @@ checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
+]
+
+[[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "static_assertions",
 ]
 
 [[package]]
@@ -8080,6 +8138,7 @@ name = "turborepo-scm"
 version = "0.1.0"
 dependencies = [
  "bstr 1.12.1",
+ "gix-attributes",
  "gix-index",
  "gix-object",
  "globwalk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ dialoguer = "0.12.0"
 dunce = "1.0.3"
 either = "1.9.0"
 futures = "0.3.31"
+gix-attributes = { version = "0.31.0", default-features = false }
 gix-index = { version = "0.47.0", default-features = false }
 gix-object = { version = "0.56.0", default-features = false }
 hex = "0.4.3"

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -69,6 +69,7 @@ pub enum Error {
 static ADDITIONAL_FILES: LazyLock<Vec<(&'static RelativeUnixPath, Option<CopyDestination>)>> =
     LazyLock::new(|| {
         vec![
+            (RelativeUnixPath::new(".gitattributes").unwrap(), None),
             (RelativeUnixPath::new(".gitignore").unwrap(), None),
             (
                 RelativeUnixPath::new(".npmrc").unwrap(),
@@ -724,7 +725,7 @@ fn merge_preserving_key_order(
 mod tests {
     use serde_json::json;
 
-    use super::merge_preserving_key_order;
+    use super::{merge_preserving_key_order, ADDITIONAL_FILES};
 
     #[test]
     fn merge_preserves_key_order() {
@@ -762,5 +763,26 @@ mod tests {
         let merged = merge_preserving_key_order(&original, &pruned);
         let keys: Vec<_> = merged.as_object().unwrap().keys().collect();
         assert_eq!(keys, vec!["existing", "new_key"]);
+    }
+
+    #[test]
+    fn additional_files_snapshot() {
+        let file_names: Vec<&str> = ADDITIONAL_FILES
+            .iter()
+            .map(|(path, _)| path.as_str())
+            .collect();
+        // Update this list when adding new entries to ADDITIONAL_FILES.
+        assert_eq!(
+            file_names,
+            vec![
+                ".gitattributes",
+                ".gitignore",
+                ".npmrc",
+                ".yarnrc.yml",
+                "bunfig.toml"
+            ],
+            "ADDITIONAL_FILES changed — update this snapshot and the prune integration tests \
+             (prune_test.rs) accordingly"
+        );
     }
 }

--- a/crates/turborepo-scm/Cargo.toml
+++ b/crates/turborepo-scm/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 
 [dependencies]
 bstr = "1.4.0"
+gix-attributes = { workspace = true, default-features = false }
 gix-index = { workspace = true, default-features = false }
 gix-object = { workspace = true, default-features = false }
 globwalk = { path = "../turborepo-globwalk" }

--- a/crates/turborepo-scm/src/crlf.rs
+++ b/crates/turborepo-scm/src/crlf.rs
@@ -1,0 +1,900 @@
+//! CRLF→LF normalization for file hashing.
+//!
+//! When `.gitattributes` marks a file as `text` or `text=auto`, git normalizes
+//! CRLF line endings to LF in blob objects. This module replicates that
+//! behavior so that turbo's file hashes match git's, regardless of whether
+//! we're using the git code path or the manual (no-git) code path.
+//!
+//! # Known Limitations
+//!
+//! - Only the root `.gitattributes` is loaded. Nested per-directory
+//!   `.gitattributes` files are not supported.
+//! - The `eol=` attribute is not handled; only `text`, `text=auto`, `-text`,
+//!   and `binary` are recognized.
+
+use std::io::{Read, Seek, SeekFrom};
+
+use gix_attributes::{Search, search::MetadataCollection};
+use sha1::{Digest, Sha1};
+use tracing::warn;
+use turbopath::AbsoluteSystemPath;
+
+use crate::OidHash;
+
+/// How the `text` attribute is set for a given file path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TextAttr {
+    /// `text` — always normalize CRLF→LF.
+    Set,
+    /// `text=auto` — normalize if the file content appears to be text.
+    Auto,
+    /// `-text` or `binary` — never normalize.
+    Unset,
+    /// Attribute not mentioned — don't normalize.
+    Unspecified,
+}
+
+/// Loaded `.gitattributes` context for resolving per-file text attributes.
+///
+/// Only the root-level `.gitattributes` is loaded. Per-directory
+/// `.gitattributes` files (e.g. `src/.gitattributes`) are not consulted.
+pub(crate) struct GitAttrs {
+    search: Search,
+    collection: MetadataCollection,
+}
+
+/// Matches git's `FIRST_FEW_BYTES` (8KB) used by `buffer_is_binary()` to
+/// detect binary content. A file is considered binary if a NUL byte appears
+/// in the first 8KB. Do not change without verifying against git's behavior.
+const GIT_BINARY_DETECT_LEN: usize = 8 * 1024;
+const BUF_SIZE: usize = 64 * 1024;
+
+impl GitAttrs {
+    /// Load `.gitattributes` from `root`. Returns `None` if no file exists or
+    /// the file cannot be parsed.
+    pub(crate) fn load(root: &AbsoluteSystemPath) -> Option<Self> {
+        let mut buf = Vec::new();
+        let mut collection = MetadataCollection::default();
+
+        // Initialize with built-in macros (e.g. `binary` → `-diff -merge -text`)
+        let mut search = match Search::new_globals(
+            std::iter::empty::<std::path::PathBuf>(),
+            &mut buf,
+            &mut collection,
+        ) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("failed to initialize gitattributes globals: {e}");
+                Search::default()
+            }
+        };
+
+        let gitattributes_path = root.join_component(".gitattributes");
+        let added = match search.add_patterns_file(
+            gitattributes_path.as_std_path().into(),
+            false,
+            Some(root.as_std_path()),
+            &mut buf,
+            &mut collection,
+            true,
+        ) {
+            Ok(added) => added,
+            Err(e) => {
+                warn!(
+                    path = %gitattributes_path,
+                    "failed to parse .gitattributes, CRLF normalization will be skipped: {e}"
+                );
+                false
+            }
+        };
+
+        if !added {
+            return None;
+        }
+
+        Some(Self { search, collection })
+    }
+
+    /// Create a reusable `Outcome` for repeated calls to
+    /// [`resolve_text_attr_with`]. Callers in hot loops (e.g. rayon
+    /// parallel iterators) should create one per thread and pass it into
+    /// each call to avoid per-file allocation.
+    pub(crate) fn new_outcome(&self) -> gix_attributes::search::Outcome {
+        let mut outcome = gix_attributes::search::Outcome::default();
+        outcome.initialize(&self.collection);
+        outcome
+    }
+
+    /// Resolve the `text` attribute using a caller-supplied `Outcome`,
+    /// avoiding per-file allocation. The outcome is reset before each
+    /// query so it can be reused across calls.
+    pub(crate) fn resolve_text_attr_with(
+        &self,
+        relative_path: &str,
+        outcome: &mut gix_attributes::search::Outcome,
+    ) -> TextAttr {
+        outcome.reset();
+
+        let matched = self.search.pattern_matching_relative_path(
+            relative_path.into(),
+            gix_attributes::glob::pattern::Case::Sensitive,
+            Some(false),
+            outcome,
+        );
+
+        if !matched {
+            return TextAttr::Unspecified;
+        }
+
+        Self::text_attr_from_outcome(outcome)
+    }
+
+    /// Convenience method that allocates an `Outcome` per call. Prefer
+    /// [`resolve_text_attr_with`] in hot paths.
+    pub(crate) fn resolve_text_attr(&self, relative_path: &str) -> TextAttr {
+        let mut outcome = self.new_outcome();
+        self.resolve_text_attr_with(relative_path, &mut outcome)
+    }
+
+    fn text_attr_from_outcome(outcome: &gix_attributes::search::Outcome) -> TextAttr {
+        for m in outcome.iter() {
+            if m.assignment.name.as_str() == "text" {
+                return match m.assignment.state {
+                    gix_attributes::StateRef::Set => TextAttr::Set,
+                    gix_attributes::StateRef::Unset => TextAttr::Unset,
+                    gix_attributes::StateRef::Value(v) => {
+                        if v.as_bstr() == "auto" {
+                            TextAttr::Auto
+                        } else {
+                            TextAttr::Set
+                        }
+                    }
+                    gix_attributes::StateRef::Unspecified => TextAttr::Unspecified,
+                };
+            }
+        }
+
+        TextAttr::Unspecified
+    }
+}
+
+/// Resolve cached attrs or load them from disk on demand.
+///
+/// `storage` provides owned backing when `cached` is `None` — callers
+/// declare `let mut storage = None;` and pass `&mut storage` here.
+pub(crate) fn resolve_or_load<'a>(
+    cached: Option<&'a GitAttrs>,
+    root: &AbsoluteSystemPath,
+    storage: &'a mut Option<GitAttrs>,
+) -> Option<&'a GitAttrs> {
+    match cached {
+        Some(a) => Some(a),
+        None => {
+            *storage = GitAttrs::load(root);
+            storage.as_ref()
+        }
+    }
+}
+
+/// Whether normalization should actually be applied given the text attribute
+/// and the file's scan results. Centralizes the decision so the gix and sha1
+/// hash paths cannot diverge.
+fn should_normalize(attr: TextAttr, scan: &ScanResult) -> bool {
+    match attr {
+        TextAttr::Set => scan.crlf_count > 0,
+        TextAttr::Auto => !scan.is_binary && scan.crlf_count > 0,
+        TextAttr::Unset | TextAttr::Unspecified => false,
+    }
+}
+
+struct ScanResult {
+    /// Total raw byte count (including \r bytes from CRLF pairs).
+    byte_count: u64,
+    /// Number of \r\n pairs found.
+    crlf_count: u64,
+    /// Whether a NUL byte was found in the first 8KB (only meaningful when
+    /// `detect_binary` was true).
+    is_binary: bool,
+}
+
+/// Scan a file to count CRLF pairs, total byte length, and optionally detect
+/// binary content (NUL in first 8KB).
+#[cfg(test)]
+fn scan_file(reader: &mut impl Read, detect_binary: bool) -> std::io::Result<ScanResult> {
+    scan_file_and_feed(reader, detect_binary, |_| {})
+}
+
+/// Same as [`scan_file`], but also feeds each raw chunk to `on_data`. This
+/// lets callers fuse the scan pass with a hash computation so the common case
+/// (no normalization needed) completes in a single read of the file.
+fn scan_file_and_feed(
+    reader: &mut impl Read,
+    detect_binary: bool,
+    mut on_data: impl FnMut(&[u8]),
+) -> std::io::Result<ScanResult> {
+    let mut byte_count: u64 = 0;
+    let mut crlf_count: u64 = 0;
+    let mut is_binary = false;
+    let mut prev_was_cr = false;
+    let mut buf = [0u8; BUF_SIZE];
+
+    loop {
+        let n = reader.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+
+        if detect_binary && !is_binary && byte_count < GIT_BINARY_DETECT_LEN as u64 {
+            let check_end = n.min(GIT_BINARY_DETECT_LEN.saturating_sub(byte_count as usize));
+            if buf[..check_end].contains(&0) {
+                is_binary = true;
+            }
+        }
+
+        for &b in &buf[..n] {
+            if b == b'\n' && prev_was_cr {
+                crlf_count += 1;
+            }
+            prev_was_cr = b == b'\r';
+        }
+
+        on_data(&buf[..n]);
+        byte_count += n as u64;
+    }
+
+    Ok(ScanResult {
+        byte_count,
+        crlf_count,
+        is_binary,
+    })
+}
+
+/// Stream file contents through `update`, normalizing CRLF→LF.
+///
+/// The output buffer is allocated once and reused across chunks, bounding
+/// memory at ~128KB per call (64KB read buffer + 64KB output buffer).
+fn stream_normalized(reader: &mut impl Read, mut update: impl FnMut(&[u8])) -> std::io::Result<()> {
+    let mut buf = [0u8; BUF_SIZE];
+    let mut out = Vec::with_capacity(BUF_SIZE);
+    let mut prev_was_cr = false;
+
+    loop {
+        let n = reader.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+
+        out.clear();
+        for &b in &buf[..n] {
+            if prev_was_cr && b != b'\n' {
+                out.push(b'\r');
+            }
+            if b != b'\r' {
+                out.push(b);
+            }
+            prev_was_cr = b == b'\r';
+        }
+        update(&out);
+    }
+
+    if prev_was_cr {
+        update(b"\r");
+    }
+
+    Ok(())
+}
+
+/// Abstraction over SHA1 hasher implementations (gix and sha1 crate) so the
+/// normalization algorithm is written exactly once. Both
+/// [`hash_file_maybe_normalized`] and [`manual_hash_file_maybe_normalized`]
+/// delegate to [`hash_file_normalized`].
+trait BlobHasher: Sized {
+    type Output;
+
+    fn new() -> Self;
+    fn write_blob_header(&mut self, blob_len: u64);
+    fn update(&mut self, data: &[u8]);
+    fn finalize(self) -> Result<Self::Output, std::io::Error>;
+}
+
+struct GixBlobHasher(gix_index::hash::Hasher);
+
+impl BlobHasher for GixBlobHasher {
+    type Output = gix_index::hash::ObjectId;
+
+    fn new() -> Self {
+        Self(gix_index::hash::hasher(gix_index::hash::Kind::Sha1))
+    }
+
+    fn write_blob_header(&mut self, blob_len: u64) {
+        self.0.update(&gix_object::encode::loose_header(
+            gix_object::Kind::Blob,
+            blob_len,
+        ));
+    }
+
+    fn update(&mut self, data: &[u8]) {
+        self.0.update(data);
+    }
+
+    fn finalize(self) -> Result<gix_index::hash::ObjectId, std::io::Error> {
+        self.0.try_finalize().map_err(std::io::Error::other)
+    }
+}
+
+struct ManualBlobHasher(Sha1);
+
+impl BlobHasher for ManualBlobHasher {
+    type Output = OidHash;
+
+    fn new() -> Self {
+        Self(Sha1::new())
+    }
+
+    fn write_blob_header(&mut self, blob_len: u64) {
+        self.0.update(b"blob ");
+        self.0.update(blob_len.to_string().as_bytes());
+        self.0.update([b'\0']);
+    }
+
+    fn update(&mut self, data: &[u8]) {
+        self.0.update(data);
+    }
+
+    fn finalize(self) -> Result<OidHash, std::io::Error> {
+        let result = self.0.finalize();
+        let mut hex_buf = [0u8; 40];
+        hex::encode_to_slice(result, &mut hex_buf).unwrap();
+        Ok(OidHash::from_hex_buf(hex_buf))
+    }
+}
+
+fn validate_file_type(
+    path: &AbsoluteSystemPath,
+    metadata: &std::fs::Metadata,
+) -> Result<(), std::io::Error> {
+    // Reject exotic file types (sockets, FIFOs, device nodes). Directories
+    // pass through to fail naturally with a descriptive IsADirectory error.
+    if !metadata.is_file() && !metadata.is_dir() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("{path}: not a regular file"),
+        ));
+    }
+    Ok(())
+}
+
+/// Hash a file as a git blob, applying CRLF→LF normalization when the
+/// `text` attribute requires it.
+///
+/// For `TextAttr::Auto`, binary detection (NUL in first 8KB) is performed
+/// during the fused scan+hash pass — no separate file open.
+///
+/// Single-pass for the common case (no normalization needed):
+/// 1. Get file length from metadata
+/// 2. Fused scan + speculative raw hash: write blob header, then scan for CRLFs
+///    while simultaneously feeding raw bytes into the hasher
+/// 3. If no normalization needed, return the raw hash (one read total)
+///
+/// Two-pass only when CRLF normalization is actually required:
+/// 1. Fused scan + speculative raw hash (result discarded)
+/// 2. Seek to start, write normalized blob header, stream with CRLF→LF
+///
+/// Memory bounded at ~128KB per call.
+fn hash_file_normalized<H: BlobHasher>(
+    file: &mut std::fs::File,
+    file_len: u64,
+    attr: TextAttr,
+) -> Result<H::Output, std::io::Error> {
+    // Fused scan + speculative raw hash in a single pass. The blob header
+    // uses the raw file length; if normalization turns out to be needed we
+    // discard this hash and do a second pass with the normalized length.
+    let mut raw_hasher = H::new();
+    raw_hasher.write_blob_header(file_len);
+    let scan = scan_file_and_feed(file, attr == TextAttr::Auto, |data| {
+        raw_hasher.update(data);
+    })?;
+
+    if !should_normalize(attr, &scan) {
+        return raw_hasher.finalize();
+    }
+
+    // CRLF normalization required — second pass with the normalized length.
+    // Safety: the file may have changed between the scan pass and this
+    // normalization pass (TOCTOU). The length check below detects this.
+    file.seek(SeekFrom::Start(0))?;
+    let normalized_len = scan.byte_count.saturating_sub(scan.crlf_count);
+
+    let mut hasher = H::new();
+    hasher.write_blob_header(normalized_len);
+    let mut bytes_hashed: u64 = 0;
+    stream_normalized(file, |data| {
+        bytes_hashed += data.len() as u64;
+        hasher.update(data);
+    })?;
+    if bytes_hashed != normalized_len {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "CRLF normalization length mismatch: scan predicted {normalized_len}, stream \
+                 produced {bytes_hashed}"
+            ),
+        ));
+    }
+    hasher.finalize()
+}
+
+/// Hash via the gix code path (used when `.git/` is present).
+pub(crate) fn hash_file_maybe_normalized(
+    path: &AbsoluteSystemPath,
+    attr: TextAttr,
+) -> Result<gix_index::hash::ObjectId, std::io::Error> {
+    let mut file = std::fs::File::open(path)?;
+    let metadata = file.metadata()?;
+    validate_file_type(path, &metadata)?;
+    hash_file_normalized::<GixBlobHasher>(&mut file, metadata.len(), attr)
+}
+
+/// Hash via the manual code path (used after `turbo prune` removes `.git/`).
+pub(crate) fn manual_hash_file_maybe_normalized(
+    path: &AbsoluteSystemPath,
+    attr: TextAttr,
+) -> Result<OidHash, crate::Error> {
+    let mut file = path.open()?;
+    let metadata = file.metadata()?;
+    validate_file_type(path, &metadata)?;
+    Ok(hash_file_normalized::<ManualBlobHasher>(
+        &mut file,
+        metadata.len(),
+        attr,
+    )?)
+}
+
+#[cfg(test)]
+mod tests {
+    use turbopath::AbsoluteSystemPathBuf;
+
+    use super::*;
+
+    fn tmp_dir() -> (tempfile::TempDir, AbsoluteSystemPathBuf) {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = AbsoluteSystemPathBuf::try_from(tmp.path())
+            .unwrap()
+            .to_realpath()
+            .unwrap();
+        (tmp, dir)
+    }
+
+    // -- scan_file tests --
+
+    #[test]
+    fn test_scan_empty_file() {
+        let (_tmp, root) = tmp_dir();
+        let path = root.join_component("empty.txt");
+        std::fs::write(path.as_std_path(), b"").unwrap();
+        let mut f = std::fs::File::open(path.as_std_path()).unwrap();
+        let scan = scan_file(&mut f, false).unwrap();
+        assert_eq!(scan.byte_count, 0);
+        assert_eq!(scan.crlf_count, 0);
+        assert!(!scan.is_binary);
+    }
+
+    #[test]
+    fn test_scan_pure_crlf() {
+        let (_tmp, root) = tmp_dir();
+        let path = root.join_component("crlf.txt");
+        std::fs::write(path.as_std_path(), b"a\r\nb\r\nc\r\n").unwrap();
+        let mut f = std::fs::File::open(path.as_std_path()).unwrap();
+        let scan = scan_file(&mut f, false).unwrap();
+        assert_eq!(scan.byte_count, 9);
+        assert_eq!(scan.crlf_count, 3);
+    }
+
+    #[test]
+    fn test_scan_binary_with_crlf() {
+        let (_tmp, root) = tmp_dir();
+        let path = root.join_component("binary.bin");
+        std::fs::write(path.as_std_path(), [0x00, b'\r', b'\n', 0xFF]).unwrap();
+        let mut f = std::fs::File::open(path.as_std_path()).unwrap();
+        let scan = scan_file(&mut f, true).unwrap();
+        assert_eq!(scan.byte_count, 4);
+        assert_eq!(scan.crlf_count, 1);
+        assert!(scan.is_binary);
+    }
+
+    #[test]
+    fn test_scan_lone_cr() {
+        let (_tmp, root) = tmp_dir();
+        let path = root.join_component("lone-cr.txt");
+        std::fs::write(path.as_std_path(), b"hello\rworld\n").unwrap();
+        let mut f = std::fs::File::open(path.as_std_path()).unwrap();
+        let scan = scan_file(&mut f, false).unwrap();
+        assert_eq!(scan.crlf_count, 0);
+    }
+
+    #[test]
+    fn test_scan_old_mac_cr_only() {
+        let (_tmp, root) = tmp_dir();
+        let path = root.join_component("old-mac.txt");
+        std::fs::write(path.as_std_path(), b"hello\rworld\r").unwrap();
+        let mut f = std::fs::File::open(path.as_std_path()).unwrap();
+        let scan = scan_file(&mut f, false).unwrap();
+        assert_eq!(scan.crlf_count, 0);
+        assert_eq!(scan.byte_count, 12);
+    }
+
+    #[test]
+    fn test_scan_binary_detect_nul_after_8kb_is_text() {
+        let (_tmp, root) = tmp_dir();
+        let path = root.join_component("late-nul.bin");
+        // 8KB of text followed by NUL — should be classified as text
+        let mut content = vec![b'x'; GIT_BINARY_DETECT_LEN];
+        content.push(0x00);
+        std::fs::write(path.as_std_path(), &content).unwrap();
+        let mut f = std::fs::File::open(path.as_std_path()).unwrap();
+        let scan = scan_file(&mut f, true).unwrap();
+        assert!(
+            !scan.is_binary,
+            "NUL after the first 8KB should not trigger binary detection"
+        );
+    }
+
+    #[test]
+    fn test_scan_binary_detect_nul_in_first_8kb() {
+        let (_tmp, root) = tmp_dir();
+        let path = root.join_component("early-nul.bin");
+        let mut content = vec![b'x'; 100];
+        content.push(0x00);
+        content.extend_from_slice(&[b'y'; 100]);
+        std::fs::write(path.as_std_path(), &content).unwrap();
+        let mut f = std::fs::File::open(path.as_std_path()).unwrap();
+        let scan = scan_file(&mut f, true).unwrap();
+        assert!(scan.is_binary);
+    }
+
+    #[test]
+    fn test_scan_crlf_split_across_chunk_boundary() {
+        let (_tmp, root) = tmp_dir();
+        let path = root.join_component("boundary.txt");
+        // \r is the last byte of the first 64KB chunk, \n is the first
+        // byte of the second chunk
+        let mut content = vec![b'x'; BUF_SIZE - 1];
+        content.push(b'\r');
+        content.push(b'\n');
+        content.extend_from_slice(b"after");
+        std::fs::write(path.as_std_path(), &content).unwrap();
+
+        let mut f = std::fs::File::open(path.as_std_path()).unwrap();
+        let scan = scan_file(&mut f, false).unwrap();
+        assert_eq!(
+            scan.crlf_count, 1,
+            "CRLF split across chunk boundary must be detected"
+        );
+        assert_eq!(scan.byte_count, (BUF_SIZE + 6) as u64);
+    }
+
+    #[test]
+    fn test_scan_standalone_cr_at_chunk_boundary() {
+        let (_tmp, root) = tmp_dir();
+        let path = root.join_component("boundary-cr.txt");
+        // \r is the last byte of the first chunk, next byte is NOT \n
+        let mut content = vec![b'x'; BUF_SIZE - 1];
+        content.push(b'\r');
+        content.push(b'y'); // not \n
+        std::fs::write(path.as_std_path(), &content).unwrap();
+
+        let mut f = std::fs::File::open(path.as_std_path()).unwrap();
+        let scan = scan_file(&mut f, false).unwrap();
+        assert_eq!(
+            scan.crlf_count, 0,
+            "standalone \\r at chunk boundary must not be counted as CRLF"
+        );
+    }
+
+    // -- stream_normalized tests --
+
+    #[test]
+    fn test_stream_normalized_basic() {
+        let input = b"a\r\nb\r\nc\r\n";
+        let mut output = Vec::new();
+        stream_normalized(&mut &input[..], |data| output.extend_from_slice(data)).unwrap();
+        assert_eq!(output, b"a\nb\nc\n");
+    }
+
+    #[test]
+    fn test_stream_normalized_preserves_standalone_cr() {
+        let input = b"hello\rworld\n";
+        let mut output = Vec::new();
+        stream_normalized(&mut &input[..], |data| output.extend_from_slice(data)).unwrap();
+        assert_eq!(output, b"hello\rworld\n");
+    }
+
+    #[test]
+    fn test_stream_normalized_trailing_cr() {
+        let input = b"data\r";
+        let mut output = Vec::new();
+        stream_normalized(&mut &input[..], |data| output.extend_from_slice(data)).unwrap();
+        assert_eq!(output, b"data\r");
+    }
+
+    #[test]
+    fn test_stream_normalized_chunk_boundary_crlf() {
+        // \r at end of first chunk, \n at start of second
+        let mut input = vec![b'x'; BUF_SIZE - 1];
+        input.push(b'\r');
+        input.push(b'\n');
+        input.extend_from_slice(b"end");
+
+        let mut output = Vec::new();
+        stream_normalized(&mut &input[..], |data| output.extend_from_slice(data)).unwrap();
+
+        let mut expected = vec![b'x'; BUF_SIZE - 1];
+        expected.push(b'\n');
+        expected.extend_from_slice(b"end");
+        assert_eq!(
+            output, expected,
+            "CRLF split across chunk boundary must be normalized"
+        );
+    }
+
+    #[test]
+    fn test_stream_normalized_chunk_boundary_standalone_cr() {
+        // \r at end of first chunk, NOT followed by \n
+        let mut input = vec![b'x'; BUF_SIZE - 1];
+        input.push(b'\r');
+        input.push(b'y');
+
+        let mut output = Vec::new();
+        stream_normalized(&mut &input[..], |data| output.extend_from_slice(data)).unwrap();
+
+        let mut expected = vec![b'x'; BUF_SIZE - 1];
+        expected.push(b'\r');
+        expected.push(b'y');
+        assert_eq!(
+            output, expected,
+            "standalone \\r at chunk boundary must be preserved"
+        );
+    }
+
+    // -- hash function tests --
+
+    /// Verify that our normalized hashing produces OIDs identical to
+    /// `git hash-object --path` (which applies .gitattributes filters).
+    /// This is the ground-truth test for CRLF normalization correctness.
+    #[test]
+    fn test_normalized_hash_matches_git_hash_object_with_filters() {
+        let (_tmp, root) = tmp_dir();
+
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(root.as_std_path())
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["config", "--local", "core.autocrlf", "false"])
+            .current_dir(root.as_std_path())
+            .output()
+            .unwrap();
+        std::fs::write(root.as_std_path().join(".gitattributes"), "* text=auto\n").unwrap();
+
+        let cases: Vec<(&str, Vec<u8>)> = vec![
+            ("pure-crlf.txt", b"a\r\nb\r\nc\r\n".to_vec()),
+            ("mixed.txt", b"line1\nline2\r\nline3\n".to_vec()),
+            ("no-crlf.txt", b"just lf\n".to_vec()),
+            ("empty.txt", b"".to_vec()),
+        ];
+
+        for (name, content) in &cases {
+            std::fs::write(root.as_std_path().join(name), content).unwrap();
+        }
+
+        for (name, _) in &cases {
+            let output = std::process::Command::new("git")
+                .args(["hash-object", "--path", name, "--stdin"])
+                .stdin(std::process::Stdio::from(
+                    std::fs::File::open(root.as_std_path().join(name)).unwrap(),
+                ))
+                .current_dir(root.as_std_path())
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "git hash-object --path failed for {name}: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            let expected = String::from_utf8(output.stdout).unwrap();
+            let expected = expected.trim();
+
+            let path = root.join_component(name);
+            let actual = hash_file_maybe_normalized(&path, TextAttr::Auto).unwrap();
+            let mut hex_buf = [0u8; 40];
+            hex::encode_to_slice(actual.as_bytes(), &mut hex_buf).unwrap();
+            let actual_str = std::str::from_utf8(&hex_buf).unwrap();
+
+            assert_eq!(
+                actual_str, expected,
+                "normalized hash for {name} must match git hash-object --path (with filters)"
+            );
+        }
+    }
+
+    /// Verify that the gix-based and sha1-based normalized hashers produce
+    /// identical OIDs for a comprehensive set of inputs. This is critical
+    /// because the git path uses gix and the manual path uses sha1 — they
+    /// must always agree.
+    #[test]
+    fn test_gix_and_manual_normalized_hashes_agree() {
+        let (_tmp, root) = tmp_dir();
+
+        let mut boundary_content = vec![b'x'; BUF_SIZE - 1];
+        boundary_content.push(b'\r');
+        boundary_content.push(b'\n');
+        boundary_content.extend_from_slice(b"after-boundary");
+
+        let cases: Vec<(&str, Vec<u8>, TextAttr)> = vec![
+            ("empty.txt", vec![], TextAttr::Set),
+            ("lf-only.txt", b"line1\nline2\n".to_vec(), TextAttr::Set),
+            ("pure-crlf.txt", b"a\r\nb\r\nc\r\n".to_vec(), TextAttr::Set),
+            (
+                "mixed.txt",
+                b"line1\nline2\r\nline3\n".to_vec(),
+                TextAttr::Set,
+            ),
+            ("trailing-cr.txt", b"data\r".to_vec(), TextAttr::Set),
+            (
+                "standalone-cr.txt",
+                b"hello\rworld\n".to_vec(),
+                TextAttr::Set,
+            ),
+            ("boundary-crlf.txt", boundary_content, TextAttr::Set),
+            // Auto with text content
+            (
+                "auto-text.txt",
+                b"hello\r\nworld\r\n".to_vec(),
+                TextAttr::Auto,
+            ),
+            // Auto with binary content (NUL byte)
+            (
+                "auto-binary.bin",
+                vec![0x00, b'\r', b'\n', 0xFF],
+                TextAttr::Auto,
+            ),
+            // Unspecified — should hash raw
+            ("unspec.txt", b"a\r\nb\r\n".to_vec(), TextAttr::Unspecified),
+        ];
+
+        for (name, content, attr) in &cases {
+            let path = root.join_component(name);
+            std::fs::write(path.as_std_path(), content).unwrap();
+
+            let gix_result = hash_file_maybe_normalized(&path, *attr).unwrap();
+            let manual_result = manual_hash_file_maybe_normalized(&path, *attr).unwrap();
+
+            let mut hex_buf = [0u8; 40];
+            hex::encode_to_slice(gix_result.as_bytes(), &mut hex_buf).unwrap();
+            let gix_hex = std::str::from_utf8(&hex_buf).unwrap();
+
+            assert_eq!(
+                gix_hex, &*manual_result,
+                "gix and manual hashes must agree for {name} (attr={attr:?})"
+            );
+        }
+    }
+
+    // -- GitAttrs tests --
+
+    #[test]
+    fn test_gitattrs_load_and_resolve() {
+        let (_tmp, root) = tmp_dir();
+        std::fs::write(
+            root.as_std_path().join(".gitattributes"),
+            "* text=auto\n*.png binary\n*.md text\n*.dat -text\n",
+        )
+        .unwrap();
+
+        let attrs = GitAttrs::load(&root).expect("should load .gitattributes");
+
+        assert_eq!(attrs.resolve_text_attr("README.md"), TextAttr::Set);
+        assert_eq!(attrs.resolve_text_attr("src/index.ts"), TextAttr::Auto);
+        assert_eq!(attrs.resolve_text_attr("image.png"), TextAttr::Unset);
+        assert_eq!(attrs.resolve_text_attr("data.dat"), TextAttr::Unset);
+    }
+
+    #[test]
+    fn test_gitattrs_returns_none_when_missing() {
+        let (_tmp, root) = tmp_dir();
+        assert!(GitAttrs::load(&root).is_none());
+    }
+
+    // -- hash_file_maybe_normalized edge-case tests --
+
+    #[test]
+    fn test_hash_binary_file_with_auto_is_raw() {
+        let (_tmp, root) = tmp_dir();
+        let path = root.join_component("binary.bin");
+        let content = vec![0x00, b'\r', b'\n', 0xFF, 0xFE];
+        std::fs::write(path.as_std_path(), &content).unwrap();
+
+        // With Auto, binary should be hashed raw (no normalization)
+        let auto_result = hash_file_maybe_normalized(&path, TextAttr::Auto).unwrap();
+
+        // With Unspecified, should also be raw
+        let raw_result = hash_file_maybe_normalized(&path, TextAttr::Unspecified).unwrap();
+
+        // Both should produce the same hash (raw bytes)
+        assert_eq!(
+            auto_result, raw_result,
+            "binary file with Auto should hash the same as Unspecified (raw)"
+        );
+    }
+
+    #[test]
+    fn test_hash_text_auto_normalizes_crlf() {
+        let (_tmp, root) = tmp_dir();
+        let path = root.join_component("text.txt");
+        std::fs::write(path.as_std_path(), b"a\r\nb\r\n").unwrap();
+
+        let auto_hash = hash_file_maybe_normalized(&path, TextAttr::Auto).unwrap();
+        let set_hash = hash_file_maybe_normalized(&path, TextAttr::Set).unwrap();
+
+        // Both Auto and Set should normalize CRLF for a text file
+        assert_eq!(auto_hash, set_hash);
+
+        // Unspecified should hash raw (different from normalized)
+        let raw_hash = hash_file_maybe_normalized(&path, TextAttr::Unspecified).unwrap();
+        assert_ne!(
+            auto_hash, raw_hash,
+            "normalized hash should differ from raw for CRLF content"
+        );
+    }
+
+    /// Verify chunk-boundary CRLF normalization against `git hash-object`.
+    #[test]
+    fn test_chunk_boundary_crlf_matches_git() {
+        let (_tmp, root) = tmp_dir();
+
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(root.as_std_path())
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["config", "--local", "core.autocrlf", "false"])
+            .current_dir(root.as_std_path())
+            .output()
+            .unwrap();
+        std::fs::write(root.as_std_path().join(".gitattributes"), "* text=auto\n").unwrap();
+
+        // \r at end of first 64KB chunk, \n at start of second
+        let mut content = vec![b'A'; BUF_SIZE - 1];
+        content.push(b'\r');
+        content.push(b'\n');
+        content.extend_from_slice(b"tail");
+
+        let name = "boundary.txt";
+        std::fs::write(root.as_std_path().join(name), &content).unwrap();
+
+        let output = std::process::Command::new("git")
+            .args(["hash-object", "--path", name, "--stdin"])
+            .stdin(std::process::Stdio::from(
+                std::fs::File::open(root.as_std_path().join(name)).unwrap(),
+            ))
+            .current_dir(root.as_std_path())
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        let expected = String::from_utf8(output.stdout).unwrap();
+        let expected = expected.trim();
+
+        let path = root.join_component(name);
+        let actual = hash_file_maybe_normalized(&path, TextAttr::Auto).unwrap();
+        let mut hex_buf = [0u8; 40];
+        hex::encode_to_slice(actual.as_bytes(), &mut hex_buf).unwrap();
+        let actual_str = std::str::from_utf8(&hex_buf).unwrap();
+
+        assert_eq!(
+            actual_str, expected,
+            "chunk-boundary CRLF normalization must match git hash-object"
+        );
+    }
+}

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -1644,6 +1644,7 @@ mod tests {
         GitRepo {
             root: root.to_owned(),
             bin,
+            attrs: std::sync::OnceLock::new(),
         }
     }
 

--- a/crates/turborepo-scm/src/hash_object.rs
+++ b/crates/turborepo-scm/src/hash_object.rs
@@ -1,5 +1,3 @@
-use std::io::{BufReader, Read};
-
 use rayon::prelude::*;
 use tracing::debug;
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf, RelativeUnixPath, RelativeUnixPathBuf};
@@ -10,67 +8,23 @@ const MAX_RETRIES: u32 = 10;
 const BASE_DELAY_MS: u64 = 10;
 const MAX_DELAY_MS: u64 = 1000;
 
-fn hash_file_with_retry(
-    path: &AbsoluteSystemPath,
-) -> Result<gix_index::hash::ObjectId, std::io::Error> {
+fn with_emfile_retry<T>(f: impl Fn() -> Result<T, std::io::Error>) -> Result<T, std::io::Error> {
     for attempt in 0..MAX_RETRIES {
-        match hash_file(path) {
-            Ok(oid) => return Ok(oid),
+        match f() {
+            Ok(v) => return Ok(v),
             Err(e) if is_too_many_open_files(&e) => {
                 let delay = std::cmp::min(BASE_DELAY_MS * 2u64.pow(attempt), MAX_DELAY_MS);
                 debug!(
                     attempt = attempt + 1,
                     delay_ms = delay,
-                    "too many open files, retrying hash_file"
+                    "too many open files, retrying"
                 );
                 std::thread::sleep(std::time::Duration::from_millis(delay));
             }
             Err(e) => return Err(e),
         }
     }
-    hash_file(path)
-}
-
-/// Hash a file as a git blob object using streaming I/O.
-///
-/// Instead of reading the entire file into memory, we stat the file for its
-/// size, write the git blob header ("blob {size}\0") into the hasher, then
-/// stream the file contents through in fixed-size chunks. Peak memory per
-/// call is bounded by `BUF_SIZE` (~64KB) regardless of file size.
-fn hash_file(path: &AbsoluteSystemPath) -> Result<gix_index::hash::ObjectId, std::io::Error> {
-    let file = std::fs::File::open(path)?;
-    let metadata = file.metadata()?;
-    // Reject exotic file types (sockets, FIFOs, device nodes) that cause
-    // EOPNOTSUPP on read(). Directories pass through to fail naturally
-    // with a descriptive IsADirectory error.
-    if !metadata.is_file() && !metadata.is_dir() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            format!("{path}: not a regular file"),
-        ));
-    }
-    let file_len = metadata.len();
-
-    // Build the hasher with the blob loose header pre-written, exactly as
-    // gix_object::compute_hash does internally.
-    let mut hasher = gix_index::hash::hasher(gix_index::hash::Kind::Sha1);
-    hasher.update(&gix_object::encode::loose_header(
-        gix_object::Kind::Blob,
-        file_len,
-    ));
-
-    const BUF_SIZE: usize = 64 * 1024;
-    let mut reader = BufReader::with_capacity(BUF_SIZE, file);
-    let mut buf = [0u8; BUF_SIZE];
-    loop {
-        let n = reader.read(&mut buf)?;
-        if n == 0 {
-            break;
-        }
-        hasher.update(&buf[..n]);
-    }
-
-    hasher.try_finalize().map_err(std::io::Error::other)
+    f()
 }
 
 fn is_too_many_open_files(e: &std::io::Error) -> bool {
@@ -78,55 +32,84 @@ fn is_too_many_open_files(e: &std::io::Error) -> bool {
         || e.to_string().contains("Too many open files")
 }
 
-#[tracing::instrument(skip(git_root, hashes, to_hash))]
+/// Hash a batch of files as git blob objects, applying CRLF→LF
+/// normalization when `.gitattributes` requires it.
+///
+/// `cached_attrs` reuses a pre-loaded [`crate::crlf::GitAttrs`] when
+/// available (e.g. from the `GitRepo`'s `OnceLock`). When `None`, attrs
+/// are loaded per-batch from `git_root`.
+#[tracing::instrument(skip(git_root, hashes, to_hash, cached_attrs))]
 pub(crate) fn hash_objects(
     git_root: &AbsoluteSystemPath,
     pkg_path: &AbsoluteSystemPath,
     to_hash: Vec<RelativeUnixPathBuf>,
     hashes: &mut GitHashes,
+    cached_attrs: Option<&crate::crlf::GitAttrs>,
 ) -> Result<(), Error> {
     let pkg_prefix = git_root.anchor(pkg_path).ok().map(|a| a.to_unix());
+
+    let mut owned_attrs = None;
+    let attrs = crate::crlf::resolve_or_load(cached_attrs, git_root, &mut owned_attrs);
 
     hashes.reserve(to_hash.len());
     let results: Vec<Result<Option<(RelativeUnixPathBuf, OidHash)>, Error>> = to_hash
         .into_par_iter()
-        .map(|filename| {
-            let full_file_path = git_root.join_unix_path(&filename);
-            match hash_file_with_retry(&full_file_path) {
-                Ok(hash) => {
-                    let package_relative_path = pkg_prefix
-                        .as_ref()
-                        .and_then(|prefix| {
-                            RelativeUnixPath::strip_prefix(&filename, prefix)
-                                .ok()
-                                .map(|stripped| stripped.to_owned())
-                        })
-                        .unwrap_or_else(|| {
-                            AnchoredSystemPathBuf::relative_path_between(pkg_path, &full_file_path)
+        // `map_init` creates one Outcome per rayon thread, reused across all
+        // files in that thread's partition. This avoids a per-file allocation
+        // inside `resolve_text_attr`.
+        .map_init(
+            || attrs.map(|a| a.new_outcome()),
+            |outcome, filename| {
+                let full_file_path = git_root.join_unix_path(&filename);
+
+                let text_attr = match (attrs, outcome.as_mut()) {
+                    (Some(a), Some(o)) => a.resolve_text_attr_with(filename.as_str(), o),
+                    _ => crate::crlf::TextAttr::Unspecified,
+                };
+
+                let hash_result = with_emfile_retry(|| {
+                    crate::crlf::hash_file_maybe_normalized(&full_file_path, text_attr)
+                });
+
+                match hash_result {
+                    Ok(hash) => {
+                        let package_relative_path = pkg_prefix
+                            .as_ref()
+                            .and_then(|prefix| {
+                                RelativeUnixPath::strip_prefix(&filename, prefix)
+                                    .ok()
+                                    .map(|stripped| stripped.to_owned())
+                            })
+                            .unwrap_or_else(|| {
+                                AnchoredSystemPathBuf::relative_path_between(
+                                    pkg_path,
+                                    &full_file_path,
+                                )
                                 .to_unix()
-                        });
-                    let mut hex_buf = [0u8; 40];
-                    hex::encode_to_slice(hash.as_bytes(), &mut hex_buf).unwrap();
-                    Ok(Some((
-                        package_relative_path,
-                        OidHash::from_hex_buf(hex_buf),
-                    )))
-                }
-                Err(e) => {
-                    // Gracefully skip non-regular files (symlinks, sockets,
-                    // FIFOs, device nodes) that can't be read as normal files.
-                    if full_file_path
-                        .symlink_metadata()
-                        .map(|md| !md.is_file())
-                        .unwrap_or(false)
-                    {
-                        Ok(None)
-                    } else {
-                        Err(Error::git_error(format!("{}: {}", full_file_path, e)))
+                            });
+                        let mut hex_buf = [0u8; 40];
+                        hex::encode_to_slice(hash.as_bytes(), &mut hex_buf).unwrap();
+                        Ok(Some((
+                            package_relative_path,
+                            OidHash::from_hex_buf(hex_buf),
+                        )))
+                    }
+                    Err(e) => {
+                        // Gracefully skip non-regular files (symlinks, sockets,
+                        // FIFOs, device nodes) that can't be read as normal files.
+                        if full_file_path
+                            .symlink_metadata()
+                            .map(|md| !md.is_file())
+                            .unwrap_or(false)
+                        {
+                            Ok(None)
+                        } else {
+                            Err(Error::git_error(format!("{}: {}", full_file_path, e)))
+                        }
                     }
                 }
-            }
-        })
+            },
+        )
         .collect();
 
     for result in results {
@@ -194,7 +177,7 @@ mod test {
             let expected_hashes = GitHashes::from_iter(file_hashes);
             let mut hashes = GitHashes::new();
             let to_hash = expected_hashes.keys().map(|k| pkg_prefix.join(k)).collect();
-            hash_objects(&git_root, pkg_path, to_hash, &mut hashes).unwrap();
+            hash_objects(&git_root, pkg_path, to_hash, &mut hashes, None).unwrap();
             assert_eq!(hashes, expected_hashes);
         }
 
@@ -214,7 +197,7 @@ mod test {
                 .collect();
 
             let mut hashes = GitHashes::new();
-            let result = hash_objects(&git_root, pkg_path, to_hash, &mut hashes);
+            let result = hash_objects(&git_root, pkg_path, to_hash, &mut hashes, None);
             assert!(result.is_err());
         }
     }
@@ -248,6 +231,14 @@ mod test {
             ("large.txt", vec![b'x'; 10_000]),
             ("multi_buf.bin", multi_buf_content),
             ("exact_buf.bin", exact_buf_content),
+            // CRLF edge cases: without --filters, git hash-object hashes raw
+            // bytes. These must remain stable after CRLF normalization is added
+            // to ensure we only normalize when .gitattributes says to.
+            ("lone-cr.txt", b"hello\rworld\n".to_vec()),
+            ("mixed-eol.txt", b"line1\nline2\r\nline3\n".to_vec()),
+            ("trailing-cr.bin", b"data\r".to_vec()),
+            ("crlf-in-binary.bin", vec![0x00, b'\r', b'\n', 0xFF, 0xFE]),
+            ("pure-crlf.txt", b"a\r\nb\r\nc\r\n".to_vec()),
         ];
 
         for (name, content) in &cases {
@@ -277,7 +268,7 @@ mod test {
             .map(|(name, _)| RelativeUnixPathBuf::new(*name).unwrap())
             .collect();
         let mut actual = GitHashes::new();
-        hash_objects(&tmp_path, &tmp_path, to_hash, &mut actual).unwrap();
+        hash_objects(&tmp_path, &tmp_path, to_hash, &mut actual, None).unwrap();
 
         assert_eq!(actual, expected, "blob hashes must match git hash-object");
     }

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -11,8 +11,10 @@
 use std::{
     backtrace::{self, Backtrace},
     collections::HashMap,
+    fmt,
     io::Read,
     process::{Child, Command},
+    sync::OnceLock,
 };
 
 use bstr::io::BufReadExt;
@@ -20,6 +22,7 @@ use thiserror::Error;
 use tracing::debug;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, PathError, RelativeUnixPathBuf};
 
+pub(crate) mod crlf;
 pub mod git;
 mod hash_object;
 mod ls_tree;
@@ -205,10 +208,37 @@ pub(crate) fn wait_for_success<R: Read, T>(
     Err(Error::Git(err_text, Backtrace::capture()))
 }
 
-#[derive(Debug, Clone)]
 pub struct GitRepo {
     root: AbsoluteSystemPathBuf,
     bin: AbsoluteSystemPathBuf,
+    attrs: OnceLock<Option<crlf::GitAttrs>>,
+}
+
+impl GitRepo {
+    pub(crate) fn git_attrs(&self) -> Option<&crlf::GitAttrs> {
+        self.attrs
+            .get_or_init(|| crlf::GitAttrs::load(&self.root))
+            .as_ref()
+    }
+}
+
+impl Clone for GitRepo {
+    fn clone(&self) -> Self {
+        Self {
+            root: self.root.clone(),
+            bin: self.bin.clone(),
+            attrs: OnceLock::new(),
+        }
+    }
+}
+
+impl fmt::Debug for GitRepo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GitRepo")
+            .field("root", &self.root)
+            .field("bin", &self.bin)
+            .finish()
+    }
 }
 
 #[derive(Debug, Error)]
@@ -227,7 +257,11 @@ impl GitRepo {
         let bin = Self::find_bin()?;
         let root =
             find_git_root(path_in_repo).map_err(|e| GitError::Root(path_in_repo.to_owned(), e))?;
-        Ok(Self { root, bin })
+        Ok(Self {
+            root,
+            bin,
+            attrs: OnceLock::new(),
+        })
     }
 
     pub fn find_bin() -> Result<AbsoluteSystemPathBuf, which::Error> {
@@ -296,6 +330,7 @@ impl SCM {
             Ok(bin) => SCM::Git(GitRepo {
                 root: git_root,
                 bin,
+                attrs: OnceLock::new(),
             }),
             Err(e) => {
                 debug!(

--- a/crates/turborepo-scm/src/manual.rs
+++ b/crates/turborepo-scm/src/manual.rs
@@ -1,65 +1,13 @@
-use std::{
-    borrow::Cow,
-    collections::HashSet,
-    io::{BufReader, ErrorKind, Read},
-    str::FromStr,
-};
+use std::{borrow::Cow, collections::HashSet, io::ErrorKind, str::FromStr};
 
 use globwalk::{ValidatedGlob, fix_glob_pattern, is_glob_pattern};
 use ignore::WalkBuilder;
-use sha1::{Digest, Sha1};
 use turbopath::{
     AbsoluteSystemPath, AnchoredSystemPath, AnchoredSystemPathBuf, IntoUnix, RelativeUnixPath,
 };
 use wax::{Glob, Program, any};
 
 use crate::{Error, GitHashes, OidHash};
-
-/// Hash a file as a git blob object using streaming I/O.
-///
-/// Writes the git blob header ("blob {size}\0") into the hasher using the
-/// file size from metadata, then streams the file contents in fixed-size
-/// chunks. Peak memory per call is bounded by `BUF_SIZE` (~64KB) regardless
-/// of file size.
-///
-/// Note: for symlinks, `open()` follows the link and reads the target. This
-/// is intentional for dotEnv file hashing.
-fn git_like_hash_file(path: &AbsoluteSystemPath) -> Result<OidHash, Error> {
-    let mut hasher = Sha1::new();
-    let f = path.open()?;
-    let metadata = f.metadata()?;
-    // Reject exotic file types (sockets, FIFOs, device nodes) that cause
-    // EOPNOTSUPP on read(). Directories pass through to fail naturally
-    // with a descriptive IsADirectory error.
-    if !metadata.is_file() && !metadata.is_dir() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            format!("{path}: not a regular file"),
-        )
-        .into());
-    }
-    let file_len = metadata.len();
-
-    hasher.update(b"blob ");
-    hasher.update(file_len.to_string().as_bytes());
-    hasher.update([b'\0']);
-
-    const BUF_SIZE: usize = 64 * 1024;
-    let mut reader = BufReader::with_capacity(BUF_SIZE, f);
-    let mut buf = [0u8; BUF_SIZE];
-    loop {
-        let n = reader.read(&mut buf)?;
-        if n == 0 {
-            break;
-        }
-        hasher.update(&buf[..n]);
-    }
-
-    let result = hasher.finalize();
-    let mut hex_buf = [0u8; 40];
-    hex::encode_to_slice(result, &mut hex_buf).unwrap();
-    Ok(OidHash::from_hex_buf(hex_buf))
-}
 
 fn expand_dir_pattern<'a>(base: &AbsoluteSystemPath, pattern: &'a str) -> Cow<'a, str> {
     if is_glob_pattern(pattern) {
@@ -87,16 +35,33 @@ fn to_glob(input: &str) -> Result<Glob<'static>, Error> {
     Ok(g)
 }
 
+/// Hash a set of files as git blob objects, applying CRLF→LF normalization
+/// when `.gitattributes` requires it.
+///
+/// `attrs_root` overrides where `.gitattributes` is loaded from (e.g. the
+/// git root when falling back from the git path). When `None`, uses
+/// `root_path`.
+///
+/// `cached_attrs` reuses a pre-loaded `GitAttrs` (e.g. from `GitRepo`'s
+/// `OnceLock`). When `None`, attrs are loaded from `attrs_root`.
 pub(crate) fn hash_files(
     root_path: &AbsoluteSystemPath,
     files: impl Iterator<Item = impl AsRef<AnchoredSystemPath>>,
     allow_missing: bool,
+    attrs_root: Option<&AbsoluteSystemPath>,
+    cached_attrs: Option<&crate::crlf::GitAttrs>,
 ) -> Result<GitHashes, Error> {
+    let effective_attrs_root = attrs_root.unwrap_or(root_path);
+    let mut owned_attrs = None;
+    let attrs = crate::crlf::resolve_or_load(cached_attrs, effective_attrs_root, &mut owned_attrs);
     let mut hashes = GitHashes::new();
     for file in files.into_iter() {
-        let path = root_path.resolve(file.as_ref());
-        match git_like_hash_file(&path) {
-            Ok(hash) => hashes.insert(file.as_ref().to_unix(), hash),
+        let anchored = file.as_ref();
+        let path = root_path.resolve(anchored);
+        let root_relative = anchored.to_unix();
+        let attr_path = effective_attrs_root.anchor(&path)?.to_unix();
+        match hash_file_with_attrs(&path, attr_path.as_str(), attrs) {
+            Ok(hash) => hashes.insert(root_relative, hash),
             Err(Error::Io(ref io_error, _))
                 if allow_missing && io_error.kind() == ErrorKind::NotFound =>
             {
@@ -108,15 +73,40 @@ pub(crate) fn hash_files(
     Ok(hashes)
 }
 
+/// Hash a file as a git blob, applying CRLF→LF normalization when
+/// `.gitattributes` requires it.
+///
+/// `attr_path` must be relative to the root where `GitAttrs` was loaded
+/// (typically turbo_root or git_root). This is NOT necessarily the same as
+/// the package-relative path used for hash map insertion — callers must
+/// compute the correct root-relative path.
+fn hash_file_with_attrs(
+    path: &AbsoluteSystemPath,
+    attr_path: &str,
+    attrs: Option<&crate::crlf::GitAttrs>,
+) -> Result<OidHash, Error> {
+    let text_attr = attrs
+        .map(|a| a.resolve_text_attr(attr_path))
+        .unwrap_or(crate::crlf::TextAttr::Unspecified);
+
+    crate::crlf::manual_hash_file_maybe_normalized(path, text_attr)
+}
+
 pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
     turbo_root: &AbsoluteSystemPath,
     package_path: &AnchoredSystemPath,
     inputs: &[S],
     include_default_files: bool,
+    attrs_root: Option<&AbsoluteSystemPath>,
+    cached_attrs: Option<&crate::crlf::GitAttrs>,
 ) -> Result<GitHashes, Error> {
     let full_package_path = turbo_root.resolve(package_path);
     let package_unix_path = package_path.to_unix();
     let mut hashes = GitHashes::new();
+
+    let effective_attrs_root = attrs_root.unwrap_or(turbo_root);
+    let mut owned_attrs = None;
+    let attrs = crate::crlf::resolve_or_load(cached_attrs, effective_attrs_root, &mut owned_attrs);
     let mut default_file_hashes = GitHashes::new();
     let mut excluded_file_paths = HashSet::new();
 
@@ -159,7 +149,9 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
             let relative_path =
                 AnchoredSystemPathBuf::relative_path_between(&full_package_path, file_path)
                     .to_unix();
-            let hash = git_like_hash_file(file_path)?;
+            // Use attrs-root-relative path for .gitattributes pattern matching.
+            let attr_path = effective_attrs_root.anchor(file_path)?.to_unix();
+            let hash = hash_file_with_attrs(file_path, attr_path.as_str(), attrs)?;
             hashes.insert(relative_path, hash);
         }
     }
@@ -244,7 +236,8 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
             continue;
         }
 
-        let hash = git_like_hash_file(path)?;
+        let attr_path = effective_attrs_root.anchor(path)?.to_unix();
+        let hash = hash_file_with_attrs(path, attr_path.as_str(), attrs)?;
         hashes.insert(relative_path, hash);
     }
 
@@ -286,7 +279,8 @@ pub(crate) fn get_package_file_hashes_without_git<S: AsRef<str>>(
                 continue;
             }
 
-            let hash = git_like_hash_file(path)?;
+            let attr_path = effective_attrs_root.anchor(path)?.to_unix();
+            let hash = hash_file_with_attrs(path, attr_path.as_str(), attrs)?;
             default_file_hashes.insert(relative_path, hash);
         }
     }
@@ -346,7 +340,7 @@ mod tests {
         let files = files
             .iter()
             .map(|s| AnchoredSystemPathBuf::from_raw(s).unwrap());
-        match hash_files(&turbo_root, files, allow_missing) {
+        match hash_files(&turbo_root, files, allow_missing, None, None) {
             Err(e) => assert!(want_err, "unexpected error {e}"),
             Ok(hashes) => assert_eq!(hashes, expected),
         }
@@ -374,6 +368,8 @@ mod tests {
             &turbo_root,
             [AnchoredSystemPathBuf::from_raw("symlink-from-to-file").unwrap()].iter(),
             true,
+            None,
+            None,
         )
         .unwrap();
         let from_to_file_hash = out
@@ -391,6 +387,8 @@ mod tests {
                 &turbo_root,
                 [AnchoredSystemPathBuf::from_raw("symlink-from-to-dir").unwrap()].iter(),
                 true,
+                None,
+                None,
             );
             match out.err().unwrap() {
                 Error::Io(io_error, _) => assert_eq!(io_error.kind(), ErrorKind::IsADirectory),
@@ -403,6 +401,8 @@ mod tests {
             &turbo_root,
             [AnchoredSystemPathBuf::from_raw("symlink-from-to-dir").unwrap()].iter(),
             false,
+            None,
+            None,
         );
         #[cfg(windows)]
         let expected_err_kind = ErrorKind::PermissionDenied;
@@ -415,6 +415,8 @@ mod tests {
             &turbo_root,
             [AnchoredSystemPathBuf::from_raw("symlink-broken").unwrap()].iter(),
             true,
+            None,
+            None,
         )
         .unwrap();
         let broken_hash = out.get(&RelativeUnixPathBuf::new("symlink-broken").unwrap());
@@ -425,6 +427,8 @@ mod tests {
             &turbo_root,
             [AnchoredSystemPathBuf::from_raw("symlink-broken").unwrap()].iter(),
             false,
+            None,
+            None,
         );
         match out.err().unwrap() {
             Error::Io(io_error, _) => assert_eq!(io_error.kind(), ErrorKind::NotFound),
@@ -512,9 +516,15 @@ mod tests {
             OidHash::from_hex_str("3237694bc3312ded18386964a855074af7b066af"),
         );
 
-        let hashes =
-            get_package_file_hashes_without_git::<&str>(&turbo_root, &pkg_path, &[], false)
-                .unwrap();
+        let hashes = get_package_file_hashes_without_git::<&str>(
+            &turbo_root,
+            &pkg_path,
+            &[],
+            false,
+            None,
+            None,
+        )
+        .unwrap();
         assert_eq!(hashes, expected);
 
         // set a hash for an ignored file
@@ -548,6 +558,8 @@ mod tests {
             &pkg_path,
             &["**/*file", "!some-dir/excluded-file"],
             false,
+            None,
+            None,
         )
         .unwrap();
 
@@ -584,8 +596,15 @@ mod tests {
         // "*.ts" matches both shared.ts and default-only.ts in the first walk
         // (since git_ignore=false for explicit inputs). The second walk with
         // git_ignore=true should not re-hash files already found.
-        let hashes =
-            get_package_file_hashes_without_git(&turbo_root, &pkg_path, &["*.ts"], true).unwrap();
+        let hashes = get_package_file_hashes_without_git(
+            &turbo_root,
+            &pkg_path,
+            &["*.ts"],
+            true,
+            None,
+            None,
+        )
+        .unwrap();
 
         // All four files should appear exactly once
         assert!(
@@ -606,8 +625,15 @@ mod tests {
         );
 
         // Verify the hash values are deterministic (same content = same hash)
-        let hashes2 =
-            get_package_file_hashes_without_git(&turbo_root, &pkg_path, &["*.ts"], true).unwrap();
+        let hashes2 = get_package_file_hashes_without_git(
+            &turbo_root,
+            &pkg_path,
+            &["*.ts"],
+            true,
+            None,
+            None,
+        )
+        .unwrap();
         assert_eq!(hashes, hashes2, "hashes should be deterministic");
     }
 
@@ -631,6 +657,8 @@ mod tests {
             &pkg_path,
             &["*.ts", "!excluded.ts"],
             true,
+            None,
+            None,
         )
         .unwrap();
 
@@ -672,8 +700,15 @@ mod tests {
             .create_with_contents("readme")
             .unwrap();
 
-        let hashes =
-            get_package_file_hashes_without_git(&turbo_root, &pkg_path, &["src"], false).unwrap();
+        let hashes = get_package_file_hashes_without_git(
+            &turbo_root,
+            &pkg_path,
+            &["src"],
+            false,
+            None,
+            None,
+        )
+        .unwrap();
 
         assert!(
             hashes.contains_key(&RelativeUnixPathBuf::new("src/index.ts").unwrap()),
@@ -716,7 +751,8 @@ mod tests {
             .unwrap();
 
         let hashes =
-            get_package_file_hashes_without_git(&turbo_root, &pkg_path, &["src"], true).unwrap();
+            get_package_file_hashes_without_git(&turbo_root, &pkg_path, &["src"], true, None, None)
+                .unwrap();
 
         assert!(
             hashes.contains_key(&RelativeUnixPathBuf::new("src/index.ts").unwrap()),
@@ -752,6 +788,14 @@ mod tests {
             ("small.txt", vec![b'x'; 10_000]),
             ("multi_buf.bin", multi_buf_content),
             ("exact_buf.bin", exact_buf_content),
+            // CRLF edge cases: without --filters, git hash-object hashes raw
+            // bytes. These must remain stable after CRLF normalization is added
+            // to ensure we only normalize when .gitattributes says to.
+            ("lone-cr.txt", b"hello\rworld\n".to_vec()),
+            ("mixed-eol.txt", b"line1\nline2\r\nline3\n".to_vec()),
+            ("trailing-cr.bin", b"data\r".to_vec()),
+            ("crlf-in-binary.bin", vec![0x00, b'\r', b'\n', 0xFF, 0xFE]),
+            ("pure-crlf.txt", b"a\r\nb\r\nc\r\n".to_vec()),
         ];
 
         for (name, content) in &cases {
@@ -776,7 +820,11 @@ mod tests {
             let expected_hash = expected_hash.trim();
 
             let path = turbo_root.join_component(name);
-            let actual = git_like_hash_file(&path).unwrap();
+            let actual = crate::crlf::manual_hash_file_maybe_normalized(
+                &path,
+                crate::crlf::TextAttr::Unspecified,
+            )
+            .unwrap();
             assert_eq!(
                 &*actual, expected_hash,
                 "manual hash for {name} must match git hash-object"
@@ -814,6 +862,8 @@ mod tests {
             &pkg_path,
             &["../../root-file"],
             false,
+            None,
+            None,
         )
         .unwrap();
 
@@ -848,9 +898,15 @@ mod tests {
         let pkg_json = full_pkg_path.join_component("package.json");
         pkg_json.create_with_contents("{}").unwrap();
 
-        let hashes =
-            get_package_file_hashes_without_git(&turbo_root, &pkg_path, &["../../*-file"], false)
-                .unwrap();
+        let hashes = get_package_file_hashes_without_git(
+            &turbo_root,
+            &pkg_path,
+            &["../../*-file"],
+            false,
+            None,
+            None,
+        )
+        .unwrap();
 
         assert!(
             hashes.contains_key(&RelativeUnixPathBuf::new("../../root-file").unwrap()),

--- a/crates/turborepo-scm/src/package_deps.rs
+++ b/crates/turborepo-scm/src/package_deps.rs
@@ -41,6 +41,8 @@ impl SCM {
                     package_path,
                     inputs,
                     include_default_files,
+                    None,
+                    None,
                 )
             }
             SCM::Git(git) => {
@@ -82,6 +84,8 @@ impl SCM {
                             package_path,
                             inputs,
                             include_default_files,
+                            Some(&git.root),
+                            git.git_attrs(),
                         )
                     }
                 }
@@ -95,7 +99,7 @@ impl SCM {
         files: impl Iterator<Item = impl AsRef<AnchoredSystemPath>>,
     ) -> Result<GitHashes, Error> {
         match self {
-            SCM::Manual => crate::manual::hash_files(turbo_root, files, false),
+            SCM::Manual => crate::manual::hash_files(turbo_root, files, false, None, None),
             SCM::Git(git) => git.hash_files(turbo_root, files),
         }
     }
@@ -108,7 +112,11 @@ impl SCM {
         turbo_root: &AbsoluteSystemPath,
         files: impl Iterator<Item = impl AsRef<AnchoredSystemPath>>,
     ) -> Result<GitHashes, Error> {
-        crate::manual::hash_files(turbo_root, files, true)
+        let (attrs_root, cached_attrs) = match self {
+            SCM::Git(git) => (Some(git.root.as_ref()), git.git_attrs()),
+            SCM::Manual => (None, None),
+        };
+        crate::manual::hash_files(turbo_root, files, true, attrs_root, cached_attrs)
     }
 }
 
@@ -163,7 +171,13 @@ impl GitRepo {
         };
 
         // Note: to_hash is *git repo relative*
-        hash_objects(&self.root, &full_pkg_path, to_hash, &mut hashes)?;
+        hash_objects(
+            &self.root,
+            &full_pkg_path,
+            to_hash,
+            &mut hashes,
+            self.git_attrs(),
+        )?;
         Ok(hashes)
     }
 
@@ -182,7 +196,13 @@ impl GitRepo {
             })
             .collect::<Result<Vec<_>, PathError>>()?;
         // Note: to_hash is *git repo relative*
-        hash_objects(&self.root, process_relative_to, to_hash, &mut hashes)?;
+        hash_objects(
+            &self.root,
+            process_relative_to,
+            to_hash,
+            &mut hashes,
+            self.git_attrs(),
+        )?;
         Ok(hashes)
     }
 
@@ -229,7 +249,13 @@ impl GitRepo {
 
         if !to_hash.is_empty() {
             let mut new_hashes = GitHashes::with_capacity(to_hash.len());
-            hash_objects(&self.root, full_pkg_path, to_hash, &mut new_hashes)?;
+            hash_objects(
+                &self.root,
+                full_pkg_path,
+                to_hash,
+                &mut new_hashes,
+                self.git_attrs(),
+            )?;
             hashes.extend(new_hashes);
         }
 
@@ -513,12 +539,13 @@ mod tests {
         let mut hashes = GitHashes::new();
         // FIXME: This test verifies a bug: we don't hash symlinks.
         // TODO: update this test to point at get_package_file_hashes
-        hash_objects(&git_root, &git_root, to_hash, &mut hashes).unwrap();
+        hash_objects(&git_root, &git_root, to_hash, &mut hashes, None).unwrap();
         assert!(hashes.is_empty());
 
         let pkg_path = git_root.anchor(&git_root).unwrap();
         let manual_hashes =
-            get_package_file_hashes_without_git(&git_root, &pkg_path, &["l*"], false).unwrap();
+            get_package_file_hashes_without_git(&git_root, &pkg_path, &["l*"], false, None, None)
+                .unwrap();
         assert!(manual_hashes.is_empty());
     }
 
@@ -924,5 +951,576 @@ mod tests {
                 OidHash::from_hex_str(hash),
             )
         }))
+    }
+
+    /// Regression test: for LF-only files, the git path and manual path must
+    /// produce identical hashes. With `text=auto` in `.gitattributes`, the
+    /// normalization scan runs but should produce the same result as raw
+    /// hashing since there are no CRLF pairs.
+    #[test]
+    fn test_git_and_manual_paths_agree_for_lf_files() {
+        let (_repo_root_tmp, repo_root) = tmp_dir();
+        let pkg_dir = repo_root.join_component("my-pkg");
+        pkg_dir.create_dir_all().unwrap();
+
+        // Add .gitattributes to exercise the normalization decision path
+        std::fs::write(
+            repo_root.as_std_path().join(".gitattributes"),
+            "* text=auto\n",
+        )
+        .unwrap();
+
+        let files: &[(&str, &[u8])] = &[
+            ("my-pkg/package.json", b"{\"name\": \"my-pkg\"}\n"),
+            ("my-pkg/index.ts", b"export const x = 1;\n"),
+            ("my-pkg/data.json", b"{\"key\": \"value\"}\n"),
+            (
+                "my-pkg/binary.bin",
+                &[0x89, 0x50, 0x4E, 0x47, 0x00, 0x01, 0x02],
+            ),
+        ];
+
+        for (path, content) in files {
+            let file_path =
+                repo_root.join_unix_path(turbopath::RelativeUnixPath::new(path).unwrap());
+            file_path.ensure_dir().unwrap();
+            std::fs::write(file_path.as_std_path(), content).unwrap();
+        }
+
+        setup_repository(&repo_root);
+        require_git_cmd(&repo_root, &["config", "--local", "core.autocrlf", "false"]);
+        commit_all(&repo_root);
+
+        let pkg_path = AnchoredSystemPathBuf::from_raw("my-pkg").unwrap();
+
+        // Hash via git path
+        let git = SCM::new(&repo_root);
+        let git_hashes = git
+            .get_package_file_hashes::<&str>(&repo_root, &pkg_path, &[], false, None, None)
+            .unwrap();
+
+        // Hash via manual path
+        let manual_hashes = get_package_file_hashes_without_git::<&str>(
+            &repo_root,
+            &pkg_path,
+            &[],
+            false,
+            None,
+            None,
+        )
+        .unwrap();
+
+        // Filter to the same set of keys (manual path may pick up .gitignore etc.)
+        for (path, git_hash) in &git_hashes {
+            let manual_hash = manual_hashes.get(path);
+            assert_eq!(
+                Some(git_hash),
+                manual_hash,
+                "hash mismatch for {path}: git={git_hash}, manual={manual_hash:?}"
+            );
+        }
+    }
+
+    /// Regression test: binary files must never be normalized, even when
+    /// .gitattributes says `text=auto`. The NUL-byte heuristic must detect
+    /// them and hash raw bytes.
+    #[test]
+    fn test_binary_files_hash_raw_with_text_auto() {
+        let (_repo_root_tmp, repo_root) = tmp_dir();
+        let pkg_dir = repo_root.join_component("my-pkg");
+        pkg_dir.create_dir_all().unwrap();
+
+        // .gitattributes with text=auto
+        std::fs::write(
+            repo_root.as_std_path().join(".gitattributes"),
+            "* text=auto\n",
+        )
+        .unwrap();
+
+        // Binary files with CRLF bytes that must NOT be normalized
+        let binary_cases: &[(&str, &[u8])] = &[
+            // PNG-like header with NUL byte + CRLF
+            (
+                "my-pkg/image.png",
+                &[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00],
+            ),
+            // Arbitrary binary with NUL + CRLF in the middle
+            ("my-pkg/data.bin", &[0xFF, 0x00, 0x0D, 0x0A, 0xFE, 0xFD]),
+        ];
+
+        std::fs::write(
+            pkg_dir.as_std_path().join("package.json"),
+            "{\"name\": \"my-pkg\"}\n",
+        )
+        .unwrap();
+        for (path, content) in binary_cases {
+            let full_path = repo_root.as_std_path().join(path);
+            std::fs::create_dir_all(full_path.parent().unwrap()).unwrap();
+            std::fs::write(&full_path, content).unwrap();
+        }
+
+        setup_repository(&repo_root);
+        // Disable autocrlf to ensure git stores raw bytes
+        require_git_cmd(&repo_root, &["config", "--local", "core.autocrlf", "false"]);
+        commit_all(&repo_root);
+
+        let pkg_path = AnchoredSystemPathBuf::from_raw("my-pkg").unwrap();
+
+        // Hash via git path
+        let git = SCM::new(&repo_root);
+        let git_hashes = git
+            .get_package_file_hashes::<&str>(&repo_root, &pkg_path, &[], false, None, None)
+            .unwrap();
+
+        // Hash via manual path (no .git/) to verify both paths agree
+        let (_prune_tmp, prune_root) = tmp_dir();
+        let prune_pkg = prune_root.join_component("my-pkg");
+        prune_pkg.create_dir_all().unwrap();
+        std::fs::copy(
+            repo_root.as_std_path().join(".gitattributes"),
+            prune_root.as_std_path().join(".gitattributes"),
+        )
+        .unwrap();
+        std::fs::copy(
+            pkg_dir.as_std_path().join("package.json"),
+            prune_pkg.as_std_path().join("package.json"),
+        )
+        .unwrap();
+        for (rel_path, content) in binary_cases {
+            let pkg_relative = rel_path.strip_prefix("my-pkg/").unwrap();
+            std::fs::write(prune_pkg.as_std_path().join(pkg_relative), content).unwrap();
+        }
+
+        let prune_pkg_path = AnchoredSystemPathBuf::from_raw("my-pkg").unwrap();
+        let manual_hashes = get_package_file_hashes_without_git::<&str>(
+            &prune_root,
+            &prune_pkg_path,
+            &[],
+            false,
+            None,
+            None,
+        )
+        .unwrap();
+
+        // Verify git and manual paths agree, and both match `git hash-object`
+        for (rel_path, _content) in binary_cases {
+            let pkg_relative = rel_path.strip_prefix("my-pkg/").unwrap();
+            let full_path = repo_root.as_std_path().join(rel_path);
+
+            let output = Command::new("git")
+                .args(["hash-object", "--no-filters", full_path.to_str().unwrap()])
+                .current_dir(repo_root.as_std_path())
+                .output()
+                .unwrap();
+            let expected_hash = String::from_utf8(output.stdout).unwrap();
+            let expected_hash = expected_hash.trim();
+
+            let key = RelativeUnixPathBuf::new(pkg_relative).unwrap();
+            let git_actual = git_hashes
+                .get(&key)
+                .expect("binary file should be in git hashes");
+            assert_eq!(
+                &**git_actual, expected_hash,
+                "binary file {rel_path} should be hashed raw (no normalization) via git path"
+            );
+
+            let manual_actual = manual_hashes
+                .get(&key)
+                .expect("binary file should be in manual hashes");
+            assert_eq!(
+                &**manual_actual, expected_hash,
+                "binary file {rel_path} should be hashed raw (no normalization) via manual path"
+            );
+        }
+    }
+
+    /// Bug reproduction for https://github.com/vercel/turborepo/issues/9616
+    ///
+    /// When .gitattributes has `text=auto`, git normalizes CRLF→LF in blobs.
+    /// After `turbo prune`, the pruned output has no .git/ directory, so turbo
+    /// falls back to manual hashing which hashes raw bytes (with CRLF). This
+    /// produces a different hash than the git path.
+    #[test]
+    fn test_crlf_hash_matches_after_simulated_prune() {
+        let (_repo_root_tmp, repo_root) = tmp_dir();
+        let pkg_dir = repo_root.join_component("my-pkg");
+        pkg_dir.create_dir_all().unwrap();
+
+        // .gitattributes with text=auto (the common setup)
+        std::fs::write(
+            repo_root.as_std_path().join(".gitattributes"),
+            "* text=auto\n",
+        )
+        .unwrap();
+
+        let test_files: &[(&str, &[u8])] = &[
+            // Text file with CRLF (the primary case)
+            ("readme.md", b"Hello\r\nWorld\r\n"),
+            // LF-only text file (should match trivially)
+            ("lf-only.txt", b"line1\nline2\n"),
+            // Binary file with CRLF bytes + NUL (must NOT be normalized)
+            ("image.bin", &[0x89, 0x50, 0x0D, 0x0A, 0x00, 0x01]),
+            // Mixed CRLF/LF
+            ("mixed.txt", b"first\nsecond\r\nthird\n"),
+        ];
+
+        std::fs::write(
+            pkg_dir.as_std_path().join("package.json"),
+            "{\"name\": \"my-pkg\"}\n",
+        )
+        .unwrap();
+        for (name, content) in test_files {
+            std::fs::write(pkg_dir.as_std_path().join(name), content).unwrap();
+        }
+
+        setup_repository(&repo_root);
+        require_git_cmd(&repo_root, &["config", "--local", "core.autocrlf", "false"]);
+        commit_all(&repo_root);
+
+        let pkg_path = AnchoredSystemPathBuf::from_raw("my-pkg").unwrap();
+
+        // Hash via git path (uses git ls-tree OIDs which are LF-normalized)
+        let git = SCM::new(&repo_root);
+        let git_hashes = git
+            .get_package_file_hashes::<&str>(&repo_root, &pkg_path, &[], false, None, None)
+            .unwrap();
+
+        // Simulate turbo prune: copy files to a non-git directory
+        let (_prune_tmp, prune_root) = tmp_dir();
+        let prune_pkg = prune_root.join_component("my-pkg");
+        prune_pkg.create_dir_all().unwrap();
+
+        // Copy .gitattributes (our fix adds this to ADDITIONAL_FILES)
+        std::fs::copy(
+            repo_root.as_std_path().join(".gitattributes"),
+            prune_root.as_std_path().join(".gitattributes"),
+        )
+        .unwrap();
+        // Copy all package files byte-for-byte (like turbo prune does)
+        std::fs::copy(
+            pkg_dir.as_std_path().join("package.json"),
+            prune_pkg.as_std_path().join("package.json"),
+        )
+        .unwrap();
+        for (name, _) in test_files {
+            std::fs::copy(
+                pkg_dir.as_std_path().join(name),
+                prune_pkg.as_std_path().join(name),
+            )
+            .unwrap();
+        }
+
+        let prune_pkg_path = AnchoredSystemPathBuf::from_raw("my-pkg").unwrap();
+
+        // Hash via manual path (no .git/ in pruned output)
+        let manual_hashes = get_package_file_hashes_without_git::<&str>(
+            &prune_root,
+            &prune_pkg_path,
+            &[],
+            false,
+            None,
+            None,
+        )
+        .unwrap();
+
+        for (name, _) in test_files {
+            let key = RelativeUnixPathBuf::new(*name).unwrap();
+            let git_hash = git_hashes
+                .get(&key)
+                .unwrap_or_else(|| panic!("{name} in git hashes"));
+            let manual_hash = manual_hashes
+                .get(&key)
+                .unwrap_or_else(|| panic!("{name} in manual hashes"));
+
+            assert_eq!(
+                git_hash, manual_hash,
+                "{name}: hash should match between git path and manual path (simulating turbo \
+                 prune). git={git_hash}, manual={manual_hash}"
+            );
+        }
+    }
+
+    /// Bug reproduction for https://github.com/vercel/turborepo/issues/5081
+    ///
+    /// When a file with `text=auto` in .gitattributes is committed (git
+    /// normalizes CRLF→LF in the blob), then touched (making it dirty but
+    /// content-identical), the dirty-file hash should match the committed
+    /// blob hash. Currently it doesn't because hash_objects() hashes raw
+    /// bytes without applying .gitattributes filters.
+    #[test]
+    fn test_dirty_crlf_file_matches_committed_hash() {
+        let (_repo_root_tmp, repo_root) = tmp_dir();
+        let pkg_dir = repo_root.join_component("my-pkg");
+        pkg_dir.create_dir_all().unwrap();
+
+        std::fs::write(
+            repo_root.as_std_path().join(".gitattributes"),
+            "* text=auto\n",
+        )
+        .unwrap();
+
+        std::fs::write(
+            pkg_dir.as_std_path().join("readme.md"),
+            b"Hello\r\nWorld\r\n",
+        )
+        .unwrap();
+        std::fs::write(
+            pkg_dir.as_std_path().join("package.json"),
+            "{\"name\": \"my-pkg\"}\n",
+        )
+        .unwrap();
+
+        setup_repository(&repo_root);
+        require_git_cmd(&repo_root, &["config", "--local", "core.autocrlf", "false"]);
+        commit_all(&repo_root);
+
+        let pkg_path = AnchoredSystemPathBuf::from_raw("my-pkg").unwrap();
+
+        // Get committed hash (from git ls-tree — uses normalized blob OID)
+        let git = SCM::new(&repo_root);
+        let committed_hashes = git
+            .get_package_file_hashes::<&str>(&repo_root, &pkg_path, &[], false, None, None)
+            .unwrap();
+
+        // Touch the file to make it dirty (content unchanged, mtime updated)
+        let readme_path = pkg_dir.join_component("readme.md");
+        let content = std::fs::read(readme_path.as_std_path()).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        std::fs::write(readme_path.as_std_path(), &content).unwrap();
+
+        // Re-hash — now readme.md is dirty, goes through hash_objects()
+        let dirty_hashes = git
+            .get_package_file_hashes::<&str>(&repo_root, &pkg_path, &[], false, None, None)
+            .unwrap();
+
+        let key = RelativeUnixPathBuf::new("readme.md").unwrap();
+        let committed = committed_hashes.get(&key).expect("readme.md committed");
+        let dirty = dirty_hashes.get(&key).expect("readme.md dirty");
+
+        assert_eq!(
+            committed, dirty,
+            "dirty CRLF file hash should match committed hash when content is identical. \
+             committed={committed}, dirty={dirty}"
+        );
+    }
+
+    /// Verify that package-scoped .gitattributes patterns resolve correctly
+    /// through both git and manual hashing paths.
+    ///
+    /// Regression test for path relativity mismatch: hash_objects() uses
+    /// git-root-relative paths while the manual path previously used
+    /// package-relative paths for attribute resolution. A pattern like
+    /// `my-pkg/*.md text` must match in both paths.
+    #[test]
+    fn test_package_scoped_gitattributes_pattern() {
+        let (_repo_root_tmp, repo_root) = tmp_dir();
+        let pkg_dir = repo_root.join_component("my-pkg");
+        pkg_dir.create_dir_all().unwrap();
+
+        // Pattern that references the package directory explicitly.
+        // If the manual path passes only "readme.md" (package-relative) instead
+        // of "my-pkg/readme.md" (root-relative), this pattern won't match.
+        std::fs::write(
+            repo_root.as_std_path().join(".gitattributes"),
+            "my-pkg/*.md text\n",
+        )
+        .unwrap();
+
+        std::fs::write(
+            pkg_dir.as_std_path().join("readme.md"),
+            b"Hello\r\nWorld\r\n",
+        )
+        .unwrap();
+        std::fs::write(
+            pkg_dir.as_std_path().join("package.json"),
+            "{\"name\": \"my-pkg\"}\n",
+        )
+        .unwrap();
+
+        setup_repository(&repo_root);
+        require_git_cmd(&repo_root, &["config", "--local", "core.autocrlf", "false"]);
+        commit_all(&repo_root);
+
+        let pkg_path = AnchoredSystemPathBuf::from_raw("my-pkg").unwrap();
+
+        // Hash via git path
+        let git = SCM::new(&repo_root);
+        let git_hashes = git
+            .get_package_file_hashes::<&str>(&repo_root, &pkg_path, &[], false, None, None)
+            .unwrap();
+
+        // Simulate prune: copy to a non-git directory
+        let (_prune_tmp, prune_root) = tmp_dir();
+        let prune_pkg = prune_root.join_component("my-pkg");
+        prune_pkg.create_dir_all().unwrap();
+        std::fs::copy(
+            repo_root.as_std_path().join(".gitattributes"),
+            prune_root.as_std_path().join(".gitattributes"),
+        )
+        .unwrap();
+        std::fs::copy(
+            pkg_dir.as_std_path().join("package.json"),
+            prune_pkg.as_std_path().join("package.json"),
+        )
+        .unwrap();
+        std::fs::copy(
+            pkg_dir.as_std_path().join("readme.md"),
+            prune_pkg.as_std_path().join("readme.md"),
+        )
+        .unwrap();
+
+        let manual_hashes = get_package_file_hashes_without_git::<&str>(
+            &prune_root,
+            &pkg_path,
+            &[],
+            false,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let key = RelativeUnixPathBuf::new("readme.md").unwrap();
+        let git_hash = git_hashes.get(&key).expect("readme.md in git hashes");
+        let manual_hash = manual_hashes.get(&key).expect("readme.md in manual hashes");
+
+        assert_eq!(
+            git_hash, manual_hash,
+            "package-scoped .gitattributes pattern must produce matching hashes. git={git_hash}, \
+             manual={manual_hash}"
+        );
+    }
+
+    /// Verify that hash_files (used for global dependencies) respects
+    /// .gitattributes CRLF normalization.
+    #[test]
+    fn test_hash_files_respects_gitattributes() {
+        let (_tmp, root) = tmp_dir();
+
+        std::fs::write(root.as_std_path().join(".gitattributes"), "* text=auto\n").unwrap();
+
+        let crlf_file = root.join_component("global-dep.env");
+        std::fs::write(crlf_file.as_std_path(), b"KEY=value\r\nOTHER=val\r\n").unwrap();
+
+        let lf_file = root.join_component("lockfile.lock");
+        std::fs::write(lf_file.as_std_path(), b"dep=1.0\n").unwrap();
+
+        // Initialize a git repo to get the expected normalized hashes
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(root.as_std_path())
+            .output()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["config", "--local", "core.autocrlf", "false"])
+            .current_dir(root.as_std_path())
+            .output()
+            .unwrap();
+
+        // git hash-object --path applies .gitattributes filters (normalizes CRLF)
+        for name in &["global-dep.env", "lockfile.lock"] {
+            let git_output = Command::new("git")
+                .args(["hash-object", "--path", name, "--stdin"])
+                .stdin(std::process::Stdio::from(
+                    std::fs::File::open(root.as_std_path().join(name)).unwrap(),
+                ))
+                .current_dir(root.as_std_path())
+                .output()
+                .unwrap();
+            assert!(git_output.status.success());
+            let expected = String::from_utf8(git_output.stdout).unwrap();
+            let expected = expected.trim();
+
+            let files = [AnchoredSystemPathBuf::from_raw(name).unwrap()];
+            let hashes = crate::manual::hash_files(&root, files.iter(), false, None, None).unwrap();
+            let key = RelativeUnixPathBuf::new(*name).unwrap();
+            let actual = hashes.get(&key).expect("file should be in hashes");
+
+            assert_eq!(
+                &**actual, expected,
+                "hash_files for {name} must match git hash-object --path (with filters)"
+            );
+        }
+    }
+
+    /// Verify CRLF normalization works correctly when core.autocrlf=true,
+    /// which is the default Windows configuration. Git normalizes CRLF→LF
+    /// in blobs when autocrlf is enabled, even without .gitattributes. Our
+    /// normalization relies on .gitattributes, so this test validates the
+    /// combined scenario (autocrlf=true + text=auto).
+    #[test]
+    fn test_crlf_hash_with_autocrlf_true() {
+        let (_repo_root_tmp, repo_root) = tmp_dir();
+        let pkg_dir = repo_root.join_component("my-pkg");
+        pkg_dir.create_dir_all().unwrap();
+
+        std::fs::write(
+            repo_root.as_std_path().join(".gitattributes"),
+            "* text=auto\n",
+        )
+        .unwrap();
+
+        std::fs::write(
+            pkg_dir.as_std_path().join("readme.md"),
+            b"Hello\r\nWorld\r\n",
+        )
+        .unwrap();
+        std::fs::write(
+            pkg_dir.as_std_path().join("package.json"),
+            "{\"name\": \"my-pkg\"}\n",
+        )
+        .unwrap();
+
+        setup_repository(&repo_root);
+        // Enable autocrlf — the real Windows scenario
+        require_git_cmd(&repo_root, &["config", "--local", "core.autocrlf", "true"]);
+        commit_all(&repo_root);
+
+        let pkg_path = AnchoredSystemPathBuf::from_raw("my-pkg").unwrap();
+
+        // Hash via git path (with autocrlf=true)
+        let git = SCM::new(&repo_root);
+        let git_hashes = git
+            .get_package_file_hashes::<&str>(&repo_root, &pkg_path, &[], false, None, None)
+            .unwrap();
+
+        // Hash via manual path
+        let (_prune_tmp, prune_root) = tmp_dir();
+        let prune_pkg = prune_root.join_component("my-pkg");
+        prune_pkg.create_dir_all().unwrap();
+        std::fs::copy(
+            repo_root.as_std_path().join(".gitattributes"),
+            prune_root.as_std_path().join(".gitattributes"),
+        )
+        .unwrap();
+        std::fs::copy(
+            pkg_dir.as_std_path().join("package.json"),
+            prune_pkg.as_std_path().join("package.json"),
+        )
+        .unwrap();
+        std::fs::copy(
+            pkg_dir.as_std_path().join("readme.md"),
+            prune_pkg.as_std_path().join("readme.md"),
+        )
+        .unwrap();
+
+        let manual_hashes = get_package_file_hashes_without_git::<&str>(
+            &prune_root,
+            &pkg_path,
+            &[],
+            false,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let key = RelativeUnixPathBuf::new("readme.md").unwrap();
+        let git_hash = git_hashes.get(&key).expect("readme.md in git");
+        let manual_hash = manual_hashes.get(&key).expect("readme.md in manual");
+
+        assert_eq!(
+            git_hash, manual_hash,
+            "hashes must match with core.autocrlf=true + text=auto. git={git_hash}, \
+             manual={manual_hash}"
+        );
     }
 }

--- a/crates/turborepo-task-hash/src/global_hash.rs
+++ b/crates/turborepo-task-hash/src/global_hash.rs
@@ -160,6 +160,14 @@ pub fn collect_global_file_hash_inputs<'a, L: ?Sized + Lockfile>(
         }
     }
 
+    // .gitattributes drives CRLF→LF normalization which affects file hashes.
+    // Including it in the global hash ensures cache invalidation when
+    // normalization rules change.
+    let gitattributes_path = root_path.join_component(".gitattributes");
+    if gitattributes_path.exists() {
+        global_deps.insert(gitattributes_path);
+    }
+
     let global_deps_paths = global_deps
         .iter()
         .map(|p| root_path.anchor(p).expect("path should be from root"))

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -232,6 +232,13 @@ Creates a "content identifier" for a specific task depending on current state of
 - **Explicit Inputs**: When tasks use custom `inputs`, glob matches still walk the
   filesystem, but clean tracked matches reuse blob OIDs from the repo index
   instead of re-hashing file contents
+- **CRLF Normalization**: When `.gitattributes` marks files as `text` or
+  `text=auto`, git normalizes CRLF line endings to LF in blob objects. The
+  `crlf` module in `turborepo-scm` replicates this so turbo's file hashes
+  match git's regardless of the code path (git or manual/no-git after
+  `turbo prune`). `.gitattributes` is included in the global hash inputs
+  and preserved by `turbo prune`. Known limitations: only root-level
+  `.gitattributes` is loaded; `eol=` is not handled.
 
 #### `globalConfiguration` and `global.inputs`
 


### PR DESCRIPTION
## Summary

When `.gitattributes` marks files as `text` or `text=auto`, git normalizes CRLF→LF in blob objects. After `turbo prune` removes `.git/`, the manual hashing path was hashing raw bytes (with CRLF), producing different hashes than the git path. This caused cache misses when running `turbo run` in pruned output.

This PR adds a `crlf` module to `turborepo-scm` that replicates git's CRLF→LF normalization so turbo's file hashes match git's regardless of whether the git or manual (no-git) code path is used.

## What changed

- **New `crlf` module** (`crates/turborepo-scm/src/crlf.rs`): Parses `.gitattributes` via `gix-attributes`, resolves `text`/`text=auto`/`-text`/`binary` attributes per-file, and normalizes CRLF→LF during hashing. Uses a `BlobHasher` trait to write the normalization algorithm once across both the gix and sha1 hasher implementations. Single-pass for the common case (no CRLFs), two-pass only when normalization is actually needed.
- **`turbo prune` preserves `.gitattributes`**: Added to `ADDITIONAL_FILES` so the manual hashing path in pruned output has the same normalization context.
- **`.gitattributes` in global hash**: Changing normalization rules now invalidates all caches.
- **Consolidated duplicate code**: Removed parallel `hash_file` (hash_object.rs) and `git_like_hash_file` (manual.rs) implementations. Both paths now route through the unified `BlobHasher` abstraction in `crlf.rs`, eliminating duplicate blob-header construction and file-type validation. Extracted `resolve_or_load` helper to replace 3x copy-pasted attrs-resolution boilerplate.
- **CI comments updated**: Clarified that CRLF normalization is driven by `.gitattributes`, not `core.autocrlf`.

## Known limitations

- Only root `.gitattributes` is loaded (nested per-directory files are not consulted)
- `eol=` attribute is not handled
- `core.autocrlf` from git config is not read; normalization is exclusively `.gitattributes`-driven

## Testing

The test suite covers:
- Ground-truth validation against `git hash-object --path` (with filters)
- Cross-implementation agreement between gix and sha1 hashers
- Chunk-boundary edge cases (CRLF split across 64KB buffer boundary)
- Binary detection (NUL in first 8KB)
- Simulated `turbo prune` → manual hash → verify hashes match git path
- Dirty file re-hashing matches committed blob OID
- `core.autocrlf=true` combined with `text=auto`
- Package-scoped `.gitattributes` patterns

Fixes #9616
Fixes #5081