### PR TITLE
fix: Align Markdown docs routing with docs/md endpoints

### DIFF
--- a/apps/docs/app/[lang]/docs/md/[[...slug]]/route.ts
+++ b/apps/docs/app/[lang]/docs/md/[[...slug]]/route.ts
@@ -5,7 +5,7 @@ export const revalidate = false;
 
 export async function GET(
   _req: Request,
-  { params }: RouteContext<"/[lang]/llms.md/[[...slug]]">
+  { params }: RouteContext<"/[lang]/docs/md/[[...slug]]">
 ) {
   const { slug, lang } = await params;
   const page = source.getPage(slug, lang);
@@ -16,7 +16,7 @@ export async function GET(
 
   return new Response(await getLLMText(page), {
     headers: {
-      "Content-Type": "text/markdown",
+      "Content-Type": "text/markdown; charset=utf-8",
       Vary: "Accept"
     }
   });
@@ -24,7 +24,7 @@ export async function GET(
 
 export const generateStaticParams = async ({
   params
-}: RouteContext<"/[lang]/llms.md/[[...slug]]">) => {
+}: RouteContext<"/[lang]/docs/md/[[...slug]]">) => {
   const { lang } = await params;
 
   return source.generateParams(lang);

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -14,16 +14,6 @@ const config: NextConfig = {
     ignoreBuildErrors: true
   },
 
-  // biome-ignore lint/suspicious/useAwait: rewrite is async
-  async rewrites() {
-    return [
-      {
-        source: "/docs/:path*.md",
-        destination: "/en/llms.md/:path*"
-      }
-    ];
-  },
-
   // biome-ignore lint/suspicious/useAwait: redirect is async
   async redirects() {
     return [

--- a/apps/docs/proxy.ts
+++ b/apps/docs/proxy.ts
@@ -1,6 +1,5 @@
-import { generateNotFoundMarkdown, isAIAgent } from "@vercel/agent-readability";
+import { acceptsMarkdown, isAIAgent } from "@vercel/agent-readability";
 import { createI18nMiddleware } from "fumadocs-core/i18n/middleware";
-import { isMarkdownPreferred, rewritePath } from "fumadocs-core/negotiation";
 import {
   type NextFetchEvent,
   type NextRequest,
@@ -9,12 +8,35 @@ import {
 import { i18n } from "@/lib/geistdocs/i18n";
 import { trackMdRequest } from "@/lib/md-tracking";
 
-const { rewrite: rewriteLLM } = rewritePath(
-  "/docs{/*path}",
-  "/en/llms.md{/*path}"
-);
-
 const internationalizer = createI18nMiddleware(i18n);
+
+function getTrackedDocsPath(pathname: string): string | null {
+  if (pathname === "/docs" || pathname === "/docs.md") {
+    return "/docs/index";
+  }
+
+  if (!pathname.startsWith("/docs/")) {
+    return null;
+  }
+
+  const docPath = pathname.replace("/docs/", "").replace(/\.md$/, "") || "index";
+
+  return `/docs/${docPath}`;
+}
+
+function getMarkdownRewritePath(pathname: string): string | null {
+  if (pathname === "/docs" || pathname === "/docs.md") {
+    return "/en/docs/md";
+  }
+
+  if (!pathname.startsWith("/docs/")) {
+    return null;
+  }
+
+  const docPath = pathname.replace("/docs/", "").replace(/\.md$/, "");
+
+  return docPath ? `/en/docs/md/${docPath}` : "/en/docs/md";
+}
 
 function trackMd(
   request: NextRequest,
@@ -38,41 +60,57 @@ const proxy = (request: NextRequest, context: NextFetchEvent) => {
 
   // Handle .md extension in URL path (e.g., /docs/getting-started.md or /docs.md)
   if (pathname === "/docs.md") {
-    trackMd(request, context, "/llms.md");
-    return NextResponse.rewrite(new URL("/en/llms.md", request.nextUrl));
+    const trackingPath = getTrackedDocsPath(pathname);
+    const rewritePath = getMarkdownRewritePath(pathname);
+
+    if (trackingPath && rewritePath) {
+      trackMd(request, context, trackingPath);
+      return NextResponse.rewrite(new URL(rewritePath, request.nextUrl));
+    }
   }
+
   if (pathname.startsWith("/docs/") && pathname.endsWith(".md")) {
-    const pathWithoutMd = pathname.slice(0, -3);
-    const docPath = pathWithoutMd.replace(/^\/docs\//, "");
-    trackMd(request, context, `/llms.md/${docPath}`);
-    return NextResponse.rewrite(
-      new URL(`/en/llms.md/${docPath}`, request.nextUrl)
-    );
+    const trackingPath = getTrackedDocsPath(pathname);
+    const rewritePath = getMarkdownRewritePath(pathname);
+
+    if (trackingPath && rewritePath) {
+      trackMd(request, context, trackingPath);
+      return NextResponse.rewrite(new URL(rewritePath, request.nextUrl));
+    }
   }
 
   // Handle Markdown preference via Accept header
-  if (isMarkdownPreferred(request)) {
-    const result = rewriteLLM(pathname);
-    if (result) {
-      const trackingPath = result.replace(/^\/[a-z]{2}\//, "/");
+  if (
+    acceptsMarkdown(request) &&
+    (pathname === "/docs" || pathname.startsWith("/docs/")) &&
+    pathname !== "/docs/md" &&
+    !pathname.startsWith("/docs/md/")
+  ) {
+    const trackingPath = getTrackedDocsPath(pathname);
+    const rewritePath = getMarkdownRewritePath(pathname);
+
+    if (trackingPath && rewritePath) {
       trackMd(request, context, trackingPath, "header-negotiated");
-      return NextResponse.rewrite(new URL(result, request.nextUrl));
+      return NextResponse.rewrite(new URL(rewritePath, request.nextUrl));
     }
   }
 
   // Handle AI agent detection — serve markdown automatically
-  if (pathname === "/docs" || pathname.startsWith("/docs/")) {
+  if (
+    (pathname === "/docs" || pathname.startsWith("/docs/")) &&
+    pathname !== "/docs/md" &&
+    !pathname.startsWith("/docs/md/")
+  ) {
     const { detected } = isAIAgent(request);
+
     if (detected) {
-      const result = rewriteLLM(pathname);
-      if (result) {
-        const trackingPath = result.replace(/^\/[a-z]{2}\//, "/");
+      const trackingPath = getTrackedDocsPath(pathname);
+      const rewritePath = getMarkdownRewritePath(pathname);
+
+      if (trackingPath && rewritePath) {
         trackMd(request, context, trackingPath, "agent-rewrite");
-        return NextResponse.rewrite(new URL(result, request.nextUrl));
+        return NextResponse.rewrite(new URL(rewritePath, request.nextUrl));
       }
-      return new NextResponse(generateNotFoundMarkdown(pathname), {
-        headers: { "Content-Type": "text/markdown; charset=utf-8" },
-      });
     }
   }
 


### PR DESCRIPTION
## Summary
- replace the internal `llms.md` docs markdown route with the same `docs/md` namespace used in the current geistdocs and front implementations
- keep the public markdown behavior the same by rewriting `.md`, `Accept: text/markdown`, and AI-agent docs requests to the new internal route
- remove the old `next.config` rewrite and track markdown requests against `/docs/...` paths instead of `/llms.md/...`

## Testing
- `pnpm check-types` in `apps/docs` *(fails due to existing issues: missing `content/examples-data.json`, implicit `any` parameters in `components/geistdocs/examples-table.tsx`, and unresolved `@vercel/agent-readability` module types in `proxy.ts`)*