### PR TITLE
ci: Stop VS Code publish from blocking release PR

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -8,7 +8,7 @@
 # 4. Publish JS packages to npm and the VS Code extension as parallel worksets
 # 5. Create the git tag (only after npm publish succeeds)
 # 6. Alias versioned docs (e.g., v2-5-4.turborepo.dev)
-# 7. Create a release branch and open a PR
+# 7. Create a release branch and open a PR, even if VS Code publishing fails
 # 8. On failure, cleanup the staging branch and release tag automatically
 #
 # Canary releases run on an hourly schedule.
@@ -618,15 +618,8 @@ jobs:
 
   create-release-pr:
     name: "Create Release PR"
-    needs:
-      [
-        stage,
-        npm-publish,
-        create-release-tag,
-        publish-vscode-extension,
-        alias-versioned-docs
-      ]
-    if: ${{ always() && needs.npm-publish.result == 'success' && needs.create-release-tag.result == 'success' && needs.publish-vscode-extension.result == 'success' && !inputs.dry_run }}
+    needs: [stage, npm-publish, create-release-tag, alias-versioned-docs]
+    if: ${{ always() && needs.npm-publish.result == 'success' && needs.create-release-tag.result == 'success' && !inputs.dry_run }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
@@ -750,7 +743,6 @@ jobs:
         js-smoke-test,
         npm-publish,
         create-release-tag,
-        publish-vscode-extension,
         create-release-pr
       ]
     if: >-
@@ -762,7 +754,6 @@ jobs:
           || needs.js-smoke-test.result == 'failure'
           || needs.npm-publish.result == 'failure'
           || needs.create-release-tag.result == 'failure'
-          || needs.publish-vscode-extension.result == 'failure'
           || needs.create-release-pr.result == 'failure'
         )
       }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,4 +55,4 @@ docs: Update installation instructions
 
 - The `LSP` workflow packages `packages/turbo-vsc` VSIX artifacts for release. Stable and canary Turborepo versions are mapped to Marketplace-safe `major.minor.patch` versions before packaging.
 - Canary VS Code extension packages use `--pre-release`.
-- Non-dry-run releases publish the VS Code extension through the `LSP` workflow using `publish=true`, `dry_run=false`, and a `VSCE_PAT` secret on the protected `vscode-marketplace` environment.
+- Non-dry-run releases publish the VS Code extension through the `LSP` workflow using `publish=true`, `dry_run=false`, and a `VSCE_PAT` secret on the protected `vscode-marketplace` environment. This publish path must not block release PR creation or cleanup published npm release state.


### PR DESCRIPTION
## Summary

- Let release PR creation proceed after npm publish and tag creation even when VS Code extension publishing fails.
- Prevent failed VS Code publishing from triggering cleanup of already-published npm release state.
- Document that Marketplace publishing is non-blocking for release PR recovery.

## Testing

- `pnpm exec oxfmt --check .github/workflows/turborepo-release.yml AGENTS.md`
- YAML parse check for `.github/workflows/turborepo-release.yml`
- DevOps review agent: no findings