### PR TITLE
fix: Install turbo globally in tbx base

### DIFF
--- a/packages/tbx/README.md
+++ b/packages/tbx/README.md
@@ -99,7 +99,7 @@ Verifies brokered GitHub auth and Vercel provider detection inside `turbo-<name>
 pnpm tbx base refresh
 ```
 
-Creates or refreshes `turbo-base-<origin-main-sha12>`, installs Turborepo dependencies, runs `cargo build`, stops the sandbox, and snapshots it.
+Creates or refreshes `turbo-base-<origin-main-sha12>`, installs `turbo@latest` globally so it is on `PATH`, installs Turborepo dependencies, runs `cargo build`, stops the sandbox, and snapshots it.
 
 For mapped Vercel users, the base name includes the username:
 

--- a/packages/tbx/src/cli.mjs
+++ b/packages/tbx/src/cli.mjs
@@ -1123,6 +1123,10 @@ step "corepack enable"
 corepack enable
 step "corepack prepare ${rootPackageJson.packageManager} --activate"
 corepack prepare ${rootPackageJson.packageManager} --activate
+step "npm install --global turbo@latest"
+npm install --global turbo@latest
+step "turbo --version"
+turbo --version
 step "mkdir -p ${shellQuote(dirname(config.repoPath))}"
 mkdir -p ${shellQuote(dirname(config.repoPath))}
 if [ ! -d ${shellQuote(join(config.repoPath, ".git"))} ]; then


### PR DESCRIPTION
## Summary
- Ensure `tbx base refresh` installs `turbo@latest` globally so task sandboxes inherit a `turbo` binary on `PATH`.
- Verify the global binary during base refresh and document the behavior.