### PR TITLE
feat: Recognize nub as a package manager

### DIFF
--- a/crates/turborepo-daemon/src/lib.rs
+++ b/crates/turborepo-daemon/src/lib.rs
@@ -222,6 +222,12 @@ pub mod proto {
                 PackageManager::Pnpm6 => Self::Pnpm6,
                 PackageManager::Pnpm9 => Self::Pnpm9,
                 PackageManager::Bun => Self::Bun,
+                // The wire format does not carry nub's underlying lockfile
+                // manager. Default to npm's lockfile here; the daemon re-resolves
+                // the concrete package manager from disk on the server side.
+                PackageManager::Nub => Self::Nub {
+                    lockfile: Box::new(Self::Npm),
+                },
             }
         }
     }
@@ -236,6 +242,7 @@ pub mod proto {
                 turborepo_repository::package_manager::PackageManager::Pnpm6 => Self::Pnpm6,
                 turborepo_repository::package_manager::PackageManager::Pnpm9 => Self::Pnpm9,
                 turborepo_repository::package_manager::PackageManager::Bun => Self::Bun,
+                turborepo_repository::package_manager::PackageManager::Nub { .. } => Self::Nub,
             }
         }
     }

--- a/crates/turborepo-daemon/src/lib.rs
+++ b/crates/turborepo-daemon/src/lib.rs
@@ -223,8 +223,8 @@ pub mod proto {
                 PackageManager::Pnpm9 => Self::Pnpm9,
                 PackageManager::Bun => Self::Bun,
                 // The wire format does not carry nub's underlying lockfile
-                // manager. Default to npm's lockfile here; the daemon re-resolves
-                // the concrete package manager from disk on the server side.
+                // manager. Clients must call [`PackageManager::with_resolved_nub_lockfile`]
+                // after deserializing to re-resolve from disk.
                 PackageManager::Nub => Self::Nub {
                     lockfile: Box::new(Self::Npm),
                 },

--- a/crates/turborepo-daemon/src/proto/turbod.proto
+++ b/crates/turborepo-daemon/src/proto/turbod.proto
@@ -135,6 +135,7 @@ enum PackageManager {
   Yarn = 4;
   Bun = 5;
   Pnpm9 = 6;
+  Nub = 7;
 }
 
 message GetFileHashesRequest {

--- a/crates/turborepo-lib/src/commands/generate.rs
+++ b/crates/turborepo-lib/src/commands/generate.rs
@@ -68,6 +68,10 @@ fn turbo_gen_command(package_manager: &PackageManager, tag: &str) -> PackageMana
             executable: "bun",
             args: vec!["x".to_string(), package],
         },
+        PackageManager::Nub { .. } => PackageManagerCommand {
+            executable: "nubx",
+            args: vec![package],
+        },
     }
 }
 

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -314,12 +314,7 @@ pub async fn prune(
 
     // Prune pnpm-workspace.yaml's patchedDependencies so it only
     // references patches that are actually in the pruned output.
-    if matches!(
-        package_manager,
-        turborepo_repository::package_manager::PackageManager::Pnpm
-            | turborepo_repository::package_manager::PackageManager::Pnpm6
-            | turborepo_repository::package_manager::PackageManager::Pnpm9
-    ) {
+    if package_manager.is_pnpm_family() {
         let ws_config = turborepo_repository::package_manager::pnpm::WORKSPACE_CONFIGURATION_PATH;
         let ws_path = AnchoredSystemPathBuf::from_raw(ws_config)?;
         let out_ws = prune.out_directory.resolve(&ws_path);
@@ -379,10 +374,7 @@ fn collect_patch_paths(
     if !patch_keys.is_empty() {
         patches.extend(package_json_patch_paths(root_package_json, &patch_keys));
 
-        if matches!(
-            package_manager,
-            PackageManager::Pnpm | PackageManager::Pnpm6 | PackageManager::Pnpm9
-        ) {
+        if package_manager.is_pnpm_family() {
             let workspace_yaml_path = repo_root.join_component(
                 turborepo_repository::package_manager::pnpm::WORKSPACE_CONFIGURATION_PATH,
             );
@@ -536,15 +528,11 @@ impl<'a> Prune<'a> {
             return Err(Error::MissingLockfile);
         }
 
-        let uses_per_workspace_lockfiles = matches!(
-            package_graph.package_manager(),
-            turborepo_repository::package_manager::PackageManager::Pnpm
-                | turborepo_repository::package_manager::PackageManager::Pnpm6
-                | turborepo_repository::package_manager::PackageManager::Pnpm9
-        ) && NpmRc::from_file(&base.repo_root)
-            .unwrap_or_default()
-            .shared_workspace_lockfile
-            == Some(false);
+        let uses_per_workspace_lockfiles = package_graph.package_manager().is_pnpm_family()
+            && NpmRc::from_file(&base.repo_root)
+                .unwrap_or_default()
+                .shared_workspace_lockfile
+                == Some(false);
 
         full_directory.resolve(package_json()).ensure_dir()?;
         if docker {

--- a/crates/turborepo-lib/src/run/package_discovery/mod.rs
+++ b/crates/turborepo-lib/src/run/package_discovery/mod.rs
@@ -3,16 +3,20 @@ use turborepo_daemon::{
     proto::{DiscoverPackagesResponse, PackageFiles, PackageManager as ProtoPackageManager},
     DaemonClient,
 };
-use turborepo_repository::discovery::{DiscoveryResponse, Error, PackageDiscovery, WorkspaceData};
+use turborepo_repository::{
+    discovery::{DiscoveryResponse, Error, PackageDiscovery, WorkspaceData},
+    package_manager::PackageManager,
+};
 
 #[derive(Debug)]
 pub struct DaemonPackageDiscovery<C> {
     daemon: DaemonClient<C>,
+    repo_root: AbsoluteSystemPathBuf,
 }
 
 impl<C> DaemonPackageDiscovery<C> {
-    pub fn new(daemon: DaemonClient<C>) -> Self {
-        Self { daemon }
+    pub fn new(daemon: DaemonClient<C>, repo_root: AbsoluteSystemPathBuf) -> Self {
+        Self { daemon, repo_root }
     }
 }
 
@@ -37,8 +41,9 @@ fn workspace_data_from_proto(package_files: PackageFiles) -> Result<WorkspaceDat
 
 fn discovery_response_from_proto(
     response: DiscoverPackagesResponse,
+    repo_root: &turbopath::AbsoluteSystemPath,
 ) -> Result<DiscoveryResponse, Error> {
-    let package_manager = ProtoPackageManager::try_from(response.package_manager)
+    let package_manager: PackageManager = ProtoPackageManager::try_from(response.package_manager)
         .map_err(|_| {
             Error::InvalidResponse(format!(
                 "daemon returned invalid package manager: {}",
@@ -54,7 +59,7 @@ fn discovery_response_from_proto(
 
     Ok(DiscoveryResponse {
         workspaces,
-        package_manager,
+        package_manager: package_manager.with_resolved_nub_lockfile(repo_root),
     })
 }
 
@@ -70,7 +75,7 @@ impl<C: Clone + Send + Sync> PackageDiscovery for DaemonPackageDiscovery<C> {
             .await
             .map_err(|e| Error::Failed(Box::new(e)))?;
 
-        discovery_response_from_proto(response)
+        discovery_response_from_proto(response, &self.repo_root)
     }
 
     async fn discover_packages_blocking(&self) -> Result<DiscoveryResponse, Error> {
@@ -84,6 +89,6 @@ impl<C: Clone + Send + Sync> PackageDiscovery for DaemonPackageDiscovery<C> {
             .await
             .map_err(|e| Error::Failed(Box::new(e)))?;
 
-        discovery_response_from_proto(response)
+        discovery_response_from_proto(response, &self.repo_root)
     }
 }

--- a/crates/turborepo-lsp/src/lib.rs
+++ b/crates/turborepo-lsp/src/lib.rs
@@ -718,6 +718,9 @@ impl Backend {
     }
 
     pub async fn package_discovery(&self) -> Result<DiscoveryResponse, discovery::Error> {
+        let repo_root = lock_or_recover(&self.repo_root)
+            .clone()
+            .ok_or(discovery::Error::Unavailable)?;
         let daemon = {
             let mut daemon = self.daemon.clone();
             let daemon = daemon
@@ -730,7 +733,7 @@ impl Backend {
             daemon.clone()
         };
 
-        DaemonPackageDiscovery::new(daemon)
+        DaemonPackageDiscovery::new(daemon, repo_root)
             .discover_packages_blocking()
             .await
     }

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -408,7 +408,11 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedPackageManager, T> {
             ..
         } = self;
 
-        let package_manager = package_discovery.discover_packages().await?.package_manager;
+        let package_manager = package_discovery
+            .discover_packages()
+            .await?
+            .package_manager
+            .with_resolved_nub_lockfile(repo_root);
 
         debug_assert!(single, "expected single package graph");
         Ok(PackageGraph {
@@ -498,7 +502,8 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedWorkspaces, T> {
             .package_discovery
             .discover_packages()
             .await?
-            .package_manager;
+            .package_manager
+            .with_resolved_nub_lockfile(self.repo_root);
 
         match self.lockfile.take() {
             Some(lockfile) => Ok(lockfile),
@@ -527,7 +532,8 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedWorkspaces, T> {
             .package_discovery
             .discover_packages()
             .await?
-            .package_manager;
+            .package_manager
+            .with_resolved_nub_lockfile(self.repo_root);
         turborepo_rayon_compat::block_in_place(|| {
             self.connect_internal_dependencies(&package_manager)
         })?;
@@ -641,7 +647,8 @@ impl<T: PackageDiscovery> BuildState<'_, ResolvedLockfile, T> {
             .discover_packages()
             .instrument(tracing::debug_span!("package discovery"))
             .await?
-            .package_manager;
+            .package_manager
+            .with_resolved_nub_lockfile(self.repo_root);
         let Self {
             workspaces,
             workspace_graph,

--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -246,6 +246,34 @@ static DEV_ENGINES_VERSION_PATTERN: Lazy<Regex> =
     lazy_regex!(r"\A\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?\z");
 
 impl PackageManager {
+    /// Returns the package manager responsible for lockfile operations.
+    pub fn lockfile_manager(&self) -> &PackageManager {
+        match self {
+            PackageManager::Nub { lockfile } => lockfile.as_ref(),
+            other => other,
+        }
+    }
+
+    /// Whether this package manager uses a pnpm-family lockfile.
+    pub fn is_pnpm_family(&self) -> bool {
+        matches!(
+            self.lockfile_manager(),
+            PackageManager::Pnpm | PackageManager::Pnpm6 | PackageManager::Pnpm9
+        )
+    }
+
+    /// Re-resolves the underlying lockfile manager for [`PackageManager::Nub`]
+    /// from disk. No-op for other variants. Call after daemon proto round-trips
+    /// that cannot carry the underlying lockfile type.
+    pub fn with_resolved_nub_lockfile(self, repo_root: &AbsoluteSystemPath) -> Self {
+        match self {
+            PackageManager::Nub { .. } => PackageManager::Nub {
+                lockfile: Box::new(nub::underlying_lockfile_manager(repo_root)),
+            },
+            other => other,
+        }
+    }
+
     pub fn supported_managers() -> &'static [Self] {
         [
             Self::Npm,
@@ -328,16 +356,39 @@ impl PackageManager {
             PackageManager::Berry
             | PackageManager::Npm
             | PackageManager::Yarn
-            | PackageManager::Bun
-            | PackageManager::Nub { .. } => {
+            | PackageManager::Bun => {
                 let package_json_text = fs::read_to_string(self.workspace_glob_source(root_path))?;
                 let package_json: PackageJsonWorkspaces = serde_json::from_str(&package_json_text)
-                    .map_err(|_| Error::Workspace(MissingWorkspaceError::from(self.clone())))?; // Make sure to convert this to a missing workspace error
+                    .map_err(|_| Error::Workspace(MissingWorkspaceError::from(self.clone())))?;
 
                 if package_json.workspaces.as_ref().is_empty() {
                     return Err(MissingWorkspaceError::from(self.clone()).into());
                 } else {
                     package_json.workspaces.into()
+                }
+            }
+            PackageManager::Nub { lockfile } => {
+                if lockfile.is_pnpm_family()
+                    && root_path
+                        .join_component(pnpm::WORKSPACE_CONFIGURATION_PATH)
+                        .exists()
+                {
+                    pnpm::get_configured_workspace_globs(root_path).ok_or_else(|| {
+                        Error::Workspace(MissingWorkspaceError::from(self.clone()))
+                    })?
+                } else {
+                    let package_json_text =
+                        fs::read_to_string(self.workspace_glob_source(root_path))?;
+                    let package_json: PackageJsonWorkspaces =
+                        serde_json::from_str(&package_json_text).map_err(|_| {
+                            Error::Workspace(MissingWorkspaceError::from(self.clone()))
+                        })?;
+
+                    if package_json.workspaces.as_ref().is_empty() {
+                        return Err(MissingWorkspaceError::from(self.clone()).into());
+                    } else {
+                        package_json.workspaces.into()
+                    }
                 }
             }
         };
@@ -489,11 +540,12 @@ impl PackageManager {
                 "`devEngines.packageManager.name` must not contain leading or trailing whitespace",
             ));
         }
-        if !matches!(name, "npm" | "pnpm" | "yarn" | "bun") {
+        if !matches!(name, "npm" | "pnpm" | "yarn" | "bun" | "nub") {
             return Err(Self::invalid_dev_engines_package_manager_at(
                 dev_engines,
                 &["packageManager", "name"],
-                "`devEngines.packageManager.name` must be one of `npm`, `pnpm`, `yarn`, or `bun`",
+                "`devEngines.packageManager.name` must be one of `npm`, `pnpm`, `yarn`, `bun`, or \
+                 `nub`",
             ));
         }
 
@@ -541,16 +593,23 @@ impl PackageManager {
                 format!("invalid semantic version: {err}"),
             )
         })?;
-        let declared = Self::package_manager_from_name_and_version(name, &version)?;
+        let declared = Self::package_manager_from_name_and_version(repo_root, name, &version)?;
         Self::validate_package_manager_lockfile_match(repo_root, &declared, dev_engines)?;
 
         Ok(declared)
     }
 
-    fn package_manager_from_name_and_version(name: &str, version: &Version) -> Result<Self, Error> {
+    fn package_manager_from_name_and_version(
+        repo_root: &AbsoluteSystemPath,
+        name: &str,
+        version: &Version,
+    ) -> Result<Self, Error> {
         match name {
             "npm" => Ok(PackageManager::Npm),
             "bun" => Ok(PackageManager::Bun),
+            "nub" => Ok(PackageManager::Nub {
+                lockfile: Box::new(nub::underlying_lockfile_manager(repo_root)),
+            }),
             "yarn" => YarnDetector::detect_berry_or_yarn(version),
             "pnpm" => PnpmDetector::detect_pnpm6_or_pnpm(version),
             _ => unreachable!("devEngines package manager name should have been validated"),
@@ -583,6 +642,10 @@ impl PackageManager {
     }
 
     fn same_lockfile_family(left: &Self, right: &Self) -> bool {
+        Self::same_concrete_lockfile_family(left.lockfile_manager(), right.lockfile_manager())
+    }
+
+    fn same_concrete_lockfile_family(left: &Self, right: &Self) -> bool {
         matches!(
             (left, right),
             (
@@ -859,11 +922,14 @@ impl PackageManager {
             PackageManager::Pnpm | PackageManager::Pnpm6 | PackageManager::Pnpm9 => {
                 Some(pnpm::WORKSPACE_CONFIGURATION_PATH)
             }
+            PackageManager::Nub { lockfile } if lockfile.is_pnpm_family() => {
+                Some(pnpm::WORKSPACE_CONFIGURATION_PATH)
+            }
             PackageManager::Npm
             | PackageManager::Berry
             | PackageManager::Yarn
             | PackageManager::Bun
-            // nub reads `workspaces` from package.json, like npm/yarn/bun.
+            // nub with a non-pnpm underlying lockfile reads `workspaces` from package.json.
             | PackageManager::Nub { .. } => None,
         }
     }
@@ -874,6 +940,10 @@ impl PackageManager {
         root_path: &AbsoluteSystemPath,
         root_package_json: &PackageJson,
     ) -> Result<Box<dyn Lockfile>, Error> {
+        if let PackageManager::Nub { lockfile } = self {
+            return lockfile.read_lockfile(root_path, root_package_json);
+        }
+
         // For pnpm, check if per-workspace lockfiles are configured
         if matches!(
             self,
@@ -1083,7 +1153,7 @@ impl PackageManager {
     /// Read catalog definitions from the package manager's configuration.
     /// Currently only pnpm supports catalogs in pnpm-workspace.yaml.
     pub fn read_catalogs(&self, repo_root: &AbsoluteSystemPath) -> Option<pnpm::PnpmCatalogs> {
-        match self {
+        match self.lockfile_manager() {
             PackageManager::Pnpm9 | PackageManager::Pnpm | PackageManager::Pnpm6 => {
                 pnpm::read_catalogs(repo_root)
             }
@@ -1426,6 +1496,7 @@ mod tests {
     #[test_case("pnpm", "8.15.9", PackageManager::Pnpm ; "pnpm")]
     #[test_case("pnpm", "9.12.3", PackageManager::Pnpm9 ; "pnpm9")]
     #[test_case("pnpm", "9.12.3-alpha.0", PackageManager::Pnpm ; "pnpm prerelease")]
+    #[test_case("nub", "0.1.0", PackageManager::Nub { lockfile: Box::new(PackageManager::Npm) } ; "nub")]
     fn test_read_dev_engines_package_manager(
         name: &str,
         version: &str,
@@ -1544,6 +1615,23 @@ mod tests {
             PackageManager::read_or_detect_package_manager(&package_json, &repo_root).unwrap_err();
 
         assert!(matches!(err, Error::MissingPackageManager));
+        Ok(())
+    }
+
+    #[test]
+    fn test_dev_engines_nub_matches_underlying_pnpm_lockfile() -> Result<(), Error> {
+        let (_dir, repo_root) = temp_repo_root()?;
+        repo_root.join_component(pnpm::LOCKFILE).create()?;
+        let package_json = dev_engines_package_manager(json!("nub"), json!("0.1.0"));
+
+        let package_manager = PackageManager::read_package_manager(&repo_root, &package_json)?;
+
+        assert_eq!(
+            package_manager,
+            PackageManager::Nub {
+                lockfile: Box::new(PackageManager::Pnpm)
+            }
+        );
         Ok(())
     }
 

--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -2,6 +2,7 @@ pub mod berry;
 pub mod bun;
 pub mod npm;
 pub mod npmrc;
+pub mod nub;
 pub mod pnpm;
 pub mod yarn;
 pub mod yarnrc;
@@ -71,6 +72,13 @@ pub enum PackageManager {
     Pnpm6,
     Yarn,
     Bun,
+    /// nub (<https://nub.dev>). nub has no lockfile format of its own; it is
+    /// lockfile-compatible with whatever the project already uses. `lockfile`
+    /// holds the concrete package manager whose lockfile is present in the
+    /// repository, which lockfile operations delegate to. See [`nub`].
+    Nub {
+        lockfile: Box<PackageManager>,
+    },
 }
 
 #[derive(Debug)]
@@ -112,6 +120,10 @@ impl Display for MissingWorkspaceError {
             PackageManager::Bun => {
                 "package.json: no workspaces found. Turborepo requires bun workspaces to be \
                  defined in the root package.json"
+            }
+            PackageManager::Nub { .. } => {
+                "package.json: no workspaces found. Turborepo requires workspaces to be defined in \
+                 the root package.json"
             }
         };
         write!(f, "{err}")
@@ -227,7 +239,7 @@ impl From<std::convert::Infallible> for Error {
 }
 
 static PACKAGE_MANAGER_PATTERN: Lazy<Regex> = lazy_regex!(
-    r"\A(?P<manager>bun|npm|pnpm|yarn)@(?P<version>\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?|https?://\S+)\z"
+    r"\A(?P<manager>bun|npm|nub|pnpm|yarn)@(?P<version>\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?|https?://\S+)\z"
 );
 
 static DEV_ENGINES_VERSION_PATTERN: Lazy<Regex> =
@@ -256,6 +268,7 @@ impl PackageManager {
             PackageManager::Pnpm9 => "pnpm9",
             PackageManager::Yarn => "yarn",
             PackageManager::Bun => "bun",
+            PackageManager::Nub { .. } => "nub",
         }
     }
 
@@ -265,6 +278,7 @@ impl PackageManager {
             PackageManager::Pnpm | PackageManager::Pnpm6 | PackageManager::Pnpm9 => "pnpm",
             PackageManager::Yarn | PackageManager::Berry => "yarn",
             PackageManager::Bun => "bun",
+            PackageManager::Nub { .. } => "nub",
         }
     }
 
@@ -292,7 +306,7 @@ impl PackageManager {
             PackageManager::Pnpm | PackageManager::Pnpm6 | PackageManager::Pnpm9 => {
                 pnpm::get_default_exclusions()
             }
-            PackageManager::Npm => ["**/node_modules/**"].as_slice(),
+            PackageManager::Npm | PackageManager::Nub { .. } => ["**/node_modules/**"].as_slice(),
             PackageManager::Bun => ["**/node_modules", "**/.git"].as_slice(),
             PackageManager::Berry => ["**/node_modules", "**/.git", "**/.yarn"].as_slice(),
             PackageManager::Yarn => [].as_slice(), // yarn does its own handling above
@@ -314,7 +328,8 @@ impl PackageManager {
             PackageManager::Berry
             | PackageManager::Npm
             | PackageManager::Yarn
-            | PackageManager::Bun => {
+            | PackageManager::Bun
+            | PackageManager::Nub { .. } => {
                 let package_json_text = fs::read_to_string(self.workspace_glob_source(root_path))?;
                 let package_json: PackageJsonWorkspaces = serde_json::from_str(&package_json_text)
                     .map_err(|_| Error::Workspace(MissingWorkspaceError::from(self.clone())))?; // Make sure to convert this to a missing workspace error
@@ -376,6 +391,9 @@ impl PackageManager {
             match manager {
                 "npm" => Ok(PackageManager::Npm),
                 "bun" => Ok(PackageManager::Bun),
+                "nub" => Ok(PackageManager::Nub {
+                    lockfile: Box::new(nub::underlying_lockfile_manager(repo_root)),
+                }),
                 "yarn" => Ok(YarnDetector::new(repo_root)
                     .next()
                     .ok_or_else(|| Error::MissingPackageManager)??),
@@ -398,6 +416,9 @@ impl PackageManager {
             match manager {
                 "npm" => Ok(PackageManager::Npm),
                 "bun" => Ok(PackageManager::Bun),
+                "nub" => Ok(PackageManager::Nub {
+                    lockfile: Box::new(nub::underlying_lockfile_manager(repo_root)),
+                }),
                 "yarn" => Ok(YarnDetector::detect_berry_or_yarn(&version)?),
                 "pnpm" => Ok(PnpmDetector::detect_pnpm6_or_pnpm(&version)?),
                 _ => unreachable!(
@@ -827,6 +848,9 @@ impl PackageManager {
             PackageManager::Bun => bun::LOCKFILE,
             PackageManager::Pnpm | PackageManager::Pnpm6 | PackageManager::Pnpm9 => pnpm::LOCKFILE,
             PackageManager::Yarn | PackageManager::Berry => yarn::LOCKFILE,
+            // nub uses the lockfile of whichever package manager the project
+            // already uses; delegate to the resolved underlying manager.
+            PackageManager::Nub { lockfile } => lockfile.lockfile_name(),
         }
     }
 
@@ -838,7 +862,9 @@ impl PackageManager {
             PackageManager::Npm
             | PackageManager::Berry
             | PackageManager::Yarn
-            | PackageManager::Bun => None,
+            | PackageManager::Bun
+            // nub reads `workspaces` from package.json, like npm/yarn/bun.
+            | PackageManager::Nub { .. } => None,
         }
     }
 
@@ -911,6 +937,10 @@ impl PackageManager {
                     Some(manifest),
                 )?)
             }
+            // nub delegates to the parser of the lockfile actually present.
+            PackageManager::Nub { lockfile } => {
+                return lockfile.parse_lockfile(root_package_json, contents, yarnrc);
+            }
         })
     }
 
@@ -928,6 +958,10 @@ impl PackageManager {
             PackageManager::Bun => bun::prune_patches(package_json, patches),
             PackageManager::Yarn | PackageManager::Npm => {
                 unreachable!("npm and yarn 1 don't have a concept of patches")
+            }
+            // nub delegates patch pruning to the underlying package manager.
+            PackageManager::Nub { lockfile } => {
+                lockfile.prune_patched_packages(package_json, patches, repo_root)
             }
         }
     }
@@ -1016,7 +1050,12 @@ impl PackageManager {
                 }
             }
             PackageManager::Npm | PackageManager::Pnpm6 => Some("--"),
-            PackageManager::Pnpm | PackageManager::Pnpm9 | PackageManager::Berry => None,
+            // nub has a pnpm-compatible CLI, which forwards script arguments
+            // without needing a `--` separator.
+            PackageManager::Pnpm
+            | PackageManager::Pnpm9
+            | PackageManager::Berry
+            | PackageManager::Nub { .. } => None,
         }
     }
 
@@ -1035,6 +1074,9 @@ impl PackageManager {
                 pnpm::link_workspace_packages(pnpm_version, repo_root)
             }
             PackageManager::Yarn | PackageManager::Bun | PackageManager::Npm => true,
+            // nub links workspace packages by default, delegating to the
+            // underlying manager's behavior where it has one.
+            PackageManager::Nub { lockfile } => lockfile.link_workspace_packages(repo_root),
         }
     }
 
@@ -1183,6 +1225,7 @@ mod tests {
                     "**/bower_components/**",
                     "packages/skip",
                 ],
+                PackageManager::Nub { .. } => &["**/node_modules/**"],
             };
             let expected: HashSet<String> =
                 HashSet::from_iter(expected.iter().map(|s| s.to_string()));
@@ -1285,6 +1328,13 @@ mod tests {
                 expected_error: false,
             },
             TestCase {
+                name: "supports nub".to_owned(),
+                package_manager: Spanned::new("nub@0.1.0".to_owned()),
+                expected_manager: "nub".to_owned(),
+                expected_version: "0.1.0".to_owned(),
+                expected_error: false,
+            },
+            TestCase {
                 name: "supports custom URL".to_owned(),
                 package_manager: Spanned::new("npm@https://some-npm-fork".to_owned()),
                 expected_manager: "npm".to_owned(),
@@ -1353,6 +1403,17 @@ mod tests {
         package_json.package_manager = Some(Spanned::new("bun@1.0.1".to_string()));
         let package_manager = PackageManager::read_package_manager(repo_root, &package_json)?;
         assert_eq!(package_manager, PackageManager::Bun);
+
+        // nub has no lockfile of its own, so with none present it resolves to the
+        // npm-compatible default lockfile.
+        package_json.package_manager = Some(Spanned::new("nub@0.1.0".to_string()));
+        let package_manager = PackageManager::read_package_manager(repo_root, &package_json)?;
+        assert_eq!(
+            package_manager,
+            PackageManager::Nub {
+                lockfile: Box::new(PackageManager::Npm)
+            }
+        );
 
         Ok(())
     }

--- a/crates/turborepo-repository/src/package_manager/nub.rs
+++ b/crates/turborepo-repository/src/package_manager/nub.rs
@@ -1,0 +1,86 @@
+//! nub support.
+//!
+//! nub (<https://nub.dev>) is a Rust CLI that augments the user's installed
+//! Node and ships a pnpm-compatible package-manager command surface. Unlike the
+//! other supported package managers, nub does not define its own lockfile
+//! format: it is lockfile-compatible with whatever the project already uses
+//! (npm, pnpm, yarn, or bun). For that reason nub is recognized only through
+//! the `packageManager` field in `package.json` (`"nub@x.y.z"`); there is no
+//! file-based detector, since a bare foreign lockfile alone does not imply nub.
+//!
+//! Because Turborepo needs a parsed lockfile for pruning and cache hashing, the
+//! [`PackageManager::Nub`] variant carries the concrete package manager whose
+//! lockfile is present in the repository, and lockfile-related operations
+//! delegate to it.
+
+use turbopath::AbsoluteSystemPath;
+
+use crate::package_manager::{PackageManager, bun, pnpm, yarn};
+
+/// Determine which package manager's lockfile is present in the repository
+/// root, in priority order. Defaults to npm when no lockfile is found yet (e.g.
+/// a fresh nub project before the first install), matching nub's npm-compatible
+/// default lockfile.
+pub fn underlying_lockfile_manager(repo_root: &AbsoluteSystemPath) -> PackageManager {
+    if repo_root.join_component(bun::LOCKFILE).exists() {
+        PackageManager::Bun
+    } else if repo_root.join_component(pnpm::LOCKFILE).exists() {
+        PackageManager::Pnpm
+    } else if repo_root.join_component(yarn::LOCKFILE).exists() {
+        PackageManager::Yarn
+    } else {
+        // npm's lockfile, or no lockfile at all -> treat as npm.
+        PackageManager::Npm
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+    use turbopath::AbsoluteSystemPathBuf;
+    use turborepo_errors::Spanned;
+
+    use super::*;
+    use crate::{
+        package_json::PackageJson,
+        package_manager::{PackageManager, npm},
+    };
+
+    #[test]
+    fn test_nub_detected_only_via_package_manager_field() {
+        let dir = tempdir().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(dir.path()).unwrap();
+
+        // A bare npm lockfile alone must NOT be detected as nub.
+        repo_root.join_component(npm::LOCKFILE).create().unwrap();
+        let detected = PackageManager::detect_package_manager(&repo_root).unwrap();
+        assert_eq!(detected, PackageManager::Npm);
+
+        // The `packageManager` field is the only signal for nub.
+        let package_json = PackageJson {
+            package_manager: Some(Spanned::new("nub@0.1.0".to_string())),
+            ..Default::default()
+        };
+        let pm = PackageManager::read_or_detect_package_manager(&package_json, &repo_root).unwrap();
+        assert!(matches!(pm, PackageManager::Nub { .. }));
+    }
+
+    #[test]
+    fn test_nub_underlying_lockfile_resolution() {
+        let dir = tempdir().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(dir.path()).unwrap();
+
+        // No lockfile yet -> npm default.
+        assert_eq!(underlying_lockfile_manager(&repo_root), PackageManager::Npm);
+
+        repo_root.join_component(pnpm::LOCKFILE).create().unwrap();
+        assert_eq!(
+            underlying_lockfile_manager(&repo_root),
+            PackageManager::Pnpm
+        );
+
+        // bun takes priority when multiple are present.
+        repo_root.join_component(bun::LOCKFILE).create().unwrap();
+        assert_eq!(underlying_lockfile_manager(&repo_root), PackageManager::Bun);
+    }
+}

--- a/crates/turborepo-repository/src/package_manager/nub.rs
+++ b/crates/turborepo-repository/src/package_manager/nub.rs
@@ -15,7 +15,7 @@
 
 use turbopath::AbsoluteSystemPath;
 
-use crate::package_manager::{PackageManager, bun, pnpm, yarn};
+use crate::package_manager::{PackageManager, bun, pnpm, yarn, yarn::YarnDetector};
 
 /// Determine which package manager's lockfile is present in the repository
 /// root, in priority order. Defaults to npm when no lockfile is found yet (e.g.
@@ -25,9 +25,11 @@ pub fn underlying_lockfile_manager(repo_root: &AbsoluteSystemPath) -> PackageMan
     if repo_root.join_component(bun::LOCKFILE).exists() {
         PackageManager::Bun
     } else if repo_root.join_component(pnpm::LOCKFILE).exists() {
-        PackageManager::Pnpm
+        pnpm::detect_from_lockfile(repo_root).unwrap_or(PackageManager::Pnpm)
     } else if repo_root.join_component(yarn::LOCKFILE).exists() {
-        PackageManager::Yarn
+        YarnDetector::new(repo_root)
+            .detect_from_lockfile()
+            .unwrap_or(PackageManager::Yarn)
     } else {
         // npm's lockfile, or no lockfile at all -> treat as npm.
         PackageManager::Npm
@@ -82,5 +84,40 @@ mod tests {
         // bun takes priority when multiple are present.
         repo_root.join_component(bun::LOCKFILE).create().unwrap();
         assert_eq!(underlying_lockfile_manager(&repo_root), PackageManager::Bun);
+    }
+
+    #[test]
+    fn test_nub_underlying_lockfile_detects_berry() {
+        let dir = tempdir().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(dir.path()).unwrap();
+
+        repo_root
+            .join_component(yarn::LOCKFILE)
+            .create_with_contents(
+                "__metadata:\n  version: 6\n  cacheKey: 8\n\n\"@pkg/foo@npm:1.0.0\":\n  version: \
+                 1.0.0\n",
+            )
+            .unwrap();
+
+        assert_eq!(
+            underlying_lockfile_manager(&repo_root),
+            PackageManager::Berry
+        );
+    }
+
+    #[test]
+    fn test_nub_underlying_lockfile_detects_pnpm9() {
+        let dir = tempdir().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(dir.path()).unwrap();
+
+        repo_root
+            .join_component(pnpm::LOCKFILE)
+            .create_with_contents("lockfileVersion: '9.0'\n")
+            .unwrap();
+
+        assert_eq!(
+            underlying_lockfile_manager(&repo_root),
+            PackageManager::Pnpm9
+        );
     }
 }

--- a/crates/turborepo-repository/src/package_manager/pnpm.rs
+++ b/crates/turborepo-repository/src/package_manager/pnpm.rs
@@ -52,6 +52,41 @@ impl<'a> PnpmDetector<'a> {
     }
 }
 
+/// Detect the pnpm variant from a `pnpm-lock.yaml` on disk.
+pub fn detect_from_lockfile(repo_root: &AbsoluteSystemPath) -> Result<PackageManager, Error> {
+    let lockfile_path = repo_root.join_component(LOCKFILE);
+    let contents = lockfile_path.read()?;
+    Ok(detect_from_lockfile_contents(&contents))
+}
+
+pub(crate) fn detect_from_lockfile_contents(contents: &[u8]) -> PackageManager {
+    #[derive(Deserialize)]
+    struct PnpmLockfileHeader {
+        #[serde(rename = "lockfileVersion")]
+        lockfile_version: String,
+    }
+
+    let header: PnpmLockfileHeader =
+        serde_yaml_ng::from_slice(contents).unwrap_or(PnpmLockfileHeader {
+            lockfile_version: String::new(),
+        });
+    detect_pnpm_from_lockfile_version(&header.lockfile_version)
+}
+
+fn detect_pnpm_from_lockfile_version(version: &str) -> PackageManager {
+    let major = version
+        .trim_matches('\'')
+        .trim_matches('"')
+        .split('.')
+        .next()
+        .unwrap_or_default();
+    match major {
+        "9" => PackageManager::Pnpm9,
+        "6" => PackageManager::Pnpm6,
+        _ => PackageManager::Pnpm,
+    }
+}
+
 impl Iterator for PnpmDetector<'_> {
     type Item = Result<PackageManager, Error>;
 

--- a/crates/turborepo-repository/src/package_manager/pnpm.rs
+++ b/crates/turborepo-repository/src/package_manager/pnpm.rs
@@ -274,7 +274,8 @@ impl TryFrom<&'_ PackageManager> for PnpmVersion {
             PackageManager::Berry
             | PackageManager::Yarn
             | PackageManager::Npm
-            | PackageManager::Bun => Err(NotPnpmError {
+            | PackageManager::Bun
+            | PackageManager::Nub { .. } => Err(NotPnpmError {
                 package_manager: value.clone(),
             }),
         }

--- a/crates/turborepo-repository/src/package_manager/yarn.rs
+++ b/crates/turborepo-repository/src/package_manager/yarn.rs
@@ -21,7 +21,7 @@ impl<'a> YarnDetector<'a> {
         }
     }
 
-    fn detect_from_lockfile(&self) -> Result<PackageManager, Error> {
+    pub(crate) fn detect_from_lockfile(&self) -> Result<PackageManager, Error> {
         let yarn_lockfile = self.repo_root.join_component(LOCKFILE);
         let contents = String::from_utf8(yarn_lockfile.read()?)?;
         Self::detect_from_lockfile_contents(&contents)

--- a/crates/turborepo-updater/src/lib.rs
+++ b/crates/turborepo-updater/src/lib.rs
@@ -149,6 +149,7 @@ pub fn display_update_check(config: UpdateCheckConfig) -> Result<(), UpdateNotif
                 style("pnpm dlx @turbo/codemod@latest update").cyan().bold()
             }
             PackageManager::Bun => style("bunx @turbo/codemod@latest update").cyan().bold(),
+            PackageManager::Nub { .. } => style("nubx @turbo/codemod@latest update").cyan().bold(),
         };
 
         let msg = format!(

--- a/plans/refactors/package-manager-resolving.md
+++ b/plans/refactors/package-manager-resolving.md
@@ -1,0 +1,163 @@
+# Package manager resolving refactor
+
+Notes on a future refactor motivated by [nub](https://nub.dev) support and the
+`PackageManager::Nub { lockfile }` wrapper introduced in #13120.
+
+## Problem
+
+`PackageManager` currently conflates several concerns:
+
+1. **Declared identity** — what the user set in `package.json` (`packageManager`)
+2. **CLI execution** — which binary to invoke (`npm`, `pnpm`, `nub`, …)
+3. **Lockfile semantics** — parsing, pruning, patch handling, cache hashing
+4. **Workspace discovery** — globs, `pnpm-workspace.yaml`, default exclusions
+
+Every supported manager except nub maps 1:1 across these axes. nub splits them:
+
+- Identity / CLI: `nub`
+- Lockfile: whatever is already on disk (npm, pnpm, yarn, bun)
+
+The current fix is a **wrapper variant** on the existing enum:
+
+```rust
+Nub {
+    lockfile: Box<PackageManager>, // concrete backend, never nested Nub
+}
+```
+
+This works but leaks complexity: call sites must know whether to use the outer
+identity or the inner lockfile backend, and behavior routing is inconsistent
+(some methods delegate, some special-case `Nub`, some use `lockfile_manager()`).
+
+## Current implementation (as of nub integration)
+
+### Detection
+
+- nub is recognized **only** from declaration fields, never from lockfile alone.
+- On detection, `underlying_lockfile_manager(repo_root)` probes disk:
+  bun → pnpm → yarn → npm (default).
+- Yarn Berry and pnpm6/9 are distinguished by lockfile contents, not just
+  filename.
+
+### Helpers introduced to contain leakage
+
+| Helper                                  | Purpose                                                        |
+| --------------------------------------- | -------------------------------------------------------------- |
+| `lockfile_manager()`                    | Peel `Nub` to the concrete lockfile backend                    |
+| `is_pnpm_family()`                      | Predicate for pnpm lockfile semantics via `lockfile_manager()` |
+| `with_resolved_nub_lockfile(repo_root)` | Re-probe disk after daemon proto round-trip                    |
+
+### Delegation vs nub-specific behavior
+
+| Operation                                                   | Route                                             |
+| ----------------------------------------------------------- | ------------------------------------------------- |
+| `command()`, `name()`                                       | Outer nub identity                                |
+| `read_lockfile`, `parse_lockfile`, `prune_patched_packages` | Delegate to inner `lockfile`                      |
+| `read_catalogs`, `is_pnpm_family` (external)                | Via `lockfile_manager()`                          |
+| `arg_separator`                                             | Outer nub (pnpm-compatible CLI)                   |
+| `get_default_exclusions`                                    | Outer nub (npm-style)                             |
+| `get_configured_workspace_globs`                            | Hybrid: pnpm-workspace.yaml if underlying is pnpm |
+
+### Known limitations of the wrapper approach
+
+- **Match-arm proliferation** — easy to miss a `Nub` arm when adding new
+  `PackageManager` behavior.
+- **Snapshot state** — `lockfile` is resolved at detection time; not automatically
+  refreshed if lockfiles change without re-discovery.
+- **Proto wire format** — daemon carries `Nub = 7` only; underlying type is lost
+  on the wire and must be re-resolved from disk on the client.
+- **Recursive type** — `Box<PackageManager>` inside `PackageManager` is a smell
+  that the enum is doing composition without a composition model.
+- **`supported_managers()`** — intentionally excludes nub (no lockfile of its
+  own); lockfile change detection relies on iterating known lockfile names.
+
+## Proposed target model
+
+Split identity from lockfile backend explicitly:
+
+```rust
+struct ResolvedPackageManager {
+    /// What the user declared and what we execute.
+    identity: PackageManagerIdentity,
+
+    /// Always concrete: Npm | Pnpm | Pnpm6 | Pnpm9 | Yarn | Berry | Bun.
+    /// Never Nub.
+    lockfile_backend: LockfileBackend,
+}
+
+enum PackageManagerIdentity {
+    Npm,
+    Pnpm,
+    Yarn,
+    Bun,
+    Nub,
+    // ...
+}
+```
+
+Or a trait-based split:
+
+```rust
+trait TaskExecutor {
+    fn binary(&self) -> &str;
+    fn arg_separator(&self, user_args: &[impl AsRef<str>]) -> Option<&str>;
+}
+
+trait LockfileProvider {
+    fn read_lockfile(&self, root: &AbsoluteSystemPath, pkg: &PackageJson)
+        -> Result<Box<dyn Lockfile>, Error>;
+    fn lockfile_name(&self) -> &str;
+}
+
+trait WorkspaceDiscoverer {
+    fn get_workspace_globs(&self, root: &AbsoluteSystemPath)
+        -> Result<WorkspaceGlobs, Error>;
+}
+```
+
+nub would implement `TaskExecutor` as nub and `LockfileProvider` /
+`WorkspaceDiscoverer` by forwarding to `lockfile_backend`.
+
+## Migration path
+
+1. **Introduce `ResolvedPackageManager`** alongside the existing enum; populate
+   both during detection. No call-site changes yet.
+2. **Move lockfile methods** onto `LockfileBackend` (or `lockfile_backend` field
+   accessors). Update `PackageGraph`, prune, cache hashing to use
+   `resolved.lockfile_backend` instead of matching on `PackageManager`.
+3. **Move execution methods** onto `identity`. Task executor uses
+   `resolved.identity.binary()` only.
+4. **Deprecate `PackageManager::Nub { lockfile }`** once all call sites use the
+   split struct.
+5. **Extend daemon proto** (or always re-resolve from disk at a single boundary)
+   to carry `lockfile_backend` or document that identity-only wire values require
+   disk re-probe.
+
+## When to do this
+
+- **Now (nub only):** wrapper + helpers is acceptable; cost is localized.
+- **Trigger for refactor:** a second "facade" package manager with no native
+  lockfile, or repeated bugs from missed `Nub` match arms / delegation gaps.
+- **Do not block nub merge** on this refactor; treat it as follow-up technical
+  debt with a clear migration sketch.
+
+## Related files
+
+- `crates/turborepo-repository/src/package_manager/mod.rs` — enum, helpers,
+  delegation match arms
+- `crates/turborepo-repository/src/package_manager/nub.rs` — underlying lockfile
+  resolution
+- `crates/turborepo-repository/src/package_graph/builder.rs` —
+  `with_resolved_nub_lockfile` after discovery
+- `crates/turborepo-lib/src/run/package_discovery/mod.rs` — daemon client
+  re-resolution
+- `crates/turborepo-daemon/src/proto/turbod.proto` — `Nub = 7` wire value
+- `crates/turborepo-lib/src/commands/prune.rs` — `is_pnpm_family()` usage
+
+## Open questions
+
+- Should workspace discovery always follow `lockfile_backend`, or should nub have
+  fixed opinions (current hybrid for pnpm-workspace.yaml)?
+- Should the JS tooling (`packages/turbo-workspaces`) share a single
+  `SUPPORTED_PACKAGE_MANAGERS` list with Rust via codegen or a shared JSON
+  schema?


### PR DESCRIPTION
### Description

This adds [nub](https://nub.dev) as a supported package manager.

nub is a Node toolchain that ships a pnpm-compatible package-manager CLI (`nub install`, `nub run <task>`, etc.). The one way it differs from the package managers Turborepo already supports is relevant to detection: **nub does not define a lockfile format of its own.** It is lockfile-compatible with whatever the project already uses, round-tripping npm, pnpm, yarn, and bun lockfiles.

#### Detection signal

Because there is no unique "nub lockfile", nub is recognized **only** through the `packageManager` field in `package.json` (`"nub@x.y.z"`). No file-based detector is added, so a repository containing only a foreign lockfile (e.g. just `package-lock.json`) and no `packageManager` field is never inferred as nub — it continues to resolve exactly as it does today. This mirrors how Turborepo already treats the `packageManager` field as the authoritative signal.

#### Lockfile / pruning / hashing

Turborepo needs a parsed lockfile for pruning and cache hashing. Since a nub project uses the lockfile of whichever package manager it adopted, the new `PackageManager::Nub` variant carries the concrete package manager whose lockfile is present in the repository (resolved at detection time, in the order bun → pnpm → yarn → npm, defaulting to npm when no lockfile exists yet). Lockfile parsing, patch pruning, and workspace-package linking delegate to that underlying manager. Task execution maps to `nub run <task>`.

#### What this is

This is a draft to open discussion on the detection model before polishing. The core behavior works end-to-end (see testing instructions). Open questions for maintainers:

- **`pnpm-workspace.yaml` for nub projects.** This PR has nub read `workspaces` from `package.json` (npm/yarn/bun style). A nub project that uses a `pnpm-workspace.yaml` is not yet handled; happy to add a probe if that combination should be supported.
- **Catalogs.** nub supports catalogs via the underlying manager; this PR returns `None` from `read_catalogs` for nub. Can be wired through if desired.
- **`@turbo/codemod add-package-manager`** is a JS package and out of scope for this Rust change; a follow-up could teach it to write `nub@…`.

### Testing Instructions

Unit tests (added, mirroring the existing per-package-manager tests):

```
cargo test -p turborepo-repository package_manager
```

- `test_nub_detected_only_via_package_manager_field` — a bare npm lockfile is **not** detected as nub; the `packageManager: "nub@…"` field is.
- `test_nub_underlying_lockfile_resolution` — the underlying lockfile manager resolves by priority and defaults to npm.
- nub cases added to `test_parse_package_manager_string` and `test_read_package_manager`.

End-to-end (manual): a single-package repo with `"packageManager": "nub@0.1.0"`, a `build` script, and a `nub` shim on `PATH`. `turbo run build` detects nub, resolves the `nub` binary, and invokes it as `nub run build`:

```
build: NUB_INVOKED_WITH: run build
build: hello-from-build
 Tasks:    1 successful, 1 total
```

`cargo lint` and `cargo fmt --check` are clean.
