### PR TITLE
fix: Handle JSON decoration visitor depth

### DIFF
--- a/packages/turbo-vsc/.vscodeignore
+++ b/packages/turbo-vsc/.vscodeignore
@@ -2,5 +2,6 @@
 **/tsconfig.json
 node_modules
 out/artifacts
+out/test
 .turbo
 **/*.vsix

--- a/packages/turbo-vsc/package.json
+++ b/packages/turbo-vsc/package.json
@@ -38,7 +38,9 @@
     "copy-linux-x64": "cp out/artifacts/turborepo-lsp-x86_64-unknown-linux-musl/turborepo-lsp out/turborepo-lsp-linux-x64 && chmod +x out/turborepo-lsp-linux-x64",
     "copy-win32-arm64": "cp out/artifacts/turborepo-lsp-aarch64-pc-windows-msvc/turborepo-lsp.exe out/turborepo-lsp-win32-arm64.exe",
     "copy": "pnpm run copy-darwin-arm64 && pnpm run copy-darwin-x64 && pnpm run copy-win32-arm64 && pnpm run copy-win32-x64 && pnpm run copy-linux-arm64 && pnpm run copy-linux-x64",
-    "test-compile": "tsc -p ./ --noEmit"
+    "test": "pnpm run test-unit",
+    "test-compile": "tsc -p ./ --noEmit",
+    "test-unit": "esbuild ./src/json-decorations.test.ts --bundle --packages=external --outfile=out/test/json-decorations.test.js --platform=node --format=cjs && node --test out/test/json-decorations.test.js"
   },
   "dependencies": {
     "brace-expansion": "2.0.3",

--- a/packages/turbo-vsc/src/extension.ts
+++ b/packages/turbo-vsc/src/extension.ts
@@ -20,7 +20,7 @@ import {
   ServerOptions
 } from "vscode-languageclient/node";
 
-import { visit } from "jsonc-parser";
+import { getPipelineDecorationOffsets } from "./json-decorations";
 
 let client: LanguageClient;
 
@@ -307,40 +307,19 @@ function updateJSONDecorations(editor?: TextEditor) {
     return;
   }
 
-  let depth = 0; // indicates we're not in a pipeline block
-  let inPipeline = false; // we do not use this right now but could highlight tasks
+  const decorationOffsets = getPipelineDecorationOffsets(
+    editor.document.getText()
+  );
 
-  visit(editor.document.getText(), {
-    onObjectProperty: (property, offset) => {
-      // only highlight pipeline at the top level
-      if (property === "pipeline" && depth === 0 && !inPipeline) {
-        inPipeline = true;
-        for (let i = 1; i < 9; i++) {
-          const index = i + offset;
-          editor.setDecorations(pipelineColors[i], [
-            new Range(
-              editor.document.positionAt(index),
-              editor.document.positionAt(index + 1)
-            )
-          ]);
-        }
-      }
-    },
-    onObjectBegin: () => {
-      if (depth === -1) {
-        depth = 0;
-      } else if (depth !== -1) {
-        depth += 1;
-      }
-    },
-    onObjectEnd: () => {
-      if (depth < -1) {
-        depth -= 1;
-      } else {
-        throw Error("imbalanced visitor");
-      }
-    }
-  });
+  for (let i = 0; i < decorationOffsets.length; i++) {
+    const index = decorationOffsets[i];
+    editor.setDecorations(pipelineColors[i + 1], [
+      new Range(
+        editor.document.positionAt(index),
+        editor.document.positionAt(index + 1)
+      )
+    ]);
+  }
 }
 
 async function promptGlobalTurbo(useLocalTurbo: boolean) {

--- a/packages/turbo-vsc/src/extension.ts
+++ b/packages/turbo-vsc/src/extension.ts
@@ -20,7 +20,7 @@ import {
   ServerOptions
 } from "vscode-languageclient/node";
 
-import { getPipelineDecorationOffsets } from "./json-decorations";
+import { getTaskDefinitionKeyDecorationOffsets } from "./json-decorations";
 
 let client: LanguageClient;
 
@@ -51,11 +51,13 @@ function rainbowRgb(i: number) {
     .padStart(2, "0")}${Math.round(b).toString(16).padStart(2, "0")}`;
 }
 
-const pipelineColors = [...Array(10).keys()].map(rainbowRgb).map((color) =>
-  window.createTextEditorDecorationType({
-    color
-  })
-);
+const taskDefinitionColors = [...Array(10).keys()]
+  .map(rainbowRgb)
+  .map((color) =>
+    window.createTextEditorDecorationType({
+      color
+    })
+  );
 
 const refreshDecorations = useDebounce(updateJSONDecorations, 1000);
 
@@ -307,13 +309,13 @@ function updateJSONDecorations(editor?: TextEditor) {
     return;
   }
 
-  const decorationOffsets = getPipelineDecorationOffsets(
+  const decorationOffsets = getTaskDefinitionKeyDecorationOffsets(
     editor.document.getText()
   );
 
   for (let i = 0; i < decorationOffsets.length; i++) {
     const index = decorationOffsets[i];
-    editor.setDecorations(pipelineColors[i + 1], [
+    editor.setDecorations(taskDefinitionColors[i + 1], [
       new Range(
         editor.document.positionAt(index),
         editor.document.positionAt(index + 1)

--- a/packages/turbo-vsc/src/json-decorations.test.ts
+++ b/packages/turbo-vsc/src/json-decorations.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getPipelineDecorationOffsets } from "./json-decorations";
+
+function pipelineOffsets(json: string): number[] {
+  const start = json.indexOf("pipeline");
+  return Array.from({ length: "pipeline".length }, (_, i) => start + i);
+}
+
+test("decorates top-level pipeline without throwing", () => {
+  const json = `{"pipeline":{"build":{}}}`;
+
+  assert.deepEqual(getPipelineDecorationOffsets(json), pipelineOffsets(json));
+});
+
+test("does not decorate nested pipeline", () => {
+  assert.deepEqual(
+    getPipelineDecorationOffsets(`{"tasks":{"pipeline":{}}}`),
+    []
+  );
+});
+
+test("returns to top-level after a sibling object", () => {
+  const json = `{"tasks":{},"pipeline":{}}`;
+
+  assert.deepEqual(getPipelineDecorationOffsets(json), pipelineOffsets(json));
+});

--- a/packages/turbo-vsc/src/json-decorations.test.ts
+++ b/packages/turbo-vsc/src/json-decorations.test.ts
@@ -1,28 +1,54 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { getPipelineDecorationOffsets } from "./json-decorations";
+import { getTaskDefinitionKeyDecorationOffsets } from "./json-decorations";
 
-function pipelineOffsets(json: string): number[] {
-  const start = json.indexOf("pipeline");
-  return Array.from({ length: "pipeline".length }, (_, i) => start + i);
+function keyOffsets(json: string, key: "pipeline" | "tasks"): number[] {
+  const start = json.indexOf(key);
+  return Array.from({ length: key.length }, (_, i) => start + i);
 }
 
-test("decorates top-level pipeline without throwing", () => {
-  const json = `{"pipeline":{"build":{}}}`;
+test("decorates top-level tasks without throwing", () => {
+  const json = `{"tasks":{"build":{}}}`;
 
-  assert.deepEqual(getPipelineDecorationOffsets(json), pipelineOffsets(json));
+  assert.deepEqual(
+    getTaskDefinitionKeyDecorationOffsets(json),
+    keyOffsets(json, "tasks")
+  );
 });
 
-test("does not decorate nested pipeline", () => {
+test("decorates legacy top-level pipeline", () => {
+  const json = `{"pipeline":{"build":{}}}`;
+
   assert.deepEqual(
-    getPipelineDecorationOffsets(`{"tasks":{"pipeline":{}}}`),
+    getTaskDefinitionKeyDecorationOffsets(json),
+    keyOffsets(json, "pipeline")
+  );
+});
+
+test("does not decorate nested task definition keys", () => {
+  assert.deepEqual(
+    getTaskDefinitionKeyDecorationOffsets(
+      `{"config":{"tasks":{},"pipeline":{}}}`
+    ),
     []
   );
 });
 
 test("returns to top-level after a sibling object", () => {
-  const json = `{"tasks":{},"pipeline":{}}`;
+  const json = `{"globalEnv":{},"tasks":{}}`;
 
-  assert.deepEqual(getPipelineDecorationOffsets(json), pipelineOffsets(json));
+  assert.deepEqual(
+    getTaskDefinitionKeyDecorationOffsets(json),
+    keyOffsets(json, "tasks")
+  );
+});
+
+test("prefers tasks over pipeline", () => {
+  const json = `{"pipeline":{},"tasks":{}}`;
+
+  assert.deepEqual(
+    getTaskDefinitionKeyDecorationOffsets(json),
+    keyOffsets(json, "tasks")
+  );
 });

--- a/packages/turbo-vsc/src/json-decorations.ts
+++ b/packages/turbo-vsc/src/json-decorations.ts
@@ -1,0 +1,30 @@
+import { visit } from "jsonc-parser";
+
+export function getPipelineDecorationOffsets(json: string): number[] {
+  const offsets: number[] = [];
+  let depth = -1;
+  let hasDecoratedPipeline = false;
+
+  visit(json, {
+    onObjectProperty: (property, offset) => {
+      if (property === "pipeline" && depth === 0 && !hasDecoratedPipeline) {
+        hasDecoratedPipeline = true;
+        for (let i = 1; i < 9; i++) {
+          offsets.push(offset + i);
+        }
+      }
+    },
+    onObjectBegin: () => {
+      depth += 1;
+    },
+    onObjectEnd: () => {
+      if (depth < 0) {
+        throw Error("imbalanced visitor");
+      }
+
+      depth -= 1;
+    }
+  });
+
+  return offsets;
+}

--- a/packages/turbo-vsc/src/json-decorations.ts
+++ b/packages/turbo-vsc/src/json-decorations.ts
@@ -1,17 +1,17 @@
 import { visit } from "jsonc-parser";
 
-export function getPipelineDecorationOffsets(json: string): number[] {
-  const offsets: number[] = [];
+const taskDefinitionKeys = ["tasks", "pipeline"] as const;
+
+type TaskDefinitionKey = (typeof taskDefinitionKeys)[number];
+
+export function getTaskDefinitionKeyDecorationOffsets(json: string): number[] {
+  const topLevelTaskDefinitionKeyOffsets = new Map<TaskDefinitionKey, number>();
   let depth = -1;
-  let hasDecoratedPipeline = false;
 
   visit(json, {
     onObjectProperty: (property, offset) => {
-      if (property === "pipeline" && depth === 0 && !hasDecoratedPipeline) {
-        hasDecoratedPipeline = true;
-        for (let i = 1; i < 9; i++) {
-          offsets.push(offset + i);
-        }
+      if (depth === 0 && isTaskDefinitionKey(property)) {
+        topLevelTaskDefinitionKeyOffsets.set(property, offset);
       }
     },
     onObjectBegin: () => {
@@ -26,5 +26,17 @@ export function getPipelineDecorationOffsets(json: string): number[] {
     }
   });
 
-  return offsets;
+  for (const key of taskDefinitionKeys) {
+    const offset = topLevelTaskDefinitionKeyOffsets.get(key);
+
+    if (offset !== undefined) {
+      return Array.from({ length: key.length }, (_, i) => offset + i + 1);
+    }
+  }
+
+  return [];
+}
+
+function isTaskDefinitionKey(property: string): property is TaskDefinitionKey {
+  return taskDefinitionKeys.includes(property as TaskDefinitionKey);
 }


### PR DESCRIPTION
## Summary
- Prevents VS Code turbo.json decorations from failing on valid JSON objects by correcting visitor depth tracking.
- Decorates the modern top-level `tasks` key, with legacy `pipeline` fallback for older configs.
- Adds regression coverage for top-level `tasks`, legacy `pipeline`, nested keys, and configs containing both keys.

<sub>Fixes TURBO-5502</sub>