### PR TITLE
fix: Ignore symlink cycles when caching outputs

### DIFF
--- a/crates/turborepo-globwalk/src/lib.rs
+++ b/crates/turborepo-globwalk/src/lib.rs
@@ -324,6 +324,8 @@ pub struct Settings {
     /// directories are traversed into (their targets are read). Cycles are
     /// detected and handled gracefully by the underlying walkdir layer.
     follow_links: bool,
+    /// Skip symlink cycle errors and continue walking other entries.
+    ignore_link_cycles: bool,
 }
 
 impl Settings {
@@ -334,6 +336,11 @@ impl Settings {
 
     pub fn follow_links(mut self) -> Self {
         self.follow_links = true;
+        self
+    }
+
+    pub fn ignore_link_cycles(mut self) -> Self {
+        self.ignore_link_cycles = true;
         self
     }
 }
@@ -802,10 +809,10 @@ fn walk_glob(
 
             None
         })
-        .filter_map(|entry| visit_file(walk_type, entry))
+        .filter_map(|entry| visit_file(walk_type, entry, settings))
         .collect::<Vec<_>>()
     } else {
-        iter.filter_map(|entry| visit_file(walk_type, entry))
+        iter.filter_map(|entry| visit_file(walk_type, entry, settings))
             .collect::<Vec<_>>()
     }
 }
@@ -813,6 +820,7 @@ fn walk_glob(
 fn visit_file(
     walk_type: WalkType,
     entry: Result<wax::walk::GlobEntry, wax::walk::WalkError>,
+    settings: Settings,
 ) -> Option<Result<AbsoluteSystemPathBuf, WalkError>> {
     match entry {
         Ok(entry)
@@ -824,6 +832,10 @@ fn visit_file(
         }
         Ok(entry) => Some(AbsoluteSystemPathBuf::try_from(entry.path()).map_err(|e| e.into())),
         Err(e) => {
+            if settings.ignore_link_cycles && e.is_link_cycle() {
+                return None;
+            }
+
             let io_err = std::io::Error::from(e);
             match io_err.kind() {
                 // Ignore missing file and permission errors

--- a/crates/turborepo-run-cache/src/lib.rs
+++ b/crates/turborepo-run-cache/src/lib.rs
@@ -558,7 +558,9 @@ impl TaskCache {
             &validated_inclusions,
             &validated_exclusions,
             globwalk::WalkType::All,
-            globwalk::Settings::default().follow_links(),
+            globwalk::Settings::default()
+                .follow_links()
+                .ignore_link_cycles(),
         )?;
 
         for path in &files_to_be_cached {
@@ -1417,5 +1419,59 @@ mod test {
             cached.is_none(),
             "symlinked output outside repo root should not write a cache artifact"
         );
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn save_outputs_ignores_symlink_cycles() {
+        let temp = tempdir().unwrap();
+        let repo_dir = temp.path().join("repo");
+        std::fs::create_dir_all(repo_dir.join("apps/app/node_modules/@vercel")).unwrap();
+        std::fs::create_dir_all(repo_dir.join("apps/app/node_modules/.cache")).unwrap();
+        std::fs::create_dir_all(
+            repo_dir.join("packages/navigation-metrics/examples/basic/node_modules/@vercel"),
+        )
+        .unwrap();
+        std::fs::write(
+            repo_dir.join("apps/app/node_modules/.cache/tsbuildinfo.json"),
+            b"{}",
+        )
+        .unwrap();
+
+        std::os::unix::fs::symlink(
+            "../../../../packages/navigation-metrics",
+            repo_dir.join("apps/app/node_modules/@vercel/navigation-metrics"),
+        )
+        .unwrap();
+        std::os::unix::fs::symlink(
+            "../../../..",
+            repo_dir
+                .join("packages/navigation-metrics")
+                .join("examples/basic/node_modules/@vercel/navigation-metrics"),
+        )
+        .unwrap();
+
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_dir.as_path()).unwrap();
+        let mut task_cache = task_cache_for_outputs(
+            &repo_root,
+            vec!["**/node_modules/.cache/tsbuildinfo.json".to_string()],
+        );
+        let telemetry = PackageTaskEventBuilder::new("pkg", "type-check");
+
+        task_cache
+            .save_outputs(Duration::from_millis(10), &telemetry)
+            .await
+            .unwrap();
+
+        let expected = AnchoredSystemPathBuf::from_raw(format!(
+            "apps{}app{}node_modules{}.cache{}tsbuildinfo.json",
+            std::path::MAIN_SEPARATOR_STR,
+            std::path::MAIN_SEPARATOR_STR,
+            std::path::MAIN_SEPARATOR_STR,
+            std::path::MAIN_SEPARATOR_STR,
+        ))
+        .unwrap();
+
+        assert!(task_cache.expanded_outputs().contains(&expected));
     }
 }

--- a/crates/turborepo-wax/src/walk/mod.rs
+++ b/crates/turborepo-wax/src/walk/mod.rs
@@ -183,6 +183,10 @@ impl WalkError {
     pub fn depth(&self) -> usize {
         self.depth
     }
+
+    pub fn is_link_cycle(&self) -> bool {
+        matches!(self.kind, WalkErrorKind::LinkCycle { .. })
+    }
 }
 
 impl From<walkdir::Error> for WalkError {


### PR DESCRIPTION
## Why

Turborepo can fail after successful tasks when output cache collection follows workspace symlinks into a package that contains a nested self-referential `node_modules` symlink. 

## What

Allow task output cache collection to skip detected symlink-cycle edges while continuing to collect other matching outputs. The behavior is opt-in for output caching only, so other globwalk callers keep existing error behavior. Existing archive-time repo-boundary protections remain unchanged.

## How

Added an explicit link-cycle check to the wax walk error wrapper, exposed an opt-in `globwalk` setting for best-effort output enumeration, and used it from `TaskCache::save_outputs`. Added a Unix regression matching the `front` symlink shape.

Verified with:

- `cargo test -p turborepo-run-cache`
- `cargo test -p globwalk symlink_cycle_handled_gracefully`