### PR TITLE
docs: Add Bun equivalent for updating dependencies

### DIFF
--- a/apps/docs/content/docs/crafting-your-repository/managing-dependencies.mdx
+++ b/apps/docs/content/docs/crafting-your-repository/managing-dependencies.mdx
@@ -216,9 +216,12 @@ npm install typescript@latest --workspaces
 </Tab>
 
 <Tab value="bun">
-No equivalent
 
-<small>[-> Bun documentation](https://bun.sh/docs/install/workspaces)</small>
+```bash title="Terminal"
+bun update typescript --latest
+```
+
+<small>[-> Bun documentation](https://bun.sh/docs/cli/update)</small>
 
 </Tab>
 </PackageManagerTabs>


### PR DESCRIPTION
## Summary

- Replaces "No equivalent" in the Bun tab of the "Keeping dependencies on the same version" section with `bun update typescript --latest`
- Updates the documentation link to point to the correct Bun CLI update page

Closes #12579