### PR TITLE
fix: Soften force shutdown message

### DIFF
--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -241,31 +241,28 @@ impl Run {
     ) {
         let message = match (reason, task_names.is_empty()) {
             (ForceShutdownReason::Signal, false) if is_interactive => {
-                format!(
-                    " - Force killing Turborepo tasks: {}",
-                    task_names.join(", ")
-                )
+                format!(" - Force killed Turborepo tasks: {}", task_names.join(", "))
             }
             (ForceShutdownReason::Signal, false) => {
-                format!("Force killing Turborepo tasks: {}", task_names.join(", "))
+                format!("Force killed Turborepo tasks: {}", task_names.join(", "))
             }
             (ForceShutdownReason::Timeout, false) => format!(
-                "Graceful shutdown timed out. Force killing Turborepo tasks: {}",
+                "Graceful shutdown timed out. Force killed Turborepo tasks: {}",
                 task_names.join(", ")
             ),
             (ForceShutdownReason::Signal, true) if is_interactive => {
-                " - Force killing remaining Turborepo tasks...".to_string()
+                " - Force killed remaining Turborepo tasks...".to_string()
             }
             (ForceShutdownReason::Signal, true) => {
-                "Force killing remaining Turborepo tasks...".to_string()
+                "Force killed remaining Turborepo tasks...".to_string()
             }
-            (ForceShutdownReason::Timeout, true) => "Graceful shutdown timed out. Force killing \
-                                                     remaining Turborepo tasks..."
-                .to_string(),
+            (ForceShutdownReason::Timeout, true) => {
+                "Graceful shutdown timed out. Force killed remaining Turborepo tasks...".to_string()
+            }
         };
-        turborepo_log::warn(
+        turborepo_log::info(
             turborepo_log::Source::turbo(turborepo_log::Subsystem::Run),
-            message,
+            LIGHT_GREY.apply_to(message).to_string(),
         )
         .emit();
     }

--- a/crates/turborepo/tests/graceful_shutdown_test.rs
+++ b/crates/turborepo/tests/graceful_shutdown_test.rs
@@ -636,6 +636,14 @@ while true; do sleep 0.2 || true; done
             transcript.contains("1 task shutting down..."),
             "expected repeated shutdown status after the initial banner\n{transcript}"
         );
+        assert!(
+            transcript.contains(" - Force killed Turborepo tasks: app-a#dev"),
+            "expected force-kill status after second Ctrl+C\n{transcript}"
+        );
+        assert!(
+            !transcript.contains(" WARNING "),
+            "force-kill status should not use warning styling\n{transcript}"
+        );
     }
 
     #[test]
@@ -695,7 +703,7 @@ while true; do sleep 0.2 || true; done
         );
         assert!(
             combined
-                .contains("Graceful shutdown timed out. Force killing Turborepo tasks: app-a#dev"),
+                .contains("Graceful shutdown timed out. Force killed Turborepo tasks: app-a#dev"),
             "expected auto-force banner after timeout\n{combined}"
         );
     }


### PR DESCRIPTION
### Why
The forced shutdown message is part of normal Ctrl+C handling and should not look like a loud warning in the terminal.

### What
Render the force-shutdown status using the same dim Turborepo status styling as the graceful shutdown prompt, and update the wording to say tasks were force killed.

### How
Verified with `cargo test -p turbo --test graceful_shutdown_test run_force_kills_on_second_sigint_in_tty`.