### PR TITLE
fix: Harden VS Code extension command execution

### DIFF
--- a/packages/turbo-vsc/package.json
+++ b/packages/turbo-vsc/package.json
@@ -38,7 +38,7 @@
     "copy-linux-x64": "cp out/artifacts/turborepo-lsp-x86_64-unknown-linux-musl/turborepo-lsp out/turborepo-lsp-linux-x64 && chmod +x out/turborepo-lsp-linux-x64",
     "copy-win32-arm64": "cp out/artifacts/turborepo-lsp-aarch64-pc-windows-msvc/turborepo-lsp.exe out/turborepo-lsp-win32-arm64.exe",
     "copy": "pnpm run copy-darwin-arm64 && pnpm run copy-darwin-x64 && pnpm run copy-win32-arm64 && pnpm run copy-win32-x64 && pnpm run copy-linux-arm64 && pnpm run copy-linux-x64",
-    "test": "pnpm run test-compile",
+    "test": "node --import tsx --test src/*.test.ts",
     "test-compile": "tsc -p ./ --noEmit"
   },
   "dependencies": {
@@ -50,7 +50,8 @@
     "@types/node": "20.10.8",
     "@types/vscode": "1.84.2",
     "@vscode/vsce": "3.9.1",
-    "esbuild": "0.27.2"
+    "esbuild": "0.27.2",
+    "tsx": "4.21.0"
   },
   "contributes": {
     "commands": [
@@ -75,12 +76,14 @@
       "properties": {
         "turbo.path": {
           "type": "string",
+          "scope": "machine",
           "required": false,
           "default": null,
           "description": "The path to your `turbo` executable, if you'd rather not rely on auto-detection. Relative paths are resolved from the workspace root."
         },
         "turbo.useLocalTurbo": {
           "type": "boolean",
+          "scope": "machine",
           "required": false,
           "default": false,
           "description": "Silence the 'install global turbo' prompt and always use local turbo."
@@ -97,6 +100,10 @@
     "vscode": "^1.84.2"
   },
   "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": false,
+      "description": "The extension starts the turbo daemon and runs turbo commands for the workspace."
+    },
     "virtualWorkspaces": {
       "supported": "limited",
       "description": "The language server requires a turbo daemon to function correctly."

--- a/packages/turbo-vsc/src/extension.ts
+++ b/packages/turbo-vsc/src/extension.ts
@@ -18,6 +18,9 @@ import {
   ServerOptions
 } from "vscode-languageclient/node";
 
+import { createTurboDaemonArgs } from "./turbo-daemon-command";
+import { createTurboRunTerminalOptions } from "./turbo-run-terminal-options";
+
 let client: LanguageClient;
 
 let toolbar: StatusBarItem;
@@ -29,8 +32,15 @@ type InternalLspProbeResult =
   | { supported: false; reason: string };
 
 export function activate(context: ExtensionContext) {
+  if (!workspace.isTrusted) {
+    window.showWarningMessage(
+      "The Turborepo extension is disabled in untrusted workspaces."
+    );
+    return;
+  }
+
   const workspaceRoot = workspace.workspaceFolders?.[0]?.uri.fsPath;
-  const options = { cwd: workspaceRoot };
+  const options: cp.ExecFileOptions = { cwd: workspaceRoot };
   const syncOptions: cp.ExecSyncOptionsWithStringEncoding = {
     ...options,
     encoding: "utf8"
@@ -89,9 +99,9 @@ export function activate(context: ExtensionContext) {
         return;
       }
 
-      cp.exec(`${quoteCommand(daemonPath)} daemon start`, options, (err) => {
+      cp.execFile(daemonPath, createTurboDaemonArgs("start"), options, (err) => {
         if (err) {
-          if (err.message.includes("command not found")) {
+          if (isCommandNotFoundError(err)) {
             promptGlobalTurbo(useLocalTurbo);
           } else {
             logs.appendLine(`unable to start turbo: ${err.message}`);
@@ -111,9 +121,9 @@ export function activate(context: ExtensionContext) {
         return;
       }
 
-      cp.exec(`${quoteCommand(daemonPath)} daemon stop`, options, (err) => {
+      cp.execFile(daemonPath, createTurboDaemonArgs("stop"), options, (err) => {
         if (err) {
-          if (err.message.includes("command not found")) {
+          if (isCommandNotFoundError(err)) {
             promptGlobalTurbo(useLocalTurbo);
           } else {
             logs.appendLine(`unable to stop turbo: ${err.message}`);
@@ -133,9 +143,9 @@ export function activate(context: ExtensionContext) {
         return;
       }
 
-      cp.exec(`${quoteCommand(daemonPath)} daemon status`, options, (err) => {
+      cp.execFile(daemonPath, createTurboDaemonArgs("status"), options, (err) => {
         if (err) {
-          if (err.message.includes("command not found")) {
+          if (isCommandNotFoundError(err)) {
             promptGlobalTurbo(useLocalTurbo);
           } else {
             logs.appendLine(`unable to get turbo status: ${err.message}`);
@@ -150,18 +160,16 @@ export function activate(context: ExtensionContext) {
   );
 
   context.subscriptions.push(
-    commands.registerCommand("turbo.run", async (args) => {
+    commands.registerCommand("turbo.run", async (args: string) => {
       const turboPath = await getTurboPath();
       if (!turboPath) {
         return;
       }
 
       const terminal = window.createTerminal({
-        name: `${args}`,
-        isTransient: true,
+        ...createTurboRunTerminalOptions(turboPath, args),
         iconPath: Uri.joinPath(context.extensionUri, "resources", "icon.svg")
       });
-      terminal.sendText(`${quoteCommand(turboPath)} run ${args}`);
       terminal.show();
     })
   );
@@ -258,6 +266,12 @@ export function deactivate(): Thenable<void> | undefined {
     return undefined;
   }
   return client.stop();
+}
+
+function isCommandNotFoundError(err: Error): boolean {
+  return (
+    err.message.includes("command not found") || err.message.includes("ENOENT")
+  );
 }
 
 function updateStatusBarItem(running: boolean) {

--- a/packages/turbo-vsc/src/extension.ts
+++ b/packages/turbo-vsc/src/extension.ts
@@ -19,7 +19,10 @@ import {
 } from "vscode-languageclient/node";
 
 import { createTurboDaemonArgs } from "./turbo-daemon-command";
-import { createTurboRunTerminalOptions } from "./turbo-run-terminal-options";
+import {
+  createTurboRunTerminalOptions,
+  sanitizeTurboRunTaskName
+} from "./turbo-run-terminal-options";
 
 let client: LanguageClient;
 
@@ -42,7 +45,7 @@ export function activate(context: ExtensionContext) {
   const workspaceRoot = workspace.workspaceFolders?.[0]?.uri.fsPath;
   const options: cp.ExecFileOptions = { cwd: workspaceRoot };
   const syncOptions: cp.ExecSyncOptionsWithStringEncoding = {
-    ...options,
+    cwd: workspaceRoot,
     encoding: "utf8"
   };
 
@@ -160,14 +163,20 @@ export function activate(context: ExtensionContext) {
   );
 
   context.subscriptions.push(
-    commands.registerCommand("turbo.run", async (args: string) => {
+    commands.registerCommand("turbo.run", async (args: unknown) => {
+      const taskName = sanitizeTurboRunTaskName(args);
+      if (!taskName) {
+        window.showWarningMessage("Invalid Turborepo task name.");
+        return;
+      }
+
       const turboPath = await getTurboPath();
       if (!turboPath) {
         return;
       }
 
       const terminal = window.createTerminal({
-        ...createTurboRunTerminalOptions(turboPath, args),
+        ...createTurboRunTerminalOptions(turboPath, taskName),
         iconPath: Uri.joinPath(context.extensionUri, "resources", "icon.svg")
       });
       terminal.show();

--- a/packages/turbo-vsc/src/extension.ts
+++ b/packages/turbo-vsc/src/extension.ts
@@ -102,18 +102,23 @@ export function activate(context: ExtensionContext) {
         return;
       }
 
-      cp.execFile(daemonPath, createTurboDaemonArgs("start"), options, (err) => {
-        if (err) {
-          if (isCommandNotFoundError(err)) {
-            promptGlobalTurbo(useLocalTurbo);
+      cp.execFile(
+        daemonPath,
+        createTurboDaemonArgs("start"),
+        options,
+        (err) => {
+          if (err) {
+            if (isCommandNotFoundError(err)) {
+              promptGlobalTurbo(useLocalTurbo);
+            } else {
+              logs.appendLine(`unable to start turbo: ${err.message}`);
+            }
           } else {
-            logs.appendLine(`unable to start turbo: ${err.message}`);
+            updateStatusBarItem(true);
+            window.showInformationMessage("Turbo daemon started");
           }
-        } else {
-          updateStatusBarItem(true);
-          window.showInformationMessage("Turbo daemon started");
         }
-      });
+      );
     })
   );
 
@@ -146,19 +151,24 @@ export function activate(context: ExtensionContext) {
         return;
       }
 
-      cp.execFile(daemonPath, createTurboDaemonArgs("status"), options, (err) => {
-        if (err) {
-          if (isCommandNotFoundError(err)) {
-            promptGlobalTurbo(useLocalTurbo);
+      cp.execFile(
+        daemonPath,
+        createTurboDaemonArgs("status"),
+        options,
+        (err) => {
+          if (err) {
+            if (isCommandNotFoundError(err)) {
+              promptGlobalTurbo(useLocalTurbo);
+            } else {
+              logs.appendLine(`unable to get turbo status: ${err.message}`);
+              updateStatusBarItem(false);
+            }
           } else {
-            logs.appendLine(`unable to get turbo status: ${err.message}`);
-            updateStatusBarItem(false);
+            updateStatusBarItem(true);
+            window.showInformationMessage("Turbo daemon is running");
           }
-        } else {
-          updateStatusBarItem(true);
-          window.showInformationMessage("Turbo daemon is running");
         }
-      });
+      );
     })
   );
 

--- a/packages/turbo-vsc/src/package-json.test.ts
+++ b/packages/turbo-vsc/src/package-json.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
+
+test("keeps executable settings machine-scoped", () => {
+  const properties = packageJson.contributes.configuration.properties;
+
+  assert.equal(properties["turbo.path"].scope, "machine");
+  assert.equal(properties["turbo.useLocalTurbo"].scope, "machine");
+});
+
+test("does not activate in untrusted workspaces", () => {
+  assert.equal(packageJson.capabilities.untrustedWorkspaces.supported, false);
+});

--- a/packages/turbo-vsc/src/turbo-daemon-command.test.ts
+++ b/packages/turbo-vsc/src/turbo-daemon-command.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createTurboDaemonArgs } from "./turbo-daemon-command";
+
+test("passes daemon commands as argv", () => {
+  assert.deepEqual(createTurboDaemonArgs("start"), ["daemon", "start"]);
+  assert.deepEqual(createTurboDaemonArgs("stop"), ["daemon", "stop"]);
+  assert.deepEqual(createTurboDaemonArgs("status"), ["daemon", "status"]);
+});

--- a/packages/turbo-vsc/src/turbo-daemon-command.ts
+++ b/packages/turbo-vsc/src/turbo-daemon-command.ts
@@ -1,0 +1,5 @@
+export type TurboDaemonCommand = "start" | "stop" | "status";
+
+export function createTurboDaemonArgs(command: TurboDaemonCommand): string[] {
+  return ["daemon", command];
+}

--- a/packages/turbo-vsc/src/turbo-run-terminal-options.test.ts
+++ b/packages/turbo-vsc/src/turbo-run-terminal-options.test.ts
@@ -1,11 +1,26 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { createTurboRunTerminalOptions } from "./turbo-run-terminal-options";
+import {
+  createTurboRunTerminalOptions,
+  sanitizeTurboRunTaskName
+} from "./turbo-run-terminal-options";
 
-const taskNames = [
+const validTaskNames = [
   "build",
   "build:prod",
+  "lint-staged",
+  "test.unit",
+  "web#build",
+  "@acme/web#build",
+  "//#build"
+];
+
+const invalidTaskNames = [
+  "",
+  "-build",
+  " build",
+  "build ",
   "foo bar",
   "foo; touch /tmp/pwned",
   "foo && touch /tmp/pwned",
@@ -18,8 +33,10 @@ const taskNames = [
   "foo ^& calc"
 ];
 
-for (const [index, taskName] of taskNames.entries()) {
-  test(`passes task name ${index} as one terminal argument`, () => {
+for (const [index, taskName] of validTaskNames.entries()) {
+  test(`passes valid task name ${index} as one terminal argument`, () => {
+    assert.equal(sanitizeTurboRunTaskName(taskName), taskName);
+
     const options = createTurboRunTerminalOptions(
       "/Applications/Turbo CLI/bin/turbo",
       taskName
@@ -30,3 +47,14 @@ for (const [index, taskName] of taskNames.entries()) {
     assert.deepEqual(options.shellArgs, ["run", taskName]);
   });
 }
+
+for (const [index, taskName] of invalidTaskNames.entries()) {
+  test(`rejects invalid task name ${index}`, () => {
+    assert.equal(sanitizeTurboRunTaskName(taskName), undefined);
+  });
+}
+
+test("rejects non-string task names", () => {
+  assert.equal(sanitizeTurboRunTaskName(undefined), undefined);
+  assert.equal(sanitizeTurboRunTaskName(["build"]), undefined);
+});

--- a/packages/turbo-vsc/src/turbo-run-terminal-options.test.ts
+++ b/packages/turbo-vsc/src/turbo-run-terminal-options.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createTurboRunTerminalOptions } from "./turbo-run-terminal-options";
+
+const taskNames = [
+  "build",
+  "build:prod",
+  "foo bar",
+  "foo; touch /tmp/pwned",
+  "foo && touch /tmp/pwned",
+  "foo | sh",
+  "foo $(touch /tmp/pwned)",
+  "foo`touch /tmp/pwned`",
+  "foo\n touch /tmp/pwned",
+  "foo' && touch /tmp/pwned && '",
+  "foo & calc",
+  "foo ^& calc"
+];
+
+for (const [index, taskName] of taskNames.entries()) {
+  test(`passes task name ${index} as one terminal argument`, () => {
+    const options = createTurboRunTerminalOptions(
+      "/Applications/Turbo CLI/bin/turbo",
+      taskName
+    );
+
+    assert.equal(options.name, taskName);
+    assert.equal(options.shellPath, "/Applications/Turbo CLI/bin/turbo");
+    assert.deepEqual(options.shellArgs, ["run", taskName]);
+  });
+}

--- a/packages/turbo-vsc/src/turbo-run-terminal-options.ts
+++ b/packages/turbo-vsc/src/turbo-run-terminal-options.ts
@@ -1,8 +1,26 @@
+const TASK_NAME_PATTERN = /^(?!(?:-|$))[A-Za-z0-9_:@./#-]+$/;
+const UNSAFE_TASK_NAME_PATTERN = /[\s;&|`"'$()<>\\\u0000-\u001f\u007f]/;
+
 export interface TurboRunTerminalOptions {
   name: string;
   shellPath: string;
   shellArgs: string[];
   isTransient: true;
+}
+
+export function sanitizeTurboRunTaskName(taskName: unknown): string | undefined {
+  if (typeof taskName !== "string") {
+    return undefined;
+  }
+
+  if (
+    !TASK_NAME_PATTERN.test(taskName) ||
+    UNSAFE_TASK_NAME_PATTERN.test(taskName)
+  ) {
+    return undefined;
+  }
+
+  return taskName;
 }
 
 export function createTurboRunTerminalOptions(

--- a/packages/turbo-vsc/src/turbo-run-terminal-options.ts
+++ b/packages/turbo-vsc/src/turbo-run-terminal-options.ts
@@ -1,0 +1,18 @@
+export interface TurboRunTerminalOptions {
+  name: string;
+  shellPath: string;
+  shellArgs: string[];
+  isTransient: true;
+}
+
+export function createTurboRunTerminalOptions(
+  turboPath: string,
+  taskName: string
+): TurboRunTerminalOptions {
+  return {
+    name: taskName,
+    shellPath: turboPath,
+    shellArgs: ["run", taskName],
+    isTransient: true
+  };
+}

--- a/packages/turbo-vsc/src/turbo-run-terminal-options.ts
+++ b/packages/turbo-vsc/src/turbo-run-terminal-options.ts
@@ -1,5 +1,4 @@
 const TASK_NAME_PATTERN = /^(?!(?:-|$))[A-Za-z0-9_:@./#-]+$/;
-const UNSAFE_TASK_NAME_PATTERN = /[\s;&|`"'$()<>\\\u0000-\u001f\u007f]/;
 
 export interface TurboRunTerminalOptions {
   name: string;
@@ -15,10 +14,7 @@ export function sanitizeTurboRunTaskName(
     return undefined;
   }
 
-  if (
-    !TASK_NAME_PATTERN.test(taskName) ||
-    UNSAFE_TASK_NAME_PATTERN.test(taskName)
-  ) {
+  if (!TASK_NAME_PATTERN.test(taskName)) {
     return undefined;
   }
 

--- a/packages/turbo-vsc/src/turbo-run-terminal-options.ts
+++ b/packages/turbo-vsc/src/turbo-run-terminal-options.ts
@@ -8,7 +8,9 @@ export interface TurboRunTerminalOptions {
   isTransient: true;
 }
 
-export function sanitizeTurboRunTaskName(taskName: unknown): string | undefined {
+export function sanitizeTurboRunTaskName(
+  taskName: unknown
+): string | undefined {
   if (typeof taskName !== "string") {
     return undefined;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -914,6 +914,9 @@ importers:
       esbuild:
         specifier: 0.27.2
         version: 0.27.2
+      tsx:
+        specifier: 4.21.0
+        version: 4.21.0
 
   packages/turbo-workspaces:
     dependencies:


### PR DESCRIPTION
- Stops the VS Code extension from interpolating daemon commands and task names through shell strings.
- Disables the extension in untrusted workspaces and keeps executable-related settings machine-scoped.