### PR TITLE
feat: Expose resolved experimentalCI task configuration in `turbo query`

### DIFF
--- a/crates/turborepo-engine/src/task_definition.rs
+++ b/crates/turborepo-engine/src/task_definition.rs
@@ -124,6 +124,7 @@ impl TaskDefinitionFromProcessed for TaskDefinition {
             env_mode: processed.env_mode.map(|mode| *mode.as_inner()),
             with,
             incremental,
+            experimental_ci: processed.experimental_ci.map(Spanned::into_inner),
         })
     }
 

--- a/crates/turborepo-lib/src/turbo_json/mod.rs
+++ b/crates/turborepo-lib/src/turbo_json/mod.rs
@@ -159,6 +159,7 @@ mod tests {
           env_mode: None,
           with: None,
           incremental: None,
+          experimental_ci: None,
         }
       ; "full"
     )]
@@ -210,6 +211,7 @@ mod tests {
             env_mode: None,
             with: None,
             incremental: None,
+            experimental_ci: None,
         }
       ; "full (windows)"
     )]

--- a/crates/turborepo-query/src/task.rs
+++ b/crates/turborepo-query/src/task.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use async_graphql::Object;
+use async_graphql::{Json, Object};
 use turborepo_engine::TaskNode;
 use turborepo_errors::Spanned;
 use turborepo_task_id::TaskId;
@@ -64,6 +64,21 @@ impl RepositoryTask {
 
     async fn script(&self) -> Option<String> {
         self.script.as_ref().map(|script| script.value.to_string())
+    }
+
+    /// The fully resolved `experimentalCI` configuration for this task from
+    /// turbo.json, including Package Configuration overrides. Either a
+    /// boolean or an object with arbitrary keys. Null if the key is not set.
+    #[graphql(name = "experimentalCI")]
+    async fn experimental_ci(&self) -> Result<Option<Json<serde_json::Value>>, Error> {
+        let task_id = TaskId::from_static(self.package.get_name().to_string(), self.name.clone());
+        self.package
+            .run()
+            .engine()
+            .task_definition(&task_id)
+            .and_then(|definition| definition.experimental_ci.as_ref())
+            .map(|config| serde_json::to_value(config).map(Json).map_err(Error::from))
+            .transpose()
     }
 
     async fn direct_dependents(&self) -> Result<Array<RepositoryTask>, Error> {

--- a/crates/turborepo-run-summary/src/task.rs
+++ b/crates/turborepo-run-summary/src/task.rs
@@ -410,6 +410,8 @@ impl From<TaskDefinition> for TaskSummaryTaskDefinition {
             env_mode,
             with: _,
             incremental,
+            // Not surfaced in the run summary; queryable via `turbo query`.
+            experimental_ci: _,
         } = value;
 
         let mut outputs = inclusions;

--- a/crates/turborepo-turbo-json/src/extend.rs
+++ b/crates/turborepo-turbo-json/src/extend.rs
@@ -163,6 +163,7 @@ impl ProcessedTaskDefinition {
         set_field!(self, other, interactive);
         set_field!(self, other, env_mode);
         set_field!(self, other, incremental);
+        set_field!(self, other, experimental_ci);
     }
 }
 
@@ -214,6 +215,7 @@ mod test {
             env_mode: None,
             with: None,
             incremental: None,
+            experimental_ci: None,
         }
     }
 
@@ -252,6 +254,7 @@ mod test {
             env_mode: None,
             with: None,
             incremental: None,
+            experimental_ci: None,
         }
     }
 
@@ -272,6 +275,7 @@ mod test {
             env_mode: None,
             with: None,
             incremental: None,
+            experimental_ci: None,
         }
     }
 
@@ -540,6 +544,39 @@ mod test {
             globs: vec![],
             extends: true,
         }
+    }
+
+    #[test]
+    fn test_merge_experimental_ci_package_overrides_root() {
+        use turborepo_types::ExperimentalCIConfig;
+
+        let root = ProcessedTaskDefinition {
+            experimental_ci: Some(Spanned::new(ExperimentalCIConfig::Enabled(true))),
+            ..Default::default()
+        };
+
+        // A package configuration without the key inherits the root value.
+        let package_without_key = ProcessedTaskDefinition {
+            cache: Some(Spanned::new(false)),
+            ..Default::default()
+        };
+        let result =
+            ProcessedTaskDefinition::from_iter(vec![root.clone(), package_without_key.clone()]);
+        assert_eq!(result.experimental_ci, root.experimental_ci);
+
+        // A package configuration with the key replaces the root value.
+        let mut options = serde_json::Map::new();
+        options.insert("provider".to_string(), serde_json::Value::from("github"));
+        options.insert("attempts".to_string(), serde_json::Value::from(3));
+        let package_with_key = ProcessedTaskDefinition {
+            experimental_ci: Some(Spanned::new(ExperimentalCIConfig::Options(options.clone()))),
+            ..Default::default()
+        };
+        let result = ProcessedTaskDefinition::from_iter(vec![root, package_with_key]);
+        assert_eq!(
+            result.experimental_ci,
+            Some(Spanned::new(ExperimentalCIConfig::Options(options)))
+        );
     }
 
     #[test]

--- a/crates/turborepo-turbo-json/src/parser.rs
+++ b/crates/turborepo-turbo-json/src/parser.rs
@@ -22,8 +22,8 @@ use turborepo_task_id::TaskName;
 use turborepo_unescape::UnescapedString;
 
 use crate::raw::{
-    Pipeline, RawExperimentalCIConfig, RawExperimentalObservability, RawGlobalConfig,
-    RawObservabilityOtel, RawObservabilityOtelMetrics, RawObservabilityOtelRunAttributes,
+    Pipeline, RawExperimentalObservability, RawGlobalConfig, RawObservabilityOtel,
+    RawObservabilityOtelMetrics, RawObservabilityOtelRunAttributes,
     RawObservabilityOtelTaskAttributes, RawPackageTurboJson, RawRemoteCacheOptions,
     RawRootTurboJson, RawStructuredInput, RawTaskDefinition, RawTaskInput, RawTurboJson,
 };
@@ -209,53 +209,6 @@ impl WithMetadata for Pipeline {
             entry.add_path(path.clone());
             entry.value.add_path(path.clone());
         }
-    }
-}
-
-impl Deserializable for RawExperimentalCIConfig {
-    fn deserialize(
-        value: &impl DeserializableValue,
-        name: &str,
-        diagnostics: &mut Vec<DeserializationDiagnostic>,
-    ) -> Option<Self> {
-        value.deserialize(RawExperimentalCIConfigVisitor, name, diagnostics)
-    }
-}
-
-struct RawExperimentalCIConfigVisitor;
-
-impl DeserializationVisitor for RawExperimentalCIConfigVisitor {
-    type Output = RawExperimentalCIConfig;
-
-    const EXPECTED_TYPE: VisitableType = VisitableType::BOOL.union(VisitableType::MAP);
-
-    fn visit_bool(
-        self,
-        value: bool,
-        _range: TextRange,
-        _name: &str,
-        _diagnostics: &mut Vec<DeserializationDiagnostic>,
-    ) -> Option<Self::Output> {
-        Some(RawExperimentalCIConfig::Enabled(value))
-    }
-
-    fn visit_map(
-        self,
-        members: impl Iterator<Item = Option<(impl DeserializableValue, impl DeserializableValue)>>,
-        _range: TextRange,
-        _name: &str,
-        diagnostics: &mut Vec<DeserializationDiagnostic>,
-    ) -> Option<Self::Output> {
-        let entries = members
-            .filter_map(|entry| {
-                let (key, value) = entry?;
-                let key = String::deserialize(&key, "", diagnostics)?;
-                let value = serde_json::Value::deserialize(&value, "", diagnostics)?;
-                Some((key, value))
-            })
-            .collect();
-
-        Some(RawExperimentalCIConfig::Options(entries))
     }
 }
 
@@ -747,7 +700,7 @@ mod tests {
 
         assert_eq!(
             task.experimental_ci.as_ref().map(|v| v.as_inner()),
-            Some(&RawExperimentalCIConfig::Enabled(true))
+            Some(&turborepo_types::ExperimentalCIConfig::Enabled(true))
         );
     }
 
@@ -775,7 +728,7 @@ mod tests {
 
         assert_eq!(
             task.experimental_ci.as_ref().map(|v| v.as_inner()),
-            Some(&RawExperimentalCIConfig::Options(
+            Some(&turborepo_types::ExperimentalCIConfig::Options(
                 serde_json::json!({
                     "provider": "github",
                     "enabled": true,

--- a/crates/turborepo-turbo-json/src/processed.rs
+++ b/crates/turborepo-turbo-json/src/processed.rs
@@ -8,7 +8,7 @@ use camino::Utf8Path;
 use turbopath::RelativeUnixPath;
 use turborepo_errors::Spanned;
 use turborepo_task_id::TaskName;
-use turborepo_types::{EnvMode, OutputLogsMode};
+use turborepo_types::{EnvMode, ExperimentalCIConfig, OutputLogsMode};
 use turborepo_unescape::UnescapedString;
 
 use crate::{
@@ -578,6 +578,7 @@ pub struct ProcessedTaskDefinition {
     pub env_mode: Option<Spanned<EnvMode>>,
     pub with: Option<ProcessedWith>,
     pub incremental: Option<Vec<ProcessedIncrementalPartition>>,
+    pub experimental_ci: Option<Spanned<ExperimentalCIConfig>>,
 }
 
 impl ProcessedTaskDefinition {
@@ -670,6 +671,7 @@ impl ProcessedTaskDefinition {
                 .map(|with| ProcessedWith::new(with, future_flags))
                 .transpose()?,
             incremental,
+            experimental_ci: raw_task.experimental_ci,
         })
     }
 
@@ -688,6 +690,7 @@ impl ProcessedTaskDefinition {
             || self.interactive.is_some()
             || self.with.is_some()
             || self.incremental.is_some()
+            || self.experimental_ci.is_some()
     }
 }
 
@@ -780,6 +783,23 @@ mod tests {
 
         let resolved = glob.resolve(replacement);
         assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn test_from_raw_carries_experimental_ci() {
+        let raw_task = RawTaskDefinition {
+            experimental_ci: Some(Spanned::new(ExperimentalCIConfig::Enabled(true))),
+            ..Default::default()
+        };
+
+        let processed =
+            ProcessedTaskDefinition::from_raw(raw_task, &FutureFlags::default()).unwrap();
+
+        assert_eq!(
+            processed.experimental_ci,
+            Some(Spanned::new(ExperimentalCIConfig::Enabled(true)))
+        );
+        assert!(processed.has_config_beyond_extends());
     }
 
     #[test]

--- a/crates/turborepo-turbo-json/src/raw.rs
+++ b/crates/turborepo-turbo-json/src/raw.rs
@@ -15,7 +15,7 @@ use turborepo_boundaries::BoundariesConfig;
 use turborepo_errors::Spanned;
 use turborepo_repository::package_graph::ROOT_PKG_NAME;
 use turborepo_task_id::TaskName;
-use turborepo_types::{EnvMode, OutputLogsMode, UIMode};
+use turborepo_types::{EnvMode, ExperimentalCIConfig, OutputLogsMode, UIMode};
 use turborepo_unescape::UnescapedString;
 
 use crate::{error::Error, future_flags::FutureFlags};
@@ -104,13 +104,6 @@ impl IntoIterator for Pipeline {
 /// empty marker.
 pub trait HasConfigBeyondExtends {
     fn has_config_beyond_extends(&self) -> bool;
-}
-
-#[derive(Serialize, Debug, PartialEq, Clone)]
-#[serde(untagged)]
-pub enum RawExperimentalCIConfig {
-    Enabled(bool),
-    Options(serde_json::Map<String, serde_json::Value>),
 }
 
 /// Configuration options that control how turbo interfaces with the remote
@@ -866,7 +859,7 @@ pub struct RawTaskDefinition {
     #[deserializable(rename = "experimentalCI")]
     #[schemars(skip)]
     #[ts(skip)]
-    pub experimental_ci: Option<Spanned<RawExperimentalCIConfig>>,
+    pub experimental_ci: Option<Spanned<ExperimentalCIConfig>>,
 
     /// Incremental cache partitions for tool-specific incremental artifacts.
     ///
@@ -896,6 +889,7 @@ impl HasConfigBeyondExtends for RawTaskDefinition {
             || self.interactive.is_some()
             || self.with.is_some()
             || self.incremental.is_some()
+            || self.experimental_ci.is_some()
     }
 }
 

--- a/crates/turborepo-types/Cargo.toml
+++ b/crates/turborepo-types/Cargo.toml
@@ -16,12 +16,10 @@ globwalk = { version = "0.1.0", path = "../turborepo-globwalk" }
 schemars = { workspace = true }
 secrecy = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 tracing = { workspace = true }
 ts-rs = { workspace = true }
 turbopath = { workspace = true }
 turborepo-errors = { workspace = true }
 turborepo-task-id = { workspace = true }
 wax = { workspace = true }
-
-[dev-dependencies]
-serde_json = { workspace = true }

--- a/crates/turborepo-types/src/lib.rs
+++ b/crates/turborepo-types/src/lib.rs
@@ -807,6 +807,85 @@ mod tests {
     }
 }
 
+/// Configuration for the experimental `experimentalCI` task key.
+///
+/// The key accepts either a boolean toggle or an object with arbitrary
+/// options. Turborepo does not interpret the contents; the value is parsed
+/// and carried through task resolution so that external tooling can read
+/// the fully resolved configuration (e.g. via `turbo query`).
+#[derive(Debug, PartialEq, Clone, Serialize)]
+#[serde(untagged)]
+pub enum ExperimentalCIConfig {
+    Enabled(bool),
+    Options(serde_json::Map<String, serde_json::Value>),
+}
+
+// `serde_json::Value` is not `Eq` because JSON numbers may be floats, but
+// values parsed from JSON text are never NaN, so equality is reflexive in
+// practice.
+impl Eq for ExperimentalCIConfig {}
+
+impl biome_deserialize::Deserializable for ExperimentalCIConfig {
+    fn deserialize(
+        value: &impl biome_deserialize::DeserializableValue,
+        name: &str,
+        diagnostics: &mut Vec<biome_deserialize::DeserializationDiagnostic>,
+    ) -> Option<Self> {
+        value.deserialize(ExperimentalCIConfigVisitor, name, diagnostics)
+    }
+}
+
+struct ExperimentalCIConfigVisitor;
+
+impl biome_deserialize::DeserializationVisitor for ExperimentalCIConfigVisitor {
+    type Output = ExperimentalCIConfig;
+
+    const EXPECTED_TYPE: biome_deserialize::VisitableType =
+        biome_deserialize::VisitableType::BOOL.union(biome_deserialize::VisitableType::MAP);
+
+    fn visit_bool(
+        self,
+        value: bool,
+        _range: biome_deserialize::TextRange,
+        _name: &str,
+        _diagnostics: &mut Vec<biome_deserialize::DeserializationDiagnostic>,
+    ) -> Option<Self::Output> {
+        Some(ExperimentalCIConfig::Enabled(value))
+    }
+
+    fn visit_map(
+        self,
+        members: impl Iterator<
+            Item = Option<(
+                impl biome_deserialize::DeserializableValue,
+                impl biome_deserialize::DeserializableValue,
+            )>,
+        >,
+        _range: biome_deserialize::TextRange,
+        _name: &str,
+        diagnostics: &mut Vec<biome_deserialize::DeserializationDiagnostic>,
+    ) -> Option<Self::Output> {
+        let entries = members
+            .filter_map(|entry| {
+                let (key, value) = entry?;
+                let key = <String as biome_deserialize::Deserializable>::deserialize(
+                    &key,
+                    "",
+                    diagnostics,
+                )?;
+                let value = <serde_json::Value as biome_deserialize::Deserializable>::deserialize(
+                    &value,
+                    "",
+                    diagnostics,
+                )?;
+                Some((key, value))
+            })
+            .collect();
+
+        Some(ExperimentalCIConfig::Options(entries))
+    }
+}
+
 /// Constructed from a RawTaskDefinition, this represents the fully resolved
 /// configuration for a task.
 #[derive(Debug, PartialEq, Clone, Eq)]
@@ -864,6 +943,10 @@ pub struct TaskDefinition {
     // tool-managed incremental artifacts to persist across runs via remote
     // cache, enabling faster re-execution on cache misses.
     pub incremental: Option<Vec<IncrementalPartition>>,
+
+    // Experimental CI configuration. Not interpreted by turborepo; carried
+    // through resolution so tooling can read it (e.g. via `turbo query`).
+    pub experimental_ci: Option<ExperimentalCIConfig>,
 }
 
 impl Default for TaskDefinition {
@@ -883,6 +966,7 @@ impl Default for TaskDefinition {
             env_mode: Default::default(),
             with: Default::default(),
             incremental: Default::default(),
+            experimental_ci: Default::default(),
         }
     }
 }

--- a/crates/turborepo/tests/snapshots/query__basic_monorepo_get_schema_(npm@10.5.0).snap
+++ b/crates/turborepo/tests/snapshots/query__basic_monorepo_get_schema_(npm@10.5.0).snap
@@ -325,6 +325,18 @@ expression: query_output
               "deprecationReason": null
             },
             {
+              "name": "experimentalCI",
+              "description": "The fully resolved `experimentalCI` configuration for this task from\nturbo.json, including Package Configuration overrides. Either a\nboolean or an object with arbitrary keys. Null if the key is not set.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "JSON",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "directDependents",
               "description": null,
               "args": [],
@@ -2432,6 +2444,18 @@ expression: query_output
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "experimentalCI",
+              "description": "The fully resolved `experimentalCI` configuration for this task from\nturbo.json, including Package Configuration overrides. Either a\nboolean or an object with arbitrary keys. Null if the key is not set.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "JSON",
                 "ofType": null
               },
               "isDeprecated": false,


### PR DESCRIPTION
## Why

The `experimentalCI` task key (boolean or object with arbitrary options) was parsed from turbo.json but dropped during task resolution, so external tooling had no way to discover which tasks have it set or what their effective configuration is. CI tooling needs the fully resolved value per task, including Package Configuration overrides.

## What

Adds an `experimentalCI` field to `RepositoryTask` in the `turbo query` GraphQL schema, returning the fully resolved value as JSON (`true`/`false`, an object with arbitrary keys, or `null` when unset).

## How

- Moved the enum into `turborepo-types` as `ExperimentalCIConfig` (single source of truth, replacing the raw-only `RawExperimentalCIConfig`) with its biome `Deserializable` impl
- Threaded the value through `ProcessedTaskDefinition` into the resolved `TaskDefinition`
- Included it in the `extends` merge, so Package Configurations replace the root value when set and inherit it when not; also counted in `has_config_beyond_extends`
- Object contents are stored as `serde_json::Map`, so arbitrary keys and nested structures pass through uninterpreted
- Not included in task hashing or run summaries; the key has no effect on execution

## Testing

Unit tests cover parse-through and the package-override merge. Verified end-to-end against `vercel/front` with a locally built binary:

```graphql
{ packages { items { tasks { items { fullName experimentalCI } } } } }
```

- 263 of 852 tasks resolved `{"cpus":4}` from the root turbo.jsonc
- Package Configuration in `apps/admin/turbo.json`: adding `experimentalCI` to `build` surfaced it; a boolean on `type-check` replaced the root object; untouched tasks inherited the root value
- Arbitrary object contents round-trip exactly (nested arrays/objects, nulls, floats, unicode keys)

Note when testing by hand: use `--skip-infer`, otherwise the repo's locally installed turbo is executed instead of your build.