### PR TITLE
feat: Make turbo watch Cargo-aware

### DIFF
--- a/crates/turborepo-lib/src/commands/daemon.rs
+++ b/crates/turborepo-lib/src/commands/daemon.rs
@@ -343,15 +343,29 @@ pub async fn daemon_server(
         exit_signal,
         custom_turbo_json_path,
         allow_no_package_manager,
-        |args| {
-            PackageChangesWatcher::new(
-                args.repo_root,
-                args.file_events,
-                args.hash_watcher,
-                args.custom_turbo_json_path,
-                false,
-                args.allow_no_package_manager,
-            )
+        {
+            let cargo_enabled = crate::run::builder::cargo_enabled(&base.opts().future_flags);
+            move |args| {
+                // Mirror the run builder: the daemon-side watcher must see
+                // the same package set a run would.
+                let mut extra_toolchains: Vec<
+                    std::sync::Arc<dyn turborepo_repository::toolchain::Toolchain>,
+                > = Vec::new();
+                if cargo_enabled {
+                    extra_toolchains.push(turborepo_repository::cargo::CargoToolchain::new(
+                        args.repo_root.clone(),
+                    ));
+                }
+                PackageChangesWatcher::new(
+                    args.repo_root,
+                    args.file_events,
+                    args.hash_watcher,
+                    args.custom_turbo_json_path,
+                    false,
+                    args.allow_no_package_manager,
+                    extra_toolchains,
+                )
+            }
         },
     );
 

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -21,6 +21,7 @@ use turborepo_repository::{
     },
     package_graph::{PackageGraph, PackageGraphBuilder, PackageName, WorkspacePackage},
     package_json::PackageJson,
+    toolchain::{Toolchain, WatchSpec},
 };
 use turborepo_scm::GitHashes;
 
@@ -58,6 +59,7 @@ pub(crate) fn startup_timeout_secs() -> u64 {
 }
 
 impl PackageChangesWatcher {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         repo_root: AbsoluteSystemPathBuf,
         file_events_lazy: OptionalWatch<broadcast::Receiver<Result<Event, NotifyError>>>,
@@ -65,6 +67,7 @@ impl PackageChangesWatcher {
         custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
         single_package: bool,
         allow_no_package_manager: bool,
+        extra_toolchains: Vec<Arc<dyn Toolchain>>,
     ) -> Self {
         let (exit_tx, exit_rx) = oneshot::channel();
         let (package_change_events_tx, package_change_events_rx) =
@@ -77,6 +80,7 @@ impl PackageChangesWatcher {
             custom_turbo_json_path,
             single_package,
             allow_no_package_manager,
+            extra_toolchains,
         );
 
         let _handle = tokio::spawn(subscriber.watch(exit_rx));
@@ -124,6 +128,10 @@ struct Subscriber {
     custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
     single_package: bool,
     allow_no_package_manager: bool,
+    /// Toolchains registered in addition to JavaScript (e.g. Cargo when
+    /// futureFlags.experimentalCargoWorkspaces is enabled), mirroring the
+    /// run builder so the watcher sees the same package graph a run would.
+    extra_toolchains: Vec<Arc<dyn Toolchain>>,
 }
 
 // This is a workaround because `ignore` doesn't match against a path's
@@ -183,6 +191,7 @@ fn classify_changed_files(
     root_gitignore: &Gitignore,
     custom_turbo_json_path: Option<&AbsoluteSystemPathBuf>,
     change_mapper: &ChangeMapper<'_, GlobalDepsPackageChangeMapper<'_>>,
+    watch_spec: &WatchSpec,
 ) -> FileChangeAction {
     let turbo_json_path = repo_root.join_component(CONFIG_FILE);
     let turbo_jsonc_path = repo_root.join_component(CONFIG_FILE_JSONC);
@@ -198,6 +207,48 @@ fn classify_changed_files(
         return FileChangeAction::ConfigChanged;
     }
 
+    // Whether an anchored path is under one of the toolchains'
+    // build-byproduct directories.
+    let in_ignored_prefix = |path: &AnchoredSystemPathBuf| {
+        watch_spec.ignore_prefixes.iter().any(|prefix| {
+            path.components()
+                .next()
+                .is_some_and(|component| component.as_str() == prefix)
+        })
+    };
+
+    // Toolchain workspace-definition files (e.g. Cargo manifests and the
+    // Cargo lockfile) define the package set and its edges; the watcher's
+    // package graph is stale after any of them change, so trigger full
+    // rediscovery. Definition-named files inside a byproduct directory
+    // (e.g. a Cargo.toml cargo itself writes under target/) are exempt.
+    if !watch_spec.definition_file_names.is_empty() || !watch_spec.definition_paths.is_empty() {
+        let definition_changed = trie.keys().any(|p| {
+            let Some(anchored) = AbsoluteSystemPathBuf::new(p)
+                .ok()
+                .and_then(|p| repo_root.anchor(p).ok())
+            else {
+                return false;
+            };
+            if in_ignored_prefix(&anchored) {
+                return false;
+            }
+            let unix = anchored.to_unix();
+            watch_spec
+                .definition_paths
+                .iter()
+                .any(|path| unix.as_str() == path)
+                || watch_spec.definition_file_names.iter().any(|name| {
+                    std::path::Path::new(p)
+                        .file_name()
+                        .is_some_and(|file_name| file_name == name.as_str())
+                })
+        });
+        if definition_changed {
+            return FileChangeAction::ConfigChanged;
+        }
+    }
+
     let changed_files: HashSet<_> = trie
         .keys()
         .filter_map(|p| {
@@ -211,6 +262,11 @@ fn classify_changed_files(
             repo_root.anchor(p).ok()
         })
         .filter(|p| !(ancestors_is_ignored(root_gitignore, p) || is_in_git_folder(p)))
+        // Toolchain build byproducts (e.g. Cargo's target/) are written
+        // continuously by the very tasks a change would re-trigger; letting
+        // them through would create a feedback loop. Usually gitignored and
+        // dropped above, but the loop must not depend on that.
+        .filter(|p| !in_ignored_prefix(p))
         .collect();
 
     if changed_files.is_empty() {
@@ -251,6 +307,7 @@ impl RepoState {
 }
 
 impl Subscriber {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         repo_root: AbsoluteSystemPathBuf,
         file_events_lazy: OptionalWatch<broadcast::Receiver<Result<Event, NotifyError>>>,
@@ -259,6 +316,7 @@ impl Subscriber {
         custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
         single_package: bool,
         allow_no_package_manager: bool,
+        extra_toolchains: Vec<Arc<dyn Toolchain>>,
     ) -> Self {
         // Try to canonicalize the custom path to match what the file watcher reports
         let normalized_custom_path = custom_turbo_json_path.map(|path| {
@@ -301,6 +359,7 @@ impl Subscriber {
             custom_turbo_json_path: normalized_custom_path,
             single_package,
             allow_no_package_manager,
+            extra_toolchains,
         }
     }
 
@@ -311,13 +370,13 @@ impl Subscriber {
             tracing::debug!("no package.json found, package watcher not available");
             return None;
         };
-        let Ok(pkg_dep_graph) =
-            PackageGraphBuilder::new(&self.repo_root, root_package_json.clone())
-                .with_single_package_mode(self.single_package)
-                .with_allow_no_package_manager(self.allow_no_package_manager)
-                .build()
-                .await
-        else {
+        let mut builder = PackageGraphBuilder::new(&self.repo_root, root_package_json.clone())
+            .with_single_package_mode(self.single_package)
+            .with_allow_no_package_manager(self.allow_no_package_manager);
+        for toolchain in &self.extra_toolchains {
+            builder = builder.with_toolchain(toolchain.clone());
+        }
+        let Ok(pkg_dep_graph) = builder.build().await else {
             tracing::debug!("package graph not available, package watcher not available");
             return None;
         };
@@ -554,12 +613,14 @@ impl Subscriber {
                     root_gitignore = new_root_gitignore;
                 }
 
+                let watch_spec = repo_state.pkg_dep_graph.toolchains().watch_spec();
                 let action = classify_changed_files(
                     &trie,
                     &self.repo_root,
                     &root_gitignore,
                     self.custom_turbo_json_path.as_ref(),
                     &change_mapper,
+                    &watch_spec,
                 );
                 tracing::debug!(?action, "classified file changes");
 
@@ -647,6 +708,7 @@ mod test {
         change_mapper::{ChangeMapper, GlobalDepsPackageChangeMapper, PackageChanges},
         package_graph::{PackageGraph, PackageGraphBuilder},
         package_json::PackageJson,
+        toolchain::WatchSpec,
     };
     use turborepo_scm::SCM;
 
@@ -729,6 +791,21 @@ mod test {
             gitignore_lines: &[&str],
             custom_turbo_json: Option<&AbsoluteSystemPathBuf>,
         ) -> FileChangeAction {
+            self.classify_with_spec(
+                trie,
+                gitignore_lines,
+                custom_turbo_json,
+                WatchSpec::default(),
+            )
+        }
+
+        fn classify_with_spec(
+            &self,
+            trie: &Trie<String, ()>,
+            gitignore_lines: &[&str],
+            custom_turbo_json: Option<&AbsoluteSystemPathBuf>,
+            watch_spec: WatchSpec,
+        ) -> FileChangeAction {
             let mapper =
                 GlobalDepsPackageChangeMapper::new(&self.pkg_graph, std::iter::empty::<&str>())
                     .unwrap();
@@ -740,6 +817,7 @@ mod test {
                 &gitignore,
                 custom_turbo_json,
                 &change_mapper,
+                &watch_spec,
             )
         }
     }
@@ -862,6 +940,71 @@ mod test {
 
         let action = f.classify(&trie, &[], None);
         assert!(matches!(action, FileChangeAction::ConfigChanged));
+    }
+
+    #[tokio::test]
+    async fn classify_cargo_manifest_triggers_rediscovery() {
+        let f = ClassifyFixture::new().await;
+        let manifest = f
+            .repo_root
+            .join_components(&["crates", "foo", "Cargo.toml"]);
+        let mut trie = Trie::new();
+        trie.insert(manifest.to_string(), ());
+
+        // Manifests define the crate set and its edges; the watcher's graph
+        // is stale after any manifest change.
+        let action =
+            f.classify_with_spec(&trie, &[], None, turborepo_repository::cargo::watch_spec());
+        assert!(matches!(action, FileChangeAction::ConfigChanged));
+
+        // Without the Cargo toolchain registered, the same file is ordinary
+        // content.
+        let action = f.classify_with_spec(&trie, &[], None, WatchSpec::default());
+        assert!(matches!(action, FileChangeAction::PackagesChanged(..)));
+    }
+
+    #[tokio::test]
+    async fn classify_cargo_lock_triggers_rediscovery() {
+        let f = ClassifyFixture::new().await;
+        let lock = f.repo_root.join_component("Cargo.lock");
+        let mut trie = Trie::new();
+        trie.insert(lock.to_string(), ());
+
+        let action =
+            f.classify_with_spec(&trie, &[], None, turborepo_repository::cargo::watch_spec());
+        assert!(matches!(action, FileChangeAction::ConfigChanged));
+    }
+
+    #[tokio::test]
+    async fn classify_target_dir_writes_ignored() {
+        let f = ClassifyFixture::new().await;
+        let mut trie = Trie::new();
+        // Build byproducts, including a manifest cargo itself writes under
+        // target/ — neither may re-trigger the tasks that produced them.
+        trie.insert(
+            f.repo_root
+                .join_components(&["target", "debug", "foo"])
+                .to_string(),
+            (),
+        );
+        trie.insert(
+            f.repo_root
+                .join_components(&["target", "package", "foo", "Cargo.toml"])
+                .to_string(),
+            (),
+        );
+
+        let action =
+            f.classify_with_spec(&trie, &[], None, turborepo_repository::cargo::watch_spec());
+        assert!(
+            matches!(action, FileChangeAction::NoRelevantChanges),
+            "target/ writes must be dropped, got {action:?}"
+        );
+
+        // Without the Cargo toolchain, a directory named target/ is
+        // ordinary.
+        let action = f.classify_with_spec(&trie, &[], None, WatchSpec::default());
+        assert!(matches!(action, FileChangeAction::PackagesChanged(..)));
     }
 
     #[tokio::test]
@@ -1201,6 +1344,7 @@ mod test {
             None,
             single_package,
             allow_no_package_manager,
+            Vec::new(),
         );
 
         TestWatcherHandle {
@@ -1301,7 +1445,14 @@ mod test {
         let mut trie = Trie::new();
         trie.insert(changed_file.to_string(), ());
 
-        let action = classify_changed_files(&trie, &repo_root, &gitignore, None, &change_mapper);
+        let action = classify_changed_files(
+            &trie,
+            &repo_root,
+            &gitignore,
+            None,
+            &change_mapper,
+            &WatchSpec::default(),
+        );
 
         match &action {
             FileChangeAction::PackagesChanged(PackageChanges::Some(pkgs), _) => {

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -299,6 +299,16 @@ impl WatchClient {
             recv.clone(),
             scm,
         ));
+        // The watcher builds its own package graph; register the same
+        // toolchains a run would so it watches the same package set.
+        let mut extra_toolchains: Vec<
+            std::sync::Arc<dyn turborepo_repository::toolchain::Toolchain>,
+        > = Vec::new();
+        if crate::run::builder::cargo_enabled(&base.opts().future_flags) {
+            extra_toolchains.push(turborepo_repository::cargo::CargoToolchain::new(
+                base.repo_root.clone(),
+            ));
+        }
         let package_changes_watcher = PackageChangesWatcher::new(
             base.repo_root.clone(),
             recv,
@@ -306,6 +316,7 @@ impl WatchClient {
             custom_turbo_json_path,
             base.opts().run_opts.single_package,
             base.opts().repo_opts.allow_no_package_manager,
+            extra_toolchains,
         );
 
         // Subscribe before building the Run so we don't miss the initial

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -432,6 +432,10 @@ impl Toolchain for CargoToolchain {
             .is_some()
     }
 
+    fn watch_spec(&self) -> toolchain::WatchSpec {
+        watch_spec()
+    }
+
     fn derived_task_io(
         &self,
         package: &crate::package_graph::PackageInfo,
@@ -612,6 +616,26 @@ impl Toolchain for CargoToolchain {
 
             Ok(packages)
         })
+    }
+}
+
+/// The Cargo default build directory, relative to the repo root.
+pub const TARGET_DIR: &str = "target";
+
+/// How filesystem events relate to Cargo in watch mode. Manifests and the
+/// lockfile define the crate set and its edges — any change makes the
+/// watcher's package graph stale, so they trigger full rediscovery
+/// (`Cargo.toml` files under `target/` are build byproducts, not workspace
+/// definition, and are exempted via the ignore prefix). Events under the
+/// root `target/` directory are dropped entirely: Cargo writes there
+/// continuously during builds, and letting those events through would
+/// re-trigger the very tasks that produced them — usually `target/` is
+/// gitignored, but a feedback loop must not depend on a `.gitignore` entry.
+pub fn watch_spec() -> toolchain::WatchSpec {
+    toolchain::WatchSpec {
+        definition_file_names: vec![CARGO_TOML.to_string()],
+        definition_paths: vec![CARGO_LOCK.to_string()],
+        ignore_prefixes: vec![TARGET_DIR.to_string()],
     }
 }
 

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -239,6 +239,42 @@ pub trait Toolchain: Send + Sync {
         );
         None
     }
+
+    /// How filesystem events relate to this toolchain in watch mode:
+    /// workspace-definition files whose change requires rediscovery, and
+    /// build-byproduct directories whose events must be ignored.
+    fn watch_spec(&self) -> WatchSpec {
+        WatchSpec::default()
+    }
+}
+
+/// How filesystem events relate to a toolchain in watch mode. See
+/// [`Toolchain::watch_spec`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WatchSpec {
+    /// Manifest file names that define the toolchain's workspace membership
+    /// or edges wherever they appear in the repository (outside
+    /// [`WatchSpec::ignore_prefixes`]): a change means the package set may
+    /// have changed, requiring full rediscovery.
+    pub definition_file_names: Vec<String>,
+    /// Repo-root-relative unix paths that define the workspace, with the
+    /// same rediscovery consequence.
+    pub definition_paths: Vec<String>,
+    /// Repo-root-relative unix directory prefixes containing the
+    /// toolchain's own build byproducts. Events under them are dropped:
+    /// they are written by the very tasks a change would re-trigger, and
+    /// must not feed back into the watcher even when not gitignored.
+    pub ignore_prefixes: Vec<String>,
+}
+
+impl WatchSpec {
+    /// Merge another spec into this one.
+    pub fn extend(&mut self, other: WatchSpec) {
+        self.definition_file_names
+            .extend(other.definition_file_names);
+        self.definition_paths.extend(other.definition_paths);
+        self.ignore_prefixes.extend(other.ignore_prefixes);
+    }
 }
 
 /// Hash wiring derived by a toolchain for one task. See
@@ -291,6 +327,15 @@ impl ToolchainRegistry {
 
     pub fn iter(&self) -> impl Iterator<Item = &dyn Toolchain> {
         self.toolchains.iter().map(AsRef::as_ref)
+    }
+
+    /// The union of every registered toolchain's [`WatchSpec`].
+    pub fn watch_spec(&self) -> WatchSpec {
+        let mut merged = WatchSpec::default();
+        for toolchain in self.iter() {
+            merged.extend(toolchain.watch_spec());
+        }
+        merged
     }
 }
 
@@ -481,6 +526,16 @@ impl<P: PackageDiscovery + Send + Sync> Toolchain for JavaScriptToolchain<P> {
         // whatever the user declares, and no tool-level files or env vars
         // are implied. This is the real answer, not an unimplemented stub.
         None
+    }
+
+    fn watch_spec(&self) -> WatchSpec {
+        // Deliberately nothing: JavaScript workspace redefinition (a new or
+        // removed package.json, a lockfile change) is caught by the change
+        // mapper's conservative fallback — unattributable files map to
+        // "all packages", which triggers rediscovery — and JS build outputs
+        // land inside package directories where gitignore filtering already
+        // applies. This is the real answer, not an unimplemented stub.
+        WatchSpec::default()
     }
 
     fn discover_packages(&self) -> DiscoverPackagesFuture<'_> {

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -236,6 +236,22 @@ whether anything changed; Cargo decides how and in what order to build.**
   (sccache) is the sound layer, and it participates in task hashes so
   toggling it invalidates caches.
 
+- **Watch mode** (`Toolchain::watch_spec`, consumed by
+  `turborepo-lib/src/package_changes_watcher.rs`): each toolchain declares
+  its workspace-definition files and build-byproduct directories. For
+  Cargo, any `Cargo.toml` or the root `Cargo.lock` triggers full
+  rediscovery (the crate set or its edges may have changed), while events
+  under the root `target/` directory are dropped — Cargo writes there
+  continuously during builds, and the feedback loop must not depend on a
+  `.gitignore` entry (`Cargo.toml` files under `target/` are build
+  byproducts, not workspace definition). The watcher builds its package
+  graph with the same toolchains a run would register, so watch sees the
+  same package set. JavaScript declares nothing extra: workspace
+  redefinition is caught by the change mapper's conservative
+  all-packages fallback. Known gap: the hash watcher's content-hash dedup
+  is JS-glob-based, so a no-op save inside a crate re-runs its tasks as a
+  fast cache hit rather than being suppressed.
+
 A `--filter` that names a crate while support is disabled gets an error
 hint pointing at the flag. Released turbo versions hard-error on unknown
 `futureFlags` keys, so a repo can only adopt the flag once every consumer

--- a/packages/turbo-repository/rust/src/internal.rs
+++ b/packages/turbo-repository/rust/src/internal.rs
@@ -71,21 +71,19 @@ impl Workspace {
         // declaration is missing or unusable — mirroring the CLI's
         // `--dangerously-allow-missing-package-manager` behavior. If detection
         // also fails, surface the original declaration error below.
-        if workspace_state.package_manager.is_err() {
-            if let Ok(detected) =
+        if workspace_state.package_manager.is_err()
+            && let Ok(detected) =
                 package_manager::PackageManager::detect_package_manager(&workspace_state.root)
-            {
-                // `mode` was derived while the package manager was unresolved,
-                // so workspace globs could not be read; recompute it with the
-                // detected package manager.
-                workspace_state.mode =
-                    if detected.get_workspace_globs(&workspace_state.root).is_ok() {
-                        WorkspaceType::MultiPackage
-                    } else {
-                        WorkspaceType::SinglePackage
-                    };
-                workspace_state.package_manager = Ok(detected);
-            }
+        {
+            // `mode` was derived while the package manager was unresolved,
+            // so workspace globs could not be read; recompute it with the
+            // detected package manager.
+            workspace_state.mode = if detected.get_workspace_globs(&workspace_state.root).is_ok() {
+                WorkspaceType::MultiPackage
+            } else {
+                WorkspaceType::SinglePackage
+            };
+            workspace_state.package_manager = Ok(detected);
         }
         let workspace_state = workspace_state;
         let is_multi_package = workspace_state.mode == WorkspaceType::MultiPackage;


### PR DESCRIPTION
## Why

Next in the Cargo workspace series. `turbo watch` in a Cargo-enabled repo has two failure modes today: the watcher's private package graph is JS-only (crate edits map to nothing), and nothing protects against the feedback loop where Cargo's continuous `target/` writes re-trigger the very tasks that produced them. Per the series design, the fix is a trait surface — `Toolchain::watch_spec` — with both implementations stated honestly.

## What

- `Toolchain::watch_spec`: workspace-definition file names/paths (change → full rediscovery) and build-byproduct directory prefixes (events dropped). Plain-string data per the toolchain design rules
- **Cargo**: any `Cargo.toml` or the root `Cargo.lock` triggers rediscovery (the crate set or its edges may have changed); manifests under `target/` are exempt; all events under root `target/` are dropped — the feedback loop must not depend on a `.gitignore` entry
- **JavaScript**: declares nothing extra, documented as the real answer — JS workspace redefinition is already caught by the change mapper's conservative all-packages fallback
- The watcher builds its package graph with the same toolchains a run registers (plumbed from the future flag in `watch.rs` and `daemon.rs`), so watch sees the run's package set
- Known gap documented in ARCHITECTURE.md: hash-watcher content dedup is JS-glob-based, so a no-op crate save re-runs as a fast cache hit
- Rider: one-line collapsible-if fix in `turborepo-napi` that currently breaks `cargo lint` on main (and therefore every contributor's pre-push hook) — flagged here rather than a separate PR since it blocks this branch's own push

## How

Flag off: watcher behavior is unchanged (the merged spec is empty; classify short-circuits identically). Flag on, verified live under `turbo watch` on the `cargo_monorepo` fixture: dependency-crate source edit re-runs the entrypoint; JS edit re-runs only the JS package; writes under `target/` (including a `Cargo.toml` cargo places there) trigger nothing; adding a new crate manifest triggers full rediscovery. Unit coverage: three classify tests (manifest → rediscovery, lockfile → rediscovery, target/ suppression) each asserting the flag-off behavior too.