### PR TITLE
ci: Add PR workflow timeouts

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   docs-quality:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -15,7 +15,7 @@ jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
   determine_changes:
     name: Determine changes
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: read
@@ -59,7 +59,7 @@ jobs:
     needs: determine_changes
     if: ${{ needs.determine_changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -79,7 +79,7 @@ jobs:
     needs: determine_changes
     if: ${{ needs.determine_changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     env:
       # AWS-backed sccache is disabled.
       # SCCACHE_BUCKET: turborepo-sccache
@@ -114,7 +114,7 @@ jobs:
     needs: determine_changes
     if: ${{ needs.determine_changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -131,7 +131,7 @@ jobs:
     needs: determine_changes
     if: ${{ needs.determine_changes.outputs.formatting == 'true' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     env:
       TURBO_CACHE: local:rw
     steps:

--- a/.github/workflows/pr-clean-caches.yml
+++ b/.github/workflows/pr-clean-caches.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     if: ${{ github.ref != 'refs/heads/main' }}
     steps:
       - name: Cleanup

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -13,6 +13,7 @@ jobs:
   find-changes:
     name: Find path changes
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: read
@@ -115,7 +116,7 @@ jobs:
     name: "(${{matrix.os.name}}, Node ${{matrix.node-version}})"
     needs: find-changes
     if: needs.find-changes.outputs.is-release-pr != 'true' && needs.find-changes.outputs.js-packages == 'true'
-    timeout-minutes: 30
+    timeout-minutes: 15
     runs-on: ${{ matrix.os.runner }}
     strategy:
       fail-fast: false
@@ -174,7 +175,7 @@ jobs:
   summary:
     name: JS Test Summary
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     if: always()
     needs:
       - find-changes

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -15,7 +15,7 @@ jobs:
   find-changes:
     name: Find path changes
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: read
@@ -187,7 +187,7 @@ jobs:
       - find-changes
     if: ${{ needs.find-changes.outputs.is-release-pr != 'true' && needs.find-changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -219,7 +219,7 @@ jobs:
 
   rust_test_macos:
     runs-on: macos-latest-xlarge
-    timeout-minutes: 90
+    timeout-minutes: 15
     env:
       CARGO_INCREMENTAL: 0
     needs:
@@ -248,7 +248,7 @@ jobs:
           tool: nextest
 
       - name: Run tests
-        timeout-minutes: 90
+        timeout-minutes: 15
         run: |
           cargo nextest run --workspace \
             --exclude turborepo-lsp \
@@ -259,7 +259,7 @@ jobs:
 
   rust_test_windows:
     runs-on: windows-latest-8-core-oss
-    timeout-minutes: 180
+    timeout-minutes: 15
     env:
       CARGO_INCREMENTAL: 0
     needs:
@@ -322,7 +322,7 @@ jobs:
           tar -xf "%TEMP%\nextest.zip" -C "%USERPROFILE%\.cargo\bin"
 
       - name: Run tests
-        timeout-minutes: 180
+        timeout-minutes: 15
         run: |
           cargo nextest run --workspace \
             --exclude turborepo-lsp \
@@ -335,7 +335,7 @@ jobs:
 
   rust_test_ubuntu:
     runs-on: ubuntu-latest-8-core-oss
-    timeout-minutes: 90
+    timeout-minutes: 15
     env:
       CARGO_INCREMENTAL: 0
     needs:
@@ -364,7 +364,7 @@ jobs:
           tool: nextest
 
       - name: Run tests
-        timeout-minutes: 90
+        timeout-minutes: 15
         run: |
           cargo nextest run --workspace \
             --exclude turborepo-lsp \
@@ -461,7 +461,7 @@ jobs:
     needs:
       - find-changes
     if: ${{ needs.find-changes.outputs.is-release-pr != 'true' && needs.find-changes.outputs.native-lib == 'true' }}
-    timeout-minutes: 30
+    timeout-minutes: 15
     runs-on: ${{ matrix.os.runner }}
     strategy:
       fail-fast: false
@@ -511,7 +511,7 @@ jobs:
   summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     if: always()
     needs:
       - find-changes


### PR DESCRIPTION
## Why
PR checks should fail sooner when a job hangs or runs unexpectedly long, reducing wasted CI time and improving feedback loops.

## What
Sets PR-capable GitHub Actions jobs to a 15 minute timeout.

## How
Updated timeout-minutes values in pull_request workflows and added a missing job-level timeout for JS package change detection. Verified via pre-push hooks.