### PR TITLE
ci: Harden non-release GitHub Actions

### DIFF
--- a/.github/actions/install-global-turbo/action.yml
+++ b/.github/actions/install-global-turbo/action.yml
@@ -13,9 +13,15 @@ runs:
     - name: Determine Turbo Version
       id: determine-version
       shell: bash
+      env:
+        TURBO_VERSION_INPUT: ${{ inputs.turbo-version }}
       run: |
-        if [[ -n "${{ inputs.turbo-version }}" ]]; then
-          VERSION="${{ inputs.turbo-version }}"
+        if [[ -n "$TURBO_VERSION_INPUT" ]]; then
+          if [[ ! "$TURBO_VERSION_INPUT" =~ ^[0-9A-Za-z][0-9A-Za-z._-]{0,127}$ ]]; then
+            echo "::error::Invalid Turbo version '${TURBO_VERSION_INPUT}'. Use a semver version or safe npm dist-tag."
+            exit 1
+          fi
+          VERSION="$TURBO_VERSION_INPUT"
         else
           VERSION=$(npm view turbo --json | jq -r '.versions | map(select(test("^2\\."))) | last')
           echo "No version provided, using latest 2.x version: $VERSION"
@@ -26,4 +32,4 @@ runs:
       shell: bash
       run: |
         echo "Installing turbo@$TURBO_VERSION..."
-        npm i -g turbo@$TURBO_VERSION
+        npm i -g "turbo@$TURBO_VERSION"

--- a/.github/actions/setup-capnproto/action.yml
+++ b/.github/actions/setup-capnproto/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
     - name: "Cache capnproto (Linux)"
       if: runner.os == 'Linux' && inputs.use-cache == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       id: cache-capnp-linux
       with:
         path: |
@@ -34,8 +34,11 @@ runs:
         elif command -v apk &> /dev/null; then
           apk add capnproto-dev
         else
-          curl -sSL https://capnproto.org/capnproto-c++-1.1.0.tar.gz | tar -zxf -
+          curl --fail --show-error --silent --location --output capnproto-c++-1.1.0.tar.gz https://capnproto.org/capnproto-c++-1.1.0.tar.gz
+          echo "07167580e563f5e821e3b2af1c238c16ec7181612650c5901330fa9a0da50939  capnproto-c++-1.1.0.tar.gz" | sha256sum --check --strict
+          tar -zxf capnproto-c++-1.1.0.tar.gz
           cd capnproto-c++-1.1.0 && ./configure --prefix=/usr --disable-shared && make -j$(nproc) && make install && cd .. && rm -rf capnproto-c++-1.1.0
+          rm capnproto-c++-1.1.0.tar.gz
         fi
 
     - name: "Setup capnproto for macos"
@@ -45,7 +48,7 @@ runs:
 
     - name: "Cache capnproto (Windows)"
       if: runner.os == 'Windows' && inputs.use-cache == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       id: cache-capnp-windows
       with:
         path: C:\capnproto
@@ -59,6 +62,12 @@ runs:
         $zip = "$env:RUNNER_TEMP\capnproto.zip"
         Write-Host "Downloading capnproto from $url"
         Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing
+        $expectedHash = "623b7525501d410e6479c8029eba265aa57ac8153c6fa09ab21a62f906b3e3f9"
+        $actualHash = (Get-FileHash -Path $zip -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($actualHash -ne $expectedHash) {
+          Write-Error "capnproto checksum mismatch. Expected $expectedHash, got $actualHash"
+          exit 1
+        }
         Expand-Archive -Path $zip -DestinationPath "C:\capnproto" -Force
         Remove-Item $zip
 

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -21,10 +21,10 @@ runs:
   using: "composite"
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         # node-version-file is the default, but can be overridden using node-version
         node-version-file: "package.json"
@@ -38,7 +38,7 @@ runs:
       # The bundled version in node 16 has known issues.
       # Prepends the npm bin dir so that it is always first.
       run: |
-        npm install --force --global corepack@latest
+        npm install --force --global corepack@0.32.0
         npm config get prefix >> $GITHUB_PATH
 
     - name: Configure corepack

--- a/.github/actions/setup-protoc/action.yml
+++ b/.github/actions/setup-protoc/action.yml
@@ -15,14 +15,14 @@ runs:
     - name: Set Up Protoc
       id: set-up-protoc
       continue-on-error: true
-      uses: arduino/setup-protoc@v3
+      uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
       with:
         version: ${{ inputs.version }}
         repo-token: ${{ inputs.github-token }}
 
     - name: Set Up Protoc (second try)
       if: steps.set-up-protoc.outcome == 'failure'
-      uses: arduino/setup-protoc@v3
+      uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
       with:
         version: ${{ inputs.version }}
         repo-token: ${{ inputs.github-token }}

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -26,7 +26,7 @@ runs:
   using: "composite"
   steps:
     - name: "Setup Rust toolchain"
-      uses: actions-rust-lang/setup-rust-toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
       with:
         target: ${{ inputs.targets }}
         # needed to not make it override the defaults
@@ -46,7 +46,7 @@ runs:
 
     - name: "Setup Rust Cache"
       if: inputs.cache == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
       with:
         shared-key: ${{ inputs.shared-cache-key }}
         key: ${{ inputs.cache-key }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,13 +9,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   docs-quality:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-node
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,7 @@ env:
   RUSTFLAGS: "-D warnings"
 
 permissions:
-  actions: write
   contents: read
-  pull-requests: read
 
 jobs:
   determine_changes:
@@ -21,16 +19,19 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
       formatting: ${{ steps.filter.outputs.formatting }}
       dependencies: ${{ steps.filter.outputs.dependencies }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Check for changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v3
         id: filter
         with:
           filters: |
@@ -61,7 +62,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
@@ -90,7 +93,9 @@ jobs:
       # SCCACHE_ERROR_LOG: error
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
@@ -112,10 +117,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Check licenses
-        uses: EmbarkStudios/cargo-deny-action@v2
+        uses: EmbarkStudios/cargo-deny-action@5bb39ff5d5a0e94dc9e2dc94eced0c6129743a57 # v2
         with:
           command: check licenses
 
@@ -126,12 +133,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
+      TURBO_CACHE: local:rw
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: "Setup Node"
         uses: ./.github/actions/setup-node
@@ -153,5 +160,7 @@ jobs:
       - rust_licenses
       - format_lint
     if: always()
+    permissions:
+      actions: write
     uses: ./.github/workflows/pr-clean-caches.yml
     secrets: inherit

--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -8,6 +8,9 @@ name: LSP
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-rust:
     name: "Build Rust"
@@ -46,7 +49,9 @@ jobs:
       options: ${{ matrix.settings.container-options }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Setup Container
         if: ${{ matrix.settings.container-setup }}
         run: ${{ matrix.settings.container-setup }}
@@ -69,7 +74,7 @@ jobs:
         run: ${{ matrix.settings.rust-build-env }} cargo build --profile release-turborepo-lsp -p turborepo-lsp --target ${{ matrix.settings.target }}
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: turborepo-lsp-${{ matrix.settings.target }}
           path: target/${{ matrix.settings.target }}/release-turborepo-lsp/turborepo-lsp*

--- a/.github/workflows/pr-clean-caches.yml
+++ b/.github/workflows/pr-clean-caches.yml
@@ -23,19 +23,20 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh extension install actions/gh-actions-cache
-
           REPO=${{ github.repository }}
           BRANCH=${{ github.ref }}
 
-          echo "Fetching list of cache key"
-          cacheKeysForPR=$(gh actions-cache list -R "$REPO" -B "$BRANCH" --limit 100 | cut -f 1)
+          echo "Fetching cache ids for ${BRANCH}"
+          cacheIdsForBranch=$(gh api --method GET "repos/${REPO}/actions/caches" \
+            -f ref="${BRANCH}" \
+            -f per_page=100 \
+            --jq '.actions_caches[].id')
 
-          ## Setting this to not fail the workflow while deleting cache keys.
+          # Cache deletion is best-effort so cleanup failures do not fail CI.
           set +e
           echo "Deleting caches..."
-          for cacheKey in $cacheKeysForPR
+          for cacheId in $cacheIdsForBranch
           do
-              gh actions-cache delete "$cacheKey" -R "$REPO" -B "$BRANCH" --confirm
+              gh api --method DELETE "repos/${REPO}/actions/caches/${cacheId}"
           done
           echo "Done"

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -7,9 +7,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
-  actions: write
   contents: read
-  pull-requests: read
 
 jobs:
   find-changes:
@@ -20,7 +18,9 @@ jobs:
       js-packages: ${{ steps.filter.outputs.js-packages }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Check if automated release PR
         id: check
@@ -71,9 +71,7 @@ jobs:
           - 22
           - 24
     env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
+      TURBO_CACHE: local:rw
 
     steps:
       # on main -> current + prev commit
@@ -84,10 +82,11 @@ jobs:
           echo "depth=$(( ${{ github.event.pull_request.commits || 1 }} + 1 ))" >> $GITHUB_OUTPUT
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.ref }}
           fetch-depth: ${{ steps.fetch-depth.outputs.depth  }}
+          persist-credentials: false
 
       - name: "Setup Node"
         uses: ./.github/actions/setup-node
@@ -97,7 +96,7 @@ jobs:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
 
       - name: Install Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install Global Turbo
         uses: ./.github/actions/install-global-turbo

--- a/.github/workflows/turborepo-compare-cache-item.yml
+++ b/.github/workflows/turborepo-compare-cache-item.yml
@@ -8,6 +8,9 @@ on:
         type: string
         default: "canary"
 
+permissions:
+  contents: read
+
 jobs:
   generate_cache_artifact:
     strategy:
@@ -15,15 +18,33 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    env:
+      TURBO_VERSION: ${{ inputs.version }}
 
     steps:
+      - name: Validate version input
+        shell: bash
+        run: |
+          if [[ ! "$TURBO_VERSION" =~ ^[0-9A-Za-z][0-9A-Za-z._-]{0,127}$ ]]; then
+            echo "::error::Invalid Turborepo version '${TURBO_VERSION}'. Use a semver version or safe npm dist-tag."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
       - name: Setup Node
         uses: ./.github/actions/setup-node
+        with:
+          package-install: false
 
       - name: create-turbo
+        shell: bash
         run: |
-          npm install -g pnpm turbo@${{ inputs.version }}
-          pnpm dlx create-turbo@${{ inputs.version }} my-turborepo pnpm
+          npm install -g "turbo@${TURBO_VERSION}"
+          pnpm dlx "create-turbo@${TURBO_VERSION}" my-turborepo pnpm
 
       - name: Run build
         run: |
@@ -31,7 +52,7 @@ jobs:
           turbo run build --filter=docs --filter=web --summarize --skip-infer -vvv
 
       - name: Grab artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cache-item-${{ matrix.os }}-${{ inputs.version }}
           path: |
@@ -48,18 +69,36 @@ jobs:
         cache_os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    env:
+      TURBO_VERSION: ${{ inputs.version }}
 
     steps:
+      - name: Validate version input
+        shell: bash
+        run: |
+          if [[ ! "$TURBO_VERSION" =~ ^[0-9A-Za-z][0-9A-Za-z._-]{0,127}$ ]]; then
+            echo "::error::Invalid Turborepo version '${TURBO_VERSION}'. Use a semver version or safe npm dist-tag."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
       - name: Setup Node
         uses: ./.github/actions/setup-node
+        with:
+          package-install: false
 
       - name: create-turbo
+        shell: bash
         run: |
-          npm install -g pnpm turbo@${{ inputs.version }}
-          pnpm dlx create-turbo@${{ inputs.version }} my-turborepo pnpm
+          npm install -g "turbo@${TURBO_VERSION}"
+          pnpm dlx "create-turbo@${TURBO_VERSION}" my-turborepo pnpm
 
       - name: Download cache artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: cache-item-${{ matrix.cache_os }}-${{ inputs.version }}
           path: my-turborepo
@@ -73,5 +112,4 @@ jobs:
 
       - name: Check for functional server
         run: |
-          curl https://raw.githubusercontent.com/vercel/turbo/main/scripts/server.js -O
-          node server.js my-turborepo/apps/docs
+          node scripts/server.js my-turborepo/apps/docs

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -9,9 +9,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
-  actions: write
   contents: read
-  pull-requests: write
 
 jobs:
   find-changes:
@@ -29,7 +27,9 @@ jobs:
       # These PRs are created by the release workflow after code has already
       # been tested on main. Skipping tests on version-only changes saves CI time.
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Check if automated release PR
         id: check-release
@@ -130,7 +130,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
@@ -165,9 +167,9 @@ jobs:
     if: ${{ false }}
     name: Build test artifacts (windows)
     env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
+      TURBO_TOKEN: ${{ github.event_name == 'pull_request' && 'unused' || secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ github.event_name == 'pull_request' && 'unused' || vars.TURBO_TEAM }}
+      TURBO_CACHE: ${{ github.event_name == 'pull_request' && 'local:rw' || 'remote:rw' }}
       # AWS-backed sccache is disabled.
       # SCCACHE_BUCKET: turborepo-sccache
       # SCCACHE_REGION: us-east-2
@@ -199,7 +201,9 @@ jobs:
           git config --global core.eol lf
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
@@ -234,9 +238,9 @@ jobs:
     if: ${{ false }}
     name: Build test artifacts (macos)
     env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
+      TURBO_TOKEN: ${{ github.event_name == 'pull_request' && 'unused' || secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ github.event_name == 'pull_request' && 'unused' || vars.TURBO_TEAM }}
+      TURBO_CACHE: ${{ github.event_name == 'pull_request' && 'local:rw' || 'remote:rw' }}
       # AWS-backed sccache is disabled.
       # SCCACHE_BUCKET: turborepo-sccache
       # SCCACHE_REGION: us-east-2
@@ -249,7 +253,9 @@ jobs:
       # SCCACHE_ERROR_LOG: error
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
@@ -287,7 +293,9 @@ jobs:
     name: Rust testing on macos (partition ${{ matrix.partition }}/2)
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
@@ -346,7 +354,9 @@ jobs:
           git config --global core.eol lf
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
@@ -398,9 +408,9 @@ jobs:
     if: ${{ false }}
     name: Build test artifacts (ubuntu)
     env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
+      TURBO_TOKEN: ${{ github.event_name == 'pull_request' && 'unused' || secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ github.event_name == 'pull_request' && 'unused' || vars.TURBO_TEAM }}
+      TURBO_CACHE: ${{ github.event_name == 'pull_request' && 'local:rw' || 'remote:rw' }}
       # AWS-backed sccache is disabled.
       # SCCACHE_BUCKET: turborepo-sccache
       # SCCACHE_REGION: us-east-2
@@ -413,7 +423,9 @@ jobs:
       # SCCACHE_ERROR_LOG: error
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
@@ -451,7 +463,9 @@ jobs:
     name: Rust testing on ubuntu (partition ${{ matrix.partition }}/2)
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
@@ -491,24 +505,26 @@ jobs:
     timeout-minutes: 40
     needs:
       - find-changes
-    if: ${{ needs.find-changes.outputs.is-release-pr != 'true' && !github.event.pull_request.head.repo.fork }}
+    if: ${{ needs.find-changes.outputs.is-release-pr != 'true' && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
+      TURBO_TOKEN: ${{ github.event_name == 'pull_request' && 'unused' || secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ github.event_name == 'pull_request' && 'unused' || vars.TURBO_TEAM }}
+      TURBO_CACHE: ${{ github.event_name == 'pull_request' && 'local:rw' || 'remote:rw' }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
       - name: Install dependencies
         run: pnpm install
@@ -519,8 +535,8 @@ jobs:
       - name: Setup Vercel credentials
         run: |
           cd examples
-          npx vercel link --yes --token=${{ secrets.VERCEL_TOKEN }} --project turborepo-examples-app
-          npx vercel env pull --yes --token=${{ secrets.VERCEL_TOKEN }}
+          npx vercel link --yes --token="${VERCEL_TOKEN}" --project turborepo-examples-app
+          npx vercel env pull --yes --token="${VERCEL_TOKEN}"
 
       - name: Run examples check
         run: turbo run check-examples --filter=turborepo-examples --env-mode=strict
@@ -533,9 +549,9 @@ jobs:
     if: ${{ needs.find-changes.outputs.is-release-pr != 'true' }}
     runs-on: ubuntu-latest
     env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
+      TURBO_TOKEN: ${{ github.event_name == 'pull_request' && 'unused' || secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ github.event_name == 'pull_request' && 'unused' || vars.TURBO_TEAM }}
+      TURBO_CACHE: ${{ github.event_name == 'pull_request' && 'local:rw' || 'remote:rw' }}
       # AWS-backed sccache is disabled.
       # SCCACHE_BUCKET: turborepo-sccache
       # SCCACHE_REGION: us-east-2
@@ -545,7 +561,9 @@ jobs:
       # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
@@ -586,9 +604,9 @@ jobs:
           - 22
           - 24
     env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_CACHE: remote:rw
+      TURBO_TOKEN: ${{ github.event_name == 'pull_request' && 'unused' || secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ github.event_name == 'pull_request' && 'unused' || vars.TURBO_TEAM }}
+      TURBO_CACHE: ${{ github.event_name == 'pull_request' && 'local:rw' || 'remote:rw' }}
     steps:
       - name: Determine fetch depth
         id: fetch-depth
@@ -596,10 +614,11 @@ jobs:
           echo "depth=$(( ${{ github.event.pull_request.commits || 1 }} + 1 ))" >> $GITHUB_OUTPUT
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.ref }}
           fetch-depth: ${{ steps.fetch-depth.outputs.depth  }}
+          persist-credentials: false
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
@@ -686,5 +705,7 @@ jobs:
     name: Cleanup
     needs: summary
     if: always()
+    permissions:
+      actions: write
     uses: ./.github/workflows/pr-clean-caches.yml
     secrets: inherit


### PR DESCRIPTION
## Summary
- Removes broad PR workflow write permissions and keeps Actions cache deletion isolated to cleanup jobs.
- Prevents PR jobs from receiving remote-cache/deploy secrets, disables Vercel-backed example checks on PRs, and prevents checkout token persistence.
- Pins non-release workflow/shared action dependencies, validates manual Turbo version inputs, and verifies capnproto fallback downloads.

<sub>Closes TURBO-5464, TURBO-5465, TURBO-5466, TURBO-5467, TURBO-5468, TURBO-5474, TURBO-5432, TURBO-5433, TURBO-5438.</sub>