### PR TITLE
fix: Strip special mode bits from cache restore

### DIFF
--- a/crates/turborepo-cache/src/cache_archive/restore.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore.rs
@@ -219,8 +219,17 @@ mod tests {
             path: &'static str,
             body: Vec<u8>,
         },
+        FileWithMode {
+            path: &'static str,
+            body: Vec<u8>,
+            mode: u32,
+        },
         Directory {
             path: &'static str,
+        },
+        DirectoryWithMode {
+            path: &'static str,
+            mode: u32,
         },
         Symlink {
             link_path: &'static str,
@@ -241,11 +250,25 @@ mod tests {
                         header.set_mode(0o644);
                         builder.append_data(&mut header, path, &body[..]).unwrap();
                     }
+                    RawTarEntry::FileWithMode { path, body, mode } => {
+                        let mut header = Header::new_gnu();
+                        header.set_size(body.len() as u64);
+                        header.set_entry_type(tar::EntryType::Regular);
+                        header.set_mode(*mode);
+                        builder.append_data(&mut header, path, &body[..]).unwrap();
+                    }
                     RawTarEntry::Directory { path } => {
                         let mut header = Header::new_gnu();
                         header.set_entry_type(tar::EntryType::Directory);
                         header.set_size(0);
                         header.set_mode(0o755);
+                        builder.append_data(&mut header, path, empty()).unwrap();
+                    }
+                    RawTarEntry::DirectoryWithMode { path, mode } => {
+                        let mut header = Header::new_gnu();
+                        header.set_entry_type(tar::EntryType::Directory);
+                        header.set_size(0);
+                        header.set_mode(*mode);
                         builder.append_data(&mut header, path, empty()).unwrap();
                     }
                     RawTarEntry::Symlink {
@@ -1907,6 +1930,59 @@ mod tests {
                     .symlink_metadata()?
                     .is_symlink()
             );
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_restore_regular_file_strips_special_mode_bits() -> Result<()> {
+            use std::os::unix::fs::PermissionsExt;
+
+            let output_dir = tempdir()?;
+            let output_dir_path = output_dir.path().to_string_lossy().into_owned();
+            let anchor = AbsoluteSystemPath::new(&output_dir_path)?;
+            let tar = generate_raw_tar(&[RawTarEntry::FileWithMode {
+                path: "helper",
+                body: b"payload".to_vec(),
+                mode: 0o7755,
+            }]);
+
+            let mut reader = CacheReader::from_reader(&tar[..], false)?;
+            reader.restore(anchor, None)?;
+
+            let mode = anchor
+                .join_component("helper")
+                .symlink_metadata()?
+                .permissions()
+                .mode()
+                & 0o7777;
+            assert_eq!(mode & 0o7000, 0);
+
+            Ok(())
+        }
+
+        #[test]
+        fn test_restore_directory_strips_special_mode_bits() -> Result<()> {
+            use std::os::unix::fs::PermissionsExt;
+
+            let output_dir = tempdir()?;
+            let output_dir_path = output_dir.path().to_string_lossy().into_owned();
+            let anchor = AbsoluteSystemPath::new(&output_dir_path)?;
+            let tar = generate_raw_tar(&[RawTarEntry::DirectoryWithMode {
+                path: "dist",
+                mode: 0o7755,
+            }]);
+
+            let mut reader = CacheReader::from_reader(&tar[..], false)?;
+            reader.restore(anchor, None)?;
+
+            let mode = anchor
+                .join_component("dist")
+                .symlink_metadata()?
+                .permissions()
+                .mode()
+                & 0o7777;
+            assert_eq!(mode & 0o7000, 0);
 
             Ok(())
         }

--- a/crates/turborepo-cache/src/cache_archive/restore_directory.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore_directory.rs
@@ -161,7 +161,7 @@ fn create_dir_all_with_mode(path: &AbsoluteSystemPath, mode: u32) -> io::Result<
 
     std::fs::DirBuilder::new()
         .recursive(true)
-        .mode(mode & 0o7777)
+        .mode(mode & 0o777)
         .create(path.as_path())
 }
 

--- a/crates/turborepo-cache/src/cache_archive/restore_manifest.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore_manifest.rs
@@ -60,7 +60,7 @@ impl RestoreManifest {
         #[cfg(unix)]
         {
             use std::os::unix::fs::MetadataExt;
-            if (meta.mode() & 0o7777) != expected.mode {
+            if (meta.mode() & 0o777) != expected.mode {
                 return false;
             }
         }
@@ -91,7 +91,7 @@ impl RestoreManifest {
         #[cfg(unix)]
         let mode = {
             use std::os::unix::fs::MetadataExt;
-            meta.mode() & 0o7777
+            meta.mode() & 0o777
         };
         #[cfg(not(unix))]
         let mode = 0o644;

--- a/crates/turborepo-cache/src/cache_archive/restore_regular.rs
+++ b/crates/turborepo-cache/src/cache_archive/restore_regular.rs
@@ -42,10 +42,20 @@ pub fn restore_regular(
     #[cfg(not(unix))]
     let mode = 0;
 
-    let mut file = open_for_restore(&resolved_path, mode)?;
+    let mut file = open_for_restore(&resolved_path, sanitized_mode(mode))?;
     io::copy(entry, &mut file)?;
 
     Ok((processed_name, false))
+}
+
+#[cfg(unix)]
+fn sanitized_mode(mode: u32) -> u32 {
+    mode & 0o777
+}
+
+#[cfg(not(unix))]
+fn sanitized_mode(mode: u32) -> u32 {
+    mode
 }
 
 fn open_for_restore(


### PR DESCRIPTION
## Why
Remote cache archives are untrusted input unless signature verification is enabled. Restoring setuid, setgid, or sticky bits from tar metadata can create surprising and unsafe filesystem permissions, especially when Turbo runs in privileged CI contexts.

## What
Sanitize restored Unix modes to normal permission bits for regular files and directories. Keep the restore manifest aligned with the sanitized mode so cache validation remains stable.

## How
Added regression coverage for tar entries with special mode bits and verified restore strips those bits while preserving normal permission handling.

Tests:
- `cargo test -p turborepo-cache cache_archive::restore`