### PR TITLE
fix: Harden query server file access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5506,7 +5506,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower 0.5.2",
- "tower-http 0.6.8",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -6992,22 +6992,6 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
-dependencies = [
- "bitflags 2.10.0",
- "bytes",
- "http",
- "http-body",
- "http-body-util",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-http"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
@@ -8060,7 +8044,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "tower-http 0.5.2",
  "tracing",
  "turbo-trace",
  "turbopath",

--- a/crates/turborepo-query/Cargo.toml
+++ b/crates/turborepo-query/Cargo.toml
@@ -21,7 +21,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-tower-http = { version = "0.5.2", features = ["cors"] }
 tracing = { workspace = true }
 turbo-trace = { workspace = true }
 turbopath = { workspace = true }

--- a/crates/turborepo-query/src/file.rs
+++ b/crates/turborepo-query/src/file.rs
@@ -6,7 +6,7 @@ use miette::SourceCode;
 use turbo_trace::Tracer;
 use turbopath::AbsoluteSystemPathBuf;
 
-use crate::{Array, Diagnostic, Error, QueryRun};
+use crate::{confine_file_path, Array, Diagnostic, Error, QueryRun};
 
 pub struct File {
     run: Arc<dyn QueryRun>,
@@ -16,8 +16,7 @@ pub struct File {
 
 impl File {
     pub fn new(run: Arc<dyn QueryRun>, path: AbsoluteSystemPathBuf) -> Result<Self, Error> {
-        #[cfg(windows)]
-        let path = path.to_realpath()?;
+        let path = confine_file_path(run.repo_root(), path)?;
 
         Ok(Self {
             run,

--- a/crates/turborepo-query/src/lib.rs
+++ b/crates/turborepo-query/src/lib.rs
@@ -24,7 +24,7 @@ use package_graph::{Edge, PackageGraph};
 pub use server::run_server;
 use tokio::select;
 use turbo_trace::TraceError;
-use turbopath::AbsoluteSystemPathBuf;
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 pub use turborepo_query_api::{
     AffectedPackagesError, BoundariesFuture, QueryErrorLocation, QueryResult, QueryRun,
     SCHEMA_QUERY,
@@ -48,6 +48,8 @@ pub enum Error {
     NoSignalHandler,
     #[error("File `{0}` not found.")]
     FileNotFound(String),
+    #[error("File `{0}` is outside the repository root.")]
+    FileOutsideRepository(String),
     #[error("Package not found: {0}")]
     PackageNotFound(PackageName),
     #[error("Failed to serialize result: {0}")]
@@ -588,6 +590,33 @@ struct ChangedTask {
     task: task::RepositoryTask,
 }
 
+fn resolve_file_path(
+    repo_root: &AbsoluteSystemPath,
+    path: String,
+) -> Result<AbsoluteSystemPathBuf, Error> {
+    let abs_path = AbsoluteSystemPathBuf::from_unknown(repo_root, path);
+
+    confine_file_path(repo_root, abs_path)
+}
+
+pub(crate) fn confine_file_path(
+    repo_root: &AbsoluteSystemPath,
+    abs_path: AbsoluteSystemPathBuf,
+) -> Result<AbsoluteSystemPathBuf, Error> {
+    if !abs_path.exists() {
+        return Err(Error::FileNotFound(abs_path.to_string()));
+    }
+
+    let real_repo_root = repo_root.to_realpath()?;
+    let real_path = abs_path.to_realpath()?;
+
+    if !real_repo_root.contains(&real_path) {
+        return Err(Error::FileOutsideRepository(abs_path.to_string()));
+    }
+
+    Ok(real_path)
+}
+
 #[Object]
 impl RepositoryQuery {
     async fn affected_packages(
@@ -712,11 +741,7 @@ impl RepositoryQuery {
     }
 
     async fn file(&self, path: String) -> Result<file::File, Error> {
-        let abs_path = AbsoluteSystemPathBuf::from_unknown(self.run.repo_root(), path);
-
-        if !abs_path.exists() {
-            return Err(Error::FileNotFound(abs_path.to_string()));
-        }
+        let abs_path = resolve_file_path(self.run.repo_root(), path)?;
 
         file::File::new(self.run.clone(), abs_path)
     }
@@ -860,4 +885,74 @@ pub async fn execute_query(
         result_json,
         errors,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use turbopath::AbsoluteSystemPath;
+
+    use super::{resolve_file_path, Error};
+
+    #[test]
+    fn resolve_file_path_allows_repo_relative_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let file = tmp.path().join("package.json");
+        fs::write(&file, "{}").unwrap();
+
+        let resolved = resolve_file_path(root, "package.json".to_string()).unwrap();
+        let expected = AbsoluteSystemPath::from_std_path(&file)
+            .unwrap()
+            .to_realpath()
+            .unwrap();
+
+        assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn resolve_file_path_rejects_absolute_files_outside_repo() {
+        let tmp = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let outside_file = outside.path().join("secret.txt");
+        fs::write(&outside_file, "secret").unwrap();
+
+        let err = resolve_file_path(root, outside_file.to_string_lossy().to_string()).unwrap_err();
+
+        assert!(matches!(err, Error::FileOutsideRepository(_)));
+    }
+
+    #[test]
+    fn resolve_file_path_rejects_relative_traversal_outside_repo() {
+        let parent = tempfile::tempdir().unwrap();
+        let repo = parent.path().join("repo");
+        fs::create_dir(&repo).unwrap();
+        let outside_file = parent.path().join("secret.txt");
+        fs::write(&outside_file, "secret").unwrap();
+        let root = AbsoluteSystemPath::from_std_path(&repo).unwrap();
+
+        let err = resolve_file_path(root, "../secret.txt".to_string()).unwrap_err();
+
+        assert!(matches!(err, Error::FileOutsideRepository(_)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_file_path_rejects_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPath::from_std_path(tmp.path()).unwrap();
+        let outside_file = outside.path().join("secret.txt");
+        let link = tmp.path().join("link.txt");
+        fs::write(&outside_file, "secret").unwrap();
+        symlink(&outside_file, &link).unwrap();
+
+        let err = resolve_file_path(root, "link.txt".to_string()).unwrap_err();
+
+        assert!(matches!(err, Error::FileOutsideRepository(_)));
+    }
 }

--- a/crates/turborepo-query/src/server.rs
+++ b/crates/turborepo-query/src/server.rs
@@ -2,26 +2,72 @@ use std::sync::Arc;
 
 use async_graphql::{EmptyMutation, EmptySubscription, Schema};
 use async_graphql_axum::GraphQL;
-use axum::{http::Method, routing::get, Router};
+use axum::{
+    extract::Request,
+    http::{header::HOST, StatusCode},
+    middleware::{self, Next},
+    response::Response,
+    routing::get,
+    Router,
+};
 use tokio::net::TcpListener;
-use tower_http::cors::{Any, CorsLayer};
 
 use crate::{graphiql, QueryRun, RepositoryQuery};
 
-pub async fn run_server(run: Arc<dyn QueryRun>) -> std::io::Result<()> {
-    let cors = CorsLayer::new()
-        .allow_methods([Method::GET, Method::POST])
-        .allow_headers(Any)
-        .allow_origin(Any);
+fn is_allowed_host(host: &str) -> bool {
+    let host = match host.rsplit_once(':') {
+        Some((host, port)) if !host.contains(':') && port.chars().all(|c| c.is_ascii_digit()) => {
+            host
+        }
+        Some(_) => return false,
+        None => host,
+    };
 
+    matches!(host, "127.0.0.1" | "localhost")
+}
+
+async fn require_localhost_host(request: Request, next: Next) -> Result<Response, StatusCode> {
+    let allowed = request
+        .headers()
+        .get(HOST)
+        .and_then(|host| host.to_str().ok())
+        .is_some_and(is_allowed_host);
+
+    if !allowed {
+        return Err(StatusCode::FORBIDDEN);
+    }
+
+    Ok(next.run(request).await)
+}
+
+pub async fn run_server(run: Arc<dyn QueryRun>) -> std::io::Result<()> {
     let turbo_query = RepositoryQuery::new(run);
 
     let schema = Schema::new(turbo_query, EmptyMutation, EmptySubscription);
     let app = Router::new()
         .route("/", get(graphiql).post_service(GraphQL::new(schema)))
-        .layer(cors);
+        .layer(middleware::from_fn(require_localhost_host));
 
     axum::serve(TcpListener::bind("127.0.0.1:8000").await?, app).await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_allowed_host;
+
+    #[test]
+    fn allows_localhost_hosts() {
+        assert!(is_allowed_host("127.0.0.1:8000"));
+        assert!(is_allowed_host("localhost:8000"));
+    }
+
+    #[test]
+    fn rejects_non_localhost_hosts() {
+        assert!(!is_allowed_host("example.com:8000"));
+        assert!(!is_allowed_host("localhost.example.com:8000"));
+        assert!(!is_allowed_host("127.0.0.1:8000:extra"));
+        assert!(!is_allowed_host("127.0.0.1:not-a-port"));
+    }
 }

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -398,8 +398,8 @@ package/task graph).
 **Data flow:** `main()` constructs `Arc<TurboQueryServer>` → passes to
 `turborepo_lib::main` → threaded through `shim` → `cli::run` →
 `commands::run` → `RunBuilder` → `Run`.  The `Run` struct stores the
-`query_server` and uses it in `start_web_ui()` and the `turbo query`
-command handler.
+`query_server`; the `turbo query` command handler uses it for direct query
+execution and the local GraphQL server mode.
 
 ## Data Flow Overview
 


### PR DESCRIPTION
## Why

The local query server should only expose repository-scoped file data to trusted localhost requests. Binding to loopback is not enough when browsers can reach localhost services.

## What

Restricts the query server to localhost Host headers, removes permissive CORS, and canonicalizes GraphQL file paths before enforcing that returned files stay inside the repository root. Also updates stale query subsystem documentation.

## How

Verified with:

- `cargo test -p turborepo-query`
- `cargo check -p turborepo-query`

Manual checks confirmed localhost requests still work, non-local Host headers are rejected, CORS no longer grants arbitrary origins, repo files can be read, and outside paths are rejected.