### PR TITLE
fix: Restrict Vercel token reuse to trusted API origins

### DIFF
--- a/crates/turborepo-auth/src/auth/login.rs
+++ b/crates/turborepo-auth/src/auth/login.rs
@@ -12,7 +12,10 @@ use url::Url;
 
 use crate::{
     LoginOptions, Token,
-    auth::{ExistingTokenSource, classify_existing_vercel_token, is_vercel},
+    auth::{
+        ExistingTokenSource, classify_existing_vercel_token, ensure_trusted_vercel_api, is_vercel,
+        should_attempt_vercel_token_refresh, should_skip_existing_token_for_login,
+    },
     device_flow::{self, TokenSet},
     error, ui,
 };
@@ -139,23 +142,22 @@ pub async fn login<T: Client + TokenClient>(
     } = *options;
 
     let is_vercel_login = is_vercel(login_url_configuration);
+    if is_vercel_login {
+        ensure_trusted_vercel_api(api_client)?;
+    }
 
     // Check if passed in token exists first.
     // For Vercel logins, --force is silently ignored.
     if !force || is_vercel_login {
         if let Some(token) = existing_token {
-            let token_source = if is_vercel_login {
-                classify_existing_vercel_token(token)?
-            } else {
-                ExistingTokenSource::Other
-            };
+            let token_source = classify_existing_vercel_token(token)?;
+            let skip_existing_token = should_skip_existing_token_for_login(
+                token_source,
+                is_vercel_login,
+                login_url_configuration,
+            );
 
-            if is_vercel_login
-                && matches!(
-                    token_source,
-                    ExistingTokenSource::TurboConfig | ExistingTokenSource::LegacyAuth
-                )
-            {
+            if is_vercel_login && should_attempt_vercel_token_refresh(token_source) {
                 match crate::auth::get_token_with_refresh_for_login().await {
                     Ok(Some(token_secret)) => {
                         if classify_existing_vercel_token(token_secret.expose())?
@@ -176,7 +178,7 @@ pub async fn login<T: Client + TokenClient>(
                         warn!("Failed to load existing token, proceeding with new login: {e}");
                     }
                 }
-            } else if token_source != ExistingTokenSource::LegacyAuth {
+            } else if !skip_existing_token && token_source != ExistingTokenSource::LegacyAuth {
                 let token = Token::existing(token.into());
                 let reused_token = if is_vercel_login {
                     reuse_existing_token_with_recovery(
@@ -486,8 +488,12 @@ mod tests {
 
     impl MockApiClient {
         fn new() -> Self {
+            Self::with_base_url("https://vercel.com/api")
+        }
+
+        fn with_base_url(base_url: &str) -> Self {
             Self {
-                base_url: String::new(),
+                base_url: base_url.to_string(),
             }
         }
     }
@@ -670,6 +676,21 @@ mod tests {
 
         assert_matches!(token, Token::New(ref token) if token.expose() == "fresh-login-token");
         assert!(token_set.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_vercel_login_rejects_untrusted_api_url() {
+        let color_config = turborepo_ui::ColorConfig::new(false);
+        let api_client = MockApiClient::with_base_url("https://attacker.test/api");
+        let options = LoginOptions::new(&color_config, "https://vercel.com", &api_client);
+
+        let result = login(&options).await;
+
+        assert_matches!(
+            result,
+            Err(Error::UntrustedVercelApiUrl { ref api_url })
+                if api_url == "https://attacker.test/api"
+        );
     }
 
     #[tokio::test]

--- a/crates/turborepo-auth/src/auth/mod.rs
+++ b/crates/turborepo-auth/src/auth/mod.rs
@@ -11,9 +11,62 @@ use turbopath::AbsoluteSystemPath;
 use turbopath::AbsoluteSystemPathBuf;
 use turborepo_api_client::{Client, TokenClient};
 use turborepo_ui::ColorConfig;
+use url::Url;
 
 pub(crate) fn is_vercel(login_url: &str) -> bool {
-    login_url.contains("vercel.com")
+    Url::parse(login_url)
+        .ok()
+        .is_some_and(|url| is_trusted_vercel_origin(&url))
+}
+
+pub(crate) fn ensure_trusted_vercel_api<T: Client>(api_client: &T) -> Result<(), Error> {
+    let api_url = api_client.make_url("")?;
+
+    if is_trusted_vercel_origin(&api_url) {
+        return Ok(());
+    }
+
+    Err(Error::UntrustedVercelApiUrl {
+        api_url: api_url.to_string(),
+    })
+}
+
+pub(crate) fn should_attempt_vercel_token_refresh(source: ExistingTokenSource) -> bool {
+    matches!(
+        source,
+        ExistingTokenSource::TurboAuth
+            | ExistingTokenSource::TurboConfig
+            | ExistingTokenSource::LegacyAuth
+    )
+}
+
+pub(crate) fn should_skip_existing_token_for_login(
+    source: ExistingTokenSource,
+    is_vercel_login: bool,
+    login_url: &str,
+) -> bool {
+    if is_vercel_login {
+        return false;
+    }
+
+    matches!(
+        source,
+        ExistingTokenSource::TurboAuth | ExistingTokenSource::LegacyAuth
+    ) || (looks_like_vercel_substring(login_url) && source == ExistingTokenSource::TurboConfig)
+}
+
+fn looks_like_vercel_substring(login_url: &str) -> bool {
+    login_url.to_ascii_lowercase().contains("vercel.com")
+}
+
+fn is_trusted_vercel_origin(url: &Url) -> bool {
+    url.scheme() == "https"
+        && url.port().is_none_or(|port| port == 443)
+        && url.host_str().is_some_and(is_vercel_host)
+}
+
+fn is_vercel_host(host: &str) -> bool {
+    host == "vercel.com" || host.ends_with(".vercel.com")
 }
 
 const VERCEL_TOKEN_DIR: &str = "com.vercel.cli";
@@ -21,6 +74,7 @@ const VERCEL_TOKEN_FILE: &str = "auth.json";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ExistingTokenSource {
+    TurboAuth,
     TurboConfig,
     LegacyAuth,
     Other,
@@ -130,29 +184,12 @@ fn load_turbo_auth_tokens_from_paths(
     Ok(load_tokens_from_path(turbo_config_path, "Turbo config file")?.unwrap_or_default())
 }
 
-fn load_turbo_auth_tokens() -> Result<crate::AuthTokens, Error> {
-    use crate::{TURBO_AUTH_FILE, TURBO_TOKEN_DIR, TURBO_TOKEN_FILE};
-
-    let Some(turbo_config_dir) = turborepo_dirs::config_dir()? else {
-        return Ok(crate::AuthTokens::default());
-    };
-    let turbo_auth_path = turbo_config_dir.join_components(&[TURBO_TOKEN_DIR, TURBO_AUTH_FILE]);
-    let turbo_config_path = turbo_config_dir.join_components(&[TURBO_TOKEN_DIR, TURBO_TOKEN_FILE]);
-
-    load_turbo_auth_tokens_from_paths(&turbo_auth_path, &turbo_config_path)
-}
-
 pub(crate) fn classify_existing_vercel_token(token: &str) -> Result<ExistingTokenSource, Error> {
     if let Some(turbo_config_dir) = turborepo_dirs::config_dir()? {
         let turbo_auth_path =
             turbo_config_dir.join_components(&[crate::TURBO_TOKEN_DIR, crate::TURBO_AUTH_FILE]);
-        if let Some(turbo_auth_tokens) = load_tokens_from_path(&turbo_auth_path, "Turbo auth file")?
-            && turbo_auth_tokens
-                .token
-                .as_ref()
-                .is_some_and(|stored_token| stored_token.expose() == token)
-        {
-            return Ok(ExistingTokenSource::TurboConfig);
+        if path_contains_token(&turbo_auth_path, "Turbo auth file", token)? {
+            return Ok(ExistingTokenSource::TurboAuth);
         }
     }
 
@@ -165,13 +202,12 @@ pub(crate) fn classify_existing_vercel_token(token: &str) -> Result<ExistingToke
         return Ok(ExistingTokenSource::LegacyAuth);
     }
 
-    let turbo_auth_tokens = load_turbo_auth_tokens()?;
-    if turbo_auth_tokens
-        .token
-        .as_ref()
-        .is_some_and(|stored_token| stored_token.expose() == token)
-    {
-        return Ok(ExistingTokenSource::TurboConfig);
+    if let Some(turbo_config_dir) = turborepo_dirs::config_dir()? {
+        let turbo_config_path =
+            turbo_config_dir.join_components(&[crate::TURBO_TOKEN_DIR, crate::TURBO_TOKEN_FILE]);
+        if path_contains_token(&turbo_config_path, "Turbo config file", token)? {
+            return Ok(ExistingTokenSource::TurboConfig);
+        }
     }
 
     Ok(ExistingTokenSource::Other)
@@ -467,7 +503,7 @@ pub async fn recover_token_after_forbidden(
             )
             .await
         }
-        ExistingTokenSource::TurboConfig => {
+        ExistingTokenSource::TurboAuth | ExistingTokenSource::TurboConfig => {
             let auth_tokens = load_auth_tokens(&turbo_auth_path, &turbo_config_path)?;
             if auth_tokens.token.as_ref().map(|token| token.expose())
                 != Some(current_token.expose())
@@ -517,7 +553,7 @@ mod tests {
     use super::{
         ExistingTokenSource, can_refresh_token, classify_existing_vercel_token,
         get_token_with_refresh, is_vercel, load_auth_tokens, recover_token_after_forbidden,
-        should_exchange_turbo_config_token,
+        should_exchange_turbo_config_token, should_skip_existing_token_for_login,
     };
     use crate::{
         AuthTokens, TURBO_AUTH_FILE, TURBO_TOKEN_DIR, TURBO_TOKEN_FILE, Token,
@@ -653,7 +689,7 @@ mod tests {
 
         let source = classify_existing_vercel_token("duplicated-token").unwrap();
 
-        assert_eq!(source, ExistingTokenSource::TurboConfig);
+        assert_eq!(source, ExistingTokenSource::TurboAuth);
 
         unsafe {
             env::remove_var("TURBO_CONFIG_DIR_PATH");
@@ -1136,7 +1172,28 @@ mod tests {
         assert!(is_vercel("https://vercel.com"));
         assert!(is_vercel("https://api.vercel.com"));
         assert!(is_vercel("https://vercel.com/api"));
+        assert!(is_vercel("https://preview.vercel.com/login"));
         assert!(!is_vercel("https://my-cache.example.com"));
         assert!(!is_vercel("http://localhost:3000"));
+        assert!(!is_vercel("http://vercel.com"));
+        assert!(!is_vercel("https://notvercel.com"));
+        assert!(!is_vercel("https://vercel.com.attacker.test"));
+        assert!(!is_vercel("https://attacker.test/vercel.com"));
+        assert!(!is_vercel("https://api.vercel.com:444"));
+    }
+
+    #[test]
+    fn test_suspicious_vercel_substring_skips_stored_config_token() {
+        assert!(should_skip_existing_token_for_login(
+            ExistingTokenSource::TurboConfig,
+            false,
+            "https://vercel.com.attacker.test"
+        ));
+
+        assert!(!should_skip_existing_token_for_login(
+            ExistingTokenSource::TurboConfig,
+            false,
+            "https://cache.example.com"
+        ));
     }
 }

--- a/crates/turborepo-auth/src/auth/sso.rs
+++ b/crates/turborepo-auth/src/auth/sso.rs
@@ -15,7 +15,10 @@ use super::login::{
 };
 use crate::{
     Error, LoginOptions, Token,
-    auth::{ExistingTokenSource, classify_existing_vercel_token, is_vercel},
+    auth::{
+        ExistingTokenSource, classify_existing_vercel_token, ensure_trusted_vercel_api, is_vercel,
+        should_attempt_vercel_token_refresh, should_skip_existing_token_for_login,
+    },
     device_flow::TokenSet,
     error, ui,
 };
@@ -158,24 +161,23 @@ pub async fn sso_login<T: Client + TokenClient>(
 
     let sso_team = sso_team.ok_or(Error::EmptySSOTeam)?;
     let is_vercel_login = is_vercel(login_url_configuration);
+    if is_vercel_login {
+        ensure_trusted_vercel_api(api_client)?;
+    }
 
     // Check if token exists first. Must be there for the user and contain the
     // sso_team passed into this function.
     // For Vercel logins, --force is silently ignored.
     if !force || is_vercel_login {
         if let Some(token) = existing_token {
-            let token_source = if is_vercel_login {
-                classify_existing_vercel_token(token)?
-            } else {
-                ExistingTokenSource::Other
-            };
+            let token_source = classify_existing_vercel_token(token)?;
+            let skip_existing_token = should_skip_existing_token_for_login(
+                token_source,
+                is_vercel_login,
+                login_url_configuration,
+            );
 
-            if is_vercel_login
-                && matches!(
-                    token_source,
-                    ExistingTokenSource::TurboConfig | ExistingTokenSource::LegacyAuth
-                )
-            {
+            if is_vercel_login && should_attempt_vercel_token_refresh(token_source) {
                 match crate::auth::get_token_with_refresh_for_login().await {
                     Ok(Some(token_secret)) => {
                         if classify_existing_vercel_token(token_secret.expose())?
@@ -202,7 +204,7 @@ pub async fn sso_login<T: Client + TokenClient>(
                         warn!("Failed to load existing token for SSO, proceeding: {e}");
                     }
                 }
-            } else if token_source != ExistingTokenSource::LegacyAuth {
+            } else if !skip_existing_token && token_source != ExistingTokenSource::LegacyAuth {
                 let token_action = if is_vercel_login {
                     classify_existing_sso_token_with_recovery(
                         Token::existing(token.to_string()),
@@ -496,8 +498,12 @@ mod tests {
 
     impl MockApiClient {
         fn new() -> Self {
+            Self::with_base_url("https://vercel.com/api")
+        }
+
+        fn with_base_url(base_url: &str) -> Self {
             Self {
-                base_url: String::new(),
+                base_url: base_url.to_string(),
             }
         }
     }
@@ -648,6 +654,30 @@ mod tests {
         let (result, token_set) = sso_login(&options).await.unwrap();
         assert_matches!(result, Token::Existing(ref token) if token.expose() == "existing-token");
         assert!(token_set.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_vercel_sso_rejects_untrusted_api_url() {
+        let color_config = turborepo_ui::ColorConfig::new(false);
+        let api_client = MockApiClient::with_base_url("https://attacker.test/api");
+
+        let options = LoginOptions {
+            color_config: &color_config,
+            login_url: "https://vercel.com",
+            api_client: &api_client,
+            existing_token: Some("existing-token"),
+            sso_team: Some("my-team"),
+            force: false,
+            sso_login_callback_port: None,
+        };
+
+        let result = sso_login(&options).await;
+
+        assert_matches!(
+            result,
+            Err(Error::UntrustedVercelApiUrl { ref api_url })
+                if api_url == "https://attacker.test/api"
+        );
     }
 
     #[tokio::test]

--- a/crates/turborepo-auth/src/device_flow.rs
+++ b/crates/turborepo-auth/src/device_flow.rs
@@ -107,12 +107,12 @@ fn truncate(s: &str, max: usize) -> &str {
 }
 
 /// Derive the OIDC issuer URL from a login URL.
-/// If the login URL is a Vercel-hosted URL (contains "vercel.com"),
-/// use the default Vercel issuer. Otherwise fall back to `https://` + host
-/// of the login URL to support self-hosted/enterprise deployments.
+/// If the login URL is a trusted Vercel URL, use the default Vercel issuer.
+/// Otherwise fall back to `https://` + host of the login URL to support
+/// self-hosted/enterprise deployments.
 /// Non-HTTPS schemes are rejected to prevent token exchange over plaintext.
 fn issuer_from_login_url(login_url: &str) -> Result<String, Error> {
-    if login_url.contains("vercel.com") {
+    if crate::auth::is_vercel(login_url) {
         return Ok(DEFAULT_VERCEL_ISSUER.to_string());
     }
     if let Ok(parsed) = Url::parse(login_url) {
@@ -390,6 +390,14 @@ mod tests {
         assert_eq!(
             issuer_from_login_url("https://my-company.example.com/api").unwrap(),
             "https://my-company.example.com"
+        );
+        assert_eq!(
+            issuer_from_login_url("https://vercel.com.attacker.test/api").unwrap(),
+            "https://vercel.com.attacker.test"
+        );
+        assert_eq!(
+            issuer_from_login_url("https://attacker.test/vercel.com").unwrap(),
+            "https://attacker.test"
         );
     }
 

--- a/crates/turborepo-auth/src/error.rs
+++ b/crates/turborepo-auth/src/error.rs
@@ -41,6 +41,11 @@ pub enum Error {
     FailedToFetchUser(#[source] turborepo_api_client::Error),
     #[error("url is invalid: {0}")]
     InvalidUrl(#[from] url::ParseError),
+    #[error(
+        "Vercel login requires a trusted Vercel API URL, but `apiUrl` is configured to \
+         \"{api_url}\""
+    )]
+    UntrustedVercelApiUrl { api_url: String },
 
     #[error("failed to validate sso token")]
     FailedToValidateSSOToken(#[source] turborepo_api_client::Error),


### PR DESCRIPTION
- Tightens Vercel URL matching.
- Rejects Vercel login flows when `apiUrl` points at an untrusted origin.
- Keeps self-hosted issuer fallback behavior for non-Vercel login URLs.