### PR TITLE
fix: Validate auth callback state

### DIFF
--- a/crates/turborepo-auth/src/auth/login.rs
+++ b/crates/turborepo-auth/src/auth/login.rs
@@ -13,8 +13,9 @@ use url::Url;
 use crate::{
     LoginOptions, Token,
     auth::{
-        ExistingTokenSource, classify_existing_vercel_token, ensure_trusted_vercel_api, is_vercel,
-        should_attempt_vercel_token_refresh, should_skip_existing_token_for_login,
+        ExistingTokenSource, classify_existing_vercel_token, ensure_trusted_vercel_api,
+        generate_csrf_state, is_vercel, should_attempt_vercel_token_refresh,
+        should_skip_existing_token_for_login,
     },
     device_flow::{self, TokenSet},
     error, ui,
@@ -307,8 +308,8 @@ fn wait_for_browser_confirmation() -> Result<bool, Error> {
 
 /// Non-Vercel login via browser redirect to a localhost server.
 /// Preserves the original login flow for self-hosted remote cache servers:
-/// opens `{login_url}/turborepo/token?redirect_uri=http://127.0.0.1:{port}`,
-/// waits for the server to redirect back with a `?token=` query parameter.
+/// opens `{login_url}/turborepo/token?redirect_uri=http://127.0.0.1:{port}&state=...`,
+/// waits for the server to redirect back with `?token=...&state=...`.
 async fn login_redirect<T: Client>(
     api_client: &T,
     color_config: &ColorConfig,
@@ -319,6 +320,7 @@ async fn login_redirect<T: Client>(
         .map_err(error::Error::CallbackListenerFailed)?;
     let port = listener.local_addr().unwrap().port();
     let redirect_url = format!("http://{DEFAULT_HOST_NAME}:{port}");
+    let state = generate_csrf_state();
 
     let mut login_url =
         Url::parse(login_url_configuration).map_err(|_| error::Error::LoginUrlCannotBeABase {
@@ -342,7 +344,8 @@ async fn login_redirect<T: Client>(
 
     login_url
         .query_pairs_mut()
-        .append_pair("redirect_uri", &redirect_url);
+        .append_pair("redirect_uri", &redirect_url)
+        .append_pair("state", &state);
 
     println!(">>> Opening browser to {login_url}");
     let spinner = start_spinner("Waiting for your authorization...");
@@ -353,10 +356,11 @@ async fn login_redirect<T: Client>(
     }
 
     let success_redirect = success_url.to_string();
-    let token_string =
-        tokio::task::spawn_blocking(move || wait_for_login_redirect(listener, &success_redirect))
-            .await
-            .map_err(|_| Error::CallbackTaskFailed)??;
+    let token_string = tokio::task::spawn_blocking(move || {
+        wait_for_login_redirect(listener, &success_redirect, &state)
+    })
+    .await
+    .map_err(|_| Error::CallbackTaskFailed)??;
 
     spinner.finish_and_clear();
 
@@ -376,7 +380,11 @@ async fn login_redirect<T: Client>(
 /// parameter. Browsers may send preflight, favicon, or other auxiliary
 /// requests before the real redirect arrives — looping prevents those from
 /// consuming the single-shot listener.
-fn wait_for_login_redirect(listener: TcpListener, success_redirect: &str) -> Result<String, Error> {
+fn wait_for_login_redirect(
+    listener: TcpListener,
+    success_redirect: &str,
+    expected_state: &str,
+) -> Result<String, Error> {
     listener
         .set_nonblocking(false)
         .map_err(Error::CallbackListenerFailed)?;
@@ -425,6 +433,14 @@ fn wait_for_login_redirect(listener: TcpListener, success_redirect: &str) -> Res
             .collect();
 
         if let Some(token) = params.get("token").cloned() {
+            match params.get("state") {
+                Some(returned_state) if returned_state == expected_state => {}
+                _ => {
+                    warn!("Login redirect state parameter mismatch or missing");
+                    return Err(Error::CsrfStateMismatch);
+                }
+            }
+
             let response = format!(
                 "HTTP/1.1 302 Found\r\nLocation: {success_redirect}\r\nConnection: close\r\n\r\n"
             );
@@ -609,13 +625,18 @@ mod tests {
         }
     }
 
-    fn spawn_login_callback(port: u16, token: &'static str) -> std::thread::JoinHandle<()> {
+    fn spawn_login_callback(
+        port: u16,
+        token: &'static str,
+        state: &'static str,
+    ) -> std::thread::JoinHandle<()> {
         std::thread::spawn(move || {
             for _ in 0..100 {
                 match std::net::TcpStream::connect(format!("127.0.0.1:{port}")) {
                     Ok(mut stream) => {
-                        let request =
-                            format!("GET /?token={token} HTTP/1.1\r\nHost: localhost\r\n\r\n");
+                        let request = format!(
+                            "GET /?token={token}&state={state} HTTP/1.1\r\nHost: localhost\r\n\r\n"
+                        );
                         stream.write_all(request.as_bytes()).unwrap();
                         return;
                     }
@@ -655,10 +676,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_login_stale_existing_token_falls_back_to_redirect() {
+        let _lock = ENV_LOCK.lock().await;
+        unsafe { env::set_var("TURBO_TEST_CSRF_STATE", "test-login-state") };
+
         let color_config = turborepo_ui::ColorConfig::new(false);
         let api_client = MockApiClient::new();
         let port = port_scanner::request_open_port().unwrap();
-        let callback = spawn_login_callback(port, "fresh-login-token");
+        let callback = spawn_login_callback(port, "fresh-login-token", "test-login-state");
 
         let options = LoginOptions {
             color_config: &color_config,
@@ -673,6 +697,7 @@ mod tests {
         let (token, token_set) = login(&options).await.unwrap();
 
         callback.join().unwrap();
+        unsafe { env::remove_var("TURBO_TEST_CSRF_STATE") };
 
         assert_matches!(token, Token::New(ref token) if token.expose() == "fresh-login-token");
         assert!(token_set.is_none());
@@ -735,13 +760,38 @@ mod tests {
 
         let handle = std::thread::spawn(move || {
             let mut stream = std::net::TcpStream::connect(format!("127.0.0.1:{port}")).unwrap();
-            let request = "GET /?token=my-login-token HTTP/1.1\r\nHost: localhost\r\n\r\n";
+            let request =
+                "GET /?token=my-login-token&state=test-state HTTP/1.1\r\nHost: localhost\r\n\r\n";
             stream.write_all(request.as_bytes()).unwrap();
         });
 
-        let result = wait_for_login_redirect(listener, "https://example.com/turborepo/success");
+        let result = wait_for_login_redirect(
+            listener,
+            "https://example.com/turborepo/success",
+            "test-state",
+        );
         handle.join().unwrap();
         assert_eq!(result.unwrap(), "my-login-token");
+    }
+
+    #[test]
+    fn test_wait_for_login_redirect_rejects_missing_state() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let handle = std::thread::spawn(move || {
+            let mut stream = std::net::TcpStream::connect(format!("127.0.0.1:{port}")).unwrap();
+            let request = "GET /?token=stolen-token HTTP/1.1\r\nHost: localhost\r\n\r\n";
+            stream.write_all(request.as_bytes()).unwrap();
+        });
+
+        let result = wait_for_login_redirect(
+            listener,
+            "https://example.com/turborepo/success",
+            "test-state",
+        );
+        handle.join().unwrap();
+        assert_matches!(result, Err(Error::CsrfStateMismatch));
     }
 
     #[test]
@@ -760,11 +810,16 @@ mod tests {
 
             // Second: the real callback with a token.
             let mut stream = std::net::TcpStream::connect(format!("127.0.0.1:{port}")).unwrap();
-            let request = "GET /?token=my-login-token HTTP/1.1\r\nHost: localhost\r\n\r\n";
+            let request =
+                "GET /?token=my-login-token&state=test-state HTTP/1.1\r\nHost: localhost\r\n\r\n";
             stream.write_all(request.as_bytes()).unwrap();
         });
 
-        let result = wait_for_login_redirect(listener, "https://example.com/turborepo/success");
+        let result = wait_for_login_redirect(
+            listener,
+            "https://example.com/turborepo/success",
+            "test-state",
+        );
         handle.join().unwrap();
         assert_eq!(result.unwrap(), "my-login-token");
     }

--- a/crates/turborepo-auth/src/auth/mod.rs
+++ b/crates/turborepo-auth/src/auth/mod.rs
@@ -4,6 +4,7 @@ mod sso;
 
 pub use login::*;
 pub use logout::*;
+use rand::distr::{Alphanumeric, SampleString};
 pub use sso::*;
 use tracing::warn;
 use turbopath::AbsoluteSystemPath;
@@ -12,6 +13,8 @@ use turbopath::AbsoluteSystemPathBuf;
 use turborepo_api_client::{Client, TokenClient};
 use turborepo_ui::ColorConfig;
 use url::Url;
+
+const CSRF_STATE_LENGTH: usize = 32;
 
 pub(crate) fn is_vercel(login_url: &str) -> bool {
     Url::parse(login_url)
@@ -67,6 +70,15 @@ fn is_trusted_vercel_origin(url: &Url) -> bool {
 
 fn is_vercel_host(host: &str) -> bool {
     host == "vercel.com" || host.ends_with(".vercel.com")
+}
+
+fn generate_csrf_state() -> String {
+    #[cfg(test)]
+    if let Ok(state) = std::env::var("TURBO_TEST_CSRF_STATE") {
+        return state;
+    }
+
+    Alphanumeric.sample_string(&mut rand::rng(), CSRF_STATE_LENGTH)
 }
 
 const VERCEL_TOKEN_DIR: &str = "com.vercel.cli";

--- a/crates/turborepo-auth/src/auth/sso.rs
+++ b/crates/turborepo-auth/src/auth/sso.rs
@@ -16,8 +16,9 @@ use super::login::{
 use crate::{
     Error, LoginOptions, Token,
     auth::{
-        ExistingTokenSource, classify_existing_vercel_token, ensure_trusted_vercel_api, is_vercel,
-        should_attempt_vercel_token_refresh, should_skip_existing_token_for_login,
+        ExistingTokenSource, classify_existing_vercel_token, ensure_trusted_vercel_api,
+        generate_csrf_state, is_vercel, should_attempt_vercel_token_refresh,
+        should_skip_existing_token_for_login,
     },
     device_flow::TokenSet,
     error, ui,
@@ -139,7 +140,8 @@ async fn classify_existing_sso_token_with_recovery<T: Client + TokenClient>(
 /// 4. Validates that the resulting token has access to the requested team.
 ///
 /// For non-Vercel (self-hosted):
-/// 1. Opens browser to `{login_url}/api/auth/sso?teamId=...&next=localhost`.
+/// 1. Opens browser to
+///    `{login_url}/api/auth/sso?teamId=...&next=localhost&state=...`.
 /// 2. Receives token via localhost redirect.
 /// 3. Verifies the SSO token with the API.
 ///
@@ -307,6 +309,7 @@ async fn sso_redirect(
         .map_err(Error::CallbackListenerFailed)?;
     let port = listener.local_addr().unwrap().port();
     let redirect_url = format!("http://{DEFAULT_HOST_NAME}:{port}");
+    let state = generate_csrf_state();
 
     let mut login_url =
         Url::parse(login_url_configuration).map_err(|_| error::Error::LoginUrlCannotBeABase {
@@ -324,7 +327,8 @@ async fn sso_redirect(
         .query_pairs_mut()
         .append_pair("teamId", sso_team)
         .append_pair("mode", "login")
-        .append_pair("next", &redirect_url);
+        .append_pair("next", &redirect_url)
+        .append_pair("state", &state);
 
     println!(">>> Opening browser to {login_url}");
     let spinner = start_spinner("Waiting for your authorization...");
@@ -335,7 +339,7 @@ async fn sso_redirect(
     }
 
     let verification_token =
-        tokio::task::spawn_blocking(move || wait_for_sso_redirect(listener, None))
+        tokio::task::spawn_blocking(move || wait_for_sso_redirect(listener, &state))
             .await
             .map_err(|_| Error::CallbackTaskFailed)??;
 
@@ -348,13 +352,8 @@ async fn sso_redirect(
 /// other auxiliary requests before the real redirect arrives — looping
 /// prevents those from consuming the single-shot listener.
 ///
-/// If `expected_state` is provided, validates the CSRF state param. This is
-/// only used by tests right now; non-Vercel flows skip state validation since
-/// the remote server may not support it.
-fn wait_for_sso_redirect(
-    listener: TcpListener,
-    expected_state: Option<&str>,
-) -> Result<String, Error> {
+/// Validates the CSRF state param before accepting a callback token.
+fn wait_for_sso_redirect(listener: TcpListener, expected_state: &str) -> Result<String, Error> {
     listener
         .set_nonblocking(false)
         .map_err(Error::CallbackListenerFailed)?;
@@ -406,14 +405,11 @@ fn wait_for_sso_redirect(
             continue;
         }
 
-        // Validate CSRF state parameter if expected (Vercel flow only)
-        if let Some(expected) = expected_state {
-            match params.get("state") {
-                Some(returned_state) if returned_state == expected => {}
-                _ => {
-                    warn!("SSO redirect state parameter mismatch or missing");
-                    return Err(Error::CsrfStateMismatch);
-                }
+        match params.get("state") {
+            Some(returned_state) if returned_state == expected_state => {}
+            _ => {
+                warn!("SSO redirect state parameter mismatch or missing");
+                return Err(Error::CsrfStateMismatch);
             }
         }
 
@@ -739,13 +735,13 @@ mod tests {
             }
         });
 
-        let result = wait_for_sso_redirect(listener, Some(state));
+        let result = wait_for_sso_redirect(listener, state);
         handle.join().unwrap();
         assert_eq!(result.unwrap(), "my-sso-token");
     }
 
     #[test]
-    fn test_wait_for_sso_redirect_happy_path_without_state() {
+    fn test_wait_for_sso_redirect_rejects_missing_state() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
 
@@ -755,9 +751,9 @@ mod tests {
             stream.write_all(request.as_bytes()).unwrap();
         });
 
-        let result = wait_for_sso_redirect(listener, None);
+        let result = wait_for_sso_redirect(listener, "test-state");
         handle.join().unwrap();
-        assert_eq!(result.unwrap(), "my-sso-token");
+        assert_matches!(result, Err(Error::CsrfStateMismatch));
     }
 
     #[test]
@@ -786,7 +782,7 @@ mod tests {
             }
         });
 
-        let result = wait_for_sso_redirect(listener, Some(state));
+        let result = wait_for_sso_redirect(listener, state);
         handle.join().unwrap();
         assert_eq!(result.unwrap(), "my-sso-token");
     }
@@ -803,9 +799,9 @@ mod tests {
             stream.write_all(request.as_bytes()).unwrap();
         });
 
-        let result = wait_for_sso_redirect(listener, Some("correct-state"));
+        let result = wait_for_sso_redirect(listener, "correct-state");
         handle.join().unwrap();
-        assert!(result.is_err());
+        assert_matches!(result, Err(Error::CsrfStateMismatch));
     }
 
     #[test]
@@ -825,7 +821,7 @@ mod tests {
             }
         });
 
-        let result = wait_for_sso_redirect(listener, Some(state));
+        let result = wait_for_sso_redirect(listener, state);
         handle.join().unwrap();
         assert!(result.is_err());
     }

--- a/crates/turborepo-auth/src/error.rs
+++ b/crates/turborepo-auth/src/error.rs
@@ -27,7 +27,7 @@ pub enum Error {
     CallbackTimeout,
     #[error("login callback task panicked or was cancelled")]
     CallbackTaskFailed,
-    #[error("CSRF state parameter mismatch on SSO redirect")]
+    #[error("CSRF state parameter mismatch on login callback")]
     CsrfStateMismatch,
     #[error("login callback returned an error from the remote server")]
     LoginCallbackError,


### PR DESCRIPTION
- Adds CSRF state generation and validation to self-hosted login and SSO callback flows.
- Rejects missing or mismatched callback state before accepting returned tokens.
