### PR TITLE
fix: Preserve legacy Vercel auth compatibility

### DIFF
--- a/crates/turborepo-auth/README.md
+++ b/crates/turborepo-auth/README.md
@@ -15,10 +15,11 @@ turborepo-auth
     │   ├── Vercel device-flow team validation
     │   └── Localhost redirect for self-hosted SSO callback
     └── Token storage
-        └── ~/.turbo/config.json (Turbo tokens and refresh metadata)
+        ├── ~/.turbo/auth.json (Turbo-managed OAuth sessions)
+        └── ~/.turbo/config.json (Legacy/manual tokens and config)
 ```
 
-Older Vercel CLI auth files may still be read for backward compatibility. When possible, Turbo exchanges that legacy token for a Turbo-scoped token and persists the result in `~/.turbo/config.json`.
+Older Vercel CLI auth files may still be read for backward compatibility. When possible, Turbo exchanges that legacy token for a Turbo-scoped token and persists the result in `~/.turbo/auth.json` so older Turbo releases do not try to reuse OAuth access tokens from the legacy config slot.
 
 ## Notes
 

--- a/crates/turborepo-auth/src/auth/logout.rs
+++ b/crates/turborepo-auth/src/auth/logout.rs
@@ -5,8 +5,8 @@ use turborepo_dirs::{config_dir, vercel_config_dir};
 use turborepo_ui::{GREY, cprintln};
 
 use crate::{
-    AuthTokens, Error, LogoutOptions, TURBO_TOKEN_DIR, TURBO_TOKEN_FILE, Token, VERCEL_TOKEN_DIR,
-    VERCEL_TOKEN_FILE,
+    AuthTokens, Error, LogoutOptions, TURBO_AUTH_FILE, TURBO_TOKEN_DIR, TURBO_TOKEN_FILE, Token,
+    VERCEL_TOKEN_DIR, VERCEL_TOKEN_FILE,
 };
 
 pub async fn logout<T: TokenClient>(options: &LogoutOptions<T>) -> Result<(), Error> {
@@ -64,32 +64,56 @@ impl<T: TokenClient> LogoutOptions<T> {
             return self.try_remove_token(path, self.invalidate).await;
         }
 
-        let turbo_path =
+        let turbo_auth_path =
+            config_dir()?.map(|dir| dir.join_components(&[TURBO_TOKEN_DIR, TURBO_AUTH_FILE]));
+        let turbo_config_path =
             config_dir()?.map(|dir| dir.join_components(&[TURBO_TOKEN_DIR, TURBO_TOKEN_FILE]));
         let legacy_path = vercel_config_dir()?
             .map(|dir| dir.join_components(&[VERCEL_TOKEN_DIR, VERCEL_TOKEN_FILE]));
-        let skip_legacy_invalidate = if self.invalidate {
-            match (
-                turbo_path
-                    .as_ref()
-                    .map(|path| Self::token_at_path(path))
-                    .transpose()?,
-                legacy_path
-                    .as_ref()
-                    .map(|path| Self::token_at_path(path))
-                    .transpose()?,
-            ) {
-                (Some(Some(turbo_token)), Some(Some(legacy_token))) => {
-                    turbo_token.expose() == legacy_token.expose()
-                }
-                _ => false,
-            }
+        let (skip_config_invalidate, skip_legacy_invalidate) = if self.invalidate {
+            let turbo_auth_token = turbo_auth_path
+                .as_ref()
+                .map(|path| Self::token_at_path(path))
+                .transpose()?
+                .flatten();
+            let turbo_config_token = turbo_config_path
+                .as_ref()
+                .map(|path| Self::token_at_path(path))
+                .transpose()?
+                .flatten();
+            let legacy_token = legacy_path
+                .as_ref()
+                .map(|path| Self::token_at_path(path))
+                .transpose()?
+                .flatten();
+
+            let skip_config_invalidate = matches!(
+                (turbo_auth_token.as_ref(), turbo_config_token.as_ref()),
+                (Some(auth_token), Some(config_token)) if auth_token.expose() == config_token.expose()
+            );
+            let skip_legacy_invalidate = matches!(
+                (
+                    turbo_auth_token.as_ref().or(turbo_config_token.as_ref()),
+                    legacy_token.as_ref(),
+                ),
+                (Some(turbo_token), Some(legacy_token)) if turbo_token.expose() == legacy_token.expose()
+            );
+
+            (skip_config_invalidate, skip_legacy_invalidate)
         } else {
-            false
+            (false, false)
         };
 
-        if let Some(turbo_path) = turbo_path.as_ref() {
-            self.try_remove_token(turbo_path, self.invalidate).await?;
+        if let Some(turbo_auth_path) = turbo_auth_path.as_ref() {
+            self.try_remove_token(turbo_auth_path, self.invalidate)
+                .await?;
+        }
+        if let Some(turbo_config_path) = turbo_config_path.as_ref() {
+            self.try_remove_token(
+                turbo_config_path,
+                self.invalidate && !skip_config_invalidate,
+            )
+            .await?;
         }
         if let Some(legacy_path) = legacy_path.as_ref() {
             self.try_remove_token(legacy_path, self.invalidate && !skip_legacy_invalidate)

--- a/crates/turborepo-auth/src/auth/mod.rs
+++ b/crates/turborepo-auth/src/auth/mod.rs
@@ -61,13 +61,13 @@ pub struct LogoutOptions<T> {
     pub path: Option<AbsoluteSystemPathBuf>,
 }
 
-// Tokens and refresh metadata now live in turborepo/config.json. For existing
-// sessions, we can still read matching refresh metadata from the legacy Vercel
-// CLI auth file without rewriting it.
-fn load_auth_tokens(turbo_config_path: &AbsoluteSystemPath) -> Result<crate::AuthTokens, Error> {
-    use crate::Token;
-
-    let turbo_auth_tokens = Token::from_auth_file(turbo_config_path)?;
+// Device-flow sessions live in Turbo's auth.json. We still fall back to the
+// legacy config.json slot for non-OAuth tokens and older persisted sessions.
+fn load_auth_tokens(
+    turbo_auth_path: &AbsoluteSystemPath,
+    turbo_config_path: &AbsoluteSystemPath,
+) -> Result<crate::AuthTokens, Error> {
+    let turbo_auth_tokens = load_turbo_auth_tokens_from_paths(turbo_auth_path, turbo_config_path)?;
     let Some(turbo_token) = turbo_auth_tokens.token.as_ref() else {
         return Ok(turbo_auth_tokens);
     };
@@ -92,25 +92,60 @@ fn load_auth_tokens(turbo_config_path: &AbsoluteSystemPath) -> Result<crate::Aut
     })
 }
 
-fn load_turbo_auth_tokens() -> Result<crate::AuthTokens, Error> {
-    use crate::{TURBO_TOKEN_DIR, TURBO_TOKEN_FILE, Token};
+fn load_tokens_from_path(
+    path: &AbsoluteSystemPath,
+    label: &str,
+) -> Result<Option<crate::AuthTokens>, Error> {
+    use crate::Token;
 
-    let Some(turbo_config_dir) = turborepo_dirs::config_dir()? else {
-        return Ok(crate::AuthTokens::default());
-    };
-    let turbo_auth_path = turbo_config_dir.join_components(&[TURBO_TOKEN_DIR, TURBO_TOKEN_FILE]);
-
-    match Token::from_auth_file(&turbo_auth_path) {
-        Ok(tokens) => Ok(tokens),
+    match Token::from_auth_file(path) {
+        Ok(tokens) if tokens.token.is_some() => Ok(Some(tokens)),
+        Ok(_) | Err(Error::TokenNotFound) => Ok(None),
         Err(Error::InvalidTokenFileFormat { .. }) => {
-            warn!("Ignoring malformed Turbo auth file at {turbo_auth_path}");
-            Ok(crate::AuthTokens::default())
+            warn!("Ignoring malformed {label} at {path}");
+            Ok(None)
         }
         Err(e) => Err(e),
     }
 }
 
+fn load_turbo_auth_tokens_from_paths(
+    turbo_auth_path: &AbsoluteSystemPath,
+    turbo_config_path: &AbsoluteSystemPath,
+) -> Result<crate::AuthTokens, Error> {
+    if let Some(tokens) = load_tokens_from_path(turbo_auth_path, "Turbo auth file")? {
+        return Ok(tokens);
+    }
+
+    Ok(load_tokens_from_path(turbo_config_path, "Turbo config file")?.unwrap_or_default())
+}
+
+fn load_turbo_auth_tokens() -> Result<crate::AuthTokens, Error> {
+    use crate::{TURBO_AUTH_FILE, TURBO_TOKEN_DIR, TURBO_TOKEN_FILE};
+
+    let Some(turbo_config_dir) = turborepo_dirs::config_dir()? else {
+        return Ok(crate::AuthTokens::default());
+    };
+    let turbo_auth_path = turbo_config_dir.join_components(&[TURBO_TOKEN_DIR, TURBO_AUTH_FILE]);
+    let turbo_config_path = turbo_config_dir.join_components(&[TURBO_TOKEN_DIR, TURBO_TOKEN_FILE]);
+
+    load_turbo_auth_tokens_from_paths(&turbo_auth_path, &turbo_config_path)
+}
+
 pub(crate) fn classify_existing_vercel_token(token: &str) -> Result<ExistingTokenSource, Error> {
+    if let Some(turbo_config_dir) = turborepo_dirs::config_dir()? {
+        let turbo_auth_path =
+            turbo_config_dir.join_components(&[crate::TURBO_TOKEN_DIR, crate::TURBO_AUTH_FILE]);
+        if let Some(turbo_auth_tokens) = load_tokens_from_path(&turbo_auth_path, "Turbo auth file")?
+            && turbo_auth_tokens
+                .token
+                .as_ref()
+                .is_some_and(|stored_token| stored_token.expose() == token)
+        {
+            return Ok(ExistingTokenSource::TurboConfig);
+        }
+    }
+
     let legacy_auth_tokens = load_legacy_auth_tokens(None)?;
     if legacy_auth_tokens
         .token
@@ -165,6 +200,7 @@ fn load_legacy_auth_tokens(
 }
 
 async fn exchange_legacy_auth_token(
+    turbo_auth_path: &AbsoluteSystemPath,
     turbo_config_path: &AbsoluteSystemPath,
     expected_token: Option<&turborepo_api_client::SecretString>,
 ) -> Result<Option<turborepo_api_client::SecretString>, Error> {
@@ -190,8 +226,13 @@ async fn exchange_legacy_auth_token(
 
     match exchange_source.exchange_legacy_token().await {
         Ok(exchanged_tokens) => {
-            if let Err(e) = exchanged_tokens.write_to_config_file(turbo_config_path) {
-                warn!("Failed to write exchanged tokens to {turbo_config_path}: {e}");
+            if let Err(e) =
+                persist_turbo_oauth_tokens(&exchanged_tokens, turbo_auth_path, turbo_config_path)
+            {
+                warn!(
+                    "Failed to write exchanged tokens to {turbo_auth_path} and clear \
+                     {turbo_config_path}: {e}"
+                );
             }
             Ok(exchanged_tokens.token)
         }
@@ -206,21 +247,33 @@ async fn exchange_legacy_auth_token(
     }
 }
 
+fn persist_turbo_oauth_tokens(
+    auth_tokens: &crate::AuthTokens,
+    turbo_auth_path: &AbsoluteSystemPath,
+    turbo_config_path: &AbsoluteSystemPath,
+) -> Result<(), Error> {
+    auth_tokens.write_to_config_file(turbo_auth_path)?;
+    crate::AuthTokens::clear_from_config_file(turbo_config_path)?;
+    Ok(())
+}
+
 /// Attempts to get a valid token with automatic refresh if expired.
 pub async fn get_token_with_refresh() -> Result<Option<turborepo_api_client::SecretString>, Error> {
-    use crate::{TURBO_TOKEN_DIR, TURBO_TOKEN_FILE};
+    use crate::{TURBO_AUTH_FILE, TURBO_TOKEN_DIR, TURBO_TOKEN_FILE};
 
     let turbo_config_dir = match turborepo_dirs::config_dir()? {
         Some(dir) => dir,
         None => return Ok(None),
     };
 
+    let turbo_auth_path = turbo_config_dir.join_components(&[TURBO_TOKEN_DIR, TURBO_AUTH_FILE]);
     let turbo_config_path = turbo_config_dir.join_components(&[TURBO_TOKEN_DIR, TURBO_TOKEN_FILE]);
-    let auth_tokens = load_auth_tokens(&turbo_config_path)?;
+    let auth_tokens = load_auth_tokens(&turbo_auth_path, &turbo_config_path)?;
 
     if let Some(token) = &auth_tokens.token {
         if classify_existing_vercel_token(token.expose())? == ExistingTokenSource::LegacyAuth {
-            return exchange_legacy_auth_token(&turbo_config_path, Some(token)).await;
+            return exchange_legacy_auth_token(&turbo_auth_path, &turbo_config_path, Some(token))
+                .await;
         }
 
         if auth_tokens.is_expired() {
@@ -229,18 +282,23 @@ pub async fn get_token_with_refresh() -> Result<Option<turborepo_api_client::Sec
                 && auth_tokens.refresh_token.is_some()
                 && let Ok(new_tokens) = auth_tokens.refresh_token().await
             {
-                if let Err(e) = new_tokens.write_to_config_file(&turbo_config_path) {
-                    tracing::warn!("Failed to write refreshed tokens to {turbo_config_path}: {e}");
+                if let Err(e) =
+                    persist_turbo_oauth_tokens(&new_tokens, &turbo_auth_path, &turbo_config_path)
+                {
+                    tracing::warn!(
+                        "Failed to write refreshed tokens to {turbo_auth_path} and clear \
+                         {turbo_config_path}: {e}"
+                    );
                 }
                 return Ok(new_tokens.token);
             }
 
-            exchange_legacy_auth_token(&turbo_config_path, Some(token)).await
+            exchange_legacy_auth_token(&turbo_auth_path, &turbo_config_path, Some(token)).await
         } else {
             Ok(Some(token.clone()))
         }
     } else {
-        exchange_legacy_auth_token(&turbo_config_path, None).await
+        exchange_legacy_auth_token(&turbo_auth_path, &turbo_config_path, None).await
     }
 }
 
@@ -249,10 +307,15 @@ mod tests {
     use std::{env, fs};
 
     use tempfile::tempdir;
+    use tokio::sync::Mutex;
     use turbopath::AbsoluteSystemPathBuf;
 
-    use super::{ExistingTokenSource, classify_existing_vercel_token, is_vercel};
-    use crate::{AuthTokens, Token, current_unix_time_secs};
+    use super::{
+        ExistingTokenSource, classify_existing_vercel_token, get_token_with_refresh, is_vercel,
+    };
+    use crate::{AuthTokens, TURBO_AUTH_FILE, TURBO_TOKEN_DIR, Token, current_unix_time_secs};
+
+    static ENV_LOCK: Mutex<()> = Mutex::const_new(());
 
     // Mock the turborepo_dirs functions for testing
     fn create_mock_vercel_config_dir() -> AbsoluteSystemPathBuf {
@@ -297,8 +360,30 @@ mod tests {
             .expect("Failed to write turbo config");
     }
 
+    fn setup_turbo_auth_file(
+        config_dir: &AbsoluteSystemPathBuf,
+        token: &str,
+        refresh_token: Option<&str>,
+        expires_at: Option<u64>,
+    ) {
+        let turbo_dir = config_dir.join_component(TURBO_TOKEN_DIR);
+        fs::create_dir_all(&turbo_dir).expect("Failed to create turbo dir");
+        let auth_file = turbo_dir.join_component(TURBO_AUTH_FILE);
+
+        let auth_tokens = AuthTokens {
+            token: Some(token.into()),
+            refresh_token: refresh_token.map(|s| s.into()),
+            expires_at,
+        };
+
+        auth_tokens
+            .write_to_config_file(&auth_file)
+            .expect("Failed to write turbo auth file");
+    }
+
     #[test]
     fn test_classify_existing_vercel_token_prefers_turbo_config() {
+        let _lock = ENV_LOCK.blocking_lock();
         let turbo_config_dir = create_mock_turbo_config_dir();
         let vercel_config_dir = create_mock_vercel_config_dir();
 
@@ -322,6 +407,7 @@ mod tests {
 
     #[test]
     fn test_classify_existing_vercel_token_detects_legacy_auth() {
+        let _lock = ENV_LOCK.blocking_lock();
         let turbo_config_dir = create_mock_turbo_config_dir();
         let vercel_config_dir = create_mock_vercel_config_dir();
 
@@ -343,7 +429,32 @@ mod tests {
     }
 
     #[test]
+    fn test_classify_existing_vercel_token_prefers_turbo_auth_file() {
+        let _lock = ENV_LOCK.blocking_lock();
+        let turbo_config_dir = create_mock_turbo_config_dir();
+        let vercel_config_dir = create_mock_vercel_config_dir();
+
+        setup_turbo_auth_file(&turbo_config_dir, "duplicated-token", None, None);
+        setup_auth_file(&vercel_config_dir, "duplicated-token", None, None);
+
+        unsafe {
+            env::set_var("TURBO_CONFIG_DIR_PATH", turbo_config_dir.as_path());
+            env::set_var("VERCEL_CONFIG_DIR_PATH", vercel_config_dir.as_path());
+        }
+
+        let source = classify_existing_vercel_token("duplicated-token").unwrap();
+
+        assert_eq!(source, ExistingTokenSource::TurboConfig);
+
+        unsafe {
+            env::remove_var("TURBO_CONFIG_DIR_PATH");
+            env::remove_var("VERCEL_CONFIG_DIR_PATH");
+        }
+    }
+
+    #[test]
     fn test_classify_existing_vercel_token_prefers_legacy_when_duplicated() {
+        let _lock = ENV_LOCK.blocking_lock();
         let turbo_config_dir = create_mock_turbo_config_dir();
         let vercel_config_dir = create_mock_vercel_config_dir();
 
@@ -367,6 +478,7 @@ mod tests {
 
     #[test]
     fn test_classify_existing_vercel_token_returns_other_for_untracked_token() {
+        let _lock = ENV_LOCK.blocking_lock();
         let turbo_config_dir = create_mock_turbo_config_dir();
         let vercel_config_dir = create_mock_vercel_config_dir();
 
@@ -381,6 +493,65 @@ mod tests {
         let source = classify_existing_vercel_token("explicit-token").unwrap();
 
         assert_eq!(source, ExistingTokenSource::Other);
+
+        unsafe {
+            env::remove_var("TURBO_CONFIG_DIR_PATH");
+            env::remove_var("VERCEL_CONFIG_DIR_PATH");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_token_with_refresh_prefers_turbo_auth_file() {
+        let _lock = ENV_LOCK.lock().await;
+        let vercel_config_dir = create_mock_vercel_config_dir();
+        let turbo_config_dir = create_mock_turbo_config_dir();
+        let current_time = current_unix_time_secs();
+
+        setup_turbo_auth_file(
+            &turbo_config_dir,
+            "vca_turbo_auth_token",
+            Some("refresh_token_123"),
+            Some(current_time + 3600),
+        );
+        setup_turbo_config_file(&turbo_config_dir, "legacy_config_token");
+        setup_auth_file(
+            &vercel_config_dir,
+            "legacy_auth_token",
+            Some("refresh_token_456"),
+            Some(current_time + 3600),
+        );
+
+        unsafe {
+            env::set_var("TURBO_CONFIG_DIR_PATH", turbo_config_dir.as_path());
+            env::set_var("VERCEL_CONFIG_DIR_PATH", vercel_config_dir.as_path());
+        }
+
+        let token = get_token_with_refresh().await.unwrap().unwrap();
+
+        assert_eq!(token.expose(), "vca_turbo_auth_token");
+
+        unsafe {
+            env::remove_var("TURBO_CONFIG_DIR_PATH");
+            env::remove_var("VERCEL_CONFIG_DIR_PATH");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_token_with_refresh_falls_back_to_legacy_config() {
+        let _lock = ENV_LOCK.lock().await;
+        let vercel_config_dir = create_mock_vercel_config_dir();
+        let turbo_config_dir = create_mock_turbo_config_dir();
+
+        setup_turbo_config_file(&turbo_config_dir, "legacy_config_token");
+
+        unsafe {
+            env::set_var("TURBO_CONFIG_DIR_PATH", turbo_config_dir.as_path());
+            env::set_var("VERCEL_CONFIG_DIR_PATH", vercel_config_dir.as_path());
+        }
+
+        let token = get_token_with_refresh().await.unwrap().unwrap();
+
+        assert_eq!(token.expose(), "legacy_config_token");
 
         unsafe {
             env::remove_var("TURBO_CONFIG_DIR_PATH");

--- a/crates/turborepo-auth/src/lib.rs
+++ b/crates/turborepo-auth/src/lib.rs
@@ -28,6 +28,7 @@ pub struct TeamInfo<'a> {
 pub const VERCEL_TOKEN_DIR: &str = "com.vercel.cli";
 pub const VERCEL_TOKEN_FILE: &str = "auth.json";
 pub const TURBO_TOKEN_DIR: &str = "turborepo";
+pub const TURBO_AUTH_FILE: &str = "auth.json";
 pub const TURBO_TOKEN_FILE: &str = "config.json";
 
 const VERCEL_OAUTH_TOKEN_URL: &str = "https://api.vercel.com/login/oauth/token";

--- a/crates/turborepo-config/src/file.rs
+++ b/crates/turborepo-config/src/file.rs
@@ -1,5 +1,7 @@
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
-use turborepo_auth::{TURBO_TOKEN_DIR, TURBO_TOKEN_FILE, VERCEL_TOKEN_DIR, VERCEL_TOKEN_FILE};
+use turborepo_auth::{
+    TURBO_AUTH_FILE, TURBO_TOKEN_DIR, TURBO_TOKEN_FILE, VERCEL_TOKEN_DIR, VERCEL_TOKEN_FILE,
+};
 use turborepo_dirs::{config_dir, vercel_config_dir};
 
 use crate::{ConfigurationOptions, Error, ResolvedConfigurationOptions};
@@ -43,6 +45,7 @@ impl ResolvedConfigurationOptions for ConfigFile {
 
 pub struct AuthFile {
     path: AbsoluteSystemPathBuf,
+    fallback_path: Option<AbsoluteSystemPathBuf>,
     legacy_path: Option<AbsoluteSystemPathBuf>,
 }
 
@@ -51,10 +54,12 @@ impl AuthFile {
         match override_path {
             Some(path) => Ok(Self {
                 path,
+                fallback_path: None,
                 legacy_path: None,
             }),
             None => Ok(Self {
-                path: global_config_path()?,
+                path: global_auth_path()?,
+                fallback_path: Some(global_config_path()?),
                 legacy_path: legacy_auth_path()?,
             }),
         }
@@ -66,25 +71,41 @@ impl ResolvedConfigurationOptions for AuthFile {
         &self,
         _existing_config: &ConfigurationOptions,
     ) -> Result<ConfigurationOptions, Error> {
-        let fallback_legacy_token = || -> Result<Option<turborepo_auth::Token>, Error> {
-            let Some(legacy_path) = self.legacy_path.as_ref() else {
-                return Ok(None);
+        let load_token =
+            |path: &AbsoluteSystemPath| -> Result<Option<turborepo_auth::Token>, Error> {
+                let contents =
+                    path.read_existing_to_string()
+                        .map_err(|error| Error::FailedToReadConfig {
+                            config_path: path.to_owned(),
+                            error,
+                        })?;
+
+                if contents.as_deref().is_none_or(str::is_empty) {
+                    return Ok(None);
+                }
+
+                match turborepo_auth::Token::from_file(path) {
+                    Ok(token) if !token.into_inner().expose().is_empty() => Ok(Some(token)),
+                    Ok(_)
+                    | Err(turborepo_auth::Error::TokenNotFound)
+                    | Err(turborepo_auth::Error::InvalidTokenFileFormat { .. }) => Ok(None),
+                    Err(e) => Err(e.into()),
+                }
             };
 
-            match turborepo_auth::Token::from_file(legacy_path) {
-                Ok(token) if !token.into_inner().expose().is_empty() => Ok(Some(token)),
-                Ok(_)
-                | Err(turborepo_auth::Error::TokenNotFound)
-                | Err(turborepo_auth::Error::InvalidTokenFileFormat { .. }) => Ok(None),
-                Err(e) => Err(e.into()),
-            }
-        };
+        let mut token = load_token(&self.path)?;
 
-        let token = match turborepo_auth::Token::from_file(&self.path) {
-            Ok(token) if !token.into_inner().expose().is_empty() => Some(token),
-            Ok(_) | Err(turborepo_auth::Error::TokenNotFound) => fallback_legacy_token()?,
-            Err(e) => return Err(e.into()),
-        };
+        if token.is_none()
+            && let Some(path) = self.fallback_path.as_ref()
+        {
+            token = load_token(path)?;
+        }
+
+        if token.is_none()
+            && let Some(path) = self.legacy_path.as_ref()
+        {
+            token = load_token(path)?;
+        }
 
         Ok(token.map_or_else(ConfigurationOptions::default, |token| {
             ConfigurationOptions {
@@ -101,25 +122,42 @@ fn global_config_path() -> Result<AbsoluteSystemPathBuf, Error> {
     Ok(config_dir.join_components(&[TURBO_TOKEN_DIR, TURBO_TOKEN_FILE]))
 }
 
+fn global_auth_path() -> Result<AbsoluteSystemPathBuf, Error> {
+    let config_dir = config_dir()?.ok_or(Error::NoGlobalConfigPath)?;
+
+    Ok(config_dir.join_components(&[TURBO_TOKEN_DIR, TURBO_AUTH_FILE]))
+}
+
 fn legacy_auth_path() -> Result<Option<AbsoluteSystemPathBuf>, Error> {
     Ok(vercel_config_dir()?.map(|dir| dir.join_components(&[VERCEL_TOKEN_DIR, VERCEL_TOKEN_FILE])))
 }
 
 #[cfg(test)]
 mod tests {
-    use std::{env, fs};
+    use std::{env, fs, sync::Mutex};
 
     use tempfile::tempdir;
 
     use super::*;
 
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn write_auth_file(path: &AbsoluteSystemPathBuf, token: &str) {
+        path.create_with_contents(&format!(r#"{{"token":"{token}"}}"#))
+            .expect("Failed to write auth file");
+    }
+
     #[test]
-    fn global_auth_prefers_turbo_config_token() {
+    fn global_auth_prefers_turbo_auth_token() {
+        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
         let turbo_dir = tempdir().expect("Failed to create turbo dir");
         let vercel_dir = tempdir().expect("Failed to create vercel dir");
+        let turbo_auth_path = turbo_dir.path().join("turborepo/auth.json");
         let turbo_config_path = turbo_dir.path().join("turborepo/config.json");
         let legacy_auth_path = vercel_dir.path().join("com.vercel.cli/auth.json");
 
+        let turbo_auth_path = AbsoluteSystemPathBuf::try_from(turbo_auth_path.clone())
+            .expect("Failed to create turbo auth path");
         let turbo_config_path = AbsoluteSystemPathBuf::try_from(turbo_config_path.clone())
             .expect("Failed to create turbo config path");
         let legacy_auth_path = AbsoluteSystemPathBuf::try_from(legacy_auth_path.clone())
@@ -128,12 +166,47 @@ mod tests {
         fs::create_dir_all(turbo_dir.path().join("turborepo")).expect("Failed to create turbo dir");
         fs::create_dir_all(vercel_dir.path().join("com.vercel.cli"))
             .expect("Failed to create legacy auth dir");
+        write_auth_file(&turbo_auth_path, "turbo-auth-token");
         turbo_config_path
             .create_with_contents(r#"{"token":"turbo-token"}"#)
             .expect("Failed to write turbo config");
         legacy_auth_path
             .create_with_contents(r#"{"token":"legacy-token"}"#)
             .expect("Failed to write legacy auth");
+
+        unsafe {
+            env::set_var("TURBO_CONFIG_DIR_PATH", turbo_dir.path());
+            env::set_var("VERCEL_CONFIG_DIR_PATH", vercel_dir.path());
+        }
+
+        let auth_file = AuthFile::global_auth(None).expect("Failed to create auth file");
+        let config = auth_file
+            .get_configuration_options(&ConfigurationOptions::default())
+            .expect("Failed to load auth config");
+
+        assert_eq!(config.token(), Some("turbo-auth-token"));
+
+        unsafe {
+            env::remove_var("TURBO_CONFIG_DIR_PATH");
+            env::remove_var("VERCEL_CONFIG_DIR_PATH");
+        }
+    }
+
+    #[test]
+    fn global_auth_falls_back_to_turbo_config_token() {
+        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+        let turbo_dir = tempdir().expect("Failed to create turbo dir");
+        let vercel_dir = tempdir().expect("Failed to create vercel dir");
+        let turbo_config_path = turbo_dir.path().join("turborepo/config.json");
+
+        let turbo_config_path = AbsoluteSystemPathBuf::try_from(turbo_config_path.clone())
+            .expect("Failed to create turbo config path");
+
+        fs::create_dir_all(turbo_dir.path().join("turborepo")).expect("Failed to create turbo dir");
+
+        turbo_config_path
+            .create_with_contents(r#"{"token":"turbo-token"}"#)
+            .expect("Failed to write turbo config");
 
         unsafe {
             env::set_var("TURBO_CONFIG_DIR_PATH", turbo_dir.path());
@@ -155,6 +228,7 @@ mod tests {
 
     #[test]
     fn global_auth_falls_back_to_legacy_vercel_auth() {
+        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
         let turbo_dir = tempdir().expect("Failed to create turbo dir");
         let vercel_dir = tempdir().expect("Failed to create vercel dir");
         let legacy_auth_path = vercel_dir.path().join("com.vercel.cli/auth.json");

--- a/crates/turborepo-config/src/file.rs
+++ b/crates/turborepo-config/src/file.rs
@@ -143,7 +143,7 @@ mod tests {
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn write_auth_file(path: &AbsoluteSystemPathBuf, token: &str) {
-        path.create_with_contents(&format!(r#"{{"token":"{token}"}}"#))
+        path.create_with_contents(format!(r#"{{"token":"{token}"}}"#))
             .expect("Failed to write auth file");
     }
 

--- a/crates/turborepo-lib/src/commands/login/mod.rs
+++ b/crates/turborepo-lib/src/commands/login/mod.rs
@@ -4,6 +4,7 @@ use manual::login_manual;
 use turborepo_api_client::APIClient;
 use turborepo_auth::{
     login as auth_login, sso_login as auth_sso_login, AuthTokens, LoginOptions, Token, TokenSet,
+    TURBO_AUTH_FILE, TURBO_TOKEN_DIR,
 };
 use turborepo_telemetry::events::command::{CommandEventBuilder, LoginMethod};
 
@@ -119,9 +120,8 @@ impl<'a> Drop for LoginTelemetry<'a> {
     }
 }
 
-/// Writes a token to turborepo/config.json. If device-flow login returned
-/// refresh metadata, persist that alongside the access token so Turbo can
-/// refresh it without touching the Vercel CLI directory.
+/// Writes a token to disk. Device-flow OAuth tokens go into Turbo's auth.json
+/// so older Turbos never treat them as legacy API tokens.
 fn write_token(
     base: &CommandBase,
     token: Token,
@@ -129,6 +129,7 @@ fn write_token(
 ) -> Result<(), Error> {
     let global_config_path = base.global_config_path()?;
     let token = token.into_inner().clone();
+    let token_str = token.expose().to_string();
     let auth_tokens = match token_set {
         Some(ts) => {
             let now_secs = std::time::SystemTime::now()
@@ -150,6 +151,19 @@ fn write_token(
             expires_at: None,
         },
     };
+
+    if token_str.starts_with("vca_") {
+        let Some(config_dir) =
+            turborepo_dirs::config_dir().map_err(|_| crate::config::Error::NoGlobalConfigPath)?
+        else {
+            return Err(crate::config::Error::NoGlobalConfigPath.into());
+        };
+        let turbo_auth_path = config_dir.join_components(&[TURBO_TOKEN_DIR, TURBO_AUTH_FILE]);
+
+        auth_tokens.write_to_config_file(&turbo_auth_path)?;
+        AuthTokens::clear_from_config_file(&global_config_path)?;
+        return Ok(());
+    }
 
     auth_tokens.write_to_config_file(&global_config_path)?;
 

--- a/crates/turborepo-lib/src/commands/login/mod.rs
+++ b/crates/turborepo-lib/src/commands/login/mod.rs
@@ -128,6 +128,12 @@ fn write_token(
     token_set: Option<&TokenSet>,
 ) -> Result<(), Error> {
     let global_config_path = base.global_config_path()?;
+    let Some(config_dir) =
+        turborepo_dirs::config_dir().map_err(|_| crate::config::Error::NoGlobalConfigPath)?
+    else {
+        return Err(crate::config::Error::NoGlobalConfigPath.into());
+    };
+    let turbo_auth_path = config_dir.join_components(&[TURBO_TOKEN_DIR, TURBO_AUTH_FILE]);
     let token = token.into_inner().clone();
     let token_str = token.expose().to_string();
     let auth_tokens = match token_set {
@@ -153,19 +159,91 @@ fn write_token(
     };
 
     if token_str.starts_with("vca_") {
-        let Some(config_dir) =
-            turborepo_dirs::config_dir().map_err(|_| crate::config::Error::NoGlobalConfigPath)?
-        else {
-            return Err(crate::config::Error::NoGlobalConfigPath.into());
-        };
-        let turbo_auth_path = config_dir.join_components(&[TURBO_TOKEN_DIR, TURBO_AUTH_FILE]);
-
         auth_tokens.write_to_config_file(&turbo_auth_path)?;
         AuthTokens::clear_from_config_file(&global_config_path)?;
         return Ok(());
     }
 
     auth_tokens.write_to_config_file(&global_config_path)?;
+    AuthTokens::clear_from_config_file(&turbo_auth_path)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{env, sync::Mutex};
+
+    use tempfile::tempdir;
+    use turbopath::AbsoluteSystemPathBuf;
+    use turborepo_ui::ColorConfig;
+
+    use super::*;
+    use crate::{config::TurborepoConfigBuilder, opts::Opts, Args};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn create_command_base(repo_root: AbsoluteSystemPathBuf) -> CommandBase {
+        let args = Args::default();
+        let config = TurborepoConfigBuilder::new(&repo_root).build().unwrap();
+        let opts = Opts::new(&repo_root, &args, config).unwrap();
+
+        CommandBase::from_opts(opts, repo_root, "test-version", ColorConfig::new(false))
+    }
+
+    #[test]
+    fn write_token_clears_stale_turbo_auth_for_manual_tokens() {
+        let _lock = ENV_LOCK.lock().expect("env lock poisoned");
+        let repo_root = tempdir().expect("failed to create repo tempdir");
+        let config_root = tempdir().expect("failed to create config tempdir");
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root.path().to_path_buf())
+            .expect("failed to create repo path");
+        let config_root = AbsoluteSystemPathBuf::try_from(config_root.path().to_path_buf())
+            .expect("failed to create config path");
+
+        repo_root
+            .join_component("turbo.json")
+            .create_with_contents("{}")
+            .expect("failed to write turbo.json");
+        repo_root
+            .join_component("package.json")
+            .create_with_contents("{}")
+            .expect("failed to write package.json");
+
+        let turbo_auth_path = config_root.join_components(&[TURBO_TOKEN_DIR, TURBO_AUTH_FILE]);
+        AuthTokens {
+            token: Some(turborepo_api_client::SecretString::new(
+                "vca_stale_token".to_owned(),
+            )),
+            refresh_token: Some(turborepo_api_client::SecretString::new(
+                "stale_refresh_token".to_owned(),
+            )),
+            expires_at: Some(4_102_444_800),
+        }
+        .write_to_config_file(&turbo_auth_path)
+        .expect("failed to write stale turbo auth file");
+
+        unsafe {
+            env::set_var("TURBO_CONFIG_DIR_PATH", config_root.as_path());
+        }
+
+        let base = create_command_base(repo_root);
+        write_token(&base, Token::new("manual_token".to_owned()), None)
+            .expect("failed to write manual token");
+
+        let global_config_path = config_root.join_components(&[TURBO_TOKEN_DIR, "config.json"]);
+        let written_token = Token::from_file(&global_config_path)
+            .expect("manual token should be written to config.json");
+        assert_eq!(written_token.into_inner().expose(), "manual_token");
+
+        let auth_tokens = Token::from_auth_file(&turbo_auth_path)
+            .expect("auth.json should remain parseable after clearing");
+        assert!(auth_tokens.token.is_none());
+        assert!(auth_tokens.refresh_token.is_none());
+        assert!(auth_tokens.expires_at.is_none());
+
+        unsafe {
+            env::remove_var("TURBO_CONFIG_DIR_PATH");
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Stop writing device-flow `vca_` access tokens into the legacy `turborepo/config.json` slot that older Turbo releases still read and validate via `/v5/user/tokens/current`.
- Store Turborepo-managed OAuth sessions in `turborepo/auth.json`, prefer that file during auth lookup, and clear both Turbo auth locations during logout.
- Keep the current `main` branch's legacy-auth exchange and refresh logic intact while adding tests for auth-file precedence and legacy fallback.

## Why
Older Turbo releases only understand the legacy config token slot. When newer device-flow builds persisted `vca_` OAuth tokens there, downgrading to an older CLI broke login reuse instead of falling back to a fresh login flow.

## How to Test

Upgrade/downgrade across legacy versions and make sure you don't get errors.