### PR TITLE
perf: Probe microfrontends configs in parallel

### DIFF
--- a/crates/turborepo-lib/src/microfrontends.rs
+++ b/crates/turborepo-lib/src/microfrontends.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use tracing::warn;
 use turbopath::{AbsoluteSystemPath, RelativeUnixPath, RelativeUnixPathBuf};
 use turborepo_microfrontends::{Error, TurborepoMfeConfig as MfeConfig, MICROFRONTENDS_PACKAGE};
-use turborepo_repository::package_graph::{PackageGraph, PackageName};
+use turborepo_repository::package_graph::{PackageGraph, PackageInfo, PackageName};
 use turborepo_task_executor::MfeConfigProvider;
 use turborepo_task_id::{TaskId, TaskName};
 
@@ -53,13 +53,38 @@ impl MicrofrontendsConfigs {
             any_has_mfe_dep
         );
 
-        let metadata = package_graph.packages().fold(
+        type LoadedConfig<'a> = (
+            &'a PackageName,
+            &'a PackageInfo,
+            Result<Option<MfeConfig>, Error>,
+        );
+        // Probing every package directory for a config is two file reads per
+        // package; do them in parallel. Package order is preserved (rayon's
+        // indexed collect), so downstream config processing is unaffected.
+        let loaded: Vec<LoadedConfig> = crate::rayon_compat::block_in_place(|| {
+            use rayon::prelude::*;
+            package_graph
+                .packages()
+                .collect::<Vec<_>>()
+                .into_par_iter()
+                .map(|(name, info)| {
+                    let config_result = MfeConfig::load_from_dir_with_mfe_dep(
+                        repo_root,
+                        info.package_path(),
+                        any_has_mfe_dep,
+                    );
+                    (name, info, config_result)
+                })
+                .collect()
+        });
+
+        let metadata = loaded.into_iter().fold(
             PackageMetadata {
                 names: HashSet::new(),
                 has_mfe_dep: HashMap::new(),
                 configs: Vec::new(),
             },
-            |mut acc, (name, info)| {
+            |mut acc, (name, info, config_result)| {
                 let name_str = name.as_str();
                 acc.names.insert(name_str);
                 let has_dep = info
@@ -73,11 +98,6 @@ impl MicrofrontendsConfigs {
                 );
                 acc.has_mfe_dep.insert(name_str, has_dep);
 
-                let config_result = MfeConfig::load_from_dir_with_mfe_dep(
-                    repo_root,
-                    info.package_path(),
-                    any_has_mfe_dep,
-                );
                 if let Ok(Some(ref _config)) = config_result {
                     tracing::debug!(
                         "from_disk - found config in package: {}, path: {:?}",


### PR DESCRIPTION
## Why

`MicrofrontendsConfigs::from_disk` sits on the run startup path and probed every package directory for a config sequentially — two file-read attempts per package, ~2,400 serial syscalls on a 1191-package monorepo, ~14ms per run.

## What

The per-package config probes now run on the rayon pool. Package order is preserved (rayon's indexed collect feeds the same ordered iterator into `from_configs`), so downstream config processing — including any ordering-sensitive conflict handling — is byte-for-byte unchanged.

## How to verify

- `cargo test -p turborepo-lib` microfrontends suite (22 tests) passes unchanged.
- Measured on the monorepo above (8-core Linux, interleaved A/B, 8 runs): `from_disk` 13.9ms → 4.6ms. `--dry=json` output byte-identical.
