### PR TITLE
docs: Clarify package hash file inputs

### DIFF
--- a/apps/docs/content/docs/crafting-your-repository/caching.mdx
+++ b/apps/docs/content/docs/crafting-your-repository/caching.mdx
@@ -227,7 +227,7 @@ Under the hood, Turborepo creates two hashes: a global hash and a task hash. If 
 | [Package Configuration](/docs/reference/package-configurations) changes | Changing a package's `turbo.json`                       |
 | Lockfile changes that affect the package                                | Updating dependencies in a package's `package.json`     |
 | Package's `package.json` changes                                        | Updating the `name` field in a package's `package.json` |
-| File changes | Defaults to all files in the package, configurable with [`inputs`](/docs/reference/configuration#inputs) |
+| File changes | Defaults to all source-controlled files in the package directory. Configurable with [`inputs`](/docs/reference/configuration#inputs) |
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- Clarifies that package hash file changes default to source-controlled files in the package directory.
- Points readers to `inputs` for customizing the file set.