### PR TITLE
fix: Resolve relative `turbo path` in VS Code extension

### DIFF
--- a/packages/turbo-vsc/package.json
+++ b/packages/turbo-vsc/package.json
@@ -77,7 +77,7 @@
           "type": "string",
           "required": false,
           "default": null,
-          "description": "The path to your global `turbo` executable, if you'd rather not rely on auto-detection."
+          "description": "The path to your `turbo` executable, if you'd rather not rely on auto-detection. Relative paths are resolved from the workspace root."
         },
         "turbo.useLocalTurbo": {
           "type": "boolean",

--- a/packages/turbo-vsc/src/extension.ts
+++ b/packages/turbo-vsc/src/extension.ts
@@ -68,8 +68,13 @@ export function activate(context: ExtensionContext) {
   const turboSettings = workspace.getConfiguration("turbo");
   let turboPath: string | undefined = turboSettings.get("path");
   const useLocalTurbo: boolean = turboSettings.get("useLocalTurbo") ?? false;
+  const workspacePath = workspace.workspaceFolders?.[0].uri.fsPath;
 
   logs.appendLine("starting the turbo extension");
+
+  if (turboPath && workspacePath && !path.isAbsolute(turboPath)) {
+    turboPath = path.resolve(workspacePath, turboPath);
+  }
 
   if (turboPath && !fs.existsSync(turboPath)) {
     logs.appendLine(


### PR DESCRIPTION
## Summary
- Resolves configured relative `turbo.path` values from the VS Code workspace root so `./node_modules/.bin/turbo` works as expected.
- Updates the setting description to clarify how relative paths are resolved.

Closes #8583