### PR TITLE
feat: Add --shard, --max-shards, and --max-nodes-per-shard to turbo run

### DIFF
--- a/crates/turborepo-engine/src/lib.rs
+++ b/crates/turborepo-engine/src/lib.rs
@@ -47,7 +47,7 @@ use thiserror::Error;
 use turborepo_errors::Spanned;
 use turborepo_repository::package_graph::PackageName;
 use turborepo_task_id::TaskId;
-use turborepo_types::{EngineInfo, TaskDefinition};
+use turborepo_types::{EngineInfo, ShardSpec, ShardSummary, ShardingSummary, TaskDefinition};
 pub use validate::{TaskDefinitionResult, validate_task_name};
 
 /// Trait for types that provide task definition information needed by the
@@ -111,6 +111,22 @@ impl TryFrom<TaskNode> for TaskId<'static> {
             TaskNode::Task(id) => Ok(id),
         }
     }
+}
+
+/// The result of dividing the task graph into shards.
+///
+/// Carries both the serializable [`ShardingSummary`] (surfaced in run summaries
+/// / `--dry=json`) and the per-shard entry task sets needed to prune the engine
+/// down to a single selected shard.
+#[derive(Debug, Clone)]
+pub struct ShardingPlan {
+    /// Human/machine-readable summary of the sharding decision.
+    pub summary: ShardingSummary,
+    /// For each shard (indexed 0-based; shard `n` in the summary is
+    /// `shard_entry_tasks[n - 1]`), the set of entry (top-level requested)
+    /// tasks assigned to it. Pruning the engine to a shard means retaining
+    /// these tasks and their transitive dependencies.
+    pub shard_entry_tasks: Vec<HashSet<TaskId<'static>>>,
 }
 
 #[derive(Debug, Default)]
@@ -652,6 +668,216 @@ impl<T: TaskDefinitionInfo + Clone> Engine<Built, T> {
     /// Provides access to the task lookup map (task_id -> node index)
     pub fn task_lookup(&self) -> &HashMap<TaskId<'static>, petgraph::graph::NodeIndex> {
         &self.task_lookup
+    }
+
+    /// The "entry" tasks: the top-level tasks that nothing else depends on,
+    /// i.e. the sinks of the dependency DAG (the final outputs the user asked
+    /// for). Edges point from a dependent to its dependency, so an entry task
+    /// is a task node with no incoming edges. These are the units the sharder
+    /// distributes across shards; every other task is pulled into a shard as a
+    /// transitive dependency of one of these.
+    ///
+    /// (Note: the synthetic root is connected *from* the leaf tasks that have
+    /// no dependencies, so it is not an entry task and is skipped here.)
+    fn entrypoint_indices(&self) -> Vec<petgraph::graph::NodeIndex> {
+        self.task_graph
+            .node_indices()
+            .filter(|&idx| {
+                idx != self.root_index
+                    && matches!(self.task_graph.node_weight(idx), Some(TaskNode::Task(_)))
+                    && self
+                        .task_graph
+                        .neighbors_directed(idx, petgraph::Direction::Incoming)
+                        .next()
+                        .is_none()
+            })
+            .collect()
+    }
+
+    /// Forward (dependency) closure of a single task node: the node itself plus
+    /// every task it transitively depends on. Root is excluded. This is exactly
+    /// the set of tasks that must be present for the seed task to run.
+    fn dependency_closure(
+        &self,
+        seed: petgraph::graph::NodeIndex,
+    ) -> HashSet<petgraph::graph::NodeIndex> {
+        let mut set = HashSet::new();
+        depth_first_search(&self.task_graph, Some(seed), |event| {
+            if let DfsEvent::Discover(n, _) = event
+                && n != self.root_index
+            {
+                set.insert(n);
+            }
+        });
+        set
+    }
+
+    fn node_to_task_id(&self, idx: petgraph::graph::NodeIndex) -> Option<TaskId<'static>> {
+        match self.task_graph.node_weight(idx)? {
+            TaskNode::Task(id) => Some(id.clone()),
+            TaskNode::Root => None,
+        }
+    }
+
+    fn sorted_task_ids(
+        &self,
+        indices: impl IntoIterator<Item = petgraph::graph::NodeIndex>,
+    ) -> Vec<String> {
+        let mut ids: Vec<String> = indices
+            .into_iter()
+            .filter_map(|idx| self.node_to_task_id(idx).map(|id| id.to_string()))
+            .collect();
+        ids.sort();
+        ids
+    }
+
+    /// Divides the task graph into shards according to `spec`.
+    ///
+    /// Sharding distributes the *entry* tasks (top-level requested tasks) and
+    /// pulls each entry's transitive dependencies into the same shard so every
+    /// shard is independently runnable. A dependency shared by entries in
+    /// different shards therefore lands in each of those shards; this
+    /// duplication is reported via `shared_tasks`.
+    ///
+    /// Balancing strategy:
+    /// - `MaxShards(k)`: at most `k` shards (capped by the number of entries).
+    ///   Entries are placed into the currently least-loaded shard, heaviest
+    ///   first (LPT / greedy multiway partitioning), balancing node counts.
+    /// - `MaxNodesPerShard(p)`: as many shards as needed so each holds at most
+    ///   `p` task nodes. Entries are bin-packed heaviest-first (first-fit
+    ///   decreasing). A single entry whose closure already exceeds `p` gets its
+    ///   own shard.
+    ///
+    /// Node counts used for balancing are per-entry dependency-closure sizes,
+    /// which over-count shared dependencies; this is an intentional, simple
+    /// heuristic. The reported `task_count`/`tasks` reflect the true,
+    /// de-duplicated shard contents.
+    pub fn compute_sharding(&self, spec: ShardSpec) -> ShardingPlan {
+        // Entries, sorted deterministically by task id so sharding is stable
+        // across runs.
+        let mut entries: Vec<(TaskId<'static>, petgraph::graph::NodeIndex)> = self
+            .entrypoint_indices()
+            .into_iter()
+            .filter_map(|idx| self.node_to_task_id(idx).map(|id| (id, idx)))
+            .collect();
+        entries.sort_by_key(|(id, _)| id.to_string());
+
+        let closures: Vec<HashSet<petgraph::graph::NodeIndex>> = entries
+            .iter()
+            .map(|(_, idx)| self.dependency_closure(*idx))
+            .collect();
+        let weights: Vec<usize> = closures.iter().map(|c| c.len()).collect();
+        let num_entries = entries.len();
+
+        let (limit, assignment, num_shards) = match spec {
+            ShardSpec::MaxShards(k) => {
+                let k = k.max(1);
+                let num_shards = if num_entries == 0 {
+                    0
+                } else {
+                    k.min(num_entries)
+                };
+                let mut assignment = vec![0usize; num_entries];
+                if num_shards > 0 {
+                    // Heaviest entries first.
+                    let mut order: Vec<usize> = (0..num_entries).collect();
+                    order.sort_by(|&a, &b| {
+                        weights[b]
+                            .cmp(&weights[a])
+                            .then_with(|| entries[a].0.to_string().cmp(&entries[b].0.to_string()))
+                    });
+                    let mut loads = vec![0usize; num_shards];
+                    for entry in order {
+                        // Least-loaded shard, ties broken by lowest index.
+                        let shard = (0..num_shards).min_by_key(|&s| (loads[s], s)).unwrap_or(0);
+                        assignment[entry] = shard;
+                        loads[shard] += weights[entry];
+                    }
+                }
+                (k, assignment, num_shards)
+            }
+            ShardSpec::MaxNodesPerShard(p) => {
+                let p = p.max(1);
+                let mut assignment = vec![0usize; num_entries];
+                let mut loads: Vec<usize> = Vec::new();
+                // Heaviest entries first.
+                let mut order: Vec<usize> = (0..num_entries).collect();
+                order.sort_by(|&a, &b| {
+                    weights[b]
+                        .cmp(&weights[a])
+                        .then_with(|| entries[a].0.to_string().cmp(&entries[b].0.to_string()))
+                });
+                for entry in order {
+                    let fit = loads.iter().position(|&load| load + weights[entry] <= p);
+                    let shard = match fit {
+                        Some(s) => s,
+                        None => {
+                            loads.push(0);
+                            loads.len() - 1
+                        }
+                    };
+                    assignment[entry] = shard;
+                    loads[shard] += weights[entry];
+                }
+                (p, assignment, loads.len())
+            }
+        };
+
+        // Build each shard's node set as the union of its entries' closures.
+        let mut shard_nodes: Vec<HashSet<petgraph::graph::NodeIndex>> =
+            vec![HashSet::new(); num_shards];
+        let mut shard_entry_indices: Vec<Vec<petgraph::graph::NodeIndex>> =
+            vec![Vec::new(); num_shards];
+        let mut shard_entry_tasks: Vec<HashSet<TaskId<'static>>> = vec![HashSet::new(); num_shards];
+        for (entry, shard) in assignment.iter().copied().enumerate() {
+            shard_nodes[shard].extend(closures[entry].iter().copied());
+            shard_entry_indices[shard].push(entries[entry].1);
+            shard_entry_tasks[shard].insert(entries[entry].0.clone());
+        }
+
+        // Count how many shards each node appears in to find shared deps.
+        let mut shard_count: HashMap<petgraph::graph::NodeIndex, usize> = HashMap::new();
+        for nodes in &shard_nodes {
+            for &node in nodes {
+                *shard_count.entry(node).or_default() += 1;
+            }
+        }
+        let is_shared = |idx: petgraph::graph::NodeIndex| -> bool {
+            shard_count.get(&idx).is_some_and(|&c| c > 1)
+        };
+
+        let shared_indices: Vec<petgraph::graph::NodeIndex> = shard_count
+            .iter()
+            .filter_map(|(&n, &c)| (c > 1).then_some(n))
+            .collect();
+        let shared_tasks = self.sorted_task_ids(shared_indices);
+
+        let shards: Vec<ShardSummary> = (0..num_shards)
+            .map(|s| {
+                let tasks = self.sorted_task_ids(shard_nodes[s].iter().copied());
+                let shared =
+                    self.sorted_task_ids(shard_nodes[s].iter().copied().filter(|&n| is_shared(n)));
+                ShardSummary {
+                    index: s + 1,
+                    entry_tasks: self.sorted_task_ids(shard_entry_indices[s].iter().copied()),
+                    task_count: tasks.len(),
+                    tasks,
+                    shared_tasks: shared,
+                }
+            })
+            .collect();
+
+        ShardingPlan {
+            summary: ShardingSummary {
+                strategy: spec.strategy(),
+                limit,
+                total_shards: num_shards,
+                selected_shard: None,
+                shards,
+                shared_tasks,
+            },
+            shard_entry_tasks,
+        }
     }
 }
 
@@ -1230,6 +1456,125 @@ impl turborepo_task_executor::TaskWarningCollector for TaskWarningCollectorWrapp
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .push(warning);
+        }
+    }
+}
+
+#[cfg(test)]
+mod sharding_tests {
+    use turborepo_types::ShardSpec;
+
+    use super::*;
+
+    /// Builds a fan-in graph with four independent `test` sinks, each
+    /// depending on its own `#build` plus one `shared#build` dependency:
+    ///
+    ///   {a,b,c,d}#test ── depend on ──> {a,b,c,d}#build
+    ///                  └─ depend on ──> shared#build
+    ///
+    /// Entry tasks (no dependents) are the four `#test` tasks; each has a
+    /// dependency closure of size 3 (`X#test`, `X#build`, `shared#build`).
+    fn build_fan_in_engine() -> Engine {
+        let mut engine: Engine<Building> = Engine::new();
+        let shared = TaskId::new("shared", "build");
+        let shared_idx = engine.get_index(&shared);
+        engine.add_definition(shared.clone(), TaskInfo::default());
+        engine.connect_to_root(&shared);
+
+        for pkg in ["a", "b", "c", "d"] {
+            let test = TaskId::new(pkg, "test");
+            let build = TaskId::new(pkg, "build");
+            let test_idx = engine.get_index(&test);
+            let build_idx = engine.get_index(&build);
+            engine.add_definition(test.clone(), TaskInfo::default());
+            engine.add_definition(build.clone(), TaskInfo::default());
+            // test depends on its own build and the shared build.
+            engine.task_graph_mut().add_edge(test_idx, build_idx, ());
+            engine.task_graph_mut().add_edge(test_idx, shared_idx, ());
+            // build has no deps, so it anchors to root.
+            engine.connect_to_root(&build);
+        }
+
+        engine.seal()
+    }
+
+    #[test]
+    fn entrypoints_are_the_sinks() {
+        let engine = build_fan_in_engine();
+        let mut entries: Vec<String> = engine
+            .entrypoint_indices()
+            .into_iter()
+            .filter_map(|idx| engine.node_to_task_id(idx).map(|id| id.to_string()))
+            .collect();
+        entries.sort();
+        assert_eq!(
+            entries,
+            vec!["a#test", "b#test", "c#test", "d#test"],
+            "only the test tasks (no dependents) are entries"
+        );
+    }
+
+    #[test]
+    fn max_shards_balances_and_reports_shared() {
+        let engine = build_fan_in_engine();
+        let plan = engine.compute_sharding(ShardSpec::MaxShards(2));
+        let summary = &plan.summary;
+
+        assert_eq!(summary.strategy, "maxShards");
+        assert_eq!(summary.limit, 2);
+        assert_eq!(summary.total_shards, 2);
+        assert_eq!(summary.selected_shard, None);
+        // 4 entries split evenly across 2 shards.
+        assert_eq!(summary.shards.len(), 2);
+        for shard in &summary.shards {
+            assert_eq!(shard.entry_tasks.len(), 2);
+            // {X#test, X#build, Y#test, Y#build, shared#build} == 5
+            assert_eq!(shard.task_count, 5);
+            assert!(shard.tasks.contains(&"shared#build".to_string()));
+            assert!(shard.shared_tasks.contains(&"shared#build".to_string()));
+        }
+        // shared#build is the only task in more than one shard.
+        assert_eq!(summary.shared_tasks, vec!["shared#build".to_string()]);
+
+        // Every entry is assigned to exactly one shard.
+        let total_entries: usize = plan.shard_entry_tasks.iter().map(|s| s.len()).sum();
+        assert_eq!(total_entries, 4);
+    }
+
+    #[test]
+    fn max_shards_is_capped_by_entry_count() {
+        let engine = build_fan_in_engine();
+        // Asking for more shards than entries yields one shard per entry.
+        let plan = engine.compute_sharding(ShardSpec::MaxShards(100));
+        assert_eq!(plan.summary.total_shards, 4);
+        for shard in &plan.summary.shards {
+            assert_eq!(shard.entry_tasks.len(), 1);
+        }
+    }
+
+    #[test]
+    fn max_nodes_per_shard_packs_entries() {
+        let engine = build_fan_in_engine();
+        // Each entry's closure weight is 3, so a limit of 6 packs two entries
+        // per shard (2 shards total).
+        let plan = engine.compute_sharding(ShardSpec::MaxNodesPerShard(6));
+        assert_eq!(plan.summary.strategy, "maxNodesPerShard");
+        assert_eq!(plan.summary.limit, 6);
+        assert_eq!(plan.summary.total_shards, 2);
+        for shard in &plan.summary.shards {
+            assert_eq!(shard.entry_tasks.len(), 2);
+        }
+    }
+
+    #[test]
+    fn max_nodes_per_shard_isolates_oversized_entries() {
+        let engine = build_fan_in_engine();
+        // A limit smaller than a single entry's closure (3) forces each entry
+        // into its own shard.
+        let plan = engine.compute_sharding(ShardSpec::MaxNodesPerShard(1));
+        assert_eq!(plan.summary.total_shards, 4);
+        for shard in &plan.summary.shards {
+            assert_eq!(shard.entry_tasks.len(), 1);
         }
     }
 }

--- a/crates/turborepo-engine/src/lib.rs
+++ b/crates/turborepo-engine/src/lib.rs
@@ -733,25 +733,33 @@ impl<T: TaskDefinitionInfo + Clone> Engine<Built, T> {
 
     /// Divides the task graph into shards according to `spec`.
     ///
-    /// Sharding distributes the *entry* tasks (top-level requested tasks) and
-    /// pulls each entry's transitive dependencies into the same shard so every
-    /// shard is independently runnable. A dependency shared by entries in
-    /// different shards therefore lands in each of those shards; this
-    /// duplication is reported via `shared_tasks`.
+    /// The unit of distribution is the set of *entry* tasks (task nodes with no
+    /// dependents). Each entry's transitive dependencies are pulled into its
+    /// shard so every shard is independently runnable. Because the graph is a
+    /// dependency graph, entries share large parts of their dependency closures
+    /// (e.g. when `test` depends on `^test`, sibling packages pull in the same
+    /// lower layers), so a naive split duplicates those shared layers into
+    /// every shard.
     ///
-    /// Balancing strategy:
-    /// - `MaxShards(k)`: at most `k` shards (capped by the number of entries).
-    ///   Entries are placed into the currently least-loaded shard, heaviest
-    ///   first (LPT / greedy multiway partitioning), balancing node counts.
+    /// To reduce that duplication, assignment is *overlap-aware*: entries whose
+    /// closures overlap are co-located so a shared dependency is duplicated
+    /// across as few shards as possible. Concretely we minimize, greedily, the
+    /// number of *new* nodes each entry adds to the shard it is placed in.
+    ///
+    /// - `MaxShards(k)`: at most `k` shards (capped by the entry count). Shards
+    ///   are seeded with `k` entries chosen farthest-first (each seed maximizes
+    ///   the new nodes it adds versus already-chosen seeds) so the shards start
+    ///   in different regions of the graph and none stays empty. Remaining
+    ///   entries, heaviest first, go to the shard they overlap most with,
+    ///   capped at `ceil(entries / k)` entries per shard for balance.
     /// - `MaxNodesPerShard(p)`: as many shards as needed so each holds at most
-    ///   `p` task nodes. Entries are bin-packed heaviest-first (first-fit
-    ///   decreasing). A single entry whose closure already exceeds `p` gets its
-    ///   own shard.
+    ///   `p` *distinct* task nodes. Entries (heaviest first) go to the existing
+    ///   shard they overlap most with that still fits under `p`; otherwise a
+    ///   new shard is opened. A single entry whose own closure exceeds `p` gets
+    ///   its own (over-sized) shard.
     ///
-    /// Node counts used for balancing are per-entry dependency-closure sizes,
-    /// which over-count shared dependencies; this is an intentional, simple
-    /// heuristic. The reported `task_count`/`tasks` reflect the true,
-    /// de-duplicated shard contents.
+    /// Overlap is measured on the true, de-duplicated shard node sets, so the
+    /// reported `task_count`/`total_task_instances` reflect actual duplication.
     pub fn compute_sharding(&self, spec: ShardSpec) -> ShardingPlan {
         // Entries, sorted deterministically by task id so sharding is stable
         // across runs.
@@ -766,10 +774,31 @@ impl<T: TaskDefinitionInfo + Clone> Engine<Built, T> {
             .iter()
             .map(|(_, idx)| self.dependency_closure(*idx))
             .collect();
-        let weights: Vec<usize> = closures.iter().map(|c| c.len()).collect();
         let num_entries = entries.len();
 
-        let (limit, assignment, num_shards) = match spec {
+        // Deterministic processing order: heaviest closures first, ties by id.
+        // Placing big entries first lets smaller, overlapping entries slot into
+        // the shard that already contains their dependencies.
+        let mut order: Vec<usize> = (0..num_entries).collect();
+        order.sort_by(|&a, &b| {
+            closures[b]
+                .len()
+                .cmp(&closures[a].len())
+                .then_with(|| entries[a].0.to_string().cmp(&entries[b].0.to_string()))
+        });
+
+        // Number of nodes in `closures[entry]` not already in `shard`.
+        let added_nodes = |shard: &HashSet<petgraph::graph::NodeIndex>, entry: usize| -> usize {
+            closures[entry]
+                .iter()
+                .filter(|n| !shard.contains(n))
+                .count()
+        };
+
+        let mut shard_nodes: Vec<HashSet<petgraph::graph::NodeIndex>> = Vec::new();
+        let mut shard_entries: Vec<Vec<usize>> = Vec::new();
+
+        let limit = match spec {
             ShardSpec::MaxShards(k) => {
                 let k = k.max(1);
                 let num_shards = if num_entries == 0 {
@@ -777,63 +806,109 @@ impl<T: TaskDefinitionInfo + Clone> Engine<Built, T> {
                 } else {
                     k.min(num_entries)
                 };
-                let mut assignment = vec![0usize; num_entries];
+
                 if num_shards > 0 {
-                    // Heaviest entries first.
-                    let mut order: Vec<usize> = (0..num_entries).collect();
-                    order.sort_by(|&a, &b| {
-                        weights[b]
-                            .cmp(&weights[a])
-                            .then_with(|| entries[a].0.to_string().cmp(&entries[b].0.to_string()))
-                    });
-                    let mut loads = vec![0usize; num_shards];
-                    for entry in order {
-                        // Least-loaded shard, ties broken by lowest index.
-                        let shard = (0..num_shards).min_by_key(|&s| (loads[s], s)).unwrap_or(0);
-                        assignment[entry] = shard;
-                        loads[shard] += weights[entry];
+                    // Farthest-first seeding: first seed is the largest closure,
+                    // each subsequent seed maximizes new coverage versus the
+                    // union of chosen seeds. Guarantees `num_shards` non-empty
+                    // shards spread across the graph.
+                    let mut chosen = vec![false; num_entries];
+                    let mut seed_union: HashSet<petgraph::graph::NodeIndex> = HashSet::new();
+                    let mut seeds: Vec<usize> = Vec::with_capacity(num_shards);
+                    while seeds.len() < num_shards {
+                        // Pick the not-yet-chosen entry (iterating in `order` for
+                        // determinism) that adds the most new nodes.
+                        let mut best: Option<usize> = None;
+                        let mut best_added = 0usize;
+                        for &entry in &order {
+                            if chosen[entry] {
+                                continue;
+                            }
+                            let added = added_nodes(&seed_union, entry);
+                            if best.is_none() || added > best_added {
+                                best = Some(entry);
+                                best_added = added;
+                            }
+                        }
+                        let seed = best.unwrap_or(order[seeds.len()]);
+                        chosen[seed] = true;
+                        seed_union.extend(closures[seed].iter().copied());
+                        seeds.push(seed);
+                    }
+
+                    shard_nodes = seeds.iter().map(|&e| closures[e].clone()).collect();
+                    shard_entries = seeds.iter().map(|&e| vec![e]).collect();
+
+                    // Balance: cap entries per shard.
+                    let cap = num_entries.div_ceil(num_shards);
+                    for &entry in &order {
+                        if chosen[entry] {
+                            continue;
+                        }
+                        // Place in the under-cap shard the entry overlaps most
+                        // with (fewest new nodes); ties to the smaller shard.
+                        let mut best: Option<usize> = None;
+                        let mut best_key = (usize::MAX, usize::MAX);
+                        for s in 0..shard_nodes.len() {
+                            if shard_entries[s].len() >= cap {
+                                continue;
+                            }
+                            let key = (added_nodes(&shard_nodes[s], entry), shard_nodes[s].len());
+                            if key < best_key {
+                                best_key = key;
+                                best = Some(s);
+                            }
+                        }
+                        let s = best.unwrap_or(0);
+                        shard_nodes[s].extend(closures[entry].iter().copied());
+                        shard_entries[s].push(entry);
                     }
                 }
-                (k, assignment, num_shards)
+                k
             }
             ShardSpec::MaxNodesPerShard(p) => {
                 let p = p.max(1);
-                let mut assignment = vec![0usize; num_entries];
-                let mut loads: Vec<usize> = Vec::new();
-                // Heaviest entries first.
-                let mut order: Vec<usize> = (0..num_entries).collect();
-                order.sort_by(|&a, &b| {
-                    weights[b]
-                        .cmp(&weights[a])
-                        .then_with(|| entries[a].0.to_string().cmp(&entries[b].0.to_string()))
-                });
-                for entry in order {
-                    let fit = loads.iter().position(|&load| load + weights[entry] <= p);
-                    let shard = match fit {
-                        Some(s) => s,
-                        None => {
-                            loads.push(0);
-                            loads.len() - 1
+                for &entry in &order {
+                    // Best-overlap existing shard that still fits under `p`.
+                    let mut best: Option<usize> = None;
+                    let mut best_added = usize::MAX;
+                    for (s, shard) in shard_nodes.iter().enumerate() {
+                        let added = added_nodes(shard, entry);
+                        if shard.len() + added > p {
+                            continue;
                         }
-                    };
-                    assignment[entry] = shard;
-                    loads[shard] += weights[entry];
+                        if added < best_added {
+                            best_added = added;
+                            best = Some(s);
+                        }
+                    }
+                    match best {
+                        Some(s) => {
+                            shard_nodes[s].extend(closures[entry].iter().copied());
+                            shard_entries[s].push(entry);
+                        }
+                        None => {
+                            // Doesn't fit anywhere (or graph is empty of shards):
+                            // open a new shard, even if this single entry's
+                            // closure already exceeds `p`.
+                            shard_nodes.push(closures[entry].clone());
+                            shard_entries.push(vec![entry]);
+                        }
+                    }
                 }
-                (p, assignment, loads.len())
+                p
             }
         };
 
-        // Build each shard's node set as the union of its entries' closures.
-        let mut shard_nodes: Vec<HashSet<petgraph::graph::NodeIndex>> =
-            vec![HashSet::new(); num_shards];
-        let mut shard_entry_indices: Vec<Vec<petgraph::graph::NodeIndex>> =
-            vec![Vec::new(); num_shards];
-        let mut shard_entry_tasks: Vec<HashSet<TaskId<'static>>> = vec![HashSet::new(); num_shards];
-        for (entry, shard) in assignment.iter().copied().enumerate() {
-            shard_nodes[shard].extend(closures[entry].iter().copied());
-            shard_entry_indices[shard].push(entries[entry].1);
-            shard_entry_tasks[shard].insert(entries[entry].0.clone());
-        }
+        let num_shards = shard_nodes.len();
+        let shard_entry_indices: Vec<Vec<petgraph::graph::NodeIndex>> = shard_entries
+            .iter()
+            .map(|es| es.iter().map(|&e| entries[e].1).collect())
+            .collect();
+        let shard_entry_tasks: Vec<HashSet<TaskId<'static>>> = shard_entries
+            .iter()
+            .map(|es| es.iter().map(|&e| entries[e].0.clone()).collect())
+            .collect();
 
         // Count how many shards each node appears in to find shared deps.
         let mut shard_count: HashMap<petgraph::graph::NodeIndex, usize> = HashMap::new();
@@ -867,11 +942,18 @@ impl<T: TaskDefinitionInfo + Clone> Engine<Built, T> {
             })
             .collect();
 
+        // total_tasks: distinct tasks across all shards (the work that must run
+        // once). total_task_instances: sum of shard sizes (with duplication).
+        let total_tasks = shard_count.len();
+        let total_task_instances: usize = shard_nodes.iter().map(|nodes| nodes.len()).sum();
+
         ShardingPlan {
             summary: ShardingSummary {
                 strategy: spec.strategy(),
                 limit,
                 total_shards: num_shards,
+                total_tasks,
+                total_task_instances,
                 selected_shard: None,
                 shards,
                 shared_tasks,
@@ -1576,5 +1658,72 @@ mod sharding_tests {
         for shard in &plan.summary.shards {
             assert_eq!(shard.entry_tasks.len(), 1);
         }
+    }
+
+    /// Two groups of entries; entries within a group share a deep subtree but
+    /// the groups share nothing:
+    ///
+    ///   a1#test, a2#test ──> libA#typecheck ──> libA#build
+    ///   b1#test, b2#test ──> libB#typecheck ──> libB#build
+    fn build_two_cluster_engine() -> Engine {
+        let mut engine: Engine<Building> = Engine::new();
+        for (lib, entries) in [("libA", ["a1", "a2"]), ("libB", ["b1", "b2"])] {
+            let lib_build = TaskId::new(lib, "build").into_owned();
+            let lib_check = TaskId::new(lib, "typecheck").into_owned();
+            let lib_build_idx = engine.get_index(&lib_build);
+            let lib_check_idx = engine.get_index(&lib_check);
+            engine.add_definition(lib_build.clone(), TaskInfo::default());
+            engine.add_definition(lib_check.clone(), TaskInfo::default());
+            engine
+                .task_graph_mut()
+                .add_edge(lib_check_idx, lib_build_idx, ());
+            engine.connect_to_root(&lib_build);
+
+            for pkg in entries {
+                let test = TaskId::new(pkg, "test").into_owned();
+                let test_idx = engine.get_index(&test);
+                engine.add_definition(test.clone(), TaskInfo::default());
+                engine
+                    .task_graph_mut()
+                    .add_edge(test_idx, lib_check_idx, ());
+            }
+        }
+        engine.seal()
+    }
+
+    #[test]
+    fn overlap_aware_clustering_avoids_duplication() {
+        let engine = build_two_cluster_engine();
+        let plan = engine.compute_sharding(ShardSpec::MaxShards(2));
+        let summary = &plan.summary;
+
+        assert_eq!(summary.total_shards, 2);
+        // 6 distinct tasks: a1,a2,b1,b2 tests + libA{build,typecheck} +
+        // libB{build,typecheck} = 4 + 2 + 2 = 8.
+        assert_eq!(summary.total_tasks, 8);
+        // Clustering the two groups onto separate shards duplicates nothing, so
+        // instances == distinct tasks. A naive size-balanced split (e.g.
+        // a1+b1 / a2+b2) would duplicate both lib subtrees, giving 12.
+        assert_eq!(
+            summary.total_task_instances, 8,
+            "overlap-aware clustering should add no duplicated work"
+        );
+        assert!(
+            summary.shared_tasks.is_empty(),
+            "no task should span both shards: {:?}",
+            summary.shared_tasks
+        );
+
+        // Each group's two entries must land together.
+        let shard_of = |task: &str| -> usize {
+            summary
+                .shards
+                .iter()
+                .position(|s| s.entry_tasks.iter().any(|t| t == task))
+                .expect("entry assigned to a shard")
+        };
+        assert_eq!(shard_of("a1#test"), shard_of("a2#test"));
+        assert_eq!(shard_of("b1#test"), shard_of("b2#test"));
+        assert_ne!(shard_of("a1#test"), shard_of("b1#test"));
     }
 }

--- a/crates/turborepo-lib/src/cli/args.rs
+++ b/crates/turborepo-lib/src/cli/args.rs
@@ -1046,6 +1046,7 @@ impl ExecutionArgs {
 #[derive(Parser, Clone, Debug, PartialEq)]
 #[command(groups = [
     ArgGroup::new("daemon-group").multiple(false).required(false),
+    ArgGroup::new("shard-spec-group").multiple(false).required(false),
 ])]
 pub struct RunArgs {
     /// Set the cache behavior for this run. Pass a list of comma-separated key,
@@ -1112,6 +1113,23 @@ pub struct RunArgs {
     /// (`persistent`, `with`) instead.
     #[clap(long)]
     pub parallel: bool,
+
+    /// Execute only the given shard of the task graph (1-based). Requires
+    /// `--max-shards` or `--max-nodes-per-shard` to determine how many shards
+    /// the graph is divided into.
+    #[clap(long, requires = "shard-spec-group")]
+    pub shard: Option<usize>,
+
+    /// Divide the task graph into at most this many shards, balancing the
+    /// number of tasks across them. Mutually exclusive with
+    /// `--max-nodes-per-shard`.
+    #[clap(long, group = "shard-spec-group")]
+    pub max_shards: Option<usize>,
+
+    /// Divide the task graph into as many shards as needed so each shard holds
+    /// at most this many task nodes. Mutually exclusive with `--max-shards`.
+    #[clap(long, group = "shard-spec-group")]
+    pub max_nodes_per_shard: Option<usize>,
 }
 
 impl Default for RunArgs {
@@ -1131,6 +1149,9 @@ impl Default for RunArgs {
             remote_cache_read_only: None,
             summarize: None,
             parallel: false,
+            shard: None,
+            max_shards: None,
+            max_nodes_per_shard: None,
         }
     }
 }

--- a/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__turbo_long_help.snap
+++ b/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__turbo_long_help.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/turborepo-lib/src/cli/mod.rs
+source: crates/turborepo-lib/src/cli/test.rs
 expression: "String::from_utf8(buf).unwrap()"
 ---
 The build system that makes ship happen
@@ -182,6 +182,15 @@ Run Arguments:
 
       --parallel
           [DEPRECATED] Execute all tasks in parallel. Use task configuration (`persistent`, `with`) instead
+
+      --shard <SHARD>
+          Execute only the given shard of the task graph (1-based). Requires `--max-shards` or `--max-nodes-per-shard` to determine how many shards the graph is divided into
+
+      --max-shards <MAX_SHARDS>
+          Divide the task graph into at most this many shards, balancing the number of tasks across them. Mutually exclusive with `--max-nodes-per-shard`
+
+      --max-nodes-per-shard <MAX_NODES_PER_SHARD>
+          Divide the task graph into as many shards as needed so each shard holds at most this many task nodes. Mutually exclusive with `--max-shards`
 
       --cache-dir <CACHE_DIR>
           Override the filesystem cache directory

--- a/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__turbo_short_help.snap
+++ b/crates/turborepo-lib/src/cli/snapshots/turborepo_lib__cli__test__turbo_short_help.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/turborepo-lib/src/cli/mod.rs
+source: crates/turborepo-lib/src/cli/test.rs
 expression: "String::from_utf8(buf).unwrap()"
 ---
 The build system that makes ship happen
@@ -115,6 +115,12 @@ Run Arguments:
           Generate a summary of the turbo run [possible values: true, false]
       --parallel
           [DEPRECATED] Execute all tasks in parallel. Use task configuration (`persistent`, `with`) instead
+      --shard <SHARD>
+          Execute only the given shard of the task graph (1-based). Requires `--max-shards` or `--max-nodes-per-shard` to determine how many shards the graph is divided into
+      --max-shards <MAX_SHARDS>
+          Divide the task graph into at most this many shards, balancing the number of tasks across them. Mutually exclusive with `--max-nodes-per-shard`
+      --max-nodes-per-shard <MAX_NODES_PER_SHARD>
+          Divide the task graph into as many shards as needed so each shard holds at most this many task nodes. Mutually exclusive with `--max-shards`
       --cache-dir <CACHE_DIR>
           Override the filesystem cache directory
       --concurrency <CONCURRENCY>

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -7,8 +7,8 @@ use turborepo_api_client::APIAuth;
 use turborepo_cache::{CacheOpts, RemoteCacheOpts};
 use turborepo_types::{
     APIClientOpts, ContinueMode, DryRunMode, EnvMode, GraphOpts, LogOrder, LogPrefix, RepoOpts,
-    ResolvedLogOrder, ResolvedLogPrefix, RunCacheOpts, RunOptsInfo, ScopeOpts, TaskArgs, TuiOpts,
-    UIMode,
+    ResolvedLogOrder, ResolvedLogPrefix, RunCacheOpts, RunOptsInfo, ScopeOpts, ShardSpec,
+    ShardingSummary, TaskArgs, TuiOpts, UIMode,
 };
 
 use crate::{
@@ -417,6 +417,15 @@ pub struct RunOpts {
     pub summarize: bool,
     pub is_github_actions: bool,
     pub ui_mode: UIMode,
+    /// Which shard to execute (1-based), if `--shard` was passed.
+    pub(crate) shard: Option<usize>,
+    /// How to divide the task graph into shards, if `--max-shards` or
+    /// `--max-nodes-per-shard` was passed.
+    #[serde(skip)]
+    pub(crate) shard_spec: Option<ShardSpec>,
+    /// Summary of the sharding decision, computed against the task graph during
+    /// run building. Surfaced in `--summarize` / `--dry=json` output.
+    pub(crate) sharding: Option<ShardingSummary>,
 }
 
 impl RunOpts {
@@ -491,10 +500,25 @@ impl<'a> TryFrom<OptsInputs<'a>> for RunOpts {
             log_order
         };
 
+        let shard_spec = match (
+            inputs.run_args.max_shards,
+            inputs.run_args.max_nodes_per_shard,
+        ) {
+            (Some(n), None) => Some(ShardSpec::MaxShards(n)),
+            (None, Some(n)) => Some(ShardSpec::MaxNodesPerShard(n)),
+            (None, None) => None,
+            // clap's `shard-spec-group` (multiple(false)) enforces that at most
+            // one of these is set.
+            (Some(_), Some(_)) => unreachable!("--max-shards and --max-nodes-per-shard conflict"),
+        };
+
         Ok(Self {
             tasks: inputs.execution_args.tasks.clone(),
             log_prefix,
             log_order,
+            shard: inputs.run_args.shard,
+            shard_spec,
+            sharding: None,
             summarize: inputs.config.run_summary(),
             framework_inference: inputs.execution_args.framework_inference,
             concurrency,
@@ -716,6 +740,10 @@ impl RunOptsInfo for RunOpts {
     fn tasks(&self) -> &[String] {
         &self.tasks
     }
+
+    fn sharding(&self) -> Option<&ShardingSummary> {
+        self.sharding.as_ref()
+    }
 }
 
 impl<'a> From<OptsInputs<'a>> for TuiOpts {
@@ -889,6 +917,9 @@ mod test {
             summarize: false,
             is_github_actions: false,
             daemon: None,
+            shard: None,
+            shard_spec: None,
+            sharding: None,
         };
         let cache_opts = CacheOpts {
             cache_dir: ".turbo/cache".into(),

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -419,7 +419,7 @@ impl RunBuilder {
 
     #[tracing::instrument(skip(self, signal_handler))]
     pub async fn build(
-        self,
+        mut self,
         signal_handler: &SignalHandler,
         telemetry: CommandEventBuilder,
     ) -> Result<(Run, Option<AnalyticsHandle>), Error> {
@@ -799,6 +799,42 @@ impl RunBuilder {
                 &root_turbo_json,
                 &scm,
             )?;
+        }
+
+        // Sharding: divide the task graph into shards and, if a specific shard
+        // was selected via --shard, prune the engine down to it. Runs after all
+        // other filtering so shards reflect the tasks that would actually run.
+        if let Some(spec) = self.opts.run_opts.shard_spec {
+            let plan = engine.compute_sharding(spec);
+            let mut summary = plan.summary;
+            let selected = self.opts.run_opts.shard;
+
+            if let Some(selected) = selected {
+                if summary.total_shards == 0 {
+                    return Err(Error::NoShards);
+                }
+                if selected < 1 || selected > summary.total_shards {
+                    return Err(Error::ShardOutOfRange {
+                        requested: selected,
+                        total: summary.total_shards,
+                    });
+                }
+                summary.selected_shard = Some(selected);
+                // Prune to the selected shard's entry tasks; retain_filtered_tasks
+                // re-derives the same transitive-dependency closure used to build
+                // the shard, so the executed engine matches the shard summary.
+                if let Some(entry_tasks) = plan.shard_entry_tasks.get(selected - 1) {
+                    engine = engine.retain_filtered_tasks(entry_tasks);
+                }
+                tracing::info!(
+                    selected_shard = selected,
+                    total_shards = summary.total_shards,
+                    strategy = summary.strategy,
+                    "pruned task graph to selected shard"
+                );
+            }
+
+            self.opts.run_opts.sharding = Some(summary);
         }
 
         // Validate after all filtering so the persistent task count reflects

--- a/crates/turborepo-lib/src/run/error.rs
+++ b/crates/turborepo-lib/src/run/error.rs
@@ -77,4 +77,11 @@ pub enum Error {
     GlobalFileHashTaskIncomplete,
     #[error("Affected range was not configured")]
     MissingAffectedRange,
+    #[error(
+        "--shard {requested} is out of range: the task graph was divided into {total} shard(s) \
+         (valid range is 1..={total})"
+    )]
+    ShardOutOfRange { requested: usize, total: usize },
+    #[error("--shard was requested but the task graph produced no shards (no tasks to run)")]
+    NoShards,
 }

--- a/crates/turborepo-run-summary/src/tracker.rs
+++ b/crates/turborepo-run-summary/src/tracker.rs
@@ -17,7 +17,9 @@ use turborepo_env::EnvironmentVariableMap;
 use turborepo_repository::package_graph::{PackageGraph, PackageName};
 use turborepo_scm::SCM;
 use turborepo_task_id::TaskId;
-use turborepo_types::{DryRunMode, EngineInfo, EnvMode, HashTrackerInfo, RunOptsInfo};
+use turborepo_types::{
+    DryRunMode, EngineInfo, EnvMode, HashTrackerInfo, RunOptsInfo, ShardingSummary,
+};
 use turborepo_ui::{BOLD, BOLD_CYAN, ColorConfig, GREY, color, cprintln, cwriteln};
 
 use crate::{
@@ -72,6 +74,8 @@ pub struct RunSummary<'a> {
     packages: Vec<&'a PackageName>,
     env_mode: EnvMode,
     framework_inference: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sharding: Option<&'a ShardingSummary>,
     tasks: Vec<TaskSummary>,
     user: String,
     scm: SCMState,
@@ -190,6 +194,7 @@ impl RunTracker {
             execution: Some(execution_summary),
             env_mode: global_env_mode,
             framework_inference: run_opts.framework_inference(),
+            sharding: run_opts.sharding(),
             tasks,
             global_hash_summary,
             scm: scm_state,
@@ -328,6 +333,8 @@ pub struct SinglePackageRunSummary<'a> {
     global_hash_summary: &'a GlobalHashSummary<'a>,
     env_mode: EnvMode,
     framework_inference: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sharding: Option<&'a ShardingSummary>,
     tasks: Vec<SinglePackageTaskSummary>,
     user: &'a str,
     pub scm: &'a SCMState,
@@ -351,6 +358,7 @@ impl<'a> From<&'a RunSummary<'a>> for SinglePackageRunSummary<'a> {
             global_hash_summary: &run_summary.global_hash_summary,
             env_mode: run_summary.env_mode,
             framework_inference: run_summary.framework_inference,
+            sharding: run_summary.sharding,
             tasks,
             user: &run_summary.user,
             scm: &run_summary.scm,

--- a/crates/turborepo-types/src/lib.rs
+++ b/crates/turborepo-types/src/lib.rs
@@ -196,6 +196,14 @@ pub struct ShardingSummary {
     pub limit: usize,
     /// Total number of shards the graph was divided into.
     pub total_shards: usize,
+    /// Number of distinct tasks in the graph being sharded (the work that must
+    /// run exactly once).
+    pub total_tasks: usize,
+    /// Sum of every shard's task count. Because shards duplicate shared
+    /// dependencies, this is >= `total_tasks`; the gap is wasted/duplicated
+    /// work. Lower is more efficient. `total_task_instances / total_tasks` is
+    /// the average number of shards a task lands in.
+    pub total_task_instances: usize,
     /// The shard selected to execute (1-based), if `--shard` was provided.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub selected_shard: Option<usize>,

--- a/crates/turborepo-types/src/lib.rs
+++ b/crates/turborepo-types/src/lib.rs
@@ -152,6 +152,79 @@ impl fmt::Display for DryRunMode {
     }
 }
 
+/// How to divide the task graph into shards.
+///
+/// Exactly one of these can be specified at a time (enforced at the CLI layer).
+/// Both are used as an upper bound that the sharder balances against:
+/// - `MaxShards`: produce at most this many shards, balancing node counts
+///   across them.
+/// - `MaxNodesPerShard`: produce as many shards as needed so that each shard
+///   holds at most this many task nodes.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ShardSpec {
+    /// Produce at most `n` shards.
+    MaxShards(usize),
+    /// Each shard holds at most `n` task nodes.
+    MaxNodesPerShard(usize),
+}
+
+impl ShardSpec {
+    /// A short, stable identifier for how the shard count was derived. Used in
+    /// the run summary so consumers can understand the sharding strategy.
+    pub fn strategy(&self) -> &'static str {
+        match self {
+            ShardSpec::MaxShards(_) => "maxShards",
+            ShardSpec::MaxNodesPerShard(_) => "maxNodesPerShard",
+        }
+    }
+}
+
+/// Summary of how the task graph was divided into shards.
+///
+/// Because the task graph is a dependency graph, splitting it means a single
+/// task (a shared dependency) can land in more than one shard — every shard
+/// that contains a task which (transitively) depends on it must also contain
+/// it so the shard is independently runnable. `shared_tasks` makes that
+/// duplication visible.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ShardingSummary {
+    /// How the shard count was derived: `maxShards` or `maxNodesPerShard`.
+    pub strategy: &'static str,
+    /// The numeric value supplied for `strategy` (the max-shards or
+    /// max-nodes-per-shard bound).
+    pub limit: usize,
+    /// Total number of shards the graph was divided into.
+    pub total_shards: usize,
+    /// The shard selected to execute (1-based), if `--shard` was provided.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_shard: Option<usize>,
+    /// Per-shard breakdown.
+    pub shards: Vec<ShardSummary>,
+    /// Task ids that appear in more than one shard (shared dependencies),
+    /// sorted. A surfaced view of the unavoidable duplication that comes from
+    /// splitting a dependency graph.
+    pub shared_tasks: Vec<String>,
+}
+
+/// Summary of a single shard.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ShardSummary {
+    /// 1-based shard index.
+    pub index: usize,
+    /// The top-level (requested) tasks assigned to this shard, sorted.
+    pub entry_tasks: Vec<String>,
+    /// Every task in this shard: the entry tasks plus all of their transitive
+    /// dependencies, sorted.
+    pub tasks: Vec<String>,
+    /// Number of tasks in this shard.
+    pub task_count: usize,
+    /// Tasks in this shard that also appear in at least one other shard,
+    /// sorted.
+    pub shared_tasks: Vec<String>,
+}
+
 /// Enable use of the UI for `turbo`.
 ///
 /// Documentation: https://turborepo.dev/docs/reference/configuration#ui
@@ -1066,6 +1139,11 @@ pub trait RunOptsInfo {
     fn pass_through_args(&self) -> &[String];
     /// Returns the list of task names being run
     fn tasks(&self) -> &[String];
+    /// Returns the sharding summary when `--shard`/`--max-shards`/
+    /// `--max-nodes-per-shard` divided the task graph, None otherwise.
+    fn sharding(&self) -> Option<&ShardingSummary> {
+        None
+    }
 }
 
 /// Trait for accessing task hash tracking information.

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -193,16 +193,26 @@ into independently runnable shards so a large run can be split across machines.
   entry, so each shard is self-contained.
 - Because a dependency shared by entries in different shards must appear in
   every shard that needs it, splitting necessarily duplicates shared
-  dependencies across shards. This duplication is surfaced as `sharedTasks` in
-  the run summary (per-shard and overall).
+  dependencies. Entries typically overlap heavily (e.g. when `test` depends on
+  `^test`, sibling packages pull in the same lower layers), so assignment is
+  **overlap-aware**: entries whose dependency closures overlap are co-located so
+  a shared task is duplicated across as few shards as possible. The heuristic
+  greedily minimizes the number of *new* nodes each entry adds to its shard.
 - `compute_sharding(ShardSpec)` returns a `ShardingPlan` (summary + per-shard
-  entry task sets). Balancing is greedy on per-entry dependency-closure size:
-  - `--max-shards N`: at most `N` shards (capped by the entry count); entries
-    are placed heaviest-first into the least-loaded shard (LPT).
-  - `--max-nodes-per-shard N`: as many shards as needed for each to hold at most
-    `N` nodes; entries are bin-packed first-fit-decreasing. A single entry whose
-    closure already exceeds `N` gets its own shard.
+  entry task sets):
+  - `--max-shards N`: at most `N` shards (capped by the entry count). Shards are
+    seeded farthest-first (each seed maximizes new nodes vs. chosen seeds) so
+    they start in different graph regions and none stays empty; remaining
+    entries go to the shard they overlap most with, capped at
+    `ceil(entries / N)` entries per shard for balance.
+  - `--max-nodes-per-shard N`: as many shards as needed so each holds at most
+    `N` *distinct* nodes. Entries go to the best-overlap shard that still fits;
+    otherwise a new shard opens. A single entry whose closure exceeds `N` gets
+    its own over-sized shard.
   `--max-shards` and `--max-nodes-per-shard` are mutually exclusive.
+- The summary reports efficiency directly: `totalTasks` (distinct work),
+  `totalTaskInstances` (sum of shard sizes — the gap is duplicated work), plus
+  per-shard and overall `sharedTasks`.
 - When `--shard K` selects a shard, the run builder prunes the engine to that
   shard's entry tasks via `retain_filtered_tasks` (reusing the same
   dependency-closure logic), so the executed graph matches the shard summary.

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -182,6 +182,32 @@ The core task graph consists of:
   tasks, transitive dependents, and only cacheable upstream dependencies that can
   restore outputs without forcing non-cacheable tasks to rerun
 
+#### Sharding (`crates/turborepo-engine/src/lib.rs`)
+
+`--shard`, `--max-shards`, and `--max-nodes-per-shard` divide the task graph
+into independently runnable shards so a large run can be split across machines.
+
+- The unit of distribution is the set of *entry* tasks: task nodes with no
+  dependents (the sinks of the dependency DAG — the outputs the user asked for).
+  Every other task is pulled into a shard as a transitive dependency of an
+  entry, so each shard is self-contained.
+- Because a dependency shared by entries in different shards must appear in
+  every shard that needs it, splitting necessarily duplicates shared
+  dependencies across shards. This duplication is surfaced as `sharedTasks` in
+  the run summary (per-shard and overall).
+- `compute_sharding(ShardSpec)` returns a `ShardingPlan` (summary + per-shard
+  entry task sets). Balancing is greedy on per-entry dependency-closure size:
+  - `--max-shards N`: at most `N` shards (capped by the entry count); entries
+    are placed heaviest-first into the least-loaded shard (LPT).
+  - `--max-nodes-per-shard N`: as many shards as needed for each to hold at most
+    `N` nodes; entries are bin-packed first-fit-decreasing. A single entry whose
+    closure already exceeds `N` gets its own shard.
+  `--max-shards` and `--max-nodes-per-shard` are mutually exclusive.
+- When `--shard K` selects a shard, the run builder prunes the engine to that
+  shard's entry tasks via `retain_filtered_tasks` (reusing the same
+  dependency-closure logic), so the executed graph matches the shard summary.
+  Without `--shard`, the plan is reported but the full graph runs.
+
 ### 4. Task Visitor (`crates/turborepo-lib/src/task_graph/visitor/`)
 
 The task graph visitor handles task execution:


### PR DESCRIPTION
## What

Adds graph sharding to `turbo run`, letting a large run be split into independently-runnable pieces (e.g. to fan out across CI machines):

- `--max-shards N` — divide the task graph into at most `N` shards.
- `--max-nodes-per-shard N` — divide into as many shards as needed so each holds at most `N` distinct task nodes.
- `--shard K` — execute only shard `K` (1-based). Requires one of the two flags above to know the shard count.

`--max-shards` and `--max-nodes-per-shard` are mutually exclusive (enforced by clap).

## How it shards

The unit of distribution is the set of **entry** tasks: task nodes with no dependents — the sinks of the dependency DAG, i.e. the outputs the user actually asked for. Each entry's transitive dependencies are pulled into its shard so every shard is self-contained and runnable on its own.

Because the graph is a dependency graph, entries share large parts of their closures — when `test` depends on `^test`, sibling packages pull in the same lower layers. A naive split duplicates those shared layers into every shard. To avoid that, assignment is **overlap-aware**: entries whose closures overlap are co-located so a shared task is duplicated across as few shards as possible. The heuristic greedily minimizes the number of *new* nodes each entry adds to the shard it joins.

- `--max-shards`: shards are seeded farthest-first (each seed maximizes new nodes vs. already-chosen seeds, so shards start in different graph regions and none stays empty), then remaining entries go to the shard they overlap most with, capped at `ceil(entries / N)` entries per shard for balance.
- `--max-nodes-per-shard`: each entry goes to the best-overlap existing shard that still fits under the node cap; otherwise a new shard opens. A single entry whose own closure exceeds the cap gets its own over-sized shard.

When `--shard K` is given, the engine is pruned to that shard's entry tasks via the existing `retain_filtered_tasks` closure logic, so the executed graph exactly matches the shard summary. Without `--shard`, the plan is reported but the full graph runs.

## Visibility / efficiency

The sharding decision is serialized into the run summary under `sharding` (shown in `--summarize` and `--dry=json`): strategy, limit, total shards, the selected shard, and a per-shard breakdown of entry tasks, total tasks, and shared tasks. It also reports `totalTasks` (distinct work) and `totalTaskInstances` (sum of shard sizes), so the remaining duplication — and the benefit of overlap-aware clustering — is directly measurable.

## Validation

Verified against the `vercel/api` monorepo with `test` depending on `^test`/`^typecheck` (deep, heavily-overlapping closures) via `--dry=json`:
- `--max-shards=4` → 4 shards over 5471 distinct tasks; `totalTaskInstances` 11648 (duplication factor 2.13 vs. a worst case of 4.0 if every shard held everything).
- `--max-nodes-per-shard=4000` → 2 shards, each capped at exactly 4000 distinct nodes (factor 1.43).
- `--shard=K` → the executed task set exactly equals the reported shard-K task list.
- Error/conflict paths: both max flags together, `--shard` without a max flag, and an out-of-range `--shard` all fail with clear messages.

Unit tests cover entry detection, balancing + shared-task reporting, the entry-count cap, bin-packing (including oversized-entry isolation), and a crafted two-cluster graph where overlap-aware clustering yields zero avoidable duplication (8 instances) where a size-balanced split would duplicate both subtrees (12).