### PR TITLE
ci: Scope GitHub Actions caches by branch

### DIFF
--- a/.github/actions/setup-capnproto/action.yml
+++ b/.github/actions/setup-capnproto/action.yml
@@ -18,7 +18,7 @@ runs:
         path: |
           /usr/bin/capnp
           /usr/bin/capnpc
-        key: ${{ runner.os }}-capnproto-1.1.0
+        key: ${{ runner.os }}-${{ github.head_ref || github.ref_name }}-capnproto-1.1.0
 
     - name: "Setup capnproto for Linux"
       if: runner.os == 'Linux' && (steps.cache-capnp-linux.outcome == 'skipped' || steps.cache-capnp-linux.outputs.cache-hit != 'true')
@@ -52,7 +52,7 @@ runs:
       id: cache-capnp-windows
       with:
         path: C:\capnproto
-        key: ${{ runner.os }}-capnproto-1.1.0
+        key: ${{ runner.os }}-${{ github.head_ref || github.ref_name }}-capnproto-1.1.0
 
     - name: "Setup capnproto for Windows"
       if: runner.os == 'Windows' && (steps.cache-capnp-windows.outcome == 'skipped' || steps.cache-capnp-windows.outputs.cache-hit != 'true')

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -29,7 +29,6 @@ runs:
         # node-version-file is the default, but can be overridden using node-version
         node-version-file: "package.json"
         node-version: ${{ inputs.node-version }}
-        cache: ${{ inputs.package-install == 'true' && 'pnpm' || '' }}
 
     - name: Upgrade corepack
       if: ${{ inputs.enable-corepack == 'true' }}
@@ -45,6 +44,21 @@ runs:
       if: ${{ inputs.enable-corepack == 'true' }}
       shell: bash
       run: corepack enable
+
+    - name: Get pnpm store path
+      if: ${{ inputs.package-install == 'true' }}
+      id: pnpm-store
+      shell: bash
+      run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+    - name: Cache pnpm store
+      if: ${{ inputs.package-install == 'true' }}
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ${{ steps.pnpm-store.outputs.path }}
+        key: ${{ runner.os }}-${{ runner.arch }}-pnpm-${{ github.head_ref || github.ref_name }}-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-pnpm-${{ github.head_ref || github.ref_name }}-
 
     - name: pnpm install
       id: install

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -48,7 +48,7 @@ runs:
       if: inputs.cache == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
       uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
       with:
-        shared-key: ${{ inputs.shared-cache-key }}
-        key: ${{ inputs.cache-key }}
+        shared-key: ${{ inputs.shared-cache-key && format('{0}-{1}', github.head_ref || github.ref_name, inputs.shared-cache-key) || '' }}
+        key: ${{ inputs.cache-key && format('{0}-{1}', github.head_ref || github.ref_name, inputs.cache-key) || (github.head_ref || github.ref_name) }}
         # the cache is huge and we only get 10gb max, so we only save on master
         save-if: ${{ github.ref == 'refs/heads/main' && inputs.save-cache || 'false' }}


### PR DESCRIPTION
- Scopes GitHub Actions caches to the current branch so unrelated branches do not share pnpm, Rust, or Cap'n Proto cache entries.
- Keeps same-branch restore behavior while avoiding cross-branch cache pollution.