### PR TITLE
perf: Evaluate simple include globs without wax compilation

### DIFF
--- a/crates/turborepo-globwalk/src/lib.rs
+++ b/crates/turborepo-globwalk/src/lib.rs
@@ -578,8 +578,84 @@ where
 struct CompiledGlobs {
     base_path: PathBuf,
     include_patterns: Vec<Glob<'static>>,
+    /// Include patterns classified from their raw strings as literal paths;
+    /// they never went through wax compilation. Absolute, like the strings
+    /// `preprocess_paths_and_globs` produces.
+    literal_paths: Vec<PathBuf>,
+    /// Include patterns classified from their raw strings as
+    /// `<prefix>/*/<suffix>` shapes; they never went through wax
+    /// compilation.
+    shallow_wildcards: Vec<(PathBuf, PathBuf)>,
     ex_patterns: Vec<Glob<'static>>,
     ex_filter: FilterAny,
+}
+
+/// A preprocessed include pattern classified from its raw string, without
+/// wax compilation. Compiling a wax glob costs 1-2ms of regex
+/// construction, and workspace discovery hands us ~20 patterns during the
+/// most CPU-contended window of startup — while the overwhelmingly common
+/// shapes (`packages/foo/package.json`, `packages/*/package.json`) need no
+/// pattern matching at all to evaluate.
+enum SimplePattern {
+    /// No metacharacters anywhere: a concrete path, resolvable by one stat.
+    Literal(PathBuf),
+    /// Exactly one bare `*` segment with a non-empty literal suffix:
+    /// resolvable by one readdir plus a stat per child.
+    Shallow(PathBuf, PathBuf),
+    /// Anything else — compile with wax as before.
+    Complex,
+}
+
+/// Classify a preprocessed (absolute) glob pattern string. Deliberately
+/// conservative: every byte outside a small known-plain set (or a segment
+/// that is anything other than exactly `*`) sends the pattern to wax, so
+/// escapes, character classes, alternations, and wax's extended syntax are
+/// never reinterpreted here.
+fn classify_simple_pattern(pattern: &str) -> SimplePattern {
+    fn plain_segment(segment: &str) -> bool {
+        !segment.is_empty()
+            && segment.bytes().all(|b| {
+                b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-' | b'@' | b'+' | b' ')
+            })
+    }
+
+    // Windows drive prefixes (`C:`) contain a colon; the leading empty
+    // segment from the root `/` is skipped.
+    let segments: Vec<&str> = pattern.split('/').skip_while(|s| s.is_empty()).collect();
+    if segments.is_empty() {
+        return SimplePattern::Complex;
+    }
+    let mut star_index = None;
+    for (index, segment) in segments.iter().enumerate() {
+        if *segment == "*" {
+            if star_index.is_some() {
+                return SimplePattern::Complex;
+            }
+            star_index = Some(index);
+        } else if index == 0 && is_plain_windows_drive(segment) {
+            // Allowed: `C:`-style prefix opening a Windows absolute pattern.
+        } else if !plain_segment(segment) {
+            return SimplePattern::Complex;
+        }
+    }
+
+    let root = if pattern.starts_with('/') { "/" } else { "" };
+    match star_index {
+        None => SimplePattern::Literal(PathBuf::from(format!("{root}{}", segments.join("/")))),
+        // Require at least one suffix segment after the star — `dir/*`
+        // matches files directly and keeps the full walker.
+        Some(index) if index + 1 < segments.len() && index > 0 => SimplePattern::Shallow(
+            PathBuf::from(format!("{root}{}", segments[..index].join("/"))),
+            segments[index + 1..].iter().collect(),
+        ),
+        Some(_) => SimplePattern::Complex,
+    }
+}
+
+/// `C:`-style drive segment at the start of a Windows absolute pattern.
+fn is_plain_windows_drive(segment: &str) -> bool {
+    let bytes = segment.as_bytes();
+    bytes.len() == 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
 }
 
 #[tracing::instrument(skip(include, exclude))]
@@ -599,7 +675,21 @@ fn compile_globs<S: AsRef<str>>(
     let ex_filter = FilterAny::any(ex_patterns.clone())
         .map_err(|e| WalkError::BadPattern("exclusion".into(), Box::new(e)))?;
 
-    let include_patterns = include_paths
+    // Evaluate simple shapes without wax: compiling a glob costs 1-2ms of
+    // regex construction each, which dwarfs the walk itself for the common
+    // literal and `<prefix>/*/<suffix>` workspace patterns.
+    let mut literal_paths = Vec::new();
+    let mut shallow_wildcards = Vec::new();
+    let mut complex_paths = Vec::new();
+    for path in include_paths {
+        match classify_simple_pattern(&path) {
+            SimplePattern::Literal(path) => literal_paths.push(path),
+            SimplePattern::Shallow(prefix, suffix) => shallow_wildcards.push((prefix, suffix)),
+            SimplePattern::Complex => complex_paths.push(path),
+        }
+    }
+
+    let include_patterns = complex_paths
         .into_par_iter()
         .map(glob_with_contextual_error)
         .collect::<Result<Vec<_>, _>>()?;
@@ -607,6 +697,8 @@ fn compile_globs<S: AsRef<str>>(
     Ok(CompiledGlobs {
         base_path: base_path_new,
         include_patterns,
+        literal_paths,
+        shallow_wildcards,
         ex_patterns,
         ex_filter,
     })
@@ -695,24 +787,31 @@ fn walk_compiled_globs(
     //    single glob walker would sequentially traverse hundreds of entries.
     // 3. General variant — full wax directory walk (one rayon task per pattern).
     let mut literal_results: Vec<AbsoluteSystemPathBuf> = Vec::new();
-    let mut shallow_wildcards: Vec<(PathBuf, PathBuf)> = Vec::new();
+    let mut shallow_wildcards: Vec<(PathBuf, PathBuf)> = compiled.shallow_wildcards.clone();
     let mut variant_globs: Vec<&Glob<'static>> = Vec::new();
+
+    let mut check_literal = |full_path: PathBuf| {
+        let dominated = full_path
+            .symlink_metadata()
+            .ok()
+            .is_some_and(|m| match walk_type {
+                WalkType::Files => m.is_file() || m.is_symlink(),
+                WalkType::Folders => m.is_dir(),
+                WalkType::All => true,
+            });
+        if dominated && let Ok(abs) = AbsoluteSystemPathBuf::try_from(full_path.as_path()) {
+            literal_results.push(abs);
+        }
+    };
+
+    for path in &compiled.literal_paths {
+        check_literal(compiled.base_path.join(path));
+    }
 
     for glob in &compiled.include_patterns {
         if let Some(path) = glob.variance().path() {
             // Invariant: no wildcards at all — single stat.
-            let full_path = compiled.base_path.join(path);
-            let dominated = full_path
-                .symlink_metadata()
-                .ok()
-                .is_some_and(|m| match walk_type {
-                    WalkType::Files => m.is_file() || m.is_symlink(),
-                    WalkType::Folders => m.is_dir(),
-                    WalkType::All => true,
-                });
-            if dominated && let Ok(abs) = AbsoluteSystemPathBuf::try_from(full_path.as_path()) {
-                literal_results.push(abs);
-            }
+            check_literal(compiled.base_path.join(path));
         } else if let Some(decomposed) = try_decompose_shallow_wildcard(&compiled.base_path, glob) {
             shallow_wildcards.push(decomposed);
         } else {
@@ -846,6 +945,80 @@ fn visit_file(
                 std::io::ErrorKind::NotFound | std::io::ErrorKind::PermissionDenied => None,
                 _ => Some(Err(io_err.into())),
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod classify_test {
+    use std::path::PathBuf;
+
+    use super::{SimplePattern, classify_simple_pattern};
+
+    fn classify(pattern: &str) -> SimplePattern {
+        classify_simple_pattern(pattern)
+    }
+
+    #[test]
+    fn test_literals() {
+        for pattern in [
+            "/repo/package.json",
+            "/repo/apps/docs 2.0/package.json",
+            "/repo/.github/actions/package.json",
+            "C:/repo/pkg/package.json",
+            "/repo/a+b/x@y/pkg_1.tgz",
+        ] {
+            match classify(pattern) {
+                SimplePattern::Literal(path) => assert_eq!(path, PathBuf::from(pattern)),
+                _ => panic!("{pattern} should classify as literal"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_shallow() {
+        match classify("/repo/packages/*/package.json") {
+            SimplePattern::Shallow(prefix, suffix) => {
+                assert_eq!(prefix, PathBuf::from("/repo/packages"));
+                assert_eq!(suffix, PathBuf::from("package.json"));
+            }
+            _ => panic!("should classify as shallow"),
+        }
+        match classify("/repo/platform/kinds/*/hooks/package.json") {
+            SimplePattern::Shallow(prefix, suffix) => {
+                assert_eq!(prefix, PathBuf::from("/repo/platform/kinds"));
+                assert_eq!(suffix, PathBuf::from("hooks/package.json"));
+            }
+            _ => panic!("should classify as shallow"),
+        }
+    }
+
+    #[test]
+    fn test_complex_falls_through_to_wax() {
+        for pattern in [
+            // Star without a suffix matches files directly.
+            "/repo/packages/*",
+            // Multiple or embedded stars.
+            "/repo/*/x/*/package.json",
+            "/repo/pkg-*/package.json",
+            "/repo/packages/**/package.json",
+            // Star as the first segment has no readdir prefix.
+            "*/package.json",
+            // Metacharacters, escapes, and wax extended syntax.
+            "/repo/p?g/package.json",
+            "/repo/p[ab]g/package.json",
+            "/repo/{a,b}/package.json",
+            "/repo/a\\*b/package.json",
+            "/repo/<a:1,2>/package.json",
+            "/repo/a!b/package.json",
+            // Trailing slash and empty input.
+            "/repo/pkg/",
+            "",
+        ] {
+            assert!(
+                matches!(classify(pattern), SimplePattern::Complex),
+                "{pattern} should classify as complex"
+            );
         }
     }
 }


### PR DESCRIPTION
## Why

Compiling a wax glob costs 1-2ms of regex construction. Workspace discovery hands globwalk ~20 include patterns during the most CPU-contended window of startup, and on a 1191-package monorepo the compile step measured 36-46ms while the walk it enables took under a millisecond — every workspace pattern there is a literal path or a `<prefix>/*/<suffix>` shape that the walker already evaluates with a stat or readdir, never consulting the compiled matcher.

## What

Classify raw pattern strings before compilation:

- Literals (no metacharacters) and single-bare-star `<prefix>/*/<suffix>` shapes skip wax entirely and feed the existing literal/shallow fast paths.
- Classification is deliberately conservative — a small plain-byte whitelist per segment — so escapes, character classes, alternations, and wax's extended syntax all still compile exactly as before. Exclusion patterns are untouched.

## How to verify

- `cargo test -p globwalk`: 164 passing — the existing suite now routes its literal/star patterns through the raw classification, so it doubles as differential coverage; plus new classification unit tests for the literal/shallow/complex boundaries.
- `--dry=json` byte-identical on the monorepo above.
- Honest performance framing: include-glob compile drops 36ms → 0.6ms of CPU, but on an 8-core machine real time-to-first-task is unchanged — the startup window there is I/O-saturated and the freed CPU idles. On 2 cores (CI-runner class), TTFT improves 439.8 → 426.3ms median with clean separation. This is a CPU-waste removal that pays on constrained machines, not an 8-core wall-clock win.
