### PR TITLE
chore: Release 2.9.13

### DIFF
--- a/packages/create-turbo/package.json
+++ b/packages/create-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-turbo",
-  "version": "2.9.12",
+  "version": "2.9.13",
   "description": "Create a new Turborepo",
   "homepage": "https://turborepo.dev",
   "bugs": {

--- a/packages/eslint-config-turbo/package.json
+++ b/packages/eslint-config-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-turbo",
-  "version": "2.9.12",
+  "version": "2.9.13",
   "description": "ESLint config for Turborepo",
   "keywords": [
     "eslint",

--- a/packages/eslint-plugin-turbo/package.json
+++ b/packages/eslint-plugin-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-turbo",
-  "version": "2.9.12",
+  "version": "2.9.13",
   "description": "ESLint plugin for Turborepo",
   "keywords": [
     "eslint",

--- a/packages/turbo-codemod/package.json
+++ b/packages/turbo-codemod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/codemod",
-  "version": "2.9.12",
+  "version": "2.9.13",
   "description": "Provides Codemod transformations to help upgrade your Turborepo codebase when a feature is deprecated.",
   "homepage": "https://turborepo.dev",
   "bugs": {

--- a/packages/turbo-gen/package.json
+++ b/packages/turbo-gen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/gen",
-  "version": "2.9.12",
+  "version": "2.9.13",
   "description": "Extend a Turborepo",
   "homepage": "https://turborepo.dev",
   "bugs": {

--- a/packages/turbo-ignore/package.json
+++ b/packages/turbo-ignore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-ignore",
-  "version": "2.9.12",
+  "version": "2.9.13",
   "description": "",
   "keywords": [],
   "homepage": "https://turborepo.dev",

--- a/packages/turbo-types/package.json
+++ b/packages/turbo-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/types",
-  "version": "2.9.12",
+  "version": "2.9.13",
   "description": "Turborepo types",
   "homepage": "https://turborepo.dev",
   "bugs": {

--- a/packages/turbo-workspaces/package.json
+++ b/packages/turbo-workspaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/workspaces",
-  "version": "2.9.12",
+  "version": "2.9.13",
   "description": "Tools for working with package managers",
   "homepage": "https://turborepo.dev",
   "bugs": {

--- a/packages/turbo/package.json
+++ b/packages/turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo",
-  "version": "2.9.12",
+  "version": "2.9.13",
   "description": "Turborepo is a high-performance build system for JavaScript and TypeScript codebases.",
   "homepage": "https://turborepo.dev",
   "bugs": "https://github.com/vercel/turborepo/issues",
@@ -18,11 +18,11 @@
     "postversion": "node bump-version.js"
   },
   "optionalDependencies": {
-    "@turbo/darwin-64": "2.9.12",
-    "@turbo/darwin-arm64": "2.9.12",
-    "@turbo/linux-64": "2.9.12",
-    "@turbo/linux-arm64": "2.9.12",
-    "@turbo/windows-64": "2.9.12",
-    "@turbo/windows-arm64": "2.9.12"
+    "@turbo/darwin-64": "2.9.13",
+    "@turbo/darwin-arm64": "2.9.13",
+    "@turbo/linux-64": "2.9.13",
+    "@turbo/linux-arm64": "2.9.13",
+    "@turbo/windows-64": "2.9.13",
+    "@turbo/windows-arm64": "2.9.13"
   }
 }

--- a/skills/turborepo/SKILL.md
+++ b/skills/turborepo/SKILL.md
@@ -9,7 +9,7 @@ description: |
   monorepo, shares code between apps, runs changed/affected packages, debugs cache,
   or has apps/packages directories.
 metadata:
-  version: 2.9.12
+  version: 2.9.13
 ---
 
 # Turborepo Skill
@@ -740,7 +740,7 @@ import { Button } from "@repo/ui/button";
 
 ```json
 {
-  "$schema": "https://v2-9-12.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-13.turborepo.dev/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],

--- a/skills/turborepo/references/best-practices/structure.md
+++ b/skills/turborepo/references/best-practices/structure.md
@@ -95,7 +95,7 @@ Package tasks enable Turborepo to:
 
 ```json
 {
-  "$schema": "https://v2-9-12.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-13.turborepo.dev/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
@@ -117,7 +117,7 @@ With `futureFlags.globalConfiguration`, global settings move under a `global` ke
 
 ```json
 {
-  "$schema": "https://v2-9-12.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-13.turborepo.dev/schema.json",
   "futureFlags": { "globalConfiguration": true },
   "global": {
     "inputs": ["tsconfig.json"],

--- a/skills/turborepo/references/configuration/RULE.md
+++ b/skills/turborepo/references/configuration/RULE.md
@@ -73,7 +73,7 @@ When you run `turbo run lint`, Turborepo finds all packages with a `lint` script
 
 ```json
 {
-  "$schema": "https://v2-9-12.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-13.turborepo.dev/schema.json",
   "globalEnv": ["CI"],
   "globalDependencies": ["tsconfig.json"],
   "tasks": {
@@ -97,7 +97,7 @@ When the `globalConfiguration` future flag is enabled, global options move under
 
 ```json
 {
-  "$schema": "https://v2-9-12.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-13.turborepo.dev/schema.json",
   "futureFlags": { "globalConfiguration": true },
   "global": {
     "inputs": ["tsconfig.json"],

--- a/skills/turborepo/references/environment/RULE.md
+++ b/skills/turborepo/references/environment/RULE.md
@@ -107,7 +107,7 @@ When the `globalConfiguration` future flag is enabled, global environment keys m
 
 ```json
 {
-  "$schema": "https://v2-9-12.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-13.turborepo.dev/schema.json",
   "globalEnv": ["CI", "NODE_ENV"],
   "globalPassThroughEnv": ["GITHUB_TOKEN", "NPM_TOKEN"],
   "tasks": {

--- a/skills/turborepo/references/environment/gotchas.md
+++ b/skills/turborepo/references/environment/gotchas.md
@@ -112,7 +112,7 @@ If you use `.env.development` and `.env.production`, both should be in inputs.
 
 ```json
 {
-  "$schema": "https://v2-9-12.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-13.turborepo.dev/schema.json",
   "globalEnv": ["CI", "NODE_ENV", "VERCEL"],
   "globalPassThroughEnv": ["GITHUB_TOKEN", "VERCEL_URL"],
   "tasks": {
@@ -146,7 +146,7 @@ The same config using the `global` key. The `.env` files move to `global.inputs`
 
 ```json
 {
-  "$schema": "https://v2-9-12.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-13.turborepo.dev/schema.json",
   "futureFlags": { "globalConfiguration": true },
   "global": {
     "env": ["CI", "NODE_ENV", "VERCEL"],

--- a/version.txt
+++ b/version.txt
@@ -1,2 +1,2 @@
-2.9.13-canary.0
+2.9.14-canary.0
 canary


### PR DESCRIPTION
## Summary

- Recreates the release PR that the failed v2.9.13 workflow never opened.
- Advances `version.txt` to `2.9.14-canary.0` so the next release does not retry `2.9.13`.
- Keeps package and Turborepo skill metadata aligned with the attempted `2.9.13` release state.

## Context

The v2.9.13 release failed during npm publishing after a partial native package publish. This PR only moves repository state forward; it does not create a `v2.9.13` tag or complete the npm publish.

## Changes Since v2.9.12

- release(turborepo): 2.9.12 (#12774) (`c1f923a`)
- fix: Restore docs mobile menu (#12782) (`859c629`)
- ci: Use `pull_request` for PR title linting (#12787) (`4cf9fab`)
- ci: Scope GitHub Actions caches by branch (#12788) (`5fcb960`)
- test: Validate lockfiles without dependency downloads (#12789) (`71f8c90`)
- Removed unneeded import form hash creation script in docs (#12799) (`1779ad7`)
- fix: Validate auth callback state (#12802) (`84f4508`)
- fix: Harden VS Code extension command execution (#12800) (`91c90cb`)
- fix: Avoid project-local Yarn during detection (#12801) (`e8e629d`)