### PR TITLE
fix: Remove napi panic lint allows

### DIFF
--- a/packages/turbo-repository/rust/src/internal.rs
+++ b/packages/turbo-repository/rust/src/internal.rs
@@ -20,6 +20,8 @@ use crate::{Package, PackageManager, Workspace};
 pub(crate) enum Error {
     #[error("Failed to resolve starting path from {path}: {path_error}")]
     StartingPath { path_error: PathError, path: String },
+    #[error("Failed to resolve package path: {0}")]
+    PackagePath(#[from] PathError),
     #[error(transparent)]
     Inference(#[from] inference::Error),
     #[error("Failed to resolve package manager from {path}: {error}")]
@@ -32,6 +34,8 @@ pub(crate) enum Error {
         error: package_manager::Error,
         workspace_root: AbsoluteSystemPathBuf,
     },
+    #[error("Failed to join package discovery task: {0}")]
+    PackageDiscoveryJoin(#[from] tokio::task::JoinError),
     #[error("Package directory {0} has no parent")]
     MissingParent(AbsoluteSystemPathBuf),
     #[error("Package graph error: {0}")]
@@ -113,7 +117,7 @@ impl Workspace {
         let package_json_paths =
             tokio::task::spawn(async move { package_manager.get_package_jsons(&workspace_root) })
                 .await
-                .expect("package enumeration should not crash")
+                .map_err(Error::PackageDiscoveryJoin)?
                 .map_err(|error| Error::PackageJsons {
                     error,
                     workspace_root: self.workspace_state.root.clone(),
@@ -139,7 +143,7 @@ impl Workspace {
                             name.into_inner(),
                             &self.workspace_state.root,
                             package_path,
-                        ))
+                        )?)
                     })
                     .or_else(|| Some(Err(Error::MissingParent(path.to_owned()))))
             })

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -1,5 +1,4 @@
 #![allow(clippy::result_large_err)]
-#![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use std::collections::{HashMap, HashSet};
 
@@ -74,15 +73,13 @@ impl Package {
         name: String,
         workspace_path: &AbsoluteSystemPath,
         package_path: &AbsoluteSystemPath,
-    ) -> Self {
-        let relative_path = workspace_path
-            .anchor(package_path)
-            .expect("Package path is within the workspace");
-        Self {
+    ) -> Result<Self, turbopath::PathError> {
+        let relative_path = workspace_path.anchor(package_path)?;
+        Ok(Self {
             name,
             absolute_path: package_path.to_string(),
             relative_path: relative_path.to_string(),
-        }
+        })
     }
 
     fn dependents(
@@ -103,7 +100,7 @@ impl Package {
                 let name = info.package_name()?;
                 let anchored_package_path = info.package_path();
                 let package_path = workspace_path.resolve(anchored_package_path);
-                Some(Package::new(name, workspace_path, &package_path))
+                Package::new(name, workspace_path, &package_path).ok()
             })
             .collect()
     }
@@ -127,7 +124,7 @@ impl Package {
                 let name = info.package_name()?;
                 let anchored_package_path = info.package_path();
                 let package_path = workspace_path.resolve(anchored_package_path);
-                Some(Package::new(name, workspace_path, &package_path))
+                Package::new(name, workspace_path, &package_path).ok()
             })
             .collect()
     }
@@ -220,7 +217,11 @@ impl Workspace {
         from_commit: &str,
     ) -> LockfileContents {
         let lockfile_name = self.graph.package_manager().lockfile_name();
-        if changed_files.contains(AnchoredSystemPath::new(&lockfile_name).unwrap()) {
+        let Ok(lockfile_path) = AnchoredSystemPath::new(&lockfile_name) else {
+            return LockfileContents::Unchanged;
+        };
+
+        if changed_files.contains(lockfile_path) {
             let git = SCM::new(workspace_root);
             let anchored_path = workspace_root.join_component(lockfile_name);
             git.previous_content(Some(from_commit), &anchored_path)
@@ -275,9 +276,9 @@ impl Workspace {
 
         let lockfile_contents = if let Some(base) = base {
             self.get_lockfile_contents(&changed_files, workspace_root, base)
-        } else if changed_files.contains(
-            AnchoredSystemPath::new(self.graph.package_manager().lockfile_name())
-                .expect("the lockfile name will not be an absolute path"),
+        } else if matches!(
+            AnchoredSystemPath::new(self.graph.package_manager().lockfile_name()),
+            Ok(path) if changed_files.contains(path)
         ) {
             LockfileContents::UnknownChange
         } else {
@@ -311,7 +312,8 @@ impl Workspace {
                 let package_path = workspace_root.resolve(&p.path);
                 Package::new(p.name.to_string(), workspace_root, &package_path)
             })
-            .collect();
+            .collect::<Result<Vec<Package>, _>>()
+            .map_err(|e| Error::from_reason(e.to_string()))?;
 
         serializable_packages.sort_by_key(|p| p.name.clone());
 
@@ -344,11 +346,8 @@ impl Workspace {
                     Err(e) => return Err(Error::from_reason(e.to_string())),
                 };
                 let package_path = workspace_root.resolve(&package.path);
-                Ok(Package::new(
-                    package.name.to_string(),
-                    workspace_root,
-                    &package_path,
-                ))
+                Package::new(package.name.to_string(), workspace_root, &package_path)
+                    .map_err(|e| Error::from_reason(e.to_string()))
             }
         }
     }


### PR DESCRIPTION
TURBO-5618, TURBO-5659

Removes implementation panic helpers from `turborepo-napi` so the crate can enforce `expect`/`unwrap` Clippy lints outside tests.

## Verification

- `cargo fmt --package turborepo-napi`
- `cargo test --package turborepo-napi`
- `cargo clippy --package turborepo-napi --all-targets -- -D warnings`
- Pre-push hook passed
