### PR TITLE
perf: Pre-size engine task collections

### DIFF
--- a/crates/turborepo-engine/src/builder.rs
+++ b/crates/turborepo-engine/src/builder.rs
@@ -285,6 +285,9 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         let traversal_span = tracing::info_span!("engine_traversal").entered();
         let mut visited = HashSet::new();
         let mut engine: Engine<Building, TaskDefinition> = Engine::default();
+        // Entry points are a floor for the final task count; doubling covers
+        // dependency tasks in the common case so the maps allocate once.
+        engine.reserve(traversal_queue.len() * 2);
         let mut turbo_json_chain_cache: HashMap<PackageName, Vec<&TurboJson>> = HashMap::new();
         let mut task_def_memo: HashMap<definitions::TaskDefMemoKey, TaskDefinition> =
             HashMap::new();

--- a/crates/turborepo-engine/src/lib.rs
+++ b/crates/turborepo-engine/src/lib.rs
@@ -186,6 +186,17 @@ impl<T: TaskDefinitionInfo + Default + Clone> Engine<Building, T> {
         self.task_graph.add_edge(source, self.root_index, ());
     }
 
+    /// Pre-size the task collections for an expected task count.
+    /// `TaskDefinition` values are large, so growing the definitions map
+    /// incrementally repeatedly reallocates and moves hundreds of kilobytes;
+    /// on large graphs those moves showed up as multi-millisecond
+    /// page-compaction stalls during engine construction.
+    pub fn reserve(&mut self, additional_tasks: usize) {
+        self.task_lookup.reserve(additional_tasks);
+        self.task_definitions.reserve(additional_tasks);
+        self.task_locations.reserve(additional_tasks);
+    }
+
     pub fn add_definition(&mut self, task_id: TaskId<'static>, definition: T) -> Option<T> {
         if definition.persistent() && !definition.interruptible() {
             self.has_non_interruptible_tasks = true;


### PR DESCRIPTION
## Why

Profiling engine construction on a 1191-package monorepo (perf, stacks filtered through `EngineBuilder::build`) showed the single largest cost was kernel page-compaction stalls: the task-definitions map grows incrementally during traversal, its values (`TaskDefinition`) are large, and each rehash reallocates and moves hundreds of kilobytes — landing on transparent-huge-page allocation paths that stall for milliseconds.

## What

`Engine::reserve`: pre-size the task lookup/definitions/locations maps, called by `EngineBuilder::build` with the entry-point count doubled as a floor for the final task count, so the maps allocate once.

## How to verify

- `cargo test -p turborepo-engine` (110 tests) passes unchanged; `--dry=json` byte-identical on the monorepo above.
- Honest sizing: median engine traversal improves modestly (~31.5 → ~29.2ms); the measured win is in the tail, where the episodic compaction stalls lived (38 of 138 in-window perf samples in the profiled run). Small, but it's 12 lines of allocation hygiene at a hot construction site.
