### PR TITLE
[codex] Include Windows DLL sidecars in Turbo releases

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -501,7 +501,9 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: turbo-${{ matrix.settings.target }}
-          path: target/${{ matrix.settings.target }}/release-turborepo/turbo*
+          path: |
+            target/${{ matrix.settings.target }}/release-turborepo/turbo*
+            target/${{ matrix.settings.target }}/release-turborepo/*.dll
 
   npm-publish:
     name: "Publish To NPM"

--- a/packages/turbo-releaser/src/operations.test.ts
+++ b/packages/turbo-releaser/src/operations.test.ts
@@ -45,11 +45,13 @@ describe("packPlatform", () => {
     const mockCopyFile = mock.fn((_src: string, _dst: string) =>
       Promise.resolve()
     );
+    const mockReaddir = mock.fn(() => Promise.resolve(["ghostty-vt.dll"]));
     const mockStat = mock.fn(() => Promise.resolve({ mode: 0 }));
     const mockChmod = mock.fn();
 
     t.mock.method(native, "generateNativePackage", mockGenerateNativePackage);
     t.mock.method(fs, "mkdir", mockMkdir);
+    t.mock.method(fs, "readdir", mockReaddir);
     t.mock.method(fs, "stat", mockStat);
     t.mock.method(fs, "chmod", mockChmod);
     t.mock.method(fs, "copyFile", mockCopyFile);
@@ -74,9 +76,17 @@ describe("packPlatform", () => {
       mockCopyFile.mock.calls[0].arguments[1].endsWith("turbo.exe"),
       "destination ends with .exe"
     );
+    assert.ok(
+      mockCopyFile.mock.calls[1].arguments[0].endsWith("ghostty-vt.dll"),
+      "source includes DLL sidecar"
+    );
+    assert.ok(
+      mockCopyFile.mock.calls[1].arguments[1].endsWith("ghostty-vt.dll"),
+      "destination includes DLL sidecar"
+    );
     assert.equal(mockGenerateNativePackage.mock.calls.length, 1);
     assert.equal(mockMkdir.mock.calls.length, 1);
-    assert.equal(mockCopyFile.mock.calls.length, 1);
+    assert.equal(mockCopyFile.mock.calls.length, 2);
     assert.equal(mockChmod.mock.calls.length, 1);
     assert.equal(mockChmod.mock.calls[0].arguments[1], 0o111);
   });

--- a/packages/turbo-releaser/src/operations.ts
+++ b/packages/turbo-releaser/src/operations.ts
@@ -94,6 +94,16 @@ async function packPlatform({
   const destPath = path.join(scaffoldDir, "bin", binaryName);
   await fs.mkdir(path.dirname(destPath), { recursive: true });
   await fs.copyFile(sourcePath, destPath);
+  if (os === "windows") {
+    for (const file of await fs.readdir(path.dirname(sourcePath))) {
+      if (file.endsWith(".dll")) {
+        await fs.copyFile(
+          path.join(path.dirname(sourcePath), file),
+          path.join(scaffoldDir, "bin", file)
+        );
+      }
+    }
+  }
   const stat = await fs.stat(destPath);
   const currMode = stat.mode;
   // eslint-disable-next-line no-bitwise -- necessary for enabling the executable bits


### PR DESCRIPTION
Fix Windows native package releases that require runtime DLL sidecars.

The Windows Rust artifact upload only captured turbo*, and the native npm packer only copied turbo.exe. When the built executable imports a sidecar DLL such as ghostty-vt.dll, the published @turbo/windows-* package can install an exe that fails before startup.

This keeps DLL sidecars in the release artifact and copies them into bin next to turbo.exe.

Validation:
node --import tsx --test src/operations.test.ts
node ../../node_modules/typescript/bin/tsc --noEmit
oxfmt --check .github/workflows/turborepo-release.yml packages/turbo-releaser/src/operations.ts packages/turbo-releaser/src/operations.test.ts