### PR TITLE
docs: Remove ESM warning from gen page

### DIFF
--- a/apps/docs/content/docs/guides/generating-code.mdx
+++ b/apps/docs/content/docs/guides/generating-code.mdx
@@ -323,7 +323,7 @@ When running actions, Turborepo automatically injects a `turbo` object into the 
 In [Handlebars templates](https://plopjs.com/documentation/#built-in-actions), access the variables using double curly braces:
 
 ```hbs title="turbo/generators/templates/component.hbs"
-// Generated at {{turbo.paths.root}}/src/components
+// Generated at {{ turbo.paths.root }}/src/components
 ```
 
 #### Using in custom actions

--- a/apps/docs/content/docs/guides/generating-code.mdx
+++ b/apps/docs/content/docs/guides/generating-code.mdx
@@ -67,10 +67,6 @@ generators within a repo configured with Turborepo.
 4. TypeScript generators are supported with zero configuration
 5. `plop` is not required to be installed as a dependency of your repo
 
-<Callout type="info" title="Known issue">
-  ESM dependencies are not currently supported within custom generators.
-</Callout>
-
 ### Getting started
 
 To build and run a custom generator, run the following command from anywhere within your monorepo using Turborepo.
@@ -327,7 +323,7 @@ When running actions, Turborepo automatically injects a `turbo` object into the 
 In [Handlebars templates](https://plopjs.com/documentation/#built-in-actions), access the variables using double curly braces:
 
 ```hbs title="turbo/generators/templates/component.hbs"
-// Generated at {{ turbo.paths.root }}/src/components
+// Generated at {{turbo.paths.root}}/src/components
 ```
 
 #### Using in custom actions


### PR DESCRIPTION
### Description

These have worked for awhile now.
