### PR TITLE
fix(repository): deterministic per-workspace lockfile merge order

### DIFF
--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -604,6 +604,11 @@ impl PackageManager {
             }
         }
 
+        // get_package_jsons returns paths from a HashSet, so iteration order is
+        // random. merge_per_workspace_lockfiles is first-wins for shared keys —
+        // sort to make the merged lockfile bytes (and the resulting hashes) stable.
+        workspace_lockfile_data.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+
         let refs: Vec<(&str, &[u8])> = workspace_lockfile_data
             .iter()
             .map(|(path, bytes)| (path.as_str(), bytes.as_slice()))
@@ -1039,6 +1044,79 @@ mod tests {
         assert!(
             actual,
             "all package managers without a special implementation should use workspace packages"
+        );
+    }
+
+    // Regression test: when shared-workspace-lockfile=false, per-workspace
+    // lockfiles are discovered via get_package_jsons, which returns paths from
+    // a HashSet. Merge is first-wins, so divergent shared keys would resolve to
+    // different bytes per run with HashSet iteration randomness. The merged
+    // lockfile must be byte-stable across runs so hashOfExternalDependencies
+    // (and therefore task cache hits) are deterministic.
+    #[test]
+    fn test_per_workspace_lockfile_merge_is_deterministic() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmpdir.path()).unwrap();
+
+        root.join_component(".npmrc")
+            .create_with_contents("shared-workspace-lockfile=false\n")
+            .unwrap();
+        root.join_component("pnpm-workspace.yaml")
+            .create_with_contents("packages:\n  - 'pkgs/*'\n")
+            .unwrap();
+        root.join_component("package.json")
+            .create_with_contents(r#"{"name":"root","private":true}"#)
+            .unwrap();
+        root.join_component("pnpm-lock.yaml")
+            .create_with_contents("lockfileVersion: '9.0'\nimporters:\n  .: {}\n")
+            .unwrap();
+
+        // Many workspaces sharing `lodash@4.17.21` but with divergent body —
+        // emulating pnpm resolving the same package differently per workspace
+        // context, which is the situation that triggers the bug in real repos.
+        let workspaces = ["a", "b", "c", "d", "e", "f", "g", "h"];
+        for (i, name) in workspaces.iter().enumerate() {
+            let dir = root.join_components(&["pkgs", name]);
+            dir.create_dir_all().unwrap();
+            dir.join_component("package.json")
+                .create_with_contents(format!(r#"{{"name":"{name}","private":true}}"#).as_bytes())
+                .unwrap();
+            let lockfile_yaml = format!(
+                r#"lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+packages:
+  lodash@4.17.21:
+    resolution: {{integrity: sha512-marker{i}}}
+snapshots:
+  lodash@4.17.21: {{}}
+"#
+            );
+            dir.join_component("pnpm-lock.yaml")
+                .create_with_contents(lockfile_yaml.as_bytes())
+                .unwrap();
+        }
+
+        let pm = PackageManager::Pnpm;
+        let root_pkg = PackageJson::load(&root.join_component("package.json")).unwrap();
+
+        // With 8 workspaces sharing one divergent key, the chance that 20 random
+        // HashSet orderings all happen to pick the same first-write is (1/8)^19,
+        // i.e. effectively zero. 20 iterations is plenty to catch a regression.
+        let mut encoded = HashSet::new();
+        for _ in 0..20 {
+            let lockfile = pm.read_lockfile(root, &root_pkg).unwrap();
+            encoded.insert(lockfile.encode().unwrap());
+        }
+        assert_eq!(
+            encoded.len(),
+            1,
+            "merged lockfile bytes should be identical across runs; got {} variants",
+            encoded.len()
         );
     }
 }


### PR DESCRIPTION
> Authored by Claude (Anthropic), guided by Joël Kuijper.

## Problem

When a pnpm monorepo uses `shared-workspace-lockfile=false` (each workspace gets its own `pnpm-lock.yaml`), turbo's per-task `hashOfExternalDependencies` is non-deterministic across consecutive runs. Result: the task cache misses on every run even when inputs are identical.

## Root cause

`crates/turborepo-repository/src/package_manager/mod.rs::try_read_pnpm_per_workspace_lockfiles` builds `workspace_lockfile_data` by iterating the result of `get_package_jsons`, which returns paths from a `HashSet<AbsoluteSystemPathBuf>` (`crates/turborepo-globwalk/src/lib.rs::globwalk_with_settings`). Rust's default `HashSet` uses `RandomState`, so iteration order varies per process.

The downstream `merge_per_workspace_lockfiles` in `crates/turborepo-lockfiles/src/pnpm/data.rs` uses `entry(key).or_insert(pkg)` (first-write-wins) for shared package keys. When two per-workspace lockfiles contain the same `name@version` key with divergent body — common because pnpm resolves peer-deps differently per workspace context — the "winner" flips with iteration order, producing different merged lockfile bytes and therefore different external-dep hashes per package.

## Fix

Sort `workspace_lockfile_data` by path before constructing the refs passed to `merge_per_workspace_lockfiles`. Single-line change; the merge function itself is untouched (its first-wins semantics are preserved).

## Test

Added `test_per_workspace_lockfile_merge_is_deterministic` in the package_manager tests module. It builds a fixture with 8 workspaces whose per-workspace lockfiles share `lodash@4.17.21` with divergent body, then calls `read_lockfile` 20 times and asserts the encoded merged bytes are identical across runs. Without the sort the test reproducibly fails with multiple distinct variants; with the sort it passes with 1.

## Reproduction

Self-contained repro: 5 workspaces with `shared-workspace-lockfile=false`, then force a divergent shared `lodash@4.18.1` entry between two of them. Needs `pnpm`, `jq`, `perl`, and a `turbo` binary on PATH.

<details><summary>Repro script</summary>

```bash
REPRO=/tmp/turbo-merge-repro
mkdir -p "$REPRO" && cd "$REPRO"

cat > .npmrc <<'CFG'
shared-workspace-lockfile=false
node-linker=hoisted
CFG
cat > package.json <<'CFG'
{ "name": "repro", "private": true, "packageManager": "pnpm@10.28.0" }
CFG
cat > pnpm-workspace.yaml <<'CFG'
packages: [pkgs/*]
catalog:
  lodash: ^4.17.21
  react: ^18.3.1
  vue: ^3.5.0
  axios: ^1.7.0
  yup: ^1.4.0
  zod: ^3.23.0
CFG
cat > turbo.json <<'CFG'
{ "$schema": "https://turbo.build/schema.json", "tasks": { "lint:ci": { "inputs": ["src/**", "package.json"], "outputs": [] } } }
CFG
for n in a b c d e; do
  mkdir -p "pkgs/$n/src"
  echo "export const x = '$n'" > "pkgs/$n/src/index.ts"
done
printf '%s\n' '{ "name": "a", "private": true, "scripts": { "lint:ci": "echo ok" }, "devDependencies": { "lodash": "catalog:", "react": "catalog:", "axios": "catalog:", "b": "workspace:*" } }' > pkgs/a/package.json
printf '%s\n' '{ "name": "b", "private": true, "scripts": { "lint:ci": "echo ok" }, "devDependencies": { "lodash": "catalog:", "vue": "catalog:", "yup": "catalog:" } }' > pkgs/b/package.json
printf '%s\n' '{ "name": "c", "private": true, "scripts": { "lint:ci": "echo ok" }, "devDependencies": { "react": "catalog:", "zod": "catalog:", "a": "workspace:*" } }' > pkgs/c/package.json
printf '%s\n' '{ "name": "d", "private": true, "scripts": { "lint:ci": "echo ok" }, "devDependencies": { "axios": "catalog:", "vue": "catalog:" } }' > pkgs/d/package.json
printf '%s\n' '{ "name": "e", "private": true, "scripts": { "lint:ci": "echo ok" }, "devDependencies": { "yup": "catalog:", "zod": "catalog:" } }' > pkgs/e/package.json

pnpm install

# Force divergence: pkgs/b's lodash@4.18.1 gets an extra dependency entry,
# pkgs/a's stays empty. The two per-workspace lockfiles now disagree on the
# body of that shared key — which is what triggers the flipping merge.
perl -i -pe 's|^  lodash\@4\.18\.1: \{\}|  lodash\@4.18.1:\n    dependencies:\n      yup: 1.7.1|' pkgs/b/pnpm-lock.yaml

# Replace `turbo` with whichever binary you want to test
# (e.g. ./target/release/turbo from a local build).
TURBO="${TURBO:-turbo}"
for i in $(seq 1 50); do
  $TURBO run lint:ci --filter=a --dry=json --skip-infer 2>/dev/null \
    | jq -r '.tasks[] | select(.taskId == "a#lint:ci") | .hashOfExternalDependencies'
done | sort | uniq -c
```

</details>

On `main`, the script prints two different hashes for `a#lint:ci` split roughly evenly across 50 runs (~24/26 in one observed run). With this PR applied it prints one hash, 50 times.

## Related

Similar pnpm-side concerns were raised in #12252. The merge-time bug here only triggers when two per-workspace lockfiles actually carry the same package key with diverging body — easy to miss on repos where peer-dep resolutions happen to be uniform across workspaces.