### PR TITLE
ci: Harden release workflow handling

### DIFF
--- a/.github/actions/find-rust-changes/action.yml
+++ b/.github/actions/find-rust-changes/action.yml
@@ -11,24 +11,29 @@ runs:
     - name: Check for Rust changes
       id: check
       shell: bash
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        BASE_REF: ${{ github.base_ref }}
+        BEFORE_SHA: ${{ github.event.before }}
+        AFTER_SHA: ${{ github.event.after }}
       run: |
-        if [ "${{ github.event_name }}" == "pull_request" ]; then
-          git fetch origin ${{ github.base_ref }}
-          BASE_COMMIT="origin/${{ github.base_ref }}"
+        if [ "$EVENT_NAME" = "pull_request" ]; then
+          git fetch origin "$BASE_REF"
+          BASE_COMMIT="origin/${BASE_REF}"
           HEAD_COMMIT="HEAD"
         else
-          BASE_COMMIT="${{ github.event.before }}"
-          HEAD_COMMIT="${{ github.event.after }}"
+          BASE_COMMIT="$BEFORE_SHA"
+          HEAD_COMMIT="$AFTER_SHA"
         fi
 
-        echo "Comparing changes between $BASE_COMMIT and $HEAD_COMMIT"
+        echo "Comparing changes between ${BASE_COMMIT} and ${HEAD_COMMIT}"
 
-        RUST_PATHS="crates/ Cargo.toml Cargo.lock .cargo/ rust-toolchain.toml"
+        RUST_PATHS=("crates/" "Cargo.toml" "Cargo.lock" ".cargo/" "rust-toolchain.toml")
 
-        if git diff --name-only $BASE_COMMIT $HEAD_COMMIT -- $RUST_PATHS | grep -q .; then
-          echo "changed=true" >> $GITHUB_OUTPUT
+        if git diff --name-only "$BASE_COMMIT" "$HEAD_COMMIT" -- "${RUST_PATHS[@]}" | grep -q .; then
+          echo "changed=true" >> "$GITHUB_OUTPUT"
           echo "Changes detected in Rust paths"
         else
-          echo "changed=false" >> $GITHUB_OUTPUT
+          echo "changed=false" >> "$GITHUB_OUTPUT"
           echo "No changes in Rust paths"
         fi

--- a/.github/workflows/docs-alias-failure-notification.yml
+++ b/.github/workflows/docs-alias-failure-notification.yml
@@ -10,6 +10,9 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+
 jobs:
   notify-failure:
     name: "Notify Slack on Docs Alias Failure"
@@ -23,12 +26,19 @@ jobs:
 
       - name: Get version
         id: version
+        shell: bash
         run: |
           if [ -f version.txt ]; then
-            VERSION=$(head -n 1 version.txt)
-            echo "version=${VERSION}" >> $GITHUB_OUTPUT
+            IFS= read -r VERSION < version.txt
+
+            if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+              printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
+            else
+              echo "::warning::version.txt did not contain a valid release version. Reporting unknown version."
+              echo "version=unknown" >> "$GITHUB_OUTPUT"
+            fi
           else
-            echo "version=unknown" >> $GITHUB_OUTPUT
+            echo "version=unknown" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Send failure notification to Slack
@@ -38,5 +48,5 @@ jobs:
           webhook-type: incoming-webhook
           payload: |
             {
-              "version": "${{ steps.version.outputs.version }}"
+              "version": ${{ toJSON(steps.version.outputs.version) }}
             }

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -538,10 +538,16 @@ jobs:
       - name: Find Vercel deployment for SHA
         id: find-deployment
         env:
+          BASE_SHA: ${{ needs.stage.outputs.base-sha }}
           VERCEL_TOKEN: ${{ secrets.TURBO_TOKEN }}
         run: |
-          SHA="${{ needs.stage.outputs.base-sha }}"
-          DEPLOYMENT_URL=$(vercel list turbo-site --scope=vercel -m githubCommitSha="${SHA}" --status=READY --token="${VERCEL_TOKEN}" 2>&1 | tee /dev/stderr | grep -E '^\S+\.vercel\.(app|sh)' | head -n 1 | awk '{print $1}')
+          SHA="${BASE_SHA}"
+          VERCEL_LIST_STDERR="${RUNNER_TEMP}/vercel-list.stderr"
+          if ! VERCEL_LIST_OUTPUT=$(vercel list turbo-site --scope=vercel -m githubCommitSha="${SHA}" --status=READY --token="${VERCEL_TOKEN}" 2>"${VERCEL_LIST_STDERR}"); then
+            echo "::error::Failed to list Vercel deployments for SHA ${SHA}. Vercel CLI stderr was captured without printing to logs."
+            exit 1
+          fi
+          DEPLOYMENT_URL=$(printf '%s\n' "${VERCEL_LIST_OUTPUT}" | grep -E '^\S+\.vercel\.(app|sh)' | head -n 1 | awk '{print $1}' || true)
 
           if [ -z "$DEPLOYMENT_URL" ]; then
             echo "::error::No deployment found for SHA ${SHA}."

--- a/packages/turbo-releaser/src/native.test.ts
+++ b/packages/turbo-releaser/src/native.test.ts
@@ -6,6 +6,7 @@ import native from "./native";
 import type { Platform } from "./types";
 
 describe("generateNativePackage", () => {
+  const outputBaseDir = "/path/to";
   const outputDir = "/path/to/output";
 
   it("should generate package correctly for non-Windows platform", async (t) => {
@@ -29,6 +30,7 @@ describe("generateNativePackage", () => {
       platform,
       version,
       outputDir,
+      outputBaseDir,
       packagePrefix: "@turbo"
     });
 
@@ -103,6 +105,7 @@ describe("generateNativePackage", () => {
       platform: { os: "windows", arch: "x64" },
       version: "1.0.0",
       outputDir,
+      outputBaseDir,
       packagePrefix: "@turbo"
     });
 
@@ -132,9 +135,26 @@ describe("generateNativePackage", () => {
         platform: { os: "linux", arch: "x64" },
         version: "1.2.0",
         outputDir,
+        outputBaseDir,
         packagePrefix: "@turbo"
       }),
       { message: "Failed to remove directory" }
+    );
+  });
+
+  it("should reject output directories outside the package base", async () => {
+    await assert.rejects(
+      native.generateNativePackage({
+        platform: { os: "linux", arch: "x64" },
+        version: "1.2.0",
+        outputDir: "/path/elsewhere",
+        outputBaseDir,
+        packagePrefix: "@turbo"
+      }),
+      {
+        message:
+          "Refusing to clean output directory outside package base: /path/elsewhere"
+      }
     );
   });
 });

--- a/packages/turbo-releaser/src/native.ts
+++ b/packages/turbo-releaser/src/native.ts
@@ -25,27 +25,30 @@ async function generateNativePackage({
   platform,
   version,
   outputDir,
+  outputBaseDir,
   packagePrefix = "turbo",
   description
 }: {
   platform: Platform;
   version: string;
   outputDir: string;
+  outputBaseDir: string;
   packagePrefix?: string;
   description?: string;
 }) {
   const { os, arch } = platform;
+  const safeOutputDir = resolveOutputDir(outputDir, outputBaseDir);
   console.log(`Generating native package for ${os}-${arch}...`);
 
-  console.log(`Cleaning output directory: ${outputDir}`);
-  await rm(outputDir, { recursive: true, force: true });
-  await mkdir(path.join(outputDir, "bin"), { recursive: true });
+  console.log(`Cleaning output directory: ${safeOutputDir}`);
+  await rm(safeOutputDir, { recursive: true, force: true });
+  await mkdir(path.join(safeOutputDir, "bin"), { recursive: true });
 
   const copyFromTemplate = async (part: string, ...parts: Array<string>) => {
     console.log("Copying ", path.join(part, ...parts));
     await copyFile(
       path.join(templateDir, part, ...parts),
-      path.join(outputDir, part, ...parts)
+      path.join(safeOutputDir, part, ...parts)
     );
   };
 
@@ -77,11 +80,32 @@ async function generateNativePackage({
     packageJson.publishConfig = { access: "public" };
   }
   await writeFile(
-    path.join(outputDir, "package.json"),
+    path.join(safeOutputDir, "package.json"),
     JSON.stringify(packageJson, null, 2)
   );
 
-  console.log(`Native package generated successfully in ${outputDir}`);
+  console.log(`Native package generated successfully in ${safeOutputDir}`);
+}
+
+function resolveOutputDir(outputDir: string, outputBaseDir: string) {
+  const resolvedOutputDir = path.resolve(outputDir);
+  const resolvedOutputBaseDir = path.resolve(outputBaseDir);
+  const relativeOutputDir = path.relative(
+    resolvedOutputBaseDir,
+    resolvedOutputDir
+  );
+
+  if (
+    relativeOutputDir === "" ||
+    relativeOutputDir.startsWith("..") ||
+    path.isAbsolute(relativeOutputDir)
+  ) {
+    throw new Error(
+      `Refusing to clean output directory outside package base: ${outputDir}`
+    );
+  }
+
+  return resolvedOutputDir;
 }
 
 // Exported asn an object instead of export keyword, so that these functions

--- a/packages/turbo-releaser/src/operations.ts
+++ b/packages/turbo-releaser/src/operations.ts
@@ -69,7 +69,8 @@ async function packPlatform({
     .replace("@", "")
     .replace("/", "-");
   validatePathSegment("package directory name", npmDirName);
-  const tarballDir = path.join(srcDir, "dist", `${npmDirName}-${version}`);
+  const distDir = path.join(srcDir, "dist");
+  const tarballDir = path.join(distDir, `${npmDirName}-${version}`);
   const scaffoldDir = path.join(tarballDir, npmDirName);
 
   console.log("Generating native package...");
@@ -77,6 +78,7 @@ async function packPlatform({
     platform,
     version,
     outputDir: scaffoldDir,
+    outputBaseDir: tarballDir,
     packagePrefix,
     description
   });
@@ -99,7 +101,7 @@ async function packPlatform({
 
   console.log("Creating tar.gz...");
   const tarName = `${npmDirName}-${version}.tar.gz`;
-  const tarPath = path.join(srcDir, "dist", tarName);
+  const tarPath = path.join(distDir, tarName);
   await tar.create(
     {
       gzip: true,


### PR DESCRIPTION
- Remove shell-injection patterns from Rust change detection by routing GitHub contexts through environment variables and quoting shell inputs.
- Reduce release workflow data exposure by avoiding token-bearing Vercel CLI output in logs.
- Harden docs alias failure notifications against over-privileged tokens and JSON injection from branch-controlled `version.txt`.
- Add a local safety boundary before recursively cleaning turbo-releaser package output directories.