### PR TITLE
fix: Keep workspace config discovery inside root

### DIFF
--- a/packages/turbo-codemod/__tests__/migrate-dot-env.test.ts
+++ b/packages/turbo-codemod/__tests__/migrate-dot-env.test.ts
@@ -1,6 +1,8 @@
+import path from "node:path";
 import { setupTestFixtures } from "@turbo/test-utils";
 import { type Schema } from "@turbo/types";
 import { describe, it, expect } from "@jest/globals";
+import { ensureDirSync, writeJsonSync } from "fs-extra";
 import { transformer } from "../src/transforms/migrate-dot-env";
 
 describe("migrate-dot-env", () => {
@@ -125,6 +127,48 @@ describe("migrate-dot-env", () => {
         },
       }
     `);
+  });
+
+  it("does not migrate workspace configs outside the root", () => {
+    const { root, readJson, write } = useFixture({
+      fixture: "workspace-configs"
+    });
+    const outsideWorkspace = path.join(root, "..", "outside-workspace");
+    const outsideConfig = {
+      extends: ["//"],
+      tasks: {
+        build: {
+          dotEnv: [".env"]
+        }
+      }
+    };
+    ensureDirSync(outsideWorkspace);
+    writeJsonSync(path.join(outsideWorkspace, "turbo.json"), outsideConfig);
+    write(
+      "package.json",
+      JSON.stringify(
+        {
+          private: true,
+          workspaces: ["apps/*", "packages/*", "../outside-workspace"],
+          packageManager: "yarn@1.22.19"
+        },
+        null,
+        2
+      )
+    );
+
+    const result = transformer({
+      root,
+      options: { force: false, dryRun: false, print: false }
+    });
+
+    expect(readJson(path.join(outsideWorkspace, "turbo.json"))).toStrictEqual(
+      outsideConfig
+    );
+    expect(result.fatalError).toBeUndefined();
+    expect(result.changes).not.toHaveProperty(
+      "../outside-workspace/turbo.json"
+    );
   });
 
   it("migrates turbo.json dot-env - dry", () => {

--- a/packages/turbo-utils/__tests__/get-turbo-configs.test.ts
+++ b/packages/turbo-utils/__tests__/get-turbo-configs.test.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { setupTestFixtures } from "@turbo/test-utils";
 import { describe, it, expect } from "@jest/globals";
+import { ensureDirSync, writeJsonSync } from "fs-extra";
 import JSON5 from "json5";
 import type { TurboConfigs } from "../src/get-turbo-configs";
 import { getTurboConfigs } from "../src/get-turbo-configs";
@@ -143,6 +144,84 @@ describe("getTurboConfigs", () => {
         },
       }
     `);
+  });
+
+  it("ignores workspace config globs that leave the root", () => {
+    const { root, write } = useFixture({ fixture: "workspace-configs" });
+    const outsideWorkspace = path.join(root, "..", "outside-workspace");
+    ensureDirSync(outsideWorkspace);
+    writeJsonSync(path.join(outsideWorkspace, "turbo.json"), {
+      extends: ["//"],
+      tasks: {
+        build: {
+          env: ["OUTSIDE"]
+        }
+      }
+    });
+    write(
+      "package.json",
+      JSON.stringify(
+        {
+          private: true,
+          workspaces: ["apps/*", "../outside-workspace"],
+          packageManager: "yarn@1.22.19"
+        },
+        null,
+        2
+      )
+    );
+
+    const configs = getTurboConfigs(root, { cache: false });
+    const configPaths = configs.map(({ turboConfigPath }) =>
+      path.relative(root, turboConfigPath)
+    );
+
+    expect(configPaths).not.toContain("../outside-workspace/turbo.json");
+    expect(
+      configPaths.every((configPath) => !configPath.startsWith(".."))
+    ).toBe(true);
+  });
+
+  it("ignores absolute workspace config globs", () => {
+    const { root, write } = useFixture({ fixture: "workspace-configs" });
+    const outsideWorkspace = path.join(
+      root,
+      "..",
+      "outside-absolute-workspace"
+    );
+    ensureDirSync(outsideWorkspace);
+    writeJsonSync(path.join(outsideWorkspace, "turbo.json"), {
+      extends: ["//"],
+      tasks: {
+        build: {
+          env: ["OUTSIDE"]
+        }
+      }
+    });
+    write(
+      "package.json",
+      JSON.stringify(
+        {
+          private: true,
+          workspaces: [outsideWorkspace],
+          packageManager: "yarn@1.22.19"
+        },
+        null,
+        2
+      )
+    );
+
+    const configs = getTurboConfigs(root, { cache: false });
+    const configPaths = configs.map(({ turboConfigPath }) =>
+      path.relative(root, turboConfigPath)
+    );
+
+    expect(configPaths).not.toContain(
+      "../outside-absolute-workspace/turbo.json"
+    );
+    expect(
+      configPaths.every((configPath) => !configPath.startsWith(".."))
+    ).toBe(true);
   });
 
   it("throws when both turbo.json and turbo.jsonc exist", () => {

--- a/packages/turbo-utils/src/get-turbo-configs.ts
+++ b/packages/turbo-utils/src/get-turbo-configs.ts
@@ -17,6 +17,50 @@ import type { PackageJson, PNPMWorkspaceConfig } from "./types";
 const ROOT_GLOB = "{turbo.json,turbo.jsonc}";
 const ROOT_WORKSPACE_GLOB = "package.json";
 
+function isInsideRoot(root: string, filePath: string): boolean {
+  const relativePath = path.relative(root, filePath);
+  return (
+    relativePath === "" ||
+    (!relativePath.startsWith("..") && !path.isAbsolute(relativePath))
+  );
+}
+
+function realpathSync(filePath: string): string | null {
+  try {
+    return fs.realpathSync(filePath);
+  } catch {
+    return null;
+  }
+}
+
+function isSafeWorkspaceGlob(workspaceGlob: string): boolean {
+  const glob = workspaceGlob.startsWith("!")
+    ? workspaceGlob.slice(1)
+    : workspaceGlob;
+
+  return (
+    !path.isAbsolute(glob) &&
+    !path.posix.isAbsolute(glob) &&
+    !path.win32.isAbsolute(glob) &&
+    !glob.split(/[\\/]/).includes("..")
+  );
+}
+
+function filterPathsInsideRoot(
+  root: string,
+  filePaths: Array<string>
+): Array<string> {
+  const realRoot = realpathSync(root);
+  if (!realRoot) {
+    return [];
+  }
+
+  return filePaths.filter((filePath) => {
+    const realFilePath = realpathSync(filePath);
+    return realFilePath ? isInsideRoot(realRoot, realFilePath) : false;
+  });
+}
+
 /**
  * Given a directory path, determines which turbo config file to use.
  * Returns error information if both turbo.json and turbo.jsonc exist in the same directory.
@@ -113,18 +157,22 @@ export function getTurboConfigs(cwd?: string, opts?: Options): TurboConfigs {
 
   // parse workspaces
   if (turboRoot) {
-    const workspaceGlobs = getWorkspaceGlobs(turboRoot);
+    const workspaceGlobs =
+      getWorkspaceGlobs(turboRoot).filter(isSafeWorkspaceGlob);
     const workspaceConfigGlobs = workspaceGlobs.map(
       (glob) => `${glob}/${ROOT_GLOB}`
     );
 
-    const configPaths = sync([ROOT_GLOB, ...workspaceConfigGlobs], {
-      cwd: turboRoot,
-      onlyFiles: true,
-      followSymbolicLinks: false,
-      // avoid throwing when encountering permission errors or unreadable paths
-      suppressErrors: true
-    }).map((configPath) => path.join(turboRoot, configPath));
+    const configPaths = filterPathsInsideRoot(
+      turboRoot,
+      sync([ROOT_GLOB, ...workspaceConfigGlobs], {
+        cwd: turboRoot,
+        onlyFiles: true,
+        followSymbolicLinks: false,
+        // avoid throwing when encountering permission errors or unreadable paths
+        suppressErrors: true
+      }).map((configPath) => path.resolve(turboRoot, configPath))
+    );
 
     // Check for both turbo.json and turbo.jsonc in the same directory
     const configPathsByDir: Record<string, Array<string>> = {};
@@ -198,18 +246,22 @@ export function getWorkspaceConfigs(
 
   // parse workspaces
   if (turboRoot) {
-    const workspaceGlobs = getWorkspaceGlobs(turboRoot);
+    const workspaceGlobs =
+      getWorkspaceGlobs(turboRoot).filter(isSafeWorkspaceGlob);
     const workspaceConfigGlobs = workspaceGlobs.map(
       (glob) => `${glob}/package.json`
     );
 
-    const configPaths = sync([ROOT_WORKSPACE_GLOB, ...workspaceConfigGlobs], {
-      cwd: turboRoot,
-      onlyFiles: true,
-      followSymbolicLinks: false,
-      // avoid throwing when encountering permission errors or unreadable paths
-      suppressErrors: true
-    }).map((configPath) => path.join(turboRoot, configPath));
+    const configPaths = filterPathsInsideRoot(
+      turboRoot,
+      sync([ROOT_WORKSPACE_GLOB, ...workspaceConfigGlobs], {
+        cwd: turboRoot,
+        onlyFiles: true,
+        followSymbolicLinks: false,
+        // avoid throwing when encountering permission errors or unreadable paths
+        suppressErrors: true
+      }).map((configPath) => path.resolve(turboRoot, configPath))
+    );
 
     for (const configPath of configPaths) {
       try {


### PR DESCRIPTION
- Keep workspace config discovery scoped to the selected Turborepo root.
- Ignore workspace patterns that resolve outside that root before returning configs to callers.
- Add regression coverage for escaped and absolute workspace patterns.