### PR TITLE
fix: Remove auth unwrap usage

### DIFF
--- a/crates/turborepo-auth/src/auth/login.rs
+++ b/crates/turborepo-auth/src/auth/login.rs
@@ -319,7 +319,10 @@ async fn login_redirect<T: Client>(
 ) -> Result<(Token, Option<TokenSet>), Error> {
     let listener = TcpListener::bind(format!("{DEFAULT_HOST_NAME}:{port}"))
         .map_err(error::Error::CallbackListenerFailed)?;
-    let port = listener.local_addr().unwrap().port();
+    let port = listener
+        .local_addr()
+        .map_err(error::Error::CallbackListenerFailed)?
+        .port();
     let redirect_url = format!("http://{DEFAULT_HOST_NAME}:{port}");
     let state = generate_csrf_state();
 

--- a/crates/turborepo-auth/src/auth/sso.rs
+++ b/crates/turborepo-auth/src/auth/sso.rs
@@ -307,7 +307,10 @@ async fn sso_redirect(
 ) -> Result<String, Error> {
     let listener = TcpListener::bind(format!("{DEFAULT_HOST_NAME}:{port}"))
         .map_err(Error::CallbackListenerFailed)?;
-    let port = listener.local_addr().unwrap().port();
+    let port = listener
+        .local_addr()
+        .map_err(Error::CallbackListenerFailed)?
+        .port();
     let redirect_url = format!("http://{DEFAULT_HOST_NAME}:{port}");
     let state = generate_csrf_state();
 

--- a/crates/turborepo-auth/src/lib.rs
+++ b/crates/turborepo-auth/src/lib.rs
@@ -2,7 +2,7 @@
 // miette's derive macro causes false positives for this lint
 #![allow(unused_assignments)]
 #![deny(clippy::all)]
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
 //! Turborepo's library for authenticating with the Vercel API.
 //! Handles logging into Vercel, verifying SSO, and storing the token.
 


### PR DESCRIPTION
## Why

`turborepo-auth` still allowed implementation `.unwrap()` usage while reading callback listener addresses for login and SSO redirects. These flows should report listener errors instead of panicking.

Closes TURBO-5641

## What

Propagates listener address failures through the existing callback listener error, and narrows the crate-level lint exemption to the separate expect cleanup.

## How

- `cargo fmt -p turborepo-auth`
- `cargo test -p turborepo-auth`
- `cargo clippy -p turborepo-auth --all-targets -- -D warnings`
- Pre-push hook passed with format, check:toml, and Rust checks