### PR TITLE
fix: Preserve nested Bun dependency versions

### DIFF
--- a/crates/turborepo-lockfiles/src/bun/mod.rs
+++ b/crates/turborepo-lockfiles/src/bun/mod.rs
@@ -4228,4 +4228,78 @@ mod test {
         assert_eq!(pruned.data.packages["is-number"].ident, "is-number@7.0.0");
         assert_eq!(pruned.data.packages["b/is-number"].ident, "is-number@6.0.0");
     }
+
+    // Regression test for https://github.com/vercel/turborepo/issues/12962
+    #[test]
+    fn test_subgraph_preserves_hoisted_transitive_version_with_nested_mismatch() {
+        let contents = serde_json::to_string(&json!({
+            "lockfileVersion": 1,
+            "configVersion": 1,
+            "workspaces": {
+                "": {
+                    "name": "turbo-prune-bun-nested-major-mismatch",
+                    "dependencies": {
+                        "bs58": "5.0.0"
+                    }
+                },
+                "apps/app": {
+                    "name": "@repro/app",
+                    "version": "0.0.0",
+                    "dependencies": {
+                        "@repro/lib": "workspace:*",
+                        "bs58": "6.0.0"
+                    }
+                },
+                "packages/lib": {
+                    "name": "@repro/lib",
+                    "version": "0.0.0",
+                    "dependencies": {
+                        "bs58": "5.0.0"
+                    }
+                }
+            },
+            "packages": {
+                "@repro/app": ["@repro/app@workspace:apps/app"],
+                "@repro/lib": ["@repro/lib@workspace:packages/lib"],
+                "base-x": ["base-x@4.0.1", "", {}, "sha512-base-x-4"],
+                "bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-bs58-5"],
+                "@repro/app/bs58": ["bs58@6.0.0", "", { "dependencies": { "base-x": "^5.0.0" } }, "sha512-bs58-6"],
+                "@repro/app/bs58/base-x": ["base-x@5.0.1", "", {}, "sha512-base-x-5"]
+            }
+        }))
+        .unwrap();
+
+        let lockfile = BunLockfile::from_str(&contents).unwrap();
+        let subgraph = <BunLockfile as crate::Lockfile>::subgraph(
+            &lockfile,
+            &["apps/app".into(), "packages/lib".into()],
+            &[],
+        )
+        .unwrap();
+
+        let encoded = subgraph.encode().unwrap();
+        let encoded_str = String::from_utf8(encoded).unwrap();
+        let pruned = BunLockfile::from_str(&encoded_str).unwrap();
+
+        assert!(
+            pruned.data.packages.contains_key("base-x"),
+            "hoisted base-x@4 used by bs58@5 must remain in the pruned lockfile"
+        );
+        assert!(
+            pruned.data.packages.contains_key("@repro/app/bs58/base-x"),
+            "nested base-x@5 used by bs58@6 must remain in the pruned lockfile"
+        );
+
+        let lib_base_x = pruned
+            .resolve_package("packages/lib", "base-x", "^4.0.0")
+            .unwrap()
+            .expect("bs58@5 should resolve base-x@4");
+        assert_eq!(lib_base_x.key, "base-x@4.0.1");
+
+        let app_base_x = pruned
+            .resolve_package("apps/app", "base-x", "=5.0.1")
+            .unwrap()
+            .expect("bs58@6 should resolve base-x@5");
+        assert_eq!(app_base_x.key, "base-x@5.0.1");
+    }
 }

--- a/crates/turborepo-lockfiles/src/bun/types.rs
+++ b/crates/turborepo-lockfiles/src/bun/types.rs
@@ -44,14 +44,14 @@ impl PackageKey {
         }
 
         if let Some((parent, name)) = split_nested_key(s) {
-            if let Some(stripped_parent) = parent.strip_prefix('@') {
-                if let Some(first_slash) = stripped_parent.find('/') {
-                    return Self::ScopedNested {
-                        scope: stripped_parent[..first_slash].to_string(),
-                        parent: stripped_parent[first_slash + 1..].to_string(),
-                        name: name.to_string(),
-                    };
-                }
+            if let Some(stripped_parent) = parent.strip_prefix('@')
+                && let Some(first_slash) = stripped_parent.find('/')
+            {
+                return Self::ScopedNested {
+                    scope: stripped_parent[..first_slash].to_string(),
+                    parent: stripped_parent[first_slash + 1..].to_string(),
+                    name: name.to_string(),
+                };
             }
 
             Self::Nested {

--- a/crates/turborepo-lockfiles/src/bun/types.rs
+++ b/crates/turborepo-lockfiles/src/bun/types.rs
@@ -31,39 +31,34 @@ pub enum PackageKey {
 impl PackageKey {
     /// Parse a package key string into its structured form.
     pub fn parse(s: &str) -> Self {
-        if s.starts_with('@') {
-            // Scoped package or scoped nested
+        let slash_count = s.bytes().filter(|b| *b == b'/').count();
+        if s.starts_with('@') && slash_count == 1 {
             if let Some(first_slash) = s.find('/') {
-                let scope = s[1..first_slash].to_string(); // Skip '@'
-                let after_scope = &s[first_slash + 1..];
-
-                if let Some(second_slash) = after_scope.find('/') {
-                    // ScopedNested: @scope/parent/name
-                    let parent = after_scope[..second_slash].to_string();
-                    let name = after_scope[second_slash + 1..].to_string();
-                    Self::ScopedNested {
-                        scope,
-                        parent,
-                        name,
-                    }
-                } else {
-                    // Scoped: @scope/name
-                    Self::Scoped {
-                        scope,
-                        name: after_scope.to_string(),
-                    }
-                }
-            } else {
-                // Malformed scoped package, treat as simple
-                Self::Simple(s.to_string())
+                return Self::Scoped {
+                    scope: s[1..first_slash].to_string(),
+                    name: s[first_slash + 1..].to_string(),
+                };
             }
-        } else if let Some(slash_pos) = s.find('/') {
-            // Nested: parent/name
-            let parent = s[..slash_pos].to_string();
-            let name = s[slash_pos + 1..].to_string();
-            Self::Nested { parent, name }
+
+            return Self::Simple(s.to_string());
+        }
+
+        if let Some((parent, name)) = split_nested_key(s) {
+            if let Some(stripped_parent) = parent.strip_prefix('@') {
+                if let Some(first_slash) = stripped_parent.find('/') {
+                    return Self::ScopedNested {
+                        scope: stripped_parent[..first_slash].to_string(),
+                        parent: stripped_parent[first_slash + 1..].to_string(),
+                        name: name.to_string(),
+                    };
+                }
+            }
+
+            Self::Nested {
+                parent: parent.to_string(),
+                name: name.to_string(),
+            }
         } else {
-            // Simple: name
             Self::Simple(s.to_string())
         }
     }
@@ -118,6 +113,18 @@ impl PackageKey {
             _ => None,
         }
     }
+}
+
+fn split_nested_key(s: &str) -> Option<(&str, &str)> {
+    if let Some(scoped_child_pos) = s.rfind("/@") {
+        let child = &s[scoped_child_pos + 1..];
+        if child[1..].contains('/') {
+            return Some((&s[..scoped_child_pos], child));
+        }
+    }
+
+    let slash_pos = s.rfind('/')?;
+    Some((&s[..slash_pos], &s[slash_pos + 1..]))
 }
 
 impl fmt::Display for PackageKey {
@@ -467,6 +474,14 @@ mod tests {
         assert_eq!(key.name(), "dep");
         assert_eq!(key.to_string(), "parent/dep");
         assert_eq!(key.parent(), Some("parent".to_string()));
+
+        let key = PackageKey::parse("grandparent/parent/dep");
+        assert_eq!(key.name(), "dep");
+        assert_eq!(key.parent(), Some("grandparent/parent".to_string()));
+
+        let key = PackageKey::parse("parent/@scope/dep");
+        assert_eq!(key.name(), "@scope/dep");
+        assert_eq!(key.parent(), Some("parent".to_string()));
     }
 
     #[test]
@@ -483,6 +498,14 @@ mod tests {
         assert_eq!(key.name(), "dep");
         assert_eq!(key.to_string(), "@scope/parent/dep");
         assert_eq!(key.parent(), Some("@scope/parent".to_string()));
+
+        let key = PackageKey::parse("@scope/workspace/parent/dep");
+        assert_eq!(key.name(), "dep");
+        assert_eq!(key.parent(), Some("@scope/workspace/parent".to_string()));
+
+        let key = PackageKey::parse("@babel/core/@babel/traverse");
+        assert_eq!(key.name(), "@babel/traverse");
+        assert_eq!(key.parent(), Some("@babel/core".to_string()));
     }
 
     #[test]

--- a/lockfile-tests/fixtures/bun-nested-major-mismatch/apps/app/package.json
+++ b/lockfile-tests/fixtures/bun-nested-major-mismatch/apps/app/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@repro/app",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@repro/lib": "workspace:*",
+    "bs58": "6.0.0"
+  }
+}

--- a/lockfile-tests/fixtures/bun-nested-major-mismatch/bun.lock
+++ b/lockfile-tests/fixtures/bun-nested-major-mismatch/bun.lock
@@ -1,0 +1,57 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "turbo-prune-bun-nested-major-mismatch",
+      "dependencies": {
+        "bs58": "5.0.0",
+      },
+      "devDependencies": {
+        "turbo": "canary",
+      },
+    },
+    "apps/app": {
+      "name": "@repro/app",
+      "version": "0.0.0",
+      "dependencies": {
+        "@repro/lib": "workspace:*",
+        "bs58": "6.0.0",
+      },
+    },
+    "packages/lib": {
+      "name": "@repro/lib",
+      "version": "0.0.0",
+      "dependencies": {
+        "bs58": "5.0.0",
+      },
+    },
+  },
+  "packages": {
+    "@repro/app": ["@repro/app@workspace:apps/app"],
+
+    "@repro/lib": ["@repro/lib@workspace:packages/lib"],
+
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.16-canary.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-mog35WvcWFMT7GtcVsMCbUa36GJcNeKN4FwcNhR49HoswZnzXMdsplE1Ab//wYUHo58z3qE++HOqF3oO/8kDbg=="],
+
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.16-canary.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-YjFYsHjXwMPaIApzeif+PpHxk7GvzjqbIomkpWwRkh4wGlzB7byYQKPiI4h/r112sYPH0PtiUjkJDRvhcofGLw=="],
+
+    "@turbo/linux-64": ["@turbo/linux-64@2.9.16-canary.2", "", { "os": "linux", "cpu": "x64" }, "sha512-/oA0i1/Fzrle7PAWb7CycCc/84jXX8IO46mSOxkPnndO+Rj2j7v7Da/R61NeDxL7as11kWIs+GsULzuANIC2qg=="],
+
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.16-canary.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Wr9nZViVxdR8GMuZTNGb83WEKIUwq0D18K0PuEn4MOkmAkNLFlNX7yi6N2et/uscbjwjUCezgDSAXvsfe3vlJA=="],
+
+    "@turbo/windows-64": ["@turbo/windows-64@2.9.16-canary.2", "", { "os": "win32", "cpu": "x64" }, "sha512-3L9y++CT+zl94azrZo2tMf4UyrCpIjVmw0/GwwLv1BAnnI5AOt937XG0rs62BlZ5xfdQIZW1uNrVrAk+cBNGag=="],
+
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.16-canary.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-++Ajf8cUH5uKuyFzyoBLEthtvYQn9CfG2jMY8s0ocAVZzkpRi0ddYW2lWPTerb6iF+8pakupzuOyLlnxGBaglA=="],
+
+    "base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
+
+    "bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
+
+    "turbo": ["turbo@2.9.16-canary.2", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.16-canary.2", "@turbo/darwin-arm64": "2.9.16-canary.2", "@turbo/linux-64": "2.9.16-canary.2", "@turbo/linux-arm64": "2.9.16-canary.2", "@turbo/windows-64": "2.9.16-canary.2", "@turbo/windows-arm64": "2.9.16-canary.2" }, "bin": { "turbo": "bin/turbo" } }, "sha512-ICTfobk+VG38iju+pwe74EFYfx1fvJRw8DEiHPLVkO5mdILuhw4nKNj+6IF5iK0Lz6/oc9H91Q5OALZTLxg1kA=="],
+
+    "@repro/app/bs58": ["bs58@6.0.0", "", { "dependencies": { "base-x": "^5.0.0" } }, "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw=="],
+
+    "@repro/app/bs58/base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
+  }
+}

--- a/lockfile-tests/fixtures/bun-nested-major-mismatch/meta.json
+++ b/lockfile-tests/fixtures/bun-nested-major-mismatch/meta.json
@@ -1,0 +1,7 @@
+{
+  "packageManager": "bun",
+  "packageManagerVersion": "bun@1.3.14",
+  "lockfileName": "bun.lock",
+  "pruneTargets": ["@repro/app"],
+  "docker": true
+}

--- a/lockfile-tests/fixtures/bun-nested-major-mismatch/package.json
+++ b/lockfile-tests/fixtures/bun-nested-major-mismatch/package.json
@@ -1,12 +1,15 @@
 {
   "name": "turbo-prune-bun-nested-major-mismatch",
   "private": true,
-  "packageManager": "bun@1.3.14",
-  "workspaces": ["apps/*", "packages/*"],
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "dependencies": {
+    "bs58": "5.0.0"
+  },
   "devDependencies": {
     "turbo": "canary"
   },
-  "dependencies": {
-    "bs58": "5.0.0"
-  }
+  "packageManager": "bun@1.3.14"
 }

--- a/lockfile-tests/fixtures/bun-nested-major-mismatch/package.json
+++ b/lockfile-tests/fixtures/bun-nested-major-mismatch/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "turbo-prune-bun-nested-major-mismatch",
+  "private": true,
+  "packageManager": "bun@1.3.14",
+  "workspaces": ["apps/*", "packages/*"],
+  "devDependencies": {
+    "turbo": "canary"
+  },
+  "dependencies": {
+    "bs58": "5.0.0"
+  }
+}

--- a/lockfile-tests/fixtures/bun-nested-major-mismatch/packages/lib/package.json
+++ b/lockfile-tests/fixtures/bun-nested-major-mismatch/packages/lib/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@repro/lib",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "bs58": "5.0.0"
+  }
+}

--- a/lockfile-tests/fixtures/bun-nested-major-mismatch/turbo.json
+++ b/lockfile-tests/fixtures/bun-nested-major-mismatch/turbo.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {}
+}


### PR DESCRIPTION
## Why

Bun lockfile pruning could drop a hoisted transitive dependency when a target workspace also used a newer nested version of the same package. That left the pruned lockfile accepted by Bun but resolving a dependency outside its declared semver range.

## What

Fix Bun package key parsing for deeply nested package keys so pruning preserves the correct parent-child relationship for each nested dependency. Add a regression test and a check-lockfiles fixture based on issue #12962.

## How

Verified with:

- `cargo test -p turborepo-lockfiles`
- `cargo fmt --check`
- `cargo build -p turbo`
- `pnpm check-lockfiles --fixture bun-nested-major-mismatch --turbo-path ../target/debug/turbo`

Pre-push hooks also passed on push.