### PR TITLE
fix: Ignore `SIGINT` in shim after spawning local `turbo`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8232,6 +8232,7 @@ dependencies = [
  "crossterm 0.27.0",
  "dunce",
  "itertools 0.14.0",
+ "libc",
  "miette",
  "pretty_assertions",
  "semver 1.0.23",

--- a/crates/turborepo-shim/Cargo.toml
+++ b/crates/turborepo-shim/Cargo.toml
@@ -45,6 +45,9 @@ itertools = { workspace = true }
 const_format = "0.2.32"
 tiny-gradient = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [target.'cfg(windows)'.dependencies]
 crossterm = "0.27"
 

--- a/crates/turborepo-shim/src/run.rs
+++ b/crates/turborepo-shim/src/run.rs
@@ -524,6 +524,16 @@ where
         Err(e) => return ShimResult::ShimError(err(e)),
     };
 
+    // The child turbo process shares our process group and will receive
+    // SIGINT directly from the kernel when the user presses Ctrl+C.
+    // Ignore SIGINT in the shim *after* spawning so the child inherits
+    // the default disposition (and can register its own handler), while
+    // the shim stays alive to collect the child's exit status.
+    #[cfg(unix)]
+    unsafe {
+        libc::signal(libc::SIGINT, libc::SIG_IGN);
+    }
+
     let exit_status = match child.wait() {
         Ok(status) => status,
         Err(e) => return ShimResult::ShimError(err(e)),


### PR DESCRIPTION
## Summary

When the shim spawns a locally-installed turbo from `node_modules`, both processes share the same foreground process group. Pressing Ctrl+C sends SIGINT to the entire group — the shim had no signal handler, so it was killed immediately by the default disposition while the local turbo was still running graceful shutdown.

This caused:
- Shell prompt appearing mid-shutdown output
- Garbled/interleaved terminal output
- Orphaned child processes continuing to write to the terminal after the shell prompt

The fix ignores SIGINT in the shim **after** spawning the child process, so:
- The child inherits the default SIGINT disposition and can register its own handler normally
- The shim stays alive to collect the child's exit status via `wait()`
- The shell prompt only appears after the local turbo fully exits

## Testing

From a repo with `turbo` as a devDependency (so the shim spawns local turbo):

1. `turbo dev` (with a persistent task that has a SIGINT handler with a countdown)
2. Press Ctrl+C
3. Verify the countdown completes without the shell prompt appearing mid-output
4. Verify the summary prints cleanly after child output