### PR TITLE
fix: Remove telemetry panic callsites

### DIFF
--- a/crates/turborepo-telemetry/src/config.rs
+++ b/crates/turborepo-telemetry/src/config.rs
@@ -82,12 +82,12 @@ impl TelemetryConfig {
         // file and write a new one, otherwise return the error
         let config = match settings {
             Ok(settings) => settings.try_deserialize::<TelemetryConfigContents>()?,
-            Err(ConfigError::FileParse { .. }) => {
+            Err(err @ ConfigError::FileParse { .. }) => {
                 config_path
                     .remove_file()
                     .map_err(|e| ConfigError::Message(e.to_string()))?;
                 write_new_config(&config_path)?;
-                return Err(settings.unwrap_err());
+                return Err(err);
             }
             // Propagate other errors
             Err(err) => return Err(err),

--- a/crates/turborepo-telemetry/src/lib.rs
+++ b/crates/turborepo-telemetry/src/lib.rs
@@ -6,7 +6,7 @@
 #![feature(error_generic_member_access)]
 // miette's derive macro causes false positives for this lint
 #![allow(unused_assignments)]
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 
 pub mod config;
 pub mod errors;
@@ -125,7 +125,9 @@ pub fn init_telemetry(
     }
     let config = TelemetryConfig::with_default_config_path()?;
     let (handle, sender, enabled) = init(config, client, color_config)?;
-    SENDER_INSTANCE.set(sender).unwrap();
+    SENDER_INSTANCE
+        .set(sender)
+        .map_err(|_| Box::new(Error::AlreadyInitialized()) as Box<dyn std::error::Error>)?;
     Ok((handle, enabled))
 }
 


### PR DESCRIPTION
TURBO-5607, TURBO-5653

Removes implementation panic helpers from `turborepo-telemetry` so initialization and config parse paths return explicit errors instead of panicking. Test panic helpers remain scoped to tests.

## Verification

- `cargo fmt --package turborepo-telemetry`
- `cargo test --package turborepo-telemetry`
- `cargo clippy --package turborepo-telemetry --all-targets -- -D warnings`
- Pre-push hook passed
