### PR TITLE
fix: Improve tbx sandbox startup defaults

### DIFF
--- a/packages/tbx/README.md
+++ b/packages/tbx/README.md
@@ -129,13 +129,13 @@ Creates `turbo-<name>` from the newest available base snapshot, applies credenti
 pnpm tbx sh <name>
 ```
 
-Opens an interactive login Zsh shell in `turbo-<name>`. Creates it first if missing.
+Opens an interactive login Bash shell in `turbo-<name>`. Creates it first if missing.
 
 ```bash
 pnpm tbx run <name> -- <command>
 ```
 
-Runs a command in `/vercel/sandbox/src/turbo` inside `turbo-<name>`. Creates it first if missing.
+Runs a command in `/vercel/sandbox/turbo` inside `turbo-<name>`. Creates it first if missing.
 
 ```bash
 pnpm tbx stop <name>
@@ -160,7 +160,7 @@ Memory: 64 GiB, derived by Vercel from 32 vCPUs
 Timeout: 30m, the current Sandbox API maximum
 Task snapshot expiration: 14d
 Base snapshot expiration: none
-Repo path: /vercel/sandbox/src/turbo
+Repo path: /vercel/sandbox/turbo
 ```
 
 ## Notes

--- a/packages/tbx/src/cli.mjs
+++ b/packages/tbx/src/cli.mjs
@@ -25,7 +25,7 @@ const toolPackageJson = JSON.parse(
 const defaults = {
   prefix: "turbo",
   baseSandbox: "turbo-base",
-  repoPath: "/vercel/sandbox/src/turbo",
+  repoPath: "/vercel/sandbox/turbo",
   defaultTimeout: "30m",
   snapshotExpiration: "14d",
   baseSnapshotExpiration: "none",
@@ -986,7 +986,7 @@ async function shell(name) {
       config.repoPath,
       ...brokeredCredentialEnvArgs(),
       sandboxName,
-      "zsh",
+      "bash",
       "-l"
     ]);
   } finally {


### PR DESCRIPTION
## Summary
- Restore Bash as the interactive shell for `pnpm tbx sh` to avoid sandbox connection hangs seen with Zsh.
- Move the sandbox repo checkout to `/vercel/sandbox/turbo` and update the docs to match.