### PR TITLE
fix: Enforce cache filesystem boundaries

### DIFF
--- a/apps/docs/content/docs/reference/configuration.mdx
+++ b/apps/docs/content/docs/reference/configuration.mdx
@@ -768,7 +768,7 @@ A list of file glob patterns relative to the package's `package.json` to cache w
 See [`$TURBO_ROOT$`](#turbo_root) if output paths need to be relative to the repository root.
 
 Output paths must resolve inside the repository root. Turborepo will not cache
-outputs that escape the repository, even through `..` traversal.
+outputs that escape the repository.
 
 ```jsonc title="./turbo.json"
 {

--- a/apps/docs/content/docs/reference/configuration.mdx
+++ b/apps/docs/content/docs/reference/configuration.mdx
@@ -767,6 +767,9 @@ A list of file glob patterns relative to the package's `package.json` to cache w
 
 See [`$TURBO_ROOT$`](#turbo_root) if output paths need to be relative to the repository root.
 
+Output paths must resolve inside the repository root. Turborepo will not cache
+outputs that escape the repository, even through `..` traversal.
+
 ```jsonc title="./turbo.json"
 {
   "tasks": {

--- a/crates/turborepo-cache/src/cache_archive/restore.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore.rs
@@ -326,6 +326,22 @@ mod tests {
         buf
     }
 
+    fn generate_tar_with_symlink(link_path: &str, link_target: &str) -> Vec<u8> {
+        let mut buf = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut buf);
+            let mut header = Header::new_gnu();
+            header.set_entry_type(tar::EntryType::Symlink);
+            header.set_size(0);
+            header.set_mode(0o777);
+            builder
+                .append_link(&mut header, link_path, link_target)
+                .unwrap();
+            builder.into_inner().unwrap();
+        }
+        buf
+    }
+
     // Expected output of the cache
     #[derive(Debug)]
     struct ExpectedOutput(Vec<AnchoredSystemPathBuf>);
@@ -463,6 +479,162 @@ mod tests {
             .into_iter()
             .map(|item| AnchoredSystemPathBuf::try_from(Path::new(item)).unwrap())
             .collect()
+    }
+
+    #[test]
+    fn restore_preserves_broken_symlink_that_stays_inside_anchor() -> Result<()> {
+        let tar_bytes = generate_tar_with_symlink("missing-link", "missing-target");
+
+        let mut reader = CacheReader::from_reader(&tar_bytes[..], false)?;
+        let output_dir = tempdir()?;
+        let output_dir_path = output_dir.path().to_string_lossy();
+        let anchor = AbsoluteSystemPath::new(&output_dir_path)?;
+
+        let (restored, _) = reader.restore(anchor, None)?;
+
+        assert_eq!(
+            restored,
+            into_anchored_system_path_vec(vec!["missing-link"])
+        );
+        assert_eq!(
+            fs::read_link(output_dir.path().join("missing-link"))?,
+            Path::new("missing-target")
+        );
+        assert!(!output_dir.path().join("missing-target").exists());
+
+        Ok(())
+    }
+
+    #[test]
+    fn restore_allows_archive_symlink_that_resolves_inside_anchor_via_parent() -> Result<()> {
+        let input_dir = tempdir()?;
+        let archive_path = generate_tar(
+            &input_dir,
+            &[
+                TarFile::Directory {
+                    path: AnchoredSystemPathBuf::from_raw("src/runtime").unwrap(),
+                },
+                TarFile::Directory {
+                    path: AnchoredSystemPathBuf::from_raw("dist").unwrap(),
+                },
+                TarFile::Symlink {
+                    link_path: AnchoredSystemPathBuf::from_raw("dist/runtime").unwrap(),
+                    link_target: AnchoredSystemPathBuf::from_raw("../src/runtime").unwrap(),
+                },
+            ],
+        )?;
+
+        let output_dir = tempdir()?;
+        let output_dir_path = output_dir.path().to_string_lossy();
+        let anchor = AbsoluteSystemPath::new(&output_dir_path)?;
+
+        let mut reader = CacheReader::open(&archive_path)?;
+        reader.restore(anchor, None)?;
+
+        let runtime = output_dir.path().join("dist/runtime");
+        assert!(runtime.symlink_metadata()?.is_symlink());
+        assert_eq!(fs::read_link(runtime)?, Path::new("../src/runtime"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn restore_rejects_archive_symlink_to_parent_directory_without_followup_entry() -> Result<()> {
+        let tar_bytes = generate_tar_with_symlink("escape", "..");
+
+        let mut reader = CacheReader::from_reader(&tar_bytes[..], false)?;
+        let output_dir = tempdir()?;
+        let output_dir_path = output_dir.path().to_string_lossy();
+        let anchor = AbsoluteSystemPath::new(&output_dir_path)?;
+
+        let result = reader.restore(anchor, None);
+
+        assert!(
+            result.is_err(),
+            "symlink target outside anchor should be rejected"
+        );
+        assert!(!output_dir.path().join("escape").exists());
+
+        Ok(())
+    }
+
+    #[test]
+    fn restore_rejects_archive_symlink_to_absolute_unix_path() -> Result<()> {
+        let outside = tempdir()?;
+        let outside_file = outside.path().join("target");
+        fs::write(&outside_file, b"outside")?;
+        let tar_bytes = generate_tar_with_symlink("escape", &outside_file.to_string_lossy());
+
+        let mut reader = CacheReader::from_reader(&tar_bytes[..], false)?;
+        let output_dir = tempdir()?;
+        let output_dir_path = output_dir.path().to_string_lossy();
+        let anchor = AbsoluteSystemPath::new(&output_dir_path)?;
+
+        let result = reader.restore(anchor, None);
+
+        assert!(
+            result.is_err(),
+            "absolute symlink target outside anchor should be rejected"
+        );
+        assert!(!output_dir.path().join("escape").exists());
+
+        Ok(())
+    }
+
+    #[test]
+    fn restore_rejects_archive_symlink_to_windows_absolute_path() -> Result<()> {
+        let tar_bytes = generate_tar_with_symlink("escape", "C:\\Users\\turbo\\outside");
+
+        let mut reader = CacheReader::from_reader(&tar_bytes[..], false)?;
+        let output_dir = tempdir()?;
+        let output_dir_path = output_dir.path().to_string_lossy();
+        let anchor = AbsoluteSystemPath::new(&output_dir_path)?;
+
+        let result = reader.restore(anchor, None);
+
+        assert!(
+            result.is_err(),
+            "Windows absolute symlink target should be rejected on every platform"
+        );
+        assert!(!output_dir.path().join("escape").exists());
+
+        Ok(())
+    }
+
+    #[test]
+    fn restore_regular_file_replaces_final_symlink_instead_of_following_it() -> Result<()> {
+        let input_dir = tempdir()?;
+        let archive_path = generate_tar(
+            &input_dir,
+            &[TarFile::File {
+                path: AnchoredSystemPathBuf::from_raw("dist/index.js").unwrap(),
+                body: b"safe output".to_vec(),
+            }],
+        )?;
+
+        let outside_dir = tempdir()?;
+        let outside_target = outside_dir.path().join("target.js");
+        fs::write(&outside_target, b"do not overwrite")?;
+        let outside_target = AbsoluteSystemPathBuf::try_from(outside_target.as_path())?;
+
+        let output_dir = tempdir()?;
+        let output_dir_path = output_dir.path().to_string_lossy();
+        let anchor = AbsoluteSystemPath::new(&output_dir_path)?;
+        anchor.join_component("dist").create_dir_all()?;
+        let restored_file = anchor.join_components(&["dist", "index.js"]);
+        restored_file.symlink_to_file(outside_target.as_str())?;
+
+        let mut cache_reader = CacheReader::open(&archive_path)?;
+        cache_reader.restore(anchor, None)?;
+
+        assert_eq!(fs::read(outside_target.as_path())?, b"do not overwrite");
+        assert!(
+            !restored_file.symlink_metadata()?.is_symlink(),
+            "final symlink should be replaced by a regular file"
+        );
+        assert_eq!(fs::read(restored_file.as_path())?, b"safe output");
+
+        Ok(())
     }
 
     #[test]

--- a/crates/turborepo-cache/src/cache_archive/restore_regular.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore_regular.rs
@@ -26,6 +26,11 @@ pub fn restore_regular(
     }
 
     dir_cache.safe_mkdir_file(anchor, &processed_name)?;
+    if let Ok(metadata) = resolved_path.symlink_metadata()
+        && metadata.is_symlink()
+    {
+        remove_symlink(&resolved_path)?;
+    }
 
     let mut open_options = OpenOptions::new();
     open_options.write(true).truncate(true).create(true);
@@ -41,6 +46,18 @@ pub fn restore_regular(
     io::copy(entry, &mut file)?;
 
     Ok((processed_name, false))
+}
+
+fn remove_symlink(path: &AbsoluteSystemPath) -> Result<(), CacheError> {
+    #[cfg(not(windows))]
+    {
+        path.remove_file()?;
+    }
+    #[cfg(windows)]
+    {
+        path.remove_file().or_else(|_| path.remove_dir())?;
+    }
+    Ok(())
 }
 
 impl CachedDirTree {

--- a/crates/turborepo-cache/src/cache_archive/restore_symlink.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore_symlink.rs
@@ -19,7 +19,7 @@ pub fn restore_symlink(
         .link_name()?
         .ok_or_else(|| CacheError::MalformedTar(Backtrace::capture()))?;
 
-    let processed_linkname = canonicalize_linkname(anchor, &processed_name, &linkname)?;
+    let processed_linkname = validate_linkname(anchor, &processed_name, &linkname)?;
 
     if processed_linkname.symlink_metadata().is_err() {
         return Err(CacheError::LinkTargetDoesNotExist(
@@ -40,9 +40,50 @@ pub fn restore_symlink_allow_missing_target(
 ) -> Result<AnchoredSystemPathBuf, CacheError> {
     let processed_name = AnchoredSystemPathBuf::from_system_path(&entry.path()?)?;
 
+    let linkname = entry
+        .link_name()?
+        .ok_or_else(|| CacheError::MalformedTar(Backtrace::capture()))?;
+    validate_linkname(anchor, &processed_name, &linkname)?;
+
     actually_restore_symlink(dir_cache, anchor, &processed_name, entry)?;
 
     Ok(processed_name)
+}
+
+fn validate_linkname(
+    anchor: &AbsoluteSystemPath,
+    processed_name: &AnchoredSystemPathBuf,
+    linkname: &std::path::Path,
+) -> Result<AbsoluteSystemPathBuf, CacheError> {
+    let linkname_str = linkname.to_str().ok_or_else(|| {
+        CacheError::PathError(
+            PathError::InvalidUnicode(linkname.to_string_lossy().to_string()),
+            Backtrace::capture(),
+        )
+    })?;
+
+    if is_windows_absolute_path(linkname_str) {
+        return Err(CacheError::LinkOutsideOfDirectory(
+            linkname_str.to_string(),
+            Backtrace::capture(),
+        ));
+    }
+
+    let processed_linkname = canonicalize_linkname(anchor, processed_name, linkname)?;
+    if !processed_linkname.starts_with(anchor) {
+        return Err(CacheError::LinkOutsideOfDirectory(
+            linkname_str.to_string(),
+            Backtrace::capture(),
+        ));
+    }
+
+    Ok(processed_linkname)
+}
+
+fn is_windows_absolute_path(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    bytes.first() == Some(&b'\\')
+        || matches!(bytes, [drive, b':', ..] if drive.is_ascii_alphabetic())
 }
 
 fn actually_restore_symlink<'a>(

--- a/crates/turborepo-lib/src/run/task_access.rs
+++ b/crates/turborepo-lib/src/run/task_access.rs
@@ -138,8 +138,44 @@ impl TaskAccessTraceFile {
             }
         }
 
+        for output in &self.outputs {
+            let output = output.strip_prefix('!').unwrap_or(output.as_str());
+            if is_windows_absolute_path(output) {
+                turborepo_log::warn(
+                    turborepo_log::Source::turbo(turborepo_log::Subsystem::TaskAccess),
+                    format!(
+                        "skipping automatic task caching - output generated outside of repo root \
+                         ({output})"
+                    ),
+                )
+                .emit();
+                return false;
+            }
+
+            let path = AbsoluteSystemPathBuf::new(output.to_string())
+                .unwrap_or_else(|_| AbsoluteSystemPathBuf::from_unknown(repo_root, output));
+            let relation = path.relation_to_path(repo_root);
+            if relation == PathRelation::Parent || relation == PathRelation::Divergent {
+                turborepo_log::warn(
+                    turborepo_log::Source::turbo(turborepo_log::Subsystem::TaskAccess),
+                    format!(
+                        "skipping automatic task caching - output generated outside of repo root \
+                         ({output})"
+                    ),
+                )
+                .emit();
+                return false;
+            }
+        }
+
         true
     }
+}
+
+fn is_windows_absolute_path(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    bytes.first() == Some(&b'\\')
+        || matches!(bytes, [drive, b':', ..] if drive.is_ascii_alphabetic())
 }
 
 #[derive(Clone)]
@@ -311,5 +347,71 @@ impl TaskAccessProvider for TaskAccess {
 
     async fn save(&self) {
         TaskAccess::save(self).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn trace_with_outputs(outputs: Vec<UnescapedString>) -> TaskAccessTraceFile {
+        TaskAccessTraceFile {
+            accessed: TaskAccessTraceAccess {
+                network: false,
+                file_paths: Vec::new(),
+                env_var_keys: Vec::new(),
+            },
+            outputs,
+        }
+    }
+
+    #[test]
+    fn can_cache_allows_generated_outputs_inside_repo() {
+        let temp = tempdir().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(temp.path()).unwrap();
+        let trace = trace_with_outputs(vec!["dist/**".into(), "apps/web/.next/**".into()]);
+
+        assert!(trace.can_cache(&repo_root));
+    }
+
+    #[test]
+    fn can_cache_rejects_accessed_file_outside_repo() {
+        let repo = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo.path()).unwrap();
+        let outside_file = outside.path().join("secret.txt");
+        std::fs::write(&outside_file, b"secret").unwrap();
+        let trace = TaskAccessTraceFile {
+            accessed: TaskAccessTraceAccess {
+                network: false,
+                file_paths: vec![outside_file.to_string_lossy().into_owned().into()],
+                env_var_keys: Vec::new(),
+            },
+            outputs: Vec::new(),
+        };
+
+        assert!(!trace.can_cache(&repo_root));
+    }
+
+    #[test]
+    fn can_cache_rejects_generated_absolute_output_outside_repo() {
+        let repo = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo.path()).unwrap();
+        let outside_output = outside.path().join("dist");
+        let trace = trace_with_outputs(vec![outside_output.to_string_lossy().into_owned().into()]);
+
+        assert!(!trace.can_cache(&repo_root));
+    }
+
+    #[test]
+    fn can_cache_rejects_generated_relative_output_that_traverses_outside_repo() {
+        let temp = tempdir().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(temp.path()).unwrap();
+        let trace = trace_with_outputs(vec!["../outside/**".into()]);
+
+        assert!(!trace.can_cache(&repo_root));
     }
 }

--- a/crates/turborepo-paths/src/relative_unix_path.rs
+++ b/crates/turborepo-paths/src/relative_unix_path.rs
@@ -64,13 +64,26 @@ impl RelativeUnixPath {
         &self,
         prefix: impl AsRef<RelativeUnixPath>,
     ) -> Result<&RelativeUnixPath, PathError> {
-        let stripped_path = self
-            .0
-            .strip_prefix(&prefix.as_ref().0)
-            .ok_or_else(|| PathError::NotParent(prefix.as_ref().to_string(), self.to_string()))?;
+        let prefix = prefix.as_ref();
+        let prefix_len = prefix.0.len();
+        if prefix_len == 0 {
+            return Ok(self);
+        }
 
-        // Remove leading '/' if present
-        let stripped_path = stripped_path.strip_prefix('/').unwrap_or(stripped_path);
+        if !self.0.starts_with(&prefix.0) {
+            return Err(PathError::NotParent(prefix.to_string(), self.to_string()));
+        }
+
+        if self.0.len() == prefix_len {
+            let empty = "";
+            return Ok(unsafe { &*(empty as *const str as *const Self) });
+        }
+
+        if self.0.as_bytes()[prefix_len] != b'/' {
+            return Err(PathError::PrefixError(prefix.to_string(), self.to_string()));
+        }
+
+        let stripped_path = &self.0[(prefix_len + 1)..];
 
         Ok(unsafe { &*(stripped_path as *const str as *const Self) })
     }
@@ -120,5 +133,23 @@ mod test {
         })
         .unwrap();
         assert_eq!(&*path.to_anchored_system_path_buf(), expected);
+    }
+
+    #[test]
+    fn test_strip_prefix_rejects_partial_component_match() {
+        let path = RelativeUnixPath::new("foobar/baz").unwrap();
+        let prefix = RelativeUnixPath::new("foo").unwrap();
+
+        assert!(path.strip_prefix(prefix).is_err());
+    }
+
+    #[test]
+    fn test_strip_prefix_accepts_component_boundary_match() {
+        let path = RelativeUnixPath::new("foo/bar/baz").unwrap();
+        let prefix = RelativeUnixPath::new("foo").unwrap();
+
+        let stripped = path.strip_prefix(prefix).unwrap();
+
+        assert_eq!(stripped.as_str(), "bar/baz");
     }
 }

--- a/crates/turborepo-repository/src/workspaces.rs
+++ b/crates/turborepo-repository/src/workspaces.rs
@@ -17,6 +17,10 @@ pub enum Error {
     Globwalk(#[from] globwalk::GlobError),
     #[error(transparent)]
     WalkError(#[from] globwalk::WalkError),
+    #[error(transparent)]
+    Path(#[from] PathError),
+    #[error("Workspace package resolves outside repository root: {0}")]
+    WorkspacePackageOutsideRepo(String),
 }
 
 // WorkspaceGlobs is suitable for finding package.json files via globwalk
@@ -155,6 +159,13 @@ impl WorkspaceGlobs {
             globwalk::WalkType::Files,
             globwalk::Settings::default().follow_links(),
         )?;
+        let repo_root = repo_root.to_realpath()?;
+        for file in &files {
+            let real_file = file.to_realpath()?;
+            if !real_file.starts_with(&repo_root) {
+                return Err(Error::WorkspacePackageOutsideRepo(file.to_string()));
+            }
+        }
         Ok(files.into_iter())
     }
 }
@@ -258,6 +269,34 @@ mod test {
                         .replace('/', std::path::MAIN_SEPARATOR_STR)
                 ),
                 "doublestar glob should find packages behind symlinks, got: {package_jsons:?}"
+            );
+        }
+
+        #[test]
+        fn rejects_package_behind_symlink_outside_repo_root() {
+            let root_tmp = tempfile::TempDir::with_prefix("ws-symlink-outside-root").unwrap();
+            let root = root_tmp.path();
+            let outside_tmp = tempfile::TempDir::with_prefix("ws-symlink-outside-target").unwrap();
+            let outside = outside_tmp.path();
+
+            std::fs::create_dir_all(outside.join("widget-a")).unwrap();
+            std::fs::write(
+                outside.join("widget-a/package.json"),
+                r#"{"name": "widget-a"}"#,
+            )
+            .unwrap();
+            std::fs::create_dir_all(root.join("widgets")).unwrap();
+            std::os::unix::fs::symlink(outside.join("widget-a"), root.join("widgets/widget-a"))
+                .unwrap();
+
+            let repo_root = AbsoluteSystemPathBuf::try_from(root).unwrap();
+            let globs = WorkspaceGlobs::new(vec!["widgets/*"], vec![]).unwrap();
+
+            let result = globs.get_package_jsons(&repo_root);
+
+            assert!(
+                result.is_err(),
+                "workspace discovery should reject symlinked packages outside the repo root"
             );
         }
     }

--- a/crates/turborepo-run-cache/src/lib.rs
+++ b/crates/turborepo-run-cache/src/lib.rs
@@ -802,7 +802,7 @@ mod test {
     };
 
     use tempfile::tempdir;
-    use turbopath::AbsoluteSystemPathBuf;
+    use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
     use turborepo_cache::{AsyncCache, CacheActions, CacheConfig, CacheOpts, LazyScmState};
     use turborepo_task_id::TaskId;
     use turborepo_telemetry::events::task::PackageTaskEventBuilder;
@@ -1116,12 +1116,13 @@ mod test {
             .await
             .unwrap();
 
-        assert!(
-            task_cache
-                .expanded_outputs()
-                .iter()
-                .any(|path| path.as_str().ends_with("dist/output.txt"))
-        );
+        let expected = AnchoredSystemPathBuf::from_raw(format!(
+            "dist{}output.txt",
+            std::path::MAIN_SEPARATOR_STR
+        ))
+        .unwrap();
+
+        assert!(task_cache.expanded_outputs().contains(&expected));
     }
 
     #[tokio::test]

--- a/crates/turborepo-run-cache/src/lib.rs
+++ b/crates/turborepo-run-cache/src/lib.rs
@@ -53,6 +53,8 @@ pub enum Error {
     OutputWatcher(#[from] OutputWatcherError),
     #[error("Task spawn failed: {0}")]
     SpawnBlocking(String),
+    #[error("Task output resolves outside of repository root: {0}")]
+    OutputOutsideRepo(String),
     #[error(transparent)]
     Scm(#[from] turborepo_scm::Error),
     #[error(transparent)]
@@ -560,6 +562,12 @@ impl TaskCache {
             globwalk::WalkType::All,
         )?;
 
+        for path in &files_to_be_cached {
+            if !self.run_cache.repo_root.contains(path) {
+                return Err(Error::OutputOutsideRepo(path.to_string()));
+            }
+        }
+
         // If we're only caching the log output, *and* output globs are not empty,
         // we should warn the user
         if files_to_be_cached.len() == 1 && !self.repo_relative_globs.is_empty() {
@@ -786,10 +794,85 @@ fn format_sha_context(meta: Option<&CacheHitMetadata>) -> Option<String> {
 mod test {
     use std::{
         collections::HashSet,
-        sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+        },
+        time::Duration,
     };
 
-    use super::{OutputWatcher, OutputWatcherError};
+    use tempfile::tempdir;
+    use turbopath::AbsoluteSystemPathBuf;
+    use turborepo_cache::{AsyncCache, CacheActions, CacheConfig, CacheOpts, LazyScmState};
+    use turborepo_task_id::TaskId;
+    use turborepo_telemetry::events::task::PackageTaskEventBuilder;
+    use turborepo_types::{OutputLogsMode, TaskOutputs};
+    use turborepo_ui::ColorConfig;
+
+    use super::{OutputWatcher, OutputWatcherError, RunCache, TaskCache};
+
+    fn local_cache_opts(repo_root: &AbsoluteSystemPathBuf) -> CacheOpts {
+        CacheOpts {
+            cache_dir: repo_root.as_path().join(".turbo/cache"),
+            cache: CacheConfig {
+                local: CacheActions::enabled(),
+                remote: CacheActions::disabled(),
+            },
+            workers: 1,
+            remote_cache_opts: None,
+            cache_max_age: None,
+            cache_max_size: None,
+        }
+    }
+
+    fn task_cache_for_outputs(
+        repo_root: &AbsoluteSystemPathBuf,
+        outputs: Vec<String>,
+    ) -> TaskCache {
+        let cache_opts = local_cache_opts(repo_root);
+        let cache = AsyncCache::new(
+            &cache_opts,
+            repo_root,
+            None,
+            None,
+            None,
+            LazyScmState::resolved(None),
+        )
+        .unwrap();
+        let warnings = Arc::new(Mutex::new(Vec::new()));
+        let ui = ColorConfig::new(true);
+        let run_cache = Arc::new(RunCache {
+            task_output_logs: None,
+            cache,
+            warnings: warnings.clone(),
+            reads_disabled: false,
+            writes_disabled: false,
+            repo_root: repo_root.to_owned(),
+            output_watcher: None,
+            ui,
+            errors_only_show_hash: false,
+            remote_only: false,
+        });
+
+        TaskCache {
+            expanded_outputs: Vec::new(),
+            run_cache,
+            repo_relative_globs: TaskOutputs {
+                inclusions: outputs,
+                exclusions: Vec::new(),
+            },
+            hash: "test-hash".to_string(),
+            task_id: TaskId::new("pkg", "build"),
+            task_output_logs: OutputLogsMode::None,
+            caching_disabled: false,
+            log_file_path: repo_root.join_components(&["pkg", ".turbo", "turbo-build.log"]),
+            output_watcher: None,
+            ui,
+            warnings,
+            errors_only_show_hash: false,
+            incremental_cache: None,
+        }
+    }
 
     /// Mock OutputWatcher that records calls and returns configurable results.
     struct MockOutputWatcher {
@@ -1016,5 +1099,51 @@ mod test {
         // OutputWatcherError must be Send + Sync for use across async boundaries
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<OutputWatcherError>();
+    }
+
+    #[tokio::test]
+    async fn save_outputs_allows_files_inside_repo_root() {
+        let temp = tempdir().unwrap();
+        let repo_dir = temp.path().join("repo");
+        std::fs::create_dir_all(repo_dir.join("dist")).unwrap();
+        std::fs::write(repo_dir.join("dist/output.txt"), b"output").unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_dir.as_path()).unwrap();
+        let mut task_cache = task_cache_for_outputs(&repo_root, vec!["dist/**".to_string()]);
+        let telemetry = PackageTaskEventBuilder::new("pkg", "build");
+
+        task_cache
+            .save_outputs(Duration::from_millis(10), &telemetry)
+            .await
+            .unwrap();
+
+        assert!(
+            task_cache
+                .expanded_outputs()
+                .iter()
+                .any(|path| path.as_str().ends_with("dist/output.txt"))
+        );
+    }
+
+    #[tokio::test]
+    async fn save_outputs_rejects_glob_that_escapes_repo_root() {
+        let temp = tempdir().unwrap();
+        let repo_dir = temp.path().join("repo");
+        let outside_dir = temp.path().join("outside");
+        std::fs::create_dir_all(&repo_dir).unwrap();
+        std::fs::create_dir_all(&outside_dir).unwrap();
+        std::fs::write(outside_dir.join("output.txt"), b"outside").unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_dir.as_path()).unwrap();
+        let mut task_cache = task_cache_for_outputs(&repo_root, vec!["../outside/**".to_string()]);
+        let telemetry = PackageTaskEventBuilder::new("pkg", "build");
+
+        let result = task_cache
+            .save_outputs(Duration::from_millis(10), &telemetry)
+            .await;
+
+        assert!(
+            result.is_err(),
+            "outputs outside repo root should be rejected before cache upload"
+        );
+        assert!(task_cache.expanded_outputs().is_empty());
     }
 }

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -228,6 +228,11 @@ Multi-layered caching system:
 3. **Cache Storage**: Compress and store task outputs
 4. **Cache Metadata**: Track cache hits, timing, and sources
 
+Cache restore and storage enforce filesystem boundaries. Restores are anchored
+to the selected restore directory, preserve safe symlinks, and reject symlink
+targets that escape that anchor. Cache storage rejects task outputs that resolve
+outside the repository root.
+
 #### Key Components
 
 - `RunCache`: High-level cache coordination


### PR DESCRIPTION
- Keep cache restore and storage anchored to repository/restore boundaries so symlinks and output globs cannot redirect work outside the intended tree.
- Preserve supported in-repository symlink cases while rejecting outside-repo outputs and workspace packages earlier.
- Document that cached outputs must resolve inside the repository root.