### PR TITLE
fix: Raise the open-file soft limit at startup

### DIFF
--- a/crates/turborepo-lib/src/lib.rs
+++ b/crates/turborepo-lib/src/lib.rs
@@ -64,7 +64,51 @@ pub fn get_version() -> &'static str {
 pub fn main(
     query_server: Option<std::sync::Arc<dyn turborepo_query_api::QueryServer>>,
 ) -> Result<i32, shim::Error> {
+    raise_open_file_limit();
     shim::run(query_server)
+}
+
+/// Raise the process's soft `RLIMIT_NOFILE` to its hard limit.
+///
+/// Task execution costs several descriptors per live child (pipes or pty),
+/// and default concurrency is ten times the core count, so a large run
+/// needs hundreds of descriptors at once. macOS defaults the soft limit to
+/// 256, which `turbo run` on a many-core machine exhausts at the first
+/// spawn burst (`Too many open files`). Raising the soft limit at startup
+/// is the same remedy Node.js and the Go runtime apply.
+#[cfg(unix)]
+fn raise_open_file_limit() {
+    let mut limit = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    // SAFETY: getrlimit/setrlimit are passed a valid, initialized rlimit.
+    unsafe {
+        if libc::getrlimit(libc::RLIMIT_NOFILE, &mut limit) != 0 || limit.rlim_cur >= limit.rlim_max
+        {
+            return;
+        }
+        let mut raised = limit;
+        // Clamp below the hard limit: tools spawned by tasks may iterate
+        // file descriptors up to the soft limit (the classic `closefrom`
+        // loop), which a million-entry table makes pathological. 65536
+        // covers any realistic spawn burst.
+        raised.rlim_cur = limit.rlim_max.min(65536);
+        if libc::setrlimit(libc::RLIMIT_NOFILE, &raised) != 0 {
+            // macOS reports RLIM_INFINITY as the hard limit but rejects
+            // raising the soft limit past `kern.maxfilesperproc`; its
+            // documented ceiling for unprivileged processes is OPEN_MAX
+            // (10240).
+            raised.rlim_cur = limit.rlim_max.min(10240);
+            let _ = libc::setrlimit(libc::RLIMIT_NOFILE, &raised);
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn raise_open_file_limit() {
+    // Windows has no RLIMIT_NOFILE equivalent; handle limits are already
+    // in the tens of thousands.
 }
 
 #[cfg(all(feature = "native-tls", feature = "rustls-tls"))]


### PR DESCRIPTION
## Why

`turbo run typecheck` in a 1191-package monorepo on a many-core macOS machine fails at the first spawn burst:

```
ERROR unable to spawn child process: Too many open files (os error 24)
```

Task execution costs several parent-side descriptors per live child (pipes/pty, log files), and default concurrency is 10x the core count — hundreds of descriptors at once. macOS defaults the soft `RLIMIT_NOFILE` to 256, and turbo has never raised it. Node.js and the Go runtime both raise the soft limit at startup for exactly this reason.

## What

Raise the soft limit toward the hard limit in `turborepo_lib::main`, clamped to 65536 (tools spawned by tasks may loop-close descriptors up to the soft limit; a million-entry table makes that pathological), with a 10240 fallback for macOS's `setrlimit` ceiling when the hard limit reports as infinity. No-op on Windows.

## How to verify

On Linux with `ulimit -Sn 256` (hard 1048576), a running `turbo run` process's `/proc/pid/limits` shows `Max open files 65536 / 1048576`. Reproduces the macOS default-limit situation; the spawn burst that previously exhausted 256 descriptors now has 65536.
