### PR TITLE
fix: Respect terminal default colors in TUI renderer

### DIFF
--- a/crates/turborepo-ghostty/src/widget.rs
+++ b/crates/turborepo-ghostty/src/widget.rs
@@ -99,8 +99,8 @@ impl Widget for &mut TerminalWidget<'_, '_, '_> {
             self.cursor.blinking = cursor_blinking;
         }
 
-        let default_fg = rgb_to_color(colors.foreground);
-        let default_bg = rgb_to_color(colors.background);
+        let default_fg = Color::Reset;
+        let default_bg = Color::Reset;
 
         let Ok(mut row_iter) = RowIterator::new() else {
             return;
@@ -231,5 +231,33 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Unstyled cells stay `Color::Reset` so the terminal theme shows
+    /// through.
+    #[test]
+    fn default_colors_defer_to_terminal_theme() {
+        let (cols, rows): (u16, u16) = (20, 2);
+        let backend = TestBackend::new(cols, rows);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+
+        let mut parser = Parser::new(rows, cols, 0);
+        parser.process(b"a\x1b[38;2;1;2;3mb");
+        terminal
+            .draw(|frame| {
+                let mut widget =
+                    TerminalWidget::new(&mut parser.terminal, &mut parser.render_state);
+                widget.render(frame.area(), frame.buffer_mut());
+            })
+            .expect("draw");
+
+        let buf = terminal.backend().buffer();
+        let cell = |col: u16| &buf[ratatui::layout::Position::new(col, 0)];
+
+        // Unstyled cell: both colors stay unset for the terminal to resolve.
+        assert_eq!(cell(0).fg, Color::Reset);
+        assert_eq!(cell(0).bg, Color::Reset);
+        // Explicitly colored cells are unaffected.
+        assert_eq!(cell(1).fg, Color::Rgb(1, 2, 3));
     }
 }


### PR DESCRIPTION
### Description

Issue source: https://github.com/vercel/turborepo/issues/13214

Since the migration to Ghostty in 2.10.1 (#13135), the TUI renders task panes with an opaque #000 background (and default text as opaque white) instead of background unset so the terminal theme. This breaks terminal color schemes and white themes, where the pane becomes a white-on-black box inside a white terminal.

This wasn't the case before 2.10.1: the vt100 renderer mapped default colors to `Color::Reset` ([turborepo-vt100/src/tui_term.rs#L105-L112](https://github.com/vercel/turborepo/blob/12fb0d9e152265658aa57d42580aaf49779ff319/crates/turborepo-vt100/src/tui_term.rs#L105-L112)), which emits no color escape and lets the terminal supply its theme defaults. 

Since 2.10.1, the Ghostty widget sets libghostty RGB values instead of unset ones ([turborepo-ghostty/src/widget.rs#L102-L103](https://github.com/vercel/turborepo/blob/de17750cb2abc8e81dfc779196d100f52bcedfdf/crates/turborepo-ghostty/src/widget.rs#L102-L103)).

### Testing Instructions

<!--
  Give a quick description of steps to test your changes.
-->

1. Use a terminal whose theme background is not pure black, example configuration I have with ghostty:
```toml
# ~/.config/ghostty/config   
theme = "Ayu Light"
```

2. Clone https://github.com/shellbear/turborepo-background-tui-issue and install (bun install / npm install).
3. Run the pinned canary with the TUI (`"ui": "tui"` is set in turbo.json):
```
bunx turbo dev
```

4. Compare with the last pre-Ghostty release in the same repo and terminal:
```
bunx turbo@2.10.0 dev --skip-infer
```

Previous turbo `v2.10.0` on the top with the right default terminal background vs latest canary on the bottom
<img width="1512" height="982" alt="Screenshot 2026-07-03 at 16 13 46" src="https://github.com/user-attachments/assets/2d3ce74d-b0b0-4f3e-9187-824a737de2a8" />

### Demo with the fix

Building then retrying with the fixed version:
```
PATH="/opt/homebrew/opt/zig@0.15/bin:$PATH" cargo build -p turbo
```

We get the same display as before, respecting user's terminal theme.

#### White theme
<img width="1512" height="982" alt="Screenshot 2026-07-03 at 16 34 41" src="https://github.com/user-attachments/assets/248184dc-3e02-4c70-98c5-ace321ce9900" />

#### Dark theme
<img width="1512" height="982" alt="Screenshot 2026-07-03 at 16 42 57" src="https://github.com/user-attachments/assets/ef1049ab-da1c-418c-bc3e-288e391817f8" />
