### PR TITLE
fix: Respect SCM env vars in `turbo query affected`

### DIFF
--- a/apps/docs/content/docs/guides/skipping-tasks.mdx
+++ b/apps/docs/content/docs/guides/skipping-tasks.mdx
@@ -85,7 +85,7 @@ You can customize this with `--base` and `--head`:
 turbo query affected --packages web --base main --head HEAD
 ```
 
-You can also set `TURBO_SCM_BASE` and `TURBO_SCM_HEAD` environment variables.
+You can also set `TURBO_SCM_BASE` and `TURBO_SCM_HEAD` environment variables. Explicit `--base` and `--head` flags take precedence.
 
 ### Quick check with `--exit-code`
 

--- a/apps/docs/content/docs/reference/query.mdx
+++ b/apps/docs/content/docs/reference/query.mdx
@@ -196,7 +196,7 @@ turbo query affected --packages web docs
 
 Base git ref for comparison. Defaults to the auto-detected base (e.g. `GITHUB_BASE_REF` on GitHub Actions, or the merge-base with `main`).
 
-Can also be set with the `TURBO_SCM_BASE` environment variable.
+Can also be set with the `TURBO_SCM_BASE` environment variable. When both are provided, `--base` takes precedence.
 
 ```bash title="Terminal"
 turbo query affected --base main
@@ -206,7 +206,7 @@ turbo query affected --base main
 
 Head git ref for comparison. Defaults to `HEAD`.
 
-Can also be set with the `TURBO_SCM_HEAD` environment variable.
+Can also be set with the `TURBO_SCM_HEAD` environment variable. When both are provided, `--head` takes precedence.
 
 ```bash title="Terminal"
 turbo query affected --head my-branch

--- a/apps/docs/content/docs/reference/system-environment-variables.mdx
+++ b/apps/docs/content/docs/reference/system-environment-variables.mdx
@@ -289,8 +289,9 @@ System environment variables are always overridden by flag values provided direc
         <code>TURBO_SCM_BASE</code>
       </td>
       <td>
-        Base used by <code>--affected</code> when calculating what has changed
-        from <code>base...head</code>
+        Base used by <code>--affected</code> and{" "}
+        <code>turbo query affected</code> when calculating what has changed from{" "}
+        <code>base...head</code>
       </td>
     </tr>
     <tr id="turbo_scm_head">
@@ -298,8 +299,9 @@ System environment variables are always overridden by flag values provided direc
         <code>TURBO_SCM_HEAD</code>
       </td>
       <td>
-        Head used by <code>--affected</code> when calculating what has changed
-        from <code>base...head</code>
+        Head used by <code>--affected</code> and{" "}
+        <code>turbo query affected</code> when calculating what has changed from{" "}
+        <code>base...head</code>
       </td>
     </tr>
     <tr id="turbo_team">

--- a/crates/turborepo-lib/src/commands/query.rs
+++ b/crates/turborepo-lib/src/commands/query.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Write, fs, sync::Arc};
+use std::{env, fmt::Write, fs, sync::Arc};
 
 use camino::Utf8Path;
 use miette::{Diagnostic, Report, SourceSpan};
@@ -107,18 +107,32 @@ pub(crate) fn escape_graphql_string(s: &str) -> String {
 
 impl AffectedArgs {
     fn to_graphql_query(&self) -> String {
+        self.to_graphql_query_with_refs(None, None)
+    }
+
+    fn to_graphql_query_with_env(&self) -> String {
+        let scm_base = Self::env_ref("TURBO_SCM_BASE");
+        let scm_head = Self::env_ref("TURBO_SCM_HEAD");
+        self.to_graphql_query_with_refs(scm_base.as_deref(), scm_head.as_deref())
+    }
+
+    fn to_graphql_query_with_refs(&self, scm_base: Option<&str>, scm_head: Option<&str>) -> String {
         // --packages alone → affectedPackages
         // Everything else (default, --tasks, --tasks + --packages) → affectedTasks
         if self.packages.is_some() && self.tasks.is_none() {
-            self.build_affected_packages_query()
+            self.build_affected_packages_query(scm_base, scm_head)
         } else {
-            self.build_affected_tasks_query()
+            self.build_affected_tasks_query(scm_base, scm_head)
         }
     }
 
-    fn build_affected_packages_query(&self) -> String {
+    fn build_affected_packages_query(
+        &self,
+        scm_base: Option<&str>,
+        scm_head: Option<&str>,
+    ) -> String {
         let mut query = String::from("{ affectedPackages");
-        let mut args = self.build_ref_args();
+        let mut args = self.build_ref_args(scm_base, scm_head);
         self.push_package_filter(&mut args);
         if !args.is_empty() {
             let joined = args.join(", ");
@@ -128,9 +142,9 @@ impl AffectedArgs {
         query
     }
 
-    fn build_affected_tasks_query(&self) -> String {
+    fn build_affected_tasks_query(&self, scm_base: Option<&str>, scm_head: Option<&str>) -> String {
         let mut query = String::from("{ affectedTasks");
-        let mut args = self.build_ref_args();
+        let mut args = self.build_ref_args(scm_base, scm_head);
         let tasks = self.tasks.as_deref().unwrap_or_default();
         if !tasks.is_empty() {
             let task_values: Vec<String> = tasks
@@ -150,15 +164,25 @@ impl AffectedArgs {
         query
     }
 
-    fn build_ref_args(&self) -> Vec<String> {
+    fn build_ref_args(&self, scm_base: Option<&str>, scm_head: Option<&str>) -> Vec<String> {
         let mut args = Vec::new();
-        if let Some(ref base) = self.base {
+        if let Some(base) = Self::ref_arg(self.base.as_ref(), scm_base) {
             args.push(format!("base: \"{}\"", escape_graphql_string(base)));
         }
-        if let Some(ref head) = self.head {
+        if let Some(head) = Self::ref_arg(self.head.as_ref(), scm_head) {
             args.push(format!("head: \"{}\"", escape_graphql_string(head)));
         }
         args
+    }
+
+    fn ref_arg<'a>(cli_value: Option<&'a String>, env_value: Option<&'a str>) -> Option<&'a str> {
+        cli_value
+            .map(String::as_str)
+            .or_else(|| env_value.filter(|value| !value.is_empty()))
+    }
+
+    fn env_ref(env_key: &str) -> Option<String> {
+        env::var(env_key).ok().filter(|value| !value.is_empty())
     }
 
     fn push_package_filter(&self, args: &mut Vec<String>) {
@@ -222,7 +246,7 @@ pub async fn run(
     if let Some(subcommand) = subcommand {
         match &subcommand {
             QuerySubcommand::Affected(args) => {
-                let query = args.to_graphql_query();
+                let query = args.to_graphql_query_with_env();
                 let (exit_code, result_json) =
                     execute_query_and_print(run, query_server, &query, None).await?;
 

--- a/crates/turborepo/tests/affected_test.rs
+++ b/crates/turborepo/tests/affected_test.rs
@@ -947,6 +947,134 @@ fn test_affected_tasks_with_explicit_base() {
     );
 }
 
+#[test]
+fn test_query_affected_shorthand_respects_scm_base_env() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_affected_tasks_fixture(tempdir.path());
+
+    fs::write(
+        tempdir.path().join("packages/lib-a/index.ts"),
+        "export const changed = true;",
+    )
+    .unwrap();
+    git(tempdir.path(), &["add", "."]);
+    git(tempdir.path(), &["commit", "-m", "change lib-a", "--quiet"]);
+
+    let output = run_turbo_with_env(
+        tempdir.path(),
+        &["query", "affected", "--tasks", "build", "--exit-code"],
+        &[("TURBO_SCM_BASE", "HEAD")],
+    );
+    assert!(
+        output.status.success(),
+        "TURBO_SCM_BASE=HEAD should show no affected tasks: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["data"]["affectedTasks"]["length"], 0);
+}
+
+#[test]
+fn test_query_affected_shorthand_respects_scm_head_env() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_affected_tasks_fixture(tempdir.path());
+
+    fs::write(
+        tempdir.path().join("packages/lib-a/index.ts"),
+        "export const changed = true;",
+    )
+    .unwrap();
+    git(tempdir.path(), &["add", "."]);
+    git(tempdir.path(), &["commit", "-m", "change lib-a", "--quiet"]);
+
+    let output = run_turbo_with_env(
+        tempdir.path(),
+        &["query", "affected", "--tasks", "build", "--exit-code"],
+        &[("TURBO_SCM_BASE", "main"), ("TURBO_SCM_HEAD", "main")],
+    );
+    assert!(
+        output.status.success(),
+        "TURBO_SCM_HEAD=main should be respected: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["data"]["affectedTasks"]["length"], 0);
+}
+
+#[test]
+fn test_query_affected_shorthand_base_flag_overrides_scm_base_env() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_affected_tasks_fixture(tempdir.path());
+
+    fs::write(
+        tempdir.path().join("packages/lib-a/index.ts"),
+        "export const changed = true;",
+    )
+    .unwrap();
+    git(tempdir.path(), &["add", "."]);
+    git(tempdir.path(), &["commit", "-m", "change lib-a", "--quiet"]);
+
+    let output = run_turbo_with_env(
+        tempdir.path(),
+        &[
+            "query",
+            "affected",
+            "--tasks",
+            "build",
+            "--base",
+            "HEAD",
+            "--exit-code",
+        ],
+        &[("TURBO_SCM_BASE", "main")],
+    );
+    assert!(
+        output.status.success(),
+        "--base=HEAD should override TURBO_SCM_BASE=main: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["data"]["affectedTasks"]["length"], 0);
+}
+
+#[test]
+fn test_query_affected_shorthand_head_flag_overrides_scm_head_env() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_affected_tasks_fixture(tempdir.path());
+
+    fs::write(
+        tempdir.path().join("packages/lib-a/index.ts"),
+        "export const changed = true;",
+    )
+    .unwrap();
+    git(tempdir.path(), &["add", "."]);
+    git(tempdir.path(), &["commit", "-m", "change lib-a", "--quiet"]);
+
+    let output = run_turbo_with_env(
+        tempdir.path(),
+        &[
+            "query",
+            "affected",
+            "--tasks",
+            "build",
+            "--head",
+            "HEAD",
+            "--exit-code",
+        ],
+        &[("TURBO_SCM_BASE", "main"), ("TURBO_SCM_HEAD", "main")],
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "--head=HEAD should override TURBO_SCM_HEAD=main: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(
+        json["data"]["affectedTasks"]["length"].as_i64().unwrap() > 0,
+        "--head=HEAD should find affected tasks: {json}"
+    );
+}
+
 // ── turbo run --affected + affectedUsingTaskInputs future flag ──
 
 const TURBO_JSON_WITH_TASK_INPUTS_FLAG: &str = r#"{


### PR DESCRIPTION
## Summary
- Makes `turbo query affected` honor `TURBO_SCM_BASE` and `TURBO_SCM_HEAD` when matching flags are omitted.
- Keeps explicit `--base` and `--head` flags higher precedence than env vars.
- Adds regression coverage for env handling and flag precedence.

Fixes #12650