### PR TITLE
fix(prune): keep nested Bun version shadowed by an intermediate ancestor

### DIFF
--- a/crates/turborepo-lockfiles/src/bun/subgraph.rs
+++ b/crates/turborepo-lockfiles/src/bun/subgraph.rs
@@ -747,19 +747,58 @@ impl BunLockfile {
                 })
                 .collect();
 
-            pruned_data.packages.retain(|key, entry| {
-                if PackageKey::parse(key).parent().is_none() {
-                    return true;
-                }
-                let ident = PackageIdent::parse(&entry.ident);
-                if ident.is_workspace() {
-                    return true;
-                }
-                match hoisted_idents.get(ident.name()) {
-                    Some(hoisted_ident) => &entry.ident != hoisted_ident,
-                    None => true,
-                }
-            });
+            // A nested entry that matches the hoisted top-level is redundant ONLY
+            // if removing it would not change resolution. Bun resolves a nested
+            // package by walking up parent scopes (nearest ancestor wins). If an
+            // INTERMEDIATE ancestor scope pins a different version of the same
+            // package, the nested entry shadows it and must be kept — otherwise
+            // bun resolves to the intermediate (wrong) version instead of the
+            // hoisted one. See vercel/turborepo#12962 follow-up: a 3-level split
+            // such as `@vite-pwa/nuxt/@nuxt/kit/pathe@2` sitting above
+            // `@vite-pwa/nuxt/pathe@1` was incorrectly dropped.
+            let redundant_keys: Vec<String> = pruned_data
+                .packages
+                .iter()
+                .filter_map(|(key, entry)| {
+                    if PackageKey::parse(key).parent().is_none() {
+                        return None;
+                    }
+                    let ident = PackageIdent::parse(&entry.ident);
+                    if ident.is_workspace() {
+                        return None;
+                    }
+                    let name = ident.name();
+                    // Only a candidate if it matches the hoisted top-level ident.
+                    match hoisted_idents.get(name) {
+                        Some(hoisted_ident) if hoisted_ident == &entry.ident => {}
+                        _ => return None,
+                    }
+                    let suffix = format!("/{name}");
+                    let parent_scope = key.strip_suffix(&suffix)?;
+                    // Find the nearest ancestor scope (longest strict prefix-scope
+                    // of parent_scope) that also provides `name`.
+                    let nearest = pruned_data
+                        .packages
+                        .iter()
+                        .filter_map(|(other_key, other_entry)| {
+                            let anc = other_key.strip_suffix(&suffix)?;
+                            let descends = parent_scope == anc
+                                || parent_scope.starts_with(&format!("{anc}/"));
+                            (anc.len() < parent_scope.len() && descends)
+                                .then_some((anc.len(), &other_entry.ident))
+                        })
+                        .max_by_key(|(len, _)| *len)
+                        .map(|(_, ident)| ident);
+                    // Without this entry, resolution falls to the nearest ancestor
+                    // (or the hoisted top-level when none). Redundant only if that
+                    // resolves to the same ident.
+                    let resolves_to = nearest.unwrap_or(&entry.ident);
+                    (resolves_to == &entry.ident).then(|| key.clone())
+                })
+                .collect();
+            for key in redundant_keys {
+                pruned_data.packages.remove(&key);
+            }
         }
 
         // De-aliasing can turn a workspace-scoped package key like

--- a/crates/turborepo-lockfiles/src/bun/test.rs
+++ b/crates/turborepo-lockfiles/src/bun/test.rs
@@ -2186,3 +2186,66 @@ fn test_subgraph_preserves_patch_when_patched_version_missing_from_lockfile_keys
         "nested is-odd@2.0.0 should remain under pkg-old"
     );
 }
+
+/// Regression for a 3-level nested version split that `turbo prune` drops.
+///
+/// `@vite-pwa/nuxt@1` depends on `pathe@^1` (direct) AND `@nuxt/kit@^3`, while
+/// the workspace also depends on `@nuxt/kit@^4`. The hoisted `@nuxt/kit@4` keeps
+/// `@nuxt/kit@3` nested under `@vite-pwa/nuxt`, and that nested `@nuxt/kit@3`
+/// needs `pathe@^2` — recorded at the 3-level key
+/// `@vite-pwa/nuxt/@nuxt/kit/pathe`. Prune must preserve that key, otherwise bun
+/// resolves the nested `@nuxt/kit@3`'s pathe to the nearest ancestor
+/// `@vite-pwa/nuxt/pathe@1.1.2` (wrong major).
+#[test]
+fn test_prune_preserves_three_level_nested_version() {
+    let contents = serde_json::to_string(&json!({
+        "lockfileVersion": 1,
+        "workspaces": {
+            "": { "name": "root" },
+            "apps/web": {
+                "name": "web",
+                "dependencies": {
+                    "@nuxt/kit": "^4.4.8",
+                    "@vite-pwa/nuxt": "1.1.1"
+                }
+            }
+        },
+        "packages": {
+            "@nuxt/kit": ["@nuxt/kit@4.4.8", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-a"],
+            "@vite-pwa/nuxt": ["@vite-pwa/nuxt@1.1.1", "", { "dependencies": { "@nuxt/kit": "^3.9.0", "pathe": "^1.1.1" } }, "sha512-b"],
+            "pathe": ["pathe@2.0.3", "", {}, "sha512-c"],
+            "@vite-pwa/nuxt/@nuxt/kit": ["@nuxt/kit@3.21.8", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-d"],
+            "@vite-pwa/nuxt/pathe": ["pathe@1.1.2", "", {}, "sha512-e"],
+            "@vite-pwa/nuxt/@nuxt/kit/pathe": ["pathe@2.0.3", "", {}, "sha512-c"]
+        }
+    }))
+    .unwrap();
+
+    let lockfile = BunLockfile::from_str(&contents).unwrap();
+
+    let unresolved_deps: std::collections::BTreeMap<String, String> = [
+        ("@nuxt/kit".to_string(), "^4.4.8".to_string()),
+        ("@vite-pwa/nuxt".to_string(), "1.1.1".to_string()),
+    ]
+    .into_iter()
+    .collect();
+    let closure = crate::transitive_closure(&lockfile, "apps/web", unresolved_deps, false).unwrap();
+    let package_idents: Vec<String> = closure.iter().map(|pkg| pkg.key.clone()).collect();
+
+    let subgraph = lockfile
+        .subgraph(&["apps/web".into()], &package_idents)
+        .unwrap();
+    let pruned = subgraph.lockfile().unwrap();
+
+    assert!(
+        pruned.packages.contains_key("@vite-pwa/nuxt/@nuxt/kit/pathe"),
+        "3-level nested pathe@2.0.3 must be preserved so the nested @nuxt/kit@3 \
+         resolves pathe@2, not the sibling @vite-pwa/nuxt/pathe@1.1.2. \
+         pruned pathe keys: {:?}",
+        pruned
+            .packages
+            .keys()
+            .filter(|k| k.ends_with("pathe"))
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION

## What

The Bun lockfile **nested entry deduplication** pass in `subgraph.rs` removed any
nested entry whose ident matched the hoisted top-level entry. That assumption only
holds when there is no *intermediate* ancestor scope pinning a different version of
the same package.

Bun resolves a nested dependency by walking up parent scopes (nearest ancestor
wins). With a 3-level split like:

```
pathe                              -> pathe@2.0.3   (hoisted top-level)
@vite-pwa/nuxt/pathe               -> pathe@1.1.2   (@vite-pwa/nuxt needs ^1)
@vite-pwa/nuxt/@nuxt/kit           -> @nuxt/kit@3.21.8 (needs pathe ^2)
@vite-pwa/nuxt/@nuxt/kit/pathe     -> pathe@2.0.3   (3-level disambiguation)
```

the old pass deleted `@vite-pwa/nuxt/@nuxt/kit/pathe@2.0.3` as "redundant" with the
hoisted `pathe@2.0.3`. After install, bun resolves the nested `@nuxt/kit@3`'s
`pathe` to the nearer `@vite-pwa/nuxt/pathe@1.1.2` — an out-of-range major —
breaking e.g. `@nuxt/test-utils/module` (`reverseResolveAlias` not in pathe@1).

## Fix

Only drop a nested entry when removing it would not change resolution: compute the
**nearest ancestor** scope that also provides the package and keep the entry unless
that ancestor (or the hoisted top-level, when none) resolves to the same ident.

## Test

`test_prune_preserves_three_level_nested_version` reproduces the drop with a minimal
synthetic lockfile and asserts the 3-level key survives. Full `turborepo-lockfiles`
suite: **195 passed, 0 failed**.

Fixes the follow-up case left by #12963/#12965 (#12962, #12156).

Closes #13152.
