### PR TITLE
feat: Add aube package manager support

### DIFF
--- a/crates/turborepo-daemon/src/lib.rs
+++ b/crates/turborepo-daemon/src/lib.rs
@@ -228,6 +228,9 @@ pub mod proto {
                 PackageManager::Nub => Self::Nub {
                     lockfile: Box::new(Self::Npm),
                 },
+                PackageManager::Aube => Self::Aube {
+                    lockfile: Box::new(Self::Npm),
+                },
             }
         }
     }
@@ -243,6 +246,7 @@ pub mod proto {
                 turborepo_repository::package_manager::PackageManager::Pnpm9 => Self::Pnpm9,
                 turborepo_repository::package_manager::PackageManager::Bun => Self::Bun,
                 turborepo_repository::package_manager::PackageManager::Nub { .. } => Self::Nub,
+                turborepo_repository::package_manager::PackageManager::Aube { .. } => Self::Aube,
             }
         }
     }

--- a/crates/turborepo-daemon/src/proto/turbod.proto
+++ b/crates/turborepo-daemon/src/proto/turbod.proto
@@ -136,6 +136,7 @@ enum PackageManager {
   Bun = 5;
   Pnpm9 = 6;
   Nub = 7;
+  Aube = 8;
 }
 
 message GetFileHashesRequest {

--- a/crates/turborepo-filewatch/src/package_watcher.rs
+++ b/crates/turborepo-filewatch/src/package_watcher.rs
@@ -178,7 +178,10 @@ enum State {
 // or going from no package manager to some package manager.
 const INVALIDATION_PATHS: &[&str] = &[
     "package.json",
+    package_manager::aube::WORKSPACE_CONFIGURATION_PATH,
+    package_manager::aube::LOCKFILE,
     "pnpm-workspace.yaml",
+    package_manager::nub::LOCKFILE,
     package_manager::pnpm::LOCKFILE,
     package_manager::npm::LOCKFILE,
     package_manager::yarn::LOCKFILE,

--- a/crates/turborepo-lib/src/commands/generate.rs
+++ b/crates/turborepo-lib/src/commands/generate.rs
@@ -72,6 +72,10 @@ fn turbo_gen_command(package_manager: &PackageManager, tag: &str) -> PackageMana
             executable: "nubx",
             args: vec![package],
         },
+        PackageManager::Aube { .. } => PackageManagerCommand {
+            executable: "aubx",
+            args: vec![package],
+        },
     }
 }
 

--- a/crates/turborepo-repository/src/package_manager/aube.rs
+++ b/crates/turborepo-repository/src/package_manager/aube.rs
@@ -7,7 +7,7 @@
 
 use turbopath::AbsoluteSystemPath;
 
-use crate::package_manager::{PackageManager, bun, npm, pnpm, yarn, yarn::YarnDetector};
+use crate::package_manager::{PackageManager, bun, pnpm, yarn, yarn::YarnDetector};
 
 pub const LOCKFILE: &str = "aube-lock.yaml";
 pub const WORKSPACE_CONFIGURATION_PATH: &str = "aube-workspace.yaml";
@@ -31,8 +31,6 @@ pub fn underlying_lockfile_manager(repo_root: &AbsoluteSystemPath) -> PackageMan
         YarnDetector::new(repo_root)
             .detect_from_lockfile()
             .unwrap_or(PackageManager::Yarn)
-    } else if repo_root.join_component(npm::LOCKFILE).exists() {
-        PackageManager::Npm
     } else {
         PackageManager::Npm
     }

--- a/crates/turborepo-repository/src/package_manager/aube.rs
+++ b/crates/turborepo-repository/src/package_manager/aube.rs
@@ -1,0 +1,71 @@
+//! aube support.
+//!
+//! aube (<https://aube.jdx.dev>) reads and writes existing package-manager
+//! lockfiles in place, and uses `aube-lock.yaml` for new aube-first projects.
+//! Turborepo keeps aube's CLI identity while delegating lockfile operations to
+//! the concrete lockfile format present in the repository.
+
+use turbopath::AbsoluteSystemPath;
+
+use crate::package_manager::{PackageManager, bun, npm, pnpm, yarn, yarn::YarnDetector};
+
+pub const LOCKFILE: &str = "aube-lock.yaml";
+pub const WORKSPACE_CONFIGURATION_PATH: &str = "aube-workspace.yaml";
+
+/// Determine which package manager's lockfile is present in the repository
+/// root, using aube's documented write precedence. Defaults to npm when no
+/// lockfile is found yet because npm-family lockfile operations are the least
+/// surprising fallback for an empty project.
+pub fn underlying_lockfile_manager(repo_root: &AbsoluteSystemPath) -> PackageManager {
+    if repo_root.join_component(LOCKFILE).exists() {
+        repo_root
+            .join_component(LOCKFILE)
+            .read()
+            .map(|contents| pnpm::detect_from_lockfile_contents(&contents))
+            .unwrap_or(PackageManager::Pnpm9)
+    } else if repo_root.join_component(pnpm::LOCKFILE).exists() {
+        pnpm::detect_from_lockfile(repo_root).unwrap_or(PackageManager::Pnpm)
+    } else if repo_root.join_component(bun::LOCKFILE).exists() {
+        PackageManager::Bun
+    } else if repo_root.join_component(yarn::LOCKFILE).exists() {
+        YarnDetector::new(repo_root)
+            .detect_from_lockfile()
+            .unwrap_or(PackageManager::Yarn)
+    } else if repo_root.join_component(npm::LOCKFILE).exists() {
+        PackageManager::Npm
+    } else {
+        PackageManager::Npm
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+    use turbopath::AbsoluteSystemPathBuf;
+
+    use super::*;
+    use crate::package_manager::{PackageManager, pnpm};
+
+    #[test]
+    fn test_aube_underlying_lockfile_resolution() {
+        let dir = tempdir().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(dir.path()).unwrap();
+
+        assert_eq!(underlying_lockfile_manager(&repo_root), PackageManager::Npm);
+
+        repo_root.join_component(pnpm::LOCKFILE).create().unwrap();
+        assert_eq!(
+            underlying_lockfile_manager(&repo_root),
+            PackageManager::Pnpm
+        );
+
+        repo_root
+            .join_component(LOCKFILE)
+            .create_with_contents("lockfileVersion: '9.0'\n")
+            .unwrap();
+        assert_eq!(
+            underlying_lockfile_manager(&repo_root),
+            PackageManager::Pnpm9
+        );
+    }
+}

--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -1,3 +1,4 @@
+pub mod aube;
 pub mod berry;
 pub mod bun;
 pub mod npm;
@@ -79,6 +80,12 @@ pub enum PackageManager {
     Nub {
         lockfile: Box<PackageManager>,
     },
+    /// aube (<https://aube.jdx.dev>) reads and writes existing lockfile formats
+    /// in place. `lockfile` holds the concrete package manager whose lockfile
+    /// is present in the repository, which lockfile operations delegate to.
+    Aube {
+        lockfile: Box<PackageManager>,
+    },
 }
 
 #[derive(Debug)]
@@ -124,6 +131,10 @@ impl Display for MissingWorkspaceError {
             PackageManager::Nub { .. } => {
                 "package.json: no workspaces found. Turborepo requires workspaces to be defined in \
                  the root package.json"
+            }
+            PackageManager::Aube { .. } => {
+                "aube-workspace.yaml or package.json: no packages found. Turborepo requires \
+                 workspaces to be defined in the root aube-workspace.yaml or package.json"
             }
         };
         write!(f, "{err}")
@@ -239,7 +250,7 @@ impl From<std::convert::Infallible> for Error {
 }
 
 static PACKAGE_MANAGER_PATTERN: Lazy<Regex> = lazy_regex!(
-    r"\A(?P<manager>bun|npm|nub|pnpm|yarn)@(?P<version>\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?|https?://\S+)\z"
+    r"\A(?P<manager>aube|bun|npm|nub|pnpm|yarn)@(?P<version>\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?|https?://\S+)\z"
 );
 
 static DEV_ENGINES_VERSION_PATTERN: Lazy<Regex> =
@@ -249,6 +260,7 @@ impl PackageManager {
     /// Returns the package manager responsible for lockfile operations.
     pub fn lockfile_manager(&self) -> &PackageManager {
         match self {
+            PackageManager::Aube { lockfile } => lockfile.as_ref(),
             PackageManager::Nub { lockfile } => lockfile.as_ref(),
             other => other,
         }
@@ -262,11 +274,14 @@ impl PackageManager {
         )
     }
 
-    /// Re-resolves the underlying lockfile manager for [`PackageManager::Nub`]
-    /// from disk. No-op for other variants. Call after daemon proto round-trips
-    /// that cannot carry the underlying lockfile type.
+    /// Re-resolves the underlying lockfile manager for wrapper managers from
+    /// disk. No-op for other variants. Call after daemon proto round-trips that
+    /// cannot carry the underlying lockfile type.
     pub fn with_resolved_nub_lockfile(self, repo_root: &AbsoluteSystemPath) -> Self {
         match self {
+            PackageManager::Aube { .. } => PackageManager::Aube {
+                lockfile: Box::new(aube::underlying_lockfile_manager(repo_root)),
+            },
             PackageManager::Nub { .. } => PackageManager::Nub {
                 lockfile: Box::new(nub::underlying_lockfile_manager(repo_root)),
             },
@@ -297,6 +312,7 @@ impl PackageManager {
             PackageManager::Yarn => "yarn",
             PackageManager::Bun => "bun",
             PackageManager::Nub { .. } => "nub",
+            PackageManager::Aube { .. } => "aube",
         }
     }
 
@@ -307,6 +323,7 @@ impl PackageManager {
             PackageManager::Yarn | PackageManager::Berry => "yarn",
             PackageManager::Bun => "bun",
             PackageManager::Nub { .. } => "nub",
+            PackageManager::Aube { .. } => "aube",
         }
     }
 
@@ -334,7 +351,9 @@ impl PackageManager {
             PackageManager::Pnpm | PackageManager::Pnpm6 | PackageManager::Pnpm9 => {
                 pnpm::get_default_exclusions()
             }
-            PackageManager::Npm | PackageManager::Nub { .. } => ["**/node_modules/**"].as_slice(),
+            PackageManager::Npm | PackageManager::Nub { .. } | PackageManager::Aube { .. } => {
+                ["**/node_modules/**"].as_slice()
+            }
             PackageManager::Bun => ["**/node_modules", "**/.git"].as_slice(),
             PackageManager::Berry => ["**/node_modules", "**/.git", "**/.yarn"].as_slice(),
             PackageManager::Yarn => [].as_slice(), // yarn does its own handling above
@@ -369,6 +388,39 @@ impl PackageManager {
             }
             PackageManager::Nub { lockfile } => {
                 if lockfile.is_pnpm_family()
+                    && root_path
+                        .join_component(pnpm::WORKSPACE_CONFIGURATION_PATH)
+                        .exists()
+                {
+                    pnpm::get_configured_workspace_globs(root_path).ok_or_else(|| {
+                        Error::Workspace(MissingWorkspaceError::from(self.clone()))
+                    })?
+                } else {
+                    let package_json_text =
+                        fs::read_to_string(root_path.join_component("package.json"))?;
+                    let package_json: PackageJsonWorkspaces =
+                        serde_json::from_str(&package_json_text).map_err(|_| {
+                            Error::Workspace(MissingWorkspaceError::from(self.clone()))
+                        })?;
+
+                    if package_json.workspaces.as_ref().is_empty() {
+                        return Err(MissingWorkspaceError::from(self.clone()).into());
+                    } else {
+                        package_json.workspaces.into()
+                    }
+                }
+            }
+            PackageManager::Aube { lockfile } => {
+                if root_path
+                    .join_component(aube::WORKSPACE_CONFIGURATION_PATH)
+                    .exists()
+                {
+                    pnpm::get_configured_workspace_globs_from_path(
+                        root_path,
+                        aube::WORKSPACE_CONFIGURATION_PATH,
+                    )
+                    .ok_or_else(|| Error::Workspace(MissingWorkspaceError::from(self.clone())))?
+                } else if lockfile.is_pnpm_family()
                     && root_path
                         .join_component(pnpm::WORKSPACE_CONFIGURATION_PATH)
                         .exists()
@@ -440,6 +492,9 @@ impl PackageManager {
         // if version is a https attempt to check that instead
         if version.starts_with("http") {
             match manager {
+                "aube" => Ok(PackageManager::Aube {
+                    lockfile: Box::new(aube::underlying_lockfile_manager(repo_root)),
+                }),
                 "npm" => Ok(PackageManager::Npm),
                 "bun" => Ok(PackageManager::Bun),
                 "nub" => Ok(PackageManager::Nub {
@@ -465,6 +520,9 @@ impl PackageManager {
                 }
             })?;
             match manager {
+                "aube" => Ok(PackageManager::Aube {
+                    lockfile: Box::new(aube::underlying_lockfile_manager(repo_root)),
+                }),
                 "npm" => Ok(PackageManager::Npm),
                 "bun" => Ok(PackageManager::Bun),
                 "nub" => Ok(PackageManager::Nub {
@@ -540,12 +598,12 @@ impl PackageManager {
                 "`devEngines.packageManager.name` must not contain leading or trailing whitespace",
             ));
         }
-        if !matches!(name, "npm" | "pnpm" | "yarn" | "bun" | "nub") {
+        if !matches!(name, "npm" | "pnpm" | "yarn" | "bun" | "nub" | "aube") {
             return Err(Self::invalid_dev_engines_package_manager_at(
                 dev_engines,
                 &["packageManager", "name"],
-                "`devEngines.packageManager.name` must be one of `npm`, `pnpm`, `yarn`, `bun`, or \
-                 `nub`",
+                "`devEngines.packageManager.name` must be one of `npm`, `pnpm`, `yarn`, `bun`, \
+                 `nub`, or `aube`",
             ));
         }
 
@@ -605,6 +663,9 @@ impl PackageManager {
         version: &Version,
     ) -> Result<Self, Error> {
         match name {
+            "aube" => Ok(PackageManager::Aube {
+                lockfile: Box::new(aube::underlying_lockfile_manager(repo_root)),
+            }),
             "npm" => Ok(PackageManager::Npm),
             "bun" => Ok(PackageManager::Bun),
             "nub" => Ok(PackageManager::Nub {
@@ -847,6 +908,13 @@ impl PackageManager {
     /// Try to detect package manager based on configuration files and binaries
     /// installed on the system.
     pub fn detect_package_manager(repo_root: &AbsoluteSystemPath) -> Result<Self, Error> {
+        let native_aube =
+            repo_root
+                .join_component(aube::LOCKFILE)
+                .exists()
+                .then(|| PackageManager::Aube {
+                    lockfile: Box::new(aube::underlying_lockfile_manager(repo_root)),
+                });
         let native_nub =
             repo_root
                 .join_component(nub::LOCKFILE)
@@ -854,8 +922,9 @@ impl PackageManager {
                 .then(|| PackageManager::Nub {
                     lockfile: Box::new(nub::underlying_lockfile_manager(repo_root)),
                 });
-        let detected_package_managers = native_nub
+        let detected_package_managers = native_aube
             .into_iter()
+            .chain(native_nub)
             .map(Ok)
             .chain(PnpmDetector::new(repo_root))
             .chain(NpmDetector::new(repo_root))
@@ -921,6 +990,7 @@ impl PackageManager {
             PackageManager::Bun => bun::LOCKFILE,
             PackageManager::Pnpm | PackageManager::Pnpm6 | PackageManager::Pnpm9 => pnpm::LOCKFILE,
             PackageManager::Yarn | PackageManager::Berry => yarn::LOCKFILE,
+            PackageManager::Aube { lockfile } => lockfile.lockfile_name(),
             // nub uses the lockfile of whichever package manager the project
             // already uses; delegate to the resolved underlying manager.
             PackageManager::Nub { lockfile } => lockfile.lockfile_name(),
@@ -935,6 +1005,7 @@ impl PackageManager {
             PackageManager::Nub { lockfile } if lockfile.is_pnpm_family() => {
                 Some(pnpm::WORKSPACE_CONFIGURATION_PATH)
             }
+            PackageManager::Aube { .. } => Some(aube::WORKSPACE_CONFIGURATION_PATH),
             PackageManager::Npm
             | PackageManager::Berry
             | PackageManager::Yarn
@@ -950,9 +1021,14 @@ impl PackageManager {
         root_path: &AbsoluteSystemPath,
         root_package_json: &PackageJson,
     ) -> Result<Box<dyn Lockfile>, Error> {
-        if let PackageManager::Nub { lockfile } = self {
-            if root_path.join_component(nub::LOCKFILE).exists() {
-                let contents = root_path.join_component(nub::LOCKFILE).read()?;
+        if let PackageManager::Nub { lockfile } | PackageManager::Aube { lockfile } = self {
+            let native_lockfile = match self {
+                PackageManager::Nub { .. } => nub::LOCKFILE,
+                PackageManager::Aube { .. } => aube::LOCKFILE,
+                _ => unreachable!(),
+            };
+            if root_path.join_component(native_lockfile).exists() {
+                let contents = root_path.join_component(native_lockfile).read()?;
                 return lockfile.parse_lockfile(root_package_json, &contents, None);
             }
             return lockfile.read_lockfile(root_path, root_package_json);
@@ -1022,7 +1098,7 @@ impl PackageManager {
                 )?)
             }
             // nub delegates to the parser of the lockfile actually present.
-            PackageManager::Nub { lockfile } => {
+            PackageManager::Nub { lockfile } | PackageManager::Aube { lockfile } => {
                 return lockfile.parse_lockfile(root_package_json, contents, yarnrc);
             }
         })
@@ -1044,7 +1120,7 @@ impl PackageManager {
                 unreachable!("npm and yarn 1 don't have a concept of patches")
             }
             // nub delegates patch pruning to the underlying package manager.
-            PackageManager::Nub { lockfile } => {
+            PackageManager::Nub { lockfile } | PackageManager::Aube { lockfile } => {
                 lockfile.prune_patched_packages(package_json, patches, repo_root)
             }
         }
@@ -1122,6 +1198,11 @@ impl PackageManager {
         {
             return turbo_root.join_component(nub::LOCKFILE);
         }
+        if matches!(self, PackageManager::Aube { .. })
+            && turbo_root.join_component(aube::LOCKFILE).exists()
+        {
+            return turbo_root.join_component(aube::LOCKFILE);
+        }
 
         turbo_root.join_component(self.lockfile_name())
     }
@@ -1145,7 +1226,8 @@ impl PackageManager {
             PackageManager::Pnpm
             | PackageManager::Pnpm9
             | PackageManager::Berry
-            | PackageManager::Nub { .. } => None,
+            | PackageManager::Nub { .. }
+            | PackageManager::Aube { .. } => None,
         }
     }
 
@@ -1166,7 +1248,9 @@ impl PackageManager {
             PackageManager::Yarn | PackageManager::Bun | PackageManager::Npm => true,
             // nub links workspace packages by default, delegating to the
             // underlying manager's behavior where it has one.
-            PackageManager::Nub { lockfile } => lockfile.link_workspace_packages(repo_root),
+            PackageManager::Nub { lockfile } | PackageManager::Aube { lockfile } => {
+                lockfile.link_workspace_packages(repo_root)
+            }
         }
     }
 
@@ -1175,7 +1259,15 @@ impl PackageManager {
     pub fn read_catalogs(&self, repo_root: &AbsoluteSystemPath) -> Option<pnpm::PnpmCatalogs> {
         match self.lockfile_manager() {
             PackageManager::Pnpm9 | PackageManager::Pnpm | PackageManager::Pnpm6 => {
-                pnpm::read_catalogs(repo_root)
+                if matches!(self, PackageManager::Aube { .. })
+                    && repo_root
+                        .join_component(aube::WORKSPACE_CONFIGURATION_PATH)
+                        .exists()
+                {
+                    pnpm::read_catalogs_from_path(repo_root, aube::WORKSPACE_CONFIGURATION_PATH)
+                } else {
+                    pnpm::read_catalogs(repo_root)
+                }
             }
             // Berry catalogs are handled during lockfile parsing, not here.
             // Bun catalogs are handled during lockfile parsing, not here.
@@ -1315,7 +1407,7 @@ mod tests {
                     "**/bower_components/**",
                     "packages/skip",
                 ],
-                PackageManager::Nub { .. } => &["**/node_modules/**"],
+                PackageManager::Nub { .. } | PackageManager::Aube { .. } => &["**/node_modules/**"],
             };
             let expected: HashSet<String> =
                 HashSet::from_iter(expected.iter().map(|s| s.to_string()));
@@ -1425,6 +1517,13 @@ mod tests {
                 expected_error: false,
             },
             TestCase {
+                name: "supports aube".to_owned(),
+                package_manager: Spanned::new("aube@0.1.0".to_owned()),
+                expected_manager: "aube".to_owned(),
+                expected_version: "0.1.0".to_owned(),
+                expected_error: false,
+            },
+            TestCase {
                 name: "supports custom URL".to_owned(),
                 package_manager: Spanned::new("npm@https://some-npm-fork".to_owned()),
                 expected_manager: "npm".to_owned(),
@@ -1505,6 +1604,15 @@ mod tests {
             }
         );
 
+        package_json.package_manager = Some(Spanned::new("aube@0.1.0".to_string()));
+        let package_manager = PackageManager::read_package_manager(repo_root, &package_json)?;
+        assert_eq!(
+            package_manager,
+            PackageManager::Aube {
+                lockfile: Box::new(PackageManager::Npm)
+            }
+        );
+
         Ok(())
     }
 
@@ -1517,6 +1625,7 @@ mod tests {
     #[test_case("pnpm", "9.12.3", PackageManager::Pnpm9 ; "pnpm9")]
     #[test_case("pnpm", "9.12.3-alpha.0", PackageManager::Pnpm ; "pnpm prerelease")]
     #[test_case("nub", "0.1.0", PackageManager::Nub { lockfile: Box::new(PackageManager::Npm) } ; "nub")]
+    #[test_case("aube", "0.1.0", PackageManager::Aube { lockfile: Box::new(PackageManager::Npm) } ; "aube")]
     fn test_read_dev_engines_package_manager(
         name: &str,
         version: &str,
@@ -1677,6 +1786,78 @@ mod tests {
             PackageManager::detect_package_manager(&repo_root),
             Err(Error::MultiplePackageManagers { .. })
         ));
+        Ok(())
+    }
+
+    #[test]
+    fn test_native_aube_lockfile_detects_aube() -> Result<(), Error> {
+        let (_dir, repo_root) = temp_repo_root()?;
+        std::fs::write(
+            repo_root.join_component(aube::LOCKFILE).as_std_path(),
+            "lockfileVersion: '9.0'\nimporters:\n  .: {}\n",
+        )?;
+
+        assert_eq!(
+            PackageManager::detect_package_manager(&repo_root)?,
+            PackageManager::Aube {
+                lockfile: Box::new(PackageManager::Pnpm9)
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_dev_engines_aube_native_workspace_file() -> Result<(), Error> {
+        let (_dir, repo_root) = temp_repo_root()?;
+        std::fs::create_dir_all(repo_root.join_components(&["apps", "web"]).as_std_path())?;
+        std::fs::write(
+            repo_root.join_component("package.json").as_std_path(),
+            r#"{
+  "devEngines": {
+    "packageManager": {
+      "name": "aube",
+      "version": "0.1.0"
+    }
+  }
+}"#,
+        )?;
+        std::fs::write(
+            repo_root
+                .join_components(&["apps", "web", "package.json"])
+                .as_std_path(),
+            r#"{"name":"web"}"#,
+        )?;
+        std::fs::write(
+            repo_root
+                .join_component(aube::WORKSPACE_CONFIGURATION_PATH)
+                .as_std_path(),
+            "packages:\n  - apps/*\n",
+        )?;
+        std::fs::write(
+            repo_root.join_component(aube::LOCKFILE).as_std_path(),
+            "lockfileVersion: '9.0'\nimporters:\n  .: {}\n",
+        )?;
+        let package_json = PackageJson::load(&repo_root.join_component("package.json"))?;
+
+        let package_manager = PackageManager::read_package_manager(&repo_root, &package_json)?;
+        let found: HashSet<AbsoluteSystemPathBuf> =
+            HashSet::from_iter(package_manager.get_package_jsons(&repo_root)?);
+
+        assert_eq!(
+            package_manager,
+            PackageManager::Aube {
+                lockfile: Box::new(PackageManager::Pnpm9)
+            }
+        );
+        assert_eq!(
+            found,
+            HashSet::from_iter([repo_root.join_components(&["apps", "web", "package.json"])])
+        );
+        assert_eq!(
+            package_manager.lockfile_path(&repo_root),
+            repo_root.join_component(aube::LOCKFILE)
+        );
+        package_manager.read_lockfile(&repo_root, &package_json)?;
         Ok(())
     }
 

--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -1248,9 +1248,26 @@ impl PackageManager {
             PackageManager::Yarn | PackageManager::Bun | PackageManager::Npm => true,
             // nub links workspace packages by default, delegating to the
             // underlying manager's behavior where it has one.
-            PackageManager::Nub { lockfile } | PackageManager::Aube { lockfile } => {
-                lockfile.link_workspace_packages(repo_root)
-            }
+            PackageManager::Nub { lockfile } => lockfile.link_workspace_packages(repo_root),
+            PackageManager::Aube { lockfile } => match lockfile.as_ref() {
+                PackageManager::Pnpm9 | PackageManager::Pnpm | PackageManager::Pnpm6 => {
+                    let pnpm_version = pnpm::PnpmVersion::try_from(lockfile.as_ref())
+                        .expect("attempted to extract pnpm version from non-pnpm package manager");
+                    if repo_root
+                        .join_component(aube::WORKSPACE_CONFIGURATION_PATH)
+                        .exists()
+                    {
+                        pnpm::link_workspace_packages_from_path(
+                            pnpm_version,
+                            repo_root,
+                            aube::WORKSPACE_CONFIGURATION_PATH,
+                        )
+                    } else {
+                        lockfile.link_workspace_packages(repo_root)
+                    }
+                }
+                _ => lockfile.link_workspace_packages(repo_root),
+            },
         }
     }
 
@@ -2158,5 +2175,21 @@ mod tests {
             actual,
             "all package managers without a special implementation should use workspace packages"
         );
+    }
+
+    #[test]
+    fn test_aube_link_workspace_packages_reads_aube_workspace_yaml() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let repo_root = AbsoluteSystemPath::from_std_path(tmpdir.path()).unwrap();
+        repo_root
+            .join_component(aube::WORKSPACE_CONFIGURATION_PATH)
+            .create_with_contents("packages:\n  - packages/*\nlinkWorkspacePackages: true\n")
+            .unwrap();
+
+        let package_manager = PackageManager::Aube {
+            lockfile: Box::new(PackageManager::Pnpm9),
+        };
+
+        assert!(package_manager.link_workspace_packages(repo_root));
     }
 }

--- a/crates/turborepo-repository/src/package_manager/pnpm.rs
+++ b/crates/turborepo-repository/src/package_manager/pnpm.rs
@@ -174,13 +174,21 @@ pub fn patch_paths_for_keys(
 }
 
 pub fn link_workspace_packages(pnpm_version: PnpmVersion, repo_root: &AbsoluteSystemPath) -> bool {
+    link_workspace_packages_from_path(pnpm_version, repo_root, WORKSPACE_CONFIGURATION_PATH)
+}
+
+pub fn link_workspace_packages_from_path(
+    pnpm_version: PnpmVersion,
+    repo_root: &AbsoluteSystemPath,
+    workspace_configuration_path: &str,
+) -> bool {
     let npmrc_config = npmrc::NpmRc::from_file(repo_root)
         .inspect_err(|e| debug!("unable to read npmrc: {e}"))
         .unwrap_or_default();
     let workspace_config = matches!(pnpm_version, PnpmVersion::Pnpm9)
         .then(|| {
-            PnpmWorkspace::from_file(repo_root, WORKSPACE_CONFIGURATION_PATH)
-                .inspect_err(|e| debug!("unable to read {WORKSPACE_CONFIGURATION_PATH}: {e}"))
+            PnpmWorkspace::from_file(repo_root, workspace_configuration_path)
+                .inspect_err(|e| debug!("unable to read {workspace_configuration_path}: {e}"))
                 .ok()
         })
         .flatten()

--- a/crates/turborepo-repository/src/package_manager/pnpm.rs
+++ b/crates/turborepo-repository/src/package_manager/pnpm.rs
@@ -179,7 +179,7 @@ pub fn link_workspace_packages(pnpm_version: PnpmVersion, repo_root: &AbsoluteSy
         .unwrap_or_default();
     let workspace_config = matches!(pnpm_version, PnpmVersion::Pnpm9)
         .then(|| {
-            PnpmWorkspace::from_file(repo_root)
+            PnpmWorkspace::from_file(repo_root, WORKSPACE_CONFIGURATION_PATH)
                 .inspect_err(|e| debug!("unable to read {WORKSPACE_CONFIGURATION_PATH}: {e}"))
                 .ok()
         })
@@ -196,7 +196,14 @@ pub fn link_workspace_packages(pnpm_version: PnpmVersion, repo_root: &AbsoluteSy
 }
 
 pub fn get_configured_workspace_globs(repo_root: &AbsoluteSystemPath) -> Option<Vec<String>> {
-    let pnpm_workspace = PnpmWorkspace::from_file(repo_root).ok()?;
+    get_configured_workspace_globs_from_path(repo_root, WORKSPACE_CONFIGURATION_PATH)
+}
+
+pub fn get_configured_workspace_globs_from_path(
+    repo_root: &AbsoluteSystemPath,
+    workspace_configuration_path: &str,
+) -> Option<Vec<String>> {
+    let pnpm_workspace = PnpmWorkspace::from_file(repo_root, workspace_configuration_path).ok()?;
     if pnpm_workspace.packages.is_empty() {
         None
     } else {
@@ -232,8 +239,11 @@ enum LinkWorkspacePackages {
 }
 
 impl PnpmWorkspace {
-    pub fn from_file(repo_root: &AbsoluteSystemPath) -> Result<Self, Error> {
-        let workspace_yaml_path = repo_root.join_component(WORKSPACE_CONFIGURATION_PATH);
+    pub fn from_file(
+        repo_root: &AbsoluteSystemPath,
+        workspace_configuration_path: &str,
+    ) -> Result<Self, Error> {
+        let workspace_yaml_path = repo_root.join_component(workspace_configuration_path);
         let workspace_yaml = workspace_yaml_path.read_to_string()?;
         Ok(serde_yaml_ng::from_str(&workspace_yaml)?)
     }
@@ -250,8 +260,15 @@ impl PnpmWorkspace {
 /// Read catalog definitions from pnpm-workspace.yaml. Returns `None` if the
 /// file doesn't exist or can't be parsed (non-fatal).
 pub fn read_catalogs(repo_root: &AbsoluteSystemPath) -> Option<PnpmCatalogs> {
-    let workspace = PnpmWorkspace::from_file(repo_root)
-        .inspect_err(|e| debug!("unable to read {WORKSPACE_CONFIGURATION_PATH}: {e}"))
+    read_catalogs_from_path(repo_root, WORKSPACE_CONFIGURATION_PATH)
+}
+
+pub fn read_catalogs_from_path(
+    repo_root: &AbsoluteSystemPath,
+    workspace_configuration_path: &str,
+) -> Option<PnpmCatalogs> {
+    let workspace = PnpmWorkspace::from_file(repo_root, workspace_configuration_path)
+        .inspect_err(|e| debug!("unable to read {workspace_configuration_path}: {e}"))
         .ok()?;
     if workspace.catalog.is_empty() && workspace.catalogs.is_empty() {
         return None;
@@ -310,7 +327,8 @@ impl TryFrom<&'_ PackageManager> for PnpmVersion {
             | PackageManager::Yarn
             | PackageManager::Npm
             | PackageManager::Bun
-            | PackageManager::Nub { .. } => Err(NotPnpmError {
+            | PackageManager::Nub { .. }
+            | PackageManager::Aube { .. } => Err(NotPnpmError {
                 package_manager: value.clone(),
             }),
         }

--- a/crates/turborepo-updater/src/lib.rs
+++ b/crates/turborepo-updater/src/lib.rs
@@ -150,6 +150,7 @@ pub fn display_update_check(config: UpdateCheckConfig) -> Result<(), UpdateNotif
             }
             PackageManager::Bun => style("bunx @turbo/codemod@latest update").cyan().bold(),
             PackageManager::Nub { .. } => style("nubx @turbo/codemod@latest update").cyan().bold(),
+            PackageManager::Aube { .. } => style("aubx @turbo/codemod@latest update").cyan().bold(),
         };
 
         let msg = format!(

--- a/crates/turborepo/tests/package_manager_test.rs
+++ b/crates/turborepo/tests/package_manager_test.rs
@@ -56,6 +56,14 @@ fn test_detect_npm_from_dev_engines_package_manager() {
 }
 
 #[test]
+fn test_detect_aube_from_dev_engines_package_manager() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@8.19.4", false).unwrap();
+    set_dev_engines_package_manager(tempdir.path(), "aube", "0.1.0");
+    assert_eq!(get_package_manager(tempdir.path()), "aube");
+}
+
+#[test]
 fn test_errors_without_package_manager_declaration() {
     let tempdir = tempfile::tempdir().unwrap();
     setup::setup_integration_test(tempdir.path(), "basic_monorepo", "npm@8.19.4", false).unwrap();

--- a/packages/create-turbo/__tests__/index.test.ts
+++ b/packages/create-turbo/__tests__/index.test.ts
@@ -63,7 +63,8 @@ describe("create-turbo", () => {
           yarn: "1.22.10",
           pnpm: "7.22.2",
           bun: "1.0.1",
-          nub: "0.1.0"
+          nub: "0.1.0",
+          aube: "0.1.0"
         });
 
       const mockCreateProject = jest
@@ -144,7 +145,8 @@ describe("create-turbo", () => {
     { packageManager: "npm" },
     { packageManager: "pnpm" },
     { packageManager: "bun" },
-    { packageManager: "nub" }
+    { packageManager: "nub" },
+    { packageManager: "aube" }
   ])(
     "outputs expected console messages when using $packageManager (arg)",
     async ({ packageManager }) => {
@@ -159,7 +161,8 @@ describe("create-turbo", () => {
           yarn: "1.22.10",
           pnpm: "7.22.2",
           bun: "1.0.1",
-          nub: "0.1.0"
+          nub: "0.1.0",
+          aube: "0.1.0"
         });
 
       const mockCreateProject = jest
@@ -244,7 +247,8 @@ describe("create-turbo", () => {
         yarn: "1.22.10",
         pnpm: "7.22.2",
         bun: "1.0.1",
-        nub: "0.1.0"
+        nub: "0.1.0",
+        aube: "0.1.0"
       });
 
     const mockCreateProject = jest
@@ -308,7 +312,8 @@ describe("create-turbo", () => {
         yarn: "1.22.10",
         pnpm: "7.22.2",
         bun: "1.0.1",
-        nub: "0.1.0"
+        nub: "0.1.0",
+        aube: "0.1.0"
       });
 
     const mockCreateProject = jest
@@ -370,7 +375,8 @@ describe("create-turbo", () => {
         yarn: "1.22.10",
         pnpm: "7.22.2",
         bun: "1.0.1",
-        nub: "0.1.0"
+        nub: "0.1.0",
+        aube: "0.1.0"
       });
 
     const mockCreateProject = jest

--- a/packages/create-turbo/src/cli.ts
+++ b/packages/create-turbo/src/cli.ts
@@ -45,7 +45,7 @@ createTurboCli
     new Option(
       "-m, --package-manager <package-manager>",
       "Specify the package manager to use"
-    ).choices(["npm", "yarn", "pnpm", "bun", "nub"])
+    ).choices(["npm", "yarn", "pnpm", "bun", "nub", "aube"])
   )
   .option(
     "--skip-install",

--- a/packages/create-turbo/src/commands/create/prompts.ts
+++ b/packages/create-turbo/src/commands/create/prompts.ts
@@ -52,7 +52,8 @@ export async function packageManager({
       { pm: "pnpm", label: "pnpm" },
       { pm: "yarn", label: "yarn" },
       { pm: "bun", label: "bun" },
-      { pm: "nub", label: "nub" }
+      { pm: "nub", label: "nub" },
+      { pm: "aube", label: "aube" }
     ]
       .sort((a, b) => {
         const aInstalled = Boolean(

--- a/packages/turbo-codemod/__tests__/add-package-manager.test.ts
+++ b/packages/turbo-codemod/__tests__/add-package-manager.test.ts
@@ -179,7 +179,8 @@ describe("add-package-manager-2", () => {
           npm: packageManager === "npm" ? packageManagerVersion : undefined,
           yarn: packageManager === "yarn" ? packageManagerVersion : undefined,
           bun: packageManager === "bun" ? packageManagerVersion : undefined,
-          nub: packageManager === "nub" ? packageManagerVersion : undefined
+          nub: packageManager === "nub" ? packageManagerVersion : undefined,
+          aube: packageManager === "aube" ? packageManagerVersion : undefined
         });
 
       const mockGetWorkspaceDetails = jest
@@ -289,7 +290,8 @@ describe("add-package-manager-2", () => {
           npm: undefined,
           yarn: undefined,
           bun: undefined,
-          nub: undefined
+          nub: undefined,
+          aube: undefined
         });
 
       const mockGetWorkspaceDetails = jest
@@ -338,7 +340,8 @@ describe("add-package-manager-2", () => {
           npm: undefined,
           yarn: undefined,
           bun: undefined,
-          nub: undefined
+          nub: undefined,
+          aube: undefined
         });
 
       const mockGetWorkspaceDetails = jest

--- a/packages/turbo-codemod/__tests__/get-turbo-upgrade-command.test.ts
+++ b/packages/turbo-codemod/__tests__/get-turbo-upgrade-command.test.ts
@@ -569,7 +569,8 @@ describe("get-turbo-upgrade-command", () => {
           npm: undefined,
           yarn: undefined,
           bun: undefined,
-          nub: undefined
+          nub: undefined,
+          aube: undefined
         });
       const mockGetAvailablePackageManagers = jest
         .spyOn(turboUtils, "getAvailablePackageManagers")
@@ -578,7 +579,8 @@ describe("get-turbo-upgrade-command", () => {
           npm: packageManager === "npm" ? packageManagerVersion : undefined,
           yarn: packageManager === "yarn" ? packageManagerVersion : undefined,
           bun: packageManager === "bun" ? packageManagerVersion : undefined,
-          nub: packageManager === "nub" ? packageManagerVersion : undefined
+          nub: packageManager === "nub" ? packageManagerVersion : undefined,
+          aube: packageManager === "aube" ? packageManagerVersion : undefined
         });
 
       const project = getWorkspaceDetailsMockReturnValue({
@@ -633,7 +635,8 @@ describe("get-turbo-upgrade-command", () => {
           npm: `/global/npm/bin`,
           yarn: `/global/yarn/bin`,
           bun: `/global/bun/bin`,
-          nub: `/global/nub/bin`
+          nub: `/global/nub/bin`,
+          aube: `/global/aube/bin`
         });
 
       const mockGetAvailablePackageManagers = jest
@@ -643,7 +646,8 @@ describe("get-turbo-upgrade-command", () => {
           npm: packageManager === "npm" ? packageManagerVersion : undefined,
           yarn: packageManager === "yarn" ? packageManagerVersion : undefined,
           bun: packageManager === "bun" ? packageManagerVersion : undefined,
-          nub: packageManager === "nub" ? packageManagerVersion : undefined
+          nub: packageManager === "nub" ? packageManagerVersion : undefined,
+          aube: packageManager === "aube" ? packageManagerVersion : undefined
         });
 
       const project = getWorkspaceDetailsMockReturnValue({
@@ -781,7 +785,8 @@ describe("get-turbo-upgrade-command", () => {
           npm: undefined,
           yarn: undefined,
           bun: undefined,
-          nub: undefined
+          nub: undefined,
+          aube: undefined
         });
 
       const project = getWorkspaceDetailsMockReturnValue({
@@ -840,7 +845,8 @@ describe("get-turbo-upgrade-command", () => {
             npm: undefined,
             yarn: undefined,
             bun: undefined,
-            nub: undefined
+            nub: undefined,
+            aube: undefined
           });
 
         const project = getWorkspaceDetailsMockReturnValue({

--- a/packages/turbo-codemod/__tests__/migrate.test.ts
+++ b/packages/turbo-codemod/__tests__/migrate.test.ts
@@ -73,7 +73,8 @@ describe("migrate", () => {
         npm: undefined,
         yarn: undefined,
         bun: undefined,
-        nub: undefined
+        nub: undefined,
+        aube: undefined
       });
     const mockedGetWorkspaceDetails = jest
       .spyOn(turboWorkspaces, "getWorkspaceDetails")
@@ -158,7 +159,8 @@ describe("migrate", () => {
         npm: undefined,
         yarn: undefined,
         bun: undefined,
-        nub: undefined
+        nub: undefined,
+        aube: undefined
       });
     const mockedGetWorkspaceDetails = jest
       .spyOn(turboWorkspaces, "getWorkspaceDetails")
@@ -228,7 +230,8 @@ describe("migrate", () => {
         npm: undefined,
         yarn: undefined,
         bun: undefined,
-        nub: undefined
+        nub: undefined,
+        aube: undefined
       });
     const mockedGetWorkspaceDetails = jest
       .spyOn(turboWorkspaces, "getWorkspaceDetails")
@@ -311,7 +314,8 @@ describe("migrate", () => {
         npm: undefined,
         yarn: undefined,
         bun: undefined,
-        nub: undefined
+        nub: undefined,
+        aube: undefined
       });
     const mockedGetWorkspaceDetails = jest
       .spyOn(turboWorkspaces, "getWorkspaceDetails")
@@ -513,7 +517,8 @@ describe("migrate", () => {
         npm: undefined,
         yarn: undefined,
         bun: undefined,
-        nub: undefined
+        nub: undefined,
+        aube: undefined
       });
     const mockedGetWorkspaceDetails = jest
       .spyOn(turboWorkspaces, "getWorkspaceDetails")
@@ -619,7 +624,8 @@ describe("migrate", () => {
         npm: undefined,
         yarn: undefined,
         bun: undefined,
-        nub: undefined
+        nub: undefined,
+        aube: undefined
       });
     const mockedGetWorkspaceDetails = jest
       .spyOn(turboWorkspaces, "getWorkspaceDetails")
@@ -854,7 +860,8 @@ describe("migrate", () => {
         npm: undefined,
         yarn: undefined,
         bun: undefined,
-        nub: undefined
+        nub: undefined,
+        aube: undefined
       });
     const mockedGetWorkspaceDetails = jest
       .spyOn(turboWorkspaces, "getWorkspaceDetails")
@@ -969,7 +976,8 @@ describe("migrate", () => {
         npm: undefined,
         yarn: undefined,
         bun: undefined,
-        nub: undefined
+        nub: undefined,
+        aube: undefined
       });
     const mockedGetWorkspaceDetails = jest
       .spyOn(turboWorkspaces, "getWorkspaceDetails")

--- a/packages/turbo-codemod/__tests__/transform.test.ts
+++ b/packages/turbo-codemod/__tests__/transform.test.ts
@@ -55,7 +55,8 @@ describe("transform", () => {
         npm: undefined,
         yarn: undefined,
         bun: undefined,
-        nub: undefined
+        nub: undefined,
+        aube: undefined
       });
 
     const mockGetWorkspaceDetails = jest
@@ -108,7 +109,8 @@ describe("transform", () => {
         npm: undefined,
         yarn: undefined,
         bun: undefined,
-        nub: undefined
+        nub: undefined,
+        aube: undefined
       });
 
     const mockGetWorkspaceDetails = jest

--- a/packages/turbo-codemod/src/cli.ts
+++ b/packages/turbo-codemod/src/cli.ts
@@ -32,6 +32,8 @@ const notifyUpdate = createNotifyUpdate({
         return "pnpm i -g @turbo/codemod";
       } else if (packageManager === "nub") {
         return "nub add -g @turbo/codemod";
+      } else if (packageManager === "aube") {
+        return "aube add -g @turbo/codemod";
       }
       return "npm i -g @turbo/codemod";
     } catch {

--- a/packages/turbo-codemod/src/commands/migrate/steps/get-turbo-upgrade-command.ts
+++ b/packages/turbo-codemod/src/commands/migrate/steps/get-turbo-upgrade-command.ts
@@ -44,6 +44,9 @@ function getGlobalUpgradeCommand({
     case "nub": {
       return `nub add turbo@${to} --global`;
     }
+    case "aube": {
+      return `aube add turbo@${to} --global`;
+    }
   }
 }
 
@@ -119,6 +122,15 @@ function getLocalUpgradeCommand({
         isUsingWorkspaces && "-w"
       ]);
     }
+    case "aube": {
+      return renderCommand([
+        "aube",
+        "add",
+        `turbo@${to}`,
+        installType === "devDependencies" && "--save-dev",
+        isUsingWorkspaces && "-w"
+      ]);
+    }
   }
 }
 
@@ -142,6 +154,9 @@ function getInstallCommand({
     }
     case "nub": {
       return "nub install";
+    }
+    case "aube": {
+      return "aube install";
     }
   }
 }

--- a/packages/turbo-utils/__tests__/managers.test.ts
+++ b/packages/turbo-utils/__tests__/managers.test.ts
@@ -63,7 +63,8 @@ describe("managers", () => {
         .mockResolvedValueOnce({ stdout: "9.5.0" } as any) // npm
         .mockResolvedValueOnce({ stdout: "8.6.7" } as any) // pnpm
         .mockResolvedValueOnce({ stdout: "1.0.0" } as any) // bun
-        .mockResolvedValueOnce({ stdout: "0.1.0" } as any); // nub
+        .mockResolvedValueOnce({ stdout: "0.1.0" } as any) // nub
+        .mockResolvedValueOnce({ stdout: "0.1.0" } as any); // aube
 
       const result = await getAvailablePackageManagers({
         projectRoot: MISSING_PROJECT_ROOT
@@ -74,7 +75,8 @@ describe("managers", () => {
         npm: "9.5.0",
         pnpm: "8.6.7",
         bun: "1.0.0",
-        nub: "0.1.0"
+        nub: "0.1.0",
+        aube: "0.1.0"
       });
     });
 
@@ -84,7 +86,8 @@ describe("managers", () => {
         .mockRejectedValueOnce(new Error("npm not found")) // npm
         .mockResolvedValueOnce({ stdout: "8.6.7" } as any) // pnpm
         .mockRejectedValueOnce(new Error("bun not found")) // bun
-        .mockRejectedValueOnce(new Error("nub not found")); // nub
+        .mockRejectedValueOnce(new Error("nub not found")) // nub
+        .mockRejectedValueOnce(new Error("aube not found")); // aube
 
       const result = await getAvailablePackageManagers({
         projectRoot: MISSING_PROJECT_ROOT
@@ -95,7 +98,8 @@ describe("managers", () => {
         npm: undefined,
         pnpm: "8.6.7",
         bun: undefined,
-        nub: undefined
+        nub: undefined,
+        aube: undefined
       });
     });
 
@@ -107,7 +111,8 @@ describe("managers", () => {
         .mockResolvedValueOnce({ stdout: "9.5.0" } as any) // npm
         .mockResolvedValueOnce({ stdout: "8.6.7" } as any) // pnpm
         .mockResolvedValueOnce({ stdout: "1.0.0" } as any) // bun
-        .mockResolvedValueOnce({ stdout: "0.1.0" } as any); // nub
+        .mockResolvedValueOnce({ stdout: "0.1.0" } as any) // nub
+        .mockResolvedValueOnce({ stdout: "0.1.0" } as any); // aube
 
       const result = await getAvailablePackageManagers({ projectRoot });
 
@@ -116,13 +121,15 @@ describe("managers", () => {
         npm: "9.5.0",
         pnpm: "8.6.7",
         bun: "1.0.0",
-        nub: "0.1.0"
+        nub: "0.1.0",
+        aube: "0.1.0"
       });
       expect(mockExeca.mock.calls.map(([command]) => command)).toEqual([
         "npm",
         "pnpm",
         "bun",
-        "nub"
+        "nub",
+        "aube"
       ]);
     });
 
@@ -134,7 +141,8 @@ describe("managers", () => {
         .mockResolvedValueOnce({ stdout: "9.5.0" } as any) // npm
         .mockResolvedValueOnce({ stdout: "8.6.7" } as any) // pnpm
         .mockResolvedValueOnce({ stdout: "1.0.0" } as any) // bun
-        .mockResolvedValueOnce({ stdout: "0.1.0" } as any); // nub
+        .mockResolvedValueOnce({ stdout: "0.1.0" } as any) // nub
+        .mockResolvedValueOnce({ stdout: "0.1.0" } as any); // aube
 
       const result = await getAvailablePackageManagers({ projectRoot });
 
@@ -143,7 +151,8 @@ describe("managers", () => {
         "npm",
         "pnpm",
         "bun",
-        "nub"
+        "nub",
+        "aube"
       ]);
     });
 
@@ -155,7 +164,8 @@ describe("managers", () => {
         .mockResolvedValueOnce({ stdout: "9.5.0" } as any) // npm
         .mockResolvedValueOnce({ stdout: "8.6.7" } as any) // pnpm
         .mockResolvedValueOnce({ stdout: "1.0.0" } as any) // bun
-        .mockResolvedValueOnce({ stdout: "0.1.0" } as any); // nub
+        .mockResolvedValueOnce({ stdout: "0.1.0" } as any) // nub
+        .mockResolvedValueOnce({ stdout: "0.1.0" } as any); // aube
 
       const result = await getAvailablePackageManagers({ projectRoot });
 
@@ -164,7 +174,8 @@ describe("managers", () => {
         "npm",
         "pnpm",
         "bun",
-        "nub"
+        "nub",
+        "aube"
       ]);
     });
   });
@@ -176,7 +187,8 @@ describe("managers", () => {
         .mockResolvedValueOnce({ stdout: "/usr/local/bin" } as any) // npm prefix
         .mockResolvedValueOnce({ stdout: "/usr/local/pnpm" } as any) // pnpm bin
         .mockResolvedValueOnce({ stdout: "/usr/local/bun" } as any) // bun bin
-        .mockResolvedValueOnce({ stdout: "/usr/local/bin/nub" } as any); // nub bin
+        .mockResolvedValueOnce({ stdout: "/usr/local/bin/nub" } as any) // nub bin
+        .mockResolvedValueOnce({ stdout: "/usr/local/bin/aube" } as any); // aube bin
 
       const result = await getPackageManagersBinPaths({
         projectRoot: MISSING_PROJECT_ROOT
@@ -187,7 +199,8 @@ describe("managers", () => {
         npm: "/usr/local/bin",
         pnpm: "/usr/local/pnpm",
         bun: "/usr/local/bun",
-        nub: "/usr/local/bin"
+        nub: "/usr/local/bin",
+        aube: "/usr/local/bin"
       });
     });
 
@@ -211,8 +224,11 @@ describe("managers", () => {
         if (command === "bun") {
           return Promise.resolve({ stdout: "/usr/local/bun" } as any);
         }
-        if (command === "which") {
+        if (command === "which" && args?.[0] === "nub") {
           return Promise.resolve({ stdout: "/usr/local/bin/nub" } as any);
+        }
+        if (command === "which" && args?.[0] === "aube") {
+          return Promise.resolve({ stdout: "/usr/local/bin/aube" } as any);
         }
         return Promise.reject(new Error(`${command} not found`));
       }) as typeof execa);
@@ -226,6 +242,7 @@ describe("managers", () => {
       expect(result.pnpm).toBe("/usr/local/pnpm");
       expect(result.bun).toBe("/usr/local/bun");
       expect(result.nub).toBe("/usr/local/bin");
+      expect(result.aube).toBe("/usr/local/bin");
     });
 
     test("should return undefined for failed package manager checks", async () => {
@@ -234,7 +251,8 @@ describe("managers", () => {
         .mockRejectedValueOnce(new Error("npm not found")) // npm
         .mockResolvedValueOnce({ stdout: "/usr/local/pnpm" } as any) // pnpm
         .mockRejectedValueOnce(new Error("bun not found")) // bun
-        .mockRejectedValueOnce(new Error("nub not found")); // nub
+        .mockRejectedValueOnce(new Error("nub not found")) // nub
+        .mockRejectedValueOnce(new Error("aube not found")); // aube
 
       const result = await getPackageManagersBinPaths({
         projectRoot: MISSING_PROJECT_ROOT
@@ -245,7 +263,8 @@ describe("managers", () => {
         npm: undefined,
         pnpm: "/usr/local/pnpm",
         bun: undefined,
-        nub: undefined
+        nub: undefined,
+        aube: undefined
       });
     });
 
@@ -284,6 +303,11 @@ describe("managers", () => {
         env: { COREPACK_ENABLE_STRICT: "0" },
         timeout: 5000
       });
+      expect(mockExeca).toHaveBeenCalledWith("which", ["aube"], {
+        cwd: "/tmp",
+        env: { COREPACK_ENABLE_STRICT: "0" },
+        timeout: 5000
+      });
     });
 
     test("should infer yarn berry bin path without executing yarn", async () => {
@@ -294,7 +318,8 @@ describe("managers", () => {
         .mockResolvedValueOnce({ stdout: "/usr/local/bin" } as any) // npm prefix
         .mockResolvedValueOnce({ stdout: "/usr/local/pnpm" } as any) // pnpm bin
         .mockResolvedValueOnce({ stdout: "/usr/local/bun" } as any) // bun bin
-        .mockResolvedValueOnce({ stdout: "/usr/local/bin/nub" } as any); // nub bin
+        .mockResolvedValueOnce({ stdout: "/usr/local/bin/nub" } as any) // nub bin
+        .mockResolvedValueOnce({ stdout: "/usr/local/bin/aube" } as any); // aube bin
 
       const result = await getPackageManagersBinPaths({ projectRoot });
 
@@ -303,12 +328,14 @@ describe("managers", () => {
         npm: "/usr/local/bin",
         pnpm: "/usr/local/pnpm",
         bun: "/usr/local/bun",
-        nub: "/usr/local/bin"
+        nub: "/usr/local/bin",
+        aube: "/usr/local/bin"
       });
       expect(mockExeca.mock.calls.map(([command]) => command)).toEqual([
         "npm",
         "pnpm",
         "bun",
+        "which",
         "which"
       ]);
     });

--- a/packages/turbo-utils/src/managers.ts
+++ b/packages/turbo-utils/src/managers.ts
@@ -171,16 +171,26 @@ async function getNubBinPath() {
   return path.dirname(nubBinaryPath);
 }
 
+async function getAubeBinPath() {
+  const aubeBinaryPath = await exec("which", ["aube"]);
+  if (!aubeBinaryPath) {
+    return undefined;
+  }
+
+  return path.dirname(aubeBinaryPath);
+}
+
 export async function getAvailablePackageManagers(
   options: PackageManagerDetectionOptions = {}
-): Promise<Record<PackageManager, string | undefined>> {
+): Promise<Partial<Record<PackageManager, string | undefined>>> {
   const projectRoot = options.projectRoot ?? process.cwd();
-  const [yarn, npm, pnpm, bun, nub] = await Promise.all([
+  const [yarn, npm, pnpm, bun, nub, aube] = await Promise.all([
     getYarnVersion(projectRoot),
     exec("npm", ["--version"]),
     exec("pnpm", ["--version"]),
     exec("bun", ["--version"]),
-    exec("nub", ["--version"])
+    exec("nub", ["--version"]),
+    exec("aube", ["--version"])
   ]);
 
   return {
@@ -188,20 +198,22 @@ export async function getAvailablePackageManagers(
     pnpm,
     npm,
     bun,
-    nub
+    nub,
+    aube
   };
 }
 
 export async function getPackageManagersBinPaths(
   options: PackageManagerDetectionOptions = {}
-): Promise<Record<PackageManager, string | undefined>> {
+): Promise<Partial<Record<PackageManager, string | undefined>>> {
   const projectRoot = options.projectRoot ?? process.cwd();
-  const [yarn, npm, pnpm, bun, nub] = await Promise.all([
+  const [yarn, npm, pnpm, bun, nub, aube] = await Promise.all([
     getYarnBinPath(projectRoot),
     exec("npm", ["config", "get", "prefix"]),
     exec("pnpm", ["bin", "--global"]),
     exec("bun", ["pm", "--g", "bin"]),
-    getNubBinPath()
+    getNubBinPath(),
+    getAubeBinPath()
   ]);
 
   return {
@@ -209,6 +221,7 @@ export async function getPackageManagersBinPaths(
     pnpm,
     npm,
     bun,
-    nub
+    nub,
+    aube
   };
 }

--- a/packages/turbo-utils/src/managers.ts
+++ b/packages/turbo-utils/src/managers.ts
@@ -182,7 +182,7 @@ async function getAubeBinPath() {
 
 export async function getAvailablePackageManagers(
   options: PackageManagerDetectionOptions = {}
-): Promise<Partial<Record<PackageManager, string | undefined>>> {
+): Promise<Record<PackageManager, string | undefined>> {
   const projectRoot = options.projectRoot ?? process.cwd();
   const [yarn, npm, pnpm, bun, nub, aube] = await Promise.all([
     getYarnVersion(projectRoot),
@@ -205,7 +205,7 @@ export async function getAvailablePackageManagers(
 
 export async function getPackageManagersBinPaths(
   options: PackageManagerDetectionOptions = {}
-): Promise<Partial<Record<PackageManager, string | undefined>>> {
+): Promise<Record<PackageManager, string | undefined>> {
   const projectRoot = options.projectRoot ?? process.cwd();
   const [yarn, npm, pnpm, bun, nub, aube] = await Promise.all([
     getYarnBinPath(projectRoot),

--- a/packages/turbo-utils/src/types.ts
+++ b/packages/turbo-utils/src/types.ts
@@ -1,6 +1,6 @@
 import type { Schema } from "@turbo/types";
 
-export type PackageManager = "npm" | "yarn" | "pnpm" | "bun" | "nub";
+export type PackageManager = "npm" | "yarn" | "pnpm" | "bun" | "nub" | "aube";
 
 export type ExitCode = 0 | 1;
 

--- a/packages/turbo-workspaces/__tests__/aube.test.ts
+++ b/packages/turbo-workspaces/__tests__/aube.test.ts
@@ -1,0 +1,397 @@
+import os from "node:os";
+import path from "node:path";
+import fs from "fs-extra";
+import { describe, it, expect } from "@jest/globals";
+import { Logger } from "../src/logger";
+import { getWorkspaceDetails } from "../src/get-workspace-details";
+import {
+  getUnderlyingLockfileManager,
+  getUnderlyingLockfileName,
+  getWorkspacePackageManager
+} from "../src/utils";
+import { MANAGERS } from "../src/managers";
+
+function makeWorkspace(files: Record<string, unknown>): string {
+  const workspaceRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), "turbo-workspaces-aube-")
+  );
+
+  for (const [filePath, content] of Object.entries(files)) {
+    const absolutePath = path.join(workspaceRoot, filePath);
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+    if (typeof content === "string") {
+      fs.writeFileSync(absolutePath, content);
+    } else {
+      fs.writeJsonSync(absolutePath, content);
+    }
+  }
+
+  return workspaceRoot;
+}
+
+describe("aube", () => {
+  describe("getWorkspacePackageManager", () => {
+    it("reads aube from packageManager field", () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": { packageManager: "aube@0.1.0" }
+      });
+
+      expect(getWorkspacePackageManager({ workspaceRoot })).toEqual("aube");
+    });
+
+    it("reads aube from devEngines.packageManager", () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": {
+          devEngines: {
+            packageManager: {
+              name: "aube",
+              version: "0.1.0"
+            }
+          }
+        }
+      });
+
+      expect(getWorkspacePackageManager({ workspaceRoot })).toEqual("aube");
+    });
+  });
+
+  describe("underlying lockfile resolution", () => {
+    it("defaults to npm when no lockfile exists", () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": { packageManager: "aube@0.1.0" }
+      });
+
+      expect(getUnderlyingLockfileManager({ workspaceRoot })).toEqual("npm");
+      expect(getUnderlyingLockfileName({ workspaceRoot })).toEqual(
+        "package-lock.json"
+      );
+    });
+
+    it("uses aube-lock.yaml when present", () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": { packageManager: "aube@0.1.0" },
+        "aube-lock.yaml": "lockfileVersion: '9.0'\n"
+      });
+
+      expect(getUnderlyingLockfileManager({ workspaceRoot })).toEqual("pnpm");
+      expect(getUnderlyingLockfileName({ workspaceRoot })).toEqual(
+        "aube-lock.yaml"
+      );
+    });
+
+    it("prefers bun over non-native foreign lockfiles", () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": { packageManager: "aube@0.1.0" },
+        "bun.lock": "",
+        "pnpm-lock.yaml": "",
+        "yarn.lock": "",
+        "package-lock.json": "{}"
+      });
+
+      expect(getUnderlyingLockfileManager({ workspaceRoot })).toEqual("bun");
+      expect(getUnderlyingLockfileName({ workspaceRoot })).toEqual("bun.lock");
+    });
+  });
+
+  describe("detection", () => {
+    it("detects aube only via packageManager field", async () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": {},
+        "aube-lock.yaml": "lockfileVersion: '9.0'\n"
+      });
+
+      await expect(MANAGERS.aube.detect({ workspaceRoot })).resolves.toEqual(
+        false
+      );
+    });
+
+    it("detects aube when packageManager field is set", async () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": { packageManager: "aube@0.1.0" },
+        "aube-lock.yaml": "lockfileVersion: '9.0'\n"
+      });
+
+      await expect(MANAGERS.aube.detect({ workspaceRoot })).resolves.toEqual(
+        true
+      );
+    });
+  });
+
+  describe("getWorkspaceDetails", () => {
+    it("returns aube as the package manager", async () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": {
+          name: "aube-project",
+          packageManager: "aube@0.1.0",
+          workspaces: ["packages/*"]
+        },
+        "package-lock.json": "{}"
+      });
+
+      const project = await getWorkspaceDetails({ root: workspaceRoot });
+
+      expect(project.packageManager).toEqual("aube");
+      expect(project.paths.lockfile).toEqual(
+        path.join(workspaceRoot, "package-lock.json")
+      );
+      expect(project.workspaceData.globs).toEqual(["packages/*"]);
+    });
+  });
+
+  describe("manager operations", () => {
+    it("creates aube workspace metadata", async () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": {
+          name: "aube-project",
+          packageManager: "npm@10.0.0",
+          workspaces: ["packages/*"]
+        },
+        "package-lock.json": "{}"
+      });
+      const project = await MANAGERS.npm.read({ workspaceRoot });
+      const packageJsonPath = path.join(workspaceRoot, "package.json");
+
+      await MANAGERS.aube.create({
+        project,
+        to: { name: "aube", version: "0.1.0" },
+        logger: new Logger({ dry: false, interactive: false })
+      });
+
+      const packageJson = fs.readJsonSync(packageJsonPath);
+      expect(packageJson.devEngines?.packageManager).toEqual({
+        name: "aube",
+        version: "0.1.0"
+      });
+      expect(packageJson.packageManager).toBeUndefined();
+    });
+
+    it("creates aube metadata without workspaces", async () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": {
+          name: "aube-project",
+          packageManager: "npm@10.0.0"
+        },
+        "package-lock.json": "{}"
+      });
+      const project = await MANAGERS.npm.read({ workspaceRoot });
+
+      await MANAGERS.aube.create({
+        project: { ...project, workspaceData: { globs: [], workspaces: [] } },
+        to: { name: "aube", version: "0.1.0" },
+        logger: new Logger({ dry: false, interactive: false })
+      });
+
+      const packageJson = fs.readJsonSync(
+        path.join(workspaceRoot, "package.json")
+      );
+      expect(packageJson.devEngines?.packageManager).toEqual({
+        name: "aube",
+        version: "0.1.0"
+      });
+    });
+
+    it("does not write aube metadata during dry creation", async () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": {
+          name: "aube-project",
+          packageManager: "npm@10.0.0"
+        },
+        "package-lock.json": "{}"
+      });
+      const project = await MANAGERS.npm.read({ workspaceRoot });
+
+      await MANAGERS.aube.create({
+        project: { ...project, workspaceData: { globs: [], workspaces: [] } },
+        to: { name: "aube", version: "0.1.0" },
+        logger: new Logger({ dry: true, interactive: false }),
+        options: { dry: true }
+      });
+
+      const packageJson = fs.readJsonSync(
+        path.join(workspaceRoot, "package.json")
+      );
+      expect(packageJson.devEngines?.packageManager).toBeUndefined();
+    });
+
+    it("removes aube workspace metadata", async () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": {
+          name: "aube-project",
+          devEngines: {
+            packageManager: {
+              name: "aube",
+              version: "0.1.0"
+            }
+          },
+          workspaces: ["packages/*"]
+        },
+        "packages/app/package.json": { name: "app" },
+        "packages/app/node_modules/.keep": ""
+      });
+      const project = await MANAGERS.aube.read({ workspaceRoot });
+
+      await MANAGERS.aube.remove({
+        project,
+        to: { name: "npm", version: "10.0.0" },
+        logger: new Logger({ dry: false, interactive: false })
+      });
+
+      const packageJson = fs.readJsonSync(
+        path.join(workspaceRoot, "package.json")
+      );
+      expect(packageJson.workspaces).toBeUndefined();
+      expect(packageJson.devEngines?.packageManager).toBeUndefined();
+      expect(
+        fs.existsSync(path.join(workspaceRoot, "packages/app/node_modules"))
+      ).toEqual(false);
+    });
+
+    it("does not remove aube metadata during dry removal", async () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": {
+          name: "aube-project",
+          devEngines: {
+            packageManager: {
+              name: "aube",
+              version: "0.1.0"
+            }
+          },
+          workspaces: ["packages/*"]
+        }
+      });
+      const project = await MANAGERS.aube.read({ workspaceRoot });
+
+      await MANAGERS.aube.remove({
+        project,
+        to: { name: "npm", version: "10.0.0" },
+        logger: new Logger({ dry: true, interactive: false }),
+        options: { dry: true }
+      });
+
+      const packageJson = fs.readJsonSync(
+        path.join(workspaceRoot, "package.json")
+      );
+      expect(packageJson.workspaces).toEqual(["packages/*"]);
+      expect(packageJson.devEngines?.packageManager).toEqual({
+        name: "aube",
+        version: "0.1.0"
+      });
+    });
+
+    it("cleans the underlying lockfile", async () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": {
+          name: "aube-project",
+          packageManager: "aube@0.1.0"
+        },
+        "aube-lock.yaml": "lockfileVersion: '9.0'\n"
+      });
+      const project = await MANAGERS.aube.read({ workspaceRoot });
+
+      await MANAGERS.aube.clean({
+        project,
+        logger: new Logger({ dry: false, interactive: false })
+      });
+
+      expect(fs.existsSync(path.join(workspaceRoot, "aube-lock.yaml"))).toEqual(
+        false
+      );
+    });
+
+    it("does not clean the underlying lockfile during dry clean", async () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": {
+          name: "aube-project",
+          packageManager: "aube@0.1.0"
+        },
+        "aube-lock.yaml": "lockfileVersion: '9.0'\n"
+      });
+      const project = await MANAGERS.aube.read({ workspaceRoot });
+
+      await MANAGERS.aube.clean({
+        project,
+        logger: new Logger({ dry: true, interactive: false }),
+        options: { dry: true }
+      });
+
+      expect(fs.existsSync(path.join(workspaceRoot, "aube-lock.yaml"))).toEqual(
+        true
+      );
+    });
+
+    it("removes foreign lockfiles when converting to aube", async () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": {
+          name: "pnpm-project",
+          packageManager: "pnpm@9.0.0"
+        },
+        "pnpm-lock.yaml": "lockfileVersion: '9.0'\n"
+      });
+      const project = await MANAGERS.pnpm.read({ workspaceRoot });
+
+      await MANAGERS.aube.convertLock({
+        project,
+        to: { name: "aube", version: "0.1.0" },
+        logger: new Logger({ dry: false, interactive: false })
+      });
+
+      expect(fs.existsSync(path.join(workspaceRoot, "pnpm-lock.yaml"))).toEqual(
+        false
+      );
+    });
+
+    it("keeps compatible lockfiles when converting to aube", async () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": {
+          name: "npm-project",
+          packageManager: "npm@10.0.0"
+        },
+        "package-lock.json": "{}"
+      });
+      const project = await MANAGERS.npm.read({ workspaceRoot });
+
+      await MANAGERS.aube.convertLock({
+        project,
+        to: { name: "aube", version: "0.1.0" },
+        logger: new Logger({ dry: false, interactive: false })
+      });
+
+      expect(
+        fs.existsSync(path.join(workspaceRoot, "package-lock.json"))
+      ).toEqual(true);
+    });
+
+    it("reads workspace data from aube-workspace.yaml", async () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": {
+          name: "aube-project",
+          packageManager: "aube@0.1.0"
+        },
+        "aube-lock.yaml": "lockfileVersion: '9.0'\n",
+        "aube-workspace.yaml": "packages:\n  - packages/*\n"
+      });
+
+      const project = await MANAGERS.aube.read({ workspaceRoot });
+
+      expect(project.packageManager).toEqual("aube");
+      expect(project.paths.lockfile).toEqual(
+        path.join(workspaceRoot, "aube-lock.yaml")
+      );
+      expect(project.paths.workspaceConfig).toEqual(
+        path.join(workspaceRoot, "aube-workspace.yaml")
+      );
+      expect(project.workspaceData.globs).toEqual(["packages/*"]);
+    });
+
+    it("throws when read is called on a non-aube project", async () => {
+      const workspaceRoot = makeWorkspace({
+        "package.json": { packageManager: "npm@10.0.0" },
+        "package-lock.json": "{}"
+      });
+
+      await expect(MANAGERS.aube.read({ workspaceRoot })).rejects.toThrow(
+        "Not an aube project"
+      );
+    });
+  });
+});

--- a/packages/turbo-workspaces/__tests__/index.test.ts
+++ b/packages/turbo-workspaces/__tests__/index.test.ts
@@ -209,7 +209,8 @@ describe("Node entrypoint", () => {
             yarn: "1.22.19",
             pnpm: "7.29.1",
             bun: "1.0.1",
-            nub: "0.1.0"
+            nub: "0.1.0",
+            aube: "0.1.0"
           });
 
         const { root } = useFixture({
@@ -252,7 +253,8 @@ describe("Node entrypoint", () => {
             yarn: "1.22.19",
             pnpm: "7.29.1",
             bun: "1.0.1",
-            nub: "0.1.0"
+            nub: "0.1.0",
+            aube: "0.1.0"
           });
 
         const { root } = useFixture({

--- a/packages/turbo-workspaces/src/commands/convert/index.ts
+++ b/packages/turbo-workspaces/src/commands/convert/index.ts
@@ -15,7 +15,7 @@ function isPackageManagerDisabled({
 }: {
   packageManager: PackageManager;
   currentWorkspaceManger: PackageManager;
-  availablePackageManagers: Partial<Record<PackageManager, string | undefined>>;
+  availablePackageManagers: Record<PackageManager, string | undefined>;
 }) {
   if (currentWorkspaceManger === packageManager) {
     return "already in use";

--- a/packages/turbo-workspaces/src/commands/convert/index.ts
+++ b/packages/turbo-workspaces/src/commands/convert/index.ts
@@ -15,7 +15,7 @@ function isPackageManagerDisabled({
 }: {
   packageManager: PackageManager;
   currentWorkspaceManger: PackageManager;
-  availablePackageManagers: Record<PackageManager, string | undefined>;
+  availablePackageManagers: Partial<Record<PackageManager, string | undefined>>;
 }) {
   if (currentWorkspaceManger === packageManager) {
     return "already in use";

--- a/packages/turbo-workspaces/src/install.ts
+++ b/packages/turbo-workspaces/src/install.ts
@@ -91,6 +91,18 @@ export const PACKAGE_MANAGERS: Record<
       semver: "*",
       default: true
     }
+  ],
+  aube: [
+    {
+      name: "aube",
+      template: "aube",
+      command: "aube",
+      installArgs: ["install"],
+      version: "latest",
+      executable: "aube",
+      semver: "*",
+      default: true
+    }
   ]
 };
 

--- a/packages/turbo-workspaces/src/managers/aube.ts
+++ b/packages/turbo-workspaces/src/managers/aube.ts
@@ -24,7 +24,6 @@ import {
   removePackageManagerDeclaration,
   parseWorkspacePackages,
   getAubeWorkspaces,
-  getPnpmWorkspaces,
   getUnderlyingLockfileManager,
   getUnderlyingLockfileName,
   removeLockFile
@@ -77,7 +76,6 @@ async function read(args: ReadArgs): Promise<Project> {
     workspaceRoot: args.workspaceRoot
   });
   const aubeGlobs = getAubeWorkspaces(args);
-  const pnpmGlobs = getPnpmWorkspaces(args);
   let workspaceConfig: string | undefined;
   let workspaceGlobs = parseWorkspacePackages({
     workspaces: packageJson.workspaces
@@ -85,9 +83,6 @@ async function read(args: ReadArgs): Promise<Project> {
   if (aubeGlobs.length > 0) {
     workspaceConfig = "aube-workspace.yaml";
     workspaceGlobs = aubeGlobs;
-  } else if (underlying === "pnpm" && pnpmGlobs.length > 0) {
-    workspaceConfig = "pnpm-workspace.yaml";
-    workspaceGlobs = pnpmGlobs;
   }
 
   return {

--- a/packages/turbo-workspaces/src/managers/aube.ts
+++ b/packages/turbo-workspaces/src/managers/aube.ts
@@ -23,55 +23,81 @@ import {
   setPackageManagerDeclaration,
   removePackageManagerDeclaration,
   parseWorkspacePackages,
-  isCompatibleWithBunWorkspaces,
+  getAubeWorkspaces,
+  getPnpmWorkspaces,
+  getUnderlyingLockfileManager,
+  getUnderlyingLockfileName,
   removeLockFile
 } from "../utils";
+import { npm } from "./npm";
+import { pnpm } from "./pnpm";
+import { yarn } from "./yarn";
+import { bun } from "./bun";
 
 const PACKAGE_MANAGER_DETAILS: Manager = {
-  name: "bun",
-  lock: "bun.lockb"
+  name: "aube",
+  lock: "package-lock.json"
 };
 
-/**
- * Check if a given project is using bun workspaces
- * Verify by checking for the existence of:
- *  1. bun.lockb
- *  2. Package manager declaration in package.json
- */
+const UNDERLYING_MANAGERS = {
+  npm,
+  pnpm,
+  yarn,
+  bun
+} as const;
+
 // eslint-disable-next-line @typescript-eslint/require-await -- must match the detect type signature
 async function detect(args: DetectArgs): Promise<boolean> {
-  const lockFile = path.join(args.workspaceRoot, PACKAGE_MANAGER_DETAILS.lock);
-  const packageManager = getWorkspacePackageManager({
-    workspaceRoot: args.workspaceRoot
-  });
   return (
-    fs.existsSync(lockFile) || packageManager === PACKAGE_MANAGER_DETAILS.name
+    getWorkspacePackageManager({ workspaceRoot: args.workspaceRoot }) ===
+    PACKAGE_MANAGER_DETAILS.name
   );
 }
 
-/**
-  Read workspace data from bun workspaces into generic format
-*/
 async function read(args: ReadArgs): Promise<Project> {
-  const isBun = await detect(args);
-  if (!isBun) {
-    throw new ConvertError("Not a bun project", {
+  if (!(await detect(args))) {
+    throw new ConvertError("Not an aube project", {
       type: "package_manager-unexpected"
     });
   }
 
+  const underlying = getUnderlyingLockfileManager({
+    workspaceRoot: args.workspaceRoot
+  });
+  const underlyingHandler = UNDERLYING_MANAGERS[underlying];
+
+  if (await underlyingHandler.detect(args)) {
+    const project = await underlyingHandler.read(args);
+    return { ...project, packageManager: PACKAGE_MANAGER_DETAILS.name };
+  }
+
   const packageJson = getPackageJson(args);
   const { name, description } = getWorkspaceInfo(args);
-  const workspaceGlobs = parseWorkspacePackages({
+  const lockfile = getUnderlyingLockfileName({
+    workspaceRoot: args.workspaceRoot
+  });
+  const aubeGlobs = getAubeWorkspaces(args);
+  const pnpmGlobs = getPnpmWorkspaces(args);
+  let workspaceConfig: string | undefined;
+  let workspaceGlobs = parseWorkspacePackages({
     workspaces: packageJson.workspaces
   });
+  if (aubeGlobs.length > 0) {
+    workspaceConfig = "aube-workspace.yaml";
+    workspaceGlobs = aubeGlobs;
+  } else if (underlying === "pnpm" && pnpmGlobs.length > 0) {
+    workspaceConfig = "pnpm-workspace.yaml";
+    workspaceGlobs = pnpmGlobs;
+  }
+
   return {
     name,
     description,
     packageManager: PACKAGE_MANAGER_DETAILS.name,
     paths: expandPaths({
       root: args.workspaceRoot,
-      lockFile: PACKAGE_MANAGER_DETAILS.lock
+      lockFile: lockfile,
+      workspaceConfig
     }),
     workspaceData: {
       globs: workspaceGlobs,
@@ -83,28 +109,10 @@ async function read(args: ReadArgs): Promise<Project> {
   };
 }
 
-/**
- * Create bun workspaces from generic format
- *
- * Creating bun workspaces involves:
- *  1. Validating that the project can be converted to bun workspace
- *  2. Adding the workspaces field in package.json
- *  3. Setting the devEngines.packageManager field in package.json
- *  4. Updating all workspace package.json dependencies to ensure correct format
- */
 // eslint-disable-next-line @typescript-eslint/require-await -- must match the create type signature
 async function create(args: CreateArgs): Promise<void> {
-  const { project, to, logger, options } = args;
+  const { project, options, to, logger } = args;
   const hasWorkspaces = project.workspaceData.globs.length > 0;
-
-  if (!isCompatibleWithBunWorkspaces({ project })) {
-    throw new ConvertError(
-      "Unable to convert project to bun - workspace globs unsupported",
-      {
-        type: "bun-workspace_glob_error"
-      }
-    );
-  }
 
   logger.mainStep(
     getMainStep({
@@ -116,7 +124,6 @@ async function create(args: CreateArgs): Promise<void> {
   const packageJson = getPackageJson({ workspaceRoot: project.paths.root });
   logger.rootHeader();
 
-  // package manager
   logger.rootStep(
     `adding "devEngines.packageManager" field to ${path.relative(
       project.paths.root,
@@ -130,7 +137,6 @@ async function create(args: CreateArgs): Promise<void> {
   });
 
   if (hasWorkspaces) {
-    // workspaces field
     logger.rootStep(
       `adding "workspaces" field to ${path.relative(
         project.paths.root,
@@ -143,7 +149,6 @@ async function create(args: CreateArgs): Promise<void> {
       fs.writeJSONSync(project.paths.packageJson, packageJson, { spaces: 2 });
     }
 
-    // root dependencies
     updateDependencies({
       workspace: { name: "root", paths: project.paths },
       project,
@@ -152,7 +157,6 @@ async function create(args: CreateArgs): Promise<void> {
       options
     });
 
-    // workspace dependencies
     logger.workspaceHeader();
     for (const workspace of project.workspaceData.workspaces) {
       updateDependencies({ workspace, project, to, logger, options });
@@ -162,13 +166,6 @@ async function create(args: CreateArgs): Promise<void> {
   }
 }
 
-/**
- * Remove bun workspace data
- *
- * Removing bun workspaces involves:
- *  1. Removing the workspaces field from package.json
- *  2. Removing the node_modules directory
- */
 async function remove(args: RemoveArgs): Promise<void> {
   const { project, logger, options } = args;
   const hasWorkspaces = project.workspaceData.globs.length > 0;
@@ -199,32 +196,16 @@ async function remove(args: RemoveArgs): Promise<void> {
 
   if (!options?.dry) {
     fs.writeJSONSync(project.paths.packageJson, packageJson, { spaces: 2 });
-
-    // collect all workspace node_modules directories
     const allModulesDirs = [
       project.paths.nodeModules,
       ...project.workspaceData.workspaces.map((w) => w.paths.nodeModules)
     ];
-    try {
-      logger.subStep(`removing "node_modules"`);
-      await Promise.all(
-        allModulesDirs.map((dir) =>
-          fs.rm(dir, { recursive: true, force: true })
-        )
-      );
-    } catch (err) {
-      throw new ConvertError("Failed to remove node_modules", {
-        type: "error_removing_node_modules"
-      });
-    }
+    await Promise.all(
+      allModulesDirs.map((dir) => fs.rm(dir, { recursive: true, force: true }))
+    );
   }
 }
 
-/**
- * Clean is called post install, and is used to clean up any files
- * from this package manager that were needed for install,
- * but not required after migration
- */
 // eslint-disable-next-line @typescript-eslint/require-await -- must match the clean type signature
 async function clean(args: CleanArgs): Promise<void> {
   const { project, logger, options } = args;
@@ -237,48 +218,26 @@ async function clean(args: CleanArgs): Promise<void> {
   }
 }
 
-/**
- * Attempts to convert an existing, non bun lockfile to a bun lockfile
- *
- * If this is not possible, the non bun lockfile is removed
- */
 // eslint-disable-next-line @typescript-eslint/require-await -- must match the convertLock type signature
 async function convertLock(args: ConvertArgs): Promise<void> {
   const { project, options } = args;
 
-  // handle moving lockfile from `packageManager` to npm
   switch (project.packageManager) {
-    case "pnpm": {
-      // can't convert from pnpm to bun - just remove the lock
-      removeLockFile({ project, options });
-      break;
-    }
-    case "bun": {
-      // we're already using bun, so we don't need to convert
-      break;
-    }
-    case "npm": {
-      // can't convert from npm to bun - just remove the lock
-      removeLockFile({ project, options });
-      break;
-    }
+    case "pnpm":
+    case "bun":
     case "yarn": {
-      // can't convert from yarn to bun - just remove the lock
       removeLockFile({ project, options });
       break;
     }
-    case "nub": {
-      removeLockFile({ project, options });
-      break;
-    }
+    case "npm":
+    case "nub":
     case "aube": {
-      removeLockFile({ project, options });
       break;
     }
   }
 }
 
-export const bun: ManagerHandler = {
+export const aube: ManagerHandler = {
   detect,
   read,
   create,

--- a/packages/turbo-workspaces/src/managers/index.ts
+++ b/packages/turbo-workspaces/src/managers/index.ts
@@ -1,5 +1,6 @@
 import type { PackageManager } from "../types";
 import type { ManagerHandler } from "../types";
+import { aube } from "./aube";
 import { nub } from "./nub";
 import { pnpm } from "./pnpm";
 import { npm } from "./npm";
@@ -7,6 +8,7 @@ import { yarn } from "./yarn";
 import { bun } from "./bun";
 
 export const MANAGERS: Record<PackageManager, ManagerHandler> = {
+  aube,
   nub,
   pnpm,
   yarn,

--- a/packages/turbo-workspaces/src/managers/npm.ts
+++ b/packages/turbo-workspaces/src/managers/npm.ts
@@ -260,6 +260,10 @@ async function convertLock(args: ConvertArgs): Promise<void> {
       removeLockFile({ project, options });
       break;
     }
+    case "aube": {
+      removeLockFile({ project, options });
+      break;
+    }
   }
 }
 

--- a/packages/turbo-workspaces/src/managers/nub.ts
+++ b/packages/turbo-workspaces/src/managers/nub.ts
@@ -242,6 +242,9 @@ async function convertLock(args: ConvertArgs): Promise<void> {
     case "nub": {
       break;
     }
+    case "aube": {
+      break;
+    }
   }
 }
 

--- a/packages/turbo-workspaces/src/managers/pnpm.ts
+++ b/packages/turbo-workspaces/src/managers/pnpm.ts
@@ -291,6 +291,10 @@ async function convertLock(args: ConvertArgs): Promise<void> {
       removeLockFile({ project, options });
       break;
     }
+    case "aube": {
+      removeLockFile({ project, options });
+      break;
+    }
   }
 }
 

--- a/packages/turbo-workspaces/src/managers/yarn.ts
+++ b/packages/turbo-workspaces/src/managers/yarn.ts
@@ -270,6 +270,10 @@ async function convertLock(args: ConvertArgs): Promise<void> {
       removeLockFile({ project, options });
       break;
     }
+    case "aube": {
+      removeLockFile({ project, options });
+      break;
+    }
   }
 }
 

--- a/packages/turbo-workspaces/src/types.ts
+++ b/packages/turbo-workspaces/src/types.ts
@@ -1,6 +1,6 @@
 import type { Logger } from "./logger";
 
-export type PackageManager = "npm" | "yarn" | "pnpm" | "bun" | "nub";
+export type PackageManager = "npm" | "yarn" | "pnpm" | "bun" | "nub" | "aube";
 
 export interface Manager {
   name: PackageManager;

--- a/packages/turbo-workspaces/src/utils.ts
+++ b/packages/turbo-workspaces/src/utils.ts
@@ -313,7 +313,10 @@ function getPnpmWorkspaces({
 }: {
   workspaceRoot: string;
 }): Array<string> {
-  return getYamlWorkspaces({ workspaceRoot, workspaceFileName: "pnpm-workspace.yaml" });
+  return getYamlWorkspaces({
+    workspaceRoot,
+    workspaceFileName: "pnpm-workspace.yaml"
+  });
 }
 
 function getAubeWorkspaces({
@@ -321,7 +324,10 @@ function getAubeWorkspaces({
 }: {
   workspaceRoot: string;
 }): Array<string> {
-  return getYamlWorkspaces({ workspaceRoot, workspaceFileName: "aube-workspace.yaml" });
+  return getYamlWorkspaces({
+    workspaceRoot,
+    workspaceFileName: "aube-workspace.yaml"
+  });
 }
 
 function getYamlWorkspaces({

--- a/packages/turbo-workspaces/src/utils.ts
+++ b/packages/turbo-workspaces/src/utils.ts
@@ -46,7 +46,8 @@ const SUPPORTED_PACKAGE_MANAGERS = new Set<PackageManager>([
   "pnpm",
   "yarn",
   "bun",
-  "nub"
+  "nub",
+  "aube"
 ]);
 const DEV_ENGINES_VERSION_REGEX =
   /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
@@ -159,7 +160,7 @@ function getWorkspacePackageManager({
 
   if (!isPackageManager(name)) {
     throw invalidDevEnginesPackageManager(
-      "`devEngines.packageManager.name` must be one of `npm`, `pnpm`, `yarn`, `bun`, or `nub`"
+      "`devEngines.packageManager.name` must be one of `npm`, `pnpm`, `yarn`, `bun`, `nub`, or `aube`"
     );
   }
 
@@ -312,7 +313,25 @@ function getPnpmWorkspaces({
 }: {
   workspaceRoot: string;
 }): Array<string> {
-  const workspaceFile = path.join(workspaceRoot, "pnpm-workspace.yaml");
+  return getYamlWorkspaces({ workspaceRoot, workspaceFileName: "pnpm-workspace.yaml" });
+}
+
+function getAubeWorkspaces({
+  workspaceRoot
+}: {
+  workspaceRoot: string;
+}): Array<string> {
+  return getYamlWorkspaces({ workspaceRoot, workspaceFileName: "aube-workspace.yaml" });
+}
+
+function getYamlWorkspaces({
+  workspaceRoot,
+  workspaceFileName
+}: {
+  workspaceRoot: string;
+  workspaceFileName: string;
+}): Array<string> {
+  const workspaceFile = path.join(workspaceRoot, workspaceFileName);
   if (existsSync(workspaceFile)) {
     try {
       const workspaceConfig = yaml.load(readFileSync(workspaceFile, "utf8"));
@@ -418,14 +437,14 @@ function expandWorkspaces({
     });
 }
 
-type LockfilePackageManager = Exclude<PackageManager, "nub">;
+type LockfilePackageManager = Exclude<PackageManager, "nub" | "aube">;
 
 const LOCKFILE_PROBE_ORDER: Array<{
   manager: LockfilePackageManager;
   lockfiles: Array<string>;
 }> = [
   { manager: "bun", lockfiles: ["bun.lock", "bun.lockb"] },
-  { manager: "pnpm", lockfiles: ["pnpm-lock.yaml"] },
+  { manager: "pnpm", lockfiles: ["aube-lock.yaml", "pnpm-lock.yaml"] },
   { manager: "yarn", lockfiles: ["yarn.lock"] },
   { manager: "npm", lockfiles: ["package-lock.json"] }
 ];
@@ -463,6 +482,9 @@ function getUnderlyingLockfileName({
       return "bun.lockb";
     }
     case "pnpm": {
+      if (existsSync(path.join(workspaceRoot, "aube-lock.yaml"))) {
+        return "aube-lock.yaml";
+      }
       return "pnpm-lock.yaml";
     }
     case "yarn": {
@@ -580,6 +602,7 @@ export {
   expandPaths,
   expandWorkspaces,
   parseWorkspacePackages,
+  getAubeWorkspaces,
   getPnpmWorkspaces,
   getUnderlyingLockfileManager,
   getUnderlyingLockfileName,


### PR DESCRIPTION
## Why

Aube can run Turborepo workspaces using existing package-manager lockfiles or aube-native lockfiles. Supporting it lets projects that use aube get correct package discovery, lockfile parsing, pruning, codemod guidance, and create-turbo scaffolding instead of being rejected as an unknown package manager.

## What

- Adds aube as a package-manager identity in Rust package-manager resolution and daemon serialization.
- Delegates aube lockfile behavior to the underlying lockfile format, including aube-native and pnpm-family workspace metadata.
- Updates create-turbo, turbo-workspaces, turbo-utils, and turbo-codemod to recognize and use aube commands.
- Adds focused Rust and JS test coverage for aube detection and package-manager mocks.