### PR TITLE
fix: include root tasks in query affected detection

### DIFF
--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -716,8 +716,30 @@ impl RunBuilder {
         } else {
             Vec::new()
         };
+
+        // `add_all_tasks` (used by `turbo query` and devtools) wants the full
+        // task graph, which includes root tasks declared as `//#task` in the
+        // root turbo.json. Package scope resolution only ever returns named
+        // workspaces, so the root package must be added explicitly or the
+        // engine builder skips every root task. See the affected-tasks query,
+        // which would otherwise never see a changed root task.
+        let add_root_workspace = self.add_all_tasks
+            && !needs_all_packages
+            && !filtered_pkgs.contains_key(&PackageName::Root);
+        let filtered_engine_pkgs: Vec<PackageName> = if add_root_workspace {
+            filtered_pkgs
+                .keys()
+                .cloned()
+                .chain(std::iter::once(PackageName::Root))
+                .collect()
+        } else {
+            Vec::new()
+        };
+
         let engine_pkgs: Box<dyn Iterator<Item = &PackageName>> = if needs_all_packages {
             Box::new(all_pkgs.iter())
+        } else if add_root_workspace {
+            Box::new(filtered_engine_pkgs.iter())
         } else {
             Box::new(filtered_pkgs.keys())
         };
@@ -743,6 +765,8 @@ impl RunBuilder {
             pkg_dep_graph.remove_package_dependencies();
             let engine_pkgs: Box<dyn Iterator<Item = &PackageName>> = if needs_all_packages {
                 Box::new(all_pkgs.iter())
+            } else if add_root_workspace {
+                Box::new(filtered_engine_pkgs.iter())
             } else {
                 Box::new(filtered_pkgs.keys())
             };

--- a/crates/turborepo-query/src/lib.rs
+++ b/crates/turborepo-query/src/lib.rs
@@ -656,8 +656,16 @@ impl RepositoryQuery {
             .into_iter()
             .filter(|ct| {
                 let has_script = ct.task.script.is_some();
+                // A requested task name may be bare (`deploy`) or fully
+                // qualified (`web#build`, `//#deploy`). Match against both so
+                // root tasks declared as `//#task` in turbo.json can be
+                // selected by their canonical name.
+                let full_name = format!("{}#{}", ct.task.package.get_name(), ct.task.name);
                 let task_ok = tasks.as_ref().is_none_or(|names| {
-                    names.is_empty() || names.iter().any(|n| n.as_str() == ct.task.name)
+                    names.is_empty()
+                        || names
+                            .iter()
+                            .any(|n| n.as_str() == ct.task.name || n.as_str() == full_name)
                 });
                 let package_ok = filter.as_ref().is_none_or(|f| f.check(&ct.task.package));
                 has_script && task_ok && package_ok

--- a/crates/turborepo/tests/command_query_test.rs
+++ b/crates/turborepo/tests/command_query_test.rs
@@ -4,7 +4,7 @@ mod common;
 
 use std::fs;
 
-use common::{run_turbo, setup};
+use common::{git, run_turbo, setup};
 
 #[test]
 fn test_query_from_file() {
@@ -44,4 +44,103 @@ fn test_query_inline() {
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     let version = json["data"]["version"].as_str().unwrap();
     assert!(!version.is_empty(), "version should not be empty");
+}
+
+fn affected_task_full_names(output: &std::process::Output) -> Vec<String> {
+    assert!(
+        output.status.success(),
+        "query failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let mut names: Vec<String> = json["data"]["affectedTasks"]["items"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|i| i["fullName"].as_str().unwrap().to_string())
+        .collect();
+    names.sort();
+    names
+}
+
+// Regression test for https://github.com/vercel/turborepo/issues/12947
+//
+// A root task declared as `//#task` in the root turbo.json was never included
+// in the engine that `turbo query affected` builds, so changing a file the task
+// declares as an input reported zero affected tasks. The basic_monorepo fixture
+// declares `//#something`, which uses default inputs (every root file), so a
+// change to a root file should mark it affected.
+#[test]
+fn test_query_affected_detects_root_task() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+
+    // bar.txt lives at the repo root and is not a declared globalDependency,
+    // so changing it must not mark every task affected. Only the root task
+    // (default inputs) and nothing else should be flagged.
+    fs::write(tempdir.path().join("bar.txt"), "changed\n").unwrap();
+    git(tempdir.path(), &["commit", "-am", "change bar", "--quiet"]);
+
+    let output = run_turbo(
+        tempdir.path(),
+        &["query", "affected", "--base", "HEAD~1", "--head", "HEAD"],
+    );
+    let names = affected_task_full_names(&output);
+    assert!(
+        names.contains(&"//#something".to_string()),
+        "root task //#something should be affected by a root file change, got {names:?}"
+    );
+}
+
+// Companion to test_query_affected_detects_root_task: the `--tasks` filter must
+// accept the canonical `//#task` name as well as the bare task name, otherwise
+// the documented `turbo query affected --tasks //#task --exit-code` pattern can
+// never select a root task.
+#[test]
+fn test_query_affected_tasks_filter_matches_root_task() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+
+    fs::write(tempdir.path().join("bar.txt"), "changed\n").unwrap();
+    git(tempdir.path(), &["commit", "-am", "change bar", "--quiet"]);
+
+    // Fully-qualified root task name.
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "query",
+            "affected",
+            "--tasks",
+            "//#something",
+            "--base",
+            "HEAD~1",
+            "--head",
+            "HEAD",
+        ],
+    );
+    assert_eq!(
+        affected_task_full_names(&output),
+        vec!["//#something".to_string()],
+        "--tasks //#something should select the root task"
+    );
+
+    // Bare task name resolves to the same root task.
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "query",
+            "affected",
+            "--tasks",
+            "something",
+            "--base",
+            "HEAD~1",
+            "--head",
+            "HEAD",
+        ],
+    );
+    assert_eq!(
+        affected_task_full_names(&output),
+        vec!["//#something".to_string()],
+        "--tasks something (bare name) should select the root task"
+    );
 }


### PR DESCRIPTION
## Description

`turbo query affected` never reported root tasks (tasks declared as `//#task` in the root `turbo.json`) as affected, even when a file the task lists in its `inputs` changed. The documented `turbo query affected --tasks //#task --exit-code` pattern from the [Skipping tasks guide](https://turborepo.dev/docs/guides/skipping-tasks) therefore always returned exit code 0, silently skipping root task CI gating.

The asymmetry was real: `turbo run //#task --filter='[HEAD^]' --dry-run=json` correctly reports the same task as a `MISS`, so the hashing machinery understood it was affected. Only the query path missed it.

## Root cause

There were two separate gaps:

1. The query engine is built from package scope resolution, and the "all packages" path only returns named workspaces (`PackageName::Other`), never the root package. With the root workspace absent, the engine builder's workspace-by-task loop skipped every `//#task`, so the root task was never in the engine `match_tasks_against_changed_files` iterates.

2. The `--tasks` filter compared the requested name only against the bare task name (`deploy:sst`), so passing the canonical `//#deploy:sst` matched nothing.

## Fix

- In `RunBuilder`, add the root package to the engine workspaces whenever `add_all_tasks` is set. Both `turbo query` and devtools use `add_all_tasks` to get the complete task graph, which by definition includes root tasks. The engine builder already gates root tasks behind `root_enabled_tasks`, so only declared root tasks are added.
- In the `affectedTasks` resolver, match a task against its fully qualified `//#task` name in addition to its bare name, so both `--tasks //#deploy:sst` and `--tasks deploy:sst` select it.

## Testing

Two integration tests in `command_query_test.rs` against the `basic_monorepo` fixture (which declares `//#something`):

- `test_query_affected_detects_root_task`: changing a root file flags `//#something` as affected.
- `test_query_affected_tasks_filter_matches_root_task`: both the `//#something` and bare `something` filters select the root task.

Both fail on `main` (zero affected) and pass with this change. I also confirmed a change scoped to a single package still affects only that package's task and does not spuriously flag the root task.

Verified locally: `cargo test -p turbo --test command_query_test --test affected_test --test query_test`, `cargo test -p turborepo-lib --lib`, `cargo test -p turborepo-query -p turborepo-engine`, `cargo fmt --check`, and `cargo clippy -- -D warnings` on the touched crates all pass.

Fixes #12947