### PR TITLE
fix: Remove microfrontends proxy expect lint allow

### DIFF
--- a/crates/turborepo-microfrontends-proxy/src/lib.rs
+++ b/crates/turborepo-microfrontends-proxy/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(clippy::all)]
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::unwrap_used)]
 
 mod error;
 mod headers;


### PR DESCRIPTION
## Summary
Remove the implementation-level `clippy::expect_used` allow from `turborepo-microfrontends-proxy` now that implementation code has no `.expect()` callsites.

Linear: TURBO-5614

## Verification
- `cargo fmt --package turborepo-microfrontends-proxy`
- `cargo test --package turborepo-microfrontends-proxy`
- `cargo clippy --package turborepo-microfrontends-proxy --all-targets -- -D warnings`
- Pre-push hook with Node 22