### PR TITLE
fix: Thread `allow_no_package_manager` to daemon and watcher

### DIFF
--- a/crates/turborepo-daemon/src/lib.rs
+++ b/crates/turborepo-daemon/src/lib.rs
@@ -60,6 +60,7 @@ pub struct PackageChangesWatcherArgs {
     >,
     pub hash_watcher: std::sync::Arc<turborepo_filewatch::hash_watcher::HashWatcher>,
     pub custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
+    pub allow_no_package_manager: bool,
 }
 
 /// Events that indicate package changes in the repository.

--- a/crates/turborepo-daemon/src/server.rs
+++ b/crates/turborepo-daemon/src/server.rs
@@ -65,6 +65,7 @@ pub struct FileWatching<W: PackageChangesWatcher + 'static> {
     pub package_changes_watcher: OnceLock<Arc<W>>,
     pub hash_watcher: Arc<HashWatcher>,
     custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
+    allow_no_package_manager: bool,
     package_changes_watcher_factory: Arc<dyn Fn(PackageChangesWatcherArgs) -> W + Send + Sync>,
 }
 
@@ -87,6 +88,7 @@ impl<W: PackageChangesWatcher + 'static> Clone for FileWatching<W> {
             package_changes_watcher: new_package_changes_watcher,
             hash_watcher: self.hash_watcher.clone(),
             custom_turbo_json_path: self.custom_turbo_json_path.clone(),
+            allow_no_package_manager: self.allow_no_package_manager,
             package_changes_watcher_factory: self.package_changes_watcher_factory.clone(),
         }
     }
@@ -139,6 +141,7 @@ impl<W: PackageChangesWatcher + 'static> FileWatching<W> {
     pub fn new<F>(
         repo_root: AbsoluteSystemPathBuf,
         custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
+        allow_no_package_manager: bool,
         package_changes_watcher_factory: F,
     ) -> Result<FileWatching<W>, WatchError>
     where
@@ -158,8 +161,13 @@ impl<W: PackageChangesWatcher + 'static> FileWatching<W> {
             recv.clone(),
         ));
         let package_watcher = Arc::new(
-            PackageWatcher::new(repo_root.clone(), recv.clone(), cookie_writer)
-                .map_err(|e| WatchError::Setup(format!("{e:?}")))?,
+            PackageWatcher::new(
+                repo_root.clone(),
+                recv.clone(),
+                cookie_writer,
+                allow_no_package_manager,
+            )
+            .map_err(|e| WatchError::Setup(format!("{e:?}")))?,
         );
         let scm = SCM::new(&repo_root);
         let hash_watcher = Arc::new(HashWatcher::new(
@@ -177,6 +185,7 @@ impl<W: PackageChangesWatcher + 'static> FileWatching<W> {
             package_changes_watcher: OnceLock::new(),
             hash_watcher,
             custom_turbo_json_path,
+            allow_no_package_manager,
             package_changes_watcher_factory: Arc::new(package_changes_watcher_factory),
         })
     }
@@ -214,6 +223,7 @@ where
     timeout: Duration,
     external_shutdown: S,
     custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
+    allow_no_package_manager: bool,
     package_changes_watcher_factory: Arc<dyn Fn(PackageChangesWatcherArgs) -> W + Send + Sync>,
 }
 
@@ -234,6 +244,7 @@ where
         timeout: Duration,
         external_shutdown: S,
         custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
+        allow_no_package_manager: bool,
         package_changes_watcher_factory: F,
     ) -> Self
     where
@@ -248,6 +259,7 @@ where
             timeout,
             external_shutdown,
             custom_turbo_json_path,
+            allow_no_package_manager,
             package_changes_watcher_factory: Arc::new(package_changes_watcher_factory),
         }
     }
@@ -259,6 +271,7 @@ where
             repo_root,
             timeout,
             custom_turbo_json_path,
+            allow_no_package_manager,
             package_changes_watcher_factory,
         } = self;
 
@@ -273,6 +286,7 @@ where
             trigger_shutdown,
             paths.log_file,
             custom_turbo_json_path,
+            allow_no_package_manager,
             move |args| (factory)(args),
         ) {
             Ok(inner) => inner,
@@ -363,6 +377,7 @@ impl<W: PackageChangesWatcher + 'static> TurboGrpcServiceInner<W> {
         trigger_shutdown: mpsc::Sender<()>,
         log_file: AbsoluteSystemPathBuf,
         custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
+        allow_no_package_manager: bool,
         package_changes_watcher_factory: F,
     ) -> TurboGrpcServiceInnerInit<W>
     where
@@ -371,6 +386,7 @@ impl<W: PackageChangesWatcher + 'static> TurboGrpcServiceInner<W> {
         let file_watching = FileWatching::new(
             repo_root.clone(),
             custom_turbo_json_path,
+            allow_no_package_manager,
             package_changes_watcher_factory,
         )?;
 
@@ -909,6 +925,7 @@ mod test {
             Duration::from_secs(60 * 60),
             exit_signal,
             None,
+            false,
             MockPackageChangesWatcher::new,
         );
 
@@ -968,6 +985,7 @@ mod test {
             Duration::from_millis(10),
             exit_signal,
             None,
+            false,
             MockPackageChangesWatcher::new,
         );
 
@@ -1027,6 +1045,7 @@ mod test {
             Duration::from_secs(60 * 60),
             exit_signal,
             None,
+            false,
             MockPackageChangesWatcher::new,
         );
 

--- a/crates/turborepo-daemon/src/server.rs
+++ b/crates/turborepo-daemon/src/server.rs
@@ -199,6 +199,7 @@ impl<W: PackageChangesWatcher + 'static> FileWatching<W> {
                     file_events: recv,
                     hash_watcher: self.hash_watcher.clone(),
                     custom_turbo_json_path: self.custom_turbo_json_path.clone(),
+                    allow_no_package_manager: self.allow_no_package_manager,
                 };
                 Arc::new((self.package_changes_watcher_factory)(args))
             })

--- a/crates/turborepo-filewatch/src/hash_watcher.rs
+++ b/crates/turborepo-filewatch/src/hash_watcher.rs
@@ -909,7 +909,7 @@ mod tests {
 
         let scm = SCM::new(&repo_root);
         assert!(!scm.is_manual());
-        let package_watcher = PackageWatcher::new(repo_root.clone(), recv, cookie_writer).unwrap();
+        let package_watcher = PackageWatcher::new(repo_root.clone(), recv, cookie_writer, false).unwrap();
         let package_discovery = package_watcher.watch_discovery();
         let hash_watcher =
             HashWatcher::new(repo_root.clone(), package_discovery, watcher.watch(), scm);
@@ -997,7 +997,7 @@ mod tests {
 
         let scm = SCM::new(&repo_root);
         assert!(!scm.is_manual());
-        let package_watcher = PackageWatcher::new(repo_root.clone(), recv, cookie_writer).unwrap();
+        let package_watcher = PackageWatcher::new(repo_root.clone(), recv, cookie_writer, false).unwrap();
         let package_discovery = package_watcher.watch_discovery();
         let hash_watcher =
             HashWatcher::new(repo_root.clone(), package_discovery, watcher.watch(), scm);
@@ -1051,7 +1051,7 @@ mod tests {
 
         let scm = SCM::new(&repo_root);
         assert!(!scm.is_manual());
-        let package_watcher = PackageWatcher::new(repo_root.clone(), recv, cookie_writer).unwrap();
+        let package_watcher = PackageWatcher::new(repo_root.clone(), recv, cookie_writer, false).unwrap();
         let package_discovery = package_watcher.watch_discovery();
         let hash_watcher =
             HashWatcher::new(repo_root.clone(), package_discovery, watcher.watch(), scm);
@@ -1249,7 +1249,7 @@ mod tests {
 
         let scm = SCM::new(&repo_root);
         assert!(!scm.is_manual());
-        let package_watcher = PackageWatcher::new(repo_root.clone(), recv, cookie_writer).unwrap();
+        let package_watcher = PackageWatcher::new(repo_root.clone(), recv, cookie_writer, false).unwrap();
         let package_discovery = package_watcher.watch_discovery();
         let hash_watcher =
             HashWatcher::new(repo_root.clone(), package_discovery, watcher.watch(), scm);
@@ -1306,7 +1306,7 @@ mod tests {
 
         let scm = SCM::new(&repo_root);
         assert!(!scm.is_manual());
-        let package_watcher = PackageWatcher::new(repo_root.clone(), recv, cookie_writer).unwrap();
+        let package_watcher = PackageWatcher::new(repo_root.clone(), recv, cookie_writer, false).unwrap();
         let package_discovery = package_watcher.watch_discovery();
         let hash_watcher =
             HashWatcher::new(repo_root.clone(), package_discovery, watcher.watch(), scm);
@@ -1368,7 +1368,7 @@ mod tests {
 
         let scm = SCM::new(&repo_root);
         assert!(!scm.is_manual());
-        let package_watcher = PackageWatcher::new(repo_root.clone(), recv, cookie_writer).unwrap();
+        let package_watcher = PackageWatcher::new(repo_root.clone(), recv, cookie_writer, false).unwrap();
         let package_discovery = package_watcher.watch_discovery();
         let hash_watcher =
             HashWatcher::new(repo_root.clone(), package_discovery, watcher.watch(), scm);
@@ -1454,7 +1454,7 @@ mod tests {
 
         let scm = SCM::new(&repo_root);
         assert!(!scm.is_manual());
-        let package_watcher = PackageWatcher::new(repo_root.clone(), recv, cookie_writer).unwrap();
+        let package_watcher = PackageWatcher::new(repo_root.clone(), recv, cookie_writer, false).unwrap();
         let package_discovery = package_watcher.watch_discovery();
         let hash_watcher =
             HashWatcher::new(repo_root.clone(), package_discovery, watcher.watch(), scm);

--- a/crates/turborepo-filewatch/src/hash_watcher.rs
+++ b/crates/turborepo-filewatch/src/hash_watcher.rs
@@ -909,7 +909,8 @@ mod tests {
 
         let scm = SCM::new(&repo_root);
         assert!(!scm.is_manual());
-        let package_watcher = PackageWatcher::new(repo_root.clone(), recv, cookie_writer, false).unwrap();
+        let package_watcher =
+            PackageWatcher::new(repo_root.clone(), recv, cookie_writer, false).unwrap();
         let package_discovery = package_watcher.watch_discovery();
         let hash_watcher =
             HashWatcher::new(repo_root.clone(), package_discovery, watcher.watch(), scm);
@@ -997,7 +998,8 @@ mod tests {
 
         let scm = SCM::new(&repo_root);
         assert!(!scm.is_manual());
-        let package_watcher = PackageWatcher::new(repo_root.clone(), recv, cookie_writer, false).unwrap();
+        let package_watcher =
+            PackageWatcher::new(repo_root.clone(), recv, cookie_writer, false).unwrap();
         let package_discovery = package_watcher.watch_discovery();
         let hash_watcher =
             HashWatcher::new(repo_root.clone(), package_discovery, watcher.watch(), scm);
@@ -1051,7 +1053,8 @@ mod tests {
 
         let scm = SCM::new(&repo_root);
         assert!(!scm.is_manual());
-        let package_watcher = PackageWatcher::new(repo_root.clone(), recv, cookie_writer, false).unwrap();
+        let package_watcher =
+            PackageWatcher::new(repo_root.clone(), recv, cookie_writer, false).unwrap();
         let package_discovery = package_watcher.watch_discovery();
         let hash_watcher =
             HashWatcher::new(repo_root.clone(), package_discovery, watcher.watch(), scm);
@@ -1249,7 +1252,8 @@ mod tests {
 
         let scm = SCM::new(&repo_root);
         assert!(!scm.is_manual());
-        let package_watcher = PackageWatcher::new(repo_root.clone(), recv, cookie_writer, false).unwrap();
+        let package_watcher =
+            PackageWatcher::new(repo_root.clone(), recv, cookie_writer, false).unwrap();
         let package_discovery = package_watcher.watch_discovery();
         let hash_watcher =
             HashWatcher::new(repo_root.clone(), package_discovery, watcher.watch(), scm);
@@ -1306,7 +1310,8 @@ mod tests {
 
         let scm = SCM::new(&repo_root);
         assert!(!scm.is_manual());
-        let package_watcher = PackageWatcher::new(repo_root.clone(), recv, cookie_writer, false).unwrap();
+        let package_watcher =
+            PackageWatcher::new(repo_root.clone(), recv, cookie_writer, false).unwrap();
         let package_discovery = package_watcher.watch_discovery();
         let hash_watcher =
             HashWatcher::new(repo_root.clone(), package_discovery, watcher.watch(), scm);
@@ -1368,7 +1373,8 @@ mod tests {
 
         let scm = SCM::new(&repo_root);
         assert!(!scm.is_manual());
-        let package_watcher = PackageWatcher::new(repo_root.clone(), recv, cookie_writer, false).unwrap();
+        let package_watcher =
+            PackageWatcher::new(repo_root.clone(), recv, cookie_writer, false).unwrap();
         let package_discovery = package_watcher.watch_discovery();
         let hash_watcher =
             HashWatcher::new(repo_root.clone(), package_discovery, watcher.watch(), scm);
@@ -1454,7 +1460,8 @@ mod tests {
 
         let scm = SCM::new(&repo_root);
         assert!(!scm.is_manual());
-        let package_watcher = PackageWatcher::new(repo_root.clone(), recv, cookie_writer, false).unwrap();
+        let package_watcher =
+            PackageWatcher::new(repo_root.clone(), recv, cookie_writer, false).unwrap();
         let package_discovery = package_watcher.watch_discovery();
         let hash_watcher =
             HashWatcher::new(repo_root.clone(), package_discovery, watcher.watch(), scm);

--- a/crates/turborepo-filewatch/src/package_watcher.rs
+++ b/crates/turborepo-filewatch/src/package_watcher.rs
@@ -89,9 +89,10 @@ impl PackageWatcher {
         root: AbsoluteSystemPathBuf,
         recv: OptionalWatch<broadcast::Receiver<Result<Event, NotifyError>>>,
         cookie_writer: CookieWriter,
+        allow_no_package_manager: bool,
     ) -> Result<Self, package_manager::Error> {
         let (exit_tx, exit_rx) = oneshot::channel();
-        let subscriber = Subscriber::new(root, cookie_writer)?;
+        let subscriber = Subscriber::new(root, cookie_writer, allow_no_package_manager)?;
         let package_discovery_lazy = subscriber.package_discovery();
         let handle = tokio::spawn(subscriber.watch(exit_rx, recv));
         Ok(Self {
@@ -145,6 +146,7 @@ struct Subscriber {
     package_discovery_lazy: CookiedOptionalWatch<DiscoveryData, ()>,
     cookie_tx: CookieRegister,
     next_version: AtomicUsize,
+    allow_no_package_manager: bool,
 }
 
 /// PackageWatcher state. We either don't have a valid package manager,
@@ -192,6 +194,7 @@ impl Subscriber {
     fn new(
         repo_root: AbsoluteSystemPathBuf,
         writer: CookieWriter,
+        allow_no_package_manager: bool,
     ) -> Result<Self, package_manager::Error> {
         let (package_discovery_tx, cookie_tx, package_discovery_lazy) =
             CookiedOptionalWatch::new(writer);
@@ -206,6 +209,7 @@ impl Subscriber {
             package_discovery_lazy,
             cookie_tx,
             next_version: AtomicUsize::new(0),
+            allow_no_package_manager,
         })
     }
 
@@ -226,9 +230,10 @@ impl Subscriber {
         let debouncer = Arc::new(debouncer);
         let debouncer_copy = debouncer.clone();
         let repo_root = self.repo_root.clone();
+        let allow_no_package_manager = self.allow_no_package_manager;
         tokio::task::spawn(async move {
             debouncer_copy.debounce().await;
-            let state = discover_packages(repo_root).await;
+            let state = discover_packages(repo_root, allow_no_package_manager).await;
             let _ = package_state_tx
                 .send(DiscoveryResult { version, state })
                 .await;
@@ -531,10 +536,15 @@ impl Subscriber {
     }
 }
 
-async fn discover_packages(repo_root: AbsoluteSystemPathBuf) -> PackageState {
+async fn discover_packages(
+    repo_root: AbsoluteSystemPathBuf,
+    allow_no_package_manager: bool,
+) -> PackageState {
     // If we're rediscovering everything, we need to rediscover the package manager.
     // It may have changed if a lockfile changed or package.json changed.
-    let discovery = match LocalPackageDiscoveryBuilder::new(repo_root.clone(), None, None).build() {
+    let mut builder = LocalPackageDiscoveryBuilder::new(repo_root.clone(), None, None);
+    builder.with_allow_no_package_manager(allow_no_package_manager);
+    let discovery = match builder.build() {
         Ok(discovery) => discovery,
         Err(e) => return PackageState::NoPackageManager(e.to_string()),
     };
@@ -631,7 +641,8 @@ mod test {
             recv.clone(),
         );
 
-        let package_watcher = PackageWatcher::new(repo_root.clone(), recv, cookie_writer).unwrap();
+        let package_watcher =
+            PackageWatcher::new(repo_root.clone(), recv, cookie_writer, false).unwrap();
 
         let mut data = package_watcher.discover_packages_blocking().await.unwrap();
         data.workspaces
@@ -736,7 +747,8 @@ mod test {
             recv.clone(),
         );
 
-        let package_watcher = PackageWatcher::new(repo_root.clone(), recv, cookie_writer).unwrap();
+        let package_watcher =
+            PackageWatcher::new(repo_root.clone(), recv, cookie_writer, false).unwrap();
 
         let mut data = package_watcher.discover_packages_blocking().await.unwrap();
         data.workspaces
@@ -843,7 +855,8 @@ mod test {
             recv.clone(),
         );
 
-        let package_watcher = PackageWatcher::new(repo_root.clone(), recv, cookie_writer).unwrap();
+        let package_watcher =
+            PackageWatcher::new(repo_root.clone(), recv, cookie_writer, false).unwrap();
 
         package_watcher
             .discover_packages_blocking()
@@ -912,7 +925,8 @@ mod test {
             recv.clone(),
         );
 
-        let package_watcher = PackageWatcher::new(repo_root.clone(), recv, cookie_writer).unwrap();
+        let package_watcher =
+            PackageWatcher::new(repo_root.clone(), recv, cookie_writer, false).unwrap();
         // expect an error, we don't have a workspaces glob
         package_watcher
             .discover_packages_blocking()
@@ -982,7 +996,8 @@ mod test {
             recv.clone(),
         );
 
-        let package_watcher = PackageWatcher::new(repo_root.clone(), recv, cookie_writer).unwrap();
+        let package_watcher =
+            PackageWatcher::new(repo_root.clone(), recv, cookie_writer, false).unwrap();
 
         let resp = package_watcher.discover_packages_blocking().await.unwrap();
         assert_eq!(resp.package_manager, PackageManager::Pnpm);
@@ -1008,5 +1023,44 @@ mod test {
             .unwrap();
         let resp = package_watcher.discover_packages_blocking().await.unwrap();
         assert_eq!(resp.package_manager, PackageManager::Npm);
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn allow_no_package_manager_infers_from_lockfile() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(tmp.path())
+            .unwrap()
+            .to_realpath()
+            .unwrap();
+
+        // Root package.json without a `packageManager` field.
+        repo_root
+            .join_component("package.json")
+            .create_with_contents(r#"{"name": "root"}"#)
+            .unwrap();
+        // A pnpm workspace + lockfile, so pnpm can be inferred.
+        repo_root
+            .join_component("pnpm-workspace.yaml")
+            .create_with_contents(r#"packages: ["foo/*"]"#)
+            .unwrap();
+        repo_root
+            .join_component("pnpm-lock.yaml")
+            .create_with_contents("")
+            .unwrap();
+
+        let watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root).unwrap();
+        let recv = watcher.watch();
+        let cookie_writer = CookieWriter::new(
+            watcher.cookie_dir(),
+            Duration::from_millis(100),
+            recv.clone(),
+        );
+
+        let package_watcher =
+            PackageWatcher::new(repo_root.clone(), recv, cookie_writer, true).unwrap();
+
+        let resp = package_watcher.discover_packages_blocking().await.unwrap();
+        assert_eq!(resp.package_manager, PackageManager::Pnpm);
     }
 }

--- a/crates/turborepo-lib/src/commands/daemon.rs
+++ b/crates/turborepo-lib/src/commands/daemon.rs
@@ -350,6 +350,7 @@ pub async fn daemon_server(
                 args.hash_watcher,
                 args.custom_turbo_json_path,
                 false,
+                args.allow_no_package_manager,
             )
         },
     );

--- a/crates/turborepo-lib/src/commands/daemon.rs
+++ b/crates/turborepo-lib/src/commands/daemon.rs
@@ -335,12 +335,14 @@ pub async fn daemon_server(
         CloseReason::Interrupt
     });
     let custom_turbo_json_path = convert_turbo_json_path(turbo_json_path.as_deref())?;
+    let allow_no_package_manager = base.opts().repo_opts.allow_no_package_manager;
     let server = TurboGrpcService::new(
         base.repo_root.clone(),
         paths,
         timeout,
         exit_signal,
         custom_turbo_json_path,
+        allow_no_package_manager,
         |args| {
             PackageChangesWatcher::new(
                 args.repo_root,

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -47,6 +47,7 @@ impl PackageChangesWatcher {
         hash_watcher: Arc<HashWatcher>,
         custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
         single_package: bool,
+        allow_no_package_manager: bool,
     ) -> Self {
         let (exit_tx, exit_rx) = oneshot::channel();
         let (package_change_events_tx, package_change_events_rx) =
@@ -58,6 +59,7 @@ impl PackageChangesWatcher {
             hash_watcher,
             custom_turbo_json_path,
             single_package,
+            allow_no_package_manager,
         );
 
         let _handle = tokio::spawn(subscriber.watch(exit_rx));
@@ -104,6 +106,7 @@ struct Subscriber {
     hash_watcher: Arc<HashWatcher>,
     custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
     single_package: bool,
+    allow_no_package_manager: bool,
 }
 
 // This is a workaround because `ignore` doesn't match against a path's
@@ -238,6 +241,7 @@ impl Subscriber {
         hash_watcher: Arc<HashWatcher>,
         custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
         single_package: bool,
+        allow_no_package_manager: bool,
     ) -> Self {
         // Try to canonicalize the custom path to match what the file watcher reports
         let normalized_custom_path = custom_turbo_json_path.map(|path| {
@@ -279,6 +283,7 @@ impl Subscriber {
             hash_watcher,
             custom_turbo_json_path: normalized_custom_path,
             single_package,
+            allow_no_package_manager,
         }
     }
 
@@ -292,6 +297,7 @@ impl Subscriber {
         let Ok(pkg_dep_graph) =
             PackageGraphBuilder::new(&self.repo_root, root_package_json.clone())
                 .with_single_package_mode(self.single_package)
+                .with_allow_no_package_manager(self.allow_no_package_manager)
                 .build()
                 .await
         else {
@@ -1138,12 +1144,13 @@ mod test {
 
     /// Create a PackageChangesWatcher backed by a synthetic file event channel.
     fn create_test_watcher(repo_root: &AbsoluteSystemPathBuf) -> TestWatcherHandle {
-        create_test_watcher_with_opts(repo_root, false)
+        create_test_watcher_with_opts(repo_root, false, false)
     }
 
     fn create_test_watcher_with_opts(
         repo_root: &AbsoluteSystemPathBuf,
         single_package: bool,
+        allow_no_package_manager: bool,
     ) -> TestWatcherHandle {
         let (file_events_tx, file_events_rx) = broadcast::channel(128);
         let (opt_tx, opt_watch) = OptionalWatch::new();
@@ -1175,6 +1182,7 @@ mod test {
             hash_watcher,
             None,
             single_package,
+            allow_no_package_manager,
         );
 
         TestWatcherHandle {
@@ -1476,7 +1484,7 @@ mod test {
     #[tokio::test]
     async fn single_package_watcher_sends_initial_rediscover() {
         let (_tmp, repo_root) = setup_single_package_git_repo();
-        let handle = create_test_watcher_with_opts(&repo_root, true);
+        let handle = create_test_watcher_with_opts(&repo_root, true, false);
         let mut rx = handle.watcher.package_change_events_rx.resubscribe();
 
         let event = recv_event(&mut rx, Duration::from_secs(2)).await;
@@ -1506,6 +1514,95 @@ mod test {
             pkg_names.iter().any(|n| n == "//"),
             "root package '//' not found in graph. packages: {:?}",
             pkg_names
+        );
+    }
+
+    /// Set up a git-initialized pnpm monorepo whose package manager must be
+    /// inferred from the lockfile, and return everything needed to create a
+    /// PackageChangesWatcher.
+    fn setup_pnpm_repo_without_package_manager() -> (tempfile::TempDir, AbsoluteSystemPathBuf) {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root =
+            AbsoluteSystemPathBuf::new(tmp.path().to_str().unwrap().to_string()).unwrap();
+        let repo_root = repo_root.to_realpath().unwrap();
+
+        std::process::Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(repo_root.as_std_path())
+            .status()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["config", "user.name", "test"])
+            .current_dir(repo_root.as_std_path())
+            .status()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@test.com"])
+            .current_dir(repo_root.as_std_path())
+            .status()
+            .unwrap();
+
+        // Root package.json — no `packageManager` field
+        repo_root
+            .join_component("package.json")
+            .create_with_contents(r#"{"name":"root"}"#.as_bytes())
+            .unwrap();
+        repo_root
+            .join_component("pnpm-workspace.yaml")
+            .create_with_contents(r#"packages: ["packages/*"]"#.as_bytes())
+            .unwrap();
+        repo_root
+            .join_component("pnpm-lock.yaml")
+            .create_with_contents("lockfileVersion: '6.0'\n".as_bytes())
+            .unwrap();
+        repo_root
+            .join_component("turbo.json")
+            .create_with_contents(r#"{"tasks":{"build":{}}}"#.as_bytes())
+            .unwrap();
+        repo_root
+            .join_component(".gitignore")
+            .create_with_contents("node_modules/\n.turbo/\n".as_bytes())
+            .unwrap();
+
+        let pkg_a_dir = repo_root.join_components(&["packages", "a"]);
+        pkg_a_dir.create_dir_all().unwrap();
+        pkg_a_dir
+            .join_component("package.json")
+            .create_with_contents(r#"{"name":"a","scripts":{"build":"echo built"}}"#.as_bytes())
+            .unwrap();
+        pkg_a_dir
+            .join_component("index.ts")
+            .create_with_contents(b"export const a = 1;")
+            .unwrap();
+
+        std::process::Command::new("git")
+            .args(["add", "."])
+            .current_dir(repo_root.as_std_path())
+            .status()
+            .unwrap();
+        std::process::Command::new("git")
+            .args(["commit", "-m", "init", "--quiet"])
+            .current_dir(repo_root.as_std_path())
+            .status()
+            .unwrap();
+
+        (tmp, repo_root)
+    }
+
+    #[tokio::test]
+    async fn watcher_initializes_without_package_manager_when_allowed() {
+        // The watcher only emits the initial Rediscover after the package graph
+        // builds, so receiving it proves discovery succeeded without a root
+        // `packageManager` field.
+        let (_tmp, repo_root) = setup_pnpm_repo_without_package_manager();
+        let handle = create_test_watcher_with_opts(&repo_root, false, true);
+        let mut rx = handle.watcher.package_change_events_rx.resubscribe();
+
+        let event = recv_event(&mut rx, Duration::from_secs(2)).await;
+        assert!(
+            matches!(event, Some(PackageChangeEvent::Rediscover)),
+            "expected Rediscover when allow_no_package_manager is set, got {:?}",
+            event
         );
     }
 

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -271,6 +271,7 @@ impl WatchClient {
             hash_watcher,
             custom_turbo_json_path,
             base.opts().run_opts.single_package,
+            base.opts().repo_opts.allow_no_package_manager,
         );
 
         // Subscribe before building the Run so we don't miss the initial

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -250,8 +250,13 @@ impl WatchClient {
             recv.clone(),
         ));
         let package_watcher = Arc::new(
-            PackageWatcher::new(base.repo_root.clone(), recv.clone(), cookie_writer)
-                .map_err(|e| Error::PackageWatcher(format!("{e:?}")))?,
+            PackageWatcher::new(
+                base.repo_root.clone(),
+                recv.clone(),
+                cookie_writer,
+                base.opts().repo_opts.allow_no_package_manager,
+            )
+            .map_err(|e| Error::PackageWatcher(format!("{e:?}")))?,
         );
         let scm = SCM::new(&base.repo_root);
         let hash_watcher = Arc::new(HashWatcher::new(


### PR DESCRIPTION
### Description

While testing [the `expo/expo` migration to Turborepo](https://github.com/expo/expo/pull/46801), we also tested `turbo watch build` and noticed that this seems to invoke the `daemon`, which quits because we don't have (or would like to have) a root `packageManager` field.

This flag doesn't seem to propagate to the `PackagerWatcher` or to the daemon's `PackageChangesWatcher` and is hence inactive in those code paths, which should be observable by running `turbo daemon --verbosity 6` in a repo and then triggering `turbo watch build`.

### Testing Instructions

- Tested added
- Alternatively; create a template without `packageManager` and invoke `turbo watch [task]` (see `expo/expo` branch linked above, or tests)
