### PR TITLE
chore: Avoid engine graph node expects

### DIFF
--- a/crates/turborepo-engine/src/dot.rs
+++ b/crates/turborepo-engine/src/dot.rs
@@ -27,12 +27,11 @@ fn render_graph<N>(
     mut display_node: impl FnMut(&N) -> String,
     mut writer: impl io::Write,
 ) -> Result<(), io::Error> {
-    let mut get_node = |i| {
-        display_node(
-            graph
-                .node_weight(i)
-                .expect("node index should exist in graph"),
-        )
+    let mut get_node = |i| -> Result<String, io::Error> {
+        graph
+            .node_weight(i)
+            .map(&mut display_node)
+            .ok_or_else(|| io::Error::other("node index should exist in graph"))
     };
 
     // These are hardcoded writes from the Go side that we just copy
@@ -41,11 +40,11 @@ fn render_graph<N>(
     let mut edges = graph
         .edge_references()
         .map(|edge| {
-            let source = get_node(edge.source());
-            let target = get_node(edge.target());
-            format!("\t\t\"[root] {source}\" -> \"[root] {target}\"")
+            let source = get_node(edge.source())?;
+            let target = get_node(edge.target())?;
+            Ok(format!("\t\t\"[root] {source}\" -> \"[root] {target}\""))
         })
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>, io::Error>>()?;
     edges.sort();
 
     writer.write_all(edges.join("\n").as_bytes())?;

--- a/crates/turborepo-engine/src/lib.rs
+++ b/crates/turborepo-engine/src/lib.rs
@@ -433,7 +433,7 @@ impl<T: TaskDefinitionInfo + Clone> Engine<Built, T> {
         reachable: &HashSet<petgraph::graph::NodeIndex>,
         exclude_non_interruptible_persistent: bool,
     ) -> Self {
-        self.task_graph = self.task_graph.filter_map(
+        let pruned_graph = self.task_graph.filter_map(
             |node_idx, node| {
                 if !reachable.contains(&node_idx) {
                     return None;
@@ -455,10 +455,9 @@ impl<T: TaskDefinitionInfo + Clone> Engine<Built, T> {
         // Rebuild all metadata from the pruned graph. root_index is recovered
         // during the task_lookup rebuild to avoid a separate linear scan.
         let mut new_root_index = None;
-        self.task_lookup = self
-            .task_graph
+        let task_lookup = pruned_graph
             .node_indices()
-            .filter_map(|index| match self.task_graph.node_weight(index)? {
+            .filter_map(|index| match pruned_graph.node_weight(index)? {
                 TaskNode::Root => {
                     new_root_index = Some(index);
                     None
@@ -466,9 +465,14 @@ impl<T: TaskDefinitionInfo + Clone> Engine<Built, T> {
                 TaskNode::Task(task) => Some((task.clone(), index)),
             })
             .collect();
-        if let Some(root_index) = new_root_index {
-            self.root_index = root_index;
-        }
+        let Some(root_index) = new_root_index else {
+            tracing::debug!("skipping task graph prune because the root node was not retained");
+            return self;
+        };
+
+        self.task_graph = pruned_graph;
+        self.task_lookup = task_lookup;
+        self.root_index = root_index;
 
         self.task_definitions
             .retain(|id, _| self.task_lookup.contains_key(id));

--- a/crates/turborepo-engine/src/lib.rs
+++ b/crates/turborepo-engine/src/lib.rs
@@ -412,18 +412,13 @@ impl<T: TaskDefinitionInfo + Clone> Engine<Built, T> {
     }
 
     fn is_cacheable_task_node(&self, node: petgraph::graph::NodeIndex) -> bool {
-        let TaskNode::Task(task) = self
-            .task_graph
-            .node_weight(node)
-            .expect("node index should be present")
-        else {
+        let Some(TaskNode::Task(task)) = self.task_graph.node_weight(node) else {
             return false;
         };
 
         self.task_definitions
             .get(task)
-            .expect("task should have definition")
-            .cache()
+            .is_some_and(|def| def.cache())
     }
 
     /// Prunes the engine graph to only nodes in `reachable` and rebuilds all
@@ -443,14 +438,14 @@ impl<T: TaskDefinitionInfo + Clone> Engine<Built, T> {
                 if !reachable.contains(&node_idx) {
                     return None;
                 }
-                if exclude_non_interruptible_persistent && let TaskNode::Task(task) = node {
-                    let def = self
+                if exclude_non_interruptible_persistent
+                    && let TaskNode::Task(task) = node
+                    && self
                         .task_definitions
                         .get(task)
-                        .expect("task should have definition");
-                    if def.persistent() && !def.interruptible() {
-                        return None;
-                    }
+                        .is_some_and(|def| def.persistent() && !def.interruptible())
+                {
+                    return None;
                 }
                 Some(node.clone())
             },
@@ -463,21 +458,17 @@ impl<T: TaskDefinitionInfo + Clone> Engine<Built, T> {
         self.task_lookup = self
             .task_graph
             .node_indices()
-            .filter_map(|index| {
-                match self
-                    .task_graph
-                    .node_weight(index)
-                    .expect("node index should be present")
-                {
-                    TaskNode::Root => {
-                        new_root_index = Some(index);
-                        None
-                    }
-                    TaskNode::Task(task) => Some((task.clone(), index)),
+            .filter_map(|index| match self.task_graph.node_weight(index)? {
+                TaskNode::Root => {
+                    new_root_index = Some(index);
+                    None
                 }
+                TaskNode::Task(task) => Some((task.clone(), index)),
             })
             .collect();
-        self.root_index = new_root_index.expect("root node should be present");
+        if let Some(root_index) = new_root_index {
+            self.root_index = root_index;
+        }
 
         self.task_definitions
             .retain(|id, _| self.task_lookup.contains_key(id));
@@ -622,11 +613,7 @@ impl<T: TaskDefinitionInfo + Clone> Engine<Built, T> {
         Some(
             self.task_graph
                 .neighbors_directed(*index, direction)
-                .map(|index| {
-                    self.task_graph
-                        .node_weight(index)
-                        .expect("node index should be present")
-                })
+                .filter_map(|index| self.task_graph.node_weight(index))
                 .collect(),
         )
     }

--- a/crates/turborepo-engine/src/mermaid.rs
+++ b/crates/turborepo-engine/src/mermaid.rs
@@ -43,24 +43,21 @@ fn render_graph<W: io::Write>(
         },
         false => |node: &TaskNode| node.to_string(),
     };
+    let get_node = |i| -> Result<String, io::Error> {
+        graph
+            .node_weight(i)
+            .map(display_node)
+            .ok_or_else(|| io::Error::other("node index should exist in graph"))
+    };
 
     let mut edges = graph
         .edge_references()
         .map(|e| {
-            (
-                display_node(
-                    graph
-                        .node_weight(e.source())
-                        .expect("node index should exist in graph"),
-                ),
-                display_node(
-                    graph
-                        .node_weight(e.target())
-                        .expect("node index should exist in graph"),
-                ),
-            )
+            let source = get_node(e.source())?;
+            let target = get_node(e.target())?;
+            Ok((source, target))
         })
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>, io::Error>>()?;
     edges.sort();
 
     writeln!(writer, "graph TD")?;


### PR DESCRIPTION
## Why

Engine graph traversal and rendering paths were relying on `expect()` for node lookups that can be represented by existing return types. This removes those implementation panics from the contained engine graph paths and lets rendering surface malformed graph access as `io::Error`.