### PR TITLE
fix: Restore docs mobile menu

### DIFF
--- a/apps/docs/components/geistdocs/docs-layout.tsx
+++ b/apps/docs/components/geistdocs/docs-layout.tsx
@@ -4,7 +4,7 @@ import {
   Folder,
   Item,
   Separator,
-  Sidebar
+  sidebarSlots
 } from "@/components/geistdocs/sidebar";
 import { i18n } from "@/lib/geistdocs/i18n";
 
@@ -29,12 +29,14 @@ export const DocsLayout = ({ tree, children }: DocsLayoutProps) => (
     }}
     sidebar={{
       collapsible: false,
-      component: <Sidebar />,
       components: {
         Folder,
         Item,
         Separator
       }
+    }}
+    slots={{
+      sidebar: sidebarSlots
     }}
     tabMode="auto"
     themeSwitch={{

--- a/apps/docs/components/geistdocs/home-layout.tsx
+++ b/apps/docs/components/geistdocs/home-layout.tsx
@@ -1,7 +1,7 @@
 import { DocsLayout as FumadocsDocsLayout } from "fumadocs-ui/layouts/docs";
 import type { ComponentProps, CSSProperties, ReactNode } from "react";
 import { i18n } from "@/lib/geistdocs/i18n";
-import { Folder, Item, Separator, Sidebar } from "./sidebar";
+import { Folder, Item, Separator, sidebarSlots } from "./sidebar";
 
 type HomeLayoutProps = {
   tree: ComponentProps<typeof FumadocsDocsLayout>["tree"];
@@ -28,12 +28,14 @@ export const HomeLayout = ({ tree, children }: HomeLayoutProps) => (
     sidebar={{
       className: "md:hidden",
       collapsible: false,
-      component: <Sidebar />,
       components: {
         Folder,
         Item,
         Separator
       }
+    }}
+    slots={{
+      sidebar: sidebarSlots
     }}
     tabMode="auto"
     themeSwitch={{

--- a/apps/docs/components/geistdocs/mobile-menu.tsx
+++ b/apps/docs/components/geistdocs/mobile-menu.tsx
@@ -10,13 +10,13 @@ type MobileMenuProps = {
 };
 
 export const MobileMenu = ({ className }: MobileMenuProps) => {
-  const { isOpen, setIsOpen } = useSidebarContext();
+  const { setIsOpen } = useSidebarContext();
 
   return (
     <Button
       aria-label="Toggle navigation menu"
       className={cn(className)}
-      onClick={() => setIsOpen(!isOpen)}
+      onClick={() => setIsOpen((open) => !open)}
       size="icon-sm"
       variant="ghost"
     >

--- a/apps/docs/components/geistdocs/sidebar.tsx
+++ b/apps/docs/components/geistdocs/sidebar.tsx
@@ -2,6 +2,12 @@
 
 import type { Node } from "fumadocs-core/page-tree";
 import DynamicLink from "fumadocs-core/dynamic-link";
+import type { DocsSlots } from "fumadocs-ui/layouts/docs";
+import {
+  SidebarProvider,
+  SidebarTrigger,
+  useSidebar
+} from "fumadocs-ui/layouts/docs/slots/sidebar";
 import {
   SidebarFolder,
   SidebarFolderContent,
@@ -24,35 +30,47 @@ import {
 } from "@/components/ui/sheet";
 import { github, nav } from "@/geistdocs";
 import { useSidebarContext } from "@/hooks/geistdocs/use-sidebar";
+import { cn } from "@/lib/utils";
 import { SearchButton } from "./search";
 import { VersionWarning } from "@/components/version-warning";
 
-export const Sidebar = () => {
+export const Sidebar: DocsSlots["sidebar"]["root"] = ({
+  className,
+  components
+}) => {
   const { root } = useTreeContext();
   const { isOpen, setIsOpen } = useSidebarContext();
+  const {
+    Folder: FolderComponent = Folder,
+    Item: ItemComponent = Item,
+    Separator: SeparatorComponent = Separator
+  } = components ?? {};
 
   const renderSidebarList = (items: Node[]) =>
     items.map((item) => {
       if (item.type === "separator") {
-        return <Separator item={item} key={item.$id} />;
+        return <SeparatorComponent item={item} key={item.$id} />;
       }
 
       if (item.type === "folder") {
         const children = renderSidebarList(item.children);
         return (
-          <Folder item={item} key={item.$id}>
+          <FolderComponent item={item} key={item.$id}>
             {children}
-          </Folder>
+          </FolderComponent>
         );
       }
 
-      return <Item item={item} key={item.$id} />;
+      return <ItemComponent item={item} key={item.$id} />;
     });
 
   return (
     <>
       <div
-        className="pointer-events-none sticky top-(--fd-docs-row-1) z-20 h-[calc(var(--fd-docs-height)-var(--fd-docs-row-1))] [grid-area:sidebar] *:pointer-events-auto max-md:hidden md:layout:[--fd-sidebar-width:268px]"
+        className={cn(
+          "pointer-events-none sticky top-(--fd-docs-row-1) z-20 h-[calc(var(--fd-docs-height)-var(--fd-docs-row-1))] [grid-area:sidebar] *:pointer-events-auto max-md:hidden md:layout:[--fd-sidebar-width:268px]",
+          className
+        )}
         data-sidebar-placeholder
       >
         <div className="px-4 pt-12 pb-4 h-full overflow-y-auto">
@@ -115,6 +133,13 @@ export const Sidebar = () => {
       </Sheet>
     </>
   );
+};
+
+export const sidebarSlots: DocsSlots["sidebar"] = {
+  provider: SidebarProvider,
+  root: Sidebar,
+  trigger: SidebarTrigger,
+  useSidebar
 };
 
 export const Folder: SidebarPageTreeComponents["Folder"] = ({

--- a/apps/docs/geistdocs.tsx
+++ b/apps/docs/geistdocs.tsx
@@ -6,11 +6,11 @@ import {
 
 export const Logo = () => (
   <>
-    {/* Logo icon only on screens <= 400px and between 768px-940px */}
-    <TurborepoLogo className="block h-6 w-auto min-[401px]:hidden min-[768px]:block min-[941px]:hidden" />
-    {/* Wordmark on screens 401px-767px and > 940px */}
-    <TurborepoWordmarkDark className="hidden h-6 w-auto dark:min-[401px]:block dark:min-[768px]:hidden dark:min-[941px]:block" />
-    <TurborepoWordmarkLight className="hidden h-6 w-auto min-[401px]:block dark:min-[401px]:hidden min-[768px]:hidden min-[941px]:block dark:min-[941px]:hidden" />
+    {/* Logo icon only on screens <= 480px and between 768px-940px */}
+    <TurborepoLogo className="block h-6 w-auto min-[481px]:hidden min-[768px]:block min-[941px]:hidden" />
+    {/* Wordmark on screens 481px-767px and > 940px */}
+    <TurborepoWordmarkDark className="hidden h-6 w-auto dark:min-[481px]:block dark:min-[768px]:hidden dark:min-[941px]:block" />
+    <TurborepoWordmarkLight className="hidden h-6 w-auto min-[481px]:block dark:min-[481px]:hidden min-[768px]:hidden min-[941px]:block dark:min-[941px]:hidden" />
   </>
 );
 


### PR DESCRIPTION
## Summary
- Restores the custom docs sidebar slot so the mobile menu button opens the navigation drawer again.
- Keeps the compact Turborepo logo through narrow mobile widths to avoid navbar overlap.

## Testing
- `pnpm --filter docs lint`
- `pnpm --filter docs exec tsc --noEmit --pretty false` currently fails on existing docs type issues: missing `content/examples-data.json`, MDX component typing, and OpenAPI schema typing.
- `NEXT_TELEMETRY_DISABLED=1 pnpm --filter docs exec next build` currently fails on the same missing `content/examples-data.json`.

Fixes #12778
Addresses #12776