### PR TITLE
fix: Link ghostty-vt statically on Windows MSVC

### DIFF
--- a/crates/turborepo-ghostty-sys/build.rs
+++ b/crates/turborepo-ghostty-sys/build.rs
@@ -198,9 +198,9 @@ fn build_vendored(link_mode: LinkMode) {
     match link_mode {
         LinkMode::Dynamic => println!("cargo:rustc-link-lib=dylib=ghostty-vt"),
         LinkMode::Static => {
-            // MSVC resolves `static=ghostty-vt` to `ghostty-vt.lib`, which is the DLL import
-            // library. Link the actual static archive so release binaries do not depend on
-            // `ghostty-vt.dll` at runtime.
+            // MSVC resolves `static=ghostty-vt` to `ghostty-vt.lib`, which is the DLL
+            // import library. Link the actual static archive so release
+            // binaries do not depend on `ghostty-vt.dll` at runtime.
             if target.contains("windows") && target.contains("msvc") {
                 println!("cargo:rustc-link-lib=static=ghostty-vt-static");
             } else {

--- a/crates/turborepo-ghostty-sys/build.rs
+++ b/crates/turborepo-ghostty-sys/build.rs
@@ -197,7 +197,16 @@ fn build_vendored(link_mode: LinkMode) {
     }
     match link_mode {
         LinkMode::Dynamic => println!("cargo:rustc-link-lib=dylib=ghostty-vt"),
-        LinkMode::Static => println!("cargo:rustc-link-lib=static=ghostty-vt"),
+        LinkMode::Static => {
+            // MSVC resolves `static=ghostty-vt` to `ghostty-vt.lib`, which is the DLL import
+            // library. Link the actual static archive so release binaries do not depend on
+            // `ghostty-vt.dll` at runtime.
+            if target.contains("windows") && target.contains("msvc") {
+                println!("cargo:rustc-link-lib=static=ghostty-vt-static");
+            } else {
+                println!("cargo:rustc-link-lib=static=ghostty-vt");
+            }
+        }
     }
     emit_include_metadata(&[include_dir]);
 }


### PR DESCRIPTION
On MSVC, rustc resolves static=ghostty-vt to ghostty-vt.lib, which is the DLL import library rather than the static archive. That left release turbo.exe importing ghostty-vt.dll even though turborepo-ghostty-sys defaults to static linking.

Use static=ghostty-vt-static on Windows MSVC so published @turbo/windows-* packages do not require a runtime ghostty-vt.dll sidecar.

Fixes #13170