### PR TITLE
ci: Disable AWS-backed sccache

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -78,15 +78,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      SCCACHE_BUCKET: turborepo-sccache
-      SCCACHE_REGION: us-east-2
-      RUSTC_WRAPPER: ${{ !github.event.pull_request.head.repo.fork && 'sccache' || '' }}
+      # AWS-backed sccache is disabled.
+      # SCCACHE_BUCKET: turborepo-sccache
+      # SCCACHE_REGION: us-east-2
+      # RUSTC_WRAPPER: ${{ !github.event.pull_request.head.repo.fork && 'sccache' || '' }}
       CARGO_INCREMENTAL: 0
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SCCACHE_IDLE_TIMEOUT: 0
-      SCCACHE_REQUEST_TIMEOUT: 30
-      SCCACHE_ERROR_LOG: error
+      # AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      # SCCACHE_IDLE_TIMEOUT: 0
+      # SCCACHE_REQUEST_TIMEOUT: 30
+      # SCCACHE_ERROR_LOG: error
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -97,15 +98,11 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           node: "false"
 
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
+      # - name: Run sccache-cache
+      #   uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Run cargo clippy
-        run: |
-          if [ -z "${RUSTC_WRAPPER}" ]; then
-            unset RUSTC_WRAPPER
-          fi
-          cargo lint
+        run: cargo lint
 
   rust_licenses:
     name: Rust licenses

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -166,15 +166,16 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       TURBO_CACHE: remote:rw
-      SCCACHE_BUCKET: turborepo-sccache
-      SCCACHE_REGION: us-east-2
-      RUSTC_WRAPPER: ${{ !github.event.pull_request.head.repo.fork && 'sccache' || '' }}
+      # AWS-backed sccache is disabled.
+      # SCCACHE_BUCKET: turborepo-sccache
+      # SCCACHE_REGION: us-east-2
+      # RUSTC_WRAPPER: ${{ !github.event.pull_request.head.repo.fork && 'sccache' || '' }}
       CARGO_INCREMENTAL: 0
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SCCACHE_IDLE_TIMEOUT: 0
-      SCCACHE_REQUEST_TIMEOUT: 30
-      SCCACHE_ERROR_LOG: error
+      # AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      # SCCACHE_IDLE_TIMEOUT: 0
+      # SCCACHE_REQUEST_TIMEOUT: 30
+      # SCCACHE_ERROR_LOG: error
     steps:
       - name: Install git (Windows larger runners)
         shell: cmd
@@ -205,8 +206,8 @@ jobs:
           node-version: "18.20.2"
           package-install: "false"
 
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
+      # - name: Run sccache-cache
+      #   uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Install cargo-nextest
         shell: cmd
@@ -218,11 +219,7 @@ jobs:
         uses: ./.github/actions/install-global-turbo
 
       - name: Build and archive test binaries
-        run: |
-          if [ -z "${RUSTC_WRAPPER}" ]; then
-            unset RUSTC_WRAPPER
-          fi
-          turbo run build:test-archive --filter=@turbo/cli
+        run: turbo run build:test-archive --filter=@turbo/cli
         shell: bash
 
   build_rust_test_macos:
@@ -236,15 +233,16 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       TURBO_CACHE: remote:rw
-      SCCACHE_BUCKET: turborepo-sccache
-      SCCACHE_REGION: us-east-2
-      RUSTC_WRAPPER: ${{ !github.event.pull_request.head.repo.fork && 'sccache' || '' }}
+      # AWS-backed sccache is disabled.
+      # SCCACHE_BUCKET: turborepo-sccache
+      # SCCACHE_REGION: us-east-2
+      # RUSTC_WRAPPER: ${{ !github.event.pull_request.head.repo.fork && 'sccache' || '' }}
       CARGO_INCREMENTAL: 0
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SCCACHE_IDLE_TIMEOUT: 0
-      SCCACHE_REQUEST_TIMEOUT: 30
-      SCCACHE_ERROR_LOG: error
+      # AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      # SCCACHE_IDLE_TIMEOUT: 0
+      # SCCACHE_REQUEST_TIMEOUT: 30
+      # SCCACHE_ERROR_LOG: error
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -256,8 +254,8 @@ jobs:
           node-version: "18.20.2"
           package-install: "false"
 
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
+      # - name: Run sccache-cache
+      #   uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532
@@ -268,11 +266,7 @@ jobs:
         uses: ./.github/actions/install-global-turbo
 
       - name: Build and archive test binaries
-        run: |
-          if [ -z "${RUSTC_WRAPPER}" ]; then
-            unset RUSTC_WRAPPER
-          fi
-          turbo run build:test-archive --filter=@turbo/cli
+        run: turbo run build:test-archive --filter=@turbo/cli
         shell: bash
 
   rust_test_macos:
@@ -398,15 +392,16 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       TURBO_CACHE: remote:rw
-      SCCACHE_BUCKET: turborepo-sccache
-      SCCACHE_REGION: us-east-2
-      RUSTC_WRAPPER: ${{ !github.event.pull_request.head.repo.fork && 'sccache' || '' }}
+      # AWS-backed sccache is disabled.
+      # SCCACHE_BUCKET: turborepo-sccache
+      # SCCACHE_REGION: us-east-2
+      # RUSTC_WRAPPER: ${{ !github.event.pull_request.head.repo.fork && 'sccache' || '' }}
       CARGO_INCREMENTAL: 0
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      SCCACHE_IDLE_TIMEOUT: 0
-      SCCACHE_REQUEST_TIMEOUT: 30
-      SCCACHE_ERROR_LOG: error
+      # AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      # SCCACHE_IDLE_TIMEOUT: 0
+      # SCCACHE_REQUEST_TIMEOUT: 30
+      # SCCACHE_ERROR_LOG: error
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -418,8 +413,8 @@ jobs:
           node-version: "18.20.2"
           package-install: "false"
 
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
+      # - name: Run sccache-cache
+      #   uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532
@@ -430,11 +425,7 @@ jobs:
         uses: ./.github/actions/install-global-turbo
 
       - name: Build and archive test binaries
-        run: |
-          if [ -z "${RUSTC_WRAPPER}" ]; then
-            unset RUSTC_WRAPPER
-          fi
-          turbo run build:test-archive --filter=@turbo/cli
+        run: turbo run build:test-archive --filter=@turbo/cli
         shell: bash
 
   rust_test_ubuntu:
@@ -535,12 +526,13 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       TURBO_CACHE: remote:rw
-      SCCACHE_BUCKET: turborepo-sccache
-      SCCACHE_REGION: us-east-2
-      RUSTC_WRAPPER: ${{ !github.event.pull_request.head.repo.fork && 'sccache' || '' }}
+      # AWS-backed sccache is disabled.
+      # SCCACHE_BUCKET: turborepo-sccache
+      # SCCACHE_REGION: us-east-2
+      # RUSTC_WRAPPER: ${{ !github.event.pull_request.head.repo.fork && 'sccache' || '' }}
       CARGO_INCREMENTAL: 0
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      # AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -553,8 +545,8 @@ jobs:
       - name: Install Bun
         uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
 
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
+      # - name: Run sccache-cache
+      #   uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Build turbo binary
         run: cargo build

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -160,7 +160,9 @@ jobs:
     timeout-minutes: 45
     needs:
       - find-changes
-    if: ${{ needs.find-changes.outputs.is-release-pr != 'true' && needs.find-changes.outputs.rust == 'true' }}
+    # Prebuilding test archives depends on Turborepo remote cache auth, which is disabled for now.
+    # if: ${{ needs.find-changes.outputs.is-release-pr != 'true' && needs.find-changes.outputs.rust == 'true' }}
+    if: ${{ false }}
     name: Build test artifacts (windows)
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -227,7 +229,9 @@ jobs:
     timeout-minutes: 45
     needs:
       - find-changes
-    if: ${{ needs.find-changes.outputs.is-release-pr != 'true' && needs.find-changes.outputs.rust == 'true' }}
+    # Prebuilding test archives depends on Turborepo remote cache auth, which is disabled for now.
+    # if: ${{ needs.find-changes.outputs.is-release-pr != 'true' && needs.find-changes.outputs.rust == 'true' }}
+    if: ${{ false }}
     name: Build test artifacts (macos)
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -274,7 +278,7 @@ jobs:
     timeout-minutes: 45
     needs:
       - find-changes
-      - build_rust_test_macos
+      # - build_rust_test_macos
     if: ${{ needs.find-changes.outputs.is-release-pr != 'true' && needs.find-changes.outputs.rust == 'true' }}
     strategy:
       fail-fast: false
@@ -303,13 +307,14 @@ jobs:
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo
 
-      - name: Restore test archive from cache
+      - name: Build test archive
         run: turbo run build:test-archive --filter=@turbo/cli
         shell: bash
-        env:
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-          TURBO_CACHE: remote:rw
+        # Remote cache is not authed right now; build locally instead.
+        # env:
+        #   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+        #   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+        #   TURBO_CACHE: remote:rw
 
       - name: Run tests
         timeout-minutes: 45
@@ -326,7 +331,7 @@ jobs:
     timeout-minutes: 45
     needs:
       - find-changes
-      - build_rust_test_windows
+      # - build_rust_test_windows
     if: ${{ needs.find-changes.outputs.is-release-pr != 'true' && needs.find-changes.outputs.rust == 'true' }}
     name: Rust testing on windows (partition ${{ matrix.partition }}/10)
     steps:
@@ -348,10 +353,11 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           node-version: "18.20.2"
-          capnproto: ${{ github.event.pull_request.head.repo.fork && 'true' || 'false' }}
-          rust: ${{ github.event.pull_request.head.repo.fork && 'true' || 'false' }}
+          # Local archive builds need Rust and capnproto even when remote cache is unavailable.
+          # capnproto: ${{ github.event.pull_request.head.repo.fork && 'true' || 'false' }}
+          # rust: ${{ github.event.pull_request.head.repo.fork && 'true' || 'false' }}
           package-install: "false"
-          rust-cache: "false"
+          rust-cache: "true"
 
       - name: Install Bun
         uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
@@ -365,13 +371,14 @@ jobs:
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo
 
-      - name: Restore test archive from cache
+      - name: Build test archive
         run: turbo run build:test-archive --filter=@turbo/cli
         shell: bash
-        env:
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-          TURBO_CACHE: remote:rw
+        # Remote cache is not authed right now; build locally instead.
+        # env:
+        #   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+        #   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+        #   TURBO_CACHE: remote:rw
 
       - name: Run tests
         timeout-minutes: 45
@@ -386,7 +393,9 @@ jobs:
     timeout-minutes: 45
     needs:
       - find-changes
-    if: ${{ needs.find-changes.outputs.is-release-pr != 'true' && needs.find-changes.outputs.rust == 'true' }}
+    # Prebuilding test archives depends on Turborepo remote cache auth, which is disabled for now.
+    # if: ${{ needs.find-changes.outputs.is-release-pr != 'true' && needs.find-changes.outputs.rust == 'true' }}
+    if: ${{ false }}
     name: Build test artifacts (ubuntu)
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -433,7 +442,7 @@ jobs:
     timeout-minutes: 45
     needs:
       - find-changes
-      - build_rust_test_ubuntu
+      # - build_rust_test_ubuntu
     if: ${{ needs.find-changes.outputs.is-release-pr != 'true' && needs.find-changes.outputs.rust == 'true' }}
     strategy:
       fail-fast: false
@@ -462,13 +471,14 @@ jobs:
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo
 
-      - name: Restore test archive from cache
+      - name: Build test archive
         run: turbo run build:test-archive --filter=@turbo/cli
         shell: bash
-        env:
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-          TURBO_CACHE: remote:rw
+        # Remote cache is not authed right now; build locally instead.
+        # env:
+        #   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+        #   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+        #   TURBO_CACHE: remote:rw
 
       - name: Run tests
         timeout-minutes: 45


### PR DESCRIPTION
## Summary
- Disables AWS-backed `sccache` usage in Rust CI jobs while leaving the prior config commented in place for visibility.
- Keeps Turborepo remote cache and existing GitHub cache behavior unchanged.