### PR TITLE
docs: Fix TURBO_PLATFORM_ENV_DISABLED value in docs (true, not false)

### DIFF
--- a/apps/docs/content/docs/crafting-your-repository/using-environment-variables.mdx
+++ b/apps/docs/content/docs/crafting-your-repository/using-environment-variables.mdx
@@ -144,7 +144,7 @@ When you're using Loose Mode, `MY_API_URL` is available in the task runtime **ev
 When deploying your application to [Vercel](https://vercel.com/new?ref=turborepo), you likely already have [environment variables](https://vercel.com/docs/projects/environment-variables) configured on your project. Turborepo will automatically check these variables against your `turbo.json` configuration to ensure that you've [accounted for them](#adding-environment-variables-to-task-hashes),
 and will warn you about any missing variables.
 
-This functionality can be disabled by setting `TURBO_PLATFORM_ENV_DISABLED=false`
+This functionality can be disabled by setting `TURBO_PLATFORM_ENV_DISABLED=true`
 
 ## Handling `.env` files
 


### PR DESCRIPTION
The docs incorrectly state that setting `TURBO_PLATFORM_ENV_DISABLED` to `false` disables platform env vars. The correct value is `true`.

Fixes #12619