### PR TITLE
fix: Remove `turbopath`'s `unwrap()` usage

### DIFF
--- a/crates/turborepo-paths/src/absolute_system_path.rs
+++ b/crates/turborepo-paths/src/absolute_system_path.rs
@@ -20,6 +20,13 @@ use crate::{
     AbsoluteSystemPathBuf, AnchoredSystemPath, AnchoredSystemPathBuf, PathError, RelativeUnixPath,
 };
 
+fn clean_utf8_path(path: Utf8PathBuf) -> Utf8PathBuf {
+    match Utf8PathBuf::from_path_buf(path.as_std_path().clean()) {
+        Ok(cleaned) => cleaned,
+        Err(_) => path,
+    }
+}
+
 /// Models how two paths relate to each other
 #[derive(Debug, PartialEq, Eq)]
 pub enum PathRelation {
@@ -237,14 +244,7 @@ impl AbsoluteSystemPath {
     /// Intended for joining literals or obviously single-token strings
     pub fn join_component(&self, segment: &str) -> AbsoluteSystemPathBuf {
         debug_assert!(!segment.contains(std::path::MAIN_SEPARATOR));
-        AbsoluteSystemPathBuf(
-            self.0
-                .join(segment)
-                .as_std_path()
-                .clean()
-                .try_into()
-                .unwrap(),
-        )
+        AbsoluteSystemPathBuf(clean_utf8_path(self.0.join(segment)))
     }
 
     /// Intended for joining a path composed of literals
@@ -254,14 +254,9 @@ impl AbsoluteSystemPath {
                 .iter()
                 .any(|segment| segment.contains(std::path::MAIN_SEPARATOR))
         );
-        AbsoluteSystemPathBuf(
-            self.0
-                .join(segments.join(std::path::MAIN_SEPARATOR_STR))
-                .as_std_path()
-                .clean()
-                .try_into()
-                .unwrap(),
-        )
+        AbsoluteSystemPathBuf(clean_utf8_path(
+            self.0.join(segments.join(std::path::MAIN_SEPARATOR_STR)),
+        ))
     }
 
     pub fn as_str(&self) -> &str {

--- a/crates/turborepo-paths/src/anchored_system_path.rs
+++ b/crates/turborepo-paths/src/anchored_system_path.rs
@@ -1,10 +1,17 @@
 use std::{fmt, path::Path};
 
-use camino::{Utf8Component, Utf8Path};
+use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
 use path_clean::PathClean;
 use serde::Serialize;
 
 use crate::{AnchoredSystemPathBuf, PathError, PathRelation, RelativeUnixPathBuf};
+
+fn clean_utf8_path(path: Utf8PathBuf) -> Utf8PathBuf {
+    match Utf8PathBuf::from_path_buf(path.as_std_path().clean()) {
+        Ok(cleaned) => cleaned,
+        Err(_) => path,
+    }
+}
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Hash)]
 #[serde(transparent)]
@@ -113,18 +120,12 @@ impl AnchoredSystemPath {
                 .iter()
                 .any(|segment| segment.contains(std::path::MAIN_SEPARATOR))
         );
-        AnchoredSystemPathBuf(
-            self.0
-                .join(segments.join(std::path::MAIN_SEPARATOR_STR))
-                .as_std_path()
-                .clean()
-                .try_into()
-                .unwrap(),
-        )
+        let joined = self.0.join(segments.join(std::path::MAIN_SEPARATOR_STR));
+        AnchoredSystemPathBuf(clean_utf8_path(joined))
     }
 
     pub fn clean(&self) -> AnchoredSystemPathBuf {
-        AnchoredSystemPathBuf(self.0.as_std_path().clean().try_into().unwrap())
+        AnchoredSystemPathBuf(clean_utf8_path(self.0.to_owned()))
     }
 
     /// relation_to_path does a lexical comparison of path components to

--- a/crates/turborepo-paths/src/lib.rs
+++ b/crates/turborepo-paths/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(clippy::all)]
-#![allow(clippy::unwrap_used)]
 
 //! Turborepo's path handling library.
 //! Defines distinct path types for the different uses of paths in Turborepo's


### PR DESCRIPTION
## Why

`turbopath` still allowed implementation `.unwrap()` usage when cleaning joined UTF-8 paths. These helpers are used across path boundary handling, so conversion failures should not require a panic path or crate-level unwrap exemption.

Closes TURBO-5627

## What

Adds non-panicking UTF-8 path cleaning for absolute and anchored path joins, falls back to the original UTF-8 path if cleaned conversion ever fails, and removes the crate-level unwrap lint exemption.

## How

- `cargo fmt -p turbopath`
- `cargo clippy -p turbopath --all-targets -- -D warnings`
- `cargo test -p turbopath`
- Pre-push hook passed with format, check:toml, and Rust checks