### PR TITLE
perf: Remove lock and dispatch overhead from task hash precomputation

### DIFF
--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -550,77 +550,81 @@ impl<'a> Visitor<'a> {
             waves[d].push(node_idx);
         }
 
-        let results: Arc<Mutex<HashMap<TaskId<'static>, PrecomputedTask>>> =
-            Arc::new(Mutex::new(HashMap::with_capacity(sorted.len())));
+        let mut results: HashMap<TaskId<'static>, PrecomputedTask> =
+            HashMap::with_capacity(sorted.len());
+        // Task IDs that resolved to `PrecomputedTask::Deferred` so far.
+        // Deferral is rare (JIT inputs or dependency-output inputs), so
+        // most runs never insert here and the per-task dependency scan
+        // below short-circuits on `is_empty`.
+        let mut deferred: HashSet<TaskId<'static>> = HashSet::new();
 
         // Process each wave in parallel. Within a wave, all dependencies
-        // have already been hashed in earlier waves.
+        // have already been hashed in earlier waves, and `results` /
+        // `deferred` are only written between waves, so wave workers read
+        // them without locking.
+        //
+        // Deep dependency chains produce long tails of single-task waves;
+        // dispatching those through rayon costs more than the hashing
+        // itself, so small waves run inline.
+        const PAR_WAVE_MIN_TASKS: usize = 4;
+        type HashResult = Result<Option<(TaskId<'static>, PrecomputedTask)>, Error>;
         for wave in &waves {
-            type HashResult = Result<Option<(TaskId<'static>, PrecomputedTask)>, Error>;
-            let wave_results: Vec<HashResult> = wave
-                .par_iter()
-                .map(|&node_idx| {
-                    let node = &graph[node_idx];
-                    let TaskNode::Task(task_id) = node else {
-                        return Ok(None);
-                    };
+            let hash_one = |&node_idx: &petgraph::graph::NodeIndex| -> HashResult {
+                let node = &graph[node_idx];
+                let TaskNode::Task(task_id) = node else {
+                    return Ok(None);
+                };
 
-                    let task_definition = engine
-                        .task_definition(task_id)
-                        .ok_or(Error::MissingDefinition)?;
-                    let task_env_mode = task_definition.env_mode.unwrap_or(self.global_env_mode);
+                let task_definition = engine
+                    .task_definition(task_id)
+                    .ok_or(Error::MissingDefinition)?;
+                let task_env_mode = task_definition.env_mode.unwrap_or(self.global_env_mode);
 
-                    let dependency_set = engine
-                        .dependencies(task_id)
-                        .ok_or(Error::MissingDefinition)?;
+                let dependency_set = engine
+                    .dependencies(task_id)
+                    .ok_or(Error::MissingDefinition)?;
 
-                    let has_deferred_dependency = {
-                        let map = results
-                            .lock()
-                            .unwrap_or_else(|poisoned| poisoned.into_inner());
-                        dependency_set.iter().any(|dependency| {
-                            let TaskNode::Task(dependency_task_id) = dependency else {
-                                return false;
-                            };
+                let has_deferred_dependency = !deferred.is_empty()
+                    && dependency_set.iter().any(|dependency| {
+                        let TaskNode::Task(dependency_task_id) = dependency else {
+                            return false;
+                        };
 
-                            matches!(map.get(dependency_task_id), Some(PrecomputedTask::Deferred))
-                        })
-                    };
+                        deferred.contains(dependency_task_id)
+                    });
 
-                    if task_definition.inputs.has_deferred_inputs() || has_deferred_dependency {
-                        if self.dry {
-                            self.task_hasher.insert_deferred_hash(
-                                task_id,
-                                task_definition,
-                                task_env_mode,
-                            )?;
-                        }
-                        return Ok(Some((task_id.clone(), PrecomputedTask::Deferred)));
+                if task_definition.inputs.has_deferred_inputs() || has_deferred_dependency {
+                    if self.dry {
+                        self.task_hasher.insert_deferred_hash(
+                            task_id,
+                            task_definition,
+                            task_env_mode,
+                        )?;
                     }
+                    return Ok(Some((task_id.clone(), PrecomputedTask::Deferred)));
+                }
 
-                    self.precompute_ready_task_hash(engine, telemetry, task_id)
-                        .map(|precomputed_task| Some((task_id.clone(), precomputed_task)))
-                })
-                .collect();
+                self.precompute_ready_task_hash(engine, telemetry, task_id)
+                    .map(|precomputed_task| Some((task_id.clone(), precomputed_task)))
+            };
 
-            let mut map = results
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let wave_results: Vec<HashResult> = if wave.len() >= PAR_WAVE_MIN_TASKS {
+                wave.par_iter().map(hash_one).collect()
+            } else {
+                wave.iter().map(hash_one).collect()
+            };
+
             for result in wave_results {
                 if let Some((task_id, precomputed)) = result? {
-                    map.insert(task_id, precomputed);
+                    if matches!(precomputed, PrecomputedTask::Deferred) {
+                        deferred.insert(task_id.clone());
+                    }
+                    results.insert(task_id, precomputed);
                 }
             }
         }
 
-        match Arc::try_unwrap(results) {
-            Ok(mutex) => Ok(mutex
-                .into_inner()
-                .unwrap_or_else(|poisoned| poisoned.into_inner())),
-            Err(arc) => Ok(std::mem::take(
-                &mut *arc.lock().unwrap_or_else(|poisoned| poisoned.into_inner()),
-            )),
-        }
+        Ok(results)
     }
 
     #[tracing::instrument(skip_all)]


### PR DESCRIPTION
## Why

Task hash precomputation is the last gate before the first task starts. On a 1191-package monorepo the task graph is 64 topological waves deep, and instrumentation showed the wave loop paying for a global results mutex (locked once per task for a deferred-dependency check, again per wave to merge), a full dependency-set scan per task for deferral that almost never occurs, and rayon dispatch on ~60 waves holding one or two tasks each — where dispatch costs more than the hashing.

## What

- The results map is a plain `HashMap` owned by the wave loop: waves are sequential, workers read it immutably during a wave, merges write between waves. No lock existed for a reason.
- Deferred task IDs go in a dedicated set; the per-task dependency scan short-circuits when it's empty (the common case — deferral needs JIT or dependency-output inputs).
- Waves under four tasks run inline instead of through `par_iter`.

No semantic changes: same hashes, same wave ordering, same deferral behavior, same error surfacing.

## How to verify

- Real-run time-to-first-task on the monorepo above, two interleaved A/B rounds of 8: median 202.2→192.6ms and 191.2→186.2ms (−5 to −10ms, consistent direction, tighter tails).
- `--dry=json` byte-identical; `cargo test -p turborepo-lib` 432 passing.
