### PR TITLE
fix: Normalize package manager version output

### DIFF
--- a/packages/turbo-utils/__tests__/managers.test.ts
+++ b/packages/turbo-utils/__tests__/managers.test.ts
@@ -80,6 +80,24 @@ describe("managers", () => {
       });
     });
 
+    test("should parse package manager versions from verbose output", async () => {
+      mockExeca
+        .mockResolvedValueOnce({ stdout: "1.22.19" } as any) // yarn
+        .mockResolvedValueOnce({ stdout: "9.5.0" } as any) // npm
+        .mockResolvedValueOnce({ stdout: "8.6.7" } as any) // pnpm
+        .mockResolvedValueOnce({ stdout: "1.0.0" } as any) // bun
+        .mockResolvedValueOnce({ stdout: "0.1.0" } as any) // nub
+        .mockResolvedValueOnce({
+          stdout: "1.25.1 macos-arm64 (2026-06-30)"
+        } as any); // aube
+
+      const result = await getAvailablePackageManagers({
+        projectRoot: MISSING_PROJECT_ROOT
+      });
+
+      expect(result.aube).toBe("1.25.1");
+    });
+
     test("should return undefined for unavailable package managers", async () => {
       mockExeca
         .mockResolvedValueOnce({ stdout: "1.22.19" } as any) // yarn

--- a/packages/turbo-utils/src/managers.ts
+++ b/packages/turbo-utils/src/managers.ts
@@ -7,6 +7,7 @@ import type { PackageManager } from "./types";
 
 const EXEC_TIMEOUT = 5000;
 const SEMVER_VERSION = "\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?";
+const PACKAGE_MANAGER_VERSION = new RegExp(`(?<version>${SEMVER_VERSION})`);
 const YARN_PACKAGE_MANAGER_VERSION = new RegExp(
   `^yarn@(?<version>${SEMVER_VERSION})(?:\\+[0-9A-Za-z.-]+)?$`
 );
@@ -39,6 +40,10 @@ async function exec(command: string, args: Array<string> = [], opts?: Options) {
   } catch {
     return undefined;
   }
+}
+
+function parsePackageManagerVersion(output: string | undefined) {
+  return output?.match(PACKAGE_MANAGER_VERSION)?.groups?.version;
 }
 
 function readFile(filePath: string): string | undefined {
@@ -194,12 +199,12 @@ export async function getAvailablePackageManagers(
   ]);
 
   return {
-    yarn,
-    pnpm,
-    npm,
-    bun,
-    nub,
-    aube
+    yarn: parsePackageManagerVersion(yarn),
+    pnpm: parsePackageManagerVersion(pnpm),
+    npm: parsePackageManagerVersion(npm),
+    bun: parsePackageManagerVersion(bun),
+    nub: parsePackageManagerVersion(nub),
+    aube: parsePackageManagerVersion(aube)
   };
 }
 


### PR DESCRIPTION
## Why
create-turbo records detected package manager versions in devEngines.packageManager. aube prints platform/build metadata in its --version output, which produced an invalid exact semantic version in generated package.json files.

## What
Normalize detected package manager CLI output to the first semantic version before create-turbo consumes it. Add regression coverage for verbose aube version output.