### PR TITLE
fix(tui): add left padding to terminal pane to prevent pipe char merging into VSCode links

### DIFF
--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -1,7 +1,7 @@
 use ratatui::{
     style::{Modifier, Style, Stylize},
     text::Line,
-    widgets::{Block, Widget},
+    widgets::{Block, Padding, Widget},
 };
 use tui_term::widget::PseudoTerminal;
 
@@ -83,13 +83,20 @@ impl<W> Widget for &TerminalPane<'_, W> {
         Self: Sized,
     {
         let screen = self.terminal_output.parser.screen();
-        let block = Block::default()
+        let mut block = Block::default()
             .title(
                 self.terminal_output
                     .title(self.task_name)
                     .add_modifier(Modifier::DIM),
             )
             .title_bottom(self.footer());
+        // When the task list sidebar is visible, its right border (│) is
+        // directly adjacent to terminal content, causing IDE link parsers to
+        // absorb the pipe character into file paths or URLs. A single column
+        // of left padding creates a visual gap that prevents this.
+        if self.has_sidebar {
+            block = block.padding(Padding::left(1));
+        }
 
         let term = PseudoTerminal::new(screen).block(block);
         term.render(area, buf)


### PR DESCRIPTION
## Summary

When the task list sidebar is visible, its right border (`│`) is drawn directly adjacent to terminal output content. IDE link parsers in VSCode's integrated terminal absorb the `│` character as part of file paths or URLs, resulting in broken/unclickable links.

## Fix

Add `Padding::left(1)` to the terminal pane `Block` when `has_sidebar` is `true`. This inserts a single blank column between the sidebar border and terminal content, preventing the pipe character from merging into adjacent text.

```rust
// Before
let block = Block::default()
    .title(...)
    .title_bottom(self.footer());

// After  
let mut block = Block::default()
    .title(...)
    .title_bottom(self.footer());
if self.has_sidebar {
    block = block.padding(Padding::left(1));
}
```

The padding is only applied when `has_sidebar = true` (task list is visible) since that's the only case where the `│` border is adjacent to terminal content.

## Testing

- `cargo check -p turborepo-ui` passes cleanly
- Existing unit tests pass

Fixes #12791