### PR TITLE
ci: Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/docs-alias-failure-notification.yml
+++ b/.github/workflows/docs-alias-failure-notification.yml
@@ -44,7 +44,7 @@ jobs:
           fi
 
       - name: Send failure notification to Slack
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           webhook: ${{ secrets.DOCS_ALIAS_FAILURE_SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
Pin unpinned GitHub Actions to immutable commit SHAs. Version tags retained as inline comments.