### PR TITLE
fix: Remove `turbo-trace`'s `expect()` allow

### DIFF
--- a/crates/turbo-trace/src/lib.rs
+++ b/crates/turbo-trace/src/lib.rs
@@ -5,7 +5,6 @@
 // miette's derive macro causes false positives for this lint
 #![allow(unused_assignments)]
 #![deny(clippy::all)]
-#![allow(clippy::expect_used)]
 mod import_finder;
 mod tracer;
 

--- a/crates/turbo-trace/src/tracer.rs
+++ b/crates/turbo-trace/src/tracer.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, fmt, sync::Arc};
 
 use camino::{Utf8Path, Utf8PathBuf};
-use globwalk::WalkType;
+use globwalk::{ValidatedGlob, WalkType};
 use miette::{Diagnostic, Report, SourceSpan};
 use oxc_allocator::Allocator;
 use oxc_estree::{CompactTSSerializer, ESTree};
@@ -58,6 +58,8 @@ pub enum TraceError {
     },
     #[error("failed to walk files")]
     GlobError(Arc<globwalk::WalkError>),
+    #[error("failed to parse trace glob: {0}")]
+    InvalidTraceGlob(String),
     #[error("trace task failed to complete: {0}")]
     TaskJoinError(String),
 }
@@ -394,29 +396,49 @@ impl Tracer {
         }
     }
 
+    fn parse_trace_globs(patterns: &[&str]) -> Result<Vec<ValidatedGlob>, TraceError> {
+        patterns
+            .iter()
+            .map(|pattern| {
+                pattern
+                    .parse::<ValidatedGlob>()
+                    .map_err(|err| TraceError::InvalidTraceGlob(err.to_string()))
+            })
+            .collect()
+    }
+
     pub async fn reverse_trace(self) -> TraceResult {
-        let files = match globwalk::globwalk(
-            &self.cwd,
-            &[
-                "**/*.js".parse().expect("valid glob"),
-                "**/*.jsx".parse().expect("valid glob"),
-                "**/*.ts".parse().expect("valid glob"),
-                "**/*.tsx".parse().expect("valid glob"),
-            ],
-            &[
-                "**/node_modules/**".parse().expect("valid glob"),
-                "**/.next/**".parse().expect("valid glob"),
-            ],
-            WalkType::Files,
-        ) {
-            Ok(files) => files,
-            Err(e) => {
+        let include_globs =
+            match Self::parse_trace_globs(&["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]) {
+                Ok(globs) => globs,
+                Err(error) => {
+                    return TraceResult {
+                        files: HashMap::new(),
+                        errors: vec![error],
+                    };
+                }
+            };
+
+        let exclude_globs = match Self::parse_trace_globs(&["**/node_modules/**", "**/.next/**"]) {
+            Ok(globs) => globs,
+            Err(error) => {
                 return TraceResult {
                     files: HashMap::new(),
-                    errors: vec![TraceError::GlobError(Arc::new(e))],
+                    errors: vec![error],
                 };
             }
         };
+
+        let files =
+            match globwalk::globwalk(&self.cwd, &include_globs, &exclude_globs, WalkType::Files) {
+                Ok(files) => files,
+                Err(e) => {
+                    return TraceResult {
+                        files: HashMap::new(),
+                        errors: vec![TraceError::GlobError(Arc::new(e))],
+                    };
+                }
+            };
 
         let mut futures = JoinSet::new();
 

--- a/crates/turborepo-query/src/file.rs
+++ b/crates/turborepo-query/src/file.rs
@@ -71,6 +71,10 @@ impl From<turbo_trace::TraceError> for Diagnostic {
                 message: format!("failed to glob files: {err}"),
                 ..Default::default()
             },
+            turbo_trace::TraceError::InvalidTraceGlob(_) => Diagnostic {
+                message,
+                ..Default::default()
+            },
             turbo_trace::TraceError::TaskJoinError(_) => Diagnostic {
                 message,
                 ..Default::default()


### PR DESCRIPTION
## Why

`turbo-trace` still allowed implementation `.expect()` usage for reverse-trace glob setup. That kept TURBO-5590 open and left a panic path where trace errors should be reported as diagnostics.

Closes TURBO-5590

## What

Hardens reverse-trace glob parsing so failures are returned through `TraceResult.errors`, then keeps the downstream query diagnostic conversion exhaustive for the new trace error.

## How

- `cargo fmt -p turbo-trace`
- `cargo test -p turbo-trace`
- `cargo clippy -p turbo-trace --all-targets -- -D warnings`
- `cargo fmt -p turborepo-query`
- `cargo clippy -p turborepo-query --all-targets -- -D warnings`
- `cargo test -p turborepo-query`
- Pre-push hook passed with format, check:toml, and Rust checks