### PR TITLE
perf: Defer the untracked-scan barrier to first file-hash use

### DIFF
--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -924,11 +924,11 @@ impl RunBuilder {
                 });
                 observability::Handle::try_init(opts, token)
             });
-        let repo_index = Arc::new(
-            repo_index_task
-                .instrument(tracing::info_span!("repo_index_untracked_await"))
-                .await?,
-        );
+        // The untracked-file scan keeps running in the background;
+        // `execute_visitor` awaits it right before file hashing. Deferring
+        // the barrier lets everything between `Run` construction and
+        // hashing overlap the scan.
+        let repo_index = crate::run::PendingRepoIndex::new(repo_index_task);
 
         {
             let scm_state = scm_state.clone();
@@ -937,6 +937,7 @@ impl RunBuilder {
             tokio::spawn(
                 async move {
                     let sha = scm_state_task.await.ok().flatten();
+                    let repo_index = repo_index.get().await;
                     let dirty_hash =
                         tokio::task::spawn_blocking(move || match repo_index.as_ref() {
                             Some(repo_index) => scm.get_dirty_hash_from_repo_index(repo_index),

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -76,6 +76,39 @@ pub(crate) enum RemoteCacheStatus {
     Unavailable(RemoteCacheUnavailableReason),
 }
 
+/// A repo index whose untracked-file scan may still be running in the
+/// background. Holding this instead of the finished index lets `Run`
+/// construction complete without waiting for the scan; consumers await
+/// [`PendingRepoIndex::get`] at their barrier point and share the result.
+///
+/// A scan task that fails to join (panic/cancellation) resolves to `None`:
+/// every consumer treats the index as an optimization and has a slower
+/// index-free fallback.
+#[derive(Clone)]
+pub struct PendingRepoIndex {
+    index: futures::future::Shared<futures::future::BoxFuture<'static, Arc<Option<RepoGitIndex>>>>,
+}
+
+impl PendingRepoIndex {
+    pub(crate) fn new(task: tokio::task::JoinHandle<Option<RepoGitIndex>>) -> Self {
+        use futures::FutureExt;
+        Self {
+            index: async move {
+                Arc::new(task.await.unwrap_or_else(|e| {
+                    tracing::debug!("repo index task failed to join: {e}");
+                    None
+                }))
+            }
+            .boxed()
+            .shared(),
+        }
+    }
+
+    pub(crate) async fn get(&self) -> Arc<Option<RepoGitIndex>> {
+        self.index.clone().await
+    }
+}
+
 #[derive(Clone)]
 pub struct Run {
     version: &'static str,
@@ -98,7 +131,7 @@ pub struct Run {
     engine: Arc<Engine>,
     task_access: TaskAccess,
     micro_frontend_configs: Option<MicrofrontendsConfigs>,
-    repo_index: Arc<Option<RepoGitIndex>>,
+    repo_index: PendingRepoIndex,
     observability_handle: Option<ObservabilityHandle>,
     pub(crate) query_server: Option<Arc<dyn turborepo_query_api::QueryServer>>,
     shutdown_started_emitted: Arc<AtomicBool>,
@@ -962,7 +995,17 @@ impl Run {
         )>,
     ) -> Result<i32, Error> {
         let workspaces = self.pkg_dep_graph.packages().collect();
-        let repo_index = self.repo_index.as_ref().as_ref();
+        // Barrier for the untracked-file scan: file hashing below needs the
+        // complete index. Nothing executes before this resolves, so hash
+        // error semantics are unchanged from when `Run` construction waited.
+        let repo_index_arc = {
+            use tracing::Instrument;
+            self.repo_index
+                .get()
+                .instrument(tracing::info_span!("repo_index_untracked_await"))
+                .await
+        };
+        let repo_index = repo_index_arc.as_ref().as_ref();
 
         let root_workspace = self
             .pkg_dep_graph


### PR DESCRIPTION
## Why

`Run` construction awaited the full repo index (tracked git index + untracked-file scan) before returning. On a 1191-package/43k-file monorepo the scan is the longest item on the startup critical path, and nothing between `Run` construction and package file hashing needs it. This is step one of overlapping per-task hash precomputation with the scan; on its own it lets run-cache setup, UI startup, and engine validation ride the scan's tail.

## What

- `PendingRepoIndex`: a shared future over the background scan task, held by `Run` instead of the finished `Arc<Option<RepoGitIndex>>`.
- `execute_visitor` awaits it immediately before file hashing — the barrier moved, not removed. No task executes before the full index resolves, so hash results and error surfacing are unchanged.
- The background `capture_scm_state` task awaits the same shared future.
- One deliberate change: a scan task that fails to join (panic) now degrades to the index-free fallback paths instead of failing the run — the index is an optimization at every consumer.

## How to verify

- Real-run interleaved A/B on the monorepo above (time to first task output): median 199.4ms → 195.9ms with a tighter tail; the point of this PR is enabling the follow-up, not this delta.
- `--dry=json` byte-identical; `cargo test -p turborepo-lib` 432 passing.
