### PR TITLE
fix: Normalize package manager versions

### DIFF
--- a/packages/turbo-workspaces/__tests__/utils.test.ts
+++ b/packages/turbo-workspaces/__tests__/utils.test.ts
@@ -5,7 +5,8 @@ import fs from "fs-extra";
 import type { Project } from "../src/types";
 import {
   getWorkspacePackageManager,
-  isCompatibleWithBunWorkspaces
+  isCompatibleWithBunWorkspaces,
+  setPackageManagerDeclaration
 } from "../src/utils";
 
 function makeWorkspace(packageJson: unknown): string {
@@ -17,6 +18,27 @@ function makeWorkspace(packageJson: unknown): string {
 }
 
 describe("utils", () => {
+  describe("setPackageManagerDeclaration", () => {
+    it("normalizes a leading v from package manager versions", () => {
+      const packageJson: {
+        name: string;
+        version: string;
+        devEngines?: { packageManager?: unknown };
+      } = { name: "test", version: "0.0.0" };
+
+      setPackageManagerDeclaration({
+        packageJson,
+        packageManager: "nub",
+        version: "v0.2.10"
+      });
+
+      expect(packageJson.devEngines?.packageManager).toEqual({
+        name: "nub",
+        version: "0.2.10"
+      });
+    });
+  });
+
   describe("isCompatibleWithBunWorkspace", () => {
     it.each([
       { globs: ["apps/*"], expected: true },

--- a/packages/turbo-workspaces/src/utils.ts
+++ b/packages/turbo-workspaces/src/utils.ts
@@ -237,6 +237,7 @@ function setPackageManagerDeclaration({
   packageManager: PackageManager;
   version: string;
 }): void {
+  const normalizedVersion = semver.valid(version) ?? version;
   delete packageJson.packageManager;
   const devEngines =
     packageJson.devEngines &&
@@ -248,7 +249,7 @@ function setPackageManagerDeclaration({
     ...devEngines,
     packageManager: {
       name: packageManager,
-      version
+      version: normalizedVersion
     }
   };
 }


### PR DESCRIPTION
## Why

Package managers can report versions with a leading `v`, but `devEngines.packageManager.version` must be an exact semver string without that prefix. This caused repos generated by `create-turbo` with `nub` to fail workspace resolution immediately.

## What

Normalize package manager versions before writing `devEngines.packageManager`.

## How

Added a regression test for a `v0.2.10` package manager version and verified `@turbo/workspaces` tests/typecheck.