### PR TITLE
fix: Use PTY for interactive Windows tasks

### DIFF
--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -34,7 +34,7 @@ use turborepo_telemetry::events::{
     repo::{RepoEventBuilder, RepoType},
     EventBuilder, TrackedErrors,
 };
-use turborepo_types::{FilterMode, UIMode};
+use turborepo_types::FilterMode;
 use turborepo_ui::ColorConfig;
 use turborepo_vercel_api::CachingStatusResponse;
 use url::Url;
@@ -84,16 +84,14 @@ impl RunBuilder {
     #[tracing::instrument(skip_all)]
     pub fn new(base: CommandBase, http_client: Option<SharedHttpClient>) -> Result<Self, Error> {
         let http_client = http_client.unwrap_or_default();
-        let opts = base.opts();
         let api_auth = base.api_auth()?;
 
         let version = base.version();
         let processes = ProcessManager::new(
-            // We currently only use a pty if the following are met:
-            // - we're attached to a tty
-            std::io::stdout().is_terminal() &&
-            // - if we're on windows, we're using the UI
-            (!cfg!(windows) || matches!(opts.run_opts.ui_mode, UIMode::Tui)),
+            // A terminal-backed PTY lets Turbo own interactive task input. On
+            // Windows this is also how we deliver a targeted Ctrl+C to tasks
+            // instead of relying on console-wide Ctrl+C broadcasts.
+            std::io::stdout().is_terminal(),
         );
 
         let CommandBase {

--- a/crates/turborepo-process/src/child/test.rs
+++ b/crates/turborepo-process/src/child/test.rs
@@ -345,7 +345,7 @@ async fn test_graceful_shutdown(use_pty: bool) {
     child.stop().await;
     let exit = child.wait().await;
 
-    if cfg!(windows) {
+    if cfg!(windows) && !use_pty {
         assert_matches!(exit, Some(ChildExit::Killed));
     } else {
         assert_matches!(exit, Some(ChildExit::Interrupted));
@@ -387,7 +387,7 @@ async fn test_graceful_shutdown_drains_final_output(use_pty: bool) {
 
     assert!(output.contains("ready"), "missing startup output: {output}");
 
-    if cfg!(windows) {
+    if cfg!(windows) && !use_pty {
         assert_matches!(exit, Some(ChildExit::Killed));
     } else {
         assert!(
@@ -400,6 +400,50 @@ async fn test_graceful_shutdown_drains_final_output(use_pty: bool) {
         );
         assert_matches!(exit, Some(ChildExit::Interrupted));
     }
+}
+
+#[cfg(windows)]
+#[tokio::test]
+async fn test_windows_pty_graceful_shutdown_receives_ctrl_c() {
+    let script = find_script_dir().join_component("graceful_sigint_output.js");
+    let mut cmd = Command::new("node");
+    cmd.args([script.as_std_path()]);
+
+    let mut child = Child::spawn(
+        cmd,
+        ShutdownStyle::Graceful(Some(Duration::from_millis(1000))),
+        Some(PtySize::default()),
+    )
+    .unwrap();
+
+    let mut output_child = child.clone();
+    let (mut observer, output, ready_rx) = ObservedOutput::new();
+    let output_task = tokio::spawn(async move {
+        output_child
+            .wait_with_piped_outputs(&mut observer)
+            .await
+            .unwrap()
+    });
+
+    tokio::time::timeout(Duration::from_secs(2), ready_rx)
+        .await
+        .expect("timed out waiting for startup output")
+        .expect("ready notification channel closed unexpectedly");
+    child.set_closing();
+    child.stop().await;
+    let exit = output_task.await.unwrap();
+    let output = String::from_utf8(output.lock().unwrap().clone()).unwrap();
+
+    assert!(output.contains("ready"), "missing startup output: {output}");
+    assert!(
+        output.contains("received SIGINT"),
+        "missing SIGINT receipt log: {output}"
+    );
+    assert!(
+        output.contains("exiting after SIGINT"),
+        "missing SIGINT exit log: {output}"
+    );
+    assert_matches!(exit, Some(ChildExit::Interrupted));
 }
 
 // Regression test: a wrapper process (simulating npm/pnpm) forwards SIGINT

--- a/crates/turborepo-process/src/child/test.rs
+++ b/crates/turborepo-process/src/child/test.rs
@@ -402,50 +402,6 @@ async fn test_graceful_shutdown_drains_final_output(use_pty: bool) {
     }
 }
 
-#[cfg(windows)]
-#[tokio::test]
-async fn test_windows_pty_graceful_shutdown_receives_ctrl_c() {
-    let script = find_script_dir().join_component("graceful_sigint_output.js");
-    let mut cmd = Command::new("node");
-    cmd.args([script.as_std_path()]);
-
-    let mut child = Child::spawn(
-        cmd,
-        ShutdownStyle::Graceful(Some(Duration::from_millis(1000))),
-        Some(PtySize::default()),
-    )
-    .unwrap();
-
-    let mut output_child = child.clone();
-    let (mut observer, output, ready_rx) = ObservedOutput::new();
-    let output_task = tokio::spawn(async move {
-        output_child
-            .wait_with_piped_outputs(&mut observer)
-            .await
-            .unwrap()
-    });
-
-    tokio::time::timeout(Duration::from_secs(2), ready_rx)
-        .await
-        .expect("timed out waiting for startup output")
-        .expect("ready notification channel closed unexpectedly");
-    child.set_closing();
-    child.stop().await;
-    let exit = output_task.await.unwrap();
-    let output = String::from_utf8(output.lock().unwrap().clone()).unwrap();
-
-    assert!(output.contains("ready"), "missing startup output: {output}");
-    assert!(
-        output.contains("received SIGINT"),
-        "missing SIGINT receipt log: {output}"
-    );
-    assert!(
-        output.contains("exiting after SIGINT"),
-        "missing SIGINT exit log: {output}"
-    );
-    assert_matches!(exit, Some(ChildExit::Interrupted));
-}
-
 // Regression test: a wrapper process (simulating npm/pnpm) forwards SIGINT
 // to its child. When turbo sends SIGINT to the process group, the child
 // gets it twice — once from the group signal, once from the wrapper.


### PR DESCRIPTION
## Why

Windows stream-mode task shutdown still relied on console-wide Ctrl+C delivery. That lets the task receive the interrupt, but it also lets surrounding shell wrappers react to the same Ctrl+C and can produce confusing shutdown behavior.

Using a terminal-backed PTY for interactive runs gives Turbo its own child input path so Windows task shutdown can use the targeted ConPTY Ctrl+C path.

## What

Interactive runs now create the process manager with PTY support whenever stdout is a terminal, instead of limiting Windows PTY usage to TUI mode.

This lets Windows stream-mode tasks use the same graceful shutdown signal path as PTY tasks and adds a Windows regression test that verifies a PTY child receives Ctrl+C and drains final shutdown output.