### PR TITLE
perf: Build tracked repo index concurrently with package graph

### DIFF
--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -436,9 +436,21 @@ impl RunBuilder {
         let scm_task = {
             let repo_root = self.repo_root.clone();
             let git_root = self.opts.git_root.clone();
-            tokio::task::spawn_blocking(move || match git_root {
-                Some(root) => SCM::new_with_git_root(&repo_root, root),
-                None => SCM::new(&repo_root),
+            tokio::task::spawn_blocking(move || {
+                let scm = match git_root {
+                    Some(root) => SCM::new_with_git_root(&repo_root, root),
+                    None => SCM::new(&repo_root),
+                };
+                // The tracked half of the repo index only needs `.git/index`,
+                // not the package graph, so build it here where it overlaps
+                // with package discovery instead of waiting for the graph.
+                // Untracked discovery is layered on later once package
+                // prefixes are known.
+                let tracked_index = {
+                    let _span = tracing::info_span!("build_tracked_repo_index_gix").entered();
+                    scm.build_tracked_repo_index_eager()
+                };
+                (scm, tracked_index)
             })
         };
         let package_json_path = self.repo_root.join_component("package.json");
@@ -511,27 +523,28 @@ impl RunBuilder {
         repo_telemetry.track_size(pkg_dep_graph.len());
         run_telemetry.track_run_type(self.opts.run_opts.dry_run.is_some());
 
-        // Build the repo index by reading .git/index directly via gix-index
-        // (fast, in-process, no subprocess spawns) then running a scoped
-        // parallel walk for untracked file discovery. This replaces the
-        // subprocess approach (ls-tree + diff-index + ls-files race) which
-        // burned ~500ms of CPU on background threads.
-        let scm = scm_task
+        // The repo index caches git state (tracked entries + untracked file
+        // discovery) by reading .git/index directly via gix-index — fast,
+        // in-process, no subprocess spawns. The tracked half was already
+        // built inside scm_task, overlapping with package graph
+        // construction; only the untracked walk, which needs the package
+        // prefixes derived from the graph, runs from here.
+        let (scm, tracked_index) = scm_task
             .instrument(tracing::info_span!("scm_task_await"))
             .await?;
         let all_prefixes = Self::all_package_prefixes(&pkg_dep_graph, &scm)?;
-        let repo_index_task = if all_prefixes.is_empty() {
-            None
-        } else {
-            let scm = scm.clone();
-            Some(tokio::task::spawn_blocking(move || {
-                let _span = tracing::info_span!("build_repo_index_gix").entered();
-                let mut index = scm.build_tracked_repo_index_eager()?;
-                if let Err(e) = scm.populate_repo_index_untracked(&mut index, &all_prefixes) {
-                    tracing::debug!("failed to populate untracked files: {e}");
-                }
-                Some(index)
-            }))
+        let repo_index_task = match tracked_index {
+            Some(mut index) if !all_prefixes.is_empty() => {
+                let scm = scm.clone();
+                Some(tokio::task::spawn_blocking(move || {
+                    let _span = tracing::info_span!("populate_repo_index_untracked").entered();
+                    if let Err(e) = scm.populate_repo_index_untracked(&mut index, &all_prefixes) {
+                        tracing::debug!("failed to populate untracked files: {e}");
+                    }
+                    Some(index)
+                }))
+            }
+            _ => None,
         };
         let micro_frontend_configs = {
             let _span = tracing::info_span!("micro_frontends_from_disk").entered();


### PR DESCRIPTION
## Why

The repo git index has two halves: the tracked index (read directly from `.git/index` via gix-index) and untracked-file discovery (a scoped parallel walk). Only the walk needs package prefixes derived from the package graph — but today both halves sit in a single task that cannot start until the graph is built, so the tracked read serializes behind graph construction for no reason. On large repos the tail of that task is still in flight when the run needs it, delaying the first task dispatch.

## What

`scm_task` (which already runs concurrently with package graph construction) now also builds the tracked index; the post-graph task shrinks to just the untracked walk over the already-built index. Behavior is unchanged: manual SCM and the empty-prefix case still yield no index, and dry-run JSON output is byte-identical on every repo tested.

## How to verify

Benchmarked on two internal-scale monorepos (repo A: 1191 packages, ~43k files; repo B: ~140 packages, ~42k files), interleaved A/B on the same machine, telemetry disabled:

| Metric | before | after |
|---|---|---|
| repo A time-to-first-task (real run, 4 interleaved pairs) | 1450ms median | 1395ms median — every pair improved, −41 to −57ms |
| repo A exposed repo-index wait (span timeline) | 22.7ms | 13.5ms (46ms tracked build fully hidden) |
| repo B exposed repo-index wait (span timeline) | 86.1ms | 55.7ms (43ms tracked build fully hidden) |
| repo B `--dry=json` total (10 interleaved pairs) | 534ms median | 522ms median |

The remaining exposed wait is the untracked walk itself, which genuinely depends on the graph.

Span-level check: in a chrome profile (`--profile=...`), `build_tracked_repo_index_gix` now starts at ~t=0 inside `scm_task` and completes well inside `pkg_dep_graph_build`; `populate_repo_index_untracked` is all that runs post-graph.