### PR TITLE
ci: Harden release API commits

### DIFF
--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -99,9 +99,10 @@ jobs:
         if: ${{ matrix.settings.install }}
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
@@ -147,9 +148,10 @@ jobs:
       branch: ${{ steps.version.outputs.branch }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node
         uses: ./.github/actions/setup-node
@@ -162,11 +164,6 @@ jobs:
           npm install -g npm@11.5.1
           npm config set registry https://registry.npmjs.org
 
-      - name: Configure git
-        run: |
-          git config --global user.name 'Turbobot'
-          git config --global user.email 'turbobot@vercel.com'
-
       - name: Bump version
         id: version
         run: |
@@ -178,11 +175,18 @@ jobs:
           cd "$GITHUB_WORKSPACE"
           BRANCH="library-release/${NEXT_VERSION}"
           git checkout -b "${BRANCH}"
-          git add -A
-          git commit -m "library release: ${NEXT_VERSION}"
-          git push origin "${BRANCH}"
           echo "version=${NEXT_VERSION}" >> $GITHUB_OUTPUT
           echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
+
+      - name: Commit version bump
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/create-github-api-commit.mjs \
+            --branch "${{ steps.version.outputs.branch }}" \
+            --message "library release: ${{ steps.version.outputs.version }}" \
+            --all-tracked \
+            --include-untracked
 
       - name: Download Artifacts
         uses: actions/download-artifact@v4
@@ -255,12 +259,21 @@ jobs:
         run: |
           VERSION="${{ needs.package.outputs.version }}"
           BRANCH="${{ needs.package.outputs.branch }}"
-          gh pr create \
+          PR_URL=$(gh pr list \
             --repo "${{ github.repository }}" \
-            --title "release(library): ${VERSION}" \
-            --body "Bumps \`@turbo/repository\` packages to \`${VERSION}\`." \
             --head "${BRANCH}" \
-            --base main
+            --base main \
+            --state open \
+            --json url \
+            --jq '.[0].url // ""')
+          if [ -z "$PR_URL" ]; then
+            PR_URL=$(gh pr create \
+              --repo "${{ github.repository }}" \
+              --title "release(library): ${VERSION}" \
+              --body "Bumps \`@turbo/repository\` packages to \`${VERSION}\`." \
+              --head "${BRANCH}" \
+              --base main)
+          fi
           PR_NUM=$(gh pr view "${BRANCH}" --repo "${{ github.repository }}" --json number --jq '.number')
           gh pr merge "$PR_NUM" --repo "${{ github.repository }}" --auto --squash
 

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -148,15 +148,11 @@ jobs:
         with:
           ref: ${{ inputs.sha || github.sha }}
           filter: blob:none
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-node
         with:
           enable-corepack: false
-
-      - name: Configure git
-        run: |
-          git config --global user.name 'Turbobot'
-          git config --global user.email 'turbobot@vercel.com'
 
       - name: Get base SHA
         id: base-sha
@@ -195,6 +191,7 @@ jobs:
       - name: Clear stale staging branch (if requested)
         if: ${{ inputs.clear-staging-branch }}
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INCREMENT: ${{ github.event_name == 'schedule' && 'prerelease' || inputs.increment }}
           TAG_OVERRIDE: ${{ inputs.tag-override }}
         run: |
@@ -209,7 +206,7 @@ jobs:
 
           if git ls-remote --exit-code --heads origin "staging-${VERSION}" >/dev/null 2>&1; then
             echo "::warning::Deleting staging branch staging-${VERSION}..."
-            git push origin --delete "staging-${VERSION}"
+            gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/staging-${VERSION}"
             echo "Deleted staging branch staging-${VERSION}"
           else
             echo "No staging branch found for staging-${VERSION}"
@@ -254,10 +251,16 @@ jobs:
           echo "New version: $VERSION"
           cat version.txt
 
-      - name: Stage Commit
-        id: stage
+      - name: Prepare stage branch
         run: |
-          cd cli && make stage-release
+          cd cli && make prepare-stage-release
+
+      - name: Commit stage branch
+        id: stage
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd cli && make commit-stage-release
           echo "stage-branch=$(git branch --show-current)" >> $GITHUB_OUTPUT
 
   # TODO: Re-enable Rust unit tests once flakiness is resolved.
@@ -298,6 +301,7 @@ jobs:
         with:
           ref: ${{ needs.stage.outputs.stage-branch }}
           filter: blob:none
+          persist-credentials: false
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
@@ -402,11 +406,6 @@ jobs:
         with:
           turbo-version: ${{ inputs.ci-tag-override || '' }}
 
-      - name: Configure git
-        run: |
-          git config --global user.name 'Turbobot'
-          git config --global user.email 'turbobot@vercel.com'
-
       - name: Download Rust artifacts
         uses: actions/download-artifact@v4
         with:
@@ -450,11 +449,6 @@ jobs:
         with:
           ref: ${{ needs.stage.outputs.stage-branch }}
           filter: blob:none
-
-      - name: Configure git
-        run: |
-          git config --global user.name 'Turbobot'
-          git config --global user.email 'turbobot@vercel.com'
 
       - name: Create and push release tag
         run: cd cli && make create-release-tag
@@ -588,22 +582,22 @@ jobs:
           enable-corepack: false
           extra-flags: "--no-frozen-lockfile"
 
-      - name: Configure git
-        run: |
-          git config --global user.name 'Turbobot'
-          git config --global user.email 'turbobot@vercel.com'
-
       - name: Commit lockfile if updated by install
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if git diff --quiet pnpm-lock.yaml; then
             echo "Lockfile already up to date."
           else
-            git add pnpm-lock.yaml
-            git commit -m "Update lockfile for release"
-            git push origin "${{ needs.stage.outputs.stage-branch }}"
+            node scripts/create-github-api-commit.mjs \
+              --branch "${{ needs.stage.outputs.stage-branch }}" \
+              --message "Update lockfile for release" \
+              --path pnpm-lock.yaml \
+              --if-exists update
           fi
 
       - name: Bump to next canary for stable releases
+        id: next-canary
         run: |
           TAG=$(sed -n '2p' version.txt)
 
@@ -612,11 +606,23 @@ jobs:
             echo "Stable release detected (${VERSION}). Bumping to next prepatch canary..."
             ./scripts/version.js prepatch
             cat version.txt
-            git commit -anm "bump to next canary after ${VERSION}"
-            git push origin "${{ needs.stage.outputs.stage-branch }}"
+            echo "updated=true" >> $GITHUB_OUTPUT
+            echo "version=${VERSION}" >> $GITHUB_OUTPUT
           else
             echo "Pre-release ($TAG), skipping canary bump."
+            echo "updated=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Commit next canary bump
+        if: ${{ steps.next-canary.outputs.updated == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/create-github-api-commit.mjs \
+            --branch "${{ needs.stage.outputs.stage-branch }}" \
+            --message "bump to next canary after ${{ steps.next-canary.outputs.version }}" \
+            --all-tracked \
+            --if-exists update
 
       - name: Build PR body
         env:

--- a/.github/workflows/update-examples-on-release.yml
+++ b/.github/workflows/update-examples-on-release.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-examples-pr:
     name: "Update examples PR"
@@ -13,6 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           filter: blob:none
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-node
 
@@ -21,11 +26,6 @@ jobs:
         run: |
           npm install --force --global corepack@latest
           npm config get prefix >> $GITHUB_PATH
-
-      - name: Configure git
-        run: |
-          git config --global user.name 'Turbobot'
-          git config --global user.email 'turbobot@vercel.com'
 
       - name: Make branch
         id: branch
@@ -38,24 +38,34 @@ jobs:
 
       - name: Commit and push
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HUSKY: "0"
         run: |
-          git commit -am "release(turborepo): update examples to latest"
-
-          for attempt in 1 2 3; do
-            git pull --rebase origin ${{ steps.branch.outputs.STAGE_BRANCH }} || true
-            git push origin ${{ steps.branch.outputs.STAGE_BRANCH }} && break
-            echo "Push attempt $attempt failed, retrying..."
-            sleep 5
-          done
+          node scripts/create-github-api-commit.mjs \
+            --branch "${{ steps.branch.outputs.STAGE_BRANCH }}" \
+            --message "release(turborepo): update examples to latest" \
+            --all-tracked \
+            --if-exists update
 
       - name: Create pull request
         id: pr
-        uses: thomaseizinger/create-pull-request@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          head: ${{ steps.branch.outputs.STAGE_BRANCH }}
-          base: main
-          title: "release(turborepo): update examples to latest"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_URL=$(gh pr list \
+            --head "${{ steps.branch.outputs.STAGE_BRANCH }}" \
+            --base main \
+            --state open \
+            --json url \
+            --jq '.[0].url // ""')
+          if [ -z "$PR_URL" ]; then
+            PR_URL=$(gh pr create \
+              --title "release(turborepo): update examples to latest" \
+              --body "Updates examples to use the latest released Turborepo packages." \
+              --head "${{ steps.branch.outputs.STAGE_BRANCH }}" \
+              --base main)
+          fi
+          echo "html_url=$PR_URL" >> $GITHUB_OUTPUT
+
       - name: PR link
         run: echo ${{ steps.pr.outputs.html_url }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -154,11 +154,11 @@ When a release is triggered, the `scripts/version.js` script:
 
 #### Version Synchronization
 
-Once the version is calculated, the `cli/Makefile` (target: `stage-release`) updates all package.json files by running `pnpm version` for each package to match `TURBO_VERSION`.
+Once the version is calculated, the `cli/Makefile` (target: `prepare-stage-release`) updates all package.json files by running `pnpm version` for each package to match `TURBO_VERSION`.
 
 Additionally, the `packages/turbo/bump-version.js` postversion hook updates the `optionalDependencies` in `packages/turbo/package.json` to reference the correct versions of platform-specific packages.
 
-See: `cli/Makefile` (stage-release target) and `packages/turbo/bump-version.js`
+See: `cli/Makefile` (`prepare-stage-release` and `commit-stage-release` targets) and `packages/turbo/bump-version.js`
 
 ---
 
@@ -172,8 +172,7 @@ The release workflow consists of 7 sequential and parallel stages:
 │ - Calculate new version                                      │
 │ - Create staging branch (staging-X.Y.Z)                      │
 │ - Update all package.json files                              │
-│ - Commit and tag (vX.Y.Z)                                     │
-│ - Push staging branch                                         │
+│ - Commit staging branch through GitHub API                    │
 └──────────────────────┬──────────────────────────────────────┘
                        │
           ┌────────────┴────────────┐
@@ -224,22 +223,22 @@ The release workflow consists of 7 sequential and parallel stages:
 
 1. Checkout repository at the specified SHA (defaults to latest commit on `main`)
 2. Setup Node.js environment
-3. Configure git with Turbobot credentials
-4. Run `node scripts/version.js <increment>` to calculate the new version
-5. Create staging branch: `staging-$(VERSION)` (e.g., `staging-2.6.2`)
-6. Execute `make -C cli stage-release` which:
+3. Run `node scripts/version.js <increment>` to calculate the new version
+4. Execute `make -C cli prepare-stage-release` which:
    - Verifies no unpushed commits exist
    - Verifies `version.txt` was updated
+   - Verifies the release tag and staging branch do not already exist
    - Updates all `package.json` files with the new version
-   - Commits with message: `"publish $(VERSION) to registry"`
-7. Create git tag: `v$(VERSION)` (e.g., `v2.6.2`)
-8. Force push staging branch with tags to origin
+   - Creates staging branch: `staging-$(VERSION)` (e.g., `staging-2.6.2`)
+5. Execute `make -C cli commit-stage-release` which creates the staging commit through `scripts/create-github-api-commit.mjs`
 
 **Output**: `stage-branch` (e.g., `staging-2.6.2`)
 
-**Safety Checks**: The Makefile includes safety checks to verify no unpushed commits exist and that `version.txt` was properly updated before proceeding.
+**Safety Checks**: The Makefile includes safety checks to verify no unpushed commits exist, `version.txt` was properly updated, and the target staging branch is not already present before proceeding. The commit helper creates the remote branch from local `HEAD`, uploads selected file changes through GitHub's `createCommitOnBranch` API, waits for GitHub commit verification, and then updates the local branch ref.
 
-See: `cli/Makefile` (stage-release target)
+If the API commit is created but verification does not complete, the helper leaves the remote branch in place and exits with the commit SHA in the logs. Use the logged SHA and branch name to inspect recovery state before retrying or clearing the staging branch.
+
+See: `cli/Makefile` (`prepare-stage-release` and `commit-stage-release` targets)
 
 #### Stage 2: Rust Smoke Test
 
@@ -502,25 +501,36 @@ See: `packages/turbo-releaser/` for the Windows wrapper generation
 
 #### Key Scripts and Commands
 
-| Script/Command                                     | Location                   | Purpose                                        |
-| -------------------------------------------------- | -------------------------- | ---------------------------------------------- |
-| `node scripts/version.js <increment>`              | `scripts/version.js`       | Calculate new version and update `version.txt` |
-| `make -C cli stage-release`                        | `cli/Makefile`             | Update all package.json versions and commit    |
-| `cargo build --profile release-turborepo -p turbo` | `Cargo.toml`               | Build Rust binary for release                  |
-| `turbo release-native`                             | `cli/turbo.json`           | Pack and publish native packages               |
-| `make -C cli build`                                | `cli/Makefile`             | Build all JavaScript packages                  |
-| `make -C cli publish-turbo`                        | `cli/Makefile`             | Pack and publish all packages                  |
-| `pnpm version <version> --allow-same-version`      | package.json               | Update package version                         |
-| `turboreleaser --version-path ../version.txt`      | `packages/turbo-releaser/` | Pack native packages                           |
+| Script/Command                                     | Location                   | Purpose                                           |
+| -------------------------------------------------- | -------------------------- | ------------------------------------------------- |
+| `node scripts/version.js <increment>`              | `scripts/version.js`       | Calculate new version and update `version.txt`    |
+| `make -C cli prepare-stage-release`                | `cli/Makefile`             | Update package versions and create staging branch |
+| `make -C cli commit-stage-release`                 | `cli/Makefile`             | Commit staging changes through GitHub API         |
+| `node scripts/create-github-api-commit.mjs`        | `scripts/`                 | Create a GitHub-verified API commit on a branch   |
+| `cargo build --profile release-turborepo -p turbo` | `Cargo.toml`               | Build Rust binary for release                     |
+| `turbo release-native`                             | `cli/turbo.json`           | Pack and publish native packages                  |
+| `make -C cli build`                                | `cli/Makefile`             | Build all JavaScript packages                     |
+| `make -C cli publish-turbo`                        | `cli/Makefile`             | Pack and publish all packages                     |
+| `pnpm version <version> --allow-same-version`      | package.json               | Update package version                            |
+| `turboreleaser --version-path ../version.txt`      | `packages/turbo-releaser/` | Pack native packages                              |
 
 #### Environment Variables
 
-| Variable                    | Purpose                                    | Example              |
-| --------------------------- | ------------------------------------------ | -------------------- |
-| `TURBO_VERSION`             | Version to release (read from version.txt) | `2.6.2`              |
-| `TURBO_TAG`                 | npm dist-tag (read from version.txt)       | `latest` or `canary` |
-| `CARGO_PROFILE_RELEASE_LTO` | Enable link-time optimization for Rust     | `true`               |
-| `TURBO_BINARY_PATH`         | Override binary path (development only)    | `/path/to/turbo`     |
+| Variable                    | Purpose                                    | Example                       |
+| --------------------------- | ------------------------------------------ | ----------------------------- |
+| `TURBO_VERSION`             | Version to release (read from version.txt) | `2.6.2`                       |
+| `TURBO_TAG`                 | npm dist-tag (read from version.txt)       | `latest` or `canary`          |
+| `CARGO_PROFILE_RELEASE_LTO` | Enable link-time optimization for Rust     | `true`                        |
+| `TURBO_BINARY_PATH`         | Override binary path (development only)    | `/path/to/turbo`              |
+| `GH_TOKEN`                  | GitHub API token for commit/PR steps only  | `${{ secrets.GITHUB_TOKEN }}` |
+
+#### API Commit Helper
+
+`scripts/create-github-api-commit.mjs` replaces local release `git commit` and branch pushes for generated release commits. It requires `GITHUB_REPOSITORY` and `GH_TOKEN` or `GITHUB_TOKEN`, creates a missing branch from local `HEAD`, then calls GitHub's `createCommitOnBranch` mutation with selected file changes.
+
+Use explicit `--path` values when possible. `--all-tracked` includes all tracked changes compared to `HEAD`, and `--include-untracked` also includes unignored untracked files. The helper refuses sensitive-looking files, unsupported non-regular files, and oversized payloads before creating or updating the remote branch.
+
+By default, an existing remote branch must point at local `HEAD`; otherwise the helper fails to preserve release lock semantics. Use `--if-exists update` only for idempotent workflows, such as the examples update PR, where reruns should commit onto an existing branch.
 
 #### Rust Build Profile
 

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -15,8 +15,8 @@ build:
 		--filter=eslint-config-turbo \
 		--filter=@turbo/types
 
-.PHONY: stage-release
-stage-release:
+.PHONY: prepare-stage-release
+prepare-stage-release:
 	echo "Version: $(TURBO_VERSION)"
 	echo "Tag: $(TURBO_TAG)"
 	cat $(CLI_DIR)/../version.txt
@@ -70,8 +70,20 @@ stage-release:
 	"
 
 	git checkout -b staging-$(TURBO_VERSION)
-	git commit -anm "publish $(TURBO_VERSION) to registry"
-	HUSKY=0 git push origin staging-$(TURBO_VERSION) --force
+
+.PHONY: commit-stage-release
+commit-stage-release:
+	node $(CLI_DIR)/../scripts/create-github-api-commit.mjs \
+		--branch staging-$(TURBO_VERSION) \
+		--message "publish $(TURBO_VERSION) to registry" \
+		--all-tracked
+
+.PHONY: stage-release
+stage-release: prepare-stage-release
+	node $(CLI_DIR)/../scripts/create-github-api-commit.mjs \
+		--branch staging-$(TURBO_VERSION) \
+		--message "publish $(TURBO_VERSION) to registry" \
+		--all-tracked
 
 .PHONY: create-release-tag
 create-release-tag:
@@ -146,4 +158,3 @@ fixture-%:
 	rm -rf testbed
 	mkdir -p testbed
 	../turborepo-tests/helpers/setup_integration_test.sh ./testbed $($@_FIXTURE)
-

--- a/scripts/create-github-api-commit.mjs
+++ b/scripts/create-github-api-commit.mjs
@@ -1,0 +1,482 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { appendFileSync, lstatSync, readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const MAX_FILES = Number(process.env.CREATE_GITHUB_API_COMMIT_MAX_FILES ?? 500);
+const MAX_FILE_BYTES = Number(
+  process.env.CREATE_GITHUB_API_COMMIT_MAX_FILE_BYTES ?? 2 * 1024 * 1024,
+);
+const MAX_TOTAL_BYTES = Number(
+  process.env.CREATE_GITHUB_API_COMMIT_MAX_TOTAL_BYTES ?? 10 * 1024 * 1024,
+);
+const FETCH_TIMEOUT_MS = Number(
+  process.env.CREATE_GITHUB_API_COMMIT_FETCH_TIMEOUT_MS ?? 30_000,
+);
+
+const SENSITIVE_PATH_PATTERNS = [
+  /^\.env($|\.)/,
+  /^\.npmrc$/,
+  /(^|\/)(credentials|secrets?)\.(json|ya?ml|txt)$/i,
+  /(^|\/)id_rsa$/,
+];
+
+function usage() {
+  return `Usage: create-github-api-commit.mjs --branch <branch> --message <message> (--all-tracked | --path <path>...)
+
+Creates a GitHub-verified commit on a branch using the GitHub API.
+
+Options:
+  --branch <branch>          Target branch name. Created from local HEAD if missing.
+  --message <message>        Commit headline.
+  --all-tracked              Include all tracked file changes compared to HEAD.
+  --include-untracked        Include untracked files matched by the path selection.
+  --path <path>              Include changes for one repository-relative path.
+  --if-exists fail|update    Existing branch policy. Defaults to fail.
+  --help                     Show this help text.
+
+Environment:
+  GH_TOKEN or GITHUB_TOKEN   GitHub token with contents:write.
+  GITHUB_REPOSITORY          Repository in owner/name format.`;
+}
+
+export function parseArgs(args = process.argv.slice(2)) {
+  const options = {
+    allTracked: false,
+    ifExists: "fail",
+    includeUntracked: false,
+    paths: [],
+  };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--branch" || arg === "--message") {
+      const value = args[i + 1];
+      if (!value) {
+        throw new Error(`Missing value for ${arg}`);
+      }
+      options[arg.slice(2)] = value;
+      i += 1;
+    } else if (arg === "--path") {
+      const value = args[i + 1];
+      if (!value) {
+        throw new Error("Missing value for --path");
+      }
+      options.paths.push(value);
+      i += 1;
+    } else if (arg === "--if-exists") {
+      const value = args[i + 1];
+      if (value !== "fail" && value !== "update") {
+        throw new Error("--if-exists must be 'fail' or 'update'");
+      }
+      options.ifExists = value;
+      i += 1;
+    } else if (arg === "--all-tracked") {
+      options.allTracked = true;
+    } else if (arg === "--include-untracked") {
+      options.includeUntracked = true;
+    } else if (arg === "--help") {
+      options.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (options.help) {
+    return options;
+  }
+  if (!options.branch) {
+    throw new Error("Missing required --branch argument");
+  }
+  if (!options.message) {
+    throw new Error("Missing required --message argument");
+  }
+  if (!options.allTracked && options.paths.length === 0) {
+    throw new Error("Specify --all-tracked or at least one --path");
+  }
+  if (options.allTracked && options.paths.length > 0) {
+    throw new Error("Use either --all-tracked or --path, not both");
+  }
+  assertBranchName(options.branch);
+  for (const path of options.paths) {
+    assertRepoRelativePath(path);
+  }
+
+  return options;
+}
+
+function git(args, { trim = true } = {}) {
+  const output = execFileSync("git", args, { encoding: "utf8" });
+  return trim ? output.trim() : output;
+}
+
+function splitNull(output) {
+  return output.split("\0").filter(Boolean);
+}
+
+function assertRepositoryName(value) {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(value)) {
+    throw new Error(`Invalid GITHUB_REPOSITORY: ${value}`);
+  }
+}
+
+function assertBranchName(branch) {
+  git(["check-ref-format", "--branch", branch]);
+  if (branch.startsWith("refs/")) {
+    throw new Error(`Invalid branch name: ${branch}`);
+  }
+}
+
+function assertRepoRelativePath(path) {
+  if (
+    path.length === 0 ||
+    path.startsWith("/") ||
+    path.includes("..") ||
+    path.startsWith(":")
+  ) {
+    throw new Error(`Invalid commit path: ${path}`);
+  }
+}
+
+function assertSafeCommitPath(path) {
+  assertRepoRelativePath(path);
+  if (SENSITIVE_PATH_PATTERNS.some((pattern) => pattern.test(path))) {
+    throw new Error(`Refusing to commit sensitive-looking file: ${path}`);
+  }
+}
+
+function getChangedPaths({ allTracked, includeUntracked, paths }) {
+  const pathspec = allTracked ? [] : paths;
+  const entries = [];
+  const diff = splitNull(
+    git(
+      ["diff", "--name-status", "--no-renames", "-z", "HEAD", "--", ...pathspec],
+      { trim: false },
+    ),
+  );
+
+  for (let i = 0; i < diff.length; i += 2) {
+    entries.push({ path: diff[i + 1], deleted: diff[i] === "D" });
+  }
+
+  if (includeUntracked) {
+    const untracked = splitNull(
+      git(
+        ["ls-files", "--others", "--exclude-standard", "-z", "--", ...pathspec],
+        { trim: false },
+      ),
+    );
+    for (const path of untracked) {
+      entries.push({ path, deleted: false });
+    }
+  }
+
+  return entries;
+}
+
+function fileContents(path) {
+  const stat = lstatSync(path);
+  if (!stat.isFile()) {
+    throw new Error(`${path} is not a regular file`);
+  }
+  if (stat.size > MAX_FILE_BYTES) {
+    throw new Error(
+      `${path} is ${stat.size} bytes, exceeding limit ${MAX_FILE_BYTES}`,
+    );
+  }
+  return { contents: readFileSync(path).toString("base64"), size: stat.size };
+}
+
+function repository() {
+  const value = process.env.GITHUB_REPOSITORY;
+  if (!value) {
+    throw new Error("Missing GITHUB_REPOSITORY");
+  }
+  assertRepositoryName(value);
+  return value;
+}
+
+function token() {
+  const value = process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN;
+  if (!value) {
+    throw new Error("Missing GH_TOKEN or GITHUB_TOKEN");
+  }
+  return value;
+}
+
+async function fetchJson(url, options, retryable = false) {
+  let lastError;
+
+  for (let attempt = 1; attempt <= (retryable ? 3 : 1); attempt += 1) {
+    const signal = AbortSignal.timeout(FETCH_TIMEOUT_MS);
+    try {
+      const response = await fetch(url, { ...options, signal });
+      const data = await response.json();
+      if (
+        retryable &&
+        (response.status === 429 || response.status >= 500) &&
+        attempt < 3
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, attempt * 1000));
+        continue;
+      }
+      return { data, response };
+    } catch (error) {
+      lastError = error;
+      if (!retryable || attempt === 3) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, attempt * 1000));
+    }
+  }
+
+  throw lastError;
+}
+
+async function githubRest(path) {
+  const { data, response } = await fetchJson(`https://api.github.com${path}`, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token()}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  }, true);
+
+  if (!response.ok) {
+    throw new Error(
+      `GET ${path} failed: ${data.message ?? response.statusText}`,
+    );
+  }
+
+  return data;
+}
+
+async function githubGraphql(query, variables, { retryable = false } = {}) {
+  const { data, response } = await fetchJson("https://api.github.com/graphql", {
+    method: "POST",
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token()}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query, variables }),
+  }, retryable);
+
+  if (!response.ok || data.errors) {
+    const message =
+      data.errors?.map((error) => error.message).join("; ") ?? data.message;
+    throw new Error(`GraphQL request failed: ${message}`);
+  }
+
+  return data.data;
+}
+
+async function getRepositoryInfo(repositoryName, branch) {
+  const [owner, repo] = repositoryName.split("/");
+  const data = await githubGraphql(
+    `query($owner: String!, $repo: String!, $ref: String!) {
+      repository(owner: $owner, name: $repo) {
+        id
+        nameWithOwner
+        ref(qualifiedName: $ref) {
+          target {
+            ... on Commit {
+              oid
+            }
+          }
+        }
+      }
+    }`,
+    { owner, repo, ref: `refs/heads/${branch}` },
+    { retryable: true },
+  );
+
+  return data.repository;
+}
+
+async function createBranch(repositoryId, branch, oid) {
+  const data = await githubGraphql(
+    `mutation($input: CreateRefInput!) {
+      createRef(input: $input) {
+        ref {
+          id
+        }
+      }
+    }`,
+    {
+      input: {
+        repositoryId,
+        name: `refs/heads/${branch}`,
+        oid,
+      },
+    },
+  );
+
+  return data.createRef.ref.id;
+}
+
+export function buildFileChanges(changes) {
+  const additions = [];
+  const deletions = [];
+  const seen = new Set();
+  let totalBytes = 0;
+
+  if (changes.length > MAX_FILES) {
+    throw new Error(
+      `Refusing to commit ${changes.length} files, exceeding limit ${MAX_FILES}`,
+    );
+  }
+
+  for (const change of changes) {
+    assertSafeCommitPath(change.path);
+    if (seen.has(change.path)) {
+      continue;
+    }
+    seen.add(change.path);
+
+    if (change.deleted) {
+      deletions.push({ path: change.path });
+    } else {
+      const file = fileContents(change.path);
+      totalBytes += file.size;
+      if (totalBytes > MAX_TOTAL_BYTES) {
+        throw new Error(
+          `Refusing to commit ${totalBytes} bytes, exceeding limit ${MAX_TOTAL_BYTES}`,
+        );
+      }
+      additions.push({
+        path: change.path,
+        contents: file.contents,
+      });
+    }
+  }
+
+  const fileChanges = {};
+  if (additions.length > 0) {
+    fileChanges.additions = additions;
+  }
+  if (deletions.length > 0) {
+    fileChanges.deletions = deletions;
+  }
+
+  return fileChanges;
+}
+
+async function createCommit({
+  branch,
+  expectedHeadOid,
+  fileChanges,
+  message,
+  repositoryName,
+}) {
+  const data = await githubGraphql(
+    `mutation($input: CreateCommitOnBranchInput!) {
+      createCommitOnBranch(input: $input) {
+        commit {
+          oid
+        }
+      }
+    }`,
+    {
+      input: {
+        branch: { repositoryNameWithOwner: repositoryName, branchName: branch },
+        expectedHeadOid,
+        message: { headline: message },
+        fileChanges,
+      },
+    },
+  );
+
+  return data.createCommitOnBranch.commit.oid;
+}
+
+async function assertVerified(repositoryName, sha) {
+  let reason = "unknown";
+  const attempts = Number(
+    process.env.CREATE_GITHUB_API_COMMIT_VERIFY_ATTEMPTS ?? 5,
+  );
+  const delayMs = Number(process.env.CREATE_GITHUB_API_COMMIT_VERIFY_DELAY_MS);
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const commit = await githubRest(`/repos/${repositoryName}/commits/${sha}`);
+      if (commit.commit.verification.verified) {
+        return;
+      }
+      reason = commit.commit.verification.reason;
+    } catch (error) {
+      reason = error instanceof Error ? error.message : String(error);
+    }
+
+    await new Promise((resolve) =>
+      setTimeout(resolve, Number.isNaN(delayMs) ? attempt * 1000 : delayMs),
+    );
+  }
+
+  throw new Error(`GitHub did not verify commit ${sha}: ${reason}`);
+}
+
+export async function run(options = parseArgs()) {
+  if (options.help) {
+    console.log(usage());
+    return;
+  }
+
+  const repositoryName = repository();
+  const currentHead = git(["rev-parse", "HEAD"]);
+  const currentBranch = git(["branch", "--show-current"]);
+  const changes = getChangedPaths(options);
+  if (changes.length === 0) {
+    throw new Error("No changes to commit");
+  }
+  const fileChanges = buildFileChanges(changes);
+
+  const repositoryInfo = await getRepositoryInfo(repositoryName, options.branch);
+  let expectedHeadOid = repositoryInfo.ref?.target?.oid;
+  if (expectedHeadOid && options.ifExists === "fail") {
+    throw new Error(
+      `Remote branch ${options.branch} already exists at ${expectedHeadOid}. Use --if-exists update to commit onto the remote branch.`,
+    );
+  }
+
+  if (!expectedHeadOid) {
+    await createBranch(repositoryInfo.id, options.branch, currentHead);
+    expectedHeadOid = currentHead;
+  }
+
+  const commitSha = await createCommit({
+    branch: options.branch,
+    expectedHeadOid,
+    fileChanges,
+    message: options.message,
+    repositoryName,
+  });
+
+  try {
+    await assertVerified(repositoryName, commitSha);
+  } catch (error) {
+    console.error(
+      `Created ${commitSha} on ${options.branch}, but verification did not complete. Leaving the branch in place for recovery.`,
+    );
+    throw error;
+  }
+
+  git(["update-ref", `refs/heads/${options.branch}`, commitSha]);
+  if (currentBranch === options.branch) {
+    git(["reset", "--mixed", commitSha]);
+  }
+
+  console.log(`Created ${commitSha} on ${options.branch}`);
+
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `commit-sha=${commitSha}\n`);
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  run().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}

--- a/scripts/create-github-api-commit.test.mjs
+++ b/scripts/create-github-api-commit.test.mjs
@@ -1,0 +1,240 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  buildFileChanges,
+  parseArgs,
+  run,
+} from "./create-github-api-commit.mjs";
+
+function git(args) {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+async function withTempRepo(callback) {
+  const cwd = process.cwd();
+  const dir = mkdtempSync(join(tmpdir(), "github-api-commit-"));
+
+  try {
+    process.chdir(dir);
+    git(["init"]);
+    git(["checkout", "-b", "main"]);
+    git(["config", "user.name", "Test User"]);
+    git(["config", "user.email", "test@example.com"]);
+    writeFileSync("file.txt", "base\n");
+    git(["add", "file.txt"]);
+    git(["commit", "-m", "initial"]);
+    await callback(dir);
+  } finally {
+    process.chdir(cwd);
+    rmSync(dir, { force: true, recursive: true });
+  }
+}
+
+function mockGitHub({ remoteOid, verified = false }) {
+  const requests = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (url, options = {}) => {
+    const body = options.body ? JSON.parse(options.body) : undefined;
+    requests.push({ body, url: String(url) });
+
+    if (String(url).endsWith("/graphql")) {
+      if (body.query.includes("repository(owner:")) {
+        return response({
+          data: {
+            repository: {
+              id: "repo-id",
+              nameWithOwner: "vercel/turbo",
+              ref: remoteOid ? { target: { oid: remoteOid } } : null,
+            },
+          },
+        });
+      }
+      if (body.query.includes("createRef")) {
+        return response({ data: { createRef: { ref: { id: "ref-id" } } } });
+      }
+      if (body.query.includes("deleteRef")) {
+        return response({ data: { deleteRef: { clientMutationId: null } } });
+      }
+      if (body.query.includes("createCommitOnBranch")) {
+        return response({
+          data: { createCommitOnBranch: { commit: { oid: "commit-sha" } } },
+        });
+      }
+    }
+
+    return response({
+      commit: { verification: { reason: "unsigned", verified } },
+    });
+  };
+
+  return {
+    requests,
+    restore() {
+      globalThis.fetch = originalFetch;
+    },
+  };
+}
+
+function response(data) {
+  return { json: async () => data, ok: true, status: 200, statusText: "OK" };
+}
+
+test("parseArgs validates branch policy", () => {
+  assert.deepEqual(
+    parseArgs([
+      "--branch",
+      "release/test",
+      "--message",
+      "test",
+      "--all-tracked",
+      "--if-exists",
+      "update",
+    ]),
+    {
+      allTracked: true,
+      branch: "release/test",
+      ifExists: "update",
+      includeUntracked: false,
+      message: "test",
+      paths: [],
+    },
+  );
+  assert.throws(
+    () =>
+      parseArgs([
+        "--branch",
+        "release/test",
+        "--message",
+        "test",
+        "--all-tracked",
+        "--if-exists",
+        "replace",
+      ]),
+    /--if-exists must be 'fail' or 'update'/,
+  );
+});
+
+test("buildFileChanges refuses sensitive-looking paths", async () => {
+  await withTempRepo(() => {
+    writeFileSync(".env", "TOKEN=secret\n");
+    assert.throws(
+      () => buildFileChanges([{ deleted: false, path: ".env" }]),
+      /Refusing to commit sensitive-looking file/,
+    );
+  });
+});
+
+test("verification failure preserves a branch after commit creation", async () => {
+  await withTempRepo(async () => {
+    writeFileSync("file.txt", "changed\n");
+    process.env.GITHUB_REPOSITORY = "vercel/turbo";
+    process.env.GH_TOKEN = "test-token";
+    process.env.CREATE_GITHUB_API_COMMIT_VERIFY_ATTEMPTS = "1";
+    process.env.CREATE_GITHUB_API_COMMIT_VERIFY_DELAY_MS = "0";
+
+    const github = mockGitHub({ remoteOid: null, verified: false });
+    try {
+      await assert.rejects(
+        run({
+          allTracked: true,
+          branch: "release/test",
+          ifExists: "fail",
+          includeUntracked: false,
+          message: "test commit",
+          paths: [],
+        }),
+        /GitHub did not verify commit commit-sha/,
+      );
+      assert.equal(
+        github.requests.some((request) =>
+          request.body?.query.includes("deleteRef"),
+        ),
+        false,
+      );
+    } finally {
+      github.restore();
+      delete process.env.GITHUB_REPOSITORY;
+      delete process.env.GH_TOKEN;
+      delete process.env.CREATE_GITHUB_API_COMMIT_VERIFY_ATTEMPTS;
+      delete process.env.CREATE_GITHUB_API_COMMIT_VERIFY_DELAY_MS;
+    }
+  });
+});
+
+test("update policy commits onto an existing remote branch", async () => {
+  await withTempRepo(async () => {
+    writeFileSync("file.txt", "changed\n");
+    process.env.GITHUB_REPOSITORY = "vercel/turbo";
+    process.env.GH_TOKEN = "test-token";
+    process.env.CREATE_GITHUB_API_COMMIT_VERIFY_ATTEMPTS = "1";
+    process.env.CREATE_GITHUB_API_COMMIT_VERIFY_DELAY_MS = "0";
+
+    const github = mockGitHub({ remoteOid: "remote-sha", verified: false });
+    try {
+      await assert.rejects(
+        run({
+          allTracked: true,
+          branch: "post-release-bump-examples",
+          ifExists: "update",
+          includeUntracked: false,
+          message: "test commit",
+          paths: [],
+        }),
+        /GitHub did not verify commit commit-sha/,
+      );
+      const createCommitRequest = github.requests.find((request) =>
+        request.body?.query.includes("createCommitOnBranch"),
+      );
+      assert.equal(
+        createCommitRequest.body.variables.input.expectedHeadOid,
+        "remote-sha",
+      );
+    } finally {
+      github.restore();
+      delete process.env.GITHUB_REPOSITORY;
+      delete process.env.GH_TOKEN;
+      delete process.env.CREATE_GITHUB_API_COMMIT_VERIFY_ATTEMPTS;
+      delete process.env.CREATE_GITHUB_API_COMMIT_VERIFY_DELAY_MS;
+    }
+  });
+});
+
+test("default policy refuses an existing remote branch", async () => {
+  await withTempRepo(async () => {
+    writeFileSync("file.txt", "changed\n");
+    process.env.GITHUB_REPOSITORY = "vercel/turbo";
+    process.env.GH_TOKEN = "test-token";
+
+    const currentHead = git(["rev-parse", "HEAD"]);
+    const github = mockGitHub({ remoteOid: currentHead, verified: false });
+    try {
+      await assert.rejects(
+        run({
+          allTracked: true,
+          branch: "release/test",
+          ifExists: "fail",
+          includeUntracked: false,
+          message: "test commit",
+          paths: [],
+        }),
+        /Remote branch release\/test already exists/,
+      );
+      assert.equal(
+        github.requests.some((request) =>
+          request.body?.query.includes("createCommitOnBranch"),
+        ),
+        false,
+      );
+    } finally {
+      github.restore();
+      delete process.env.GITHUB_REPOSITORY;
+      delete process.env.GH_TOKEN;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Replace release branch commits with a guarded GitHub API helper so generated release commits do not depend on local git identity or push credentials.
- Tighten release workflow token exposure and make rerun-sensitive PR creation idempotent.
- Document the API commit flow and add focused tests for branch policy, verification failures, and unsafe file selection.