### PR TITLE
fix: Preserve graceful shutdown exit code

### DIFF
--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -4,10 +4,10 @@ use tracing::error;
 use turborepo_api_client::SharedHttpClient;
 use turborepo_log::StructuredLogSink;
 use turborepo_query_api::QueryServer;
-use turborepo_signals::{SignalHandler, listeners::get_signal};
+use turborepo_signals::{listeners::get_signal, SignalHandler};
 use turborepo_telemetry::events::command::CommandEventBuilder;
 use turborepo_types::DryRunMode;
-use turborepo_ui::{LogSinks, sender::UISender};
+use turborepo_ui::{sender::UISender, LogSinks};
 
 use crate::{commands::CommandBase, run, run::builder::RunBuilder, tracing::TurboSubscriber};
 
@@ -230,9 +230,9 @@ mod tests {
 
     use futures::stream;
     use tokio::sync::oneshot;
-    use turborepo_signals::{SignalHandler, signals::Signal};
+    use turborepo_signals::{signals::Signal, SignalHandler};
 
-    use super::{RunOutcome, wait_for_run_cleanup_on_signal};
+    use super::{wait_for_run_cleanup_on_signal, RunOutcome};
 
     #[cfg(windows)]
     const DEFAULT_SIGNAL: Signal = Signal::CtrlC;

--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -4,10 +4,10 @@ use tracing::error;
 use turborepo_api_client::SharedHttpClient;
 use turborepo_log::StructuredLogSink;
 use turborepo_query_api::QueryServer;
-use turborepo_signals::{listeners::get_signal, SignalHandler};
+use turborepo_signals::{SignalHandler, listeners::get_signal};
 use turborepo_telemetry::events::command::CommandEventBuilder;
 use turborepo_types::DryRunMode;
-use turborepo_ui::{sender::UISender, LogSinks};
+use turborepo_ui::{LogSinks, sender::UISender};
 
 use crate::{commands::CommandBase, run, run::builder::RunBuilder, tracing::TurboSubscriber};
 
@@ -182,9 +182,7 @@ pub async fn run(
     };
 
     let result = match wait_for_run_cleanup_on_signal(&handler, run_fut).await {
-        RunOutcome::Completed(result) => result,
-        // The run future has already drained shutdown and closed the UI.
-        RunOutcome::Interrupted(_result) => Ok(1),
+        RunOutcome::Completed(result) | RunOutcome::Interrupted(result) => result,
     };
 
     turborepo_log::flush();
@@ -232,9 +230,9 @@ mod tests {
 
     use futures::stream;
     use tokio::sync::oneshot;
-    use turborepo_signals::{signals::Signal, SignalHandler};
+    use turborepo_signals::{SignalHandler, signals::Signal};
 
-    use super::{wait_for_run_cleanup_on_signal, RunOutcome};
+    use super::{RunOutcome, wait_for_run_cleanup_on_signal};
 
     #[cfg(windows)]
     const DEFAULT_SIGNAL: Signal = Signal::CtrlC;

--- a/crates/turborepo/tests/graceful_shutdown_test.rs
+++ b/crates/turborepo/tests/graceful_shutdown_test.rs
@@ -389,6 +389,47 @@ while true; do sleep 0.2 || true; done
     }
 
     #[test]
+    fn run_gracefully_shuts_down_on_first_sigint_without_tty_and_exits_zero() {
+        let (_tempdir, test_dir) = setup_shutdown_example(
+            "graceful.sh",
+            r#"#!/usr/bin/env bash
+set -u
+trap 'printf "graceful cleanup start\n"; sleep 0.5; : > cleanup.done; printf "graceful cleanup done\n"; exit 0' INT
+printf "graceful ready\n"
+: > ready
+while true; do sleep 0.2 || true; done
+"#,
+        );
+
+        let ready_file = test_dir.join("apps/app-a/ready");
+        let cleanup_file = test_dir.join("apps/app-a/cleanup.done");
+
+        let mut child = spawn_noninteractive_turbo(&test_dir);
+        wait_for_path(&ready_file, START_TIMEOUT);
+
+        send_signal(child.child_mut().id() as i32, Signal::SIGINT);
+        let output = child.into_output(EXIT_TIMEOUT);
+        let combined = normalize_output(&format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        ));
+
+        assert!(
+            output.status.success(),
+            "graceful shutdown on SIGINT should exit 0\n{combined}"
+        );
+        assert!(
+            cleanup_file.exists(),
+            "graceful cleanup marker should exist"
+        );
+        assert!(
+            combined.contains("graceful cleanup done"),
+            "expected cleanup completion log after signal\n{combined}"
+        );
+    }
+
+    #[test]
     fn run_force_kills_on_second_sigint_in_tty() {
         let (_tempdir, test_dir) = setup_shutdown_example(
             "stubborn.sh",


### PR DESCRIPTION
## Summary
- Stop `turbo run dev` from reporting a failed command when a persistent task handles `SIGINT` and exits cleanly
- Preserve the real run result after shutdown cleanup so graceful exits stay successful
- Cover the non-interactive graceful shutdown path with a regression test