### PR TITLE
fix: Improve watch graceful shutdown

### DIFF
--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -1230,6 +1230,25 @@ impl RunStopper {
         self.manager.stop().await;
     }
 
+    pub async fn shutdown(
+        &self,
+        force_shutdown_timeout: Option<Duration>,
+        in_process_signals: Option<tokio::sync::broadcast::Receiver<()>>,
+    ) {
+        let process_manager = self.manager.clone();
+        let graceful_process_manager = process_manager.clone();
+        let graceful_shutdown = async move {
+            graceful_process_manager.shutdown(None).await;
+        };
+        Run::wait_for_process_manager_shutdown(
+            process_manager,
+            force_shutdown_timeout,
+            in_process_signals,
+            graceful_shutdown,
+        )
+        .await;
+    }
+
     pub async fn shutdown_cache(&self) {
         if self.skip_cache_writes {
             return;

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -576,11 +576,14 @@ impl Run {
     pub fn stopper(&self) -> RunStopper {
         RunStopper {
             manager: self.processes.clone(),
+            run_cache: self.run_cache.clone(),
+            skip_cache_writes: self.opts.cache_opts.cache.skip_writes(),
         }
     }
 
     async fn start_proxy_if_needed(
         &self,
+        register_shutdown_handler: bool,
     ) -> Result<
         Option<(
             tokio::sync::broadcast::Sender<()>,
@@ -603,8 +606,11 @@ impl Run {
         let config = self.load_proxy_config(mfe_configs).await?;
         let (mut server, shutdown_handle) = self.start_proxy_server(config).await?;
 
-        let signal_handler_complete_rx =
-            self.setup_shutdown_handlers(&mut server, shutdown_handle.clone());
+        let signal_handler_complete_rx = self.setup_shutdown_handlers(
+            &mut server,
+            shutdown_handle.clone(),
+            register_shutdown_handler,
+        );
 
         tokio::spawn(async move {
             if let Err(e) = server.run().await {
@@ -664,23 +670,30 @@ impl Run {
         &self,
         server: &mut ProxyServer,
         shutdown_handle: tokio::sync::broadcast::Sender<()>,
+        register_signal_handler: bool,
     ) -> tokio::sync::oneshot::Receiver<()> {
         let (proxy_shutdown_complete_tx, proxy_shutdown_complete_rx) =
             tokio::sync::oneshot::channel();
         let (cleanup_complete_tx, cleanup_complete_rx) = tokio::sync::oneshot::channel();
-        let (signal_handler_complete_tx, signal_handler_complete_rx) =
-            tokio::sync::oneshot::channel();
+        let (signal_handler_complete_tx, signal_handler_complete_rx) = register_signal_handler
+            .then(tokio::sync::oneshot::channel)
+            .map(|(tx, rx)| (Some(tx), Some(rx)))
+            .unwrap_or((None, None));
 
         server.set_shutdown_complete_tx(proxy_shutdown_complete_tx);
 
         tokio::spawn(async move {
             if proxy_shutdown_complete_rx.await.is_ok() {
                 let _ = cleanup_complete_tx.send(());
-                let _ = signal_handler_complete_tx.send(());
+                if let Some(signal_handler_complete_tx) = signal_handler_complete_tx {
+                    let _ = signal_handler_complete_tx.send(());
+                }
             }
         });
 
-        self.register_proxy_signal_handler(shutdown_handle, signal_handler_complete_rx);
+        if let Some(signal_handler_complete_rx) = signal_handler_complete_rx {
+            self.register_proxy_signal_handler(shutdown_handle, signal_handler_complete_rx);
+        }
 
         cleanup_complete_rx
     }
@@ -1166,13 +1179,15 @@ impl Run {
 
     #[instrument(skip_all)]
     pub async fn run(&self, ui_sender: Option<UISender>, is_watch: bool) -> Result<i32, Error> {
-        let proxy_shutdown = self.start_proxy_if_needed().await?;
-        self.setup_cache_shutdown_handler();
+        let proxy_shutdown = self.start_proxy_if_needed(!is_watch).await?;
+        if !is_watch {
+            self.setup_cache_shutdown_handler();
+        }
 
         // If there's no proxy, we need a fallback signal handler for the process
         // manager When a proxy is present, register_proxy_signal_handler
         // handles process manager shutdown
-        if proxy_shutdown.is_none() {
+        if proxy_shutdown.is_none() && !is_watch {
             self.setup_process_manager_shutdown_handler();
         }
 
@@ -1203,14 +1218,30 @@ impl Run {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct RunStopper {
     manager: ProcessManager,
+    run_cache: Arc<RunCache>,
+    skip_cache_writes: bool,
 }
 
 impl RunStopper {
     pub async fn stop(&self) {
         self.manager.stop().await;
+    }
+
+    pub async fn shutdown_cache(&self) {
+        if self.skip_cache_writes {
+            return;
+        }
+
+        if let Ok((_status, closed)) = self.run_cache.shutdown_cache().await {
+            let _ = closed.await;
+        }
+    }
+
+    pub fn cache_writes_enabled(&self) -> bool {
+        !self.skip_cache_writes
     }
 
     pub async fn stop_tasks(&self, task_ids: &[turborepo_task_id::TaskId<'static>]) {

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -24,7 +24,7 @@ use turborepo_repository::package_graph::PackageName;
 use turborepo_run_cache::{OutputWatcher, OutputWatcherError};
 use turborepo_scm::SCM;
 use turborepo_scope::target_selector::InvalidSelectorError;
-use turborepo_signals::{listeners::get_signal, SignalHandler};
+use turborepo_signals::{listeners::get_signal, ShutdownReason, SignalHandler};
 use turborepo_telemetry::events::command::CommandEventBuilder;
 use turborepo_ui::{sender::UISender, LogSinks};
 
@@ -522,15 +522,50 @@ impl WatchClient {
     }
 
     pub async fn shutdown(&mut self) {
+        let force_shutdown_timeout = Run::force_shutdown_timeout();
+        if self.handler.shutdown_reason() == Some(ShutdownReason::Signal) {
+            Run::emit_shutdown_started_once(
+                self.run.shutdown_started_emitted.as_ref(),
+                force_shutdown_timeout,
+            );
+        }
+
         if let Some(sender) = &self.ui_sender {
             sender.stop().await;
         }
-        for stopper in self.background_stoppers.drain(..) {
+        if let Some(handle) = self.ui_handle.take() {
+            match handle.await {
+                Ok(Err(err)) => tracing::error!("error encountered rendering tui: {err}"),
+                Err(err) => tracing::error!("render thread panicked: {err}"),
+                Ok(Ok(())) => {}
+            }
+        }
+
+        let mut stoppers = self.background_stoppers.drain(..).collect::<Vec<_>>();
+        for stopper in &stoppers {
             stopper.stop().await;
         }
+
         for handle in self.active_runs.drain(..) {
-            handle.stopper.stop().await;
-            let _ = handle.run_task.await;
+            let RunHandle { stopper, run_task } = handle;
+            stopper.stop().await;
+            let _ = run_task.await;
+            stoppers.push(stopper);
+        }
+
+        if stoppers
+            .iter()
+            .any(|stopper| stopper.cache_writes_enabled())
+        {
+            turborepo_log::info(
+                turborepo_log::Source::turbo(turborepo_log::Subsystem::Cache),
+                "Finishing writing to cache...",
+            )
+            .emit();
+        }
+
+        for stopper in &stoppers {
+            stopper.shutdown_cache().await;
         }
     }
 

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -523,32 +523,40 @@ impl WatchClient {
 
     pub async fn shutdown(&mut self) {
         let force_shutdown_timeout = Run::force_shutdown_timeout();
-        if self.handler.shutdown_reason() == Some(ShutdownReason::Signal) {
+        let graceful_shutdown = self.handler.shutdown_reason() == Some(ShutdownReason::Signal);
+        if graceful_shutdown {
             Run::emit_shutdown_started_once(
                 self.run.shutdown_started_emitted.as_ref(),
                 force_shutdown_timeout,
             );
         }
 
-        if let Some(sender) = &self.ui_sender {
-            sender.stop().await;
-        }
-        if let Some(handle) = self.ui_handle.take() {
-            match handle.await {
-                Ok(Err(err)) => tracing::error!("error encountered rendering tui: {err}"),
-                Err(err) => tracing::error!("render thread panicked: {err}"),
-                Ok(Ok(())) => {}
-            }
-        }
-
         let mut stoppers = self.background_stoppers.drain(..).collect::<Vec<_>>();
         for stopper in &stoppers {
-            stopper.stop().await;
+            if graceful_shutdown {
+                stopper
+                    .shutdown(
+                        force_shutdown_timeout,
+                        Some(self.handler.subscribe_in_process_signals()),
+                    )
+                    .await;
+            } else {
+                stopper.stop().await;
+            }
         }
 
         for handle in self.active_runs.drain(..) {
             let RunHandle { stopper, run_task } = handle;
-            stopper.stop().await;
+            if graceful_shutdown {
+                stopper
+                    .shutdown(
+                        force_shutdown_timeout,
+                        Some(self.handler.subscribe_in_process_signals()),
+                    )
+                    .await;
+            } else {
+                stopper.stop().await;
+            }
             let _ = run_task.await;
             stoppers.push(stopper);
         }
@@ -566,6 +574,17 @@ impl WatchClient {
 
         for stopper in &stoppers {
             stopper.shutdown_cache().await;
+        }
+
+        if let Some(sender) = &self.ui_sender {
+            sender.stop().await;
+        }
+        if let Some(handle) = self.ui_handle.take() {
+            match handle.await {
+                Ok(Err(err)) => tracing::error!("error encountered rendering tui: {err}"),
+                Err(err) => tracing::error!("render thread panicked: {err}"),
+                Ok(Ok(())) => {}
+            }
         }
     }
 

--- a/crates/turborepo/tests/watch_test.rs
+++ b/crates/turborepo/tests/watch_test.rs
@@ -92,6 +92,15 @@ fn wait_for_markers(test_dir: &Path, pkg: &str, expected: usize, timeout: Durati
 
 /// Spawn `turbo watch` with the given tasks as a child process.
 fn spawn_turbo_watch_with_tasks(test_dir: &Path, tasks: &[&str]) -> Child {
+    spawn_turbo_watch_with_tasks_and_stdio(test_dir, tasks, Stdio::null(), Stdio::null())
+}
+
+fn spawn_turbo_watch_with_tasks_and_stdio(
+    test_dir: &Path,
+    tasks: &[&str],
+    stdout: Stdio,
+    stderr: Stdio,
+) -> Child {
     let turbo_bin = assert_cmd::cargo::cargo_bin("turbo");
     let mut cmd = std::process::Command::new(turbo_bin);
     #[cfg(unix)]
@@ -114,8 +123,8 @@ fn spawn_turbo_watch_with_tasks(test_dir: &Path, tasks: &[&str]) -> Child {
         .env_remove("CI")
         .env_remove("GITHUB_ACTIONS")
         .current_dir(test_dir)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stdout(stdout)
+        .stderr(stderr)
         .spawn()
         .expect("failed to spawn turbo watch")
 }
@@ -351,6 +360,68 @@ fn watch_clean_shutdown_on_sigint() {
             Err(e) => panic!("error waiting for turbo watch: {e}"),
         }
     }
+}
+
+#[cfg(unix)]
+#[test]
+fn watch_shutdown_after_rebuild_emits_single_shutdown_banner() {
+    use nix::{
+        sys::signal::{self, Signal},
+        unistd::Pid,
+    };
+
+    let (_tempdir, test_dir) = setup_watch_test();
+    let guard = WatchGuard::new(spawn_turbo_watch_with_tasks_and_stdio(
+        &test_dir,
+        &["build"],
+        Stdio::piped(),
+        Stdio::piped(),
+    ));
+
+    let initial = wait_for_markers(&test_dir, "a", 1, Duration::from_secs(30));
+    assert!(initial >= 1, "initial watch run did not complete");
+    let rebuilt = retry_file_change(&test_dir, "a", initial, 3);
+    assert!(rebuilt > initial, "watch rebuild did not complete");
+
+    let mut child = guard.take();
+    let pid = Pid::from_raw(child.id() as i32);
+    signal::kill(Pid::from_raw(-pid.as_raw()), Signal::SIGINT).expect("failed to send SIGINT");
+
+    let start = Instant::now();
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if start.elapsed() <= Duration::from_secs(10) => {
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Ok(None) => {
+                stop_watch(child);
+                panic!("turbo watch did not exit within 10s after SIGINT");
+            }
+            Err(e) => panic!("error waiting for turbo watch: {e}"),
+        }
+    };
+
+    let output = child.wait_with_output().expect("failed to collect output");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        status.success(),
+        "turbo watch should exit cleanly on SIGINT\n{combined}"
+    );
+    assert_eq!(
+        combined.matches("Shutting down Turborepo tasks...").count(),
+        1,
+        "shutdown banner should be emitted once after rebuilds\n{combined}"
+    );
+    assert!(
+        !combined.contains("could not start shutdown, exiting"),
+        "stale run cache shutdown handlers should not warn\n{combined}"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

`turbo watch` registered shutdown handlers for every rebuild. On Ctrl-C, stale runs also tried to shut down caches/processes, producing duplicate shutdown banners and cache warnings.

Watch also stopped the TUI before stopping active task processes. In TUI mode this hid graceful-shutdown output and caused watch tasks to use the shorter restart timeout instead of waiting for user-initiated graceful shutdown.

## What

Centralizes watch shutdown in `WatchClient` so completed rebuilds do not keep active signal subscribers.

Keeps the TUI alive while watch tasks receive graceful shutdown, then closes the TUI after task/cache shutdown finishes.

## How

Manual validation: `target/debug/turbo watch start --ui=tui --skip-infer -vvv` in a reproduction repo now forwards Ctrl-C to the child and waits for graceful shutdown output before closing the TUI.