### PR TITLE
test: Add end-to-end coverage for Cargo workspaces

### DIFF
--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -6,7 +6,7 @@ This document serves as a sketch of the architecture of the `turbo run` command
 
 A run consists of the following steps:
 
-1. Build a package graph based on the Javascript package manager settings
+1. Build a package graph based on the JavaScript package manager settings (and, behind `futureFlags.experimentalCargoWorkspaces`, Cargo workspace crates)
 2. Build a task graph based on package dependencies and configuration
 3. Determine global/task hashes
 4. Execute tasks in topological order
@@ -144,6 +144,111 @@ this aligns with how npm, pnpm, and yarn handle cyclic workspace deps. Cycle
 detection is deferred to the task graph layer (engine builder), since
 package-level cycles only matter when they produce task-level cycles via
 topological (`^`) dependencies.
+
+#### Toolchains (`crates/turborepo-repository/src/toolchain.rs`)
+
+The package graph is generic over language toolchains. A `Toolchain` answers
+ecosystem-specific questions — which packages exist, what command a task
+runs, what hash wiring a task derives — so graph construction and execution
+never branch on a specific ecosystem. All lookups go through the
+`ToolchainRegistry` (carried by the `PackageGraph`); `ToolchainId` is an
+open string identifier, not a closed enum; and trait methods are
+coarse-grained and data-in/data-out, keeping the door open to out-of-process
+plugin adapters. JavaScript is the first, production implementation: its
+discovery, script command construction, and phantom-task detection flow
+through the trait. Machinery that predates the abstraction and has no trait
+surface yet (package-manager resolution for dependency splitting, the JS
+lockfile closure phase) is documented as known debt in the module.
+
+#### Experimental Cargo Support (`crates/turborepo-repository/src/cargo.rs`)
+
+Behind `futureFlags.experimentalCargoWorkspaces` in the root turbo.json,
+`turbo run` also discovers Rust crates from a Cargo workspace at the repo
+root and adds them to the package graph. `CargoToolchain` is the second
+`Toolchain` implementation.
+
+Turborepo does not replace Cargo. Cargo is itself a build system with its
+own dependency graph, scheduler, and incremental cache (`target/`), so the
+division of labor is: **Turborepo decides which crates are in scope and
+whether anything changed; Cargo decides how and in what order to build.**
+
+- **Discovery** (`discover_crates`) shells out to `cargo metadata --no-deps`
+  — Cargo is the only correct implementation of its own membership semantics
+  (member globs, automatic path-dependency members, excludes, target-specific
+  dependency tables, renames). Dev-dependency edges that would form a cycle
+  are dropped (Cargo permits dev-dep cycles; crate edges must support
+  topological `^` ordering). Manifests outside the repository root are
+  skipped, crate names are validated, and a crate/JS package name collision
+  hard-errors. Crate path dependencies are synthesized as `workspace:*`
+  specifiers in the toolchain-neutral descriptor, so the existing dependency
+  splitter wires crate→crate edges.
+- **Package shapes**: crates are classified via `CargoPackageKind`.
+  *Entrypoints* (crates with `bin`/`cdylib`/`staticlib` targets) are the
+  workspace's deliverables. *Libraries* exist in the package graph — so
+  `--filter` and `--affected` propagate through them — but their tasks are
+  no-ops: Cargo builds them implicitly as part of an entrypoint's closure. A
+  synthetic *workspace* package (named `cargo`) depends on every crate and
+  hosts workspace-scoped verbs.
+- **Execution** (`Toolchain::task_command`, adapted into the provider chain
+  by `ToolchainCommandProvider` in `turborepo-task-executor`): entrypoint
+  `build`/`run`/`dev` tasks run `cargo <verb> --package=<crate>` — one cargo
+  process that builds the crate's whole dependency closure with Cargo's own
+  parallelism. Verification verbs run once at workspace scope: `cargo#test`
+  → `cargo test --workspace`, `cargo#lint` → `cargo clippy --workspace`,
+  etc. Cargo commands (except `cargo run`) share a mutually-exclusive
+  serial group: concurrent cargo processes serialize on the build-directory
+  lock anyway, so the executor runs one at a time without the "waiting for
+  file lock" noise. Run summaries derive display commands from the same
+  verb tables via `Toolchain::task_display_command`, so display cannot
+  drift from execution.
+- **Hashing** (`Toolchain::derived_task_io`, consumed by
+  `turborepo-engine/src/builder/definitions.rs`): entrypoint tasks hash
+  their own sources plus their transitive dependency crates' sources
+  (flattened, so invalidation doesn't depend on `dependsOn` wiring), the
+  workspace files (root `Cargo.toml`, `.cargo/config*`, `rust-toolchain*`),
+  and cargo-relevant env vars (`RUSTFLAGS`, `RUSTC_WRAPPER`,
+  `CARGO_TARGET_DIR`, `CARGO_BUILD_TARGET`). The workspace package hashes
+  all crate directories instead of default-hashing the repo root.
+  `$TURBO_DEFAULT$` in a Cargo task's `inputs` means "everything turbo
+  derives automatically", so extra inputs (e.g. a file embedded via
+  `include_str!` from outside any crate directory) are additive.
+- **External dependencies** (`turborepo-lockfiles/src/cargo.rs`): locked
+  registry/git packages and the compiler itself flow through the same
+  external-dependency hash JS packages use
+  (`PackageInfo.transitive_dependencies`). Each crate's closure is computed
+  from `Cargo.lock` (identity = version + source + checksum, so git rev
+  bumps count), so a dependency bump only invalidates crates that actually
+  depend on it. `rustc --version` (resolved from the repo root, so
+  `rust-toolchain` overrides apply) is added to every Cargo package's set —
+  compiling with a different toolchain never restores another toolchain's
+  artifacts. A missing `Cargo.lock` contributes nothing; an unparsable one
+  is a hard error.
+- **Caching**: task caches store logs plus, for entrypoint builds, the
+  deliverables: bins (`target/*/<bin>`) and cdylib/staticlib artifacts
+  (`target/*/lib<name>.{so,dylib,a}`, `<name>.{dll,lib}` — all platform
+  spellings are emitted; unmatched globs contribute nothing). The profile
+  segment is a wildcard, so `--release` and custom profiles cache without
+  configuration — pass-through args participate in the task hash, giving
+  each profile its own cache entry. Cargo's internal `target/` state is
+  deliberately never cached — it is Cargo's own incremental cache, and
+  tarballing it fights Cargo instead of leaning on it (it is also
+  multi-gigabyte). For fine-grained compile caching, `RUSTC_WRAPPER`
+  (sccache) is the sound layer, and it participates in task hashes so
+  toggling it invalidates caches.
+
+A `--filter` that names a crate while support is disabled gets an error
+hint pointing at the flag. Released turbo versions hard-error on unknown
+`futureFlags` keys, so a repo can only adopt the flag once every consumer
+(hooks, CI) runs a version that knows it.
+
+End-to-end coverage lives in `crates/turborepo/tests/cargo_workspace_test.rs`
+against the `cargo_monorepo` fixture (a mixed npm + Cargo workspace):
+graph shape, execution, caching, deliverable restoration, cross-crate
+invalidation, and the filter hint. `turbo query` serves Cargo packages
+through the same graph. Discovery adds roughly 170ms to invocations on a
+~60-crate workspace (`cargo metadata`, `rustc --version`, and lockfile
+parsing); daemon-side caching is the optimization path if that ever
+matters.
 
 ### 3. Task Graph (`crates/turborepo-lib/src/engine/`)
 

--- a/crates/turborepo/tests/cargo_workspace_test.rs
+++ b/crates/turborepo/tests/cargo_workspace_test.rs
@@ -1,0 +1,173 @@
+//! End-to-end tests for experimental Cargo workspace support: a mixed
+//! npm + Cargo fixture driven through the real turbo binary, covering
+//! discovery, execution, caching, invalidation, output restoration, and the
+//! opt-in surface (`futureFlags.experimentalCargoWorkspaces`).
+//!
+//! These tests invoke `cargo build` inside the fixture, so they require a
+//! Rust toolchain — which is guaranteed, since the tests themselves are
+//! built with one.
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+
+mod common;
+
+use std::{fs, path::Path};
+
+use common::{run_turbo, setup};
+
+fn setup_cargo_monorepo(dir: &Path) {
+    setup::setup_integration_test(dir, "cargo_monorepo", "npm@10.5.0", false).unwrap();
+}
+
+/// The fixture's turbo.json opts in via
+/// `futureFlags.experimentalCargoWorkspaces`; no environment variable is
+/// involved anywhere.
+#[test]
+fn test_cargo_packages_in_task_graph() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_cargo_monorepo(tempdir.path());
+
+    let output = run_turbo(tempdir.path(), &["build", "--dry-run=json"]);
+    assert!(output.status.success(), "dry-run failed: {output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("dry-run emits JSON");
+
+    let tasks = json["tasks"].as_array().expect("tasks array");
+    let task =
+        |id: &str| -> Option<&serde_json::Value> { tasks.iter().find(|t| t["taskId"] == id) };
+
+    // The bin crate is an entrypoint: it executes a real cargo command.
+    let app_build = task("app#build").expect("app#build in graph");
+    assert_eq!(app_build["command"], "cargo build --package=app");
+    // Its dependency crate participates in the graph (for --filter/--affected
+    // propagation) but is a no-op — cargo builds it implicitly.
+    let lib_build = task("lib-a#build").expect("lib-a#build in graph");
+    assert_eq!(lib_build["command"], "<NONEXISTENT>");
+    // JS packages coexist in the same graph.
+    let js_build = task("js-pkg#build").expect("js-pkg#build in graph");
+    assert!(
+        js_build["command"]
+            .as_str()
+            .is_some_and(|c| c.contains("echo")),
+        "js task keeps its script command, got {js_build:?}"
+    );
+
+    // The entrypoint's hash covers its dependency crate's sources and the
+    // crate's bin deliverable is the cached output.
+    let inputs: Vec<&str> = app_build["resolvedTaskDefinition"]["inputs"]
+        .as_array()
+        .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
+        .unwrap_or_default();
+    assert!(
+        inputs.iter().any(|i| i.contains("crates/lib-a")),
+        "dependency crate sources must be inputs, got {inputs:?}"
+    );
+    let outputs: Vec<&str> = app_build["resolvedTaskDefinition"]["outputs"]
+        .as_array()
+        .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
+        .unwrap_or_default();
+    assert!(
+        outputs.iter().any(|o| o.ends_with("target/*/app")),
+        "bin deliverable must be an output, got {outputs:?}"
+    );
+}
+
+#[test]
+fn test_cargo_build_executes_caches_and_restores() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_cargo_monorepo(tempdir.path());
+
+    // Cold: executes cargo.
+    let output = run_turbo(
+        tempdir.path(),
+        &["build", "--filter=app", "--log-order", "grouped"],
+    );
+    assert!(output.status.success(), "cold build failed: {output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("cache miss"), "expected miss: {stdout}");
+    let bin = tempdir
+        .path()
+        .join("target")
+        .join("debug")
+        .join(if cfg!(windows) { "app.exe" } else { "app" });
+    assert!(bin.exists(), "cargo build must produce the binary");
+
+    // Warm: everything from cache.
+    let output = run_turbo(
+        tempdir.path(),
+        &["build", "--filter=app", "--log-order", "grouped"],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("FULL TURBO"),
+        "second run should be fully cached: {stdout}"
+    );
+
+    // Deleting the deliverable and re-running restores it from cache
+    // without executing cargo.
+    fs::remove_file(&bin).unwrap();
+    let output = run_turbo(
+        tempdir.path(),
+        &["build", "--filter=app", "--log-order", "grouped"],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("FULL TURBO"),
+        "restore run should be fully cached: {stdout}"
+    );
+    assert!(bin.exists(), "deliverable must be restored from cache");
+}
+
+#[test]
+fn test_dependency_crate_change_invalidates_entrypoint() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_cargo_monorepo(tempdir.path());
+
+    let output = run_turbo(tempdir.path(), &["build", "--filter=app"]);
+    assert!(output.status.success(), "cold build failed: {output:?}");
+
+    // Content change in the dependency crate must invalidate the
+    // entrypoint's task, with no dependsOn wiring in the fixture's
+    // turbo.json beyond the default ^build.
+    let lib = tempdir.path().join("crates/lib-a/src/lib.rs");
+    fs::write(
+        &lib,
+        "pub fn greeting() -> &'static str {\n    \"changed\"\n}\n",
+    )
+    .unwrap();
+
+    let output = run_turbo(
+        tempdir.path(),
+        &["build", "--filter=app", "--log-order", "grouped"],
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("cache miss"),
+        "dependency source change must invalidate the entrypoint: {stdout}"
+    );
+}
+
+#[test]
+fn test_filter_hint_when_cargo_disabled() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_cargo_monorepo(tempdir.path());
+
+    // Remove the opt-in: crates vanish from the graph, and filtering for
+    // one should point the user at the flag.
+    fs::write(
+        tempdir.path().join("turbo.json"),
+        r#"{ "tasks": { "build": { "dependsOn": ["^build"] } } }"#,
+    )
+    .unwrap();
+
+    let output = run_turbo(tempdir.path(), &["build", "--filter=app"]);
+    assert!(!output.status.success(), "filter miss must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("No package found with name 'app'"),
+        "expected filter miss: {stderr}"
+    );
+    assert!(
+        stderr.contains("experimentalCargoWorkspaces"),
+        "expected the opt-in hint: {stderr}"
+    );
+}

--- a/turborepo-tests/integration/fixtures/cargo_monorepo/.gitignore
+++ b/turborepo-tests/integration/fixtures/cargo_monorepo/.gitignore
@@ -1,0 +1,3 @@
+target/
+node_modules/
+.turbo/

--- a/turborepo-tests/integration/fixtures/cargo_monorepo/Cargo.toml
+++ b/turborepo-tests/integration/fixtures/cargo_monorepo/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+members = ["crates/*"]
+resolver = "2"

--- a/turborepo-tests/integration/fixtures/cargo_monorepo/crates/app/Cargo.toml
+++ b/turborepo-tests/integration/fixtures/cargo_monorepo/crates/app/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "app"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+lib-a = { path = "../lib-a" }

--- a/turborepo-tests/integration/fixtures/cargo_monorepo/crates/app/src/main.rs
+++ b/turborepo-tests/integration/fixtures/cargo_monorepo/crates/app/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("{}", lib_a::greeting());
+}

--- a/turborepo-tests/integration/fixtures/cargo_monorepo/crates/lib-a/Cargo.toml
+++ b/turborepo-tests/integration/fixtures/cargo_monorepo/crates/lib-a/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "lib-a"
+version = "0.1.0"
+edition = "2021"

--- a/turborepo-tests/integration/fixtures/cargo_monorepo/crates/lib-a/src/lib.rs
+++ b/turborepo-tests/integration/fixtures/cargo_monorepo/crates/lib-a/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn greeting() -> &'static str {
+    "hello from lib-a"
+}

--- a/turborepo-tests/integration/fixtures/cargo_monorepo/package-lock.json
+++ b/turborepo-tests/integration/fixtures/cargo_monorepo/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "name": "cargo-monorepo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cargo-monorepo",
+      "workspaces": ["packages/**"]
+    },
+    "node_modules/js-pkg": {
+      "resolved": "packages/js-pkg",
+      "link": true
+    },
+    "packages/js-pkg": {
+      "name": "js-pkg",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/turborepo-tests/integration/fixtures/cargo_monorepo/package.json
+++ b/turborepo-tests/integration/fixtures/cargo_monorepo/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "cargo-monorepo",
+  "private": true,
+  "packageManager": "npm@10.5.0",
+  "workspaces": ["packages/**"]
+}

--- a/turborepo-tests/integration/fixtures/cargo_monorepo/packages/js-pkg/package.json
+++ b/turborepo-tests/integration/fixtures/cargo_monorepo/packages/js-pkg/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "js-pkg",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "echo js-pkg built"
+  }
+}

--- a/turborepo-tests/integration/fixtures/cargo_monorepo/turbo.json
+++ b/turborepo-tests/integration/fixtures/cargo_monorepo/turbo.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": { "experimentalCargoWorkspaces": true },
+  "tasks": {
+    "build": {
+      "outputs": ["dist/**"],
+      "dependsOn": ["^build"]
+    }
+  }
+}


### PR DESCRIPTION
## Why

The Cargo workspace series (#13227 → #13267) has so far been verified by unit tests plus manual smoke runs documented in each PR. This PR turns that manual verification into a permanent e2e suite driving the **real turbo binary** against a mixed npm + Cargo fixture, so the full feature surface — discovery through caching — is guarded on all three CI platforms. It also lands the ARCHITECTURE.md documentation for the toolchain abstraction and Cargo support.

## What

- `turborepo-tests/integration/fixtures/cargo_monorepo`: an npm workspace (`js-pkg`) plus a Cargo workspace (`app` bin crate → `lib-a` library), opted in via `futureFlags.experimentalCargoWorkspaces` — no env vars anywhere. `.turbo/` is gitignored, matching real-world configuration (task logs would otherwise churn default input hashing)
- `crates/turborepo/tests/cargo_workspace_test.rs`, four tests:
  - **Graph shape**: `app#build` = `cargo build --package=app`, `lib-a#build` = no-op, JS coexists, dependency-crate sources in inputs, `target/*/app` in outputs
  - **Execute/cache/restore**: cold run executes cargo; second run FULL TURBO; deleted binary restored from cache without executing cargo
  - **Cross-crate invalidation**: editing `lib-a` sources invalidates `app#build` with no `dependsOn` wiring
  - **Filter hint**: flag removed → `--filter=app` fails with the `experimentalCargoWorkspaces` hint
- ARCHITECTURE.md: new Toolchains section (registry, open ids, JS as first implementor, documented debt) and the Experimental Cargo Support section covering everything landed so far (discovery, package shapes, execution + serial groups, derived hashing, per-crate lockfile closures + rustc stamp, deliverable caching). Watch/prune sections come with their PRs

## How

Tests require a Rust toolchain, which is guaranteed — they are built with one. Verified on the devbox: all four pass against the freshly built binary (~3s total; the fixture crate is trivial). No production code changes in this PR.