### PR TITLE
Document cache behavior with --only

### DIFF
--- a/.github/workflows/release-binary.yaml
+++ b/.github/workflows/release-binary.yaml
@@ -1,0 +1,68 @@
+name: Release Binary
+
+on:
+  push:
+    tags: ["*"]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            short: linux-amd64
+            setup: sudo apt-get update && sudo apt-get install -y build-essential clang lldb llvm libclang-dev musl-tools protobuf-compiler capnproto lld
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            short: linux-arm64
+            setup: sudo apt-get update && sudo apt-get install -y build-essential musl-tools clang llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu protobuf-compiler capnproto lld
+            rust-build-env: 'CC_aarch64_unknown_linux_musl=clang AR_aarch64_unknown_linux_musl=llvm-ar RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld"'
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            short: darwin-amd64
+            setup: brew install capnp protobuf
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            short: darwin-arm64
+            setup: brew install capnp protobuf
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-01-16
+          targets: ${{ matrix.target }}
+      - name: Install dependencies
+        if: matrix.setup
+        run: ${{ matrix.setup }}
+      - name: Build
+        run: ${{ matrix.rust-build-env }} cargo build --profile release-turborepo -p turbo --target ${{ matrix.target }}
+      - name: Prepare artifact
+        run: |
+          cp target/${{ matrix.target }}/release-turborepo/turbo turbo-${{ matrix.short }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: turbo-${{ matrix.short }}
+          path: turbo-${{ matrix.short }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+      - name: Generate checksums
+        run: |
+          cd artifacts
+          sha256sum turbo-* > checksums-sha256.txt
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            artifacts/turbo-*
+            artifacts/checksums-sha256.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7560,6 +7560,7 @@ dependencies = [
  "turborepo-task-id",
  "turborepo-turbo-json",
  "turborepo-types",
+ "wax",
  "which",
 ]
 

--- a/crates/turborepo-engine/Cargo.toml
+++ b/crates/turborepo-engine/Cargo.toml
@@ -28,6 +28,7 @@ turborepo-task-executor = { path = "../turborepo-task-executor" }
 turborepo-task-id = { path = "../turborepo-task-id" }
 turborepo-turbo-json = { path = "../turborepo-turbo-json" }
 turborepo-types = { workspace = true }
+wax = { workspace = true }
 which = { workspace = true }
 
 [dev-dependencies]

--- a/crates/turborepo-engine/src/builder.rs
+++ b/crates/turborepo-engine/src/builder.rs
@@ -398,6 +398,16 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                         if let Some(allowed_tasks) = &allowed_tasks
                             && !allowed_tasks.contains(&from_task_id)
                         {
+                            tracing::warn!(
+                                "--only: dropping topological dependency {} from {}. \
+                                 Changes in {} won't affect the cache key for {}. \
+                                 To include it, add --filter={}",
+                                from_task_id,
+                                to_task_id,
+                                from_task_id.package(),
+                                to_task_id,
+                                from_task_id.package(),
+                            );
                             return;
                         }
                         let from_task_index = engine.get_index(&from_task_id);
@@ -431,6 +441,16 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                 if let Some(allowed_tasks) = &allowed_tasks
                     && !allowed_tasks.contains(&from_task_id)
                 {
+                    tracing::warn!(
+                        "--only: dropping task dependency {} from {}. \
+                         Changes in {} won't affect the cache key for {}. \
+                         To include it, add --filter={}",
+                        from_task_id,
+                        to_task_id,
+                        from_task_id.package(),
+                        to_task_id,
+                        from_task_id.package(),
+                    );
                     continue;
                 }
                 has_deps = true;

--- a/crates/turborepo-engine/src/builder.rs
+++ b/crates/turborepo-engine/src/builder.rs
@@ -1957,6 +1957,86 @@ mod test {
         assert_eq!(all_dependencies(&engine), expected);
     }
 
+    /// --only should preserve ^dependency edges for packages that are
+    /// direct dependencies in the package graph, even if they aren't
+    /// explicitly in the --filter set.
+    ///
+    /// Currently FAILS: --only drops ALL dependency edges for packages
+    /// not in the filter, even when they're direct package.json
+    /// dependencies. Users must manually add --filter for each upstream
+    /// package, which is fragile and defeats the purpose of ^dependsOn.
+    ///
+    /// Real-world scenario: checkit-runtime depends on yolean-types and
+    /// declares `"bundle": { "dependsOn": ["^bundle"] }`.
+    /// Running `turbo bundle --only --filter=checkit-runtime` should
+    /// still include yolean-types#bundle in the cache key because
+    /// checkit-runtime declares it as a package dependency.
+    /// Instead, the edge is dropped and changes in yolean-types don't
+    /// invalidate the cache — causing stale builds shipped to prod.
+    ///
+    /// Workaround: explicitly add --filter=yolean-types --filter=yolean-op
+    /// or declare $TURBO_ROOT$ inputs in turbo.json.
+    #[test]
+    #[should_panic]
+    fn test_tasks_only_should_preserve_package_dependency_edges() {
+        let repo_root_dir = TempDir::with_prefix("repo").unwrap();
+        let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
+        let package_graph = mock_package_graph(
+            &repo_root,
+            package_jsons! {
+                repo_root,
+                "types" => [],
+                "runtime" => ["types"]
+            },
+        );
+        let turbo_jsons = vec![(
+            PackageName::Root,
+            turbo_json(json!({
+                "tasks": {
+                    "fetch": {
+                        "cache": false,
+                        "outputs": ["target-fetched/**"]
+                    },
+                    "bundle": {
+                        "dependsOn": ["fetch", "^bundle"],
+                        "inputs": ["target-fetched/**"],
+                        "outputs": ["target/**"]
+                    }
+                }
+            })),
+        )]
+        .into_iter()
+        .collect();
+        let loader = TestTurboJsonLoader::new(turbo_jsons);
+
+        // --only with ONLY runtime in filter.
+        // types is a package.json dependency of runtime and bundle
+        // declares ^bundle, so types#bundle should be in the graph.
+        let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
+            .with_tasks_only(true)
+            .with_tasks(Some(Spanned::new(TaskName::from("bundle"))))
+            .with_workspaces(vec![PackageName::from("runtime")])
+            .with_root_tasks(vec![
+                TaskName::from("fetch"),
+                TaskName::from("bundle"),
+            ])
+            .build()
+            .unwrap();
+
+        let deps = all_dependencies(&engine);
+
+        // runtime depends on types in package.json and bundle declares
+        // ^bundle, so types#bundle should be preserved as a dependency
+        // even though types is not in the --filter set.
+        let expected = deps! {
+            "runtime#bundle" => ["types#bundle"],
+            "types#bundle" => ["___ROOT___"]
+        };
+        assert_eq!(deps, expected,
+            "--only should preserve ^bundle edges for package.json dependencies \
+             so that upstream changes invalidate the cache key");
+    }
+
     // Note: test_validate_task_name has been moved to turborepo-engine crate
     // See: crates/turborepo-engine/src/validate.rs
 

--- a/crates/turborepo-engine/src/dep_output_overlap.rs
+++ b/crates/turborepo-engine/src/dep_output_overlap.rs
@@ -1,0 +1,572 @@
+//! Detects tasks whose inputs overlap with their dependencies' outputs.
+//!
+//! When task B depends on task A and B's `inputs` include a file that A
+//! declares as an `output`, turbo must defer B's file hashing until after
+//! A has executed, so the output files exist on disk and hash correctly.
+
+use std::collections::HashSet;
+
+use turborepo_task_id::TaskId;
+use turborepo_types::TaskDefinition;
+use wax::Program as _;
+
+use crate::{Built, Engine, TaskNode};
+
+/// A detected overlap between a task's inputs and a dependency's outputs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DepOutputOverlap {
+    /// The task whose inputs overlap with a dependency's outputs.
+    pub task_id: TaskId<'static>,
+    /// The dependency task that produces the overlapping outputs.
+    pub dep_task_id: TaskId<'static>,
+    /// The patterns that overlap (from the dependency's outputs).
+    pub overlapping_patterns: Vec<String>,
+}
+
+/// Analyze the engine's task graph to detect tasks whose inputs include
+/// files produced by their dependencies' outputs.
+///
+/// Only considers same-package dependencies since cross-package tasks
+/// write to different package directories.
+pub fn detect_dep_output_overlaps(engine: &Engine<Built, TaskDefinition>) -> Vec<DepOutputOverlap> {
+    let mut overlaps = Vec::new();
+
+    for task_id in engine.task_ids() {
+        let task_def = match engine.task_definition(task_id) {
+            Some(def) => def,
+            None => continue,
+        };
+
+        let input_globs = &task_def.inputs.globs;
+        if input_globs.is_empty() {
+            continue;
+        }
+
+        // Walk all transitive dependencies to catch chains like
+        // prepare -> transform -> build.
+        let transitive_deps = engine.transitive_dependencies(task_id);
+
+        for dep_node in transitive_deps {
+            let TaskNode::Task(dep_id) = dep_node else {
+                continue;
+            };
+
+            // Only same-package deps can have overlapping paths.
+            if dep_id.package() != task_id.package() {
+                continue;
+            }
+
+            let dep_def = match engine.task_definition(dep_id) {
+                Some(def) => def,
+                None => continue,
+            };
+
+            let dep_outputs = &dep_def.outputs.inclusions;
+            if dep_outputs.is_empty() {
+                continue;
+            }
+
+            let matching = find_overlapping_patterns(input_globs, dep_outputs);
+            if !matching.is_empty() {
+                overlaps.push(DepOutputOverlap {
+                    task_id: task_id.clone(),
+                    dep_task_id: dep_id.clone(),
+                    overlapping_patterns: matching,
+                });
+            }
+        }
+    }
+
+    // Sort for deterministic output.
+    overlaps.sort_by(|a, b| {
+        a.task_id
+            .cmp(&b.task_id)
+            .then_with(|| a.dep_task_id.cmp(&b.dep_task_id))
+    });
+
+    overlaps
+}
+
+/// Build a set of task IDs that need deferred file hashing.
+pub fn deferred_hash_tasks(overlaps: &[DepOutputOverlap]) -> HashSet<TaskId<'static>> {
+    overlaps.iter().map(|o| o.task_id.clone()).collect()
+}
+
+/// A config-level overlap, deduplicated by task name (package stripped).
+/// Represents a pattern in the turbo.json task definitions, not a specific
+/// package instance.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigOverlap {
+    /// The task name whose inputs overlap (e.g. "bundle").
+    pub task_name: String,
+    /// The dependency task name that produces the overlapping outputs (e.g.
+    /// "fetch").
+    pub dep_task_name: String,
+    /// The patterns that overlap.
+    pub overlapping_patterns: Vec<String>,
+}
+
+/// Deduplicate per-task overlaps into config-level overlaps by stripping
+/// the package prefix. This produces one warning per turbo.json task
+/// pattern regardless of how many packages inherit it.
+pub fn config_level_overlaps(overlaps: &[DepOutputOverlap]) -> Vec<ConfigOverlap> {
+    use std::collections::BTreeSet;
+
+    // Key: (task_name, dep_task_name) → set of patterns
+    let mut seen: std::collections::BTreeMap<(String, String), BTreeSet<String>> =
+        std::collections::BTreeMap::new();
+
+    for overlap in overlaps {
+        let key = (
+            overlap.task_id.task().to_string(),
+            overlap.dep_task_id.task().to_string(),
+        );
+        let patterns = seen.entry(key).or_default();
+        for pat in &overlap.overlapping_patterns {
+            patterns.insert(pat.clone());
+        }
+    }
+
+    seen.into_iter()
+        .map(|((task_name, dep_task_name), patterns)| ConfigOverlap {
+            task_name,
+            dep_task_name,
+            overlapping_patterns: patterns.into_iter().collect(),
+        })
+        .collect()
+}
+
+/// Check if any input glob matches any output pattern.
+///
+/// Uses exact string matching first, then glob-based matching where one
+/// pattern could match the other (e.g., output `dist/**` matches input
+/// `dist/bundle.js`).
+fn find_overlapping_patterns(input_globs: &[String], output_patterns: &[String]) -> Vec<String> {
+    let mut matched = Vec::new();
+
+    for output in output_patterns {
+        for input in input_globs {
+            // Skip negated inputs (exclusions).
+            if input.starts_with('!') {
+                continue;
+            }
+
+            // Exact match.
+            if input == output {
+                if !matched.contains(output) {
+                    matched.push(output.clone());
+                }
+                continue;
+            }
+
+            // Try: does the output glob match the input as a literal path?
+            // e.g., output "dist/**" matches input "dist/bundle.js"
+            if let Ok(output_glob) = wax::Glob::new(output)
+                && output_glob.is_match(input.as_str())
+                && !matched.contains(output)
+            {
+                matched.push(output.clone());
+                continue;
+            }
+
+            // Try: does the input glob match the output as a literal path?
+            // e.g., input "generated.*" matches output "generated.txt"
+            if let Ok(input_glob) = wax::Glob::new(input)
+                && input_glob.is_match(output.as_str())
+                && !matched.contains(output)
+            {
+                matched.push(output.clone());
+                continue;
+            }
+
+            // Directory containment: input "dir" should match output "dir/**"
+            // because turbo treats a bare directory name as "everything in it".
+            let input_dir = input.trim_end_matches('/');
+            let output_dir = output.trim_end_matches("/**").trim_end_matches("/*");
+            if (input_dir == output_dir
+                || output.starts_with(&format!("{input_dir}/"))
+                || input.starts_with(&format!("{output_dir}/")))
+                && !matched.contains(output)
+            {
+                matched.push(output.clone());
+            }
+        }
+    }
+
+    matched
+}
+
+#[cfg(test)]
+mod tests {
+    use turborepo_types::{TaskInputs, TaskOutputs};
+
+    use super::*;
+
+    fn make_task_def(
+        inputs: Vec<&str>,
+        outputs: Vec<&str>,
+        task_deps: Vec<&str>,
+    ) -> TaskDefinition {
+        TaskDefinition {
+            inputs: TaskInputs {
+                globs: inputs.into_iter().map(|s| s.to_string()).collect(),
+                default: false,
+            },
+            outputs: TaskOutputs {
+                inclusions: outputs.into_iter().map(|s| s.to_string()).collect(),
+                exclusions: vec![],
+            },
+            task_dependencies: task_deps
+                .into_iter()
+                .map(|s| {
+                    turborepo_errors::Spanned::new(
+                        turborepo_task_id::TaskName::from(s.to_string()).into_owned(),
+                    )
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_exact_match_detection() {
+        let overlaps =
+            find_overlapping_patterns(&["generated.txt".into()], &["generated.txt".into()]);
+        assert_eq!(overlaps, vec!["generated.txt"]);
+    }
+
+    #[test]
+    fn test_glob_output_matches_literal_input() {
+        let overlaps = find_overlapping_patterns(&["dist/bundle.js".into()], &["dist/**".into()]);
+        assert_eq!(overlaps, vec!["dist/**"]);
+    }
+
+    #[test]
+    fn test_glob_input_matches_literal_output() {
+        let overlaps =
+            find_overlapping_patterns(&["generated.*".into()], &["generated.txt".into()]);
+        assert_eq!(overlaps, vec!["generated.txt"]);
+    }
+
+    #[test]
+    fn test_no_overlap() {
+        let overlaps = find_overlapping_patterns(&["src/**".into()], &["dist/**".into()]);
+        assert!(overlaps.is_empty());
+    }
+
+    #[test]
+    fn test_negated_input_ignored() {
+        let overlaps =
+            find_overlapping_patterns(&["!generated.txt".into()], &["generated.txt".into()]);
+        assert!(overlaps.is_empty());
+    }
+
+    #[test]
+    fn test_directory_input_matches_glob_output() {
+        // turbo treats bare "dir" as "everything in dir"
+        let overlaps =
+            find_overlapping_patterns(&["target-schemas".into()], &["target-schemas/**".into()]);
+        assert_eq!(overlaps, vec!["target-schemas/**"]);
+    }
+
+    #[test]
+    fn test_directory_output_matches_subpath_input() {
+        let overlaps = find_overlapping_patterns(&["dist/bundle.js".into()], &["dist/**".into()]);
+        assert_eq!(overlaps, vec!["dist/**"]);
+    }
+
+    // --- Engine-level tests for detect_dep_output_overlaps ---
+
+    fn make_engine(
+        tasks: &[(TaskId<'static>, TaskDefinition)],
+        edges: &[(TaskId<'static>, TaskId<'static>)],
+    ) -> Engine<crate::Built, TaskDefinition> {
+        use crate::Building;
+        let mut engine: Engine<Building, TaskDefinition> = Engine::new();
+        let mut indices = std::collections::HashMap::new();
+        for (task_id, def) in tasks {
+            let idx = engine.get_index(task_id);
+            engine.add_definition(task_id.clone(), def.clone());
+            indices.insert(task_id.clone(), idx);
+        }
+        for (from, to) in edges {
+            let from_idx = indices[from];
+            let to_idx = indices[to];
+            // Edge points dependent → dependency (Outgoing = dependencies)
+            engine.task_graph_mut().add_edge(from_idx, to_idx, ());
+        }
+        // Connect leaf nodes to root
+        for (task_id, _) in tasks {
+            let has_deps = edges.iter().any(|(_, to)| to == task_id);
+            if !has_deps {
+                engine.connect_to_root(task_id);
+            }
+        }
+        engine.seal()
+    }
+
+    fn tid(pkg: &str, task: &str) -> TaskId<'static> {
+        TaskId::new(pkg, task).into_owned()
+    }
+
+    #[test]
+    fn test_engine_simple_overlap() {
+        let prepare = tid("pkg", "prepare");
+        let build = tid("pkg", "build");
+
+        let engine = make_engine(
+            &[
+                (
+                    prepare.clone(),
+                    make_task_def(vec!["package.json"], vec!["generated.txt"], vec![]),
+                ),
+                (
+                    build.clone(),
+                    make_task_def(vec!["generated.txt"], vec![], vec!["prepare"]),
+                ),
+            ],
+            &[(build.clone(), prepare.clone())],
+        );
+
+        let overlaps = detect_dep_output_overlaps(&engine);
+        assert_eq!(overlaps.len(), 1);
+        assert_eq!(overlaps[0].task_id, build);
+        assert_eq!(overlaps[0].dep_task_id, prepare);
+        assert_eq!(overlaps[0].overlapping_patterns, vec!["generated.txt"]);
+    }
+
+    #[test]
+    fn test_engine_transitive_overlap() {
+        // prepare -> transform -> build
+        // prepare outputs generated.txt
+        // build inputs generated.txt (transitive dep, not direct)
+        let prepare = tid("pkg", "prepare");
+        let transform = tid("pkg", "transform");
+        let build = tid("pkg", "build");
+
+        let engine = make_engine(
+            &[
+                (
+                    prepare.clone(),
+                    make_task_def(vec!["package.json"], vec!["generated.txt"], vec![]),
+                ),
+                (
+                    transform.clone(),
+                    make_task_def(
+                        vec!["generated.txt"],
+                        vec!["transformed.txt"],
+                        vec!["prepare"],
+                    ),
+                ),
+                (
+                    build.clone(),
+                    make_task_def(
+                        vec!["generated.txt", "transformed.txt"],
+                        vec![],
+                        vec!["transform"],
+                    ),
+                ),
+            ],
+            &[
+                (transform.clone(), prepare.clone()),
+                (build.clone(), transform.clone()),
+            ],
+        );
+
+        let overlaps = detect_dep_output_overlaps(&engine);
+
+        // build should detect overlap with prepare (generated.txt) and transform
+        // (transformed.txt) transform should detect overlap with prepare
+        // (generated.txt)
+        let build_overlaps: Vec<_> = overlaps.iter().filter(|o| o.task_id == build).collect();
+        let transform_overlaps: Vec<_> =
+            overlaps.iter().filter(|o| o.task_id == transform).collect();
+
+        assert_eq!(
+            build_overlaps.len(),
+            2,
+            "build should overlap with both prepare and transform"
+        );
+        assert_eq!(
+            transform_overlaps.len(),
+            1,
+            "transform should overlap with prepare"
+        );
+
+        // Check specific patterns
+        let build_prepare = build_overlaps
+            .iter()
+            .find(|o| o.dep_task_id == prepare)
+            .unwrap();
+        assert_eq!(build_prepare.overlapping_patterns, vec!["generated.txt"]);
+
+        let build_transform = build_overlaps
+            .iter()
+            .find(|o| o.dep_task_id == transform)
+            .unwrap();
+        assert_eq!(
+            build_transform.overlapping_patterns,
+            vec!["transformed.txt"]
+        );
+    }
+
+    #[test]
+    fn test_engine_no_overlap_different_packages() {
+        // Cross-package deps should NOT be detected (different package dirs)
+        let lib_build = tid("lib", "build");
+        let app_build = tid("app", "build");
+
+        let engine = make_engine(
+            &[
+                (
+                    lib_build.clone(),
+                    make_task_def(vec!["src/**"], vec!["dist/**"], vec![]),
+                ),
+                (
+                    app_build.clone(),
+                    make_task_def(vec!["dist/**"], vec![], vec![]),
+                ),
+            ],
+            &[(app_build.clone(), lib_build.clone())],
+        );
+
+        let overlaps = detect_dep_output_overlaps(&engine);
+        assert!(
+            overlaps.is_empty(),
+            "cross-package deps should not trigger overlap detection"
+        );
+    }
+
+    #[test]
+    fn test_engine_no_overlap_unrelated_patterns() {
+        let prepare = tid("pkg", "prepare");
+        let build = tid("pkg", "build");
+
+        let engine = make_engine(
+            &[
+                (
+                    prepare.clone(),
+                    make_task_def(vec!["package.json"], vec!["generated.txt"], vec![]),
+                ),
+                (
+                    build.clone(),
+                    make_task_def(vec!["src/**"], vec![], vec!["prepare"]),
+                ),
+            ],
+            &[(build.clone(), prepare.clone())],
+        );
+
+        let overlaps = detect_dep_output_overlaps(&engine);
+        assert!(
+            overlaps.is_empty(),
+            "non-overlapping patterns should not trigger detection"
+        );
+    }
+
+    #[test]
+    fn test_engine_directory_containment() {
+        // schemas outputs "target-schemas/**", contain inputs "target-schemas" (bare
+        // dir)
+        let schemas = tid("pkg", "schemas");
+        let contain = tid("pkg", "contain");
+
+        let engine = make_engine(
+            &[
+                (
+                    schemas.clone(),
+                    make_task_def(vec!["src/**"], vec!["target-schemas/**"], vec![]),
+                ),
+                (
+                    contain.clone(),
+                    make_task_def(vec!["target-schemas"], vec![], vec!["schemas"]),
+                ),
+            ],
+            &[(contain.clone(), schemas.clone())],
+        );
+
+        let overlaps = detect_dep_output_overlaps(&engine);
+        assert_eq!(overlaps.len(), 1);
+        assert_eq!(overlaps[0].task_id, contain);
+        assert_eq!(overlaps[0].dep_task_id, schemas);
+        assert_eq!(overlaps[0].overlapping_patterns, vec!["target-schemas/**"]);
+    }
+
+    // --- Config-level deduplication tests ---
+
+    #[test]
+    fn test_config_level_deduplicates_across_packages() {
+        // Same task pattern in multiple packages should produce one config overlap
+        let overlaps = vec![
+            DepOutputOverlap {
+                task_id: tid("app-a", "bundle"),
+                dep_task_id: tid("app-a", "fetch"),
+                overlapping_patterns: vec!["target-fetched/**".into()],
+            },
+            DepOutputOverlap {
+                task_id: tid("app-b", "bundle"),
+                dep_task_id: tid("app-b", "fetch"),
+                overlapping_patterns: vec!["target-fetched/**".into()],
+            },
+            DepOutputOverlap {
+                task_id: tid("lib-c", "bundle"),
+                dep_task_id: tid("lib-c", "fetch"),
+                overlapping_patterns: vec!["target-fetched/**".into()],
+            },
+        ];
+
+        let config = config_level_overlaps(&overlaps);
+        assert_eq!(config.len(), 1, "should deduplicate to one config overlap");
+        assert_eq!(config[0].task_name, "bundle");
+        assert_eq!(config[0].dep_task_name, "fetch");
+        assert_eq!(config[0].overlapping_patterns, vec!["target-fetched/**"]);
+    }
+
+    #[test]
+    fn test_config_level_preserves_distinct_patterns() {
+        // Different task pairs should remain separate
+        let overlaps = vec![
+            DepOutputOverlap {
+                task_id: tid("pkg", "bundle"),
+                dep_task_id: tid("pkg", "fetch"),
+                overlapping_patterns: vec!["target-fetched/**".into()],
+            },
+            DepOutputOverlap {
+                task_id: tid("pkg", "contain"),
+                dep_task_id: tid("pkg", "schemas"),
+                overlapping_patterns: vec!["target-schemas/**".into()],
+            },
+        ];
+
+        let config = config_level_overlaps(&overlaps);
+        assert_eq!(config.len(), 2);
+        assert_eq!(config[0].task_name, "bundle");
+        assert_eq!(config[0].dep_task_name, "fetch");
+        assert_eq!(config[1].task_name, "contain");
+        assert_eq!(config[1].dep_task_name, "schemas");
+    }
+
+    #[test]
+    fn test_config_level_merges_patterns_from_different_packages() {
+        // If different packages contribute different patterns for the same
+        // task pair, they should be merged
+        let overlaps = vec![
+            DepOutputOverlap {
+                task_id: tid("app-a", "bundle"),
+                dep_task_id: tid("app-a", "fetch"),
+                overlapping_patterns: vec!["target-fetched/**".into()],
+            },
+            DepOutputOverlap {
+                task_id: tid("app-b", "bundle"),
+                dep_task_id: tid("app-b", "fetch"),
+                overlapping_patterns: vec!["target-fetched/**".into(), "data/**".into()],
+            },
+        ];
+
+        let config = config_level_overlaps(&overlaps);
+        assert_eq!(config.len(), 1);
+        assert_eq!(
+            config[0].overlapping_patterns,
+            vec!["data/**", "target-fetched/**"]
+        );
+    }
+}

--- a/crates/turborepo-engine/src/lib.rs
+++ b/crates/turborepo-engine/src/lib.rs
@@ -12,6 +12,7 @@ pub mod affected;
 mod builder;
 mod builder_error;
 mod builder_errors;
+pub mod dep_output_overlap;
 mod dot;
 mod execute;
 mod graph_visualizer;

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -429,6 +429,25 @@ impl Run {
             "",
         )
         .emit();
+
+        // Config-level info for dependsOn output/input overlaps.
+        // Deduplicated by task name (package stripped) — informs the config
+        // author that turbo.json task definitions have patterns where a
+        // task's inputs match a dependency's outputs.
+        let overlaps =
+            turborepo_engine::dep_output_overlap::detect_dep_output_overlaps(&self.engine);
+        let config_overlaps =
+            turborepo_engine::dep_output_overlap::config_level_overlaps(&overlaps);
+        for co in &config_overlaps {
+            turborepo_log::info(
+                turborepo_log::Source::turbo(turborepo_log::Subsystem::Run),
+                format!(
+                    "{pad}Task \"{}\" inputs match \"{}\" outputs: {:?}",
+                    co.task_name, co.dep_task_name, co.overlapping_patterns
+                ),
+            )
+            .emit();
+        }
     }
 
     pub fn turbo_json_loader(&self) -> &UnifiedTurboJsonLoader {

--- a/turborepo-tests/integration/tests/run-caching/dependent-task-hashing/dependent-task-hashing.t
+++ b/turborepo-tests/integration/tests/run-caching/dependent-task-hashing/dependent-task-hashing.t
@@ -1,0 +1,18 @@
+Setup
+  $ . ${TESTDIR}/../../../../helpers/setup_integration_test.sh
+
+Copy fixture files
+  $ mkdir -p ${TARGET_DIR}/packages/dependent-task-hashing
+  $ cp ${TESTDIR}/turbo.json ${TARGET_DIR}/packages/dependent-task-hashing/turbo.json
+  $ cp ${TESTDIR}/package.json ${TARGET_DIR}/packages/dependent-task-hashing/package.json
+
+First run - everything should be a cache miss
+  $ ${TURBO} run build --filter=dependent-task-hashing | grep -Eo "(FULL TURBO|cache miss|cache hit)"
+  cache miss
+  cache miss
+
+Second run - should be a cache hit for both tasks
+  $ ${TURBO} run build --filter=dependent-task-hashing | grep -Eo "(FULL TURBO|cache miss|cache hit)"
+  cache hit
+  cache hit
+  FULL TURBO

--- a/turborepo-tests/integration/tests/run-caching/dependent-task-hashing/package.json
+++ b/turborepo-tests/integration/tests/run-caching/dependent-task-hashing/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "dependent-task-hashing",
+  "scripts": {
+    "prepare": "echo Preparing && echo foo > generated.txt",
+    "build": "echo Building"
+  }
+}

--- a/turborepo-tests/integration/tests/run-caching/dependent-task-hashing/turbo.json
+++ b/turborepo-tests/integration/tests/run-caching/dependent-task-hashing/turbo.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "prepare": {
+      "inputs": ["src"],
+      "outputs": ["generated.txt"]
+    },
+    "build": {
+      "inputs": ["generated.txt"],
+      "dependsOn": ["prepare"]
+    }
+  }
+}


### PR DESCRIPTION
Sibling to https://github.com/solsson/turbo/pull/1, same level of surprise. The definition of "correctness" for build cache is unclear. Turbo has flexibility in config and CLI flags that's easy to use but hard to grasp the cache effects of.