### PR TITLE
fix: Preserve vt100 cell byte counts

### DIFF
--- a/crates/turborepo-vt100/src/cell.rs
+++ b/crates/turborepo-vt100/src/cell.rs
@@ -47,7 +47,7 @@ impl Cell {
 
     #[inline]
     fn num_bytes(&self) -> usize {
-        usize::from(self.num_bytes & 0x0f)
+        usize::from(self.num_bytes)
     }
 
     pub(crate) fn set(&mut self, c: char, a: crate::attrs::Attrs) {
@@ -121,8 +121,9 @@ impl Cell {
     #[must_use]
     pub fn contents(&self) -> &str {
         let num_bytes = self.num_bytes();
-        // Since contents has been constructed by appending chars encoded as UTF-8 it will be valid UTF-8
-        unsafe { std::str::from_utf8_unchecked(&self.contents[..num_bytes]) }
+        std::str::from_utf8(&self.contents[..num_bytes]).unwrap_or_else(
+            |_| unreachable!("cell contents should be valid UTF-8"),
+        )
     }
 
     /// Returns whether the cell contains any text data.

--- a/crates/turborepo-vt100/tests/basic.rs
+++ b/crates/turborepo-vt100/tests/basic.rs
@@ -95,6 +95,15 @@ fn cell_contents() {
 }
 
 #[test]
+fn cell_contents_handles_more_than_15_bytes() {
+    let mut parser = vt100::Parser::default();
+    let input = "\u{0800}\u{20d0}\u{20d1}\u{20d2}\u{20d3}\u{20d4}";
+    parser.process(input.as_bytes());
+
+    assert_eq!(parser.screen().cell(0, 0).unwrap().contents(), input);
+}
+
+#[test]
 fn cell_colors() {
     let mut parser = vt100::Parser::default();
     let input = b"foo\x1b[31m\x1b[32mb\x1b[3;7;42ma\x1b[23mr";


### PR DESCRIPTION
## Why

`turborepo-vt100` could store more than 15 UTF-8 bytes in a cell while reading the byte count through a 4-bit mask, allowing `Cell::contents()` to slice in the middle of a multi-byte codepoint.

## What

Preserve the full stored byte count for cell contents and replace unchecked UTF-8 conversion with checked decoding that treats invalid contents as an unreachable invariant violation.

## How

Added regression coverage for a single cell containing one 3-byte base codepoint plus five 3-byte combining marks. Verified with:

- `cargo fmt --check`
- `cargo test -p turborepo-vt100`
- `cargo clippy -p turborepo-vt100 --all-targets --all-features`