### PR TITLE
feat: Hash Cargo external dependencies per-crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2804,7 +2804,7 @@ dependencies = [
  "os_info",
  "serde",
  "serde_derive",
- "toml",
+ "toml 0.8.14",
  "uuid",
 ]
 
@@ -5957,6 +5957,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6886,9 +6895,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.6",
+ "toml_datetime 0.6.6",
  "toml_edit 0.22.15",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -6901,13 +6925,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime",
+ "toml_datetime 0.6.6",
  "winnow 0.5.40",
 ]
 
@@ -6919,9 +6952,24 @@ checksum = "d59a3a72298453f564e2b111fa896f8d07fabb36f51f06d7e875fc5e0b5a3ef1"
 dependencies = [
  "indexmap 2.13.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.6",
+ "toml_datetime 0.6.6",
 ]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -7930,6 +7978,7 @@ dependencies = [
  "serde_yaml_ng",
  "test-case",
  "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
  "tracing",
  "turbopath",
  "turborepo-errors",
@@ -9497,6 +9546,12 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,7 @@ thiserror = "2.0.18"
 tiny-gradient = "0.1.0"
 tokio = "1.47.1"
 tokio-util = { version = "0.7.7", features = ["io"] }
+toml = "0.9.5"
 tracing = "0.1.37"
 tracing-appender = "0.2.2"
 tracing-subscriber = "0.3.20"

--- a/crates/turborepo-lockfiles/Cargo.toml
+++ b/crates/turborepo-lockfiles/Cargo.toml
@@ -28,6 +28,7 @@ serde = { version = "1.0.228", features = ["derive", "rc"] }
 serde_json = "1.0.86"
 serde_yaml_ng = { workspace = true }
 thiserror = { workspace = true }
+toml = { workspace = true }
 tracing.workspace = true
 turbopath = { path = "../turborepo-paths" }
 turborepo-errors = { workspace = true }

--- a/crates/turborepo-lockfiles/src/cargo.rs
+++ b/crates/turborepo-lockfiles/src/cargo.rs
@@ -1,0 +1,316 @@
+//! Cargo.lock parsing for external-dependency hashing.
+//!
+//! Unlike the JS lockfile implementations, this module does not implement
+//! the [`crate::Lockfile`] trait: Cargo owns resolution, subgraph pruning,
+//! and installation, so Turborepo only needs one thing from Cargo.lock —
+//! the set of external packages in each workspace member's transitive
+//! dependency closure, so a crate task's hash changes exactly when a
+//! dependency in *its* closure changes (and not when an unrelated crate
+//! bumps a dependency).
+//!
+//! Cargo.lock is a flat list of `[[package]]` entries. Workspace members
+//! have no `source`; external packages (registry or git) do. A package's
+//! `dependencies` are strings of the form `"name"`, `"name version"`, or
+//! `"name version (source)"` — the longer forms appear only when the short
+//! form would be ambiguous.
+
+use std::collections::{HashMap, HashSet};
+
+use serde::Deserialize;
+
+use crate::Package;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Unable to parse Cargo.lock: {0}")]
+    Parse(#[from] Box<toml::de::Error>),
+    #[error("Cargo.lock dependency '{0}' does not match any package entry.")]
+    UnknownDependency(String),
+    #[error(
+        "Cargo.lock dependency '{0}' is ambiguous: multiple versions exist and no version was \
+         specified."
+    )]
+    AmbiguousDependency(String),
+}
+
+#[derive(Deserialize)]
+struct CargoLock {
+    #[serde(default)]
+    package: Vec<LockPackage>,
+}
+
+#[derive(Deserialize, Clone)]
+struct LockPackage {
+    name: String,
+    version: String,
+    source: Option<String>,
+    checksum: Option<String>,
+    #[serde(default)]
+    dependencies: Vec<String>,
+}
+
+impl LockPackage {
+    /// The hash identity of an external package: everything Cargo.lock pins
+    /// about it. Version alone is insufficient — a git dependency's rev
+    /// lives in `source`, and a registry package's content is pinned by
+    /// `checksum`.
+    fn hash_identity(&self) -> Package {
+        let mut version = self.version.clone();
+        if let Some(source) = &self.source {
+            version.push(' ');
+            version.push_str(source);
+        }
+        if let Some(checksum) = &self.checksum {
+            version.push(' ');
+            version.push_str(checksum);
+        }
+        Package {
+            key: self.name.clone(),
+            version,
+        }
+    }
+}
+
+/// For each named workspace member present in the lockfile, compute the set
+/// of external packages (those with a `source`) in its transitive dependency
+/// closure.
+///
+/// Members missing from the lockfile are simply absent from the result (a
+/// stale lockfile is Cargo's to repair, not ours). Cargo.lock merges normal,
+/// build, and dev dependencies into one edge list, so closures include dev
+/// dependencies — over-inclusive, which is the safe direction for hashing.
+pub fn cargo_external_closures(
+    contents: &str,
+    members: &[String],
+) -> Result<HashMap<String, HashSet<Package>>, Error> {
+    let lock: CargoLock = toml::from_str(contents).map_err(Box::new)?;
+    let index = LockIndex::new(&lock);
+
+    let mut closures = HashMap::new();
+    for member in members {
+        let Some(start) = index.member(member) else {
+            continue;
+        };
+        let mut externals = HashSet::new();
+        for idx in index.reachable(start)? {
+            let package = &lock.package[idx];
+            if package.source.is_some() {
+                externals.insert(package.hash_identity());
+            }
+        }
+        closures.insert(member.clone(), externals);
+    }
+    Ok(closures)
+}
+
+/// Index over a parsed lockfile for name/version dependency resolution.
+struct LockIndex<'a> {
+    lock: &'a CargoLock,
+    by_name: HashMap<&'a str, Vec<usize>>,
+}
+
+impl<'a> LockIndex<'a> {
+    fn new(lock: &'a CargoLock) -> Self {
+        let mut by_name: HashMap<&str, Vec<usize>> = HashMap::new();
+        for (idx, package) in lock.package.iter().enumerate() {
+            by_name.entry(package.name.as_str()).or_default().push(idx);
+        }
+        Self { lock, by_name }
+    }
+
+    /// A member crate appears in the lock without a source. Duplicate names
+    /// cannot occur among members (Cargo rejects them), so a sourceless
+    /// entry with this name is the member.
+    fn member(&self, name: &str) -> Option<usize> {
+        self.by_name.get(name).and_then(|candidates| {
+            candidates
+                .iter()
+                .copied()
+                .find(|&idx| self.lock.package[idx].source.is_none())
+        })
+    }
+
+    /// Resolve a dependency string — `"name"`, `"name version"`, or
+    /// `"name version (source)"` — to a package index.
+    fn resolve(&self, dep: &str) -> Result<usize, Error> {
+        let mut parts = dep.split_whitespace();
+        let name = parts.next().unwrap_or(dep);
+        let version = parts.next();
+        let candidates = self
+            .by_name
+            .get(name)
+            .ok_or_else(|| Error::UnknownDependency(dep.to_string()))?;
+        match version {
+            Some(version) => candidates
+                .iter()
+                .copied()
+                .find(|&idx| self.lock.package[idx].version == version)
+                .ok_or_else(|| Error::UnknownDependency(dep.to_string())),
+            None => match candidates.as_slice() {
+                [only] => Ok(*only),
+                _ => Err(Error::AmbiguousDependency(dep.to_string())),
+            },
+        }
+    }
+
+    /// All package indices reachable from `start`, including itself.
+    fn reachable(&self, start: usize) -> Result<HashSet<usize>, Error> {
+        let mut visited = HashSet::new();
+        let mut stack = vec![start];
+        while let Some(idx) = stack.pop() {
+            if !visited.insert(idx) {
+                continue;
+            }
+            for dep in &self.lock.package[idx].dependencies {
+                stack.push(self.resolve(dep)?);
+            }
+        }
+        Ok(visited)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const LOCK: &str = r#"
+version = 4
+
+[[package]]
+name = "app"
+version = "0.1.0"
+dependencies = ["lib-a", "serde"]
+
+[[package]]
+name = "lib-a"
+version = "0.1.0"
+dependencies = ["itoa 1.0.0"]
+
+[[package]]
+name = "other"
+version = "0.1.0"
+dependencies = ["itoa 0.4.8"]
+
+[[package]]
+name = "serde"
+version = "1.0.200"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abc123"
+dependencies = ["itoa 1.0.0"]
+
+[[package]]
+name = "itoa"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def456"
+
+[[package]]
+name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ld"
+
+[[package]]
+name = "git-dep"
+version = "0.2.0"
+source = "git+https://example.com/dep#deadbeef"
+"#;
+
+    fn names(closure: &HashSet<Package>) -> Vec<String> {
+        let mut names: Vec<_> = closure
+            .iter()
+            .map(|p| format!("{}@{}", p.key, p.version))
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn test_closures_are_per_member() {
+        let members = vec!["app".to_string(), "lib-a".to_string(), "other".to_string()];
+        let closures = cargo_external_closures(LOCK, &members).unwrap();
+
+        // app's closure flows through lib-a and serde to itoa 1.0.0; the
+        // identity captures version, source, and checksum.
+        assert_eq!(
+            names(&closures["app"]),
+            vec![
+                "itoa@1.0.0 registry+https://github.com/rust-lang/crates.io-index def456",
+                "serde@1.0.200 registry+https://github.com/rust-lang/crates.io-index abc123",
+            ]
+        );
+        // lib-a doesn't see serde; other pins the old itoa. A serde bump
+        // must not invalidate either of them.
+        assert_eq!(
+            names(&closures["lib-a"]),
+            vec!["itoa@1.0.0 registry+https://github.com/rust-lang/crates.io-index def456"]
+        );
+        assert_eq!(
+            names(&closures["other"]),
+            vec!["itoa@0.4.8 registry+https://github.com/rust-lang/crates.io-index 0ld"]
+        );
+    }
+
+    #[test]
+    fn test_missing_member_is_skipped() {
+        let members = vec!["not-in-lock".to_string()];
+        let closures = cargo_external_closures(LOCK, &members).unwrap();
+        assert!(closures.is_empty());
+    }
+
+    #[test]
+    fn test_ambiguous_short_dependency_errors() {
+        let lock = r#"
+[[package]]
+name = "app"
+version = "0.1.0"
+dependencies = ["itoa"]
+
+[[package]]
+name = "itoa"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+"#;
+        let err = cargo_external_closures(lock, &["app".to_string()]).unwrap_err();
+        assert!(matches!(err, Error::AmbiguousDependency(_)));
+    }
+
+    #[test]
+    fn test_unknown_dependency_errors() {
+        let lock = r#"
+[[package]]
+name = "app"
+version = "0.1.0"
+dependencies = ["ghost"]
+"#;
+        let err = cargo_external_closures(lock, &["app".to_string()]).unwrap_err();
+        assert!(matches!(err, Error::UnknownDependency(_)));
+    }
+
+    #[test]
+    fn test_git_source_participates_in_identity() {
+        let lock = r#"
+[[package]]
+name = "app"
+version = "0.1.0"
+dependencies = ["git-dep"]
+
+[[package]]
+name = "git-dep"
+version = "0.2.0"
+source = "git+https://example.com/dep#deadbeef"
+"#;
+        let closures = cargo_external_closures(lock, &["app".to_string()]).unwrap();
+        // A git rev bump changes `source` but not `version`; the identity
+        // must capture it.
+        assert_eq!(
+            names(&closures["app"]),
+            vec!["git-dep@0.2.0 git+https://example.com/dep#deadbeef"]
+        );
+    }
+}

--- a/crates/turborepo-lockfiles/src/error.rs
+++ b/crates/turborepo-lockfiles/src/error.rs
@@ -26,6 +26,8 @@ pub enum Error {
     Bun(#[from] crate::bun::Error),
     #[error(transparent)]
     Berry(#[from] crate::berry::Error),
+    #[error(transparent)]
+    CargoLock(#[from] crate::cargo::Error),
     #[error("Lockfile contains invalid path: {0}")]
     Path(#[from] turbopath::PathError),
 }

--- a/crates/turborepo-lockfiles/src/lib.rs
+++ b/crates/turborepo-lockfiles/src/lib.rs
@@ -14,6 +14,7 @@
 
 mod berry;
 mod bun;
+mod cargo;
 mod closure_dp;
 mod error;
 mod npm;
@@ -29,6 +30,7 @@ use std::{
 
 pub use berry::{Error as BerryError, *};
 pub use bun::{BunLockfile, bun_global_change};
+pub use cargo::{Error as CargoLockError, cargo_external_closures};
 use dashmap::DashMap;
 pub use error::Error;
 pub use npm::*;

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -57,6 +57,74 @@ pub enum Error {
     Metadata { stderr: String },
     #[error("failed to parse `cargo metadata` output: {0}")]
     Parse(#[from] serde_json::Error),
+    #[error("failed to read Cargo.lock: {0}")]
+    LockfileRead(#[source] io::Error),
+    #[error(transparent)]
+    Lockfile(#[from] turborepo_lockfiles::CargoLockError),
+}
+
+/// The version of the Rust compiler that Cargo will invoke, as a hashable
+/// external-dependency identity, or `None` (with a warning) when rustc
+/// can't be queried.
+///
+/// Run from `repo_root` so rustup's shim resolves `rust-toolchain`
+/// overrides the same way a task's `cargo` invocation will. Participating
+/// in the external-dependency hash means compiling with a different
+/// toolchain never restores another toolchain's artifacts — the gap that
+/// makes remote cache sharing unsound when no toolchain file is committed.
+pub fn rustc_version(repo_root: &AbsoluteSystemPath) -> Option<turborepo_lockfiles::Package> {
+    let output = std::process::Command::new("rustc")
+        .arg("--version")
+        .current_dir(repo_root.as_std_path())
+        .output();
+    match output {
+        Ok(output) if output.status.success() => {
+            let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            (!version.is_empty()).then_some(turborepo_lockfiles::Package {
+                key: "rustc".to_string(),
+                version,
+            })
+        }
+        Ok(output) => {
+            tracing::warn!(
+                "`rustc --version` failed; the compiler version will not participate in Cargo \
+                 task hashes: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+            None
+        }
+        Err(error) => {
+            tracing::warn!(
+                "unable to run `rustc --version`; the compiler version will not participate in \
+                 Cargo task hashes: {error}"
+            );
+            None
+        }
+    }
+}
+
+/// Per-crate external dependency closures from Cargo.lock, for the crates'
+/// external-dependency hashes.
+///
+/// A missing Cargo.lock yields an empty map (the workspace is unpinned;
+/// Cargo will create the lockfile on first build). An unreadable or
+/// unparsable lockfile is a hard error — silently hashing nothing would be
+/// unsound.
+pub fn external_closures(
+    repo_root: &AbsoluteSystemPath,
+    members: &[String],
+) -> Result<HashMap<String, HashSet<turborepo_lockfiles::Package>>, Error> {
+    let lock_path = repo_root.join_component(CARGO_LOCK);
+    let contents = match lock_path.read_to_string() {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Ok(HashMap::new());
+        }
+        Err(error) => return Err(Error::LockfileRead(error)),
+    };
+    Ok(turborepo_lockfiles::cargo_external_closures(
+        &contents, members,
+    )?)
 }
 
 /// How a Cargo-toolchain package participates in task execution.
@@ -164,22 +232,20 @@ fn join_prefix(prefix: &str, rel: &str) -> String {
 }
 
 /// Input globs whose changes should invalidate a Cargo task's cache: the
-/// workspace lockfile and root manifest (locked dependencies, profiles,
-/// lints, `[patch]`, and feature unification all live there), Cargo config
-/// files, and pinned toolchain files — expressed relative to the task's
-/// package directory via `prefix` (the path from the package to the repo
-/// root, e.g. `../..`; empty for the workspace package). Globs that don't
-/// match anything (e.g. a missing `rust-toolchain` file) simply contribute
-/// nothing.
+/// workspace root manifest (profiles, lints, `[patch]`, and feature
+/// unification all live there), Cargo config files, and pinned toolchain
+/// files — expressed relative to the task's package directory via `prefix`
+/// (the path from the package to the repo root, e.g. `../..`; empty for the
+/// workspace package). Globs that don't match anything (e.g. a missing
+/// `rust-toolchain` file) simply contribute nothing.
 ///
-/// Cargo.lock as a raw input makes every dependency change invalidate every
-/// crate task — coarse but sound. It will move to per-crate
-/// external-dependency closures when the external-dependency hashing
-/// surface lands, so a dependency bump only invalidates the crates whose
-/// closures contain it.
+/// Cargo.lock is deliberately absent: locked dependencies participate in
+/// each crate task's external-dependency hash, scoped to that crate's
+/// transitive closure (see [`external_closures`]), so a dependency bump only
+/// invalidates the crates that actually depend on it. The compiler version
+/// participates the same way (see [`rustc_version`]).
 pub fn hash_input_globs(prefix: &str) -> Vec<String> {
     [
-        CARGO_LOCK,
         "Cargo.toml",
         ".cargo/config.toml",
         ".cargo/config",
@@ -459,6 +525,25 @@ impl Toolchain for CargoToolchain {
             // Discovery only reports dependencies on other discovered
             // crates, so every synthesized specifier resolves internally and
             // Cargo edges never leak into unresolved externals.
+            // External dependencies (locked crates.io/git packages plus the
+            // compiler itself) participate in each crate task's hash through
+            // the same external-dependency mechanism JS packages use, scoped
+            // to the crate's transitive closure — a dependency bump only
+            // invalidates crates that actually depend on it, and a toolchain
+            // change invalidates everything.
+            let all_names: Vec<String> = crates.iter().map(|c| c.name.clone()).collect();
+            let rustc = rustc_version(&self.repo_root);
+            let mut closures = turborepo_rayon_compat::block_in_place(|| {
+                external_closures(&self.repo_root, &all_names)
+            })
+            .map_err(|err| toolchain::Error::Failed(Box::new(err)))?;
+            let workspace_externals: HashSet<turborepo_lockfiles::Package> = closures
+                .values()
+                .flatten()
+                .cloned()
+                .chain(rustc.clone())
+                .collect();
+
             let mut packages = Vec::with_capacity(crates.len() + 1);
             let mut crate_names = Vec::with_capacity(crates.len());
             for cargo_crate in crates {
@@ -479,6 +564,12 @@ impl Toolchain for CargoToolchain {
                         deliverables: cargo_crate.deliverables,
                     },
                 );
+                let external_dependencies: HashSet<turborepo_lockfiles::Package> = closures
+                    .remove(&cargo_crate.name)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .chain(rustc.clone())
+                    .collect();
                 crate_names.push(cargo_crate.name.clone());
                 packages.push(DiscoveredPackage {
                     descriptor: PackageJson {
@@ -487,6 +578,7 @@ impl Toolchain for CargoToolchain {
                         ..Default::default()
                     },
                     manifest_path: cargo_crate.manifest_path,
+                    external_dependencies: Some(external_dependencies),
                 });
             }
 
@@ -512,6 +604,9 @@ impl Toolchain for CargoToolchain {
                         ..Default::default()
                     },
                     manifest_path: self.repo_root.join_component(CARGO_TOML),
+                    // Workspace-scoped verbs run every crate, so the union
+                    // of all closures is this package's external surface.
+                    external_dependencies: Some(workspace_externals),
                 });
             }
 
@@ -919,6 +1014,34 @@ mod test {
              \"2021\"\n\n[dependencies]\nlib-a = { path = \"../lib-a\" }\n",
         );
         write(root, &["crates", "lib-a-test-util", "src", "lib.rs"], "");
+        // A lockfile pinning an external dependency of app only. Metadata
+        // discovery (--no-deps) never reads it; only closure parsing does.
+        write(
+            root,
+            &["Cargo.lock"],
+            r#"version = 4
+
+[[package]]
+name = "app"
+version = "0.1.0"
+dependencies = ["lib-a", "serde"]
+
+[[package]]
+name = "lib-a"
+version = "0.1.0"
+
+[[package]]
+name = "lib-a-test-util"
+version = "0.1.0"
+dependencies = ["lib-a"]
+
+[[package]]
+name = "serde"
+version = "1.0.200"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abc123"
+"#,
+        );
     }
 
     #[test]
@@ -1078,6 +1201,28 @@ mod test {
         let workspace_deps = workspace.descriptor.dependencies.as_ref().unwrap();
         assert_eq!(workspace_deps.len(), 3);
         assert!(workspace_deps.values().all(|v| v == "workspace:*"));
+
+        // External identities from Cargo.lock are scoped per crate: app's
+        // closure pins serde, lib-a's does not. The compiler version stamps
+        // every closure (rustc is available wherever discovery ran, since
+        // discovery shells out to cargo).
+        let app_externals = app.external_dependencies.as_ref().unwrap();
+        assert!(
+            app_externals.iter().any(|p| p.key == "serde"),
+            "app depends on serde via Cargo.lock, got {app_externals:?}"
+        );
+        assert!(
+            app_externals.iter().any(|p| p.key == "rustc"),
+            "compiler version stamps the closure, got {app_externals:?}"
+        );
+        let lib_a_externals = packages[2].external_dependencies.as_ref().unwrap();
+        assert!(
+            !lib_a_externals.iter().any(|p| p.key == "serde"),
+            "a serde bump must not invalidate lib-a, got {lib_a_externals:?}"
+        );
+        // The workspace package unions every closure.
+        let workspace_externals = workspace.external_dependencies.as_ref().unwrap();
+        assert!(workspace_externals.iter().any(|p| p.key == "serde"));
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1230,7 +1375,13 @@ mod test {
         let io = toolchain
             .derived_task_io(&app, "build", "../..", &deps, true)
             .expect("entrypoint build derives IO");
-        assert!(io.input_globs.contains(&"../../Cargo.lock".to_string()));
+        assert!(
+            !io.input_globs
+                .iter()
+                .any(|glob| glob.contains("Cargo.lock")),
+            "Cargo.lock is hashed via per-crate closures, not as a raw input: {:?}",
+            io.input_globs
+        );
         assert!(
             io.input_globs
                 .contains(&"../../rust-toolchain.toml".to_string())
@@ -1264,7 +1415,7 @@ mod test {
         let io = toolchain
             .derived_task_io(&app, "build", "../..", &deps, false)
             .expect("entrypoint build derives IO");
-        assert!(io.input_globs.contains(&"../../Cargo.lock".to_string()));
+        assert!(io.input_globs.contains(&"../../Cargo.toml".to_string()));
         assert!(!io.input_globs.iter().any(|glob| glob.contains("lib-a")));
         assert_eq!(io.package_default_inputs, None);
 
@@ -1283,7 +1434,7 @@ mod test {
         assert_eq!(io.package_default_inputs, Some(false));
         assert!(io.input_globs.contains(&"crates/app/**".to_string()));
         assert!(io.input_globs.contains(&"crates/lib-a/**".to_string()));
-        assert!(io.input_globs.contains(&"Cargo.lock".to_string()));
+        assert!(io.input_globs.contains(&"Cargo.toml".to_string()));
         assert!(io.output_globs.is_empty());
 
         // Libraries derive nothing.

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -386,6 +386,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
         let DiscoveredPackage {
             descriptor: json,
             manifest_path,
+            external_dependencies,
         } = package;
         let relative_json_path =
             AnchoredSystemPathBuf::relative_path_between(self.repo_root, &manifest_path);
@@ -395,10 +396,22 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
                 .ok_or(Error::PackageJsonMissingName(manifest_path))?
                 .into_inner(),
         );
+        // Toolchain-resolved external identities (e.g. Cargo's per-crate
+        // lockfile closures), in the sorted representation the JS lockfile
+        // phase produces. That phase later fills this for JavaScript
+        // packages and never touches non-JS ones; the external-dependency
+        // hash is computed on demand from the sorted closure.
+        let transitive_dependencies = external_dependencies.map(|externals| {
+            let mut sorted: Vec<std::sync::Arc<turborepo_lockfiles::Package>> =
+                externals.into_iter().map(std::sync::Arc::new).collect();
+            sorted.sort_by(|a, b| (&a.key, &a.version).cmp(&(&b.key, &b.version)));
+            sorted
+        });
         let entry = PackageInfo {
             package_json: json,
             package_json_path: relative_json_path,
             toolchain,
+            transitive_dependencies,
             ..Default::default()
         };
         match self.workspaces.entry(name) {
@@ -439,6 +452,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
                         DiscoveredPackage {
                             descriptor: json,
                             manifest_path: path,
+                            external_dependencies: None,
                         },
                     )
                 }));

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -108,9 +108,11 @@ pub struct PackageInfo {
     /// The workspace's external dependency closure, sorted by `Package`'s
     /// `(key, version)` ordering. Members are `Arc`-shared across workspaces.
     pub transitive_dependencies: Option<Vec<Arc<turborepo_lockfiles::Package>>>,
-    /// Hash of `transitive_dependencies`, precomputed where the closure is
-    /// computed so task hashing and run summaries never re-sort or re-hash
-    /// closures. `Some` exactly when `transitive_dependencies` is `Some`.
+    /// Hash of `transitive_dependencies`, precomputed by the JavaScript
+    /// lockfile phase so task hashing and run summaries never re-sort or
+    /// re-hash closures. When `None` with a `Some` closure (toolchain-
+    /// resolved closures, e.g. Cargo's), consumers compute the hash from
+    /// the sorted closure on demand.
     pub external_deps_hash: Option<String>,
     /// The toolchain that discovered this package. Defaults to JavaScript.
     pub toolchain: crate::toolchain::ToolchainId,
@@ -2016,9 +2018,17 @@ mod test {
                     Arc::new(turborepo_lockfiles::Package::new("key:c", "1")),
                 ],
             );
-            assert_eq!(
-                workspace_pkg.transitive_dependencies, None,
-                "the cargo workspace package has no JS lockfile closure"
+            // Cargo packages carry toolchain-resolved closures (here just
+            // the rustc stamp — the fixture has no Cargo.lock), never JS
+            // lockfile entries.
+            assert!(
+                workspace_pkg
+                    .transitive_dependencies
+                    .iter()
+                    .flatten()
+                    .all(|package| package.key == "rustc"),
+                "the cargo workspace package must not carry JS lockfile entries, got {:?}",
+                workspace_pkg.transitive_dependencies
             );
         }
     }

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -104,6 +104,19 @@ pub struct DiscoveredPackage {
     /// Absolute path to the package's native manifest (`package.json`,
     /// `Cargo.toml`, ...).
     pub manifest_path: AbsoluteSystemPathBuf,
+    /// External-dependency identities for this package, when the toolchain
+    /// resolves them at discovery time. They feed the package's
+    /// external-dependency hash: a task's hash changes exactly when an
+    /// identity in its package's set changes. Cargo computes these from
+    /// Cargo.lock (per-crate transitive closures) plus a compiler-version
+    /// stamp.
+    ///
+    /// `None` defers to the toolchain's own pipeline. Known debt (see
+    /// module docs): JavaScript's closures are computed by the graph
+    /// builder's lockfile phase — deliberately concurrent with run setup —
+    /// rather than through this field; folding that in requires a
+    /// deferred-aware trait surface.
+    pub external_dependencies: Option<std::collections::HashSet<turborepo_lockfiles::Package>>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -491,6 +504,10 @@ impl<P: PackageDiscovery + Send + Sync> Toolchain for JavaScriptToolchain<P> {
                         Ok(DiscoveredPackage {
                             descriptor,
                             manifest_path: workspace.package_json,
+                            // JavaScript closures come from the builder's
+                            // (deliberately concurrent) lockfile phase; see
+                            // the field docs.
+                            external_dependencies: None,
                         })
                     })
                     .collect::<Result<Vec<_>, Error>>()


### PR DESCRIPTION
## Why

Next in the Cargo workspace series (#13227, #13235, #13248, #13261, #13263). The previous PR hashed `Cargo.lock` as a raw input — sound but coarse: any dependency bump invalidated every crate task, and even a lockfile comment invalidated everything. This PR replaces that with per-crate external-dependency closures, so a crate's task hash changes exactly when something in **its** closure changes. It also closes the toolchain-sharing hole: the compiler version now participates in every hash, so a different rustc never restores another toolchain's artifacts.

## What

- `turborepo-lockfiles::cargo_external_closures`: parses `Cargo.lock` and computes each member's transitive external closure. External identity = version + source + checksum (version alone misses git rev bumps and registry content changes). Dev/build edges are merged in the lockfile, so closures are over-inclusive — the safe direction. Missing lockfile → contributes nothing; unparsable → hard error
- `rustc --version` (resolved from the repo root, so `rust-toolchain` overrides apply) becomes a synthetic identity in every crate's closure
- `DiscoveredPackage.external_dependencies`: toolchains that resolve identities at discovery hand them to the graph builder, stored in the sorted representation task hashing already consumes; the synthetic `cargo` package carries the union of all closures
- `Cargo.lock` drops out of the raw input globs from #13263
- **Documented deviation from the series pattern**: JS lockfile closures do NOT move behind the trait here. #13250 just made that pipeline deliberately concurrent/deferred with run setup; a synchronous trait surface would regress it. The `external_dependencies` field docs carry this as known debt pending a deferred-aware surface — flagging for reviewers rather than burying it

## How

Flag off: zero behavior change (new field is `None` on the JS path everywhere). Flag on, verified live on a fixture with two entrypoint crates with disjoint closures: mutating one external dependency's checksum flips only the dependent crate's hash (plus the workspace union); a comment-only `Cargo.lock` edit flips nothing (we hash parsed identities, not file bytes); reverting restores original hashes. Unit coverage: closure scoping per member, ambiguous/unknown dependency errors, git-source identity, missing-member skip, discovery-time closure wiring incl. the rustc stamp and workspace union.