### PR TITLE
fix: Harden cache archive symlink restore

### DIFF
--- a/crates/turborepo-cache/src/cache_archive/restore.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore.rs
@@ -661,6 +661,43 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn restore_rejects_chained_symlink_escape() -> Result<()> {
+        let base_dir = tempdir()?;
+        let output_dir = base_dir.path().join("repo");
+        let outside_file = base_dir.path().join("pwned");
+        let tar = generate_raw_tar(&[
+            RawTarEntry::Directory { path: "sub" },
+            RawTarEntry::Symlink {
+                link_path: "sub/up",
+                link_target: "..",
+            },
+            RawTarEntry::Symlink {
+                link_path: "escape",
+                link_target: "sub/up/..",
+            },
+            RawTarEntry::File {
+                path: "escape/pwned",
+                body: b"should not escape".to_vec(),
+            },
+        ]);
+
+        let output_dir_path = output_dir.to_string_lossy();
+        let anchor = AbsoluteSystemPath::new(&output_dir_path)?;
+        let mut reader = CacheReader::from_reader(&tar[..], false)?;
+
+        let result = reader.restore(anchor, None);
+
+        assert!(result.is_err());
+        assert!(
+            !outside_file.exists(),
+            "chained symlink restore must not write outside anchor"
+        );
+
+        Ok(())
+    }
+
     #[test]
     fn test_windows_unsafe() -> Result<()> {
         let uncompressed_tar = include_bytes!("../../fixtures/windows-unsafe.tar");

--- a/crates/turborepo-cache/src/cache_archive/restore_directory.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore_directory.rs
@@ -206,32 +206,55 @@ fn check_path(
         return Ok(combined_path);
     }
 
-    // Check to see if the symlink targets outside of the originalAnchor.
-    // We don't do eval symlinks because we could find ourself in a totally
-    // different place.
-
-    // 1. Get the target.
+    // Check the real target of any existing path prefix so archive-created
+    // symlink chains cannot hide an escape behind lexical cleaning.
     let link_target = combined_path.read_link()?;
     debug!(
         "link source: {:?}, link target {:?}",
         combined_path, link_target
     );
-    if link_target.is_absolute() {
-        let absolute_link_target = AbsoluteSystemPathBuf::new(link_target.clone())?;
-        if path_clean::clean(&absolute_link_target).starts_with(original_anchor) {
-            return Ok(absolute_link_target);
-        }
+    let link_target_path = if link_target.is_absolute() {
+        AbsoluteSystemPathBuf::new(link_target.clone())?
     } else {
-        let relative_link_target = AnchoredSystemPath::new(link_target.as_str())?;
-        // We clean here to resolve the `..` and `.` segments.
-        let computed_target = path_clean::clean(accumulated_anchor.resolve(relative_link_target));
-        if computed_target.starts_with(original_anchor) {
-            return check_path(original_anchor, accumulated_anchor, relative_link_target);
-        }
+        accumulated_anchor.resolve(AnchoredSystemPath::new(link_target.as_str())?)
+    };
+
+    let real_anchor = original_anchor.to_realpath()?;
+    if let Some(real_target) = realpath_existing_prefix(&link_target_path)?
+        && !real_target.starts_with(&real_anchor)
+    {
+        return Err(CacheError::LinkOutsideOfDirectory(
+            link_target.to_string(),
+            Backtrace::capture(),
+        ));
+    }
+
+    let clean_target = link_target_path.clean()?;
+    if clean_target.starts_with(original_anchor) {
+        return Ok(clean_target);
     }
 
     Err(CacheError::LinkOutsideOfDirectory(
         link_target.to_string(),
         Backtrace::capture(),
     ))
+}
+
+pub(crate) fn realpath_existing_prefix(
+    path: &AbsoluteSystemPath,
+) -> Result<Option<AbsoluteSystemPathBuf>, CacheError> {
+    let mut candidate = path.as_path().to_path_buf();
+
+    loop {
+        let candidate_path = AbsoluteSystemPathBuf::try_from(candidate.as_std_path())?;
+        match candidate_path.to_realpath() {
+            Ok(realpath) => return Ok(Some(realpath)),
+            Err(err) if err.is_io_error(io::ErrorKind::NotFound) => {
+                if !candidate.pop() {
+                    return Ok(None);
+                }
+            }
+            Err(err) => return Err(err.into()),
+        }
+    }
 }

--- a/crates/turborepo-cache/src/cache_archive/restore_symlink.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore_symlink.rs
@@ -6,7 +6,10 @@ use turbopath::{
     PathError, UnknownPathType,
 };
 
-use crate::{CacheError, cache_archive::restore_directory::CachedDirTree};
+use crate::{
+    CacheError,
+    cache_archive::restore_directory::{CachedDirTree, realpath_existing_prefix},
+};
 
 pub fn restore_symlink(
     dir_cache: &mut CachedDirTree,
@@ -77,7 +80,38 @@ fn validate_linkname(
         ));
     }
 
+    let raw_linkname = raw_linkname_path(anchor, processed_name, linkname_str)?;
+    let real_anchor = anchor.to_realpath()?;
+    if let Some(real_target) = realpath_existing_prefix(&raw_linkname)?
+        && !real_target.starts_with(&real_anchor)
+    {
+        return Err(CacheError::LinkOutsideOfDirectory(
+            linkname_str.to_string(),
+            Backtrace::capture(),
+        ));
+    }
+
     Ok(processed_linkname)
+}
+
+fn raw_linkname_path(
+    anchor: &AbsoluteSystemPath,
+    processed_name: &AnchoredSystemPathBuf,
+    linkname: &str,
+) -> Result<AbsoluteSystemPathBuf, CacheError> {
+    if Utf8Path::new(linkname).is_absolute() {
+        return Ok(AbsoluteSystemPathBuf::new(linkname.to_string())?);
+    }
+
+    let source = anchor.resolve(processed_name);
+    let Some(parent) = source.parent() else {
+        return Err(CacheError::InvalidFilePath(
+            source.to_string(),
+            Backtrace::capture(),
+        ));
+    };
+
+    Ok(parent.resolve(AnchoredSystemPath::new(linkname)?))
 }
 
 fn is_windows_absolute_path(path: &str) -> bool {


### PR DESCRIPTION
## Why

Cache artifacts should not be able to restore files outside the repository root. This is a defense-in-depth hardening for cache archive extraction.

## What

Harden cache archive restore so symlink validation checks real resolved prefixes instead of relying only on lexically cleaned paths. This prevents chained symlinks from appearing in-root lexically while resolving outside the extraction anchor at runtime.

## How

- Added regression coverage for a chained archive symlink restore that attempts to write outside the repo boundary.
- Verified that valid in-root symlink usage and broken in-root symlinks continue to work.
- Ran `cargo test -p turborepo-cache`.