### PR TITLE
ci: Fix LSP workflow container matrix

### DIFF
--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -20,41 +20,32 @@ jobs:
         settings:
           - host: macos-latest
             target: "x86_64-apple-darwin"
-            container-options: "--rm"
           - host: macos-latest
             target: "aarch64-apple-darwin"
-            container-options: "--rm"
           - host: ubuntu-latest
-            container-options: "--platform=linux/amd64 --rm"
-            container-setup: "sudo apt-get update && sudo apt-get install -y curl musl-tools"
+            prepare: "sudo apt-get update && sudo apt-get install -y curl musl-tools"
             target: "x86_64-unknown-linux-musl"
             setup: "sudo apt-get install -y build-essential"
           - host: ubuntu-latest
-            container-options: "--rm"
             target: "aarch64-unknown-linux-musl"
             rust-build-env: 'CC_aarch64_unknown_linux_musl=clang AR_aarch64_unknown_linux_musl=llvm-ar RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld"'
             setup: "sudo apt-get update && sudo apt-get install -y build-essential musl-tools clang llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu"
           - host: windows-latest
             target: x86_64-pc-windows-msvc
             setup: "rustup set default-host x86_64-pc-windows-msvc"
-            container-options: "--rm"
           - host: windows-latest
             target: aarch64-pc-windows-msvc
             setup: "rustup set default-host aarch64-pc-windows-msvc"
-            container-options: "--rm"
     runs-on: ${{ matrix.settings.host }}
     timeout-minutes: 30
-    container:
-      image: ${{ matrix.settings.container }}
-      options: ${{ matrix.settings.container-options }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
-      - name: Setup Container
-        if: ${{ matrix.settings.container-setup }}
-        run: ${{ matrix.settings.container-setup }}
+      - name: Prepare build environment
+        if: ${{ matrix.settings.prepare }}
+        run: ${{ matrix.settings.prepare }}
 
       - name: Setup capnproto
         uses: ./.github/actions/setup-capnproto


### PR DESCRIPTION
## Summary
- Removes the undefined job-level LSP container image so every matrix entry can start on its selected runner.
- Keeps the Linux preparation command as a normal runner step instead of a dead container setup path.

Closes TURBO-5507

## Testing
- pnpm format
- pnpm check:toml
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0))' ".github/workflows/lsp.yml"