### PR TITLE
fix: Respect terminal default colors in TUI renderer

### DIFF
--- a/crates/turborepo-ghostty/src/widget.rs
+++ b/crates/turborepo-ghostty/src/widget.rs
@@ -99,8 +99,15 @@ impl Widget for &mut TerminalWidget<'_, '_, '_> {
             self.cursor.blinking = cursor_blinking;
         }
 
-        let default_fg = rgb_to_color(colors.foreground);
-        let default_bg = rgb_to_color(colors.background);
+        // Cells without an explicit color must stay unset (`Color::Reset`) so
+        // the user's terminal theme supplies the default fg/bg, matching the
+        // pre-Ghostty vt100 renderer. Resolving them through libghostty's
+        // stock palette would paint an opaque background over the terminal
+        // theme. Like the vt100 renderer, OSC 10/11 default-color overrides
+        // are intentionally not applied; `Terminal::fg_color`/`bg_color`
+        // expose them should that ever be wanted.
+        let default_fg = Color::Reset;
+        let default_bg = Color::Reset;
 
         let Ok(mut row_iter) = RowIterator::new() else {
             return;
@@ -231,5 +238,57 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Unstyled cells stay `Color::Reset` so the terminal theme shows
+    /// through; see the rationale comment in `render`.
+    #[test]
+    fn default_colors_defer_to_terminal_theme() {
+        let (cols, rows): (u16, u16) = (20, 2);
+        let backend = TestBackend::new(cols, rows);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+
+        let mut parser = Parser::new(rows, cols, 0);
+        parser.process(b"a\x1b[38;2;1;2;3mb");
+        terminal
+            .draw(|frame| {
+                let mut widget =
+                    TerminalWidget::new(&mut parser.terminal, &mut parser.render_state);
+                widget.render(frame.area(), frame.buffer_mut());
+            })
+            .expect("draw");
+
+        let buf = terminal.backend().buffer();
+        let cell = |col: u16| &buf[ratatui::layout::Position::new(col, 0)];
+
+        // Unstyled cell: both colors stay unset for the terminal to resolve.
+        assert_eq!(cell(0).fg, Color::Reset);
+        assert_eq!(cell(0).bg, Color::Reset);
+        // Explicitly colored cells are unaffected.
+        assert_eq!(cell(1).fg, Color::Rgb(1, 2, 3));
+    }
+
+    /// OSC 10/11 default-color overrides are intentionally not applied,
+    /// matching the pre-Ghostty vt100 renderer: default cells keep
+    /// deferring to the user's terminal theme.
+    #[test]
+    fn osc_default_color_overrides_are_ignored() {
+        let (cols, rows): (u16, u16) = (20, 2);
+        let backend = TestBackend::new(cols, rows);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+
+        let mut parser = Parser::new(rows, cols, 0);
+        parser.process(b"\x1b]11;#010203\x07x");
+        terminal
+            .draw(|frame| {
+                let mut widget =
+                    TerminalWidget::new(&mut parser.terminal, &mut parser.render_state);
+                widget.render(frame.area(), frame.buffer_mut());
+            })
+            .expect("draw");
+
+        let buf = terminal.backend().buffer();
+        let cell = &buf[ratatui::layout::Position::new(0, 0)];
+        assert_eq!(cell.bg, Color::Reset);
     }
 }


### PR DESCRIPTION
Fixes #13214

### Description

Since 2.10.1 (#13135, vt100 → Ghostty migration), the TUI paints every cell that has no explicit color with libghostty's stock defaults (black background, white foreground) as concrete RGB values. In any terminal whose theme background isn't pure black, the task pane renders as an opaque black box instead of inheriting the terminal's colors like `turbo` ≤ 2.10.0 did.

The pre-Ghostty renderer (`tui-term`) mapped `vt100::Color::Default` to ratatui's `Color::Reset`, which emits no color escape and lets the terminal supply its theme defaults. This PR restores that behavior in `TerminalWidget`: cells with unset fg/bg fall back to `Color::Reset` instead of `colors.foreground` / `colors.background`. Explicitly colored cells are unaffected.

|  | ≤ 2.10.0 (vt100) | 2.10.1+ (Ghostty) | this PR |
|---|---|---|---|
| default fg/bg | `Color::Reset` → terminal theme | libghostty stock RGB (white on black) | `Color::Reset` → terminal theme |

**Before (2.10.2):** _screenshot — pane painted `rgb(0,0,0)` inside a `rgb(32,36,47)`-themed terminal_

**After (this PR):** _screenshot — pane matches the terminal theme, identical to 2.10.0_

Two deliberate scope choices, both restoring long-standing (2.0 → 2.10.0) behavior — happy to adjust either if you'd rather keep the migration's incidental changes:

- **OSC 10/11 default-color overrides are not applied.** The vendored vt100 parser only handled OSC 0/1/2 and dropped everything else (`turborepo-vt100/src/perform.rs`, `osc_dispatch`), so programs redefining default colors never affected panes before 2.10.1. This PR returns to that behavior; a test (`osc_default_color_overrides_are_ignored`) pins it as a decision rather than an accident. If you'd rather honor them, `Terminal::fg_color()`/`bg_color()` return exactly the effective override (`Some(rgb)`) vs. unconfigured (`None`) — a two-line change I'm glad to make instead.
- **ANSI palette colors (SGR 30–37, 38;5;n) still resolve through libghostty's palette to concrete RGB.** The old renderer emitted `Color::Indexed(n)` and let the terminal's palette resolve them. Fixing that needs a small restructure of the cell-style path, which would also touch code being moved in #13205, so it's left for a possible follow-up.

### Testing Instructions

1. Use a terminal whose theme background is not pure black, example configuration I have with ghostty:
```toml
# ~/.config/ghostty/config   
theme = "Ayu Light"
```

2. Clone https://github.com/shellbear/turborepo-background-tui-issue and install (bun install / npm install).
3. Run the pinned canary with the TUI (`"ui": "tui"` is set in turbo.json):
```
bunx turbo dev
```

4. Compare with the last pre-Ghostty release in the same repo and terminal:
```
bunx turbo@2.10.0 dev --skip-infer
```

Previous turbo `v2.10.0` on the top with the right default terminal background vs latest canary on the bottom
<img width="1512" height="982" alt="Screenshot 2026-07-03 at 16 13 46" src="https://github.com/user-attachments/assets/2d3ce74d-b0b0-4f3e-9187-824a737de2a8" />
