### PR TITLE
ci: Remove dead sccache configuration

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -81,16 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      # AWS-backed sccache is disabled.
-      # SCCACHE_BUCKET: turborepo-sccache
-      # SCCACHE_REGION: us-east-2
-      # RUSTC_WRAPPER: ${{ !github.event.pull_request.head.repo.fork && 'sccache' || '' }}
       CARGO_INCREMENTAL: 0
-      # AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      # SCCACHE_IDLE_TIMEOUT: 0
-      # SCCACHE_REQUEST_TIMEOUT: 30
-      # SCCACHE_ERROR_LOG: error
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -102,9 +93,6 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           node: "false"
-
-      # - name: Run sccache-cache
-      #   uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Run cargo clippy
         run: cargo lint

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -425,13 +425,7 @@ jobs:
       TURBO_TOKEN: ${{ github.event_name == 'pull_request' && 'unused' || secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ github.event_name == 'pull_request' && 'unused' || vars.TURBO_TEAM }}
       TURBO_CACHE: ${{ github.event_name == 'pull_request' && 'local:rw' || 'remote:rw' }}
-      # AWS-backed sccache is disabled.
-      # SCCACHE_BUCKET: turborepo-sccache
-      # SCCACHE_REGION: us-east-2
-      # RUSTC_WRAPPER: ${{ !github.event.pull_request.head.repo.fork && 'sccache' || '' }}
       CARGO_INCREMENTAL: 0
-      # AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -445,9 +439,6 @@ jobs:
 
       - name: Install Bun
         uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
-
-      # - name: Run sccache-cache
-      #   uses: mozilla-actions/sccache-action@v0.0.6
 
       - name: Build turbo binary
         run: cargo build


### PR DESCRIPTION
## Why

The AWS-backed sccache setup in CI was disabled a while ago, leaving commented-out env vars and steps in two workflows. Dead config is noise that misleads readers into thinking sccache is one uncomment away from working; the AWS bucket and credentials backing it are no longer in play.

## What

Removes the commented-out `SCCACHE_*`/`RUSTC_WRAPPER`/AWS env vars and `mozilla-actions/sccache-action` steps from the `rust_clippy` job (`lint.yml`) and the `check-lockfiles` job (`turborepo-test.yml`).

`CARGO_INCREMENTAL: 0` stays: disabling incremental compilation remains the right call in CI even without sccache, since incremental artifacts add build time with no reuse across jobs.

## How

Comment-only deletions; no behavioral change to CI. Verifiable by confirming both workflows produce identical runs before and after.