### PR TITLE
perf: Compute transitive closures and external dependency hashes concurrently with run setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8137,10 +8137,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-once-cell",
- "biome_deserialize 0.6.0",
- "biome_deserialize_macros 0.6.0",
- "biome_diagnostics",
- "biome_json_parser",
  "either",
  "globwalk",
  "insta",
@@ -8167,7 +8163,6 @@ dependencies = [
  "turborepo-graph-utils",
  "turborepo-lockfiles",
  "turborepo-rayon-compat",
- "turborepo-unescape",
  "wax",
 ]
 

--- a/crates/turborepo-errors/src/lib.rs
+++ b/crates/turborepo-errors/src/lib.rs
@@ -44,6 +44,16 @@ pub struct ParseDiagnostic {
     label: Option<SourceSpan>,
 }
 
+impl ParseDiagnostic {
+    pub fn new(message: String, path: &str, source: String, span: Option<Range<usize>>) -> Self {
+        Self {
+            message,
+            source_code: NamedSource::new(path, source),
+            label: span.map(|span| (span.start, span.len()).into()),
+        }
+    }
+}
+
 struct BiomeMessage<'a, T: ?Sized>(&'a T);
 
 impl<T: biome_diagnostics::Diagnostic + ?Sized> Display for BiomeMessage<'_, T> {

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -7,9 +7,7 @@ use std::{
 
 use chrono::Local;
 use tracing::Instrument;
-use turbopath::{
-    AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPath, RelativeUnixPathBuf,
-};
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, RelativeUnixPathBuf};
 use turborepo_analytics::{start_analytics, AnalyticsHandle};
 use turborepo_api_client::{APIAuth, APIClient, CacheClient, SharedHttpClient};
 use turborepo_cache::{AsyncCache, CacheScmState, LazyScmState};
@@ -289,39 +287,17 @@ impl RunBuilder {
         }
     }
 
-    fn package_prefix_for_repo_index(
+    /// The scan prefix for untracked-file discovery: the repo root anchored
+    /// to the git root. When the repo is nested inside a larger git
+    /// repository this restricts the scan to the repo's subtree; when the
+    /// two coincide it is empty and the scan walks the whole repository.
+    /// Every package lives under the repo root (enforced at discovery), so
+    /// this single prefix covers exactly what per-package prefixes used to.
+    fn repo_prefix_for_repo_index(
         repo_root: &AbsoluteSystemPath,
         index_root: &AbsoluteSystemPath,
-        package_dir: &AnchoredSystemPath,
-    ) -> Result<RelativeUnixPathBuf, Error> {
-        let full_package_dir = repo_root.resolve(package_dir);
-        Ok(index_root.anchor(&full_package_dir)?.to_unix())
-    }
-
-    fn all_package_prefixes(
-        pkg_dep_graph: &PackageGraph,
-        scm: &SCM,
-    ) -> Result<Vec<RelativeUnixPathBuf>, Error> {
-        let repo_root = pkg_dep_graph.repo_root();
-        let index_root = scm.git_root().unwrap_or(repo_root);
-        let mut prefixes = pkg_dep_graph
-            .packages()
-            .filter_map(|(name, _)| pkg_dep_graph.package_dir(name))
-            .map(|package_dir| {
-                Self::package_prefix_for_repo_index(repo_root, index_root, package_dir)
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-
-        let root_dependency_prefixes = pkg_dep_graph
-            .root_internal_package_dependencies_paths()
-            .into_iter()
-            .map(|package_dir| {
-                Self::package_prefix_for_repo_index(repo_root, index_root, package_dir)
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        prefixes.extend(root_dependency_prefixes);
-
-        Ok(prefixes)
+    ) -> Result<RelativeUnixPathBuf, turbopath::PathError> {
+        Ok(index_root.anchor(repo_root)?.to_unix())
     }
 
     /// Resolve the set of packages that should participate in this run.
@@ -433,7 +409,20 @@ impl RunBuilder {
         );
         let start_at = Local::now();
 
-        let scm_task = {
+        // SCM detection, the tracked repo index, and untracked-file discovery
+        // all run on one background task, overlapping package graph and
+        // engine construction. The SCM handle is sent back as soon as it
+        // exists so the main flow never waits behind the scans.
+        //
+        // Untracked discovery historically waited for the package graph to
+        // compute package prefixes, but the scan scope was always exactly
+        // the repo-root subtree: every package lives under the repo root
+        // (enforced at discovery), the root package's prefix is always in
+        // the set, and `UntrackedScope` deduplicates nested prefixes.
+        // Scanning the repo-root prefix directly is equivalent and needs
+        // nothing from the graph.
+        let (scm_tx, scm_rx) = tokio::sync::oneshot::channel();
+        let repo_index_task = {
             let repo_root = self.repo_root.clone();
             let git_root = self.opts.git_root.clone();
             tokio::task::spawn_blocking(move || {
@@ -441,16 +430,31 @@ impl RunBuilder {
                     Some(root) => SCM::new_with_git_root(&repo_root, root),
                     None => SCM::new(&repo_root),
                 };
-                // The tracked half of the repo index only needs `.git/index`,
-                // not the package graph, so build it here where it overlaps
-                // with package discovery instead of waiting for the graph.
-                // Untracked discovery is layered on later once package
-                // prefixes are known.
+                // The tracked half of the repo index only needs `.git/index`.
                 let tracked_index = {
                     let _span = tracing::info_span!("build_tracked_repo_index_gix").entered();
                     scm.build_tracked_repo_index_eager()
                 };
-                (scm, tracked_index)
+                let _ = scm_tx.send(scm.clone());
+                tracked_index.map(|mut index| {
+                    let _span = tracing::info_span!("populate_repo_index_untracked").entered();
+                    let index_root = scm.git_root().unwrap_or(&repo_root);
+                    match Self::repo_prefix_for_repo_index(&repo_root, index_root) {
+                        Ok(repo_prefix) => {
+                            if let Err(e) =
+                                scm.populate_repo_index_untracked(&mut index, &[repo_prefix])
+                            {
+                                tracing::debug!("failed to populate untracked files: {e}");
+                            }
+                        }
+                        Err(e) => {
+                            tracing::debug!(
+                                "failed to compute repo prefix for untracked files: {e}"
+                            );
+                        }
+                    }
+                    index
+                })
             })
         };
         let package_json_path = self.repo_root.join_component("package.json");
@@ -536,28 +540,21 @@ impl RunBuilder {
         repo_telemetry.track_size(pkg_dep_graph.len());
         run_telemetry.track_run_type(self.opts.run_opts.dry_run.is_some());
 
-        // The repo index caches git state (tracked entries + untracked file
-        // discovery) by reading .git/index directly via gix-index — fast,
-        // in-process, no subprocess spawns. The tracked half was already
-        // built inside scm_task, overlapping with package graph
-        // construction; only the untracked walk, which needs the package
-        // prefixes derived from the graph, runs from here.
-        let (scm, tracked_index) = scm_task
-            .instrument(tracing::info_span!("scm_task_await"))
-            .await?;
-        let all_prefixes = Self::all_package_prefixes(&pkg_dep_graph, &scm)?;
-        let repo_index_task = match tracked_index {
-            Some(mut index) if !all_prefixes.is_empty() => {
-                let scm = scm.clone();
-                Some(tokio::task::spawn_blocking(move || {
-                    let _span = tracing::info_span!("populate_repo_index_untracked").entered();
-                    if let Err(e) = scm.populate_repo_index_untracked(&mut index, &all_prefixes) {
-                        tracing::debug!("failed to populate untracked files: {e}");
-                    }
-                    Some(index)
-                }))
+        // The SCM handle arrives as soon as detection and the tracked index
+        // build finish; the untracked scan continues in the background and
+        // is joined just before the first repo-index consumer.
+        let scm = {
+            let _span = tracing::info_span!("scm_task_await").entered();
+            match scm_rx.await {
+                Ok(scm) => scm,
+                Err(_) => {
+                    // The sender only drops without sending if the SCM task
+                    // panicked; that panic surfaces when the repo-index task
+                    // is joined below. Detect inline so the run reaches that
+                    // point.
+                    SCM::new(&self.repo_root)
+                }
             }
-            _ => None,
         };
         let micro_frontend_configs = {
             let _span = tracing::info_span!("micro_frontends_from_disk").entered();
@@ -908,14 +905,11 @@ impl RunBuilder {
                 });
                 observability::Handle::try_init(opts, token)
             });
-        let repo_index = Arc::new(match repo_index_task {
-            Some(repo_index_task) => {
-                repo_index_task
-                    .instrument(tracing::info_span!("repo_index_untracked_await"))
-                    .await?
-            }
-            None => None,
-        });
+        let repo_index = Arc::new(
+            repo_index_task
+                .instrument(tracing::info_span!("repo_index_untracked_await"))
+                .await?,
+        );
 
         {
             let scm_state = scm_state.clone();
@@ -1157,42 +1151,25 @@ mod package_prefix_tests {
     use super::*;
 
     #[test]
-    fn repo_index_prefixes_are_git_root_relative_for_nested_turbo_root() {
+    fn repo_index_prefix_is_git_root_relative_for_nested_turbo_root() {
         let tmp = tempfile::tempdir().unwrap();
         let git_root = AbsoluteSystemPathBuf::try_from(tmp.path()).unwrap();
         let repo_root = git_root.join_component("downloaded-app");
 
-        let root_package = AnchoredSystemPath::new("").unwrap();
-        let workspace_package = AnchoredSystemPath::new("packages/web").unwrap();
-
         assert_eq!(
-            RunBuilder::package_prefix_for_repo_index(&repo_root, &git_root, root_package).unwrap(),
+            RunBuilder::repo_prefix_for_repo_index(&repo_root, &git_root).unwrap(),
             RelativeUnixPathBuf::new("downloaded-app").unwrap()
-        );
-        assert_eq!(
-            RunBuilder::package_prefix_for_repo_index(&repo_root, &git_root, workspace_package)
-                .unwrap(),
-            RelativeUnixPathBuf::new("downloaded-app/packages/web").unwrap()
         );
     }
 
     #[test]
-    fn repo_index_prefixes_stay_repo_relative_when_git_root_matches_turbo_root() {
+    fn repo_index_prefix_is_empty_when_git_root_matches_turbo_root() {
         let tmp = tempfile::tempdir().unwrap();
         let repo_root = AbsoluteSystemPathBuf::try_from(tmp.path()).unwrap();
 
-        let root_package = AnchoredSystemPath::new("").unwrap();
-        let workspace_package = AnchoredSystemPath::new("packages/web").unwrap();
-
         assert_eq!(
-            RunBuilder::package_prefix_for_repo_index(&repo_root, &repo_root, root_package)
-                .unwrap(),
+            RunBuilder::repo_prefix_for_repo_index(&repo_root, &repo_root).unwrap(),
             RelativeUnixPathBuf::new("").unwrap()
-        );
-        assert_eq!(
-            RunBuilder::package_prefix_for_repo_index(&repo_root, &repo_root, workspace_package)
-                .unwrap(),
-            RelativeUnixPathBuf::new("packages/web").unwrap()
         );
     }
 }

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -500,7 +500,13 @@ impl RunBuilder {
                 // `ensure_transitive_closures` call before package filtering,
                 // the earliest possible consumer (`--affected` with a changed
                 // lockfile compares closures).
-                .defer_transitive_closures(true);
+                .defer_transitive_closures(true)
+                // External dependency hashes are computed on the same
+                // background thread, straight from the sorted closures, so
+                // task hashing and run summaries read them as fields.
+                .with_closure_hasher(std::sync::Arc::new(
+                    turborepo_task_hash::hash_sorted_closures,
+                ));
 
             let graph = builder
                 .build()

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -493,7 +493,14 @@ impl RunBuilder {
         let mut pkg_dep_graph = {
             let builder = PackageGraph::builder(&self.repo_root, root_package_json.clone())
                 .with_single_package_mode(self.opts.run_opts.single_package)
-                .with_allow_no_package_manager(self.opts.repo_opts.allow_no_package_manager);
+                .with_allow_no_package_manager(self.opts.repo_opts.allow_no_package_manager)
+                // Transitive closures compute on a background thread while
+                // microfrontends config, turbo.json preloading, and other
+                // package-list consumers run. Joined by the
+                // `ensure_transitive_closures` call before package filtering,
+                // the earliest possible consumer (`--affected` with a changed
+                // lockfile compares closures).
+                .defer_transitive_closures(true);
 
             let graph = builder
                 .build()
@@ -685,6 +692,27 @@ impl RunBuilder {
             let _span = tracing::info_span!("turbo_json_preload").entered();
             turbo_json_loader.preload_all();
         });
+
+        // Package filtering reads transitive closures only when a git-based
+        // selector may compare lockfile closures: `--affected`, or a
+        // `--filter` containing a git range (bracket syntax). Joining the
+        // background closure computation here in only those cases lets the
+        // common run keep overlapping it with filtering and engine
+        // construction; the unconditional join below runs before the first
+        // universal consumer (task hashing).
+        let scope_may_read_closures = self.opts.scope_opts.affected_range.is_some()
+            || self
+                .opts
+                .scope_opts
+                .filter_patterns
+                .iter()
+                .any(|pattern| pattern.contains('['));
+        if scope_may_read_closures {
+            crate::rayon_compat::block_in_place(|| {
+                let _span = tracing::info_span!("ensure_transitive_closures").entered();
+                pkg_dep_graph.ensure_transitive_closures();
+            });
+        }
 
         let filtered_pkgs = {
             let _span = tracing::info_span!("calculate_filtered_packages").entered();
@@ -908,6 +936,15 @@ impl RunBuilder {
                 .instrument(tracing::info_span!("capture_scm_state")),
             );
         }
+
+        // Unconditional join point for the background transitive-closure
+        // computation (idempotent when the conditional join above already
+        // ran). The graph is immutable once inside `Run`, and its first
+        // closure consumer (external dependency hashing) runs shortly after.
+        crate::rayon_compat::block_in_place(|| {
+            let _span = tracing::info_span!("ensure_transitive_closures").entered();
+            pkg_dep_graph.ensure_transitive_closures();
+        });
 
         Ok((
             Run {

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -1061,8 +1061,12 @@ impl Run {
         let global_file_inputs =
             global_file_result.ok_or(Error::GlobalFileHashTaskIncomplete)??;
 
-        let root_external_dependencies_hash =
-            is_monorepo.then(|| get_external_deps_hash(&root_workspace.transitive_dependencies));
+        let root_external_dependencies_hash = is_monorepo.then(|| {
+            root_workspace
+                .external_deps_hash
+                .clone()
+                .unwrap_or_else(|| get_external_deps_hash(&root_workspace.transitive_dependencies))
+        });
 
         let pass_through_env = match env_mode {
             EnvMode::Loose => {

--- a/crates/turborepo-lockfiles/src/closure_dp.rs
+++ b/crates/turborepo-lockfiles/src/closure_dp.rs
@@ -33,13 +33,15 @@
 //! cost: each chunk pass touches every condensation edge once.
 
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashMap},
     sync::Arc,
 };
 
 use rustc_hash::FxHashMap;
 
-use crate::{Error, Lockfile, Package, TransitiveEdgeResolution, TransitiveEdgeResolver};
+use crate::{
+    Error, Lockfile, Package, SortedClosures, TransitiveEdgeResolution, TransitiveEdgeResolver,
+};
 
 /// Upper bound for one chunk's closure bitsets. 64MiB of transient memory
 /// keeps large graphs to a handful of passes without noticeable pressure.
@@ -56,7 +58,7 @@ pub(crate) fn all_transitive_closures_dp<L: Lockfile + ?Sized>(
     resolver: &dyn TransitiveEdgeResolver,
     workspaces: &HashMap<String, BTreeMap<String, String>>,
     ignore_missing_packages: bool,
-) -> Result<Option<HashMap<String, HashSet<Package>>>, Error> {
+) -> Result<Option<SortedClosures>, Error> {
     // Interned package table. Ids index `packages` and bitset positions.
     let mut ids: FxHashMap<Package, u32> = FxHashMap::default();
     let mut packages: Vec<Arc<Package>> = Vec::new();
@@ -144,10 +146,24 @@ pub(crate) fn all_transitive_closures_dp<L: Lockfile + ?Sized>(
         return Ok(Some(
             roots
                 .into_iter()
-                .map(|(ws, _)| (ws.clone(), HashSet::new()))
+                .map(|(ws, _)| (ws.clone(), Vec::new()))
                 .collect(),
         ));
     }
+
+    // Rank permutation: position of each package id under (key, version)
+    // ordering (`Package`'s derived `Ord`). Closure members are emitted in id
+    // order per chunk; a final u32 sort by rank yields the canonical sorted
+    // closure without comparing strings per element.
+    let rank: Vec<u32> = {
+        let mut order: Vec<u32> = (0..node_count as u32).collect();
+        order.sort_unstable_by(|&a, &b| packages[a as usize].cmp(&packages[b as usize]));
+        let mut rank = vec![0u32; node_count];
+        for (pos, &id) in order.iter().enumerate() {
+            rank[id as usize] = pos as u32;
+        }
+        rank
+    };
 
     // 3. SCC condensation. Tarjan emits SCCs successors-first, so a later SCC's
     //    closure only references already-computed rows.
@@ -197,9 +213,9 @@ pub(crate) fn all_transitive_closures_dp<L: Lockfile + ?Sized>(
         return Ok(None);
     }
 
-    let mut result: HashMap<String, HashSet<Package>> = workspace_root_sccs
+    let mut member_ids: HashMap<String, Vec<u32>> = workspace_root_sccs
         .iter()
-        .map(|(ws, _)| ((*ws).clone(), HashSet::new()))
+        .map(|(ws, _)| ((*ws).clone(), Vec::new()))
         .collect();
 
     let words_per_chunk = chunk_bits / 64;
@@ -243,10 +259,10 @@ pub(crate) fn all_transitive_closures_dp<L: Lockfile + ?Sized>(
                     *dst |= src;
                 }
             }
-            // Inserted for every workspace when `result` was built; a miss
-            // is unreachable but must not panic under the workspace lint
-            // policy.
-            let Some(set) = result.get_mut(*workspace) else {
+            // Inserted for every workspace when `member_ids` was built; a
+            // miss is unreachable but must not panic under the workspace
+            // lint policy.
+            let Some(ids) = member_ids.get_mut(*workspace) else {
                 continue;
             };
             for (word_idx, &word) in accumulator.iter().enumerate() {
@@ -255,11 +271,23 @@ pub(crate) fn all_transitive_closures_dp<L: Lockfile + ?Sized>(
                     let bit = word.trailing_zeros() as usize;
                     word &= word - 1;
                     let id = chunk_start + word_idx * 64 + bit;
-                    set.insert((*packages[id]).clone());
+                    ids.push(id as u32);
                 }
             }
         }
     }
+
+    let result: SortedClosures = member_ids
+        .into_iter()
+        .map(|(ws, mut ids)| {
+            ids.sort_unstable_by_key(|&id| rank[id as usize]);
+            let closure = ids
+                .into_iter()
+                .map(|id| Arc::clone(&packages[id as usize]))
+                .collect();
+            (ws, closure)
+        })
+        .collect();
 
     Ok(Some(result))
 }
@@ -341,6 +369,8 @@ fn tarjan_scc(adjacency: &[Vec<u32>]) -> SccResult {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use pretty_assertions::assert_eq;
 
     use super::*;
@@ -368,7 +398,22 @@ mod tests {
             })
             .collect();
         match via_dp {
-            Some(dp) => assert_eq!(dp, legacy, "dp result must match the legacy walk"),
+            Some(dp) => {
+                let dp_as_sets: HashMap<String, HashSet<Package>> = dp
+                    .iter()
+                    .map(|(ws, closure)| {
+                        assert!(
+                            closure.is_sorted_by(|a, b| a <= b),
+                            "dp closure for {ws} must be sorted by (key, version)"
+                        );
+                        (
+                            ws.clone(),
+                            closure.iter().map(|pkg| (**pkg).clone()).collect(),
+                        )
+                    })
+                    .collect();
+                assert_eq!(dp_as_sets, legacy, "dp result must match the legacy walk");
+            }
             None => panic!("dp unexpectedly fell back for a uniform lockfile"),
         }
     }

--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -206,6 +206,30 @@ pub fn all_transitive_closures<L: Lockfile + ?Sized>(
     workspaces: HashMap<String, BTreeMap<String, String>>,
     ignore_missing_packages: bool,
 ) -> Result<HashMap<String, HashSet<Package>>, Error> {
+    Ok(
+        all_transitive_closures_sorted(lockfile, workspaces, ignore_missing_packages)?
+            .into_iter()
+            .map(|(ws, closure)| (ws, closure.into_iter().map(|pkg| (*pkg).clone()).collect()))
+            .collect(),
+    )
+}
+
+/// Per-workspace transitive closures keyed by workspace directory, each
+/// sorted by `Package`'s `(key, version)` ordering with members shared via
+/// `Arc`.
+pub type SortedClosures = HashMap<String, Vec<Arc<Package>>>;
+
+/// Like [`all_transitive_closures`], but each closure is a `Vec` sorted by
+/// `Package`'s `(key, version)` ordering with members shared via `Arc`.
+/// The sorted form lets consumers hash or diff closures without re-sorting,
+/// and the `Arc` sharing avoids cloning two `String`s per closure member per
+/// workspace (shared dependencies are the overwhelming majority in a
+/// monorepo).
+pub fn all_transitive_closures_sorted<L: Lockfile + ?Sized>(
+    lockfile: &L,
+    workspaces: HashMap<String, BTreeMap<String, String>>,
+    ignore_missing_packages: bool,
+) -> Result<SortedClosures, Error> {
     // Shared DP fast path: computes each closure once over the global
     // package graph instead of once per workspace. Only sound when the
     // lockfile proves every transitive edge resolves identically across
@@ -237,7 +261,9 @@ pub fn all_transitive_closures<L: Lockfile + ?Sized>(
                 &deps_cache,
                 &interner,
             )?;
-            Ok((workspace, closure))
+            let mut sorted: Vec<Arc<Package>> = closure.into_iter().map(Arc::new).collect();
+            sorted.sort_unstable();
+            Ok((workspace, sorted))
         })
         .collect()
 }

--- a/crates/turborepo-repository/Cargo.toml
+++ b/crates/turborepo-repository/Cargo.toml
@@ -11,10 +11,6 @@ workspace = true
 anyhow = { workspace = true }
 async-once-cell = "0.5.3"
 
-biome_deserialize = { workspace = true }
-biome_deserialize_macros = { workspace = true }
-biome_diagnostics = { workspace = true }
-biome_json_parser = { workspace = true }
 
 either = { workspace = true }
 globwalk = { version = "0.1.0", path = "../turborepo-globwalk" }
@@ -33,12 +29,11 @@ thiserror = { workspace = true }
 tokio-stream = "0.1.14"
 tokio.workspace = true
 tracing.workspace = true
-turbopath = { workspace = true, features = ["biome"] }
+turbopath = { workspace = true }
 turborepo-errors = { workspace = true }
 turborepo-graph-utils = { path = "../turborepo-graph-utils" }
 turborepo-lockfiles = { workspace = true }
 turborepo-rayon-compat = { workspace = true }
-turborepo-unescape = { workspace = true }
 wax = { workspace = true }
 
 [dev-dependencies]

--- a/crates/turborepo-repository/src/lib.rs
+++ b/crates/turborepo-repository/src/lib.rs
@@ -14,6 +14,7 @@
 pub mod change_mapper;
 pub mod discovery;
 pub mod inference;
+mod manifest_parser;
 pub mod package_graph;
 pub mod package_json;
 pub mod package_manager;

--- a/crates/turborepo-repository/src/manifest_parser.rs
+++ b/crates/turborepo-repository/src/manifest_parser.rs
@@ -1,0 +1,786 @@
+//! Span-tracking JSON parser for package manifests.
+//!
+//! Manifest parsing sits on the critical path of every run: one parse per
+//! workspace package. The general-purpose biome CST parser this replaces
+//! spends ~27µs per manifest building a full syntax tree with error
+//! recovery; this parser scans the source once, extracting exactly what
+//! [`PackageJson`] needs, in ~1-2µs.
+//!
+//! Diagnostics keep their fidelity: `Spanned` fields carry the value
+//! token's full source range (quotes and braces included), so miette
+//! snippets in downstream errors — packageManager mismatches, devEngines
+//! validation, recursive turbo invocations — render with highlighted
+//! snippets. Parse errors point at the offending token.
+//!
+//! Acceptance rules: strict JSON syntax, a tolerated leading BOM,
+//! duplicate keys last-win, and explicit `null` is a type error in typed
+//! fields but a valid `devEngines` value (package-manager resolution
+//! reports it with this span). `serde_json` imposes a 128-level nesting
+//! limit when materializing unstructured field values.
+
+use std::{collections::BTreeMap, ops::Range, sync::Arc};
+
+use serde::de::DeserializeOwned;
+use turborepo_errors::{ParseDiagnostic, Spanned, WithMetadata};
+
+use crate::package_json::{Error, PackageJson, PnpmConfig};
+
+pub(crate) fn parse(contents: &str, path: &str) -> Result<PackageJson, Error> {
+    Parser::new(contents)
+        .parse_manifest()
+        .map_err(|diag| Error::Parse(vec![diag.into_parse_diagnostic(contents, path)]))
+        .map(|manifest| manifest.finish(contents, path))
+}
+
+/// A parse or type error at a source range.
+struct Diag {
+    message: String,
+    span: Option<Range<usize>>,
+}
+
+impl Diag {
+    fn at(span: Range<usize>, message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            span: Some(span),
+        }
+    }
+
+    fn into_parse_diagnostic(self, contents: &str, path: &str) -> ParseDiagnostic {
+        ParseDiagnostic::new(self.message, path, contents.to_owned(), self.span)
+    }
+}
+
+/// Parsed manifest before file text/path metadata is attached.
+#[derive(Default)]
+struct Manifest {
+    package_json: PackageJson,
+}
+
+impl Manifest {
+    /// Attach source text and path to the fields whose spans feed
+    /// diagnostics.
+    fn finish(mut self, contents: &str, path: &str) -> PackageJson {
+        let text: Arc<str> = contents.into();
+        let path: Arc<str> = path.into();
+        if let Some(package_manager) = self.package_json.package_manager.as_mut() {
+            package_manager.add_text(text.clone());
+            package_manager.add_path(path.clone());
+        }
+        if let Some(dev_engines) = self.package_json.dev_engines.as_mut() {
+            dev_engines.add_text(text.clone());
+            dev_engines.add_path(path.clone());
+        }
+        for script in self.package_json.scripts.values_mut() {
+            script.add_text(text.clone());
+            script.add_path(path.clone());
+        }
+        self.package_json
+    }
+}
+
+struct Parser<'a> {
+    bytes: &'a [u8],
+    text: &'a str,
+    pos: usize,
+}
+
+impl<'a> Parser<'a> {
+    fn new(text: &'a str) -> Self {
+        let mut parser = Parser {
+            bytes: text.as_bytes(),
+            text,
+            pos: 0,
+        };
+        // A leading BOM is tolerated, matching the biome parser.
+        if text.as_bytes().starts_with(b"\xef\xbb\xbf") {
+            parser.pos = 3;
+        }
+        parser
+    }
+
+    fn parse_manifest(&mut self) -> Result<Manifest, Diag> {
+        let mut manifest = Manifest::default();
+        self.skip_ws();
+        if self.peek() != Some(b'{') {
+            return Err(self.error_here("expected `{` at the start of the manifest"));
+        }
+        self.parse_object_members(|parser, key, key_range| {
+            manifest.member(parser, key, key_range)
+        })?;
+        self.skip_ws();
+        if self.pos != self.bytes.len() {
+            return Err(self.error_here("unexpected trailing content after the manifest object"));
+        }
+        Ok(manifest)
+    }
+
+    /// Parse the object starting at `self.pos` (which must be `{`), calling
+    /// `member` for each key. `member` must consume the member's value.
+    fn parse_object_members(
+        &mut self,
+        mut member: impl FnMut(&mut Self, String, Range<usize>) -> Result<(), Diag>,
+    ) -> Result<(), Diag> {
+        debug_assert_eq!(self.peek(), Some(b'{'));
+        self.pos += 1;
+        self.skip_ws();
+        if self.peek() == Some(b'}') {
+            self.pos += 1;
+            return Ok(());
+        }
+        loop {
+            self.skip_ws();
+            let key_range = self.scan_string()?;
+            let key: String = self.deserialize_slice(key_range.clone(), "an object key")?;
+            self.skip_ws();
+            if self.peek() != Some(b':') {
+                return Err(self.error_here("expected `:` after object key"));
+            }
+            self.pos += 1;
+            self.skip_ws();
+            member(self, key, key_range)?;
+            self.skip_ws();
+            match self.peek() {
+                Some(b',') => self.pos += 1,
+                Some(b'}') => {
+                    self.pos += 1;
+                    return Ok(());
+                }
+                _ => return Err(self.error_here("expected `,` or `}` in object")),
+            }
+        }
+    }
+
+    /// Deserialize the source slice at `range` with serde_json. The slice is
+    /// a single JSON value already validated structurally by the scanner;
+    /// serde performs content validation (escapes, number precision) and
+    /// unescaping.
+    fn deserialize_slice<T: DeserializeOwned>(
+        &self,
+        range: Range<usize>,
+        expected: &str,
+    ) -> Result<T, Diag> {
+        serde_json::from_str(&self.text[range.clone()])
+            .map_err(|_| Diag::at(range, format!("expected {expected}")))
+    }
+
+    fn spanned<T: DeserializeOwned>(
+        &self,
+        range: Range<usize>,
+        expected: &str,
+    ) -> Result<Spanned<T>, Diag> {
+        let value: T = self.deserialize_slice(range.clone(), expected)?;
+        Ok(Spanned::new(value).with_range(range))
+    }
+
+    /// Parse an object of string values, keeping each value's span.
+    fn parse_string_map_spanned(
+        &mut self,
+        field: &str,
+    ) -> Result<BTreeMap<String, Spanned<String>>, Diag> {
+        if self.peek() != Some(b'{') {
+            let range = self.scan_value()?;
+            return Err(Diag::at(
+                range,
+                format!("expected `{field}` to be an object"),
+            ));
+        }
+        let mut map = BTreeMap::new();
+        self.parse_object_members(|parser, key, _| {
+            let value_range = parser.scan_value()?;
+            let value = parser.spanned(value_range, "a string")?;
+            map.insert(key, value);
+            Ok(())
+        })?;
+        Ok(map)
+    }
+
+    // -- scanning ---------------------------------------------------------
+
+    fn peek(&self) -> Option<u8> {
+        self.bytes.get(self.pos).copied()
+    }
+
+    fn skip_ws(&mut self) {
+        while matches!(self.peek(), Some(b' ' | b'\t' | b'\n' | b'\r')) {
+            self.pos += 1;
+        }
+    }
+
+    fn error_here(&self, message: impl Into<String>) -> Diag {
+        let end = (self.pos + 1).min(self.bytes.len());
+        Diag {
+            message: message.into(),
+            span: Some(self.pos.min(self.bytes.len())..end),
+        }
+    }
+
+    /// Scan one JSON value, returning its full source range. Validates
+    /// syntax structurally with an explicit container stack, so nesting
+    /// depth is unbounded here (materialization of unstructured values via
+    /// serde_json is what imposes a depth limit).
+    fn scan_value(&mut self) -> Result<Range<usize>, Diag> {
+        let start = self.pos;
+        let mut stack: Vec<u8> = Vec::new();
+        'value: loop {
+            self.skip_ws();
+            match self.peek() {
+                Some(b'{') => {
+                    self.pos += 1;
+                    self.skip_ws();
+                    if self.peek() == Some(b'}') {
+                        self.pos += 1;
+                        // Empty object: a complete value; unwind below.
+                    } else {
+                        stack.push(b'{');
+                        self.scan_string()?;
+                        self.skip_ws();
+                        if self.peek() != Some(b':') {
+                            return Err(self.error_here("expected `:` after object key"));
+                        }
+                        self.pos += 1;
+                        continue 'value;
+                    }
+                }
+                Some(b'[') => {
+                    self.pos += 1;
+                    self.skip_ws();
+                    if self.peek() == Some(b']') {
+                        self.pos += 1;
+                    } else {
+                        stack.push(b'[');
+                        continue 'value;
+                    }
+                }
+                Some(b'"') => {
+                    self.scan_string()?;
+                }
+                Some(b't') => self.scan_keyword(b"true")?,
+                Some(b'f') => self.scan_keyword(b"false")?,
+                Some(b'n') => self.scan_keyword(b"null")?,
+                Some(b'-' | b'0'..=b'9') => self.scan_number()?,
+                _ => return Err(self.error_here("expected a JSON value")),
+            }
+            // A complete value has been consumed; unwind commas and
+            // container closers until another value is expected.
+            loop {
+                let Some(&container) = stack.last() else {
+                    return Ok(start..self.pos);
+                };
+                self.skip_ws();
+                match self.peek() {
+                    Some(b',') => {
+                        self.pos += 1;
+                        self.skip_ws();
+                        if container == b'{' {
+                            self.scan_string()?;
+                            self.skip_ws();
+                            if self.peek() != Some(b':') {
+                                return Err(self.error_here("expected `:` after object key"));
+                            }
+                            self.pos += 1;
+                        }
+                        continue 'value;
+                    }
+                    Some(b'}') if container == b'{' => {
+                        self.pos += 1;
+                        stack.pop();
+                    }
+                    Some(b']') if container == b'[' => {
+                        self.pos += 1;
+                        stack.pop();
+                    }
+                    _ => {
+                        return Err(self.error_here("expected `,` or a closing delimiter"));
+                    }
+                }
+            }
+        }
+    }
+
+    /// Scan a string token (opening quote at `self.pos`), returning the
+    /// range including quotes. Validates escape structure; full escape
+    /// content validation happens in serde when the slice is deserialized.
+    fn scan_string(&mut self) -> Result<Range<usize>, Diag> {
+        let start = self.pos;
+        if self.peek() != Some(b'"') {
+            return Err(self.error_here("expected a string"));
+        }
+        self.pos += 1;
+        while let Some(byte) = self.peek() {
+            match byte {
+                b'"' => {
+                    self.pos += 1;
+                    return Ok(start..self.pos);
+                }
+                b'\\' => {
+                    self.pos += 1;
+                    match self.peek() {
+                        Some(b'"' | b'\\' | b'/' | b'b' | b'f' | b'n' | b'r' | b't') => {
+                            self.pos += 1;
+                        }
+                        Some(b'u') => {
+                            self.pos += 1;
+                            for _ in 0..4 {
+                                if !matches!(
+                                    self.peek(),
+                                    Some(b'0'..=b'9' | b'a'..=b'f' | b'A'..=b'F')
+                                ) {
+                                    return Err(self.error_here("invalid unicode escape in string"));
+                                }
+                                self.pos += 1;
+                            }
+                        }
+                        _ => return Err(self.error_here("invalid escape in string")),
+                    }
+                }
+                0x00..=0x1f => {
+                    return Err(self.error_here("unescaped control character in string"));
+                }
+                _ => self.pos += 1,
+            }
+        }
+        Err(Diag::at(
+            start..self.bytes.len(),
+            "unterminated string".to_owned(),
+        ))
+    }
+
+    fn scan_keyword(&mut self, keyword: &[u8]) -> Result<(), Diag> {
+        if self.bytes[self.pos..].starts_with(keyword) {
+            self.pos += keyword.len();
+            Ok(())
+        } else {
+            Err(self.error_here("expected a JSON value"))
+        }
+    }
+
+    fn scan_number(&mut self) -> Result<(), Diag> {
+        if self.peek() == Some(b'-') {
+            self.pos += 1;
+        }
+        match self.peek() {
+            Some(b'0') => self.pos += 1,
+            Some(b'1'..=b'9') => {
+                while matches!(self.peek(), Some(b'0'..=b'9')) {
+                    self.pos += 1;
+                }
+            }
+            _ => return Err(self.error_here("invalid number")),
+        }
+        if self.peek() == Some(b'.') {
+            self.pos += 1;
+            if !matches!(self.peek(), Some(b'0'..=b'9')) {
+                return Err(self.error_here("invalid number"));
+            }
+            while matches!(self.peek(), Some(b'0'..=b'9')) {
+                self.pos += 1;
+            }
+        }
+        if matches!(self.peek(), Some(b'e' | b'E')) {
+            self.pos += 1;
+            if matches!(self.peek(), Some(b'+' | b'-')) {
+                self.pos += 1;
+            }
+            if !matches!(self.peek(), Some(b'0'..=b'9')) {
+                return Err(self.error_here("invalid number"));
+            }
+            while matches!(self.peek(), Some(b'0'..=b'9')) {
+                self.pos += 1;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Manifest {
+    /// Handle one top-level manifest member. Duplicate keys last-win,
+    /// matching the biome deserializer.
+    fn member(
+        &mut self,
+        parser: &mut Parser,
+        key: String,
+        _key_range: Range<usize>,
+    ) -> Result<(), Diag> {
+        let pkg = &mut self.package_json;
+        match key.as_str() {
+            "name" => {
+                let range = parser.scan_value()?;
+                pkg.name = Some(parser.spanned(range, "`name` to be a string")?);
+            }
+            "version" => {
+                let range = parser.scan_value()?;
+                pkg.version = Some(parser.deserialize_slice(range, "`version` to be a string")?);
+            }
+            "packageManager" => {
+                let range = parser.scan_value()?;
+                pkg.package_manager =
+                    Some(parser.spanned(range, "`packageManager` to be a string")?);
+            }
+            "devEngines" => {
+                // Any JSON value is accepted here (validation happens in
+                // package-manager resolution, with this span).
+                let range = parser.scan_value()?;
+                pkg.dev_engines = Some(parser.spanned(range, "`devEngines` to be valid JSON")?);
+            }
+            "dependencies" => {
+                let range = parser.scan_value()?;
+                pkg.dependencies = Some(parser.deserialize_slice(
+                    range,
+                    "`dependencies` to be a map of package names to version specifiers",
+                )?);
+            }
+            "devDependencies" => {
+                let range = parser.scan_value()?;
+                pkg.dev_dependencies = Some(parser.deserialize_slice(
+                    range,
+                    "`devDependencies` to be a map of package names to version specifiers",
+                )?);
+            }
+            "optionalDependencies" => {
+                let range = parser.scan_value()?;
+                pkg.optional_dependencies = Some(parser.deserialize_slice(
+                    range,
+                    "`optionalDependencies` to be a map of package names to version specifiers",
+                )?);
+            }
+            "peerDependencies" => {
+                let range = parser.scan_value()?;
+                pkg.peer_dependencies = Some(parser.deserialize_slice(
+                    range,
+                    "`peerDependencies` to be a map of package names to version specifiers",
+                )?);
+            }
+            "scripts" => {
+                pkg.scripts = parser.parse_string_map_spanned("scripts")?;
+            }
+            "resolutions" => {
+                let range = parser.scan_value()?;
+                pkg.resolutions = Some(parser.deserialize_slice(
+                    range,
+                    "`resolutions` to be a map of package names to version specifiers",
+                )?);
+            }
+            "pnpm" => {
+                pkg.pnpm = Some(Self::parse_pnpm(parser)?);
+            }
+            "patchedDependencies" => {
+                let range = parser.scan_value()?;
+                pkg.patched_dependencies = Some(parser.deserialize_slice(
+                    range,
+                    "`patchedDependencies` to be a map of package specifiers to relative patch \
+                     paths",
+                )?);
+            }
+            _ => {
+                let range = parser.scan_value()?;
+                let value = parser.deserialize_slice(range, "valid JSON")?;
+                pkg.other.insert(key, value);
+            }
+        }
+        Ok(())
+    }
+
+    fn parse_pnpm(parser: &mut Parser) -> Result<PnpmConfig, Diag> {
+        if parser.peek() != Some(b'{') {
+            let range = parser.scan_value()?;
+            return Err(Diag::at(
+                range,
+                "expected `pnpm` to be an object".to_owned(),
+            ));
+        }
+        let mut config = PnpmConfig {
+            patched_dependencies: None,
+            other: BTreeMap::new(),
+        };
+        parser.parse_object_members(|parser, key, _| {
+            let range = parser.scan_value()?;
+            if key == "patchedDependencies" {
+                config.patched_dependencies = Some(parser.deserialize_slice(
+                    range,
+                    "`pnpm.patchedDependencies` to be a map of package specifiers to relative \
+                     patch paths",
+                )?);
+            } else {
+                let value = parser.deserialize_slice(range, "valid JSON")?;
+                config.other.insert(key, value);
+            }
+            Ok(())
+        })?;
+        Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+    use test_case::test_case;
+
+    use super::*;
+
+    fn parse_ok(contents: &str) -> PackageJson {
+        parse(contents, "pkg/package.json").expect("parser must accept")
+    }
+
+    /// The source range of `token`'s first occurrence: the span convention
+    /// is the value token's full source text, quotes and braces included.
+    fn range_of(contents: &str, token: &str) -> Range<usize> {
+        let start = contents.find(token).expect("token present");
+        start..start + token.len()
+    }
+
+    #[test]
+    fn test_every_field() {
+        let contents = r#"{
+            "name": "full",
+            "version": "0.1.0",
+            "packageManager": "pnpm@9.0.0",
+            "devEngines": {"packageManager": {"name": "pnpm", "version": "9.12.3"}},
+            "dependencies": {"a": "^1.0.0", "b": "workspace:*"},
+            "devDependencies": {"c": "~2.0.0"},
+            "optionalDependencies": {"d": "3.0.0"},
+            "peerDependencies": {"e": ">=4"},
+            "scripts": {"build": "turbo build", "test": "jest --ci"},
+            "resolutions": {"f": "5.0.0"},
+            "pnpm": {"patchedDependencies": {"g@1.0.0": "patches/g.patch"}, "overrides": {"h": "6.0.0"}},
+            "patchedDependencies": {"i@2.0.0": "patches/i.patch"},
+            "private": true,
+            "workspaces": ["packages/*"],
+            "exports": {".": {"import": "./dist/index.mjs"}, "./sub": null}
+        }"#;
+        let pkg = parse_ok(contents);
+
+        let name = pkg.name.as_ref().expect("name");
+        assert_eq!(name.value, "full");
+        assert_eq!(name.range, Some(range_of(contents, "\"full\"")));
+
+        assert_eq!(pkg.version.as_deref(), Some("0.1.0"));
+
+        let pm = pkg.package_manager.as_ref().expect("packageManager");
+        assert_eq!(pm.value, "pnpm@9.0.0");
+        assert_eq!(pm.range, Some(range_of(contents, "\"pnpm@9.0.0\"")));
+
+        let dev_engines = pkg.dev_engines.as_ref().expect("devEngines");
+        assert_eq!(
+            dev_engines.value,
+            json!({"packageManager": {"name": "pnpm", "version": "9.12.3"}})
+        );
+        assert_eq!(
+            dev_engines.range,
+            Some(range_of(
+                contents,
+                r#"{"packageManager": {"name": "pnpm", "version": "9.12.3"}}"#
+            ))
+        );
+
+        assert_eq!(
+            pkg.dependencies,
+            Some(BTreeMap::from([
+                ("a".into(), "^1.0.0".into()),
+                ("b".into(), "workspace:*".into()),
+            ]))
+        );
+        assert_eq!(
+            pkg.dev_dependencies,
+            Some(BTreeMap::from([("c".into(), "~2.0.0".into())]))
+        );
+        assert_eq!(
+            pkg.optional_dependencies,
+            Some(BTreeMap::from([("d".into(), "3.0.0".into())]))
+        );
+        assert_eq!(
+            pkg.peer_dependencies,
+            Some(BTreeMap::from([("e".into(), ">=4".into())]))
+        );
+        assert_eq!(
+            pkg.resolutions,
+            Some(BTreeMap::from([("f".into(), "5.0.0".into())]))
+        );
+
+        let build = pkg.scripts.get("build").expect("build script");
+        assert_eq!(build.value, "turbo build");
+        assert_eq!(build.range, Some(range_of(contents, "\"turbo build\"")));
+        assert_eq!(pkg.scripts.get("test").unwrap().value, "jest --ci");
+
+        let pnpm = pkg.pnpm.as_ref().expect("pnpm");
+        assert_eq!(
+            pnpm.patched_dependencies
+                .as_ref()
+                .unwrap()
+                .get("g@1.0.0")
+                .unwrap()
+                .as_str(),
+            "patches/g.patch"
+        );
+        assert_eq!(pnpm.other.get("overrides"), Some(&json!({"h": "6.0.0"})));
+
+        assert_eq!(
+            pkg.patched_dependencies
+                .as_ref()
+                .unwrap()
+                .get("i@2.0.0")
+                .unwrap()
+                .as_str(),
+            "patches/i.patch"
+        );
+
+        assert_eq!(pkg.other.get("private"), Some(&json!(true)));
+        assert_eq!(pkg.other.get("workspaces"), Some(&json!(["packages/*"])));
+        assert_eq!(
+            pkg.other.get("exports"),
+            Some(&json!({".": {"import": "./dist/index.mjs"}, "./sub": null}))
+        );
+    }
+
+    #[test]
+    fn test_metadata_attachment() {
+        let contents = r#"{"name": "a", "packageManager": "pnpm@9.0.0", "devEngines": {}, "scripts": {"build": "turbo build"}}"#;
+        let pkg = parse_ok(contents);
+        for (label, text, path) in [
+            (
+                "packageManager",
+                pkg.package_manager.as_ref().unwrap().text.as_deref(),
+                pkg.package_manager.as_ref().unwrap().path.as_deref(),
+            ),
+            (
+                "devEngines",
+                pkg.dev_engines.as_ref().unwrap().text.as_deref(),
+                pkg.dev_engines.as_ref().unwrap().path.as_deref(),
+            ),
+            (
+                "script",
+                pkg.scripts.get("build").unwrap().text.as_deref(),
+                pkg.scripts.get("build").unwrap().path.as_deref(),
+            ),
+        ] {
+            assert_eq!(text, Some(contents), "{label} text");
+            assert_eq!(path, Some("pkg/package.json"), "{label} path");
+        }
+    }
+
+    #[test]
+    fn test_escapes_are_unescaped() {
+        let contents = r#"{"name": "esc\u0041pe", "scripts": {"x": "echo \"hi\"\n\t\\"}}"#;
+        let pkg = parse_ok(contents);
+        assert_eq!(pkg.name.unwrap().value, "escApe");
+        assert_eq!(pkg.scripts.get("x").unwrap().value, "echo \"hi\"\n\t\\");
+    }
+
+    #[test]
+    fn test_escaped_keys_are_unescaped() {
+        let pkg = parse_ok(r#"{"na\u006de": "k"}"#);
+        assert_eq!(pkg.name.unwrap().value, "k");
+    }
+
+    #[test]
+    fn test_duplicate_keys_last_win() {
+        let pkg = parse_ok(r#"{"name": "first", "name": "second"}"#);
+        assert_eq!(pkg.name.unwrap().value, "second");
+
+        let pkg = parse_ok(r#"{"dependencies": {"x": "1", "x": "2"}}"#);
+        assert_eq!(pkg.dependencies.unwrap()["x"], "2");
+
+        let pkg = parse_ok(r#"{"scripts": {"b": "one", "b": "two"}}"#);
+        assert_eq!(pkg.scripts["b"].value, "two");
+
+        let pkg = parse_ok(r#"{"custom": 1, "custom": 2}"#);
+        assert_eq!(pkg.other.get("custom"), Some(&json!(2)));
+    }
+
+    #[test]
+    fn test_leading_bom_tolerated_and_ranges_stay_aligned() {
+        let contents = "\u{feff}{\"name\": \"bom\"}";
+        let pkg = parse_ok(contents);
+        let name = pkg.name.expect("name");
+        assert_eq!(name.value, "bom");
+        // Ranges index the original text, BOM included, so snippet
+        // extraction stays aligned.
+        let range = name.range.expect("range");
+        assert_eq!(&contents[range], "\"bom\"");
+    }
+
+    #[test]
+    fn test_null_dev_engines_is_kept() {
+        // `devEngines: null` is a declaration; package-manager resolution
+        // reports it as invalid, pointing at this span.
+        let contents = r#"{"devEngines": null}"#;
+        let pkg = parse_ok(contents);
+        let dev_engines = pkg.dev_engines.expect("devEngines");
+        assert_eq!(dev_engines.value, serde_json::Value::Null);
+        assert_eq!(dev_engines.range, Some(range_of(contents, "null")));
+    }
+
+    #[test_case("{}" ; "empty object")]
+    #[test_case("  {  }  " ; "whitespace around empty object")]
+    #[test_case("{\n  \"name\"\n  :\n  \"spread\"\n}\n" ; "whitespace everywhere")]
+    #[test_case(r#"{"pnpm": {}}"# ; "empty pnpm")]
+    #[test_case(r#"{"scripts": {}}"# ; "empty scripts")]
+    #[test_case(r#"{"devEngines": "string"}"# ; "devEngines accepts any json")]
+    #[test_case(r#"{"patchedDependencies": {"x": "../up.patch"}}"# ; "parent-relative patch path")]
+    #[test_case(r#"{"custom": [1, -2.5, 0, 1e3, 2E-2, null, {"k": "v"}, []]}"# ; "numbers arrays and nesting in unknown fields")]
+    fn test_accepts(contents: &str) {
+        parse_ok(contents);
+    }
+
+    #[test]
+    fn test_unknown_field_values_roundtrip() {
+        let contents = r#"{"custom": [1, -2.5, 0, 1e3, 2E-2, null, {"k": "v"}, []]}"#;
+        let pkg = parse_ok(contents);
+        assert_eq!(
+            pkg.other.get("custom"),
+            Some(&json!([1, -2.5, 0, 1e3, 2E-2, null, {"k": "v"}, []]))
+        );
+    }
+
+    #[test_case(r#"{"name": "a",}"# ; "trailing comma")]
+    #[test_case(r#"{"name": "a"} // comment"# ; "line comment")]
+    #[test_case(r#"{/* c */ "name": "a"}"# ; "block comment")]
+    #[test_case(r#"{"name": 5}"# ; "name not a string")]
+    #[test_case(r#"{"name": null}"# ; "name null")]
+    #[test_case(r#"{"dependencies": null}"# ; "dependencies null")]
+    #[test_case(r#"{"dependencies": {"x": 1}}"# ; "dependency version not a string")]
+    #[test_case(r#"{"dependencies": ["x"]}"# ; "dependencies an array")]
+    #[test_case(r#"{"scripts": "build"}"# ; "scripts not an object")]
+    #[test_case(r#"{"scripts": {"b": 1}}"# ; "script not a string")]
+    #[test_case(r#"{"pnpm": null}"# ; "pnpm null")]
+    #[test_case(r#"{"pnpm": "config"}"# ; "pnpm not an object")]
+    #[test_case(r#"{"patchedDependencies": {"x": "/abs/path"}}"# ; "absolute patch path")]
+    #[test_case("not json" ; "not json")]
+    #[test_case("" ; "empty input")]
+    #[test_case("   " ; "whitespace only")]
+    #[test_case("[]" ; "array root")]
+    #[test_case("\"str\"" ; "string root")]
+    #[test_case("{\"a\": 1} tail" ; "trailing garbage")]
+    #[test_case(r#"{"a": "unterminated"# ; "unterminated string")]
+    #[test_case("{\"name\": \"\n}" ; "unescaped newline in string")]
+    #[test_case(r#"{"a": 01}"# ; "leading zero number")]
+    #[test_case(r#"{"a": 1.}"# ; "bare decimal point")]
+    #[test_case(r#"{"a": .5}"# ; "leading decimal point")]
+    #[test_case(r#"{"a": +1}"# ; "plus sign number")]
+    #[test_case(r#"{"a": 1e}"# ; "empty exponent")]
+    #[test_case(r#"{"a": tru}"# ; "bad keyword")]
+    #[test_case(r#"{"a": "bad \x escape"}"# ; "invalid escape")]
+    #[test_case(r#"{"a": "bad \u00zz escape"}"# ; "invalid unicode escape")]
+    #[test_case("{\"a\": \"ctrl \u{0001} char\"}" ; "unescaped control character")]
+    #[test_case(r#"{"a": {"b": 1]}"# ; "mismatched delimiters")]
+    #[test_case(r#"{"a" "b"}"# ; "missing colon")]
+    #[test_case(r#"{"a": 1 "b": 2}"# ; "missing comma")]
+    #[test_case(r#"{"exports": {"a": 1]}"# ; "mismatched delimiters in unknown field")]
+    #[test_case(r#"{"exports": {"a": 1,}}"# ; "trailing comma in unknown field")]
+    fn test_rejects(contents: &str) {
+        assert!(
+            parse(contents, "package.json").is_err(),
+            "parser must reject: {contents}"
+        );
+    }
+
+    #[test]
+    fn test_type_errors_produce_diagnostics() {
+        let err = parse(r#"{"name": "a", "dependencies": {"x": 1}}"#, "package.json").unwrap_err();
+        let Error::Parse(diagnostics) = err else {
+            panic!("expected a parse error");
+        };
+        assert!(!diagnostics.is_empty());
+    }
+}

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -33,6 +33,7 @@ pub struct PackageGraphBuilder<'a, T> {
     lockfile: Option<Box<dyn Lockfile>>,
     package_discovery: T,
     package_manager: Option<PackageManager>,
+    defer_closures: bool,
 }
 
 #[derive(Debug, Diagnostic, thiserror::Error)]
@@ -104,6 +105,7 @@ impl<'a> PackageGraphBuilder<'a, LocalPackageDiscoveryBuilder> {
             package_jsons: None,
             lockfile: None,
             package_manager: None,
+            defer_closures: false,
         }
     }
 
@@ -135,6 +137,15 @@ impl<'a, P> PackageGraphBuilder<'a, P> {
         self
     }
 
+    /// Defer transitive-closure computation to a background thread. The
+    /// resulting graph's `transitive_dependencies` are absent until
+    /// [`PackageGraph::ensure_transitive_closures`] is called; callers that
+    /// enable this own calling it before any closure consumer runs.
+    pub fn defer_transitive_closures(mut self, defer: bool) -> Self {
+        self.defer_closures = defer;
+        self
+    }
+
     pub fn with_lockfile(mut self, lockfile: Option<Box<dyn Lockfile>>) -> Self {
         self.lockfile = lockfile;
         self
@@ -155,6 +166,7 @@ impl<'a, P> PackageGraphBuilder<'a, P> {
             lockfile: self.lockfile,
             package_discovery: discovery,
             package_manager: self.package_manager,
+            defer_closures: self.defer_closures,
         }
     }
 }
@@ -219,6 +231,7 @@ struct BuildState<'a, S, T> {
     root_package_json: PackageJson,
     lockfile: Option<Box<dyn Lockfile>>,
     package_jsons: Option<HashMap<AbsoluteSystemPathBuf, PackageJson>>,
+    defer_closures: bool,
     state: std::marker::PhantomData<S>,
     /// The JavaScript toolchain, typed. Package-manager resolution for
     /// dependency splitting and lockfile handling reaches through this —
@@ -261,6 +274,7 @@ where
         let PackageGraphBuilder {
             repo_root,
             root_package_json,
+            defer_closures,
             is_single_package: single,
 
             package_jsons,
@@ -312,6 +326,7 @@ where
             root_workspace_index,
             node_lookup,
             root_package_json,
+            defer_closures,
             state: std::marker::PhantomData,
             javascript,
             toolchains,
@@ -422,6 +437,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             lockfile,
             javascript,
             toolchains,
+            defer_closures,
             ..
         } = self;
         Ok(BuildState {
@@ -436,6 +452,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             lockfile,
             javascript,
             toolchains,
+            defer_closures,
             package_jsons: None,
             state: std::marker::PhantomData,
         })
@@ -469,9 +486,10 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             node_lookup,
             root_package_json,
             packages: workspaces,
-            lockfile,
+            lockfile: lockfile.map(Arc::from),
             package_manager,
             repo_root: repo_root.to_owned(),
+            deferred_closures: std::sync::Mutex::new(None),
             external_dep_to_internal_dependents: std::sync::OnceLock::new(),
             root_internal_dependencies: std::sync::OnceLock::new(),
         })
@@ -618,6 +636,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             root_package_json,
             javascript,
             toolchains,
+            defer_closures,
             ..
         } = self;
         Ok(BuildState {
@@ -630,6 +649,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             node_lookup,
             root_package_json,
             lockfile,
+            defer_closures,
             package_jsons: None,
             state: std::marker::PhantomData,
             javascript,
@@ -686,11 +706,50 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
 
     #[tracing::instrument(skip(self))]
     async fn build_inner(mut self) -> Result<PackageGraph, discovery::Error> {
-        if let Err(e) =
-            turborepo_rayon_compat::block_in_place(|| self.populate_transitive_dependencies())
-        {
-            warn!("Unable to calculate transitive closures: {}", e);
-        }
+        // Transitive closures are only consumed by task hashing and
+        // change-detection, well after graph construction. When deferral is
+        // requested, compute them on a background thread so package-list
+        // consumers (microfrontends config, turbo.json preloading, engine
+        // construction) overlap with the closure work instead of waiting
+        // behind it. `PackageGraph::ensure_transitive_closures` joins.
+        let mut deferred_closures = None;
+        let arc_lockfile: Option<Arc<dyn Lockfile>> = if self.defer_closures {
+            let lockfile: Option<Arc<dyn Lockfile>> = self.lockfile.take().map(Arc::from);
+            if let Some(lockfile) = lockfile.clone() {
+                match self.all_external_dependencies() {
+                    Ok(external_deps) => {
+                        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+                        let spawned = std::thread::Builder::new()
+                            .name("turbo-closures".into())
+                            .spawn(move || {
+                                let closures = turborepo_lockfiles::all_transitive_closures(
+                                    lockfile.as_ref(),
+                                    external_deps,
+                                    false,
+                                );
+                                let _ = tx.send(closures.map_err(|e| e.to_string()));
+                            });
+                        match spawned {
+                            Ok(_) => deferred_closures = Some(rx),
+                            Err(e) => {
+                                warn!("Unable to spawn transitive closure thread: {}", e);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        warn!("Unable to calculate transitive closures: {}", e);
+                    }
+                }
+            }
+            lockfile
+        } else {
+            if let Err(e) =
+                turborepo_rayon_compat::block_in_place(|| self.populate_transitive_dependencies())
+            {
+                warn!("Unable to calculate transitive closures: {}", e);
+            }
+            self.lockfile.take().map(Arc::from)
+        };
         let package_manager = self
             .javascript
             .package_manager()
@@ -704,7 +763,6 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             root_workspace_index,
             node_lookup,
             root_package_json,
-            lockfile,
             repo_root,
             ..
         } = self;
@@ -716,8 +774,9 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             root_package_json,
             packages: workspaces,
             package_manager,
-            lockfile,
+            lockfile: arc_lockfile,
             repo_root: repo_root.to_owned(),
+            deferred_closures: std::sync::Mutex::new(deferred_closures),
             external_dep_to_internal_dependents: std::sync::OnceLock::new(),
             root_internal_dependencies: std::sync::OnceLock::new(),
         })

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -426,6 +426,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
         self.workspaces.reserve(discovered.len());
         self.node_lookup.reserve(discovered.len());
 
+        let _span = tracing::info_span!("add_packages").entered();
         for (toolchain, package) in discovered {
             match self.add_package(toolchain, package) {
                 Ok(()) => {}

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -34,6 +34,7 @@ pub struct PackageGraphBuilder<'a, T> {
     package_discovery: T,
     package_manager: Option<PackageManager>,
     defer_closures: bool,
+    closure_hasher: Option<ClosureHasher>,
 }
 
 #[derive(Debug, Diagnostic, thiserror::Error)]
@@ -106,6 +107,7 @@ impl<'a> PackageGraphBuilder<'a, LocalPackageDiscoveryBuilder> {
             lockfile: None,
             package_manager: None,
             defer_closures: false,
+            closure_hasher: None,
         }
     }
 
@@ -146,6 +148,16 @@ impl<'a, P> PackageGraphBuilder<'a, P> {
         self
     }
 
+    /// Provide a function that hashes each workspace's sorted external
+    /// dependency closure. When set, `PackageInfo::external_deps_hash` is
+    /// populated wherever closures are computed (inline or deferred).
+    /// Injected because the capnp-based hasher lives in `turborepo-hash`,
+    /// which transitively depends on this crate.
+    pub fn with_closure_hasher(mut self, hasher: ClosureHasher) -> Self {
+        self.closure_hasher = Some(hasher);
+        self
+    }
+
     pub fn with_lockfile(mut self, lockfile: Option<Box<dyn Lockfile>>) -> Self {
         self.lockfile = lockfile;
         self
@@ -167,6 +179,7 @@ impl<'a, P> PackageGraphBuilder<'a, P> {
             package_discovery: discovery,
             package_manager: self.package_manager,
             defer_closures: self.defer_closures,
+            closure_hasher: self.closure_hasher,
         }
     }
 }
@@ -232,6 +245,7 @@ struct BuildState<'a, S, T> {
     lockfile: Option<Box<dyn Lockfile>>,
     package_jsons: Option<HashMap<AbsoluteSystemPathBuf, PackageJson>>,
     defer_closures: bool,
+    closure_hasher: Option<ClosureHasher>,
     state: std::marker::PhantomData<S>,
     /// The JavaScript toolchain, typed. Package-manager resolution for
     /// dependency splitting and lockfile handling reaches through this —
@@ -275,6 +289,7 @@ where
             repo_root,
             root_package_json,
             defer_closures,
+            closure_hasher,
             is_single_package: single,
 
             package_jsons,
@@ -327,6 +342,7 @@ where
             node_lookup,
             root_package_json,
             defer_closures,
+            closure_hasher,
             state: std::marker::PhantomData,
             javascript,
             toolchains,
@@ -438,6 +454,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             javascript,
             toolchains,
             defer_closures,
+            closure_hasher,
             ..
         } = self;
         Ok(BuildState {
@@ -453,6 +470,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             javascript,
             toolchains,
             defer_closures,
+            closure_hasher,
             package_jsons: None,
             state: std::marker::PhantomData,
         })
@@ -637,6 +655,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             javascript,
             toolchains,
             defer_closures,
+            closure_hasher,
             ..
         } = self;
         Ok(BuildState {
@@ -650,6 +669,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             root_package_json,
             lockfile,
             defer_closures,
+            closure_hasher,
             package_jsons: None,
             state: std::marker::PhantomData,
             javascript,
@@ -657,6 +677,15 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
         })
     }
 }
+
+/// Computes per-workspace external dependency hashes from sorted closures,
+/// keyed by workspace unix directory. See
+/// [`PackageGraphBuilder::with_closure_hasher`].
+pub type ClosureHasher = Arc<
+    dyn Fn(&HashMap<String, Vec<Arc<turborepo_lockfiles::Package>>>) -> HashMap<String, String>
+        + Send
+        + Sync,
+>;
 
 impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
     fn all_external_dependencies(
@@ -693,13 +722,20 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
 
         // We cannot ignore missing packages in this context, it would indicate a
         // malformed or stale lockfile.
-        let mut closures = turborepo_lockfiles::all_transitive_closures(
+        let mut closures = turborepo_lockfiles::all_transitive_closures_sorted(
             lockfile,
             self.all_external_dependencies()?,
             false,
         )?;
+        let mut hashes = self
+            .closure_hasher
+            .as_ref()
+            .map(|hasher| hasher(&closures))
+            .unwrap_or_default();
         for (_, entry) in self.workspaces.iter_mut() {
-            entry.transitive_dependencies = closures.remove(&entry.unix_dir_str()?);
+            let dir = entry.unix_dir_str()?;
+            entry.transitive_dependencies = closures.remove(&dir);
+            entry.external_deps_hash = hashes.remove(&dir);
         }
         Ok(())
     }
@@ -719,15 +755,23 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
                 match self.all_external_dependencies() {
                     Ok(external_deps) => {
                         let (tx, rx) = std::sync::mpsc::sync_channel(1);
+                        let hasher = self.closure_hasher.clone();
                         let spawned = std::thread::Builder::new()
                             .name("turbo-closures".into())
                             .spawn(move || {
-                                let closures = turborepo_lockfiles::all_transitive_closures(
+                                let result = turborepo_lockfiles::all_transitive_closures_sorted(
                                     lockfile.as_ref(),
                                     external_deps,
                                     false,
-                                );
-                                let _ = tx.send(closures.map_err(|e| e.to_string()));
+                                )
+                                .map(|closures| {
+                                    let hashes = hasher
+                                        .as_ref()
+                                        .map(|hasher| hasher(&closures))
+                                        .unwrap_or_default();
+                                    super::DeferredClosures { closures, hashes }
+                                });
+                                let _ = tx.send(result.map_err(|e| e.to_string()));
                             });
                         match spawned {
                             Ok(_) => deferred_closures = Some(rx),

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -30,11 +30,17 @@ pub use crate::package_json::DependencyKind;
 
 pub const ROOT_PKG_NAME: &str = "//";
 
-/// Channel end delivering the background transitive-closure result: closures
-/// keyed by workspace unix directory, or a rendered error message.
-pub(crate) type DeferredClosuresReceiver = std::sync::mpsc::Receiver<
-    Result<HashMap<String, HashSet<turborepo_lockfiles::Package>>, String>,
->;
+/// Background transitive-closure result: per-workspace sorted closures and
+/// their external-dependency hashes, keyed by workspace unix directory.
+pub(crate) struct DeferredClosures {
+    pub closures: HashMap<String, Vec<Arc<turborepo_lockfiles::Package>>>,
+    pub hashes: HashMap<String, String>,
+}
+
+/// Channel end delivering the background transitive-closure result, or a
+/// rendered error message.
+pub(crate) type DeferredClosuresReceiver =
+    std::sync::mpsc::Receiver<Result<DeferredClosures, String>>;
 
 #[derive(Debug)]
 pub struct PackageGraph {
@@ -95,7 +101,13 @@ pub struct PackageInfo {
     /// Path to the package's native manifest, anchored to the repo root.
     pub package_json_path: AnchoredSystemPathBuf,
     pub unresolved_external_dependencies: Option<BTreeMap<PackageKey, PackageVersion>>, /* name -> version */
-    pub transitive_dependencies: Option<HashSet<turborepo_lockfiles::Package>>,
+    /// The workspace's external dependency closure, sorted by `Package`'s
+    /// `(key, version)` ordering. Members are `Arc`-shared across workspaces.
+    pub transitive_dependencies: Option<Vec<Arc<turborepo_lockfiles::Package>>>,
+    /// Hash of `transitive_dependencies`, precomputed where the closure is
+    /// computed so task hashing and run summaries never re-sort or re-hash
+    /// closures. `Some` exactly when `transitive_dependencies` is `Some`.
+    pub external_deps_hash: Option<String>,
     /// The toolchain that discovered this package. Defaults to JavaScript.
     pub toolchain: crate::toolchain::ToolchainId,
 }
@@ -373,10 +385,14 @@ impl PackageGraph {
             return;
         };
         match receiver.recv() {
-            Ok(Ok(mut closures)) => {
+            Ok(Ok(DeferredClosures {
+                mut closures,
+                mut hashes,
+            })) => {
                 for (_, info) in self.packages.iter_mut() {
-                    info.transitive_dependencies =
-                        closures.remove(info.package_path().to_unix().as_str());
+                    let dir = info.package_path().to_unix();
+                    info.transitive_dependencies = closures.remove(dir.as_str());
+                    info.external_deps_hash = hashes.remove(dir.as_str());
                 }
             }
             Ok(Err(e)) => {
@@ -701,6 +717,7 @@ impl PackageGraph {
             .filter_map(|package| self.packages.get(package))
             .filter_map(|entry| entry.transitive_dependencies.as_ref())
             .flatten()
+            .map(|pkg| &**pkg)
             .collect()
     }
 
@@ -732,7 +749,8 @@ impl PackageGraph {
         // we're fine to ignore it. Assuming there is not a commit with a stale
         // lockfile, the same commit should add the package, so it will get
         // picked up as changed.
-        let closures = turborepo_lockfiles::all_transitive_closures(previous, external_deps, true)?;
+        let closures =
+            turborepo_lockfiles::all_transitive_closures_sorted(previous, external_deps, true)?;
 
         let global_change = current.global_change(previous);
 
@@ -743,30 +761,32 @@ impl PackageGraph {
                 .iter()
                 .filter_map(|(name, info)| {
                     let previous_closure = closures.get(info.package_path().to_unix().as_str());
+                    // Both closures are sorted by (key, version), so `Vec`
+                    // equality is set equality here.
                     let not_equal = previous_closure != info.transitive_dependencies.as_ref();
                     if not_equal {
-                        if let (Some(prev), Some(curr)) =
-                            (previous_closure, info.transitive_dependencies.as_ref())
-                        {
-                            debug!(
-                                "package {name} has differing closure: {:?}",
-                                prev.symmetric_difference(curr)
-                            );
-                        }
-                        let empty_set = HashSet::default();
-                        let prev_deps = previous_closure.unwrap_or(&empty_set);
-                        let curr_deps = info.transitive_dependencies.as_ref().unwrap_or(&empty_set);
+                        let empty = Vec::new();
+                        let prev_deps = previous_closure.unwrap_or(&empty);
+                        let curr_deps = info.transitive_dependencies.as_ref().unwrap_or(&empty);
+                        let prev_set: HashSet<&turborepo_lockfiles::Package> =
+                            prev_deps.iter().map(|pkg| &**pkg).collect();
+                        let curr_set: HashSet<&turborepo_lockfiles::Package> =
+                            curr_deps.iter().map(|pkg| &**pkg).collect();
+                        debug!(
+                            "package {name} has differing closure: {:?}",
+                            prev_set.symmetric_difference(&curr_set)
+                        );
                         // {a, b} -> {a, c}
                         // b was removed
                         // c was added
-                        let added = curr_deps
-                            .difference(prev_deps)
-                            .cloned()
+                        let added = curr_set
+                            .difference(&prev_set)
+                            .map(|pkg| (*pkg).clone())
                             .sorted()
                             .collect::<Vec<_>>();
-                        let removed = prev_deps
-                            .difference(curr_deps)
-                            .cloned()
+                        let removed = prev_set
+                            .difference(&curr_set)
+                            .map(|pkg| (*pkg).clone())
                             .sorted()
                             .collect::<Vec<_>>();
                         Some((name, info, added, removed))
@@ -834,7 +854,7 @@ impl PackageGraph {
         // First find which packages directly depend on each external package
         for (pkg, info) in self.packages.iter() {
             for dep in info.transitive_dependencies.iter().flatten() {
-                let rdeps = map.entry(dep.clone()).or_default();
+                let rdeps = map.entry((**dep).clone()).or_default();
                 rdeps.insert(PackageNode::Workspace(pkg.clone()));
             }
         }
@@ -1341,8 +1361,9 @@ mod test {
         let a = turborepo_lockfiles::Package::new("key:a", "1");
         let b = turborepo_lockfiles::Package::new("key:b", "1");
         let c = turborepo_lockfiles::Package::new("key:c", "1");
-        assert_eq!(foo_deps, &HashSet::from_iter(vec![a.clone(), c.clone(),]));
-        assert_eq!(bar_deps, &HashSet::from_iter(vec![b.clone(), c.clone(),]));
+        // Closures are sorted by (key, version).
+        assert_eq!(foo_deps, &vec![Arc::new(a.clone()), Arc::new(c.clone())]);
+        assert_eq!(bar_deps, &vec![Arc::new(b.clone()), Arc::new(c.clone())]);
         assert_eq!(
             pkg_graph.transitive_external_dependencies([&foo, &bar].iter().copied()),
             HashSet::from_iter(vec![&a, &b, &c,])
@@ -1377,6 +1398,23 @@ mod test {
             map
         };
 
+        // Stub hasher: enough to prove the hash is computed and delivered on
+        // both paths. The production hasher's byte-identity with the legacy
+        // sort-then-hash path is proven in `turborepo-task-hash` tests.
+        let hasher: crate::package_graph::builder::ClosureHasher = Arc::new(|closures| {
+            closures
+                .iter()
+                .map(|(ws, closure)| {
+                    let rendered = closure
+                        .iter()
+                        .map(|pkg| format!("{}@{}", pkg.key, pkg.version))
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    (ws.clone(), rendered)
+                })
+                .collect()
+        });
+
         let inline = PackageGraph::builder(
             &root,
             PackageJson::from_value(json!({ "name": "root" })).unwrap(),
@@ -1384,6 +1422,7 @@ mod test {
         .with_package_discovery(MockDiscovery)
         .with_package_jsons(Some(package_jsons()))
         .with_lockfile(Some(Box::new(MockLockfile {})))
+        .with_closure_hasher(hasher.clone())
         .build()
         .await
         .unwrap();
@@ -1396,6 +1435,7 @@ mod test {
         .with_package_jsons(Some(package_jsons()))
         .with_lockfile(Some(Box::new(MockLockfile {})))
         .defer_transitive_closures(true)
+        .with_closure_hasher(hasher)
         .build()
         .await
         .unwrap();
@@ -1414,10 +1454,19 @@ mod test {
         deferred.ensure_transitive_closures();
 
         for (name, info) in inline.packages.iter() {
+            let deferred_info = deferred.packages.get(name).unwrap();
             assert_eq!(
-                info.transitive_dependencies,
-                deferred.packages.get(name).unwrap().transitive_dependencies,
+                info.transitive_dependencies, deferred_info.transitive_dependencies,
                 "closures must match for {name}"
+            );
+            assert_eq!(
+                info.external_deps_hash, deferred_info.external_deps_hash,
+                "external deps hashes must match for {name}"
+            );
+            assert_eq!(
+                info.external_deps_hash.is_some(),
+                info.transitive_dependencies.is_some(),
+                "hash must be present exactly when the closure is, for {name}"
             );
         }
     }

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fmt,
-    sync::OnceLock,
+    sync::{Arc, Mutex, OnceLock},
 };
 
 use itertools::Itertools;
@@ -30,6 +30,12 @@ pub use crate::package_json::DependencyKind;
 
 pub const ROOT_PKG_NAME: &str = "//";
 
+/// Channel end delivering the background transitive-closure result: closures
+/// keyed by workspace unix directory, or a rendered error message.
+pub(crate) type DeferredClosuresReceiver = std::sync::mpsc::Receiver<
+    Result<HashMap<String, HashSet<turborepo_lockfiles::Package>>, String>,
+>;
+
 #[derive(Debug)]
 pub struct PackageGraph {
     graph: petgraph::Graph<PackageNode, DependencyKind>,
@@ -40,8 +46,12 @@ pub struct PackageGraph {
     packages: HashMap<PackageName, PackageInfo>,
     root_package_json: PackageJson,
     package_manager: PackageManager,
-    lockfile: Option<Box<dyn Lockfile>>,
+    lockfile: Option<Arc<dyn Lockfile>>,
     repo_root: AbsoluteSystemPathBuf,
+    /// Receiver for background transitive-closure computation when the graph
+    /// was built with deferred closures. Consumed (exactly once) by
+    /// [`Self::ensure_transitive_closures`].
+    deferred_closures: Mutex<Option<DeferredClosuresReceiver>>,
     external_dep_to_internal_dependents:
         OnceLock<HashMap<turborepo_lockfiles::Package, HashSet<PackageNode>>>,
     /// Lazily computed internal dependencies of the root package. They are
@@ -347,6 +357,35 @@ impl PackageGraph {
 
     pub fn lockfile(&self) -> Option<&dyn Lockfile> {
         self.lockfile.as_deref()
+    }
+
+    /// Join the background transitive-closure computation (if the graph was
+    /// built with deferred closures) and install the results. Idempotent and
+    /// cheap when there is nothing to join. Must be called before any
+    /// consumer of `PackageInfo::transitive_dependencies` runs.
+    pub fn ensure_transitive_closures(&mut self) {
+        let receiver = self
+            .deferred_closures
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        let Some(receiver) = receiver else {
+            return;
+        };
+        match receiver.recv() {
+            Ok(Ok(mut closures)) => {
+                for (_, info) in self.packages.iter_mut() {
+                    info.transitive_dependencies =
+                        closures.remove(info.package_path().to_unix().as_str());
+                }
+            }
+            Ok(Err(e)) => {
+                tracing::warn!("Unable to calculate transitive closures: {}", e);
+            }
+            Err(_) => {
+                tracing::warn!("transitive closure thread disappeared without a result");
+            }
+        }
     }
 
     pub fn package_json(&self, package: &PackageName) -> Option<&PackageJson> {
@@ -1308,6 +1347,79 @@ mod test {
             pkg_graph.transitive_external_dependencies([&foo, &bar].iter().copied()),
             HashSet::from_iter(vec![&a, &b, &c,])
         );
+    }
+
+    /// A graph built with deferred closures must, after
+    /// `ensure_transitive_closures`, be indistinguishable from one built
+    /// inline.
+    #[tokio::test]
+    async fn test_deferred_closures_match_inline() {
+        let root =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+        let package_jsons = || {
+            let mut map = HashMap::new();
+            map.insert(
+                root.join_components(&["package_a", "package.json"]),
+                PackageJson::from_value(json!({
+                    "name": "foo",
+                    "dependencies": { "a": "1" }
+                }))
+                .unwrap(),
+            );
+            map.insert(
+                root.join_components(&["package_b", "package.json"]),
+                PackageJson::from_value(json!({
+                    "name": "bar",
+                    "dependencies": { "b": "1" }
+                }))
+                .unwrap(),
+            );
+            map
+        };
+
+        let inline = PackageGraph::builder(
+            &root,
+            PackageJson::from_value(json!({ "name": "root" })).unwrap(),
+        )
+        .with_package_discovery(MockDiscovery)
+        .with_package_jsons(Some(package_jsons()))
+        .with_lockfile(Some(Box::new(MockLockfile {})))
+        .build()
+        .await
+        .unwrap();
+
+        let mut deferred = PackageGraph::builder(
+            &root,
+            PackageJson::from_value(json!({ "name": "root" })).unwrap(),
+        )
+        .with_package_discovery(MockDiscovery)
+        .with_package_jsons(Some(package_jsons()))
+        .with_lockfile(Some(Box::new(MockLockfile {})))
+        .defer_transitive_closures(true)
+        .build()
+        .await
+        .unwrap();
+
+        // Before the join, closures are absent.
+        assert!(
+            deferred
+                .packages
+                .values()
+                .all(|info| info.transitive_dependencies.is_none()),
+            "deferred graph must not have closures before ensure"
+        );
+
+        deferred.ensure_transitive_closures();
+        // Idempotent.
+        deferred.ensure_transitive_closures();
+
+        for (name, info) in inline.packages.iter() {
+            assert_eq!(
+                info.transitive_dependencies,
+                deferred.packages.get(name).unwrap().transitive_dependencies,
+                "closures must match for {name}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/turborepo-repository/src/package_json.rs
+++ b/crates/turborepo-repository/src/package_json.rs
@@ -1,18 +1,10 @@
-use std::{
-    collections::{BTreeMap, HashMap},
-    sync::Arc,
-};
+use std::collections::{BTreeMap, HashMap};
 
 use anyhow::Result;
-use biome_deserialize::Text;
-use biome_deserialize_macros::Deserializable;
-use biome_diagnostics::DiagnosticExt;
-use biome_json_parser::JsonParserOptions;
 use miette::Diagnostic;
 use serde::Serialize;
 use turbopath::{AbsoluteSystemPath, RelativeUnixPathBuf};
-use turborepo_errors::{ParseDiagnostic, Spanned, WithMetadata};
-use turborepo_unescape::UnescapedString;
+use turborepo_errors::{ParseDiagnostic, Spanned};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DependencyKind {
@@ -63,33 +55,6 @@ pub struct PnpmConfig {
     pub other: BTreeMap<String, serde_json::Value>,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Deserializable)]
-pub struct RawPackageJson {
-    pub name: Option<Spanned<UnescapedString>>,
-    pub version: Option<UnescapedString>,
-    pub package_manager: Option<Spanned<UnescapedString>>,
-    pub dev_engines: Option<Spanned<serde_json::Value>>,
-    pub dependencies: Option<BTreeMap<String, UnescapedString>>,
-    pub dev_dependencies: Option<BTreeMap<String, UnescapedString>>,
-    pub optional_dependencies: Option<BTreeMap<String, UnescapedString>>,
-    pub peer_dependencies: Option<BTreeMap<String, UnescapedString>>,
-    pub scripts: BTreeMap<String, Spanned<UnescapedString>>,
-    pub resolutions: Option<BTreeMap<String, UnescapedString>>,
-    pub pnpm: Option<RawPnpmConfig>,
-    pub patched_dependencies: Option<BTreeMap<String, RelativeUnixPathBuf>>,
-    // Unstructured fields kept for round trip capabilities
-    #[deserializable(rest)]
-    pub other: BTreeMap<Text, serde_json::Value>,
-}
-
-#[derive(Debug, Default, Clone, PartialEq, Eq, Deserializable)]
-pub struct RawPnpmConfig {
-    pub patched_dependencies: Option<BTreeMap<String, RelativeUnixPathBuf>>,
-    // Unstructured config options kept for round trip capabilities
-    #[deserializable(rest)]
-    pub other: BTreeMap<Text, serde_json::Value>,
-}
-
 #[derive(Debug, thiserror::Error, Diagnostic)]
 pub enum Error {
     #[error("Unable to read package.json: {0}")]
@@ -101,83 +66,6 @@ pub enum Error {
     Parse(#[related] Vec<ParseDiagnostic>),
 }
 
-impl WithMetadata for RawPackageJson {
-    fn add_text(&mut self, text: Arc<str>) {
-        if let Some(ref mut package_manager) = self.package_manager {
-            package_manager.add_text(text.clone());
-        }
-        if let Some(ref mut dev_engines) = self.dev_engines {
-            dev_engines.add_text(text.clone());
-        }
-        self.scripts
-            .iter_mut()
-            .for_each(|(_, v)| v.add_text(text.clone()));
-    }
-
-    fn add_path(&mut self, path: Arc<str>) {
-        if let Some(ref mut package_manager) = self.package_manager {
-            package_manager.add_path(path.clone());
-        }
-        if let Some(ref mut dev_engines) = self.dev_engines {
-            dev_engines.add_path(path.clone());
-        }
-        self.scripts
-            .iter_mut()
-            .for_each(|(_, v)| v.add_path(path.clone()));
-    }
-}
-
-impl From<RawPackageJson> for PackageJson {
-    fn from(raw: RawPackageJson) -> Self {
-        Self {
-            name: raw.name.map(|s| s.map(|s| s.into())),
-            version: raw.version.map(|s| s.into()),
-            package_manager: raw.package_manager.map(|s| s.map(|s| s.into())),
-            dev_engines: raw.dev_engines,
-            dependencies: raw
-                .dependencies
-                .map(|m| m.into_iter().map(|(k, v)| (k, v.into())).collect()),
-            dev_dependencies: raw
-                .dev_dependencies
-                .map(|m| m.into_iter().map(|(k, v)| (k, v.into())).collect()),
-            optional_dependencies: raw
-                .optional_dependencies
-                .map(|m| m.into_iter().map(|(k, v)| (k, v.into())).collect()),
-            peer_dependencies: raw
-                .peer_dependencies
-                .map(|m| m.into_iter().map(|(k, v)| (k, v.into())).collect()),
-            scripts: raw
-                .scripts
-                .into_iter()
-                .map(|(k, v)| (k, v.map(|v| v.into())))
-                .collect(),
-            resolutions: raw
-                .resolutions
-                .map(|m| m.into_iter().map(|(k, v)| (k, v.into())).collect()),
-            pnpm: raw.pnpm.map(|p| p.into()),
-            patched_dependencies: raw.patched_dependencies.map(|m| m.into_iter().collect()),
-            other: raw
-                .other
-                .into_iter()
-                .map(|(k, v)| (k.to_string(), v))
-                .collect(),
-        }
-    }
-}
-
-impl From<RawPnpmConfig> for PnpmConfig {
-    fn from(raw: RawPnpmConfig) -> Self {
-        Self {
-            patched_dependencies: raw.patched_dependencies,
-            other: raw
-                .other
-                .into_iter()
-                .map(|(k, v)| (k.to_string(), v))
-                .collect(),
-        }
-    }
-}
-
 impl PackageJson {
     pub fn load(path: &AbsoluteSystemPath) -> Result<PackageJson, Error> {
         tracing::trace!("loading package.json from {}", path);
@@ -186,33 +74,7 @@ impl PackageJson {
     }
 
     pub fn load_from_str(contents: &str, path: &str) -> Result<PackageJson, Error> {
-        let (result, errors): (Option<RawPackageJson>, _) =
-            turborepo_errors::json::deserialize_from_json_str(
-                contents,
-                JsonParserOptions::default(),
-                path,
-            );
-        if !errors.is_empty() {
-            return Err(Error::Parse(
-                errors
-                    .into_iter()
-                    .map(|d| {
-                        d.with_file_source_code(contents)
-                            .with_file_path(path)
-                            .as_ref()
-                            .into()
-                    })
-                    .collect(),
-            ));
-        }
-
-        // We expect a result if there are no errors
-        let mut package_json = result.expect("no parse errors produced but no result");
-
-        package_json.add_path(path.into());
-        package_json.add_text(contents.into());
-
-        Ok(package_json.into())
+        crate::manifest_parser::parse(contents, path)
     }
 
     // Utility method for easy construction of package.json during testing

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -205,9 +205,16 @@ impl<P: PackageDiscovery + Send + Sync> Toolchain for JavaScriptToolchain<P> {
 
     fn discover_packages(&self) -> DiscoverPackagesFuture<'_> {
         Box::pin(async move {
-            let workspaces = self.discovery.discover_packages().await?.workspaces;
+            use tracing::Instrument;
+            let workspaces = self
+                .discovery
+                .discover_packages()
+                .instrument(tracing::info_span!("workspace_discovery"))
+                .await?
+                .workspaces;
             // Parse manifests in parallel; manifest parsing dominates
             // discovery time on large repositories.
+            let _span = tracing::info_span!("manifest_parse").entered();
             turborepo_rayon_compat::block_in_place(|| {
                 use rayon::prelude::*;
                 workspaces

--- a/crates/turborepo-run-summary/src/task_factory.rs
+++ b/crates/turborepo-run-summary/src/task_factory.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use turbopath::AnchoredSystemPath;
 use turborepo_env::EnvironmentVariableMap;
 use turborepo_lockfiles::Package;
@@ -176,9 +174,13 @@ where
             })
             .unwrap_or_default();
 
-        // Compute external deps hash from workspace info
-        let hash_of_external_dependencies =
-            get_external_deps_hash(&workspace_info.transitive_dependencies);
+        // The hash is precomputed where the closure is computed; the
+        // recompute below only runs for graphs built without a closure
+        // hasher.
+        let hash_of_external_dependencies = workspace_info
+            .external_deps_hash
+            .clone()
+            .unwrap_or_else(|| get_external_deps_hash(&workspace_info.transitive_dependencies));
 
         Ok(SharedTaskSummary {
             hash,
@@ -250,21 +252,19 @@ fn workspace_relative_log_file(
     Ok(log_dir.join_component(&task_log_filename(task_name)))
 }
 
-/// Computes a hash of external dependencies from transitive dependencies.
-/// This is a pure function that doesn't require any trait access.
-pub fn get_external_deps_hash(transitive_dependencies: &Option<HashSet<Package>>) -> String {
+/// Computes a hash of external dependencies from a workspace's sorted
+/// transitive dependency closure. The closure is already sorted by
+/// `Package`'s `(key, version)` ordering, so no re-sort is needed.
+pub fn get_external_deps_hash(
+    transitive_dependencies: &Option<Vec<std::sync::Arc<Package>>>,
+) -> String {
     use turborepo_hash::{LockFilePackagesRef, TurboHash};
 
     let Some(transitive_dependencies) = transitive_dependencies else {
         return "".into();
     };
 
-    let mut transitive_deps: Vec<&Package> = transitive_dependencies.iter().collect();
-
-    transitive_deps.sort_unstable_by(|a, b| match a.key.cmp(&b.key) {
-        std::cmp::Ordering::Equal => a.version.cmp(&b.version),
-        other => other,
-    });
+    let transitive_deps: Vec<&Package> = transitive_dependencies.iter().map(|pkg| &**pkg).collect();
 
     LockFilePackagesRef(transitive_deps).hash()
 }

--- a/crates/turborepo-task-hash/src/lib.rs
+++ b/crates/turborepo-task-hash/src/lib.rs
@@ -247,17 +247,20 @@ impl PackageInputsHashes {
     }
 }
 
-/// Compute the external dependency hash for every workspace in parallel.
-/// Many tasks share the same package, so hashing once per package avoids
-/// re-sorting transitive dependencies for every task.
+/// Collect the external dependency hash for every workspace, keyed by
+/// package name. Hashes are precomputed where closures are computed (see
+/// [`hash_sorted_closures`]); the per-package fallback only runs for graphs
+/// built without a closure hasher.
 #[tracing::instrument(skip_all)]
 pub fn compute_external_deps_hashes<'b>(
     workspaces: impl Iterator<Item = (&'b PackageName, &'b PackageInfo)>,
 ) -> HashMap<String, String> {
-    let ws: Vec<_> = workspaces.collect();
-    ws.par_iter()
+    workspaces
         .map(|(name, info)| {
-            let hash = get_external_deps_hash(&info.transitive_dependencies);
+            let hash = info
+                .external_deps_hash
+                .clone()
+                .unwrap_or_else(|| get_external_deps_hash(&info.transitive_dependencies));
             (name.as_str().to_owned(), hash)
         })
         .collect()
@@ -717,22 +720,36 @@ pub fn deferred_task_hash_message(inputs: &TaskInputs) -> &'static str {
 }
 
 pub fn get_external_deps_hash(
-    transitive_dependencies: &Option<HashSet<turborepo_lockfiles::Package>>,
+    transitive_dependencies: &Option<Vec<Arc<turborepo_lockfiles::Package>>>,
 ) -> String {
     let Some(transitive_dependencies) = transitive_dependencies else {
         return "".into();
     };
 
-    // Collect references instead of cloning each Package (which has two Strings).
-    let mut transitive_deps: Vec<&turborepo_lockfiles::Package> =
-        transitive_dependencies.iter().collect();
-
-    transitive_deps.sort_unstable_by(|a, b| match a.key.cmp(&b.key) {
-        std::cmp::Ordering::Equal => a.version.cmp(&b.version),
-        other => other,
-    });
+    // The closure is already sorted by `Package`'s `(key, version)` ordering,
+    // so hashing is a single linear pass.
+    let transitive_deps: Vec<&turborepo_lockfiles::Package> =
+        transitive_dependencies.iter().map(|pkg| &**pkg).collect();
 
     LockFilePackagesRef(transitive_deps).hash()
+}
+
+/// Hash every workspace's sorted external dependency closure, keyed by the
+/// closure map's own keys. Intended as the `PackageGraphBuilder`
+/// closure-hasher, so hashes are computed where closures are computed
+/// (on the deferred-closure background thread) instead of after graph
+/// construction.
+pub fn hash_sorted_closures(
+    closures: &HashMap<String, Vec<Arc<turborepo_lockfiles::Package>>>,
+) -> HashMap<String, String> {
+    closures
+        .par_iter()
+        .map(|(ws, closure)| {
+            let refs: Vec<&turborepo_lockfiles::Package> =
+                closure.iter().map(|pkg| &**pkg).collect();
+            (ws.clone(), LockFilePackagesRef(refs).hash())
+        })
+        .collect()
 }
 
 pub fn get_internal_deps_hash(
@@ -1199,11 +1216,20 @@ mod test {
         assert_eq!(result[3].1, "dddddddddddddddddddddddddddddddddddddddd");
     }
 
+    fn sorted_closure(
+        packages: Vec<turborepo_lockfiles::Package>,
+    ) -> Vec<Arc<turborepo_lockfiles::Package>> {
+        let mut closure: Vec<Arc<turborepo_lockfiles::Package>> =
+            packages.into_iter().map(Arc::new).collect();
+        closure.sort_unstable();
+        closure
+    }
+
     #[test]
     fn test_external_deps_hash_deterministic() {
         use turborepo_lockfiles::Package;
 
-        let deps: HashSet<Package> = vec![
+        let deps = sorted_closure(vec![
             Package {
                 key: "react".to_string(),
                 version: "18.0.0".to_string(),
@@ -1216,9 +1242,7 @@ mod test {
                 key: "typescript".to_string(),
                 version: "5.0.0".to_string(),
             },
-        ]
-        .into_iter()
-        .collect();
+        ]);
 
         let hash1 = get_external_deps_hash(&Some(deps.clone()));
         let hash2 = get_external_deps_hash(&Some(deps));
@@ -1231,48 +1255,53 @@ mod test {
         let hash_none = get_external_deps_hash(&None);
         assert_eq!(hash_none, "", "None deps should produce empty hash");
 
-        let hash_empty = get_external_deps_hash(&Some(HashSet::new()));
+        let hash_empty = get_external_deps_hash(&Some(Vec::new()));
         assert!(
             !hash_empty.is_empty(),
-            "empty set should produce non-empty hash"
+            "empty closure should produce non-empty hash"
         );
     }
 
+    /// The linear hash of a pre-sorted closure must be byte-identical to the
+    /// legacy path, which collected a `HashSet` and sorted by
+    /// `(key, version)` before hashing.
     #[test]
-    fn test_external_deps_hash_order_independent() {
+    fn test_external_deps_hash_matches_legacy_sort_then_hash() {
         use turborepo_lockfiles::Package;
 
-        let deps1: HashSet<Package> = vec![
-            Package {
-                key: "a".to_string(),
-                version: "1.0".to_string(),
-            },
-            Package {
-                key: "b".to_string(),
-                version: "2.0".to_string(),
-            },
-        ]
-        .into_iter()
-        .collect();
-
-        let deps2: HashSet<Package> = vec![
+        let packages = vec![
             Package {
                 key: "b".to_string(),
                 version: "2.0".to_string(),
             },
             Package {
                 key: "a".to_string(),
+                version: "1.1".to_string(),
+            },
+            Package {
+                key: "a".to_string(),
                 version: "1.0".to_string(),
             },
-        ]
-        .into_iter()
-        .collect();
+            Package {
+                key: "c".to_string(),
+                version: "0.1".to_string(),
+            },
+        ];
 
-        let hash1 = get_external_deps_hash(&Some(deps1));
-        let hash2 = get_external_deps_hash(&Some(deps2));
+        let legacy_hash = {
+            let set: HashSet<Package> = packages.iter().cloned().collect();
+            let mut refs: Vec<&Package> = set.iter().collect();
+            refs.sort_unstable_by(|a, b| match a.key.cmp(&b.key) {
+                std::cmp::Ordering::Equal => a.version.cmp(&b.version),
+                other => other,
+            });
+            LockFilePackagesRef(refs).hash()
+        };
+
+        let sorted_hash = get_external_deps_hash(&Some(sorted_closure(packages)));
         assert_eq!(
-            hash1, hash2,
-            "hash should be order-independent since we sort"
+            legacy_hash, sorted_hash,
+            "sorted-closure hash must match the legacy sort-then-hash path"
         );
     }
 


### PR DESCRIPTION
## Why

Transitive closure computation sat on the critical path of every `turbo run`, even though its results are only consumed by task hashing and change detection — well after graph construction. Worse, task hashing paid for closures twice more after that: materialization cloned two `String`s per closure member per workspace into `HashSet`s, and `hash_scope` re-sorted and capnp-hashed every workspace's closure. On a 1191-package monorepo this held back time-to-first-task by roughly 100ms and contended for cores with file hashing.

## What

Two stacked changes (second was #13253, merged into this branch):

**Deferred closures.** `PackageGraphBuilder::defer_transitive_closures` moves closure computation to a background thread so microfrontends config, turbo.json preloading, and engine construction overlap with it. `PackageGraph::ensure_transitive_closures` joins (idempotent); `RunBuilder` joins before package filtering only when `--affected` or a git-range `--filter` may read closures, and unconditionally before constructing `Run`. Only `RunBuilder` opts in; other consumers keep inline behavior. `PackageGraph.lockfile` becomes `Arc<dyn Lockfile>` so the thread can share it.

**Hash where closures are computed.** Closures leave the lockfile layer as `Vec<Arc<Package>>` sorted by `(key, version)` (`Package`'s derived `Ord`, identical to the old sort comparator); the closure DP emits sorted rows via a one-time u32 rank permutation, eliminating per-member `String` clones at materialization. An injected closure hasher (injected because `turborepo-hash` transitively depends on `turborepo-repository`) computes each workspace's external dependency hash on the same background thread, straight from the pre-sorted rows. Task hashing, run summaries, and the root global-hash input read the precomputed `PackageInfo::external_deps_hash`, each with a linear-hash fallback for graphs built without a hasher.

## How to verify

- Differential tests: deferred-vs-inline graphs must produce identical closures and hashes; the DP oracle test asserts sortedness against the legacy walk; `turborepo-task-hash` proves the linear hash of a sorted closure is byte-identical to the legacy collect-sort-hash path.
- Measured on a 1191-package monorepo (interleaved A/B, 6 runs, medians): time-to-first-task 371.5ms → 266.8ms (−28%) vs main. Within `hash_scope`: `compute_external_deps_hashes` 44.4ms → 0.3ms, and the concurrent file-hash leg dropped 45ms → 15ms from reduced core contention. `--dry=json` output is byte-identical.

Note: precomputing the hash as a field subsumes the run-summary recompute that #13249 avoids; if this lands, #13249 reduces to a trivial rebase or can be closed.