### PR TITLE
fix: Avoid graph walker `expect()` calls

### DIFF
--- a/crates/turborepo-graph-utils/src/lib.rs
+++ b/crates/turborepo-graph-utils/src/lib.rs
@@ -2,8 +2,6 @@
 //! Provides transitive closure calculation and cycle detection with cut
 //! candidates to break cycles
 
-#![allow(clippy::expect_used, clippy::unwrap_used)]
-
 mod walker;
 
 use std::{collections::HashSet, fmt::Display, hash::Hash};

--- a/crates/turborepo-graph-utils/src/walker.rs
+++ b/crates/turborepo-graph-utils/src/walker.rs
@@ -14,7 +14,7 @@ use tracing::trace;
 pub struct Walker<N, S> {
     marker: std::marker::PhantomData<S>,
     cancel: watch::Sender<bool>,
-    node_events: Option<mpsc::Receiver<(N, oneshot::Sender<bool>)>>,
+    node_events: mpsc::Receiver<(N, oneshot::Sender<bool>)>,
     join_handles: FuturesUnordered<JoinHandle<()>>,
 }
 
@@ -54,15 +54,20 @@ impl<N: Eq + Hash + Copy + Send + 'static> Walker<N, Start> {
         let (node_tx, node_rx) = mpsc::channel(std::cmp::max(txs.len(), 1));
         let join_handles = FuturesUnordered::new();
         for node in graph.node_identifiers() {
-            let tx = txs.remove(&node).expect("should have sender for all nodes");
+            let Some(tx) = txs.remove(&node) else {
+                trace!("Graph walker node did not have a sender");
+                continue;
+            };
             let mut cancel_rx = cancel_rx.clone();
             let node_tx = node_tx.clone();
             let mut deps_rx = graph
                 .neighbors_directed(node, Direction::Outgoing)
-                .map(|dep| {
-                    rxs.get(&dep)
-                        .expect("graph should have all nodes")
-                        .resubscribe()
+                .filter_map(|dep| match rxs.get(&dep) {
+                    Some(rx) => Some(rx.resubscribe()),
+                    None => {
+                        trace!("Graph walker dependency did not have a receiver");
+                        None
+                    }
                 })
                 .collect::<Vec<_>>();
 
@@ -135,7 +140,7 @@ impl<N: Eq + Hash + Copy + Send + 'static> Walker<N, Start> {
 
         Self {
             cancel,
-            node_events: Some(node_rx),
+            node_events: node_rx,
             join_handles,
             marker: std::marker::PhantomData,
         }
@@ -148,18 +153,16 @@ impl<N: Eq + Hash + Copy + Send + 'static> Walker<N, Start> {
     pub fn walk(self) -> (Walker<N, Walking>, mpsc::Receiver<WalkMessage<N>>) {
         let Self {
             cancel,
-            mut node_events,
+            node_events,
             join_handles,
             ..
         } = self;
-        let node_events = node_events
-            .take()
-            .expect("walking graph with walker that has already been used");
+        let (_unused_tx, unused_node_events) = mpsc::channel(1);
         (
             Walker {
                 marker: std::marker::PhantomData,
                 cancel,
-                node_events: None,
+                node_events: unused_node_events,
                 join_handles,
             },
             node_events,


### PR DESCRIPTION
## Why

The graph walker already uses typestate to make `walk(self)` single-use, so it does not need an `Option` plus `expect()` to retrieve the receiver. Walker setup can also tolerate inconsistent graph node/dependency iteration without panicking.

Together with #12844, this removes the remaining implementation `expect()` callsites from `turborepo-graph-utils`.