### PR TITLE
fix: Keep Node wrapper alive during graceful shutdown

### DIFF
--- a/crates/turborepo/tests/graceful_shutdown_test.rs
+++ b/crates/turborepo/tests/graceful_shutdown_test.rs
@@ -516,6 +516,64 @@ while true; do sleep 0.2 || true; done
     }
 
     #[test]
+    fn node_wrapper_forwards_sigterm_to_turbo() {
+        let (_tempdir, test_dir) = setup_shutdown_example(
+            "slow-sigterm.sh",
+            r#"#!/usr/bin/env bash
+set -u
+trap 'printf "wrapper sigterm cleanup start\n"; sleep 2; : > cleanup.done; printf "wrapper sigterm cleanup done\n"; exit 0' INT
+printf "wrapper term ready\n"
+: > ready
+while true; do sleep 0.2 || true; done
+"#,
+        );
+
+        let ready_file = test_dir.join("apps/app-a/ready");
+        let cleanup_file = test_dir.join("apps/app-a/cleanup.done");
+
+        let mut child = spawn_noninteractive_turbo_via_node_wrapper(&test_dir);
+        wait_for_path(&ready_file, START_TIMEOUT);
+
+        let wrapper_pid = child.child_mut().id() as i32;
+        send_signal(wrapper_pid, Signal::SIGTERM);
+        thread::sleep(Duration::from_secs(1));
+
+        let exited_early = child
+            .child_mut()
+            .try_wait()
+            .expect("failed waiting for node wrapper")
+            .is_some();
+
+        if exited_early {
+            let _ = signal::kill(Pid::from_raw(-wrapper_pid), Signal::SIGKILL);
+        }
+
+        let output = child.into_output(EXIT_TIMEOUT);
+        let combined = normalize_output(&format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        ));
+
+        assert!(
+            !exited_early,
+            "node wrapper exited before turbo finished graceful shutdown on SIGTERM\n{combined}"
+        );
+        assert!(
+            output.status.success(),
+            "graceful shutdown via node wrapper should exit 0 on SIGTERM\n{combined}"
+        );
+        assert!(
+            cleanup_file.exists(),
+            "graceful cleanup marker should exist"
+        );
+        assert!(
+            combined.contains("wrapper sigterm cleanup done"),
+            "expected cleanup completion log after signal\n{combined}"
+        );
+    }
+
+    #[test]
     fn run_force_kills_on_second_sigint_in_tty() {
         let (_tempdir, test_dir) = setup_shutdown_example(
             "stubborn.sh",

--- a/crates/turborepo/tests/graceful_shutdown_test.rs
+++ b/crates/turborepo/tests/graceful_shutdown_test.rs
@@ -5,6 +5,7 @@ mod unix {
     use std::{
         fs,
         io::{Read, Write},
+        os::unix::process::CommandExt,
         path::{Path, PathBuf},
         process::{Child, Command, Output, Stdio},
         sync::{Arc, Mutex},
@@ -171,6 +172,10 @@ mod unix {
         assert_cmd::cargo::cargo_bin("turbo")
     }
 
+    fn turbo_node_wrapper() -> PathBuf {
+        common::manifest_dir().join("../../packages/turbo/bin/turbo")
+    }
+
     fn spawn_noninteractive_turbo(test_dir: &Path) -> ChildGuard {
         let mut cmd = Command::new(turbo_bin());
         cmd.arg("run")
@@ -188,6 +193,28 @@ mod unix {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
         ChildGuard::new(cmd.spawn().expect("failed to spawn turbo"))
+    }
+
+    fn spawn_noninteractive_turbo_via_node_wrapper(test_dir: &Path) -> ChildGuard {
+        let mut cmd = Command::new("node");
+        cmd.arg(turbo_node_wrapper())
+            .arg("run")
+            .arg("dev")
+            .arg("--filter=app-a")
+            .env("TURBO_BINARY_PATH", turbo_bin())
+            .env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
+            .env("TURBO_GLOBAL_WARNING_DISABLED", "1")
+            .env("TURBO_PRINT_VERSION_DISABLED", "1")
+            .env("DO_NOT_TRACK", "1")
+            .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
+            .env("COREPACK_ENABLE_DOWNLOAD_PROMPT", "0")
+            .env_remove("CI")
+            .env_remove("GITHUB_ACTIONS")
+            .current_dir(test_dir)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .process_group(0);
+        ChildGuard::new(cmd.spawn().expect("failed to spawn turbo wrapper"))
     }
 
     fn spawn_interactive_turbo(test_dir: &Path) -> PtyTurbo {
@@ -294,6 +321,11 @@ mod unix {
 
     fn send_signal(pid: i32, signal_kind: Signal) {
         signal::kill(Pid::from_raw(pid), signal_kind).expect("failed to send signal");
+    }
+
+    fn send_signal_to_process_group(process_group_id: i32, signal_kind: Signal) {
+        signal::kill(Pid::from_raw(-process_group_id), signal_kind)
+            .expect("failed to send signal to process group");
     }
 
     fn process_exists(pid: i32) -> bool {
@@ -425,6 +457,60 @@ while true; do sleep 0.2 || true; done
         );
         assert!(
             combined.contains("graceful cleanup done"),
+            "expected cleanup completion log after signal\n{combined}"
+        );
+    }
+
+    #[test]
+    fn node_wrapper_waits_for_graceful_shutdown_on_sigint() {
+        let (_tempdir, test_dir) = setup_shutdown_example(
+            "slow-graceful.sh",
+            r#"#!/usr/bin/env bash
+set -u
+trap 'printf "wrapper cleanup start\n"; sleep 2; : > cleanup.done; printf "wrapper cleanup done\n"; exit 0' INT
+printf "wrapper ready\n"
+: > ready
+while true; do sleep 0.2 || true; done
+"#,
+        );
+
+        let ready_file = test_dir.join("apps/app-a/ready");
+        let cleanup_file = test_dir.join("apps/app-a/cleanup.done");
+
+        let mut child = spawn_noninteractive_turbo_via_node_wrapper(&test_dir);
+        wait_for_path(&ready_file, START_TIMEOUT);
+
+        let wrapper_pid = child.child_mut().id() as i32;
+        send_signal_to_process_group(wrapper_pid, Signal::SIGINT);
+        thread::sleep(Duration::from_secs(1));
+
+        let exited_early = child
+            .child_mut()
+            .try_wait()
+            .expect("failed waiting for node wrapper")
+            .is_some();
+
+        let output = child.into_output(EXIT_TIMEOUT);
+        let combined = normalize_output(&format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        ));
+
+        assert!(
+            !exited_early,
+            "node wrapper exited before turbo finished graceful shutdown\n{combined}"
+        );
+        assert!(
+            output.status.success(),
+            "graceful shutdown via node wrapper should exit 0\n{combined}"
+        );
+        assert!(
+            cleanup_file.exists(),
+            "graceful cleanup marker should exist"
+        );
+        assert!(
+            combined.contains("wrapper cleanup done"),
             "expected cleanup completion log after signal\n{combined}"
         );
     }

--- a/packages/turbo/bin/turbo
+++ b/packages/turbo/bin/turbo
@@ -297,14 +297,54 @@ function getBinaryPath() {
   process.exit(1);
 }
 
-// Run the binary we got.
-try {
-  child_process.execFileSync(
+function exitWithCodeOrSignal(code, signal) {
+  if (signal) {
+    try {
+      process.kill(process.pid, signal);
+      return;
+    } catch (e) {
+      process.exit(1);
+    }
+  }
+
+  process.exit(code === null ? 1 : code);
+}
+
+function runTurbo() {
+  const child = child_process.spawn(
     getBinaryPath(),
     process.argv.slice(2),
     { stdio: "inherit" }
   );
-} catch (e) {
-  if (e && e.status) process.exit(e.status);
-  throw e;
+
+  const handleSigint = () => {
+    // The child shares our process group, so Ctrl+C already reached it.
+    // Keep the wrapper alive until the child finishes its own shutdown.
+  };
+
+  const handleSigterm = () => {
+    if (!child.killed) {
+      child.kill("SIGTERM");
+    }
+  };
+
+  const cleanup = () => {
+    process.off("SIGINT", handleSigint);
+    process.off("SIGTERM", handleSigterm);
+  };
+
+  process.on("SIGINT", handleSigint);
+  process.on("SIGTERM", handleSigterm);
+
+  child.once("error", (error) => {
+    cleanup();
+    throw error;
+  });
+
+  child.once("exit", (code, signal) => {
+    cleanup();
+    exitWithCodeOrSignal(code, signal);
+  });
 }
+
+runTurbo();


### PR DESCRIPTION
## Summary
- Packaged and global `turbo` installs go through the Node wrapper, so a `SIGINT` could kill the wrapper before the Rust child finished its graceful shutdown.
- Keep the wrapper process alive until the child exits, while still preserving the child's exit code or signal semantics.
- Add regression coverage for the wrapper path so graceful shutdown behavior is exercised beyond the direct binary entrypoint.

## Testing
- `cargo test -p turbo --test graceful_shutdown_test -- --nocapture`
- Manually reproduced against `/Users/anthonyshew/projects/debugs/graceful-shutdown` with the fixed wrapper path.