### PR TITLE
fix: Remove `auth`'s `expect()` usage

### DIFF
--- a/crates/turborepo-auth/src/auth/sso.rs
+++ b/crates/turborepo-auth/src/auth/sso.rs
@@ -418,23 +418,21 @@ fn wait_for_sso_redirect(listener: TcpListener, expected_state: &str) -> Result<
 
         // Determine redirect location (matching vc's getNotificationUrl behavior)
         let redirect_location = if params.contains_key("loginError") {
-            let mut redirect_url =
-                Url::parse("https://vercel.com/notifications/cli-login-failed").expect("valid URL");
+            let mut redirect_url = Url::parse("https://vercel.com/notifications/cli-login-failed")?;
             for (k, v) in &params {
                 redirect_url.query_pairs_mut().append_pair(k, v);
             }
             redirect_url.to_string()
         } else if params.contains_key("ssoEmail") {
             let mut redirect_url =
-                Url::parse("https://vercel.com/notifications/cli-login-incomplete")
-                    .expect("valid URL");
+                Url::parse("https://vercel.com/notifications/cli-login-incomplete")?;
             for (k, v) in &params {
                 redirect_url.query_pairs_mut().append_pair(k, v);
             }
             redirect_url.to_string()
         } else {
-            let mut redirect_url = Url::parse("https://vercel.com/notifications/cli-login-success")
-                .expect("valid URL");
+            let mut redirect_url =
+                Url::parse("https://vercel.com/notifications/cli-login-success")?;
             if let Some(email) = params.get("email") {
                 redirect_url.query_pairs_mut().append_pair("email", email);
             }

--- a/crates/turborepo-auth/src/lib.rs
+++ b/crates/turborepo-auth/src/lib.rs
@@ -2,7 +2,6 @@
 // miette's derive macro causes false positives for this lint
 #![allow(unused_assignments)]
 #![deny(clippy::all)]
-#![allow(clippy::expect_used)]
 //! Turborepo's library for authenticating with the Vercel API.
 //! Handles logging into Vercel, verifying SSO, and storing the token.
 
@@ -356,16 +355,14 @@ fn current_unix_time() -> u128 {
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .expect("Time went backwards")
-        .as_millis()
+        .map_or(0, |duration| duration.as_millis())
 }
 
 pub(crate) fn current_unix_time_secs() -> u64 {
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .expect("Time went backwards")
-        .as_secs()
+        .map_or(0, |duration| duration.as_secs())
 }
 
 // As of the time of writing, this should always be true, since a token that


### PR DESCRIPTION
## Why

`turborepo-auth` still required a crate-level `.expect()` allowance for a few implementation paths. That kept auth outside the workspace panic-hardening policy even after the unwrap cleanup.

Closes TURBO-5602

## What

Removes the remaining implementation `.expect()` calls from auth time handling and SSO notification redirect URL parsing, then drops the crate-level `clippy::expect_used` allowance.

## How

- `cargo fmt -p turborepo-auth`
- `cargo test -p turborepo-auth`
- `cargo clippy -p turborepo-auth --all-targets -- -D warnings`
- Pre-push hook passed with format, check:toml, and Rust checks