### PR TITLE
test: Skip installs for JSON output fixtures

### DIFF
--- a/crates/turborepo/tests/common/mod.rs
+++ b/crates/turborepo/tests/common/mod.rs
@@ -351,21 +351,24 @@ pub fn setup_fixture(
     fixture: &str,
     package_manager: &str,
     test_dir: &Path,
+    install: bool,
 ) -> Result<(), anyhow::Error> {
-    setup::setup_integration_test(test_dir, fixture, package_manager, true)
+    setup::setup_integration_test(test_dir, fixture, package_manager, install)
 }
 
 /// Executes a command and snapshots the output as JSON.
 ///
 /// Takes fixture, package manager, and command, and sets of arguments.
 /// Creates a snapshot file for each set of arguments.
-/// Note that the command must return valid JSON
+/// Note that the command must return valid JSON.
+/// Defaults to skipping dependency installation; use `@install` when module
+/// resolution requires `node_modules`.
 #[macro_export]
 macro_rules! check_json_output {
-    ($fixture:expr, $package_manager:expr, $command:expr, $($name:expr => [$($query:expr),*$(,)?],)*) => {
+    (@with_install $install:expr, $fixture:expr, $package_manager:expr, $command:expr, $($name:expr => [$($query:expr),*$(,)?],)*) => {
         {
             let tempdir = tempfile::tempdir()?;
-            $crate::common::setup_fixture($fixture, $package_manager, tempdir.path())?;
+            $crate::common::setup_fixture($fixture, $package_manager, tempdir.path(), $install)?;
             $(
                 let mut command = $crate::common::turbo_command(tempdir.path());
                 command
@@ -399,5 +402,11 @@ macro_rules! check_json_output {
                 });
             )*
         }
+    };
+    (@install $fixture:expr, $package_manager:expr, $command:expr, $($name:expr => [$($query:expr),*$(,)?],)*) => {
+        $crate::check_json_output!(@with_install true, $fixture, $package_manager, $command, $($name => [$($query),*],)*)
+    };
+    ($fixture:expr, $package_manager:expr, $command:expr, $($name:expr => [$($query:expr),*$(,)?],)*) => {
+        $crate::check_json_output!(@with_install false, $fixture, $package_manager, $command, $($name => [$($query),*],)*)
     }
 }

--- a/crates/turborepo/tests/query.rs
+++ b/crates/turborepo/tests/query.rs
@@ -87,7 +87,7 @@ fn test_trace() -> Result<(), anyhow::Error> {
 #[test]
 fn test_trace_on_monorepo() -> Result<(), anyhow::Error> {
     insta::with_settings!({ filters => vec![(r"\\\\", "/")]}, {
-        check_json_output!(
+        check_json_output!(@install
             "turbo_trace_monorepo",
             "npm@10.5.0",
             "query",


### PR DESCRIPTION
## Why

Rust JSON snapshot tests should not pay for package-manager installs when they only inspect repository metadata. Skipping that setup reduces test overhead while keeping install-dependent resolution tests explicit.

## What

- Default check_json_output! fixture setup to skip dependency installation.
- Add an `@install` opt-in for JSON output tests that need node_modules.

## How

Verified with:

`- cargo nextest run -p turbo --test query --test boundaries --test ls`