### PR TITLE
test: Deflake Corepack prepare lock on Windows

### DIFF
--- a/crates/turborepo/tests/common/setup.rs
+++ b/crates/turborepo/tests/common/setup.rs
@@ -448,20 +448,28 @@ where
     loop {
         match fs::create_dir(&lock_dir) {
             Ok(()) => break,
-            Err(e) if e.kind() == ErrorKind::AlreadyExists => {
-                if is_stale_lock(&lock_dir, STALE_LOCK_AGE) {
+            Err(e) => {
+                let lock_exists = e.kind() == ErrorKind::AlreadyExists;
+                // Windows can report access denied while another test process is
+                // removing the directory lock. Treat it as contention and retry.
+                let access_denied_during_lock_transition =
+                    cfg!(windows) && e.kind() == ErrorKind::PermissionDenied;
+                if !lock_exists && !access_denied_during_lock_transition {
+                    return Err(e.into());
+                }
+
+                if lock_exists && is_stale_lock(&lock_dir, STALE_LOCK_AGE) {
                     let _ = fs::remove_dir_all(&lock_dir);
                     continue;
                 }
                 if start.elapsed() > LOCK_TIMEOUT {
                     anyhow::bail!(
-                        "timed out waiting for Corepack prepare lock: {}",
-                        lock_dir.display()
+                        "timed out waiting for Corepack prepare lock: {} ({e})",
+                        lock_dir.display(),
                     );
                 }
                 thread::sleep(Duration::from_millis(100));
             }
-            Err(e) => return Err(e.into()),
         }
     }
 


### PR DESCRIPTION
## Why
Windows CI can report `Access is denied` while parallel Rust tests contend over the shared Corepack prepare directory lock. That fails unrelated integration tests before they exercise their assertions.

## What
Treat transient Windows `PermissionDenied` during Corepack lock acquisition as lock contention and retry until the existing timeout. Non-lock errors still fail immediately.

## How
Verified with:
- `cargo nextest run -p turbo --test affected_test test_affected_dependency_changed`
- pre-push hook: `pnpm exec lint-staged`, `turbo run format check:toml`, `cargo fmt --check`, `cargo lint`, `cargo check --workspace`