### PR TITLE
fix: Preserve non-UTF-8 Git path boundaries

### DIFF
--- a/crates/turborepo-scm/src/git_index_regression_tests.rs
+++ b/crates/turborepo-scm/src/git_index_regression_tests.rs
@@ -12,7 +12,7 @@
 
 use turbopath::{AnchoredSystemPathBuf, RelativeUnixPathBuf};
 
-use crate::{GitHashes, RepoGitIndex, SCM, test_utils, walk_candidate_files};
+use crate::{Error, GitHashes, RepoGitIndex, SCM, test_utils, walk_candidate_files};
 
 fn path(s: &str) -> RelativeUnixPathBuf {
     RelativeUnixPathBuf::new(s).unwrap()
@@ -256,6 +256,38 @@ fn test_clean_tree_committed_files_have_correct_hashes() {
         root_hashes.len() >= 7,
         "root should see all committed files"
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_repo_index_defers_non_utf8_paths_until_matching_package_query() {
+    use std::{ffi::OsString, os::unix::ffi::OsStringExt, path::PathBuf};
+
+    let repo = TestRepo::new();
+
+    repo.create_file("apps/web/src/index.ts", "console.log('hello')");
+    repo.create_file("apps/web/package.json", "{}");
+
+    let invalid_rel = PathBuf::from(OsString::from_vec(b"outside-\xff.txt".to_vec()));
+    let invalid_abs = repo.root.as_std_path().join(invalid_rel);
+    if std::fs::write(&invalid_abs, b"bad").is_err() {
+        return;
+    }
+
+    repo.commit_all();
+
+    let index = repo.build_repo_index();
+    let web_hashes = repo.get_hashes_with_index("apps/web", &index);
+    assert_eq!(web_hashes.len(), 2);
+    assert!(web_hashes.contains_key(&path("src/index.ts")));
+    assert!(web_hashes.contains_key(&path("package.json")));
+
+    let scm = repo.scm();
+    let root_pkg = AnchoredSystemPathBuf::from_raw("").unwrap();
+    let err = scm
+        .get_package_file_hashes::<&str>(&repo.root, &root_pkg, &[], false, None, Some(&index))
+        .unwrap_err();
+    assert!(matches!(err, Error::UnsupportedGitPath { .. }));
 }
 
 #[test]

--- a/crates/turborepo-scm/src/git_path.rs
+++ b/crates/turborepo-scm/src/git_path.rs
@@ -1,0 +1,131 @@
+use std::{borrow::Cow, fmt::Write, path::Path};
+
+use turbopath::RelativeUnixPathBuf;
+
+use crate::Error;
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) struct UnsupportedGitPath {
+    source: &'static str,
+    bytes: Vec<u8>,
+}
+
+impl UnsupportedGitPath {
+    pub fn new(source: &'static str, bytes: &[u8]) -> Self {
+        Self {
+            source,
+            bytes: bytes.to_vec(),
+        }
+    }
+
+    pub fn is_within_prefix(&self, prefix: &RelativeUnixPathBuf) -> bool {
+        let prefix = prefix.as_str().as_bytes();
+        let path = self.bytes.as_slice();
+
+        prefix.is_empty()
+            || path == prefix
+            || (path.len() > prefix.len() && path.starts_with(prefix) && path[prefix.len()] == b'/')
+    }
+
+    pub fn into_error(self) -> Error {
+        Error::UnsupportedGitPath {
+            origin: self.source,
+            path: escape_bytes(&self.bytes),
+            backtrace: std::backtrace::Backtrace::capture(),
+        }
+    }
+}
+
+pub(crate) fn parse_git_path(
+    bytes: &[u8],
+    source: &'static str,
+) -> Result<Result<RelativeUnixPathBuf, UnsupportedGitPath>, Error> {
+    let path = match std::str::from_utf8(bytes) {
+        Ok(path) => path,
+        Err(_) => return Ok(Err(UnsupportedGitPath::new(source, bytes))),
+    };
+
+    Ok(Ok(RelativeUnixPathBuf::new(path)?))
+}
+
+pub(crate) fn require_git_path(
+    bytes: &[u8],
+    source: &'static str,
+) -> Result<RelativeUnixPathBuf, Error> {
+    match parse_git_path(bytes, source)? {
+        Ok(path) => Ok(path),
+        Err(path) => Err(path.into_error()),
+    }
+}
+
+pub(crate) fn parse_path(
+    path: &Path,
+    source: &'static str,
+) -> Result<Result<RelativeUnixPathBuf, UnsupportedGitPath>, Error> {
+    let bytes = path_to_git_path_bytes(path);
+    parse_git_path(bytes.as_ref(), source)
+}
+
+pub(crate) fn path_to_git_path_bytes(path: &Path) -> Cow<'_, [u8]> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+
+        Cow::Borrowed(path.as_os_str().as_bytes())
+    }
+
+    #[cfg(windows)]
+    {
+        Cow::Owned(path.to_string_lossy().replace('\\', "/").into_bytes())
+    }
+}
+
+fn escape_bytes(bytes: &[u8]) -> String {
+    let mut escaped = String::with_capacity(bytes.len());
+    for byte in bytes {
+        match byte {
+            b'\\' => escaped.push_str("\\\\"),
+            b'\n' => escaped.push_str("\\n"),
+            b'\r' => escaped.push_str("\\r"),
+            b'\t' => escaped.push_str("\\t"),
+            b'\0' => escaped.push_str("\\0"),
+            0x20..=0x7e => escaped.push(*byte as char),
+            _ => write!(escaped, "\\x{byte:02x}").expect("writing to String cannot fail"),
+        }
+    }
+    escaped
+}
+
+#[cfg(test)]
+mod tests {
+    use turbopath::RelativeUnixPathBuf;
+
+    use super::{UnsupportedGitPath, parse_git_path};
+    use crate::Error;
+
+    #[test]
+    fn parse_git_path_reports_non_utf8() {
+        let parsed = parse_git_path(b"pkg/bad-\xff", "test source").unwrap();
+        let path = parsed.unwrap_err();
+        assert!(path.is_within_prefix(&RelativeUnixPathBuf::new("pkg").unwrap()));
+
+        let err = path.into_error();
+        match err {
+            Error::UnsupportedGitPath { origin, path, .. } => {
+                assert_eq!(origin, "test source");
+                assert_eq!(path, "pkg/bad-\\xff");
+            }
+            _ => panic!("expected unsupported git path error"),
+        }
+    }
+
+    #[test]
+    fn unsupported_path_prefix_matching_respects_components() {
+        let path = UnsupportedGitPath::new("test source", b"packages/app/file-\xff");
+
+        assert!(path.is_within_prefix(&RelativeUnixPathBuf::new("").unwrap()));
+        assert!(path.is_within_prefix(&RelativeUnixPathBuf::new("packages/app").unwrap()));
+        assert!(!path.is_within_prefix(&RelativeUnixPathBuf::new("packages/ap").unwrap()));
+        assert!(!path.is_within_prefix(&RelativeUnixPathBuf::new("apps/web").unwrap()));
+    }
+}

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -34,6 +34,7 @@ pub mod worktree;
 
 #[cfg(test)]
 mod git_index_regression_tests;
+mod git_path;
 #[cfg(test)]
 mod test_utils;
 
@@ -63,6 +64,13 @@ pub enum Error {
         #[from] std::string::FromUtf8Error,
         #[backtrace] backtrace::Backtrace,
     ),
+    #[error("Git path contains non-UTF-8 bytes from {origin}: {path}")]
+    UnsupportedGitPath {
+        origin: &'static str,
+        path: String,
+        #[backtrace]
+        backtrace: backtrace::Backtrace,
+    },
     #[error("Package traversal error: {0}")]
     Ignore(#[from] ignore::Error, #[backtrace] backtrace::Backtrace),
     #[error("Invalid glob: {0}")]
@@ -122,6 +130,10 @@ impl Error {
             _ => false,
         }
     }
+
+    pub fn is_unsupported_git_path(&self) -> bool {
+        matches!(self, Error::UnsupportedGitPath { .. })
+    }
 }
 
 fn read_git_error_to_string<R: Read>(stderr: &mut R) -> Option<String> {
@@ -169,6 +181,11 @@ pub(crate) fn wait_for_success<R: Read, T>(
                 child.try_wait().ok();
             }
         };
+
+        if parse_err.is_unsupported_git_path() {
+            return Err(parse_err);
+        }
+
         let stderr_output = read_git_error_to_string(stderr);
         let stderr_text = stderr_output
             .map(|stderr| format!(" stderr: {stderr}"))
@@ -593,5 +610,26 @@ mod tests {
         // We should, however, have our injected error of "any error" in the error
         // message.
         assert!(err.to_string().contains("any error"));
+    }
+
+    #[test]
+    fn test_wait_for_success_preserves_unsupported_git_path_errors() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPathBuf::try_from(tmp_dir.path()).unwrap();
+        let mut cmd = Command::new("git")
+            .arg("--version")
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let mut stderr = cmd.stderr.take().unwrap();
+        let parse_result: Result<(), super::Error> = Err(Error::UnsupportedGitPath {
+            origin: "test git path",
+            path: "bad-\\xff".to_string(),
+            backtrace: std::backtrace::Backtrace::capture(),
+        });
+
+        let err =
+            wait_for_success(cmd, &mut stderr, "git --version", &root, parse_result).unwrap_err();
+        assert_matches!(err, Error::UnsupportedGitPath { .. });
     }
 }

--- a/crates/turborepo-scm/src/ls_tree.rs
+++ b/crates/turborepo-scm/src/ls_tree.rs
@@ -6,13 +6,59 @@ use std::{
 use nom::Finish;
 use turbopath::{AbsoluteSystemPathBuf, RelativeUnixPathBuf};
 
-use crate::{Error, GitHashes, GitRepo, OidHash, wait_for_success};
+use crate::{
+    Error, GitHashes, GitRepo, OidHash,
+    git_path::{UnsupportedGitPath, parse_git_path, require_git_path},
+    wait_for_success,
+};
 
 /// Sorted list of (path, hash) pairs from `git ls-tree`. Uses a `Vec` instead
 /// of `BTreeMap` because git output is already sorted by pathname, giving us
 /// free insertion order with better cache locality for the `partition_point`
 /// range lookups performed in `RepoGitIndex::get_package_hashes`.
 pub(crate) type SortedGitHashes = Vec<(RelativeUnixPathBuf, OidHash)>;
+
+pub(crate) struct GitTreeState {
+    pub hashes: SortedGitHashes,
+    pub unsupported_paths: Vec<UnsupportedGitPath>,
+}
+
+impl GitTreeState {
+    fn new() -> Self {
+        Self {
+            hashes: SortedGitHashes::new(),
+            unsupported_paths: Vec::new(),
+        }
+    }
+}
+
+pub(crate) struct GitStatusState {
+    pub entries: Vec<crate::status::RepoStatusEntry>,
+    pub unsupported_paths: Vec<UnsupportedGitPath>,
+}
+
+impl GitStatusState {
+    fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+            unsupported_paths: Vec::new(),
+        }
+    }
+}
+
+pub(crate) struct GitPathList {
+    pub paths: Vec<RelativeUnixPathBuf>,
+    pub unsupported_paths: Vec<UnsupportedGitPath>,
+}
+
+impl GitPathList {
+    fn new() -> Self {
+        Self {
+            paths: Vec::new(),
+            unsupported_paths: Vec::new(),
+        }
+    }
+}
 
 impl GitRepo {
     #[tracing::instrument(skip(self))]
@@ -48,8 +94,19 @@ impl GitRepo {
 
     /// Run `git ls-tree -r HEAD -z` at the repo root, returning a sorted Vec
     /// suitable for binary-search range queries in `RepoGitIndex`.
+    #[cfg(test)]
     #[tracing::instrument(skip(self))]
     pub(crate) fn git_ls_tree_repo_root_sorted(&self) -> Result<SortedGitHashes, Error> {
+        let state = self.git_ls_tree_repo_root_sorted_with_unsupported()?;
+        if let Some(path) = state.unsupported_paths.into_iter().next() {
+            return Err(path.into_error());
+        }
+        Ok(state.hashes)
+    }
+
+    pub(crate) fn git_ls_tree_repo_root_sorted_with_unsupported(
+        &self,
+    ) -> Result<GitTreeState, Error> {
         let mut git = Command::new(self.bin.as_std_path())
             .args(["ls-tree", "-r", "-z", "HEAD"])
             .env("GIT_OPTIONAL_LOCKS", "0")
@@ -66,18 +123,29 @@ impl GitRepo {
             .stderr
             .take()
             .ok_or_else(|| Error::git_error("failed to get stderr for git ls-tree"))?;
-        let mut hashes = SortedGitHashes::new();
-        let parse_result = read_ls_tree_sorted(stdout, &mut hashes);
+        let mut state = GitTreeState::new();
+        let parse_result = read_ls_tree_sorted_with_unsupported(stdout, &mut state);
         wait_for_success(git, &mut stderr, "git ls-tree", &self.root, parse_result)?;
-        Ok(hashes)
+        Ok(state)
     }
 
     /// Run `git diff-index HEAD -z` to find modified/deleted files relative to
     /// HEAD. Returns sorted `RepoStatusEntry` entries.
+    #[cfg(test)]
     #[tracing::instrument(skip(self))]
     pub(crate) fn git_diff_index_repo_root(
         &self,
     ) -> Result<Vec<crate::status::RepoStatusEntry>, Error> {
+        let state = self.git_diff_index_repo_root_with_unsupported()?;
+        if let Some(path) = state.unsupported_paths.into_iter().next() {
+            return Err(path.into_error());
+        }
+        Ok(state.entries)
+    }
+
+    pub(crate) fn git_diff_index_repo_root_with_unsupported(
+        &self,
+    ) -> Result<GitStatusState, Error> {
         let mut git = Command::new(self.bin.as_std_path())
             .args([
                 "diff-index",
@@ -100,17 +168,26 @@ impl GitRepo {
             .stderr
             .take()
             .ok_or_else(|| Error::git_error("failed to get stderr for git diff-index"))?;
-        let mut entries = Vec::new();
-        let parse_result = read_diff_index(stdout, &mut entries);
+        let mut state = GitStatusState::new();
+        let parse_result = read_diff_index_with_unsupported(stdout, &mut state);
         wait_for_success(git, &mut stderr, "git diff-index", &self.root, parse_result)?;
-        entries.sort_by(|a, b| a.path.cmp(&b.path));
-        Ok(entries)
+        state.entries.sort_by(|a, b| a.path.cmp(&b.path));
+        Ok(state)
     }
 
     /// Run `git ls-files --others --exclude-standard -z` to find untracked
     /// files.
+    #[cfg(test)]
     #[tracing::instrument(skip(self))]
     pub(crate) fn git_ls_files_untracked(&self) -> Result<Vec<RelativeUnixPathBuf>, Error> {
+        let state = self.git_ls_files_untracked_with_unsupported()?;
+        if let Some(path) = state.unsupported_paths.into_iter().next() {
+            return Err(path.into_error());
+        }
+        Ok(state.paths)
+    }
+
+    pub(crate) fn git_ls_files_untracked_with_unsupported(&self) -> Result<GitPathList, Error> {
         let mut git = Command::new(self.bin.as_std_path())
             .args(["ls-files", "--others", "--exclude-standard", "-z"])
             .env("GIT_OPTIONAL_LOCKS", "0")
@@ -127,10 +204,10 @@ impl GitRepo {
             .stderr
             .take()
             .ok_or_else(|| Error::git_error("failed to get stderr for git ls-files"))?;
-        let mut paths = Vec::new();
-        let parse_result = read_null_terminated_paths(stdout, &mut paths);
+        let mut state = GitPathList::new();
+        let parse_result = read_null_terminated_paths_with_unsupported(stdout, &mut state);
         wait_for_success(git, &mut stderr, "git ls-files", &self.root, parse_result)?;
-        Ok(paths)
+        Ok(state)
     }
 }
 
@@ -141,18 +218,33 @@ fn read_ls_tree<R: Read>(reader: R, hashes: &mut GitHashes) -> Result<(), Error>
         let entry = parse_ls_tree(&buffer)?;
         let hash = std::str::from_utf8(entry.hash)
             .map_err(|e| Error::git_error(format!("invalid utf8 in ls-tree hash: {e}")))?;
-        let filename = std::str::from_utf8(entry.filename)
-            .map_err(|e| Error::git_error(format!("invalid utf8 in ls-tree filename: {e}")))?;
-        let path = RelativeUnixPathBuf::new(filename)?;
+        let path = require_git_path(entry.filename, "git ls-tree filename")?;
         hashes.insert(path, OidHash::from_hex_str(hash));
         buffer.clear();
     }
     Ok(())
 }
 
+#[cfg(test)]
 pub(crate) fn read_ls_tree_sorted<R: Read>(
     reader: R,
     hashes: &mut SortedGitHashes,
+) -> Result<(), Error> {
+    let mut state = GitTreeState {
+        hashes: std::mem::take(hashes),
+        unsupported_paths: Vec::new(),
+    };
+    read_ls_tree_sorted_with_unsupported(reader, &mut state)?;
+    if let Some(path) = state.unsupported_paths.into_iter().next() {
+        return Err(path.into_error());
+    }
+    *hashes = state.hashes;
+    Ok(())
+}
+
+fn read_ls_tree_sorted_with_unsupported<R: Read>(
+    reader: R,
+    state: &mut GitTreeState,
 ) -> Result<(), Error> {
     let mut reader = BufReader::with_capacity(64 * 1024, reader);
     let mut buffer = Vec::new();
@@ -160,22 +252,22 @@ pub(crate) fn read_ls_tree_sorted<R: Read>(
         let entry = parse_ls_tree(&buffer)?;
         let hash = std::str::from_utf8(entry.hash)
             .map_err(|e| Error::git_error(format!("invalid utf8 in ls-tree hash: {e}")))?;
-        let filename = std::str::from_utf8(entry.filename)
-            .map_err(|e| Error::git_error(format!("invalid utf8 in ls-tree filename: {e}")))?;
-        let path = RelativeUnixPathBuf::new(filename)?;
-        hashes.push((path, OidHash::from_hex_str(hash)));
+        match parse_git_path(entry.filename, "git ls-tree filename")? {
+            Ok(path) => state.hashes.push((path, OidHash::from_hex_str(hash))),
+            Err(path) => state.unsupported_paths.push(path),
+        }
         buffer.clear();
     }
     debug_assert!(
-        hashes.windows(2).all(|w| w[0].0 < w[1].0),
+        state.hashes.windows(2).all(|w| w[0].0 < w[1].0),
         "git ls-tree output should be sorted by pathname"
     );
     Ok(())
 }
 
-fn read_diff_index<R: Read>(
+fn read_diff_index_with_unsupported<R: Read>(
     reader: R,
-    entries: &mut Vec<crate::status::RepoStatusEntry>,
+    state: &mut GitStatusState,
 ) -> Result<(), Error> {
     // git diff-index -z output: ":old_mode new_mode old_sha new_sha status\0path\0"
     // Each record is two null-terminated fields: the diff header and the path.
@@ -195,23 +287,26 @@ fn read_diff_index<R: Read>(
         if path_buf.last() == Some(&b'\0') {
             path_buf.pop();
         }
-        let path_str = std::str::from_utf8(&path_buf)
-            .map_err(|e| Error::git_error(format!("invalid utf8 in diff-index path: {e}")))?;
-        let path = RelativeUnixPathBuf::new(path_str)?;
+        let path = parse_git_path(&path_buf, "git diff-index path")?;
 
         // Status letter is the last non-null char in the header
         let header = header_buf.strip_suffix(b"\0").unwrap_or(&header_buf);
         let status_byte = header.last().copied().unwrap_or(b'M');
         let is_delete = status_byte == b'D';
 
-        entries.push(crate::status::RepoStatusEntry { path, is_delete });
+        match path {
+            Ok(path) => state
+                .entries
+                .push(crate::status::RepoStatusEntry { path, is_delete }),
+            Err(path) => state.unsupported_paths.push(path),
+        }
     }
     Ok(())
 }
 
-fn read_null_terminated_paths<R: Read>(
+fn read_null_terminated_paths_with_unsupported<R: Read>(
     reader: R,
-    paths: &mut Vec<RelativeUnixPathBuf>,
+    state: &mut GitPathList,
 ) -> Result<(), Error> {
     let mut reader = BufReader::with_capacity(64 * 1024, reader);
     let mut buffer = Vec::new();
@@ -224,10 +319,10 @@ fn read_null_terminated_paths<R: Read>(
             buffer.clear();
             continue;
         }
-        let path_str = std::str::from_utf8(&buffer)
-            .map_err(|e| Error::git_error(format!("invalid utf8 in path: {e}")))?;
-        let path = RelativeUnixPathBuf::new(path_str)?;
-        paths.push(path);
+        match parse_git_path(&buffer, "git ls-files path")? {
+            Ok(path) => state.paths.push(path),
+            Err(path) => state.unsupported_paths.push(path),
+        }
         buffer.clear();
     }
     Ok(())
@@ -268,7 +363,7 @@ mod tests {
 
     use turbopath::RelativeUnixPathBuf;
 
-    use crate::{GitHashes, OidHash, ls_tree::read_ls_tree};
+    use crate::{Error, GitHashes, OidHash, ls_tree::read_ls_tree};
 
     fn to_hash_map(pairs: &[(&str, &str)]) -> GitHashes {
         HashMap::from_iter(pairs.iter().map(|(path, hash)| {
@@ -380,6 +475,21 @@ mod tests {
             let expected = to_hash_map(expected);
             read_ls_tree(input_bytes, &mut hashes).unwrap();
             assert_eq!(hashes, expected);
+        }
+    }
+
+    #[test]
+    fn test_ls_tree_rejects_non_utf8_filename() {
+        let input = b"100644 blob e69de29bb2d1d6434b8b29ae775ad8c2e48c5391\tbad-\xff\0";
+        let mut hashes = GitHashes::new();
+        let err = read_ls_tree(&input[..], &mut hashes).unwrap_err();
+
+        match err {
+            Error::UnsupportedGitPath { origin, path, .. } => {
+                assert_eq!(origin, "git ls-tree filename");
+                assert_eq!(path, "bad-\\xff");
+            }
+            _ => panic!("expected unsupported git path error"),
         }
     }
 }

--- a/crates/turborepo-scm/src/package_deps.rs
+++ b/crates/turborepo-scm/src/package_deps.rs
@@ -72,6 +72,10 @@ impl SCM {
                             return Err(err);
                         }
 
+                        if err.is_unsupported_git_path() {
+                            return Err(err);
+                        }
+
                         debug!(
                             "git hashing failed for {:?}: {}. Falling back to manual",
                             package_path, err,

--- a/crates/turborepo-scm/src/repo_index.rs
+++ b/crates/turborepo-scm/src/repo_index.rs
@@ -2,7 +2,10 @@ use tracing::{debug, trace};
 use turbopath::RelativeUnixPathBuf;
 
 use crate::{
-    Error, GitHashes, GitRepo, OidHash, ls_tree::SortedGitHashes, status::RepoStatusEntry,
+    Error, GitHashes, GitRepo, OidHash,
+    git_path::{UnsupportedGitPath, parse_git_path, parse_path, path_to_git_path_bytes},
+    ls_tree::{GitPathList, SortedGitHashes},
+    status::RepoStatusEntry,
 };
 
 /// Pre-computed repo-wide git index that caches file hashes and working-tree
@@ -17,6 +20,7 @@ pub struct RepoGitIndex {
     /// Sorted by path so per-package filtering can use binary-search range
     /// queries instead of linear scans.
     status_entries: Vec<RepoStatusEntry>,
+    unsupported_paths: Vec<UnsupportedGitPath>,
     untracked_entries_populated: bool,
 }
 
@@ -29,6 +33,7 @@ impl RepoGitIndex {
         Self {
             ls_tree_hashes,
             status_entries,
+            unsupported_paths: Vec::new(),
             untracked_entries_populated: true,
         }
     }
@@ -105,10 +110,10 @@ impl RepoGitIndex {
             .filter(|e| !e.mode.is_submodule())
             .map(|e| {
                 let path_bytes = e.path(&index);
-                let path_str = std::str::from_utf8(path_bytes).map_err(|err| {
-                    Error::git_error(format!("invalid utf8 in index path: {}", err))
-                })?;
-                let rel_path = RelativeUnixPathBuf::new(path_str)?;
+                let rel_path = match parse_git_path(path_bytes, "git index path")? {
+                    Ok(path) => path,
+                    Err(path) => return Ok(EntryClassification::Unsupported(path)),
+                };
                 let abs_path = git.root.join_unix_path(&rel_path);
 
                 match gix_index::fs::Metadata::from_path_no_follow(abs_path.as_std_path()) {
@@ -116,7 +121,7 @@ impl RepoGitIndex {
                         let fs_stat = gix_index::entry::Stat::from_fs(&fs_meta).map_err(|err| {
                             Error::git_error(format!(
                                 "failed to convert stat for {}: {}",
-                                path_str, err
+                                rel_path, err
                             ))
                         })?;
 
@@ -145,6 +150,7 @@ impl RepoGitIndex {
 
         let mut ls_tree_hashes = SortedGitHashes::with_capacity(num_entries);
         let mut status_entries = Vec::new();
+        let mut unsupported_paths = Vec::new();
 
         for result in classified {
             match result? {
@@ -163,6 +169,7 @@ impl RepoGitIndex {
                         is_delete: true,
                     });
                 }
+                EntryClassification::Unsupported(path) => unsupported_paths.push(path),
             }
         }
 
@@ -172,6 +179,8 @@ impl RepoGitIndex {
         // (sorted). Sort once now so find_untracked_files can binary search
         // directly on &[RepoStatusEntry] without cloning paths into Strings.
         status_entries.sort_by(|a, b| a.path.cmp(&b.path));
+        unsupported_paths.sort();
+        unsupported_paths.dedup();
 
         debug!(
             "built tracked repo git index (gix-index): clean_count={}, status_count={}",
@@ -182,6 +191,7 @@ impl RepoGitIndex {
         Ok(Self {
             ls_tree_hashes,
             status_entries,
+            unsupported_paths,
             untracked_entries_populated: false,
         })
     }
@@ -208,10 +218,10 @@ impl RepoGitIndex {
 
         enum UntrackedResult {
             /// Direct untracked file list from `git ls-files --others`
-            LsFiles(Result<Vec<RelativeUnixPathBuf>, Error>),
+            LsFiles(Result<GitPathList, Error>),
             /// All candidate files (tracked + untracked) from the walk;
             /// must be filtered against ls_tree to find untracked
-            Walk(Result<Vec<RelativeUnixPathBuf>, Error>),
+            Walk(Result<WalkedPaths, Error>),
         }
 
         let git1 = git.clone();
@@ -220,8 +230,10 @@ impl RepoGitIndex {
         let walk_root = git.root.as_std_path().to_path_buf();
         let walk_prefixes: Vec<_> = prefixes.to_vec();
 
-        let ls_tree_handle = thread::spawn(move || git1.git_ls_tree_repo_root_sorted());
-        let diff_index_handle = thread::spawn(move || git2.git_diff_index_repo_root());
+        let ls_tree_handle =
+            thread::spawn(move || git1.git_ls_tree_repo_root_sorted_with_unsupported());
+        let diff_index_handle =
+            thread::spawn(move || git2.git_diff_index_repo_root_with_unsupported());
 
         // Race: spawn both untracked discovery methods, use whichever
         // finishes first.
@@ -229,22 +241,26 @@ impl RepoGitIndex {
 
         let tx1 = untracked_tx.clone();
         let _ls_files_handle = thread::spawn(move || {
-            let result = git3.git_ls_files_untracked();
+            let result = git3.git_ls_files_untracked_with_unsupported();
             let _ = tx1.send(UntrackedResult::LsFiles(result));
         });
 
         let tx2 = untracked_tx;
         let _walk_handle = thread::spawn(move || {
-            let result = walk_candidate_files(&walk_root, Some(&walk_prefixes));
+            let result = walk_candidate_files_with_unsupported(&walk_root, Some(&walk_prefixes));
             let _ = tx2.send(UntrackedResult::Walk(result));
         });
 
-        let ls_tree_hashes = ls_tree_handle
+        let tree_state = ls_tree_handle
             .join()
             .map_err(|_| Error::git_error("git ls-tree thread panicked"))??;
-        let mut status_entries = diff_index_handle
+        let status_state = diff_index_handle
             .join()
             .map_err(|_| Error::git_error("git diff-index thread panicked"))??;
+        let ls_tree_hashes = tree_state.hashes;
+        let mut status_entries = status_state.entries;
+        let mut unsupported_paths = tree_state.unsupported_paths;
+        unsupported_paths.extend(status_state.unsupported_paths);
 
         // Use whichever untracked result arrives first.
         let untracked_winner = untracked_rx
@@ -256,9 +272,10 @@ impl RepoGitIndex {
                 let untracked_files = result?;
                 debug!(
                     "untracked race winner: git ls-files ({} files)",
-                    untracked_files.len()
+                    untracked_files.paths.len()
                 );
-                for path in untracked_files {
+                unsupported_paths.extend(untracked_files.unsupported_paths);
+                for path in untracked_files.paths {
                     status_entries.push(RepoStatusEntry {
                         path,
                         is_delete: false,
@@ -269,10 +286,14 @@ impl RepoGitIndex {
                 let candidates = result?;
                 debug!(
                     "untracked race winner: walk ({} candidates)",
-                    candidates.len()
+                    candidates.paths.len()
                 );
-                let untracked =
-                    filter_untracked_from_candidates(candidates, &ls_tree_hashes, &status_entries);
+                unsupported_paths.extend(candidates.unsupported_paths);
+                let untracked = filter_untracked_from_candidates(
+                    candidates.paths,
+                    &ls_tree_hashes,
+                    &status_entries,
+                );
                 for path in untracked {
                     status_entries.push(RepoStatusEntry {
                         path,
@@ -283,6 +304,8 @@ impl RepoGitIndex {
         }
 
         status_entries.sort_by(|a, b| a.path.cmp(&b.path));
+        unsupported_paths.sort();
+        unsupported_paths.dedup();
 
         debug!(
             "built repo git index (subprocess + walk race): clean_count={}, status_count={}",
@@ -293,6 +316,7 @@ impl RepoGitIndex {
         Ok(Self {
             ls_tree_hashes,
             status_entries,
+            unsupported_paths,
             untracked_entries_populated: true,
         })
     }
@@ -362,7 +386,10 @@ impl RepoGitIndex {
         let before_status_count = self.status_entries.len();
         let untracked =
             find_untracked_files(git, &self.ls_tree_hashes, &self.status_entries, prefixes)?;
-        for path in untracked {
+        self.unsupported_paths.extend(untracked.unsupported_paths);
+        self.unsupported_paths.sort();
+        self.unsupported_paths.dedup();
+        for path in untracked.paths {
             self.status_entries.push(RepoStatusEntry {
                 path,
                 is_delete: false,
@@ -394,6 +421,14 @@ impl RepoGitIndex {
         &self,
         pkg_prefix: &RelativeUnixPathBuf,
     ) -> Result<(GitHashes, Vec<RelativeUnixPathBuf>), Error> {
+        if let Some(path) = self
+            .unsupported_paths
+            .iter()
+            .find(|path| path.is_within_prefix(pkg_prefix))
+        {
+            return Err(path.clone().into_error());
+        }
+
         let prefix_str = pkg_prefix.as_str();
         let prefix_is_empty = prefix_str.is_empty();
 
@@ -503,6 +538,24 @@ impl RepoGitIndex {
     }
 }
 
+struct WalkedPaths {
+    paths: Vec<RelativeUnixPathBuf>,
+    unsupported_paths: Vec<UnsupportedGitPath>,
+}
+
+impl WalkedPaths {
+    fn new() -> Self {
+        Self {
+            paths: Vec::new(),
+            unsupported_paths: Vec::new(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.paths.is_empty() && self.unsupported_paths.is_empty()
+    }
+}
+
 /// Walk the working tree to collect candidate files (all non-gitignored
 /// files within scope). This is the I/O-bound phase that can run without
 /// the git index.
@@ -518,6 +571,18 @@ pub fn walk_candidate_files(
     git_root: &std::path::Path,
     prefixes: Option<&[RelativeUnixPathBuf]>,
 ) -> Result<Vec<RelativeUnixPathBuf>, Error> {
+    let walked = walk_candidate_files_with_unsupported(git_root, prefixes)?;
+    if let Some(path) = walked.unsupported_paths.into_iter().next() {
+        return Err(path.into_error());
+    }
+
+    Ok(walked.paths)
+}
+
+fn walk_candidate_files_with_unsupported(
+    git_root: &std::path::Path,
+    prefixes: Option<&[RelativeUnixPathBuf]>,
+) -> Result<WalkedPaths, Error> {
     use std::sync::mpsc;
 
     use ignore::WalkBuilder;
@@ -525,7 +590,7 @@ pub fn walk_candidate_files(
     let root = std::sync::Arc::new(git_root.to_path_buf());
     let scope = std::sync::Arc::new(UntrackedScope::new(prefixes));
 
-    let (tx, rx) = mpsc::channel::<Vec<RelativeUnixPathBuf>>();
+    let (tx, rx) = mpsc::channel::<WalkedPaths>();
 
     let walker = WalkBuilder::new(root.as_path())
         .follow_links(false)
@@ -550,20 +615,15 @@ pub fn walk_candidate_files(
                     Ok(rel) => rel,
                     Err(_) => return false,
                 };
-                #[cfg(windows)]
-                let rel_path_owned = rel_path.to_string_lossy().replace('\\', "/");
-                #[cfg(windows)]
-                let rel_path = rel_path_owned.as_str();
-                #[cfg(not(windows))]
-                let rel_path = match rel_path.to_str() {
-                    Some(rel) => rel,
-                    None => return false,
-                };
+                let rel_path = path_to_git_path_bytes(rel_path);
 
                 if is_dir {
-                    scope.should_visit_dir(rel_path)
+                    scope.should_visit_dir_bytes(rel_path.as_ref())
                 } else {
-                    scope.should_consider_file(rel_path, entry.file_name() == ".gitignore")
+                    scope.should_consider_file_bytes(
+                        rel_path.as_ref(),
+                        entry.file_name() == ".gitignore",
+                    )
                 }
             }
         })
@@ -571,14 +631,17 @@ pub fn walk_candidate_files(
         .build_parallel();
 
     struct FlushOnDrop {
-        buf: Vec<RelativeUnixPathBuf>,
-        tx: mpsc::Sender<Vec<RelativeUnixPathBuf>>,
+        batch: WalkedPaths,
+        tx: mpsc::Sender<WalkedPaths>,
     }
 
     impl Drop for FlushOnDrop {
         fn drop(&mut self) {
-            if !self.buf.is_empty() {
-                let batch = std::mem::take(&mut self.buf);
+            if !self.batch.is_empty() {
+                let batch = WalkedPaths {
+                    paths: std::mem::take(&mut self.batch.paths),
+                    unsupported_paths: std::mem::take(&mut self.batch.unsupported_paths),
+                };
                 let _ = self.tx.send(batch);
             }
         }
@@ -587,7 +650,7 @@ pub fn walk_candidate_files(
     walker.run(|| {
         let root = root.clone();
         let mut guard = FlushOnDrop {
-            buf: Vec::new(),
+            batch: WalkedPaths::new(),
             tx: tx.clone(),
         };
 
@@ -609,18 +672,10 @@ pub fn walk_candidate_files(
                 Err(_) => return ignore::WalkState::Continue,
             };
 
-            let unix_str = match rel_path.to_str() {
-                Some(s) => s,
-                None => return ignore::WalkState::Continue,
-            };
-
-            #[cfg(windows)]
-            let unix_str_owned = unix_str.replace('\\', "/");
-            #[cfg(windows)]
-            let unix_str: &str = &unix_str_owned;
-
-            if let Ok(path) = RelativeUnixPathBuf::new(unix_str) {
-                guard.buf.push(path);
+            match parse_path(rel_path, "working tree path") {
+                Ok(Ok(path)) => guard.batch.paths.push(path),
+                Ok(Err(path)) => guard.batch.unsupported_paths.push(path),
+                Err(_) => {}
             }
 
             ignore::WalkState::Continue
@@ -628,9 +683,10 @@ pub fn walk_candidate_files(
     });
     drop(tx);
 
-    let mut candidates: Vec<RelativeUnixPathBuf> = Vec::new();
+    let mut candidates = WalkedPaths::new();
     for batch in rx.iter() {
-        candidates.extend(batch);
+        candidates.paths.extend(batch.paths);
+        candidates.unsupported_paths.extend(batch.unsupported_paths);
     }
 
     Ok(candidates)
@@ -679,7 +735,7 @@ fn find_untracked_files(
     ls_tree_hashes: &SortedGitHashes,
     status_entries: &[RepoStatusEntry],
     prefixes: Option<&[RelativeUnixPathBuf]>,
-) -> Result<Vec<RelativeUnixPathBuf>, Error> {
+) -> Result<WalkedPaths, Error> {
     use std::sync::mpsc;
 
     use ignore::WalkBuilder;
@@ -759,7 +815,7 @@ fn find_untracked_files(
     };
     let gitignore_matchers = std::sync::Arc::new(gitignore_matchers);
 
-    let (tx, rx) = mpsc::channel::<Vec<RelativeUnixPathBuf>>();
+    let (tx, rx) = mpsc::channel::<WalkedPaths>();
 
     // Disable ALL per-directory probing. Gitignore rules are applied via
     // filter_entry using the pre-built matcher above.
@@ -786,20 +842,15 @@ fn find_untracked_files(
                     Ok(rel) => rel,
                     Err(_) => return false,
                 };
-                #[cfg(windows)]
-                let rel_path_owned = rel_path.to_string_lossy().replace('\\', "/");
-                #[cfg(windows)]
-                let rel_path = rel_path_owned.as_str();
-                #[cfg(not(windows))]
-                let rel_path = match rel_path.to_str() {
-                    Some(rel) => rel,
-                    None => return false,
-                };
+                let rel_path = path_to_git_path_bytes(rel_path);
 
                 let in_scope = if is_dir {
-                    scope.should_visit_dir(rel_path)
+                    scope.should_visit_dir_bytes(rel_path.as_ref())
                 } else {
-                    scope.should_consider_file(rel_path, entry.file_name() == ".gitignore")
+                    scope.should_consider_file_bytes(
+                        rel_path.as_ref(),
+                        entry.file_name() == ".gitignore",
+                    )
                 };
                 if !in_scope {
                     return false;
@@ -820,14 +871,17 @@ fn find_untracked_files(
         .build_parallel();
 
     struct FlushOnDrop {
-        buf: Vec<RelativeUnixPathBuf>,
-        tx: mpsc::Sender<Vec<RelativeUnixPathBuf>>,
+        batch: WalkedPaths,
+        tx: mpsc::Sender<WalkedPaths>,
     }
 
     impl Drop for FlushOnDrop {
         fn drop(&mut self) {
-            if !self.buf.is_empty() {
-                let batch = std::mem::take(&mut self.buf);
+            if !self.batch.is_empty() {
+                let batch = WalkedPaths {
+                    paths: std::mem::take(&mut self.batch.paths),
+                    unsupported_paths: std::mem::take(&mut self.batch.unsupported_paths),
+                };
                 let _ = self.tx.send(batch);
             }
         }
@@ -836,7 +890,7 @@ fn find_untracked_files(
     walker.run(|| {
         let root = root.clone();
         let mut guard = FlushOnDrop {
-            buf: Vec::new(),
+            batch: WalkedPaths::new(),
             tx: tx.clone(),
         };
 
@@ -858,16 +912,16 @@ fn find_untracked_files(
                 Err(_) => return ignore::WalkState::Continue,
             };
 
-            let unix_str = match rel_path.to_str() {
-                Some(s) => s,
-                None => return ignore::WalkState::Continue,
+            let path = match parse_path(rel_path, "working tree path") {
+                Ok(Ok(path)) => path,
+                Ok(Err(path)) => {
+                    guard.batch.unsupported_paths.push(path);
+                    return ignore::WalkState::Continue;
+                }
+                Err(_) => return ignore::WalkState::Continue,
             };
 
-            #[cfg(windows)]
-            let unix_str_owned = unix_str.replace('\\', "/");
-            #[cfg(windows)]
-            let unix_str: &str = &unix_str_owned;
-
+            let unix_str = path.as_str();
             let in_ls_tree = ls_tree_hashes
                 .binary_search_by(|(p, _)| p.as_str().cmp(unix_str))
                 .is_ok();
@@ -875,11 +929,8 @@ fn find_untracked_files(
                 .binary_search_by(|e| e.path.as_str().cmp(unix_str))
                 .is_ok();
 
-            if !in_ls_tree
-                && !in_status
-                && let Ok(path) = RelativeUnixPathBuf::new(unix_str)
-            {
-                guard.buf.push(path);
+            if !in_ls_tree && !in_status {
+                guard.batch.paths.push(path);
             }
 
             ignore::WalkState::Continue
@@ -887,15 +938,17 @@ fn find_untracked_files(
     });
     drop(tx);
 
-    let mut untracked: Vec<RelativeUnixPathBuf> = Vec::new();
+    let mut untracked = WalkedPaths::new();
     for batch in rx.iter() {
-        untracked.extend(batch);
+        untracked.paths.extend(batch.paths);
+        untracked.unsupported_paths.extend(batch.unsupported_paths);
     }
 
     // Post-filter: check for untracked .gitignore files that we couldn't
     // know about during the walk. If any exist, build per-directory matchers
     // from them and remove files that should be ignored.
     let untracked_gitignores: Vec<&RelativeUnixPathBuf> = untracked
+        .paths
         .iter()
         .filter(|p| p.as_str().ends_with(".gitignore"))
         .collect();
@@ -914,7 +967,7 @@ fn find_untracked_files(
             }
         }
         if !extra_matchers.is_empty() {
-            untracked.retain(|p| {
+            untracked.paths.retain(|p| {
                 if p.as_str().ends_with(".gitignore") {
                     return true;
                 }
@@ -976,47 +1029,67 @@ impl UntrackedScope {
         }
     }
 
+    #[cfg(test)]
     fn should_visit_dir(&self, rel_path: &str) -> bool {
+        self.should_visit_dir_bytes(rel_path.as_bytes())
+    }
+
+    fn should_visit_dir_bytes(&self, rel_path: &[u8]) -> bool {
         if self.is_full_walk || rel_path.is_empty() {
             return true;
         }
 
         self.prefixes.iter().any(|prefix| {
+            let prefix = prefix.as_bytes();
             rel_path == prefix
-                || is_nested_path(rel_path, prefix)
-                || is_nested_path(prefix, rel_path)
+                || is_nested_path_bytes(rel_path, prefix)
+                || is_nested_path_bytes(prefix, rel_path)
         })
     }
 
+    #[cfg(test)]
     fn should_consider_file(&self, rel_path: &str, is_gitignore: bool) -> bool {
-        if self.is_full_walk || self.is_within_selected_prefix(rel_path) {
+        self.should_consider_file_bytes(rel_path.as_bytes(), is_gitignore)
+    }
+
+    fn should_consider_file_bytes(&self, rel_path: &[u8], is_gitignore: bool) -> bool {
+        if self.is_full_walk || self.is_within_selected_prefix_bytes(rel_path) {
             return true;
         }
 
-        is_gitignore && self.should_visit_dir(parent_path(rel_path))
+        is_gitignore && self.should_visit_dir_bytes(parent_path_bytes(rel_path))
     }
 
+    #[cfg(test)]
     fn is_within_selected_prefix(&self, rel_path: &str) -> bool {
+        self.is_within_selected_prefix_bytes(rel_path.as_bytes())
+    }
+
+    fn is_within_selected_prefix_bytes(&self, rel_path: &[u8]) -> bool {
         if self.is_full_walk {
             return true;
         }
 
-        self.prefixes
-            .iter()
-            .any(|prefix| rel_path == prefix || is_nested_path(rel_path, prefix))
+        self.prefixes.iter().any(|prefix| {
+            let prefix = prefix.as_bytes();
+            rel_path == prefix || is_nested_path_bytes(rel_path, prefix)
+        })
     }
 }
 
 fn is_nested_path(path: &str, prefix: &str) -> bool {
-    path.len() > prefix.len()
-        && path.starts_with(prefix)
-        && path.as_bytes().get(prefix.len()) == Some(&b'/')
+    is_nested_path_bytes(path.as_bytes(), prefix.as_bytes())
 }
 
-fn parent_path(path: &str) -> &str {
-    path.rsplit_once('/')
-        .map(|(parent, _)| parent)
-        .unwrap_or("")
+fn is_nested_path_bytes(path: &[u8], prefix: &[u8]) -> bool {
+    path.len() > prefix.len() && path.starts_with(prefix) && path.get(prefix.len()) == Some(&b'/')
+}
+
+fn parent_path_bytes(path: &[u8]) -> &[u8] {
+    path.iter()
+        .rposition(|byte| *byte == b'/')
+        .map(|idx| &path[..idx])
+        .unwrap_or(b"")
 }
 
 enum EntryClassification {
@@ -1030,6 +1103,7 @@ enum EntryClassification {
     Deleted {
         path: RelativeUnixPathBuf,
     },
+    Unsupported(UnsupportedGitPath),
 }
 
 #[cfg(test)]
@@ -1065,6 +1139,7 @@ mod tests {
         RepoGitIndex {
             ls_tree_hashes,
             status_entries,
+            unsupported_paths: Vec::new(),
             untracked_entries_populated: true,
         }
     }

--- a/crates/turborepo-scm/src/status.rs
+++ b/crates/turborepo-scm/src/status.rs
@@ -6,7 +6,7 @@ use std::{
 use nom::Finish;
 use turbopath::{AbsoluteSystemPath, RelativeUnixPathBuf};
 
-use crate::{Error, GitHashes, GitRepo, wait_for_success};
+use crate::{Error, GitHashes, GitRepo, git_path::require_git_path, wait_for_success};
 
 pub(crate) struct RepoStatusEntry {
     pub path: RelativeUnixPathBuf,
@@ -60,9 +60,7 @@ fn read_status<R: Read>(
     let mut buffer = Vec::new();
     while reader.read_until(b'\0', &mut buffer)? != 0 {
         let entry = parse_status(&buffer)?;
-        let filename = std::str::from_utf8(entry.filename)
-            .map_err(|e| Error::git_error(format!("invalid utf8 in git status: {e}")))?;
-        let path = RelativeUnixPathBuf::new(filename)?;
+        let path = require_git_path(entry.filename, "git status path")?;
         if entry.is_delete {
             let path = path.strip_prefix(pkg_prefix).map_err(|_| {
                 Error::git_error(format!(
@@ -86,9 +84,7 @@ fn read_status_raw<R: Read>(reader: R) -> Result<Vec<RepoStatusEntry>, Error> {
     let mut buffer = Vec::new();
     while reader.read_until(b'\0', &mut buffer)? != 0 {
         let entry = parse_status(&buffer)?;
-        let filename = std::str::from_utf8(entry.filename)
-            .map_err(|e| Error::git_error(format!("invalid utf8 in git status: {e}")))?;
-        let path = RelativeUnixPathBuf::new(filename)?;
+        let path = require_git_path(entry.filename, "git status path")?;
         entries.push(RepoStatusEntry {
             path,
             is_delete: entry.is_delete,
@@ -136,7 +132,7 @@ mod tests {
     use turbopath::{AbsoluteSystemPathBuf, RelativeUnixPathBuf, RelativeUnixPathBufTestExt};
 
     use super::read_status;
-    use crate::{GitHashes, OidHash};
+    use crate::{Error, GitHashes, OidHash};
 
     #[test]
     fn test_status() {
@@ -168,6 +164,28 @@ mod tests {
                 let expected = prefix.join(&RelativeUnixPathBuf::new(*expected_filename).unwrap());
                 assert_eq!(to_hash[0], expected);
             }
+        }
+    }
+
+    #[test]
+    fn test_status_rejects_non_utf8_filename() {
+        let root_path = AbsoluteSystemPathBuf::cwd().unwrap();
+        let prefix = RelativeUnixPathBuf::new("").unwrap();
+        let mut hashes = GitHashes::new();
+        let err = read_status(
+            b"M  bad-\xff\0".as_slice(),
+            &root_path,
+            &prefix,
+            &mut hashes,
+        )
+        .unwrap_err();
+
+        match err {
+            Error::UnsupportedGitPath { origin, path, .. } => {
+                assert_eq!(origin, "git status path");
+                assert_eq!(path, "bad-\\xff");
+            }
+            _ => panic!("expected unsupported git path error"),
         }
     }
 


### PR DESCRIPTION
Why:
- Valid Unix Git paths may contain non-UTF-8 bytes, and strict UTF-8 parsing at SCM boundaries could make unrelated packages fail to hash.
- SCM parsing now keeps unsupported raw Git paths explicit, defers errors until a queried package actually includes one, and avoids falling back to manual hashing for unsupported Git paths.