### PR TITLE
chore: Deny Rust panic extraction by default

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [alias]
-lint = "clippy --workspace --features rustls-tls --all-targets -- -D warnings"
+lint = "clippy --workspace --features rustls-tls --lib --bins --examples --benches -- -D warnings"
 
 [env]
 CARGO_WORKSPACE_DIR = { value = "", relative = true }
@@ -33,5 +33,4 @@ rustflags = [
   "-Csymbol-mangling-version=v0",
   "-Clink-arg=-fuse-ld=lld"
 ]
-
 

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -33,5 +33,3 @@ rustflags = [
   "-Csymbol-mangling-version=v0",
   "-Clink-arg=-fuse-ld=lld"
 ]
-
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,12 @@ When making changes to the codebase, check if the following docs need updates:
 - You are not allowed to use `--no-verify` when making a commit or push.
 - If you do not have dependencies available, you can download them with `pnpm install --frozen-lockfile`.
 
+### Rust panic extraction policy
+
+- Workspace Clippy lints deny `.unwrap()`, `.unwrap_err()`, `.unwrap_none()`, and `.expect()` in Rust targets covered by `cargo lint`.
+- Crates with existing implementation-code violations may temporarily allow `clippy::unwrap_used` and `clippy::expect_used` at the crate root; remove those allows as each crate is cleaned up.
+- Tests are exempt from this panic-extraction policy, but still linted by `cargo lint` with panic-extraction lints allowed under `cfg(test)`.
+
 ### PR Title Format
 
 PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/). See [`.github/workflows/lint-pr-title.yml`](./.github/workflows/lint-pr-title.yml) for the enforced constraints.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,12 @@ When making changes to the codebase, check if the following docs need updates:
 - You are not allowed to use `--no-verify` when making a commit or push.
 - If you do not have dependencies available, you can download them with `pnpm install --frozen-lockfile`.
 
+### Rust panic extraction policy
+
+- Workspace Clippy lints deny `.unwrap()`, `.unwrap_err()`, `.unwrap_none()`, and `.expect()` in Rust targets covered by `cargo lint`.
+- Crates with existing implementation-code violations may temporarily allow `clippy::unwrap_used` and `clippy::expect_used` at the crate root; remove those allows as each crate is cleaned up.
+- Tests are exempt from this policy.
+
 ### PR Title Format
 
 PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/). See [`.github/workflows/lint-pr-title.yml`](./.github/workflows/lint-pr-title.yml) for the enforced constraints.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ Thank you for your interest in contributing to Turborepo!
 - [Building Turborepo](#building-turborepo)
   - [TLS Implementation](#tls-implementation)
 - [Running tests](#running-tests)
+- [Running Rust checks](#running-rust-checks)
 - [Manually testing `turbo`](#manually-testing-turbo)
   - [Repositories to test with](#repositories-to-test-with)
 - [Debugging tips](#debugging-tips)
@@ -109,6 +110,16 @@ cargo test -p <module>
   ```bash
   cargo test -p turbo --test force_test
   ```
+
+## Running Rust checks
+
+Run Clippy with:
+
+```bash
+cargo lint
+```
+
+Rust program targets deny `.unwrap()`, `.unwrap_err()`, `.unwrap_none()`, and `.expect()` by default. Tests are exempt. Existing implementation-code violations are temporarily allowed at crate roots while they are removed incrementally.
 
 ## Manually testing `turbo`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ Thank you for your interest in contributing to Turborepo!
 - [Building Turborepo](#building-turborepo)
   - [TLS Implementation](#tls-implementation)
 - [Running tests](#running-tests)
+- [Running Rust checks](#running-rust-checks)
 - [Manually testing `turbo`](#manually-testing-turbo)
   - [Repositories to test with](#repositories-to-test-with)
 - [Debugging tips](#debugging-tips)
@@ -109,6 +110,16 @@ cargo test -p <module>
   ```bash
   cargo test -p turbo --test force_test
   ```
+
+## Running Rust checks
+
+Run Clippy with:
+
+```bash
+cargo lint
+```
+
+Rust targets deny `.unwrap()`, `.unwrap_err()`, `.unwrap_none()`, and `.expect()` by default. Tests are exempt from that panic-extraction policy, but still linted for other Clippy warnings. Existing implementation-code violations are temporarily allowed at crate roots while they are removed incrementally.
 
 ## Manually testing `turbo`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,9 @@ turborepo = ["path:crates/turborepo*"]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(debug_assert)'] }
 
 [workspace.lints.clippy]
+expect_used = "deny"
 too_many_arguments = "allow"
+unwrap_used = "deny"
 
 [profile.dev]
 debug = 0

--- a/clippy.toml
+++ b/clippy.toml
@@ -7,3 +7,8 @@ disallowed-methods = [
   # Instead use VecDeque::with_capacity to make it explicit or opt-out of that.
   "std::collections::VecDeque::new",
 ]
+
+# Tests can use panic-extraction helpers freely. The cargo lint alias skips
+# test targets, but this keeps #[cfg(test)] modules exempt if linted directly.
+allow-expect-in-tests = true
+allow-unwrap-in-tests = true

--- a/crates/turbo-trace/src/lib.rs
+++ b/crates/turbo-trace/src/lib.rs
@@ -5,6 +5,7 @@
 // miette's derive macro causes false positives for this lint
 #![allow(unused_assignments)]
 #![deny(clippy::all)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 mod import_finder;
 mod tracer;
 

--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -6,6 +6,7 @@
 // miette's derive macro causes false positives for this lint
 #![allow(unused_assignments)]
 #![deny(clippy::all)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::{backtrace::Backtrace, env, future::Future, sync::LazyLock, time::Duration};
 #[cfg(feature = "rustls-tls")]

--- a/crates/turborepo-auth/src/lib.rs
+++ b/crates/turborepo-auth/src/lib.rs
@@ -2,6 +2,7 @@
 // miette's derive macro causes false positives for this lint
 #![allow(unused_assignments)]
 #![deny(clippy::all)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 //! Turborepo's library for authenticating with the Vercel API.
 //! Handles logging into Vercel, verifying SSO, and storing the token.
 

--- a/crates/turborepo-boundaries/src/lib.rs
+++ b/crates/turborepo-boundaries/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::sliced_string_as_bytes)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 // miette's derive macro causes false positives for these lints
 #![allow(unused_assignments)]
 

--- a/crates/turborepo-cache/src/lib.rs
+++ b/crates/turborepo-cache/src/lib.rs
@@ -9,6 +9,7 @@
 // miette's derive macro causes false positives for this lint
 #![allow(unused_assignments)]
 #![deny(clippy::all)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 
 /// A wrapper for the cache that uses a worker pool to perform cache operations
 mod async_cache;

--- a/crates/turborepo-daemon/build.rs
+++ b/crates/turborepo-daemon/build.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let tonic_build_result = tonic_prost_build::configure()
         .build_server(true)

--- a/crates/turborepo-daemon/src/lib.rs
+++ b/crates/turborepo-daemon/src/lib.rs
@@ -22,6 +22,7 @@
 
 #![feature(impl_trait_in_assoc_type)]
 #![deny(clippy::all)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 #![allow(clippy::needless_lifetimes)]
 #![allow(clippy::uninlined_format_args)]
 

--- a/crates/turborepo-devtools/src/lib.rs
+++ b/crates/turborepo-devtools/src/lib.rs
@@ -5,6 +5,7 @@
 //! via file watching and pushed to connected clients.
 
 #![deny(clippy::all)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 
 mod graph;
 mod server;

--- a/crates/turborepo-engine/src/lib.rs
+++ b/crates/turborepo-engine/src/lib.rs
@@ -7,6 +7,7 @@
 // Allow large error types - boxing would be a significant refactor and these
 // errors are already established patterns in the codebase
 #![allow(clippy::result_large_err)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 
 pub mod affected;
 mod builder;

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -21,6 +21,7 @@
 //! `tokio::time::interval`.
 
 #![deny(clippy::all)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 #![allow(clippy::mutable_key_type)]
 #![allow(clippy::result_large_err)]
 

--- a/crates/turborepo-fixed-map/src/lib.rs
+++ b/crates/turborepo-fixed-map/src/lib.rs
@@ -4,6 +4,7 @@
 //! results, and return a reference to the loaded `turbo.json`.
 
 #![deny(clippy::all)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::sync::OnceLock;
 

--- a/crates/turborepo-frameworks/src/lib.rs
+++ b/crates/turborepo-frameworks/src/lib.rs
@@ -2,6 +2,8 @@
 //! Automatically identifies JavaScript frameworks and what environment
 //! variables impact it.
 
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
 use std::{collections::HashMap, sync::OnceLock};
 
 use serde::Deserialize;

--- a/crates/turborepo-fs/src/lib.rs
+++ b/crates/turborepo-fs/src/lib.rs
@@ -2,6 +2,7 @@
 //! At the moment only used for `turbo prune` to copy over package directories.
 
 #![deny(clippy::all)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::{
     fs::{DirBuilder, FileType, Metadata},

--- a/crates/turborepo-globwalk/src/lib.rs
+++ b/crates/turborepo-globwalk/src/lib.rs
@@ -4,6 +4,7 @@
 //! but we do not support.
 
 #![deny(clippy::all)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::{
     borrow::Cow,

--- a/crates/turborepo-globwatch/examples/cancel.rs
+++ b/crates/turborepo-globwatch/examples/cancel.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
 use std::{path::PathBuf, time::Duration};
 
 use futures::{StreamExt, join};

--- a/crates/turborepo-globwatch/src/lib.rs
+++ b/crates/turborepo-globwatch/src/lib.rs
@@ -18,6 +18,7 @@
     unused_must_use,
     unsafe_code
 )]
+#![allow(clippy::expect_used)]
 
 use std::{
     collections::HashMap,

--- a/crates/turborepo-graph-utils/src/lib.rs
+++ b/crates/turborepo-graph-utils/src/lib.rs
@@ -2,6 +2,8 @@
 //! Provides transitive closure calculation and cycle detection with cut
 //! candidates to break cycles
 
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
 mod walker;
 
 use std::{collections::HashSet, fmt::Display, hash::Hash};

--- a/crates/turborepo-hash/build.rs
+++ b/crates/turborepo-hash/build.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let capnpc_result = capnpc::CompilerCommand::new()
         .file("./src/proto.capnp")

--- a/crates/turborepo-hash/src/lib.rs
+++ b/crates/turborepo-hash/src/lib.rs
@@ -4,6 +4,8 @@
 //! deterministic serialization across languages and platforms, then applies
 //! xxHash64 for fast hashing.
 
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
 mod oid_hash;
 mod traits;
 

--- a/crates/turborepo-json-rewrite/src/lib.rs
+++ b/crates/turborepo-json-rewrite/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
 use jsonc_parser::{errors::ParseError, parse_to_ast};
 use thiserror::Error;
 

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -6,6 +6,7 @@
 // miette's derive macro causes false positives for this lint
 #![allow(unused_assignments)]
 #![deny(clippy::all)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 // Clippy's needless mut lint is buggy: https://github.com/rust-lang/rust-clippy/issues/11299
 #![allow(clippy::needless_pass_by_ref_mut)]
 #![allow(clippy::result_large_err)]

--- a/crates/turborepo-lockfiles/examples/berry_resolutions.rs
+++ b/crates/turborepo-lockfiles/examples/berry_resolutions.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
 use turborepo_lockfiles::{BerryLockfile, BerryManifest, Lockfile, LockfileData};
 
 fn main() {

--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -9,6 +9,7 @@
 //! prone than deserialization and analysis.
 
 #![deny(clippy::all)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 // the pest proc macro adds an empty doc comment.
 #![allow(clippy::empty_docs)]
 

--- a/crates/turborepo-lsp/Cargo.toml
+++ b/crates/turborepo-lsp/Cargo.toml
@@ -11,6 +11,9 @@ rustls-tls = ["turborepo-lib/rustls-tls"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lints]
+workspace = true
+
 [dependencies]
 crop = "0.4.0"
 itertools.workspace = true

--- a/crates/turborepo-lsp/src/lib.rs
+++ b/crates/turborepo-lsp/src/lib.rs
@@ -10,6 +10,7 @@
 // miette's derive macro causes false positives for this lint
 #![allow(unused_assignments)]
 #![deny(clippy::all)]
+#![allow(clippy::expect_used)]
 #![warn(clippy::unwrap_used)]
 
 use std::{

--- a/crates/turborepo-microfrontends-proxy/Cargo.toml
+++ b/crates/turborepo-microfrontends-proxy/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = { workspace = true }
 license = "MIT"
 
+[lints]
+workspace = true
+
 [dependencies]
 dashmap = { workspace = true }
 futures-util = "0.3.31"

--- a/crates/turborepo-microfrontends-proxy/src/lib.rs
+++ b/crates/turborepo-microfrontends-proxy/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::all)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 
 mod error;
 mod headers;

--- a/crates/turborepo-microfrontends-proxy/tests/integration_test.rs
+++ b/crates/turborepo-microfrontends-proxy/tests/integration_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 use std::time::Duration;
 
 use http_body_util::{BodyExt, Full};

--- a/crates/turborepo-microfrontends/src/lib.rs
+++ b/crates/turborepo-microfrontends/src/lib.rs
@@ -21,6 +21,7 @@
 //!    passed through but ignored by Turborepo
 
 #![deny(clippy::all)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 mod configv1;
 mod error;
 mod port;

--- a/crates/turborepo-otel/Cargo.toml
+++ b/crates/turborepo-otel/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = { workspace = true }
 license = "MIT"
 
+[lints]
+workspace = true
+
 [dependencies]
 opentelemetry = { version = "0.31", features = ["metrics"] }
 opentelemetry-otlp = { version = "0.31", default-features = false, features = [

--- a/crates/turborepo-paths/src/lib.rs
+++ b/crates/turborepo-paths/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::all)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 
 //! Turborepo's path handling library.
 //! Defines distinct path types for the different uses of paths in Turborepo's

--- a/crates/turborepo-pidlock/src/lib.rs
+++ b/crates/turborepo-pidlock/src/lib.rs
@@ -3,6 +3,7 @@
 //! ability to query the owner of the pidlock.
 
 #![deny(clippy::all)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::{
     fs,

--- a/crates/turborepo-process/src/lib.rs
+++ b/crates/turborepo-process/src/lib.rs
@@ -10,6 +10,7 @@
 //! must be either `wait`ed on or `stop`ped to drive state.
 
 #![deny(clippy::all)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 
 mod child;
 mod command;

--- a/crates/turborepo-repository/src/lib.rs
+++ b/crates/turborepo-repository/src/lib.rs
@@ -10,6 +10,7 @@
 // miette's derive macro causes false positives for this lint
 #![allow(unused_assignments)]
 #![allow(clippy::result_large_err)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 
 pub mod change_mapper;
 pub mod discovery;

--- a/crates/turborepo-run-summary/src/lib.rs
+++ b/crates/turborepo-run-summary/src/lib.rs
@@ -3,6 +3,8 @@
 //! This crate provides types and traits for tracking task execution
 //! and generating run summaries.
 
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
 mod duration;
 mod execution;
 mod global_hash;

--- a/crates/turborepo-schema-gen/Cargo.toml
+++ b/crates/turborepo-schema-gen/Cargo.toml
@@ -9,6 +9,9 @@ description = "JSON Schema and TypeScript type generator for turbo.json configur
 name = "turbo-schema-gen"
 path = "src/main.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 # Schema generation
 schemars = { workspace = true }

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(io_error_more)]
 #![deny(clippy::all)]
 #![allow(clippy::result_large_err)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 
 //! Turborepo's library for interacting with source control management (SCM).
 //! Currently we only support git. We use SCM for finding changed files,

--- a/crates/turborepo-scope/src/lib.rs
+++ b/crates/turborepo-scope/src/lib.rs
@@ -8,6 +8,7 @@
 //! Extracted from turborepo-lib to reduce coupling.
 
 #![deny(clippy::all)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 // Allow large error types - ResolutionError contains ChangeMapError which is 128+ bytes.
 // Boxing would complicate error handling without significant benefit for a CLI tool.
 #![allow(clippy::result_large_err)]

--- a/crates/turborepo-shim/src/lib.rs
+++ b/crates/turborepo-shim/src/lib.rs
@@ -11,6 +11,8 @@
 //! The crate uses trait-based dependency injection to avoid circular
 //! dependencies with `turborepo-lib`.
 
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
 mod local_turbo_config;
 mod local_turbo_state;
 mod parser;

--- a/crates/turborepo-signals/src/lib.rs
+++ b/crates/turborepo-signals/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::all)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 
 //! A crate for registering listeners for a given signal
 

--- a/crates/turborepo-task-executor/Cargo.toml
+++ b/crates/turborepo-task-executor/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2024"
 license = "MIT"
 
+[lints]
+workspace = true
+
 [dependencies]
 # Foundation crates
 turbopath = { path = "../turborepo-paths" }

--- a/crates/turborepo-task-executor/src/lib.rs
+++ b/crates/turborepo-task-executor/src/lib.rs
@@ -19,6 +19,8 @@
 //! - Cache saving on success
 //! - Error and warning collection
 
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
 mod command;
 mod exec;
 mod output;

--- a/crates/turborepo-task-hash/src/lib.rs
+++ b/crates/turborepo-task-hash/src/lib.rs
@@ -4,6 +4,8 @@
 //! hashes for tasks based on their inputs (files, environment variables,
 //! dependencies) to determine cache invalidation.
 
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
 pub mod global_hash;
 
 use std::{

--- a/crates/turborepo-telemetry/src/lib.rs
+++ b/crates/turborepo-telemetry/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(error_generic_member_access)]
 // miette's derive macro causes false positives for this lint
 #![allow(unused_assignments)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 
 pub mod config;
 pub mod errors;

--- a/crates/turborepo-turbo-json/src/lib.rs
+++ b/crates/turborepo-turbo-json/src/lib.rs
@@ -13,6 +13,7 @@
 // This is intentional for rich error reporting. Boxing would add indirection overhead
 // for error paths that are not performance-critical.
 #![allow(clippy::result_large_err)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::{collections::HashSet, sync::Arc};
 

--- a/crates/turborepo-types/src/lib.rs
+++ b/crates/turborepo-types/src/lib.rs
@@ -14,6 +14,8 @@
 //! - [`HashTrackerInfo`]: Provides access to task hash information
 //! - [`GlobalHashInputs`]: Provides access to global hash inputs
 
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
 pub mod secret;
 pub mod task_input_matching;
 use std::{collections::HashMap, fmt, str::FromStr, sync::Arc};

--- a/crates/turborepo-ui/src/lib.rs
+++ b/crates/turborepo-ui/src/lib.rs
@@ -2,6 +2,7 @@
 //! logging sinks, and the TUI. Includes a `ColorSelector` that lets multiple
 //! concurrent resources get an assigned color.
 #![feature(deadline_api)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 
 mod color_selector;
 mod log_sinks;

--- a/crates/turborepo-vercel-api-mock/src/lib.rs
+++ b/crates/turborepo-vercel-api-mock/src/lib.rs
@@ -1,6 +1,7 @@
 //! Mock server implementation for a subset of the Vercel API.
 
 #![deny(clippy::all)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::{collections::HashMap, fs::OpenOptions, io::Write, net::SocketAddr, sync::Arc};
 

--- a/crates/turborepo-vercel-api-mock/src/main.rs
+++ b/crates/turborepo-vercel-api-mock/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
 use anyhow::Result;
 use turborepo_vercel_api_mock::start_test_server;
 

--- a/crates/turborepo-vt100/Cargo.toml
+++ b/crates/turborepo-vt100/Cargo.toml
@@ -13,6 +13,9 @@ categories = ["command-line-interface", "encoding"]
 license = "MIT"
 include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 
+[lints]
+workspace = true
+
 [features]
 default = ["tui-term"]
 tui-term = ["dep:tui-term", "dep:ratatui"]

--- a/crates/turborepo-vt100/src/lib.rs
+++ b/crates/turborepo-vt100/src/lib.rs
@@ -45,6 +45,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::type_complexity)]
 #![allow(unused_imports)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 
 mod attrs;
 mod callbacks;

--- a/crates/turborepo-vt100/tests/basic.rs
+++ b/crates/turborepo-vt100/tests/basic.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 use turborepo_vt100 as vt100;
 
 #[test]

--- a/crates/turborepo-vt100/tests/csi.rs
+++ b/crates/turborepo-vt100/tests/csi.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 use turborepo_vt100 as vt100;
 
 mod helpers;

--- a/crates/turborepo-vt100/tests/entire_screen.rs
+++ b/crates/turborepo-vt100/tests/entire_screen.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 use turborepo_vt100 as vt100;
 
 #[test]

--- a/crates/turborepo-vt100/tests/helpers/fixtures.rs
+++ b/crates/turborepo-vt100/tests/helpers/fixtures.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 use turborepo_vt100 as vt100;
 
 use serde::de::Deserialize as _;

--- a/crates/turborepo-vt100/tests/helpers/mod.rs
+++ b/crates/turborepo-vt100/tests/helpers/mod.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 #![allow(unused_imports)]
 mod fixtures;
 pub use fixtures::FixtureScreen;

--- a/crates/turborepo-vt100/tests/init.rs
+++ b/crates/turborepo-vt100/tests/init.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 use turborepo_vt100 as vt100;
 
 #[test]

--- a/crates/turborepo-vt100/tests/select.rs
+++ b/crates/turborepo-vt100/tests/select.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 use turborepo_vt100 as vt100;
 
 mod helpers;

--- a/crates/turborepo-vt100/tests/split-escapes.rs
+++ b/crates/turborepo-vt100/tests/split-escapes.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 use turborepo_vt100 as vt100;
 
 use std::io::Read as _;

--- a/crates/turborepo-vt100/tests/window_contents.rs
+++ b/crates/turborepo-vt100/tests/window_contents.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 #![allow(unused_imports)]
 use turborepo_vt100 as vt100;
 

--- a/crates/turborepo-vt100/tests/write.rs
+++ b/crates/turborepo-vt100/tests/write.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 use turborepo_vt100 as vt100;
 
 use std::io::Write as _;

--- a/crates/turborepo-wax/src/lib.rs
+++ b/crates/turborepo-wax/src/lib.rs
@@ -32,6 +32,7 @@
     clippy::unreadable_literal,
     clippy::unused_self
 )]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 
 mod capture;
 mod diagnostics;

--- a/crates/turborepo-wax/tests/walk.rs
+++ b/crates/turborepo-wax/tests/walk.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 #![cfg(feature = "walk")]
 
 use std::{collections::HashSet, path::PathBuf};

--- a/crates/turborepo/tests/absolute_path_error_test.rs
+++ b/crates/turborepo/tests/absolute_path_error_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{replace_turbo_json, run_turbo, setup};

--- a/crates/turborepo/tests/affected_rdeps_test.rs
+++ b/crates/turborepo/tests/affected_rdeps_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::fs;

--- a/crates/turborepo/tests/affected_test.rs
+++ b/crates/turborepo/tests/affected_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::{fs, path::Path};

--- a/crates/turborepo/tests/allow_no_root_turbo_test.rs
+++ b/crates/turborepo/tests/allow_no_root_turbo_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{run_turbo, run_turbo_with_env, setup};

--- a/crates/turborepo/tests/bad_turbo_json_test.rs
+++ b/crates/turborepo/tests/bad_turbo_json_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{replace_turbo_json, run_turbo, setup};

--- a/crates/turborepo/tests/big_status_test.rs
+++ b/crates/turborepo/tests/big_status_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::fs;

--- a/crates/turborepo/tests/command_bin_test.rs
+++ b/crates/turborepo/tests/command_bin_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{run_turbo, setup};

--- a/crates/turborepo/tests/command_link_test.rs
+++ b/crates/turborepo/tests/command_link_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{combined_output, mock_turbo_config, turbo_command};

--- a/crates/turborepo/tests/command_logout_test.rs
+++ b/crates/turborepo/tests/command_logout_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::{fs, net::TcpListener, path::Path};

--- a/crates/turborepo/tests/command_ls_test.rs
+++ b/crates/turborepo/tests/command_ls_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{run_turbo, setup};

--- a/crates/turborepo/tests/command_query_test.rs
+++ b/crates/turborepo/tests/command_query_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::fs;

--- a/crates/turborepo/tests/command_telemetry_test.rs
+++ b/crates/turborepo/tests/command_telemetry_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{mock_telemetry_config, turbo_command};

--- a/crates/turborepo/tests/command_test.rs
+++ b/crates/turborepo/tests/command_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::fs;

--- a/crates/turborepo/tests/common/mod.rs
+++ b/crates/turborepo/tests/common/mod.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 #![allow(dead_code)]
 
 pub mod setup;

--- a/crates/turborepo/tests/common/setup.rs
+++ b/crates/turborepo/tests/common/setup.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 #![allow(dead_code)]
 
 use std::{

--- a/crates/turborepo/tests/config_layering_test.rs
+++ b/crates/turborepo/tests/config_layering_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::fs;

--- a/crates/turborepo/tests/config_test.rs
+++ b/crates/turborepo/tests/config_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{run_turbo, run_turbo_with_env, setup};

--- a/crates/turborepo/tests/continue_test.rs
+++ b/crates/turborepo/tests/continue_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{run_turbo, setup};

--- a/crates/turborepo/tests/daemon_test.rs
+++ b/crates/turborepo/tests/daemon_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::setup;

--- a/crates/turborepo/tests/dry_json.rs
+++ b/crates/turborepo/tests/dry_json.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::path::Path;

--- a/crates/turborepo/tests/dry_run_test.rs
+++ b/crates/turborepo/tests/dry_run_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{git, run_turbo, run_turbo_with_env, setup};

--- a/crates/turborepo/tests/edit_turbo_json.rs
+++ b/crates/turborepo/tests/edit_turbo_json.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::path::Path;

--- a/crates/turborepo/tests/engines_test.rs
+++ b/crates/turborepo/tests/engines_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::fs;

--- a/crates/turborepo/tests/experimental_otel_test.rs
+++ b/crates/turborepo/tests/experimental_otel_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::fs;

--- a/crates/turborepo/tests/filter_run_test.rs
+++ b/crates/turborepo/tests/filter_run_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::{fs, path::Path};

--- a/crates/turborepo/tests/find_correct_turbo_test.rs
+++ b/crates/turborepo/tests/find_correct_turbo_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::turbo_command;

--- a/crates/turborepo/tests/find_turbo_test.rs
+++ b/crates/turborepo/tests/find_turbo_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::path::Path;

--- a/crates/turborepo/tests/force_test.rs
+++ b/crates/turborepo/tests/force_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{run_turbo, run_turbo_with_env, setup};

--- a/crates/turborepo/tests/framework_inference_test.rs
+++ b/crates/turborepo/tests/framework_inference_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::fs;

--- a/crates/turborepo/tests/gitignored_inputs_test.rs
+++ b/crates/turborepo/tests/gitignored_inputs_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::fs;

--- a/crates/turborepo/tests/global_deps_test.rs
+++ b/crates/turborepo/tests/global_deps_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::fs;

--- a/crates/turborepo/tests/global_env_test.rs
+++ b/crates/turborepo/tests/global_env_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{run_turbo, run_turbo_with_env, setup};

--- a/crates/turborepo/tests/global_inputs_test.rs
+++ b/crates/turborepo/tests/global_inputs_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::fs;

--- a/crates/turborepo/tests/globs_test.rs
+++ b/crates/turborepo/tests/globs_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::fs;

--- a/crates/turborepo/tests/graceful_shutdown_test.rs
+++ b/crates/turborepo/tests/graceful_shutdown_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 #[cfg(unix)]

--- a/crates/turborepo/tests/graph_test.rs
+++ b/crates/turborepo/tests/graph_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::fs;

--- a/crates/turborepo/tests/infer_pkg_test.rs
+++ b/crates/turborepo/tests/infer_pkg_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{run_turbo, setup};

--- a/crates/turborepo/tests/inference_test.rs
+++ b/crates/turborepo/tests/inference_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::{path::Path, process::Command};

--- a/crates/turborepo/tests/interactive_test.rs
+++ b/crates/turborepo/tests/interactive_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{replace_turbo_json, run_turbo, setup};

--- a/crates/turborepo/tests/invalid_package_json_test.rs
+++ b/crates/turborepo/tests/invalid_package_json_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::fs;

--- a/crates/turborepo/tests/jsonc_test.rs
+++ b/crates/turborepo/tests/jsonc_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::{fs, path::Path};

--- a/crates/turborepo/tests/lockfile_aware_caching_test.rs
+++ b/crates/turborepo/tests/lockfile_aware_caching_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{git, run_turbo, setup_lockfile_test};

--- a/crates/turborepo/tests/lockfile_new_package_test.rs
+++ b/crates/turborepo/tests/lockfile_new_package_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::fs;

--- a/crates/turborepo/tests/missing_tasks_test.rs
+++ b/crates/turborepo/tests/missing_tasks_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{run_turbo, setup};

--- a/crates/turborepo/tests/no_args_test.rs
+++ b/crates/turborepo/tests/no_args_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{run_turbo, run_turbo_with_env, setup, turbo_output_filters};

--- a/crates/turborepo/tests/no_root_turbo_test.rs
+++ b/crates/turborepo/tests/no_root_turbo_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::fs;

--- a/crates/turborepo/tests/one_script_error_test.rs
+++ b/crates/turborepo/tests/one_script_error_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{run_turbo, setup};

--- a/crates/turborepo/tests/package_manager_test.rs
+++ b/crates/turborepo/tests/package_manager_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::fs;

--- a/crates/turborepo/tests/passthrough_args_test.rs
+++ b/crates/turborepo/tests/passthrough_args_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{run_turbo, setup, turbo_output_filters};

--- a/crates/turborepo/tests/path_with_spaces_test.rs
+++ b/crates/turborepo/tests/path_with_spaces_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::fs;

--- a/crates/turborepo/tests/persistent_dependencies.rs
+++ b/crates/turborepo/tests/persistent_dependencies.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{run_turbo, setup, turbo_output_filters};

--- a/crates/turborepo/tests/pkg_inference_test.rs
+++ b/crates/turborepo/tests/pkg_inference_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{run_turbo, setup};

--- a/crates/turborepo/tests/pkg_task_entry_test.rs
+++ b/crates/turborepo/tests/pkg_task_entry_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{combined_output, run_turbo, setup};

--- a/crates/turborepo/tests/profile_test.rs
+++ b/crates/turborepo/tests/profile_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::fs;

--- a/crates/turborepo/tests/prune_test.rs
+++ b/crates/turborepo/tests/prune_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::{fs, path::Path};

--- a/crates/turborepo/tests/query_test.rs
+++ b/crates/turborepo/tests/query_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::fs;

--- a/crates/turborepo/tests/recursive_turbo_test.rs
+++ b/crates/turborepo/tests/recursive_turbo_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{combined_output, run_turbo, setup};

--- a/crates/turborepo/tests/run_caching.rs
+++ b/crates/turborepo/tests/run_caching.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::fs;

--- a/crates/turborepo/tests/run_logging.rs
+++ b/crates/turborepo/tests/run_logging.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{run_turbo, run_turbo_with_env, setup, turbo_output_filters};

--- a/crates/turborepo/tests/run_summary.rs
+++ b/crates/turborepo/tests/run_summary.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::{fs, path::Path};

--- a/crates/turborepo/tests/shim_errors_test.rs
+++ b/crates/turborepo/tests/shim_errors_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::turbo_command;

--- a/crates/turborepo/tests/single_package_dry_run_test.rs
+++ b/crates/turborepo/tests/single_package_dry_run_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::fs;

--- a/crates/turborepo/tests/single_package_graph_test.rs
+++ b/crates/turborepo/tests/single_package_graph_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::fs;

--- a/crates/turborepo/tests/single_package_run_test.rs
+++ b/crates/turborepo/tests/single_package_run_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{run_turbo, setup};

--- a/crates/turborepo/tests/single_package_with_deps_test.rs
+++ b/crates/turborepo/tests/single_package_with_deps_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{run_turbo, setup, turbo_output_filters};

--- a/crates/turborepo/tests/stdin_eof_startup_test.rs
+++ b/crates/turborepo/tests/stdin_eof_startup_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::{

--- a/crates/turborepo/tests/strict_env_vars.rs
+++ b/crates/turborepo/tests/strict_env_vars.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::{fs, path::Path};

--- a/crates/turborepo/tests/structured_logging.rs
+++ b/crates/turborepo/tests/structured_logging.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{run_turbo, setup};

--- a/crates/turborepo/tests/task_dependencies.rs
+++ b/crates/turborepo/tests/task_dependencies.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::fs;

--- a/crates/turborepo/tests/turbo_trace_test.rs
+++ b/crates/turborepo/tests/turbo_trace_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{run_turbo, setup};

--- a/crates/turborepo/tests/unnamed_packages_test.rs
+++ b/crates/turborepo/tests/unnamed_packages_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{run_turbo, setup, turbo_output_filters};

--- a/crates/turborepo/tests/watch_test.rs
+++ b/crates/turborepo/tests/watch_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::{

--- a/crates/turborepo/tests/workspace_config_deps_test.rs
+++ b/crates/turborepo/tests/workspace_config_deps_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use common::{run_turbo, setup};

--- a/crates/turborepo/tests/workspace_config_inheritance_test.rs
+++ b/crates/turborepo/tests/workspace_config_inheritance_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::fs;

--- a/crates/turborepo/tests/workspace_config_override_test.rs
+++ b/crates/turborepo/tests/workspace_config_override_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::fs;

--- a/crates/turborepo/tests/workspace_config_special_test.rs
+++ b/crates/turborepo/tests/workspace_config_special_test.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
 mod common;
 
 use std::fs;

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::result_large_err)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::collections::{HashMap, HashSet};
 


### PR DESCRIPTION
## Summary
- Denies Clippy unwrap/expect usage at the workspace level.
- Adds temporary crate-level allows for existing implementation-code violations so cleanup can proceed incrementally.
- Keeps test targets in cargo lint and scopes the panic-extraction exemption to test crates/modules with cfg_attr(test, allow(...)).