### PR TITLE
fix: Add ComSpec and PATHEXT to default Windows env passthrough

### DIFF
--- a/crates/turborepo-env/src/lib.rs
+++ b/crates/turborepo-env/src/lib.rs
@@ -86,6 +86,10 @@ pub const BUILTIN_PASS_THROUGH_ENV: &[&str] = &[
     "PNPM_HOME",
     "pnpm_config_verify_deps_before_run",
     "NPM_CONFIG_STORE_DIR",
+    // Needed by npm to spawn scripts now that turbo invokes the bundled npm
+    // directly instead of going through cmd.exe (see vercel/turborepo#13113)
+    "COMSPEC",
+    "PATHEXT",
 ];
 
 #[derive(Clone, Debug, Error)]


### PR DESCRIPTION
## Why

On Windows under the default strict env mode, npm tasks fail silently (exit 1, no output) when using the npm bundled with older Node versions (e.g. Node 24.1.0 / npm 11.3.0). The script never spawns.

Since #13040, turbo invokes the bundled npm directly instead of going through `npm.cmd`/`cmd.exe`. That `cmd.exe` layer used to forward `ComSpec` and `PATHEXT`; without them, older bundled npm can't spawn scripts. Affects 2.9.17–2.9.19-canary.9 (2.9.16 was fine). Users currently have to work around it with `globalPassThroughEnv: ["ComSpec", "PATHEXT"]` or `--env-mode=loose`.

Fixes #13113.

## What

Add `COMSPEC` and `PATHEXT` to `BUILTIN_PASS_THROUGH_ENV` so they're forwarded by default. Env matching is case-insensitive on Windows, so these match `ComSpec`/`PATHEXT`.

## How

Reviewer note: hard to validate without a Windows host + older bundled npm. Repro from the issue: https://github.com/pavelsushkov/turbo-13113-repro — `npx turbo run build` should now print the node version instead of exiting 1.