### PR TITLE
perf: Replace per-package graph traversals in scope filtering

### DIFF
--- a/crates/turborepo-scope/src/filter.rs
+++ b/crates/turborepo-scope/src/filter.rs
@@ -500,33 +500,50 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
                                 dependency: package.to_owned(),
                             },
                         );
+                    }
 
-                        // get the dependent's dependencies
-                        if selector.include_dependencies {
-                            let dependent_node =
-                                package_graph::PackageNode::Workspace(dependent.to_owned());
+                    // Get the dependents' dependencies with a single
+                    // multi-source traversal instead of one traversal per
+                    // dependent. The closure includes the dependents
+                    // themselves, but they already carry the same inclusion
+                    // reason via `walked_dependents`, which takes precedence
+                    // in the merge below. Like `dependencies`, the root
+                    // package's own dependencies count as implied
+                    // dependencies of every dependent.
+                    if selector.include_dependencies && !dependents.is_empty() {
+                        let dependent_nodes: Vec<package_graph::PackageNode> = dependents
+                            .iter()
+                            .map(|i| {
+                                package_graph::PackageNode::Workspace(i.as_package_name().clone())
+                            })
+                            .collect();
 
-                            let dependent_dependencies =
-                                self.pkg_graph.dependencies(&dependent_node);
+                        let dependent_dependencies = self
+                            .pkg_graph
+                            .transitive_closure(dependent_nodes.iter())
+                            .into_iter()
+                            .filter(|node| !matches!(node, package_graph::PackageNode::Root))
+                            .map(|i| i.as_package_name().to_owned())
+                            .chain(
+                                self.pkg_graph
+                                    .root_internal_package_dependencies()
+                                    .into_iter()
+                                    .map(|workspace| workspace.name),
+                            )
+                            .map(|name| {
+                                (
+                                    name,
+                                    PackageInclusionReason::DependencyChanged {
+                                        dependency: package.to_owned(),
+                                    },
+                                )
+                            })
+                            .collect::<HashSet<_>>();
 
-                            let dependent_dependencies = dependent_dependencies
-                                .iter()
-                                .filter(|node| !matches!(node, package_graph::PackageNode::Root))
-                                .map(|i| {
-                                    (
-                                        i.as_package_name().to_owned(),
-                                        PackageInclusionReason::DependencyChanged {
-                                            dependency: package.to_owned(),
-                                        },
-                                    )
-                                })
-                                .collect::<HashSet<_>>();
-
-                            merge_changed_packages(
-                                &mut walked_dependent_dependencies,
-                                dependent_dependencies,
-                            );
-                        }
+                        merge_changed_packages(
+                            &mut walked_dependent_dependencies,
+                            dependent_dependencies,
+                        );
                     }
                 }
 
@@ -622,37 +639,40 @@ impl<'a, T: GitChangeDetector> FilterResolver<'a, T> {
             entry_packages
         };
 
-        let mut roots = HashMap::new();
-        let mut matched = HashSet::new();
         let changed_packages = if let Some(git_range) = selector.git_range.as_ref() {
             self.packages_changed_in_range(git_range)?
         } else {
             HashMap::default()
         };
 
-        for (package, reason) in filtered_entry_packages {
-            if matched.contains(&package) {
-                roots.insert(package, reason);
-                continue;
+        // A package is selected if it is itself changed (unless excluded) or
+        // if it transitively depends on a changed package. Answering the
+        // latter with reverse traversals from the changed set is much cheaper
+        // than computing a forward dependency closure for every candidate
+        // package: the changed set is typically far smaller than the package
+        // count. `ancestors` also matches the semantics of `dependencies`
+        // here, including treating the root package's dependencies as implied
+        // dependencies of every package.
+        let mut dependent_on_changed = HashSet::new();
+        for changed_package in changed_packages.keys() {
+            let changed_node = package_graph::PackageNode::Workspace(changed_package.to_owned());
+            for ancestor in self.pkg_graph.ancestors(&changed_node) {
+                // `dependencies` never includes the package itself, so a
+                // package's own change must not mark it as depending on a
+                // changed package; self-selection is handled below.
+                if *ancestor != changed_node
+                    && !matches!(ancestor, package_graph::PackageNode::Root)
+                {
+                    dependent_on_changed.insert(ancestor.as_package_name().clone());
+                }
             }
+        }
 
-            let workspace_node = package_graph::PackageNode::Workspace(package.clone());
-            let dependencies = self.pkg_graph.dependencies(&workspace_node);
-
-            for changed_package in changed_packages.keys() {
-                if !selector.exclude_self && package.eq(changed_package) {
-                    roots.insert(package, reason);
-                    break;
-                }
-
-                let changed_node =
-                    package_graph::PackageNode::Workspace(changed_package.to_owned());
-
-                if dependencies.contains(&changed_node) {
-                    roots.insert(package.clone(), reason);
-                    matched.insert(package);
-                    break;
-                }
+        let mut roots = HashMap::new();
+        for (package, reason) in filtered_entry_packages {
+            let self_matched = !selector.exclude_self && changed_packages.contains_key(&package);
+            if self_matched || dependent_on_changed.contains(&package) {
+                roots.insert(package, reason);
             }
         }
 


### PR DESCRIPTION
## Why

Scope filtering had two O(packages x DFS) hot spots that scale badly with monorepo size:

1. `filter_subtrees_with_selector` (the `pkg...[git-range]` syntax) computed a full forward dependency closure for **every candidate package** just to ask "does it depend on a changed package?" — and computed them even when the changed set was empty, making all of that work dead.
2. `filter_graph_with_selectors` with `include_dependents` + `include_dependencies` (e.g. `...pkg...`) computed a dependency closure **per dependent** of each selected package.

Both questions are answerable from the (typically tiny) changed/selected side of the graph instead of the (large) candidate side.

## What

1. The subtree filter now unions `ancestors()` over the changed set — O(changed x DFS) instead of O(packages x DFS) — then selects candidates with set lookups. `ancestors` preserves the implied-dependency semantics of `dependencies` (root package dependencies are dependencies of everything). A package's own change no longer routes through the closure at all; self-selection is an explicit check, preserving `exclude_self` behavior.
2. The dependents' dependencies are computed with one multi-source `transitive_closure` over all dependents instead of one traversal each. The closure includes the dependents themselves where the old per-dependent call excluded each from its own result; this is output-neutral because those packages already carry the identical `DependencyChanged` reason via `walked_dependents`, which takes precedence in the first-writer-wins merge.
3. Removed the `matched` bookkeeping set, which could never affect the result (entry packages are unique HashMap keys).

## How

Benchmarked both algorithms side-by-side on a synthetic 2,000-package graph (500 libs, 1,500 apps x 5 deps, root depending on 20 libs), asserting identical outputs in the same binary:

| Path | Scenario | Old | New |
|---|---|---|---|
| subtree filter | 3 changed packages | 7.0ms | 0.12ms (~60x) |
| subtree filter | 25 changed | 8.7ms | 0.29ms (~30x) |
| subtree filter | 100 changed | 12.8ms | 0.82ms (~15x) |
| subtree filter | changed set includes a root dep | 9.1ms | 0.71ms (~13x) |
| dependent deps | 1 selected package | 8.9ms | 0.75ms (~12x) |

Savings grow with package count and shrink with changed-set size; `turbo watch` re-runs filtering on rebuilds and benefits repeatedly. All 95 `turborepo-scope` tests (including the `match_dependencies`/git-range and `include_dependents` cases) and 233 `turborepo-repository` tests pass unchanged.

For reviewers: the key invariant is `dependencies(P) ∋ C  <=>  P ∈ ancestors(C)`, including the root-dependency special case (`ancestors` of a root dep returns all packages) and cycles (both directions include all cycle members). The one asymmetry — `dependencies(P)` never contains `P` itself — is handled by excluding the changed node from its own ancestor union.