### PR TITLE
fix: Tweaks for nub support

### DIFF
--- a/crates/turborepo-repository/src/package_manager/mod.rs
+++ b/crates/turborepo-repository/src/package_manager/mod.rs
@@ -994,16 +994,15 @@ impl PackageManager {
                 .then(|| PackageManager::Aube {
                     lockfile: Box::new(aube::underlying_lockfile_manager(repo_root)),
                 });
-        let native_nub =
-            repo_root
-                .join_component(nub::LOCKFILE)
-                .exists()
-                .then(|| PackageManager::Nub {
-                    lockfile: Box::new(nub::underlying_lockfile_manager(repo_root)),
-                });
+        // nub is recognized ONLY through the `packageManager` field /
+        // `devEngines.packageManager` (handled in `get_package_manager`), never
+        // from the presence of its `lock.yaml`: nub's lockfile name is
+        // deliberately neutral and nub is lockfile-compatible with whatever the
+        // project already uses, so the file's presence is not a reliable nub
+        // signal. Lockfile parsing still happens once nub is detected via the
+        // field — only the name-based *detection* is dropped here.
         let detected_package_managers = native_aube
             .into_iter()
-            .chain(native_nub)
             .map(Ok)
             .chain(PnpmDetector::new(repo_root))
             .chain(NpmDetector::new(repo_root))
@@ -1325,9 +1324,13 @@ impl PackageManager {
                 pnpm::link_workspace_packages(pnpm_version, repo_root)
             }
             PackageManager::Yarn | PackageManager::Bun | PackageManager::Npm => true,
-            // nub links workspace packages by default, delegating to the
-            // underlying manager's behavior where it has one.
-            PackageManager::Nub { lockfile } => lockfile.link_workspace_packages(repo_root),
+            // nub links a local workspace package for a bare version specifier
+            // (e.g. `"@repo/ui": "*"`), like npm/yarn/bun and unlike pnpm. It
+            // does not require the `workspace:` protocol. Delegating to the
+            // underlying lockfile format (pnpm) would default this to false and
+            // drop every internal workspace edge declared without `workspace:`,
+            // so resolve it from nub's own behavior instead.
+            PackageManager::Nub { .. } => true,
             PackageManager::Aube { lockfile } => match lockfile.as_ref() {
                 PackageManager::Pnpm9 | PackageManager::Pnpm | PackageManager::Pnpm6 => {
                     let pnpm_version = pnpm::PnpmVersion::try_from(lockfile.as_ref())
@@ -1878,8 +1881,11 @@ mod tests {
     }
 
     #[test]
-    fn test_native_nub_lockfile_with_existing_lockfile_is_ambiguous() -> Result<(), Error> {
+    fn test_native_nub_lockfile_is_ignored_by_detection() -> Result<(), Error> {
         let (_dir, repo_root) = temp_repo_root()?;
+        // A native `lock.yaml` does not participate in detection (nub is
+        // field-only), so a co-present `pnpm-lock.yaml` resolves cleanly to pnpm
+        // rather than producing an ambiguous multi-manager result.
         std::fs::write(
             repo_root.join_component(nub::LOCKFILE).as_std_path(),
             "lockfileVersion: '9.0'\nimporters:\n  .: {}\n",
@@ -1889,10 +1895,28 @@ mod tests {
             "lockfileVersion: '9.0'\nimporters:\n  .: {}\n",
         )?;
 
-        assert!(matches!(
-            PackageManager::detect_package_manager(&repo_root),
-            Err(Error::MultiplePackageManagers { .. })
-        ));
+        assert_eq!(
+            PackageManager::detect_package_manager(&repo_root)?,
+            PackageManager::Pnpm
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_nub_links_workspace_packages_unlike_underlying_pnpm() -> Result<(), Error> {
+        let (_dir, repo_root) = temp_repo_root()?;
+        // A pnpm9 manager with no workspace config defaults link-workspace-packages
+        // to false; nub links bare specifiers (`"*"`) to local workspace packages,
+        // so the Nub variant must report true regardless of its pnpm9 lockfile.
+        // Without this, every internal workspace edge declared without the
+        // `workspace:` protocol is dropped from the graph.
+        assert!(!PackageManager::Pnpm9.link_workspace_packages(&repo_root));
+        assert!(
+            PackageManager::Nub {
+                lockfile: Box::new(PackageManager::Pnpm9)
+            }
+            .link_workspace_packages(&repo_root)
+        );
         Ok(())
     }
 

--- a/crates/turborepo-repository/src/package_manager/nub.rs
+++ b/crates/turborepo-repository/src/package_manager/nub.rs
@@ -4,14 +4,17 @@
 //! Node and ships a pnpm-compatible package-manager command surface. Unlike the
 //! other supported package managers, nub does not define its own lockfile
 //! format: it is lockfile-compatible with whatever the project already uses
-//! (npm, pnpm, yarn, or bun). For that reason nub is recognized through the
-//! `packageManager` field in `package.json` (`"nub@x.y.z"`) or nub's native
-//! `lock.yaml`; a bare foreign lockfile alone does not imply nub.
+//! (npm, pnpm, yarn, or bun). For that reason nub is recognized ONLY through
+//! the `packageManager` field in `package.json` (`"nub@x.y.z"`) or
+//! `devEngines.packageManager` — never from the presence of a lockfile. nub's
+//! `lock.yaml` name is deliberately neutral, so its presence is not a reliable
+//! nub signal; a bare lockfile (nub's or any other) alone does not imply nub.
 //!
 //! Because Turborepo needs a parsed lockfile for pruning and cache hashing, the
 //! [`PackageManager::Nub`] variant carries the concrete package manager whose
 //! lockfile is present in the repository, and lockfile-related operations
-//! delegate to it.
+//! delegate to it. That parsing happens once nub is detected via the field;
+//! the lockfile name is never itself a detection signal.
 
 use turbopath::AbsoluteSystemPath;
 
@@ -66,7 +69,34 @@ mod tests {
         let detected = PackageManager::detect_package_manager(&repo_root).unwrap();
         assert_eq!(detected, PackageManager::Npm);
 
-        // A foreign lockfile alone must not imply nub.
+        // The `packageManager` field is the nub signal.
+        let package_json = PackageJson {
+            package_manager: Some(Spanned::new("nub@0.1.0".to_string())),
+            ..Default::default()
+        };
+        let pm = PackageManager::read_or_detect_package_manager(&package_json, &repo_root).unwrap();
+        assert!(matches!(pm, PackageManager::Nub { .. }));
+    }
+
+    #[test]
+    fn test_native_lockfile_without_field_is_not_nub() {
+        let dir = tempdir().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(dir.path()).unwrap();
+
+        // A native `lock.yaml` with NO `packageManager` field must NOT be
+        // detected as nub: nub is recognized only via the field. With no other
+        // recognized lockfile present, detection finds no package manager.
+        repo_root
+            .join_component(LOCKFILE)
+            .create_with_contents("lockfileVersion: '9.0'\n")
+            .unwrap();
+        let detected = PackageManager::detect_package_manager(&repo_root);
+        assert!(
+            !matches!(detected, Ok(PackageManager::Nub { .. })),
+            "a bare lock.yaml must not be detected as nub, got {detected:?}"
+        );
+
+        // The same repo IS nub once the field is present.
         let package_json = PackageJson {
             package_manager: Some(Spanned::new("nub@0.1.0".to_string())),
             ..Default::default()
@@ -142,24 +172,6 @@ mod tests {
         assert_eq!(
             underlying_lockfile_manager(&repo_root),
             PackageManager::Pnpm9
-        );
-    }
-
-    #[test]
-    fn test_nub_detected_from_native_lockfile() {
-        let dir = tempdir().unwrap();
-        let repo_root = AbsoluteSystemPathBuf::try_from(dir.path()).unwrap();
-
-        repo_root
-            .join_component(LOCKFILE)
-            .create_with_contents("lockfileVersion: '9.0'\n")
-            .unwrap();
-
-        assert_eq!(
-            PackageManager::detect_package_manager(&repo_root).unwrap(),
-            PackageManager::Nub {
-                lockfile: Box::new(PackageManager::Pnpm9)
-            }
         );
     }
 }

--- a/packages/turbo-workspaces/src/install.ts
+++ b/packages/turbo-workspaces/src/install.ts
@@ -87,7 +87,7 @@ export const PACKAGE_MANAGERS: Record<
       command: "nub",
       installArgs: ["install"],
       version: "latest",
-      executable: "nub",
+      executable: "nub exec",
       semver: "*",
       default: true
     }


### PR DESCRIPTION
We maintain [nub](https://nubjs.com) and have been testing Turborepo's nub support (added in #13120 / #13169 / #13179) end-to-end against a `create-turbo --package-manager nub` monorepo. This carries three fixes; each is scoped to `crates/turborepo-repository/src/package_manager/` and the `create-turbo` login hint. R1 below is a heads-up only, not a code change here.

## 1. Correct the `create-turbo` remote-cache login hint

The post-scaffold hint for nub printed `nub turbo login`, which errors: `turbo` is a project-local binary, and nub runs local binaries through `nub exec` (alias `nubx`), not as a bare `nub <name>` subcommand. Setting the nub `executable` to `nub exec` makes the hint read `nub exec turbo login`, matching the package-binary-exec form already used for the other managers (`npx`, `pnpm dlx`, `yarn dlx`, `bunx`).

## 2. Detect nub only via the `packageManager` field, not the lockfile name

`detect_package_manager` treated the presence of nub's native `lock.yaml` as a nub signal. This drops that: nub is now recognized only through the `packageManager` field / `devEngines.packageManager`. nub's lockfile name is deliberately neutral and nub is lockfile-compatible with whatever the project already uses, so the file's presence is not a reliable nub signal. Lockfile parsing is unchanged — once nub is detected via the field, `PackageManager::Nub { lockfile }` still parses `lock.yaml` through the underlying (pnpm) path; only the name-based detection is removed.

> [!NOTE]
> Detection tradeoff: a nub project identified only by a bare `lock.yaml` — no `packageManager` field, no other recognized lockfile — is no longer detected as nub. Turborepo falls back to its normal lockfile-based detection, which finds no package manager when only `lock.yaml` is present. The field is written on the adoption paths that matter: the `create-turbo` nub template writes `devEngines.packageManager`, and `nub pm use nub` writes it when converting an existing project — so scaffolded and converted repos are covered. A hand-authored, field-less nub repo is not. We think the field is the more robust signal, but the narrower lockfile-name coverage is your call.

## 3. Build internal workspace edges in a nub monorepo (`link_workspace_packages`)

In a nub monorepo, Turborepo discovers the workspace packages but builds no internal dependency edges between them: `web#build` depends on nothing, where the same scaffold under pnpm or npm depends on `@repo/ui#build` et al. Two consequences: dependents serve stale cache after an internal package changes, and `turbo prune --docker web` drops the internal packages entirely (the pruned build then fails to resolve `@repo/ui`).

Root cause: the `create-turbo` nub template declares internal deps with a bare specifier (`"@repo/ui": "*"`), like the npm and bun templates — not `"workspace:*"`. `PackageManager::Nub` delegated `link_workspace_packages` to its underlying lockfile format (pnpm), which defaults to `false` on pnpm 9, so `is_internal` treated every non-`workspace:` internal dep as external. npm, yarn, and bun all return `true` here, and nub links a bare specifier to the local workspace package exactly as they do (nub symlinks it and records `version: link:...` in its lockfile). This sets `link_workspace_packages` to `true` for nub, putting it on the same edge-resolution path as npm/bun rather than pnpm's `workspace:`-only default. It reuses the existing package.json dependency-splitting path — no new lockfile-graph machinery.

Reproduction on current `main` (turbo 2.10.3-canary.4):

```
# nub scaffold (before this change)
$ turbo build --dry=json | jq '.tasks[] | select(.taskId=="web#build") | .dependencies'
[]                                    # ❌ no internal edges
$ turbo prune web --docker
 - Added web                          # ❌ @repo/ui dropped

# same scaffold under npm (link_workspace_packages = true, identical "*" specifiers)
$ turbo build --dry=json | jq '.tasks[] | select(.taskId=="web#build") | .dependencies'
["@repo/eslint-config#build","@repo/typescript-config#build","@repo/ui#build"]   # ✓
```

The fix puts nub on that same `true` path, so the nub scaffold resolves identically. Covered by unit tests in `package_manager/mod.rs` (`test_nub_links_workspace_packages_unlike_underlying_pnpm`) and the detection tests in `nub.rs` / `mod.rs`. `cargo test -p turborepo-repository` is green (219 tests).

## R1 (heads-up, not fixed here): Turbopack workspace-root inference

On a fresh nub scaffold, the first `turbo build` hits Next/Turbopack's own workspace-root inference, which keys off recognized lockfile names and doesn't include nub's `lock.yaml`, so it warns and infers the wrong root. That lives in Next's root-inference code, not this module, so it's out of scope for this PR — flagging it in case the two teams want to coordinate. The identical pnpm scaffold builds clean.

Happy to adjust any of these or split them if you'd prefer separate PRs.
