### PR TITLE
fix: Re-authenticate when stored token loses access to linked team

### DIFF
--- a/crates/turborepo-auth/src/auth/login.rs
+++ b/crates/turborepo-auth/src/auth/login.rs
@@ -6,7 +6,7 @@ use std::{
 
 pub use error::Error;
 use tracing::warn;
-use turborepo_api_client::{Client, TokenClient};
+use turborepo_api_client::{CacheClient, Client, TokenClient};
 use turborepo_types::SecretString;
 use turborepo_ui::{BOLD, ColorConfig, start_spinner};
 use url::Url;
@@ -59,35 +59,70 @@ pub(super) fn valid_token_callback(message: &str, color_config: &ColorConfig) ->
 async fn reuse_existing_token<T, F>(
     token: Token,
     api_client: &T,
+    linked_team_id: Option<&str>,
+    linked_team_slug: Option<&str>,
     valid_message_fn: Option<F>,
 ) -> Result<Option<Token>, Error>
 where
-    T: Client + TokenClient,
+    T: Client + TokenClient + CacheClient,
     F: FnOnce(&str),
 {
-    match token.is_valid(api_client, valid_message_fn).await {
-        Ok(true) => Ok(Some(token)),
-        Ok(false) => Ok(None),
+    match token.is_valid(api_client, Option::<fn(&str)>::None).await {
+        Ok(true) => {}
+        Ok(false) => return Ok(None),
         Err(err) if is_inactive_token_error(&err) => {
             warn!("Stored token is no longer active, proceeding with new login");
-            Ok(None)
+            return Ok(None);
         }
-        Err(err) => Err(err),
+        Err(err) => return Err(err),
     }
+
+    // A token can be active at the user level while no longer having access
+    // to the linked team, most commonly when the team enforces SAML and the
+    // session behind the token has expired. Reusing such a token would leave
+    // the user stuck getting 403s from every team-scoped endpoint, so verify
+    // team access before deciding the stored token is good.
+    if linked_team_id.is_some() || linked_team_slug.is_some() {
+        match token
+            .has_cache_access(api_client, linked_team_id, linked_team_slug)
+            .await
+        {
+            Ok(true) => {}
+            Ok(false) => {
+                warn!(
+                    "Stored token no longer has access to the linked team, proceeding with new \
+                     login"
+                );
+                return Ok(None);
+            }
+            Err(err) => return Err(err),
+        }
+    }
+
+    if let Some(message_callback) = valid_message_fn {
+        let user = token.user(api_client).await?;
+        message_callback(&user.email);
+    }
+
+    Ok(Some(token))
 }
 
 async fn reuse_existing_token_with_recovery<T>(
     token: Token,
     api_client: &T,
+    linked_team_id: Option<&str>,
+    linked_team_slug: Option<&str>,
     valid_message: &str,
     color_config: &ColorConfig,
 ) -> Result<Option<Token>, Error>
 where
-    T: Client + TokenClient,
+    T: Client + TokenClient + CacheClient,
 {
     match reuse_existing_token(
         token.clone(),
         api_client,
+        linked_team_id,
+        linked_team_slug,
         Some(valid_token_callback(valid_message, color_config)),
     )
     .await
@@ -107,6 +142,8 @@ where
     match reuse_existing_token(
         Token::existing_secret(recovered_token),
         api_client,
+        linked_team_id,
+        linked_team_slug,
         Some(valid_token_callback(valid_message, color_config)),
     )
     .await
@@ -130,7 +167,7 @@ where
 /// The `TokenSet` is `Some` when login completed via the device authorization
 /// flow (Vercel only). It's `None` for non-Vercel logins or when an existing
 /// token was reused.
-pub async fn login<T: Client + TokenClient>(
+pub async fn login<T: Client + TokenClient + CacheClient>(
     options: &LoginOptions<'_, T>,
 ) -> Result<(Token, Option<TokenSet>), Error> {
     let LoginOptions {
@@ -143,6 +180,8 @@ pub async fn login<T: Client + TokenClient>(
         force,
         sso_team: _,
         sso_login_callback_port,
+        linked_team_id,
+        linked_team_slug,
     } = *options;
 
     let is_vercel_login = is_vercel(login_url_configuration);
@@ -169,6 +208,8 @@ pub async fn login<T: Client + TokenClient>(
                             && let Some(token) = reuse_existing_token_with_recovery(
                                 Token::existing_secret(token_secret),
                                 api_client,
+                                linked_team_id,
+                                linked_team_slug,
                                 "Using existing Vercel login.",
                                 color_config,
                             )
@@ -188,14 +229,21 @@ pub async fn login<T: Client + TokenClient>(
                     reuse_existing_token_with_recovery(
                         token,
                         api_client,
+                        linked_team_id,
+                        linked_team_slug,
                         "Using existing Vercel login.",
                         color_config,
                     )
                     .await?
                 } else {
+                    // Self-hosted remote caches aren't guaranteed to implement
+                    // the caching-status endpoint, so skip the linked-team
+                    // access check for non-Vercel logins.
                     reuse_existing_token(
                         token,
                         api_client,
+                        None,
+                        None,
                         Some(valid_token_callback("Using existing login.", color_config)),
                     )
                     .await?
@@ -213,6 +261,8 @@ pub async fn login<T: Client + TokenClient>(
                         && let Some(token) = reuse_existing_token_with_recovery(
                             Token::existing_secret(token_secret),
                             api_client,
+                            linked_team_id,
+                            linked_team_slug,
                             "Using existing Vercel login.",
                             color_config,
                         )
@@ -485,7 +535,8 @@ mod tests {
     use tokio::sync::Mutex;
     use turbopath::AbsoluteSystemPathBuf;
     use turborepo_vercel_api::{
-        Membership, Role, Team, TeamsResponse, User, UserResponse, VerifiedSsoUser,
+        CachingStatus, CachingStatusResponse, Membership, Role, Team, TeamsResponse, User,
+        UserResponse, VerifiedSsoUser,
     };
     use turborepo_vercel_api_mock::start_test_server;
 
@@ -640,6 +691,80 @@ mod tests {
         }
     }
 
+    impl turborepo_api_client::CacheClient for MockApiClient {
+        async fn get_artifact(
+            &self,
+            _hash: &str,
+            _token: &SecretString,
+            _team_id: Option<&str>,
+            _team_slug: Option<&str>,
+            _method: reqwest::Method,
+        ) -> turborepo_api_client::Result<Option<Response>> {
+            unimplemented!("get_artifact")
+        }
+
+        async fn fetch_artifact(
+            &self,
+            _hash: &str,
+            _token: &SecretString,
+            _team_id: Option<&str>,
+            _team_slug: Option<&str>,
+        ) -> turborepo_api_client::Result<Option<Response>> {
+            unimplemented!("fetch_artifact")
+        }
+
+        async fn put_artifact(
+            &self,
+            _hash: &str,
+            _artifact_body: impl turborepo_api_client::Stream<
+                Item = turborepo_api_client::Result<turborepo_api_client::Bytes>,
+            > + Send
+            + Sync
+            + 'static,
+            _body_len: usize,
+            _duration: u64,
+            _tag: Option<&str>,
+            _token: &SecretString,
+            _team_id: Option<&str>,
+            _team_slug: Option<&str>,
+            _sha: Option<&str>,
+            _dirty_hash: Option<&str>,
+        ) -> turborepo_api_client::Result<()> {
+            unimplemented!("put_artifact")
+        }
+
+        async fn artifact_exists(
+            &self,
+            _hash: &str,
+            _token: &SecretString,
+            _team_id: Option<&str>,
+            _team_slug: Option<&str>,
+        ) -> turborepo_api_client::Result<Option<Response>> {
+            unimplemented!("artifact_exists")
+        }
+
+        async fn get_caching_status(
+            &self,
+            token: &SecretString,
+            _team_id: Option<&str>,
+            _team_slug: Option<&str>,
+        ) -> turborepo_api_client::Result<CachingStatusResponse> {
+            // Mimics a token that is active at the user level but has lost
+            // access to the team (e.g. an expired SAML session).
+            if token.expose() == "team-forbidden-token" {
+                return Err(turborepo_api_client::Error::UnknownStatus {
+                    code: "forbidden".to_string(),
+                    message: "Not authorized".to_string(),
+                    backtrace: std::backtrace::Backtrace::capture(),
+                });
+            }
+
+            Ok(CachingStatusResponse {
+                status: CachingStatus::Enabled,
+            })
+        }
+    }
+
     fn spawn_login_callback(
         port: u16,
         token: &'static str,
@@ -708,6 +833,8 @@ mod tests {
             existing_token: Some("stale-token"),
             force: false,
             sso_team: None,
+            linked_team_id: None,
+            linked_team_slug: None,
             sso_login_callback_port: Some(port),
         };
 
@@ -792,6 +919,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_reuse_existing_token_discards_token_without_linked_team_access() {
+        let api_client = MockApiClient::new();
+
+        let reused = reuse_existing_token(
+            Token::existing("team-forbidden-token".to_string()),
+            &api_client,
+            Some("team_id"),
+            Some("team_slug"),
+            Option::<fn(&str)>::None,
+        )
+        .await
+        .unwrap();
+
+        assert!(reused.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_reuse_existing_token_with_linked_team_access() {
+        let api_client = MockApiClient::new();
+
+        let reused = reuse_existing_token(
+            Token::existing("good-token".to_string()),
+            &api_client,
+            Some("team_id"),
+            Some("team_slug"),
+            Option::<fn(&str)>::None,
+        )
+        .await
+        .unwrap();
+
+        assert_matches!(reused, Some(Token::Existing(ref token)) if token.expose() == "good-token");
+    }
+
+    #[tokio::test]
+    async fn test_reuse_existing_token_skips_team_check_when_unlinked() {
+        let api_client = MockApiClient::new();
+
+        // The team-forbidden token is reusable when no team is linked because
+        // the team access check should not run at all.
+        let reused = reuse_existing_token(
+            Token::existing("team-forbidden-token".to_string()),
+            &api_client,
+            None,
+            None,
+            Option::<fn(&str)>::None,
+        )
+        .await
+        .unwrap();
+
+        assert!(reused.is_some());
+    }
+
+    #[tokio::test]
     async fn test_reuse_existing_token_with_recovery_discards_invalid_token_errors() {
         let _lock = ENV_LOCK.lock().await;
         let turbo_config_dir = create_mock_config_dir();
@@ -807,6 +987,8 @@ mod tests {
         let reused = reuse_existing_token_with_recovery(
             Token::existing("forbidden-token".to_string()),
             &api_client,
+            None,
+            None,
             "Using existing Vercel login.",
             &color_config,
         )

--- a/crates/turborepo-auth/src/auth/mod.rs
+++ b/crates/turborepo-auth/src/auth/mod.rs
@@ -159,6 +159,13 @@ pub struct LoginOptions<'a, T: Client + TokenClient> {
     pub existing_token: Option<&'a str>,
     pub force: bool,
     pub sso_login_callback_port: Option<u16>,
+    /// The team currently linked in configuration, if any. When set, reusing
+    /// an existing token additionally requires that the token still has
+    /// access to this team. This catches tokens that are active at the user
+    /// level but have lost team access (e.g. an expired SAML session on an
+    /// SSO-enforced team).
+    pub linked_team_id: Option<&'a str>,
+    pub linked_team_slug: Option<&'a str>,
 }
 impl<'a, T: Client + TokenClient> LoginOptions<'a, T> {
     pub fn new(color_config: &'a ColorConfig, login_url: &'a str, api_client: &'a T) -> Self {
@@ -172,6 +179,8 @@ impl<'a, T: Client + TokenClient> LoginOptions<'a, T> {
             existing_token: None,
             force: false,
             sso_login_callback_port: None,
+            linked_team_id: None,
+            linked_team_slug: None,
         }
     }
 }

--- a/crates/turborepo-auth/src/auth/sso.rs
+++ b/crates/turborepo-auth/src/auth/sso.rs
@@ -162,6 +162,9 @@ pub async fn sso_login<T: Client + TokenClient>(
         existing_token,
         force,
         sso_login_callback_port,
+        // SSO login validates team access via `is_valid_sso` instead.
+        linked_team_id: _,
+        linked_team_slug: _,
     } = *options;
 
     let sso_team = sso_team.ok_or(Error::EmptySSOTeam)?;
@@ -640,6 +643,8 @@ mod tests {
             existing_token: None,
             sso_team: None,
             force: false,
+            linked_team_id: None,
+            linked_team_slug: None,
             sso_login_callback_port: None,
         };
 
@@ -661,6 +666,8 @@ mod tests {
             existing_token: Some("existing-token"),
             sso_team: Some("my-team"),
             force: false,
+            linked_team_id: None,
+            linked_team_slug: None,
             sso_login_callback_port: None,
         };
 
@@ -683,6 +690,8 @@ mod tests {
             existing_token: Some("existing-token"),
             sso_team: Some("my-team"),
             force: false,
+            linked_team_id: None,
+            linked_team_slug: None,
             sso_login_callback_port: None,
         };
 
@@ -709,6 +718,8 @@ mod tests {
             sso_team: Some("my-team"),
             force: false,
             sso_login_callback_port: None,
+            linked_team_id: None,
+            linked_team_slug: None,
             color_config: &color_config,
         };
 

--- a/crates/turborepo-auth/src/lib.rs
+++ b/crates/turborepo-auth/src/lib.rs
@@ -174,18 +174,16 @@ impl Token {
 
     /// Checks if the token is still valid. The checks ran are:
     /// 1. If the token is active.
-    /// 2. If the token has access to the cache.
-    ///     - If the token is forbidden from accessing the cache, we consider it
-    ///       invalid.
-    /// 3. We are able to fetch the user associated with the token.
+    /// 2. We are able to fetch the user associated with the token (only when
+    ///    `valid_message_fn` is provided).
+    ///
+    /// This validates token activity and user identity only. It does NOT
+    /// verify team or cache access; use `has_cache_access` for that.
     ///
     /// ## Arguments
     /// * `client` - The client to use for API calls.
     /// * `valid_message_fn` - An optional callback that gets called if the
     ///   token is valid. It will be passed the user's email.
-    ///
-    /// This validates token activity and user identity only. Cache access is
-    /// checked later when the cache is actually used.
     // TODO(voz): This should do a `get_user` or `get_teams` instead of the caller
     // doing it. The reason we don't do it here is because the caller
     // needs to do printing and requires the user struct, which we don't want to

--- a/crates/turborepo-lib/src/commands/login/mod.rs
+++ b/crates/turborepo-lib/src/commands/login/mod.rs
@@ -89,12 +89,16 @@ async fn login_no_sso(base: &mut CommandBase, force: bool) -> Result<(), Error> 
     let login_url_source = base.opts.api_client_opts.login_url_source;
     let api_url_source = base.opts.api_client_opts.api_url_source;
     let existing_token = base.opts.api_client_opts.token.as_ref().map(|t| t.expose());
+    let linked_team_id = base.opts.api_client_opts.team_id.as_deref();
+    let linked_team_slug = base.opts.api_client_opts.team_slug.as_deref();
 
     let options = LoginOptions {
         existing_token,
         force,
         login_url_source,
         api_url_source,
+        linked_team_id,
+        linked_team_slug,
         ..LoginOptions::new(&color_config, &login_url_config, &api_client)
     };
 


### PR DESCRIPTION
## Why

Users on SAML-enforced teams get stuck in a login loop. Their token stays active at the user level after the SAML session expires, so team-scoped requests 403 while `turbo login` keeps saying "Using existing login" and never re-authenticates. Previously `--force` was the escape hatch, but it is now a no-op for Vercel logins, leaving no way out of the loop via plain `turbo login`.

Root cause: token reuse during login validated only token activity and user identity (`Token::is_valid`), never team access. The `--sso-team` path doesn't have this hole because `is_valid_sso` checks the team.

## What

- `turbo login` now verifies the stored token still has access to the linked team (via the existing `has_cache_access` check) before reusing it. On a 403, the token is discarded and a fresh interactive login runs, which re-establishes the SAML session.
- The check composes with the Vercel token-recovery path: if the refreshed token also lacks team access, full device-flow re-auth happens.
- Non-Vercel (self-hosted) logins skip the check, since self-hosted caches aren't guaranteed to implement the caching-status endpoint and an error there would hard-fail login.
- Fixed the self-contradictory doc comment on `Token::is_valid`.

## How to test

1. On a SAML-enforced team, log in and link a repo.
2. Let the SAML session expire (or revoke it from the Vercel dashboard) so cache requests 403.
3. Run `turbo login` with no flags. Before: "Using existing login" and continued 403s. After: a fresh login flow starts and the new token works.

Unit tests cover the three reuse outcomes: discard on team 403, reuse on team access, and no team check when no team is linked.