### PR TITLE
perf: Cache root internal dependencies in package graph

### DIFF
--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -434,6 +434,7 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedPackageManager, T> {
             package_manager,
             repo_root: repo_root.to_owned(),
             external_dep_to_internal_dependents: std::sync::OnceLock::new(),
+            root_internal_dependencies: std::sync::OnceLock::new(),
         })
     }
 }
@@ -680,6 +681,7 @@ impl<T: PackageDiscovery> BuildState<'_, ResolvedLockfile, T> {
             lockfile,
             repo_root: repo_root.to_owned(),
             external_dep_to_internal_dependents: std::sync::OnceLock::new(),
+            root_internal_dependencies: std::sync::OnceLock::new(),
         })
     }
 }

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -44,6 +44,11 @@ pub struct PackageGraph {
     repo_root: AbsoluteSystemPathBuf,
     external_dep_to_internal_dependents:
         OnceLock<HashMap<turborepo_lockfiles::Package, HashSet<PackageNode>>>,
+    /// Lazily computed internal dependencies of the root package. They are
+    /// implied dependencies of every package, so per-package operations like
+    /// `dependencies` and `ancestors` consult them on every call; the set is
+    /// invariant once the graph is built.
+    root_internal_dependencies: OnceLock<HashSet<PackageNode>>,
 }
 
 /// The WorkspacePackage.
@@ -518,7 +523,7 @@ impl PackageGraph {
     pub fn root_internal_package_dependencies(&self) -> HashSet<WorkspacePackage> {
         let dependencies = self.root_internal_dependencies();
         dependencies
-            .into_iter()
+            .iter()
             .filter_map(|node| match node {
                 PackageNode::Workspace(package) => {
                     let path = self.package_dir_for_node(node)?;
@@ -535,7 +540,7 @@ impl PackageGraph {
     pub fn root_internal_package_dependencies_paths(&self) -> Vec<&AnchoredSystemPath> {
         let dependencies = self.root_internal_dependencies();
         dependencies
-            .into_iter()
+            .iter()
             .filter_map(|node| match node {
                 PackageNode::Workspace(_) => self.package_dir_for_node(node),
                 PackageNode::Root => None,
@@ -573,16 +578,21 @@ impl PackageGraph {
         Some(package_names.join(" -> "))
     }
 
-    fn root_internal_dependencies(&self) -> HashSet<&PackageNode> {
-        // We cannot call self.dependencies(&PackageNode::Workspace(PackageName::Root))
-        // as it will infinitely recurse.
-        let mut dependencies = turborepo_graph_utils::transitive_closure(
-            &self.graph,
-            Some(self.root_workspace_index),
-            petgraph::Direction::Outgoing,
-        );
-        dependencies.remove(&PackageNode::Workspace(PackageName::Root));
-        dependencies
+    fn root_internal_dependencies(&self) -> &HashSet<PackageNode> {
+        self.root_internal_dependencies.get_or_init(|| {
+            // We cannot call self.dependencies(&PackageNode::Workspace(PackageName::Root))
+            // as it will infinitely recurse.
+            let mut dependencies: HashSet<PackageNode> = turborepo_graph_utils::transitive_closure(
+                &self.graph,
+                Some(self.root_workspace_index),
+                petgraph::Direction::Outgoing,
+            )
+            .into_iter()
+            .cloned()
+            .collect();
+            dependencies.remove(&PackageNode::Workspace(PackageName::Root));
+            dependencies
+        })
     }
 
     /// Returns the transitive closure of the given nodes in the package
@@ -783,11 +793,7 @@ impl PackageGraph {
             }
         }
         // Now trace through all ancestors of the direct dependants
-        let root_internal_dependencies = self
-            .root_internal_dependencies()
-            .into_iter()
-            .cloned()
-            .collect::<HashSet<_>>();
+        let root_internal_dependencies = self.root_internal_dependencies();
         let root_external_dependencies =
             self.transitive_external_dependencies(Some(&PackageName::Root));
         for (external_pkg, rdeps) in map.iter_mut() {


### PR DESCRIPTION
## Why

`PackageGraph::root_internal_dependencies()` performs a full graph DFS from the root package, and its result is invariant once the graph is built. It was recomputed inside every `dependencies()` and `ancestors()` call, both of which scope filtering (`--filter`, `--affected`) invokes once per package — making filter resolution O(packages x DFS) for work that should be done once. `turbo watch` pays this again on every rebuild.

## What

- Cache the root's internal dependency set in a `OnceLock` on `PackageGraph`, following the existing `external_dep_to_internal_dependents` pattern. The getter now returns `&HashSet<PackageNode>`.
- `build_external_dep_to_internal_dependents_map` uses the cached set directly instead of cloning it into a fresh `HashSet`.

## How

Benchmarked per-package `dependencies()`/`ancestors()` over a synthetic 2,000-package monorepo (500 libs, 1,500 apps with 5 deps each, root depending on 20 tooling libs), interleaved A/B, 20-iteration averages:

| Operation (all 2,000 packages) | Baseline | Cached | Speedup |
|---|---|---|---|
| `dependencies()` | 6.4-7.9ms | 2.7-3.0ms | ~2.4x |
| `ancestors()` | 5.8-6.1ms | 2.4-2.5ms | ~2.4x |

Outputs are identical on both sides (49,180 total dependency entries). Savings grow linearly with package count and the size of the root package's dependency closure. All 233 `turborepo-repository` tests and all `turborepo-scope` tests pass unchanged.