### PR TITLE
perf: Trim microfrontends proxy HTTP features

### DIFF
--- a/crates/turborepo-microfrontends-proxy/Cargo.toml
+++ b/crates/turborepo-microfrontends-proxy/Cargo.toml
@@ -11,13 +11,16 @@ workspace = true
 dashmap = { workspace = true }
 futures-util = "0.3.31"
 http-body-util = "0.1"
-hyper = { version = "1.0", features = ["full"] }
+hyper = { version = "1.0", default-features = false, features = [
+  "http1",
+  "server",
+] }
 hyper-rustls = { workspace = true, features = [
   "http1",
   "native-tokio",
   "ring",
 ] }
-hyper-util = { version = "0.1", features = [
+hyper-util = { version = "0.1", default-features = false, features = [
   "client-legacy",
   "http1",
   "http2",


### PR DESCRIPTION
Why
The microfrontends proxy was enabling broad default/full HTTP dependency features even though it uses a narrower HTTP surface. Trimming those features reduces unnecessary compile work while keeping the proxy build behavior explicit.

What
Disable default features for hyper and hyper-util in turborepo-microfrontends-proxy, and keep only the HTTP client/server features used by the crate.

How
Verified with cargo check -p turborepo-microfrontends-proxy --all-targets and cargo test -p turborepo-microfrontends-proxy. Pre-push hooks also ran format, check:toml, and Rust checks before pushing.