### PR TITLE
fix(eslint-plugin-turbo): Preserve flat config types on exported configs

### DIFF
--- a/packages/eslint-plugin-turbo/lib/index.ts
+++ b/packages/eslint-plugin-turbo/lib/index.ts
@@ -8,7 +8,7 @@ import flatRecommended from "./configs/flat/recommended";
 export type { RuleContextWithOptions } from "./rules/no-undeclared-env-vars";
 export type { ProjectKey } from "./utils/calculate-inputs";
 
-const plugin: ESLint.Plugin = {
+const plugin = {
   meta: { name, version },
   rules: {
     [RULES.noUndeclaredEnvVars]: noUndeclaredEnvVars
@@ -24,9 +24,9 @@ const plugin: ESLint.Plugin = {
       }
     }
   }
-};
+} satisfies ESLint.Plugin;
 
-export const rules: ESLint.Plugin["rules"] = plugin.rules;
-export const configs: ESLint.Plugin["configs"] = plugin.configs;
+export const rules = plugin.rules;
+export const configs = plugin.configs;
 
 export default plugin;


### PR DESCRIPTION
### Description

The explicit `ESLint.Plugin["configs"]` annotation on the named exports was widening the inferred type of configs to the full union:
```ts
Record<string, LegacyConfigObject | ConfigObject | ConfigObject[]> | undefined
```

This caused TypeScript errors in consumers passing `configs['flat/recommended']` to `defineConfig()` from `eslint/config`, because the widened union includes `LegacyConfigObject` which is not assignable to the flat `ConfigWithExtends` type.

This change switches the `plugin` const from a type annotation to `satisfies ESLint.Plugin` and drops the explicit annotations from the named exports. `satisfies` validates the shape without widening, so the specific literal type of configs flows through to consumers. `configs['flat/recommended']` now resolves to the specific flat `ConfigObject` rather than the widened union, making it directly assignable to flat config APIs without casts.

`ESLint.Plugin["configs"]` already includes `ConfigObject` in its union, so `satisfies ESLint.Plugin` accepts the `flat/recommended` entry's plugins shape (`Record<string, Plugin>`) without error.

### Testing Instructions

The following code no longer causes any TypeScript errors
<details>
<summary>TS2345</summary>

```text
Argument of type 'LegacyConfigObject<RulesConfig, RulesConfig> | ConfigObject<RulesConfig> | ConfigObject<RulesConfig>[] | undefined' is not assignable to parameter of type 'InfiniteArray<ConfigWithExtends>'.
  Type 'undefined' is not assignable to type 'InfiniteArray<ConfigWithExtends>'.ts(2345)
```
</details>

<details>
<summary>TS18048</summary>

```text
'turboPlugin.configs' is possibly 'undefined'.ts(18048)
```
</details>

`packages/config-eslint/base.ts`:
```ts
import turboPlugin from 'eslint-plugin-turbo';
import { defineConfig } from 'eslint/config';

export const baseConfig = defineConfig(
  turboPlugin.configs['flat/recommended'],
  /* ... */
);
```
