### PR TITLE
fix: Ignore peer dependencies in package graph

### DIFF
--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -1,7 +1,7 @@
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet, HashSet},
     str::FromStr,
     sync::{LazyLock, OnceLock},
 };
@@ -160,12 +160,7 @@ pub async fn prune(
     let mut workspace_paths = Vec::new();
     let mut workspace_names = Vec::new();
     let workspaces = prune.internal_dependencies();
-    let lockfile_keys: Vec<_> = prune
-        .package_graph
-        .transitive_external_dependencies(workspaces.iter())
-        .into_iter()
-        .map(|pkg| pkg.key.clone())
-        .collect();
+    let lockfile_keys = prune.lockfile_keys(&workspaces)?;
     for workspace in workspaces {
         let entry = prune
             .package_graph
@@ -748,17 +743,111 @@ impl<'a> Prune<'a> {
                     .map(|workspace| PackageNode::Workspace(PackageName::Other(workspace.clone()))),
             )
             .collect::<Vec<_>>();
-        let nodes = self.package_graph.transitive_closure(workspaces.iter());
-
-        let mut names: Vec<_> = nodes
+        let mut names = self
+            .package_graph
+            .transitive_closure(workspaces.iter())
             .into_iter()
             .filter_map(|node| match node {
                 PackageNode::Root => None,
                 PackageNode::Workspace(workspace) => Some(workspace.clone()),
             })
-            .collect();
+            .collect::<HashSet<_>>();
+
+        loop {
+            let mut changed = false;
+            for workspace in names.clone() {
+                let Some(info) = self.package_graph.package_info(&workspace) else {
+                    continue;
+                };
+                for (peer_name, _) in info.package_json.peer_dependencies.iter().flatten() {
+                    if info.package_json.is_optional_peer_dependency(peer_name) {
+                        continue;
+                    }
+
+                    let peer = PackageName::from(peer_name.as_str());
+                    if self.package_graph.package_info(&peer).is_some() && names.insert(peer) {
+                        changed = true;
+                    }
+                }
+            }
+
+            if !changed {
+                break;
+            }
+
+            let workspace_nodes = names
+                .iter()
+                .cloned()
+                .map(PackageNode::Workspace)
+                .collect::<Vec<_>>();
+            names.extend(
+                self.package_graph
+                    .transitive_closure(workspace_nodes.iter())
+                    .into_iter()
+                    .filter_map(|node| match node {
+                        PackageNode::Root => None,
+                        PackageNode::Workspace(workspace) => Some(workspace.clone()),
+                    }),
+            );
+        }
+
+        let mut names = names.into_iter().collect::<Vec<_>>();
         names.sort();
         names
+    }
+
+    fn lockfile_keys(&self, workspaces: &[PackageName]) -> Result<Vec<String>, Error> {
+        let mut keys = self
+            .package_graph
+            .transitive_external_dependencies(workspaces.iter())
+            .into_iter()
+            .map(|pkg| pkg.key.clone())
+            .collect::<HashSet<_>>();
+
+        let lockfile = self
+            .package_graph
+            .lockfile()
+            .ok_or(Error::MissingLockfile)?;
+
+        for workspace in workspaces {
+            let Some(info) = self.package_graph.package_info(workspace) else {
+                continue;
+            };
+
+            let peer_dependencies = info
+                .package_json
+                .peer_dependencies
+                .iter()
+                .flatten()
+                .filter(|(name, _)| !info.package_json.is_optional_peer_dependency(name))
+                .filter(|(name, _)| {
+                    self.package_graph
+                        .package_info(&PackageName::from(name.as_str()))
+                        .is_none()
+                })
+                .map(|(name, version)| (name.clone(), version.clone()))
+                .collect::<BTreeMap<_, _>>();
+
+            if peer_dependencies.is_empty() {
+                continue;
+            }
+
+            let workspace_path = info.package_path().to_unix();
+            keys.extend(
+                turborepo_lockfiles::transitive_closure(
+                    lockfile,
+                    workspace_path.as_str(),
+                    peer_dependencies,
+                    false,
+                )?
+                .into_iter()
+                .map(|pkg| pkg.key),
+            );
+        }
+
+        let mut keys = keys.into_iter().collect::<Vec<_>>();
+        keys.sort();
+        Ok(keys)
     }
 
     /// Copy files matched by `globalDependencies` globs when the
@@ -1081,6 +1170,84 @@ mod tests {
                 PackageName::Root,
                 PackageName::from("pkg-a"),
                 PackageName::from("pkg-b")
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn internal_dependencies_includes_non_optional_peer_workspaces() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPathBuf::try_from(tempdir.path()).unwrap();
+        let package_graph = PackageGraph::builder(
+            &root,
+            PackageJson::from_value(json!({
+                "name": "repo",
+                "packageManager": "npm@10.5.0"
+            }))
+            .unwrap(),
+        )
+        .with_package_discovery(MockDiscovery)
+        .with_package_jsons(Some(HashMap::from([
+            (
+                root.join_components(&["packages", "pkg-b", "package.json"]),
+                PackageJson::from_value(json!({
+                    "name": "pkg-b",
+                    "peerDependencies": {
+                        "pkg-c": "*",
+                        "pkg-e": "*"
+                    },
+                    "peerDependenciesMeta": {
+                        "pkg-e": { "optional": true }
+                    }
+                }))
+                .unwrap(),
+            ),
+            (
+                root.join_components(&["packages", "pkg-c", "package.json"]),
+                PackageJson {
+                    name: Some(Spanned::new("pkg-c".to_string())),
+                    dependencies: Some(BTreeMap::from([("pkg-d".to_string(), "*".to_string())])),
+                    ..Default::default()
+                },
+            ),
+            (
+                root.join_components(&["packages", "pkg-d", "package.json"]),
+                PackageJson {
+                    name: Some(Spanned::new("pkg-d".to_string())),
+                    ..Default::default()
+                },
+            ),
+            (
+                root.join_components(&["packages", "pkg-e", "package.json"]),
+                PackageJson {
+                    name: Some(Spanned::new("pkg-e".to_string())),
+                    ..Default::default()
+                },
+            ),
+        ])))
+        .build()
+        .await
+        .unwrap();
+        let scope = vec!["pkg-b".to_string()];
+        let out_directory = root.join_component("out");
+        let prune = Prune {
+            package_graph,
+            root: root.clone(),
+            out_directory: out_directory.clone(),
+            full_directory: out_directory,
+            docker: false,
+            scope: &scope,
+            use_gitignore: false,
+            uses_per_workspace_lockfiles: false,
+        };
+
+        assert_eq!(
+            prune.internal_dependencies(),
+            vec![
+                PackageName::Root,
+                PackageName::from("pkg-b"),
+                PackageName::from("pkg-c"),
+                PackageName::from("pkg-d")
             ]
         );
     }

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -705,7 +705,7 @@ impl Dependencies {
 
             match kind {
                 // Peers are provided by consumers and are not package graph inputs.
-                DependencyKind::Peer => {}
+                DependencyKind::Peer { .. } => {}
                 DependencyKind::Normal => {
                     if let Some(workspace) = splitter.is_internal(name, version) {
                         internal.insert(workspace);
@@ -1184,7 +1184,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_prune_excludes_internal_peer_and_external_peer() {
+    async fn test_peer_dependencies_do_not_create_internal_edges() {
         let root =
             AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
 
@@ -1240,7 +1240,8 @@ mod test {
         let lib_closure = graph.transitive_closure([&lib]);
         assert!(
             !lib_closure.contains(&app),
-            "prune closure for lib should exclude pure-peer workspace app, got: {lib_closure:?}"
+            "package graph closure for lib should exclude pure-peer workspace app, got: \
+             {lib_closure:?}"
         );
         assert!(
             graph.transitive_closure([&app]).contains(&lib),
@@ -1255,7 +1256,7 @@ mod test {
             .unwrap();
         assert!(
             !lib_external.contains_key("react"),
-            "external peer should not be retained for prune, got: {:?}",
+            "external peer should not be retained by package graph, got: {:?}",
             lib_external
         );
     }

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -703,13 +703,15 @@ impl Dependencies {
                 continue;
             }
 
-            match splitter.is_internal(name, version) {
-                // A peer that is internal, does not create a build-order edge
-                Some(_) if kind == DependencyKind::Peer => {}
-                Some(workspace) => {
+            match (kind, splitter.is_internal(name, version)) {
+                // Peers are provided by consumers, never a build-order edge
+                (DependencyKind::Peer | DependencyKind::OptionalPeer, Some(_)) => {}
+                (DependencyKind::Normal, Some(workspace)) => {
                     internal.insert(workspace);
                 }
-                None => {
+                // Optional peers aren't auto-installed, so no need to retain them for external deps
+                (DependencyKind::OptionalPeer, None) => {}
+                (_, None) => {
                     external.insert(name.clone(), version.clone());
                 }
             }
@@ -1123,6 +1125,74 @@ mod test {
             a_external.get("react").map(|v| v.as_str()),
             Some("*"),
             "external peer dependency should be retained as an external dep"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_optional_external_peer_is_not_retained() {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+
+        let graph = PackageGraphBuilder::new(
+            &root,
+            PackageJson {
+                name: Some(Spanned::new("root".into())),
+                ..Default::default()
+            },
+        )
+        .with_single_package_mode(false)
+        .with_package_discovery(MockDiscovery)
+        .with_package_jsons(Some({
+            let mut package_jsons = HashMap::new();
+            package_jsons.insert(
+                root.join_components(&["packages", "a", "package.json"]),
+                PackageJson {
+                    name: Some(Spanned::new("a".into())),
+                    version: Some("1.0.0".to_string()),
+                    peer_dependencies: Some(
+                        [
+                            ("react".to_string(), "*".to_string()),
+                            ("lodash".to_string(), "*".to_string()),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    ),
+                    peer_dependencies_meta: Some(
+                        [(
+                            "react".to_string(),
+                            crate::package_json::PeerDependencyMeta {
+                                optional: Some(true),
+                                ..Default::default()
+                            },
+                        )]
+                        .into_iter()
+                        .collect(),
+                    ),
+                    ..Default::default()
+                },
+            );
+            package_jsons
+        }))
+        .build()
+        .await
+        .unwrap();
+
+        let a = PackageName::from("a");
+        let a_external = graph
+            .package_info(&a)
+            .unwrap()
+            .unresolved_external_dependencies
+            .as_ref()
+            .unwrap();
+        assert_eq!(
+            a_external.get("lodash").map(|v| v.as_str()),
+            Some("*"),
+            "required peer should be retained as an external dep"
+        );
+        assert!(
+            !a_external.contains_key("react"),
+            "optional peer should not be retained, got: {:?}",
+            a_external
         );
     }
 

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -1197,6 +1197,83 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_prune_excludes_internal_peer_keeps_external_peer() {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+
+        let graph = PackageGraphBuilder::new(
+            &root,
+            PackageJson {
+                name: Some(Spanned::new("root".into())),
+                ..Default::default()
+            },
+        )
+        .with_single_package_mode(false)
+        .with_package_discovery(MockDiscovery)
+        .with_package_jsons(Some({
+            let mut package_jsons = HashMap::new();
+            package_jsons.insert(
+                root.join_components(&["packages", "app", "package.json"]),
+                PackageJson {
+                    name: Some(Spanned::new("app".into())),
+                    version: Some("1.0.0".to_string()),
+                    dependencies: Some(
+                        [("lib".to_string(), "workspace:*".to_string())]
+                            .into_iter()
+                            .collect(),
+                    ),
+                    ..Default::default()
+                },
+            );
+            package_jsons.insert(
+                root.join_components(&["packages", "lib", "package.json"]),
+                PackageJson {
+                    name: Some(Spanned::new("lib".into())),
+                    version: Some("1.0.0".to_string()),
+                    peer_dependencies: Some(
+                        [
+                            ("app".to_string(), "workspace:*".to_string()),
+                            ("react".to_string(), "*".to_string()),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    ),
+                    ..Default::default()
+                },
+            );
+            package_jsons
+        }))
+        .build()
+        .await
+        .unwrap();
+
+        let app = PackageNode::Workspace(PackageName::from("app"));
+        let lib = PackageNode::Workspace(PackageName::from("lib"));
+
+        let lib_closure = graph.transitive_closure([&lib]);
+        assert!(
+            !lib_closure.contains(&app),
+            "prune closure for lib should exclude pure-peer workspace app, got: {lib_closure:?}"
+        );
+        assert!(
+            graph.transitive_closure([&app]).contains(&lib),
+            "prune closure for app should include its regular dependency lib"
+        );
+
+        let lib_external = graph
+            .package_info(&PackageName::from("lib"))
+            .unwrap()
+            .unresolved_external_dependencies
+            .as_ref()
+            .unwrap();
+        assert_eq!(
+            lib_external.get("react").map(|v| v.as_str()),
+            Some("*"),
+            "external peer should be retained for prune"
+        );
+    }
+
+    #[tokio::test]
     async fn test_duplicate_package_names() {
         let root =
             AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -17,7 +17,7 @@ use crate::{
         self, CachingPackageDiscovery, LocalPackageDiscoveryBuilder, PackageDiscovery,
         PackageDiscoveryBuilder,
     },
-    package_json::PackageJson,
+    package_json::{DependencyKind, PackageJson},
     package_manager::{PackageManager, pnpm::PnpmCatalogs},
 };
 
@@ -453,7 +453,7 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedWorkspaces, T> {
                             &entry.package_json_path,
                             &self.workspaces,
                             link_workspace_packages,
-                            entry.package_json.all_dependencies(),
+                            entry.package_json.dependencies_with_kind(),
                             &path_index,
                             catalogs.as_ref(),
                         ),
@@ -674,7 +674,7 @@ struct Dependencies {
 }
 
 impl Dependencies {
-    pub fn new<'a, I: IntoIterator<Item = (&'a String, &'a String)>>(
+    pub fn new<'a, I: IntoIterator<Item = (&'a String, &'a String, DependencyKind)>>(
         repo_root: &AbsoluteSystemPath,
         workspace_json_path: &AnchoredSystemPathBuf,
         workspaces: &HashMap<PackageName, PackageInfo>,
@@ -698,15 +698,20 @@ impl Dependencies {
             path_index,
             catalogs,
         );
-        for (name, version) in dependencies.into_iter() {
+        for (name, version, kind) in dependencies.into_iter() {
             if !seen.insert(name.clone()) {
                 continue;
             }
 
-            if let Some(workspace) = splitter.is_internal(name, version) {
-                internal.insert(workspace);
-            } else {
-                external.insert(name.clone(), version.clone());
+            match splitter.is_internal(name, version) {
+                // A peer that is internal, does not create a build-order edge
+                Some(_) if kind == DependencyKind::Peer => {}
+                Some(workspace) => {
+                    internal.insert(workspace);
+                }
+                None => {
+                    external.insert(name.clone(), version.clone());
+                }
             }
         }
         Self { internal, external }
@@ -994,6 +999,130 @@ mod test {
         assert_eq!(
             b_external.get("buffer").map(|v| v.as_str()),
             Some("npm:buffer@6.0.3")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_pure_peer_workspace_dep_does_not_create_edge() {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+
+        let graph = PackageGraphBuilder::new(
+            &root,
+            PackageJson {
+                name: Some(Spanned::new("root".into())),
+                ..Default::default()
+            },
+        )
+        .with_single_package_mode(false)
+        .with_package_discovery(MockDiscovery)
+        .with_package_jsons(Some({
+            let mut package_jsons = HashMap::new();
+            package_jsons.insert(
+                root.join_components(&["packages", "a", "package.json"]),
+                PackageJson {
+                    name: Some(Spanned::new("a".into())),
+                    version: Some("1.0.0".to_string()),
+                    dependencies: Some(
+                        [("b".to_string(), "workspace:*".to_string())]
+                            .into_iter()
+                            .collect(),
+                    ),
+                    ..Default::default()
+                },
+            );
+            package_jsons.insert(
+                root.join_components(&["packages", "b", "package.json"]),
+                PackageJson {
+                    name: Some(Spanned::new("b".into())),
+                    version: Some("1.0.0".to_string()),
+                    peer_dependencies: Some(
+                        [("a".to_string(), "workspace:*".to_string())]
+                            .into_iter()
+                            .collect(),
+                    ),
+                    ..Default::default()
+                },
+            );
+            package_jsons
+        }))
+        .build()
+        .await
+        .unwrap();
+
+        let a = PackageName::from("a");
+        let b = PackageName::from("b");
+
+        let a_deps = graph
+            .immediate_dependencies(&PackageNode::Workspace(a.clone()))
+            .unwrap();
+        assert!(
+            a_deps.contains(&PackageNode::Workspace(b.clone())),
+            "a should depend on b, got: {:?}",
+            a_deps
+        );
+
+        let b_deps = graph
+            .immediate_dependencies(&PackageNode::Workspace(b.clone()))
+            .unwrap();
+        assert!(
+            !b_deps.contains(&PackageNode::Workspace(a)),
+            "pure peer workspace specifier should not create an internal edge, got: {:?}",
+            b_deps
+        );
+
+        assert!(
+            graph.find_cycles().is_empty(),
+            "package graph should be acyclic once the pure peer edge is dropped"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_external_peer_dep_is_retained_as_external() {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+
+        let graph = PackageGraphBuilder::new(
+            &root,
+            PackageJson {
+                name: Some(Spanned::new("root".into())),
+                ..Default::default()
+            },
+        )
+        .with_single_package_mode(false)
+        .with_package_discovery(MockDiscovery)
+        .with_package_jsons(Some({
+            let mut package_jsons = HashMap::new();
+            package_jsons.insert(
+                root.join_components(&["packages", "a", "package.json"]),
+                PackageJson {
+                    name: Some(Spanned::new("a".into())),
+                    version: Some("1.0.0".to_string()),
+                    peer_dependencies: Some(
+                        [("react".to_string(), "*".to_string())]
+                            .into_iter()
+                            .collect(),
+                    ),
+                    ..Default::default()
+                },
+            );
+            package_jsons
+        }))
+        .build()
+        .await
+        .unwrap();
+
+        let a = PackageName::from("a");
+        let a_external = graph
+            .package_info(&a)
+            .unwrap()
+            .unresolved_external_dependencies
+            .as_ref()
+            .unwrap();
+        assert_eq!(
+            a_external.get("react").map(|v| v.as_str()),
+            Some("*"),
+            "external peer dependency should be retained as an external dep"
         );
     }
 

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -703,16 +703,15 @@ impl Dependencies {
                 continue;
             }
 
-            match (kind, splitter.is_internal(name, version)) {
-                // Peers are provided by consumers, never a build-order edge
-                (DependencyKind::Peer | DependencyKind::OptionalPeer, Some(_)) => {}
-                (DependencyKind::Normal, Some(workspace)) => {
-                    internal.insert(workspace);
-                }
-                // Optional peers aren't auto-installed, so no need to retain them for external deps
-                (DependencyKind::OptionalPeer, None) => {}
-                (_, None) => {
-                    external.insert(name.clone(), version.clone());
+            match kind {
+                // Peers are provided by consumers and are not package graph inputs.
+                DependencyKind::Peer => {}
+                DependencyKind::Normal => {
+                    if let Some(workspace) = splitter.is_internal(name, version) {
+                        internal.insert(workspace);
+                    } else {
+                        external.insert(name.clone(), version.clone());
+                    }
                 }
             }
         }
@@ -1080,7 +1079,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_external_peer_dep_is_retained_as_external() {
+    async fn test_external_peer_dep_is_not_retained_as_external() {
         let root =
             AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
 
@@ -1121,10 +1120,10 @@ mod test {
             .unresolved_external_dependencies
             .as_ref()
             .unwrap();
-        assert_eq!(
-            a_external.get("react").map(|v| v.as_str()),
-            Some("*"),
-            "external peer dependency should be retained as an external dep"
+        assert!(
+            !a_external.contains_key("react"),
+            "external peer dependency should not be retained as an external dep, got: {:?}",
+            a_external
         );
     }
 
@@ -1146,30 +1145,18 @@ mod test {
             let mut package_jsons = HashMap::new();
             package_jsons.insert(
                 root.join_components(&["packages", "a", "package.json"]),
-                PackageJson {
-                    name: Some(Spanned::new("a".into())),
-                    version: Some("1.0.0".to_string()),
-                    peer_dependencies: Some(
-                        [
-                            ("react".to_string(), "*".to_string()),
-                            ("lodash".to_string(), "*".to_string()),
-                        ]
-                        .into_iter()
-                        .collect(),
-                    ),
-                    peer_dependencies_meta: Some(
-                        [(
-                            "react".to_string(),
-                            crate::package_json::PeerDependencyMeta {
-                                optional: Some(true),
-                                ..Default::default()
-                            },
-                        )]
-                        .into_iter()
-                        .collect(),
-                    ),
-                    ..Default::default()
-                },
+                PackageJson::from_value(serde_json::json!({
+                    "name": "a",
+                    "version": "1.0.0",
+                    "peerDependencies": {
+                        "react": "*",
+                        "lodash": "*"
+                    },
+                    "peerDependenciesMeta": {
+                        "react": { "optional": true }
+                    }
+                }))
+                .unwrap(),
             );
             package_jsons
         }))
@@ -1184,20 +1171,20 @@ mod test {
             .unresolved_external_dependencies
             .as_ref()
             .unwrap();
-        assert_eq!(
-            a_external.get("lodash").map(|v| v.as_str()),
-            Some("*"),
-            "required peer should be retained as an external dep"
-        );
         assert!(
             !a_external.contains_key("react"),
             "optional peer should not be retained, got: {:?}",
             a_external
         );
+        assert!(
+            !a_external.contains_key("lodash"),
+            "required peer should not be retained, got: {:?}",
+            a_external
+        );
     }
 
     #[tokio::test]
-    async fn test_prune_excludes_internal_peer_keeps_external_peer() {
+    async fn test_prune_excludes_internal_peer_and_external_peer() {
         let root =
             AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
 
@@ -1266,10 +1253,10 @@ mod test {
             .unresolved_external_dependencies
             .as_ref()
             .unwrap();
-        assert_eq!(
-            lib_external.get("react").map(|v| v.as_str()),
-            Some("*"),
-            "external peer should be retained for prune"
+        assert!(
+            !lib_external.contains_key("react"),
+            "external peer should not be retained for prune, got: {:?}",
+            lib_external
         );
     }
 

--- a/crates/turborepo-repository/src/package_json.rs
+++ b/crates/turborepo-repository/src/package_json.rs
@@ -14,6 +14,12 @@ use turbopath::{AbsoluteSystemPath, RelativeUnixPathBuf};
 use turborepo_errors::{ParseDiagnostic, Spanned, WithMetadata};
 use turborepo_unescape::UnescapedString;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DependencyKind {
+    Normal,
+    Peer,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PackageJson {
@@ -208,6 +214,24 @@ impl PackageJson {
             .chain(self.dev_dependencies.iter().flatten())
             .chain(self.optional_dependencies.iter().flatten())
             .chain(self.peer_dependencies.iter().flatten())
+    }
+
+    pub fn dependencies_with_kind(
+        &self,
+    ) -> impl Iterator<Item = (&String, &String, DependencyKind)> + '_ {
+        let normal = self
+            .dependencies
+            .iter()
+            .flatten()
+            .chain(self.dev_dependencies.iter().flatten())
+            .chain(self.optional_dependencies.iter().flatten())
+            .map(|(name, version)| (name, version, DependencyKind::Normal));
+        let peer = self
+            .peer_dependencies
+            .iter()
+            .flatten()
+            .map(|(name, version)| (name, version, DependencyKind::Peer));
+        normal.chain(peer)
     }
 
     /// Returns the command for script_name if it is non-empty

--- a/crates/turborepo-repository/src/package_json.rs
+++ b/crates/turborepo-repository/src/package_json.rs
@@ -17,7 +17,7 @@ use turborepo_unescape::UnescapedString;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DependencyKind {
     Normal,
-    Peer,
+    Peer { optional: bool },
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
@@ -230,8 +230,27 @@ impl PackageJson {
             .peer_dependencies
             .iter()
             .flatten()
-            .map(|(name, version)| (name, version, DependencyKind::Peer));
+            .map(|(name, version)| {
+                (
+                    name,
+                    version,
+                    DependencyKind::Peer {
+                        optional: self.is_optional_peer_dependency(name),
+                    },
+                )
+            });
         normal.chain(peer)
+    }
+
+    pub fn is_optional_peer_dependency(&self, name: &str) -> bool {
+        self.other
+            .get("peerDependenciesMeta")
+            .and_then(|meta| meta.as_object())
+            .and_then(|meta| meta.get(name))
+            .and_then(|entry| entry.as_object())
+            .and_then(|entry| entry.get("optional"))
+            .and_then(|optional| optional.as_bool())
+            .unwrap_or(false)
     }
 
     /// Returns the command for script_name if it is non-empty

--- a/crates/turborepo-repository/src/package_json.rs
+++ b/crates/turborepo-repository/src/package_json.rs
@@ -18,7 +18,6 @@ use turborepo_unescape::UnescapedString;
 pub enum DependencyKind {
     Normal,
     Peer,
-    OptionalPeer,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
@@ -38,8 +37,6 @@ pub struct PackageJson {
     pub optional_dependencies: Option<BTreeMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub peer_dependencies: Option<BTreeMap<String, String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub peer_dependencies_meta: Option<BTreeMap<String, PeerDependencyMeta>>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub scripts: BTreeMap<String, Spanned<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -63,16 +60,6 @@ pub struct PnpmConfig {
     pub other: BTreeMap<String, serde_json::Value>,
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PeerDependencyMeta {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub optional: Option<bool>,
-    // Unstructured fields kept for round trip capabilities
-    #[serde(flatten)]
-    pub other: BTreeMap<String, serde_json::Value>,
-}
-
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserializable)]
 pub struct RawPackageJson {
     pub name: Option<Spanned<UnescapedString>>,
@@ -82,7 +69,6 @@ pub struct RawPackageJson {
     pub dev_dependencies: Option<BTreeMap<String, UnescapedString>>,
     pub optional_dependencies: Option<BTreeMap<String, UnescapedString>>,
     pub peer_dependencies: Option<BTreeMap<String, UnescapedString>>,
-    pub peer_dependencies_meta: Option<BTreeMap<String, RawPeerDependencyMeta>>,
     pub scripts: BTreeMap<String, Spanned<UnescapedString>>,
     pub resolutions: Option<BTreeMap<String, UnescapedString>>,
     pub pnpm: Option<RawPnpmConfig>,
@@ -96,14 +82,6 @@ pub struct RawPackageJson {
 pub struct RawPnpmConfig {
     pub patched_dependencies: Option<BTreeMap<String, RelativeUnixPathBuf>>,
     // Unstructured config options kept for round trip capabilities
-    #[deserializable(rest)]
-    pub other: BTreeMap<Text, serde_json::Value>,
-}
-
-#[derive(Debug, Default, Clone, PartialEq, Eq, Deserializable)]
-pub struct RawPeerDependencyMeta {
-    pub optional: Option<bool>,
-    // Unstructured fields kept for round trip capabilities
     #[deserializable(rest)]
     pub other: BTreeMap<Text, serde_json::Value>,
 }
@@ -157,9 +135,6 @@ impl From<RawPackageJson> for PackageJson {
             peer_dependencies: raw
                 .peer_dependencies
                 .map(|m| m.into_iter().map(|(k, v)| (k, v.into())).collect()),
-            peer_dependencies_meta: raw
-                .peer_dependencies_meta
-                .map(|m| m.into_iter().map(|(k, v)| (k, v.into())).collect()),
             scripts: raw
                 .scripts
                 .into_iter()
@@ -183,19 +158,6 @@ impl From<RawPnpmConfig> for PnpmConfig {
     fn from(raw: RawPnpmConfig) -> Self {
         Self {
             patched_dependencies: raw.patched_dependencies,
-            other: raw
-                .other
-                .into_iter()
-                .map(|(k, v)| (k.to_string(), v))
-                .collect(),
-        }
-    }
-}
-
-impl From<RawPeerDependencyMeta> for PeerDependencyMeta {
-    fn from(raw: RawPeerDependencyMeta) -> Self {
-        Self {
-            optional: raw.optional,
             other: raw
                 .other
                 .into_iter()
@@ -264,20 +226,11 @@ impl PackageJson {
             .chain(self.dev_dependencies.iter().flatten())
             .chain(self.optional_dependencies.iter().flatten())
             .map(|(name, version)| (name, version, DependencyKind::Normal));
-        let peer = self.peer_dependencies.iter().flatten().map(|(name, version)| {
-            let optional = self
-                .peer_dependencies_meta
-                .as_ref()
-                .and_then(|meta| meta.get(name))
-                .and_then(|meta| meta.optional)
-                .unwrap_or(false);
-            let kind = if optional {
-                DependencyKind::OptionalPeer
-            } else {
-                DependencyKind::Peer
-            };
-            (name, version, kind)
-        });
+        let peer = self
+            .peer_dependencies
+            .iter()
+            .flatten()
+            .map(|(name, version)| (name, version, DependencyKind::Peer));
         normal.chain(peer)
     }
 

--- a/crates/turborepo-repository/src/package_json.rs
+++ b/crates/turborepo-repository/src/package_json.rs
@@ -18,6 +18,7 @@ use turborepo_unescape::UnescapedString;
 pub enum DependencyKind {
     Normal,
     Peer,
+    OptionalPeer,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
@@ -37,6 +38,8 @@ pub struct PackageJson {
     pub optional_dependencies: Option<BTreeMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub peer_dependencies: Option<BTreeMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peer_dependencies_meta: Option<BTreeMap<String, PeerDependencyMeta>>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub scripts: BTreeMap<String, Spanned<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -60,6 +63,16 @@ pub struct PnpmConfig {
     pub other: BTreeMap<String, serde_json::Value>,
 }
 
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PeerDependencyMeta {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub optional: Option<bool>,
+    // Unstructured fields kept for round trip capabilities
+    #[serde(flatten)]
+    pub other: BTreeMap<String, serde_json::Value>,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserializable)]
 pub struct RawPackageJson {
     pub name: Option<Spanned<UnescapedString>>,
@@ -69,6 +82,7 @@ pub struct RawPackageJson {
     pub dev_dependencies: Option<BTreeMap<String, UnescapedString>>,
     pub optional_dependencies: Option<BTreeMap<String, UnescapedString>>,
     pub peer_dependencies: Option<BTreeMap<String, UnescapedString>>,
+    pub peer_dependencies_meta: Option<BTreeMap<String, RawPeerDependencyMeta>>,
     pub scripts: BTreeMap<String, Spanned<UnescapedString>>,
     pub resolutions: Option<BTreeMap<String, UnescapedString>>,
     pub pnpm: Option<RawPnpmConfig>,
@@ -82,6 +96,14 @@ pub struct RawPackageJson {
 pub struct RawPnpmConfig {
     pub patched_dependencies: Option<BTreeMap<String, RelativeUnixPathBuf>>,
     // Unstructured config options kept for round trip capabilities
+    #[deserializable(rest)]
+    pub other: BTreeMap<Text, serde_json::Value>,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Deserializable)]
+pub struct RawPeerDependencyMeta {
+    pub optional: Option<bool>,
+    // Unstructured fields kept for round trip capabilities
     #[deserializable(rest)]
     pub other: BTreeMap<Text, serde_json::Value>,
 }
@@ -135,6 +157,9 @@ impl From<RawPackageJson> for PackageJson {
             peer_dependencies: raw
                 .peer_dependencies
                 .map(|m| m.into_iter().map(|(k, v)| (k, v.into())).collect()),
+            peer_dependencies_meta: raw
+                .peer_dependencies_meta
+                .map(|m| m.into_iter().map(|(k, v)| (k, v.into())).collect()),
             scripts: raw
                 .scripts
                 .into_iter()
@@ -158,6 +183,19 @@ impl From<RawPnpmConfig> for PnpmConfig {
     fn from(raw: RawPnpmConfig) -> Self {
         Self {
             patched_dependencies: raw.patched_dependencies,
+            other: raw
+                .other
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v))
+                .collect(),
+        }
+    }
+}
+
+impl From<RawPeerDependencyMeta> for PeerDependencyMeta {
+    fn from(raw: RawPeerDependencyMeta) -> Self {
+        Self {
+            optional: raw.optional,
             other: raw
                 .other
                 .into_iter()
@@ -226,11 +264,20 @@ impl PackageJson {
             .chain(self.dev_dependencies.iter().flatten())
             .chain(self.optional_dependencies.iter().flatten())
             .map(|(name, version)| (name, version, DependencyKind::Normal));
-        let peer = self
-            .peer_dependencies
-            .iter()
-            .flatten()
-            .map(|(name, version)| (name, version, DependencyKind::Peer));
+        let peer = self.peer_dependencies.iter().flatten().map(|(name, version)| {
+            let optional = self
+                .peer_dependencies_meta
+                .as_ref()
+                .and_then(|meta| meta.get(name))
+                .and_then(|meta| meta.optional)
+                .unwrap_or(false);
+            let kind = if optional {
+                DependencyKind::OptionalPeer
+            } else {
+                DependencyKind::Peer
+            };
+            (name, version, kind)
+        });
         normal.chain(peer)
     }
 
@@ -274,6 +321,7 @@ mod test {
     #[test_case(json!({"devDependencies": { "turbo": "latest" }, "foo": "bar"}) ; "dev dependencies")]
     #[test_case(json!({"optionalDependencies": { "turbo": "latest" }, "foo": "bar"}) ; "optional dependencies")]
     #[test_case(json!({"peerDependencies": { "turbo": "latest" }, "foo": "bar"}) ; "peer dependencies")]
+    #[test_case(json!({"peerDependenciesMeta": { "turbo": { "optional": true } }, "foo": "bar"}) ; "peer dependencies meta")]
     #[test_case(json!({"scripts": { "build": "turbo build" }, "foo": "bar"}) ; "scripts")]
     #[test_case(json!({"resolutions": { "turbo": "latest" }, "foo": "bar"}) ; "resolutions")]
     fn test_roundtrip(json: serde_json::Value) {


### PR DESCRIPTION
## Why

Turborepo should not treat `peerDependencies` as package graph inputs. Peers are supplied by consumers and should not create workspace build-order edges, participate in cycle detection, or influence package graph external dependency metadata.

This fixes a regression where pure peer back-edges could make otherwise valid monorepos fail with circular package dependency errors.

## What

- Ignore peer dependencies during package graph dependency splitting.
- Preserve normal dependency behavior for `dependencies`, `devDependencies`, and `optionalDependencies`.
- Add regression coverage for internal peer back-edges and external peer declarations.

## How

Run:

```sh
cargo test -p turborepo-repository
```

Manual reproduction:

1. Create a workspace where `app` depends on `lib` and `lib` declares `app` only as a peer.
2. Configure `build` with `dependsOn: ["^build"]`.
3. Run `turbo run build`.

Expected result: Turbo builds `lib` before `app` and does not report a package dependency cycle.
