### PR TITLE
test: Add stdin EOF startup regression coverage

### DIFF
--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -1686,7 +1686,7 @@ mod test {
             .expect("child should exit after stdin is closed");
         assert_matches!(exit, Some(ChildExit::Finished(Some(0))));
 
-        let output = String::from_utf8(output).unwrap();
+        let output = String::from_utf8(output).unwrap().replace("\r\n", "\n");
         assert_eq!(output, "stdin bytes=0\nstarted\n");
     }
 
@@ -1709,7 +1709,7 @@ mod test {
         .expect("failed to wait for child output");
         assert_matches!(exit, Some(ChildExit::Finished(Some(0))));
 
-        let output = String::from_utf8(output).unwrap();
+        let output = String::from_utf8(output).unwrap().replace("\r\n", "\n");
         assert_eq!(output, "stdin bytes=0\nstarted\n");
     }
 

--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -1642,6 +1642,77 @@ mod test {
         assert_matches!(exit, Some(ChildExit::Finished(Some(0))));
     }
 
+    /// Regression test for #7834: proves that a child process can block
+    /// before producing any output if stdin is an open pipe instead of EOF.
+    ///
+    /// This models the v1.13 regression on Windows stream mode:
+    /// `tsx watch` received an open piped stdin and never started executing.
+    #[tokio::test]
+    async fn test_std_open_stdin_blocks_startup_until_eof() {
+        let script = find_script_dir().join_component("startup_after_stdin_eof.js");
+        let mut cmd = Command::new("node");
+        cmd.args([script.as_std_path()]);
+        cmd.open_stdin();
+        let mut child = Child::spawn(cmd, ShutdownStyle::Kill, None).unwrap();
+
+        tokio::time::sleep(STARTUP_DELAY).await;
+
+        let ChildOutput::Std { mut stdout, .. } = child.outputs().unwrap() else {
+            panic!("expected stdio child");
+        };
+
+        let mut output = Vec::new();
+        let result =
+            tokio::time::timeout(Duration::from_secs(1), stdout.read_to_end(&mut output)).await;
+        assert!(
+            result.is_err(),
+            "child should stay blocked while stdin is held open"
+        );
+        assert!(
+            output.is_empty(),
+            "child should not produce output before stdin reaches EOF"
+        );
+
+        // Closing the parent's stdin pipe should unblock the child immediately.
+        drop(child.stdin_inner());
+
+        tokio::time::timeout(Duration::from_secs(5), stdout.read_to_end(&mut output))
+            .await
+            .expect("child should finish reading after stdin is closed")
+            .expect("failed to read child output");
+
+        let exit = tokio::time::timeout(Duration::from_secs(5), child.wait())
+            .await
+            .expect("child should exit after stdin is closed");
+        assert_matches!(exit, Some(ChildExit::Finished(Some(0))));
+
+        let output = String::from_utf8(output).unwrap();
+        assert_eq!(output, "stdin bytes=0\nstarted\n");
+    }
+
+    /// Regression test for #7834: verifies the pre-v1.13 behavior where tasks
+    /// that do not need input start immediately when stdin is already at EOF.
+    #[tokio::test]
+    async fn test_std_null_stdin_allows_startup() {
+        let script = find_script_dir().join_component("startup_after_stdin_eof.js");
+        let mut cmd = Command::new("node");
+        cmd.args([script.as_std_path()]);
+        let mut child = Child::spawn(cmd, ShutdownStyle::Kill, None).unwrap();
+
+        let mut output = Vec::new();
+        let exit = tokio::time::timeout(
+            Duration::from_secs(5),
+            child.wait_with_piped_outputs(&mut output),
+        )
+        .await
+        .expect("child should not block when stdin is null")
+        .expect("failed to wait for child output");
+        assert_matches!(exit, Some(ChildExit::Finished(Some(0))));
+
+        let output = String::from_utf8(output).unwrap();
+        assert_eq!(output, "stdin bytes=0\nstarted\n");
+    }
+
     #[test_case(false)]
     #[test_case(TEST_PTY)]
     #[tokio::test]

--- a/crates/turborepo-process/test/scripts/startup_after_stdin_eof.js
+++ b/crates/turborepo-process/test/scripts/startup_after_stdin_eof.js
@@ -2,8 +2,16 @@
 // With stdin connected to NUL/null it gets EOF immediately and continues.
 // With an open pipe held by the parent it hangs before producing any output.
 
-const fs = require("node:fs");
+const chunks = [];
 
-const input = fs.readFileSync(0);
-process.stdout.write(`stdin bytes=${input.length}\n`);
-process.stdout.write("started\n");
+process.stdin.on("data", (chunk) => {
+  chunks.push(chunk);
+});
+
+process.stdin.on("end", () => {
+  const input = Buffer.concat(chunks);
+  process.stdout.write(`stdin bytes=${input.length}\n`);
+  process.stdout.write("started\n");
+});
+
+process.stdin.resume();

--- a/crates/turborepo-process/test/scripts/startup_after_stdin_eof.js
+++ b/crates/turborepo-process/test/scripts/startup_after_stdin_eof.js
@@ -1,0 +1,9 @@
+// Simulates a tool that blocks on stdin before doing any startup work.
+// With stdin connected to NUL/null it gets EOF immediately and continues.
+// With an open pipe held by the parent it hangs before producing any output.
+
+const fs = require("node:fs");
+
+const input = fs.readFileSync(0);
+process.stdout.write(`stdin bytes=${input.length}\n`);
+process.stdout.write("started\n");

--- a/crates/turborepo/tests/stdin_eof_startup_test.rs
+++ b/crates/turborepo/tests/stdin_eof_startup_test.rs
@@ -1,0 +1,112 @@
+mod common;
+
+use std::{
+    io::Read,
+    path::Path,
+    process::{Child, Command, Output, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+use common::{combined_output, setup};
+
+fn setup_stdin_eof_fixture() -> tempfile::TempDir {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(tempdir.path(), "stdin_eof_startup", "npm@10.5.0", false)
+        .unwrap();
+    tempdir
+}
+
+fn spawn_turbo_run_dev(test_dir: &Path, config_dir: &Path) -> Child {
+    let turbo_bin = assert_cmd::cargo::cargo_bin("turbo");
+    let mut cmd = Command::new(turbo_bin);
+    cmd.arg("run")
+        .arg("dev")
+        .env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
+        .env("TURBO_GLOBAL_WARNING_DISABLED", "1")
+        .env("TURBO_PRINT_VERSION_DISABLED", "1")
+        .env("TURBO_CONFIG_DIR_PATH", config_dir)
+        .env("DO_NOT_TRACK", "1")
+        .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
+        .env("COREPACK_ENABLE_DOWNLOAD_PROMPT", "0")
+        .env_remove("CI")
+        .env_remove("GITHUB_ACTIONS")
+        .current_dir(test_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    cmd.spawn().expect("failed to spawn turbo")
+}
+
+fn read_child_output(child: &mut Child) -> (Vec<u8>, Vec<u8>) {
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+
+    if let Some(mut reader) = child.stdout.take() {
+        reader
+            .read_to_end(&mut stdout)
+            .expect("failed to read child stdout");
+    }
+    if let Some(mut reader) = child.stderr.take() {
+        reader
+            .read_to_end(&mut stderr)
+            .expect("failed to read child stderr");
+    }
+
+    (stdout, stderr)
+}
+
+fn wait_with_timeout(mut child: Child, timeout: Duration) -> Output {
+    let start = Instant::now();
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if start.elapsed() > timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    let (stdout, stderr) = read_child_output(&mut child);
+                    panic!(
+                        "turbo timed out after {timeout:?}\nstdout:\n{}\nstderr:\n{}",
+                        String::from_utf8_lossy(&stdout),
+                        String::from_utf8_lossy(&stderr),
+                    );
+                }
+                thread::sleep(Duration::from_millis(100));
+            }
+            Err(err) => panic!("failed waiting for turbo: {err}"),
+        }
+    };
+
+    let (stdout, stderr) = read_child_output(&mut child);
+    Output {
+        status,
+        stdout,
+        stderr,
+    }
+}
+
+#[test]
+fn nonpersistent_task_sees_eof_on_stdin_in_stream_mode() {
+    let tempdir = setup_stdin_eof_fixture();
+    let config_dir = tempfile::tempdir().unwrap();
+
+    let child = spawn_turbo_run_dev(tempdir.path(), config_dir.path());
+    let output = wait_with_timeout(child, Duration::from_secs(15));
+
+    assert!(
+        output.status.success(),
+        "expected turbo to succeed, got {:?}\n{}",
+        output.status.code(),
+        combined_output(&output)
+    );
+
+    let combined = combined_output(&output);
+    assert!(
+        combined.contains("stdin bytes=0"),
+        "expected task output to show EOF on stdin, got:\n{combined}"
+    );
+    assert!(
+        combined.contains("started"),
+        "expected task output to show startup completed, got:\n{combined}"
+    );
+}

--- a/turborepo-tests/integration/fixtures/stdin_eof_startup/dev.js
+++ b/turborepo-tests/integration/fixtures/stdin_eof_startup/dev.js
@@ -1,0 +1,9 @@
+const fs = require("node:fs");
+
+// This intentionally blocks until stdin reaches EOF. A non-persistent task
+// should see stdin closed immediately by Turbo; an open pipe causes a hang
+// before any startup output is produced.
+const input = fs.readFileSync(0);
+
+console.log(`stdin bytes=${input.length}`);
+console.log("started");

--- a/turborepo-tests/integration/fixtures/stdin_eof_startup/dev.js
+++ b/turborepo-tests/integration/fixtures/stdin_eof_startup/dev.js
@@ -1,9 +1,16 @@
-const fs = require("node:fs");
-
 // This intentionally blocks until stdin reaches EOF. A non-persistent task
 // should see stdin closed immediately by Turbo; an open pipe causes a hang
 // before any startup output is produced.
-const input = fs.readFileSync(0);
+const chunks = [];
 
-console.log(`stdin bytes=${input.length}`);
-console.log("started");
+process.stdin.on("data", (chunk) => {
+  chunks.push(chunk);
+});
+
+process.stdin.on("end", () => {
+  const input = Buffer.concat(chunks);
+  console.log(`stdin bytes=${input.length}`);
+  console.log("started");
+});
+
+process.stdin.resume();

--- a/turborepo-tests/integration/fixtures/stdin_eof_startup/package.json
+++ b/turborepo-tests/integration/fixtures/stdin_eof_startup/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "stdin-eof-startup",
+  "private": true,
+  "scripts": {
+    "dev": "node dev.js"
+  }
+}

--- a/turborepo-tests/integration/fixtures/stdin_eof_startup/turbo.json
+++ b/turborepo-tests/integration/fixtures/stdin_eof_startup/turbo.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://turborepo.dev/schema.json",
+  "tasks": {
+    "dev": {
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add a `turbo run dev` integration test that proves non-persistent stream-mode tasks receive EOF on stdin and complete startup
- Add lower-level `turborepo-process` tests plus a shared fixture script that distinguish an open stdin pipe from immediate EOF
- Guard against regressions in the startup-hang behavior behind #7834 without depending on `tsx` or `googleapis`