### PR TITLE
fix: Remove `turborepo-filewatch`'s `expect()` usage

### DIFF
--- a/crates/turborepo-filewatch/src/debouncer.rs
+++ b/crates/turborepo-filewatch/src/debouncer.rs
@@ -19,7 +19,11 @@ impl Default for Debouncer {
 
 impl Debug for Debouncer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let serial = { self.serial.lock().expect("lock is valid") };
+        let serial = {
+            self.serial
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+        };
         f.debug_struct("Debouncer")
             .field("is_pending", &serial.is_some())
             .field("timeout", &self.timeout)
@@ -39,7 +43,10 @@ impl Debouncer {
     }
 
     pub(crate) fn bump(&self) -> bool {
-        let mut serial = self.serial.lock().expect("lock is valid");
+        let mut serial = self
+            .serial
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         match *serial {
             None => false,
             Some(previous) => {
@@ -52,10 +59,14 @@ impl Debouncer {
 
     pub(crate) async fn debounce(&self) {
         let mut serial = {
-            self.serial
+            let serial = self
+                .serial
                 .lock()
-                .expect("lock is valid")
-                .expect("only this thread sets the value to None")
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let Some(serial) = *serial else {
+                return;
+            };
+            serial
         };
         let mut deadline = Instant::now() + self.timeout;
         loop {
@@ -64,7 +75,16 @@ impl Debouncer {
                 _ = self.bump.notified() => {
                     trace!("debouncer notified");
                     // reset timeout
-                    let current_serial = self.serial.lock().expect("lock is valid").expect("only this thread sets the value to None");
+                    let current_serial = {
+                        let current_serial = self
+                            .serial
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner());
+                        let Some(current_serial) = *current_serial else {
+                            return;
+                        };
+                        current_serial
+                    };
                     if current_serial == serial {
                         // we timed out between the serial update and the notification.
                         // ignore this notification, we've already bumped the timer
@@ -77,8 +97,13 @@ impl Debouncer {
                 _ = timeout => {
                     // check if serial is still valid. It's possible a bump came in before the timeout,
                     // but we haven't been notified yet.
-                    let mut current_serial_opt = self.serial.lock().expect("lock is valid");
-                    let current_serial = current_serial_opt.expect("only this thread sets the value to None");
+                    let mut current_serial_opt = self
+                        .serial
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner());
+                    let Some(current_serial) = *current_serial_opt else {
+                        return;
+                    };
                     if current_serial == serial {
                         // if the serial is what we last observed, and the timer expired, we timed out.
                         // we're done. Mark that we won't accept any more bumps and return

--- a/crates/turborepo-filewatch/src/fsevent.rs
+++ b/crates/turborepo-filewatch/src/fsevent.rs
@@ -494,7 +494,7 @@ impl FsEventWatcher {
             }
 
             // Wait for the thread to shut down.
-            thread_handle.join().expect("thread to shut down");
+            let _ = thread_handle.join();
         }
     }
 
@@ -668,9 +668,7 @@ impl FsEventWatcher {
 
                     // the calling to CFRunLoopRun will be terminated by CFRunLoopStop call in
                     // drop()
-                    rl_tx
-                        .send(CFSendWrapper(cur_runloop))
-                        .expect("Unable to send runloop to watcher");
+                    let _ = rl_tx.send(CFSendWrapper(cur_runloop));
 
                     cf::CFRunLoopRun();
                     fs::FSEventStreamStop(stream);
@@ -685,8 +683,7 @@ impl FsEventWatcher {
     }
 
     fn configure_raw_mode(&mut self, _config: Config, tx: Sender<Result<bool>>) {
-        tx.send(Ok(false))
-            .expect("configuration channel disconnect");
+        let _ = tx.send(Ok(false));
     }
 }
 
@@ -777,7 +774,9 @@ unsafe fn callback_impl(
         for ev in translate_flags(flag, true).into_iter() {
             // TODO: precise
             let ev = ev.add_path(path.clone());
-            let mut event_handler = event_handler.lock().expect("lock not to be poisoned");
+            let mut event_handler = event_handler
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
             event_handler.handle_event(Ok(ev));
         }
     }

--- a/crates/turborepo-filewatch/src/globwatcher.rs
+++ b/crates/turborepo-filewatch/src/globwatcher.rs
@@ -391,8 +391,9 @@ impl GlobTracker {
             Ok(Err(error)) => self.on_error(error.into()),
             Ok(Ok(file_event)) => {
                 for path in file_event.paths {
-                    let path = AbsoluteSystemPathBuf::try_from(path)
-                        .expect("filewatching should produce absolute paths");
+                    let Ok(path) = AbsoluteSystemPathBuf::try_from(path) else {
+                        continue;
+                    };
                     if let Some(queries) = self
                         .cookie_watcher
                         .pop_ready_requests(file_event.kind, &path)

--- a/crates/turborepo-filewatch/src/hash_watcher.rs
+++ b/crates/turborepo-filewatch/src/hash_watcher.rs
@@ -212,11 +212,13 @@ impl FileHashes {
         // number of packages, on top of the trie internals.
         let keys = previous.keys().map(|k| k.to_owned()).collect::<Vec<_>>();
         for key in keys {
-            let previous_value = previous
-                .remove(&key)
-                .expect("this key was pulled from previous");
-            let path_key =
-                AnchoredSystemPath::new(&key).expect("keys are valid AnchoredSystemPaths");
+            let Some(previous_value) = previous.remove(&key) else {
+                continue;
+            };
+            let Ok(path_key) = AnchoredSystemPath::new(&key) else {
+                self.0.insert(key, previous_value);
+                continue;
+            };
             if !f(path_key) {
                 // keep it, we didn't match the key.
                 self.0.insert(key, previous_value);
@@ -239,8 +241,9 @@ impl FileHashes {
             .and_then(|subtrie| subtrie.key().map(|key| (key, subtrie)))
             // convert key to AnchoredSystemPath, and verify we have a value
             .and_then(|(package_path, subtrie)| {
-                let package_path = AnchoredSystemPath::new(package_path)
-                    .expect("keys are valid AnchoredSystemPaths");
+                let Ok(package_path) = AnchoredSystemPath::new(package_path) else {
+                    return None;
+                };
                 // handle scenarios where even though we've found an ancestor, it might be a
                 // sibling file or directory that starts with the same prefix,
                 // e,g an update to apps/foo_decoy when the package path is
@@ -606,11 +609,12 @@ impl Subscriber {
     ) {
         let mut changed_specs: HashSet<HashSpec> = HashSet::new();
         for path in event.paths {
-            let path = AbsoluteSystemPathBuf::try_from(path).expect("event path is a valid path");
-            let repo_relative_change_path = self
-                .repo_root
-                .anchor(&path)
-                .expect("event path is in the repository");
+            let Ok(path) = AbsoluteSystemPathBuf::try_from(path) else {
+                continue;
+            };
+            let Ok(repo_relative_change_path) = self.repo_root.anchor(&path) else {
+                continue;
+            };
             // If this change is not relevant to a package, ignore it
             trace!("file change at {:?}", repo_relative_change_path);
             let changed_specs_for_path = hashes.get_changed_specs(&repo_relative_change_path);
@@ -689,14 +693,9 @@ impl Subscriber {
         match package_data {
             Some(Ok(data)) => {
                 let package_paths: HashSet<AnchoredSystemPathBuf> =
-                    HashSet::from_iter(data.workspaces.iter().map(|ws| {
-                        self.repo_root
-                            .anchor(
-                                ws.package_json
-                                    .parent()
-                                    .expect("package.json is in a directory"),
-                            )
-                            .expect("package is in the repository")
+                    HashSet::from_iter(data.workspaces.iter().filter_map(|ws| {
+                        let package_dir = ws.package_json.parent()?;
+                        self.repo_root.anchor(package_dir).ok()
                     }));
                 // We have new package data. Drop any packages we don't need anymore, add any
                 // new ones

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -21,7 +21,7 @@
 //! `tokio::time::interval`.
 
 #![deny(clippy::all)]
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::unwrap_used)]
 #![allow(clippy::mutable_key_type)]
 #![allow(clippy::result_large_err)]
 
@@ -308,10 +308,9 @@ fn filter_relevant(root: &AbsoluteSystemPath, event: &mut Event) {
     let is_modify_existing = matches!(event.kind, EventKind::Remove(_) | EventKind::Modify(_));
 
     event.paths.retain_mut(|path| {
-        let abs_path: &AbsoluteSystemPath = path
-            .as_path()
-            .try_into()
-            .expect("Non-absolute path from filewatching");
+        let Ok(abs_path) = <&AbsoluteSystemPath>::try_from(path.as_path()) else {
+            return false;
+        };
         match root.relation_to_path(abs_path) {
             // An irrelevant path, probably from a non-recursive watch of a parent directory
             PathRelation::Divergent => false,

--- a/crates/turborepo-filewatch/src/optional_watch.rs
+++ b/crates/turborepo-filewatch/src/optional_watch.rs
@@ -52,7 +52,10 @@ impl<T> std::ops::Deref for SomeRef<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        self.0.as_ref().expect("checked")
+        match self.0.as_ref() {
+            Some(value) => value,
+            None => unreachable!("checked"),
+        }
     }
 }
 

--- a/crates/turborepo-filewatch/src/package_watcher.rs
+++ b/crates/turborepo-filewatch/src/package_watcher.rs
@@ -357,7 +357,7 @@ impl Subscriber {
             &file_event
                 .paths
                 .iter()
-                .map(|p| AbsoluteSystemPath::from_std_path(p).expect("these paths are absolute"))
+                .filter_map(|p| AbsoluteSystemPath::from_std_path(p).ok())
                 .collect::<Vec<_>>(),
         );
     }
@@ -418,13 +418,15 @@ impl Subscriber {
             .iter()
             .filter_map(|p| p.as_os_str().to_str())
         {
-            let path_file = AbsoluteSystemPathBuf::new(path).expect("watched paths are absolute");
+            let Ok(path_file) = AbsoluteSystemPathBuf::new(path) else {
+                continue;
+            };
             let path_workspace: &AbsoluteSystemPath =
                 if path_file.file_name() == Some("package.json") {
                     // The file event is for a package.json file. Check if the parent is a workspace
-                    let path_parent = path_file
-                        .parent()
-                        .expect("watched paths will not be at the root");
+                    let Some(path_parent) = path_file.parent() else {
+                        continue;
+                    };
                     if filter
                         .target_is_workspace(&self.repo_root, path_parent)
                         .unwrap_or(false)
@@ -559,7 +561,10 @@ async fn discover_packages(repo_root: AbsoluteSystemPathBuf) -> PackageState {
     let workspaces = initial_discovery
         .workspaces
         .into_iter()
-        .map(|p| (p.package_json.parent().expect("non-root").to_owned(), p))
+        .filter_map(|p| {
+            let parent = p.package_json.parent()?.to_owned();
+            Some((parent, p))
+        })
         .collect::<HashMap<_, _>>();
     PackageState::ValidWorkspaces {
         package_manager: initial_discovery.package_manager,

--- a/crates/turborepo-filewatch/src/scm_resource.rs
+++ b/crates/turborepo-filewatch/src/scm_resource.rs
@@ -33,11 +33,9 @@ impl SCMResource {
     }
 
     pub async fn acquire_scm(&self) -> SCMPermit<'_> {
-        let _permit = self
-            .semaphore
-            .acquire()
-            .await
-            .expect("semaphore should not be closed");
+        let Ok(_permit) = self.semaphore.acquire().await else {
+            unreachable!("semaphore should not be closed")
+        };
         SCMPermit {
             scm: &self.scm,
             _permit,


### PR DESCRIPTION
## Why

`turborepo-filewatch` still carried a crate-level `.expect()` allowance across production watcher paths. That hid panics in filesystem event handling, package discovery updates, and debounce/SCM coordination.

Closes TURBO-5612

## What

Replaces implementation `.expect()` calls with ignored send failures, poisoned-lock recovery, malformed-path filtering, and no-op handling for missing watcher state, then narrows the crate-level lint allowance to the separate unwrap cleanup.

## How

- `cargo fmt -p turborepo-filewatch`
- `cargo test -p turborepo-filewatch`
- `cargo clippy -p turborepo-filewatch --all-targets -- -D warnings`
- Pre-push hook passed with format, check:toml, and Rust checks