### PR TITLE
fix: Include Windows DLL sidecars in releases

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -501,7 +501,9 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: turbo-${{ matrix.settings.target }}
-          path: target/${{ matrix.settings.target }}/release-turborepo/turbo*
+          path: |
+            target/${{ matrix.settings.target }}/release-turborepo/turbo*
+            target/${{ matrix.settings.target }}/release-turborepo/*.dll
 
   npm-publish:
     name: "Publish To NPM"

--- a/packages/turbo-releaser/src/operations.test.ts
+++ b/packages/turbo-releaser/src/operations.test.ts
@@ -45,11 +45,13 @@ describe("packPlatform", () => {
     const mockCopyFile = mock.fn((_src: string, _dst: string) =>
       Promise.resolve()
     );
+    const mockReaddir = mock.fn(() => Promise.resolve(["ghostty-vt.DLL"]));
     const mockStat = mock.fn(() => Promise.resolve({ mode: 0 }));
     const mockChmod = mock.fn();
 
     t.mock.method(native, "generateNativePackage", mockGenerateNativePackage);
     t.mock.method(fs, "mkdir", mockMkdir);
+    t.mock.method(fs, "readdir", mockReaddir);
     t.mock.method(fs, "stat", mockStat);
     t.mock.method(fs, "chmod", mockChmod);
     t.mock.method(fs, "copyFile", mockCopyFile);
@@ -74,9 +76,17 @@ describe("packPlatform", () => {
       mockCopyFile.mock.calls[0].arguments[1].endsWith("turbo.exe"),
       "destination ends with .exe"
     );
+    assert.ok(
+      mockCopyFile.mock.calls[1].arguments[0].endsWith("ghostty-vt.DLL"),
+      "source includes DLL sidecar"
+    );
+    assert.ok(
+      mockCopyFile.mock.calls[1].arguments[1].endsWith("ghostty-vt.DLL"),
+      "destination includes DLL sidecar"
+    );
     assert.equal(mockGenerateNativePackage.mock.calls.length, 1);
     assert.equal(mockMkdir.mock.calls.length, 1);
-    assert.equal(mockCopyFile.mock.calls.length, 1);
+    assert.equal(mockCopyFile.mock.calls.length, 2);
     assert.equal(mockChmod.mock.calls.length, 1);
     assert.equal(mockChmod.mock.calls[0].arguments[1], 0o111);
   });

--- a/packages/turbo-releaser/src/operations.ts
+++ b/packages/turbo-releaser/src/operations.ts
@@ -94,6 +94,16 @@ async function packPlatform({
   const destPath = path.join(scaffoldDir, "bin", binaryName);
   await fs.mkdir(path.dirname(destPath), { recursive: true });
   await fs.copyFile(sourcePath, destPath);
+  if (os === "windows") {
+    for (const file of await fs.readdir(path.dirname(sourcePath))) {
+      if (file.toLowerCase().endsWith(".dll")) {
+        await fs.copyFile(
+          path.join(path.dirname(sourcePath), file),
+          path.join(scaffoldDir, "bin", file)
+        );
+      }
+    }
+  }
   const stat = await fs.stat(destPath);
   const currMode = stat.mode;
   // eslint-disable-next-line no-bitwise -- necessary for enabling the executable bits


### PR DESCRIPTION
Problem:
Windows release packaging can publish @turbo/windows-* without runtime DLL sidecars required by turbo.exe. The Rust artifact upload only included turbo*, and the native npm packer only copied turbo.exe. If the binary imports a sidecar such as ghostty-vt.dll, the installed package fails before startup with a missing shared library error.

Solution:
Upload DLL sidecars from the Windows build output with the release artifact, then copy DLLs into bin next to turbo.exe when building the native npm package. The copy filter is case-insensitive so mixed-case Windows DLL filenames are included.

Validation:
node --import tsx --test src/operations.test.ts
pnpm --filter @turbo/releaser check-types
oxfmt --check .github/workflows/turborepo-release.yml packages/turbo-releaser/src/operations.ts packages/turbo-releaser/src/operations.test.ts
git diff --check
pre-push: lint-staged, format, check:toml