### PR TITLE
fix(tui): add left padding between task list border and pane output

### DIFF
--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -1,7 +1,7 @@
 use ratatui::{
     style::{Modifier, Style, Stylize},
     text::Line,
-    widgets::{Block, Widget},
+    widgets::{Block, Padding, Widget},
 };
 use tui_term::widget::PseudoTerminal;
 
@@ -83,13 +83,20 @@ impl<W> Widget for &TerminalPane<'_, W> {
         Self: Sized,
     {
         let screen = self.terminal_output.parser.screen();
+        // One space so the task list's │ border doesn't attach to paths/URLs in output.
+        let padding = if self.has_sidebar {
+            Padding::new(1, 0, 0, 0)
+        } else {
+            Padding::ZERO
+        };
         let block = Block::default()
             .title(
                 self.terminal_output
                     .title(self.task_name)
                     .add_modifier(Modifier::DIM),
             )
-            .title_bottom(self.footer());
+            .title_bottom(self.footer())
+            .padding(padding);
 
         let term = PseudoTerminal::new(screen).block(block);
         term.render(area, buf)

--- a/crates/turborepo-ui/src/tui/size.rs
+++ b/crates/turborepo-ui/src/tui/size.rs
@@ -47,8 +47,9 @@ impl SizeInfo {
             let full_task_width = self.cols.saturating_sub(self.task_width_hint);
             full_task_width
                 .max(ratio_pane_width)
-                // We need to account for the left border of the pane
-                .saturating_sub(1)
+                // Account for the task list right border (│) and the 1-space
+                // left padding added in pane.rs to separate it from task output.
+                .saturating_sub(2)
         } else {
             // When sidebar is hidden, pane takes full width minus border
             self.cols.saturating_sub(1)


### PR DESCRIPTION
## Summary

- The task list's right border character (`│`) was immediately adjacent to task output in the TUI pane.
- Terminal emulators such as VSCode include the `│` when auto-detecting file paths and URLs in output, breaking ctrl-click links.
- Adds a 1-space left `Padding` to the terminal pane block when the sidebar is visible, putting a space between `│` and the output.
- Reduces `pane_cols` by 1 in the sidebar-visible case so the PTY dimensions stay consistent with the padded render area.
- No change when the sidebar is hidden (no `│` border present in that layout).

Fixes #12791

## Test plan

- [ ] Run `npx turbo dev` in a project with file path output (e.g. TypeScript errors, linter output)
- [ ] Confirm there is a visible space between the `│` border and task output text
- [ ] Ctrl-click a file path link in the VSCode terminal -- it should open correctly
- [ ] Press `h` to toggle the sidebar off and back on -- spacing should only appear when sidebar is visible
- [ ] Run existing TUI tests: `cargo test -p turborepo-ui`