### PR TITLE
fix: Refactor execsync to execfilesync for Shell command built from environment values

### DIFF
--- a/packages/turbo-vsc/src/extension.ts
+++ b/packages/turbo-vsc/src/extension.ts
@@ -416,7 +416,7 @@ function probeInternalLsp(
 ): InternalLspProbeResult {
   try {
     const output = cp
-      .execSync(`${quoteCommand(turboPath)} __internal_lsp --probe`, {
+      .execFileSync(turboPath, ["__internal_lsp", "--probe"], {
         ...options,
         stdio: ["ignore", "pipe", "pipe"],
         timeout: 1000


### PR DESCRIPTION

Use `cp.execFileSync` instead of `cp.execSync` in `probeInternalLsp`, passing `turboPath` as the executable and `["__internal_lsp", "--probe"]` as argv. This prevents shell interpretation of `turboPath` and addresses both alert variants in one change. 

