### PR TITLE
fix: Remove UI `expect()` usage

### DIFF
--- a/crates/turborepo-ui/src/color_selector.rs
+++ b/crates/turborepo-ui/src/color_selector.rs
@@ -35,14 +35,19 @@ struct ColorSelectorInner {
 impl ColorSelector {
     #[allow(clippy::let_and_return)]
     pub fn color_for_key(&self, key: &str) -> &'static Style {
-        if let Some(style) = self.inner.read().expect("lock poisoned").color(key) {
+        let inner = self
+            .inner
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(style) = inner.color(key) {
             return style;
         }
+        drop(inner);
 
         let color = {
             self.inner
                 .write()
-                .expect("lock poisoned")
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .insert_color(key.to_string())
         };
 

--- a/crates/turborepo-ui/src/lib.rs
+++ b/crates/turborepo-ui/src/lib.rs
@@ -2,7 +2,7 @@
 //! logging sinks, and the TUI. Includes a `ColorSelector` that lets multiple
 //! concurrent resources get an assigned color.
 #![feature(deadline_api)]
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::unwrap_used)]
 
 mod color_selector;
 mod log_sinks;

--- a/crates/turborepo-ui/src/sender.rs
+++ b/crates/turborepo-ui/src/sender.rs
@@ -118,7 +118,10 @@ impl TaskSender {
 
     fn finish(&self, result: TaskResult) -> Vec<u8> {
         self.handle.end_task(self.name.clone(), result);
-        self.logs.lock().expect("logs lock poisoned").clone()
+        self.logs
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
     }
 
     pub fn set_stdin(&self, stdin: Box<dyn std::io::Write + Send>) {
@@ -140,7 +143,7 @@ impl std::io::Write for TaskSender {
         {
             self.logs
                 .lock()
-                .expect("log lock poisoned")
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .extend_from_slice(buf);
         }
 

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -406,7 +406,9 @@ impl<W> App<W> {
         {
             let new_selection = result.to_owned();
             self.is_task_selection_pinned = true;
-            self.select_task(&new_selection).expect("todo");
+            if let Err(error) = self.select_task(&new_selection) {
+                debug!("failed to select search result: {error}");
+            }
         }
     }
 
@@ -879,7 +881,9 @@ async fn run_app_inner(
             let term = startup(color_config)?;
             *terminal = Some(term);
             // Render initial state to paint the screen
-            terminal.as_mut().unwrap().draw(|f| view(app, f))?;
+            if let Some(terminal) = terminal.as_mut() {
+                terminal.draw(|f| view(app, f))?;
+            }
             last_render = Instant::now();
         }
 
@@ -891,12 +895,10 @@ async fn run_app_inner(
 
         let mut event = Some(event);
         let mut resize_event = None;
-        if matches!(event, Some(Event::Resize { .. })) {
-            resize_event = resize_debouncer.update(
-                event
-                    .take()
-                    .expect("we just matched against a present value"),
-            );
+        if matches!(event, Some(Event::Resize { .. }))
+            && let Some(event) = event.take()
+        {
+            resize_event = resize_debouncer.update(event);
         }
         if let Some(resize) = resize_event.take().or_else(|| resize_debouncer.query()) {
             // If we got a resize event, make sure to update ratatui backend.

--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -205,8 +205,10 @@ fn encode_key(key: KeyEvent) -> Vec<u8> {
     };
 
     match code {
-        Char(c) if mods.contains(KeyModifiers::CONTROL) && ctrl_mapping(c).is_some() => {
-            let c = ctrl_mapping(c).unwrap();
+        Char(c) if mods.contains(KeyModifiers::CONTROL) => {
+            let Some(c) = ctrl_mapping(c) else {
+                return Vec::new();
+            };
             if mods.contains(KeyModifiers::ALT) {
                 buf.push(0x1b as char);
             }

--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -205,10 +205,8 @@ fn encode_key(key: KeyEvent) -> Vec<u8> {
     };
 
     match code {
-        Char(c) if mods.contains(KeyModifiers::CONTROL) => {
-            let Some(c) = ctrl_mapping(c) else {
-                return Vec::new();
-            };
+        Char(c) if mods.contains(KeyModifiers::CONTROL) && ctrl_mapping(c).is_some() => {
+            let c = ctrl_mapping(c).unwrap();
             if mods.contains(KeyModifiers::ALT) {
                 buf.push(0x1b as char);
             }


### PR DESCRIPTION
## Why

`turborepo-ui` still allowed implementation `.expect()` usage in TUI selection/rendering and shared UI state locks. These paths should recover or degrade without panicking, while the remaining unwrap cleanup can stay scoped to the separate unwrap ticket.

Closes TURBO-5594

## What

Removes implementation expect callsites, handles poisoned locks by recovering their inner values, avoids invariant expects in resize/render paths, and narrows the crate-level lint exemption to `unwrap_used` only.

## How

- `cargo fmt -p turborepo-ui`
- `cargo test -p turborepo-ui`
- `cargo clippy -p turborepo-ui --all-targets -- -D warnings`
- Pre-push hook passed with format, check:toml, and Rust checks