### PR TITLE
fix: Remove api client unwrap usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7287,7 +7287,6 @@ dependencies = [
  "httpmock",
  "insta",
  "port_scanner",
- "regex",
  "reqwest",
  "rustc_version_runtime",
  "rustls-pemfile",

--- a/crates/turborepo-api-client/Cargo.toml
+++ b/crates/turborepo-api-client/Cargo.toml
@@ -26,7 +26,6 @@ workspace = true
 
 [dependencies]
 bytes.workspace = true
-regex = { workspace = true }
 reqwest = { workspace = true, features = ["json", "stream"] }
 rustc_version_runtime = "0.2.1"
 rustls-pemfile = "2.1.2"

--- a/crates/turborepo-api-client/src/error.rs
+++ b/crates/turborepo-api-client/src/error.rs
@@ -13,6 +13,8 @@ pub enum Error {
     ReqwestError(#[from] reqwest::Error),
     #[error("Skipping HTTP Request. Too many failures have occurred.\nLast error: {0}")]
     TooManyFailures(#[from] Box<reqwest::Error>),
+    #[error("Skipping HTTP Request. Too many failures have occurred without an error response.")]
+    RetryExhaustedWithoutError,
     #[error("Unable to set up TLS.")]
     TlsError(#[source] reqwest::Error),
     #[error("HTTP client initialization was cancelled (runtime shutting down)")]

--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -6,13 +6,11 @@
 // miette's derive macro causes false positives for this lint
 #![allow(unused_assignments)]
 #![deny(clippy::all)]
-#![allow(clippy::unwrap_used)]
 
-use std::{backtrace::Backtrace, env, future::Future, sync::LazyLock, time::Duration};
+use std::{backtrace::Backtrace, env, future::Future, time::Duration};
 #[cfg(feature = "rustls-tls")]
 use std::{io::Cursor, path::Path};
 
-use regex::Regex;
 pub use reqwest::Response;
 use reqwest::{Body, Method, RequestBuilder, StatusCode};
 #[cfg(feature = "rustls-tls")]
@@ -39,8 +37,23 @@ pub use bytes::Bytes;
 pub use shared_http_client::SharedHttpClient;
 pub use tokio_stream::Stream;
 
-static AUTHORIZATION_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?i)(?:^|,) *authorization *(?:,|$)").unwrap());
+fn allows_authorization_header(allowed_headers: &str) -> bool {
+    allowed_headers == "*"
+        || allowed_headers
+            .split(',')
+            .any(|header| header.trim().eq_ignore_ascii_case("authorization"))
+}
+
+fn response_error(response: Response, status: StatusCode) -> Error {
+    match response.error_for_status() {
+        Ok(response) => Error::UnknownStatus {
+            code: status.to_string(),
+            message: format!("request to {} returned unexpected status", response.url()),
+            backtrace: Backtrace::capture(),
+        },
+        Err(err) => err.into(),
+    }
+}
 
 pub trait Client {
     fn get_user(&self, token: &SecretString) -> impl Future<Output = Result<UserResponse>> + Send;
@@ -531,7 +544,7 @@ impl TokenClient for APIClient {
                     url: self.make_url(endpoint)?.to_string(),
                 })
             }
-            _ => Err(response.error_for_status().unwrap_err().into()),
+            _ => Err(response_error(response, status)),
         }
     }
 
@@ -590,7 +603,7 @@ impl TokenClient for APIClient {
                     url: self.make_url(endpoint)?.to_string(),
                 })
             }
-            _ => Err(response.error_for_status().unwrap_err().into()),
+            _ => Err(response_error(response, status)),
         }
     }
 }
@@ -875,7 +888,7 @@ impl APIClient {
             .get("Access-Control-Allow-Headers")
             .map_or("", |h| h.to_str().unwrap_or(""));
 
-        let allow_auth = allowed_headers == "*" || AUTHORIZATION_REGEX.is_match(allowed_headers);
+        let allow_auth = allows_authorization_header(allowed_headers);
 
         Ok(PreflightResponse {
             location,

--- a/crates/turborepo-api-client/src/retry.rs
+++ b/crates/turborepo-api-client/src/retry.rs
@@ -79,7 +79,10 @@ pub(crate) async fn make_retryable_request(
         sleep(std::time::Duration::from_secs(sleep_period)).await;
     }
 
-    Err(Error::TooManyFailures(Box::new(last_error.unwrap())))
+    match last_error {
+        Some(error) => Err(Error::TooManyFailures(Box::new(error))),
+        None => Err(Error::RetryExhaustedWithoutError),
+    }
 }
 
 /// A retry strategy. Note that error statuses and TOO_MANY_REQUESTS are always


### PR DESCRIPTION
## Why

`turborepo-api-client` still allowed implementation `.unwrap()` usage in retry handling, preflight auth-header parsing, and token response error handling. These are request boundary paths where failures should become typed errors instead of panics.

Closes TURBO-5629

## What

Replaces regex-based auth-header matching with token parsing, handles unexpected non-error response statuses explicitly, makes retry exhaustion robust without a recorded last error, and removes the unused regex dependency plus unwrap lint exemption.

## How

- `cargo fmt -p turborepo-api-client`
- `cargo test -p turborepo-api-client --features rustls-tls`
- `cargo clippy -p turborepo-api-client --features rustls-tls --all-targets -- -D warnings`
- Pre-push hook passed with format, check:toml, and Rust checks