### PR TITLE
fix: Avoid rerunning non-cacheable watch dependencies

### DIFF
--- a/crates/turborepo-engine/src/lib.rs
+++ b/crates/turborepo-engine/src/lib.rs
@@ -56,6 +56,10 @@ pub use validate::{TaskDefinitionResult, validate_task_name};
 /// This allows the engine to be decoupled from the full TaskDefinition type
 /// while still having access to the fields it needs for execution decisions.
 pub trait TaskDefinitionInfo {
+    /// Returns true if this task can restore outputs from cache.
+    fn cache(&self) -> bool {
+        true
+    }
     /// Returns true if this task is persistent (long-running)
     fn persistent(&self) -> bool;
     /// Returns true if this task can be interrupted and restarted
@@ -65,6 +69,10 @@ pub trait TaskDefinitionInfo {
 }
 
 impl TaskDefinitionInfo for turborepo_types::TaskDefinition {
+    fn cache(&self) -> bool {
+        self.cache
+    }
+
     fn persistent(&self) -> bool {
         self.persistent
     }
@@ -237,15 +245,16 @@ impl<T: TaskDefinitionInfo + Default + Clone> Default for Engine<Building, T> {
 
 impl<T: TaskDefinitionInfo + Clone> Engine<Built, T> {
     /// Creates an engine containing only tasks reachable from the given
-    /// packages: their direct tasks, transitive dependents, and all
+    /// packages: their direct tasks, transitive dependents, and cacheable
     /// transitive dependencies needed for execution. Persistent
     /// non-interruptible tasks are excluded (they can't be restarted in
     /// watch mode). Used by watch mode to scope rebuilds to the changed
     /// portion of the task graph.
     ///
-    /// Transitive dependencies are included because the executor needs them
-    /// to produce outputs that downstream tasks consume — on a cold cache
-    /// or first run, those outputs won't already be on disk.
+    /// Cacheable transitive dependencies are included because the executor
+    /// needs them to restore outputs that downstream tasks consume.
+    /// Non-cacheable dependencies are excluded because retaining them would
+    /// force execution even when they did not change.
     pub fn create_engine_for_subgraph(self, changed_packages: &HashSet<PackageName>) -> Self {
         let entrypoint_indices: Vec<_> = changed_packages
             .iter()
@@ -254,7 +263,7 @@ impl<T: TaskDefinitionInfo + Clone> Engine<Built, T> {
             .copied()
             .collect();
 
-        let reachable = self.reachable_closure(entrypoint_indices);
+        let reachable = self.watch_reachable_closure(entrypoint_indices);
         self.prune_to_reachable(&reachable, true)
     }
 
@@ -359,6 +368,61 @@ impl<T: TaskDefinitionInfo + Clone> Engine<Built, T> {
         });
 
         reachable
+    }
+
+    /// Computes the watch-mode reachable set from changed package task nodes:
+    /// reverse DFS for transitive dependents, then forward traversal for only
+    /// cacheable transitive dependencies.
+    fn watch_reachable_closure(
+        &self,
+        entrypoint_indices: Vec<petgraph::graph::NodeIndex>,
+    ) -> HashSet<petgraph::graph::NodeIndex> {
+        // Reverse DFS: find transitive dependents (downstream consumers).
+        let mut reachable = HashSet::new();
+        reachable.insert(self.root_index);
+        depth_first_search(Reversed(&self.task_graph), entrypoint_indices, |event| {
+            if let DfsEvent::Discover(n, _) = event {
+                reachable.insert(n);
+            }
+        });
+
+        let mut stack: Vec<_> = reachable
+            .iter()
+            .copied()
+            .filter(|&n| n != self.root_index)
+            .collect();
+
+        while let Some(node) = stack.pop() {
+            for dependency in self
+                .task_graph
+                .neighbors_directed(node, petgraph::Direction::Outgoing)
+            {
+                if dependency == self.root_index || !self.is_cacheable_task_node(dependency) {
+                    continue;
+                }
+
+                if reachable.insert(dependency) {
+                    stack.push(dependency);
+                }
+            }
+        }
+
+        reachable
+    }
+
+    fn is_cacheable_task_node(&self, node: petgraph::graph::NodeIndex) -> bool {
+        let TaskNode::Task(task) = self
+            .task_graph
+            .node_weight(node)
+            .expect("node index should be present")
+        else {
+            return false;
+        };
+
+        self.task_definitions
+            .get(task)
+            .expect("task should have definition")
+            .cache()
     }
 
     /// Prunes the engine graph to only nodes in `reachable` and rebuilds all

--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -518,6 +518,50 @@ mod test {
         );
     }
 
+    /// Regression test for https://github.com/vercel/turborepo/issues/12654
+    ///
+    /// `turbo watch dev` should not re-run a dependency package's `dev` task
+    /// when only the dependent app changed. Non-cacheable tasks cannot restore
+    /// outputs from cache, so retaining them would force unnecessary execution.
+    #[test]
+    fn test_subgraph_excludes_non_cacheable_upstream_dependency() {
+        let mut engine: Engine<Building> = Engine::new();
+
+        let lib_dev = TaskId::new("lib", "dev");
+        let app_dev = TaskId::new("app", "dev");
+
+        let lib_idx = engine.get_index(&lib_dev);
+        let app_idx = engine.get_index(&app_dev);
+
+        let dev_definition = TaskDefinition {
+            cache: false,
+            ..Default::default()
+        };
+
+        engine.add_definition(lib_dev.clone(), dev_definition.clone());
+        engine.add_definition(app_dev.clone(), dev_definition);
+
+        // app#dev depends on lib#dev (^dev)
+        engine.task_graph_mut().add_edge(app_idx, lib_idx, ());
+        engine.connect_to_root(&lib_dev);
+
+        let engine = engine.seal();
+
+        // Only app's files changed — lib is untouched.
+        let subgraph =
+            engine.create_engine_for_subgraph(&[PackageName::from("app")].into_iter().collect());
+
+        let task_ids: HashSet<_> = subgraph.task_ids().cloned().collect();
+        assert!(
+            task_ids.contains(&app_dev),
+            "changed package's task should survive"
+        );
+        assert!(
+            !task_ids.contains(&lib_dev),
+            "non-cacheable upstream dependency should not be re-run for an app-only change"
+        );
+    }
+
     #[tokio::test]
     async fn test_tasks_impacted_by_packages() {
         // Tests the batched transitive dependents lookup for watch mode.

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -143,6 +143,14 @@ The core task graph consists of:
 - Root is an artifacts of our Go graph library which required all graphs have a single entrypoint
 - Edges: Dependencies between tasks, at the moment no additional data (weights) are added to the edge
 
+#### Engine Pruning (`crates/turborepo-engine/src/lib.rs`)
+
+- `retain_affected_tasks` keeps directly affected tasks, transitive dependents,
+  and all transitive dependencies required for normal `--affected` execution
+- `create_engine_for_subgraph` is used by watch mode. It keeps changed package
+  tasks, transitive dependents, and only cacheable upstream dependencies that can
+  restore outputs without forcing non-cacheable tasks to rerun
+
 ### 4. Task Visitor (`crates/turborepo-lib/src/task_graph/visitor/`)
 
 The task graph visitor handles task execution:


### PR DESCRIPTION
- Prevents `turbo watch` from re-running unchanged upstream dependency tasks when those tasks have `cache: false`.
- Keeps cacheable upstream dependencies in the watch subgraph so downstream tasks can still restore required outputs.
- Adds a regression test for the `turbo watch dev` issue reported in #12654.

## Testing

- Verified manually against the issue repro