### PR TITLE
fix: Remove `turborepo-daemon`'s `expect()` usage

### DIFF
--- a/crates/turborepo-daemon/build.rs
+++ b/crates/turborepo-daemon/build.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::expect_used)]
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let tonic_build_result = tonic_prost_build::configure()
         .build_server(true)
@@ -13,9 +11,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
 
         return Ok(());
-    } else {
-        tonic_build_result.expect("tonic_build command");
     }
+
+    tonic_build_result?;
 
     Ok(())
 }

--- a/crates/turborepo-daemon/src/connector.rs
+++ b/crates/turborepo-daemon/src/connector.rs
@@ -248,8 +248,7 @@ impl DaemonConnector {
 
         // note, this endpoint is just a placeholder. the actual path is passed in via
         // make_service
-        Endpoint::try_from("http://[::]:50051")
-            .expect("this is a valid uri")
+        Endpoint::from_static("http://[::]:50051")
             .timeout(Self::CONNECT_TIMEOUT)
             .connect_with_connector(tower::service_fn(make_service))
             .await
@@ -433,7 +432,7 @@ async fn wait_for_file(
     // this can only fail if the channel has been closed, which will
     // always happen either after this call ends, or after this future
     // is cancelled
-    rx.recv().await.expect("will receive a message");
+    let _ = rx.recv().await;
 
     Ok(())
 }

--- a/crates/turborepo-daemon/src/default_timeout_layer.rs
+++ b/crates/turborepo-daemon/src/default_timeout_layer.rs
@@ -20,8 +20,6 @@
 //! a timeout that it wants (as long as it is less than 30s),
 //! and the server has sane defaults
 
-use std::time::Duration;
-
 use http_body::Body;
 use tonic::{codegen::http::Request, server::NamedService};
 use tower::{Layer, Service};
@@ -51,11 +49,7 @@ where
         if !req.uri().path().ends_with("Blocking") {
             req.headers_mut()
                 .entry("grpc-timeout")
-                .or_insert_with(move || {
-                    let dur = Duration::from_millis(100);
-                    tonic::codegen::http::HeaderValue::from_str(&format!("{}u", dur.as_micros()))
-                        .expect("numbers are always valid ascii")
-                });
+                .or_insert(tonic::codegen::http::HeaderValue::from_static("100000u"));
         };
 
         self.inner.call(req)

--- a/crates/turborepo-daemon/src/endpoint.rs
+++ b/crates/turborepo-daemon/src/endpoint.rs
@@ -152,9 +152,10 @@ pub async fn listen_socket(
                     };
                 });
 
-                let result = task
-                    .await
-                    .expect("no panic")?
+                let Some(accepted) = task.await.ok().flatten() else {
+                    return None;
+                };
+                let result = accepted
                     .map(|(stream, _)| stream)
                     .map(SafeUnixStream)
                     .and_then(async_io::Async::new)

--- a/crates/turborepo-daemon/src/lib.rs
+++ b/crates/turborepo-daemon/src/lib.rs
@@ -22,7 +22,6 @@
 
 #![feature(impl_trait_in_assoc_type)]
 #![deny(clippy::all)]
-#![allow(clippy::expect_used)]
 #![allow(clippy::needless_lifetimes)]
 #![allow(clippy::uninlined_format_args)]
 

--- a/crates/turborepo-daemon/src/server.rs
+++ b/crates/turborepo-daemon/src/server.rs
@@ -421,7 +421,10 @@ impl<W: PackageChangesWatcher + 'static> TurboGrpcServiceInner<W> {
             .watch_globs(hash.clone(), glob_set, REQUEST_TIMEOUT)
             .await?;
         {
-            let mut times_saved = self.times_saved.lock().expect("times saved lock poisoned");
+            let mut times_saved = self
+                .times_saved
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
             times_saved.insert(hash, time_saved);
         }
         Ok(())
@@ -433,7 +436,10 @@ impl<W: PackageChangesWatcher + 'static> TurboGrpcServiceInner<W> {
         candidates: HashSet<String>,
     ) -> Result<(HashSet<String>, u64), RpcError> {
         let time_saved = {
-            let times_saved = self.times_saved.lock().expect("times saved lock poisoned");
+            let times_saved = self
+                .times_saved
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
             times_saved.get(hash.as_str()).copied().unwrap_or_default()
         };
         let changed_globs = self


### PR DESCRIPTION
## Why

`turborepo-daemon` still carried a crate-level `.expect()` allowance after the unwrap cleanup. That hid panics in daemon metrics locking, build script proto generation, and connection setup invariants.

Closes TURBO-5610

## What

Replaces implementation/build `.expect()` calls with poisoned-lock recovery, static endpoint/header construction, ignored watcher channel closure, and propagated build errors, then removes the daemon `clippy::expect_used` allowances.

## How

- `cargo fmt -p turborepo-daemon`
- `cargo test -p turborepo-daemon`
- `cargo clippy -p turborepo-daemon --all-targets -- -D warnings`
- Pre-push hook passed with format, check:toml, and Rust checks