### PR TITLE
chore: Set pnpm minimum release age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,8 @@ packages:
   - "!examples/non-monorepo"
   - lockfile-tests
 
+minimumReleaseAge: 2880
+
 onlyBuiltDependencies:
   - "@swc/core"
   - "@vercel/speed-insights"


### PR DESCRIPTION
## Why
Delay newly published packages during pnpm installs to reduce the blast radius of compromised npm releases.