### PR TITLE
fix: Detect affected root tasks in query

### DIFF
--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -702,12 +702,13 @@ impl RunBuilder {
             && self.opts.scope_opts.affected_range.is_some()
             && self.opts.future_flags.affected_using_task_inputs;
 
-        let needs_all_packages = use_task_level_affected || use_task_level_filter;
+        let needs_all_packages =
+            use_task_level_affected || use_task_level_filter || self.add_all_tasks;
 
-        // When task-level filtering is active, the engine must contain tasks
-        // for ALL packages so that $TURBO_ROOT$ inputs in packages not flagged
-        // by the package-level scope resolution are still matched.
-        // The task-level filter (below) does the pruning.
+        // When task-level filtering or add_all_tasks is active, the engine must
+        // contain tasks for ALL packages so that $TURBO_ROOT$ inputs in packages
+        // not flagged by the package-level scope resolution are still matched.
+        // The task-level filter (below) does the pruning when needed.
         let all_pkgs: Vec<PackageName> = if needs_all_packages {
             pkg_dep_graph
                 .packages()

--- a/crates/turborepo-query/src/affected_tasks.rs
+++ b/crates/turborepo-query/src/affected_tasks.rs
@@ -49,10 +49,10 @@ pub struct AffectedTask {
 ///    change (lockfile, global dep, missing git ref), every task in the engine
 ///    is returned immediately with the corresponding reason.
 ///
-/// 2. **Direct input matching**: For each affected package, each task's
-///    `inputs` globs are checked against the changed files. Packages whose
-///    lockfile-derived external dependency closure changed seed their own tasks
-///    directly, even when no package-local file changed.
+/// 2. **Direct input matching**: Each task's `inputs` globs are checked against
+///    the changed files. Packages whose lockfile-derived external dependency
+///    closure changed seed their own tasks directly, even when no package-local
+///    file changed.
 ///
 /// 3. **Graph propagation**: BFS from directly affected tasks through the task
 ///    dependency graph in O(V + E). If task A depends on task B and B is
@@ -63,10 +63,6 @@ pub fn calculate_affected_tasks(
     head: Option<String>,
 ) -> Result<Vec<AffectedTask>, Error> {
     let affected_packages = run.calculate_affected_packages(base.clone(), head.clone())?;
-
-    if affected_packages.is_empty() {
-        return Ok(Vec::new());
-    }
 
     // Check if this is an "all packages changed" scenario
     let all_packages_reason = affected_packages.values().find_map(|reason| match reason {

--- a/crates/turborepo-query/src/lib.rs
+++ b/crates/turborepo-query/src/lib.rs
@@ -657,7 +657,14 @@ impl RepositoryQuery {
             .filter(|ct| {
                 let has_script = ct.task.script.is_some();
                 let task_ok = tasks.as_ref().is_none_or(|names| {
-                    names.is_empty() || names.iter().any(|n| n.as_str() == ct.task.name)
+                    if names.is_empty() {
+                        true
+                    } else {
+                        let full_name = format!("{}#{}", ct.task.package.get_name(), ct.task.name);
+                        names
+                            .iter()
+                            .any(|n| n.as_str() == ct.task.name || n == &full_name)
+                    }
                 });
                 let package_ok = filter.as_ref().is_none_or(|f| f.check(&ct.task.package));
                 has_script && task_ok && package_ok

--- a/crates/turborepo/tests/affected_test.rs
+++ b/crates/turborepo/tests/affected_test.rs
@@ -11,6 +11,76 @@ fn setup_affected(dir: &std::path::Path) {
     git(dir, &["checkout", "-b", "my-branch"]);
 }
 
+fn setup_nonsense_root_task_affected(dir: &Path) {
+    fs::create_dir_all(dir.join("flarble")).unwrap();
+    fs::create_dir_all(dir.join("packages/blorbo")).unwrap();
+
+    fs::write(
+        dir.join("package.json"),
+        r#"{
+  "name": "glorp",
+  "private": true,
+  "packageManager": "npm@10.5.0",
+  "workspaces": ["packages/*"],
+  "scripts": {
+    "zibble:zonk": "echo zibble"
+  }
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        dir.join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.com/schema.json",
+  "tasks": {
+    "//#zibble:zonk": {
+      "cache": false,
+      "inputs": ["flarble/**"]
+    }
+  }
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        dir.join("packages/blorbo/package.json"),
+        r#"{
+  "name": "blorbo",
+  "version": "1.0.0"
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        dir.join("package-lock.json"),
+        r#"{
+  "name": "glorp",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "glorp",
+      "workspaces": ["packages/*"]
+    },
+    "node_modules/blorbo": {
+      "resolved": "packages/blorbo",
+      "link": true
+    },
+    "packages/blorbo": {
+      "name": "blorbo",
+      "version": "1.0.0"
+    }
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    setup::setup_git(dir).unwrap();
+    git(dir, &["checkout", "-b", "my-branch"]);
+}
+
 fn setup_berry_catalog_affected(dir: &Path) {
     fs::create_dir_all(dir.join("packages/pkg-a")).unwrap();
     fs::create_dir_all(dir.join("packages/pkg-b")).unwrap();
@@ -1672,6 +1742,39 @@ fn test_query_affected_shorthand_with_tasks() {
         names.iter().any(|n| n.contains("my-app")),
         "my-app#build should be in affected tasks: {names:?}"
     );
+}
+
+#[test]
+fn test_query_affected_shorthand_with_root_task() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_nonsense_root_task_affected(tempdir.path());
+
+    fs::write(tempdir.path().join("flarble/wibble.ts"), "// test").unwrap();
+
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "query",
+            "affected",
+            "--tasks",
+            "//#zibble:zonk",
+            "--exit-code",
+        ],
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "root task should be affected by its inputs\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let items = json["data"]["affectedTasks"]["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1, "expected one affected root task: {json}");
+    assert_eq!(items[0]["name"], "zibble:zonk");
+    assert_eq!(items[0]["fullName"], "//#zibble:zonk");
+    assert_eq!(items[0]["package"]["name"], "//");
 }
 
 #[test]


### PR DESCRIPTION
## Why
`turbo query affected --tasks //#root-task --exit-code` can silently report no affected tasks even when the root task input files changed. That breaks CI gating for root-scoped deploy tasks. Closes #12947.

## What
This makes query affected detection include root tasks and match fully qualified task IDs such as `//#zibble:zonk`, while still preserving package/task filtering semantics.

## How
Verified with:
- `cargo test -p turbo --test affected_test test_query_affected`
- `cargo test -p turborepo-query affected_tasks`
- pre-push hooks: `turbo run format check:toml`, `cargo fmt --check`, `cargo lint`, `cargo check --workspace`