### PR TITLE
fix: Preserve pnpm peer-resolved prune entries

### DIFF
--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -310,35 +310,34 @@ pub async fn prune(
         for patch in &pruned_patches {
             prune.copy_patch_file(patch)?;
         }
+    }
 
-        // Prune pnpm-workspace.yaml's patchedDependencies so it only
-        // references patches that are actually in the pruned output.
-        if matches!(
-            package_manager,
-            turborepo_repository::package_manager::PackageManager::Pnpm
-                | turborepo_repository::package_manager::PackageManager::Pnpm6
-                | turborepo_repository::package_manager::PackageManager::Pnpm9
-        ) {
-            let ws_config =
-                turborepo_repository::package_manager::pnpm::WORKSPACE_CONFIGURATION_PATH;
-            let ws_path = AnchoredSystemPathBuf::from_raw(ws_config)?;
-            let full_ws = prune.full_directory.resolve(&ws_path);
+    // Prune pnpm-workspace.yaml's patchedDependencies so it only
+    // references patches that are actually in the pruned output.
+    if matches!(
+        package_manager,
+        turborepo_repository::package_manager::PackageManager::Pnpm
+            | turborepo_repository::package_manager::PackageManager::Pnpm6
+            | turborepo_repository::package_manager::PackageManager::Pnpm9
+    ) {
+        let ws_config = turborepo_repository::package_manager::pnpm::WORKSPACE_CONFIGURATION_PATH;
+        let ws_path = AnchoredSystemPathBuf::from_raw(ws_config)?;
+        let out_ws = prune.out_directory.resolve(&ws_path);
+        turborepo_repository::package_manager::pnpm::prune_workspace_patches(
+            &out_ws,
+            &pruned_patches,
+        )?;
+        let full_ws = prune.full_directory.resolve(&ws_path);
+        turborepo_repository::package_manager::pnpm::prune_workspace_patches(
+            &full_ws,
+            &pruned_patches,
+        )?;
+        if prune.docker {
+            let docker_ws = prune.docker_directory().resolve(&ws_path);
             turborepo_repository::package_manager::pnpm::prune_workspace_patches(
-                &full_ws,
+                &docker_ws,
                 &pruned_patches,
             )?;
-            if prune.docker {
-                let out_ws = prune.out_directory.resolve(&ws_path);
-                turborepo_repository::package_manager::pnpm::prune_workspace_patches(
-                    &out_ws,
-                    &pruned_patches,
-                )?;
-                let docker_ws = prune.docker_directory().resolve(&ws_path);
-                turborepo_repository::package_manager::pnpm::prune_workspace_patches(
-                    &docker_ws,
-                    &pruned_patches,
-                )?;
-            }
         }
     }
 

--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -548,6 +548,50 @@ impl PnpmLockfile {
         }
         Ok((pruned_packages, None))
     }
+
+    fn retain_package(
+        &self,
+        key: &str,
+        pruned_packages: &mut Packages,
+        pruned_snapshots: &mut Option<Snapshots>,
+    ) -> Result<(), crate::Error> {
+        if let Some(snapshots) = self.snapshots.as_ref() {
+            let Some(snapshot) = snapshots.get(key) else {
+                return Ok(());
+            };
+
+            if let Some(pruned_snapshots) = pruned_snapshots.as_mut() {
+                if pruned_snapshots
+                    .insert(key.to_string(), snapshot.clone())
+                    .is_some()
+                {
+                    return Ok(());
+                }
+            }
+
+            let package_key = self.package_key_for_snapshot(key)?;
+            if let Some(package) = self.get_packages(&package_key) {
+                pruned_packages
+                    .entry(package_key)
+                    .or_insert_with(|| package.clone());
+            }
+
+            for (dep_name, dep_version) in snapshot.dependencies() {
+                let dep_key = self.format_key(&dep_name, &dep_version);
+                self.retain_package(&dep_key, pruned_packages, pruned_snapshots)?;
+            }
+
+            return Ok(());
+        }
+
+        if let Some(package) = self.get_packages(key) {
+            pruned_packages
+                .entry(key.to_string())
+                .or_insert_with(|| package.clone());
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -657,7 +701,19 @@ impl crate::Lockfile for PnpmLockfile {
             .and_then(|s| s.inject_workspace_packages)
             .unwrap_or(false);
 
-        for importer in importers.values() {
+        for (importer_key, importer) in &importers {
+            if importer_key != "." {
+                for dependency in importer.dependencies.all_dependency_names() {
+                    let Some((_, version)) = importer.dependencies.find_resolution(dependency)
+                    else {
+                        continue;
+                    };
+
+                    let key = self.format_key(dependency, version);
+                    self.retain_package(&key, &mut pruned_packages, &mut pruned_snapshots)?;
+                }
+            }
+
             let injected_deps: Vec<_> = importer
                 .dependencies
                 .all_dependency_names()
@@ -1826,6 +1882,159 @@ snapshots:
         // The importer for apps/my-app should retain dependenciesMeta
         let importer = pruned_lockfile.importers.get("apps/my-app").unwrap();
         assert!(importer.dependencies_meta.is_some());
+    }
+
+    #[test]
+    fn test_subgraph_keeps_peer_resolved_importer_dependency() {
+        let yaml = r#"lockfileVersion: '9.0'
+
+importers:
+
+  .: {}
+
+  packages/backend:
+    optionalDependencies:
+      '@nestjs/throttler':
+        specifier: ^6.5.0
+        version: 6.5.0(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)
+
+packages:
+
+  '@nestjs/throttler@6.5.0':
+    resolution: {integrity: sha512-aaa}
+    peerDependencies:
+      '@nestjs/common': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+      reflect-metadata: ^0.1.13 || ^0.2.0
+
+  '@nestjs/common@11.1.26':
+    resolution: {integrity: sha512-bbb}
+
+  '@nestjs/core@11.1.26':
+    resolution: {integrity: sha512-ccc}
+
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-ddd}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-eee}
+
+snapshots:
+
+  '@nestjs/throttler@6.5.0(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)':
+    dependencies:
+      '@nestjs/common': 11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.26(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      reflect-metadata: 0.2.2
+
+  '@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+    dependencies:
+      reflect-metadata: 0.2.2
+      rxjs: 7.8.2
+
+  '@nestjs/core@11.1.26(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+    dependencies:
+      '@nestjs/common': 11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      reflect-metadata: 0.2.2
+      rxjs: 7.8.2
+
+  reflect-metadata@0.2.2: {}
+
+  rxjs@7.8.2: {}
+"#;
+        let lockfile = PnpmLockfile::from_bytes(yaml.as_bytes()).unwrap();
+
+        let workspace_packages = vec!["packages/backend".to_string()];
+        let resolved_packages = vec!["rxjs@7.8.2".to_string()];
+        let pruned = lockfile
+            .subgraph(&workspace_packages, &resolved_packages)
+            .unwrap();
+
+        let pruned_bytes = pruned.encode().unwrap();
+        let pruned_lockfile = PnpmLockfile::from_bytes(&pruned_bytes).unwrap();
+
+        let packages = pruned_lockfile
+            .packages
+            .as_ref()
+            .expect("should have packages");
+        let snapshots = pruned_lockfile
+            .snapshots
+            .as_ref()
+            .expect("should have snapshots");
+        let throttler_snapshot = "@nestjs/throttler@6.5.0(@nestjs/common@11.1.26(reflect-metadata@\
+                                  0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26(@nestjs/common@11.1.\
+                                  26(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.\
+                                  2)(rxjs@7.8.2))(reflect-metadata@0.2.2)";
+
+        assert!(packages.contains_key("@nestjs/throttler@6.5.0"));
+        assert!(snapshots.contains_key(throttler_snapshot));
+        assert!(
+            snapshots.contains_key("@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2)")
+        );
+        assert!(snapshots.contains_key(
+            "@nestjs/core@11.1.26(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.\
+             2))(reflect-metadata@0.2.2)(rxjs@7.8.2)"
+        ));
+    }
+
+    #[test]
+    fn test_subgraph_does_not_keep_unreferenced_patched_dependencies() {
+        let yaml = r#"lockfileVersion: '9.0'
+
+patchedDependencies:
+  is-odd@3.0.1:
+    hash: abc
+    path: patches/is-odd@3.0.1.patch
+
+importers:
+
+  .: {}
+
+  apps/web:
+    dependencies:
+      lodash:
+        specifier: 4.17.21
+        version: 4.17.21
+
+  packages/other:
+    dependencies:
+      is-odd:
+        specifier: 3.0.1
+        version: 3.0.1
+
+packages:
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-aaa}
+
+  is-odd@3.0.1:
+    resolution: {integrity: sha512-bbb}
+    patched: true
+
+snapshots:
+
+  lodash@4.17.21: {}
+
+  is-odd@3.0.1: {}
+"#;
+        let lockfile = PnpmLockfile::from_bytes(yaml.as_bytes()).unwrap();
+
+        let workspace_packages = vec!["apps/web".to_string()];
+        let resolved_packages = vec!["lodash@4.17.21".to_string()];
+        let pruned = lockfile
+            .subgraph(&workspace_packages, &resolved_packages)
+            .unwrap();
+
+        let pruned_bytes = pruned.encode().unwrap();
+        let pruned_lockfile = PnpmLockfile::from_bytes(&pruned_bytes).unwrap();
+        let packages = pruned_lockfile
+            .packages
+            .as_ref()
+            .expect("should have packages");
+
+        assert!(packages.contains_key("lodash@4.17.21"));
+        assert!(!packages.contains_key("is-odd@3.0.1"));
+        assert_eq!(pruned_lockfile.patched_dependencies, Some(BTreeMap::new()));
     }
 
     /// Regression test for https://github.com/vercel/turborepo/issues/12252

--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -560,13 +560,12 @@ impl PnpmLockfile {
                 return Ok(());
             };
 
-            if let Some(pruned_snapshots) = pruned_snapshots.as_mut() {
-                if pruned_snapshots
+            if let Some(pruned_snapshots) = pruned_snapshots.as_mut()
+                && pruned_snapshots
                     .insert(key.to_string(), snapshot.clone())
                     .is_some()
-                {
-                    return Ok(());
-                }
+            {
+                return Ok(());
             }
 
             let package_key = self.package_key_for_snapshot(key)?;

--- a/lockfile-tests/fixtures/pnpm-peer-resolved-importer/apps/script-runner/package.json
+++ b/lockfile-tests/fixtures/pnpm-peer-resolved-importer/apps/script-runner/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "script-runner",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@nestjs/common": "^11.1.26",
+    "@nestjs/core": "^11.1.26",
+    "@repro/backend": "workspace:*",
+    "reflect-metadata": "^0.2.2",
+    "rxjs": "^7.8.2"
+  }
+}

--- a/lockfile-tests/fixtures/pnpm-peer-resolved-importer/apps/workers/package.json
+++ b/lockfile-tests/fixtures/pnpm-peer-resolved-importer/apps/workers/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "workers",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@nestjs/common": "^11.1.26",
+    "@nestjs/core": "^11.1.26",
+    "@repro/backend": "workspace:*",
+    "reflect-metadata": "^0.2.2",
+    "rxjs": "^7.8.2"
+  }
+}

--- a/lockfile-tests/fixtures/pnpm-peer-resolved-importer/meta.json
+++ b/lockfile-tests/fixtures/pnpm-peer-resolved-importer/meta.json
@@ -1,0 +1,8 @@
+{
+  "packageManager": "pnpm",
+  "packageManagerVersion": "pnpm@10.28.1",
+  "lockfileName": "pnpm-lock.yaml",
+  "pruneTargets": ["script-runner"],
+  "docker": true,
+  "expectedFailures": []
+}

--- a/lockfile-tests/fixtures/pnpm-peer-resolved-importer/package.json
+++ b/lockfile-tests/fixtures/pnpm-peer-resolved-importer/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "pnpm-peer-resolved-importer",
+  "private": true,
+  "devDependencies": {
+    "turbo": "^2.9.18"
+  },
+  "packageManager": "pnpm@10.28.1"
+}

--- a/lockfile-tests/fixtures/pnpm-peer-resolved-importer/packages/backend/package.json
+++ b/lockfile-tests/fixtures/pnpm-peer-resolved-importer/packages/backend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@repro/backend",
+  "version": "0.0.0",
+  "private": true,
+  "peerDependencies": {
+    "@nestjs/common": "^11.1.26",
+    "@nestjs/core": "^11.1.26",
+    "@nestjs/throttler": "^6.5.0",
+    "reflect-metadata": "^0.2.2"
+  },
+  "peerDependenciesMeta": {
+    "@nestjs/throttler": {
+      "optional": true
+    }
+  }
+}

--- a/lockfile-tests/fixtures/pnpm-peer-resolved-importer/pnpm-lock.yaml
+++ b/lockfile-tests/fixtures/pnpm-peer-resolved-importer/pnpm-lock.yaml
@@ -1,0 +1,330 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      turbo:
+        specifier: ^2.9.18
+        version: 2.9.18
+
+  apps/script-runner:
+    dependencies:
+      '@nestjs/common':
+        specifier: ^11.1.26
+        version: 11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core':
+        specifier: ^11.1.26
+        version: 11.1.26(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@repro/backend':
+        specifier: workspace:*
+        version: link:../../packages/backend
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
+      rxjs:
+        specifier: ^7.8.2
+        version: 7.8.2
+
+  apps/workers:
+    dependencies:
+      '@nestjs/common':
+        specifier: ^11.1.26
+        version: 11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core':
+        specifier: ^11.1.26
+        version: 11.1.26(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@repro/backend':
+        specifier: workspace:*
+        version: link:../../packages/backend
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
+      rxjs:
+        specifier: ^7.8.2
+        version: 7.8.2
+
+  packages/backend:
+    dependencies:
+      '@nestjs/common':
+        specifier: ^11.1.26
+        version: 11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core':
+        specifier: ^11.1.26
+        version: 11.1.26(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/throttler':
+        specifier: ^6.5.0
+        version: 6.5.0(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
+
+packages:
+
+  '@borewit/text-codec@0.2.2':
+    resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
+
+  '@lukeed/csprng@1.1.0':
+    resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
+    engines: {node: '>=8'}
+
+  '@nestjs/common@11.1.26':
+    resolution: {integrity: sha512-0VARQyzuGbprvjO+slWq9Jtj1P0jYCSKAUSv9LWFNWD39ZbDzXXM1pMs35kReVXwchra0urMfTQxw4uAOfdSzA==}
+    peerDependencies:
+      class-transformer: '>=0.4.1'
+      class-validator: '>=0.13.2'
+      reflect-metadata: ^0.1.12 || ^0.2.0
+      rxjs: ^7.1.0
+    peerDependenciesMeta:
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
+
+  '@nestjs/core@11.1.26':
+    resolution: {integrity: sha512-K45zUwYpowEsVqm8qNIzsMcl4LJev0MK9zVhDnmym7YRTJ2/caslqVeKYhPRd5+Fh81IkvWUVu6vEo46uZ5mgQ==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@nestjs/common': ^11.0.0
+      '@nestjs/microservices': ^11.0.0
+      '@nestjs/platform-express': ^11.0.0
+      '@nestjs/websockets': ^11.0.0
+      reflect-metadata: ^0.1.12 || ^0.2.0
+      rxjs: ^7.1.0
+    peerDependenciesMeta:
+      '@nestjs/microservices':
+        optional: true
+      '@nestjs/platform-express':
+        optional: true
+      '@nestjs/websockets':
+        optional: true
+
+  '@nestjs/throttler@6.5.0':
+    resolution: {integrity: sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==}
+    peerDependencies:
+      '@nestjs/common': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+      reflect-metadata: ^0.1.13 || ^0.2.0
+
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
+  '@turbo/darwin-64@2.9.18':
+    resolution: {integrity: sha512-9f27peFu16ur8c0v9nUFUEyBnbKuuFsUTjHFWfmwGfzySBXbHwzU44QhZon6Mznz0cHsIr3984NQj/bVrnGSRw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@turbo/darwin-arm64@2.9.18':
+    resolution: {integrity: sha512-9A6TMRq/Ib+QnbhLlgkhOm+624wO4pzSQ/yQviQfWHOlFvaYxdnIAYmu2H6TS6y7kSVL0DvzNe04NbESTOzFVQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@turbo/linux-64@2.9.18':
+    resolution: {integrity: sha512-zCdIDtz69AnbYh913elJRRoF3QY5aa2HNnf+4rAkc7bQ+tWujiDkCNV7stazOUPggaDvhKIf2Z87qHftTeXSkw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@turbo/linux-arm64@2.9.18':
+    resolution: {integrity: sha512-Va1kXI04naMgYwqv/5Dfa36dTDx8015U7oaQAjrXa45ua9OoFjSV4OmvkML4EmXvUclQHCiBRbY8bvd0jV7eAg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@turbo/windows-64@2.9.18':
+    resolution: {integrity: sha512-m0kDhZANxSNz9ck1ybogFscHabriAsp4eDFNrN/1H5WrgTF7b3VlcPZnhuO3v2+E2KnCbeAc+UUT10BZZHdDKw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@turbo/windows-arm64@2.9.18':
+    resolution: {integrity: sha512-nUdR8WqoomUys9iIQmG45TMiizJ+5BV8egSeLLZba/AWblyp3fVBcIH1kSE58OtK4g2YzbMJEth6Ttv9w5rqMA==}
+    cpu: [arm64]
+    os: [win32]
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
+  file-type@21.3.4:
+    resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
+    engines: {node: '>=20'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  iterare@1.2.1:
+    resolution: {integrity: sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==}
+    engines: {node: '>=6'}
+
+  load-esm@1.0.3:
+    resolution: {integrity: sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==}
+    engines: {node: '>=13.2.0'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  strtok3@10.3.5:
+    resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
+    engines: {node: '>=18'}
+
+  token-types@6.1.2:
+    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
+    engines: {node: '>=14.16'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  turbo@2.9.18:
+    resolution: {integrity: sha512-bwabv6PupzeavybzEoArBAkwq5fnzwf8OFnRtpHwnviFWuwJPFxtyH+aVp36TmIqK3aYYgtTJ3J0m2ysxxSzQg==}
+    hasBin: true
+
+  uid@2.0.2:
+    resolution: {integrity: sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==}
+    engines: {node: '>=8'}
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
+
+snapshots:
+
+  '@borewit/text-codec@0.2.2': {}
+
+  '@lukeed/csprng@1.1.0': {}
+
+  '@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+    dependencies:
+      file-type: 21.3.4
+      iterare: 1.2.1
+      load-esm: 1.0.3
+      reflect-metadata: 0.2.2
+      rxjs: 7.8.2
+      tslib: 2.8.1
+      uid: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@nestjs/core@11.1.26(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+    dependencies:
+      '@nestjs/common': 11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      fast-safe-stringify: 2.1.1
+      iterare: 1.2.1
+      path-to-regexp: 8.4.2
+      reflect-metadata: 0.2.2
+      rxjs: 7.8.2
+      tslib: 2.8.1
+      uid: 2.0.2
+
+  '@nestjs/throttler@6.5.0(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)':
+    dependencies:
+      '@nestjs/common': 11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.26(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      reflect-metadata: 0.2.2
+
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
+
+  '@turbo/darwin-64@2.9.18':
+    optional: true
+
+  '@turbo/darwin-arm64@2.9.18':
+    optional: true
+
+  '@turbo/linux-64@2.9.18':
+    optional: true
+
+  '@turbo/linux-arm64@2.9.18':
+    optional: true
+
+  '@turbo/windows-64@2.9.18':
+    optional: true
+
+  '@turbo/windows-arm64@2.9.18':
+    optional: true
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  fast-safe-stringify@2.1.1: {}
+
+  file-type@21.3.4:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  ieee754@1.2.1: {}
+
+  iterare@1.2.1: {}
+
+  load-esm@1.0.3: {}
+
+  ms@2.1.3: {}
+
+  path-to-regexp@8.4.2: {}
+
+  reflect-metadata@0.2.2: {}
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
+  strtok3@10.3.5:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+
+  token-types@6.1.2:
+    dependencies:
+      '@borewit/text-codec': 0.2.2
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
+
+  tslib@2.8.1: {}
+
+  turbo@2.9.18:
+    optionalDependencies:
+      '@turbo/darwin-64': 2.9.18
+      '@turbo/darwin-arm64': 2.9.18
+      '@turbo/linux-64': 2.9.18
+      '@turbo/linux-arm64': 2.9.18
+      '@turbo/windows-64': 2.9.18
+      '@turbo/windows-arm64': 2.9.18
+
+  uid@2.0.2:
+    dependencies:
+      '@lukeed/csprng': 1.1.0
+
+  uint8array-extras@1.5.0: {}

--- a/lockfile-tests/fixtures/pnpm-peer-resolved-importer/pnpm-workspace.yaml
+++ b/lockfile-tests/fixtures/pnpm-peer-resolved-importer/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "apps/*"
+  - "packages/*"

--- a/lockfile-tests/fixtures/pnpm-peer-resolved-importer/turbo.json
+++ b/lockfile-tests/fixtures/pnpm-peer-resolved-importer/turbo.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "outputs": []
+    }
+  }
+}


### PR DESCRIPTION
## Why

`turbo prune --docker` can keep pnpm importer references to peer-resolved dependency versions while dropping the matching package and snapshot entries from the pruned lockfile. pnpm then rejects frozen installs with `ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY`. This fixes #13082 without regressing the pnpm workspace patch filtering from #13066.

## What

Retain concrete pnpm package and snapshot entries referenced by retained non-root importers, including their snapshot dependency closure. Keep `pnpm-workspace.yaml` patch filtering aligned across prune outputs so stale patch declarations do not survive in Docker install contexts. Add a `check-lockfiles` fixture based on the #13082 reproduction so the real `turbo prune --docker` output is validated by pnpm.

## How

Added unit coverage for the peer-resolved importer dependency case and unreferenced patched dependencies. Verified with `cargo test --package turborepo-lockfiles` and `pnpm check-lockfiles --fixture pnpm-peer-resolved-importer --turbo-path ../target/debug/turbo` using `COREPACK_INTEGRITY_KEYS=0` locally for Corepack signature compatibility. Pre-push hooks passed.