### PR TITLE
Update Next.js version to 16.2.5

### DIFF
--- a/examples/non-monorepo/package.json
+++ b/examples/non-monorepo/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "geist": "^1.7.1",
-    "next": "16.2.0",
+    "next": "16.2.5",
     "react": "19.2.3",
     "react-dom": "19.2.0"
   },


### PR DESCRIPTION
Next.js is a React framework for building full-stack web applications. From 13.4.13 to before 15.5.16 and 16.2.5, self-hosted applications using the built-in Node.js server can be vulnerable to server-side request forgery through crafted WebSocket upgrade requests. An attacker can cause the server to proxy requests to arbitrary internal or external destinations, which may expose internal services or cloud metadata endpoints. Vercel-hosted deployments are not affected. This vulnerability is fixed in 15.5.16 and 16.2.5.


