### PR TITLE
fix: Validate microfrontend proxy Host header

### DIFF
--- a/crates/turborepo-microfrontends-proxy/src/headers.rs
+++ b/crates/turborepo-microfrontends-proxy/src/headers.rs
@@ -1,6 +1,6 @@
 use hyper::{
     Request,
-    header::{CONNECTION, CONTENT_LENGTH, TRANSFER_ENCODING, UPGRADE},
+    header::{CONNECTION, CONTENT_LENGTH, HOST, TRANSFER_ENCODING, UPGRADE},
 };
 
 use crate::error::ProxyError;
@@ -9,7 +9,9 @@ use crate::error::ProxyError;
 ///
 /// While this proxy is intended for local development only, we check for
 /// conflicting Content-Length and Transfer-Encoding headers, which could be
-/// exploited if different servers in the chain interpret them differently.
+/// exploited if different servers in the chain interpret them differently. We
+/// also require a single localhost Host header so browser-driven requests
+/// cannot use this proxy as a forwarding primitive for arbitrary hostnames.
 pub(crate) fn validate_request_headers<T>(req: &Request<T>) -> Result<(), ProxyError> {
     let has_content_length = req.headers().contains_key(CONTENT_LENGTH);
     let has_transfer_encoding = req.headers().contains_key(TRANSFER_ENCODING);
@@ -20,6 +22,42 @@ pub(crate) fn validate_request_headers<T>(req: &Request<T>) -> Result<(), ProxyE
         ));
     }
 
+    let host = validated_host_header(req)?;
+    validate_request_uri_host(req, host)?;
+
+    Ok(())
+}
+
+pub(crate) fn validated_host_header<T>(req: &Request<T>) -> Result<&str, ProxyError> {
+    let mut host_headers = req.headers().get_all(HOST).iter();
+    let host_header = host_headers
+        .next()
+        .ok_or_else(|| ProxyError::InvalidRequest("Missing Host header".to_string()))?;
+
+    if host_headers.next().is_some() {
+        return Err(ProxyError::InvalidRequest(
+            "Duplicate Host headers are not allowed".to_string(),
+        ));
+    }
+
+    let host = host_header
+        .to_str()
+        .map_err(|_| ProxyError::InvalidRequest("Malformed Host header".to_string()))?;
+
+    validate_host_header(host)?;
+
+    Ok(host)
+}
+
+fn validate_request_uri_host<T>(req: &Request<T>, host: &str) -> Result<(), ProxyError> {
+    if let Some(authority) = req.uri().authority() {
+        if authority.as_str() != host {
+            return Err(ProxyError::InvalidRequest(
+                "Request URI host does not match Host header".to_string(),
+            ));
+        }
+    }
+
     Ok(())
 }
 
@@ -28,23 +66,23 @@ pub(crate) fn validate_request_headers<T>(req: &Request<T>) -> Result<(), ProxyE
 /// This proxy is intended for local development only, so we restrict
 /// Host headers to localhost or 127.0.0.1 addresses only.
 pub(crate) fn validate_host_header(host: &str) -> Result<(), ProxyError> {
-    if let Some(colon_idx) = host.rfind(':') {
-        let host_part = &host[..colon_idx];
-        let port_part = &host[colon_idx + 1..];
-
-        if (host_part == "localhost" || host_part == "127.0.0.1")
-            && !port_part.is_empty()
-            && port_part.chars().all(|c| c.is_ascii_digit())
-        {
-            return Ok(());
-        }
-    } else if host == "localhost" || host == "127.0.0.1" {
+    if host == "localhost"
+        || host == "127.0.0.1"
+        || valid_localhost_with_port(host, "localhost")
+        || valid_localhost_with_port(host, "127.0.0.1")
+    {
         return Ok(());
     }
 
     Err(ProxyError::InvalidRequest(
         "Invalid host header: only localhost and 127.0.0.1 are allowed".to_string(),
     ))
+}
+
+fn valid_localhost_with_port(host: &str, allowed_host: &str) -> bool {
+    host.strip_prefix(allowed_host)
+        .and_then(|remaining| remaining.strip_prefix(':'))
+        .is_some_and(|port| !port.is_empty() && port.parse::<u16>().is_ok())
 }
 
 pub(crate) fn is_websocket_upgrade<T>(req: &Request<T>) -> bool {
@@ -175,6 +213,7 @@ mod tests {
         let req = Request::builder()
             .method(Method::POST)
             .uri("http://localhost:3000/api")
+            .header(HOST, "localhost:3000")
             .header(CONTENT_LENGTH, "100")
             .body(())
             .unwrap();
@@ -187,6 +226,7 @@ mod tests {
         let req = Request::builder()
             .method(Method::POST)
             .uri("http://localhost:3000/api")
+            .header(HOST, "localhost:3000")
             .header(CONTENT_LENGTH, "100")
             .header(TRANSFER_ENCODING, "chunked")
             .body(())
@@ -203,7 +243,8 @@ mod tests {
     fn test_validate_request_headers_no_body_headers() {
         let req = Request::builder()
             .method(Method::GET)
-            .uri("http://localhost:3000/api")
+            .uri("/api")
+            .header(HOST, "localhost:3000")
             .body(())
             .unwrap();
 
@@ -215,11 +256,96 @@ mod tests {
         let req = Request::builder()
             .method(Method::POST)
             .uri("http://localhost:3000/api")
+            .header(HOST, "localhost:3000")
             .header(TRANSFER_ENCODING, "chunked")
             .body(())
             .unwrap();
 
         assert!(validate_request_headers(&req).is_ok());
+    }
+
+    #[test]
+    fn test_validate_request_headers_missing_host() {
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("/api")
+            .body(())
+            .unwrap();
+
+        let result = validate_request_headers(&req);
+        assert!(result.is_err());
+        if let Err(ProxyError::InvalidRequest(msg)) = result {
+            assert!(msg.contains("Missing Host header"));
+        }
+    }
+
+    #[test]
+    fn test_validate_request_headers_duplicate_host() {
+        let mut req = Request::builder()
+            .method(Method::GET)
+            .uri("/api")
+            .header(HOST, "localhost:3000")
+            .body(())
+            .unwrap();
+        req.headers_mut()
+            .append(HOST, HeaderValue::from_static("127.0.0.1:3000"));
+
+        let result = validate_request_headers(&req);
+        assert!(result.is_err());
+        if let Err(ProxyError::InvalidRequest(msg)) = result {
+            assert!(msg.contains("Duplicate Host headers"));
+        }
+    }
+
+    #[test]
+    fn test_validate_request_headers_malformed_host() {
+        let mut req = Request::builder()
+            .method(Method::GET)
+            .uri("/api")
+            .body(())
+            .unwrap();
+        req.headers_mut().insert(
+            HOST,
+            HeaderValue::from_bytes(b"localhost:3000\xff").unwrap(),
+        );
+
+        let result = validate_request_headers(&req);
+        assert!(result.is_err());
+        if let Err(ProxyError::InvalidRequest(msg)) = result {
+            assert!(msg.contains("Malformed Host header"));
+        }
+    }
+
+    #[test]
+    fn test_validate_request_headers_rejects_non_localhost_host() {
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("/api")
+            .header(HOST, "example.com")
+            .body(())
+            .unwrap();
+
+        let result = validate_request_headers(&req);
+        assert!(result.is_err());
+        if let Err(ProxyError::InvalidRequest(msg)) = result {
+            assert!(msg.contains("Invalid host header"));
+        }
+    }
+
+    #[test]
+    fn test_validate_request_headers_rejects_mismatched_uri_host() {
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("http://evil.com/api")
+            .header(HOST, "localhost:3000")
+            .body(())
+            .unwrap();
+
+        let result = validate_request_headers(&req);
+        assert!(result.is_err());
+        if let Err(ProxyError::InvalidRequest(msg)) = result {
+            assert!(msg.contains("Request URI host does not match Host header"));
+        }
     }
 
     #[test]
@@ -266,6 +392,13 @@ mod tests {
     fn test_validate_host_header_malicious_injection() {
         let result = validate_host_header("localhost:3000\r\nX-Injected: evil");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_host_header_invalid_port() {
+        assert!(validate_host_header("localhost:").is_err());
+        assert!(validate_host_header("localhost:abc").is_err());
+        assert!(validate_host_header("localhost:99999").is_err());
     }
 
     #[test]

--- a/crates/turborepo-microfrontends-proxy/src/headers.rs
+++ b/crates/turborepo-microfrontends-proxy/src/headers.rs
@@ -50,12 +50,12 @@ pub(crate) fn validated_host_header<T>(req: &Request<T>) -> Result<&str, ProxyEr
 }
 
 fn validate_request_uri_host<T>(req: &Request<T>, host: &str) -> Result<(), ProxyError> {
-    if let Some(authority) = req.uri().authority() {
-        if authority.as_str() != host {
-            return Err(ProxyError::InvalidRequest(
-                "Request URI host does not match Host header".to_string(),
-            ));
-        }
+    if let Some(authority) = req.uri().authority()
+        && authority.as_str() != host
+    {
+        return Err(ProxyError::InvalidRequest(
+            "Request URI host does not match Host header".to_string(),
+        ));
     }
 
     Ok(())

--- a/crates/turborepo-microfrontends-proxy/src/http.rs
+++ b/crates/turborepo-microfrontends-proxy/src/http.rs
@@ -9,7 +9,7 @@ use hyper_util::client::legacy::Client;
 use tracing::{debug, error, warn};
 
 use crate::{
-    ProxyError, error::ErrorPage, headers::validate_host_header, http_router::RouteMatch,
+    ProxyError, error::ErrorPage, headers::validated_host_header, http_router::RouteMatch,
     ports::validate_port,
 };
 
@@ -63,8 +63,7 @@ pub(crate) async fn forward_request(
             .unwrap_or("/")
     );
 
-    let original_host = req.uri().host().unwrap_or("localhost").to_string();
-    validate_host_header(&original_host)?;
+    let original_host = validated_host_header(&req)?.to_string();
 
     let headers = req.headers_mut();
     headers.insert("Host", format!("localhost:{port}").parse()?);

--- a/crates/turborepo-microfrontends-proxy/src/proxy.rs
+++ b/crates/turborepo-microfrontends-proxy/src/proxy.rs
@@ -66,6 +66,12 @@ pub(crate) async fn handle_request(
 }
 
 fn create_generic_error_response(error: ProxyError) -> Response<BoxedBody> {
+    let status = if matches!(&error, ProxyError::InvalidRequest(_)) {
+        StatusCode::BAD_REQUEST
+    } else {
+        StatusCode::BAD_GATEWAY
+    };
+
     let body_text = format!(
         r#"<!DOCTYPE html>
 <html lang="en">
@@ -177,7 +183,7 @@ fn create_generic_error_response(error: ProxyError) -> Response<BoxedBody> {
     );
 
     Response::builder()
-        .status(StatusCode::BAD_GATEWAY)
+        .status(status)
         .header("Content-Type", "text/html; charset=utf-8")
         .body(
             Full::new(Bytes::from(body_text))
@@ -198,6 +204,9 @@ fn create_generic_error_response(error: ProxyError) -> Response<BoxedBody> {
 
 #[cfg(test)]
 mod tests {
+    use hyper::StatusCode;
+
+    use super::create_generic_error_response;
     use crate::ProxyError;
 
     #[test]
@@ -230,5 +239,14 @@ mod tests {
         let error_string = error.to_string();
         assert!(error_string.contains("web"));
         assert!(error_string.contains("3000"));
+    }
+
+    #[test]
+    fn test_invalid_request_error_response_is_bad_request() {
+        let response = create_generic_error_response(ProxyError::InvalidRequest(
+            "Invalid host header".to_string(),
+        ));
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/crates/turborepo-microfrontends-proxy/src/websocket.rs
+++ b/crates/turborepo-microfrontends-proxy/src/websocket.rs
@@ -16,7 +16,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::{
     ProxyError,
-    headers::validate_host_header,
+    headers::validated_host_header,
     http::{BoxedBody, HttpClient, handle_forward_result},
     http_router::RouteMatch,
 };
@@ -116,8 +116,7 @@ fn prepare_websocket_request(
             .unwrap_or("/")
     );
 
-    let original_host = req.uri().host().unwrap_or("localhost").to_string();
-    validate_host_header(&original_host)?;
+    let original_host = validated_host_header(req)?.to_string();
 
     let headers = req.headers_mut();
     headers.insert("Host", format!("localhost:{port}").parse()?);

--- a/crates/turborepo-microfrontends-proxy/tests/integration_test.rs
+++ b/crates/turborepo-microfrontends-proxy/tests/integration_test.rs
@@ -257,6 +257,35 @@ fn mock_server(listener: TcpListener, response_text: &'static str) -> tokio::tas
     })
 }
 
+fn forwarded_host_echo_server(listener: TcpListener) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = listener.accept().await.unwrap();
+            let io = TokioIo::new(stream);
+
+            let service = service_fn(move |req: Request<Incoming>| async move {
+                let forwarded_host = req
+                    .headers()
+                    .get("x-forwarded-host")
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or("")
+                    .to_string();
+
+                Ok::<_, hyper::Error>(
+                    Response::builder()
+                        .status(200)
+                        .body(Full::new(Bytes::from(forwarded_host)))
+                        .unwrap(),
+                )
+            });
+
+            let _ = hyper::server::conn::http1::Builder::new()
+                .serve_connection(io, service)
+                .await;
+        }
+    })
+}
+
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn test_end_to_end_proxy() {
@@ -369,6 +398,72 @@ async fn test_end_to_end_proxy() {
 
     web_handle.abort();
     docs_handle.abort();
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn test_proxy_forwards_validated_host_header() {
+    let (ports, mut listeners) = find_available_port_range(2).await.unwrap();
+    let web_port = ports[0];
+    let proxy_port = ports[1];
+
+    let web_listener = listeners.remove(0);
+    let proxy_listener = listeners.remove(0);
+
+    drop(proxy_listener);
+
+    let web_handle = forwarded_host_echo_server(web_listener);
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let config_json = format!(
+        r#"{{
+        "options": {{
+            "localProxyPort": {proxy_port}
+        }},
+        "applications": {{
+            "web": {{
+                "development": {{
+                    "local": {{ "port": {web_port} }}
+                }}
+            }}
+        }}
+    }}"#
+    );
+
+    let config = Config::from_str(&config_json, "test.json").unwrap();
+    let mut server = ProxyServer::new(config).unwrap();
+
+    let (shutdown_complete_tx, shutdown_complete_rx) = tokio::sync::oneshot::channel();
+    server.set_shutdown_complete_tx(shutdown_complete_tx);
+    let shutdown_handle = server.shutdown_handle();
+
+    tokio::spawn(async move {
+        let _ = server.run().await;
+    });
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let connector = hyper_util::client::legacy::connect::HttpConnector::new();
+    let client: Client<_, Full<Bytes>> =
+        Client::builder(hyper_util::rt::TokioExecutor::new()).build(connector);
+
+    let response = tokio::time::timeout(
+        Duration::from_secs(5),
+        client.get(format!("http://127.0.0.1:{proxy_port}/").parse().unwrap()),
+    )
+    .await
+    .expect("Request timed out")
+    .expect("Request failed");
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(body, format!("127.0.0.1:{proxy_port}"));
+
+    let _ = shutdown_handle.send(());
+    let _ = tokio::time::timeout(Duration::from_secs(3), shutdown_complete_rx).await;
+
+    web_handle.abort();
 
     tokio::time::sleep(Duration::from_millis(100)).await;
 }


### PR DESCRIPTION
- Reject untrusted or ambiguous Host headers before proxy routing.
- Preserve the validated Host value when setting X-Forwarded-Host for HTTP and WebSocket forwarding.