### PR TITLE
chore: Add tracing spans to workspace discovery and globwalk phases

### DIFF
--- a/crates/turborepo-globwalk/src/lib.rs
+++ b/crates/turborepo-globwalk/src/lib.rs
@@ -508,7 +508,11 @@ pub fn globwalk_with_settings(
     walk_type: WalkType,
     settings: Settings,
 ) -> Result<HashSet<AbsoluteSystemPathBuf>, WalkError> {
-    let compiled = compile_globs(base_path, include, exclude)?;
+    let compiled = {
+        let _span = tracing::info_span!("globwalk_compile").entered();
+        compile_globs(base_path, include, exclude)?
+    };
+    let _span = tracing::info_span!("globwalk_walk").entered();
     retry_on_emfile(|| walk_compiled_globs(&compiled, walk_type, settings))
 }
 

--- a/crates/turborepo-repository/src/workspaces.rs
+++ b/crates/turborepo-repository/src/workspaces.rs
@@ -152,13 +152,17 @@ impl WorkspaceGlobs {
         &self,
         repo_root: &AbsoluteSystemPath,
     ) -> Result<impl Iterator<Item = AbsoluteSystemPathBuf> + use<>, Error> {
-        let files = globwalk::globwalk_with_settings(
-            repo_root,
-            &self.package_json_inclusions,
-            &self.validated_exclusions,
-            globwalk::WalkType::Files,
-            globwalk::Settings::default().follow_links(),
-        )?;
+        let files = {
+            let _span = tracing::info_span!("package_json_walk").entered();
+            globwalk::globwalk_with_settings(
+                repo_root,
+                &self.package_json_inclusions,
+                &self.validated_exclusions,
+                globwalk::WalkType::Files,
+                globwalk::Settings::default().follow_links(),
+            )?
+        };
+        let _span = tracing::info_span!("package_json_realpath_check").entered();
         let repo_root = repo_root.to_realpath()?;
         for file in &files {
             let real_file = file.to_realpath()?;


### PR DESCRIPTION
## Why

Investigating the workspace discovery cost on a 1191-package monorepo required splitting an opaque ~100ms `parse_package_jsons` span into its phases. The answer was worth having permanently in `--profile` output: it showed the glob walk's apparent 30-67ms cost is contention variance on small-core machines (intrinsic cost ~6ms), redirecting optimization effort to the actual contention source.

## What

Four spans, no behavior change:

- `package_json_walk` / `package_json_realpath_check` split `WorkspaceGlobs::get_package_jsons` (the realpath symlink guard measured 3.6ms for 1191 packages — cheap, kept as-is)
- `globwalk_compile` / `globwalk_walk` split every `globwalk_with_settings` call into wax pattern compilation vs. filesystem traversal
