### PR TITLE
chore: Rename turborepo-repository napi package to @turbo/repository

### DIFF
--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -164,11 +164,11 @@ jobs:
 
       - name: Run tests
         # We manually set TURBO_API to an empty string to override Hetzner env
-        # We filter out turborepo-repository because it's a native package and needs
+        # We filter out @turbo/repository because it's a native package and needs
         # to run when turbo core changes. This job (`js_packages`) does not run on turborpeo core
         # changes, and we don't want to enable that beahvior for _all_ our JS packages.
         run: |
-          TURBO_API= turbo run check-types test build package-checks --filter="!turborepo-repository" --filter={./packages/*}...[${{ github.event.pull_request.base.sha || 'HEAD^1' }}] --color --env-mode=strict
+          TURBO_API= turbo run check-types test build package-checks --filter="!@turbo/repository" --filter={./packages/*}...[${{ github.event.pull_request.base.sha || 'HEAD^1' }}] --color --env-mode=strict
         env:
           NODE_VERSION: ${{ matrix.node-version }}
 

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -341,7 +341,7 @@ jobs:
           turbo-version: ${{ inputs.ci-tag-override || '' }}
 
       - name: Run JS Package Tests
-        run: turbo run check-types test --filter="./packages/*" --filter="!turborepo-repository" --color
+        run: turbo run check-types test --filter="./packages/*" --filter="!@turbo/repository" --color
 
   build-rust:
     name: "Build Rust"

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -504,7 +504,7 @@ jobs:
 
       - name: Run tests
         run: |
-          TURBO_API= turbo run test --filter "turborepo-repository" --color --env-mode=strict
+          TURBO_API= turbo run test --filter "@turbo/repository" --color --env-mode=strict
         env:
           NODE_VERSION: ${{ matrix.node-version }}
 

--- a/crates/turborepo-auth/Cargo.toml
+++ b/crates/turborepo-auth/Cargo.toml
@@ -25,7 +25,6 @@ turborepo-json-rewrite = { path = "../turborepo-json-rewrite" }
 turborepo-types = { workspace = true }
 turborepo-ui.workspace = true
 turborepo-vercel-api = { workspace = true }
-turborepo-vercel-api-mock = { workspace = true }
 url = { workspace = true }
 webbrowser = { workspace = true }
 
@@ -35,3 +34,4 @@ httpmock = { workspace = true }
 insta = { workspace = true }
 port_scanner = { workspace = true }
 tempfile = { workspace = true }
+turborepo-vercel-api-mock = { workspace = true }

--- a/packages/turbo-repository/package.json
+++ b/packages/turbo-repository/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "turborepo-repository",
+  "name": "@turbo/repository",
   "version": "0.0.1",
+  "private": true,
   "description": "",
   "keywords": [],
   "homepage": "https://turborepo.dev",


### PR DESCRIPTION
## Why

The napi bindings package in `packages/turbo-repository` is named `turborepo-repository`, which collides with the Rust crate of the same name in `crates/turborepo-repository`. Upcoming work makes crate/package name collisions a hard error when Rust crates join the package graph, so the JS side moves to a non-colliding name now. `@turbo/repository` is the package's existing published napi name.

## What

- `packages/turbo-repository/package.json`: `name` -> `@turbo/repository`, marked `private` (it has no in-repo consumers; the `npm/*` platform packages are the published artifacts)
- The three CI workflow filters referencing the old name are updated
- Rider: `turborepo-vercel-api-mock` moves to dev-dependencies in `turborepo-auth` — it is only used under `cfg(test)` but sat in the production dependency closure

## How

Rename only; no behavior change. Verify via the updated `--filter` expressions in CI (`turborepo-test.yml` runs the package's tests under the new name) and `cargo check -p turborepo-auth --tests`.