### PR TITLE
fix: Defer hashes for JIT task dependents

### DIFF
--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -288,7 +288,24 @@ impl<'a> Visitor<'a> {
 
                     let task_env_mode = task_definition.env_mode.unwrap_or(self.global_env_mode);
 
-                    if task_definition.inputs.has_jit_inputs() {
+                    let dependency_set = engine
+                        .dependencies(task_id)
+                        .ok_or(Error::MissingDefinition)?;
+
+                    let has_deferred_dependency = {
+                        let map = results
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner());
+                        dependency_set.iter().any(|dependency| {
+                            let TaskNode::Task(dependency_task_id) = dependency else {
+                                return false;
+                            };
+
+                            matches!(map.get(dependency_task_id), Some(PrecomputedTask::Deferred))
+                        })
+                    };
+
+                    if task_definition.inputs.has_jit_inputs() || has_deferred_dependency {
                         if self.dry {
                             self.task_hasher.insert_deferred_hash(
                                 task_id,
@@ -298,10 +315,6 @@ impl<'a> Visitor<'a> {
                         }
                         return Ok(Some((task_id.clone(), PrecomputedTask::Deferred)));
                     }
-
-                    let dependency_set = engine
-                        .dependencies(task_id)
-                        .ok_or(Error::MissingDefinition)?;
 
                     let package_task_event =
                         PackageTaskEventBuilder::new(task_id.package(), task_id.task())
@@ -473,21 +486,38 @@ impl<'a> Visitor<'a> {
                             PackageTaskEventBuilder::new(info.package(), info.task())
                                 .with_parent(telemetry);
                         let task_hash_telemetry = package_task_event.child();
-                        let task_hash = match self.task_hasher.calculate_task_hash_with_jit_inputs(
-                            &info,
-                            task_definition,
-                            task_env_mode,
-                            workspace_info,
-                            &dependency_set,
-                            task_hash_telemetry,
-                            self.scm,
-                            self.repo_root,
-                            self.repo_index,
-                        ) {
-                            Ok(hash) => hash,
-                            Err(err) => {
-                                dispatch_error = Some(Error::TaskHash(err));
-                                break;
+                        let task_hash = if task_definition.inputs.has_jit_inputs() {
+                            match self.task_hasher.calculate_task_hash_with_jit_inputs(
+                                &info,
+                                task_definition,
+                                task_env_mode,
+                                workspace_info,
+                                &dependency_set,
+                                task_hash_telemetry,
+                                self.scm,
+                                self.repo_root,
+                                self.repo_index,
+                            ) {
+                                Ok(hash) => hash,
+                                Err(err) => {
+                                    dispatch_error = Some(Error::TaskHash(err));
+                                    break;
+                                }
+                            }
+                        } else {
+                            match self.task_hasher.calculate_task_hash(
+                                &info,
+                                task_definition,
+                                task_env_mode,
+                                workspace_info,
+                                &dependency_set,
+                                task_hash_telemetry,
+                            ) {
+                                Ok(hash) => hash,
+                                Err(err) => {
+                                    dispatch_error = Some(Error::TaskHash(err));
+                                    break;
+                                }
                             }
                         };
                         let execution_env =

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -192,7 +192,8 @@ The task graph visitor handles task execution:
 - Calculates task hashes. Most task hashes are precomputed before scheduling,
   but tasks with `$TURBO_JIT$` inputs defer final file-input hashing until the
   engine dispatches the task, after its dependencies have completed and restored
-  any cached outputs.
+  any cached outputs. Tasks that depend on deferred tasks are also deferred so
+  their dependency hashes are available before their own hash is calculated.
 - Creates `ExecContext` for each task
 - Manages UI output and progress tracking
 - Collects errors and execution information

--- a/crates/turborepo/tests/run_caching.rs
+++ b/crates/turborepo/tests/run_caching.rs
@@ -302,6 +302,72 @@ fn test_jit_inputs_hash_after_dependencies_complete() {
 }
 
 #[test]
+fn test_jit_dependency_defers_dependent_hashing() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+
+    fs::write(
+        tempdir.path().join("packages/util/package.json"),
+        r#"{
+  "name": "util"
+}
+"#,
+    )
+    .unwrap();
+
+    fs::write(
+        tempdir.path().join("apps/my-app/package.json"),
+        r#"{
+  "name": "my-app",
+  "scripts": {
+    "build": "node -e \"require('fs').mkdirSync('.output', { recursive: true }); require('fs').writeFileSync('.output/result.txt', 'built')\""
+  },
+  "dependencies": {
+    "util": "*"
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    fs::write(
+        tempdir.path().join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "tasks": {
+    "codegen": {
+      "dependsOn": ["^build"],
+      "cache": false
+    },
+    "build": {
+      "dependsOn": ["^build", "codegen"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!src/generated/**",
+        "$TURBO_JIT$/src/generated/**"
+      ],
+      "outputs": [".output/**"]
+    }
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "build", "--filter=my-app", "--output-logs=none"],
+    );
+
+    assert!(
+        output.status.success(),
+        "expected JIT-dependent task graph to succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn test_gitignored_output_deletion_restores_from_cache() {
     let tempdir = tempfile::tempdir().unwrap();
     setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();


### PR DESCRIPTION
## Why

Tasks that use `$TURBO_JIT$` defer final hash calculation until dispatch, after dependency outputs can exist. Dependents of those tasks also need to wait; otherwise precompute can try to read a dependency hash that has intentionally not been produced yet.

## What

Defers hash calculation for tasks whose dependency hash is deferred, then calculates non-JIT deferred hashes normally at dispatch time once dependencies have completed. Adds regression coverage for a task graph where a JIT task has a same-package dependent task and an upstream package without the target script.

## How

Run:

- `cargo test -p turbo --test run_caching`
- `cargo test -p turborepo-types jit_`