### PR TITLE
fix: Remove signals panic callsites

### DIFF
--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -693,7 +693,10 @@ impl Run {
             let shutdown_started_emitted = self.shutdown_started_emitted.clone();
             tokio::spawn(async move {
                 info!("Proxy signal handler registered and waiting");
-                let _guard = subscriber.listen().await;
+                let Ok(_guard) = subscriber.listen().await else {
+                    debug!("proxy signal handler exited before notifying subscriber");
+                    return;
+                };
 
                 let shutdown_reason = signal_handler.shutdown_reason();
 
@@ -768,7 +771,12 @@ impl Run {
         let shutdown_started_emitted = self.shutdown_started_emitted.clone();
         let use_tui = self.opts.run_opts.ui_mode.use_tui();
         tokio::spawn(async move {
-            let _guard = subscriber.listen().await;
+            let Ok(_guard) = subscriber.listen().await else {
+                tracing::debug!(
+                    "signal handler exited before cache shutdown subscriber was notified"
+                );
+                return;
+            };
             let shutdown_reason = signal_handler.shutdown_reason();
 
             if shutdown_reason == Some(ShutdownReason::Signal) {
@@ -859,7 +867,10 @@ impl Run {
         let force_shutdown_timeout = Self::force_shutdown_timeout();
         let shutdown_started_emitted = self.shutdown_started_emitted.clone();
         tokio::spawn(async move {
-            let _guard = subscriber.listen().await;
+            let Ok(_guard) = subscriber.listen().await else {
+                debug!("signal handler exited before process manager subscriber was notified");
+                return;
+            };
             let shutdown_reason = signal_handler.shutdown_reason();
 
             if shutdown_reason != Some(ShutdownReason::Signal) {

--- a/crates/turborepo-signals/src/lib.rs
+++ b/crates/turborepo-signals/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(clippy::all)]
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 
 //! A crate for registering listeners for a given signal
 
@@ -50,6 +50,12 @@ struct HandlerState {
 
 pub struct SignalSubscriber(oneshot::Receiver<oneshot::Sender<Signal>>);
 
+#[derive(Debug, thiserror::Error)]
+pub enum ListenError {
+    #[error("signal handler worker exited before alerting subscriber")]
+    WorkerExited,
+}
+
 /// SubscriberGuard should be kept until a subscriber is done processing the
 /// signal
 pub struct SubscriberGuard {
@@ -84,7 +90,9 @@ impl SignalHandler {
             worker_started.notify_waiters();
 
             let mut callbacks = {
-                let mut state = worker_state.lock().expect("lock poisoned");
+                let mut state = worker_state
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
                 // Mark ourselves as closing to prevent any additional subscribers from being
                 // added
                 state.is_closing = true;
@@ -118,7 +126,7 @@ impl SignalHandler {
     pub fn subscribe(&self) -> Option<SignalSubscriber> {
         self.state
             .lock()
-            .expect("poisoned lock")
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
             .add_subscriber()
             .map(SignalSubscriber)
     }
@@ -181,12 +189,9 @@ impl SignalHandler {
 
 impl SignalSubscriber {
     /// Wait until signal is received by the signal handler
-    pub async fn listen(self) -> SubscriberGuard {
-        let _guard = self
-            .0
-            .await
-            .expect("signal handler worker thread exited without alerting subscribers");
-        SubscriberGuard { _guard }
+    pub async fn listen(self) -> Result<SubscriberGuard, ListenError> {
+        let _guard = self.0.await.map_err(|_| ListenError::WorkerExited)?;
+        Ok(SubscriberGuard { _guard })
     }
 }
 


### PR DESCRIPTION
## Why

`turborepo-signals` still allowed `clippy::expect_used` and `clippy::unwrap_used` in implementation code. That keeps the crate outside the Rust panic-extraction policy and hides a real failure mode when signal subscriber notification fails.

## What

- Makes `SignalSubscriber::listen` return a `Result` instead of panicking when the worker exits early.
- Recovers poisoned mutex state instead of panicking while registering or notifying subscribers.
- Narrows panic lint allowances to tests.

## How

Verified with:

- `cargo fmt --package turborepo-signals --package turborepo-lib --package turborepo-query`
- `cargo test --package turborepo-signals`
- `cargo clippy --package turborepo-signals --package turborepo-lib --package turborepo-query --all-targets -- -D warnings`
- pre-push hook

Closes TURBO-5621
Closes TURBO-5657
