### PR TITLE
test: Make Rust tests parallel-safe

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -4,19 +4,6 @@
 [profile.default]
 failure-output = "immediate-final"
 
-[test-groups]
-# turborepo-process tests should run serially to avoid resource contention
-# and timing issues, especially on macOS where PTY devices are limited
-turborepo-process-serial = { max-threads = 1 }
-
-# turborepo-dirs tests should run serially to avoid race conditions
-# with environment variable manipulation
-turborepo-dirs-serial = { max-threads = 1 }
-
-# turbo watch tests spawn daemon processes and file watchers that fight
-# over resources when run concurrently
-turbo-watch-serial = { max-threads = 1 }
-
 [[profile.default.overrides]]
 # These tests run package installs from the network during setup, which can
 # take 20-60s+ on cold CI runners. Give them extra time instead of retries.
@@ -24,21 +11,9 @@ filter = 'package(turbo) and (test(prune_test::test_prune_composable_config) or 
 slow-timeout = { period = "120s", terminate-after = 2 }
 
 [[profile.default.overrides]]
-# Run all tests in the turborepo-process crate serially
-filter = 'package(turborepo-process)'
-test-group = 'turborepo-process-serial'
-
-[[profile.default.overrides]]
-# Run all tests in the turborepo-dirs crate serially
-# These tests manipulate environment variables
-filter = 'package(turborepo-dirs)'
-test-group = 'turborepo-dirs-serial'
-
-[[profile.default.overrides]]
 # Watch tests spawn long-running turbo watch processes with 30s internal
-# timeouts. Serialize to avoid daemon socket contention and give extra time.
+# timeouts. Give them extra time without restricting concurrency.
 filter = 'package(turbo) and test(/^watch_/)'
-test-group = 'turbo-watch-serial'
 slow-timeout = { period = "60s", terminate-after = 2 }
 
 [[profile.default.overrides]]

--- a/crates/turborepo-dirs/src/lib.rs
+++ b/crates/turborepo-dirs/src/lib.rs
@@ -2,6 +2,8 @@
 //! A small patch on top of `dirs_next` that makes use of turbopath and respects
 //! `VERCEL_CONFIG_DIR_PATH` as an override.
 
+use std::path::PathBuf;
+
 use dirs_next::config_dir as dirs_config_dir;
 use thiserror::Error;
 use turbopath::{AbsoluteSystemPathBuf, PathError};
@@ -12,29 +14,11 @@ use turbopath::{AbsoluteSystemPathBuf, PathError};
 /// `TURBO_CONFIG_DIR_PATH` environment variable. If the environment variable
 /// is set, it will return that path instead of `dirs_next::config_dir`.
 pub fn config_dir() -> Result<Option<AbsoluteSystemPathBuf>, PathError> {
-    if let Ok(dir) = std::env::var("TURBO_CONFIG_DIR_PATH") {
-        // Reject empty strings per Unix convention
-        if dir.is_empty() {
-            return Err(PathError::InvalidUnicode(dir));
-        }
-
-        let raw = std::path::PathBuf::from(&dir);
-
-        // Resolve to absolute path if necessary
-        let abs = if raw.is_absolute() {
-            raw
-        } else {
-            std::env::current_dir()?.join(raw)
-        };
-
-        let abs_str = abs.to_str().ok_or(PathError::InvalidUnicode(dir))?;
-
-        return AbsoluteSystemPathBuf::new(abs_str).map(Some);
-    }
-
-    dirs_config_dir()
-        .map(AbsoluteSystemPathBuf::try_from)
-        .transpose()
+    config_dir_from_parts(
+        std::env::var("TURBO_CONFIG_DIR_PATH").ok().as_deref(),
+        dirs_config_dir(),
+        std::env::current_dir,
+    )
 }
 
 /// Returns the path to the user's configuration directory.
@@ -43,16 +27,58 @@ pub fn config_dir() -> Result<Option<AbsoluteSystemPathBuf>, PathError> {
 ///  `VERCEL_CONFIG_DIR_PATH` environment variable. If the environment variable
 /// is set, it will return that path instead of `dirs_next::config_dir`.
 pub fn vercel_config_dir() -> Result<Option<AbsoluteSystemPathBuf>, PathError> {
-    if let Ok(dir) = std::env::var("VERCEL_CONFIG_DIR_PATH") {
+    vercel_config_dir_from_parts(
+        std::env::var("VERCEL_CONFIG_DIR_PATH").ok().as_deref(),
+        dirs_config_dir(),
+    )
+}
+
+fn config_dir_from_parts(
+    override_dir: Option<&str>,
+    default_config_dir: Option<PathBuf>,
+    current_dir: impl FnOnce() -> Result<PathBuf, std::io::Error>,
+) -> Result<Option<AbsoluteSystemPathBuf>, PathError> {
+    if let Some(dir) = override_dir {
+        // Reject empty strings per Unix convention
+        if dir.is_empty() {
+            return Err(PathError::InvalidUnicode(dir.to_string()));
+        }
+
+        let raw = PathBuf::from(dir);
+
+        // Resolve to absolute path if necessary
+        let abs = if raw.is_absolute() {
+            raw
+        } else {
+            current_dir()?.join(raw)
+        };
+
+        let abs_str = abs
+            .to_str()
+            .ok_or_else(|| PathError::InvalidUnicode(dir.to_string()))?;
+
+        return AbsoluteSystemPathBuf::new(abs_str).map(Some);
+    }
+
+    default_config_dir
+        .map(AbsoluteSystemPathBuf::try_from)
+        .transpose()
+}
+
+fn vercel_config_dir_from_parts(
+    override_dir: Option<&str>,
+    default_config_dir: Option<PathBuf>,
+) -> Result<Option<AbsoluteSystemPathBuf>, PathError> {
+    if let Some(dir) = override_dir {
         // Reject empty strings per Unix convention.
         if dir.is_empty() {
-            return Err(PathError::InvalidUnicode(dir));
+            return Err(PathError::InvalidUnicode(dir.to_string()));
         }
 
         return AbsoluteSystemPathBuf::new(dir).map(Some);
     }
 
-    dirs_config_dir()
+    default_config_dir
         .map(AbsoluteSystemPathBuf::try_from)
         .transpose()
 }
@@ -65,177 +91,119 @@ pub enum Error {
 
 #[cfg(test)]
 mod tests {
-    use std::env;
+    use std::path::PathBuf;
 
     use super::*;
 
+    fn current_dir() -> Result<PathBuf, std::io::Error> {
+        Ok(if cfg!(windows) {
+            PathBuf::from("C:\\repo")
+        } else {
+            PathBuf::from("/repo")
+        })
+    }
+
     #[test]
     fn test_config_dir_with_env_var() {
-        // Set TURBO_CONFIG_DIR_PATH to an absolute path
         let test_path = if cfg!(windows) {
             "C:\\test\\config"
         } else {
             "/test/config"
         };
 
-        unsafe {
-            env::set_var("TURBO_CONFIG_DIR_PATH", test_path);
-        }
-
-        let result = config_dir();
+        let result = config_dir_from_parts(Some(test_path), None, current_dir);
         assert!(result.is_ok());
         let path = result.unwrap();
         assert!(path.is_some());
         assert_eq!(path.unwrap().as_str(), test_path);
-
-        unsafe {
-            env::remove_var("TURBO_CONFIG_DIR_PATH");
-        }
     }
 
     #[test]
     fn test_config_dir_with_relative_path() {
-        // Set TURBO_CONFIG_DIR_PATH to a relative path (should be resolved to absolute)
-        unsafe {
-            env::set_var("TURBO_CONFIG_DIR_PATH", "relative/path");
-        }
-
-        let result = config_dir();
+        let result = config_dir_from_parts(Some("relative/path"), None, current_dir);
         assert!(result.is_ok());
         let path = result.unwrap();
         assert!(path.is_some());
         // Verify it was resolved to an absolute path
         assert!(path.unwrap().as_path().is_absolute());
-
-        unsafe {
-            env::remove_var("TURBO_CONFIG_DIR_PATH");
-        }
     }
 
     #[test]
     fn test_config_dir_without_env_var() {
-        // Ensure TURBO_CONFIG_DIR_PATH is not set
-        unsafe {
-            env::remove_var("TURBO_CONFIG_DIR_PATH");
-        }
-
-        let result = config_dir();
+        let default_path = if cfg!(windows) {
+            PathBuf::from("C:\\Users\\test\\config")
+        } else {
+            PathBuf::from("/Users/test/config")
+        };
+        let result = config_dir_from_parts(None, Some(default_path), current_dir);
         assert!(result.is_ok());
-        // On most systems, config_dir should return Some path
-        // We can't assert the exact path since it's platform-specific
         let path = result.unwrap();
-        if let Some(p) = path {
-            // Verify it's an absolute path
-            assert!(p.as_path().is_absolute());
-        }
+        assert!(path.is_some());
+        assert!(path.unwrap().as_path().is_absolute());
     }
 
     #[test]
     fn test_vercel_config_dir_with_env_var() {
-        // Set VERCEL_CONFIG_DIR_PATH to an absolute path
         let test_path = if cfg!(windows) {
             "C:\\vercel\\config"
         } else {
             "/vercel/config"
         };
 
-        unsafe {
-            env::set_var("VERCEL_CONFIG_DIR_PATH", test_path);
-        }
-
-        let result = vercel_config_dir();
+        let result = vercel_config_dir_from_parts(Some(test_path), None);
         assert!(result.is_ok());
         let path = result.unwrap();
         assert!(path.is_some());
         assert_eq!(path.unwrap().as_str(), test_path);
-
-        unsafe {
-            env::remove_var("VERCEL_CONFIG_DIR_PATH");
-        }
     }
 
     #[test]
     fn test_vercel_config_dir_with_invalid_env_var() {
-        // Set VERCEL_CONFIG_DIR_PATH to a relative path (invalid)
-        unsafe {
-            env::set_var("VERCEL_CONFIG_DIR_PATH", "relative/path");
-        }
-
-        let result = vercel_config_dir();
+        let result = vercel_config_dir_from_parts(Some("relative/path"), None);
         assert!(result.is_err());
-
-        unsafe {
-            env::remove_var("VERCEL_CONFIG_DIR_PATH");
-        }
     }
 
     #[test]
     fn test_vercel_config_dir_without_env_var() {
-        // Ensure VERCEL_CONFIG_DIR_PATH is not set
-        unsafe {
-            env::remove_var("VERCEL_CONFIG_DIR_PATH");
-        }
-
-        let result = vercel_config_dir();
+        let default_path = if cfg!(windows) {
+            PathBuf::from("C:\\Users\\test\\config")
+        } else {
+            PathBuf::from("/Users/test/config")
+        };
+        let result = vercel_config_dir_from_parts(None, Some(default_path));
         assert!(result.is_ok());
-        // On most systems, config_dir should return Some path
-        // We can't assert the exact path since it's platform-specific
         let path = result.unwrap();
-        if let Some(p) = path {
-            // Verify it's an absolute path
-            assert!(p.as_path().is_absolute());
-        }
+        assert!(path.is_some());
+        assert!(path.unwrap().as_path().is_absolute());
     }
 
     #[test]
     fn test_config_dir_empty_env_var() {
-        // Set TURBO_CONFIG_DIR_PATH to empty string
-        unsafe {
-            env::set_var("TURBO_CONFIG_DIR_PATH", "");
-        }
-
-        let result = config_dir();
-        // Empty string should be invalid as it's not an absolute path
+        let result = config_dir_from_parts(Some(""), None, current_dir);
         assert!(result.is_err());
-
-        unsafe {
-            env::remove_var("TURBO_CONFIG_DIR_PATH");
-        }
     }
 
     #[test]
     fn test_vercel_config_dir_empty_env_var() {
-        // Set VERCEL_CONFIG_DIR_PATH to empty string
-        unsafe {
-            env::set_var("VERCEL_CONFIG_DIR_PATH", "");
-        }
-
-        let result = vercel_config_dir();
-        // Empty string should be invalid as it's not an absolute path
+        let result = vercel_config_dir_from_parts(Some(""), None);
         assert!(result.is_err());
-
-        unsafe {
-            env::remove_var("VERCEL_CONFIG_DIR_PATH");
-        }
     }
 
     #[test]
     fn test_config_dir_and_vercel_config_dir_independence() {
-        // Test that TURBO_CONFIG_DIR_PATH doesn't affect vercel_config_dir
-        // Use a path that would be created by dirs_config_dir to ensure both succeed
         let turbo_path = if cfg!(windows) {
             "C:\\Users\\test\\config"
         } else {
             "/Users/test/config"
         };
+        let default_vercel_path = if cfg!(windows) {
+            PathBuf::from("C:\\Users\\test\\vercel")
+        } else {
+            PathBuf::from("/Users/test/vercel")
+        };
 
-        unsafe {
-            env::set_var("TURBO_CONFIG_DIR_PATH", turbo_path);
-            env::remove_var("VERCEL_CONFIG_DIR_PATH");
-        }
-
-        let turbo_result = config_dir();
-        let vercel_result = vercel_config_dir();
+        let turbo_result = config_dir_from_parts(Some(turbo_path), None, current_dir);
+        let vercel_result = vercel_config_dir_from_parts(None, Some(default_vercel_path));
 
         assert!(turbo_result.is_ok(), "turbo_result should be ok");
         let turbo_path_result = turbo_result.unwrap();
@@ -243,32 +211,25 @@ mod tests {
         assert_eq!(turbo_path_result.unwrap().as_str(), turbo_path);
 
         assert!(vercel_result.is_ok(), "vercel_result should be ok");
-        // vercel_config_dir should return the default, not turbo_path
-        if let Some(vercel_path) = vercel_result.unwrap() {
-            assert_ne!(vercel_path.as_str(), turbo_path);
-        }
-
-        unsafe {
-            env::remove_var("TURBO_CONFIG_DIR_PATH");
-        }
+        let vercel_path = vercel_result.unwrap().expect("vercel path should be some");
+        assert_ne!(vercel_path.as_str(), turbo_path);
     }
 
     #[test]
     fn test_vercel_config_dir_and_config_dir_independence() {
-        // Test that VERCEL_CONFIG_DIR_PATH doesn't affect config_dir
         let vercel_path = if cfg!(windows) {
             "C:\\Users\\test\\vercel"
         } else {
             "/Users/test/vercel"
         };
+        let default_turbo_path = if cfg!(windows) {
+            PathBuf::from("C:\\Users\\test\\config")
+        } else {
+            PathBuf::from("/Users/test/config")
+        };
 
-        unsafe {
-            env::set_var("VERCEL_CONFIG_DIR_PATH", vercel_path);
-            env::remove_var("TURBO_CONFIG_DIR_PATH");
-        }
-
-        let vercel_result = vercel_config_dir();
-        let turbo_result = config_dir();
+        let vercel_result = vercel_config_dir_from_parts(Some(vercel_path), None);
+        let turbo_result = config_dir_from_parts(None, Some(default_turbo_path), current_dir);
 
         assert!(vercel_result.is_ok(), "vercel_result should be ok");
         let vercel_path_result = vercel_result.unwrap();
@@ -276,14 +237,8 @@ mod tests {
         assert_eq!(vercel_path_result.unwrap().as_str(), vercel_path);
 
         assert!(turbo_result.is_ok(), "turbo_result should be ok");
-        // config_dir should return the default, not vercel_path
-        if let Some(turbo_path) = turbo_result.unwrap() {
-            assert_ne!(turbo_path.as_str(), vercel_path);
-        }
-
-        unsafe {
-            env::remove_var("VERCEL_CONFIG_DIR_PATH");
-        }
+        let turbo_path = turbo_result.unwrap().expect("turbo path should be some");
+        assert_ne!(turbo_path.as_str(), vercel_path);
     }
 
     #[test]

--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -40,6 +40,81 @@ use tracing::{debug, trace};
 
 use super::{Command, PtySize};
 
+// The atomic covers `cargo test`'s in-process parallelism; flock covers
+// nextest's process-per-test parallelism.
+#[cfg(test)]
+static PTY_TEST_LOCK: AtomicBool = AtomicBool::new(false);
+
+#[cfg(test)]
+#[derive(Debug)]
+struct PtyTestGuard {
+    #[cfg(unix)]
+    file: std::fs::File,
+}
+
+#[cfg(test)]
+impl PtyTestGuard {
+    fn acquire() -> Self {
+        while PTY_TEST_LOCK
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        #[cfg(unix)]
+        {
+            use std::{fs::OpenOptions, os::fd::AsRawFd};
+
+            let path = std::env::temp_dir().join("turborepo-process-pty.lock");
+            let file = match OpenOptions::new()
+                .create(true)
+                .truncate(false)
+                .read(true)
+                .write(true)
+                .open(path)
+            {
+                Ok(file) => file,
+                Err(err) => {
+                    PTY_TEST_LOCK.store(false, Ordering::Release);
+                    panic!("failed to open PTY test lock: {err}");
+                }
+            };
+            let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+            if result != 0 {
+                PTY_TEST_LOCK.store(false, Ordering::Release);
+                panic!(
+                    "failed to lock PTY test lock: {}",
+                    io::Error::last_os_error()
+                );
+            }
+            Self { file }
+        }
+
+        #[cfg(not(unix))]
+        {
+            Self {}
+        }
+    }
+}
+
+#[cfg(all(test, unix))]
+impl Drop for PtyTestGuard {
+    fn drop(&mut self) {
+        use std::os::fd::AsRawFd;
+
+        let _ = unsafe { libc::flock(self.file.as_raw_fd(), libc::LOCK_UN) };
+        PTY_TEST_LOCK.store(false, Ordering::Release);
+    }
+}
+
+#[cfg(all(test, not(unix)))]
+impl Drop for PtyTestGuard {
+    fn drop(&mut self) {
+        PTY_TEST_LOCK.store(false, Ordering::Release);
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum ChildExit {
     Finished(Option<i32>),
@@ -816,6 +891,8 @@ pub struct Child {
     /// Flag indicating this child is being stopped as part of a shutdown of the
     /// ProcessManager, rather than individually stopped.
     closing: Arc<AtomicBool>,
+    #[cfg(test)]
+    _pty_test_guard: Option<Arc<PtyTestGuard>>,
 }
 
 #[derive(Clone, Debug)]
@@ -854,6 +931,8 @@ impl Child {
         pty_size: Option<PtySize>,
     ) -> io::Result<Self> {
         let label = command.label();
+        #[cfg(test)]
+        let pty_test_guard = pty_size.map(|_| Arc::new(PtyTestGuard::acquire()));
         let SpawnResult {
             handle: mut child,
             io: ChildIO { stdin, output },
@@ -947,6 +1026,8 @@ impl Child {
             label,
             shutdown_style,
             closing: Arc::new(AtomicBool::new(false)),
+            #[cfg(test)]
+            _pty_test_guard: pty_test_guard,
         })
     }
 
@@ -1935,7 +2016,7 @@ mod test {
     #[tokio::test]
     async fn test_orphan_process() {
         let mut cmd = Command::new("sh");
-        cmd.args(["-c", "echo hello; sleep 120; echo done"]);
+        cmd.args(["-c", "echo hello; exec sleep 120"]);
         let mut child = Child::spawn(cmd, ShutdownStyle::Kill, None).unwrap();
 
         tokio::time::sleep(STARTUP_DELAY).await;

--- a/crates/turborepo/tests/watch_test.rs
+++ b/crates/turborepo/tests/watch_test.rs
@@ -2,6 +2,8 @@
 
 mod common;
 
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -92,6 +94,12 @@ fn wait_for_markers(test_dir: &Path, pkg: &str, expected: usize, timeout: Durati
 fn spawn_turbo_watch_with_tasks(test_dir: &Path, tasks: &[&str]) -> Child {
     let turbo_bin = assert_cmd::cargo::cargo_bin("turbo");
     let mut cmd = std::process::Command::new(turbo_bin);
+    #[cfg(unix)]
+    cmd.process_group(0);
+
+    let config_dir = test_dir.join(".turbo/test-config");
+    fs::create_dir_all(&config_dir).expect("failed to create isolated config dir");
+
     cmd.arg("watch");
     for task in tasks {
         cmd.arg(task);
@@ -102,11 +110,12 @@ fn spawn_turbo_watch_with_tasks(test_dir: &Path, tasks: &[&str]) -> Child {
         .env("DO_NOT_TRACK", "1")
         .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
         .env("COREPACK_ENABLE_DOWNLOAD_PROMPT", "0")
+        .env("TURBO_CONFIG_DIR_PATH", &config_dir)
         .env_remove("CI")
         .env_remove("GITHUB_ACTIONS")
         .current_dir(test_dir)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .spawn()
         .expect("failed to spawn turbo watch")
 }
@@ -124,7 +133,11 @@ fn stop_watch(mut child: Child) {
             sys::signal::{self, Signal},
             unistd::Pid,
         };
-        let _ = signal::kill(Pid::from_raw(child.id() as i32), Signal::SIGTERM);
+        let pgid = Pid::from_raw(-(child.id() as i32));
+        let _ = signal::kill(pgid, Signal::SIGTERM);
+        if !wait_for_child_exit(&mut child, Duration::from_secs(5)) {
+            let _ = signal::kill(pgid, Signal::SIGKILL);
+        }
     }
     #[cfg(windows)]
     {
@@ -134,10 +147,24 @@ fn stop_watch(mut child: Child) {
     let _ = child.wait();
 }
 
+fn wait_for_child_exit(child: &mut Child, timeout: Duration) -> bool {
+    let start = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return true,
+            Ok(None) if start.elapsed() < timeout => {
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Ok(None) => return false,
+            Err(_) => return true,
+        }
+    }
+}
+
 /// RAII guard that ensures `stop_watch` runs even if a test panics.
 /// Without this, a panic between `spawn_turbo_watch` and `stop_watch` would
-/// leak the turbo process and its daemon, causing socket contention for
-/// subsequent serialized tests.
+/// leak the turbo process and its descendants, causing resource contention for
+/// parallel tests.
 struct WatchGuard(Option<Child>);
 
 impl WatchGuard {
@@ -300,7 +327,7 @@ fn watch_clean_shutdown_on_sigint() {
 
     let mut child = guard.take();
     let pid = Pid::from_raw(child.id() as i32);
-    signal::kill(pid, Signal::SIGINT).expect("failed to send SIGINT");
+    signal::kill(Pid::from_raw(-pid.as_raw()), Signal::SIGINT).expect("failed to send SIGINT");
 
     // Wait for process to exit
     let start = Instant::now();
@@ -316,7 +343,7 @@ fn watch_clean_shutdown_on_sigint() {
             }
             Ok(None) => {
                 if start.elapsed() > Duration::from_secs(10) {
-                    child.kill().unwrap();
+                    stop_watch(child);
                     panic!("turbo watch did not exit within 10s after SIGINT");
                 }
                 std::thread::sleep(Duration::from_millis(100));
@@ -651,9 +678,9 @@ fn watch_rapid_edits_produce_single_rebuild() {
 
     let a_before = marker_count(&test_dir, "a");
 
-    // Fire 10 rapid edits. Using more edits widens the gap between
-    // "debouncing works" and "debouncing is broken", making the assertion
-    // resilient to CI timing variance.
+    // Fire 10 rapid edits without staging or committing each one. The watcher
+    // only needs file-system events here, and per-edit git commits can take
+    // longer than the debounce window under parallel CI load.
     let num_edits = 10;
     let src_file = test_dir.join("packages/a/src.js");
     for i in 0..num_edits {
@@ -662,18 +689,6 @@ fn watch_rapid_edits_produce_single_rebuild() {
             format!("module.exports = {{ a: 'rapid-{i}' }};\n"),
         )
         .unwrap();
-        common::git(&test_dir, &["add", "."]);
-        common::git(
-            &test_dir,
-            &[
-                "commit",
-                "-m",
-                &format!("rapid edit {i}"),
-                "--quiet",
-                "--allow-empty",
-            ],
-        );
-        std::thread::sleep(Duration::from_millis(10));
     }
 
     // Wait for at least one rebuild, then let the system fully settle.
@@ -758,7 +773,7 @@ fn watch_sigint_exits_with_zero() {
 
     let mut child = guard.take();
     let pid = Pid::from_raw(child.id() as i32);
-    signal::kill(pid, Signal::SIGINT).expect("failed to send SIGINT");
+    signal::kill(Pid::from_raw(-pid.as_raw()), Signal::SIGINT).expect("failed to send SIGINT");
 
     let start = Instant::now();
     loop {
@@ -772,7 +787,7 @@ fn watch_sigint_exits_with_zero() {
             }
             Ok(None) => {
                 if start.elapsed() > Duration::from_secs(10) {
-                    child.kill().unwrap();
+                    stop_watch(child);
                     panic!("turbo watch did not exit within 10s after SIGINT");
                 }
                 std::thread::sleep(Duration::from_millis(100));


### PR DESCRIPTION
## Why
Rust tests were paying for broad nextest serialization even though only specific tests needed isolation. This moves isolation into the test code so nextest can schedule the affected targets concurrently.

## Testing
- cargo fmt --check
- cargo clippy -p turborepo-dirs -p turborepo-process -p turbo --all-targets -- -D warnings
- cargo nextest run -p turborepo-dirs --no-fail-fast --status-level fail --final-status-level slow
- cargo nextest run -p turborepo-process --no-fail-fast --status-level fail --final-status-level slow -j 8
- cargo nextest run -p turbo --test watch_test --no-fail-fast --status-level fail --final-status-level slow -j 8
- cargo test -p turborepo-dirs
- cargo test -p turborepo-process