### PR TITLE
fix: Preserve terminal settings for child PTYs

### DIFF
--- a/crates/turborepo-process/src/child.rs
+++ b/crates/turborepo-process/src/child.rs
@@ -79,6 +79,32 @@ impl Child {
         shutdown_style: ShutdownStyle,
         pty_size: Option<PtySize>,
     ) -> std::io::Result<Self> {
+        #[cfg(unix)]
+        {
+            Self::spawn_with_termios(command, shutdown_style, pty_size, None)
+        }
+        #[cfg(not(unix))]
+        {
+            Self::spawn_inner(command, shutdown_style, pty_size)
+        }
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn spawn_with_termios(
+        command: Command,
+        shutdown_style: ShutdownStyle,
+        pty_size: Option<PtySize>,
+        pty_termios: Option<libc::termios>,
+    ) -> std::io::Result<Self> {
+        Self::spawn_inner(command, shutdown_style, pty_size, pty_termios)
+    }
+
+    fn spawn_inner(
+        command: Command,
+        shutdown_style: ShutdownStyle,
+        pty_size: Option<PtySize>,
+        #[cfg(unix)] pty_termios: Option<libc::termios>,
+    ) -> std::io::Result<Self> {
         let label = command.label();
         #[cfg(test)]
         let pty_test_guard = pty_size.map(|_| Arc::new(PtyTestGuard::acquire()));
@@ -87,7 +113,14 @@ impl Child {
             io: ChildIO { stdin, output },
             controller,
         } = if let Some(size) = pty_size {
-            ChildHandle::spawn_pty(command, size)
+            #[cfg(unix)]
+            {
+                ChildHandle::spawn_pty(command, size, pty_termios)
+            }
+            #[cfg(not(unix))]
+            {
+                ChildHandle::spawn_pty(command, size)
+            }
         } else {
             ChildHandle::spawn_normal(command)
         }?;

--- a/crates/turborepo-process/src/child/handle.rs
+++ b/crates/turborepo-process/src/child/handle.rs
@@ -344,7 +344,11 @@ impl ChildHandle {
     }
 
     #[tracing::instrument(skip(command))]
-    pub(super) fn spawn_pty(command: Command, size: PtySize) -> io::Result<SpawnResult> {
+    pub(super) fn spawn_pty(
+        command: Command,
+        size: PtySize,
+        #[cfg(unix)] pty_termios: Option<libc::termios>,
+    ) -> io::Result<SpawnResult> {
         let keep_stdin_open = command.will_open_stdin();
 
         let command = portable_pty::CommandBuilder::from(command);
@@ -367,20 +371,19 @@ impl ChildHandle {
 
         #[cfg(unix)]
         {
-            use nix::sys::termios;
-            if let Some((file_desc, mut termios)) = controller
-                .as_raw_fd()
-                .and_then(|fd| Some(fd).zip(termios::tcgetattr(fd).ok()))
+            if let Some(file_desc) = controller.as_raw_fd()
+                && let Some(mut termios) = pty_termios.or_else(|| {
+                    let mut termios = std::mem::MaybeUninit::<libc::termios>::uninit();
+                    let result = unsafe { libc::tcgetattr(file_desc, termios.as_mut_ptr()) };
+                    (result == 0).then(|| unsafe { termios.assume_init() })
+                })
             {
                 // We unset ECHOCTL to disable rendering of the closing of stdin
                 // as ^D
-                termios.local_flags &= !nix::sys::termios::LocalFlags::ECHOCTL;
-                if let Err(e) = nix::sys::termios::tcsetattr(
-                    file_desc,
-                    nix::sys::termios::SetArg::TCSANOW,
-                    &termios,
-                ) {
-                    debug!("unable to unset ECHOCTL: {e}");
+                termios.c_lflag &= !(libc::ECHOCTL as libc::tcflag_t);
+                if unsafe { libc::tcsetattr(file_desc, libc::TCSANOW, &termios) } != 0 {
+                    let e = io::Error::last_os_error();
+                    debug!("unable to configure PTY termios: {e}");
                 }
             }
         }

--- a/crates/turborepo-process/src/child/handle.rs
+++ b/crates/turborepo-process/src/child/handle.rs
@@ -1,6 +1,7 @@
 use std::{io, time::Duration};
 
 use portable_pty::{Child as PtyChild, MasterPty as PtyController, native_pty_system};
+#[cfg(unix)]
 use sysinfo::{PidExt, ProcessExt, System, SystemExt};
 use tokio::{process::Command as TokioCommand, sync::mpsc};
 use tracing::debug;
@@ -343,7 +344,7 @@ impl ChildHandle {
         })
     }
 
-    #[tracing::instrument(skip(command))]
+    #[tracing::instrument(skip(command, pty_termios))]
     pub(super) fn spawn_pty(
         command: Command,
         size: PtySize,

--- a/crates/turborepo-process/src/lib.rs
+++ b/crates/turborepo-process/src/lib.rs
@@ -39,6 +39,10 @@ pub use self::child::{Child, ChildExit, ChildStdin};
 pub struct ProcessManager {
     state: Arc<Mutex<ProcessManagerInner>>,
     use_pty: bool,
+    // Captured before the TUI may put stdout in raw mode. Reapply it to child
+    // PTYs so task processes do not inherit TUI-specific terminal settings.
+    #[cfg(unix)]
+    pty_termios: Option<libc::termios>,
 }
 
 #[derive(Debug)]
@@ -78,6 +82,8 @@ impl ProcessManager {
                 size: None,
             })),
             use_pty,
+            #[cfg(unix)]
+            pty_termios: use_pty.then(capture_stdout_termios).flatten(),
         }
     }
 
@@ -147,6 +153,14 @@ impl ProcessManager {
             return None;
         }
         let pty_size = self.use_pty.then(|| lock.pty_size()).flatten();
+        #[cfg(unix)]
+        let child = child::Child::spawn_with_termios(
+            command,
+            child::ShutdownStyle::Graceful(Some(stop_timeout)),
+            pty_size,
+            self.pty_termios,
+        );
+        #[cfg(not(unix))]
         let child = child::Child::spawn(
             command,
             child::ShutdownStyle::Graceful(Some(stop_timeout)),
@@ -286,6 +300,13 @@ impl ProcessManager {
     pub fn is_closing(&self) -> bool {
         self.lock_state().is_closing
     }
+}
+
+#[cfg(unix)]
+fn capture_stdout_termios() -> Option<libc::termios> {
+    let mut termios = std::mem::MaybeUninit::<libc::termios>::uninit();
+    let result = unsafe { libc::tcgetattr(libc::STDOUT_FILENO, termios.as_mut_ptr()) };
+    (result == 0).then(|| unsafe { termios.assume_init() })
 }
 
 impl ProcessManagerInner {


### PR DESCRIPTION
## Why

Fixes #12198. Turbo TUI can put the parent terminal in raw mode before task PTYs are spawned, which can let TUI-specific terminal settings leak into long-running child processes. That makes TUI task execution behave differently from stream mode and can trigger runtime-sensitive crashes.

## What

Capture the parent stdout termios when the process manager is created, before TUI startup mutates terminal state, and apply that snapshot to Unix child PTYs before spawning tasks. Existing PTY behavior is preserved otherwise, including clearing ECHOCTL.

## How

Verified locally by using the reproduction in the attached issue.