### PR TITLE
test: Skip remaining unnecessary fixture installs

### DIFF
--- a/crates/turborepo/tests/affected_rdeps_test.rs
+++ b/crates/turborepo/tests/affected_rdeps_test.rs
@@ -9,7 +9,7 @@ use common::{git, run_turbo, setup};
 #[test]
 fn test_affected_includes_reverse_deps() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     git(tempdir.path(), &["checkout", "-b", "my-branch"]);
 

--- a/crates/turborepo/tests/affected_test.rs
+++ b/crates/turborepo/tests/affected_test.rs
@@ -7,7 +7,7 @@ use std::{fs, path::Path};
 use common::{git, run_turbo, run_turbo_with_env, setup, turbo_output_filters};
 
 fn setup_affected(dir: &std::path::Path) {
-    setup::setup_integration_test(dir, "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(dir, "basic_monorepo", "npm@10.5.0", false).unwrap();
     git(dir, &["checkout", "-b", "my-branch"]);
 }
 
@@ -615,7 +615,7 @@ fn test_affected_tasks_file_change() {
 fn test_affected_tasks_input_exclusion() {
     let tempdir = tempfile::tempdir().unwrap();
     // Use a special fixture that has task input exclusions
-    setup::setup_integration_test(tempdir.path(), "affected_tasks_inputs", "npm@10.5.0", true)
+    setup::setup_integration_test(tempdir.path(), "affected_tasks_inputs", "npm@10.5.0", false)
         .unwrap();
     git(tempdir.path(), &["checkout", "-b", "my-branch"]);
 
@@ -693,7 +693,7 @@ fn test_affected_tasks_global_dep_change() {
 }
 
 fn setup_affected_tasks_fixture(dir: &std::path::Path) {
-    setup::setup_integration_test(dir, "affected_tasks_inputs", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(dir, "affected_tasks_inputs", "npm@10.5.0", false).unwrap();
     git(dir, &["checkout", "-b", "my-branch"]);
 }
 
@@ -1174,7 +1174,7 @@ const TURBO_JSON_WITH_TASK_INPUTS_FLAG: &str = r#"{
 /// Sets up the `affected_tasks_inputs` fixture with the
 /// `affectedUsingTaskInputs` future flag enabled.
 fn setup_task_level_affected(dir: &Path) {
-    setup::setup_integration_test(dir, "affected_tasks_inputs", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(dir, "affected_tasks_inputs", "npm@10.5.0", false).unwrap();
     // Enable the future flag before branching so it's on main.
     fs::write(dir.join("turbo.json"), TURBO_JSON_WITH_TASK_INPUTS_FLAG).unwrap();
     git(dir, &["add", "."]);
@@ -1479,7 +1479,7 @@ fn test_task_level_affected_turbo_root_input() {
     let tempdir = tempfile::tempdir().unwrap();
     let dir = tempdir.path();
 
-    setup::setup_integration_test(dir, "affected_tasks_inputs", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(dir, "affected_tasks_inputs", "npm@10.5.0", false).unwrap();
 
     // Create a root-level config file that tasks will reference.
     fs::write(dir.join("rootconfig.txt"), "v1").unwrap();
@@ -1555,7 +1555,7 @@ fn test_task_level_affected_different_turbo_root_inputs_are_isolated() {
     let tempdir = tempfile::tempdir().unwrap();
     let dir = tempdir.path();
 
-    setup::setup_integration_test(dir, "affected_tasks_inputs", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(dir, "affected_tasks_inputs", "npm@10.5.0", false).unwrap();
 
     // Create two distinct root-level config files.
     fs::write(dir.join("build-config.txt"), "v1").unwrap();

--- a/crates/turborepo/tests/daemon_test.rs
+++ b/crates/turborepo/tests/daemon_test.rs
@@ -31,7 +31,7 @@ fn run_daemon_status(dir: &std::path::Path, env_val: &str, extra_args: &[&str]) 
 #[test]
 fn test_log_verbosity_debug() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_daemon_status(tempdir.path(), "debug", &[]);
     assert!(output.contains("[DEBUG]"), "expected [DEBUG] in output");
@@ -44,7 +44,7 @@ fn test_log_verbosity_debug() {
 #[test]
 fn test_v_flag_overrides_global_log_verbosity() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_daemon_status(tempdir.path(), "debug", &["-v"]);
     assert!(
@@ -60,7 +60,7 @@ fn test_v_flag_overrides_global_log_verbosity() {
 #[test]
 fn test_package_specific_verbosity_preserved_with_v_flag() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_daemon_status(tempdir.path(), "turborepo_daemon=debug", &["-v"]);
     assert!(

--- a/crates/turborepo/tests/gitignored_inputs_test.rs
+++ b/crates/turborepo/tests/gitignored_inputs_test.rs
@@ -9,7 +9,7 @@ use common::{git, replace_turbo_json, run_turbo, setup};
 #[test]
 fn test_gitignored_file_in_explicit_inputs() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
     replace_turbo_json(tempdir.path(), "gitignored-inputs.json");
 
     fs::write(

--- a/crates/turborepo/tests/global_deps_test.rs
+++ b/crates/turborepo/tests/global_deps_test.rs
@@ -9,7 +9,7 @@ use common::{run_turbo, setup};
 #[test]
 fn test_global_deps_change_causes_cache_miss() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "global_deps", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "global_deps", "npm@10.5.0", false).unwrap();
 
     // First build: cache miss
     let output1 = run_turbo(

--- a/crates/turborepo/tests/global_env_test.rs
+++ b/crates/turborepo/tests/global_env_test.rs
@@ -5,7 +5,7 @@ mod common;
 use common::{run_turbo, run_turbo_with_env, setup};
 
 fn setup_basic(dir: &std::path::Path) {
-    setup::setup_integration_test(dir, "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(dir, "basic_monorepo", "npm@10.5.0", false).unwrap();
 }
 
 #[test]

--- a/crates/turborepo/tests/global_inputs_test.rs
+++ b/crates/turborepo/tests/global_inputs_test.rs
@@ -44,7 +44,7 @@ const TURBO_JSON_GLOBAL_INPUTS_TOPO: &str = r#"{
 "#;
 
 fn setup_fixture(dir: &std::path::Path, turbo_json: &str) {
-    setup::setup_integration_test(dir, "global_inputs", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(dir, "global_inputs", "npm@10.5.0", false).unwrap();
     fs::write(dir.join("turbo.json"), turbo_json).unwrap();
     git(dir, &["add", "."]);
     git(dir, &["commit", "-m", "set turbo config", "--quiet"]);

--- a/crates/turborepo/tests/interactive_test.rs
+++ b/crates/turborepo/tests/interactive_test.rs
@@ -7,7 +7,7 @@ use common::{replace_turbo_json, run_turbo, setup};
 #[test]
 fn test_interactive_cacheable_task_errors() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
     replace_turbo_json(tempdir.path(), "interactive.json");
 
     let output = run_turbo(tempdir.path(), &["build"]);

--- a/crates/turborepo/tests/recursive_turbo_test.rs
+++ b/crates/turborepo/tests/recursive_turbo_test.rs
@@ -7,7 +7,7 @@ use common::{combined_output, run_turbo, setup};
 #[test]
 fn test_recursive_turbo_invocation_detected() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["something"]);
     let combined = combined_output(&output);

--- a/crates/turborepo/tests/run_summary.rs
+++ b/crates/turborepo/tests/run_summary.rs
@@ -45,7 +45,7 @@ fn get_task(summary: &serde_json::Value, task_id: &str) -> serde_json::Value {
 #[test]
 fn test_run_summary_discovery() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
     let _ = fs::remove_dir_all(tempdir.path().join(".turbo/runs"));
 
     let output = run_turbo(
@@ -63,7 +63,7 @@ fn test_run_summary_discovery() {
 #[test]
 fn test_run_summary_enable_matrix() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     struct Case {
         env_val: Option<&'static str>,
@@ -173,7 +173,7 @@ fn test_run_summary_enable_matrix() {
 #[test]
 fn test_run_summary_sorting_deps() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "with-pkg-deps", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "with-pkg-deps", "npm@10.5.0", false).unwrap();
     let _ = fs::remove_dir_all(tempdir.path().join(".turbo/runs"));
 
     // Need a fresh commit for the filter to work
@@ -203,7 +203,7 @@ fn test_run_summary_sorting_deps() {
 #[test]
 fn test_run_summary_single_package() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "single_package", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "single_package", "npm@10.5.0", false).unwrap();
 
     run_turbo(tempdir.path(), &["run", "build", "--summarize"]);
 
@@ -279,7 +279,7 @@ fn test_run_summary_single_package() {
 #[test]
 fn test_run_summary_monorepo() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
     let _ = fs::remove_dir_all(tempdir.path().join(".turbo/runs"));
 
     // First run (cache miss)
@@ -348,7 +348,7 @@ fn test_run_summary_monorepo() {
 #[test]
 fn test_run_summary_error() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
     let _ = fs::remove_dir_all(tempdir.path().join(".turbo/runs"));
 
     // Run failing task with summarize

--- a/crates/turborepo/tests/single_package_run_test.rs
+++ b/crates/turborepo/tests/single_package_run_test.rs
@@ -7,7 +7,7 @@ use common::{run_turbo, setup};
 #[test]
 fn test_single_package_build_npm() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "single_package", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "single_package", "npm@10.5.0", false).unwrap();
 
     // First run: cache miss
     let output = run_turbo(tempdir.path(), &["run", "build"]);
@@ -34,7 +34,7 @@ fn test_single_package_build_npm() {
 #[test]
 fn test_single_package_build_yarn() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "single_package", "yarn@1.22.17", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "single_package", "yarn@1.22.17", false).unwrap();
 
     // First run: cache miss
     let output = run_turbo(tempdir.path(), &["run", "build"]);

--- a/crates/turborepo/tests/turbo_trace_test.rs
+++ b/crates/turborepo/tests/turbo_trace_test.rs
@@ -31,7 +31,7 @@ fn file_paths(json: &serde_json::Value) -> Vec<String> {
 #[test]
 fn test_file_path_query() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "turbo_trace", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "turbo_trace", "npm@10.5.0", false).unwrap();
 
     let json = query(
         tempdir.path(),
@@ -43,7 +43,7 @@ fn test_file_path_query() {
 #[test]
 fn test_file_dependencies() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "turbo_trace", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "turbo_trace", "npm@10.5.0", false).unwrap();
 
     let json = query(
         tempdir.path(),
@@ -66,7 +66,7 @@ fn test_file_dependencies() {
 #[test]
 fn test_button_dependencies() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "turbo_trace", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "turbo_trace", "npm@10.5.0", false).unwrap();
 
     let json = query(
         tempdir.path(),
@@ -79,7 +79,7 @@ fn test_button_dependencies() {
 #[test]
 fn test_circular_dependencies() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "turbo_trace", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "turbo_trace", "npm@10.5.0", false).unwrap();
 
     let json = query(
         tempdir.path(),
@@ -92,7 +92,7 @@ fn test_circular_dependencies() {
 #[test]
 fn test_invalid_import_reports_error() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "turbo_trace", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "turbo_trace", "npm@10.5.0", false).unwrap();
 
     let json = query(
         tempdir.path(),
@@ -115,7 +115,7 @@ fn test_invalid_import_reports_error() {
 #[test]
 fn test_ast_query() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "turbo_trace", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "turbo_trace", "npm@10.5.0", false).unwrap();
 
     let json = query(
         tempdir.path(),
@@ -134,7 +134,7 @@ fn test_ast_query() {
 #[test]
 fn test_require_dependencies() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "turbo_trace", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "turbo_trace", "npm@10.5.0", false).unwrap();
 
     let json = query(
         tempdir.path(),
@@ -147,7 +147,7 @@ fn test_require_dependencies() {
 #[test]
 fn test_dependencies_with_depth() {
     let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "turbo_trace", "npm@10.5.0", true).unwrap();
+    setup::setup_integration_test(tempdir.path(), "turbo_trace", "npm@10.5.0", false).unwrap();
 
     let json = query(
         tempdir.path(),


### PR DESCRIPTION
## Why

After previous fixture setup cleanups, several integration tests could still skip dependency installation without changing snapshots or behavior. Removing these installs continues reducing Rust integration test setup cost while leaving hash-sensitive suites install-backed.

## What

- Switch additional integration tests from install=true to install=false where verified safe.
- Leave install-backed tests in place for suites that produced snapshot/hash changes: passthrough args, single-package dependency dry-run, and run caching.

## How

Verified with:

- cargo nextest run -p turbo --test passthrough_args_test --test affected_rdeps_test --test daemon_test --test interactive_test --test recursive_turbo_test --test single_package_run_test --no-fail-fast
- cargo nextest run -p turbo --test run_summary --test single_package_with_deps_test --test global_env_test --no-fail-fast
- cargo nextest run -p turbo --test run_caching --test global_deps_test --test global_inputs_test --test gitignored_inputs_test --test turbo_trace_test --test affected_test --no-fail-fast
- cargo nextest run -p turbo --test run_summary --test daemon_test --test single_package_run_test --test gitignored_inputs_test --test recursive_turbo_test --test global_deps_test --test global_env_test --test global_inputs_test --test affected_rdeps_test --test interactive_test --no-fail-fast
- cargo nextest run -p turbo --test turbo_trace_test --test affected_test --no-fail-fast
- cargo fmt -p turbo --check