### PR TITLE
fix: Preserve bun patchedDependencies during prune

### DIFF
--- a/crates/turborepo-lockfiles/src/bun/subgraph.rs
+++ b/crates/turborepo-lockfiles/src/bun/subgraph.rs
@@ -1,8 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use super::{
-    data::WorkspaceEntry, BunLockfile, BunLockfileData, Error, Map, PackageEntry, PackageIdent,
-    PackageIndex, PackageInfo, PackageKey,
+    BunLockfile, BunLockfileData, Error, Map, PackageEntry, PackageIdent, PackageIndex,
+    PackageInfo, PackageKey, data::WorkspaceEntry,
 };
 
 impl BunLockfile {
@@ -626,9 +626,10 @@ impl BunLockfile {
                 }
 
                 let pkg_name = ident.name().to_string();
-                if required_patched_idents.iter().any(|patched_ident| {
-                    PackageIdent::parse(patched_ident).name() == pkg_name
-                }) {
+                if required_patched_idents
+                    .iter()
+                    .any(|patched_ident| PackageIdent::parse(patched_ident).name() == pkg_name)
+                {
                     continue;
                 }
                 if !top_level_pkg_names.contains(&pkg_name) {
@@ -932,9 +933,7 @@ impl BunLockfile {
             if let Some(entry) = self.data.packages.get(&pkg_name)
                 && entry.ident == *ident
             {
-                pruned_data
-                    .packages
-                    .insert(pkg_name.clone(), entry.clone());
+                pruned_data.packages.insert(pkg_name.clone(), entry.clone());
                 let hoisted_prefix = format!("{pkg_name}/");
                 for (key, child) in &self.data.packages {
                     if key.starts_with(&hoisted_prefix) {

--- a/crates/turborepo-lockfiles/src/bun/subgraph.rs
+++ b/crates/turborepo-lockfiles/src/bun/subgraph.rs
@@ -1,5 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
+use semver::{Version, VersionReq};
+
 use super::{
     BunLockfile, BunLockfileData, Error, Map, PackageEntry, PackageIdent, PackageIndex,
     PackageInfo, PackageKey, data::WorkspaceEntry,
@@ -905,14 +907,47 @@ impl BunLockfile {
                     if version.contains("workspace:") {
                         continue;
                     }
-                    let ident = format!("{name}@{version}");
-                    if self.data.patched_dependencies.contains_key(&ident) {
-                        required.insert(ident);
+                    for patched_ident in self.data.patched_dependencies.keys() {
+                        if self.patched_ident_satisfies_dep(patched_ident, name, version) {
+                            required.insert(patched_ident.clone());
+                        }
                     }
                 }
             }
         }
         required
+    }
+
+    fn patched_ident_satisfies_dep(&self, patched_ident: &str, name: &str, version: &str) -> bool {
+        let parsed_ident = PackageIdent::parse(patched_ident);
+        if parsed_ident.name() != name {
+            return false;
+        }
+
+        let Some((_, patched_version)) = patched_ident.rsplit_once('@') else {
+            return false;
+        };
+
+        let version = self
+            .resolve_catalog_version(name, version)
+            .unwrap_or(version);
+        let version = self.apply_overrides(name, version);
+
+        if let Some(exact_version) = version.strip_prefix('=') {
+            return patched_version == exact_version;
+        }
+        if Version::parse(version).is_ok() {
+            return patched_version == version;
+        }
+
+        let Ok(req) = VersionReq::parse(version) else {
+            return false;
+        };
+        let Ok(patched_version) = Version::parse(patched_version) else {
+            return false;
+        };
+
+        req.matches(&patched_version)
     }
 
     fn restore_patched_hoisted_entries(

--- a/crates/turborepo-lockfiles/src/bun/subgraph.rs
+++ b/crates/turborepo-lockfiles/src/bun/subgraph.rs
@@ -1,8 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use super::{
-    BunLockfile, BunLockfileData, Error, Map, PackageEntry, PackageIdent, PackageIndex,
-    PackageInfo, PackageKey,
+    data::WorkspaceEntry, BunLockfile, BunLockfileData, Error, Map, PackageEntry, PackageIdent,
+    PackageIndex, PackageInfo, PackageKey,
 };
 
 impl BunLockfile {
@@ -443,29 +443,12 @@ impl BunLockfile {
             }
         }
 
-        // Collect idents of all packages in the subgraph for filtering purposes
-        let included_idents: HashSet<&str> = pruned_data
-            .packages
-            .values()
-            .map(|entry| entry.ident.as_str())
-            .collect();
-
         // Preserve ALL overrides from the original lockfile. turbo prune copies
         // the root package.json with all overrides intact, so the lockfile must
         // keep them in sync. If overrides are selectively stripped here, bun
         // detects the mismatch with package.json and re-resolves, which breaks
         // `bun install --frozen-lockfile` when a range has drifted (e.g. "latest").
         pruned_data.overrides = self.data.overrides.clone();
-
-        // Filter patched_dependencies to only include those for packages in the
-        // subgraph
-        for (pkg_ident, patch_path) in &self.data.patched_dependencies {
-            if included_idents.contains(pkg_ident.as_str()) {
-                pruned_data
-                    .patched_dependencies
-                    .insert(pkg_ident.clone(), patch_path.clone());
-            }
-        }
 
         // ORPHAN REMOVAL: After de-aliasing, some packages may be orphaned
         // (only depended on by packages that were skipped due to de-aliasing
@@ -594,6 +577,14 @@ impl BunLockfile {
         // keeps a nested version, we must promote the nested entry to top-level
         // to maintain a valid lockfile structure that bun's --frozen-lockfile
         // accepts.
+        //
+        // Restore patched hoisted entries first so promotion does not replace a
+        // still-required patched version with an unrelated nested alternative.
+        // See https://github.com/vercel/turborepo/issues/13101
+        let required_patched_idents =
+            self.workspace_required_patched_idents(&pruned_data.workspaces);
+        self.restore_patched_hoisted_entries(&mut pruned_data, &required_patched_idents);
+
         loop {
             let top_level_pkg_names: HashSet<String> = pruned_data
                 .packages
@@ -635,6 +626,11 @@ impl BunLockfile {
                 }
 
                 let pkg_name = ident.name().to_string();
+                if required_patched_idents.iter().any(|patched_ident| {
+                    PackageIdent::parse(patched_ident).name() == pkg_name
+                }) {
+                    continue;
+                }
                 if !top_level_pkg_names.contains(&pkg_name) {
                     promote_target = Some((pkg_name, key.clone()));
                     break;
@@ -858,6 +854,8 @@ impl BunLockfile {
         // rewrite the pruned lockfile.
         self.include_duplicate_alias_children(&mut pruned_data);
 
+        self.preserve_patched_dependencies(&mut pruned_data);
+
         // Rebuild key_to_entry HashMap for the pruned lockfile
         let mut key_to_entry: HashMap<String, String> =
             HashMap::with_capacity(pruned_data.packages.len());
@@ -886,5 +884,87 @@ impl BunLockfile {
             key_to_entry,
             index,
         })
+    }
+
+    fn workspace_required_patched_idents(
+        &self,
+        workspaces: &Map<String, WorkspaceEntry>,
+    ) -> HashSet<String> {
+        let mut required = HashSet::new();
+        for workspace in workspaces.values() {
+            for deps in [
+                workspace.dependencies.as_ref(),
+                workspace.dev_dependencies.as_ref(),
+                workspace.optional_dependencies.as_ref(),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                for (name, version) in deps {
+                    if version.contains("workspace:") {
+                        continue;
+                    }
+                    let ident = format!("{name}@{version}");
+                    if self.data.patched_dependencies.contains_key(&ident) {
+                        required.insert(ident);
+                    }
+                }
+            }
+        }
+        required
+    }
+
+    fn restore_patched_hoisted_entries(
+        &self,
+        pruned_data: &mut BunLockfileData,
+        required_patched_idents: &HashSet<String>,
+    ) {
+        for ident in required_patched_idents {
+            let pkg_name = PackageIdent::parse(ident).name().to_string();
+            let hoisted_correct = pruned_data
+                .packages
+                .get(&pkg_name)
+                .is_some_and(|entry| entry.ident == *ident);
+            if hoisted_correct {
+                continue;
+            }
+
+            if let Some(entry) = self.data.packages.get(&pkg_name)
+                && entry.ident == *ident
+            {
+                pruned_data
+                    .packages
+                    .insert(pkg_name.clone(), entry.clone());
+                let hoisted_prefix = format!("{pkg_name}/");
+                for (key, child) in &self.data.packages {
+                    if key.starts_with(&hoisted_prefix) {
+                        pruned_data.packages.insert(key.clone(), child.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    fn preserve_patched_dependencies(&self, pruned_data: &mut BunLockfileData) {
+        let required_patched_idents =
+            self.workspace_required_patched_idents(&pruned_data.workspaces);
+        self.restore_patched_hoisted_entries(pruned_data, &required_patched_idents);
+
+        let included_idents: HashSet<&str> = pruned_data
+            .packages
+            .values()
+            .map(|entry| entry.ident.as_str())
+            .collect();
+
+        pruned_data.patched_dependencies.clear();
+        for (pkg_ident, patch_path) in &self.data.patched_dependencies {
+            if required_patched_idents.contains(pkg_ident)
+                || included_idents.contains(pkg_ident.as_str())
+            {
+                pruned_data
+                    .patched_dependencies
+                    .insert(pkg_ident.clone(), patch_path.clone());
+            }
+        }
     }
 }

--- a/crates/turborepo-lockfiles/src/bun/test.rs
+++ b/crates/turborepo-lockfiles/src/bun/test.rs
@@ -1996,3 +1996,193 @@ fn test_subgraph_preserves_hoisted_transitive_version_with_nested_mismatch() {
         .expect("bs58@6 should resolve base-x@5");
     assert_eq!(app_base_x.key, "base-x@5.0.1");
 }
+
+// Regression test for https://github.com/vercel/turborepo/issues/13101
+// When a patched package exists at two versions in the prune closure, the
+// patched hoisted version must be preserved and patchedDependencies must not
+// be dropped.
+#[test]
+fn test_subgraph_preserves_patched_dependency_when_two_versions_exist() {
+    let contents = serde_json::to_string(&json!({
+        "lockfileVersion": 1,
+        "configVersion": 1,
+        "workspaces": {
+            "": {
+                "name": "turbo-prune-patch-repro",
+                "devDependencies": {
+                    "turbo": "2.9.14"
+                }
+            },
+            "apps/app-a": {
+                "name": "app-a",
+                "version": "0.0.0",
+                "dependencies": {
+                    "is-odd": "3.0.1",
+                    "pkg-old": "workspace:*"
+                }
+            },
+            "packages/pkg-old": {
+                "name": "pkg-old",
+                "version": "0.0.0",
+                "dependencies": {
+                    "is-odd": "2.0.0"
+                }
+            }
+        },
+        "patchedDependencies": {
+            "is-odd@3.0.1": "patches/is-odd@3.0.1.patch"
+        },
+        "packages": {
+            "app-a": ["app-a@workspace:apps/app-a"],
+            "is-number": ["is-number@6.0.0", "", {}, "sha512-is-number-6"],
+            "is-odd": ["is-odd@3.0.1", "", { "dependencies": { "is-number": "^6.0.0" } }, "sha512-is-odd-3"],
+            "pkg-old": ["pkg-old@workspace:packages/pkg-old"],
+            "pkg-old/is-odd": ["is-odd@2.0.0", "", { "dependencies": { "is-number": "^4.0.0" } }, "sha512-is-odd-2"],
+            "pkg-old/is-odd/is-number": ["is-number@4.0.0", "", {}, "sha512-is-number-4"]
+        }
+    }))
+    .unwrap();
+
+    let lockfile = BunLockfile::from_str(&contents).unwrap();
+
+    // Simulate lockfile_keys from `turbo prune` (external transitive deps only).
+    let lockfile_keys: Vec<String> = [
+        "is-number@4.0.0",
+        "is-number@6.0.0",
+        "is-odd@2.0.0",
+        "is-odd@3.0.1",
+        "turbo@2.9.14",
+    ]
+    .into_iter()
+    .map(String::from)
+    .collect();
+
+    let subgraph = Lockfile::subgraph(
+        &lockfile,
+        &["apps/app-a".into(), "packages/pkg-old".into()],
+        &lockfile_keys,
+    )
+    .unwrap();
+
+    let encoded = subgraph.encode().unwrap();
+    let encoded_str = String::from_utf8(encoded).unwrap();
+    let pruned = BunLockfile::from_str(&encoded_str).unwrap();
+
+    assert!(
+        pruned
+            .data
+            .patched_dependencies
+            .contains_key("is-odd@3.0.1"),
+        "patchedDependencies should retain is-odd@3.0.1, got {:?}",
+        pruned.data.patched_dependencies
+    );
+    assert_eq!(
+        pruned.data.packages.get("is-odd").map(|e| e.ident.as_str()),
+        Some("is-odd@3.0.1"),
+        "hoisted is-odd should remain the patched 3.0.1 version, got {:?}",
+        pruned.data.packages.get("is-odd")
+    );
+    assert!(
+        pruned.data.packages.contains_key("pkg-old/is-odd"),
+        "nested is-odd@2.0.0 should remain under pkg-old, packages: {:?}",
+        pruned
+            .data
+            .packages
+            .iter()
+            .filter(|(k, _)| k.contains("is-odd"))
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        pruned.data.packages.get("pkg-old/is-odd").map(|e| e.ident.as_str()),
+        Some("is-odd@2.0.0")
+    );
+}
+
+// When the patched hoisted version is missing from lockfile_keys but still
+// required by a workspace importer, prune must retain the patch and the
+// patched version instead of promoting the nested alternative.
+#[test]
+fn test_subgraph_preserves_patch_when_patched_version_missing_from_lockfile_keys() {
+    let contents = serde_json::to_string(&json!({
+        "lockfileVersion": 1,
+        "configVersion": 1,
+        "workspaces": {
+            "": {
+                "name": "turbo-prune-patch-repro",
+                "devDependencies": {
+                    "turbo": "2.9.14"
+                }
+            },
+            "apps/app-a": {
+                "name": "app-a",
+                "version": "0.0.0",
+                "dependencies": {
+                    "is-odd": "3.0.1",
+                    "pkg-old": "workspace:*"
+                }
+            },
+            "packages/pkg-old": {
+                "name": "pkg-old",
+                "version": "0.0.0",
+                "dependencies": {
+                    "is-odd": "2.0.0"
+                }
+            }
+        },
+        "patchedDependencies": {
+            "is-odd@3.0.1": "patches/is-odd@3.0.1.patch"
+        },
+        "packages": {
+            "app-a": ["app-a@workspace:apps/app-a"],
+            "is-number": ["is-number@6.0.0", "", {}, "sha512-is-number-6"],
+            "is-odd": ["is-odd@3.0.1", "", { "dependencies": { "is-number": "^6.0.0" } }, "sha512-is-odd-3"],
+            "pkg-old": ["pkg-old@workspace:packages/pkg-old"],
+            "pkg-old/is-odd": ["is-odd@2.0.0", "", { "dependencies": { "is-number": "^4.0.0" } }, "sha512-is-odd-2"],
+            "pkg-old/is-odd/is-number": ["is-number@4.0.0", "", {}, "sha512-is-number-4"]
+        }
+    }))
+    .unwrap();
+
+    let lockfile = BunLockfile::from_str(&contents).unwrap();
+
+    // Omit is-odd@3.0.1 from lockfile_keys, as can happen when only the nested
+    // version appears in the package graph's transitive external dependencies.
+    let lockfile_keys: Vec<String> = [
+        "is-number@4.0.0",
+        "is-odd@2.0.0",
+        "turbo@2.9.14",
+    ]
+    .into_iter()
+    .map(String::from)
+    .collect();
+
+    let subgraph = Lockfile::subgraph(
+        &lockfile,
+        &["apps/app-a".into(), "packages/pkg-old".into()],
+        &lockfile_keys,
+    )
+    .unwrap();
+
+    let encoded = subgraph.encode().unwrap();
+    let encoded_str = String::from_utf8(encoded).unwrap();
+    let pruned = BunLockfile::from_str(&encoded_str).unwrap();
+
+    assert!(
+        pruned
+            .data
+            .patched_dependencies
+            .contains_key("is-odd@3.0.1"),
+        "patchedDependencies should retain is-odd@3.0.1, got {:?}",
+        pruned.data.patched_dependencies
+    );
+    assert_eq!(
+        pruned.data.packages.get("is-odd").map(|e| e.ident.as_str()),
+        Some("is-odd@3.0.1"),
+        "hoisted is-odd should remain the patched 3.0.1 version, got {:?}",
+        pruned.data.packages.get("is-odd")
+    );
+    assert!(
+        pruned.data.packages.contains_key("pkg-old/is-odd"),
+        "nested is-odd@2.0.0 should remain under pkg-old"
+    );
+}

--- a/crates/turborepo-lockfiles/src/bun/test.rs
+++ b/crates/turborepo-lockfiles/src/bun/test.rs
@@ -2121,7 +2121,7 @@ fn test_subgraph_preserves_patch_when_patched_version_missing_from_lockfile_keys
                 "name": "app-a",
                 "version": "0.0.0",
                 "dependencies": {
-                    "is-odd": "3.0.1",
+                    "is-odd": "^3.0.1",
                     "pkg-old": "workspace:*"
                 }
             },

--- a/crates/turborepo-lockfiles/src/bun/test.rs
+++ b/crates/turborepo-lockfiles/src/bun/test.rs
@@ -2093,7 +2093,11 @@ fn test_subgraph_preserves_patched_dependency_when_two_versions_exist() {
             .collect::<Vec<_>>()
     );
     assert_eq!(
-        pruned.data.packages.get("pkg-old/is-odd").map(|e| e.ident.as_str()),
+        pruned
+            .data
+            .packages
+            .get("pkg-old/is-odd")
+            .map(|e| e.ident.as_str()),
         Some("is-odd@2.0.0")
     );
 }
@@ -2147,14 +2151,10 @@ fn test_subgraph_preserves_patch_when_patched_version_missing_from_lockfile_keys
 
     // Omit is-odd@3.0.1 from lockfile_keys, as can happen when only the nested
     // version appears in the package graph's transitive external dependencies.
-    let lockfile_keys: Vec<String> = [
-        "is-number@4.0.0",
-        "is-odd@2.0.0",
-        "turbo@2.9.14",
-    ]
-    .into_iter()
-    .map(String::from)
-    .collect();
+    let lockfile_keys: Vec<String> = ["is-number@4.0.0", "is-odd@2.0.0", "turbo@2.9.14"]
+        .into_iter()
+        .map(String::from)
+        .collect();
 
     let subgraph = Lockfile::subgraph(
         &lockfile,

--- a/lockfile-tests/fixtures/bun-v1-issue-13101/apps/app-a/package.json
+++ b/lockfile-tests/fixtures/bun-v1-issue-13101/apps/app-a/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "app-a",
+  "version": "0.0.0",
+  "scripts": {
+    "build": "echo build app-a"
+  },
+  "dependencies": {
+    "is-odd": "3.0.1",
+    "pkg-old": "workspace:*"
+  }
+}

--- a/lockfile-tests/fixtures/bun-v1-issue-13101/bun.lock
+++ b/lockfile-tests/fixtures/bun-v1-issue-13101/bun.lock
@@ -1,0 +1,57 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "turbo-prune-patch-repro",
+      "devDependencies": {
+        "turbo": "2.9.14",
+      },
+    },
+    "apps/app-a": {
+      "name": "app-a",
+      "version": "0.0.0",
+      "dependencies": {
+        "is-odd": "3.0.1",
+        "pkg-old": "workspace:*",
+      },
+    },
+    "packages/pkg-old": {
+      "name": "pkg-old",
+      "version": "0.0.0",
+      "dependencies": {
+        "is-odd": "2.0.0",
+      },
+    },
+  },
+  "patchedDependencies": {
+    "is-odd@3.0.1": "patches/is-odd@3.0.1.patch",
+  },
+  "packages": {
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-t7QiPflaEyBE4oayeZtSmu4mEfjgIrcNlNNl1z1dmIVPqEdtA7+CfTf8d7KXsOGPh6aNgWjKxyvQg9uGfDQF+A=="],
+
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-d23147mC9BsCPA9mJ0h/ubcpbRgcJBXbcG3+Vq7YLhjz3IXuvQsJ1UXH8f4MD76ZjJ4m/E4aRdJV+MW88CDfbw=="],
+
+    "@turbo/linux-64": ["@turbo/linux-64@2.9.14", "", { "os": "linux", "cpu": "x64" }, "sha512-P3ZKB5tuUDdDQWuAsACGUR1qv9W7BNWxdxqVJ0kZNuNNPRaVYTPPikLcp79+GiEcW3npsR+KyP38lnQiBc5aSA=="],
+
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZRTlzcUMrrPv9ZuDzRF9n60Ym13bKeG9jDB8WjxyLhWNzV+AJQN+zdpIk3NJYf2zQsGUm1mNar2P0elRzLw25g=="],
+
+    "@turbo/windows-64": ["@turbo/windows-64@2.9.14", "", { "os": "win32", "cpu": "x64" }, "sha512-exanwN6sIduZwykYeiTQj8kCmOhazP5WOz3bvXMcYtjhL6Z3iRWLewKrXCBq0bqwSP3iBMb/AerRCnHI4lx46A=="],
+
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.14", "", { "os": "win32", "cpu": "arm64" }, "sha512-fVdCsnmYoKICsycbWuuGp6Jvi51/3G/UluFWuAUCvR8PIW5IJkAk5BM9UF8PSm0Q2IphWHFZjYEgjHsh3B9y/g=="],
+
+    "app-a": ["app-a@workspace:apps/app-a"],
+
+    "is-number": ["is-number@6.0.0", "", {}, "sha512-Wu1VHeILBK8KAWJUAiSZQX94GmOE45Rg6/538fKwiloUu21KncEkYGPqob2oSZ5mUT73vLGrHQjKw3KMPwfDzg=="],
+
+    "is-odd": ["is-odd@3.0.1", "", { "dependencies": { "is-number": "^6.0.0" } }, "sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA=="],
+
+    "pkg-old": ["pkg-old@workspace:packages/pkg-old"],
+
+    "turbo": ["turbo@2.9.14", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.14", "@turbo/darwin-arm64": "2.9.14", "@turbo/linux-64": "2.9.14", "@turbo/linux-arm64": "2.9.14", "@turbo/windows-64": "2.9.14", "@turbo/windows-arm64": "2.9.14" }, "bin": { "turbo": "bin/turbo" } }, "sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw=="],
+
+    "pkg-old/is-odd": ["is-odd@2.0.0", "", { "dependencies": { "is-number": "^4.0.0" } }, "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ=="],
+
+    "pkg-old/is-odd/is-number": ["is-number@4.0.0", "", {}, "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="],
+  }
+}

--- a/lockfile-tests/fixtures/bun-v1-issue-13101/meta.json
+++ b/lockfile-tests/fixtures/bun-v1-issue-13101/meta.json
@@ -1,0 +1,7 @@
+{
+  "packageManager": "bun",
+  "packageManagerVersion": "bun@1.3.14",
+  "lockfileName": "bun.lock",
+  "docker": true,
+  "pruneTargets": ["app-a"]
+}

--- a/lockfile-tests/fixtures/bun-v1-issue-13101/package.json
+++ b/lockfile-tests/fixtures/bun-v1-issue-13101/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "turbo-prune-patch-repro",
+  "private": true,
+  "packageManager": "bun@1.3.14",
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "devDependencies": {
+    "turbo": "2.9.14"
+  },
+  "patchedDependencies": {
+    "is-odd@3.0.1": "patches/is-odd@3.0.1.patch"
+  }
+}

--- a/lockfile-tests/fixtures/bun-v1-issue-13101/package.json
+++ b/lockfile-tests/fixtures/bun-v1-issue-13101/package.json
@@ -1,7 +1,6 @@
 {
   "name": "turbo-prune-patch-repro",
   "private": true,
-  "packageManager": "bun@1.3.14",
   "workspaces": [
     "apps/*",
     "packages/*"
@@ -9,6 +8,7 @@
   "devDependencies": {
     "turbo": "2.9.14"
   },
+  "packageManager": "bun@1.3.14",
   "patchedDependencies": {
     "is-odd@3.0.1": "patches/is-odd@3.0.1.patch"
   }

--- a/lockfile-tests/fixtures/bun-v1-issue-13101/packages/pkg-old/package.json
+++ b/lockfile-tests/fixtures/bun-v1-issue-13101/packages/pkg-old/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pkg-old",
+  "version": "0.0.0",
+  "scripts": {
+    "build": "echo build pkg-old"
+  },
+  "dependencies": {
+    "is-odd": "2.0.0"
+  }
+}

--- a/lockfile-tests/fixtures/bun-v1-issue-13101/patches/is-odd@3.0.1.patch
+++ b/lockfile-tests/fixtures/bun-v1-issue-13101/patches/is-odd@3.0.1.patch
@@ -1,0 +1,9 @@
+diff --git a/index.js b/index.js
+index 79d1f22a8e7a27efb8841bb83cb682ea1ff3a59c..1a2f89d374aedf5a6414d7fb4878bfa63f256a78 100644
+--- a/index.js
++++ b/index.js
+@@ -1,3 +1,4 @@
++// PATCH_MARKER_IS_ODD_3_0_1 — applied via patchedDependencies
+ /*!
+  * is-odd <https://github.com/jonschlinkert/is-odd>
+  *

--- a/lockfile-tests/fixtures/bun-v1-issue-13101/turbo.json
+++ b/lockfile-tests/fixtures/bun-v1-issue-13101/turbo.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "outputs": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Fix `turbo prune --docker` dropping bun `patchedDependencies` when a patched package exists at two versions in the prune closure (fixes #13101)
- Restore required patched hoisted entries before nested-key promotion, skip promoting over still-required patched packages, and re-sync `patchedDependencies` after all pruning transforms
- Add regression tests and a `check-lockfiles` fixture (`bun-v1-issue-13101`) based on the upstream repro

## Test plan

- [x] `cargo test -p turborepo-lockfiles bun::`
- [x] `pnpm check-lockfiles --fixture bun-v1-issue-13101 --turbo-path ../target/release/turbo`
- [x] Manual repro: `turbo --skip-infer prune app-a --docker` retains `patchedDependencies`, `patches/`, and hoisted `is-odd@3.0.1`


Made with [Cursor](https://cursor.com)