### PR TITLE
test: Narrow Windows integration test group

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -5,22 +5,23 @@
 failure-output = "immediate-final"
 
 [test-groups]
-windows-turbo-integration = { max-threads = 4 }
-windows-scm = { max-threads = 1 }
+windows-turbo-subprocess-heavy = { max-threads = 2 }
+windows-scm = { max-threads = 2 }
 
 [[profile.default.overrides]]
-# Windows runners can fail subprocess-heavy `turbo` integration tests under
-# high nextest fanout. Keep full coverage, but cap the binary integration test
-# fanout so tests that spawn git/turbo child processes do not stampede process
-# startup.
-filter = 'package(turbo)'
+# Windows runners can fail subprocess-heavy `turbo` integration tests under high
+# nextest fanout. Keep full coverage, but cap the integration files that create
+# many git repos, run package managers, or spawn child `turbo` processes so they
+# do not stampede process startup while the rest of the package still runs at
+# normal concurrency.
+filter = 'package(turbo) and (binary(run_summary) or binary(workspace_config_deps_test) or binary(lockfile_aware_caching_test) or binary(one_script_error_test) or binary(inference_test))'
 platform = 'cfg(windows)'
-test-group = 'windows-turbo-integration'
+test-group = 'windows-turbo-subprocess-heavy'
 
 [[profile.default.overrides]]
 # Windows runners sporadically fail to start many turborepo-scm test processes
-# at once with DLL initialization error 0xc0000142. Keep full coverage, but run
-# this crate serially on Windows so process startup has breathing room.
+# at once with DLL initialization error 0xc0000142. Keep full coverage, but cap
+# this crate's Windows fanout so process startup has breathing room.
 filter = 'package(turborepo-scm)'
 platform = 'cfg(windows)'
 test-group = 'windows-scm'


### PR DESCRIPTION
## Why
The previous Windows mitigation capped all `turbo` integration tests, which stabilized process-heavy tests but made the Windows Rust job much slower. We only need to cap the files that showed subprocess/resource failures.

## What
Narrows the Windows `turbo` integration test group from the whole `turbo` package to `run_summary` and `workspace_config_deps_test`. Keeps the existing serialized `turborepo-scm` Windows group.

## How
Uses a targeted nextest filter for the subprocess-heavy test binaries while allowing the rest of `package(turbo)` to run at normal concurrency.

Verification:
- `cargo nextest show-config test-groups --package turbo --test run_summary`
- `cargo nextest show-config test-groups --package turbo --test workspace_config_deps_test`
- `cargo nextest list -p turbo --test run_summary -E 'binary(run_summary)'`\n- `cargo nextest list -p turbo --test workspace_config_deps_test -E 'binary(workspace_config_deps_test)'`\n- pre-push hooks ran on push