### PR TITLE
fix: Suppress telemetry alert when running on Vercel

### DIFF
--- a/crates/turborepo-telemetry/src/config.rs
+++ b/crates/turborepo-telemetry/src/config.rs
@@ -135,7 +135,11 @@ impl TelemetryConfig {
     }
 
     pub fn show_alert(&mut self, color_config: ColorConfig) {
-        if !self.has_seen_alert() && self.is_enabled() && Self::is_telemetry_warning_enabled() {
+        if !self.has_seen_alert()
+            && self.is_enabled()
+            && Self::is_telemetry_warning_enabled()
+            && turborepo_ci::Vendor::get_constant() != Some("VERCEL")
+        {
             eprintln!(
                 "\n{}\n{}\n{}\n{}\n{}\n",
                 color!(color_config, BOLD, "{}", "Attention:"),

--- a/packages/turbo-telemetry/src/config.ts
+++ b/packages/turbo-telemetry/src/config.ts
@@ -154,7 +154,8 @@ export class TelemetryConfig {
     if (
       !this.hasSeenAlert() &&
       this.isEnabled() &&
-      this.isTelemetryWarningEnabled()
+      this.isTelemetryWarningEnabled() &&
+      !process.env.VERCEL
     ) {
       logger.log();
       logger.bold("Attention:");


### PR DESCRIPTION
## Summary

- Suppresses the "Attention: Turborepo now collects completely anonymous telemetry" message when running on Vercel, where it's unnecessary noise in build logs.
- Updated both Rust (`turborepo-telemetry`) and TypeScript (`turbo-telemetry`) implementations to check for the Vercel environment before showing the alert.