### PR TITLE
fix: Wait for Windows graceful shutdown

### DIFF
--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -122,7 +122,7 @@ impl Drop for PtyTestGuard {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum ChildExit {
     Finished(Option<i32>),
-    /// The child process was sent an interrupt and shut down on it's own
+    /// The child process exited during graceful shutdown.
     Interrupted,
     /// The child process was killed, it could either be explicitly killed or it
     /// did not respond to an interrupt and was killed as a result
@@ -136,8 +136,9 @@ pub enum ChildExit {
 
 #[derive(Debug, Clone, Copy)]
 pub enum ShutdownStyle {
-    /// On Windows this immediately kills the process. On Unix it sends SIGINT
-    /// to the process group.
+    /// On Unix this sends SIGINT to the process group. On Windows, Turbo cannot
+    /// send a signal directly, so it waits for an externally delivered console
+    /// event or for the timeout/explicit kill.
     ///
     /// `Graceful(Some(timeout))` escalates to `Kill` after `timeout` elapses.
     /// `Graceful(None)` waits indefinitely until an explicit `Kill` command
@@ -657,6 +658,7 @@ impl ChildHandle {
     #[cfg(windows)]
     async fn wait_for_job_exit(
         &mut self,
+        deadline: Option<tokio::time::Instant>,
         command_rx: &mut mpsc::Receiver<ChildCommand>,
         command_rx_open: &mut bool,
     ) -> ChildExit {
@@ -687,6 +689,15 @@ impl ChildHandle {
                         Some(ChildCommand::Shutdown(_)) => {}
                         None => *command_rx_open = false,
                     }
+                }
+                _ = async {
+                    if let Some(deadline) = deadline {
+                        tokio::time::sleep_until(deadline).await;
+                    }
+                }, if deadline.is_some() => {
+                    debug!("graceful shutdown timed out, terminating Windows process tree");
+                    self.terminate_windows_process_tree();
+                    return ChildExit::Killed;
                 }
                 _ = async {
                     if let Some(deadline) = descendant_drain_deadline {
@@ -848,12 +859,7 @@ impl ShutdownStyle {
         child: &mut ChildHandle,
         command_rx: &mut mpsc::Receiver<ChildCommand>,
     ) -> ChildExit {
-        #[cfg(windows)]
-        let _ = &command_rx;
-
         match self {
-            // Windows doesn't give the ability to send a signal to a process so we
-            // can't make use of the graceful shutdown timeout.
             #[allow(unused)]
             ShutdownStyle::Graceful(timeout) => {
                 // try ro run the command for the given timeout
@@ -954,10 +960,76 @@ impl ShutdownStyle {
 
                 #[cfg(windows)]
                 {
-                    debug!("timeout not supported on windows, killing");
-                    match child.kill().await {
-                        Ok(_) => ChildExit::Killed,
-                        Err(_) => ChildExit::Failed,
+                    // Windows consoles deliver Ctrl+C to attached child processes.
+                    // Turbo can't send a targeted signal, so graceful shutdown waits
+                    // for that external event to finish before force killing.
+                    let deadline = timeout.map(|timeout| tokio::time::Instant::now() + timeout);
+                    let mut command_rx_open = true;
+
+                    let exit = loop {
+                        match deadline {
+                            Some(deadline) => {
+                                tokio::select! {
+                                    result = child.wait() => {
+                                        break match result {
+                                            Ok(_exit_code) => ChildExit::Interrupted,
+                                            Err(_) => ChildExit::Failed,
+                                        };
+                                    }
+                                    command = command_rx.recv(), if command_rx_open => {
+                                        match command {
+                                            Some(ChildCommand::Kill) => {
+                                                debug!("graceful shutdown interrupted, killing child");
+                                                break match child.kill().await {
+                                                    Ok(_) => ChildExit::Killed,
+                                                    Err(_) => ChildExit::Failed,
+                                                };
+                                            }
+                                            Some(ChildCommand::Shutdown(_)) => {}
+                                            None => command_rx_open = false,
+                                        }
+                                    }
+                                    _ = tokio::time::sleep_until(deadline) => {
+                                        debug!("graceful shutdown timed out, killing child");
+                                        break match child.kill().await {
+                                            Ok(_) => ChildExit::Killed,
+                                            Err(_) => ChildExit::Failed,
+                                        };
+                                    }
+                                }
+                            }
+                            None => {
+                                tokio::select! {
+                                    result = child.wait() => {
+                                        break match result {
+                                            Ok(_exit_code) => ChildExit::Interrupted,
+                                            Err(_) => ChildExit::Failed,
+                                        };
+                                    }
+                                    command = command_rx.recv(), if command_rx_open => {
+                                        match command {
+                                            Some(ChildCommand::Kill) => {
+                                                debug!("graceful shutdown interrupted, killing child");
+                                                break match child.kill().await {
+                                                    Ok(_) => ChildExit::Killed,
+                                                    Err(_) => ChildExit::Failed,
+                                                };
+                                            }
+                                            Some(ChildCommand::Shutdown(_)) => {}
+                                            None => command_rx_open = false,
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    };
+
+                    if exit == ChildExit::Interrupted {
+                        child
+                            .wait_for_job_exit(deadline, command_rx, &mut command_rx_open)
+                            .await
+                    } else {
+                        exit
                     }
                 }
             }
@@ -2171,14 +2243,14 @@ mod test {
         }
     }
 
-    #[cfg(unix)]
     #[test_case(false)]
     #[test_case(TEST_PTY)]
     #[tokio::test]
     #[traced_test]
     async fn test_graceful_shutdown_waits_for_force_kill(use_pty: bool) {
-        let mut cmd = Command::new("sh");
-        cmd.args(["-c", "trap '' INT; while true; do sleep 0.2; done"]);
+        let script = find_script_dir().join_component("sleep_5_ignore.js");
+        let mut cmd = Command::new("node");
+        cmd.args([script.as_std_path()]);
         let mut child = Child::spawn(
             cmd,
             ShutdownStyle::Graceful(Some(Duration::from_secs(5))),
@@ -2186,7 +2258,15 @@ mod test {
         )
         .unwrap();
 
-        tokio::time::sleep(STARTUP_DELAY).await;
+        let mut buf = vec![0; 4];
+        match child.outputs().unwrap() {
+            ChildOutput::Std { mut stdout, .. } => {
+                stdout.read_exact(&mut buf).await.unwrap();
+            }
+            ChildOutput::Pty(mut stdout) => {
+                stdout.read_exact(&mut buf).unwrap();
+            }
+        };
 
         let mut shutdown_child = child.clone();
         let shutdown =

--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -140,12 +140,9 @@ pub enum ShutdownStyle {
     /// send a signal directly, so it waits for an externally delivered console
     /// event or an explicit kill.
     ///
-    /// On Unix, `Graceful(Some(timeout))` escalates to `Kill` after `timeout`
-    /// elapses. `Graceful(None)` waits indefinitely until an explicit `Kill`
-    /// command arrives.
-    ///
-    /// On Windows, `Graceful` waits indefinitely until the child exits or an
-    /// explicit `Kill` command arrives.
+    /// `Graceful(Some(timeout))` escalates to `Kill` after `timeout` elapses.
+    /// `Graceful(None)` waits indefinitely until an explicit `Kill` command
+    /// arrives.
     Graceful(Option<Duration>),
 
     Kill,
@@ -661,6 +658,7 @@ impl ChildHandle {
     #[cfg(windows)]
     async fn wait_for_job_exit(
         &mut self,
+        deadline: Option<tokio::time::Instant>,
         command_rx: &mut mpsc::Receiver<ChildCommand>,
         command_rx_open: &mut bool,
     ) -> ChildExit {
@@ -691,6 +689,15 @@ impl ChildHandle {
                         Some(ChildCommand::Shutdown(_)) => {}
                         None => *command_rx_open = false,
                     }
+                }
+                _ = async {
+                    if let Some(deadline) = deadline {
+                        tokio::time::sleep_until(deadline).await;
+                    }
+                }, if deadline.is_some() => {
+                    debug!("graceful shutdown timed out, terminating Windows process tree");
+                    self.terminate_windows_process_tree();
+                    return ChildExit::Killed;
                 }
                 _ = async {
                     if let Some(deadline) = descendant_drain_deadline {
@@ -954,29 +961,64 @@ impl ShutdownStyle {
                 #[cfg(windows)]
                 {
                     // Windows consoles deliver Ctrl+C to attached child processes.
-                    // Turbo can't send a targeted signal, so graceful shutdown waits
-                    // for that external event to finish until the user forces shutdown.
+                    // Turbo can't send a targeted signal, so graceful shutdown
+                    // waits for that external event when no timeout is provided.
+                    let deadline = timeout.map(|timeout| tokio::time::Instant::now() + timeout);
                     let mut command_rx_open = true;
 
                     let exit = loop {
-                        tokio::select! {
-                            result = child.wait() => {
-                                break match result {
-                                    Ok(_exit_code) => ChildExit::Interrupted,
-                                    Err(_) => ChildExit::Failed,
-                                };
-                            }
-                            command = command_rx.recv(), if command_rx_open => {
-                                match command {
-                                    Some(ChildCommand::Kill) => {
-                                        debug!("graceful shutdown interrupted, killing child");
+                        match deadline {
+                            Some(deadline) => {
+                                tokio::select! {
+                                    result = child.wait() => {
+                                        break match result {
+                                            Ok(_exit_code) => ChildExit::Interrupted,
+                                            Err(_) => ChildExit::Failed,
+                                        };
+                                    }
+                                    command = command_rx.recv(), if command_rx_open => {
+                                        match command {
+                                            Some(ChildCommand::Kill) => {
+                                                debug!("graceful shutdown interrupted, killing child");
+                                                break match child.kill().await {
+                                                    Ok(_) => ChildExit::Killed,
+                                                    Err(_) => ChildExit::Failed,
+                                                };
+                                            }
+                                            Some(ChildCommand::Shutdown(_)) => {}
+                                            None => command_rx_open = false,
+                                        }
+                                    }
+                                    _ = tokio::time::sleep_until(deadline) => {
+                                        debug!("graceful shutdown timed out, killing child");
                                         break match child.kill().await {
                                             Ok(_) => ChildExit::Killed,
                                             Err(_) => ChildExit::Failed,
                                         };
                                     }
-                                    Some(ChildCommand::Shutdown(_)) => {}
-                                    None => command_rx_open = false,
+                                }
+                            }
+                            None => {
+                                tokio::select! {
+                                    result = child.wait() => {
+                                        break match result {
+                                            Ok(_exit_code) => ChildExit::Interrupted,
+                                            Err(_) => ChildExit::Failed,
+                                        };
+                                    }
+                                    command = command_rx.recv(), if command_rx_open => {
+                                        match command {
+                                            Some(ChildCommand::Kill) => {
+                                                debug!("graceful shutdown interrupted, killing child");
+                                                break match child.kill().await {
+                                                    Ok(_) => ChildExit::Killed,
+                                                    Err(_) => ChildExit::Failed,
+                                                };
+                                            }
+                                            Some(ChildCommand::Shutdown(_)) => {}
+                                            None => command_rx_open = false,
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -984,7 +1026,7 @@ impl ShutdownStyle {
 
                     if exit == ChildExit::Interrupted {
                         child
-                            .wait_for_job_exit(command_rx, &mut command_rx_open)
+                            .wait_for_job_exit(deadline, command_rx, &mut command_rx_open)
                             .await
                     } else {
                         exit
@@ -1808,7 +1850,6 @@ mod test {
         assert_eq!(output, "stdin bytes=0\nstarted\n");
     }
 
-    #[cfg(unix)]
     #[test_case(false)]
     #[test_case(TEST_PTY)]
     #[tokio::test]
@@ -1878,9 +1919,7 @@ mod test {
         child.stop().await;
         let exit = child.wait().await;
 
-        // We should ignore the exit code of the process and always treat it as killed
         if cfg!(windows) {
-            // There are no signals on Windows so we must kill
             assert_matches!(exit, Some(ChildExit::Killed));
         } else {
             assert_matches!(exit, Some(ChildExit::Interrupted));
@@ -2131,7 +2170,6 @@ mod test {
         assert_matches!(exit, Some(ChildExit::Finished(Some(0))));
     }
 
-    #[cfg(unix)]
     #[test_case(false)]
     #[test_case(TEST_PTY)]
     #[tokio::test]
@@ -2594,7 +2632,6 @@ mod test {
         );
     }
 
-    #[cfg(unix)]
     #[test_case(false)]
     #[test_case(TEST_PTY)]
     #[tokio::test]

--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -2170,6 +2170,7 @@ mod test {
         assert_matches!(exit, Some(ChildExit::Finished(Some(0))));
     }
 
+    #[cfg(unix)]
     #[test_case(false)]
     #[test_case(TEST_PTY)]
     #[tokio::test]

--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -138,11 +138,14 @@ pub enum ChildExit {
 pub enum ShutdownStyle {
     /// On Unix this sends SIGINT to the process group. On Windows, Turbo cannot
     /// send a signal directly, so it waits for an externally delivered console
-    /// event or for the timeout/explicit kill.
+    /// event or an explicit kill.
     ///
-    /// `Graceful(Some(timeout))` escalates to `Kill` after `timeout` elapses.
-    /// `Graceful(None)` waits indefinitely until an explicit `Kill` command
-    /// arrives.
+    /// On Unix, `Graceful(Some(timeout))` escalates to `Kill` after `timeout`
+    /// elapses. `Graceful(None)` waits indefinitely until an explicit `Kill`
+    /// command arrives.
+    ///
+    /// On Windows, `Graceful` waits indefinitely until the child exits or an
+    /// explicit `Kill` command arrives.
     Graceful(Option<Duration>),
 
     Kill,
@@ -658,7 +661,6 @@ impl ChildHandle {
     #[cfg(windows)]
     async fn wait_for_job_exit(
         &mut self,
-        deadline: Option<tokio::time::Instant>,
         command_rx: &mut mpsc::Receiver<ChildCommand>,
         command_rx_open: &mut bool,
     ) -> ChildExit {
@@ -689,15 +691,6 @@ impl ChildHandle {
                         Some(ChildCommand::Shutdown(_)) => {}
                         None => *command_rx_open = false,
                     }
-                }
-                _ = async {
-                    if let Some(deadline) = deadline {
-                        tokio::time::sleep_until(deadline).await;
-                    }
-                }, if deadline.is_some() => {
-                    debug!("graceful shutdown timed out, terminating Windows process tree");
-                    self.terminate_windows_process_tree();
-                    return ChildExit::Killed;
                 }
                 _ = async {
                     if let Some(deadline) = descendant_drain_deadline {
@@ -962,63 +955,28 @@ impl ShutdownStyle {
                 {
                     // Windows consoles deliver Ctrl+C to attached child processes.
                     // Turbo can't send a targeted signal, so graceful shutdown waits
-                    // for that external event to finish before force killing.
-                    let deadline = timeout.map(|timeout| tokio::time::Instant::now() + timeout);
+                    // for that external event to finish until the user forces shutdown.
                     let mut command_rx_open = true;
 
                     let exit = loop {
-                        match deadline {
-                            Some(deadline) => {
-                                tokio::select! {
-                                    result = child.wait() => {
-                                        break match result {
-                                            Ok(_exit_code) => ChildExit::Interrupted,
-                                            Err(_) => ChildExit::Failed,
-                                        };
-                                    }
-                                    command = command_rx.recv(), if command_rx_open => {
-                                        match command {
-                                            Some(ChildCommand::Kill) => {
-                                                debug!("graceful shutdown interrupted, killing child");
-                                                break match child.kill().await {
-                                                    Ok(_) => ChildExit::Killed,
-                                                    Err(_) => ChildExit::Failed,
-                                                };
-                                            }
-                                            Some(ChildCommand::Shutdown(_)) => {}
-                                            None => command_rx_open = false,
-                                        }
-                                    }
-                                    _ = tokio::time::sleep_until(deadline) => {
-                                        debug!("graceful shutdown timed out, killing child");
+                        tokio::select! {
+                            result = child.wait() => {
+                                break match result {
+                                    Ok(_exit_code) => ChildExit::Interrupted,
+                                    Err(_) => ChildExit::Failed,
+                                };
+                            }
+                            command = command_rx.recv(), if command_rx_open => {
+                                match command {
+                                    Some(ChildCommand::Kill) => {
+                                        debug!("graceful shutdown interrupted, killing child");
                                         break match child.kill().await {
                                             Ok(_) => ChildExit::Killed,
                                             Err(_) => ChildExit::Failed,
                                         };
                                     }
-                                }
-                            }
-                            None => {
-                                tokio::select! {
-                                    result = child.wait() => {
-                                        break match result {
-                                            Ok(_exit_code) => ChildExit::Interrupted,
-                                            Err(_) => ChildExit::Failed,
-                                        };
-                                    }
-                                    command = command_rx.recv(), if command_rx_open => {
-                                        match command {
-                                            Some(ChildCommand::Kill) => {
-                                                debug!("graceful shutdown interrupted, killing child");
-                                                break match child.kill().await {
-                                                    Ok(_) => ChildExit::Killed,
-                                                    Err(_) => ChildExit::Failed,
-                                                };
-                                            }
-                                            Some(ChildCommand::Shutdown(_)) => {}
-                                            None => command_rx_open = false,
-                                        }
-                                    }
+                                    Some(ChildCommand::Shutdown(_)) => {}
+                                    None => command_rx_open = false,
                                 }
                             }
                         }
@@ -1026,7 +984,7 @@ impl ShutdownStyle {
 
                     if exit == ChildExit::Interrupted {
                         child
-                            .wait_for_job_exit(deadline, command_rx, &mut command_rx_open)
+                            .wait_for_job_exit(command_rx, &mut command_rx_open)
                             .await
                     } else {
                         exit
@@ -1850,6 +1808,7 @@ mod test {
         assert_eq!(output, "stdin bytes=0\nstarted\n");
     }
 
+    #[cfg(unix)]
     #[test_case(false)]
     #[test_case(TEST_PTY)]
     #[tokio::test]

--- a/crates/turborepo-process/src/lib.rs
+++ b/crates/turborepo-process/src/lib.rs
@@ -161,9 +161,9 @@ impl ProcessManager {
         Some(child)
     }
 
-    /// Stop the process manager, closing all child processes. On posix
-    /// systems this will send a SIGINT, and on windows it will just kill
-    /// the process immediately.
+    /// Stop the process manager, closing all child processes. On posix systems
+    /// this will send SIGINT. On Windows, Turbo waits for the child's stop
+    /// timeout before force killing because it cannot send a process signal.
     pub async fn stop(&self) {
         self.close(CloseMode::Stop).await
     }

--- a/crates/turborepo-process/src/lib.rs
+++ b/crates/turborepo-process/src/lib.rs
@@ -162,8 +162,9 @@ impl ProcessManager {
     }
 
     /// Stop the process manager, closing all child processes. On posix systems
-    /// this will send SIGINT. On Windows, Turbo waits for the child to exit
-    /// because it cannot send a process signal.
+    /// this will send SIGINT. On Windows, Turbo waits for the child stop
+    /// timeout before force killing because it cannot send a process
+    /// signal.
     pub async fn stop(&self) {
         self.close(CloseMode::Stop).await
     }

--- a/crates/turborepo-process/src/lib.rs
+++ b/crates/turborepo-process/src/lib.rs
@@ -162,8 +162,8 @@ impl ProcessManager {
     }
 
     /// Stop the process manager, closing all child processes. On posix systems
-    /// this will send SIGINT. On Windows, Turbo waits for the child's stop
-    /// timeout before force killing because it cannot send a process signal.
+    /// this will send SIGINT. On Windows, Turbo waits for the child to exit
+    /// because it cannot send a process signal.
     pub async fn stop(&self) {
         self.close(CloseMode::Stop).await
     }


### PR DESCRIPTION
## Why

Windows tasks already receive the console Ctrl+C event, but Turbo immediately killed them during graceful shutdown. This prevented dev servers from finishing cleanup and caused issue #12651.

The intended interactive behavior is to match Unix: first Ctrl+C starts graceful shutdown and waits; a second Ctrl+C forces shutdown.

Closes #12651.

## What

Allow Windows signal-triggered graceful shutdown to wait for the child process and its job object instead of force killing immediately.

This preserves the existing `Graceful` timeout distinction used by non-signal stop/restart paths: `Graceful(None)` waits until the child exits or an explicit kill command arrives, while `Graceful(Some(timeout))` can still escalate after the timeout.

## How

- Verified with `cargo test -p turborepo-process graceful_shutdown -- --nocapture`
- Verified with `cargo test -p turborepo-process`
- Verified with `cargo check -p turborepo-process --target x86_64-pc-windows-msvc`
- Manually reproduced on Windows with a dev server that exits after a 2s shutdown delay