### PR TITLE
perf: Reuse per-package external dependency hashes in run summaries

### DIFF
--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -1063,6 +1063,7 @@ impl<'a> Visitor<'a> {
                 env_at_execution_start,
                 scm,
                 is_watch,
+                Some(task_hasher.external_deps_hash_cache()),
             )
             .await?)
     }

--- a/crates/turborepo-run-summary/src/task_factory.rs
+++ b/crates/turborepo-run-summary/src/task_factory.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use turbopath::AnchoredSystemPath;
 use turborepo_env::EnvironmentVariableMap;
@@ -24,6 +24,10 @@ pub struct TaskSummaryFactory<'a, E, H, R> {
     env_at_start: &'a EnvironmentVariableMap,
     run_opts: &'a R,
     global_env_mode: EnvMode,
+    /// Per-package external dependency hashes computed during task hashing.
+    /// When present, summaries reuse these instead of re-sorting and
+    /// re-hashing each package's transitive closure per task.
+    external_deps_hashes: Option<&'a HashMap<String, String>>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -57,6 +61,7 @@ where
         env_at_start: &'a EnvironmentVariableMap,
         run_opts: &'a R,
         global_env_mode: EnvMode,
+        external_deps_hashes: Option<&'a HashMap<String, String>>,
     ) -> Self {
         Self {
             package_graph,
@@ -65,6 +70,7 @@ where
             env_at_start,
             run_opts,
             global_env_mode,
+            external_deps_hashes,
         }
     }
 
@@ -176,9 +182,14 @@ where
             })
             .unwrap_or_default();
 
-        // Compute external deps hash from workspace info
-        let hash_of_external_dependencies =
-            get_external_deps_hash(&workspace_info.transitive_dependencies);
+        // Reuse the per-package hash computed during task hashing when
+        // available; recomputing sorts and serializes the package's full
+        // transitive closure per task. The fallback produces byte-identical
+        // output (same sort, same hashable message).
+        let hash_of_external_dependencies = self
+            .external_deps_hashes
+            .and_then(|hashes| hashes.get(task_id.package()).cloned())
+            .unwrap_or_else(|| get_external_deps_hash(&workspace_info.transitive_dependencies));
 
         Ok(SharedTaskSummary {
             hash,

--- a/crates/turborepo-run-summary/src/tracker.rs
+++ b/crates/turborepo-run-summary/src/tracker.rs
@@ -4,7 +4,11 @@
 //! displaying it. We have this split because the tracker representation is not
 //! exactly what we want to display to the user.
 
-use std::{collections::HashSet, io, io::Write};
+use std::{
+    collections::{HashMap, HashSet},
+    io,
+    io::Write,
+};
 
 use chrono::{DateTime, Local};
 use itertools::Itertools;
@@ -230,6 +234,7 @@ impl RunTracker {
         env_at_execution_start: &'a EnvironmentVariableMap,
         scm: &SCM,
         is_watch: bool,
+        external_deps_hashes: Option<&HashMap<String, String>>,
     ) -> Result<(), Error>
     where
         E: EngineInfo + Sync,
@@ -282,6 +287,7 @@ impl RunTracker {
             env_at_execution_start,
             run_opts,
             global_env_mode,
+            external_deps_hashes,
         );
 
         let run_summary: RunSummary = self

--- a/crates/turborepo-task-hash/src/lib.rs
+++ b/crates/turborepo-task-hash/src/lib.rs
@@ -357,6 +357,13 @@ impl<'a, R: RunOptsHashInfo> TaskHasher<'a, R> {
         self.external_deps_hash_cache = cache;
     }
 
+    /// Per-package external dependency hashes computed for task hashing.
+    /// Exposed so run-summary construction can reuse them instead of
+    /// re-sorting and re-hashing each package's transitive closure.
+    pub fn external_deps_hash_cache(&self) -> &HashMap<String, String> {
+        &self.external_deps_hash_cache
+    }
+
     #[tracing::instrument(skip(self, task_definition, task_env_mode, workspace, dependency_set))]
     pub fn calculate_task_hash<T: TaskDefinitionHashInfo>(
         &self,


### PR DESCRIPTION
## Why

Run-summary construction (`--dry`, `--summarize`, observability) calls `get_external_deps_hash` per *task*: it re-sorts the package's transitive dependency closure and rebuilds a capnp message every time, even though task hashing already computed exactly this value once per package. On a 1191-package monorepo dry run this pipeline (capnp wire helpers + closure sorts) was 15.9% of total CPU — the largest single subsystem left after the lockfile and hashing work merged.

## What

Expose the per-package cache that task hashing already maintains (`TaskHasher::external_deps_hash_cache`, populated since #13234) and thread it through `RunTracker::finish` into `TaskSummaryFactory`, which now looks up instead of recomputing. The fallback path (cache absent or package missing) calls the same function as before and produces byte-identical output — both implementations sort by `(key, version)` and hash the same `LockFilePackagesRef` message.

Normal runs (no dry/summarize/observability) are unaffected: they already skip summary construction entirely.

## Benchmarks

Interleaved A/B, 12 pairs, `turbo run build --dry=json` on a 1191-package/43k-file pnpm monorepo (4-core Linux), fresh git index:

| binary | wall (mean) | wall (stdev) | CPU (mean) |
|---|---|---|---|
| main | 440ms | 21ms | 1091ms |
| this PR | **401ms (−8.9%)** | 16ms | **941ms (−13.7%)** |

capnp+sort symbols drop from 15.9% to 6.6% of profile samples (the remainder is the legitimate once-per-package/per-task hashing). Full dry-run JSON is byte-identical (only the random run `.id` differs).
