### PR TITLE
test: Increase Windows Rust test threads

### DIFF
--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -316,6 +316,7 @@ jobs:
             --exclude turborepo-lsp \
             --exclude turborepo-schema-gen \
             --exclude turborepo-napi \
+            --test-threads 16 \
             --no-fail-fast
         shell: bash
         env:


### PR DESCRIPTION
## Why

Windows Rust testing is the remaining slow platform after collapsing Rust CI to one runner per OS. This draft PR tests whether the Windows job is I/O/process-bound enough to benefit from oversubscribing nextest on the 8-core runner.

The experiment is Windows-only. macOS and Ubuntu stay on the default nextest thread count because they are already finishing around 5 minutes.

## What To Watch

Compare the `Rust testing on windows` duration against recent main runs. This sets `--test-threads 16`, which is 2x the `windows-latest-8-core-oss` runner size.

## Validation

- ruby YAML parse for .github/workflows/turborepo-test.yml
- pnpm exec oxfmt --check .github/workflows/turborepo-test.yml
- pre-push hook