### PR TITLE
feat: Introduce toolchain provider abstraction

### DIFF
--- a/crates/turborepo-boundaries/src/lib.rs
+++ b/crates/turborepo-boundaries/src/lib.rs
@@ -894,6 +894,7 @@ mod tests {
                     .unwrap(),
                     unresolved_external_dependencies: None,
                     transitive_dependencies: None,
+                    ..Default::default()
                 },
             ),
             (
@@ -906,6 +907,7 @@ mod tests {
                     .unwrap(),
                     unresolved_external_dependencies: None,
                     transitive_dependencies: None,
+                    ..Default::default()
                 },
             ),
         ];

--- a/crates/turborepo-boundaries/src/tags.rs
+++ b/crates/turborepo-boundaries/src/tags.rs
@@ -455,6 +455,7 @@ mod tests {
                     .unwrap(),
                     unresolved_external_dependencies: None,
                     transitive_dependencies: None,
+                    ..Default::default()
                 },
             ));
         }

--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -233,7 +233,6 @@ mod test {
 
     use std::collections::{BTreeMap, HashSet};
 
-    use tempfile::TempDir;
     use turbopath::AbsoluteSystemPath;
     use turborepo_errors::Spanned;
     use turborepo_repository::{
@@ -244,9 +243,9 @@ mod test {
 
     use super::*;
 
-    struct DummyDiscovery<'a>(&'a TempDir);
+    struct DummyDiscovery(turbopath::AbsoluteSystemPathBuf);
 
-    impl<'a> PackageDiscovery for DummyDiscovery<'a> {
+    impl PackageDiscovery for DummyDiscovery {
         async fn discover_packages(
             &self,
         ) -> Result<
@@ -257,7 +256,7 @@ mod test {
             let workspaces = [("a", true), ("b", true), ("c", false)]
                 .into_iter()
                 .map(|(name, had_build)| {
-                    let path = AbsoluteSystemPath::from_std_path(self.0.path()).unwrap();
+                    let path = &self.0;
                     let package_json = path.join_component(&format!("{}.json", name));
 
                     let scripts = if had_build {
@@ -335,7 +334,9 @@ mod test {
             AbsoluteSystemPath::from_std_path(tmp.path()).unwrap(),
             PackageJson::default(),
         )
-        .with_package_discovery(DummyDiscovery(&tmp));
+        .with_package_discovery(DummyDiscovery(
+            turbopath::AbsoluteSystemPathBuf::try_from(tmp.path()).unwrap(),
+        ));
 
         let graph = graph_builder.build().await.unwrap();
 
@@ -387,7 +388,9 @@ mod test {
             AbsoluteSystemPath::from_std_path(tmp.path()).unwrap(),
             PackageJson::default(),
         )
-        .with_package_discovery(DummyDiscovery(&tmp));
+        .with_package_discovery(DummyDiscovery(
+            turbopath::AbsoluteSystemPathBuf::try_from(tmp.path()).unwrap(),
+        ));
 
         let graph = graph_builder.build().await.unwrap();
 
@@ -420,7 +423,9 @@ mod test {
             AbsoluteSystemPath::from_std_path(tmp.path()).unwrap(),
             PackageJson::default(),
         )
-        .with_package_discovery(DummyDiscovery(&tmp));
+        .with_package_discovery(DummyDiscovery(
+            turbopath::AbsoluteSystemPathBuf::try_from(tmp.path()).unwrap(),
+        ));
 
         let graph = graph_builder.build().await.unwrap();
 
@@ -453,7 +458,9 @@ mod test {
             AbsoluteSystemPath::from_std_path(tmp.path()).unwrap(),
             PackageJson::default(),
         )
-        .with_package_discovery(DummyDiscovery(&tmp))
+        .with_package_discovery(DummyDiscovery(
+            turbopath::AbsoluteSystemPathBuf::try_from(tmp.path()).unwrap(),
+        ))
         .build()
         .await
         .unwrap();
@@ -494,7 +501,9 @@ mod test {
             AbsoluteSystemPath::from_std_path(tmp.path()).unwrap(),
             PackageJson::default(),
         )
-        .with_package_discovery(DummyDiscovery(&tmp))
+        .with_package_discovery(DummyDiscovery(
+            turbopath::AbsoluteSystemPathBuf::try_from(tmp.path()).unwrap(),
+        ))
         .build()
         .await
         .unwrap();

--- a/crates/turborepo-lib/src/task_graph/visitor/command.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/command.rs
@@ -182,6 +182,7 @@ mod test {
             package_json_path: AnchoredSystemPath::new("package.json").unwrap().to_owned(),
             unresolved_external_dependencies: None,
             transitive_dependencies: None,
+            ..Default::default()
         });
         let mut factory = CommandFactory::new();
         factory.add_provider(MicroFrontendProxyProvider::new(

--- a/crates/turborepo-repository/src/lib.rs
+++ b/crates/turborepo-repository/src/lib.rs
@@ -17,4 +17,5 @@ pub mod inference;
 pub mod package_graph;
 pub mod package_json;
 pub mod package_manager;
+pub mod toolchain;
 pub mod workspaces;

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -60,8 +60,19 @@ pub enum Error {
     Lockfile(#[from] turborepo_lockfiles::Error),
     #[error(transparent)]
     Discovery(#[from] crate::discovery::Error),
-    #[error(transparent)]
-    Toolchain(#[from] crate::toolchain::Error),
+}
+
+// Toolchain errors map onto the pre-existing variants rather than adding a
+// new one: consumers match on `Error::PackageJson` (diagnostic rendering,
+// io-NotFound telemetry in the run builder), and those contracts must not
+// depend on whether the error surfaced through a toolchain.
+impl From<crate::toolchain::Error> for Error {
+    fn from(err: crate::toolchain::Error) -> Self {
+        match err {
+            crate::toolchain::Error::Discovery(err) => Error::Discovery(err),
+            crate::toolchain::Error::Descriptor(err) => Error::PackageJson(err),
+        }
+    }
 }
 
 /// Attempts to extract the file path that caused the error from the error chain

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -1,4 +1,7 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    sync::Arc,
+};
 
 use miette::{Diagnostic, Report};
 use petgraph::graph::{Graph, NodeIndex};
@@ -19,6 +22,7 @@ use crate::{
     },
     package_json::{DependencyKind, PackageJson},
     package_manager::{PackageManager, pnpm::PnpmCatalogs},
+    toolchain::{DiscoveredPackage, JavaScriptToolchain, ToolchainId, ToolchainRegistry},
 };
 
 pub struct PackageGraphBuilder<'a, T> {
@@ -56,6 +60,8 @@ pub enum Error {
     Lockfile(#[from] turborepo_lockfiles::Error),
     #[error(transparent)]
     Discovery(#[from] crate::discovery::Error),
+    #[error(transparent)]
+    Toolchain(#[from] crate::toolchain::Error),
 }
 
 /// Attempts to extract the file path that caused the error from the error chain
@@ -145,7 +151,7 @@ impl<'a, P> PackageGraphBuilder<'a, P> {
 impl<T> PackageGraphBuilder<'_, T>
 where
     T: PackageDiscoveryBuilder,
-    T::Output: Send + Sync,
+    T::Output: Send + Sync + 'static,
     T::Error: Into<crate::package_manager::Error>,
 {
     /// Build the `PackageGraph`.
@@ -203,7 +209,13 @@ struct BuildState<'a, S, T> {
     lockfile: Option<Box<dyn Lockfile>>,
     package_jsons: Option<HashMap<AbsoluteSystemPathBuf, PackageJson>>,
     state: std::marker::PhantomData<S>,
-    package_discovery: T,
+    /// The JavaScript toolchain, typed. Package-manager resolution for
+    /// dependency splitting and lockfile handling reaches through this —
+    /// documented debt, see `crate::toolchain` module docs.
+    javascript: Arc<JavaScriptToolchain<T>>,
+    /// Every toolchain contributing packages, JavaScript included. Package
+    /// discovery goes through this and only this.
+    toolchains: ToolchainRegistry,
 }
 
 // Allows us to perform workspace discovery and parse package jsons
@@ -226,7 +238,7 @@ impl<S, T> BuildState<'_, S, T> {
 impl<'a, T> BuildState<'a, ResolvedPackageManager, T>
 where
     T: PackageDiscoveryBuilder,
-    T::Output: Send,
+    T::Output: Send + Sync + 'static,
     T::Error: Into<crate::package_manager::Error>,
 {
     fn new(
@@ -268,6 +280,15 @@ where
         node_lookup.insert(PackageNode::Root, root_node_index);
         node_lookup.insert(root_workspace, root_workspace_index);
 
+        // The discovery strategy is shared (via the JavaScript toolchain)
+        // between package discovery and package-manager resolution; the
+        // caching wrapper guarantees the underlying strategy runs once.
+        let javascript = Arc::new(JavaScriptToolchain::new(CachingPackageDiscovery::new(
+            package_discovery.build().map_err(Into::into)?,
+        )));
+        let mut toolchains = ToolchainRegistry::new();
+        toolchains.register(javascript.clone());
+
         Ok(BuildState {
             repo_root,
             single,
@@ -281,30 +302,34 @@ where
             node_lookup,
             root_package_json,
             state: std::marker::PhantomData,
-            package_discovery: CachingPackageDiscovery::new(
-                package_discovery.build().map_err(Into::into)?,
-            ),
+            javascript,
+            toolchains,
         })
     }
 }
 
-impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedPackageManager, T> {
-    fn add_json(
+impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManager, T> {
+    fn add_package(
         &mut self,
-        package_json_path: AbsoluteSystemPathBuf,
-        json: PackageJson,
+        toolchain: ToolchainId,
+        package: DiscoveredPackage,
     ) -> Result<(), Error> {
+        let DiscoveredPackage {
+            descriptor: json,
+            manifest_path,
+        } = package;
         let relative_json_path =
-            AnchoredSystemPathBuf::relative_path_between(self.repo_root, &package_json_path);
+            AnchoredSystemPathBuf::relative_path_between(self.repo_root, &manifest_path);
         let name = PackageName::Other(
             json.name
                 .clone()
-                .ok_or(Error::PackageJsonMissingName(package_json_path))?
+                .ok_or(Error::PackageJsonMissingName(manifest_path))?
                 .into_inner(),
         );
         let entry = PackageInfo {
             package_json: json,
             package_json_path: relative_json_path,
+            toolchain,
             ..Default::default()
         };
         match self.workspaces.entry(name) {
@@ -329,36 +354,38 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedPackageManager, T> {
     // need our own type
     #[tracing::instrument(skip(self))]
     async fn parse_package_jsons(mut self) -> Result<BuildState<'a, ResolvedWorkspaces, T>, Error> {
-        let package_jsons = match self.package_jsons.take() {
-            Some(jsons) => Ok(jsons),
+        let discovered: Vec<(ToolchainId, DiscoveredPackage)> = match self.package_jsons.take() {
+            // A pre-supplied set of parsed package.json files (used by the
+            // package-change watcher and tests) stands in for JavaScript
+            // discovery.
+            Some(jsons) => jsons
+                .into_iter()
+                .map(|(path, json)| {
+                    (
+                        ToolchainId::JAVASCRIPT,
+                        DiscoveredPackage {
+                            descriptor: json,
+                            manifest_path: path,
+                        },
+                    )
+                })
+                .collect(),
             None => {
-                let workspace_paths: Vec<_> =
-                    self.package_discovery.discover_packages().await?.workspaces;
-
-                let results: Vec<_> = turborepo_rayon_compat::block_in_place(|| {
-                    use rayon::prelude::*;
-                    workspace_paths
-                        .into_par_iter()
-                        .map(|path| {
-                            let json = PackageJson::load(&path.package_json)?;
-                            Ok((path.package_json, json))
-                        })
-                        .collect::<Result<Vec<_>, Error>>()
-                })?;
-
-                let mut jsons = HashMap::with_capacity(results.len());
-                for (path, json) in results {
-                    jsons.insert(path, json);
+                let mut discovered = Vec::new();
+                for toolchain in self.toolchains.iter() {
+                    let id = toolchain.id();
+                    let packages = toolchain.discover_packages().await?;
+                    discovered.extend(packages.into_iter().map(|package| (id.clone(), package)));
                 }
-                Ok::<_, Error>(jsons)
+                discovered
             }
-        }?;
+        };
 
-        self.workspaces.reserve(package_jsons.len());
-        self.node_lookup.reserve(package_jsons.len());
+        self.workspaces.reserve(discovered.len());
+        self.node_lookup.reserve(discovered.len());
 
-        for (path, json) in package_jsons {
-            match self.add_json(path, json) {
+        for (toolchain, package) in discovered {
+            match self.add_package(toolchain, package) {
                 Ok(()) => {}
                 Err(Error::PackageJsonMissingName(path)) => {
                     // previous implementations of turbo would silently ignore package.json files
@@ -382,7 +409,8 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedPackageManager, T> {
             node_lookup,
             root_package_json,
             lockfile,
-            package_discovery,
+            javascript,
+            toolchains,
             ..
         } = self;
         Ok(BuildState {
@@ -395,7 +423,8 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedPackageManager, T> {
             node_lookup,
             root_package_json,
             lockfile,
-            package_discovery,
+            javascript,
+            toolchains,
             package_jsons: None,
             state: std::marker::PhantomData,
         })
@@ -411,15 +440,14 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedPackageManager, T> {
             node_lookup,
             root_package_json,
             lockfile,
-            package_discovery,
+            javascript,
             repo_root,
             ..
         } = self;
 
-        let package_manager = package_discovery
-            .discover_packages()
+        let package_manager = javascript
+            .package_manager()
             .await?
-            .package_manager
             .with_resolved_nub_lockfile(repo_root);
 
         debug_assert!(single, "expected single package graph");
@@ -439,7 +467,7 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedPackageManager, T> {
     }
 }
 
-impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedWorkspaces, T> {
+impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T> {
     #[tracing::instrument(skip(self))]
     fn connect_internal_dependencies(
         &mut self,
@@ -509,10 +537,9 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedWorkspaces, T> {
     #[tracing::instrument(skip(self))]
     async fn populate_lockfile(&mut self) -> Result<Box<dyn Lockfile>, Error> {
         let package_manager = self
-            .package_discovery
-            .discover_packages()
+            .javascript
+            .package_manager()
             .await?
-            .package_manager
             .with_resolved_nub_lockfile(self.repo_root);
 
         match self.lockfile.take() {
@@ -539,10 +566,9 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedWorkspaces, T> {
         // Since we've already performed package discovery, this should just be a cache
         // hit
         let package_manager = self
-            .package_discovery
-            .discover_packages()
+            .javascript
+            .package_manager()
             .await?
-            .package_manager
             .with_resolved_nub_lockfile(self.repo_root);
         turborepo_rayon_compat::block_in_place(|| {
             self.connect_internal_dependencies(&package_manager)
@@ -579,7 +605,8 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedWorkspaces, T> {
             root_workspace_index,
             node_lookup,
             root_package_json,
-            package_discovery,
+            javascript,
+            toolchains,
             ..
         } = self;
         Ok(BuildState {
@@ -594,12 +621,13 @@ impl<'a, T: PackageDiscovery> BuildState<'a, ResolvedWorkspaces, T> {
             lockfile,
             package_jsons: None,
             state: std::marker::PhantomData,
-            package_discovery,
+            javascript,
+            toolchains,
         })
     }
 }
 
-impl<T: PackageDiscovery> BuildState<'_, ResolvedLockfile, T> {
+impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
     fn all_external_dependencies(
         &self,
     ) -> Result<HashMap<String, BTreeMap<String, String>>, Error> {
@@ -653,11 +681,10 @@ impl<T: PackageDiscovery> BuildState<'_, ResolvedLockfile, T> {
             warn!("Unable to calculate transitive closures: {}", e);
         }
         let package_manager = self
-            .package_discovery
-            .discover_packages()
+            .javascript
+            .package_manager()
             .instrument(tracing::debug_span!("package discovery"))
             .await?
-            .package_manager
             .with_resolved_nub_lockfile(self.repo_root);
         let Self {
             workspaces,

--- a/crates/turborepo-repository/src/package_graph/dep_splitter.rs
+++ b/crates/turborepo-repository/src/package_graph/dep_splitter.rs
@@ -331,6 +331,7 @@ mod test {
                     .unwrap(),
                     unresolved_external_dependencies: None,
                     transitive_dependencies: None,
+                    ..Default::default()
                 },
             );
             map.insert(
@@ -346,6 +347,7 @@ mod test {
                     .unwrap(),
                     unresolved_external_dependencies: None,
                     transitive_dependencies: None,
+                    ..Default::default()
                 },
             );
             map.insert(
@@ -361,6 +363,7 @@ mod test {
                     .unwrap(),
                     unresolved_external_dependencies: None,
                     transitive_dependencies: None,
+                    ..Default::default()
                 },
             );
             map.insert(
@@ -376,6 +379,7 @@ mod test {
                     .unwrap(),
                     unresolved_external_dependencies: None,
                     transitive_dependencies: None,
+                    ..Default::default()
                 },
             );
             map
@@ -467,6 +471,7 @@ mod test {
                     .unwrap(),
                     unresolved_external_dependencies: None,
                     transitive_dependencies: None,
+                    ..Default::default()
                 },
             );
             map
@@ -511,6 +516,7 @@ mod test {
                     .unwrap(),
                     unresolved_external_dependencies: None,
                     transitive_dependencies: None,
+                    ..Default::default()
                 },
             );
             map
@@ -555,6 +561,7 @@ mod test {
                     .unwrap(),
                     unresolved_external_dependencies: None,
                     transitive_dependencies: None,
+                    ..Default::default()
                 },
             );
             map
@@ -624,6 +631,7 @@ mod test {
                     .unwrap(),
                     unresolved_external_dependencies: None,
                     transitive_dependencies: None,
+                    ..Default::default()
                 },
             );
             map
@@ -665,6 +673,7 @@ mod test {
                     .unwrap(),
                     unresolved_external_dependencies: None,
                     transitive_dependencies: None,
+                    ..Default::default()
                 },
             );
             map

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -77,10 +77,17 @@ impl WorkspacePackage {
 /// PackageInfo represents a package within the workspace.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct PackageInfo {
+    /// The toolchain-neutral package descriptor (see
+    /// [`crate::toolchain::DiscoveredPackage`]). For JavaScript packages
+    /// this is the parsed `package.json`; other toolchains synthesize one
+    /// from their native manifest.
     pub package_json: PackageJson,
+    /// Path to the package's native manifest, anchored to the repo root.
     pub package_json_path: AnchoredSystemPathBuf,
     pub unresolved_external_dependencies: Option<BTreeMap<PackageKey, PackageVersion>>, /* name -> version */
     pub transitive_dependencies: Option<HashSet<turborepo_lockfiles::Package>>,
+    /// The toolchain that discovered this package. Defaults to JavaScript.
+    pub toolchain: crate::toolchain::ToolchainId,
 }
 
 impl PackageInfo {

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -29,9 +29,12 @@
 //!
 //! # Known debt
 //!
-//! JavaScript machinery that predates this abstraction is still reachable
-//! outside the trait where other build phases need it. Each access point is
-//! the shrink list for future iterations of the trait surface:
+//! Some JavaScript machinery that predates this abstraction is still called
+//! directly, outside the trait, because the build phases that need it have
+//! no trait surface yet. The list below is a checklist to burn down: as the
+//! trait gains a surface for each concern, the corresponding direct access
+//! goes away. When the list is empty, JavaScript is fully behind the
+//! abstraction.
 //!
 //! - [`JavaScriptToolchain::package_manager`]: package-manager resolution feeds
 //!   dependency splitting and lockfile handling in the package graph builder.

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -1,0 +1,264 @@
+//! Toolchains: the abstraction that makes Turborepo generic over language
+//! ecosystems.
+//!
+//! A [`Toolchain`] answers ecosystem-specific questions about packages —
+//! starting with "which packages exist?" — so that the package graph and the
+//! rest of the system never branch on a specific ecosystem. JavaScript is the
+//! first implementation ([`JavaScriptToolchain`]); additional toolchains
+//! (e.g. Cargo) register alongside it in the [`ToolchainRegistry`].
+//!
+//! The trait grows one concern at a time (discovery today; command
+//! resolution, derived task inputs/outputs, external-dependency hashing,
+//! watch triggers, and prune participation as they are needed), and every
+//! concern must ship with real implementations for every registered
+//! toolchain.
+//!
+//! # Design rules
+//!
+//! These rules keep the door open to an out-of-process plugin architecture
+//! (subprocess or WASM adapters implementing this same trait) without
+//! committing to one today:
+//!
+//! 1. Trait methods are coarse-grained and data-in/data-out: arguments and
+//!    return values are serializable-shaped (paths, strings, plain structs). No
+//!    internal graph types, no lifetime-carrying views, no callbacks.
+//! 2. [`ToolchainId`] is an open identifier, never a closed enum. A future
+//!    toolchain (or plugin) mints a new id without touching existing code.
+//! 3. All toolchain lookups go through the [`ToolchainRegistry`]. Scattered
+//!    per-toolchain branch points (`if id == "cargo"`) are a design defect.
+//!
+//! # Known debt
+//!
+//! JavaScript machinery that predates this abstraction is still reachable
+//! outside the trait where other build phases need it. Each access point is
+//! the shrink list for future iterations of the trait surface:
+//!
+//! - [`JavaScriptToolchain::package_manager`]: package-manager resolution feeds
+//!   dependency splitting and lockfile handling in the package graph builder.
+//!   Lockfile handling gains a trait surface with external dependency hashing;
+//!   dependency splitting remains JS-native for now.
+
+use std::{borrow::Cow, fmt, future::Future, pin::Pin, sync::Arc};
+
+use turbopath::AbsoluteSystemPathBuf;
+
+use crate::{
+    discovery::{self, PackageDiscovery},
+    package_json::PackageJson,
+    package_manager::PackageManager,
+};
+
+/// Identifies a toolchain: the language ecosystem a package belongs to.
+///
+/// Open by design (see the module's design rules): any string can be a
+/// toolchain id, so new toolchains — including, potentially, ones loaded as
+/// plugins — do not require changes to this type.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ToolchainId(Cow<'static, str>);
+
+impl ToolchainId {
+    /// The JavaScript toolchain: packages discovered from `package.json`
+    /// manifests, regardless of package manager or runtime.
+    pub const JAVASCRIPT: ToolchainId = ToolchainId(Cow::Borrowed("javascript"));
+
+    pub fn new(id: impl Into<Cow<'static, str>>) -> Self {
+        Self(id.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Default for ToolchainId {
+    fn default() -> Self {
+        Self::JAVASCRIPT
+    }
+}
+
+impl fmt::Display for ToolchainId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// A package discovered by a toolchain.
+///
+/// `descriptor` is the toolchain-neutral package descriptor. [`PackageJson`]
+/// serves as that descriptor for every toolchain: JavaScript packages parse
+/// theirs from disk, while other toolchains synthesize one from their native
+/// manifest (only the fields they populate — at minimum `name` and internal
+/// dependencies — are meaningful).
+#[derive(Debug, Clone)]
+pub struct DiscoveredPackage {
+    /// The toolchain-neutral package descriptor.
+    pub descriptor: PackageJson,
+    /// Absolute path to the package's native manifest (`package.json`,
+    /// `Cargo.toml`, ...).
+    pub manifest_path: AbsoluteSystemPathBuf,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    Discovery(#[from] discovery::Error),
+    #[error(transparent)]
+    Descriptor(#[from] crate::package_json::Error),
+}
+
+/// The future returned by [`Toolchain::discover_packages`]. Boxed so the
+/// trait stays object-safe; toolchains live behind `dyn Toolchain` in the
+/// [`ToolchainRegistry`].
+pub type DiscoverPackagesFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<Vec<DiscoveredPackage>, Error>> + Send + 'a>>;
+
+/// A language ecosystem that contributes packages to the repository.
+///
+/// See the module docs for the design rules trait methods must follow.
+pub trait Toolchain: Send + Sync {
+    /// This toolchain's identifier.
+    fn id(&self) -> ToolchainId;
+
+    /// Discover this toolchain's packages.
+    fn discover_packages(&self) -> DiscoverPackagesFuture<'_>;
+}
+
+/// The set of toolchains contributing packages to the repository.
+///
+/// All toolchain lookups go through the registry; it is the single place
+/// that knows which toolchains exist. Today entries are registered
+/// statically during package graph construction. A future plugin system
+/// would construct entries from a manifest instead — an additive change.
+#[derive(Default)]
+pub struct ToolchainRegistry {
+    toolchains: Vec<Arc<dyn Toolchain>>,
+}
+
+impl ToolchainRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a toolchain. Registration order is discovery order.
+    pub fn register(&mut self, toolchain: Arc<dyn Toolchain>) {
+        debug_assert!(
+            self.get(&toolchain.id()).is_none(),
+            "toolchain {} registered twice",
+            toolchain.id()
+        );
+        self.toolchains.push(toolchain);
+    }
+
+    pub fn get(&self, id: &ToolchainId) -> Option<&dyn Toolchain> {
+        self.toolchains
+            .iter()
+            .find(|toolchain| toolchain.id() == *id)
+            .map(AsRef::as_ref)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &dyn Toolchain> {
+        self.toolchains.iter().map(AsRef::as_ref)
+    }
+}
+
+impl fmt::Debug for ToolchainRegistry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list()
+            .entries(self.toolchains.iter().map(|toolchain| toolchain.id()))
+            .finish()
+    }
+}
+
+/// The JavaScript toolchain: packages discovered from `package.json`
+/// manifests.
+///
+/// Wraps a [`PackageDiscovery`] strategy (local filesystem walk,
+/// daemon-backed, or a composition) — the strategy decides *how* manifests
+/// are found, the toolchain owns *what a JavaScript package is*: it loads
+/// and parses each manifest into the package descriptor.
+pub struct JavaScriptToolchain<P> {
+    discovery: P,
+}
+
+impl<P: PackageDiscovery + Send + Sync> JavaScriptToolchain<P> {
+    pub fn new(discovery: P) -> Self {
+        Self { discovery }
+    }
+
+    /// The repository's JavaScript package manager.
+    ///
+    /// Known debt (see module docs): dependency splitting and lockfile
+    /// handling in the package graph builder are not yet trait concerns, so
+    /// they reach into the JavaScript toolchain directly for this.
+    pub async fn package_manager(&self) -> Result<PackageManager, discovery::Error> {
+        Ok(self.discovery.discover_packages().await?.package_manager)
+    }
+}
+
+impl<P: PackageDiscovery + Send + Sync> Toolchain for JavaScriptToolchain<P> {
+    fn id(&self) -> ToolchainId {
+        ToolchainId::JAVASCRIPT
+    }
+
+    fn discover_packages(&self) -> DiscoverPackagesFuture<'_> {
+        Box::pin(async move {
+            let workspaces = self.discovery.discover_packages().await?.workspaces;
+            // Parse manifests in parallel; manifest parsing dominates
+            // discovery time on large repositories.
+            turborepo_rayon_compat::block_in_place(|| {
+                use rayon::prelude::*;
+                workspaces
+                    .into_par_iter()
+                    .map(|workspace| {
+                        let descriptor = PackageJson::load(&workspace.package_json)?;
+                        Ok(DiscoveredPackage {
+                            descriptor,
+                            manifest_path: workspace.package_json,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, Error>>()
+            })
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_toolchain_id_is_open() {
+        let js = ToolchainId::default();
+        assert_eq!(js, ToolchainId::JAVASCRIPT);
+        assert_eq!(js.as_str(), "javascript");
+
+        // Any string is a valid id; no closed set to extend.
+        let custom = ToolchainId::new("cargo");
+        assert_ne!(custom, js);
+        assert_eq!(custom.to_string(), "cargo");
+        let dynamic = ToolchainId::new(String::from("python-uv"));
+        assert_eq!(dynamic.as_str(), "python-uv");
+    }
+
+    #[test]
+    fn test_registry_lookup() {
+        struct Fake(ToolchainId);
+        impl Toolchain for Fake {
+            fn id(&self) -> ToolchainId {
+                self.0.clone()
+            }
+            fn discover_packages(&self) -> DiscoverPackagesFuture<'_> {
+                Box::pin(async { Ok(Vec::new()) })
+            }
+        }
+
+        let mut registry = ToolchainRegistry::new();
+        registry.register(Arc::new(Fake(ToolchainId::JAVASCRIPT)));
+        registry.register(Arc::new(Fake(ToolchainId::new("cargo"))));
+
+        assert!(registry.get(&ToolchainId::JAVASCRIPT).is_some());
+        assert!(registry.get(&ToolchainId::new("cargo")).is_some());
+        assert!(registry.get(&ToolchainId::new("zig")).is_none());
+        assert_eq!(registry.iter().count(), 2);
+    }
+}

--- a/crates/turborepo-task-executor/src/command.rs
+++ b/crates/turborepo-task-executor/src/command.rs
@@ -573,6 +573,7 @@ mod tests {
             package_json_path: AnchoredSystemPathBuf::from_raw("web/package.json").unwrap(),
             unresolved_external_dependencies: None,
             transitive_dependencies: None,
+            ..Default::default()
         }
     }
 


### PR DESCRIPTION
## Why

This PR makes Turborepo generic over language toolchains. The abstraction has to enter the codebase somewhere, and I want it to be validated by a real implementor from day one — so this PR introduces the `Toolchain` trait with **JavaScript as its first, production implementation**.

## What

- `crates/turborepo-repository/src/toolchain.rs`: `ToolchainId` (open identifier), `Toolchain` trait (identity + package discovery), `ToolchainRegistry`, and `JavaScriptToolchain` — which wraps the existing `PackageDiscovery` strategy (local walk, daemon-backed, or composed) and owns package.json parsing
- The package graph builder discovers packages **only** by iterating the registry; `PackageInfo` records which toolchain discovered each package (default: JavaScript)
- The trait grows one concern at a time in later PRs (command resolution, derived inputs/outputs, external-dependency hashing, watch triggers, prune participation), each shipping with real JS and Cargo implementations
- Known debt, documented in the module: package-manager resolution for dep splitting and lockfile handling still reaches into the JS toolchain directly until those concerns get trait surfaces

## How

Behavior-preserving refactor — no functional change intended. The builder's discovery/parse step moved from inline code into `JavaScriptToolchain::discover_packages` (same strategy instance, same caching wrapper, same parallel manifest parsing, same missing-name tolerance). Reviewers can verify the JS path is real, not a facade: the old inline discovery code in `parse_package_jsons` is gone, and `rg "discover_packages" crates/turborepo-repository/src/package_graph/builder.rs` shows the builder only reaches discovery through toolchains. Acceptance gate is the existing test suite (737 tests across repository/boundaries/task-executor/lib pass unchanged, plus new unit tests for the registry and id semantics).