### PR TITLE
fix: Remove shim test unwrap usage

### DIFF
--- a/crates/turborepo-shim/src/lib.rs
+++ b/crates/turborepo-shim/src/lib.rs
@@ -11,8 +11,6 @@
 //! The crate uses trait-based dependency injection to avoid circular
 //! dependencies with `turborepo-lib`.
 
-#![cfg_attr(test, allow(clippy::unwrap_used))]
-
 mod local_turbo_config;
 mod local_turbo_state;
 mod parser;
@@ -198,11 +196,12 @@ mod tests {
     }
 
     #[test]
-    fn test_default_config_provider() {
+    fn test_default_config_provider() -> Result<(), Box<dyn std::error::Error>> {
         let provider = DefaultConfigProvider;
         let fake_root =
-            AbsoluteSystemPathBuf::new(if cfg!(windows) { "C:\\repo" } else { "/repo" }).unwrap();
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { "C:\\repo" } else { "/repo" })?;
         let config = provider.get_config(&fake_root, None);
         assert!(!config.no_update_notifier());
+        Ok(())
     }
 }

--- a/crates/turborepo-shim/src/local_turbo_config.rs
+++ b/crates/turborepo-shim/src/local_turbo_config.rs
@@ -74,9 +74,9 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_package_manager_and_lockfile() {
-        let tmpdir = TempDir::with_prefix("local_config").unwrap();
-        let root = AbsoluteSystemPath::from_std_path(tmpdir.path()).unwrap();
+    fn test_package_manager_and_lockfile() -> Result<(), Box<dyn std::error::Error>> {
+        let tmpdir = TempDir::with_prefix("local_config")?;
+        let root = AbsoluteSystemPath::from_std_path(tmpdir.path())?;
         let repo = RepoState {
             root: root.to_owned(),
             mode: RepoMode::MultiPackage,
@@ -84,11 +84,9 @@ mod test {
             package_manager: Ok(PackageManager::Npm),
         };
         let lockfile = root.join_component("package-lock.json");
-        lockfile
-            .create_with_contents(include_bytes!(
-                "../fixtures/local_config/turbov2.package-lock.json"
-            ))
-            .unwrap();
+        lockfile.create_with_contents(include_bytes!(
+            "../fixtures/local_config/turbov2.package-lock.json"
+        ))?;
 
         assert_eq!(
             LocalTurboConfig::infer_internal(&repo, Some(true)),
@@ -96,12 +94,13 @@ mod test {
                 turbo_version: "2.0.3".into()
             })
         );
+        Ok(())
     }
 
     #[test]
-    fn test_just_lockfile() {
-        let tmpdir = TempDir::with_prefix("local_config").unwrap();
-        let root = AbsoluteSystemPath::from_std_path(tmpdir.path()).unwrap();
+    fn test_just_lockfile() -> Result<(), Box<dyn std::error::Error>> {
+        let tmpdir = TempDir::with_prefix("local_config")?;
+        let root = AbsoluteSystemPath::from_std_path(tmpdir.path())?;
         let repo = RepoState {
             root: root.to_owned(),
             mode: RepoMode::MultiPackage,
@@ -109,11 +108,9 @@ mod test {
             package_manager: Err(Error::MissingPackageManager),
         };
         let lockfile = root.join_component("package-lock.json");
-        lockfile
-            .create_with_contents(include_bytes!(
-                "../fixtures/local_config/turbov2.package-lock.json"
-            ))
-            .unwrap();
+        lockfile.create_with_contents(include_bytes!(
+            "../fixtures/local_config/turbov2.package-lock.json"
+        ))?;
 
         assert_eq!(
             LocalTurboConfig::infer_internal(&repo, Some(true)),
@@ -121,12 +118,13 @@ mod test {
                 turbo_version: "2.0.3".into()
             })
         );
+        Ok(())
     }
 
     #[test]
-    fn test_package_json_dep() {
-        let tmpdir = TempDir::with_prefix("local_config").unwrap();
-        let root = AbsoluteSystemPath::from_std_path(tmpdir.path()).unwrap();
+    fn test_package_json_dep() -> Result<(), Box<dyn std::error::Error>> {
+        let tmpdir = TempDir::with_prefix("local_config")?;
+        let root = AbsoluteSystemPath::from_std_path(tmpdir.path())?;
         let repo = RepoState {
             root: root.to_owned(),
             mode: RepoMode::MultiPackage,
@@ -142,12 +140,13 @@ mod test {
         };
 
         assert_eq!(LocalTurboConfig::infer_internal(&repo, Some(true)), None,);
+        Ok(())
     }
 
     #[test]
-    fn test_package_json_dev_dep() {
-        let tmpdir = TempDir::with_prefix("local_config").unwrap();
-        let root = AbsoluteSystemPath::from_std_path(tmpdir.path()).unwrap();
+    fn test_package_json_dev_dep() -> Result<(), Box<dyn std::error::Error>> {
+        let tmpdir = TempDir::with_prefix("local_config")?;
+        let root = AbsoluteSystemPath::from_std_path(tmpdir.path())?;
         let repo = RepoState {
             root: root.to_owned(),
             mode: RepoMode::MultiPackage,
@@ -163,12 +162,13 @@ mod test {
         };
 
         assert_eq!(LocalTurboConfig::infer_internal(&repo, Some(true)), None);
+        Ok(())
     }
 
     #[test]
-    fn test_v1_schema() {
-        let tmpdir = TempDir::with_prefix("local_config").unwrap();
-        let root = AbsoluteSystemPath::from_std_path(tmpdir.path()).unwrap();
+    fn test_v1_schema() -> Result<(), Box<dyn std::error::Error>> {
+        let tmpdir = TempDir::with_prefix("local_config")?;
+        let root = AbsoluteSystemPath::from_std_path(tmpdir.path())?;
         let repo = RepoState {
             root: root.to_owned(),
             mode: RepoMode::MultiPackage,
@@ -177,15 +177,15 @@ mod test {
         };
         let turbo_json = root.join_component("turbo.json");
         turbo_json
-            .create_with_contents(include_bytes!("../fixtures/local_config/turbo.v1.json"))
-            .unwrap();
+            .create_with_contents(include_bytes!("../fixtures/local_config/turbo.v1.json"))?;
         assert_eq!(LocalTurboConfig::infer_internal(&repo, Some(true)), None);
+        Ok(())
     }
 
     #[test]
-    fn test_v2_schema() {
-        let tmpdir = TempDir::with_prefix("local_config").unwrap();
-        let root = AbsoluteSystemPath::from_std_path(tmpdir.path()).unwrap();
+    fn test_v2_schema() -> Result<(), Box<dyn std::error::Error>> {
+        let tmpdir = TempDir::with_prefix("local_config")?;
+        let root = AbsoluteSystemPath::from_std_path(tmpdir.path())?;
         let repo = RepoState {
             root: root.to_owned(),
             mode: RepoMode::MultiPackage,
@@ -194,15 +194,15 @@ mod test {
         };
         let turbo_json = root.join_component("turbo.json");
         turbo_json
-            .create_with_contents(include_bytes!("../fixtures/local_config/turbo.v2.json"))
-            .unwrap();
+            .create_with_contents(include_bytes!("../fixtures/local_config/turbo.v2.json"))?;
         assert_eq!(LocalTurboConfig::infer_internal(&repo, Some(true)), None,);
+        Ok(())
     }
 
     #[test]
-    fn nothing() {
-        let tmpdir = TempDir::with_prefix("local_config").unwrap();
-        let root = AbsoluteSystemPath::from_std_path(tmpdir.path()).unwrap();
+    fn nothing() -> Result<(), Box<dyn std::error::Error>> {
+        let tmpdir = TempDir::with_prefix("local_config")?;
+        let root = AbsoluteSystemPath::from_std_path(tmpdir.path())?;
         let repo = RepoState {
             root: root.to_owned(),
             mode: RepoMode::MultiPackage,
@@ -210,5 +210,6 @@ mod test {
             package_manager: Err(Error::MissingPackageManager),
         };
         assert_eq!(LocalTurboConfig::infer_internal(&repo, Some(true)), None,);
+        Ok(())
     }
 }

--- a/crates/turborepo-shim/src/local_turbo_state.rs
+++ b/crates/turborepo-shim/src/local_turbo_state.rs
@@ -319,25 +319,28 @@ mod test {
         assert_eq!(turbo_version_has_shim(version), expected);
     }
 
-    fn create_mock_turbo_install(root: &AbsoluteSystemPath, package_path: &[&str], version: &str) {
+    fn create_mock_turbo_install(
+        root: &AbsoluteSystemPath,
+        package_path: &[&str],
+        version: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let binary_name = TurboState::binary_name();
 
         let mut bin_components: Vec<&str> = package_path.to_vec();
         bin_components.extend_from_slice(&["bin", binary_name]);
         let bin_file = root.join_components(&bin_components);
-        bin_file.ensure_dir().unwrap();
-        bin_file.create_with_contents("").unwrap();
+        bin_file.ensure_dir()?;
+        bin_file.create_with_contents("")?;
 
         let mut json_components: Vec<&str> = package_path.to_vec();
         json_components.push("package.json");
         let json_file = root.join_components(&json_components);
-        json_file.ensure_dir().unwrap();
-        json_file
-            .create_with_contents(format!(
-                r#"{{"name": "test-turbo", "version": "{}"}}"#,
-                version,
-            ))
-            .unwrap();
+        json_file.ensure_dir()?;
+        json_file.create_with_contents(format!(
+            r#"{{"name": "test-turbo", "version": "{}"}}"#,
+            version,
+        ))?;
+        Ok(())
     }
 
     fn scoped_path() -> Vec<&'static str> {
@@ -352,53 +355,64 @@ mod test {
     }
 
     #[test]
-    fn test_infer_hoisted_scoped() {
-        let tmpdir = TempDir::with_prefix("turbo_infer").unwrap();
-        let root = AbsoluteSystemPath::from_std_path(tmpdir.path()).unwrap();
+    fn test_infer_hoisted_scoped() -> Result<(), Box<dyn std::error::Error>> {
+        let tmpdir = TempDir::with_prefix("turbo_infer")?;
+        let root = AbsoluteSystemPath::from_std_path(tmpdir.path())?;
         let nm = root.join_component("node_modules");
 
-        create_mock_turbo_install(&nm, &scoped_path(), "2.0.0");
+        create_mock_turbo_install(&nm, &scoped_path(), "2.0.0")?;
 
-        let result = LocalTurboState::infer(root).unwrap();
+        let Some(result) = LocalTurboState::infer(root) else {
+            panic!("local turbo state should be inferred");
+        };
         assert_eq!(result.version(), "2.0.0");
+        Ok(())
     }
 
     #[test]
-    fn test_infer_hoisted_legacy_fallback() {
-        let tmpdir = TempDir::with_prefix("turbo_infer").unwrap();
-        let root = AbsoluteSystemPath::from_std_path(tmpdir.path()).unwrap();
+    fn test_infer_hoisted_legacy_fallback() -> Result<(), Box<dyn std::error::Error>> {
+        let tmpdir = TempDir::with_prefix("turbo_infer")?;
+        let root = AbsoluteSystemPath::from_std_path(tmpdir.path())?;
         let nm = root.join_component("node_modules");
 
-        create_mock_turbo_install(&nm, &legacy_path(), "1.9.0");
+        create_mock_turbo_install(&nm, &legacy_path(), "1.9.0")?;
 
-        let result = LocalTurboState::infer(root).unwrap();
+        let Some(result) = LocalTurboState::infer(root) else {
+            panic!("local turbo state should be inferred");
+        };
         assert_eq!(result.version(), "1.9.0");
+        Ok(())
     }
 
     #[test]
-    fn test_infer_scoped_preferred_over_legacy() {
-        let tmpdir = TempDir::with_prefix("turbo_infer").unwrap();
-        let root = AbsoluteSystemPath::from_std_path(tmpdir.path()).unwrap();
+    fn test_infer_scoped_preferred_over_legacy() -> Result<(), Box<dyn std::error::Error>> {
+        let tmpdir = TempDir::with_prefix("turbo_infer")?;
+        let root = AbsoluteSystemPath::from_std_path(tmpdir.path())?;
         let nm = root.join_component("node_modules");
 
-        create_mock_turbo_install(&nm, &scoped_path(), "3.0.0");
-        create_mock_turbo_install(&nm, &legacy_path(), "2.0.0");
+        create_mock_turbo_install(&nm, &scoped_path(), "3.0.0")?;
+        create_mock_turbo_install(&nm, &legacy_path(), "2.0.0")?;
 
-        let result = LocalTurboState::infer(root).unwrap();
+        let Some(result) = LocalTurboState::infer(root) else {
+            panic!("local turbo state should be inferred");
+        };
         assert_eq!(result.version(), "3.0.0");
+        Ok(())
     }
 
     #[test]
-    fn test_infer_empty_dir_returns_none() {
-        let tmpdir = TempDir::with_prefix("turbo_infer").unwrap();
-        let root = AbsoluteSystemPath::from_std_path(tmpdir.path()).unwrap();
+    fn test_infer_empty_dir_returns_none() -> Result<(), Box<dyn std::error::Error>> {
+        let tmpdir = TempDir::with_prefix("turbo_infer")?;
+        let root = AbsoluteSystemPath::from_std_path(tmpdir.path())?;
         assert!(LocalTurboState::infer(root).is_none());
+        Ok(())
     }
 
     #[test]
-    fn test_infer_malformed_package_json_continues_search() {
-        let tmpdir = TempDir::with_prefix("turbo_infer").unwrap();
-        let root = AbsoluteSystemPath::from_std_path(tmpdir.path()).unwrap();
+    fn test_infer_malformed_package_json_continues_search() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let tmpdir = TempDir::with_prefix("turbo_infer")?;
+        let root = AbsoluteSystemPath::from_std_path(tmpdir.path())?;
         let nm = root.join_component("node_modules");
 
         let scoped = scoped_path();
@@ -408,27 +422,30 @@ mod test {
         let mut bin_components: Vec<&str> = scoped.clone();
         bin_components.extend_from_slice(&["bin", binary_name]);
         let bin_file = nm.join_components(&bin_components);
-        bin_file.ensure_dir().unwrap();
-        bin_file.create_with_contents("").unwrap();
+        bin_file.ensure_dir()?;
+        bin_file.create_with_contents("")?;
 
         let mut json_components: Vec<&str> = scoped.clone();
         json_components.push("package.json");
         let json_file = nm.join_components(&json_components);
-        json_file.ensure_dir().unwrap();
-        json_file.create_with_contents("not valid json").unwrap();
+        json_file.ensure_dir()?;
+        json_file.create_with_contents("not valid json")?;
 
         // Create valid legacy install
-        create_mock_turbo_install(&nm, &legacy_path(), "1.8.0");
+        create_mock_turbo_install(&nm, &legacy_path(), "1.8.0")?;
 
         // Should fall through to legacy despite scoped binary existing
-        let result = LocalTurboState::infer(root).unwrap();
+        let Some(result) = LocalTurboState::infer(root) else {
+            panic!("local turbo state should be inferred");
+        };
         assert_eq!(result.version(), "1.8.0");
+        Ok(())
     }
 
     #[test]
-    fn test_infer_unplugged_scoped() {
-        let tmpdir = TempDir::with_prefix("turbo_infer").unwrap();
-        let root = AbsoluteSystemPath::from_std_path(tmpdir.path()).unwrap();
+    fn test_infer_unplugged_scoped() -> Result<(), Box<dyn std::error::Error>> {
+        let tmpdir = TempDir::with_prefix("turbo_infer")?;
+        let root = AbsoluteSystemPath::from_std_path(tmpdir.path())?;
 
         // Berry unplugged dirs use `{identity}-npm-{version}-{hash}`.
         // For @turbo/linux-64 → @turbo-linux-64-npm-2.1.0-abc123
@@ -437,25 +454,31 @@ mod test {
 
         let unplugged_nm =
             root.join_components(&[".yarn", "unplugged", &unplugged_dir_name, "node_modules"]);
-        create_mock_turbo_install(&unplugged_nm, &scoped_path(), "2.1.0");
+        create_mock_turbo_install(&unplugged_nm, &scoped_path(), "2.1.0")?;
 
-        let result = LocalTurboState::infer(root).unwrap();
+        let Some(result) = LocalTurboState::infer(root) else {
+            panic!("local turbo state should be inferred");
+        };
         assert_eq!(result.version(), "2.1.0");
+        Ok(())
     }
 
     #[test]
-    fn test_infer_unplugged_legacy() {
-        let tmpdir = TempDir::with_prefix("turbo_infer").unwrap();
-        let root = AbsoluteSystemPath::from_std_path(tmpdir.path()).unwrap();
+    fn test_infer_unplugged_legacy() -> Result<(), Box<dyn std::error::Error>> {
+        let tmpdir = TempDir::with_prefix("turbo_infer")?;
+        let root = AbsoluteSystemPath::from_std_path(tmpdir.path())?;
 
         let platform_package_name = TurboState::platform_package_name();
         let unplugged_dir_name = format!("{}-npm-1.9.0-def456", platform_package_name);
 
         let unplugged_nm =
             root.join_components(&[".yarn", "unplugged", &unplugged_dir_name, "node_modules"]);
-        create_mock_turbo_install(&unplugged_nm, &legacy_path(), "1.9.0");
+        create_mock_turbo_install(&unplugged_nm, &legacy_path(), "1.9.0")?;
 
-        let result = LocalTurboState::infer(root).unwrap();
+        let Some(result) = LocalTurboState::infer(root) else {
+            panic!("local turbo state should be inferred");
+        };
         assert_eq!(result.version(), "1.9.0");
+        Ok(())
     }
 }

--- a/crates/turborepo-shim/src/parser.rs
+++ b/crates/turborepo-shim/src/parser.rs
@@ -633,15 +633,18 @@ mod test {
         }
         ; "root turbo json absolute path"
     )]
-    fn test_shim_parsing(args: &[&str], expected: ExpectedArgs) {
+    fn test_shim_parsing(
+        args: &[&str],
+        expected: ExpectedArgs,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let cwd = AbsoluteSystemPathBuf::new(if cfg!(windows) {
             "Z:\\some\\dir"
         } else {
             "/some/dir"
-        })
-        .unwrap();
+        })?;
         let expected = expected.build(&cwd);
-        let actual = ShimArgs::parse_from_iter(cwd, args.iter().map(|s| s.to_string())).unwrap();
+        let actual = ShimArgs::parse_from_iter(cwd, args.iter().map(|s| s.to_string()))?;
         assert_eq!(expected, actual);
+        Ok(())
     }
 }


### PR DESCRIPTION
## Why

`TURBO-5656` was still open even though shim implementation code was already clean. Removing the remaining test unwraps and test-only allowance lets the ticket close without keeping a crate-level exception.

Closes TURBO-5656

## What

Converts shim tests and helpers to return `Result` or explicit pattern assertions instead of unwrapping setup, parsing, and inference results.

## How

- `cargo fmt -p turborepo-shim`
- `cargo test -p turborepo-shim`
- `cargo clippy -p turborepo-shim --all-targets -- -D warnings`
- Pre-push hook passed with format, check:toml, and Rust checks