### PR TITLE
fix: Remove microfrontends unwrap allow

### DIFF
--- a/crates/turborepo-microfrontends/src/lib.rs
+++ b/crates/turborepo-microfrontends/src/lib.rs
@@ -21,7 +21,6 @@
 //!    passed through but ignored by Turborepo
 
 #![deny(clippy::all)]
-#![allow(clippy::unwrap_used)]
 mod configv1;
 mod error;
 mod port;


### PR DESCRIPTION
## Why

`turborepo-microfrontends` no longer has implementation `.unwrap()` usage, but it still carried a crate-level unwrap lint exemption. Removing the exemption lets the workspace lint prevent regressions.

Closes TURBO-5655

## What

Removes the remaining crate-level `clippy::unwrap_used` allowance from `turborepo-microfrontends`.

## How

- `cargo fmt -p turborepo-microfrontends`
- `cargo test -p turborepo-microfrontends`
- `cargo clippy -p turborepo-microfrontends --all-targets -- -D warnings`
- Pre-push hook passed with format, check:toml, and Rust checks