### PR TITLE
fix: Remove scm expect usage

### DIFF
--- a/crates/turborepo-scm/src/git_path.rs
+++ b/crates/turborepo-scm/src/git_path.rs
@@ -90,7 +90,9 @@ fn escape_bytes(bytes: &[u8]) -> String {
             b'\t' => escaped.push_str("\\t"),
             b'\0' => escaped.push_str("\\0"),
             0x20..=0x7e => escaped.push(*byte as char),
-            _ => write!(escaped, "\\x{byte:02x}").expect("writing to String cannot fail"),
+            _ => {
+                let _ = write!(escaped, "\\x{byte:02x}");
+            }
         }
     }
     escaped

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -2,7 +2,7 @@
 #![feature(io_error_more)]
 #![deny(clippy::all)]
 #![allow(clippy::result_large_err)]
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::unwrap_used)]
 
 //! Turborepo's library for interacting with source control management (SCM).
 //! Currently we only support git. We use SCM for finding changed files,


### PR DESCRIPTION
## Why

`turborepo-scm` still allowed implementation `.expect()` usage while escaping unsupported Git paths. Formatting into a `String` should not require a panic helper or crate-level expect exemption.

Closes TURBO-5596

## What

Removes the `expect` from Git path byte escaping and narrows the crate-level lint exemption to the separate unwrap cleanup.

## How

- `cargo fmt -p turborepo-scm`
- `cargo test -p turborepo-scm`
- `cargo clippy -p turborepo-scm --all-targets -- -D warnings`
- Pre-push hook passed with format, check:toml, and Rust checks