### PR TITLE
ci: Fetch API-created commit before updating local ref

### DIFF
--- a/scripts/create-github-api-commit.mjs
+++ b/scripts/create-github-api-commit.mjs
@@ -111,6 +111,17 @@ function git(args, { trim = true } = {}) {
   return trim ? output.trim() : output;
 }
 
+function hasLocalCommit(sha) {
+  try {
+    execFileSync("git", ["cat-file", "-e", `${sha}^{commit}`], {
+      stdio: "ignore",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function splitNull(output) {
   return output.split("\0").filter(Boolean);
 }
@@ -464,6 +475,11 @@ export async function run(options = parseArgs()) {
     throw error;
   }
 
+  // createCommitOnBranch mints the commit on GitHub's side, so the object
+  // does not exist locally until we fetch it.
+  if (!hasLocalCommit(commitSha)) {
+    git(["fetch", "--quiet", "origin", `refs/heads/${options.branch}`]);
+  }
   git(["update-ref", `refs/heads/${options.branch}`, commitSha]);
   if (currentBranch === options.branch) {
     git(["reset", "--mixed", commitSha]);

--- a/scripts/create-github-api-commit.test.mjs
+++ b/scripts/create-github-api-commit.test.mjs
@@ -219,6 +219,72 @@ test("run reads changed files from repository root when invoked in a subdirector
   });
 });
 
+test("fetches the API-created commit before updating the local ref", async () => {
+  const cwd = process.cwd();
+  const originDir = mkdtempSync(join(tmpdir(), "github-api-commit-origin-"));
+  const cloneDir = join(mkdtempSync(join(tmpdir(), "github-api-commit-work-")), "clone");
+
+  try {
+    process.chdir(originDir);
+    git(["init"]);
+    git(["checkout", "-b", "main"]);
+    git(["config", "user.name", "Test User"]);
+    git(["config", "user.email", "test@example.com"]);
+    writeFileSync("file.txt", "base\n");
+    git(["add", "file.txt"]);
+    git(["commit", "-m", "initial"]);
+
+    git(["clone", "--quiet", originDir, cloneDir]);
+
+    // Simulate createCommitOnBranch: a commit that exists only on the remote,
+    // at the tip of the target branch.
+    git(["checkout", "-b", "release/test"]);
+    writeFileSync("file.txt", "remote change\n");
+    git(["add", "file.txt"]);
+    git(["commit", "-m", "api commit"]);
+    const remoteOnlySha = git(["rev-parse", "HEAD"]);
+    git(["checkout", "main"]);
+
+    process.chdir(cloneDir);
+    git(["config", "user.name", "Test User"]);
+    git(["config", "user.email", "test@example.com"]);
+    writeFileSync("file.txt", "local change\n");
+
+    process.env.GITHUB_REPOSITORY = "vercel/turbo";
+    process.env.GH_TOKEN = "test-token";
+    process.env.CREATE_GITHUB_API_COMMIT_VERIFY_ATTEMPTS = "1";
+    process.env.CREATE_GITHUB_API_COMMIT_VERIFY_DELAY_MS = "0";
+
+    const github = mockGitHub({
+      commitOid: remoteOnlySha,
+      remoteOid: null,
+      verified: true,
+    });
+    try {
+      await run({
+        allTracked: true,
+        branch: "release/test",
+        ifExists: "fail",
+        includeUntracked: false,
+        message: "test commit",
+        paths: [],
+      });
+
+      assert.equal(git(["rev-parse", "refs/heads/release/test"]), remoteOnlySha);
+    } finally {
+      github.restore();
+      delete process.env.GITHUB_REPOSITORY;
+      delete process.env.GH_TOKEN;
+      delete process.env.CREATE_GITHUB_API_COMMIT_VERIFY_ATTEMPTS;
+      delete process.env.CREATE_GITHUB_API_COMMIT_VERIFY_DELAY_MS;
+    }
+  } finally {
+    process.chdir(cwd);
+    rmSync(originDir, { force: true, recursive: true });
+    rmSync(join(cloneDir, ".."), { force: true, recursive: true });
+  }
+});
+
 test("update policy commits onto an existing remote branch", async () => {
   await withTempRepo(async () => {
     writeFileSync("file.txt", "changed\n");


### PR DESCRIPTION
### Why

Library Release run 28803106189 got past the build matrix (after #13269/#13270) but failed in `Publish to NPM` at `Commit version bump`:

```
fatal: update_ref failed for ref 'refs/heads/library-release/0.0.1-canary.22': ... nonexistent object
```

`create-github-api-commit.mjs` creates the commit remotely via GraphQL `createCommitOnBranch`, then runs `git update-ref` with that SHA — but the object only exists on GitHub, never in the local object store. The existing test masked this by mocking the API commit SHA as the local HEAD.

### What

- Fetch `refs/heads/<branch>` from origin before `git update-ref` when the commit object is missing locally.
- Add a regression test that uses a real origin remote holding a commit the local clone doesn't have.

### How

The fetch is skipped when the object already exists (keeps tests without a remote working, avoids a needless network call). Verify with `node --test scripts/create-github-api-commit.test.mjs` (7/7 pass), then re-dispatch Library Release with `dry_run: true`. This also fixes the same latent failure in `turborepo-release.yml` and `update-examples-on-release.yml`, which call the same script.