### PR TITLE
fix: Remove `boundaries`'s `expect()` usage

### DIFF
--- a/crates/turborepo-boundaries/src/imports.rs
+++ b/crates/turborepo-boundaries/src/imports.rs
@@ -111,7 +111,9 @@ fn check_import_as_tsconfig_path_alias(
         return Ok((false, None));
     }
 
-    let dir = file_path.parent().expect("file_path must have a parent");
+    let dir = file_path
+        .parent()
+        .ok_or_else(|| Error::NoParentDir(file_path.to_owned()))?;
 
     match resolver.resolve(dir, import) {
         Ok(resolution) => {
@@ -395,7 +397,7 @@ pub(crate) fn check_package_import(
         });
     }
     let package_node = PackageNode::Workspace(PackageName::Other(package_name.to_string()));
-    let folder = file_path.parent().expect("file_path should have a parent");
+    let folder = file_path.parent()?;
     let is_valid_dependency = dependency_locations.is_dependency(&package_node);
 
     if !is_valid_dependency

--- a/crates/turborepo-boundaries/src/lib.rs
+++ b/crates/turborepo-boundaries/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::sliced_string_as_bytes)]
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::unwrap_used)]
 // miette's derive macro causes false positives for these lints
 #![allow(unused_assignments)]
 


### PR DESCRIPTION
## Why

`turborepo-boundaries` still allowed implementation `.expect()` usage when resolving imports from file paths. Missing parent directories should be handled through existing diagnostics or no-diagnostic returns instead of panicking.

Closes TURBO-5599

## What

Replaces parent-directory expect callsites in import checking and narrows the crate-level lint exemption to the separate unwrap cleanup.

## How

- `cargo fmt -p turborepo-boundaries`
- `cargo test -p turborepo-boundaries`
- `cargo clippy -p turborepo-boundaries --all-targets -- -D warnings`
- Pre-push hook passed with format, check:toml, and Rust checks