### PR TITLE
fix: Isolate Corepack state in integration tests

### DIFF
--- a/crates/turborepo/tests/common/mod.rs
+++ b/crates/turborepo/tests/common/mod.rs
@@ -36,7 +36,7 @@ pub fn turbo_command(test_dir: &Path) -> assert_cmd::Command {
     let corepack_dir = setup::corepack_dir_for_test_dir(test_dir);
     if corepack_dir.exists() {
         cmd.env("PATH", setup::prepend_to_path(&corepack_dir))
-            .env("COREPACK_HOME", setup::corepack_home(&corepack_dir));
+            .env("COREPACK_HOME", setup::corepack_home());
     }
     cmd.env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
         .env("TURBO_GLOBAL_WARNING_DISABLED", "1")

--- a/crates/turborepo/tests/common/mod.rs
+++ b/crates/turborepo/tests/common/mod.rs
@@ -33,12 +33,17 @@ pub fn turbo_output_filters() -> Vec<(&'static str, &'static str)> {
 /// before calling `.output()`.
 pub fn turbo_command(test_dir: &Path) -> assert_cmd::Command {
     let mut cmd = assert_cmd::Command::cargo_bin("turbo").expect("turbo binary not found");
+    let corepack_dir = setup::corepack_dir_for_test_dir(test_dir);
+    if corepack_dir.exists() {
+        cmd.env("PATH", setup::prepend_to_path(&corepack_dir))
+            .env("COREPACK_HOME", setup::corepack_home(&corepack_dir));
+    }
     cmd.env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
         .env("TURBO_GLOBAL_WARNING_DISABLED", "1")
         .env("TURBO_PRINT_VERSION_DISABLED", "1")
         .env("DO_NOT_TRACK", "1")
         .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
-        // Corepack intercepts package manager calls (yarn, pnpm) and can
+        // Corepack intercepts package manager calls (npm, yarn, pnpm) and can
         // prompt for download confirmation, which hangs in non-interactive CI.
         // The test setup pre-warms the corepack cache via `corepack prepare`
         // so the correct version is available locally without network access.

--- a/crates/turborepo/tests/common/setup.rs
+++ b/crates/turborepo/tests/common/setup.rs
@@ -4,8 +4,11 @@
 use std::{
     ffi::{OsStr, OsString},
     fs,
+    io::ErrorKind,
     path::{Path, PathBuf},
     process::Command,
+    thread,
+    time::{Duration, Instant},
 };
 
 fn manifest_dir() -> PathBuf {
@@ -149,7 +152,7 @@ pub fn setup_package_manager(
     }
 
     fs::create_dir_all(corepack_dir)?;
-    let corepack_home = corepack_home(corepack_dir);
+    let corepack_home = corepack_home();
     fs::create_dir_all(&corepack_home)?;
 
     run_corepack(
@@ -167,11 +170,7 @@ pub fn setup_package_manager(
     // resolve locally without any network access. Without this, every
     // corepack-intercepted PM call can trigger a slow download that causes
     // tests to timeout in CI.
-    run_corepack(
-        target_dir,
-        &corepack_home,
-        ["prepare", package_manager, "--activate"],
-    )?;
+    prepare_corepack_package_manager(target_dir, &corepack_home, package_manager)?;
 
     Ok(())
 }
@@ -199,7 +198,7 @@ pub fn prepare_corepack_from_package_json(dir: &Path) {
 
     let corepack_dir = corepack_dir_for_test_dir(dir);
     fs::create_dir_all(&corepack_dir).expect("failed to create corepack dir");
-    let corepack_home = corepack_home(&corepack_dir);
+    let corepack_home = corepack_home();
     fs::create_dir_all(&corepack_home).expect("failed to create corepack home");
 
     run_corepack(
@@ -213,8 +212,7 @@ pub fn prepare_corepack_from_package_json(dir: &Path) {
     )
     .expect("failed to enable corepack");
 
-    run_corepack(dir, &corepack_home, ["prepare", &pm, "--activate"])
-        .expect("failed to prepare corepack");
+    prepare_corepack_package_manager(dir, &corepack_home, &pm).expect("failed to prepare corepack");
 }
 
 /// Install dependencies using the specified package manager.
@@ -230,17 +228,11 @@ pub fn install_deps(
 
     match pm_name {
         "npm" => {
-            run_cmd(
-                target_dir,
-                "npm",
-                &["install", "--offline"],
-                &path_env,
-                corepack_dir,
-            )?;
+            run_cmd(target_dir, "npm", &["install", "--offline"], &path_env)?;
             normalize_lockfile_on_windows(target_dir, "package-lock.json");
         }
         "pnpm" => {
-            run_cmd(target_dir, "pnpm", &["install"], &path_env, corepack_dir)?;
+            run_cmd(target_dir, "pnpm", &["install"], &path_env)?;
             normalize_lockfile_on_windows(target_dir, "pnpm-lock.yaml");
         }
         "yarn" => {
@@ -255,7 +247,6 @@ pub fn install_deps(
                     &format!("--cache-folder={}", cache.display()),
                 ],
                 &path_env,
-                corepack_dir,
             )?;
 
             // Ignore the cache from git
@@ -269,7 +260,7 @@ pub fn install_deps(
             normalize_lockfile_on_windows(target_dir, "yarn.lock");
         }
         "bun" => {
-            run_cmd(target_dir, "bun", &["install"], &path_env, corepack_dir)?;
+            run_cmd(target_dir, "bun", &["install"], &path_env)?;
         }
         other => anyhow::bail!("unsupported package manager: {other}"),
     }
@@ -309,17 +300,11 @@ pub fn setup_integration_test(
     Ok(())
 }
 
-fn run_cmd(
-    dir: &Path,
-    program: &str,
-    args: &[&str],
-    path_env: &str,
-    corepack_dir: &Path,
-) -> Result<(), anyhow::Error> {
+fn run_cmd(dir: &Path, program: &str, args: &[&str], path_env: &str) -> Result<(), anyhow::Error> {
     let output = cmd_with_path(program, path_env)
         .args(args)
         .current_dir(dir)
-        .env("COREPACK_HOME", corepack_home(corepack_dir))
+        .env("COREPACK_HOME", corepack_home())
         // Safety net: auto-approve any corepack download prompt in case the
         // cache is somehow cold. The setup pre-warms the cache via
         // `corepack prepare` so this should rarely be needed.
@@ -373,8 +358,11 @@ pub fn corepack_dir_for_test_dir(target_dir: &Path) -> PathBuf {
     ))
 }
 
-pub fn corepack_home(corepack_dir: &Path) -> PathBuf {
-    corepack_dir.join("home")
+pub fn corepack_home() -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "turborepo-test-corepack-{:x}",
+        stable_hash(workspace_root().as_os_str().as_encoded_bytes())
+    ))
 }
 
 pub fn prepend_to_path(dir: &Path) -> String {
@@ -415,6 +403,101 @@ where
     }
 
     Ok(())
+}
+
+fn prepare_corepack_package_manager(
+    dir: &Path,
+    corepack_home: &Path,
+    package_manager: &str,
+) -> Result<(), anyhow::Error> {
+    let marker = corepack_home
+        .join("prepared")
+        .join(safe_filename(package_manager));
+    if marker.exists() {
+        return Ok(());
+    }
+
+    with_corepack_prepare_lock(corepack_home, || {
+        if marker.exists() {
+            return Ok(());
+        }
+
+        run_corepack(
+            dir,
+            corepack_home,
+            ["prepare", package_manager, "--activate"],
+        )?;
+        if let Some(parent) = marker.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(marker, b"")?;
+
+        Ok(())
+    })
+}
+
+fn with_corepack_prepare_lock<F>(corepack_home: &Path, f: F) -> Result<(), anyhow::Error>
+where
+    F: FnOnce() -> Result<(), anyhow::Error>,
+{
+    const LOCK_TIMEOUT: Duration = Duration::from_secs(120);
+    const STALE_LOCK_AGE: Duration = Duration::from_secs(300);
+
+    let lock_dir = corepack_home.join("prepare.lock");
+    let start = Instant::now();
+    loop {
+        match fs::create_dir(&lock_dir) {
+            Ok(()) => break,
+            Err(e) if e.kind() == ErrorKind::AlreadyExists => {
+                if is_stale_lock(&lock_dir, STALE_LOCK_AGE) {
+                    let _ = fs::remove_dir_all(&lock_dir);
+                    continue;
+                }
+                if start.elapsed() > LOCK_TIMEOUT {
+                    anyhow::bail!(
+                        "timed out waiting for Corepack prepare lock: {}",
+                        lock_dir.display()
+                    );
+                }
+                thread::sleep(Duration::from_millis(100));
+            }
+            Err(e) => return Err(e.into()),
+        }
+    }
+
+    struct LockGuard(PathBuf);
+    impl Drop for LockGuard {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    let _guard = LockGuard(lock_dir);
+    f()
+}
+
+fn is_stale_lock(lock_dir: &Path, stale_after: Duration) -> bool {
+    fs::metadata(lock_dir)
+        .and_then(|metadata| metadata.modified())
+        .and_then(|modified| modified.elapsed().map_err(std::io::Error::other))
+        .map(|age| age > stale_after)
+        .unwrap_or(false)
+}
+
+fn safe_filename(value: &str) -> String {
+    value
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect()
+}
+
+fn stable_hash(bytes: &[u8]) -> u64 {
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
 }
 
 /// Create a Command for a program, resolving it via PATH (including PATHEXT on

--- a/crates/turborepo/tests/common/setup.rs
+++ b/crates/turborepo/tests/common/setup.rs
@@ -2,6 +2,7 @@
 #![allow(dead_code)]
 
 use std::{
+    ffi::{OsStr, OsString},
     fs,
     path::{Path, PathBuf},
     process::Command,
@@ -139,51 +140,38 @@ pub fn setup_package_manager(
         &format!("Updated package manager to {package_manager}"),
     )?;
 
-    // Corepack only manages yarn and pnpm. npm ships with node and bun is
-    // its own runtime — neither needs corepack setup.
+    // Exercise package manager resolution through Corepack for every PM it
+    // supports, including npm. Keep Corepack state per test so parallel tests
+    // do not contend over the user's global Corepack cache/last-known-good data.
     let pm_name = package_manager.split('@').next().unwrap_or(package_manager);
     if !corepack_supports(pm_name) {
         return Ok(());
     }
 
     fs::create_dir_all(corepack_dir)?;
+    let corepack_home = corepack_home(corepack_dir);
+    fs::create_dir_all(&corepack_home)?;
 
-    let status = cmd("corepack")
-        .arg("enable")
-        .arg(pm_name)
-        .arg(format!("--install-directory={}", corepack_dir.display()))
-        .current_dir(target_dir)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map_err(|e| anyhow::anyhow!("failed to run corepack: {e}"))?;
-
-    if !status.success() {
-        anyhow::bail!("corepack enable {} failed with {}", pm_name, status);
-    }
+    run_corepack(
+        target_dir,
+        &corepack_home,
+        [
+            OsString::from("enable"),
+            OsString::from(pm_name),
+            OsString::from(format!("--install-directory={}", corepack_dir.display())),
+        ],
+    )?;
 
     // Pre-download the exact PM version into corepack's cache so that
     // subsequent invocations (yarn install, turbo run build → yarn run build)
     // resolve locally without any network access. Without this, every
     // corepack-intercepted PM call can trigger a slow download that causes
     // tests to timeout in CI.
-    let status = cmd("corepack")
-        .arg("prepare")
-        .arg(package_manager) // e.g. "yarn@1.22.17"
-        .arg("--activate")
-        .current_dir(target_dir)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::piped())
-        .status()
-        .map_err(|e| anyhow::anyhow!("failed to run corepack prepare: {e}"))?;
-
-    if !status.success() {
-        anyhow::bail!(
-            "corepack prepare {} failed with {}",
-            package_manager,
-            status
-        );
-    }
+    run_corepack(
+        target_dir,
+        &corepack_home,
+        ["prepare", package_manager, "--activate"],
+    )?;
 
     Ok(())
 }
@@ -209,20 +197,24 @@ pub fn prepare_corepack_from_package_json(dir: &Path) {
         return;
     }
 
-    let status = cmd("corepack")
-        .arg("prepare")
-        .arg(&pm)
-        .arg("--activate")
-        .current_dir(dir)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::piped())
-        .status()
-        .unwrap_or_else(|e| panic!("failed to run corepack prepare {pm}: {e}"));
+    let corepack_dir = corepack_dir_for_test_dir(dir);
+    fs::create_dir_all(&corepack_dir).expect("failed to create corepack dir");
+    let corepack_home = corepack_home(&corepack_dir);
+    fs::create_dir_all(&corepack_home).expect("failed to create corepack home");
 
-    assert!(
-        status.success(),
-        "corepack prepare {pm} failed with {status}"
-    );
+    run_corepack(
+        dir,
+        &corepack_home,
+        [
+            OsString::from("enable"),
+            OsString::from(pm_name),
+            OsString::from(format!("--install-directory={}", corepack_dir.display())),
+        ],
+    )
+    .expect("failed to enable corepack");
+
+    run_corepack(dir, &corepack_home, ["prepare", &pm, "--activate"])
+        .expect("failed to prepare corepack");
 }
 
 /// Install dependencies using the specified package manager.
@@ -238,11 +230,17 @@ pub fn install_deps(
 
     match pm_name {
         "npm" => {
-            run_cmd(target_dir, "npm", &["install", "--offline"], &path_env)?;
+            run_cmd(
+                target_dir,
+                "npm",
+                &["install", "--offline"],
+                &path_env,
+                corepack_dir,
+            )?;
             normalize_lockfile_on_windows(target_dir, "package-lock.json");
         }
         "pnpm" => {
-            run_cmd(target_dir, "pnpm", &["install"], &path_env)?;
+            run_cmd(target_dir, "pnpm", &["install"], &path_env, corepack_dir)?;
             normalize_lockfile_on_windows(target_dir, "pnpm-lock.yaml");
         }
         "yarn" => {
@@ -257,6 +255,7 @@ pub fn install_deps(
                     &format!("--cache-folder={}", cache.display()),
                 ],
                 &path_env,
+                corepack_dir,
             )?;
 
             // Ignore the cache from git
@@ -270,7 +269,7 @@ pub fn install_deps(
             normalize_lockfile_on_windows(target_dir, "yarn.lock");
         }
         "bun" => {
-            run_cmd(target_dir, "bun", &["install"], &path_env)?;
+            run_cmd(target_dir, "bun", &["install"], &path_env, corepack_dir)?;
         }
         other => anyhow::bail!("unsupported package manager: {other}"),
     }
@@ -298,13 +297,7 @@ pub fn setup_integration_test(
     package_manager: &str,
     install: bool,
 ) -> Result<(), anyhow::Error> {
-    let corepack_dir = target_dir.with_file_name(format!(
-        "{}-corepack",
-        target_dir
-            .file_name()
-            .expect("target_dir should have a file name")
-            .to_string_lossy()
-    ));
+    let corepack_dir = corepack_dir_for_test_dir(target_dir);
     fs::create_dir_all(&corepack_dir)?;
 
     copy_fixture(fixture, target_dir)?;
@@ -316,10 +309,17 @@ pub fn setup_integration_test(
     Ok(())
 }
 
-fn run_cmd(dir: &Path, program: &str, args: &[&str], path_env: &str) -> Result<(), anyhow::Error> {
+fn run_cmd(
+    dir: &Path,
+    program: &str,
+    args: &[&str],
+    path_env: &str,
+    corepack_dir: &Path,
+) -> Result<(), anyhow::Error> {
     let output = cmd_with_path(program, path_env)
         .args(args)
         .current_dir(dir)
+        .env("COREPACK_HOME", corepack_home(corepack_dir))
         // Safety net: auto-approve any corepack download prompt in case the
         // cache is somehow cold. The setup pre-warms the cache via
         // `corepack prepare` so this should rarely be needed.
@@ -363,10 +363,58 @@ fn corepack_supports(pm_name: &str) -> bool {
     matches!(pm_name, "npm" | "yarn" | "pnpm" | "berry")
 }
 
-fn prepend_to_path(dir: &Path) -> String {
+pub fn corepack_dir_for_test_dir(target_dir: &Path) -> PathBuf {
+    target_dir.with_file_name(format!(
+        "{}-corepack",
+        target_dir
+            .file_name()
+            .expect("target_dir should have a file name")
+            .to_string_lossy()
+    ))
+}
+
+pub fn corepack_home(corepack_dir: &Path) -> PathBuf {
+    corepack_dir.join("home")
+}
+
+pub fn prepend_to_path(dir: &Path) -> String {
     let current = std::env::var("PATH").unwrap_or_default();
     let sep = if cfg!(windows) { ";" } else { ":" };
     format!("{}{sep}{current}", dir.display())
+}
+
+fn run_corepack<I, S>(dir: &Path, corepack_home: &Path, args: I) -> Result<(), anyhow::Error>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let args = args
+        .into_iter()
+        .map(|arg| arg.as_ref().to_os_string())
+        .collect::<Vec<_>>();
+    let output = cmd("corepack")
+        .args(&args)
+        .current_dir(dir)
+        .env("COREPACK_HOME", corepack_home)
+        .env("COREPACK_ENABLE_DOWNLOAD_PROMPT", "0")
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .map_err(|e| anyhow::anyhow!("failed to run corepack {args:?}: {e}"))?;
+
+    if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "corepack {:?} failed with {}:\n{}{}",
+            args,
+            output.status,
+            stdout,
+            stderr
+        );
+    }
+
+    Ok(())
 }
 
 /// Create a Command for a program, resolving it via PATH (including PATHEXT on


### PR DESCRIPTION
## Summary
Use test-local Corepack shims while sharing a prepared Corepack cache per worktree. This avoids global Corepack contention in parallel Rust integration tests without forcing every test to re-prepare npm independently.

## Testing
- cargo nextest run -p turbo --test run_logging --test global_deps_test
- cargo test -p turbo --test run_logging -- --nocapture
- cargo test -p turbo --tests --no-run
- git diff --check
- pre-push hook via git push