### PR TITLE
fix(repository): deterministic per-workspace lockfile merge order

### DIFF
--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -604,6 +604,12 @@ impl PackageManager {
             }
         }
 
+        // get_package_jsons returns paths from a HashSet, so iteration order is
+        // non-deterministic. Sort by path so that merge_per_workspace_lockfiles
+        // sees inputs in a stable order — its first-wins semantics for shared
+        // keys would otherwise produce different merged bytes per run.
+        workspace_lockfile_data.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+
         let refs: Vec<(&str, &[u8])> = workspace_lockfile_data
             .iter()
             .map(|(path, bytes)| (path.as_str(), bytes.as_slice()))
@@ -1039,6 +1045,75 @@ mod tests {
         assert!(
             actual,
             "all package managers without a special implementation should use workspace packages"
+        );
+    }
+
+    // Regression test: when shared-workspace-lockfile=false, per-workspace
+    // lockfiles are discovered via get_package_jsons, which returns paths from
+    // a HashSet. Merge is first-wins, so divergent shared keys would resolve to
+    // different bytes per run with HashSet iteration randomness. The merged
+    // lockfile must be byte-stable across runs so hashOfExternalDependencies
+    // (and therefore task cache hits) are deterministic.
+    #[test]
+    fn test_per_workspace_lockfile_merge_is_deterministic() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmpdir.path()).unwrap();
+
+        root.join_component(".npmrc")
+            .create_with_contents("shared-workspace-lockfile=false\n")
+            .unwrap();
+        root.join_component("pnpm-workspace.yaml")
+            .create_with_contents("packages:\n  - 'pkgs/*'\n")
+            .unwrap();
+        root.join_component("package.json")
+            .create_with_contents(r#"{"name":"root","private":true}"#)
+            .unwrap();
+        root.join_component("pnpm-lock.yaml")
+            .create_with_contents("lockfileVersion: '9.0'\nimporters:\n  .: {}\n")
+            .unwrap();
+
+        // Many workspaces sharing `lodash@4.17.21` but with divergent body —
+        // emulating pnpm resolving the same package differently per workspace
+        // context, which is the situation that triggers the bug in real repos.
+        let workspaces = ["a", "b", "c", "d", "e", "f", "g", "h"];
+        for (i, name) in workspaces.iter().enumerate() {
+            let dir = root.join_components(&["pkgs", name]);
+            dir.create_dir_all().unwrap();
+            dir.join_component("package.json")
+                .create_with_contents(format!(r#"{{"name":"{name}","private":true}}"#).as_bytes())
+                .unwrap();
+            let lockfile_yaml = format!(
+                "lockfileVersion: '9.0'\n\
+                 importers:\n  \
+                   .:\n    \
+                     dependencies:\n      \
+                       lodash:\n        \
+                         specifier: ^4.17.21\n        \
+                         version: 4.17.21\n\
+                 packages:\n  \
+                   lodash@4.17.21:\n    \
+                     resolution: {{integrity: sha512-marker{i}}}\n\
+                 snapshots:\n  \
+                   lodash@4.17.21: {{}}\n"
+            );
+            dir.join_component("pnpm-lock.yaml")
+                .create_with_contents(lockfile_yaml.as_bytes())
+                .unwrap();
+        }
+
+        let pm = PackageManager::Pnpm;
+        let root_pkg = PackageJson::load(&root.join_component("package.json")).unwrap();
+
+        let mut encoded = HashSet::new();
+        for _ in 0..50 {
+            let lockfile = pm.read_lockfile(root, &root_pkg).unwrap();
+            encoded.insert(lockfile.encode().unwrap());
+        }
+        assert_eq!(
+            encoded.len(),
+            1,
+            "merged lockfile bytes should be identical across 50 runs; got {} variants",
+            encoded.len()
         );
     }
 }


### PR DESCRIPTION
> Authored by Claude (Anthropic), guided by Joël Kuijper.

## Problem

When a pnpm monorepo uses `shared-workspace-lockfile=false` (each workspace gets its own `pnpm-lock.yaml`), turbo's per-task `hashOfExternalDependencies` is non-deterministic across consecutive runs. Result: the task cache misses on every run even when inputs are identical.

## Root cause

`crates/turborepo-repository/src/package_manager/mod.rs::try_read_pnpm_per_workspace_lockfiles` builds `workspace_lockfile_data` by iterating the result of `get_package_jsons`, which returns paths from a `HashSet<AbsoluteSystemPathBuf>` (`crates/turborepo-globwalk/src/lib.rs::globwalk_with_settings`). Rust's default `HashSet` uses `RandomState`, so iteration order varies per process.

The downstream `merge_per_workspace_lockfiles` in `crates/turborepo-lockfiles/src/pnpm/data.rs` uses `entry(key).or_insert(pkg)` (first-write-wins) for shared package keys. When two per-workspace lockfiles contain the same `name@version` key with divergent body — common because pnpm resolves peer-deps differently per workspace context — the "winner" flips with iteration order, producing different merged lockfile bytes and therefore different external-dep hashes per package.

## Fix

Sort `workspace_lockfile_data` by path before constructing the refs passed to `merge_per_workspace_lockfiles`. Single-line change; the merge function itself is untouched (its first-wins semantics are preserved).

## Test

Added `test_per_workspace_lockfile_merge_is_deterministic` in the package_manager tests module. It builds a fixture with 8 workspaces whose per-workspace lockfiles share `lodash@4.18.1` with divergent body, then calls `read_lockfile` 50 times and asserts the encoded merged bytes are identical across runs. Without the sort the test reproducibly fails with ~8 distinct variants; with the sort it passes with 1.

## Reproduction in a real repo

Minimal repro with 5 workspaces using `shared-workspace-lockfile=false` and divergent shared `lodash@4.18.1` entries across two workspace lockfiles. 50 runs per package:

**Stock binary (without fix):**
```
--- pkg=a ---  28 cab31a842ae7079f
              22 df77d12107374413
--- pkg=c ---  50 29bf19563ae3697f
--- pkg=b ---  50 8e93509476413b72
```

**Patched binary:**
```
--- pkg=a ---  50 cab31a842ae7079f
--- pkg=c ---  50 29bf19563ae3697f
--- pkg=b ---  50 8e93509476413b72
```

(pkg `c` and `b` happen to be stable in this seed because the keys their closure sees aren't divergent across the lockfiles that touch them; pkg `a` flips because its closure crosses both `pkgs/a/pnpm-lock.yaml` and `pkgs/b/pnpm-lock.yaml`, which share `lodash@4.18.1`.)

## Related

Similar pnpm-side concerns were raised in #12252. The merge-time bug here only triggers when two per-workspace lockfiles actually carry the same package key with diverging body — easy to miss on repos where peer-dep resolutions happen to be uniform across workspaces.