### PR TITLE
chore: Restore aarch64 musl release builds

### DIFF
--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -58,7 +58,9 @@ jobs:
             setup: "sudo apt-get install -y build-essential"
           - host: ubuntu-latest
             target: "aarch64-unknown-linux-musl"
-            rust-build-env: 'CC_aarch64_unknown_linux_musl=clang AR_aarch64_unknown_linux_musl=llvm-ar RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld"'
+            # clang sees glibc 2.39 headers when compiling aws-lc-sys C code,
+            # but the final static link uses musl, which only exports the base symbols.
+            rust-build-env: 'CC_aarch64_unknown_linux_musl=clang AR_aarch64_unknown_linux_musl=llvm-ar RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld -Clink-arg=--defsym=__isoc23_sscanf=sscanf -Clink-arg=--defsym=__isoc23_strtol=strtol"'
             setup: "sudo apt-get update && sudo apt-get install -y build-essential musl-tools clang llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu"
           - host: windows-latest
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -360,7 +360,9 @@ jobs:
             setup: "sudo apt-get update && sudo apt-get install -y build-essential clang lldb llvm libclang-dev curl musl-tools sudo unzip"
           - host: ubuntu-24.04
             target: "aarch64-unknown-linux-musl"
-            rust-build-env: 'CC_aarch64_unknown_linux_musl=clang AR_aarch64_unknown_linux_musl=llvm-ar RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld"'
+            # clang sees glibc 2.39 headers when compiling aws-lc-sys C code,
+            # but the final static link uses musl, which only exports the base symbols.
+            rust-build-env: 'CC_aarch64_unknown_linux_musl=clang AR_aarch64_unknown_linux_musl=llvm-ar RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld -Clink-arg=--defsym=__isoc23_sscanf=sscanf -Clink-arg=--defsym=__isoc23_strtol=strtol"'
             setup: "sudo apt-get update && sudo apt-get install -y build-essential musl-tools clang llvm gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu"
           - host: windows-2022
             target: x86_64-pc-windows-msvc


### PR DESCRIPTION
## Why

The release workflow is failing for the aarch64 musl binary after adding aws-lc-rs for P-521 certificate verification. The new C objects reference glibc C23 symbol names, but the final binary is statically linked against musl.

## What

Teach the aarch64 musl release and LSP Rust builds to alias the glibc C23 sscanf/strtol symbols back to the musl-exported symbols during the rust-lld link.

## How

Verified locally with workflow YAML parsing, cargo check, cargo tree confirming aws-lc-sys remains in the aarch64-unknown-linux-musl dependency graph, and the repository pre-push hooks.