### PR TITLE
test: Collapse summary and caching test setup

### DIFF
--- a/crates/turborepo/tests/global_inputs_test.rs
+++ b/crates/turborepo/tests/global_inputs_test.rs
@@ -103,7 +103,7 @@ fn test_global_dependencies_cannot_be_excluded_by_task_inputs() {
 /// folded into the global hash. This means task-level negation globs
 /// can successfully exclude them.
 #[test]
-fn test_global_inputs_can_be_excluded_by_task_inputs() {
+fn test_global_inputs_can_be_excluded_and_affect_tasks() {
     let tempdir = tempfile::tempdir().unwrap();
     setup_fixture(tempdir.path(), TURBO_JSON_GLOBAL_INPUTS);
 
@@ -124,6 +124,20 @@ fn test_global_inputs_can_be_excluded_by_task_inputs() {
         stdout.contains("FULL TURBO"),
         "expected full cache hit on second run, got: {stdout}"
     );
+
+    // Record the base commit before changing the global input so the affected
+    // assertion below exercises the same transition as the cache assertion.
+    let base_sha = String::from_utf8(
+        std::process::Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(tempdir.path())
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .unwrap()
+    .trim()
+    .to_string();
 
     // Modify the global input file
     fs::write(tempdir.path().join("config.txt"), "changed value").unwrap();
@@ -147,6 +161,30 @@ fn test_global_inputs_can_be_excluded_by_task_inputs() {
     assert!(
         combined.contains("app-b:build") && combined.contains("cache hit"),
         "expected app-b cache hit (negation glob works with global.inputs), got: {combined}"
+    );
+
+    git(tempdir.path(), &["add", "."]);
+    git(
+        tempdir.path(),
+        &["commit", "-m", "change config", "--quiet"],
+    );
+
+    // --affected should detect both tasks.
+    let output = run_turbo_with_env(
+        tempdir.path(),
+        &["build", "--affected", "--output-logs=hash-only"],
+        &[("TURBO_SCM_BASE", &base_sha), ("TURBO_SCM_HEAD", "HEAD")],
+    );
+    assert!(output.status.success());
+    let combined = combined_output(&output);
+
+    assert!(
+        combined.contains("app-a:build"),
+        "expected app-a:build to be affected by global input change, got: {combined}"
+    );
+    assert!(
+        combined.contains("app-b:build"),
+        "expected app-b:build to be affected by global input change, got: {combined}"
     );
 }
 
@@ -199,54 +237,6 @@ fn test_global_inputs_preserves_default_package_file_hashing() {
     assert!(
         stdout.contains("cache miss"),
         "expected cache miss after package file change (default hashing preserved), got: {stdout}"
-    );
-}
-
-/// `--affected` should detect that tasks are affected when a
-/// `global.inputs` file changes, even though the file is no longer
-/// in the global hash.
-#[test]
-fn test_global_inputs_affected_detects_changes() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup_fixture(tempdir.path(), TURBO_JSON_GLOBAL_INPUTS);
-
-    // Record the base commit before any changes.
-    let base_sha = String::from_utf8(
-        std::process::Command::new("git")
-            .args(["rev-parse", "HEAD"])
-            .current_dir(tempdir.path())
-            .output()
-            .unwrap()
-            .stdout,
-    )
-    .unwrap()
-    .trim()
-    .to_string();
-
-    // Modify the global input file and commit.
-    fs::write(tempdir.path().join("config.txt"), "changed value").unwrap();
-    git(tempdir.path(), &["add", "."]);
-    git(
-        tempdir.path(),
-        &["commit", "-m", "change config", "--quiet"],
-    );
-
-    // --affected should detect both tasks.
-    let output = run_turbo_with_env(
-        tempdir.path(),
-        &["build", "--affected", "--output-logs=hash-only"],
-        &[("TURBO_SCM_BASE", &base_sha), ("TURBO_SCM_HEAD", "HEAD")],
-    );
-    assert!(output.status.success());
-    let combined = combined_output(&output);
-
-    assert!(
-        combined.contains("app-a:build"),
-        "expected app-a:build to be affected by global input change, got: {combined}"
-    );
-    assert!(
-        combined.contains("app-b:build"),
-        "expected app-b:build to be affected by global input change, got: {combined}"
     );
 }
 

--- a/crates/turborepo/tests/run_caching.rs
+++ b/crates/turborepo/tests/run_caching.rs
@@ -18,10 +18,8 @@ fn extract_hash<'a>(output: &'a str, prefix: &str) -> &'a str {
         .expect("could not find hash in output")
 }
 
-// --- global-deps.t ---
-
 #[test]
-fn test_global_deps_caching() {
+fn test_basic_monorepo_cache_behaviors() {
     let tempdir = tempfile::tempdir().unwrap();
     setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
 
@@ -51,9 +49,51 @@ fn test_global_deps_caching() {
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("0 cached, 1 total"));
-}
 
-// --- root-deps.t ---
+    // Warm cache
+    run_turbo(tempdir.path(), &["run", "build", "--output-logs=none"]);
+
+    // Dry run to get cache state
+    let output = run_turbo(tempdir.path(), &["run", "build", "--dry=json"]);
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+
+    // Get my-app#build hash and check cache meta
+    let my_app_task = json["tasks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|t| t["taskId"] == "my-app#build")
+        .unwrap();
+
+    let hash = my_app_task["hash"].as_str().unwrap();
+
+    // Read cache meta file
+    let meta_path = tempdir
+        .path()
+        .join(format!(".turbo/cache/{hash}-meta.json"));
+    let meta_contents = fs::read_to_string(&meta_path).unwrap();
+    let meta: serde_json::Value = serde_json::from_str(&meta_contents).unwrap();
+    let duration = meta["duration"].as_u64().unwrap();
+    assert!(duration > 0, "cache duration should be > 0, got {duration}");
+
+    // Validate cache state in dry run
+    let cache = &my_app_task["cache"];
+    assert_eq!(cache["local"], true);
+    assert_eq!(cache["remote"], false);
+    assert_eq!(cache["status"], "HIT");
+    assert_eq!(cache["source"], "LOCAL");
+
+    let output = run_turbo_with_env(
+        tempdir.path(),
+        &["run", "build", "--output-logs=none"],
+        &[("TURBO_CACHE", "remote:rw")],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Remote caching disabled (remote cache requested"),
+        "Expected 'remote cache requested' message, got:\n{stdout}"
+    );
+}
 
 #[test]
 fn test_root_deps_caching() {
@@ -228,65 +268,6 @@ fn test_remote_caching_enable() {
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Remote caching disabled (in configuration)"));
-}
-
-#[test]
-fn test_remote_cache_requested_without_credentials() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
-
-    // TURBO_CACHE=remote:rw without TURBO_TOKEN or TURBO_TEAM
-    let output = run_turbo_with_env(
-        tempdir.path(),
-        &["run", "build", "--output-logs=none"],
-        &[("TURBO_CACHE", "remote:rw")],
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        stdout.contains("Remote caching disabled (remote cache requested"),
-        "Expected 'remote cache requested' message, got:\n{stdout}"
-    );
-}
-
-// --- cache-state.t ---
-
-#[test]
-fn test_cache_state() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
-
-    // Warm cache
-    run_turbo(tempdir.path(), &["run", "build", "--output-logs=none"]);
-
-    // Dry run to get cache state
-    let output = run_turbo(tempdir.path(), &["run", "build", "--dry=json"]);
-    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-
-    // Get my-app#build hash and check cache meta
-    let my_app_task = json["tasks"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .find(|t| t["taskId"] == "my-app#build")
-        .unwrap();
-
-    let hash = my_app_task["hash"].as_str().unwrap();
-
-    // Read cache meta file
-    let meta_path = tempdir
-        .path()
-        .join(format!(".turbo/cache/{hash}-meta.json"));
-    let meta_contents = fs::read_to_string(&meta_path).unwrap();
-    let meta: serde_json::Value = serde_json::from_str(&meta_contents).unwrap();
-    let duration = meta["duration"].as_u64().unwrap();
-    assert!(duration > 0, "cache duration should be > 0, got {duration}");
-
-    // Validate cache state in dry run
-    let cache = &my_app_task["cache"];
-    assert_eq!(cache["local"], true);
-    assert_eq!(cache["remote"], false);
-    assert_eq!(cache["status"], "HIT");
-    assert_eq!(cache["source"], "LOCAL");
 }
 
 // --- excluded-inputs.t ---

--- a/crates/turborepo/tests/run_summary.rs
+++ b/crates/turborepo/tests/run_summary.rs
@@ -40,12 +40,11 @@ fn get_task(summary: &serde_json::Value, task_id: &str) -> serde_json::Value {
         .unwrap_or(serde_json::Value::Null)
 }
 
-// --- discovery.t ---
-
 #[test]
-fn test_run_summary_discovery() {
+fn test_run_summary_basic_monorepo_behaviors() {
     let tempdir = tempfile::tempdir().unwrap();
     setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
+
     let _ = fs::remove_dir_all(tempdir.path().join(".turbo/runs"));
 
     let output = run_turbo(
@@ -56,14 +55,6 @@ fn test_run_summary_discovery() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Summary:"));
     assert!(stdout.contains(".turbo"));
-}
-
-// --- enable.t ---
-
-#[test]
-fn test_run_summary_enable_matrix() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     struct Case {
         env_val: Option<&'static str>,
@@ -166,6 +157,117 @@ fn test_run_summary_enable_matrix() {
             case.env_val, case.flag, case.expect_summary, has_summary
         );
     }
+
+    let _ = fs::remove_dir_all(tempdir.path().join(".turbo/runs"));
+
+    // First run (cache miss)
+    run_turbo(
+        tempdir.path(),
+        &["run", "build", "--summarize", "--", "someargs"],
+    );
+
+    // Second run (cache hit)
+    run_turbo(
+        tempdir.path(),
+        &["run", "build", "--summarize", "--", "someargs"],
+    );
+
+    let mut summaries = read_run_summaries(tempdir.path());
+    assert_eq!(summaries.len(), 2);
+
+    // Sort by cached count so first=miss (0 cached), second=hit (2 cached).
+    // This avoids relying on ksuid timestamp ordering which needs a 1s sleep.
+    summaries.sort_by_key(|s| s["execution"]["cached"].as_u64().unwrap_or(0));
+
+    let first = &summaries[0];
+    let second = &summaries[1];
+
+    // Top-level keys
+    let mut keys: Vec<String> = first.as_object().unwrap().keys().cloned().collect();
+    keys.sort();
+    assert!(keys.contains(&"execution".to_string()));
+    assert!(keys.contains(&"tasks".to_string()));
+
+    assert_eq!(first["scm"]["type"], "git");
+    assert_eq!(first["tasks"].as_array().unwrap().len(), 2);
+    assert_eq!(first["version"], "1");
+    assert_eq!(first["execution"]["exitCode"], 0);
+    assert_eq!(first["execution"]["attempted"], 2);
+    assert_eq!(first["execution"]["cached"], 0);
+    assert_eq!(first["execution"]["success"], 2);
+
+    // Task summaries
+    let first_app = get_task(first, "my-app#build");
+    let second_app = get_task(second, "my-app#build");
+
+    assert_eq!(first_app["execution"]["exitCode"], 0);
+    assert_eq!(first_app["cliArguments"], serde_json::json!(["someargs"]));
+    insta::assert_snapshot!(
+        "external_deps_hash",
+        first_app["hashOfExternalDependencies"].as_str().unwrap()
+    );
+
+    // First run: MISS, second run: HIT
+    assert_eq!(first_app["cache"]["status"], "MISS");
+    assert_eq!(second_app["cache"]["status"], "HIT");
+    assert_eq!(second_app["cache"]["local"], true);
+
+    // util#build present
+    let first_util = get_task(first, "util#build");
+    assert_eq!(first_util["execution"]["exitCode"], 0);
+
+    // another#build not present (no build script)
+    let another = get_task(first, "another#build");
+    assert!(another.is_null());
+
+    let _ = fs::remove_dir_all(tempdir.path().join(".turbo/runs"));
+
+    // Run failing task with summarize
+    run_turbo(
+        tempdir.path(),
+        &["run", "maybefails", "--filter=my-app", "--summarize"],
+    );
+
+    let summaries = read_run_summaries(tempdir.path());
+    assert_eq!(summaries.len(), 1);
+
+    let summary = &summaries[0];
+    assert_eq!(summary["execution"]["failed"], serde_json::json!(1));
+    assert!(
+        [1, 4].contains(&summary["execution"]["exitCode"].as_i64().unwrap()),
+        "exitCode should be 1 or 4"
+    );
+    assert_eq!(summary["execution"]["attempted"], serde_json::json!(1));
+
+    // Task summary for failed task
+    let task = get_task(summary, "my-app#maybefails");
+    assert!(!task.is_null());
+    assert_eq!(task["hash"], "9f05a7188fdf4e93");
+    assert_eq!(task["cache"]["status"], "MISS");
+    assert!([1, 4].contains(&task["execution"]["exitCode"].as_i64().unwrap()));
+    let error = task["execution"]["error"].as_str().unwrap();
+    assert!(
+        error.contains("maybefails exited"),
+        "expected error message, got: {error}"
+    );
+
+    // With --continue --force
+    let _ = fs::remove_dir_all(tempdir.path().join(".turbo/runs"));
+    run_turbo(
+        tempdir.path(),
+        &["run", "maybefails", "--summarize", "--force", "--continue"],
+    );
+
+    let summaries = read_run_summaries(tempdir.path());
+    assert_eq!(summaries.len(), 1);
+    let summary = &summaries[0];
+    assert_eq!(summary["execution"]["success"], serde_json::json!(1));
+    assert_eq!(summary["execution"]["failed"], serde_json::json!(1));
+    assert_eq!(summary["execution"]["attempted"], serde_json::json!(2));
+    assert_eq!(summary["tasks"].as_array().unwrap().len(), 2);
+
+    let failed_task = get_task(summary, "my-app#maybefails");
+    assert!([1, 4].contains(&failed_task["execution"]["exitCode"].as_i64().unwrap()));
 }
 
 // --- sorting-deps.t ---
@@ -272,131 +374,6 @@ fn test_run_summary_single_package() {
 
     assert_eq!(task["cache"]["status"], "MISS");
     assert_eq!(task["cliArguments"], serde_json::json!([]));
-}
-
-// --- monorepo.t ---
-
-#[test]
-fn test_run_summary_monorepo() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
-    let _ = fs::remove_dir_all(tempdir.path().join(".turbo/runs"));
-
-    // First run (cache miss)
-    run_turbo(
-        tempdir.path(),
-        &["run", "build", "--summarize", "--", "someargs"],
-    );
-
-    // Second run (cache hit)
-    run_turbo(
-        tempdir.path(),
-        &["run", "build", "--summarize", "--", "someargs"],
-    );
-
-    let mut summaries = read_run_summaries(tempdir.path());
-    assert_eq!(summaries.len(), 2);
-
-    // Sort by cached count so first=miss (0 cached), second=hit (2 cached).
-    // This avoids relying on ksuid timestamp ordering which needs a 1s sleep.
-    summaries.sort_by_key(|s| s["execution"]["cached"].as_u64().unwrap_or(0));
-
-    let first = &summaries[0];
-    let second = &summaries[1];
-
-    // Top-level keys
-    let mut keys: Vec<String> = first.as_object().unwrap().keys().cloned().collect();
-    keys.sort();
-    assert!(keys.contains(&"execution".to_string()));
-    assert!(keys.contains(&"tasks".to_string()));
-
-    assert_eq!(first["scm"]["type"], "git");
-    assert_eq!(first["tasks"].as_array().unwrap().len(), 2);
-    assert_eq!(first["version"], "1");
-    assert_eq!(first["execution"]["exitCode"], 0);
-    assert_eq!(first["execution"]["attempted"], 2);
-    assert_eq!(first["execution"]["cached"], 0);
-    assert_eq!(first["execution"]["success"], 2);
-
-    // Task summaries
-    let first_app = get_task(first, "my-app#build");
-    let second_app = get_task(second, "my-app#build");
-
-    assert_eq!(first_app["execution"]["exitCode"], 0);
-    assert_eq!(first_app["cliArguments"], serde_json::json!(["someargs"]));
-    insta::assert_snapshot!(
-        "external_deps_hash",
-        first_app["hashOfExternalDependencies"].as_str().unwrap()
-    );
-
-    // First run: MISS, second run: HIT
-    assert_eq!(first_app["cache"]["status"], "MISS");
-    assert_eq!(second_app["cache"]["status"], "HIT");
-    assert_eq!(second_app["cache"]["local"], true);
-
-    // util#build present
-    let first_util = get_task(first, "util#build");
-    assert_eq!(first_util["execution"]["exitCode"], 0);
-
-    // another#build not present (no build script)
-    let another = get_task(first, "another#build");
-    assert!(another.is_null());
-}
-
-// --- error.t ---
-
-#[test]
-fn test_run_summary_error() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
-    let _ = fs::remove_dir_all(tempdir.path().join(".turbo/runs"));
-
-    // Run failing task with summarize
-    run_turbo(
-        tempdir.path(),
-        &["run", "maybefails", "--filter=my-app", "--summarize"],
-    );
-
-    let summaries = read_run_summaries(tempdir.path());
-    assert_eq!(summaries.len(), 1);
-
-    let summary = &summaries[0];
-    assert_eq!(summary["execution"]["failed"], serde_json::json!(1));
-    assert!(
-        [1, 4].contains(&summary["execution"]["exitCode"].as_i64().unwrap()),
-        "exitCode should be 1 or 4"
-    );
-    assert_eq!(summary["execution"]["attempted"], serde_json::json!(1));
-
-    // Task summary for failed task
-    let task = get_task(summary, "my-app#maybefails");
-    assert!(!task.is_null());
-    assert_eq!(task["hash"], "9f05a7188fdf4e93");
-    assert_eq!(task["cache"]["status"], "MISS");
-    assert!([1, 4].contains(&task["execution"]["exitCode"].as_i64().unwrap()));
-    let error = task["execution"]["error"].as_str().unwrap();
-    assert!(
-        error.contains("maybefails exited"),
-        "expected error message, got: {error}"
-    );
-
-    // With --continue --force
-    let _ = fs::remove_dir_all(tempdir.path().join(".turbo/runs"));
-    run_turbo(
-        tempdir.path(),
-        &["run", "maybefails", "--summarize", "--force", "--continue"],
-    );
-
-    let summaries = read_run_summaries(tempdir.path());
-    assert_eq!(summaries.len(), 1);
-    let summary = &summaries[0];
-    assert_eq!(summary["execution"]["success"], serde_json::json!(1));
-    assert_eq!(summary["execution"]["failed"], serde_json::json!(1));
-    assert_eq!(summary["execution"]["attempted"], serde_json::json!(2));
-    assert_eq!(summary["tasks"].as_array().unwrap().len(), 2);
-
-    let failed_task = get_task(summary, "my-app#maybefails");
-    assert!([1, 4].contains(&failed_task["execution"]["exitCode"].as_i64().unwrap()));
 }
 
 // --- strict-env.t ---

--- a/crates/turborepo/tests/run_summary.rs
+++ b/crates/turborepo/tests/run_summary.rs
@@ -41,7 +41,7 @@ fn get_task(summary: &serde_json::Value, task_id: &str) -> serde_json::Value {
 }
 
 #[test]
-fn test_run_summary_basic_monorepo_behaviors() {
+fn test_run_summary_discovery() {
     let tempdir = tempfile::tempdir().unwrap();
     setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
@@ -55,6 +55,12 @@ fn test_run_summary_basic_monorepo_behaviors() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Summary:"));
     assert!(stdout.contains(".turbo"));
+}
+
+#[test]
+fn test_run_summary_enable_matrix() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     struct Case {
         env_val: Option<&'static str>,
@@ -157,6 +163,12 @@ fn test_run_summary_basic_monorepo_behaviors() {
             case.env_val, case.flag, case.expect_summary, has_summary
         );
     }
+}
+
+#[test]
+fn test_run_summary_monorepo() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let _ = fs::remove_dir_all(tempdir.path().join(".turbo/runs"));
 
@@ -219,6 +231,12 @@ fn test_run_summary_basic_monorepo_behaviors() {
     // another#build not present (no build script)
     let another = get_task(first, "another#build");
     assert!(another.is_null());
+}
+
+#[test]
+fn test_run_summary_error() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
 
     let _ = fs::remove_dir_all(tempdir.path().join(".turbo/runs"));
 


### PR DESCRIPTION
## Why
`run_caching` and `global_inputs` repeated setup for compatible scenarios. Collapsing those transitions lowers subprocess-heavy integration work without removing behavioral assertions.

## What
- Reused the unmodified `basic_monorepo` caching fixture for env/global cache behavior, cache-state metadata, and remote-cache-requested messaging.
- Combined compatible `global.inputs` cache invalidation and `--affected` detection checks into one fixture transition.
- Left distinct contract coverage separate: run summary cases, strict env summaries, single-package summaries, root dependency caching, remote cache config mutation, excluded inputs, gitignored output restore, and phantom dependency behavior.

## How
Verified locally with:
- `cargo nextest run -p turbo --test run_summary --test run_caching --test global_inputs_test`
- `git diff --check`

Note: an earlier push over-combined `run_summary`; that has been split back into bounded tests to avoid long-running Windows cases.