### PR TITLE
chore: Remove turborepo-hash build expect

### DIFF
--- a/crates/turborepo-hash/build.rs
+++ b/crates/turborepo-hash/build.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::expect_used, clippy::unwrap_used)]
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let capnpc_result = capnpc::CompilerCommand::new()
         .file("./src/proto.capnp")
@@ -11,9 +9,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("cargo:warning=capnpc failed, but continuing with rust-analyzer");
         }
         return Ok(());
-    } else {
-        capnpc_result.expect("schema compiler command");
     }
+
+    capnpc_result?;
 
     Ok(())
 }


### PR DESCRIPTION
TURBO-5597

Removes the remaining implementation `.expect()` from the `turborepo-hash` build script and drops the now-unneeded build-script Clippy allow. This lets build-script failures propagate normally while preserving the `rust-analyzer` fallback.