### PR TITLE
docs: Clarify root task guidance

### DIFF
--- a/skills/turborepo/SKILL.md
+++ b/skills/turborepo/SKILL.md
@@ -18,15 +18,15 @@ Build system for JavaScript/TypeScript monorepos. Turborepo caches task outputs 
 
 ## IMPORTANT: Package Tasks, Not Root Tasks
 
-**DO NOT create Root Tasks. ALWAYS create package tasks.**
+**Prefer package tasks over Root Tasks.**
 
-When creating tasks/scripts/pipelines, you MUST:
+When creating tasks/scripts/pipelines, you MUST default to package tasks:
 
 1. Add the script to each relevant package's `package.json`
 2. Register the task in root `turbo.json`
 3. Root `package.json` only delegates via `turbo run <task>`
 
-**DO NOT** put task logic in root `package.json`. This defeats Turborepo's parallelization.
+**DO NOT** put task logic in root `package.json` when it can live in packages. This defeats Turborepo's parallelization.
 
 ```json
 // DO THIS: Scripts in each package
@@ -74,7 +74,7 @@ When creating tasks/scripts/pipelines, you MUST:
 }
 ```
 
-Root Tasks (`//#taskname`) are ONLY for tasks that truly cannot exist in packages (rare).
+Root Tasks (`//#taskname`) are ONLY for tasks that truly cannot exist in packages, such as Vitest Projects' `//#test`, repo-wide release scripts, or tooling that does not invoke `turbo` itself.
 
 ## Secondary Rule: `turbo run` vs `turbo`
 

--- a/skills/turborepo/command/turborepo.md
+++ b/skills/turborepo/command/turborepo.md
@@ -41,10 +41,10 @@ Apply Turborepo-specific patterns from references to complete the user's request
 
 **CRITICAL - When creating tasks/scripts/pipelines:**
 
-1. **DO NOT create Root Tasks** - Always create package tasks
+1. **Prefer package tasks over Root Tasks.** Root Tasks (`//#taskname`) are only for tasks that truly cannot exist in packages, such as Vitest Projects' `//#test`, repo-wide release scripts, or tooling that does not invoke `turbo` itself.
 2. Add scripts to each relevant package's `package.json` (e.g., `apps/web/package.json`, `packages/ui/package.json`)
 3. Register the task in root `turbo.json`
-4. Root `package.json` only contains `turbo run <task>` - never actual task logic
+4. Root `package.json` only contains `turbo run <task>` - never actual task logic, unless defining a valid Root Task exception
 
 **Other things to verify:**
 

--- a/skills/turborepo/references/configuration/gotchas.md
+++ b/skills/turborepo/references/configuration/gotchas.md
@@ -138,9 +138,9 @@ Don't use relative paths like `../` to reference files outside the package. Use 
 
 ## #6 MOST COMMON MISTAKE: Creating Root Tasks
 
-**DO NOT create Root Tasks. ALWAYS create package tasks.**
+**Prefer package tasks over Root Tasks.**
 
-When you need to create a task (build, lint, test, typecheck, etc.):
+When you need to create a task (build, lint, test, typecheck, etc.), default to package tasks:
 
 1. Add the script to **each relevant package's** `package.json`
 2. Register the task in root `turbo.json`
@@ -186,7 +186,7 @@ When you need to create a task (build, lint, test, typecheck, etc.):
 - Each package's output is cached **individually**
 - You can **filter** to specific packages: `turbo run test --filter=web`
 
-Root Tasks (`//#taskname`) defeat all these benefits. Only use them for tasks that truly cannot exist in any package (extremely rare).
+Root Tasks (`//#taskname`) defeat all these benefits when a task can live in packages. Only use them for tasks that truly cannot exist in any package, such as Vitest Projects' `//#test`, repo-wide release scripts, or tooling that does not invoke `turbo` itself.
 
 ## #7 Tasks That Need Parallel Execution + Cache Invalidation
 


### PR DESCRIPTION
## Summary

- Aligns the Turborepo skill dispatcher with the skill guidance for rare valid Root Tasks.
- Keeps package tasks as the default while documenting exceptions like Vitest Projects, release scripts, and tooling that does not invoke `turbo`.

Closes #12638

## Testing

- `pnpm exec oxfmt --check skills/turborepo/command/turborepo.md skills/turborepo/SKILL.md skills/turborepo/references/configuration/gotchas.md`
- pre-push hooks: `format`, `check:toml`, Rust checks