### PR TITLE
fix(prune): create empty bin stub files in docker json directory

### DIFF
--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -161,7 +161,7 @@ pub async fn prune(
 
         // We don't want to do any copying for the root workspace
         if let PackageName::Other(workspace) = workspace {
-            prune.copy_workspace(entry.package_json_path())?;
+            prune.copy_workspace(entry.package_json_path(), &entry.package_json)?;
             workspace_paths.push(
                 entry
                     .package_json_path()
@@ -487,7 +487,7 @@ impl<'a> Prune<'a> {
         Ok(())
     }
 
-    fn copy_workspace(&self, package_json_path: &AnchoredSystemPath) -> Result<(), Error> {
+    fn copy_workspace(&self, package_json_path: &AnchoredSystemPath, pkg_json: &PackageJson) -> Result<(), Error> {
         let package_json_path = self.root.resolve(package_json_path);
         let original_dir = package_json_path
             .parent()
@@ -517,6 +517,44 @@ impl<'a> Prune<'a> {
                     )?;
                 }
             }
+
+            // Create empty stub files for bin entries so pnpm generates .bin shims
+            self.create_docker_bin_stubs(&docker_workspace_dir, pkg_json)?;
+        }
+
+        Ok(())
+    }
+
+    fn create_docker_bin_stubs(
+        &self,
+        docker_workspace_dir: &AbsoluteSystemPathBuf,
+        pkg_json: &PackageJson,
+    ) -> Result<(), Error> {
+        let Some(bin_value) = pkg_json.other.get("bin") else {
+            return Ok(());
+        };
+
+        let bin_paths: Vec<String> = match bin_value {
+            serde_json::Value::String(path) => vec![path.clone()],
+            serde_json::Value::Object(map) => map
+                .values()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect(),
+            _ => return Ok(()),
+        };
+
+        for bin_path in bin_paths {
+            // Strip leading "./" if present
+            let normalized = bin_path.trim_start_matches("./");
+            // Use join_unix_path to handle multi-segment paths (e.g. "dist/index.js")
+            let Ok(relative) = RelativeUnixPathBuf::new(normalized) else {
+                trace!("Skipping invalid bin path: {normalized}");
+                continue;
+            };
+            let stub_path = docker_workspace_dir.join_unix_path(&relative);
+            // Create parent directories and then an empty stub file
+            stub_path.ensure_dir()?;
+            stub_path.create_with_contents(b"")?;
         }
 
         Ok(())

--- a/crates/turborepo/tests/prune_test.rs
+++ b/crates/turborepo/tests/prune_test.rs
@@ -687,6 +687,61 @@ fn test_prune_pnpm_per_workspace_lockfile_docker() {
 }
 
 #[test]
+fn test_prune_docker_bin_stubs() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(
+        tempdir.path(),
+        "monorepo_with_bin",
+        "pnpm@9.0.0",
+        false,
+    )
+    .unwrap();
+
+    let output = run_turbo(tempdir.path(), &["prune", "web", "--docker"]);
+    assert!(
+        output.status.success(),
+        "prune failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json_dir = tempdir.path().join("out/json");
+
+    // cli package: bin as object -> "my-cli": "./dist/index.js"
+    let cli_stub = json_dir.join("packages/cli/dist/index.js");
+    assert!(
+        cli_stub.exists(),
+        "bin stub for cli/dist/index.js not created in docker json dir"
+    );
+    assert_eq!(
+        fs::read(&cli_stub).unwrap(),
+        b"",
+        "bin stub should be empty"
+    );
+
+    // single-bin package: bin as string -> "./bin/run.js"
+    let single_stub = json_dir.join("packages/single-bin/bin/run.js");
+    assert!(
+        single_stub.exists(),
+        "bin stub for single-bin/bin/run.js not created in docker json dir"
+    );
+    assert_eq!(
+        fs::read(&single_stub).unwrap(),
+        b"",
+        "bin stub should be empty"
+    );
+
+    // Verify the full dir has the REAL files (not stubs)
+    let full_cli = tempdir.path().join("out/full/packages/cli/dist/index.js");
+    assert!(full_cli.exists(), "real cli file should exist in full dir");
+    assert_ne!(
+        fs::read(&full_cli).unwrap(),
+        b"",
+        "real file in full dir should not be empty"
+    );
+}
+
+#[test]
 fn test_prune_pnpm_v11_multi_document_lockfile() {
     let tempdir = tempfile::tempdir().unwrap();
     setup::copy_fixture("pnpm_v11_multi_document_lockfile", tempdir.path()).unwrap();

--- a/turborepo-tests/integration/fixtures/monorepo_with_bin/apps/web/package.json
+++ b/turborepo-tests/integration/fixtures/monorepo_with_bin/apps/web/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "web",
+  "version": "0.0.1",
+  "dependencies": {
+    "cli": "workspace:*",
+    "single-bin": "workspace:*"
+  }
+}

--- a/turborepo-tests/integration/fixtures/monorepo_with_bin/package.json
+++ b/turborepo-tests/integration/fixtures/monorepo_with_bin/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "monorepo-with-bin",
+  "private": true,
+  "devDependencies": {
+    "turbo": "latest"
+  }
+}

--- a/turborepo-tests/integration/fixtures/monorepo_with_bin/packages/cli/dist/index.js
+++ b/turborepo-tests/integration/fixtures/monorepo_with_bin/packages/cli/dist/index.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log("hello");

--- a/turborepo-tests/integration/fixtures/monorepo_with_bin/packages/cli/package.json
+++ b/turborepo-tests/integration/fixtures/monorepo_with_bin/packages/cli/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "cli",
+  "version": "1.0.0",
+  "bin": {
+    "my-cli": "./dist/index.js"
+  }
+}

--- a/turborepo-tests/integration/fixtures/monorepo_with_bin/packages/single-bin/bin/run.js
+++ b/turborepo-tests/integration/fixtures/monorepo_with_bin/packages/single-bin/bin/run.js
@@ -1,0 +1,1 @@
+#!/usr/bin/env node

--- a/turborepo-tests/integration/fixtures/monorepo_with_bin/packages/single-bin/package.json
+++ b/turborepo-tests/integration/fixtures/monorepo_with_bin/packages/single-bin/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "single-bin",
+  "version": "1.0.0",
+  "bin": "./bin/run.js"
+}

--- a/turborepo-tests/integration/fixtures/monorepo_with_bin/pnpm-lock.yaml
+++ b/turborepo-tests/integration/fixtures/monorepo_with_bin/pnpm-lock.yaml
@@ -1,0 +1,31 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      turbo:
+        specifier: latest
+        version: 2.0.0
+
+  apps/web:
+    dependencies:
+      cli:
+        specifier: workspace:*
+        version: link:../../packages/cli
+      single-bin:
+        specifier: workspace:*
+        version: link:../../packages/single-bin
+
+  packages/cli: {}
+
+  packages/single-bin: {}
+
+packages:
+
+  turbo@2.0.0:
+    resolution: {integrity: sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa==}

--- a/turborepo-tests/integration/fixtures/monorepo_with_bin/pnpm-workspace.yaml
+++ b/turborepo-tests/integration/fixtures/monorepo_with_bin/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "apps/*"
+  - "packages/*"

--- a/turborepo-tests/integration/fixtures/monorepo_with_bin/turbo.json
+++ b/turborepo-tests/integration/fixtures/monorepo_with_bin/turbo.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {}
+  }
+}


### PR DESCRIPTION
## Summary

When using `turbo prune --docker`, pnpm requires bin entry source files to exist in the `json` folder in order to generate `.bin` shims during `pnpm install`. Without these stubs, the Docker multi-stage build pattern (`copy json → pnpm install → copy full → turbo build`) fails when a pruned workspace depends on a tool from another workspace.

This change adds logic to detect `bin` entries in each workspace's `package.json` and creates **empty stub files** at the referenced paths within the docker `json` directory. The stubs are zero-byte files — their mere presence is sufficient for pnpm to create `.bin` shims.

The full source files are still copied to `out/full` as before; only zero-byte stubs are placed in `out/json`.

## Changes

- `crates/turborepo-lib/src/commands/prune.rs`: Added `create_docker_bin_stubs` method, called from `copy_workspace` when in docker mode
- New test fixture `turborepo-tests/integration/fixtures/monorepo_with_bin/` with packages using both string and object `bin` fields
- New test `test_prune_docker_bin_stubs` verifying stubs are created correctly

Fixes #12610