### PR TITLE
ci: Pin macOS Rust builds to macOS 15

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -351,9 +351,9 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-15-xlarge
+          - host: macos-15-large
             target: "x86_64-apple-darwin"
-          - host: macos-15-xlarge
+          - host: macos-15-large
             target: "aarch64-apple-darwin"
           - host: ubuntu-24.04
             target: "x86_64-unknown-linux-musl"

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -351,9 +351,9 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-15-large
+          - host: macos-15-xlarge
             target: "x86_64-apple-darwin"
-          - host: macos-15-large
+          - host: macos-15-xlarge
             target: "aarch64-apple-darwin"
           - host: ubuntu-24.04
             target: "x86_64-unknown-linux-musl"

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -351,9 +351,9 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-14
+          - host: macos-15-xlarge
             target: "x86_64-apple-darwin"
-          - host: macos-14
+          - host: macos-15-xlarge
             target: "aarch64-apple-darwin"
           - host: ubuntu-24.04
             target: "x86_64-unknown-linux-musl"

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -218,7 +218,8 @@ jobs:
           fi
 
   rust_test_macos:
-    runs-on: macos-latest-xlarge
+    # Zig 0.15.2 fails to link its macOS build runner on macOS 26/Tahoe.
+    runs-on: macos-15-xlarge
     timeout-minutes: 15
     env:
       CARGO_INCREMENTAL: 0

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -218,7 +218,7 @@ jobs:
           fi
 
   rust_test_macos:
-    runs-on: macos-15-xlarge
+    runs-on: macos-15-large
     timeout-minutes: 15
     env:
       CARGO_INCREMENTAL: 0

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -218,7 +218,6 @@ jobs:
           fi
 
   rust_test_macos:
-    # Zig 0.15.2 fails to link its macOS build runner on macOS 26/Tahoe.
     runs-on: macos-15-xlarge
     timeout-minutes: 15
     env:

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -218,7 +218,7 @@ jobs:
           fi
 
   rust_test_macos:
-    runs-on: macos-15-large
+    runs-on: macos-15-xlarge
     timeout-minutes: 15
     env:
       CARGO_INCREMENTAL: 0


### PR DESCRIPTION
## Why

Recent PRs are failing in the macOS Rust test job after the runner resolved to macOS 26/Tahoe. Zig 0.15.2 fails to link its macOS build runner there while compiling the vendored Ghostty dependency.

## What

Pin macOS Rust PR tests and release Rust builds to the documented macOS 15 large runner.