### PR TITLE
fix: Remove `turborepo-process`'s `unwrap()` usage

### DIFF
--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -735,7 +735,7 @@ impl ChildHandle {
                 let mut killer = child.clone_killer();
                 tokio::task::spawn_blocking(move || killer.kill())
                     .await
-                    .unwrap()
+                    .map_err(|err| io::Error::other(format!("pty kill task failed: {err}")))?
             }
         }
     }
@@ -1111,11 +1111,17 @@ impl Child {
     }
 
     fn stdin_inner(&mut self) -> Option<ChildInput> {
-        self.stdin.lock().unwrap().take()
+        self.stdin
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
     }
 
     fn outputs(&self) -> Option<ChildOutput> {
-        self.output.lock().unwrap().take()
+        self.output
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
     }
 
     pub fn stdin(&mut self) -> Option<Box<dyn Write + Send>> {

--- a/crates/turborepo-process/src/lib.rs
+++ b/crates/turborepo-process/src/lib.rs
@@ -10,7 +10,7 @@
 //! must be either `wait`ed on or `stop`ped to drive state.
 
 #![deny(clippy::all)]
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
 
 mod child;
 mod command;
@@ -131,7 +131,10 @@ impl ProcessManager {
             .then(|| command.label())
             .unwrap_or_default();
         trace!("acquiring lock for spawning {label}");
-        let mut lock = self.state.lock().unwrap();
+        let mut lock = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         trace!("acquired lock for spawning {label}");
         if lock.is_closing {
             debug!("process manager closing");


### PR DESCRIPTION
## Why

`turborepo-process` still allowed implementation `.unwrap()` usage around process manager locks, child IO locks, and PTY kill task joins. These paths are part of process lifecycle management and should recover or return errors instead of panicking.

Closes TURBO-5650

## What

Recovers poisoned mutexes by taking their inner values, maps PTY kill task join failures to `io::Error`, and narrows the crate-level lint exemption to the separate expect cleanup.

## How

- `cargo fmt -p turborepo-process`
- `cargo test -p turborepo-process`
- `cargo clippy -p turborepo-process --all-targets -- -D warnings`
- Pre-push hook passed with format, check:toml, and Rust checks