### PR TITLE
fix: Escape graph HTML payloads

### DIFF
--- a/crates/turborepo-engine/src/graph_visualizer.rs
+++ b/crates/turborepo-engine/src/graph_visualizer.rs
@@ -209,12 +209,13 @@ fn render_html<T: TaskDefinitionInfo + Clone>(
     let mut graph_buffer = Vec::new();
     render_dot_graph(&mut graph_buffer, engine, single_package)?;
     let graph_string = String::from_utf8(graph_buffer).expect("graph rendering should be UTF-8");
+    let graph_json = html_safe_json_string(&graph_string);
 
     file.write_all(HTML_PREFIX.as_bytes())
         .map_err(Error::GraphOutput)?;
     write!(
         &mut file,
-        "const s = `{graph_string}`.replace(/\\_\\_\\_ROOT\\_\\_\\_/g, \
+        "const s = {graph_json}.replace(/\\_\\_\\_ROOT\\_\\_\\_/g, \
          \"Root\").replace(/\\[root\\]/g, \"\");new Viz().renderSVGElement(s).then(el => \
          document.body.appendChild(el)).catch(e => console.error(e));"
     )
@@ -222,6 +223,16 @@ fn render_html<T: TaskDefinitionInfo + Clone>(
     file.write_all(HTML_SUFFIX.as_bytes())
         .map_err(Error::GraphOutput)?;
     Ok(())
+}
+
+fn html_safe_json_string(value: &str) -> String {
+    serde_json::to_string(value)
+        .expect("serializing graph output should not fail")
+        .replace('<', "\\u003C")
+        .replace('>', "\\u003E")
+        .replace('&', "\\u0026")
+        .replace('\u{2028}', "\\u2028")
+        .replace('\u{2029}', "\\u2029")
 }
 
 fn render_svg<T: TaskDefinitionInfo + Clone>(
@@ -309,5 +320,18 @@ fn filename_and_extension(
             })?
             .join_component(&jpg_filename);
         Ok((jpg_graph_file, extension))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::html_safe_json_string;
+
+    #[test]
+    fn html_safe_json_string_escapes_script_data() {
+        assert_eq!(
+            html_safe_json_string("` ${globalThis.alert(1)} </script> & \u{2028}\u{2029}"),
+            r#""` ${globalThis.alert(1)} \u003C/script\u003E \u0026 \u2028\u2029""#
+        );
     }
 }

--- a/crates/turborepo/tests/graph_test.rs
+++ b/crates/turborepo/tests/graph_test.rs
@@ -2,7 +2,8 @@ mod common;
 
 use std::fs;
 
-use common::{run_turbo, setup, turbo_output_filters};
+use common::{combined_output, run_turbo, setup, turbo_output_filters};
+use serde_json::json;
 
 fn setup_topological(dir: &std::path::Path) {
     setup::setup_integration_test(dir, "task_dependencies/topological", "npm@10.5.0", true)
@@ -66,6 +67,71 @@ fn test_graph_to_html_file() {
 
     let html = fs::read_to_string(tempdir.path().join("graph.html")).unwrap();
     assert!(html.contains("DOCTYPE"), "expected HTML DOCTYPE");
+}
+
+#[test]
+fn test_graph_to_html_escapes_task_names() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_graph_escape_fixture(tempdir.path());
+
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "run",
+            "back`tick",
+            "interpolate${globalThis.alert(1)}",
+            "break</script>out",
+            "--graph=graph.html",
+        ],
+    );
+    assert!(output.status.success(), "{}", combined_output(&output));
+
+    let html = fs::read_to_string(tempdir.path().join("graph.html")).unwrap();
+    assert!(html.contains("back`tick"));
+    assert!(html.contains("interpolate${globalThis.alert(1)}"));
+    assert!(!html.contains("const s = `"));
+    assert!(!html.contains("break</script>out"));
+    assert!(html.contains(r#"break\u003C/script\u003Eout"#));
+}
+
+fn setup_graph_escape_fixture(dir: &std::path::Path) {
+    fs::create_dir_all(dir.join("apps/app")).unwrap();
+    fs::write(
+        dir.join("package.json"),
+        serde_json::to_string_pretty(&json!({
+            "name": "monorepo",
+            "packageManager": "npm@10.5.0",
+            "workspaces": ["apps/*"]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    fs::write(
+        dir.join("turbo.json"),
+        serde_json::to_string_pretty(&json!({
+            "$schema": "https://turborepo.dev/schema.json",
+            "tasks": {
+                "back`tick": {},
+                "interpolate${globalThis.alert(1)}": {},
+                "break</script>out": {}
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    fs::write(
+        dir.join("apps/app/package.json"),
+        serde_json::to_string_pretty(&json!({
+            "name": "app",
+            "scripts": {
+                "back`tick": "echo backtick",
+                "interpolate${globalThis.alert(1)}": "echo interpolate",
+                "break</script>out": "echo break"
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Prevent generated graph HTML from treating DOT output as executable template-literal or script content.
- Add regression coverage for task names containing backticks, `${...}`, and `</script>`.


<sub>Closes TURBO-5511</sub>