### PR TITLE
fix: Reduce VS Code extension startup popups

### DIFF
--- a/crates/turborepo-lsp/src/lib.rs
+++ b/crates/turborepo-lsp/src/lib.rs
@@ -151,12 +151,21 @@ impl LanguageServer for Backend {
                 }
                 Err(e) => {
                     self.client
+                        .show_message(
+                            MessageType::ERROR,
+                            "Turborepo language server failed to connect to the daemon. See the \
+                             output for details.",
+                        )
+                        .await;
+                    self.client
                         .log_message(
                             MessageType::ERROR,
                             format!("failed to connect to daemon: {e}"),
                         )
                         .await;
-                    return Err(Error::internal_error());
+                    return Ok(InitializeResult {
+                        ..Default::default()
+                    });
                 }
             };
 
@@ -184,12 +193,21 @@ impl LanguageServer for Backend {
                 }
                 Err(e) => {
                     self.client
+                        .show_message(
+                            MessageType::ERROR,
+                            "Turborepo language server failed to initialize. See the output for \
+                             details.",
+                        )
+                        .await;
+                    self.client
                         .log_message(
                             MessageType::ERROR,
                             format!("Failed to acquire pidlock: {e}"),
                         )
                         .await;
-                    return Err(Error::internal_error());
+                    return Ok(InitializeResult {
+                        ..Default::default()
+                    });
                 }
             }
         }

--- a/packages/turbo-vsc/src/extension.ts
+++ b/packages/turbo-vsc/src/extension.ts
@@ -80,6 +80,22 @@ export function activate(context: ExtensionContext) {
     logs.appendLine(`using turbo at path ${turboPath}`);
   }
 
+  const packagedLspPath = Uri.joinPath(
+    context.extensionUri,
+    "out",
+    `turborepo-lsp-${process.platform}-${process.arch}${
+      process.platform === "win32" ? ".exe" : ""
+    }`
+  ).fsPath;
+
+  const installedTurboLspPath = findInstalledTurboLsp(
+    workspaceRoot,
+    syncOptions,
+    turboPath
+  );
+
+  const daemonCommandPath = installedTurboLspPath ?? packagedLspPath;
+
   const getTurboPath = async () => {
     turboPath ??= findTurbo(workspaceRoot, syncOptions);
     if (turboPath) {
@@ -91,14 +107,22 @@ export function activate(context: ExtensionContext) {
     return turboPath;
   };
 
+  const getDaemonCommandPath = async () => {
+    if (fs.existsSync(daemonCommandPath)) {
+      return daemonCommandPath;
+    }
+
+    return getTurboPath();
+  };
+
   context.subscriptions.push(
     commands.registerCommand("turbo.daemon.start", async () => {
-      const turboPath = await getTurboPath();
-      if (!turboPath) {
+      const daemonPath = await getDaemonCommandPath();
+      if (!daemonPath) {
         return;
       }
 
-      cp.exec(`${quoteCommand(turboPath)} daemon start`, options, (err) => {
+      cp.exec(`${quoteCommand(daemonPath)} daemon start`, options, (err) => {
         if (err) {
           if (err.message.includes("command not found")) {
             promptGlobalTurbo(useLocalTurbo);
@@ -115,12 +139,12 @@ export function activate(context: ExtensionContext) {
 
   context.subscriptions.push(
     commands.registerCommand("turbo.daemon.stop", async () => {
-      const turboPath = await getTurboPath();
-      if (!turboPath) {
+      const daemonPath = await getDaemonCommandPath();
+      if (!daemonPath) {
         return;
       }
 
-      cp.exec(`${quoteCommand(turboPath)} daemon stop`, options, (err) => {
+      cp.exec(`${quoteCommand(daemonPath)} daemon stop`, options, (err) => {
         if (err) {
           if (err.message.includes("command not found")) {
             promptGlobalTurbo(useLocalTurbo);
@@ -137,12 +161,12 @@ export function activate(context: ExtensionContext) {
 
   context.subscriptions.push(
     commands.registerCommand("turbo.daemon.status", async () => {
-      const turboPath = await getTurboPath();
-      if (!turboPath) {
+      const daemonPath = await getDaemonCommandPath();
+      if (!daemonPath) {
         return;
       }
 
-      cp.exec(`${quoteCommand(turboPath)} daemon status`, options, (err) => {
+      cp.exec(`${quoteCommand(daemonPath)} daemon status`, options, (err) => {
         if (err) {
           if (err.message.includes("command not found")) {
             promptGlobalTurbo(useLocalTurbo);
@@ -240,20 +264,6 @@ export function activate(context: ExtensionContext) {
 
   // If the extension is launched in debug mode then the debug server options are used
   // Otherwise the run options are used
-
-  const packagedLspPath = Uri.joinPath(
-    context.extensionUri,
-    "out",
-    `turborepo-lsp-${process.platform}-${process.arch}${
-      process.platform === "win32" ? ".exe" : ""
-    }`
-  ).fsPath;
-
-  const installedTurboLspPath = findInstalledTurboLsp(
-    workspaceRoot,
-    syncOptions,
-    turboPath
-  );
 
   if (!installedTurboLspPath && !fs.existsSync(packagedLspPath)) {
     window.showInformationMessage(
@@ -363,7 +373,7 @@ function resolveTurboPath(
 
   if (!fs.existsSync(resolvedPath)) {
     logs.appendLine(
-      `manually specified turbo does not exist at path ${turboPath}`
+      `Manually specified turbo does not exist at path ${turboPath}`
     );
     return undefined;
   }


### PR DESCRIPTION
- Use the LSP-capable binary for daemon commands so startup does not require a separate global Turbo CLI.
- Treat expected LSP daemon initialization failures as a single user-facing message instead of triggering vscode-languageclient fallback popups.