### PR TITLE
docs: Fix link to passthrough variables source code

### DIFF
--- a/apps/docs/content/docs/reference/configuration.mdx
+++ b/apps/docs/content/docs/reference/configuration.mdx
@@ -79,7 +79,7 @@ For more on wildcard and negation syntax, [see the `env` section](#env).
 
 A list of environment variables that you want to make available to tasks. Using this key opts all tasks into [Strict Environment Variable Mode](/docs/crafting-your-repository/using-environment-variables#strict-mode).
 
-Additionally, Turborepo has a built-in set of global passthrough variables for common cases, like operating system environment variables. This includes variables like `HOME`, `PATH`, `APPDATA`, `SHELL`, `PWD`, and more. The full list can be found [in the source code](https://github.com/vercel/turborepo/blob/main/crates/turborepo-lib/src/task_hash.rs).
+Additionally, Turborepo has a built-in set of global passthrough variables for common cases, like operating system environment variables. This includes variables like `HOME`, `PATH`, `APPDATA`, `SHELL`, `PWD`, and more. The full list can be found [in the source code](https://github.com/vercel/turborepo/blob/main/crates/turborepo-env/src/lib.rs).
 
 <Callout
   type="warn"


### PR DESCRIPTION

### Description
The link to the file containing all built-in passthrough variables opens a file that doesn't contain them. `lib.rs` does contain `BUILTIN_PASS_THROUGH_ENV`

