### PR TITLE
fix: Wait for process group on the normal task exit path

### DIFF
--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -781,7 +781,39 @@ impl Child {
                 }
                 status = child.wait() => {
                     drop(controller);
-                    manager.handle_child_exit(status).await;
+
+                    // After the direct child exits, wait for any descendants in
+                    // the tracked process group to finish before signalling task
+                    // completion. Without this, dependent tasks can be scheduled
+                    // before subprocesses have written their declared `outputs`.
+                    // The `wait_for_process_group_after_child_exit` flag was
+                    // flipped to true in #12699, but the wait was only wired
+                    // into the graceful-shutdown path. Fixes #12786.
+                    #[cfg(unix)]
+                    let killed_during_drain = if let Some(pid) = pid {
+                        let mut command_rx_open = true;
+                        child
+                            .wait_for_process_group_exit(
+                                pid as libc::pid_t,
+                                None,
+                                &mut command_rx,
+                                &mut command_rx_open,
+                            )
+                            .await
+                            == ChildExit::Killed
+                    } else {
+                        false
+                    };
+                    #[cfg(not(unix))]
+                    let killed_during_drain = false;
+
+                    if killed_during_drain {
+                        // Kill command arrived during the drain wait; honour it
+                        // instead of reporting the child's natural exit.
+                        manager.exit_tx.send(Some(ChildExit::Killed)).ok();
+                    } else {
+                        manager.handle_child_exit(status).await;
+                    }
                 }
             }
 

--- a/crates/turborepo-process/src/lib.rs
+++ b/crates/turborepo-process/src/lib.rs
@@ -698,4 +698,63 @@ mod test {
 
         let _ = fs::remove_file(pid_file);
     }
+
+    /// On a normal task exit (no graceful shutdown), the watcher should still
+    /// wait for the tracked process group to drain before signalling
+    /// completion. Without this, a dependent task can be scheduled before a
+    /// subprocess in the same process group has written its declared outputs.
+    /// See #12786.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_normal_exit_waits_for_process_group_to_drain() {
+        let manager = ProcessManager::new(false);
+        let pid_file = std::env::temp_dir().join(format!(
+            "turbo-normal-exit-grandchild-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_file(&pid_file);
+
+        // Parent shell records the grandchild pid, backgrounds the grandchild,
+        // then exits 0 immediately. The grandchild stays in the same process
+        // group (no setsid / setpgid) and lives for ~500ms before exiting
+        // cleanly. With the fix, `child.wait()` should block until the
+        // grandchild has exited; without it, `wait()` returns the moment the
+        // direct child exits while the grandchild is still alive.
+        let script = format!(
+            "(sleep 0.5; echo done) & echo $! > {}; exit 0",
+            pid_file.display()
+        );
+        let mut command = Command::new("sh");
+        command.args(["-c", &script]);
+        let mut child = manager
+            .spawn(command, Duration::from_secs(30), test_task_id())
+            .unwrap()
+            .unwrap();
+
+        let grandchild_pid = loop {
+            if let Ok(contents) = fs::read_to_string(&pid_file)
+                && let Ok(pid) = contents.trim().parse::<libc::pid_t>()
+                && process_exists(pid)
+            {
+                break pid;
+            }
+            sleep(Duration::from_millis(20)).await;
+        };
+
+        let start = Instant::now();
+        let exit = child.wait().await;
+        let elapsed = start.elapsed();
+
+        assert_eq!(exit, Some(ChildExit::Finished(Some(0))));
+        assert!(
+            elapsed >= Duration::from_millis(400),
+            "child.wait() should have blocked for the grandchild; only waited {elapsed:?}"
+        );
+        assert!(
+            !process_exists(grandchild_pid),
+            "grandchild should be gone when wait returns",
+        );
+
+        let _ = fs::remove_file(pid_file);
+    }
 }


### PR DESCRIPTION
## Summary

- Wires `wait_for_process_group_exit` into the normal-exit arm of `Child::spawn`'s watcher (`crates/turborepo-process/src/child.rs`).
- The wait function was already gated by `wait_for_process_group_after_child_exit: true` after #12699 but only reachable from `ShutdownStyle::Graceful::process`. On a non-interrupted task exit the watcher called `handle_child_exit` the moment the direct child reaped, so descendants in the tracked process group never got a chance to finish writing declared `outputs`.
- Adds a regression test `test_normal_exit_waits_for_process_group_to_drain` that exercises an in-group grandchild outliving its parent by ~500ms.

## Why

When a task script spawns a subprocess that writes the task's declared `outputs` (e.g. a code generator that delegates to a worker binary) and the direct child exits before the worker finishes, Turbo signals task complete, schedules dependents, and the dependents fail to resolve missing files. Turbo also prints `WARNING no output files found for task <pkg>#<task>` because cache collection ran before the writes.

This matches the architectural intent already documented in `crates/turborepo/ARCHITECTURE.md`:

> Turbo must not treat direct-child exit as task-tree exit. Package managers, shells, and watch commands can leave descendants running after the leader exits, so the process manager should track the process targets it spawned and keep Turbo alive until all tracked process groups are gone.

The graceful path enforces this; the normal-exit path did not.

## Reproducer

Deterministic synthetic in #12786: producer task script spawns a Node grandchild with `detached: false` and `.unref()`s without awaiting, so the grandchild stays in the parent's pgid and lives ~400ms past the parent's exit. On `turbo@2.9.12` this races 100% of iterations across darwin/arm64 and linux/arm64.

Real-world report (the issue's motivating case): `bunx --bun prisma generate` in CI hits this at ~1.2% because Prisma's `schema-engine` subprocess writes the generated client files after the `prisma` parent has returned. The synthetic above isolates the same fork pattern with no Prisma involved.

## Verification

| mode | grandchild stays in tracked pgid? | unpatched 2.9.12 | this PR |
| --- | :---: | :---: | :---: |
| `same-group` (control) | yes | 0/30 race | 0/30 race |
| `in-group-orphan` (Prisma-shape) | yes | **30/30 race** | **0/30 race** |
| `detached` | no (setsid) | 30/30 race | 30/30 race (see below) |
| `double-fork` | no (setsid in worker) | 30/30 race | 30/30 race (see below) |
| `delayed-pgid` | no (setsid mid-run) | 30/30 race | 30/30 race (see below) |

`cargo test -p turborepo-process` → 67/67 pass (including the new test and the existing `test_shutdown_waits_for_process_group_after_child_exit`).
`cargo fmt --check` and `cargo clippy -p turborepo-process --tests -- -D warnings` are both clean.

## Known limitation (out of scope for this PR)

Descendants that explicitly leave the tracked process group via `setsid` / `detached: true` / double-fork remain invisible to `has_running_process_group` (it does an exact pgid+sid identity match, then falls back to `kill(-pgid, 0)`). A follow-up could track these via `PR_SET_CHILD_SUBREAPER` on Linux or `proc_pidinfo` ancestry walks on macOS; that's a larger change than the actually-reported race needs and is intentionally not bundled here.

Closes #12786