### PR TITLE
docs: Prefer devEngines packageManager

### DIFF
--- a/apps/docs/content/docs/crafting-your-repository/structuring-a-repository.mdx
+++ b/apps/docs/content/docs/crafting-your-repository/structuring-a-repository.mdx
@@ -260,7 +260,12 @@ The root `package.json` is the base for your workspace. Below is a common exampl
   "devDependencies": {
     "turbo": "latest"
   },
-  "packageManager": "pnpm@9.0.0"
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "9.0.0"
+    }
+  }
 }
 ```
 
@@ -279,7 +284,12 @@ The root `package.json` is the base for your workspace. Below is a common exampl
   "devDependencies": {
     "turbo": "latest"
   },
-  "packageManager": "yarn@1.22.19",
+  "devEngines": {
+    "packageManager": {
+      "name": "yarn",
+      "version": "1.22.19"
+    }
+  },
   "workspaces": ["apps/*", "packages/*"]
 }
 ```
@@ -299,7 +309,12 @@ The root `package.json` is the base for your workspace. Below is a common exampl
   "devDependencies": {
     "turbo": "latest"
   },
-  "packageManager": "npm@10.0.0",
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": "10.0.0"
+    }
+  },
   "workspaces": ["apps/*", "packages/*"]
 }
 ```
@@ -319,7 +334,12 @@ The root `package.json` is the base for your workspace. Below is a common exampl
   "devDependencies": {
     "turbo": "latest"
   },
-  "packageManager": "bun@1.2.0",
+  "devEngines": {
+    "packageManager": {
+      "name": "bun",
+      "version": "1.2.0"
+    }
+  },
   "workspaces": ["apps/*", "packages/*"]
 }
 ```

--- a/apps/docs/content/docs/crafting-your-repository/upgrading.mdx
+++ b/apps/docs/content/docs/crafting-your-repository/upgrading.mdx
@@ -67,11 +67,11 @@ Additionally, a `name` field will be added to any `package.json` in the Workspac
 
 <Step>
 
-### Add a `packageManager` field to root `package.json`
+### Add `devEngines.packageManager` to root `package.json`
 
-[The `packageManager` field](https://nodejs.org/api/packages.html#packagemanager) is a convention from the Node.js ecosystem that defines which package manager is expected to be used in the Workspace.
+The `devEngines.packageManager` field declares which package manager is expected to be used in the Workspace. The legacy top-level [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) field is also supported for backwards compatibility.
 
-Turborepo 2.0 requires that your Workspace define this field as a way to improve the stability and behavioral predictability of your codebase. If you do not have one already, add this field to your root `package.json`:
+Turborepo 2.0 requires that your Workspace define a package manager declaration as a way to improve the stability and behavioral predictability of your codebase. If you do not have one already, add this field to your root `package.json`:
 
 <PackageManagerTabs>
 
@@ -79,7 +79,12 @@ Turborepo 2.0 requires that your Workspace define this field as a way to improve
 
 ```diff title="./package.json"
 {
-+ "packageManager": "pnpm@9.2.0"
++ "devEngines": {
++   "packageManager": {
++     "name": "pnpm",
++     "version": "9.2.0"
++   }
++ }
 }
 ```
 
@@ -89,7 +94,12 @@ Turborepo 2.0 requires that your Workspace define this field as a way to improve
 
 ```diff title="./package.json"
 {
-+ "packageManager": "yarn@1.22.19"
++ "devEngines": {
++   "packageManager": {
++     "name": "yarn",
++     "version": "1.22.19"
++   }
++ }
 }
 ```
 
@@ -99,7 +109,12 @@ Turborepo 2.0 requires that your Workspace define this field as a way to improve
 
 ```diff title="./package.json"
 {
-+ "packageManager": "npm@10.8.1"
++ "devEngines": {
++   "packageManager": {
++     "name": "npm",
++     "version": "10.8.1"
++   }
++ }
 }
 ```
 
@@ -109,7 +124,12 @@ Turborepo 2.0 requires that your Workspace define this field as a way to improve
 
 ```diff title="./package.json"
 {
-+ "packageManager": "bun@1.2.0"
++ "devEngines": {
++   "packageManager": {
++     "name": "bun",
++     "version": "1.2.0"
++   }
++ }
 }
 ```
 

--- a/apps/docs/content/docs/getting-started/add-to-existing-repository.mdx
+++ b/apps/docs/content/docs/getting-started/add-to-existing-repository.mdx
@@ -196,9 +196,9 @@ Add `.turbo` to your `.gitignore` file. The `turbo` CLI uses these folders for p
 
 </Step>
 <Step>
-### Add a `packageManager` field to root `package.json`
+### Add `devEngines.packageManager` to root `package.json`
 
-Turborepo optimizes your repository using information from your package manager. To declare which package manager you're using, add a [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) field to your root `package.json` if you don't have one already.
+Turborepo optimizes your repository using information from your package manager. To declare which package manager you're using, add `devEngines.packageManager` to your root `package.json` if you don't have a package manager declaration already. The legacy top-level [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) field is also supported.
 
 <PackageManagerTabs>
 
@@ -206,7 +206,12 @@ Turborepo optimizes your repository using information from your package manager.
 
 ```diff title="package.json"
 {
-+  "packageManager": "pnpm@10.0.0"
++  "devEngines": {
++    "packageManager": {
++      "name": "pnpm",
++      "version": "10.0.0"
++    }
++  }
 }
 ```
 
@@ -216,7 +221,12 @@ Turborepo optimizes your repository using information from your package manager.
 
 ```diff title="package.json"
 {
-+  "packageManager": "yarn@1.22.19"
++  "devEngines": {
++    "packageManager": {
++      "name": "yarn",
++      "version": "1.22.19"
++    }
++  }
 }
 ```
 
@@ -226,7 +236,12 @@ Turborepo optimizes your repository using information from your package manager.
 
 ```diff title="package.json"
 {
-+  "packageManager": "npm@8.5.0"
++  "devEngines": {
++    "packageManager": {
++      "name": "npm",
++      "version": "8.5.0"
++    }
++  }
 }
 ```
 
@@ -236,7 +251,12 @@ Turborepo optimizes your repository using information from your package manager.
 
 ```diff title="package.json"
 {
-+  "packageManager": "bun@1.2.0"
++  "devEngines": {
++    "packageManager": {
++      "name": "bun",
++      "version": "1.2.0"
++    }
++  }
 }
 ```
 
@@ -247,8 +267,8 @@ Turborepo optimizes your repository using information from your package manager.
 <Callout type="info">
   Depending on your repository, you may need to use the
   [`dangerouslyDisablePackageManagerCheck`](/docs/reference/configuration#dangerouslydisablepackagemanagercheck)
-  while migrating or in situations where you can't use the `packageManager` key
-  yet.
+  while migrating or in situations where you can't use a package manager
+  declaration yet.
 </Callout>
 
 </Step>

--- a/apps/docs/content/docs/guides/migrating-from-nx.mdx
+++ b/apps/docs/content/docs/guides/migrating-from-nx.mdx
@@ -236,9 +236,9 @@ const nextConfig = {};
 module.exports = nextConfig;
 ```
 
-### Step 5: Add the `packageManager` field
+### Step 5: Add `devEngines.packageManager`
 
-The root package.json needs to have the `packageManager` field. This ensures developers in the repository use the correct package manager, and that Turborepo can optimize your package graph based on your lockfile.
+The root package.json needs to have a package manager declaration. We recommend `devEngines.packageManager`. This ensures developers in the repository use the correct package manager, and that Turborepo can optimize your package graph based on your lockfile.
 
 <PackageManagerTabs>
 
@@ -246,7 +246,12 @@ The root package.json needs to have the `packageManager` field. This ensures dev
 
 ```json title="./package.json"
 {
-  "packageManager": "pnpm@9.0.0"
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "9.0.0"
+    }
+  }
 }
 ```
 
@@ -256,7 +261,12 @@ The root package.json needs to have the `packageManager` field. This ensures dev
 
 ```json title="./package.json"
 {
-  "packageManager": "yarn@1.22.19"
+  "devEngines": {
+    "packageManager": {
+      "name": "yarn",
+      "version": "1.22.19"
+    }
+  }
 }
 ```
 
@@ -266,7 +276,12 @@ The root package.json needs to have the `packageManager` field. This ensures dev
 
 ```json title="./package.json"
 {
-  "packageManager": "npm@10.0.0"
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": "10.0.0"
+    }
+  }
 }
 ```
 
@@ -276,7 +291,12 @@ The root package.json needs to have the `packageManager` field. This ensures dev
 
 ```json title="./package.json"
 {
-  "packageManager": "bun@1.2.0"
+  "devEngines": {
+    "packageManager": {
+      "name": "bun",
+      "version": "1.2.0"
+    }
+  }
 }
 ```
 

--- a/apps/docs/content/docs/reference/configuration.mdx
+++ b/apps/docs/content/docs/reference/configuration.mdx
@@ -135,9 +135,9 @@ Set/limit the maximum concurrency for task execution. Must be an integer greater
 
 Default: `false`
 
-Turborepo uses your repository's lockfile to determine caching behavior, [Package Graphs](https://turborepo.dev/docs/core-concepts/internal-packages), and more. Because of this, we use [the `packageManager` field](https://nodejs.org/api/packages.html#packagemanager) to help you stabilize your Turborepo.
+Turborepo uses your repository's lockfile to determine caching behavior, [Package Graphs](https://turborepo.dev/docs/core-concepts/internal-packages), and more. Because of this, we use the package manager declaration in your root `package.json` to help you stabilize your Turborepo. We recommend `devEngines.packageManager`; the legacy top-level [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) field is also supported.
 
-To help with incremental migration or in situations where you can't use the `packageManager` field, you may use `--dangerously-disable-package-manager-check` to opt out of this check and assume the risks of unstable lockfiles producing unpredictable behavior. When disabled, Turborepo will attempt a best-effort discovery of the intended package manager meant for the repository.
+To help with incremental migration or in situations where you can't use a package manager declaration, you may use `--dangerously-disable-package-manager-check` to opt out of this check and assume the risks of unstable lockfiles producing unpredictable behavior. When disabled, Turborepo will attempt a best-effort discovery of the intended package manager meant for the repository.
 
 ```jsonc title="./turbo.json"
 {

--- a/apps/docs/content/docs/reference/run.mdx
+++ b/apps/docs/content/docs/reference/run.mdx
@@ -177,9 +177,9 @@ turbo run build --cwd=./somewhere/else/in/your/repo
 
 ### `--dangerously-disable-package-manager-check`
 
-Turborepo uses your repository's lockfile to determine caching behavior, [Package Graphs](https://turborepo.dev/docs/core-concepts/internal-packages), and more. Because of this, we use [the `packageManager` field](https://nodejs.org/api/packages.html#packagemanager) to help you stabilize your Turborepo.
+Turborepo uses your repository's lockfile to determine caching behavior, [Package Graphs](https://turborepo.dev/docs/core-concepts/internal-packages), and more. Because of this, we use the package manager declaration in your root `package.json` to help you stabilize your Turborepo. We recommend `devEngines.packageManager`; the legacy top-level [`packageManager`](https://nodejs.org/api/packages.html#packagemanager) field is also supported.
 
-To help with incremental migration or in situations where you cannot use the `packageManager` field, you may use `--dangerously-disable-package-manager-check` to opt out of this check and assume the risks of unstable lockfiles producing unpredictable behavior. When disabled, Turborepo will attempt a best-effort discovery of the intended package manager meant for the repository.
+To help with incremental migration or in situations where you cannot use a package manager declaration, you may use `--dangerously-disable-package-manager-check` to opt out of this check and assume the risks of unstable lockfiles producing unpredictable behavior. When disabled, Turborepo will attempt a best-effort discovery of the intended package manager meant for the repository.
 
 <Callout type="info">
   You may also opt out of this check using [configuration in

--- a/apps/docs/content/docs/reference/system-environment-variables.mdx
+++ b/apps/docs/content/docs/reference/system-environment-variables.mdx
@@ -105,8 +105,7 @@ System environment variables are always overridden by flag values provided direc
         <code>TURBO_DANGEROUSLY_DISABLE_PACKAGE_MANAGER_CHECK</code>
       </td>
       <td>
-        Disable checking the <code>packageManager</code>
-        field in <code>package.json</code>.
+        Disable package manager declaration checks in root <code>package.json</code>.
         <div></div>
         You may run into [errors and unexpected caching
         behavior](/docs/reference/run#--dangerously-disable-package-manager-check)

--- a/apps/docs/content/docs/reference/turbo-codemod.mdx
+++ b/apps/docs/content/docs/reference/turbo-codemod.mdx
@@ -356,7 +356,7 @@ npx @turbo/codemod migrate-env-var-dependencies
 
 </Accordion>
 <Accordion title="add-package-manager (1.1.0)" id="add-package-manager">
-Transforms the root `package.json` so that `packageManager` key as the detected package manager (`yarn`, `npm`, `pnpm`) and version (e.g. `yarn@1.22.17`). This key is now [supported by Node.js](https://nodejs.org/dist/latest-v17.x/docs/api/packages.html#packagemanager) and is used by Turborepo for faster package manager detection (vs. inferring from just the filesystem alone).
+Transforms the root `package.json` so that `devEngines.packageManager` declares the detected package manager (`yarn`, `npm`, `pnpm`, `bun`) and version. Turborepo uses this declaration for faster package manager detection, rather than inferring from the filesystem alone.
 
 ```bash title="Terminal"
 npx @turbo/codemod add-package-manager
@@ -369,7 +369,12 @@ npx @turbo/codemod add-package-manager
   "name": "turborepo-basic",
   "version": "0.0.0",
   "private": true,
-+  "packageManager": "yarn@1.22.17",
++  "devEngines": {
++    "packageManager": {
++      "name": "yarn",
++      "version": "1.22.17"
++    }
++  },
   "workspaces": [
     "apps/*",
     "packages/*"

--- a/crates/turborepo-schema-gen/src/main.rs
+++ b/crates/turborepo-schema-gen/src/main.rs
@@ -637,7 +637,7 @@ fn generate_root_schema_interface() -> String {
   concurrency?: string;
 
   /**
-   * Disable check for `packageManager` in root `package.json`
+   * Disable package manager declaration checks in root `package.json`.
    *
    * This is highly discouraged as it leaves `turbo` dependent on system
    * configuration to infer the correct package manager.
@@ -874,7 +874,7 @@ fn generate_global_config_interface() -> String {
   concurrency?: string;
 
   /**
-   * Disable check for `packageManager` in root `package.json`.
+   * Disable package manager declaration checks in root `package.json`.
    *
    * @defaultValue `false`
    */

--- a/crates/turborepo-turbo-json/bindings/GlobalConfig.ts
+++ b/crates/turborepo-turbo-json/bindings/GlobalConfig.ts
@@ -43,7 +43,7 @@ passThroughEnv?: Array<string>,
  */
 ui?: UI, 
 /**
- * Disable check for `packageManager` in root `package.json`.
+ * Disable package manager declaration checks in root `package.json`.
  */
 dangerouslyDisablePackageManagerCheck?: boolean, 
 /**

--- a/crates/turborepo-turbo-json/bindings/RawTurboJson.ts
+++ b/crates/turborepo-turbo-json/bindings/RawTurboJson.ts
@@ -78,7 +78,7 @@ remoteCache?: RemoteCache,
  */
 ui?: UI, 
 /**
- * Disable check for `packageManager` in root `package.json`.
+ * Disable package manager declaration checks in root `package.json`.
  *
  * This is highly discouraged as it leaves `turbo` dependent on system
  * configuration to infer the correct package manager. Some turbo features

--- a/crates/turborepo-turbo-json/src/raw.rs
+++ b/crates/turborepo-turbo-json/src/raw.rs
@@ -314,7 +314,7 @@ pub struct RawGlobalConfig {
     #[ts(optional)]
     pub ui: Option<Spanned<UIMode>>,
 
-    /// Disable check for `packageManager` in root `package.json`.
+    /// Disable package manager declaration checks in root `package.json`.
     #[serde(
         skip_serializing_if = "Option::is_none",
         rename = "dangerouslyDisablePackageManagerCheck"
@@ -538,7 +538,7 @@ pub struct RawTurboJson {
     #[ts(optional)]
     pub ui: Option<Spanned<UIMode>>,
 
-    /// Disable check for `packageManager` in root `package.json`.
+    /// Disable package manager declaration checks in root `package.json`.
     ///
     /// This is highly discouraged as it leaves `turbo` dependent on system
     /// configuration to infer the correct package manager. Some turbo features

--- a/packages/turbo-ignore/__tests__/errors.test.ts
+++ b/packages/turbo-ignore/__tests__/errors.test.ts
@@ -4,7 +4,7 @@ import { shouldWarn, NON_FATAL_ERRORS } from "../src/errors";
 describe("shouldWarn()", () => {
   it("it detects errors when packageManager is missing", () => {
     const result = shouldWarn({
-      err: `run failed: We did not detect an in-use package manager for your project. Please set the "packageManager" property in your root package.json (https://nodejs.org/api/packages.html#packagemanager) or run \`npx @turbo/codemod add-package-manager\` in the root of your monorepo.`
+      err: `run failed: We did not find a package manager specified in your root package.json. Please set the "devEngines.packageManager" property in your root package.json or the legacy "packageManager" property (https://nodejs.org/api/packages.html#packagemanager) or run \`npx @turbo/codemod add-package-manager\` in the root of your monorepo.`
     });
     expect(result.code).toBe("NO_PACKAGE_MANAGER");
     expect(result.level).toBe("warn");

--- a/packages/turbo-ignore/__tests__/ignore.test.ts
+++ b/packages/turbo-ignore/__tests__/ignore.test.ts
@@ -119,7 +119,7 @@ describe("turboIgnore()", () => {
     expect(mockConsole.warn).toHaveBeenNthCalledWith(
       3,
       "≫  ",
-      `turbo-ignore could not complete - no package manager detected, please commit a lockfile, or set "packageManager" in your root "package.json"`
+      `turbo-ignore could not complete - no package manager detected, please commit a lockfile, or set "devEngines.packageManager" in your root "package.json"`
     );
 
     expectBuild(mockExit);

--- a/packages/turbo-ignore/src/errors.ts
+++ b/packages/turbo-ignore/src/errors.ts
@@ -9,9 +9,10 @@ export const NON_FATAL_ERRORS: NonFatalErrors = {
   },
   NO_PACKAGE_MANAGER: {
     regex: [
-      /run failed: We did not detect an in-use package manager for your project/i
+      /run failed: We did not detect an in-use package manager for your project/i,
+      /run failed: We did not find a package manager specified in your root package.json/i
     ],
-    message: `turbo-ignore could not complete - no package manager detected, please commit a lockfile, or set "packageManager" in your root "package.json"`
+    message: `turbo-ignore could not complete - no package manager detected, please commit a lockfile, or set "devEngines.packageManager" in your root "package.json"`
   },
   UNREACHABLE_PARENT: {
     regex: [/failed to resolve packages to run: commit HEAD\^ does not exist/i],

--- a/packages/turbo-types/schemas/schema.json
+++ b/packages/turbo-types/schemas/schema.json
@@ -82,7 +82,7 @@
       ]
     },
     "dangerouslyDisablePackageManagerCheck": {
-      "description": "Disable check for `packageManager` in root `package.json`.\n\nThis is highly discouraged as it leaves `turbo` dependent on system configuration to infer the correct package manager. Some turbo features are disabled if this is set to true.",
+      "description": "Disable package manager declaration checks in root `package.json`.\n\nThis is highly discouraged as it leaves `turbo` dependent on system configuration to infer the correct package manager. Some turbo features are disabled if this is set to true.",
       "anyOf": [
         {
           "$ref": "#/definitions/Boolean"
@@ -392,7 +392,7 @@
           ]
         },
         "dangerouslyDisablePackageManagerCheck": {
-          "description": "Disable check for `packageManager` in root `package.json`.",
+          "description": "Disable package manager declaration checks in root `package.json`.",
           "anyOf": [
             {
               "$ref": "#/definitions/Boolean"

--- a/packages/turbo-types/schemas/schema.ts
+++ b/packages/turbo-types/schemas/schema.ts
@@ -135,7 +135,7 @@ export interface RootSchema extends BaseSchema {
   concurrency?: string;
 
   /**
-   * Disable check for `packageManager` in root `package.json`
+   * Disable package manager declaration checks in root `package.json`.
    *
    * This is highly discouraged as it leaves `turbo` dependent on system
    * configuration to infer the correct package manager.
@@ -366,7 +366,7 @@ export interface GlobalConfig {
   concurrency?: string;
 
   /**
-   * Disable check for `packageManager` in root `package.json`.
+   * Disable package manager declaration checks in root `package.json`.
    *
    * @defaultValue `false`
    */

--- a/packages/turbo-types/schemas/schema.v2.json
+++ b/packages/turbo-types/schemas/schema.v2.json
@@ -84,7 +84,7 @@
       ]
     },
     "dangerouslyDisablePackageManagerCheck": {
-      "description": "Disable check for `packageManager` in root `package.json`.\n\nThis is highly discouraged as it leaves `turbo` dependent on system configuration to infer the correct package manager. Some turbo features are disabled if this is set to true.",
+      "description": "Disable package manager declaration checks in root `package.json`.\n\nThis is highly discouraged as it leaves `turbo` dependent on system configuration to infer the correct package manager. Some turbo features are disabled if this is set to true.",
       "anyOf": [
         {
           "$ref": "#/definitions/Boolean"

--- a/packages/turbo-types/src/types/config-v2.ts
+++ b/packages/turbo-types/src/types/config-v2.ts
@@ -135,7 +135,7 @@ export interface RootSchema extends BaseSchema {
   concurrency?: string;
 
   /**
-   * Disable check for `packageManager` in root `package.json`
+   * Disable package manager declaration checks in root `package.json`.
    *
    * This is highly discouraged as it leaves `turbo` dependent on system
    * configuration to infer the correct package manager.
@@ -366,7 +366,7 @@ export interface GlobalConfig {
   concurrency?: string;
 
   /**
-   * Disable check for `packageManager` in root `package.json`.
+   * Disable package manager declaration checks in root `package.json`.
    *
    * @defaultValue `false`
    */

--- a/packages/turbo-workspaces/src/managers/bun.ts
+++ b/packages/turbo-workspaces/src/managers/bun.ts
@@ -36,7 +36,7 @@ const PACKAGE_MANAGER_DETAILS: Manager = {
  * Check if a given project is using bun workspaces
  * Verify by checking for the existence of:
  *  1. bun.lockb
- *  2. packageManager field in package.json
+ *  2. Package manager declaration in package.json
  */
 // eslint-disable-next-line @typescript-eslint/require-await -- must match the detect type signature
 async function detect(args: DetectArgs): Promise<boolean> {

--- a/packages/turbo-workspaces/src/managers/npm.ts
+++ b/packages/turbo-workspaces/src/managers/npm.ts
@@ -35,7 +35,7 @@ const PACKAGE_MANAGER_DETAILS: Manager = {
  * Check if a given project is using npm workspaces
  * Verify by checking for the existence of:
  *  1. package-lock.json
- *  2. packageManager field in package.json
+ *  2. Package manager declaration in package.json
  */
 // eslint-disable-next-line @typescript-eslint/require-await -- must match the detect type signature
 async function detect(args: DetectArgs): Promise<boolean> {

--- a/packages/turbo-workspaces/src/managers/yarn.ts
+++ b/packages/turbo-workspaces/src/managers/yarn.ts
@@ -36,7 +36,7 @@ const PACKAGE_MANAGER_DETAILS: Manager = {
  * Check if a given project is using yarn workspaces
  * Verify by checking for the existence of:
  *  1. yarn.lock
- *  2. packageManager field in package.json
+ *  2. Package manager declaration in package.json
  */
 // eslint-disable-next-line @typescript-eslint/require-await -- must match the detect type signature
 async function detect(args: DetectArgs): Promise<boolean> {


### PR DESCRIPTION
## Why

Turborepo now supports `devEngines.packageManager` across detection, codemods, and workspace conversion. User-facing guidance should point users at the preferred declaration while still acknowledging legacy top-level `packageManager` support.

## What

Updates docs, schema comments, generated schema copies, and warning copy to prefer `devEngines.packageManager` or use declaration-neutral wording.

## How

- Updates active setup, migration, reference, and codemod docs.
- Updates `dangerouslyDisablePackageManagerCheck` descriptions to refer to package manager declaration checks.
- Regenerates schema/type descriptions.
- Updates `turbo-ignore` missing package manager warning copy.