### PR TITLE
fix: Remove task executor unwrap usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8255,7 +8255,6 @@ dependencies = [
  "either",
  "futures",
  "miette",
- "regex",
  "serde",
  "tempfile",
  "thiserror 2.0.18",

--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -23,7 +23,7 @@ use turborepo_process::ProcessManager;
 use turborepo_repository::package_graph::{PackageGraph, PackageName, ROOT_PKG_NAME};
 use turborepo_run_summary::{self as summary, GlobalHashSummary, RunTracker, TaskTracker};
 use turborepo_scm::SCM;
-use turborepo_task_executor::{turbo_regex, TaskOutput};
+use turborepo_task_executor::{command_invokes_turbo, TaskOutput};
 use turborepo_task_hash::{
     Error as TaskHashError, GlobalHashableInputs, PackageInputsHashes, TaskHashTrackerState,
 };
@@ -376,7 +376,9 @@ impl<'a> Visitor<'a> {
             let command = workspace_info.package_json.scripts.get(info.task());
 
             match command {
-                Some(cmd) if info.package() == ROOT_PKG_NAME && turbo_regex().is_match(cmd) => {
+                Some(cmd)
+                    if info.package() == ROOT_PKG_NAME && command_invokes_turbo(cmd.as_str()) =>
+                {
                     let package_task_event =
                         PackageTaskEventBuilder::new(info.package(), info.task())
                             .with_parent(telemetry);

--- a/crates/turborepo-task-executor/Cargo.toml
+++ b/crates/turborepo-task-executor/Cargo.toml
@@ -66,9 +66,6 @@ chrono = { workspace = true }
 # Binary lookup
 which = { workspace = true }
 
-# Regex for turbo detection
-regex = { workspace = true }
-
 # Case conversion for error codes
 convert_case = "0.6.0"
 

--- a/crates/turborepo-task-executor/src/lib.rs
+++ b/crates/turborepo-task-executor/src/lib.rs
@@ -19,8 +19,6 @@
 //! - Cache saving on success
 //! - Error and warning collection
 
-#![allow(clippy::unwrap_used)]
-
 mod command;
 mod exec;
 mod output;
@@ -40,7 +38,8 @@ use turbopath::AbsoluteSystemPathBuf;
 use turborepo_task_id::TaskId;
 use turborepo_types::{ContinueMode, EnvMode, ResolvedLogOrder, ResolvedLogPrefix, UIMode};
 pub use visitor::{
-    EngineExecutor, EngineMessage, EngineProvider, TaskCallback, TaskHashProvider, turbo_regex,
+    EngineExecutor, EngineMessage, EngineProvider, TaskCallback, TaskHashProvider,
+    command_invokes_turbo,
 };
 
 /// Configuration for task execution.

--- a/crates/turborepo-task-executor/src/visitor.rs
+++ b/crates/turborepo-task-executor/src/visitor.rs
@@ -4,9 +4,6 @@
 //! visitor. The concrete `Visitor` implementation remains in `turborepo-lib`,
 //! but these abstractions allow for decoupling and testing.
 
-use std::sync::OnceLock;
-
-use regex::Regex;
 use tokio::sync::mpsc;
 use turborepo_repository::package_graph::PackageInfo;
 use turborepo_task_id::TaskId;
@@ -75,10 +72,9 @@ pub trait EngineExecutor: Send {
     ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send;
 }
 
-/// Check if a command invokes turbo (which would create a recursive loop).
-pub fn turbo_regex() -> &'static Regex {
-    static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| Regex::new(r"(?:^|\s)turbo(?:$|\s)").unwrap())
+/// Check if a command invokes turbo, which would create a recursive loop.
+pub fn command_invokes_turbo(command: &str) -> bool {
+    command.split_whitespace().any(|part| part == "turbo")
 }
 
 #[cfg(test)]
@@ -86,12 +82,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_turbo_regex() {
-        let re = turbo_regex();
-        assert!(re.is_match("turbo"));
-        assert!(re.is_match("turbo build"));
-        assert!(re.is_match("npx turbo build"));
-        assert!(!re.is_match("turbopack"));
-        assert!(!re.is_match("myturbo"));
+    fn test_command_invokes_turbo() {
+        assert!(command_invokes_turbo("turbo"));
+        assert!(command_invokes_turbo("turbo build"));
+        assert!(command_invokes_turbo("npx turbo build"));
+        assert!(!command_invokes_turbo("turbopack"));
+        assert!(!command_invokes_turbo("myturbo"));
     }
 }


### PR DESCRIPTION
## Why

`turborepo-task-executor` still allowed implementation `.unwrap()` usage for recursive `turbo` command detection. Removing that panic path lets the workspace lint enforce future unwrap removals in the crate.

Closes TURBO-5646

## What

Replaces the regex-backed recursive command check with equivalent whitespace-token matching, removes the now-unused regex dependency, and drops the crate-level unwrap lint exemption.

## How

- `cargo fmt -p turborepo-task-executor -p turborepo-lib`
- `cargo test -p turborepo-task-executor`
- `cargo clippy -p turborepo-task-executor --all-targets -- -D warnings`
- `cargo clippy -p turborepo-lib --all-targets -- -D warnings`
- Pre-push hook passed with format, check:toml, and Rust checks