### PR TITLE
perf: Skip the dirty-hash git diff when the working tree is provably clean

### DIFF
--- a/crates/turborepo-scm/src/crlf.rs
+++ b/crates/turborepo-scm/src/crlf.rs
@@ -314,6 +314,15 @@ impl BlobHasher {
     }
 }
 
+/// Hash a byte slice as a git blob. Used to verify symlink entries, whose
+/// blob content is the link target path (no filters ever apply).
+pub(crate) fn hash_bytes_as_blob(bytes: &[u8]) -> Result<OidHash, std::io::Error> {
+    let mut hasher = BlobHasher::new();
+    hasher.write_blob_header(bytes.len() as u64);
+    hasher.update(bytes);
+    hasher.finalize()
+}
+
 fn validate_file_type(
     path: &AbsoluteSystemPath,
     metadata: &std::fs::Metadata,
@@ -345,23 +354,48 @@ fn validate_file_type(
 /// 1. Fused scan + speculative raw hash (result discarded)
 /// 2. Seek to start, write normalized blob header, stream with CRLF→LF
 ///
+/// Facts about how a blob hash was produced, used by the repo-index
+/// verification pass to decide whether a stat-stale entry is provably
+/// identical to what `git diff HEAD` would see.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct HashOutcome {
+    /// Whether CRLF→LF normalization was applied (the returned oid is over
+    /// normalized content, not raw bytes).
+    pub(crate) normalized: bool,
+    /// Number of `\r\n` pairs in the raw content.
+    pub(crate) crlf_count: u64,
+    /// Whether a NUL byte was found in the first 8KB. Conservative subset of
+    /// git's binary detection (git scans the whole file), so `true` here
+    /// implies git also considers the content binary and exempts it from
+    /// eol conversion.
+    pub(crate) is_binary: bool,
+}
+
 /// Memory bounded at ~128KB per call.
 fn hash_file_normalized(
     file: &mut std::fs::File,
     file_len: u64,
     attr: TextAttr,
-) -> Result<OidHash, std::io::Error> {
+) -> Result<(OidHash, HashOutcome), std::io::Error> {
     // Fused scan + speculative raw hash in a single pass. The blob header
     // uses the raw file length; if normalization turns out to be needed we
     // discard this hash and do a second pass with the normalized length.
     let mut raw_hasher = BlobHasher::new();
     raw_hasher.write_blob_header(file_len);
-    let scan = scan_file_and_feed(file, attr == TextAttr::Auto, |data| {
+    // Always detect binary content (not just for `text=auto`): the
+    // verification pass needs it to reason about git's eol conversion, and
+    // the NUL scan over the first 8KB is negligible next to hashing.
+    let scan = scan_file_and_feed(file, true, |data| {
         raw_hasher.update(data);
     })?;
 
     if !should_normalize(attr, &scan) {
-        return raw_hasher.finalize();
+        let outcome = HashOutcome {
+            normalized: false,
+            crlf_count: scan.crlf_count,
+            is_binary: scan.is_binary,
+        };
+        return Ok((raw_hasher.finalize()?, outcome));
     }
 
     // CRLF normalization required — second pass with the normalized length.
@@ -386,7 +420,12 @@ fn hash_file_normalized(
             ),
         ));
     }
-    hasher.finalize()
+    let outcome = HashOutcome {
+        normalized: true,
+        crlf_count: scan.crlf_count,
+        is_binary: scan.is_binary,
+    };
+    Ok((hasher.finalize()?, outcome))
 }
 
 /// Hash a working-tree file as a git blob (used when `.git/` is present).
@@ -407,6 +446,18 @@ pub(crate) fn hash_file_maybe_normalized(
     let mut file = std::fs::File::open(path)?;
     let metadata = file.metadata()?;
     validate_file_type(path, &metadata)?;
+    Ok(hash_file_normalized(&mut file, metadata.len(), attr)?.0)
+}
+
+/// Like [`hash_file_maybe_normalized`], but also reports how the hash was
+/// produced. Used by the repo-index verification pass.
+pub(crate) fn hash_file_for_verification(
+    path: &AbsoluteSystemPath,
+    attr: TextAttr,
+) -> Result<(OidHash, HashOutcome), std::io::Error> {
+    let mut file = std::fs::File::open(path)?;
+    let metadata = file.metadata()?;
+    validate_file_type(path, &metadata)?;
     hash_file_normalized(&mut file, metadata.len(), attr)
 }
 
@@ -418,7 +469,7 @@ pub(crate) fn manual_hash_file_maybe_normalized(
     let mut file = path.open()?;
     let metadata = file.metadata()?;
     validate_file_type(path, &metadata)?;
-    Ok(hash_file_normalized(&mut file, metadata.len(), attr)?)
+    Ok(hash_file_normalized(&mut file, metadata.len(), attr)?.0)
 }
 
 #[cfg(test)]

--- a/crates/turborepo-scm/src/git.rs
+++ b/crates/turborepo-scm/src/git.rs
@@ -265,7 +265,99 @@ impl GitRepo {
 
         let mut hasher = Sha256::new();
         let has_status = repo_index.append_dirty_status_to_hasher(&mut hasher);
+
+        // If the repo index proved the working tree clean of unstaged
+        // changes, and the index's cache-tree equals HEAD's tree (no staged
+        // changes), then `git diff HEAD` is guaranteed to produce no output
+        // — skip spawning it. On stat-stale indexes (snapshot-restored
+        // workspaces) that subprocess re-hashes every tracked file with
+        // sha1dc and costs seconds of serial wall time.
+        let info_attributes_exists = self
+            .root
+            .join_components(&[".git", "info", "attributes"])
+            .exists();
+        if let Some((root, sensitivity)) =
+            repo_index.tracked_diff_clean_root(info_attributes_exists)
+        {
+            let eol_ok = match sensitivity {
+                crate::repo_index::EolSensitivity::ConfigIndependent => true,
+                crate::repo_index::EolSensitivity::RequiresInertEolConversion => {
+                    self.eol_conversion_inert()
+                }
+            };
+            if eol_ok
+                && self
+                    .head_tree_oid()
+                    .is_some_and(|head_tree| head_tree == root)
+            {
+                // The diff would have contributed nothing to the hasher, so
+                // the resulting hash is identical to the diff-running path.
+                if !has_status {
+                    return None;
+                }
+                return Some(hex::encode(hasher.finalize()));
+            }
+        }
+
         self.finish_dirty_hash(hasher, has_status)
+    }
+
+    /// Returns true when git provably performs no eol conversion at checkin:
+    /// `core.autocrlf` is unset or false, no `core.attributesFile` is
+    /// configured, and no default global/system attribute files exist.
+    /// Conservative on any failure.
+    fn eol_conversion_inert(&self) -> bool {
+        let Ok(output) = self.execute_git_command(&["config", "-z", "--list"], "") else {
+            return false;
+        };
+        let mut autocrlf_ok = true;
+        for kv in output.split(|b| *b == 0) {
+            // `-z` output: `key\nvalue` per NUL-terminated record.
+            let mut parts = kv.splitn(2, |b| *b == b'\n');
+            let key = parts.next().unwrap_or_default();
+            let value = parts.next().unwrap_or_default();
+            match key {
+                b"core.autocrlf" => {
+                    // Last definition wins, mirroring git.
+                    autocrlf_ok = value.eq_ignore_ascii_case(b"false");
+                }
+                b"core.attributesfile" => return false,
+                _ => {}
+            }
+        }
+        if !autocrlf_ok {
+            return false;
+        }
+
+        // Default global attributes locations git consults when
+        // core.attributesFile is unset.
+        let xdg_attrs = std::env::var_os("XDG_CONFIG_HOME")
+            .map(|base| {
+                std::path::PathBuf::from(base)
+                    .join("git")
+                    .join("attributes")
+            })
+            .or_else(|| {
+                std::env::var_os("HOME")
+                    .map(|home| std::path::PathBuf::from(home).join(".config/git/attributes"))
+            });
+        if xdg_attrs.is_some_and(|p| p.exists()) {
+            return false;
+        }
+        // System-wide attributes. The exact path depends on git's compiled
+        // prefix; /etc/gitattributes is the common location.
+        !std::path::Path::new("/etc/gitattributes").exists()
+    }
+
+    /// Resolve `HEAD^{tree}` to its oid. `None` on failure (unborn HEAD,
+    /// corrupt repo) — callers treat that as "nothing proven".
+    fn head_tree_oid(&self) -> Option<String> {
+        let output = self
+            .execute_git_command(&["rev-parse", "HEAD^{tree}"], "")
+            .ok()?;
+        let output = String::from_utf8(output).ok()?;
+        let trimmed = output.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_owned())
     }
 
     fn finish_dirty_hash(&self, mut hasher: sha2::Sha256, has_status: bool) -> Option<String> {
@@ -1773,6 +1865,14 @@ mod tests {
                 false,
             ),
             (
+                "intent_to_add",
+                |root| {
+                    fs::write(root.join("ita.txt"), "ita").unwrap();
+                    run_git(root, &["add", "-N", "ita.txt"]);
+                },
+                true,
+            ),
+            (
                 "racy_rewrite_same_content",
                 |root| {
                     // Rewrite identical content: mtime changes, content does
@@ -1964,6 +2064,218 @@ mod tests {
         let repo_index = RepoGitIndex::new(&git).unwrap();
 
         assert!(scm.get_dirty_hash_from_repo_index(&repo_index).is_some());
+    }
+
+    /// After `git read-tree HEAD` every index entry loses its stat info, so
+    /// every tracked file becomes a verification candidate (the
+    /// snapshot-restored-workspace scenario). On a clean tree the
+    /// verification pass must prove `git diff HEAD` empty and skip it.
+    #[test]
+    fn test_dirty_hash_stale_index_clean_tree_skips_diff() {
+        let (repo_root, repo_path) = setup_repository(None).unwrap();
+        fs::write(repo_root.path().join("foo.txt"), "initial").unwrap();
+        commit_file(&repo_path, Path::new("foo.txt"), None);
+        fs::write(repo_root.path().join("bar.txt"), "other content\n").unwrap();
+        run_git(repo_root.path(), &["add", "bar.txt"]);
+        run_git(repo_root.path(), &["commit", "-q", "-m", "bar"]);
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink("foo.txt", repo_root.path().join("link.txt")).unwrap();
+            run_git(repo_root.path(), &["add", "link.txt"]);
+            run_git(repo_root.path(), &["commit", "-q", "-m", "link"]);
+        }
+
+        run_git(repo_root.path(), &["read-tree", "HEAD"]);
+
+        let git_root = AbsoluteSystemPathBuf::try_from(repo_root.path()).unwrap();
+        let scm = SCM::new(&git_root);
+        let git = make_git_repo(&git_root);
+        let repo_index = RepoGitIndex::new(&git).unwrap();
+
+        assert!(
+            repo_index.tracked_diff_clean_root(false).is_some(),
+            "clean stale index must prove the tree clean"
+        );
+        assert_eq!(scm.get_dirty_hash_from_repo_index(&repo_index), None);
+        assert_eq!(scm.get_dirty_hash(), None, "subprocess path must agree");
+    }
+
+    /// A genuinely modified file on a stale index must block the skip and
+    /// produce a dirty hash through the diff path.
+    #[test]
+    fn test_dirty_hash_stale_index_modified_file() {
+        let (repo_root, repo_path) = setup_repository(None).unwrap();
+        fs::write(repo_root.path().join("foo.txt"), "initial").unwrap();
+        commit_file(&repo_path, Path::new("foo.txt"), None);
+
+        run_git(repo_root.path(), &["read-tree", "HEAD"]);
+        fs::write(repo_root.path().join("foo.txt"), "changed").unwrap();
+
+        let git_root = AbsoluteSystemPathBuf::try_from(repo_root.path()).unwrap();
+        let scm = SCM::new(&git_root);
+        let git = make_git_repo(&git_root);
+        let repo_index = RepoGitIndex::new(&git).unwrap();
+
+        assert!(repo_index.tracked_diff_clean_root(false).is_none());
+        assert!(scm.get_dirty_hash_from_repo_index(&repo_index).is_some());
+        assert!(scm.get_dirty_hash().is_some(), "subprocess path must agree");
+    }
+
+    /// Staged changes invalidate the index's cache-tree, so the skip gate
+    /// must not fire even when every candidate verifies clean.
+    #[test]
+    fn test_dirty_hash_stale_index_staged_change_blocks_skip() {
+        let (repo_root, repo_path) = setup_repository(None).unwrap();
+        fs::write(repo_root.path().join("foo.txt"), "initial").unwrap();
+        commit_file(&repo_path, Path::new("foo.txt"), None);
+
+        run_git(repo_root.path(), &["read-tree", "HEAD"]);
+        fs::write(repo_root.path().join("foo.txt"), "staged").unwrap();
+        run_git(repo_root.path(), &["add", "foo.txt"]);
+
+        let git_root = AbsoluteSystemPathBuf::try_from(repo_root.path()).unwrap();
+        let scm = SCM::new(&git_root);
+        let git = make_git_repo(&git_root);
+        let repo_index = RepoGitIndex::new(&git).unwrap();
+
+        assert!(
+            repo_index.tracked_diff_clean_root(false).is_none(),
+            "staged change must block the diff skip"
+        );
+        assert!(scm.get_dirty_hash_from_repo_index(&repo_index).is_some());
+        assert!(scm.get_dirty_hash().is_some(), "subprocess path must agree");
+    }
+
+    /// An exec-bit flip is content-identical but `git diff HEAD` reports it
+    /// as a mode change. Verification must not let the skip fire.
+    #[cfg(unix)]
+    #[test]
+    fn test_dirty_hash_stale_index_exec_bit_flip() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (repo_root, repo_path) = setup_repository(None).unwrap();
+        fs::write(repo_root.path().join("foo.txt"), "initial").unwrap();
+        commit_file(&repo_path, Path::new("foo.txt"), None);
+
+        run_git(repo_root.path(), &["read-tree", "HEAD"]);
+        fs::set_permissions(
+            repo_root.path().join("foo.txt"),
+            fs::Permissions::from_mode(0o755),
+        )
+        .unwrap();
+
+        let git_root = AbsoluteSystemPathBuf::try_from(repo_root.path()).unwrap();
+        let scm = SCM::new(&git_root);
+        let git = make_git_repo(&git_root);
+        let repo_index = RepoGitIndex::new(&git).unwrap();
+
+        assert!(
+            repo_index.tracked_diff_clean_root(false).is_none(),
+            "exec-bit mismatch must block the diff skip"
+        );
+        assert!(
+            scm.get_dirty_hash_from_repo_index(&repo_index).is_some(),
+            "mode change must produce a dirty hash"
+        );
+        assert!(scm.get_dirty_hash().is_some(), "subprocess path must agree");
+    }
+
+    /// CRLF-containing content that raw-matches the index blocks the skip
+    /// (git's checkin conversion could disagree under configs we don't
+    /// read), but the diff then confirms cleanliness — both paths must
+    /// still report clean.
+    #[test]
+    fn test_dirty_hash_stale_index_crlf_content_stays_clean() {
+        let (repo_root, _repo_path) = setup_repository(None).unwrap();
+        run_git(repo_root.path(), &["config", "core.autocrlf", "false"]);
+        fs::write(repo_root.path().join("win.txt"), b"a\r\nb\r\n").unwrap();
+        run_git(repo_root.path(), &["add", "win.txt"]);
+        run_git(repo_root.path(), &["commit", "-q", "-m", "crlf"]);
+
+        run_git(repo_root.path(), &["read-tree", "HEAD"]);
+
+        let git_root = AbsoluteSystemPathBuf::try_from(repo_root.path()).unwrap();
+        let scm = SCM::new(&git_root);
+        let git = make_git_repo(&git_root);
+        let repo_index = RepoGitIndex::new(&git).unwrap();
+
+        let evidence = repo_index.tracked_diff_clean_root(false);
+        assert!(
+            matches!(
+                evidence,
+                Some((
+                    _,
+                    crate::repo_index::EolSensitivity::RequiresInertEolConversion
+                ))
+            ),
+            "CRLF text content must make the proof eol-sensitive, got {evidence:?}"
+        );
+        // Whether the skip fires depends on the machine's git config; the
+        // observable result must be clean either way (skip and diff agree).
+        assert_eq!(
+            scm.get_dirty_hash_from_repo_index(&repo_index),
+            None,
+            "tree must be reported clean"
+        );
+        assert_eq!(scm.get_dirty_hash(), None, "subprocess path must agree");
+    }
+
+    /// A retargeted symlink on a stale index must be caught as dirty.
+    #[cfg(unix)]
+    #[test]
+    fn test_dirty_hash_stale_index_symlink_retarget() {
+        let (repo_root, repo_path) = setup_repository(None).unwrap();
+        fs::write(repo_root.path().join("foo.txt"), "initial").unwrap();
+        commit_file(&repo_path, Path::new("foo.txt"), None);
+        std::os::unix::fs::symlink("foo.txt", repo_root.path().join("link.txt")).unwrap();
+        run_git(repo_root.path(), &["add", "link.txt"]);
+        run_git(repo_root.path(), &["commit", "-q", "-m", "link"]);
+
+        run_git(repo_root.path(), &["read-tree", "HEAD"]);
+        fs::remove_file(repo_root.path().join("link.txt")).unwrap();
+        std::os::unix::fs::symlink("elsewhere.txt", repo_root.path().join("link.txt")).unwrap();
+
+        let git_root = AbsoluteSystemPathBuf::try_from(repo_root.path()).unwrap();
+        let scm = SCM::new(&git_root);
+        let git = make_git_repo(&git_root);
+        let repo_index = RepoGitIndex::new(&git).unwrap();
+
+        assert!(repo_index.tracked_diff_clean_root(false).is_none());
+        assert!(scm.get_dirty_hash_from_repo_index(&repo_index).is_some());
+        assert!(scm.get_dirty_hash().is_some(), "subprocess path must agree");
+    }
+
+    /// Verified stat-stale entries must yield identical package hashes to a
+    /// fresh index, with nothing left to re-hash per package.
+    #[test]
+    fn test_stale_index_package_hashes_match_fresh() {
+        let (repo_root, repo_path) = setup_repository(None).unwrap();
+        fs::write(repo_root.path().join("foo.txt"), "initial").unwrap();
+        commit_file(&repo_path, Path::new("foo.txt"), None);
+        fs::write(repo_root.path().join("bar.txt"), "more\n").unwrap();
+        run_git(repo_root.path(), &["add", "bar.txt"]);
+        run_git(repo_root.path(), &["commit", "-q", "-m", "bar"]);
+
+        let git_root = AbsoluteSystemPathBuf::try_from(repo_root.path()).unwrap();
+        let git = make_git_repo(&git_root);
+        let prefix = turbopath::RelativeUnixPathBuf::new("").unwrap();
+
+        let fresh = RepoGitIndex::new(&git).unwrap();
+        let (fresh_hashes, _fresh_to_hash) = fresh.get_package_hashes(&prefix).unwrap();
+
+        run_git(repo_root.path(), &["read-tree", "HEAD"]);
+
+        let stale = RepoGitIndex::new(&git).unwrap();
+        let (stale_hashes, stale_to_hash) = stale.get_package_hashes(&prefix).unwrap();
+
+        assert_eq!(
+            fresh_hashes, stale_hashes,
+            "stale-index package hashes must match fresh-index hashes"
+        );
+        assert!(
+            stale_to_hash.is_empty(),
+            "verified entries must not be deferred to per-package hashing, got {stale_to_hash:?}"
+        );
     }
 
     #[test]

--- a/crates/turborepo-scm/src/hash_object.rs
+++ b/crates/turborepo-scm/src/hash_object.rs
@@ -8,7 +8,9 @@ const MAX_RETRIES: u32 = 10;
 const BASE_DELAY_MS: u64 = 10;
 const MAX_DELAY_MS: u64 = 1000;
 
-fn with_emfile_retry<T>(f: impl Fn() -> Result<T, std::io::Error>) -> Result<T, std::io::Error> {
+pub(crate) fn with_emfile_retry<T>(
+    f: impl Fn() -> Result<T, std::io::Error>,
+) -> Result<T, std::io::Error> {
     for attempt in 0..MAX_RETRIES {
         match f() {
             Ok(v) => return Ok(v),

--- a/crates/turborepo-scm/src/repo_index.rs
+++ b/crates/turborepo-scm/src/repo_index.rs
@@ -28,6 +28,21 @@ pub struct RepoGitIndex {
     untracked_symlinks: Vec<RelativeUnixPathBuf>,
     unsupported_paths: Vec<UnsupportedGitPath>,
     untracked_entries_populated: bool,
+    /// True when some condition prevents proving that `git diff HEAD` would
+    /// be empty (sparse index, submodules, intent-to-add/skip-worktree
+    /// entries, `.gitattributes` presence, unsupported paths, or a
+    /// stat-stale entry whose content matched only after CRLF normalization
+    /// / with an exec-bit mismatch). See [`Self::tracked_diff_clean_root`].
+    diff_skip_blocked: bool,
+    /// True when at least one verified entry's diff-safety additionally
+    /// requires eol conversion to be off (`core.autocrlf` etc.) — checked by
+    /// the caller at dirty-hash time.
+    eol_sensitive: bool,
+    /// The index's cache-tree root oid (hex), present only when the TREE
+    /// extension is valid and covers every entry — i.e. this is the tree
+    /// `git write-tree` would produce. `None` after `git add` or when the
+    /// extension is missing.
+    cache_tree_root: Option<String>,
 }
 
 impl RepoGitIndex {
@@ -42,6 +57,9 @@ impl RepoGitIndex {
             unsupported_paths: Vec::new(),
             untracked_symlinks: Vec::new(),
             untracked_entries_populated: true,
+            diff_skip_blocked: true,
+            eol_sensitive: false,
+            cache_tree_root: None,
         }
     }
 
@@ -107,67 +125,131 @@ impl RepoGitIndex {
         // sequential scan of all entries).
         let num_entries = index.entries().len();
 
+        // Conditions under which we can never prove `git diff HEAD` empty:
+        // submodule changes don't appear in the index stat comparison;
+        // intent-to-add / skip-worktree / sparse entries all make `git diff`
+        // see things this walk doesn't; and any `.gitattributes` file could
+        // carry conversion rules (eol, filters, working-tree-encoding) that
+        // this code doesn't interpret. The attributes restriction is
+        // deliberately coarse for now — repos with no attributes are fully
+        // provable, repos with attributes always run the diff.
+        let has_special_entries = index.is_sparse()
+            || git.git_attrs().is_some()
+            || index.entries().iter().any(|e| {
+                e.mode.is_submodule()
+                    || e.flags.intersects(
+                        gix_index::entry::Flags::INTENT_TO_ADD
+                            | gix_index::entry::Flags::SKIP_WORKTREE,
+                    )
+                    || e.path(&index).ends_with(b".gitattributes")
+            });
+
+        // A valid cache-tree root covering every entry is exactly the tree
+        // `git write-tree` would produce for this index. If it equals
+        // HEAD^{tree} there are no staged changes. `git add`/merge conflicts
+        // invalidate the extension, so absence is the conservative signal.
+        let cache_tree_root = index.tree().and_then(|tree| {
+            (tree.name.is_empty() && tree.num_entries == Some(num_entries as u32))
+                .then(|| tree.id.to_string())
+        });
+
+        let attrs = git.git_attrs();
+
         // Classify entries in parallel: stat each file, compare with index,
         // and carry the raw ObjectId (20 bytes, Copy) instead of a heap-allocated
         // hex String. Hex conversion uses a thread-local stack buffer to avoid
         // allocator contention across rayon threads.
+        //
+        // Stat-stale (or racy) entries are content-verified inline with the
+        // hardware-accelerated blob hasher: if the working file still hashes
+        // to the index oid, the entry is clean and downstream consumers can
+        // use the committed hash instead of re-hashing it per package. This
+        // is what makes snapshot-restored workspaces (where every entry is
+        // stat-stale) behave like fresh checkouts.
         let classified: Vec<Result<EntryClassification, Error>> = index
             .entries()
             .par_iter()
             .filter(|e| !e.mode.is_submodule())
-            .map(|e| {
-                let path_bytes = e.path(&index);
-                let rel_path = match parse_git_path(path_bytes, "git index path")? {
-                    Ok(path) => path,
-                    Err(path) => return Ok(EntryClassification::Unsupported(path)),
-                };
-                // Git index paths are normalized repo-relative paths, so avoid
-                // per-entry path_clean normalization before stat calls.
-                let abs_path = git.root.join_unix_path_unchecked(&rel_path);
+            .map_init(
+                || attrs.map(|a| a.new_outcome()),
+                |attr_outcome, e| {
+                    let path_bytes = e.path(&index);
+                    let rel_path = match parse_git_path(path_bytes, "git index path")? {
+                        Ok(path) => path,
+                        Err(path) => return Ok(EntryClassification::Unsupported(path)),
+                    };
+                    // Git index paths are normalized repo-relative paths, so avoid
+                    // per-entry path_clean normalization before stat calls.
+                    let abs_path = git.root.join_unix_path_unchecked(&rel_path);
 
-                match gix_index::fs::Metadata::from_path_no_follow(abs_path.as_std_path()) {
-                    Ok(fs_meta) => {
-                        let fs_stat = gix_index::entry::Stat::from_fs(&fs_meta).map_err(|err| {
-                            Error::git_error(format!(
-                                "failed to convert stat for {}: {}",
-                                rel_path, err
-                            ))
-                        })?;
+                    match gix_index::fs::Metadata::from_path_no_follow(abs_path.as_std_path()) {
+                        Ok(fs_meta) => {
+                            let fs_stat =
+                                gix_index::entry::Stat::from_fs(&fs_meta).map_err(|err| {
+                                    Error::git_error(format!(
+                                        "failed to convert stat for {}: {}",
+                                        rel_path, err
+                                    ))
+                                })?;
 
-                        let stat_matches = e.stat.matches(&fs_stat, stat_opts);
+                            let stat_matches = e.stat.matches(&fs_stat, stat_opts);
+                            let is_racy = e.stat.is_racy(index_timestamp, stat_opts);
 
-                        if !stat_matches {
-                            return Ok(EntryClassification::Modified { path: rel_path });
+                            if !stat_matches || is_racy {
+                                let text_attr = match (attrs, attr_outcome.as_mut()) {
+                                    (Some(a), Some(o)) => {
+                                        a.resolve_text_attr_with(rel_path.as_str(), o)
+                                    }
+                                    _ => crate::crlf::TextAttr::Unspecified,
+                                };
+                                return Ok(verify_candidate(
+                                    e, rel_path, &abs_path, &fs_meta, text_attr,
+                                ));
+                            }
+
+                            let mut hex_buf = [0u8; 40];
+                            hex::encode_to_slice(e.id.as_bytes(), &mut hex_buf).map_err(|err| {
+                                Error::git_error(format!(
+                                    "failed to encode object id for {rel_path}: {err}"
+                                ))
+                            })?;
+                            Ok(EntryClassification::Clean {
+                                path: rel_path,
+                                oid: OidHash::from_hex_buf(hex_buf),
+                                diff_safe: DiffSafety::Safe,
+                            })
                         }
-
-                        let is_racy = e.stat.is_racy(index_timestamp, stat_opts);
-                        if is_racy {
-                            return Ok(EntryClassification::Modified { path: rel_path });
-                        }
-
-                        let mut hex_buf = [0u8; 40];
-                        hex::encode_to_slice(e.id.as_bytes(), &mut hex_buf).map_err(|err| {
-                            Error::git_error(format!(
-                                "failed to encode object id for {rel_path}: {err}"
-                            ))
-                        })?;
-                        Ok(EntryClassification::Clean {
-                            path: rel_path,
-                            oid: OidHash::from_hex_buf(hex_buf),
-                        })
+                        Err(_) => Ok(EntryClassification::Deleted { path: rel_path }),
                     }
-                    Err(_) => Ok(EntryClassification::Deleted { path: rel_path }),
-                }
-            })
+                },
+            )
             .collect();
 
         let mut ls_tree_hashes = SortedGitHashes::with_capacity(num_entries);
         let mut status_entries = Vec::new();
         let mut unsupported_paths = Vec::new();
+        let mut diff_skip_blocked = has_special_entries;
+        let mut diff_unsafe_count = 0usize;
+        let mut eol_sensitive_count = 0usize;
 
         for result in classified {
             match result? {
-                EntryClassification::Clean { path, oid } => {
+                EntryClassification::Clean {
+                    path,
+                    oid,
+                    diff_safe,
+                } => {
+                    match diff_safe {
+                        DiffSafety::Safe => {}
+                        DiffSafety::SafeIfEolInert => eol_sensitive_count += 1,
+                        DiffSafety::Unsafe => {
+                            diff_skip_blocked = true;
+                            diff_unsafe_count += 1;
+                            if diff_unsafe_count <= 5 {
+                                debug!("diff-unsafe verified entry: {path}");
+                            }
+                        }
+                    }
                     ls_tree_hashes.push((path, oid));
                 }
                 EntryClassification::Modified { path } => {
@@ -188,6 +270,12 @@ impl RepoGitIndex {
             }
         }
 
+        if !unsupported_paths.is_empty() {
+            // Unrepresentable paths are tracked files whose diff state we
+            // can't reason about.
+            diff_skip_blocked = true;
+        }
+
         // ls_tree_hashes is already sorted (git index is sorted, rayon
         // preserves order for indexed iterators, sequential loop preserves
         // order). status_entries from Modified/Deleted are also in index order
@@ -198,9 +286,16 @@ impl RepoGitIndex {
         unsupported_paths.dedup();
 
         debug!(
-            "built tracked repo git index (gix-index): clean_count={}, status_count={}",
+            "built tracked repo git index (gix-index): clean_count={}, status_count={}, \
+             diff_skip_blocked={}, diff_unsafe_count={}, eol_sensitive_count={}, special={}, \
+             cache_tree_root={:?}",
             ls_tree_hashes.len(),
             status_entries.len(),
+            diff_skip_blocked,
+            diff_unsafe_count,
+            eol_sensitive_count,
+            has_special_entries,
+            cache_tree_root,
         );
 
         Ok(Self {
@@ -209,6 +304,9 @@ impl RepoGitIndex {
             unsupported_paths,
             untracked_symlinks: Vec::new(),
             untracked_entries_populated: false,
+            diff_skip_blocked,
+            eol_sensitive: eol_sensitive_count > 0,
+            cache_tree_root,
         })
     }
 
@@ -337,6 +435,11 @@ impl RepoGitIndex {
             unsupported_paths,
             untracked_symlinks: Vec::new(),
             untracked_entries_populated: true,
+            // The subprocess path has no per-entry verification or
+            // cache-tree access; the dirty hash always runs the diff.
+            diff_skip_blocked: true,
+            eol_sensitive: false,
+            cache_tree_root: None,
         })
     }
 
@@ -442,6 +545,52 @@ impl RepoGitIndex {
     /// stream is the canonical input for tracked content changes. The repo
     /// index may conservatively mark clean racy-git entries as modified so they
     /// get content-hashed later, and those must not make a clean tree dirty.
+    /// When `Some(root_tree_hex)` is returned, the working tree provably has
+    /// no unstaged changes to tracked files: every stat-stale entry was
+    /// content-verified against the index under diff-safe conditions, and no
+    /// modified/deleted/special entries remain. The caller must additionally
+    /// confirm `root_tree_hex == HEAD^{tree}` (no staged changes) before
+    /// concluding that `git diff HEAD` would produce no output.
+    ///
+    /// `info_attributes_exists` is the caller's answer to whether
+    /// `$GIT_DIR/info/attributes` exists — attribute rules from there (like
+    /// any `.gitattributes`, which is checked here against tracked and
+    /// untracked entries) could impose conversions this code doesn't
+    /// interpret.
+    ///
+    /// `None` means nothing is proven — run the diff. Otherwise returns the
+    /// cache-tree root plus whether the caller must also verify that eol
+    /// conversion is inert (`core.autocrlf` off, no attribute sources
+    /// outside the repo) before trusting the proof.
+    pub fn tracked_diff_clean_root(
+        &self,
+        info_attributes_exists: bool,
+    ) -> Option<(&str, EolSensitivity)> {
+        if self.diff_skip_blocked || info_attributes_exists {
+            return None;
+        }
+        if self.status_entries.iter().any(|e| !e.is_untracked) {
+            return None;
+        }
+        // Untracked .gitattributes files affect git's conversion right now
+        // even though they're not in the index.
+        if self
+            .status_entries
+            .iter()
+            .any(|e| e.is_untracked && e.path.as_str().ends_with(".gitattributes"))
+        {
+            return None;
+        }
+        let sensitivity = if self.eol_sensitive {
+            EolSensitivity::RequiresInertEolConversion
+        } else {
+            EolSensitivity::ConfigIndependent
+        };
+        self.cache_tree_root
+            .as_deref()
+            .map(|root| (root, sensitivity))
+    }
+
     pub fn append_dirty_status_to_hasher(&self, hasher: &mut sha2::Sha256) -> bool {
         use sha2::Digest;
 
@@ -1323,10 +1472,40 @@ fn parent_path_bytes(path: &[u8]) -> &[u8] {
         .unwrap_or(b"")
 }
 
+/// Whether the clean-tree proof from [`RepoGitIndex::tracked_diff_clean_root`]
+/// additionally depends on git's eol conversion being inert.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EolSensitivity {
+    /// The proof holds under any git config.
+    ConfigIndependent,
+    /// The proof requires `core.autocrlf` to be unset/false and no attribute
+    /// sources outside the repo (`core.attributesFile`, global/system
+    /// attribute files).
+    RequiresInertEolConversion,
+}
+
+/// Whether an entry provably contributes nothing to `git diff HEAD`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DiffSafety {
+    /// Provable under any git config.
+    Safe,
+    /// Provable only if eol conversion is off (`core.autocrlf` unset/false
+    /// and no attribute sources outside the repo): a text file with CRLFs
+    /// whose raw bytes match the index oid.
+    SafeIfEolInert,
+    /// Not provable: content matched only after CRLF normalization, or the
+    /// executable bit changed (content-identical, but `git diff` reports
+    /// mode changes).
+    Unsafe,
+}
+
 enum EntryClassification {
     Clean {
         path: RelativeUnixPathBuf,
         oid: OidHash,
+        /// `Safe` for stat-fresh entries (git trusts the same stat cache);
+        /// verified entries carry the safety of their content match.
+        diff_safe: DiffSafety,
     },
     Modified {
         path: RelativeUnixPathBuf,
@@ -1335,6 +1514,109 @@ enum EntryClassification {
         path: RelativeUnixPathBuf,
     },
     Unsupported(UnsupportedGitPath),
+}
+
+/// Content-verify a stat-stale (or racy) index entry against its recorded
+/// oid. Returns `Clean` when the working-tree content still hashes to the
+/// index oid, `Modified` otherwise — including every case we can't verify
+/// (type changes, read errors, exotic modes), which downstream consumers
+/// re-hash or hand to `git diff` exactly as before this optimization.
+fn verify_candidate(
+    entry: &gix_index::Entry,
+    rel_path: RelativeUnixPathBuf,
+    abs_path: &turbopath::AbsoluteSystemPath,
+    fs_meta: &gix_index::fs::Metadata,
+    text_attr: crate::crlf::TextAttr,
+) -> EntryClassification {
+    use gix_index::entry::Mode;
+
+    let modified = |path| EntryClassification::Modified { path };
+
+    let mut hex_buf = [0u8; 40];
+    if hex::encode_to_slice(entry.id.as_bytes(), &mut hex_buf).is_err() {
+        return modified(rel_path);
+    }
+    let index_oid = OidHash::from_hex_buf(hex_buf);
+
+    match entry.mode {
+        Mode::SYMLINK => {
+            if !fs_meta.is_symlink() {
+                return modified(rel_path);
+            }
+            let Ok(target) = std::fs::read_link(abs_path.as_std_path()) else {
+                return modified(rel_path);
+            };
+            #[cfg(unix)]
+            let target_bytes = {
+                use std::os::unix::ffi::OsStrExt;
+                target.as_os_str().as_bytes().to_vec()
+            };
+            #[cfg(not(unix))]
+            let target_bytes = match target.to_str() {
+                Some(s) => s.as_bytes().to_vec(),
+                None => return modified(rel_path),
+            };
+            match crate::crlf::hash_bytes_as_blob(&target_bytes) {
+                Ok(oid) if oid == index_oid => EntryClassification::Clean {
+                    path: rel_path,
+                    oid,
+                    // Symlink blobs are the target string; no filters or
+                    // mode bits can diverge once type and target match.
+                    diff_safe: DiffSafety::Safe,
+                },
+                _ => modified(rel_path),
+            }
+        }
+        Mode::FILE | Mode::FILE_EXECUTABLE => {
+            if !fs_meta.is_file() || fs_meta.is_symlink() {
+                return modified(rel_path);
+            }
+            let Ok((oid, outcome)) = crate::hash_object::with_emfile_retry(|| {
+                crate::crlf::hash_file_for_verification(abs_path, text_attr)
+            }) else {
+                return modified(rel_path);
+            };
+            if oid != index_oid {
+                return modified(rel_path);
+            }
+
+            #[cfg(unix)]
+            let exec_matches = (entry.mode == Mode::FILE_EXECUTABLE) == fs_meta.is_executable();
+            // git ignores the executable bit where the filesystem can't
+            // represent it (core.fileMode=false, the default on Windows).
+            #[cfg(not(unix))]
+            let exec_matches = true;
+
+            // Safety of the raw-byte match against git's checkin conversion
+            // (these flags are only consulted when no `.gitattributes`
+            // exists anywhere — see the constructor and
+            // `tracked_diff_clean_root`):
+            // - `crlf_count == 0`: CRLF-free content is a fixed point of every eol/autocrlf
+            //   conversion — safe under any config.
+            // - `is_binary`: git's autocrlf/`text=auto` detection refuses to convert binary
+            //   content, and our NUL check is a conservative subset of git's — safe under
+            //   any config.
+            // - text with CRLFs: safe only if `core.autocrlf` is provably off (otherwise
+            //   git would report the file modified even though the raw bytes match) —
+            //   deferred to a config check at dirty-hash time.
+            let diff_safe = if !exec_matches || outcome.normalized {
+                DiffSafety::Unsafe
+            } else if outcome.crlf_count == 0 || outcome.is_binary {
+                DiffSafety::Safe
+            } else {
+                DiffSafety::SafeIfEolInert
+            };
+
+            EntryClassification::Clean {
+                path: rel_path,
+                oid,
+                diff_safe,
+            }
+        }
+        // Anything exotic (sparse dir entries, unexpected modes) stays
+        // conservative.
+        _ => modified(rel_path),
+    }
 }
 
 #[cfg(test)]
@@ -1378,6 +1660,9 @@ mod tests {
             unsupported_paths: Vec::new(),
             untracked_symlinks: Vec::new(),
             untracked_entries_populated: true,
+            diff_skip_blocked: true,
+            eol_sensitive: false,
+            cache_tree_root: None,
         }
     }
 


### PR DESCRIPTION
## Why

Every `turbo run` spawns `git diff HEAD` to compute the dirty hash (cache provenance metadata). On a stat-stale git index — snapshot-restored workspaces: dev containers, CI workspace caches — that diff re-verifies every tracked file with sha1dc, costing ~2.9s of serial wall time on a 1191-package/43k-file monorepo. Separately, staleness floods per-package hashing: every stat-stale entry is deferred to `to_hash` and re-hashed, and stale symlinks are hashed *by following them*, which disagrees with git and with the same repo's fresh-index hashes (same content, different task hashes).

## What

**Verification pass** (`repo_index.rs`): stat-stale/racy entries are content-verified inline during index construction (parallel, hardware SHA-1 from the base PR). Entries whose working content still hashes to the index oid are reclassified clean, carrying the committed oid — eliminating the per-package re-hash flood and making stale-index outputs byte-identical to fresh-index outputs (including symlinks, verified via readlink against the blob).

**Diff skip** (`git.rs`): when *every* candidate verified clean under diff-safe conditions and the index's cache-tree root equals `HEAD^{tree}` (no staged changes), `git diff HEAD` provably produces no output and is not spawned. The hash bytes are identical to the diff-running path (the diff would have contributed nothing).

The proof is conservative — any of these runs the diff exactly as before: `.gitattributes` anywhere (tracked, untracked, `info/attributes`), submodules, sparse index, intent-to-add/skip-worktree entries, deletions, exec-bit changes, content that matched only after CRLF normalization, invalid cache-tree, unborn HEAD. Text files containing CRLFs additionally require `core.autocrlf` to be provably off (one `git config -z --list` spawn, plus global/system attribute-file existence checks); CRLF-free and binary content is config-independent (CRLF-free content is a fixed point of every eol conversion; git's own binary detection exempts binary from autocrlf, and our NUL check is a conservative subset of git's).

## Benchmarks

1191-package/43k-file monorepo, 4-core Linux. `git read-tree HEAD` once (fully stat-stale index, the snapshot-restore case), then consecutive dry runs; median of 5 lifecycles:

| | run 1 | run 2 | run 3 | run 4 |
|---|---|---|---|---|
| main | 3571ms | 915ms | 903ms | 888ms |
| this PR | **1072ms (−70%)** | 1085ms | 1084ms | 1055ms |

Two honest caveats visible in that table:

- **main heals, this PR doesn't**: git's diff opportunistically refreshes the index stat cache (even under `GIT_OPTIONAL_LOCKS=0`), so main pays 3.6s once and then runs fresh. With the skip, the index stays stale and each run pays ~170ms of re-verification. Break-even is ~15 runs — but the environments that hit this hardest (ephemeral CI restores) are *always* run 1, and any user git command heals the index anyway. A detached background heal was considered and rejected: a killed-mid-write orphan can leave `.git/index.lock` behind.
- **Fresh steady state is unchanged** (878 vs 902ms medians, within noise): no candidates → no verification cost; the saved 27ms diff roughly cancels the added `rev-parse HEAD^{tree}` spawn.

## Behavior change

On stale indexes, task hashes for packages containing stat-stale symlinks change to the git-correct values: previously a stale symlink was hashed by following its target (or dropped if broken) while a fresh one used the index oid — same repo content, different hashes depending on index freshness. Stale and fresh outputs are now byte-identical (verified on the full `--dry=json` of the benchmark repo).

## How to verify

- `turborepo-scm` tests include: stale-clean tree skips the diff and agrees with the subprocess path; modified file / staged change / exec-bit flip / symlink retarget / intent-to-add all block the skip and agree; CRLF text content makes the proof eol-sensitive; stale package hashes equal fresh ones with nothing deferred to re-hashing.
- On a real repo: `git read-tree HEAD && GIT_TRACE=1 turbo run build --dry=json` — no `git diff` in the trace when the tree is clean; identical dry-run JSON (modulo run id) before/after.

Stacked on #13245 (hardware SHA-1), which makes the verification pass affordable.
