### PR TITLE
fix: Remove cache unwrap usage

### DIFF
--- a/crates/turborepo-cache/src/async_cache.rs
+++ b/crates/turborepo-cache/src/async_cache.rs
@@ -74,7 +74,9 @@ impl AsyncCache {
                         duration,
                         files,
                     } => {
-                        let permit = semaphore.clone().acquire_owned().await.unwrap();
+                        let Ok(permit) = semaphore.clone().acquire_owned().await else {
+                            break;
+                        };
                         let real_cache = real_cache.clone();
                         let warnings = warnings.clone();
                         let worker_span = tracing::span!(Level::TRACE, "cache worker: cache PUT");

--- a/crates/turborepo-cache/src/cache_archive/create.rs
+++ b/crates/turborepo-cache/src/cache_archive/create.rs
@@ -500,9 +500,13 @@ fn unix_mode_to_u32(mode: libc::mode_t) -> u32 {
 fn set_consistent_header_metadata(header: &mut Header) {
     header.set_uid(0);
     header.set_gid(0);
-    header.as_gnu_mut().unwrap().set_atime(0);
+    if let Some(header) = header.as_gnu_mut() {
+        header.set_atime(0);
+    }
     header.set_mtime(0);
-    header.as_gnu_mut().unwrap().set_ctime(0);
+    if let Some(header) = header.as_gnu_mut() {
+        header.set_ctime(0);
+    }
 }
 
 #[cfg(not(unix))]

--- a/crates/turborepo-cache/src/cache_archive/restore_directory.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore_directory.rs
@@ -114,7 +114,9 @@ impl CachedDirTree {
             // replaced with a real directory. Symlinks restored during the
             // current operation are preserved (they were intentionally placed
             // by the same tar archive).
-            let current = current_anchored.as_ref().unwrap();
+            let Some(current) = current_anchored.as_ref() else {
+                continue;
+            };
             let literal_path = anchor.resolve(AnchoredSystemPath::new(current.as_str())?);
             if let Ok(metadata) = literal_path.symlink_metadata()
                 && metadata.is_symlink()

--- a/crates/turborepo-cache/src/cache_archive/restore_manifest.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore_manifest.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, io::BufWriter, time::UNIX_EPOCH};
+use std::{backtrace::Backtrace, collections::HashMap, io::BufWriter, time::UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 use turbopath::AbsoluteSystemPath;
@@ -159,10 +159,14 @@ impl RestoreManifest {
     }
 
     pub fn write_atomic(&self, path: &AbsoluteSystemPath) -> Result<(), CacheError> {
-        let tmp_path = path
-            .parent()
-            .unwrap()
-            .join_component(&format!("{}.tmp", path.file_name().unwrap_or("manifest")));
+        let Some(parent) = path.parent() else {
+            return Err(CacheError::InvalidFilePath(
+                path.to_string(),
+                Backtrace::capture(),
+            ));
+        };
+        let tmp_path =
+            parent.join_component(&format!("{}.tmp", path.file_name().unwrap_or("manifest")));
         let file = std::fs::File::create(tmp_path.as_path())?;
         let writer = BufWriter::new(file);
         serde_json::to_writer(writer, self)

--- a/crates/turborepo-cache/src/cache_archive/restore_regular.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore_regular.rs
@@ -137,8 +137,7 @@ impl CachedDirTree {
         let parent = processed_name.as_path().parent();
         // Handles ./foo and foo
         let is_root_file = parent == Some(Path::new(".")) || parent == Some(Path::new(""));
-        if !is_root_file {
-            let dir = processed_name.parent().unwrap();
+        if !is_root_file && let Some(dir) = processed_name.parent() {
             self.safe_mkdir_all(anchor, dir, 0o755)?;
         }
 

--- a/crates/turborepo-cache/src/duration.rs
+++ b/crates/turborepo-cache/src/duration.rs
@@ -38,7 +38,9 @@ pub fn parse_human_duration(input: &str) -> Result<Duration, DurationParseError>
         return Ok(Duration::ZERO);
     }
 
-    let last = input.chars().last().unwrap();
+    let Some((unit_start, last)) = input.char_indices().last() else {
+        return Err(DurationParseError::Empty);
+    };
 
     if last.is_ascii_digit() {
         // Plain integer — treat as days
@@ -51,8 +53,8 @@ pub fn parse_human_duration(input: &str) -> Result<Duration, DurationParseError>
         return Ok(Duration::from_secs(secs));
     }
 
-    let (num_part, unit) = input.split_at(input.len() - 1);
-    let unit_char = unit.chars().next().unwrap();
+    let num_part = &input[..unit_start];
+    let unit_char = last;
 
     let n: u64 = num_part
         .parse()

--- a/crates/turborepo-cache/src/http.rs
+++ b/crates/turborepo-cache/src/http.rs
@@ -147,14 +147,22 @@ impl HTTPCache {
         Fut: std::future::Future<Output = Result<T, turborepo_api_client::Error>>,
     {
         // Try the operation with the current token
-        let api_auth = self.api_auth.lock().unwrap().clone();
+        let api_auth = self
+            .api_auth
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
         match operation(api_auth.clone()).await {
             Ok(result) => Ok(result),
             Err(turborepo_api_client::Error::UnknownStatus { code, .. }) if code == "forbidden" => {
                 // Try to refresh the token
                 if self.try_refresh_token().await {
                     // Retry the operation with the refreshed token
-                    let refreshed_auth = self.api_auth.lock().unwrap().clone();
+                    let refreshed_auth = self
+                        .api_auth
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner())
+                        .clone();
                     operation(refreshed_auth)
                         .await
                         .map_err(|err| Self::convert_api_error(hash, err))
@@ -219,7 +227,9 @@ impl HTTPCache {
                 let (progress, query) = UploadProgress::<10, 100, _>::new(stream, Some(body_len));
 
                 {
-                    let mut uploads = uploads_ref.lock().unwrap();
+                    let mut uploads = uploads_ref
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner());
                     uploads.insert(hash.to_string(), query);
                 }
 

--- a/crates/turborepo-cache/src/lib.rs
+++ b/crates/turborepo-cache/src/lib.rs
@@ -9,7 +9,6 @@
 // miette's derive macro causes false positives for this lint
 #![allow(unused_assignments)]
 #![deny(clippy::all)]
-#![allow(clippy::unwrap_used)]
 
 /// A wrapper for the cache that uses a worker pool to perform cache operations
 mod async_cache;

--- a/crates/turborepo-cache/src/upload_progress.rs
+++ b/crates/turborepo-cache/src/upload_progress.rs
@@ -59,7 +59,10 @@ where
                     let r#gen = (this.start.elapsed().as_millis() as usize) / INTERVAL;
                     (r#gen, r#gen % BUCKETS)
                 };
-                let mut state = this.state.lock().unwrap();
+                let mut state = this
+                    .state
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
                 let (r#gen, value) = &mut state.1[index];
                 if *r#gen != curr_gen {
                     *r#gen = curr_gen;
@@ -128,7 +131,9 @@ impl<const BUCKETS: usize, const INTERVAL: usize> UploadProgressQuery<BUCKETS, I
     ///
     /// Returns `None` if the `UploadProgress` has been dropped.
     pub fn bytes(&self) -> Option<usize> {
-        self.state.upgrade().map(|s| s.lock().unwrap().0)
+        self.state
+            .upgrade()
+            .map(|s| s.lock().unwrap_or_else(|poisoned| poisoned.into_inner()).0)
     }
 
     pub fn size(&self) -> Option<usize> {
@@ -146,7 +151,7 @@ impl<const BUCKETS: usize, const INTERVAL: usize> UploadProgressQuery<BUCKETS, I
         let curr_gen = self.curr_gen();
         let min_gen = curr_gen.saturating_sub(BUCKETS);
         self.state.upgrade().map(|s| {
-            let s = s.lock().unwrap();
+            let s = s.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
             let total_bytes =
                 s.1.iter()
                     .filter(|(r#gen, _)| *r#gen >= min_gen)


### PR DESCRIPTION
## Why

`turborepo-cache` still carried a crate-level `.unwrap()` allowance after the expect cleanup. That hid panics in archive restore/create paths, upload progress tracking, token refresh, and duration parsing.

Closes TURBO-5636

## What

Replaces implementation unwraps with malformed-path errors, poisoned-lock recovery, safe duration parsing, optional tar header handling, and graceful semaphore shutdown handling, then removes the cache `clippy::unwrap_used` allowance.

## How

- `cargo fmt -p turborepo-cache`
- `cargo test -p turborepo-cache`
- `cargo clippy -p turborepo-cache --all-targets -- -D warnings`
- Pre-push hook passed with format, check:toml, and Rust checks