### PR TITLE
feat: Add futureFlags.experimentalCargoWorkspaces flag (no-op)

### DIFF
--- a/crates/turborepo-schema-gen/src/main.rs
+++ b/crates/turborepo-schema-gen/src/main.rs
@@ -805,6 +805,16 @@ export interface FutureFlags {
    * @defaultValue `false`
    */
   globalConfiguration?: boolean;
+  /**
+   * Treat the crates of a Cargo workspace as Turborepo packages.
+   *
+   * When enabled, Rust crates are discovered via `cargo metadata` and
+   * participate in the package graph. Experimental: support is landing
+   * incrementally, and this flag currently has no effect.
+   *
+   * @defaultValue `false`
+   */
+  experimentalCargoWorkspaces?: boolean;
 }
 
 "#

--- a/crates/turborepo-turbo-json/src/future_flags.rs
+++ b/crates/turborepo-turbo-json/src/future_flags.rs
@@ -89,6 +89,13 @@ pub struct FutureFlags {
     #[serde(default)]
     #[schemars(skip)]
     pub incremental_tasks: bool,
+    /// Treat the crates of a Cargo workspace as Turborepo packages.
+    ///
+    /// When enabled, Rust crates are discovered via `cargo metadata` and
+    /// participate in the package graph. Experimental: support is landing
+    /// incrementally, and this flag currently has no effect.
+    #[serde(default)]
+    pub experimental_cargo_workspaces: bool,
 }
 
 // Manual TS impl because #[derive(TS)] conflicts with the Iterable and
@@ -106,7 +113,7 @@ impl TS for FutureFlags {
         "{ errorsOnlyShowHash?: boolean, experimentalObservability?: boolean, longerSignatureKey?: \
          boolean, affectedUsingTaskInputs?: boolean, watchUsingTaskInputs?: boolean, \
          pruneIncludesGlobalFiles?: boolean, filterUsingTasks?: boolean, globalConfiguration?: \
-         boolean }"
+         boolean, experimentalCargoWorkspaces?: boolean }"
             .to_string()
     }
 
@@ -114,7 +121,7 @@ impl TS for FutureFlags {
         "{ errorsOnlyShowHash?: boolean, experimentalObservability?: boolean, longerSignatureKey?: \
          boolean, affectedUsingTaskInputs?: boolean, watchUsingTaskInputs?: boolean, \
          pruneIncludesGlobalFiles?: boolean, filterUsingTasks?: boolean, globalConfiguration?: \
-         boolean }"
+         boolean, experimentalCargoWorkspaces?: boolean }"
             .to_string()
     }
 
@@ -122,7 +129,7 @@ impl TS for FutureFlags {
         "type FutureFlags = { errorsOnlyShowHash?: boolean, experimentalObservability?: boolean, \
          longerSignatureKey?: boolean, affectedUsingTaskInputs?: boolean, watchUsingTaskInputs?: \
          boolean, pruneIncludesGlobalFiles?: boolean, filterUsingTasks?: boolean, \
-         globalConfiguration?: boolean };"
+         globalConfiguration?: boolean, experimentalCargoWorkspaces?: boolean };"
             .to_string()
     }
 
@@ -130,7 +137,7 @@ impl TS for FutureFlags {
         "type FutureFlags = { errorsOnlyShowHash?: boolean, experimentalObservability?: boolean, \
          longerSignatureKey?: boolean, affectedUsingTaskInputs?: boolean, watchUsingTaskInputs?: \
          boolean, pruneIncludesGlobalFiles?: boolean, filterUsingTasks?: boolean, \
-         globalConfiguration?: boolean };"
+         globalConfiguration?: boolean, experimentalCargoWorkspaces?: boolean };"
             .to_string()
     }
 

--- a/packages/turbo-types/schemas/schema.json
+++ b/packages/turbo-types/schemas/schema.json
@@ -300,6 +300,11 @@
           "default": false,
           "type": "boolean"
         },
+        "experimentalCargoWorkspaces": {
+          "description": "Treat the crates of a Cargo workspace as Turborepo packages.\n\nWhen enabled, Rust crates are discovered via `cargo metadata` and participate in the package graph. Experimental: support is landing incrementally, and this flag currently has no effect.",
+          "default": false,
+          "type": "boolean"
+        },
         "experimentalObservability": {
           "description": "Enable experimental OpenTelemetry exporter support.\n\nWhen enabled, Turborepo will honor the `experimentalObservability` configuration block (if present) to send run summaries to an observability backend.",
           "default": false,

--- a/packages/turbo-types/src/types/config-v2.ts
+++ b/packages/turbo-types/src/types/config-v2.ts
@@ -303,6 +303,16 @@ export interface FutureFlags {
    * @defaultValue `false`
    */
   globalConfiguration?: boolean;
+  /**
+   * Treat the crates of a Cargo workspace as Turborepo packages.
+   *
+   * When enabled, Rust crates are discovered via `cargo metadata` and
+   * participate in the package graph. Experimental: support is landing
+   * incrementally, and this flag currently has no effect.
+   *
+   * @defaultValue `false`
+   */
+  experimentalCargoWorkspaces?: boolean;
 }
 
 export interface GlobalConfig {


### PR DESCRIPTION
## Why

This is the first PR in a series adding experimental Cargo workspace support (Rust crates as Turborepo packages). Everything in that series is gated behind `futureFlags.experimentalCargoWorkspaces`, and the flag must exist **before** any functionality does: released turbo binaries hard-error on unknown `futureFlags` keys, so a release that knows the key has to exist before any repository can durably opt in. Landing the key first starts that clock.

## What

- `futureFlags.experimentalCargoWorkspaces` in the root `turbo.json`: parses, validates, and appears in the JSON schema and `@turbo/types` definitions
- Currently controls nothing — discovery, execution, and caching arrive behind it in follow-up PRs

## How

New field on `FutureFlags` in `turborepo-turbo-json`; `schema.json` and `config-v2.ts` are regenerated through the schema pipeline (`generate-schema` + oxfmt), with the hand-maintained TypeScript `FutureFlags` template in `turborepo-schema-gen` updated alongside. `verify-schema` passes. Reviewers can confirm the flag is inert by grepping for `experimental_cargo_workspaces` — the field is read nowhere outside parsing/serialization.