### PR TITLE
fix: Remove turborepo-shim expect callsites

### DIFF
--- a/crates/turborepo-shim/src/lib.rs
+++ b/crates/turborepo-shim/src/lib.rs
@@ -11,7 +11,7 @@
 //! The crate uses trait-based dependency injection to avoid circular
 //! dependencies with `turborepo-lib`.
 
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![cfg_attr(test, allow(clippy::unwrap_used))]
 
 mod local_turbo_config;
 mod local_turbo_state;

--- a/crates/turborepo-shim/src/parser.rs
+++ b/crates/turborepo-shim/src/parser.rs
@@ -302,10 +302,10 @@ impl ShimArgs {
     pub fn profile_file_and_include_args(&self) -> Option<(String, bool)> {
         let resolve = |file: &str| -> String {
             if file.is_empty() {
-                let now = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .expect("system clock is before unix epoch")
-                    .as_millis();
+                let now = match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+                    Ok(duration) => duration.as_millis(),
+                    Err(_) => 0,
+                };
                 format!("profile.{now}")
             } else {
                 file.to_string()

--- a/crates/turborepo-shim/src/turbo_state.rs
+++ b/crates/turborepo-shim/src/turbo_state.rs
@@ -76,7 +76,7 @@ impl TurboState {
         include_str!("../../../version.txt")
             .lines()
             .next()
-            .expect("Failed to read version from version.txt")
+            .unwrap_or_default()
     }
 }
 


### PR DESCRIPTION
TURBO-5617

Removes implementation `.expect()` usage from `turborepo-shim` so the crate no longer needs the broad `clippy::expect_used` allow. Keeps the existing unwrap allowance scoped to tests only.

Verification:
- `cargo fmt --package turborepo-shim`
- `cargo test --package turborepo-shim`
- `cargo clippy --package turborepo-shim --all-targets -- -D warnings`
- pre-push hook passed with Node 22