### PR TITLE
fix: Remove turbo json test unwrap allowance

### DIFF
--- a/crates/turborepo-turbo-json/src/lib.rs
+++ b/crates/turborepo-turbo-json/src/lib.rs
@@ -13,7 +13,6 @@
 // This is intentional for rich error reporting. Boxing would add indirection overhead
 // for error paths that are not performance-critical.
 #![allow(clippy::result_large_err)]
-#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
 
 use std::{collections::HashSet, sync::Arc};
 


### PR DESCRIPTION
## Why

`TURBO-5644` was still open even though turbo-json implementation code is already clean. The only remaining source-level panic-helper exception was a test-only crate attribute.

Closes TURBO-5644

## What

Removes the redundant `cfg_attr(test)` unwrap/expect allowance from `turborepo-turbo-json` source. Test unwraps remain covered by the workspace test exemption.

## How

- `cargo fmt -p turborepo-turbo-json`
- `cargo clippy -p turborepo-turbo-json --all-targets -- -D warnings`
- `cargo test -p turborepo-turbo-json`
- Pre-push hook passed with format, check:toml, and Rust checks