### PR TITLE
fix: Disable the sccache proxy when remote cache use is off

### DIFF
--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -991,6 +991,14 @@ impl Run {
             debug!("sccache compile cache disabled: not running in CI");
             return None;
         }
+        // The compile cache *is* the remote cache; when remote cache use is
+        // off for this run (e.g. `TURBO_CACHE=local:rw` in PR CI, where the
+        // credentials are placeholders), a proxy would only convert every
+        // sccache request into a doomed API call and a logged warning.
+        if !self.opts.cache_opts.cache.remote.should_use() {
+            debug!("sccache compile cache disabled: remote cache is not enabled for this run");
+            return None;
+        }
         let (Some(client), Some(auth)) = (self.api_client.clone(), self.api_auth.clone()) else {
             debug!("sccache compile cache disabled: Remote Cache is not configured");
             return None;


### PR DESCRIPTION
## Why

The sccache compile-cache proxy (#13288) gates on an initialized API client, but `should_initialize_http_client()` initializes one whenever credentials merely *look* linked. In CI configurations like this repo's PR jobs — `TURBO_TOKEN=unused`, `TURBO_TEAM=unused`, `TURBO_CACHE=local:rw` — the proxy would start with placeholder credentials, converting every sccache request into a doomed 403 and a visible warning line per compilation unit.

## What

One more precondition in `start_sccache_proxy_if_needed`: when remote cache use is disabled for the run (`cache_opts.cache.remote.should_use()` is false), the proxy soft-disables with a debug log, like the other absent-optimization paths.

## How

The compile cache *is* the remote cache, so "remote cache off" is a strictly correct reason not to serve it — this also covers `--cache=local:rw` and `TURBO_REMOTE_CACHE_ENABLED=0` generally, not just the placeholder-credentials case. Needed before dogfooding the flag here (the dogfood PR's CI would otherwise spam warnings on every PR run).