### PR TITLE
fix: Avoid repository NAPI unwrap calls

### DIFF
--- a/packages/turbo-repository/rust/src/internal.rs
+++ b/packages/turbo-repository/rust/src/internal.rs
@@ -52,19 +52,18 @@ impl From<Error> for napi::Error<Status> {
 
 impl Workspace {
     pub(crate) async fn find_internal(path: Option<String>) -> Result<Self, Error> {
-        let reference_dir = path
-            .map(|path| {
+        let reference_dir = match path {
+            Some(path) => {
                 AbsoluteSystemPathBuf::from_cwd(&path).map_err(|path_error| Error::StartingPath {
                     path: path.clone(),
                     path_error,
                 })
-            })
-            .unwrap_or_else(|| {
-                AbsoluteSystemPathBuf::cwd().map_err(|path_error| Error::StartingPath {
-                    path: "".to_string(),
-                    path_error,
-                })
-            })?;
+            }
+            None => AbsoluteSystemPathBuf::cwd().map_err(|path_error| Error::StartingPath {
+                path: "".to_string(),
+                path_error,
+            }),
+        }?;
         let workspace_state = WorkspaceState::infer(&reference_dir)?;
         let is_multi_package = workspace_state.mode == WorkspaceType::MultiPackage;
         let package_manager =

--- a/packages/turbo-repository/rust/src/lib.rs
+++ b/packages/turbo-repository/rust/src/lib.rs
@@ -224,11 +224,13 @@ impl Workspace {
         if changed_files.contains(lockfile_path) {
             let git = SCM::new(workspace_root);
             let anchored_path = workspace_root.join_component(lockfile_name);
-            git.previous_content(Some(from_commit), &anchored_path)
-                .map(LockfileContents::Changed)
-                .inspect_err(|e| debug!("{e}"))
-                .ok()
-                .unwrap_or(LockfileContents::UnknownChange)
+            match git.previous_content(Some(from_commit), &anchored_path) {
+                Ok(contents) => LockfileContents::Changed(contents),
+                Err(e) => {
+                    debug!("{e}");
+                    LockfileContents::UnknownChange
+                }
+            }
         } else {
             LockfileContents::Unchanged
         }
@@ -245,8 +247,7 @@ impl Workspace {
         base: Option<&str>, // this is required when optimize_global_invalidations is true
         optimize_global_invalidations: Option<bool>,
     ) -> Result<Vec<Package>, Error> {
-        let base = optimize_global_invalidations
-            .unwrap_or(false)
+        let base = matches!(optimize_global_invalidations, Some(true))
             .then(|| {
                 base.ok_or_else(|| {
                     Error::from_reason("optimizeGlobalInvalidations true, but no base commit given")


### PR DESCRIPTION
## Why

TURBO-5592 and TURBO-5630 are removing panic-prone Rust patterns from the turbo-repository NAPI boundary so JavaScript callers get sane boundary behavior instead of process panics.

## What

Replaced the remaining unwrap-style control flow in packages/turbo-repository/rust with explicit matches while preserving existing results and error handling.

## How

Verified with cargo fmt --package turborepo-napi --check, cargo test --package turborepo-napi, cargo clippy --package turborepo-napi --all-targets -- -D warnings, and the enabled pre-push hook.