### PR TITLE
fix: Avoid hanging PTY shutdown

### DIFF
--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -18,7 +18,7 @@
 const CHILD_POLL_INTERVAL: Duration = Duration::from_micros(50);
 const POST_EXIT_OUTPUT_DRAIN_TIMEOUT: Duration = Duration::from_millis(100);
 #[cfg(unix)]
-const PTY_PROCESS_GROUP_SIGINT_DELAY: Duration = Duration::from_millis(500);
+const PTY_PROCESS_GROUP_SIGINT_DELAY: Duration = Duration::from_secs(1);
 #[cfg(any(unix, windows))]
 const PROCESS_TREE_DRAIN_POLL_INTERVAL: Duration = Duration::from_millis(10);
 #[cfg(windows)]

--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -17,6 +17,8 @@
 
 const CHILD_POLL_INTERVAL: Duration = Duration::from_micros(50);
 const POST_EXIT_OUTPUT_DRAIN_TIMEOUT: Duration = Duration::from_millis(100);
+#[cfg(unix)]
+const PTY_PROCESS_GROUP_SIGINT_DELAY: Duration = Duration::from_millis(500);
 #[cfg(any(unix, windows))]
 const PROCESS_TREE_DRAIN_POLL_INTERVAL: Duration = Duration::from_millis(10);
 #[cfg(windows)]
@@ -163,6 +165,8 @@ struct ChildHandle {
     shutdown_semantics: ShutdownSemantics,
     #[cfg(unix)]
     target_identity: Option<TargetIdentity>,
+    #[cfg(unix)]
+    pty_controller_fd: Option<libc::c_int>,
     #[cfg(windows)]
     _job: Option<super::job_object::JobObject>,
 }
@@ -175,7 +179,7 @@ enum ChildHandleImpl {
 #[cfg(unix)]
 #[derive(Debug, Clone, Copy)]
 enum GracefulInterruptTarget {
-    DirectChild,
+    DirectChildWithProcessGroupFallback,
     ProcessGroup,
 }
 
@@ -197,9 +201,9 @@ impl ShutdownSemantics {
         }
     }
 
-    fn direct_child_then_wait_for_process_group() -> Self {
+    fn direct_child_with_process_group_fallback() -> Self {
         Self {
-            graceful_interrupt_target: GracefulInterruptTarget::DirectChild,
+            graceful_interrupt_target: GracefulInterruptTarget::DirectChildWithProcessGroupFallback,
             wait_for_process_group_after_child_exit: true,
         }
     }
@@ -348,6 +352,8 @@ impl ChildHandle {
                 shutdown_semantics: ShutdownSemantics::process_group(),
                 #[cfg(unix)]
                 target_identity,
+                #[cfg(unix)]
+                pty_controller_fd: None,
                 #[cfg(windows)]
                 _job: job,
             },
@@ -421,6 +427,9 @@ impl ChildHandle {
                 .ok()
         });
 
+        #[cfg(unix)]
+        let pty_controller_fd = controller.as_raw_fd();
+
         let mut stdin = controller.take_writer().ok();
         let output = controller.try_clone_reader().ok().map(ChildOutput::Pty);
 
@@ -450,9 +459,11 @@ impl ChildHandle {
                 pid,
                 imp: ChildHandleImpl::Pty(child),
                 #[cfg(unix)]
-                shutdown_semantics: ShutdownSemantics::direct_child_then_wait_for_process_group(),
+                shutdown_semantics: ShutdownSemantics::direct_child_with_process_group_fallback(),
                 #[cfg(unix)]
                 target_identity,
+                #[cfg(unix)]
+                pty_controller_fd,
                 #[cfg(windows)]
                 _job: job,
             },
@@ -476,25 +487,46 @@ impl ChildHandle {
     }
 
     #[cfg(unix)]
-    fn send_graceful_interrupt(&self, pid: libc::pid_t) {
-        let target = match self.shutdown_semantics.graceful_interrupt_target {
-            GracefulInterruptTarget::DirectChild => {
-                debug!("sending SIGINT to child {}", pid);
-                pid
-            }
-            GracefulInterruptTarget::ProcessGroup => {
-                let Some(process_group_id) = self.process_group_id() else {
-                    debug!("missing process group id for child {}", pid);
-                    return;
-                };
-                debug!("sending SIGINT to process group -{}", process_group_id);
-                -process_group_id
-            }
+    fn graceful_process_group_id(&self) -> Option<libc::pid_t> {
+        self.pty_controller_fd
+            .and_then(|fd| match unsafe { libc::tcgetpgrp(fd) } {
+                process_group_id if process_group_id > 0 => Some(process_group_id),
+                _ => None,
+            })
+            .or_else(|| self.process_group_id())
+    }
+
+    #[cfg(unix)]
+    fn send_signal_to_process_group(&self, pid: libc::pid_t, signal: libc::c_int) {
+        let Some(process_group_id) = self.graceful_process_group_id() else {
+            debug!("missing process group id for child {pid}");
+            return;
         };
 
-        if unsafe { libc::kill(target, libc::SIGINT) } == -1 {
-            debug!("failed to send SIGINT to {target}");
+        debug!("sending signal {signal} to process group -{process_group_id}");
+        signal_process_group(process_group_id, signal);
+    }
+
+    #[cfg(unix)]
+    fn send_graceful_interrupt(&self, pid: libc::pid_t) -> bool {
+        match self.shutdown_semantics.graceful_interrupt_target {
+            GracefulInterruptTarget::DirectChildWithProcessGroupFallback => {
+                debug!("sending SIGINT to child {pid}");
+                if unsafe { libc::kill(pid, libc::SIGINT) } == -1 {
+                    debug!("failed to send SIGINT to {pid}");
+                }
+                false
+            }
+            GracefulInterruptTarget::ProcessGroup => {
+                self.send_signal_to_process_group(pid, libc::SIGINT);
+                true
+            }
         }
+    }
+
+    #[cfg(unix)]
+    fn send_fallback_graceful_interrupt(&self, pid: libc::pid_t) {
+        self.send_signal_to_process_group(pid, libc::SIGINT);
     }
 
     #[cfg(unix)]
@@ -811,7 +843,10 @@ impl ShutdownStyle {
                         return ChildExit::Interrupted;
                     };
 
-                    child.send_graceful_interrupt(pid as libc::pid_t);
+                    let pid = pid as libc::pid_t;
+                    let mut process_group_interrupt_sent = child.send_graceful_interrupt(pid);
+                    let process_group_interrupt_deadline =
+                        tokio::time::Instant::now() + PTY_PROCESS_GROUP_SIGINT_DELAY;
                     debug!("waiting for child {}", pid);
 
                     let deadline = timeout.map(|timeout| tokio::time::Instant::now() + timeout);
@@ -826,6 +861,10 @@ impl ShutdownStyle {
                                             Ok(_exit_code) => ChildExit::Interrupted,
                                             Err(_) => ChildExit::Failed,
                                         };
+                                    }
+                                    _ = tokio::time::sleep_until(process_group_interrupt_deadline), if !process_group_interrupt_sent => {
+                                        child.send_fallback_graceful_interrupt(pid);
+                                        process_group_interrupt_sent = true;
                                     }
                                     command = command_rx.recv(), if command_rx_open => {
                                         match command {
@@ -857,6 +896,10 @@ impl ShutdownStyle {
                                             Err(_) => ChildExit::Failed,
                                         };
                                     }
+                                    _ = tokio::time::sleep_until(process_group_interrupt_deadline), if !process_group_interrupt_sent => {
+                                        child.send_fallback_graceful_interrupt(pid);
+                                        process_group_interrupt_sent = true;
+                                    }
                                     command = command_rx.recv(), if command_rx_open => {
                                         match command {
                                             Some(ChildCommand::Kill) => {
@@ -878,7 +921,7 @@ impl ShutdownStyle {
                     if exit == ChildExit::Interrupted {
                         child
                             .wait_for_process_group_exit(
-                                pid as libc::pid_t,
+                                pid,
                                 deadline,
                                 command_rx,
                                 &mut command_rx_open,
@@ -1423,7 +1466,7 @@ impl Child {
 #[cfg(test)]
 mod test {
     use std::{
-        assert_matches, io,
+        assert_matches, fs, io,
         sync::{Arc, Mutex},
         time::Duration,
     };
@@ -2058,11 +2101,7 @@ mod test {
         let exit = child.stop().await;
 
         // On Unix, shell scripts may not respond to SIGINT and will timeout,
-        // resulting in being killed rather than interrupted. For non-PTY
-        // children, SIGINT goes to the process group but shells may still
-        // continue their loop. For PTY children, SIGINT goes only to the
-        // direct child to avoid double delivery through package managers,
-        // which also means the shell may not exit gracefully.
+        // resulting in being killed rather than interrupted.
         if cfg!(unix) {
             assert_matches!(exit, Some(ChildExit::Killed) | Some(ChildExit::Interrupted));
         } else {
@@ -2626,6 +2665,65 @@ mod test {
         child.stop().await;
         // Give OS time to clean up
         tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_pty_graceful_shutdown_signals_process_group() {
+        let marker_file = std::env::temp_dir().join(format!(
+            "turbo-pty-process-group-sigint-{}",
+            std::process::id()
+        ));
+        let ready_file = std::env::temp_dir().join(format!(
+            "turbo-pty-process-group-ready-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_file(&marker_file);
+        let _ = fs::remove_file(&ready_file);
+        let marker_file = marker_file.to_string_lossy().into_owned();
+        let ready_file = ready_file.to_string_lossy().into_owned();
+
+        let script = r#"
+const { spawn } = require("child_process");
+process.on("SIGINT", () => {});
+const child = spawn(process.execPath, [
+  "-e",
+  "process.on('SIGINT', () => { require('fs').writeFileSync(process.argv[1], 'interrupted'); process.exit(0); }); require('fs').writeFileSync(process.argv[2], 'ready'); setInterval(() => {}, 1000);",
+  process.argv[1],
+  process.argv[2],
+], { stdio: "inherit" });
+child.on("exit", () => process.exit(0));
+"#;
+        let mut cmd = Command::new("node");
+        cmd.args(["-e", script, marker_file.as_str(), ready_file.as_str()]);
+        let mut child = Child::spawn(
+            cmd,
+            ShutdownStyle::Graceful(Some(Duration::from_secs(2))),
+            Some(PtySize::default()),
+        )
+        .unwrap();
+
+        for _ in 0..50 {
+            if fs::metadata(&ready_file).is_ok() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        assert!(
+            fs::metadata(&ready_file).is_ok(),
+            "node child should become ready before shutdown"
+        );
+
+        let exit = child.stop().await;
+
+        assert_eq!(exit, Some(ChildExit::Interrupted));
+        assert!(
+            fs::metadata(&marker_file).is_ok(),
+            "node child should receive SIGINT from PTY process-group shutdown"
+        );
+
+        let _ = fs::remove_file(marker_file);
+        let _ = fs::remove_file(ready_file);
     }
 
     #[cfg(unix)]

--- a/crates/turborepo/tests/graceful_shutdown_test.rs
+++ b/crates/turborepo/tests/graceful_shutdown_test.rs
@@ -599,7 +599,7 @@ while true; do sleep 0.2 || true; done
         let task_child_pid = wait_for_pid_file(&child_pid_file, START_TIMEOUT);
 
         child.send_ctrl_c();
-        thread::sleep(Duration::from_millis(3500));
+        thread::sleep(Duration::from_millis(500));
         child.send_ctrl_c();
 
         let transcript = child.finish(Duration::from_secs(5));


### PR DESCRIPTION
## Why

Interactive PTY tasks can hang during graceful shutdown when the direct wrapper process does not forward SIGINT to its child process. This makes Ctrl+C require a second interrupt to force-kill tasks instead of shutting down cleanly.

## What

Closes #12920 

Adds a Unix PTY shutdown fallback that first gives wrapper processes a chance to forward SIGINT, then signals the PTY foreground process group if the wrapper is still running.

## How

Unit testing add in `cargo test -p turborepo-process`. Used a Vercel-internal repository that started showing the behavior from #12920.
