### PR TITLE
fix: Remove Vercel API mock unwrap usage

### DIFF
--- a/crates/turborepo-vercel-api-mock/src/lib.rs
+++ b/crates/turborepo-vercel-api-mock/src/lib.rs
@@ -1,7 +1,6 @@
 //! Mock server implementation for a subset of the Vercel API.
 
 #![deny(clippy::all)]
-#![allow(clippy::unwrap_used)]
 
 use std::{collections::HashMap, fs::OpenOptions, io::Write, net::SocketAddr, sync::Arc};
 
@@ -139,11 +138,20 @@ pub async fn start_test_server(
                 |Path(hash): Path<String>, headers: HeaderMap, body: Body| async move {
                     let root_path = put_tempdir_ref.path();
                     let file_path = root_path.join(&hash);
-                    let mut file = OpenOptions::new()
+                    let mut file = match OpenOptions::new()
                         .append(true)
                         .create(true)
                         .open(&file_path)
-                        .unwrap();
+                    {
+                        Ok(file) => file,
+                        Err(err) => {
+                            return (
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                format!("failed to open artifact file: {err}"),
+                            )
+                                .into_response();
+                        }
+                    };
 
                     let Some(duration) = headers
                         .get("x-artifact-duration")
@@ -157,10 +165,10 @@ pub async fn start_test_server(
                             .into_response();
                     };
 
-                    assert!(
-                        headers.get(CONTENT_LENGTH).is_some(),
-                        "expected to get content-length"
-                    );
+                    if headers.get(CONTENT_LENGTH).is_none() {
+                        return (StatusCode::BAD_REQUEST, "content-length header is missing")
+                            .into_response();
+                    }
 
                     let mut durations_map = put_durations_ref.lock().await;
                     durations_map.insert(hash.clone(), duration);
@@ -180,8 +188,23 @@ pub async fn start_test_server(
 
                     let mut body_stream = body.into_data_stream();
                     while let Some(item) = body_stream.next().await {
-                        let chunk = item.unwrap();
-                        file.write_all(&chunk).unwrap();
+                        let chunk = match item {
+                            Ok(chunk) => chunk,
+                            Err(err) => {
+                                return (
+                                    StatusCode::BAD_REQUEST,
+                                    format!("failed to read artifact body: {err}"),
+                                )
+                                    .into_response();
+                            }
+                        };
+                        if let Err(err) = file.write_all(&chunk) {
+                            return (
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                format!("failed to write artifact body: {err}"),
+                            )
+                                .into_response();
+                        }
                     }
 
                     (StatusCode::CREATED, Json(hash)).into_response()
@@ -204,20 +227,28 @@ pub async fn start_test_server(
                     .unwrap_or(0);
                 let mut headers = HeaderMap::new();
 
-                headers.insert(
-                    "x-artifact-duration",
-                    HeaderValue::from_str(&duration.to_string()).unwrap(),
-                );
+                headers.insert("x-artifact-duration", HeaderValue::from(duration));
 
                 if let Some((sha, dirty_hash)) = get_metadata_ref.lock().await.get(&hash).cloned() {
                     if let Some(sha) = sha {
-                        headers.insert("x-artifact-sha", HeaderValue::from_str(&sha).unwrap());
+                        let Ok(value) = HeaderValue::from_str(&sha) else {
+                            return (
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                HeaderMap::new(),
+                                Vec::new(),
+                            );
+                        };
+                        headers.insert("x-artifact-sha", value);
                     }
                     if let Some(dirty_hash) = dirty_hash {
-                        headers.insert(
-                            "x-artifact-dirty-hash",
-                            HeaderValue::from_str(&dirty_hash).unwrap(),
-                        );
+                        let Ok(value) = HeaderValue::from_str(&dirty_hash) else {
+                            return (
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                HeaderMap::new(),
+                                Vec::new(),
+                            );
+                        };
+                        headers.insert("x-artifact-dirty-hash", value);
                     }
                 }
 
@@ -233,21 +264,21 @@ pub async fn start_test_server(
                     return (StatusCode::NOT_FOUND, headers);
                 };
 
-                headers.insert(
-                    "x-artifact-duration",
-                    HeaderValue::from_str(&duration.to_string()).unwrap(),
-                );
+                headers.insert("x-artifact-duration", HeaderValue::from(duration));
 
                 if let Some((sha, dirty_hash)) = head_metadata_ref.lock().await.get(&hash).cloned()
                 {
                     if let Some(sha) = sha {
-                        headers.insert("x-artifact-sha", HeaderValue::from_str(&sha).unwrap());
+                        let Ok(value) = HeaderValue::from_str(&sha) else {
+                            return (StatusCode::INTERNAL_SERVER_ERROR, HeaderMap::new());
+                        };
+                        headers.insert("x-artifact-sha", value);
                     }
                     if let Some(dirty_hash) = dirty_hash {
-                        headers.insert(
-                            "x-artifact-dirty-hash",
-                            HeaderValue::from_str(&dirty_hash).unwrap(),
-                        );
+                        let Ok(value) = HeaderValue::from_str(&dirty_hash) else {
+                            return (StatusCode::INTERNAL_SERVER_ERROR, HeaderMap::new());
+                        };
+                        headers.insert("x-artifact-dirty-hash", value);
                     }
                 }
 
@@ -273,7 +304,10 @@ pub async fn start_test_server(
             "/preflight/absolute-location",
             options(|| async {
                 let mut headers = HeaderMap::new();
-                headers.insert("Location", "http://example.com/about".parse().unwrap());
+                headers.insert(
+                    "Location",
+                    HeaderValue::from_static("http://example.com/about"),
+                );
 
                 headers
             }),
@@ -282,7 +316,7 @@ pub async fn start_test_server(
             "/preflight/relative-location",
             options(|| async {
                 let mut headers = HeaderMap::new();
-                headers.insert("Location", "/about/me".parse().unwrap());
+                headers.insert("Location", HeaderValue::from_static("/about/me"));
 
                 headers
             }),
@@ -293,9 +327,9 @@ pub async fn start_test_server(
                 let mut headers = HeaderMap::new();
                 headers.insert(
                     "Access-Control-Allow-Headers",
-                    "Authorization, Location, Access-Control-Allow-Headers"
-                        .parse()
-                        .unwrap(),
+                    HeaderValue::from_static(
+                        "Authorization, Location, Access-Control-Allow-Headers",
+                    ),
                 );
 
                 headers
@@ -307,7 +341,7 @@ pub async fn start_test_server(
                 let mut headers = HeaderMap::new();
                 headers.insert(
                     "Access-Control-Allow-Headers",
-                    "x-authorization-foo, Location".parse().unwrap(),
+                    HeaderValue::from_static("x-authorization-foo, Location"),
                 );
 
                 headers
@@ -317,7 +351,10 @@ pub async fn start_test_server(
             "/preflight/wildcard-allow-auth",
             options(|| async {
                 let mut headers = HeaderMap::new();
-                headers.insert("Access-Control-Allow-Headers", "*".parse().unwrap());
+                headers.insert(
+                    "Access-Control-Allow-Headers",
+                    HeaderValue::from_static("*"),
+                );
 
                 headers
             }),

--- a/crates/turborepo-vercel-api-mock/src/main.rs
+++ b/crates/turborepo-vercel-api-mock/src/main.rs
@@ -1,11 +1,9 @@
-#![allow(clippy::unwrap_used)]
-
-use anyhow::Result;
+use anyhow::{Context, Result};
 use turborepo_vercel_api_mock::start_test_server;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let port = port_scanner::request_open_port().unwrap();
+    let port = port_scanner::request_open_port().context("failed to find open port")?;
     tokio::task::block_in_place(|| start_test_server(port, None)).await?;
     Ok(())
 }


### PR DESCRIPTION
## Why

`turborepo-vercel-api-mock` still allowed implementation `.unwrap()` usage in mock server startup and request handling. These paths should return startup errors or HTTP failures instead of panicking, and the crate should rely on the workspace lint to prevent regressions.

Closes TURBO-5635

## What

Hardens the mock API server so invalid request/body/header/file cases are handled without panics, then removes the crate-level unwrap lint exemption.

## How

- `cargo fmt -p turborepo-vercel-api-mock`
- `cargo test -p turborepo-vercel-api-mock`
- `cargo clippy -p turborepo-vercel-api-mock --all-targets -- -D warnings`
- Pre-push hook passed with format, check:toml, and Rust checks