### PR TITLE
fix: Handle task executor join errors as internal errors

### DIFF
--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -870,8 +870,10 @@ impl<'a> Visitor<'a> {
         // the ExecutionTracker is dropped.
         let mut internal_errors = Vec::new();
         while let Some(result) = tasks.next().await {
-            if let Err(e) = result.unwrap_or_else(|e| panic!("task executor panicked: {e}")) {
-                internal_errors.push(e);
+            match result {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => internal_errors.push(e.to_string()),
+                Err(e) => internal_errors.push(format!("task executor panicked: {e}")),
             }
         }
         drop(factory);
@@ -890,9 +892,7 @@ impl<'a> Visitor<'a> {
         engine_result?;
 
         if !internal_errors.is_empty() {
-            return Err(Error::InternalErrors(
-                internal_errors.into_iter().map(|e| e.to_string()).join(","),
-            ));
+            return Err(Error::InternalErrors(internal_errors.into_iter().join(",")));
         }
 
         // Write out the traced-config.json file if we have one

--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -4,6 +4,8 @@ mod exec;
 use std::{
     borrow::Cow,
     collections::{BTreeMap, HashMap, HashSet},
+    error::Error as StdError,
+    fmt,
     sync::{Arc, Mutex},
 };
 
@@ -12,7 +14,7 @@ use exec::ExecContextFactory;
 use futures::{stream::FuturesUnordered, StreamExt};
 use itertools::Itertools;
 use miette::{Diagnostic, NamedSource, SourceSpan};
-use tokio::sync::mpsc;
+use tokio::{sync::mpsc, task::JoinError};
 use tracing::{debug, Instrument, Span};
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPath, AnchoredSystemPathBuf};
 use turborepo_engine::{TaskError, TaskWarning};
@@ -23,7 +25,9 @@ use turborepo_process::ProcessManager;
 use turborepo_repository::package_graph::{PackageGraph, PackageName, ROOT_PKG_NAME};
 use turborepo_run_summary::{self as summary, GlobalHashSummary, RunTracker, TaskTracker};
 use turborepo_scm::{RepoGitIndex, SCM};
-use turborepo_task_executor::{command_invokes_turbo, TaskOutput};
+use turborepo_task_executor::{
+    command_invokes_turbo, InternalError as TaskInternalError, TaskOutput,
+};
 use turborepo_task_hash::{
     Error as TaskHashError, GlobalHashableInputs, PackageInputsHashes, TaskHashTrackerState,
 };
@@ -119,11 +123,77 @@ pub enum Error {
     #[error(transparent)]
     RunSummary(#[from] summary::Error),
     #[error("Internal errors encountered: {0}")]
-    InternalErrors(String),
+    InternalErrors(InternalErrors),
     #[error("Unable to find package manager binary: {0}")]
     Which(#[from] which::Error),
     #[error(transparent)]
     CommandProvider(#[from] turborepo_task_executor::CommandProviderError),
+}
+
+#[derive(Debug)]
+pub struct InternalErrors(Vec<InternalVisitorError>);
+
+impl InternalErrors {
+    fn new(errors: Vec<InternalVisitorError>) -> Self {
+        Self(errors)
+    }
+}
+
+impl From<String> for InternalErrors {
+    fn from(message: String) -> Self {
+        Self(vec![InternalVisitorError::Message(message)])
+    }
+}
+
+impl From<&str> for InternalErrors {
+    fn from(message: &str) -> Self {
+        Self::from(message.to_string())
+    }
+}
+
+impl fmt::Display for InternalErrors {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.iter().format(","))
+    }
+}
+
+#[derive(Debug)]
+enum InternalVisitorError {
+    EngineJoin(JoinError),
+    Task(TaskInternalError),
+    TaskJoin(JoinError),
+    Message(String),
+}
+
+impl fmt::Display for InternalVisitorError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EngineJoin(err) => write_join_error(f, "engine execution", err),
+            Self::Task(err) => write!(f, "{err}"),
+            Self::TaskJoin(err) => write_join_error(f, "task executor", err),
+            Self::Message(message) => write!(f, "{message}"),
+        }
+    }
+}
+
+impl StdError for InternalVisitorError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Self::EngineJoin(err) | Self::TaskJoin(err) => Some(err),
+            Self::Task(err) => Some(err),
+            Self::Message(_) => None,
+        }
+    }
+}
+
+fn write_join_error(f: &mut fmt::Formatter<'_>, context: &str, err: &JoinError) -> fmt::Result {
+    if err.is_panic() {
+        write!(f, "{context} panicked: {err}")
+    } else if err.is_cancelled() {
+        write!(f, "{context} was cancelled: {err}")
+    } else {
+        write!(f, "{context} join failed: {err}")
+    }
 }
 
 impl<'a> Visitor<'a> {
@@ -862,9 +932,11 @@ impl<'a> Visitor<'a> {
         // Always wait for the engine, even after a dispatch error. If we broke
         // early the engine will see the closed channel and return
         // Err(ExecuteError::Visitor), which is expected — not a real error.
-        let engine_result = engine_handle
-            .await
-            .map_err(|err| Error::InternalErrors(format!("engine execution panicked: {err}")))?;
+        let engine_result = engine_handle.await.map_err(|err| {
+            Error::InternalErrors(InternalErrors::new(vec![InternalVisitorError::EngineJoin(
+                err,
+            )]))
+        })?;
 
         // Always drain spawned tasks so every TaskTracker is consumed before
         // the ExecutionTracker is dropped.
@@ -872,8 +944,8 @@ impl<'a> Visitor<'a> {
         while let Some(result) = tasks.next().await {
             match result {
                 Ok(Ok(())) => {}
-                Ok(Err(e)) => internal_errors.push(e.to_string()),
-                Err(e) => internal_errors.push(format!("task executor panicked: {e}")),
+                Ok(Err(e)) => internal_errors.push(InternalVisitorError::Task(e)),
+                Err(e) => internal_errors.push(InternalVisitorError::TaskJoin(e)),
             }
         }
         drop(factory);
@@ -892,7 +964,7 @@ impl<'a> Visitor<'a> {
         engine_result?;
 
         if !internal_errors.is_empty() {
-            return Err(Error::InternalErrors(internal_errors.into_iter().join(",")));
+            return Err(Error::InternalErrors(InternalErrors::new(internal_errors)));
         }
 
         // Write out the traced-config.json file if we have one


### PR DESCRIPTION
## Summary

This PR makes `task_graph::visitor` handle spawned task `JoinError`s through the existing `Error::InternalErrors` path instead of panicking.

Previously, if a spawned task itself panicked and returned a `JoinError`, the drain loop would panic again while unwrapping the task result. This change collects that error into `internal_errors` and returns it through the same internal error flow already used for task execution failures.

## Changes

- Match on the result of `tasks.next().await` explicitly.
- Ignore successfully completed tasks.
- Continue collecting task-returned errors into `internal_errors`.
- Collect spawned task `JoinError`s into `internal_errors` instead of panicking.
- Simplify the final `Error::InternalErrors` construction now that errors are collected as strings.

## Rationale

This section of the visitor already drains spawned task results and collects internal task errors before returning them as `Error::InternalErrors`.

The surrounding flow is:

1. Drain all spawned task results.
2. Drop the factory so the `ExecutionTracker` can be finalized.
3. Check the engine result.
4. Return collected internal errors as `Error::InternalErrors`.

That means the existing design is already to collect internal task execution failures, finish the required cleanup path, and then return them as structured errors.

However, the previous code treated one failure path differently:

```rust
result.unwrap_or_else(|e| panic!("task executor panicked: {e}"))
```

Task-returned errors were collected into `internal_errors`, but spawned task `JoinError`s were converted into a panic. That made this one internal failure path bypass the existing error-returning behavior.

This PR keeps the existing structure and routes `JoinError`s into the same `internal_errors -> Error::InternalErrors` path. Since this failure occurs in the same drain loop and represents another task executor failure, handling it the same way is consistent with the surrounding code.

## Why this stays minimal

This change does not introduce a new error type, helper function, or abstraction because the code already has the right error aggregation path.

The issue is only that `JoinError` was not using that path. A local `match` is enough to preserve the existing behavior for successful tasks and task-returned errors while also avoiding a panic for spawned task failures.

