### PR TITLE
fix: Remove wax unwrap usage

### DIFF
--- a/crates/turborepo-wax/src/capture.rs
+++ b/crates/turborepo-wax/src/capture.rs
@@ -30,7 +30,11 @@ impl<'t> From<BorrowedText<'t>> for OwnedText {
 
 impl<'m, 't> From<&'m BorrowedText<'t>> for OwnedText {
     fn from(captures: &'m BorrowedText<'t>) -> Self {
-        let matched = captures.get(0).unwrap().as_str().into();
+        let matched = captures
+            .get(0)
+            .expect("captures have no complete text")
+            .as_str()
+            .into();
         let ranges = captures
             .iter()
             .skip(1)

--- a/crates/turborepo-wax/src/lib.rs
+++ b/crates/turborepo-wax/src/lib.rs
@@ -32,7 +32,7 @@
     clippy::unreadable_literal,
     clippy::unused_self
 )]
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
 
 mod capture;
 mod diagnostics;

--- a/crates/turborepo-wax/src/rule.rs
+++ b/crates/turborepo-wax/src/rule.rs
@@ -140,13 +140,10 @@ trait SliceExt<T> {
 
 impl<T> SliceExt<T> for [T] {
     fn terminals(&self) -> Option<Terminals<&T>> {
-        match self.len() {
-            0 => None,
-            1 => Some(Terminals::Only(self.first().unwrap())),
-            _ => Some(Terminals::StartEnd(
-                self.first().unwrap(),
-                self.last().unwrap(),
-            )),
+        match self {
+            [] => None,
+            [only] => Some(Terminals::Only(only)),
+            [first, .., last] => Some(Terminals::StartEnd(first, last)),
         }
     }
 }

--- a/crates/turborepo-wax/src/token/mod.rs
+++ b/crates/turborepo-wax/src/token/mod.rs
@@ -919,14 +919,9 @@ impl<'i, 't> LiteralSequence<'i, 't> {
     }
 
     pub fn text(&self) -> Cow<'t, str> {
-        if self.literals().len() == 1 {
-            self.literals().first().unwrap().text.clone()
-        } else {
-            self.literals()
-                .iter()
-                .map(|literal| &literal.text)
-                .join("")
-                .into()
+        match self.literals() {
+            [literal] => literal.text.clone(),
+            literals => literals.iter().map(|literal| &literal.text).join("").into(),
         }
     }
 

--- a/crates/turborepo-wax/src/walk/mod.rs
+++ b/crates/turborepo-wax/src/walk/mod.rs
@@ -128,7 +128,9 @@ trait SplitAtDepth {
 impl SplitAtDepth for Path {
     fn split_at_depth(&self, depth: usize) -> (&Path, &Path) {
         let ancestor = self.ancestors().nth(depth).unwrap_or(Path::new(""));
-        let descendant = self.strip_prefix(ancestor).unwrap();
+        let descendant = self
+            .strip_prefix(ancestor)
+            .expect("path ancestor is not a prefix");
         (ancestor, descendant)
     }
 }


### PR DESCRIPTION
## Why

`wax` still required a crate-level `.unwrap()` allowance, hiding implementation unwraps behind the workspace panic-hardening exemption.

Closes TURBO-5625

## What

Replaces implementation unwraps with slice matching or explicit invariant `expect()`s, then narrows the crate-level allowance to `expect_used` only.

## How

- `cargo fmt -p wax`
- `cargo test -p wax`
- `cargo clippy -p wax --all-targets -- -D warnings`
- Pre-push hook passed with format, check:toml, and Rust checks