### PR TITLE
perf: Cache env wildcard matches across tasks during hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7589,6 +7589,7 @@ dependencies = [
 name = "turborepo-env"
 version = "0.1.0"
 dependencies = [
+ "dashmap 6.1.0",
  "hex",
  "regex",
  "serde",

--- a/crates/turborepo-env/Cargo.toml
+++ b/crates/turborepo-env/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 workspace = true
 
 [dependencies]
+dashmap = { workspace = true }
 hex = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }

--- a/crates/turborepo-env/src/lib.rs
+++ b/crates/turborepo-env/src/lib.rs
@@ -6,8 +6,10 @@ use std::{
     collections::HashMap,
     env,
     ops::{Deref, DerefMut},
+    sync::Arc,
 };
 
+use dashmap::DashMap;
 use regex::{Regex, RegexBuilder};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
@@ -164,6 +166,30 @@ pub struct DetailedMap {
     pub by_source: BySource,
 }
 
+impl DetailedMap {
+    /// Combines framework-inferred env vars with the user's task env matches,
+    /// giving user exclusions primacy over inferred inclusions.
+    pub fn from_task_env_parts(inference: &EnvironmentVariableMap, user: &WildcardMaps) -> Self {
+        let mut all = EnvironmentVariableMap::default();
+        all.union(&user.inclusions);
+        all.union(inference);
+        all.difference(&user.exclusions);
+
+        let mut explicit = EnvironmentVariableMap::default();
+        explicit.union(&user.inclusions);
+        explicit.difference(&user.exclusions);
+
+        let mut matching = EnvironmentVariableMap::default();
+        matching.union(inference);
+        matching.difference(&user.exclusions);
+
+        DetailedMap {
+            all,
+            by_source: BySource { explicit, matching },
+        }
+    }
+}
+
 // A list of "k=v" strings for env variables and their values
 pub type EnvironmentVariablePairs = Vec<String>;
 
@@ -180,6 +206,44 @@ impl WildcardMaps {
         let mut output = self.inclusions;
         output.difference(&self.exclusions);
         output
+    }
+}
+
+/// The result of matching one wildcard pattern list against an environment.
+pub struct WildcardMatch {
+    /// The inclusions and exclusions matched by the patterns.
+    pub maps: WildcardMaps,
+    /// `maps` collapsed into a single map (inclusions minus exclusions).
+    pub resolved: EnvironmentVariableMap,
+}
+
+/// Memoizes wildcard matches against a fixed environment, keyed by pattern
+/// list.
+///
+/// Task env configurations repeat heavily across the tasks in a run, so this
+/// avoids recompiling regexes and rescanning the environment for every task.
+/// Only valid for as long as the underlying environment map is unchanged;
+/// callers are expected to match one cache to one environment snapshot.
+#[derive(Default)]
+pub struct WildcardMapCache {
+    cache: DashMap<Box<[String]>, Arc<WildcardMatch>>,
+}
+
+impl WildcardMapCache {
+    pub fn get_or_compute(
+        &self,
+        env: &EnvironmentVariableMap,
+        patterns: &[String],
+    ) -> Result<Arc<WildcardMatch>, Error> {
+        if let Some(hit) = self.cache.get(patterns) {
+            return Ok(hit.clone());
+        }
+        let maps = env.wildcard_map_from_wildcards_unresolved(patterns)?;
+        let mut resolved = maps.inclusions.clone();
+        resolved.difference(&maps.exclusions);
+        let entry = Arc::new(WildcardMatch { maps, resolved });
+        self.cache.insert(patterns.into(), entry.clone());
+        Ok(entry)
     }
 }
 
@@ -369,51 +433,12 @@ impl EnvironmentVariableMap {
         computed_wildcards: &[String],
         task_env: &[String],
     ) -> Result<DetailedMap, Error> {
-        let mut explicit_env_var_map = EnvironmentVariableMap::default();
-        let mut all_env_var_map = EnvironmentVariableMap::default();
-        let mut matching_env_var_map = EnvironmentVariableMap::default();
         let inference_env_var_map = self.from_wildcards(computed_wildcards)?;
-
         let user_env_var_set = self.wildcard_map_from_wildcards_unresolved(task_env)?;
-
-        all_env_var_map.union(&user_env_var_set.inclusions);
-        all_env_var_map.union(&inference_env_var_map);
-        all_env_var_map.difference(&user_env_var_set.exclusions);
-
-        explicit_env_var_map.union(&user_env_var_set.inclusions);
-        explicit_env_var_map.difference(&user_env_var_set.exclusions);
-
-        matching_env_var_map.union(&inference_env_var_map);
-        matching_env_var_map.difference(&user_env_var_set.exclusions);
-
-        Ok(DetailedMap {
-            all: all_env_var_map,
-            by_source: BySource {
-                explicit: explicit_env_var_map,
-                matching: matching_env_var_map,
-            },
-        })
-    }
-
-    /// Constructs an environment map that contains pass through environment
-    /// variables
-    pub fn pass_through_env(
-        &self,
-        builtins: &[&str],
-        global_env: &Self,
-        task_pass_through: &[impl AsRef<str>],
-    ) -> Result<Self, Error> {
-        let mut pass_through_env = EnvironmentVariableMap::default();
-        let default_env_var_pass_through_map = self.from_wildcards(builtins)?;
-        let task_pass_through_env =
-            self.wildcard_map_from_wildcards_unresolved(task_pass_through)?;
-
-        pass_through_env.union(&default_env_var_pass_through_map);
-        pass_through_env.union(global_env);
-        pass_through_env.union(&task_pass_through_env.inclusions);
-        pass_through_env.difference(&task_pass_through_env.exclusions);
-
-        Ok(pass_through_env)
+        Ok(DetailedMap::from_task_env_parts(
+            &inference_env_var_map,
+            &user_env_var_set,
+        ))
     }
 
     /// Like `from_wildcards` but uses pre-compiled regexes.
@@ -434,26 +459,23 @@ impl EnvironmentVariableMap {
         }
         output
     }
+}
 
-    /// Like `pass_through_env` but uses pre-compiled builtin wildcards.
-    pub fn pass_through_env_compiled(
-        &self,
-        compiled_builtins: &CompiledWildcards,
-        global_env: &Self,
-        task_pass_through: &[impl AsRef<str>],
-    ) -> Result<Self, Error> {
-        let default_env_var_pass_through_map = self.from_compiled_wildcards(compiled_builtins);
-        let task_pass_through_env =
-            self.wildcard_map_from_wildcards_unresolved(task_pass_through)?;
-
-        let mut pass_through_env = EnvironmentVariableMap::default();
-        pass_through_env.union(&default_env_var_pass_through_map);
-        pass_through_env.union(global_env);
-        pass_through_env.union(&task_pass_through_env.inclusions);
-        pass_through_env.difference(&task_pass_through_env.exclusions);
-
-        Ok(pass_through_env)
-    }
+/// Constructs an environment map that contains pass through environment
+/// variables from pre-matched parts. `builtin_pass_through` and the task's
+/// `WildcardMaps` are expected to have been matched against the same
+/// environment snapshot.
+pub fn pass_through_env_from_parts(
+    builtin_pass_through: &EnvironmentVariableMap,
+    global_env: &EnvironmentVariableMap,
+    task_pass_through: &WildcardMaps,
+) -> EnvironmentVariableMap {
+    let mut pass_through_env = EnvironmentVariableMap::default();
+    pass_through_env.union(builtin_pass_through);
+    pass_through_env.union(global_env);
+    pass_through_env.union(&task_pass_through.inclusions);
+    pass_through_env.difference(&task_pass_through.exclusions);
+    pass_through_env
 }
 
 const WILDCARD: char = '*';
@@ -638,38 +660,7 @@ mod tests {
     #[test_case(&["!FOO"], &["PATH"] ; "remove global")]
     #[test_case(&["!PATH"], &["FOO"] ; "remove builtin")]
     #[test_case(&["FOO*", "!FOOD"], &["FOO", "FOOBAR", "PATH"] ; "mixing negations")]
-    fn test_pass_through_env(task: &[&str], expected: &[&str]) {
-        let env_at_start = EnvironmentVariableMap(
-            vec![
-                ("PATH", "of"),
-                ("FOO", "bar"),
-                ("FOOBAR", "baz"),
-                ("FOOD", "cheese"),
-                ("BAR", "nuts"),
-            ]
-            .into_iter()
-            .map(|(k, v)| (k.to_owned(), v.to_owned()))
-            .collect(),
-        );
-        let global_env = EnvironmentVariableMap(
-            vec![("FOO", "bar")]
-                .into_iter()
-                .map(|(k, v)| (k.to_owned(), v.to_owned()))
-                .collect(),
-        );
-        let output = env_at_start
-            .pass_through_env(&["PATH"], &global_env, task)
-            .unwrap();
-        let mut actual: Vec<_> = output.keys().map(|s| s.as_str()).collect();
-        actual.sort();
-        assert_eq!(actual, expected);
-    }
-
-    #[test_case(&["FOO*"], &["FOO", "FOOBAR", "FOOD", "PATH"] ; "folds 3 sources")]
-    #[test_case(&["!FOO"], &["PATH"] ; "remove global")]
-    #[test_case(&["!PATH"], &["FOO"] ; "remove builtin")]
-    #[test_case(&["FOO*", "!FOOD"], &["FOO", "FOOBAR", "PATH"] ; "mixing negations")]
-    fn test_pass_through_env_compiled_matches_original(task: &[&str], expected: &[&str]) {
+    fn test_pass_through_env_from_parts(task: &[&str], expected: &[&str]) {
         let env_at_start = EnvironmentVariableMap(
             vec![
                 ("PATH", "of"),
@@ -690,12 +681,61 @@ mod tests {
         );
         let builtins: &[&str] = &["PATH"];
         let compiled = CompiledWildcards::compile(builtins).unwrap();
-        let output = env_at_start
-            .pass_through_env_compiled(&compiled, &global_env, task)
+        let builtin_pass_through = env_at_start.from_compiled_wildcards(&compiled);
+        let task: Vec<String> = task.iter().map(|s| s.to_string()).collect();
+        let task_pass_through = env_at_start
+            .wildcard_map_from_wildcards_unresolved(&task)
             .unwrap();
+        let output =
+            pass_through_env_from_parts(&builtin_pass_through, &global_env, &task_pass_through);
         let mut actual: Vec<_> = output.keys().map(|s| s.as_str()).collect();
         actual.sort();
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_wildcard_map_cache_matches_uncached() {
+        let env = EnvironmentVariableMap(
+            vec![("FOO", "1"), ("FOOBAR", "2"), ("FOOD", "3"), ("BAR", "4")]
+                .into_iter()
+                .map(|(k, v)| (k.to_owned(), v.to_owned()))
+                .collect(),
+        );
+
+        let patterns: Vec<String> = vec!["FOO*".to_string(), "!FOOD".to_string()];
+        let cache = WildcardMapCache::default();
+
+        // Hit the cache twice to exercise both the miss and hit paths.
+        for _ in 0..2 {
+            let cached = cache.get_or_compute(&env, &patterns).unwrap();
+            let uncached = env.from_wildcards(&patterns).unwrap();
+
+            let mut cached_keys: Vec<_> = cached.resolved.keys().cloned().collect();
+            let mut uncached_keys: Vec<_> = uncached.keys().cloned().collect();
+            cached_keys.sort();
+            uncached_keys.sort();
+            assert_eq!(cached_keys, uncached_keys);
+            assert_eq!(cached_keys, vec!["FOO", "FOOBAR"]);
+
+            let mut exclusion_keys: Vec<_> = cached.maps.exclusions.keys().cloned().collect();
+            exclusion_keys.sort();
+            assert_eq!(exclusion_keys, vec!["FOOD"]);
+        }
+    }
+
+    #[test]
+    fn test_wildcard_map_cache_empty_patterns() {
+        let env = EnvironmentVariableMap(
+            vec![("FOO", "bar")]
+                .into_iter()
+                .map(|(k, v)| (k.to_owned(), v.to_owned()))
+                .collect(),
+        );
+        let cache = WildcardMapCache::default();
+        let cached = cache.get_or_compute(&env, &[]).unwrap();
+        assert!(cached.resolved.is_empty());
+        assert!(cached.maps.inclusions.is_empty());
+        assert!(cached.maps.exclusions.is_empty());
     }
 
     #[test]

--- a/crates/turborepo-task-hash/src/lib.rs
+++ b/crates/turborepo-task-hash/src/lib.rs
@@ -25,6 +25,7 @@ use turborepo_cache::CacheHitMetadata;
 use turborepo_engine::TaskNode;
 use turborepo_env::{
     BUILTIN_PASS_THROUGH_ENV, BySource, CompiledWildcards, DetailedMap, EnvironmentVariableMap,
+    WildcardMapCache,
 };
 use turborepo_frameworks::{Framework, Slug as FrameworkSlug, infer_framework};
 use turborepo_hash::{FileHashes, LockFilePackagesRef, TaskHashable, TurboHash};
@@ -260,7 +261,13 @@ pub struct TaskHasher<'a, R> {
     global_env_patterns: &'a [String],
     global_hash: &'a str,
     task_hash_tracker: TaskHashTracker,
-    compiled_builtins: Option<CompiledWildcards>,
+    /// Builtin pass-through env vars matched against the environment once at
+    /// construction; the set is invariant for the lifetime of the hasher.
+    builtin_pass_through_env: EnvironmentVariableMap,
+    /// Memoized wildcard matches so tasks sharing the same `env` or
+    /// `passThroughEnv` patterns don't recompile regexes and rescan the
+    /// environment.
+    wildcard_cache: WildcardMapCache,
     external_deps_hash_cache: HashMap<String, String>,
 }
 
@@ -278,7 +285,10 @@ impl<'a, R: RunOptsHashInfo> TaskHasher<'a, R> {
             expanded_hashes,
         } = package_inputs_hashes;
 
-        let compiled_builtins = CompiledWildcards::compile(BUILTIN_PASS_THROUGH_ENV).ok();
+        let builtin_pass_through_env = CompiledWildcards::compile(BUILTIN_PASS_THROUGH_ENV)
+            .ok()
+            .map(|compiled| env_at_execution_start.from_compiled_wildcards(&compiled))
+            .unwrap_or_default();
 
         Self {
             hashes,
@@ -288,7 +298,8 @@ impl<'a, R: RunOptsHashInfo> TaskHasher<'a, R> {
             global_env,
             global_env_patterns,
             task_hash_tracker: TaskHashTracker::new(expanded_hashes),
-            compiled_builtins,
+            builtin_pass_through_env,
+            wildcard_cache: WildcardMapCache::default(),
             external_deps_hash_cache: HashMap::new(),
         }
     }
@@ -546,23 +557,36 @@ impl<'a, R: RunOptsHashInfo> TaskHasher<'a, R> {
                 .cloned()
                 .collect();
 
-            self.env_at_execution_start
-                .hashable_task_env(&computed_wildcards, &combined_env_patterns)
+            let inference = self
+                .wildcard_cache
+                .get_or_compute(self.env_at_execution_start, &computed_wildcards)
                 .map_err(|err| Error::EnvPattern {
                     task_id: task_id.clone().into_owned(),
                     err,
-                })
+                })?;
+            let user_env_var_set = self
+                .wildcard_cache
+                .get_or_compute(self.env_at_execution_start, &combined_env_patterns)
+                .map_err(|err| Error::EnvPattern {
+                    task_id: task_id.clone().into_owned(),
+                    err,
+                })?;
+
+            Ok(DetailedMap::from_task_env_parts(
+                &inference.resolved,
+                &user_env_var_set.maps,
+            ))
         } else {
-            let all_env_var_map = self
-                .env_at_execution_start
-                .from_wildcards(task_definition.env())?;
+            let matched = self
+                .wildcard_cache
+                .get_or_compute(self.env_at_execution_start, task_definition.env())?;
 
             Ok(DetailedMap {
                 by_source: BySource {
-                    explicit: all_env_var_map.clone(),
+                    explicit: matched.resolved.clone(),
                     matching: EnvironmentVariableMap::default(),
                 },
-                all: all_env_var_map,
+                all: matched.resolved.clone(),
             })
         }
     }
@@ -625,20 +649,16 @@ impl<'a, R: RunOptsHashInfo> TaskHasher<'a, R> {
     ) -> Result<EnvironmentVariableMap, Error> {
         match task_env_mode {
             EnvMode::Strict => {
-                let pass_through_env_vars = match &self.compiled_builtins {
-                    Some(compiled_builtins) => {
-                        self.env_at_execution_start.pass_through_env_compiled(
-                            compiled_builtins,
-                            &self.global_env,
-                            task_definition.pass_through_env().unwrap_or_default(),
-                        )?
-                    }
-                    None => self.env_at_execution_start.pass_through_env(
-                        &[] as &[&str],
-                        &self.global_env,
-                        task_definition.pass_through_env().unwrap_or_default(),
-                    )?,
-                };
+                let task_pass_through = self.wildcard_cache.get_or_compute(
+                    self.env_at_execution_start,
+                    task_definition.pass_through_env().unwrap_or_default(),
+                )?;
+
+                let pass_through_env_vars = turborepo_env::pass_through_env_from_parts(
+                    &self.builtin_pass_through_env,
+                    &self.global_env,
+                    &task_pass_through.maps,
+                );
 
                 let tracker_env = self
                     .task_hash_tracker


### PR DESCRIPTION
## Why

Task hashing did identical env-var work once per task instance instead of once per distinct configuration. For every task, `calculate_env_vars` compiled 2-4 fresh regexes from the task's `env` patterns and scanned the entire environment; in strict mode, `TaskHasher::env` re-matched the ~90-pattern `BUILTIN_PASS_THROUGH_ENV` list against the full environment per executed task. A monorepo typically has a handful of distinct env configs in `turbo.json`, so 500 packages running `build` meant 500 identical regex compilations and environment scans.

## What

- `WildcardMapCache` (new, in `turborepo-env`): memoizes wildcard match results against the run's fixed environment snapshot, keyed by pattern list. Tasks sharing the same `env`/`passThroughEnv` config get an `Arc` clone instead of recompiling and rescanning. `DashMap` because hashing runs in parallel.
- The builtin pass-through map is computed once in `TaskHasher::new` instead of per executed task.
- Combination semantics stay in `turborepo-env` as `DetailedMap::from_task_env_parts` and `pass_through_env_from_parts`; `hashable_task_env` delegates to the former. The now-dead `pass_through_env`/`pass_through_env_compiled` methods are removed, with their test cases ported to the parts-based function.

## How

Correctness: the cache is valid because `env_at_execution_start` is immutable for the life of a `TaskHasher`, and the cached path calls the same matching code on miss. New tests assert cached == uncached results (including the empty-pattern and exclusion cases); existing `turborepo-env` and `turborepo-task-hash` tests pass unchanged.

Performance: simulated 1000 tasks with 4 distinct env configs against a 162-var environment (release build): 177µs -> 10µs per task on this path (~17.5x), or roughly 165ms saved per 1000-task run. The saving scales with task count and applies on every run, including full cache hits, since hashing always executes.