### PR TITLE
ci: Use `pull_request` for PR title linting

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,7 +1,7 @@
 name: Lint pull request title
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited


### PR DESCRIPTION
- Removes `pull_request_target` from the PR title lint workflow so it no longer runs with target-repo privileges.
- Keeps the same PR title validation behavior on normal `pull_request` events.