### PR TITLE
fix: Remove engine expect usage

### DIFF
--- a/crates/turborepo-engine/src/builder.rs
+++ b/crates/turborepo-engine/src/builder.rs
@@ -157,7 +157,7 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         let turbo_json_loader = self
             .turbo_json_loader
             .take()
-            .expect("engine builder cannot be constructed without TurboJsonLoader");
+            .ok_or(BuilderError::MissingTurboJsonLoader)?;
         let mut missing_tasks: HashMap<&TaskName<'_>, Spanned<()>> =
             HashMap::from_iter(self.tasks.iter().map(|spanned| spanned.as_ref().split()));
         let mut traversal_queue = VecDeque::with_capacity(1);
@@ -746,10 +746,8 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         // Normal inheritance path
         let mut turbo_json_chain = turbo_json_chain.into_iter();
 
-        if let Some(root_definition) = turbo_json_chain
-            .next()
-            .expect("root turbo.json is always in chain")
-            .task(task_id, task_name)?
+        if let Some(root_turbo_json) = turbo_json_chain.next()
+            && let Some(root_definition) = root_turbo_json.task(task_id, task_name)?
         {
             task_definitions.push(root_definition)
         }

--- a/crates/turborepo-engine/src/builder_error.rs
+++ b/crates/turborepo-engine/src/builder_error.rs
@@ -57,6 +57,8 @@ pub enum Error {
     #[error(transparent)]
     #[diagnostic(transparent)]
     InvalidTaskName(Box<InvalidTaskNameError>),
+    #[error("Engine builder cannot be constructed without a turbo.json loader")]
+    MissingTurboJsonLoader,
 }
 
 impl From<ValidateError> for Error {

--- a/crates/turborepo-engine/src/execute.rs
+++ b/crates/turborepo-engine/src/execute.rs
@@ -38,6 +38,8 @@ impl ExecutionOptions {
 pub enum ExecuteError {
     #[error("Semaphore closed before all tasks finished")]
     Semaphore(#[from] tokio::sync::AcquireError),
+    #[error("Task worker failed: {0}")]
+    Join(#[from] tokio::task::JoinError),
     #[error("Engine visitor closed channel before walk finished")]
     Visitor,
     #[error(
@@ -96,7 +98,7 @@ impl<T: TaskDefinitionInfo + Clone + Send + Sync + 'static> Engine<Built, T> {
                 let TaskNode::Task(task_id) = this
                     .task_graph
                     .node_weight(node_id)
-                    .expect("node id should be present")
+                    .unwrap_or(&TaskNode::Root)
                 else {
                     // Root task has nothing to do so we don't emit any event for it
                     if done.send(true).is_err() {
@@ -110,10 +112,7 @@ impl<T: TaskDefinitionInfo + Clone + Send + Sync + 'static> Engine<Built, T> {
 
                 // Acquire the semaphore unless parallel
                 let _permit = match parallel {
-                    false => Some(sema.acquire().await.expect(
-                        "Graph concurrency semaphore closed while tasks are still attempting to \
-                         acquire permits",
-                    )),
+                    false => Some(sema.acquire().await?),
                     true => None,
                 };
 
@@ -131,7 +130,7 @@ impl<T: TaskDefinitionInfo + Clone + Send + Sync + 'static> Engine<Built, T> {
                     Err(StopExecution::AllTasks)
                         if walker
                             .lock()
-                            .expect("Walker mutex poisoned")
+                            .unwrap_or_else(|poisoned| poisoned.into_inner())
                             .cancel()
                             .is_err() =>
                     {
@@ -150,7 +149,7 @@ impl<T: TaskDefinitionInfo + Clone + Send + Sync + 'static> Engine<Built, T> {
         }
 
         while let Some(res) = tasks.next().await {
-            res.expect("unable to join task")?;
+            res??;
         }
 
         Ok(())

--- a/crates/turborepo-engine/src/graph_visualizer.rs
+++ b/crates/turborepo-engine/src/graph_visualizer.rs
@@ -136,7 +136,9 @@ pub fn write_graph<T: TaskDefinitionInfo + Clone, S: ChildSpawner>(
                     .args(["-T", extension.as_str(), "-o", filename.as_str()])
                     .current_dir(cwd);
                 let child = spawner.spawn(cmd).map_err(Error::Graphviz)?;
-                let stdin = child.take_stdin().expect("graphviz should have a stdin");
+                let stdin = child.take_stdin().ok_or_else(|| {
+                    Error::GraphOutput(io::Error::other("graphviz process did not provide stdin"))
+                })?;
                 render_dot_graph(stdin, engine, single_package)?;
                 child.wait().map_err(Error::Graphviz)?;
             } else {
@@ -208,7 +210,8 @@ fn render_html<T: TaskDefinitionInfo + Clone>(
         .map_err(Error::GraphOutput)?;
     let mut graph_buffer = Vec::new();
     render_dot_graph(&mut graph_buffer, engine, single_package)?;
-    let graph_string = String::from_utf8(graph_buffer).expect("graph rendering should be UTF-8");
+    let graph_string = String::from_utf8(graph_buffer)
+        .map_err(|err| Error::GraphOutput(io::Error::new(io::ErrorKind::InvalidData, err)))?;
     let graph_json = html_safe_json_string(&graph_string);
 
     file.write_all(HTML_PREFIX.as_bytes())
@@ -227,7 +230,7 @@ fn render_html<T: TaskDefinitionInfo + Clone>(
 
 fn html_safe_json_string(value: &str) -> String {
     serde_json::to_string(value)
-        .expect("serializing graph output should not fail")
+        .unwrap_or_else(|_| "\"\"".to_string())
         .replace('<', "\\u003C")
         .replace('>', "\\u003E")
         .replace('&', "\\u0026")

--- a/crates/turborepo-engine/src/lib.rs
+++ b/crates/turborepo-engine/src/lib.rs
@@ -7,7 +7,6 @@
 // Allow large error types - boxing would be a significant refactor and these
 // errors are already established patterns in the codebase
 #![allow(clippy::result_large_err)]
-#![allow(clippy::expect_used)]
 
 pub mod affected;
 mod builder;
@@ -1187,14 +1186,14 @@ impl turborepo_task_executor::TaskErrorCollector for TaskErrorCollectorWrapper {
     fn push_spawn_error(&self, task_id: String, error: std::io::Error) {
         self.0
             .lock()
-            .expect("lock poisoned")
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
             .push(TaskError::from_spawn(task_id, error));
     }
 
     fn push_execution_error(&self, task_id: String, command: String, exit_code: i32) {
         self.0
             .lock()
-            .expect("lock poisoned")
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
             .push(TaskError::from_execution(task_id, command, exit_code));
     }
 }
@@ -1227,7 +1226,10 @@ impl Default for TaskWarningCollectorWrapper {
 impl turborepo_task_executor::TaskWarningCollector for TaskWarningCollectorWrapper {
     fn push_platform_env_warning(&self, task_id: &str, missing_vars: Vec<String>) {
         if let Some(warning) = TaskWarning::new(task_id, missing_vars) {
-            self.0.lock().expect("lock poisoned").push(warning);
+            self.0
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push(warning);
         }
     }
 }


### PR DESCRIPTION
## Why

`turborepo-engine` still carried a crate-level `.expect()` allowance after the unwrap cleanup. That hid panics in execution, graph rendering, and collector locking paths.

Closes TURBO-5606

## What

Replaces implementation `.expect()` calls with explicit builder/join errors, poisoned-lock recovery, graph output errors, and non-panicking task graph handling, then removes the engine `clippy::expect_used` allowance.

## How

- `cargo fmt -p turborepo-engine`
- `cargo test -p turborepo-engine`
- `cargo clippy -p turborepo-engine --all-targets -- -D warnings`
- Pre-push hook passed with format, check:toml, and Rust checks