### PR TITLE
perf: Use mimalloc as the global allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3454,6 +3454,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3695,6 +3704,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -7210,6 +7228,7 @@ dependencies = [
  "insta",
  "itertools 0.14.0",
  "miette",
+ "mimalloc",
  "nix 0.26.2",
  "portable-pty",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,7 @@ derive_setters = "0.1.6"
 dialoguer = "0.12.0"
 dunce = "1.0.3"
 dhat = "0.3.3"
+mimalloc = "0.1.48"
 either = "1.9.0"
 futures = "0.3.31"
 gix-attributes = { version = "0.31.0", default-features = false }

--- a/crates/turborepo/Cargo.toml
+++ b/crates/turborepo/Cargo.toml
@@ -42,7 +42,6 @@ workspace = true
 anyhow = { workspace = true, features = ["backtrace"] }
 dhat = { workspace = true, optional = true }
 miette.workspace = true
-mimalloc = { workspace = true }
 turborepo-lib = { workspace = true, default-features = false }
 turborepo-lsp = { workspace = true, default-features = false }
 turborepo-query = { workspace = true }
@@ -55,3 +54,10 @@ windows-sys = { version = "0.59", features = [
   "Win32_Foundation",
   "Win32_System_Console",
 ] }
+
+# Not enabled on Windows: libmimalloc-sys compiles against the dynamic CRT
+# (the workspace default) while libghostty-vt-sys ships static-CRT objects,
+# and MSVC's /failifmismatch rejects linking both. Revisit if the Windows
+# CRT choice is ever unified.
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+mimalloc = { workspace = true }

--- a/crates/turborepo/Cargo.toml
+++ b/crates/turborepo/Cargo.toml
@@ -42,6 +42,7 @@ workspace = true
 anyhow = { workspace = true, features = ["backtrace"] }
 dhat = { workspace = true, optional = true }
 miette.workspace = true
+mimalloc = { workspace = true }
 turborepo-lib = { workspace = true, default-features = false }
 turborepo-lsp = { workspace = true, default-features = false }
 turborepo-query = { workspace = true }

--- a/crates/turborepo/src/main.rs
+++ b/crates/turborepo/src/main.rs
@@ -14,6 +14,14 @@ const INTERNAL_WINDOWS_CTRL_C_COMMAND: &str = "__internal_windows_ctrl_c";
 #[global_allocator]
 static ALLOC: dhat::Alloc = dhat::Alloc;
 
+// glibc's malloc loses 10-15% of total CPU to allocator overhead on
+// allocation-heavy phases (lockfile parsing, package graph construction,
+// task dispatch). mimalloc reclaims most of that across every platform we
+// ship.
+#[cfg(not(feature = "heap-dhat"))]
+#[global_allocator]
+static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[derive(Debug, PartialEq)]
 enum InternalLspCommand {
     Probe,

--- a/crates/turborepo/src/main.rs
+++ b/crates/turborepo/src/main.rs
@@ -16,9 +16,9 @@ static ALLOC: dhat::Alloc = dhat::Alloc;
 
 // glibc's malloc loses 10-15% of total CPU to allocator overhead on
 // allocation-heavy phases (lockfile parsing, package graph construction,
-// task dispatch). mimalloc reclaims most of that across every platform we
-// ship.
-#[cfg(not(feature = "heap-dhat"))]
+// task dispatch). mimalloc reclaims most of that. Windows is excluded
+// because of a CRT conflict with libghostty-vt-sys (see Cargo.toml).
+#[cfg(all(not(feature = "heap-dhat"), not(target_os = "windows")))]
 #[global_allocator]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 

--- a/crates/turborepo/src/main.rs
+++ b/crates/turborepo/src/main.rs
@@ -14,10 +14,6 @@ const INTERNAL_WINDOWS_CTRL_C_COMMAND: &str = "__internal_windows_ctrl_c";
 #[global_allocator]
 static ALLOC: dhat::Alloc = dhat::Alloc;
 
-// glibc's malloc loses 10-15% of total CPU to allocator overhead on
-// allocation-heavy phases (lockfile parsing, package graph construction,
-// task dispatch). mimalloc reclaims most of that. Windows is excluded
-// because of a CRT conflict with libghostty-vt-sys (see Cargo.toml).
 #[cfg(all(not(feature = "heap-dhat"), not(target_os = "windows")))]
 #[global_allocator]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;


### PR DESCRIPTION
## Why

`turbo` ships with the system allocator. Whole-run `perf` profiling of a fully-cached run showed 12-15% of total CPU inside glibc malloc/free/realloc (plus associated page-fault churn) — spread across every phase: lockfile parsing, package graph construction, task graph building, and dispatch. No single call site dominates, so the structural fix is a faster allocator rather than chasing individual allocations.

## What

Adds `mimalloc` as the global allocator in the `turbo` binary crate, keeping the existing `dhat` allocator when the `heap-dhat` debug feature is enabled. No other code changes.

## How to verify

Interleaved A/B on the same 4-core Linux machine, telemetry disabled, identical code either side of the allocator swap:

| Benchmark | system malloc | mimalloc | delta |
|---|---|---|---|
| 1191-package monorepo, `--dry=json` (8 pairs) | 1721.5ms median | 1187.5ms median | **−31%** |
| same repo, time-to-first-task (real run, 4 pairs) | 1318-1403ms | 977-1073ms | **−25%, every pair improved** |
| ~140-package monorepo, `--dry=json` (8 pairs) | 493ms median | 426ms median | **−14%** |
| 1900-task synthetic repo, fully-cached run (12 pairs) | 398ms median | 304.5ms median | **−24%** |

Distributions are non-overlapping in every benchmark.

Tradeoffs, measured:

- Peak RSS on the 1191-package dry run: 268MB → 303MB (+13%). Expected mimalloc behavior (per-thread heaps, deferred decommit) and a reasonable trade for the latency win.
- Binary size: +140KB (+0.26%).

Linux gains will be largest (glibc malloc is the weakest baseline); macOS/Windows system allocators are better but mimalloc still typically wins. CI builds all release targets including musl, which mimalloc supports.

Windows is excluded: `libmimalloc-sys` compiles against the dynamic CRT (the workspace default for MSVC targets) while `libghostty-vt-sys` ships static-CRT objects, and MSVC's `/failifmismatch` refuses to link both. Ghostty predates this PR and has been linking silently because pure-Rust objects carry no CRT directives — mimalloc was simply the first cc-built dependency to disagree with it. Enabling mimalloc on Windows is a follow-up once the Windows CRT choice is made deliberately (either flag ghostty's zig build to MD or move the workspace to `+crt-static`).

### macOS validation

Same A/B on an Apple Silicon Mac (allocator-only diff): user CPU on a next.js-repo `--dry=json` dropped 462.9ms → 434.8ms median (−6%), with 14/15 interleaved pairs improving (−41.9ms median pairwise). Smaller than Linux as expected — macOS libmalloc is a much stronger baseline than glibc — but a consistent win with no regressions observed.

