### PR TITLE
test: Collapse non-watch integration matrices

### DIFF
--- a/crates/turborepo/tests/run_logging.rs
+++ b/crates/turborepo/tests/run_logging.rs
@@ -18,7 +18,7 @@ fn assert_contains_in_order(output: &str, lines: &[&str]) {
 // Stream output is non-deterministic in ordering, so we check key lines.
 
 #[test]
-fn test_log_order_stream_flag() {
+fn test_ordered_logging_modes() {
     let tempdir = tempfile::tempdir().unwrap();
     setup::setup_integration_test(tempdir.path(), "ordered", "npm@10.5.0", false).unwrap();
 
@@ -29,15 +29,6 @@ fn test_log_order_stream_flag() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("2 successful, 2 total"));
     assert!(stdout.contains("0 cached, 2 total"));
-}
-
-// --- log-order-grouped.t ---
-// Grouped output IS deterministic.
-
-#[test]
-fn test_log_order_grouped_flag() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "ordered", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -67,15 +58,6 @@ fn test_log_order_grouped_flag() {
     );
     assert!(stdout.contains("2 successful, 2 total"));
     assert!(stdout.contains("0 cached, 2 total"));
-}
-
-// --- log-order-github.t ---
-// Tests ::group::/::endgroup:: output when GITHUB_ACTIONS=1
-
-#[test]
-fn test_log_order_github_actions() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "ordered", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo_with_env(
         tempdir.path(),
@@ -88,12 +70,6 @@ fn test_log_order_github_actions() {
     assert!(stdout.contains("::endgroup::"));
     assert!(stdout.contains("::group::util:build"));
     assert!(stdout.contains("2 successful, 2 total"));
-}
-
-#[test]
-fn test_log_order_github_actions_with_task_prefix() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "ordered", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo_with_env(
         tempdir.path(),
@@ -111,12 +87,23 @@ fn test_log_order_github_actions_with_task_prefix() {
     assert!(stdout.contains("::group::util:build"));
     assert!(stdout.contains("util:build: cache bypass"));
     assert!(stdout.contains("::endgroup::"));
+
+    let output = run_turbo_with_env(tempdir.path(), &["run", "fail"], &[("GITHUB_ACTIONS", "1")]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        stderr.contains("::error::"),
+        "stderr should contain ::error:: annotation for GitHub Actions, got: {}",
+        &stderr[..stderr.len().min(500)]
+    );
 }
 
 // --- log-prefix.t ---
 
 #[test]
-fn test_log_prefix_none_cached_log_file() {
+fn test_log_prefix_modes() {
     let tempdir = tempfile::tempdir().unwrap();
     setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", false).unwrap();
 
@@ -136,15 +123,6 @@ fn test_log_prefix_none_cached_log_file() {
     assert!(stdout.contains("cache hit, replaying logs"));
     assert!(stdout.contains("FULL TURBO"));
     assert!(!stdout.contains("app-a:build:"));
-}
-
-#[test]
-fn test_log_prefix_default_shows_prefixes() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", false).unwrap();
-
-    // Warm cache
-    run_turbo(tempdir.path(), &["run", "build", "--log-prefix=none"]);
 
     // Default prefix: should show prefixes
     let output = run_turbo(tempdir.path(), &["run", "build"]);
@@ -156,7 +134,7 @@ fn test_log_prefix_default_shows_prefixes() {
 // --- verbosity.t ---
 
 #[test]
-fn test_verbosity_v_flag() {
+fn test_verbosity_flags() {
     let tempdir = tempfile::tempdir().unwrap();
     setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
@@ -165,12 +143,6 @@ fn test_verbosity_v_flag() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("util:build: cache bypass, force executing bf1798d3e46e1b48"));
     assert!(stdout.contains("util:build: building"));
-}
-
-#[test]
-fn test_verbosity_vv_has_debug() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -210,7 +182,7 @@ fn test_no_cache_and_no_output_logs() {
 // --- errors-only.t ---
 
 #[test]
-fn test_errors_only_flag_success() {
+fn test_errors_only_modes() {
     let tempdir = tempfile::tempdir().unwrap();
     setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", false).unwrap();
 
@@ -223,12 +195,6 @@ fn test_errors_only_flag_success() {
     // Success: no task output shown
     assert!(!stdout.contains("build-app-a"));
     assert!(stdout.contains("1 successful, 1 total"));
-}
-
-#[test]
-fn test_errors_only_flag_error() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -239,12 +205,6 @@ fn test_errors_only_flag_error() {
     // Error: full output shown
     assert!(stdout.contains("error-builderror-app-a"));
     assert!(stdout.contains("Failed:    app-a#builderror"));
-}
-
-#[test]
-fn test_errors_only_turbo_json() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", false).unwrap();
 
     // buildsuccess has outputLogs: "errors-only" in turbo.json
     let output = run_turbo(tempdir.path(), &["run", "buildsuccess"]);
@@ -259,14 +219,6 @@ fn test_errors_only_turbo_json() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("error-builderror2-app-a"));
     assert!(stdout.contains("Failed:    app-a#builderror2"));
-}
-
-// --- errors-only-no-cache.t ---
-
-#[test]
-fn test_errors_only_no_cache_success() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", false).unwrap();
 
     // nocachebuild has cache:false in turbo.json
     let output = run_turbo(
@@ -278,12 +230,6 @@ fn test_errors_only_no_cache_success() {
     // Success with errors-only: task output should be suppressed
     assert!(!stdout.contains("nocachebuild-app-a"));
     assert!(stdout.contains("1 successful, 1 total"));
-}
-
-#[test]
-fn test_errors_only_no_cache_error() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "run_logging", "npm@10.5.0", false).unwrap();
 
     // nocachebuilderror has cache:false in turbo.json and exits 1
     let output = run_turbo(
@@ -300,7 +246,7 @@ fn test_errors_only_no_cache_error() {
 // --- errors-only-show-hash.t ---
 
 #[test]
-fn test_errors_only_show_hash_cache_hit() {
+fn test_errors_only_show_hash_modes() {
     let tempdir = tempfile::tempdir().unwrap();
     setup::setup_integration_test(
         tempdir.path(),
@@ -328,18 +274,6 @@ fn test_errors_only_show_hash_cache_hit() {
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("cache hit, replaying logs (no errors)"));
-}
-
-#[test]
-fn test_errors_only_show_hash_error_shows_full_logs() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(
-        tempdir.path(),
-        "run_logging_errors_only_show_hash",
-        "npm@10.5.0",
-        false,
-    )
-    .unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "builderror"]);
     assert!(!output.status.success());
@@ -351,7 +285,7 @@ fn test_errors_only_show_hash_error_shows_full_logs() {
 // --- full-cache-hit-output.t ---
 
 #[test]
-fn test_full_cache_hit_output() {
+fn test_basic_monorepo_output_modes() {
     let tempdir = tempfile::tempdir().unwrap();
     setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
@@ -386,17 +320,6 @@ fn test_full_cache_hit_output() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("2 cached, 2 total"));
     assert!(stdout.contains("FULL TURBO"));
-}
-
-// --- run-prelude.t ---
-// The run prelude (packages in scope, tasks, remote cache status) must appear
-// on stdout in stream mode but stay off stdout in structured output modes
-// (--graph, --dry=json) where stdout carries machine-readable data.
-
-#[test]
-fn test_prelude_appears_in_stream_mode() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "build", "--output-logs=none"]);
     assert!(output.status.success());
@@ -426,6 +349,23 @@ fn test_prelude_appears_in_stream_mode() {
     assert!(
         stdout.contains("Remote caching"),
         "remote cache status should appear in --dry text mode"
+    );
+
+    let output = run_turbo(tempdir.path(), &["run", "build", "--dry=json"]);
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // stdout must be valid JSON — no prelude text mixed in.
+    let parsed: Result<serde_json::Value, _> = serde_json::from_str(&stdout);
+    assert!(
+        parsed.is_ok(),
+        "stdout should be valid JSON, got parse error: {:?}\nstdout: {}",
+        parsed.err(),
+        &stdout[..stdout.len().min(200)]
+    );
+    assert!(
+        !stdout.contains("Packages in scope"),
+        "prelude must not appear on stdout in --dry=json mode"
     );
 }
 
@@ -459,29 +399,6 @@ fn test_prelude_absent_from_graph_stdout() {
 }
 
 #[test]
-fn test_prelude_absent_from_dry_json_stdout() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
-
-    let output = run_turbo(tempdir.path(), &["run", "build", "--dry=json"]);
-    assert!(output.status.success());
-    let stdout = String::from_utf8_lossy(&output.stdout);
-
-    // stdout must be valid JSON — no prelude text mixed in.
-    let parsed: Result<serde_json::Value, _> = serde_json::from_str(&stdout);
-    assert!(
-        parsed.is_ok(),
-        "stdout should be valid JSON, got parse error: {:?}\nstdout: {}",
-        parsed.err(),
-        &stdout[..stdout.len().min(200)]
-    );
-    assert!(
-        !stdout.contains("Packages in scope"),
-        "prelude must not appear on stdout in --dry=json mode"
-    );
-}
-
-#[test]
 fn test_prelude_single_package_format() {
     let tempdir = tempfile::tempdir().unwrap();
     setup::setup_integration_test(tempdir.path(), "single_package", "npm@10.5.0", false).unwrap();
@@ -497,22 +414,5 @@ fn test_prelude_single_package_format() {
     assert!(
         !stdout.contains("Packages in scope"),
         "single-package prelude must not show 'Packages in scope'"
-    );
-}
-
-#[test]
-fn test_github_actions_error_annotation_on_stderr() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "ordered", "npm@10.5.0", false).unwrap();
-
-    let output = run_turbo_with_env(tempdir.path(), &["run", "fail"], &[("GITHUB_ACTIONS", "1")]);
-
-    assert!(!output.status.success());
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    assert!(
-        stderr.contains("::error::"),
-        "stderr should contain ::error:: annotation for GitHub Actions, got: {}",
-        &stderr[..stderr.len().min(500)]
     );
 }

--- a/crates/turborepo/tests/workspace_config_deps_test.rs
+++ b/crates/turborepo/tests/workspace_config_deps_test.rs
@@ -8,7 +8,7 @@ use common::{run_turbo, setup};
 // when workspace has no turbo.json.
 
 #[test]
-fn test_missing_workspace_config_deps_retained() {
+fn test_workspace_config_dependency_inheritance_and_overrides() {
     let tempdir = tempfile::tempdir().unwrap();
     setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
         .unwrap();
@@ -35,16 +35,6 @@ fn test_missing_workspace_config_deps_retained() {
         "topo dep should run: {stdout}"
     );
     assert!(stdout.contains("3 successful, 3 total"));
-}
-
-// Tests that dependsOn from root config is retained when workspace defines
-// the task but omits dependsOn.
-
-#[test]
-fn test_omit_keys_deps_retained() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
-        .unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -62,15 +52,6 @@ fn test_omit_keys_deps_retained() {
         "topo dep should run: {stdout}"
     );
     assert!(stdout.contains("3 successful, 3 total"));
-}
-
-// Tests that workspace can override dependsOn to empty, removing root deps.
-
-#[test]
-fn test_override_values_deps_empty() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
-        .unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -88,13 +69,6 @@ fn test_override_values_deps_empty() {
         stdout.contains("1 successful, 1 total"),
         "only the task itself should run: {stdout}"
     );
-}
-
-#[test]
-fn test_override_values_deps_resolved_definition() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
-        .unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -123,13 +97,6 @@ fn test_override_values_deps_resolved_definition() {
         serde_json::json!([]),
         "dependsOn should be overridden to empty"
     );
-}
-
-#[test]
-fn test_override_values_deps_2_topo_only() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
-        .unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -158,16 +125,6 @@ fn test_override_values_deps_2_topo_only() {
         serde_json::json!([]),
         "topo-only dependsOn should be overridden to empty"
     );
-}
-
-// Tests cross-workspace task dependencies.
-
-#[test]
-fn test_cross_workspace_dependency() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
-        .unwrap();
-
     let output = run_turbo(
         tempdir.path(),
         &["run", "cross-workspace-task", "--filter=cross-workspace"],
@@ -179,13 +136,6 @@ fn test_cross_workspace_dependency() {
         "cross-workspace dep should run: {stdout}"
     );
     assert!(stdout.contains("2 successful, 2 total"));
-}
-
-#[test]
-fn test_cross_workspace_task_id_syntax() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
-        .unwrap();
 
     // Prime cache
     run_turbo(

--- a/crates/turborepo/tests/workspace_config_inheritance_test.rs
+++ b/crates/turborepo/tests/workspace_config_inheritance_test.rs
@@ -10,7 +10,7 @@ use common::{run_turbo, run_turbo_with_env, setup};
 // when a workspace has no turbo.json.
 
 #[test]
-fn test_missing_workspace_config_outputs_cached() {
+fn test_missing_workspace_config_inherits_root_keys() {
     let tempdir = tempfile::tempdir().unwrap();
     setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
         .unwrap();
@@ -43,22 +43,27 @@ fn test_missing_workspace_config_outputs_cached() {
         stdout2.contains("FULL TURBO"),
         "expected cache hit: {stdout2}"
     );
-}
 
-#[test]
-fn test_missing_workspace_config_inputs_cause_cache_miss() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
-        .unwrap();
+    // Change a file NOT in inputs
+    let bar_path = tempdir
+        .path()
+        .join("apps/missing-workspace-config/src/bar.txt");
+    let mut contents = fs::read_to_string(&bar_path).unwrap_or_default();
+    contents.push_str("\nmore text");
+    fs::write(&bar_path, contents).unwrap();
 
-    // Prime cache
-    run_turbo(
+    let output = run_turbo(
         tempdir.path(),
         &[
             "run",
             "missing-workspace-config-task",
             "--filter=missing-workspace-config",
         ],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("FULL TURBO"),
+        "non-input change should not bust cache: {stdout}"
     );
 
     // Change the declared input file
@@ -82,62 +87,6 @@ fn test_missing_workspace_config_inputs_cause_cache_miss() {
         stdout.contains("cache miss"),
         "expected cache miss after input change: {stdout}"
     );
-}
-
-#[test]
-fn test_missing_workspace_config_non_input_no_cache_miss() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
-        .unwrap();
-
-    // Prime cache (two runs to get past initial miss + input change)
-    run_turbo(
-        tempdir.path(),
-        &[
-            "run",
-            "missing-workspace-config-task",
-            "--filter=missing-workspace-config",
-        ],
-    );
-
-    // Change a file NOT in inputs
-    let bar_path = tempdir
-        .path()
-        .join("apps/missing-workspace-config/src/bar.txt");
-    let mut contents = fs::read_to_string(&bar_path).unwrap_or_default();
-    contents.push_str("\nmore text");
-    fs::write(&bar_path, contents).unwrap();
-
-    let output = run_turbo(
-        tempdir.path(),
-        &[
-            "run",
-            "missing-workspace-config-task",
-            "--filter=missing-workspace-config",
-        ],
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        stdout.contains("FULL TURBO"),
-        "non-input change should not bust cache: {stdout}"
-    );
-}
-
-#[test]
-fn test_missing_workspace_config_env_causes_cache_miss() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
-        .unwrap();
-
-    // Prime cache
-    run_turbo(
-        tempdir.path(),
-        &[
-            "run",
-            "missing-workspace-config-task",
-            "--filter=missing-workspace-config",
-        ],
-    );
 
     let output = run_turbo_with_env(
         tempdir.path(),
@@ -153,13 +102,6 @@ fn test_missing_workspace_config_env_causes_cache_miss() {
         stdout.contains("cache miss"),
         "env var should bust cache: {stdout}"
     );
-}
-
-#[test]
-fn test_missing_workspace_config_cache_false_not_cached() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
-        .unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -176,7 +118,7 @@ fn test_missing_workspace_config_cache_false_not_cached() {
 // but omits all keys.
 
 #[test]
-fn test_omit_keys_outputs_cached() {
+fn test_omit_keys_inherits_root_keys() {
     let tempdir = tempfile::tempdir().unwrap();
     setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
         .unwrap();
@@ -199,45 +141,6 @@ fn test_omit_keys_outputs_cached() {
         stdout2.contains("FULL TURBO"),
         "expected cache hit: {stdout2}"
     );
-}
-
-#[test]
-fn test_omit_keys_inputs_cause_cache_miss() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
-        .unwrap();
-
-    run_turbo(
-        tempdir.path(),
-        &["run", "omit-keys-task", "--filter=omit-keys"],
-    );
-
-    let foo_path = tempdir.path().join("apps/omit-keys/src/foo.txt");
-    let mut contents = fs::read_to_string(&foo_path).unwrap();
-    contents.push_str("\nmore text");
-    fs::write(&foo_path, contents).unwrap();
-
-    let output = run_turbo(
-        tempdir.path(),
-        &["run", "omit-keys-task", "--filter=omit-keys"],
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        stdout.contains("cache miss"),
-        "expected miss after input change: {stdout}"
-    );
-}
-
-#[test]
-fn test_omit_keys_non_input_no_cache_miss() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
-        .unwrap();
-
-    run_turbo(
-        tempdir.path(),
-        &["run", "omit-keys-task", "--filter=omit-keys"],
-    );
 
     let bar_path = tempdir.path().join("apps/omit-keys/src/bar.txt");
     let mut contents = fs::read_to_string(&bar_path).unwrap_or_default();
@@ -253,17 +156,20 @@ fn test_omit_keys_non_input_no_cache_miss() {
         stdout.contains("FULL TURBO"),
         "non-input change should not bust cache: {stdout}"
     );
-}
 
-#[test]
-fn test_omit_keys_env_causes_cache_miss() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
-        .unwrap();
+    let foo_path = tempdir.path().join("apps/omit-keys/src/foo.txt");
+    let mut contents = fs::read_to_string(&foo_path).unwrap();
+    contents.push_str("\nmore text");
+    fs::write(&foo_path, contents).unwrap();
 
-    run_turbo(
+    let output = run_turbo(
         tempdir.path(),
         &["run", "omit-keys-task", "--filter=omit-keys"],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("cache miss"),
+        "expected miss after input change: {stdout}"
     );
 
     let output = run_turbo_with_env(

--- a/crates/turborepo/tests/workspace_config_special_test.rs
+++ b/crates/turborepo/tests/workspace_config_special_test.rs
@@ -9,7 +9,7 @@ use common::{run_turbo, setup};
 // persistent tests
 
 #[test]
-fn test_persistent_inherited_from_root_blocks_parent() {
+fn test_persistent_and_cache_workspace_config() {
     let tempdir = tempfile::tempdir().unwrap();
     setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
         .unwrap();
@@ -25,13 +25,6 @@ fn test_persistent_inherited_from_root_blocks_parent() {
         stderr.contains("is a persistent task"),
         "expected persistent dependency error: {stderr}"
     );
-}
-
-#[test]
-fn test_persistent_overridden_to_false() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
-        .unwrap();
 
     // persistent-task-2 is overridden to persistent:false in workspace
     let output = run_turbo(
@@ -41,13 +34,6 @@ fn test_persistent_overridden_to_false() {
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("2 successful, 2 total"));
-}
-
-#[test]
-fn test_persistent_workspace_omits_flag_inherits_true() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
-        .unwrap();
 
     // persistent-task-3 is persistent:true in root, workspace defines task but
     // doesn't touch persistent
@@ -61,13 +47,6 @@ fn test_persistent_workspace_omits_flag_inherits_true() {
         stderr.contains("is a persistent task"),
         "inherited persistent should block parent: {stderr}"
     );
-}
-
-#[test]
-fn test_persistent_added_in_workspace() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
-        .unwrap();
 
     // persistent-task-4 has no persistent in root, workspace adds persistent:true
     let output = run_turbo(
@@ -80,15 +59,6 @@ fn test_persistent_added_in_workspace() {
         stderr.contains("is a persistent task"),
         "workspace-added persistent should block parent: {stderr}"
     );
-}
-
-// cache override tests
-
-#[test]
-fn test_cache_false_in_root_override_true_in_workspace() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
-        .unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "cached-task-1", "--filter=cached"]);
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -97,13 +67,6 @@ fn test_cache_false_in_root_override_true_in_workspace() {
         stdout.contains("cache miss"),
         "cache:true override should cache: {stdout}"
     );
-}
-
-#[test]
-fn test_cache_true_in_root_override_false_in_workspace() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
-        .unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "cached-task-2", "--filter=cached"]);
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -111,13 +74,6 @@ fn test_cache_true_in_root_override_false_in_workspace() {
         stdout.contains("cache bypass"),
         "cache:false override should bypass: {stdout}"
     );
-}
-
-#[test]
-fn test_no_cache_in_root_false_in_workspace() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
-        .unwrap();
 
     let output = run_turbo(tempdir.path(), &["run", "cached-task-3", "--filter=cached"]);
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -186,7 +142,7 @@ fn test_config_change_causes_hash_change() {
 // task-extends tests
 
 #[test]
-fn test_task_extends_build_inherited() {
+fn test_task_extends_inheritance_and_exclusion() {
     let tempdir = tempfile::tempdir().unwrap();
     setup::setup_integration_test(tempdir.path(), "task_extends", "npm@10.5.0", false).unwrap();
 
@@ -197,12 +153,6 @@ fn test_task_extends_build_inherited() {
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("1 successful, 1 total"));
-}
-
-#[test]
-fn test_task_extends_test_inherited() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "task_extends", "npm@10.5.0", false).unwrap();
 
     let output = run_turbo(
         tempdir.path(),
@@ -211,12 +161,6 @@ fn test_task_extends_test_inherited() {
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("1 successful, 1 total"));
-}
-
-#[test]
-fn test_task_extends_false_excludes_task() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "task_extends", "npm@10.5.0", false).unwrap();
 
     // lint has extends: false, so it should be excluded
     let output = run_turbo(
@@ -255,13 +199,6 @@ fn test_invalid_config_errors() {
         combined.contains("No \"extends\" key found"),
         "expected extends key error: {combined}"
     );
-}
-
-#[test]
-fn test_invalid_config_errors_on_valid_task_too() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
-        .unwrap();
 
     // Even running a valid task in the package should error
     let output = run_turbo(
@@ -279,15 +216,6 @@ fn test_invalid_config_errors_on_valid_task_too() {
         combined.contains("No \"extends\" key found"),
         "expected extends error even for valid task: {combined}"
     );
-}
-
-// bad-json tests
-
-#[test]
-fn test_bad_json_errors() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "composable_config", "npm@10.5.0", false)
-        .unwrap();
 
     // Write malformed JSON
     fs::write(


### PR DESCRIPTION
## Why
More non-watch integration suites were repeating the same fixture setup across separate tests. That creates extra subprocess and package-manager pressure in Windows CI without adding distinct assertions.

## What
- Collapsed repeated `run_logging` fixture setup into shared behavior tests while preserving stream/grouped/GitHub Actions/log-prefix/verbosity/errors-only/prelude assertions.
- Collapsed workspace config inheritance, dependency, and special-case suites into shared fixture tests while preserving existing cache, input, env, dependency, persistent, invalid-config, and task-extends assertions.
- Did not touch watch tests or package-manager/root-discovery contract suites where coverage cannot safely be collapsed without new lower-level seams.

## How
Verified locally with:
- `cargo nextest run -p turbo --test run_logging --test workspace_config_inheritance_test --test workspace_config_deps_test --test workspace_config_special_test`

This removes another 20 binary integration tests by removing duplicated setup, not coverage.