### PR TITLE
fix: Remove `turborepo-lib`'s `unwrap()` usage

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -274,7 +274,9 @@ fn get_run_args_options() -> Vec<String> {
         .get_arguments()
         .filter(|arg| arg.get_long().is_some())
         .map(|arg| {
-            let long = arg.get_long().unwrap();
+            let Some(long) = arg.get_long() else {
+                return String::new();
+            };
             let value_names: Vec<_> = arg.get_value_names().unwrap_or_default().to_vec();
 
             if value_names.is_empty() {
@@ -426,11 +428,10 @@ impl Args {
             }
             if let Some(graph) = &run_args.graph {
                 match Utf8Path::new(graph).extension() {
-                    Some("png" | "jpg" | "pdf") => {
+                    Some(ext @ ("png" | "jpg" | "pdf")) => {
                         warn!(
                             "--graph with .{ext} output is deprecated and will be removed in \
                              version 3.0. Use .svg, .html, .mermaid, or .dot instead.",
-                            ext = Utf8Path::new(graph).extension().unwrap()
                         );
                     }
                     Some("json") => {
@@ -1541,7 +1542,11 @@ async fn run_main(
     // track args
     cli_args.track(&root_telemetry);
 
-    let cli_result = match cli_args.command.as_ref().unwrap() {
+    let Some(command) = cli_args.command.as_ref() else {
+        return Err(Error::NoCommand);
+    };
+
+    let cli_result = match command {
         Command::Bin => {
             CommandEventBuilder::new("bin")
                 .with_parent(&root_telemetry)

--- a/crates/turborepo-lib/src/commands/login/manual.rs
+++ b/crates/turborepo-lib/src/commands/login/manual.rs
@@ -156,7 +156,7 @@ fn write_remote(
     let with_api_url = set_path(
         &turbo_json_before,
         &["remoteCache", "apiUrl"],
-        &serde_json::to_string(api_url).unwrap(),
+        &serde_json::to_string(api_url)?,
     )?;
     let (key, value) = match team_id {
         TeamIdentifier::Id(id) => ("teamId", id),
@@ -165,7 +165,7 @@ fn write_remote(
     let with_team = set_path(
         &with_api_url,
         &["remoteCache", key],
-        &serde_json::to_string(&value).unwrap(),
+        &serde_json::to_string(&value)?,
     )?;
     root_turbo_json.ensure_dir()?;
     root_turbo_json.create_with_contents(with_team)?;

--- a/crates/turborepo-lib/src/commands/login/mod.rs
+++ b/crates/turborepo-lib/src/commands/login/mod.rs
@@ -26,6 +26,8 @@ pub enum Error {
     #[error(transparent)]
     Io(#[from] std::io::Error),
     #[error(transparent)]
+    SerdeJson(#[from] serde_json::Error),
+    #[error(transparent)]
     TurboJsonParse(#[from] crate::turbo_json::parser::Error),
 }
 

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -70,18 +70,15 @@ pub enum Error {
 static ADDITIONAL_FILES: LazyLock<Vec<(&'static RelativeUnixPath, Option<CopyDestination>)>> =
     LazyLock::new(|| {
         vec![
-            (RelativeUnixPath::new(".gitattributes").unwrap(), None),
-            (RelativeUnixPath::new(".gitignore").unwrap(), None),
+            (relative_unix_path(".gitattributes"), None),
+            (relative_unix_path(".gitignore"), None),
+            (relative_unix_path(".npmrc"), Some(CopyDestination::Docker)),
             (
-                RelativeUnixPath::new(".npmrc").unwrap(),
+                relative_unix_path(".yarnrc.yml"),
                 Some(CopyDestination::Docker),
             ),
             (
-                RelativeUnixPath::new(".yarnrc.yml").unwrap(),
-                Some(CopyDestination::Docker),
-            ),
-            (
-                RelativeUnixPath::new("bunfig.toml").unwrap(),
+                relative_unix_path("bunfig.toml"),
                 Some(CopyDestination::Docker),
             ),
         ]
@@ -90,29 +87,43 @@ static ADDITIONAL_DIRECTORIES: LazyLock<Vec<(&'static RelativeUnixPath, Option<C
     LazyLock::new(|| {
         vec![
             (
-                RelativeUnixPath::new(".yarn/plugins").unwrap(),
+                relative_unix_path(".yarn/plugins"),
                 Some(CopyDestination::Docker),
             ),
             (
-                RelativeUnixPath::new(".yarn/releases").unwrap(),
+                relative_unix_path(".yarn/releases"),
                 Some(CopyDestination::Docker),
             ),
         ]
     });
 
+fn relative_unix_path(path: &'static str) -> &'static RelativeUnixPath {
+    match RelativeUnixPath::new(path) {
+        Ok(path) => path,
+        Err(_) => unreachable!("static relative Unix path should be valid"),
+    }
+}
+
+fn anchored_path(path: &'static str) -> &'static AnchoredSystemPath {
+    match AnchoredSystemPath::new(path) {
+        Ok(path) => path,
+        Err(_) => unreachable!("static anchored path should be valid"),
+    }
+}
+
 fn package_json() -> &'static AnchoredSystemPath {
     static PATH: OnceLock<&'static AnchoredSystemPath> = OnceLock::new();
-    PATH.get_or_init(|| AnchoredSystemPath::new("package.json").unwrap())
+    PATH.get_or_init(|| anchored_path("package.json"))
 }
 
 fn turbo_json() -> &'static AnchoredSystemPath {
     static PATH: OnceLock<&'static AnchoredSystemPath> = OnceLock::new();
-    PATH.get_or_init(|| AnchoredSystemPath::new(CONFIG_FILE).unwrap())
+    PATH.get_or_init(|| anchored_path(CONFIG_FILE))
 }
 
 fn turbo_jsonc() -> &'static AnchoredSystemPath {
     static PATH: OnceLock<&'static AnchoredSystemPath> = OnceLock::new();
-    PATH.get_or_init(|| AnchoredSystemPath::new(CONFIG_FILE_JSONC).unwrap())
+    PATH.get_or_init(|| anchored_path(CONFIG_FILE_JSONC))
 }
 
 pub async fn prune(
@@ -163,14 +174,9 @@ pub async fn prune(
         // We don't want to do any copying for the root workspace
         if let PackageName::Other(workspace) = workspace {
             prune.copy_workspace(entry.package_json_path(), &entry.package_json)?;
-            workspace_paths.push(
-                entry
-                    .package_json_path()
-                    .parent()
-                    .unwrap()
-                    .to_unix()
-                    .to_string(),
-            );
+            if let Some(parent) = entry.package_json_path().parent() {
+                workspace_paths.push(parent.to_unix().to_string());
+            }
 
             println!(" - Added {workspace}");
             workspace_names.push(workspace);

--- a/crates/turborepo-lib/src/commands/query.rs
+++ b/crates/turborepo-lib/src/commands/query.rs
@@ -97,7 +97,7 @@ pub(crate) fn escape_graphql_string(s: &str) -> String {
             '\u{0008}' => out.push_str("\\b"),
             '\u{000C}' => out.push_str("\\f"),
             c if c.is_control() => {
-                write!(out, "\\u{:04X}", c as u32).unwrap();
+                let _ = write!(out, "\\u{:04X}", c as u32);
             }
             c => out.push(c),
         }
@@ -136,7 +136,7 @@ impl AffectedArgs {
         self.push_package_filter(&mut args);
         if !args.is_empty() {
             let joined = args.join(", ");
-            write!(query, "({joined})").unwrap();
+            let _ = write!(query, "({joined})");
         }
         query.push_str(" { items { name path reason { __typename } } length } }");
         query
@@ -156,7 +156,7 @@ impl AffectedArgs {
         self.push_package_filter(&mut args);
         if !args.is_empty() {
             let joined = args.join(", ");
-            write!(query, "({joined})").unwrap();
+            let _ = write!(query, "({joined})");
         }
         query.push_str(
             " { items { name fullName package { name } reason { __typename } } length } }",

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -6,7 +6,7 @@
 // miette's derive macro causes false positives for this lint
 #![allow(unused_assignments)]
 #![deny(clippy::all)]
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
 // Clippy's needless mut lint is buggy: https://github.com/rust-lang/rust-clippy/issues/11299
 #![allow(clippy::needless_pass_by_ref_mut)]
 #![allow(clippy::result_large_err)]

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -802,7 +802,9 @@ impl Run {
                         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
                         let (bytes_per_second, bytes_uploaded, bytes_total) = {
-                            let status = status.lock().unwrap();
+                            let status = status
+                                .lock()
+                                .unwrap_or_else(|poisoned| poisoned.into_inner());
                             let total_bps: f64 =
                                 status.values().filter_map(|task| task.average_bps()).sum();
                             let bytes_uploaded: usize =

--- a/crates/turborepo-lib/src/run/task_access.rs
+++ b/crates/turborepo-lib/src/run/task_access.rs
@@ -314,8 +314,13 @@ impl TaskAccess {
         }
 
         if let Some(config_cache) = &self.config_cache {
-            let traced_config =
-                RawTurboJson::from_task_access_trace(&self.trace_by_task.lock().unwrap());
+            let traced_config = {
+                let trace_by_task = self
+                    .trace_by_task
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                RawTurboJson::from_task_access_trace(&trace_by_task)
+            };
             if traced_config.is_some() {
                 // convert the traced_config to json and write the file to disk
                 let traced_config_json = serde_json::to_string_pretty(&traced_config)?;

--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -73,7 +73,11 @@ pub struct Visitor<'a> {
     code(recursive_turbo_invocations),
     url(
             "{}/messages/{}",
-            TURBO_SITE, self.code().unwrap().to_string().to_case(Case::Kebab)
+            TURBO_SITE,
+            self.code().map_or_else(
+                || "recursive-turbo-invocations".to_string(),
+                |code| code.to_string().to_case(Case::Kebab),
+            )
     )
 )]
 pub struct RecursiveTurboError {

--- a/crates/turborepo-lib/src/tracing.rs
+++ b/crates/turborepo-lib/src/tracing.rs
@@ -58,7 +58,10 @@ impl Write for SwitchableOutput {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         match &self.target {
             WriterTarget::Stderr => io::stderr().write(buf),
-            WriterTarget::File(f) => f.lock().unwrap().write(buf),
+            WriterTarget::File(f) => f
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .write(buf),
             WriterTarget::Null => Ok(buf.len()),
         }
     }
@@ -66,7 +69,10 @@ impl Write for SwitchableOutput {
     fn flush(&mut self) -> io::Result<()> {
         match &self.target {
             WriterTarget::Stderr => io::stderr().flush(),
-            WriterTarget::File(f) => f.lock().unwrap().flush(),
+            WriterTarget::File(f) => f
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .flush(),
             WriterTarget::Null => Ok(()),
         }
     }
@@ -92,7 +98,11 @@ impl<'a> MakeWriter<'a> for SwitchableWriter {
 
     fn make_writer(&'a self) -> Self::Writer {
         SwitchableOutput {
-            target: self.target.lock().unwrap().clone(),
+            target: self
+                .target
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone(),
         }
     }
 }
@@ -107,25 +117,50 @@ pub struct SwitchableWriterHandle {
 
 impl SwitchableWriterHandle {
     pub fn is_stderr(&self) -> bool {
-        matches!(*self.target.lock().unwrap(), WriterTarget::Stderr)
+        matches!(
+            *self
+                .target
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+            WriterTarget::Stderr
+        )
     }
 
     pub fn suppress(&self) {
-        *self.target.lock().unwrap() = WriterTarget::Null;
+        *self
+            .target
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = WriterTarget::Null;
     }
 
     pub fn redirect_to_file(&self, writer: Box<dyn Write + Send>, path: String) {
-        *self.target.lock().unwrap() = WriterTarget::File(Arc::new(Mutex::new(writer)));
-        *self.redirect_path.lock().unwrap() = Some(path);
+        *self
+            .target
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) =
+            WriterTarget::File(Arc::new(Mutex::new(writer)));
+        *self
+            .redirect_path
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(path);
     }
 
     pub fn redirect_path(&self) -> Option<String> {
-        self.redirect_path.lock().unwrap().clone()
+        self.redirect_path
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
     }
 
     pub fn restore(&self) {
-        *self.target.lock().unwrap() = WriterTarget::Stderr;
-        *self.redirect_path.lock().unwrap() = None;
+        *self
+            .target
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = WriterTarget::Stderr;
+        *self
+            .redirect_path
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
     }
 }
 
@@ -207,14 +242,16 @@ impl TurboSubscriber {
         };
 
         let env_filter = |level: LevelFilter| {
-            let filter = EnvFilter::builder()
+            let mut filter = EnvFilter::builder()
                 .with_default_directive(level.into())
                 .with_env_var("TURBO_LOG_VERBOSITY")
-                .from_env_lossy()
-                .add_directive("reqwest=error".parse().unwrap())
-                .add_directive("rustls=error".parse().unwrap())
-                .add_directive("hyper=warn".parse().unwrap())
-                .add_directive("h2=warn".parse().unwrap());
+                .from_env_lossy();
+
+            for directive in ["reqwest=error", "rustls=error", "hyper=warn", "h2=warn"] {
+                if let Ok(directive) = directive.parse() {
+                    filter = filter.add_directive(directive);
+                }
+            }
 
             if let Some(max_level) = level_override {
                 filter.add_directive(max_level.into())


### PR DESCRIPTION
## Why

`turborepo-lib` still carried a crate-level `.unwrap()` allowance after the expect cleanup. Removing it keeps the main library under the workspace panic-hardening policy for unwraps.

Closes TURBO-5631

## What

Replaces implementation unwraps in CLI/query building, login config writes, prune constants, task access, cache shutdown status tracking, diagnostics, and tracing lock handling, then narrows the lib lint allowance to the separate expect cleanup.

## How

- `cargo fmt -p turborepo-lib`
- `cargo clippy -p turborepo-lib --all-targets -- -D warnings`
- `cargo test -p turborepo-lib`
- Pre-push hook passed with format, check:toml, and Rust checks