### PR TITLE
ci: Retry Windows nextest aborts from transient 0xc0000142 spawn failures

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -5,6 +5,16 @@
 failure-output = "immediate-final"
 
 [[profile.default.overrides]]
+# Windows runners intermittently fail process spawns en masse with DLL
+# initialization error 0xc0000142 (STATUS_DLL_INIT_FAILED, os error 1114) when
+# session resources are momentarily exhausted under nextest's process churn.
+# The condition clears within seconds, so retry with a delay instead of capping
+# concurrency. See the removal of the previous caps in #12999 and the failure
+# mode analysis in #12991.
+platform = 'cfg(windows)'
+retries = { backoff = "fixed", count = 2, delay = "2s" }
+
+[[profile.default.overrides]]
 # These tests run package installs from the network during setup, which can
 # take 20-60s+ on cold CI runners. Give them extra time instead of retries.
 filter = 'package(turbo) and (test(prune_test::test_prune_composable_config) or test(lockfile-aware-caching/new-package))'


### PR DESCRIPTION
## Why

The Windows Rust test job intermittently fails with a cascade of `0xc0000142` (STATUS_DLL_INIT_FAILED, os error 1114) aborts, e.g. [this run](https://github.com/vercel/turborepo/actions/runs/28689953287/job/85089402247): 2,651 tests passed normally, then every remaining process spawn failed instantly for ~2.5 seconds, aborting ~880 tests. This is transient session resource exhaustion under nextest's process churn, not a test bug.

We previously mitigated this class by capping concurrency for subprocess-heavy integration binaries (removed in #12999 after test trimming, see analysis in #12991). The latest occurrence cascaded through plain unit-test crates (turborepo-run-cache, turborepo-scm, turborepo-ui) that those caps never covered, so capping specific binaries is not sufficient.

## What

Adds a Windows-only nextest override that retries aborted tests twice with a fixed 2s delay, keeping full concurrency.

## How

Since the exhaustion clears within seconds, a delayed retry recovers regardless of which tests are in flight when the storm hits. The override is scoped with `platform = 'cfg(windows)'`, so Linux/macOS behavior is unchanged.

Verified: `taplo format --check .config/nextest.toml`, `cargo nextest show-config version`, and a Linux `cargo nextest run -p turborepo-microfrontends` pass with the new config. Note for reviewers: retries also mask genuinely flaky Windows tests; flakes will show as `TRY 2 PASS` in logs rather than failing the job.