### PR TITLE
fix: Remove `turborepo-engine`'s `unwrap()` usage

### DIFF
--- a/crates/turborepo-engine/src/builder.rs
+++ b/crates/turborepo-engine/src/builder.rs
@@ -1141,11 +1141,10 @@ impl<'a, L: TurboJsonLoader> TaskInheritanceResolver<'a, L> {
         // Validate that the task exists in the extends chain (only at entry point)
         if self.validation_mode == ValidationMode::Validate && !inherited_tasks.contains(task_name)
         {
-            let (span, text) = task_def
-                .extends
-                .as_ref()
-                .unwrap()
-                .span_and_text("turbo.json");
+            let Some(extends) = task_def.extends.as_ref() else {
+                return Ok(());
+            };
+            let (span, text) = extends.span_and_text("turbo.json");
             let extends_chain = Self::format_extends_chain(turbo_json, inherited_tasks);
             return Err(BuilderError::TurboJson(
                 turborepo_turbo_json::Error::TaskNotInExtendsChain {

--- a/crates/turborepo-engine/src/builder_errors.rs
+++ b/crates/turborepo-engine/src/builder_errors.rs
@@ -81,7 +81,11 @@ impl InvalidTaskNameError {
     code(missing_root_task_in_turbo_json),
     url(
             "{}/messages/{}",
-            TURBO_SITE, self.code().unwrap().to_string().to_case(Case::Kebab)
+            TURBO_SITE,
+            self.code().map_or_else(
+                || "missing-root-task-in-turbo-json".to_string(),
+                |code| code.to_string().to_case(Case::Kebab),
+            )
     )
 )]
 pub struct MissingRootTaskInTurboJsonError {

--- a/crates/turborepo-engine/src/lib.rs
+++ b/crates/turborepo-engine/src/lib.rs
@@ -7,7 +7,7 @@
 // Allow large error types - boxing would be a significant refactor and these
 // errors are already established patterns in the codebase
 #![allow(clippy::result_large_err)]
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
 
 pub mod affected;
 mod builder;


### PR DESCRIPTION
## Why

`turborepo-engine` still carried a crate-level `.unwrap()` allowance even though implementation usage was limited. Removing it brings the crate under the workspace panic-hardening policy for unwraps.

Closes TURBO-5645

## What

Removes implementation unwraps from task inheritance validation and diagnostic URL generation, then narrows the engine lint allowance to the separate expect cleanup.

## How

- `cargo fmt -p turborepo-engine`
- `cargo test -p turborepo-engine`
- `cargo clippy -p turborepo-engine --all-targets -- -D warnings`
- Pre-push hook passed with format, check:toml, and Rust checks