### PR TITLE
fix: Report malformed JSON parse errors instead of panicking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7604,7 +7604,9 @@ name = "turborepo-errors"
 version = "0.1.0"
 dependencies = [
  "biome_deserialize 0.6.0",
+ "biome_deserialize_macros 0.6.0",
  "biome_diagnostics",
+ "biome_json_parser",
  "miette",
  "schemars",
  "serde",

--- a/clippy.toml
+++ b/clippy.toml
@@ -6,6 +6,14 @@ disallowed-methods = [
   # We forbid the use of VecDeque::new as it allocates, which is kind of unexpected
   # Instead use VecDeque::with_capacity to make it explicit or opt-out of that.
   "std::collections::VecDeque::new",
+  # biome's deserialization entry points run even when the source failed to
+  # parse, and deserializing a broken syntax tree can panic (e.g. unterminated
+  # string literals, vercel/turborepo#13197). Use
+  # turborepo_errors::json::deserialize_from_json_str, which reports parse
+  # errors instead of deserializing a broken tree.
+  "biome_deserialize::json::deserialize_from_json_str",
+  "biome_deserialize::json::deserialize_from_str",
+  "biome_deserialize::json::deserialize_from_json_ast",
 ]
 
 # Tests can use panic-extraction helpers freely. The cargo lint alias skips

--- a/crates/turborepo-errors/Cargo.toml
+++ b/crates/turborepo-errors/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 [dependencies]
 biome_deserialize = { workspace = true }
 biome_diagnostics = { workspace = true }
+biome_json_parser = { workspace = true }
 miette = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
@@ -16,6 +17,7 @@ thiserror = { workspace = true }
 ts-rs = { workspace = true }
 
 [dev-dependencies]
+biome_deserialize_macros = { workspace = true }
 serde_json = { workspace = true }
 test-case = { workspace = true }
 

--- a/crates/turborepo-errors/src/json.rs
+++ b/crates/turborepo-errors/src/json.rs
@@ -1,0 +1,92 @@
+//! JSON deserialization helpers that guard against panics in biome.
+//!
+//! `biome_deserialize::json::deserialize_from_json_str` runs deserialization
+//! even when the source failed to parse. On malformed input containing an
+//! unterminated string literal (e.g. a dangling `"` at the end of a line or
+//! file), deserialization panics inside `biome_json_syntax::inner_string_text`
+//! with `assertion failed: start <= end`. No published biome release fixes
+//! this, so we check for parse errors *before* deserializing and surface them
+//! as diagnostics instead.
+
+use biome_deserialize::{Deserializable, json::deserialize_from_json_ast};
+use biome_diagnostics::{DiagnosticExt, Error};
+use biome_json_parser::{JsonParserOptions, parse_json};
+
+/// A replacement for `biome_deserialize::json::deserialize_from_json_str`
+/// that reports parse errors rather than attempting to deserialize a broken
+/// syntax tree (which can panic, see module docs).
+///
+/// Returns the same `(deserialized, diagnostics)` pair as
+/// `Deserialized::consume`. When the source fails to parse, the deserialized
+/// value is `None` and the diagnostics contain only the parse errors.
+pub fn deserialize_from_json_str<Output: Deserializable>(
+    source: &str,
+    options: JsonParserOptions,
+    name: &str,
+) -> (Option<Output>, Vec<Error>) {
+    let parse = parse_json(source, options);
+    if parse.has_errors() {
+        let diagnostics = parse
+            .into_diagnostics()
+            .into_iter()
+            .map(|diagnostic| Error::from(diagnostic).with_file_source_code(source))
+            .collect();
+        return (None, diagnostics);
+    }
+    // The tree is known to be error-free at this point, so deserializing it
+    // directly is safe. This is the one place allowed to call biome's
+    // deserialization entry points (see disallowed-methods in clippy.toml).
+    #[allow(clippy::disallowed_methods)]
+    let (deserialized, diagnostics) =
+        deserialize_from_json_ast::<Output>(&parse.tree(), name).consume();
+    let diagnostics = diagnostics
+        .into_iter()
+        .map(|diagnostic| diagnostic.with_file_source_code(source))
+        .collect();
+    (deserialized, diagnostics)
+}
+
+#[cfg(test)]
+mod tests {
+    use biome_deserialize_macros::Deserializable;
+
+    use super::*;
+
+    #[derive(Debug, Default, Deserializable, PartialEq, Eq)]
+    struct TestConfig {
+        name: Option<String>,
+    }
+
+    #[test]
+    fn test_valid_json_deserializes() {
+        let (config, diagnostics) = deserialize_from_json_str::<TestConfig>(
+            r#"{"name": "turbo"}"#,
+            JsonParserOptions::default(),
+            "test.json",
+        );
+        assert_eq!(diagnostics.len(), 0);
+        assert_eq!(
+            config,
+            Some(TestConfig {
+                name: Some("turbo".to_owned())
+            })
+        );
+    }
+
+    // Regression tests for https://github.com/vercel/turborepo/issues/13197
+    // Unterminated string literals used to panic inside biome instead of
+    // producing parse errors.
+    #[test_case::test_case("\""; "lone quote")]
+    #[test_case::test_case("{\"name\": \""; "quote at eof")]
+    #[test_case::test_case("{\"name\": \"\n}"; "quote before newline")]
+    #[test_case::test_case("{\"name\": [\""; "quote in array")]
+    fn test_unterminated_string_reports_error(source: &str) {
+        let (config, diagnostics) = deserialize_from_json_str::<TestConfig>(
+            source,
+            JsonParserOptions::default(),
+            "test.json",
+        );
+        assert_eq!(config, None);
+        assert!(!diagnostics.is_empty());
+    }
+}

--- a/crates/turborepo-errors/src/lib.rs
+++ b/crates/turborepo-errors/src/lib.rs
@@ -6,6 +6,8 @@
 // miette's derive macro causes false positives for this lint
 #![allow(unused_assignments)]
 
+pub mod json;
+
 use std::{
     fmt::Display,
     iter,

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -78,13 +78,12 @@ impl RawTurboJsonExt for RawTurboJson {
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
-    use biome_deserialize::json::deserialize_from_json_str;
     use biome_json_parser::JsonParserOptions;
     use pretty_assertions::assert_eq;
     use test_case::test_case;
     use turbopath::RelativeUnixPath;
     use turborepo_engine::TaskDefinitionFromProcessed;
-    use turborepo_errors::Spanned;
+    use turborepo_errors::{json::deserialize_from_json_str, Spanned};
     use turborepo_turbo_json::raw::RawTaskInput;
     use turborepo_types::{TaskDefinition, TaskInputs, TaskOutputs};
 
@@ -258,13 +257,12 @@ mod tests {
         expected_raw_task_definition: RawTaskDefinition,
         expected_task_definition: TaskDefinition,
     ) -> Result<()> {
-        let deserialized_result = deserialize_from_json_str(
+        let (deserialized, _) = deserialize_from_json_str(
             task_definition_content,
             JsonParserOptions::default().with_allow_comments(),
             "turbo.json",
         );
-        let raw_task_definition: RawTaskDefinition =
-            deserialized_result.into_deserialized().unwrap();
+        let raw_task_definition: RawTaskDefinition = deserialized.unwrap();
         assert_eq!(raw_task_definition, expected_raw_task_definition);
 
         let task_definition =

--- a/crates/turborepo-microfrontends/src/configv1.rs
+++ b/crates/turborepo-microfrontends/src/configv1.rs
@@ -127,23 +127,21 @@ impl ConfigV1 {
             .with_allow_trailing_commas();
 
         // attempt to parse a child, ignoring any errors
-        let (config, errs) = biome_deserialize::json::deserialize_from_json_str::<ChildConfig>(
+        let (config, errs) = turborepo_errors::json::deserialize_from_json_str::<ChildConfig>(
             input,
             jsonc_options,
             source,
-        )
-        .consume();
+        );
 
         if let Some(ChildConfig { part_of }) = errs.is_empty().then_some(config).flatten() {
             return Ok(ParseResult::Reference(part_of));
         }
         // attempt to parse a real one
-        let (config, errs) = biome_deserialize::json::deserialize_from_json_str::<ConfigV1>(
+        let (config, errs) = turborepo_errors::json::deserialize_from_json_str::<ConfigV1>(
             input,
             jsonc_options,
             source,
-        )
-        .consume();
+        );
 
         if let Some(config) = config {
             // Only accept the config if there were no errors during parsing
@@ -314,6 +312,15 @@ mod test {
                 assert_eq!(default_app, "web");
             }
         }
+    }
+
+    // Regression test for https://github.com/vercel/turborepo/issues/13197
+    // Unterminated string literals used to panic inside biome during
+    // deserialization instead of producing a parse error.
+    #[test]
+    fn test_unterminated_string_reports_parse_error() {
+        let input = "{\"version\": \"\n}";
+        assert!(ConfigV1::from_str(input, "somewhere").is_err());
     }
 
     #[test]

--- a/crates/turborepo-microfrontends/src/schema.rs
+++ b/crates/turborepo-microfrontends/src/schema.rs
@@ -107,12 +107,11 @@ impl TurborepoConfig {
             .with_allow_comments()
             .with_allow_trailing_commas();
 
-        let (config, errs) = biome_deserialize::json::deserialize_from_json_str::<TurborepoConfig>(
+        let (config, errs) = turborepo_errors::json::deserialize_from_json_str::<TurborepoConfig>(
             input,
             jsonc_options,
             source,
-        )
-        .consume();
+        );
 
         if let Some(config) = config {
             // Only accept the config if there were no errors during parsing
@@ -216,6 +215,15 @@ mod test {
         let config = TurborepoConfig::from_str(input, "somewhere").unwrap();
         assert!(config.applications.contains_key("web"));
         assert!(config.applications.contains_key("docs"));
+    }
+
+    // Regression test for https://github.com/vercel/turborepo/issues/13197
+    // Unterminated string literals used to panic inside biome during
+    // deserialization instead of producing a parse error.
+    #[test]
+    fn test_unterminated_string_reports_parse_error() {
+        let input = "{\"version\": \"\n}";
+        assert!(TurborepoConfig::from_str(input, "somewhere").is_err());
     }
 
     #[test]

--- a/crates/turborepo-repository/src/package_json.rs
+++ b/crates/turborepo-repository/src/package_json.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anyhow::Result;
-use biome_deserialize::{Text, json::deserialize_from_json_str};
+use biome_deserialize::Text;
 use biome_deserialize_macros::Deserializable;
 use biome_diagnostics::DiagnosticExt;
 use biome_json_parser::JsonParserOptions;
@@ -187,7 +187,11 @@ impl PackageJson {
 
     pub fn load_from_str(contents: &str, path: &str) -> Result<PackageJson, Error> {
         let (result, errors): (Option<RawPackageJson>, _) =
-            deserialize_from_json_str(contents, JsonParserOptions::default(), path).consume();
+            turborepo_errors::json::deserialize_from_json_str(
+                contents,
+                JsonParserOptions::default(),
+                path,
+            );
         if !errors.is_empty() {
             return Err(Error::Parse(
                 errors
@@ -316,6 +320,15 @@ mod test {
         let package_json: PackageJson = PackageJson::from_value(json.clone()).unwrap();
         let actual = serde_json::to_value(package_json).unwrap();
         assert_eq!(actual, json);
+    }
+
+    // Regression test for https://github.com/vercel/turborepo/issues/13197
+    // Unterminated string literals used to panic inside biome during
+    // deserialization instead of producing a parse error.
+    #[test_case("{\"name\": \"\n}" ; "quote before newline")]
+    #[test_case("{\"dependencies\": {\"turbo\": \"" ; "quote at eof")]
+    fn test_unterminated_string_reports_parse_error(contents: &str) {
+        assert!(PackageJson::load_from_str(contents, "package.json").is_err());
     }
 
     #[test]

--- a/crates/turborepo-turbo-json/src/lib.rs
+++ b/crates/turborepo-turbo-json/src/lib.rs
@@ -466,13 +466,13 @@ pub fn task_outputs_from_processed(
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
-    use biome_deserialize::json::deserialize_from_json_str;
     use biome_json_parser::JsonParserOptions;
     use pretty_assertions::assert_eq;
     use serde_json::json;
     use test_case::test_case;
     use turbopath::RelativeUnixPath;
     use turborepo_boundaries::BoundariesConfig;
+    use turborepo_errors::json::deserialize_from_json_str;
     use turborepo_task_id::TaskName;
     use turborepo_types::{OutputLogsMode, TaskOutputs, UIMode};
     use turborepo_unescape::UnescapedString;
@@ -688,12 +688,12 @@ mod tests {
             }
         }"#;
 
-        let deserialized_result = deserialize_from_json_str(
+        let (deserialized, _) = deserialize_from_json_str(
             json,
             JsonParserOptions::default().with_allow_comments(),
             "turbo.json",
         );
-        let raw_turbo_json: RawTurboJson = deserialized_result.into_deserialized().unwrap();
+        let raw_turbo_json: RawTurboJson = deserialized.unwrap();
 
         // Try to convert to TurboJson - this should fail
         let turbo_json_result = TurboJson::try_from(raw_turbo_json);
@@ -716,12 +716,12 @@ mod tests {
             }
         }"#;
 
-        let deserialized_result = deserialize_from_json_str(
+        let (deserialized, _) = deserialize_from_json_str(
             json,
             JsonParserOptions::default().with_allow_comments(),
             "turbo.json",
         );
-        let raw_turbo_json: RawTurboJson = deserialized_result.into_deserialized().unwrap();
+        let raw_turbo_json: RawTurboJson = deserialized.unwrap();
 
         // Verify that futureFlags is parsed correctly (empty now that flags are
         // removed)
@@ -746,12 +746,12 @@ mod tests {
             }
         }"#;
 
-        let deserialized_result = deserialize_from_json_str(
+        let (deserialized, _) = deserialize_from_json_str(
             json,
             JsonParserOptions::default().with_allow_comments(),
             "turbo.json",
         );
-        let raw_turbo_json: RawTurboJson = deserialized_result.into_deserialized().unwrap();
+        let raw_turbo_json: RawTurboJson = deserialized.unwrap();
 
         // Verify that futureFlags is parsed correctly
         assert!(raw_turbo_json.future_flags.is_some());
@@ -776,12 +776,12 @@ mod tests {
             }
         }"#;
 
-        let deserialized_result = deserialize_from_json_str(
+        let (deserialized, _) = deserialize_from_json_str(
             json,
             JsonParserOptions::default().with_allow_comments(),
             "turbo.json",
         );
-        let raw_turbo_json: RawTurboJson = deserialized_result.into_deserialized().unwrap();
+        let raw_turbo_json: RawTurboJson = deserialized.unwrap();
 
         assert!(raw_turbo_json.future_flags.is_some());
         let future_flags = raw_turbo_json.future_flags.as_ref().unwrap();
@@ -833,7 +833,7 @@ mod tests {
     #[test_case("{}", "empty boundaries")]
     #[test_case(r#"{"tags": {} }"#, "empty tags")]
     #[test_case(
-        r#"{"tags": { "my-tag": { "dependencies": { "allow": ["my-package"] } } }"#,
+        r#"{"tags": { "my-tag": { "dependencies": { "allow": ["my-package"] } } } }"#,
         "tags and dependencies"
     )]
     #[test_case(
@@ -891,13 +891,16 @@ mod tests {
         "package rule"
     )]
     fn test_deserialize_boundaries(json: &str, name: &str) {
-        let deserialized_result = deserialize_from_json_str(
+        // Match the options used by parse_turbo_json: production turbo.json
+        // parsing allows comments and trailing commas.
+        let (deserialized, _) = deserialize_from_json_str(
             json,
-            JsonParserOptions::default().with_allow_comments(),
+            JsonParserOptions::default()
+                .with_allow_comments()
+                .with_allow_trailing_commas(),
             "turbo.json",
         );
-        let raw_boundaries_config: BoundariesConfig =
-            deserialized_result.into_deserialized().unwrap();
+        let raw_boundaries_config: BoundariesConfig = deserialized.unwrap();
         insta::assert_json_snapshot!(name.replace(' ', "_"), raw_boundaries_config);
     }
 

--- a/crates/turborepo-turbo-json/src/parser.rs
+++ b/crates/turborepo-turbo-json/src/parser.rs
@@ -8,7 +8,7 @@ use std::{backtrace, collections::BTreeMap, fmt::Debug, sync::Arc};
 
 use biome_deserialize::{
     Deserializable, DeserializableValue, DeserializationDiagnostic, DeserializationVisitor,
-    VisitableType, json::deserialize_from_json_str,
+    VisitableType,
 };
 use biome_diagnostics::DiagnosticExt;
 use biome_json_parser::JsonParserOptions;
@@ -584,7 +584,7 @@ pub fn parse_turbo_json<T: Deserializable + WithMetadata>(
     text: &str,
     file_path: &str,
 ) -> Result<T, BiomeParseError> {
-    let result = deserialize_from_json_str::<T>(
+    let (deserialized, errors) = turborepo_errors::json::deserialize_from_json_str::<T>(
         text,
         JsonParserOptions::default()
             .with_allow_comments()
@@ -592,9 +592,8 @@ pub fn parse_turbo_json<T: Deserializable + WithMetadata>(
         file_path,
     );
 
-    if !result.diagnostics().is_empty() {
-        let diagnostics = result
-            .into_diagnostics()
+    if !errors.is_empty() {
+        let diagnostics = errors
             .into_iter()
             .map(|d| {
                 d.with_file_source_code(text)
@@ -607,9 +606,7 @@ pub fn parse_turbo_json<T: Deserializable + WithMetadata>(
         return Err(BiomeParseError::new(diagnostics));
     }
 
-    let mut turbo_json = result
-        .into_deserialized()
-        .ok_or_else(BiomeParseError::empty)?;
+    let mut turbo_json = deserialized.ok_or_else(BiomeParseError::empty)?;
     turbo_json.add_text(Arc::from(text));
     turbo_json.add_path(Arc::from(file_path));
 
@@ -639,6 +636,15 @@ mod tests {
     fn test_biome_parse_error_display() {
         let err = BiomeParseError::empty();
         assert_eq!(err.to_string(), "Failed to parse turbo.json.");
+    }
+
+    // Regression tests for https://github.com/vercel/turborepo/issues/13197
+    // Unterminated string literals used to panic inside biome during
+    // deserialization instead of producing a parse error.
+    #[test_case("{\"tasks\": {\"build\": {\"persistent\": \"\n}}}"; "quote before newline")]
+    #[test_case("{\"tasks\": {\"build\": {\"dependsOn\": [\""; "quote at eof")]
+    fn test_unterminated_string_reports_parse_error(json: &str) {
+        assert!(RawRootTurboJson::parse(json, "turbo.json").is_err());
     }
 
     #[test_case(r#"{"daemon": true}"#; "daemon in package turbo.json")]


### PR DESCRIPTION
### Why

`turbo` panics with `assertion failed: start <= end` (from `biome_text_size`) when any JSON config it reads contains an unterminated string literal — e.g. a dangling `"` left in `turbo.json` or a `package.json` mid-edit while watch mode re-reads the file. Fixes #13197.

The root cause is in biome 0.5.7: `deserialize_from_json_str` runs deserialization even when parsing failed, and `inner_string_text` assumes every string token has both quote delimiters, computing `TextRange::new(1, 0)` for a lone-quote token. No newer version of the affected biome crates is published to crates.io, so this cannot be fixed by upgrading.

### What

- Adds `turborepo_errors::json::deserialize_from_json_str`, which checks for parse errors **before** deserializing and returns them as diagnostics instead of deserializing a broken syntax tree.
- Switches all user-facing JSON config parsing to it: `turbo.json`/`turbo.jsonc`, `package.json`, and microfrontends configs. (`bun.lock` parsing already guarded correctly.)
- Bans the raw biome entry points workspace-wide via clippy `disallowed-methods` so future call sites can't reintroduce the panic. The single `#[allow]` lives inside the wrapper, where the tree is proven error-free.
- Fixes a boundaries test fixture the new guard exposed: one input was missing a closing brace and two relied on trailing commas without enabling that parser option — old biome silently error-recovered through both.

### How to test

Put a dangling quote in a `turbo.json` value (e.g. `"persistent": "` followed by a newline) and run any `turbo` command. Before: internal Rust panic. After:

```
x Failed to parse turbo.json.
`->   x Missing closing quote
       ,-[turbo.json:4:21]
     4 |       "persistent": "
       :                     ^
```

Same for `package.json`. Regression tests cover the panicking inputs at every converted call site, verified against a repro that panics with the exact same inputs through biome's raw entry point.