### PR TITLE
fix: Add token exchange recovery guidance

### DIFF
--- a/crates/turborepo-auth/src/auth/mod.rs
+++ b/crates/turborepo-auth/src/auth/mod.rs
@@ -430,10 +430,14 @@ async fn exchange_auth_tokens(
                 if let Some(refresh_error) = refresh_error {
                     warn!(
                         "Failed to refresh or exchange {source_label} after a forbidden response: \
-                         refresh error: {refresh_error}; exchange error: {e}"
+                         refresh error: {refresh_error}; exchange error: {e}. Run `turbo login` \
+                         to create a new local session."
                     );
                 } else {
-                    warn!("Failed to exchange {source_label} after a forbidden response: {e}");
+                    warn!(
+                        "Failed to exchange {source_label} after a forbidden response: {e}. Run \
+                         `turbo login` to create a new local session."
+                    );
                 }
                 Ok(None)
             }


### PR DESCRIPTION
## Why

Users can hit a Turbo config token exchange failure after a forbidden response and only see the OAuth 400 details, which does not explain how to recover locally.

## What

Adds explicit guidance to run `turbo login` when token exchange recovery cannot create a replacement session.