### PR TITLE
fix: Avoid non-reentrant libc calls in concurrent shutdown process scans

### DIFF
--- a/crates/turborepo-process/src/child/handle.rs
+++ b/crates/turborepo-process/src/child/handle.rs
@@ -184,7 +184,12 @@ fn capture_target_identity(pid: Option<u32>) -> Option<TargetIdentity> {
 
 #[cfg(unix)]
 fn descendant_pids(root_pid: libc::pid_t) -> Vec<libc::pid_t> {
-    let mut system = System::new_all();
+    // Only the process table is needed here. `System::new_all` would also
+    // refresh the users list, which on musl calls the non-reentrant
+    // `getgrgid`/`getpwuid`. This function runs concurrently (once per child)
+    // during graceful shutdown, and racing those libc calls corrupts musl's
+    // heap and segfaults (#13254).
+    let mut system = System::new();
     system.refresh_processes();
 
     let root_pid = sysinfo::Pid::from_u32(root_pid as u32);


### PR DESCRIPTION
## Why

Fixes #13254 — `turbo` segfaults roughly every other Ctrl-C when running multiple persistent tasks on Linux (musl builds, i.e. all published Linux binaries), starting in 2.10.

Root cause, confirmed via core dump from the published `linux-arm64` binary: `descendant_pids()` (added in #13100 for graceful PTY shutdown) builds a `sysinfo::System::new_all()`. In sysinfo 0.27, `new_all()` also refreshes the **users list**, which calls libc `getgrgid()`/`getpwuid()` — the non-reentrant variants that share static internal buffers (`getline` buffer + result structs) with no locking. `descendant_pids()` runs once per child, concurrently, at the moment Ctrl-C arrives. Two threads racing through those statics issue concurrent `realloc`/`free` on the same allocation; musl's hardened mallocng detects the corruption in `get_meta()` and deliberately crashes (`a_crash()` — a null write), which surfaces as SIGSEGV.

2.9.18 is unaffected because the sysinfo scan didn't exist yet. glibc builds have the same race but rarely crash, which is why it went unnoticed in local dev builds.

## What

Construct an empty `System` and refresh only the process table, which is all `descendant_pids()` reads. This removes the users-list refresh (and the disks/networks/components refreshes) from the shutdown path entirely — no more non-reentrant libc calls, and a cheaper scan.

## How

To reproduce/verify: on linux-arm64 (musl), run the reproduction from https://github.com/PAStheLoD/turborepo-sigint-pty-segfault — `turbo run start-dev` under a real PTY, send `^C` after both servers are listening. Pre-fix binaries segfault ~10-50% of attempts depending on machine; 2.9.18 never does.

The mechanism is independently provable with a 20-line C program: 2+ threads looping `getgrgid(0); getpwuid(0);` linked against static musl segfaults immediately, every run.

Follow-ups worth considering (not in this PR): upgrade sysinfo (≥0.30 moved users out of `System`), and dedupe the per-child process-table scans at shutdown.