### PR TITLE
perf: Avoid normalizing git index path joins

### DIFF
--- a/crates/turborepo-paths/src/absolute_system_path.rs
+++ b/crates/turborepo-paths/src/absolute_system_path.rs
@@ -271,6 +271,24 @@ impl AbsoluteSystemPath {
         })
     }
 
+    /// Joins a normalized relative Unix path without resolving `.` or `..`.
+    /// Use `join_unix_path` unless the caller knows the path is normalized.
+    pub fn join_unix_path_unchecked(
+        &self,
+        unix_path: impl AsRef<RelativeUnixPath>,
+    ) -> AbsoluteSystemPathBuf {
+        #[cfg(unix)]
+        {
+            AbsoluteSystemPathBuf(self.0.join(unix_path.as_ref().as_str()))
+        }
+
+        #[cfg(windows)]
+        {
+            let tail = unix_path.as_ref().to_system_path_buf();
+            AbsoluteSystemPathBuf(self.0.join(tail))
+        }
+    }
+
     /// Note: This does not handle resolutions, so `../` in a path won't
     /// resolve.
     pub fn anchor(&self, path: &AbsoluteSystemPath) -> Result<AnchoredSystemPathBuf, PathError> {

--- a/crates/turborepo-paths/src/absolute_system_path_buf.rs
+++ b/crates/turborepo-paths/src/absolute_system_path_buf.rs
@@ -275,6 +275,15 @@ mod tests {
                 .join_unix_path(tail),
             AbsoluteSystemPathBuf::new("/some/other").unwrap(),
         );
+
+        let normalized_tail = RelativeUnixPathBuf::new("workspace/package.json").unwrap();
+
+        assert_eq!(
+            AbsoluteSystemPathBuf::new("/some/dir")
+                .unwrap()
+                .join_unix_path_unchecked(normalized_tail),
+            AbsoluteSystemPathBuf::new("/some/dir/workspace/package.json").unwrap(),
+        );
     }
 
     #[cfg(windows)]
@@ -301,6 +310,15 @@ mod tests {
                 .unwrap()
                 .join_unix_path(&tail),
             AbsoluteSystemPathBuf::new("C:\\some\\other").unwrap(),
+        );
+
+        let normalized_tail = RelativeUnixPathBuf::new("workspace/package.json").unwrap();
+
+        assert_eq!(
+            AbsoluteSystemPathBuf::new("C:\\some\\dir")
+                .unwrap()
+                .join_unix_path_unchecked(&normalized_tail),
+            AbsoluteSystemPathBuf::new("C:\\some\\dir\\workspace\\package.json").unwrap(),
         );
     }
 }

--- a/crates/turborepo-scm/src/repo_index.rs
+++ b/crates/turborepo-scm/src/repo_index.rs
@@ -114,7 +114,9 @@ impl RepoGitIndex {
                     Ok(path) => path,
                     Err(path) => return Ok(EntryClassification::Unsupported(path)),
                 };
-                let abs_path = git.root.join_unix_path(&rel_path);
+                // Git index paths are normalized repo-relative paths, so avoid
+                // per-entry path_clean normalization before stat calls.
+                let abs_path = git.root.join_unix_path_unchecked(&rel_path);
 
                 match gix_index::fs::Metadata::from_path_no_follow(abs_path.as_std_path()) {
                     Ok(fs_meta) => {


### PR DESCRIPTION
## Why

Building the repo git index joins every normalized git-index path to the repository root before stat comparison. The normal join path cleans every joined path, which adds allocation churn in a hot turbo run planning path.

Using the new heap profiling, turbo run build --dry=json on this repository showed this path accounting for about 9.25 MiB and 18k allocations. Avoiding the normalization step removed about 12 MiB and 55k total allocations from that dry run. Additional local hyperfine runs showed roughly 3-5% improvement.

## What

Adds a narrowly named join_unix_path_unchecked helper for already-normalized relative Unix paths and uses it when statting entries from .git/index.

The existing join_unix_path remains the safe/default API for callers that need `.` or `..` normalization.

## How

Verified with:

Benchmarked locally with release-turborepo binaries using `TURBO_TELEMETRY_DISABLED=1 turbo run build --dry=json`.

Representative 30-run hyperfine sample:

- Before: 710.2 ms ± 135.2 ms
- After: 670.5 ms ± 80.4 ms