### PR TITLE
fix: Remove task hash panic lints

### DIFF
--- a/crates/turborepo-task-hash/src/global_hash.rs
+++ b/crates/turborepo-task-hash/src/global_hash.rs
@@ -39,6 +39,8 @@ pub enum Error {
     Scm(#[from] turborepo_scm::Error),
     #[error(transparent)]
     PackageManager(#[from] turborepo_repository::package_manager::Error),
+    #[error(transparent)]
+    Path(#[from] turbopath::PathError),
 }
 
 #[derive(Debug)]
@@ -170,8 +172,8 @@ pub fn collect_global_file_hash_inputs<'a, L: ?Sized + Lockfile>(
 
     let global_deps_paths = global_deps
         .iter()
-        .map(|p| root_path.anchor(p).expect("path should be from root"))
-        .collect::<Vec<_>>();
+        .map(|p| root_path.anchor(p).map_err(Error::from))
+        .collect::<Result<Vec<_>, _>>()?;
 
     let global_file_hash_map = hasher
         .get_hashes_for_files(root_path, &global_deps_paths, false)?

--- a/crates/turborepo-task-hash/src/lib.rs
+++ b/crates/turborepo-task-hash/src/lib.rs
@@ -4,7 +4,7 @@
 //! hashes for tasks based on their inputs (files, environment variables,
 //! dependencies) to determine cache invalidation.
 
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 
 pub mod global_hash;
 
@@ -142,7 +142,7 @@ impl PackageInputsHashes {
             let package_path = pkg
                 .package_json_path
                 .parent()
-                .unwrap_or_else(|| AnchoredSystemPath::new("").unwrap());
+                .unwrap_or_else(|| AnchoredSystemPath::empty());
             let inputs = task_definition.inputs();
             task_infos.push(TaskInfo {
                 task_id: task_id.clone(),
@@ -265,7 +265,7 @@ pub struct TaskHasher<'a, R> {
     global_env_patterns: &'a [String],
     global_hash: &'a str,
     task_hash_tracker: TaskHashTracker,
-    compiled_builtins: CompiledWildcards,
+    compiled_builtins: Option<CompiledWildcards>,
     external_deps_hash_cache: HashMap<String, String>,
 }
 
@@ -283,11 +283,7 @@ impl<'a, R: RunOptsHashInfo> TaskHasher<'a, R> {
             expanded_hashes,
         } = package_inputs_hashes;
 
-        let compiled_builtins = CompiledWildcards::compile(BUILTIN_PASS_THROUGH_ENV)
-            .unwrap_or_else(|_| {
-                let empty: &[&str] = &[];
-                CompiledWildcards::compile(empty).unwrap()
-            });
+        let compiled_builtins = CompiledWildcards::compile(BUILTIN_PASS_THROUGH_ENV).ok();
 
         Self {
             hashes,
@@ -515,11 +511,20 @@ impl<'a, R: RunOptsHashInfo> TaskHasher<'a, R> {
     ) -> Result<EnvironmentVariableMap, Error> {
         match task_env_mode {
             EnvMode::Strict => {
-                let pass_through_env_vars = self.env_at_execution_start.pass_through_env_compiled(
-                    &self.compiled_builtins,
-                    &self.global_env,
-                    task_definition.pass_through_env().unwrap_or_default(),
-                )?;
+                let pass_through_env_vars = match &self.compiled_builtins {
+                    Some(compiled_builtins) => {
+                        self.env_at_execution_start.pass_through_env_compiled(
+                            compiled_builtins,
+                            &self.global_env,
+                            task_definition.pass_through_env().unwrap_or_default(),
+                        )?
+                    }
+                    None => self.env_at_execution_start.pass_through_env(
+                        &[] as &[&str],
+                        &self.global_env,
+                        task_definition.pass_through_env().unwrap_or_default(),
+                    )?,
+                };
 
                 let tracker_env = self
                     .task_hash_tracker


### PR DESCRIPTION
TURBO-5622, TURBO-5661

Removes remaining implementation `expect`/`unwrap` callsites from `turborepo-task-hash` so the crate-level panic lint allow can be narrowed to test builds only. Production code now propagates path errors or uses non-panicking fallbacks.

## Verification

- `cargo fmt --package turborepo-task-hash`
- `cargo test --package turborepo-task-hash`
- `cargo clippy --package turborepo-task-hash --all-targets -- -D warnings`
- Pre-push hook passed
