### PR TITLE
docs: Correct attribute presence claims in turborepo-otel

### DIFF
--- a/crates/turborepo-otel/src/lib.rs
+++ b/crates/turborepo-otel/src/lib.rs
@@ -70,16 +70,23 @@
 //! series in backends like Datadog that charge per unique series.
 //!
 //! **Always attached** (bounded cardinality):
-//! - `turbo.run.exit_code`, `turbo.version`, `turbo.scm.branch`
+//! - `turbo.run.exit_code`, `turbo.version`
 //! - `turbo.task.name`, `turbo.task.package`, `turbo.task.command`
-//! - `turbo.task.cache_status`, `turbo.task.cache_source`,
-//!   `turbo.task.exit_code`
+//! - `turbo.task.cache_status`
 //!
-//! **Gated by `run_attributes`** (unbounded — opt-in):
-//! - `turbo.run.id` — unique KSUID per invocation
-//! - `turbo.scm.revision` — full Git SHA, unique per commit
+//! **Attached when available** (bounded cardinality, omitted when the
+//! underlying value is missing):
+//! - `turbo.scm.branch`: omitted when SCM branch detection fails
+//! - `turbo.task.cache_source`: omitted on cache misses
+//! - `turbo.task.exit_code`: omitted when the task did not execute (for
+//!   example, on a cache hit)
 //!
-//! **Gated by `task_attributes`** (unbounded — opt-in):
+//! **Gated by `run_attributes`** (unbounded, opt-in):
+//! - `turbo.run.id`: unique KSUID per invocation
+//! - `turbo.scm.revision`: full Git SHA, unique per commit (also omitted when
+//!   SCM revision detection fails)
+//!
+//! **Gated by `task_attributes`** (unbounded, opt-in):
 //! - `turbo.task.id`, `turbo.task.hash`, `turbo.task.external_inputs_hash`
 
 use std::{


### PR DESCRIPTION
The crate-level docs in `turborepo-otel` list `turbo.scm.branch`, `turbo.task.cache_source`, and `turbo.task.exit_code` under "Always attached", but `build_run_attributes` and `record_task_details` only push those keys when the underlying value is `Some`. SCM branch detection can fail, cache hits skip `cache_source`, and tasks that did not execute have no `exit_code`. Dashboards built against the docs end up with missing series exactly when those branches hit.

This change keeps "Always attached" honest by listing only the values that are unconditionally emitted, then introduces an "Attached when available" group that calls out the three optional attributes and the precise condition under which each is omitted. The note on `turbo.scm.revision` also picks up the same caveat, since the value falls back to `None` when SCM detection fails even with the `run_attributes` opt-in.

No runtime behavior changes. `cargo test -p turborepo-otel` (15 passed), `cargo fmt -p turborepo-otel`, and `cargo clippy -p turborepo-otel --all-targets -- -D warnings` are clean.