### PR TITLE
test: Skip installs for metadata-only Rust tests

### DIFF
--- a/crates/turborepo/tests/absolute_path_error_test.rs
+++ b/crates/turborepo/tests/absolute_path_error_test.rs
@@ -31,7 +31,7 @@ fn global_deps_config() -> &'static str {
 #[test]
 fn test_absolute_path_in_inputs() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
     replace_turbo_json(tempdir.path(), inputs_config());
 
     let output = run_turbo(tempdir.path(), &["build"]);
@@ -51,7 +51,7 @@ fn test_absolute_path_in_inputs() {
 #[test]
 fn test_absolute_path_in_outputs() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
     replace_turbo_json(tempdir.path(), outputs_config());
 
     let output = run_turbo(tempdir.path(), &["build"]);
@@ -71,7 +71,7 @@ fn test_absolute_path_in_outputs() {
 #[test]
 fn test_absolute_path_in_global_deps() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
     replace_turbo_json(tempdir.path(), global_deps_config());
 
     let output = run_turbo(tempdir.path(), &["build"]);

--- a/crates/turborepo/tests/allow_no_root_turbo_test.rs
+++ b/crates/turborepo/tests/allow_no_root_turbo_test.rs
@@ -7,8 +7,13 @@ use common::{run_turbo, run_turbo_with_env, setup};
 #[test]
 fn test_fails_without_turbo_json() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "monorepo_no_turbo_json", "npm@10.5.0", true)
-        .unwrap();
+    setup::setup_integration_test(
+        tempdir.path(),
+        "monorepo_no_turbo_json",
+        "npm@10.5.0",
+        false,
+    )
+    .unwrap();
 
     let output = run_turbo(tempdir.path(), &["test"]);
     assert!(!output.status.success());
@@ -22,8 +27,13 @@ fn test_fails_without_turbo_json() {
 #[test]
 fn test_allow_no_turbo_json_flag_runs_tasks() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "monorepo_no_turbo_json", "npm@10.5.0", true)
-        .unwrap();
+    setup::setup_integration_test(
+        tempdir.path(),
+        "monorepo_no_turbo_json",
+        "npm@10.5.0",
+        false,
+    )
+    .unwrap();
 
     let output = run_turbo_with_env(
         tempdir.path(),
@@ -42,8 +52,13 @@ fn test_allow_no_turbo_json_flag_runs_tasks() {
 #[test]
 fn test_allow_no_turbo_json_caching_disabled() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "monorepo_no_turbo_json", "npm@10.5.0", true)
-        .unwrap();
+    setup::setup_integration_test(
+        tempdir.path(),
+        "monorepo_no_turbo_json",
+        "npm@10.5.0",
+        false,
+    )
+    .unwrap();
 
     // First run
     run_turbo_with_env(
@@ -69,8 +84,13 @@ fn test_allow_no_turbo_json_caching_disabled() {
 #[test]
 fn test_allow_no_turbo_json_env_var_discovers_tasks() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "monorepo_no_turbo_json", "npm@10.5.0", true)
-        .unwrap();
+    setup::setup_integration_test(
+        tempdir.path(),
+        "monorepo_no_turbo_json",
+        "npm@10.5.0",
+        false,
+    )
+    .unwrap();
 
     let output = run_turbo_with_env(
         tempdir.path(),

--- a/crates/turborepo/tests/bad_turbo_json_test.rs
+++ b/crates/turborepo/tests/bad_turbo_json_test.rs
@@ -7,7 +7,7 @@ use common::{replace_turbo_json, run_turbo, setup};
 #[test]
 fn test_package_task_syntax_in_workspace_config() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let app_dir = tempdir.path().join("apps/my-app");
     replace_turbo_json(&app_dir, "package-task.json");
@@ -24,7 +24,7 @@ fn test_package_task_syntax_in_workspace_config() {
 #[test]
 fn test_invalid_env_var_prefix() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
     replace_turbo_json(tempdir.path(), "invalid-env-var.json");
 
     let output = run_turbo(tempdir.path(), &["build"]);
@@ -43,7 +43,7 @@ fn test_invalid_env_var_prefix() {
 #[test]
 fn test_package_task_in_single_package_mode() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
     replace_turbo_json(tempdir.path(), "invalid-env-var.json");
 
     let output = run_turbo(tempdir.path(), &["build", "--single-package"]);
@@ -58,7 +58,7 @@ fn test_package_task_in_single_package_mode() {
 #[test]
 fn test_interruptible_but_not_persistent() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
     replace_turbo_json(tempdir.path(), "interruptible-but-not-persistent.json");
 
     let output = run_turbo(tempdir.path(), &["run", "build"]);
@@ -73,7 +73,7 @@ fn test_interruptible_but_not_persistent() {
 #[test]
 fn test_syntax_error_in_turbo_json() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
     replace_turbo_json(tempdir.path(), "syntax-error.json");
 
     let output = run_turbo(tempdir.path(), &["build"]);

--- a/crates/turborepo/tests/big_status_test.rs
+++ b/crates/turborepo/tests/big_status_test.rs
@@ -9,7 +9,7 @@ use common::{run_turbo, setup};
 #[test]
 fn test_large_git_status_with_spaces() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let util_dir = tempdir.path().join("packages/util");
     for i in 1..=100 {

--- a/crates/turborepo/tests/command_query_test.rs
+++ b/crates/turborepo/tests/command_query_test.rs
@@ -9,7 +9,7 @@ use common::{run_turbo, setup};
 #[test]
 fn test_query_from_file() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     fs::write(
         tempdir.path().join("query.gql"),
@@ -36,7 +36,7 @@ fn test_query_from_file() {
 #[test]
 fn test_query_inline() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["query", "query { version }"]);
     assert!(output.status.success());

--- a/crates/turborepo/tests/dry_run_test.rs
+++ b/crates/turborepo/tests/dry_run_test.rs
@@ -7,7 +7,7 @@ use common::{git, run_turbo, run_turbo_with_env, setup};
 #[test]
 fn test_dry_run_packages_in_scope() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "build", "--dry"]);
     assert!(output.status.success());
@@ -22,7 +22,7 @@ fn test_dry_run_packages_in_scope() {
 #[test]
 fn test_dry_run_global_hash_inputs() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "build", "--dry"]);
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -35,7 +35,7 @@ fn test_dry_run_global_hash_inputs() {
 #[test]
 fn test_dry_run_task_details() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "build", "--dry"]);
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -53,7 +53,7 @@ fn test_dry_run_task_details() {
 #[test]
 fn test_dry_run_env_var_not_in_output() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     // Set NODE_ENV and verify it doesn't leak into the output as "Environment
     // Variables"
@@ -76,7 +76,7 @@ fn test_dry_run_cache_hit_after_real_run() {
     // Regression test for https://github.com/vercel/turborepo/issues/9044
     // After a real run populates the cache, --dry=json should report HIT.
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     // First: real run to populate cache
     let output = run_turbo(tempdir.path(), &["run", "build"]);
@@ -110,7 +110,7 @@ fn test_dry_run_respects_cache_false() {
     // When a task has cache:false, --dry=json should report MISS,
     // matching what a normal run would do (cache bypass).
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     // Replace turbo.json with a config that disables caching for build
     std::fs::write(

--- a/crates/turborepo/tests/edit_turbo_json.rs
+++ b/crates/turborepo/tests/edit_turbo_json.rs
@@ -65,7 +65,7 @@ fn global_cache_inputs(dir: &Path) -> String {
 #[test]
 fn test_global_hash_changes() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     // Baseline
     replace_turbo_json(tempdir.path(), "1-baseline.json");
@@ -115,7 +115,7 @@ fn test_global_hash_changes() {
 #[test]
 fn test_task_hash_changes() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     replace_turbo_json(tempdir.path(), "a-baseline.json");
     insta::assert_snapshot!("task_hashes_baseline", task_hash_snapshot(tempdir.path()));

--- a/crates/turborepo/tests/experimental_otel_test.rs
+++ b/crates/turborepo/tests/experimental_otel_test.rs
@@ -7,7 +7,7 @@ use std::fs;
 use common::{run_turbo_with_env, setup};
 
 fn setup_otel_fixture(dir: &std::path::Path) {
-    setup::setup_integration_test(dir, "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(dir, "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     // Enable experimentalObservability by inserting futureFlags after the opening
     // brace

--- a/crates/turborepo/tests/filter_run_test.rs
+++ b/crates/turborepo/tests/filter_run_test.rs
@@ -11,7 +11,7 @@ use common::{git, run_turbo, setup};
 /// triggers recursion detection. This replaces it with a simple echo so we
 /// can test root task scoping via `--dry=json` without side effects.
 fn setup_root_task_fixture(dir: &Path) {
-    setup::setup_integration_test(dir, "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(dir, "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let pkg_json = r#"{
   "name": "monorepo",
@@ -32,7 +32,7 @@ fn setup_root_task_fixture(dir: &Path) {
 #[test]
 fn test_filter_git_range_no_changes() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "build", "--filter=[main]"]);
     assert!(output.status.success());
@@ -43,7 +43,7 @@ fn test_filter_git_range_no_changes() {
 #[test]
 fn test_filter_git_range_with_unstaged() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     fs::write(tempdir.path().join("bar.txt"), "new file contents\n").unwrap();
 
@@ -56,7 +56,7 @@ fn test_filter_git_range_with_unstaged() {
 #[test]
 fn test_filter_git_range_committed_change() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let foo_path = tempdir.path().join("foo.txt");
     let mut contents = fs::read_to_string(&foo_path).unwrap_or_default();
@@ -82,7 +82,7 @@ fn test_filter_git_range_committed_change() {
 #[test]
 fn test_filter_git_range_two_dot_committed_change() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let foo_path = tempdir.path().join("foo.txt");
     let mut contents = fs::read_to_string(&foo_path).unwrap_or_default();
@@ -114,7 +114,7 @@ fn test_filter_git_range_two_dot_committed_change() {
 #[test]
 fn test_filter_nonexistent_package_errors() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(
         tempdir.path(),

--- a/crates/turborepo/tests/force_test.rs
+++ b/crates/turborepo/tests/force_test.rs
@@ -5,7 +5,7 @@ mod common;
 use common::{run_turbo, run_turbo_with_env, setup};
 
 fn setup_and_prime_cache(dir: &std::path::Path) {
-    setup::setup_integration_test(dir, "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(dir, "basic_monorepo", "npm@10.5.0", false).unwrap();
     // Baseline run to populate the cache
     let output = run_turbo(
         dir,

--- a/crates/turborepo/tests/globs_test.rs
+++ b/crates/turborepo/tests/globs_test.rs
@@ -9,7 +9,7 @@ use common::{run_turbo, setup};
 #[test]
 fn test_input_directory_glob_causes_cache_miss() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "dir_globs", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "dir_globs", "npm@10.5.0", false).unwrap();
 
     // First build: cache miss
     let output1 = run_turbo(

--- a/crates/turborepo/tests/graph_test.rs
+++ b/crates/turborepo/tests/graph_test.rs
@@ -8,7 +8,7 @@ use common::{combined_output, run_turbo, setup, turbo_output_filters};
 use serde_json::json;
 
 fn setup_topological(dir: &std::path::Path) {
-    setup::setup_integration_test(dir, "task_dependencies/topological", "npm@10.5.0", true)
+    setup::setup_integration_test(dir, "task_dependencies/topological", "npm@10.5.0", false)
         .unwrap();
 }
 

--- a/crates/turborepo/tests/infer_pkg_test.rs
+++ b/crates/turborepo/tests/infer_pkg_test.rs
@@ -20,7 +20,7 @@ fn get_packages(output: &std::process::Output) -> Vec<String> {
 #[test]
 fn test_all_packages() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["build", "--dry=json"]);
     assert!(output.status.success());
@@ -30,7 +30,7 @@ fn test_all_packages() {
 #[test]
 fn test_glob_filter_packages_dir() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -43,7 +43,7 @@ fn test_glob_filter_packages_dir() {
 #[test]
 fn test_name_glob_filter() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["build", "--dry=json", "-F", "*-app"]);
     assert!(output.status.success());
@@ -53,7 +53,7 @@ fn test_name_glob_filter() {
 #[test]
 fn test_infer_from_packages_subdir() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     // Run from packages/ with a relative filter
     let packages_dir = tempdir.path().join("packages");
@@ -65,7 +65,7 @@ fn test_infer_from_packages_subdir() {
 #[test]
 fn test_filter_sibling_directory() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let packages_dir = tempdir.path().join("packages");
     let output = run_turbo(&packages_dir, &["build", "--dry=json", "-F", "../apps/*"]);
@@ -76,7 +76,7 @@ fn test_filter_sibling_directory() {
 #[test]
 fn test_infer_from_package_dir() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     // Run from packages/util — should infer util as the package
     let util_dir = tempdir.path().join("packages/util");
@@ -88,7 +88,7 @@ fn test_infer_from_package_dir() {
 #[test]
 fn test_cwd_overrides_inference() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let util_dir = tempdir.path().join("packages/util");
     let output = run_turbo(&util_dir, &["build", "--cwd=../..", "--dry=json"]);
@@ -100,7 +100,7 @@ fn test_cwd_overrides_inference() {
 #[test]
 fn test_glob_filter_from_package_dir() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let util_dir = tempdir.path().join("packages/util");
     let output = run_turbo(&util_dir, &["build", "--dry=json", "-F", "../*"]);
@@ -111,7 +111,7 @@ fn test_glob_filter_from_package_dir() {
 #[test]
 fn test_name_glob_from_package_dir() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let util_dir = tempdir.path().join("packages/util");
     let output = run_turbo(&util_dir, &["build", "--dry=json", "-F", "*nother"]);

--- a/crates/turborepo/tests/jsonc_test.rs
+++ b/crates/turborepo/tests/jsonc_test.rs
@@ -32,7 +32,7 @@ fn basic_with_extends_json() -> std::path::PathBuf {
 #[test]
 fn test_both_json_and_jsonc_in_root_is_error() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     fs::copy(
         tempdir.path().join("turbo.json"),
@@ -54,7 +54,7 @@ fn test_both_json_and_jsonc_in_root_is_error() {
 #[test]
 fn test_turbo_jsonc_only_in_root() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     fs::rename(
         tempdir.path().join("turbo.json"),
@@ -73,7 +73,7 @@ fn test_turbo_jsonc_only_in_root() {
 #[test]
 fn test_root_json_package_jsonc() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     fs::copy(
         basic_with_extends_json(),
@@ -92,7 +92,7 @@ fn test_root_json_package_jsonc() {
 #[test]
 fn test_root_jsonc_package_json() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     fs::rename(
         tempdir.path().join("turbo.json"),
@@ -117,7 +117,7 @@ fn test_root_jsonc_package_json() {
 #[test]
 fn test_both_json_and_jsonc_in_package_is_error() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let app_dir = tempdir.path().join("apps/my-app");
     fs::copy(basic_with_extends_json(), app_dir.join("turbo.json")).unwrap();

--- a/crates/turborepo/tests/missing_tasks_test.rs
+++ b/crates/turborepo/tests/missing_tasks_test.rs
@@ -7,7 +7,7 @@ use common::{run_turbo, setup};
 #[test]
 fn test_single_missing_task() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "doesnotexist"]);
     assert!(!output.status.success());
@@ -21,7 +21,7 @@ fn test_single_missing_task() {
 #[test]
 fn test_multiple_missing_tasks() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "doesnotexist", "alsono"]);
     assert!(!output.status.success());
@@ -39,7 +39,7 @@ fn test_multiple_missing_tasks() {
 #[test]
 fn test_one_good_one_bad_task() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "build", "doesnotexist"]);
     assert!(!output.status.success());
@@ -55,7 +55,7 @@ fn test_one_good_one_bad_task() {
 #[test]
 fn test_no_recursive_turbo_warning_for_missing_task() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "something", "--dry"]);
     let combined = format!(

--- a/crates/turborepo/tests/no_args_test.rs
+++ b/crates/turborepo/tests/no_args_test.rs
@@ -7,7 +7,7 @@ use common::{run_turbo, run_turbo_with_env, setup, turbo_output_filters};
 #[test]
 fn test_no_args_prints_help() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &[]);
     assert!(!output.status.success());
@@ -23,7 +23,7 @@ fn test_no_args_prints_help() {
 #[test]
 fn test_run_no_tasks_shows_potential_tasks() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["run"]);
     assert!(!output.status.success());
@@ -37,7 +37,7 @@ fn test_run_no_tasks_shows_potential_tasks() {
 #[test]
 fn test_run_no_tasks_with_filter() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "--filter", "my-app"]);
     assert!(!output.status.success());
@@ -51,7 +51,7 @@ fn test_run_no_tasks_with_filter() {
 #[test]
 fn test_watch_no_tasks_shows_potential_tasks() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["watch"]);
     assert!(!output.status.success());
@@ -65,7 +65,7 @@ fn test_watch_no_tasks_shows_potential_tasks() {
 #[test]
 fn test_env_var_for_run_does_not_change_no_args() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo_with_env(tempdir.path(), &[], &[("TURBO_LOG_ORDER", "stream")]);
     assert!(!output.status.success());
@@ -81,7 +81,8 @@ fn test_env_var_for_run_does_not_change_no_args() {
 #[test]
 fn test_composable_config_run_no_tasks() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     let output = run_turbo(tempdir.path(), &["run"]);
     assert!(!output.status.success());
@@ -95,7 +96,8 @@ fn test_composable_config_run_no_tasks() {
 #[test]
 fn test_composable_config_watch_no_tasks() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     let output = run_turbo(tempdir.path(), &["watch"]);
     assert!(!output.status.success());

--- a/crates/turborepo/tests/no_root_turbo_test.rs
+++ b/crates/turborepo/tests/no_root_turbo_test.rs
@@ -9,7 +9,7 @@ use common::{run_turbo, run_turbo_with_env, setup};
 #[test]
 fn test_fails_without_turbo_json() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     // Rename turbo.json so it can't be found
     fs::rename(
@@ -30,7 +30,7 @@ fn test_fails_without_turbo_json() {
 #[test]
 fn test_root_turbo_json_flag() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     fs::rename(
         tempdir.path().join("turbo.json"),
@@ -57,7 +57,7 @@ fn test_root_turbo_json_flag() {
 #[test]
 fn test_root_turbo_json_env_var_with_cache_hit() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     fs::rename(
         tempdir.path().join("turbo.json"),

--- a/crates/turborepo/tests/path_with_spaces_test.rs
+++ b/crates/turborepo/tests/path_with_spaces_test.rs
@@ -9,7 +9,7 @@ use common::{run_turbo, setup};
 #[test]
 fn test_files_with_spaces_can_be_hashed() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     // Create a file with spaces in the name
     fs::write(

--- a/crates/turborepo/tests/pkg_inference_test.rs
+++ b/crates/turborepo/tests/pkg_inference_test.rs
@@ -10,7 +10,7 @@ use common::{run_turbo, setup};
 #[test]
 fn test_package_inference_from_subdirectory() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let util_dir = tempdir.path().join("packages/util");
     let output = run_turbo(&util_dir, &["build"]);

--- a/crates/turborepo/tests/pkg_task_entry_test.rs
+++ b/crates/turborepo/tests/pkg_task_entry_test.rs
@@ -5,7 +5,7 @@ mod common;
 use common::{combined_output, run_turbo, setup};
 
 fn setup_fixture(dir: &std::path::Path) {
-    setup::setup_integration_test(dir, "pkg_task_entry", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(dir, "pkg_task_entry", "npm@10.5.0", false).unwrap();
 }
 
 fn dry_run_tasks(dir: &std::path::Path, args: &[&str]) -> Vec<String> {

--- a/crates/turborepo/tests/profile_test.rs
+++ b/crates/turborepo/tests/profile_test.rs
@@ -8,7 +8,7 @@ use common::{run_turbo, setup};
 
 fn setup_and_run(args: &[&str]) -> (tempfile::TempDir, std::process::Output) {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
     let output = run_turbo(tempdir.path(), args);
     assert!(output.status.success());
     (tempdir, output)
@@ -103,7 +103,7 @@ fn test_anon_profile_default_filename() {
 #[test]
 fn test_profile_no_tasks_generates_markdown() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
     let output = run_turbo(tempdir.path(), &["run", "--profile=no-tasks.trace"]);
     assert_eq!(output.status.code(), Some(1));
 

--- a/crates/turborepo/tests/run_logging.rs
+++ b/crates/turborepo/tests/run_logging.rs
@@ -10,7 +10,7 @@ use common::{run_turbo, run_turbo_with_env, setup, turbo_output_filters};
 #[test]
 fn test_log_order_stream_flag() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "ordered", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "ordered", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -24,7 +24,7 @@ fn test_log_order_stream_flag() {
 #[test]
 fn test_log_order_stream_env_var() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "ordered", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "ordered", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo_with_env(
         tempdir.path(),
@@ -38,7 +38,7 @@ fn test_log_order_stream_env_var() {
 #[test]
 fn test_log_order_stream_flag_wins_over_env() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "ordered", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "ordered", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo_with_env(
         tempdir.path(),
@@ -55,7 +55,7 @@ fn test_log_order_stream_flag_wins_over_env() {
 #[test]
 fn test_log_order_grouped_flag() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "ordered", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "ordered", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -70,7 +70,7 @@ fn test_log_order_grouped_flag() {
 #[test]
 fn test_log_order_grouped_env_var() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "ordered", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "ordered", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo_with_env(
         tempdir.path(),
@@ -86,7 +86,7 @@ fn test_log_order_grouped_env_var() {
 #[test]
 fn test_log_order_grouped_flag_wins_over_env() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "ordered", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "ordered", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo_with_env(
         tempdir.path(),
@@ -105,7 +105,7 @@ fn test_log_order_grouped_flag_wins_over_env() {
 #[test]
 fn test_log_order_github_actions() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "ordered", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "ordered", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo_with_env(
         tempdir.path(),
@@ -123,7 +123,7 @@ fn test_log_order_github_actions() {
 #[test]
 fn test_log_order_github_actions_with_task_prefix() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "ordered", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "ordered", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo_with_env(
         tempdir.path(),
@@ -146,7 +146,7 @@ fn test_log_order_github_actions_with_task_prefix() {
 #[test]
 fn test_log_order_github_actions_error() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "ordered", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "ordered", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo_with_env(tempdir.path(), &["run", "fail"], &[("GITHUB_ACTIONS", "1")]);
 
@@ -162,7 +162,7 @@ fn test_log_order_github_actions_error() {
 #[test]
 fn test_log_prefix_none_cache_miss() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "build", "--log-prefix=none"]);
     assert!(output.status.success());
@@ -176,7 +176,7 @@ fn test_log_prefix_none_cache_miss() {
 #[test]
 fn test_log_prefix_none_cached_log_file() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", false).unwrap();
 
     // First run to populate cache
     run_turbo(tempdir.path(), &["run", "build", "--log-prefix=none"]);
@@ -190,7 +190,7 @@ fn test_log_prefix_none_cached_log_file() {
 #[test]
 fn test_log_prefix_none_cache_hit() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", false).unwrap();
 
     // First run
     run_turbo(tempdir.path(), &["run", "build", "--log-prefix=none"]);
@@ -206,7 +206,7 @@ fn test_log_prefix_none_cache_hit() {
 #[test]
 fn test_log_prefix_default_shows_prefixes() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", false).unwrap();
 
     // Warm cache
     run_turbo(tempdir.path(), &["run", "build", "--log-prefix=none"]);
@@ -221,7 +221,7 @@ fn test_log_prefix_default_shows_prefixes() {
 #[test]
 fn test_log_prefix_bogus_value() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "build", "--log-prefix=blah"]);
     assert!(!output.status.success());
@@ -232,7 +232,7 @@ fn test_log_prefix_bogus_value() {
 #[test]
 fn test_log_prefix_missing_value() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "build", "--log-prefix"]);
     assert!(!output.status.success());
@@ -245,7 +245,7 @@ fn test_log_prefix_missing_value() {
 #[test]
 fn test_verbosity_v_flag() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["build", "-v", "--filter=util", "--force"]);
     assert!(output.status.success());
@@ -257,7 +257,7 @@ fn test_verbosity_v_flag() {
 #[test]
 fn test_verbosity_1_flag() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -271,7 +271,7 @@ fn test_verbosity_1_flag() {
 #[test]
 fn test_verbosity_vv_has_debug() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -288,7 +288,7 @@ fn test_verbosity_vv_has_debug() {
 #[test]
 fn test_verbosity_2_has_debug() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -305,7 +305,7 @@ fn test_verbosity_2_has_debug() {
 #[test]
 fn test_verbosity_v_and_verbosity_conflict() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["build", "-v", "--verbosity=1"]);
     assert!(!output.status.success());
@@ -318,7 +318,7 @@ fn test_verbosity_v_and_verbosity_conflict() {
 #[test]
 fn test_no_cache_and_no_output_logs() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -341,7 +341,7 @@ fn test_no_cache_and_no_output_logs() {
 #[test]
 fn test_errors_only_flag_success() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -357,7 +357,7 @@ fn test_errors_only_flag_success() {
 #[test]
 fn test_errors_only_turbo_json_success() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", false).unwrap();
 
     // buildsuccess has outputLogs: "errors-only" in turbo.json
     let output = run_turbo(tempdir.path(), &["run", "buildsuccess"]);
@@ -370,7 +370,7 @@ fn test_errors_only_turbo_json_success() {
 #[test]
 fn test_errors_only_flag_error() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -386,7 +386,7 @@ fn test_errors_only_flag_error() {
 #[test]
 fn test_errors_only_turbo_json_error() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", false).unwrap();
 
     // builderror2 has outputLogs: "errors-only" in turbo.json
     let output = run_turbo(tempdir.path(), &["run", "builderror2"]);
@@ -401,7 +401,7 @@ fn test_errors_only_turbo_json_error() {
 #[test]
 fn test_errors_only_no_cache_success() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", false).unwrap();
 
     // nocachebuild has cache:false in turbo.json
     let output = run_turbo(
@@ -418,7 +418,7 @@ fn test_errors_only_no_cache_success() {
 #[test]
 fn test_errors_only_no_cache_error() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", false).unwrap();
 
     // nocachebuilderror has cache:false in turbo.json and exits 1
     let output = run_turbo(
@@ -441,7 +441,7 @@ fn test_errors_only_show_hash_cache_miss() {
         tempdir.path(),
         "run_logging_errors_only_show_hash",
         "npm@10.5.0",
-        true,
+        false,
     )
     .unwrap();
 
@@ -462,7 +462,7 @@ fn test_errors_only_show_hash_cache_hit() {
         tempdir.path(),
         "run_logging_errors_only_show_hash",
         "npm@10.5.0",
-        true,
+        false,
     )
     .unwrap();
 
@@ -489,7 +489,7 @@ fn test_errors_only_show_hash_error_shows_full_logs() {
         tempdir.path(),
         "run_logging_errors_only_show_hash",
         "npm@10.5.0",
-        true,
+        false,
     )
     .unwrap();
 
@@ -505,7 +505,7 @@ fn test_errors_only_show_hash_error_shows_full_logs() {
 #[test]
 fn test_full_cache_hit_output() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     // Warm cache
     run_turbo(tempdir.path(), &["run", "build", "--output-logs=none"]);
@@ -548,7 +548,7 @@ fn test_full_cache_hit_output() {
 #[test]
 fn test_prelude_appears_in_stream_mode() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "build", "--output-logs=none"]);
     assert!(output.status.success());
@@ -575,7 +575,7 @@ fn test_prelude_absent_from_graph_stdout() {
         tempdir.path(),
         "task_dependencies/topological",
         "npm@10.5.0",
-        true,
+        false,
     )
     .unwrap();
 
@@ -623,7 +623,7 @@ fn test_prelude_absent_from_dry_json_stdout() {
 #[test]
 fn test_prelude_appears_in_dry_text_mode() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "build", "--dry"]);
     assert!(output.status.success());
@@ -642,7 +642,7 @@ fn test_prelude_appears_in_dry_text_mode() {
 #[test]
 fn test_prelude_single_package_format() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "single_package", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "single_package", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "build", "--output-logs=none"]);
     assert!(output.status.success());
@@ -661,7 +661,7 @@ fn test_prelude_single_package_format() {
 #[test]
 fn test_github_actions_error_annotation_on_stderr() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "ordered", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "ordered", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo_with_env(tempdir.path(), &["run", "fail"], &[("GITHUB_ACTIONS", "1")]);
 

--- a/crates/turborepo/tests/single_package_graph_test.rs
+++ b/crates/turborepo/tests/single_package_graph_test.rs
@@ -9,7 +9,7 @@ use common::{run_turbo, setup};
 #[test]
 fn test_single_package_graph_to_stdout() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "single_package", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "single_package", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "build", "--graph"]);
     assert!(output.status.success());
@@ -22,7 +22,7 @@ fn test_single_package_graph_to_stdout() {
 #[test]
 fn test_single_package_graph_to_dot_file() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "single_package", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "single_package", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["build", "--graph=graph.dot"]);
     assert!(output.status.success());
@@ -34,7 +34,7 @@ fn test_single_package_graph_to_dot_file() {
 #[test]
 fn test_single_package_with_deps_graph() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "single_package", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "single_package", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "test", "--graph"]);
     assert!(output.status.success());

--- a/crates/turborepo/tests/snapshots/run_logging__log_order_grouped_env_var.snap
+++ b/crates/turborepo/tests/snapshots/run_logging__log_order_grouped_env_var.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/turborepo/tests/run_logging.rs
-assertion_line: 80
 expression: stdout.to_string()
 ---
    • Packages in scope: my-app, util

--- a/crates/turborepo/tests/snapshots/run_logging__log_order_grouped_flag.snap
+++ b/crates/turborepo/tests/snapshots/run_logging__log_order_grouped_flag.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/turborepo/tests/run_logging.rs
-assertion_line: 64
 expression: stdout.to_string()
 ---
    • Packages in scope: my-app, util

--- a/crates/turborepo/tests/snapshots/run_logging__log_order_grouped_flag_wins.snap
+++ b/crates/turborepo/tests/snapshots/run_logging__log_order_grouped_flag_wins.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/turborepo/tests/run_logging.rs
-assertion_line: 96
 expression: stdout.to_string()
 ---
    • Packages in scope: my-app, util

--- a/crates/turborepo/tests/snapshots/unnamed_packages_test__unnamed_packages_build.snap
+++ b/crates/turborepo/tests/snapshots/unnamed_packages_test__unnamed_packages_build.snap
@@ -6,7 +6,7 @@ expression: stdout.to_string()
    • Running build in 2 packages
    • Remote caching disabled
 
-my-app:build: cache miss, executing 997bd49b625fad50
+my-app:build: cache miss, executing 6fa89b5c9a7d4158
 my-app:build: 
 my-app:build: > build
 my-app:build: > echo building

--- a/crates/turborepo/tests/structured_logging.rs
+++ b/crates/turborepo/tests/structured_logging.rs
@@ -9,7 +9,7 @@ use common::{run_turbo, setup};
 #[test]
 fn log_file_produces_valid_json() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", false).unwrap();
 
     let log_path = tempdir.path().join("structured.json");
     let output = run_turbo(
@@ -54,7 +54,7 @@ fn log_file_produces_valid_json() {
 #[test]
 fn json_flag_produces_ndjson() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "build", "--force", "--json"]);
 
@@ -79,7 +79,7 @@ fn json_flag_produces_ndjson() {
 #[test]
 fn structured_log_strips_ansi() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", false).unwrap();
 
     let log_path = tempdir.path().join("ansi_test.json");
     let output = run_turbo(
@@ -110,7 +110,7 @@ fn structured_log_strips_ansi() {
 #[test]
 fn log_file_rejects_path_traversal() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", false).unwrap();
 
     // Attempt to write outside the repo root.
     let output = run_turbo(

--- a/crates/turborepo/tests/unnamed_packages_test.rs
+++ b/crates/turborepo/tests/unnamed_packages_test.rs
@@ -7,7 +7,7 @@ use common::{run_turbo, setup, turbo_output_filters};
 #[test]
 fn test_unnamed_packages_are_filtered() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "nested_packages", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "nested_packages", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["build"]);
     assert!(output.status.success());

--- a/crates/turborepo/tests/workspace_config_deps_test.rs
+++ b/crates/turborepo/tests/workspace_config_deps_test.rs
@@ -10,7 +10,8 @@ use common::{run_turbo, setup};
 #[test]
 fn test_missing_workspace_config_deps_retained() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -42,7 +43,8 @@ fn test_missing_workspace_config_deps_retained() {
 #[test]
 fn test_omit_keys_deps_retained() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -67,7 +69,8 @@ fn test_omit_keys_deps_retained() {
 #[test]
 fn test_override_values_deps_empty() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -90,7 +93,8 @@ fn test_override_values_deps_empty() {
 #[test]
 fn test_override_values_deps_resolved_definition() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -124,7 +128,8 @@ fn test_override_values_deps_resolved_definition() {
 #[test]
 fn test_override_values_deps_2_topo_only() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -160,7 +165,8 @@ fn test_override_values_deps_2_topo_only() {
 #[test]
 fn test_cross_workspace_dependency() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -178,7 +184,8 @@ fn test_cross_workspace_dependency() {
 #[test]
 fn test_cross_workspace_task_id_syntax() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     // Prime cache
     run_turbo(

--- a/crates/turborepo/tests/workspace_config_inheritance_test.rs
+++ b/crates/turborepo/tests/workspace_config_inheritance_test.rs
@@ -12,7 +12,8 @@ use common::{run_turbo, run_turbo_with_env, setup};
 #[test]
 fn test_missing_workspace_config_outputs_cached() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     // First run: cache miss
     let output = run_turbo(
@@ -47,7 +48,8 @@ fn test_missing_workspace_config_outputs_cached() {
 #[test]
 fn test_missing_workspace_config_inputs_cause_cache_miss() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     // Prime cache
     run_turbo(
@@ -85,7 +87,8 @@ fn test_missing_workspace_config_inputs_cause_cache_miss() {
 #[test]
 fn test_missing_workspace_config_non_input_no_cache_miss() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     // Prime cache (two runs to get past initial miss + input change)
     run_turbo(
@@ -123,7 +126,8 @@ fn test_missing_workspace_config_non_input_no_cache_miss() {
 #[test]
 fn test_missing_workspace_config_env_causes_cache_miss() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     // Prime cache
     run_turbo(
@@ -154,7 +158,8 @@ fn test_missing_workspace_config_env_causes_cache_miss() {
 #[test]
 fn test_missing_workspace_config_cache_false_not_cached() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -173,7 +178,8 @@ fn test_missing_workspace_config_cache_false_not_cached() {
 #[test]
 fn test_omit_keys_outputs_cached() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -198,7 +204,8 @@ fn test_omit_keys_outputs_cached() {
 #[test]
 fn test_omit_keys_inputs_cause_cache_miss() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     run_turbo(
         tempdir.path(),
@@ -224,7 +231,8 @@ fn test_omit_keys_inputs_cause_cache_miss() {
 #[test]
 fn test_omit_keys_non_input_no_cache_miss() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     run_turbo(
         tempdir.path(),
@@ -250,7 +258,8 @@ fn test_omit_keys_non_input_no_cache_miss() {
 #[test]
 fn test_omit_keys_env_causes_cache_miss() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     run_turbo(
         tempdir.path(),

--- a/crates/turborepo/tests/workspace_config_override_test.rs
+++ b/crates/turborepo/tests/workspace_config_override_test.rs
@@ -12,7 +12,8 @@ use common::{run_turbo, run_turbo_with_env, setup};
 #[test]
 fn test_override_values_outputs() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -42,7 +43,8 @@ fn test_override_values_outputs() {
 #[test]
 fn test_override_values_inputs() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     run_turbo(
         tempdir.path(),
@@ -68,7 +70,8 @@ fn test_override_values_inputs() {
 #[test]
 fn test_override_values_root_input_no_miss() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     run_turbo(
         tempdir.path(),
@@ -96,7 +99,8 @@ fn test_override_values_root_input_no_miss() {
 #[test]
 fn test_override_values_env() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     run_turbo(
         tempdir.path(),
@@ -121,7 +125,8 @@ fn test_override_values_env() {
 #[test]
 fn test_add_keys_deps_and_outputs() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -140,7 +145,8 @@ fn test_add_keys_deps_and_outputs() {
 #[test]
 fn test_add_keys_cache_and_output_logs() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     // Prime cache
     run_turbo(
@@ -168,7 +174,8 @@ fn test_add_keys_cache_and_output_logs() {
 #[test]
 fn test_add_keys_input_change() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     run_turbo(
         tempdir.path(),
@@ -194,7 +201,8 @@ fn test_add_keys_input_change() {
 #[test]
 fn test_add_keys_env_change() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     run_turbo(
         tempdir.path(),
@@ -218,7 +226,8 @@ fn test_add_keys_env_change() {
 #[test]
 fn test_add_tasks() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "added-task", "--filter=add-tasks"]);
     assert!(output.status.success());

--- a/crates/turborepo/tests/workspace_config_special_test.rs
+++ b/crates/turborepo/tests/workspace_config_special_test.rs
@@ -11,7 +11,8 @@ use common::{run_turbo, setup};
 #[test]
 fn test_persistent_inherited_from_root_blocks_parent() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     // persistent-task-1 is persistent:true in root, not overridden in workspace
     let output = run_turbo(
@@ -29,7 +30,8 @@ fn test_persistent_inherited_from_root_blocks_parent() {
 #[test]
 fn test_persistent_overridden_to_false() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     // persistent-task-2 is overridden to persistent:false in workspace
     let output = run_turbo(
@@ -44,7 +46,8 @@ fn test_persistent_overridden_to_false() {
 #[test]
 fn test_persistent_workspace_omits_flag_inherits_true() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     // persistent-task-3 is persistent:true in root, workspace defines task but
     // doesn't touch persistent
@@ -63,7 +66,8 @@ fn test_persistent_workspace_omits_flag_inherits_true() {
 #[test]
 fn test_persistent_added_in_workspace() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     // persistent-task-4 has no persistent in root, workspace adds persistent:true
     let output = run_turbo(
@@ -83,7 +87,8 @@ fn test_persistent_added_in_workspace() {
 #[test]
 fn test_cache_false_in_root_override_true_in_workspace() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "cached-task-1", "--filter=cached"]);
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -97,7 +102,8 @@ fn test_cache_false_in_root_override_true_in_workspace() {
 #[test]
 fn test_cache_true_in_root_override_false_in_workspace() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "cached-task-2", "--filter=cached"]);
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -110,7 +116,8 @@ fn test_cache_true_in_root_override_false_in_workspace() {
 #[test]
 fn test_no_cache_in_root_false_in_workspace() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "cached-task-3", "--filter=cached"]);
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -125,7 +132,8 @@ fn test_no_cache_in_root_false_in_workspace() {
 #[test]
 fn test_config_change_causes_hash_change() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     // Get initial hash
     let output1 = run_turbo(
@@ -180,7 +188,7 @@ fn test_config_change_causes_hash_change() {
 #[test]
 fn test_task_extends_build_inherited() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "task_extends", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "task_extends", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -194,7 +202,7 @@ fn test_task_extends_build_inherited() {
 #[test]
 fn test_task_extends_test_inherited() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "task_extends", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "task_extends", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -208,7 +216,7 @@ fn test_task_extends_test_inherited() {
 #[test]
 fn test_task_extends_false_excludes_task() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "task_extends", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "task_extends", "npm@10.5.0", false).unwrap();
 
     // lint has extends: false, so it should be excluded
     let output = run_turbo(
@@ -228,7 +236,8 @@ fn test_task_extends_false_excludes_task() {
 #[test]
 fn test_invalid_config_errors() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "build", "--filter=invalid-config"]);
     assert!(!output.status.success());
@@ -251,7 +260,8 @@ fn test_invalid_config_errors() {
 #[test]
 fn test_invalid_config_errors_on_valid_task_too() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     // Even running a valid task in the package should error
     let output = run_turbo(
@@ -276,7 +286,8 @@ fn test_invalid_config_errors_on_valid_task_too() {
 #[test]
 fn test_bad_json_errors() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
+        .unwrap();
 
     // Write malformed JSON
     fs::write(

--- a/turborepo-tests/integration/fixtures/ordered/package-lock.json
+++ b/turborepo-tests/integration/fixtures/ordered/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "monorepo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "monorepo",
+      "workspaces": [
+        "apps/**",
+        "packages/**"
+      ]
+    },
+    "apps/my-app": {
+      "dependencies": {
+        "util": "*"
+      }
+    },
+    "node_modules/my-app": {
+      "resolved": "apps/my-app",
+      "link": true
+    },
+    "node_modules/util": {
+      "resolved": "packages/util",
+      "link": true
+    },
+    "packages/util": {}
+  }
+}


### PR DESCRIPTION
## Why

Many Rust integration tests only inspect CLI output, config resolution, dry-run plans, or graph/error behavior, but still ran full dependency installation during fixture setup. Skipping installs keeps those tests focused on the behavior under test and reduces wall-clock time.

## What

- Switch metadata-only Rust integration tests to install=false.
- Add a committed ordered fixture lockfile so grouped log-order snapshots keep stable package graph hashes without running install.
- Update snapshots affected by removing incidental install-generated lockfile inputs.

## How

Verified with `cargo nextest run` over a bunch of the changed crates/tests/etc.

Focused run_logging wall-clock comparison after warm compile:

- Before: average 14.85s over 3 runs
- After: average 11.19s over 3 runs
- Delta: about 3.7s faster, roughly 25% faster