### PR TITLE
fix: Harden OG image signatures

### DIFF
--- a/apps/docs/lib/og/sign-edge.ts
+++ b/apps/docs/lib/og/sign-edge.ts
@@ -37,7 +37,7 @@ export async function signOgParamsEdge(
 
   const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(data));
 
-  return bufferToHex(signature).slice(0, 16);
+  return bufferToHex(signature);
 }
 
 /**

--- a/apps/docs/lib/og/sign-edge.ts
+++ b/apps/docs/lib/og/sign-edge.ts
@@ -1,4 +1,5 @@
 const OG_SECRET = process.env.OG_IMAGE_SECRET || "fallback-secret-for-dev";
+const HMAC_SHA256_HEX_LENGTH = 64;
 
 /**
  * Normalizes parameters into a consistent string for signing.
@@ -15,6 +16,19 @@ function bufferToHex(buffer: ArrayBuffer): string {
   return Array.from(new Uint8Array(buffer))
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");
+}
+
+function hexToUint8Array(hex: string): Uint8Array | null {
+  if (hex.length % 2 !== 0 || !/^[0-9a-f]*$/i.test(hex)) {
+    return null;
+  }
+
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let index = 0; index < bytes.length; index++) {
+    bytes[index] = Number.parseInt(hex.slice(index * 2, index * 2 + 2), 16);
+  }
+
+  return bytes;
 }
 
 /**
@@ -48,6 +62,24 @@ export async function verifyOgSignatureEdge(
   params: Record<string, string>,
   signature: string
 ): Promise<boolean> {
-  const expectedSignature = await signOgParamsEdge(params);
-  return signature === expectedSignature;
+  if (signature.length !== HMAC_SHA256_HEX_LENGTH) {
+    return false;
+  }
+
+  const signatureBytes = hexToUint8Array(signature);
+  if (!signatureBytes) {
+    return false;
+  }
+
+  const data = normalizeParams(params);
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(OG_SECRET),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["verify"]
+  );
+
+  return crypto.subtle.verify("HMAC", key, signatureBytes, encoder.encode(data));
 }

--- a/apps/docs/lib/og/sign.ts
+++ b/apps/docs/lib/og/sign.ts
@@ -1,4 +1,4 @@
-import { createHmac } from "node:crypto";
+import { createHmac, timingSafeEqual } from "node:crypto";
 
 const OG_SECRET = process.env.OG_IMAGE_SECRET || "fallback-secret-for-dev";
 
@@ -30,7 +30,19 @@ export function verifyOgSignature(
   signature: string
 ): boolean {
   const expectedSignature = signOgParams(params);
-  return signature === expectedSignature;
+
+  if (signature.length !== expectedSignature.length) {
+    return false;
+  }
+
+  const signatureBuffer = Buffer.from(signature, "hex");
+  const expectedSignatureBuffer = Buffer.from(expectedSignature, "hex");
+
+  if (signatureBuffer.length !== expectedSignatureBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(signatureBuffer, expectedSignatureBuffer);
 }
 
 /**

--- a/apps/docs/lib/og/sign.ts
+++ b/apps/docs/lib/og/sign.ts
@@ -18,8 +18,7 @@ export function signOgParams(params: Record<string, string>): string {
   const data = normalizeParams(params);
   return createHmac("sha256", OG_SECRET)
     .update(data)
-    .digest("hex")
-    .slice(0, 16);
+    .digest("hex");
 }
 
 /**


### PR DESCRIPTION
## Summary
- Strengthens docs OG image signing to use full HMAC-SHA256 digests instead of 64-bit truncated tags.
- Uses timing-safe verification for Node and Web Crypto verification for Edge to avoid leaking signature comparisons.

Fixes TURBO-5453.
Fixes TURBO-5454.

## Testing
- Passed: Node/Edge smoke check confirmed matching 64-character signatures and rejected tampered/short signatures.
- Passed: push hooks.
- Failed unrelated: `pnpm --filter docs check-types` currently fails on existing docs type errors in generated Next route types, MDX component props, and OpenAPI typing.