### PR TITLE
fix: Remove `turborepo-wax`'s `expect()` usage

### DIFF
--- a/crates/turborepo-wax/src/capture.rs
+++ b/crates/turborepo-wax/src/capture.rs
@@ -32,8 +32,8 @@ impl<'m, 't> From<&'m BorrowedText<'t>> for OwnedText {
     fn from(captures: &'m BorrowedText<'t>) -> Self {
         let matched = captures
             .get(0)
-            .expect("captures have no complete text")
-            .as_str()
+            .map(|capture| capture.as_str())
+            .unwrap_or_default()
             .into();
         let ranges = captures
             .iter()
@@ -153,7 +153,13 @@ impl<'t> MatchedText<'t> {
     /// [`get`]: crate::MatchedText::get
     /// [`Program`]: crate::Program
     pub fn complete(&self) -> &str {
-        self.get(0).expect("match has no complete text")
+        match &self.inner {
+            MaybeOwnedText::Borrowed(captures) => captures
+                .get(0)
+                .map(|capture| capture.as_str())
+                .unwrap_or_default(),
+            MaybeOwnedText::Owned(captures) => captures.matched.as_ref(),
+        }
     }
 
     /// Gets the matched text of a capture at the given index.

--- a/crates/turborepo-wax/src/diagnostics/miette.rs
+++ b/crates/turborepo-wax/src/diagnostics/miette.rs
@@ -106,18 +106,19 @@ fn diagnose<'i, 't>(
         .chain(
             token::literals(tokenized.tokens())
                 .filter(|(_, literal)| literal.is_semantic_literal())
-                .map(|(component, literal)| {
-                    Box::new(SemanticLiteralWarning {
+                .filter_map(|(component, literal)| {
+                    let span = component
+                        .tokens()
+                        .iter()
+                        .map(|token| *token.annotation())
+                        .reduce(|left, right| left.union(&right))
+                        .map(SourceSpan::from)?;
+
+                    Some(Box::new(SemanticLiteralWarning {
                         expression: tokenized.expression().clone(),
                         literal: literal.text().clone(),
-                        span: component
-                            .tokens()
-                            .iter()
-                            .map(|token| *token.annotation())
-                            .reduce(|left, right| left.union(&right))
-                            .map(SourceSpan::from)
-                            .expect("no tokens in component"),
-                    }) as BoxedDiagnostic
+                        span,
+                    }) as BoxedDiagnostic)
                 }),
         )
         .chain(

--- a/crates/turborepo-wax/src/encode.rs
+++ b/crates/turborepo-wax/src/encode.rs
@@ -132,8 +132,9 @@ impl Grouping {
 }
 
 pub fn case_folded_eq(left: &str, right: &str) -> bool {
-    let regex = Regex::new(&format!("(?i){}", regex::escape(left)))
-        .expect("failed to compile literal regular expression");
+    let Ok(regex) = Regex::new(&format!("(?i){}", regex::escape(left))) else {
+        return false;
+    };
     if let Some(matched) = regex.find(right) {
         matched.start() == 0 && matched.end() == right.len()
     } else {

--- a/crates/turborepo-wax/src/lib.rs
+++ b/crates/turborepo-wax/src/lib.rs
@@ -32,8 +32,6 @@
     clippy::unreadable_literal,
     clippy::unused_self
 )]
-#![allow(clippy::expect_used)]
-
 mod capture;
 mod diagnostics;
 mod encode;
@@ -696,11 +694,19 @@ impl<'t> Glob<'t> {
     /// [`RuleError`]: crate::RuleError
     /// [`walk`]: crate::Glob::walk
     pub fn partition(self) -> (PathBuf, Self) {
-        let Glob { tree, .. } = self;
+        let Glob { tree, program } = self;
+        let original = tree.clone();
         let (prefix, tree) = tree.partition();
-        let program =
-            Glob::compile(tree.as_ref().tokens()).expect("failed to compile partitioned glob");
-        (prefix, Glob { tree, program })
+        match Glob::compile(tree.as_ref().tokens()) {
+            Ok(program) => (prefix, Glob { tree, program }),
+            Err(_) => (
+                PathBuf::new(),
+                Glob {
+                    tree: original,
+                    program,
+                },
+            ),
+        }
     }
 
     /// Clones any borrowed data into an owning instance.

--- a/crates/turborepo-wax/src/token/mod.rs
+++ b/crates/turborepo-wax/src/token/mod.rs
@@ -8,7 +8,7 @@ use std::{
     mem,
     ops::Deref,
     path::{MAIN_SEPARATOR, PathBuf},
-    slice, str,
+    slice,
 };
 
 use itertools::Itertools as _;
@@ -71,8 +71,13 @@ impl<'t> Tokenized<'t, Annotation> {
     pub fn partition(self) -> (PathBuf, Self) {
         fn pop_expression_bytes(expression: &str, n: usize) -> &str {
             let n = cmp::min(expression.len(), n);
-            str::from_utf8(&expression.as_bytes()[n..])
-                .expect("span offset split UTF-8 byte sequence")
+            expression.get(n..).unwrap_or_else(|| {
+                match ((n + 1)..=expression.len()).find(|index| expression.is_char_boundary(*index))
+                {
+                    Some(index) => &expression[index..],
+                    None => "",
+                }
+            })
         }
 
         let Tokenized {

--- a/crates/turborepo-wax/src/token/variance.rs
+++ b/crates/turborepo-wax/src/token/variance.rs
@@ -213,11 +213,7 @@ impl Mul<usize> for InvariantSize {
     type Output = Self;
 
     fn mul(self, n: usize) -> Self::Output {
-        InvariantSize(
-            self.0
-                .checked_mul(n)
-                .expect("overflow determining invariant size"),
-        )
+        InvariantSize(self.0.saturating_mul(n))
     }
 }
 
@@ -260,9 +256,7 @@ impl<'t> InvariantText<'t> {
             self
         } else {
             let InvariantText { fragments } = self;
-            let n = (n - 1)
-                .checked_mul(fragments.len())
-                .expect("overflow determining invariant text");
+            let n = (n - 1).saturating_mul(fragments.len());
             let first = fragments.clone();
             InvariantText {
                 fragments: first

--- a/crates/turborepo-wax/src/walk/glob.rs
+++ b/crates/turborepo-wax/src/walk/glob.rs
@@ -306,8 +306,7 @@ impl WalkProgram {
     fn from_glob(glob: &Glob<'_>) -> Self {
         WalkProgram {
             complete: glob.program.clone(),
-            components: WalkProgram::compile(glob.tree.as_ref().tokens())
-                .expect("failed to compile glob sub-expressions"),
+            components: WalkProgram::compile(glob.tree.as_ref().tokens()).unwrap_or_default(),
         }
     }
 }

--- a/crates/turborepo-wax/src/walk/mod.rs
+++ b/crates/turborepo-wax/src/walk/mod.rs
@@ -128,10 +128,10 @@ trait SplitAtDepth {
 impl SplitAtDepth for Path {
     fn split_at_depth(&self, depth: usize) -> (&Path, &Path) {
         let ancestor = self.ancestors().nth(depth).unwrap_or(Path::new(""));
-        let descendant = self
-            .strip_prefix(ancestor)
-            .expect("path ancestor is not a prefix");
-        (ancestor, descendant)
+        match self.strip_prefix(ancestor) {
+            Ok(descendant) => (ancestor, descendant),
+            Err(_) => (Path::new(""), self),
+        }
     }
 }
 
@@ -148,9 +148,7 @@ impl JoinAndGetDepth for Path {
             // If `path` is absolute, then it replaces `self` (`joined` and `path` are the
             // same). In this case, the depth of the join is the depth of
             // `joined` (there is no root sub-path).
-            depth
-                .checked_add(1)
-                .expect("overflow determining join depth")
+            depth.saturating_add(1)
         } else if path.has_root() {
             depth
         } else {
@@ -191,23 +189,18 @@ impl From<walkdir::Error> for WalkError {
     fn from(error: walkdir::Error) -> Self {
         let depth = error.depth();
         let path = error.path().map(From::from);
-        if error.io_error().is_some() {
+        let root = error.loop_ancestor().map(From::from);
+        if let Some(error) = error.into_io_error() {
             WalkError {
                 depth,
-                kind: WalkErrorKind::Io {
-                    path,
-                    error: error.into_io_error().expect("incongruent error kind"),
-                },
+                kind: WalkErrorKind::Io { path, error },
             }
         } else {
             WalkError {
                 depth,
                 kind: WalkErrorKind::LinkCycle {
-                    root: error
-                        .loop_ancestor()
-                        .expect("incongruent error kind")
-                        .into(),
-                    leaf: path.expect("incongruent error kind"),
+                    root: root.unwrap_or_default(),
+                    leaf: path.unwrap_or_default(),
                 },
             }
         }
@@ -542,7 +535,9 @@ impl TryFrom<walkdir::Error> for WaxDirEntry {
             .filter(|e| e.kind() == ErrorKind::NotFound)
             .is_some()
         {
-            let path = error.path().expect("not found errors always have paths");
+            let Some(path) = error.path() else {
+                return Err(error);
+            };
 
             if let Some(symlink_meta) = std::fs::symlink_metadata(path)
                 .ok()
@@ -616,11 +611,8 @@ impl Entry for TreeEntry {
     }
 
     fn root_relative_paths(&self) -> (&Path, &Path) {
-        self.path().split_at_depth(
-            self.depth()
-                .checked_add(self.prefix)
-                .expect("overflow determining root-relative paths"),
-        )
+        self.path()
+            .split_at_depth(self.depth().saturating_add(self.prefix))
     }
 
     fn metadata(&self) -> Result<Metadata, WalkError> {


### PR DESCRIPTION
## Why

`wax` still carried a crate-level `.expect()` allowance after the unwrap cleanup. That kept implementation panic helpers hidden from the workspace hardening policy.

Closes TURBO-5591

## What

Replaces implementation `.expect()` calls with non-panicking fallbacks, saturating arithmetic, or skipped diagnostics when derived invariants are missing, then removes the crate-level `clippy::expect_used` allowance.

## How

- `cargo fmt -p wax`
- `cargo test -p wax`
- `cargo clippy -p wax --all-targets -- -D warnings`
- Pre-push hook passed with format, check:toml, and Rust checks