### PR TITLE
docs: Use local schema path in turbo.json examples in "Add to existing repository"

### DIFF
--- a/apps/docs/content/docs/getting-started/add-to-existing-repository.mdx
+++ b/apps/docs/content/docs/getting-started/add-to-existing-repository.mdx
@@ -107,7 +107,7 @@ We'll be using `build` and `check-types` tasks in this guide but you can replace
   <Tab value="Next.js">
 ```json title="./turbo.json"
 {
-  "$schema": "https://turborepo.dev/schema.json",
+  "$schema": "./node_modules/turbo/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
@@ -140,7 +140,7 @@ In your Next.js application, make sure you have a `check-types` script for `turb
   <Tab value="Vite">
 ```json title="./turbo.json"
 {
-  "$schema": "https://turborepo.dev/schema.json",
+  "$schema": "./node_modules/turbo/schema.json",
   "tasks": {
     "build": {
       "outputs": ["dist/**"]


### PR DESCRIPTION
### Description

Updated the schema path in turbo.json into using the local one from `node_modules`.

Reference: https://turborepo.dev/blog/turbo-2-4#schemajson-in-node_modules

### Testing Instructions

N/A
