### PR TITLE
perf: Trim OpenTelemetry crate features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4058,7 +4058,6 @@ dependencies = [
  "js-sys",
  "pin-project-lite",
  "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]

--- a/crates/turborepo-otel/Cargo.toml
+++ b/crates/turborepo-otel/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-opentelemetry = { version = "0.31", features = ["metrics"] }
+opentelemetry = { version = "0.31", default-features = false, features = ["metrics"] }
 opentelemetry-otlp = { version = "0.31", default-features = false, features = [
   "grpc-tonic",
   "http-proto",
@@ -16,7 +16,7 @@ opentelemetry-otlp = { version = "0.31", default-features = false, features = [
   "reqwest-client",
 ] }
 opentelemetry-semantic-conventions = "0.31"
-opentelemetry_sdk = { version = "0.31", features = [
+opentelemetry_sdk = { version = "0.31", default-features = false, features = [
   "metrics",
   "rt-tokio",
   "experimental_async_runtime",
@@ -25,5 +25,5 @@ opentelemetry_sdk = { version = "0.31", features = [
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-tonic = "0.14"
+tonic = { version = "0.14", default-features = false }
 tracing = { workspace = true }

--- a/crates/turborepo-otel/Cargo.toml
+++ b/crates/turborepo-otel/Cargo.toml
@@ -8,7 +8,9 @@ license = "MIT"
 workspace = true
 
 [dependencies]
-opentelemetry = { version = "0.31", default-features = false, features = ["metrics"] }
+opentelemetry = { version = "0.31", default-features = false, features = [
+  "metrics",
+] }
 opentelemetry-otlp = { version = "0.31", default-features = false, features = [
   "grpc-tonic",
   "http-proto",


### PR DESCRIPTION
Why
OpenTelemetry is on the Rust build graph and was compiling default SDK features that turborepo-otel does not use directly. Trimming those defaults gives CI a chance to do less work while preserving the metrics exporter behavior.

What
Disable default features for opentelemetry, opentelemetry_sdk, and tonic in turborepo-otel.

How
Verified with cargo check -p turborepo-otel --all-targets. Pre-push hooks also ran format, check:toml, and Rust checks before pushing.