### PR TITLE
feat: Discover Cargo crates as packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8141,6 +8141,7 @@ dependencies = [
  "biome_deserialize_macros 0.6.0",
  "biome_diagnostics",
  "biome_json_parser",
+ "dunce",
  "either",
  "globwalk",
  "insta",

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -353,7 +353,21 @@ impl RunBuilder {
             pkg_dep_graph,
             scm,
             root_turbo_json,
-        )?;
+        )
+        .map_err(|err| match err {
+            // A filter that names a Rust crate is a likely mistake when the
+            // repository has a Cargo workspace but Cargo package support is
+            // not enabled; point at the opt-in.
+            ResolutionError::NoPackagesMatchedWithName(name)
+                if !cargo_enabled(&opts.future_flags)
+                    && repo_root
+                        .join_component(turborepo_repository::cargo::CARGO_TOML)
+                        .exists() =>
+            {
+                Error::PackageMayBeCargoCrate { name }
+            }
+            err => Error::Scope(err),
+        })?;
 
         let should_include_root_tasks = match filter_mode {
             FilterMode::AllPackages => true,
@@ -491,9 +505,14 @@ impl RunBuilder {
         }
 
         let mut pkg_dep_graph = {
-            let builder = PackageGraph::builder(&self.repo_root, root_package_json.clone())
+            let mut builder = PackageGraph::builder(&self.repo_root, root_package_json.clone())
                 .with_single_package_mode(self.opts.run_opts.single_package)
                 .with_allow_no_package_manager(self.opts.repo_opts.allow_no_package_manager);
+            if cargo_enabled(&self.opts.future_flags) {
+                builder = builder.with_toolchain(turborepo_repository::cargo::CargoToolchain::new(
+                    self.repo_root.to_owned(),
+                ));
+            }
 
             let graph = builder
                 .build()
@@ -1091,6 +1110,14 @@ impl RunBuilder {
 
         Ok(engine)
     }
+}
+
+/// Whether experimental Cargo package support is enabled, via
+/// `futureFlags.experimentalCargoWorkspaces` in the root turbo.json. The
+/// future flag is the only switch: it is repo-level configuration, so every
+/// invoker sees the same package graph.
+pub(crate) fn cargo_enabled(future_flags: &turborepo_turbo_json::FutureFlags) -> bool {
+    future_flags.experimental_cargo_workspaces
 }
 
 fn origins_match(url1: &str, url2: &str) -> bool {

--- a/crates/turborepo-lib/src/run/error.rs
+++ b/crates/turborepo-lib/src/run/error.rs
@@ -77,4 +77,11 @@ pub enum Error {
     GlobalFileHashTaskIncomplete,
     #[error("Affected range was not configured")]
     MissingAffectedRange,
+    #[error("No package found with name '{name}' in workspace")]
+    #[diagnostic(help(
+        "This repository contains a Cargo workspace, but Cargo package support is not enabled. \
+         Rust crates become packages when `futureFlags.experimentalCargoWorkspaces` is set in the \
+         root turbo.json."
+    ))]
+    PackageMayBeCargoCrate { name: String },
 }

--- a/crates/turborepo-repository/Cargo.toml
+++ b/crates/turborepo-repository/Cargo.toml
@@ -16,6 +16,7 @@ biome_deserialize_macros = { workspace = true }
 biome_diagnostics = { workspace = true }
 biome_json_parser = { workspace = true }
 
+dunce = { workspace = true }
 either = { workspace = true }
 globwalk = { version = "0.1.0", path = "../turborepo-globwalk" }
 itertools = { workspace = true }

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -1,0 +1,689 @@
+//! The Cargo toolchain: Rust crates as Turborepo packages.
+//!
+//! Turborepo does not replace Cargo — Cargo is itself a build system with
+//! its own dependency graph, scheduler, and incremental cache. Turborepo's
+//! job is orchestration: decide *which* crates are in scope and *whether*
+//! anything changed, then hand the work to Cargo and get out of the way.
+//!
+//! Discovery shells out to `cargo metadata`, because Cargo is the only
+//! correct implementation of its own workspace-membership semantics (member
+//! globs, automatic path-dependency members, excludes, target-specific
+//! dependency tables, renames). Crates are classified into two shapes:
+//!
+//! * **Entrypoints** — crates with `bin`/`cdylib`/`staticlib` targets: the
+//!   deliverables of the workspace.
+//! * **Libraries** — everything else. They exist in the package graph (so
+//!   `--filter` and `--affected` propagate through them): being buildable is
+//!   not the same as being an entrypoint.
+//!
+//! A synthetic package named [`WORKSPACE_PACKAGE_NAME`], anchored at the
+//! root `Cargo.toml` and depending on every crate, represents the workspace
+//! itself; it will host workspace-scoped verification verbs (`cargo test
+//! --workspace`, ...) once command resolution gains a toolchain surface.
+//!
+//! Support is experimental and gated behind
+//! `futureFlags.experimentalCargoWorkspaces`.
+
+use std::{
+    collections::{BTreeSet, HashMap, HashSet},
+    io,
+    sync::Arc,
+};
+
+use serde::Deserialize;
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
+use turborepo_errors::Spanned;
+
+use crate::{
+    package_json::PackageJson,
+    toolchain::{self, DiscoverPackagesFuture, DiscoveredPackage, Toolchain, ToolchainId},
+};
+
+/// The conventional file name for a Cargo manifest.
+pub const CARGO_TOML: &str = "Cargo.toml";
+
+/// The conventional file name for a Cargo lockfile.
+pub const CARGO_LOCK: &str = "Cargo.lock";
+
+/// Name of the synthetic package that represents the Cargo workspace itself.
+/// A real workspace member with this name is skipped with a warning.
+pub const WORKSPACE_PACKAGE_NAME: &str = "cargo";
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("failed to run `cargo metadata`: {0}")]
+    MetadataSpawn(#[source] io::Error),
+    #[error("`cargo metadata` failed: {stderr}")]
+    Metadata { stderr: String },
+    #[error("failed to parse `cargo metadata` output: {0}")]
+    Parse(#[from] serde_json::Error),
+}
+
+/// The Cargo toolchain. Registered in the
+/// [`crate::toolchain::ToolchainRegistry`] when
+/// `futureFlags.experimentalCargoWorkspaces` is enabled and the repository
+/// root contains a `Cargo.toml`.
+pub struct CargoToolchain {
+    repo_root: AbsoluteSystemPathBuf,
+}
+
+impl CargoToolchain {
+    pub fn new(repo_root: AbsoluteSystemPathBuf) -> Arc<Self> {
+        Arc::new(Self { repo_root })
+    }
+}
+
+impl Toolchain for CargoToolchain {
+    fn id(&self) -> ToolchainId {
+        ToolchainId::CARGO
+    }
+
+    fn discover_packages(&self) -> DiscoverPackagesFuture<'_> {
+        Box::pin(async move {
+            // Discovery spawns `cargo metadata` synchronously, so keep it off
+            // the async runtime like the JavaScript manifest-parsing path.
+            let crates =
+                turborepo_rayon_compat::block_in_place(|| discover_crates(&self.repo_root))
+                    .map_err(|err| toolchain::Error::Failed(Box::new(err)))?;
+
+            // Each crate becomes a package. Internal dependencies are
+            // expressed as `workspace:*` specifiers in the synthesized
+            // descriptor so the existing dependency splitter wires
+            // crate->crate edges (powering `--filter`/`--affected`).
+            // Discovery only reports dependencies on other discovered
+            // crates, so every synthesized specifier resolves internally and
+            // Cargo edges never leak into unresolved externals.
+            let mut packages = Vec::with_capacity(crates.len() + 1);
+            let mut crate_names = Vec::with_capacity(crates.len());
+            for cargo_crate in crates {
+                let dependencies = cargo_crate
+                    .internal_dependencies
+                    .iter()
+                    .map(|dep| (dep.clone(), "workspace:*".to_string()))
+                    .collect();
+                crate_names.push(cargo_crate.name.clone());
+                packages.push(DiscoveredPackage {
+                    descriptor: PackageJson {
+                        name: Some(Spanned::new(cargo_crate.name)),
+                        dependencies: Some(dependencies),
+                        ..Default::default()
+                    },
+                    manifest_path: cargo_crate.manifest_path,
+                });
+            }
+
+            // The synthetic workspace package, anchored at the root
+            // Cargo.toml. It depends on every crate so `--affected` and
+            // dependent-filters propagate crate changes to it.
+            if !crate_names.is_empty() {
+                let dependencies = crate_names
+                    .into_iter()
+                    .map(|name| (name, "workspace:*".to_string()))
+                    .collect();
+                packages.push(DiscoveredPackage {
+                    descriptor: PackageJson {
+                        name: Some(Spanned::new(WORKSPACE_PACKAGE_NAME.to_string())),
+                        dependencies: Some(dependencies),
+                        ..Default::default()
+                    },
+                    manifest_path: self.repo_root.join_component(CARGO_TOML),
+                });
+            }
+
+            Ok(packages)
+        })
+    }
+}
+
+/// Whether `name` is a valid Cargo crate name for our purposes. Cargo itself
+/// enforces this for published crates; local manifests are looser, so guard
+/// against names that would break downstream task identifiers.
+pub fn is_valid_crate_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+}
+
+/// A deliverable artifact an entrypoint crate produces: the target name plus
+/// the artifact flavor, which determines the file names Cargo writes to the
+/// target directory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Deliverable {
+    /// The target name as reported by `cargo metadata`. Bin targets keep
+    /// their manifest spelling; lib-flavored targets are already
+    /// snake_cased, matching the artifact file name.
+    pub name: String,
+    pub kind: DeliverableKind,
+}
+
+/// The artifact flavor of a [`Deliverable`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeliverableKind {
+    /// An executable: `<name>` / `<name>.exe`.
+    Bin,
+    /// A C-compatible dynamic library: `lib<name>.so` / `lib<name>.dylib` /
+    /// `<name>.dll`.
+    Cdylib,
+    /// A C-compatible static archive: `lib<name>.a` / `<name>.lib`.
+    Staticlib,
+}
+
+/// A single Rust crate discovered within a Cargo workspace.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CargoCrate {
+    /// The crate's package name (from `[package].name`).
+    pub name: String,
+    /// Absolute path to the crate's `Cargo.toml`.
+    pub manifest_path: AbsoluteSystemPathBuf,
+    /// Names of other workspace crates this crate depends on, resolved by
+    /// Cargo itself (`cargo metadata`). Dev-dependency edges that would form
+    /// a cycle are dropped, since Cargo permits dev-dep cycles but the
+    /// package graph must remain a DAG.
+    pub internal_dependencies: Vec<String>,
+    /// The crate's deliverable targets. Non-empty exactly when the crate is
+    /// an entrypoint (has `bin`/`cdylib`/`staticlib` targets).
+    pub deliverables: Vec<Deliverable>,
+}
+
+impl CargoCrate {
+    /// Whether this crate is an entrypoint: it produces deliverable
+    /// artifacts.
+    pub fn is_entrypoint(&self) -> bool {
+        !self.deliverables.is_empty()
+    }
+}
+
+/// Discover all Rust crates in the Cargo workspace rooted at `repo_root` by
+/// invoking `cargo metadata --no-deps`.
+///
+/// Returns an empty vec if `repo_root` has no `Cargo.toml`. A root manifest
+/// that exists but that Cargo rejects is an error — the user opted into
+/// Cargo support, so silently discovering nothing would be misleading.
+/// `--no-deps` skips registry resolution, so no lockfile or network access
+/// is required.
+///
+/// Crates whose manifests live outside the repository root, or whose names
+/// are invalid, are skipped with a warning. A `[package]` in the root
+/// manifest is skipped too: its directory would be the entire repository.
+pub fn discover_crates(repo_root: &AbsoluteSystemPath) -> Result<Vec<CargoCrate>, Error> {
+    let root_manifest_path = repo_root.join_component(CARGO_TOML);
+    if !root_manifest_path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let output = std::process::Command::new("cargo")
+        .args([
+            "metadata",
+            "--format-version",
+            "1",
+            "--no-deps",
+            "--manifest-path",
+            root_manifest_path.as_str(),
+        ])
+        .current_dir(repo_root.as_std_path())
+        .output()
+        .map_err(Error::MetadataSpawn)?;
+    if !output.status.success() {
+        return Err(Error::Metadata {
+            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        });
+    }
+    let metadata: Metadata = serde_json::from_slice(&output.stdout)?;
+
+    Ok(connect_crates(parse_members(
+        repo_root,
+        &root_manifest_path,
+        metadata,
+    )))
+}
+
+/// A workspace member parsed from `cargo metadata`, before dependency edges
+/// are resolved to crate names.
+struct ParsedCrate {
+    name: String,
+    manifest_path: AbsoluteSystemPathBuf,
+    dependencies: Vec<ResolvedDep>,
+    deliverables: Vec<Deliverable>,
+}
+
+/// A path dependency resolved to the directory Cargo reports for it.
+struct ResolvedDep {
+    dir: AbsoluteSystemPathBuf,
+    dev: bool,
+}
+
+fn parse_members(
+    repo_root: &AbsoluteSystemPath,
+    root_manifest_path: &AbsoluteSystemPath,
+    metadata: Metadata,
+) -> Vec<ParsedCrate> {
+    let mut parsed = Vec::new();
+    for package in metadata.packages {
+        let Ok(manifest_path) = AbsoluteSystemPathBuf::new(package.manifest_path.clone()) else {
+            tracing::warn!(
+                "skipping Cargo crate {}: non-absolute manifest path {}",
+                package.name,
+                package.manifest_path
+            );
+            continue;
+        };
+        if &*manifest_path == root_manifest_path {
+            tracing::warn!(
+                "ignoring [package] in the root Cargo.toml: a crate at the repository root is not \
+                 supported as a Turborepo package"
+            );
+            continue;
+        }
+        if !repo_root.contains(&manifest_path) {
+            tracing::warn!(
+                "skipping Cargo crate {}: manifest {manifest_path} is outside the repository",
+                package.name
+            );
+            continue;
+        }
+        if !is_valid_crate_name(&package.name) {
+            tracing::warn!(
+                "skipping Cargo manifest {manifest_path}: invalid crate name {:?}",
+                package.name
+            );
+            continue;
+        }
+        if package.name == WORKSPACE_PACKAGE_NAME {
+            tracing::warn!(
+                "skipping Cargo crate {:?}: the name is reserved for Turborepo's synthetic \
+                 workspace package",
+                package.name
+            );
+            continue;
+        }
+
+        // A target's `kind` distinguishes real bins from tests/benches/
+        // build scripts (which share the `bin` crate-type). A single lib
+        // target can carry multiple flavors (`crate-type = ["lib",
+        // "cdylib", "staticlib"]`), so each flavor becomes its own
+        // deliverable.
+        let deliverables: Vec<Deliverable> = package
+            .targets
+            .iter()
+            .flat_map(|target| {
+                target.kind.iter().filter_map(|kind| {
+                    let kind = match kind.as_str() {
+                        "bin" => DeliverableKind::Bin,
+                        "cdylib" => DeliverableKind::Cdylib,
+                        "staticlib" => DeliverableKind::Staticlib,
+                        _ => return None,
+                    };
+                    Some(Deliverable {
+                        name: target.name.clone(),
+                        kind,
+                    })
+                })
+            })
+            .collect();
+
+        let dependencies = package
+            .dependencies
+            .into_iter()
+            .filter_map(|dep| {
+                let path = dep.path?;
+                let dir = AbsoluteSystemPathBuf::new(path).ok()?;
+                Some(ResolvedDep {
+                    dir,
+                    dev: dep.kind.as_deref() == Some("dev"),
+                })
+            })
+            .collect();
+
+        parsed.push(ParsedCrate {
+            name: package.name,
+            manifest_path,
+            dependencies,
+            deliverables,
+        });
+    }
+    parsed
+}
+
+/// Resolve dependency edges to crate names by manifest directory and drop
+/// dev-dependency edges that would form a cycle (Cargo permits dev-dep
+/// cycles; the package graph is a DAG).
+fn connect_crates(parsed: Vec<ParsedCrate>) -> Vec<CargoCrate> {
+    let dir_to_name: HashMap<&AbsoluteSystemPath, &str> = parsed
+        .iter()
+        .filter_map(|c| Some((c.manifest_path.parent()?, c.name.as_str())))
+        .collect();
+
+    let mut adjacency: HashMap<&str, BTreeSet<&str>> = HashMap::new();
+    let mut dev_edges: Vec<(&str, &str)> = Vec::new();
+    for parsed_crate in &parsed {
+        let from = parsed_crate.name.as_str();
+        adjacency.entry(from).or_default();
+        for dep in &parsed_crate.dependencies {
+            let Some(&to) = dir_to_name.get(&*dep.dir) else {
+                // Path dependency on a non-member (e.g. outside the repo).
+                continue;
+            };
+            if to == from {
+                continue;
+            }
+            if dep.dev {
+                dev_edges.push((from, to));
+            } else {
+                adjacency.entry(from).or_default().insert(to);
+            }
+        }
+    }
+    // Deterministic order so the same dev edge always wins when a cycle must
+    // be broken.
+    dev_edges.sort_unstable();
+    dev_edges.dedup();
+    for (from, to) in dev_edges {
+        if reaches(&adjacency, to, from) {
+            tracing::debug!(
+                "dropping dev-dependency edge {from} -> {to}: it would create a cycle in the \
+                 package graph"
+            );
+        } else {
+            adjacency.entry(from).or_default().insert(to);
+        }
+    }
+
+    let mut edges: HashMap<String, Vec<String>> = adjacency
+        .into_iter()
+        .map(|(name, deps)| {
+            (
+                name.to_string(),
+                deps.into_iter().map(String::from).collect(),
+            )
+        })
+        .collect();
+
+    parsed
+        .into_iter()
+        .map(|parsed_crate| CargoCrate {
+            internal_dependencies: edges.remove(parsed_crate.name.as_str()).unwrap_or_default(),
+            name: parsed_crate.name,
+            manifest_path: parsed_crate.manifest_path,
+            deliverables: parsed_crate.deliverables,
+        })
+        .collect()
+}
+
+/// Whether `target` is reachable from `start` in the current adjacency map.
+fn reaches(adjacency: &HashMap<&str, BTreeSet<&str>>, start: &str, target: &str) -> bool {
+    if start == target {
+        return true;
+    }
+    let mut stack = vec![start];
+    let mut visited = HashSet::new();
+    while let Some(node) = stack.pop() {
+        if !visited.insert(node) {
+            continue;
+        }
+        if let Some(next) = adjacency.get(node) {
+            for &dep in next {
+                if dep == target {
+                    return true;
+                }
+                stack.push(dep);
+            }
+        }
+    }
+    false
+}
+
+/// The subset of `cargo metadata --no-deps` output we consume. With
+/// `--no-deps`, `packages` contains exactly the workspace members.
+#[derive(Debug, Deserialize)]
+struct Metadata {
+    packages: Vec<MetadataPackage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MetadataPackage {
+    name: String,
+    manifest_path: String,
+    #[serde(default)]
+    dependencies: Vec<MetadataDependency>,
+    #[serde(default)]
+    targets: Vec<MetadataTarget>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MetadataDependency {
+    /// Absolute path to the dependency's directory, present only for path
+    /// dependencies.
+    path: Option<String>,
+    /// `null` for normal deps, `"dev"` or `"build"` otherwise.
+    kind: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MetadataTarget {
+    name: String,
+    kind: Vec<String>,
+}
+
+#[cfg(test)]
+mod test {
+    use turbopath::AbsoluteSystemPathBuf;
+
+    use super::*;
+
+    fn tempdir_root() -> (tempfile::TempDir, AbsoluteSystemPathBuf) {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPathBuf::new(
+            tmp.path()
+                .canonicalize()
+                .unwrap()
+                .to_string_lossy()
+                .to_string(),
+        )
+        .unwrap();
+        (tmp, root)
+    }
+
+    fn write(root: &AbsoluteSystemPathBuf, rel: &[&str], contents: &str) {
+        let path = root.join_components(rel);
+        std::fs::create_dir_all(path.parent().unwrap().as_std_path()).unwrap();
+        std::fs::write(path.as_std_path(), contents).unwrap();
+    }
+
+    /// Write a small workspace: `app` (bin) depends on `lib-a` (lib), plus a
+    /// dev-dep cycle between `lib-a` and `lib-a-test-util`.
+    fn write_fixture_workspace(root: &AbsoluteSystemPathBuf) {
+        write(
+            root,
+            &["Cargo.toml"],
+            "[workspace]\nmembers = [\"crates/*\"]\nresolver = \"2\"\n",
+        );
+        write(
+            root,
+            &["crates", "app", "Cargo.toml"],
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\nedition = \
+             \"2021\"\n\n[dependencies]\nlib-a = { path = \"../lib-a\" }\n",
+        );
+        write(root, &["crates", "app", "src", "main.rs"], "fn main() {}\n");
+        write(
+            root,
+            &["crates", "lib-a", "Cargo.toml"],
+            "[package]\nname = \"lib-a\"\nversion = \"0.1.0\"\nedition = \
+             \"2021\"\n\n[dev-dependencies]\nlib-a-test-util = { path = \"../lib-a-test-util\" }\n",
+        );
+        write(root, &["crates", "lib-a", "src", "lib.rs"], "");
+        write(
+            root,
+            &["crates", "lib-a-test-util", "Cargo.toml"],
+            "[package]\nname = \"lib-a-test-util\"\nversion = \"0.1.0\"\nedition = \
+             \"2021\"\n\n[dependencies]\nlib-a = { path = \"../lib-a\" }\n",
+        );
+        write(root, &["crates", "lib-a-test-util", "src", "lib.rs"], "");
+    }
+
+    #[test]
+    fn test_discover_crates_via_metadata() {
+        let (_tmp, root) = tempdir_root();
+        write_fixture_workspace(&root);
+
+        let mut crates = discover_crates(&root).unwrap();
+        crates.sort_by(|a, b| a.name.cmp(&b.name));
+
+        assert_eq!(
+            crates.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
+            vec!["app", "lib-a", "lib-a-test-util"]
+        );
+
+        let app = &crates[0];
+        assert!(app.is_entrypoint(), "bin crate should be an entrypoint");
+        assert_eq!(
+            app.deliverables,
+            vec![Deliverable {
+                name: "app".to_string(),
+                kind: DeliverableKind::Bin,
+            }]
+        );
+        assert_eq!(app.internal_dependencies, vec!["lib-a".to_string()]);
+
+        let lib_a = &crates[1];
+        assert!(
+            !lib_a.is_entrypoint(),
+            "plain lib crate is not an entrypoint"
+        );
+        assert!(lib_a.deliverables.is_empty());
+        // The dev-dep edge lib-a -> lib-a-test-util closes a cycle with the
+        // normal edge lib-a-test-util -> lib-a, so it must be dropped.
+        assert!(
+            lib_a.internal_dependencies.is_empty(),
+            "cycle-closing dev edge should be dropped, got {:?}",
+            lib_a.internal_dependencies
+        );
+
+        let test_util = &crates[2];
+        assert_eq!(test_util.internal_dependencies, vec!["lib-a".to_string()]);
+    }
+
+    #[test]
+    fn test_discover_crates_not_a_workspace() {
+        let (_tmp, root) = tempdir_root();
+        assert!(discover_crates(&root).unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_discover_crates_malformed_root_errors() {
+        let (_tmp, root) = tempdir_root();
+        write(&root, &["Cargo.toml"], "[workspace\nmembers = [");
+        assert!(
+            discover_crates(&root).is_err(),
+            "a broken root manifest should surface an error, not silently discover nothing"
+        );
+    }
+
+    #[test]
+    fn test_discover_crates_skips_root_crate() {
+        let (_tmp, root) = tempdir_root();
+        write(
+            &root,
+            &["Cargo.toml"],
+            "[package]\nname = \"root-crate\"\nversion = \"0.1.0\"\nedition = \
+             \"2021\"\n\n[workspace]\nmembers = [\"crates/*\"]\n",
+        );
+        write(&root, &["src", "lib.rs"], "");
+        write(
+            &root,
+            &["crates", "member", "Cargo.toml"],
+            "[package]\nname = \"member\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        );
+        write(&root, &["crates", "member", "src", "lib.rs"], "");
+
+        let crates = discover_crates(&root).unwrap();
+        assert_eq!(
+            crates.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
+            vec!["member"],
+            "the root crate's directory is the whole repository, so it is not a package"
+        );
+    }
+
+    #[test]
+    fn test_discover_crates_auto_includes_path_dependency_members() {
+        // `tools/helper` matches no `members` glob but is a path dependency
+        // of a member; Cargo treats it as an automatic workspace member and
+        // so must we (via `cargo metadata`).
+        let (_tmp, root) = tempdir_root();
+        write(
+            &root,
+            &["Cargo.toml"],
+            "[workspace]\nmembers = [\"crates/*\"]\nresolver = \"2\"\n",
+        );
+        write(
+            &root,
+            &["crates", "app", "Cargo.toml"],
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\nedition = \
+             \"2021\"\n\n[dependencies]\nhelper = { path = \"../../tools/helper\" }\n",
+        );
+        write(&root, &["crates", "app", "src", "lib.rs"], "");
+        write(
+            &root,
+            &["tools", "helper", "Cargo.toml"],
+            "[package]\nname = \"helper\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        );
+        write(&root, &["tools", "helper", "src", "lib.rs"], "");
+
+        let mut crates = discover_crates(&root).unwrap();
+        crates.sort_by(|a, b| a.name.cmp(&b.name));
+        assert_eq!(
+            crates.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
+            vec!["app", "helper"]
+        );
+        assert_eq!(crates[0].internal_dependencies, vec!["helper".to_string()]);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_cargo_toolchain_synthesizes_descriptors() {
+        let (_tmp, root) = tempdir_root();
+        write_fixture_workspace(&root);
+
+        let toolchain = CargoToolchain::new(root.clone());
+        assert_eq!(toolchain.id(), ToolchainId::CARGO);
+
+        let mut packages = toolchain.discover_packages().await.unwrap();
+        packages.sort_by(|a, b| {
+            a.descriptor
+                .name
+                .as_ref()
+                .map(|name| name.as_inner())
+                .cmp(&b.descriptor.name.as_ref().map(|name| name.as_inner()))
+        });
+
+        let names: Vec<&str> = packages
+            .iter()
+            .map(|p| p.descriptor.name.as_ref().unwrap().as_inner().as_str())
+            .collect();
+        assert_eq!(names, vec!["app", "cargo", "lib-a", "lib-a-test-util"]);
+
+        let app = &packages[0];
+        assert_eq!(
+            app.descriptor.dependencies.as_ref().unwrap()["lib-a"],
+            "workspace:*"
+        );
+        assert_eq!(
+            app.manifest_path,
+            root.join_components(&["crates", "app", "Cargo.toml"])
+        );
+
+        // The synthetic workspace package is anchored at the root manifest
+        // and depends on every crate.
+        let workspace = &packages[1];
+        assert_eq!(workspace.manifest_path, root.join_component(CARGO_TOML));
+        let workspace_deps = workspace.descriptor.dependencies.as_ref().unwrap();
+        assert_eq!(workspace_deps.len(), 3);
+        assert!(workspace_deps.values().all(|v| v == "workspace:*"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_cargo_toolchain_empty_without_manifest() {
+        let (_tmp, root) = tempdir_root();
+        let toolchain = CargoToolchain::new(root);
+        assert!(toolchain.discover_packages().await.unwrap().is_empty());
+    }
+}

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -253,6 +253,20 @@ struct ResolvedDep {
     dev: bool,
 }
 
+/// Normalize a path reported by `cargo metadata` into an
+/// [`AbsoluteSystemPathBuf`]. On Windows, Cargo reports canonicalized
+/// dependency paths in verbatim form (`\\?\C:\...`) while manifest paths
+/// stay plain — `dunce::simplified` strips the verbatim prefix so the two
+/// families compare equal.
+fn metadata_path(path: &str) -> Option<AbsoluteSystemPathBuf> {
+    AbsoluteSystemPathBuf::new(
+        dunce::simplified(std::path::Path::new(path))
+            .to_str()?
+            .to_owned(),
+    )
+    .ok()
+}
+
 fn parse_members(
     repo_root: &AbsoluteSystemPath,
     root_manifest_path: &AbsoluteSystemPath,
@@ -260,7 +274,7 @@ fn parse_members(
 ) -> Vec<ParsedCrate> {
     let mut parsed = Vec::new();
     for package in metadata.packages {
-        let Ok(manifest_path) = AbsoluteSystemPathBuf::new(package.manifest_path.clone()) else {
+        let Some(manifest_path) = metadata_path(&package.manifest_path) else {
             tracing::warn!(
                 "skipping Cargo crate {}: non-absolute manifest path {}",
                 package.name,
@@ -327,7 +341,7 @@ fn parse_members(
             .into_iter()
             .filter_map(|dep| {
                 let path = dep.path?;
-                let dir = AbsoluteSystemPathBuf::new(path).ok()?;
+                let dir = metadata_path(&path)?;
                 Some(ResolvedDep {
                     dir,
                     dev: dep.kind.as_deref() == Some("dev"),
@@ -473,9 +487,10 @@ mod test {
 
     fn tempdir_root() -> (tempfile::TempDir, AbsoluteSystemPathBuf) {
         let tmp = tempfile::tempdir().unwrap();
+        // dunce: `cargo metadata` reports plain (non-verbatim) paths on
+        // Windows, so the fixture root must be plain too.
         let root = AbsoluteSystemPathBuf::new(
-            tmp.path()
-                .canonicalize()
+            dunce::canonicalize(tmp.path())
                 .unwrap()
                 .to_string_lossy()
                 .to_string(),

--- a/crates/turborepo-repository/src/lib.rs
+++ b/crates/turborepo-repository/src/lib.rs
@@ -11,6 +11,7 @@
 #![allow(clippy::result_large_err)]
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
+pub mod cargo;
 pub mod change_mapper;
 pub mod discovery;
 pub mod inference;

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -22,7 +22,9 @@ use crate::{
     },
     package_json::{DependencyKind, PackageJson},
     package_manager::{PackageManager, pnpm::PnpmCatalogs},
-    toolchain::{DiscoveredPackage, JavaScriptToolchain, ToolchainId, ToolchainRegistry},
+    toolchain::{
+        DiscoveredPackage, JavaScriptToolchain, Toolchain, ToolchainId, ToolchainRegistry,
+    },
 };
 
 pub struct PackageGraphBuilder<'a, T> {
@@ -33,6 +35,11 @@ pub struct PackageGraphBuilder<'a, T> {
     lockfile: Option<Box<dyn Lockfile>>,
     package_discovery: T,
     package_manager: Option<PackageManager>,
+    /// Toolchains registered in addition to JavaScript (e.g. Cargo when
+    /// `futureFlags.experimentalCargoWorkspaces` is enabled). Their packages
+    /// are discovered alongside JavaScript packages; name collisions across
+    /// toolchains are a hard error.
+    extra_toolchains: Vec<Arc<dyn Toolchain>>,
 }
 
 #[derive(Debug, Diagnostic, thiserror::Error)]
@@ -60,10 +67,12 @@ pub enum Error {
     Lockfile(#[from] turborepo_lockfiles::Error),
     #[error(transparent)]
     Discovery(#[from] crate::discovery::Error),
+    #[error(transparent)]
+    Toolchain(Box<dyn std::error::Error + Send + Sync>),
 }
 
-// Toolchain errors map onto the pre-existing variants rather than adding a
-// new one: consumers match on `Error::PackageJson` (diagnostic rendering,
+// JavaScript toolchain errors map onto the pre-existing variants rather than
+// new ones: consumers match on `Error::PackageJson` (diagnostic rendering,
 // io-NotFound telemetry in the run builder), and those contracts must not
 // depend on whether the error surfaced through a toolchain.
 impl From<crate::toolchain::Error> for Error {
@@ -71,6 +80,7 @@ impl From<crate::toolchain::Error> for Error {
         match err {
             crate::toolchain::Error::Discovery(err) => Error::Discovery(err),
             crate::toolchain::Error::Descriptor(err) => Error::PackageJson(err),
+            crate::toolchain::Error::Failed(err) => Error::Toolchain(err),
         }
     }
 }
@@ -104,6 +114,7 @@ impl<'a> PackageGraphBuilder<'a, LocalPackageDiscoveryBuilder> {
             package_jsons: None,
             lockfile: None,
             package_manager: None,
+            extra_toolchains: Vec::new(),
         }
     }
 
@@ -140,6 +151,14 @@ impl<'a, P> PackageGraphBuilder<'a, P> {
         self
     }
 
+    /// Register a toolchain in addition to JavaScript. Its packages are
+    /// discovered alongside JavaScript packages; a package name collision
+    /// across toolchains is a hard error, like any duplicate package name.
+    pub fn with_toolchain(mut self, toolchain: Arc<dyn Toolchain>) -> Self {
+        self.extra_toolchains.push(toolchain);
+        self
+    }
+
     /// Set the package discovery strategy to use. Note that whatever strategy
     /// selected here will be wrapped in a `CachingPackageDiscovery` to
     /// prevent unnecessary work during building.
@@ -155,6 +174,7 @@ impl<'a, P> PackageGraphBuilder<'a, P> {
             lockfile: self.lockfile,
             package_discovery: discovery,
             package_manager: self.package_manager,
+            extra_toolchains: self.extra_toolchains,
         }
     }
 }
@@ -267,6 +287,7 @@ where
             lockfile,
             package_discovery,
             package_manager: _,
+            extra_toolchains,
         } = builder;
         let mut workspaces = HashMap::new();
         let root_package_info = PackageInfo {
@@ -298,7 +319,13 @@ where
             package_discovery.build().map_err(Into::into)?,
         )));
         let mut toolchains = ToolchainRegistry::new();
+        // JavaScript registers first: its packages claim names before any
+        // other toolchain's, so a cross-toolchain collision surfaces as the
+        // non-JS package failing to add.
         toolchains.register(javascript.clone());
+        for toolchain in extra_toolchains {
+            toolchains.register(toolchain);
+        }
 
         Ok(BuildState {
             repo_root,
@@ -365,13 +392,17 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
     // need our own type
     #[tracing::instrument(skip(self))]
     async fn parse_package_jsons(mut self) -> Result<BuildState<'a, ResolvedWorkspaces, T>, Error> {
-        let discovered: Vec<(ToolchainId, DiscoveredPackage)> = match self.package_jsons.take() {
-            // A pre-supplied set of parsed package.json files (used by the
-            // package-change watcher and tests) stands in for JavaScript
-            // discovery.
-            Some(jsons) => jsons
-                .into_iter()
-                .map(|(path, json)| {
+        // A pre-supplied set of parsed package.json files (used by the
+        // package-change watcher and tests) stands in for JavaScript
+        // discovery only; other toolchains always discover for themselves.
+        let mut pre_supplied = self.package_jsons.take();
+        let mut discovered: Vec<(ToolchainId, DiscoveredPackage)> = Vec::new();
+        for toolchain in self.toolchains.iter() {
+            let id = toolchain.id();
+            if id == ToolchainId::JAVASCRIPT
+                && let Some(jsons) = pre_supplied.take()
+            {
+                discovered.extend(jsons.into_iter().map(|(path, json)| {
                     (
                         ToolchainId::JAVASCRIPT,
                         DiscoveredPackage {
@@ -379,18 +410,12 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
                             manifest_path: path,
                         },
                     )
-                })
-                .collect(),
-            None => {
-                let mut discovered = Vec::new();
-                for toolchain in self.toolchains.iter() {
-                    let id = toolchain.id();
-                    let packages = toolchain.discover_packages().await?;
-                    discovered.extend(packages.into_iter().map(|package| (id.clone(), package)));
-                }
-                discovered
+                }));
+                continue;
             }
-        };
+            let packages = toolchain.discover_packages().await?;
+            discovered.extend(packages.into_iter().map(|package| (id.clone(), package)));
+        }
 
         self.workspaces.reserve(discovered.len());
         self.node_lookup.reserve(discovered.len());
@@ -644,6 +669,14 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
     ) -> Result<HashMap<String, BTreeMap<String, String>>, Error> {
         self.workspaces
             .values()
+            // Only JavaScript packages participate in the JS lockfile's
+            // external-dependency closures. This map is keyed by directory,
+            // and a non-JS package can share a directory with a JS one (the
+            // synthetic Cargo workspace package lives at the repo root, like
+            // the root package) — including both would let HashMap iteration
+            // order decide which entry survives, flipping the root's
+            // external-dependency hash run to run.
+            .filter(|entry| entry.toolchain == ToolchainId::JAVASCRIPT)
             .map(|entry| {
                 let workspace_path = entry
                     .package_json_path
@@ -679,6 +712,12 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             false,
         )?;
         for (_, entry) in self.workspaces.iter_mut() {
+            // Mirror of the filter in all_external_dependencies: a non-JS
+            // package sharing a directory with a JS package must not steal
+            // its closure.
+            if entry.toolchain != ToolchainId::JAVASCRIPT {
+                continue;
+            }
             entry.transitive_dependencies = closures.remove(&entry.unix_dir_str()?);
         }
         Ok(())

--- a/crates/turborepo-repository/src/package_graph/dep_splitter.rs
+++ b/crates/turborepo-repository/src/package_graph/dep_splitter.rs
@@ -10,6 +10,11 @@ use crate::package_manager::pnpm::PnpmCatalogs;
 
 /// Reverse index from package path to package name, built once and shared
 /// across all `DependencySplitter` instances.
+///
+/// Non-JavaScript packages are excluded: JS `workspace:`/`file:` path
+/// specifiers can never target them, and the synthetic Cargo workspace
+/// package lives at the repo root, which would otherwise collide with the
+/// Root package's path.
 pub struct WorkspacePathIndex<'a>(HashMap<&'a AnchoredSystemPath, &'a PackageName>);
 
 impl<'a> WorkspacePathIndex<'a> {
@@ -17,6 +22,7 @@ impl<'a> WorkspacePathIndex<'a> {
         Self(
             workspaces
                 .iter()
+                .filter(|(_, info)| info.toolchain == crate::toolchain::ToolchainId::JAVASCRIPT)
                 .map(|(name, info)| (info.package_path(), name))
                 .collect(),
         )

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -1718,6 +1718,166 @@ mod test {
         assert_eq!(&cycles[0][0], min_traced);
     }
 
+    fn write_cargo_workspace_fixture(root: &AbsoluteSystemPathBuf) {
+        let write = |rel: &[&str], contents: &str| {
+            let path = root.join_components(rel);
+            std::fs::create_dir_all(path.parent().unwrap().as_std_path()).unwrap();
+            std::fs::write(path.as_std_path(), contents).unwrap();
+        };
+        write(
+            &["Cargo.toml"],
+            "[workspace]\nmembers = [\"rust/*\"]\nresolver = \"2\"\n",
+        );
+        write(
+            &["rust", "app", "Cargo.toml"],
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\nedition = \
+             \"2021\"\n\n[dependencies]\nlib-a = { path = \"../lib-a\" }\n",
+        );
+        write(&["rust", "app", "src", "main.rs"], "fn main() {}\n");
+        write(
+            &["rust", "lib-a", "Cargo.toml"],
+            "[package]\nname = \"lib-a\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        );
+        write(&["rust", "lib-a", "src", "lib.rs"], "");
+    }
+
+    fn canonical_tempdir() -> (tempfile::TempDir, AbsoluteSystemPathBuf) {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPathBuf::new(
+            tmp.path()
+                .canonicalize()
+                .unwrap()
+                .to_string_lossy()
+                .to_string(),
+        )
+        .unwrap();
+        (tmp, root)
+    }
+
+    /// Crates from a registered Cargo toolchain join the graph alongside JS
+    /// packages: crate->crate edges come from Cargo path dependencies, the
+    /// synthetic `cargo` workspace package depends on every crate, and the
+    /// JS lockfile closure of the root package is untouched by the Cargo
+    /// packages (the workspace package shares the repo-root directory with
+    /// the root package, which previously made closure attribution
+    /// nondeterministic).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_cargo_toolchain_packages_in_graph() {
+        let (_tmp, root) = canonical_tempdir();
+        write_cargo_workspace_fixture(&root);
+
+        // Several iterations: the closure-attribution regression this guards
+        // was decided by HashMap iteration order, roughly a coin flip per
+        // process/build.
+        for _ in 0..8 {
+            let pkg_graph = PackageGraph::builder(
+                &root,
+                PackageJson::from_value(json!({ "name": "root", "dependencies": { "a": "1" } }))
+                    .unwrap(),
+            )
+            .with_package_discovery(MockDiscovery)
+            .with_package_jsons(Some({
+                let mut map = HashMap::new();
+                map.insert(
+                    root.join_components(&["js-pkg", "package.json"]),
+                    PackageJson::from_value(json!({ "name": "js-pkg" })).unwrap(),
+                );
+                map
+            }))
+            .with_lockfile(Some(Box::new(MockLockfile {})))
+            .with_toolchain(crate::cargo::CargoToolchain::new(root.clone()))
+            .build()
+            .await
+            .unwrap();
+
+            assert!(pkg_graph.validate().is_ok());
+
+            // All packages present, tagged with their toolchain.
+            let app = pkg_graph.package_info(&PackageName::from("app")).unwrap();
+            assert_eq!(app.toolchain, crate::toolchain::ToolchainId::CARGO);
+            let js_pkg = pkg_graph
+                .package_info(&PackageName::from("js-pkg"))
+                .unwrap();
+            assert_eq!(js_pkg.toolchain, crate::toolchain::ToolchainId::JAVASCRIPT);
+            let workspace_pkg = pkg_graph.package_info(&PackageName::from("cargo")).unwrap();
+            assert_eq!(
+                workspace_pkg.toolchain,
+                crate::toolchain::ToolchainId::CARGO
+            );
+
+            // Crate path dependencies became graph edges.
+            let app_deps = pkg_graph
+                .immediate_dependencies(&PackageNode::Workspace(PackageName::from("app")))
+                .unwrap();
+            assert!(
+                app_deps.contains(&PackageNode::Workspace(PackageName::from("lib-a"))),
+                "app should depend on lib-a, got {app_deps:?}"
+            );
+            let workspace_deps = pkg_graph
+                .immediate_dependencies(&PackageNode::Workspace(PackageName::from("cargo")))
+                .unwrap();
+            assert!(
+                workspace_deps.contains(&PackageNode::Workspace(PackageName::from("app")))
+                    && workspace_deps.contains(&PackageNode::Workspace(PackageName::from("lib-a"))),
+                "workspace package should depend on every crate, got {workspace_deps:?}"
+            );
+
+            // The root's JS lockfile closure is attributed to the root, not
+            // stolen by the cargo workspace package sharing its directory.
+            let root_closure = pkg_graph
+                .package_info(&PackageName::Root)
+                .unwrap()
+                .transitive_dependencies
+                .as_ref()
+                .expect("root should have a lockfile closure");
+            assert_eq!(
+                root_closure,
+                &vec![
+                    turborepo_lockfiles::Package::new("key:a", "1"),
+                    turborepo_lockfiles::Package::new("key:c", "1"),
+                ]
+                .into_iter()
+                .collect::<HashSet<_>>(),
+            );
+            assert_eq!(
+                workspace_pkg.transitive_dependencies, None,
+                "the cargo workspace package has no JS lockfile closure"
+            );
+        }
+    }
+
+    /// A crate and a JS package sharing a name is a hard error, like any
+    /// other duplicate package name.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_cargo_js_name_collision_hard_errors() {
+        let (_tmp, root) = canonical_tempdir();
+        write_cargo_workspace_fixture(&root);
+
+        let result = PackageGraph::builder(
+            &root,
+            PackageJson::from_value(json!({ "name": "root" })).unwrap(),
+        )
+        .with_package_discovery(MockDiscovery)
+        .with_package_jsons(Some({
+            let mut map = HashMap::new();
+            map.insert(
+                root.join_components(&["js-app", "package.json"]),
+                PackageJson::from_value(json!({ "name": "app" })).unwrap(),
+            );
+            map
+        }))
+        .with_lockfile(Some(Box::new(MockLockfile {})))
+        .with_toolchain(crate::cargo::CargoToolchain::new(root.clone()))
+        .build()
+        .await;
+
+        let err = result.expect_err("cross-toolchain name collision must error");
+        assert!(
+            err.to_string().contains("app"),
+            "error should name the colliding package: {err}"
+        );
+    }
+
     #[tokio::test]
     async fn test_does_not_require_name_for_root_package_json() {
         let root =

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -1743,9 +1743,10 @@ mod test {
 
     fn canonical_tempdir() -> (tempfile::TempDir, AbsoluteSystemPathBuf) {
         let tmp = tempfile::tempdir().unwrap();
+        // dunce: `cargo metadata` reports plain (non-verbatim) paths on
+        // Windows, so the fixture root must be plain too.
         let root = AbsoluteSystemPathBuf::new(
-            tmp.path()
-                .canonicalize()
+            dunce::canonicalize(tmp.path())
                 .unwrap()
                 .to_string_lossy()
                 .to_string(),

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -64,6 +64,11 @@ impl ToolchainId {
     /// manifests, regardless of package manager or runtime.
     pub const JAVASCRIPT: ToolchainId = ToolchainId(Cow::Borrowed("javascript"));
 
+    /// The Cargo toolchain: Rust crates discovered from a Cargo workspace
+    /// (see [`crate::cargo`]). Experimental, gated behind
+    /// `futureFlags.experimentalCargoWorkspaces`.
+    pub const CARGO: ToolchainId = ToolchainId(Cow::Borrowed("cargo"));
+
     pub fn new(id: impl Into<Cow<'static, str>>) -> Self {
         Self(id.into())
     }
@@ -107,6 +112,10 @@ pub enum Error {
     Discovery(#[from] discovery::Error),
     #[error(transparent)]
     Descriptor(#[from] crate::package_json::Error),
+    /// A toolchain-specific failure. Boxed rather than enumerated so the
+    /// generic error surface does not accumulate a variant per toolchain.
+    #[error(transparent)]
+    Failed(Box<dyn std::error::Error + Send + Sync>),
 }
 
 /// The future returned by [`Toolchain::discover_packages`]. Boxed so the

--- a/crates/turborepo-schema-gen/src/main.rs
+++ b/crates/turborepo-schema-gen/src/main.rs
@@ -809,8 +809,10 @@ export interface FutureFlags {
    * Treat the crates of a Cargo workspace as Turborepo packages.
    *
    * When enabled, Rust crates are discovered via `cargo metadata` and
-   * participate in the package graph. Experimental: support is landing
-   * incrementally, and this flag currently has no effect.
+   * participate in the package graph: they resolve in `--filter`
+   * expressions, propagate `--affected`, and appear in `turbo query`.
+   * Experimental: support is landing incrementally — task execution and
+   * caching for crates are not wired up yet, so their tasks are no-ops.
    *
    * @defaultValue `false`
    */

--- a/crates/turborepo-turbo-json/src/future_flags.rs
+++ b/crates/turborepo-turbo-json/src/future_flags.rs
@@ -92,8 +92,10 @@ pub struct FutureFlags {
     /// Treat the crates of a Cargo workspace as Turborepo packages.
     ///
     /// When enabled, Rust crates are discovered via `cargo metadata` and
-    /// participate in the package graph. Experimental: support is landing
-    /// incrementally, and this flag currently has no effect.
+    /// participate in the package graph: they resolve in `--filter`
+    /// expressions, propagate `--affected`, and appear in `turbo query`.
+    /// Experimental: support is landing incrementally — task execution and
+    /// caching for crates are not wired up yet, so their tasks are no-ops.
     #[serde(default)]
     pub experimental_cargo_workspaces: bool,
 }

--- a/packages/turbo-types/schemas/schema.json
+++ b/packages/turbo-types/schemas/schema.json
@@ -301,7 +301,7 @@
           "type": "boolean"
         },
         "experimentalCargoWorkspaces": {
-          "description": "Treat the crates of a Cargo workspace as Turborepo packages.\n\nWhen enabled, Rust crates are discovered via `cargo metadata` and participate in the package graph. Experimental: support is landing incrementally, and this flag currently has no effect.",
+          "description": "Treat the crates of a Cargo workspace as Turborepo packages.\n\nWhen enabled, Rust crates are discovered via `cargo metadata` and participate in the package graph: they resolve in `--filter` expressions, propagate `--affected`, and appear in `turbo query`. Experimental: support is landing incrementally — task execution and caching for crates are not wired up yet, so their tasks are no-ops.",
           "default": false,
           "type": "boolean"
         },

--- a/packages/turbo-types/src/types/config-v2.ts
+++ b/packages/turbo-types/src/types/config-v2.ts
@@ -307,8 +307,10 @@ export interface FutureFlags {
    * Treat the crates of a Cargo workspace as Turborepo packages.
    *
    * When enabled, Rust crates are discovered via `cargo metadata` and
-   * participate in the package graph. Experimental: support is landing
-   * incrementally, and this flag currently has no effect.
+   * participate in the package graph: they resolve in `--filter`
+   * expressions, propagate `--affected`, and appear in `turbo query`.
+   * Experimental: support is landing incrementally — task execution and
+   * caching for crates are not wired up yet, so their tasks are no-ops.
    *
    * @defaultValue `false`
    */


### PR DESCRIPTION
## Why

Second PR of the Cargo workspace series (abstraction landed in #13235, flag in #13227). This makes the `Toolchain` trait earn its keep: `CargoToolchain` is its **second real implementation**, so the discovery surface is now validated by two ecosystems. Behind `futureFlags.experimentalCargoWorkspaces`, Rust crates become first-class packages in the graph — `--filter`, `--affected`, and `turbo query` all work on them. Task execution and caching land in the next PRs; until then crate tasks are no-ops.

## What

- `crates/turborepo-repository/src/cargo.rs`: discovery via `cargo metadata --no-deps` (Cargo is the only correct implementation of its own membership semantics — member globs, auto path-dep members, excludes, renames), entrypoint/library classification, cycle-forming dev-dep edges dropped
- Crate path dependencies synthesize `workspace:*` specifiers in the toolchain-neutral descriptor, so the existing dependency splitter wires crate→crate edges with zero Cargo-specific graph code
- A synthetic `cargo` package anchored at the root `Cargo.toml` represents the workspace and depends on every crate (propagates `--affected` to future workspace-scoped verbs)
- `PackageGraphBuilder::with_toolchain`: JS registers first, so crate/JS name collisions hard-error as `DuplicateWorkspace`
- Non-JS packages excluded from the workspace path index and from JS lockfile closure attribution (read + write) — the closure map is keyed by directory and the workspace package shares the repo root with the root package; without the filters, HashMap iteration order flipped the root external-dependency hash ~50/50 per run. Guarded by a repeated-build regression test
- Unknown `--filter` target + Cargo workspace present + flag off → diagnostic hint pointing at the opt-in
- Flag description refreshed (no longer a no-op); schema/types regenerated

## How

Flag off (the default): only change is the filter-miss hint path; the JS-only graph is untouched (full existing suite passes). Flag on: reviewers can reproduce the verification — mixed npm+Cargo fixture, then `turbo ls` lists crates, `turbo build --dry --filter=app...` includes the crate's dependency closure, and `--affected` after editing a crate source scopes to the crate, its dependents, and `cargo`. Unit coverage: discovery semantics (auto-members, root-crate skip, malformed-manifest error, dev-dep cycle drop), descriptor synthesis, graph shape, collision error, closure-attribution determinism.