### PR TITLE
fix: Preserve pnpm override-resolved prune deps

### DIFF
--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -462,9 +462,9 @@ impl PnpmLockfile {
             return Ok(Some(specifier));
         }
 
-        if resolved_specifier == override_specifier {
-            Ok(Some(resolved_version))
-        } else if self.has_package_by_parts(name, resolved_version, key_buf) {
+        if resolved_specifier == override_specifier
+            || self.has_package_by_parts(name, resolved_version, key_buf)
+        {
             Ok(Some(resolved_version))
         } else if self.has_package_by_parts(name, override_specifier, key_buf) {
             Ok(Some(override_specifier))

--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -464,6 +464,8 @@ impl PnpmLockfile {
 
         if resolved_specifier == override_specifier {
             Ok(Some(resolved_version))
+        } else if self.has_package_by_parts(name, resolved_version, key_buf) {
+            Ok(Some(resolved_version))
         } else if self.has_package_by_parts(name, override_specifier, key_buf) {
             Ok(Some(override_specifier))
         } else {
@@ -1136,6 +1138,64 @@ importers:
             !pruned_lockfile.importers.contains_key("apps/docs"),
             "pruned lockfile should still trim workspaces from the final document"
         );
+    }
+
+    #[test]
+    fn test_pnpm_v9_resolves_override_rewritten_importer_versions() {
+        let yaml = r#"lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false
+
+overrides:
+  ms@>=2.1.0: 2.0.0
+  picomatch@>=3.0.0 <4: 3.0.2
+
+importers:
+
+  .: {}
+
+  apps/web-inrange:
+    dependencies:
+      picomatch:
+        specifier: 3.0.2
+        version: 3.0.2
+
+  apps/web-override:
+    dependencies:
+      ms:
+        specifier: 2.0.0
+        version: 2.0.0
+
+packages:
+
+  ms@2.0.0:
+    resolution: {integrity: sha512-abc}
+
+  picomatch@3.0.2:
+    resolution: {integrity: sha512-def}
+
+snapshots:
+
+  ms@2.0.0: {}
+
+  picomatch@3.0.2: {}
+"#;
+
+        let lockfile = PnpmLockfile::from_bytes(yaml.as_bytes()).unwrap();
+
+        let in_range = lockfile
+            .resolve_package("apps/web-inrange", "picomatch", "^3.0.1")
+            .unwrap()
+            .expect("override-rewritten in-range specifier should resolve");
+        assert_eq!(in_range.key, "picomatch@3.0.2");
+
+        let out_of_range = lockfile
+            .resolve_package("apps/web-override", "ms", "^2.1.3")
+            .unwrap()
+            .expect("override-rewritten out-of-range specifier should resolve");
+        assert_eq!(out_of_range.key, "ms@2.0.0");
     }
 
     #[test]

--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -462,8 +462,12 @@ impl PnpmLockfile {
             return Ok(Some(specifier));
         }
 
-        if resolved_specifier == override_specifier
-            || self.has_package_by_parts(name, resolved_version, key_buf)
+        if resolved_specifier == override_specifier {
+            Ok(Some(resolved_version))
+        } else if self.has_package_by_parts(name, specifier, key_buf) {
+            Ok(Some(specifier))
+        } else if resolved_specifier == resolved_version
+            && self.has_package_by_parts(name, resolved_version, key_buf)
         {
             Ok(Some(resolved_version))
         } else if self.has_package_by_parts(name, override_specifier, key_buf) {
@@ -1196,6 +1200,71 @@ snapshots:
             .unwrap()
             .expect("override-rewritten out-of-range specifier should resolve");
         assert_eq!(out_of_range.key, "ms@2.0.0");
+    }
+
+    #[test]
+    fn test_pnpm_keeps_transitive_exact_version_when_importer_has_same_dep() {
+        let yaml = r#"lockfileVersion: 5.4
+
+importers:
+  packages/a:
+    specifiers:
+      ci-info: ^2.0.0
+      is-ci: ^3.0.1
+    dependencies:
+      ci-info: 2.0.0
+      is-ci: 3.0.1
+
+packages:
+  /ci-info/2.0.0:
+    resolution: {integrity: sha512-abc}
+
+  /ci-info/3.7.1:
+    resolution: {integrity: sha512-def}
+
+  /is-ci/3.0.1:
+    resolution: {integrity: sha512-ghi}
+    dependencies:
+      ci-info: 3.7.1
+"#;
+
+        let lockfile = PnpmLockfile::from_bytes(yaml.as_bytes()).unwrap();
+
+        let transitive = lockfile
+            .resolve_package("packages/a", "ci-info", "3.7.1")
+            .unwrap()
+            .expect("transitive exact version should resolve independently of importer range");
+        assert_eq!(transitive.key, "/ci-info/3.7.1");
+
+        let yaml = r#"lockfileVersion: '9.0'
+
+importers:
+  apps/api:
+    dependencies:
+      express:
+        specifier: 4.21.2
+        version: 4.21.2
+
+packages:
+  express@4.21.2:
+    resolution: {integrity: sha512-abc}
+
+  express@5.1.0:
+    resolution: {integrity: sha512-def}
+
+snapshots:
+  express@4.21.2: {}
+
+  express@5.1.0: {}
+"#;
+
+        let lockfile = PnpmLockfile::from_bytes(yaml.as_bytes()).unwrap();
+
+        let transitive = lockfile
+            .resolve_package("apps/api", "express", "5.1.0")
+            .unwrap()
+            .expect("transitive exact version should resolve independently of importer exact dep");
+        assert_eq!(transitive.key, "express@5.1.0");
     }
 
     #[test]

--- a/lockfile-tests/fixtures/pnpm-11-flat-patch/meta.json
+++ b/lockfile-tests/fixtures/pnpm-11-flat-patch/meta.json
@@ -3,5 +3,6 @@
   "packageManagerVersion": "pnpm@11.0.0-rc.5",
   "lockfileName": "pnpm-lock.yaml",
   "frozenInstallCommand": ["pnpm", "install", "--frozen-lockfile"],
+  "docker": true,
   "expectedFailures": []
 }

--- a/lockfile-tests/fixtures/pnpm-11-flat-patch/packages/b/package.json
+++ b/lockfile-tests/fixtures/pnpm-11-flat-patch/packages/b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "b",
+  "version": "0.0.0",
+  "private": true
+}

--- a/lockfile-tests/fixtures/pnpm-11-flat-patch/pnpm-lock.yaml
+++ b/lockfile-tests/fixtures/pnpm-11-flat-patch/pnpm-lock.yaml
@@ -17,6 +17,8 @@ importers:
         specifier: 3.0.1
         version: 3.0.1(patch_hash=14cc7ca69e60d7f134a084780497229ca84ff01fcd958298f26495bd6c120c6f)
 
+  packages/b: {}
+
 packages:
 
   is-number@6.0.0:

--- a/lockfile-tests/fixtures/pnpm-override-and-patches/apps/web-inrange/package.json
+++ b/lockfile-tests/fixtures/pnpm-override-and-patches/apps/web-inrange/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "web-inrange",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "picomatch": "^3.0.1"
+  }
+}

--- a/lockfile-tests/fixtures/pnpm-override-and-patches/apps/web-override/package.json
+++ b/lockfile-tests/fixtures/pnpm-override-and-patches/apps/web-override/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "web-override",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "ms": "^2.1.3"
+  }
+}

--- a/lockfile-tests/fixtures/pnpm-override-and-patches/meta.json
+++ b/lockfile-tests/fixtures/pnpm-override-and-patches/meta.json
@@ -1,0 +1,7 @@
+{
+  "packageManager": "pnpm",
+  "packageManagerVersion": "pnpm@11.2.2",
+  "lockfileName": "pnpm-lock.yaml",
+  "pruneTargets": ["web-inrange", "web-override"],
+  "docker": true
+}

--- a/lockfile-tests/fixtures/pnpm-override-and-patches/package.json
+++ b/lockfile-tests/fixtures/pnpm-override-and-patches/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "turbo-prune-pnpm11-lockfile-repro",
+  "private": true,
+  "packageManager": "pnpm@11.2.2"
+}

--- a/lockfile-tests/fixtures/pnpm-override-and-patches/packages/other/package.json
+++ b/lockfile-tests/fixtures/pnpm-override-and-patches/packages/other/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "other",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "is-odd": "3.0.1"
+  }
+}

--- a/lockfile-tests/fixtures/pnpm-override-and-patches/patches/is-odd@3.0.1.patch
+++ b/lockfile-tests/fixtures/pnpm-override-and-patches/patches/is-odd@3.0.1.patch
@@ -1,0 +1,10 @@
+diff --git a/index.js b/index.js
+index 79d1f22a8e7a27efb8841bb83cb682ea1ff3a59c..ce3722059108565de2de0676ff0ffcab2bc5813d 100644
+--- a/index.js
++++ b/index.js
+@@ -23,3 +23,5 @@ module.exports = function isOdd(value) {
+   return (n % 2) === 1;
+ };
+ 
++
++// repro: patched marker

--- a/lockfile-tests/fixtures/pnpm-override-and-patches/pnpm-lock.yaml
+++ b/lockfile-tests/fixtures/pnpm-override-and-patches/pnpm-lock.yaml
@@ -1,0 +1,64 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: false
+  dedupePeers: true
+  excludeLinksFromLockfile: false
+
+overrides:
+  ms@>=2.1.0: 2.0.0
+  picomatch@>=3.0.0 <4: 3.0.2
+
+patchedDependencies:
+  is-odd@3.0.1: 66290452f179b5d7f514e314e13e46caf04cf274071e5ca9db6508f272ed4a31
+
+importers:
+
+  .: {}
+
+  apps/web-inrange:
+    dependencies:
+      picomatch:
+        specifier: 3.0.2
+        version: 3.0.2
+
+  apps/web-override:
+    dependencies:
+      ms:
+        specifier: 2.0.0
+        version: 2.0.0
+
+  packages/other:
+    dependencies:
+      is-odd:
+        specifier: 3.0.1
+        version: 3.0.1(patch_hash=66290452f179b5d7f514e314e13e46caf04cf274071e5ca9db6508f272ed4a31)
+
+packages:
+
+  is-number@6.0.0:
+    resolution: {integrity: sha512-Wu1VHeILBK8KAWJUAiSZQX94GmOE45Rg6/538fKwiloUu21KncEkYGPqob2oSZ5mUT73vLGrHQjKw3KMPwfDzg==}
+    engines: {node: '>=0.10.0'}
+
+  is-odd@3.0.1:
+    resolution: {integrity: sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==}
+    engines: {node: '>=4'}
+
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
+  picomatch@3.0.2:
+    resolution: {integrity: sha512-cfDHL6LStTEKlNilboNtobT/kEa30PtAf2Q1OgszfrG/rpVl1xaFWT9ktfkS306GmHgmnad1Sw4wabhlvFtsTw==}
+    engines: {node: '>=10'}
+
+snapshots:
+
+  is-number@6.0.0: {}
+
+  is-odd@3.0.1(patch_hash=66290452f179b5d7f514e314e13e46caf04cf274071e5ca9db6508f272ed4a31):
+    dependencies:
+      is-number: 6.0.0
+
+  ms@2.0.0: {}
+
+  picomatch@3.0.2: {}

--- a/lockfile-tests/fixtures/pnpm-override-and-patches/pnpm-workspace.yaml
+++ b/lockfile-tests/fixtures/pnpm-override-and-patches/pnpm-workspace.yaml
@@ -1,0 +1,14 @@
+packages:
+  - apps/*
+  - packages/*
+
+autoInstallPeers: false
+dedupePeers: true
+allowUnusedPatches: true
+
+overrides:
+  ms@>=2.1.0: 2.0.0
+  picomatch@>=3.0.0 <4: 3.0.2
+
+patchedDependencies:
+  is-odd@3.0.1: patches/is-odd@3.0.1.patch

--- a/lockfile-tests/fixtures/pnpm-override-and-patches/turbo.json
+++ b/lockfile-tests/fixtures/pnpm-override-and-patches/turbo.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "tasks": {
+    "build": {}
+  }
+}


### PR DESCRIPTION
## Why

pnpm 11 frozen installs can reject `turbo prune --docker` output when pnpm rewrites importer specifiers because of workspace overrides. The pruned lockfile kept the importer entries but dropped their package nodes, producing missing dependency errors. The same reproduction also covers pruned workspace patch config mismatches from #13028.

Fixes #13027
Fixes #13028

## What

- Preserve package nodes reachable through pnpm importer `version` values when override-rewritten `specifier` values no longer match package.json ranges.
- Add a `check-lockfiles` pnpm 11 fixture that reproduces the override and patch cases from the issues.
- Keep the existing pnpm workspace patch pruning covered by the new end-to-end fixture.

## How

Added some tests:

- `cargo test -p turborepo-lockfiles test_pnpm_v9_resolves_override_rewritten_importer_versions`
- `pnpm --dir lockfile-tests check-lockfiles --fixture pnpm-override-and-patches --concurrency 1`