### PR TITLE
fix: Install Zig for LSP builds

### DIFF
--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -87,6 +87,9 @@ jobs:
           github-token: ${{ github.token }}
           targets: ${{ matrix.settings.target }}
 
+      - name: Setup Zig
+        uses: ./.github/actions/setup-zig
+
       - name: Build Setup
         shell: bash
         if: ${{ matrix.settings.setup }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,4 +63,4 @@ docs: Update installation instructions
 - Canary VS Code extension packages use `--pre-release`.
 - Non-dry-run releases publish the VS Code extension through the `LSP` workflow using `publish=true`, `dry_run=false`, and a `VSCE_PAT` secret on the protected `vscode-marketplace` environment. This publish path must not block release PR creation or cleanup published npm release state.
 - The `Release` workflow signs and notarizes macOS `turbo` binaries during `build-rust` using static GitHub secrets and `apple-codesign`/`rcodesign`.
-- The `Release` workflow installs Zig during `build-rust` because `turbo` links vendored `libghostty-vt` through `turborepo-ghostty-sys`.
+- The `Release` and `LSP` workflows install Zig during `build-rust` because `turbo` and `turborepo-lsp` link vendored `libghostty-vt` through `turborepo-ghostty-sys`.


### PR DESCRIPTION
## Why
VS Code extension release builds fail because `turborepo-lsp` now links `turborepo-ghostty-sys`, whose build script requires `zig`. The main release Rust build already installs Zig, but the LSP workflow did not, so every VS Code extension Rust matrix job failed before packaging.

## What
Install the shared Zig toolchain setup in the LSP Rust build matrix before `cargo build`. Update the repo workflow notes so future release workflow changes preserve this requirement.

## How
Validated the workflow YAML parses and confirmed the failed release logs show `turborepo-ghostty-sys` panicking on missing `zig` across macOS and Windows. Pre-push hooks ran: `lint-staged`, `turbo run format check:toml`, and `cargo fmt --check`.