### PR TITLE
feat: Add --production flag to turbo prune

### DIFF
--- a/apps/docs/content/docs/reference/prune.mdx
+++ b/apps/docs/content/docs/reference/prune.mdx
@@ -211,6 +211,12 @@ Default: `true`
 
 Respect `.gitignore` file(s) when copying files to the output directory.
 
+#### `--production`
+
+Default: `false`
+
+Exclude in-workspace packages listed only in `devDependencies` when selecting which packages to include in the pruned output. Only workspace packages reachable through `dependencies` (and non-optional peer workspace dependencies) are included.
+
 ### Including `globalDependencies`
 
 By default, `turbo prune` does not copy files referenced by [`globalDependencies`](/docs/reference/configuration#globaldependencies) into the output directory. The `globalDependencies` field is preserved in the pruned `turbo.json`, but the files themselves (e.g., a root `tsconfig.json` or `.env`) are not included.

--- a/crates/turborepo-lib/src/cli/args.rs
+++ b/crates/turborepo-lib/src/cli/args.rs
@@ -704,6 +704,10 @@ pub enum Command {
         scope_arg: Option<Vec<String>>,
         #[clap(long)]
         docker: bool,
+        /// Exclude in-workspace devDependencies when selecting packages to
+        /// include
+        #[clap(long)]
+        production: bool,
         #[clap(long = "out-dir", default_value_t = String::from(prune::DEFAULT_OUTPUT_DIR), value_parser)]
         output_dir: String,
         /// Respect `.gitignore` when copying files to <OUT-DIR>

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -697,6 +697,7 @@ async fn run_main(
             scope,
             scope_arg,
             docker,
+            production,
             output_dir,
             use_gitignore,
         } => {
@@ -708,6 +709,7 @@ async fn run_main(
                 .cloned()
                 .unwrap_or_default();
             let docker = *docker;
+            let production = *production;
             let output_dir = output_dir.clone();
             let use_gitignore = use_gitignore.unwrap_or(true);
             let base = CommandBase::new(cli_args, repo_root, version, color_config)?;
@@ -717,6 +719,7 @@ async fn run_main(
                 &base,
                 &scope,
                 docker,
+                production,
                 &output_dir,
                 use_gitignore,
                 event_child,

--- a/crates/turborepo-lib/src/cli/test.rs
+++ b/crates/turborepo-lib/src/cli/test.rs
@@ -1227,6 +1227,7 @@ fn test_parse_prune() {
         scope: None,
         scope_arg: Some(vec!["foo".into()]),
         docker: false,
+        production: false,
         output_dir: "out".to_string(),
         use_gitignore: None,
     };
@@ -1258,6 +1259,7 @@ fn test_parse_prune() {
                 scope: Some(vec!["bar".to_string()]),
                 scope_arg: None,
                 docker: false,
+                production: false,
                 output_dir: "out".to_string(),
                 use_gitignore: None,
             }),
@@ -1272,6 +1274,7 @@ fn test_parse_prune() {
                 scope: None,
                 scope_arg: Some(vec!["foo".to_string(), "bar".to_string()]),
                 docker: false,
+                production: false,
                 output_dir: "out".to_string(),
                 use_gitignore: None,
             }),
@@ -1286,6 +1289,7 @@ fn test_parse_prune() {
                 scope: None,
                 scope_arg: Some(vec!["foo".into()]),
                 docker: true,
+                production: false,
                 output_dir: "out".to_string(),
                 use_gitignore: None,
             }),
@@ -1300,6 +1304,7 @@ fn test_parse_prune() {
                 scope: None,
                 scope_arg: Some(vec!["foo".into()]),
                 docker: false,
+                production: false,
                 output_dir: "dist".to_string(),
                 use_gitignore: None,
             }),
@@ -1316,6 +1321,7 @@ fn test_parse_prune() {
                 scope: None,
                 scope_arg: Some(vec!["foo".into()]),
                 docker: true,
+                production: false,
                 output_dir: "dist".to_string(),
                 use_gitignore: None,
             }),
@@ -1333,6 +1339,7 @@ fn test_parse_prune() {
                 scope: None,
                 scope_arg: Some(vec!["foo".into()]),
                 docker: true,
+                production: false,
                 output_dir: "dist".to_string(),
                 use_gitignore: None,
             }),
@@ -1355,6 +1362,7 @@ fn test_parse_prune() {
                 scope: Some(vec!["foo".to_string()]),
                 scope_arg: None,
                 docker: true,
+                production: false,
                 output_dir: "dist".to_string(),
                 use_gitignore: None,
             }),
@@ -1372,6 +1380,7 @@ fn test_parse_prune() {
                 scope: None,
                 scope_arg: Some(vec!["foo".to_string()]),
                 docker: false,
+                production: false,
                 output_dir: "out".to_string(),
                 use_gitignore: Some(true),
             }),
@@ -1389,6 +1398,7 @@ fn test_parse_prune() {
                 scope: None,
                 scope_arg: Some(vec!["foo".to_string()]),
                 docker: false,
+                production: false,
                 output_dir: "out".to_string(),
                 use_gitignore: Some(true),
             }),
@@ -1406,6 +1416,7 @@ fn test_parse_prune() {
                 scope: None,
                 scope_arg: Some(vec!["foo".to_string()]),
                 docker: false,
+                production: false,
                 output_dir: "out".to_string(),
                 use_gitignore: Some(false),
             }),
@@ -1413,6 +1424,36 @@ fn test_parse_prune() {
         },
     }
     .test();
+
+    assert_eq!(
+        Args::try_parse_from(["turbo", "prune", "--production", "foo"]).unwrap(),
+        Args {
+            command: Some(Command::Prune {
+                scope: None,
+                scope_arg: Some(vec!["foo".to_string()]),
+                docker: false,
+                production: true,
+                output_dir: "out".to_string(),
+                use_gitignore: None,
+            }),
+            ..Args::default()
+        }
+    );
+
+    assert_eq!(
+        Args::try_parse_from(["turbo", "prune", "--docker", "--production", "foo"]).unwrap(),
+        Args {
+            command: Some(Command::Prune {
+                scope: None,
+                scope_arg: Some(vec!["foo".to_string()]),
+                docker: true,
+                production: true,
+                output_dir: "out".to_string(),
+                use_gitignore: None,
+            }),
+            ..Args::default()
+        }
+    );
 }
 
 #[test]

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -135,14 +135,25 @@ pub async fn prune(
     base: &CommandBase,
     scope: &[String],
     docker: bool,
+    production: bool,
     output_dir: &str,
     use_gitignore: bool,
     telemetry: CommandEventBuilder,
 ) -> Result<(), Error> {
     telemetry.track_arg_usage("docker", docker);
+    telemetry.track_arg_usage("production", production);
     telemetry.track_arg_usage("out-dir", output_dir != DEFAULT_OUTPUT_DIR);
 
-    let prune = Prune::new(base, scope, docker, output_dir, use_gitignore, telemetry).await?;
+    let prune = Prune::new(
+        base,
+        scope,
+        docker,
+        production,
+        output_dir,
+        use_gitignore,
+        telemetry,
+    )
+    .await?;
 
     println!(
         "Generating pruned monorepo for {} in {}",
@@ -452,6 +463,7 @@ struct Prune<'a> {
     out_directory: AbsoluteSystemPathBuf,
     full_directory: AbsoluteSystemPathBuf,
     docker: bool,
+    production: bool,
     scope: &'a [String],
     use_gitignore: bool,
     uses_per_workspace_lockfiles: bool,
@@ -471,6 +483,7 @@ impl<'a> Prune<'a> {
         base: &CommandBase,
         scope: &'a [String],
         docker: bool,
+        production: bool,
         output_dir: &str,
         use_gitignore: bool,
         telemetry: CommandEventBuilder,
@@ -502,6 +515,7 @@ impl<'a> Prune<'a> {
 
         trace!("scope: {}", scope.join(", "));
         trace!("docker: {}", docker);
+        trace!("production: {}", production);
         trace!("out directory: {}", &out_directory);
 
         for target in scope {
@@ -548,6 +562,7 @@ impl<'a> Prune<'a> {
             out_directory,
             full_directory,
             docker,
+            production,
             scope,
             use_gitignore,
             uses_per_workspace_lockfiles,
@@ -796,6 +811,17 @@ impl<'a> Prune<'a> {
         Ok(())
     }
 
+    fn workspace_transitive_closure<'graph, 'node, I: IntoIterator<Item = &'node PackageNode>>(
+        &'graph self,
+        nodes: I,
+    ) -> HashSet<&'graph PackageNode> {
+        if self.production {
+            self.package_graph.production_transitive_closure(nodes)
+        } else {
+            self.package_graph.transitive_closure(nodes)
+        }
+    }
+
     fn internal_dependencies(&self) -> Vec<PackageName> {
         let workspaces = std::iter::once(PackageNode::Workspace(PackageName::Root))
             .chain(
@@ -805,8 +831,7 @@ impl<'a> Prune<'a> {
             )
             .collect::<Vec<_>>();
         let mut names = self
-            .package_graph
-            .transitive_closure(workspaces.iter())
+            .workspace_transitive_closure(workspaces.iter())
             .into_iter()
             .filter_map(|node| match node {
                 PackageNode::Root => None,
@@ -842,8 +867,7 @@ impl<'a> Prune<'a> {
                 .map(PackageNode::Workspace)
                 .collect::<Vec<_>>();
             names.extend(
-                self.package_graph
-                    .transitive_closure(workspace_nodes.iter())
+                self.workspace_transitive_closure(workspace_nodes.iter())
                     .into_iter()
                     .filter_map(|node| match node {
                         PackageNode::Root => None,
@@ -1220,6 +1244,7 @@ mod tests {
             out_directory: out_directory.clone(),
             full_directory: out_directory,
             docker: false,
+            production: false,
             scope: &scope,
             use_gitignore: false,
             uses_per_workspace_lockfiles: false,
@@ -1231,6 +1256,87 @@ mod tests {
                 PackageName::Root,
                 PackageName::from("pkg-a"),
                 PackageName::from("pkg-b")
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn internal_dependencies_excludes_dev_dependencies_with_production() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPathBuf::try_from(tempdir.path()).unwrap();
+        let package_graph = PackageGraph::builder(
+            &root,
+            PackageJson::from_value(json!({
+                "name": "repo",
+                "packageManager": "npm@10.5.0",
+                "devDependencies": {
+                    "root-tooling": "workspace:*"
+                }
+            }))
+            .unwrap(),
+        )
+        .with_package_discovery(MockDiscovery)
+        .with_package_jsons(Some(HashMap::from([
+            (
+                root.join_components(&["apps", "web", "package.json"]),
+                PackageJson {
+                    name: Some(Spanned::new("web".to_string())),
+                    dependencies: Some(BTreeMap::from([(
+                        "lib".to_string(),
+                        "workspace:*".to_string(),
+                    )])),
+                    dev_dependencies: Some(BTreeMap::from([(
+                        "tooling".to_string(),
+                        "workspace:*".to_string(),
+                    )])),
+                    ..Default::default()
+                },
+            ),
+            (
+                root.join_components(&["packages", "lib", "package.json"]),
+                PackageJson {
+                    name: Some(Spanned::new("lib".to_string())),
+                    ..Default::default()
+                },
+            ),
+            (
+                root.join_components(&["packages", "tooling", "package.json"]),
+                PackageJson {
+                    name: Some(Spanned::new("tooling".to_string())),
+                    ..Default::default()
+                },
+            ),
+            (
+                root.join_components(&["packages", "root-tooling", "package.json"]),
+                PackageJson {
+                    name: Some(Spanned::new("root-tooling".to_string())),
+                    ..Default::default()
+                },
+            ),
+        ])))
+        .build()
+        .await
+        .unwrap();
+        let scope = vec!["web".to_string()];
+        let out_directory = root.join_component("out");
+        let prune = Prune {
+            package_graph,
+            root: root.clone(),
+            out_directory: out_directory.clone(),
+            full_directory: out_directory,
+            docker: false,
+            production: true,
+            scope: &scope,
+            use_gitignore: false,
+            uses_per_workspace_lockfiles: false,
+        };
+
+        assert_eq!(
+            prune.internal_dependencies(),
+            vec![
+                PackageName::Root,
+                PackageName::from("lib"),
+                PackageName::from("web"),
             ]
         );
     }
@@ -1297,6 +1403,86 @@ mod tests {
             out_directory: out_directory.clone(),
             full_directory: out_directory,
             docker: false,
+            production: false,
+            scope: &scope,
+            use_gitignore: false,
+            uses_per_workspace_lockfiles: false,
+        };
+
+        assert_eq!(
+            prune.internal_dependencies(),
+            vec![
+                PackageName::Root,
+                PackageName::from("pkg-b"),
+                PackageName::from("pkg-c"),
+                PackageName::from("pkg-d")
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn internal_dependencies_includes_non_optional_peer_workspaces_with_production() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPathBuf::try_from(tempdir.path()).unwrap();
+        let package_graph = PackageGraph::builder(
+            &root,
+            PackageJson::from_value(json!({
+                "name": "repo",
+                "packageManager": "npm@10.5.0"
+            }))
+            .unwrap(),
+        )
+        .with_package_discovery(MockDiscovery)
+        .with_package_jsons(Some(HashMap::from([
+            (
+                root.join_components(&["packages", "pkg-b", "package.json"]),
+                PackageJson::from_value(json!({
+                    "name": "pkg-b",
+                    "peerDependencies": {
+                        "pkg-c": "*",
+                        "pkg-e": "*"
+                    },
+                    "peerDependenciesMeta": {
+                        "pkg-e": { "optional": true }
+                    }
+                }))
+                .unwrap(),
+            ),
+            (
+                root.join_components(&["packages", "pkg-c", "package.json"]),
+                PackageJson {
+                    name: Some(Spanned::new("pkg-c".to_string())),
+                    dependencies: Some(BTreeMap::from([("pkg-d".to_string(), "*".to_string())])),
+                    ..Default::default()
+                },
+            ),
+            (
+                root.join_components(&["packages", "pkg-d", "package.json"]),
+                PackageJson {
+                    name: Some(Spanned::new("pkg-d".to_string())),
+                    ..Default::default()
+                },
+            ),
+            (
+                root.join_components(&["packages", "pkg-e", "package.json"]),
+                PackageJson {
+                    name: Some(Spanned::new("pkg-e".to_string())),
+                    ..Default::default()
+                },
+            ),
+        ])))
+        .build()
+        .await
+        .unwrap();
+        let scope = vec!["pkg-b".to_string()];
+        let out_directory = root.join_component("out");
+        let prune = Prune {
+            package_graph,
+            root: root.clone(),
+            out_directory: out_directory.clone(),
+            full_directory: out_directory,
+            docker: false,
+            production: true,
             scope: &scope,
             use_gitignore: false,
             uses_per_workspace_lockfiles: false,

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -1002,6 +1002,11 @@ mod test {
             graph.dependency_kind(&web, &tooling),
             Some(DependencyKind::Development)
         );
+
+        let web_closure = graph.production_transitive_closure([&web]);
+        assert!(web_closure.contains(&web));
+        assert!(web_closure.contains(&lib));
+        assert!(!web_closure.contains(&tooling));
     }
 
     #[tokio::test]

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -606,6 +606,36 @@ impl PackageGraph {
         )
     }
 
+    /// Like [`Self::transitive_closure`], but only follows edges with
+    /// [`DependencyKind::Production`].
+    pub fn production_transitive_closure<'a, 'b, I: IntoIterator<Item = &'b PackageNode>>(
+        &'a self,
+        nodes: I,
+    ) -> HashSet<&'a PackageNode> {
+        let mut visited = HashSet::new();
+        let mut stack: Vec<NodeIndex> = nodes
+            .into_iter()
+            .filter_map(|node| self.node_lookup.get(node).cloned())
+            .collect();
+
+        while let Some(index) = stack.pop() {
+            let Some(node) = self.graph.node_weight(index) else {
+                continue;
+            };
+            if !visited.insert(node) {
+                continue;
+            }
+
+            for edge in self.graph.edges(index) {
+                if matches!(*edge.weight(), DependencyKind::Production) {
+                    stack.push(edge.target());
+                }
+            }
+        }
+
+        visited
+    }
+
     pub fn transitive_external_dependencies<'a, I: IntoIterator<Item = &'a PackageName>>(
         &self,
         packages: I,

--- a/crates/turborepo/tests/prune_test.rs
+++ b/crates/turborepo/tests/prune_test.rs
@@ -15,6 +15,65 @@ fn ls_dir(dir: &Path) -> Vec<String> {
     entries
 }
 
+#[test]
+fn test_prune_production_excludes_dev_dependencies() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(
+        tempdir.path(),
+        "monorepo_with_root_dep",
+        "pnpm@7.25.1",
+        false,
+    )
+    .unwrap();
+
+    let output = run_turbo(tempdir.path(), &["prune", "web", "--production"]);
+    assert!(
+        output.status.success(),
+        "prune --production failed: {}",
+        combined_output(&output)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Added web"));
+    assert!(stdout.contains("Added shared"));
+    assert!(!stdout.contains("Added util"));
+
+    let packages_dir = tempdir.path().join("out/packages");
+    let package_entries = ls_dir(&packages_dir);
+    assert_eq!(package_entries, vec!["shared".to_string()]);
+    assert!(!packages_dir.join("util").exists());
+}
+
+#[test]
+fn test_prune_production_docker_excludes_dev_dependencies() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::setup_integration_test(
+        tempdir.path(),
+        "monorepo_with_root_dep",
+        "pnpm@7.25.1",
+        false,
+    )
+    .unwrap();
+
+    let output = run_turbo(
+        tempdir.path(),
+        &["prune", "web", "--production", "--docker"],
+    );
+    assert!(
+        output.status.success(),
+        "prune --production --docker failed: {}",
+        combined_output(&output)
+    );
+
+    let full_packages = ls_dir(&tempdir.path().join("out/full/packages"));
+    assert_eq!(full_packages, vec!["shared".to_string()]);
+    assert!(!tempdir.path().join("out/full/packages/util").exists());
+
+    let json_packages = ls_dir(&tempdir.path().join("out/json/packages"));
+    assert_eq!(json_packages, vec!["shared".to_string()]);
+    assert!(!tempdir.path().join("out/json/packages/util").exists());
+}
+
 // --- docker.t ---
 
 #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Adds `turbo prune --production` to exclude in-workspace packages that are only reachable through `devDependencies` when selecting which workspace packages to copy into the pruned output.

This builds on the dependency kind data added to the package graph in #13188. When `--production` is set, prune uses a production-only transitive closure over internal workspace edges. Peer workspace handling, lockfile pruning, and copied `package.json` contents are unchanged.

Closes #1100.

### Testing Instructions

1. In a monorepo where a scope target has both `dependencies` and `devDependencies` on workspace packages, run:
   - `turbo prune <scope>` and confirm dev-only workspace packages are included.
   - `turbo prune <scope> --production` and confirm dev-only workspace packages are excluded.
2. Confirm root `devDependencies` on workspace packages are excluded with `--production`.
3. Confirm `--production` works with `--docker` (both `full/` and `json/` outputs omit dev-only packages).
4. Run tests:
   - `cargo test -p turborepo-lib --lib internal_dependencies`
   - `cargo test -p turbo --test prune_test test_prune_production`
   - `cargo test -p turborepo-repository test_dev_dependency_edge_kind`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1b82-c058-787d-8d7d-03052c32ffcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1b82-c058-787d-8d7d-03052c32ffcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

