### PR TITLE
fix: Block self-hosted login URLs from attempting to use Vercel's SSO

### DIFF
--- a/crates/turborepo-auth/src/auth/login.rs
+++ b/crates/turborepo-auth/src/auth/login.rs
@@ -14,9 +14,9 @@ use url::Url;
 use crate::{
     LoginOptions, Token,
     auth::{
-        ExistingTokenSource, classify_existing_vercel_token, ensure_trusted_vercel_api,
-        generate_csrf_state, is_vercel, should_attempt_vercel_token_refresh,
-        should_skip_existing_token_for_login,
+        ExistingTokenSource, classify_existing_vercel_token, ensure_non_vercel_redirect_allowed,
+        ensure_trusted_vercel_api, generate_csrf_state, is_vercel,
+        should_attempt_vercel_token_refresh, should_skip_existing_token_for_login,
     },
     device_flow::{self, TokenSet},
     error, ui,
@@ -137,6 +137,8 @@ pub async fn login<T: Client + TokenClient>(
         api_client,
         color_config,
         login_url: login_url_configuration,
+        login_url_source,
+        api_url_source,
         existing_token,
         force,
         sso_team: _,
@@ -231,7 +233,15 @@ pub async fn login<T: Client + TokenClient>(
         login_vercel_device_flow(api_client, color_config, login_url_configuration).await
     } else {
         let port = sso_login_callback_port.unwrap_or(DEFAULT_PORT);
-        login_redirect(api_client, color_config, login_url_configuration, port).await
+        login_redirect(
+            api_client,
+            color_config,
+            login_url_configuration,
+            login_url_source,
+            api_url_source,
+            port,
+        )
+        .await
     }
 }
 
@@ -315,8 +325,17 @@ async fn login_redirect<T: Client>(
     api_client: &T,
     color_config: &ColorConfig,
     login_url_configuration: &str,
+    login_url_source: Option<turborepo_types::ConfigurationSource>,
+    api_url_source: Option<turborepo_types::ConfigurationSource>,
     port: u16,
 ) -> Result<(Token, Option<TokenSet>), Error> {
+    let mut login_url =
+        Url::parse(login_url_configuration).map_err(|_| error::Error::LoginUrlCannotBeABase {
+            value: login_url_configuration.to_string(),
+        })?;
+
+    ensure_non_vercel_redirect_allowed(&login_url, login_url_source, api_client, api_url_source)?;
+
     let listener = TcpListener::bind(format!("{DEFAULT_HOST_NAME}:{port}"))
         .map_err(error::Error::CallbackListenerFailed)?;
     let port = listener
@@ -325,11 +344,6 @@ async fn login_redirect<T: Client>(
         .port();
     let redirect_url = format!("http://{DEFAULT_HOST_NAME}:{port}");
     let state = generate_csrf_state();
-
-    let mut login_url =
-        Url::parse(login_url_configuration).map_err(|_| error::Error::LoginUrlCannotBeABase {
-            value: login_url_configuration.to_string(),
-        })?;
 
     let mut success_url = login_url.clone();
     success_url
@@ -688,6 +702,8 @@ mod tests {
         let options = LoginOptions {
             color_config: &color_config,
             login_url: "https://example.com",
+            login_url_source: Some(turborepo_types::ConfigurationSource::Cli),
+            api_url_source: None,
             api_client: &api_client,
             existing_token: Some("stale-token"),
             force: false,
@@ -717,6 +733,62 @@ mod tests {
             Err(Error::UntrustedVercelApiUrl { ref api_url })
                 if api_url == "https://attacker.test/api"
         );
+    }
+
+    #[tokio::test]
+    async fn test_non_vercel_login_rejects_repo_controlled_login_url() {
+        let color_config = turborepo_ui::ColorConfig::new(false);
+        let api_client = MockApiClient::new();
+
+        let options = LoginOptions {
+            login_url_source: Some(turborepo_types::ConfigurationSource::TurboJson),
+            ..LoginOptions::new(&color_config, "https://attacker.test", &api_client)
+        };
+
+        let result = login(&options).await;
+
+        assert_matches!(
+            result,
+            Err(Error::UntrustedNonVercelLoginUrlSource {
+                url_source: Some(turborepo_types::ConfigurationSource::TurboJson)
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn test_non_vercel_login_rejects_repo_controlled_api_url() {
+        let color_config = turborepo_ui::ColorConfig::new(false);
+        let api_client = MockApiClient::with_base_url("https://attacker.test/api");
+
+        let options = LoginOptions {
+            login_url_source: Some(turborepo_types::ConfigurationSource::Cli),
+            api_url_source: Some(turborepo_types::ConfigurationSource::TurboJson),
+            ..LoginOptions::new(&color_config, "https://cache.example.com", &api_client)
+        };
+
+        let result = login(&options).await;
+
+        assert_matches!(
+            result,
+            Err(Error::UntrustedNonVercelApiUrlSource {
+                url_source: Some(turborepo_types::ConfigurationSource::TurboJson)
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn test_non_vercel_login_rejects_http_remote_url() {
+        let color_config = turborepo_ui::ColorConfig::new(false);
+        let api_client = MockApiClient::new();
+
+        let options = LoginOptions {
+            login_url_source: Some(turborepo_types::ConfigurationSource::Cli),
+            ..LoginOptions::new(&color_config, "http://attacker.test", &api_client)
+        };
+
+        let result = login(&options).await;
+
+        assert_matches!(result, Err(Error::UntrustedNonVercelLoginUrlScheme));
     }
 
     #[tokio::test]

--- a/crates/turborepo-auth/src/auth/mod.rs
+++ b/crates/turborepo-auth/src/auth/mod.rs
@@ -11,7 +11,7 @@ use turbopath::AbsoluteSystemPath;
 #[cfg(test)]
 use turbopath::AbsoluteSystemPathBuf;
 use turborepo_api_client::{Client, TokenClient};
-use turborepo_types::SecretString;
+use turborepo_types::{ConfigurationSource, SecretString};
 use turborepo_ui::ColorConfig;
 use url::Url;
 
@@ -33,6 +33,59 @@ pub(crate) fn ensure_trusted_vercel_api<T: Client>(api_client: &T) -> Result<(),
     Err(Error::UntrustedVercelApiUrl {
         api_url: api_url.to_string(),
     })
+}
+
+pub(crate) fn ensure_non_vercel_redirect_allowed<T: Client>(
+    login_url: &Url,
+    login_url_source: Option<ConfigurationSource>,
+    api_client: &T,
+    api_url_source: Option<ConfigurationSource>,
+) -> Result<(), Error> {
+    ensure_non_vercel_login_url_is_safe(login_url)?;
+
+    if !is_user_controlled_url_source(login_url_source) {
+        return Err(Error::UntrustedNonVercelLoginUrlSource {
+            url_source: login_url_source,
+        });
+    }
+
+    let api_url = api_client.make_url("")?;
+    if !is_trusted_vercel_origin(&api_url) && !is_user_controlled_url_source(api_url_source) {
+        return Err(Error::UntrustedNonVercelApiUrlSource {
+            url_source: api_url_source,
+        });
+    }
+
+    Ok(())
+}
+
+fn is_user_controlled_url_source(source: Option<ConfigurationSource>) -> bool {
+    matches!(
+        source,
+        Some(ConfigurationSource::Cli)
+            | Some(ConfigurationSource::Environment)
+            | Some(ConfigurationSource::GlobalConfig)
+    )
+}
+
+fn ensure_non_vercel_login_url_is_safe(login_url: &Url) -> Result<(), Error> {
+    if !login_url.username().is_empty() || login_url.password().is_some() {
+        return Err(Error::LoginUrlIncludesCredentials);
+    }
+
+    if login_url.scheme() == "https" {
+        return Ok(());
+    }
+
+    if login_url.scheme() == "http" && login_url.host_str().is_some_and(is_localhost) {
+        return Ok(());
+    }
+
+    Err(Error::UntrustedNonVercelLoginUrlScheme)
+}
+
+fn is_localhost(host: &str) -> bool {
+    matches!(host, "localhost" | "127.0.0.1" | "::1")
 }
 
 pub(crate) fn should_attempt_vercel_token_refresh(source: ExistingTokenSource) -> bool {
@@ -96,6 +149,8 @@ pub(crate) enum ExistingTokenSource {
 pub struct LoginOptions<'a, T: Client + TokenClient> {
     pub color_config: &'a ColorConfig,
     pub login_url: &'a str,
+    pub login_url_source: Option<ConfigurationSource>,
+    pub api_url_source: Option<ConfigurationSource>,
     pub api_client: &'a T,
 
     pub sso_team: Option<&'a str>,
@@ -108,6 +163,8 @@ impl<'a, T: Client + TokenClient> LoginOptions<'a, T> {
         Self {
             color_config,
             login_url,
+            login_url_source: None,
+            api_url_source: None,
             api_client,
             sso_team: None,
             existing_token: None,

--- a/crates/turborepo-auth/src/auth/mod.rs
+++ b/crates/turborepo-auth/src/auth/mod.rs
@@ -85,7 +85,9 @@ fn ensure_non_vercel_login_url_is_safe(login_url: &Url) -> Result<(), Error> {
 }
 
 fn is_localhost(host: &str) -> bool {
-    matches!(host, "localhost" | "127.0.0.1" | "::1")
+    // `Url::host_str` returns IPv6 addresses wrapped in brackets (e.g. `[::1]`),
+    // so match both the bracketed and bare forms to be safe.
+    matches!(host, "localhost" | "127.0.0.1" | "::1" | "[::1]")
 }
 
 pub(crate) fn should_attempt_vercel_token_refresh(source: ExistingTokenSource) -> bool {

--- a/crates/turborepo-auth/src/auth/sso.rs
+++ b/crates/turborepo-auth/src/auth/sso.rs
@@ -17,9 +17,9 @@ use super::login::{
 use crate::{
     Error, LoginOptions, Token,
     auth::{
-        ExistingTokenSource, classify_existing_vercel_token, ensure_trusted_vercel_api,
-        generate_csrf_state, is_vercel, should_attempt_vercel_token_refresh,
-        should_skip_existing_token_for_login,
+        ExistingTokenSource, classify_existing_vercel_token, ensure_non_vercel_redirect_allowed,
+        ensure_trusted_vercel_api, generate_csrf_state, is_vercel,
+        should_attempt_vercel_token_refresh, should_skip_existing_token_for_login,
     },
     device_flow::TokenSet,
     error, ui,
@@ -156,6 +156,8 @@ pub async fn sso_login<T: Client + TokenClient>(
         api_client,
         color_config,
         login_url: login_url_configuration,
+        login_url_source,
+        api_url_source,
         sso_team,
         existing_token,
         force,
@@ -275,7 +277,15 @@ pub async fn sso_login<T: Client + TokenClient>(
     }
 
     let port = sso_login_callback_port.unwrap_or(DEFAULT_PORT);
-    let verification_token = sso_redirect(login_url_configuration, sso_team, port).await?;
+    let verification_token = sso_redirect(
+        api_client,
+        login_url_configuration,
+        login_url_source,
+        api_url_source,
+        sso_team,
+        port,
+    )
+    .await?;
 
     // Verify the SSO token with the API
     let secret_verification_token = SecretString::new(verification_token.clone());
@@ -300,11 +310,21 @@ pub async fn sso_login<T: Client + TokenClient>(
 /// Non-Vercel SSO: open browser to `{login_url}/api/auth/sso` with
 /// `teamId`, `mode`, and `next` params, then wait for localhost redirect.
 /// This preserves the original SSO flow for self-hosted remote cache servers.
-async fn sso_redirect(
+async fn sso_redirect<T: Client>(
+    api_client: &T,
     login_url_configuration: &str,
+    login_url_source: Option<turborepo_types::ConfigurationSource>,
+    api_url_source: Option<turborepo_types::ConfigurationSource>,
     sso_team: &str,
     port: u16,
 ) -> Result<String, Error> {
+    let mut login_url =
+        Url::parse(login_url_configuration).map_err(|_| error::Error::LoginUrlCannotBeABase {
+            value: login_url_configuration.to_string(),
+        })?;
+
+    ensure_non_vercel_redirect_allowed(&login_url, login_url_source, api_client, api_url_source)?;
+
     let listener = TcpListener::bind(format!("{DEFAULT_HOST_NAME}:{port}"))
         .map_err(Error::CallbackListenerFailed)?;
     let port = listener
@@ -313,11 +333,6 @@ async fn sso_redirect(
         .port();
     let redirect_url = format!("http://{DEFAULT_HOST_NAME}:{port}");
     let state = generate_csrf_state();
-
-    let mut login_url =
-        Url::parse(login_url_configuration).map_err(|_| error::Error::LoginUrlCannotBeABase {
-            value: login_url_configuration.to_string(),
-        })?;
 
     login_url
         .path_segments_mut()
@@ -619,6 +634,8 @@ mod tests {
         let options = LoginOptions {
             color_config: &color_config,
             login_url: "https://api.vercel.com",
+            login_url_source: None,
+            api_url_source: None,
             api_client: &api_client,
             existing_token: None,
             sso_team: None,
@@ -638,6 +655,8 @@ mod tests {
         let options = LoginOptions {
             color_config: &color_config,
             login_url: "https://api.vercel.com",
+            login_url_source: None,
+            api_url_source: None,
             api_client: &api_client,
             existing_token: Some("existing-token"),
             sso_team: Some("my-team"),
@@ -658,6 +677,8 @@ mod tests {
         let options = LoginOptions {
             color_config: &color_config,
             login_url: "https://vercel.com",
+            login_url_source: None,
+            api_url_source: None,
             api_client: &api_client,
             existing_token: Some("existing-token"),
             sso_team: Some("my-team"),
@@ -671,6 +692,33 @@ mod tests {
             result,
             Err(Error::UntrustedVercelApiUrl { ref api_url })
                 if api_url == "https://attacker.test/api"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_non_vercel_sso_rejects_repo_controlled_login_url() {
+        let color_config = turborepo_ui::ColorConfig::new(false);
+        let api_client = MockApiClient::new();
+
+        let options = LoginOptions {
+            login_url: "https://attacker.test",
+            login_url_source: Some(turborepo_types::ConfigurationSource::TurboJson),
+            api_url_source: None,
+            api_client: &api_client,
+            existing_token: None,
+            sso_team: Some("my-team"),
+            force: false,
+            sso_login_callback_port: None,
+            color_config: &color_config,
+        };
+
+        let result = sso_login(&options).await;
+
+        assert_matches!(
+            result,
+            Err(Error::UntrustedNonVercelLoginUrlSource {
+                url_source: Some(turborepo_types::ConfigurationSource::TurboJson)
+            })
         );
     }
 

--- a/crates/turborepo-auth/src/error.rs
+++ b/crates/turborepo-auth/src/error.rs
@@ -46,6 +46,24 @@ pub enum Error {
          \"{api_url}\""
     )]
     UntrustedVercelApiUrl { api_url: String },
+    #[error(
+        "Refusing to open non-Vercel `loginUrl` from {url_source:?}. Re-run with `--login <url>` \
+         or set `TURBO_LOGIN` if you trust this remote cache."
+    )]
+    UntrustedNonVercelLoginUrlSource {
+        url_source: Option<turborepo_types::ConfigurationSource>,
+    },
+    #[error(
+        "Refusing non-Vercel login because `apiUrl` is from {url_source:?}. Re-run with `--api \
+         <url>` or set `TURBO_API` if you trust this remote cache."
+    )]
+    UntrustedNonVercelApiUrlSource {
+        url_source: Option<turborepo_types::ConfigurationSource>,
+    },
+    #[error("non-Vercel `loginUrl` must use HTTPS, except for localhost development URLs")]
+    UntrustedNonVercelLoginUrlScheme,
+    #[error("non-Vercel `loginUrl` must not include a username or password")]
+    LoginUrlIncludesCredentials,
 
     #[error("failed to validate sso token")]
     FailedToValidateSSOToken(#[source] turborepo_api_client::Error),

--- a/crates/turborepo-config/src/env.rs
+++ b/crates/turborepo-config/src/env.rs
@@ -302,7 +302,9 @@ impl ResolvedConfigurationOptions for EnvVars {
 
         let output = ConfigurationOptions {
             api_url: self.output_map.get("api_url").cloned(),
+            api_url_source: None,
             login_url: self.output_map.get("login_url").cloned(),
+            login_url_source: None,
             team_slug: self.output_map.get("team_slug").cloned(),
             team_id: self.output_map.get("team_id").cloned(),
             token: self.output_map.get("token").cloned(),

--- a/crates/turborepo-config/src/lib.rs
+++ b/crates/turborepo-config/src/lib.rs
@@ -50,7 +50,7 @@ use turborepo_cache::CacheConfig;
 use turborepo_repository::package_graph::PackageName;
 use turborepo_scm::WorktreeInfo;
 use turborepo_turbo_json::FutureFlags;
-use turborepo_types::{EnvMode, LogOrder, UIMode};
+use turborepo_types::{ConfigurationSource, EnvMode, LogOrder, UIMode};
 
 pub const CONFIG_FILE: &str = "turbo.json";
 pub const CONFIG_FILE_JSONC: &str = "turbo.jsonc";
@@ -269,10 +269,14 @@ pub struct ConfigurationOptions {
     #[serde(alias = "ApiUrl")]
     #[serde(alias = "APIURL")]
     pub api_url: Option<String>,
+    #[serde(skip)]
+    pub api_url_source: Option<ConfigurationSource>,
     #[serde(alias = "loginurl")]
     #[serde(alias = "LoginUrl")]
     #[serde(alias = "LOGINURL")]
     pub login_url: Option<String>,
+    #[serde(skip)]
+    pub login_url_source: Option<ConfigurationSource>,
     #[serde(alias = "teamslug")]
     #[serde(alias = "TeamSlug")]
     #[serde(alias = "TEAMSLUG")]
@@ -344,12 +348,31 @@ pub struct TurborepoConfigBuilder {
 
 // Getters
 impl ConfigurationOptions {
+    fn with_url_sources(mut self, source: ConfigurationSource) -> Self {
+        if self.api_url.is_some() {
+            self.api_url_source = Some(source);
+        }
+        if self.login_url.is_some() {
+            self.login_url_source = Some(source);
+        }
+
+        self
+    }
+
     pub fn api_url(&self) -> &str {
         non_empty_str(self.api_url.as_deref()).unwrap_or(DEFAULT_API_URL)
     }
 
     pub fn login_url(&self) -> &str {
         non_empty_str(self.login_url.as_deref()).unwrap_or(DEFAULT_LOGIN_URL)
+    }
+
+    pub fn api_url_source(&self) -> Option<ConfigurationSource> {
+        self.api_url_source
+    }
+
+    pub fn login_url_source(&self) -> Option<ConfigurationSource> {
+        self.login_url_source
     }
 
     pub fn team_slug(&self) -> Option<&str> {
@@ -687,20 +710,24 @@ impl TurborepoConfigBuilder {
         let env_var_config = EnvVars::new(&env_vars)?;
         let override_env_var_config = OverrideEnvVars::new(&env_vars)?;
 
-        let sources: [Box<dyn ResolvedConfigurationOptions>; 7] = [
-            Box::new(&self.override_config),
-            Box::new(env_var_config),
-            Box::new(override_env_var_config),
-            Box::new(local_config),
-            Box::new(global_auth),
-            Box::new(global_config),
-            Box::new(turbo_json),
+        let sources: [(ConfigurationSource, Box<dyn ResolvedConfigurationOptions>); 7] = [
+            (ConfigurationSource::Cli, Box::new(&self.override_config)),
+            (ConfigurationSource::Environment, Box::new(env_var_config)),
+            (
+                ConfigurationSource::OverrideEnvironment,
+                Box::new(override_env_var_config),
+            ),
+            (ConfigurationSource::LocalConfig, Box::new(local_config)),
+            (ConfigurationSource::GlobalAuth, Box::new(global_auth)),
+            (ConfigurationSource::GlobalConfig, Box::new(global_config)),
+            (ConfigurationSource::TurboJson, Box::new(turbo_json)),
         ];
 
         let config = sources.into_iter().try_fold(
             ConfigurationOptions::default(),
-            |mut acc, current_source| {
+            |mut acc, (source, current_source)| {
                 let current_source_config = current_source.get_configuration_options(&acc)?;
+                let current_source_config = current_source_config.with_url_sources(source);
                 acc.merge(current_source_config);
                 Ok(acc)
             },
@@ -745,7 +772,7 @@ mod test {
 
     use tempfile::TempDir;
     use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
-    use turborepo_types::LogOrder;
+    use turborepo_types::{ConfigurationSource, LogOrder};
 
     use crate::{
         CONFIG_FILE, CONFIG_FILE_JSONC, ConfigurationOptions, DEFAULT_API_URL, DEFAULT_LOGIN_URL,
@@ -1288,6 +1315,112 @@ mod test {
         assert!(
             config.no_update_notifier(),
             "noUpdateNotifier from turbo.json should be respected"
+        );
+    }
+
+    #[test]
+    fn test_turbo_json_url_sources_are_recorded() {
+        let tmp_dir = TempDir::new().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(tmp_dir.path()).unwrap();
+
+        repo_root
+            .join_component("turbo.json")
+            .create_with_contents(
+                r#"{
+                    "remoteCache": {
+                        "apiUrl": "https://attacker.test/api",
+                        "loginUrl": "https://attacker.test"
+                    }
+                }"#,
+            )
+            .unwrap();
+
+        let config = TurborepoConfigBuilder {
+            repo_root,
+            override_config: ConfigurationOptions::default(),
+            global_config_path: None,
+            environment: Some(HashMap::default()),
+        }
+        .build()
+        .unwrap();
+
+        assert_eq!(
+            config.api_url_source(),
+            Some(ConfigurationSource::TurboJson)
+        );
+        assert_eq!(
+            config.login_url_source(),
+            Some(ConfigurationSource::TurboJson)
+        );
+    }
+
+    #[test]
+    fn test_cli_login_url_source_overrides_turbo_json_source() {
+        let tmp_dir = TempDir::new().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(tmp_dir.path()).unwrap();
+
+        repo_root
+            .join_component("turbo.json")
+            .create_with_contents(
+                r#"{
+                    "remoteCache": {
+                        "loginUrl": "https://attacker.test"
+                    }
+                }"#,
+            )
+            .unwrap();
+
+        let config = TurborepoConfigBuilder {
+            repo_root,
+            override_config: ConfigurationOptions {
+                login_url: Some("https://cache.example.com".to_string()),
+                ..Default::default()
+            },
+            global_config_path: None,
+            environment: Some(HashMap::default()),
+        }
+        .build()
+        .unwrap();
+
+        assert_eq!(config.login_url(), "https://cache.example.com");
+        assert_eq!(config.login_url_source(), Some(ConfigurationSource::Cli));
+    }
+
+    #[test]
+    fn test_env_login_url_source_overrides_turbo_json_source() {
+        let tmp_dir = TempDir::new().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(tmp_dir.path()).unwrap();
+
+        repo_root
+            .join_component("turbo.json")
+            .create_with_contents(
+                r#"{
+                    "remoteCache": {
+                        "loginUrl": "https://attacker.test"
+                    }
+                }"#,
+            )
+            .unwrap();
+
+        let mut env = HashMap::new();
+        env.insert(
+            OsString::from("turbo_login"),
+            OsString::from("https://cache.example.com"),
+        );
+
+        let config = TurborepoConfigBuilder {
+            repo_root,
+            override_config: ConfigurationOptions::default(),
+            global_config_path: None,
+            environment: Some(env),
+        }
+        .build()
+        .unwrap();
+
+        assert_eq!(config.login_url(), "https://cache.example.com");
+        assert_eq!(
+            config.login_url_source(),
+            Some(ConfigurationSource::Environment)
         );
     }
 }

--- a/crates/turborepo-lib/src/commands/login/manual.rs
+++ b/crates/turborepo-lib/src/commands/login/manual.rs
@@ -184,12 +184,14 @@ mod test {
     fn test_default_api_url_filtered_out() {
         let api_opts = APIClientOpts {
             api_url: "https://vercel.com/api".into(),
+            api_url_source: None,
             team_id: None,
             team_slug: None,
             token: None,
             timeout: 0,
             upload_timeout: 0,
             login_url: "".into(),
+            login_url_source: None,
             preflight: false,
             sso_login_callback_port: None,
         };
@@ -208,12 +210,14 @@ mod test {
     fn test_finds_existing_values() {
         let api_opts = APIClientOpts {
             api_url: "https://my-remote-cache.com".into(),
+            api_url_source: None,
             team_slug: Some("custom-cache".into()),
             team_id: None,
             token: Some("token".into()),
             timeout: 0,
             upload_timeout: 0,
             login_url: "".into(),
+            login_url_source: None,
             preflight: false,
             sso_login_callback_port: None,
         };

--- a/crates/turborepo-lib/src/commands/login/mod.rs
+++ b/crates/turborepo-lib/src/commands/login/mod.rs
@@ -60,11 +60,15 @@ async fn sso_login(base: &mut CommandBase, sso_team: &str, force: bool) -> Resul
     let api_client: APIClient = base.api_client()?;
     let color_config = base.color_config;
     let login_url_config = base.opts.api_client_opts.login_url.to_string();
+    let login_url_source = base.opts.api_client_opts.login_url_source;
+    let api_url_source = base.opts.api_client_opts.api_url_source;
     let sso_login_callback_port = base.opts.api_client_opts.sso_login_callback_port;
     let options = LoginOptions {
         existing_token: base.opts.api_client_opts.token.as_ref().map(|t| t.expose()),
         sso_team: Some(sso_team),
         force,
+        login_url_source,
+        api_url_source,
         sso_login_callback_port,
         ..LoginOptions::new(&color_config, &login_url_config, &api_client)
     };
@@ -82,11 +86,15 @@ async fn login_no_sso(base: &mut CommandBase, force: bool) -> Result<(), Error> 
     let api_client: APIClient = base.api_client()?;
     let color_config = base.color_config;
     let login_url_config = base.opts.api_client_opts.login_url.to_string();
+    let login_url_source = base.opts.api_client_opts.login_url_source;
+    let api_url_source = base.opts.api_client_opts.api_url_source;
     let existing_token = base.opts.api_client_opts.token.as_ref().map(|t| t.expose());
 
     let options = LoginOptions {
         existing_token,
         force,
+        login_url_source,
+        api_url_source,
         ..LoginOptions::new(&color_config, &login_url_config, &api_client)
     };
 

--- a/crates/turborepo-lib/src/opts.rs
+++ b/crates/turborepo-lib/src/opts.rs
@@ -583,12 +583,14 @@ impl<'a> From<OptsInputs<'a>> for APIClientOpts {
 
         APIClientOpts {
             api_url,
+            api_url_source: inputs.config.api_url_source(),
             timeout,
             upload_timeout,
             token,
             team_id,
             team_slug,
             login_url,
+            login_url_source: inputs.config.login_url_source(),
             preflight,
             sso_login_callback_port,
         }
@@ -924,12 +926,14 @@ mod test {
             },
             api_client_opts: APIClientOpts {
                 api_url: "".to_string(),
+                api_url_source: None,
                 timeout: 0,
                 upload_timeout: 0,
                 token: None,
                 team_id: None,
                 team_slug: None,
                 login_url: "".to_string(),
+                login_url_source: None,
                 preflight: false,
                 sso_login_callback_port: None,
             },

--- a/crates/turborepo-types/src/lib.rs
+++ b/crates/turborepo-types/src/lib.rs
@@ -342,6 +342,17 @@ pub enum GraphOpts {
     File(String),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum ConfigurationSource {
+    Cli,
+    Environment,
+    OverrideEnvironment,
+    LocalConfig,
+    GlobalAuth,
+    GlobalConfig,
+    TurboJson,
+}
+
 /// API client configuration options.
 ///
 /// Contains all settings needed to connect to the Turborepo remote cache API,
@@ -350,6 +361,8 @@ pub enum GraphOpts {
 pub struct APIClientOpts {
     /// Base URL for the Turborepo API
     pub api_url: String,
+    /// Source that provided the API URL, if explicitly configured.
+    pub api_url_source: Option<ConfigurationSource>,
     /// Request timeout in seconds
     pub timeout: u64,
     /// Upload-specific timeout in seconds
@@ -365,6 +378,8 @@ pub struct APIClientOpts {
     pub team_slug: Option<String>,
     /// Login URL for authentication flow
     pub login_url: String,
+    /// Source that provided the login URL, if explicitly configured.
+    pub login_url_source: Option<ConfigurationSource>,
     /// Whether to use preflight requests
     pub preflight: bool,
     /// Port for SSO login callback (non-Vercel flows only)


### PR DESCRIPTION
## Why

Repository-controlled `remoteCache.loginUrl` can redirect `turbo login` and `turbo login --sso-team` to an attacker-controlled origin. That exposes the CSRF state in the opened URL and can lead to credential phishing or token injection through the localhost callback.

This intentionally changes self-hosted login setup when the login destination only comes from repo config. Users who trust a self-hosted remote cache should provide the non-Vercel auth endpoints from a user-controlled source instead, for example:

```sh
TURBO_LOGIN=https://cache.example.com TURBO_API=https://cache.example.com/api turbo login
```

or:

```sh
turbo login --login https://cache.example.com --api https://cache.example.com/api
```

Default Vercel login and Vercel SSO flows are not expected to require workflow changes.

## What

Adds source tracking for resolved `apiUrl` and `loginUrl`, then blocks non-Vercel browser login redirects unless those URLs came from CLI/env/global config instead of repo-controlled config.

Also rejects non-Vercel login URLs that use non-HTTPS remote origins or embed username/password credentials. Localhost HTTP remains allowed for development.

## How

- `cargo test -p turborepo-auth`
- `cargo test -p turborepo-config`
- `cargo check -p turborepo-lib`
- `cargo test -p turborepo-lib commands::login`
- `cargo fmt --check`
- Pre-push hooks: format, TOML formatting, Rust checks

Reviewer notes: verify that a repo-level `remoteCache.loginUrl` pointing to a non-Vercel host is rejected by `turbo login`, and that the same URL still works when supplied explicitly with `--login`/`--api` or `TURBO_LOGIN`/`TURBO_API`.