### PR TITLE
fix: Prune package.json workspaces

### DIFF
--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -238,33 +238,41 @@ pub async fn prune(
         &prune.root,
         package_manager,
     )?;
-    if !original_patches.is_empty() {
-        let pruned_patches = collect_patch_paths(
+    let pruned_patches = if original_patches.is_empty() {
+        Vec::new()
+    } else {
+        collect_patch_paths(
             lockfile.as_ref(),
             prune.package_graph.root_package_json(),
             &prune.root,
             package_manager,
-        )?;
+        )?
+    };
+
+    if !original_patches.is_empty() {
         trace!(
             "original patches: {:?}, pruned patches: {:?}",
             original_patches,
             pruned_patches
         );
+    }
 
-        let repo_root = &prune.root;
-        let pruned_json = package_manager.prune_patched_packages(
-            prune.package_graph.root_package_json(),
-            &pruned_patches,
-            repo_root,
-        );
+    let original_contents = prune.root.resolve(package_json()).read_to_string()?;
+    let original_value: serde_json::Value = serde_json::from_str(&original_contents)?;
+    if !original_patches.is_empty() || original_value.get("workspaces").is_some() {
+        let pruned_json = if original_patches.is_empty() {
+            prune.package_graph.root_package_json().clone()
+        } else {
+            package_manager.prune_patched_packages(
+                prune.package_graph.root_package_json(),
+                &pruned_patches,
+                &prune.root,
+            )
+        };
 
-        // Read the original package.json as serde_json::Value to preserve key
-        // ordering. Serializing the PackageJson struct directly would sort keys
-        // alphabetically, producing a byte-different file that invalidates
-        // cache hashes. See https://github.com/vercel/turborepo/issues/12369
-        let original_contents = prune.root.resolve(package_json()).read_to_string()?;
-        let original_value: serde_json::Value = serde_json::from_str(&original_contents)?;
-        let pruned_value = serde_json::to_value(&pruned_json)?;
+        let mut pruned_value = serde_json::to_value(&pruned_json)?;
+        prune_package_json_workspaces(&mut pruned_value, &workspace_paths);
+        // Merge into the original JSON value so package.json key order stays stable.
         let merged = merge_preserving_key_order(&original_value, &pruned_value);
         let mut pruned_json_contents = serde_json::to_string_pretty(&merged)?;
         // Add trailing newline to match Go behavior
@@ -286,7 +294,11 @@ pub async fn prune(
                 prune.docker_directory().resolve(package_json()),
             )?;
         }
+    } else {
+        prune.copy_file(package_json(), Some(CopyDestination::Docker))?;
+    }
 
+    if !original_patches.is_empty() {
         for patch in &pruned_patches {
             prune.copy_file(
                 &patch.to_anchored_system_path_buf(),
@@ -318,11 +330,32 @@ pub async fn prune(
                 )?;
             }
         }
-    } else {
-        prune.copy_file(package_json(), Some(CopyDestination::Docker))?;
     }
 
     Ok(())
+}
+
+fn prune_package_json_workspaces(package_json: &mut serde_json::Value, workspace_paths: &[String]) {
+    let Some(workspaces) = package_json.get_mut("workspaces") else {
+        return;
+    };
+
+    let pruned_workspaces = || {
+        workspace_paths
+            .iter()
+            .map(|workspace| serde_json::Value::String(workspace.clone()))
+            .collect::<Vec<_>>()
+    };
+
+    match workspaces {
+        serde_json::Value::Array(packages) => *packages = pruned_workspaces(),
+        serde_json::Value::Object(config) => {
+            if let Some(packages) = config.get_mut("packages") {
+                *packages = serde_json::Value::Array(pruned_workspaces());
+            }
+        }
+        _ => {}
+    }
 }
 
 fn collect_patch_paths(
@@ -847,7 +880,9 @@ mod tests {
     use serde_json::json;
     use turborepo_repository::package_json::PackageJson;
 
-    use super::{bin_paths, merge_preserving_key_order, ADDITIONAL_FILES};
+    use super::{
+        bin_paths, merge_preserving_key_order, prune_package_json_workspaces, ADDITIONAL_FILES,
+    };
 
     #[test]
     fn bin_paths_reads_string_bin() {
@@ -910,6 +945,39 @@ mod tests {
         let merged = merge_preserving_key_order(&original, &pruned);
         let keys: Vec<_> = merged.as_object().unwrap().keys().collect();
         assert_eq!(keys, vec!["existing", "new_key"]);
+    }
+
+    #[test]
+    fn prune_workspaces_replaces_top_level_workspace_list() {
+        let mut package_json = json!({
+            "name": "repo",
+            "workspaces": ["app", "scripts", "packages/*"]
+        });
+
+        prune_package_json_workspaces(&mut package_json, &["app".into(), "packages/ui".into()]);
+
+        assert_eq!(package_json["workspaces"], json!(["app", "packages/ui"]));
+    }
+
+    #[test]
+    fn prune_workspaces_preserves_nested_workspace_metadata() {
+        let mut package_json = json!({
+            "name": "repo",
+            "workspaces": {
+                "packages": ["app", "scripts", "packages/*"],
+                "catalog": {
+                    "react": "latest"
+                }
+            }
+        });
+
+        prune_package_json_workspaces(&mut package_json, &["app".into()]);
+
+        assert_eq!(package_json["workspaces"]["packages"], json!(["app"]));
+        assert_eq!(
+            package_json["workspaces"]["catalog"],
+            json!({"react": "latest"})
+        );
     }
 
     #[test]

--- a/lockfile-tests/check-lockfiles.ts
+++ b/lockfile-tests/check-lockfiles.ts
@@ -36,6 +36,8 @@ interface FixtureMeta {
   packageManagerVersion: string;
   lockfileName: string;
   pruneTargets?: string[];
+  /** Run `turbo prune --docker` and validate `out/json`. */
+  docker?: boolean;
   /** Workspace names where pruning or lockfile validation is known to fail. */
   expectedFailures?: string[];
 }
@@ -213,6 +215,7 @@ function buildTestCases(
         },
         targetWorkspace: { name: target },
         label,
+        docker: fixture.meta.docker,
         expectedFailure: isExpected
       });
     }

--- a/lockfile-tests/fixtures/issue-12785/app/package.json
+++ b/lockfile-tests/fixtures/issue-12785/app/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "echo app"
+  }
+}

--- a/lockfile-tests/fixtures/issue-12785/bun.lock
+++ b/lockfile-tests/fixtures/issue-12785/bun.lock
@@ -1,0 +1,34 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "issue-12785",
+    },
+    "app": {
+      "name": "app",
+      "version": "1.0.0",
+    },
+    "packages/ui": {
+      "name": "@repo/ui",
+      "version": "1.0.0",
+    },
+    "scripts": {
+      "name": "scripts",
+      "version": "1.0.0",
+    },
+    "web-e2e-tests": {
+      "name": "web-e2e-tests",
+      "version": "1.0.0",
+    },
+  },
+  "packages": {
+    "@repo/ui": ["@repo/ui@workspace:packages/ui"],
+
+    "app": ["app@workspace:app"],
+
+    "scripts": ["scripts@workspace:scripts"],
+
+    "web-e2e-tests": ["web-e2e-tests@workspace:web-e2e-tests"],
+  }
+}

--- a/lockfile-tests/fixtures/issue-12785/meta.json
+++ b/lockfile-tests/fixtures/issue-12785/meta.json
@@ -1,0 +1,7 @@
+{
+  "packageManager": "bun",
+  "packageManagerVersion": "bun@1.3.13",
+  "lockfileName": "bun.lock",
+  "pruneTargets": ["app"],
+  "docker": true
+}

--- a/lockfile-tests/fixtures/issue-12785/package.json
+++ b/lockfile-tests/fixtures/issue-12785/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "issue-12785",
+  "private": true,
+  "workspaces": [
+    "app",
+    "scripts",
+    "web-e2e-tests",
+    "packages/*"
+  ],
+  "packageManager": "bun@1.3.13"
+}

--- a/lockfile-tests/fixtures/issue-12785/packages/ui/package.json
+++ b/lockfile-tests/fixtures/issue-12785/packages/ui/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@repo/ui",
+  "version": "1.0.0"
+}

--- a/lockfile-tests/fixtures/issue-12785/scripts/package.json
+++ b/lockfile-tests/fixtures/issue-12785/scripts/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "scripts",
+  "version": "1.0.0"
+}

--- a/lockfile-tests/fixtures/issue-12785/turbo.json
+++ b/lockfile-tests/fixtures/issue-12785/turbo.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"]
+    }
+  }
+}

--- a/lockfile-tests/fixtures/issue-12785/web-e2e-tests/package.json
+++ b/lockfile-tests/fixtures/issue-12785/web-e2e-tests/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "web-e2e-tests",
+  "version": "1.0.0"
+}

--- a/lockfile-tests/runners/local.ts
+++ b/lockfile-tests/runners/local.ts
@@ -449,11 +449,9 @@ export class LocalRunner {
             tc.docker ? " --docker" : ""
           }`;
           log(`[${label}] ${pruneCommand}`);
-          const pruneResult = await exec(
-            pruneCommand,
-            tmpDir,
-            { PATH: fullPath }
-          );
+          const pruneResult = await exec(pruneCommand, tmpDir, {
+            PATH: fullPath
+          });
 
           result.pruneOutput = [pruneResult.stdout, pruneResult.stderr]
             .filter(Boolean)

--- a/lockfile-tests/runners/local.ts
+++ b/lockfile-tests/runners/local.ts
@@ -445,9 +445,12 @@ export class LocalRunner {
 
         try {
           // turbo prune
-          log(`[${label}] turbo prune ${targetWorkspace.name}`);
+          const pruneCommand = `turbo prune ${targetWorkspace.name}${
+            tc.docker ? " --docker" : ""
+          }`;
+          log(`[${label}] ${pruneCommand}`);
           const pruneResult = await exec(
-            `turbo prune ${targetWorkspace.name}`,
+            pruneCommand,
             tmpDir,
             { PATH: fullPath }
           );
@@ -468,12 +471,17 @@ export class LocalRunner {
           log(`[${label}] Prune succeeded`);
 
           // Validate the pruned lockfile without downloading packages.
-          const outDir = path.join(tmpDir, "out");
+          const outDir = tc.docker
+            ? path.join(tmpDir, "out", "json")
+            : path.join(tmpDir, "out");
+          const outLabel = tc.docker ? "out/json" : "out";
           const validation = lockfileValidationCommand(
             fixture.packageManager,
             outDir
           );
-          log(`[${label}] ${validation.command} (lockfile validation in out/)`);
+          log(
+            `[${label}] ${validation.command} (lockfile validation in ${outLabel}/)`
+          );
 
           const validationResult = await this.runLockfileValidation(
             fixture,

--- a/lockfile-tests/types.ts
+++ b/lockfile-tests/types.ts
@@ -12,6 +12,7 @@ export interface TestCase {
     name: string;
   };
   label: string;
+  docker?: boolean;
   expectedFailure?: boolean;
 }
 


### PR DESCRIPTION
## Summary
- Fixes #12785 by writing pruned root workspace declarations so Docker prunes do not reference excluded literal Bun workspaces.
- Adds a Docker-mode lockfile fixture that validates `out/json` with Bun.

## Testing
- Added repro case to `check-lockfiles` fixtures.