### PR TITLE
ci: Fetch version.txt via API in docs alias failure notification

### DIFF
--- a/.github/workflows/docs-alias-failure-notification.yml
+++ b/.github/workflows/docs-alias-failure-notification.yml
@@ -19,18 +19,19 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     steps:
-      - name: Checkout staging branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_branch }}
-
+      # Fetch version.txt via the API at the exact commit of the failed run
+      # instead of checking out the branch. This avoids checking out a ref by
+      # name (the staging branch may already be deleted by the failure cleanup
+      # job) and avoids putting any repo content on disk.
       - name: Get version
         id: version
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          if [ -f version.txt ]; then
-            IFS= read -r VERSION < version.txt
-
+          if CONTENT=$(gh api -H "Accept: application/vnd.github.raw+json" "repos/${{ github.repository }}/contents/version.txt?ref=${HEAD_SHA}"); then
+            IFS= read -r VERSION <<< "$CONTENT"
             if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
               printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
             else
@@ -38,6 +39,7 @@ jobs:
               echo "version=unknown" >> "$GITHUB_OUTPUT"
             fi
           else
+            echo "::warning::Could not fetch version.txt at ${HEAD_SHA}. Reporting unknown version."
             echo "version=unknown" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
### Why

Security audit (VULN-10701) flagged this workflow for checking out `github.event.workflow_run.head_branch` in a `workflow_run` context. The finding is not exploitable — the triggering "Release" workflow is `workflow_dispatch`-only, so `head_branch` is always a maintainer-created branch — but the checkout is unnecessary surface area. It also has a latent correctness bug: the Release workflow's failure cleanup deletes the staging branch, so by the time this notification workflow runs, the branch it tries to check out may no longer exist.

### What

- Remove `actions/checkout` entirely
- Fetch `version.txt` via `gh api` (raw content) pinned to `workflow_run.head_sha`, which is immutable and survives branch deletion
- Keep the existing semver validation and `unknown` fallback; add a fallback for when the API fetch itself fails

### How to verify

The fetch logic was tested against the live repo:

```bash
gh api -H "Accept: application/vnd.github.raw+json" \
  "repos/vercel/turborepo/contents/version.txt?ref=$(git rev-parse origin/main)"
# → 2.9.18-canary.0, passes the semver regex
```

End-to-end verification requires a failed Release run; the next docs-alias failure will exercise this path.