### PR TITLE
chore: Deduplicate hash canonicalization

### DIFF
--- a/crates/turborepo-hash/src/lib.rs
+++ b/crates/turborepo-hash/src/lib.rs
@@ -9,7 +9,7 @@
 mod oid_hash;
 mod traits;
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, fmt, sync::Arc};
 
 use capnp::{
     message::{Builder, HeapAllocator},
@@ -86,12 +86,12 @@ impl TaskHashable<'_> {
     /// Calculate the task hash, applying env_mode rules.
     ///
     /// In Loose mode, pass_through_env is cleared before hashing.
-    pub fn calculate_task_hash(mut self) -> String {
+    pub fn calculate_task_hash(mut self) -> Result<String, Error> {
         if matches!(self.env_mode, EnvMode::Loose) {
             self.pass_through_env = &[];
         }
 
-        self.hash()
+        self.try_hash()
     }
 }
 
@@ -123,21 +123,58 @@ pub struct FileHashes(pub Vec<(turbopath::RelativeUnixPathBuf, OidHash)>);
 /// for two foreign types (TaskOutputs and Builder).
 pub struct HashableTaskOutputs(pub TaskOutputs);
 
+#[derive(Debug)]
+pub enum Error {
+    MessageSize(capnp::Error),
+    Canonicalize(capnp::Error),
+    ReadTaskOutputs(capnp::Error),
+    SetTaskOutputs(capnp::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MessageSize(err) => {
+                write!(f, "unable to calculate Cap'n Proto message size: {err}")
+            }
+            Self::Canonicalize(err) => {
+                write!(f, "unable to canonicalize Cap'n Proto message: {err}")
+            }
+            Self::ReadTaskOutputs(err) => {
+                write!(f, "unable to read Cap'n Proto task outputs: {err}")
+            }
+            Self::SetTaskOutputs(err) => write!(f, "unable to set Cap'n Proto task outputs: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::MessageSize(err)
+            | Self::Canonicalize(err)
+            | Self::ReadTaskOutputs(err)
+            | Self::SetTaskOutputs(err) => Some(err),
+        }
+    }
+}
+
+pub trait HashableMessage {
+    fn into_builder(self) -> Result<Builder<HeapAllocator>, Error>;
+}
+
 fn canonical_builder<T: Owned>(
     size: capnp::Result<capnp::MessageSize>,
     value: impl SetterInput<T>,
-) -> Builder<HeapAllocator> {
-    let size = match size {
-        Ok(size) => size.word_count + 1,
-        Err(err) => panic!("unable to calculate total size: {err}"),
-    };
+) -> Result<Builder<HeapAllocator>, Error> {
+    let size = size.map_err(Error::MessageSize)?.word_count + 1;
 
     let mut canon_builder = Builder::new(HeapAllocator::default().first_segment_words(size as u32));
-    if let Err(err) = canon_builder.set_root_canonical::<T>(value) {
-        panic!("unable to canonicalize Cap'n Proto message: {err}");
-    }
-
     canon_builder
+        .set_root_canonical::<T>(value)
+        .map_err(Error::Canonicalize)?;
+
+    Ok(canon_builder)
 }
 
 impl From<TaskOutputs> for HashableTaskOutputs {
@@ -176,8 +213,9 @@ impl From<HashableTaskOutputs> for Builder<HeapAllocator> {
     }
 }
 
-impl From<LockFilePackages> for Builder<HeapAllocator> {
-    fn from(LockFilePackages(packages): LockFilePackages) -> Self {
+impl HashableMessage for LockFilePackages {
+    fn into_builder(self) -> Result<Builder<HeapAllocator>, Error> {
+        let LockFilePackages(packages) = self;
         let mut message = ::capnp::message::TypedBuilder::<
             proto_capnp::lock_file_packages::Owned,
             HeapAllocator,
@@ -202,8 +240,9 @@ impl From<LockFilePackages> for Builder<HeapAllocator> {
     }
 }
 
-impl<'a> From<LockFilePackagesRef<'a>> for Builder<HeapAllocator> {
-    fn from(LockFilePackagesRef(packages): LockFilePackagesRef<'a>) -> Self {
+impl HashableMessage for LockFilePackagesRef<'_> {
+    fn into_builder(self) -> Result<Builder<HeapAllocator>, Error> {
+        let LockFilePackagesRef(packages) = self;
         let mut message = ::capnp::message::TypedBuilder::<
             proto_capnp::lock_file_packages::Owned,
             HeapAllocator,
@@ -228,8 +267,9 @@ impl<'a> From<LockFilePackagesRef<'a>> for Builder<HeapAllocator> {
     }
 }
 
-impl From<FileHashes> for Builder<HeapAllocator> {
-    fn from(FileHashes(file_hashes): FileHashes) -> Self {
+impl HashableMessage for FileHashes {
+    fn into_builder(self) -> Result<Builder<HeapAllocator>, Error> {
+        let FileHashes(file_hashes) = self;
         debug_assert!(
             file_hashes.windows(2).all(|w| w[0].0 <= w[1].0),
             "FileHashes inner Vec must be sorted by key"
@@ -260,8 +300,9 @@ impl From<FileHashes> for Builder<HeapAllocator> {
     }
 }
 
-impl From<&FileHashes> for Builder<HeapAllocator> {
-    fn from(FileHashes(file_hashes): &FileHashes) -> Self {
+impl HashableMessage for &FileHashes {
+    fn into_builder(self) -> Result<Builder<HeapAllocator>, Error> {
+        let FileHashes(file_hashes) = self;
         debug_assert!(
             file_hashes.windows(2).all(|w| w[0].0 <= w[1].0),
             "FileHashes inner Vec must be sorted by key"
@@ -292,8 +333,9 @@ impl From<&FileHashes> for Builder<HeapAllocator> {
     }
 }
 
-impl From<TaskHashable<'_>> for Builder<HeapAllocator> {
-    fn from(task_hashable: TaskHashable) -> Self {
+impl HashableMessage for TaskHashable<'_> {
+    fn into_builder(self) -> Result<Builder<HeapAllocator>, Error> {
+        let task_hashable = self;
         let mut message =
             ::capnp::message::TypedBuilder::<proto_capnp::task_hashable::Owned>::new_default();
         let mut builder = message.init_root();
@@ -313,9 +355,12 @@ impl From<TaskHashable<'_>> for Builder<HeapAllocator> {
 
         {
             let output_builder: Builder<_> = HashableTaskOutputs(task_hashable.outputs).into();
+            let output_reader = output_builder
+                .get_root_as_reader()
+                .map_err(Error::ReadTaskOutputs)?;
             builder
-                .set_outputs(output_builder.get_root_as_reader().unwrap())
-                .unwrap();
+                .set_outputs(output_reader)
+                .map_err(Error::SetTaskOutputs)?;
         }
 
         {
@@ -368,8 +413,9 @@ impl From<TaskHashable<'_>> for Builder<HeapAllocator> {
     }
 }
 
-impl From<GlobalHashable<'_>> for Builder<HeapAllocator> {
-    fn from(hashable: GlobalHashable) -> Self {
+impl HashableMessage for GlobalHashable<'_> {
+    fn into_builder(self) -> Result<Builder<HeapAllocator>, Error> {
+        let hashable = self;
         let mut message =
             ::capnp::message::TypedBuilder::<proto_capnp::global_hashable::Owned>::new_default();
 

--- a/crates/turborepo-hash/src/lib.rs
+++ b/crates/turborepo-hash/src/lib.rs
@@ -11,7 +11,10 @@ mod traits;
 
 use std::{collections::HashMap, sync::Arc};
 
-use capnp::message::{Builder, HeapAllocator};
+use capnp::{
+    message::{Builder, HeapAllocator},
+    traits::{Owned, SetterInput},
+};
 pub use oid_hash::OidHash;
 pub use traits::TurboHash;
 // Re-export for backward compatibility. New code should import from `turborepo_types`.
@@ -120,6 +123,23 @@ pub struct FileHashes(pub Vec<(turbopath::RelativeUnixPathBuf, OidHash)>);
 /// for two foreign types (TaskOutputs and Builder).
 pub struct HashableTaskOutputs(pub TaskOutputs);
 
+fn canonical_builder<T: Owned>(
+    size: capnp::Result<capnp::MessageSize>,
+    value: impl SetterInput<T>,
+) -> Builder<HeapAllocator> {
+    let size = match size {
+        Ok(size) => size.word_count + 1,
+        Err(err) => panic!("unable to calculate total size: {err}"),
+    };
+
+    let mut canon_builder = Builder::new(HeapAllocator::default().first_segment_words(size as u32));
+    if let Err(err) = canon_builder.set_root_canonical::<T>(value) {
+        panic!("unable to canonicalize Cap'n Proto message: {err}");
+    }
+
+    canon_builder
+}
+
 impl From<TaskOutputs> for HashableTaskOutputs {
     fn from(value: TaskOutputs) -> Self {
         HashableTaskOutputs(value)
@@ -175,20 +195,10 @@ impl From<LockFilePackages> for Builder<HeapAllocator> {
             }
         }
 
-        // We're okay to unwrap here because we haven't hit the nesting
-        // limit and the message will not have cycles.
-        let size = builder
-            .total_size()
-            .expect("unable to calculate total size")
-            .word_count
-            + 1; // + 1 to solve an off by one error inside capnp
-        let mut canon_builder =
-            Builder::new(HeapAllocator::default().first_segment_words(size as u32));
-        canon_builder
-            .set_root_canonical(builder.reborrow_as_reader())
-            .expect("can't fail");
-
-        canon_builder
+        canonical_builder::<proto_capnp::lock_file_packages::Owned>(
+            builder.total_size(),
+            builder.reborrow_as_reader(),
+        )
     }
 }
 
@@ -211,20 +221,10 @@ impl<'a> From<LockFilePackagesRef<'a>> for Builder<HeapAllocator> {
             }
         }
 
-        // We're okay to unwrap here because we haven't hit the nesting
-        // limit and the message will not have cycles.
-        let size = builder
-            .total_size()
-            .expect("unable to calculate total size")
-            .word_count
-            + 1; // + 1 to solve an off by one error inside capnp
-        let mut canon_builder =
-            Builder::new(HeapAllocator::default().first_segment_words(size as u32));
-        canon_builder
-            .set_root_canonical(builder.reborrow_as_reader())
-            .expect("can't fail");
-
-        canon_builder
+        canonical_builder::<proto_capnp::lock_file_packages::Owned>(
+            builder.total_size(),
+            builder.reborrow_as_reader(),
+        )
     }
 }
 
@@ -253,20 +253,10 @@ impl From<FileHashes> for Builder<HeapAllocator> {
             }
         }
 
-        // We're okay to unwrap here because we haven't hit the nesting
-        // limit and the message will not have cycles.
-        let size = builder
-            .total_size()
-            .expect("unable to calculate total size")
-            .word_count
-            + 1; // + 1 to solve an off by one error inside capnp
-        let mut canon_builder =
-            Builder::new(HeapAllocator::default().first_segment_words(size as u32));
-        canon_builder
-            .set_root_canonical(builder.reborrow_as_reader())
-            .expect("can't fail");
-
-        canon_builder
+        canonical_builder::<proto_capnp::file_hashes::Owned>(
+            builder.total_size(),
+            builder.reborrow_as_reader(),
+        )
     }
 }
 
@@ -295,20 +285,10 @@ impl From<&FileHashes> for Builder<HeapAllocator> {
             }
         }
 
-        // We're okay to unwrap here because we haven't hit the nesting
-        // limit and the message will not have cycles.
-        let size = builder
-            .total_size()
-            .expect("unable to calculate total size")
-            .word_count
-            + 1; // + 1 to solve an off by one error inside capnp
-        let mut canon_builder =
-            Builder::new(HeapAllocator::default().first_segment_words(size as u32));
-        canon_builder
-            .set_root_canonical(builder.reborrow_as_reader())
-            .expect("can't fail");
-
-        canon_builder
+        canonical_builder::<proto_capnp::file_hashes::Owned>(
+            builder.total_size(),
+            builder.reborrow_as_reader(),
+        )
     }
 }
 
@@ -381,20 +361,10 @@ impl From<TaskHashable<'_>> for Builder<HeapAllocator> {
             }
         }
 
-        // We're okay to unwrap here because we haven't hit the nesting
-        // limit and the message will not have cycles.
-        let size = builder
-            .total_size()
-            .expect("unable to calculate total size")
-            .word_count
-            + 1; // + 1 to solve an off by one error inside capnp
-        let mut canon_builder =
-            Builder::new(HeapAllocator::default().first_segment_words(size as u32));
-        canon_builder
-            .set_root_canonical(builder.reborrow_as_reader())
-            .expect("can't fail");
-
-        canon_builder
+        canonical_builder::<proto_capnp::task_hashable::Owned>(
+            builder.total_size(),
+            builder.reborrow_as_reader(),
+        )
     }
 }
 
@@ -484,20 +454,10 @@ impl From<GlobalHashable<'_>> for Builder<HeapAllocator> {
         builder.set_framework_inference(hashable.framework_inference);
         builder.set_global_configuration(hashable.global_configuration);
 
-        // We're okay to unwrap here because we haven't hit the nesting
-        // limit and the message will not have cycles.
-        let size = builder
-            .total_size()
-            .expect("unable to calculate total size")
-            .word_count
-            + 1; // + 1 to solve an off by one error inside capnp
-        let mut canon_builder =
-            Builder::new(HeapAllocator::default().first_segment_words(size as u32));
-        canon_builder
-            .set_root_canonical(builder.reborrow_as_reader())
-            .expect("can't fail");
-
-        canon_builder
+        canonical_builder::<proto_capnp::global_hashable::Owned>(
+            builder.total_size(),
+            builder.reborrow_as_reader(),
+        )
     }
 }
 

--- a/crates/turborepo-hash/src/traits.rs
+++ b/crates/turborepo-hash/src/traits.rs
@@ -1,25 +1,16 @@
-use capnp::message::{Allocator, Builder};
+use crate::{Error, HashableMessage};
 
-pub trait Sealed<A> {}
-
-pub trait TurboHash<A>: Sealed<A> {
+pub trait TurboHash: HashableMessage {
+    fn try_hash(self) -> Result<String, Error>;
     fn hash(self) -> String;
 }
 
-impl<T, A> Sealed<A> for T
+impl<T> TurboHash for T
 where
-    T: Into<Builder<A>>,
-    A: Allocator,
+    T: HashableMessage,
 {
-}
-
-impl<T, A> TurboHash<A> for T
-where
-    T: Into<Builder<A>>,
-    A: Allocator,
-{
-    fn hash(self) -> String {
-        let message = self.into();
+    fn try_hash(self) -> Result<String, Error> {
+        let message = self.into_builder()?;
 
         debug_assert_eq!(
             message.get_segments_for_output().len(),
@@ -31,6 +22,11 @@ where
 
         let out = xxhash_rust::xxh64::xxh64(buf, 0);
 
-        hex::encode(out.to_be_bytes())
+        Ok(hex::encode(out.to_be_bytes()))
+    }
+
+    fn hash(self) -> String {
+        self.try_hash()
+            .unwrap_or_else(|err| panic!("failed to calculate Turbo hash: {err}"))
     }
 }

--- a/crates/turborepo-run-cache/src/lib.rs
+++ b/crates/turborepo-run-cache/src/lib.rs
@@ -772,7 +772,9 @@ impl ConfigCache {
 
         let mut file_hashes: Vec<_> = hash_object.into_iter().collect();
         file_hashes.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
-        Ok(FileHashes(file_hashes).hash())
+        FileHashes(file_hashes)
+            .try_hash()
+            .map_err(|_| CacheError::ConfigCacheError)
     }
 }
 

--- a/crates/turborepo-task-hash/src/lib.rs
+++ b/crates/turborepo-task-hash/src/lib.rs
@@ -73,6 +73,8 @@ pub enum Error {
     Regex(#[from] regex::Error),
     #[error(transparent)]
     Path(#[from] turbopath::PathError),
+    #[error(transparent)]
+    Hash(#[from] turborepo_hash::Error),
 }
 
 #[derive(Debug, Default)]
@@ -448,7 +450,7 @@ impl<'a, R: RunOptsHashInfo> TaskHasher<'a, R> {
             env_mode: task_env_mode,
         };
 
-        let task_hash = task_hashable.calculate_task_hash();
+        let task_hash = task_hashable.calculate_task_hash()?;
 
         let task_hash_arc: Arc<str> = Arc::from(task_hash.as_str());
         self.task_hash_tracker.insert_hash(
@@ -590,7 +592,7 @@ pub fn get_internal_deps_hash(
 
     let mut file_hashes: Vec<_> = merged.into_iter().collect();
     file_hashes.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
-    Ok(FileHashes(file_hashes).hash())
+    Ok(FileHashes(file_hashes).try_hash()?)
 }
 
 impl TaskHashTracker {


### PR DESCRIPTION
## Why

`turborepo-hash` repeated the same Cap'n Proto canonicalization invariant in every hashable conversion. Centralizing it keeps future hashable types on one path for canonical message construction.

This also adds a fallible `try_hash()` path with typed `turborepo_hash::Error` values, then migrates Result-returning production hash callers so canonicalization failures can be reported instead of panicking. The existing `hash()` method remains as a compatibility path for callers that still require infallible hashing.

## Testing

- `cargo fmt --package turborepo-hash --package turborepo-task-hash --package turborepo-run-cache`
- `cargo test --package turborepo-hash --package turborepo-task-hash --package turborepo-run-cache`
- `cargo clippy --package turborepo-hash --package turborepo-task-hash --package turborepo-run-cache --all-targets -- -D warnings`
- pre-push hook: `pnpm exec lint-staged`, `turbo run format check:toml`, `cargo fmt --check`, `cargo lint`, `cargo check --workspace`
