### PR TITLE
fix: Wait for process trees before task completion

### DIFF
--- a/crates/turborepo-process/Cargo.toml
+++ b/crates/turborepo-process/Cargo.toml
@@ -27,6 +27,7 @@ workspace = true
 windows-sys = { version = "0.59", features = [
   "Win32_Foundation",
   "Win32_Security",
+  "Win32_System_Diagnostics_ToolHelp",
   "Win32_System_JobObjects",
   "Win32_System_Threading",
 ] }

--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -235,6 +235,9 @@ fn empty_descendant_tracker() -> Arc<Mutex<HashSet<u32>>> {
 impl ChildHandle {
     #[tracing::instrument(skip(command))]
     pub fn spawn_normal(command: Command) -> io::Result<SpawnResult> {
+        #[cfg(windows)]
+        let command_for_fallback = command.clone();
+
         let mut command = TokioCommand::from(command);
 
         // Create a new process group so we can send signals (e.g. SIGINT) to
@@ -247,10 +250,27 @@ impl ChildHandle {
 
         #[cfg(windows)]
         if job.is_some() {
-            command.creation_flags(windows_sys::Win32::System::Threading::CREATE_SUSPENDED);
+            command.creation_flags(
+                windows_sys::Win32::System::Threading::CREATE_SUSPENDED
+                    | windows_sys::Win32::System::Threading::CREATE_BREAKAWAY_FROM_JOB,
+            );
         }
 
+        #[cfg(not(windows))]
         let mut child = command.spawn()?;
+
+        #[cfg(windows)]
+        let mut child = match command.spawn() {
+            Ok(child) => child,
+            Err(err) if job.is_some() => {
+                debug!("failed to spawn child with job breakaway: {err}");
+                let mut fallback_command = TokioCommand::from(command_for_fallback);
+                fallback_command
+                    .creation_flags(windows_sys::Win32::System::Threading::CREATE_SUSPENDED);
+                fallback_command.spawn()?
+            }
+            Err(err) => return Err(err),
+        };
         let pid = child.id();
 
         #[cfg(windows)]

--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -19,11 +19,7 @@ const CHILD_POLL_INTERVAL: Duration = Duration::from_micros(50);
 const POST_EXIT_OUTPUT_DRAIN_TIMEOUT: Duration = Duration::from_millis(100);
 #[cfg(any(unix, windows))]
 const PROCESS_TREE_DRAIN_POLL_INTERVAL: Duration = Duration::from_millis(10);
-#[cfg(windows)]
-const WINDOWS_DESCENDANT_TRACKER_POLL_INTERVAL: Duration = Duration::from_millis(1);
 
-#[cfg(windows)]
-use std::collections::HashSet;
 use std::{
     fmt,
     io::{self, BufRead, Read, Write},
@@ -33,8 +29,6 @@ use std::{
     },
     time::Duration,
 };
-#[cfg(windows)]
-use std::{sync::mpsc as std_mpsc, thread};
 
 use portable_pty::{Child as PtyChild, MasterPty as PtyController, native_pty_system};
 use tokio::{
@@ -94,8 +88,6 @@ struct ChildHandle {
     target_identity: Option<TargetIdentity>,
     #[cfg(windows)]
     _job: Option<super::job_object::JobObject>,
-    #[cfg(windows)]
-    tracked_descendants: Arc<Mutex<HashSet<u32>>>,
 }
 
 enum ChildHandleImpl {
@@ -193,70 +185,6 @@ fn capture_target_identity(pid: Option<u32>) -> Option<TargetIdentity> {
     })
 }
 
-#[cfg(windows)]
-fn start_descendant_tracker(root_pid: u32) -> Arc<Mutex<HashSet<u32>>> {
-    let tracked = Arc::new(Mutex::new(HashSet::new()));
-    let tracked_for_thread = tracked.clone();
-    let (ready_tx, ready_rx) = std_mpsc::channel();
-
-    thread::spawn(move || {
-        let mut root_missing_ticks = 0;
-        let mut ready_tx = Some(ready_tx);
-        let mut last_tracked = Vec::new();
-        eprintln!("[turbo-process-debug] descendant tracker starting root_pid={root_pid}");
-        loop {
-            if let Ok(descendants) = super::job_object::descendant_processes(root_pid) {
-                let mut lock = tracked_for_thread.lock().expect("not poisoned");
-                lock.extend(descendants);
-            }
-
-            if let Some(ready_tx) = ready_tx.take() {
-                ready_tx.send(()).ok();
-            }
-
-            let tracked_pids = {
-                let lock = tracked_for_thread.lock().expect("not poisoned");
-                lock.iter().copied().collect::<Vec<_>>()
-            };
-            if tracked_pids != last_tracked {
-                eprintln!(
-                    "[turbo-process-debug] descendant tracker root_pid={root_pid} \
-                     tracked={tracked_pids:?}"
-                );
-                last_tracked = tracked_pids.clone();
-            }
-            let root_exists = super::job_object::process_exists(root_pid).unwrap_or(false);
-            let tracked_descendant_exists = tracked_pids
-                .iter()
-                .any(|pid| super::job_object::process_exists(*pid).unwrap_or(false));
-
-            if root_exists || tracked_descendant_exists {
-                root_missing_ticks = 0;
-            } else {
-                root_missing_ticks += 1;
-                if root_missing_ticks > 100 {
-                    eprintln!(
-                        "[turbo-process-debug] descendant tracker exiting root_pid={root_pid} \
-                         tracked={tracked_pids:?}"
-                    );
-                    break;
-                }
-            }
-
-            thread::sleep(WINDOWS_DESCENDANT_TRACKER_POLL_INTERVAL);
-        }
-    });
-
-    ready_rx.recv().ok();
-
-    tracked
-}
-
-#[cfg(windows)]
-fn empty_descendant_tracker() -> Arc<Mutex<HashSet<u32>>> {
-    Arc::new(Mutex::new(HashSet::new()))
-}
-
 impl ChildHandle {
     #[tracing::instrument(skip(command))]
     pub fn spawn_normal(command: Command) -> io::Result<SpawnResult> {
@@ -272,12 +200,9 @@ impl ChildHandle {
 
         #[cfg(windows)]
         let job = match super::job_object::JobObject::new() {
-            Ok(job) => {
-                eprintln!("[turbo-process-debug] created Windows JobObject");
-                Some(job)
-            }
+            Ok(job) => Some(job),
             Err(err) => {
-                eprintln!("[turbo-process-debug] failed to create Windows JobObject: {err}");
+                debug!("failed to create Windows JobObject: {err}");
                 None
             }
         };
@@ -295,34 +220,17 @@ impl ChildHandle {
 
         #[cfg(windows)]
         let mut child = match command.spawn() {
-            Ok(child) => {
-                eprintln!(
-                    "[turbo-process-debug] spawned child with CREATE_BREAKAWAY_FROM_JOB pid={:?}",
-                    child.id()
-                );
-                child
-            }
+            Ok(child) => child,
             Err(err) if job.is_some() => {
-                eprintln!("[turbo-process-debug] breakaway spawn failed, falling back: {err}");
                 debug!("failed to spawn child with job breakaway: {err}");
                 let mut fallback_command = TokioCommand::from(command_for_fallback);
                 fallback_command
                     .creation_flags(windows_sys::Win32::System::Threading::CREATE_SUSPENDED);
-                let child = fallback_command.spawn()?;
-                eprintln!(
-                    "[turbo-process-debug] spawned child with CREATE_SUSPENDED fallback pid={:?}",
-                    child.id()
-                );
-                child
+                fallback_command.spawn()?
             }
             Err(err) => return Err(err),
         };
         let pid = child.id();
-
-        #[cfg(windows)]
-        let tracked_descendants = pid
-            .map(start_descendant_tracker)
-            .unwrap_or_else(empty_descendant_tracker);
 
         #[cfg(unix)]
         let target_identity = capture_target_identity(pid);
@@ -330,19 +238,9 @@ impl ChildHandle {
         #[cfg(windows)]
         let job = job.and_then(|job| match child.raw_handle() {
             Some(handle) => match job.assign_suspended_process(handle) {
-                Ok(true) => {
-                    eprintln!("[turbo-process-debug] child assigned to JobObject");
-                    Some(job)
-                }
-                Ok(false) => {
-                    eprintln!("[turbo-process-debug] child not assigned to JobObject");
-                    None
-                }
+                Ok(true) => Some(job),
+                Ok(false) => None,
                 Err(err) => {
-                    eprintln!(
-                        "[turbo-process-debug] failed to resume suspended process after job \
-                         assignment: {err}"
-                    );
                     debug!("failed to resume suspended process after job assignment: {err}");
                     child.start_kill().ok();
                     None
@@ -375,8 +273,6 @@ impl ChildHandle {
                 target_identity,
                 #[cfg(windows)]
                 _job: job,
-                #[cfg(windows)]
-                tracked_descendants,
             },
             io: ChildIO {
                 stdin,
@@ -437,11 +333,6 @@ impl ChildHandle {
 
         let pid = child.process_id();
 
-        #[cfg(windows)]
-        let tracked_descendants = pid
-            .map(start_descendant_tracker)
-            .unwrap_or_else(empty_descendant_tracker);
-
         #[cfg(unix)]
         let target_identity = capture_target_identity(pid);
 
@@ -487,8 +378,6 @@ impl ChildHandle {
                 target_identity,
                 #[cfg(windows)]
                 _job: job,
-                #[cfg(windows)]
-                tracked_descendants,
             },
             io: ChildIO {
                 stdin: stdin.map(ChildInput::Pty),
@@ -615,7 +504,7 @@ impl ChildHandle {
     }
 
     #[cfg(windows)]
-    fn has_running_job(&self) -> bool {
+    fn has_running_windows_process_tree(&self) -> bool {
         let has_active_job = self
             ._job
             .as_ref()
@@ -638,22 +527,7 @@ impl ChildHandle {
             None => false,
         };
 
-        let tracked_descendants = {
-            let lock = self.tracked_descendants.lock().expect("not poisoned");
-            lock.iter().copied().collect::<Vec<_>>()
-        };
-        let has_tracked_descendants = tracked_descendants
-            .iter()
-            .any(|pid| super::job_object::process_exists(*pid).unwrap_or(false));
-
-        eprintln!(
-            "[turbo-process-debug] wait_for_job root_pid={:?} has_active_job={has_active_job} \
-             has_descendants={has_descendants} tracked={tracked_descendants:?} \
-             has_tracked_descendants={has_tracked_descendants}",
-            self.pid
-        );
-
-        has_active_job || has_descendants || has_tracked_descendants
+        has_active_job || has_descendants
     }
 
     #[cfg(windows)]
@@ -677,7 +551,7 @@ impl ChildHandle {
         command_rx: &mut mpsc::Receiver<ChildCommand>,
         command_rx_open: &mut bool,
     ) -> ChildExit {
-        while self.has_running_job() {
+        while self.has_running_windows_process_tree() {
             tokio::select! {
                 command = command_rx.recv(), if *command_rx_open => {
                     match command {

--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -195,6 +195,14 @@ impl ChildHandle {
         #[cfg(unix)]
         command.process_group(0);
 
+        #[cfg(windows)]
+        let job = super::job_object::JobObject::new().ok();
+
+        #[cfg(windows)]
+        if job.is_some() {
+            command.creation_flags(windows_sys::Win32::System::Threading::CREATE_SUSPENDED);
+        }
+
         let mut child = command.spawn()?;
         let pid = child.id();
 
@@ -202,11 +210,19 @@ impl ChildHandle {
         let target_identity = capture_target_identity(pid);
 
         #[cfg(windows)]
-        let job = pid.and_then(|pid| {
-            super::job_object::JobObject::new()
-                .and_then(|job| job.assign_pid(pid).map(|_| job))
-                .map_err(|e| debug!("failed to set up job object for process {pid}: {e}"))
-                .ok()
+        let job = job.and_then(|job| match child.raw_handle() {
+            Some(handle) => match job.assign_suspended_process(handle) {
+                Ok(()) => Some(job),
+                Err(err) => {
+                    debug!("failed to assign suspended process to job object: {err}");
+                    None
+                }
+            },
+            None => {
+                debug!("failed to get child process handle for job assignment");
+                child.start_kill().ok();
+                None
+            }
         });
 
         let stdin = child.stdin.take().map(ChildInput::Std);

--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -18,7 +18,7 @@
 const CHILD_POLL_INTERVAL: Duration = Duration::from_micros(50);
 const POST_EXIT_OUTPUT_DRAIN_TIMEOUT: Duration = Duration::from_millis(100);
 #[cfg(any(unix, windows))]
-const PROCESS_GROUP_DRAIN_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const PROCESS_TREE_DRAIN_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 use std::{
     fmt,
@@ -434,7 +434,7 @@ impl ChildHandle {
                             self.kill_process_group(pid);
                             return ChildExit::Killed;
                         }
-                        _ = tokio::time::sleep(PROCESS_GROUP_DRAIN_POLL_INTERVAL) => {}
+                        _ = tokio::time::sleep(PROCESS_TREE_DRAIN_POLL_INTERVAL) => {}
                     }
                 }
                 None => {
@@ -450,7 +450,7 @@ impl ChildHandle {
                                 None => *command_rx_open = false,
                             }
                         }
-                        _ = tokio::time::sleep(PROCESS_GROUP_DRAIN_POLL_INTERVAL) => {}
+                        _ = tokio::time::sleep(PROCESS_TREE_DRAIN_POLL_INTERVAL) => {}
                     }
                 }
             }
@@ -502,7 +502,7 @@ impl ChildHandle {
                         None => *command_rx_open = false,
                     }
                 }
-                _ = tokio::time::sleep(PROCESS_GROUP_DRAIN_POLL_INTERVAL) => {}
+                _ = tokio::time::sleep(PROCESS_TREE_DRAIN_POLL_INTERVAL) => {}
             }
         }
 

--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -19,6 +19,8 @@ const CHILD_POLL_INTERVAL: Duration = Duration::from_micros(50);
 const POST_EXIT_OUTPUT_DRAIN_TIMEOUT: Duration = Duration::from_millis(100);
 #[cfg(any(unix, windows))]
 const PROCESS_TREE_DRAIN_POLL_INTERVAL: Duration = Duration::from_millis(10);
+#[cfg(windows)]
+const WINDOWS_DESCENDANT_TRACKER_POLL_INTERVAL: Duration = Duration::from_millis(1);
 
 #[cfg(windows)]
 use std::collections::HashSet;
@@ -31,6 +33,8 @@ use std::{
     },
     time::Duration,
 };
+#[cfg(windows)]
+use std::{sync::mpsc as std_mpsc, thread};
 
 use portable_pty::{Child as PtyChild, MasterPty as PtyController, native_pty_system};
 use tokio::{
@@ -192,18 +196,24 @@ fn capture_target_identity(pid: Option<u32>) -> Option<TargetIdentity> {
 #[cfg(windows)]
 fn start_descendant_tracker(root_pid: u32) -> Arc<Mutex<HashSet<u32>>> {
     let tracked = Arc::new(Mutex::new(HashSet::new()));
-    let tracked_for_task = tracked.clone();
+    let tracked_for_thread = tracked.clone();
+    let (ready_tx, ready_rx) = std_mpsc::channel();
 
-    tokio::spawn(async move {
+    thread::spawn(move || {
         let mut root_missing_ticks = 0;
+        let mut ready_tx = Some(ready_tx);
         loop {
             if let Ok(descendants) = super::job_object::descendant_processes(root_pid) {
-                let mut lock = tracked_for_task.lock().expect("not poisoned");
+                let mut lock = tracked_for_thread.lock().expect("not poisoned");
                 lock.extend(descendants);
             }
 
+            if let Some(ready_tx) = ready_tx.take() {
+                ready_tx.send(()).ok();
+            }
+
             let tracked_pids = {
-                let lock = tracked_for_task.lock().expect("not poisoned");
+                let lock = tracked_for_thread.lock().expect("not poisoned");
                 lock.iter().copied().collect::<Vec<_>>()
             };
             let root_exists = super::job_object::process_exists(root_pid).unwrap_or(false);
@@ -220,9 +230,11 @@ fn start_descendant_tracker(root_pid: u32) -> Arc<Mutex<HashSet<u32>>> {
                 }
             }
 
-            tokio::time::sleep(PROCESS_TREE_DRAIN_POLL_INTERVAL).await;
+            thread::sleep(WINDOWS_DESCENDANT_TRACKER_POLL_INTERVAL);
         }
     });
+
+    ready_rx.recv().ok();
 
     tracked
 }

--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -17,7 +17,7 @@
 
 const CHILD_POLL_INTERVAL: Duration = Duration::from_micros(50);
 const POST_EXIT_OUTPUT_DRAIN_TIMEOUT: Duration = Duration::from_millis(100);
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 const PROCESS_GROUP_DRAIN_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 use std::{
@@ -459,6 +459,56 @@ impl ChildHandle {
         ChildExit::Interrupted
     }
 
+    #[cfg(windows)]
+    fn has_running_job(&self) -> bool {
+        let Some(job) = &self._job else {
+            return false;
+        };
+
+        match job.active_processes() {
+            Ok(active_processes) => active_processes > 0,
+            Err(err) => {
+                debug!("failed to query job object: {err}");
+                false
+            }
+        }
+    }
+
+    #[cfg(windows)]
+    fn terminate_job(&self) {
+        if let Some(job) = &self._job
+            && let Err(err) = job.terminate()
+        {
+            debug!("failed to terminate job object: {err}");
+        }
+    }
+
+    #[cfg(windows)]
+    async fn wait_for_job_exit(
+        &mut self,
+        command_rx: &mut mpsc::Receiver<ChildCommand>,
+        command_rx_open: &mut bool,
+    ) -> ChildExit {
+        while self.has_running_job() {
+            tokio::select! {
+                command = command_rx.recv(), if *command_rx_open => {
+                    match command {
+                        Some(ChildCommand::Kill) => {
+                            debug!("process tree drain interrupted, terminating job object");
+                            self.terminate_job();
+                            return ChildExit::Killed;
+                        }
+                        Some(ChildCommand::Shutdown(_)) => {}
+                        None => *command_rx_open = false,
+                    }
+                }
+                _ = tokio::time::sleep(PROCESS_GROUP_DRAIN_POLL_INTERVAL) => {}
+            }
+        }
+
+        ChildExit::Interrupted
+    }
+
     /// Perform a `wait` syscall on the child until it exits
     pub async fn wait(&mut self) -> io::Result<Option<i32>> {
         match &mut self.imp {
@@ -781,7 +831,45 @@ impl Child {
                 }
                 status = child.wait() => {
                     drop(controller);
-                    manager.handle_child_exit(status).await;
+                    let should_drain_process_tree = matches!(&status, Ok(Some(0)));
+
+                    #[cfg(unix)]
+                    let killed_during_drain = if should_drain_process_tree
+                        && let Some(pid) = pid
+                    {
+                        let mut command_rx_open = true;
+                        child
+                            .wait_for_process_group_exit(
+                                pid as libc::pid_t,
+                                None,
+                                &mut command_rx,
+                                &mut command_rx_open,
+                            )
+                            .await
+                            == ChildExit::Killed
+                    } else {
+                        false
+                    };
+
+                    #[cfg(windows)]
+                    let killed_during_drain = if should_drain_process_tree {
+                        let mut command_rx_open = true;
+                        child
+                            .wait_for_job_exit(&mut command_rx, &mut command_rx_open)
+                            .await
+                            == ChildExit::Killed
+                    } else {
+                        false
+                    };
+
+                    #[cfg(not(any(unix, windows)))]
+                    let killed_during_drain = false;
+
+                    if killed_during_drain {
+                        manager.exit_tx.send(Some(ChildExit::Killed)).ok();
+                    } else {
+                        manager.handle_child_exit(status).await;
+                    }
                 }
             }
 

--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -212,9 +212,11 @@ impl ChildHandle {
         #[cfg(windows)]
         let job = job.and_then(|job| match child.raw_handle() {
             Some(handle) => match job.assign_suspended_process(handle) {
-                Ok(()) => Some(job),
+                Ok(true) => Some(job),
+                Ok(false) => None,
                 Err(err) => {
-                    debug!("failed to assign suspended process to job object: {err}");
+                    debug!("failed to resume suspended process after job assignment: {err}");
+                    child.start_kill().ok();
                     None
                 }
             },
@@ -477,25 +479,43 @@ impl ChildHandle {
 
     #[cfg(windows)]
     fn has_running_job(&self) -> bool {
-        let Some(job) = &self._job else {
-            return false;
+        let has_active_job = self
+            ._job
+            .as_ref()
+            .is_some_and(|job| match job.active_processes() {
+                Ok(active_processes) => active_processes > 0,
+                Err(err) => {
+                    debug!("failed to query job object: {err}");
+                    false
+                }
+            });
+
+        let has_descendants = match self.pid {
+            Some(pid) => match super::job_object::has_descendant_processes(pid) {
+                Ok(has_descendants) => has_descendants,
+                Err(err) => {
+                    debug!("failed to query descendant processes: {err}");
+                    false
+                }
+            },
+            None => false,
         };
 
-        match job.active_processes() {
-            Ok(active_processes) => active_processes > 0,
-            Err(err) => {
-                debug!("failed to query job object: {err}");
-                false
-            }
-        }
+        has_active_job || has_descendants
     }
 
     #[cfg(windows)]
-    fn terminate_job(&self) {
+    fn terminate_windows_process_tree(&self) {
         if let Some(job) = &self._job
             && let Err(err) = job.terminate()
         {
             debug!("failed to terminate job object: {err}");
+        }
+
+        if let Some(pid) = self.pid
+            && let Err(err) = super::job_object::terminate_descendant_processes(pid)
+        {
+            debug!("failed to terminate descendant process tree: {err}");
         }
     }
 
@@ -511,7 +531,7 @@ impl ChildHandle {
                     match command {
                         Some(ChildCommand::Kill) => {
                             debug!("process tree drain interrupted, terminating job object");
-                            self.terminate_job();
+                            self.terminate_windows_process_tree();
                             return ChildExit::Killed;
                         }
                         Some(ChildCommand::Shutdown(_)) => {}

--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -202,6 +202,8 @@ fn start_descendant_tracker(root_pid: u32) -> Arc<Mutex<HashSet<u32>>> {
     thread::spawn(move || {
         let mut root_missing_ticks = 0;
         let mut ready_tx = Some(ready_tx);
+        let mut last_tracked = Vec::new();
+        eprintln!("[turbo-process-debug] descendant tracker starting root_pid={root_pid}");
         loop {
             if let Ok(descendants) = super::job_object::descendant_processes(root_pid) {
                 let mut lock = tracked_for_thread.lock().expect("not poisoned");
@@ -216,6 +218,13 @@ fn start_descendant_tracker(root_pid: u32) -> Arc<Mutex<HashSet<u32>>> {
                 let lock = tracked_for_thread.lock().expect("not poisoned");
                 lock.iter().copied().collect::<Vec<_>>()
             };
+            if tracked_pids != last_tracked {
+                eprintln!(
+                    "[turbo-process-debug] descendant tracker root_pid={root_pid} \
+                     tracked={tracked_pids:?}"
+                );
+                last_tracked = tracked_pids.clone();
+            }
             let root_exists = super::job_object::process_exists(root_pid).unwrap_or(false);
             let tracked_descendant_exists = tracked_pids
                 .iter()
@@ -226,6 +235,10 @@ fn start_descendant_tracker(root_pid: u32) -> Arc<Mutex<HashSet<u32>>> {
             } else {
                 root_missing_ticks += 1;
                 if root_missing_ticks > 100 {
+                    eprintln!(
+                        "[turbo-process-debug] descendant tracker exiting root_pid={root_pid} \
+                         tracked={tracked_pids:?}"
+                    );
                     break;
                 }
             }
@@ -258,7 +271,16 @@ impl ChildHandle {
         command.process_group(0);
 
         #[cfg(windows)]
-        let job = super::job_object::JobObject::new().ok();
+        let job = match super::job_object::JobObject::new() {
+            Ok(job) => {
+                eprintln!("[turbo-process-debug] created Windows JobObject");
+                Some(job)
+            }
+            Err(err) => {
+                eprintln!("[turbo-process-debug] failed to create Windows JobObject: {err}");
+                None
+            }
+        };
 
         #[cfg(windows)]
         if job.is_some() {
@@ -273,13 +295,25 @@ impl ChildHandle {
 
         #[cfg(windows)]
         let mut child = match command.spawn() {
-            Ok(child) => child,
+            Ok(child) => {
+                eprintln!(
+                    "[turbo-process-debug] spawned child with CREATE_BREAKAWAY_FROM_JOB pid={:?}",
+                    child.id()
+                );
+                child
+            }
             Err(err) if job.is_some() => {
+                eprintln!("[turbo-process-debug] breakaway spawn failed, falling back: {err}");
                 debug!("failed to spawn child with job breakaway: {err}");
                 let mut fallback_command = TokioCommand::from(command_for_fallback);
                 fallback_command
                     .creation_flags(windows_sys::Win32::System::Threading::CREATE_SUSPENDED);
-                fallback_command.spawn()?
+                let child = fallback_command.spawn()?;
+                eprintln!(
+                    "[turbo-process-debug] spawned child with CREATE_SUSPENDED fallback pid={:?}",
+                    child.id()
+                );
+                child
             }
             Err(err) => return Err(err),
         };
@@ -296,9 +330,19 @@ impl ChildHandle {
         #[cfg(windows)]
         let job = job.and_then(|job| match child.raw_handle() {
             Some(handle) => match job.assign_suspended_process(handle) {
-                Ok(true) => Some(job),
-                Ok(false) => None,
+                Ok(true) => {
+                    eprintln!("[turbo-process-debug] child assigned to JobObject");
+                    Some(job)
+                }
+                Ok(false) => {
+                    eprintln!("[turbo-process-debug] child not assigned to JobObject");
+                    None
+                }
                 Err(err) => {
+                    eprintln!(
+                        "[turbo-process-debug] failed to resume suspended process after job \
+                         assignment: {err}"
+                    );
                     debug!("failed to resume suspended process after job assignment: {err}");
                     child.start_kill().ok();
                     None
@@ -601,6 +645,13 @@ impl ChildHandle {
         let has_tracked_descendants = tracked_descendants
             .iter()
             .any(|pid| super::job_object::process_exists(*pid).unwrap_or(false));
+
+        eprintln!(
+            "[turbo-process-debug] wait_for_job root_pid={:?} has_active_job={has_active_job} \
+             has_descendants={has_descendants} tracked={tracked_descendants:?} \
+             has_tracked_descendants={has_tracked_descendants}",
+            self.pid
+        );
 
         has_active_job || has_descendants || has_tracked_descendants
     }

--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -20,6 +20,8 @@ const POST_EXIT_OUTPUT_DRAIN_TIMEOUT: Duration = Duration::from_millis(100);
 #[cfg(any(unix, windows))]
 const PROCESS_TREE_DRAIN_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
+#[cfg(windows)]
+use std::collections::HashSet;
 use std::{
     fmt,
     io::{self, BufRead, Read, Write},
@@ -88,6 +90,8 @@ struct ChildHandle {
     target_identity: Option<TargetIdentity>,
     #[cfg(windows)]
     _job: Option<super::job_object::JobObject>,
+    #[cfg(windows)]
+    tracked_descendants: Arc<Mutex<HashSet<u32>>>,
 }
 
 enum ChildHandleImpl {
@@ -185,6 +189,49 @@ fn capture_target_identity(pid: Option<u32>) -> Option<TargetIdentity> {
     })
 }
 
+#[cfg(windows)]
+fn start_descendant_tracker(root_pid: u32) -> Arc<Mutex<HashSet<u32>>> {
+    let tracked = Arc::new(Mutex::new(HashSet::new()));
+    let tracked_for_task = tracked.clone();
+
+    tokio::spawn(async move {
+        let mut root_missing_ticks = 0;
+        loop {
+            if let Ok(descendants) = super::job_object::descendant_processes(root_pid) {
+                let mut lock = tracked_for_task.lock().expect("not poisoned");
+                lock.extend(descendants);
+            }
+
+            let tracked_pids = {
+                let lock = tracked_for_task.lock().expect("not poisoned");
+                lock.iter().copied().collect::<Vec<_>>()
+            };
+            let root_exists = super::job_object::process_exists(root_pid).unwrap_or(false);
+            let tracked_descendant_exists = tracked_pids
+                .iter()
+                .any(|pid| super::job_object::process_exists(*pid).unwrap_or(false));
+
+            if root_exists || tracked_descendant_exists {
+                root_missing_ticks = 0;
+            } else {
+                root_missing_ticks += 1;
+                if root_missing_ticks > 100 {
+                    break;
+                }
+            }
+
+            tokio::time::sleep(PROCESS_TREE_DRAIN_POLL_INTERVAL).await;
+        }
+    });
+
+    tracked
+}
+
+#[cfg(windows)]
+fn empty_descendant_tracker() -> Arc<Mutex<HashSet<u32>>> {
+    Arc::new(Mutex::new(HashSet::new()))
+}
+
 impl ChildHandle {
     #[tracing::instrument(skip(command))]
     pub fn spawn_normal(command: Command) -> io::Result<SpawnResult> {
@@ -205,6 +252,11 @@ impl ChildHandle {
 
         let mut child = command.spawn()?;
         let pid = child.id();
+
+        #[cfg(windows)]
+        let tracked_descendants = pid
+            .map(start_descendant_tracker)
+            .unwrap_or_else(empty_descendant_tracker);
 
         #[cfg(unix)]
         let target_identity = capture_target_identity(pid);
@@ -247,6 +299,8 @@ impl ChildHandle {
                 target_identity,
                 #[cfg(windows)]
                 _job: job,
+                #[cfg(windows)]
+                tracked_descendants,
             },
             io: ChildIO {
                 stdin,
@@ -307,6 +361,11 @@ impl ChildHandle {
 
         let pid = child.process_id();
 
+        #[cfg(windows)]
+        let tracked_descendants = pid
+            .map(start_descendant_tracker)
+            .unwrap_or_else(empty_descendant_tracker);
+
         #[cfg(unix)]
         let target_identity = capture_target_identity(pid);
 
@@ -352,6 +411,8 @@ impl ChildHandle {
                 target_identity,
                 #[cfg(windows)]
                 _job: job,
+                #[cfg(windows)]
+                tracked_descendants,
             },
             io: ChildIO {
                 stdin: stdin.map(ChildInput::Pty),
@@ -501,7 +562,15 @@ impl ChildHandle {
             None => false,
         };
 
-        has_active_job || has_descendants
+        let tracked_descendants = {
+            let lock = self.tracked_descendants.lock().expect("not poisoned");
+            lock.iter().copied().collect::<Vec<_>>()
+        };
+        let has_tracked_descendants = tracked_descendants
+            .iter()
+            .any(|pid| super::job_object::process_exists(*pid).unwrap_or(false));
+
+        has_active_job || has_descendants || has_tracked_descendants
     }
 
     #[cfg(windows)]

--- a/crates/turborepo-process/src/job_object.rs
+++ b/crates/turborepo-process/src/job_object.rs
@@ -6,14 +6,15 @@
 // `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, we ensure the entire process tree
 // is terminated when the job handle is closed.
 
-use std::{io, os::windows::io::RawHandle};
+use std::{collections::HashSet, io, os::windows::io::RawHandle};
 
 use tracing::debug;
 use windows_sys::Win32::{
     Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE},
     System::{
         Diagnostics::ToolHelp::{
-            CreateToolhelp32Snapshot, TH32CS_SNAPTHREAD, THREADENTRY32, Thread32First, Thread32Next,
+            CreateToolhelp32Snapshot, PROCESSENTRY32, Process32First, Process32Next,
+            TH32CS_SNAPPROCESS, TH32CS_SNAPTHREAD, THREADENTRY32, Thread32First, Thread32Next,
         },
         JobObjects::{
             AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
@@ -23,7 +24,7 @@ use windows_sys::Win32::{
         },
         Threading::{
             GetProcessId, OpenProcess, OpenThread, PROCESS_SET_QUOTA, PROCESS_TERMINATE,
-            ResumeThread, THREAD_SUSPEND_RESUME,
+            ResumeThread, THREAD_SUSPEND_RESUME, TerminateProcess,
         },
     },
 };
@@ -93,19 +94,20 @@ impl JobObject {
         }
     }
 
-    pub fn assign_suspended_process(&self, process_handle: RawHandle) -> io::Result<()> {
+    pub fn assign_suspended_process(&self, process_handle: RawHandle) -> io::Result<bool> {
         let process_handle = process_handle as HANDLE;
 
-        let assign_result = if unsafe { AssignProcessToJobObject(self.handle, process_handle) } == 0
-        {
-            Err(io::Error::last_os_error())
+        let assigned = if unsafe { AssignProcessToJobObject(self.handle, process_handle) } == 0 {
+            let err = io::Error::last_os_error();
+            debug!("failed to assign suspended process to job object: {err}");
+            false
         } else {
-            Ok(())
+            true
         };
 
         resume_threads(process_handle)?;
 
-        assign_result
+        Ok(assigned)
     }
 
     pub fn active_processes(&self) -> io::Result<u32> {
@@ -138,6 +140,28 @@ impl JobObject {
     }
 }
 
+pub fn has_descendant_processes(root_pid: u32) -> io::Result<bool> {
+    Ok(!descendant_processes(root_pid)?.is_empty())
+}
+
+pub fn terminate_descendant_processes(root_pid: u32) -> io::Result<()> {
+    let mut first_error = None;
+    let mut descendants = descendant_processes(root_pid)?;
+    descendants.reverse();
+
+    for pid in descendants {
+        if let Err(err) = terminate_process(pid) {
+            debug!("failed to terminate descendant process {pid}: {err}");
+            first_error.get_or_insert(err);
+        }
+    }
+
+    match first_error {
+        Some(err) => Err(err),
+        None => Ok(()),
+    }
+}
+
 impl Drop for JobObject {
     fn drop(&mut self) {
         unsafe {
@@ -162,6 +186,82 @@ fn resume_threads(process_handle: HANDLE) -> io::Result<()> {
         CloseHandle(snapshot);
     }
     result
+}
+
+fn descendant_processes(root_pid: u32) -> io::Result<Vec<u32>> {
+    let entries = process_entries()?;
+    let mut visited = HashSet::from([root_pid]);
+    let mut current_generation = vec![root_pid];
+    let mut descendants = Vec::new();
+
+    while !current_generation.is_empty() {
+        let mut next_generation = Vec::new();
+        for (pid, parent_pid) in &entries {
+            if current_generation.contains(parent_pid) && visited.insert(*pid) {
+                descendants.push(*pid);
+                next_generation.push(*pid);
+            }
+        }
+        current_generation = next_generation;
+    }
+
+    Ok(descendants)
+}
+
+fn process_entries() -> io::Result<Vec<(u32, u32)>> {
+    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) };
+    if snapshot == INVALID_HANDLE_VALUE {
+        return Err(io::Error::last_os_error());
+    }
+
+    let result = process_entries_from_snapshot(snapshot);
+    unsafe {
+        CloseHandle(snapshot);
+    }
+    result
+}
+
+fn process_entries_from_snapshot(snapshot: HANDLE) -> io::Result<Vec<(u32, u32)>> {
+    let mut entry = PROCESSENTRY32 {
+        dwSize: std::mem::size_of::<PROCESSENTRY32>() as u32,
+        cntUsage: 0,
+        th32ProcessID: 0,
+        th32DefaultHeapID: 0,
+        th32ModuleID: 0,
+        cntThreads: 0,
+        th32ParentProcessID: 0,
+        pcPriClassBase: 0,
+        dwFlags: 0,
+        szExeFile: [0; 260],
+    };
+
+    let mut entries = Vec::new();
+    let mut has_entry = unsafe { Process32First(snapshot, &mut entry) } != 0;
+    while has_entry {
+        entries.push((entry.th32ProcessID, entry.th32ParentProcessID));
+        has_entry = unsafe { Process32Next(snapshot, &mut entry) } != 0;
+    }
+
+    Ok(entries)
+}
+
+fn terminate_process(pid: u32) -> io::Result<()> {
+    let process_handle = unsafe { OpenProcess(PROCESS_TERMINATE, 0, pid) };
+    if process_handle.is_null() {
+        return Err(io::Error::last_os_error());
+    }
+
+    let terminate_result = unsafe { TerminateProcess(process_handle, 1) };
+    let close_result = unsafe { CloseHandle(process_handle) };
+
+    if terminate_result == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if close_result == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(())
 }
 
 fn resume_threads_from_snapshot(snapshot: HANDLE, process_id: u32) -> io::Result<()> {

--- a/crates/turborepo-process/src/job_object.rs
+++ b/crates/turborepo-process/src/job_object.rs
@@ -14,8 +14,9 @@ use windows_sys::Win32::{
     System::{
         JobObjects::{
             AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
-            JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
-            SetInformationJobObject,
+            JOBOBJECT_BASIC_ACCOUNTING_INFORMATION, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+            JobObjectBasicAccountingInformation, JobObjectExtendedLimitInformation,
+            QueryInformationJobObject, SetInformationJobObject, TerminateJobObject,
         },
         Threading::{OpenProcess, PROCESS_SET_QUOTA, PROCESS_TERMINATE},
     },
@@ -80,6 +81,35 @@ impl JobObject {
                 let err = io::Error::last_os_error();
                 debug!("failed to assign process {pid} to job object: {err}");
                 return Err(err);
+            }
+
+            Ok(())
+        }
+    }
+
+    pub fn active_processes(&self) -> io::Result<u32> {
+        unsafe {
+            let mut info: JOBOBJECT_BASIC_ACCOUNTING_INFORMATION = std::mem::zeroed();
+            let result = QueryInformationJobObject(
+                self.handle,
+                JobObjectBasicAccountingInformation,
+                &mut info as *mut _ as *mut _,
+                std::mem::size_of::<JOBOBJECT_BASIC_ACCOUNTING_INFORMATION>() as u32,
+                std::ptr::null_mut(),
+            );
+
+            if result == 0 {
+                return Err(io::Error::last_os_error());
+            }
+
+            Ok(info.ActiveProcesses)
+        }
+    }
+
+    pub fn terminate(&self) -> io::Result<()> {
+        unsafe {
+            if TerminateJobObject(self.handle, 1) == 0 {
+                return Err(io::Error::last_os_error());
             }
 
             Ok(())

--- a/crates/turborepo-process/src/job_object.rs
+++ b/crates/turborepo-process/src/job_object.rs
@@ -99,13 +99,16 @@ impl JobObject {
 
         let assigned = if unsafe { AssignProcessToJobObject(self.handle, process_handle) } == 0 {
             let err = io::Error::last_os_error();
+            eprintln!("[turbo-process-debug] AssignProcessToJobObject failed: {err}");
             debug!("failed to assign suspended process to job object: {err}");
             false
         } else {
+            eprintln!("[turbo-process-debug] AssignProcessToJobObject succeeded");
             true
         };
 
         resume_threads(process_handle)?;
+        eprintln!("[turbo-process-debug] resumed suspended process threads");
 
         Ok(assigned)
     }
@@ -212,6 +215,26 @@ pub fn process_exists(pid: u32) -> io::Result<bool> {
     Ok(process_entries()?
         .iter()
         .any(|(entry_pid, _)| *entry_pid == pid))
+}
+
+#[cfg(test)]
+pub fn debug_process_snapshot(root_pid: u32, worker_pid: Option<u32>) -> String {
+    match process_entries() {
+        Ok(entries) => {
+            let descendants = descendant_processes(root_pid)
+                .map(|descendants| format!("{descendants:?}"))
+                .unwrap_or_else(|err| format!("error: {err}"));
+            let root_entry = entries.iter().find(|(pid, _)| *pid == root_pid).copied();
+            let worker_entry = worker_pid
+                .and_then(|worker_pid| entries.iter().find(|(pid, _)| *pid == worker_pid).copied());
+
+            format!(
+                "root_pid={root_pid} root_entry={root_entry:?} worker_pid={worker_pid:?} \
+                 worker_entry={worker_entry:?} descendants={descendants}"
+            )
+        }
+        Err(err) => format!("process snapshot error: {err}"),
+    }
 }
 
 fn process_entries() -> io::Result<Vec<(u32, u32)>> {

--- a/crates/turborepo-process/src/job_object.rs
+++ b/crates/turborepo-process/src/job_object.rs
@@ -6,19 +6,25 @@
 // `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, we ensure the entire process tree
 // is terminated when the job handle is closed.
 
-use std::io;
+use std::{io, os::windows::io::RawHandle};
 
 use tracing::debug;
 use windows_sys::Win32::{
-    Foundation::{CloseHandle, HANDLE},
+    Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE},
     System::{
+        Diagnostics::ToolHelp::{
+            CreateToolhelp32Snapshot, TH32CS_SNAPTHREAD, THREADENTRY32, Thread32First, Thread32Next,
+        },
         JobObjects::{
             AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
             JOBOBJECT_BASIC_ACCOUNTING_INFORMATION, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
             JobObjectBasicAccountingInformation, JobObjectExtendedLimitInformation,
             QueryInformationJobObject, SetInformationJobObject, TerminateJobObject,
         },
-        Threading::{OpenProcess, PROCESS_SET_QUOTA, PROCESS_TERMINATE},
+        Threading::{
+            GetProcessId, OpenProcess, OpenThread, PROCESS_SET_QUOTA, PROCESS_TERMINATE,
+            ResumeThread, THREAD_SUSPEND_RESUME,
+        },
     },
 };
 
@@ -87,6 +93,21 @@ impl JobObject {
         }
     }
 
+    pub fn assign_suspended_process(&self, process_handle: RawHandle) -> io::Result<()> {
+        let process_handle = process_handle as HANDLE;
+
+        let assign_result = if unsafe { AssignProcessToJobObject(self.handle, process_handle) } == 0
+        {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
+        };
+
+        resume_threads(process_handle)?;
+
+        assign_result
+    }
+
     pub fn active_processes(&self) -> io::Result<u32> {
         unsafe {
             let mut info: JOBOBJECT_BASIC_ACCOUNTING_INFORMATION = std::mem::zeroed();
@@ -123,4 +144,73 @@ impl Drop for JobObject {
             CloseHandle(self.handle);
         }
     }
+}
+
+fn resume_threads(process_handle: HANDLE) -> io::Result<()> {
+    let process_id = unsafe { GetProcessId(process_handle) };
+    if process_id == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0) };
+    if snapshot == INVALID_HANDLE_VALUE {
+        return Err(io::Error::last_os_error());
+    }
+
+    let result = resume_threads_from_snapshot(snapshot, process_id);
+    unsafe {
+        CloseHandle(snapshot);
+    }
+    result
+}
+
+fn resume_threads_from_snapshot(snapshot: HANDLE, process_id: u32) -> io::Result<()> {
+    let mut entry = THREADENTRY32 {
+        dwSize: std::mem::size_of::<THREADENTRY32>() as u32,
+        cntUsage: 0,
+        th32ThreadID: 0,
+        th32OwnerProcessID: 0,
+        tpBasePri: 0,
+        tpDeltaPri: 0,
+        dwFlags: 0,
+    };
+
+    let mut found_thread = false;
+    let mut has_entry = unsafe { Thread32First(snapshot, &mut entry) } != 0;
+    while has_entry {
+        if entry.th32OwnerProcessID == process_id {
+            found_thread = true;
+            resume_thread(entry.th32ThreadID)?;
+        }
+
+        has_entry = unsafe { Thread32Next(snapshot, &mut entry) } != 0;
+    }
+
+    if found_thread {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("no threads found for process {process_id}"),
+        ))
+    }
+}
+
+fn resume_thread(thread_id: u32) -> io::Result<()> {
+    let thread_handle = unsafe { OpenThread(THREAD_SUSPEND_RESUME, 0, thread_id) };
+    if thread_handle.is_null() {
+        return Err(io::Error::last_os_error());
+    }
+
+    let resume_result = unsafe { ResumeThread(thread_handle) };
+    let close_result = unsafe { CloseHandle(thread_handle) };
+
+    if resume_result == u32::MAX {
+        return Err(io::Error::last_os_error());
+    }
+    if close_result == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(())
 }

--- a/crates/turborepo-process/src/job_object.rs
+++ b/crates/turborepo-process/src/job_object.rs
@@ -82,12 +82,15 @@ impl JobObject {
             }
 
             let result = AssignProcessToJobObject(self.handle, process_handle);
-            CloseHandle(process_handle);
+            let assign_error = (result == 0).then(io::Error::last_os_error);
+            let close_result = CloseHandle(process_handle);
 
-            if result == 0 {
-                let err = io::Error::last_os_error();
+            if let Some(err) = assign_error {
                 debug!("failed to assign process {pid} to job object: {err}");
                 return Err(err);
+            }
+            if close_result == 0 {
+                return Err(io::Error::last_os_error());
             }
 
             Ok(())
@@ -252,10 +255,11 @@ fn terminate_process(pid: u32) -> io::Result<()> {
     }
 
     let terminate_result = unsafe { TerminateProcess(process_handle, 1) };
+    let terminate_error = (terminate_result == 0).then(io::Error::last_os_error);
     let close_result = unsafe { CloseHandle(process_handle) };
 
-    if terminate_result == 0 {
-        return Err(io::Error::last_os_error());
+    if let Some(err) = terminate_error {
+        return Err(err);
     }
     if close_result == 0 {
         return Err(io::Error::last_os_error());
@@ -303,10 +307,11 @@ fn resume_thread(thread_id: u32) -> io::Result<()> {
     }
 
     let resume_result = unsafe { ResumeThread(thread_handle) };
+    let resume_error = (resume_result == u32::MAX).then(io::Error::last_os_error);
     let close_result = unsafe { CloseHandle(thread_handle) };
 
-    if resume_result == u32::MAX {
-        return Err(io::Error::last_os_error());
+    if let Some(err) = resume_error {
+        return Err(err);
     }
     if close_result == 0 {
         return Err(io::Error::last_os_error());

--- a/crates/turborepo-process/src/job_object.rs
+++ b/crates/turborepo-process/src/job_object.rs
@@ -188,7 +188,7 @@ fn resume_threads(process_handle: HANDLE) -> io::Result<()> {
     result
 }
 
-fn descendant_processes(root_pid: u32) -> io::Result<Vec<u32>> {
+pub fn descendant_processes(root_pid: u32) -> io::Result<Vec<u32>> {
     let entries = process_entries()?;
     let mut visited = HashSet::from([root_pid]);
     let mut current_generation = vec![root_pid];
@@ -206,6 +206,12 @@ fn descendant_processes(root_pid: u32) -> io::Result<Vec<u32>> {
     }
 
     Ok(descendants)
+}
+
+pub fn process_exists(pid: u32) -> io::Result<bool> {
+    Ok(process_entries()?
+        .iter()
+        .any(|(entry_pid, _)| *entry_pid == pid))
 }
 
 fn process_entries() -> io::Result<Vec<(u32, u32)>> {

--- a/crates/turborepo-process/src/job_object.rs
+++ b/crates/turborepo-process/src/job_object.rs
@@ -99,16 +99,13 @@ impl JobObject {
 
         let assigned = if unsafe { AssignProcessToJobObject(self.handle, process_handle) } == 0 {
             let err = io::Error::last_os_error();
-            eprintln!("[turbo-process-debug] AssignProcessToJobObject failed: {err}");
             debug!("failed to assign suspended process to job object: {err}");
             false
         } else {
-            eprintln!("[turbo-process-debug] AssignProcessToJobObject succeeded");
             true
         };
 
         resume_threads(process_handle)?;
-        eprintln!("[turbo-process-debug] resumed suspended process threads");
 
         Ok(assigned)
     }
@@ -209,32 +206,6 @@ pub fn descendant_processes(root_pid: u32) -> io::Result<Vec<u32>> {
     }
 
     Ok(descendants)
-}
-
-pub fn process_exists(pid: u32) -> io::Result<bool> {
-    Ok(process_entries()?
-        .iter()
-        .any(|(entry_pid, _)| *entry_pid == pid))
-}
-
-#[cfg(test)]
-pub fn debug_process_snapshot(root_pid: u32, worker_pid: Option<u32>) -> String {
-    match process_entries() {
-        Ok(entries) => {
-            let descendants = descendant_processes(root_pid)
-                .map(|descendants| format!("{descendants:?}"))
-                .unwrap_or_else(|err| format!("error: {err}"));
-            let root_entry = entries.iter().find(|(pid, _)| *pid == root_pid).copied();
-            let worker_entry = worker_pid
-                .and_then(|worker_pid| entries.iter().find(|(pid, _)| *pid == worker_pid).copied());
-
-            format!(
-                "root_pid={root_pid} root_entry={root_entry:?} worker_pid={worker_pid:?} \
-                 worker_entry={worker_entry:?} descendants={descendants}"
-            )
-        }
-        Err(err) => format!("process snapshot error: {err}"),
-    }
 }
 
 fn process_entries() -> io::Result<Vec<(u32, u32)>> {

--- a/crates/turborepo-process/src/lib.rs
+++ b/crates/turborepo-process/src/lib.rs
@@ -698,4 +698,65 @@ mod test {
 
         let _ = fs::remove_file(pid_file);
     }
+
+    #[tokio::test]
+    async fn test_normal_exit_waits_for_worker_before_completing() {
+        let manager = ProcessManager::new(false);
+        let marker_file =
+            std::env::temp_dir().join(format!("turbo-normal-exit-marker-{}", std::process::id()));
+        let pid_file =
+            std::env::temp_dir().join(format!("turbo-normal-exit-worker-{}", std::process::id()));
+        let _ = fs::remove_file(&marker_file);
+        let _ = fs::remove_file(&pid_file);
+
+        let mut command = Command::new("node");
+        command.args([
+            std::ffi::OsString::from("./test/scripts/normal_exit_worker.js"),
+            marker_file.as_os_str().to_os_string(),
+            pid_file.as_os_str().to_os_string(),
+            std::ffi::OsString::from("800"),
+        ]);
+        let mut child = manager
+            .spawn(command, Duration::from_secs(30), test_task_id())
+            .unwrap()
+            .unwrap();
+
+        for _ in 0..50 {
+            if pid_file.exists() {
+                break;
+            }
+            sleep(Duration::from_millis(20)).await;
+        }
+        assert!(
+            pid_file.exists(),
+            "worker pid file should have been written"
+        );
+
+        let start = Instant::now();
+        let exit = child.wait().await;
+        let elapsed = start.elapsed();
+        let marker_existed_when_wait_returned = marker_file.exists();
+
+        if !marker_existed_when_wait_returned {
+            for _ in 0..100 {
+                if marker_file.exists() {
+                    break;
+                }
+                sleep(Duration::from_millis(20)).await;
+            }
+        }
+
+        let _ = fs::remove_file(&marker_file);
+        let _ = fs::remove_file(&pid_file);
+
+        assert_eq!(exit, Some(ChildExit::Finished(Some(0))));
+        assert!(
+            marker_existed_when_wait_returned,
+            "child.wait() returned before the worker wrote its output"
+        );
+        assert!(
+            elapsed >= Duration::from_millis(700),
+            "child.wait() should have blocked for the worker; only waited {elapsed:?}"
+        );
+    }
 }

--- a/crates/turborepo-process/src/lib.rs
+++ b/crates/turborepo-process/src/lib.rs
@@ -731,28 +731,11 @@ mod test {
             pid_file.exists(),
             "worker pid file should have been written"
         );
-        let worker_pid = fs::read_to_string(&pid_file)
-            .ok()
-            .and_then(|contents| contents.trim().parse::<u32>().ok());
-        #[cfg(windows)]
-        let before_wait_snapshot = child
-            .pid()
-            .map(|pid| job_object::debug_process_snapshot(pid, worker_pid))
-            .unwrap_or_else(|| "missing child pid before wait".to_string());
-        #[cfg(windows)]
-        eprintln!("[turbo-process-debug] before wait: {before_wait_snapshot}");
 
         let start = Instant::now();
         let exit = child.wait().await;
         let elapsed = start.elapsed();
         let marker_existed_when_wait_returned = marker_file.exists();
-        #[cfg(windows)]
-        let after_wait_snapshot = child
-            .pid()
-            .map(|pid| job_object::debug_process_snapshot(pid, worker_pid))
-            .unwrap_or_else(|| "missing child pid after wait".to_string());
-        #[cfg(windows)]
-        eprintln!("[turbo-process-debug] after wait: {after_wait_snapshot}");
 
         if !marker_existed_when_wait_returned {
             for _ in 0..100 {
@@ -762,13 +745,6 @@ mod test {
                 sleep(Duration::from_millis(20)).await;
             }
         }
-        #[cfg(windows)]
-        let after_marker_settle_snapshot = child
-            .pid()
-            .map(|pid| job_object::debug_process_snapshot(pid, worker_pid))
-            .unwrap_or_else(|| "missing child pid after marker settle".to_string());
-        #[cfg(windows)]
-        eprintln!("[turbo-process-debug] after marker settle: {after_marker_settle_snapshot}");
 
         let _ = fs::remove_file(&marker_file);
         let _ = fs::remove_file(&pid_file);
@@ -776,23 +752,7 @@ mod test {
         assert_eq!(exit, Some(ChildExit::Finished(Some(0))));
         assert!(
             marker_existed_when_wait_returned,
-            "child.wait() returned before the worker wrote its output; exit={exit:?}; \
-             elapsed={elapsed:?}; worker_pid={worker_pid:?}; marker_exists_after_settle={};{}",
-            marker_file.exists(),
-            {
-                #[cfg(windows)]
-                {
-                    format!(
-                        " before_wait=({before_wait_snapshot}); \
-                         after_wait=({after_wait_snapshot}); \
-                         after_marker_settle=({after_marker_settle_snapshot})"
-                    )
-                }
-                #[cfg(not(windows))]
-                {
-                    String::new()
-                }
-            }
+            "child.wait() returned before the worker wrote its output"
         );
         assert!(
             elapsed >= Duration::from_millis(700),

--- a/crates/turborepo-process/src/lib.rs
+++ b/crates/turborepo-process/src/lib.rs
@@ -731,11 +731,28 @@ mod test {
             pid_file.exists(),
             "worker pid file should have been written"
         );
+        let worker_pid = fs::read_to_string(&pid_file)
+            .ok()
+            .and_then(|contents| contents.trim().parse::<u32>().ok());
+        #[cfg(windows)]
+        let before_wait_snapshot = child
+            .pid()
+            .map(|pid| job_object::debug_process_snapshot(pid, worker_pid))
+            .unwrap_or_else(|| "missing child pid before wait".to_string());
+        #[cfg(windows)]
+        eprintln!("[turbo-process-debug] before wait: {before_wait_snapshot}");
 
         let start = Instant::now();
         let exit = child.wait().await;
         let elapsed = start.elapsed();
         let marker_existed_when_wait_returned = marker_file.exists();
+        #[cfg(windows)]
+        let after_wait_snapshot = child
+            .pid()
+            .map(|pid| job_object::debug_process_snapshot(pid, worker_pid))
+            .unwrap_or_else(|| "missing child pid after wait".to_string());
+        #[cfg(windows)]
+        eprintln!("[turbo-process-debug] after wait: {after_wait_snapshot}");
 
         if !marker_existed_when_wait_returned {
             for _ in 0..100 {
@@ -745,6 +762,13 @@ mod test {
                 sleep(Duration::from_millis(20)).await;
             }
         }
+        #[cfg(windows)]
+        let after_marker_settle_snapshot = child
+            .pid()
+            .map(|pid| job_object::debug_process_snapshot(pid, worker_pid))
+            .unwrap_or_else(|| "missing child pid after marker settle".to_string());
+        #[cfg(windows)]
+        eprintln!("[turbo-process-debug] after marker settle: {after_marker_settle_snapshot}");
 
         let _ = fs::remove_file(&marker_file);
         let _ = fs::remove_file(&pid_file);
@@ -752,7 +776,23 @@ mod test {
         assert_eq!(exit, Some(ChildExit::Finished(Some(0))));
         assert!(
             marker_existed_when_wait_returned,
-            "child.wait() returned before the worker wrote its output"
+            "child.wait() returned before the worker wrote its output; exit={exit:?}; \
+             elapsed={elapsed:?}; worker_pid={worker_pid:?}; marker_exists_after_settle={};{}",
+            marker_file.exists(),
+            {
+                #[cfg(windows)]
+                {
+                    format!(
+                        " before_wait=({before_wait_snapshot}); \
+                         after_wait=({after_wait_snapshot}); \
+                         after_marker_settle=({after_marker_settle_snapshot})"
+                    )
+                }
+                #[cfg(not(windows))]
+                {
+                    String::new()
+                }
+            }
         );
         assert!(
             elapsed >= Duration::from_millis(700),

--- a/crates/turborepo-process/test/scripts/normal_exit_worker.js
+++ b/crates/turborepo-process/test/scripts/normal_exit_worker.js
@@ -20,4 +20,5 @@ if (mode === "worker") {
 
   fs.writeFileSync(pidPath, `${worker.pid}\n`);
   worker.unref();
+  setTimeout(() => {}, 100);
 }

--- a/crates/turborepo-process/test/scripts/normal_exit_worker.js
+++ b/crates/turborepo-process/test/scripts/normal_exit_worker.js
@@ -15,6 +15,7 @@ if (mode === "worker") {
   const pidPath = process.argv[3];
   const delayMs = process.argv[4];
   const worker = spawn(process.execPath, [__filename, "worker", markerPath, delayMs], {
+    detached: process.platform === "win32",
     stdio: "ignore",
   });
 

--- a/crates/turborepo-process/test/scripts/normal_exit_worker.js
+++ b/crates/turborepo-process/test/scripts/normal_exit_worker.js
@@ -20,5 +20,4 @@ if (mode === "worker") {
 
   fs.writeFileSync(pidPath, `${worker.pid}\n`);
   worker.unref();
-  setTimeout(() => {}, 100);
 }

--- a/crates/turborepo-process/test/scripts/normal_exit_worker.js
+++ b/crates/turborepo-process/test/scripts/normal_exit_worker.js
@@ -1,0 +1,23 @@
+const { spawn } = require("node:child_process");
+const fs = require("node:fs");
+
+const mode = process.argv[2];
+
+if (mode === "worker") {
+  const markerPath = process.argv[3];
+  const delayMs = Number(process.argv[4]);
+
+  setTimeout(() => {
+    fs.writeFileSync(markerPath, "done\n");
+  }, delayMs);
+} else {
+  const markerPath = process.argv[2];
+  const pidPath = process.argv[3];
+  const delayMs = process.argv[4];
+  const worker = spawn(process.execPath, [__filename, "worker", markerPath, delayMs], {
+    stdio: "ignore",
+  });
+
+  fs.writeFileSync(pidPath, `${worker.pid}\n`);
+  worker.unref();
+}


### PR DESCRIPTION
## Summary

- Ensures successful task completion waits for surviving worker processes before dependents can run.
- Extends Windows Job Object handling to observe and terminate process trees instead of dropping the job on direct-child exit.
- Adds regression coverage for a parent process that exits before its worker writes output.

Closes #12786