### PR TITLE
chore: Update flags SDK

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@ai-sdk/react": "^2.0.115",
-    "@flags-sdk/vercel": "^0.1.8",
+    "@flags-sdk/vercel": "^1.3.0",
     "@hookform/resolvers": "^5.2.2",
     "@icons-pack/react-simple-icons": "^13.8.0",
     "@orama/tokenizers": "^3.1.16",
@@ -39,7 +39,7 @@
     "dexie-react-hooks": "^4.2.0",
     "embla-carousel-react": "^8.6.0",
     "feed": "^5.1.0",
-    "flags": "^4.0.2",
+    "flags": "^4.0.6",
     "fumadocs-core": "16.7.11",
     "fumadocs-mdx": "14.2.6",
     "fumadocs-openapi": "^10.6.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^2.0.115
         version: 2.0.130(react@19.2.4)(zod@4.3.6)
       '@flags-sdk/vercel':
-        specifier: ^0.1.8
-        version: 0.1.8(@opentelemetry/api@1.9.0)(flags@4.0.2(@opentelemetry/api@1.9.0)(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        specifier: ^1.3.0
+        version: 1.3.0(flags@4.0.6(@opentelemetry/api@1.9.0)(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.71.1(react@19.2.4))
@@ -102,8 +102,8 @@ importers:
         specifier: ^5.1.0
         version: 5.2.0
       flags:
-        specifier: ^4.0.2
-        version: 4.0.2(@opentelemetry/api@1.9.0)(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^4.0.6
+        version: 4.0.6(@opentelemetry/api@1.9.0)(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       fumadocs-core:
         specifier: 16.7.11
         version: 16.7.11(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.13)(lucide-react@0.555.0(react@19.2.4))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
@@ -377,7 +377,7 @@ importers:
         version: 20.11.30
       bunchee:
         specifier: 6.9.4
-        version: 6.9.4(typescript@5.9.3)
+        version: 6.9.4(typescript@5.5.4)
       eslint:
         specifier: 10.2.0
         version: 10.2.0(jiti@2.6.1)
@@ -1586,8 +1586,8 @@ packages:
   '@fastify/deepmerge@3.2.1':
     resolution: {integrity: sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==}
 
-  '@flags-sdk/vercel@0.1.8':
-    resolution: {integrity: sha512-V4Ek26i7Kuv2EMjZ0S4hqWsiZoybdfz0Kww0Nsr3cr/m76Z1IVrU6wWuaYFduLUzc40pcDqhTpMHGZB6+xYqDw==}
+  '@flags-sdk/vercel@1.3.0':
+    resolution: {integrity: sha512-IGwC8ye94+CnOYDxIdic1f2wZLbJQ67zXacD3J1/UWErcPdjtfp44RG23Qb9WujJ2VJbB8bzLdZ6R89nALtDeg==}
     peerDependencies:
       flags: '*'
 
@@ -4456,28 +4456,24 @@ packages:
       vue-router:
         optional: true
 
-  '@vercel/edge-config-fs@0.1.0':
-    resolution: {integrity: sha512-NRIBwfcS0bUoUbRWlNGetqjvLSwgYH/BqKqDN7vK1g32p7dN96k0712COgaz6VFizAm9b0g6IG6hR6+hc0KCPg==}
-
-  '@vercel/edge-config@1.4.3':
-    resolution: {integrity: sha512-8vTDATodRrH49wMzKEjZ8/5H2qs1aPkD0uRK585f/Fx4YN2wfHfY/3td9OFrh+gdnCq07z8A5f0hoY6xhBcPkg==}
-    engines: {node: '>=14.6'}
+  '@vercel/flags-core@1.4.0':
+    resolution: {integrity: sha512-VeWaNAMZoBmOC5B0POjYXkuP+Llt9MtMDg0DFJObBRLKQ/zTtc9lY4hVVcOIx1JjJmO3JKMZDv43WtX/1jDbmg==}
     peerDependencies:
-      '@opentelemetry/api': ^1.7.0
-      next: '>=1'
+      '@openfeature/server-sdk': 1.18.0
+      next: '*'
     peerDependenciesMeta:
-      '@opentelemetry/api':
+      '@openfeature/server-sdk':
         optional: true
       next:
         optional: true
 
-  '@vercel/flags-core@0.1.8':
-    resolution: {integrity: sha512-tFdHFpvlrKvfXdxjM5Xyi6vpDg6y23tqQgnqfvleGuw+T5NZz2LX+WYh3D/DUJzGGWAxZt1/aZ+0SKlIjdG0lA==}
+  '@vercel/functions@3.4.4':
+    resolution: {integrity: sha512-mdmCTMxAUTT5GMSs/iS4EuovzoofXNbb44/iPFwlgqulnJg3FEf6Sk46kLlZL4zuTTJQPT5YPTdBgZVlYZ5Azg==}
+    engines: {node: '>= 20'}
     peerDependencies:
-      '@openfeature/server-sdk': 1.18.0
-      flags: '*'
+      '@aws-sdk/credential-provider-web-identity': '*'
     peerDependenciesMeta:
-      '@openfeature/server-sdk':
+      '@aws-sdk/credential-provider-web-identity':
         optional: true
 
   '@vercel/oidc@3.1.0':
@@ -4486,6 +4482,10 @@ packages:
 
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
+  '@vercel/oidc@3.2.1':
+    resolution: {integrity: sha512-UUqZ2y+VXHgVH1Luoo+477/NcrO4X+ln38U70ldRgGiWJAuHhtjTm7cCAnyLkl2feg7ZmTBK3F1kvJKFEQc01w==}
     engines: {node: '>= 20'}
 
   '@vercel/sandbox@2.0.0-beta.13':
@@ -5601,8 +5601,8 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
-  flags@4.0.2:
-    resolution: {integrity: sha512-qNMPc10TKe/5pA0evWxS0vDm3AMpicB7uf6e/+828chNAWUoVziRJfyOcBWwadl4zBhmTfPz+hxTVpNKF7+/PA==}
+  flags@4.0.6:
+    resolution: {integrity: sha512-8Rz/5L8Gkl2+LmlV2gOXx3iJNTYDooa8eGvshFev9nrXtrcvsXa5z/DXdtElHvN15psnSHg+r51lYHge2rCASw==}
     peerDependencies:
       '@opentelemetry/api': ^1.7.0
       '@sveltejs/kit': '*'
@@ -9030,16 +9030,13 @@ snapshots:
 
   '@fastify/deepmerge@3.2.1': {}
 
-  '@flags-sdk/vercel@0.1.8(@opentelemetry/api@1.9.0)(flags@4.0.2(@opentelemetry/api@1.9.0)(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@flags-sdk/vercel@1.3.0(flags@4.0.6(@opentelemetry/api@1.9.0)(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
-      '@vercel/edge-config': 1.4.3(@opentelemetry/api@1.9.0)(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
-      '@vercel/flags-core': 0.1.8(@opentelemetry/api@1.9.0)(flags@4.0.2(@opentelemetry/api@1.9.0)(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
-      flags: 4.0.2(@opentelemetry/api@1.9.0)(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      jose: 5.2.1
-      js-xxhash: 4.0.0
+      '@vercel/flags-core': 1.4.0(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      flags: 4.0.6(@opentelemetry/api@1.9.0)(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-web-identity'
       - '@openfeature/server-sdk'
-      - '@opentelemetry/api'
       - next
 
   '@floating-ui/core@1.7.4':
@@ -11729,28 +11726,25 @@ snapshots:
       next: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
 
-  '@vercel/edge-config-fs@0.1.0': {}
-
-  '@vercel/edge-config@1.4.3(@opentelemetry/api@1.9.0)(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@vercel/flags-core@1.4.0(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
-      '@vercel/edge-config-fs': 0.1.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-      next: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-
-  '@vercel/flags-core@0.1.8(@opentelemetry/api@1.9.0)(flags@4.0.2(@opentelemetry/api@1.9.0)(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
-    dependencies:
-      '@vercel/edge-config': 1.4.3(@opentelemetry/api@1.9.0)(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
-      flags: 4.0.2(@opentelemetry/api@1.9.0)(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@vercel/functions': 3.4.4
       jose: 5.2.1
       js-xxhash: 4.0.0
+    optionalDependencies:
+      next: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - next
+      - '@aws-sdk/credential-provider-web-identity'
+
+  '@vercel/functions@3.4.4':
+    dependencies:
+      '@vercel/oidc': 3.2.1
 
   '@vercel/oidc@3.1.0': {}
 
   '@vercel/oidc@3.2.0': {}
+
+  '@vercel/oidc@3.2.1': {}
 
   '@vercel/sandbox@2.0.0-beta.13':
     dependencies:
@@ -12042,7 +12036,7 @@ snapshots:
     dependencies:
       semver: 7.7.3
 
-  bunchee@6.9.4(typescript@5.9.3):
+  bunchee@6.9.4(typescript@5.5.4):
     dependencies:
       '@rollup/plugin-commonjs': 29.0.2(rollup@4.59.0)
       '@rollup/plugin-json': 6.1.0(rollup@4.59.0)
@@ -12058,14 +12052,14 @@ snapshots:
       picomatch: 4.0.4
       pretty-bytes: 5.6.0
       rollup: 4.59.0
-      rollup-plugin-dts: 6.3.0(rollup@4.59.0)(typescript@5.9.3)
+      rollup-plugin-dts: 6.3.0(rollup@4.59.0)(typescript@5.5.4)
       rollup-plugin-swc3: 0.11.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(rollup@4.59.0)
       rollup-preserve-directives: 1.1.3(rollup@4.59.0)
       tinyglobby: 0.2.15
       tslib: 2.8.1
       yargs: 17.7.2
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 5.5.4
 
   cac@6.7.14: {}
 
@@ -12925,7 +12919,7 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
-  flags@4.0.2(@opentelemetry/api@1.9.0)(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  flags@4.0.6(@opentelemetry/api@1.9.0)(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@edge-runtime/cookies': 5.0.2
       jose: 5.10.0
@@ -15724,11 +15718,11 @@ snapshots:
       '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.9
       '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.9
 
-  rollup-plugin-dts@6.3.0(rollup@4.59.0)(typescript@5.9.3):
+  rollup-plugin-dts@6.3.0(rollup@4.59.0)(typescript@5.5.4):
     dependencies:
       magic-string: 0.30.21
       rollup: 4.59.0
-      typescript: 5.9.3
+      typescript: 5.5.4
     optionalDependencies:
       '@babel/code-frame': 7.29.0
 


### PR DESCRIPTION
Part of [FLA-2789](https://linear.app/vercel/issue/FLA-2789).

This PR updates the flags SDK packages because the `FLAGS` environment variable format changed; some earlier SDK releases are incompatible with the new format, and two adapter package names have been deprecated.

## Changes
- Replace `@vercel-private/flags-adapter-native` / `@vercel/flags-adapter-native` with `@flags-sdk/vercel@1.3.0`.
- Bump `flags` to `4.0.6` where below.
- Lockfile regenerated automatically.

## Affected package.json files
- `apps/docs/package.json`

## Affected Vercel projects using this repo
- vercel/turbo-site

## Follow-up
- After merging, trigger a fresh deployment so the new `FLAGS` env var format takes effect.

_Opened automatically by `sec-inc/3-flags-sdk-update-prs.ts`._