### PR TITLE
fix: Remove filewatch unwrap usage

### DIFF
--- a/crates/turborepo-filewatch/src/fsevent.rs
+++ b/crates/turborepo-filewatch/src/fsevent.rs
@@ -569,7 +569,9 @@ impl FsEventWatcher {
             // First path - create device context
             let ctx = DeviceContext::new(path)?;
             self.device_context = Some(ctx);
-            self.device_context.as_ref().unwrap()
+            self.device_context
+                .as_ref()
+                .ok_or_else(|| Error::generic("missing device context"))?
         };
 
         // Use DeviceContext to convert path to device-relative format
@@ -677,7 +679,11 @@ impl FsEventWatcher {
                 }
             })?;
         // block until runloop has been sent
-        self.runloop = Some((rl_rx.recv().unwrap().0, thread_handle));
+        let Ok(runloop) = rl_rx.recv() else {
+            let _ = thread_handle.join();
+            return Err(Error::generic("runloop channel disconnected"));
+        };
+        self.runloop = Some((runloop.0, thread_handle));
 
         Ok(())
     }

--- a/crates/turborepo-filewatch/src/hash_watcher.rs
+++ b/crates/turborepo-filewatch/src/hash_watcher.rs
@@ -453,7 +453,7 @@ impl Subscriber {
                 if let Some(state) = hashes.get_mut(&spec) {
                     match state {
                         HashState::Hashes(hashes) => {
-                            tx.send(Ok(Arc::clone(hashes))).unwrap();
+                            let _ = tx.send(Ok(Arc::clone(hashes)));
                         }
                         HashState::Pending { txs, .. } => {
                             txs.push(tx);

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -21,7 +21,6 @@
 //! `tokio::time::interval`.
 
 #![deny(clippy::all)]
-#![allow(clippy::unwrap_used)]
 #![allow(clippy::mutable_key_type)]
 #![allow(clippy::result_large_err)]
 


### PR DESCRIPTION
## Why

`turborepo-filewatch` still had a crate-level `.unwrap()` allowance after the expect cleanup. Removing it keeps production watcher code under the workspace panic-hardening policy.

Closes TURBO-5649

## What

Replaces implementation unwraps in hash response sending and macOS file watcher runloop/device setup, then removes the crate-level `clippy::unwrap_used` allowance.

## How

- `cargo fmt -p turborepo-filewatch`
- `cargo test -p turborepo-filewatch`
- `cargo clippy -p turborepo-filewatch --all-targets -- -D warnings`
- Pre-push hook passed with format, check:toml, and Rust checks