### PR TITLE
fix: Remove microfrontends proxy unwrap usage

### DIFF
--- a/crates/turborepo-microfrontends-proxy/src/lib.rs
+++ b/crates/turborepo-microfrontends-proxy/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(clippy::all)]
-#![allow(clippy::unwrap_used)]
 
 mod error;
 mod headers;

--- a/crates/turborepo-microfrontends-proxy/src/proxy.rs
+++ b/crates/turborepo-microfrontends-proxy/src/proxy.rs
@@ -4,6 +4,7 @@ use http_body_util::{BodyExt, Full};
 use hyper::{
     Request, Response, StatusCode,
     body::{Bytes, Incoming},
+    header::{CONTENT_TYPE, HeaderValue},
 };
 use tracing::{debug, error};
 
@@ -182,24 +183,17 @@ fn create_generic_error_response(error: ProxyError) -> Response<BoxedBody> {
 </html>"#
     );
 
-    Response::builder()
-        .status(status)
-        .header("Content-Type", "text/html; charset=utf-8")
-        .body(
-            Full::new(Bytes::from(body_text))
-                .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
-                .boxed(),
-        )
-        .unwrap_or_else(|_| {
-            Response::builder()
-                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body(
-                    Full::new(Bytes::from("Internal Server Error"))
-                        .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
-                        .boxed(),
-                )
-                .unwrap()
-        })
+    let mut response = Response::new(
+        Full::new(Bytes::from(body_text))
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
+            .boxed(),
+    );
+    *response.status_mut() = status;
+    response.headers_mut().insert(
+        CONTENT_TYPE,
+        HeaderValue::from_static("text/html; charset=utf-8"),
+    );
+    response
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Why

`turborepo-microfrontends-proxy` still allowed implementation `.unwrap()` usage while building generic proxy error responses. Even defensive error rendering should not depend on a panic fallback.

Closes TURBO-5658

## What

Builds the proxy error response directly instead of through fallible response builders, then removes the crate-level unwrap lint exemption.

## How

- `cargo fmt -p turborepo-microfrontends-proxy`
- `cargo test -p turborepo-microfrontends-proxy`
- `cargo clippy -p turborepo-microfrontends-proxy --all-targets -- -D warnings`
- Pre-push hook passed with format, check:toml, and Rust checks