### PR TITLE
fix: Include untracked symlinks in repo-index dirty hash

### DIFF
--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -1875,6 +1875,48 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
+    fn test_dirty_hash_untracked_symlink_agreement() {
+        // An untracked symlink is the one entry class where the repo-index
+        // untracked walk (regular files only) and `git status` (lists
+        // symlinks) could disagree. Pin whatever the truth is.
+        let (repo_root, repo_path) = setup_repository(None).unwrap();
+        fs::write(repo_root.path().join("foo.txt"), "initial").unwrap();
+        commit_file(&repo_path, Path::new("foo.txt"), None);
+
+        std::os::unix::fs::symlink("foo.txt", repo_root.path().join("untracked_link")).unwrap();
+
+        let git_root = AbsoluteSystemPathBuf::try_from(repo_root.path()).unwrap();
+        let scm = SCM::new(&git_root);
+        let git = make_git_repo(&git_root);
+        let repo_index = RepoGitIndex::new(&git).unwrap();
+
+        let old = scm.get_dirty_hash();
+        let new = scm.get_dirty_hash_from_repo_index(&repo_index);
+
+        assert_eq!(
+            old.is_some(),
+            new.is_some(),
+            "untracked symlink dirtiness must agree: status-based={old:?}, repo-index={new:?}"
+        );
+        assert!(new.is_some(), "untracked symlink must dirty the tree");
+
+        // A broken symlink is still untracked state.
+        fs::remove_file(repo_root.path().join("untracked_link")).unwrap();
+        std::os::unix::fs::symlink("does_not_exist", repo_root.path().join("broken_link")).unwrap();
+        let repo_index = RepoGitIndex::new(&git).unwrap();
+        let broken = scm.get_dirty_hash_from_repo_index(&repo_index);
+        assert!(
+            broken.is_some(),
+            "broken untracked symlink must dirty the tree"
+        );
+        assert_ne!(
+            new, broken,
+            "different symlink names must produce different hashes"
+        );
+    }
+
+    #[test]
     fn test_dirty_hash_from_repo_index_clean_tree_returns_none() {
         let (repo_root, repo_path) = setup_repository(None).unwrap();
         let file = repo_root.path().join("foo.txt");

--- a/crates/turborepo-scm/src/repo_index.rs
+++ b/crates/turborepo-scm/src/repo_index.rs
@@ -20,6 +20,12 @@ pub struct RepoGitIndex {
     /// Sorted by path so per-package filtering can use binary-search range
     /// queries instead of linear scans.
     status_entries: Vec<RepoStatusEntry>,
+    /// Untracked symlinks discovered by the working-tree walk. Kept out of
+    /// `status_entries` so per-package hashing never attempts to hash them,
+    /// while dirty-hash provenance still reflects them (git tracks symlinks).
+    /// Only populated by [`Self::populate_untracked_for_prefixes`] /
+    /// [`Self::populate_all_untracked`].
+    untracked_symlinks: Vec<RelativeUnixPathBuf>,
     unsupported_paths: Vec<UnsupportedGitPath>,
     untracked_entries_populated: bool,
 }
@@ -34,6 +40,7 @@ impl RepoGitIndex {
             ls_tree_hashes,
             status_entries,
             unsupported_paths: Vec::new(),
+            untracked_symlinks: Vec::new(),
             untracked_entries_populated: true,
         }
     }
@@ -200,6 +207,7 @@ impl RepoGitIndex {
             ls_tree_hashes,
             status_entries,
             unsupported_paths,
+            untracked_symlinks: Vec::new(),
             untracked_entries_populated: false,
         })
     }
@@ -327,6 +335,7 @@ impl RepoGitIndex {
             ls_tree_hashes,
             status_entries,
             unsupported_paths,
+            untracked_symlinks: Vec::new(),
             untracked_entries_populated: true,
         })
     }
@@ -407,15 +416,19 @@ impl RepoGitIndex {
                 is_untracked: true,
             });
         }
+        self.untracked_symlinks = untracked.symlink_paths;
+        self.untracked_symlinks.sort();
 
         self.status_entries.sort_by(|a, b| a.path.cmp(&b.path));
         self.untracked_entries_populated = true;
 
         debug!(
-            "populated repo git index with untracked files: added_count={}, status_count={}",
+            "populated repo git index with untracked files: added_count={}, \
+             untracked_symlinks={}, status_count={}",
             self.status_entries
                 .len()
                 .saturating_sub(before_status_count),
+            self.untracked_symlinks.len(),
             self.status_entries.len(),
         );
 
@@ -440,6 +453,12 @@ impl RepoGitIndex {
             has_untracked = true;
             hasher.update(b"?\0");
             hasher.update(entry.path.as_str().as_bytes());
+            hasher.update(b"\0");
+        }
+        for path in &self.untracked_symlinks {
+            has_untracked = true;
+            hasher.update(b"?\0");
+            hasher.update(path.as_str().as_bytes());
             hasher.update(b"\0");
         }
 
@@ -576,6 +595,10 @@ impl RepoGitIndex {
 
 struct WalkedPaths {
     paths: Vec<RelativeUnixPathBuf>,
+    /// Untracked symlinks. Kept separate from `paths` because per-package
+    /// hashing intentionally ignores symlinks, while dirty-hash provenance
+    /// must still account for them (git treats symlinks as trackable).
+    symlink_paths: Vec<RelativeUnixPathBuf>,
     unsupported_paths: Vec<UnsupportedGitPath>,
 }
 
@@ -583,12 +606,13 @@ impl WalkedPaths {
     fn new() -> Self {
         Self {
             paths: Vec::new(),
+            symlink_paths: Vec::new(),
             unsupported_paths: Vec::new(),
         }
     }
 
     fn is_empty(&self) -> bool {
-        self.paths.is_empty() && self.unsupported_paths.is_empty()
+        self.paths.is_empty() && self.symlink_paths.is_empty() && self.unsupported_paths.is_empty()
     }
 }
 
@@ -676,6 +700,7 @@ fn walk_candidate_files_with_unsupported(
             if !self.batch.is_empty() {
                 let batch = WalkedPaths {
                     paths: std::mem::take(&mut self.batch.paths),
+                    symlink_paths: std::mem::take(&mut self.batch.symlink_paths),
                     unsupported_paths: std::mem::take(&mut self.batch.unsupported_paths),
                 };
                 let _ = self.tx.send(batch);
@@ -910,6 +935,7 @@ fn find_untracked_files(
             if !self.batch.is_empty() {
                 let batch = WalkedPaths {
                     paths: std::mem::take(&mut self.batch.paths),
+                    symlink_paths: std::mem::take(&mut self.batch.symlink_paths),
                     unsupported_paths: std::mem::take(&mut self.batch.unsupported_paths),
                 };
                 let _ = self.tx.send(batch);
@@ -930,9 +956,14 @@ fn find_untracked_files(
                 Err(_) => return ignore::WalkState::Continue,
             };
 
-            // Skip anything that isn't a regular file (directories,
-            // symlinks, sockets, FIFOs, device nodes).
-            if !entry.file_type().is_some_and(|ft| ft.is_file()) {
+            // Regular files feed per-package hashing. Symlinks are trackable
+            // by git and so count as untracked working-tree state, but are
+            // collected separately so hashing never sees them. Everything
+            // else (directories, sockets, FIFOs, device nodes) is skipped.
+            let file_type = entry.file_type();
+            let is_file = file_type.as_ref().is_some_and(|ft| ft.is_file());
+            let is_symlink = file_type.is_some_and(|ft| ft.is_symlink());
+            if !is_file && !is_symlink {
                 return ignore::WalkState::Continue;
             }
 
@@ -960,7 +991,11 @@ fn find_untracked_files(
                 .is_ok();
 
             if !in_ls_tree && !in_status {
-                guard.batch.paths.push(path);
+                if is_file {
+                    guard.batch.paths.push(path);
+                } else {
+                    guard.batch.symlink_paths.push(path);
+                }
             }
 
             ignore::WalkState::Continue
@@ -971,6 +1006,7 @@ fn find_untracked_files(
     let mut untracked = WalkedPaths::new();
     for batch in rx.iter() {
         untracked.paths.extend(batch.paths);
+        untracked.symlink_paths.extend(batch.symlink_paths);
         untracked.unsupported_paths.extend(batch.unsupported_paths);
     }
 
@@ -998,7 +1034,7 @@ fn find_untracked_files(
             }
         }
         if !extra_matchers.is_empty() {
-            untracked.paths.retain(|p| {
+            let not_ignored = |p: &RelativeUnixPathBuf| {
                 if p.as_str().ends_with(".gitignore") {
                     return true;
                 }
@@ -1009,7 +1045,9 @@ fn find_untracked_files(
                     &abs,
                     false,
                 )
-            });
+            };
+            untracked.paths.retain(not_ignored);
+            untracked.symlink_paths.retain(not_ignored);
         }
     }
 
@@ -1212,6 +1250,7 @@ mod tests {
             ls_tree_hashes,
             status_entries,
             unsupported_paths: Vec::new(),
+            untracked_symlinks: Vec::new(),
             untracked_entries_populated: true,
         }
     }


### PR DESCRIPTION
## Why

Follow-up to #13213. Continued differential validation of the repo-index dirty hash found one remaining divergence from the `git status`-based path: an untracked **symlink** made the old path report a dirty tree but the new path report clean. Git tracks symlinks, so they are uncommitted working-tree state and must influence provenance. The gap exists because the untracked walk deliberately skips non-regular files — correct for per-package hashing, incorrect for dirty-hash coverage.

## What

- `find_untracked_files` now records untracked symlinks in a separate `symlink_paths` collection (filtered against the tracked index and gitignore rules exactly like regular files, including the untracked-`.gitignore` post-filter).
- `RepoGitIndex` stores them in a dedicated `untracked_symlinks` field, kept **out of `status_entries`** so per-package hashing behavior is completely unchanged — only `append_dirty_status_to_hasher` consumes them.
- A differential unit test pins agreement between the status-based and repo-index paths for untracked symlinks, including broken symlinks and name sensitivity.

## How

The new test fails on the parent commit (repo-index path reported clean) and passes with this change. Full `turborepo-scm` suite: 178 passed; `turborepo-lib`: 431 passed; clippy and fmt clean. Per-package hashing is unaffected by construction: `status_entries` and `get_package_hashes` inputs are byte-identical to before.