### PR TITLE
fix: Cache outputs through internal symlinks

### DIFF
--- a/crates/turborepo-cache/src/cache_archive/create.rs
+++ b/crates/turborepo-cache/src/cache_archive/create.rs
@@ -334,6 +334,8 @@ fn open_parent_dir(
     use std::os::unix::io::AsRawFd;
 
     let mut dir = fs::File::open(anchor.as_std_path())?;
+    let real_anchor = anchor.to_realpath()?;
+    let mut dir_path = real_anchor.clone();
     let mut components = file_path.components().peekable();
 
     while let Some(component) = components.next() {
@@ -342,13 +344,76 @@ fn open_parent_dir(
             return Ok((dir, component.to_string()));
         }
 
-        dir = open_dir_at(dir.as_raw_fd(), component)?;
+        let (next_dir, next_dir_path) = open_dir_at_allowing_internal_symlink(
+            &real_anchor,
+            &dir_path,
+            dir.as_raw_fd(),
+            component,
+        )?;
+        dir = next_dir;
+        dir_path = next_dir_path;
     }
 
     Err(CacheError::InvalidFilePath(
         file_path.to_string(),
         Backtrace::capture(),
     ))
+}
+
+#[cfg(unix)]
+fn open_dir_at_allowing_internal_symlink(
+    real_anchor: &AbsoluteSystemPath,
+    parent_path: &AbsoluteSystemPath,
+    parent_fd: i32,
+    component: &str,
+) -> Result<(fs::File, AbsoluteSystemPathBuf), CacheError> {
+    match open_dir_at(parent_fd, component) {
+        Ok(file) => {
+            let path = parent_path.join_component(component).to_realpath()?;
+            Ok((file, path))
+        }
+        Err(CacheError::IO(err, _)) if err.kind() == std::io::ErrorKind::NotADirectory => {
+            let link_target = read_link_at(parent_fd, component)?;
+            let target_path = if link_target.is_absolute() {
+                AbsoluteSystemPathBuf::new(link_target.as_str())?
+            } else {
+                parent_path.resolve(AnchoredSystemPath::new(link_target.as_str())?)
+            };
+
+            let file = fs::File::open(target_path.as_std_path())?;
+            if !file.metadata()?.is_dir() {
+                return Err(CacheError::CreateUnsupportedFileType(Backtrace::capture()));
+            }
+
+            let real_target = file_realpath(&file, &target_path)?;
+            if !real_target.starts_with(real_anchor) {
+                return Err(CacheError::LinkOutsideOfDirectory(
+                    link_target.to_string(),
+                    Backtrace::capture(),
+                ));
+            }
+
+            Ok((file, real_target))
+        }
+        Err(err) => Err(err),
+    }
+}
+
+#[cfg(unix)]
+fn file_realpath(
+    file: &fs::File,
+    fallback_path: &AbsoluteSystemPath,
+) -> Result<AbsoluteSystemPathBuf, CacheError> {
+    use std::os::unix::io::AsRawFd;
+
+    for fd_dir in ["/proc/self/fd", "/dev/fd"] {
+        let fd_path = std::path::PathBuf::from(format!("{}/{}", fd_dir, file.as_raw_fd()));
+        if let Ok(realpath) = std::fs::read_link(fd_path) {
+            return Ok(AbsoluteSystemPathBuf::try_from(realpath.as_path())?);
+        }
+    }
+
+    fallback_path.to_realpath().map_err(Into::into)
 }
 
 #[cfg(unix)]
@@ -881,6 +946,129 @@ mod tests {
 
         let link = input_dir_path.join_component("linked");
         link.symlink_to_dir(outside_dir_path.as_str())?;
+
+        let mut cache_archive = CacheWriter::create(&archive_path)?;
+        let file_path = AnchoredSystemPathBuf::from_raw("linked/secret.txt")?;
+        assert!(cache_archive.add_file(&input_dir_path, &file_path).is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn add_file_allows_file_through_internal_symlinked_parent() -> Result<()> {
+        let input_dir = tempdir()?;
+        let input_dir_path = AbsoluteSystemPathBuf::try_from(input_dir.path())?;
+        let archive_dir = tempdir()?;
+        let archive_path = AbsoluteSystemPathBuf::try_from(archive_dir.path().join("out.tar"))?;
+
+        let actual_dist = input_dir_path.join_component("actual-dist");
+        actual_dist.create_dir_all()?;
+        actual_dist
+            .join_component("file.txt")
+            .create_with_contents("hello")?;
+
+        let link = input_dir_path.join_component("dist");
+        link.symlink_to_dir("actual-dist")?;
+
+        let mut cache_archive = CacheWriter::create(&archive_path)?;
+        let file_path = AnchoredSystemPathBuf::from_raw("dist/file.txt")?;
+        cache_archive.add_file(&input_dir_path, &file_path)?;
+        cache_archive.finish()?;
+
+        let restore_dir = tempdir()?;
+        let restore_dir_path = AbsoluteSystemPathBuf::try_from(restore_dir.path())?;
+        let mut restore = CacheReader::open(&archive_path)?;
+        let (files, _) = restore.restore(&restore_dir_path, None)?;
+
+        assert_eq!(files, vec![file_path]);
+        assert_eq!(
+            restore_dir_path
+                .join_component("dist")
+                .join_component("file.txt")
+                .read_to_string()?,
+            "hello"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn add_file_allows_repo_relative_file_through_internal_symlinked_parent() -> Result<()> {
+        let repo_dir = tempdir()?;
+        let repo_dir_path = AbsoluteSystemPathBuf::try_from(repo_dir.path())?;
+        let app_dir = repo_dir_path
+            .join_component("packages")
+            .join_component("app");
+        app_dir.create_dir_all()?;
+
+        let archive_dir = tempdir()?;
+        let archive_path = AbsoluteSystemPathBuf::try_from(archive_dir.path().join("out.tar"))?;
+
+        let actual_dist = app_dir.join_component("actual-dist");
+        actual_dist.create_dir_all()?;
+        actual_dist
+            .join_component("file.txt")
+            .create_with_contents("hello")?;
+
+        let link = app_dir.join_component("dist");
+        link.symlink_to_dir("actual-dist")?;
+
+        let mut cache_archive = CacheWriter::create(&archive_path)?;
+        let file_path = AnchoredSystemPathBuf::from_raw("packages/app/dist/file.txt")?;
+        cache_archive.add_file(&repo_dir_path, &file_path)?;
+        cache_archive.finish()?;
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn add_file_allows_repo_relative_internal_symlinked_directory() -> Result<()> {
+        let repo_dir = tempdir()?;
+        let repo_dir_path = AbsoluteSystemPathBuf::try_from(repo_dir.path())?;
+        let app_dir = repo_dir_path
+            .join_component("packages")
+            .join_component("app");
+        app_dir.create_dir_all()?;
+
+        let archive_dir = tempdir()?;
+        let archive_path = AbsoluteSystemPathBuf::try_from(archive_dir.path().join("out.tar"))?;
+
+        app_dir.join_component("actual-dist").create_dir_all()?;
+        app_dir
+            .join_component("dist")
+            .symlink_to_dir("actual-dist")?;
+
+        let mut cache_archive = CacheWriter::create(&archive_path)?;
+        let file_path = AnchoredSystemPathBuf::from_raw("packages/app/dist/")?;
+        cache_archive.add_file(&repo_dir_path, &file_path)?;
+        cache_archive.finish()?;
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn add_file_rejects_relative_symlink_escape() -> Result<()> {
+        let root_dir = tempdir()?;
+        let input_path = root_dir.path().join("input");
+        let outside_path = root_dir.path().join("outside");
+        std::fs::create_dir_all(&input_path)?;
+        std::fs::create_dir_all(&outside_path)?;
+
+        let input_dir_path = AbsoluteSystemPathBuf::try_from(input_path.as_path())?;
+        let outside_dir_path = AbsoluteSystemPathBuf::try_from(outside_path.as_path())?;
+        let archive_dir = tempdir()?;
+        let archive_path = AbsoluteSystemPathBuf::try_from(archive_dir.path().join("out.tar"))?;
+
+        outside_dir_path
+            .join_component("secret.txt")
+            .create_with_contents("secret")?;
+
+        let link = input_dir_path.join_component("linked");
+        link.symlink_to_dir("../outside")?;
 
         let mut cache_archive = CacheWriter::create(&archive_path)?;
         let file_path = AnchoredSystemPathBuf::from_raw("linked/secret.txt")?;

--- a/crates/turborepo-cache/src/fs.rs
+++ b/crates/turborepo-cache/src/fs.rs
@@ -537,6 +537,50 @@ mod test {
         Ok(())
     }
 
+    #[test]
+    #[cfg(unix)]
+    fn put_allows_file_through_internal_symlinked_parent() -> Result<()> {
+        let repo_root = tempdir()?;
+        let repo_root_path = AbsoluteSystemPath::from_std_path(repo_root.path())?;
+        let app_dir = repo_root_path
+            .join_component("packages")
+            .join_component("app");
+        app_dir.create_dir_all()?;
+
+        let actual_dist = app_dir.join_component("actual-dist");
+        actual_dist.create_dir_all()?;
+        actual_dist
+            .join_component("file.txt")
+            .create_with_contents("hello")?;
+        app_dir
+            .join_component("dist")
+            .symlink_to_dir("actual-dist")?;
+        let log_dir = app_dir.join_component(".turbo");
+        log_dir.create_dir_all()?;
+        log_dir
+            .join_component("turbo-build.log")
+            .create_with_contents("log")?;
+
+        let cache = FSCache::new(
+            Utf8Path::new("cache"),
+            repo_root_path,
+            None,
+            LazyScmState::resolved(None),
+        )?;
+        let files = vec![
+            AnchoredSystemPathBuf::from_raw("packages/app/.turbo/turbo-build.log")?,
+            AnchoredSystemPathBuf::from_raw("packages/app/dist")?,
+            AnchoredSystemPathBuf::from_raw("packages/app/dist/file.txt")?,
+        ];
+
+        cache.put(repo_root_path, "symlinked-parent", &files, 50)?;
+        let result = cache.fetch(repo_root_path, "symlinked-parent")?;
+
+        assert!(result.is_some());
+
+        Ok(())
+    }
+
     /// Test that multiple concurrent writes to the same hash don't corrupt the
     /// cache. This tests the atomic write pattern
     /// (write-to-temp-then-rename).

--- a/crates/turborepo-run-cache/src/lib.rs
+++ b/crates/turborepo-run-cache/src/lib.rs
@@ -553,11 +553,12 @@ impl TaskCache {
 
         let validated_inclusions = self.repo_relative_globs.validated_inclusions()?;
         let validated_exclusions = self.repo_relative_globs.validated_exclusions()?;
-        let files_to_be_cached = globwalk::globwalk(
+        let files_to_be_cached = globwalk::globwalk_with_settings(
             &self.run_cache.repo_root,
             &validated_inclusions,
             &validated_exclusions,
             globwalk::WalkType::All,
+            globwalk::Settings::default().follow_links(),
         )?;
 
         for path in &files_to_be_cached {
@@ -1382,5 +1383,39 @@ mod test {
             "outputs outside repo root should be rejected before cache upload"
         );
         assert!(task_cache.expanded_outputs().is_empty());
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn save_outputs_does_not_follow_symlink_that_escapes_repo_root() {
+        let temp = tempdir().unwrap();
+        let repo_dir = temp.path().join("repo");
+        let outside_dir = temp.path().join("outside");
+        std::fs::create_dir_all(&repo_dir).unwrap();
+        std::fs::create_dir_all(&outside_dir).unwrap();
+        std::fs::write(outside_dir.join("output.txt"), b"outside").unwrap();
+        std::os::unix::fs::symlink("../outside", repo_dir.join("dist")).unwrap();
+
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_dir.as_path()).unwrap();
+        let mut task_cache = task_cache_for_outputs(&repo_root, vec!["dist/**".to_string()]);
+        let telemetry = PackageTaskEventBuilder::new("pkg", "build");
+
+        task_cache
+            .save_outputs(Duration::from_millis(10), &telemetry)
+            .await
+            .unwrap();
+
+        task_cache.run_cache.cache.wait().await.unwrap();
+        let cached = task_cache
+            .run_cache
+            .cache
+            .fetch(&repo_root, "test-hash")
+            .await
+            .unwrap();
+
+        assert!(
+            cached.is_none(),
+            "symlinked output outside repo root should not write a cache artifact"
+        );
     }
 }


### PR DESCRIPTION
## Why

Fixes https://github.com/vercel/turborepo/issues/13042.

Tasks can produce cache outputs where an output directory is an internal symlink, such as `dist -> actual-dist`. Those outputs should be cacheable without `Not a directory` warnings, while symlink escapes outside the repo must remain rejected.

## What

Allow task output glob expansion and archive creation to handle symlinked parent directories that resolve inside the repo/cache anchor. Preserve no-follow behavior for final file components and reject symlink parent escapes.

## How

Validated with:

- `cargo fmt --check`
- `cargo test -p turborepo-cache cache_archive::create::tests:: -- --nocapture`
- `cargo test -p turborepo-cache fs::test::put_allows_file_through_internal_symlinked_parent -- --nocapture`
- `cargo test -p turborepo-run-cache save_outputs -- --nocapture`
- `cargo build -p turbo`

Manual repro for #13042 now gets a cache hit on the second run without the `Not a directory` warning.