### PR TITLE
test: Skip Corepack setup without installs

### DIFF
--- a/crates/turborepo/tests/common/mod.rs
+++ b/crates/turborepo/tests/common/mod.rs
@@ -45,9 +45,8 @@ pub fn turbo_command(test_dir: &Path) -> assert_cmd::Command {
         .env("NPM_CONFIG_UPDATE_NOTIFIER", "false")
         // Corepack intercepts package manager calls (npm, yarn, pnpm) and can
         // prompt for download confirmation, which hangs in non-interactive CI.
-        // The test setup pre-warms the corepack cache via `corepack prepare`
-        // so the correct version is available locally without network access.
-        // DOWNLOAD_PROMPT=0 is a safety net in case the cache is somehow cold.
+        // Tests that need Corepack pre-warm its cache during setup. This env
+        // var is a safety net in case the cache is somehow cold.
         .env("COREPACK_ENABLE_DOWNLOAD_PROMPT", "0")
         .env_remove("CI")
         .env_remove("GITHUB_ACTIONS")

--- a/crates/turborepo/tests/common/setup.rs
+++ b/crates/turborepo/tests/common/setup.rs
@@ -118,13 +118,10 @@ pub fn setup_git(target_dir: &Path) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-/// Write the `packageManager` field into `package.json` and configure corepack.
-/// The corepack install directory is placed outside `target_dir` so corepack
-/// shims don't appear as task inputs.
+/// Write the `packageManager` field into `package.json`.
 pub fn setup_package_manager(
     target_dir: &Path,
     package_manager: &str,
-    corepack_dir: &Path,
 ) -> Result<(), anyhow::Error> {
     // Read, modify, and write package.json
     let pkg_json_path = target_dir.join("package.json");
@@ -143,9 +140,18 @@ pub fn setup_package_manager(
         &format!("Updated package manager to {package_manager}"),
     )?;
 
-    // Exercise package manager resolution through Corepack for every PM it
-    // supports, including npm. Keep Corepack state per test so parallel tests
-    // do not contend over the user's global Corepack cache/last-known-good data.
+    Ok(())
+}
+
+/// Configure Corepack for the package manager used by a fixture.
+///
+/// The install directory is placed outside `target_dir` so Corepack shims don't
+/// appear as task inputs.
+pub fn setup_corepack(
+    target_dir: &Path,
+    package_manager: &str,
+    corepack_dir: &Path,
+) -> Result<(), anyhow::Error> {
     let pm_name = package_manager.split('@').next().unwrap_or(package_manager);
     if !corepack_supports(pm_name) {
         return Ok(());
@@ -191,28 +197,8 @@ pub fn prepare_corepack_from_package_json(dir: &Path) {
         None => return,
     };
 
-    let pm_name = pm.split('@').next().unwrap_or(&pm);
-    if !corepack_supports(pm_name) {
-        return;
-    }
-
     let corepack_dir = corepack_dir_for_test_dir(dir);
-    fs::create_dir_all(&corepack_dir).expect("failed to create corepack dir");
-    let corepack_home = corepack_home();
-    fs::create_dir_all(&corepack_home).expect("failed to create corepack home");
-
-    run_corepack(
-        dir,
-        &corepack_home,
-        [
-            OsString::from("enable"),
-            OsString::from(pm_name),
-            OsString::from(format!("--install-directory={}", corepack_dir.display())),
-        ],
-    )
-    .expect("failed to enable corepack");
-
-    prepare_corepack_package_manager(dir, &corepack_home, &pm).expect("failed to prepare corepack");
+    setup_corepack(dir, &pm, &corepack_dir).expect("failed to configure corepack");
 }
 
 /// Install dependencies using the specified package manager.
@@ -288,13 +274,12 @@ pub fn setup_integration_test(
     package_manager: &str,
     install: bool,
 ) -> Result<(), anyhow::Error> {
-    let corepack_dir = corepack_dir_for_test_dir(target_dir);
-    fs::create_dir_all(&corepack_dir)?;
-
     copy_fixture(fixture, target_dir)?;
     setup_git(target_dir)?;
-    setup_package_manager(target_dir, package_manager, &corepack_dir)?;
+    setup_package_manager(target_dir, package_manager)?;
     if install {
+        let corepack_dir = corepack_dir_for_test_dir(target_dir);
+        setup_corepack(target_dir, package_manager, &corepack_dir)?;
         install_deps(target_dir, package_manager, &corepack_dir)?;
     }
     Ok(())


### PR DESCRIPTION
## Why

No-install Rust integration tests only need packageManager metadata, but the shared setup still enabled Corepack and prepared package-manager shims for every fixture. Avoiding that work reduces setup cost for metadata-only tests while preserving Corepack setup for tests that install dependencies or explicitly prepare package managers.

## What

- Split packageManager writes from Corepack setup.
- Run Corepack enable/prepare only when setup installs dependencies.
- Keep `prepare_corepack_from_package_json` as the explicit escape hatch for fixtures that need package-manager shims without a full install.