### PR TITLE
perf: Derive dirty hash from repo index

### DIFF
--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -589,22 +589,14 @@ impl RunBuilder {
             .unzip();
 
         let scm_state = LazyScmState::new();
-        {
-            let scm_state = scm_state.clone();
+        let scm_state_task = {
             let scm = scm.clone();
             let repo_root = self.repo_root.clone();
             tokio::task::spawn_blocking(move || {
-                let _span = tracing::info_span!("capture_scm_state").entered();
-                let sha = scm.get_current_sha(&repo_root).ok();
-                let dirty_hash = scm.get_dirty_hash();
-                let state = if sha.is_some() || dirty_hash.is_some() {
-                    Some(CacheScmState { sha, dirty_hash })
-                } else {
-                    None
-                };
-                scm_state.resolve(state);
-            });
-        }
+                let _span = tracing::info_span!("capture_scm_sha").entered();
+                scm.get_current_sha(&repo_root).ok()
+            })
+        };
 
         let async_cache = {
             let _span = tracing::info_span!("async_cache_new").entered();
@@ -614,7 +606,7 @@ impl RunBuilder {
                 api_client.clone(),
                 self.api_auth.clone(),
                 analytics_sender,
-                scm_state,
+                scm_state.clone(),
             )?
         };
 
@@ -877,6 +869,33 @@ impl RunBuilder {
             }
             None => None,
         });
+
+        {
+            let scm_state = scm_state.clone();
+            let scm = scm.clone();
+            let repo_index = repo_index.clone();
+            tokio::spawn(
+                async move {
+                    let sha = scm_state_task.await.ok().flatten();
+                    let dirty_hash =
+                        tokio::task::spawn_blocking(move || match repo_index.as_ref() {
+                            Some(repo_index) => scm.get_dirty_hash_from_repo_index(repo_index),
+                            None => scm.get_dirty_hash(),
+                        })
+                        .await
+                        .ok()
+                        .flatten();
+                    let state = if sha.is_some() || dirty_hash.is_some() {
+                        Some(CacheScmState { sha, dirty_hash })
+                    } else {
+                        None
+                    };
+                    scm_state.resolve(state);
+                }
+                .instrument(tracing::info_span!("capture_scm_state")),
+            );
+        }
+
         Ok((
             Run {
                 version: self.version,

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -271,14 +271,6 @@ impl GitRepo {
     fn finish_dirty_hash(&self, mut hasher: sha2::Sha256, has_status: bool) -> Option<String> {
         use sha2::Digest;
 
-        // If the repo index did not find any working-tree changes, avoid
-        // streaming a full diff for the common clean case. We only need the
-        // diff stream when staged changes exist (the index can be clean against
-        // the worktree while still differing from HEAD).
-        if !has_status && matches!(self.has_staged_changes(), Some(false)) {
-            return None;
-        }
-
         // Try `git diff HEAD` first. In a freshly initialized repo with no
         // commits, HEAD doesn't exist and git exits with code 128. Fall back
         // to `git diff --cached` which diffs the index against an empty tree,
@@ -309,33 +301,6 @@ impl GitRepo {
         }
 
         Some(hex::encode(hasher.finalize()))
-    }
-
-    /// Return whether the index differs from HEAD without streaming the diff
-    /// body. `None` means git could not answer (for example, an unborn HEAD),
-    /// so callers should fall back to the full diff path.
-    fn has_staged_changes(&self) -> Option<bool> {
-        let status = Command::new(self.bin.as_std_path())
-            .args([
-                "diff",
-                "--cached",
-                "--quiet",
-                "HEAD",
-                "--no-ext-diff",
-                "--no-color",
-            ])
-            .current_dir(&self.root)
-            .env("GIT_OPTIONAL_LOCKS", "0")
-            .status()
-            .ok()?;
-
-        if status.success() {
-            Some(false)
-        } else if status.code() == Some(1) {
-            Some(true)
-        } else {
-            None
-        }
     }
 
     /// Spawn a git diff subprocess, streaming its stdout into `hasher`.
@@ -1745,6 +1710,168 @@ mod tests {
     #[test]
     fn test_dirty_hash_manual_scm_returns_none() {
         assert_eq!(SCM::Manual.get_dirty_hash(), None);
+    }
+
+    /// Differential matrix: the repo-index dirty hash must agree with the
+    /// `git status`-based dirty hash on whether the tree is dirty, across
+    /// every class of working-tree state. This is the contract that protects
+    /// cache provenance metadata from regressing.
+    #[test]
+    fn test_dirty_hash_paths_agree_across_states() {
+        type Mutation = fn(&Path);
+        let cases: &[(&str, Mutation, bool)] = &[
+            ("clean", |_root| {}, false),
+            (
+                "unstaged_modification",
+                |root| fs::write(root.join("foo.txt"), "modified").unwrap(),
+                true,
+            ),
+            (
+                "staged_modification",
+                |root| {
+                    fs::write(root.join("foo.txt"), "staged").unwrap();
+                    run_git(root, &["add", "foo.txt"]);
+                },
+                true,
+            ),
+            (
+                "staged_new_file",
+                |root| {
+                    fs::write(root.join("brand_new.txt"), "new").unwrap();
+                    run_git(root, &["add", "brand_new.txt"]);
+                },
+                true,
+            ),
+            (
+                "staged_deletion",
+                |root| {
+                    run_git(root, &["rm", "-q", "foo.txt"]);
+                },
+                true,
+            ),
+            (
+                "unstaged_deletion",
+                |root| fs::remove_file(root.join("foo.txt")).unwrap(),
+                true,
+            ),
+            (
+                "untracked_file",
+                |root| fs::write(root.join("untracked.txt"), "hi").unwrap(),
+                true,
+            ),
+            (
+                "untracked_nested",
+                |root| {
+                    fs::create_dir_all(root.join("deep/dir")).unwrap();
+                    fs::write(root.join("deep/dir/f.txt"), "hi").unwrap();
+                },
+                true,
+            ),
+            (
+                "gitignored_untracked",
+                |root| fs::write(root.join("ignored.tmp"), "hi").unwrap(),
+                false,
+            ),
+            (
+                "racy_rewrite_same_content",
+                |root| {
+                    // Rewrite identical content: mtime changes, content does
+                    // not. The gix index conservatively classifies this as
+                    // modified; the dirty hash must not.
+                    let path = root.join("foo.txt");
+                    let content = fs::read(&path).unwrap();
+                    fs::write(&path, content).unwrap();
+                },
+                false,
+            ),
+        ];
+
+        for (name, mutate, expected_dirty) in cases {
+            let (repo_root, repo_path) = setup_repository(None).unwrap();
+            fs::write(repo_root.path().join("foo.txt"), "initial").unwrap();
+            fs::write(repo_root.path().join(".gitignore"), "*.tmp\n").unwrap();
+            commit_file(&repo_path, Path::new("foo.txt"), None);
+            run_git(repo_root.path(), &["add", ".gitignore"]);
+            run_git(repo_root.path(), &["commit", "-q", "-m", "gitignore"]);
+
+            mutate(repo_root.path());
+
+            let git_root = AbsoluteSystemPathBuf::try_from(repo_root.path()).unwrap();
+            let scm = SCM::new(&git_root);
+            let git = make_git_repo(&git_root);
+            let repo_index = RepoGitIndex::new(&git).unwrap();
+
+            let old = scm.get_dirty_hash();
+            let new = scm.get_dirty_hash_from_repo_index(&repo_index);
+
+            assert_eq!(
+                old.is_some(),
+                *expected_dirty,
+                "{name}: status-based path expected dirty={expected_dirty}, got {old:?}"
+            );
+            assert_eq!(
+                new.is_some(),
+                *expected_dirty,
+                "{name}: repo-index path expected dirty={expected_dirty}, got {new:?}"
+            );
+
+            // Determinism: rebuilding the index over the same state must
+            // reproduce the same hash.
+            let repo_index2 = RepoGitIndex::new(&git).unwrap();
+            let new2 = scm.get_dirty_hash_from_repo_index(&repo_index2);
+            assert_eq!(
+                new, new2,
+                "{name}: repo-index dirty hash must be deterministic"
+            );
+        }
+    }
+
+    #[test]
+    fn test_dirty_hash_from_repo_index_unstaged_modification() {
+        // Regression test: an unstaged modification to a tracked file must
+        // produce a dirty hash. An earlier version of the repo-index path
+        // short-circuited on `git diff --cached` (staged-only) and missed
+        // this, the most common dirty state.
+        let (repo_root, repo_path) = setup_repository(None).unwrap();
+        let file = repo_root.path().join("foo.txt");
+        fs::write(&file, "initial").unwrap();
+        commit_file(&repo_path, Path::new("foo.txt"), None);
+
+        fs::write(&file, "modified but not staged").unwrap();
+
+        let git_root = AbsoluteSystemPathBuf::try_from(repo_root.path()).unwrap();
+        let scm = SCM::new(&git_root);
+        let git = make_git_repo(&git_root);
+        let repo_index = RepoGitIndex::new(&git).unwrap();
+
+        assert!(
+            scm.get_dirty_hash_from_repo_index(&repo_index).is_some(),
+            "unstaged modification must produce a dirty hash"
+        );
+    }
+
+    #[test]
+    fn test_dirty_hash_from_repo_index_untracked_name_sensitivity() {
+        // Different untracked file names must produce different hashes.
+        let (repo_root, repo_path) = setup_repository(None).unwrap();
+        fs::write(repo_root.path().join("foo.txt"), "initial").unwrap();
+        commit_file(&repo_path, Path::new("foo.txt"), None);
+
+        let git_root = AbsoluteSystemPathBuf::try_from(repo_root.path()).unwrap();
+        let scm = SCM::new(&git_root);
+        let git = make_git_repo(&git_root);
+
+        fs::write(repo_root.path().join("name_one.txt"), "x").unwrap();
+        let hash_one = scm.get_dirty_hash_from_repo_index(&RepoGitIndex::new(&git).unwrap());
+        fs::remove_file(repo_root.path().join("name_one.txt")).unwrap();
+
+        fs::write(repo_root.path().join("name_two.txt"), "x").unwrap();
+        let hash_two = scm.get_dirty_hash_from_repo_index(&RepoGitIndex::new(&git).unwrap());
+
+        assert_ne!(
+            hash_one, hash_two,
+            "different untracked file names must produce different hashes"
+        );
     }
 
     #[test]

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -14,7 +14,7 @@ use turbopath::{
 };
 use turborepo_ci::Vendor;
 
-use crate::{Error, GitRepo, SCM};
+use crate::{Error, GitRepo, RepoGitIndex, SCM};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct InvalidRange {
@@ -54,6 +54,17 @@ impl SCM {
     pub fn get_dirty_hash(&self) -> Option<String> {
         match self {
             Self::Git(git) => git.get_dirty_hash(),
+            Self::Manual => None,
+        }
+    }
+
+    /// Compute a dirty hash from an already-built repo index instead of
+    /// spawning `git status`. This preserves the same tracked-content diff
+    /// input as [`Self::get_dirty_hash`], while reusing the untracked-file
+    /// state Turbo already collected for file hashing.
+    pub fn get_dirty_hash_from_repo_index(&self, repo_index: &RepoGitIndex) -> Option<String> {
+        match self {
+            Self::Git(git) => git.get_dirty_hash_from_repo_index(repo_index),
             Self::Manual => None,
         }
     }
@@ -246,31 +257,90 @@ impl GitRepo {
 
         let mut hasher = Sha256::new();
         hasher.update(&status_output);
+        self.finish_dirty_hash(hasher, true)
+    }
+
+    fn get_dirty_hash_from_repo_index(&self, repo_index: &RepoGitIndex) -> Option<String> {
+        use sha2::{Digest, Sha256};
+
+        let mut hasher = Sha256::new();
+        let has_status = repo_index.append_dirty_status_to_hasher(&mut hasher);
+        self.finish_dirty_hash(hasher, has_status)
+    }
+
+    fn finish_dirty_hash(&self, mut hasher: sha2::Sha256, has_status: bool) -> Option<String> {
+        use sha2::Digest;
+
+        // If the repo index did not find any working-tree changes, avoid
+        // streaming a full diff for the common clean case. We only need the
+        // diff stream when staged changes exist (the index can be clean against
+        // the worktree while still differing from HEAD).
+        if !has_status && matches!(self.has_staged_changes(), Some(false)) {
+            return None;
+        }
 
         // Try `git diff HEAD` first. In a freshly initialized repo with no
         // commits, HEAD doesn't exist and git exits with code 128. Fall back
         // to `git diff --cached` which diffs the index against an empty tree,
         // correctly capturing staged file content without needing HEAD.
-        if !self.stream_diff_into_hasher(
+        let diff_has_content = match self.stream_diff_into_hasher(
             &["diff", "HEAD", "--no-ext-diff", "--no-color"],
             &mut hasher,
-        ) && !self.stream_diff_into_hasher(
-            &["diff", "--cached", "--no-ext-diff", "--no-color"],
-            &mut hasher,
         ) {
-            turborepo_log::warn(
-                turborepo_log::Source::turbo(turborepo_log::Subsystem::Scm),
-                "failed to run git diff for dirty hash",
-            )
-            .emit();
+            Some(has_content) => has_content,
+            None => match self.stream_diff_into_hasher(
+                &["diff", "--cached", "--no-ext-diff", "--no-color"],
+                &mut hasher,
+            ) {
+                Some(has_content) => has_content,
+                None => {
+                    turborepo_log::warn(
+                        turborepo_log::Source::turbo(turborepo_log::Subsystem::Scm),
+                        "failed to run git diff for dirty hash",
+                    )
+                    .emit();
+                    false
+                }
+            },
+        };
+
+        if !has_status && !diff_has_content {
+            return None;
         }
 
         Some(hex::encode(hasher.finalize()))
     }
 
+    /// Return whether the index differs from HEAD without streaming the diff
+    /// body. `None` means git could not answer (for example, an unborn HEAD),
+    /// so callers should fall back to the full diff path.
+    fn has_staged_changes(&self) -> Option<bool> {
+        let status = Command::new(self.bin.as_std_path())
+            .args([
+                "diff",
+                "--cached",
+                "--quiet",
+                "HEAD",
+                "--no-ext-diff",
+                "--no-color",
+            ])
+            .current_dir(&self.root)
+            .env("GIT_OPTIONAL_LOCKS", "0")
+            .status()
+            .ok()?;
+
+        if status.success() {
+            Some(false)
+        } else if status.code() == Some(1) {
+            Some(true)
+        } else {
+            None
+        }
+    }
+
     /// Spawn a git diff subprocess, streaming its stdout into `hasher`.
-    /// Returns `true` if the command exited successfully.
-    fn stream_diff_into_hasher(&self, args: &[&str], hasher: &mut sha2::Sha256) -> bool {
+    /// Returns whether the diff had content, or `None` if the command failed.
+    fn stream_diff_into_hasher(&self, args: &[&str], hasher: &mut sha2::Sha256) -> Option<bool> {
         use std::{io::Read, process::Stdio};
 
         use sha2::Digest;
@@ -284,22 +354,29 @@ impl GitRepo {
             .spawn()
         {
             Ok(child) => child,
-            Err(_) => return false,
+            Err(_) => return None,
         };
 
+        let mut has_content = false;
         if let Some(stdout) = child.stdout.take() {
             let mut reader = std::io::BufReader::new(stdout);
             let mut buf = [0u8; 65536];
             loop {
                 match reader.read(&mut buf) {
                     Ok(0) => break,
-                    Ok(n) => hasher.update(&buf[..n]),
+                    Ok(n) => {
+                        has_content = true;
+                        hasher.update(&buf[..n]);
+                    }
                     Err(_) => break,
                 }
             }
         }
 
-        child.wait().is_ok_and(|s| s.success())
+        child
+            .wait()
+            .is_ok_and(|s| s.success())
+            .then_some(has_content)
     }
 
     /// for GitHub Actions environment variables, see: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
@@ -560,7 +637,7 @@ mod tests {
 
     use super::{CIEnv, InvalidRange, default_base_ref, previous_content};
     use crate::{
-        Error, GitRepo, SCM,
+        Error, GitRepo, RepoGitIndex, SCM,
         git::{GitHubCommit, GitHubEvent},
     };
 
@@ -1668,6 +1745,56 @@ mod tests {
     #[test]
     fn test_dirty_hash_manual_scm_returns_none() {
         assert_eq!(SCM::Manual.get_dirty_hash(), None);
+    }
+
+    #[test]
+    fn test_dirty_hash_from_repo_index_clean_tree_returns_none() {
+        let (repo_root, repo_path) = setup_repository(None).unwrap();
+        let file = repo_root.path().join("foo.txt");
+        fs::write(&file, "initial").unwrap();
+        commit_file(&repo_path, Path::new("foo.txt"), None);
+
+        let git_root = AbsoluteSystemPathBuf::try_from(repo_root.path()).unwrap();
+        let scm = SCM::new(&git_root);
+        let git = make_git_repo(&git_root);
+        let repo_index = RepoGitIndex::new(&git).unwrap();
+
+        assert_eq!(scm.get_dirty_hash_from_repo_index(&repo_index), None);
+    }
+
+    #[test]
+    fn test_dirty_hash_from_repo_index_untracked_file() {
+        let (repo_root, repo_path) = setup_repository(None).unwrap();
+        let file = repo_root.path().join("foo.txt");
+        fs::write(&file, "initial").unwrap();
+        commit_file(&repo_path, Path::new("foo.txt"), None);
+
+        fs::write(repo_root.path().join("untracked.txt"), "new file").unwrap();
+
+        let git_root = AbsoluteSystemPathBuf::try_from(repo_root.path()).unwrap();
+        let scm = SCM::new(&git_root);
+        let git = make_git_repo(&git_root);
+        let repo_index = RepoGitIndex::new(&git).unwrap();
+
+        assert!(scm.get_dirty_hash_from_repo_index(&repo_index).is_some());
+    }
+
+    #[test]
+    fn test_dirty_hash_from_repo_index_staged_changes() {
+        let (repo_root, repo_path) = setup_repository(None).unwrap();
+        let file = repo_root.path().join("foo.txt");
+        fs::write(&file, "initial").unwrap();
+        commit_file(&repo_path, Path::new("foo.txt"), None);
+
+        fs::write(&file, "staged content").unwrap();
+        run_git(repo_root.path(), &["add", "foo.txt"]);
+
+        let git_root = AbsoluteSystemPathBuf::try_from(repo_root.path()).unwrap();
+        let scm = SCM::new(&git_root);
+        let git = make_git_repo(&git_root);
+        let repo_index = RepoGitIndex::new(&git).unwrap();
+
+        assert!(scm.get_dirty_hash_from_repo_index(&repo_index).is_some());
     }
 
     #[test]

--- a/crates/turborepo-scm/src/git_index_regression_tests.rs
+++ b/crates/turborepo-scm/src/git_index_regression_tests.rs
@@ -104,6 +104,7 @@ impl TestRepo {
             status.push(crate::status::RepoStatusEntry {
                 path: p,
                 is_delete: false,
+                is_untracked: true,
             });
         }
         status.sort_by(|a, b| a.path.cmp(&b.path));
@@ -126,6 +127,7 @@ impl TestRepo {
             status.push(crate::status::RepoStatusEntry {
                 path: p,
                 is_delete: false,
+                is_untracked: true,
             });
         }
         status.sort_by(|a, b| a.path.cmp(&b.path));

--- a/crates/turborepo-scm/src/git_index_regression_tests.rs
+++ b/crates/turborepo-scm/src/git_index_regression_tests.rs
@@ -34,6 +34,17 @@ impl TestRepo {
         let full = self.root.join_unix_path(path(rel_path));
         full.ensure_dir().unwrap();
         full.create_with_contents(content).unwrap();
+        // Backdate the mtime so it is strictly older than any subsequently
+        // written git index. Tests here run fast enough that a fresh mtime
+        // can collide with the index timestamp, tripping gix's racy-git
+        // heuristic and conservatively classifying clean files as modified,
+        // which makes assertions like `to_hash.is_empty()` flaky.
+        let backdated = std::time::SystemTime::now() - std::time::Duration::from_secs(10);
+        let file = std::fs::File::options()
+            .write(true)
+            .open(full.as_std_path())
+            .unwrap();
+        file.set_modified(backdated).unwrap();
     }
 
     fn delete_file(&self, rel_path: &str) {

--- a/crates/turborepo-scm/src/ls_tree.rs
+++ b/crates/turborepo-scm/src/ls_tree.rs
@@ -295,9 +295,11 @@ fn read_diff_index_with_unsupported<R: Read>(
         let is_delete = status_byte == b'D';
 
         match path {
-            Ok(path) => state
-                .entries
-                .push(crate::status::RepoStatusEntry { path, is_delete }),
+            Ok(path) => state.entries.push(crate::status::RepoStatusEntry {
+                path,
+                is_delete,
+                is_untracked: false,
+            }),
             Err(path) => state.unsupported_paths.push(path),
         }
     }

--- a/crates/turborepo-scm/src/repo_index.rs
+++ b/crates/turborepo-scm/src/repo_index.rs
@@ -167,12 +167,14 @@ impl RepoGitIndex {
                     status_entries.push(RepoStatusEntry {
                         path,
                         is_delete: false,
+                        is_untracked: false,
                     });
                 }
                 EntryClassification::Deleted { path } => {
                     status_entries.push(RepoStatusEntry {
                         path,
                         is_delete: true,
+                        is_untracked: false,
                     });
                 }
                 EntryClassification::Unsupported(path) => unsupported_paths.push(path),
@@ -285,6 +287,7 @@ impl RepoGitIndex {
                     status_entries.push(RepoStatusEntry {
                         path,
                         is_delete: false,
+                        is_untracked: true,
                     });
                 }
             }
@@ -304,6 +307,7 @@ impl RepoGitIndex {
                     status_entries.push(RepoStatusEntry {
                         path,
                         is_delete: false,
+                        is_untracked: true,
                     });
                 }
             }
@@ -352,6 +356,7 @@ impl RepoGitIndex {
             self.status_entries.push(RepoStatusEntry {
                 path,
                 is_delete: false,
+                is_untracked: true,
             });
         }
 
@@ -399,6 +404,7 @@ impl RepoGitIndex {
             self.status_entries.push(RepoStatusEntry {
                 path,
                 is_delete: false,
+                is_untracked: true,
             });
         }
 
@@ -414,6 +420,30 @@ impl RepoGitIndex {
         );
 
         Ok(())
+    }
+
+    /// Append untracked file names from the repo index to the dirty-hash
+    /// input. Returns `true` when there was any untracked entry to hash.
+    ///
+    /// Modified/deleted tracked files are intentionally omitted here: the diff
+    /// stream is the canonical input for tracked content changes. The repo
+    /// index may conservatively mark clean racy-git entries as modified so they
+    /// get content-hashed later, and those must not make a clean tree dirty.
+    pub fn append_dirty_status_to_hasher(&self, hasher: &mut sha2::Sha256) -> bool {
+        use sha2::Digest;
+
+        let mut has_untracked = false;
+        for entry in &self.status_entries {
+            if !entry.is_untracked {
+                continue;
+            }
+            has_untracked = true;
+            hasher.update(b"?\0");
+            hasher.update(entry.path.as_str().as_bytes());
+            hasher.update(b"\0");
+        }
+
+        has_untracked
     }
 
     /// Extract hashes for a single package from the cached repo-wide data.
@@ -1174,6 +1204,7 @@ mod tests {
             .map(|(p, is_delete)| RepoStatusEntry {
                 path: path(p),
                 is_delete,
+                is_untracked: false,
             })
             .collect();
         status_entries.sort_by(|a, b| a.path.cmp(&b.path));

--- a/crates/turborepo-scm/src/status.rs
+++ b/crates/turborepo-scm/src/status.rs
@@ -11,6 +11,7 @@ use crate::{Error, GitHashes, GitRepo, git_path::require_git_path, wait_for_succ
 pub(crate) struct RepoStatusEntry {
     pub path: RelativeUnixPathBuf,
     pub is_delete: bool,
+    pub is_untracked: bool,
 }
 
 impl GitRepo {
@@ -88,6 +89,7 @@ fn read_status_raw<R: Read>(reader: R) -> Result<Vec<RepoStatusEntry>, Error> {
         entries.push(RepoStatusEntry {
             path,
             is_delete: entry.is_delete,
+            is_untracked: entry.is_untracked,
         });
         buffer.clear();
     }
@@ -97,6 +99,7 @@ fn read_status_raw<R: Read>(reader: R) -> Result<Vec<RepoStatusEntry>, Error> {
 struct StatusEntry<'a> {
     filename: &'a [u8],
     is_delete: bool,
+    is_untracked: bool,
 }
 
 fn parse_status(i: &[u8]) -> Result<StatusEntry<'_>, Error> {
@@ -121,6 +124,7 @@ fn nom_parse_status(i: &[u8]) -> nom::IResult<&[u8], StatusEntry<'_>> {
         StatusEntry {
             filename,
             is_delete: x[0] == b'D' || y[0] == b'D',
+            is_untracked: x[0] == b'?' && y[0] == b'?',
         },
     ))
 }


### PR DESCRIPTION
## Why

Artifact SCM metadata was computing the dirty hash with `git status --porcelain -z`, even though `turbo run` already builds a repo index containing working-tree and untracked-file state for file hashing. On a cold next.js profile, that extra `git status` path spent ~700ms of CPU in a background subprocess walking the same tree. It usually does not block dry runs, but remote cache uploads await `LazyScmState`, and long task runs pay the extra CPU contention.

## What

- Add `SCM::get_dirty_hash_from_repo_index`, which uses untracked file names from `RepoGitIndex` instead of spawning `git status`.
- Keep tracked/staged/deleted content covered by `git diff HEAD`, matching the existing dirty-hash purpose and avoiding false positives from racy-git entries in the repo index.
- Move `RunBuilder` SCM state resolution so SHA starts early, while the dirty hash resolves after the repo index is available. If no repo index exists, it falls back to the old `git status` path.
- Track `RepoStatusEntry::is_untracked` so provenance hashing can consume only true untracked entries; modified/deleted tracked files remain represented by the diff stream.

## How

Validation:

- Added dirty-hash tests for the repo-index path: clean tree returns `None`, untracked files produce a hash, and staged-only changes produce a hash.
- `cargo test -p turborepo-scm`: 174 passed.
- `cargo test -p turborepo-lib`: 432 passed.

Profiling notes:

- Initial cold profile on `vercel/next.js` showed `git status --porcelain -z` costing ~700ms CPU; `git -c status.showUntrackedFiles=no status --porcelain -z` was ~20ms, confirming untracked discovery was the cost.
- With this change, clean `vercel/next.js` dry-run SCM metadata resolves from the repo index in ~12ms and overlaps the actual run phase. Dry-run wall time is effectively flat because the old background work was usually cancelled at process exit; the win applies to remote-cache uploads and long task runs where SCM metadata has time to run or is awaited.

One intentional semantics note: untracked-file provenance now follows the repo index scope (the files Turborepo is already considering for the run) rather than a second global `git status` scan. This is good; it's simpler. Tracked/staged content remains repo-wide through `git diff HEAD`. The dirty hash is provenance metadata, not a cache key.