### PR TITLE
feat: Update workspace package manager declarations

### DIFF
--- a/packages/turbo-workspaces/__tests__/managers.test.ts
+++ b/packages/turbo-workspaces/__tests__/managers.test.ts
@@ -16,6 +16,16 @@ import {
 
 jest.mock("execa", () => jest.fn());
 
+type PackageJsonWithDevEngines = PackageJson & {
+  devEngines?: {
+    packageManager?: {
+      name: string;
+      version: string;
+    };
+    [key: string]: unknown;
+  };
+};
+
 describe("managers", () => {
   const { useFixture } = setupTestFixtures({
     directory: path.join(__dirname, "../")
@@ -40,9 +50,9 @@ describe("managers", () => {
     it.each(generateCreateMatrix())(
       "creates $manager project from $project $type project (interactive=$interactive, dry=$dry)",
       async ({ project, manager, type, interactive, dry }) => {
-        expect.assertions(2);
-
-        const { root } = useFixture({ fixture: `./${project}/${type}` });
+        const { root, readJson } = useFixture({
+          fixture: `./${project}/${type}`
+        });
         const testProject = await MANAGERS[project].read({
           workspaceRoot: root
         });
@@ -67,6 +77,14 @@ describe("managers", () => {
           await expect(
             MANAGERS[manager].detect({ workspaceRoot: root })
           ).resolves.toEqual(true);
+          const packageJson = readJson<PackageJsonWithDevEngines>(
+            path.join(root, "package.json")
+          );
+          expect(packageJson?.packageManager).toBeUndefined();
+          expect(packageJson?.devEngines?.packageManager).toEqual({
+            name: manager,
+            version: "1.2.3"
+          });
         }
       }
     );
@@ -109,7 +127,9 @@ describe("managers", () => {
           expect(fs.existsSync(project.paths.nodeModules)).toEqual(dry);
         }
 
-        const packageJson = readJson<PackageJson>(project.paths.packageJson);
+        const packageJson = readJson<PackageJsonWithDevEngines>(
+          project.paths.packageJson
+        );
         if (dry) {
           expect(packageJson?.packageManager).toBeDefined();
           expect(packageJson?.packageManager?.split("@")[0]).toEqual(
@@ -136,6 +156,7 @@ describe("managers", () => {
           }
         } else {
           expect(packageJson?.packageManager).toBeUndefined();
+          expect(packageJson?.devEngines?.packageManager).toBeUndefined();
           if (fixtureType === "monorepo") {
             expect(packageJson?.workspaces).toBeUndefined();
 
@@ -152,6 +173,74 @@ describe("managers", () => {
         }
       }
     );
+
+    it("removes matching declarations and preserves declarations for other managers", async () => {
+      const { root, readJson, write } = useFixture({
+        fixture: "./npm/monorepo"
+      });
+      const packageJsonPath = path.join(root, "package.json");
+      const packageJson = readJson<PackageJsonWithDevEngines>(packageJsonPath);
+      if (!packageJson) {
+        throw new Error("expected package.json fixture");
+      }
+      packageJson.packageManager = "pnpm@9.12.3";
+      packageJson.devEngines = {
+        ...packageJson.devEngines,
+        packageManager: {
+          name: "bun",
+          version: "1.1.0"
+        }
+      };
+      write(packageJsonPath, JSON.stringify(packageJson, null, 2));
+
+      const project = await MANAGERS.npm.read({ workspaceRoot: root });
+      await MANAGERS.npm.remove({
+        project,
+        to: { name: "pnpm", version: "9.12.3" },
+        logger: new Logger({ interactive: false, dry: false }),
+        options: { interactive: false, dry: false }
+      });
+
+      const updatedPackageJson =
+        readJson<PackageJsonWithDevEngines>(packageJsonPath);
+      expect(updatedPackageJson?.packageManager).toEqual("pnpm@9.12.3");
+      expect(updatedPackageJson?.devEngines?.packageManager).toEqual({
+        name: "bun",
+        version: "1.1.0"
+      });
+    });
+
+    it("removes both matching declaration fields", async () => {
+      const { root, readJson, write } = useFixture({
+        fixture: "./npm/monorepo"
+      });
+      const packageJsonPath = path.join(root, "package.json");
+      const packageJson = readJson<PackageJsonWithDevEngines>(packageJsonPath);
+      if (!packageJson) {
+        throw new Error("expected package.json fixture");
+      }
+      packageJson.devEngines = {
+        ...packageJson.devEngines,
+        packageManager: {
+          name: "npm",
+          version: "10.5.0"
+        }
+      };
+      write(packageJsonPath, JSON.stringify(packageJson, null, 2));
+
+      const project = await MANAGERS.npm.read({ workspaceRoot: root });
+      await MANAGERS.npm.remove({
+        project,
+        to: { name: "pnpm", version: "9.12.3" },
+        logger: new Logger({ interactive: false, dry: false }),
+        options: { interactive: false, dry: false }
+      });
+
+      const updatedPackageJson =
+        readJson<PackageJsonWithDevEngines>(packageJsonPath);
+      expect(updatedPackageJson?.packageManager).toBeUndefined();
+      expect(updatedPackageJson?.devEngines?.packageManager).toBeUndefined();
+    });
   });
 
   describe("read", () => {

--- a/packages/turbo-workspaces/src/managers/bun.ts
+++ b/packages/turbo-workspaces/src/managers/bun.ts
@@ -20,6 +20,8 @@ import {
   expandPaths,
   expandWorkspaces,
   getWorkspacePackageManager,
+  setPackageManagerDeclaration,
+  removePackageManagerDeclaration,
   parseWorkspacePackages,
   isCompatibleWithBunWorkspaces,
   removeLockFile
@@ -87,7 +89,7 @@ async function read(args: ReadArgs): Promise<Project> {
  * Creating bun workspaces involves:
  *  1. Validating that the project can be converted to bun workspace
  *  2. Adding the workspaces field in package.json
- *  3. Setting the packageManager field in package.json
+ *  3. Setting the devEngines.packageManager field in package.json
  *  4. Updating all workspace package.json dependencies to ensure correct format
  */
 // eslint-disable-next-line @typescript-eslint/require-await -- must match the create type signature
@@ -116,13 +118,16 @@ async function create(args: CreateArgs): Promise<void> {
 
   // package manager
   logger.rootStep(
-    `adding "packageManager" field to ${path.relative(
+    `adding "devEngines.packageManager" field to ${path.relative(
       project.paths.root,
       project.paths.packageJson
     )}`
   );
-  // TODO: This technically isn't valid as part of the spec (yet)
-  packageJson.packageManager = `${to.name}@${to.version}`;
+  setPackageManagerDeclaration({
+    packageJson,
+    packageManager: to.name,
+    version: to.version
+  });
 
   if (hasWorkspaces) {
     // workspaces field
@@ -185,9 +190,12 @@ async function remove(args: RemoveArgs): Promise<void> {
   }
 
   logger.subStep(
-    `removing "packageManager" field in ${project.name} root "package.json"`
+    `removing ${PACKAGE_MANAGER_DETAILS.name} package manager declarations in ${project.name} root "package.json"`
   );
-  delete packageJson.packageManager;
+  removePackageManagerDeclaration({
+    packageJson,
+    packageManager: PACKAGE_MANAGER_DETAILS.name
+  });
 
   if (!options?.dry) {
     fs.writeJSONSync(project.paths.packageJson, packageJson, { spaces: 2 });

--- a/packages/turbo-workspaces/src/managers/npm.ts
+++ b/packages/turbo-workspaces/src/managers/npm.ts
@@ -19,6 +19,8 @@ import {
   getPackageJson,
   expandWorkspaces,
   getWorkspacePackageManager,
+  setPackageManagerDeclaration,
+  removePackageManagerDeclaration,
   expandPaths,
   parseWorkspacePackages,
   removeLockFile
@@ -85,7 +87,7 @@ async function read(args: ReadArgs): Promise<Project> {
  *
  * Creating npm workspaces involves:
  *  1. Adding the workspaces field in package.json
- *  2. Setting the packageManager field in package.json
+ *  2. Setting the devEngines.packageManager field in package.json
  *  3. Updating all workspace package.json dependencies to ensure correct format
  */
 // eslint-disable-next-line @typescript-eslint/require-await -- must match the create type signature
@@ -105,12 +107,16 @@ async function create(args: CreateArgs): Promise<void> {
 
   // package manager
   logger.rootStep(
-    `adding "packageManager" field to ${path.relative(
+    `adding "devEngines.packageManager" field to ${path.relative(
       project.paths.root,
       project.paths.packageJson
     )}`
   );
-  packageJson.packageManager = `${to.name}@${to.version}`;
+  setPackageManagerDeclaration({
+    packageJson,
+    packageManager: to.name,
+    version: to.version
+  });
 
   if (hasWorkspaces) {
     // workspaces field
@@ -173,9 +179,12 @@ async function remove(args: RemoveArgs): Promise<void> {
   }
 
   logger.subStep(
-    `removing "packageManager" field in ${project.name} root "package.json"`
+    `removing ${PACKAGE_MANAGER_DETAILS.name} package manager declarations in ${project.name} root "package.json"`
   );
-  delete packageJson.packageManager;
+  removePackageManagerDeclaration({
+    packageJson,
+    packageManager: PACKAGE_MANAGER_DETAILS.name
+  });
 
   if (!options?.dry) {
     fs.writeJSONSync(project.paths.packageJson, packageJson, { spaces: 2 });

--- a/packages/turbo-workspaces/src/managers/pnpm.ts
+++ b/packages/turbo-workspaces/src/managers/pnpm.ts
@@ -22,6 +22,8 @@ import {
   getPnpmWorkspaces,
   getPackageJson,
   getWorkspacePackageManager,
+  setPackageManagerDeclaration,
+  removePackageManagerDeclaration,
   removeLockFile,
   bunLockToYarnLock
 } from "../utils";
@@ -87,7 +89,7 @@ async function read(args: ReadArgs): Promise<Project> {
  *
  * Creating pnpm workspaces involves:
  *  1. Create pnpm-workspace.yaml
- *  2. Setting the packageManager field in package.json
+ *  2. Setting the devEngines.packageManager field in package.json
  *  3. Updating all workspace package.json dependencies to ensure correct format
  */
 // eslint-disable-next-line @typescript-eslint/require-await -- must match the create type signature
@@ -105,9 +107,13 @@ async function create(args: CreateArgs): Promise<void> {
 
   const packageJson = getPackageJson({ workspaceRoot: project.paths.root });
   logger.rootHeader();
-  packageJson.packageManager = `${to.name}@${to.version}`;
+  setPackageManagerDeclaration({
+    packageJson,
+    packageManager: to.name,
+    version: to.version
+  });
   logger.rootStep(
-    `adding "packageManager" field to ${project.name} root "package.json"`
+    `adding "devEngines.packageManager" field to ${project.name} root "package.json"`
   );
 
   // write the changes
@@ -172,9 +178,12 @@ async function remove(args: RemoveArgs): Promise<void> {
   }
 
   logger.subStep(
-    `removing "packageManager" field in ${project.name} root "package.json"`
+    `removing ${PACKAGE_MANAGER_DETAILS.name} package manager declarations in ${project.name} root "package.json"`
   );
-  delete packageJson.packageManager;
+  removePackageManagerDeclaration({
+    packageJson,
+    packageManager: PACKAGE_MANAGER_DETAILS.name
+  });
 
   if (!options?.dry) {
     fs.writeJSONSync(project.paths.packageJson, packageJson, { spaces: 2 });

--- a/packages/turbo-workspaces/src/managers/yarn.ts
+++ b/packages/turbo-workspaces/src/managers/yarn.ts
@@ -20,6 +20,8 @@ import {
   expandPaths,
   expandWorkspaces,
   getWorkspacePackageManager,
+  setPackageManagerDeclaration,
+  removePackageManagerDeclaration,
   parseWorkspacePackages,
   removeLockFile,
   bunLockToYarnLock
@@ -86,7 +88,7 @@ async function read(args: ReadArgs): Promise<Project> {
  *
  * Creating yarn workspaces involves:
  *  1. Adding the workspaces field in package.json
- *  2. Setting the packageManager field in package.json
+ *  2. Setting the devEngines.packageManager field in package.json
  *  3. Updating all workspace package.json dependencies to ensure correct format
  */
 // eslint-disable-next-line @typescript-eslint/require-await -- must match the create type signature
@@ -106,12 +108,16 @@ async function create(args: CreateArgs): Promise<void> {
 
   // package manager
   logger.rootStep(
-    `adding "packageManager" field to ${path.relative(
+    `adding "devEngines.packageManager" field to ${path.relative(
       project.paths.root,
       project.paths.packageJson
     )}`
   );
-  packageJson.packageManager = `${to.name}@${to.version}`;
+  setPackageManagerDeclaration({
+    packageJson,
+    packageManager: to.name,
+    version: to.version
+  });
 
   if (hasWorkspaces) {
     // workspaces field
@@ -174,9 +180,12 @@ async function remove(args: RemoveArgs): Promise<void> {
   }
 
   logger.subStep(
-    `removing "packageManager" field in ${project.name} root "package.json"`
+    `removing ${PACKAGE_MANAGER_DETAILS.name} package manager declarations in ${project.name} root "package.json"`
   );
-  delete packageJson.packageManager;
+  removePackageManagerDeclaration({
+    packageJson,
+    packageManager: PACKAGE_MANAGER_DETAILS.name
+  });
 
   if (!options?.dry) {
     fs.writeJSONSync(project.paths.packageJson, packageJson, { spaces: 2 });

--- a/packages/turbo-workspaces/src/utils.ts
+++ b/packages/turbo-workspaces/src/utils.ts
@@ -34,6 +34,11 @@ interface PackageJson {
   optionalDependencies?: Record<string, string>;
 }
 
+interface DevEnginesPackageManagerDeclaration {
+  name: PackageManager;
+  version: string;
+}
+
 // adapted from https://github.com/nodejs/corepack/blob/cae770694e62f15fed33dd8023649d77d96023c1/sources/specUtils.ts#L14
 const PACKAGE_MANAGER_REGEX = /^(?!_)(?<manager>.+)@(?<version>.+)$/;
 const SUPPORTED_PACKAGE_MANAGERS = new Set<PackageManager>([
@@ -207,6 +212,80 @@ function invalidDevEnginesPackageManager(message: string): ConvertError {
     {
       type: "package_manager-unable_to_detect"
     }
+  );
+}
+
+function getPackageManagerFromPackageManagerField(
+  packageManager: string | undefined
+): PackageManager | undefined {
+  if (!packageManager) {
+    return undefined;
+  }
+
+  const match = PACKAGE_MANAGER_REGEX.exec(packageManager);
+  const manager = match?.groups?.manager;
+  return isPackageManager(manager) ? manager : undefined;
+}
+
+function setPackageManagerDeclaration({
+  packageJson,
+  packageManager,
+  version
+}: {
+  packageJson: PackageJson;
+  packageManager: PackageManager;
+  version: string;
+}): void {
+  delete packageJson.packageManager;
+  const devEngines =
+    packageJson.devEngines &&
+    typeof packageJson.devEngines === "object" &&
+    !Array.isArray(packageJson.devEngines)
+      ? packageJson.devEngines
+      : {};
+  packageJson.devEngines = {
+    ...devEngines,
+    packageManager: {
+      name: packageManager,
+      version
+    }
+  };
+}
+
+function removePackageManagerDeclaration({
+  packageJson,
+  packageManager
+}: {
+  packageJson: PackageJson;
+  packageManager: PackageManager;
+}): void {
+  if (
+    getPackageManagerFromPackageManagerField(packageJson.packageManager) ===
+    packageManager
+  ) {
+    delete packageJson.packageManager;
+  }
+
+  const devEnginesPackageManager = packageJson.devEngines?.packageManager;
+  if (
+    isDevEnginesPackageManagerDeclaration(devEnginesPackageManager) &&
+    devEnginesPackageManager.name === packageManager
+  ) {
+    delete packageJson.devEngines?.packageManager;
+  }
+}
+
+function isDevEnginesPackageManagerDeclaration(
+  value: unknown
+): value is DevEnginesPackageManagerDeclaration {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    "name" in value &&
+    isPackageManager(value.name) &&
+    "version" in value &&
+    typeof value.version === "string"
   );
 }
 
@@ -437,6 +516,8 @@ async function bunLockToYarnLock({
 export {
   getPackageJson,
   getWorkspacePackageManager,
+  setPackageManagerDeclaration,
+  removePackageManagerDeclaration,
   getWorkspaceInfo,
   expandPaths,
   expandWorkspaces,


### PR DESCRIPTION
## Why

Workspace conversion should not leave stale top-level `packageManager` declarations around now that `devEngines.packageManager` is the preferred declaration. If stale metadata remains, detection precedence can resolve to the old manager after a conversion.

## What

Updates `@turbo/workspaces` create/remove flows to write `devEngines.packageManager` and clean up package-manager declarations based on the manager they identify.

## How

- Adds shared helpers for writing and removing package-manager declarations.
- Create paths write `devEngines.packageManager` and remove stale top-level declarations.
- Remove paths delete matching top-level and nested declarations while preserving declarations for other managers.
- Adds coverage for nested declaration output, stale top-level removal, and preservation behavior.

Verified with:

- `pnpm --dir packages/turbo-workspaces test`
- `pnpm --dir packages/turbo-workspaces check-types`
- `pnpm exec oxlint --deny-warnings ...` on touched files