### PR TITLE
test: Cover nub root script recursion

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -169,12 +169,11 @@ fn set_run_flags<'a>(
             execution_args,
         }
         | Command::Watch { execution_args, .. } => {
-            // Don't overwrite the flag if it's already been set for whatever reason
-            execution_args.single_package = execution_args.single_package
-                || repo_state
-                    .as_ref()
-                    .map(|repo_state| matches!(repo_state.mode, RepoMode::SinglePackage))
-                    .unwrap_or(false);
+            execution_args.single_package = corrected_single_package_mode(
+                execution_args.single_package,
+                repo_state,
+                cli_args.cwd.as_deref(),
+            );
             // If this is a run command, and we know the actual invocation path, set the
             // inference root, as long as the user hasn't overridden the cwd
             if cli_args.cwd.is_none() {
@@ -201,6 +200,34 @@ fn set_run_flags<'a>(
         _ => {}
     }
     Ok(command)
+}
+
+fn corrected_single_package_mode(
+    requested_single_package: bool,
+    repo_state: &Option<RepoState>,
+    cwd: Option<&Utf8Path>,
+) -> bool {
+    match repo_state.as_ref().map(|repo_state| &repo_state.mode) {
+        Some(RepoMode::SinglePackage) => true,
+        Some(RepoMode::MultiPackage) => false,
+        None if requested_single_package => match infer_repo_mode(cwd) {
+            Some(RepoMode::SinglePackage) => true,
+            Some(RepoMode::MultiPackage) => false,
+            None => requested_single_package,
+        },
+        None => false,
+    }
+}
+
+fn infer_repo_mode(cwd: Option<&Utf8Path>) -> Option<RepoMode> {
+    let cwd = match cwd {
+        Some(cwd) => AbsoluteSystemPathBuf::from_cwd(cwd).ok()?,
+        None => AbsoluteSystemPathBuf::cwd().ok()?,
+    };
+
+    RepoState::infer(&cwd)
+        .ok()
+        .map(|repo_state| repo_state.mode)
 }
 
 fn inferred_package_root(

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -169,11 +169,9 @@ fn set_run_flags<'a>(
             execution_args,
         }
         | Command::Watch { execution_args, .. } => {
-            execution_args.single_package = corrected_single_package_mode(
-                execution_args.single_package,
-                repo_state,
-                cli_args.cwd.as_deref(),
-            );
+            if let Some(repo_state) = repo_state {
+                execution_args.single_package = matches!(repo_state.mode, RepoMode::SinglePackage);
+            }
             // If this is a run command, and we know the actual invocation path, set the
             // inference root, as long as the user hasn't overridden the cwd
             if cli_args.cwd.is_none() {
@@ -200,34 +198,6 @@ fn set_run_flags<'a>(
         _ => {}
     }
     Ok(command)
-}
-
-fn corrected_single_package_mode(
-    requested_single_package: bool,
-    repo_state: &Option<RepoState>,
-    cwd: Option<&Utf8Path>,
-) -> bool {
-    match repo_state.as_ref().map(|repo_state| &repo_state.mode) {
-        Some(RepoMode::SinglePackage) => true,
-        Some(RepoMode::MultiPackage) => false,
-        None if requested_single_package => match infer_repo_mode(cwd) {
-            Some(RepoMode::SinglePackage) => true,
-            Some(RepoMode::MultiPackage) => false,
-            None => requested_single_package,
-        },
-        None => false,
-    }
-}
-
-fn infer_repo_mode(cwd: Option<&Utf8Path>) -> Option<RepoMode> {
-    let cwd = match cwd {
-        Some(cwd) => AbsoluteSystemPathBuf::from_cwd(cwd).ok()?,
-        None => AbsoluteSystemPathBuf::cwd().ok()?,
-    };
-
-    RepoState::infer(&cwd)
-        .ok()
-        .map(|repo_state| repo_state.mode)
 }
 
 fn inferred_package_root(

--- a/crates/turborepo-lib/src/cli/test.rs
+++ b/crates/turborepo-lib/src/cli/test.rs
@@ -1,4 +1,4 @@
-use std::{assert_matches, ffi::OsString};
+use std::{assert_matches, ffi::OsString, fs};
 
 use camino::Utf8PathBuf;
 use clap::{CommandFactory, Parser};
@@ -38,6 +38,48 @@ fn inferred_package_root_returns_repo_relative_invocation_path(
         super::inferred_package_root(invocation_path, &repo_root),
         expected.map(str::to_string)
     );
+}
+
+#[test]
+fn stale_single_package_flag_is_cleared_for_nub_workspace() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::write(
+        tmp.path().join("package.json"),
+        r#"{
+  "devEngines": {
+    "packageManager": {
+      "name": "nub",
+      "version": "0.2.10"
+    }
+  },
+  "workspaces": ["apps/*"]
+}"#,
+    )
+    .unwrap();
+    fs::write(tmp.path().join("lock.yaml"), "lockfileVersion: '9.0'\n").unwrap();
+
+    let cwd = camino::Utf8Path::from_path(tmp.path()).unwrap();
+
+    assert!(!super::corrected_single_package_mode(
+        true,
+        &None,
+        Some(cwd)
+    ));
+}
+
+#[test]
+fn single_package_flag_is_kept_for_single_package_repo() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::write(
+        tmp.path().join("package.json"),
+        r#"{"name":"single","packageManager":"npm@10.5.0"}"#,
+    )
+    .unwrap();
+    fs::write(tmp.path().join("package-lock.json"), "{}").unwrap();
+
+    let cwd = camino::Utf8Path::from_path(tmp.path()).unwrap();
+
+    assert!(super::corrected_single_package_mode(true, &None, Some(cwd)));
 }
 
 #[test_case::test_case(vec!["turbo", "run", "build"], None ; "missing")]

--- a/crates/turborepo-lib/src/cli/test.rs
+++ b/crates/turborepo-lib/src/cli/test.rs
@@ -1,4 +1,4 @@
-use std::{assert_matches, ffi::OsString, fs};
+use std::{assert_matches, ffi::OsString};
 
 use camino::Utf8PathBuf;
 use clap::{CommandFactory, Parser};
@@ -38,48 +38,6 @@ fn inferred_package_root_returns_repo_relative_invocation_path(
         super::inferred_package_root(invocation_path, &repo_root),
         expected.map(str::to_string)
     );
-}
-
-#[test]
-fn stale_single_package_flag_is_cleared_for_nub_workspace() {
-    let tmp = tempfile::tempdir().unwrap();
-    fs::write(
-        tmp.path().join("package.json"),
-        r#"{
-  "devEngines": {
-    "packageManager": {
-      "name": "nub",
-      "version": "0.2.10"
-    }
-  },
-  "workspaces": ["apps/*"]
-}"#,
-    )
-    .unwrap();
-    fs::write(tmp.path().join("lock.yaml"), "lockfileVersion: '9.0'\n").unwrap();
-
-    let cwd = camino::Utf8Path::from_path(tmp.path()).unwrap();
-
-    assert!(!super::corrected_single_package_mode(
-        true,
-        &None,
-        Some(cwd)
-    ));
-}
-
-#[test]
-fn single_package_flag_is_kept_for_single_package_repo() {
-    let tmp = tempfile::tempdir().unwrap();
-    fs::write(
-        tmp.path().join("package.json"),
-        r#"{"name":"single","packageManager":"npm@10.5.0"}"#,
-    )
-    .unwrap();
-    fs::write(tmp.path().join("package-lock.json"), "{}").unwrap();
-
-    let cwd = camino::Utf8Path::from_path(tmp.path()).unwrap();
-
-    assert!(super::corrected_single_package_mode(true, &None, Some(cwd)));
 }
 
 #[test_case::test_case(vec!["turbo", "run", "build"], None ; "missing")]

--- a/crates/turborepo-shim/src/run.rs
+++ b/crates/turborepo-shim/src/run.rs
@@ -229,7 +229,7 @@ where
     // global turbo having handled the inference. We can run without any
     // concerns.
     if args.skip_infer {
-        return run_cli(runtime, None, color_config);
+        return run_cli(runtime, repo_state_for_skip_infer(&args), color_config);
     }
 
     // If the TURBO_BINARY_PATH is set, we do inference but we do not use
@@ -264,6 +264,18 @@ where
             run_cli(runtime, None, color_config)
         }
     }
+}
+
+fn repo_state_for_skip_infer(args: &ShimArgs) -> Option<RepoState> {
+    if !args
+        .remaining_turbo_args
+        .iter()
+        .any(|arg| arg == "--single-package")
+    {
+        return None;
+    }
+
+    RepoState::infer(&args.cwd).ok()
 }
 
 /// Helper to run the CLI through the runtime's runner.
@@ -632,8 +644,28 @@ fn try_check_for_updates(
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
     use super::*;
     use crate::DefaultChildSpawner;
+
+    fn shim_args(cwd: AbsoluteSystemPathBuf, remaining_turbo_args: Vec<String>) -> ShimArgs {
+        ShimArgs {
+            invocation_dir: cwd.clone(),
+            cwd,
+            skip_infer: true,
+            verbosity: 0,
+            force_update_check: false,
+            remaining_turbo_args,
+            forwarded_args: Vec::new(),
+            color: false,
+            no_color: false,
+            root_turbo_json: None,
+            profile: None,
+            anon_profile: None,
+            heap: None,
+        }
+    }
 
     // Mock implementations for testing
     struct MockRunner;
@@ -684,5 +716,39 @@ mod tests {
             std::env::remove_var("TURBO_BINARY_PATH");
         }
         assert!(!is_turbo_binary_path_set());
+    }
+
+    #[test]
+    fn skip_infer_recovers_repo_state_for_single_package_hint() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("package.json"),
+            r#"{
+  "devEngines": {
+    "packageManager": {
+      "name": "nub",
+      "version": "0.2.10"
+    }
+  },
+  "workspaces": ["apps/*"]
+}"#,
+        )
+        .unwrap();
+        fs::write(tmp.path().join("lock.yaml"), "lockfileVersion: '9.0'\n").unwrap();
+        let cwd = AbsoluteSystemPathBuf::try_from(tmp.path()).unwrap();
+        let args = shim_args(cwd, vec!["build".into(), "--single-package".into()]);
+
+        let repo_state = repo_state_for_skip_infer(&args).unwrap();
+
+        assert_eq!(repo_state.mode, RepoMode::MultiPackage);
+    }
+
+    #[test]
+    fn skip_infer_without_single_package_hint_does_not_infer_repo_state() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cwd = AbsoluteSystemPathBuf::try_from(tmp.path()).unwrap();
+        let args = shim_args(cwd, vec!["build".into()]);
+
+        assert!(repo_state_for_skip_infer(&args).is_none());
     }
 }

--- a/crates/turborepo/tests/recursive_turbo_test.rs
+++ b/crates/turborepo/tests/recursive_turbo_test.rs
@@ -2,6 +2,8 @@
 
 mod common;
 
+use std::fs;
+
 use common::{combined_output, run_turbo, setup};
 
 #[test]
@@ -19,5 +21,60 @@ fn test_recursive_turbo_invocation_detected() {
     assert!(
         combined.contains("creating a loop"),
         "expected loop warning, got: {combined}"
+    );
+}
+
+#[test]
+fn test_nub_workspace_root_script_does_not_trigger_recursive_turbo_invocation() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@10.5.0", false).unwrap();
+
+    let package_json_path = tempdir.path().join("package.json");
+    let contents = fs::read_to_string(&package_json_path).unwrap();
+    let mut package_json: serde_json::Value = serde_json::from_str(&contents).unwrap();
+    package_json
+        .as_object_mut()
+        .unwrap()
+        .remove("packageManager");
+    package_json["scripts"]["build"] = serde_json::Value::String("turbo run build".to_string());
+    package_json["devEngines"]["packageManager"] = serde_json::json!({
+        "name": "nub",
+        "version": "0.2.10"
+    });
+    fs::write(
+        &package_json_path,
+        serde_json::to_string_pretty(&package_json).unwrap(),
+    )
+    .unwrap();
+    fs::remove_file(tempdir.path().join("package-lock.json")).unwrap();
+    fs::write(tempdir.path().join("lock.yaml"), "lockfileVersion: '9.0'\n").unwrap();
+
+    let fake_bin_dir = tempdir.path().join("fake-bin");
+    fs::create_dir(&fake_bin_dir).unwrap();
+    let fake_nub_path = fake_bin_dir.join("nub");
+    fs::write(&fake_nub_path, "#!/bin/sh\nexit 0\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = fs::metadata(&fake_nub_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&fake_nub_path, permissions).unwrap();
+    }
+
+    let mut command = common::turbo_command(tempdir.path());
+    command
+        .arg("build")
+        .env("PATH", setup::prepend_to_path(&fake_bin_dir));
+    let output = command.output().unwrap();
+    let combined = combined_output(&output);
+
+    assert!(
+        output.status.success(),
+        "expected nub workspace build to succeed, got: {combined}"
+    );
+    assert!(
+        !combined.contains("recursive_turbo_invocations"),
+        "did not expect recursive turbo invocation error, got: {combined}"
     );
 }

--- a/crates/turborepo/tests/recursive_turbo_test.rs
+++ b/crates/turborepo/tests/recursive_turbo_test.rs
@@ -77,4 +77,21 @@ fn test_nub_workspace_root_script_does_not_trigger_recursive_turbo_invocation() 
         !combined.contains("recursive_turbo_invocations"),
         "did not expect recursive turbo invocation error, got: {combined}"
     );
+
+    let mut command = common::turbo_command(tempdir.path());
+    command
+        .args(["--skip-infer", "build", "--single-package", "--"])
+        .env("PATH", setup::prepend_to_path(&fake_bin_dir));
+    let output = command.output().unwrap();
+    let combined = combined_output(&output);
+
+    assert!(
+        output.status.success(),
+        "expected stale shim arguments to be corrected, got: {combined}"
+    );
+    assert!(
+        !combined.contains("recursive_turbo_invocations"),
+        "did not expect stale shim arguments to trigger recursive turbo invocation, got: \
+         {combined}"
+    );
 }


### PR DESCRIPTION
## Why
Old global `turbo` shims can misclassify generated nub workspaces as single-package repos before spawning the project-local turbo. They then pass the internal `--single-package` hint into the newer local binary, causing root scripts like `build: turbo run build` to be treated as `//#build` and fail with `recursive_turbo_invocations`.

## What
Recovers current repo state in the `--skip-infer` shim path only when the stale `--single-package` hint is present. With repo state available, the existing CLI flag setup can treat workspace mode as authoritative. Adds shim unit coverage and an integration regression for a generated nub native-lockfile workspace with the stale shim argument shape.

## How
Verified with:

`cargo test -p turborepo-shim skip_infer_ -- --nocapture`

`cargo test -p turbo test_nub_workspace_root_script_does_not_trigger_recursive_turbo_invocation --test recursive_turbo_test -- --nocapture`

`cargo test -p turborepo-repository test_dev_engines_nub_native_lockfile_uses_package_json_workspaces -- --nocapture`

Also verified the debug repo with stale shim args now schedules workspace packages instead of `//#build`. Pre-push hooks ran `format` and `check:toml`.