### PR TITLE
fix: Keep PTY stdin open for tasks

### DIFF
--- a/crates/turborepo-process/src/child/test.rs
+++ b/crates/turborepo-process/src/child/test.rs
@@ -942,6 +942,39 @@ async fn test_held_stdin_keeps_persistent_child_alive() {
 }
 
 #[tokio::test]
+async fn test_taken_pty_stdin_guard_keeps_persistent_child_alive() {
+    if !TEST_PTY {
+        return;
+    }
+    let script = find_script_dir().join_component("persistent_server.js");
+    let mut cmd = Command::new("node");
+    cmd.args([script.as_std_path()]);
+    cmd.open_stdin();
+    let mut child = Child::spawn(cmd, ShutdownStyle::Kill, Some(PtySize::default())).unwrap();
+
+    tokio::time::sleep(STARTUP_DELAY).await;
+
+    let stdin_guard = child.take_stdin();
+    assert!(
+        matches!(stdin_guard, Some(ChildStdin::Writable(_))),
+        "PTY child should return a writable stdin guard"
+    );
+
+    let result = tokio::time::timeout(Duration::from_secs(2), child.wait()).await;
+    assert!(
+        result.is_err(),
+        "child should still be alive while stdin is held"
+    );
+
+    drop(stdin_guard);
+
+    let exit = tokio::time::timeout(Duration::from_secs(5), child.wait())
+        .await
+        .expect("child should exit after stdin guard is dropped");
+    assert_matches!(exit, Some(ChildExit::Finished(Some(0))));
+}
+
+#[tokio::test]
 async fn test_non_pty_stdin_guard_keeps_persistent_child_alive() {
     let script = find_script_dir().join_component("persistent_server.js");
     let mut cmd = Command::new("node");

--- a/crates/turborepo-task-executor/src/exec.rs
+++ b/crates/turborepo-task-executor/src/exec.rs
@@ -458,10 +458,22 @@ where
             None
         };
 
-        // Close stdin for non-persistent tasks
-        if !self.takes_input && !self.manager.closing_stdin_ends_process() {
-            process.stdin();
-        }
+        // Close piped stdin for non-interactive tasks so tools that read stdin
+        // before starting don't hang. In PTY mode, keep stdin open without
+        // forwarding input: EOF on a PTY is observable and can shut down tools
+        // that treat it as a terminal/session close signal.
+        let _non_interactive_stdin_guard = if !self.takes_input {
+            if self.manager.use_pty() {
+                process.take_stdin()
+            } else if !self.manager.closing_stdin_ends_process() {
+                process.stdin();
+                None
+            } else {
+                None
+            }
+        } else {
+            None
+        };
 
         // Create output writer and pipe outputs.
         // The stdout_writer is scoped so that TaskHandleWriter drops before


### PR DESCRIPTION
## Why

Closes #13021

When Turbo runs tasks in a terminal, it attaches task output to a PTY. For non-interactive tasks, Turbo closed the PTY stdin side immediately. Some tools interpret PTY stdin EOF as the terminal/session ending, which can prematurely shut down internal servers used during a build. This caused Astro Cloudflare builds to dispose Miniflare during prerendering in #13021.

## What

Keep PTY stdin open for non-interactive tasks without forwarding user input. Preserve the existing behavior for non-PTY tasks by closing piped stdin so tools that wait for EOF before starting do not hang.

## How

Verified with:

- cargo test -p turborepo-task-executor
- cargo test -p turborepo-process test_taken_pty_stdin_guard_keeps_persistent_child_alive
- cargo test -p turborepo-process test_successful_task_cleans_up_long_lived_worker_after_output_drain
- script -q /dev/null /Users/anthonyshew/projects/open/turbo/target/debug/turbo run build in the #13021 Astro repro using Node 22

