### PR TITLE
feat: Add nub to create-turbo options

### DIFF
--- a/packages/create-turbo/__tests__/index.test.ts
+++ b/packages/create-turbo/__tests__/index.test.ts
@@ -47,7 +47,8 @@ describe("create-turbo", () => {
     { packageManager: "yarn" },
     { packageManager: "npm" },
     { packageManager: "pnpm" },
-    { packageManager: "bun" }
+    { packageManager: "bun" },
+    { packageManager: "nub" }
   ])(
     "outputs expected console messages when using $packageManager (option)",
     async ({ packageManager }) => {
@@ -142,7 +143,8 @@ describe("create-turbo", () => {
     { packageManager: "yarn" },
     { packageManager: "npm" },
     { packageManager: "pnpm" },
-    { packageManager: "bun" }
+    { packageManager: "bun" },
+    { packageManager: "nub" }
   ])(
     "outputs expected console messages when using $packageManager (arg)",
     async ({ packageManager }) => {

--- a/packages/create-turbo/src/cli.ts
+++ b/packages/create-turbo/src/cli.ts
@@ -45,7 +45,7 @@ createTurboCli
     new Option(
       "-m, --package-manager <package-manager>",
       "Specify the package manager to use"
-    ).choices(["npm", "yarn", "pnpm", "bun"])
+    ).choices(["npm", "yarn", "pnpm", "bun", "nub"])
   )
   .option(
     "--skip-install",

--- a/packages/create-turbo/src/commands/create/prompts.ts
+++ b/packages/create-turbo/src/commands/create/prompts.ts
@@ -51,7 +51,8 @@ export async function packageManager({
       { pm: "npm", label: "npm" },
       { pm: "pnpm", label: "pnpm" },
       { pm: "yarn", label: "yarn" },
-      { pm: "bun", label: "bun" }
+      { pm: "bun", label: "bun" },
+      { pm: "nub", label: "nub" }
     ]
       .sort((a, b) => {
         const aInstalled = Boolean(


### PR DESCRIPTION
## Why
`create-turbo` already detects `nub`, but the interactive prompt and `--package-manager` validation did not expose it. Users could not select `nub` during project creation.

## What
Adds `nub` to the `create-turbo` package manager prompt, CLI option validation, and existing package manager test matrix.