### PR TITLE
fix: Remove turbo-trace unwrap callsite

### DIFF
--- a/crates/turbo-trace/src/lib.rs
+++ b/crates/turbo-trace/src/lib.rs
@@ -5,7 +5,7 @@
 // miette's derive macro causes false positives for this lint
 #![allow(unused_assignments)]
 #![deny(clippy::all)]
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
 mod import_finder;
 mod tracer;
 

--- a/crates/turbo-trace/src/tracer.rs
+++ b/crates/turbo-trace/src/tracer.rs
@@ -58,6 +58,8 @@ pub enum TraceError {
     },
     #[error("failed to walk files")]
     GlobError(Arc<globwalk::WalkError>),
+    #[error("trace task failed to complete: {0}")]
+    TaskJoinError(String),
 }
 
 impl TraceResult {
@@ -470,7 +472,20 @@ impl Tracer {
         let mut errors = Vec::new();
 
         while let Some(result) = futures.join_next().await {
-            let (errs, file) = result.unwrap();
+            let (errs, file) = match result {
+                Ok(result) => result,
+                Err(err) => {
+                    let reason = if err.is_panic() {
+                        "trace task panicked"
+                    } else if err.is_cancelled() {
+                        "trace task was cancelled"
+                    } else {
+                        "trace task failed"
+                    };
+                    errors.push(TraceError::TaskJoinError(format!("{reason}: {err}")));
+                    continue;
+                }
+            };
             errors.extend(errs);
 
             if let Some((path, seen_file)) = file {

--- a/crates/turborepo-query/src/file.rs
+++ b/crates/turborepo-query/src/file.rs
@@ -71,6 +71,10 @@ impl From<turbo_trace::TraceError> for Diagnostic {
                 message: format!("failed to glob files: {err}"),
                 ..Default::default()
             },
+            turbo_trace::TraceError::TaskJoinError(_) => Diagnostic {
+                message,
+                ..Default::default()
+            },
             turbo_trace::TraceError::Resolve {
                 span,
                 text,


### PR DESCRIPTION
TURBO-5624

Removes the implementation unwrap in turbo-trace reverse tracing and reports JoinSet failures as trace errors instead of panicking. Also narrows the turbo-trace crate-level panic lint allow by removing clippy::unwrap_used.

Verification:
- cargo fmt --package turbo-trace
- cargo test --package turbo-trace
- cargo clippy --package turbo-trace --all-targets -- -D warnings
- pre-push hooks ran successfully