### PR TITLE
test: Trim lockfile-aware caching integration matrix

### DIFF
--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -809,6 +809,8 @@ impl AsRef<str> for PackageName {
 
 #[cfg(test)]
 mod test {
+    use std::{fs, path::Path, process::Command};
+
     use serde_json::json;
     use turborepo_errors::Spanned;
 
@@ -830,6 +832,172 @@ mod test {
             &self,
         ) -> Result<crate::discovery::DiscoveryResponse, crate::discovery::Error> {
             self.discover_packages().await
+        }
+    }
+
+    fn repo_root() -> std::path::PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(Path::parent)
+            .expect("crate is under <repo>/crates")
+            .to_owned()
+    }
+
+    fn copy_dir_all(from: &Path, to: &Path) {
+        fs::create_dir_all(to).unwrap();
+        for entry in fs::read_dir(from).unwrap() {
+            let entry = entry.unwrap();
+            let file_type = entry.file_type().unwrap();
+            let dest = to.join(entry.file_name());
+            if file_type.is_dir() {
+                copy_dir_all(&entry.path(), &dest);
+            } else {
+                fs::copy(entry.path(), dest).unwrap();
+            }
+        }
+    }
+
+    fn apply_patch(dir: &Path, target: &str, patch_file: &str) {
+        let status = Command::new("patch")
+            .args([target, patch_file])
+            .current_dir(dir)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .unwrap();
+        assert!(status.success(), "patch {target} {patch_file} failed");
+    }
+
+    fn setup_lockfile_aware_fixture(dir: &Path, pm_name: &str) {
+        let root = repo_root();
+        copy_dir_all(
+            &root.join("turborepo-tests/integration/fixtures/lockfile_aware_caching"),
+            dir,
+        );
+        copy_dir_all(
+            &root.join(format!(
+                "turborepo-tests/integration/tests/lockfile-aware-caching/{pm_name}"
+            )),
+            dir,
+        );
+    }
+
+    fn build_lockfile_aware_graph(
+        root: &AbsoluteSystemPath,
+        package_manager: PackageManager,
+    ) -> PackageGraph {
+        let root_package_json = PackageJson::load(&root.join_component("package.json")).unwrap();
+        let builder = PackageGraph::builder(root, root_package_json)
+            .with_package_manager(package_manager)
+            .with_package_discovery(MockDiscovery)
+            .with_package_jsons(Some(HashMap::from([
+                (
+                    root.join_components(&["apps", "a", "package.json"]),
+                    PackageJson::load(&root.join_components(&["apps", "a", "package.json"]))
+                        .unwrap(),
+                ),
+                (
+                    root.join_components(&["apps", "b", "package.json"]),
+                    PackageJson::load(&root.join_components(&["apps", "b", "package.json"]))
+                        .unwrap(),
+                ),
+            ])));
+
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(builder.build())
+            .unwrap()
+    }
+
+    #[test]
+    fn lockfile_changes_are_scoped_by_package_manager() {
+        let cases = [
+            (
+                PackageManager::Npm,
+                "npm",
+                "package-lock.json",
+                "package-lock.patch",
+                "turbo-bump.patch",
+            ),
+            (
+                PackageManager::Yarn,
+                "yarn",
+                "yarn.lock",
+                "yarn-lock.patch",
+                "turbo-bump.patch",
+            ),
+            (
+                PackageManager::Pnpm,
+                "pnpm",
+                "pnpm-lock.yaml",
+                "pnpm-lock.patch",
+                "turbo-bump.patch",
+            ),
+            (
+                PackageManager::Berry,
+                "berry",
+                "yarn.lock",
+                "yarn-lock.patch",
+                "turbo-bump.patch",
+            ),
+            (
+                PackageManager::Bun,
+                "bun",
+                "bun.lock",
+                "bun-lock.patch",
+                "turbo-bump.patch",
+            ),
+        ];
+
+        for (package_manager, pm_name, lockfile, dep_patch, root_patch) in cases {
+            let tempdir = tempfile::tempdir().unwrap();
+            setup_lockfile_aware_fixture(tempdir.path(), pm_name);
+            let root = AbsoluteSystemPathBuf::try_from(tempdir.path()).unwrap();
+            let root_package_json =
+                PackageJson::load(&root.join_component("package.json")).unwrap();
+
+            let previous = package_manager
+                .read_lockfile(&root, &root_package_json)
+                .unwrap();
+
+            apply_patch(tempdir.path(), lockfile, dep_patch);
+            let dep_graph = build_lockfile_aware_graph(&root, package_manager.clone());
+            let mut dep_changed = dep_graph
+                .changed_packages_from_lockfile(previous.as_ref())
+                .unwrap();
+            dep_changed.sort_by(|a, b| a.package.name.cmp(&b.package.name));
+
+            assert_eq!(
+                dep_changed
+                    .iter()
+                    .map(|change| change.package.name.clone())
+                    .collect::<Vec<_>>(),
+                vec![PackageName::from("b")],
+                "{pm_name}: dependency lockfile change should only affect b"
+            );
+
+            let previous_dep = package_manager
+                .read_lockfile(&root, &root_package_json)
+                .unwrap();
+            apply_patch(tempdir.path(), lockfile, root_patch);
+            let root_graph = build_lockfile_aware_graph(&root, package_manager);
+            let mut root_changed = root_graph
+                .changed_packages_from_lockfile(previous_dep.as_ref())
+                .unwrap();
+            root_changed.sort_by(|a, b| a.package.name.cmp(&b.package.name));
+
+            let root_changed_names = root_changed
+                .iter()
+                .map(|change| change.package.name.clone())
+                .collect::<HashSet<_>>();
+            assert!(
+                root_changed_names.contains(&PackageName::from("a"))
+                    && root_changed_names.contains(&PackageName::from("b")),
+                "{pm_name}: root lockfile change should affect all workspaces: \
+                 {root_changed_names:?}"
+            );
         }
     }
 

--- a/crates/turborepo/tests/lockfile_aware_caching_test.rs
+++ b/crates/turborepo/tests/lockfile_aware_caching_test.rs
@@ -121,28 +121,3 @@ fn test_lockfile_aware_caching_npm() {
         "turbo-bump.patch",
     );
 }
-
-#[test]
-fn test_lockfile_aware_caching_yarn() {
-    run_lockfile_test("yarn", "yarn.lock", "yarn-lock.patch", "turbo-bump.patch");
-}
-
-#[test]
-fn test_lockfile_aware_caching_pnpm() {
-    run_lockfile_test(
-        "pnpm",
-        "pnpm-lock.yaml",
-        "pnpm-lock.patch",
-        "turbo-bump.patch",
-    );
-}
-
-#[test]
-fn test_lockfile_aware_caching_berry() {
-    run_lockfile_test("berry", "yarn.lock", "yarn-lock.patch", "turbo-bump.patch");
-}
-
-#[test]
-fn test_lockfile_aware_caching_bun() {
-    run_lockfile_test("bun", "bun.lock", "bun-lock.patch", "turbo-bump.patch");
-}


### PR DESCRIPTION
## Why
`lockfile_aware_caching_test` repeated the same expensive binary cache/filter scenario across five package managers. The package-manager-specific contract is lockfile change scoping, which can be tested directly without spawning `turbo` and package manager scripts for each variant.

## What
- Added lower-level `PackageGraph::changed_packages_from_lockfile` coverage for npm, Yarn, pnpm, Berry, and Bun using the existing lockfile-aware fixtures and patches.
- Kept the npm binary integration test as the end-to-end smoke for cache hit/miss and `--filter=[HEAD^1]` behavior.
- Removed the duplicate Yarn, pnpm, Berry, and Bun binary variants.

## How
Verified locally with:
- `cargo test -p turborepo-repository lockfile_changes_are_scoped_by_package_manager`
- `cargo nextest run -p turbo --test lockfile_aware_caching_test`
- `git diff --check`

This keeps package-manager-specific lockfile scoping coverage while reducing the subprocess-heavy integration matrix.