### PR TITLE
fix: Use build-scale OTel duration buckets

### DIFF
--- a/crates/turborepo-otel/src/lib.rs
+++ b/crates/turborepo-otel/src/lib.rs
@@ -103,6 +103,24 @@ use thiserror::Error;
 use tonic::metadata::{MetadataKey, MetadataMap, MetadataValue};
 use tracing::debug;
 
+const DURATION_HISTOGRAM_BOUNDARIES_MS: &[f64] = &[
+    100.0,
+    500.0,
+    1_000.0,
+    2_500.0,
+    5_000.0,
+    10_000.0,
+    15_000.0,
+    30_000.0,
+    60_000.0,
+    120_000.0,
+    300_000.0,
+    600_000.0,
+    900_000.0,
+    1_800_000.0,
+    3_600_000.0,
+];
+
 /// Protocol supported by the OTLP exporter.
 ///
 /// Both gRPC and HTTP transports use `https://` endpoints - see
@@ -530,6 +548,8 @@ fn create_instruments(meter: &Meter) -> Instruments {
     let run_duration = meter
         .f64_histogram("turbo.run.duration_ms")
         .with_description("Turborepo run duration in milliseconds")
+        .with_unit("ms")
+        .with_boundaries(DURATION_HISTOGRAM_BOUNDARIES_MS.to_vec())
         .build();
     let run_attempted = meter
         .u64_counter("turbo.run.tasks.attempted")
@@ -546,6 +566,8 @@ fn create_instruments(meter: &Meter) -> Instruments {
     let task_duration = meter
         .f64_histogram("turbo.task.duration_ms")
         .with_description("Task execution duration in milliseconds")
+        .with_unit("ms")
+        .with_boundaries(DURATION_HISTOGRAM_BOUNDARIES_MS.to_vec())
         .build();
     let task_cache = meter
         .u64_counter("turbo.task.cache.events")
@@ -743,6 +765,19 @@ mod tests {
             }
             _ => panic!("Expected InvalidHeader error"),
         }
+    }
+
+    #[test]
+    fn test_duration_histogram_boundaries_cover_build_durations() {
+        assert!(
+            DURATION_HISTOGRAM_BOUNDARIES_MS
+                .windows(2)
+                .all(|w| w[0] < w[1])
+        );
+        assert!(DURATION_HISTOGRAM_BOUNDARIES_MS.contains(&10_000.0));
+        assert!(DURATION_HISTOGRAM_BOUNDARIES_MS.contains(&120_000.0));
+        assert!(DURATION_HISTOGRAM_BOUNDARIES_MS.contains(&300_000.0));
+        assert_eq!(DURATION_HISTOGRAM_BOUNDARIES_MS.last(), Some(&3_600_000.0));
     }
 
     #[test]

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -579,6 +579,8 @@ Configuration can also be set via environment variables (`TURBO_EXPERIMENTAL_OTE
 - `turbo.task.duration_ms` - Per-task duration histogram (when `taskDetails` enabled)
 - `turbo.task.cache.events` - Per-task cache events (when `taskDetails` enabled)
 
+Duration histograms use custom millisecond buckets sized for build and task durations, rather than the OpenTelemetry SDK's default latency buckets.
+
 Attributes with unbounded cardinality (unique run IDs, Git SHAs, content hashes) are gated behind `runAttributes` and `taskAttributes` config flags, all defaulting to `false`. See the `Metric Attributes and Cardinality` section in `crates/turborepo-otel/src/lib.rs` for the full attribute inventory.
 
 #### Data Flow


### PR DESCRIPTION
## Why

Fixes #12922.

Turborepo duration histograms used the OpenTelemetry SDK's default explicit buckets, which top out at 10s. That made bucket-based queries like P50/P95 and Grafana heatmaps unusable for typical build and task durations because most real values landed in +Inf.

## What

Adds Turborepo-specific millisecond bucket boundaries for run and task duration histograms, covering sub-second work through one-hour CI/build durations. Also records the histogram unit as ms and documents that these metrics intentionally avoid the SDK latency defaults.