### PR TITLE
Removed unneeded import form hash creation script in docs

### DIFF
--- a/apps/docs/content/docs/guides/handling-platforms.mdx
+++ b/apps/docs/content/docs/guides/handling-platforms.mdx
@@ -26,7 +26,6 @@ First, create a script that accounts for the hash contributors that you are inte
 #!/usr/bin/env node
 
 const { writeFileSync } = require("fs");
-const { join } = require("path");
 
 const { platform, arch } = process;
 const file = "turbo-cache-key.json";


### PR DESCRIPTION
`path.join` is unused in the hash creation script, so it should be removed; otherwise it will make linters sad

### Description

Update to documentation

### Testing Instructions

n/a