### PR TITLE
fix: Remove scm unwrap usage

### DIFF
--- a/crates/turborepo-scm/src/crlf.rs
+++ b/crates/turborepo-scm/src/crlf.rs
@@ -344,7 +344,7 @@ impl BlobHasher for ManualBlobHasher {
     fn finalize(self) -> Result<OidHash, std::io::Error> {
         let result = self.0.finalize();
         let mut hex_buf = [0u8; 40];
-        hex::encode_to_slice(result, &mut hex_buf).unwrap();
+        hex::encode_to_slice(result, &mut hex_buf).map_err(std::io::Error::other)?;
         Ok(OidHash::from_hex_buf(hex_buf))
     }
 }

--- a/crates/turborepo-scm/src/hash_object.rs
+++ b/crates/turborepo-scm/src/hash_object.rs
@@ -88,7 +88,11 @@ pub(crate) fn hash_objects(
                                 .to_unix()
                             });
                         let mut hex_buf = [0u8; 40];
-                        hex::encode_to_slice(hash.as_bytes(), &mut hex_buf).unwrap();
+                        hex::encode_to_slice(hash.as_bytes(), &mut hex_buf).map_err(|err| {
+                            Error::git_error(format!(
+                                "failed to encode object id for {filename}: {err}"
+                            ))
+                        })?;
                         Ok(Some((
                             package_relative_path,
                             OidHash::from_hex_buf(hex_buf),

--- a/crates/turborepo-scm/src/lib.rs
+++ b/crates/turborepo-scm/src/lib.rs
@@ -2,7 +2,6 @@
 #![feature(io_error_more)]
 #![deny(clippy::all)]
 #![allow(clippy::result_large_err)]
-#![allow(clippy::unwrap_used)]
 
 //! Turborepo's library for interacting with source control management (SCM).
 //! Currently we only support git. We use SCM for finding changed files,

--- a/crates/turborepo-scm/src/repo_index.rs
+++ b/crates/turborepo-scm/src/repo_index.rs
@@ -137,7 +137,11 @@ impl RepoGitIndex {
                         }
 
                         let mut hex_buf = [0u8; 40];
-                        hex::encode_to_slice(e.id.as_bytes(), &mut hex_buf).unwrap();
+                        hex::encode_to_slice(e.id.as_bytes(), &mut hex_buf).map_err(|err| {
+                            Error::git_error(format!(
+                                "failed to encode object id for {rel_path}: {err}"
+                            ))
+                        })?;
                         Ok(EntryClassification::Clean {
                             path: rel_path,
                             oid: OidHash::from_hex_buf(hex_buf),


### PR DESCRIPTION
## Why

`turborepo-scm` still needed a crate-level `.unwrap()` allowance for object-id hex encoding paths. Removing it keeps SCM under the workspace panic-hardening policy and prevents future implementation unwraps from slipping through.

Closes TURBO-5643

## What

Propagates hex encoding failures through existing SCM/io error paths and removes the crate-level `clippy::unwrap_used` allowance.

## How

- `cargo fmt -p turborepo-scm`
- `cargo test -p turborepo-scm`
- `cargo clippy -p turborepo-scm --all-targets -- -D warnings`
- Pre-push hook passed with format, check:toml, and Rust checks