### PR TITLE
perf: Overhaul pnpm lockfile parsing and dependency closure computation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7877,6 +7877,7 @@ dependencies = [
  "pretty_assertions",
  "rayon",
  "regex",
+ "rustc-hash 2.0.0",
  "semver 1.0.23",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7896,6 +7896,7 @@ dependencies = [
  "dashmap 6.1.0",
  "insta",
  "itertools 0.14.0",
+ "memchr",
  "nom",
  "pest",
  "pest_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2642,6 +2648,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -5683,6 +5698,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "saphyr-parser"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb771b59f6b1985d1406325ec28f97cfb14256abcec4fdfb37b36a1766d6af7"
+dependencies = [
+ "arraydeque",
+ "hashlink",
+]
+
+[[package]]
 name = "scc"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7878,6 +7903,7 @@ dependencies = [
  "rayon",
  "regex",
  "rustc-hash 2.0.0",
+ "saphyr-parser",
  "semver 1.0.23",
  "serde",
  "serde_json",

--- a/crates/turborepo-lockfiles/Cargo.toml
+++ b/crates/turborepo-lockfiles/Cargo.toml
@@ -20,6 +20,7 @@ pest = "2.8.6"
 pest_derive = "2.8.6"
 rayon = "1"
 regex = "1"
+rustc-hash = "2"
 semver = "1.0.17"
 serde = { version = "1.0.228", features = ["derive", "rc"] }
 serde_json = "1.0.86"

--- a/crates/turborepo-lockfiles/Cargo.toml
+++ b/crates/turborepo-lockfiles/Cargo.toml
@@ -21,6 +21,7 @@ pest_derive = "2.8.6"
 rayon = "1"
 regex = "1"
 rustc-hash = "2"
+saphyr-parser = "0.0.6"
 semver = "1.0.17"
 serde = { version = "1.0.228", features = ["derive", "rc"] }
 serde_json = "1.0.86"

--- a/crates/turborepo-lockfiles/Cargo.toml
+++ b/crates/turborepo-lockfiles/Cargo.toml
@@ -15,6 +15,7 @@ biome_json_formatter = { workspace = true }
 biome_json_parser = { workspace = true }
 dashmap = { workspace = true }
 itertools = { workspace = true }
+memchr = "2.7"
 nom = "7"
 pest = "2.8.6"
 pest_derive = "2.8.6"

--- a/crates/turborepo-lockfiles/src/closure_dp.rs
+++ b/crates/turborepo-lockfiles/src/closure_dp.rs
@@ -1,0 +1,448 @@
+//! Shared transitive-closure computation over the global package graph.
+//!
+//! The legacy walk in `lib.rs` recomputes every workspace's closure
+//! independently: each workspace re-resolves and re-visits every edge of its
+//! closure, so shared dependencies (the overwhelming majority in a monorepo)
+//! are traversed once per workspace that reaches them. This module instead
+//! computes closures once, globally:
+//!
+//! 1. resolve each workspace's *direct* dependencies exactly as the legacy walk
+//!    does (direct resolution is inherently workspace-scoped),
+//! 2. build the global package graph, resolving each distinct transitive edge
+//!    once through a [`TransitiveEdgeResolver`],
+//! 3. condense strongly connected components (npm graphs have cycles) with an
+//!    iterative Tarjan pass, which emits SCCs successors-first,
+//! 4. run a bottom-up closure DP over the condensation using bitsets, so set
+//!    unions are word-parallel, then
+//! 5. materialize each workspace's closure as the union of its direct
+//!    dependencies' SCC closures.
+//!
+//! Soundness: transitive resolution is not workspace-independent for every
+//! lockfile format (pnpm importers can shadow a transitive dependency's
+//! name; Bun resolves through the workspace). The resolver therefore
+//! *proves* uniformity per edge and reports [`TransitiveEdgeResolution::
+//! WorkspaceSensitive`] when any workspace could resolve an edge
+//! differently. A single sensitive edge aborts the DP (`Ok(None)`) and the
+//! caller falls back to the legacy walk, so behavior is preserved
+//! unconditionally — the DP is only ever a faster path to the identical
+//! answer.
+//!
+//! Memory: closure bitsets are computed in fixed-size id-range chunks
+//! (blocked transitive closure), so peak usage is bounded by
+//! `SCC count x chunk size` regardless of graph size, at no asymptotic
+//! cost: each chunk pass touches every condensation edge once.
+
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    sync::Arc,
+};
+
+use rustc_hash::FxHashMap;
+
+use crate::{Error, Lockfile, Package, TransitiveEdgeResolution, TransitiveEdgeResolver};
+
+/// Upper bound for one chunk's closure bitsets. 64MiB of transient memory
+/// keeps large graphs to a handful of passes without noticeable pressure.
+const MAX_CHUNK_BYTES: usize = 64 * 1024 * 1024;
+/// Below this chunk width the per-pass graph traversal overhead dominates;
+/// prefer the legacy walk for absurdly large graphs instead.
+const MIN_CHUNK_BITS: usize = 1024;
+
+/// Compute all workspace closures via the shared DP. Returns `Ok(None)`
+/// when the graph contains a workspace-sensitive edge (caller must use the
+/// legacy walk).
+pub(crate) fn all_transitive_closures_dp<L: Lockfile + ?Sized>(
+    lockfile: &L,
+    resolver: &dyn TransitiveEdgeResolver,
+    workspaces: &HashMap<String, BTreeMap<String, String>>,
+    ignore_missing_packages: bool,
+) -> Result<Option<HashMap<String, HashSet<Package>>>, Error> {
+    // Interned package table. Ids index `packages` and bitset positions.
+    let mut ids: FxHashMap<Package, u32> = FxHashMap::default();
+    let mut packages: Vec<Arc<Package>> = Vec::new();
+    let mut intern = |pkg: Package, packages: &mut Vec<Arc<Package>>| -> u32 {
+        *ids.entry(pkg).or_insert_with_key(|key| {
+            packages.push(Arc::new(key.clone()));
+            (packages.len() - 1) as u32
+        })
+    };
+
+    // 1. Direct dependencies stay workspace-resolved, mirroring the legacy walk's
+    //    root handling (including `ignore_missing_packages`).
+    let mut roots: Vec<(&String, Vec<u32>)> = Vec::with_capacity(workspaces.len());
+    for (workspace, unresolved) in workspaces {
+        let mut root_ids = Vec::with_capacity(unresolved.len());
+        for (name, specifier) in unresolved {
+            match lockfile.resolve_package(workspace, name, specifier) {
+                Ok(Some(pkg)) => root_ids.push(intern(pkg, &mut packages)),
+                Ok(None) => {}
+                Err(Error::MissingWorkspace(_)) if ignore_missing_packages => {}
+                Err(e) => return Err(e),
+            }
+        }
+        roots.push((workspace, root_ids));
+    }
+
+    // 2. Global graph: BFS from all roots, resolving each distinct (name, version)
+    //    edge once.
+    let mut adjacency: Vec<Vec<u32>> = vec![Vec::new(); packages.len()];
+    let mut edge_memo: FxHashMap<(String, String), Option<u32>> = FxHashMap::default();
+    let mut stack: Vec<u32> = {
+        let mut seen = vec![false; packages.len()];
+        let mut stack = Vec::new();
+        for (_, root_ids) in &roots {
+            for &id in root_ids {
+                if !seen[id as usize] {
+                    seen[id as usize] = true;
+                    stack.push(id);
+                }
+            }
+        }
+        stack
+    };
+    let mut expanded = vec![false; packages.len()];
+    while let Some(id) = stack.pop() {
+        if expanded[id as usize] {
+            continue;
+        }
+        expanded[id as usize] = true;
+
+        let Some(deps) = lockfile.all_dependencies(&packages[id as usize].key)? else {
+            continue;
+        };
+        for (name, version) in deps.as_ref() {
+            let target = match edge_memo.get(&(name.clone(), version.clone())) {
+                Some(cached) => *cached,
+                None => {
+                    let resolved = match resolver.resolve_edge(name, version)? {
+                        TransitiveEdgeResolution::Global(resolved) => resolved,
+                        TransitiveEdgeResolution::WorkspaceSensitive => return Ok(None),
+                    };
+                    let target = resolved.map(|pkg| {
+                        let id = intern(pkg, &mut packages);
+                        if id as usize >= adjacency.len() {
+                            adjacency.resize(id as usize + 1, Vec::new());
+                            expanded.resize(id as usize + 1, false);
+                        }
+                        id
+                    });
+                    edge_memo.insert((name.clone(), version.clone()), target);
+                    target
+                }
+            };
+            if let Some(target) = target {
+                adjacency[id as usize].push(target);
+                if !expanded[target as usize] {
+                    stack.push(target);
+                }
+            }
+        }
+    }
+
+    let node_count = packages.len();
+    if node_count == 0 {
+        return Ok(Some(
+            roots
+                .into_iter()
+                .map(|(ws, _)| (ws.clone(), HashSet::new()))
+                .collect(),
+        ));
+    }
+
+    // 3. SCC condensation. Tarjan emits SCCs successors-first, so a later SCC's
+    //    closure only references already-computed rows.
+    let sccs = tarjan_scc(&adjacency);
+    let scc_count = sccs.components.len();
+
+    // Condensation edges, deduplicated per source SCC.
+    let mut scc_edges: Vec<Vec<u32>> = vec![Vec::new(); scc_count];
+    {
+        let mut last_seen = vec![u32::MAX; scc_count];
+        for (scc_idx, members) in sccs.components.iter().enumerate() {
+            for &node in members {
+                for &succ in &adjacency[node as usize] {
+                    let succ_scc = sccs.scc_of[succ as usize];
+                    if succ_scc != scc_idx as u32 && last_seen[succ_scc as usize] != scc_idx as u32
+                    {
+                        last_seen[succ_scc as usize] = scc_idx as u32;
+                        scc_edges[scc_idx].push(succ_scc);
+                    }
+                }
+            }
+        }
+    }
+
+    // Workspace roots as deduplicated SCC indices.
+    let workspace_root_sccs: Vec<(&String, Vec<u32>)> = roots
+        .iter()
+        .map(|(ws, root_ids)| {
+            let mut root_sccs: Vec<u32> = root_ids
+                .iter()
+                .map(|&id| sccs.scc_of[id as usize])
+                .collect();
+            root_sccs.sort_unstable();
+            root_sccs.dedup();
+            (*ws, root_sccs)
+        })
+        .collect();
+
+    // 4 + 5. Blocked bitset DP with per-chunk materialization.
+    let chunk_bits = {
+        let by_memory = (MAX_CHUNK_BYTES / scc_count.max(1)) * 8;
+        let wanted = node_count.next_multiple_of(64);
+        wanted.min(by_memory).max(64) / 64 * 64
+    };
+    if chunk_bits < MIN_CHUNK_BITS && node_count > chunk_bits {
+        // Graph so large the blocked DP would need excessive passes.
+        return Ok(None);
+    }
+
+    let mut result: HashMap<String, HashSet<Package>> = workspace_root_sccs
+        .iter()
+        .map(|(ws, _)| ((*ws).clone(), HashSet::new()))
+        .collect();
+
+    let words_per_chunk = chunk_bits / 64;
+    let mut closures = vec![0u64; scc_count * words_per_chunk];
+    let mut accumulator = vec![0u64; words_per_chunk];
+
+    for chunk_start in (0..node_count).step_by(chunk_bits) {
+        let chunk_end = (chunk_start + chunk_bits).min(node_count);
+        if chunk_start > 0 {
+            closures.fill(0);
+        }
+
+        for (scc_idx, (members, edges)) in sccs.components.iter().zip(&scc_edges).enumerate() {
+            // Successor rows live strictly before this SCC's row (Tarjan
+            // emission order), so split the buffer to union them in.
+            let (done, current) = closures.split_at_mut(scc_idx * words_per_chunk);
+            let row = &mut current[..words_per_chunk];
+            for &member in members {
+                let member = member as usize;
+                if (chunk_start..chunk_end).contains(&member) {
+                    let bit = member - chunk_start;
+                    row[bit / 64] |= 1u64 << (bit % 64);
+                }
+            }
+            for &succ in edges {
+                let succ_row = &done[succ as usize * words_per_chunk..][..words_per_chunk];
+                for (dst, src) in row.iter_mut().zip(succ_row) {
+                    *dst |= src;
+                }
+            }
+        }
+
+        for (workspace, root_sccs) in &workspace_root_sccs {
+            if root_sccs.is_empty() {
+                continue;
+            }
+            accumulator.fill(0);
+            for &scc_idx in root_sccs {
+                let row = &closures[scc_idx as usize * words_per_chunk..][..words_per_chunk];
+                for (dst, src) in accumulator.iter_mut().zip(row) {
+                    *dst |= src;
+                }
+            }
+            // Inserted for every workspace when `result` was built; a miss
+            // is unreachable but must not panic under the workspace lint
+            // policy.
+            let Some(set) = result.get_mut(*workspace) else {
+                continue;
+            };
+            for (word_idx, &word) in accumulator.iter().enumerate() {
+                let mut word = word;
+                while word != 0 {
+                    let bit = word.trailing_zeros() as usize;
+                    word &= word - 1;
+                    let id = chunk_start + word_idx * 64 + bit;
+                    set.insert((*packages[id]).clone());
+                }
+            }
+        }
+    }
+
+    Ok(Some(result))
+}
+
+struct SccResult {
+    /// SCCs in emission order: every SCC's successors appear earlier.
+    components: Vec<Vec<u32>>,
+    /// Node id -> index into `components`.
+    scc_of: Vec<u32>,
+}
+
+/// Iterative Tarjan SCC. Recursion-free: lockfile graphs can chain
+/// thousands of packages deep.
+fn tarjan_scc(adjacency: &[Vec<u32>]) -> SccResult {
+    let n = adjacency.len();
+    const UNVISITED: u32 = u32::MAX;
+    let mut index = vec![UNVISITED; n];
+    let mut lowlink = vec![0u32; n];
+    let mut on_stack = vec![false; n];
+    let mut scc_of = vec![0u32; n];
+    let mut components = Vec::new();
+    let mut next_index = 0u32;
+    let mut tarjan_stack: Vec<u32> = Vec::new();
+    // (node, next edge offset)
+    let mut call_stack: Vec<(u32, usize)> = Vec::new();
+
+    for start in 0..n as u32 {
+        if index[start as usize] != UNVISITED {
+            continue;
+        }
+        call_stack.push((start, 0));
+        while let Some(&mut (node, ref mut edge_pos)) = call_stack.last_mut() {
+            let node_usize = node as usize;
+            if *edge_pos == 0 {
+                index[node_usize] = next_index;
+                lowlink[node_usize] = next_index;
+                next_index += 1;
+                tarjan_stack.push(node);
+                on_stack[node_usize] = true;
+            }
+
+            if let Some(&succ) = adjacency[node_usize].get(*edge_pos) {
+                *edge_pos += 1;
+                let succ_usize = succ as usize;
+                if index[succ_usize] == UNVISITED {
+                    call_stack.push((succ, 0));
+                } else if on_stack[succ_usize] {
+                    lowlink[node_usize] = lowlink[node_usize].min(index[succ_usize]);
+                }
+                continue;
+            }
+
+            // Node finished.
+            call_stack.pop();
+            if let Some(&mut (parent, _)) = call_stack.last_mut() {
+                let parent = parent as usize;
+                lowlink[parent] = lowlink[parent].min(lowlink[node_usize]);
+            }
+            if lowlink[node_usize] == index[node_usize] {
+                let scc_idx = components.len() as u32;
+                let mut members = Vec::new();
+                // `node` is always on the Tarjan stack here, so this drains
+                // at most to it; an empty stack is unreachable.
+                while let Some(member) = tarjan_stack.pop() {
+                    on_stack[member as usize] = false;
+                    scc_of[member as usize] = scc_idx;
+                    members.push(member);
+                    if member == node {
+                        break;
+                    }
+                }
+                components.push(members);
+            }
+        }
+    }
+
+    SccResult { components, scc_of }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+    use crate::PnpmLockfile;
+
+    /// The DP must agree with the legacy per-workspace walk. The legacy
+    /// walk is invoked directly (single-workspace entry point never uses
+    /// the DP), making it an independent oracle.
+    fn assert_dp_matches_legacy(
+        lockfile: &PnpmLockfile,
+        workspaces: HashMap<String, BTreeMap<String, String>>,
+    ) {
+        let via_dp = {
+            let resolver = crate::Lockfile::transitive_edge_resolver(lockfile)
+                .expect("pnpm supports edge resolution");
+            all_transitive_closures_dp(lockfile, resolver.as_ref(), &workspaces, false)
+                .expect("dp closure")
+        };
+        let legacy: HashMap<String, HashSet<Package>> = workspaces
+            .iter()
+            .map(|(ws, deps)| {
+                let closure =
+                    crate::transitive_closure(lockfile, ws, deps.clone(), false).expect("legacy");
+                (ws.clone(), closure)
+            })
+            .collect();
+        match via_dp {
+            Some(dp) => assert_eq!(dp, legacy, "dp result must match the legacy walk"),
+            None => panic!("dp unexpectedly fell back for a uniform lockfile"),
+        }
+    }
+
+    fn workspaces_of(lockfile: &PnpmLockfile) -> HashMap<String, BTreeMap<String, String>> {
+        lockfile.test_workspaces()
+    }
+
+    #[test]
+    fn test_dp_matches_legacy_on_repo_lockfile() {
+        let manifest_dir = env!("CARGO_MANIFEST_DIR");
+        let lockfile_path = std::path::Path::new(manifest_dir)
+            .join("../..")
+            .join("pnpm-lock.yaml");
+        let bytes = std::fs::read(&lockfile_path).expect("repo lockfile readable");
+        let lockfile = PnpmLockfile::from_bytes(&bytes).expect("parse");
+        assert_dp_matches_legacy(&lockfile, workspaces_of(&lockfile));
+    }
+
+    #[test]
+    fn test_dp_falls_back_on_divergent_edge() {
+        // Workspace `.` pins `shadowed` with an exact specifier equal to
+        // the transitive version string but resolving to a peer-suffixed
+        // snapshot. The transitive edge `shadowed@1.0.0` then resolves
+        // differently for importers with and without that entry: the
+        // ladder's `resolved_specifier == override_specifier` arm returns
+        // the peer-suffixed version for `.`, while the agnostic path keeps
+        // the plain one. The DP must detect this and fall back.
+        let yaml = r#"lockfileVersion: '6.0'
+
+importers:
+
+  .:
+    dependencies:
+      shadowed:
+        specifier: 1.0.0
+        version: 1.0.0(peer@2.0.0)
+  packages/a:
+    dependencies:
+      carrier:
+        specifier: ^1.0.0
+        version: 1.0.0
+
+packages:
+
+  /carrier@1.0.0:
+    resolution: {integrity: sha512-carrier}
+    dependencies:
+      shadowed: 1.0.0
+
+  /shadowed@1.0.0:
+    resolution: {integrity: sha512-shadowed}
+
+  /shadowed@1.0.0(peer@2.0.0):
+    resolution: {integrity: sha512-shadowedpeer}
+
+  /peer@2.0.0:
+    resolution: {integrity: sha512-peer}
+"#;
+        let lockfile = PnpmLockfile::from_bytes(yaml.as_bytes()).expect("parse");
+        let workspaces = workspaces_of(&lockfile);
+
+        let resolver = crate::Lockfile::transitive_edge_resolver(&lockfile)
+            .expect("pnpm supports edge resolution");
+        let dp = all_transitive_closures_dp(&lockfile, resolver.as_ref(), &workspaces, false)
+            .expect("dp run");
+        assert!(dp.is_none(), "divergent edge must force fallback");
+
+        // And the public entry point must still produce the legacy result.
+        let via_public =
+            crate::all_transitive_closures(&lockfile, workspaces.clone(), false).expect("public");
+        for (ws, deps) in workspaces {
+            let legacy = crate::transitive_closure(&lockfile, &ws, deps, false).expect("legacy");
+            assert_eq!(via_public[&ws], legacy);
+        }
+    }
+}

--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -14,6 +14,7 @@
 
 mod berry;
 mod bun;
+mod closure_dp;
 mod error;
 mod npm;
 mod pnpm;
@@ -171,6 +172,31 @@ pub trait Lockfile: Send + Sync + Any + std::fmt::Debug {
     fn human_name(&self, package: &Package) -> Option<String> {
         None
     }
+
+    /// A resolver for transitive dependency edges whose resolution can be
+    /// proven identical across workspaces, enabling the shared closure DP
+    /// in [`all_transitive_closures`]. `None` (the default) means the
+    /// format cannot make that promise and closures use the per-workspace
+    /// walk.
+    fn transitive_edge_resolver(&self) -> Option<Box<dyn TransitiveEdgeResolver + '_>> {
+        None
+    }
+}
+
+/// Outcome of resolving a transitive `(name, version)` edge without a
+/// workspace context.
+pub enum TransitiveEdgeResolution {
+    /// Every workspace resolves this edge to the same package (or fails to
+    /// resolve it).
+    Global(Option<Package>),
+    /// Some workspace could resolve this edge differently; the shared DP
+    /// must not be used.
+    WorkspaceSensitive,
+}
+
+/// See [`Lockfile::transitive_edge_resolver`].
+pub trait TransitiveEdgeResolver {
+    fn resolve_edge(&self, name: &str, version: &str) -> Result<TransitiveEdgeResolution, Error>;
 }
 
 /// Takes a lockfile, and a map of workspace directory paths -> (package name,
@@ -180,6 +206,22 @@ pub fn all_transitive_closures<L: Lockfile + ?Sized>(
     workspaces: HashMap<String, BTreeMap<String, String>>,
     ignore_missing_packages: bool,
 ) -> Result<HashMap<String, HashSet<Package>>, Error> {
+    // Shared DP fast path: computes each closure once over the global
+    // package graph instead of once per workspace. Only sound when the
+    // lockfile proves every transitive edge resolves identically across
+    // workspaces; any sensitive edge falls through to the walk below.
+    if workspaces.len() > 1
+        && let Some(resolver) = lockfile.transitive_edge_resolver()
+        && let Some(closures) = closure_dp::all_transitive_closures_dp(
+            lockfile,
+            resolver.as_ref(),
+            &workspaces,
+            ignore_missing_packages,
+        )?
+    {
+        return Ok(closures);
+    }
+
     let resolve_cache: ResolveCache = DashMap::default();
     let deps_cache: DepsCache = DashMap::default();
     let interner = PackageInterner::default();

--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -33,16 +33,49 @@ pub use error::Error;
 pub use npm::*;
 pub use pnpm::{PnpmLockfile, pnpm_global_change, pnpm_subgraph};
 use rayon::prelude::*;
+use rustc_hash::{FxBuildHasher, FxHashSet};
 use serde::Serialize;
 use turbopath::RelativeUnixPathBuf;
 pub use yarn1::{Yarn1Lockfile, yarn_subgraph};
 
-type ResolveCache = DashMap<String, Option<Package>>;
+// The closure walk visits every edge of every workspace's dependency closure,
+// so these caches are probed millions of times on large repos. They use
+// FxHash instead of the DoS-resistant default: lockfile contents are developer
+// tooling input, not an adversarial hash-flooding vector, and the long string
+// keys make SipHash a measurable cost.
+//
+// Resolutions cache interned package ids (plus a shared `Arc` of the package)
+// so a cache hit is a refcount bump instead of cloning the package's strings.
+type ResolveCache = DashMap<String, Option<(u32, Arc<Package>)>, FxBuildHasher>;
 // Dependency maps are shared behind an `Arc` so cache hits are a refcount bump
 // instead of a deep clone of the map. The cache is shared across all
 // workspaces, so each package's dependency map would otherwise be cloned once
-// per workspace whose closure contains it.
-type DepsCache = DashMap<String, Option<Arc<BTreeMap<String, String>>>>;
+// per workspace whose closure contains it. Keyed by interned package id to
+// avoid re-hashing package key strings on every node visit.
+type DepsCache = DashMap<u32, Option<Arc<BTreeMap<String, String>>>, FxBuildHasher>;
+
+/// Assigns dense integer ids to resolved packages. Distinct cache keys (e.g.
+/// the same package reached from different workspaces) intern to the same id,
+/// letting visited-set checks hash a `u32` instead of two heap strings.
+#[derive(Default)]
+struct PackageInterner {
+    ids: DashMap<Package, (u32, Arc<Package>), FxBuildHasher>,
+    next: std::sync::atomic::AtomicU32,
+}
+
+impl PackageInterner {
+    fn intern(&self, package: Package) -> (u32, Arc<Package>) {
+        match self.ids.entry(package) {
+            dashmap::mapref::entry::Entry::Occupied(entry) => entry.get().clone(),
+            dashmap::mapref::entry::Entry::Vacant(entry) => {
+                let id = self.next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                let package = Arc::new(entry.key().clone());
+                entry.insert((id, package.clone()));
+                (id, package)
+            }
+        }
+    }
+}
 
 #[derive(Debug, PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Serialize)]
 pub struct Package {
@@ -147,8 +180,9 @@ pub fn all_transitive_closures<L: Lockfile + ?Sized>(
     workspaces: HashMap<String, BTreeMap<String, String>>,
     ignore_missing_packages: bool,
 ) -> Result<HashMap<String, HashSet<Package>>, Error> {
-    let resolve_cache: ResolveCache = DashMap::new();
-    let deps_cache: DepsCache = DashMap::new();
+    let resolve_cache: ResolveCache = DashMap::default();
+    let deps_cache: DepsCache = DashMap::default();
+    let interner = PackageInterner::default();
     workspaces
         .into_par_iter()
         .map(|(workspace, unresolved_deps)| {
@@ -159,6 +193,7 @@ pub fn all_transitive_closures<L: Lockfile + ?Sized>(
                 ignore_missing_packages,
                 &resolve_cache,
                 &deps_cache,
+                &interner,
             )?;
             Ok((workspace, closure))
         })
@@ -172,8 +207,9 @@ pub fn transitive_closure<L: Lockfile + ?Sized>(
     unresolved_deps: BTreeMap<String, String>,
     ignore_missing_packages: bool,
 ) -> Result<HashSet<Package>, Error> {
-    let resolve_cache: ResolveCache = DashMap::new();
-    let deps_cache: DepsCache = DashMap::new();
+    let resolve_cache: ResolveCache = DashMap::default();
+    let deps_cache: DepsCache = DashMap::default();
+    let interner = PackageInterner::default();
     transitive_closure_cached(
         lockfile,
         workspace_path,
@@ -181,9 +217,11 @@ pub fn transitive_closure<L: Lockfile + ?Sized>(
         ignore_missing_packages,
         &resolve_cache,
         &deps_cache,
+        &interner,
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn transitive_closure_cached<L: Lockfile + ?Sized>(
     lockfile: &L,
     workspace_path: &str,
@@ -191,18 +229,22 @@ fn transitive_closure_cached<L: Lockfile + ?Sized>(
     ignore_missing_packages: bool,
     resolve_cache: &ResolveCache,
     deps_cache: &DepsCache,
+    interner: &PackageInterner,
 ) -> Result<HashSet<Package>, Error> {
     let mut ctx = ClosureContext {
         lockfile,
         workspace_path,
         resolve_cache,
         deps_cache,
+        interner,
         key_buf: String::new(),
     };
     let mut transitive_deps = HashSet::new();
+    let mut visited = FxHashSet::default();
     ctx.walk(
         &unresolved_deps,
         &mut transitive_deps,
+        &mut visited,
         ignore_missing_packages,
         true,
     )?;
@@ -214,6 +256,7 @@ struct ClosureContext<'a, L: Lockfile + ?Sized> {
     workspace_path: &'a str,
     resolve_cache: &'a ResolveCache,
     deps_cache: &'a DepsCache,
+    interner: &'a PackageInterner,
     key_buf: String,
 }
 
@@ -238,7 +281,7 @@ impl<L: Lockfile + ?Sized> ClosureContext<'_, L> {
         unresolved_deps: &BTreeMap<String, String>,
         ignore_missing_packages: bool,
         _is_workspace_root_deps: bool,
-    ) -> Result<Vec<Package>, Error> {
+    ) -> Result<Vec<(u32, Arc<Package>)>, Error> {
         let mut newly_resolved = Vec::new();
 
         for (name, specifier) in unresolved_deps {
@@ -266,9 +309,10 @@ impl<L: Lockfile + ?Sized> ClosureContext<'_, L> {
                             }
                             Err(e) => return Err(e),
                         };
+                    let interned = result.map(|pkg| self.interner.intern(pkg));
                     self.resolve_cache
-                        .insert(self.key_buf.clone(), result.clone());
-                    result
+                        .insert(self.key_buf.clone(), interned.clone());
+                    interned
                 }
             };
 
@@ -284,6 +328,7 @@ impl<L: Lockfile + ?Sized> ClosureContext<'_, L> {
         &mut self,
         unresolved_deps: &BTreeMap<String, String>,
         resolved_deps: &mut HashSet<Package>,
+        visited: &mut FxHashSet<u32>,
         ignore_missing_packages: bool,
         is_workspace_root_deps: bool,
     ) -> Result<(), Error> {
@@ -293,25 +338,25 @@ impl<L: Lockfile + ?Sized> ClosureContext<'_, L> {
             is_workspace_root_deps,
         )?;
 
-        for pkg in newly_resolved {
-            if resolved_deps.contains(&pkg) {
+        for (id, pkg) in newly_resolved {
+            if !visited.insert(id) {
                 continue;
             }
 
-            let all_deps = if let Some(cached) = self.deps_cache.get(&pkg.key) {
+            let all_deps = if let Some(cached) = self.deps_cache.get(&id) {
                 cached.clone()
             } else {
                 let deps = self
                     .lockfile
                     .all_dependencies(&pkg.key)?
                     .map(|cow| Arc::new(cow.into_owned()));
-                self.deps_cache.insert(pkg.key.clone(), deps.clone());
+                self.deps_cache.insert(id, deps.clone());
                 deps
             };
 
-            resolved_deps.insert(pkg);
+            resolved_deps.insert((*pkg).clone());
             if let Some(deps) = all_deps {
-                self.walk(&deps, resolved_deps, false, false)?;
+                self.walk(&deps, resolved_deps, visited, false, false)?;
             }
         }
 

--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -7,6 +7,13 @@ use turbopath::RelativeUnixPathBuf;
 
 use super::{Error, LockfileVersion, SupportedLockfileVersion, dep_path::DepPath};
 
+// A child module of `data` so it can construct the private lockfile structs.
+// The file lives at `data_fast_parse.rs` instead of the default
+// `data/fast_parse.rs` because the repo-root .gitignore ignores any path
+// segment named `data`.
+#[path = "data_fast_parse.rs"]
+mod fast_parse;
+
 type Map<K, V> = std::collections::BTreeMap<K, V>;
 
 type Packages = BTreeMap<String, PackageSnapshot>;
@@ -244,6 +251,26 @@ struct LockfileSettings {
 
 impl PnpmLockfile {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, crate::Error> {
+        // Machine-generated pnpm lockfiles parse on a fast event-driven path
+        // (~2x the scanner throughput of the serde path). Inputs outside its
+        // supported YAML subset — and malformed inputs — return `None` and
+        // take the serde path below, which either handles them (e.g. multi-
+        // document lockfiles) or reports a proper error.
+        if let Some(mut this) = fast_parse::parse(bytes) {
+            this.cached_version = this.compute_version();
+            this.build_dependency_index();
+            return Ok(this);
+        }
+
+        tracing::debug!("pnpm lockfile outside fast-parse subset; using serde path");
+        Self::from_bytes_via_serde(bytes)
+    }
+
+    /// The serde-based parse path. Handles everything the fast path doesn't
+    /// (multi-document lockfiles, exotic YAML) and produces proper errors
+    /// for malformed input. Also serves as the correctness oracle for the
+    /// fast path in tests.
+    fn from_bytes_via_serde(bytes: &[u8]) -> Result<Self, crate::Error> {
         let mut documents = serde_yaml_ng::Deserializer::from_slice(bytes).peekable();
         let mut leading_documents = Vec::new();
 

--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -400,6 +400,25 @@ impl PnpmLockfile {
         entry.version.as_deref()
     }
 
+    /// Reconstruct the workspace -> (name -> specifier) map from importer
+    /// entries. Production callers derive this from package.jsons; tests
+    /// use the importers so lockfile fixtures are self-contained.
+    #[cfg(test)]
+    pub(crate) fn test_workspaces(&self) -> std::collections::HashMap<String, Map<String, String>> {
+        self.importers
+            .iter()
+            .map(|(path, importer)| {
+                let mut deps = Map::new();
+                for name in importer.dependencies.all_dependency_names() {
+                    if let Some((specifier, _)) = importer.dependencies.find_resolution(name) {
+                        deps.insert(name.to_string(), specifier.to_string());
+                    }
+                }
+                (path.clone(), deps)
+            })
+            .collect()
+    }
+
     fn get_workspace(&self, workspace_path: &str) -> Result<&ProjectSnapshot, crate::Error> {
         let key = match workspace_path {
             // For pnpm, the root is named "."
@@ -497,13 +516,30 @@ impl PnpmLockfile {
         key_buf: &mut String,
     ) -> Result<Option<&'a str>, crate::Error> {
         let importer = self.get_workspace(workspace_path)?;
+        Ok(self.resolution_ladder(
+            importer.dependencies.find_resolution(name),
+            name,
+            specifier,
+            key_buf,
+        ))
+    }
 
-        let Some((resolved_specifier, resolved_version)) =
-            importer.dependencies.find_resolution(name)
-        else {
-            return Ok(self
+    /// The specifier-resolution decision ladder, parameterized over the
+    /// importer's `(specifier, version)` entry for `name` (if any). Shared
+    /// by workspace-scoped resolution and the global transitive-edge
+    /// resolver, which evaluates it against every distinct importer entry
+    /// to prove workspace independence.
+    fn resolution_ladder<'a>(
+        &'a self,
+        resolution: Option<(&'a str, &'a str)>,
+        name: &str,
+        specifier: &'a str,
+        key_buf: &mut String,
+    ) -> Option<&'a str> {
+        let Some((resolved_specifier, resolved_version)) = resolution else {
+            return self
                 .has_package_by_parts(name, specifier, key_buf)
-                .then_some(specifier));
+                .then_some(specifier);
         };
 
         let override_specifier = self.apply_overrides(name, specifier);
@@ -511,21 +547,21 @@ impl PnpmLockfile {
         // Prefer the original specifier if it already matches a snapshot,
         // so overrides don't corrupt resolved peer-dep variants.
         if override_specifier != specifier && self.has_package_by_parts(name, specifier, key_buf) {
-            return Ok(Some(specifier));
+            return Some(specifier);
         }
 
         if resolved_specifier == override_specifier {
-            Ok(Some(resolved_version))
+            Some(resolved_version)
         } else if self.has_package_by_parts(name, specifier, key_buf) {
-            Ok(Some(specifier))
+            Some(specifier)
         } else if resolved_specifier == resolved_version
             && self.has_package_by_parts(name, resolved_version, key_buf)
         {
-            Ok(Some(resolved_version))
+            Some(resolved_version)
         } else if self.has_package_by_parts(name, override_specifier, key_buf) {
-            Ok(Some(override_specifier))
+            Some(override_specifier)
         } else {
-            Ok(None)
+            None
         }
     }
 
@@ -938,6 +974,79 @@ impl crate::Lockfile for PnpmLockfile {
             // the delimiter between name and version
             Some(package.key.strip_prefix('/')?.to_owned())
         }
+    }
+
+    fn transitive_edge_resolver(&self) -> Option<Box<dyn crate::TransitiveEdgeResolver + '_>> {
+        let any_workspace = self.importers.keys().next()?;
+        // Importer entries are the only workspace-varying input to
+        // `resolution_ladder`. Group the distinct `(specifier, version)`
+        // entries per dependency name so the resolver can prove (per edge)
+        // that every importer resolves it identically.
+        let mut importer_entries: rustc_hash::FxHashMap<&str, Vec<(&str, &str)>> =
+            rustc_hash::FxHashMap::default();
+        for importer in self.importers.values() {
+            for name in importer.dependencies.all_dependency_names() {
+                if let Some(entry) = importer.dependencies.find_resolution(name) {
+                    let entries = importer_entries.entry(name).or_default();
+                    if !entries.contains(&entry) {
+                        entries.push(entry);
+                    }
+                }
+            }
+        }
+        Some(Box::new(PnpmEdgeResolver {
+            lockfile: self,
+            any_workspace,
+            importer_entries,
+        }))
+    }
+}
+
+/// Proves per-edge workspace independence for the shared closure DP.
+///
+/// pnpm resolution consults the importer only through
+/// `find_resolution(name)` inside [`PnpmLockfile::resolution_ladder`]. An
+/// edge's resolution is therefore uniform across workspaces iff the ladder
+/// produces the same outcome for the no-entry case and for every distinct
+/// importer entry for that name. When it does, the edge resolves through
+/// the ordinary `resolve_package` path with an arbitrary importer, so the
+/// fast path shares the exact production resolution code.
+struct PnpmEdgeResolver<'a> {
+    lockfile: &'a PnpmLockfile,
+    any_workspace: &'a str,
+    importer_entries: rustc_hash::FxHashMap<&'a str, Vec<(&'a str, &'a str)>>,
+}
+
+impl crate::TransitiveEdgeResolver for PnpmEdgeResolver<'_> {
+    fn resolve_edge(
+        &self,
+        name: &str,
+        version: &str,
+    ) -> Result<crate::TransitiveEdgeResolution, crate::Error> {
+        // `resolve_package`'s key short-circuit never consults the
+        // importer; the ladder only needs checking when it misses.
+        if !self.lockfile.has_package(version)
+            && let Some(entries) = self.importer_entries.get(name)
+        {
+            let mut key_buf = String::new();
+            let agnostic = self
+                .lockfile
+                .resolution_ladder(None, name, version, &mut key_buf);
+            for &(specifier, resolved) in entries {
+                let outcome = self.lockfile.resolution_ladder(
+                    Some((specifier, resolved)),
+                    name,
+                    version,
+                    &mut key_buf,
+                );
+                if outcome != agnostic {
+                    return Ok(crate::TransitiveEdgeResolution::WorkspaceSensitive);
+                }
+            }
+        }
+        Ok(crate::TransitiveEdgeResolution::Global(
+            crate::Lockfile::resolve_package(self.lockfile, self.any_workspace, name, version)?,
+        ))
     }
 }
 

--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -1,5 +1,6 @@
 use std::{any::Any, borrow::Cow, collections::BTreeMap};
 
+use rustc_hash::FxHashMap;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use turbopath::RelativeUnixPathBuf;
@@ -43,9 +44,23 @@ pub struct PnpmLockfile {
     #[serde(skip_serializing_if = "Option::is_none")]
     snapshots: Option<Snapshots>,
     #[serde(skip)]
-    dependency_index: BTreeMap<String, BTreeMap<String, String>>,
+    dependency_index: FxHashMap<String, DepIndexEntry>,
     #[serde(skip_serializing_if = "Option::is_none")]
     time: Option<Map<String, String>>,
+}
+
+/// Per-key lookup entry built once after parse so the hot resolution paths
+/// (`has_package`, `package_version`, `all_dependencies`) are O(1) hash
+/// probes instead of `BTreeMap` walks over long dependency-path keys.
+///
+/// `deps` stays a `BTreeMap` deliberately: its iteration order feeds the
+/// closure walk and must be deterministic across processes.
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+struct DepIndexEntry {
+    deps: BTreeMap<String, String>,
+    in_packages: bool,
+    in_snapshots: bool,
+    version: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
@@ -303,17 +318,27 @@ impl PnpmLockfile {
     }
 
     fn build_dependency_index(&mut self) {
-        let mut index = BTreeMap::new();
+        let capacity = self.snapshots.as_ref().map_or(0, |s| s.len())
+            + self.packages.as_ref().map_or(0, |p| p.len());
+        let mut index: FxHashMap<String, DepIndexEntry> =
+            FxHashMap::with_capacity_and_hasher(capacity, Default::default());
         if let Some(snapshots) = &self.snapshots {
             for (key, snapshot) in snapshots {
-                index.insert(key.clone(), snapshot.dependencies());
+                let entry = index.entry(key.clone()).or_default();
+                entry.deps = snapshot.dependencies();
+                entry.in_snapshots = true;
             }
         }
         if let Some(packages) = &self.packages {
-            for (key, entry) in packages {
-                index
-                    .entry(key.clone())
-                    .or_insert_with(|| entry.snapshot.dependencies());
+            for (key, package) in packages {
+                let entry = index.entry(key.clone()).or_default();
+                // Snapshot dependency maps take priority, matching the
+                // previous insert-then-or_insert construction order.
+                if !entry.in_snapshots {
+                    entry.deps = package.snapshot.dependencies();
+                }
+                entry.in_packages = true;
+                entry.version = package.version.clone();
             }
         }
         self.dependency_index = index;
@@ -331,21 +356,21 @@ impl PnpmLockfile {
     }
 
     fn has_package(&self, key: &str) -> bool {
+        let Some(entry) = self.dependency_index.get(key) else {
+            return false;
+        };
         match self.version() {
-            SupportedLockfileVersion::V5 | SupportedLockfileVersion::V6 => {
-                self.packages.as_ref().map(|pkgs| pkgs.contains_key(key))
-            }
-            SupportedLockfileVersion::V7AndV9 => {
-                self.snapshots.as_ref().map(|snaps| snaps.contains_key(key))
-            }
+            SupportedLockfileVersion::V5 | SupportedLockfileVersion::V6 => entry.in_packages,
+            SupportedLockfileVersion::V7AndV9 => entry.in_snapshots,
         }
-        .unwrap_or_default()
     }
 
     fn package_version(&self, key: &str) -> Option<&str> {
-        let pkgs = self.packages.as_ref()?;
-        let pkg = pkgs.get(key)?;
-        pkg.version.as_deref()
+        let entry = self.dependency_index.get(key)?;
+        if !entry.in_packages {
+            return None;
+        }
+        entry.version.as_deref()
     }
 
     fn get_workspace(&self, workspace_path: &str) -> Result<&ProjectSnapshot, crate::Error> {
@@ -665,7 +690,7 @@ impl crate::Lockfile for PnpmLockfile {
         Ok(self
             .dependency_index
             .get(key)
-            .map(std::borrow::Cow::Borrowed))
+            .map(|entry| std::borrow::Cow::Borrowed(&entry.deps)))
     }
 
     fn subgraph(
@@ -789,7 +814,7 @@ impl crate::Lockfile for PnpmLockfile {
             .map(|patches| self.prune_patches(patches, &pruned_packages))
             .transpose()?;
 
-        Ok(Box::new(Self {
+        let mut pruned = Self {
             leading_documents: self.leading_documents.clone(),
             importers,
             packages: match pruned_packages.is_empty() {
@@ -805,12 +830,16 @@ impl crate::Lockfile for PnpmLockfile {
             package_extensions_checksum: self.package_extensions_checksum.clone(),
             patched_dependencies: patches,
             snapshots: pruned_snapshots,
-            dependency_index: BTreeMap::new(),
+            dependency_index: FxHashMap::default(),
             time: None,
             settings: self.settings.clone(),
             pnpmfile_checksum: self.pnpmfile_checksum.clone(),
             catalogs: self.catalogs.clone(),
-        }))
+        };
+        // The pruned lockfile must be queryable like a parsed one
+        // (has_package/all_dependencies consult the index).
+        pruned.build_dependency_index();
+        Ok(Box::new(pruned))
     }
 
     fn encode(&self) -> Result<Vec<u8>, crate::Error> {

--- a/crates/turborepo-lockfiles/src/pnpm/data_fast_parse.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data_fast_parse.rs
@@ -19,6 +19,9 @@ use std::collections::BTreeMap;
 use saphyr_parser::{Event, Parser, ScalarStyle, StrInput};
 use serde_yaml_ng::{Mapping, Number, Value};
 
+#[path = "data_scanner.rs"]
+mod scanner;
+
 use super::{
     DependenciesMeta, Dependency, DependencyInfo, LockfileSettings, Map, PackageResolution,
     PackageSnapshot, PackageSnapshotV7, Packages, PatchFile, PnpmLockfile, ProjectSnapshot,
@@ -50,21 +53,40 @@ impl Unsupported {
 
 type FResult<T> = Result<T, Unsupported>;
 
-/// Attempt to parse a pnpm lockfile from YAML using the fast event-driven
-/// path. Returns `None` when the input uses YAML constructs outside the
+/// Attempt to parse a pnpm lockfile from YAML using the fast paths.
+/// Tier 1 is a structural line scanner specialized to the pnpm subset;
+/// tier 2 replays the input through the general saphyr event parser.
+/// Returns `None` when the input uses YAML constructs outside the
 /// supported subset (or is malformed); the caller must then use the serde
 /// path, which either parses it or reports a proper error.
 pub(super) fn parse(bytes: &[u8]) -> Option<PnpmLockfile> {
     let text = std::str::from_utf8(bytes).ok()?;
+    parse_with_scanner(text).or_else(|| parse_with_saphyr(text))
+}
+
+fn parse_with_scanner(text: &str) -> Option<PnpmLockfile> {
     let mut events = Events {
-        parser: Parser::new_from_str(text),
+        source: Source::Lines(scanner::LineScanner::new(text)),
         peeked: None,
     };
     parse_lockfile(&mut events).ok()
 }
 
+fn parse_with_saphyr(text: &str) -> Option<PnpmLockfile> {
+    let mut events = Events {
+        source: Source::Saphyr(Box::new(Parser::new_from_str(text))),
+        peeked: None,
+    };
+    parse_lockfile(&mut events).ok()
+}
+
+enum Source<'a> {
+    Saphyr(Box<Parser<'a, StrInput<'a>>>),
+    Lines(scanner::LineScanner<'a>),
+}
+
 struct Events<'a> {
-    parser: Parser<'a, StrInput<'a>>,
+    source: Source<'a>,
     peeked: Option<Event<'a>>,
 }
 
@@ -73,9 +95,12 @@ impl<'a> Events<'a> {
         if let Some(ev) = self.peeked.take() {
             return Ok(ev);
         }
-        match self.parser.next() {
-            Some(Ok((ev, _span))) => Ok(ev),
-            Some(Err(_)) | None => Err(Unsupported::here()),
+        match &mut self.source {
+            Source::Saphyr(parser) => match parser.next() {
+                Some(Ok((ev, _span))) => Ok(ev),
+                Some(Err(_)) | None => Err(Unsupported::here()),
+            },
+            Source::Lines(scanner) => scanner.next_event(),
         }
     }
 
@@ -910,6 +935,8 @@ mod tests {
 
     /// Parse via the fast path (applying the same post-parse steps as
     /// `from_bytes`) and via the serde oracle; both must succeed and agree.
+    /// When the structural scanner accepts the input, its result must agree
+    /// with the oracle too.
     fn assert_fast_matches_serde(yaml: &str) {
         let mut fast = parse(yaml.as_bytes()).expect("fast path must accept this input");
         fast.cached_version = fast.compute_version();
@@ -923,6 +950,24 @@ mod tests {
             String::from_utf8(crate::Lockfile::encode(&fast).expect("fast encodes")).ok(),
             String::from_utf8(crate::Lockfile::encode(&serde).expect("serde encodes")).ok(),
         );
+
+        if let Some(mut scanned) = parse_with_scanner(yaml) {
+            scanned.cached_version = scanned.compute_version();
+            scanned.build_dependency_index();
+            assert_eq!(scanned, serde, "scanner tier must agree with serde");
+        }
+    }
+
+    /// Like [`assert_fast_matches_serde`], but additionally requires the
+    /// structural scanner tier to accept the input. Guards against silent
+    /// regressions where mainline pnpm shapes start falling through to the
+    /// slower tiers.
+    fn assert_scanner_matches_serde(yaml: &str) {
+        assert!(
+            parse_with_scanner(yaml).is_some(),
+            "structural scanner must accept this input"
+        );
+        assert_fast_matches_serde(yaml);
     }
 
     fn assert_falls_back(yaml: &str) {
@@ -934,7 +979,7 @@ mod tests {
 
     #[test]
     fn test_v9_lockfile_differential() {
-        assert_fast_matches_serde(
+        assert_scanner_matches_serde(
             r#"lockfileVersion: '9.0'
 
 settings:
@@ -1016,7 +1061,7 @@ snapshots:
 
     #[test]
     fn test_v5_lockfile_differential() {
-        assert_fast_matches_serde(
+        assert_scanner_matches_serde(
             r#"lockfileVersion: 5.4
 
 importers:
@@ -1038,7 +1083,7 @@ packages:
 
     #[test]
     fn test_v6_lockfile_differential() {
-        assert_fast_matches_serde(
+        assert_scanner_matches_serde(
             r#"lockfileVersion: '6.0'
 
 importers:
@@ -1061,7 +1106,7 @@ packages:
 
     #[test]
     fn test_time_and_checksums_differential() {
-        assert_fast_matches_serde(
+        assert_scanner_matches_serde(
             r#"lockfileVersion: '9.0'
 pnpmfileChecksum: abc123
 packageExtensionsChecksum: def456
@@ -1188,6 +1233,93 @@ packages:
     }
 
     #[test]
+    fn test_scanner_rejects_what_saphyr_rejects() {
+        // `a: b: c` is a YAML error; accepting it would fabricate a
+        // lockfile where the serde path reports an error.
+        assert!(
+            parse_with_scanner("lockfileVersion: '9.0'\nimporters:\n  .: {}\nx: a: b\n").is_none()
+        );
+        // Plain value ending in a colon is likewise invalid.
+        assert!(
+            parse_with_scanner("lockfileVersion: '9.0'\nimporters:\n  .: {}\nx: a:\n").is_none()
+        );
+    }
+
+    #[test]
+    fn test_scanner_empty_flow_and_null_values() {
+        assert_scanner_matches_serde("lockfileVersion: '9.0'\nimporters:\n  .: {}\n");
+    }
+
+    #[test]
+    fn test_scanner_folded_scalars_differential() {
+        assert_scanner_matches_serde(
+            "lockfileVersion: '9.0'\nimporters:\n  .: {}\npackages:\n  a@1.0.0:\n    resolution: {integrity: sha512-a}\n    deprecated: >-\n      This package is deprecated. Use\n      something else instead.\n\n      Second paragraph here.\n  b@1.0.0:\n    resolution: {integrity: sha512-b}\n    deprecated: >\n      trailing newline kept\n",
+        );
+    }
+
+    #[test]
+    fn test_scanner_literal_scalars_differential() {
+        // Literal blocks (`|`, `|-`) keep line breaks and more-indented
+        // lines verbatim; next.js's lockfile uses `|-` for deprecation
+        // messages.
+        assert_scanner_matches_serde(
+            "lockfileVersion: '9.0'\nimporters:\n  .: {}\npackages:\n  a@1.0.0:\n    resolution: \
+             {integrity: sha512-a}\n    deprecated: |-\n      line one\n      line two\n\n      \
+             after a blank\n        more indented kept verbatim\n  b@1.0.0:\n    resolution: \
+             {integrity: sha512-b}\n    deprecated: |\n      clipped keeps one newline\n",
+        );
+        // A blank separator line after a block scalar (pnpm emits one
+        // between package entries) is discarded by both strip and clip
+        // chomping.
+        assert_scanner_matches_serde(
+            "lockfileVersion: '9.0'\nimporters:\n  .: {}\npackages:\n  a@1.0.0:\n    resolution: \
+             {integrity: sha512-a}\n    deprecated: |-\n      last line\n\n  b@1.0.0:\n    \
+             resolution: {integrity: sha512-b}\n    deprecated: >-\n      folded last\n\n    \
+             engines: {node: '>=10'}\n",
+        );
+        // `|+` keep-chomping stays outside the scanner subset.
+        assert!(
+            parse_with_scanner(
+                "lockfileVersion: '9.0'\nimporters:\n  .: {}\npackages:\n  a@1.0.0:\n    \
+                 resolution: {integrity: sha512-a}\n    deprecated: |+\n      kept\n\n"
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn test_scanner_sequence_forms_differential() {
+        // Block sequence at key indent and deeper, plus flow sequences.
+        assert_scanner_matches_serde(
+            "lockfileVersion: '9.0'\nneverBuiltDependencies:\n- \
+             fsevents\nonlyBuiltDependencies:\n  - esbuild\nimporters:\n  .: {}\npackages:\n  \
+             a@1.0.0:\n    resolution: {integrity: sha512-a}\n    os: [darwin, linux]\n    cpu: \
+             [x64]\n",
+        );
+    }
+
+    #[test]
+    fn test_scanner_quoting_differential() {
+        assert_scanner_matches_serde(
+            "lockfileVersion: '9.0'\nimporters:\n  .:\n    dependencies:\n      '@scope/pkg':\n        specifier: '>=1.0.0'\n        version: 1.0.0\npackages:\n  '@scope/pkg@1.0.0':\n    resolution: {integrity: sha512-a, tarball: 'https://example.com/x, y.tgz'}\n    weird: 'it''s quoted'\n    dquote: \"plain dq\"\n",
+        );
+    }
+
+    #[test]
+    fn test_scanner_comment_and_crlf_handling() {
+        // Full-line comments are meaning-preserving to skip.
+        assert_scanner_matches_serde("lockfileVersion: '9.0'\n# a comment\nimporters:\n  .: {}\n");
+        // Inline comments and CRLF are outside the scanner subset but fine
+        // for the later tiers.
+        let inline_comment = "lockfileVersion: '9.0'\nimporters:\n  .: {}\nx: y # trailing\n";
+        assert!(parse_with_scanner(inline_comment).is_none());
+        assert_fast_matches_serde(inline_comment);
+        let crlf = "lockfileVersion: '9.0'\r\nimporters:\r\n  .: {}\r\n";
+        assert!(parse_with_scanner(crlf).is_none());
+        assert_fast_matches_serde(crlf);
+    }
+
+    #[test]
     fn test_repo_own_lockfile_differential() {
         let manifest_dir = env!("CARGO_MANIFEST_DIR");
         let lockfile_path = std::path::Path::new(manifest_dir)
@@ -1195,6 +1327,6 @@ packages:
             .join("pnpm-lock.yaml");
         let bytes = std::fs::read(&lockfile_path).expect("repo lockfile readable");
         let text = std::str::from_utf8(&bytes).expect("utf8");
-        assert_fast_matches_serde(text);
+        assert_scanner_matches_serde(text);
     }
 }

--- a/crates/turborepo-lockfiles/src/pnpm/data_fast_parse.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data_fast_parse.rs
@@ -1,0 +1,1200 @@
+//! Fast-path parser for pnpm lockfiles built directly on YAML parse events.
+//!
+//! `serde_yaml_ng` (backed by `unsafe-libyaml`) spends the majority of pnpm
+//! lockfile parsing inside the YAML scanner, and its serde layer adds
+//! buffering overhead for the `#[serde(flatten)]`/`#[serde(untagged)]`
+//! shapes in [`PnpmLockfile`]. This module builds the same structs from
+//! `saphyr-parser` events, which scan roughly twice as fast.
+//!
+//! Correctness strategy: this parser is deliberately conservative. Anything
+//! outside the regular, machine-generated subset of YAML that pnpm emits —
+//! anchors, aliases, tags, multiple documents, block scalars, duplicate
+//! keys, exotic numeric forms — aborts the fast path by returning `None`,
+//! and the caller falls back to the serde path. Both paths must produce
+//! equal (`==`) lockfiles for any input the fast path accepts; tests
+//! enforce this differentially.
+
+use std::collections::BTreeMap;
+
+use saphyr_parser::{Event, Parser, ScalarStyle, StrInput};
+use serde_yaml_ng::{Mapping, Number, Value};
+
+use super::{
+    DependenciesMeta, Dependency, DependencyInfo, LockfileSettings, Map, PackageResolution,
+    PackageSnapshot, PackageSnapshotV7, Packages, PatchFile, PnpmLockfile, ProjectSnapshot,
+    Snapshots,
+};
+use crate::pnpm::LockfileVersion;
+
+/// Marker for "this input is outside the supported fast-path subset".
+/// Callers fall back to the serde parser; this is not an error condition.
+struct Unsupported;
+
+impl Unsupported {
+    /// Construct while optionally tracing the bail location. Tracing is
+    /// compiled in but effectively free unless debug logging is enabled;
+    /// knowing *why* a lockfile leaves the fast path matters in the field.
+    #[track_caller]
+    fn here() -> Self {
+        if tracing::enabled!(tracing::Level::DEBUG) {
+            let loc = std::panic::Location::caller();
+            tracing::debug!(
+                "pnpm fast parse unsupported at {}:{}",
+                loc.file(),
+                loc.line()
+            );
+        }
+        Unsupported
+    }
+}
+
+type FResult<T> = Result<T, Unsupported>;
+
+/// Attempt to parse a pnpm lockfile from YAML using the fast event-driven
+/// path. Returns `None` when the input uses YAML constructs outside the
+/// supported subset (or is malformed); the caller must then use the serde
+/// path, which either parses it or reports a proper error.
+pub(super) fn parse(bytes: &[u8]) -> Option<PnpmLockfile> {
+    let text = std::str::from_utf8(bytes).ok()?;
+    let mut events = Events {
+        parser: Parser::new_from_str(text),
+        peeked: None,
+    };
+    parse_lockfile(&mut events).ok()
+}
+
+struct Events<'a> {
+    parser: Parser<'a, StrInput<'a>>,
+    peeked: Option<Event<'a>>,
+}
+
+impl<'a> Events<'a> {
+    fn next(&mut self) -> FResult<Event<'a>> {
+        if let Some(ev) = self.peeked.take() {
+            return Ok(ev);
+        }
+        match self.parser.next() {
+            Some(Ok((ev, _span))) => Ok(ev),
+            Some(Err(_)) | None => Err(Unsupported::here()),
+        }
+    }
+
+    fn peek(&mut self) -> FResult<&Event<'a>> {
+        if self.peeked.is_none() {
+            self.peeked = Some(self.next()?);
+        }
+        self.peeked.as_ref().ok_or(Unsupported)
+    }
+
+    /// Consume the next event and require it to be a scalar without anchor
+    /// or tag, returning its decoded text and style. Block scalars (`|`,
+    /// `>`) are fine here: the parser hands us the spec-decoded value, and
+    /// serde treats any non-plain scalar as a string (pnpm emits folded
+    /// scalars for long `deprecated` messages).
+    fn scalar(&mut self) -> FResult<(String, ScalarStyle)> {
+        match self.next()? {
+            Event::Scalar(value, style, anchor_id, tag) => {
+                if anchor_id != 0 || tag.is_some() {
+                    return Err(Unsupported::here());
+                }
+                Ok((value.into_owned(), style))
+            }
+            _ => Err(Unsupported::here()),
+        }
+    }
+
+    /// Consume a scalar in a string-typed position (map key, `String`
+    /// field, `Map<String, String>` value). Mirrors serde: a plain scalar
+    /// that reads as YAML null fails string deserialization, so it aborts
+    /// the fast path rather than silently becoming a string.
+    fn string(&mut self) -> FResult<String> {
+        let (value, style) = self.scalar()?;
+        if style == ScalarStyle::Plain && is_yaml_null(&value) {
+            return Err(Unsupported::here());
+        }
+        Ok(value)
+    }
+
+    fn mapping_start(&mut self) -> FResult<()> {
+        match self.next()? {
+            Event::MappingStart(anchor_id, tag) if anchor_id == 0 && tag.is_none() => Ok(()),
+            _ => Err(Unsupported::here()),
+        }
+    }
+
+    /// True when the next event ends the current mapping (consumes it).
+    fn at_mapping_end(&mut self) -> FResult<bool> {
+        if matches!(self.peek()?, Event::MappingEnd) {
+            self.next()?;
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    /// Skip a complete node (scalar, sequence, or mapping) without
+    /// interpreting it. Used for unknown fields that serde would ignore.
+    fn skip_node(&mut self) -> FResult<()> {
+        let mut depth = 0usize;
+        loop {
+            match self.next()? {
+                Event::Scalar(_, _, anchor_id, _) => {
+                    if anchor_id != 0 {
+                        return Err(Unsupported::here());
+                    }
+                    if depth == 0 {
+                        return Ok(());
+                    }
+                }
+                Event::SequenceStart(anchor_id, _) | Event::MappingStart(anchor_id, _) => {
+                    if anchor_id != 0 {
+                        return Err(Unsupported::here());
+                    }
+                    depth += 1;
+                }
+                Event::SequenceEnd | Event::MappingEnd => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return Ok(());
+                    }
+                }
+                Event::Alias(_) => return Err(Unsupported::here()),
+                _ => return Err(Unsupported::here()),
+            }
+        }
+    }
+}
+
+fn is_yaml_null(scalar: &str) -> bool {
+    matches!(scalar, "" | "null" | "Null" | "NULL" | "~")
+}
+
+fn parse_bool_scalar(value: &str, style: ScalarStyle) -> FResult<bool> {
+    if style != ScalarStyle::Plain {
+        return Err(Unsupported::here());
+    }
+    match value {
+        "true" | "True" | "TRUE" => Ok(true),
+        "false" | "False" | "FALSE" => Ok(false),
+        _ => Err(Unsupported::here()),
+    }
+}
+
+/// Convert a plain scalar to a `serde_yaml_ng::Value`, mirroring
+/// `serde_yaml_ng`'s untagged scalar typing for the common subset. Exotic
+/// forms it types differently (hex/octal/binary ints, `+` prefixes,
+/// `.inf`/`.nan`, 128-bit integers) abort the fast path.
+fn plain_scalar_to_value(value: String) -> FResult<Value> {
+    if is_yaml_null(&value) {
+        return Ok(Value::Null);
+    }
+    match value.as_str() {
+        "true" | "True" | "TRUE" => return Ok(Value::Bool(true)),
+        "false" | "False" | "FALSE" => return Ok(Value::Bool(false)),
+        _ => {}
+    }
+    let bytes = value.as_bytes();
+    let first = bytes[0];
+
+    // Exotic prefixes serde parses as numbers: bail instead of matching its
+    // radix handling.
+    if value.starts_with('+')
+        || value.starts_with("0x")
+        || value.starts_with("0o")
+        || value.starts_with("0b")
+        || value.starts_with("-0x")
+        || value.starts_with("-0o")
+        || value.starts_with("-0b")
+    {
+        return Err(Unsupported::here());
+    }
+    if matches!(
+        value.as_str(),
+        ".inf" | ".Inf" | ".INF" | "-.inf" | "-.Inf" | "-.INF" | ".nan" | ".NaN" | ".NAN"
+    ) {
+        return Err(Unsupported::here());
+    }
+
+    let digits = if first == b'-' { &bytes[1..] } else { bytes };
+    let all_digits = !digits.is_empty() && digits.iter().all(|b| b.is_ascii_digit());
+    // YAML 1.2: leading zeros make it a string, not a number.
+    let leading_zero_string = digits.len() > 1 && digits[0] == b'0';
+
+    if all_digits && !leading_zero_string {
+        if first == b'-' {
+            if let Ok(int) = value.parse::<i64>() {
+                return Ok(Value::Number(Number::from(int)));
+            }
+        } else if let Ok(int) = value.parse::<u64>() {
+            return Ok(Value::Number(Number::from(int)));
+        }
+        // Out of 64-bit range: serde falls through to i128/u128 handling.
+        return Err(Unsupported::here());
+    }
+
+    if !(all_digits && leading_zero_string)
+        && let Ok(float) = value.parse::<f64>()
+        && float.is_finite()
+    {
+        return Ok(Value::Number(Number::from(float)));
+    }
+
+    Ok(Value::String(value))
+}
+
+/// Build a `serde_yaml_ng::Value` from events for unknown subtrees that
+/// round-trip through `other` fields.
+fn parse_value(events: &mut Events) -> FResult<Value> {
+    match events.next()? {
+        Event::Scalar(value, style, anchor_id, tag) => {
+            if anchor_id != 0 || tag.is_some() {
+                return Err(Unsupported::here());
+            }
+            match style {
+                ScalarStyle::Plain => plain_scalar_to_value(value.into_owned()),
+                // Quoted and block scalars are always strings under serde's
+                // untagged typing.
+                _ => Ok(Value::String(value.into_owned())),
+            }
+        }
+        Event::SequenceStart(anchor_id, tag) => {
+            if anchor_id != 0 || tag.is_some() {
+                return Err(Unsupported::here());
+            }
+            let mut seq = Vec::new();
+            while !matches!(events.peek()?, Event::SequenceEnd) {
+                seq.push(parse_value(events)?);
+            }
+            events.next()?;
+            Ok(Value::Sequence(seq))
+        }
+        Event::MappingStart(anchor_id, tag) => {
+            if anchor_id != 0 || tag.is_some() {
+                return Err(Unsupported::here());
+            }
+            let mut mapping = Mapping::new();
+            loop {
+                if matches!(events.peek()?, Event::MappingEnd) {
+                    events.next()?;
+                    break;
+                }
+                let key = parse_value(events)?;
+                let value = parse_value(events)?;
+                // serde_yaml_ng errors on duplicate mapping keys when
+                // deserializing a Value; mirror by falling back.
+                if mapping.insert(key, value).is_some() {
+                    return Err(Unsupported::here());
+                }
+            }
+            Ok(Value::Mapping(mapping))
+        }
+        _ => Err(Unsupported::here()),
+    }
+}
+
+/// Parse `Map<String, String>` (BTreeMap semantics: duplicate keys last-win
+/// under serde, but pnpm never emits duplicates; abort to stay exact).
+fn parse_string_map(events: &mut Events) -> FResult<BTreeMap<String, String>> {
+    events.mapping_start()?;
+    let mut map = BTreeMap::new();
+    while !events.at_mapping_end()? {
+        let key = events.string()?;
+        let value = events.string()?;
+        if map.insert(key, value).is_some() {
+            return Err(Unsupported::here());
+        }
+    }
+    Ok(map)
+}
+
+fn parse_string_seq(events: &mut Events) -> FResult<Vec<String>> {
+    match events.next()? {
+        Event::SequenceStart(anchor_id, tag) if anchor_id == 0 && tag.is_none() => {}
+        _ => return Err(Unsupported::here()),
+    }
+    let mut seq = Vec::new();
+    while !matches!(events.peek()?, Event::SequenceEnd) {
+        seq.push(events.string()?);
+    }
+    events.next()?;
+    Ok(seq)
+}
+
+/// A dependency section of an importer, before deciding between the
+/// pre-v6 (`name -> version` strings) and v6 (`name -> {specifier,
+/// version}`) representations.
+enum DepSection {
+    Strings(BTreeMap<String, String>),
+    Structured(BTreeMap<String, Dependency>),
+    /// `{}` — compatible with either representation.
+    Empty,
+}
+
+fn parse_dep_section(events: &mut Events) -> FResult<DepSection> {
+    events.mapping_start()?;
+    if events.at_mapping_end()? {
+        return Ok(DepSection::Empty);
+    }
+    let first_key = events.string()?;
+    match events.peek()? {
+        Event::Scalar(..) => {
+            let mut map = BTreeMap::new();
+            map.insert(first_key, events.string()?);
+            while !events.at_mapping_end()? {
+                let key = events.string()?;
+                if map.insert(key, events.string()?).is_some() {
+                    return Err(Unsupported::here());
+                }
+            }
+            Ok(DepSection::Strings(map))
+        }
+        Event::MappingStart(..) => {
+            let mut map = BTreeMap::new();
+            map.insert(first_key, parse_dependency(events)?);
+            while !events.at_mapping_end()? {
+                let key = events.string()?;
+                if map.insert(key, parse_dependency(events)?).is_some() {
+                    return Err(Unsupported::here());
+                }
+            }
+            Ok(DepSection::Structured(map))
+        }
+        _ => Err(Unsupported::here()),
+    }
+}
+
+fn parse_dependency(events: &mut Events) -> FResult<Dependency> {
+    events.mapping_start()?;
+    let mut specifier = None;
+    let mut version = None;
+    while !events.at_mapping_end()? {
+        let key = events.string()?;
+        match key.as_str() {
+            "specifier" => set_once(&mut specifier, events.string()?)?,
+            "version" => set_once(&mut version, events.string()?)?,
+            _ => events.skip_node()?,
+        }
+    }
+    // Both fields are required by the serde struct; missing means the serde
+    // path errors, so fall back and let it produce that error.
+    Ok(Dependency {
+        specifier: specifier.ok_or_else(Unsupported::here)?,
+        version: version.ok_or_else(Unsupported::here)?,
+    })
+}
+
+fn set_once<T>(slot: &mut Option<T>, value: T) -> FResult<()> {
+    // serde rejects duplicate struct fields.
+    if slot.replace(value).is_some() {
+        return Err(Unsupported::here());
+    }
+    Ok(())
+}
+
+fn parse_project_snapshot(events: &mut Events) -> FResult<ProjectSnapshot> {
+    events.mapping_start()?;
+    let mut specifiers = None;
+    let mut dependencies = None;
+    let mut optional_dependencies = None;
+    let mut dev_dependencies = None;
+    let mut dependencies_meta = None;
+    let mut publish_directory = None;
+
+    while !events.at_mapping_end()? {
+        let key = events.string()?;
+        match key.as_str() {
+            "specifiers" => set_once(&mut specifiers, parse_string_map(events)?)?,
+            "dependencies" => set_once(&mut dependencies, parse_dep_section(events)?)?,
+            "optionalDependencies" => {
+                set_once(&mut optional_dependencies, parse_dep_section(events)?)?
+            }
+            "devDependencies" => set_once(&mut dev_dependencies, parse_dep_section(events)?)?,
+            "dependenciesMeta" => {
+                set_once(&mut dependencies_meta, parse_dependencies_meta(events)?)?
+            }
+            "publishDirectory" => set_once(&mut publish_directory, events.string()?)?,
+            // ProjectSnapshot's flatten chain silently ignores unknown keys.
+            _ => events.skip_node()?,
+        }
+    }
+
+    // Mirror serde's untagged resolution order for DependencyInfo: PreV6 is
+    // declared first, so it wins whenever every present section deserializes
+    // as plain strings (including when all are absent or empty). A single
+    // structured section forces V6; a conflict (structured + strings) fails
+    // both variants under serde, so fall back.
+    let any_structured = [&dependencies, &optional_dependencies, &dev_dependencies]
+        .into_iter()
+        .flatten()
+        .any(|s| matches!(s, DepSection::Structured(_)));
+    let any_strings = [&dependencies, &optional_dependencies, &dev_dependencies]
+        .into_iter()
+        .flatten()
+        .any(|s| matches!(s, DepSection::Strings(_)));
+    if any_structured && any_strings {
+        return Err(Unsupported::here());
+    }
+    if any_structured && specifiers.is_some() {
+        return Err(Unsupported::here());
+    }
+
+    let dependencies_info = if any_structured {
+        DependencyInfo::V6 {
+            dependencies: dependencies.map(into_structured).transpose()?,
+            optional_dependencies: optional_dependencies.map(into_structured).transpose()?,
+            dev_dependencies: dev_dependencies.map(into_structured).transpose()?,
+        }
+    } else {
+        DependencyInfo::PreV6 {
+            specifiers,
+            dependencies: dependencies.map(into_strings).transpose()?,
+            optional_dependencies: optional_dependencies.map(into_strings).transpose()?,
+            dev_dependencies: dev_dependencies.map(into_strings).transpose()?,
+        }
+    };
+
+    Ok(ProjectSnapshot {
+        dependencies: dependencies_info,
+        dependencies_meta,
+        publish_directory,
+    })
+}
+
+fn into_strings(section: DepSection) -> FResult<BTreeMap<String, String>> {
+    match section {
+        DepSection::Strings(map) => Ok(map),
+        DepSection::Empty => Ok(BTreeMap::new()),
+        DepSection::Structured(_) => Err(Unsupported::here()),
+    }
+}
+
+fn into_structured(section: DepSection) -> FResult<BTreeMap<String, Dependency>> {
+    match section {
+        DepSection::Structured(map) => Ok(map),
+        DepSection::Empty => Ok(BTreeMap::new()),
+        DepSection::Strings(_) => Err(Unsupported::here()),
+    }
+}
+
+fn parse_dependencies_meta(events: &mut Events) -> FResult<Map<String, DependenciesMeta>> {
+    events.mapping_start()?;
+    let mut map = BTreeMap::new();
+    while !events.at_mapping_end()? {
+        let key = events.string()?;
+        events.mapping_start()?;
+        let mut injected = None;
+        let mut node = None;
+        let mut patch = None;
+        while !events.at_mapping_end()? {
+            let field = events.string()?;
+            match field.as_str() {
+                "injected" => {
+                    let (value, style) = events.scalar()?;
+                    set_once(&mut injected, parse_bool_scalar(&value, style)?)?;
+                }
+                "node" => set_once(&mut node, events.string()?)?,
+                "patch" => set_once(&mut patch, events.string()?)?,
+                _ => events.skip_node()?,
+            }
+        }
+        if map
+            .insert(
+                key,
+                DependenciesMeta {
+                    injected,
+                    node,
+                    patch,
+                },
+            )
+            .is_some()
+        {
+            return Err(Unsupported::here());
+        }
+    }
+    Ok(map)
+}
+
+fn parse_resolution(events: &mut Events) -> FResult<PackageResolution> {
+    events.mapping_start()?;
+    let mut type_field = None;
+    let mut integrity = None;
+    let mut tarball = None;
+    let mut directory = None;
+    let mut repo = None;
+    let mut commit = None;
+    while !events.at_mapping_end()? {
+        let key = events.string()?;
+        match key.as_str() {
+            "type" => set_once(&mut type_field, events.string()?)?,
+            "integrity" => set_once(&mut integrity, events.string()?)?,
+            "tarball" => set_once(&mut tarball, events.string()?)?,
+            "directory" => set_once(&mut directory, events.string()?)?,
+            "repo" => set_once(&mut repo, events.string()?)?,
+            "commit" => set_once(&mut commit, events.string()?)?,
+            _ => events.skip_node()?,
+        }
+    }
+    Ok(PackageResolution {
+        type_field,
+        integrity,
+        tarball,
+        directory,
+        repo,
+        commit,
+    })
+}
+
+/// Fields shared by `packages` entries (which flatten a
+/// [`PackageSnapshotV7`]) and `snapshots` entries.
+struct SnapshotV7Fields {
+    optional: Option<bool>,
+    dependencies: Option<Map<String, String>>,
+    optional_dependencies: Option<Map<String, String>>,
+    transitive_peer_dependencies: Option<Vec<String>>,
+}
+
+impl SnapshotV7Fields {
+    fn new() -> Self {
+        Self {
+            optional: None,
+            dependencies: None,
+            optional_dependencies: None,
+            transitive_peer_dependencies: None,
+        }
+    }
+
+    /// Try to consume a known V7 snapshot field. Returns false when the key
+    /// isn't part of the snapshot shape.
+    fn consume(&mut self, key: &str, events: &mut Events) -> FResult<bool> {
+        match key {
+            "optional" => {
+                let (value, style) = events.scalar()?;
+                set_once(&mut self.optional, parse_bool_scalar(&value, style)?)?;
+            }
+            "dependencies" => set_once(&mut self.dependencies, parse_string_map(events)?)?,
+            "optionalDependencies" => {
+                set_once(&mut self.optional_dependencies, parse_string_map(events)?)?
+            }
+            "transitivePeerDependencies" => set_once(
+                &mut self.transitive_peer_dependencies,
+                parse_string_seq(events)?,
+            )?,
+            _ => return Ok(false),
+        }
+        Ok(true)
+    }
+
+    fn build(self) -> PackageSnapshotV7 {
+        PackageSnapshotV7 {
+            optional: self.optional.unwrap_or_default(),
+            dependencies: self.dependencies,
+            optional_dependencies: self.optional_dependencies,
+            transitive_peer_dependencies: self.transitive_peer_dependencies,
+        }
+    }
+}
+
+fn parse_package_snapshot(events: &mut Events) -> FResult<PackageSnapshot> {
+    events.mapping_start()?;
+    let mut resolution = None;
+    let mut id = None;
+    let mut name = None;
+    let mut version = None;
+    let mut patched = None;
+    let mut v7 = SnapshotV7Fields::new();
+    let mut other = Map::new();
+
+    while !events.at_mapping_end()? {
+        let key = events.string()?;
+        match key.as_str() {
+            "resolution" => set_once(&mut resolution, parse_resolution(events)?)?,
+            "id" => set_once(&mut id, events.string()?)?,
+            "name" => set_once(&mut name, events.string()?)?,
+            "version" => set_once(&mut version, events.string()?)?,
+            "patched" => {
+                let (value, style) = events.scalar()?;
+                set_once(&mut patched, parse_bool_scalar(&value, style)?)?;
+            }
+            _ => {
+                if !v7.consume(&key, events)? {
+                    let value = parse_value(events)?;
+                    if other.insert(key, value).is_some() {
+                        return Err(Unsupported::here());
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(PackageSnapshot {
+        resolution: resolution.ok_or_else(Unsupported::here)?,
+        id,
+        name,
+        version,
+        snapshot: v7.build(),
+        patched,
+        other,
+    })
+}
+
+fn parse_snapshot_v7(events: &mut Events) -> FResult<PackageSnapshotV7> {
+    events.mapping_start()?;
+    let mut v7 = SnapshotV7Fields::new();
+    while !events.at_mapping_end()? {
+        let key = events.string()?;
+        if !v7.consume(&key, events)? {
+            events.skip_node()?;
+        }
+    }
+    Ok(v7.build())
+}
+
+fn parse_packages(events: &mut Events) -> FResult<Packages> {
+    events.mapping_start()?;
+    let mut map = BTreeMap::new();
+    while !events.at_mapping_end()? {
+        let key = events.string()?;
+        if map.insert(key, parse_package_snapshot(events)?).is_some() {
+            return Err(Unsupported::here());
+        }
+    }
+    Ok(map)
+}
+
+fn parse_snapshots(events: &mut Events) -> FResult<Snapshots> {
+    events.mapping_start()?;
+    let mut map = BTreeMap::new();
+    while !events.at_mapping_end()? {
+        let key = events.string()?;
+        if map.insert(key, parse_snapshot_v7(events)?).is_some() {
+            return Err(Unsupported::here());
+        }
+    }
+    Ok(map)
+}
+
+fn parse_importers(events: &mut Events) -> FResult<BTreeMap<String, ProjectSnapshot>> {
+    events.mapping_start()?;
+    let mut map = BTreeMap::new();
+    while !events.at_mapping_end()? {
+        let key = events.string()?;
+        if map.insert(key, parse_project_snapshot(events)?).is_some() {
+            return Err(Unsupported::here());
+        }
+    }
+    Ok(map)
+}
+
+fn parse_patched_dependencies(events: &mut Events) -> FResult<Map<String, PatchFile>> {
+    events.mapping_start()?;
+    let mut map = BTreeMap::new();
+    while !events.at_mapping_end()? {
+        let key = events.string()?;
+        let patch = match events.peek()? {
+            Event::Scalar(..) => PatchFile::Hash(events.string()?),
+            Event::MappingStart(..) => {
+                events.mapping_start()?;
+                let mut path = None;
+                let mut hash = None;
+                while !events.at_mapping_end()? {
+                    let field = events.string()?;
+                    match field.as_str() {
+                        "path" => set_once(&mut path, events.string()?)?,
+                        "hash" => set_once(&mut hash, events.string()?)?,
+                        _ => events.skip_node()?,
+                    }
+                }
+                PatchFile::PathAndHash {
+                    path: path.ok_or_else(Unsupported::here)?,
+                    hash: hash.ok_or_else(Unsupported::here)?,
+                }
+            }
+            _ => return Err(Unsupported::here()),
+        };
+        if map.insert(key, patch).is_some() {
+            return Err(Unsupported::here());
+        }
+    }
+    Ok(map)
+}
+
+fn parse_catalogs(events: &mut Events) -> FResult<Map<String, Map<String, Dependency>>> {
+    events.mapping_start()?;
+    let mut map = BTreeMap::new();
+    while !events.at_mapping_end()? {
+        let key = events.string()?;
+        events.mapping_start()?;
+        let mut catalog = BTreeMap::new();
+        while !events.at_mapping_end()? {
+            let name = events.string()?;
+            if catalog.insert(name, parse_dependency(events)?).is_some() {
+                return Err(Unsupported::here());
+            }
+        }
+        if map.insert(key, catalog).is_some() {
+            return Err(Unsupported::here());
+        }
+    }
+    Ok(map)
+}
+
+fn parse_settings(events: &mut Events) -> FResult<LockfileSettings> {
+    events.mapping_start()?;
+    let mut auto_install_peers = None;
+    let mut exclude_links_from_lockfile = None;
+    let mut inject_workspace_packages = None;
+    let mut dedupe_peers = None;
+    let mut peers_suffix_max_length = None;
+    while !events.at_mapping_end()? {
+        let key = events.string()?;
+        match key.as_str() {
+            "autoInstallPeers" => {
+                let (value, style) = events.scalar()?;
+                set_once(&mut auto_install_peers, parse_bool_scalar(&value, style)?)?;
+            }
+            "excludeLinksFromLockfile" => {
+                let (value, style) = events.scalar()?;
+                set_once(
+                    &mut exclude_links_from_lockfile,
+                    parse_bool_scalar(&value, style)?,
+                )?;
+            }
+            "injectWorkspacePackages" => {
+                let (value, style) = events.scalar()?;
+                set_once(
+                    &mut inject_workspace_packages,
+                    parse_bool_scalar(&value, style)?,
+                )?;
+            }
+            "dedupePeers" => {
+                let (value, style) = events.scalar()?;
+                set_once(&mut dedupe_peers, parse_bool_scalar(&value, style)?)?;
+            }
+            "peersSuffixMaxLength" => {
+                let (value, style) = events.scalar()?;
+                if style != ScalarStyle::Plain {
+                    return Err(Unsupported::here());
+                }
+                set_once(
+                    &mut peers_suffix_max_length,
+                    value.parse::<u32>().map_err(|_| Unsupported::here())?,
+                )?;
+            }
+            _ => events.skip_node()?,
+        }
+    }
+    Ok(LockfileSettings {
+        auto_install_peers,
+        exclude_links_from_lockfile,
+        inject_workspace_packages,
+        dedupe_peers,
+        peers_suffix_max_length,
+    })
+}
+
+fn parse_lockfile_version(events: &mut Events) -> FResult<LockfileVersion> {
+    let (value, style) = events.scalar()?;
+    match style {
+        // Mirror serde's untagged StringOrNum: a plain scalar deserializes
+        // as f32 when possible (`5.4` → Float format via f32::to_string).
+        ScalarStyle::Plain => match value.parse::<f32>() {
+            Ok(num) => Ok(LockfileVersion::from(num)),
+            Err(_) => Ok(LockfileVersion::from(value)),
+        },
+        ScalarStyle::SingleQuoted | ScalarStyle::DoubleQuoted => Ok(LockfileVersion::from(value)),
+        _ => Err(Unsupported::here()),
+    }
+}
+
+fn parse_lockfile(events: &mut Events) -> FResult<PnpmLockfile> {
+    // StreamStart, then exactly one document.
+    match events.next()? {
+        Event::StreamStart => {}
+        _ => return Err(Unsupported::here()),
+    }
+    match events.next()? {
+        Event::DocumentStart(_) => {}
+        _ => return Err(Unsupported::here()),
+    }
+
+    events.mapping_start()?;
+
+    let mut lockfile_version = None;
+    let mut settings = None;
+    let mut catalogs = None;
+    let mut pnpmfile_checksum = None;
+    let mut never_built_dependencies = None;
+    let mut only_built_dependencies = None;
+    let mut ignored_optional_dependencies = None;
+    let mut overrides = None;
+    let mut package_extensions_checksum = None;
+    let mut patched_dependencies = None;
+    let mut importers = None;
+    let mut packages = None;
+    let mut snapshots = None;
+    let mut time = None;
+
+    while !events.at_mapping_end()? {
+        let key = events.string()?;
+        match key.as_str() {
+            "lockfileVersion" => set_once(&mut lockfile_version, parse_lockfile_version(events)?)?,
+            "settings" => set_once(&mut settings, parse_settings(events)?)?,
+            "catalogs" => set_once(&mut catalogs, parse_catalogs(events)?)?,
+            "pnpmfileChecksum" => set_once(&mut pnpmfile_checksum, events.string()?)?,
+            "neverBuiltDependencies" => {
+                set_once(&mut never_built_dependencies, parse_string_seq(events)?)?
+            }
+            "onlyBuiltDependencies" => {
+                set_once(&mut only_built_dependencies, parse_string_seq(events)?)?
+            }
+            "ignoredOptionalDependencies" => set_once(
+                &mut ignored_optional_dependencies,
+                parse_string_seq(events)?,
+            )?,
+            "overrides" => set_once(&mut overrides, parse_string_map(events)?)?,
+            "packageExtensionsChecksum" => {
+                set_once(&mut package_extensions_checksum, events.string()?)?
+            }
+            "patchedDependencies" => set_once(
+                &mut patched_dependencies,
+                parse_patched_dependencies(events)?,
+            )?,
+            "importers" => set_once(&mut importers, parse_importers(events)?)?,
+            "packages" => set_once(&mut packages, parse_packages(events)?)?,
+            "snapshots" => set_once(&mut snapshots, parse_snapshots(events)?)?,
+            "time" => set_once(&mut time, parse_string_map(events)?)?,
+            // Unknown root keys are ignored by the serde struct.
+            _ => events.skip_node()?,
+        }
+    }
+
+    // Exactly one document: anything after DocumentEnd other than stream end
+    // means multi-document input (leading documents), handled by the serde
+    // path.
+    match events.next()? {
+        Event::DocumentEnd => {}
+        _ => return Err(Unsupported::here()),
+    }
+    match events.next()? {
+        Event::StreamEnd => {}
+        _ => return Err(Unsupported::here()),
+    }
+
+    Ok(PnpmLockfile {
+        lockfile_version: lockfile_version.ok_or_else(Unsupported::here)?,
+        cached_version: Default::default(),
+        leading_documents: Vec::new(),
+        settings,
+        catalogs,
+        pnpmfile_checksum,
+        never_built_dependencies,
+        only_built_dependencies,
+        ignored_optional_dependencies,
+        overrides,
+        package_extensions_checksum,
+        patched_dependencies,
+        // `importers` has no `#[serde(default)]`; a missing field is a serde
+        // error, so let the fallback path report it.
+        importers: importers.ok_or_else(Unsupported::here)?,
+        packages,
+        snapshots,
+        dependency_index: rustc_hash::FxHashMap::default(),
+        time,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    /// Parse via the fast path (applying the same post-parse steps as
+    /// `from_bytes`) and via the serde oracle; both must succeed and agree.
+    fn assert_fast_matches_serde(yaml: &str) {
+        let mut fast = parse(yaml.as_bytes()).expect("fast path must accept this input");
+        fast.cached_version = fast.compute_version();
+        fast.build_dependency_index();
+        let serde = PnpmLockfile::from_bytes_via_serde(yaml.as_bytes())
+            .expect("serde path must accept this input");
+        assert_eq!(fast, serde);
+
+        // Round-trip fidelity must match too: prune re-encodes lockfiles.
+        assert_eq!(
+            String::from_utf8(crate::Lockfile::encode(&fast).expect("fast encodes")).ok(),
+            String::from_utf8(crate::Lockfile::encode(&serde).expect("serde encodes")).ok(),
+        );
+    }
+
+    fn assert_falls_back(yaml: &str) {
+        assert!(
+            parse(yaml.as_bytes()).is_none(),
+            "input should be outside the fast-path subset"
+        );
+    }
+
+    #[test]
+    fn test_v9_lockfile_differential() {
+        assert_fast_matches_serde(
+            r#"lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+catalogs:
+  default:
+    react:
+      specifier: ^19.0.0
+      version: 19.0.0
+
+overrides:
+  semver: 7.5.3
+
+patchedDependencies:
+  is-even@1.0.0:
+    hash: abcdef123456
+    path: patches/is-even@1.0.0.patch
+  is-odd: legacyhashonly
+
+importers:
+
+  .:
+    dependencies:
+      express:
+        specifier: 4.18.2
+        version: 4.18.2
+    devDependencies:
+      turbo:
+        specifier: canary
+        version: 2.0.0
+
+  apps/empty: {}
+
+  apps/meta:
+    dependencies:
+      ui:
+        specifier: workspace:*
+        version: link:../../packages/ui
+    dependenciesMeta:
+      ui:
+        injected: true
+    publishDirectory: dist
+
+packages:
+
+  express@4.18.2:
+    resolution: {integrity: sha512-aaa}
+    engines: {node: '>= 0.10.0'}
+    hasBin: true
+    deprecated: use something else
+    cpu: [x64, arm64]
+    peerDependencies:
+      react: '>=16'
+    peerDependenciesMeta:
+      react:
+        optional: true
+
+  turbo@2.0.0:
+    resolution: {integrity: sha512-bbb}
+    version: 2.0.0-canary.1
+    name: turbo
+    optional: true
+
+snapshots:
+
+  express@4.18.2:
+    dependencies:
+      body-parser: 1.20.1
+    transitivePeerDependencies:
+      - supports-color
+
+  turbo@2.0.0:
+    optional: true
+"#,
+        );
+    }
+
+    #[test]
+    fn test_v5_lockfile_differential() {
+        assert_fast_matches_serde(
+            r#"lockfileVersion: 5.4
+
+importers:
+
+  .:
+    specifiers:
+      lodash: ^4.17.21
+    dependencies:
+      lodash: 4.17.21
+
+packages:
+
+  /lodash/4.17.21:
+    resolution: {integrity: sha512-ccc}
+    dev: false
+"#,
+        );
+    }
+
+    #[test]
+    fn test_v6_lockfile_differential() {
+        assert_fast_matches_serde(
+            r#"lockfileVersion: '6.0'
+
+importers:
+
+  .:
+    dependencies:
+      chalk:
+        specifier: ^5.0.0
+        version: 5.3.0
+
+packages:
+
+  /chalk@5.3.0:
+    resolution: {integrity: sha512-ddd}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+    dev: false
+"#,
+        );
+    }
+
+    #[test]
+    fn test_time_and_checksums_differential() {
+        assert_fast_matches_serde(
+            r#"lockfileVersion: '9.0'
+pnpmfileChecksum: abc123
+packageExtensionsChecksum: def456
+neverBuiltDependencies:
+  - fsevents
+onlyBuiltDependencies:
+  - esbuild
+importers:
+  .: {}
+time:
+  /lodash/4.17.21: '2021-02-20T15:42:16.891Z'
+"#,
+        );
+    }
+
+    #[test]
+    fn test_unknown_fields_are_ignored_like_serde() {
+        assert_fast_matches_serde(
+            r#"lockfileVersion: '9.0'
+someFutureRootField:
+  nested: [1, two, false]
+importers:
+  .:
+    someFutureImporterField: hello
+packages:
+  a@1.0.0:
+    resolution: {integrity: sha512-a, futureResolutionField: x}
+    futureCustomField:
+      deeply:
+        nested: true
+"#,
+        );
+    }
+
+    #[test]
+    fn test_scalar_typing_in_other_fields() {
+        // `other` passthrough values must type plain scalars exactly like
+        // serde_yaml_ng: ints, floats, bools, nulls, leading-zero strings.
+        assert_fast_matches_serde(
+            r#"lockfileVersion: '9.0'
+importers:
+  .: {}
+packages:
+  a@1.0.0:
+    resolution: {integrity: sha512-a}
+    someInt: 42
+    someNegative: -7
+    someFloat: 1.5
+    someBool: true
+    someNull: ~
+    leadingZeros: 0123
+    quotedNumber: '42'
+    someList: [1, 2.5, x]
+"#,
+        );
+    }
+
+    #[test]
+    fn test_block_scalars_differential() {
+        // pnpm emits folded scalars for long deprecated messages. Both
+        // parsers must decode block scalars (including chomping variants)
+        // to identical strings.
+        assert_fast_matches_serde(
+            r#"lockfileVersion: '9.0'
+importers:
+  .: {}
+packages:
+  a@1.0.0:
+    resolution: {integrity: sha512-a}
+    deprecated: >-
+      This package has been deprecated in favor of something-else.
+      Please migrate at your earliest convenience.
+  b@1.0.0:
+    resolution: {integrity: sha512-b}
+    deprecated: |
+      literal block
+      keeps newlines
+  c@1.0.0:
+    resolution: {integrity: sha512-c}
+    deprecated: |+
+      keep trailing
+
+  d@1.0.0:
+    resolution: {integrity: sha512-d}
+    deprecated: >
+      folded with trailing newline
+"#,
+        );
+    }
+
+    #[test]
+    fn test_multi_document_falls_back() {
+        assert_falls_back("---\nleading: doc\n---\nlockfileVersion: '9.0'\nimporters:\n  .: {}\n");
+    }
+
+    #[test]
+    fn test_anchors_fall_back() {
+        assert_falls_back("lockfileVersion: '9.0'\nimporters:\n  .: {}\nx: &a hello\ny: *a\n");
+    }
+
+    #[test]
+    fn test_duplicate_keys_fall_back() {
+        assert_falls_back("lockfileVersion: '9.0'\nimporters:\n  .: {}\n  .: {}\n");
+    }
+
+    #[test]
+    fn test_hex_int_falls_back() {
+        assert_falls_back(
+            "lockfileVersion: '9.0'\nimporters:\n  .: {}\npackages:\n  a@1.0.0:\n    resolution: \
+             {integrity: sha512-a}\n    weird: 0x2A\n",
+        );
+    }
+
+    #[test]
+    fn test_null_in_string_position_falls_back() {
+        // serde errors on `~` where a String is expected; the fast path must
+        // not silently produce a different result.
+        assert_falls_back("lockfileVersion: '9.0'\nimporters:\n  .: {}\noverrides:\n  foo: ~\n");
+    }
+
+    #[test]
+    fn test_missing_importers_falls_back() {
+        assert_falls_back("lockfileVersion: '9.0'\n");
+    }
+
+    #[test]
+    fn test_repo_own_lockfile_differential() {
+        let manifest_dir = env!("CARGO_MANIFEST_DIR");
+        let lockfile_path = std::path::Path::new(manifest_dir)
+            .join("../..")
+            .join("pnpm-lock.yaml");
+        let bytes = std::fs::read(&lockfile_path).expect("repo lockfile readable");
+        let text = std::str::from_utf8(&bytes).expect("utf8");
+        assert_fast_matches_serde(text);
+    }
+}

--- a/crates/turborepo-lockfiles/src/pnpm/data_scanner.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data_scanner.rs
@@ -1,0 +1,650 @@
+//! Structural line scanner for the pnpm lockfile YAML subset.
+//!
+//! pnpm-lock.yaml is machine-generated, line-oriented YAML: block mappings
+//! indented with spaces, plain or single-quoted scalars, one-line flow
+//! collections for `resolution:`/`engines:`/`os:`, block sequences of
+//! scalars, and the occasional folded (`>-`) scalar for `deprecated:`
+//! messages. A general YAML scanner spends most of lockfile parsing in its
+//! state machine; this scanner instead walks the input line by line with
+//! `memchr`, emitting the same [`saphyr_parser::Event`] stream the semantic
+//! layer in `data_fast_parse` already consumes.
+//!
+//! Correctness strategy is inherited from the fast-parse tier: anything
+//! outside the shapes this scanner fully understands returns
+//! [`Unsupported`], and the caller falls back to the saphyr event parser
+//! (and from there to serde). The scanner must never *accept* input with a
+//! different meaning than saphyr would assign — differential tests enforce
+//! scanner == saphyr == serde on everything the scanner accepts. Notably,
+//! anything saphyr would *reject* (e.g. `a: b: c`) must be rejected here
+//! too, since accepting it would fabricate a lockfile where the serde path
+//! reports an error.
+
+use std::borrow::Cow;
+
+use saphyr_parser::{Event, ScalarStyle};
+
+use super::Unsupported;
+
+type FResult<T> = Result<T, Unsupported>;
+
+/// Block collection kinds tracked on the indent stack.
+#[derive(Clone, Copy, PartialEq)]
+enum Kind {
+    Mapping,
+    Sequence,
+}
+
+enum State {
+    /// Nothing emitted yet.
+    Start,
+    /// Inside the document; block structure tracked by `stack`.
+    Body,
+    /// Document closed; emit `StreamEnd` next.
+    Closing,
+    /// Everything emitted.
+    Done,
+}
+
+pub(super) struct LineScanner<'a> {
+    text: &'a str,
+    /// Byte offset of the next unread character.
+    pos: usize,
+    /// Events produced by the last processed line, drained in order.
+    queue: std::collections::VecDeque<Event<'a>>,
+    /// Open block collections as (indent, kind).
+    stack: Vec<(usize, Kind)>,
+    /// Set after a `key:` line whose value, if any, is a nested block
+    /// collection introduced by the next line's indentation.
+    pending_child: Option<usize>,
+    state: State,
+}
+
+impl<'a> LineScanner<'a> {
+    pub(super) fn new(text: &'a str) -> Self {
+        Self {
+            text,
+            pos: 0,
+            // A line yields at most a handful of events (flow mappings emit
+            // start + members + end).
+            queue: std::collections::VecDeque::with_capacity(16),
+            stack: Vec::new(),
+            pending_child: None,
+            state: State::Start,
+        }
+    }
+
+    pub(super) fn next_event(&mut self) -> FResult<Event<'a>> {
+        loop {
+            if let Some(ev) = self.queue.pop_front() {
+                return Ok(ev);
+            }
+            match self.state {
+                State::Done => return Err(Unsupported::here()),
+                State::Closing => {
+                    self.state = State::Done;
+                    return Ok(Event::StreamEnd);
+                }
+                State::Start | State::Body => self.advance()?,
+            }
+        }
+    }
+
+    /// Consume input lines until at least one event is queued or the
+    /// document is finished.
+    fn advance(&mut self) -> FResult<()> {
+        let Some((indent, content)) = self.next_content_line()? else {
+            // EOF: resolve any pending empty value, close open collections
+            // and the document.
+            if matches!(self.state, State::Start) {
+                // Empty input isn't a mapping; let the fallback error.
+                return Err(Unsupported::here());
+            }
+            if self.pending_child.take().is_some() {
+                self.queue.push_back(null_scalar());
+            }
+            while let Some((_, kind)) = self.stack.pop() {
+                self.queue.push_back(end_event(kind));
+            }
+            self.queue.push_back(Event::DocumentEnd);
+            self.state = State::Closing;
+            return Ok(());
+        };
+
+        if matches!(self.state, State::Start) {
+            if indent != 0 || is_document_marker(content) {
+                // Leading documents / weird openings: serde handles them.
+                return Err(Unsupported::here());
+            }
+            self.queue.push_back(Event::StreamStart);
+            self.queue.push_back(Event::DocumentStart(false));
+            self.queue.push_back(Event::MappingStart(0, None));
+            self.stack.push((0, Kind::Mapping));
+            self.state = State::Body;
+        } else if is_document_marker(content) {
+            // Multi-document input.
+            return Err(Unsupported::here());
+        }
+
+        // A `key:` line opens a child collection only if the next content
+        // line is more deeply indented (or is a sequence item at the key's
+        // own indent). Otherwise the value was an empty scalar.
+        if let Some(key_indent) = self.pending_child.take() {
+            if indent > key_indent {
+                let kind = if is_sequence_item(content) {
+                    Kind::Sequence
+                } else {
+                    Kind::Mapping
+                };
+                self.queue.push_back(start_event(kind));
+                self.stack.push((indent, kind));
+            } else if indent == key_indent && is_sequence_item(content) {
+                self.queue.push_back(start_event(Kind::Sequence));
+                self.stack.push((indent, Kind::Sequence));
+            } else {
+                self.queue.push_back(null_scalar());
+            }
+        }
+
+        // Close collections the line has dedented out of. A sequence living
+        // at the same indent as its parent mapping's keys also closes when a
+        // non-item line appears at that indent.
+        while let Some(&(open_indent, kind)) = self.stack.last() {
+            if indent < open_indent
+                || (indent == open_indent && kind == Kind::Sequence && !is_sequence_item(content))
+            {
+                self.queue.push_back(end_event(kind));
+                self.stack.pop();
+            } else {
+                break;
+            }
+        }
+
+        let Some(&(open_indent, kind)) = self.stack.last() else {
+            return Err(Unsupported::here());
+        };
+        if indent != open_indent {
+            // A line deeper than the open collection with no pending key is
+            // a multiline plain scalar or an indentation we don't model.
+            return Err(Unsupported::here());
+        }
+
+        match kind {
+            Kind::Mapping => self.key_line(indent, content),
+            Kind::Sequence => self.sequence_item(content),
+        }
+    }
+
+    /// Next non-blank, non-comment line as (indent, content). Content
+    /// excludes indentation and the trailing newline. pnpm never emits
+    /// comments; full-line comments are skipped anyway since dropping them
+    /// preserves meaning.
+    fn next_content_line(&mut self) -> FResult<Option<(usize, &'a str)>> {
+        loop {
+            if self.pos >= self.text.len() {
+                return Ok(None);
+            }
+            let rest = &self.text[self.pos..];
+            let (line, next_pos) = match memchr::memchr(b'\n', rest.as_bytes()) {
+                Some(i) => (&rest[..i], self.pos + i + 1),
+                None => (rest, self.text.len()),
+            };
+            self.pos = next_pos;
+
+            if line.contains('\r') {
+                // CRLF input: saphyr handles it, we don't model it.
+                return Err(Unsupported::here());
+            }
+            let indent = count_indent(line);
+            let content = &line[indent..];
+            if content.is_empty() {
+                continue;
+            }
+            if content.as_bytes()[0] == b'\t' {
+                return Err(Unsupported::here());
+            }
+            if content.starts_with('#') {
+                continue;
+            }
+            return Ok(Some((indent, content)));
+        }
+    }
+
+    fn key_line(&mut self, indent: usize, content: &'a str) -> FResult<()> {
+        let (key_event, rest) = split_key(content)?;
+        self.queue.push_back(key_event);
+
+        let value = rest.trim_start_matches(' ');
+        if value.is_empty() {
+            self.pending_child = Some(indent);
+            return Ok(());
+        }
+        self.value_events(indent, value)
+    }
+
+    fn sequence_item(&mut self, content: &'a str) -> FResult<()> {
+        let Some(item) = content.strip_prefix("- ") else {
+            return Err(Unsupported::here());
+        };
+        let item = item.trim_start_matches(' ');
+        // Items are scalars only in the pnpm subset; nested collections
+        // under `-` leave the fast path.
+        let ev = inline_scalar(item, FlowContext::Block)?;
+        self.queue.push_back(ev);
+        Ok(())
+    }
+
+    /// Emit events for a value that starts on the key's own line.
+    fn value_events(&mut self, key_indent: usize, value: &'a str) -> FResult<()> {
+        match value.as_bytes()[0] {
+            b'{' => self.flow_mapping(value),
+            b'[' => self.flow_sequence(value),
+            b'>' | b'|' => self.block_scalar(key_indent, value),
+            _ => {
+                let ev = inline_scalar(value, FlowContext::Block)?;
+                self.queue.push_back(ev);
+                Ok(())
+            }
+        }
+    }
+
+    /// One-line flow mapping: `{a: b, c: 'd'}`. Nested collections bail.
+    fn flow_mapping(&mut self, value: &'a str) -> FResult<()> {
+        let inner = value
+            .strip_prefix('{')
+            .and_then(|v| v.strip_suffix('}'))
+            .ok_or_else(Unsupported::here)?;
+        self.queue.push_back(Event::MappingStart(0, None));
+        for member in split_flow_members(inner)? {
+            let member = member.trim_matches(' ');
+            if member.is_empty() {
+                return Err(Unsupported::here());
+            }
+            let (key_event, rest) = split_key(member)?;
+            let member_value = rest.trim_start_matches(' ');
+            if member_value.is_empty() {
+                return Err(Unsupported::here());
+            }
+            self.queue.push_back(key_event);
+            self.queue
+                .push_back(inline_scalar(member_value, FlowContext::Flow)?);
+        }
+        self.queue.push_back(Event::MappingEnd);
+        Ok(())
+    }
+
+    /// One-line flow sequence of scalars: `[darwin, linux]`.
+    fn flow_sequence(&mut self, value: &'a str) -> FResult<()> {
+        let inner = value
+            .strip_prefix('[')
+            .and_then(|v| v.strip_suffix(']'))
+            .ok_or_else(Unsupported::here)?;
+        self.queue.push_back(Event::SequenceStart(0, None));
+        for member in split_flow_members(inner)? {
+            let member = member.trim_matches(' ');
+            if member.is_empty() {
+                return Err(Unsupported::here());
+            }
+            self.queue
+                .push_back(inline_scalar(member, FlowContext::Flow)?);
+        }
+        self.queue.push_back(Event::SequenceEnd);
+        Ok(())
+    }
+
+    /// Block scalar (`>`, `>-`, `|`, `|-`), the shapes pnpm emits for long
+    /// `deprecated:` messages. Folded (`>`) blocks fold line breaks into
+    /// spaces; literal (`|`) blocks keep them. Explicit indentation
+    /// indicators, `keep` (`+`) chomping, leading/trailing blank lines, and
+    /// more-indented lines under folding all bail: their rules are subtle
+    /// enough that the general parser should decide. (Literal blocks keep
+    /// more-indented lines verbatim, so those are safe to accept.)
+    fn block_scalar(&mut self, key_indent: usize, value: &'a str) -> FResult<()> {
+        let (literal, chomp_strip) = match value {
+            ">" => (false, false),
+            ">-" => (false, true),
+            "|" => (true, false),
+            "|-" => (true, true),
+            _ => return Err(Unsupported::here()),
+        };
+
+        let mut result = String::new();
+        let mut block_indent: Option<usize> = None;
+        let mut pending_breaks = 0usize;
+        let mut saw_content = false;
+
+        loop {
+            let rest = &self.text[self.pos..];
+            if rest.is_empty() {
+                break;
+            }
+            let (line, next_pos) = match memchr::memchr(b'\n', rest.as_bytes()) {
+                Some(i) => (&rest[..i], self.pos + i + 1),
+                None => (rest, self.text.len()),
+            };
+            if line.contains('\r') || line.contains('\t') {
+                return Err(Unsupported::here());
+            }
+            let indent = count_indent(line);
+            let content = &line[indent..];
+
+            if content.is_empty() {
+                if !saw_content {
+                    // Leading blank lines interact with block indent
+                    // detection in ways we don't model.
+                    return Err(Unsupported::here());
+                }
+                pending_breaks += 1;
+                self.pos = next_pos;
+                continue;
+            }
+            if indent <= key_indent {
+                // Block ended at the previous line.
+                break;
+            }
+            let expected = *block_indent.get_or_insert(indent);
+            if indent < expected || (indent > expected && !literal) {
+                // Less-indented content is invalid; more-indented lines are
+                // kept literally under folding — leave those to the general
+                // parser. Literal blocks keep them verbatim below.
+                return Err(Unsupported::here());
+            }
+            let text = &line[expected..];
+            if literal && text.ends_with(' ') {
+                // Trailing whitespace preservation in literal blocks is a
+                // corner we'd rather not mirror by hand.
+                return Err(Unsupported::here());
+            }
+            if saw_content {
+                if literal {
+                    for _ in 0..=pending_breaks {
+                        result.push('\n');
+                    }
+                } else if pending_breaks > 0 {
+                    for _ in 0..pending_breaks {
+                        result.push('\n');
+                    }
+                } else {
+                    result.push(' ');
+                }
+            }
+            pending_breaks = 0;
+            result.push_str(if literal {
+                text
+            } else {
+                text.trim_end_matches(' ')
+            });
+            saw_content = true;
+            self.pos = next_pos;
+        }
+
+        if !saw_content {
+            // Empty blocks hit chomping subtleties; bail. Trailing blank
+            // lines (`pending_breaks` left over) are safe: both strip and
+            // clip chomping discard trailing breaks, and `keep` (`+`)
+            // already bailed at the indicator.
+            return Err(Unsupported::here());
+        }
+        if !chomp_strip {
+            result.push('\n');
+        }
+        let style = if literal {
+            ScalarStyle::Literal
+        } else {
+            ScalarStyle::Folded
+        };
+        self.queue
+            .push_back(Event::Scalar(Cow::Owned(result), style, 0, None));
+        Ok(())
+    }
+}
+
+fn count_indent(line: &str) -> usize {
+    line.as_bytes().iter().take_while(|&&b| b == b' ').count()
+}
+
+fn is_document_marker(content: &str) -> bool {
+    content == "---"
+        || content == "..."
+        || content.starts_with("--- ")
+        || content.starts_with("... ")
+}
+
+fn is_sequence_item(content: &str) -> bool {
+    content.starts_with("- ")
+}
+
+fn null_scalar() -> Event<'static> {
+    // What saphyr emits for a key with no value.
+    Event::Scalar(Cow::Borrowed("~"), ScalarStyle::Plain, 0, None)
+}
+
+fn start_event(kind: Kind) -> Event<'static> {
+    match kind {
+        Kind::Mapping => Event::MappingStart(0, None),
+        Kind::Sequence => Event::SequenceStart(0, None),
+    }
+}
+
+fn end_event(kind: Kind) -> Event<'static> {
+    match kind {
+        Kind::Mapping => Event::MappingEnd,
+        Kind::Sequence => Event::SequenceEnd,
+    }
+}
+
+/// Split `key: rest` or `key:` (end of line), returning the key's scalar
+/// event and the remainder after the colon.
+fn split_key(content: &str) -> FResult<(Event<'_>, &str)> {
+    match content.as_bytes()[0] {
+        b'\'' => {
+            let (event, rest) = single_quoted(content)?;
+            let rest = rest.strip_prefix(':').ok_or_else(Unsupported::here)?;
+            if !rest.is_empty() && !rest.starts_with(' ') {
+                return Err(Unsupported::here());
+            }
+            Ok((event, rest))
+        }
+        b'"' => {
+            let (event, rest) = double_quoted(content)?;
+            let rest = rest.strip_prefix(':').ok_or_else(Unsupported::here)?;
+            if !rest.is_empty() && !rest.starts_with(' ') {
+                return Err(Unsupported::here());
+            }
+            Ok((event, rest))
+        }
+        _ => {
+            // Plain key: ends at the first `:` that is followed by a space
+            // or the end of the line.
+            let bytes = content.as_bytes();
+            let mut search_from = 0;
+            loop {
+                let Some(i) = memchr::memchr(b':', &bytes[search_from..]) else {
+                    return Err(Unsupported::here());
+                };
+                let colon = search_from + i;
+                if colon + 1 == bytes.len() || bytes[colon + 1] == b' ' {
+                    let key = &content[..colon];
+                    plain_scalar_check(key, FlowContext::Block)?;
+                    return Ok((
+                        Event::Scalar(Cow::Borrowed(key), ScalarStyle::Plain, 0, None),
+                        &content[colon + 1..],
+                    ));
+                }
+                search_from = colon + 1;
+            }
+        }
+    }
+}
+
+enum FlowContext {
+    Block,
+    Flow,
+}
+
+/// Scalar occupying the remainder of a line (or a flow member): plain,
+/// single-quoted, or double-quoted.
+fn inline_scalar(value: &str, ctx: FlowContext) -> FResult<Event<'_>> {
+    match value.as_bytes()[0] {
+        b'\'' => {
+            let (event, rest) = single_quoted(value)?;
+            if !rest.trim_matches(' ').is_empty() {
+                return Err(Unsupported::here());
+            }
+            Ok(event)
+        }
+        b'"' => {
+            let (event, rest) = double_quoted(value)?;
+            if !rest.trim_matches(' ').is_empty() {
+                return Err(Unsupported::here());
+            }
+            Ok(event)
+        }
+        _ => {
+            let value = value.trim_end_matches(' ');
+            plain_scalar_check(value, ctx)?;
+            Ok(Event::Scalar(
+                Cow::Borrowed(value),
+                ScalarStyle::Plain,
+                0,
+                None,
+            ))
+        }
+    }
+}
+
+/// Reject plain scalars whose meaning we can't guarantee matches a general
+/// YAML scanner: indicator-led strings, embedded `: `/` #`, trailing `:`,
+/// and (in flow context) flow delimiters.
+fn plain_scalar_check(value: &str, ctx: FlowContext) -> FResult<()> {
+    if value.is_empty() {
+        return Err(Unsupported::here());
+    }
+    let bytes = value.as_bytes();
+    match bytes[0] {
+        b'!' | b'&' | b'*' | b'|' | b'>' | b'%' | b'@' | b'`' | b'\'' | b'"' | b'{' | b'}'
+        | b'[' | b']' | b',' | b'#' => return Err(Unsupported::here()),
+        b'-' | b'?' | b':' if bytes.len() == 1 || bytes[1] == b' ' => {
+            return Err(Unsupported::here());
+        }
+        _ => {}
+    }
+    if bytes.contains(&b'\t') {
+        return Err(Unsupported::here());
+    }
+    if value.ends_with(':') || value.contains(": ") || value.contains(" #") {
+        return Err(Unsupported::here());
+    }
+    if matches!(ctx, FlowContext::Flow)
+        && bytes
+            .iter()
+            .any(|b| matches!(b, b'{' | b'}' | b'[' | b']' | b','))
+    {
+        return Err(Unsupported::here());
+    }
+    Ok(())
+}
+
+/// Parse a single-quoted scalar at the start of `s`, returning its event
+/// and the remainder. `''` escapes force an owned string; otherwise the
+/// content is borrowed.
+fn single_quoted(s: &str) -> FResult<(Event<'_>, &str)> {
+    let inner = &s[1..];
+    let bytes = inner.as_bytes();
+    let mut i = 0;
+    let mut has_escape = false;
+    loop {
+        let Some(q) = memchr::memchr(b'\'', &bytes[i..]) else {
+            // Closing quote on another line: multiline quoted scalar.
+            return Err(Unsupported::here());
+        };
+        let q = i + q;
+        if bytes.get(q + 1) == Some(&b'\'') {
+            has_escape = true;
+            i = q + 2;
+            continue;
+        }
+        let raw = &inner[..q];
+        if raw.contains('\t') {
+            return Err(Unsupported::here());
+        }
+        let value = if has_escape {
+            Cow::Owned(raw.replace("''", "'"))
+        } else {
+            Cow::Borrowed(raw)
+        };
+        return Ok((
+            Event::Scalar(value, ScalarStyle::SingleQuoted, 0, None),
+            &inner[q + 1..],
+        ));
+    }
+}
+
+/// Parse a double-quoted scalar at the start of `s`. Backslash escapes
+/// bail: pnpm doesn't emit them and their decoding table is long.
+fn double_quoted(s: &str) -> FResult<(Event<'_>, &str)> {
+    let inner = &s[1..];
+    let bytes = inner.as_bytes();
+    let Some(q) = memchr::memchr(b'"', bytes) else {
+        return Err(Unsupported::here());
+    };
+    let raw = &inner[..q];
+    if raw.contains('\\') || raw.contains('\t') {
+        return Err(Unsupported::here());
+    }
+    Ok((
+        Event::Scalar(Cow::Borrowed(raw), ScalarStyle::DoubleQuoted, 0, None),
+        &inner[q + 1..],
+    ))
+}
+
+/// Split the inside of a one-line flow collection on top-level commas,
+/// respecting quoted members. Nested flow collections bail.
+fn split_flow_members(inner: &str) -> FResult<Vec<&str>> {
+    let inner = inner.trim_matches(' ');
+    let mut members = Vec::new();
+    if inner.is_empty() {
+        return Ok(members);
+    }
+    let bytes = inner.as_bytes();
+    let mut start = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\'' => {
+                // Skip to the closing quote, honoring '' escapes.
+                i += 1;
+                loop {
+                    let Some(q) = memchr::memchr(b'\'', &bytes[i..]) else {
+                        return Err(Unsupported::here());
+                    };
+                    i += q;
+                    if bytes.get(i + 1) == Some(&b'\'') {
+                        i += 2;
+                    } else {
+                        i += 1;
+                        break;
+                    }
+                }
+            }
+            b'"' => {
+                i += 1;
+                let Some(q) = memchr::memchr(b'"', &bytes[i..]) else {
+                    return Err(Unsupported::here());
+                };
+                if bytes[i..i + q].contains(&b'\\') {
+                    return Err(Unsupported::here());
+                }
+                i += q + 1;
+            }
+            b'{' | b'[' => return Err(Unsupported::here()),
+            b',' => {
+                members.push(&inner[start..i]);
+                i += 1;
+                start = i;
+            }
+            _ => i += 1,
+        }
+    }
+    members.push(&inner[start..]);
+    Ok(members)
+}


### PR DESCRIPTION
## Why

On large pnpm monorepos, the bulk of `turbo run` startup — the window between invocation and the first task starting — is spent parsing `pnpm-lock.yaml` and computing per-workspace transitive dependency closures. Profiling a 1191-package internal monorepo (43k tracked files, 5.4MB lockfile) showed the closure walk dominated by string allocation, hashing, and map probes rather than actual resolution work, and YAML parsing spending ~75% of its time inside a general-purpose scanner that pnpm's rigid machine-generated output doesn't need.

## What

This PR has grown into the full pnpm startup overhaul: five stacked changes, each merged into this branch after independent review and verification.

**1. Closure walk interning + FxHash.** Resolved packages are interned to dense `u32` ids behind the existing caches: resolve-cache hits become a refcount bump instead of cloning two `String`s per closure edge, visited sets hash a `u32` instead of two heap strings, and the deps cache is keyed by id. Cache maps use FxHash — lockfile content is developer tooling input, not a hash-flooding vector.

**2. pnpm hash index** (#13229). The post-parse `dependency_index` becomes an `FxHashMap` carrying membership flags and versions, making `has_package`/`package_version`/`all_dependencies` O(1) probes instead of `BTreeMap` walks over long keys. Entry dependency maps stay `BTreeMap` so closure iteration order remains deterministic. Also fixes `subgraph()` returning pruned lockfiles with an empty index.

**3. Fast pnpm parse on saphyr events** (#13230). An event-driven parser (pure Rust, ~2x libyaml scanner throughput) builds `PnpmLockfile` without serde on the hot path. Deliberately conservative: multi-document input, anchors/aliases, tags, duplicate keys, and exotic numeric forms bail to the unchanged serde path. Observable serde quirks (untagged variant order, `lockfileVersion` float formatting, plain-scalar typing, unknown-field dropping) are mirrored exactly and enforced differentially.

**4. Structural line scanner** (#13238). pnpm-lock.yaml is line-oriented machine-generated YAML, so a `memchr`-driven scanner specialized to exactly that subset replaces the general YAML state machine as tier 1, emitting the same event stream the semantic layer from (3) consumes — quirk handling is shared, not duplicated. Tier order: scanner → saphyr → serde; the scanner also declines anything a general parser would *reject*, so it can never fabricate a lockfile from invalid input. Roughly halves parse time again on every corpus measured.

**5. Shared bitset closure DP** (#13239). Closures were recomputed per workspace, so shared dependencies were re-walked once per workspace reaching them. When the lockfile can prove every transitive edge resolves identically across workspaces (pnpm importers can shadow transitive resolution, so this is proven per edge via importer equivalence classes, not assumed), closures are computed once globally: iterative Tarjan SCC condensation, then a bottom-up bitset DP where set unions are word-parallel `u64` ORs, processed in bounded-memory chunks. Any sensitive edge, non-pnpm lockfile, or single-workspace call falls back to the unchanged legacy walk.

## Results

Interleaved A/B against current `main`, 4-core Linux, telemetry disabled, on the 1191-package monorepo. Time-to-first-task is measured in-process (invocation to first task dispatch in the chrome profile).

| Benchmark | main | this PR | delta |
|---|---|---|---|
| time-to-first-task (real run) | 1117ms | 472ms | **−58%** |
| `turbo run build --dry=json` end-to-end | 1481ms | 871ms | **−41%** |
| lockfile parse (5.4MB, `from_bytes`) | ~285ms | 56ms | **−80%** |
| peak RSS (dry) | — | −27MB vs branch base | bitsets beat per-workspace set churn |

Parse deltas hold on public corpora too: next.js lockfile (1.29MB) 30.9→15.0ms, this repo's (707KB) 15.3→8.0ms for the scanner tier alone.

## How to verify

- Full `--dry=json` output diffed against current main on the internal benchmark monorepo and this repo — byte-identical modulo run id and version string.
- 20 differential parse tests assert scanner == saphyr == serde (`Eq`-identical lockfiles, byte-identical `encode()` round-trips) across v5/v6/v9 fixtures, folded/literal block scalars with chomping/blank-line edges, quoting, flow collections, catalogs, patches, and this repo's own `pnpm-lock.yaml` — with scanner acceptance *required* on mainline shapes so regressions can't silently fall through to slower tiers. Each unsupported construct has explicit fallback coverage.
- The closure DP is differentially tested against the legacy walk (an independent oracle — the single-workspace entry point never uses the DP), including a crafted divergent-edge fixture proving the fallback triggers. 220 crate tests pass.
