### PR TITLE
fix(change-mapper): resolve catalog: protocol when diffing Berry lockfile

### DIFF
--- a/crates/turborepo-repository/src/change_mapper/mod.rs
+++ b/crates/turborepo-repository/src/change_mapper/mod.rs
@@ -14,6 +14,8 @@ use tracing::debug;
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf};
 use wax::Program;
 
+use crate::package_manager::{yarnrc, PackageManager};
+
 use crate::package_graph::{
     ChangedPackagesError, ExternalDependencyChange, PackageGraph, PackageName, WorkspacePackage,
 };
@@ -266,12 +268,23 @@ impl<'a, PD: PackageChangeMapper> ChangeMapper<'a, PD> {
         &self,
         lockfile_content: &[u8],
     ) -> Result<Vec<ExternalDependencyChange>, ChangeMapError> {
-        // We pass None for yarnrc since we're only comparing lockfiles for changes,
-        // not resolving package dependencies. Catalog resolution isn't needed here.
+        // For Berry (Yarn 4) repos that use the `catalog:` protocol we must
+        // resolve catalog entries when parsing the *previous* lockfile so that
+        // version strings are comparable across both snapshots.  Without this
+        // the catalog: literal survives as-is on one side of the diff, causing
+        // every cataloged dependency to appear as changed even when it is not.
+        let yarnrc = if matches!(self.pkg_graph.package_manager(), PackageManager::Berry) {
+            yarnrc::YarnRc::from_file(self.pkg_graph.repo_root())
+                .inspect_err(|e| debug!("unable to read yarnrc for lockfile diff: {e}"))
+                .ok()
+        } else {
+            None
+        };
+
         let previous_lockfile = self.pkg_graph.package_manager().parse_lockfile(
             self.pkg_graph.root_package_json(),
             lockfile_content,
-            None,
+            yarnrc,
         )?;
 
         let additional_packages = self

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -376,6 +376,10 @@ impl PackageGraph {
             .expect("package graph was built without root package.json")
     }
 
+    pub fn repo_root(&self) -> &AbsoluteSystemPath {
+        &self.repo_root
+    }
+
     /// Gets all the nodes that directly depend on this one, that is to say
     /// have a edge to `package`.
     ///


### PR DESCRIPTION
## Problem

When a Yarn 4 (Berry) repo uses the `catalog:` protocol in `package.json`, `turbo query affectedPackages` reports empty `LockfileChanged` deltas even after dependencies actually change.

**Root cause:** `ChangeMapper::get_changed_packages_from_lockfile` always passes `None` for `yarnrc` when parsing the previous lockfile snapshot. This means the `catalog:` protocol specifiers are left as literal strings instead of being resolved to actual version ranges, so the two lockfile snapshots never produce matching keys and the diff returns nothing.

The same fix was already applied to the *current* lockfile path (`PackageManager::get_lockfile` in #11115 / #12185) but not to the comparison lockfile used for change detection.

## Fix

- Add `PackageGraph::repo_root()` accessor (the field was already stored privately, just unexposed).
- In `get_changed_packages_from_lockfile`, when the package manager is Berry, read `.yarnrc.yml` from the repo root and pass it to `parse_lockfile` — the same pattern used by `PackageManager::get_lockfile`.

Fixes #12635