### PR TITLE
fix: Harden TUI terminal restore during shutdown

### DIFF
--- a/crates/turborepo-lib/src/panic_handler.rs
+++ b/crates/turborepo-lib/src/panic_handler.rs
@@ -21,7 +21,7 @@ pub fn panic_handler(panic_info: &std::panic::PanicHookInfo) {
     // If the TUI was active, restore terminal to a sane state before printing
     // anything. This function checks a global flag and only runs restoration
     // if the TUI actually modified terminal state.
-    turborepo_ui::restore_terminal_on_panic();
+    turborepo_ui::restore_terminal_best_effort();
 
     let cause = panic_info.to_string();
 
@@ -79,9 +79,9 @@ mod test {
     /// restoration.
     ///
     /// This test verifies that:
-    /// 1. When the TUI is inactive, restore_terminal_on_panic returns false
-    /// 2. When the TUI is active, restore_terminal_on_panic returns true
-    /// 3. The panic handler correctly calls restore_terminal_on_panic
+    /// 1. When the TUI is inactive, restore_terminal_best_effort returns false
+    /// 2. When the TUI is active, restore_terminal_best_effort returns true
+    /// 3. The panic handler correctly calls restore_terminal_best_effort
     ///
     /// Note: We can't easily test actual panic behavior without spawning a
     /// subprocess, so we test the individual components that make up the flow.
@@ -93,10 +93,10 @@ mod test {
         assert!(!is_tui_active(), "TUI should start inactive");
 
         // When TUI is inactive, restoration should be skipped
-        let restored = turborepo_ui::restore_terminal_on_panic();
+        let restored = turborepo_ui::restore_terminal_best_effort();
         assert!(
             !restored,
-            "restore_terminal_on_panic should return false when TUI inactive"
+            "restore_terminal_best_effort should return false when TUI inactive"
         );
 
         // Simulate TUI becoming active (as would happen in startup())
@@ -104,10 +104,10 @@ mod test {
         assert!(is_tui_active(), "TUI should be active after set_tui_active");
 
         // When TUI is active, restoration should run
-        let restored = turborepo_ui::restore_terminal_on_panic();
+        let restored = turborepo_ui::restore_terminal_best_effort();
         assert!(
             restored,
-            "restore_terminal_on_panic should return true when TUI active"
+            "restore_terminal_best_effort should return true when TUI active"
         );
 
         // Clean up - simulate cleanup() completing
@@ -118,10 +118,10 @@ mod test {
         );
 
         // After cleanup, restoration should be skipped again
-        let restored = turborepo_ui::restore_terminal_on_panic();
+        let restored = turborepo_ui::restore_terminal_best_effort();
         assert!(
             !restored,
-            "restore_terminal_on_panic should return false after cleanup"
+            "restore_terminal_best_effort should return false after cleanup"
         );
     }
 

--- a/crates/turborepo-ui/src/lib.rs
+++ b/crates/turborepo-ui/src/lib.rs
@@ -28,7 +28,7 @@ pub use crate::{
 #[cfg(feature = "tui")]
 pub use crate::{
     log_sinks::LogSinks,
-    tui::{TaskTable, TerminalPane, panic_handler::restore_terminal_on_panic},
+    tui::{TaskTable, TerminalPane, panic_handler::restore_terminal_best_effort},
     tui_sink::TuiSink,
 };
 
@@ -36,17 +36,17 @@ pub use crate::{
 //
 // ## Panic Recovery
 //
-// The [`restore_terminal_on_panic`] function should be called from your panic
-// handler if using the TUI. It will restore terminal state (raw mode, alternate
-// screen, mouse capture) only if the TUI was active, making panic messages
-// visible. This is a best-effort operation that ignores all errors since we're
-// already in a panic context.
+// The [`restore_terminal_best_effort`] function should be called from your
+// panic handler if using the TUI. It will restore terminal state (raw mode,
+// alternate screen, mouse capture) only if the TUI was active, making panic
+// messages visible. This is a best-effort operation that ignores all errors
+// since we're already in a panic context.
 //
 // Example usage in a panic handler:
 // ```ignore
 // pub fn panic_handler(panic_info: &std::panic::PanicHookInfo) {
 //     // Restore terminal first so panic message is visible
-//     turborepo_ui::restore_terminal_on_panic();
+//     turborepo_ui::restore_terminal_best_effort();
 //     // ... rest of panic handling
 // }
 // ```

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -1018,15 +1018,22 @@ pub async fn run_app(
         }
     };
 
-    final_cleanup(
+    let cleanup_result = final_cleanup(
         terminal,
         display,
         raw_mode_enabled,
         app,
         callback,
         &terminal_sink,
-    )?;
+    );
 
+    // Safety net for racy shutdowns: if any restore step failed (or startup
+    // failed partway), fall back to raw escape sequences so we never exit
+    // leaving the user's terminal in the alternate screen or raw mode. This is
+    // a flag-gated no-op when cleanup fully succeeded.
+    super::panic_handler::restore_terminal_best_effort();
+
+    cleanup_result?;
     result
 }
 
@@ -1361,15 +1368,17 @@ fn enter_alt_screen(terminal: &mut Option<Terminal<CrosstermBackend<Stdout>>>) -
     // Ensure all pending writes are flushed before we switch to alternative screen
     stdout.flush()?;
 
+    // Track terminal-state modification before issuing the commands: if the
+    // execute partially applies (e.g. mouse capture enabled but the flush
+    // fails), cleanup must still attempt restoration. Best-effort cleanup
+    // tolerates disabling state that was never enabled.
+    super::panic_handler::set_mouse_capture_enabled();
+    super::panic_handler::set_tui_active();
     crossterm::execute!(
         stdout,
         crossterm::event::EnableMouseCapture,
         crossterm::terminal::EnterAlternateScreen
     )?;
-    // Track that mouse capture was enabled (important for Windows cleanup)
-    super::panic_handler::set_mouse_capture_enabled();
-    // Mark TUI as active so panic handler knows to restore terminal state
-    super::panic_handler::set_tui_active();
 
     match terminal.as_mut() {
         // Re-entering after a stream excursion: force a full repaint.
@@ -1393,11 +1402,33 @@ fn enter_alt_screen(terminal: &mut Option<Terminal<CrosstermBackend<Stdout>>>) -
     Ok(())
 }
 
+/// Record `result` into `first_error`, keeping the earliest failure.
+///
+/// Terminal restoration must be best-effort: aborting a restore sequence
+/// halfway (e.g. because the terminal went away during a racy shutdown) would
+/// leave the user's terminal stuck in the alternate screen, raw mode, or with
+/// mouse capture enabled. Each step is attempted regardless of earlier
+/// failures and the first error is surfaced at the end.
+fn record_restore_error(first_error: &mut Option<io::Error>, result: io::Result<()>) {
+    if let Err(err) = result
+        && first_error.is_none()
+    {
+        *first_error = Some(err);
+    }
+}
+
 /// Leave the alternate screen, returning to the main screen with the cursor
 /// visible and mouse capture off (so native terminal scrollback/selection
 /// works while streaming). Does not touch raw mode.
+///
+/// Restoration is best-effort: every step runs even if an earlier one fails,
+/// and the first error is returned. State-tracking flags are only cleared when
+/// the corresponding step succeeds, so the panic handler or the caller's
+/// fallback can re-attempt restoration.
 fn leave_alt_screen(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> io::Result<()> {
-    terminal.clear()?;
+    let mut first_error = None;
+
+    record_restore_error(&mut first_error, terminal.clear());
 
     // On Windows, we must only call DisableMouseCapture if EnableMouseCapture
     // was called first, because crossterm requires the original console mode
@@ -1407,45 +1438,53 @@ fn leave_alt_screen(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> io::Re
     //
     // On Unix, we can safely always disable mouse capture as it uses escape
     // sequences that are idempotent.
+    //
+    // Mouse capture and the alternate screen are restored in separate steps so
+    // a failure in one cannot prevent the other.
     #[cfg(windows)]
-    {
-        if super::panic_handler::is_mouse_capture_enabled() {
-            crossterm::execute!(
-                terminal.backend_mut(),
-                crossterm::event::DisableMouseCapture,
-                crossterm::terminal::LeaveAlternateScreen,
-            )?;
-            super::panic_handler::set_mouse_capture_disabled();
-        } else {
-            crossterm::execute!(
-                terminal.backend_mut(),
-                crossterm::terminal::LeaveAlternateScreen,
-            )?;
-        }
-    }
+    let disable_mouse_capture = super::panic_handler::is_mouse_capture_enabled();
     #[cfg(not(windows))]
-    {
-        // On Unix, always disable mouse capture - it's safe and handles child
-        // processes that may have enabled mouse capture (especially in VSCode).
-        crossterm::execute!(
+    let disable_mouse_capture = true;
+
+    if disable_mouse_capture {
+        let result = crossterm::execute!(
             terminal.backend_mut(),
-            crossterm::event::DisableMouseCapture,
-            crossterm::terminal::LeaveAlternateScreen,
-        )?;
-        super::panic_handler::set_mouse_capture_disabled();
+            crossterm::event::DisableMouseCapture
+        );
+        if result.is_ok() {
+            super::panic_handler::set_mouse_capture_disabled();
+        }
+        record_restore_error(&mut first_error, result);
     }
 
-    terminal.show_cursor()?;
-    // TUI no longer owns the screen; a panic now should not try to leave the
-    // alternate screen.
-    super::panic_handler::set_tui_inactive();
-    terminal.backend_mut().flush()?;
-    Ok(())
+    let leave_result = crossterm::execute!(
+        terminal.backend_mut(),
+        crossterm::terminal::LeaveAlternateScreen
+    );
+    if leave_result.is_ok() {
+        // TUI no longer owns the screen; a panic now should not try to leave
+        // the alternate screen.
+        super::panic_handler::set_tui_inactive();
+    }
+    record_restore_error(&mut first_error, leave_result);
+
+    record_restore_error(&mut first_error, terminal.show_cursor());
+    record_restore_error(&mut first_error, terminal.backend_mut().flush());
+
+    match first_error {
+        Some(err) => Err(err),
+        None => Ok(()),
+    }
 }
 
 /// Restores terminal to expected state at the end of the run, handling both the
 /// case where we exit from the TUI (must leave the alternate screen) and from
 /// streamed logs (already on the main screen).
+///
+/// Cleanup is best-effort: every step runs even if an earlier one fails, and
+/// the first error is returned. State-tracking flags are only cleared when the
+/// corresponding restore step succeeds, so `restore_terminal_best_effort` can
+/// re-attempt whatever is still outstanding.
 #[tracing::instrument(skip_all)]
 fn final_cleanup(
     terminal: Option<Terminal<CrosstermBackend<Stdout>>>,
@@ -1455,34 +1494,42 @@ fn final_cleanup(
     callback: Option<oneshot::Sender<()>>,
     terminal_sink: &TerminalSink,
 ) -> io::Result<()> {
+    let mut first_error = None;
+
     if let Some(mut terminal) = terminal
         && display == DisplayState::Tui
     {
         // Only leave the alternate screen if we're currently in it. When
         // streaming we're already on the main screen with the cursor shown.
-        leave_alt_screen(&mut terminal)?;
+        record_restore_error(&mut first_error, leave_alt_screen(&mut terminal));
     }
 
     // Return the stream sink to a quiescent state.
     terminal_sink.set_stream_filter(None);
 
     let tasks_started = app.tasks_by_status.tasks_started();
-    app.persist_tasks(tasks_started)?;
-    app.persist_summary()?;
+    record_restore_error(&mut first_error, app.persist_tasks(tasks_started));
+    record_restore_error(&mut first_error, app.persist_summary());
     app.preferences.flush_to_disk().ok();
 
     if raw_mode_enabled {
         terminal_sink.set_raw_terminal(false);
-        crossterm::terminal::disable_raw_mode()?;
-        super::panic_handler::set_raw_mode_disabled();
+        let raw_result = crossterm::terminal::disable_raw_mode();
+        if raw_result.is_ok() {
+            super::panic_handler::set_raw_mode_disabled();
+        }
+        record_restore_error(&mut first_error, raw_result);
     }
 
-    // Mark TUI as inactive - cleanup is complete
-    super::panic_handler::set_tui_inactive();
-
-    // We can close the channel now that terminal is back restored to a normal state
+    // We can close the channel now that terminal restoration has been
+    // attempted. Note that on failure the panic-handler flags stay set so the
+    // caller can fall back to restoring with raw escape sequences.
     drop(callback);
-    Ok(())
+
+    match first_error {
+        Some(err) => Err(err),
+        None => Ok(()),
+    }
 }
 
 fn update(
@@ -1697,6 +1744,20 @@ mod test {
 
     use super::*;
     use crate::{ColorConfig, tui::event::CacheResult};
+
+    #[test]
+    fn record_restore_error_keeps_first_error_and_continues() {
+        let mut first_error = None;
+        record_restore_error(&mut first_error, Ok(()));
+        assert!(first_error.is_none());
+
+        record_restore_error(&mut first_error, Err(io::Error::other("first")));
+        record_restore_error(&mut first_error, Err(io::Error::other("second")));
+        record_restore_error(&mut first_error, Ok(()));
+
+        let err = first_error.expect("error should be recorded");
+        assert_eq!(err.to_string(), "first");
+    }
 
     #[test]
     fn replay_offset_resumes_from_watermark_when_buffer_grows() {

--- a/crates/turborepo-ui/src/tui/panic_handler.rs
+++ b/crates/turborepo-ui/src/tui/panic_handler.rs
@@ -80,13 +80,16 @@ pub fn is_raw_mode_enabled() -> bool {
 
 /// Attempts to restore terminal to a sane state if the TUI was active.
 ///
-/// This is designed to be called from a panic handler. It is best-effort:
-/// - Only runs if the TUI was marked as active
-/// - Ignores all errors since we're already in a panic
+/// This is called from the panic handler, and as a last-resort safety net
+/// when normal TUI cleanup fails (e.g. racy shutdown while the terminal is
+/// going away). It is best-effort:
+/// - Only runs if terminal state is still marked as modified
+/// - Ignores all errors
 /// - Uses raw escape sequences to minimize risk of additional panics
 ///
-/// Returns `true` if restoration was attempted, `false` if TUI wasn't active.
-pub fn restore_terminal_on_panic() -> bool {
+/// Returns `true` if restoration was attempted, `false` if there was nothing
+/// to restore.
+pub fn restore_terminal_best_effort() -> bool {
     let tui_active = TUI_ACTIVE.load(Ordering::SeqCst);
     let raw_mode_enabled = RAW_MODE_ENABLED.load(Ordering::SeqCst);
 
@@ -188,7 +191,7 @@ mod test {
         set_raw_mode_disabled();
 
         // Should return false and not attempt restoration
-        assert!(!restore_terminal_on_panic());
+        assert!(!restore_terminal_best_effort());
     }
 
     #[test]
@@ -198,7 +201,7 @@ mod test {
         set_tui_inactive();
         set_raw_mode_enabled();
 
-        assert!(restore_terminal_on_panic());
+        assert!(restore_terminal_best_effort());
 
         // Clean up
         set_raw_mode_disabled();
@@ -213,7 +216,7 @@ mod test {
         // Should return true indicating restoration was attempted
         // Note: This will write escape sequences to stdout, but that's harmless in
         // tests
-        assert!(restore_terminal_on_panic());
+        assert!(restore_terminal_best_effort());
 
         // Clean up
         set_tui_inactive();


### PR DESCRIPTION
## Why

Users occasionally end up with a corrupted terminal after quitting the TUI (stuck in the alternate screen, mouse wheel acting like arrow keys, raw mode left on). See the recent reports on #8860. The terminal restore sequence was a `?` chain, so a single failed write — easy to hit when the terminal is being torn down during a racy shutdown — aborted all remaining restore steps, and nothing re-attempted restoration on a non-panic exit.

## What

- `leave_alt_screen` and `final_cleanup` are now best-effort: every restore step runs even if an earlier one fails, and the first error is still surfaced. Mouse-capture disable and `LeaveAlternateScreen` are issued as separate commands so one failing cannot block the other.
- Terminal-state flags (`TUI_ACTIVE`, `RAW_MODE_ENABLED`, `MOUSE_CAPTURE_ENABLED`) are only cleared when their corresponding restore step succeeds, and are set optimistically in `enter_alt_screen` so partially-applied startup still gets cleaned up.
- `run_app` gained a safety net: after cleanup it calls `restore_terminal_best_effort()` (renamed from `restore_terminal_on_panic`, since it is no longer panic-only), which re-restores via raw escape sequences if any state flag is still set. This is a no-op when cleanup fully succeeded.

## How

The failure mode is inherently racy and hard to reproduce; the hardening guarantees that `LeaveAlternateScreen` and `disable_raw_mode` are always attempted at least twice (crossterm path, then raw-escape fallback) before exit. Reviewers can simulate the old failure by making `terminal.clear()` error: previously that skipped every subsequent restore step.