### PR TITLE
fix: Restore TUI force shutdown

### DIFF
--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -107,7 +107,7 @@ type UIResult<T> = Result<Option<(T, JoinHandle<Result<(), turborepo_ui::Error>>
 
 type TuiResult = UIResult<TuiSender>;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ForceShutdownReason {
     Signal,
     Timeout,
@@ -272,11 +272,31 @@ impl Run {
 
     async fn wait_for_forced_shutdown(
         force_shutdown_timeout: Option<Duration>,
+        in_process_signals: Option<tokio::sync::broadcast::Receiver<()>>,
     ) -> ForceShutdownReason {
+        let in_process_signal = async move {
+            let Some(mut in_process_signals) = in_process_signals else {
+                std::future::pending::<()>().await;
+                return;
+            };
+
+            loop {
+                match in_process_signals.recv().await {
+                    Ok(()) | Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => return,
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        std::future::pending::<()>().await;
+                    }
+                }
+            }
+        };
+        pin!(in_process_signal);
+
         match force_shutdown_timeout {
             Some(timeout) => {
-                tokio::time::sleep(timeout).await;
-                ForceShutdownReason::Timeout
+                select! {
+                    _ = tokio::time::sleep(timeout) => ForceShutdownReason::Timeout,
+                    _ = &mut in_process_signal => ForceShutdownReason::Signal,
+                }
             }
             None => {
                 let interrupt = async {
@@ -288,8 +308,10 @@ impl Run {
                         tokio::time::sleep(Duration::MAX).await;
                     }
                 };
-                interrupt.await;
-                ForceShutdownReason::Signal
+                select! {
+                    _ = interrupt => ForceShutdownReason::Signal,
+                    _ = &mut in_process_signal => ForceShutdownReason::Signal,
+                }
             }
         }
     }
@@ -297,6 +319,7 @@ impl Run {
     async fn wait_for_cache_shutdown<FClosed, FProgress>(
         shutdown_reason: Option<ShutdownReason>,
         force_shutdown_timeout: Option<Duration>,
+        in_process_signals: Option<tokio::sync::broadcast::Receiver<()>>,
         closed: FClosed,
         progress: FProgress,
     ) -> CacheShutdownOutcome
@@ -308,7 +331,7 @@ impl Run {
             select! {
                 _ = closed => CacheShutdownOutcome::Complete,
                 _ = progress => CacheShutdownOutcome::Complete,
-                _ = Self::wait_for_forced_shutdown(force_shutdown_timeout) => {
+                _ = Self::wait_for_forced_shutdown(force_shutdown_timeout, in_process_signals) => {
                     CacheShutdownOutcome::ForcedShutdown
                 }
             }
@@ -323,6 +346,7 @@ impl Run {
     async fn wait_for_process_manager_shutdown<F>(
         process_manager: ProcessManager,
         force_shutdown_timeout: Option<Duration>,
+        in_process_signals: Option<tokio::sync::broadcast::Receiver<()>>,
         graceful_shutdown: F,
     ) where
         F: Future<Output = ()> + Send,
@@ -333,7 +357,8 @@ impl Run {
             SLOW_SHUTDOWN_STATUS_INTERVAL,
         );
         shutdown_status.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-        let force_shutdown = Self::wait_for_forced_shutdown(force_shutdown_timeout);
+        let force_shutdown =
+            Self::wait_for_forced_shutdown(force_shutdown_timeout, in_process_signals);
         pin!(graceful_shutdown, force_shutdown);
 
         loop {
@@ -726,6 +751,7 @@ impl Run {
                 Self::wait_for_process_manager_shutdown(
                     process_manager.clone(),
                     force_shutdown_timeout,
+                    Some(signal_handler.subscribe_in_process_signals()),
                     graceful_shutdown,
                 )
                 .await;
@@ -822,6 +848,7 @@ impl Run {
                 if Self::wait_for_cache_shutdown(
                     shutdown_reason,
                     force_shutdown_timeout,
+                    Some(signal_handler.subscribe_in_process_signals()),
                     async {
                         let _ = closed.await;
                     },
@@ -875,6 +902,7 @@ impl Run {
             Self::wait_for_process_manager_shutdown(
                 process_manager.clone(),
                 force_shutdown_timeout,
+                Some(signal_handler.subscribe_in_process_signals()),
                 graceful_shutdown,
             )
             .await;
@@ -1330,7 +1358,7 @@ mod tests {
     use turborepo_signals::ShutdownReason;
 
     use super::{
-        remote_cache_status_message, CacheShutdownOutcome, RemoteCacheStatus,
+        remote_cache_status_message, CacheShutdownOutcome, ForceShutdownReason, RemoteCacheStatus,
         RemoteCacheUnavailableReason, Run,
     };
     use crate::opts::RemoteCacheDisabledReason;
@@ -1383,6 +1411,7 @@ mod tests {
             Run::wait_for_cache_shutdown(
                 Some(ShutdownReason::Close),
                 Some(Duration::from_millis(10)),
+                None,
                 pending::<()>(),
                 pending::<()>(),
             ),
@@ -1400,6 +1429,34 @@ mod tests {
         let result = Run::wait_for_cache_shutdown(
             Some(ShutdownReason::Signal),
             Some(Duration::from_millis(10)),
+            None,
+            pending::<()>(),
+            pending::<()>(),
+        )
+        .await;
+
+        assert_eq!(result, CacheShutdownOutcome::ForcedShutdown);
+    }
+
+    #[tokio::test]
+    async fn forced_shutdown_accepts_in_process_signal_before_timeout() {
+        let (tx, rx) = tokio::sync::broadcast::channel(1);
+        tx.send(()).unwrap();
+
+        let result = Run::wait_for_forced_shutdown(Some(Duration::from_secs(60)), Some(rx)).await;
+
+        assert_eq!(result, ForceShutdownReason::Signal);
+    }
+
+    #[tokio::test]
+    async fn cache_shutdown_signal_accepts_in_process_signal() {
+        let (tx, rx) = tokio::sync::broadcast::channel(1);
+        tx.send(()).unwrap();
+
+        let result = Run::wait_for_cache_shutdown(
+            Some(ShutdownReason::Signal),
+            Some(Duration::from_secs(60)),
+            Some(rx),
             pending::<()>(),
             pending::<()>(),
         )

--- a/crates/turborepo-signals/src/lib.rs
+++ b/crates/turborepo-signals/src/lib.rs
@@ -18,7 +18,7 @@ use futures::{Stream, StreamExt, stream::FuturesUnordered};
 use signals::Signal;
 use tokio::{
     pin,
-    sync::{Notify, mpsc, oneshot},
+    sync::{Notify, broadcast, mpsc, oneshot},
 };
 
 /// Why the signal handler started shutdown.
@@ -39,6 +39,7 @@ pub struct SignalHandler {
     state: Arc<Mutex<HandlerState>>,
     close: mpsc::Sender<()>,
     in_process_signal: mpsc::Sender<()>,
+    in_process_signals: broadcast::Sender<()>,
     shutdown_reason: Arc<AtomicU8>,
     started: Arc<Notify>,
 }
@@ -77,6 +78,7 @@ impl SignalHandler {
         let worker_started = started.clone();
         let (close, mut rx) = mpsc::channel::<()>(1);
         let (in_process_signal, mut in_process_signal_rx) = mpsc::channel::<()>(1);
+        let (in_process_signals, _) = broadcast::channel::<()>(16);
         tokio::spawn(async move {
             pin!(signal_source);
             let shutdown_reason = tokio::select! {
@@ -119,6 +121,7 @@ impl SignalHandler {
             state,
             close,
             in_process_signal,
+            in_process_signals,
             shutdown_reason,
             started,
         }
@@ -150,6 +153,14 @@ impl SignalHandler {
     /// active.
     pub fn notify_signal(&self) {
         self.in_process_signal.try_send(()).ok();
+        self.in_process_signals.send(()).ok();
+    }
+
+    /// Subscribe to in-process signals after the initial shutdown has started.
+    /// This is used by UIs that consume Ctrl-C while the terminal is in raw
+    /// mode.
+    pub fn subscribe_in_process_signals(&self) -> broadcast::Receiver<()> {
+        self.in_process_signals.subscribe()
     }
 
     /// Wait until handler is finished and all subscribers finish their cleanup


### PR DESCRIPTION
## Why

Windows TUI mode consumes Ctrl-C while the terminal is in raw mode. The first Ctrl-C could start graceful shutdown, but subsequent Ctrl-C presses were not visible to the forced-shutdown waiters, so users could not force-exit stuck tasks from the TUI.

Refs #12651.

## What

Broadcast in-process Ctrl-C notifications from the shared signal handler and let process/cache shutdown waiters treat those notifications as force-shutdown signals after graceful shutdown has started.

## How

Verified with:

- `cargo fmt --package turborepo-lib --package turborepo-signals`
- `cargo test -p turborepo-signals`
- `cargo test -p turborepo-lib shutdown`
- `cargo test -p turbo --test graceful_shutdown_test run_force_kills_on_second_sigint_in_tty`