### PR TITLE
ci: Parallelize LSP release publishing

### DIFF
--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -120,7 +120,7 @@ jobs:
           extra-flags: "--frozen-lockfile"
 
       - name: Validate manual publish ref
-        if: ${{ inputs.publish && !inputs.dry_run }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish && !inputs.dry_run }}
         env:
           PUBLISH_REF: ${{ inputs.ref || github.ref_name }}
         run: |
@@ -217,16 +217,14 @@ jobs:
 
           const marketplaceVersion = `${marketplaceMajor}.${marketplaceMinor}.${marketplacePatch}`;
 
-          const releaseTag =
+          const releaseRef =
             process.env.RELEASE_REF ||
             (process.env.GITHUB_REF_TYPE === "tag" ? process.env.GITHUB_REF_NAME : "");
-          if (releaseTag) {
-            const tagVersion = releaseTag.startsWith("v")
-              ? releaseTag.slice(1)
-              : releaseTag;
+          if (releaseRef.startsWith("v")) {
+            const tagVersion = releaseRef.slice(1);
             if (tagVersion !== version) {
               throw new Error(
-                `Release tag ${releaseTag} does not match version.txt ${version}`
+                `Release tag ${releaseRef} does not match version.txt ${version}`
               );
             }
           }

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -618,7 +618,14 @@ jobs:
 
   create-release-pr:
     name: "Create Release PR"
-    needs: [stage, npm-publish, create-release-tag, publish-vscode-extension, alias-versioned-docs]
+    needs:
+      [
+        stage,
+        npm-publish,
+        create-release-tag,
+        publish-vscode-extension,
+        alias-versioned-docs
+      ]
     if: ${{ always() && needs.npm-publish.result == 'success' && needs.create-release-tag.result == 'success' && needs.publish-vscode-extension.result == 'success' && !inputs.dry_run }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -5,7 +5,7 @@
 # 1. Create a staging branch (acts as a lock to prevent concurrent releases)
 # 2. Run some smoke tests on that branch
 # 3. Build the Rust binary
-# 4. Publish JS packages to npm (including turbo itself)
+# 4. Publish JS packages to npm and the VS Code extension as parallel worksets
 # 5. Create the git tag (only after npm publish succeeds)
 # 6. Alias versioned docs (e.g., v2-5-4.turborepo.dev)
 # 7. Create a release branch and open a PR
@@ -506,15 +506,15 @@ jobs:
 
   publish-vscode-extension:
     name: "Publish VS Code Extension"
-    needs: [stage, create-release-tag]
-    if: ${{ always() && needs.create-release-tag.result == 'success' && !inputs.dry_run }}
+    needs: [stage, js-smoke-test]
+    if: ${{ always() && needs.stage.result == 'success' && needs.js-smoke-test.result == 'success' && !inputs.dry_run }}
     permissions:
       contents: read
     uses: ./.github/workflows/lsp.yml
     with:
       publish: true
       dry_run: false
-      ref: v${{ needs.stage.outputs.version }}
+      ref: ${{ needs.stage.outputs.stage-branch }}
     secrets: inherit
 
   alias-versioned-docs:
@@ -618,8 +618,8 @@ jobs:
 
   create-release-pr:
     name: "Create Release PR"
-    needs: [stage, npm-publish, create-release-tag, alias-versioned-docs]
-    if: ${{ always() && needs.npm-publish.result == 'success' && needs.create-release-tag.result == 'success' && !inputs.dry_run }}
+    needs: [stage, npm-publish, create-release-tag, publish-vscode-extension, alias-versioned-docs]
+    if: ${{ always() && needs.npm-publish.result == 'success' && needs.create-release-tag.result == 'success' && needs.publish-vscode-extension.result == 'success' && !inputs.dry_run }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
@@ -743,6 +743,7 @@ jobs:
         js-smoke-test,
         npm-publish,
         create-release-tag,
+        publish-vscode-extension,
         create-release-pr
       ]
     if: >-
@@ -754,6 +755,7 @@ jobs:
           || needs.js-smoke-test.result == 'failure'
           || needs.npm-publish.result == 'failure'
           || needs.create-release-tag.result == 'failure'
+          || needs.publish-vscode-extension.result == 'failure'
           || needs.create-release-pr.result == 'failure'
         )
       }}


### PR DESCRIPTION
## Summary
- Runs VS Code extension/LSP release work in parallel with npm publishing once staging and JS smoke tests pass.
- Keeps release PR creation gated on npm publish, tag creation, and extension publish success.
- Preserves tag validation for manual LSP publishes while allowing release workflow calls to publish from the staging branch.