### PR TITLE
perf: Avoid deep-cloning dependency maps in lockfile closure cache

### DIFF
--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -23,6 +23,7 @@ use std::{
     any::Any,
     borrow::Cow,
     collections::{BTreeMap, HashMap, HashSet},
+    sync::Arc,
 };
 
 pub use berry::{Error as BerryError, *};
@@ -37,7 +38,11 @@ use turbopath::RelativeUnixPathBuf;
 pub use yarn1::{Yarn1Lockfile, yarn_subgraph};
 
 type ResolveCache = DashMap<String, Option<Package>>;
-type DepsCache = DashMap<String, Option<BTreeMap<String, String>>>;
+// Dependency maps are shared behind an `Arc` so cache hits are a refcount bump
+// instead of a deep clone of the map. The cache is shared across all
+// workspaces, so each package's dependency map would otherwise be cloned once
+// per workspace whose closure contains it.
+type DepsCache = DashMap<String, Option<Arc<BTreeMap<String, String>>>>;
 
 #[derive(Debug, PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Serialize)]
 pub struct Package {
@@ -299,7 +304,7 @@ impl<L: Lockfile + ?Sized> ClosureContext<'_, L> {
                 let deps = self
                     .lockfile
                     .all_dependencies(&pkg.key)?
-                    .map(|cow| cow.into_owned());
+                    .map(|cow| Arc::new(cow.into_owned()));
                 self.deps_cache.insert(pkg.key.clone(), deps.clone());
                 deps
             };


### PR DESCRIPTION
## Why

`transitive_closure_cached` runs during package graph construction on every `turbo run`. Its shared `DepsCache` stored `Option<BTreeMap<String, String>>` and deep-cloned the entire dependency map on every cache hit — once per (workspace x package-in-closure). For pnpm this made the cache strictly slower than the underlying lookup: `PnpmLockfile::all_dependencies` returns a zero-cost `Cow::Borrowed` from a precomputed index, but the cache layer forced `into_owned()` plus a clone per hit.

## What

Store dependency maps in the cache behind an `Arc`, making cache hits a refcount bump instead of a deep clone. `DepsCache` is private, so there is no API change.

## How

Interleaved A/B benchmark of `all_transitive_closures()` against real lockfiles (100 iterations per sample, 10 samples per side):

| Lockfile | Base mean | Arc mean | Delta |
|---|---|---|---|
| turborepo (23 workspaces) | 10.0ms | 9.8ms | ~0 (noise) |
| next.js (41 workspaces) | 20.4ms | 20.0ms | -2% |
| astro (516 workspaces, small dep maps) | 18.9ms | 18.8ms | ~0 |
| n8n (72 workspaces, 29k closure entries) | 56.9ms | 53.3ms | -6% |

The saving scales with workspaces x size of shared dependency maps, so it is a wash for small repos (one extra `Arc` allocation per unique package, offset by cheaper hits) and grows with monorepo size. No regression observed at any scale. All existing `turborepo-lockfiles` tests pass unchanged.