### PR TITLE
perf: Hash external dependencies where closures are computed

### DIFF
--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -500,7 +500,13 @@ impl RunBuilder {
                 // `ensure_transitive_closures` call before package filtering,
                 // the earliest possible consumer (`--affected` with a changed
                 // lockfile compares closures).
-                .defer_transitive_closures(true);
+                .defer_transitive_closures(true)
+                // External dependency hashes are computed on the same
+                // background thread, straight from the sorted closures, so
+                // task hashing and run summaries read them as fields.
+                .with_closure_hasher(std::sync::Arc::new(
+                    turborepo_task_hash::hash_sorted_closures,
+                ));
 
             let graph = builder
                 .build()

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -1061,8 +1061,12 @@ impl Run {
         let global_file_inputs =
             global_file_result.ok_or(Error::GlobalFileHashTaskIncomplete)??;
 
-        let root_external_dependencies_hash =
-            is_monorepo.then(|| get_external_deps_hash(&root_workspace.transitive_dependencies));
+        let root_external_dependencies_hash = is_monorepo.then(|| {
+            root_workspace
+                .external_deps_hash
+                .clone()
+                .unwrap_or_else(|| get_external_deps_hash(&root_workspace.transitive_dependencies))
+        });
 
         let pass_through_env = match env_mode {
             EnvMode::Loose => {

--- a/crates/turborepo-lockfiles/src/closure_dp.rs
+++ b/crates/turborepo-lockfiles/src/closure_dp.rs
@@ -33,13 +33,15 @@
 //! cost: each chunk pass touches every condensation edge once.
 
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashMap},
     sync::Arc,
 };
 
 use rustc_hash::FxHashMap;
 
-use crate::{Error, Lockfile, Package, TransitiveEdgeResolution, TransitiveEdgeResolver};
+use crate::{
+    Error, Lockfile, Package, SortedClosures, TransitiveEdgeResolution, TransitiveEdgeResolver,
+};
 
 /// Upper bound for one chunk's closure bitsets. 64MiB of transient memory
 /// keeps large graphs to a handful of passes without noticeable pressure.
@@ -56,7 +58,7 @@ pub(crate) fn all_transitive_closures_dp<L: Lockfile + ?Sized>(
     resolver: &dyn TransitiveEdgeResolver,
     workspaces: &HashMap<String, BTreeMap<String, String>>,
     ignore_missing_packages: bool,
-) -> Result<Option<HashMap<String, HashSet<Package>>>, Error> {
+) -> Result<Option<SortedClosures>, Error> {
     // Interned package table. Ids index `packages` and bitset positions.
     let mut ids: FxHashMap<Package, u32> = FxHashMap::default();
     let mut packages: Vec<Arc<Package>> = Vec::new();
@@ -144,10 +146,24 @@ pub(crate) fn all_transitive_closures_dp<L: Lockfile + ?Sized>(
         return Ok(Some(
             roots
                 .into_iter()
-                .map(|(ws, _)| (ws.clone(), HashSet::new()))
+                .map(|(ws, _)| (ws.clone(), Vec::new()))
                 .collect(),
         ));
     }
+
+    // Rank permutation: position of each package id under (key, version)
+    // ordering (`Package`'s derived `Ord`). Closure members are emitted in id
+    // order per chunk; a final u32 sort by rank yields the canonical sorted
+    // closure without comparing strings per element.
+    let rank: Vec<u32> = {
+        let mut order: Vec<u32> = (0..node_count as u32).collect();
+        order.sort_unstable_by(|&a, &b| packages[a as usize].cmp(&packages[b as usize]));
+        let mut rank = vec![0u32; node_count];
+        for (pos, &id) in order.iter().enumerate() {
+            rank[id as usize] = pos as u32;
+        }
+        rank
+    };
 
     // 3. SCC condensation. Tarjan emits SCCs successors-first, so a later SCC's
     //    closure only references already-computed rows.
@@ -197,9 +213,9 @@ pub(crate) fn all_transitive_closures_dp<L: Lockfile + ?Sized>(
         return Ok(None);
     }
 
-    let mut result: HashMap<String, HashSet<Package>> = workspace_root_sccs
+    let mut member_ids: HashMap<String, Vec<u32>> = workspace_root_sccs
         .iter()
-        .map(|(ws, _)| ((*ws).clone(), HashSet::new()))
+        .map(|(ws, _)| ((*ws).clone(), Vec::new()))
         .collect();
 
     let words_per_chunk = chunk_bits / 64;
@@ -243,10 +259,10 @@ pub(crate) fn all_transitive_closures_dp<L: Lockfile + ?Sized>(
                     *dst |= src;
                 }
             }
-            // Inserted for every workspace when `result` was built; a miss
-            // is unreachable but must not panic under the workspace lint
-            // policy.
-            let Some(set) = result.get_mut(*workspace) else {
+            // Inserted for every workspace when `member_ids` was built; a
+            // miss is unreachable but must not panic under the workspace
+            // lint policy.
+            let Some(ids) = member_ids.get_mut(*workspace) else {
                 continue;
             };
             for (word_idx, &word) in accumulator.iter().enumerate() {
@@ -255,11 +271,23 @@ pub(crate) fn all_transitive_closures_dp<L: Lockfile + ?Sized>(
                     let bit = word.trailing_zeros() as usize;
                     word &= word - 1;
                     let id = chunk_start + word_idx * 64 + bit;
-                    set.insert((*packages[id]).clone());
+                    ids.push(id as u32);
                 }
             }
         }
     }
+
+    let result: SortedClosures = member_ids
+        .into_iter()
+        .map(|(ws, mut ids)| {
+            ids.sort_unstable_by_key(|&id| rank[id as usize]);
+            let closure = ids
+                .into_iter()
+                .map(|id| Arc::clone(&packages[id as usize]))
+                .collect();
+            (ws, closure)
+        })
+        .collect();
 
     Ok(Some(result))
 }
@@ -341,6 +369,8 @@ fn tarjan_scc(adjacency: &[Vec<u32>]) -> SccResult {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use pretty_assertions::assert_eq;
 
     use super::*;
@@ -368,7 +398,22 @@ mod tests {
             })
             .collect();
         match via_dp {
-            Some(dp) => assert_eq!(dp, legacy, "dp result must match the legacy walk"),
+            Some(dp) => {
+                let dp_as_sets: HashMap<String, HashSet<Package>> = dp
+                    .iter()
+                    .map(|(ws, closure)| {
+                        assert!(
+                            closure.is_sorted_by(|a, b| a <= b),
+                            "dp closure for {ws} must be sorted by (key, version)"
+                        );
+                        (
+                            ws.clone(),
+                            closure.iter().map(|pkg| (**pkg).clone()).collect(),
+                        )
+                    })
+                    .collect();
+                assert_eq!(dp_as_sets, legacy, "dp result must match the legacy walk");
+            }
             None => panic!("dp unexpectedly fell back for a uniform lockfile"),
         }
     }

--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -206,6 +206,30 @@ pub fn all_transitive_closures<L: Lockfile + ?Sized>(
     workspaces: HashMap<String, BTreeMap<String, String>>,
     ignore_missing_packages: bool,
 ) -> Result<HashMap<String, HashSet<Package>>, Error> {
+    Ok(
+        all_transitive_closures_sorted(lockfile, workspaces, ignore_missing_packages)?
+            .into_iter()
+            .map(|(ws, closure)| (ws, closure.into_iter().map(|pkg| (*pkg).clone()).collect()))
+            .collect(),
+    )
+}
+
+/// Per-workspace transitive closures keyed by workspace directory, each
+/// sorted by `Package`'s `(key, version)` ordering with members shared via
+/// `Arc`.
+pub type SortedClosures = HashMap<String, Vec<Arc<Package>>>;
+
+/// Like [`all_transitive_closures`], but each closure is a `Vec` sorted by
+/// `Package`'s `(key, version)` ordering with members shared via `Arc`.
+/// The sorted form lets consumers hash or diff closures without re-sorting,
+/// and the `Arc` sharing avoids cloning two `String`s per closure member per
+/// workspace (shared dependencies are the overwhelming majority in a
+/// monorepo).
+pub fn all_transitive_closures_sorted<L: Lockfile + ?Sized>(
+    lockfile: &L,
+    workspaces: HashMap<String, BTreeMap<String, String>>,
+    ignore_missing_packages: bool,
+) -> Result<SortedClosures, Error> {
     // Shared DP fast path: computes each closure once over the global
     // package graph instead of once per workspace. Only sound when the
     // lockfile proves every transitive edge resolves identically across
@@ -237,7 +261,9 @@ pub fn all_transitive_closures<L: Lockfile + ?Sized>(
                 &deps_cache,
                 &interner,
             )?;
-            Ok((workspace, closure))
+            let mut sorted: Vec<Arc<Package>> = closure.into_iter().map(Arc::new).collect();
+            sorted.sort_unstable();
+            Ok((workspace, sorted))
         })
         .collect()
 }

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -34,6 +34,7 @@ pub struct PackageGraphBuilder<'a, T> {
     package_discovery: T,
     package_manager: Option<PackageManager>,
     defer_closures: bool,
+    closure_hasher: Option<ClosureHasher>,
 }
 
 #[derive(Debug, Diagnostic, thiserror::Error)]
@@ -106,6 +107,7 @@ impl<'a> PackageGraphBuilder<'a, LocalPackageDiscoveryBuilder> {
             lockfile: None,
             package_manager: None,
             defer_closures: false,
+            closure_hasher: None,
         }
     }
 
@@ -146,6 +148,16 @@ impl<'a, P> PackageGraphBuilder<'a, P> {
         self
     }
 
+    /// Provide a function that hashes each workspace's sorted external
+    /// dependency closure. When set, `PackageInfo::external_deps_hash` is
+    /// populated wherever closures are computed (inline or deferred).
+    /// Injected because the capnp-based hasher lives in `turborepo-hash`,
+    /// which transitively depends on this crate.
+    pub fn with_closure_hasher(mut self, hasher: ClosureHasher) -> Self {
+        self.closure_hasher = Some(hasher);
+        self
+    }
+
     pub fn with_lockfile(mut self, lockfile: Option<Box<dyn Lockfile>>) -> Self {
         self.lockfile = lockfile;
         self
@@ -167,6 +179,7 @@ impl<'a, P> PackageGraphBuilder<'a, P> {
             package_discovery: discovery,
             package_manager: self.package_manager,
             defer_closures: self.defer_closures,
+            closure_hasher: self.closure_hasher,
         }
     }
 }
@@ -232,6 +245,7 @@ struct BuildState<'a, S, T> {
     lockfile: Option<Box<dyn Lockfile>>,
     package_jsons: Option<HashMap<AbsoluteSystemPathBuf, PackageJson>>,
     defer_closures: bool,
+    closure_hasher: Option<ClosureHasher>,
     state: std::marker::PhantomData<S>,
     /// The JavaScript toolchain, typed. Package-manager resolution for
     /// dependency splitting and lockfile handling reaches through this —
@@ -275,6 +289,7 @@ where
             repo_root,
             root_package_json,
             defer_closures,
+            closure_hasher,
             is_single_package: single,
 
             package_jsons,
@@ -327,6 +342,7 @@ where
             node_lookup,
             root_package_json,
             defer_closures,
+            closure_hasher,
             state: std::marker::PhantomData,
             javascript,
             toolchains,
@@ -438,6 +454,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             javascript,
             toolchains,
             defer_closures,
+            closure_hasher,
             ..
         } = self;
         Ok(BuildState {
@@ -453,6 +470,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             javascript,
             toolchains,
             defer_closures,
+            closure_hasher,
             package_jsons: None,
             state: std::marker::PhantomData,
         })
@@ -637,6 +655,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             javascript,
             toolchains,
             defer_closures,
+            closure_hasher,
             ..
         } = self;
         Ok(BuildState {
@@ -650,6 +669,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             root_package_json,
             lockfile,
             defer_closures,
+            closure_hasher,
             package_jsons: None,
             state: std::marker::PhantomData,
             javascript,
@@ -657,6 +677,15 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
         })
     }
 }
+
+/// Computes per-workspace external dependency hashes from sorted closures,
+/// keyed by workspace unix directory. See
+/// [`PackageGraphBuilder::with_closure_hasher`].
+pub type ClosureHasher = Arc<
+    dyn Fn(&HashMap<String, Vec<Arc<turborepo_lockfiles::Package>>>) -> HashMap<String, String>
+        + Send
+        + Sync,
+>;
 
 impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
     fn all_external_dependencies(
@@ -693,13 +722,20 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
 
         // We cannot ignore missing packages in this context, it would indicate a
         // malformed or stale lockfile.
-        let mut closures = turborepo_lockfiles::all_transitive_closures(
+        let mut closures = turborepo_lockfiles::all_transitive_closures_sorted(
             lockfile,
             self.all_external_dependencies()?,
             false,
         )?;
+        let mut hashes = self
+            .closure_hasher
+            .as_ref()
+            .map(|hasher| hasher(&closures))
+            .unwrap_or_default();
         for (_, entry) in self.workspaces.iter_mut() {
-            entry.transitive_dependencies = closures.remove(&entry.unix_dir_str()?);
+            let dir = entry.unix_dir_str()?;
+            entry.transitive_dependencies = closures.remove(&dir);
+            entry.external_deps_hash = hashes.remove(&dir);
         }
         Ok(())
     }
@@ -719,15 +755,23 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
                 match self.all_external_dependencies() {
                     Ok(external_deps) => {
                         let (tx, rx) = std::sync::mpsc::sync_channel(1);
+                        let hasher = self.closure_hasher.clone();
                         let spawned = std::thread::Builder::new()
                             .name("turbo-closures".into())
                             .spawn(move || {
-                                let closures = turborepo_lockfiles::all_transitive_closures(
+                                let result = turborepo_lockfiles::all_transitive_closures_sorted(
                                     lockfile.as_ref(),
                                     external_deps,
                                     false,
-                                );
-                                let _ = tx.send(closures.map_err(|e| e.to_string()));
+                                )
+                                .map(|closures| {
+                                    let hashes = hasher
+                                        .as_ref()
+                                        .map(|hasher| hasher(&closures))
+                                        .unwrap_or_default();
+                                    super::DeferredClosures { closures, hashes }
+                                });
+                                let _ = tx.send(result.map_err(|e| e.to_string()));
                             });
                         match spawned {
                             Ok(_) => deferred_closures = Some(rx),

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -30,11 +30,17 @@ pub use crate::package_json::DependencyKind;
 
 pub const ROOT_PKG_NAME: &str = "//";
 
-/// Channel end delivering the background transitive-closure result: closures
-/// keyed by workspace unix directory, or a rendered error message.
-pub(crate) type DeferredClosuresReceiver = std::sync::mpsc::Receiver<
-    Result<HashMap<String, HashSet<turborepo_lockfiles::Package>>, String>,
->;
+/// Background transitive-closure result: per-workspace sorted closures and
+/// their external-dependency hashes, keyed by workspace unix directory.
+pub(crate) struct DeferredClosures {
+    pub closures: HashMap<String, Vec<Arc<turborepo_lockfiles::Package>>>,
+    pub hashes: HashMap<String, String>,
+}
+
+/// Channel end delivering the background transitive-closure result, or a
+/// rendered error message.
+pub(crate) type DeferredClosuresReceiver =
+    std::sync::mpsc::Receiver<Result<DeferredClosures, String>>;
 
 #[derive(Debug)]
 pub struct PackageGraph {
@@ -95,7 +101,13 @@ pub struct PackageInfo {
     /// Path to the package's native manifest, anchored to the repo root.
     pub package_json_path: AnchoredSystemPathBuf,
     pub unresolved_external_dependencies: Option<BTreeMap<PackageKey, PackageVersion>>, /* name -> version */
-    pub transitive_dependencies: Option<HashSet<turborepo_lockfiles::Package>>,
+    /// The workspace's external dependency closure, sorted by `Package`'s
+    /// `(key, version)` ordering. Members are `Arc`-shared across workspaces.
+    pub transitive_dependencies: Option<Vec<Arc<turborepo_lockfiles::Package>>>,
+    /// Hash of `transitive_dependencies`, precomputed where the closure is
+    /// computed so task hashing and run summaries never re-sort or re-hash
+    /// closures. `Some` exactly when `transitive_dependencies` is `Some`.
+    pub external_deps_hash: Option<String>,
     /// The toolchain that discovered this package. Defaults to JavaScript.
     pub toolchain: crate::toolchain::ToolchainId,
 }
@@ -373,10 +385,14 @@ impl PackageGraph {
             return;
         };
         match receiver.recv() {
-            Ok(Ok(mut closures)) => {
+            Ok(Ok(DeferredClosures {
+                mut closures,
+                mut hashes,
+            })) => {
                 for (_, info) in self.packages.iter_mut() {
-                    info.transitive_dependencies =
-                        closures.remove(info.package_path().to_unix().as_str());
+                    let dir = info.package_path().to_unix();
+                    info.transitive_dependencies = closures.remove(dir.as_str());
+                    info.external_deps_hash = hashes.remove(dir.as_str());
                 }
             }
             Ok(Err(e)) => {
@@ -701,6 +717,7 @@ impl PackageGraph {
             .filter_map(|package| self.packages.get(package))
             .filter_map(|entry| entry.transitive_dependencies.as_ref())
             .flatten()
+            .map(|pkg| &**pkg)
             .collect()
     }
 
@@ -732,7 +749,8 @@ impl PackageGraph {
         // we're fine to ignore it. Assuming there is not a commit with a stale
         // lockfile, the same commit should add the package, so it will get
         // picked up as changed.
-        let closures = turborepo_lockfiles::all_transitive_closures(previous, external_deps, true)?;
+        let closures =
+            turborepo_lockfiles::all_transitive_closures_sorted(previous, external_deps, true)?;
 
         let global_change = current.global_change(previous);
 
@@ -743,30 +761,32 @@ impl PackageGraph {
                 .iter()
                 .filter_map(|(name, info)| {
                     let previous_closure = closures.get(info.package_path().to_unix().as_str());
+                    // Both closures are sorted by (key, version), so `Vec`
+                    // equality is set equality here.
                     let not_equal = previous_closure != info.transitive_dependencies.as_ref();
                     if not_equal {
-                        if let (Some(prev), Some(curr)) =
-                            (previous_closure, info.transitive_dependencies.as_ref())
-                        {
-                            debug!(
-                                "package {name} has differing closure: {:?}",
-                                prev.symmetric_difference(curr)
-                            );
-                        }
-                        let empty_set = HashSet::default();
-                        let prev_deps = previous_closure.unwrap_or(&empty_set);
-                        let curr_deps = info.transitive_dependencies.as_ref().unwrap_or(&empty_set);
+                        let empty = Vec::new();
+                        let prev_deps = previous_closure.unwrap_or(&empty);
+                        let curr_deps = info.transitive_dependencies.as_ref().unwrap_or(&empty);
+                        let prev_set: HashSet<&turborepo_lockfiles::Package> =
+                            prev_deps.iter().map(|pkg| &**pkg).collect();
+                        let curr_set: HashSet<&turborepo_lockfiles::Package> =
+                            curr_deps.iter().map(|pkg| &**pkg).collect();
+                        debug!(
+                            "package {name} has differing closure: {:?}",
+                            prev_set.symmetric_difference(&curr_set)
+                        );
                         // {a, b} -> {a, c}
                         // b was removed
                         // c was added
-                        let added = curr_deps
-                            .difference(prev_deps)
-                            .cloned()
+                        let added = curr_set
+                            .difference(&prev_set)
+                            .map(|pkg| (*pkg).clone())
                             .sorted()
                             .collect::<Vec<_>>();
-                        let removed = prev_deps
-                            .difference(curr_deps)
-                            .cloned()
+                        let removed = prev_set
+                            .difference(&curr_set)
+                            .map(|pkg| (*pkg).clone())
                             .sorted()
                             .collect::<Vec<_>>();
                         Some((name, info, added, removed))
@@ -834,7 +854,7 @@ impl PackageGraph {
         // First find which packages directly depend on each external package
         for (pkg, info) in self.packages.iter() {
             for dep in info.transitive_dependencies.iter().flatten() {
-                let rdeps = map.entry(dep.clone()).or_default();
+                let rdeps = map.entry((**dep).clone()).or_default();
                 rdeps.insert(PackageNode::Workspace(pkg.clone()));
             }
         }
@@ -1341,8 +1361,9 @@ mod test {
         let a = turborepo_lockfiles::Package::new("key:a", "1");
         let b = turborepo_lockfiles::Package::new("key:b", "1");
         let c = turborepo_lockfiles::Package::new("key:c", "1");
-        assert_eq!(foo_deps, &HashSet::from_iter(vec![a.clone(), c.clone(),]));
-        assert_eq!(bar_deps, &HashSet::from_iter(vec![b.clone(), c.clone(),]));
+        // Closures are sorted by (key, version).
+        assert_eq!(foo_deps, &vec![Arc::new(a.clone()), Arc::new(c.clone())]);
+        assert_eq!(bar_deps, &vec![Arc::new(b.clone()), Arc::new(c.clone())]);
         assert_eq!(
             pkg_graph.transitive_external_dependencies([&foo, &bar].iter().copied()),
             HashSet::from_iter(vec![&a, &b, &c,])
@@ -1377,6 +1398,23 @@ mod test {
             map
         };
 
+        // Stub hasher: enough to prove the hash is computed and delivered on
+        // both paths. The production hasher's byte-identity with the legacy
+        // sort-then-hash path is proven in `turborepo-task-hash` tests.
+        let hasher: crate::package_graph::builder::ClosureHasher = Arc::new(|closures| {
+            closures
+                .iter()
+                .map(|(ws, closure)| {
+                    let rendered = closure
+                        .iter()
+                        .map(|pkg| format!("{}@{}", pkg.key, pkg.version))
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    (ws.clone(), rendered)
+                })
+                .collect()
+        });
+
         let inline = PackageGraph::builder(
             &root,
             PackageJson::from_value(json!({ "name": "root" })).unwrap(),
@@ -1384,6 +1422,7 @@ mod test {
         .with_package_discovery(MockDiscovery)
         .with_package_jsons(Some(package_jsons()))
         .with_lockfile(Some(Box::new(MockLockfile {})))
+        .with_closure_hasher(hasher.clone())
         .build()
         .await
         .unwrap();
@@ -1396,6 +1435,7 @@ mod test {
         .with_package_jsons(Some(package_jsons()))
         .with_lockfile(Some(Box::new(MockLockfile {})))
         .defer_transitive_closures(true)
+        .with_closure_hasher(hasher)
         .build()
         .await
         .unwrap();
@@ -1414,10 +1454,19 @@ mod test {
         deferred.ensure_transitive_closures();
 
         for (name, info) in inline.packages.iter() {
+            let deferred_info = deferred.packages.get(name).unwrap();
             assert_eq!(
-                info.transitive_dependencies,
-                deferred.packages.get(name).unwrap().transitive_dependencies,
+                info.transitive_dependencies, deferred_info.transitive_dependencies,
                 "closures must match for {name}"
+            );
+            assert_eq!(
+                info.external_deps_hash, deferred_info.external_deps_hash,
+                "external deps hashes must match for {name}"
+            );
+            assert_eq!(
+                info.external_deps_hash.is_some(),
+                info.transitive_dependencies.is_some(),
+                "hash must be present exactly when the closure is, for {name}"
             );
         }
     }

--- a/crates/turborepo-run-summary/src/task_factory.rs
+++ b/crates/turborepo-run-summary/src/task_factory.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use turbopath::AnchoredSystemPath;
 use turborepo_env::EnvironmentVariableMap;
 use turborepo_lockfiles::Package;
@@ -176,9 +174,13 @@ where
             })
             .unwrap_or_default();
 
-        // Compute external deps hash from workspace info
-        let hash_of_external_dependencies =
-            get_external_deps_hash(&workspace_info.transitive_dependencies);
+        // The hash is precomputed where the closure is computed; the
+        // recompute below only runs for graphs built without a closure
+        // hasher.
+        let hash_of_external_dependencies = workspace_info
+            .external_deps_hash
+            .clone()
+            .unwrap_or_else(|| get_external_deps_hash(&workspace_info.transitive_dependencies));
 
         Ok(SharedTaskSummary {
             hash,
@@ -250,21 +252,19 @@ fn workspace_relative_log_file(
     Ok(log_dir.join_component(&task_log_filename(task_name)))
 }
 
-/// Computes a hash of external dependencies from transitive dependencies.
-/// This is a pure function that doesn't require any trait access.
-pub fn get_external_deps_hash(transitive_dependencies: &Option<HashSet<Package>>) -> String {
+/// Computes a hash of external dependencies from a workspace's sorted
+/// transitive dependency closure. The closure is already sorted by
+/// `Package`'s `(key, version)` ordering, so no re-sort is needed.
+pub fn get_external_deps_hash(
+    transitive_dependencies: &Option<Vec<std::sync::Arc<Package>>>,
+) -> String {
     use turborepo_hash::{LockFilePackagesRef, TurboHash};
 
     let Some(transitive_dependencies) = transitive_dependencies else {
         return "".into();
     };
 
-    let mut transitive_deps: Vec<&Package> = transitive_dependencies.iter().collect();
-
-    transitive_deps.sort_unstable_by(|a, b| match a.key.cmp(&b.key) {
-        std::cmp::Ordering::Equal => a.version.cmp(&b.version),
-        other => other,
-    });
+    let transitive_deps: Vec<&Package> = transitive_dependencies.iter().map(|pkg| &**pkg).collect();
 
     LockFilePackagesRef(transitive_deps).hash()
 }

--- a/crates/turborepo-task-hash/src/lib.rs
+++ b/crates/turborepo-task-hash/src/lib.rs
@@ -247,17 +247,20 @@ impl PackageInputsHashes {
     }
 }
 
-/// Compute the external dependency hash for every workspace in parallel.
-/// Many tasks share the same package, so hashing once per package avoids
-/// re-sorting transitive dependencies for every task.
+/// Collect the external dependency hash for every workspace, keyed by
+/// package name. Hashes are precomputed where closures are computed (see
+/// [`hash_sorted_closures`]); the per-package fallback only runs for graphs
+/// built without a closure hasher.
 #[tracing::instrument(skip_all)]
 pub fn compute_external_deps_hashes<'b>(
     workspaces: impl Iterator<Item = (&'b PackageName, &'b PackageInfo)>,
 ) -> HashMap<String, String> {
-    let ws: Vec<_> = workspaces.collect();
-    ws.par_iter()
+    workspaces
         .map(|(name, info)| {
-            let hash = get_external_deps_hash(&info.transitive_dependencies);
+            let hash = info
+                .external_deps_hash
+                .clone()
+                .unwrap_or_else(|| get_external_deps_hash(&info.transitive_dependencies));
             (name.as_str().to_owned(), hash)
         })
         .collect()
@@ -717,22 +720,36 @@ pub fn deferred_task_hash_message(inputs: &TaskInputs) -> &'static str {
 }
 
 pub fn get_external_deps_hash(
-    transitive_dependencies: &Option<HashSet<turborepo_lockfiles::Package>>,
+    transitive_dependencies: &Option<Vec<Arc<turborepo_lockfiles::Package>>>,
 ) -> String {
     let Some(transitive_dependencies) = transitive_dependencies else {
         return "".into();
     };
 
-    // Collect references instead of cloning each Package (which has two Strings).
-    let mut transitive_deps: Vec<&turborepo_lockfiles::Package> =
-        transitive_dependencies.iter().collect();
-
-    transitive_deps.sort_unstable_by(|a, b| match a.key.cmp(&b.key) {
-        std::cmp::Ordering::Equal => a.version.cmp(&b.version),
-        other => other,
-    });
+    // The closure is already sorted by `Package`'s `(key, version)` ordering,
+    // so hashing is a single linear pass.
+    let transitive_deps: Vec<&turborepo_lockfiles::Package> =
+        transitive_dependencies.iter().map(|pkg| &**pkg).collect();
 
     LockFilePackagesRef(transitive_deps).hash()
+}
+
+/// Hash every workspace's sorted external dependency closure, keyed by the
+/// closure map's own keys. Intended as the `PackageGraphBuilder`
+/// closure-hasher, so hashes are computed where closures are computed
+/// (on the deferred-closure background thread) instead of after graph
+/// construction.
+pub fn hash_sorted_closures(
+    closures: &HashMap<String, Vec<Arc<turborepo_lockfiles::Package>>>,
+) -> HashMap<String, String> {
+    closures
+        .par_iter()
+        .map(|(ws, closure)| {
+            let refs: Vec<&turborepo_lockfiles::Package> =
+                closure.iter().map(|pkg| &**pkg).collect();
+            (ws.clone(), LockFilePackagesRef(refs).hash())
+        })
+        .collect()
 }
 
 pub fn get_internal_deps_hash(
@@ -1199,11 +1216,20 @@ mod test {
         assert_eq!(result[3].1, "dddddddddddddddddddddddddddddddddddddddd");
     }
 
+    fn sorted_closure(
+        packages: Vec<turborepo_lockfiles::Package>,
+    ) -> Vec<Arc<turborepo_lockfiles::Package>> {
+        let mut closure: Vec<Arc<turborepo_lockfiles::Package>> =
+            packages.into_iter().map(Arc::new).collect();
+        closure.sort_unstable();
+        closure
+    }
+
     #[test]
     fn test_external_deps_hash_deterministic() {
         use turborepo_lockfiles::Package;
 
-        let deps: HashSet<Package> = vec![
+        let deps = sorted_closure(vec![
             Package {
                 key: "react".to_string(),
                 version: "18.0.0".to_string(),
@@ -1216,9 +1242,7 @@ mod test {
                 key: "typescript".to_string(),
                 version: "5.0.0".to_string(),
             },
-        ]
-        .into_iter()
-        .collect();
+        ]);
 
         let hash1 = get_external_deps_hash(&Some(deps.clone()));
         let hash2 = get_external_deps_hash(&Some(deps));
@@ -1231,48 +1255,53 @@ mod test {
         let hash_none = get_external_deps_hash(&None);
         assert_eq!(hash_none, "", "None deps should produce empty hash");
 
-        let hash_empty = get_external_deps_hash(&Some(HashSet::new()));
+        let hash_empty = get_external_deps_hash(&Some(Vec::new()));
         assert!(
             !hash_empty.is_empty(),
-            "empty set should produce non-empty hash"
+            "empty closure should produce non-empty hash"
         );
     }
 
+    /// The linear hash of a pre-sorted closure must be byte-identical to the
+    /// legacy path, which collected a `HashSet` and sorted by
+    /// `(key, version)` before hashing.
     #[test]
-    fn test_external_deps_hash_order_independent() {
+    fn test_external_deps_hash_matches_legacy_sort_then_hash() {
         use turborepo_lockfiles::Package;
 
-        let deps1: HashSet<Package> = vec![
-            Package {
-                key: "a".to_string(),
-                version: "1.0".to_string(),
-            },
-            Package {
-                key: "b".to_string(),
-                version: "2.0".to_string(),
-            },
-        ]
-        .into_iter()
-        .collect();
-
-        let deps2: HashSet<Package> = vec![
+        let packages = vec![
             Package {
                 key: "b".to_string(),
                 version: "2.0".to_string(),
             },
             Package {
                 key: "a".to_string(),
+                version: "1.1".to_string(),
+            },
+            Package {
+                key: "a".to_string(),
                 version: "1.0".to_string(),
             },
-        ]
-        .into_iter()
-        .collect();
+            Package {
+                key: "c".to_string(),
+                version: "0.1".to_string(),
+            },
+        ];
 
-        let hash1 = get_external_deps_hash(&Some(deps1));
-        let hash2 = get_external_deps_hash(&Some(deps2));
+        let legacy_hash = {
+            let set: HashSet<Package> = packages.iter().cloned().collect();
+            let mut refs: Vec<&Package> = set.iter().collect();
+            refs.sort_unstable_by(|a, b| match a.key.cmp(&b.key) {
+                std::cmp::Ordering::Equal => a.version.cmp(&b.version),
+                other => other,
+            });
+            LockFilePackagesRef(refs).hash()
+        };
+
+        let sorted_hash = get_external_deps_hash(&Some(sorted_closure(packages)));
         assert_eq!(
-            hash1, hash2,
-            "hash should be order-independent since we sort"
+            legacy_hash, sorted_hash,
+            "sorted-closure hash must match the legacy sort-then-hash path"
         );
     }
 


### PR DESCRIPTION
## Why

After #13250, transitive closures compute on a background thread, but task hashing still paid for them twice on the critical path: closure materialization cloned two `String`s per closure member per workspace into a `HashSet`, and `hash_scope` later re-sorted and capnp-hashed every workspace's closure. On a 1191-package monorepo that was ~44ms of hashing inside `hash_scope`, plus contention that slowed the concurrent file-hashing leg.

## What

- `all_transitive_closures_sorted`: closures leave the lockfile layer as `Vec<Arc<Package>>` sorted by `(key, version)` (`Package`'s derived `Ord`, identical to the old sort comparator). The closure DP emits sorted rows via a one-time u32 rank permutation — no string comparisons or per-member `String` clones at materialization. The legacy `HashSet` API remains as a wrapper for other callers.
- `PackageInfo::transitive_dependencies` becomes the sorted `Vec<Arc<Package>>`; new `PackageInfo::external_deps_hash` carries the precomputed hash.
- A closure hasher is injected into `PackageGraphBuilder` (injected because `turborepo-hash` transitively depends on `turborepo-repository`), so hashes are computed on the deferred-closure background thread straight from the pre-sorted rows. Task hashing, run summaries, and the root global-hash input read the field; each keeps a linear-hash fallback for graphs built without a hasher.

## How to verify

- `turborepo-task-hash` has a differential test proving the linear hash of a sorted closure is byte-identical to the legacy collect-sort-hash path; the DP's oracle test now also asserts sortedness.
- The deferred-vs-inline graph test asserts closures and hashes match on both paths.
- Measured on a 1191-package monorepo (interleaved A/B, 8 runs, vs #13250): `compute_external_deps_hashes` 44.4ms → 0.3ms; `hash_scope` 45.1ms → 15.2ms (the concurrent file-hash leg also dropped 45ms → 15ms from reduced core contention); time-to-first-task median 296.5ms → 255.5ms (−14%). `--dry=json` output is byte-identical.

Stacked on #13250; retarget to `main` when it merges. Note: this subsumes the recompute #13249 avoids in run summaries — if this lands, #13249 reduces to a trivial rebase or can be closed.
