### PR TITLE
fix: Preserve PNPM deps check config

### DIFF
--- a/crates/turborepo-env/src/lib.rs
+++ b/crates/turborepo-env/src/lib.rs
@@ -744,23 +744,6 @@ mod tests {
     }
 
     #[test]
-    fn test_builtin_pass_through_env_includes_pnpm_deps_check_marker() {
-        let env = EnvironmentVariableMap(
-            vec![("pnpm_config_verify_deps_before_run", "false")]
-                .into_iter()
-                .map(|(k, v)| (k.to_owned(), v.to_owned()))
-                .collect(),
-        );
-
-        let output = env.from_wildcards(BUILTIN_PASS_THROUGH_ENV).unwrap();
-
-        assert_eq!(
-            output.get("pnpm_config_verify_deps_before_run"),
-            Some(&"false".to_string())
-        );
-    }
-
-    #[test]
     fn test_compiled_wildcards_with_excludes() {
         let env = EnvironmentVariableMap(
             vec![("FOO", "1"), ("FOOBAR", "2"), ("FOOD", "3"), ("BAR", "4")]

--- a/crates/turborepo-env/src/lib.rs
+++ b/crates/turborepo-env/src/lib.rs
@@ -84,6 +84,7 @@ pub const BUILTIN_PASS_THROUGH_ENV: &[&str] = &[
     "HOMEDRIVE",
     "HOMEPATH",
     "PNPM_HOME",
+    "pnpm_config_verify_deps_before_run",
     "NPM_CONFIG_STORE_DIR",
 ];
 
@@ -740,6 +741,23 @@ mod tests {
     fn test_builtin_pass_through_env_compiles() {
         CompiledWildcards::compile(BUILTIN_PASS_THROUGH_ENV)
             .expect("BUILTIN_PASS_THROUGH_ENV should compile without error");
+    }
+
+    #[test]
+    fn test_builtin_pass_through_env_includes_pnpm_deps_check_marker() {
+        let env = EnvironmentVariableMap(
+            vec![("pnpm_config_verify_deps_before_run", "false")]
+                .into_iter()
+                .map(|(k, v)| (k.to_owned(), v.to_owned()))
+                .collect(),
+        );
+
+        let output = env.from_wildcards(BUILTIN_PASS_THROUGH_ENV).unwrap();
+
+        assert_eq!(
+            output.get("pnpm_config_verify_deps_before_run"),
+            Some(&"false".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Why

Fixes #13083.

PNPM 11 sets `pnpm_config_verify_deps_before_run=false` while running lifecycle scripts. Turbo strict env mode filtered that marker from tasks launched inside `postinstall`, so nested `pnpm run` commands fell back to PNPM 11's default `verify-deps-before-run=install`. During `postinstall`, PNPM has not written workspace install state yet, so that deps check ran `pnpm install` again and caused recursive `postinstall` execution.

The issue reproduced with `DerYeger/pnpm11-repro` using `rm -fr node_modules && pnpm install`. It did not reproduce with `--env-mode=loose`, and strict mode also completed when only `pnpm_config_verify_deps_before_run` was passed through.

## What

Adds `pnpm_config_verify_deps_before_run` to Turbo's built-in passthrough environment list and covers it with a unit test.

## How

Verified with:

- `cargo test -p turborepo-env`
- `cargo fmt --check`