### PR TITLE
fix: Improve tbx sandbox startup

### DIFF
--- a/packages/tbx/README.md
+++ b/packages/tbx/README.md
@@ -99,7 +99,7 @@ Verifies brokered GitHub auth and Vercel provider detection inside `turbo-<name>
 pnpm tbx base refresh
 ```
 
-Creates or refreshes `turbo-base-<origin-main-sha12>`, installs `turbo@latest` globally so it is on `PATH`, installs Turborepo dependencies, runs `cargo build`, installs mapped user dotfiles, stops the sandbox, and snapshots it.
+Creates or refreshes `turbo-base-<origin-main-sha12>`, reusing the newest previous base snapshot when the current base does not exist. It installs `turbo@latest` globally so it is on `PATH`, installs Turborepo dependencies, runs `cargo build`, installs mapped user dotfiles, stops the sandbox, and snapshots it.
 
 For mapped Vercel users, the base name includes the username:
 
@@ -129,7 +129,7 @@ Creates `turbo-<name>` from the newest available base snapshot, applies credenti
 pnpm tbx sh <name>
 ```
 
-Opens an interactive login Bash shell in `turbo-<name>`. Creates it first if missing.
+Opens an interactive login Zsh shell in `turbo-<name>`. Creates it first if missing.
 
 ```bash
 pnpm tbx run <name> -- <command>

--- a/packages/tbx/src/cli.mjs
+++ b/packages/tbx/src/cli.mjs
@@ -386,6 +386,32 @@ function latestBase(config) {
   return baseSandboxes(config).find((base) => base.snapshotId) ?? null;
 }
 
+function createBaseSandbox(config, base) {
+  const previousBase = latestBase(config);
+  const args = [
+    "create",
+    "--name",
+    base.name,
+    "--runtime",
+    config.runtime,
+    "--vcpus",
+    config.vcpus,
+    "--timeout",
+    config.defaultTimeout,
+    "--snapshot-expiration",
+    config.baseSnapshotExpiration
+  ];
+
+  if (previousBase?.snapshotId) {
+    console.log(
+      `[tbx] creating ${base.name} from previous base ${previousBase.name}`
+    );
+    args.push("--snapshot", previousBase.snapshotId);
+  }
+
+  sandbox(args);
+}
+
 function warnIfBaseIsOutOfDate(config, base) {
   const currentSha = mainSha(config);
   if (base.sha === currentSha.slice(0, 12)) {
@@ -960,7 +986,7 @@ async function shell(name) {
       config.repoPath,
       ...brokeredCredentialEnvArgs(),
       sandboxName,
-      "bash",
+      "zsh",
       "-l"
     ]);
   } finally {
@@ -1102,19 +1128,7 @@ ${dotfilesBootstrap(profile)}
   }
 
   if (!base.line) {
-    sandbox([
-      "create",
-      "--name",
-      base.name,
-      "--runtime",
-      config.runtime,
-      "--vcpus",
-      config.vcpus,
-      "--timeout",
-      config.defaultTimeout,
-      "--snapshot-expiration",
-      config.baseSnapshotExpiration
-    ]);
+    createBaseSandbox(config, base);
   }
 
   const command = `


### PR DESCRIPTION
## Summary
- Reuse the newest existing tbx base snapshot when creating a missing current base, reducing rebuild cost after main advances.
- Open `pnpm tbx sh` with login Zsh so mapped dotfiles configure the interactive sandbox shell consistently.