### PR TITLE
fix: Remove turbo-json panic lint allows

### DIFF
--- a/crates/turborepo-turbo-json/src/error.rs
+++ b/crates/turborepo-turbo-json/src/error.rs
@@ -8,10 +8,9 @@
 
 use std::backtrace;
 
-use convert_case::{Case, Casing};
 use miette::{Diagnostic, NamedSource, SourceSpan};
 use thiserror::Error;
-use turborepo_errors::{ParseDiagnostic, TURBO_SITE};
+use turborepo_errors::ParseDiagnostic;
 
 /// Error type for turbo.json parsing failures
 #[derive(Debug, Error, Diagnostic)]
@@ -39,7 +38,7 @@ impl ParseError {
 #[error("Environment variables should not be prefixed with \"{env_pipeline_delimiter}\"")]
 #[diagnostic(
     code(invalid_env_prefix),
-    url("{}/messages/{}", TURBO_SITE, self.code().unwrap().to_string().to_case(Case::Kebab))
+    url("https://turborepo.dev/messages/invalid-env-prefix")
 )]
 pub struct InvalidEnvPrefixError {
     /// The invalid value that was found
@@ -58,7 +57,7 @@ pub struct InvalidEnvPrefixError {
 #[derive(Debug, Error, Diagnostic)]
 #[diagnostic(
     code(unnecessary_package_task_syntax),
-    url("{}/messages/{}", TURBO_SITE, self.code().unwrap().to_string().to_case(Case::Kebab))
+    url("https://turborepo.dev/messages/unnecessary-package-task-syntax")
 )]
 #[error("\"{actual}\". Use \"{wanted}\" instead.")]
 pub struct UnnecessaryPackageTaskSyntaxError {
@@ -114,7 +113,10 @@ pub enum Error {
         "Package tasks (<package>#<task>) are not allowed in single-package repositories: found \
          {task_id}"
     )]
-    #[diagnostic(code(package_task_in_single_package_mode), url("{}/messages/{}", TURBO_SITE, self.code().unwrap().to_string().to_case(Case::Kebab)))]
+    #[diagnostic(
+        code(package_task_in_single_package_mode),
+        url("https://turborepo.dev/messages/package-task-in-single-package-mode")
+    )]
     PackageTaskInSinglePackageMode {
         task_id: String,
         #[source_code]

--- a/crates/turborepo-turbo-json/src/lib.rs
+++ b/crates/turborepo-turbo-json/src/lib.rs
@@ -13,8 +13,7 @@
 // This is intentional for rich error reporting. Boxing would add indirection overhead
 // for error paths that are not performance-critical.
 #![allow(clippy::result_large_err)]
-#![allow(clippy::unwrap_used)]
-#![cfg_attr(test, allow(clippy::expect_used))]
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 
 use std::{collections::HashSet, sync::Arc};
 

--- a/crates/turborepo-turbo-json/src/lib.rs
+++ b/crates/turborepo-turbo-json/src/lib.rs
@@ -13,7 +13,8 @@
 // This is intentional for rich error reporting. Boxing would add indirection overhead
 // for error paths that are not performance-critical.
 #![allow(clippy::result_large_err)]
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::unwrap_used)]
+#![cfg_attr(test, allow(clippy::expect_used))]
 
 use std::{collections::HashSet, sync::Arc};
 

--- a/crates/turborepo-turbo-json/src/loader.rs
+++ b/crates/turborepo-turbo-json/src/loader.rs
@@ -358,9 +358,10 @@ impl TurboJsonLoader<NoOpUpdater> {
                 .map(|(key, value)| (key, Some(value))),
         );
         // This never gets read from so we populate it with root
-        let repo_root = AbsoluteSystemPath::new(if cfg!(windows) { "C:\\" } else { "/" })
-            .expect("wasn't able to create absolute system path")
-            .to_owned();
+        let repo_root = match AbsoluteSystemPath::new(if cfg!(windows) { "C:\\" } else { "/" }) {
+            Ok(path) => path.to_owned(),
+            Err(_) => unreachable!("platform root path should be absolute"),
+        };
         Self {
             reader: TurboJsonReader::new(repo_root),
             cache,

--- a/crates/turborepo-turbo-json/src/parser.rs
+++ b/crates/turborepo-turbo-json/src/parser.rs
@@ -444,7 +444,7 @@ impl RawTurboJson {
     /// This is a convenience helper for constructing RawTurboJson from
     /// serde_json::json! macro in tests.
     pub fn parse_from_serde(value: serde_json::Value) -> Result<RawTurboJson, crate::error::Error> {
-        let json_string = serde_json::to_string(&value).expect("should be able to serialize");
+        let json_string = serde_json::to_string(&value)?;
         let raw_root = RawRootTurboJson::parse(&json_string, "turbo.json")?;
         raw_root.try_into()
     }


### PR DESCRIPTION
TURBO-5603, TURBO-5644

Removes implementation `expect`/`unwrap` callsites from `turborepo-turbo-json` so panic lint allows can be narrowed to test builds only.

## Verification

- `cargo fmt --package turborepo-turbo-json`
- `cargo test --package turborepo-turbo-json`
- `cargo clippy --package turborepo-turbo-json --all-targets -- -D warnings`
- Pre-push hook passed
