### PR TITLE
test: Validate lockfiles without dependency downloads

### DIFF
--- a/lockfile-tests/check-lockfiles.ts
+++ b/lockfile-tests/check-lockfiles.ts
@@ -2,13 +2,13 @@
  * check-lockfiles.ts
  *
  * End-to-end validation that turborepo's lockfile pruning produces lockfiles
- * that pass frozen-lockfile installs for every supported package manager.
+ * that package managers accept without downloading packages.
  *
  * Each fixture under lockfile-tests/fixtures/ is a complete monorepo with a
- * meta.json describing the package manager, frozen install command, and which
+ * meta.json describing the package manager, lockfile, and which
  * workspaces to prune to. This script copies each fixture into a temp
- * directory, runs `turbo prune` for every target workspace, then runs the
- * frozen install to prove the pruned lockfile is valid.
+ * directory, runs `turbo prune` for every target workspace, then validates the
+ * pruned lockfile with the package manager.
  *
  * Usage:
  *   pnpm check-lockfiles                                         # All fixtures
@@ -35,9 +35,8 @@ interface FixtureMeta {
   packageManager: PackageManagerType;
   packageManagerVersion: string;
   lockfileName: string;
-  frozenInstallCommand: string[];
   pruneTargets?: string[];
-  /** Workspace names where pruning or frozen install is known to fail. */
+  /** Workspace names where pruning or lockfile validation is known to fail. */
   expectedFailures?: string[];
 }
 
@@ -210,7 +209,6 @@ function buildTestCases(
           filepath: fixture.dir,
           packageManager: fixture.meta.packageManager,
           lockfileName: fixture.meta.lockfileName,
-          frozenInstallCommand: fixture.meta.frozenInstallCommand,
           packageManagerVersion: fixture.meta.packageManagerVersion
         },
         targetWorkspace: { name: target },
@@ -367,10 +365,10 @@ async function main(): Promise<void> {
       status = "PASS";
     } else if (expectedFailures.has(r.label)) {
       status = r.pruneSuccess
-        ? "EXPECTED FAIL (install)"
+        ? "EXPECTED FAIL (validation)"
         : "EXPECTED FAIL (prune)";
     } else {
-      status = r.pruneSuccess ? "FAIL (install)" : "FAIL (prune)";
+      status = r.pruneSuccess ? "FAIL (validation)" : "FAIL (prune)";
     }
     console.log(
       `  ${status} ${r.label} (${(r.durationMs / 1000).toFixed(1)}s)`

--- a/lockfile-tests/runners/local.ts
+++ b/lockfile-tests/runners/local.ts
@@ -95,7 +95,8 @@ function lockfileValidationCommand(
         acceptsFailure(result) {
           const output = combinedOutput(result);
           return (
-            output.includes("Lockfile is up to date") &&
+            (output.includes("Lockfile is up to date") ||
+              output.includes("Already up to date")) &&
             output.includes("ERR_PNPM_NO_OFFLINE_TARBALL")
           );
         }

--- a/lockfile-tests/runners/local.ts
+++ b/lockfile-tests/runners/local.ts
@@ -4,11 +4,24 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { PackageManagerType, TestCase, TestResult } from "../types";
 
+interface ExecResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+interface LockfileValidationCommand {
+  command: string;
+  env?: Record<string, string>;
+  acceptsFailure?: (result: ExecResult) => boolean;
+  verifyLockfileUnchanged?: boolean;
+}
+
 function exec(
   command: string,
   cwd: string,
   env?: Record<string, string>
-): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+): Promise<ExecResult> {
   return new Promise((resolve) => {
     execCb(
       command,
@@ -41,6 +54,16 @@ function exec(
   });
 }
 
+function combinedOutput(result: ExecResult): string {
+  return [result.stdout, result.stderr].filter(Boolean).join("\n");
+}
+
+function readLockfile(cwd: string, lockfileName: string): Buffer | null {
+  const lockfilePath = path.join(cwd, lockfileName);
+  if (!fs.existsSync(lockfilePath)) return null;
+  return fs.readFileSync(lockfilePath);
+}
+
 function copyDirSync(src: string, dest: string): void {
   fs.mkdirSync(dest, { recursive: true });
   for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
@@ -54,25 +77,65 @@ function copyDirSync(src: string, dest: string): void {
   }
 }
 
-function lightweightValidationCommand(
+function lockfileValidationCommand(
   pm: PackageManagerType,
-  frozenInstallCommand: string[]
-): string {
+  cwd: string
+): LockfileValidationCommand {
   switch (pm) {
     case "pnpm": {
-      return "pnpm install --frozen-lockfile --lockfile-only";
+      // Offline mode proves the frozen lockfile is accepted before pnpm can
+      // fetch missing tarballs into the empty validation store.
+      const storeDir = path.join(cwd, ".pnpm-validation-store");
+      fs.rmSync(storeDir, { recursive: true, force: true });
+      fs.mkdirSync(storeDir, { recursive: true });
+
+      return {
+        command:
+          "pnpm install --frozen-lockfile --ignore-scripts --offline --store-dir ./.pnpm-validation-store",
+        acceptsFailure(result) {
+          const output = combinedOutput(result);
+          return (
+            output.includes("Lockfile is up to date") &&
+            output.includes("ERR_PNPM_NO_OFFLINE_TARBALL")
+          );
+        }
+      };
     }
     case "npm": {
-      return "npm install --package-lock-only --ignore-scripts";
+      return {
+        command: "npm ci --dry-run --ignore-scripts --no-audit --no-fund"
+      };
     }
     case "yarn": {
-      return "yarn install --frozen-lockfile --ignore-scripts";
+      // Yarn Classic has no lockfile-only mode. With an empty offline cache,
+      // reaching the fetch step proves resolution accepted the lockfile.
+      const cacheFolder = path.join(cwd, ".yarn-offline-cache");
+      fs.rmSync(cacheFolder, { recursive: true, force: true });
+      fs.mkdirSync(cacheFolder, { recursive: true });
+
+      return {
+        command:
+          "yarn install --frozen-lockfile --ignore-scripts --offline --cache-folder ./.yarn-offline-cache",
+        acceptsFailure(result) {
+          const output = combinedOutput(result);
+          return (
+            output.includes("[2/4] Fetching packages") &&
+            output.includes("Can't make a request in offline mode")
+          );
+        }
+      };
     }
     case "yarn-berry": {
-      return "yarn install --immutable --mode=skip-build";
+      return {
+        command: "yarn install --mode=update-lockfile",
+        verifyLockfileUnchanged: true
+      };
     }
     case "bun": {
-      return frozenInstallCommand.join(" ");
+      return {
+        command: "bun install --frozen-lockfile",
+        env: { BUN_CONFIG_SKIP_INSTALL_PACKAGES: "1" }
+      };
     }
   }
 }
@@ -205,26 +268,25 @@ export class LocalRunner {
         console.log
       );
 
-      const validationCmd = lightweightValidationCommand(
+      const validation = lockfileValidationCommand(
         fixture.packageManager,
-        fixture.frozenInstallCommand
+        tmpDir
       );
       console.log(
-        `[${fixture.filename}] Validating fixture (${validationCmd})...`
+        `[${fixture.filename}] Validating fixture (${validation.command})...`
       );
-      const result = await exec(validationCmd, tmpDir, {
-        PATH: fullPath,
-        COREPACK_ENABLE_STRICT: "0"
-      });
+      const validationResult = await this.runLockfileValidation(
+        fixture,
+        tmpDir,
+        fullPath,
+        validation
+      );
 
-      if (result.exitCode !== 0) {
-        const output = [result.stdout, result.stderr]
-          .filter(Boolean)
-          .join("\n");
+      if (validationResult.error) {
         return (
-          `INVALID FIXTURE: frozen install fails on unpruned original (exit ${result.exitCode}).\n` +
+          `INVALID FIXTURE: lockfile validation fails on unpruned original.\n` +
           `This means the fixture's package.jsons don't match its lockfile.\n` +
-          `Fix the fixture or rebuild it from a real repo.\n\n${output}`
+          `Fix the fixture or rebuild it from a real repo.\n\n${validationResult.error}`
         );
       }
 
@@ -233,6 +295,59 @@ export class LocalRunner {
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
+  }
+
+  private async runLockfileValidation(
+    fixture: TestCase["fixture"],
+    cwd: string,
+    fullPath: string,
+    validation: LockfileValidationCommand
+  ): Promise<{ output: string; error: string | null }> {
+    const before = readLockfile(cwd, fixture.lockfileName);
+    if (before === null) {
+      return {
+        output: "",
+        error: `Lockfile not found before validation: ${fixture.lockfileName}`
+      };
+    }
+
+    const result = await exec(validation.command, cwd, {
+      PATH: fullPath,
+      COREPACK_ENABLE_STRICT: "0",
+      ...validation.env
+    });
+    const output = combinedOutput(result);
+    const success =
+      result.exitCode === 0 || (validation.acceptsFailure?.(result) ?? false);
+
+    if (!success) {
+      return {
+        output,
+        error: `Lockfile validation failed (exit ${result.exitCode}).\n\n${output}`
+      };
+    }
+
+    if (validation.verifyLockfileUnchanged) {
+      const after = readLockfile(cwd, fixture.lockfileName);
+      if (after === null) {
+        return {
+          output,
+          error: `Lockfile not found after validation: ${fixture.lockfileName}`
+        };
+      }
+
+      if (!before.equals(after)) {
+        return {
+          output,
+          error:
+            `Lockfile validation changed ${fixture.lockfileName}.\n` +
+            "The lockfile is not valid for the current package.json files.\n\n" +
+            output
+        };
+      }
+    }
+
+    return { output, error: null };
   }
 
   /**
@@ -280,7 +395,7 @@ export class LocalRunner {
           label: tc.label,
           success: false,
           pruneSuccess: false,
-          installSuccess: false,
+          validationSuccess: false,
           error: validationError,
           durationMs: 0
         });
@@ -300,7 +415,6 @@ export class LocalRunner {
         turboBinaryPath,
         console.log
       );
-      const installCmd = fixture.frozenInstallCommand.join(" ");
 
       // Git init once for all workspace targets
       await exec(
@@ -324,7 +438,7 @@ export class LocalRunner {
           label,
           success: false,
           pruneSuccess: false,
-          installSuccess: false,
+          validationSuccess: false,
           durationMs: 0
         };
 
@@ -352,30 +466,31 @@ export class LocalRunner {
           result.pruneSuccess = true;
           log(`[${label}] Prune succeeded`);
 
-          // Frozen install in pruned output
+          // Validate the pruned lockfile without downloading packages.
           const outDir = path.join(tmpDir, "out");
-          log(`[${label}] ${installCmd} (in out/)`);
+          const validation = lockfileValidationCommand(
+            fixture.packageManager,
+            outDir
+          );
+          log(`[${label}] ${validation.command} (lockfile validation in out/)`);
 
-          const installResult = await exec(installCmd, outDir, {
-            PATH: fullPath,
-            COREPACK_ENABLE_STRICT: "0"
-          });
+          const validationResult = await this.runLockfileValidation(
+            fixture,
+            outDir,
+            fullPath,
+            validation
+          );
+          result.validationOutput = validationResult.output;
 
-          result.installOutput = [installResult.stdout, installResult.stderr]
-            .filter(Boolean)
-            .join("\n");
-
-          if (installResult.exitCode !== 0) {
-            log(
-              `[${label}] FROZEN INSTALL FAILED (exit ${installResult.exitCode})`
-            );
-            result.error = `Frozen install failed:\n${result.installOutput}`;
+          if (validationResult.error) {
+            log(`[${label}] LOCKFILE VALIDATION FAILED`);
+            result.error = validationResult.error;
             result.durationMs = Date.now() - startTime;
             results.push(result);
             continue;
           }
 
-          result.installSuccess = true;
+          result.validationSuccess = true;
           result.success = true;
           log(`[${label}] PASSED`);
         } catch (err) {

--- a/lockfile-tests/types.ts
+++ b/lockfile-tests/types.ts
@@ -6,7 +6,6 @@ export interface TestCase {
     filepath: string;
     packageManager: PackageManagerType;
     lockfileName: string;
-    frozenInstallCommand: string[];
     packageManagerVersion: string;
   };
   targetWorkspace: {
@@ -20,9 +19,9 @@ export interface TestResult {
   label: string;
   success: boolean;
   pruneSuccess: boolean;
-  installSuccess: boolean;
+  validationSuccess: boolean;
   pruneOutput?: string;
-  installOutput?: string;
+  validationOutput?: string;
   error?: string;
   durationMs: number;
 }


### PR DESCRIPTION
## Summary
- Avoids full dependency installs in lockfile pruning checks while preserving package-manager validation of pruned lockfiles.
- Uses no-download validation paths for npm, pnpm, Yarn Classic, Yarn Berry, and Bun.

## Testing
- `pnpm --package=oxfmt@0.34.0 dlx oxfmt --check lockfile-tests/check-lockfiles.ts lockfile-tests/runners/local.ts lockfile-tests/types.ts`
- `pnpm --package=tsx@4.21.0 dlx tsx lockfile-tests/check-lockfiles.ts --fixture does-not-exist`
- Exercised validation probes for npm, pnpm 7/8/10, Yarn Classic, Yarn Berry, plus stale-lockfile negative probes.
- Pre-push hook ran format, TOML format check, and Rust checks successfully.