### PR TITLE
fix: Add TUI pane padding before logs

### DIFF
--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -659,19 +659,23 @@ impl<W> App<W> {
 
     pub fn handle_mouse(&mut self, mut event: crossterm::event::MouseEvent) -> Result<(), Error> {
         // Only offset by table width if the sidebar is visible
-        let table_width = if self.preferences.is_task_list_visible() {
+        let has_sidebar = self.preferences.is_task_list_visible();
+        let table_width = if has_sidebar {
             self.size.task_list_width()
         } else {
             0
         };
+        let pane_left_padding = self.size.pane_left_padding_with_sidebar(has_sidebar);
         debug!("original mouse event: {event:?}, table_width: {table_width}");
         // Only handle mouse event if it happens inside of pane
         // We give a 1 cell buffer to make it easier to select the first column of a row
         if event.row > 0 && event.column >= table_width {
             // Subtract 1 from the y axis due to the title of the pane
             event.row -= 1;
-            // Subtract the width of the table
-            event.column -= table_width;
+            // Subtract the width of the table and the pane's link-safe left padding.
+            event.column = event
+                .column
+                .saturating_sub(table_width.saturating_add(pane_left_padding));
             debug!("translated mouse event: {event:?}");
 
             let task = self.get_full_task_mut()?;
@@ -1255,7 +1259,7 @@ fn update(
 }
 
 fn view<W>(app: &mut App<W>, f: &mut Frame) {
-    let cols = app.size.pane_cols();
+    let cols = app.size.rendered_pane_cols();
     let horizontal = if app.preferences.is_task_list_visible() {
         Layout::horizontal([Constraint::Fill(1), Constraint::Length(cols)])
     } else {

--- a/crates/turborepo-ui/src/tui/mod.rs
+++ b/crates/turborepo-ui/src/tui/mod.rs
@@ -28,6 +28,8 @@ use size::SizeInfo;
 pub use table::TaskTable;
 pub use term_output::TerminalOutput;
 
+const PANE_LEFT_PADDING_WITH_SIDEBAR: u16 = 1;
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("Failed to send event to TUI: {0}")]

--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -1,11 +1,12 @@
 use ratatui::{
+    prelude::Rect,
     style::{Modifier, Style, Stylize},
     text::Line,
     widgets::{Block, Widget},
 };
 use tui_term::widget::PseudoTerminal;
 
-use super::{TerminalOutput, app::LayoutSections};
+use super::{PANE_LEFT_PADDING_WITH_SIDEBAR, TerminalOutput, app::LayoutSections};
 
 const EXIT_INTERACTIVE_HINT: &str = "Ctrl-z - Stop interacting";
 const ENTER_INTERACTIVE_HINT: &str = "i - Interact";
@@ -92,7 +93,23 @@ impl<W> Widget for &TerminalPane<'_, W> {
             .title_bottom(self.footer());
 
         let term = PseudoTerminal::new(screen).block(block);
-        term.render(area, buf)
+        term.render(self.content_area(area), buf)
+    }
+}
+
+impl<W> TerminalPane<'_, W> {
+    fn content_area(&self, area: Rect) -> Rect {
+        let left_padding = if self.has_sidebar {
+            PANE_LEFT_PADDING_WITH_SIDEBAR
+        } else {
+            0
+        };
+
+        Rect {
+            x: area.x.saturating_add(left_padding),
+            width: area.width.saturating_sub(left_padding),
+            ..area
+        }
     }
 }
 
@@ -117,6 +134,28 @@ mod test {
         assert_eq!(
             String::from(pane.footer()),
             "   u/d - Scroll logs   U/D - Page logs   t/b - Jump to top/bottom"
+        );
+    }
+
+    #[test]
+    fn test_content_area_pads_when_sidebar_visible() {
+        let term: TerminalOutput<Vec<u8>> = TerminalOutput::new(16, 16, None, 2048);
+        let pane = TerminalPane::new(&term, "foo", &LayoutSections::TaskList, true);
+
+        assert_eq!(
+            pane.content_area(Rect::new(10, 0, 20, 10)),
+            Rect::new(11, 0, 19, 10)
+        );
+    }
+
+    #[test]
+    fn test_content_area_has_no_padding_when_sidebar_hidden() {
+        let term: TerminalOutput<Vec<u8>> = TerminalOutput::new(16, 16, None, 2048);
+        let pane = TerminalPane::new(&term, "foo", &LayoutSections::TaskList, false);
+
+        assert_eq!(
+            pane.content_area(Rect::new(10, 0, 20, 10)),
+            Rect::new(10, 0, 20, 10)
         );
     }
 }

--- a/crates/turborepo-ui/src/tui/size.rs
+++ b/crates/turborepo-ui/src/tui/size.rs
@@ -1,3 +1,4 @@
+use super::PANE_LEFT_PADDING_WITH_SIDEBAR;
 use crate::TaskTable;
 
 const PANE_SIZE_RATIO: f32 = 3.0 / 4.0;
@@ -33,7 +34,7 @@ impl SizeInfo {
     }
 
     pub fn task_list_width(&self) -> u16 {
-        self.cols - self.pane_cols()
+        self.cols.saturating_sub(self.rendered_pane_cols())
     }
 
     pub fn pane_cols(&self) -> u16 {
@@ -47,11 +48,56 @@ impl SizeInfo {
             let full_task_width = self.cols.saturating_sub(self.task_width_hint);
             full_task_width
                 .max(ratio_pane_width)
-                // We need to account for the left border of the pane
-                .saturating_sub(1)
+                // Account for the task list border and the spacer before pane content.
+                .saturating_sub(1 + PANE_LEFT_PADDING_WITH_SIDEBAR)
         } else {
             // When sidebar is hidden, pane takes full width minus border
             self.cols.saturating_sub(1)
         }
+    }
+
+    pub fn rendered_pane_cols(&self) -> u16 {
+        self.rendered_pane_cols_with_sidebar(true)
+    }
+
+    pub fn rendered_pane_cols_with_sidebar(&self, has_sidebar: bool) -> u16 {
+        self.pane_cols_with_sidebar(has_sidebar)
+            .saturating_add(if has_sidebar {
+                PANE_LEFT_PADDING_WITH_SIDEBAR
+            } else {
+                0
+            })
+    }
+
+    pub fn pane_left_padding_with_sidebar(&self, has_sidebar: bool) -> u16 {
+        if has_sidebar {
+            PANE_LEFT_PADDING_WITH_SIDEBAR
+        } else {
+            0
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_rendered_pane_includes_left_padding_when_sidebar_visible() {
+        let size = SizeInfo::new(20, 100, ["app-a#dev"].into_iter());
+
+        assert_eq!(size.rendered_pane_cols(), size.pane_cols() + 1);
+        assert_eq!(size.task_list_width() + size.rendered_pane_cols(), 100);
+    }
+
+    #[test]
+    fn test_rendered_pane_has_no_padding_when_sidebar_hidden() {
+        let size = SizeInfo::new(20, 100, ["app-a#dev"].into_iter());
+
+        assert_eq!(
+            size.rendered_pane_cols_with_sidebar(false),
+            size.pane_cols_with_sidebar(false)
+        );
+        assert_eq!(size.pane_left_padding_with_sidebar(false), 0);
     }
 }


### PR DESCRIPTION
## Why

Fixes https://github.com/vercel/turborepo/issues/12791.

VS Code's terminal local link detector can include the TUI task-list border in file links when task output starts immediately after the border, producing targets like `│apps/app-a/repro.js:2`. That target doesn't resolve, so clicking file links in TUI logs fails.

The relevant VS Code code paths are [here](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkParsing.ts). TL;DR: VSCode has a regex that doesn't care about pipe or pipe-like characters so it includes them in the link target.

For science, I tried seeing if other characters would work:
- ASCII `|` border: link parsing worked because VS Code excludes ASCII pipe, but the divider rendered as a broken/dashed text pipe and looked bad.
- Block-element border glyphs such as `▕`: looked tighter/worse against log text and still did not reliably break VS Code's link candidate.
- Zero-width separator after `│` using `U+200B`: visually preserved the border, but VS Code still included the invisible character in the resolved target, so file lookup failed.
- Zero-width JS-whitespace separator using `U+FEFF`: should have matched VS Code's `\s` boundary in theory, but xterm/VS Code did not preserve it in the line text used for resolution, so the candidate still behaved as broken.

Given those constraints, a real whitespace boundary is the only Turborepo-side fix that works while preserving the box-drawing border. I'm okay with this, as it visually looks better, anyway.

## What

Adds one rendered spacer column between the task-list border and the task log pane when the sidebar is visible.

Other considerations:
- Keeps the task output PTY width unchanged relative to the actual log content area, so task output wrapping should not unexpectedly gain a column.
- Updates mouse coordinate translation to account for the rendered spacer, preserving pane selection and interaction behavior.

## How

Got the code authored and tried it in VSCode. It works. I also pulled up Ghostty just to see if anything strange would happen in my invariants, but just looks like there's an extra space now, as desired.

Added some unit tests to make sure things stay this way.