### PR TITLE
fix: Remove `turborepo-lockfiles` `expect()` usage

### DIFF
--- a/crates/turborepo-lockfiles/examples/berry_resolutions.rs
+++ b/crates/turborepo-lockfiles/examples/berry_resolutions.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::unwrap_used)]
 
 use turborepo_lockfiles::{BerryLockfile, BerryManifest, Lockfile, LockfileData};
 

--- a/crates/turborepo-lockfiles/src/berry/mod.rs
+++ b/crates/turborepo-lockfiles/src/berry/mod.rs
@@ -632,7 +632,7 @@ impl Lockfile for BerryLockfile {
     }
 
     fn turbo_version(&self) -> Option<String> {
-        let turbo_ident = Ident::try_from("turbo").expect("'turbo' is valid identifier");
+        let turbo_ident = Ident::try_from("turbo").ok()?;
         let key = self
             .locator_package
             .keys()

--- a/crates/turborepo-lockfiles/src/bun/de.rs
+++ b/crates/turborepo-lockfiles/src/bun/de.rs
@@ -55,9 +55,7 @@ impl<'de> Deserialize<'de> for PackageEntry {
         if key.ends_with("@root:") {
             let root = vals.pop_front().and_then(|val| {
                 serde_json::from_value::<RootInfo>(match val {
-                    Vals::Info(info) => {
-                        serde_json::to_value(info.other).expect("failed to convert info to value")
-                    }
+                    Vals::Info(info) => serde_json::to_value(info.other).ok()?,
                     _ => return None,
                 })
                 .ok()

--- a/crates/turborepo-lockfiles/src/bun/mod.rs
+++ b/crates/turborepo-lockfiles/src/bun/mod.rs
@@ -2114,10 +2114,9 @@ impl BunLockfile {
             HashMap::with_capacity(pruned_data.packages.len());
         for (path, entry) in pruned_data.packages.iter() {
             if let Some(prev_path) = key_to_entry.insert(entry.ident.clone(), path.clone()) {
-                let prev_entry = pruned_data
-                    .packages
-                    .get(&prev_path)
-                    .expect("we just got this path from the packages list");
+                let Some(prev_entry) = pruned_data.packages.get(&prev_path) else {
+                    continue;
+                };
 
                 // Verify checksums match for duplicate idents
                 if prev_entry.checksum != entry.checksum {
@@ -2184,10 +2183,9 @@ impl FromStr for BunLockfile {
             let info = data.packages.get(path).unwrap();
 
             if let Some(prev_path) = key_to_entry.get(&info.ident) {
-                let prev_info = data
-                    .packages
-                    .get(prev_path)
-                    .expect("we just got this path from the packages list");
+                let Some(prev_info) = data.packages.get(prev_path) else {
+                    continue;
+                };
 
                 // Verify checksums match for duplicate idents
                 if prev_info.checksum != info.checksum {

--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -9,7 +9,7 @@
 //! prone than deserialization and analysis.
 
 #![deny(clippy::all)]
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::unwrap_used)]
 // the pest proc macro adds an empty doc comment.
 #![allow(clippy::empty_docs)]
 

--- a/crates/turborepo-lockfiles/src/pnpm/ser.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/ser.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Serialize, ser::Error};
 
 use super::{LockfileVersion, VersionFormat};
 
@@ -12,7 +12,7 @@ impl Serialize for LockfileVersion {
             VersionFormat::Float => serializer.serialize_f32(
                 self.version
                     .parse()
-                    .expect("Expected lockfile version to be valid f32"),
+                    .map_err(|err| S::Error::custom(format!("invalid lockfile version: {err}")))?,
             ),
         }
     }

--- a/crates/turborepo-lockfiles/src/yarn1/ser.rs
+++ b/crates/turborepo-lockfiles/src/yarn1/ser.rs
@@ -57,9 +57,9 @@ impl fmt::Display for Yarn1Lockfile {
             let mut keys = match seen_key {
                 Some(seen_key) => {
                     added_keys.insert(seen_key);
-                    let all_keys = reverse_lookup
-                        .get(seen_key.as_str())
-                        .expect("entry in lockfile should appear as a key in reverse lookup");
+                    let Some(all_keys) = reverse_lookup.get(seen_key.as_str()) else {
+                        continue;
+                    };
                     all_keys.iter().copied().collect::<Vec<_>>()
                 }
                 None => {
@@ -231,8 +231,8 @@ fn maybe_wrap(s: &str) -> Cow<'_, str> {
         // yarn uses JSON.stringify to escape strings
         // we approximate this behavior using serde_json
         true => serde_json::to_string(s)
-            .expect("failed at encoding string as json")
-            .into(),
+            .map(Cow::Owned)
+            .unwrap_or_else(|_| Cow::Borrowed(s)),
         false => s.into(),
     }
 }


### PR DESCRIPTION
## Why

`turborepo-lockfiles` still carried a source-level `.expect()` allowance. Removing it keeps lockfile parsing/serialization code under the workspace panic-hardening policy for expects.

Closes TURBO-5584

## What

Replaces implementation `.expect()` calls in Berry, Bun, pnpm, and Yarn serialization/deserialization paths with option/error fallbacks, then narrows lockfiles lint allowances to the separate unwrap cleanup.

## How

- `cargo fmt -p turborepo-lockfiles`
- `cargo test -p turborepo-lockfiles`
- `cargo clippy -p turborepo-lockfiles --all-targets -- -D warnings`
- Pre-push hook passed with format, check:toml, and Rust checks