### PR TITLE
fix: Hash selected dependency outputs instead of tasks

### DIFF
--- a/crates/turborepo-engine/src/builder.rs
+++ b/crates/turborepo-engine/src/builder.rs
@@ -489,28 +489,13 @@ fn validate_dependency_outputs_inputs(
             let mut selected = Vec::new();
             for selector in from {
                 let matches = engine.dependency_output_producers_for_selector(task_id, selector);
-                if matches.is_empty() {
-                    return Err(structured_input_error(format!(
-                        "does not match any eligible dependency task node for this task: \
-                         \"dependencyOutputs.from\" contains \"{selector}\".\n\nAdd it to \
-                         dependsOn or remove it from dependencyOutputs.from."
-                    )));
-                }
                 selected.extend(matches);
             }
             selected.sort();
             selected.dedup();
             selected
         } else {
-            let selected = engine.dependency_output_producers(task_id, None);
-            if selected.is_empty() {
-                return Err(structured_input_error(format!(
-                    "dependencyOutputs mode was used for task \"{}\", but this task has no \
-                     dependency tasks to select.",
-                    task_id.task()
-                )));
-            }
-            selected
+            engine.dependency_output_producers(task_id, None)
         };
 
         for selected_task in selected {

--- a/crates/turborepo-engine/src/builder.rs
+++ b/crates/turborepo-engine/src/builder.rs
@@ -24,7 +24,8 @@ use turborepo_types::TaskDefinition;
 
 use crate::{
     BuilderError, Building, Built, Engine, MissingPackageFromTaskError,
-    MissingRootTaskInTurboJsonError, MissingTaskError, TurboJsonLoader, validate_task_name,
+    MissingRootTaskInTurboJsonError, MissingTaskError, TaskNode, TurboJsonLoader,
+    validate_task_name,
 };
 
 mod definitions;
@@ -489,17 +490,34 @@ fn validate_dependency_outputs_inputs(
             let mut selected = Vec::new();
             for selector in from {
                 let matches = engine.dependency_output_producers_for_selector(task_id, selector);
+                if matches.is_empty()
+                    && !selector_allows_empty_match(engine, task_id, task_definition, selector)
+                {
+                    return Err(structured_input_error(format!(
+                        "does not match any eligible dependency task node for this task: \
+                         \"dependencyOutputs.from\" contains \"{selector}\".\n\nAdd it to \
+                         dependsOn or remove it from dependencyOutputs.from."
+                    )));
+                }
                 selected.extend(matches);
             }
             selected.sort();
             selected.dedup();
             selected
         } else {
-            engine.dependency_output_producers(task_id, None)
+            let selected = engine.dependency_output_producers(task_id, None);
+            if selected.is_empty() && !has_configured_dependencies(task_definition) {
+                return Err(structured_input_error(format!(
+                    "dependencyOutputs mode was used for task \"{}\", but this task has no \
+                     dependency tasks to select.",
+                    task_id.task()
+                )));
+            }
+            selected
         };
 
-        for selected_task in selected {
-            let Some(selected_definition) = engine.task_definition(&selected_task) else {
+        for selected_task in &selected {
+            let Some(selected_definition) = engine.task_definition(selected_task) else {
                 continue;
             };
             if selected_definition.outputs.inclusions.is_empty()
@@ -514,9 +532,103 @@ fn validate_dependency_outputs_inputs(
                 )));
             }
         }
+
+        if !selected.is_empty() && !dependency_outputs.globs.is_empty() {
+            validate_dependency_outputs_globs(&selected, engine, &dependency_outputs.globs)?;
+        }
     }
 
     Ok(())
+}
+
+fn selector_allows_empty_match(
+    engine: &Engine<Built, TaskDefinition>,
+    task_id: &TaskId,
+    task_definition: &TaskDefinition,
+    selector: &str,
+) -> bool {
+    let has_dependency_tasks = engine
+        .dependencies(task_id)
+        .is_some_and(|deps| deps.iter().any(|node| matches!(node, TaskNode::Task(_))));
+
+    if has_dependency_tasks {
+        return false;
+    }
+
+    let Some(task) = selector.strip_prefix('^') else {
+        return false;
+    };
+
+    task_definition
+        .topological_dependencies
+        .iter()
+        .any(|dependency| dependency.task() == task)
+}
+
+fn has_configured_dependencies(task_definition: &TaskDefinition) -> bool {
+    !task_definition.topological_dependencies.is_empty()
+        || !task_definition.task_dependencies.is_empty()
+}
+
+fn validate_dependency_outputs_globs(
+    selected_tasks: &[TaskId<'static>],
+    engine: &Engine<Built, TaskDefinition>,
+    requested_globs: &[String],
+) -> Result<(), BuilderError> {
+    for requested_glob in requested_globs {
+        if requested_glob.starts_with('!') {
+            continue;
+        }
+
+        let requested_base = glob_base(requested_glob);
+        let matches_selected_outputs = selected_tasks.iter().any(|selected_task| {
+            let Some(selected_definition) = engine.task_definition(selected_task) else {
+                return false;
+            };
+            selected_definition
+                .outputs
+                .inclusions
+                .iter()
+                .any(|output_glob| glob_base(output_glob).is_prefix_of(&requested_base))
+        });
+
+        if !matches_selected_outputs {
+            return Err(structured_input_error(format!(
+                "dependencyOutputs.globs contains \"{requested_glob}\", but it is not covered by \
+                 any selected dependency task outputs.\n\nSelect files from declared outputs or \
+                 update the dependency task outputs."
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct GlobBase<'a>(&'a str);
+
+impl<'a> GlobBase<'a> {
+    fn is_prefix_of(&self, other: &GlobBase<'_>) -> bool {
+        self.0.is_empty()
+            || other.0 == self.0
+            || other
+                .0
+                .strip_prefix(self.0)
+                .is_some_and(|rest| rest.starts_with('/'))
+    }
+}
+
+fn glob_base(glob: &str) -> GlobBase<'_> {
+    let glob = glob.strip_prefix('!').unwrap_or(glob);
+    let wildcard = glob.find(['*', '?', '[', '{']).unwrap_or(glob.len());
+    if wildcard == glob.len() {
+        return GlobBase(glob.trim_end_matches('/'));
+    }
+    let base = glob[..wildcard]
+        .rsplit_once('/')
+        .map_or("", |(base, _)| base)
+        .trim_end_matches('/');
+    GlobBase(base)
 }
 
 fn structured_input_error(message: String) -> BuilderError {

--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -289,16 +289,23 @@ impl<'a> Visitor<'a> {
         &self,
         engine: &Engine,
         task_id: &TaskId<'static>,
-    ) -> Result<Option<Arc<turborepo_hash::FileHashes>>, Error> {
+    ) -> Result<
+        (
+            Option<Arc<turborepo_hash::FileHashes>>,
+            HashSet<TaskId<'static>>,
+        ),
+        Error,
+    > {
         let Some(task_definition) = engine.task_definition(task_id) else {
             return Err(Error::MissingDefinition);
         };
         let Some(dependency_outputs) = task_definition.inputs.dependency_outputs.as_ref() else {
-            return Ok(None);
+            return Ok((None, HashSet::new()));
         };
 
         let selected_tasks =
             engine.dependency_output_producers(task_id, dependency_outputs.from.as_deref());
+        let selected_task_set = selected_tasks.iter().cloned().collect::<HashSet<_>>();
 
         let mut combined = BTreeMap::new();
         let mut selected_any = false;
@@ -364,11 +371,14 @@ impl<'a> Visitor<'a> {
         }
 
         if selected_any {
-            Ok(Some(Arc::new(turborepo_hash::FileHashes(
-                combined.into_iter().collect(),
-            ))))
+            Ok((
+                Some(Arc::new(turborepo_hash::FileHashes(
+                    combined.into_iter().collect(),
+                ))),
+                selected_task_set,
+            ))
         } else {
-            Ok(None)
+            Ok((None, selected_task_set))
         }
     }
 
@@ -661,7 +671,7 @@ impl<'a> Visitor<'a> {
                                 .with_parent(telemetry);
                         let task_hash_telemetry = package_task_event.child();
                         let task_hash = if task_definition.inputs.has_deferred_inputs() {
-                            let dependency_output_hashes =
+                            let (dependency_output_hashes, dependency_output_producers) =
                                 match self.dependency_output_hashes(&engine, &info) {
                                     Ok(hashes) => hashes,
                                     Err(err) => {
@@ -680,6 +690,7 @@ impl<'a> Visitor<'a> {
                                 self.repo_root,
                                 self.repo_index,
                                 dependency_output_hashes,
+                                &dependency_output_producers,
                             ) {
                                 Ok(hash) => hash,
                                 Err(err) => {

--- a/crates/turborepo-task-hash/src/lib.rs
+++ b/crates/turborepo-task-hash/src/lib.rs
@@ -336,6 +336,7 @@ impl<'a, R: RunOptsHashInfo> TaskHasher<'a, R> {
             dependency_set,
             telemetry,
             hash_of_files,
+            None,
         )
     }
 
@@ -360,6 +361,7 @@ impl<'a, R: RunOptsHashInfo> TaskHasher<'a, R> {
         repo_root: &AbsoluteSystemPath,
         repo_index: Option<&RepoGitIndex>,
         dependency_output_hashes: Option<Arc<FileHashes>>,
+        dependency_output_producers: &HashSet<TaskId<'static>>,
     ) -> Result<String, Error> {
         let package_path = workspace.package_path();
         let jit_hashes = task_definition
@@ -400,6 +402,7 @@ impl<'a, R: RunOptsHashInfo> TaskHasher<'a, R> {
             dependency_set,
             telemetry,
             &hash_of_files,
+            Some(dependency_output_producers),
         )
     }
 
@@ -428,6 +431,7 @@ impl<'a, R: RunOptsHashInfo> TaskHasher<'a, R> {
         dependency_set: &[&TaskNode],
         telemetry: PackageTaskEventBuilder,
         hash_of_files: &str,
+        excluded_dependency_hashes: Option<&HashSet<TaskId<'static>>>,
     ) -> Result<String, Error> {
         let do_framework_inference = self.run_opts.framework_inference();
         let is_monorepo = !self.run_opts.single_package();
@@ -450,7 +454,8 @@ impl<'a, R: RunOptsHashInfo> TaskHasher<'a, R> {
             self.calculate_env_vars(task_id, task_definition, task_env_mode, framework)?;
 
         let outputs = task_definition.hashable_outputs(task_id);
-        let task_dependency_hashes = self.calculate_dependency_hashes(dependency_set)?;
+        let task_dependency_hashes =
+            self.calculate_dependency_hashes(dependency_set, excluded_dependency_hashes)?;
         let ext_hash_fallback;
         let external_deps_hash: Option<&str> = if !is_monorepo {
             None
@@ -574,6 +579,7 @@ impl<'a, R: RunOptsHashInfo> TaskHasher<'a, R> {
     fn calculate_dependency_hashes(
         &self,
         dependency_set: &[&TaskNode],
+        excluded_dependency_hashes: Option<&HashSet<TaskId<'static>>>,
     ) -> Result<Vec<Arc<str>>, Error> {
         let mut dependency_hash_list = self.task_hash_tracker.with_state(|state| {
             let mut dependency_hash_list: Vec<Arc<str>> = Vec::with_capacity(dependency_set.len());
@@ -581,6 +587,11 @@ impl<'a, R: RunOptsHashInfo> TaskHasher<'a, R> {
                 let TaskNode::Task(dependency_task_id) = dependency_task else {
                     continue;
                 };
+                if excluded_dependency_hashes
+                    .is_some_and(|excluded| excluded.contains(dependency_task_id))
+                {
+                    continue;
+                }
 
                 let dependency_hash = state
                     .package_task_hashes

--- a/crates/turborepo/tests/bad_turbo_json_test.rs
+++ b/crates/turborepo/tests/bad_turbo_json_test.rs
@@ -399,3 +399,35 @@ fn test_structured_jit_rejects_negative_only_globs_without_defaults() {
         "expected negative-only jit glob validation error, got: {stderr}"
     );
 }
+
+#[test]
+fn test_dependency_outputs_requires_dependency_tasks_to_select() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
+
+    write_turbo_json(
+        tempdir.path(),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "tasks": {
+    "build": {
+      "inputs": [
+        {
+          "mode": "dependencyOutputs"
+        }
+      ],
+      "outputs": ["dist/**"]
+    }
+  }
+}
+"#,
+    );
+
+    let output = run_turbo(tempdir.path(), &["run", "build"]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("dependencyOutputs") && stderr.contains("dependency"),
+        "expected dependencyOutputs dependency-selection validation error, got: {stderr}"
+    );
+}

--- a/crates/turborepo/tests/bad_turbo_json_test.rs
+++ b/crates/turborepo/tests/bad_turbo_json_test.rs
@@ -399,35 +399,3 @@ fn test_structured_jit_rejects_negative_only_globs_without_defaults() {
         "expected negative-only jit glob validation error, got: {stderr}"
     );
 }
-
-#[test]
-fn test_dependency_outputs_requires_dependency_tasks_to_select() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
-
-    write_turbo_json(
-        tempdir.path(),
-        r#"{
-  "$schema": "https://turborepo.dev/schema.json",
-  "tasks": {
-    "build": {
-      "inputs": [
-        {
-          "mode": "dependencyOutputs"
-        }
-      ],
-      "outputs": ["dist/**"]
-    }
-  }
-}
-"#,
-    );
-
-    let output = run_turbo(tempdir.path(), &["run", "build"]);
-    assert!(!output.status.success());
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("dependencyOutputs") && stderr.contains("dependency"),
-        "expected dependencyOutputs dependency-selection validation error, got: {stderr}"
-    );
-}

--- a/crates/turborepo/tests/run_caching.rs
+++ b/crates/turborepo/tests/run_caching.rs
@@ -1070,6 +1070,42 @@ fn test_dependency_outputs_from_selects_topological_dependencies() {
 }
 
 #[test]
+fn test_dependency_outputs_from_allows_empty_selector_matches() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+
+    fs::write(
+        tempdir.path().join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        {
+          "mode": "dependencyOutputs",
+          "from": ["^build"]
+        }
+      ],
+      "outputs": ["dist/**"]
+    }
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    let output = run_turbo(tempdir.path(), &["run", "build", "--dry=json"]);
+    assert!(
+        output.status.success(),
+        "expected terminal dependencyOutputs.from selector matches to be \
+         ignored\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn test_dependency_outputs_from_selects_package_qualified_dependency_node() {
     let tempdir = tempfile::tempdir().unwrap();
     setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
@@ -1194,6 +1230,83 @@ fn test_dependency_outputs_from_hashes_package_qualified_dependency_outputs() {
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("0 cached, 2 total"), "got:\n{stdout}");
+}
+
+#[test]
+fn test_dependency_outputs_replaces_selected_dependency_task_hashes() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+
+    fs::write(tempdir.path().join("packages/util/seed.txt"), "v1\n").unwrap();
+    fs::write(
+        tempdir.path().join("packages/util/package.json"),
+        r#"{
+  "name": "util",
+  "scripts": {
+    "build": "node -e \"const fs = require('fs'); fs.mkdirSync('dist', { recursive: true }); fs.writeFileSync('dist/generated.txt', 'stable\\n')\""
+  }
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        tempdir.path().join("apps/my-app/package.json"),
+        r#"{
+  "name": "my-app",
+  "scripts": {
+    "build": "node -e \"const fs = require('fs'); fs.mkdirSync('.output', { recursive: true }); fs.writeFileSync('.output/result.txt', 'build\\n')\""
+  },
+  "dependencies": {
+    "util": "*"
+  }
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        tempdir.path().join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "tasks": {
+    "build": {
+      "inputs": ["$TURBO_DEFAULT$", "!dist/**"],
+      "outputs": ["dist/**"]
+    },
+    "my-app#build": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        {
+          "mode": "startup",
+          "withDefaults": true,
+          "globs": ["!.output/**"]
+        },
+        {
+          "mode": "dependencyOutputs",
+          "from": ["^build"]
+        }
+      ],
+      "outputs": [".output/**"]
+    }
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "build", "--filter=my-app", "--output-logs=none"],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("0 cached, 2 total"), "got:\n{stdout}");
+
+    fs::write(tempdir.path().join("packages/util/seed.txt"), "v2\n").unwrap();
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "build", "--filter=my-app", "--output-logs=none"],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("1 cached, 2 total"), "got:\n{stdout}");
 }
 
 #[test]
@@ -1532,47 +1645,6 @@ fn test_dependency_outputs_globs_cannot_select_undeclared_outputs() {
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("0 cached, 2 total"), "got:\n{stdout}");
-}
-
-#[test]
-fn test_dependency_outputs_from_must_match_existing_dependency_task() {
-    let tempdir = tempfile::tempdir().unwrap();
-    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
-
-    fs::write(
-        tempdir.path().join("turbo.json"),
-        r#"{
-  "$schema": "https://turborepo.dev/schema.json",
-  "tasks": {
-    "codegen": {
-      "outputs": ["src/generated/**"]
-    },
-    "build": {
-      "inputs": [
-        {
-          "mode": "dependencyOutputs",
-          "from": ["codegen"]
-        }
-      ],
-      "outputs": ["dist/**"]
-    }
-  }
-}
-"#,
-    )
-    .unwrap();
-
-    let output = run_turbo(tempdir.path(), &["run", "build", "--filter=my-app"]);
-    assert!(!output.status.success());
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("does not match any eligible dependency task node"),
-        "expected dependencyOutputs.from validation error, got:\n{stderr}"
-    );
-    assert!(
-        stderr.contains("Add it to dependsOn or remove it from dependencyOutputs.from"),
-        "expected remediation guidance, got:\n{stderr}"
-    );
 }
 
 #[test]

--- a/crates/turborepo/tests/run_caching.rs
+++ b/crates/turborepo/tests/run_caching.rs
@@ -1106,6 +1106,41 @@ fn test_dependency_outputs_from_allows_empty_selector_matches() {
 }
 
 #[test]
+fn test_dependency_outputs_from_must_match_existing_dependency_task_when_dependencies_exist() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
+
+    fs::write(
+        tempdir.path().join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        {
+          "mode": "dependencyOutputs",
+          "from": ["^codegen"]
+        }
+      ],
+      "outputs": ["dist/**"]
+    }
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    let output = run_turbo(tempdir.path(), &["run", "build", "--filter=my-app"]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("does not match any eligible dependency task node"),
+        "expected dependencyOutputs.from validation error, got:\n{stderr}"
+    );
+}
+
+#[test]
 fn test_dependency_outputs_from_selects_package_qualified_dependency_node() {
     let tempdir = tempfile::tempdir().unwrap();
     setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", true).unwrap();
@@ -1619,32 +1654,13 @@ fn test_dependency_outputs_globs_cannot_select_undeclared_outputs() {
     )
     .unwrap();
 
-    let output = run_turbo(
-        tempdir.path(),
-        &["run", "build", "--filter=my-app", "--output-logs=none"],
+    let output = run_turbo(tempdir.path(), &["run", "build", "--filter=my-app"]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("dependencyOutputs.globs") && stderr.contains("private.txt"),
+        "expected dependencyOutputs.globs validation error, got:\n{stderr}"
     );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("0 cached, 2 total"), "got:\n{stdout}");
-
-    fs::write(
-        tempdir.path().join("apps/my-app/private.txt"),
-        "private-v2\n",
-    )
-    .unwrap();
-    let output = run_turbo(
-        tempdir.path(),
-        &["run", "build", "--filter=my-app", "--output-logs=none"],
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("1 cached, 2 total"), "got:\n{stdout}");
-
-    fs::write(tempdir.path().join("apps/my-app/seed.txt"), "v2\n").unwrap();
-    let output = run_turbo(
-        tempdir.path(),
-        &["run", "build", "--filter=my-app", "--output-logs=none"],
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("0 cached, 2 total"), "got:\n{stdout}");
 }
 
 #[test]


### PR DESCRIPTION
## Why

`dependencyOutputs` is meant to let downstream tasks depend on materialized dependency outputs instead of invalidating on every upstream task hash change. The current behavior still includes selected dependency task hashes, so downstream tasks can miss cache even when the selected outputs are unchanged. It also rejects valid terminal graph nodes where a configured `from` selector expands to no dependencies.

## What

Use selected dependency output file hashes in the downstream task hash and omit those selected dependency task hashes from normal dependency hash propagation.

Allow terminal `dependencyOutputs.from` selector matches only when they come from configured dependency selectors, while keeping validation errors for true mismatches or no dependency graph to select from.

Reject `dependencyOutputs.globs` that are not covered by selected dependency task outputs so configs cannot silently disconnect cache invalidation from dependency outputs.

## How

Added regression coverage for terminal `from` selector matches, mismatched selectors, missing dependency selections, stable dependency outputs preserving downstream cache hits, changed dependency outputs invalidating downstream tasks, and globs outside declared dependency outputs.

Verified with:

- `cargo fmt`
- `cargo test -p turborepo-engine dependency_outputs -- --nocapture`
- `cargo test -p turborepo-task-hash --lib`
- `cargo test -p turbo --test run_caching dependency_outputs -- --nocapture`
- `cargo test -p turbo --test bad_turbo_json_test dependency_outputs -- --nocapture`
- pre-push hook: `pnpm exec lint-staged`, `turbo run format check:toml`, `cargo fmt --check`, `cargo lint`, `cargo check --workspace`