### PR TITLE
fix: Store `PackageGraph` root invariants

### DIFF
--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -192,7 +192,10 @@ struct BuildState<'a, S, T> {
     single: bool,
     workspaces: HashMap<PackageName, PackageInfo>,
     workspace_graph: Graph<PackageNode, ()>,
+    root_node_index: NodeIndex,
+    root_workspace_index: NodeIndex,
     node_lookup: HashMap<PackageNode, NodeIndex>,
+    root_package_json: PackageJson,
     lockfile: Option<Box<dyn Lockfile>>,
     package_jsons: Option<HashMap<AbsoluteSystemPathBuf, PackageJson>>,
     state: std::marker::PhantomData<S>,
@@ -213,13 +216,6 @@ impl<S, T> BuildState<'_, S, T> {
         let idx = self.workspace_graph.add_node(node.clone());
         self.node_lookup.insert(node, idx);
         idx
-    }
-
-    fn add_root_workspace(&mut self) {
-        let root_index = self.add_node(PackageNode::Root);
-        let root_workspace = self.add_node(PackageNode::Workspace(PackageName::Root));
-        self.workspace_graph
-            .add_edge(root_workspace, root_index, ());
     }
 }
 
@@ -246,14 +242,23 @@ where
             package_manager: _,
         } = builder;
         let mut workspaces = HashMap::new();
-        workspaces.insert(
-            PackageName::Root,
-            PackageInfo {
-                package_json: root_package_json,
-                package_json_path: AnchoredSystemPathBuf::from_raw("package.json").unwrap(),
-                ..Default::default()
-            },
-        );
+        let root_package_info = PackageInfo {
+            package_json: root_package_json,
+            package_json_path: AnchoredSystemPathBuf::from_raw("package.json").unwrap(),
+            ..Default::default()
+        };
+        let root_package_json = root_package_info.package_json.clone();
+        workspaces.insert(PackageName::Root, root_package_info);
+
+        let mut workspace_graph = Graph::new();
+        let root_node_index = workspace_graph.add_node(PackageNode::Root);
+        let root_workspace = PackageNode::Workspace(PackageName::Root);
+        let root_workspace_index = workspace_graph.add_node(root_workspace.clone());
+        workspace_graph.add_edge(root_workspace_index, root_node_index, ());
+
+        let mut node_lookup = HashMap::new();
+        node_lookup.insert(PackageNode::Root, root_node_index);
+        node_lookup.insert(root_workspace, root_workspace_index);
 
         Ok(BuildState {
             repo_root,
@@ -262,8 +267,11 @@ where
             workspaces,
             lockfile,
             package_jsons,
-            workspace_graph: Graph::new(),
-            node_lookup: HashMap::new(),
+            workspace_graph,
+            root_node_index,
+            root_workspace_index,
+            node_lookup,
+            root_package_json,
             state: std::marker::PhantomData,
             package_discovery: CachingPackageDiscovery::new(
                 package_discovery.build().map_err(Into::into)?,
@@ -313,10 +321,6 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedPackageManager, T> {
     // need our own type
     #[tracing::instrument(skip(self))]
     async fn parse_package_jsons(mut self) -> Result<BuildState<'a, ResolvedWorkspaces, T>, Error> {
-        // The root workspace will be present
-        // we either read from disk or just read the map
-        self.add_root_workspace();
-
         let package_jsons = match self.package_jsons.take() {
             Some(jsons) => Ok(jsons),
             None => {
@@ -365,7 +369,10 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedPackageManager, T> {
             single,
             workspaces,
             workspace_graph,
+            root_node_index,
+            root_workspace_index,
             node_lookup,
+            root_package_json,
             lockfile,
             package_discovery,
             ..
@@ -375,7 +382,10 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedPackageManager, T> {
             single,
             workspaces,
             workspace_graph,
+            root_node_index,
+            root_workspace_index,
             node_lookup,
+            root_package_json,
             lockfile,
             package_discovery,
             package_jsons: None,
@@ -383,13 +393,15 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedPackageManager, T> {
         })
     }
 
-    async fn build_single_package_graph(mut self) -> Result<PackageGraph, discovery::Error> {
-        self.add_root_workspace();
+    async fn build_single_package_graph(self) -> Result<PackageGraph, discovery::Error> {
         let Self {
             single,
             workspaces,
             workspace_graph,
+            root_node_index,
+            root_workspace_index,
             node_lookup,
+            root_package_json,
             lockfile,
             package_discovery,
             repo_root,
@@ -401,7 +413,10 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedPackageManager, T> {
         debug_assert!(single, "expected single package graph");
         Ok(PackageGraph {
             graph: workspace_graph,
+            root_node_index,
+            root_workspace_index,
             node_lookup,
+            root_package_json,
             packages: workspaces,
             lockfile,
             package_manager,
@@ -544,7 +559,10 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedWorkspaces, T> {
             single,
             workspaces,
             workspace_graph,
+            root_node_index,
+            root_workspace_index,
             node_lookup,
+            root_package_json,
             package_discovery,
             ..
         } = self;
@@ -553,7 +571,10 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedWorkspaces, T> {
             single,
             workspaces,
             workspace_graph,
+            root_node_index,
+            root_workspace_index,
             node_lookup,
+            root_package_json,
             lockfile,
             package_jsons: None,
             state: std::marker::PhantomData,
@@ -624,14 +645,20 @@ impl<T: PackageDiscovery> BuildState<'_, ResolvedLockfile, T> {
         let Self {
             workspaces,
             workspace_graph,
+            root_node_index,
+            root_workspace_index,
             node_lookup,
+            root_package_json,
             lockfile,
             repo_root,
             ..
         } = self;
         Ok(PackageGraph {
             graph: workspace_graph,
+            root_node_index,
+            root_workspace_index,
             node_lookup,
+            root_package_json,
             packages: workspaces,
             package_manager,
             lockfile,

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -31,9 +31,12 @@ pub const ROOT_PKG_NAME: &str = "//";
 #[derive(Debug)]
 pub struct PackageGraph {
     graph: petgraph::Graph<PackageNode, ()>,
+    root_node_index: NodeIndex,
+    root_workspace_index: NodeIndex,
     #[allow(dead_code)]
     node_lookup: HashMap<PackageNode, petgraph::graph::NodeIndex>,
     packages: HashMap<PackageName, PackageInfo>,
+    root_package_json: PackageJson,
     package_manager: PackageManager,
     lockfile: Option<Box<dyn Lockfile>>,
     repo_root: AbsoluteSystemPathBuf,
@@ -302,15 +305,11 @@ impl PackageGraph {
     }
 
     pub fn remove_package_dependencies(&mut self) {
-        let root_index = self
-            .node_lookup
-            .get(&PackageNode::Root)
-            .expect("graph should have root package node");
         self.graph.retain_edges(|graph, index| {
             let Some((_src, dst)) = graph.edge_endpoints(index) else {
                 return false;
             };
-            dst == *root_index
+            dst == self.root_node_index
         });
     }
 
@@ -355,6 +354,13 @@ impl PackageGraph {
         self.packages.get(package)
     }
 
+    fn package_dir_for_node(&self, node: &PackageNode) -> Option<&AnchoredSystemPath> {
+        match node {
+            PackageNode::Workspace(package) => self.package_dir(package),
+            PackageNode::Root => None,
+        }
+    }
+
     pub fn get_package_by_index(&self, index: NodeIndex) -> Option<&PackageNode> {
         self.graph.node_weight(index)
     }
@@ -376,8 +382,7 @@ impl PackageGraph {
     }
 
     pub fn root_package_json(&self) -> &PackageJson {
-        self.package_json(&PackageName::Root)
-            .expect("package graph was built without root package.json")
+        &self.root_package_json
     }
 
     /// Gets all the nodes that directly depend on this one, that is to say
@@ -480,11 +485,9 @@ impl PackageGraph {
         let dependencies = self.root_internal_dependencies();
         dependencies
             .into_iter()
-            .filter_map(|package| match package {
+            .filter_map(|node| match node {
                 PackageNode::Workspace(package) => {
-                    let path = self
-                        .package_dir(package)
-                        .expect("packages in graph should have info");
+                    let path = self.package_dir_for_node(node)?;
                     Some(WorkspacePackage {
                         name: package.clone(),
                         path: path.to_owned(),
@@ -499,11 +502,8 @@ impl PackageGraph {
         let dependencies = self.root_internal_dependencies();
         dependencies
             .into_iter()
-            .filter_map(|package| match package {
-                PackageNode::Workspace(package) => Some(
-                    self.package_dir(package)
-                        .expect("packages in graph should have info"),
-                ),
+            .filter_map(|node| match node {
+                PackageNode::Workspace(_) => self.package_dir_for_node(node),
                 PackageNode::Root => None,
             })
             .sorted()
@@ -519,19 +519,13 @@ impl PackageGraph {
         &self,
         package: &WorkspacePackage,
     ) -> Option<String> {
-        let from = *self
-            .node_lookup
-            .get(&PackageNode::Workspace(PackageName::Root))
-            .expect("all graphs should have a root");
+        let from = self.root_workspace_index;
         let to = *self
             .node_lookup
             .get(&PackageNode::Workspace(package.name.clone()))?;
         let (_cost, path) =
             petgraph::algo::astar(&self.graph, from, |node| node == to, |_| 1, |_| 1)?;
-        Some(
-            self.path_display(&path)
-                .expect("path should only contain valid node indices"),
-        )
+        self.path_display(&path)
     }
 
     fn path_display(&self, path: &[petgraph::graph::NodeIndex]) -> Option<String> {
@@ -550,9 +544,7 @@ impl PackageGraph {
         // as it will infinitely recurse.
         let mut dependencies = turborepo_graph_utils::transitive_closure(
             &self.graph,
-            self.node_lookup
-                .get(&PackageNode::Workspace(PackageName::Root))
-                .cloned(),
+            Some(self.root_workspace_index),
             petgraph::Direction::Outgoing,
         );
         dependencies.remove(&PackageNode::Workspace(PackageName::Root));


### PR DESCRIPTION
## Why

`PackageGraph` already requires a synthetic root node, root workspace node, and root package JSON to exist. Storing those invariants when the graph is built avoids rediscovering them through map lookups later and removes several implementation `expect()` callsites.