### PR TITLE
fix: Improve profile tracing coverage

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1777,6 +1777,7 @@ async fn run_main(
 
             if execution_args.tasks.is_empty() {
                 print_potential_tasks(base, event).await?;
+                finalize_chrome_profile(logger, version);
                 return Ok(1);
             }
 
@@ -1799,23 +1800,7 @@ async fn run_main(
 
             // Chrome tracing is enabled early in shim::run(). Here we just
             // flush and generate the markdown summary.
-            if let Some(file_path) = logger.chrome_tracing_file() {
-                let _ = logger.flush_chrome_tracing();
-
-                if let Err(e) =
-                    crate::tracing::inject_trace_metadata(std::path::Path::new(&file_path), version)
-                {
-                    warn!("Failed to inject trace metadata: {e}");
-                }
-
-                let md_path = format!("{file_path}.md");
-                if let Err(e) = turborepo_profile_md::trace_to_markdown(
-                    std::path::Path::new(&file_path),
-                    std::path::Path::new(&md_path),
-                ) {
-                    warn!("Failed to generate profile markdown: {e}");
-                }
-            }
+            finalize_chrome_profile(logger, version);
 
             Ok(exit_code)
         }
@@ -1939,6 +1924,27 @@ async fn run_main(
     }
 
     cli_result
+}
+
+fn finalize_chrome_profile(logger: &TurboSubscriber, version: &str) {
+    let Some(file_path) = logger.chrome_tracing_file() else {
+        return;
+    };
+
+    let _ = logger.flush_chrome_tracing();
+
+    if let Err(e) = crate::tracing::inject_trace_metadata(std::path::Path::new(&file_path), version)
+    {
+        warn!("Failed to inject trace metadata: {e}");
+    }
+
+    let md_path = format!("{file_path}.md");
+    if let Err(e) = turborepo_profile_md::trace_to_markdown(
+        std::path::Path::new(&file_path),
+        std::path::Path::new(&md_path),
+    ) {
+        warn!("Failed to generate profile markdown: {e}");
+    }
 }
 
 #[cfg(test)]

--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -29,10 +29,12 @@ where
             // Keep the run future alive so the TUI can continue rendering task
             // output until shutdown drains and the UI closes cleanly.
             let result = (&mut run_fut).await;
+            let _span = tracing::info_span!("signal_handler_done").entered();
             handler.done().await;
             RunOutcome::Interrupted(result)
         }
         result = &mut run_fut => {
+            let _span = tracing::info_span!("signal_handler_close").entered();
             handler.close().await;
             RunOutcome::Completed(result)
         }
@@ -187,7 +189,10 @@ pub async fn run(
         RunOutcome::Completed(result) | RunOutcome::Interrupted(result) => result,
     };
 
-    turborepo_log::flush();
+    {
+        let _span = tracing::info_span!("log_flush").entered();
+        turborepo_log::flush();
+    }
     result
 }
 

--- a/crates/turborepo-lib/src/commands/run.rs
+++ b/crates/turborepo-lib/src/commands/run.rs
@@ -1,6 +1,6 @@
 use std::{env, future::Future, sync::Arc};
 
-use tracing::error;
+use tracing::{error, Instrument};
 use turborepo_api_client::SharedHttpClient;
 use turborepo_log::StructuredLogSink;
 use turborepo_query_api::QueryServer;
@@ -29,13 +29,17 @@ where
             // Keep the run future alive so the TUI can continue rendering task
             // output until shutdown drains and the UI closes cleanly.
             let result = (&mut run_fut).await;
-            let _span = tracing::info_span!("signal_handler_done").entered();
-            handler.done().await;
+            handler
+                .done()
+                .instrument(tracing::info_span!("signal_handler_done"))
+                .await;
             RunOutcome::Interrupted(result)
         }
         result = &mut run_fut => {
-            let _span = tracing::info_span!("signal_handler_close").entered();
-            handler.close().await;
+            handler
+                .close()
+                .instrument(tracing::info_span!("signal_handler_close"))
+                .await;
             RunOutcome::Completed(result)
         }
     }

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -185,6 +185,7 @@ impl RunBuilder {
         )
     }
 
+    #[tracing::instrument(skip_all)]
     async fn resolve_remote_cache_status(
         &self,
         preflight_handle: Option<
@@ -561,11 +562,14 @@ impl RunBuilder {
                 let token = auth.token.clone();
                 let team_id = auth.team_id.clone();
                 let team_slug = auth.team_slug.clone();
-                Some(tokio::spawn(async move {
-                    client
-                        .get_caching_status(&token, team_id.as_deref(), team_slug.as_deref())
-                        .await
-                }))
+                Some(tokio::spawn(
+                    async move {
+                        client
+                            .get_caching_status(&token, team_id.as_deref(), team_slug.as_deref())
+                            .await
+                    }
+                    .instrument(tracing::info_span!("remote_cache_preflight")),
+                ))
             } else {
                 None
             }

--- a/crates/turborepo/tests/profile_test.rs
+++ b/crates/turborepo/tests/profile_test.rs
@@ -20,6 +20,18 @@ fn assert_valid_trace_and_markdown(dir: &std::path::Path, trace_name: &str) {
     let trace_contents = fs::read_to_string(&trace_path).unwrap();
     let _: serde_json::Value =
         serde_json::from_str(&trace_contents).expect("trace file should be valid JSON");
+    assert!(
+        trace_contents.contains(r#""name":"resolve_remote_cache_status""#),
+        "expected profile to cover remote cache status resolution"
+    );
+    assert!(
+        trace_contents.contains(r#""name":"log_flush""#),
+        "expected profile to cover log flushing"
+    );
+    assert!(
+        trace_contents.contains(r#""name":"signal_handler_close""#),
+        "expected profile to cover signal handler shutdown"
+    );
 
     let md_path = dir.join(format!("{trace_name}.md"));
     assert!(md_path.exists(), "{trace_name}.md should exist");
@@ -86,4 +98,21 @@ fn test_anon_profile_generates_valid_trace() {
 fn test_anon_profile_default_filename() {
     let (tempdir, _) = setup_and_run(&["build", "--anon-profile"]);
     assert_default_profile_files_exist(tempdir.path());
+}
+
+#[test]
+fn test_profile_no_tasks_generates_markdown() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    let output = run_turbo(tempdir.path(), &["run", "--profile=no-tasks.trace"]);
+    assert_eq!(output.status.code(), Some(1));
+
+    let trace_path = tempdir.path().join("no-tasks.trace");
+    assert!(trace_path.exists(), "no-tasks.trace should exist");
+    let trace_contents = fs::read_to_string(&trace_path).unwrap();
+    let _: serde_json::Value =
+        serde_json::from_str(&trace_contents).expect("trace file should be valid JSON");
+
+    let md_path = tempdir.path().join("no-tasks.trace.md");
+    assert!(md_path.exists(), "no-tasks.trace.md should exist");
 }


### PR DESCRIPTION
## Why

Profiles should make it clear where time goes during `turbo run`, including cleanup and early-return paths. A few run phases were either represented as unexplained gaps or skipped profile markdown generation entirely.

## What

Adds tracing coverage for remote cache status resolution, remote cache preflight, signal-handler shutdown, and final log flushing. Also shares profile finalization so no-task `turbo run --profile` invocations generate the markdown summary.

## How

Verified with profiled local runs covering normal execution, dry-run, graph, summarize, JSON logging, only, parallel, affected, and no-task paths. Also added profile tests for the new spans and no-task markdown generation.

Tested with:

- `cargo test -p turbo --test profile_test`
- pre-push hooks (`format`, `check:toml`, Rust checks)
