### PR TITLE
fix: Avoid API client expect calls

### DIFF
--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -6,7 +6,7 @@
 // miette's derive macro causes false positives for this lint
 #![allow(unused_assignments)]
 #![deny(clippy::all)]
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::unwrap_used)]
 
 use std::{backtrace::Backtrace, env, future::Future, sync::LazyLock, time::Duration};
 #[cfg(feature = "rustls-tls")]

--- a/crates/turborepo-api-client/src/shared_http_client.rs
+++ b/crates/turborepo-api-client/src/shared_http_client.rs
@@ -54,10 +54,16 @@ impl SharedHttpClient {
         let fast = self.fast_client.clone();
         tokio::task::spawn_blocking(move || {
             let _span = tracing::info_span!("http_client_init_fast").entered();
-            let _ = fast.get_or_init(|| {
-                APIClient::build_http_client_webpki_only(None)
-                    .expect("failed to build webpki HTTP client")
-            });
+            if fast.get().is_none() {
+                match APIClient::build_http_client_webpki_only(None) {
+                    Ok(client) => {
+                        let _ = fast.set(client);
+                    }
+                    Err(e) => {
+                        tracing::warn!("Fast HTTP client init failed: {e}");
+                    }
+                }
+            }
         });
 
         // Phase 2: build full client in background (native-roots, ~200ms on macOS).
@@ -97,17 +103,17 @@ impl SharedHttpClient {
 
         // Neither is ready — build the fast client synchronously as fallback
         let fast = self.fast_client.clone();
-        let client = tokio::task::spawn_blocking(move || {
+        tokio::task::spawn_blocking(move || {
             let _span = tracing::info_span!("http_client_init_fast").entered();
-            fast.get_or_init(|| {
-                APIClient::build_http_client_webpki_only(None)
-                    .expect("failed to build webpki HTTP client")
-            })
-            .clone()
+            if let Some(client) = fast.get() {
+                return Ok(client.clone());
+            }
+
+            let client = APIClient::build_http_client_webpki_only(None)?;
+            let _ = fast.set(client.clone());
+            Ok(client)
         })
         .await
-        .map_err(|_| Error::HttpClientCancelled)?;
-
-        Ok(client)
+        .map_err(|_| Error::HttpClientCancelled)?
     }
 }


### PR DESCRIPTION
## Why
TURBO-5583 removes the remaining implementation `.expect()` calls from `turborepo-api-client` so HTTP client initialization returns or logs builder failures instead of panicking.

## Verification
- `cargo fmt --package turborepo-api-client`
- `cargo test --package turborepo-api-client`
- `cargo clippy --package turborepo-api-client --all-targets -- -D warnings`
- pre-push hook via `git push`