### PR TITLE
fix: Allow npm registry in tbx sandboxes

### DIFF
--- a/packages/tbx/src/cli.mjs
+++ b/packages/tbx/src/cli.mjs
@@ -522,13 +522,22 @@ function vercelCredentialPolicy() {
   };
 }
 
+function publicPackageRegistryPolicy() {
+  return {
+    allow: {
+      "registry.npmjs.org": []
+    }
+  };
+}
+
 function credentialPolicy() {
   requireBrokeredCredentials();
 
   return {
     allow: {
       ...githubCredentialPolicy().allow,
-      ...vercelCredentialPolicy().allow
+      ...vercelCredentialPolicy().allow,
+      ...publicPackageRegistryPolicy().allow
     }
   };
 }


### PR DESCRIPTION
## Summary
- Allows `tbx` sandbox network policies to reach the public npm registry.
- Keeps credential-brokered GitHub/Vercel access unchanged while enabling package manager installs inside sandboxes.

## Testing
- `node --check packages/tbx/src/cli.mjs`