### PR TITLE
test: Remove Windows nextest thread cap

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -4,19 +4,6 @@
 [profile.default]
 failure-output = "immediate-final"
 
-[test-groups]
-windows-turbo-subprocess-heavy = { max-threads = 2 }
-
-[[profile.default.overrides]]
-# Windows runners can fail subprocess-heavy tests under high nextest fanout with
-# DLL initialization error 0xc0000142. Keep full coverage, but cap the
-# integration files that create many git repos, run package managers, or spawn
-# child `turbo` processes so they do not stampede process startup while the rest
-# of the package still runs at normal concurrency.
-filter = 'package(turbo) and (binary(run_summary) or binary(workspace_config_deps_test) or binary(lockfile_aware_caching_test) or binary(one_script_error_test) or binary(inference_test))'
-platform = 'cfg(windows)'
-test-group = 'windows-turbo-subprocess-heavy'
-
 [[profile.default.overrides]]
 # These tests run package installs from the network during setup, which can
 # take 20-60s+ on cold CI runners. Give them extra time instead of retries.


### PR DESCRIPTION
Why

The turborepo-scm subprocess cleanup in #12998 passed Windows without its cap. This PR checks whether the remaining Windows-only nextest thread limit is still needed.

What

Removes the last Windows nextest test group and override for subprocess-heavy turbo integration tests.

How

Verified with git diff --check. Push hooks also ran format and TOML checks. CI should validate whether Windows Rust tests pass at normal nextest fanout.