### PR TITLE
Update package.json

### DIFF
--- a/packages/turbo-utils/package.json
+++ b/packages/turbo-utils/package.json
@@ -28,7 +28,7 @@
     "lint:prettier": "prettier -c . --cache --ignore-path=../../.prettierignore"
   },
   "dependencies": {
-    "undici": "^6.24.0"
+    "undici": "^6.27.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.2",


### PR DESCRIPTION
Impact: Undici's HTTP/1.1 client is vulnerable to response queue poisoning on reused keep-alive sockets. An attacker-controlled upstream server can inject an unsolicited HTTP/1.1 response onto an idle socket after a request completes. When the client dispatches the next request on that socket, it associates the injected response with the new request, causing responses to be delivered to the wrong requests. This requires an attacker-controlled or compromised upstream HTTP/1.1 server and keep-alive connection reuse. Patches: Upgrade to undici v6.26.0, v7.28.0 or v8.5.0. Workarounds: Disable keep-alive connection reuse by setting keepAliveTimeout: 0 on the Client or Pool.

### Description

The flaw resides within Undici's HTTP/1.1 client pipeline logic when handling keep-alive connection reuse. If an application concurrently pipelines requests or interacts with an untrusted upstream proxy, the endpoint can response-smuggle data packets down the wire back-to-back.

Because the client fails to securely isolate separate response streams on an idle socket wrapper, it mismaps the second smuggled header context onto the subsequent outbound application request. In the context of turborepo utilities, this could potentially be leveraged to trick the CLI or background utilities into reading corrupted, malicious, or spoofed server responses during remote caching or artifact distribution tasks.