### PR TITLE
fix: Support shimmed VS Code LSP probes

### DIFF
--- a/crates/turborepo/src/main.rs
+++ b/crates/turborepo/src/main.rs
@@ -8,6 +8,12 @@ use miette::Report;
 
 const INTERNAL_LSP_COMMAND: &str = "__internal_lsp";
 
+#[derive(Debug, PartialEq)]
+enum InternalLspCommand {
+    Probe,
+    Server,
+}
+
 /// Concrete [`turborepo_query_api::QueryServer`] that delegates to
 /// `turborepo_query`.
 ///
@@ -65,8 +71,8 @@ impl turborepo_query_api::QueryServer for TurboQueryServer {
 // This function should not expanded. Please add any logic to
 // `turborepo_lib::main` instead
 fn main() -> Result<()> {
-    if std::env::args().nth(1).as_deref() == Some(INTERNAL_LSP_COMMAND) {
-        if std::env::args().nth(2).as_deref() == Some("--probe") {
+    if let Some(command) = internal_lsp_command(std::env::args()) {
+        if command == InternalLspCommand::Probe {
             println!("turbo-lsp");
             return Ok(());
         }
@@ -84,4 +90,68 @@ fn main() -> Result<()> {
     });
 
     process::exit(exit_code)
+}
+
+fn internal_lsp_command(args: impl IntoIterator<Item = String>) -> Option<InternalLspCommand> {
+    let mut args = args.into_iter().skip(1);
+    let first_arg = args.next()?;
+    let command_arg = if first_arg == "--skip-infer" {
+        args.next()?
+    } else {
+        first_arg
+    };
+
+    if command_arg != INTERNAL_LSP_COMMAND {
+        return None;
+    }
+
+    if args.next().as_deref() == Some("--probe") {
+        Some(InternalLspCommand::Probe)
+    } else {
+        Some(InternalLspCommand::Server)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{InternalLspCommand, internal_lsp_command};
+
+    fn args(args: &[&str]) -> Vec<String> {
+        args.iter().map(|arg| arg.to_string()).collect()
+    }
+
+    #[test]
+    fn detects_internal_lsp_probe() {
+        assert_eq!(
+            internal_lsp_command(args(&["turbo", "__internal_lsp", "--probe"])),
+            Some(InternalLspCommand::Probe)
+        );
+    }
+
+    #[test]
+    fn detects_shimmed_internal_lsp_probe() {
+        assert_eq!(
+            internal_lsp_command(args(&[
+                "turbo",
+                "--skip-infer",
+                "__internal_lsp",
+                "--probe",
+                "--",
+            ])),
+            Some(InternalLspCommand::Probe)
+        );
+    }
+
+    #[test]
+    fn detects_internal_lsp_server() {
+        assert_eq!(
+            internal_lsp_command(args(&["turbo", "--skip-infer", "__internal_lsp", "--"])),
+            Some(InternalLspCommand::Server)
+        );
+    }
+
+    #[test]
+    fn ignores_regular_turbo_command() {
+        assert_eq!(internal_lsp_command(args(&["turbo", "run", "build"])), None);
+    }
 }

--- a/packages/turbo-vsc/src/extension.ts
+++ b/packages/turbo-vsc/src/extension.ts
@@ -24,6 +24,10 @@ let toolbar: StatusBarItem;
 
 const logs = window.createOutputChannel("Turborepo Extension");
 
+type InternalLspProbeResult =
+  | { supported: true }
+  | { supported: false; reason: string };
+
 export function activate(context: ExtensionContext) {
   const workspaceRoot = workspace.workspaceFolders?.[0]?.uri.fsPath;
   const options = { cwd: workspaceRoot };
@@ -355,7 +359,8 @@ function findInstalledTurboLsp(
       `turbo LSP: probing ${candidate.label} at ${candidate.path}`
     );
 
-    if (supportsInternalLsp(candidate.path, options)) {
+    const probe = probeInternalLsp(candidate.path, options);
+    if (probe.supported) {
       logs.appendLine(
         `turbo LSP: using ${candidate.label} at ${candidate.path}`
       );
@@ -363,29 +368,81 @@ function findInstalledTurboLsp(
     }
 
     logs.appendLine(
-      `turbo LSP: ${candidate.label} does not support internal LSP`
+      `turbo LSP: rejected ${candidate.label} at ${candidate.path}: ${probe.reason}`
     );
   }
 
-  logs.appendLine("turbo LSP: falling back to packaged LSP binary");
+  logs.appendLine(
+    "turbo LSP: no installed turbo candidate supports internal LSP; falling back to packaged LSP binary"
+  );
 }
 
-function supportsInternalLsp(
+function probeInternalLsp(
   turboPath: string,
   options: cp.ExecSyncOptionsWithStringEncoding
-) {
+): InternalLspProbeResult {
   try {
-    return (
-      cp
-        .execSync(`${quoteCommand(turboPath)} __internal_lsp --probe`, {
-          ...options,
-          timeout: 1000
-        })
-        .trim() === "turbo-lsp"
-    );
+    const output = cp
+      .execSync(`${quoteCommand(turboPath)} __internal_lsp --probe`, {
+        ...options,
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 1000
+      })
+      .trim();
+
+    if (output === "turbo-lsp") {
+      return { supported: true };
+    }
+
+    return { supported: false, reason: formatProbeOutput(output) };
   } catch (e) {
-    return false;
+    return { supported: false, reason: formatProbeError(e) };
   }
+}
+
+function formatProbeOutput(output: string) {
+  const line = firstNonEmptyLine(output);
+  return line ? `unexpected probe output: ${line}` : "empty probe output";
+}
+
+function formatProbeError(error: unknown) {
+  const stderr = outputFromError(error, "stderr");
+  if (stderr) {
+    return firstNonEmptyLine(stderr) ?? "probe command failed with stderr";
+  }
+
+  const stdout = outputFromError(error, "stdout");
+  if (stdout) {
+    return `probe command failed with stdout: ${firstNonEmptyLine(stdout)}`;
+  }
+
+  if (error instanceof Error && error.message) {
+    return firstNonEmptyLine(error.message) ?? error.message;
+  }
+
+  return "probe command failed";
+}
+
+function outputFromError(error: unknown, key: "stdout" | "stderr") {
+  if (typeof error !== "object" || error === null || !(key in error)) {
+    return;
+  }
+
+  const output = (error as Record<string, unknown>)[key];
+  if (Buffer.isBuffer(output)) {
+    return output.toString("utf8").trim();
+  }
+
+  if (typeof output === "string") {
+    return output.trim();
+  }
+}
+
+function firstNonEmptyLine(output: string) {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean);
 }
 
 async function promptGlobalTurbo(useLocalTurbo: boolean) {


### PR DESCRIPTION
- Fixes VS Code extension LSP probing when a global turbo shim delegates to a local turbo with `--skip-infer`.
- Adds clearer candidate resolution logs and keeps failed probe stderr out of VS Code's Window error log.