### PR TITLE
fix: Refine graceful shutdown messaging

### DIFF
--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -43,7 +43,7 @@ use turborepo_task_hash::{
 };
 use turborepo_telemetry::events::generic::GenericEventBuilder;
 use turborepo_types::{EnvMode, UIMode};
-use turborepo_ui::{sender::UISender, tui, tui::TuiSender, ColorConfig};
+use turborepo_ui::{sender::UISender, tui, tui::TuiSender, ColorConfig, LIGHT_GREY};
 
 pub use crate::run::error::Error;
 use crate::{
@@ -119,7 +119,7 @@ enum CacheShutdownOutcome {
     ForcedShutdown,
 }
 
-const SLOW_SHUTDOWN_WARNING_DELAY: Duration = Duration::from_secs(3);
+const SLOW_SHUTDOWN_STATUS_INTERVAL: Duration = Duration::from_secs(2);
 
 fn remote_cache_status_message(status: RemoteCacheStatus, api_url: &str) -> (String, bool) {
     match status {
@@ -176,20 +176,12 @@ fn remote_cache_status_message(status: RemoteCacheStatus, api_url: &str) -> (Str
 }
 
 impl Run {
-    fn shutdown_started_message(force_shutdown_timeout: Option<Duration>) -> &'static str {
-        #[cfg(windows)]
-        {
-            let _ = force_shutdown_timeout;
-            "Shutting down Turborepo tasks..."
-        }
-
-        #[cfg(not(windows))]
-        {
-            match force_shutdown_timeout {
-                Some(_) => "Shutting down Turborepo tasks...",
-                None => "^C - Shutting down Turborepo tasks...",
-            }
-        }
+    fn shutdown_started_message(force_shutdown_timeout: Option<Duration>) -> String {
+        let message = match force_shutdown_timeout {
+            Some(_) => "Shutting down Turborepo tasks...",
+            None => " - Shutting down Turborepo tasks...Press CTRL+C again to exit forcefully.",
+        };
+        LIGHT_GREY.apply_to(message).to_string()
     }
 
     fn force_shutdown_timeout() -> Option<Duration> {
@@ -216,33 +208,22 @@ impl Run {
         }
     }
 
-    fn emit_slow_tasks(task_names: &[String], force_shutdown_timeout: Option<Duration>) {
+    fn emit_shutdown_status(task_names: &[String]) {
         if task_names.is_empty() {
             return;
         }
 
-        let list = task_names.join(", ");
-        turborepo_log::warn(
+        let task_description = match task_names.len() {
+            1 => "1 task".to_string(),
+            count => format!("{count} tasks"),
+        };
+        turborepo_log::info(
             turborepo_log::Source::turbo(turborepo_log::Subsystem::Run),
-            format!("Some tasks in your Turborepo are taking awhile to shut down: {list}"),
+            LIGHT_GREY
+                .apply_to(format!("{task_description} shutting down..."))
+                .to_string(),
         )
         .emit();
-
-        if let Some(remaining) = force_shutdown_timeout
-            .map(|timeout| timeout.saturating_sub(SLOW_SHUTDOWN_WARNING_DELAY))
-        {
-            turborepo_log::warn(
-                turborepo_log::Source::turbo(turborepo_log::Subsystem::Run),
-                format!("Shutting down forcibly in {}s...", remaining.as_secs()),
-            )
-            .emit();
-        } else {
-            turborepo_log::warn(
-                turborepo_log::Source::turbo(turborepo_log::Subsystem::Run),
-                "Press CTRL+C again to force shut down, or wait.",
-            )
-            .emit();
-        }
     }
 
     fn emit_force_shutdown_message(
@@ -339,18 +320,20 @@ impl Run {
         F: Future<Output = ()> + Send,
     {
         let is_interactive = force_shutdown_timeout.is_none();
-        let slow_task_delay = tokio::time::sleep(SLOW_SHUTDOWN_WARNING_DELAY);
+        let mut shutdown_status = tokio::time::interval_at(
+            tokio::time::Instant::now() + SLOW_SHUTDOWN_STATUS_INTERVAL,
+            SLOW_SHUTDOWN_STATUS_INTERVAL,
+        );
+        shutdown_status.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         let force_shutdown = Self::wait_for_forced_shutdown(force_shutdown_timeout);
-        pin!(graceful_shutdown, slow_task_delay, force_shutdown);
-        let mut slow_tasks_emitted = false;
+        pin!(graceful_shutdown, force_shutdown);
 
         loop {
             select! {
                 _ = &mut graceful_shutdown => break,
-                _ = &mut slow_task_delay, if !slow_tasks_emitted => {
-                    slow_tasks_emitted = true;
+                _ = shutdown_status.tick() => {
                     let tasks = process_manager.running_task_ids();
-                    Self::emit_slow_tasks(&tasks, force_shutdown_timeout);
+                    Self::emit_shutdown_status(&tasks);
                 }
                 reason = &mut force_shutdown => {
                     let tasks = process_manager.running_task_ids();

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -177,10 +177,18 @@ fn remote_cache_status_message(status: RemoteCacheStatus, api_url: &str) -> (Str
 
 impl Run {
     fn shutdown_started_message(force_shutdown_timeout: Option<Duration>) -> String {
+        #[cfg(windows)]
+        let message = {
+            let _ = force_shutdown_timeout;
+            "Shutting down Turborepo tasks..."
+        };
+
+        #[cfg(not(windows))]
         let message = match force_shutdown_timeout {
             Some(_) => "Shutting down Turborepo tasks...",
             None => " - Shutting down Turborepo tasks...Press CTRL+C again to exit forcefully.",
         };
+
         LIGHT_GREY.apply_to(message).to_string()
     }
 

--- a/crates/turborepo-ui/src/lib.rs
+++ b/crates/turborepo-ui/src/lib.rs
@@ -226,6 +226,7 @@ impl ColorConfig {
 }
 
 pub static GREY: LazyLock<Style> = LazyLock::new(|| Style::new().dim());
+pub static LIGHT_GREY: LazyLock<Style> = LazyLock::new(|| Style::new().color256(245));
 pub static CYAN: LazyLock<Style> = LazyLock::new(|| Style::new().cyan());
 pub static BOLD: LazyLock<Style> = LazyLock::new(|| Style::new().bold());
 pub static MAGENTA: LazyLock<Style> = LazyLock::new(|| Style::new().magenta());

--- a/crates/turborepo/tests/graceful_shutdown_test.rs
+++ b/crates/turborepo/tests/graceful_shutdown_test.rs
@@ -420,6 +420,16 @@ while true; do sleep 0.2 || true; done
             cleanup_idx < cleanup_done_idx,
             "cleanup completion log should appear after cleanup starts\n{transcript}"
         );
+        assert!(
+            !transcript.contains("^C^C"),
+            "single Ctrl+C should only display one terminal interrupt marker\n{transcript}"
+        );
+        assert!(
+            transcript.contains(
+                " - Shutting down Turborepo tasks...Press CTRL+C again to exit forcefully."
+            ),
+            "interactive shutdown banner should follow the terminal Ctrl+C marker\n{transcript}"
+        );
     }
 
     #[test]
@@ -599,7 +609,7 @@ while true; do sleep 0.2 || true; done
         let task_child_pid = wait_for_pid_file(&child_pid_file, START_TIMEOUT);
 
         child.send_ctrl_c();
-        thread::sleep(Duration::from_millis(500));
+        thread::sleep(Duration::from_millis(2500));
         child.send_ctrl_c();
 
         let transcript = child.finish(Duration::from_secs(5));
@@ -608,6 +618,23 @@ while true; do sleep 0.2 || true; done
         assert!(
             transcript.contains("stubborn ready child="),
             "expected task output to remain visible in the TUI transcript\n{transcript}"
+        );
+        assert!(
+            transcript.contains(
+                " - Shutting down Turborepo tasks...Press CTRL+C again to exit forcefully."
+            ),
+            "expected interactive shutdown banner to include force-exit prompt\n{transcript}"
+        );
+        assert!(
+            transcript
+                .matches("Press CTRL+C again to exit forcefully.")
+                .count()
+                == 1,
+            "force-exit prompt should only appear on the initial shutdown banner\n{transcript}"
+        );
+        assert!(
+            transcript.contains("1 task shutting down..."),
+            "expected repeated shutdown status after the initial banner\n{transcript}"
         );
     }
 
@@ -655,13 +682,16 @@ while true; do sleep 0.2 || true; done
             "expected non-interactive shutdown banner\n{combined}"
         );
         assert!(
-            combined
-                .contains("Some tasks in your Turborepo are taking awhile to shut down: app-a#dev"),
-            "expected slow-task warning before the forced shutdown\n{combined}"
+            combined.matches("1 task shutting down...").count() >= 2,
+            "expected repeated shutdown status while waiting for force timeout\n{combined}"
         );
         assert!(
-            combined.contains("Shutting down forcibly in 7s..."),
-            "expected remaining timeout warning before the forced shutdown\n{combined}"
+            !combined.contains("Press CTRL+C again to exit forcefully."),
+            "non-interactive timeout shutdown should not emit force-exit prompt\n{combined}"
+        );
+        assert!(
+            !combined.contains("Some tasks in your Turborepo are taking awhile to shut down"),
+            "old warning should not be emitted\n{combined}"
         );
         assert!(
             combined


### PR DESCRIPTION
## Why
Graceful shutdown output should clearly reflect a single Ctrl+C press and avoid loud warning styling while tasks are already shutting down normally.

## What
Updates shutdown messaging to use subdued light-gray status text, keeps the terminal-echoed Ctrl+C readable as `^C - Shutting down...`, and repeats concise task-count status every two seconds with correct singular/plural wording.

## How
Verified with `cargo test -p turbo --test graceful_shutdown_test -- --nocapture`. Push hooks also ran `pnpm exec lint-staged`, `turbo run format check:toml`, `cargo fmt --check`, `cargo lint`, and `cargo check --workspace`.