### PR TITLE
fix: Support pnpm 11 flat patch lockfiles

### DIFF
--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -1,6 +1,7 @@
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::{
+    collections::BTreeSet,
     str::FromStr,
     sync::{LazyLock, OnceLock},
 };
@@ -15,7 +16,7 @@ use turbopath::{
 use turborepo_repository::{
     package_graph::{self, PackageGraph, PackageName, PackageNode},
     package_json::PackageJson,
-    package_manager::npmrc::NpmRc,
+    package_manager::{npmrc::NpmRc, PackageManager},
 };
 use turborepo_telemetry::events::command::CommandEventBuilder;
 use turborepo_ui::BOLD;
@@ -226,13 +227,24 @@ pub async fn prune(
     prune.copy_turbo_json(&workspace_names)?;
     prune.copy_global_dependencies()?;
 
-    let original_patches = prune
+    let original_lockfile = prune
         .package_graph
         .lockfile()
-        .expect("lockfile presence checked earlier")
-        .patches()?;
+        .expect("lockfile presence checked earlier");
+    let package_manager = prune.package_graph.package_manager();
+    let original_patches = collect_patch_paths(
+        original_lockfile,
+        prune.package_graph.root_package_json(),
+        &prune.root,
+        package_manager,
+    )?;
     if !original_patches.is_empty() {
-        let pruned_patches = lockfile.patches()?;
+        let pruned_patches = collect_patch_paths(
+            lockfile.as_ref(),
+            prune.package_graph.root_package_json(),
+            &prune.root,
+            package_manager,
+        )?;
         trace!(
             "original patches: {:?}, pruned patches: {:?}",
             original_patches,
@@ -240,8 +252,6 @@ pub async fn prune(
         );
 
         let repo_root = &prune.root;
-        let package_manager = prune.package_graph.package_manager();
-
         let pruned_json = package_manager.prune_patched_packages(
             prune.package_graph.root_package_json(),
             &pruned_patches,
@@ -313,6 +323,69 @@ pub async fn prune(
     }
 
     Ok(())
+}
+
+fn collect_patch_paths(
+    lockfile: &dyn turborepo_lockfiles::Lockfile,
+    root_package_json: &PackageJson,
+    repo_root: &turbopath::AbsoluteSystemPath,
+    package_manager: &PackageManager,
+) -> Result<Vec<RelativeUnixPathBuf>, Error> {
+    let mut patches = lockfile.patches()?;
+    let patch_keys = lockfile.patch_keys();
+
+    if !patch_keys.is_empty() {
+        patches.extend(package_json_patch_paths(root_package_json, &patch_keys));
+
+        if matches!(
+            package_manager,
+            PackageManager::Pnpm | PackageManager::Pnpm6 | PackageManager::Pnpm9
+        ) {
+            let workspace_yaml_path = repo_root.join_component(
+                turborepo_repository::package_manager::pnpm::WORKSPACE_CONFIGURATION_PATH,
+            );
+            patches.extend(
+                turborepo_repository::package_manager::pnpm::patch_paths_for_keys(
+                    &workspace_yaml_path,
+                    &patch_keys,
+                )?,
+            );
+        }
+    }
+
+    patches.sort();
+    patches.dedup();
+    Ok(patches)
+}
+
+fn package_json_patch_paths(
+    package_json: &PackageJson,
+    patch_keys: &[String],
+) -> Vec<RelativeUnixPathBuf> {
+    let patch_keys: BTreeSet<_> = patch_keys.iter().map(String::as_str).collect();
+    let mut patches = Vec::new();
+
+    if let Some(patched_dependencies) = package_json.patched_dependencies.as_ref() {
+        patches.extend(
+            patched_dependencies.iter().filter_map(|(key, path)| {
+                patch_keys.contains(key.as_str()).then_some(path.clone())
+            }),
+        );
+    }
+
+    if let Some(patched_dependencies) = package_json
+        .pnpm
+        .as_ref()
+        .and_then(|config| config.patched_dependencies.as_ref())
+    {
+        patches.extend(
+            patched_dependencies.iter().filter_map(|(key, path)| {
+                patch_keys.contains(key.as_str()).then_some(path.clone())
+            }),
+        );
+    }
+
+    patches
 }
 
 struct Prune<'a> {

--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -103,6 +103,15 @@ pub trait Lockfile: Send + Sync + Any + std::fmt::Debug {
         Ok(Vec::new())
     }
 
+    /// Package identifiers that have patches in the lockfile.
+    ///
+    /// Some package managers store patch paths outside of the lockfile, so
+    /// these keys are used to recover the relevant paths from package
+    /// manager config.
+    fn patch_keys(&self) -> Vec<String> {
+        Vec::new()
+    }
+
     /// Determine if there's a global change between two lockfiles
     ///
     /// This generally is only `true` across lockfile version changes or when a

--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -49,11 +49,30 @@ pub struct PnpmLockfile {
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
-pub struct PatchFile {
-    // This should be a RelativeUnixPathBuf, but since that might cause unnecessary
-    // parse failures we wait until access to validate.
-    path: String,
-    hash: String,
+#[serde(untagged)]
+pub enum PatchFile {
+    PathAndHash {
+        // This should be a RelativeUnixPathBuf, but since that might cause unnecessary
+        // parse failures we wait until access to validate.
+        path: String,
+        hash: String,
+    },
+    Hash(String),
+}
+
+impl PatchFile {
+    fn hash(&self) -> &str {
+        match self {
+            Self::PathAndHash { hash, .. } | Self::Hash(hash) => hash,
+        }
+    }
+
+    fn path(&self) -> Option<&str> {
+        match self {
+            Self::PathAndHash { path, .. } => Some(path),
+            Self::Hash(_) => None,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
@@ -460,7 +479,7 @@ impl PnpmLockfile {
             if let Some(patch) = patches.get(&patch_key).filter(|patch| {
                 // In V7 patch hash isn't included in packages key, so no need to check
                 matches!(self.version(), SupportedLockfileVersion::V7AndV9)
-                    || dp.patch_hash() == Some(&patch.hash)
+                    || dp.patch_hash() == Some(patch.hash())
             }) {
                 pruned_patches.insert(patch_key, patch.clone());
                 continue;
@@ -745,10 +764,18 @@ impl crate::Lockfile for PnpmLockfile {
             .patched_dependencies
             .iter()
             .flatten()
-            .map(|(_, patch)| RelativeUnixPathBuf::new(&patch.path))
+            .filter_map(|(_, patch)| patch.path())
+            .map(RelativeUnixPathBuf::new)
             .collect::<Result<Vec<_>, turbopath::PathError>>()?;
         patches.sort();
         Ok(patches)
+    }
+
+    fn patch_keys(&self) -> Vec<String> {
+        self.patched_dependencies
+            .iter()
+            .flat_map(|patches| patches.keys().cloned())
+            .collect()
     }
 
     fn global_change(&self, other: &dyn crate::Lockfile) -> bool {
@@ -1054,6 +1081,27 @@ snapshots:
             .expect("apps/web dependency should resolve from the final document");
         assert_eq!(package.key, "is-odd@3.0.1");
         assert_eq!(package.version, "3.0.1");
+    }
+
+    #[test]
+    fn test_from_bytes_supports_flat_pnpm_v11_patched_dependencies() {
+        let yaml = r#"
+lockfileVersion: '9.0'
+
+patchedDependencies:
+  is-odd@3.0.1: 14cc7ca69e60d7f134a084780497229ca84ff01fcd958298f26495bd6c120c6f
+
+importers:
+  .: {}
+"#;
+
+        let lockfile = PnpmLockfile::from_bytes(yaml.as_bytes()).unwrap();
+
+        assert_eq!(lockfile.patch_keys(), vec!["is-odd@3.0.1"]);
+        assert_eq!(
+            lockfile.patches().unwrap(),
+            Vec::<RelativeUnixPathBuf>::new()
+        );
     }
 
     #[test]

--- a/crates/turborepo-repository/src/package_manager/pnpm.rs
+++ b/crates/turborepo-repository/src/package_manager/pnpm.rs
@@ -117,6 +117,27 @@ pub fn prune_workspace_patches<R: AsRef<RelativeUnixPath>>(
     Ok(())
 }
 
+pub fn patch_paths_for_keys(
+    workspace_yaml_path: &AbsoluteSystemPath,
+    patch_keys: &[String],
+) -> Result<Vec<RelativeUnixPathBuf>, std::io::Error> {
+    if !workspace_yaml_path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let patch_keys: HashSet<&str> = patch_keys.iter().map(String::as_str).collect();
+    let contents = workspace_yaml_path.read_to_string()?;
+    let workspace: PnpmWorkspace = serde_yaml_ng::from_str(&contents)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+    Ok(workspace
+        .patched_dependencies
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|(key, path)| patch_keys.contains(key.as_str()).then_some(path))
+        .collect())
+}
+
 pub fn link_workspace_packages(pnpm_version: PnpmVersion, repo_root: &AbsoluteSystemPath) -> bool {
     let npmrc_config = npmrc::NpmRc::from_file(repo_root)
         .inspect_err(|e| debug!("unable to read npmrc: {e}"))
@@ -158,7 +179,7 @@ struct PnpmWorkspace {
     pub packages: Vec<String>,
     link_workspace_packages: Option<LinkWorkspacePackages>,
     #[serde(rename = "patchedDependencies")]
-    _patched_dependencies:
+    patched_dependencies:
         Option<std::collections::BTreeMap<String, turbopath::RelativeUnixPathBuf>>,
     /// Default catalog (`catalog:` protocol resolves to these)
     #[serde(default)]

--- a/lockfile-tests/fixtures/pnpm-11-flat-patch/meta.json
+++ b/lockfile-tests/fixtures/pnpm-11-flat-patch/meta.json
@@ -1,0 +1,7 @@
+{
+  "packageManager": "pnpm",
+  "packageManagerVersion": "pnpm@11.0.0-rc.5",
+  "lockfileName": "pnpm-lock.yaml",
+  "frozenInstallCommand": ["pnpm", "install", "--frozen-lockfile"],
+  "expectedFailures": []
+}

--- a/lockfile-tests/fixtures/pnpm-11-flat-patch/package.json
+++ b/lockfile-tests/fixtures/pnpm-11-flat-patch/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "root",
+  "version": "0.0.0",
+  "private": true,
+  "packageManager": "pnpm@11.0.0-rc.5"
+}

--- a/lockfile-tests/fixtures/pnpm-11-flat-patch/packages/a/package.json
+++ b/lockfile-tests/fixtures/pnpm-11-flat-patch/packages/a/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "a",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "is-odd": "3.0.1"
+  }
+}

--- a/lockfile-tests/fixtures/pnpm-11-flat-patch/patches/is-odd@3.0.1.patch
+++ b/lockfile-tests/fixtures/pnpm-11-flat-patch/patches/is-odd@3.0.1.patch
@@ -1,0 +1,10 @@
+diff --git a/index.js b/index.js
+index 79d1f22a8e7a27efb8841bb83cb682ea1ff3a59c..2b8e89fe3824ff51adc0eb8dddb2c594b6118400 100644
+--- a/index.js
++++ b/index.js
+@@ -23,3 +23,5 @@ module.exports = function isOdd(value) {
+   return (n % 2) === 1;
+ };
+ 
++
++// patched

--- a/lockfile-tests/fixtures/pnpm-11-flat-patch/pnpm-lock.yaml
+++ b/lockfile-tests/fixtures/pnpm-11-flat-patch/pnpm-lock.yaml
@@ -1,0 +1,36 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+patchedDependencies:
+  is-odd@3.0.1: 14cc7ca69e60d7f134a084780497229ca84ff01fcd958298f26495bd6c120c6f
+
+importers:
+
+  .: {}
+
+  packages/a:
+    dependencies:
+      is-odd:
+        specifier: 3.0.1
+        version: 3.0.1(patch_hash=14cc7ca69e60d7f134a084780497229ca84ff01fcd958298f26495bd6c120c6f)
+
+packages:
+
+  is-number@6.0.0:
+    resolution: {integrity: sha512-Wu1VHeILBK8KAWJUAiSZQX94GmOE45Rg6/538fKwiloUu21KncEkYGPqob2oSZ5mUT73vLGrHQjKw3KMPwfDzg==}
+    engines: {node: '>=0.10.0'}
+
+  is-odd@3.0.1:
+    resolution: {integrity: sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==}
+    engines: {node: '>=4'}
+
+snapshots:
+
+  is-number@6.0.0: {}
+
+  is-odd@3.0.1(patch_hash=14cc7ca69e60d7f134a084780497229ca84ff01fcd958298f26495bd6c120c6f):
+    dependencies:
+      is-number: 6.0.0

--- a/lockfile-tests/fixtures/pnpm-11-flat-patch/pnpm-workspace.yaml
+++ b/lockfile-tests/fixtures/pnpm-11-flat-patch/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - "packages/*"
+patchedDependencies:
+  is-odd@3.0.1: patches/is-odd@3.0.1.patch

--- a/lockfile-tests/fixtures/pnpm-11-flat-patch/turbo.json
+++ b/lockfile-tests/fixtures/pnpm-11-flat-patch/turbo.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {}
+}


### PR DESCRIPTION
## Summary
- Fixes pnpm 11 lockfile parsing when `patchedDependencies` entries are stored as hash strings instead of `{ path, hash }` objects.
- Keeps `turbo prune` working for patched pnpm 11 workspaces by resolving patch file paths from pnpm config.
- Adds a representative pnpm 11 lockfile fixture for `check-lockfiles`.

Fixes #12658.

## Testing
- `pnpm --dir lockfile-tests check-lockfiles --fixture pnpm-11-flat-patch --concurrency 1`