### PR TITLE
chore: Remove Rust re-export shims

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7272,6 +7272,7 @@ dependencies = [
  "tokio",
  "tracing",
  "turborepo-api-client",
+ "turborepo-types",
  "turborepo-vercel-api",
  "uuid",
 ]
@@ -7328,6 +7329,7 @@ dependencies = [
  "turborepo-api-client",
  "turborepo-dirs",
  "turborepo-json-rewrite",
+ "turborepo-types",
  "turborepo-ui",
  "turborepo-vercel-api",
  "turborepo-vercel-api-mock",
@@ -7409,6 +7411,7 @@ dependencies = [
  "turborepo-api-client",
  "turborepo-auth",
  "turborepo-log",
+ "turborepo-types",
  "turborepo-vercel-api",
  "turborepo-vercel-api-mock",
  "windows-sys 0.59.0",

--- a/crates/turborepo-analytics/Cargo.toml
+++ b/crates/turborepo-analytics/Cargo.toml
@@ -15,5 +15,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full", "time"] }
 tracing = { workspace = true }
 turborepo-api-client = { workspace = true }
+turborepo-types = { workspace = true }
 turborepo-vercel-api = { workspace = true }
 uuid = { version = "1.5.0", features = ["v4"] }

--- a/crates/turborepo-analytics/src/lib.rs
+++ b/crates/turborepo-analytics/src/lib.rs
@@ -179,7 +179,8 @@ mod tests {
         select,
         sync::{mpsc, mpsc::UnboundedReceiver},
     };
-    use turborepo_api_client::{APIAuth, SecretString, analytics::AnalyticsClient};
+    use turborepo_api_client::{APIAuth, analytics::AnalyticsClient};
+    use turborepo_types::SecretString;
     use turborepo_vercel_api::{AnalyticsEvent, CacheEvent, CacheSource};
     use uuid::Uuid;
 

--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -19,7 +19,7 @@ use reqwest::{Body, Method, RequestBuilder, StatusCode};
 use rustls_pemfile::{self, Item};
 use serde::Deserialize;
 use turborepo_ci::{Vendor, is_ci};
-pub use turborepo_types::SecretString;
+use turborepo_types::SecretString;
 use turborepo_vercel_api::{
     APIError, CachingStatus, CachingStatusResponse, PreflightResponse, Team, TeamsResponse, User,
     UserResponse, VerificationResponse, VerifiedSsoUser,

--- a/crates/turborepo-auth/Cargo.toml
+++ b/crates/turborepo-auth/Cargo.toml
@@ -22,6 +22,7 @@ turborepo-ai-agents = { workspace = true }
 turborepo-api-client = { workspace = true }
 turborepo-dirs = { version = "0.1.0", path = "../turborepo-dirs" }
 turborepo-json-rewrite = { path = "../turborepo-json-rewrite" }
+turborepo-types = { workspace = true }
 turborepo-ui.workspace = true
 turborepo-vercel-api = { workspace = true }
 turborepo-vercel-api-mock = { workspace = true }

--- a/crates/turborepo-auth/src/auth/login.rs
+++ b/crates/turborepo-auth/src/auth/login.rs
@@ -7,6 +7,7 @@ use std::{
 pub use error::Error;
 use tracing::warn;
 use turborepo_api_client::{Client, TokenClient};
+use turborepo_types::SecretString;
 use turborepo_ui::{BOLD, ColorConfig, start_spinner};
 use url::Url;
 
@@ -280,7 +281,7 @@ pub(super) async fn login_vercel_device_flow<T: Client>(
 
     spinner.finish_and_clear();
 
-    let secret_token = turborepo_api_client::SecretString::new(token_set.access_token.clone());
+    let secret_token = SecretString::new(token_set.access_token.clone());
 
     let user_response = api_client
         .get_user(&secret_token)
@@ -364,7 +365,7 @@ async fn login_redirect<T: Client>(
 
     spinner.finish_and_clear();
 
-    let secret_token = turborepo_api_client::SecretString::new(token_string.clone());
+    let secret_token = SecretString::new(token_string.clone());
 
     let user_response = api_client
         .get_user(&secret_token)
@@ -517,7 +518,7 @@ mod tests {
     impl Client for MockApiClient {
         async fn get_user(
             &self,
-            token: &turborepo_api_client::SecretString,
+            token: &SecretString,
         ) -> turborepo_api_client::Result<UserResponse> {
             if token.expose().is_empty() {
                 return Err(MockApiError::EmptyToken.into());
@@ -534,7 +535,7 @@ mod tests {
         }
         async fn get_teams(
             &self,
-            token: &turborepo_api_client::SecretString,
+            token: &SecretString,
         ) -> turborepo_api_client::Result<TeamsResponse> {
             if token.expose().is_empty() {
                 return Err(MockApiError::EmptyToken.into());
@@ -553,7 +554,7 @@ mod tests {
         }
         async fn get_team(
             &self,
-            _token: &turborepo_api_client::SecretString,
+            _token: &SecretString,
             _team_id: &str,
         ) -> turborepo_api_client::Result<Option<Team>> {
             unimplemented!("get_team")
@@ -563,7 +564,7 @@ mod tests {
         }
         async fn verify_sso_token(
             &self,
-            token: &turborepo_api_client::SecretString,
+            token: &SecretString,
             _: &str,
         ) -> turborepo_api_client::Result<VerifiedSsoUser> {
             Ok(VerifiedSsoUser {
@@ -584,7 +585,7 @@ mod tests {
     impl TokenClient for MockApiClient {
         async fn get_metadata(
             &self,
-            token: &turborepo_api_client::SecretString,
+            token: &SecretString,
         ) -> turborepo_api_client::Result<turborepo_vercel_api::token::ResponseTokenMetadata>
         {
             if token.expose().is_empty() {
@@ -617,10 +618,7 @@ mod tests {
                 client_id: None,
             })
         }
-        async fn delete_token(
-            &self,
-            _token: &turborepo_api_client::SecretString,
-        ) -> turborepo_api_client::Result<()> {
+        async fn delete_token(&self, _token: &SecretString) -> turborepo_api_client::Result<()> {
             Ok(())
         }
     }

--- a/crates/turborepo-auth/src/auth/logout.rs
+++ b/crates/turborepo-auth/src/auth/logout.rs
@@ -2,6 +2,7 @@ use tracing::error;
 use turbopath::AbsoluteSystemPath;
 use turborepo_api_client::TokenClient;
 use turborepo_dirs::{config_dir, vercel_config_dir};
+use turborepo_types::SecretString;
 use turborepo_ui::{GREY, cprintln};
 
 use crate::{
@@ -20,9 +21,7 @@ pub async fn logout<T: TokenClient>(options: &LogoutOptions<T>) -> Result<(), Er
 }
 
 impl<T: TokenClient> LogoutOptions<T> {
-    fn token_at_path(
-        path: &AbsoluteSystemPath,
-    ) -> Result<Option<turborepo_api_client::SecretString>, Error> {
+    fn token_at_path(path: &AbsoluteSystemPath) -> Result<Option<SecretString>, Error> {
         match Token::from_file(path) {
             Ok(token) => Ok(Some(token.into_inner().clone())),
             Err(Error::TokenNotFound) => Ok(None),
@@ -146,19 +145,19 @@ mod tests {
     impl Client for MockApiClient {
         async fn get_user(
             &self,
-            _token: &turborepo_api_client::SecretString,
+            _token: &SecretString,
         ) -> turborepo_api_client::Result<UserResponse> {
             unimplemented!("get_user")
         }
         async fn get_teams(
             &self,
-            _token: &turborepo_api_client::SecretString,
+            _token: &SecretString,
         ) -> turborepo_api_client::Result<TeamsResponse> {
             unimplemented!("get_teams")
         }
         async fn get_team(
             &self,
-            _token: &turborepo_api_client::SecretString,
+            _token: &SecretString,
             _team_id: &str,
         ) -> turborepo_api_client::Result<Option<Team>> {
             unimplemented!("get_team")
@@ -168,7 +167,7 @@ mod tests {
         }
         async fn verify_sso_token(
             &self,
-            token: &turborepo_api_client::SecretString,
+            token: &SecretString,
             _: &str,
         ) -> turborepo_api_client::Result<VerifiedSsoUser> {
             Ok(VerifiedSsoUser {
@@ -185,10 +184,7 @@ mod tests {
     }
 
     impl TokenClient for MockApiClient {
-        async fn delete_token(
-            &self,
-            _token: &turborepo_api_client::SecretString,
-        ) -> turborepo_api_client::Result<()> {
+        async fn delete_token(&self, _token: &SecretString) -> turborepo_api_client::Result<()> {
             if self.succeed_delete_request {
                 Ok(())
             } else {
@@ -201,7 +197,7 @@ mod tests {
         }
         async fn get_metadata(
             &self,
-            _token: &turborepo_api_client::SecretString,
+            _token: &SecretString,
         ) -> turborepo_api_client::Result<ResponseTokenMetadata> {
             unimplemented!("get_metadata")
         }

--- a/crates/turborepo-auth/src/auth/mod.rs
+++ b/crates/turborepo-auth/src/auth/mod.rs
@@ -11,6 +11,7 @@ use turbopath::AbsoluteSystemPath;
 #[cfg(test)]
 use turbopath::AbsoluteSystemPathBuf;
 use turborepo_api_client::{Client, TokenClient};
+use turborepo_types::SecretString;
 use turborepo_ui::ColorConfig;
 use url::Url;
 
@@ -226,7 +227,7 @@ pub(crate) fn classify_existing_vercel_token(token: &str) -> Result<ExistingToke
 }
 
 fn load_legacy_auth_tokens(
-    expected_token: Option<&turborepo_api_client::SecretString>,
+    expected_token: Option<&SecretString>,
 ) -> Result<crate::AuthTokens, Error> {
     use crate::Token;
 
@@ -260,9 +261,9 @@ fn load_legacy_auth_tokens(
 async fn exchange_legacy_auth_token(
     turbo_auth_path: &AbsoluteSystemPath,
     turbo_config_path: &AbsoluteSystemPath,
-    expected_token: Option<&turborepo_api_client::SecretString>,
+    expected_token: Option<&SecretString>,
     allow_legacy_token_fallback: bool,
-) -> Result<Option<turborepo_api_client::SecretString>, Error> {
+) -> Result<Option<SecretString>, Error> {
     let legacy_auth_tokens = load_legacy_auth_tokens(expected_token)?;
     exchange_auth_tokens(
         &legacy_auth_tokens,
@@ -309,7 +310,7 @@ async fn exchange_auth_tokens(
     turbo_config_path: &AbsoluteSystemPath,
     allow_token_fallback: bool,
     source_label: &str,
-) -> Result<Option<turborepo_api_client::SecretString>, Error> {
+) -> Result<Option<SecretString>, Error> {
     let Some(stored_token) = auth_tokens.token.clone() else {
         return Ok(None);
     };
@@ -376,7 +377,7 @@ async fn refresh_and_persist_turbo_token(
     auth_tokens: &crate::AuthTokens,
     turbo_auth_path: &AbsoluteSystemPath,
     turbo_config_path: &AbsoluteSystemPath,
-) -> Option<turborepo_api_client::SecretString> {
+) -> Option<SecretString> {
     if !can_refresh_token(auth_tokens) {
         return None;
     }
@@ -413,7 +414,7 @@ fn persist_turbo_oauth_tokens(
 async fn get_token_with_refresh_inner(
     allow_legacy_token_fallback: bool,
     allow_turbo_config_token_fallback: bool,
-) -> Result<Option<turborepo_api_client::SecretString>, Error> {
+) -> Result<Option<SecretString>, Error> {
     use crate::{TURBO_AUTH_FILE, TURBO_TOKEN_DIR, TURBO_TOKEN_FILE};
 
     let turbo_config_dir = match turborepo_dirs::config_dir()? {
@@ -477,15 +478,14 @@ async fn get_token_with_refresh_inner(
 }
 
 /// Attempts to get a valid token with automatic refresh if expired.
-pub async fn get_token_with_refresh() -> Result<Option<turborepo_api_client::SecretString>, Error> {
+pub async fn get_token_with_refresh() -> Result<Option<SecretString>, Error> {
     get_token_with_refresh_inner(true, true).await
 }
 
 /// Login prefers upgrading legacy/config tokens into Turbo OAuth sessions. If
 /// that upgrade fails, callers should fall through to a fresh login instead of
 /// silently reusing the old token.
-pub async fn get_token_with_refresh_for_login()
--> Result<Option<turborepo_api_client::SecretString>, Error> {
+pub async fn get_token_with_refresh_for_login() -> Result<Option<SecretString>, Error> {
     get_token_with_refresh_inner(false, false).await
 }
 
@@ -493,8 +493,8 @@ pub async fn get_token_with_refresh_for_login()
 /// by the server. Unlike `get_token_with_refresh`, this never falls back to the
 /// same stored token.
 pub async fn recover_token_after_forbidden(
-    current_token: &turborepo_api_client::SecretString,
-) -> Result<Option<turborepo_api_client::SecretString>, Error> {
+    current_token: &SecretString,
+) -> Result<Option<SecretString>, Error> {
     use crate::{TURBO_AUTH_FILE, TURBO_TOKEN_DIR, TURBO_TOKEN_FILE};
 
     let turbo_config_dir = match turborepo_dirs::config_dir()? {
@@ -974,11 +974,10 @@ mod tests {
             env::set_var("VERCEL_CONFIG_DIR_PATH", vercel_config_dir.as_path());
         }
 
-        let recovered = recover_token_after_forbidden(&turborepo_api_client::SecretString::new(
-            "other-token".to_string(),
-        ))
-        .await
-        .unwrap();
+        let recovered =
+            recover_token_after_forbidden(&SecretString::new("other-token".to_string()))
+                .await
+                .unwrap();
 
         assert!(recovered.is_none());
 
@@ -1155,10 +1154,8 @@ mod tests {
     async fn test_refreshability_depends_on_refresh_token_not_access_token_prefix() {
         for token in ["vca_token", "legacy_token", "corrupted!!!", ""] {
             let auth_tokens = AuthTokens {
-                token: Some(turborepo_api_client::SecretString::new(token.to_string())),
-                refresh_token: Some(turborepo_api_client::SecretString::new(
-                    "refresh_token".to_string(),
-                )),
+                token: Some(SecretString::new(token.to_string())),
+                refresh_token: Some(SecretString::new("refresh_token".to_string())),
                 expires_at: Some(current_unix_time_secs() - 3600),
             };
 
@@ -1169,9 +1166,7 @@ mod tests {
         }
 
         let auth_tokens = AuthTokens {
-            token: Some(turborepo_api_client::SecretString::new(
-                "vca_token".to_string(),
-            )),
+            token: Some(SecretString::new("vca_token".to_string())),
             refresh_token: None,
             expires_at: Some(current_unix_time_secs() - 3600),
         };

--- a/crates/turborepo-auth/src/auth/mod.rs
+++ b/crates/turborepo-auth/src/auth/mod.rs
@@ -561,6 +561,7 @@ mod tests {
     use tempfile::tempdir;
     use tokio::sync::Mutex;
     use turbopath::AbsoluteSystemPathBuf;
+    use turborepo_types::SecretString;
 
     use super::{
         ExistingTokenSource, can_refresh_token, classify_existing_vercel_token,

--- a/crates/turborepo-auth/src/auth/sso.rs
+++ b/crates/turborepo-auth/src/auth/sso.rs
@@ -6,6 +6,7 @@ use std::{
 
 use tracing::warn;
 use turborepo_api_client::{Client, TokenClient};
+use turborepo_types::SecretString;
 use turborepo_ui::{ColorConfig, start_spinner};
 use url::Url;
 
@@ -277,8 +278,7 @@ pub async fn sso_login<T: Client + TokenClient>(
     let verification_token = sso_redirect(login_url_configuration, sso_team, port).await?;
 
     // Verify the SSO token with the API
-    let secret_verification_token =
-        turborepo_api_client::SecretString::new(verification_token.clone());
+    let secret_verification_token = SecretString::new(verification_token.clone());
 
     let token_name = make_token_name()?;
 
@@ -507,7 +507,7 @@ mod tests {
     impl Client for MockApiClient {
         async fn get_user(
             &self,
-            token: &turborepo_api_client::SecretString,
+            token: &SecretString,
         ) -> turborepo_api_client::Result<UserResponse> {
             if token.expose().is_empty() {
                 return Err(MockApiError::EmptyToken.into());
@@ -524,7 +524,7 @@ mod tests {
         }
         async fn get_teams(
             &self,
-            token: &turborepo_api_client::SecretString,
+            token: &SecretString,
         ) -> turborepo_api_client::Result<TeamsResponse> {
             if token.expose().is_empty() {
                 return Err(MockApiError::EmptyToken.into());
@@ -543,7 +543,7 @@ mod tests {
         }
         async fn get_team(
             &self,
-            token: &turborepo_api_client::SecretString,
+            token: &SecretString,
             team_id: &str,
         ) -> turborepo_api_client::Result<Option<Team>> {
             if token.expose() == "needs-sso-token" || team_id == "needs-sso-team" {
@@ -564,7 +564,7 @@ mod tests {
         }
         async fn verify_sso_token(
             &self,
-            token: &turborepo_api_client::SecretString,
+            token: &SecretString,
             _: &str,
         ) -> turborepo_api_client::Result<VerifiedSsoUser> {
             Ok(VerifiedSsoUser {
@@ -585,7 +585,7 @@ mod tests {
     impl TokenClient for MockApiClient {
         async fn get_metadata(
             &self,
-            token: &turborepo_api_client::SecretString,
+            token: &SecretString,
         ) -> turborepo_api_client::Result<ResponseTokenMetadata> {
             if token.expose() == "stale-token" {
                 return Err(turborepo_api_client::Error::InvalidToken {
@@ -605,10 +605,7 @@ mod tests {
                 client_id: None,
             })
         }
-        async fn delete_token(
-            &self,
-            _token: &turborepo_api_client::SecretString,
-        ) -> turborepo_api_client::Result<()> {
+        async fn delete_token(&self, _token: &SecretString) -> turborepo_api_client::Result<()> {
             Ok(())
         }
     }

--- a/crates/turborepo-auth/src/lib.rs
+++ b/crates/turborepo-auth/src/lib.rs
@@ -16,8 +16,9 @@ pub use device_flow::TokenSet;
 pub use error::Error;
 use serde::Deserialize;
 use turbopath::AbsoluteSystemPath;
-use turborepo_api_client::{CacheClient, Client, SecretString, TokenClient};
+use turborepo_api_client::{CacheClient, Client, TokenClient};
 use turborepo_json_rewrite::{set_path, unset_path};
+use turborepo_types::SecretString;
 use turborepo_vercel_api::{User, token::ResponseTokenMetadata};
 
 pub struct TeamInfo<'a> {

--- a/crates/turborepo-cache/Cargo.toml
+++ b/crates/turborepo-cache/Cargo.toml
@@ -51,6 +51,7 @@ turborepo-analytics = { workspace = true }
 turborepo-api-client = { workspace = true }
 turborepo-auth = { workspace = true }
 turborepo-log = { path = "../turborepo-log" }
+turborepo-types = { workspace = true }
 zstd = { version = "0.13.3", default-features = false }
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/turborepo-cache/src/async_cache.rs
+++ b/crates/turborepo-cache/src/async_cache.rs
@@ -237,7 +237,8 @@ mod tests {
     use futures::future::try_join_all;
     use tempfile::tempdir;
     use turbopath::AbsoluteSystemPathBuf;
-    use turborepo_api_client::{APIAuth, APIClient, SecretString};
+    use turborepo_api_client::{APIAuth, APIClient};
+    use turborepo_types::SecretString;
     use turborepo_vercel_api_mock::start_test_server;
 
     use crate::{

--- a/crates/turborepo-cache/src/fs.rs
+++ b/crates/turborepo-cache/src/fs.rs
@@ -438,7 +438,8 @@ mod test {
     use tempfile::tempdir;
     use turbopath::AnchoredSystemPath;
     use turborepo_analytics::start_analytics;
-    use turborepo_api_client::{APIAuth, APIClient, SecretString};
+    use turborepo_api_client::{APIAuth, APIClient};
+    use turborepo_types::SecretString;
     use turborepo_vercel_api_mock::start_test_server;
 
     use super::*;

--- a/crates/turborepo-cache/src/http.rs
+++ b/crates/turborepo-cache/src/http.rs
@@ -467,6 +467,7 @@ mod test {
     use turbopath::AbsoluteSystemPathBuf;
     use turborepo_analytics::start_analytics;
     use turborepo_api_client::{APIClient, analytics};
+    use turborepo_types::SecretString;
     use turborepo_vercel_api_mock::start_test_server;
 
     use crate::{

--- a/crates/turborepo-cache/src/http.rs
+++ b/crates/turborepo-cache/src/http.rs
@@ -12,6 +12,7 @@ use turborepo_api_client::{
     APIAuth, APIClient, CacheClient, Response,
     analytics::{self, AnalyticsEvent},
 };
+use turborepo_types::SecretString;
 
 use crate::{
     CacheError, CacheHitMetadata, CacheOpts, CacheSource, LazyScmState,
@@ -22,10 +23,7 @@ use crate::{
 
 pub type UploadMap = HashMap<String, UploadProgressQuery<10, 100>>;
 
-fn replace_api_auth_token(
-    api_auth: &mut APIAuth,
-    token: turborepo_api_client::SecretString,
-) -> bool {
+fn replace_api_auth_token(api_auth: &mut APIAuth, token: SecretString) -> bool {
     if api_auth.token.expose() == token.expose() {
         return false;
     }
@@ -468,7 +466,7 @@ mod test {
     use tempfile::tempdir;
     use turbopath::AbsoluteSystemPathBuf;
     use turborepo_analytics::start_analytics;
-    use turborepo_api_client::{APIClient, SecretString, analytics};
+    use turborepo_api_client::{APIClient, analytics};
     use turborepo_vercel_api_mock::start_test_server;
 
     use crate::{

--- a/crates/turborepo-config/src/lib.rs
+++ b/crates/turborepo-config/src/lib.rs
@@ -49,8 +49,8 @@ use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_cache::CacheConfig;
 use turborepo_repository::package_graph::PackageName;
 use turborepo_scm::WorktreeInfo;
-pub use turborepo_turbo_json::FutureFlags;
-pub use turborepo_types::{EnvMode, LogOrder, UIMode};
+use turborepo_turbo_json::FutureFlags;
+use turborepo_types::{EnvMode, LogOrder, UIMode};
 
 pub const CONFIG_FILE: &str = "turbo.json";
 pub const CONFIG_FILE_JSONC: &str = "turbo.jsonc";

--- a/crates/turborepo-engine/src/execute.rs
+++ b/crates/turborepo-engine/src/execute.rs
@@ -5,8 +5,7 @@ use tokio::sync::{Semaphore, mpsc, oneshot};
 use tracing::debug;
 use turborepo_graph_utils::Walker;
 use turborepo_task_id::TaskId;
-// Re-export StopExecution from turborepo-types for backwards compatibility
-pub use turborepo_types::StopExecution;
+use turborepo_types::StopExecution;
 
 use super::{Built, Engine, TaskDefinitionInfo, TaskNode};
 

--- a/crates/turborepo-engine/src/lib.rs
+++ b/crates/turborepo-engine/src/lib.rs
@@ -33,7 +33,7 @@ pub use builder_errors::{
     CyclicExtends, InvalidTaskNameError, MissingPackageFromTaskError, MissingPackageTaskError,
     MissingRootTaskInTurboJsonError, MissingTaskError, MissingTurboJsonExtends,
 };
-pub use execute::{ExecuteError, ExecutionOptions, Message, StopExecution};
+pub use execute::{ExecuteError, ExecutionOptions, Message};
 pub use graph_visualizer::{
     ChildProcess, ChildSpawner, Error as GraphVisualizerError, GraphvizWarningFn, NoOpChild,
     NoOpSpawner, write_graph,

--- a/crates/turborepo-hash/src/lib.rs
+++ b/crates/turborepo-hash/src/lib.rs
@@ -17,17 +17,7 @@ use capnp::{
 };
 pub use oid_hash::OidHash;
 pub use traits::TurboHash;
-// Re-export for backward compatibility. New code should import from `turborepo_types`.
-#[deprecated(
-    since = "2.4.0",
-    note = "Import `EnvMode` directly from `turborepo_types` instead"
-)]
-pub use turborepo_types::EnvMode;
-#[deprecated(
-    since = "2.4.0",
-    note = "Import `TaskOutputs` directly from `turborepo_types` instead"
-)]
-pub use turborepo_types::TaskOutputs;
+use turborepo_types::{EnvMode, TaskOutputs};
 
 #[allow(dead_code)]
 mod proto_capnp {

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -9,6 +9,7 @@ use tracing::{debug, error, log::warn};
 use turbopath::AbsoluteSystemPathBuf;
 use turborepo_api_client::SharedHttpClient;
 use turborepo_repository::inference::{RepoMode, RepoState};
+use turborepo_shim::TurboState;
 use turborepo_telemetry::{
     events::{command::CommandEventBuilder, generic::GenericEventBuilder, EventBuilder, EventType},
     init_telemetry, track_usage, TelemetryHandle,
@@ -26,7 +27,6 @@ use crate::{
     },
     get_version,
     run::watch::WatchClient,
-    shim::TurboState,
     tracing::TurboSubscriber,
 };
 

--- a/crates/turborepo-lib/src/commands/link.rs
+++ b/crates/turborepo-lib/src/commands/link.rs
@@ -20,6 +20,7 @@ use tracing::warn;
 use turborepo_api_client::{CacheClient, Client};
 use turborepo_gitignore::ensure_turbo_is_gitignored;
 use turborepo_json_rewrite::{set_path, unset_path, RewriteError};
+use turborepo_types::SecretString;
 #[cfg(not(test))]
 use turborepo_ui::CYAN;
 use turborepo_ui::{DialoguerTheme, BOLD, GREY};
@@ -89,11 +90,11 @@ fn is_auth_rejection_error(error: &turborepo_api_client::Error) -> bool {
 }
 
 async fn retry_with_recovered_token<T, F, Fut>(
-    token: &mut turborepo_api_client::SecretString,
+    token: &mut SecretString,
     operation: F,
 ) -> turborepo_api_client::Result<T>
 where
-    F: Fn(turborepo_api_client::SecretString) -> Fut,
+    F: Fn(SecretString) -> Fut,
     Fut: std::future::Future<Output = turborepo_api_client::Result<T>>,
 {
     match operation(token.clone()).await {
@@ -128,7 +129,7 @@ where
 pub(crate) async fn verify_caching_enabled<'a>(
     api_client: &(impl Client + CacheClient),
     team_id: &str,
-    token: &turborepo_api_client::SecretString,
+    token: &SecretString,
     selected_team: Option<SelectedTeam<'a>>,
 ) -> Result<(), Error> {
     let team_slug = selected_team.as_ref().and_then(|team| match team {
@@ -192,20 +193,19 @@ pub async fn link(
     let api_client = base.api_client()?;
 
     // Always try to get a valid token with automatic refresh if expired
-    let mut token: turborepo_api_client::SecretString =
-        match turborepo_auth::get_token_with_refresh().await {
-            Ok(Some(refreshed_token)) => refreshed_token,
-            Ok(None) | Err(_) => {
-                // Fall back to the token from config/CLI if refresh logic didn't work
-                base.opts()
-                    .api_client_opts
-                    .token
-                    .clone()
-                    .ok_or_else(|| Error::TokenNotFound {
-                        command: base.color_config.apply(BOLD.apply_to("`npx turbo login`")),
-                    })?
-            }
-        };
+    let mut token: SecretString = match turborepo_auth::get_token_with_refresh().await {
+        Ok(Some(refreshed_token)) => refreshed_token,
+        Ok(None) | Err(_) => {
+            // Fall back to the token from config/CLI if refresh logic didn't work
+            base.opts()
+                .api_client_opts
+                .token
+                .clone()
+                .ok_or_else(|| Error::TokenNotFound {
+                    command: base.color_config.apply(BOLD.apply_to("`npx turbo login`")),
+                })?
+        }
+    };
 
     println!(
         "\n{}\n\n{}\n\nFor more information, visit: {}\n",

--- a/crates/turborepo-lib/src/commands/login/manual.rs
+++ b/crates/turborepo-lib/src/commands/login/manual.rs
@@ -2,9 +2,10 @@ use turbopath::AbsoluteSystemPath;
 use turborepo_api_client::CacheClient;
 use turborepo_auth::Token;
 use turborepo_json_rewrite::set_path;
+use turborepo_types::APIClientOpts;
 
 use super::{write_token, Error};
-use crate::{commands::CommandBase, opts::APIClientOpts};
+use crate::commands::CommandBase;
 
 #[derive(Default, Debug, PartialEq)]
 struct ManualLoginOptions<'a> {

--- a/crates/turborepo-lib/src/commands/login/mod.rs
+++ b/crates/turborepo-lib/src/commands/login/mod.rs
@@ -7,6 +7,7 @@ use turborepo_auth::{
     TURBO_AUTH_FILE, TURBO_TOKEN_DIR,
 };
 use turborepo_telemetry::events::command::{CommandEventBuilder, LoginMethod};
+use turborepo_types::SecretString;
 
 use crate::commands::CommandBase;
 
@@ -147,7 +148,7 @@ fn write_token(
                 refresh_token: ts
                     .refresh_token
                     .as_ref()
-                    .map(|rt| turborepo_api_client::SecretString::new(rt.clone())),
+                    .map(|rt| SecretString::new(rt.clone())),
                 expires_at: Some(now_secs + ts.expires_in),
             }
         }
@@ -212,12 +213,8 @@ mod tests {
 
         let turbo_auth_path = config_root.join_components(&[TURBO_TOKEN_DIR, TURBO_AUTH_FILE]);
         AuthTokens {
-            token: Some(turborepo_api_client::SecretString::new(
-                "vca_stale_token".to_owned(),
-            )),
-            refresh_token: Some(turborepo_api_client::SecretString::new(
-                "stale_refresh_token".to_owned(),
-            )),
+            token: Some(SecretString::new("vca_stale_token".to_owned())),
+            refresh_token: Some(SecretString::new("stale_refresh_token".to_owned())),
             expires_at: Some(4_102_444_800),
         }
         .write_to_config_file(&turbo_auth_path)

--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -11,8 +11,6 @@ pub use turborepo_engine::{
 };
 use turborepo_repository::package_graph::{PackageGraph, PackageName};
 use turborepo_types::{TaskDefinition, UIMode};
-// Keep backward compatibility type alias
-pub type Error = BuilderError;
 
 /// Type alias for Engine specialized with TaskDefinition.
 /// This allows existing code to continue using `Engine` without type

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -5,16 +5,10 @@ use tracing::debug;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
 use turborepo_api_client::APIAuth;
 use turborepo_cache::{CacheOpts, RemoteCacheOpts};
-// Re-export RunCacheOpts from turborepo-run-cache
-pub use turborepo_run_cache::RunCacheOpts;
-use turborepo_run_summary::RunOptsInfo;
-// Re-export ScopeOpts from turborepo-scope to avoid duplication
-pub use turborepo_scope::ScopeOpts;
-// Re-export opts types from turborepo-types
-pub use turborepo_types::{APIClientOpts, RepoOpts, TuiOpts};
 use turborepo_types::{
-    ContinueMode, DryRunMode, EnvMode, GraphOpts, LogOrder, LogPrefix, ResolvedLogOrder,
-    ResolvedLogPrefix, TaskArgs, UIMode,
+    APIClientOpts, ContinueMode, DryRunMode, EnvMode, GraphOpts, LogOrder, LogPrefix, RepoOpts,
+    ResolvedLogOrder, ResolvedLogPrefix, RunCacheOpts, RunOptsInfo, ScopeOpts, TaskArgs, TuiOpts,
+    UIMode,
 };
 
 use crate::{

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -10,9 +10,7 @@ use notify::Event;
 use radix_trie::{Trie, TrieCommon};
 use tokio::sync::{broadcast, oneshot, Mutex};
 use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPath, AnchoredSystemPathBuf};
-// Re-export the PackageChangeEvent from turborepo-daemon
-pub use turborepo_daemon::PackageChangeEvent;
-use turborepo_daemon::PackageChangesWatcher as PackageChangesWatcherTrait;
+use turborepo_daemon::{PackageChangeEvent, PackageChangesWatcher as PackageChangesWatcherTrait};
 use turborepo_filewatch::{
     hash_watcher::{HashSpec, HashWatcher, InputGlobs},
     NotifyError, OptionalWatch,

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -24,6 +24,8 @@ use turborepo_repository::{
 };
 use turborepo_run_summary::observability;
 use turborepo_scm::SCM;
+use turborepo_scope::filter::ResolutionError;
+use turborepo_shim::TurboState;
 use turborepo_signals::SignalHandler;
 use turborepo_task_id::TaskName;
 use turborepo_telemetry::events::{
@@ -32,7 +34,7 @@ use turborepo_telemetry::events::{
     repo::{RepoEventBuilder, RepoType},
     EventBuilder, TrackedErrors,
 };
-use turborepo_types::UIMode;
+use turborepo_types::{FilterMode, UIMode};
 use turborepo_ui::ColorConfig;
 use turborepo_vercel_api::CachingStatusResponse;
 use url::Url;
@@ -46,7 +48,6 @@ use crate::{
         scope, task_access::TaskAccess, Error, RemoteCacheStatus, RemoteCacheUnavailableReason,
         Run, RunCache,
     },
-    shim::TurboState,
     turbo_json::{TurboJson, TurboJsonReader, UnifiedTurboJsonLoader},
 };
 
@@ -354,9 +355,9 @@ impl RunBuilder {
         )?;
 
         let should_include_root_tasks = match filter_mode {
-            scope::FilterMode::AllPackages => true,
-            scope::FilterMode::ExcludeOnly { root_excluded } => !root_excluded,
-            scope::FilterMode::ExplicitSelection => false,
+            FilterMode::AllPackages => true,
+            FilterMode::ExcludeOnly { root_excluded } => !root_excluded,
+            FilterMode::ExplicitSelection => false,
         };
 
         if should_include_root_tasks {
@@ -378,7 +379,7 @@ impl RunBuilder {
             }
         }
 
-        if matches!(filter_mode, scope::FilterMode::AllPackages) {
+        if matches!(filter_mode, FilterMode::AllPackages) {
             // When all tasks use package#task syntax, we can narrow the package
             // set to only the referenced packages rather than the entire monorepo.
             let task_names: Vec<TaskName> = opts
@@ -760,7 +761,7 @@ impl RunBuilder {
                 .iter()
                 .map(|p| p.parse())
                 .collect::<Result<_, _>>()
-                .map_err(turborepo_scope::ResolutionError::from)?;
+                .map_err(ResolutionError::from)?;
 
             let affected_constraint =
                 if let Some(affected_range) = &self.opts.scope_opts.affected_range {

--- a/crates/turborepo-lib/src/run/error.rs
+++ b/crates/turborepo-lib/src/run/error.rs
@@ -3,9 +3,11 @@ use thiserror::Error;
 use turborepo_daemon::{DaemonConnectorError, DaemonError};
 use turborepo_engine::GraphVisualizerError;
 use turborepo_repository::package_graph;
+use turborepo_scope::filter::ResolutionError;
+use turborepo_task_hash::{global_hash, Error as TaskHashError};
 use turborepo_ui::tui;
 
-use crate::{config, engine, engine::ValidateError, opts, run::scope, task_graph, task_hash};
+use crate::{config, engine, engine::ValidateError, opts, task_graph};
 
 #[derive(Debug, Error, Diagnostic)]
 pub enum Error {
@@ -39,11 +41,11 @@ pub enum Error {
     #[error(transparent)]
     Path(#[from] turbopath::PathError),
     #[error(transparent)]
-    Scope(#[from] scope::ResolutionError),
+    Scope(#[from] ResolutionError),
     #[error(transparent)]
-    GlobalHash(#[from] task_hash::global_hash::Error),
+    GlobalHash(#[from] global_hash::Error),
     #[error(transparent)]
-    TaskHash(#[from] task_hash::Error),
+    TaskHash(#[from] TaskHashError),
     #[error(transparent)]
     #[diagnostic(transparent)]
     Visitor(#[from] task_graph::VisitorError),

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -38,6 +38,10 @@ pub use turborepo_run_cache::{ConfigCache, RunCache, TaskCache};
 use turborepo_run_summary::{ObservabilityHandle, RunTracker};
 use turborepo_scm::{RepoGitIndex, SCM};
 use turborepo_signals::{listeners::get_signal, ShutdownReason, SignalHandler};
+use turborepo_task_hash::{
+    collect_global_file_hash_inputs, get_external_deps_hash, get_internal_deps_hash,
+    global_hash::GLOBAL_CACHE_KEY, GlobalHashableInputs, PackageInputsHashes,
+};
 use turborepo_telemetry::events::generic::GenericEventBuilder;
 use turborepo_types::{EnvMode, UIMode};
 use turborepo_ui::{sender::UISender, tui, tui::TuiSender, wui::sender::WebUISender, ColorConfig};
@@ -49,10 +53,6 @@ use crate::{
     opts::{Opts, RemoteCacheDisabledReason},
     run::task_access::TaskAccess,
     task_graph::Visitor,
-    task_hash::{
-        collect_global_file_hash_inputs, get_external_deps_hash, get_internal_deps_hash,
-        global_hash::GLOBAL_CACHE_KEY, GlobalHashableInputs, PackageInputsHashes,
-    },
     turbo_json::{TurboJson, UnifiedTurboJsonLoader},
 };
 

--- a/crates/turborepo-lib/src/run/scope/mod.rs
+++ b/crates/turborepo-lib/src/run/scope/mod.rs
@@ -1,7 +1,7 @@
 //! Package scope resolution.
 //!
 //! This module delegates to the `turborepo_scope` crate for all scope
-//! resolution logic. Re-exports are provided for backward compatibility.
+//! resolution logic.
 
 use std::collections::HashMap;
 
@@ -11,7 +11,8 @@ use turborepo_repository::{
     package_graph::{PackageGraph, PackageName},
 };
 use turborepo_scm::SCM;
-pub use turborepo_scope::{filter::ResolutionError, target_selector, FilterMode, ScopeOpts};
+use turborepo_scope::filter::ResolutionError;
+use turborepo_types::{FilterMode, ScopeOpts};
 
 use crate::turbo_json::TurboJson;
 

--- a/crates/turborepo-lib/src/run/task_access.rs
+++ b/crates/turborepo-lib/src/run/task_access.rs
@@ -12,8 +12,7 @@ use turborepo_cache::AsyncCache;
 use turborepo_gitignore::ensure_turbo_is_gitignored;
 use turborepo_scm::SCM;
 use turborepo_task_executor::TaskAccessProvider;
-// Re-export from turborepo-turbo-json
-pub use turborepo_turbo_json::TASK_ACCESS_CONFIG_PATH;
+use turborepo_turbo_json::TASK_ACCESS_CONFIG_PATH;
 use turborepo_unescape::UnescapedString;
 
 use super::ConfigCache;

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -23,6 +23,7 @@ use turborepo_filewatch::{
 use turborepo_repository::package_graph::PackageName;
 use turborepo_run_cache::{OutputWatcher, OutputWatcherError};
 use turborepo_scm::SCM;
+use turborepo_scope::target_selector::InvalidSelectorError;
 use turborepo_signals::{listeners::get_signal, SignalHandler};
 use turborepo_telemetry::events::command::CommandEventBuilder;
 use turborepo_ui::{sender::UISender, LogSinks};
@@ -33,7 +34,7 @@ use crate::{
     engine::{EngineExt, TaskNode},
     get_version, opts,
     package_changes_watcher::PackageChangesWatcher,
-    run::{self, builder::RunBuilder, scope::target_selector::InvalidSelectorError, Run},
+    run::{self, builder::RunBuilder, Run},
 };
 
 #[derive(Debug)]

--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -1,8 +1,7 @@
 //! Shim module for turborepo-lib.
 //!
 //! This module provides the integration between the `turborepo-shim` crate and
-//! `turborepo-lib`. It implements the traits required by the shim and
-//! re-exports types for backward compatibility.
+//! `turborepo-lib`. It implements the traits required by the shim.
 
 use std::sync::Arc;
 
@@ -11,13 +10,9 @@ use shared_child::SharedChild;
 use thiserror::Error;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 use turborepo_repository::inference::RepoState;
-// Re-export types from turborepo-shim for backward compatibility.
-// These exports are used by other parts of turborepo-lib and external code.
-#[allow(unused_imports)]
-pub use turborepo_shim::{turbo_version_has_shim, ShimArgs, TurboState, INVOCATION_DIR_ENV_VAR};
 use turborepo_shim::{
-    ChildSpawner, ConfigProvider, ShimConfigurationOptions, ShimResult, ShimRuntime, TurboRunner,
-    VersionProvider,
+    ChildSpawner, ConfigProvider, ShimArgs, ShimConfigurationOptions, ShimResult, ShimRuntime,
+    TurboRunner, VersionProvider,
 };
 use turborepo_ui::ColorConfig;
 

--- a/crates/turborepo-lib/src/task_graph/visitor/exec.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/exec.rs
@@ -10,6 +10,7 @@ use turborepo_engine::{TaskError, TaskErrorCollectorWrapper, TaskWarningCollecto
 use turborepo_env::{platform::PlatformEnv, EnvironmentVariableMap};
 use turborepo_process::ProcessManager;
 use turborepo_task_executor::{DryRunExecutor, TaskExecutor};
+use turborepo_task_hash::TaskHashTracker;
 use turborepo_task_id::TaskId;
 
 use super::{
@@ -19,7 +20,6 @@ use super::{
 use crate::{
     engine::Engine,
     run::{task_access::TaskAccess, TaskCache},
-    task_hash::TaskHashTracker,
 };
 
 /// Type alias for the concrete TaskExecutor used in turborepo-lib.

--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -23,8 +23,10 @@ use turborepo_process::ProcessManager;
 use turborepo_repository::package_graph::{PackageGraph, PackageName, ROOT_PKG_NAME};
 use turborepo_run_summary::{self as summary, GlobalHashSummary, RunTracker, TaskTracker};
 use turborepo_scm::SCM;
-// Re-export output types and shared functions from turborepo-task-executor
-pub use turborepo_task_executor::{turbo_regex, TaskOutput};
+use turborepo_task_executor::{turbo_regex, TaskOutput};
+use turborepo_task_hash::{
+    Error as TaskHashError, GlobalHashableInputs, PackageInputsHashes, TaskHashTrackerState,
+};
 use turborepo_task_id::TaskId;
 use turborepo_telemetry::events::{
     generic::GenericEventBuilder, task::PackageTaskEventBuilder, EventBuilder, TrackedErrors,
@@ -37,9 +39,7 @@ use crate::{
     microfrontends::MicrofrontendsConfigs,
     opts::RunOpts,
     run::{task_access::TaskAccess, RunCache},
-    task_hash::{
-        self, GlobalHashableInputs, PackageInputsHashes, TaskHashTrackerState, TaskHasher,
-    },
+    task_hash::TaskHasher,
 };
 
 // This holds the whole world
@@ -100,7 +100,7 @@ pub enum Error {
     #[error("Error while executing engine: {0}")]
     Engine(#[from] crate::engine::ExecuteError),
     #[error(transparent)]
-    TaskHash(#[from] task_hash::Error),
+    TaskHash(#[from] TaskHashError),
     #[error(transparent)]
     RunSummary(#[from] summary::Error),
     #[error("Internal errors encountered: {0}")]

--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -1,13 +1,6 @@
 //! Task hashing module - delegates to turborepo-task-hash crate.
 //!
-//! This module re-exports types from turborepo-task-hash and provides
-//! trait implementations for turborepo-lib types.
-
-// Re-export all public types from turborepo-task-hash
-pub use turborepo_task_hash::{
-    collect_global_file_hash_inputs, get_external_deps_hash, get_internal_deps_hash, global_hash,
-    Error, GlobalHashableInputs, PackageInputsHashes, TaskHashTracker, TaskHashTrackerState,
-};
+//! This module provides trait implementations for turborepo-lib types.
 
 use crate::opts::RunOpts;
 
@@ -31,6 +24,8 @@ pub type TaskHasher<'a> = turborepo_task_hash::TaskHasher<'a, RunOpts>;
 
 #[cfg(test)]
 mod test {
+    use turborepo_task_hash::TaskHashTracker;
+
     use super::*;
 
     #[test]

--- a/crates/turborepo-lib/src/task_hash.rs
+++ b/crates/turborepo-lib/src/task_hash.rs
@@ -26,8 +26,6 @@ pub type TaskHasher<'a> = turborepo_task_hash::TaskHasher<'a, RunOpts>;
 mod test {
     use turborepo_task_hash::TaskHashTracker;
 
-    use super::*;
-
     #[test]
     fn test_hash_tracker_is_send_and_sync() {
         // We need the tracker to implement these traits as multiple tasks will query

--- a/crates/turborepo-run-cache/src/lib.rs
+++ b/crates/turborepo-run-cache/src/lib.rs
@@ -31,10 +31,8 @@ use turborepo_repository::package_graph::PackageInfo;
 use turborepo_scm::SCM;
 use turborepo_task_id::TaskId;
 use turborepo_telemetry::events::{TrackedErrors, task::PackageTaskEventBuilder};
-// Re-export for backwards compatibility
-pub use turborepo_types::RunCacheOpts;
 use turborepo_types::{
-    OutputLogsMode, TaskDefinition, TaskDefinitionExt, TaskOutputs, TaskOutputsExt,
+    OutputLogsMode, RunCacheOpts, TaskDefinition, TaskDefinitionExt, TaskOutputs, TaskOutputsExt,
 };
 use turborepo_ui::{ColorConfig, GREY, LogWriter, color, tui::event::CacheResult};
 

--- a/crates/turborepo-run-summary/src/lib.rs
+++ b/crates/turborepo-run-summary/src/lib.rs
@@ -27,11 +27,3 @@ pub use task::{
 };
 pub use task_factory::{Error as TaskFactoryError, TaskSummaryFactory, get_external_deps_hash};
 pub use tracker::{Error, RunSummary, RunTracker, SinglePackageRunSummary};
-// Re-export traits from turborepo-types for convenience
-// These traits are defined in turborepo-types to enable proper dependency direction:
-// infrastructure crates (turborepo-engine, turborepo-task-hash) can implement these
-// traits without depending on this crate.
-pub use turborepo_types::{
-    EngineInfo, GlobalHashInputs, HashTrackerCacheHitMetadata, HashTrackerDetailedMap,
-    HashTrackerInfo, RunOptsInfo,
-};

--- a/crates/turborepo-run-summary/src/task_factory.rs
+++ b/crates/turborepo-run-summary/src/task_factory.rs
@@ -5,10 +5,12 @@ use turborepo_env::EnvironmentVariableMap;
 use turborepo_lockfiles::Package;
 use turborepo_repository::package_graph::{PackageGraph, PackageInfo, PackageName};
 use turborepo_task_id::TaskId;
-use turborepo_types::{EnvMode, LOG_DIR, TaskDefinition, task_log_filename};
+use turborepo_types::{
+    EngineInfo, EnvMode, HashTrackerInfo, LOG_DIR, RunOptsInfo, TaskDefinition, task_log_filename,
+};
 
 use crate::{
-    EngineInfo, HashTrackerInfo, RunOptsInfo, TaskExecutionSummary,
+    TaskExecutionSummary,
     task::{
         SharedTaskSummary, SinglePackageTaskSummary, TaskCacheSummary, TaskEnvVarSummary,
         TaskSummary,

--- a/crates/turborepo-run-summary/src/tracker.rs
+++ b/crates/turborepo-run-summary/src/tracker.rs
@@ -17,11 +17,11 @@ use turborepo_env::EnvironmentVariableMap;
 use turborepo_repository::package_graph::{PackageGraph, PackageName};
 use turborepo_scm::SCM;
 use turborepo_task_id::TaskId;
-use turborepo_types::{DryRunMode, EnvMode};
+use turborepo_types::{DryRunMode, EngineInfo, EnvMode, HashTrackerInfo, RunOptsInfo};
 use turborepo_ui::{BOLD, BOLD_CYAN, ColorConfig, GREY, color, cprintln, cwriteln};
 
 use crate::{
-    EngineInfo, GlobalHashSummary, HashTrackerInfo, RunOptsInfo, SCMState, TaskTracker,
+    GlobalHashSummary, SCMState, TaskTracker,
     execution::{ExecutionSummary, ExecutionTracker, TaskState},
     observability::Handle as ObservabilityHandle,
     task::{SinglePackageTaskSummary, TaskSummary},

--- a/crates/turborepo-scope/src/lib.rs
+++ b/crates/turborepo-scope/src/lib.rs
@@ -31,7 +31,7 @@ use turborepo_repository::{
     package_graph::{PackageGraph, PackageName},
 };
 use turborepo_scm::SCM;
-pub use turborepo_types::{FilterMode, ScopeOpts};
+use turborepo_types::{FilterMode, ScopeOpts};
 
 /// Resolve which packages should be included in the run based on scope options.
 ///

--- a/crates/turborepo-task-executor/src/lib.rs
+++ b/crates/turborepo-task-executor/src/lib.rs
@@ -38,8 +38,6 @@ pub use output::{StdWriter, TaskOutput};
 use serde::Serialize;
 use turbopath::AbsoluteSystemPathBuf;
 use turborepo_task_id::TaskId;
-// Re-export StopExecution from turborepo-types for convenience
-pub use turborepo_types::StopExecution;
 use turborepo_types::{ContinueMode, EnvMode, ResolvedLogOrder, ResolvedLogPrefix, UIMode};
 pub use visitor::{
     EngineExecutor, EngineMessage, EngineProvider, TaskCallback, TaskHashProvider, turbo_regex,

--- a/crates/turborepo-task-hash/src/global_hash.rs
+++ b/crates/turborepo-task-hash/src/global_hash.rs
@@ -16,11 +16,9 @@ use turborepo_repository::{
     package_graph::PackageInfo,
     package_manager::{self, PackageManager},
 };
-use turborepo_run_summary::{
-    GlobalEnvVarSummary, GlobalHashInputs as GlobalHashInputsTrait, GlobalHashSummary,
-};
+use turborepo_run_summary::{GlobalEnvVarSummary, GlobalHashSummary};
 use turborepo_scm::SCM;
-use turborepo_types::EnvMode;
+use turborepo_types::{EnvMode, GlobalHashInputs as GlobalHashInputsTrait};
 
 #[allow(dead_code)]
 static DEFAULT_ENV_VARS: [&str; 1] = ["VERCEL_ANALYTICS_ID"];

--- a/crates/turborepo-task-hash/src/lib.rs
+++ b/crates/turborepo-task-hash/src/lib.rs
@@ -22,8 +22,7 @@ use turbopath::{
     AbsoluteSystemPath, AnchoredSystemPath, AnchoredSystemPathBuf, RelativeUnixPathBuf,
 };
 use turborepo_cache::CacheHitMetadata;
-// Re-export turborepo_engine::TaskNode for convenience
-pub use turborepo_engine::TaskNode;
+use turborepo_engine::TaskNode;
 use turborepo_env::{
     BUILTIN_PASS_THROUGH_ENV, BySource, CompiledWildcards, DetailedMap, EnvironmentVariableMap,
 };


### PR DESCRIPTION
## Why
These crates are internal to the repo, so keeping compatibility re-exports creates extra import paths without a real consumer benefit. Removing them makes ownership of shared types clearer and avoids new code depending on stale facades.

## What
- Removed Rust re-exports that only forwarded types from their owning crates.
- Updated in-repo call sites to import directly from the owning crate.
- Added explicit `turborepo-types` dependencies where crates now import `SecretString` directly.

## How
Verified with `cargo fmt`, targeted `cargo check` runs, and the pre-push hook. The first two push attempts exposed test-target imports that were fixed in follow-up commits.