### PR TITLE
ci: Install pnpm 10 in musl containers for Library Release

### DIFF
--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -66,6 +66,7 @@ jobs:
             install: |
               apk update && apk upgrade
               apk add libc6-compat curl
+              npm i -g pnpm@10.28.0
               echo /root/.cargo/bin >> ${GITHUB_PATH}
               echo /usr/local/cargo/bin/rustup >> ${GITHUB_PATH}
             setup: |
@@ -80,6 +81,7 @@ jobs:
             install: |
               apk update && apk upgrade
               apk add libc6-compat curl
+              npm i -g pnpm@10.28.0
               echo /root/.cargo/bin >> ${GITHUB_PATH}
               echo /usr/local/cargo/bin/rustup >> ${GITHUB_PATH}
               echo /aarch64-linux-musl-cross/bin >> ${GITHUB_PATH}


### PR DESCRIPTION
### Why

The Library Release workflow is failing on both musl targets with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` (see run 28802079847). The napi-rs alpine container ships pnpm 8.7.5, which can't parse our `lockfileVersion: '9.0'` lockfile — it ignores the lockfile ("Ignoring not compatible lockfile"), recomputes, and then fails the frozen-install overrides check.

### What

Install `pnpm@10.28.0` (matching `packageManager` in the root `package.json`) in the install step of both musl container jobs.

### How

Same approach the `x86_64-unknown-linux-gnu` container job already uses (`npm i -g pnpm@10.28.0`). To verify, dispatch the Library Release workflow with `dry_run: true` and confirm the two musl builds get past `pnpm install --frozen-lockfile`.