### PR TITLE
fix(docs): prevent navbar wordmark from overlapping mobile nav buttons

### DIFF
--- a/apps/docs/geistdocs.tsx
+++ b/apps/docs/geistdocs.tsx
@@ -6,11 +6,11 @@ import {
 
 export const Logo = () => (
   <>
-    {/* Logo icon only on screens <= 400px and between 768px-940px */}
-    <TurborepoLogo className="block h-6 w-auto min-[401px]:hidden min-[768px]:block min-[941px]:hidden" />
-    {/* Wordmark on screens 401px-767px and > 940px */}
-    <TurborepoWordmarkDark className="hidden h-6 w-auto dark:min-[401px]:block dark:min-[768px]:hidden dark:min-[941px]:block" />
-    <TurborepoWordmarkLight className="hidden h-6 w-auto min-[401px]:block dark:min-[401px]:hidden min-[768px]:hidden min-[941px]:block dark:min-[941px]:hidden" />
+    {/* Logo icon only on screens <= 480px and between 768px-940px */}
+    <TurborepoLogo className="block h-6 w-auto min-[481px]:hidden min-[768px]:block min-[941px]:hidden" />
+    {/* Wordmark on screens 481px-767px and > 940px */}
+    <TurborepoWordmarkDark className="hidden h-6 w-auto dark:min-[481px]:block dark:min-[768px]:hidden dark:min-[941px]:block" />
+    <TurborepoWordmarkLight className="hidden h-6 w-auto min-[481px]:block dark:min-[481px]:hidden min-[768px]:hidden min-[941px]:block dark:min-[941px]:hidden" />
   </>
 );
 


### PR DESCRIPTION
### Description

Fixes #12776 

At viewport widths between ~401px and ~450px, the Turborepo wordmark and the mobile navigation buttons (search, Ask AI, menu) didn't have enough horizontal space to coexist, causing the menu icon to overlap the Ask AI button.

The wordmark visibility in `geistdocs.tsx` switches at `min-[401px]`, but the navbar's right section which holds the mobile search icon, Ask AI button, and menu icon needs roughly 160px of space. At ~420px viewport, only ~150px remains after the wordmark's left section, which is enough to cause the overflow.

Raising the threshold to `min-[481px]` gives ~38px of breathing room at the transition point. The icon-only logo is shown in the 401–480px range instead, consistent with the existing behavior at ≤400px. All other breakpoints (`768px`, `941px`) are unchanged.

**Changed file:** `apps/docs/geistdocs.tsx`  
**Change:** 4 occurrences of `min-[401px]` → `min-[481px]`

| Before (~420px) | After (~420px) |
|---|---|
| <img width="420" height="522" alt="tr-i-420px" src="https://github.com/user-attachments/assets/81f931e7-9c17-429d-954d-16dcf14e5869" /> | <img width="420" height="522" alt="tr-p-420px" src="https://github.com/user-attachments/assets/ea673ea5-4e74-48c9-bb26-c7e6e66bf2c6" /> |

| Before (iPhone 17 Pro) | After (iPhone 17 Pro) |
|---|---|
| <img width="1206" height="2454" alt="tr-b" src="https://github.com/user-attachments/assets/e626440b-02bc-40fd-afa0-2a17e8f58227" /> | <img width="1206" height="2423" alt="tr-a" src="https://github.com/user-attachments/assets/2e426b16-4f24-497c-ad31-f53df69984ab" />|

### Testing Instructions

1. Open the site in a browser with DevTools responsive mode
2. Drag viewport between **401px – 480px** → icon-only logo, no overlap between Ask AI and menu icon
3. Drag viewport to **481px** → wordmark appears, all elements fit cleanly
4. Confirm existing breakpoints are unaffected:
   - ≤400px → icon only
   - 481px–767px → wordmark
   - 768px–940px → icon only
   - 941px+ → wordmark
5. Verify on a real mobile device if possible (tested on iOS and Android)