### PR TITLE
fix: Remove UI unwrap usage

### DIFF
--- a/crates/turborepo-ui/src/lib.rs
+++ b/crates/turborepo-ui/src/lib.rs
@@ -2,7 +2,6 @@
 //! logging sinks, and the TUI. Includes a `ColorSelector` that lets multiple
 //! concurrent resources get an assigned color.
 #![feature(deadline_api)]
-#![allow(clippy::unwrap_used)]
 
 mod color_selector;
 mod log_sinks;

--- a/crates/turborepo-ui/src/terminal_sink.rs
+++ b/crates/turborepo-ui/src/terminal_sink.rs
@@ -118,7 +118,10 @@ impl TerminalSink {
     /// writes `prefix + line` to stdout. Handles `\r` for progress
     /// bars by rewriting the prefix at the start of the line.
     fn write_task_output(&self, task: &str, bytes: &[u8]) {
-        let mut tasks = self.tasks.lock().unwrap();
+        let mut tasks = self
+            .tasks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let Some(state) = tasks.get_mut(task) else {
             // Task not registered — write raw bytes as fallback
             let stdout = io::stdout();
@@ -205,7 +208,10 @@ impl LogSink for TerminalSink {
     fn register_task(&self, task: &str, prefix: &str) {
         let styled = self.color_selector.prefix_with_color(task, prefix);
         let formatted = self.color_config.apply(styled).to_string();
-        let mut tasks = self.tasks.lock().unwrap();
+        let mut tasks = self
+            .tasks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         tasks.entry(task.to_string()).or_insert(TaskRenderState {
             prefix: formatted,
             line_buffer: Vec::with_capacity(512),

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -1264,20 +1264,21 @@ fn view<W>(app: &mut App<W>, f: &mut Frame) {
     };
     let [table, pane] = horizontal.areas(f.area());
 
-    let active_task = app.active_task().unwrap().to_string();
-
-    let output_logs = app.tasks.get(&active_task).unwrap();
-    let pane_to_render: TerminalPane<W> = TerminalPane::new(
-        output_logs,
-        &active_task,
-        &app.section_focus,
-        app.preferences.is_task_list_visible(),
-    );
-
     let table_to_render = TaskTable::new(&app.tasks_by_status, &app.section_focus);
-
     f.render_stateful_widget(&table_to_render, table, &mut app.task_list_scroll);
-    f.render_widget(&pane_to_render, pane);
+
+    if let Ok(active_task) = app.active_task() {
+        let active_task = active_task.to_string();
+        if let Some(output_logs) = app.tasks.get(&active_task) {
+            let pane_to_render: TerminalPane<W> = TerminalPane::new(
+                output_logs,
+                &active_task,
+                &app.section_focus,
+                app.preferences.is_task_list_visible(),
+            );
+            f.render_widget(&pane_to_render, pane);
+        }
+    }
 
     if app.showing_help_popup {
         let area = popup_area(*f.buffer_mut().area());

--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -205,12 +205,20 @@ fn encode_key(key: KeyEvent) -> Vec<u8> {
     };
 
     match code {
-        Char(c) if mods.contains(KeyModifiers::CONTROL) && ctrl_mapping(c).is_some() => {
-            let c = ctrl_mapping(c).unwrap();
-            if mods.contains(KeyModifiers::ALT) {
+        Char(c) if mods.contains(KeyModifiers::CONTROL) => {
+            if let Some(c) = ctrl_mapping(c) {
+                if mods.contains(KeyModifiers::ALT) {
+                    buf.push(0x1b as char);
+                }
+                buf.push(c);
+            } else if (c.is_ascii_alphanumeric() || c.is_ascii_punctuation())
+                && mods.contains(KeyModifiers::ALT)
+            {
                 buf.push(0x1b as char);
+                buf.push(c);
+            } else {
+                buf.push(c);
             }
-            buf.push(c);
         }
 
         // When alt is pressed, send escape first to indicate to the peer that

--- a/crates/turborepo-ui/src/tui_sink.rs
+++ b/crates/turborepo-ui/src/tui_sink.rs
@@ -74,7 +74,10 @@ impl TuiSink {
     /// events and task output through the sender, then forwards
     /// directly from here on.
     pub fn connect(&self, sender: TuiSender) {
-        let mut state = self.state.lock().unwrap();
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         if let SinkState::Buffering {
             events,
             task_output,
@@ -93,7 +96,10 @@ impl TuiSink {
 
 impl LogSink for TuiSink {
     fn emit(&self, event: &LogEvent) {
-        let mut state = self.state.lock().unwrap();
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         match &mut *state {
             SinkState::Buffering { events, .. } => events.push(event.clone()),
             SinkState::Connected(sender) => {
@@ -111,7 +117,10 @@ impl LogSink for TuiSink {
     }
 
     fn task_output(&self, task: &str, _channel: OutputChannel, bytes: &[u8]) {
-        let mut state = self.state.lock().unwrap();
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let normalized = normalize_newlines(bytes);
         match &mut *state {
             SinkState::Buffering { task_output, .. } => {

--- a/crates/turborepo-ui/src/wui/subscriber.rs
+++ b/crates/turborepo-ui/src/wui/subscriber.rs
@@ -49,21 +49,27 @@ impl Subscriber {
                 );
             }
             WebUIEvent::TaskOutput { task, output } => {
-                state.tasks.get_mut(&task).unwrap().output.extend(output);
+                if let Some(task) = state.tasks.get_mut(&task) {
+                    task.output.extend(output);
+                }
             }
             WebUIEvent::EndTask { task, result } => {
-                state.tasks.get_mut(&task).unwrap().status = TaskStatus::from(result);
+                if let Some(task) = state.tasks.get_mut(&task) {
+                    task.status = TaskStatus::from(result);
+                }
             }
             WebUIEvent::CacheStatus {
                 task,
                 result,
                 message,
             } => {
-                if result == CacheResult::Hit {
-                    state.tasks.get_mut(&task).unwrap().status = TaskStatus::Cached;
+                if let Some(task) = state.tasks.get_mut(&task) {
+                    if result == CacheResult::Hit {
+                        task.status = TaskStatus::Cached;
+                    }
+                    task.cache_result = Some(result);
+                    task.cache_message = Some(message);
                 }
-                state.tasks.get_mut(&task).unwrap().cache_result = Some(result);
-                state.tasks.get_mut(&task).unwrap().cache_message = Some(message);
             }
             WebUIEvent::Stop => {
                 // TODO: stop watching


### PR DESCRIPTION
## Why

`turborepo-ui` still allowed implementation `.unwrap()` usage in terminal sinks, TUI rendering, key encoding, and Web UI event handling. These runtime UI paths should recover or degrade without panicking.

Closes TURBO-5638

## What

Recovers poisoned UI mutexes, avoids panics when no active task output is available during rendering, preserves Ctrl-key fallback behavior without unwraps, ignores stale Web UI task events, and removes the crate-level unwrap lint exemption.

## How

- `cargo fmt -p turborepo-ui`
- `cargo test -p turborepo-ui`
- `cargo clippy -p turborepo-ui --all-targets -- -D warnings`
- Pre-push hook passed with format, check:toml, and Rust checks