### PR TITLE
fix: Avoid path-racy chmod during directory restore

### DIFF
--- a/crates/turborepo-cache/src/cache_archive/restore.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore.rs
@@ -1836,6 +1836,43 @@ mod tests {
         }
 
         #[test]
+        fn test_directory_restore_does_not_chmod_through_symlink() -> Result<()> {
+            use std::os::unix::fs::PermissionsExt;
+
+            let output_dir = tempdir()?;
+            let output_dir_path = output_dir.path().to_string_lossy().into_owned();
+            let anchor = AbsoluteSystemPath::new(&output_dir_path)?;
+            let target = anchor.join_component("target");
+            target.create_dir_all()?;
+            fs::set_permissions(target.as_path(), fs::Permissions::from_mode(0o700))?;
+
+            let tar = generate_raw_tar(&[
+                RawTarEntry::Symlink {
+                    link_path: "link",
+                    link_target: "target",
+                },
+                RawTarEntry::Directory { path: "link" },
+            ]);
+
+            let mut reader = CacheReader::from_reader(&tar[..], false)?;
+            reader.restore(anchor, None)?;
+
+            let mode = target.symlink_metadata()?.permissions().mode() & 0o777;
+            assert_eq!(
+                mode, 0o700,
+                "directory restore must not chmod symlink target"
+            );
+            assert!(
+                anchor
+                    .join_component("link")
+                    .symlink_metadata()?
+                    .is_symlink()
+            );
+
+            Ok(())
+        }
+
+        #[test]
         fn test_many_concurrent_restores() -> Result<()> {
             let output_dir = tempdir()?;
             let num_threads = 10;

--- a/crates/turborepo-cache/src/cache_archive/restore_directory.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore_directory.rs
@@ -141,28 +141,38 @@ impl CachedDirTree {
             );
         }
 
-        // If we have made it here we know that it is safe to call fs::create_dir_all
-        // on the join of anchor and processed_name.
-        //
-        // This could _still_ error, but we don't care.
+        // Directory modes are only applied when creating directories. A later
+        // path-based chmod could be redirected if a checked component is swapped.
         let resolved_name = anchor.resolve(processed_name);
         let directory_exists = resolved_name.try_exists();
         if matches!(directory_exists, Ok(false)) {
-            resolved_name.create_dir_all()?;
-        }
-
-        #[cfg(unix)]
-        {
-            use std::{fs, os::unix::fs::PermissionsExt};
-
-            let metadata = resolved_name.symlink_metadata()?;
-            let mut permissions = metadata.permissions();
-            permissions.set_mode(mode);
-            fs::set_permissions(&resolved_name, permissions)?;
+            create_dir_all_with_mode(&resolved_name, mode)?;
         }
 
         Ok(())
     }
+}
+
+#[cfg(unix)]
+fn create_dir_all_with_mode(path: &AbsoluteSystemPath, mode: u32) -> io::Result<()> {
+    use std::os::unix::fs::DirBuilderExt;
+
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(mode & 0o7777)
+        .create(path.as_path())
+}
+
+#[cfg(windows)]
+fn create_dir_all_with_mode(path: &AbsoluteSystemPath, _mode: u32) -> io::Result<()> {
+    // Windows restore does not apply tar modes, so there is no chmod equivalent
+    // to move to creation time.
+    path.create_dir_all()
+}
+
+#[cfg(not(any(unix, windows)))]
+fn create_dir_all_with_mode(path: &AbsoluteSystemPath, _mode: u32) -> io::Result<()> {
+    path.create_dir_all()
 }
 
 fn check_path(


### PR DESCRIPTION
## Summary
Avoid applying directory modes through a path after restore validation, where a swapped component could redirect chmod to another target.

On Unix, restored directory modes are applied at creation time. Windows does not apply tar modes in this restore path.

## Testing
- cargo test -p turborepo-cache
- pre-push hook: lint-staged, turbo run format check:toml, cargo fmt --check, cargo lint, cargo check --workspace