### PR TITLE
feat: Add heap allocation profiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1551,6 +1551,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "thousands",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3658,6 +3674,12 @@ checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
 ]
+
+[[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mio"
@@ -6586,6 +6608,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
+
+[[package]]
 name = "thread_local"
 version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7174,6 +7202,7 @@ dependencies = [
  "assert_cmd",
  "build-target",
  "camino",
+ "dhat",
  "dunce",
  "insta",
  "itertools 0.14.0",
@@ -7706,6 +7735,7 @@ dependencies = [
  "console 0.16.2",
  "convert_case 0.6.0",
  "ctrlc",
+ "dhat",
  "dialoguer",
  "dirs-next",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,7 @@ dashmap = "6.1.0"
 derive_setters = "0.1.6"
 dialoguer = "0.12.0"
 dunce = "1.0.3"
+dhat = "0.3.3"
 either = "1.9.0"
 futures = "0.3.31"
 gix-attributes = { version = "0.31.0", default-features = false }

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -40,8 +40,8 @@ clap_complete = { workspace = true }
 console = { workspace = true }
 convert_case = "0.6.0"
 ctrlc = { version = "3.4.0", features = ["termination"] }
-dialoguer = { workspace = true, features = ["fuzzy-select", "password"] }
 dhat = { workspace = true, optional = true }
+dialoguer = { workspace = true, features = ["fuzzy-select", "password"] }
 dirs-next = "2.0.0"
 either = { workspace = true }
 futures = { workspace = true }

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 default = ["rustls-tls"]
 native-tls = ["turborepo-api-client/native-tls", "turbo-updater/native-tls"]
 rustls-tls = ["turborepo-api-client/rustls-tls", "turbo-updater/rustls-tls"]
+heap-dhat = ["dep:dhat"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dev-dependencies]
 anyhow = { workspace = true, features = ["backtrace"] }
@@ -40,6 +41,7 @@ console = { workspace = true }
 convert_case = "0.6.0"
 ctrlc = { version = "3.4.0", features = ["termination"] }
 dialoguer = { workspace = true, features = ["fuzzy-select", "password"] }
+dhat = { workspace = true, optional = true }
 dirs-next = "2.0.0"
 either = { workspace = true }
 futures = { workspace = true }

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -33,6 +33,13 @@ use crate::{
 mod error;
 mod observability;
 
+fn exit_with_heap_profile(code: i32) -> ! {
+    #[cfg(feature = "heap-dhat")]
+    crate::heap_profile::finish_global();
+
+    process::exit(code);
+}
+
 // Global turbo sets this environment variable to its cwd so that local
 // turbo can use it for package inference.
 pub const INVOCATION_DIR_ENV_VAR: &str = "TURBO_INVOCATION_DIR";
@@ -362,7 +369,7 @@ impl Args {
                 ) =>
             {
                 let _ = e.print();
-                process::exit(1);
+                exit_with_heap_profile(1);
             }
             Err(e) if e.use_stderr() => {
                 let err_str = format_error_message(e.to_string());
@@ -373,19 +380,19 @@ impl Args {
                     "{}",
                     err_str.strip_prefix("error: ").unwrap_or(err_str.as_str())
                 );
-                process::exit(1);
+                exit_with_heap_profile(1);
             }
             // If the clap error shouldn't be printed to stderr it indicates help text
             Err(e) => {
                 let _ = e.print();
-                process::exit(0);
+                exit_with_heap_profile(0);
             }
         };
         // We have to override the --version flag because we use `get_version`
         // instead of a hard-coded version or the crate version
         if clap_args.version {
             println!("{}", get_version());
-            process::exit(0);
+            exit_with_heap_profile(0);
         }
 
         if let Some(run_args) = clap_args.run_args() {
@@ -1407,7 +1414,7 @@ fn default_to_run_command(cli_args: &Args) -> Result<Command, Error> {
     if execution_args.tasks.is_empty() {
         let mut cmd = <Args as CommandFactory>::command();
         let _ = cmd.print_help();
-        process::exit(1);
+        exit_with_heap_profile(1);
     }
 
     Ok(Command::Run {

--- a/crates/turborepo-lib/src/heap_profile.rs
+++ b/crates/turborepo-lib/src/heap_profile.rs
@@ -1,0 +1,355 @@
+use std::{
+    cmp::Reverse,
+    error::Error,
+    fmt::Write as _,
+    path::{Path, PathBuf},
+    sync::Mutex,
+};
+
+use serde::{Deserialize, Serialize};
+
+static HEAP_PROFILER: Mutex<Option<HeapProfiler>> = Mutex::new(None);
+
+pub fn start_global(raw_path: impl Into<PathBuf>) {
+    let mut profiler = HEAP_PROFILER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    if profiler.is_none() {
+        *profiler = Some(HeapProfiler::start(raw_path));
+    }
+}
+
+pub fn finish_global() {
+    let profiler = HEAP_PROFILER
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .take();
+
+    drop(profiler);
+}
+
+pub struct HeapProfiler {
+    raw_path: PathBuf,
+    profiler: Option<dhat::Profiler>,
+}
+
+impl HeapProfiler {
+    pub fn start(raw_path: impl Into<PathBuf>) -> Self {
+        let raw_path = raw_path.into();
+
+        if let Some(parent) = raw_path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            if let Err(error) = std::fs::create_dir_all(parent) {
+                eprintln!(
+                    "turbo: failed to create heap profile directory {}: {error}",
+                    parent.display()
+                );
+            }
+        }
+
+        let profiler = dhat::Profiler::builder()
+            .file_name(&raw_path)
+            .trim_backtraces(Some(12))
+            .build();
+
+        Self {
+            raw_path,
+            profiler: Some(profiler),
+        }
+    }
+}
+
+impl Drop for HeapProfiler {
+    fn drop(&mut self) {
+        let Some(profiler) = self.profiler.take() else {
+            return;
+        };
+
+        let totals = HeapTotals::from(dhat::HeapStats::get());
+        drop(profiler);
+
+        if let Err(error) = write_summaries(&self.raw_path, totals) {
+            eprintln!(
+                "turbo: failed to write heap profile summary for {}: {error}",
+                self.raw_path.display()
+            );
+        }
+    }
+}
+
+#[derive(Clone, Copy, Serialize)]
+struct HeapTotals {
+    total_allocations: u64,
+    total_allocated_bytes: u64,
+    live_allocations_at_end: usize,
+    live_bytes_at_end: usize,
+    peak_live_allocations: usize,
+    peak_live_bytes: usize,
+}
+
+impl From<dhat::HeapStats> for HeapTotals {
+    fn from(stats: dhat::HeapStats) -> Self {
+        Self {
+            total_allocations: stats.total_blocks,
+            total_allocated_bytes: stats.total_bytes,
+            live_allocations_at_end: stats.curr_blocks,
+            live_bytes_at_end: stats.curr_bytes,
+            peak_live_allocations: stats.max_blocks,
+            peak_live_bytes: stats.max_bytes,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct DhatProfile {
+    cmd: String,
+    pid: u32,
+    te: u128,
+    pps: Vec<DhatPoint>,
+    ftbl: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct DhatPoint {
+    tb: u64,
+    tbk: u64,
+    #[serde(default)]
+    mb: Option<usize>,
+    #[serde(default)]
+    mbk: Option<usize>,
+    #[serde(default)]
+    gb: Option<usize>,
+    #[serde(default)]
+    gbk: Option<usize>,
+    #[serde(default)]
+    eb: Option<usize>,
+    #[serde(default)]
+    ebk: Option<usize>,
+    fs: Vec<usize>,
+}
+
+#[derive(Serialize)]
+struct HeapSummary {
+    raw_profile: String,
+    command: String,
+    pid: u32,
+    elapsed_micros: u128,
+    totals: HeapTotals,
+    top_by_allocated_bytes: Vec<AllocationSite>,
+    top_by_allocations: Vec<AllocationSite>,
+}
+
+#[derive(Clone, Serialize)]
+struct AllocationSite {
+    allocated_bytes: u64,
+    allocations: u64,
+    peak_live_bytes: Option<usize>,
+    peak_live_allocations: Option<usize>,
+    live_bytes_at_global_peak: Option<usize>,
+    live_allocations_at_global_peak: Option<usize>,
+    live_bytes_at_end: Option<usize>,
+    live_allocations_at_end: Option<usize>,
+    frames: Vec<String>,
+}
+
+fn write_summaries(raw_path: &Path, totals: HeapTotals) -> Result<(), Box<dyn Error>> {
+    let profile: DhatProfile = serde_json::from_str(&std::fs::read_to_string(raw_path)?)?;
+    let summary = build_summary(raw_path, totals, profile);
+
+    std::fs::write(
+        summary_path(raw_path, "summary.json"),
+        serde_json::to_string_pretty(&summary)?,
+    )?;
+    std::fs::write(
+        summary_path(raw_path, "summary.txt"),
+        summary_text(&summary),
+    )?;
+
+    Ok(())
+}
+
+fn build_summary(raw_path: &Path, totals: HeapTotals, profile: DhatProfile) -> HeapSummary {
+    let mut sites: Vec<_> = profile
+        .pps
+        .iter()
+        .map(|point| allocation_site(point, &profile.ftbl))
+        .collect();
+
+    sites.sort_by_key(|site| Reverse(site.allocated_bytes));
+    let top_by_allocated_bytes = sites.iter().take(20).cloned().collect();
+
+    sites.sort_by_key(|site| Reverse(site.allocations));
+    let top_by_allocations = sites.iter().take(20).cloned().collect();
+
+    HeapSummary {
+        raw_profile: raw_path.display().to_string(),
+        command: profile.cmd,
+        pid: profile.pid,
+        elapsed_micros: profile.te,
+        totals,
+        top_by_allocated_bytes,
+        top_by_allocations,
+    }
+}
+
+fn allocation_site(point: &DhatPoint, frames: &[String]) -> AllocationSite {
+    AllocationSite {
+        allocated_bytes: point.tb,
+        allocations: point.tbk,
+        peak_live_bytes: point.mb,
+        peak_live_allocations: point.mbk,
+        live_bytes_at_global_peak: point.gb,
+        live_allocations_at_global_peak: point.gbk,
+        live_bytes_at_end: point.eb,
+        live_allocations_at_end: point.ebk,
+        frames: point
+            .fs
+            .iter()
+            .filter_map(|idx| frames.get(*idx))
+            .take(12)
+            .cloned()
+            .collect(),
+    }
+}
+
+fn summary_path(raw_path: &Path, suffix: &str) -> PathBuf {
+    let mut path = raw_path.as_os_str().to_owned();
+    path.push(format!(".{suffix}"));
+    path.into()
+}
+
+fn summary_text(summary: &HeapSummary) -> String {
+    let mut output = String::new();
+
+    let _ = writeln!(output, "Turbo Heap Allocation Summary");
+    let _ = writeln!(output, "raw_profile: {}", summary.raw_profile);
+    let _ = writeln!(output, "command: {}", summary.command);
+    let _ = writeln!(output, "pid: {}", summary.pid);
+    let _ = writeln!(output, "elapsed_micros: {}", summary.elapsed_micros);
+    let _ = writeln!(output);
+    write_totals(&mut output, summary.totals);
+    let _ = writeln!(output);
+    write_sites(
+        &mut output,
+        "top_by_allocated_bytes",
+        &summary.top_by_allocated_bytes,
+    );
+    let _ = writeln!(output);
+    write_sites(
+        &mut output,
+        "top_by_allocations",
+        &summary.top_by_allocations,
+    );
+
+    output
+}
+
+fn write_totals(output: &mut String, totals: HeapTotals) {
+    let _ = writeln!(output, "totals:");
+    let _ = writeln!(
+        output,
+        "total_allocated_bytes: {} ({})",
+        totals.total_allocated_bytes,
+        format_bytes(totals.total_allocated_bytes)
+    );
+    let _ = writeln!(output, "total_allocations: {}", totals.total_allocations);
+    let _ = writeln!(
+        output,
+        "peak_live_bytes: {} ({})",
+        totals.peak_live_bytes,
+        format_bytes(totals.peak_live_bytes as u64)
+    );
+    let _ = writeln!(
+        output,
+        "peak_live_allocations: {}",
+        totals.peak_live_allocations
+    );
+    let _ = writeln!(
+        output,
+        "live_bytes_at_end: {} ({})",
+        totals.live_bytes_at_end,
+        format_bytes(totals.live_bytes_at_end as u64)
+    );
+    let _ = writeln!(
+        output,
+        "live_allocations_at_end: {}",
+        totals.live_allocations_at_end
+    );
+}
+
+fn write_sites(output: &mut String, title: &str, sites: &[AllocationSite]) {
+    let _ = writeln!(output, "{title}:");
+    for (idx, site) in sites.iter().enumerate() {
+        let _ = writeln!(
+            output,
+            "{}. allocated_bytes: {} ({})",
+            idx + 1,
+            site.allocated_bytes,
+            format_bytes(site.allocated_bytes)
+        );
+        let _ = writeln!(output, "   allocations: {}", site.allocations);
+        write_optional_usize(output, "peak_live_bytes", site.peak_live_bytes);
+        write_optional_usize(output, "peak_live_allocations", site.peak_live_allocations);
+        write_optional_usize(
+            output,
+            "live_bytes_at_global_peak",
+            site.live_bytes_at_global_peak,
+        );
+        write_optional_usize(
+            output,
+            "live_allocations_at_global_peak",
+            site.live_allocations_at_global_peak,
+        );
+        write_optional_usize(output, "live_bytes_at_end", site.live_bytes_at_end);
+        write_optional_usize(
+            output,
+            "live_allocations_at_end",
+            site.live_allocations_at_end,
+        );
+        let _ = writeln!(output, "   frames:");
+        for frame in &site.frames {
+            let _ = writeln!(output, "   - {frame}");
+        }
+    }
+}
+
+fn write_optional_usize(output: &mut String, name: &str, value: Option<usize>) {
+    if let Some(value) = value {
+        let _ = writeln!(output, "   {name}: {value}");
+    }
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+    let mut value = bytes as f64;
+    let mut unit = UNITS[0];
+
+    for next_unit in UNITS.iter().skip(1) {
+        if value < 1024.0 {
+            break;
+        }
+        value /= 1024.0;
+        unit = next_unit;
+    }
+
+    if unit == "B" {
+        format!("{bytes} B")
+    } else {
+        format!("{value:.2} {unit}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_bytes;
+
+    #[test]
+    fn formats_bytes() {
+        assert_eq!(format_bytes(0), "0 B");
+        assert_eq!(format_bytes(1024), "1.00 KiB");
+        assert_eq!(format_bytes(1024 * 1024), "1.00 MiB");
+    }
+}

--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -17,6 +17,8 @@ mod commands;
 mod config;
 pub mod devtools;
 mod engine;
+#[cfg(feature = "heap-dhat")]
+mod heap_profile;
 
 mod boundaries;
 mod microfrontends;
@@ -40,6 +42,14 @@ pub use turborepo_daemon::{
 pub use turborepo_query_api::QueryServer;
 
 pub use crate::{child::spawn_child, cli::Args, panic_handler::panic_handler};
+
+#[cfg(feature = "heap-dhat")]
+pub fn finish_heap_profile() {
+    heap_profile::finish_global();
+}
+
+#[cfg(not(feature = "heap-dhat"))]
+pub fn finish_heap_profile() {}
 
 pub fn get_version() -> &'static str {
     include_str!("../../../version.txt")

--- a/crates/turborepo-lib/src/shim.rs
+++ b/crates/turborepo-lib/src/shim.rs
@@ -207,6 +207,17 @@ pub fn run(query_server: Option<Arc<dyn turborepo_query_api::QueryServer>>) -> R
 
     // Parse args to get verbosity and color config for the subscriber
     let args = ShimArgs::parse().map_err(turborepo_shim::Error::from)?;
+
+    #[cfg(feature = "heap-dhat")]
+    if let Some(heap_profile_file) = args.heap_profile_file() {
+        crate::heap_profile::start_global(heap_profile_file);
+    }
+
+    #[cfg(not(feature = "heap-dhat"))]
+    if args.heap_profile_file().is_some() {
+        eprintln!("turbo: --heap requires a binary built with the heap-dhat feature");
+    }
+
     let color_config = args.color_config();
     let subscriber = TurboSubscriber::new_with_verbosity(args.verbosity, &color_config);
 

--- a/crates/turborepo-shim/src/parser.rs
+++ b/crates/turborepo-shim/src/parser.rs
@@ -86,6 +86,8 @@ pub struct ShimArgs {
     /// Raw value from `--anon-profile` (Some("") means flag present with no
     /// value).
     pub anon_profile: Option<String>,
+    /// Raw value from `--heap` (Some("") means flag present with no value).
+    pub heap: Option<String>,
 }
 
 impl ShimArgs {
@@ -113,8 +115,10 @@ impl ShimArgs {
         let mut root_turbo_json = None;
         let mut profile: Option<String> = None;
         let mut anon_profile: Option<String> = None;
+        let mut heap: Option<String> = None;
         let mut found_profile_flag = false;
         let mut found_anon_profile_flag = false;
+        let mut found_heap_flag = false;
 
         let args = args.skip(1);
         for (idx, arg) in args.enumerate() {
@@ -201,6 +205,15 @@ impl ShimArgs {
                     anon_profile = Some(arg.clone());
                     remaining_turbo_args.push(arg);
                 }
+            } else if found_heap_flag {
+                found_heap_flag = false;
+                if arg.starts_with('-') {
+                    heap = Some(String::new());
+                    remaining_turbo_args.push(arg);
+                } else {
+                    heap = Some(arg.clone());
+                    remaining_turbo_args.push(arg);
+                }
             } else if arg == "--profile" {
                 remaining_turbo_args.push(arg);
                 found_profile_flag = true;
@@ -212,6 +225,12 @@ impl ShimArgs {
                 found_anon_profile_flag = true;
             } else if let Some(value) = arg.strip_prefix("--anon-profile=") {
                 anon_profile = Some(value.to_string());
+                remaining_turbo_args.push(arg);
+            } else if arg == "--heap" {
+                remaining_turbo_args.push(arg);
+                found_heap_flag = true;
+            } else if let Some(value) = arg.strip_prefix("--heap=") {
+                heap = Some(value.to_string());
                 remaining_turbo_args.push(arg);
             } else if arg == "--debug" {
                 return Err(Error::UnsupportedFlag {
@@ -238,6 +257,9 @@ impl ShimArgs {
         }
         if found_anon_profile_flag {
             anon_profile = Some(String::new());
+        }
+        if found_heap_flag {
+            heap = Some(String::new());
         }
 
         if let Some(idx) = cwd_flag_idx {
@@ -294,6 +316,7 @@ impl ShimArgs {
             root_turbo_json,
             profile,
             anon_profile,
+            heap,
         })
     }
 
@@ -318,6 +341,20 @@ impl ShimArgs {
             // Both set should be caught by clap later; just ignore here.
             _ => None,
         }
+    }
+
+    pub fn heap_profile_file(&self) -> Option<String> {
+        self.heap.as_deref().map(|file| {
+            if file.is_empty() {
+                let now = match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+                    Ok(duration) => duration.as_millis(),
+                    Err(_) => 0,
+                };
+                format!("heap.{now}.json")
+            } else {
+                file.to_string()
+            }
+        })
     }
 
     /// Takes a list of indices into a Vec of arguments, i.e. ["--graph", "foo",
@@ -444,6 +481,7 @@ mod test {
         pub no_color: bool,
         pub relative_cwd: Option<&'static [&'static str]>,
         pub relative_root_turbo_json: Option<&'static str>,
+        pub heap: Option<&'static str>,
     }
 
     impl ExpectedArgs {
@@ -458,6 +496,7 @@ mod test {
                 no_color,
                 relative_cwd,
                 relative_root_turbo_json,
+                heap,
             } = self;
             ShimArgs {
                 cwd: relative_cwd.map_or_else(
@@ -479,6 +518,7 @@ mod test {
                     .map(|path| AbsoluteSystemPathBuf::from_unknown(invocation_dir, path)),
                 profile: None,
                 anon_profile: None,
+                heap: heap.map(str::to_string),
             }
         }
     }
@@ -632,6 +672,24 @@ mod test {
             ..Default::default()
         }
         ; "root turbo json absolute path"
+    )]
+    #[test_case(
+        &["turbo", "--heap", "heap.json", "run", "build"],
+        ExpectedArgs {
+            heap: Some("heap.json"),
+            remaining_turbo_args: &["--heap", "heap.json", "run", "build"],
+            ..Default::default()
+        }
+        ; "heap value"
+    )]
+    #[test_case(
+        &["turbo", "--heap=heap.json", "run", "build"],
+        ExpectedArgs {
+            heap: Some("heap.json"),
+            remaining_turbo_args: &["--heap=heap.json", "run", "build"],
+            ..Default::default()
+        }
+        ; "heap equals"
     )]
     fn test_shim_parsing(
         args: &[&str],

--- a/crates/turborepo/Cargo.toml
+++ b/crates/turborepo/Cargo.toml
@@ -12,6 +12,7 @@ default = ["rustls-tls"]
 native-tls = ["turborepo-lib/native-tls", "turborepo-lsp/native-tls"]
 rustls-tls = ["turborepo-lib/rustls-tls", "turborepo-lsp/rustls-tls"]
 pprof = ["turborepo-lib/pprof"]
+heap-dhat = ["dep:dhat", "turborepo-lib/heap-dhat"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [build-dependencies]
@@ -39,6 +40,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true, features = ["backtrace"] }
+dhat = { workspace = true, optional = true }
 miette.workspace = true
 turborepo-lib = { workspace = true, default-features = false }
 turborepo-lsp = { workspace = true, default-features = false }

--- a/crates/turborepo/src/main.rs
+++ b/crates/turborepo/src/main.rs
@@ -8,6 +8,10 @@ use miette::Report;
 
 const INTERNAL_LSP_COMMAND: &str = "__internal_lsp";
 
+#[cfg(feature = "heap-dhat")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
 #[derive(Debug, PartialEq)]
 enum InternalLspCommand {
     Probe,
@@ -89,6 +93,7 @@ fn main() -> Result<()> {
         1
     });
 
+    turborepo_lib::finish_heap_profile();
     process::exit(exit_code)
 }
 


### PR DESCRIPTION
## Why

We need a repeatable loop for finding allocation hot spots in the Rust CLI and validating allocation reductions. The existing --heap flag was parsed but did not produce heap profiles.

## What

Adds an opt-in heap-dhat feature that wires --heap to DHAT allocation profiling. Profiling builds produce the raw DHAT JSON plus .summary.txt and .summary.json files that rank allocation sites by bytes and allocation count.

Default builds do not enable the DHAT allocator. If --heap is used without the feature, Turbo reports that a heap-dhat build is required.

## How

Verified with:

- cargo test -p turborepo-shim parser::test
- cargo check -p turbo --features heap-dhat
- cargo check -p turbo
- cargo test -p turborepo-lib --features heap-dhat heap_profile
- cargo clippy -p turbo --features heap-dhat -- -D warnings
- pre-push hooks: format and check:toml