### PR TITLE
fix: Install dotfiles during `tbx base refresh`

### DIFF
--- a/packages/tbx/README.md
+++ b/packages/tbx/README.md
@@ -40,7 +40,7 @@ Create or refresh the warm base sandbox for the current `origin/main` SHA:
 pnpm tbx base refresh
 ```
 
-After the warm base exists, mapped Vercel users can refresh only dotfiles in that base:
+Mapped Vercel users also get dotfiles installed into the base. After the warm base exists, they can refresh only dotfiles in that base:
 
 ```bash
 pnpm tbx base refresh --dotfiles
@@ -99,7 +99,7 @@ Verifies brokered GitHub auth and Vercel provider detection inside `turbo-<name>
 pnpm tbx base refresh
 ```
 
-Creates or refreshes `turbo-base-<origin-main-sha12>`, installs `turbo@latest` globally so it is on `PATH`, installs Turborepo dependencies, runs `cargo build`, stops the sandbox, and snapshots it.
+Creates or refreshes `turbo-base-<origin-main-sha12>`, installs `turbo@latest` globally so it is on `PATH`, installs Turborepo dependencies, runs `cargo build`, installs mapped user dotfiles, stops the sandbox, and snapshots it.
 
 For mapped Vercel users, the base name includes the username:
 
@@ -169,7 +169,7 @@ Repo path: /vercel/sandbox/src/turbo
 
 Project and account resolution are owned by the Sandbox CLI and normal Vercel project context.
 
-Dotfiles are installed only during `base refresh --dotfiles`, not per task sandbox. Task sandboxes inherit dotfiles from the base snapshot.
+Dotfiles are installed during `base refresh` for mapped Vercel users. Use `base refresh --dotfiles` to update only dotfiles without rebuilding the base. Task sandboxes inherit dotfiles from the base snapshot.
 
 ## Credential Brokering
 

--- a/packages/tbx/src/cli.mjs
+++ b/packages/tbx/src/cli.mjs
@@ -58,7 +58,7 @@ Commands:
   stop <name>           Stop a PR sandbox session
   rm <name>             Permanently remove a PR sandbox
   base refresh          Create or refresh the base for origin/main's SHA
-                         Use --dotfiles to install mapped user dotfiles into the base
+                         Use --dotfiles to refresh only mapped user dotfiles in the base
   base id               Print the current base sandbox name
 
 Repo auth:
@@ -1191,6 +1191,7 @@ step "cargo fetch"
 cargo fetch
 step "cargo build"
 cargo build
+${dotfilesBootstrap(profile)}
 `;
 
   console.log(`[tbx] refreshing base sandbox ${base.name}`);


### PR DESCRIPTION
## Summary

- Install mapped user dotfiles as part of the full `pnpm tbx base refresh` path so fresh base snapshots include the expected shell setup.
- Keep `pnpm tbx base refresh --dotfiles` as the faster dotfiles-only refresh and update the docs to clarify both flows.

## Testing

- `node --check packages/tbx/src/cli.mjs`
- Pre-push hooks: `format`, `check:toml`, Rust builds