### PR TITLE
docs: Fix TURBO_PLATFORM_ENV_DISABLED value (must be 'true', not 'false')

### DIFF
--- a/apps/docs/content/docs/crafting-your-repository/using-environment-variables.mdx
+++ b/apps/docs/content/docs/crafting-your-repository/using-environment-variables.mdx
@@ -144,7 +144,7 @@ When you're using Loose Mode, `MY_API_URL` is available in the task runtime **ev
 When deploying your application to [Vercel](https://vercel.com/new?ref=turborepo), you likely already have [environment variables](https://vercel.com/docs/projects/environment-variables) configured on your project. Turborepo will automatically check these variables against your `turbo.json` configuration to ensure that you've [accounted for them](#adding-environment-variables-to-task-hashes),
 and will warn you about any missing variables.
 
-This functionality can be disabled by setting `TURBO_PLATFORM_ENV_DISABLED=false`
+This functionality can be disabled by setting `TURBO_PLATFORM_ENV_DISABLED=true`
 
 ## Handling `.env` files
 


### PR DESCRIPTION
## Summary

Corrects the docs example for `TURBO_PLATFORM_ENV_DISABLED` — the variable must be set to `true` to disable platform environment variables. The previous example incorrectly showed `false`.

Closes #12619

## Details

The `TURBO_PLATFORM_ENV_DISABLED` docs had an incorrect example value. As noted in #12619, setting it to `false` has no effect — it must be `true` to disable platform env var passthrough. This is a one-word fix in the documentation.