### PR TITLE
chore: Release v2.9.11-canary.4

### DIFF
--- a/packages/create-turbo/package.json
+++ b/packages/create-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-turbo",
-  "version": "2.9.11-canary.3",
+  "version": "2.9.11-canary.4",
   "description": "Create a new Turborepo",
   "homepage": "https://turborepo.dev",
   "bugs": {

--- a/packages/eslint-config-turbo/package.json
+++ b/packages/eslint-config-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-turbo",
-  "version": "2.9.11-canary.3",
+  "version": "2.9.11-canary.4",
   "description": "ESLint config for Turborepo",
   "keywords": [
     "eslint",

--- a/packages/eslint-plugin-turbo/package.json
+++ b/packages/eslint-plugin-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-turbo",
-  "version": "2.9.11-canary.3",
+  "version": "2.9.11-canary.4",
   "description": "ESLint plugin for Turborepo",
   "keywords": [
     "eslint",

--- a/packages/turbo-codemod/package.json
+++ b/packages/turbo-codemod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/codemod",
-  "version": "2.9.11-canary.3",
+  "version": "2.9.11-canary.4",
   "description": "Provides Codemod transformations to help upgrade your Turborepo codebase when a feature is deprecated.",
   "homepage": "https://turborepo.dev",
   "bugs": {

--- a/packages/turbo-gen/package.json
+++ b/packages/turbo-gen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/gen",
-  "version": "2.9.11-canary.3",
+  "version": "2.9.11-canary.4",
   "description": "Extend a Turborepo",
   "homepage": "https://turborepo.dev",
   "bugs": {

--- a/packages/turbo-ignore/package.json
+++ b/packages/turbo-ignore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-ignore",
-  "version": "2.9.11-canary.3",
+  "version": "2.9.11-canary.4",
   "description": "",
   "keywords": [],
   "homepage": "https://turborepo.dev",

--- a/packages/turbo-types/package.json
+++ b/packages/turbo-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/types",
-  "version": "2.9.11-canary.3",
+  "version": "2.9.11-canary.4",
   "description": "Turborepo types",
   "homepage": "https://turborepo.dev",
   "bugs": {

--- a/packages/turbo-workspaces/package.json
+++ b/packages/turbo-workspaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/workspaces",
-  "version": "2.9.11-canary.3",
+  "version": "2.9.11-canary.4",
   "description": "Tools for working with package managers",
   "homepage": "https://turborepo.dev",
   "bugs": {

--- a/packages/turbo/package.json
+++ b/packages/turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo",
-  "version": "2.9.11-canary.3",
+  "version": "2.9.11-canary.4",
   "description": "Turborepo is a high-performance build system for JavaScript and TypeScript codebases.",
   "homepage": "https://turborepo.dev",
   "bugs": "https://github.com/vercel/turborepo/issues",
@@ -18,11 +18,11 @@
     "postversion": "node bump-version.js"
   },
   "optionalDependencies": {
-    "@turbo/darwin-64": "2.9.11-canary.3",
-    "@turbo/darwin-arm64": "2.9.11-canary.3",
-    "@turbo/linux-64": "2.9.11-canary.3",
-    "@turbo/linux-arm64": "2.9.11-canary.3",
-    "@turbo/windows-64": "2.9.11-canary.3",
-    "@turbo/windows-arm64": "2.9.11-canary.3"
+    "@turbo/darwin-64": "2.9.11-canary.4",
+    "@turbo/darwin-arm64": "2.9.11-canary.4",
+    "@turbo/linux-64": "2.9.11-canary.4",
+    "@turbo/linux-arm64": "2.9.11-canary.4",
+    "@turbo/windows-64": "2.9.11-canary.4",
+    "@turbo/windows-arm64": "2.9.11-canary.4"
   }
 }

--- a/skills/turborepo/SKILL.md
+++ b/skills/turborepo/SKILL.md
@@ -9,7 +9,7 @@ description: |
   monorepo, shares code between apps, runs changed/affected packages, debugs cache,
   or has apps/packages directories.
 metadata:
-  version: 2.9.11-canary.3
+  version: 2.9.11-canary.4
 ---
 
 # Turborepo Skill
@@ -740,7 +740,7 @@ import { Button } from "@repo/ui/button";
 
 ```json
 {
-  "$schema": "https://v2-9-11-canary-3.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-11-canary-4.turborepo.dev/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],

--- a/skills/turborepo/references/best-practices/structure.md
+++ b/skills/turborepo/references/best-practices/structure.md
@@ -95,7 +95,7 @@ Package tasks enable Turborepo to:
 
 ```json
 {
-  "$schema": "https://v2-9-11-canary-3.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-11-canary-4.turborepo.dev/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
@@ -117,7 +117,7 @@ With `futureFlags.globalConfiguration`, global settings move under a `global` ke
 
 ```json
 {
-  "$schema": "https://v2-9-11-canary-3.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-11-canary-4.turborepo.dev/schema.json",
   "futureFlags": { "globalConfiguration": true },
   "global": {
     "inputs": ["tsconfig.json"],

--- a/skills/turborepo/references/configuration/RULE.md
+++ b/skills/turborepo/references/configuration/RULE.md
@@ -73,7 +73,7 @@ When you run `turbo run lint`, Turborepo finds all packages with a `lint` script
 
 ```json
 {
-  "$schema": "https://v2-9-11-canary-3.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-11-canary-4.turborepo.dev/schema.json",
   "globalEnv": ["CI"],
   "globalDependencies": ["tsconfig.json"],
   "tasks": {
@@ -97,7 +97,7 @@ When the `globalConfiguration` future flag is enabled, global options move under
 
 ```json
 {
-  "$schema": "https://v2-9-11-canary-3.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-11-canary-4.turborepo.dev/schema.json",
   "futureFlags": { "globalConfiguration": true },
   "global": {
     "inputs": ["tsconfig.json"],

--- a/skills/turborepo/references/environment/RULE.md
+++ b/skills/turborepo/references/environment/RULE.md
@@ -107,7 +107,7 @@ When the `globalConfiguration` future flag is enabled, global environment keys m
 
 ```json
 {
-  "$schema": "https://v2-9-11-canary-3.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-11-canary-4.turborepo.dev/schema.json",
   "globalEnv": ["CI", "NODE_ENV"],
   "globalPassThroughEnv": ["GITHUB_TOKEN", "NPM_TOKEN"],
   "tasks": {

--- a/skills/turborepo/references/environment/gotchas.md
+++ b/skills/turborepo/references/environment/gotchas.md
@@ -112,7 +112,7 @@ If you use `.env.development` and `.env.production`, both should be in inputs.
 
 ```json
 {
-  "$schema": "https://v2-9-11-canary-3.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-11-canary-4.turborepo.dev/schema.json",
   "globalEnv": ["CI", "NODE_ENV", "VERCEL"],
   "globalPassThroughEnv": ["GITHUB_TOKEN", "VERCEL_URL"],
   "tasks": {
@@ -146,7 +146,7 @@ The same config using the `global` key. The `.env` files move to `global.inputs`
 
 ```json
 {
-  "$schema": "https://v2-9-11-canary-3.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-11-canary-4.turborepo.dev/schema.json",
   "futureFlags": { "globalConfiguration": true },
   "global": {
     "env": ["CI", "NODE_ENV", "VERCEL"],

--- a/version.txt
+++ b/version.txt
@@ -1,2 +1,2 @@
-2.9.11-canary.3
+2.9.11-canary.4
 canary


### PR DESCRIPTION
## Release v2.9.11-canary.4

> [!CAUTION]
> Versioned docs aliasing failed in the release workflow. [View logs](https://github.com/vercel/turborepo/actions/runs/25561412733)

VS Code extension publishing also failed, but npm packages were published successfully. This PR restores the missing release branch update so `main` reflects the published canary.

### Changes

- ci: Parallelize LSP release publishing (#12758) (`25aba68`)
- fix: Reduce VS Code extension startup popups (#12759) (`3c9ab14`)
- fix: Support `turbo.jsonc` in VS Code extension (#12760) (`3b3776b`)
- fix: Remove VS Code task key gradient (#12761) (`00c43d4`)
- release(turborepo): 2.9.11-canary.3 (#12756) (`bdeb64a`)