### PR TITLE
docs: Add filtered installs to Vercel guide

### DIFF
--- a/apps/agents/vercel.json
+++ b/apps/agents/vercel.json
@@ -1,0 +1,3 @@
+{
+  "installCommand": "pnpm install --filter=examples-agent..."
+}

--- a/apps/docs/content/docs/guides/ci-vendors/vercel.mdx
+++ b/apps/docs/content/docs/guides/ci-vendors/vercel.mdx
@@ -18,3 +18,45 @@ Vercel's zero-config integration with Turborepo automatically understands your m
 To deploy your Turborepo on Vercel, [create a new project](https://vercel.com/new) and import your code. Your projects will be pre-configured with the correct settings to use the [Vercel Remote Cache](https://vercel.com/docs/monorepos/remote-caching).
 
 For more information about deploying your Turborepo to Vercel, [visit the Vercel documentation](https://vercel.com/docs/concepts/monorepos/turborepo).
+
+## Filtered installs
+
+You can speed up installs by only installing the dependencies for the application being deployed and its Workspace dependencies. Set a custom Install Command in the application's `vercel.json` or [in your project's Build and Deployment settings](https://vercel.com/d?to=%2F%5Bteam%5D%2F%5Bproject%5D%2Fsettings%2Fbuild-and-deployment%23framework-settings&title=Build+and+Deployment+settings):
+
+<PackageManagerTabs>
+  <Tab value="pnpm">
+    ```json title="apps/web/vercel.json"
+    {
+      "installCommand": "pnpm install --filter web..."
+    }
+    ```
+
+    <Callout type="warn">
+      Requires pnpm 9.5 or newer. On pnpm 8.x through 9.4, `--filter` installed
+      dependencies for the entire workspace
+      ([pnpm#6300](https://github.com/pnpm/pnpm/issues/6300)).
+    </Callout>
+
+  </Tab>
+  <Tab value="yarn">
+    ```json title="apps/web/vercel.json"
+    {
+      "installCommand": "yarn workspaces focus web"
+    }
+    ```
+  </Tab>
+  <Tab value="npm">
+    ```json title="apps/web/vercel.json"
+    {
+      "installCommand": "npm install --workspace=web"
+    }
+    ```
+  </Tab>
+  <Tab value="bun">
+    ```json title="apps/web/vercel.json"
+    {
+      "installCommand": "bun install --filter web"
+    }
+    ```
+  </Tab>
+</PackageManagerTabs>

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,5 +1,5 @@
 {
-  "installCommand": "pnpm install --filter docs...",
+  "installCommand": "pnpm install",
   "buildCommand": "echo \"pnpm store package count: $(ls ../../node_modules/.pnpm | wc -l)\" && ls ../agents/node_modules 2>&1; turbo build",
   "build": {
     "env": {

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,9 +1,3 @@
 {
-  "installCommand": "pnpm install",
-  "buildCommand": "echo \"pnpm store package count: $(ls ../../node_modules/.pnpm | wc -l)\" && ls ../agents/node_modules 2>&1; turbo build",
-  "build": {
-    "env": {
-      "VERCEL_FORCE_NO_BUILD_CACHE": "1"
-    }
-  }
+  "installCommand": "pnpm install --filter=docs..."
 }

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,3 +1,4 @@
 {
-  "installCommand": "pnpm install --filter docs..."
+  "installCommand": "pnpm install --filter docs...",
+  "buildCommand": "echo \"pnpm store package count: $(ls ../../node_modules/.pnpm | wc -l)\" && ls ../agents/node_modules 2>&1; turbo build"
 }

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,4 +1,9 @@
 {
   "installCommand": "pnpm install --filter docs...",
-  "buildCommand": "echo \"pnpm store package count: $(ls ../../node_modules/.pnpm | wc -l)\" && ls ../agents/node_modules 2>&1; turbo build"
+  "buildCommand": "echo \"pnpm store package count: $(ls ../../node_modules/.pnpm | wc -l)\" && ls ../agents/node_modules 2>&1; turbo build",
+  "build": {
+    "env": {
+      "VERCEL_FORCE_NO_BUILD_CACHE": "1"
+    }
+  }
 }

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,0 +1,3 @@
+{
+  "installCommand": "pnpm install --filter docs..."
+}


### PR DESCRIPTION
## Why

Installing the entire monorepo's dependencies on every deploy is wasteful when a project only needs its own dependency subtree. Filtered installs cut installed package count roughly in half for our docs app (856 vs 1602 packages on cold builds), reducing install time, disk usage, and postinstall script surface. This wasn't documented anywhere in our Vercel guide, and there's long-standing community confusion about whether it works (vercel/turborepo#504) due to a since-fixed pnpm bug (pnpm/pnpm#6300, broken in pnpm 8.0–9.4).

## What

- Adds a "Filtered installs" section to the Vercel CI guide with `vercel.json` `installCommand` examples for pnpm, Yarn, npm, and Bun, including a callout about the pnpm version requirement.
- Adopts filtered installs for this repo's own Vercel deployments (`apps/docs`, `apps/agents`).

## How to verify

Deploy without build cache and check install logs for `Scope: N of M workspace projects` and the reduced `Packages: +N` count. We validated this with controlled cold-build A/B deploys on this branch: filtered installed 856 packages in 6.2s vs 1602 in 8.7s unfiltered, with sibling apps' node_modules absent.