### PR TITLE
fix: Remove `turborepo-lib`'s `expect()` usage

### DIFF
--- a/crates/turborepo-lib/src/child.rs
+++ b/crates/turborepo-lib/src/child.rs
@@ -22,7 +22,7 @@ pub fn spawn_child(mut command: Command) -> Result<Arc<SharedChild>, io::Error> 
             libc::kill(handler_shared_child.id() as i32, libc::SIGTERM);
         }
     })
-    .expect("handler set");
+    .map_err(io::Error::other)?;
 
     Ok(shared_child)
 }

--- a/crates/turborepo-lib/src/cli/error.rs
+++ b/crates/turborepo-lib/src/cli/error.rs
@@ -79,6 +79,8 @@ pub enum Error {
     SignalListener(#[from] turborepo_signals::listeners::Error),
     #[error(transparent)]
     Dialoguer(#[from] dialoguer::Error),
+    #[error("Failed to build Tokio runtime: {0}")]
+    Runtime(#[source] std::io::Error),
 }
 
 const MAX_CHARS_PER_TASK_LINE: usize = 100;

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1227,8 +1227,7 @@ impl RunArgs {
             if file.is_empty() {
                 let now = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
-                    .expect("system clock is before unix epoch")
-                    .as_millis();
+                    .map_or(0, |duration| duration.as_millis());
                 format!("profile.{now}")
             } else {
                 file.to_string()
@@ -1459,7 +1458,7 @@ pub fn run(
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
-        .expect("failed to build tokio runtime");
+        .map_err(Error::Runtime)?;
 
     runtime.block_on(run_main(repo_state, logger, color_config, query_server))
 }

--- a/crates/turborepo-lib/src/commands/daemon.rs
+++ b/crates/turborepo-lib/src/commands/daemon.rs
@@ -185,11 +185,13 @@ pub async fn daemon_client(
 
             let tail = which("tail").map_err(|_| DaemonError::TailNotInstalled)?;
 
-            std::process::Command::new(tail)
+            if let Err(err) = std::process::Command::new(tail)
                 .arg("-f")
                 .arg(log_file)
                 .status()
-                .expect("failed to execute tail");
+            {
+                tracing::error!("failed to execute tail: {err}");
+            }
         }
         DaemonCommand::Clean {
             clean_logs: should_clean_logs,

--- a/crates/turborepo-lib/src/commands/docs.rs
+++ b/crates/turborepo-lib/src/commands/docs.rs
@@ -27,8 +27,10 @@ fn validate_version(version_str: &str) -> Result<(), Error> {
         reason: e.to_string(),
     })?;
 
-    let min_version =
-        parse_version(MIN_DOCS_VERSION).expect("MIN_DOCS_VERSION should be a valid semver version");
+    let min_version = parse_version(MIN_DOCS_VERSION).map_err(|e| Error::InvalidVersion {
+        version: MIN_DOCS_VERSION.to_string(),
+        reason: e.to_string(),
+    })?;
 
     if version < min_version {
         return Err(Error::VersionTooOld {

--- a/crates/turborepo-lib/src/commands/login/mod.rs
+++ b/crates/turborepo-lib/src/commands/login/mod.rs
@@ -141,8 +141,7 @@ fn write_token(
         Some(ts) => {
             let now_secs = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
-                .expect("Time went backwards")
-                .as_secs();
+                .map_or(0, |duration| duration.as_secs());
             AuthTokens {
                 token: Some(token),
                 refresh_token: ts

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -184,7 +184,7 @@ pub async fn prune(
     let lockfile = prune
         .package_graph
         .lockfile()
-        .expect("Lockfile presence already checked")
+        .ok_or(Error::MissingLockfile)?
         .subgraph(&workspace_paths, &lockfile_keys)?;
 
     let lockfile_name = prune.package_graph.package_manager().lockfile_name();
@@ -230,7 +230,7 @@ pub async fn prune(
     let original_lockfile = prune
         .package_graph
         .lockfile()
-        .expect("lockfile presence checked earlier");
+        .ok_or(Error::MissingLockfile)?;
     let package_manager = prune.package_graph.package_manager();
     let original_patches = collect_patch_paths(
         original_lockfile,

--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -169,8 +169,10 @@ pub async fn run(
         }
 
         if let Some(handle) = handle {
-            if let Err(e) = handle.await.expect("render thread panicked") {
-                error!("error encountered rendering tui: {e}");
+            match handle.await {
+                Ok(Err(e)) => error!("error encountered rendering tui: {e}"),
+                Err(e) => error!("render thread panicked: {e}"),
+                Ok(Ok(())) => {}
             }
         }
 

--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -101,11 +101,10 @@ impl EngineExt for Engine<Built> {
             .task_graph()
             .node_indices()
             .map(|node_index| {
-                let TaskNode::Task(task_id) = self
-                    .task_graph()
-                    .node_weight(node_index)
-                    .expect("graph should contain weight for node index")
-                else {
+                let Some(task_node) = self.task_graph().node_weight(node_index) else {
+                    return Ok(false);
+                };
+                let TaskNode::Task(task_id) = task_node else {
                     // No need to check the root node if that's where we are.
                     return Ok(false);
                 };
@@ -114,11 +113,10 @@ impl EngineExt for Engine<Built> {
                     .task_graph()
                     .neighbors_directed(node_index, petgraph::Direction::Outgoing)
                 {
-                    let TaskNode::Task(dep_id) = self
-                        .task_graph()
-                        .node_weight(dep_index)
-                        .expect("index comes from iterating the graph and must be present")
-                    else {
+                    let Some(dep_node) = self.task_graph().node_weight(dep_index) else {
+                        continue;
+                    };
+                    let TaskNode::Task(dep_id) = dep_node else {
                         // No need to check the root node
                         continue;
                     };
@@ -154,9 +152,12 @@ impl EngineExt for Engine<Built> {
                 }
 
                 // check if the package for the task has that task in its package.json
-                let info = package_graph
-                    .package_info(&PackageName::from(task_id.package().to_string()))
-                    .expect("package graph should contain workspace info for task package");
+                let package_name = PackageName::from(task_id.package().to_string());
+                let info = package_graph.package_info(&package_name).ok_or_else(|| {
+                    ValidateError::MissingPackageJson {
+                        package: task_id.package().to_string(),
+                    }
+                })?;
 
                 let package_has_task = info
                     .package_json

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -6,7 +6,7 @@
 // miette's derive macro causes false positives for this lint
 #![allow(unused_assignments)]
 #![deny(clippy::all)]
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::unwrap_used)]
 // Clippy's needless mut lint is buggy: https://github.com/rust-lang/rust-clippy/issues/11299
 #![allow(clippy::needless_pass_by_ref_mut)]
 #![allow(clippy::result_large_err)]
@@ -45,8 +45,7 @@ pub use crate::{child::spawn_child, cli::Args, panic_handler::panic_handler};
 pub fn get_version() -> &'static str {
     include_str!("../../../version.txt")
         .split_once('\n')
-        .expect("Failed to read version from version.txt")
-        .0
+        .map_or(include_str!("../../../version.txt"), |(version, _)| version)
         // On windows we still have a trailing \r
         .trim_end()
 }

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -424,7 +424,7 @@ impl RunBuilder {
     ) -> Result<(Run, Option<AnalyticsHandle>), Error> {
         tracing::trace!(
             platform = %TurboState::platform_name(),
-            start_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).expect("system time after epoch").as_micros(),
+            start_time = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).map_or(0, |duration| duration.as_micros()),
             turbo_version = %TurboState::version(),
             numcpus = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1),
             "performing run on {:?}",
@@ -517,8 +517,7 @@ impl RunBuilder {
         // burned ~500ms of CPU on background threads.
         let scm = scm_task
             .instrument(tracing::info_span!("scm_task_await"))
-            .await
-            .expect("detecting scm panicked");
+            .await?;
         let all_prefixes = Self::all_package_prefixes(&pkg_dep_graph, &scm)?;
         let repo_index_task = if all_prefixes.is_empty() {
             None
@@ -578,11 +577,10 @@ impl RunBuilder {
             .api_auth
             .as_ref()
             .filter(|auth| auth.is_linked())
-            .map(|auth| {
-                let api_client = api_client
+            .and_then(|auth| {
+                api_client
                     .clone()
-                    .expect("linked analytics require a resolved API client");
-                start_analytics(auth.clone(), api_client)
+                    .map(|api_client| start_analytics(auth.clone(), api_client))
             })
             .unzip();
 
@@ -859,10 +857,11 @@ impl RunBuilder {
                 observability::Handle::try_init(opts, token)
             });
         let repo_index = Arc::new(match repo_index_task {
-            Some(repo_index_task) => repo_index_task
-                .instrument(tracing::info_span!("repo_index_untracked_await"))
-                .await
-                .expect("scoping repo index panicked"),
+            Some(repo_index_task) => {
+                repo_index_task
+                    .instrument(tracing::info_span!("repo_index_untracked_await"))
+                    .await?
+            }
             None => None,
         });
         Ok((
@@ -919,7 +918,7 @@ impl RunBuilder {
             .scope_opts
             .affected_range
             .as_ref()
-            .expect("caller verified affected_range is Some");
+            .ok_or(Error::MissingAffectedRange)?;
         let maybe_changed_files = scm.changed_files(
             &self.repo_root,
             from_ref.as_deref(),

--- a/crates/turborepo-lib/src/run/error.rs
+++ b/crates/turborepo-lib/src/run/error.rs
@@ -65,4 +65,16 @@ pub enum Error {
     ApiClient(#[from] turborepo_api_client::Error),
     #[error(transparent)]
     Scm(#[from] turborepo_scm::Error),
+    #[error("Background task failed: {0}")]
+    Join(#[from] tokio::task::JoinError),
+    #[error("Missing root workspace")]
+    MissingRootWorkspace,
+    #[error("File hash task did not complete")]
+    FileHashTaskIncomplete,
+    #[error("Internal dependency hash task did not complete")]
+    InternalDepsTaskIncomplete,
+    #[error("Global file hash task did not complete")]
+    GlobalFileHashTaskIncomplete,
+    #[error("Affected range was not configured")]
+    MissingAffectedRange,
 }

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -946,7 +946,7 @@ impl Run {
         let root_workspace = self
             .pkg_dep_graph
             .package_info(&PackageName::Root)
-            .expect("must have root workspace");
+            .ok_or(Error::MissingRootWorkspace)?;
 
         let is_monorepo = !self.opts.run_opts.single_package;
 
@@ -1023,11 +1023,11 @@ impl Run {
 
         let _setup_span = tracing::debug_span!("post_hashing_setup").entered();
 
-        let package_inputs_hashes = file_hash_result.expect("file hash task did not complete")?;
+        let package_inputs_hashes = file_hash_result.ok_or(Error::FileHashTaskIncomplete)??;
         let root_internal_dependencies_hash =
-            internal_deps_result.expect("internal deps task did not complete")?;
+            internal_deps_result.ok_or(Error::InternalDepsTaskIncomplete)??;
         let global_file_inputs =
-            global_file_result.expect("global file hash task did not complete")?;
+            global_file_result.ok_or(Error::GlobalFileHashTaskIncomplete)??;
 
         let root_external_dependencies_hash =
             is_monorepo.then(|| get_external_deps_hash(&root_workspace.transitive_dependencies));

--- a/crates/turborepo-lib/src/run/task_filter.rs
+++ b/crates/turborepo-lib/src/run/task_filter.rs
@@ -238,8 +238,7 @@ fn find_matching_packages(
     if let Some(parent_dir) = &selector.parent_dir {
         let parent_dir_unix = parent_dir.to_unix();
         if let Ok(globber) = wax::Glob::new(parent_dir_unix.as_str()) {
-            let root_anchor = AnchoredSystemPathBuf::from_raw(".").expect("valid anchored");
-            if parent_dir == &root_anchor {
+            if parent_dir.as_str() == "." {
                 packages.insert(PackageName::Root);
             } else {
                 for (name, info) in pkg_dep_graph.packages() {

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -406,7 +406,9 @@ impl WatchClient {
             loop {
                 notify_run.notified().await;
                 let some_changed_packages = {
-                    let mut guard = pending_changes.lock().expect("poisoned lock");
+                    let mut guard = pending_changes
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner());
                     (!guard.is_empty()).then(|| std::mem::take(guard.deref_mut()))
                 };
 
@@ -486,7 +488,11 @@ impl WatchClient {
             PackageChangeEvent::Package {
                 name,
                 changed_files: files,
-            } => match changed_packages.lock().expect("poisoned lock").deref_mut() {
+            } => match changed_packages
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .deref_mut()
+            {
                 ChangedPackages::All => {
                     // Already rediscovering everything, ignore
                 }
@@ -499,7 +505,9 @@ impl WatchClient {
                 }
             },
             PackageChangeEvent::Rediscover => {
-                *changed_packages.lock().expect("poisoned lock") = ChangedPackages::All;
+                *changed_packages
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner()) = ChangedPackages::All;
             }
         }
     }

--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -298,7 +298,9 @@ impl<'a> Visitor<'a> {
                 })
                 .collect();
 
-            let mut map = results.lock().expect("precompute lock poisoned");
+            let mut map = results
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
             for result in wave_results {
                 if let Some((task_id, hash, env)) = result? {
                     map.insert(task_id, (hash, env));
@@ -306,10 +308,14 @@ impl<'a> Visitor<'a> {
             }
         }
 
-        Ok(Arc::try_unwrap(results)
-            .expect("all wave references dropped")
-            .into_inner()
-            .expect("mutex not poisoned"))
+        match Arc::try_unwrap(results) {
+            Ok(mutex) => Ok(mutex
+                .into_inner()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())),
+            Err(arc) => Ok(std::mem::take(
+                &mut *arc.lock().unwrap_or_else(|poisoned| poisoned.into_inner()),
+            )),
+        }
     }
 
     #[tracing::instrument(skip_all)]
@@ -535,7 +541,9 @@ impl<'a> Visitor<'a> {
         // Always wait for the engine, even after a dispatch error. If we broke
         // early the engine will see the closed channel and return
         // Err(ExecuteError::Visitor), which is expected — not a real error.
-        let engine_result = engine_handle.await.expect("engine execution panicked");
+        let engine_result = engine_handle
+            .await
+            .map_err(|err| Error::InternalErrors(format!("engine execution panicked: {err}")))?;
 
         // Always drain spawned tasks so every TaskTracker is consumed before
         // the ExecutionTracker is dropped.
@@ -570,11 +578,13 @@ impl<'a> Visitor<'a> {
         self.task_access.save().await;
 
         let errors = match Arc::try_unwrap(errors) {
-            Ok(mutex) => mutex.into_inner().expect("mutex poisoned"),
+            Ok(mutex) => mutex
+                .into_inner()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
             Err(arc) => {
                 // In watch mode, fire-and-forget persistent tasks may still
                 // hold references. Drain the collected errors from the mutex.
-                std::mem::take(&mut *arc.lock().expect("mutex poisoned"))
+                std::mem::take(&mut *arc.lock().unwrap_or_else(|poisoned| poisoned.into_inner()))
             }
         };
 

--- a/crates/turborepo-lib/src/tracing.rs
+++ b/crates/turborepo-lib/src/tracing.rs
@@ -315,7 +315,7 @@ impl TurboSubscriber {
         self.daemon_update.reload(Some(layer))?;
         self.daemon_guard
             .lock()
-            .expect("not poisoned")
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
             .replace(guard);
 
         Ok(())
@@ -340,11 +340,11 @@ impl TurboSubscriber {
         self.chrome_update.reload(Some(layer))?;
         self.chrome_guard
             .lock()
-            .expect("not poisoned")
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
             .replace(guard);
         self.chrome_tracing_file
             .lock()
-            .expect("not poisoned")
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
             .replace(file_path);
 
         Ok(())
@@ -355,7 +355,7 @@ impl TurboSubscriber {
     pub fn chrome_tracing_file(&self) -> Option<String> {
         self.chrome_tracing_file
             .lock()
-            .expect("not poisoned")
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
             .clone()
     }
 
@@ -366,7 +366,10 @@ impl TurboSubscriber {
         // Disable the layer by replacing it with None
         self.chrome_update.reload(None)?;
         // Drop the flush guard to finalize the file
-        self.chrome_guard.lock().expect("not poisoned").take();
+        self.chrome_guard
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
         Ok(())
     }
 }


### PR DESCRIPTION
## Why

`turborepo-lib` still carried a crate-level `.expect()` allowance across core run, CLI, tracing, and visitor paths. Removing it keeps the main library under the workspace panic-hardening policy for expects.

Closes TURBO-5585

## What

Replaces implementation `.expect()` calls with explicit errors, poisoned-lock recovery, safe time fallbacks, graceful join handling, and existing command error paths, then narrows the lib lint allowance to the separate unwrap cleanup.

## How

- `cargo fmt -p turborepo-lib`
- `cargo clippy -p turborepo-lib --all-targets -- -D warnings`
- `cargo test -p turborepo-lib`
- Pre-push hook passed with format, check:toml, and Rust checks