### PR TITLE
fix: Remove Vercel API mock expect usage

### DIFF
--- a/crates/turborepo-vercel-api-mock/src/lib.rs
+++ b/crates/turborepo-vercel-api-mock/src/lib.rs
@@ -1,7 +1,7 @@
 //! Mock server implementation for a subset of the Vercel API.
 
 #![deny(clippy::all)]
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::unwrap_used)]
 
 use std::{collections::HashMap, fs::OpenOptions, io::Write, net::SocketAddr, sync::Arc};
 
@@ -145,11 +145,17 @@ pub async fn start_test_server(
                         .open(&file_path)
                         .unwrap();
 
-                    let duration = headers
+                    let Some(duration) = headers
                         .get("x-artifact-duration")
                         .and_then(|header_value| header_value.to_str().ok())
                         .and_then(|duration| duration.parse::<u32>().ok())
-                        .expect("x-artifact-duration header is missing");
+                    else {
+                        return (
+                            StatusCode::BAD_REQUEST,
+                            "x-artifact-duration header is missing",
+                        )
+                            .into_response();
+                    };
 
                     assert!(
                         headers.get(CONTENT_LENGTH).is_some(),
@@ -178,7 +184,7 @@ pub async fn start_test_server(
                         file.write_all(&chunk).unwrap();
                     }
 
-                    (StatusCode::CREATED, Json(hash))
+                    (StatusCode::CREATED, Json(hash)).into_response()
                 },
             ),
         )

--- a/crates/turborepo-vercel-api-mock/src/main.rs
+++ b/crates/turborepo-vercel-api-mock/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::unwrap_used)]
 
 use anyhow::Result;
 use turborepo_vercel_api_mock::start_test_server;


### PR DESCRIPTION
TURBO-5600

Removes the remaining implementation `.expect()` in `turborepo-vercel-api-mock` by returning `400 BAD_REQUEST` when `x-artifact-duration` is missing or invalid. This lets the crate drop its `clippy::expect_used` allow while keeping existing `unwrap_used` cleanup out of scope.

Verification:
- `cargo fmt --package turborepo-vercel-api-mock`
- `cargo test --package turborepo-vercel-api-mock`
- `cargo clippy --package turborepo-vercel-api-mock --all-targets -- -D warnings`
- pre-push hooks