### PR TITLE
fix: Restore a few internal invariant checks

### DIFF
--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -126,6 +126,7 @@ fn turbo_jsonc() -> &'static AnchoredSystemPath {
     PATH.get_or_init(|| anchored_path(CONFIG_FILE_JSONC))
 }
 
+#[allow(clippy::expect_used)]
 pub async fn prune(
     base: &CommandBase,
     scope: &[String],
@@ -174,9 +175,10 @@ pub async fn prune(
         // We don't want to do any copying for the root workspace
         if let PackageName::Other(workspace) = workspace {
             prune.copy_workspace(entry.package_json_path(), &entry.package_json)?;
-            let Some(parent) = entry.package_json_path().parent() else {
-                unreachable!("workspace package.json path should have a parent");
-            };
+            let parent = entry
+                .package_json_path()
+                .parent()
+                .expect("workspace package.json path should have a parent");
             workspace_paths.push(parent.to_unix().to_string());
 
             println!(" - Added {workspace}");

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -174,9 +174,10 @@ pub async fn prune(
         // We don't want to do any copying for the root workspace
         if let PackageName::Other(workspace) = workspace {
             prune.copy_workspace(entry.package_json_path(), &entry.package_json)?;
-            if let Some(parent) = entry.package_json_path().parent() {
-                workspace_paths.push(parent.to_unix().to_string());
-            }
+            let Some(parent) = entry.package_json_path().parent() else {
+                unreachable!("workspace package.json path should have a parent");
+            };
+            workspace_paths.push(parent.to_unix().to_string());
 
             println!(" - Added {workspace}");
             workspace_names.push(workspace);

--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -88,6 +88,7 @@ impl EngineExt for Engine<Built> {
             .collect()
     }
 
+    #[allow(clippy::expect_used)]
     fn validate(
         &self,
         package_graph: &PackageGraph,
@@ -101,9 +102,10 @@ impl EngineExt for Engine<Built> {
             .task_graph()
             .node_indices()
             .map(|node_index| {
-                let Some(task_node) = self.task_graph().node_weight(node_index) else {
-                    unreachable!("graph should contain weight for node index");
-                };
+                let task_node = self
+                    .task_graph()
+                    .node_weight(node_index)
+                    .expect("graph should contain weight for node index");
                 let TaskNode::Task(task_id) = task_node else {
                     // No need to check the root node if that's where we are.
                     return Ok(false);
@@ -113,9 +115,10 @@ impl EngineExt for Engine<Built> {
                     .task_graph()
                     .neighbors_directed(node_index, petgraph::Direction::Outgoing)
                 {
-                    let Some(dep_node) = self.task_graph().node_weight(dep_index) else {
-                        unreachable!("index comes from iterating the graph and must be present");
-                    };
+                    let dep_node = self
+                        .task_graph()
+                        .node_weight(dep_index)
+                        .expect("index comes from iterating the graph and must be present");
                     let TaskNode::Task(dep_id) = dep_node else {
                         // No need to check the root node
                         continue;

--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -102,7 +102,7 @@ impl EngineExt for Engine<Built> {
             .node_indices()
             .map(|node_index| {
                 let Some(task_node) = self.task_graph().node_weight(node_index) else {
-                    return Ok(false);
+                    unreachable!("graph should contain weight for node index");
                 };
                 let TaskNode::Task(task_id) = task_node else {
                     // No need to check the root node if that's where we are.
@@ -114,7 +114,7 @@ impl EngineExt for Engine<Built> {
                     .neighbors_directed(node_index, petgraph::Direction::Outgoing)
                 {
                     let Some(dep_node) = self.task_graph().node_weight(dep_index) else {
-                        continue;
+                        unreachable!("index comes from iterating the graph and must be present");
                     };
                     let TaskNode::Task(dep_id) = dep_node else {
                         // No need to check the root node

--- a/crates/turborepo-vt100/src/screen.rs
+++ b/crates/turborepo-vt100/src/screen.rs
@@ -855,6 +855,7 @@ impl Screen {
 }
 
 impl Screen {
+    #[allow(clippy::expect_used)]
     pub(crate) fn text(&mut self, c: char) {
         let pos = self.grid().pos();
         let size = self.grid().size();
@@ -878,14 +879,13 @@ impl Screen {
         // cells, which i really don't want to do).
         let mut wrap = false;
         if pos.col > size.cols - width {
-            let Some(last_cell) =
-                self.grid().drawing_cell(crate::grid::Pos {
+            let last_cell = self
+                .grid()
+                .drawing_cell(crate::grid::Pos {
                     row: pos.row,
                     col: size.cols - 1,
                 })
-            else {
-                unreachable!("cursor row and final column should be valid");
-            };
+                .expect("cursor row and final column should be valid");
             if last_cell.has_contents() || last_cell.is_wide_continuation() {
                 wrap = true;
             }
@@ -895,159 +895,121 @@ impl Screen {
 
         if width == 0 {
             if pos.col > 0 {
-                let Some(mut prev_cell) =
-                    self.grid_mut().drawing_cell_mut(crate::grid::Pos {
+                let mut prev_cell = self
+                    .grid_mut()
+                    .drawing_cell_mut(crate::grid::Pos {
                         row: pos.row,
                         col: pos.col - 1,
                     })
-                else {
-                    unreachable!(
-                        "previous cell should be valid when cursor column is nonzero"
-                    );
-                };
+                    .expect("previous cell should be valid when cursor column is nonzero");
                 if prev_cell.is_wide_continuation() {
-                    let Some(prev_wide_col) = pos.col.checked_sub(2) else {
-                        unreachable!(
-                            "wide continuation should have a leading cell"
-                        );
-                    };
-                    let Some(cell) =
-                        self.grid_mut().drawing_cell_mut(crate::grid::Pos {
+                    let prev_wide_col = pos.col.checked_sub(2).expect(
+                        "wide continuation should have a leading cell",
+                    );
+                    prev_cell = self
+                        .grid_mut()
+                        .drawing_cell_mut(crate::grid::Pos {
                             row: pos.row,
                             col: prev_wide_col,
                         })
-                    else {
-                        unreachable!(
-                            "wide continuation should have a leading cell"
+                        .expect(
+                            "wide continuation should have a leading cell",
                         );
-                    };
-                    prev_cell = cell;
                 }
                 prev_cell.append(c);
             } else if pos.row > 0 {
-                let Some(prev_row) = self.grid().drawing_row(pos.row - 1)
-                else {
-                    unreachable!(
-                        "previous row should be valid when cursor row is nonzero"
-                    );
-                };
+                let prev_row = self.grid().drawing_row(pos.row - 1).expect(
+                    "previous row should be valid when cursor row is nonzero",
+                );
                 if prev_row.wrapped() {
-                    let Some(mut prev_cell) =
-                        self.grid_mut().drawing_cell_mut(crate::grid::Pos {
+                    let mut prev_cell = self
+                        .grid_mut()
+                        .drawing_cell_mut(crate::grid::Pos {
                             row: pos.row - 1,
                             col: size.cols - 1,
                         })
-                    else {
-                        unreachable!(
-                            "previous row final cell should be valid"
-                        );
-                    };
+                        .expect("previous row final cell should be valid");
                     if prev_cell.is_wide_continuation() {
-                        let Some(prev_wide_col) = size.cols.checked_sub(2)
-                        else {
-                            unreachable!(
-                                "wide continuation should have a leading cell"
-                            );
-                        };
-                        let Some(cell) = self.grid_mut().drawing_cell_mut(
-                            crate::grid::Pos {
+                        let prev_wide_col = size.cols.checked_sub(2).expect(
+                            "wide continuation should have a leading cell",
+                        );
+                        prev_cell = self
+                            .grid_mut()
+                            .drawing_cell_mut(crate::grid::Pos {
                                 row: pos.row - 1,
                                 col: prev_wide_col,
-                            },
-                        ) else {
-                            unreachable!(
-                                "wide continuation should have a leading cell"
-                            );
-                        };
-                        prev_cell = cell;
+                            })
+                            .expect("wide continuation should have a leading cell");
                     }
                     prev_cell.append(c);
                 }
             }
         } else {
-            let Some(current_cell) = self.grid().drawing_cell(pos) else {
-                unreachable!(
-                    "cursor position should be valid after wrapping"
-                );
-            };
+            let current_cell = self
+                .grid()
+                .drawing_cell(pos)
+                .expect("cursor position should be valid after wrapping");
             if current_cell.is_wide_continuation() {
-                let Some(prev_col) = pos.col.checked_sub(1) else {
-                    unreachable!(
-                        "wide continuation should have a leading cell"
-                    );
-                };
-                let Some(prev_cell) =
-                    self.grid_mut().drawing_cell_mut(crate::grid::Pos {
+                let prev_col = pos
+                    .col
+                    .checked_sub(1)
+                    .expect("wide continuation should have a leading cell");
+                let prev_cell = self
+                    .grid_mut()
+                    .drawing_cell_mut(crate::grid::Pos {
                         row: pos.row,
                         col: prev_col,
                     })
-                else {
-                    unreachable!(
-                        "wide continuation should have a leading cell"
-                    );
-                };
+                    .expect("wide continuation should have a leading cell");
                 prev_cell.clear(attrs);
             }
 
-            let Some(current_cell) = self.grid().drawing_cell(pos) else {
-                unreachable!(
-                    "cursor position should be valid after clearing leading cell"
-                );
-            };
+            let current_cell = self.grid().drawing_cell(pos).expect(
+                "cursor position should be valid after clearing leading cell",
+            );
             if current_cell.is_wide() {
-                let Some(next_cell) =
-                    self.grid_mut().drawing_cell_mut(crate::grid::Pos {
+                let next_cell = self
+                    .grid_mut()
+                    .drawing_cell_mut(crate::grid::Pos {
                         row: pos.row,
                         col: pos.col + 1,
                     })
-                else {
-                    unreachable!("wide cell should have a continuation cell");
-                };
+                    .expect("wide cell should have a continuation cell");
                 next_cell.set(' ', attrs);
             }
 
-            let Some(cell) = self.grid_mut().drawing_cell_mut(pos) else {
-                unreachable!(
-                    "cursor position should be valid before drawing"
-                );
-            };
+            let cell = self
+                .grid_mut()
+                .drawing_cell_mut(pos)
+                .expect("cursor position should be valid before drawing");
             cell.set(c, attrs);
             self.grid_mut().col_inc(1);
             if width > 1 {
                 let pos = self.grid().pos();
-                let Some(current_cell) = self.grid().drawing_cell(pos) else {
-                    unreachable!(
-                        "cursor position should be valid after wide char advance"
-                    );
-                };
+                let current_cell = self.grid().drawing_cell(pos).expect(
+                    "cursor position should be valid after wide char advance",
+                );
                 if current_cell.is_wide() {
                     let next_next_pos = crate::grid::Pos {
                         row: pos.row,
                         col: pos.col + 1,
                     };
-                    let Some(next_next_cell) =
-                        self.grid_mut().drawing_cell_mut(next_next_pos)
-                    else {
-                        unreachable!(
-                            "wide cell should have a continuation cell"
-                        );
-                    };
+                    let next_next_cell = self
+                        .grid_mut()
+                        .drawing_cell_mut(next_next_pos)
+                        .expect("wide cell should have a continuation cell");
                     next_next_cell.clear(attrs);
                     if next_next_pos.col == size.cols - 1 {
-                        let Some(row) =
-                            self.grid_mut().drawing_row_mut(pos.row)
-                        else {
-                            unreachable!("cursor row should be valid");
-                        };
+                        let row = self
+                            .grid_mut()
+                            .drawing_row_mut(pos.row)
+                            .expect("cursor row should be valid");
                         row.wrap(false);
                     }
                 }
-                let Some(next_cell) = self.grid_mut().drawing_cell_mut(pos)
-                else {
-                    unreachable!(
-                        "wide character continuation cell should be valid"
-                    );
-                };
+                let next_cell = self.grid_mut().drawing_cell_mut(pos).expect(
+                    "wide character continuation cell should be valid",
+                );
                 next_cell.clear(crate::attrs::Attrs::default());
                 next_cell.set_wide_continuation(true);
                 self.grid_mut().col_inc(1);

--- a/crates/turborepo-vt100/src/screen.rs
+++ b/crates/turborepo-vt100/src/screen.rs
@@ -878,13 +878,15 @@ impl Screen {
         // cells, which i really don't want to do).
         let mut wrap = false;
         if pos.col > size.cols - width {
-            let last_cell = self.grid().drawing_cell(crate::grid::Pos {
-                row: pos.row,
-                col: size.cols - 1,
-            });
-            if last_cell.is_some_and(|cell| {
-                cell.has_contents() || cell.is_wide_continuation()
-            }) {
+            let Some(last_cell) =
+                self.grid().drawing_cell(crate::grid::Pos {
+                    row: pos.row,
+                    col: size.cols - 1,
+                })
+            else {
+                unreachable!("cursor row and final column should be valid");
+            };
+            if last_cell.has_contents() || last_cell.is_wide_continuation() {
                 wrap = true;
             }
         }
@@ -899,92 +901,126 @@ impl Screen {
                         col: pos.col - 1,
                     })
                 else {
-                    return;
+                    unreachable!(
+                        "previous cell should be valid when cursor column is nonzero"
+                    );
                 };
                 if prev_cell.is_wide_continuation() {
+                    let Some(prev_wide_col) = pos.col.checked_sub(2) else {
+                        unreachable!(
+                            "wide continuation should have a leading cell"
+                        );
+                    };
                     let Some(cell) =
                         self.grid_mut().drawing_cell_mut(crate::grid::Pos {
                             row: pos.row,
-                            col: pos.col - 2,
+                            col: prev_wide_col,
                         })
                     else {
-                        return;
+                        unreachable!(
+                            "wide continuation should have a leading cell"
+                        );
                     };
                     prev_cell = cell;
                 }
                 prev_cell.append(c);
-            } else if pos.row > 0
-                && self
-                    .grid()
-                    .drawing_row(pos.row - 1)
-                    .is_some_and(crate::row::Row::wrapped)
-            {
-                let Some(mut prev_cell) =
-                    self.grid_mut().drawing_cell_mut(crate::grid::Pos {
-                        row: pos.row - 1,
-                        col: size.cols - 1,
-                    })
+            } else if pos.row > 0 {
+                let Some(prev_row) = self.grid().drawing_row(pos.row - 1)
                 else {
-                    return;
+                    unreachable!(
+                        "previous row should be valid when cursor row is nonzero"
+                    );
                 };
-                if prev_cell.is_wide_continuation() {
-                    let Some(cell) =
+                if prev_row.wrapped() {
+                    let Some(mut prev_cell) =
                         self.grid_mut().drawing_cell_mut(crate::grid::Pos {
                             row: pos.row - 1,
-                            col: size.cols - 2,
+                            col: size.cols - 1,
                         })
                     else {
-                        return;
+                        unreachable!(
+                            "previous row final cell should be valid"
+                        );
                     };
-                    prev_cell = cell;
+                    if prev_cell.is_wide_continuation() {
+                        let Some(prev_wide_col) = size.cols.checked_sub(2)
+                        else {
+                            unreachable!(
+                                "wide continuation should have a leading cell"
+                            );
+                        };
+                        let Some(cell) = self.grid_mut().drawing_cell_mut(
+                            crate::grid::Pos {
+                                row: pos.row - 1,
+                                col: prev_wide_col,
+                            },
+                        ) else {
+                            unreachable!(
+                                "wide continuation should have a leading cell"
+                            );
+                        };
+                        prev_cell = cell;
+                    }
+                    prev_cell.append(c);
                 }
-                prev_cell.append(c);
             }
         } else {
-            if self
-                .grid()
-                .drawing_cell(pos)
-                .is_some_and(crate::Cell::is_wide_continuation)
-            {
+            let Some(current_cell) = self.grid().drawing_cell(pos) else {
+                unreachable!(
+                    "cursor position should be valid after wrapping"
+                );
+            };
+            if current_cell.is_wide_continuation() {
+                let Some(prev_col) = pos.col.checked_sub(1) else {
+                    unreachable!(
+                        "wide continuation should have a leading cell"
+                    );
+                };
                 let Some(prev_cell) =
                     self.grid_mut().drawing_cell_mut(crate::grid::Pos {
                         row: pos.row,
-                        col: pos.col - 1,
+                        col: prev_col,
                     })
                 else {
-                    return;
+                    unreachable!(
+                        "wide continuation should have a leading cell"
+                    );
                 };
                 prev_cell.clear(attrs);
             }
 
-            if self
-                .grid()
-                .drawing_cell(pos)
-                .is_some_and(crate::Cell::is_wide)
-            {
+            let Some(current_cell) = self.grid().drawing_cell(pos) else {
+                unreachable!(
+                    "cursor position should be valid after clearing leading cell"
+                );
+            };
+            if current_cell.is_wide() {
                 let Some(next_cell) =
                     self.grid_mut().drawing_cell_mut(crate::grid::Pos {
                         row: pos.row,
                         col: pos.col + 1,
                     })
                 else {
-                    return;
+                    unreachable!("wide cell should have a continuation cell");
                 };
                 next_cell.set(' ', attrs);
             }
 
             let Some(cell) = self.grid_mut().drawing_cell_mut(pos) else {
-                return;
+                unreachable!(
+                    "cursor position should be valid before drawing"
+                );
             };
             cell.set(c, attrs);
             self.grid_mut().col_inc(1);
             if width > 1 {
                 let pos = self.grid().pos();
-                if self
-                    .grid()
-                    .drawing_cell(pos)
-                    .is_some_and(crate::Cell::is_wide)
-                {
+                let Some(current_cell) = self.grid().drawing_cell(pos) else {
+                    unreachable!(
+                        "cursor position should be valid after wide char advance"
+                    );
+                };
+                if current_cell.is_wide() {
                     let next_next_pos = crate::grid::Pos {
                         row: pos.row,
                         col: pos.col + 1,
@@ -992,19 +1028,25 @@ impl Screen {
                     let Some(next_next_cell) =
                         self.grid_mut().drawing_cell_mut(next_next_pos)
                     else {
-                        return;
+                        unreachable!(
+                            "wide cell should have a continuation cell"
+                        );
                     };
                     next_next_cell.clear(attrs);
-                    if next_next_pos.col == size.cols - 1
-                        && let Some(row) =
+                    if next_next_pos.col == size.cols - 1 {
+                        let Some(row) =
                             self.grid_mut().drawing_row_mut(pos.row)
-                    {
+                        else {
+                            unreachable!("cursor row should be valid");
+                        };
                         row.wrap(false);
                     }
                 }
                 let Some(next_cell) = self.grid_mut().drawing_cell_mut(pos)
                 else {
-                    return;
+                    unreachable!(
+                        "wide character continuation cell should be valid"
+                    );
                 };
                 next_cell.clear(crate::attrs::Attrs::default());
                 next_cell.set_wide_continuation(true);


### PR DESCRIPTION
## Why

Some panic-extraction follow-ups converted impossible internal states into silent no-ops. That made corrupted graph/grid/path invariants harder to detect and could allow incorrect behavior to continue.

## What

Restores fail-loud invariant handling for task graph validation, prune workspace package paths, and vt100 screen cell mutation.

## How

Verified with:

- `cargo fmt -p turborepo-lib -p turborepo-vt100`
- `cargo test -p turborepo-vt100`
- `cargo clippy -p turborepo-vt100 --all-targets -- -D warnings`
- `cargo clippy -p turborepo-lib --all-targets -- -D warnings`
- `cargo test -p turborepo-lib`
- Pre-push hook passed format, TOML check, and Rust checks