### PR TITLE
fix: Remove `turborepo-cache`'s `expect()` usage

### DIFF
--- a/crates/turborepo-cache/src/async_cache.rs
+++ b/crates/turborepo-cache/src/async_cache.rs
@@ -43,7 +43,7 @@ impl AsyncCache {
         analytics_recorder: Option<AnalyticsSender>,
         scm_state: LazyScmState,
     ) -> Result<AsyncCache, CacheError> {
-        let max_workers = opts.workers.try_into().expect("usize is smaller than u32");
+        let max_workers = usize::try_from(opts.workers).unwrap_or(usize::MAX);
         let real_cache = Arc::new(CacheMultiplexer::new(
             opts,
             repo_root,

--- a/crates/turborepo-cache/src/cache_archive/create.rs
+++ b/crates/turborepo-cache/src/cache_archive/create.rs
@@ -40,7 +40,7 @@ fn generate_temp_path(final_path: &AbsoluteSystemPath) -> AbsoluteSystemPathBuf 
     let temp_name = format!(".{}.{}.{}.tmp", file_name, std::process::id(), unique_id);
     final_path
         .parent()
-        .expect("cache path must have parent")
+        .unwrap_or(final_path)
         .join_component(&temp_name)
 }
 

--- a/crates/turborepo-cache/src/cache_archive/restore.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore.rs
@@ -143,7 +143,9 @@ impl<'a> CacheReader<'a> {
             let processed_sourcename =
                 canonicalize_linkname(anchor, &processed_name, processed_name.as_path())?;
             // symlink must have a linkname
-            let linkname = entry.link_name()?.expect("symlink without linkname");
+            let linkname = entry
+                .link_name()?
+                .ok_or_else(|| CacheError::LinkTargetNotOnHeader(Backtrace::capture()))?;
 
             let processed_linkname = canonicalize_linkname(anchor, &processed_name, &linkname)?;
 

--- a/crates/turborepo-cache/src/cache_archive/restore_symlink.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore_symlink.rs
@@ -98,7 +98,9 @@ fn actually_restore_symlink<'a>(
 
     _ = symlink_from.remove();
 
-    let link_name = entry.link_name()?.expect("have linkname");
+    let link_name = entry
+        .link_name()?
+        .ok_or_else(|| CacheError::MalformedTar(Backtrace::capture()))?;
     let symlink_to = link_name.to_str().ok_or_else(|| {
         CacheError::PathError(
             PathError::InvalidUnicode(link_name.to_string_lossy().to_string()),
@@ -177,11 +179,13 @@ pub fn canonicalize_linkname(
         // a link target.
         UnknownPathType::Anchored(cleaned_linkname) => {
             let source = anchor.resolve(processed_name);
-            let canonicalized = source
-                .parent()
-                .expect("expected parent for file")
-                .resolve(&cleaned_linkname)
-                .clean()?;
+            let Some(parent) = source.parent() else {
+                return Err(CacheError::InvalidFilePath(
+                    source.to_string(),
+                    Backtrace::capture(),
+                ));
+            };
+            let canonicalized = parent.resolve(&cleaned_linkname).clean()?;
 
             Ok(canonicalized)
         }

--- a/crates/turborepo-cache/src/lib.rs
+++ b/crates/turborepo-cache/src/lib.rs
@@ -9,7 +9,7 @@
 // miette's derive macro causes false positives for this lint
 #![allow(unused_assignments)]
 #![deny(clippy::all)]
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::unwrap_used)]
 
 /// A wrapper for the cache that uses a worker pool to perform cache operations
 mod async_cache;


### PR DESCRIPTION
## Why

`turborepo-cache` still used implementation `.expect()` calls in archive and worker setup paths. Those panics hid malformed tar/header cases behind a crate-level lint exemption.

Closes TURBO-5598

## What

Converts cache archive link/header assumptions into existing `CacheError` paths, removes parent-path panics from temp/link handling, and narrows the crate-level lint allowance to the separate unwrap cleanup.

## How

- `cargo fmt -p turborepo-cache`
- `cargo test -p turborepo-cache`
- `cargo clippy -p turborepo-cache --all-targets -- -D warnings`
- Pre-push hook passed with format, check:toml, and Rust checks