### PR TITLE
fix: Prevent duplicate PTY graceful shutdown signals

### DIFF
--- a/crates/turborepo-process/src/child/handle.rs
+++ b/crates/turborepo-process/src/child/handle.rs
@@ -66,7 +66,7 @@ enum ChildHandleImpl {
 #[cfg(unix)]
 #[derive(Debug, Clone, Copy)]
 enum GracefulInterruptTarget {
-    DirectChildWithProcessGroupFallback,
+    DirectChild,
     ProcessGroup,
 }
 
@@ -88,9 +88,9 @@ impl ShutdownSemantics {
         }
     }
 
-    fn direct_child_with_process_group_fallback() -> Self {
+    fn direct_child() -> Self {
         Self {
-            graceful_interrupt_target: GracefulInterruptTarget::DirectChildWithProcessGroupFallback,
+            graceful_interrupt_target: GracefulInterruptTarget::DirectChild,
             wait_for_process_group_after_child_exit: true,
         }
     }
@@ -423,7 +423,7 @@ impl ChildHandle {
                 pid,
                 imp: ChildHandleImpl::Pty(child),
                 #[cfg(unix)]
-                shutdown_semantics: ShutdownSemantics::direct_child_with_process_group_fallback(),
+                shutdown_semantics: ShutdownSemantics::direct_child(),
                 #[cfg(unix)]
                 target_identity,
                 #[cfg(unix)]
@@ -471,25 +471,18 @@ impl ChildHandle {
     }
 
     #[cfg(unix)]
-    pub(super) fn send_graceful_interrupt(&self, pid: libc::pid_t) -> bool {
+    pub(super) fn send_graceful_interrupt(&self, pid: libc::pid_t) {
         match self.shutdown_semantics.graceful_interrupt_target {
-            GracefulInterruptTarget::DirectChildWithProcessGroupFallback => {
+            GracefulInterruptTarget::DirectChild => {
                 debug!("sending SIGINT to child {pid}");
                 if unsafe { libc::kill(pid, libc::SIGINT) } == -1 {
                     debug!("failed to send SIGINT to {pid}");
                 }
-                false
             }
             GracefulInterruptTarget::ProcessGroup => {
                 self.send_signal_to_process_group(pid, libc::SIGINT);
-                true
             }
         }
-    }
-
-    #[cfg(unix)]
-    pub(super) fn send_fallback_graceful_interrupt(&self, pid: libc::pid_t) {
-        self.send_signal_to_process_group(pid, libc::SIGINT);
     }
 
     #[cfg(unix)]

--- a/crates/turborepo-process/src/child/shutdown.rs
+++ b/crates/turborepo-process/src/child/shutdown.rs
@@ -5,9 +5,6 @@ use tracing::debug;
 
 use super::{ChildCommand, ChildHandle};
 
-#[cfg(unix)]
-const PTY_PROCESS_GROUP_SIGINT_DELAY: Duration = Duration::from_secs(1);
-
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum ChildExit {
     Finished(Option<i32>),
@@ -25,10 +22,11 @@ pub enum ChildExit {
 
 #[derive(Debug, Clone, Copy)]
 pub enum ShutdownStyle {
-    /// On Unix this sends SIGINT to the process group. On Windows, a Ctrl-C
-    /// keystroke is written to the child's ConPTY input when one exists;
-    /// children attached to turbo's real console instead rely on externally
-    /// delivered console events or an explicit kill.
+    /// On Unix this sends SIGINT to the process group for non-PTY children and
+    /// to the direct child for PTY children. On Windows, a Ctrl-C keystroke is
+    /// written to the child's ConPTY input when one exists; children attached
+    /// to turbo's real console instead rely on externally delivered console
+    /// events or an explicit kill.
     ///
     /// `Graceful(Some(timeout))` escalates to `Kill` after `timeout` elapses.
     /// `Graceful(None)` waits indefinitely until an explicit `Kill` command
@@ -70,9 +68,7 @@ impl ShutdownStyle {
                     };
 
                     let pid = pid as libc::pid_t;
-                    let mut process_group_interrupt_sent = child.send_graceful_interrupt(pid);
-                    let process_group_interrupt_deadline =
-                        tokio::time::Instant::now() + PTY_PROCESS_GROUP_SIGINT_DELAY;
+                    child.send_graceful_interrupt(pid);
                     debug!("waiting for child {}", pid);
 
                     let deadline = timeout.map(|timeout| tokio::time::Instant::now() + timeout);
@@ -87,10 +83,6 @@ impl ShutdownStyle {
                                             Ok(_exit_code) => ChildExit::Interrupted,
                                             Err(_) => ChildExit::Failed,
                                         };
-                                    }
-                                    _ = tokio::time::sleep_until(process_group_interrupt_deadline), if !process_group_interrupt_sent => {
-                                        child.send_fallback_graceful_interrupt(pid);
-                                        process_group_interrupt_sent = true;
                                     }
                                     command = command_rx.recv(), if command_rx_open => {
                                         match command {
@@ -121,10 +113,6 @@ impl ShutdownStyle {
                                             Ok(_exit_code) => ChildExit::Interrupted,
                                             Err(_) => ChildExit::Failed,
                                         };
-                                    }
-                                    _ = tokio::time::sleep_until(process_group_interrupt_deadline), if !process_group_interrupt_sent => {
-                                        child.send_fallback_graceful_interrupt(pid);
-                                        process_group_interrupt_sent = true;
                                     }
                                     command = command_rx.recv(), if command_rx_open => {
                                         match command {

--- a/crates/turborepo-process/src/child/test.rs
+++ b/crates/turborepo-process/src/child/test.rs
@@ -1,5 +1,5 @@
 use std::{
-    assert_matches, fs, io,
+    assert_matches, io,
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -403,9 +403,9 @@ async fn test_graceful_shutdown_drains_final_output(use_pty: bool) {
 }
 
 // Regression test: a wrapper process (simulating npm/pnpm) forwards SIGINT
-// to its child. When turbo sends SIGINT to the process group, the child
-// gets it twice — once from the group signal, once from the wrapper.
-// For PTY children we now signal only the direct PID to avoid this.
+// to its child. PTY children are signaled through the direct PID only so the
+// wrapped child does not receive both a process-group signal and a forwarded
+// signal.
 #[cfg(unix)]
 #[tokio::test]
 #[traced_test]
@@ -447,6 +447,53 @@ async fn test_pty_child_receives_single_sigint() {
     assert!(
         !output.contains("SIGINT_COUNT=2"),
         "child received SIGINT twice: {output}"
+    );
+}
+
+// Regression test: a forwarding wrapper may keep running while its child does
+// graceful cleanup. PTY shutdown must not send a delayed process-group SIGINT,
+// or the wrapped child receives the original forwarded signal plus duplicates.
+#[cfg(unix)]
+#[tokio::test]
+#[traced_test]
+async fn test_pty_child_receives_single_sigint_during_slow_cleanup() {
+    let script = find_script_dir().join_component("wrapper_count_sigints_slow.js");
+    let mut cmd = Command::new("node");
+    cmd.args([script.as_std_path()]);
+    cmd.open_stdin();
+    let mut child = Child::spawn(
+        cmd,
+        ShutdownStyle::Graceful(Some(Duration::from_millis(3000))),
+        Some(PtySize::default()),
+    )
+    .unwrap();
+
+    let mut output_child = child.clone();
+    let (mut observer, output, ready_rx) = ObservedOutput::new();
+    let output_task = tokio::spawn(async move {
+        output_child
+            .wait_with_piped_outputs(&mut observer)
+            .await
+            .unwrap()
+    });
+
+    tokio::time::timeout(Duration::from_secs(30), ready_rx)
+        .await
+        .expect("timed out waiting for ready")
+        .expect("ready channel closed");
+
+    child.set_closing();
+    child.stop().await;
+    output_task.await.unwrap();
+
+    let output = String::from_utf8(output.lock().unwrap().clone()).unwrap();
+    assert!(
+        output.contains("SIGINT_COUNT=1"),
+        "expected one SIGINT, got output: {output}"
+    );
+    assert!(
+        !output.contains("SIGINT_COUNT=2"),
+        "child received SIGINT more than once: {output}"
     );
 }
 
@@ -1247,65 +1294,6 @@ async fn test_grandchild_inherits_child_process_group() {
     child.stop().await;
     // Give OS time to clean up
     tokio::time::sleep(Duration::from_millis(200)).await;
-}
-
-#[cfg(unix)]
-#[tokio::test]
-async fn test_pty_graceful_shutdown_signals_process_group() {
-    let marker_file = std::env::temp_dir().join(format!(
-        "turbo-pty-process-group-sigint-{}",
-        std::process::id()
-    ));
-    let ready_file = std::env::temp_dir().join(format!(
-        "turbo-pty-process-group-ready-{}",
-        std::process::id()
-    ));
-    let _ = fs::remove_file(&marker_file);
-    let _ = fs::remove_file(&ready_file);
-    let marker_file = marker_file.to_string_lossy().into_owned();
-    let ready_file = ready_file.to_string_lossy().into_owned();
-
-    let script = r#"
-const { spawn } = require("child_process");
-process.on("SIGINT", () => {});
-const child = spawn(process.execPath, [
-  "-e",
-  "process.on('SIGINT', () => { require('fs').writeFileSync(process.argv[1], 'interrupted'); process.exit(0); }); require('fs').writeFileSync(process.argv[2], 'ready'); setInterval(() => {}, 1000);",
-  process.argv[1],
-  process.argv[2],
-], { stdio: "inherit" });
-child.on("exit", () => process.exit(0));
-"#;
-    let mut cmd = Command::new("node");
-    cmd.args(["-e", script, marker_file.as_str(), ready_file.as_str()]);
-    let mut child = Child::spawn(
-        cmd,
-        ShutdownStyle::Graceful(Some(Duration::from_secs(2))),
-        Some(PtySize::default()),
-    )
-    .unwrap();
-
-    for _ in 0..50 {
-        if fs::metadata(&ready_file).is_ok() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
-    assert!(
-        fs::metadata(&ready_file).is_ok(),
-        "node child should become ready before shutdown"
-    );
-
-    let exit = child.stop().await;
-
-    assert_eq!(exit, Some(ChildExit::Interrupted));
-    assert!(
-        fs::metadata(&marker_file).is_ok(),
-        "node child should receive SIGINT from PTY process-group shutdown"
-    );
-
-    let _ = fs::remove_file(marker_file);
-    let _ = fs::remove_file(ready_file);
 }
 
 #[cfg(unix)]

--- a/crates/turborepo-process/src/lib.rs
+++ b/crates/turborepo-process/src/lib.rs
@@ -163,11 +163,12 @@ impl ProcessManager {
     }
 
     /// Stop the process manager, closing all child processes. On posix systems
-    /// this will send SIGINT. On Windows, children spawned under ConPTY
-    /// receive a Ctrl-C keystroke via the pseudoconsole input; other children
-    /// share turbo's console and are expected to receive console Ctrl-C
-    /// events directly, with a force kill after the child stop timeout as
-    /// the fallback.
+    /// this will send SIGINT to the process group for non-PTY children and to
+    /// the direct child for PTY children. On Windows, children spawned under
+    /// ConPTY receive a Ctrl-C keystroke via the pseudoconsole input; other
+    /// children share turbo's console and are expected to receive console
+    /// Ctrl-C events directly, with a force kill after the child stop
+    /// timeout as the fallback.
     pub async fn stop(&self) {
         self.close(CloseMode::Stop).await
     }

--- a/crates/turborepo-process/test/scripts/count_sigints_slow.js
+++ b/crates/turborepo-process/test/scripts/count_sigints_slow.js
@@ -1,0 +1,13 @@
+// Counts SIGINTs and waits long enough to expose delayed fallback signals.
+let count = 0;
+
+process.on("SIGINT", () => {
+  count++;
+  console.log(`SIGINT_COUNT=${count}`);
+  setTimeout(() => {
+    process.exit(0);
+  }, 1500);
+});
+
+console.log("ready");
+setInterval(() => {}, 1000);

--- a/crates/turborepo-process/test/scripts/wrapper_count_sigints_slow.js
+++ b/crates/turborepo-process/test/scripts/wrapper_count_sigints_slow.js
@@ -1,0 +1,17 @@
+// Simulates a package manager that forwards SIGINT to a slow-cleaning child.
+const { spawn } = require("child_process");
+const path = require("path");
+
+const child = spawn(
+  process.execPath,
+  [path.join(__dirname, "count_sigints_slow.js")],
+  { stdio: "inherit" }
+);
+
+process.on("SIGINT", () => {
+  child.kill("SIGINT");
+});
+
+child.on("exit", (code) => {
+  process.exit(code ?? 1);
+});

--- a/examples/with-shell-commands/apps/app-a/package.json
+++ b/examples/with-shell-commands/apps/app-a/package.json
@@ -3,6 +3,7 @@
   "description": "An application that uses other Internal Packages",
   "scripts": {
     "build": "mkdir -p dist && echo \"Your application output!\" > dist/app-output.txt && echo \"Application A is built!\"",
+    "dev": "node scripts/count-sigint.js",
     "lint": "echo \"Linted!\"",
     "check-types": "echo \"Types checked!\""
   },

--- a/examples/with-shell-commands/apps/app-a/scripts/count-sigint.js
+++ b/examples/with-shell-commands/apps/app-a/scripts/count-sigint.js
@@ -1,0 +1,31 @@
+let sigintCount = 0;
+let sigtermCount = 0;
+let exiting = false;
+
+function scheduleExit() {
+  if (exiting) {
+    return;
+  }
+
+  exiting = true;
+  console.log("Starting slow shutdown. Waiting 2s for duplicate signals...");
+  setTimeout(() => {
+    console.log("Exiting after slow shutdown.");
+    process.exit(0);
+  }, 2000);
+}
+
+process.on("SIGINT", () => {
+  sigintCount++;
+  console.log(`SIGINT_COUNT=${sigintCount}`);
+  scheduleExit();
+});
+
+process.on("SIGTERM", () => {
+  sigtermCount++;
+  console.log(`SIGTERM_COUNT=${sigtermCount}`);
+  scheduleExit();
+});
+
+console.log("Signal counter ready. Press Ctrl+C to stop.");
+setInterval(() => {}, 1000);

--- a/examples/with-shell-commands/apps/app-a/scripts/count-sigint.js
+++ b/examples/with-shell-commands/apps/app-a/scripts/count-sigint.js
@@ -2,6 +2,16 @@ let sigintCount = 0;
 let sigtermCount = 0;
 let exiting = false;
 
+process.stdin.setEncoding("utf8");
+process.stdin.resume();
+process.stdin.on("data", (chunk) => {
+  for (const line of chunk.split(/\r?\n/)) {
+    if (line.length > 0) {
+      console.log(`STDIN_ECHO=${line}`);
+    }
+  }
+});
+
 function scheduleExit() {
   if (exiting) {
     return;
@@ -27,5 +37,5 @@ process.on("SIGTERM", () => {
   scheduleExit();
 });
 
-console.log("Signal counter ready. Press Ctrl+C to stop.");
+console.log("Signal counter ready. Type a line to echo it, or press Ctrl+C to stop.");
 setInterval(() => {}, 1000);

--- a/examples/with-shell-commands/turbo.json
+++ b/examples/with-shell-commands/turbo.json
@@ -11,6 +11,10 @@
         "dist/**"
       ]
     },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
     "prebuild": {},
     "lint": {},
     "check-types": {}

--- a/examples/with-shell-commands/turbo.json
+++ b/examples/with-shell-commands/turbo.json
@@ -13,6 +13,7 @@
     },
     "dev": {
       "cache": false,
+      "interactive": true,
       "persistent": true
     },
     "prebuild": {},


### PR DESCRIPTION
## Why
PTY tasks launched through shells or package-manager wrappers can forward SIGINT to their own children. Turbo's delayed process-group SIGINT fallback caused those wrapped children to see duplicate interrupts during graceful shutdown.

## What
Keep Unix PTY graceful shutdown to a single direct-child SIGINT and rely on the existing timeout/force-kill path for uncooperative process trees. Non-PTY shutdown still signals the process group.

## How
Added a regression that simulates a wrapper forwarding SIGINT to a slow-cleanup child and asserts the child only sees one signal.

Tested with:
- `cargo test -p turborepo-process -- --test-threads=1`
- pre-push hooks