### PR TITLE
fix: Restart deferred hash consumers in watch

### DIFF
--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -702,13 +702,21 @@ impl RunBuilder {
             && self.opts.scope_opts.affected_range.is_some()
             && self.opts.future_flags.affected_using_task_inputs;
 
-        let needs_all_packages =
-            use_task_level_affected || use_task_level_filter || self.add_all_tasks;
+        let use_watch_task_level_filter = self
+            .changed_files_for_watch
+            .as_ref()
+            .is_some_and(|changed_files| !changed_files.is_empty())
+            && self.opts.future_flags.watch_using_task_inputs;
+
+        let needs_all_packages = use_task_level_affected
+            || use_task_level_filter
+            || use_watch_task_level_filter
+            || self.add_all_tasks;
 
         // When task-level filtering or add_all_tasks is active, the engine must
-        // contain tasks for ALL packages so that $TURBO_ROOT$ inputs in packages
-        // not flagged by the package-level scope resolution are still matched.
-        // The task-level filter (below) does the pruning when needed.
+        // contain tasks for ALL packages so that tasks in packages not flagged
+        // by package-level scope resolution can still be matched. The
+        // task-level filter (below) does the pruning when needed.
         let all_pkgs: Vec<PackageName> = if needs_all_packages {
             pkg_dep_graph
                 .packages()

--- a/crates/turborepo/tests/watch_test.rs
+++ b/crates/turborepo/tests/watch_test.rs
@@ -250,6 +250,72 @@ fn setup_watch_test() -> (tempfile::TempDir, PathBuf) {
     (tempdir, test_dir)
 }
 
+fn setup_watch_deferred_dependency_outputs_test() -> (tempfile::TempDir, PathBuf) {
+    let (tempdir, test_dir) = setup_watch_test();
+
+    fs::write(
+        test_dir.join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": {
+    "watchUsingTaskInputs": true
+  },
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
+    "pkg-b#build": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        {
+          "mode": "dependencyOutputs",
+          "from": ["^build"]
+        }
+      ],
+      "outputs": ["dist/**"]
+    }
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    fs::write(
+        test_dir.join("packages/a/build.js"),
+        r#"const fs = require('fs');
+const path = require('path');
+
+const markerDir = path.join(__dirname, '.markers');
+fs.mkdirSync(markerDir, { recursive: true });
+
+const count = fs.readdirSync(markerDir).length;
+const markerFile = path.join(markerDir, `run-${count}`);
+fs.writeFileSync(markerFile, `${Date.now()}\n`);
+
+const distDir = path.join(__dirname, 'dist');
+fs.mkdirSync(distDir, { recursive: true });
+fs.copyFileSync(path.join(__dirname, 'src.js'), path.join(distDir, 'src.js'));
+console.log(`pkg-a build #${count}`);
+"#,
+    )
+    .unwrap();
+
+    common::git(&test_dir, &["add", "."]);
+    common::git(
+        &test_dir,
+        &[
+            "commit",
+            "-m",
+            "configure deferred dependency outputs watch test",
+            "--quiet",
+        ],
+    );
+
+    (tempdir, test_dir)
+}
+
 #[test]
 fn watch_initial_run_executes_tasks() {
     let (_tempdir, test_dir) = setup_watch_test();
@@ -268,6 +334,35 @@ fn watch_initial_run_executes_tasks() {
     assert!(
         b_count >= 1,
         "package b should have run at least once, ran {b_count} times"
+    );
+}
+
+#[test]
+fn watch_task_inputs_reruns_deferred_dependency_output_consumers() {
+    let (_tempdir, test_dir) = setup_watch_deferred_dependency_outputs_test();
+    let guard = WatchGuard::new(spawn_turbo_watch(&test_dir));
+
+    wait_for_markers(&test_dir, "a", 1, Duration::from_secs(30));
+    wait_for_markers(&test_dir, "b", 1, Duration::from_secs(30));
+    std::thread::sleep(Duration::from_secs(2));
+
+    let a_before = marker_count(&test_dir, "a");
+    let b_before = marker_count(&test_dir, "b");
+
+    let a_after = retry_file_change(&test_dir, "a", a_before, 3);
+    let b_after = wait_for_markers(&test_dir, "b", b_before + 1, Duration::from_secs(30));
+
+    drop(guard);
+
+    assert!(
+        a_after > a_before,
+        "package a should have rebuilt after its source changed. before: {a_before}, after: \
+         {a_after}"
+    );
+    assert!(
+        b_after > b_before,
+        "package b should have rebuilt because its hash includes package a's deferred dependency \
+         outputs. before: {b_before}, after: {b_after}"
     );
 }
 


### PR DESCRIPTION
## Why

Deferred dependency-output inputs can make tasks outside the changed package affected in watch mode. When `watchUsingTaskInputs` rebuilt from only the changed packages first, those downstream consumers were missing before task-input pruning ran, so they did not restart.

## What

Ensure watch task-input filtering builds from the full package set when changed files are available, then lets the existing task-input filter prune to the actual execution set. Added regression coverage for a downstream package whose hash includes upstream dependency outputs.

## How

Verified manually and added some tests.