### PR TITLE
fix: Remove vt100 expect lint allow

### DIFF
--- a/crates/turborepo-vt100/src/lib.rs
+++ b/crates/turborepo-vt100/src/lib.rs
@@ -45,7 +45,7 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::type_complexity)]
 #![allow(unused_imports)]
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::unwrap_used)]
 
 mod attrs;
 mod callbacks;


### PR DESCRIPTION
## Summary
Remove the production `clippy::expect_used` allow from `turborepo-vt100` now that implementation code has no `.expect()` callsites.

TURBO-5601

## Verification
- `cargo fmt --package turborepo-vt100`
- `cargo test --package turborepo-vt100`
- `cargo clippy --package turborepo-vt100 --all-targets -- -D warnings`
- pre-push hook with Node 22.14.0