### PR TITLE
feat: Add nub package manager support to JavaScript packages

### DIFF
--- a/packages/create-turbo/__tests__/index.test.ts
+++ b/packages/create-turbo/__tests__/index.test.ts
@@ -61,7 +61,9 @@ describe("create-turbo", () => {
           npm: "8.19.2",
           yarn: "1.22.10",
           pnpm: "7.22.2",
-          bun: "1.0.1"
+          bun: "1.0.1",
+        nub: "0.1.0",
+          nub: "0.1.0"
         });
 
       const mockCreateProject = jest
@@ -155,7 +157,9 @@ describe("create-turbo", () => {
           npm: "8.19.2",
           yarn: "1.22.10",
           pnpm: "7.22.2",
-          bun: "1.0.1"
+          bun: "1.0.1",
+        nub: "0.1.0",
+          nub: "0.1.0"
         });
 
       const mockCreateProject = jest
@@ -239,7 +243,8 @@ describe("create-turbo", () => {
         npm: "8.19.2",
         yarn: "1.22.10",
         pnpm: "7.22.2",
-        bun: "1.0.1"
+        bun: "1.0.1",
+        nub: "0.1.0"
       });
 
     const mockCreateProject = jest
@@ -302,7 +307,8 @@ describe("create-turbo", () => {
         npm: "8.19.2",
         yarn: "1.22.10",
         pnpm: "7.22.2",
-        bun: "1.0.1"
+        bun: "1.0.1",
+        nub: "0.1.0"
       });
 
     const mockCreateProject = jest
@@ -363,7 +369,8 @@ describe("create-turbo", () => {
         npm: "8.19.2",
         yarn: "1.22.10",
         pnpm: "7.22.2",
-        bun: "1.0.1"
+        bun: "1.0.1",
+        nub: "0.1.0"
       });
 
     const mockCreateProject = jest

--- a/packages/create-turbo/__tests__/index.test.ts
+++ b/packages/create-turbo/__tests__/index.test.ts
@@ -62,7 +62,6 @@ describe("create-turbo", () => {
           yarn: "1.22.10",
           pnpm: "7.22.2",
           bun: "1.0.1",
-          nub: "0.1.0",
           nub: "0.1.0"
         });
 
@@ -158,7 +157,6 @@ describe("create-turbo", () => {
           yarn: "1.22.10",
           pnpm: "7.22.2",
           bun: "1.0.1",
-          nub: "0.1.0",
           nub: "0.1.0"
         });
 

--- a/packages/create-turbo/__tests__/index.test.ts
+++ b/packages/create-turbo/__tests__/index.test.ts
@@ -62,7 +62,7 @@ describe("create-turbo", () => {
           yarn: "1.22.10",
           pnpm: "7.22.2",
           bun: "1.0.1",
-        nub: "0.1.0",
+          nub: "0.1.0",
           nub: "0.1.0"
         });
 
@@ -158,7 +158,7 @@ describe("create-turbo", () => {
           yarn: "1.22.10",
           pnpm: "7.22.2",
           bun: "1.0.1",
-        nub: "0.1.0",
+          nub: "0.1.0",
           nub: "0.1.0"
         });
 

--- a/packages/turbo-codemod/__tests__/add-package-manager.test.ts
+++ b/packages/turbo-codemod/__tests__/add-package-manager.test.ts
@@ -178,7 +178,8 @@ describe("add-package-manager-2", () => {
           pnpm: packageManager === "pnpm" ? packageManagerVersion : undefined,
           npm: packageManager === "npm" ? packageManagerVersion : undefined,
           yarn: packageManager === "yarn" ? packageManagerVersion : undefined,
-          bun: packageManager === "bun" ? packageManagerVersion : undefined
+          bun: packageManager === "bun" ? packageManagerVersion : undefined,
+          nub: packageManager === "nub" ? packageManagerVersion : undefined
         });
 
       const mockGetWorkspaceDetails = jest
@@ -287,7 +288,8 @@ describe("add-package-manager-2", () => {
           pnpm: undefined,
           npm: undefined,
           yarn: undefined,
-          bun: undefined
+          bun: undefined,
+          nub: undefined
         });
 
       const mockGetWorkspaceDetails = jest
@@ -335,7 +337,8 @@ describe("add-package-manager-2", () => {
           pnpm: packageManagerVersion,
           npm: undefined,
           yarn: undefined,
-          bun: undefined
+          bun: undefined,
+          nub: undefined
         });
 
       const mockGetWorkspaceDetails = jest

--- a/packages/turbo-codemod/__tests__/get-turbo-upgrade-command.test.ts
+++ b/packages/turbo-codemod/__tests__/get-turbo-upgrade-command.test.ts
@@ -523,7 +523,8 @@ describe("get-turbo-upgrade-command", () => {
           pnpm: undefined,
           npm: undefined,
           yarn: undefined,
-          bun: undefined
+          bun: undefined,
+          nub: undefined
         });
       const mockGetAvailablePackageManagers = jest
         .spyOn(turboUtils, "getAvailablePackageManagers")
@@ -531,7 +532,8 @@ describe("get-turbo-upgrade-command", () => {
           pnpm: packageManager === "pnpm" ? packageManagerVersion : undefined,
           npm: packageManager === "npm" ? packageManagerVersion : undefined,
           yarn: packageManager === "yarn" ? packageManagerVersion : undefined,
-          bun: packageManager === "bun" ? packageManagerVersion : undefined
+          bun: packageManager === "bun" ? packageManagerVersion : undefined,
+          nub: packageManager === "nub" ? packageManagerVersion : undefined
         });
 
       const project = getWorkspaceDetailsMockReturnValue({
@@ -585,7 +587,8 @@ describe("get-turbo-upgrade-command", () => {
           pnpm: `/global/pnpm/bin`,
           npm: `/global/npm/bin`,
           yarn: `/global/yarn/bin`,
-          bun: `/global/bun/bin`
+          bun: `/global/bun/bin`,
+          nub: `/global/nub/bin`
         });
 
       const mockGetAvailablePackageManagers = jest
@@ -594,7 +597,8 @@ describe("get-turbo-upgrade-command", () => {
           pnpm: packageManager === "pnpm" ? packageManagerVersion : undefined,
           npm: packageManager === "npm" ? packageManagerVersion : undefined,
           yarn: packageManager === "yarn" ? packageManagerVersion : undefined,
-          bun: packageManager === "bun" ? packageManagerVersion : undefined
+          bun: packageManager === "bun" ? packageManagerVersion : undefined,
+          nub: packageManager === "nub" ? packageManagerVersion : undefined
         });
 
       const project = getWorkspaceDetailsMockReturnValue({
@@ -709,7 +713,8 @@ describe("get-turbo-upgrade-command", () => {
           pnpm: "8.0.0",
           npm: undefined,
           yarn: undefined,
-          bun: undefined
+          bun: undefined,
+          nub: undefined
         });
 
       const project = getWorkspaceDetailsMockReturnValue({
@@ -767,7 +772,8 @@ describe("get-turbo-upgrade-command", () => {
             pnpm: "8.0.0",
             npm: undefined,
             yarn: undefined,
-            bun: undefined
+            bun: undefined,
+          nub: undefined
           });
 
         const project = getWorkspaceDetailsMockReturnValue({

--- a/packages/turbo-codemod/__tests__/get-turbo-upgrade-command.test.ts
+++ b/packages/turbo-codemod/__tests__/get-turbo-upgrade-command.test.ts
@@ -271,6 +271,36 @@ const LOCAL_INSTALL_COMMANDS: Array<TestCase> = [
     packageManagerVersion: "4.1.0",
     fixture: "single-package",
     expected: "yarn add turbo@latest"
+  },
+  // nub - workspaces
+  {
+    version: "latest",
+    packageManager: "nub",
+    packageManagerVersion: "0.1.0",
+    fixture: "pnpm-workspaces-dev-install",
+    expected: "nub add turbo@latest --save-dev -w"
+  },
+  {
+    version: "latest",
+    packageManager: "nub",
+    packageManagerVersion: "0.1.0",
+    fixture: "pnpm-workspaces",
+    expected: "nub add turbo@latest -w"
+  },
+  // nub - single package
+  {
+    version: "latest",
+    packageManager: "nub",
+    packageManagerVersion: "0.1.0",
+    fixture: "single-package-dev-install",
+    expected: "nub add turbo@latest --save-dev"
+  },
+  {
+    version: "latest",
+    packageManager: "nub",
+    packageManagerVersion: "0.1.0",
+    fixture: "single-package",
+    expected: "nub add turbo@latest"
   }
 ];
 
@@ -483,6 +513,21 @@ const GLOBAL_INSTALL_COMMANDS: Array<TestCase> = [
     packageManagerVersion: "4.1.0",
     fixture: "single-package-dev-install",
     expected: "yarn add turbo@latest --dev"
+  },
+  // nub
+  {
+    version: "latest",
+    packageManager: "nub",
+    packageManagerVersion: "0.1.0",
+    fixture: "pnpm-workspaces-dev-install",
+    expected: "nub add turbo@latest --global"
+  },
+  {
+    version: "latest",
+    packageManager: "nub",
+    packageManagerVersion: "0.1.0",
+    fixture: "single-package",
+    expected: "nub add turbo@latest --global"
   }
 ];
 
@@ -689,6 +734,28 @@ describe("get-turbo-upgrade-command", () => {
       });
 
       expect(upgradeCommand).toEqual("npm install");
+    });
+
+    it("returns nub install when catalog is used with nub", async () => {
+      const { root } = useFixture({ fixture: "pnpm-catalog-default" });
+
+      const project = getWorkspaceDetailsMockReturnValue({
+        root,
+        packageManager: "nub"
+      });
+
+      const catalogInfo: CatalogInfo = {
+        catalogName: null,
+        catalogFile: path.join(root, "pnpm-workspace.yaml"),
+        installType: "devDependencies"
+      };
+
+      const upgradeCommand = await getTurboUpgradeCommand({
+        project,
+        catalogInfo
+      });
+
+      expect(upgradeCommand).toEqual("nub install");
     });
   });
 

--- a/packages/turbo-codemod/__tests__/get-turbo-upgrade-command.test.ts
+++ b/packages/turbo-codemod/__tests__/get-turbo-upgrade-command.test.ts
@@ -773,7 +773,7 @@ describe("get-turbo-upgrade-command", () => {
             npm: undefined,
             yarn: undefined,
             bun: undefined,
-          nub: undefined
+            nub: undefined
           });
 
         const project = getWorkspaceDetailsMockReturnValue({

--- a/packages/turbo-codemod/__tests__/migrate.test.ts
+++ b/packages/turbo-codemod/__tests__/migrate.test.ts
@@ -73,7 +73,7 @@ describe("migrate", () => {
         npm: undefined,
         yarn: undefined,
         bun: undefined,
-          nub: undefined
+        nub: undefined
       });
     const mockedGetWorkspaceDetails = jest
       .spyOn(turboWorkspaces, "getWorkspaceDetails")
@@ -158,7 +158,7 @@ describe("migrate", () => {
         npm: undefined,
         yarn: undefined,
         bun: undefined,
-          nub: undefined
+        nub: undefined
       });
     const mockedGetWorkspaceDetails = jest
       .spyOn(turboWorkspaces, "getWorkspaceDetails")
@@ -228,7 +228,7 @@ describe("migrate", () => {
         npm: undefined,
         yarn: undefined,
         bun: undefined,
-          nub: undefined
+        nub: undefined
       });
     const mockedGetWorkspaceDetails = jest
       .spyOn(turboWorkspaces, "getWorkspaceDetails")
@@ -311,7 +311,7 @@ describe("migrate", () => {
         npm: undefined,
         yarn: undefined,
         bun: undefined,
-          nub: undefined
+        nub: undefined
       });
     const mockedGetWorkspaceDetails = jest
       .spyOn(turboWorkspaces, "getWorkspaceDetails")
@@ -513,7 +513,7 @@ describe("migrate", () => {
         npm: undefined,
         yarn: undefined,
         bun: undefined,
-          nub: undefined
+        nub: undefined
       });
     const mockedGetWorkspaceDetails = jest
       .spyOn(turboWorkspaces, "getWorkspaceDetails")
@@ -619,7 +619,7 @@ describe("migrate", () => {
         npm: undefined,
         yarn: undefined,
         bun: undefined,
-          nub: undefined
+        nub: undefined
       });
     const mockedGetWorkspaceDetails = jest
       .spyOn(turboWorkspaces, "getWorkspaceDetails")
@@ -854,7 +854,7 @@ describe("migrate", () => {
         npm: undefined,
         yarn: undefined,
         bun: undefined,
-          nub: undefined
+        nub: undefined
       });
     const mockedGetWorkspaceDetails = jest
       .spyOn(turboWorkspaces, "getWorkspaceDetails")
@@ -969,7 +969,7 @@ describe("migrate", () => {
         npm: undefined,
         yarn: undefined,
         bun: undefined,
-          nub: undefined
+        nub: undefined
       });
     const mockedGetWorkspaceDetails = jest
       .spyOn(turboWorkspaces, "getWorkspaceDetails")

--- a/packages/turbo-codemod/__tests__/migrate.test.ts
+++ b/packages/turbo-codemod/__tests__/migrate.test.ts
@@ -72,7 +72,8 @@ describe("migrate", () => {
         pnpm: packageManagerVersion,
         npm: undefined,
         yarn: undefined,
-        bun: undefined
+        bun: undefined,
+          nub: undefined
       });
     const mockedGetWorkspaceDetails = jest
       .spyOn(turboWorkspaces, "getWorkspaceDetails")
@@ -156,7 +157,8 @@ describe("migrate", () => {
         pnpm: packageManagerVersion,
         npm: undefined,
         yarn: undefined,
-        bun: undefined
+        bun: undefined,
+          nub: undefined
       });
     const mockedGetWorkspaceDetails = jest
       .spyOn(turboWorkspaces, "getWorkspaceDetails")
@@ -225,7 +227,8 @@ describe("migrate", () => {
         pnpm: packageManagerVersion,
         npm: undefined,
         yarn: undefined,
-        bun: undefined
+        bun: undefined,
+          nub: undefined
       });
     const mockedGetWorkspaceDetails = jest
       .spyOn(turboWorkspaces, "getWorkspaceDetails")
@@ -307,7 +310,8 @@ describe("migrate", () => {
         pnpm: packageManagerVersion,
         npm: undefined,
         yarn: undefined,
-        bun: undefined
+        bun: undefined,
+          nub: undefined
       });
     const mockedGetWorkspaceDetails = jest
       .spyOn(turboWorkspaces, "getWorkspaceDetails")
@@ -508,7 +512,8 @@ describe("migrate", () => {
         pnpm: packageManagerVersion,
         npm: undefined,
         yarn: undefined,
-        bun: undefined
+        bun: undefined,
+          nub: undefined
       });
     const mockedGetWorkspaceDetails = jest
       .spyOn(turboWorkspaces, "getWorkspaceDetails")
@@ -613,7 +618,8 @@ describe("migrate", () => {
         pnpm: packageManagerVersion,
         npm: undefined,
         yarn: undefined,
-        bun: undefined
+        bun: undefined,
+          nub: undefined
       });
     const mockedGetWorkspaceDetails = jest
       .spyOn(turboWorkspaces, "getWorkspaceDetails")
@@ -847,7 +853,8 @@ describe("migrate", () => {
         pnpm: packageManagerVersion,
         npm: undefined,
         yarn: undefined,
-        bun: undefined
+        bun: undefined,
+          nub: undefined
       });
     const mockedGetWorkspaceDetails = jest
       .spyOn(turboWorkspaces, "getWorkspaceDetails")
@@ -961,7 +968,8 @@ describe("migrate", () => {
         pnpm: packageManagerVersion,
         npm: undefined,
         yarn: undefined,
-        bun: undefined
+        bun: undefined,
+          nub: undefined
       });
     const mockedGetWorkspaceDetails = jest
       .spyOn(turboWorkspaces, "getWorkspaceDetails")

--- a/packages/turbo-codemod/__tests__/transform.test.ts
+++ b/packages/turbo-codemod/__tests__/transform.test.ts
@@ -54,7 +54,8 @@ describe("transform", () => {
         pnpm: packageManagerVersion,
         npm: undefined,
         yarn: undefined,
-        bun: undefined
+        bun: undefined,
+        nub: undefined
       });
 
     const mockGetWorkspaceDetails = jest
@@ -106,7 +107,8 @@ describe("transform", () => {
         pnpm: packageManagerVersion,
         npm: undefined,
         yarn: undefined,
-        bun: undefined
+        bun: undefined,
+        nub: undefined
       });
 
     const mockGetWorkspaceDetails = jest

--- a/packages/turbo-codemod/src/cli.ts
+++ b/packages/turbo-codemod/src/cli.ts
@@ -30,6 +30,8 @@ const notifyUpdate = createNotifyUpdate({
         return "yarn global add @turbo/codemod";
       } else if (packageManager === "pnpm") {
         return "pnpm i -g @turbo/codemod";
+      } else if (packageManager === "nub") {
+        return "nub add -g @turbo/codemod";
       }
       return "npm i -g @turbo/codemod";
     } catch {

--- a/packages/turbo-codemod/src/commands/migrate/steps/get-turbo-upgrade-command.ts
+++ b/packages/turbo-codemod/src/commands/migrate/steps/get-turbo-upgrade-command.ts
@@ -41,6 +41,9 @@ function getGlobalUpgradeCommand({
     case "bun": {
       return `bun add turbo@${to} --global`;
     }
+    case "nub": {
+      return `nub add turbo@${to} --global`;
+    }
   }
 }
 
@@ -107,6 +110,15 @@ function getLocalUpgradeCommand({
         installType === "devDependencies" && "--dev"
       ]);
     }
+    case "nub": {
+      return renderCommand([
+        "nub",
+        "add",
+        `turbo@${to}`,
+        installType === "devDependencies" && "--save-dev",
+        isUsingWorkspaces && "-w"
+      ]);
+    }
   }
 }
 
@@ -127,6 +139,9 @@ function getInstallCommand({
     }
     case "bun": {
       return "bun install";
+    }
+    case "nub": {
+      return "nub install";
     }
   }
 }

--- a/packages/turbo-utils/__tests__/managers.test.ts
+++ b/packages/turbo-utils/__tests__/managers.test.ts
@@ -62,7 +62,8 @@ describe("managers", () => {
         .mockResolvedValueOnce({ stdout: "1.22.19" } as any) // yarn
         .mockResolvedValueOnce({ stdout: "9.5.0" } as any) // npm
         .mockResolvedValueOnce({ stdout: "8.6.7" } as any) // pnpm
-        .mockResolvedValueOnce({ stdout: "1.0.0" } as any); // bun
+        .mockResolvedValueOnce({ stdout: "1.0.0" } as any) // bun
+        .mockResolvedValueOnce({ stdout: "0.1.0" } as any); // nub
 
       const result = await getAvailablePackageManagers({
         projectRoot: MISSING_PROJECT_ROOT
@@ -72,7 +73,8 @@ describe("managers", () => {
         yarn: "1.22.19",
         npm: "9.5.0",
         pnpm: "8.6.7",
-        bun: "1.0.0"
+        bun: "1.0.0",
+        nub: "0.1.0"
       });
     });
 
@@ -81,7 +83,8 @@ describe("managers", () => {
         .mockResolvedValueOnce({ stdout: "1.22.19" } as any) // yarn
         .mockRejectedValueOnce(new Error("npm not found")) // npm
         .mockResolvedValueOnce({ stdout: "8.6.7" } as any) // pnpm
-        .mockRejectedValueOnce(new Error("bun not found")); // bun
+        .mockRejectedValueOnce(new Error("bun not found")) // bun
+        .mockRejectedValueOnce(new Error("nub not found")); // nub
 
       const result = await getAvailablePackageManagers({
         projectRoot: MISSING_PROJECT_ROOT
@@ -91,7 +94,8 @@ describe("managers", () => {
         yarn: "1.22.19",
         npm: undefined,
         pnpm: "8.6.7",
-        bun: undefined
+        bun: undefined,
+        nub: undefined
       });
     });
 
@@ -102,7 +106,8 @@ describe("managers", () => {
       mockExeca
         .mockResolvedValueOnce({ stdout: "9.5.0" } as any) // npm
         .mockResolvedValueOnce({ stdout: "8.6.7" } as any) // pnpm
-        .mockResolvedValueOnce({ stdout: "1.0.0" } as any); // bun
+        .mockResolvedValueOnce({ stdout: "1.0.0" } as any) // bun
+        .mockResolvedValueOnce({ stdout: "0.1.0" } as any); // nub
 
       const result = await getAvailablePackageManagers({ projectRoot });
 
@@ -110,12 +115,14 @@ describe("managers", () => {
         yarn: "4.5.1",
         npm: "9.5.0",
         pnpm: "8.6.7",
-        bun: "1.0.0"
+        bun: "1.0.0",
+        nub: "0.1.0"
       });
       expect(mockExeca.mock.calls.map(([command]) => command)).toEqual([
         "npm",
         "pnpm",
-        "bun"
+        "bun",
+        "nub"
       ]);
     });
 
@@ -126,7 +133,8 @@ describe("managers", () => {
       mockExeca
         .mockResolvedValueOnce({ stdout: "9.5.0" } as any) // npm
         .mockResolvedValueOnce({ stdout: "8.6.7" } as any) // pnpm
-        .mockResolvedValueOnce({ stdout: "1.0.0" } as any); // bun
+        .mockResolvedValueOnce({ stdout: "1.0.0" } as any) // bun
+        .mockResolvedValueOnce({ stdout: "0.1.0" } as any); // nub
 
       const result = await getAvailablePackageManagers({ projectRoot });
 
@@ -134,7 +142,8 @@ describe("managers", () => {
       expect(mockExeca.mock.calls.map(([command]) => command)).toEqual([
         "npm",
         "pnpm",
-        "bun"
+        "bun",
+        "nub"
       ]);
     });
 
@@ -145,7 +154,8 @@ describe("managers", () => {
       mockExeca
         .mockResolvedValueOnce({ stdout: "9.5.0" } as any) // npm
         .mockResolvedValueOnce({ stdout: "8.6.7" } as any) // pnpm
-        .mockResolvedValueOnce({ stdout: "1.0.0" } as any); // bun
+        .mockResolvedValueOnce({ stdout: "1.0.0" } as any) // bun
+        .mockResolvedValueOnce({ stdout: "0.1.0" } as any); // nub
 
       const result = await getAvailablePackageManagers({ projectRoot });
 
@@ -153,7 +163,8 @@ describe("managers", () => {
       expect(mockExeca.mock.calls.map(([command]) => command)).toEqual([
         "npm",
         "pnpm",
-        "bun"
+        "bun",
+        "nub"
       ]);
     });
   });
@@ -164,7 +175,8 @@ describe("managers", () => {
         .mockResolvedValueOnce({ stdout: "3.2.1" } as any) // yarn version (berry)
         .mockResolvedValueOnce({ stdout: "/usr/local/bin" } as any) // npm prefix
         .mockResolvedValueOnce({ stdout: "/usr/local/pnpm" } as any) // pnpm bin
-        .mockResolvedValueOnce({ stdout: "/usr/local/bun" } as any); // bun bin
+        .mockResolvedValueOnce({ stdout: "/usr/local/bun" } as any) // bun bin
+        .mockResolvedValueOnce({ stdout: "/usr/local/bin/nub" } as any); // nub bin
 
       const result = await getPackageManagersBinPaths({
         projectRoot: MISSING_PROJECT_ROOT
@@ -174,17 +186,33 @@ describe("managers", () => {
         yarn: ".yarn/releases/yarn-3.2.1.cjs",
         npm: "/usr/local/bin",
         pnpm: "/usr/local/pnpm",
-        bun: "/usr/local/bun"
+        bun: "/usr/local/bun",
+        nub: "/usr/local/bin/nub"
       });
     });
 
     test("should handle yarn v1 global bin path", async () => {
-      mockExeca
-        .mockResolvedValueOnce({ stdout: "1.22.19" } as any) // yarn version check
-        .mockResolvedValueOnce({ stdout: "/usr/local/bin" } as any) // npm prefix
-        .mockResolvedValueOnce({ stdout: "/usr/local/pnpm" } as any) // pnpm bin
-        .mockResolvedValueOnce({ stdout: "/usr/local/bun" } as any) // bun bin
-        .mockResolvedValueOnce({ stdout: "/usr/local/yarn" } as any); // yarn global bin
+      mockExeca.mockImplementation(((command: string, args?: readonly string[]) => {
+        if (command === "yarnpkg") {
+          return Promise.resolve({ stdout: "1.22.19" } as any);
+        }
+        if (command === "yarn" && args?.[0] === "global") {
+          return Promise.resolve({ stdout: "/usr/local/yarn" } as any);
+        }
+        if (command === "npm") {
+          return Promise.resolve({ stdout: "/usr/local/bin" } as any);
+        }
+        if (command === "pnpm") {
+          return Promise.resolve({ stdout: "/usr/local/pnpm" } as any);
+        }
+        if (command === "bun") {
+          return Promise.resolve({ stdout: "/usr/local/bun" } as any);
+        }
+        if (command === "which") {
+          return Promise.resolve({ stdout: "/usr/local/bin/nub" } as any);
+        }
+        return Promise.reject(new Error(`${command} not found`));
+      }) as typeof execa);
 
       const result = await getPackageManagersBinPaths({
         projectRoot: MISSING_PROJECT_ROOT
@@ -194,6 +222,7 @@ describe("managers", () => {
       expect(result.npm).toBe("/usr/local/bin");
       expect(result.pnpm).toBe("/usr/local/pnpm");
       expect(result.bun).toBe("/usr/local/bun");
+      expect(result.nub).toBe("/usr/local/bin/nub");
     });
 
     test("should return undefined for failed package manager checks", async () => {
@@ -201,7 +230,8 @@ describe("managers", () => {
         .mockRejectedValueOnce(new Error("yarn not found")) // yarn
         .mockRejectedValueOnce(new Error("npm not found")) // npm
         .mockResolvedValueOnce({ stdout: "/usr/local/pnpm" } as any) // pnpm
-        .mockRejectedValueOnce(new Error("bun not found")); // bun
+        .mockRejectedValueOnce(new Error("bun not found")) // bun
+        .mockRejectedValueOnce(new Error("nub not found")); // nub
 
       const result = await getPackageManagersBinPaths({
         projectRoot: MISSING_PROJECT_ROOT
@@ -211,7 +241,8 @@ describe("managers", () => {
         yarn: undefined,
         npm: undefined,
         pnpm: "/usr/local/pnpm",
-        bun: undefined
+        bun: undefined,
+        nub: undefined
       });
     });
 
@@ -245,6 +276,11 @@ describe("managers", () => {
         env: { COREPACK_ENABLE_STRICT: "0" },
         timeout: 5000
       });
+      expect(mockExeca).toHaveBeenCalledWith("which", ["nub"], {
+        cwd: "/tmp",
+        env: { COREPACK_ENABLE_STRICT: "0" },
+        timeout: 5000
+      });
     });
 
     test("should infer yarn berry bin path without executing yarn", async () => {
@@ -254,7 +290,8 @@ describe("managers", () => {
       mockExeca
         .mockResolvedValueOnce({ stdout: "/usr/local/bin" } as any) // npm prefix
         .mockResolvedValueOnce({ stdout: "/usr/local/pnpm" } as any) // pnpm bin
-        .mockResolvedValueOnce({ stdout: "/usr/local/bun" } as any); // bun bin
+        .mockResolvedValueOnce({ stdout: "/usr/local/bun" } as any) // bun bin
+        .mockResolvedValueOnce({ stdout: "/usr/local/bin/nub" } as any); // nub bin
 
       const result = await getPackageManagersBinPaths({ projectRoot });
 
@@ -262,12 +299,14 @@ describe("managers", () => {
         yarn: ".yarn/releases/yarn-4.5.1.cjs",
         npm: "/usr/local/bin",
         pnpm: "/usr/local/pnpm",
-        bun: "/usr/local/bun"
+        bun: "/usr/local/bun",
+        nub: "/usr/local/bin/nub"
       });
       expect(mockExeca.mock.calls.map(([command]) => command)).toEqual([
         "npm",
         "pnpm",
-        "bun"
+        "bun",
+        "which"
       ]);
     });
   });

--- a/packages/turbo-utils/__tests__/managers.test.ts
+++ b/packages/turbo-utils/__tests__/managers.test.ts
@@ -192,7 +192,10 @@ describe("managers", () => {
     });
 
     test("should handle yarn v1 global bin path", async () => {
-      mockExeca.mockImplementation(((command: string, args?: readonly string[]) => {
+      mockExeca.mockImplementation(((
+        command: string,
+        args?: readonly string[]
+      ) => {
         if (command === "yarnpkg") {
           return Promise.resolve({ stdout: "1.22.19" } as any);
         }

--- a/packages/turbo-utils/__tests__/managers.test.ts
+++ b/packages/turbo-utils/__tests__/managers.test.ts
@@ -187,7 +187,7 @@ describe("managers", () => {
         npm: "/usr/local/bin",
         pnpm: "/usr/local/pnpm",
         bun: "/usr/local/bun",
-        nub: "/usr/local/bin/nub"
+        nub: "/usr/local/bin"
       });
     });
 
@@ -225,7 +225,7 @@ describe("managers", () => {
       expect(result.npm).toBe("/usr/local/bin");
       expect(result.pnpm).toBe("/usr/local/pnpm");
       expect(result.bun).toBe("/usr/local/bun");
-      expect(result.nub).toBe("/usr/local/bin/nub");
+      expect(result.nub).toBe("/usr/local/bin");
     });
 
     test("should return undefined for failed package manager checks", async () => {
@@ -303,7 +303,7 @@ describe("managers", () => {
         npm: "/usr/local/bin",
         pnpm: "/usr/local/pnpm",
         bun: "/usr/local/bun",
-        nub: "/usr/local/bin/nub"
+        nub: "/usr/local/bin"
       });
       expect(mockExeca.mock.calls.map(([command]) => command)).toEqual([
         "npm",

--- a/packages/turbo-utils/src/managers.ts
+++ b/packages/turbo-utils/src/managers.ts
@@ -166,18 +166,20 @@ export async function getAvailablePackageManagers(
   options: PackageManagerDetectionOptions = {}
 ): Promise<Record<PackageManager, string | undefined>> {
   const projectRoot = options.projectRoot ?? process.cwd();
-  const [yarn, npm, pnpm, bun] = await Promise.all([
+  const [yarn, npm, pnpm, bun, nub] = await Promise.all([
     getYarnVersion(projectRoot),
     exec("npm", ["--version"]),
     exec("pnpm", ["--version"]),
-    exec("bun", ["--version"])
+    exec("bun", ["--version"]),
+    exec("nub", ["--version"])
   ]);
 
   return {
     yarn,
     pnpm,
     npm,
-    bun
+    bun,
+    nub
   };
 }
 
@@ -185,17 +187,19 @@ export async function getPackageManagersBinPaths(
   options: PackageManagerDetectionOptions = {}
 ): Promise<Record<PackageManager, string | undefined>> {
   const projectRoot = options.projectRoot ?? process.cwd();
-  const [yarn, npm, pnpm, bun] = await Promise.all([
+  const [yarn, npm, pnpm, bun, nub] = await Promise.all([
     getYarnBinPath(projectRoot),
     exec("npm", ["config", "get", "prefix"]),
     exec("pnpm", ["bin", "--global"]),
-    exec("bun", ["pm", "--g", "bin"])
+    exec("bun", ["pm", "--g", "bin"]),
+    exec("which", ["nub"])
   ]);
 
   return {
     yarn,
     pnpm,
     npm,
-    bun
+    bun,
+    nub
   };
 }

--- a/packages/turbo-utils/src/managers.ts
+++ b/packages/turbo-utils/src/managers.ts
@@ -162,6 +162,15 @@ async function getYarnBinPath(projectRoot: string) {
   }
 }
 
+async function getNubBinPath() {
+  const nubBinaryPath = await exec("which", ["nub"]);
+  if (!nubBinaryPath) {
+    return undefined;
+  }
+
+  return path.dirname(nubBinaryPath);
+}
+
 export async function getAvailablePackageManagers(
   options: PackageManagerDetectionOptions = {}
 ): Promise<Record<PackageManager, string | undefined>> {
@@ -192,7 +201,7 @@ export async function getPackageManagersBinPaths(
     exec("npm", ["config", "get", "prefix"]),
     exec("pnpm", ["bin", "--global"]),
     exec("bun", ["pm", "--g", "bin"]),
-    exec("which", ["nub"])
+    getNubBinPath()
   ]);
 
   return {

--- a/packages/turbo-utils/src/types.ts
+++ b/packages/turbo-utils/src/types.ts
@@ -1,6 +1,6 @@
 import type { Schema } from "@turbo/types";
 
-export type PackageManager = "npm" | "yarn" | "pnpm" | "bun";
+export type PackageManager = "npm" | "yarn" | "pnpm" | "bun" | "nub";
 
 export type ExitCode = 0 | 1;
 

--- a/packages/turbo-workspaces/__tests__/index.test.ts
+++ b/packages/turbo-workspaces/__tests__/index.test.ts
@@ -208,7 +208,8 @@ describe("Node entrypoint", () => {
             npm: "8.19.2",
             yarn: "1.22.19",
             pnpm: "7.29.1",
-            bun: "1.0.1"
+            bun: "1.0.1",
+            nub: "0.1.0"
           });
 
         const { root } = useFixture({
@@ -250,7 +251,8 @@ describe("Node entrypoint", () => {
             npm: "8.19.2",
             yarn: "1.22.19",
             pnpm: "7.29.1",
-            bun: "1.0.1"
+            bun: "1.0.1",
+            nub: "0.1.0"
           });
 
         const { root } = useFixture({

--- a/packages/turbo-workspaces/__tests__/nub.test.ts
+++ b/packages/turbo-workspaces/__tests__/nub.test.ts
@@ -1,0 +1,282 @@
+import os from "node:os";
+import path from "node:path";
+import fs from "fs-extra";
+import { describe, it, expect } from "@jest/globals";
+import { Logger } from "../src/logger";
+import { getWorkspaceDetails } from "../src/get-workspace-details";
+import {
+  getUnderlyingLockfileManager,
+  getUnderlyingLockfileName,
+  getWorkspacePackageManager
+} from "../src/utils";
+import { MANAGERS } from "../src/managers";
+
+function makeWorkspace(files: Record<string, unknown>): string {
+  const workspaceRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), "turbo-workspaces-nub-")
+  );
+
+  for (const [filePath, content] of Object.entries(files)) {
+    const absolutePath = path.join(workspaceRoot, filePath);
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+    if (typeof content === "string") {
+      fs.writeFileSync(absolutePath, content);
+    } else {
+      fs.writeJsonSync(absolutePath, content);
+    }
+  }
+
+  return workspaceRoot;
+}
+
+describe("nub", () => {
+  describe("getWorkspacePackageManager", () => {
+    it("reads nub from packageManager field", () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": { packageManager: "nub@0.1.0" }
+      });
+
+      expect(getWorkspacePackageManager({ workspaceRoot })).toEqual("nub");
+    });
+
+    it("reads nub from devEngines.packageManager", () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": {
+          devEngines: {
+            packageManager: {
+              name: "nub",
+              version: "0.1.0"
+            }
+          }
+        }
+      });
+
+      expect(getWorkspacePackageManager({ workspaceRoot })).toEqual("nub");
+    });
+  });
+
+  describe("underlying lockfile resolution", () => {
+    it("defaults to npm when no lockfile exists", () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": { packageManager: "nub@0.1.0" }
+      });
+
+      expect(getUnderlyingLockfileManager({ workspaceRoot })).toEqual("npm");
+      expect(getUnderlyingLockfileName({ workspaceRoot })).toEqual(
+        "package-lock.json"
+      );
+    });
+
+    it("prefers bun over other lockfiles", () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": { packageManager: "nub@0.1.0" },
+        "bun.lock": "",
+        "pnpm-lock.yaml": "",
+        "yarn.lock": "",
+        "package-lock.json": "{}"
+      });
+
+      expect(getUnderlyingLockfileManager({ workspaceRoot })).toEqual("bun");
+      expect(getUnderlyingLockfileName({ workspaceRoot })).toEqual("bun.lock");
+    });
+
+    it("detects pnpm when pnpm lockfile is present", () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": { packageManager: "nub@0.1.0" },
+        "pnpm-lock.yaml": "lockfileVersion: '9.0'\n"
+      });
+
+      expect(getUnderlyingLockfileManager({ workspaceRoot })).toEqual("pnpm");
+    });
+  });
+
+  describe("detection", () => {
+    it("detects nub only via packageManager field", async () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": {},
+        "package-lock.json": "{}"
+      });
+
+      expect(await MANAGERS.nub.detect({ workspaceRoot })).toEqual(false);
+      expect(await MANAGERS.npm.detect({ workspaceRoot })).toEqual(true);
+    });
+
+    it("detects nub when packageManager field is set", async () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": { packageManager: "nub@0.1.0" },
+        "package-lock.json": "{}"
+      });
+
+      expect(await MANAGERS.nub.detect({ workspaceRoot })).toEqual(true);
+    });
+  });
+
+  describe("getWorkspaceDetails", () => {
+    it("returns nub as the package manager", async () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": {
+          name: "nub-project",
+          packageManager: "nub@0.1.0",
+          workspaces: ["packages/*"]
+        },
+        "package-lock.json": "{}"
+      });
+
+      const project = await getWorkspaceDetails({ root: workspaceRoot });
+
+      expect(project.packageManager).toEqual("nub");
+      expect(project.paths.lockfile).toEqual(
+        path.join(workspaceRoot, "package-lock.json")
+      );
+      expect(project.workspaceData.globs).toEqual(["packages/*"]);
+    });
+  });
+
+  describe("manager operations", () => {
+    it("creates nub workspace metadata", async () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": {
+          name: "nub-project",
+          packageManager: "npm@10.0.0",
+          workspaces: ["packages/*"]
+        },
+        "package-lock.json": "{}"
+      });
+      const project = await MANAGERS.npm.read({ workspaceRoot });
+      const packageJsonPath = path.join(workspaceRoot, "package.json");
+
+      await MANAGERS.nub.create({
+        project,
+        to: { name: "nub", version: "0.1.0" },
+        logger: new Logger({ dry: false, interactive: false })
+      });
+
+      const packageJson = fs.readJsonSync(packageJsonPath);
+      expect(packageJson.devEngines?.packageManager).toEqual({
+        name: "nub",
+        version: "0.1.0"
+      });
+      expect(packageJson.packageManager).toBeUndefined();
+    });
+
+    it("removes nub workspace metadata", async () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": {
+          name: "nub-project",
+          devEngines: {
+            packageManager: {
+              name: "nub",
+              version: "0.1.0"
+            }
+          },
+          workspaces: ["packages/*"]
+        }
+      });
+      const project = await MANAGERS.nub.read({ workspaceRoot });
+
+      await MANAGERS.nub.remove({
+        project,
+        to: { name: "npm", version: "10.0.0" },
+        logger: new Logger({ dry: false, interactive: false })
+      });
+
+      const packageJson = fs.readJsonSync(path.join(workspaceRoot, "package.json"));
+      expect(packageJson.workspaces).toBeUndefined();
+      expect(packageJson.devEngines?.packageManager).toBeUndefined();
+    });
+
+    it("cleans the underlying lockfile", async () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": {
+          name: "nub-project",
+          packageManager: "nub@0.1.0"
+        },
+        "package-lock.json": "{}"
+      });
+      const project = await MANAGERS.nub.read({ workspaceRoot });
+
+      await MANAGERS.nub.clean({
+        project,
+        logger: new Logger({ dry: false, interactive: false })
+      });
+
+      expect(
+        fs.existsSync(path.join(workspaceRoot, "package-lock.json"))
+      ).toEqual(false);
+    });
+
+    it("removes foreign lockfiles when converting to nub", async () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": {
+          name: "pnpm-project",
+          packageManager: "pnpm@9.0.0"
+        },
+        "pnpm-lock.yaml": "lockfileVersion: '9.0'\n"
+      });
+      const project = await MANAGERS.pnpm.read({ workspaceRoot });
+
+      await MANAGERS.nub.convertLock({
+        project,
+        to: { name: "nub", version: "0.1.0" },
+        logger: new Logger({ dry: false, interactive: false })
+      });
+
+      expect(
+        fs.existsSync(path.join(workspaceRoot, "pnpm-lock.yaml"))
+      ).toEqual(false);
+    });
+
+    it("reads workspace data via the underlying lockfile manager", async () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": {
+          name: "nub-project",
+          packageManager: "nub@0.1.0"
+        },
+        "pnpm-lock.yaml": "lockfileVersion: '9.0'\n",
+        "pnpm-workspace.yaml": "packages:\n  - packages/*\n"
+      });
+
+      const project = await MANAGERS.nub.read({ workspaceRoot });
+
+      expect(project.packageManager).toEqual("nub");
+      expect(project.paths.lockfile).toEqual(
+        path.join(workspaceRoot, "pnpm-lock.yaml")
+      );
+      expect(project.workspaceData.globs).toEqual(["packages/*"]);
+    });
+
+    it("throws when read is called on a non-nub project", async () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": { packageManager: "npm@10.0.0" },
+        "package-lock.json": "{}"
+      });
+
+      await expect(MANAGERS.nub.read({ workspaceRoot })).rejects.toThrow(
+        "Not a nub project"
+      );
+    });
+
+    it("creates nub metadata without workspaces", async () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": {
+          name: "nub-project",
+          packageManager: "npm@10.0.0"
+        },
+        "package-lock.json": "{}"
+      });
+      const project = await MANAGERS.npm.read({ workspaceRoot });
+
+      await MANAGERS.nub.create({
+        project: { ...project, workspaceData: { globs: [], workspaces: [] } },
+        to: { name: "nub", version: "0.1.0" },
+        logger: new Logger({ dry: false, interactive: false })
+      });
+
+      const packageJson = fs.readJsonSync(path.join(workspaceRoot, "package.json"));
+      expect(packageJson.devEngines?.packageManager).toEqual({
+        name: "nub",
+        version: "0.1.0"
+      });
+    });
+  });
+});

--- a/packages/turbo-workspaces/__tests__/nub.test.ts
+++ b/packages/turbo-workspaces/__tests__/nub.test.ts
@@ -97,8 +97,12 @@ describe("nub", () => {
         "package-lock.json": "{}"
       });
 
-      expect(await MANAGERS.nub.detect({ workspaceRoot })).toEqual(false);
-      expect(await MANAGERS.npm.detect({ workspaceRoot })).toEqual(true);
+      await expect(MANAGERS.nub.detect({ workspaceRoot })).resolves.toEqual(
+        false
+      );
+      await expect(MANAGERS.npm.detect({ workspaceRoot })).resolves.toEqual(
+        true
+      );
     });
 
     it("detects nub when packageManager field is set", async () => {
@@ -107,7 +111,9 @@ describe("nub", () => {
         "package-lock.json": "{}"
       });
 
-      expect(await MANAGERS.nub.detect({ workspaceRoot })).toEqual(true);
+      await expect(MANAGERS.nub.detect({ workspaceRoot })).resolves.toEqual(
+        true
+      );
     });
   });
 

--- a/packages/turbo-workspaces/__tests__/nub.test.ts
+++ b/packages/turbo-workspaces/__tests__/nub.test.ts
@@ -180,7 +180,9 @@ describe("nub", () => {
         logger: new Logger({ dry: false, interactive: false })
       });
 
-      const packageJson = fs.readJsonSync(path.join(workspaceRoot, "package.json"));
+      const packageJson = fs.readJsonSync(
+        path.join(workspaceRoot, "package.json")
+      );
       expect(packageJson.workspaces).toBeUndefined();
       expect(packageJson.devEngines?.packageManager).toBeUndefined();
     });
@@ -221,9 +223,9 @@ describe("nub", () => {
         logger: new Logger({ dry: false, interactive: false })
       });
 
-      expect(
-        fs.existsSync(path.join(workspaceRoot, "pnpm-lock.yaml"))
-      ).toEqual(false);
+      expect(fs.existsSync(path.join(workspaceRoot, "pnpm-lock.yaml"))).toEqual(
+        false
+      );
     });
 
     it("reads workspace data via the underlying lockfile manager", async () => {
@@ -272,7 +274,9 @@ describe("nub", () => {
         logger: new Logger({ dry: false, interactive: false })
       });
 
-      const packageJson = fs.readJsonSync(path.join(workspaceRoot, "package.json"));
+      const packageJson = fs.readJsonSync(
+        path.join(workspaceRoot, "package.json")
+      );
       expect(packageJson.devEngines?.packageManager).toEqual({
         name: "nub",
         version: "0.1.0"

--- a/packages/turbo-workspaces/__tests__/utils.test.ts
+++ b/packages/turbo-workspaces/__tests__/utils.test.ts
@@ -41,7 +41,8 @@ describe("utils", () => {
       ["npm", "10.5.0"],
       ["pnpm", "9.12.3"],
       ["yarn", "4.5.0+sha224.abc"],
-      ["bun", "1.1.0"]
+      ["bun", "1.1.0"],
+      ["nub", "0.1.0"]
     ] as const)("reads %s from devEngines.packageManager", (name, version) => {
       const workspaceRoot = makeWorkspace({
         devEngines: {

--- a/packages/turbo-workspaces/src/commands/convert/index.ts
+++ b/packages/turbo-workspaces/src/commands/convert/index.ts
@@ -82,7 +82,7 @@ export async function convertCommand(
         { pm: "npm", label: "npm" },
         { pm: "pnpm", label: "pnpm" },
         { pm: "yarn", label: "yarn" },
-        { pm: "bun", label: "Bun (beta)" },
+        { pm: "bun", label: "bun" },
         { pm: "nub", label: "nub" }
       ].map(({ pm, label }) => ({
         name: label,

--- a/packages/turbo-workspaces/src/commands/convert/index.ts
+++ b/packages/turbo-workspaces/src/commands/convert/index.ts
@@ -82,7 +82,8 @@ export async function convertCommand(
         { pm: "npm", label: "npm" },
         { pm: "pnpm", label: "pnpm" },
         { pm: "yarn", label: "yarn" },
-        { pm: "bun", label: "Bun (beta)" }
+        { pm: "bun", label: "Bun (beta)" },
+        { pm: "nub", label: "nub" }
       ].map(({ pm, label }) => ({
         name: label,
         value: pm as PackageManager,

--- a/packages/turbo-workspaces/src/install.ts
+++ b/packages/turbo-workspaces/src/install.ts
@@ -79,6 +79,18 @@ export const PACKAGE_MANAGERS: Record<
       semver: "^1.0.1",
       default: true
     }
+  ],
+  nub: [
+    {
+      name: "nub",
+      template: "nub",
+      command: "nub",
+      installArgs: ["install"],
+      version: "latest",
+      executable: "nub",
+      semver: "*",
+      default: true
+    }
   ]
 };
 

--- a/packages/turbo-workspaces/src/managers/index.ts
+++ b/packages/turbo-workspaces/src/managers/index.ts
@@ -1,11 +1,13 @@
 import type { PackageManager } from "../types";
 import type { ManagerHandler } from "../types";
+import { nub } from "./nub";
 import { pnpm } from "./pnpm";
 import { npm } from "./npm";
 import { yarn } from "./yarn";
 import { bun } from "./bun";
 
 export const MANAGERS: Record<PackageManager, ManagerHandler> = {
+  nub,
   pnpm,
   yarn,
   npm,

--- a/packages/turbo-workspaces/src/managers/npm.ts
+++ b/packages/turbo-workspaces/src/managers/npm.ts
@@ -256,6 +256,10 @@ async function convertLock(args: ConvertArgs): Promise<void> {
       removeLockFile({ project, options });
       break;
     }
+    case "nub": {
+      removeLockFile({ project, options });
+      break;
+    }
   }
 }
 

--- a/packages/turbo-workspaces/src/managers/nub.ts
+++ b/packages/turbo-workspaces/src/managers/nub.ts
@@ -23,55 +23,80 @@ import {
   setPackageManagerDeclaration,
   removePackageManagerDeclaration,
   parseWorkspacePackages,
-  isCompatibleWithBunWorkspaces,
+  getPnpmWorkspaces,
+  getUnderlyingLockfileManager,
+  getUnderlyingLockfileName,
   removeLockFile
 } from "../utils";
+import { npm } from "./npm";
+import { pnpm } from "./pnpm";
+import { yarn } from "./yarn";
+import { bun } from "./bun";
 
 const PACKAGE_MANAGER_DETAILS: Manager = {
-  name: "bun",
-  lock: "bun.lockb"
+  name: "nub",
+  lock: "package-lock.json"
 };
 
+const UNDERLYING_MANAGERS = {
+  npm,
+  pnpm,
+  yarn,
+  bun
+} as const;
+
 /**
- * Check if a given project is using bun workspaces
- * Verify by checking for the existence of:
- *  1. bun.lockb
- *  2. Package manager declaration in package.json
+ * nub is recognized only through the `packageManager` field in `package.json`
+ * (`"nub@x.y.z"`). A foreign lockfile alone does not imply nub.
  */
 // eslint-disable-next-line @typescript-eslint/require-await -- must match the detect type signature
 async function detect(args: DetectArgs): Promise<boolean> {
-  const lockFile = path.join(args.workspaceRoot, PACKAGE_MANAGER_DETAILS.lock);
   const packageManager = getWorkspacePackageManager({
     workspaceRoot: args.workspaceRoot
   });
-  return (
-    fs.existsSync(lockFile) || packageManager === PACKAGE_MANAGER_DETAILS.name
-  );
+  return packageManager === PACKAGE_MANAGER_DETAILS.name;
 }
 
-/**
-  Read workspace data from bun workspaces into generic format
-*/
 async function read(args: ReadArgs): Promise<Project> {
-  const isBun = await detect(args);
-  if (!isBun) {
-    throw new ConvertError("Not a bun project", {
+  const isNub = await detect(args);
+  if (!isNub) {
+    throw new ConvertError("Not a nub project", {
       type: "package_manager-unexpected"
     });
   }
 
+  const underlying = getUnderlyingLockfileManager({
+    workspaceRoot: args.workspaceRoot
+  });
+  const underlyingHandler = UNDERLYING_MANAGERS[underlying];
+
+  if (await underlyingHandler.detect(args)) {
+    const project = await underlyingHandler.read(args);
+    return { ...project, packageManager: PACKAGE_MANAGER_DETAILS.name };
+  }
+
   const packageJson = getPackageJson(args);
   const { name, description } = getWorkspaceInfo(args);
-  const workspaceGlobs = parseWorkspacePackages({
-    workspaces: packageJson.workspaces
+  const lockfile = getUnderlyingLockfileName({
+    workspaceRoot: args.workspaceRoot
   });
+  const pnpmGlobs = getPnpmWorkspaces(args);
+  const workspaceGlobs =
+    underlying === "pnpm" && pnpmGlobs.length > 0
+      ? pnpmGlobs
+      : parseWorkspacePackages({ workspaces: packageJson.workspaces });
+
   return {
     name,
     description,
     packageManager: PACKAGE_MANAGER_DETAILS.name,
     paths: expandPaths({
       root: args.workspaceRoot,
-      lockFile: PACKAGE_MANAGER_DETAILS.lock
+      lockFile: lockfile,
+      workspaceConfig:
+        underlying === "pnpm" && pnpmGlobs.length > 0
+          ? "pnpm-workspace.yaml"
+          : undefined
     }),
     workspaceData: {
       globs: workspaceGlobs,
@@ -83,28 +108,10 @@ async function read(args: ReadArgs): Promise<Project> {
   };
 }
 
-/**
- * Create bun workspaces from generic format
- *
- * Creating bun workspaces involves:
- *  1. Validating that the project can be converted to bun workspace
- *  2. Adding the workspaces field in package.json
- *  3. Setting the devEngines.packageManager field in package.json
- *  4. Updating all workspace package.json dependencies to ensure correct format
- */
 // eslint-disable-next-line @typescript-eslint/require-await -- must match the create type signature
 async function create(args: CreateArgs): Promise<void> {
-  const { project, to, logger, options } = args;
+  const { project, options, to, logger } = args;
   const hasWorkspaces = project.workspaceData.globs.length > 0;
-
-  if (!isCompatibleWithBunWorkspaces({ project })) {
-    throw new ConvertError(
-      "Unable to convert project to bun - workspace globs unsupported",
-      {
-        type: "bun-workspace_glob_error"
-      }
-    );
-  }
 
   logger.mainStep(
     getMainStep({
@@ -116,7 +123,6 @@ async function create(args: CreateArgs): Promise<void> {
   const packageJson = getPackageJson({ workspaceRoot: project.paths.root });
   logger.rootHeader();
 
-  // package manager
   logger.rootStep(
     `adding "devEngines.packageManager" field to ${path.relative(
       project.paths.root,
@@ -130,7 +136,6 @@ async function create(args: CreateArgs): Promise<void> {
   });
 
   if (hasWorkspaces) {
-    // workspaces field
     logger.rootStep(
       `adding "workspaces" field to ${path.relative(
         project.paths.root,
@@ -143,7 +148,6 @@ async function create(args: CreateArgs): Promise<void> {
       fs.writeJSONSync(project.paths.packageJson, packageJson, { spaces: 2 });
     }
 
-    // root dependencies
     updateDependencies({
       workspace: { name: "root", paths: project.paths },
       project,
@@ -152,7 +156,6 @@ async function create(args: CreateArgs): Promise<void> {
       options
     });
 
-    // workspace dependencies
     logger.workspaceHeader();
     for (const workspace of project.workspaceData.workspaces) {
       updateDependencies({ workspace, project, to, logger, options });
@@ -162,13 +165,6 @@ async function create(args: CreateArgs): Promise<void> {
   }
 }
 
-/**
- * Remove bun workspace data
- *
- * Removing bun workspaces involves:
- *  1. Removing the workspaces field from package.json
- *  2. Removing the node_modules directory
- */
 async function remove(args: RemoveArgs): Promise<void> {
   const { project, logger, options } = args;
   const hasWorkspaces = project.workspaceData.globs.length > 0;
@@ -200,7 +196,6 @@ async function remove(args: RemoveArgs): Promise<void> {
   if (!options?.dry) {
     fs.writeJSONSync(project.paths.packageJson, packageJson, { spaces: 2 });
 
-    // collect all workspace node_modules directories
     const allModulesDirs = [
       project.paths.nodeModules,
       ...project.workspaceData.workspaces.map((w) => w.paths.nodeModules)
@@ -212,7 +207,7 @@ async function remove(args: RemoveArgs): Promise<void> {
           fs.rm(dir, { recursive: true, force: true })
         )
       );
-    } catch (err) {
+    } catch {
       throw new ConvertError("Failed to remove node_modules", {
         type: "error_removing_node_modules"
       });
@@ -220,11 +215,6 @@ async function remove(args: RemoveArgs): Promise<void> {
   }
 }
 
-/**
- * Clean is called post install, and is used to clean up any files
- * from this package manager that were needed for install,
- * but not required after migration
- */
 // eslint-disable-next-line @typescript-eslint/require-await -- must match the clean type signature
 async function clean(args: CleanArgs): Promise<void> {
   const { project, logger, options } = args;
@@ -237,44 +227,25 @@ async function clean(args: CleanArgs): Promise<void> {
   }
 }
 
-/**
- * Attempts to convert an existing, non bun lockfile to a bun lockfile
- *
- * If this is not possible, the non bun lockfile is removed
- */
 // eslint-disable-next-line @typescript-eslint/require-await -- must match the convertLock type signature
 async function convertLock(args: ConvertArgs): Promise<void> {
   const { project, options } = args;
 
-  // handle moving lockfile from `packageManager` to npm
   switch (project.packageManager) {
-    case "pnpm": {
-      // can't convert from pnpm to bun - just remove the lock
-      removeLockFile({ project, options });
-      break;
-    }
-    case "bun": {
-      // we're already using bun, so we don't need to convert
-      break;
-    }
-    case "npm": {
-      // can't convert from npm to bun - just remove the lock
-      removeLockFile({ project, options });
-      break;
-    }
+    case "pnpm":
+    case "bun":
     case "yarn": {
-      // can't convert from yarn to bun - just remove the lock
       removeLockFile({ project, options });
       break;
     }
+    case "npm":
     case "nub": {
-      removeLockFile({ project, options });
       break;
     }
   }
 }
 
-export const bun: ManagerHandler = {
+export const nub: ManagerHandler = {
   detect,
   read,
   create,

--- a/packages/turbo-workspaces/src/managers/pnpm.ts
+++ b/packages/turbo-workspaces/src/managers/pnpm.ts
@@ -287,6 +287,10 @@ async function convertLock(args: ConvertArgs): Promise<void> {
       await importLockfile();
       break;
     }
+    case "nub": {
+      removeLockFile({ project, options });
+      break;
+    }
   }
 }
 

--- a/packages/turbo-workspaces/src/managers/yarn.ts
+++ b/packages/turbo-workspaces/src/managers/yarn.ts
@@ -266,6 +266,10 @@ async function convertLock(args: ConvertArgs): Promise<void> {
       // we're already using yarn, so we don't need to convert
       break;
     }
+    case "nub": {
+      removeLockFile({ project, options });
+      break;
+    }
   }
 }
 

--- a/packages/turbo-workspaces/src/types.ts
+++ b/packages/turbo-workspaces/src/types.ts
@@ -1,6 +1,6 @@
 import type { Logger } from "./logger";
 
-export type PackageManager = "npm" | "yarn" | "pnpm" | "bun";
+export type PackageManager = "npm" | "yarn" | "pnpm" | "bun" | "nub";
 
 export interface Manager {
   name: PackageManager;

--- a/packages/turbo-workspaces/src/utils.ts
+++ b/packages/turbo-workspaces/src/utils.ts
@@ -45,7 +45,8 @@ const SUPPORTED_PACKAGE_MANAGERS = new Set<PackageManager>([
   "npm",
   "pnpm",
   "yarn",
-  "bun"
+  "bun",
+  "nub"
 ]);
 const DEV_ENGINES_VERSION_REGEX =
   /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
@@ -158,7 +159,7 @@ function getWorkspacePackageManager({
 
   if (!isPackageManager(name)) {
     throw invalidDevEnginesPackageManager(
-      "`devEngines.packageManager.name` must be one of `npm`, `pnpm`, `yarn`, or `bun`"
+      "`devEngines.packageManager.name` must be one of `npm`, `pnpm`, `yarn`, `bun`, or `nub`"
     );
   }
 
@@ -416,6 +417,62 @@ function expandWorkspaces({
     });
 }
 
+type LockfilePackageManager = Exclude<PackageManager, "nub">;
+
+const LOCKFILE_PROBE_ORDER: Array<{
+  manager: LockfilePackageManager;
+  lockfiles: Array<string>;
+}> = [
+  { manager: "bun", lockfiles: ["bun.lock", "bun.lockb"] },
+  { manager: "pnpm", lockfiles: ["pnpm-lock.yaml"] },
+  { manager: "yarn", lockfiles: ["yarn.lock"] },
+  { manager: "npm", lockfiles: ["package-lock.json"] }
+];
+
+function getUnderlyingLockfileManager({
+  workspaceRoot
+}: {
+  workspaceRoot: string;
+}): LockfilePackageManager {
+  for (const { manager, lockfiles } of LOCKFILE_PROBE_ORDER) {
+    if (
+      lockfiles.some((lockfile) =>
+        existsSync(path.join(workspaceRoot, lockfile))
+      )
+    ) {
+      return manager;
+    }
+  }
+
+  return "npm";
+}
+
+function getUnderlyingLockfileName({
+  workspaceRoot
+}: {
+  workspaceRoot: string;
+}): string {
+  const manager = getUnderlyingLockfileManager({ workspaceRoot });
+
+  switch (manager) {
+    case "bun": {
+      if (existsSync(path.join(workspaceRoot, "bun.lock"))) {
+        return "bun.lock";
+      }
+      return "bun.lockb";
+    }
+    case "pnpm": {
+      return "pnpm-lock.yaml";
+    }
+    case "yarn": {
+      return "yarn.lock";
+    }
+    case "npm": {
+      return "package-lock.json";
+    }
+  }
+}
+
 function directoryInfo({ directory }: { directory: string }) {
   const dir = path.resolve(process.cwd(), directory);
   return { exists: existsSync(dir), absolute: dir };
@@ -523,6 +580,8 @@ export {
   expandWorkspaces,
   parseWorkspacePackages,
   getPnpmWorkspaces,
+  getUnderlyingLockfileManager,
+  getUnderlyingLockfileName,
   directoryInfo,
   getMainStep,
   isCompatibleWithBunWorkspaces,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds [nub](https://nub.dev) support to the JavaScript tooling, following the Rust implementation in #13120.

nub is recognized **only** through `packageManager` / `devEngines.packageManager` declarations (`"nub@x.y.z"`). It has no lockfile of its own; workspace and lockfile operations delegate to whichever underlying manager's lockfile is present (bun → pnpm → yarn → npm, defaulting to npm).

## Changes

### `@turbo/utils`
- Add `nub` to the `PackageManager` type
- Detect nub via `nub --version` in `getAvailablePackageManagers`
- Resolve nub binary path via `which nub` in `getPackageManagersBinPaths`

### `@turbo/workspaces`
- Add `nub` manager with declaration-only detection
- Add `getUnderlyingLockfileManager` / `getUnderlyingLockfileName` helpers mirroring Rust logic
- Register nub first in manager iteration so it wins over lockfile-based detectors
- Add nub install metadata and convert CLI option
- Handle nub in `convertLock` paths for npm/pnpm/yarn/bun managers

### `@turbo/codemod`
- Add nub upgrade/install command generation in migrate flow
- Add nub global install suggestion in CLI notify-update path