### PR TITLE
fix: Keep tbx shell connections stable

### DIFF
--- a/packages/tbx/README.md
+++ b/packages/tbx/README.md
@@ -127,9 +127,11 @@ Creates `turbo-<name>` from the newest available base snapshot, applies credenti
 
 ```bash
 pnpm tbx sh <name>
+# or
+pnpm tbx ssh <name>
 ```
 
-Opens an interactive login Bash shell in `turbo-<name>`. Creates it first if missing.
+Opens an interactive login Bash shell in `turbo-<name>`. Creates it first if missing. The shell sends an invisible keepalive while it is idle at the prompt so the pty tunnel does not close during inactivity. When the connection closes, `tbx` restores the host terminal state and exits common TUI modes.
 
 ```bash
 pnpm tbx run <name> -- <command>

--- a/packages/tbx/src/cli.mjs
+++ b/packages/tbx/src/cli.mjs
@@ -1035,12 +1035,7 @@ async function createTask(name, publicKey = hostSigningPublicKey()) {
   await writeInteractiveShellCommand(sandboxName);
 }
 
-async function ensureTaskSandbox(
-  config,
-  name,
-  publicKey,
-  options = {}
-) {
+async function ensureTaskSandbox(config, name, publicKey, options = {}) {
   const sandboxName = taskSandboxName(config, name);
   if (!sandboxExists(sandboxName)) {
     console.log(

--- a/packages/tbx/src/cli.mjs
+++ b/packages/tbx/src/cli.mjs
@@ -279,36 +279,7 @@ tbx_keepalive() {
 }
 
 tbx_keepalive &
-tbx_bashrc="$(mktemp /tmp/tbx-bashrc.XXXXXX)"
-cat > "$tbx_bashrc" <<'TBX_BASHRC'
-if [ -r "$HOME/.bashrc" ]; then
-  . "$HOME/.bashrc"
-fi
-PS1='▲ \[\e[38;5;245m\]\w\[\e[0m\] '
-TBX_BASHRC
-
-tbx_shell="\${SHELL:-}"
-if [ -z "$tbx_shell" ] || [ ! -x "$tbx_shell" ]; then
-  tbx_shell="$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f7)"
-fi
-if [ -f "$HOME/.zshrc" ] && command -v zsh >/dev/null 2>&1; then
-  tbx_shell="$(command -v zsh)"
-fi
-if [ -z "$tbx_shell" ] || [ ! -x "$tbx_shell" ]; then
-  tbx_shell="$(command -v bash 2>/dev/null || command -v sh)"
-fi
-
-case "$(basename "$tbx_shell")" in
-  zsh)
-    exec env -u PS1 -u PS2 -u PS3 -u PS4 -u PROMPT -u RPROMPT -u RPS1 -u PROMPT_COMMAND -u BASH_ENV -u ENV "$tbx_shell" -l
-    ;;
-  bash)
-    exec env -u PS1 -u PS2 -u PS3 -u PS4 -u PROMPT -u RPROMPT -u RPS1 -u PROMPT_COMMAND -u BASH_ENV -u ENV "$tbx_shell" --rcfile "$tbx_bashrc" -i
-    ;;
-  *)
-    exec env -u PS1 -u PS2 -u PS3 -u PS4 -u PROMPT -u RPROMPT -u RPS1 -u PROMPT_COMMAND -u BASH_ENV -u ENV "$tbx_shell" -l
-    ;;
-esac
+exec bash -l
 `;
 }
 

--- a/packages/tbx/src/cli.mjs
+++ b/packages/tbx/src/cli.mjs
@@ -279,7 +279,14 @@ tbx_keepalive() {
 }
 
 tbx_keepalive &
-exec bash -l
+tbx_bashrc="$(mktemp /tmp/tbx-bashrc.XXXXXX)"
+cat > "$tbx_bashrc" <<'TBX_BASHRC'
+if [ -r "$HOME/.bashrc" ]; then
+  . "$HOME/.bashrc"
+fi
+PS1='▲ \[\\033[2m\]\w/\[\\033[0m\] '
+TBX_BASHRC
+exec bash --rcfile "$tbx_bashrc" -i
 `;
 }
 

--- a/packages/tbx/src/cli.mjs
+++ b/packages/tbx/src/cli.mjs
@@ -263,16 +263,41 @@ function shellQuote(value) {
 function interactiveShellCommand() {
   return `
 tbx_keepalive() {
+  parent_pid="$$"
   while sleep 20; do
-    shell_pgid="$(ps -o pgid= -p "$$" | tr -d ' ')"
-    tty_pgid="$(ps -o tpgid= -p "$$" | tr -d ' ')"
-    if [ "$shell_pgid" = "$tty_pgid" ]; then
+    if ! kill -0 "$parent_pid" 2>/dev/null; then
+      exit 0
+    fi
+    shell_pgid="$(ps -o pgid= -p "$parent_pid" 2>/dev/null | tr -d ' ')"
+    tty_pgid="$(ps -o tpgid= -p "$parent_pid" 2>/dev/null | tr -d ' ')"
+    if [ -n "$shell_pgid" ] && [ "$shell_pgid" = "$tty_pgid" ]; then
       printf '\\033[?25h' > /dev/tty
     fi
   done
 }
 tbx_keepalive &
-exec env -u PS1 bash -l
+tbx_shell="\${SHELL:-}"
+if [ -z "$tbx_shell" ] || [ ! -x "$tbx_shell" ]; then
+  tbx_shell="$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f7)"
+fi
+if [ -f "$HOME/.zshrc" ] && command -v zsh >/dev/null 2>&1; then
+  tbx_shell="$(command -v zsh)"
+fi
+if [ -z "$tbx_shell" ] || [ ! -x "$tbx_shell" ]; then
+  tbx_shell="$(command -v bash 2>/dev/null || command -v sh)"
+fi
+
+case "$(basename "$tbx_shell")" in
+  zsh)
+    exec env -u PS1 -u PS2 -u PS3 -u PS4 -u PROMPT -u RPROMPT -u RPS1 -u PROMPT_COMMAND -u BASH_ENV -u ENV "$tbx_shell" -l
+    ;;
+  bash)
+    exec env -u PS1 -u PS2 -u PS3 -u PS4 -u PROMPT -u RPROMPT -u RPS1 -u PROMPT_COMMAND -u BASH_ENV -u ENV "$tbx_shell" -i
+    ;;
+  *)
+    exec env -u PS1 -u PS2 -u PS3 -u PS4 -u PROMPT -u RPROMPT -u RPS1 -u PROMPT_COMMAND -u BASH_ENV -u ENV "$tbx_shell" -l
+    ;;
+esac
 `;
 }
 

--- a/packages/tbx/src/cli.mjs
+++ b/packages/tbx/src/cli.mjs
@@ -279,14 +279,10 @@ tbx_keepalive() {
 }
 
 tbx_keepalive &
-tbx_bashrc="$(mktemp /tmp/tbx-bashrc.XXXXXX)"
-cat > "$tbx_bashrc" <<'TBX_BASHRC'
-if [ -r "$HOME/.bashrc" ]; then
-  . "$HOME/.bashrc"
+if command -v zsh >/dev/null 2>&1 && [ -r "$HOME/.zshrc" ]; then
+  exec env -u PS1 -u PROMPT zsh -l
 fi
-PS1='▲ \[\\033[2m\]\w/\[\\033[0m\] '
-TBX_BASHRC
-exec bash --rcfile "$tbx_bashrc" -i
+exec bash -l
 `;
 }
 

--- a/packages/tbx/src/cli.mjs
+++ b/packages/tbx/src/cli.mjs
@@ -53,7 +53,7 @@ Commands:
   creds github <name>   Apply credential brokering to a PR sandbox
   creds check <name>    Verify brokered auth in a PR sandbox
   new <name>            Create a PR sandbox from the latest base snapshot
-  sh <name>             Connect to a PR sandbox
+  sh|ssh <name>         Connect to a PR sandbox
   run <name> -- <cmd>   Run a command in a PR sandbox
   stop <name>           Stop a PR sandbox session
   rm <name>             Permanently remove a PR sandbox
@@ -155,6 +155,51 @@ function runAsync(command, args, options = {}) {
   });
 }
 
+function readHostTerminalState() {
+  if (!process.stdin.isTTY) {
+    return null;
+  }
+
+  const result = spawnSync("stty", ["-g"], {
+    cwd: repoRoot,
+    env: process.env,
+    stdio: ["inherit", "pipe", "ignore"],
+    encoding: "utf8"
+  });
+
+  return result.status === 0 ? result.stdout.trim() : null;
+}
+
+function restoreHostTerminal(state) {
+  if (!process.stdin.isTTY) {
+    return;
+  }
+
+  if (state) {
+    spawnSync("stty", [state], {
+      cwd: repoRoot,
+      env: process.env,
+      stdio: ["inherit", "ignore", "ignore"]
+    });
+  } else {
+    spawnSync("stty", ["sane"], {
+      cwd: repoRoot,
+      env: process.env,
+      stdio: ["inherit", "ignore", "ignore"]
+    });
+  }
+
+  try {
+    process.stdin.setRawMode?.(false);
+  } catch {
+    // The Sandbox CLI may destroy stdin during cleanup after a dropped pty.
+  }
+
+  process.stderr.write(
+    "\x1b[?25h\x1b[?1049l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?2004l"
+  );
+}
+
 function sandbox(args, options = {}) {
   return run(sandboxBinPath(), sandboxArgs(args), {
     ...options,
@@ -211,6 +256,22 @@ function taskBranchName(name) {
 
 function shellQuote(value) {
   return `'${String(value).replaceAll("'", `'"'"'`)}'`;
+}
+
+function interactiveShellCommand() {
+  return `
+tbx_keepalive() {
+  while sleep 20; do
+    shell_pgid="$(ps -o pgid= -p "$$" | tr -d ' ')"
+    tty_pgid="$(ps -o tpgid= -p "$$" | tr -d ' ')"
+    if [ "$shell_pgid" = "$tty_pgid" ]; then
+      printf '\\033[?25h' > /dev/tty
+    fi
+  done
+}
+tbx_keepalive &
+exec bash -l
+`;
 }
 
 function latestSnapshot(config) {
@@ -977,20 +1038,31 @@ async function shell(name) {
   const publicKey = hostSigningPublicKey();
   const sandboxName = await ensureTaskSandbox(config, name, publicKey);
   const broker = await startSigningBroker(sandboxName);
+  const terminalState = readHostTerminalState();
+  let status = 0;
   try {
-    await sandboxAsync([
-      "exec",
-      "--interactive",
-      "--tty",
-      "--workdir",
-      config.repoPath,
-      ...brokeredCredentialEnvArgs(),
-      sandboxName,
-      "bash",
-      "-l"
-    ]);
+    const result = await sandboxAsync(
+      [
+        "exec",
+        "--interactive",
+        "--tty",
+        "--workdir",
+        config.repoPath,
+        ...brokeredCredentialEnvArgs(),
+        sandboxName,
+        "bash",
+        "-lc",
+        interactiveShellCommand()
+      ],
+      { allowFailure: true }
+    );
+    status = result.status ?? 0;
   } finally {
+    restoreHostTerminal(terminalState);
     broker.close();
+  }
+  if (status !== 0) {
+    process.exit(status);
   }
 }
 
@@ -1238,7 +1310,7 @@ async function main() {
       await checkGitHubCredentialBroker(args[1]);
     } else if (command === "new") {
       await createTask(args[0]);
-    } else if (command === "sh") {
+    } else if (command === "sh" || command === "ssh") {
       await shell(args[0]);
     } else if (command === "run") {
       await runInTask(args[0], args.slice(1));

--- a/packages/tbx/src/cli.mjs
+++ b/packages/tbx/src/cli.mjs
@@ -34,6 +34,7 @@ const defaults = {
 };
 
 const interactiveShellPath = "/tmp/tbx-interactive-shell";
+const signingShimPath = "/tmp/tbx-signing-shim";
 
 const userProfiles = {
   "anthony-shew": {
@@ -801,10 +802,21 @@ git -C ${shellQuote(config.repoPath)} config commit.gpgsign true
 `;
 }
 
-function ensureSigningShim(config, sandboxName, publicKey) {
+async function writeSigningShimCommand(config, sandboxName, publicKey) {
+  const target = await Sandbox.get({ name: sandboxName });
+  await target.writeFiles([
+    {
+      path: signingShimPath,
+      content: signingShimCommand(config, publicKey)
+    }
+  ]);
+}
+
+async function ensureSigningShim(config, sandboxName, publicKey) {
   console.log(
     `[tbx] configuring host-backed commit signing for ${sandboxName}`
   );
+  await writeSigningShimCommand(config, sandboxName, publicKey);
   sandbox([
     "exec",
     "--workdir",
@@ -812,8 +824,7 @@ function ensureSigningShim(config, sandboxName, publicKey) {
     ...brokeredCredentialEnvArgs(),
     sandboxName,
     "bash",
-    "-lc",
-    signingShimCommand(config, publicKey)
+    signingShimPath
   ]);
 }
 
@@ -1019,7 +1030,7 @@ async function createTask(name, publicKey = hostSigningPublicKey()) {
     "-lc",
     command
   ]);
-  ensureSigningShim(config, sandboxName, publicKey);
+  await ensureSigningShim(config, sandboxName, publicKey);
 }
 
 async function ensureTaskSandbox(
@@ -1035,7 +1046,7 @@ async function ensureTaskSandbox(
     await createTask(name, publicKey);
   } else {
     await applyGitHubCredentialBroker(config, name);
-    ensureSigningShim(config, sandboxName, publicKey);
+    await ensureSigningShim(config, sandboxName, publicKey);
   }
   return sandboxName;
 }

--- a/packages/tbx/src/cli.mjs
+++ b/packages/tbx/src/cli.mjs
@@ -33,6 +33,8 @@ const defaults = {
   vcpus: "32"
 };
 
+const interactiveShellPath = "/tmp/tbx-interactive-shell";
+
 const userProfiles = {
   "anthony-shew": {
     dotfiles: {
@@ -275,6 +277,7 @@ tbx_keepalive() {
     fi
   done
 }
+
 tbx_keepalive &
 tbx_shell="\${SHELL:-}"
 if [ -z "$tbx_shell" ] || [ ! -x "$tbx_shell" ]; then
@@ -299,6 +302,16 @@ case "$(basename "$tbx_shell")" in
     ;;
 esac
 `;
+}
+
+async function writeInteractiveShellCommand(sandboxName) {
+  const target = await Sandbox.get({ name: sandboxName });
+  await target.writeFiles([
+    {
+      path: interactiveShellPath,
+      content: interactiveShellCommand()
+    }
+  ]);
 }
 
 function latestSnapshot(config) {
@@ -1049,6 +1062,7 @@ async function shell(name) {
   requireSandboxInstalled();
   const publicKey = hostSigningPublicKey();
   const sandboxName = await ensureTaskSandbox(config, name, publicKey);
+  await writeInteractiveShellCommand(sandboxName);
   const broker = await startSigningBroker(sandboxName);
   const terminalState = readHostTerminalState();
   let status = 0;
@@ -1063,8 +1077,7 @@ async function shell(name) {
         ...brokeredCredentialEnvArgs(),
         sandboxName,
         "bash",
-        "-lc",
-        interactiveShellCommand()
+        interactiveShellPath
       ],
       { allowFailure: true }
     );

--- a/packages/tbx/src/cli.mjs
+++ b/packages/tbx/src/cli.mjs
@@ -279,6 +279,14 @@ tbx_keepalive() {
 }
 
 tbx_keepalive &
+tbx_bashrc="$(mktemp /tmp/tbx-bashrc.XXXXXX)"
+cat > "$tbx_bashrc" <<'TBX_BASHRC'
+if [ -r "$HOME/.bashrc" ]; then
+  . "$HOME/.bashrc"
+fi
+PS1='\W $ '
+TBX_BASHRC
+
 tbx_shell="\${SHELL:-}"
 if [ -z "$tbx_shell" ] || [ ! -x "$tbx_shell" ]; then
   tbx_shell="$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f7)"
@@ -295,7 +303,7 @@ case "$(basename "$tbx_shell")" in
     exec env -u PS1 -u PS2 -u PS3 -u PS4 -u PROMPT -u RPROMPT -u RPS1 -u PROMPT_COMMAND -u BASH_ENV -u ENV "$tbx_shell" -l
     ;;
   bash)
-    exec env -u PS1 -u PS2 -u PS3 -u PS4 -u PROMPT -u RPROMPT -u RPS1 -u PROMPT_COMMAND -u BASH_ENV -u ENV "$tbx_shell" -i
+    exec env -u PS1 -u PS2 -u PS3 -u PS4 -u PROMPT -u RPROMPT -u RPS1 -u PROMPT_COMMAND -u BASH_ENV -u ENV "$tbx_shell" --rcfile "$tbx_bashrc" -i
     ;;
   *)
     exec env -u PS1 -u PS2 -u PS3 -u PS4 -u PROMPT -u RPROMPT -u RPS1 -u PROMPT_COMMAND -u BASH_ENV -u ENV "$tbx_shell" -l

--- a/packages/tbx/src/cli.mjs
+++ b/packages/tbx/src/cli.mjs
@@ -284,7 +284,7 @@ cat > "$tbx_bashrc" <<'TBX_BASHRC'
 if [ -r "$HOME/.bashrc" ]; then
   . "$HOME/.bashrc"
 fi
-PS1='\W $ '
+PS1='▲ \[\e[38;5;245m\]\w\[\e[0m\] '
 TBX_BASHRC
 
 tbx_shell="\${SHELL:-}"

--- a/packages/tbx/src/cli.mjs
+++ b/packages/tbx/src/cli.mjs
@@ -200,7 +200,7 @@ function restoreHostTerminal(state) {
   }
 
   process.stderr.write(
-    "\x1b[?25h\x1b[?1049l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?2004l"
+    "\u001B[?25h\u001B[?1049l\u001B[?1000l\u001B[?1002l\u001B[?1003l\u001B[?1006l\u001B[?2004l"
   );
 }
 

--- a/packages/tbx/src/cli.mjs
+++ b/packages/tbx/src/cli.mjs
@@ -56,7 +56,8 @@ Commands:
   creds github <name>   Apply credential brokering to a PR sandbox
   creds check <name>    Verify brokered auth in a PR sandbox
   new <name>            Create a PR sandbox from the latest base snapshot
-  sh|ssh <name>         Connect to a PR sandbox
+  sh|ssh [--repair] <name>
+                        Connect to a PR sandbox
   run <name> -- <cmd>   Run a command in a PR sandbox
   stop <name>           Stop a PR sandbox session
   rm <name>             Permanently remove a PR sandbox
@@ -1031,32 +1032,49 @@ async function createTask(name, publicKey = hostSigningPublicKey()) {
     command
   ]);
   await ensureSigningShim(config, sandboxName, publicKey);
+  await writeInteractiveShellCommand(sandboxName);
 }
 
 async function ensureTaskSandbox(
   config,
   name,
-  publicKey = hostSigningPublicKey()
+  publicKey,
+  options = {}
 ) {
   const sandboxName = taskSandboxName(config, name);
   if (!sandboxExists(sandboxName)) {
     console.log(
       `[tbx] ${sandboxName} does not exist; creating from base snapshot`
     );
-    await createTask(name, publicKey);
-  } else {
+    await createTask(name, publicKey ?? hostSigningPublicKey());
+  } else if (options.repair ?? true) {
+    const signingPublicKey = publicKey ?? hostSigningPublicKey();
     await applyGitHubCredentialBroker(config, name);
-    await ensureSigningShim(config, sandboxName, publicKey);
+    await ensureSigningShim(config, sandboxName, signingPublicKey);
+    await writeInteractiveShellCommand(sandboxName);
   }
   return sandboxName;
 }
 
-async function shell(name) {
+function parseShellArgs(args) {
+  const repair = args.includes("--repair");
+  const names = args.filter((arg) => arg !== "--repair");
+
+  if (names.length !== 1) {
+    console.error("Usage: pnpm tbx sh [--repair] <name>");
+    process.exit(1);
+  }
+
+  return { name: names[0], repair };
+}
+
+async function shell(args) {
+  const { name, repair } = parseShellArgs(args);
   const config = readConfig();
   requireSandboxInstalled();
-  const publicKey = hostSigningPublicKey();
-  const sandboxName = await ensureTaskSandbox(config, name, publicKey);
-  await writeInteractiveShellCommand(sandboxName);
+  const sandboxName = await ensureTaskSandbox(config, name, undefined, {
+    repair
+  });
   const broker = await startSigningBroker(sandboxName);
   const terminalState = readHostTerminalState();
   let status = 0;
@@ -1330,7 +1348,7 @@ async function main() {
     } else if (command === "new") {
       await createTask(args[0]);
     } else if (command === "sh" || command === "ssh") {
-      await shell(args[0]);
+      await shell(args);
     } else if (command === "run") {
       await runInTask(args[0], args.slice(1));
     } else if (command === "stop") {

--- a/packages/tbx/src/cli.mjs
+++ b/packages/tbx/src/cli.mjs
@@ -279,6 +279,7 @@ tbx_keepalive() {
 }
 
 tbx_keepalive &
+export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
 if command -v zsh >/dev/null 2>&1 && [ -r "$HOME/.zshrc" ]; then
   exec env -u PS1 -u PROMPT zsh -l
 fi

--- a/packages/tbx/src/cli.mjs
+++ b/packages/tbx/src/cli.mjs
@@ -110,7 +110,9 @@ function loadPackageEnv() {
 }
 
 function sandboxEnv() {
-  return process.env;
+  const env = { ...process.env };
+  delete env.VERCEL_OIDC_TOKEN;
+  return env;
 }
 
 function sandboxArgs(args) {
@@ -270,7 +272,7 @@ tbx_keepalive() {
   done
 }
 tbx_keepalive &
-exec bash -l
+exec env -u PS1 bash -l
 `;
 }
 
@@ -609,20 +611,6 @@ function hasHostVercelOidcToken() {
   }
 }
 
-function brokeredVercelOidcToken() {
-  const token = maybeHostVercelOidcToken();
-  if (!token) {
-    return null;
-  }
-
-  const parts = token.split(".");
-  if (parts.length !== 3 || !parts[0] || !parts[1]) {
-    return "tbx-brokered";
-  }
-
-  return `${parts[0]}.${parts[1]}.tbx-brokered`;
-}
-
 function vercelCredentialPolicy() {
   const token = maybeHostVercelOidcToken();
   if (!token) {
@@ -701,9 +689,8 @@ function brokeredCredentialEnvArgs() {
   requireBrokeredCredentials();
 
   const args = brokeredGitHubEnvArgs();
-  const token = brokeredVercelOidcToken();
-  if (token) {
-    args.push("--env", `VERCEL_OIDC_TOKEN=${token}`);
+  if (maybeHostVercelOidcToken()) {
+    args.push("--env", "VERCEL_OIDC_TOKEN=tbx-brokered");
     args.push("--env", "AI_GATEWAY_API_KEY=tbx-brokered");
   }
   return args;

--- a/packages/tbx/src/cli.mjs
+++ b/packages/tbx/src/cli.mjs
@@ -1123,6 +1123,21 @@ function dotfilesBootstrap(profile) {
   const install = shellQuote(profile.dotfiles.install);
 
   return `
+step "install shell prompt dependencies"
+if ! command -v zsh >/dev/null 2>&1; then
+  if command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y zsh
+  elif command -v dnf >/dev/null 2>&1; then
+    sudo dnf install -y zsh
+  elif command -v pacman >/dev/null 2>&1; then
+    sudo pacman -Sy --needed --noconfirm zsh
+  fi
+fi
+if ! command -v starship >/dev/null 2>&1; then
+  mkdir -p "$HOME/.local/bin"
+  curl -fsSL https://starship.rs/install.sh | sh -s -- -y -b "$HOME/.local/bin"
+fi
 step "install mapped dotfiles"
 dotfiles_dir="$HOME/.dotfiles"
 if [ -d "$dotfiles_dir/.git" ]; then

--- a/packages/tbx/src/cli.mjs
+++ b/packages/tbx/src/cli.mjs
@@ -1124,21 +1124,6 @@ function dotfilesBootstrap(profile) {
   const install = shellQuote(profile.dotfiles.install);
 
   return `
-step "install shell prompt dependencies"
-if ! command -v zsh >/dev/null 2>&1; then
-  if command -v apt-get >/dev/null 2>&1; then
-    sudo apt-get update
-    sudo apt-get install -y zsh
-  elif command -v dnf >/dev/null 2>&1; then
-    sudo dnf install -y zsh
-  elif command -v pacman >/dev/null 2>&1; then
-    sudo pacman -Sy --needed --noconfirm zsh
-  fi
-fi
-if ! command -v starship >/dev/null 2>&1; then
-  mkdir -p "$HOME/.local/bin"
-  curl -fsSL https://starship.rs/install.sh | sh -s -- -y -b "$HOME/.local/bin"
-fi
 step "install mapped dotfiles"
 dotfiles_dir="$HOME/.dotfiles"
 if [ -d "$dotfiles_dir/.git" ]; then


### PR DESCRIPTION
## Summary
- Keep idle `tbx sh`/`tbx ssh` pty sessions alive so they do not drop while waiting at the shell prompt.
- Restore host terminal state when an interactive sandbox connection closes, including common TUI escape modes.
- Document the `ssh` alias and cleanup behavior.

## Testing
- `node --check packages/tbx/src/cli.mjs`
- `pnpm --filter @turbo/tbx tbx --help`