### PR TITLE
fix: Preserve pnpm injected peer package entries

### DIFF
--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -325,6 +325,11 @@ impl PnpmLockfile {
             .and_then(|packages| packages.get(key))
     }
 
+    fn package_key_for_snapshot(&self, snapshot_key: &str) -> Result<String, crate::Error> {
+        let dp = DepPath::parse(self.version(), snapshot_key).map_err(Error::from)?;
+        Ok(self.format_key(dp.name, dp.version))
+    }
+
     fn has_package(&self, key: &str) -> bool {
         match self.version() {
             SupportedLockfileVersion::V5 | SupportedLockfileVersion::V6 => {
@@ -519,9 +524,7 @@ impl PnpmLockfile {
                     .ok_or_else(|| crate::Error::MissingPackage(package.clone()))?;
                 pruned_snapshots.insert(package.clone(), entry.clone());
 
-                // Remove peer suffix to find the key for the package entry
-                let dp = DepPath::parse(self.version(), package.as_str()).map_err(Error::from)?;
-                let package_key = self.format_key(dp.name, dp.version);
+                let package_key = self.package_key_for_snapshot(package.as_str())?;
                 let entry = self
                     .get_packages(&package_key)
                     .ok_or_else(|| crate::Error::MissingPackage(package_key.clone()))?;
@@ -675,9 +678,14 @@ impl crate::Lockfile for PnpmLockfile {
                 }
 
                 let key = self.format_key(dependency, version);
+                let package_key = if self.snapshots.is_some() {
+                    self.package_key_for_snapshot(&key)?
+                } else {
+                    key.clone()
+                };
 
-                if let Some(entry) = self.get_packages(&key) {
-                    pruned_packages.insert(key.clone(), entry.clone());
+                if let Some(entry) = self.get_packages(&package_key) {
+                    pruned_packages.insert(package_key, entry.clone());
                 }
 
                 if let Some(snapshots) = self.snapshots.as_ref()
@@ -1501,6 +1509,79 @@ snapshots:
             packages.contains_key("is-odd@3.0.1"),
             "pruned should have is-odd in packages via transitive deps"
         );
+    }
+
+    #[test]
+    fn test_subgraph_with_injected_workspace_peer_variant() {
+        let yaml = r#"lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+  injectWorkspacePackages: true
+
+importers:
+
+  .: {}
+
+  apps/my-app:
+    dependencies:
+      '@repo/shared':
+        specifier: workspace:*
+        version: file:packages/shared(react@17.0.2)
+      react:
+        specifier: 17.0.2
+        version: 17.0.2
+    dependenciesMeta:
+      '@repo/shared':
+        injected: true
+
+  packages/shared:
+    dependencies:
+      react:
+        specifier: '*'
+        version: 17.0.2
+
+packages:
+
+  '@repo/shared@file:packages/shared':
+    resolution: {directory: packages/shared, type: directory}
+    peerDependencies:
+      react: '*'
+
+  react@17.0.2:
+    resolution: {integrity: sha512-abc}
+
+snapshots:
+
+  '@repo/shared@file:packages/shared(react@17.0.2)':
+    dependencies:
+      react: 17.0.2
+
+  react@17.0.2: {}
+"#;
+        let lockfile = PnpmLockfile::from_bytes(yaml.as_bytes()).unwrap();
+
+        let workspace_packages = vec!["apps/my-app".to_string(), "packages/shared".to_string()];
+        let resolved_packages = vec!["react@17.0.2".to_string()];
+        let pruned = lockfile
+            .subgraph(&workspace_packages, &resolved_packages)
+            .unwrap();
+
+        let pruned_bytes = pruned.encode().unwrap();
+        let pruned_lockfile = PnpmLockfile::from_bytes(&pruned_bytes).unwrap();
+
+        let packages = pruned_lockfile
+            .packages
+            .as_ref()
+            .expect("should have packages");
+        let snapshots = pruned_lockfile
+            .snapshots
+            .as_ref()
+            .expect("should have snapshots");
+
+        assert!(packages.contains_key("@repo/shared@file:packages/shared"));
+        assert!(snapshots.contains_key("@repo/shared@file:packages/shared(react@17.0.2)"));
     }
 
     #[test]

--- a/lockfile-tests/fixtures/pnpm-10-injected-peer-variant/apps/app2/package.json
+++ b/lockfile-tests/fixtures/pnpm-10-injected-peer-variant/apps/app2/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "app2",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "echo build app2"
+  },
+  "dependencies": {
+    "@repo/shared": "workspace:*",
+    "react": "18.2.0"
+  },
+  "dependenciesMeta": {
+    "@repo/shared": {
+      "injected": true
+    }
+  }
+}

--- a/lockfile-tests/fixtures/pnpm-10-injected-peer-variant/apps/my-app/package.json
+++ b/lockfile-tests/fixtures/pnpm-10-injected-peer-variant/apps/my-app/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "my-app",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "echo build my-app"
+  },
+  "dependencies": {
+    "@repo/shared": "workspace:*",
+    "react": "17.0.2"
+  },
+  "dependenciesMeta": {
+    "@repo/shared": {
+      "injected": true
+    }
+  }
+}

--- a/lockfile-tests/fixtures/pnpm-10-injected-peer-variant/meta.json
+++ b/lockfile-tests/fixtures/pnpm-10-injected-peer-variant/meta.json
@@ -1,0 +1,7 @@
+{
+  "packageManager": "pnpm",
+  "packageManagerVersion": "pnpm@10.10.0",
+  "lockfileName": "pnpm-lock.yaml",
+  "pruneTargets": ["my-app"],
+  "docker": true
+}

--- a/lockfile-tests/fixtures/pnpm-10-injected-peer-variant/package.json
+++ b/lockfile-tests/fixtures/pnpm-10-injected-peer-variant/package.json
@@ -2,8 +2,8 @@
   "name": "pnpm-10-injected-peer-variant",
   "version": "0.0.0",
   "private": true,
-  "packageManager": "pnpm@10.10.0",
   "devDependencies": {
     "turbo": "2.9.15-canary.3"
-  }
+  },
+  "packageManager": "pnpm@10.10.0"
 }

--- a/lockfile-tests/fixtures/pnpm-10-injected-peer-variant/package.json
+++ b/lockfile-tests/fixtures/pnpm-10-injected-peer-variant/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "pnpm-10-injected-peer-variant",
+  "version": "0.0.0",
+  "private": true,
+  "packageManager": "pnpm@10.10.0",
+  "devDependencies": {
+    "turbo": "2.9.15-canary.3"
+  }
+}

--- a/lockfile-tests/fixtures/pnpm-10-injected-peer-variant/packages/shared/package.json
+++ b/lockfile-tests/fixtures/pnpm-10-injected-peer-variant/packages/shared/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@repo/shared",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "build": "echo build shared"
+  },
+  "peerDependencies": {
+    "react": "*"
+  }
+}

--- a/lockfile-tests/fixtures/pnpm-10-injected-peer-variant/pnpm-lock.yaml
+++ b/lockfile-tests/fixtures/pnpm-10-injected-peer-variant/pnpm-lock.yaml
@@ -1,0 +1,154 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+  injectWorkspacePackages: true
+
+importers:
+
+  .:
+    devDependencies:
+      turbo:
+        specifier: 2.9.15-canary.3
+        version: 2.9.15-canary.3
+
+  apps/app2:
+    dependencies:
+      '@repo/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      react:
+        specifier: 18.2.0
+        version: 18.2.0
+    dependenciesMeta:
+      '@repo/shared':
+        injected: true
+
+  apps/my-app:
+    dependencies:
+      '@repo/shared':
+        specifier: workspace:*
+        version: file:packages/shared(react@17.0.2)
+      react:
+        specifier: 17.0.2
+        version: 17.0.2
+    dependenciesMeta:
+      '@repo/shared':
+        injected: true
+
+  packages/shared:
+    dependencies:
+      react:
+        specifier: '*'
+        version: 18.2.0
+
+packages:
+
+  '@repo/shared@file:packages/shared':
+    resolution: {directory: packages/shared, type: directory}
+    peerDependencies:
+      react: '*'
+
+  '@turbo/darwin-64@2.9.15-canary.3':
+    resolution: {integrity: sha512-HayC5ffZGMmzw5Ope6WXmodkdSqxNWCld3FTuriChrzTpCHgczcYhpwxFKg5hoCbXUkKLt33ciHTrGVWdHa8QA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@turbo/darwin-arm64@2.9.15-canary.3':
+    resolution: {integrity: sha512-0iETVMcy0juHZgCZ56eoYsl7dVjDK34OAqAzkCDepvN8zovS2jQCl2YOMIbhm8kiZzBUAjuGCJ9kjqZC2UiqZA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@turbo/linux-64@2.9.15-canary.3':
+    resolution: {integrity: sha512-cKgpaZWQYwssEEir154GWMUD3W71M1MMu9AKaQekavgJnN30jmMc0Ne/kQmUfTD+ynu2nkTHhZRnw7yVGW1tog==}
+    cpu: [x64]
+    os: [linux]
+
+  '@turbo/linux-arm64@2.9.15-canary.3':
+    resolution: {integrity: sha512-wpqupVQG9M0eDrrOFkRvWDOMxDMQVhZrV82+/c3A7k1poNAlCGMVTar4nLysDPAggbzI/R5CIdo1fCJHY3IkKA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@turbo/windows-64@2.9.15-canary.3':
+    resolution: {integrity: sha512-hFgW7xOrFrfgJvVP8n04QgKgxSiPL3gT0zyBxymI1D5X+WE2WAgPALJHuEMgYrWPlH0R43DJmUyzSRpq2eX0nQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@turbo/windows-arm64@2.9.15-canary.3':
+    resolution: {integrity: sha512-cljTbKLy7YWrOv6S15Dv29g3aBJqfbzL1rzjeHsrFxerWaWmjf+EXe+7NOICUTgBG48FaKNniGS06sj8TbkvAA==}
+    cpu: [arm64]
+    os: [win32]
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  react@17.0.2:
+    resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
+    engines: {node: '>=0.10.0'}
+
+  react@18.2.0:
+    resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
+    engines: {node: '>=0.10.0'}
+
+  turbo@2.9.15-canary.3:
+    resolution: {integrity: sha512-7nN/khMvGpZQzjSv2UknaaoZ+34mpI/Y3HTjzRkMuII07O2ijAWdE+vB2h9Uw/cJSGQklGwCnrnOxwnET2sTZg==}
+    hasBin: true
+
+snapshots:
+
+  '@repo/shared@file:packages/shared(react@17.0.2)':
+    dependencies:
+      react: 17.0.2
+
+  '@turbo/darwin-64@2.9.15-canary.3':
+    optional: true
+
+  '@turbo/darwin-arm64@2.9.15-canary.3':
+    optional: true
+
+  '@turbo/linux-64@2.9.15-canary.3':
+    optional: true
+
+  '@turbo/linux-arm64@2.9.15-canary.3':
+    optional: true
+
+  '@turbo/windows-64@2.9.15-canary.3':
+    optional: true
+
+  '@turbo/windows-arm64@2.9.15-canary.3':
+    optional: true
+
+  js-tokens@4.0.0: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  object-assign@4.1.1: {}
+
+  react@17.0.2:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+
+  react@18.2.0:
+    dependencies:
+      loose-envify: 1.4.0
+
+  turbo@2.9.15-canary.3:
+    optionalDependencies:
+      '@turbo/darwin-64': 2.9.15-canary.3
+      '@turbo/darwin-arm64': 2.9.15-canary.3
+      '@turbo/linux-64': 2.9.15-canary.3
+      '@turbo/linux-arm64': 2.9.15-canary.3
+      '@turbo/windows-64': 2.9.15-canary.3
+      '@turbo/windows-arm64': 2.9.15-canary.3

--- a/lockfile-tests/fixtures/pnpm-10-injected-peer-variant/pnpm-workspace.yaml
+++ b/lockfile-tests/fixtures/pnpm-10-injected-peer-variant/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+packages:
+  - "apps/*"
+  - "packages/*"
+
+injectWorkspacePackages: true

--- a/lockfile-tests/fixtures/pnpm-10-injected-peer-variant/turbo.json
+++ b/lockfile-tests/fixtures/pnpm-10-injected-peer-variant/turbo.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "outputs": []
+    }
+  }
+}


### PR DESCRIPTION
## Why

Fixes #12824. pnpm injected workspace dependencies can produce peer-variant snapshot keys whose resolution lives on the base package entry. `turbo prune` dropped that base entry, so the pruned lockfile could fail `pnpm install --frozen-lockfile`.

## What

Preserve the base `packages:` entry when pruning pnpm snapshot keys with peer suffixes, including injected workspace dependency variants. Adds a pnpm 10 check-lockfiles fixture that reproduces the `--docker` prune case.

## How

Validated with:

- `cargo fmt -p turborepo-lockfiles --check`
- `cargo test -p turborepo-lockfiles pnpm::data::tests`
- `cargo build -p turbo`
- `pnpm --filter lockfile-tests check-lockfiles --fixture pnpm-10-injected-peer-variant --turbo-path ../target/debug/turbo --concurrency 1`

Pre-push hooks also passed on push.