### PR TITLE
fix: Validate OidHash hex buffers

### DIFF
--- a/crates/turborepo-hash/src/oid_hash.rs
+++ b/crates/turborepo-hash/src/oid_hash.rs
@@ -8,18 +8,28 @@ pub struct OidHash([u8; 40]);
 
 impl OidHash {
     /// Create from a pre-filled 40-byte hex buffer.
-    /// Caller must ensure `buf` contains valid lowercase ASCII hex.
+    /// Panics if `buf` contains any non-ASCII-hex bytes.
     pub fn from_hex_buf(buf: [u8; 40]) -> Self {
+        assert_ascii_hex(&buf);
         Self(buf)
     }
 
     /// Create from a hex-encoded string slice.
     pub fn from_hex_str(s: &str) -> Self {
-        debug_assert_eq!(s.len(), 40, "OID hex must be exactly 40 chars");
+        assert_eq!(s.len(), 40, "OID hex must be exactly 40 chars");
+        assert_ascii_hex(s.as_bytes());
+
         let mut buf = [0u8; 40];
         buf.copy_from_slice(s.as_bytes());
         Self(buf)
     }
+}
+
+fn assert_ascii_hex(bytes: &[u8]) {
+    assert!(
+        bytes.iter().all(u8::is_ascii_hexdigit),
+        "OID hex must contain only ASCII hex digits"
+    );
 }
 
 impl std::ops::Deref for OidHash {
@@ -71,5 +81,29 @@ impl From<OidHash> for String {
     fn from(oid: OidHash) -> Self {
         // SAFETY: OidHash is always valid ASCII hex.
         unsafe { String::from_utf8_unchecked(oid.0.to_vec()) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OidHash;
+
+    #[test]
+    fn from_hex_buf_accepts_ascii_hex() {
+        let oid = OidHash::from_hex_buf(*b"0123456789abcdef0123456789abcdef01234567");
+
+        assert_eq!(&*oid, "0123456789abcdef0123456789abcdef01234567");
+    }
+
+    #[test]
+    #[should_panic(expected = "OID hex must contain only ASCII hex digits")]
+    fn from_hex_buf_rejects_non_utf8_bytes() {
+        OidHash::from_hex_buf([0xff; 40]);
+    }
+
+    #[test]
+    #[should_panic(expected = "OID hex must contain only ASCII hex digits")]
+    fn from_hex_str_rejects_non_hex_ascii() {
+        OidHash::from_hex_str("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz");
     }
 }

--- a/crates/turborepo-scm/src/repo_index.rs
+++ b/crates/turborepo-scm/src/repo_index.rs
@@ -1357,9 +1357,9 @@ mod tests {
             ("apps/web/package.json", "ddd"),
             ("apps/web/src/index.ts", "eee"),
             ("apps/web/src/utils.ts", "fff"),
-            ("packages/ui/button.tsx", "ggg"),
-            ("packages/ui/package.json", "hhh"),
-            ("root.json", "iii"),
+            ("packages/ui/button.tsx", "111"),
+            ("packages/ui/package.json", "222"),
+            ("root.json", "333"),
         ];
         let index = make_index(ls_tree_data.clone(), vec![]);
 

--- a/crates/turborepo-scm/src/status.rs
+++ b/crates/turborepo-scm/src/status.rs
@@ -155,7 +155,7 @@ mod tests {
         ];
         for (input, prefix, (expected_filename, expect_delete)) in tests {
             let prefix = RelativeUnixPathBuf::new(*prefix).unwrap();
-            let mut hashes = to_hash_map(&[(expected_filename, "some-hash")]);
+            let mut hashes = to_hash_map(&[(expected_filename, "abc")]);
             let to_hash = read_status(input.as_bytes(), &root_path, &prefix, &mut hashes).unwrap();
             if *expect_delete {
                 assert_eq!(hashes.len(), 0, "input: {input}");


### PR DESCRIPTION
## Why

VULN-11602 reports that `OidHash::from_hex_buf` accepted arbitrary bytes even though `OidHash` later exposes the buffer through unchecked UTF-8 conversions. Invalid bytes could therefore create invalid `str`/`String` values through safe code.

## What

Enforce the ASCII-hex invariant in the safe `OidHash` constructors before storing bytes, add regression coverage for invalid non-UTF-8 input, and update test-only SCM hash fixtures to remain valid OID hex strings.

## How

Validated with:

- `cargo test -p turborepo-hash oid_hash`
- `cargo test -p turborepo-hash`
- `cargo clippy -p turborepo-hash --all-targets`
- `cargo fmt -p turborepo-scm -p turborepo-hash --check`
- `cargo test -p turborepo-scm repo_index::tests::test_range_query_equivalence_with_binary_search`
- `cargo test -p turborepo-scm status::tests::test_status`
- pre-push hooks