### PR TITLE
fix: Remove daemon unwrap usage

### DIFF
--- a/crates/turborepo-daemon/build.rs
+++ b/crates/turborepo-daemon/build.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let tonic_build_result = tonic_prost_build::configure()

--- a/crates/turborepo-daemon/src/client.rs
+++ b/crates/turborepo-daemon/src/client.rs
@@ -247,6 +247,9 @@ pub enum DaemonError {
     #[error("failed to determine package manager: {0}")]
     PackageManager(#[from] turborepo_repository::package_manager::Error),
 
+    #[error("failed to setup file watching: {0}")]
+    WatcherSetup(#[from] turborepo_filewatch::WatchError),
+
     #[error("`tail` is not installed. Please install it to use this feature.")]
     TailNotInstalled,
 

--- a/crates/turborepo-daemon/src/lib.rs
+++ b/crates/turborepo-daemon/src/lib.rs
@@ -22,7 +22,7 @@
 
 #![feature(impl_trait_in_assoc_type)]
 #![deny(clippy::all)]
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
 #![allow(clippy::needless_lifetimes)]
 #![allow(clippy::uninlined_format_args)]
 

--- a/crates/turborepo-daemon/src/server.rs
+++ b/crates/turborepo-daemon/src/server.rs
@@ -48,6 +48,7 @@ pub enum CloseReason {
     Timeout,
     Shutdown,
     WatcherClosed,
+    WatcherSetupError(WatchError),
     ServerClosed,
     Interrupt,
     SocketOpenError(SocketOpenError),
@@ -267,13 +268,16 @@ where
         let (trigger_shutdown, mut shutdown_signal) = mpsc::channel::<()>(1);
 
         let factory = package_changes_watcher_factory.clone();
-        let (service, exit_root_watch, watch_root_handle) = TurboGrpcServiceInner::new(
+        let (service, exit_root_watch, watch_root_handle) = match TurboGrpcServiceInner::new(
             repo_root.clone(),
             trigger_shutdown,
             paths.log_file,
             custom_turbo_json_path,
             move |args| (factory)(args),
-        );
+        ) {
+            Ok(inner) => inner,
+            Err(err) => return Ok(CloseReason::WatcherSetupError(err)),
+        };
 
         let running = Arc::new(AtomicBool::new(true));
         let (_pid_lock, stream) =
@@ -341,6 +345,15 @@ struct TurboGrpcServiceInner<W: PackageChangesWatcher + 'static> {
     package_watcher: Arc<PackageWatcher>,
 }
 
+type TurboGrpcServiceInnerInit<W> = Result<
+    (
+        TurboGrpcServiceInner<W>,
+        oneshot::Sender<()>,
+        JoinHandle<Result<(), WatchError>>,
+    ),
+    WatchError,
+>;
+
 // we have a grpc service that uses watching package discovery, and where the
 // watching package hasher also uses watching package discovery as well as
 // falling back to a local package hasher
@@ -351,11 +364,7 @@ impl<W: PackageChangesWatcher + 'static> TurboGrpcServiceInner<W> {
         log_file: AbsoluteSystemPathBuf,
         custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
         package_changes_watcher_factory: F,
-    ) -> (
-        Self,
-        oneshot::Sender<()>,
-        JoinHandle<Result<(), WatchError>>,
-    )
+    ) -> TurboGrpcServiceInnerInit<W>
     where
         F: Fn(PackageChangesWatcherArgs) -> W + Send + Sync + 'static,
     {
@@ -363,8 +372,7 @@ impl<W: PackageChangesWatcher + 'static> TurboGrpcServiceInner<W> {
             repo_root.clone(),
             custom_turbo_json_path,
             package_changes_watcher_factory,
-        )
-        .unwrap();
+        )?;
 
         tracing::debug!("initing package discovery");
         // Note that we're cloning the Arc, not the package watcher itself
@@ -381,7 +389,7 @@ impl<W: PackageChangesWatcher + 'static> TurboGrpcServiceInner<W> {
             root_watch_exit_signal,
         ));
 
-        (
+        Ok((
             TurboGrpcServiceInner {
                 package_watcher,
                 shutdown: trigger_shutdown,
@@ -392,7 +400,7 @@ impl<W: PackageChangesWatcher + 'static> TurboGrpcServiceInner<W> {
             },
             exit_root_watch,
             watch_root_handle,
-        )
+        ))
     }
 
     async fn trigger_shutdown(&self) {

--- a/crates/turborepo-lib/src/commands/daemon.rs
+++ b/crates/turborepo-lib/src/commands/daemon.rs
@@ -357,6 +357,7 @@ pub async fn daemon_server(
             warn!("daemon already running");
         }
         CloseReason::SocketOpenError(e) => return Err(e.into()),
+        CloseReason::WatcherSetupError(e) => return Err(e.into()),
         CloseReason::Interrupt
         | CloseReason::ServerClosed
         | CloseReason::WatcherClosed


### PR DESCRIPTION
## Why

`turborepo-daemon` still carried a crate-level `.unwrap()` allowance even though remaining unwraps are test-only. One server setup path also panicked if file watching failed to initialize.

Closes TURBO-5652

## What

Propagates file-watcher setup failures through daemon close/error handling and narrows daemon source/build-script lint allowances to `expect_used` only.

## How

- `cargo fmt -p turborepo-daemon -p turborepo-lib`
- `cargo test -p turborepo-daemon`
- `cargo clippy -p turborepo-daemon --all-targets -- -D warnings`
- `cargo clippy -p turborepo-lib --all-targets -- -D warnings`
- Pre-push hook passed with format, check:toml, and Rust checks