### PR TITLE
ci: Harden internal GitHub Actions

### DIFF
--- a/.github/actions/install-global-turbo/action.yml
+++ b/.github/actions/install-global-turbo/action.yml
@@ -26,7 +26,11 @@ runs:
           VERSION=$(npm view turbo --json | jq -r '.versions | map(select(test("^2\\."))) | last')
           echo "No version provided, using latest 2.x version: $VERSION"
         fi
-        echo "TURBO_VERSION=$VERSION" >> $GITHUB_ENV
+        if [[ ! "$VERSION" =~ ^[0-9A-Za-z][0-9A-Za-z._-]{0,127}$ ]]; then
+          echo "::error::Invalid Turbo version '${VERSION}'. Use a semver version or safe npm dist-tag."
+          exit 1
+        fi
+        echo "TURBO_VERSION=$VERSION" >> "$GITHUB_ENV"
 
     - name: Install Turbo globally
       shell: bash

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -13,18 +13,70 @@ jobs:
   find-changes:
     name: Find path changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       is-release-pr: ${{ steps.check.outputs.is-release-pr }}
       js-packages: ${{ steps.filter.outputs.js-packages }}
     steps:
+      - name: Check if automated release PR
+        id: check
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            echo "is-release-pr=false" >> "$GITHUB_OUTPUT"
+            echo "Not a pull_request event, skipping release PR check"
+            exit 0
+          fi
+
+          if [[ "$PR_AUTHOR" != "github-actions[bot]" || ! "$PR_TITLE" =~ ^release\(turborepo\): ]]; then
+            echo "is-release-pr=false" >> "$GITHUB_OUTPUT"
+            echo "Not a release PR (author: $PR_AUTHOR, title: $PR_TITLE)"
+            exit 0
+          fi
+
+          CHANGED_FILES=$(gh api --paginate "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files" --jq '.[].filename')
+          if [[ -z "$CHANGED_FILES" ]]; then
+            echo "::error::Unable to determine changed files for release PR"
+            exit 1
+          fi
+
+          echo "Changed files in release PR:"
+          printf '%s\n' "$CHANGED_FILES"
+
+          ALLOWED_PATTERN="^(version\.txt|.*/package\.json|package\.json|Cargo\.toml|Cargo\.lock|.*/Cargo\.toml|CHANGELOG.*|pnpm-lock\.yaml)$"
+          INVALID_FILES=""
+          while IFS= read -r file; do
+            if [[ -n "$file" && ! "$file" =~ $ALLOWED_PATTERN ]]; then
+              INVALID_FILES="$INVALID_FILES$file"$'\n'
+            fi
+          done <<< "$CHANGED_FILES"
+
+          if [[ -n "$INVALID_FILES" ]]; then
+            echo "::error::Release PR contains unexpected files that are not version-related:"
+            printf '%s\n' "$INVALID_FILES"
+            echo "::error::Release PRs should only modify version.txt, package.json, Cargo.toml, Cargo.lock, CHANGELOG, or pnpm-lock.yaml"
+            exit 1
+          fi
+
+          echo "is-release-pr=true" >> "$GITHUB_OUTPUT"
+          echo "Release PR content validation passed - only version-related files changed"
+
       - name: Checkout
+        if: steps.check.outputs.is-release-pr != 'true'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
-
-      - name: Check if automated release PR
-        id: check
-        uses: ./.github/actions/check-release-pr
 
       - name: Check path changes
         if: steps.check.outputs.is-release-pr != 'true'
@@ -120,6 +172,10 @@ jobs:
       - find-changes
       - js_packages
     steps:
+      - name: Fail if change detection failed
+        if: needs.find-changes.result != 'success'
+        run: exit 1
+
       - name: Skip for release PR
         if: needs.find-changes.outputs.is-release-pr == 'true'
         run: echo "Release PR detected - skipping tests (code already tested on main)"

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -16,6 +16,9 @@ jobs:
     name: Find path changes
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       is-release-pr: ${{ steps.check-release.outputs.is-release-pr }}
       docs: ${{ steps.filter.outputs.docs }}
@@ -26,14 +29,63 @@ jobs:
       # Detect automated release PRs which only contain version bumps.
       # These PRs are created by the release workflow after code has already
       # been tested on main. Skipping tests on version-only changes saves CI time.
+      - name: Check if automated release PR
+        id: check-release
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            echo "is-release-pr=false" >> "$GITHUB_OUTPUT"
+            echo "Not a pull_request event, skipping release PR check"
+            exit 0
+          fi
+
+          if [[ "$PR_AUTHOR" != "github-actions[bot]" || ! "$PR_TITLE" =~ ^release\(turborepo\): ]]; then
+            echo "is-release-pr=false" >> "$GITHUB_OUTPUT"
+            echo "Not a release PR (author: $PR_AUTHOR, title: $PR_TITLE)"
+            exit 0
+          fi
+
+          CHANGED_FILES=$(gh api --paginate "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files" --jq '.[].filename')
+          if [[ -z "$CHANGED_FILES" ]]; then
+            echo "::error::Unable to determine changed files for release PR"
+            exit 1
+          fi
+
+          echo "Changed files in release PR:"
+          printf '%s\n' "$CHANGED_FILES"
+
+          ALLOWED_PATTERN="^(version\.txt|.*/package\.json|package\.json|Cargo\.toml|Cargo\.lock|.*/Cargo\.toml|CHANGELOG.*|pnpm-lock\.yaml)$"
+          INVALID_FILES=""
+          while IFS= read -r file; do
+            if [[ -n "$file" && ! "$file" =~ $ALLOWED_PATTERN ]]; then
+              INVALID_FILES="$INVALID_FILES$file"$'\n'
+            fi
+          done <<< "$CHANGED_FILES"
+
+          if [[ -n "$INVALID_FILES" ]]; then
+            echo "::error::Release PR contains unexpected files that are not version-related:"
+            printf '%s\n' "$INVALID_FILES"
+            echo "::error::Release PRs should only modify version.txt, package.json, Cargo.toml, Cargo.lock, CHANGELOG, or pnpm-lock.yaml"
+            exit 1
+          fi
+
+          echo "is-release-pr=true" >> "$GITHUB_OUTPUT"
+          echo "Release PR content validation passed - only version-related files changed"
+
       - name: Checkout
+        if: steps.check-release.outputs.is-release-pr != 'true'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
-
-      - name: Check if automated release PR
-        id: check-release
-        uses: ./.github/actions/check-release-pr
 
       - name: Check path changes
         if: steps.check-release.outputs.is-release-pr != 'true'
@@ -653,6 +705,10 @@ jobs:
       - check-lockfiles
       - js_native_packages
     steps:
+      - name: Fail if change detection failed
+        if: needs.find-changes.result != 'success'
+        run: exit 1
+
       - name: Skip for release PR
         if: needs.find-changes.outputs.is-release-pr == 'true'
         run: |

--- a/packages/turbo-releaser/src/operations.ts
+++ b/packages/turbo-releaser/src/operations.ts
@@ -41,7 +41,8 @@ function validatePathSegment(name: string, value: string) {
 }
 
 function validatePackagePrefix(packagePrefix: string) {
-  const validPackagePrefix = /^(@[0-9A-Za-z._-]+(\/[0-9A-Za-z._-]+)?|[0-9A-Za-z._-]+)$/;
+  const validPackagePrefix =
+    /^(@[0-9A-Za-z._-]+(\/[0-9A-Za-z._-]+)?|[0-9A-Za-z._-]+)$/;
 
   if (!validPackagePrefix.test(packagePrefix)) {
     throw new Error(`Invalid package prefix: ${packagePrefix}`);

--- a/packages/turbo-releaser/src/operations.ts
+++ b/packages/turbo-releaser/src/operations.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import fs from "node:fs/promises";
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import * as tar from "tar";
 import native from "./native";
 import type { Platform } from "./types";
@@ -22,6 +22,32 @@ export interface PackOptions {
   description?: string;
 }
 
+function validateVersion(version: string) {
+  if (!/^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$/.test(version)) {
+    throw new Error(`Invalid version: ${version}`);
+  }
+}
+
+function validateNpmTag(npmTag: string) {
+  if (!/^[0-9A-Za-z][0-9A-Za-z._-]{0,127}$/.test(npmTag)) {
+    throw new Error(`Invalid npm tag: ${npmTag}`);
+  }
+}
+
+function validatePathSegment(name: string, value: string) {
+  if (!/^[0-9A-Za-z._-]+$/.test(value) || value.includes("..")) {
+    throw new Error(`Invalid ${name}: ${value}`);
+  }
+}
+
+function validatePackagePrefix(packagePrefix: string) {
+  const validPackagePrefix = /^(@[0-9A-Za-z._-]+(\/[0-9A-Za-z._-]+)?|[0-9A-Za-z._-]+)$/;
+
+  if (!validPackagePrefix.test(packagePrefix)) {
+    throw new Error(`Invalid package prefix: ${packagePrefix}`);
+  }
+}
+
 async function packPlatform({
   platform,
   version,
@@ -31,11 +57,17 @@ async function packPlatform({
   srcDirPrefix = "dist",
   description
 }: PackOptions): Promise<string> {
+  validateVersion(version);
+  validatePackagePrefix(packagePrefix);
+  validatePathSegment("binary name", binaryBaseName);
+  validatePathSegment("source directory prefix", srcDirPrefix);
+
   const { os, arch } = platform;
   console.log(`Packing platform: ${os}-${arch}`);
   const npmDirName = `${packagePrefix}-${os}-${arch}`
     .replace("@", "")
     .replace("/", "-");
+  validatePathSegment("package directory name", npmDirName);
   const tarballDir = path.join(srcDir, "dist", `${npmDirName}-${version}`);
   const scaffoldDir = path.join(tarballDir, npmDirName);
 
@@ -81,12 +113,23 @@ async function packPlatform({
 }
 
 function publishArtifacts(artifacts: Array<string>, npmTag: string) {
+  validateNpmTag(npmTag);
+
   for (const artifact of artifacts) {
-    const npmVersion = execSync("npm --version").toString().trim();
+    const npmVersion = execFileSync("npm", ["--version"], {
+      encoding: "utf8"
+    }).trim();
     console.log(`npm version: ${npmVersion}`);
-    const publishCommand = `npm publish "${artifact}" --tag ${npmTag} --access public`;
-    console.log(`Executing: ${publishCommand}`);
-    execSync(publishCommand, { stdio: "inherit" });
+    console.log(
+      `Executing: npm publish ${artifact} --tag ${npmTag} --access public`
+    );
+    execFileSync(
+      "npm",
+      ["publish", artifact, "--tag", npmTag, "--access", "public"],
+      {
+        stdio: "inherit"
+      }
+    );
   }
 }
 

--- a/packages/turbo-releaser/src/packager.ts
+++ b/packages/turbo-releaser/src/packager.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import type { Platform } from "./types";
 import operations from "./operations";
 
@@ -44,7 +44,9 @@ export async function packAndPublish({
 
   if (!skipPublish) {
     console.log("Publishing artifacts...");
-    const npmVersion = execSync("npm --version").toString().trim();
+    const npmVersion = execFileSync("npm", ["--version"], {
+      encoding: "utf8"
+    }).trim();
     console.log(`npm version: ${npmVersion}`);
     operations.publishArtifacts(artifacts, npmTag);
   } else {


### PR DESCRIPTION
## Summary
- Prevent PR-controlled local actions from deciding whether CI can skip release PR tests.
- Fail closed when release PR file validation cannot complete or is rejected.
- Remove shell interpolation from releaser publish commands and validate release metadata before path/command use.