### PR TITLE
fix: Don't delete existing `.git` when using `--no-git` flag

### DIFF
--- a/packages/create-turbo/__tests__/git.test.ts
+++ b/packages/create-turbo/__tests__/git.test.ts
@@ -4,11 +4,7 @@ import type { SpawnSyncReturns } from "node:child_process";
 import fs from "node:fs";
 import { setupTestFixtures } from "@turbo/test-utils";
 import { describe, it, expect, jest } from "@jest/globals";
-import {
-  DEFAULT_IGNORE,
-  tryGitInit,
-  removeGitDirectory
-} from "../src/utils/git";
+import { DEFAULT_IGNORE, tryGitInit } from "../src/utils/git";
 
 function spawnResult(status: number): SpawnSyncReturns<Buffer> {
   return {
@@ -253,43 +249,6 @@ describe("git", () => {
           "Directory path contains potentially unsafe characters"
         );
       }
-    });
-  });
-
-  describe("removeGitDirectory", () => {
-    const { useFixture } = setupTestFixtures({
-      directory: path.join(__dirname, "../"),
-      options: { emptyFixture: true }
-    });
-
-    it("attempts to remove .git directory", async () => {
-      const { root } = useFixture({ fixture: `remove-git` });
-      const mockRmSync = jest.spyOn(fs, "rmSync").mockReturnValue(undefined);
-
-      const result = removeGitDirectory(root);
-      expect(result).toBe(true);
-
-      expect(mockRmSync).toHaveBeenCalledWith(path.join(root, ".git"), {
-        recursive: true,
-        force: true
-      });
-      mockRmSync.mockRestore();
-    });
-
-    it("returns false on error", async () => {
-      const { root } = useFixture({ fixture: `remove-git-error` });
-      const mockRmSync = jest.spyOn(fs, "rmSync").mockImplementation(() => {
-        throw new Error("Permission denied");
-      });
-
-      const result = removeGitDirectory(root);
-      expect(result).toBe(false);
-
-      expect(mockRmSync).toHaveBeenCalledWith(path.join(root, ".git"), {
-        recursive: true,
-        force: true
-      });
-      mockRmSync.mockRestore();
     });
   });
 });

--- a/packages/create-turbo/__tests__/index.test.ts
+++ b/packages/create-turbo/__tests__/index.test.ts
@@ -292,7 +292,7 @@ describe("create-turbo", () => {
     mockSpawnSync.mockRestore();
   });
 
-  it("does not initialize git and removes .git directory when --no-git flag is used", async () => {
+  it("does not initialize git or remove .git directory when --no-git flag is used", async () => {
     const { root } = useFixture({ fixture: "create-turbo-no-git" });
     const packageManager = "npm";
 
@@ -333,13 +333,7 @@ describe("create-turbo", () => {
         signal: null
       });
 
-    const mockTryGitInit = jest
-      .spyOn(gitUtils, "tryGitInit")
-      .mockReturnValue(true);
-
-    const mockRemoveGitDirectory = jest
-      .spyOn(gitUtils, "removeGitDirectory")
-      .mockReturnValue(true);
+    const mockTryGitInit = jest.spyOn(gitUtils, "tryGitInit");
 
     await create(root as CreateCommandArgument, {
       packageManager,
@@ -350,17 +344,16 @@ describe("create-turbo", () => {
     });
 
     expect(mockTryGitInit).not.toHaveBeenCalled();
-    expect(mockRemoveGitDirectory).toHaveBeenCalledWith(root);
+    expect(mockSpawnSync).not.toHaveBeenCalled();
 
     mockAvailablePackageManagers.mockRestore();
     mockCreateProject.mockRestore();
     mockGetWorkspaceDetails.mockRestore();
     mockSpawnSync.mockRestore();
     mockTryGitInit.mockRestore();
-    mockRemoveGitDirectory.mockRestore();
   });
 
-  it("initializes git and does not remove .git directory when --no-git flag is not used", async () => {
+  it("initializes git when --no-git flag is not used", async () => {
     const { root } = useFixture({ fixture: "create-turbo-with-git" });
     const packageManager = "npm";
 
@@ -405,10 +398,6 @@ describe("create-turbo", () => {
       .spyOn(gitUtils, "tryGitInit")
       .mockReturnValue(true);
 
-    const mockRemoveGitDirectory = jest
-      .spyOn(gitUtils, "removeGitDirectory")
-      .mockReturnValue(true);
-
     await create(root as CreateCommandArgument, {
       packageManager,
       skipInstall: true,
@@ -418,13 +407,11 @@ describe("create-turbo", () => {
     });
 
     expect(mockTryGitInit).toHaveBeenCalledWith(root);
-    expect(mockRemoveGitDirectory).not.toHaveBeenCalled();
 
     mockAvailablePackageManagers.mockRestore();
     mockCreateProject.mockRestore();
     mockGetWorkspaceDetails.mockRestore();
     mockSpawnSync.mockRestore();
     mockTryGitInit.mockRestore();
-    mockRemoveGitDirectory.mockRestore();
   });
 });

--- a/packages/create-turbo/src/commands/create/index.ts
+++ b/packages/create-turbo/src/commands/create/index.ts
@@ -13,7 +13,7 @@ import {
   DownloadError,
   logger
 } from "@turbo/utils";
-import { tryGitInit, removeGitDirectory } from "../../utils/git";
+import { tryGitInit } from "../../utils/git";
 import { transforms } from "../../transforms";
 import { TransformError } from "../../transforms/errors";
 import { isDefaultExample } from "../../utils/is-default-example";
@@ -296,10 +296,6 @@ export async function create(
     if (tryGitInit(root)) {
       info("Initialized a git repository.");
     }
-  } else {
-    // User explicitly doesn't want git - remove any .git directory
-    // (e.g., if the example template came with one)
-    removeGitDirectory(root);
   }
 
   opts.telemetry?.trackCommandStatus({ command: "create", status: "end" });

--- a/packages/create-turbo/src/utils/git.ts
+++ b/packages/create-turbo/src/utils/git.ts
@@ -108,12 +108,3 @@ export function tryGitInit(root: string): boolean {
     return false;
   }
 }
-
-export function removeGitDirectory(root: string): boolean {
-  try {
-    rmSync(path.join(root, ".git"), { recursive: true, force: true });
-    return true;
-  } catch (_) {
-    return false;
-  }
-}


### PR DESCRIPTION
## Why

Closes #12967. Users who pass `--no-git` expect create-turbo to leave git alone, not initialize a repo or delete an existing `.git` directory.

## What

Stops the `--no-git` path from doing any git work and removes the now-unused `.git` deletion helper.

## How

Adds coverage that `--no-git` does not call the git init helper or spawn git commands, while preserving normal git initialization when the flag is not used.

Verified with:
- `pnpm --filter create-turbo test -- --runTestsByPath __tests__/git.test.ts __tests__/index.test.ts`
- `pnpm --filter create-turbo check-types`