### PR TITLE
fix(docs): mobile navigation menu

### DIFF
--- a/apps/docs/components/geistdocs/docs-layout.tsx
+++ b/apps/docs/components/geistdocs/docs-layout.tsx
@@ -1,4 +1,9 @@
 import { DocsLayout as FumadocsDocsLayout } from "fumadocs-ui/layouts/docs";
+import {
+  SidebarProvider,
+  SidebarTrigger,
+  useSidebar
+} from "fumadocs-ui/layouts/docs/slots/sidebar";
 import type { ComponentProps, CSSProperties, ReactNode } from "react";
 import {
   Folder,
@@ -29,11 +34,18 @@ export const DocsLayout = ({ tree, children }: DocsLayoutProps) => (
     }}
     sidebar={{
       collapsible: false,
-      component: <Sidebar />,
       components: {
         Folder,
         Item,
         Separator
+      }
+    }}
+    slots={{
+      sidebar: {
+        provider: SidebarProvider,
+        root: Sidebar,
+        trigger: SidebarTrigger,
+        useSidebar
       }
     }}
     tabMode="auto"

--- a/apps/docs/components/geistdocs/home-layout.tsx
+++ b/apps/docs/components/geistdocs/home-layout.tsx
@@ -1,4 +1,9 @@
 import { DocsLayout as FumadocsDocsLayout } from "fumadocs-ui/layouts/docs";
+import {
+  SidebarProvider,
+  SidebarTrigger,
+  useSidebar
+} from "fumadocs-ui/layouts/docs/slots/sidebar";
 import type { ComponentProps, CSSProperties, ReactNode } from "react";
 import { i18n } from "@/lib/geistdocs/i18n";
 import { Folder, Item, Separator, Sidebar } from "./sidebar";
@@ -28,11 +33,18 @@ export const HomeLayout = ({ tree, children }: HomeLayoutProps) => (
     sidebar={{
       className: "md:hidden",
       collapsible: false,
-      component: <Sidebar />,
       components: {
         Folder,
         Item,
         Separator
+      }
+    }}
+    slots={{
+      sidebar: {
+        provider: SidebarProvider,
+        root: Sidebar,
+        trigger: SidebarTrigger,
+        useSidebar
       }
     }}
     tabMode="auto"


### PR DESCRIPTION
### Description

Fixes #12778 

While working on (#12777), I noticed a second issue: the menu button does nothing when tapped on mobile. No drawer opens on any page.

I kept this as a separate PR. The two bugs are independent: one is a CSS breakpoint mismatch, the other is a component mounting problem. Bundling unrelated fixes makes review harder and attribution less clear. Hope that's the right call.

---

**What was wrong**

The custom `Sidebar` component which contains the mobile navigation drawer was passed to `fumadocs-ui` via the `sidebar.component` prop. In the fumadocs source, `sidebar.component` is marked `@deprecated` ([`packages/base-ui/src/layouts/docs/index.tsx`](https://github.com/fuma-nama/fumadocs/blob/dev/packages/base-ui/src/layouts/docs/index.tsx)):

```ts
/**
 * @deprecated use `slots.sidebar` instead.
 */
component?: ReactNode;
```

Because the drawer component was never mounted, clicking `MobileMenu` updated the shared state atom but nothing responded to it. the drawer was simply not in the DOM.

**What changed**

Replaced `sidebar.component` with `slots.sidebar`. The change is in two layout files:

- `apps/docs/components/geistdocs/home-layout.tsx`
- `apps/docs/components/geistdocs/docs-layout.tsx`

No changes to the `Sidebar` component itself, the state management, or anything else.

```tsx
// Before (deprecated, silently no-op at runtime)
sidebar={{
  component: <Sidebar />,
  ...
}}

// After
sidebar={{ ... }}
slots={{
  sidebar: {
    provider: SidebarProvider,
    root: Sidebar,
    trigger: SidebarTrigger,
    useSidebar
  }
}}
```

**After:**

https://github.com/user-attachments/assets/e298a135-7ddf-488b-9765-00239db6909c

---

### Testing Instructions
1. Open https://turborepo.dev on a browser window (below ~910px)
2. Tap the menu icon in the top-right of the navbar
3. The navigation drawer should open
4. Repeat on a docs page (e.g. https://turborepo.dev/docs)