### PR TITLE
fix: Stop shim from killing local turbo on Windows Ctrl+C

### DIFF
--- a/crates/turborepo-lib/src/child.rs
+++ b/crates/turborepo-lib/src/child.rs
@@ -5,13 +5,17 @@ use shared_child::SharedChild;
 /// Spawns a child in a way where SIGINT is correctly forwarded to the child
 pub fn spawn_child(mut command: Command) -> Result<Arc<SharedChild>, io::Error> {
     let shared_child = Arc::new(SharedChild::spawn(&mut command)?);
+
+    #[cfg(not(target_os = "windows"))]
     let handler_shared_child = shared_child.clone();
 
     ctrlc::set_handler(move || {
-        // on windows, we can't send signals so just kill
-        // we are quitting anyways so just ignore
-        #[cfg(target_os = "windows")]
-        handler_shared_child.kill().ok();
+        // On Windows the child shares our console, so the OS delivers the
+        // CTRL_C_EVENT to it directly and it can run its own graceful
+        // shutdown. Killing the child here would race ahead of that
+        // shutdown and terminate it immediately, so this handler only
+        // swallows the event to keep this process alive long enough to
+        // collect the child's exit status.
 
         // on unix, we should send a SIGTERM to the child
         // so that go can gracefully shut down process groups


### PR DESCRIPTION
## Why

Follow-up to #12651. On Windows, graceful shutdown worked with `--skip-infer` but not without it. Without `--skip-infer`, the global `turbo` binary spawns the repo-local `turbo` as a child process, and the shim's Ctrl+C handler called `TerminateProcess` on that child immediately. The local turbo also receives the `CTRL_C_EVENT` from the console and begins graceful shutdown, but the parent's kill wins the race, so tasks die without running their shutdown handlers. The handler predates graceful shutdown existing on Windows ("we are quitting anyways so just ignore").

## What

On Windows, the shim's Ctrl+C handler is now a no-op that only swallows the console event so the shim stays alive to collect the child's exit status. The child shares the console and receives `CTRL_C_EVENT` directly from the OS, so it owns its own graceful shutdown (and second-Ctrl+C force kill), mirroring the existing Unix design where the shim ignores SIGINT and the child receives the signal from the kernel.

Unix behavior is unchanged.

## How

Not coverable by unit tests (requires real console `CTRL_C_EVENT` delivery across processes). Verified manually on Windows with the repro from #12651:

- Before: `turbo.exe start` (no `--skip-infer`) exited immediately on Ctrl+C with no graceful shutdown; `turbo.exe start --skip-infer` shut down gracefully.
- After: both invocations shut down gracefully, in both cmd and PowerShell.

To review: `spawn_child` is used by the shim's local-turbo spawn, `turbo gen`'s npx child, and the graph visualizer child. All spawn console-sharing children that receive the console event directly, so the no-op is correct for each.