### PR TITLE
feat: Serve the Remote Cache as an sccache backend for Cargo tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7933,6 +7933,7 @@ dependencies = [
  "turborepo-repository",
  "turborepo-run-cache",
  "turborepo-run-summary",
+ "turborepo-sccache-proxy",
  "turborepo-scm",
  "turborepo-scope",
  "turborepo-shim",
@@ -8277,6 +8278,28 @@ dependencies = [
  "turborepo-types",
  "turborepo-ui",
  "url",
+]
+
+[[package]]
+name = "turborepo-sccache-proxy"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "bytes",
+ "futures",
+ "hex",
+ "port_scanner",
+ "rand 0.9.3",
+ "reqwest",
+ "sha2",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "turbopath",
+ "turborepo-api-client",
+ "turborepo-types",
+ "turborepo-vercel-api-mock",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ turborepo-query = { path = "crates/turborepo-query" }
 turborepo-query-api = { path = "crates/turborepo-query-api" }
 turborepo-profile-md = { path = "crates/turborepo-profile-md" }
 turborepo-repository = { path = "crates/turborepo-repository" }
+turborepo-sccache-proxy = { path = "crates/turborepo-sccache-proxy" }
 turborepo-task-id = { path = "crates/turborepo-task-id" }
 turborepo-types = { path = "crates/turborepo-types" }
 turborepo-ui = { path = "crates/turborepo-ui" }

--- a/crates/turborepo-lib/Cargo.toml
+++ b/crates/turborepo-lib/Cargo.toml
@@ -127,6 +127,7 @@ turborepo-rayon-compat = { workspace = true }
 turborepo-repository = { path = "../turborepo-repository" }
 turborepo-run-cache = { path = "../turborepo-run-cache" }
 turborepo-run-summary = { workspace = true }
+turborepo-sccache-proxy = { workspace = true }
 turborepo-scm = { workspace = true }
 turborepo-scope = { path = "../turborepo-scope" }
 turborepo-shim = { workspace = true }

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -977,6 +977,7 @@ impl RunBuilder {
                 repo_root: self.repo_root,
                 opts: Arc::new(self.opts),
                 api_auth: self.api_auth,
+                api_client,
                 env_at_execution_start,
                 filtered_pkgs: filtered_pkgs.keys().cloned().collect(),
                 pkg_dep_graph: Arc::new(pkg_dep_graph),

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -985,8 +985,12 @@ impl Run {
             debug!("sccache compile cache disabled: Remote Cache is not configured");
             return None;
         };
+        // Debug, not warn: the flag is repo-level configuration, so in a
+        // repository that dogfoods it, every contributor without sccache
+        // installed would otherwise see a warning on every run. Missing
+        // sccache is an absent optimization, not a problem with the run.
         if which::which("sccache").is_err() {
-            warn!("sccache not found on PATH; compile cache disabled");
+            debug!("sccache not found on PATH; compile cache disabled");
             return None;
         }
 

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -27,7 +27,7 @@ use shared_child::SharedChild;
 use tokio::{pin, select, task::JoinHandle};
 use tracing::{debug, error, info, instrument, warn};
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
-use turborepo_api_client::APIAuth;
+use turborepo_api_client::{APIAuth, APIClient};
 use turborepo_ci::Vendor;
 use turborepo_env::EnvironmentVariableMap;
 use turborepo_microfrontends_proxy::ProxyServer;
@@ -119,6 +119,10 @@ pub struct Run {
     repo_root: AbsoluteSystemPathBuf,
     opts: Arc<Opts>,
     api_auth: Option<APIAuth>,
+    /// Kept for run-scoped services that talk to the Remote Cache outside
+    /// the task-cache pipeline (the sccache compile-cache proxy). `None`
+    /// when the run has no reason to initialize an HTTP client.
+    api_client: Option<APIClient>,
     env_at_execution_start: EnvironmentVariableMap,
     filtered_pkgs: HashSet<PackageName>,
     pkg_dep_graph: Arc<PackageGraph>,
@@ -953,6 +957,78 @@ impl Run {
         });
     }
 
+    /// Start the sccache compile-cache proxy when
+    /// `futureFlags.experimentalCargoSccache` asks for it and the run can
+    /// support it. Every unmet precondition disables the proxy softly (the
+    /// compile cache is an optimization; a run without it is just slower),
+    /// with a log line naming the reason.
+    ///
+    /// Returns the endpoint to hand to toolchains plus the server's
+    /// shutdown handle.
+    async fn start_sccache_proxy_if_needed(
+        &self,
+    ) -> Option<(
+        turborepo_repository::toolchain::CompileCacheEndpoint,
+        tokio::sync::broadcast::Sender<()>,
+    )> {
+        if !self.opts.future_flags.experimental_cargo_sccache {
+            return None;
+        }
+        if !builder::cargo_enabled(&self.opts.future_flags) {
+            warn!(
+                "experimentalCargoSccache requires experimentalCargoWorkspaces; compile cache \
+                 disabled"
+            );
+            return None;
+        }
+        let (Some(client), Some(auth)) = (self.api_client.clone(), self.api_auth.clone()) else {
+            debug!("sccache compile cache disabled: Remote Cache is not configured");
+            return None;
+        };
+        if which::which("sccache").is_err() {
+            warn!("sccache not found on PATH; compile cache disabled");
+            return None;
+        }
+
+        let token_path = self
+            .repo_root
+            .join_components(&[".turbo", "sccache-proxy-token"]);
+        let token = match turborepo_sccache_proxy::load_or_create_token(&token_path) {
+            Ok(token) => token,
+            Err(err) => {
+                warn!("compile cache disabled: {err}");
+                return None;
+            }
+        };
+
+        // The port must be stable across runs: the sccache background
+        // server captures the endpoint at startup and outlives this run.
+        let port = turborepo_sccache_proxy::derive_port(&self.repo_root);
+        let server =
+            match turborepo_sccache_proxy::SccacheProxyServer::bind(port, client, auth, &token)
+                .await
+            {
+                Ok(server) => server,
+                Err(err) => {
+                    warn!("compile cache disabled: {err}");
+                    return None;
+                }
+            };
+
+        let endpoint = turborepo_repository::toolchain::CompileCacheEndpoint {
+            url: server.endpoint(),
+            token,
+        };
+        let shutdown = server.shutdown_handle();
+        info!("sccache compile cache proxy listening on {}", endpoint.url);
+        tokio::spawn(async move {
+            if let Err(err) = server.run().await {
+                error!("sccache compile cache proxy error: {err}");
+            }
+        });
+        Some((endpoint, shutdown))
+    }
+
     async fn cleanup_proxy(
         &self,
         proxy_shutdown: Option<(
@@ -1156,6 +1232,12 @@ impl Run {
 
         drop(_setup_span);
 
+        let sccache_proxy = self.start_sccache_proxy_if_needed().await;
+        let (compile_cache_endpoint, sccache_shutdown) = match sccache_proxy {
+            Some((endpoint, shutdown)) => (Some(endpoint), Some(shutdown)),
+            None => (None, None),
+        };
+
         let mut visitor = Visitor::new(
             self.pkg_dep_graph.clone(),
             self.run_cache.clone(),
@@ -1176,6 +1258,7 @@ impl Run {
             is_watch,
             self.micro_frontend_configs.as_ref(),
             external_deps_hashes,
+            compile_cache_endpoint,
         )
         .await;
 
@@ -1208,6 +1291,13 @@ impl Run {
         }
 
         self.cleanup_proxy(proxy_shutdown).await;
+
+        // Fire-and-forget: the proxy drains in-flight requests on its own,
+        // and trailing writes from the persistent sccache server after this
+        // point fail softly on its side (storage errors are cache misses).
+        if let Some(shutdown) = sccache_shutdown {
+            let _ = shutdown.send(());
+        }
 
         // When a proxy is present, the signal handler only stops processes on OS
         // signal. For normal completion without user interruption, we need an

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -981,6 +981,16 @@ impl Run {
             );
             return None;
         }
+        // CI-only: sccache pays off in cold environments, while local
+        // development is already served by cargo's incremental compilation
+        // and a warm target directory — which the injected
+        // `CARGO_INCREMENTAL=0` would actively degrade. The flag is
+        // repo-level configuration, so without this gate, enabling it for
+        // CI would slow down every contributor's inner loop.
+        if !turborepo_ci::is_ci() {
+            debug!("sccache compile cache disabled: not running in CI");
+            return None;
+        }
         let (Some(client), Some(auth)) = (self.api_client.clone(), self.api_auth.clone()) else {
             debug!("sccache compile cache disabled: Remote Cache is not configured");
             return None;

--- a/crates/turborepo-lib/src/task_graph/visitor/exec.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/exec.rs
@@ -58,6 +58,7 @@ impl<'a> ExecContextFactory<'a> {
             &visitor.package_graph,
             visitor.run_opts.task_args(),
             visitor.micro_frontends_configs,
+            visitor.compile_cache_endpoint.as_ref(),
         );
         let mut command_factory = CommandFactory::new();
         if let Some(micro_frontends_configs) = visitor.micro_frontends_configs {

--- a/crates/turborepo-lib/src/task_graph/visitor/mod.rs
+++ b/crates/turborepo-lib/src/task_graph/visitor/mod.rs
@@ -22,7 +22,10 @@ use turborepo_env::{platform::PlatformEnv, EnvironmentVariableMap};
 use turborepo_errors::TURBO_SITE;
 use turborepo_log::grouping::{GroupingLayer, GroupingMode};
 use turborepo_process::ProcessManager;
-use turborepo_repository::package_graph::{PackageGraph, PackageName, ROOT_PKG_NAME};
+use turborepo_repository::{
+    package_graph::{PackageGraph, PackageName, ROOT_PKG_NAME},
+    toolchain::CompileCacheEndpoint,
+};
 use turborepo_run_summary::{self as summary, GlobalHashSummary, RunTracker, TaskTracker};
 use turborepo_scm::{RepoGitIndex, SCM};
 use turborepo_task_executor::{
@@ -68,6 +71,10 @@ pub struct Visitor<'a> {
     ui_sender: Option<UISender>,
     warnings: Arc<Mutex<Vec<TaskWarning>>>,
     micro_frontends_configs: Option<&'a MicrofrontendsConfigs>,
+    /// The compile cache proxy endpoint for this run, when one is being
+    /// served (`futureFlags.experimentalCargoSccache`). Toolchains translate
+    /// it into task env vars via `Toolchain::compile_cache_env`.
+    compile_cache_endpoint: Option<CompileCacheEndpoint>,
 }
 
 #[derive(Debug, thiserror::Error, Diagnostic)]
@@ -221,6 +228,7 @@ impl<'a> Visitor<'a> {
         is_watch: bool,
         micro_frontends_configs: Option<&'a MicrofrontendsConfigs>,
         external_deps_hashes: Option<HashMap<String, String>>,
+        compile_cache_endpoint: Option<CompileCacheEndpoint>,
     ) -> Self {
         let (task_hasher, color_cache, grouping_layer) = {
             let _span = tracing::info_span!("visitor_new").entered();
@@ -287,6 +295,7 @@ impl<'a> Visitor<'a> {
             is_watch,
             warnings: Default::default(),
             micro_frontends_configs,
+            compile_cache_endpoint,
         }
     }
 

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -514,6 +514,33 @@ impl Toolchain for CargoToolchain {
         display_command(details.kind, task, &name)
     }
 
+    /// Route rustc invocations through sccache, with the Turborepo-served
+    /// endpoint as its webdav storage backend. sccache fetches per
+    /// compilation-unit objects lazily at rustc invocation time, so no state
+    /// needs restoring before the task starts.
+    ///
+    /// `CARGO_INCREMENTAL=0` accompanies the wrapper because sccache cannot
+    /// cache incrementally-compiled crates and would fall back to plain
+    /// compilation for them.
+    ///
+    /// These are injected at execution time only and deliberately do not
+    /// participate in the task hash: a compile cache is output-transparent,
+    /// so enabling it must not invalidate existing task artifacts. A
+    /// user-supplied `RUSTC_WRAPPER` (which does participate, via
+    /// [`HASHED_ENV_VARS`]) suppresses this injection entirely — see
+    /// [`Toolchain::compile_cache_env`].
+    fn compile_cache_env(
+        &self,
+        endpoint: &toolchain::CompileCacheEndpoint,
+    ) -> Vec<(String, String)> {
+        vec![
+            ("RUSTC_WRAPPER".to_string(), "sccache".to_string()),
+            ("SCCACHE_WEBDAV_ENDPOINT".to_string(), endpoint.url.clone()),
+            ("SCCACHE_WEBDAV_TOKEN".to_string(), endpoint.token.clone()),
+            ("CARGO_INCREMENTAL".to_string(), "0".to_string()),
+        ]
+    }
+
     fn defines_task(&self, package: &crate::package_graph::PackageInfo, task: &str) -> bool {
         package
             .package_name()
@@ -1409,6 +1436,35 @@ checksum = "abc123"
             vec!["app", "helper"]
         );
         assert_eq!(crates[0].internal_dependencies, vec!["helper".to_string()]);
+    }
+
+    #[test]
+    fn test_compile_cache_env_routes_rustc_through_sccache() {
+        let (_tmp, root) = tempdir_root();
+        let toolchain = CargoToolchain::new(root);
+        let endpoint = toolchain::CompileCacheEndpoint {
+            url: "http://127.0.0.1:42123".to_string(),
+            token: "proxy-token".to_string(),
+        };
+        assert_eq!(
+            toolchain.compile_cache_env(&endpoint),
+            vec![
+                ("RUSTC_WRAPPER".to_string(), "sccache".to_string()),
+                (
+                    "SCCACHE_WEBDAV_ENDPOINT".to_string(),
+                    "http://127.0.0.1:42123".to_string()
+                ),
+                (
+                    "SCCACHE_WEBDAV_TOKEN".to_string(),
+                    "proxy-token".to_string()
+                ),
+                ("CARGO_INCREMENTAL".to_string(), "0".to_string()),
+            ]
+        );
+        // The injected wrapper key must be a hashed env var so a
+        // user-supplied wrapper invalidates task results (the injected one
+        // is execution-only and deliberately does not).
+        assert!(HASHED_ENV_VARS.contains(&"RUSTC_WRAPPER"));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -275,6 +275,30 @@ pub trait Toolchain: Send + Sync {
     fn prune_finalize(&self, pruned_root: &AbsoluteSystemPath) {
         let _ = pruned_root;
     }
+
+    /// Environment variables to inject into this toolchain's task processes
+    /// when Turborepo is serving a compile cache endpoint (a local proxy in
+    /// front of the remote cache that a compiler wrapper like sccache can
+    /// use as its storage backend).
+    ///
+    /// An empty result means the toolchain has no compile-cache integration
+    /// (the JavaScript default). The executor never applies these variables
+    /// over ones already present in the task's environment: a user-supplied
+    /// configuration (e.g. their own `RUSTC_WRAPPER`) always wins.
+    fn compile_cache_env(&self, endpoint: &CompileCacheEndpoint) -> Vec<(String, String)> {
+        let _ = endpoint;
+        Vec::new()
+    }
+}
+
+/// A Turborepo-served compile cache endpoint, as plain data. See
+/// [`Toolchain::compile_cache_env`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompileCacheEndpoint {
+    /// HTTP endpoint of the local compile-cache proxy.
+    pub url: String,
+    /// Bearer token the proxy requires.
+    pub token: String,
 }
 
 /// A toolchain's contribution to a pruned repository. See

--- a/crates/turborepo-sccache-proxy/Cargo.toml
+++ b/crates/turborepo-sccache-proxy/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "turborepo-sccache-proxy"
+version = "0.1.0"
+edition = { workspace = true }
+license = "MIT"
+
+[lints]
+workspace = true
+
+[dependencies]
+axum = { workspace = true }
+bytes = { workspace = true }
+futures = { workspace = true }
+hex = { workspace = true }
+rand = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["macros", "net", "sync"] }
+tracing = { workspace = true }
+turbopath = { workspace = true }
+turborepo-api-client = { workspace = true }
+turborepo-types = { workspace = true }
+
+[dev-dependencies]
+port_scanner = { workspace = true }
+reqwest = { workspace = true, features = ["json"] }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+turborepo-vercel-api-mock = { workspace = true }

--- a/crates/turborepo-sccache-proxy/src/lib.rs
+++ b/crates/turborepo-sccache-proxy/src/lib.rs
@@ -1,0 +1,477 @@
+//! A local HTTP proxy that exposes the Turborepo Remote Cache as an
+//! sccache-compatible storage backend.
+//!
+//! sccache's `webdav` storage backend only needs plain `GET`/`PUT` (plus
+//! `HEAD` for stats) against `{endpoint}/{key}` with bearer-token
+//! authentication — no PROPFIND or other WebDAV verbs are on its read/write
+//! path. This proxy accepts those requests on a loopback listener and
+//! translates them into Remote Cache artifact API calls, so per-compilation
+//! -unit rustc results ride the same authenticated cache plumbing as task
+//! artifacts. Cache objects are fetched lazily at rustc invocation time:
+//! nothing needs to be restored into the environment before a task starts.
+//!
+//! # Endpoint stability
+//!
+//! The sccache client daemonizes a background server on first use, and that
+//! server captures its storage configuration (endpoint and token) at
+//! startup, then outlives the `turbo run` that spawned it. If the endpoint
+//! changed between runs, the persistent sccache server would keep talking to
+//! a dead port. Two things keep the endpoint stable across runs:
+//!
+//! * The listen port is derived deterministically from the repository root
+//!   ([`derive_port`]), so every run of the same repository binds the same
+//!   port.
+//! * The bearer token is persisted per repository ([`load_or_create_token`]),
+//!   so a long-lived sccache server keeps authenticating successfully.
+//!
+//! Trailing writes from the sccache server after `turbo` shuts the proxy
+//! down fail softly: sccache treats storage errors as cache misses and
+//! logs them without failing compilation.
+
+use std::sync::Arc;
+
+use axum::{
+    Router,
+    body::Body,
+    extract::{Path, State},
+    http::{HeaderMap, StatusCode, header},
+    response::{IntoResponse, Response},
+    routing::head,
+};
+use sha2::{Digest, Sha256};
+use tokio::net::TcpListener;
+use tracing::{debug, warn};
+use turbopath::AbsoluteSystemPath;
+use turborepo_api_client::{APIAuth, APIClient, CacheClient};
+use turborepo_types::SecretString;
+
+/// Ports are derived into this range. It sits inside the IANA "registered"
+/// range, away from the ephemeral range OSes assign outbound connections
+/// from, so a derived port is unlikely to be transiently occupied.
+const PORT_RANGE_START: u16 = 42000;
+const PORT_RANGE_LEN: u16 = 3000;
+
+/// Version prefix folded into artifact ids so the key scheme can change
+/// without colliding with objects written by earlier versions.
+const KEY_SCHEME: &str = "sccache-proxy-v1:";
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Failed to bind sccache proxy to 127.0.0.1:{port}: {source}")]
+    Bind {
+        port: u16,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("Failed to read or create the sccache proxy token: {0}")]
+    Token(#[source] std::io::Error),
+    #[error("sccache proxy server error: {0}")]
+    Serve(#[source] std::io::Error),
+}
+
+/// Derive the proxy's stable listen port for a repository. Deterministic on
+/// the repository root path so consecutive runs (and the persistent sccache
+/// server they share) agree on the endpoint.
+pub fn derive_port(repo_root: &AbsoluteSystemPath) -> u16 {
+    let digest = Sha256::digest(repo_root.as_str().as_bytes());
+    // Two bytes of the digest are ample for a 3000-slot range.
+    let n = u16::from_be_bytes([digest[0], digest[1]]);
+    PORT_RANGE_START + (n % PORT_RANGE_LEN)
+}
+
+/// Load the per-repository bearer token, creating it on first use.
+///
+/// The token authenticates loopback requests to the proxy so arbitrary
+/// local processes cannot read or write the team's remote cache through it.
+/// It must be stable across runs (see the module docs), so it is persisted
+/// at `token_path` with owner-only permissions rather than generated per
+/// run.
+pub fn load_or_create_token(token_path: &AbsoluteSystemPath) -> Result<String, Error> {
+    match token_path.read_existing_to_string().map_err(Error::Token)? {
+        Some(existing) if !existing.trim().is_empty() => Ok(existing.trim().to_owned()),
+        _ => {
+            let token = generate_token();
+            token_path.ensure_dir().map_err(Error::Token)?;
+            token_path
+                .create_with_contents_secret(token.as_bytes())
+                .map_err(Error::Token)?;
+            Ok(token)
+        }
+    }
+}
+
+fn generate_token() -> String {
+    use rand::RngCore;
+    let mut bytes = [0u8; 32];
+    rand::rng().fill_bytes(&mut bytes);
+    hex::encode(bytes)
+}
+
+/// Map an sccache storage key (an arbitrary path) to a Remote Cache artifact
+/// id. sccache keys are opaque to us; hashing keeps the id well-formed
+/// regardless of the key's shape and namespaces proxy objects away from task
+/// artifacts.
+fn artifact_id_for_key(key: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(KEY_SCHEME.as_bytes());
+    hasher.update(key.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+struct ProxyState {
+    client: APIClient,
+    auth: APIAuth,
+    /// Expected `Authorization` header value: `Bearer {token}`.
+    expected_authorization: String,
+}
+
+impl ProxyState {
+    fn token(&self) -> &SecretString {
+        &self.auth.token
+    }
+
+    fn team_id(&self) -> Option<&str> {
+        self.auth.team_id.as_deref()
+    }
+
+    fn team_slug(&self) -> Option<&str> {
+        self.auth.team_slug.as_deref()
+    }
+}
+
+/// The proxy server, bound but not yet serving. Construct with
+/// [`SccacheProxyServer::bind`], hand the endpoint to sccache via
+/// `SCCACHE_WEBDAV_ENDPOINT`, and drive it with
+/// [`SccacheProxyServer::run`].
+pub struct SccacheProxyServer {
+    listener: TcpListener,
+    router: Router,
+    port: u16,
+    shutdown_tx: tokio::sync::broadcast::Sender<()>,
+}
+
+impl SccacheProxyServer {
+    /// Bind the proxy on `127.0.0.1:port`. `token` is the bearer token
+    /// requests must present (see [`load_or_create_token`]).
+    pub async fn bind(
+        port: u16,
+        client: APIClient,
+        auth: APIAuth,
+        token: &str,
+    ) -> Result<Self, Error> {
+        let listener = TcpListener::bind(("127.0.0.1", port))
+            .await
+            .map_err(|source| Error::Bind { port, source })?;
+        let port = listener
+            .local_addr()
+            .map_err(|source| Error::Bind { port, source })?
+            .port();
+
+        let state = Arc::new(ProxyState {
+            client,
+            auth,
+            expected_authorization: format!("Bearer {token}"),
+        });
+        let router = Router::new()
+            .route("/{*key}", head(handle_head).get(handle_get).put(handle_put))
+            .with_state(state);
+
+        let (shutdown_tx, _) = tokio::sync::broadcast::channel(1);
+        Ok(Self {
+            listener,
+            router,
+            port,
+            shutdown_tx,
+        })
+    }
+
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// The endpoint value for `SCCACHE_WEBDAV_ENDPOINT`.
+    pub fn endpoint(&self) -> String {
+        format!("http://127.0.0.1:{}", self.port)
+    }
+
+    /// A handle that shuts the server down gracefully when signalled.
+    pub fn shutdown_handle(&self) -> tokio::sync::broadcast::Sender<()> {
+        self.shutdown_tx.clone()
+    }
+
+    /// Serve until the shutdown handle is signalled.
+    pub async fn run(self) -> Result<(), Error> {
+        let mut shutdown_rx = self.shutdown_tx.subscribe();
+        axum::serve(self.listener, self.router)
+            .with_graceful_shutdown(async move {
+                let _ = shutdown_rx.recv().await;
+            })
+            .await
+            .map_err(Error::Serve)
+    }
+}
+
+fn authorized(state: &ProxyState, headers: &HeaderMap) -> bool {
+    headers
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value == state.expected_authorization)
+}
+
+async fn handle_get(
+    State(state): State<Arc<ProxyState>>,
+    Path(key): Path<String>,
+    headers: HeaderMap,
+) -> Response {
+    if !authorized(&state, &headers) {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    let id = artifact_id_for_key(&key);
+    match state
+        .client
+        .fetch_artifact(&id, state.token(), state.team_id(), state.team_slug())
+        .await
+    {
+        Ok(Some(response)) => {
+            debug!("sccache proxy hit for key {key}");
+            Body::from_stream(response.bytes_stream()).into_response()
+        }
+        Ok(None) => {
+            debug!("sccache proxy miss for key {key}");
+            StatusCode::NOT_FOUND.into_response()
+        }
+        Err(err) => {
+            warn!("sccache proxy fetch failed for key {key}: {err}");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+async fn handle_head(
+    State(state): State<Arc<ProxyState>>,
+    Path(key): Path<String>,
+    headers: HeaderMap,
+) -> Response {
+    if !authorized(&state, &headers) {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    let id = artifact_id_for_key(&key);
+    match state
+        .client
+        .artifact_exists(&id, state.token(), state.team_id(), state.team_slug())
+        .await
+    {
+        Ok(Some(_)) => StatusCode::OK.into_response(),
+        Ok(None) => StatusCode::NOT_FOUND.into_response(),
+        Err(err) => {
+            warn!("sccache proxy stat failed for key {key}: {err}");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+async fn handle_put(
+    State(state): State<Arc<ProxyState>>,
+    Path(key): Path<String>,
+    headers: HeaderMap,
+    body: bytes::Bytes,
+) -> Response {
+    if !authorized(&state, &headers) {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    let id = artifact_id_for_key(&key);
+    let len = body.len();
+    let stream = futures::stream::once(async move { Ok(body) });
+    match state
+        .client
+        .put_artifact(
+            &id,
+            stream,
+            len,
+            0,
+            None,
+            state.token(),
+            state.team_id(),
+            state.team_slug(),
+            None,
+            None,
+        )
+        .await
+    {
+        Ok(()) => {
+            debug!("sccache proxy stored key {key} ({len} bytes)");
+            StatusCode::OK.into_response()
+        }
+        Err(err) => {
+            warn!("sccache proxy store failed for key {key}: {err}");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_auth() -> APIAuth {
+        APIAuth {
+            team_id: Some("my-team".to_string()),
+            token: SecretString::new("remote-token".to_string()),
+            team_slug: None,
+        }
+    }
+
+    async fn start_backend() -> (u16, tokio::task::JoinHandle<()>) {
+        let port = port_scanner::request_open_port().expect("open port");
+        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+        let handle = tokio::spawn(async move {
+            let _ = turborepo_vercel_api_mock::start_test_server(port, Some(ready_tx)).await;
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(5), ready_rx)
+            .await
+            .expect("mock server timed out")
+            .expect("mock server failed to start");
+        (port, handle)
+    }
+
+    fn api_client(backend_port: u16) -> APIClient {
+        APIClient::new(
+            format!("http://localhost:{backend_port}"),
+            Some(std::time::Duration::from_secs(10)),
+            None,
+            "2.0.0",
+            true,
+        )
+        .expect("api client")
+    }
+
+    async fn start_proxy(backend_port: u16, bearer: &str) -> (SccacheProxyServer, u16) {
+        // Port 0: tests must not collide on the derived range.
+        let server = SccacheProxyServer::bind(0, api_client(backend_port), test_auth(), bearer)
+            .await
+            .expect("bind proxy");
+        let port = server.port();
+        (server, port)
+    }
+
+    #[test]
+    fn key_mapping_is_stable_and_key_dependent() {
+        let a = artifact_id_for_key("a/b/0123abc");
+        let b = artifact_id_for_key("a/b/0123abd");
+        assert_eq!(a, artifact_id_for_key("a/b/0123abc"));
+        assert_ne!(a, b);
+        assert_eq!(a.len(), 64);
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn derived_port_is_stable_and_in_range() {
+        let root = if cfg!(windows) {
+            AbsoluteSystemPath::new("C:\\some\\repo").expect("path")
+        } else {
+            AbsoluteSystemPath::new("/some/repo").expect("path")
+        };
+        let port = derive_port(root);
+        assert_eq!(port, derive_port(root));
+        assert!((PORT_RANGE_START..PORT_RANGE_START + PORT_RANGE_LEN).contains(&port));
+    }
+
+    #[test]
+    fn token_persists_across_loads() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = turbopath::AbsoluteSystemPathBuf::try_from(dir.path())
+            .expect("abs path")
+            .join_components(&[".turbo", "sccache-proxy-token"]);
+        let first = load_or_create_token(&path).expect("create token");
+        let second = load_or_create_token(&path).expect("reload token");
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 64);
+    }
+
+    #[tokio::test]
+    async fn round_trip_through_proxy() {
+        let (backend_port, backend) = start_backend().await;
+        let bearer = "local-proxy-token";
+        let (server, port) = start_proxy(backend_port, bearer).await;
+        let shutdown = server.shutdown_handle();
+        let proxy = tokio::spawn(server.run());
+
+        let http = reqwest::Client::new();
+        let base = format!("http://127.0.0.1:{port}/6/2/sccache-key");
+
+        // Miss before write.
+        let resp = http
+            .get(&base)
+            .bearer_auth(bearer)
+            .send()
+            .await
+            .expect("get");
+        assert_eq!(resp.status(), reqwest::StatusCode::NOT_FOUND);
+
+        // Write.
+        let resp = http
+            .put(&base)
+            .bearer_auth(bearer)
+            .body("compiled object bytes")
+            .send()
+            .await
+            .expect("put");
+        assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+        // Stat and read back.
+        let resp = http
+            .head(&base)
+            .bearer_auth(bearer)
+            .send()
+            .await
+            .expect("head");
+        assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+        let resp = http
+            .get(&base)
+            .bearer_auth(bearer)
+            .send()
+            .await
+            .expect("get");
+        assert_eq!(resp.status(), reqwest::StatusCode::OK);
+        assert_eq!(resp.bytes().await.expect("body"), "compiled object bytes");
+
+        // A different key is still a miss.
+        let resp = http
+            .get(format!("http://127.0.0.1:{port}/6/2/other-key"))
+            .bearer_auth(bearer)
+            .send()
+            .await
+            .expect("get");
+        assert_eq!(resp.status(), reqwest::StatusCode::NOT_FOUND);
+
+        let _ = shutdown.send(());
+        let _ = proxy.await;
+        backend.abort();
+    }
+
+    #[tokio::test]
+    async fn rejects_missing_or_wrong_bearer_token() {
+        let (backend_port, backend) = start_backend().await;
+        let (server, port) = start_proxy(backend_port, "correct-token").await;
+        let shutdown = server.shutdown_handle();
+        let proxy = tokio::spawn(server.run());
+
+        let http = reqwest::Client::new();
+        let url = format!("http://127.0.0.1:{port}/some/key");
+
+        for request in [
+            http.get(&url),
+            http.get(&url).bearer_auth("wrong-token"),
+            http.put(&url).body("data"),
+            http.head(&url),
+        ] {
+            let resp = request.send().await.expect("request");
+            assert_eq!(resp.status(), reqwest::StatusCode::UNAUTHORIZED);
+        }
+
+        let _ = shutdown.send(());
+        let _ = proxy.await;
+        backend.abort();
+    }
+}

--- a/crates/turborepo-task-executor/src/command.rs
+++ b/crates/turborepo-task-executor/src/command.rs
@@ -12,6 +12,7 @@ use turborepo_process::Command;
 use turborepo_repository::{
     package_graph::{PackageGraph, PackageInfo, PackageName},
     package_manager::PackageManager,
+    toolchain::CompileCacheEndpoint,
 };
 use turborepo_task_id::TaskId;
 use turborepo_types::TaskArgs;
@@ -164,6 +165,10 @@ pub struct ToolchainCommandProvider<'a, M = crate::NoMfeConfig> {
     package_graph: &'a PackageGraph,
     task_args: TaskArgs<'a>,
     mfe_configs: Option<&'a M>,
+    /// A Turborepo-served compile cache endpoint (see
+    /// [`turborepo_repository::toolchain::Toolchain::compile_cache_env`]), when
+    /// one is running for this run.
+    compile_cache: Option<&'a CompileCacheEndpoint>,
 }
 
 impl<'a, M: MfeConfigProvider> ToolchainCommandProvider<'a, M> {
@@ -172,12 +177,14 @@ impl<'a, M: MfeConfigProvider> ToolchainCommandProvider<'a, M> {
         package_graph: &'a PackageGraph,
         task_args: TaskArgs<'a>,
         mfe_configs: Option<&'a M>,
+        compile_cache: Option<&'a CompileCacheEndpoint>,
     ) -> Self {
         Self {
             repo_root,
             package_graph,
             task_args,
             mfe_configs,
+            compile_cache,
         }
     }
 
@@ -255,11 +262,48 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
             cmd.env("TURBO_MFE_PORT", port.to_string());
         }
 
+        if let Some(endpoint) = self.compile_cache {
+            match compile_cache_env_to_inject(toolchain.compile_cache_env(endpoint), environment) {
+                Ok(vars) => {
+                    for (key, value) in vars {
+                        cmd.env(key, value);
+                    }
+                }
+                Err(conflict) => debug!(
+                    "not injecting compile cache env for {task_id}: task environment already sets \
+                     {conflict}"
+                ),
+            }
+        }
+
         // We always open stdin and the visitor will close it depending on task
         // configuration
         cmd.open_stdin();
 
         Ok(Some(cmd))
+    }
+}
+
+/// The compile-cache variables to apply for a task, given what the
+/// toolchain wants injected
+/// ([`turborepo_repository::toolchain::Toolchain::compile_cache_env`], empty
+/// for toolchains without an integration) and the task's environment.
+///
+/// Never overrides variables the task environment already sets: a
+/// user-supplied configuration (e.g. their own `RUSTC_WRAPPER` pointing at
+/// a different cache) wins, and partially applying ours on top of theirs
+/// could hijack its backend — so one conflicting variable suppresses the
+/// whole set. Returns the conflicting variable name as the error.
+fn compile_cache_env_to_inject(
+    vars: Vec<(String, String)>,
+    environment: &EnvironmentVariableMap,
+) -> Result<Vec<(String, String)>, String> {
+    match vars
+        .iter()
+        .find(|(key, _)| environment.contains_key(key.as_str()))
+    {
+        Some((conflict, _)) => Err(conflict.clone()),
+        None => Ok(vars),
     }
 }
 
@@ -713,6 +757,51 @@ mod tests {
             .command(&task_id, &EnvironmentVariableMap::default())
             .unwrap();
         assert!(cmd.is_none(), "expected no cmd, got {cmd:?}");
+    }
+
+    #[test]
+    fn test_compile_cache_env_injected_when_unconflicted() {
+        let vars = vec![
+            ("RUSTC_WRAPPER".to_owned(), "sccache".to_owned()),
+            ("SCCACHE_WEBDAV_ENDPOINT".to_owned(), "http://x".to_owned()),
+        ];
+        let environment = EnvironmentVariableMap::from(HashMap::from([(
+            "PATH".to_owned(),
+            "/usr/bin".to_owned(),
+        )]));
+        assert_eq!(
+            compile_cache_env_to_inject(vars.clone(), &environment),
+            Ok(vars)
+        );
+    }
+
+    #[test]
+    fn test_compile_cache_env_suppressed_entirely_on_conflict() {
+        // A user-supplied RUSTC_WRAPPER must suppress the whole set:
+        // injecting only SCCACHE_* on top of it could hijack the backend of
+        // the user's own wrapper.
+        let vars = vec![
+            ("RUSTC_WRAPPER".to_owned(), "sccache".to_owned()),
+            ("SCCACHE_WEBDAV_ENDPOINT".to_owned(), "http://x".to_owned()),
+        ];
+        let environment = EnvironmentVariableMap::from(HashMap::from([(
+            "RUSTC_WRAPPER".to_owned(),
+            "/home/user/bin/my-wrapper".to_owned(),
+        )]));
+        assert_eq!(
+            compile_cache_env_to_inject(vars, &environment),
+            Err("RUSTC_WRAPPER".to_owned())
+        );
+    }
+
+    #[test]
+    fn test_empty_compile_cache_env_injects_nothing() {
+        // The JavaScript default: no compile-cache integration.
+        let environment = EnvironmentVariableMap::default();
+        assert_eq!(
+            compile_cache_env_to_inject(Vec::new(), &environment),
+            Ok(Vec::new())
+        );
     }
 
     #[tokio::test]

--- a/crates/turborepo-turbo-json/src/future_flags.rs
+++ b/crates/turborepo-turbo-json/src/future_flags.rs
@@ -102,8 +102,12 @@ pub struct FutureFlags {
     /// tasks. When enabled (together with `experimentalCargoWorkspaces` and
     /// a linked Remote Cache), `turbo` starts a local proxy and routes
     /// rustc invocations through `sccache`, caching individual compilation
-    /// units in the Remote Cache. Requires `sccache` on `PATH`; silently
-    /// disabled otherwise.
+    /// units in the Remote Cache.
+    ///
+    /// Only engages in CI: cold environments are where a compile cache
+    /// pays off, while local development is better served by cargo's own
+    /// incremental compilation (which sccache would disable). Requires
+    /// `sccache` on `PATH`; silently disabled otherwise.
     #[serde(default)]
     #[schemars(skip)]
     pub experimental_cargo_sccache: bool,

--- a/crates/turborepo-turbo-json/src/future_flags.rs
+++ b/crates/turborepo-turbo-json/src/future_flags.rs
@@ -98,6 +98,15 @@ pub struct FutureFlags {
     /// caching for crates are not wired up yet, so their tasks are no-ops.
     #[serde(default)]
     pub experimental_cargo_workspaces: bool,
+    /// Serve the Remote Cache as an sccache storage backend for Cargo crate
+    /// tasks. When enabled (together with `experimentalCargoWorkspaces` and
+    /// a linked Remote Cache), `turbo` starts a local proxy and routes
+    /// rustc invocations through `sccache`, caching individual compilation
+    /// units in the Remote Cache. Requires `sccache` on `PATH`; silently
+    /// disabled otherwise.
+    #[serde(default)]
+    #[schemars(skip)]
+    pub experimental_cargo_sccache: bool,
 }
 
 // Manual TS impl because #[derive(TS)] conflicts with the Iterable and

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -273,8 +273,9 @@ whether anything changed; Cargo decides how and in what order to build.**
 
 - **Compile cache** (`Toolchain::compile_cache_env`, consumed by
   `ToolchainCommandProvider`; gated by `futureFlags.experimentalCargoSccache`):
-  when enabled alongside `experimentalCargoWorkspaces` with a linked Remote
-  Cache and `sccache` on `PATH`, the run serves a local HTTP proxy
+  when enabled alongside `experimentalCargoWorkspaces` in a CI environment
+  with a linked Remote Cache and `sccache` on `PATH`, the run serves a
+  local HTTP proxy
   (`turborepo-sccache-proxy`) that presents an sccache-compatible webdav
   storage backend and translates `GET`/`PUT`/`HEAD` into Remote Cache
   artifact calls. Cargo tasks get `RUSTC_WRAPPER=sccache`,
@@ -290,7 +291,10 @@ whether anything changed; Cargo decides how and in what order to build.**
   participate in task hashes (a compile cache is output-transparent); a
   user-supplied `RUSTC_WRAPPER` in the task environment suppresses the
   whole injected set, and every unmet precondition disables the proxy
-  softly. Lifecycle: started in `Run::execute_visitor` before the visitor,
+  softly. CI-only by design: cold environments are where a compile cache
+  pays off, while local development is served by cargo's own incremental
+  compilation — which the injected `CARGO_INCREMENTAL=0` would disable.
+  Lifecycle: started in `Run::execute_visitor` before the visitor,
   shut down fire-and-forget after it.
 
 A `--filter` that names a crate while support is disabled gets an error

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -271,6 +271,28 @@ whether anything changed; Cargo decides how and in what order to build.**
   package anchored at the repo root (the synthetic `cargo` package) is not
   a pruneable target.
 
+- **Compile cache** (`Toolchain::compile_cache_env`, consumed by
+  `ToolchainCommandProvider`; gated by `futureFlags.experimentalCargoSccache`):
+  when enabled alongside `experimentalCargoWorkspaces` with a linked Remote
+  Cache and `sccache` on `PATH`, the run serves a local HTTP proxy
+  (`turborepo-sccache-proxy`) that presents an sccache-compatible webdav
+  storage backend and translates `GET`/`PUT`/`HEAD` into Remote Cache
+  artifact calls. Cargo tasks get `RUSTC_WRAPPER=sccache`,
+  `SCCACHE_WEBDAV_ENDPOINT`/`SCCACHE_WEBDAV_TOKEN`, and
+  `CARGO_INCREMENTAL=0` injected at execution time; JavaScript injects
+  nothing. Objects are fetched lazily per rustc invocation, so nothing is
+  restored before a task runs; the two cache layers compose (task-cache
+  hit: nothing executes; miss: cargo's conservative recompiles become
+  downloads). The endpoint must be stable across runs because the sccache
+  background server captures it at startup and outlives the run: the port
+  is derived from the repo root and the bearer token is persisted at
+  `.turbo/sccache-proxy-token`. Injection is execution-only and does not
+  participate in task hashes (a compile cache is output-transparent); a
+  user-supplied `RUSTC_WRAPPER` in the task environment suppresses the
+  whole injected set, and every unmet precondition disables the proxy
+  softly. Lifecycle: started in `Run::execute_visitor` before the visitor,
+  shut down fire-and-forget after it.
+
 A `--filter` that names a crate while support is disabled gets an error
 hint pointing at the flag. Released turbo versions hard-error on unknown
 `futureFlags` keys, so a repo can only adopt the flag once every consumer


### PR DESCRIPTION
## Why

Turborepo's task cache is all-or-nothing for a Cargo crate: any input change re-runs the whole `cargo build`. In CI — cold containers with empty `target/` directories — that means recompiling everything on every task-cache miss. sccache can cache individual compilation units, but pointing it at remote storage previously required standing up separate infrastructure (S3, GHA cache) with separate credentials.

This makes the Remote Cache itself the sccache backend, so teams get CI compile caching through the cache they already have. The two layers compose: a task-cache hit skips execution entirely; a task-cache miss has its rustc invocations served from the compile cache.

**CI-only by design.** Local development is already served by cargo's incremental compilation and a warm `target/` — which the injected `CARGO_INCREMENTAL=0` (sccache cannot cache incremental units) would actively degrade. Since the flag is repo-level configuration, engaging locally would slow down every contributor's inner loop to speed up a case cargo already handles.

A second deliberate property: objects are fetched lazily by sccache at rustc invocation time over HTTP, so **nothing needs to be restored into the environment before a task executes** — no monolithic cache directories shipped through the incremental-tasks machinery.

## What

- New `turborepo-sccache-proxy` crate: a loopback HTTP server presenting an sccache-compatible webdav storage surface (`GET`/`PUT`/`HEAD`), translating requests into Remote Cache artifact API calls. Bearer-token protected so other local processes cannot reach the team cache through it.
- New `Toolchain::compile_cache_env` trait surface (per the toolchain design rules — no `if id == cargo` branching). JavaScript injects nothing; Cargo injects `RUSTC_WRAPPER=sccache`, `SCCACHE_WEBDAV_ENDPOINT`, `SCCACHE_WEBDAV_TOKEN`, and `CARGO_INCREMENTAL=0`.
- Gated by `futureFlags.experimentalCargoSccache`, which engages only when all of: running in CI, `experimentalCargoWorkspaces` enabled, Remote Cache linked, and `sccache` on `PATH`. Schema-hidden via `#[schemars(skip)]` like `incrementalTasks`. Every unmet precondition disables the proxy softly — visible warnings only for genuine misconfiguration (flag without cargo flag, token/bind failures); absent optimizations (no sccache, no CI, unlinked cache) log at debug.

## How

- **Endpoint stability**: sccache daemonizes a background server that captures its storage config at startup and outlives the run. The proxy port is therefore derived deterministically from the repo root, and the bearer token is persisted at `.turbo/sccache-proxy-token` (0600), so consecutive runs present the same endpoint to a persistent sccache server. Trailing writes after proxy shutdown fail softly on sccache's side.
- **Hash semantics**: injection happens at execution time only and does not participate in task hashes — a compile cache is output-transparent, so enabling it must not invalidate existing artifacts. A *user-supplied* `RUSTC_WRAPPER` (which does participate via `HASHED_ENV_VARS`) suppresses the entire injected set, since partially applying `SCCACHE_*` on top of a user's wrapper could hijack its backend.
- **Lifecycle**: started in `Run::execute_visitor` before the visitor, handle threaded `Visitor` → `ExecContextFactory` → `ToolchainCommandProvider`, shut down fire-and-forget after the visit.

## Testing

- Proxy round-trip/miss/auth-rejection tests against `turborepo-vercel-api-mock`; key-mapping, port-derivation, and token-persistence tests.
- Injection guard unit tests in `turborepo-task-executor`; `compile_cache_env` content test in `turborepo-repository`.
- Manual verification pending (draft): end-to-end CI-simulated run (`CI=1`) with `sccache` installed against a linked remote cache, plus an e2e test in `cargo_workspace_test.rs` to follow.

## Known limitations (draft)

- No 403 token-refresh on proxy-initiated requests (task-cache HTTP path has one).
- `PUT` buffers each object in memory before upload (objects are single compilation units, typically small).
- Disablement is silent at default verbosity; follow-up candidates: surface compile-cache status in run summary / dry-run output.