### PR TITLE
feat: Execute Cargo crate tasks via cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8170,6 +8170,7 @@ dependencies = [
  "turborepo-rayon-compat",
  "turborepo-unescape",
  "wax",
+ "which",
 ]
 
 [[package]]

--- a/crates/turborepo-lib/src/task_graph/visitor/command.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/command.rs
@@ -4,10 +4,10 @@ use crate::microfrontends::MicrofrontendsConfigs;
 // Re-export CommandFactory from turborepo-task-executor with our Error type
 pub type CommandFactory<'a> = turborepo_task_executor::CommandFactory<'a, Error>;
 
-// Re-export PackageGraphCommandProvider from turborepo-task-executor with our
+// Re-export ToolchainCommandProvider from turborepo-task-executor with our
 // MicrofrontendsConfigs type
-pub type PackageGraphCommandProvider<'a> =
-    turborepo_task_executor::PackageGraphCommandProvider<'a, MicrofrontendsConfigs>;
+pub type ToolchainCommandProvider<'a> =
+    turborepo_task_executor::ToolchainCommandProvider<'a, MicrofrontendsConfigs>;
 
 // Re-export MicroFrontendProxyProvider from turborepo-task-executor with our
 // MicrofrontendsConfigs type

--- a/crates/turborepo-lib/src/task_graph/visitor/exec.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/exec.rs
@@ -14,7 +14,7 @@ use turborepo_task_hash::TaskHashTracker;
 use turborepo_task_id::TaskId;
 
 use super::{
-    command::{CommandFactory, MicroFrontendProxyProvider, PackageGraphCommandProvider},
+    command::{CommandFactory, MicroFrontendProxyProvider, ToolchainCommandProvider},
     Visitor,
 };
 use crate::{
@@ -53,7 +53,7 @@ impl<'a> ExecContextFactory<'a> {
         manager: ProcessManager,
         engine: &'a Arc<Engine>,
     ) -> Result<Self, super::Error> {
-        let pkg_graph_provider = PackageGraphCommandProvider::new(
+        let pkg_graph_provider = ToolchainCommandProvider::new(
             visitor.repo_root,
             &visitor.package_graph,
             visitor.run_opts.task_args(),

--- a/crates/turborepo-process/src/command.rs
+++ b/crates/turborepo-process/src/command.rs
@@ -17,6 +17,7 @@ pub struct Command {
     env: BTreeMap<OsString, OsString>,
     open_stdin: bool,
     env_clear: bool,
+    serial_group: Option<String>,
 }
 
 impl Command {
@@ -29,6 +30,7 @@ impl Command {
             env: BTreeMap::new(),
             open_stdin: false,
             env_clear: false,
+            serial_group: None,
         }
     }
 
@@ -106,6 +108,21 @@ impl Command {
     pub fn program(&self) -> &OsStr {
         &self.program
     }
+
+    /// Mark this command as part of a mutually-exclusive execution group:
+    /// the executor runs at most one command per group at a time. Used for
+    /// tools that hold global locks (e.g. Cargo's build-directory lock),
+    /// where concurrent processes cannot make progress anyway and just emit
+    /// "waiting for file lock" noise.
+    pub fn serial_group(&mut self, group: impl Into<String>) -> &mut Self {
+        self.serial_group = Some(group.into());
+        self
+    }
+
+    /// The command's mutually-exclusive execution group, if any.
+    pub fn serial_group_name(&self) -> Option<&str> {
+        self.serial_group.as_deref()
+    }
 }
 
 impl From<Command> for std::process::Command {
@@ -117,6 +134,7 @@ impl From<Command> for std::process::Command {
             env,
             open_stdin,
             env_clear,
+            serial_group: _,
         } = value;
 
         let mut cmd = std::process::Command::new(program);

--- a/crates/turborepo-repository/Cargo.toml
+++ b/crates/turborepo-repository/Cargo.toml
@@ -41,6 +41,7 @@ turborepo-lockfiles = { workspace = true }
 turborepo-rayon-compat = { workspace = true }
 turborepo-unescape = { workspace = true }
 wax = { workspace = true }
+which = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -59,23 +59,202 @@ pub enum Error {
     Parse(#[from] serde_json::Error),
 }
 
+/// How a Cargo-toolchain package participates in task execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CargoPackageKind {
+    /// An internal library crate: present in the package graph for
+    /// `--filter`/`--affected` propagation, but tasks are no-ops — Cargo
+    /// builds libraries implicitly as part of an entrypoint's closure.
+    Library,
+    /// A crate with `bin`/`cdylib`/`staticlib` targets: a deliverable.
+    /// `build`/`run` tasks execute `cargo <verb> --package=<crate>`.
+    Entrypoint,
+    /// The synthetic [`WORKSPACE_PACKAGE_NAME`] package hosting
+    /// workspace-scoped verification verbs (`cargo test --workspace`, ...).
+    Workspace,
+}
+
+/// Cargo-specific details for a discovered package, retained by the
+/// [`CargoToolchain`] (keyed by package name) rather than attached to the
+/// toolchain-neutral `PackageInfo`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CargoPackageDetails {
+    pub kind: CargoPackageKind,
+    /// The crate's deliverable targets (empty for libraries and the
+    /// workspace package).
+    pub deliverables: Vec<Deliverable>,
+}
+
+/// Map a Turborepo task name to the Cargo subcommand that implements it for
+/// an entrypoint crate. Entrypoints only build and run — verification verbs
+/// happen at workspace scope.
+pub fn entrypoint_subcommand(task: &str) -> Option<&'static str> {
+    match task {
+        "build" => Some("build"),
+        "run" | "dev" => Some("run"),
+        _ => None,
+    }
+}
+
+/// Map a Turborepo task name to the Cargo subcommand that implements it at
+/// workspace scope (the synthetic [`WORKSPACE_PACKAGE_NAME`] package).
+///
+/// `build` is deliberately absent: building is entrypoint-scoped
+/// (`cargo build --package=<crate>`), and a workspace-wide build would
+/// duplicate that work in a second cargo process.
+pub fn workspace_subcommand(task: &str) -> Option<&'static str> {
+    match task {
+        "test" => Some("test"),
+        "check" => Some("check"),
+        "lint" | "clippy" => Some("clippy"),
+        "doc" | "docs" => Some("doc"),
+        "bench" => Some("bench"),
+        _ => None,
+    }
+}
+
+/// The Cargo subcommand a task resolves to for a package, given its
+/// [`CargoPackageKind`]. `None` means the task is a no-op for this package
+/// (like a missing package.json script).
+pub fn task_subcommand(kind: CargoPackageKind, task: &str) -> Option<&'static str> {
+    match kind {
+        CargoPackageKind::Entrypoint => entrypoint_subcommand(task),
+        CargoPackageKind::Workspace => workspace_subcommand(task),
+        CargoPackageKind::Library => None,
+    }
+}
+
+/// The display string for a Cargo task's command, derived from the same
+/// tables as execution so it cannot drift.
+pub fn display_command(kind: CargoPackageKind, task: &str, package: &str) -> Option<String> {
+    let subcommand = task_subcommand(kind, task)?;
+    Some(match kind {
+        CargoPackageKind::Entrypoint => format!("cargo {subcommand} --package={package}"),
+        CargoPackageKind::Workspace => format!("cargo {subcommand} --workspace"),
+        CargoPackageKind::Library => return None,
+    })
+}
+
+/// Whether pass-through args for `subcommand` must follow a `--` separator.
+/// `cargo run` forwards everything after `--` to the built binary; for other
+/// subcommands the args are cargo's own flags.
+pub fn pass_through_uses_separator(subcommand: &str) -> bool {
+    subcommand == "run"
+}
+
 /// The Cargo toolchain. Registered in the
 /// [`crate::toolchain::ToolchainRegistry`] when
 /// `futureFlags.experimentalCargoWorkspaces` is enabled and the repository
 /// root contains a `Cargo.toml`.
 pub struct CargoToolchain {
     repo_root: AbsoluteSystemPathBuf,
+    /// Per-package details recorded during discovery, consumed by command
+    /// resolution. Keyed by package name.
+    details: std::sync::Mutex<HashMap<String, CargoPackageDetails>>,
+    /// The cargo binary, resolved lazily so runs without Cargo tasks never
+    /// pay for a PATH scan.
+    cargo_binary: std::sync::OnceLock<Result<std::path::PathBuf, which::Error>>,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum CargoCommandError {
+    #[error("Unable to find cargo binary: {0}")]
+    Which(#[from] which::Error),
 }
 
 impl CargoToolchain {
     pub fn new(repo_root: AbsoluteSystemPathBuf) -> Arc<Self> {
-        Arc::new(Self { repo_root })
+        Arc::new(Self {
+            repo_root,
+            details: std::sync::Mutex::new(HashMap::new()),
+            cargo_binary: std::sync::OnceLock::new(),
+        })
+    }
+
+    fn package_details(&self, package: &str) -> Option<CargoPackageDetails> {
+        self.details
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(package)
+            .cloned()
+    }
+
+    fn record_details(&self, package: String, details: CargoPackageDetails) {
+        self.details
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(package, details);
     }
 }
 
 impl Toolchain for CargoToolchain {
     fn id(&self) -> ToolchainId {
         ToolchainId::CARGO
+    }
+
+    fn task_command(
+        &self,
+        repo_root: &AbsoluteSystemPath,
+        package: &crate::package_graph::PackageInfo,
+        task: &str,
+        pass_through_args: Option<&[String]>,
+    ) -> Result<Option<toolchain::TaskCommand>, toolchain::Error> {
+        let Some(name) = package.package_name() else {
+            return Ok(None);
+        };
+        let Some(details) = self.package_details(&name) else {
+            return Ok(None);
+        };
+        let Some(subcommand) = task_subcommand(details.kind, task) else {
+            return Ok(None);
+        };
+
+        let cargo_binary = self
+            .cargo_binary
+            .get_or_init(|| which::which("cargo"))
+            .as_deref()
+            .map_err(|err| toolchain::Error::Failed(Box::new(CargoCommandError::Which(*err))))?;
+
+        let scope = match details.kind {
+            // `--package=<name>` as a single token so a hostile crate name
+            // can never be interpreted as a separate flag.
+            CargoPackageKind::Entrypoint => format!("--package={name}"),
+            CargoPackageKind::Workspace => "--workspace".to_string(),
+            // Libraries never map to a subcommand.
+            CargoPackageKind::Library => return Ok(None),
+        };
+        let mut args: Vec<std::ffi::OsString> = vec![subcommand.into(), scope.into()];
+        if let Some(pass_through_args) = pass_through_args {
+            if pass_through_uses_separator(subcommand) {
+                args.push("--".into());
+            }
+            args.extend(pass_through_args.iter().map(std::ffi::OsString::from));
+        }
+
+        Ok(Some(toolchain::TaskCommand {
+            program: cargo_binary.as_os_str().to_owned(),
+            args,
+            // Scoping flags select the work, so we always run from the
+            // workspace root.
+            cwd: repo_root.to_owned(),
+            // Concurrent cargo processes serialize on Cargo's
+            // build-directory lock anyway (while emitting "Blocking waiting
+            // for file lock" noise), so run them one at a time and let each
+            // cargo use all cores internally. `cargo run` is exempt: the
+            // process outlives its build phase (dev servers etc.) and would
+            // starve the group.
+            serial_group: (subcommand != "run").then(|| "cargo".to_string()),
+        }))
+    }
+
+    fn task_display_command(
+        &self,
+        package: &crate::package_graph::PackageInfo,
+        task: &str,
+    ) -> Option<String> {
+        let name = package.package_name()?;
+        let details = self.package_details(&name)?;
+        display_command(details.kind, task, &name)
     }
 
     fn discover_packages(&self) -> DiscoverPackagesFuture<'_> {
@@ -101,6 +280,18 @@ impl Toolchain for CargoToolchain {
                     .iter()
                     .map(|dep| (dep.clone(), "workspace:*".to_string()))
                     .collect();
+                let kind = if cargo_crate.is_entrypoint() {
+                    CargoPackageKind::Entrypoint
+                } else {
+                    CargoPackageKind::Library
+                };
+                self.record_details(
+                    cargo_crate.name.clone(),
+                    CargoPackageDetails {
+                        kind,
+                        deliverables: cargo_crate.deliverables,
+                    },
+                );
                 crate_names.push(cargo_crate.name.clone());
                 packages.push(DiscoveredPackage {
                     descriptor: PackageJson {
@@ -116,6 +307,13 @@ impl Toolchain for CargoToolchain {
             // Cargo.toml. It depends on every crate so `--affected` and
             // dependent-filters propagate crate changes to it.
             if !crate_names.is_empty() {
+                self.record_details(
+                    WORKSPACE_PACKAGE_NAME.to_string(),
+                    CargoPackageDetails {
+                        kind: CargoPackageKind::Workspace,
+                        deliverables: Vec::new(),
+                    },
+                );
                 let dependencies = crate_names
                     .into_iter()
                     .map(|name| (name, "workspace:*".to_string()))
@@ -700,5 +898,107 @@ mod test {
         let (_tmp, root) = tempdir_root();
         let toolchain = CargoToolchain::new(root);
         assert!(toolchain.discover_packages().await.unwrap().is_empty());
+    }
+
+    fn package_info(name: &str, manifest_rel: &str) -> crate::package_graph::PackageInfo {
+        crate::package_graph::PackageInfo {
+            package_json: PackageJson {
+                name: Some(Spanned::new(name.to_string())),
+                ..Default::default()
+            },
+            package_json_path: turbopath::AnchoredSystemPathBuf::from_raw(
+                manifest_rel.replace('/', std::path::MAIN_SEPARATOR_STR),
+            )
+            .unwrap(),
+            toolchain: ToolchainId::CARGO,
+            ..Default::default()
+        }
+    }
+
+    fn os_args(args: &[&str]) -> Vec<std::ffi::OsString> {
+        args.iter().map(std::ffi::OsString::from).collect()
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_cargo_task_commands() {
+        let (_tmp, root) = tempdir_root();
+        write_fixture_workspace(&root);
+
+        let toolchain = CargoToolchain::new(root.clone());
+        // Discovery records the per-package details command resolution uses.
+        toolchain.discover_packages().await.unwrap();
+
+        let app = package_info("app", "crates/app/Cargo.toml");
+        let lib_a = package_info("lib-a", "crates/lib-a/Cargo.toml");
+        let workspace = package_info(WORKSPACE_PACKAGE_NAME, "Cargo.toml");
+
+        // Entrypoint build: scoped to the crate, serialized on the cargo
+        // group, run from the workspace root.
+        let cmd = toolchain
+            .task_command(&root, &app, "build", None)
+            .unwrap()
+            .expect("entrypoint build resolves");
+        assert_eq!(cmd.args, os_args(&["build", "--package=app"]));
+        assert_eq!(cmd.cwd, root);
+        assert_eq!(cmd.serial_group.as_deref(), Some("cargo"));
+
+        // `run` is exempt from the serial group and forwards pass-through
+        // args to the binary after `--`.
+        let cmd = toolchain
+            .task_command(&root, &app, "dev", Some(&["--port".to_string()]))
+            .unwrap()
+            .expect("entrypoint dev resolves to cargo run");
+        assert_eq!(cmd.args, os_args(&["run", "--package=app", "--", "--port"]));
+        assert_eq!(cmd.serial_group, None);
+
+        // Other subcommands attach pass-through args as cargo flags, no
+        // separator.
+        let cmd = toolchain
+            .task_command(&root, &app, "build", Some(&["--release".to_string()]))
+            .unwrap()
+            .expect("entrypoint build resolves");
+        assert_eq!(cmd.args, os_args(&["build", "--package=app", "--release"]));
+
+        // Libraries are no-ops; entrypoints do not run verification verbs.
+        assert!(
+            toolchain
+                .task_command(&root, &lib_a, "build", None)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            toolchain
+                .task_command(&root, &app, "test", None)
+                .unwrap()
+                .is_none()
+        );
+
+        // The workspace package hosts verification verbs at workspace scope.
+        let cmd = toolchain
+            .task_command(&root, &workspace, "lint", None)
+            .unwrap()
+            .expect("workspace lint resolves to clippy");
+        assert_eq!(cmd.args, os_args(&["clippy", "--workspace"]));
+        assert_eq!(cmd.serial_group.as_deref(), Some("cargo"));
+        assert!(
+            toolchain
+                .task_command(&root, &workspace, "build", None)
+                .unwrap()
+                .is_none(),
+            "workspace-wide build would duplicate entrypoint builds"
+        );
+
+        // Display strings derive from the same tables.
+        assert_eq!(
+            toolchain.task_display_command(&app, "build").as_deref(),
+            Some("cargo build --package=app")
+        );
+        assert_eq!(
+            toolchain
+                .task_display_command(&workspace, "test")
+                .as_deref(),
+            Some("cargo test --workspace")
+        );
+        assert_eq!(toolchain.task_display_command(&lib_a, "build"), None);
     }
 }

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -136,10 +136,12 @@ pub fn display_command(kind: CargoPackageKind, task: &str, package: &str) -> Opt
 }
 
 /// Whether pass-through args for `subcommand` must follow a `--` separator.
-/// `cargo run` forwards everything after `--` to the built binary; for other
-/// subcommands the args are cargo's own flags.
+/// These subcommands forward everything after `--` to the underlying tool
+/// (the built binary for `run`, the test/bench harness, clippy's lint
+/// flags); the remaining subcommands take no trailing args, so pass-through
+/// args are attached directly as cargo flags.
 pub fn pass_through_uses_separator(subcommand: &str) -> bool {
-    subcommand == "run"
+    matches!(subcommand, "test" | "bench" | "run" | "clippy")
 }
 
 /// The Cargo toolchain. Registered in the
@@ -980,6 +982,22 @@ mod test {
             .expect("workspace lint resolves to clippy");
         assert_eq!(cmd.args, os_args(&["clippy", "--workspace"]));
         assert_eq!(cmd.serial_group.as_deref(), Some("cargo"));
+
+        // Harness-forwarding subcommands separate pass-through args with
+        // `--`; e.g. `turbo test -- --nocapture` reaches the test harness.
+        let cmd = toolchain
+            .task_command(
+                &root,
+                &workspace,
+                "test",
+                Some(&["--nocapture".to_string()]),
+            )
+            .unwrap()
+            .expect("workspace test resolves");
+        assert_eq!(
+            cmd.args,
+            os_args(&["test", "--workspace", "--", "--nocapture"])
+        );
         assert!(
             toolchain
                 .task_command(&root, &workspace, "build", None)

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -477,6 +477,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             root_package_json,
             lockfile,
             javascript,
+            toolchains,
             repo_root,
             ..
         } = self;
@@ -485,6 +486,9 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             .package_manager()
             .await?
             .with_resolved_nub_lockfile(repo_root);
+        // Command resolution is synchronous; record the resolved package
+        // manager on the toolchain so it does not re-run discovery.
+        javascript.set_resolved_package_manager(package_manager.clone());
 
         debug_assert!(single, "expected single package graph");
         Ok(PackageGraph {
@@ -499,6 +503,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             repo_root: repo_root.to_owned(),
             external_dep_to_internal_dependents: std::sync::OnceLock::new(),
             root_internal_dependencies: std::sync::OnceLock::new(),
+            toolchains,
         })
     }
 }
@@ -736,6 +741,10 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             .instrument(tracing::debug_span!("package discovery"))
             .await?
             .with_resolved_nub_lockfile(self.repo_root);
+        // Command resolution is synchronous; record the resolved package
+        // manager on the toolchain so it does not re-run discovery.
+        self.javascript
+            .set_resolved_package_manager(package_manager.clone());
         let Self {
             workspaces,
             workspace_graph,
@@ -744,6 +753,7 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             node_lookup,
             root_package_json,
             lockfile,
+            toolchains,
             repo_root,
             ..
         } = self;
@@ -759,6 +769,7 @@ impl<T: PackageDiscovery + Send + Sync> BuildState<'_, ResolvedLockfile, T> {
             repo_root: repo_root.to_owned(),
             external_dep_to_internal_dependents: std::sync::OnceLock::new(),
             root_internal_dependencies: std::sync::OnceLock::new(),
+            toolchains,
         })
     }
 }

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -49,6 +49,10 @@ pub struct PackageGraph {
     /// `dependencies` and `ancestors` consult them on every call; the set is
     /// invariant once the graph is built.
     root_internal_dependencies: OnceLock<HashSet<PackageNode>>,
+    /// The toolchains that contributed packages to this graph. The single
+    /// lookup path for toolchain concerns after graph construction (command
+    /// resolution, summaries).
+    toolchains: crate::toolchain::ToolchainRegistry,
 }
 
 /// The WorkspacePackage.
@@ -339,6 +343,11 @@ impl PackageGraph {
 
     pub fn package_manager(&self) -> &PackageManager {
         &self.package_manager
+    }
+
+    /// The toolchains that contributed packages to this graph.
+    pub fn toolchains(&self) -> &crate::toolchain::ToolchainRegistry {
+        &self.toolchains
     }
 
     pub fn repo_root(&self) -> &AbsoluteSystemPath {

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -516,6 +516,43 @@ mod tests {
         assert_eq!(toolchain.task_display_command(&package, "lint"), None);
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn npm_cmd_unwraps_to_node_and_npm_cli() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let npm_cmd = tempdir.path().join("npm.cmd");
+        let node = tempdir.path().join("node.exe");
+        let npm_cli = tempdir
+            .path()
+            .join("node_modules")
+            .join("npm")
+            .join("bin")
+            .join("npm-cli.js");
+
+        std::fs::write(&npm_cmd, "").unwrap();
+        std::fs::write(&node, "").unwrap();
+        std::fs::create_dir_all(npm_cli.parent().unwrap()).unwrap();
+        std::fs::write(&npm_cli, "").unwrap();
+
+        let (program, args) = package_manager_command(&PackageManager::Npm, &npm_cmd);
+
+        assert_eq!(program, node.into_os_string());
+        assert_eq!(args, vec![npm_cli.into_os_string()]);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn npm_cmd_falls_back_when_npm_cli_missing() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let npm_cmd = tempdir.path().join("npm.cmd");
+        std::fs::write(&npm_cmd, "").unwrap();
+
+        let (program, args) = package_manager_command(&PackageManager::Npm, &npm_cmd);
+
+        assert_eq!(program, npm_cmd.into_os_string());
+        assert!(args.is_empty());
+    }
+
     #[test]
     fn test_registry_lookup() {
         struct Fake(ToolchainId);

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -41,9 +41,9 @@
 //!   Lockfile handling gains a trait surface with external dependency hashing;
 //!   dependency splitting remains JS-native for now.
 
-use std::{borrow::Cow, fmt, future::Future, pin::Pin, sync::Arc};
+use std::{borrow::Cow, ffi::OsString, fmt, future::Future, pin::Pin, sync::Arc};
 
-use turbopath::AbsoluteSystemPathBuf;
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 
 use crate::{
     discovery::{self, PackageDiscovery},
@@ -124,6 +124,25 @@ pub enum Error {
 pub type DiscoverPackagesFuture<'a> =
     Pin<Box<dyn Future<Output = Result<Vec<DiscoveredPackage>, Error>> + Send + 'a>>;
 
+/// A command resolved by a toolchain for a task, as plain data. The executor
+/// turns it into a process, applying the task's environment, stdin policy,
+/// and any decorations that are not toolchain concerns (e.g.
+/// microfrontends proxy variables).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskCommand {
+    /// The program to execute. `OsString` rather than `String` only to
+    /// tolerate non-UTF-8 binary paths; the value is still plain data.
+    pub program: OsString,
+    pub args: Vec<OsString>,
+    /// Absolute directory to run in.
+    pub cwd: AbsoluteSystemPathBuf,
+    /// Mutually-exclusive execution group: the executor runs at most one
+    /// command per group at a time, process-wide. For tools that hold
+    /// global locks (e.g. Cargo's build directory), where concurrent
+    /// processes cannot make progress anyway.
+    pub serial_group: Option<String>,
+}
+
 /// A language ecosystem that contributes packages to the repository.
 ///
 /// See the module docs for the design rules trait methods must follow.
@@ -133,6 +152,36 @@ pub trait Toolchain: Send + Sync {
 
     /// Discover this toolchain's packages.
     fn discover_packages(&self) -> DiscoverPackagesFuture<'_>;
+
+    /// Resolve the command that implements `task` for `package`, or `None`
+    /// when the toolchain defines no command for it — the task is then a
+    /// no-op, like a missing package.json script.
+    ///
+    /// `pass_through_args` are user-supplied arguments (`turbo run task --
+    /// <args>`); the toolchain owns how they are attached, since separator
+    /// conventions differ per tool.
+    fn task_command(
+        &self,
+        repo_root: &AbsoluteSystemPath,
+        package: &crate::package_graph::PackageInfo,
+        task: &str,
+        pass_through_args: Option<&[String]>,
+    ) -> Result<Option<TaskCommand>, Error> {
+        let _ = (repo_root, package, task, pass_through_args);
+        Ok(None)
+    }
+
+    /// A one-line description of what `task` runs for `package`, for
+    /// dry-run output and run summaries. Derived from the same tables as
+    /// [`Toolchain::task_command`] so display cannot drift from execution.
+    fn task_display_command(
+        &self,
+        package: &crate::package_graph::PackageInfo,
+        task: &str,
+    ) -> Option<String> {
+        let _ = (package, task);
+        None
+    }
 }
 
 /// The set of toolchains contributing packages to the repository.
@@ -190,11 +239,29 @@ impl fmt::Debug for ToolchainRegistry {
 /// and parses each manifest into the package descriptor.
 pub struct JavaScriptToolchain<P> {
     discovery: P,
+    /// The package manager as resolved during graph construction, recorded
+    /// by the builder so synchronous concerns (command resolution) can use
+    /// it without re-running discovery.
+    resolved_package_manager: std::sync::OnceLock<PackageManager>,
+    /// The package manager binary, resolved lazily on first command.
+    package_manager_binary: std::sync::OnceLock<Result<std::path::PathBuf, which::Error>>,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum JavaScriptCommandError {
+    // Message kept identical to the pre-toolchain provider error for
+    // output compatibility.
+    #[error("Unable to find package manager binary: {0}")]
+    Which(#[from] which::Error),
 }
 
 impl<P: PackageDiscovery + Send + Sync> JavaScriptToolchain<P> {
     pub fn new(discovery: P) -> Self {
-        Self { discovery }
+        Self {
+            discovery,
+            resolved_package_manager: std::sync::OnceLock::new(),
+            package_manager_binary: std::sync::OnceLock::new(),
+        }
     }
 
     /// The repository's JavaScript package manager.
@@ -205,11 +272,120 @@ impl<P: PackageDiscovery + Send + Sync> JavaScriptToolchain<P> {
     pub async fn package_manager(&self) -> Result<PackageManager, discovery::Error> {
         Ok(self.discovery.discover_packages().await?.package_manager)
     }
+
+    /// Record the package manager resolved during graph construction. Called
+    /// by the package graph builder; later calls are no-ops.
+    pub fn set_resolved_package_manager(&self, package_manager: PackageManager) {
+        let _ = self.resolved_package_manager.set(package_manager);
+    }
+}
+
+#[cfg(windows)]
+// Avoid npm.cmd so Windows Ctrl+C reaches npm/node without cmd.exe emitting
+// "Terminate batch job (Y/N)?" during graceful shutdown.
+fn npm_direct_command(
+    package_manager_binary: &std::path::Path,
+) -> Option<(std::path::PathBuf, OsString)> {
+    if package_manager_binary.file_name()?.to_str()? != "npm.cmd" {
+        return None;
+    }
+
+    let node_dir = package_manager_binary.parent()?;
+    let node = node_dir.join("node.exe");
+    let npm_cli = node_dir
+        .join("node_modules")
+        .join("npm")
+        .join("bin")
+        .join("npm-cli.js");
+
+    (node.is_file() && npm_cli.is_file()).then(|| (node, npm_cli.into_os_string()))
+}
+
+#[cfg(windows)]
+fn package_manager_command(
+    package_manager: &PackageManager,
+    package_manager_binary: &std::path::Path,
+) -> (OsString, Vec<OsString>) {
+    if package_manager == &PackageManager::Npm
+        && let Some((node, npm_cli)) = npm_direct_command(package_manager_binary)
+    {
+        return (node.into_os_string(), vec![npm_cli]);
+    }
+
+    (package_manager_binary.as_os_str().to_owned(), Vec::new())
+}
+
+#[cfg(not(windows))]
+fn package_manager_command(
+    _package_manager: &PackageManager,
+    package_manager_binary: &std::path::Path,
+) -> (OsString, Vec<OsString>) {
+    (package_manager_binary.as_os_str().to_owned(), Vec::new())
 }
 
 impl<P: PackageDiscovery + Send + Sync> Toolchain for JavaScriptToolchain<P> {
     fn id(&self) -> ToolchainId {
         ToolchainId::JAVASCRIPT
+    }
+
+    fn task_command(
+        &self,
+        repo_root: &AbsoluteSystemPath,
+        package: &crate::package_graph::PackageInfo,
+        task: &str,
+        pass_through_args: Option<&[String]>,
+    ) -> Result<Option<TaskCommand>, Error> {
+        // No script (or an empty one) means the task is a no-op.
+        if package
+            .package_json
+            .scripts
+            .get(task)
+            .is_none_or(|script| script.is_empty())
+        {
+            return Ok(None);
+        }
+        let Some(package_manager) = self.resolved_package_manager.get() else {
+            // The graph was not built through this toolchain instance;
+            // without a package manager there is no way to run a script.
+            return Ok(None);
+        };
+
+        let package_manager_binary = self
+            .package_manager_binary
+            .get_or_init(|| which::which(package_manager.command()))
+            .as_deref()
+            .map_err(|err| Error::Failed(Box::new(JavaScriptCommandError::Which(*err))))?;
+        let (program, mut args) = package_manager_command(package_manager, package_manager_binary);
+        args.extend([OsString::from("run"), OsString::from(task)]);
+        if let Some(pass_through_args) = pass_through_args {
+            args.extend(
+                package_manager
+                    .arg_separator(pass_through_args)
+                    .map(OsString::from),
+            );
+            args.extend(pass_through_args.iter().map(OsString::from));
+        }
+
+        Ok(Some(TaskCommand {
+            program,
+            args,
+            cwd: repo_root.resolve(package.package_path()),
+            serial_group: None,
+        }))
+    }
+
+    fn task_display_command(
+        &self,
+        package: &crate::package_graph::PackageInfo,
+        task: &str,
+    ) -> Option<String> {
+        // Summaries show the script text itself, matching historical
+        // behavior.
+        package
+            .package_json
+            .scripts
+            .get(task)
+            .map(|script| script.as_inner().clone())
     }
 
     fn discover_packages(&self) -> DiscoverPackagesFuture<'_> {
@@ -250,6 +426,87 @@ mod tests {
         assert_eq!(custom.to_string(), "cargo");
         let dynamic = ToolchainId::new(String::from("python-uv"));
         assert_eq!(dynamic.as_str(), "python-uv");
+    }
+
+    #[test]
+    fn test_javascript_task_command() {
+        struct StubDiscovery;
+        impl PackageDiscovery for StubDiscovery {
+            async fn discover_packages(
+                &self,
+            ) -> Result<discovery::DiscoveryResponse, discovery::Error> {
+                Ok(discovery::DiscoveryResponse {
+                    package_manager: PackageManager::Npm,
+                    workspaces: vec![],
+                })
+            }
+            async fn discover_packages_blocking(
+                &self,
+            ) -> Result<discovery::DiscoveryResponse, discovery::Error> {
+                self.discover_packages().await
+            }
+        }
+
+        let repo_root_buf =
+            AbsoluteSystemPathBuf::new(if cfg!(windows) { r"C:\repo" } else { "/repo" }).unwrap();
+        let repo_root = repo_root_buf.as_ref() as &AbsoluteSystemPath;
+
+        let toolchain = JavaScriptToolchain::new(StubDiscovery);
+        toolchain.set_resolved_package_manager(PackageManager::Npm);
+
+        let package = crate::package_graph::PackageInfo {
+            package_json: PackageJson::from_value(serde_json::json!({
+                "name": "web",
+                "scripts": { "build": "next build", "empty": "" }
+            }))
+            .unwrap(),
+            package_json_path: turbopath::AnchoredSystemPathBuf::from_raw(
+                ["apps", "web", "package.json"].join(std::path::MAIN_SEPARATOR_STR),
+            )
+            .unwrap(),
+            ..Default::default()
+        };
+
+        let command = toolchain
+            .task_command(repo_root, &package, "build", None)
+            .unwrap()
+            .expect("script exists, command resolves");
+        // The program is the resolved npm binary (or node.exe on Windows);
+        // the invocation shape is what matters.
+        assert!(
+            command
+                .args
+                .ends_with(&[OsString::from("run"), OsString::from("build")]),
+            "expected `run build` invocation, got {:?}",
+            command.args
+        );
+        assert_eq!(
+            command.cwd,
+            repo_root.join_components(&["apps", "web"]),
+            "command runs in the package directory"
+        );
+        assert_eq!(command.serial_group, None);
+
+        // Missing and empty scripts are no-ops.
+        assert!(
+            toolchain
+                .task_command(repo_root, &package, "lint", None)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            toolchain
+                .task_command(repo_root, &package, "empty", None)
+                .unwrap()
+                .is_none()
+        );
+
+        // Display shows the script text itself.
+        assert_eq!(
+            toolchain.task_display_command(&package, "build").as_deref(),
+            Some("next build")
+        );
+        assert_eq!(toolchain.task_display_command(&package, "lint"), None);
     }
 
     #[test]

--- a/crates/turborepo-run-summary/src/task_factory.rs
+++ b/crates/turborepo-run-summary/src/task_factory.rs
@@ -119,12 +119,14 @@ where
         display_task: impl Fn(&TaskId<'static>) -> Option<T> + Copy,
     ) -> Result<SharedTaskSummary<T>, Error> {
         // TODO: command should be optional
-        let command = workspace_info
-            .package_json
-            .scripts
-            .get(task_id.task())
-            .map(|script| script.as_inner())
-            .cloned()
+        // The package's toolchain owns the display string (JavaScript: the
+        // script text; Cargo: the cargo invocation), derived from the same
+        // tables as execution so display cannot drift from what runs.
+        let command = self
+            .package_graph
+            .toolchains()
+            .get(&workspace_info.toolchain)
+            .and_then(|toolchain| toolchain.task_display_command(workspace_info, task_id.task()))
             .unwrap_or_else(|| "<NONEXISTENT>".to_string());
 
         let task_definition = self.task_definition(task_id)?;

--- a/crates/turborepo-task-executor/src/command.rs
+++ b/crates/turborepo-task-executor/src/command.rs
@@ -715,43 +715,6 @@ mod tests {
         assert!(cmd.is_none(), "expected no cmd, got {cmd:?}");
     }
 
-    #[cfg(windows)]
-    #[test]
-    fn npm_cmd_unwraps_to_node_and_npm_cli() {
-        let tempdir = tempfile::tempdir().unwrap();
-        let npm_cmd = tempdir.path().join("npm.cmd");
-        let node = tempdir.path().join("node.exe");
-        let npm_cli = tempdir
-            .path()
-            .join("node_modules")
-            .join("npm")
-            .join("bin")
-            .join("npm-cli.js");
-
-        fs::write(&npm_cmd, "").unwrap();
-        fs::write(&node, "").unwrap();
-        fs::create_dir_all(npm_cli.parent().unwrap()).unwrap();
-        fs::write(&npm_cli, "").unwrap();
-
-        let (program, args) = package_manager_command(&PackageManager::Npm, &npm_cmd);
-
-        assert_eq!(program, node.into_os_string());
-        assert_eq!(args, vec![npm_cli.into_os_string()]);
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn npm_cmd_falls_back_when_npm_cli_missing() {
-        let tempdir = tempfile::tempdir().unwrap();
-        let npm_cmd = tempdir.path().join("npm.cmd");
-        fs::write(&npm_cmd, "").unwrap();
-
-        let (program, args) = package_manager_command(&PackageManager::Npm, &npm_cmd);
-
-        assert_eq!(program, npm_cmd.into_os_string());
-        assert!(args.is_empty());
-    }
-
     #[tokio::test]
     async fn test_custom_microfrontend_proxy_command_applies_filtered_environment() {
         let (_tempdir, repo_root, package_dir) = create_test_repo();

--- a/crates/turborepo-task-executor/src/command.rs
+++ b/crates/turborepo-task-executor/src/command.rs
@@ -3,11 +3,7 @@
 //! This module provides the trait and factory for creating commands to execute
 //! tasks.
 
-use std::{
-    collections::HashSet,
-    ffi::OsString,
-    path::{Path, PathBuf},
-};
+use std::collections::HashSet;
 
 use tracing::debug;
 use turbopath::{AbsoluteSystemPath, PathError, RelativeUnixPath};
@@ -27,47 +23,6 @@ fn apply_environment(cmd: &mut Command, environment: &EnvironmentVariableMap) {
     cmd.envs(environment.iter());
 }
 
-#[cfg(windows)]
-// Avoid npm.cmd so Windows Ctrl+C reaches npm/node without cmd.exe emitting
-// "Terminate batch job (Y/N)?" during graceful shutdown.
-fn npm_direct_command(package_manager_binary: &Path) -> Option<(PathBuf, OsString)> {
-    if package_manager_binary.file_name()?.to_str()? != "npm.cmd" {
-        return None;
-    }
-
-    let node_dir = package_manager_binary.parent()?;
-    let node = node_dir.join("node.exe");
-    let npm_cli = node_dir
-        .join("node_modules")
-        .join("npm")
-        .join("bin")
-        .join("npm-cli.js");
-
-    (node.is_file() && npm_cli.is_file()).then(|| (node, npm_cli.into_os_string()))
-}
-
-#[cfg(windows)]
-fn package_manager_command(
-    package_manager: &PackageManager,
-    package_manager_binary: &Path,
-) -> (OsString, Vec<OsString>) {
-    if package_manager == &PackageManager::Npm
-        && let Some((node, npm_cli)) = npm_direct_command(package_manager_binary)
-    {
-        return (node.into_os_string(), vec![npm_cli]);
-    }
-
-    (package_manager_binary.as_os_str().to_owned(), Vec::new())
-}
-
-#[cfg(not(windows))]
-fn package_manager_command(
-    _package_manager: &PackageManager,
-    package_manager_binary: &Path,
-) -> (OsString, Vec<OsString>) {
-    (package_manager_binary.as_os_str().to_owned(), Vec::new())
-}
-
 /// Trait for providing commands to execute tasks.
 ///
 /// Implementors of this trait are responsible for determining how to execute
@@ -80,8 +35,8 @@ fn package_manager_command(
 /// - `E`: The error type returned when command creation fails
 ///
 /// # Implementors
-/// - `PackageGraphCommandProvider` in turborepo-lib (executes package.json
-///   scripts)
+/// - `ToolchainCommandProvider` (resolves commands through the package's
+///   toolchain: package.json scripts for JavaScript, cargo verbs for Cargo)
 /// - `MicroFrontendProxyProvider` in turborepo-lib (starts MFE proxy)
 pub trait CommandProvider<E> {
     /// Create a command for the given task.
@@ -169,6 +124,13 @@ pub enum CommandProviderError {
     },
     #[error("Unable to find package manager binary: {0}")]
     Which(#[from] which::Error),
+    #[error("No toolchain '{toolchain}' registered for package {package_name}.")]
+    MissingToolchain {
+        toolchain: turborepo_repository::toolchain::ToolchainId,
+        package_name: PackageName,
+    },
+    #[error(transparent)]
+    Toolchain(#[from] turborepo_repository::toolchain::Error),
 }
 
 /// A trait for fetching package information required to execute commands
@@ -188,31 +150,32 @@ impl PackageInfoProvider for PackageGraph {
     }
 }
 
-/// Command provider that creates commands from package.json scripts.
+/// Command provider that resolves commands through the package's toolchain.
 ///
-/// This provider looks up the task's script in the package's package.json
-/// and creates a command to execute it via the package manager.
+/// The toolchain owns command construction (JavaScript: run the package.json
+/// script via the package manager; Cargo: `cargo <verb>` scoped to the
+/// crate or workspace). This provider adapts the resolved [`TaskCommand`]
+/// data into a process command and applies concerns that are not
+/// toolchain-specific: the task environment, stdin policy, and
+/// microfrontends proxy decorations.
 #[derive(Debug)]
-pub struct PackageGraphCommandProvider<'a, M = crate::NoMfeConfig> {
+pub struct ToolchainCommandProvider<'a, M = crate::NoMfeConfig> {
     repo_root: &'a AbsoluteSystemPath,
     package_graph: &'a PackageGraph,
-    package_manager_binary: Result<PathBuf, which::Error>,
     task_args: TaskArgs<'a>,
     mfe_configs: Option<&'a M>,
 }
 
-impl<'a, M: MfeConfigProvider> PackageGraphCommandProvider<'a, M> {
+impl<'a, M: MfeConfigProvider> ToolchainCommandProvider<'a, M> {
     pub fn new(
         repo_root: &'a AbsoluteSystemPath,
         package_graph: &'a PackageGraph,
         task_args: TaskArgs<'a>,
         mfe_configs: Option<&'a M>,
     ) -> Self {
-        let package_manager_binary = which::which(package_graph.package_manager().command());
         Self {
             repo_root,
             package_graph,
-            package_manager_binary,
             task_args,
             mfe_configs,
         }
@@ -229,7 +192,7 @@ impl<'a, M: MfeConfigProvider> PackageGraphCommandProvider<'a, M> {
 }
 
 impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
-    for PackageGraphCommandProvider<'a, M>
+    for ToolchainCommandProvider<'a, M>
 {
     fn command(
         &self,
@@ -237,37 +200,33 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
         environment: &EnvironmentVariableMap,
     ) -> Result<Option<Command>, E> {
         let workspace_info = self.package_info(task_id)?;
+        let toolchain = self
+            .package_graph
+            .toolchains()
+            .get(&workspace_info.toolchain)
+            .ok_or_else(|| CommandProviderError::MissingToolchain {
+                toolchain: workspace_info.toolchain.clone(),
+                package_name: task_id.package().into(),
+            })?;
 
-        // bail if the script doesn't exist or is empty
-        if workspace_info
-            .package_json
-            .scripts
-            .get(task_id.task())
-            .is_none_or(|script| script.is_empty())
-        {
+        let spec = toolchain
+            .task_command(
+                self.repo_root,
+                workspace_info,
+                task_id.task(),
+                self.task_args.args_for_task(task_id),
+            )
+            .map_err(CommandProviderError::from)?;
+        let Some(spec) = spec else {
             return Ok(None);
-        }
-        let package_manager_binary = self
-            .package_manager_binary
-            .as_deref()
-            .map_err(|e| CommandProviderError::from(*e))?;
-        let (program, mut args) =
-            package_manager_command(self.package_graph.package_manager(), package_manager_binary);
-        args.extend([OsString::from("run"), OsString::from(task_id.task())]);
-        if let Some(pass_through_args) = self.task_args.args_for_task(task_id) {
-            args.extend(
-                self.package_graph
-                    .package_manager()
-                    .arg_separator(pass_through_args)
-                    .map(OsString::from),
-            );
-            args.extend(pass_through_args.iter().map(OsString::from));
-        }
-        let mut cmd = Command::new(program);
-        cmd.args(args);
+        };
 
-        let package_dir = self.repo_root.resolve(workspace_info.package_path());
-        cmd.current_dir(package_dir);
+        let mut cmd = Command::new(spec.program);
+        cmd.args(spec.args);
+        cmd.current_dir(spec.cwd);
+        if let Some(group) = spec.serial_group {
+            cmd.serial_group(group);
+        }
 
         apply_environment(&mut cmd, environment);
 

--- a/crates/turborepo-task-executor/src/exec.rs
+++ b/crates/turborepo-task-executor/src/exec.rs
@@ -8,7 +8,9 @@
 //! - Result types (`ExecOutcome`, `SuccessOutcome`, `InternalError`)
 
 use std::{
+    collections::HashMap,
     io::Write,
+    sync::{Arc, Mutex, OnceLock},
     time::{Duration, Instant},
 };
 
@@ -27,6 +29,18 @@ use turborepo_types::{ContinueMode, StopExecution, UIMode};
 use turborepo_ui::ColorConfig;
 
 use crate::{TaskAccessProvider, TaskOutput};
+
+/// Per-group mutexes for commands marked with a serial group (see
+/// [`Command::serial_group`]). At most one command per group runs at a time,
+/// process-wide.
+fn serial_group_lock(group: &str) -> Arc<tokio::sync::Mutex<()>> {
+    static GROUPS: OnceLock<Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>> = OnceLock::new();
+    let mut groups = GROUPS
+        .get_or_init(Default::default)
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    groups.entry(group.to_string()).or_default().clone()
+}
 
 /// Windows NT status codes that indicate out-of-memory conditions.
 /// These are the signed i32 representations of the unsigned NT status codes.
@@ -406,6 +420,15 @@ where
                 ));
             }
         }
+
+        // Commands in a serial group run one at a time: their tools hold
+        // global locks (e.g. Cargo's build directory), so concurrent
+        // processes cannot make progress and just emit "waiting for file
+        // lock" noise. The guard is held until the process exits.
+        let _serial_group_guard = match self.cmd.serial_group_name() {
+            Some(group) => Some(serial_group_lock(group).lock_owned().await),
+            None => None,
+        };
 
         // Spawn the process
         let cmd = self.cmd.clone();

--- a/crates/turborepo-task-executor/src/lib.rs
+++ b/crates/turborepo-task-executor/src/lib.rs
@@ -26,7 +26,7 @@ mod visitor;
 
 pub use command::{
     CommandFactory, CommandProvider, CommandProviderError, MicroFrontendProxyProvider,
-    PackageGraphCommandProvider, PackageInfoProvider,
+    PackageInfoProvider, ToolchainCommandProvider,
 };
 pub use exec::{
     DryRunExecutor, ExecOutcome, HashTrackerProvider, InternalError, SuccessOutcome,


### PR DESCRIPTION
## Why

Third functional PR of the Cargo workspace series (#13227 flag, #13235 abstraction, #13248 discovery). Crates are in the package graph but their tasks are no-ops — this PR makes them execute. Per the series design, command resolution becomes a `Toolchain` trait surface shipping with **both real implementations**: the JavaScript package.json script lookup moves behind the trait (production path, not a facade), and Cargo maps task names to cargo verbs.

## What

- `Toolchain::task_command` (plain command data: program/args/cwd/serial group) and `Toolchain::task_display_command` — display derives from the same tables as execution so dry-run/summaries cannot drift from what runs
- `ToolchainCommandProvider` replaces `PackageGraphCommandProvider`: one adapter for every toolchain, applying non-toolchain concerns (task env, stdin, MFE proxy decorations). MFE proxy stays its own provider
- Cargo mapping: entrypoints get `build`/`run|dev` as `cargo <verb> --package=<crate>` (single token — hostile crate names cannot inject flags); the synthetic `cargo` package hosts `test`/`check`/`lint`/`doc`/`bench` at `--workspace` scope; libraries stay no-ops (Cargo builds them implicitly). Workspace-wide `build` is deliberately absent — it would duplicate entrypoint builds
- Serial groups: a new `turborepo-process::Command` capability, honored by the executor — at most one command per group at a time. All cargo verbs except `run` share the `cargo` group (they serialize on Cargo's build-dir lock anyway; this removes the "Blocking waiting for file lock" noise while each cargo uses all cores). `cargo run` is exempt: dev servers outlive their build phase and would starve the group
- `PackageGraph` carries the `ToolchainRegistry` so post-build consumers use the single lookup path; the builder records the resolved package manager on the JS toolchain (command resolution is synchronous)
- Dry-run/summaries show `cargo build --package=<crate>` instead of `<NONEXISTENT>`; JS summaries still show script text (unchanged)

## How

Flag off: JS commands are byte-identical to before — same script gate, same pm binary resolution (incl. the Windows npm.cmd workaround, which moved with the JS code), same arg separators, same MFE decorations; the full existing suite passes. Flag on, verified live on a mixed npm+Cargo fixture: `turbo build` compiles the crate closure via one cargo invocation while the JS package runs its script; `turbo test --filter=cargo` runs `cargo test --workspace`; `--dry` prints the real cargo commands. Unit coverage: JS command shape/no-op/display semantics, Cargo verb mapping incl. pass-through separator rules and serial-group exemption for `run`.