### PR TITLE
fix: Remove `turborepo-boundaries`'s `unwrap()` usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7354,7 +7354,6 @@ dependencies = [
  "oxc_span",
  "oxc_syntax",
  "rayon",
- "regex",
  "schemars",
  "serde",
  "struct_iterable",

--- a/crates/turborepo-boundaries/Cargo.toml
+++ b/crates/turborepo-boundaries/Cargo.toml
@@ -21,7 +21,6 @@ oxc_parser = { workspace = true }
 oxc_span = { workspace = true }
 oxc_syntax = { workspace = true }
 rayon = "1"
-regex = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 struct_iterable = "0.1.1"

--- a/crates/turborepo-boundaries/src/lib.rs
+++ b/crates/turborepo-boundaries/src/lib.rs
@@ -1,5 +1,4 @@
 #![allow(clippy::sliced_string_as_bytes)]
-#![allow(clippy::unwrap_used)]
 // miette's derive macro causes false positives for these lints
 #![allow(unused_assignments)]
 
@@ -11,16 +10,14 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fs::OpenOptions,
     io::Write,
-    sync::LazyLock,
 };
 
 pub use config::{BoundariesConfig, Permissions, Rule, RulesMap};
-use globwalk::Settings;
+use globwalk::{Settings, ValidatedGlob};
 use indicatif::ProgressBar;
 use miette::{Diagnostic, NamedSource, Report, SourceSpan};
 use oxc_ast::ast::Comment;
 use rayon::prelude::*;
-use regex::Regex;
 pub use tags::{ProcessedPermissions, ProcessedRule, ProcessedRulesMap};
 use thiserror::Error;
 use tracing::{debug_span, info_span};
@@ -215,6 +212,8 @@ pub enum Error {
     #[error(transparent)]
     Lockfiles(#[from] turborepo_lockfiles::Error),
     #[error(transparent)]
+    Glob(#[from] globwalk::GlobError),
+    #[error(transparent)]
     GlobWalk(#[from] globwalk::WalkError),
     #[error("failed to read file: {0}")]
     FileNotFound(AbsoluteSystemPathBuf),
@@ -234,9 +233,28 @@ impl BoundariesDiagnostic {
     }
 }
 
-static PACKAGE_NAME_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$").unwrap()
-});
+fn is_valid_package_name_segment(segment: &str) -> bool {
+    let Some((first, rest)) = segment.as_bytes().split_first() else {
+        return false;
+    };
+
+    matches!(*first, b'a'..=b'z' | b'0'..=b'9' | b'-' | b'~')
+        && rest
+            .iter()
+            .all(|byte| matches!(byte, b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~'))
+}
+
+fn is_valid_package_name(package_name: &str) -> bool {
+    if let Some(scoped_name) = package_name.strip_prefix('@') {
+        let Some((scope, name)) = scoped_name.split_once('/') else {
+            return false;
+        };
+
+        is_valid_package_name_segment(scope) && is_valid_package_name_segment(name)
+    } else {
+        is_valid_package_name_segment(package_name)
+    }
+}
 
 /// Maximum number of warnings to show
 const MAX_WARNINGS: usize = 16;
@@ -364,7 +382,7 @@ impl BoundariesChecker {
     /// against declared dependencies.
     fn is_potential_package_name(import: &str) -> bool {
         let base = imports::get_package_name(import);
-        PACKAGE_NAME_REGEX.is_match(base)
+        is_valid_package_name(base)
     }
 
     /// Patch a file with boundaries-ignore comments
@@ -569,19 +587,22 @@ impl BoundariesChecker {
 
         let files = {
             let _span = info_span!("globwalk", package = %package_name).entered();
+            let include_patterns: [ValidatedGlob; 8] = [
+                "**/*.js".parse()?,
+                "**/*.jsx".parse()?,
+                "**/*.ts".parse()?,
+                "**/*.tsx".parse()?,
+                "**/*.cjs".parse()?,
+                "**/*.mjs".parse()?,
+                "**/*.svelte".parse()?,
+                "**/*.vue".parse()?,
+            ];
+            let exclude_patterns: [ValidatedGlob; 1] = ["**/node_modules/**".parse()?];
+
             globwalk::globwalk_with_settings(
                 &package_root,
-                &[
-                    "**/*.js".parse().unwrap(),
-                    "**/*.jsx".parse().unwrap(),
-                    "**/*.ts".parse().unwrap(),
-                    "**/*.tsx".parse().unwrap(),
-                    "**/*.cjs".parse().unwrap(),
-                    "**/*.mjs".parse().unwrap(),
-                    "**/*.svelte".parse().unwrap(),
-                    "**/*.vue".parse().unwrap(),
-                ],
-                &["**/node_modules/**".parse().unwrap()],
+                &include_patterns,
+                &exclude_patterns,
                 globwalk::WalkType::Files,
                 Settings::default().ignore_nested_packages(),
             )?
@@ -710,7 +731,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_package_name_regex() {
+    fn test_potential_package_name() {
         assert!(BoundariesChecker::is_potential_package_name("lodash"));
         assert!(BoundariesChecker::is_potential_package_name(
             "@scope/package"


### PR DESCRIPTION
## Why

`turborepo-boundaries` still required a crate-level `.unwrap()` allowance for implementation helpers. Removing it brings the crate under the workspace panic-hardening policy and avoids hiding future unwrap regressions.

Closes TURBO-5639

## What

Removes implementation unwrap usage from package-name validation and static glob setup, then drops the now-unused regex dependency from the boundaries crate.

## How

- `cargo fmt -p turborepo-boundaries`
- `cargo test -p turborepo-boundaries`
- `cargo clippy -p turborepo-boundaries --all-targets -- -D warnings`
- Pre-push hook passed with format, check:toml, and Rust checks