### PR TITLE
feat: Support devEngines packageManager in workspaces

### DIFF
--- a/packages/turbo-workspaces/__tests__/utils.test.ts
+++ b/packages/turbo-workspaces/__tests__/utils.test.ts
@@ -1,6 +1,20 @@
 import { describe, it, expect } from "@jest/globals";
+import os from "node:os";
+import path from "node:path";
+import fs from "fs-extra";
 import type { Project } from "../src/types";
-import { isCompatibleWithBunWorkspaces } from "../src/utils";
+import {
+  getWorkspacePackageManager,
+  isCompatibleWithBunWorkspaces
+} from "../src/utils";
+
+function makeWorkspace(packageJson: unknown): string {
+  const workspaceRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), "turbo-workspaces-")
+  );
+  fs.writeJsonSync(path.join(workspaceRoot, "package.json"), packageJson);
+  return workspaceRoot;
+}
 
 describe("utils", () => {
   describe("isCompatibleWithBunWorkspace", () => {
@@ -20,5 +34,151 @@ describe("utils", () => {
       });
       expect(result).toEqual(expected);
     });
+  });
+
+  describe("getWorkspacePackageManager", () => {
+    it.each([
+      ["npm", "10.5.0"],
+      ["pnpm", "9.12.3"],
+      ["yarn", "4.5.0+sha224.abc"],
+      ["bun", "1.1.0"]
+    ] as const)("reads %s from devEngines.packageManager", (name, version) => {
+      const workspaceRoot = makeWorkspace({
+        devEngines: {
+          packageManager: {
+            name,
+            version,
+            onFail: "warn",
+            ignored: true
+          }
+        }
+      });
+
+      expect(getWorkspacePackageManager({ workspaceRoot })).toEqual(name);
+    });
+
+    it("prefers top-level packageManager over devEngines.packageManager", () => {
+      const workspaceRoot = makeWorkspace({
+        packageManager: "pnpm@9.12.3",
+        devEngines: {
+          packageManager: {
+            name: "npm",
+            version: "10.5.0"
+          }
+        }
+      });
+
+      expect(getWorkspacePackageManager({ workspaceRoot })).toEqual("pnpm");
+    });
+
+    it("ignores malformed devEngines.packageManager when top-level packageManager is present", () => {
+      const workspaceRoot = makeWorkspace({
+        packageManager: "npm@10.5.0",
+        devEngines: {
+          packageManager: []
+        }
+      });
+
+      expect(getWorkspacePackageManager({ workspaceRoot })).toEqual("npm");
+    });
+
+    it("returns undefined when no package manager declaration exists", () => {
+      const workspaceRoot = makeWorkspace({});
+
+      expect(getWorkspacePackageManager({ workspaceRoot })).toBeUndefined();
+    });
+
+    it.each([
+      [{ devEngines: [] }, "`devEngines` must be an object"],
+      [{ devEngines: null }, "`devEngines` must be an object"],
+      [
+        { devEngines: { packageManager: [] } },
+        "`devEngines.packageManager` must be an object"
+      ],
+      [
+        { devEngines: { packageManager: null } },
+        "`devEngines.packageManager` must be an object"
+      ],
+      [{ devEngines: { packageManager: {} } }, "expected"],
+      [
+        { devEngines: { packageManager: { version: "9.12.3" } } },
+        "name` is required"
+      ],
+      [
+        { devEngines: { packageManager: { name: 1, version: "9.12.3" } } },
+        "name` must be a string"
+      ],
+      [
+        { devEngines: { packageManager: { name: "", version: "9.12.3" } } },
+        "name` must not be empty"
+      ],
+      [
+        {
+          devEngines: { packageManager: { name: " pnpm", version: "9.12.3" } }
+        },
+        "name` must not contain"
+      ],
+      [
+        { devEngines: { packageManager: { name: "pip", version: 1 } } },
+        "name` must be one of"
+      ],
+      [
+        { devEngines: { packageManager: { name: "pnpm" } } },
+        "version` is required"
+      ],
+      [
+        { devEngines: { packageManager: { name: "pnpm", version: 1 } } },
+        "version` must be a string"
+      ],
+      [
+        { devEngines: { packageManager: { name: "pnpm", version: "" } } },
+        "version` must not be empty"
+      ],
+      [
+        {
+          devEngines: { packageManager: { name: "pnpm", version: " 9.12.3" } }
+        },
+        "version` must not contain"
+      ],
+      [
+        { devEngines: { packageManager: { name: "pnpm", version: "^9.0.0" } } },
+        "exact semantic version"
+      ],
+      [
+        {
+          devEngines: {
+            packageManager: {
+              name: "pnpm",
+              version: "https://registry.npmjs.org/pnpm/-/pnpm-9.12.3.tgz"
+            }
+          }
+        },
+        "exact semantic version"
+      ],
+      [
+        { devEngines: { packageManager: { name: "pnpm", version: "9" } } },
+        "exact semantic version"
+      ],
+      [
+        {
+          devEngines: {
+            packageManager: {
+              name: "pnpm",
+              version: "9.12.3+sha512.Purxi/Zex=="
+            }
+          }
+        },
+        "exact semantic version"
+      ]
+    ])(
+      "rejects invalid devEngines.packageManager %#",
+      (packageJson, message) => {
+        const workspaceRoot = makeWorkspace(packageJson);
+
+        expect(() => getWorkspacePackageManager({ workspaceRoot })).toThrow(
+          message
+        );
+      }
+    );
   });
 });

--- a/packages/turbo-workspaces/src/get-workspace-details.ts
+++ b/packages/turbo-workspaces/src/get-workspace-details.ts
@@ -28,7 +28,7 @@ export async function getWorkspaceDetails({
   }
 
   throw new ConvertError(
-    "Could not determine package manager. Add `packageManager` to `package.json` or ensure a lockfile is present.",
+    "Could not determine package manager. Add `devEngines.packageManager` or legacy `packageManager` to `package.json`, or ensure a lockfile is present.",
     {
       type: "package_manager-unable_to_detect"
     }

--- a/packages/turbo-workspaces/src/utils.ts
+++ b/packages/turbo-workspaces/src/utils.ts
@@ -95,10 +95,7 @@ function getWorkspacePackageManager({
     return undefined;
   }
 
-  const hasDevEngines = Object.prototype.hasOwnProperty.call(
-    packageJson,
-    "devEngines"
-  );
+  const hasDevEngines = Object.hasOwn(packageJson, "devEngines");
   if (
     hasDevEngines &&
     (!devEngines || typeof devEngines !== "object" || Array.isArray(devEngines))

--- a/packages/turbo-workspaces/src/utils.ts
+++ b/packages/turbo-workspaces/src/utils.ts
@@ -9,6 +9,7 @@ import {
 } from "fs-extra";
 import { sync as globSync } from "fast-glob";
 import yaml from "js-yaml";
+import semver from "semver";
 import type {
   PackageManager,
   Project,
@@ -23,6 +24,9 @@ interface PackageJson {
   version: string;
   description?: string;
   packageManager?: string;
+  devEngines?: {
+    packageManager?: unknown;
+  };
   workspaces?: Array<string> | { packages?: Array<string> };
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
@@ -32,6 +36,14 @@ interface PackageJson {
 
 // adapted from https://github.com/nodejs/corepack/blob/cae770694e62f15fed33dd8023649d77d96023c1/sources/specUtils.ts#L14
 const PACKAGE_MANAGER_REGEX = /^(?!_)(?<manager>.+)@(?<version>.+)$/;
+const SUPPORTED_PACKAGE_MANAGERS = new Set<PackageManager>([
+  "npm",
+  "pnpm",
+  "yarn",
+  "bun"
+]);
+const DEV_ENGINES_VERSION_REGEX =
+  /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 
 function getPackageJson({
   workspaceRoot
@@ -67,20 +79,138 @@ function getWorkspacePackageManager({
   workspaceRoot
 }: {
   workspaceRoot: string;
-}): string | undefined {
-  const { packageManager } = getPackageJson({ workspaceRoot });
+}): PackageManager | undefined {
+  const packageJson = getPackageJson({ workspaceRoot });
+  const { packageManager, devEngines } = packageJson;
   if (packageManager) {
     try {
       const match = PACKAGE_MANAGER_REGEX.exec(packageManager);
       if (match) {
-        const [_, manager] = match;
-        return manager;
+        const manager = match.groups?.manager;
+        return isPackageManager(manager) ? manager : undefined;
       }
     } catch (err) {
       // this won't always exist.
     }
+    return undefined;
   }
-  return undefined;
+
+  const hasDevEngines = Object.prototype.hasOwnProperty.call(
+    packageJson,
+    "devEngines"
+  );
+  if (
+    hasDevEngines &&
+    (!devEngines || typeof devEngines !== "object" || Array.isArray(devEngines))
+  ) {
+    throw invalidDevEnginesPackageManager(
+      "`devEngines` must be an object containing `packageManager`"
+    );
+  }
+
+  if (!devEngines || !("packageManager" in devEngines)) {
+    return undefined;
+  }
+
+  const devEnginesPackageManager = devEngines.packageManager;
+  if (
+    !devEnginesPackageManager ||
+    typeof devEnginesPackageManager !== "object" ||
+    Array.isArray(devEnginesPackageManager)
+  ) {
+    throw invalidDevEnginesPackageManager(
+      "`devEngines.packageManager` must be an object"
+    );
+  }
+
+  if (Object.keys(devEnginesPackageManager).length === 0) {
+    throw invalidDevEnginesPackageManager(
+      'expected `{ "name": "pnpm", "version": "9.12.3" }`'
+    );
+  }
+
+  if (!("name" in devEnginesPackageManager)) {
+    throw invalidDevEnginesPackageManager(
+      "`devEngines.packageManager.name` is required"
+    );
+  }
+
+  const { name } = devEnginesPackageManager;
+  if (typeof name !== "string") {
+    throw invalidDevEnginesPackageManager(
+      "`devEngines.packageManager.name` must be a string"
+    );
+  }
+
+  if (name.length === 0) {
+    throw invalidDevEnginesPackageManager(
+      "`devEngines.packageManager.name` must not be empty"
+    );
+  }
+
+  if (name.trim() !== name) {
+    throw invalidDevEnginesPackageManager(
+      "`devEngines.packageManager.name` must not contain leading or trailing whitespace"
+    );
+  }
+
+  if (!isPackageManager(name)) {
+    throw invalidDevEnginesPackageManager(
+      "`devEngines.packageManager.name` must be one of `npm`, `pnpm`, `yarn`, or `bun`"
+    );
+  }
+
+  if (!("version" in devEnginesPackageManager)) {
+    throw invalidDevEnginesPackageManager(
+      "`devEngines.packageManager.version` is required"
+    );
+  }
+
+  const { version } = devEnginesPackageManager;
+  if (typeof version !== "string") {
+    throw invalidDevEnginesPackageManager(
+      "`devEngines.packageManager.version` must be a string"
+    );
+  }
+
+  if (version.length === 0) {
+    throw invalidDevEnginesPackageManager(
+      "`devEngines.packageManager.version` must not be empty"
+    );
+  }
+
+  if (version.trim() !== version) {
+    throw invalidDevEnginesPackageManager(
+      "`devEngines.packageManager.version` must not contain leading or trailing whitespace"
+    );
+  }
+
+  if (
+    !DEV_ENGINES_VERSION_REGEX.test(version) ||
+    semver.valid(version) === null
+  ) {
+    throw invalidDevEnginesPackageManager(
+      "`devEngines.packageManager.version` must be an exact semantic version"
+    );
+  }
+
+  return name;
+}
+
+function isPackageManager(value: unknown): value is PackageManager {
+  return (
+    typeof value === "string" &&
+    SUPPORTED_PACKAGE_MANAGERS.has(value as PackageManager)
+  );
+}
+
+function invalidDevEnginesPackageManager(message: string): ConvertError {
+  return new ConvertError(
+    `Invalid \`devEngines.packageManager\` field in package.json: ${message}`,
+    {
+      type: "package_manager-unable_to_detect"
+    }
+  );
 }
 
 function getWorkspaceInfo({


### PR DESCRIPTION
## Why

Keep @turbo/workspaces package-manager detection aligned with the Rust implementation added in #12388, so tooling accepts the same root package manager declarations.

## What

Adds support for root `devEngines.packageManager` as a declaration source after legacy top-level `packageManager`, with validation for supported manager names and exact semver versions.

## How

- Top-level `packageManager` remains authoritative.
- Invalid `devEngines.packageManager` hard-errors instead of falling back to lockfiles.
- Existing lockfile detection still applies when no declaration exists.
- Covered with focused `@turbo/workspaces` tests.

Verified with:

- `pnpm --dir packages/turbo-workspaces test`
- `pnpm --dir packages/turbo-workspaces check-types`