### PR TITLE
fix: Remove scope panic lint allows

### DIFF
--- a/crates/turborepo-scope/src/filter.rs
+++ b/crates/turborepo-scope/src/filter.rs
@@ -109,10 +109,10 @@ impl PackageInference {
         }
     }
 
-    pub fn apply(&self, selector: &mut TargetSelector) {
+    pub fn apply(&self, selector: &mut TargetSelector) -> Result<(), ResolutionError> {
         // if the name pattern is provided, do not attempt inference
         if !selector.name_pattern.is_empty() {
-            return;
+            return Ok(());
         };
 
         // Inject package name based on the directory filter:
@@ -135,10 +135,17 @@ impl PackageInference {
             let clean_parent_dir = path_clean::clean(Path::new(repo_relative_parent_dir.as_path()))
                 .into_os_string()
                 .into_string()
-                .expect("path was valid utf8 before cleaning");
+                .map_err(|_| {
+                    ResolutionError::InvalidSelector(InvalidSelectorError::InvalidAnchoredPath(
+                        repo_relative_parent_dir.as_str().to_string(),
+                    ))
+                })?;
             selector.parent_dir = Some(
-                AnchoredSystemPathBuf::try_from(clean_parent_dir.as_str())
-                    .expect("path wasn't absolute before cleaning"),
+                AnchoredSystemPathBuf::try_from(clean_parent_dir.as_str()).map_err(|_| {
+                    ResolutionError::InvalidSelector(InvalidSelectorError::InvalidAnchoredPath(
+                        clean_parent_dir.clone(),
+                    ))
+                })?,
             );
         } else if self.package_name.is_none() {
             // fallback: the user didn't set a parent directory and we didn't find a single
@@ -147,6 +154,8 @@ impl PackageInference {
             parent_dir.push("**");
             selector.parent_dir = Some(parent_dir);
         }
+
+        Ok(())
     }
 }
 
@@ -361,7 +370,7 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
         selectors: Vec<TargetSelector>,
     ) -> Result<HashMap<PackageName, PackageInclusionReason>, ResolutionError> {
         let (_prod_selectors, all_selectors) = self
-            .apply_inference(selectors)
+            .apply_inference(selectors)?
             .into_iter()
             .partition::<Vec<_>, _>(|t| t.follow_prod_deps_only);
 
@@ -372,10 +381,13 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
         }
     }
 
-    fn apply_inference(&self, selectors: Vec<TargetSelector>) -> Vec<TargetSelector> {
+    fn apply_inference(
+        &self,
+        selectors: Vec<TargetSelector>,
+    ) -> Result<Vec<TargetSelector>, ResolutionError> {
         let inference = match self.inference {
             Some(ref inference) => inference,
-            None => return selectors,
+            None => return Ok(selectors),
         };
 
         // if there is no selector provided, synthesize one
@@ -386,10 +398,10 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
         };
 
         for selector in &mut selectors {
-            inference.apply(selector);
+            inference.apply(selector)?;
         }
 
-        selectors
+        Ok(selectors)
     }
 
     fn filter_graph(
@@ -578,14 +590,18 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
             .transpose()?;
 
         for (name, info) in self.pkg_graph.packages() {
-            if let Some(ref matcher) = parent_dir_matcher {
+            if let Some((parent_dir, matcher)) = selector
+                .parent_dir
+                .as_ref()
+                .zip(parent_dir_matcher.as_ref())
+            {
                 let matches = matcher.is_match(info.package_path().as_path());
 
                 if matches {
                     entry_packages.insert(
                         name.to_owned(),
                         PackageInclusionReason::InFilteredDirectory {
-                            directory: selector.parent_dir.as_ref().unwrap().to_owned(),
+                            directory: parent_dir.to_owned(),
                         },
                     );
                 }
@@ -667,10 +683,16 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
             // TODO: it would be more proper to use
             // `AnchoredSystemPathBuf::from_system_path` but that function
             // doesn't allow leading `.` or `..`.
-            let base = AnchoredSystemPathBuf::from_raw(
-                base.to_str().expect("glob base should be valid utf8"),
-            )
-            .expect("partitioned glob gave absolute path");
+            let base = base.to_str().ok_or_else(|| {
+                ResolutionError::InvalidSelector(InvalidSelectorError::InvalidAnchoredPath(
+                    base.to_string_lossy().into_owned(),
+                ))
+            })?;
+            let base = AnchoredSystemPathBuf::from_raw(base).map_err(|_| {
+                ResolutionError::InvalidSelector(InvalidSelectorError::InvalidAnchoredPath(
+                    base.to_string(),
+                ))
+            })?;
             // need to join this with globbing's current dir :)
             let path = self.turbo_root.resolve(&base);
             if !path.exists() {
@@ -714,7 +736,7 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
             .zip(parent_dir_globber.as_ref())
         {
             selector_valid = true;
-            if parent_dir == &*AnchoredSystemPathBuf::from_raw(".").expect("valid anchored") {
+            if parent_dir.as_str() == "." {
                 entry_packages.insert(
                     PackageName::Root,
                     PackageInclusionReason::InFilteredDirectory {

--- a/crates/turborepo-scope/src/lib.rs
+++ b/crates/turborepo-scope/src/lib.rs
@@ -8,7 +8,8 @@
 //! Extracted from turborepo-lib to reduce coupling.
 
 #![deny(clippy::all)]
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![cfg_attr(not(test), deny(clippy::expect_used, clippy::unwrap_used))]
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 // Allow large error types - ResolutionError contains ChangeMapError which is 128+ bytes.
 // Boxing would complicate error handling without significant benefit for a CLI tool.
 #![allow(clippy::result_large_err)]

--- a/crates/turborepo-scope/src/target_selector.rs
+++ b/crates/turborepo-scope/src/target_selector.rs
@@ -24,10 +24,10 @@ use turbopath::AnchoredSystemPathBuf;
 /// - `(\{(?P<directory>[^}]*)\})?` - Optional directory in curly braces
 /// - `(?P<commits>(?:\.{3})?\[[^\]]*\])?` - Optional git range in square
 ///   brackets, optionally prefixed with `...` for match_dependencies
-static SELECTOR_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+static SELECTOR_REGEX: LazyLock<Result<Regex, regex::Error>> = LazyLock::new(|| {
     Regex::new(
-        r"^(?P<name>[^.](?:[^{}\[\]]*[^{}\[\].])?)?(\{(?P<directory>[^}]*)})?(?P<commits>(?:\.{3})?\[[^\]]*\])?$"
-    ).expect("selector regex is statically validated")
+        r"^(?P<name>[^.](?:[^{}\[\]]*[^{}\[\].])?)?(\{(?P<directory>[^}]*)})?(?P<commits>(?:\.{3})?\[[^\]]*\])?$",
+    )
 });
 
 #[derive(Debug, Default, PartialEq, Clone)]
@@ -103,7 +103,10 @@ impl FromStr for TargetSelector {
 
         // We explicitly allow empty git ranges so we can return a more targeted error
         // below
-        let captures = SELECTOR_REGEX.captures(selector);
+        let captures = SELECTOR_REGEX
+            .as_ref()
+            .map_err(|err| InvalidSelectorError::InvalidSelectorRegex(err.to_string()))?
+            .captures(selector);
 
         let captures = match captures {
             Some(captures) => captures,
@@ -147,7 +150,7 @@ impl FromStr for TargetSelector {
                 let clean_directory = path_clean::clean(std::path::Path::new(directory.as_str()))
                     .into_os_string()
                     .into_string()
-                    .expect("directory was valid utf8 before cleaning");
+                    .map_err(|_| InvalidSelectorError::InvalidAnchoredPath(directory.clone()))?;
                 parent_dir = Some(
                     AnchoredSystemPathBuf::try_from(clean_directory.as_str())
                         .map_err(|_| InvalidSelectorError::InvalidAnchoredPath(directory))?,
@@ -170,7 +173,7 @@ impl FromStr for TargetSelector {
             let commits_str = commits_str
                 .strip_prefix('[')
                 .and_then(|s| s.strip_suffix(']'))
-                .expect("regex guarantees square brackets");
+                .ok_or_else(|| InvalidSelectorError::InvalidGitRange(commits_str.to_string()))?;
             if commits_str.is_empty() {
                 return Err(InvalidSelectorError::InvalidGitRange(
                     commits_str.to_string(),
@@ -246,6 +249,9 @@ pub enum InvalidSelectorError {
     #[error("invalid git range selector: {0}")]
     InvalidGitRange(String),
 
+    #[error("invalid selector regex: {0}")]
+    InvalidSelectorRegex(String),
+
     #[error("selector \"{0}\" must have a reference, directory, or name pattern")]
     InvalidSelector(String),
 }
@@ -265,11 +271,11 @@ pub fn is_selector_by_location(
         let cleaned_selector = path_clean::clean(std::path::Path::new(raw_selector))
             .into_os_string()
             .into_string()
-            .expect("raw selector was valid utf8");
-        Some(
+            .map_err(|_| InvalidSelectorError::InvalidAnchoredPath(raw_selector.to_string()));
+        Some(cleaned_selector.and_then(|cleaned_selector| {
             AnchoredSystemPathBuf::try_from(cleaned_selector.as_str())
-                .map_err(|_| InvalidSelectorError::InvalidAnchoredPath(raw_selector.to_string())),
-        )
+                .map_err(|_| InvalidSelectorError::InvalidAnchoredPath(raw_selector.to_string()))
+        }))
     } else {
         None
     }


### PR DESCRIPTION
TURBO-5623, TURBO-5660

Removes implementation panic helpers from `turborepo-scope` so the crate can enforce `expect`/`unwrap` Clippy lints outside tests. Test panic helpers remain scoped to tests.

## Verification

- `cargo fmt --package turborepo-scope`
- `cargo test --package turborepo-scope`
- `cargo clippy --package turborepo-scope --all-targets -- -D warnings`
- Pre-push hook passed
