### PR TITLE
test: Add pnpm docker patch prune coverage

### DIFF
--- a/lockfile-tests/fixtures/pnpm-11-flat-patch/meta.json
+++ b/lockfile-tests/fixtures/pnpm-11-flat-patch/meta.json
@@ -3,5 +3,6 @@
   "packageManagerVersion": "pnpm@11.0.0-rc.5",
   "lockfileName": "pnpm-lock.yaml",
   "frozenInstallCommand": ["pnpm", "install", "--frozen-lockfile"],
+  "docker": true,
   "expectedFailures": []
 }

--- a/lockfile-tests/fixtures/pnpm-11-flat-patch/packages/b/package.json
+++ b/lockfile-tests/fixtures/pnpm-11-flat-patch/packages/b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "b",
+  "version": "0.0.0",
+  "private": true
+}

--- a/lockfile-tests/fixtures/pnpm-11-flat-patch/pnpm-lock.yaml
+++ b/lockfile-tests/fixtures/pnpm-11-flat-patch/pnpm-lock.yaml
@@ -17,6 +17,8 @@ importers:
         specifier: 3.0.1
         version: 3.0.1(patch_hash=14cc7ca69e60d7f134a084780497229ca84ff01fcd958298f26495bd6c120c6f)
 
+  packages/b: {}
+
 packages:
 
   is-number@6.0.0:


### PR DESCRIPTION
## Why

pnpm 11 rejects pruned docker output when pnpm-workspace.yaml patchedDependencies do not match the pruned lockfile. The lockfile fixture suite should cover the case where a pruned workspace graph contains none of the patched packages from the original workspace.

## What

Adds an unpatched workspace to the pnpm 11 patch fixture and runs that fixture in docker mode so check-lockfiles validates out/json for both retained and removed patch cases.

## How

Verified with:

- pnpm check-lockfiles --fixture pnpm-11-flat-patch --turbo-path ../target/debug/turbo
- cargo test -p turborepo-repository test_prune_workspace_yaml_patches
- pre-push hooks