### PR TITLE
test: Skip installs for single package dry runs

### DIFF
--- a/crates/turborepo/tests/dry_json.rs
+++ b/crates/turborepo/tests/dry_json.rs
@@ -175,7 +175,7 @@ fn test_monorepo_no_changes_packages() -> Result<(), anyhow::Error> {
 #[test]
 fn test_single_package_dry_json() -> Result<(), anyhow::Error> {
     let tempdir = tempfile::tempdir()?;
-    setup::setup_integration_test(tempdir.path(), "single_package", "npm@10.5.0", true)?;
+    setup::setup_integration_test(tempdir.path(), "single_package", "npm@10.5.0", false)?;
     let json = turbo_dry_json(tempdir.path(), &["run", "build", "--dry=json"])?;
 
     insta::with_settings!({ filters => vec![(r"\\\\", "/")] }, {
@@ -214,7 +214,7 @@ fn test_single_package_no_change() -> Result<(), anyhow::Error> {
 #[test]
 fn test_single_package_no_config() -> Result<(), anyhow::Error> {
     let tempdir = tempfile::tempdir()?;
-    setup::setup_integration_test(tempdir.path(), "single_package", "npm@10.5.0", true)?;
+    setup::setup_integration_test(tempdir.path(), "single_package", "npm@10.5.0", false)?;
 
     // Remove turbo.json and commit
     std::fs::remove_file(tempdir.path().join("turbo.json"))?;
@@ -246,7 +246,7 @@ fn test_single_package_no_config() -> Result<(), anyhow::Error> {
 #[test]
 fn test_single_package_with_deps() -> Result<(), anyhow::Error> {
     let tempdir = tempfile::tempdir()?;
-    setup::setup_integration_test(tempdir.path(), "single_package", "npm@10.5.0", true)?;
+    setup::setup_integration_test(tempdir.path(), "single_package", "npm@10.5.0", false)?;
     let json = turbo_dry_json(tempdir.path(), &["run", "test", "--dry=json"])?;
 
     insta::with_settings!({ filters => vec![(r"\\\\", "/")] }, {

--- a/crates/turborepo/tests/single_package_dry_run_test.rs
+++ b/crates/turborepo/tests/single_package_dry_run_test.rs
@@ -9,7 +9,7 @@ use common::{git, run_turbo, setup, turbo_output_filters};
 #[test]
 fn test_single_package_dry_run() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "single_package", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "single_package", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "build", "--dry"]);
     assert!(output.status.success());
@@ -23,7 +23,7 @@ fn test_single_package_dry_run() {
 #[test]
 fn test_single_package_dry_run_pnpm() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "single_package", "pnpm@8.0.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "single_package", "pnpm@8.0.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "build", "--dry=json"]);
     assert!(
@@ -42,7 +42,7 @@ fn test_single_package_dry_run_pnpm() {
 #[test]
 fn test_single_package_no_config_dry_run() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "single_package", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "single_package", "npm@10.5.0", false).unwrap();
 
     fs::remove_file(tempdir.path().join("turbo.json")).unwrap();
     git(
@@ -62,7 +62,7 @@ fn test_single_package_no_config_dry_run() {
 #[test]
 fn test_single_package_no_config_graph() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "single_package", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "single_package", "npm@10.5.0", false).unwrap();
 
     fs::remove_file(tempdir.path().join("turbo.json")).unwrap();
     git(
@@ -81,7 +81,7 @@ fn test_single_package_no_config_graph() {
 #[test]
 fn test_single_package_no_config_run_bypasses_cache() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "single_package", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "single_package", "npm@10.5.0", false).unwrap();
 
     fs::remove_file(tempdir.path().join("turbo.json")).unwrap();
     git(

--- a/crates/turborepo/tests/snapshots/dry_json__single_package_dry_json.snap
+++ b/crates/turborepo/tests/snapshots/dry_json__single_package_dry_json.snap
@@ -10,7 +10,6 @@ expression: json
   "globalCacheInputs": {
     "rootKey": "I can’t see ya, but I know you’re here",
     "files": {
-      "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",
       "package.json": "8606ff4b95a5330740d8d9d0948faeada64f1f32",
       "somefile.txt": "45b983be36b73c0788dc9cbcb76cbb80fc7bb057"
     },
@@ -33,10 +32,9 @@ expression: json
     {
       "taskId": "build",
       "task": "build",
-      "hash": "99180a8fe2df621b",
+      "hash": "73f6f1ec03e09249",
       "inputs": {
         ".gitignore": "03b541460c1b836f96f9c0a941ceb48e91a9fd83",
-        "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",
         "package.json": "8606ff4b95a5330740d8d9d0948faeada64f1f32",
         "somefile.txt": "45b983be36b73c0788dc9cbcb76cbb80fc7bb057",
         "turbo.json": "7c63f35ef4a45cec9b74cacb44c5f0211c50d8f5"

--- a/crates/turborepo/tests/snapshots/dry_json__single_package_no_config.snap
+++ b/crates/turborepo/tests/snapshots/dry_json__single_package_no_config.snap
@@ -10,7 +10,6 @@ expression: json
   "globalCacheInputs": {
     "rootKey": "I can’t see ya, but I know you’re here",
     "files": {
-      "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",
       "package.json": "8606ff4b95a5330740d8d9d0948faeada64f1f32"
     },
     "hashOfExternalDependencies": "",
@@ -32,10 +31,9 @@ expression: json
     {
       "taskId": "build",
       "task": "build",
-      "hash": "e2b99dad85a4ff66",
+      "hash": "070118d9dcd50bb4",
       "inputs": {
         ".gitignore": "03b541460c1b836f96f9c0a941ceb48e91a9fd83",
-        "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",
         "package.json": "8606ff4b95a5330740d8d9d0948faeada64f1f32",
         "somefile.txt": "45b983be36b73c0788dc9cbcb76cbb80fc7bb057"
       },

--- a/crates/turborepo/tests/snapshots/dry_json__single_package_with_deps.snap
+++ b/crates/turborepo/tests/snapshots/dry_json__single_package_with_deps.snap
@@ -10,7 +10,6 @@ expression: json
   "globalCacheInputs": {
     "rootKey": "I can’t see ya, but I know you’re here",
     "files": {
-      "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",
       "package.json": "8606ff4b95a5330740d8d9d0948faeada64f1f32",
       "somefile.txt": "45b983be36b73c0788dc9cbcb76cbb80fc7bb057"
     },
@@ -33,10 +32,9 @@ expression: json
     {
       "taskId": "build",
       "task": "build",
-      "hash": "99180a8fe2df621b",
+      "hash": "73f6f1ec03e09249",
       "inputs": {
         ".gitignore": "03b541460c1b836f96f9c0a941ceb48e91a9fd83",
-        "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",
         "package.json": "8606ff4b95a5330740d8d9d0948faeada64f1f32",
         "somefile.txt": "45b983be36b73c0788dc9cbcb76cbb80fc7bb057",
         "turbo.json": "7c63f35ef4a45cec9b74cacb44c5f0211c50d8f5"
@@ -90,10 +88,9 @@ expression: json
     {
       "taskId": "test",
       "task": "test",
-      "hash": "023dbfb6010ec4b4",
+      "hash": "92736e4427fabc2d",
       "inputs": {
         ".gitignore": "03b541460c1b836f96f9c0a941ceb48e91a9fd83",
-        "package-lock.json": "1c117cce37347befafe3a9cba1b8a609b3600021",
         "package.json": "8606ff4b95a5330740d8d9d0948faeada64f1f32",
         "somefile.txt": "45b983be36b73c0788dc9cbcb76cbb80fc7bb057",
         "turbo.json": "7c63f35ef4a45cec9b74cacb44c5f0211c50d8f5"

--- a/crates/turborepo/tests/snapshots/single_package_dry_run_test__single_package_dry_run.snap
+++ b/crates/turborepo/tests/snapshots/single_package_dry_run_test__single_package_dry_run.snap
@@ -7,7 +7,7 @@ expression: stdout.to_string()
 
 
 Global Hash Inputs
-  Global Files                          = 3
+  Global Files                          = 2
   External Dependencies Hash            = 
   Global Cache Key                      = I can’t see ya, but I know you’re here
   Global Env Vars                       = 
@@ -20,7 +20,7 @@ Global Hash Inputs
 Tasks to Run
 build
   Task                           = build
-  Hash                           = 99180a8fe2df621b
+  Hash                           = 73f6f1ec03e09249
   Cached (Local)                 = false
   Cached (Remote)                = false
   Command                        = echo building > foo.txt
@@ -29,7 +29,7 @@ build
   Dependencies                   = 
   Dependents                     = 
   With                           = 
-  Inputs Files Considered        = 5
+  Inputs Files Considered        = 4
   Env Vars                       = 
   Env Vars Values                = 
   Inferred Env Vars Values       = 

--- a/crates/turborepo/tests/snapshots/single_package_dry_run_test__single_package_no_config_dry_run.snap
+++ b/crates/turborepo/tests/snapshots/single_package_dry_run_test__single_package_no_config_dry_run.snap
@@ -7,7 +7,7 @@ expression: stdout.to_string()
 
 
 Global Hash Inputs
-  Global Files                          = 2
+  Global Files                          = 1
   External Dependencies Hash            = 
   Global Cache Key                      = I can’t see ya, but I know you’re here
   Global Env Vars                       = 
@@ -20,7 +20,7 @@ Global Hash Inputs
 Tasks to Run
 build
   Task                           = build
-  Hash                           = e2b99dad85a4ff66
+  Hash                           = 070118d9dcd50bb4
   Cached (Local)                 = false
   Cached (Remote)                = false
   Command                        = echo building > foo.txt
@@ -29,7 +29,7 @@ build
   Dependencies                   = 
   Dependents                     = 
   With                           = 
-  Inputs Files Considered        = 4
+  Inputs Files Considered        = 3
   Env Vars                       = 
   Env Vars Values                = 
   Inferred Env Vars Values       = 


### PR DESCRIPTION
## Why

Single-package dry-run tests do not require installed dependencies, but several still ran the full package-manager install path. Skipping installs keeps these tests focused on dry-run behavior and avoids creating incidental lockfile inputs during setup.

## What

- Switch single-package dry-run setups to install=false.
- Update snapshots to reflect the fixture state without install-generated package-lock.json inputs.

## How

Verified with:

- `cargo nextest run -p turbo --test dry_json --test single_package_dry_run_test --no-fail-fast`
- `cargo fmt -p turbo --check`