### PR TITLE
perf(build): Enable thin LTO + codegen-units=1 for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,9 @@ debug = 0
 opt-level = 0
 
 [profile.release]
-# Crate-local fat LTO + cross-crate thin LTO. codegen-units=1 lets LLVM fully
-# optimize each crate into a single object before the thin cross-crate merge,
-# which shrinks the shipped binary ~23% (48MB -> 37MB) for a ~12% build-time
-# cost on top of plain thin LTO. See profiling in the PR description.
+# Thin lto delivers some small runtime optimizations but massive binary size wins.
+# Coupling it with codegen-units=1 means we can distribute much of the work to the crate
+# level builds and have fewer objects to merge at the root.
 lto = "thin"
 codegen-units = 1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,12 @@ debug = 0
 opt-level = 0
 
 [profile.release]
-lto = "off"
+# Crate-local fat LTO + cross-crate thin LTO. codegen-units=1 lets LLVM fully
+# optimize each crate into a single object before the thin cross-crate merge,
+# which shrinks the shipped binary ~23% (48MB -> 37MB) for a ~12% build-time
+# cost on top of plain thin LTO. See profiling in the PR description.
+lto = "thin"
+codegen-units = 1
 
 [profile.release-turborepo-lsp]
 inherits = "release"


### PR DESCRIPTION
## Description

Enables thin LTO with `codegen-units = 1` on `[profile.release]`, so every release target inherits it — the shipped `turbo` binary (`release-turborepo`), the LSP (`release-turborepo-lsp`), and plain `--release` builds — rather than configuring each profile separately.

`[profile.release]` has had `lto = "off"` since #4362 (2023). That PR was titled "Make build faster" and set LTO off purely to shave build time — and notably, *before* it there was no `lto` line at all, so the profile used Cargo's default (`false` = thin-local LTO). It was never escaping a fat-LTO build; it disabled the cheap thin-local pass. This goes the other way: full **cross-crate thin LTO**, plus `codegen-units = 1` so each crate is optimized into a single object (crate-local fat LTO) *before* the thin cross-crate merge. This matches the profile Turbopack already ships in `next.js`.

## Results

### Binary size (the headline win)

| Target | baseline (`lto=off`) | this PR | delta |
|---|---|---|---|
| `turbo` | 48.1 MB | 37.0 MB | **−23%** |
| `turborepo-lsp` | 34.3 MB | 25.1 MB | **−27%** |

The LSP is already `opt-level = "z"` (size-tuned) and still drops another ~9 MB. `codegen-units = 1` is what unlocks this — plain `lto = "thin"` alone leaves the `turbo` binary at ~46 MB; cgu=1 lets LLVM dedupe/inline far more aggressively across the crate.

### Runtime

Measured with `hyperfine` (15 runs + 3 warmup) running `turbo run build --dry=json --no-daemon` on two real monorepos. Dry-run exercises the CPU-bound graph-construction + task-hashing path without executing tasks.

| | baseline | this PR |
|---|---|---|
| repo A (43 tasks) | 0.315s ±0.006 | 0.300s ±0.006 (**+5.0%**) |
| repo B (140 tasks) | 0.353s ±0.012 | 0.343s ±0.012 (**+2.7%**) |

A few percent faster on the CPU-bound path. Real task-executing runs are I/O/subprocess-bound, so end-user wall-clock gains will be smaller than these dry-run numbers.

### Build cost

Clean release build of `turbo` goes from ~106s to ~129s (**+22%**) on a dev machine (Apple Silicon, single sample, approximate). `codegen-units = 1` adds ~12% over plain thin LTO; the rest is thin LTO itself.  Without codegen-units=1 we don't get nearly as many size benefits.

