### PR TITLE
fix: Recover Vercel auth tokens across login flows

### DIFF
--- a/crates/turborepo-auth/src/auth/login.rs
+++ b/crates/turborepo-auth/src/auth/login.rs
@@ -160,17 +160,15 @@ pub async fn login<T: Client + TokenClient>(
                     Ok(Some(token_secret)) => {
                         if classify_existing_vercel_token(token_secret.expose())?
                             != ExistingTokenSource::LegacyAuth
-                        {
-                            if let Some(token) = reuse_existing_token_with_recovery(
+                            && let Some(token) = reuse_existing_token_with_recovery(
                                 Token::existing_secret(token_secret),
                                 api_client,
                                 "Using existing Vercel login.",
                                 color_config,
                             )
                             .await?
-                            {
-                                return Ok((token, None));
-                            }
+                        {
+                            return Ok((token, None));
                         }
                     }
                     Ok(None) => {}
@@ -206,17 +204,15 @@ pub async fn login<T: Client + TokenClient>(
                 Ok(Some(token_secret)) => {
                     if classify_existing_vercel_token(token_secret.expose())?
                         != ExistingTokenSource::LegacyAuth
-                    {
-                        if let Some(token) = reuse_existing_token_with_recovery(
+                        && let Some(token) = reuse_existing_token_with_recovery(
                             Token::existing_secret(token_secret),
                             api_client,
                             "Using existing Vercel login.",
                             color_config,
                         )
                         .await?
-                        {
-                            return Ok((token, None));
-                        }
+                    {
+                        return Ok((token, None));
                     }
                 }
                 Ok(None) => {}

--- a/crates/turborepo-auth/src/auth/login.rs
+++ b/crates/turborepo-auth/src/auth/login.rs
@@ -29,6 +29,28 @@ pub(super) fn is_inactive_token_error(error: &Error) -> bool {
     )
 }
 
+pub(super) fn is_auth_rejection_error(error: &Error) -> bool {
+    match error {
+        Error::APIError(turborepo_api_client::Error::InvalidToken { .. })
+        | Error::APIError(turborepo_api_client::Error::ForbiddenToken { .. }) => true,
+        Error::APIError(turborepo_api_client::Error::UnknownStatus { code, .. }) => {
+            code == "forbidden"
+        }
+        Error::APIError(turborepo_api_client::Error::ReqwestError(err))
+        | Error::ReqwestError(err) => err.status() == Some(reqwest::StatusCode::FORBIDDEN),
+        _ => false,
+    }
+}
+
+pub(super) fn valid_token_callback(message: &str, color_config: &ColorConfig) -> impl FnOnce(&str) {
+    let message = message.to_string();
+    let color_config = *color_config;
+    move |user_email: &str| {
+        println!("{}", color_config.apply(BOLD.apply_to(message)));
+        ui::print_cli_authorized(user_email, &color_config);
+    }
+}
+
 async fn reuse_existing_token<T, F>(
     token: Token,
     api_client: &T,
@@ -45,6 +67,47 @@ where
             warn!("Stored token is no longer active, proceeding with new login");
             Ok(None)
         }
+        Err(err) => Err(err),
+    }
+}
+
+async fn reuse_existing_token_with_recovery<T>(
+    token: Token,
+    api_client: &T,
+    valid_message: &str,
+    color_config: &ColorConfig,
+) -> Result<Option<Token>, Error>
+where
+    T: Client + TokenClient,
+{
+    match reuse_existing_token(
+        token.clone(),
+        api_client,
+        Some(valid_token_callback(valid_message, color_config)),
+    )
+    .await
+    {
+        Ok(Some(token)) => return Ok(Some(token)),
+        Ok(None) => {}
+        Err(err) if is_auth_rejection_error(&err) => {}
+        Err(err) => return Err(err),
+    }
+
+    let Some(recovered_token) =
+        crate::auth::recover_token_after_forbidden(token.into_inner()).await?
+    else {
+        return Ok(None);
+    };
+
+    match reuse_existing_token(
+        Token::existing_secret(recovered_token),
+        api_client,
+        Some(valid_token_callback(valid_message, color_config)),
+    )
+    .await
+    {
+        Ok(result) => Ok(result),
+        Err(err) if is_auth_rejection_error(&err) => Ok(None),
         Err(err) => Err(err),
     }
 }
@@ -75,15 +138,6 @@ pub async fn login<T: Client + TokenClient>(
         sso_login_callback_port,
     } = *options;
 
-    let valid_token_callback = |message: &str, color_config: &ColorConfig| {
-        let message = message.to_string();
-        let color_config = *color_config;
-        move |user_email: &str| {
-            println!("{}", color_config.apply(BOLD.apply_to(message)));
-            ui::print_cli_authorized(user_email, &color_config);
-        }
-    };
-
     let is_vercel_login = is_vercel(login_url_configuration);
 
     // Check if passed in token exists first.
@@ -96,33 +150,22 @@ pub async fn login<T: Client + TokenClient>(
                 ExistingTokenSource::Other
             };
 
-            if token_source != ExistingTokenSource::LegacyAuth {
-                let token = Token::existing(token.into());
-                if let Some(token) = reuse_existing_token(
-                    token,
-                    api_client,
-                    Some(valid_token_callback("Using existing login.", color_config)),
+            if is_vercel_login
+                && matches!(
+                    token_source,
+                    ExistingTokenSource::TurboConfig | ExistingTokenSource::LegacyAuth
                 )
-                .await?
-                {
-                    return Ok((token, None));
-                }
-            }
-
-            if matches!(
-                token_source,
-                ExistingTokenSource::TurboConfig | ExistingTokenSource::LegacyAuth
-            ) {
-                match crate::auth::get_token_with_refresh().await {
+            {
+                match crate::auth::get_token_with_refresh_for_login().await {
                     Ok(Some(token_secret)) => {
                         if classify_existing_vercel_token(token_secret.expose())?
                             != ExistingTokenSource::LegacyAuth
                         {
-                            let token = Token::existing_secret(token_secret);
-                            if let Some(token) = reuse_existing_token(
-                                token,
+                            if let Some(token) = reuse_existing_token_with_recovery(
+                                Token::existing_secret(token_secret),
                                 api_client,
-                                Some(valid_token_callback("Using existing login.", color_config)),
+                                "Using existing Vercel login.",
+                                color_config,
                             )
                             .await?
                             {
@@ -135,18 +178,40 @@ pub async fn login<T: Client + TokenClient>(
                         warn!("Failed to load existing token, proceeding with new login: {e}");
                     }
                 }
+            } else if token_source != ExistingTokenSource::LegacyAuth {
+                let token = Token::existing(token.into());
+                let reused_token = if is_vercel_login {
+                    reuse_existing_token_with_recovery(
+                        token,
+                        api_client,
+                        "Using existing Vercel login.",
+                        color_config,
+                    )
+                    .await?
+                } else {
+                    reuse_existing_token(
+                        token,
+                        api_client,
+                        Some(valid_token_callback("Using existing login.", color_config)),
+                    )
+                    .await?
+                };
+
+                if let Some(token) = reused_token {
+                    return Ok((token, None));
+                }
             }
         } else if is_vercel_login {
-            match crate::auth::get_token_with_refresh().await {
+            match crate::auth::get_token_with_refresh_for_login().await {
                 Ok(Some(token_secret)) => {
                     if classify_existing_vercel_token(token_secret.expose())?
                         != ExistingTokenSource::LegacyAuth
                     {
-                        let token = Token::existing_secret(token_secret);
-                        if let Some(token) = reuse_existing_token(
-                            token,
+                        if let Some(token) = reuse_existing_token_with_recovery(
+                            Token::existing_secret(token_secret),
                             api_client,
-                            Some(valid_token_callback("Using existing login.", color_config)),
+                            "Using existing Vercel login.",
+                            color_config,
                         )
                         .await?
                         {
@@ -381,15 +446,25 @@ fn wait_for_login_redirect(listener: TcpListener, success_redirect: &str) -> Res
 
 #[cfg(test)]
 mod tests {
-    use std::{assert_matches::assert_matches, time::Duration};
+    use std::{assert_matches::assert_matches, env, time::Duration};
 
     use reqwest::{RequestBuilder, Response};
+    use tempfile::tempdir;
+    use tokio::sync::Mutex;
+    use turbopath::AbsoluteSystemPathBuf;
     use turborepo_vercel_api::{
         Membership, Role, Team, TeamsResponse, User, UserResponse, VerifiedSsoUser,
     };
     use turborepo_vercel_api_mock::start_test_server;
 
     use super::*;
+
+    static ENV_LOCK: Mutex<()> = Mutex::const_new(());
+
+    fn create_mock_config_dir() -> AbsoluteSystemPathBuf {
+        let tmp_dir = tempdir().expect("Failed to create temp dir");
+        AbsoluteSystemPathBuf::try_from(tmp_dir.keep()).expect("Failed to create path")
+    }
 
     #[derive(Debug, thiserror::Error)]
     enum MockApiError {
@@ -506,6 +581,14 @@ mod tests {
                 });
             }
 
+            if token.expose() == "forbidden-token" {
+                return Err(turborepo_api_client::Error::InvalidToken {
+                    status: 403,
+                    url: "https://vercel.com/api/v5/user/tokens/current".to_string(),
+                    message: "Not authorized".to_string(),
+                });
+            }
+
             Ok(turborepo_vercel_api::token::ResponseTokenMetadata {
                 scopes: vec![turborepo_vercel_api::token::Scope {
                     scope_type: "user".to_string(),
@@ -591,6 +674,36 @@ mod tests {
 
         assert_matches!(token, Token::New(ref token) if token.expose() == "fresh-login-token");
         assert!(token_set.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_reuse_existing_token_with_recovery_discards_invalid_token_errors() {
+        let _lock = ENV_LOCK.lock().await;
+        let turbo_config_dir = create_mock_config_dir();
+        let vercel_config_dir = create_mock_config_dir();
+        let color_config = turborepo_ui::ColorConfig::new(false);
+        let api_client = MockApiClient::new();
+
+        unsafe {
+            env::set_var("TURBO_CONFIG_DIR_PATH", turbo_config_dir.as_path());
+            env::set_var("VERCEL_CONFIG_DIR_PATH", vercel_config_dir.as_path());
+        }
+
+        let reused = reuse_existing_token_with_recovery(
+            Token::existing("forbidden-token".to_string()),
+            &api_client,
+            "Using existing Vercel login.",
+            &color_config,
+        )
+        .await
+        .unwrap();
+
+        assert!(reused.is_none());
+
+        unsafe {
+            env::remove_var("TURBO_CONFIG_DIR_PATH");
+            env::remove_var("VERCEL_CONFIG_DIR_PATH");
+        }
     }
 
     #[test]

--- a/crates/turborepo-auth/src/auth/mod.rs
+++ b/crates/turborepo-auth/src/auth/mod.rs
@@ -109,6 +109,16 @@ fn load_tokens_from_path(
     }
 }
 
+fn path_contains_token(
+    path: &AbsoluteSystemPath,
+    label: &str,
+    expected_token: &str,
+) -> Result<bool, Error> {
+    Ok(load_tokens_from_path(path, label)?
+        .and_then(|tokens| tokens.token)
+        .is_some_and(|stored_token| stored_token.expose() == expected_token))
+}
+
 fn load_turbo_auth_tokens_from_paths(
     turbo_auth_path: &AbsoluteSystemPath,
     turbo_config_path: &AbsoluteSystemPath,
@@ -203,25 +213,73 @@ async fn exchange_legacy_auth_token(
     turbo_auth_path: &AbsoluteSystemPath,
     turbo_config_path: &AbsoluteSystemPath,
     expected_token: Option<&turborepo_api_client::SecretString>,
+    allow_legacy_token_fallback: bool,
 ) -> Result<Option<turborepo_api_client::SecretString>, Error> {
     let legacy_auth_tokens = load_legacy_auth_tokens(expected_token)?;
-    let Some(legacy_token) = legacy_auth_tokens.token.clone() else {
+    exchange_auth_tokens(
+        &legacy_auth_tokens,
+        turbo_auth_path,
+        turbo_config_path,
+        allow_legacy_token_fallback,
+        "legacy Vercel auth token",
+    )
+    .await
+}
+
+fn can_refresh_token(auth_tokens: &crate::AuthTokens) -> bool {
+    // Recovery may run after the access token has been corrupted or rejected,
+    // so refreshability has to be derived from the stored refresh token rather
+    // than the access-token prefix.
+    auth_tokens.refresh_token.is_some()
+}
+
+fn should_exchange_turbo_config_token(
+    auth_tokens: &crate::AuthTokens,
+    turbo_auth_path: &AbsoluteSystemPath,
+) -> Result<bool, Error> {
+    let Some(token) = auth_tokens.token.as_ref() else {
+        return Ok(false);
+    };
+
+    if token.expose().starts_with("vca_")
+        || auth_tokens.refresh_token.is_some()
+        || auth_tokens.expires_at.is_some()
+    {
+        return Ok(false);
+    }
+
+    Ok(!path_contains_token(
+        turbo_auth_path,
+        "Turbo auth file",
+        token.expose(),
+    )?)
+}
+
+async fn exchange_auth_tokens(
+    auth_tokens: &crate::AuthTokens,
+    turbo_auth_path: &AbsoluteSystemPath,
+    turbo_config_path: &AbsoluteSystemPath,
+    allow_token_fallback: bool,
+    source_label: &str,
+) -> Result<Option<turborepo_api_client::SecretString>, Error> {
+    let Some(stored_token) = auth_tokens.token.clone() else {
         return Ok(None);
     };
 
-    let exchange_source = if legacy_auth_tokens.is_expired()
-        && legacy_token.expose().starts_with("vca_")
-        && legacy_auth_tokens.refresh_token.is_some()
-    {
-        match legacy_auth_tokens.refresh_token().await {
+    let should_refresh_before_exchange =
+        can_refresh_token(auth_tokens) && (auth_tokens.is_expired() || !allow_token_fallback);
+    let mut refresh_error = None;
+
+    let exchange_source = if should_refresh_before_exchange {
+        match auth_tokens.refresh_token().await {
             Ok(refreshed_tokens) => refreshed_tokens,
             Err(e) => {
-                warn!("Failed to refresh legacy Vercel auth token before exchange: {e}");
-                legacy_auth_tokens.clone()
+                refresh_error = Some(e);
+                auth_tokens.clone()
             }
         }
     } else {
-        legacy_auth_tokens.clone()
+        auth_tokens.clone()
     };
 
     match exchange_source.exchange_legacy_token().await {
@@ -237,12 +295,59 @@ async fn exchange_legacy_auth_token(
             Ok(exchanged_tokens.token)
         }
         Err(e) => {
-            warn!("Failed to exchange legacy Vercel auth token, using legacy token directly: {e}");
-            if exchange_source.is_expired() {
-                Ok(None)
+            if allow_token_fallback {
+                if let Some(refresh_error) = refresh_error {
+                    warn!(
+                        "Failed to refresh or exchange {source_label}, using stored token \
+                         directly: refresh error: {refresh_error}; exchange error: {e}"
+                    );
+                } else {
+                    warn!("Failed to exchange {source_label}, using stored token directly: {e}");
+                }
+                if exchange_source.is_expired() {
+                    Ok(None)
+                } else {
+                    Ok(exchange_source.token.or(Some(stored_token)))
+                }
             } else {
-                Ok(exchange_source.token.or(Some(legacy_token)))
+                if let Some(refresh_error) = refresh_error {
+                    warn!(
+                        "Failed to refresh or exchange {source_label} after a forbidden response: \
+                         refresh error: {refresh_error}; exchange error: {e}"
+                    );
+                } else {
+                    warn!("Failed to exchange {source_label} after a forbidden response: {e}");
+                }
+                Ok(None)
             }
+        }
+    }
+}
+
+async fn refresh_and_persist_turbo_token(
+    auth_tokens: &crate::AuthTokens,
+    turbo_auth_path: &AbsoluteSystemPath,
+    turbo_config_path: &AbsoluteSystemPath,
+) -> Option<turborepo_api_client::SecretString> {
+    if !can_refresh_token(auth_tokens) {
+        return None;
+    }
+
+    match auth_tokens.refresh_token().await {
+        Ok(new_tokens) => {
+            if let Err(e) =
+                persist_turbo_oauth_tokens(&new_tokens, turbo_auth_path, turbo_config_path)
+            {
+                warn!(
+                    "Failed to write refreshed tokens to {turbo_auth_path} and clear \
+                     {turbo_config_path}: {e}"
+                );
+            }
+            new_tokens.token
+        }
+        Err(e) => {
+            warn!("Failed to refresh stored Vercel auth token: {e}");
+            None
         }
     }
 }
@@ -257,8 +362,10 @@ fn persist_turbo_oauth_tokens(
     Ok(())
 }
 
-/// Attempts to get a valid token with automatic refresh if expired.
-pub async fn get_token_with_refresh() -> Result<Option<turborepo_api_client::SecretString>, Error> {
+async fn get_token_with_refresh_inner(
+    allow_legacy_token_fallback: bool,
+    allow_turbo_config_token_fallback: bool,
+) -> Result<Option<turborepo_api_client::SecretString>, Error> {
     use crate::{TURBO_AUTH_FILE, TURBO_TOKEN_DIR, TURBO_TOKEN_FILE};
 
     let turbo_config_dir = match turborepo_dirs::config_dir()? {
@@ -272,33 +379,131 @@ pub async fn get_token_with_refresh() -> Result<Option<turborepo_api_client::Sec
 
     if let Some(token) = &auth_tokens.token {
         if classify_existing_vercel_token(token.expose())? == ExistingTokenSource::LegacyAuth {
-            return exchange_legacy_auth_token(&turbo_auth_path, &turbo_config_path, Some(token))
-                .await;
+            return exchange_legacy_auth_token(
+                &turbo_auth_path,
+                &turbo_config_path,
+                Some(token),
+                allow_legacy_token_fallback,
+            )
+            .await;
+        }
+
+        if should_exchange_turbo_config_token(&auth_tokens, &turbo_auth_path)? {
+            return exchange_auth_tokens(
+                &auth_tokens,
+                &turbo_auth_path,
+                &turbo_config_path,
+                allow_turbo_config_token_fallback,
+                "Turbo config token",
+            )
+            .await;
         }
 
         if auth_tokens.is_expired() {
-            // Only attempt refresh for Vercel tokens that start with "vca_"
-            if token.expose().starts_with("vca_")
-                && auth_tokens.refresh_token.is_some()
-                && let Ok(new_tokens) = auth_tokens.refresh_token().await
+            if let Some(refreshed_token) =
+                refresh_and_persist_turbo_token(&auth_tokens, &turbo_auth_path, &turbo_config_path)
+                    .await
             {
-                if let Err(e) =
-                    persist_turbo_oauth_tokens(&new_tokens, &turbo_auth_path, &turbo_config_path)
-                {
-                    tracing::warn!(
-                        "Failed to write refreshed tokens to {turbo_auth_path} and clear \
-                         {turbo_config_path}: {e}"
-                    );
-                }
-                return Ok(new_tokens.token);
+                return Ok(Some(refreshed_token));
             }
 
-            exchange_legacy_auth_token(&turbo_auth_path, &turbo_config_path, Some(token)).await
+            exchange_legacy_auth_token(
+                &turbo_auth_path,
+                &turbo_config_path,
+                Some(token),
+                allow_legacy_token_fallback,
+            )
+            .await
         } else {
             Ok(Some(token.clone()))
         }
     } else {
-        exchange_legacy_auth_token(&turbo_auth_path, &turbo_config_path, None).await
+        exchange_legacy_auth_token(
+            &turbo_auth_path,
+            &turbo_config_path,
+            None,
+            allow_legacy_token_fallback,
+        )
+        .await
+    }
+}
+
+/// Attempts to get a valid token with automatic refresh if expired.
+pub async fn get_token_with_refresh() -> Result<Option<turborepo_api_client::SecretString>, Error> {
+    get_token_with_refresh_inner(true, true).await
+}
+
+/// Login prefers upgrading legacy/config tokens into Turbo OAuth sessions. If
+/// that upgrade fails, callers should fall through to a fresh login instead of
+/// silently reusing the old token.
+pub async fn get_token_with_refresh_for_login()
+-> Result<Option<turborepo_api_client::SecretString>, Error> {
+    get_token_with_refresh_inner(false, false).await
+}
+
+/// Attempts to recover a replacement token after the current token was rejected
+/// by the server. Unlike `get_token_with_refresh`, this never falls back to the
+/// same stored token.
+pub async fn recover_token_after_forbidden(
+    current_token: &turborepo_api_client::SecretString,
+) -> Result<Option<turborepo_api_client::SecretString>, Error> {
+    use crate::{TURBO_AUTH_FILE, TURBO_TOKEN_DIR, TURBO_TOKEN_FILE};
+
+    let turbo_config_dir = match turborepo_dirs::config_dir()? {
+        Some(dir) => dir,
+        None => return Ok(None),
+    };
+
+    let turbo_auth_path = turbo_config_dir.join_components(&[TURBO_TOKEN_DIR, TURBO_AUTH_FILE]);
+    let turbo_config_path = turbo_config_dir.join_components(&[TURBO_TOKEN_DIR, TURBO_TOKEN_FILE]);
+
+    match classify_existing_vercel_token(current_token.expose())? {
+        ExistingTokenSource::LegacyAuth => {
+            exchange_legacy_auth_token(
+                &turbo_auth_path,
+                &turbo_config_path,
+                Some(current_token),
+                false,
+            )
+            .await
+        }
+        ExistingTokenSource::TurboConfig => {
+            let auth_tokens = load_auth_tokens(&turbo_auth_path, &turbo_config_path)?;
+            if auth_tokens.token.as_ref().map(|token| token.expose())
+                != Some(current_token.expose())
+            {
+                return Ok(None);
+            }
+
+            if should_exchange_turbo_config_token(&auth_tokens, &turbo_auth_path)? {
+                return exchange_auth_tokens(
+                    &auth_tokens,
+                    &turbo_auth_path,
+                    &turbo_config_path,
+                    false,
+                    "Turbo config token",
+                )
+                .await;
+            }
+
+            if let Some(refreshed_token) =
+                refresh_and_persist_turbo_token(&auth_tokens, &turbo_auth_path, &turbo_config_path)
+                    .await
+            {
+                if refreshed_token.expose() != current_token.expose() {
+                    return Ok(Some(refreshed_token));
+                }
+            }
+
+            exchange_legacy_auth_token(
+                &turbo_auth_path,
+                &turbo_config_path,
+                Some(current_token),
+                false,
+            )
+            .await
+        }
+        ExistingTokenSource::Other => Ok(None),
     }
 }
 
@@ -311,9 +516,14 @@ mod tests {
     use turbopath::AbsoluteSystemPathBuf;
 
     use super::{
-        ExistingTokenSource, classify_existing_vercel_token, get_token_with_refresh, is_vercel,
+        ExistingTokenSource, can_refresh_token, classify_existing_vercel_token,
+        get_token_with_refresh, is_vercel, load_auth_tokens, recover_token_after_forbidden,
+        should_exchange_turbo_config_token,
     };
-    use crate::{AuthTokens, TURBO_AUTH_FILE, TURBO_TOKEN_DIR, Token, current_unix_time_secs};
+    use crate::{
+        AuthTokens, TURBO_AUTH_FILE, TURBO_TOKEN_DIR, TURBO_TOKEN_FILE, Token,
+        current_unix_time_secs,
+    };
 
     static ENV_LOCK: Mutex<()> = Mutex::const_new(());
 
@@ -500,6 +710,63 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_should_exchange_turbo_config_legacy_token() {
+        let _lock = ENV_LOCK.blocking_lock();
+        let turbo_config_dir = create_mock_turbo_config_dir();
+        let vercel_config_dir = create_mock_vercel_config_dir();
+
+        setup_turbo_config_file(&turbo_config_dir, "vcp_legacy_token");
+
+        unsafe {
+            env::set_var("TURBO_CONFIG_DIR_PATH", turbo_config_dir.as_path());
+            env::set_var("VERCEL_CONFIG_DIR_PATH", vercel_config_dir.as_path());
+        }
+
+        let turbo_auth_path = turbo_config_dir.join_components(&[TURBO_TOKEN_DIR, TURBO_AUTH_FILE]);
+        let turbo_config_path =
+            turbo_config_dir.join_components(&[TURBO_TOKEN_DIR, TURBO_TOKEN_FILE]);
+        let auth_tokens = load_auth_tokens(&turbo_auth_path, &turbo_config_path).unwrap();
+
+        assert!(should_exchange_turbo_config_token(&auth_tokens, &turbo_auth_path).unwrap());
+
+        unsafe {
+            env::remove_var("TURBO_CONFIG_DIR_PATH");
+            env::remove_var("VERCEL_CONFIG_DIR_PATH");
+        }
+    }
+
+    #[test]
+    fn test_should_not_exchange_turbo_auth_oauth_token() {
+        let _lock = ENV_LOCK.blocking_lock();
+        let turbo_config_dir = create_mock_turbo_config_dir();
+        let vercel_config_dir = create_mock_vercel_config_dir();
+
+        setup_turbo_auth_file(
+            &turbo_config_dir,
+            "vca_oauth_token",
+            Some("refresh_token_123"),
+            Some(current_unix_time_secs() + 3600),
+        );
+
+        unsafe {
+            env::set_var("TURBO_CONFIG_DIR_PATH", turbo_config_dir.as_path());
+            env::set_var("VERCEL_CONFIG_DIR_PATH", vercel_config_dir.as_path());
+        }
+
+        let turbo_auth_path = turbo_config_dir.join_components(&[TURBO_TOKEN_DIR, TURBO_AUTH_FILE]);
+        let turbo_config_path =
+            turbo_config_dir.join_components(&[TURBO_TOKEN_DIR, TURBO_TOKEN_FILE]);
+        let auth_tokens = load_auth_tokens(&turbo_auth_path, &turbo_config_path).unwrap();
+
+        assert!(!should_exchange_turbo_config_token(&auth_tokens, &turbo_auth_path).unwrap());
+
+        unsafe {
+            env::remove_var("TURBO_CONFIG_DIR_PATH");
+            env::remove_var("VERCEL_CONFIG_DIR_PATH");
+        }
+    }
+
     #[tokio::test]
     async fn test_get_token_with_refresh_prefers_turbo_auth_file() {
         let _lock = ENV_LOCK.lock().await;
@@ -559,11 +826,125 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_load_auth_tokens_backfills_matching_legacy_metadata() {
+        let _lock = ENV_LOCK.blocking_lock();
+        let turbo_config_dir = create_mock_turbo_config_dir();
+        let vercel_config_dir = create_mock_vercel_config_dir();
+        let current_time = current_unix_time_secs();
+
+        setup_turbo_auth_file(&turbo_config_dir, "shared-token", None, None);
+        setup_auth_file(
+            &vercel_config_dir,
+            "shared-token",
+            Some("refresh_token_456"),
+            Some(current_time + 3600),
+        );
+
+        unsafe {
+            env::set_var("TURBO_CONFIG_DIR_PATH", turbo_config_dir.as_path());
+            env::set_var("VERCEL_CONFIG_DIR_PATH", vercel_config_dir.as_path());
+        }
+
+        let turbo_auth_path = turbo_config_dir.join_components(&[TURBO_TOKEN_DIR, TURBO_AUTH_FILE]);
+        let turbo_config_path =
+            turbo_config_dir.join_components(&[TURBO_TOKEN_DIR, TURBO_TOKEN_FILE]);
+        let auth_tokens = load_auth_tokens(&turbo_auth_path, &turbo_config_path).unwrap();
+
+        assert_eq!(
+            auth_tokens.token.as_ref().map(|token| token.expose()),
+            Some("shared-token")
+        );
+        assert_eq!(
+            auth_tokens
+                .refresh_token
+                .as_ref()
+                .map(|token| token.expose()),
+            Some("refresh_token_456")
+        );
+        assert_eq!(auth_tokens.expires_at, Some(current_time + 3600));
+
+        unsafe {
+            env::remove_var("TURBO_CONFIG_DIR_PATH");
+            env::remove_var("VERCEL_CONFIG_DIR_PATH");
+        }
+    }
+
+    #[test]
+    fn test_load_auth_tokens_ignores_mismatched_legacy_metadata() {
+        let _lock = ENV_LOCK.blocking_lock();
+        let turbo_config_dir = create_mock_turbo_config_dir();
+        let vercel_config_dir = create_mock_vercel_config_dir();
+        let current_time = current_unix_time_secs();
+
+        setup_turbo_auth_file(&turbo_config_dir, "turbo-token", None, None);
+        setup_auth_file(
+            &vercel_config_dir,
+            "other-token",
+            Some("refresh_token_456"),
+            Some(current_time + 3600),
+        );
+
+        unsafe {
+            env::set_var("TURBO_CONFIG_DIR_PATH", turbo_config_dir.as_path());
+            env::set_var("VERCEL_CONFIG_DIR_PATH", vercel_config_dir.as_path());
+        }
+
+        let turbo_auth_path = turbo_config_dir.join_components(&[TURBO_TOKEN_DIR, TURBO_AUTH_FILE]);
+        let turbo_config_path =
+            turbo_config_dir.join_components(&[TURBO_TOKEN_DIR, TURBO_TOKEN_FILE]);
+        let auth_tokens = load_auth_tokens(&turbo_auth_path, &turbo_config_path).unwrap();
+
+        assert_eq!(
+            auth_tokens.token.as_ref().map(|token| token.expose()),
+            Some("turbo-token")
+        );
+        assert!(auth_tokens.refresh_token.is_none());
+        assert!(auth_tokens.expires_at.is_none());
+
+        unsafe {
+            env::remove_var("TURBO_CONFIG_DIR_PATH");
+            env::remove_var("VERCEL_CONFIG_DIR_PATH");
+        }
+    }
+
     #[tokio::test]
-    async fn test_vca_token_with_valid_refresh() {
-        // This test verifies that vca_ prefixed tokens attempt refresh when expired
-        // Note: This test focuses on the logic flow rather than actual HTTP refresh
-        // since we can't easily mock the HTTP client in this unit test
+    async fn test_recover_token_after_forbidden_ignores_untracked_token() {
+        let _lock = ENV_LOCK.lock().await;
+        let turbo_config_dir = create_mock_turbo_config_dir();
+        let vercel_config_dir = create_mock_vercel_config_dir();
+        let current_time = current_unix_time_secs();
+
+        setup_turbo_auth_file(
+            &turbo_config_dir,
+            "stored-token",
+            Some("refresh_token_123"),
+            Some(current_time + 3600),
+        );
+
+        unsafe {
+            env::set_var("TURBO_CONFIG_DIR_PATH", turbo_config_dir.as_path());
+            env::set_var("VERCEL_CONFIG_DIR_PATH", vercel_config_dir.as_path());
+        }
+
+        let recovered = recover_token_after_forbidden(&turborepo_api_client::SecretString::new(
+            "other-token".to_string(),
+        ))
+        .await
+        .unwrap();
+
+        assert!(recovered.is_none());
+
+        unsafe {
+            env::remove_var("TURBO_CONFIG_DIR_PATH");
+            env::remove_var("VERCEL_CONFIG_DIR_PATH");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_expired_token_with_refresh_token_is_refreshable() {
+        // This focuses on the local gating logic. The HTTP refresh itself is
+        // covered elsewhere.
 
         let vercel_config_dir = create_mock_vercel_config_dir();
         let current_time = current_unix_time_secs();
@@ -580,31 +961,20 @@ mod tests {
         let auth_path = vercel_config_dir.join_components(&["com.vercel.cli", "auth.json"]);
         let auth_tokens = Token::from_auth_file(&auth_path).expect("Failed to read auth file");
 
-        // Verify the token is expired and has vca_ prefix
+        // Any expired token with a refresh token should be refreshable, even if
+        // the access token itself is later corrupted.
         assert!(auth_tokens.is_expired());
-        assert!(
-            auth_tokens
-                .token
-                .as_ref()
-                .unwrap()
-                .expose()
-                .starts_with("vca_")
-        );
         assert!(auth_tokens.refresh_token.is_some());
-
-        // The actual refresh would happen in get_token_with_refresh, but we
-        // can't test the HTTP call in a unit test. The important logic
-        // is that it attempts refresh for vca_ tokens and falls back
-        // appropriately.
+        assert!(can_refresh_token(&auth_tokens));
     }
 
     #[tokio::test]
-    async fn test_legacy_token_skips_refresh() {
+    async fn test_non_vca_token_with_refresh_token_is_still_refreshable() {
         let vercel_config_dir = create_mock_vercel_config_dir();
         let turbo_config_dir = create_mock_turbo_config_dir();
         let current_time = current_unix_time_secs();
 
-        // Setup expired legacy token (no vca_ prefix) with refresh token
+        // Setup expired non-vca token with refresh token
         setup_auth_file(
             &vercel_config_dir,
             "legacy_token_123",
@@ -619,7 +989,8 @@ mod tests {
         let auth_path = vercel_config_dir.join_components(&["com.vercel.cli", "auth.json"]);
         let auth_tokens = Token::from_auth_file(&auth_path).expect("Failed to read auth file");
 
-        // Verify the token is expired and does NOT have vca_ prefix
+        // Recovery should use the refresh token rather than relying on the
+        // current access-token prefix.
         assert!(auth_tokens.is_expired());
         assert!(
             !auth_tokens
@@ -630,12 +1001,7 @@ mod tests {
                 .starts_with("vca_")
         );
         assert!(auth_tokens.refresh_token.is_some());
-
-        // The key behavior: legacy tokens should NOT attempt refresh even if
-        // they have a refresh token. They should fall back to turbo
-        // config instead. This is the critical logic we're testing -
-        // that the vca_ prefix check prevents refresh attempts for
-        // legacy tokens.
+        assert!(can_refresh_token(&auth_tokens));
     }
 
     #[tokio::test]
@@ -739,35 +1105,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_token_prefix_edge_cases() {
-        let current_time = current_unix_time_secs();
-
-        // Test various token prefixes to ensure only "vca_" triggers refresh
-        let test_cases = vec![
-            ("vca_token", true),         // Should attempt refresh
-            ("VCA_token", false),        // Case sensitive - should not refresh
-            ("vca_", true),              // Minimal vca_ prefix - should attempt refresh
-            ("vca", false),              // Missing underscore - should not refresh
-            ("xvca_token", false),       // Has vca_ but not at start - should not refresh
-            ("", false),                 // Empty token - should not refresh
-            ("some_other_token", false), // Different prefix - should not refresh
-        ];
-
-        for (token, should_attempt_refresh) in test_cases {
-            let _auth_tokens = AuthTokens {
+    async fn test_refreshability_depends_on_refresh_token_not_access_token_prefix() {
+        for token in ["vca_token", "legacy_token", "corrupted!!!", ""] {
+            let auth_tokens = AuthTokens {
                 token: Some(turborepo_api_client::SecretString::new(token.to_string())),
                 refresh_token: Some(turborepo_api_client::SecretString::new(
                     "refresh_token".to_string(),
                 )),
-                expires_at: Some(current_time - 3600), // Expired
+                expires_at: Some(current_unix_time_secs() - 3600),
             };
 
-            let has_vca_prefix = token.starts_with("vca_");
-            assert_eq!(
-                has_vca_prefix, should_attempt_refresh,
-                "Token '{token}' prefix check failed"
+            assert!(
+                can_refresh_token(&auth_tokens),
+                "Token '{token}' should be refreshable"
             );
         }
+
+        let auth_tokens = AuthTokens {
+            token: Some(turborepo_api_client::SecretString::new(
+                "vca_token".to_string(),
+            )),
+            refresh_token: None,
+            expires_at: Some(current_unix_time_secs() - 3600),
+        };
+
+        assert!(!can_refresh_token(&auth_tokens));
     }
 
     #[test]

--- a/crates/turborepo-auth/src/auth/mod.rs
+++ b/crates/turborepo-auth/src/auth/mod.rs
@@ -489,10 +489,9 @@ pub async fn recover_token_after_forbidden(
             if let Some(refreshed_token) =
                 refresh_and_persist_turbo_token(&auth_tokens, &turbo_auth_path, &turbo_config_path)
                     .await
+                && refreshed_token.expose() != current_token.expose()
             {
-                if refreshed_token.expose() != current_token.expose() {
-                    return Ok(Some(refreshed_token));
-                }
+                return Ok(Some(refreshed_token));
             }
 
             exchange_legacy_auth_token(

--- a/crates/turborepo-auth/src/auth/sso.rs
+++ b/crates/turborepo-auth/src/auth/sso.rs
@@ -6,10 +6,13 @@ use std::{
 
 use tracing::warn;
 use turborepo_api_client::{Client, TokenClient};
-use turborepo_ui::{BOLD, ColorConfig, start_spinner};
+use turborepo_ui::{ColorConfig, start_spinner};
 use url::Url;
 
-use super::login::{is_inactive_token_error, login_vercel_device_flow};
+use super::login::{
+    is_auth_rejection_error, is_inactive_token_error, login_vercel_device_flow,
+    valid_token_callback,
+};
 use crate::{
     Error, LoginOptions, Token,
     auth::{ExistingTokenSource, classify_existing_vercel_token, is_vercel},
@@ -63,6 +66,66 @@ async fn classify_existing_sso_token<T: Client + TokenClient>(
     }
 }
 
+async fn classify_existing_sso_token_with_recovery<T: Client + TokenClient>(
+    token: Token,
+    api_client: &T,
+    sso_team: &str,
+    valid_message: &str,
+    color_config: &ColorConfig,
+) -> Result<ExistingSSOTokenAction, Error> {
+    match classify_existing_sso_token(
+        token.clone(),
+        api_client,
+        sso_team,
+        Some(valid_token_callback(valid_message, color_config)),
+    )
+    .await
+    {
+        Ok(ExistingSSOTokenAction::Reuse(token)) => Ok(ExistingSSOTokenAction::Reuse(token)),
+        Ok(ExistingSSOTokenAction::Discard) => {
+            let Some(recovered_token) =
+                crate::auth::recover_token_after_forbidden(token.into_inner()).await?
+            else {
+                return Ok(ExistingSSOTokenAction::Discard);
+            };
+
+            match classify_existing_sso_token(
+                Token::existing_secret(recovered_token),
+                api_client,
+                sso_team,
+                Some(valid_token_callback(valid_message, color_config)),
+            )
+            .await
+            {
+                Ok(result) => Ok(result),
+                Err(err) if is_auth_rejection_error(&err) => Ok(ExistingSSOTokenAction::Discard),
+                Err(err) => Err(err),
+            }
+        }
+        Err(err) if is_auth_rejection_error(&err) => {
+            let Some(recovered_token) =
+                crate::auth::recover_token_after_forbidden(token.into_inner()).await?
+            else {
+                return Ok(ExistingSSOTokenAction::Discard);
+            };
+
+            match classify_existing_sso_token(
+                Token::existing_secret(recovered_token),
+                api_client,
+                sso_team,
+                Some(valid_token_callback(valid_message, color_config)),
+            )
+            .await
+            {
+                Ok(result) => Ok(result),
+                Err(err) if is_auth_rejection_error(&err) => Ok(ExistingSSOTokenAction::Discard),
+                Err(err) => Err(err),
+            }
+        }
+        Err(err) => Err(err),
+    }
+}
+
 /// Perform an SSO login flow.
 ///
 /// For Vercel:
@@ -96,15 +159,6 @@ pub async fn sso_login<T: Client + TokenClient>(
     let sso_team = sso_team.ok_or(Error::EmptySSOTeam)?;
     let is_vercel_login = is_vercel(login_url_configuration);
 
-    let valid_token_callback = |message: &str, color_config: &ColorConfig| {
-        let message = message.to_string();
-        let color_config = *color_config;
-        move |user_email: &str| {
-            println!("{}", color_config.apply(BOLD.apply_to(message)));
-            ui::print_cli_authorized(user_email, &color_config);
-        }
-    };
-
     // Check if token exists first. Must be there for the user and contain the
     // sso_team passed into this function.
     // For Vercel logins, --force is silently ignored.
@@ -116,37 +170,23 @@ pub async fn sso_login<T: Client + TokenClient>(
                 ExistingTokenSource::Other
             };
 
-            if token_source != ExistingTokenSource::LegacyAuth {
-                match classify_existing_sso_token(
-                    Token::existing(token.to_string()),
-                    api_client,
-                    sso_team,
-                    Some(valid_token_callback("Using existing login.", color_config)),
+            if is_vercel_login
+                && matches!(
+                    token_source,
+                    ExistingTokenSource::TurboConfig | ExistingTokenSource::LegacyAuth
                 )
-                .await?
-                {
-                    ExistingSSOTokenAction::Reuse(token) => return Ok((token, None)),
-                    ExistingSSOTokenAction::Discard => {}
-                }
-            }
-
-            if matches!(
-                token_source,
-                ExistingTokenSource::TurboConfig | ExistingTokenSource::LegacyAuth
-            ) {
-                match crate::auth::get_token_with_refresh().await {
+            {
+                match crate::auth::get_token_with_refresh_for_login().await {
                     Ok(Some(token_secret)) => {
                         if classify_existing_vercel_token(token_secret.expose())?
                             != ExistingTokenSource::LegacyAuth
                         {
-                            match classify_existing_sso_token(
+                            match classify_existing_sso_token_with_recovery(
                                 Token::existing_secret(token_secret),
                                 api_client,
                                 sso_team,
-                                Some(valid_token_callback(
-                                    &format!("Using existing login for team: {sso_team}"),
-                                    color_config,
-                                )),
+                                &format!("Using existing Vercel login for team: {sso_team}"),
+                                color_config,
                             )
                             .await?
                             {
@@ -162,21 +202,43 @@ pub async fn sso_login<T: Client + TokenClient>(
                         warn!("Failed to load existing token for SSO, proceeding: {e}");
                     }
                 }
+            } else if token_source != ExistingTokenSource::LegacyAuth {
+                let token_action = if is_vercel_login {
+                    classify_existing_sso_token_with_recovery(
+                        Token::existing(token.to_string()),
+                        api_client,
+                        sso_team,
+                        "Using existing Vercel login.",
+                        color_config,
+                    )
+                    .await?
+                } else {
+                    classify_existing_sso_token(
+                        Token::existing(token.to_string()),
+                        api_client,
+                        sso_team,
+                        Some(valid_token_callback("Using existing login.", color_config)),
+                    )
+                    .await?
+                };
+
+                match token_action {
+                    ExistingSSOTokenAction::Reuse(token) => return Ok((token, None)),
+                    ExistingSSOTokenAction::Discard => {}
+                }
             }
         } else if is_vercel_login {
-            match crate::auth::get_token_with_refresh().await {
+            match crate::auth::get_token_with_refresh_for_login().await {
                 Ok(Some(token_secret)) => {
                     if classify_existing_vercel_token(token_secret.expose())?
                         != ExistingTokenSource::LegacyAuth
                     {
-                        match classify_existing_sso_token(
+                        match classify_existing_sso_token_with_recovery(
                             Token::existing_secret(token_secret),
                             api_client,
                             sso_team,
-                            Some(valid_token_callback(
-                                &format!("Using existing login for team: {sso_team}"),
-                                color_config,
-                            )),
+                            &format!("Using existing Vercel login for team: {sso_team}"),
+                            color_config,
                         )
                         .await?
                         {

--- a/crates/turborepo-cache/src/http.rs
+++ b/crates/turborepo-cache/src/http.rs
@@ -22,6 +22,18 @@ use crate::{
 
 pub type UploadMap = HashMap<String, UploadProgressQuery<10, 100>>;
 
+fn replace_api_auth_token(
+    api_auth: &mut APIAuth,
+    token: turborepo_api_client::SecretString,
+) -> bool {
+    if api_auth.token.expose() == token.expose() {
+        return false;
+    }
+
+    api_auth.token = token;
+    true
+}
+
 pub struct HTTPCache {
     client: APIClient,
     signer_verifier: Option<ArtifactSignatureAuthenticator>,
@@ -90,24 +102,36 @@ impl HTTPCache {
     /// 403 forbidden error. Returns true if the token was successfully
     /// refreshed, false otherwise.
     async fn try_refresh_token(&self) -> bool {
-        match turborepo_auth::get_token_with_refresh().await {
+        let current_token = match self.api_auth.lock() {
+            Ok(auth) => auth.token.clone(),
+            Err(_) => {
+                warn!("Failed to acquire lock for reading auth token");
+                return false;
+            }
+        };
+
+        match turborepo_auth::recover_token_after_forbidden(&current_token).await {
             Ok(Some(new_token)) => {
                 // Update the API auth with the new token
                 if let Ok(mut auth) = self.api_auth.lock() {
-                    auth.token = new_token;
-                    debug!("Successfully refreshed auth token for cache operations");
-                    true
+                    if replace_api_auth_token(&mut auth, new_token) {
+                        debug!("Successfully recovered auth token for cache operations");
+                        true
+                    } else {
+                        debug!("Recovered auth token matched the current token; skipping retry");
+                        false
+                    }
                 } else {
                     warn!("Failed to acquire lock for updating auth token");
                     false
                 }
             }
             Ok(None) => {
-                debug!("No refresh token available or token doesn't support refresh");
+                debug!("No replacement token available after forbidden response");
                 false
             }
             Err(e) => {
-                warn!("Failed to refresh token: {:?}", e);
+                warn!("Failed to recover token after forbidden response: {:?}", e);
                 false
             }
         }
@@ -836,10 +860,10 @@ mod test {
         let initial_auth = cache.api_auth.lock().unwrap().clone();
         assert_eq!(initial_auth.token.expose(), "initial-token");
 
-        // Test the token refresh mechanism (without actual HTTP call)
+        // Test the token recovery mechanism (without actual HTTP call)
         // In a real scenario, try_refresh_token would call
-        // turborepo_auth::get_token_with_refresh and update the internal token
-        // if successful
+        // turborepo_auth::recover_token_after_forbidden and update the internal
+        // token if successful.
         let refresh_result = cache.try_refresh_token().await;
 
         // The result depends on system state - could be true or false
@@ -917,6 +941,27 @@ mod test {
             let result = handle.join().unwrap();
             assert!(result.starts_with("thread-"));
         }
+    }
+
+    #[test]
+    fn test_replace_api_auth_token_requires_a_new_token() {
+        let mut api_auth = APIAuth {
+            team_id: Some("my-team".to_string()),
+            token: SecretString::new("initial-token".to_string()),
+            team_slug: None,
+        };
+
+        assert!(!super::replace_api_auth_token(
+            &mut api_auth,
+            SecretString::new("initial-token".to_string())
+        ));
+        assert_eq!(api_auth.token.expose(), "initial-token");
+
+        assert!(super::replace_api_auth_token(
+            &mut api_auth,
+            SecretString::new("replacement-token".to_string())
+        ));
+        assert_eq!(api_auth.token.expose(), "replacement-token");
     }
 
     #[test]

--- a/crates/turborepo-lib/src/commands/link.rs
+++ b/crates/turborepo-lib/src/commands/link.rs
@@ -16,6 +16,7 @@ use dirs_next::home_dir;
 #[cfg(test)]
 use rand::Rng;
 use thiserror::Error;
+use tracing::warn;
 use turborepo_api_client::{CacheClient, Client};
 use turborepo_gitignore::ensure_turbo_is_gitignored;
 use turborepo_json_rewrite::{set_path, unset_path, RewriteError};
@@ -74,6 +75,45 @@ pub(crate) const REMOTE_CACHING_INFO: &str =
      developers and CI/CD systems.\n\nBuild and deploy faster.";
 pub(crate) const REMOTE_CACHING_URL: &str =
     "https://turborepo.dev/docs/core-concepts/remote-caching";
+
+fn is_auth_rejection_error(error: &turborepo_api_client::Error) -> bool {
+    match error {
+        turborepo_api_client::Error::InvalidToken { .. }
+        | turborepo_api_client::Error::ForbiddenToken { .. } => true,
+        turborepo_api_client::Error::UnknownStatus { code, .. } => code == "forbidden",
+        turborepo_api_client::Error::ReqwestError(err) => {
+            err.status() == Some(reqwest::StatusCode::FORBIDDEN)
+        }
+        _ => false,
+    }
+}
+
+async fn retry_with_recovered_token<T, F, Fut>(
+    token: &mut turborepo_api_client::SecretString,
+    operation: F,
+) -> turborepo_api_client::Result<T>
+where
+    F: Fn(turborepo_api_client::SecretString) -> Fut,
+    Fut: std::future::Future<Output = turborepo_api_client::Result<T>>,
+{
+    match operation(token.clone()).await {
+        Ok(result) => Ok(result),
+        Err(err) if is_auth_rejection_error(&err) => {
+            match turborepo_auth::recover_token_after_forbidden(token).await {
+                Ok(Some(recovered_token)) => {
+                    *token = recovered_token;
+                    operation(token.clone()).await
+                }
+                Ok(None) => Err(err),
+                Err(recovery_err) => {
+                    warn!("Failed to recover token for `turbo link`: {recovery_err}");
+                    Err(err)
+                }
+            }
+        }
+        Err(err) => Err(err),
+    }
+}
 
 /// Verifies that caching status for a team is enabled, or prompts the user to
 /// enable it.
@@ -152,7 +192,7 @@ pub async fn link(
     let api_client = base.api_client()?;
 
     // Always try to get a valid token with automatic refresh if expired
-    let token: turborepo_api_client::SecretString =
+    let mut token: turborepo_api_client::SecretString =
         match turborepo_auth::get_token_with_refresh().await {
             Ok(Some(refreshed_token)) => refreshed_token,
             Ok(None) | Err(_) => {
@@ -178,10 +218,12 @@ pub async fn link(
         return Err(Error::NotLinking);
     }
 
-    let user_response = api_client
-        .get_user(&token)
-        .await
-        .map_err(Error::UserNotFound)?;
+    let user_response = retry_with_recovered_token(&mut token, |token| {
+        let api_client = &api_client;
+        async move { api_client.get_user(&token).await }
+    })
+    .await
+    .map_err(Error::UserNotFound)?;
 
     let user_display_name = user_response
         .user
@@ -189,10 +231,12 @@ pub async fn link(
         .as_deref()
         .unwrap_or(user_response.user.username.as_str());
 
-    let teams_response = api_client
-        .get_teams(&token)
-        .await
-        .map_err(Error::TeamsRequest)?;
+    let teams_response = retry_with_recovered_token(&mut token, |token| {
+        let api_client = &api_client;
+        async move { api_client.get_teams(&token).await }
+    })
+    .await
+    .map_err(Error::TeamsRequest)?;
 
     let selected_team = if let Some(team_slug) = scope {
         SelectedTeam::Team(


### PR DESCRIPTION
- Recover rejected or expired Vercel tokens across `turbo login`, `turbo sso`, `turbo link`, and remote-cache retry paths instead of surfacing raw auth failures or reusing bad tokens
- Upgrade reusable legacy/config-backed Vercel tokens into Turbo OAuth state when possible, but fall back to a fresh login when Vercel rejects token exchange for login flows
- Reduce duplicate recovery warnings and add regression coverage for refresh, backfill, exchange, and forbidden-response branches