### PR TITLE
perf: Memoize resolved task definitions during engine construction

### DIFF
--- a/crates/turborepo-engine/src/builder.rs
+++ b/crates/turborepo-engine/src/builder.rs
@@ -181,6 +181,7 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
             self.tasks.clone()
         };
 
+        let entrypoints_span = tracing::info_span!("engine_entrypoints").entered();
         for (workspace, task) in self.workspaces.iter().cartesian_product(tasks.iter()) {
             // When a task uses package#task syntax (e.g. "web#build"), the task_id
             // always resolves to that specific package regardless of which workspace
@@ -216,7 +217,10 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
             }
         }
 
+        drop(entrypoints_span);
+
         {
+            let _span = tracing::info_span!("engine_missing_tasks").entered();
             // We can encounter IO errors trying to load turbo.jsons which prevents using
             // `retain` in the standard way. Instead we store the possible error
             // outside of the loop and short circuit checks if we've encountered an error.
@@ -278,9 +282,12 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
 
         let allowed_tasks = self.allowed_tasks();
 
+        let traversal_span = tracing::info_span!("engine_traversal").entered();
         let mut visited = HashSet::new();
         let mut engine: Engine<Building, TaskDefinition> = Engine::default();
         let mut turbo_json_chain_cache: HashMap<PackageName, Vec<&TurboJson>> = HashMap::new();
+        let mut task_def_memo: HashMap<definitions::TaskDefMemoKey, TaskDefinition> =
+            HashMap::new();
 
         while let Some(task_id) = traversal_queue.pop_front() {
             {
@@ -358,6 +365,7 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                 &task_id,
                 &task_id.as_non_workspace_task_name(),
                 &mut turbo_json_chain_cache,
+                &mut task_def_memo,
             )?;
 
             visited.insert(task_id.as_inner().clone());
@@ -448,6 +456,9 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
             }
         }
 
+        drop(traversal_span);
+
+        let _span = tracing::info_span!("engine_validate").entered();
         // This is the sole cycle/self-dependency check in the pipeline. Package
         // graph cycles are intentionally allowed; only task graph cycles prevent
         // execution. See #2559.

--- a/crates/turborepo-engine/src/builder/definitions.rs
+++ b/crates/turborepo-engine/src/builder/definitions.rs
@@ -15,6 +15,18 @@ use crate::{
     MissingTurboJsonExtends, TaskDefinitionFromProcessed, TaskDefinitionResult, TurboJsonLoader,
 };
 
+/// Memo key for resolved task definitions: the turbo.json chain (by
+/// address; loader-owned for the duration of a build), the task name, and
+/// the two package-dependent inputs that survive resolution — path to the
+/// repo root and script presence. See `task_definition_cached`.
+#[derive(PartialEq, Eq, Hash)]
+pub(super) struct TaskDefMemoKey {
+    chain: Vec<usize>,
+    task_name: TaskName<'static>,
+    path_to_root: turbopath::RelativeUnixPathBuf,
+    package_has_script: bool,
+}
+
 impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
     // Helper methods used when building the engine
     /// Checks if there's a task definition somewhere in the repository
@@ -174,52 +186,8 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         task_id: &Spanned<TaskId>,
         task_name: &TaskName,
         chain_cache: &mut HashMap<PackageName, Vec<&'b TurboJson>>,
+        def_memo: &mut HashMap<TaskDefMemoKey, TaskDefinition>,
     ) -> Result<TaskDefinition, BuilderError> {
-        let processed_task_definition = ProcessedTaskDefinition::from_iter(
-            self.task_definition_chain_cached(turbo_json_loader, task_id, task_name, chain_cache)?,
-        );
-        let had_explicit_inputs = processed_task_definition.inputs.is_some();
-        let path_to_root = self.path_to_root(task_id.as_inner())?;
-        let mut task_def =
-            TaskDefinition::from_processed(processed_task_definition, &path_to_root)?;
-
-        if !self.future_flags.incremental_tasks {
-            task_def.incremental = None;
-        }
-
-        // Only prepend global inputs to tasks whose package actually has a
-        // script for this task. Phantom/transit tasks (packages without a
-        // matching script that exist solely for dependency ordering via
-        // `dependsOn: ["^task"]`) should not hash global input files — they
-        // don't execute, and including the files would cause their hash to
-        // change and cascade into downstream tasks that depend on them.
-        let package_has_script = self
-            .package_graph
-            .package_json(&PackageName::from(task_id.package()))
-            .and_then(|pj| pj.scripts.get(task_id.task()))
-            .is_some_and(|script| !script.is_empty());
-
-        if !self.global_deps.is_empty() && package_has_script {
-            crate::task_definition::prepend_global_inputs(
-                &mut task_def.inputs,
-                had_explicit_inputs,
-                &self.global_deps,
-                &path_to_root,
-            );
-        }
-
-        Ok(task_def)
-    }
-
-    /// Like `task_definition_chain` but caches the turbo.json chain per
-    /// package.
-    fn task_definition_chain_cached<'b>(
-        &self,
-        turbo_json_loader: &'b L,
-        task_id: &Spanned<TaskId>,
-        task_name: &TaskName,
-        chain_cache: &mut HashMap<PackageName, Vec<&'b TurboJson>>,
-    ) -> Result<Vec<ProcessedTaskDefinition>, BuilderError> {
         let package_name = PackageName::from(task_id.package());
         let turbo_json_chain = match chain_cache.get(&package_name) {
             Some(cached) => cached.clone(),
@@ -230,13 +198,82 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
             }
         };
 
-        Self::resolve_task_definitions_from_chain(
-            turbo_json_chain,
-            task_id,
-            task_name,
-            self.is_single,
-            self.should_validate_engine,
-        )
+        let path_to_root = self.path_to_root(task_id.as_inner())?;
+        let package_has_script = self.package_has_script(task_id.as_inner());
+
+        // Most tasks resolve to an identical definition: the same turbo.json
+        // chain and task name, differing only by the package's depth (for
+        // `$TURBO_ROOT$`/global-input anchoring) and whether the package has
+        // a matching script. Memoize on exactly those inputs. The one way a
+        // definition can additionally depend on the package is a
+        // package-scoped task key (`web#build`) in the chain, which
+        // `TurboJson::task` consults first — skip the memo for those.
+        let memo_key = {
+            let package_scoped = turbo_json_chain.iter().any(|turbo_json| {
+                turbo_json
+                    .tasks
+                    .get(&task_id.as_inner().as_task_name())
+                    .is_some()
+            });
+            (!package_scoped).then(|| TaskDefMemoKey {
+                chain: turbo_json_chain
+                    .iter()
+                    .map(|turbo_json| *turbo_json as *const TurboJson as usize)
+                    .collect(),
+                task_name: task_name.clone().into_owned(),
+                path_to_root: path_to_root.clone(),
+                package_has_script,
+            })
+        };
+        if let Some(key) = &memo_key
+            && let Some(cached) = def_memo.get(key)
+        {
+            return Ok(cached.clone());
+        }
+
+        let processed_task_definition =
+            ProcessedTaskDefinition::from_iter(Self::resolve_task_definitions_from_chain(
+                turbo_json_chain,
+                task_id,
+                task_name,
+                self.is_single,
+                self.should_validate_engine,
+            )?);
+        let had_explicit_inputs = processed_task_definition.inputs.is_some();
+        let mut task_def =
+            TaskDefinition::from_processed(processed_task_definition, &path_to_root)?;
+
+        if !self.future_flags.incremental_tasks {
+            task_def.incremental = None;
+        }
+
+        if !self.global_deps.is_empty() && package_has_script {
+            crate::task_definition::prepend_global_inputs(
+                &mut task_def.inputs,
+                had_explicit_inputs,
+                &self.global_deps,
+                &path_to_root,
+            );
+        }
+
+        if let Some(key) = memo_key {
+            def_memo.insert(key, task_def.clone());
+        }
+
+        Ok(task_def)
+    }
+
+    /// Whether the task's package has a non-empty script for it. Tasks
+    /// without one are phantom/transit tasks (they exist solely for
+    /// dependency ordering via `dependsOn: ["^task"]`) and must not hash
+    /// global input files — they don't execute, and including the files
+    /// would cause their hash to change and cascade into downstream tasks
+    /// that depend on them.
+    fn package_has_script(&self, task_id: &TaskId) -> bool {
+        self.package_graph
+            .package_json(&PackageName::from(task_id.package()))
+            .and_then(|pj| pj.scripts.get(task_id.task()))
+            .is_some_and(|script| !script.is_empty())
     }
 
     pub fn task_definition_chain(


### PR DESCRIPTION
## Why

Engine construction sits on the time-to-first-task critical path and resolves a task definition per task: walk the package's turbo.json chain, extract and process raw definitions, merge, convert (glob processing, `$TURBO_ROOT$` substitution). On a 1191-package monorepo with 1866 tasks this was ~30ms of the ~73ms `build_engine` — yet most tasks resolve to an *identical* definition, since most packages inherit the root turbo.json unchanged.

## What

- Memoize resolved `TaskDefinition`s during `EngineBuilder::build`, keyed by the complete set of inputs a resolution depends on: the turbo.json chain (by address — loader-owned for the build's duration), the task name, the package's path to the repo root (for `$TURBO_ROOT$`/global-input anchoring), and whether the package has a matching script (gates global-input prepending for phantom/transit tasks).
- The one way a definition can additionally depend on the specific package is a package-scoped task key (`web#build`), which `TurboJson::task` consults before the generic key — the memo is skipped whenever any chain member defines one for the task at hand.
- Adds `engine_entrypoints`/`engine_missing_tasks`/`engine_traversal`/`engine_validate` spans breaking down `build_engine` in `--profile` output (this breakdown located the cost).

## How to verify

- `cargo test -p turborepo-engine` (110 tests: extends chains, `extends: false`, package-scoped overrides) and `cargo test -p turborepo-lib` pass unchanged.
- Measured on the monorepo above: 1489/1866 lookups hit (misses are the 239 packages with their own turbo.json, hence distinct chains); definition resolution 30ms → ~5ms within `engine_traversal`. `--dry=json` output byte-identical.
- Honest framing on wall-clock: engine construction currently overlaps the untracked-file scan, which finishes ~3ms later — so TTFT alone doesn't move on a saturated 4-core machine until that scan shortens (follow-up in progress). This change removes ~25ms of CPU from that contended window and lowers the engine-side floor for it.
