### PR TITLE
fix: Remove microfrontends expect usage

### DIFF
--- a/crates/turborepo-microfrontends/src/error.rs
+++ b/crates/turborepo-microfrontends/src/error.rs
@@ -26,6 +26,8 @@ pub enum Error {
          package root (no subdirectories or path traversal)."
     )]
     InvalidCustomConfigPath(String),
+    #[error("Invalid microfrontends configuration path: {0}")]
+    InvalidConfigPath(String),
 }
 
 impl Error {

--- a/crates/turborepo-microfrontends/src/lib.rs
+++ b/crates/turborepo-microfrontends/src/lib.rs
@@ -21,7 +21,7 @@
 //!    passed through but ignored by Turborepo
 
 #![deny(clippy::all)]
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::unwrap_used)]
 mod configv1;
 mod error;
 mod port;
@@ -145,10 +145,10 @@ impl TurborepoMfeConfig {
             return Ok(None);
         };
         let mut config = Self::from_str_with_mfe_dep(&contents, path.as_str(), has_mfe_dependency)?;
-        config.filename = path
-            .file_name()
-            .expect("microfrontends config should not be root")
-            .to_owned();
+        let Some(file_name) = path.file_name() else {
+            return Err(Error::InvalidConfigPath(path.to_string()));
+        };
+        config.filename = file_name.to_owned();
         config.set_path(package_dir);
         Ok(Some(config))
     }
@@ -351,10 +351,10 @@ impl Config {
             return Ok(None);
         };
         let mut config = Config::from_str(&contents, path.as_str())?;
-        config.filename = path
-            .file_name()
-            .expect("microfrontends config should not be root")
-            .to_owned();
+        let Some(file_name) = path.file_name() else {
+            return Err(Error::InvalidConfigPath(path.to_string()));
+        };
+        config.filename = file_name.to_owned();
         config.set_path(package_dir);
         Ok(Some(config))
     }

--- a/crates/turborepo-microfrontends/src/port.rs
+++ b/crates/turborepo-microfrontends/src/port.rs
@@ -5,12 +5,12 @@ const PORT_RANGE: u16 = MAX_PORT - MIN_PORT;
 pub fn generate_port_from_name(name: &str) -> u16 {
     let mut hash: i32 = 0;
     for c in name.chars() {
-        let code = i32::try_from(u32::from(c)).expect("char::MAX is less than 2^31");
+        let code = u32::from(c) as i32;
         hash = (hash << 5).overflowing_sub(hash).0.overflowing_add(code).0;
     }
     let hash = hash.abs_diff(0);
     let port = hash % u32::from(PORT_RANGE);
-    MIN_PORT + u16::try_from(port).expect("u32 modulo a u16 number will be a valid u16")
+    MIN_PORT + port as u16
 }
 
 pub fn parse_port_from_host(host: &str) -> Option<u16> {


### PR DESCRIPTION
## Why

`turborepo-microfrontends` still allowed implementation `.expect()` usage while deriving config filenames and generating deterministic ports. These invariants should be represented without panic helpers so the crate can enforce the workspace expect lint.

Closes TURBO-5613

## What

Adds an explicit invalid config path error, handles missing config filenames through that error, replaces bounded port conversions with direct safe casts, and narrows the crate-level lint exemption to the separate unwrap cleanup.

## How

- `cargo fmt -p turborepo-microfrontends`
- `cargo test -p turborepo-microfrontends`
- `cargo clippy -p turborepo-microfrontends --all-targets -- -D warnings`
- Pre-push hook passed with format, check:toml, and Rust checks