### PR TITLE
fix: Support nub native lockfiles

### DIFF
--- a/crates/turborepo-repository/src/discovery.rs
+++ b/crates/turborepo-repository/src/discovery.rs
@@ -125,7 +125,8 @@ impl PackageDiscoveryBuilder for LocalPackageDiscoveryBuilder {
                     PackageJson::load(&self.repo_root.join_component("package.json"))
                 })?;
                 if self.allow_missing_package_manager {
-                    PackageManager::detect_package_manager(&self.repo_root)?
+                    PackageManager::get_package_manager(&self.repo_root, &package_json)
+                        .or_else(|_| PackageManager::detect_package_manager(&self.repo_root))?
                 } else {
                     PackageManager::get_package_manager(&self.repo_root, &package_json)?
                 }

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -155,9 +155,13 @@ where
 
         // If no pre-supplied lockfile, start reading it on a blocking thread
         // concurrently with package discovery + JSON parsing.
-        let known_pm = self.package_manager.take().or_else(|| {
-            PackageManager::get_package_manager(self.repo_root, &self.root_package_json).ok()
-        });
+        let known_pm = self
+            .package_manager
+            .take()
+            .or_else(|| {
+                PackageManager::get_package_manager(self.repo_root, &self.root_package_json).ok()
+            })
+            .map(|pm| pm.with_resolved_nub_lockfile(self.repo_root));
         let lockfile_future = if !is_single_package && self.lockfile.is_none() {
             if let Some(pm) = known_pm {
                 let repo_root = self.repo_root.to_owned();

--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -378,7 +378,7 @@ impl PackageManager {
                     })?
                 } else {
                     let package_json_text =
-                        fs::read_to_string(self.workspace_glob_source(root_path))?;
+                        fs::read_to_string(root_path.join_component("package.json"))?;
                     let package_json: PackageJsonWorkspaces =
                         serde_json::from_str(&package_json_text).map_err(|_| {
                             Error::Workspace(MissingWorkspaceError::from(self.clone()))
@@ -847,7 +847,17 @@ impl PackageManager {
     /// Try to detect package manager based on configuration files and binaries
     /// installed on the system.
     pub fn detect_package_manager(repo_root: &AbsoluteSystemPath) -> Result<Self, Error> {
-        let detected_package_managers = PnpmDetector::new(repo_root)
+        let native_nub =
+            repo_root
+                .join_component(nub::LOCKFILE)
+                .exists()
+                .then(|| PackageManager::Nub {
+                    lockfile: Box::new(nub::underlying_lockfile_manager(repo_root)),
+                });
+        let detected_package_managers = native_nub
+            .into_iter()
+            .map(Ok)
+            .chain(PnpmDetector::new(repo_root))
             .chain(NpmDetector::new(repo_root))
             .chain(YarnDetector::new(repo_root))
             .chain(BunDetector::new(repo_root))
@@ -941,6 +951,10 @@ impl PackageManager {
         root_package_json: &PackageJson,
     ) -> Result<Box<dyn Lockfile>, Error> {
         if let PackageManager::Nub { lockfile } = self {
+            if root_path.join_component(nub::LOCKFILE).exists() {
+                let contents = root_path.join_component(nub::LOCKFILE).read()?;
+                return lockfile.parse_lockfile(root_package_json, &contents, None);
+            }
             return lockfile.read_lockfile(root_path, root_package_json);
         }
 
@@ -1103,6 +1117,12 @@ impl PackageManager {
     }
 
     pub fn lockfile_path(&self, turbo_root: &AbsoluteSystemPath) -> AbsoluteSystemPathBuf {
+        if matches!(self, PackageManager::Nub { .. })
+            && turbo_root.join_component(nub::LOCKFILE).exists()
+        {
+            return turbo_root.join_component(nub::LOCKFILE);
+        }
+
         turbo_root.join_component(self.lockfile_name())
     }
 
@@ -1619,6 +1639,48 @@ mod tests {
     }
 
     #[test]
+    fn test_native_nub_lockfile_does_not_affect_existing_lockfile_detection() -> Result<(), Error> {
+        let (_dir, repo_root) = temp_repo_root()?;
+        std::fs::write(repo_root.join_component(npm::LOCKFILE).as_std_path(), "{}")?;
+
+        assert_eq!(
+            PackageManager::detect_package_manager(&repo_root)?,
+            PackageManager::Npm
+        );
+
+        std::fs::remove_file(repo_root.join_component(npm::LOCKFILE).as_std_path())?;
+        std::fs::write(
+            repo_root.join_component(pnpm::LOCKFILE).as_std_path(),
+            "lockfileVersion: '9.0'\nimporters:\n  .: {}\n",
+        )?;
+
+        assert_eq!(
+            PackageManager::detect_package_manager(&repo_root)?,
+            PackageManager::Pnpm
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_native_nub_lockfile_with_existing_lockfile_is_ambiguous() -> Result<(), Error> {
+        let (_dir, repo_root) = temp_repo_root()?;
+        std::fs::write(
+            repo_root.join_component(nub::LOCKFILE).as_std_path(),
+            "lockfileVersion: '9.0'\nimporters:\n  .: {}\n",
+        )?;
+        std::fs::write(
+            repo_root.join_component(pnpm::LOCKFILE).as_std_path(),
+            "lockfileVersion: '9.0'\nimporters:\n  .: {}\n",
+        )?;
+
+        assert!(matches!(
+            PackageManager::detect_package_manager(&repo_root),
+            Err(Error::MultiplePackageManagers { .. })
+        ));
+        Ok(())
+    }
+
+    #[test]
     fn test_dev_engines_nub_matches_underlying_pnpm_lockfile() -> Result<(), Error> {
         let (_dir, repo_root) = temp_repo_root()?;
         repo_root.join_component(pnpm::LOCKFILE).create()?;
@@ -1632,6 +1694,56 @@ mod tests {
                 lockfile: Box::new(PackageManager::Pnpm)
             }
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_dev_engines_nub_native_lockfile_uses_package_json_workspaces() -> Result<(), Error> {
+        let (_dir, repo_root) = temp_repo_root()?;
+        std::fs::create_dir_all(repo_root.join_components(&["apps", "web"]).as_std_path())?;
+        std::fs::write(
+            repo_root.join_component("package.json").as_std_path(),
+            r#"{
+  "devEngines": {
+    "packageManager": {
+      "name": "nub",
+      "version": "0.2.10"
+    }
+  },
+  "workspaces": ["apps/*"]
+}"#,
+        )?;
+        std::fs::write(
+            repo_root
+                .join_components(&["apps", "web", "package.json"])
+                .as_std_path(),
+            r#"{"name":"web"}"#,
+        )?;
+        std::fs::write(
+            repo_root.join_component(nub::LOCKFILE).as_std_path(),
+            "lockfileVersion: '9.0'\nimporters:\n  .: {}\n",
+        )?;
+        let package_json = PackageJson::load(&repo_root.join_component("package.json"))?;
+
+        let package_manager = PackageManager::read_package_manager(&repo_root, &package_json)?;
+        let found: HashSet<AbsoluteSystemPathBuf> =
+            HashSet::from_iter(package_manager.get_package_jsons(&repo_root)?);
+
+        assert_eq!(
+            package_manager,
+            PackageManager::Nub {
+                lockfile: Box::new(PackageManager::Pnpm9)
+            }
+        );
+        assert_eq!(
+            found,
+            HashSet::from_iter([repo_root.join_components(&["apps", "web", "package.json"])])
+        );
+        assert_eq!(
+            package_manager.lockfile_path(&repo_root),
+            repo_root.join_component(nub::LOCKFILE)
+        );
+        package_manager.read_lockfile(&repo_root, &package_json)?;
         Ok(())
     }
 
@@ -1687,6 +1799,41 @@ mod tests {
         let response = discovery.discover_packages().await.unwrap();
 
         assert_eq!(response.package_manager, PackageManager::Npm);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_allow_no_package_manager_uses_valid_dev_engines_nub() -> Result<(), Error> {
+        let (_dir, repo_root) = temp_repo_root()?;
+        std::fs::write(
+            repo_root.join_component("package.json").as_std_path(),
+            r#"{
+  "devEngines": {
+    "packageManager": {
+      "name": "nub",
+      "version": "0.2.10"
+    }
+  },
+  "workspaces": []
+}"#,
+        )?;
+        std::fs::write(
+            repo_root.join_component(nub::LOCKFILE).as_std_path(),
+            "lockfileVersion: '9.0'\nimporters:\n  .: {}\n",
+        )?;
+        let package_json = dev_engines_package_manager(json!("nub"), json!("0.2.10"));
+        let mut builder = LocalPackageDiscoveryBuilder::new(repo_root, None, Some(package_json));
+        builder.with_allow_no_package_manager(true);
+
+        let discovery = builder.build()?;
+        let response = discovery.discover_packages().await.unwrap();
+
+        assert_eq!(
+            response.package_manager,
+            PackageManager::Nub {
+                lockfile: Box::new(PackageManager::Pnpm9)
+            }
+        );
         Ok(())
     }
 

--- a/crates/turborepo-repository/src/package_manager/nub.rs
+++ b/crates/turborepo-repository/src/package_manager/nub.rs
@@ -4,9 +4,9 @@
 //! Node and ships a pnpm-compatible package-manager command surface. Unlike the
 //! other supported package managers, nub does not define its own lockfile
 //! format: it is lockfile-compatible with whatever the project already uses
-//! (npm, pnpm, yarn, or bun). For that reason nub is recognized only through
-//! the `packageManager` field in `package.json` (`"nub@x.y.z"`); there is no
-//! file-based detector, since a bare foreign lockfile alone does not imply nub.
+//! (npm, pnpm, yarn, or bun). For that reason nub is recognized through the
+//! `packageManager` field in `package.json` (`"nub@x.y.z"`) or nub's native
+//! `lock.yaml`; a bare foreign lockfile alone does not imply nub.
 //!
 //! Because Turborepo needs a parsed lockfile for pruning and cache hashing, the
 //! [`PackageManager::Nub`] variant carries the concrete package manager whose
@@ -17,6 +17,8 @@ use turbopath::AbsoluteSystemPath;
 
 use crate::package_manager::{PackageManager, bun, pnpm, yarn, yarn::YarnDetector};
 
+pub const LOCKFILE: &str = "lock.yaml";
+
 /// Determine which package manager's lockfile is present in the repository
 /// root, in priority order. Defaults to npm when no lockfile is found yet (e.g.
 /// a fresh nub project before the first install), matching nub's npm-compatible
@@ -24,6 +26,12 @@ use crate::package_manager::{PackageManager, bun, pnpm, yarn, yarn::YarnDetector
 pub fn underlying_lockfile_manager(repo_root: &AbsoluteSystemPath) -> PackageManager {
     if repo_root.join_component(bun::LOCKFILE).exists() {
         PackageManager::Bun
+    } else if repo_root.join_component(LOCKFILE).exists() {
+        repo_root
+            .join_component(LOCKFILE)
+            .read()
+            .map(|contents| pnpm::detect_from_lockfile_contents(&contents))
+            .unwrap_or(PackageManager::Pnpm)
     } else if repo_root.join_component(pnpm::LOCKFILE).exists() {
         pnpm::detect_from_lockfile(repo_root).unwrap_or(PackageManager::Pnpm)
     } else if repo_root.join_component(yarn::LOCKFILE).exists() {
@@ -58,7 +66,7 @@ mod tests {
         let detected = PackageManager::detect_package_manager(&repo_root).unwrap();
         assert_eq!(detected, PackageManager::Npm);
 
-        // The `packageManager` field is the only signal for nub.
+        // A foreign lockfile alone must not imply nub.
         let package_json = PackageJson {
             package_manager: Some(Spanned::new("nub@0.1.0".to_string())),
             ..Default::default()
@@ -118,6 +126,40 @@ mod tests {
         assert_eq!(
             underlying_lockfile_manager(&repo_root),
             PackageManager::Pnpm9
+        );
+    }
+
+    #[test]
+    fn test_nub_underlying_native_lockfile_detects_pnpm9() {
+        let dir = tempdir().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(dir.path()).unwrap();
+
+        repo_root
+            .join_component(LOCKFILE)
+            .create_with_contents("lockfileVersion: '9.0'\n")
+            .unwrap();
+
+        assert_eq!(
+            underlying_lockfile_manager(&repo_root),
+            PackageManager::Pnpm9
+        );
+    }
+
+    #[test]
+    fn test_nub_detected_from_native_lockfile() {
+        let dir = tempdir().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(dir.path()).unwrap();
+
+        repo_root
+            .join_component(LOCKFILE)
+            .create_with_contents("lockfileVersion: '9.0'\n")
+            .unwrap();
+
+        assert_eq!(
+            PackageManager::detect_package_manager(&repo_root).unwrap(),
+            PackageManager::Nub {
+                lockfile: Box::new(PackageManager::Pnpm9)
+            }
         );
     }
 }


### PR DESCRIPTION
## Why

Nub-native repos declare `devEngines.packageManager.name = nub` and use `lock.yaml`. Turbo only handled nub when it could delegate to an inferred existing lockfile, so native nub repos could be misdetected and schedule root tasks incorrectly.

## What

Adds native `lock.yaml` recognition for nub while preserving existing package manager detection when no nub lockfile is present. Nub lockfile reads and lockfile paths now use `lock.yaml` when available, and nub workspace discovery falls back to root `package.json` workspaces when there is no `pnpm-workspace.yaml`.