### PR TITLE
fix: Apply repository .gitignore to pruned workspaces

### DIFF
--- a/crates/turborepo-fs/src/lib.rs
+++ b/crates/turborepo-fs/src/lib.rs
@@ -23,65 +23,121 @@ pub enum Error {
     Walk(#[from] ignore::Error),
 }
 
+/// Recursively copy the contents of `src` into `dst`.
+///
+/// When `use_gitignore` is true, files matched by `.gitignore` rules are
+/// skipped. `gitignore_root` declares the directory that anchors gitignore
+/// resolution, which matters when `src` is a workspace package nested inside a
+/// monorepo. `.gitignore` files between `gitignore_root` and `src` are honored,
+/// and their patterns are anchored relative to where each file lives, exactly
+/// as git does. Pass `None` (or `src` itself) when there is no enclosing
+/// repository to consider.
 pub fn recursive_copy(
     src: impl AsRef<AbsoluteSystemPath>,
     dst: impl AsRef<AbsoluteSystemPath>,
     use_gitignore: bool,
+    gitignore_root: Option<&AbsoluteSystemPath>,
 ) -> Result<(), Error> {
     let src = src.as_ref();
     let dst = dst.as_ref();
     let src_metadata = src.symlink_metadata()?;
 
-    if src_metadata.is_dir() {
-        let walker = WalkBuilder::new(src.as_path())
-            .hidden(false)
-            .parents(false)
-            .git_ignore(use_gitignore)
-            .git_global(false)
-            .git_exclude(use_gitignore)
-            .build();
+    if !src_metadata.is_dir() {
+        return copy_file_with_type(src, src_metadata.file_type(), dst);
+    }
 
-        for entry in walker {
-            match entry {
-                Err(e) => {
-                    if e.io_error().is_some() {
-                        // Matches go behavior where we translate path errors
-                        // into skipping the path we're currently walking
-                        continue;
-                    } else {
-                        return Err(e.into());
-                    }
-                }
-                Ok(entry) => {
-                    let path = entry.path();
-                    let path = AbsoluteSystemPath::from_std_path(path)?;
-                    let file_type = match entry.file_type() {
-                        Some(file_type) => file_type,
-                        None => entry.metadata()?.file_type(),
-                    };
+    // The `ignore` crate mis-anchors `.gitignore` patterns from parent
+    // directories when the walk starts inside a subdirectory: a root-anchored
+    // entry such as `/apps/web/coverage` ends up matching a nested
+    // `apps/web/src/coverage`, and unanchored entries like `node_modules` from
+    // a parent `.gitignore` are dropped entirely. To match git, we root the
+    // walk at the enclosing repository when one is provided and only descend
+    // into the directories that lead to (or live under) `src`. Patterns and
+    // negations across the whole `.gitignore` chain then resolve through the
+    // crate's single matcher, which gets the anchoring right. When no
+    // enclosing repository is provided, or it does not actually contain `src`,
+    // we fall back to walking `src` directly.
+    let walk_root = match gitignore_root {
+        Some(root)
+            if use_gitignore
+                && src != root
+                && src.as_std_path().starts_with(root.as_std_path()) =>
+        {
+            root
+        }
+        _ => src,
+    };
+    let walk_from_root = walk_root != src;
 
-                    // Note that we also don't currently copy broken symlinks
-                    if file_type.is_symlink() && path.stat().is_err() {
-                        // If we have a broken link, skip this entry
-                        continue;
-                    }
+    let mut builder = WalkBuilder::new(walk_root.as_path());
+    builder
+        .hidden(false)
+        .parents(false)
+        .git_ignore(use_gitignore)
+        .git_global(false)
+        .git_exclude(use_gitignore);
 
-                    let suffix = AnchoredSystemPathBuf::new(src, path)?;
-                    let target = dst.resolve(&suffix);
-                    if file_type.is_dir() {
-                        let src_metadata = entry.metadata()?;
-                        make_dir_copy(&target, &src_metadata)?;
-                    } else if file_type.is_file() || file_type.is_symlink() {
-                        copy_file_with_type(path, file_type, &target)?;
-                    }
-                    // Skip special files (sockets, FIFOs, device nodes)
+    if walk_from_root {
+        let src_std = src.as_std_path().to_path_buf();
+        builder.filter_entry(move |entry| {
+            let path = entry.path();
+            let is_dir = entry
+                .file_type()
+                .is_some_and(|file_type| file_type.is_dir());
+            if is_dir {
+                // Descend only into ancestors of `src` and directories inside
+                // `src`, skipping sibling trees we are not copying.
+                path.starts_with(&src_std) || src_std.starts_with(path)
+            } else {
+                path.starts_with(&src_std)
+            }
+        });
+    }
+
+    for entry in builder.build() {
+        let entry = match entry {
+            Err(e) => {
+                if e.io_error().is_some() {
+                    // Matches go behavior where we translate path errors
+                    // into skipping the path we're currently walking
+                    continue;
+                } else {
+                    return Err(e.into());
                 }
             }
+            Ok(entry) => entry,
+        };
+        let path = entry.path();
+        let path = AbsoluteSystemPath::from_std_path(path)?;
+
+        // When walking from the repository root, the root and the ancestors of
+        // `src` are yielded too. Only copy entries that live within `src`.
+        if path != src && !path.as_std_path().starts_with(src.as_std_path()) {
+            continue;
         }
-        Ok(())
-    } else {
-        Ok(copy_file_with_type(src, src_metadata.file_type(), dst)?)
+
+        let file_type = match entry.file_type() {
+            Some(file_type) => file_type,
+            None => entry.metadata()?.file_type(),
+        };
+
+        // Note that we also don't currently copy broken symlinks
+        if file_type.is_symlink() && path.stat().is_err() {
+            // If we have a broken link, skip this entry
+            continue;
+        }
+
+        let suffix = AnchoredSystemPathBuf::new(src, path)?;
+        let target = dst.resolve(&suffix);
+        if file_type.is_dir() {
+            let src_metadata = entry.metadata()?;
+            make_dir_copy(&target, &src_metadata)?;
+        } else if file_type.is_file() || file_type.is_symlink() {
+            copy_file_with_type(path, file_type, &target)?;
+        }
+        // Skip special files (sockets, FIFOs, device nodes)
     }
+    Ok(())
 }
 
 fn make_dir_copy(
@@ -287,10 +343,10 @@ mod tests {
 
         let (_dst_tmp, dst_dir) = tmp_dir()?;
 
-        recursive_copy(&src_dir, &dst_dir, true)?;
+        recursive_copy(&src_dir, &dst_dir, true, None)?;
 
         // Ensure double copy doesn't error
-        recursive_copy(&src_dir, &dst_dir, true)?;
+        recursive_copy(&src_dir, &dst_dir, true, None)?;
 
         let dst_child_path = dst_dir.join_component("child");
         let dst_a_path = dst_child_path.join_component("a");
@@ -362,7 +418,7 @@ mod tests {
         hidden.create_with_contents("polo")?;
 
         let (_dst_tmp, dst_dir) = tmp_dir()?;
-        recursive_copy(&src_dir, &dst_dir, use_gitignore)?;
+        recursive_copy(&src_dir, &dst_dir, use_gitignore, None)?;
 
         assert!(dst_dir.join_component(".gitignore").exists());
         assert_eq!(
@@ -373,6 +429,105 @@ mod tests {
         assert!(dst_dir.join_component("child").exists());
         assert!(dst_dir.join_components(&["child", "seen.txt"]).exists());
         assert!(dst_dir.join_components(&["child", ".hidden"]).exists());
+
+        Ok(())
+    }
+
+    #[test_case(true)]
+    #[test_case(false)]
+    fn test_recursive_copy_respects_repo_gitignore(use_gitignore: bool) -> Result<(), Error> {
+        // A workspace package nested inside a monorepo. The root `.gitignore`
+        // must apply to the copied package, and its anchored entries must not
+        // overmatch nested directories that happen to share a name. Layout:
+        //
+        // <root>/
+        //   .git/
+        //   .gitignore             <- node_modules, /apps/web/coverage, *.log
+        //   apps/web/              <- the package we copy
+        //     package.json
+        //     node_modules/dep/index.js   <- ignored via root rule
+        //     coverage/report.txt         <- ignored via /apps/web/coverage
+        //     src/api/coverage/keep.js     <- kept, anchored rule must not match
+        //     src/api/.gitignore           <- nested: ignored.js
+        //     src/api/ignored.js           <- ignored via nested rule
+        //     logs/.gitignore              <- nested negation: !keep.log
+        //     logs/keep.log                <- kept despite root *.log
+        //     logs/drop.log                <- ignored via root *.log
+        let (_root_tmp, root) = tmp_dir()?;
+        root.join_component(".git").create_dir_all()?;
+        root.join_component(".gitignore")
+            .create_with_contents("node_modules\n/apps/web/coverage\n*.log\n")?;
+
+        let web = root.join_components(&["apps", "web"]);
+        web.create_dir_all()?;
+        web.join_component("package.json")
+            .create_with_contents("{}")?;
+        let nm = web.join_components(&["node_modules", "dep", "index.js"]);
+        nm.ensure_dir()?;
+        nm.create_with_contents("dep")?;
+        let coverage = web.join_components(&["coverage", "report.txt"]);
+        coverage.ensure_dir()?;
+        coverage.create_with_contents("report")?;
+        let nested_coverage = web.join_components(&["src", "api", "coverage", "keep.js"]);
+        nested_coverage.ensure_dir()?;
+        nested_coverage.create_with_contents("keep")?;
+        web.join_components(&["src", "api", ".gitignore"])
+            .create_with_contents("ignored.js\n")?;
+        web.join_components(&["src", "api", "ignored.js"])
+            .create_with_contents("ignored")?;
+        let logs_keep = web.join_components(&["logs", "keep.log"]);
+        logs_keep.ensure_dir()?;
+        web.join_components(&["logs", ".gitignore"])
+            .create_with_contents("!keep.log\n")?;
+        logs_keep.create_with_contents("keep")?;
+        web.join_components(&["logs", "drop.log"])
+            .create_with_contents("drop")?;
+
+        let (_dst_tmp, dst_dir) = tmp_dir()?;
+        recursive_copy(&web, &dst_dir, use_gitignore, Some(&root))?;
+
+        // Always copied regardless of gitignore handling.
+        assert!(dst_dir.join_component("package.json").exists());
+        assert!(
+            dst_dir
+                .join_components(&["src", "api", "coverage", "keep.js"])
+                .exists()
+        );
+
+        let node_modules = dst_dir.join_components(&["node_modules", "dep", "index.js"]);
+        let real_coverage = dst_dir.join_components(&["coverage", "report.txt"]);
+        let nested_ignored = dst_dir.join_components(&["src", "api", "ignored.js"]);
+        let kept_log = dst_dir.join_components(&["logs", "keep.log"]);
+        let dropped_log = dst_dir.join_components(&["logs", "drop.log"]);
+
+        if use_gitignore {
+            // Root rule applies to the nested package.
+            assert!(
+                !node_modules.exists(),
+                "root node_modules rule should apply"
+            );
+            // Anchored root rule matches the real coverage dir.
+            assert!(
+                !real_coverage.exists(),
+                "anchored /apps/web/coverage should be ignored"
+            );
+            // Anchored root rule must not overmatch the nested coverage dir.
+            // (covered by the unconditional assert above)
+            // Nested .gitignore is still respected.
+            assert!(!nested_ignored.exists(), "nested ignore rule should apply");
+            // Nested negation re-includes a root-ignored file.
+            assert!(
+                kept_log.exists(),
+                "nested negation should re-include keep.log"
+            );
+            assert!(!dropped_log.exists(), "root *.log should ignore drop.log");
+        } else {
+            assert!(node_modules.exists());
+            assert!(real_coverage.exists());
+            assert!(nested_ignored.exists());
+            assert!(kept_log.exists());
+            assert!(dropped_log.exists());
+        }
 
         Ok(())
     }

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -585,10 +585,10 @@ impl<'a> Prune<'a> {
             return Ok(());
         }
         let full_to = self.full_directory.resolve(path);
-        turborepo_fs::recursive_copy(&from_path, full_to, self.use_gitignore)?;
+        turborepo_fs::recursive_copy(&from_path, full_to, self.use_gitignore, Some(&self.root))?;
         if matches!(destination, Some(CopyDestination::All)) {
             let out_to = self.out_directory.resolve(path);
-            turborepo_fs::recursive_copy(&from_path, out_to, self.use_gitignore)?;
+            turborepo_fs::recursive_copy(&from_path, out_to, self.use_gitignore, Some(&self.root))?;
         }
         if self.docker
             && matches!(
@@ -597,7 +597,12 @@ impl<'a> Prune<'a> {
             )
         {
             let docker_to = self.docker_directory().resolve(path);
-            turborepo_fs::recursive_copy(&from_path, docker_to, self.use_gitignore)?;
+            turborepo_fs::recursive_copy(
+                &from_path,
+                docker_to,
+                self.use_gitignore,
+                Some(&self.root),
+            )?;
         }
         Ok(())
     }
@@ -616,7 +621,12 @@ impl<'a> Prune<'a> {
         let target_dir = self.full_directory.resolve(&relative_workspace_dir);
         target_dir.create_dir_all_with_permissions(metadata.permissions())?;
 
-        turborepo_fs::recursive_copy(original_dir, &target_dir, self.use_gitignore)?;
+        turborepo_fs::recursive_copy(
+            original_dir,
+            &target_dir,
+            self.use_gitignore,
+            Some(&self.root),
+        )?;
 
         if self.docker {
             let docker_workspace_dir = self.docker_directory().resolve(&relative_workspace_dir);

--- a/crates/turborepo/tests/prune_test.rs
+++ b/crates/turborepo/tests/prune_test.rs
@@ -238,6 +238,53 @@ fn test_prune_does_not_overmatch_root_gitignore_entries() {
     );
 }
 
+#[test]
+fn test_prune_respects_root_gitignore_in_workspaces() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(
+        tempdir.path(),
+        "monorepo_with_root_dep",
+        "pnpm@7.25.1",
+        false,
+    )
+    .unwrap();
+
+    // A root `.gitignore` that ignores `node_modules` should apply to copied
+    // workspace packages, even though prune copies each package directory
+    // individually. See https://github.com/vercel/turborepo/issues/12946.
+    fs::write(tempdir.path().join(".gitignore"), "node_modules\n").unwrap();
+
+    let nested_node_modules = tempdir.path().join("packages/shared/node_modules/dep");
+    fs::create_dir_all(&nested_node_modules).unwrap();
+    fs::write(
+        nested_node_modules.join("index.js"),
+        "module.exports = {};\n",
+    )
+    .unwrap();
+
+    let output = run_turbo(tempdir.path(), &["prune", "web", "--docker"]);
+    assert!(
+        output.status.success(),
+        "prune failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !tempdir
+            .path()
+            .join("out/full/packages/shared/node_modules")
+            .exists(),
+        "root node_modules ignore should apply to copied workspace package"
+    );
+    // The package itself is still copied.
+    assert!(
+        tempdir
+            .path()
+            .join("out/full/packages/shared/package.json")
+            .exists(),
+        "workspace package contents should still be copied"
+    );
+}
+
 // --- produces-valid-turbo-json.t ---
 
 #[test]


### PR DESCRIPTION
### Description

`turbo prune` copies each workspace package directory on its own. Since #12662 the copy passed `parents(false)` to the `ignore` crate's `WalkBuilder` to stop a root-anchored entry like `/apps/web/coverage` from overmatching a nested `apps/web/src/api/coverage`. That flag also disabled every parent `.gitignore`, so an ordinary root rule such as `node_modules` no longer applied to the copied package. The result is `node_modules` getting copied into the pruned output, which is what #12946 reports (it broke a Docker build that did not expect package-level `node_modules` symlinks).

The underlying problem is that the `ignore` crate mis-anchors parent `.gitignore` patterns when the walk starts inside a subdirectory. Rooting the walk at the package directory loses the correct anchor for rules that live higher up.

This change roots the walk at the enclosing repository when one is provided, then uses `filter_entry` purely to skip sibling trees so we still only copy the package we care about. The whole `.gitignore` chain (root, intermediate, and nested files) now resolves through the crate's single matcher, which gets anchoring and negations right, matching what git itself does. When prune has no enclosing repository to consider, the behavior is unchanged.

`recursive_copy` gains a `gitignore_root` parameter so callers declare where gitignore resolution is anchored. Prune passes the monorepo root.

### Testing

- New `turborepo-fs` unit test covering a nested package: a root `node_modules` rule is applied, a root-anchored `/apps/web/coverage` ignores the real coverage dir but not a nested `src/api/coverage`, a nested `.gitignore` is still respected, and a nested negation re-includes a root-ignored file.
- New `prune` integration test asserting a root `node_modules` ignore keeps `node_modules` out of the pruned workspace while the rest of the package is copied.
- The existing #12662 regression test (`test_prune_does_not_overmatch_root_gitignore_entries`) still passes, so the overmatch fix is preserved.
- `cargo test -p turborepo-fs`, `cargo test -p turbo --test prune_test` (all 18), `cargo lint`, `cargo fmt --check`, and `cargo check --workspace` all pass locally.

Fixes #12946.