### PR TITLE
fix: Scope release npm publishing credentials

### DIFF
--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -8,7 +8,6 @@ on:
         type: boolean
 
 permissions:
-  id-token: write # Required for npm Trusted Publishing using OIDC
   contents: write
   pull-requests: write
 
@@ -142,6 +141,9 @@ jobs:
     name: Publish to NPM
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: write
+      id-token: write # Required for npm Trusted Publishing using OIDC
     needs: [build]
     outputs:
       version: ${{ steps.version.outputs.version }}

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -22,11 +22,9 @@ name: Release
 env:
   CARGO_PROFILE_RELEASE_LTO: true
   HUSKY: "0"
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   RELEASE_TURBO_CLI: true # TODO: do we need this?
 
 permissions:
-  id-token: write # Required for npm Trusted Publishing using OIDC
   contents: write # Allow workflow to checkout code from the repository
   pull-requests: write # Allows the PR for post-release to be created
   checks: write # Allows posting check statuses for release PRs
@@ -387,6 +385,9 @@ jobs:
     name: "Publish To NPM"
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write # Required for npm Trusted Publishing using OIDC
     # TODO: Add rust-smoke-test back to needs and if-condition when re-enabled.
     needs: [stage, build-rust, js-smoke-test]
     if: ${{ always() && needs.stage.result == 'success' && needs.build-rust.result == 'success' && needs.js-smoke-test.result == 'success' }}


### PR DESCRIPTION
## Summary
- Reduces release workflow credential exposure by relying on npm Trusted Publishing instead of a long-lived npm token.
- Limits OIDC token minting to the npm publishing jobs instead of the full release workflows.

<sub>Closes TURBO-5437</sub>