### PR TITLE
docs: Fix stderr debugging guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,11 +218,11 @@ In the event of a crash, Rust's crash logs will be written to your temp director
 
 The architecture of the Terminal UI makes for a tricky debugging experience. Because the UI writes to the console through `stdout` in a specific way, using `println!()` statements won't work as expected.
 
-Instead, use `eprintln!()` to print to `stdout` and output `stdout` to a file:
+Instead, use `eprintln!()` to print to `stderr` and redirect `stderr` to a file:
 
 ```bash
 # devturbo is an alias to the debug binary of `turbo` in this case
-devturbo run build --ui=tui --skip-infer 2&> ~/tmp/logs.txt
+devturbo run build --ui=tui --skip-infer 2> ~/tmp/logs.txt
 ```
 
 > [!IMPORTANT]

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -205,7 +205,7 @@ The task graph visitor handles task execution:
 - `ExecContext`: Holds state required to execute a task
 - Attempts cache restoration before execution
 - Spawns and manages child processes using `turborepo_process`
-- Captures `stdout`/`sterr` output
+- Captures `stdout`/`stderr` output
 - Saves outputs to cache on success
 - Reports task result back to the execution engine
 


### PR DESCRIPTION
### Description

Fixed the TUI debugging guidance that incorrectly described where `eprintln!()` writes output.

`eprintln!()` writes to `stderr`, not `stdout`, so this updates the explanation and example redirection command to match `stderr`. This also fixes a `sterr` typo in `ARCHITECTURE.md`.

### Testing Instructions

Documentation-only change, so no tests were run.

Verified the changed scope and checked for the remaining typo with:

```bash
rg -n "sterr|eprintln|2&>|stderr|stdout" CONTRIBUTING.md crates/turborepo/ARCHITECTURE.md
git diff -- CONTRIBUTING.md crates/turborepo/ARCHITECTURE.md