### PR TITLE
perf: Release tokio runtime at exit so background DNS lookups never stall the user

### DIFF
--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1,4 +1,4 @@
-use std::{env, io, mem, process, sync::Arc, time::Duration};
+use std::{env, io, mem, process, sync::Arc};
 
 use camino::Utf8Path;
 use clap::CommandFactory;
@@ -284,9 +284,11 @@ pub fn run(
     // (`getaddrinfo`) runs on the blocking pool and cannot be cancelled — can
     // hold the process open for seconds on a slow network after the run has
     // already finished. Everything owed to the user is awaited inside
-    // `run_main` (telemetry and analytics handles get a bounded close there),
-    // so bound the teardown instead of inheriting drop's unbounded join.
-    runtime.shutdown_timeout(Duration::from_millis(250));
+    // `run_main` (telemetry and analytics handles get a bounded close there);
+    // anything still running here is strictly best-effort, so release the
+    // runtime without waiting at all. The orphaned threads die with the
+    // process.
+    runtime.shutdown_background();
 
     result
 }

--- a/crates/turborepo-lib/src/cli/mod.rs
+++ b/crates/turborepo-lib/src/cli/mod.rs
@@ -1,4 +1,4 @@
-use std::{env, io, mem, process, sync::Arc};
+use std::{env, io, mem, process, sync::Arc, time::Duration};
 
 use camino::Utf8Path;
 use clap::CommandFactory;
@@ -277,7 +277,18 @@ pub fn run(
         .build()
         .map_err(Error::Runtime)?;
 
-    runtime.block_on(run_main(repo_state, logger, color_config, query_server))
+    let result = runtime.block_on(run_main(repo_state, logger, color_config, query_server));
+
+    // `Runtime::drop` joins blocking-pool threads with no deadline. Detached
+    // best-effort work — most notably a telemetry flush whose DNS lookup
+    // (`getaddrinfo`) runs on the blocking pool and cannot be cancelled — can
+    // hold the process open for seconds on a slow network after the run has
+    // already finished. Everything owed to the user is awaited inside
+    // `run_main` (telemetry and analytics handles get a bounded close there),
+    // so bound the teardown instead of inheriting drop's unbounded join.
+    runtime.shutdown_timeout(Duration::from_millis(250));
+
+    result
 }
 
 #[tracing::instrument(skip_all)]


### PR DESCRIPTION
## Why

On slow or lossy networks, `turbo` can hang for ~4-5 seconds *after* all work is done and the last output is written, on every invocation. We hit this repeatedly while benchmarking on a cloud sandbox: roughly half of all runs in a bad-network window took +4.4s, with `-vv` timestamps showing the process idle between the final log line and exit.

The cause is not a missing timeout in telemetry itself — the telemetry handle close is bounded to 1s and posts run under a 10s timeout. The problem is `Runtime::drop`: it joins blocking-pool threads with no deadline. Telemetry posts are detached best-effort tasks, and their DNS resolution (`getaddrinfo`, via reqwest's default resolver) runs on the blocking pool and cannot be cancelled. When `block_on(run_main)` returns with a lookup still in flight, the future-level timeouts are dropped with their tasks — but drop still sits on the uncancellable `getaddrinfo` until the resolver gives up.

## What

`cli::run` now releases the runtime with `shutdown_background()` instead of inheriting drop's unbounded join — the process never waits on background work at exit, not even a grace period. Everything owed to the user is awaited inside `run_main` (telemetry and analytics handles get a bounded close there); anything still running at teardown is strictly best-effort by construction, and a grace period is not a correctness mechanism — the old teardown already cancelled pending async tasks, so waiting bought nothing but latency. Orphaned blocking threads die with the process.

## How to verify

- Mechanism isolated in a 20-line reproducer: a runtime holding one stuck `spawn_blocking` task takes **4.90s** to drop, versus **123µs** with `shutdown_background()`.
- Field validation under real bad-network conditions (interleaved pairs on the same cloud sandbox during degraded windows, telemetry enabled), reproduced independently for both revisions of this fix: main stalled at ~6.4s on **3 of 8** runs each time; this fix had **0 of 8** above normal run time, with normal runs unaffected.
- 431 turborepo-lib tests pass; clippy and fmt clean.