### PR TITLE
feat: Automatically copy TUI selection to clipboard on mouse release

### DIFF
--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -156,10 +156,11 @@ impl<W> App<W> {
     }
 
     fn input_options(&self) -> Result<InputOptions<'_>, Error> {
-        let has_selection = self.get_full_task()?.has_selection();
+        let task = self.get_full_task()?;
         Ok(InputOptions {
             focus: &self.section_focus,
-            has_selection,
+            has_selection: task.has_selection(),
+            is_selecting: task.is_selecting(),
             is_help_popup_open: self.showing_help_popup,
             is_log_panel_open: self.showing_log_panel,
         })
@@ -729,6 +730,15 @@ impl<W> App<W> {
             if was_selecting && task.has_selection() && !shift_held {
                 self.copy_selection()?;
             }
+            return Ok(());
+        }
+
+        // A hover event can only arrive while the button is up, so if a drag
+        // is still live we missed the release (the terminal swallowed the
+        // shifted mouse events). End the drag and keep the selection, the
+        // same outcome as an observed shift-release.
+        if matches!(event.kind, crossterm::event::MouseEventKind::Moved) {
+            self.get_full_task_mut()?.handle_mouse(event)?;
             return Ok(());
         }
 
@@ -3117,6 +3127,52 @@ mod test {
         app.copy_selection()?;
         assert!(app.clipboard_notice_expiry.is_some());
         assert!(!app.get_full_task()?.has_selection());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_hover_after_swallowed_release_ends_drag_and_keeps_selection() -> Result<(), Error> {
+        use crossterm::event::{KeyModifiers, MouseEvent, MouseEventKind};
+
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())
+            .expect("Failed to create AbsoluteSystemPathBuf");
+
+        let mut app: App<Vec<u8>> = App::new(
+            100,
+            100,
+            vec!["a".to_string()],
+            PreferenceLoader::new(&repo_root),
+            2048,
+        );
+        app.start_task("a", OutputLogs::Full)?;
+        app.process_output("a", b"hello world\r\n")?;
+
+        let pane_column = app.size.task_list_width();
+        let mouse = |kind, column| MouseEvent {
+            kind,
+            column,
+            row: 1,
+            modifiers: KeyModifiers::empty(),
+        };
+
+        app.handle_mouse(mouse(
+            MouseEventKind::Down(crossterm::event::MouseButton::Left),
+            pane_column,
+        ))?;
+        app.handle_mouse(mouse(
+            MouseEventKind::Drag(crossterm::event::MouseButton::Left),
+            pane_column + 4,
+        ))?;
+        assert!(app.get_full_task()?.is_selecting());
+
+        // The user held shift and released: the terminal swallowed the
+        // shifted release, so the next thing we see is a hover event.
+        app.handle_mouse(mouse(MouseEventKind::Moved, pane_column + 4))?;
+        assert!(!app.get_full_task()?.is_selecting());
+        assert!(app.get_full_task()?.has_selection());
+        assert!(app.clipboard_notice_expiry.is_none());
 
         Ok(())
     }

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -24,6 +24,8 @@ use crate::tui::popup::{popup, popup_area};
 
 pub const FRAMERATE: Duration = Duration::from_millis(3);
 const RESIZE_DEBOUNCE_DELAY: Duration = Duration::from_millis(10);
+/// How long the pane footer shows "Copied to clipboard" after a copy.
+const CLIPBOARD_NOTICE_DURATION: Duration = Duration::from_secs(2);
 
 use super::{
     AppReceiver, Debouncer, Error, Event, InputOptions, SizeInfo, TaskTable, TerminalPane,
@@ -69,6 +71,9 @@ pub struct App<W> {
     scroll_momentum: ScrollMomentum,
     log_events: Vec<turborepo_log::LogEvent>,
     showing_log_panel: bool,
+    /// While set, the pane footer shows "Copied to clipboard". Cleared once
+    /// the deadline passes.
+    clipboard_notice_expiry: Option<Instant>,
     /// How many bytes of each task's output have already been emitted to the
     /// stream sink. Lets repeated TUI<->stream toggles backfill only the new
     /// output instead of re-printing the whole history each time.
@@ -131,6 +136,7 @@ impl<W> App<W> {
             scroll_momentum: ScrollMomentum::new(),
             log_events: Vec::new(),
             showing_log_panel: false,
+            clipboard_notice_expiry: None,
             replayed_offsets: BTreeMap::new(),
         }
     }
@@ -704,6 +710,22 @@ impl<W> App<W> {
     }
 
     pub fn handle_mouse(&mut self, mut event: crossterm::event::MouseEvent) -> Result<(), Error> {
+        // Releasing the left button ends a selection wherever the cursor is,
+        // so handle it before any hit-testing. Whatever was selected gets
+        // copied to the clipboard automatically.
+        if matches!(
+            event.kind,
+            crossterm::event::MouseEventKind::Up(crossterm::event::MouseButton::Left)
+        ) {
+            let task = self.get_full_task_mut()?;
+            let was_selecting = task.is_selecting();
+            task.handle_mouse(event)?;
+            if was_selecting && task.has_selection() {
+                self.copy_selection()?;
+            }
+            return Ok(());
+        }
+
         // Only offset by table width if the sidebar is visible
         let has_sidebar = self.preferences.is_task_list_visible();
         let table_width = if has_sidebar {
@@ -766,7 +788,22 @@ impl<W> App<W> {
             return Ok(());
         };
         super::copy_to_clipboard(&text);
+        self.clipboard_notice_expiry = Some(Instant::now() + CLIPBOARD_NOTICE_DURATION);
         Ok(())
+    }
+
+    /// Clears the "Copied to clipboard" notice once it has been shown long
+    /// enough. Returns true if the notice was just cleared, meaning the
+    /// footer needs a rerender.
+    fn clear_expired_clipboard_notice(&mut self) -> bool {
+        if self
+            .clipboard_notice_expiry
+            .is_some_and(|deadline| deadline <= Instant::now())
+        {
+            self.clipboard_notice_expiry = None;
+            return true;
+        }
+        false
     }
 
     fn select_task(&mut self, task_name: &str) -> Result<(), Error> {
@@ -1021,6 +1058,12 @@ async fn run_app_inner(
         // If we only receive ticks, then there's been no state change so no update
         // needed
         if !matches!(event, Event::Tick) {
+            needs_rerender = true;
+        }
+
+        // The "Copied to clipboard" notice expires on its own, so ticks must
+        // trigger a rerender when it does.
+        if app.clear_expired_clipboard_notice() {
             needs_rerender = true;
         }
 
@@ -1533,12 +1576,14 @@ fn view<W>(app: &mut App<W>, f: &mut Frame) {
 
     if let Ok(active_task) = app.active_task() {
         let active_task = active_task.to_string();
+        let show_copied_notice = app.clipboard_notice_expiry.is_some();
         if let Some(output_logs) = app.tasks.get_mut(&active_task) {
             let mut pane_to_render = TerminalPane::new(
                 output_logs,
                 &active_task,
                 &app.section_focus,
                 app.preferences.is_task_list_visible(),
+                show_copied_notice,
             );
             f.render_widget(&mut pane_to_render, pane);
         }
@@ -2949,6 +2994,113 @@ mod test {
         assert_eq!(app.active_task()?, "task-4");
         app.handle_mouse(click(5))?;
         assert_eq!(app.active_task()?, "task-4");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_mouse_release_copies_selection_and_shows_notice() -> Result<(), Error> {
+        use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())
+            .expect("Failed to create AbsoluteSystemPathBuf");
+
+        let mut app: App<Vec<u8>> = App::new(
+            100,
+            100,
+            vec!["a".to_string()],
+            PreferenceLoader::new(&repo_root),
+            2048,
+        );
+        app.start_task("a", OutputLogs::Full)?;
+        app.process_output("a", b"hello world\r\n")?;
+
+        let pane_column = app.size.task_list_width();
+        let mouse = |kind, column, modifiers| MouseEvent {
+            kind,
+            column,
+            row: 1,
+            modifiers,
+        };
+
+        app.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            pane_column,
+            KeyModifiers::empty(),
+        ))?;
+        app.handle_mouse(mouse(
+            MouseEventKind::Drag(MouseButton::Left),
+            pane_column + 4,
+            KeyModifiers::empty(),
+        ))?;
+        assert!(app.get_full_task()?.has_selection());
+        assert!(app.clipboard_notice_expiry.is_none());
+
+        app.handle_mouse(mouse(
+            MouseEventKind::Up(MouseButton::Left),
+            pane_column + 4,
+            KeyModifiers::empty(),
+        ))?;
+        // Releasing the button copies the selection and shows the notice.
+        assert!(app.clipboard_notice_expiry.is_some());
+        assert!(app.get_full_task()?.has_selection());
+        assert!(!app.get_full_task()?.is_selecting());
+        assert!(!app.clear_expired_clipboard_notice());
+
+        // Once the deadline passes the notice clears and requests a rerender.
+        app.clipboard_notice_expiry = Some(Instant::now() - Duration::from_millis(1));
+        assert!(app.clear_expired_clipboard_notice());
+        assert!(app.clipboard_notice_expiry.is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_mouse_release_with_shift_does_not_copy() -> Result<(), Error> {
+        use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())
+            .expect("Failed to create AbsoluteSystemPathBuf");
+
+        let mut app: App<Vec<u8>> = App::new(
+            100,
+            100,
+            vec!["a".to_string()],
+            PreferenceLoader::new(&repo_root),
+            2048,
+        );
+        app.start_task("a", OutputLogs::Full)?;
+        app.process_output("a", b"hello world\r\n")?;
+
+        let pane_column = app.size.task_list_width();
+        let mouse = |kind, column, modifiers| MouseEvent {
+            kind,
+            column,
+            row: 1,
+            modifiers,
+        };
+
+        app.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            pane_column,
+            KeyModifiers::empty(),
+        ))?;
+        app.handle_mouse(mouse(
+            MouseEventKind::Drag(MouseButton::Left),
+            pane_column + 4,
+            KeyModifiers::empty(),
+        ))?;
+        assert!(app.get_full_task()?.has_selection());
+
+        app.handle_mouse(mouse(
+            MouseEventKind::Up(MouseButton::Left),
+            pane_column + 4,
+            KeyModifiers::SHIFT,
+        ))?;
+        assert!(app.clipboard_notice_expiry.is_none());
+        assert!(!app.get_full_task()?.has_selection());
 
         Ok(())
     }

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -717,15 +717,18 @@ impl<W> App<W> {
             event.kind,
             crossterm::event::MouseEventKind::Up(crossterm::event::MouseButton::Left)
         ) {
+            let shift_held = event
+                .modifiers
+                .contains(crossterm::event::KeyModifiers::SHIFT);
             let task = self.get_full_task_mut()?;
             let was_selecting = task.is_selecting();
             task.handle_mouse(event)?;
-            if was_selecting && task.has_selection() {
+            // Shift prevents the automatic copy, leaving the selection in
+            // place so the user can still copy it with `c` or dismiss it by
+            // clicking.
+            if was_selecting && task.has_selection() && !shift_held {
                 self.copy_selection()?;
             }
-            // The selection has served its purpose once the button is up:
-            // it was either copied or cancelled. Drop the highlight.
-            self.get_full_task_mut()?.clear_selection()?;
             return Ok(());
         }
 
@@ -791,6 +794,8 @@ impl<W> App<W> {
             return Ok(());
         };
         super::copy_to_clipboard(&text);
+        // The selection has served its purpose; drop the highlight.
+        task.clear_selection()?;
         self.clipboard_notice_expiry = Some(Instant::now() + CLIPBOARD_NOTICE_DURATION);
         Ok(())
     }
@@ -3061,7 +3066,7 @@ mod test {
     }
 
     #[test]
-    fn test_mouse_release_with_shift_does_not_copy() -> Result<(), Error> {
+    fn test_mouse_release_with_shift_keeps_selection_for_manual_copy() -> Result<(), Error> {
         use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 
         let repo_root_tmp = tempdir()?;
@@ -3103,7 +3108,14 @@ mod test {
             pane_column + 4,
             KeyModifiers::SHIFT,
         ))?;
+        // No automatic copy, but the selection is kept so it can still be
+        // copied with `c`.
         assert!(app.clipboard_notice_expiry.is_none());
+        assert!(app.get_full_task()?.has_selection());
+
+        // `c` copies the held selection, then drops the highlight.
+        app.copy_selection()?;
+        assert!(app.clipboard_notice_expiry.is_some());
         assert!(!app.get_full_task()?.has_selection());
 
         Ok(())

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -723,6 +723,9 @@ impl<W> App<W> {
             if was_selecting && task.has_selection() {
                 self.copy_selection()?;
             }
+            // The selection has served its purpose once the button is up:
+            // it was either copied or cancelled. Drop the highlight.
+            self.get_full_task_mut()?.clear_selection()?;
             return Ok(());
         }
 
@@ -3042,9 +3045,10 @@ mod test {
             pane_column + 4,
             KeyModifiers::empty(),
         ))?;
-        // Releasing the button copies the selection and shows the notice.
+        // Releasing the button copies the selection, clears the highlight,
+        // and shows the notice.
         assert!(app.clipboard_notice_expiry.is_some());
-        assert!(app.get_full_task()?.has_selection());
+        assert!(!app.get_full_task()?.has_selection());
         assert!(!app.get_full_task()?.is_selecting());
         assert!(!app.clear_expired_clipboard_notice());
 

--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -46,7 +46,8 @@ impl InputOptions<'_> {
                     Some(Event::ScrollWithMomentum(Direction::Up))
                 }
                 crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left)
-                | crossterm::event::MouseEventKind::Drag(crossterm::event::MouseButton::Left) => {
+                | crossterm::event::MouseEventKind::Drag(crossterm::event::MouseButton::Left)
+                | crossterm::event::MouseEventKind::Up(crossterm::event::MouseButton::Left) => {
                     Some(Event::Mouse(m))
                 }
                 _ => None,

--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -13,6 +13,8 @@ use super::{
 pub struct InputOptions<'a> {
     pub focus: &'a LayoutSections,
     pub has_selection: bool,
+    /// Whether a mouse selection drag is (as far as we know) in progress.
+    pub is_selecting: bool,
     pub is_help_popup_open: bool,
     pub is_log_panel_open: bool,
 }
@@ -48,6 +50,14 @@ impl InputOptions<'_> {
                 crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left)
                 | crossterm::event::MouseEventKind::Drag(crossterm::event::MouseButton::Left)
                 | crossterm::event::MouseEventKind::Up(crossterm::event::MouseButton::Left) => {
+                    Some(Event::Mouse(m))
+                }
+                // A hover event while we believe a drag is in progress means
+                // we missed the release: terminals swallow shifted mouse
+                // events (shift is the native-selection escape hatch), so a
+                // shift-release is never delivered. Forward the hover so the
+                // app can end the drag.
+                crossterm::event::MouseEventKind::Moved if self.is_selecting => {
                     Some(Event::Mouse(m))
                 }
                 _ => None,
@@ -465,6 +475,7 @@ mod test {
         InputOptions {
             focus: search(),
             has_selection: false,
+            is_selecting: false,
             is_help_popup_open: false,
             is_log_panel_open: false,
         }
@@ -475,6 +486,7 @@ mod test {
         InputOptions {
             focus: LIST.get_or_init(|| LayoutSections::TaskList),
             has_selection: false,
+            is_selecting: false,
             is_help_popup_open: false,
             is_log_panel_open: false,
         }

--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -10,8 +10,8 @@ use super::{PANE_LEFT_PADDING_WITH_SIDEBAR, TerminalOutput, app::LayoutSections}
 
 const EXIT_INTERACTIVE_HINT: &str = "Ctrl-z - Stop interacting";
 const ENTER_INTERACTIVE_HINT: &str = "i - Interact";
-const CANCEL_SELECTION: &str = "hold shift - Cancel selection";
-const COPIED_TO_CLIPBOARD: &str = "Copied to clipboard";
+const CANCEL_SELECTION: &str = "Hold Shift - Prevent copy";
+const COPIED_TO_CLIPBOARD: &str = "Copied to clipboard!";
 const SCROLL_LOGS: &str = "u/d - Scroll logs";
 const PAGE_LOGS: &str = "U/D - Page logs";
 const JUMP_IN_LOGS: &str = "t/b - Jump to top/bottom";
@@ -162,7 +162,7 @@ mod test {
     fn test_footer_copied_notice() {
         let mut term: TerminalOutput<Vec<u8>> = TerminalOutput::new(16, 16, None, 2048);
         let pane = TerminalPane::new(&mut term, "foo", &LayoutSections::TaskList, true, true);
-        assert_eq!(String::from(pane.footer()), "   Copied to clipboard");
+        assert_eq!(String::from(pane.footer()), "   Copied to clipboard!");
     }
 
     #[test]
@@ -187,10 +187,7 @@ mod test {
         .unwrap();
 
         let pane = TerminalPane::new(&mut term, "foo", &LayoutSections::TaskList, true, false);
-        assert_eq!(
-            String::from(pane.footer()),
-            "   hold shift - Cancel selection"
-        );
+        assert_eq!(String::from(pane.footer()), "   Hold Shift - Prevent copy");
     }
 
     #[test]

--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -10,7 +10,6 @@ use super::{PANE_LEFT_PADDING_WITH_SIDEBAR, TerminalOutput, app::LayoutSections}
 
 const EXIT_INTERACTIVE_HINT: &str = "Ctrl-z - Stop interacting";
 const ENTER_INTERACTIVE_HINT: &str = "i - Interact";
-const HAS_SELECTION: &str = "c - Copy selection";
 const CANCEL_SELECTION: &str = "hold shift - Cancel selection";
 const COPIED_TO_CLIPBOARD: &str = "Copied to clipboard";
 const SCROLL_LOGS: &str = "u/d - Scroll logs";
@@ -48,6 +47,26 @@ impl<'a, W> TerminalPane<'a, W> {
     }
 
     fn footer(&self) -> Line<'_> {
+        let format_messages = |messages: &[&str]| -> Line {
+            // Spaces are used to pad the footer text for aesthetics
+            let formatted_messages = format!("   {}", messages.join("   "));
+
+            Line::styled(
+                formatted_messages,
+                Style::default().add_modifier(Modifier::DIM),
+            )
+            .left_aligned()
+        };
+
+        // While the user is dragging out a selection, and right after a
+        // copy, the one relevant message replaces the usual key binds.
+        if self.terminal_output.is_selecting() {
+            return format_messages(&[CANCEL_SELECTION]);
+        }
+        if self.show_copied_notice {
+            return format_messages(&[COPIED_TO_CLIPBOARD]);
+        }
+
         let build_message_vec = |footer_text: &[&str]| -> Line {
             let mut messages = Vec::new();
             messages.extend_from_slice(footer_text);
@@ -56,26 +75,7 @@ impl<'a, W> TerminalPane<'a, W> {
                 messages.push(TASK_LIST_HIDDEN);
             }
 
-            // Selection hints, in priority order: while the user is dragging
-            // out a selection, tell them how to cancel it; right after a
-            // copy, confirm it happened; otherwise advertise the copy bind
-            // for the selection they have.
-            if self.terminal_output.is_selecting() {
-                messages.push(CANCEL_SELECTION);
-            } else if self.show_copied_notice {
-                messages.push(COPIED_TO_CLIPBOARD);
-            } else if self.terminal_output.has_selection() {
-                messages.push(HAS_SELECTION);
-            }
-
-            // Spaces are used to pad the footer text for aesthetics
-            let formatted_messages = format!("   {}", messages.join("   "));
-
-            Line::styled(
-                formatted_messages.to_string(),
-                Style::default().add_modifier(Modifier::DIM),
-            )
-            .left_aligned()
+            format_messages(&messages)
         };
 
         match self.section {
@@ -162,11 +162,7 @@ mod test {
     fn test_footer_copied_notice() {
         let mut term: TerminalOutput<Vec<u8>> = TerminalOutput::new(16, 16, None, 2048);
         let pane = TerminalPane::new(&mut term, "foo", &LayoutSections::TaskList, true, true);
-        assert_eq!(
-            String::from(pane.footer()),
-            "   u/d - Scroll logs   U/D - Page logs   t/b - Jump to top/bottom   Copied to \
-             clipboard"
-        );
+        assert_eq!(String::from(pane.footer()), "   Copied to clipboard");
     }
 
     #[test]
@@ -193,8 +189,7 @@ mod test {
         let pane = TerminalPane::new(&mut term, "foo", &LayoutSections::TaskList, true, false);
         assert_eq!(
             String::from(pane.footer()),
-            "   u/d - Scroll logs   U/D - Page logs   t/b - Jump to top/bottom   hold shift - \
-             Cancel selection"
+            "   hold shift - Cancel selection"
         );
     }
 

--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -11,6 +11,8 @@ use super::{PANE_LEFT_PADDING_WITH_SIDEBAR, TerminalOutput, app::LayoutSections}
 const EXIT_INTERACTIVE_HINT: &str = "Ctrl-z - Stop interacting";
 const ENTER_INTERACTIVE_HINT: &str = "i - Interact";
 const HAS_SELECTION: &str = "c - Copy selection";
+const CANCEL_SELECTION: &str = "hold shift - Cancel selection";
+const COPIED_TO_CLIPBOARD: &str = "Copied to clipboard";
 const SCROLL_LOGS: &str = "u/d - Scroll logs";
 const PAGE_LOGS: &str = "U/D - Page logs";
 const JUMP_IN_LOGS: &str = "t/b - Jump to top/bottom";
@@ -21,6 +23,7 @@ pub struct TerminalPane<'a, W> {
     task_name: &'a str,
     section: &'a LayoutSections,
     has_sidebar: bool,
+    show_copied_notice: bool,
 }
 
 impl<'a, W> TerminalPane<'a, W> {
@@ -29,12 +32,14 @@ impl<'a, W> TerminalPane<'a, W> {
         task_name: &'a str,
         section: &'a LayoutSections,
         has_sidebar: bool,
+        show_copied_notice: bool,
     ) -> Self {
         Self {
             terminal_output,
             section,
             task_name,
             has_sidebar,
+            show_copied_notice,
         }
     }
 
@@ -51,7 +56,15 @@ impl<'a, W> TerminalPane<'a, W> {
                 messages.push(TASK_LIST_HIDDEN);
             }
 
-            if self.terminal_output.has_selection() {
+            // Selection hints, in priority order: while the user is dragging
+            // out a selection, tell them how to cancel it; right after a
+            // copy, confirm it happened; otherwise advertise the copy bind
+            // for the selection they have.
+            if self.terminal_output.is_selecting() {
+                messages.push(CANCEL_SELECTION);
+            } else if self.show_copied_notice {
+                messages.push(COPIED_TO_CLIPBOARD);
+            } else if self.terminal_output.has_selection() {
                 messages.push(HAS_SELECTION);
             }
 
@@ -128,7 +141,7 @@ mod test {
     #[test]
     fn test_footer_interactive() {
         let mut term: TerminalOutput<Vec<u8>> = TerminalOutput::new(16, 16, Some(Vec::new()), 2048);
-        let pane = TerminalPane::new(&mut term, "foo", &LayoutSections::TaskList, true);
+        let pane = TerminalPane::new(&mut term, "foo", &LayoutSections::TaskList, true, false);
         assert_eq!(
             String::from(pane.footer()),
             "   i - Interact   u/d - Scroll logs   U/D - Page logs   t/b - Jump to top/bottom"
@@ -138,7 +151,7 @@ mod test {
     #[test]
     fn test_footer_non_interactive() {
         let mut term: TerminalOutput<Vec<u8>> = TerminalOutput::new(16, 16, None, 2048);
-        let pane = TerminalPane::new(&mut term, "foo", &LayoutSections::TaskList, true);
+        let pane = TerminalPane::new(&mut term, "foo", &LayoutSections::TaskList, true, false);
         assert_eq!(
             String::from(pane.footer()),
             "   u/d - Scroll logs   U/D - Page logs   t/b - Jump to top/bottom"
@@ -146,9 +159,49 @@ mod test {
     }
 
     #[test]
+    fn test_footer_copied_notice() {
+        let mut term: TerminalOutput<Vec<u8>> = TerminalOutput::new(16, 16, None, 2048);
+        let pane = TerminalPane::new(&mut term, "foo", &LayoutSections::TaskList, true, true);
+        assert_eq!(
+            String::from(pane.footer()),
+            "   u/d - Scroll logs   U/D - Page logs   t/b - Jump to top/bottom   Copied to \
+             clipboard"
+        );
+    }
+
+    #[test]
+    fn test_footer_cancel_selection_hint_while_selecting() {
+        use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+        let mut term: TerminalOutput<Vec<u8>> = TerminalOutput::new(16, 16, None, 2048);
+        term.process(b"hello world\r\n");
+        term.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 0,
+            row: 0,
+            modifiers: KeyModifiers::empty(),
+        })
+        .unwrap();
+        term.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: 4,
+            row: 0,
+            modifiers: KeyModifiers::empty(),
+        })
+        .unwrap();
+
+        let pane = TerminalPane::new(&mut term, "foo", &LayoutSections::TaskList, true, false);
+        assert_eq!(
+            String::from(pane.footer()),
+            "   u/d - Scroll logs   U/D - Page logs   t/b - Jump to top/bottom   hold shift - \
+             Cancel selection"
+        );
+    }
+
+    #[test]
     fn test_content_area_pads_when_sidebar_visible() {
         let mut term: TerminalOutput<Vec<u8>> = TerminalOutput::new(16, 16, None, 2048);
-        let pane = TerminalPane::new(&mut term, "foo", &LayoutSections::TaskList, true);
+        let pane = TerminalPane::new(&mut term, "foo", &LayoutSections::TaskList, true, false);
 
         assert_eq!(
             pane.content_area(Rect::new(10, 0, 20, 10)),
@@ -159,7 +212,7 @@ mod test {
     #[test]
     fn test_content_area_has_no_padding_when_sidebar_hidden() {
         let mut term: TerminalOutput<Vec<u8>> = TerminalOutput::new(16, 16, None, 2048);
-        let pane = TerminalPane::new(&mut term, "foo", &LayoutSections::TaskList, false);
+        let pane = TerminalPane::new(&mut term, "foo", &LayoutSections::TaskList, false, false);
 
         assert_eq!(
             pane.content_area(Rect::new(10, 0, 20, 10)),

--- a/crates/turborepo-ui/src/tui/pane.rs
+++ b/crates/turborepo-ui/src/tui/pane.rs
@@ -12,6 +12,7 @@ const EXIT_INTERACTIVE_HINT: &str = "Ctrl-z - Stop interacting";
 const ENTER_INTERACTIVE_HINT: &str = "i - Interact";
 const CANCEL_SELECTION: &str = "Hold Shift - Prevent copy";
 const COPIED_TO_CLIPBOARD: &str = "Copied to clipboard!";
+const HAS_SELECTION: &str = "c - Copy to clipboard | Click to unselect";
 const SCROLL_LOGS: &str = "u/d - Scroll logs";
 const PAGE_LOGS: &str = "U/D - Page logs";
 const JUMP_IN_LOGS: &str = "t/b - Jump to top/bottom";
@@ -58,13 +59,18 @@ impl<'a, W> TerminalPane<'a, W> {
             .left_aligned()
         };
 
-        // While the user is dragging out a selection, and right after a
-        // copy, the one relevant message replaces the usual key binds.
+        // Selection flows replace the usual key binds with the one relevant
+        // message: how to prevent the copy while dragging, confirmation
+        // right after a copy, and the options for a selection that was kept
+        // by releasing with shift held.
         if self.terminal_output.is_selecting() {
             return format_messages(&[CANCEL_SELECTION]);
         }
         if self.show_copied_notice {
             return format_messages(&[COPIED_TO_CLIPBOARD]);
+        }
+        if self.terminal_output.has_selection() {
+            return format_messages(&[HAS_SELECTION]);
         }
 
         let build_message_vec = |footer_text: &[&str]| -> Line {
@@ -188,6 +194,43 @@ mod test {
 
         let pane = TerminalPane::new(&mut term, "foo", &LayoutSections::TaskList, true, false);
         assert_eq!(String::from(pane.footer()), "   Hold Shift - Prevent copy");
+    }
+
+    #[test]
+    fn test_footer_held_selection_offers_copy_and_unselect() {
+        use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+        let mut term: TerminalOutput<Vec<u8>> = TerminalOutput::new(16, 16, None, 2048);
+        term.process(b"hello world\r\n");
+        term.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 0,
+            row: 0,
+            modifiers: KeyModifiers::empty(),
+        })
+        .unwrap();
+        term.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: 4,
+            row: 0,
+            modifiers: KeyModifiers::empty(),
+        })
+        .unwrap();
+        term.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Up(MouseButton::Left),
+            column: 4,
+            row: 0,
+            modifiers: KeyModifiers::SHIFT,
+        })
+        .unwrap();
+        assert!(term.has_selection());
+        assert!(!term.is_selecting());
+
+        let pane = TerminalPane::new(&mut term, "foo", &LayoutSections::TaskList, true, false);
+        assert_eq!(
+            String::from(pane.footer()),
+            "   c - Copy to clipboard | Click to unselect"
+        );
     }
 
     #[test]

--- a/crates/turborepo-ui/src/tui/term_output.rs
+++ b/crates/turborepo-ui/src/tui/term_output.rs
@@ -166,7 +166,15 @@ impl<W> TerminalOutput<W> {
         match event.kind {
             crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left) => {
                 self.parser.clear_selection()?;
-                self.selection_start = Some((event.row, event.column));
+                // Shift held at click time means the user is preventing the
+                // copy before it starts, so don't anchor a selection. Most
+                // terminals never deliver shifted mouse events (shift
+                // bypasses mouse capture for native selection), but honor
+                // them when they do arrive.
+                self.selection_start = (!event
+                    .modifiers
+                    .contains(crossterm::event::KeyModifiers::SHIFT))
+                .then_some((event.row, event.column));
             }
             crossterm::event::MouseEventKind::Drag(crossterm::event::MouseButton::Left) => {
                 // Holding shift mid-drag cancels the selection so releasing
@@ -339,6 +347,31 @@ mod newline_tests {
         output.handle_mouse(MouseEvent {
             kind: MouseEventKind::Drag(MouseButton::Left),
             column: 8,
+            row: 0,
+            modifiers: KeyModifiers::empty(),
+        })?;
+        assert!(!output.has_selection());
+        Ok(())
+    }
+
+    #[test]
+    fn shift_on_click_does_not_start_selection() -> Result<(), Error> {
+        use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+        let mut output: TerminalOutput<()> = TerminalOutput::new(10, 40, None, 100);
+        output.process(b"hello world\r\n");
+
+        output.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 0,
+            row: 0,
+            modifiers: KeyModifiers::SHIFT,
+        })?;
+        assert!(!output.is_selecting());
+
+        output.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: 4,
             row: 0,
             modifiers: KeyModifiers::empty(),
         })?;

--- a/crates/turborepo-ui/src/tui/term_output.rs
+++ b/crates/turborepo-ui/src/tui/term_output.rs
@@ -184,7 +184,11 @@ impl<W> TerminalOutput<W> {
             }
             crossterm::event::MouseEventKind::ScrollDown => (),
             crossterm::event::MouseEventKind::ScrollUp => (),
-            crossterm::event::MouseEventKind::Moved => (),
+            // Hover means the button is up; drop any stale drag anchor from
+            // a release that the terminal never delivered to us.
+            crossterm::event::MouseEventKind::Moved => {
+                self.selection_start = None;
+            }
             crossterm::event::MouseEventKind::Down(_) => (),
             crossterm::event::MouseEventKind::Drag(_) => (),
             crossterm::event::MouseEventKind::ScrollLeft

--- a/crates/turborepo-ui/src/tui/term_output.rs
+++ b/crates/turborepo-ui/src/tui/term_output.rs
@@ -149,6 +149,12 @@ impl<W> TerminalOutput<W> {
         self.parser.has_selection()
     }
 
+    /// Whether a mouse-driven selection is in progress (the button is still
+    /// held down).
+    pub fn is_selecting(&self) -> bool {
+        self.selection_start.is_some()
+    }
+
     pub fn handle_mouse(&mut self, event: crossterm::event::MouseEvent) -> Result<(), Error> {
         match event.kind {
             crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left) => {
@@ -156,7 +162,15 @@ impl<W> TerminalOutput<W> {
                 self.selection_start = Some((event.row, event.column));
             }
             crossterm::event::MouseEventKind::Drag(crossterm::event::MouseButton::Left) => {
-                if let Some((start_row, start_col)) = self.selection_start {
+                // Holding shift mid-drag cancels the selection so releasing
+                // the button won't copy anything.
+                if event
+                    .modifiers
+                    .contains(crossterm::event::KeyModifiers::SHIFT)
+                {
+                    self.parser.clear_selection()?;
+                    self.selection_start = None;
+                } else if let Some((start_row, start_col)) = self.selection_start {
                     self.parser
                         .update_selection(start_row, start_col, event.row, event.column)?;
                 }
@@ -169,6 +183,12 @@ impl<W> TerminalOutput<W> {
             crossterm::event::MouseEventKind::ScrollLeft
             | crossterm::event::MouseEventKind::ScrollRight => (),
             crossterm::event::MouseEventKind::Up(_) => {
+                if event
+                    .modifiers
+                    .contains(crossterm::event::KeyModifiers::SHIFT)
+                {
+                    self.parser.clear_selection()?;
+                }
                 self.selection_start = None;
             }
         }
@@ -262,7 +282,91 @@ mod newline_tests {
         })?;
 
         assert!(output.has_selection());
+        assert!(output.is_selecting());
         assert_eq!(output.copy_selection().as_deref(), Some("hello"));
+
+        output.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Up(MouseButton::Left),
+            column: 4,
+            row: 0,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        })?;
+        // Release ends the drag but keeps the selection highlighted.
+        assert!(!output.is_selecting());
+        assert!(output.has_selection());
+        Ok(())
+    }
+
+    #[test]
+    fn shift_during_drag_cancels_selection() -> Result<(), Error> {
+        use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+        let mut output: TerminalOutput<()> = TerminalOutput::new(10, 40, None, 100);
+        output.process(b"hello world\r\n");
+
+        output.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 0,
+            row: 0,
+            modifiers: KeyModifiers::empty(),
+        })?;
+        output.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: 4,
+            row: 0,
+            modifiers: KeyModifiers::empty(),
+        })?;
+        assert!(output.has_selection());
+
+        output.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: 6,
+            row: 0,
+            modifiers: KeyModifiers::SHIFT,
+        })?;
+        assert!(!output.has_selection());
+        assert!(!output.is_selecting());
+
+        // Continuing to drag without shift doesn't resurrect the selection.
+        output.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: 8,
+            row: 0,
+            modifiers: KeyModifiers::empty(),
+        })?;
+        assert!(!output.has_selection());
+        Ok(())
+    }
+
+    #[test]
+    fn shift_on_release_cancels_selection() -> Result<(), Error> {
+        use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+        let mut output: TerminalOutput<()> = TerminalOutput::new(10, 40, None, 100);
+        output.process(b"hello world\r\n");
+
+        output.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 0,
+            row: 0,
+            modifiers: KeyModifiers::empty(),
+        })?;
+        output.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: 4,
+            row: 0,
+            modifiers: KeyModifiers::empty(),
+        })?;
+        assert!(output.has_selection());
+
+        output.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Up(MouseButton::Left),
+            column: 4,
+            row: 0,
+            modifiers: KeyModifiers::SHIFT,
+        })?;
+        assert!(!output.has_selection());
+        assert!(!output.is_selecting());
         Ok(())
     }
 }

--- a/crates/turborepo-ui/src/tui/term_output.rs
+++ b/crates/turborepo-ui/src/tui/term_output.rs
@@ -177,15 +177,7 @@ impl<W> TerminalOutput<W> {
                 .then_some((event.row, event.column));
             }
             crossterm::event::MouseEventKind::Drag(crossterm::event::MouseButton::Left) => {
-                // Holding shift mid-drag cancels the selection so releasing
-                // the button won't copy anything.
-                if event
-                    .modifiers
-                    .contains(crossterm::event::KeyModifiers::SHIFT)
-                {
-                    self.parser.clear_selection()?;
-                    self.selection_start = None;
-                } else if let Some((start_row, start_col)) = self.selection_start {
+                if let Some((start_row, start_col)) = self.selection_start {
                     self.parser
                         .update_selection(start_row, start_col, event.row, event.column)?;
                 }
@@ -198,12 +190,6 @@ impl<W> TerminalOutput<W> {
             crossterm::event::MouseEventKind::ScrollLeft
             | crossterm::event::MouseEventKind::ScrollRight => (),
             crossterm::event::MouseEventKind::Up(_) => {
-                if event
-                    .modifiers
-                    .contains(crossterm::event::KeyModifiers::SHIFT)
-                {
-                    self.parser.clear_selection()?;
-                }
                 self.selection_start = None;
             }
         }
@@ -314,47 +300,6 @@ mod newline_tests {
     }
 
     #[test]
-    fn shift_during_drag_cancels_selection() -> Result<(), Error> {
-        use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
-
-        let mut output: TerminalOutput<()> = TerminalOutput::new(10, 40, None, 100);
-        output.process(b"hello world\r\n");
-
-        output.handle_mouse(MouseEvent {
-            kind: MouseEventKind::Down(MouseButton::Left),
-            column: 0,
-            row: 0,
-            modifiers: KeyModifiers::empty(),
-        })?;
-        output.handle_mouse(MouseEvent {
-            kind: MouseEventKind::Drag(MouseButton::Left),
-            column: 4,
-            row: 0,
-            modifiers: KeyModifiers::empty(),
-        })?;
-        assert!(output.has_selection());
-
-        output.handle_mouse(MouseEvent {
-            kind: MouseEventKind::Drag(MouseButton::Left),
-            column: 6,
-            row: 0,
-            modifiers: KeyModifiers::SHIFT,
-        })?;
-        assert!(!output.has_selection());
-        assert!(!output.is_selecting());
-
-        // Continuing to drag without shift doesn't resurrect the selection.
-        output.handle_mouse(MouseEvent {
-            kind: MouseEventKind::Drag(MouseButton::Left),
-            column: 8,
-            row: 0,
-            modifiers: KeyModifiers::empty(),
-        })?;
-        assert!(!output.has_selection());
-        Ok(())
-    }
-
-    #[test]
     fn shift_on_click_does_not_start_selection() -> Result<(), Error> {
         use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 
@@ -380,7 +325,7 @@ mod newline_tests {
     }
 
     #[test]
-    fn shift_on_release_cancels_selection() -> Result<(), Error> {
+    fn release_with_shift_keeps_selection() -> Result<(), Error> {
         use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 
         let mut output: TerminalOutput<()> = TerminalOutput::new(10, 40, None, 100);
@@ -400,13 +345,14 @@ mod newline_tests {
         })?;
         assert!(output.has_selection());
 
+        // The drag ends but the selection stays for a later `c` copy.
         output.handle_mouse(MouseEvent {
             kind: MouseEventKind::Up(MouseButton::Left),
             column: 4,
             row: 0,
             modifiers: KeyModifiers::SHIFT,
         })?;
-        assert!(!output.has_selection());
+        assert!(output.has_selection());
         assert!(!output.is_selecting());
         Ok(())
     }

--- a/crates/turborepo-ui/src/tui/term_output.rs
+++ b/crates/turborepo-ui/src/tui/term_output.rs
@@ -155,6 +155,13 @@ impl<W> TerminalOutput<W> {
         self.selection_start.is_some()
     }
 
+    /// Clears the selection highlight and any pending selection anchor.
+    pub fn clear_selection(&mut self) -> Result<(), Error> {
+        self.parser.clear_selection()?;
+        self.selection_start = None;
+        Ok(())
+    }
+
     pub fn handle_mouse(&mut self, event: crossterm::event::MouseEvent) -> Result<(), Error> {
         match event.kind {
             crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left) => {
@@ -291,7 +298,8 @@ mod newline_tests {
             row: 0,
             modifiers: crossterm::event::KeyModifiers::empty(),
         })?;
-        // Release ends the drag but keeps the selection highlighted.
+        // Release ends the drag. The selection itself survives at this
+        // layer so `App` can copy it before clearing the highlight.
         assert!(!output.is_selecting());
         assert!(output.has_selection());
         Ok(())


### PR DESCRIPTION
## Why

Copying logs out of the TUI currently requires selecting text and then remembering to press `c`. Selections almost always exist to be copied, so the extra keypress is friction. Users also need a way to opt out of the copy, and feedback that the copy actually happened.

## What

- Releasing the left mouse button after dragging out a selection copies it to the clipboard and clears the highlight.
- Holding shift at release prevents the automatic copy and keeps the selection; the footer then offers `c - Copy to clipboard | Click to unselect`. `c` is only available while a selection exists.
- While a drag is in progress, the bottom bar shows only `Hold Shift - Prevent copy`; after a copy it shows only `Copied to clipboard!` for two seconds. These messages replace the usual key-bind list instead of appending to it.

## How

- `input.rs` now forwards left-button `Up` mouse events, which were previously dropped, so releases reach the app.
- `App::handle_mouse` handles the release before any hit-testing: it ends the drag and, unless shift is held, copies the surviving selection. `App::copy_selection` clears the highlight and arms the notice deadline (`clipboard_notice_expiry`), which the existing ~3ms tick loop expires after two seconds.
- Shift held at click time (when the terminal forwards it) never anchors a selection. Note that most terminals intercept shift-before-click for native selection and the app receives nothing; shift pressed mid-drag is the reliable path.

To test manually: run `turbo` with the TUI, click and drag in the log pane, release, then paste; footer shows the shift hint during the drag and the copied notice for 2s after. Drag, hold shift, release: no copy, selection stays, footer offers `c`/click-to-unselect.
