### PR TITLE
test: Add SIGINT regression for npm script shell

### DIFF
--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -97,7 +97,19 @@ enum ChildHandleImpl {
 
 #[cfg(unix)]
 #[derive(Debug, Clone, Copy)]
+enum GracefulInterruptTarget {
+    DirectChild,
+    ProcessGroup,
+}
+
+#[cfg(unix)]
+#[derive(Debug, Clone, Copy)]
 struct ShutdownSemantics {
+    // Who should receive the first graceful interrupt.
+    graceful_interrupt_target: GracefulInterruptTarget,
+    // Whether to signal the process group when the direct child exits before
+    // its process group finishes.
+    signal_process_group_after_child_exit: bool,
     // Whether we should keep waiting on the process group after the direct child exits.
     wait_for_process_group_after_child_exit: bool,
 }
@@ -106,6 +118,16 @@ struct ShutdownSemantics {
 impl ShutdownSemantics {
     fn process_group() -> Self {
         Self {
+            graceful_interrupt_target: GracefulInterruptTarget::ProcessGroup,
+            signal_process_group_after_child_exit: false,
+            wait_for_process_group_after_child_exit: true,
+        }
+    }
+
+    fn direct_child_then_process_group() -> Self {
+        Self {
+            graceful_interrupt_target: GracefulInterruptTarget::DirectChild,
+            signal_process_group_after_child_exit: true,
             wait_for_process_group_after_child_exit: true,
         }
     }
@@ -356,7 +378,7 @@ impl ChildHandle {
                 pid,
                 imp: ChildHandleImpl::Pty(child),
                 #[cfg(unix)]
-                shutdown_semantics: ShutdownSemantics::process_group(),
+                shutdown_semantics: ShutdownSemantics::direct_child_then_process_group(),
                 #[cfg(unix)]
                 target_identity,
                 #[cfg(windows)]
@@ -383,6 +405,21 @@ impl ChildHandle {
 
     #[cfg(unix)]
     fn send_graceful_interrupt(&self, pid: libc::pid_t) {
+        match self.shutdown_semantics.graceful_interrupt_target {
+            GracefulInterruptTarget::DirectChild => {
+                debug!("sending SIGINT to child {}", pid);
+                if unsafe { libc::kill(pid, libc::SIGINT) } == -1 {
+                    debug!("failed to send SIGINT to {pid}");
+                }
+            }
+            GracefulInterruptTarget::ProcessGroup => {
+                self.send_graceful_interrupt_to_process_group(pid)
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    fn send_graceful_interrupt_to_process_group(&self, pid: libc::pid_t) {
         let Some(process_group_id) = self.process_group_id() else {
             debug!("missing process group id for child {}", pid);
             return;
@@ -393,6 +430,12 @@ impl ChildHandle {
         if unsafe { libc::kill(target, libc::SIGINT) } == -1 {
             debug!("failed to send SIGINT to {target}");
         }
+    }
+
+    #[cfg(unix)]
+    fn should_signal_process_group_after_child_exit(&self) -> bool {
+        self.shutdown_semantics
+            .signal_process_group_after_child_exit
     }
 
     #[cfg(unix)]
@@ -736,6 +779,12 @@ impl ShutdownStyle {
                     };
 
                     if exit == ChildExit::Interrupted {
+                        if child.should_signal_process_group_after_child_exit()
+                            && child.has_running_process_group(pid as libc::pid_t)
+                        {
+                            child.send_graceful_interrupt_to_process_group(pid as libc::pid_t);
+                        }
+
                         child
                             .wait_for_process_group_exit(
                                 pid as libc::pid_t,

--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -97,16 +97,7 @@ enum ChildHandleImpl {
 
 #[cfg(unix)]
 #[derive(Debug, Clone, Copy)]
-enum GracefulInterruptTarget {
-    DirectChild,
-    ProcessGroup,
-}
-
-#[cfg(unix)]
-#[derive(Debug, Clone, Copy)]
 struct ShutdownSemantics {
-    // Who should receive the first graceful interrupt.
-    graceful_interrupt_target: GracefulInterruptTarget,
     // Whether we should keep waiting on the process group after the direct child exits.
     wait_for_process_group_after_child_exit: bool,
 }
@@ -115,14 +106,6 @@ struct ShutdownSemantics {
 impl ShutdownSemantics {
     fn process_group() -> Self {
         Self {
-            graceful_interrupt_target: GracefulInterruptTarget::ProcessGroup,
-            wait_for_process_group_after_child_exit: true,
-        }
-    }
-
-    fn direct_child_then_wait_for_process_group() -> Self {
-        Self {
-            graceful_interrupt_target: GracefulInterruptTarget::DirectChild,
             wait_for_process_group_after_child_exit: true,
         }
     }
@@ -373,7 +356,7 @@ impl ChildHandle {
                 pid,
                 imp: ChildHandleImpl::Pty(child),
                 #[cfg(unix)]
-                shutdown_semantics: ShutdownSemantics::direct_child_then_wait_for_process_group(),
+                shutdown_semantics: ShutdownSemantics::process_group(),
                 #[cfg(unix)]
                 target_identity,
                 #[cfg(windows)]
@@ -400,20 +383,12 @@ impl ChildHandle {
 
     #[cfg(unix)]
     fn send_graceful_interrupt(&self, pid: libc::pid_t) {
-        let target = match self.shutdown_semantics.graceful_interrupt_target {
-            GracefulInterruptTarget::DirectChild => {
-                debug!("sending SIGINT to child {}", pid);
-                pid
-            }
-            GracefulInterruptTarget::ProcessGroup => {
-                let Some(process_group_id) = self.process_group_id() else {
-                    debug!("missing process group id for child {}", pid);
-                    return;
-                };
-                debug!("sending SIGINT to process group -{}", process_group_id);
-                -process_group_id
-            }
+        let Some(process_group_id) = self.process_group_id() else {
+            debug!("missing process group id for child {}", pid);
+            return;
         };
+        debug!("sending SIGINT to process group -{}", process_group_id);
+        let target = -process_group_id;
 
         if unsafe { libc::kill(target, libc::SIGINT) } == -1 {
             debug!("failed to send SIGINT to {target}");
@@ -776,10 +751,66 @@ impl ShutdownStyle {
 
                 #[cfg(windows)]
                 {
-                    debug!("timeout not supported on windows, killing");
-                    match child.kill().await {
-                        Ok(_) => ChildExit::Killed,
-                        Err(_) => ChildExit::Failed,
+                    // Windows broadcasts Ctrl+C to all processes attached to the
+                    // console. Turbo's graceful shutdown should give child
+                    // processes a chance to handle that event before escalating.
+                    let deadline = timeout.map(|timeout| tokio::time::Instant::now() + timeout);
+                    let mut command_rx_open = true;
+
+                    match deadline {
+                        Some(deadline) => loop {
+                            tokio::select! {
+                                result = child.wait() => {
+                                    break match result {
+                                        Ok(_exit_code) => ChildExit::Interrupted,
+                                        Err(_) => ChildExit::Failed,
+                                    };
+                                }
+                                command = command_rx.recv(), if command_rx_open => {
+                                    match command {
+                                        Some(ChildCommand::Kill) => {
+                                            debug!("graceful shutdown interrupted, killing child");
+                                            break match child.kill().await {
+                                                Ok(_) => ChildExit::Killed,
+                                                Err(_) => ChildExit::Failed,
+                                            };
+                                        }
+                                        Some(ChildCommand::Shutdown(_)) => {}
+                                        None => command_rx_open = false,
+                                    }
+                                }
+                                _ = tokio::time::sleep_until(deadline) => {
+                                    debug!("graceful shutdown timed out, killing child");
+                                    break match child.kill().await {
+                                        Ok(_) => ChildExit::Killed,
+                                        Err(_) => ChildExit::Failed,
+                                    };
+                                }
+                            }
+                        },
+                        None => loop {
+                            tokio::select! {
+                                result = child.wait() => {
+                                    break match result {
+                                        Ok(_exit_code) => ChildExit::Interrupted,
+                                        Err(_) => ChildExit::Failed,
+                                    };
+                                }
+                                command = command_rx.recv(), if command_rx_open => {
+                                    match command {
+                                        Some(ChildCommand::Kill) => {
+                                            debug!("graceful shutdown interrupted, killing child");
+                                            break match child.kill().await {
+                                                Ok(_) => ChildExit::Killed,
+                                                Err(_) => ChildExit::Failed,
+                                            };
+                                        }
+                                        Some(ChildCommand::Shutdown(_)) => {}
+                                        None => command_rx_open = false,
+                                    }
+                                }
+                            }
+                        },
                     }
                 }
             }
@@ -1919,11 +1950,7 @@ mod test {
         let exit = child.stop().await;
 
         // On Unix, shell scripts may not respond to SIGINT and will timeout,
-        // resulting in being killed rather than interrupted. For non-PTY
-        // children, SIGINT goes to the process group but shells may still
-        // continue their loop. For PTY children, SIGINT goes only to the
-        // direct child to avoid double delivery through package managers,
-        // which also means the shell may not exit gracefully.
+        // resulting in being killed rather than interrupted.
         if cfg!(unix) {
             assert_matches!(exit, Some(ChildExit::Killed) | Some(ChildExit::Interrupted));
         } else {

--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -19,6 +19,8 @@ const CHILD_POLL_INTERVAL: Duration = Duration::from_micros(50);
 const POST_EXIT_OUTPUT_DRAIN_TIMEOUT: Duration = Duration::from_millis(100);
 #[cfg(any(unix, windows))]
 const PROCESS_TREE_DRAIN_POLL_INTERVAL: Duration = Duration::from_millis(10);
+#[cfg(unix)]
+const PROCESS_GROUP_INTERRUPT_FALLBACK_DELAY: Duration = Duration::from_secs(5);
 
 use std::{
     fmt,
@@ -177,6 +179,72 @@ fn process_group_matches_identity(target_pid: libc::pid_t, identity: TargetIdent
 #[cfg(unix)]
 fn signal_process_group(process_group_id: libc::pid_t, signal: libc::c_int) {
     let _ = unsafe { libc::kill(-process_group_id, signal) };
+}
+
+#[cfg(target_os = "linux")]
+fn linux_descendant_leaf_processes(root_pid: libc::pid_t) -> io::Result<Vec<libc::pid_t>> {
+    let mut processes = Vec::new();
+    for entry in std::fs::read_dir("/proc")? {
+        let entry = entry?;
+        let Some(pid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|name| name.parse::<libc::pid_t>().ok())
+        else {
+            continue;
+        };
+
+        let stat = match std::fs::read_to_string(entry.path().join("stat")) {
+            Ok(stat) => stat,
+            Err(_) => continue,
+        };
+        let Some(fields) = stat.rsplit_once(") ").map(|(_, fields)| fields) else {
+            continue;
+        };
+        let Some(parent_pid) = fields
+            .split_whitespace()
+            .nth(1)
+            .and_then(|field| field.parse::<libc::pid_t>().ok())
+        else {
+            continue;
+        };
+
+        processes.push((pid, parent_pid));
+    }
+
+    let mut descendants = Vec::new();
+    let mut queue = std::collections::VecDeque::from([root_pid]);
+    while let Some(parent_pid) = queue.pop_front() {
+        for (pid, candidate_parent_pid) in &processes {
+            if *candidate_parent_pid == parent_pid {
+                descendants.push(*pid);
+                queue.push_back(*pid);
+            }
+        }
+    }
+
+    let descendants = descendants
+        .into_iter()
+        .filter(|pid| {
+            !processes
+                .iter()
+                .any(|(_, candidate_parent_pid)| candidate_parent_pid == pid)
+        })
+        .collect();
+
+    Ok(descendants)
+}
+
+#[cfg(target_os = "linux")]
+fn signal_descendant_leaf_processes(root_pid: libc::pid_t, signal: libc::c_int) {
+    match linux_descendant_leaf_processes(root_pid) {
+        Ok(descendants) => {
+            for pid in descendants {
+                let _ = unsafe { libc::kill(pid, signal) };
+            }
+        }
+        Err(err) => debug!("failed to enumerate descendants for process {root_pid}: {err}"),
+    }
 }
 
 #[cfg(unix)]
@@ -430,6 +498,32 @@ impl ChildHandle {
         if unsafe { libc::kill(target, libc::SIGINT) } == -1 {
             debug!("failed to send SIGINT to {target}");
         }
+    }
+
+    #[cfg(unix)]
+    fn send_graceful_interrupt_to_process_group_if_separate(&self, pid: libc::pid_t) {
+        let Some(process_group_id) = self.process_group_id() else {
+            debug!("missing process group id for child {}", pid);
+            return;
+        };
+
+        if process_group_id == unsafe { libc::getpgrp() } {
+            debug!("not sending SIGINT to current process group {process_group_id}");
+            return;
+        }
+
+        self.send_graceful_interrupt_to_process_group(pid);
+    }
+
+    #[cfg(target_os = "linux")]
+    fn send_graceful_interrupt_to_descendants(&self, pid: libc::pid_t) {
+        debug!("sending SIGINT to descendants of child {}", pid);
+        signal_descendant_leaf_processes(pid, libc::SIGINT);
+    }
+
+    #[cfg(all(unix, not(target_os = "linux")))]
+    fn send_graceful_interrupt_to_descendants(&self, pid: libc::pid_t) {
+        self.send_graceful_interrupt_to_process_group_if_separate(pid);
     }
 
     #[cfg(unix)]
@@ -718,6 +812,12 @@ impl ShutdownStyle {
                     debug!("waiting for child {}", pid);
 
                     let deadline = timeout.map(|timeout| tokio::time::Instant::now() + timeout);
+                    let mut fallback_interrupt_deadline = child
+                        .should_signal_process_group_after_child_exit()
+                        .then(|| {
+                            tokio::time::Instant::now() + PROCESS_GROUP_INTERRUPT_FALLBACK_DELAY
+                        });
+                    let mut sent_fallback_interrupt = false;
                     let mut command_rx_open = true;
 
                     let exit = loop {
@@ -741,6 +841,17 @@ impl ShutdownStyle {
                                             }
                                             Some(ChildCommand::Shutdown(_)) => {}
                                             None => command_rx_open = false,
+                                        }
+                                    }
+                                    _ = async {
+                                        if let Some(deadline) = fallback_interrupt_deadline {
+                                            tokio::time::sleep_until(deadline).await;
+                                        }
+                                    }, if fallback_interrupt_deadline.is_some() => {
+                                        fallback_interrupt_deadline = None;
+                                        if child.has_running_process_group(pid as libc::pid_t) {
+                                            child.send_graceful_interrupt_to_descendants(pid as libc::pid_t);
+                                            sent_fallback_interrupt = true;
                                         }
                                     }
                                     _ = tokio::time::sleep_until(deadline) => {
@@ -773,6 +884,17 @@ impl ShutdownStyle {
                                             None => command_rx_open = false,
                                         }
                                     }
+                                    _ = async {
+                                        if let Some(deadline) = fallback_interrupt_deadline {
+                                            tokio::time::sleep_until(deadline).await;
+                                        }
+                                    }, if fallback_interrupt_deadline.is_some() => {
+                                        fallback_interrupt_deadline = None;
+                                        if child.has_running_process_group(pid as libc::pid_t) {
+                                            child.send_graceful_interrupt_to_descendants(pid as libc::pid_t);
+                                            sent_fallback_interrupt = true;
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -780,9 +902,12 @@ impl ShutdownStyle {
 
                     if exit == ChildExit::Interrupted {
                         if child.should_signal_process_group_after_child_exit()
+                            && !sent_fallback_interrupt
                             && child.has_running_process_group(pid as libc::pid_t)
                         {
-                            child.send_graceful_interrupt_to_process_group(pid as libc::pid_t);
+                            child.send_graceful_interrupt_to_process_group_if_separate(
+                                pid as libc::pid_t,
+                            );
                         }
 
                         child

--- a/crates/turborepo/tests/graceful_shutdown_test.rs
+++ b/crates/turborepo/tests/graceful_shutdown_test.rs
@@ -168,6 +168,57 @@ mod unix {
         (tempdir, test_dir)
     }
 
+    fn setup_npm_root_shutdown_example_with_command(
+        script_name: &str,
+        script_command: &str,
+        script_contents: &str,
+    ) -> (TempDir, PathBuf) {
+        let tempdir = tempfile::tempdir().expect("failed to create tempdir");
+        let test_dir = tempdir.path().to_path_buf();
+        setup::copy_fixture("basic_monorepo", &test_dir).expect("failed to copy npm fixture");
+        fs::write(
+            test_dir.join(".npmrc"),
+            "script-shell=sh\nupdate-notifier=false\n",
+        )
+        .expect("failed to write npm config");
+
+        fs::write(test_dir.join(script_name), script_contents).expect("failed to write script");
+
+        fs::write(
+            test_dir.join("package.json"),
+            serde_json::to_string_pretty(&json!({
+                "name": "monorepo",
+                "scripts": {
+                    "start": script_command,
+                },
+                "packageManager": "npm@10.5.0",
+                "workspaces": [
+                    "apps/**",
+                    "packages/**",
+                ],
+            }))
+            .expect("failed to serialize package.json"),
+        )
+        .expect("failed to update package.json");
+
+        fs::write(
+            test_dir.join("turbo.json"),
+            serde_json::to_string_pretty(&json!({
+                "$schema": "https://turborepo.dev/schema.json",
+                "tasks": {
+                    "//#start": {
+                        "cache": false,
+                        "persistent": true,
+                    }
+                }
+            }))
+            .expect("failed to serialize turbo.json"),
+        )
+        .expect("failed to update turbo.json");
+
+        (tempdir, test_dir)
+    }
+
     fn turbo_bin() -> PathBuf {
         assert_cmd::cargo::cargo_bin("turbo")
     }
@@ -262,6 +313,69 @@ mod unix {
         command.env("DO_NOT_TRACK", "1");
         command.env("NPM_CONFIG_UPDATE_NOTIFIER", "false");
         command.env("COREPACK_ENABLE_DOWNLOAD_PROMPT", "0");
+        command.env_remove("CI");
+        command.env_remove("GITHUB_ACTIONS");
+
+        let child = pair
+            .slave
+            .spawn_command(command)
+            .expect("failed to spawn turbo in pty");
+
+        PtyTurbo {
+            child: Some(child),
+            writer: Some(writer),
+            output,
+            reader_thread: Some(reader_thread),
+        }
+    }
+
+    fn spawn_interactive_turbo_start_with_env(test_dir: &Path, env: &[(&str, &str)]) -> PtyTurbo {
+        let pty_system = native_pty_system();
+        let pair = pty_system
+            .openpty(PtySize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("failed to create pty pair");
+
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let output_clone = output.clone();
+        let mut reader = pair
+            .master
+            .try_clone_reader()
+            .expect("failed to clone pty reader");
+        let reader_thread = thread::spawn(move || {
+            let mut buffer = [0; 1024];
+            loop {
+                match reader.read(&mut buffer) {
+                    Ok(0) => break,
+                    Ok(n) => append_capped_output(&output_clone, &buffer[..n]),
+                    Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
+                    Err(_) => break,
+                }
+            }
+        });
+
+        let writer = pair
+            .master
+            .take_writer()
+            .expect("failed to take pty writer");
+
+        let mut command = CommandBuilder::new(turbo_bin());
+        command.arg("run");
+        command.arg("start");
+        command.cwd(test_dir);
+        command.env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1");
+        command.env("TURBO_GLOBAL_WARNING_DISABLED", "1");
+        command.env("TURBO_PRINT_VERSION_DISABLED", "1");
+        command.env("DO_NOT_TRACK", "1");
+        command.env("NPM_CONFIG_UPDATE_NOTIFIER", "false");
+        command.env("COREPACK_ENABLE_DOWNLOAD_PROMPT", "0");
+        for (key, value) in env {
+            command.env(key, value);
+        }
         command.env_remove("CI");
         command.env_remove("GITHUB_ACTIONS");
 
@@ -417,6 +531,48 @@ while true; do sleep 0.2 || true; done
         assert!(
             cleanup_idx < cleanup_done_idx,
             "cleanup completion log should appear after cleanup starts\n{transcript}"
+        );
+    }
+
+    #[test]
+    fn run_forwards_sigint_to_root_node_script_with_sh_script_shell_in_tty() {
+        let (_tempdir, test_dir) = setup_npm_root_shutdown_example_with_command(
+            "graceful.mjs",
+            "node ./graceful.mjs",
+            r#"import { writeFileSync } from "node:fs";
+
+process.on("SIGINT", () => {
+  console.log("node cleanup start");
+  setTimeout(() => {
+    writeFileSync("cleanup.done", "");
+    console.log("node cleanup done");
+    process.exit(0);
+  }, 500);
+});
+
+console.log("node ready");
+writeFileSync("ready", "");
+setInterval(() => {}, 200);
+"#,
+        );
+
+        let ready_file = test_dir.join("ready");
+        let cleanup_file = test_dir.join("cleanup.done");
+
+        let mut child =
+            spawn_interactive_turbo_start_with_env(&test_dir, &[("NPM_CONFIG_SCRIPT_SHELL", "sh")]);
+        wait_for_path(&ready_file, START_TIMEOUT);
+
+        child.send_ctrl_c();
+        let transcript = child.finish(EXIT_TIMEOUT);
+
+        assert!(
+            cleanup_file.exists(),
+            "node SIGINT cleanup marker should exist"
+        );
+        assert!(
+            transcript.contains("node cleanup done"),
+            "expected Node SIGINT handler to finish with script-shell=sh\n{transcript}"
         );
     }
 
@@ -665,6 +821,268 @@ while true; do sleep 0.2 || true; done
             combined
                 .contains("Graceful shutdown timed out. Force killing Turborepo tasks: app-a#dev"),
             "expected auto-force banner after timeout\n{combined}"
+        );
+    }
+}
+
+#[cfg(windows)]
+mod windows {
+    use std::{
+        fs,
+        io::{Read, Write},
+        path::{Path, PathBuf},
+        sync::{Arc, Mutex},
+        thread,
+        time::{Duration, Instant},
+    };
+
+    use portable_pty::{CommandBuilder, PtySize, native_pty_system};
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    use crate::common::setup;
+
+    const START_TIMEOUT: Duration = Duration::from_secs(15);
+    const EXIT_TIMEOUT: Duration = Duration::from_secs(20);
+    const MAX_PTY_OUTPUT_BYTES: usize = 256 * 1024;
+
+    struct PtyTurbo {
+        child: Option<Box<dyn portable_pty::Child + Send + Sync>>,
+        writer: Option<Box<dyn Write + Send>>,
+        output: Arc<Mutex<Vec<u8>>>,
+        reader_thread: Option<thread::JoinHandle<()>>,
+    }
+
+    impl PtyTurbo {
+        fn send_ctrl_c(&mut self) {
+            let writer = self.writer.as_mut().expect("pty writer already taken");
+            writer
+                .write_all(&[3])
+                .expect("failed to write Ctrl+C to pty");
+            writer.flush().expect("failed to flush Ctrl+C to pty");
+        }
+
+        fn finish(mut self, timeout: Duration) -> String {
+            let start = Instant::now();
+            loop {
+                let status = self
+                    .child
+                    .as_mut()
+                    .expect("pty child guard consumed")
+                    .try_wait()
+                    .expect("failed waiting for pty child");
+                if status.is_some() {
+                    break;
+                }
+                if start.elapsed() > timeout {
+                    panic!("timed out waiting for pty child exit");
+                }
+                thread::sleep(Duration::from_millis(100));
+            }
+
+            let _ = self.child.take();
+            drop(self.writer.take());
+            if let Some(reader_thread) = self.reader_thread.take() {
+                reader_thread.join().expect("pty reader thread panicked");
+            }
+
+            normalize_output(String::from_utf8_lossy(&self.output.lock().unwrap()).as_ref())
+        }
+    }
+
+    impl Drop for PtyTurbo {
+        fn drop(&mut self) {
+            drop(self.writer.take());
+            if let Some(child) = self.child.as_mut() {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+            if let Some(reader_thread) = self.reader_thread.take() {
+                let _ = reader_thread.join();
+            }
+        }
+    }
+
+    fn append_capped_output(output: &Arc<Mutex<Vec<u8>>>, chunk: &[u8]) {
+        let mut output = output.lock().unwrap();
+        output.extend_from_slice(chunk);
+        if output.len() > MAX_PTY_OUTPUT_BYTES {
+            let excess = output.len() - MAX_PTY_OUTPUT_BYTES;
+            output.drain(..excess);
+        }
+    }
+
+    fn turbo_bin() -> PathBuf {
+        assert_cmd::cargo::cargo_bin("turbo")
+    }
+
+    fn setup_npm_root_shutdown_example_with_command(
+        script_name: &str,
+        script_command: &str,
+        script_contents: &str,
+    ) -> (TempDir, PathBuf) {
+        let tempdir = tempfile::tempdir().expect("failed to create tempdir");
+        let test_dir = tempdir.path().to_path_buf();
+        setup::copy_fixture("basic_monorepo", &test_dir).expect("failed to copy npm fixture");
+        fs::write(
+            test_dir.join(".npmrc"),
+            "script-shell=sh\nupdate-notifier=false\n",
+        )
+        .expect("failed to write npm config");
+
+        fs::write(test_dir.join(script_name), script_contents).expect("failed to write script");
+
+        fs::write(
+            test_dir.join("package.json"),
+            serde_json::to_string_pretty(&json!({
+                "name": "monorepo",
+                "scripts": {
+                    "start": script_command,
+                },
+                "packageManager": "npm@10.5.0",
+                "workspaces": [
+                    "apps/**",
+                    "packages/**",
+                ],
+            }))
+            .expect("failed to serialize package.json"),
+        )
+        .expect("failed to update package.json");
+
+        fs::write(
+            test_dir.join("turbo.json"),
+            serde_json::to_string_pretty(&json!({
+                "$schema": "https://turborepo.dev/schema.json",
+                "tasks": {
+                    "//#start": {
+                        "cache": false,
+                        "persistent": true,
+                    }
+                }
+            }))
+            .expect("failed to serialize turbo.json"),
+        )
+        .expect("failed to update turbo.json");
+
+        (tempdir, test_dir)
+    }
+
+    fn spawn_interactive_turbo_start_with_env(test_dir: &Path, env: &[(&str, &str)]) -> PtyTurbo {
+        let pty_system = native_pty_system();
+        let pair = pty_system
+            .openpty(PtySize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("failed to create pty pair");
+
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let output_clone = output.clone();
+        let mut reader = pair
+            .master
+            .try_clone_reader()
+            .expect("failed to clone pty reader");
+        let reader_thread = thread::spawn(move || {
+            let mut buffer = [0; 1024];
+            loop {
+                match reader.read(&mut buffer) {
+                    Ok(0) => break,
+                    Ok(n) => append_capped_output(&output_clone, &buffer[..n]),
+                    Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
+                    Err(_) => break,
+                }
+            }
+        });
+
+        let writer = pair
+            .master
+            .take_writer()
+            .expect("failed to take pty writer");
+
+        let mut command = CommandBuilder::new(turbo_bin());
+        command.arg("run");
+        command.arg("start");
+        command.cwd(test_dir);
+        command.env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1");
+        command.env("TURBO_GLOBAL_WARNING_DISABLED", "1");
+        command.env("TURBO_PRINT_VERSION_DISABLED", "1");
+        command.env("DO_NOT_TRACK", "1");
+        command.env("NPM_CONFIG_UPDATE_NOTIFIER", "false");
+        command.env("COREPACK_ENABLE_DOWNLOAD_PROMPT", "0");
+        for (key, value) in env {
+            command.env(key, value);
+        }
+        command.env_remove("CI");
+        command.env_remove("GITHUB_ACTIONS");
+
+        let child = pair
+            .slave
+            .spawn_command(command)
+            .expect("failed to spawn turbo in pty");
+
+        PtyTurbo {
+            child: Some(child),
+            writer: Some(writer),
+            output,
+            reader_thread: Some(reader_thread),
+        }
+    }
+
+    fn wait_for_path(path: &Path, timeout: Duration) {
+        let start = Instant::now();
+        while !path.exists() {
+            if start.elapsed() > timeout {
+                panic!("timed out waiting for {}", path.display());
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
+    }
+
+    fn normalize_output(text: &str) -> String {
+        text.replace("\r\n", "\n").replace('\r', "\n")
+    }
+
+    #[test]
+    fn run_forwards_ctrl_c_to_root_node_script_with_sh_script_shell() {
+        let (_tempdir, test_dir) = setup_npm_root_shutdown_example_with_command(
+            "graceful.mjs",
+            "node ./graceful.mjs",
+            r#"import { writeFileSync } from "node:fs";
+
+process.on("SIGINT", () => {
+  console.log("node cleanup start");
+  setTimeout(() => {
+    writeFileSync("cleanup.done", "");
+    console.log("node cleanup done");
+    process.exit(0);
+  }, 500);
+});
+
+console.log("node ready");
+writeFileSync("ready", "");
+setInterval(() => {}, 200);
+"#,
+        );
+
+        let ready_file = test_dir.join("ready");
+        let cleanup_file = test_dir.join("cleanup.done");
+
+        let mut child =
+            spawn_interactive_turbo_start_with_env(&test_dir, &[("NPM_CONFIG_SCRIPT_SHELL", "sh")]);
+        wait_for_path(&ready_file, START_TIMEOUT);
+
+        child.send_ctrl_c();
+        let transcript = child.finish(EXIT_TIMEOUT);
+
+        assert!(
+            cleanup_file.exists(),
+            "node SIGINT cleanup marker should exist"
+        );
+        assert!(
+            transcript.contains("node cleanup done"),
+            "expected Node SIGINT handler to finish with script-shell=sh\n{transcript}"
         );
     }
 }

--- a/crates/turborepo/tests/graceful_shutdown_test.rs
+++ b/crates/turborepo/tests/graceful_shutdown_test.rs
@@ -1020,10 +1020,13 @@ mod windows {
             }
         });
 
-        let writer = pair
+        let mut writer = pair
             .master
             .take_writer()
             .expect("failed to take pty writer");
+        writer
+            .write_all(b"\x1b[1;1R")
+            .expect("failed to write ConPTY cursor position response");
 
         let mut command = CommandBuilder::new(turbo_bin());
         command.arg("run");

--- a/crates/turborepo/tests/graceful_shutdown_test.rs
+++ b/crates/turborepo/tests/graceful_shutdown_test.rs
@@ -831,6 +831,7 @@ mod windows {
         fs,
         io::{Read, Write},
         path::{Path, PathBuf},
+        process::Command,
         sync::{Arc, Mutex},
         thread,
         time::{Duration, Instant},
@@ -916,17 +917,40 @@ mod windows {
         assert_cmd::cargo::cargo_bin("turbo")
     }
 
+    fn sh_script_shell() -> String {
+        let where_output = Command::new("where")
+            .arg("sh")
+            .output()
+            .expect("failed to search for sh.exe");
+        if where_output.status.success() {
+            if let Some(path) = String::from_utf8_lossy(&where_output.stdout)
+                .lines()
+                .find(|line| !line.trim().is_empty())
+            {
+                return path.trim().to_string();
+            }
+        }
+
+        let git_sh = PathBuf::from(r"C:\Program Files\Git\bin\sh.exe");
+        assert!(
+            git_sh.exists(),
+            "Windows npm script-shell=sh regression requires sh.exe"
+        );
+        git_sh.display().to_string()
+    }
+
     fn setup_npm_root_shutdown_example_with_command(
         script_name: &str,
         script_command: &str,
         script_contents: &str,
+        script_shell: &str,
     ) -> (TempDir, PathBuf) {
         let tempdir = tempfile::tempdir().expect("failed to create tempdir");
         let test_dir = tempdir.path().to_path_buf();
         setup::copy_fixture("basic_monorepo", &test_dir).expect("failed to copy npm fixture");
         fs::write(
             test_dir.join(".npmrc"),
-            "script-shell=sh\nupdate-notifier=false\n",
+            format!("script-shell={script_shell}\nupdate-notifier=false\n"),
         )
         .expect("failed to write npm config");
 
@@ -1046,6 +1070,7 @@ mod windows {
 
     #[test]
     fn run_forwards_ctrl_c_to_root_node_script_with_sh_script_shell() {
+        let script_shell = sh_script_shell();
         let (_tempdir, test_dir) = setup_npm_root_shutdown_example_with_command(
             "graceful.mjs",
             "node ./graceful.mjs",
@@ -1064,13 +1089,16 @@ console.log("node ready");
 writeFileSync("ready", "");
 setInterval(() => {}, 200);
 "#,
+            &script_shell,
         );
 
         let ready_file = test_dir.join("ready");
         let cleanup_file = test_dir.join("cleanup.done");
 
-        let mut child =
-            spawn_interactive_turbo_start_with_env(&test_dir, &[("NPM_CONFIG_SCRIPT_SHELL", "sh")]);
+        let mut child = spawn_interactive_turbo_start_with_env(
+            &test_dir,
+            &[("NPM_CONFIG_SCRIPT_SHELL", script_shell.as_str())],
+        );
         wait_for_path(&ready_file, START_TIMEOUT);
 
         child.send_ctrl_c();

--- a/crates/turborepo/tests/graceful_shutdown_test.rs
+++ b/crates/turborepo/tests/graceful_shutdown_test.rs
@@ -927,7 +927,7 @@ mod windows {
                 .lines()
                 .find(|line| !line.trim().is_empty())
             {
-                return path.trim().to_string();
+                return path.trim().replace('\\', "/");
             }
         }
 
@@ -936,7 +936,7 @@ mod windows {
             git_sh.exists(),
             "Windows npm script-shell=sh regression requires sh.exe"
         );
-        git_sh.display().to_string()
+        git_sh.display().to_string().replace('\\', "/")
     }
 
     fn setup_npm_root_shutdown_example_with_command(
@@ -1054,11 +1054,13 @@ mod windows {
         }
     }
 
-    fn wait_for_path(path: &Path, timeout: Duration) {
+    fn wait_for_path(path: &Path, timeout: Duration, output: &Arc<Mutex<Vec<u8>>>) {
         let start = Instant::now();
         while !path.exists() {
             if start.elapsed() > timeout {
-                panic!("timed out waiting for {}", path.display());
+                let transcript =
+                    normalize_output(String::from_utf8_lossy(&output.lock().unwrap()).as_ref());
+                panic!("timed out waiting for {}\n{transcript}", path.display());
             }
             thread::sleep(Duration::from_millis(100));
         }
@@ -1099,7 +1101,7 @@ setInterval(() => {}, 200);
             &test_dir,
             &[("NPM_CONFIG_SCRIPT_SHELL", script_shell.as_str())],
         );
-        wait_for_path(&ready_file, START_TIMEOUT);
+        wait_for_path(&ready_file, START_TIMEOUT, &child.output);
 
         child.send_ctrl_c();
         let transcript = child.finish(EXIT_TIMEOUT);


### PR DESCRIPTION
## Summary
- Adds regression coverage for npm root tasks using `script-shell=sh` to ensure Ctrl+C/SIGINT reaches a Node task handler.
- Includes a Windows-specific PTY test so CI can exercise console Ctrl+C behavior that is hard to validate from Linux.

Fixes #12652