### PR TITLE
release(turborepo): 2.9.15-canary.8

### DIFF
--- a/packages/create-turbo/package.json
+++ b/packages/create-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-turbo",
-  "version": "2.9.15-canary.7",
+  "version": "2.9.15-canary.8",
   "description": "Create a new Turborepo",
   "homepage": "https://turborepo.dev",
   "bugs": {

--- a/packages/eslint-config-turbo/package.json
+++ b/packages/eslint-config-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-turbo",
-  "version": "2.9.15-canary.7",
+  "version": "2.9.15-canary.8",
   "description": "ESLint config for Turborepo",
   "keywords": [
     "eslint",

--- a/packages/eslint-plugin-turbo/package.json
+++ b/packages/eslint-plugin-turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-turbo",
-  "version": "2.9.15-canary.7",
+  "version": "2.9.15-canary.8",
   "description": "ESLint plugin for Turborepo",
   "keywords": [
     "eslint",

--- a/packages/turbo-codemod/package.json
+++ b/packages/turbo-codemod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/codemod",
-  "version": "2.9.15-canary.7",
+  "version": "2.9.15-canary.8",
   "description": "Provides Codemod transformations to help upgrade your Turborepo codebase when a feature is deprecated.",
   "homepage": "https://turborepo.dev",
   "bugs": {

--- a/packages/turbo-gen/package.json
+++ b/packages/turbo-gen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/gen",
-  "version": "2.9.15-canary.7",
+  "version": "2.9.15-canary.8",
   "description": "Extend a Turborepo",
   "homepage": "https://turborepo.dev",
   "bugs": {

--- a/packages/turbo-ignore/package.json
+++ b/packages/turbo-ignore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-ignore",
-  "version": "2.9.15-canary.7",
+  "version": "2.9.15-canary.8",
   "description": "",
   "keywords": [],
   "homepage": "https://turborepo.dev",

--- a/packages/turbo-types/package.json
+++ b/packages/turbo-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/types",
-  "version": "2.9.15-canary.7",
+  "version": "2.9.15-canary.8",
   "description": "Turborepo types",
   "homepage": "https://turborepo.dev",
   "bugs": {

--- a/packages/turbo-workspaces/package.json
+++ b/packages/turbo-workspaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbo/workspaces",
-  "version": "2.9.15-canary.7",
+  "version": "2.9.15-canary.8",
   "description": "Tools for working with package managers",
   "homepage": "https://turborepo.dev",
   "bugs": {

--- a/packages/turbo/package.json
+++ b/packages/turbo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo",
-  "version": "2.9.15-canary.7",
+  "version": "2.9.15-canary.8",
   "description": "Turborepo is a high-performance build system for JavaScript and TypeScript codebases.",
   "homepage": "https://turborepo.dev",
   "bugs": "https://github.com/vercel/turborepo/issues",
@@ -18,11 +18,11 @@
     "postversion": "node bump-version.js"
   },
   "optionalDependencies": {
-    "@turbo/darwin-64": "2.9.15-canary.7",
-    "@turbo/darwin-arm64": "2.9.15-canary.7",
-    "@turbo/linux-64": "2.9.15-canary.7",
-    "@turbo/linux-arm64": "2.9.15-canary.7",
-    "@turbo/windows-64": "2.9.15-canary.7",
-    "@turbo/windows-arm64": "2.9.15-canary.7"
+    "@turbo/darwin-64": "2.9.15-canary.8",
+    "@turbo/darwin-arm64": "2.9.15-canary.8",
+    "@turbo/linux-64": "2.9.15-canary.8",
+    "@turbo/linux-arm64": "2.9.15-canary.8",
+    "@turbo/windows-64": "2.9.15-canary.8",
+    "@turbo/windows-arm64": "2.9.15-canary.8"
   }
 }

--- a/skills/turborepo/SKILL.md
+++ b/skills/turborepo/SKILL.md
@@ -9,7 +9,7 @@ description: |
   monorepo, shares code between apps, runs changed/affected packages, debugs cache,
   or has apps/packages directories.
 metadata:
-  version: 2.9.15-canary.7
+  version: 2.9.15-canary.8
 ---
 
 # Turborepo Skill
@@ -740,7 +740,7 @@ import { Button } from "@repo/ui/button";
 
 ```json
 {
-  "$schema": "https://v2-9-15-canary-7.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-15-canary-8.turborepo.dev/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],

--- a/skills/turborepo/references/best-practices/structure.md
+++ b/skills/turborepo/references/best-practices/structure.md
@@ -95,7 +95,7 @@ Package tasks enable Turborepo to:
 
 ```json
 {
-  "$schema": "https://v2-9-15-canary-7.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-15-canary-8.turborepo.dev/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
@@ -117,7 +117,7 @@ With `futureFlags.globalConfiguration`, global settings move under a `global` ke
 
 ```json
 {
-  "$schema": "https://v2-9-15-canary-7.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-15-canary-8.turborepo.dev/schema.json",
   "futureFlags": { "globalConfiguration": true },
   "global": {
     "inputs": ["tsconfig.json"],

--- a/skills/turborepo/references/configuration/RULE.md
+++ b/skills/turborepo/references/configuration/RULE.md
@@ -73,7 +73,7 @@ When you run `turbo run lint`, Turborepo finds all packages with a `lint` script
 
 ```json
 {
-  "$schema": "https://v2-9-15-canary-7.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-15-canary-8.turborepo.dev/schema.json",
   "globalEnv": ["CI"],
   "globalDependencies": ["tsconfig.json"],
   "tasks": {
@@ -97,7 +97,7 @@ When the `globalConfiguration` future flag is enabled, global options move under
 
 ```json
 {
-  "$schema": "https://v2-9-15-canary-7.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-15-canary-8.turborepo.dev/schema.json",
   "futureFlags": { "globalConfiguration": true },
   "global": {
     "inputs": ["tsconfig.json"],

--- a/skills/turborepo/references/environment/RULE.md
+++ b/skills/turborepo/references/environment/RULE.md
@@ -107,7 +107,7 @@ When the `globalConfiguration` future flag is enabled, global environment keys m
 
 ```json
 {
-  "$schema": "https://v2-9-15-canary-7.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-15-canary-8.turborepo.dev/schema.json",
   "globalEnv": ["CI", "NODE_ENV"],
   "globalPassThroughEnv": ["GITHUB_TOKEN", "NPM_TOKEN"],
   "tasks": {

--- a/skills/turborepo/references/environment/gotchas.md
+++ b/skills/turborepo/references/environment/gotchas.md
@@ -112,7 +112,7 @@ If you use `.env.development` and `.env.production`, both should be in inputs.
 
 ```json
 {
-  "$schema": "https://v2-9-15-canary-7.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-15-canary-8.turborepo.dev/schema.json",
   "globalEnv": ["CI", "NODE_ENV", "VERCEL"],
   "globalPassThroughEnv": ["GITHUB_TOKEN", "VERCEL_URL"],
   "tasks": {
@@ -146,7 +146,7 @@ The same config using the `global` key. The `.env` files move to `global.inputs`
 
 ```json
 {
-  "$schema": "https://v2-9-15-canary-7.turborepo.dev/schema.json",
+  "$schema": "https://v2-9-15-canary-8.turborepo.dev/schema.json",
   "futureFlags": { "globalConfiguration": true },
   "global": {
     "env": ["CI", "NODE_ENV", "VERCEL"],

--- a/version.txt
+++ b/version.txt
@@ -1,2 +1,2 @@
-2.9.15-canary.7
+2.9.15-canary.8
 canary


### PR DESCRIPTION
## Why
The 2.9.15-canary.8 release workflow failed during npm provenance after partially publishing packages. We are not recovering that canary publish, but main still needs the generated release metadata bump so future canaries move forward.

## What
Updates generated release metadata from 2.9.15-canary.7 to 2.9.15-canary.8. No code changes, release tag, or publish retry.

## How
Generated from failed release run SHA 31123f47 with `scripts/version.js prerelease` and `cli make prepare-stage-release`. Pre-push hooks passed: `lint-staged`, `turbo run format check:toml`, `cargo fmt --check`, `cargo lint`, and `cargo check --workspace`.