### PR TITLE
feat: Embed sccache so the Cargo compile cache needs no installation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,10 +126,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ar"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d67af77d68a931ecd5cbd8a3b5987d63a1d1d1278f7f6a60ae33db485cdebb69"
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -455,6 +467,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+ "gloo-timers",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,7 +487,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.36.7",
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
@@ -495,6 +518,15 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "biome_console"
@@ -802,6 +834,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,9 +937,9 @@ checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -984,8 +1030,10 @@ checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -1009,6 +1057,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -1188,6 +1237,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,6 +1293,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core_affinity"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a034b3a7b624016c6e13f5df875747cc25f884156aad2abd12b6c46797971342"
+dependencies = [
+ "libc",
+ "num_cpus",
+ "winapi",
+]
+
+[[package]]
 name = "countme"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,6 +1329,15 @@ name = "cpufeatures"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1412,6 +1487,15 @@ checksum = "672465ae37dc1bc6380a6547a8883d5dd397b0f1faaad4f265726cc7042a5345"
 dependencies = [
  "nix 0.28.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "daemonix"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0b747381562a10fd2104e9333ad72fe5158d79de81b64426fc9e229c6d3fb38"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1649,6 +1733,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
 name = "dirs"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1674,7 +1767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.3",
  "winapi",
 ]
 
@@ -1686,8 +1779,20 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.4.3",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1697,7 +1802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.3",
  "winapi",
 ]
 
@@ -1798,6 +1903,29 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "env_filter"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
 
 [[package]]
 name = "equator"
@@ -1972,12 +2100,24 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -2027,6 +2167,15 @@ name = "fs-err"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0845fa252299212f0389d64ba26f34fa32cfe41588355f21ed507c59a0f64541"
+
+[[package]]
+name = "fs-err"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "fs_extra"
@@ -2571,10 +2720,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "go-parse-duration"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "558b88954871f5e5b2af0e62e2e176c8bde7a6c2c4ed41b13d138d96da2e2cbd"
+
+[[package]]
+name = "gzp"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe9930717197e0ea50d8c8a1106a38b5bee0536ed4cbf4b93ba1a953f97d04"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "core_affinity",
+ "flate2",
+ "flume",
+ "log",
+ "num_cpus",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "h2"
@@ -2700,6 +2877,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2908,9 +3094,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -3611,6 +3799,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3744,11 +3942,12 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -3816,6 +4015,15 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.10",
+]
 
 [[package]]
 name = "napi"
@@ -4057,6 +4265,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
+]
+
+[[package]]
 name = "num_threads"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4064,6 +4282,12 @@ checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "objc"
@@ -4084,6 +4308,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "flate2",
+ "memchr",
+ "ruzstd",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4094,6 +4329,33 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "opendal"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d075ab8a203a6ab4bc1bce0a4b9fe486a72bf8b939037f4b78d95386384bc80a"
+dependencies = [
+ "anyhow",
+ "backon",
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "getrandom 0.2.10",
+ "http",
+ "http-body",
+ "jiff",
+ "log",
+ "md-5",
+ "percent-encoding",
+ "quick-xml",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+ "uuid",
+]
 
 [[package]]
 name = "openssl"
@@ -5169,6 +5431,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5460,6 +5732,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.10",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5502,9 +5785,11 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -5514,6 +5799,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -5701,6 +5987,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
+name = "ruzstd"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5732,6 +6027,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
 dependencies = [
  "sdd",
+]
+
+[[package]]
+name = "sccache"
+version = "0.16.0"
+source = "git+https://github.com/vercel/sccache?rev=2ae38fb94790cc8534e0fb9d7eef83dd95986a71#2ae38fb94790cc8534e0fb9d7eef83dd95986a71"
+dependencies = [
+ "anyhow",
+ "ar",
+ "async-trait",
+ "backon",
+ "base64 0.21.4",
+ "bincode",
+ "blake3",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "clap",
+ "daemonix",
+ "directories 6.0.0",
+ "encoding_rs",
+ "env_logger",
+ "filetime",
+ "fs-err 3.3.1",
+ "futures",
+ "gzp",
+ "http",
+ "itertools 0.14.0",
+ "jobserver",
+ "libc",
+ "linked-hash-map",
+ "log",
+ "memchr",
+ "memmap2 0.9.10",
+ "mime",
+ "number_prefix",
+ "object 0.37.3",
+ "opendal",
+ "rand 0.8.5",
+ "regex",
+ "reqwest",
+ "semver 1.0.23",
+ "serde",
+ "serde_json",
+ "shlex",
+ "strip-ansi-escapes",
+ "tar",
+ "tempfile",
+ "tokio",
+ "tokio-serde",
+ "tokio-util",
+ "toml 0.9.12+spec-1.1.0",
+ "tower-service",
+ "typed-path",
+ "uuid",
+ "walkdir",
+ "which 6.0.3",
+ "windows-sys 0.52.0",
+ "zip",
+ "zstd",
 ]
 
 [[package]]
@@ -5904,16 +6259,16 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "217ca874ae0207aac254aa02c957ded05585a90892cc8d87f9e5fa49669dadd8"
 dependencies = [
  "indexmap 2.13.0",
  "itoa",
  "memchr",
+ "ryu",
  "serde",
  "serde_core",
- "zmij",
 ]
 
 [[package]]
@@ -6046,7 +6401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.9",
  "digest",
 ]
 
@@ -6067,7 +6422,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.9",
  "digest",
 ]
 
@@ -6144,6 +6499,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6217,6 +6578,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spin"
@@ -6268,6 +6632,15 @@ name = "stringmetrics"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b3c8667cd96245cbb600b8dec5680a7319edd719c5aa2b5d23c6bff94f39765"
+
+[[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
+]
 
 [[package]]
 name = "strsim"
@@ -6465,6 +6838,27 @@ dependencies = [
  "once_cell",
  "rayon",
  "winapi",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.9.3",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -6848,6 +7242,18 @@ checksum = "e4beb8ba13bc53ac53ce1d52b42f02e5d8060f0f42138862869beb769722b256"
 dependencies = [
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "tokio-serde"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf600e7036b17782571dd44fa0a5cea3c82f60db5137f774a325a76a0d6852b"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project",
 ]
 
 [[package]]
@@ -7306,15 +7712,17 @@ dependencies = [
  "nix 0.26.2",
  "portable-pty",
  "pretty_assertions",
+ "sccache",
  "serde_json",
  "tempfile",
  "turborepo-lib",
  "turborepo-lsp",
  "turborepo-query",
  "turborepo-query-api",
+ "turborepo-repository",
  "turborepo-signals",
  "turborepo-ui",
- "which",
+ "which 4.4.0",
  "windows-sys 0.59.0",
 ]
 
@@ -7369,7 +7777,7 @@ dependencies = [
  "biome_json_parser",
  "camino",
  "dunce",
- "fs-err",
+ "fs-err 2.9.0",
  "miette",
  "path-clean",
  "serde",
@@ -7690,7 +8098,7 @@ dependencies = [
  "turborepo-task-id",
  "turborepo-turbo-json",
  "turborepo-types",
- "which",
+ "which 4.4.0",
 ]
 
 [[package]]
@@ -7766,7 +8174,7 @@ dependencies = [
 name = "turborepo-fs"
 version = "0.1.0"
 dependencies = [
- "fs-err",
+ "fs-err 2.9.0",
  "ignore",
  "tempfile",
  "test-case",
@@ -7952,7 +8360,7 @@ dependencies = [
  "url",
  "wax",
  "webbrowser",
- "which",
+ "which 4.4.0",
 ]
 
 [[package]]
@@ -8217,7 +8625,7 @@ dependencies = [
  "turborepo-lockfiles",
  "turborepo-rayon-compat",
  "wax",
- "which",
+ "which 4.4.0",
 ]
 
 [[package]]
@@ -8343,7 +8751,7 @@ dependencies = [
  "turborepo-log",
  "turborepo-telemetry",
  "wax",
- "which",
+ "which 4.4.0",
 ]
 
 [[package]]
@@ -8394,7 +8802,7 @@ dependencies = [
  "turbopath",
  "turborepo-repository",
  "turborepo-ui",
- "which",
+ "which 4.4.0",
 ]
 
 [[package]]
@@ -8436,7 +8844,7 @@ dependencies = [
  "turborepo-telemetry",
  "turborepo-types",
  "turborepo-ui",
- "which",
+ "which 4.4.0",
 ]
 
 [[package]]
@@ -8595,7 +9003,7 @@ dependencies = [
  "turborepo-ghostty",
  "turborepo-log",
  "turborepo-types",
- "which",
+ "which 4.4.0",
  "windows-sys 0.59.0",
 ]
 
@@ -8637,6 +9045,18 @@ dependencies = [
  "tokio",
  "turborepo-vercel-api",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
@@ -8778,7 +9198,7 @@ name = "update-informer"
 version = "1.1.0"
 source = "git+https://github.com/nicholaslyang/update-informer.git#7a78e90e62479e022bae77ada824c9df53036f96"
 dependencies = [
- "directories",
+ "directories 5.0.1",
  "reqwest",
  "semver 1.0.23",
  "serde",
@@ -8844,6 +9264,7 @@ dependencies = [
  "atomic",
  "getrandom 0.3.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -8864,6 +9285,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "vtparse"
@@ -9197,6 +9627,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+dependencies = [
+ "either",
+ "home",
+ "rustix 0.38.31",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9241,6 +9683,35 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -9597,6 +10068,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9807,10 +10284,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "zmij"
-version = "1.0.14"
+name = "zip"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,7 +1057,6 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
- "terminal_size",
 ]
 
 [[package]]
@@ -1792,7 +1791,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5352,7 +5351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -5386,7 +5385,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6032,7 +6031,7 @@ dependencies = [
 [[package]]
 name = "sccache"
 version = "0.16.0"
-source = "git+https://github.com/vercel/sccache?rev=2ae38fb94790cc8534e0fb9d7eef83dd95986a71#2ae38fb94790cc8534e0fb9d7eef83dd95986a71"
+source = "git+https://github.com/vercel/sccache?rev=8da042dcbff2c1269dcb491ef9127823563f76cb#8da042dcbff2c1269dcb491ef9127823563f76cb"
 dependencies = [
  "anyhow",
  "ar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,12 @@ turborepo-query-api = { path = "crates/turborepo-query-api" }
 turborepo-profile-md = { path = "crates/turborepo-profile-md" }
 turborepo-repository = { path = "crates/turborepo-repository" }
 turborepo-sccache-proxy = { path = "crates/turborepo-sccache-proxy" }
+# Vercel fork of mozilla/sccache (v0.16.0 + the `main_from_args` embedding
+# entrypoint from the `vercel/main-from-args` branch). Public, so anonymous
+# builds fetch it; the rev is pinned for reproducibility.
+sccache = { git = "https://github.com/vercel/sccache", rev = "2ae38fb94790cc8534e0fb9d7eef83dd95986a71", default-features = false, features = [
+  "webdav",
+] }
 turborepo-task-id = { path = "crates/turborepo-task-id" }
 turborepo-types = { path = "crates/turborepo-types" }
 turborepo-ui = { path = "crates/turborepo-ui" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ turborepo-sccache-proxy = { path = "crates/turborepo-sccache-proxy" }
 # Vercel fork of mozilla/sccache (v0.16.0 + the `main_from_args` embedding
 # entrypoint from the `vercel/main-from-args` branch). Public, so anonymous
 # builds fetch it; the rev is pinned for reproducibility.
-sccache = { git = "https://github.com/vercel/sccache", rev = "2ae38fb94790cc8534e0fb9d7eef83dd95986a71", default-features = false, features = [
+sccache = { git = "https://github.com/vercel/sccache", rev = "8da042dcbff2c1269dcb491ef9127823563f76cb", default-features = false, features = [
   "webdav",
 ] }
 turborepo-task-id = { path = "crates/turborepo-task-id" }

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -1003,14 +1003,22 @@ impl Run {
             debug!("sccache compile cache disabled: Remote Cache is not configured");
             return None;
         };
-        // Debug, not warn: the flag is repo-level configuration, so in a
-        // repository that dogfoods it, every contributor without sccache
-        // installed would otherwise see a warning on every run. Missing
-        // sccache is an absent optimization, not a problem with the run.
-        if which::which("sccache").is_err() {
-            debug!("sccache not found on PATH; compile cache disabled");
-            return None;
-        }
+        // The compiler wrapper is this very binary: turbo embeds sccache
+        // and dispatches wrapper invocations to it, so nothing needs to be
+        // installed. Cargo needs the wrapper as an executable path.
+        let wrapper = match std::env::current_exe() {
+            Ok(path) => match path.into_os_string().into_string() {
+                Ok(path) => path,
+                Err(_) => {
+                    warn!("compile cache disabled: turbo's path is not valid UTF-8");
+                    return None;
+                }
+            },
+            Err(err) => {
+                warn!("compile cache disabled: cannot determine turbo's path: {err}");
+                return None;
+            }
+        };
 
         let token_path = self
             .repo_root
@@ -1040,6 +1048,7 @@ impl Run {
         let endpoint = turborepo_repository::toolchain::CompileCacheEndpoint {
             url: server.endpoint(),
             token,
+            wrapper,
         };
         let shutdown = server.shutdown_handle();
         info!("sccache compile cache proxy listening on {}", endpoint.url);

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -514,10 +514,13 @@ impl Toolchain for CargoToolchain {
         display_command(details.kind, task, &name)
     }
 
-    /// Route rustc invocations through sccache, with the Turborepo-served
-    /// endpoint as its webdav storage backend. sccache fetches per
-    /// compilation-unit objects lazily at rustc invocation time, so no state
-    /// needs restoring before the task starts.
+    /// Route rustc invocations through the embedded sccache, with the
+    /// Turborepo-served endpoint as its webdav storage backend. The wrapper
+    /// is the running turbo binary itself (which dispatches invocations
+    /// marked by [`toolchain::COMPILE_CACHE_WRAPPER_ENV`] to the sccache it
+    /// embeds), so nothing needs to be installed. sccache fetches per
+    /// compilation-unit objects lazily at rustc invocation time, so no
+    /// state needs restoring before the task starts.
     ///
     /// `CARGO_INCREMENTAL=0` accompanies the wrapper because sccache cannot
     /// cache incrementally-compiled crates and would fall back to plain
@@ -534,7 +537,11 @@ impl Toolchain for CargoToolchain {
         endpoint: &toolchain::CompileCacheEndpoint,
     ) -> Vec<(String, String)> {
         vec![
-            ("RUSTC_WRAPPER".to_string(), "sccache".to_string()),
+            ("RUSTC_WRAPPER".to_string(), endpoint.wrapper.clone()),
+            (
+                toolchain::COMPILE_CACHE_WRAPPER_ENV.to_string(),
+                "1".to_string(),
+            ),
             ("SCCACHE_WEBDAV_ENDPOINT".to_string(), endpoint.url.clone()),
             ("SCCACHE_WEBDAV_TOKEN".to_string(), endpoint.token.clone()),
             ("CARGO_INCREMENTAL".to_string(), "0".to_string()),
@@ -1445,11 +1452,13 @@ checksum = "abc123"
         let endpoint = toolchain::CompileCacheEndpoint {
             url: "http://127.0.0.1:42123".to_string(),
             token: "proxy-token".to_string(),
+            wrapper: "/path/to/turbo".to_string(),
         };
         assert_eq!(
             toolchain.compile_cache_env(&endpoint),
             vec![
-                ("RUSTC_WRAPPER".to_string(), "sccache".to_string()),
+                ("RUSTC_WRAPPER".to_string(), "/path/to/turbo".to_string()),
+                ("TURBO_SCCACHE_WRAPPER".to_string(), "1".to_string()),
                 (
                     "SCCACHE_WEBDAV_ENDPOINT".to_string(),
                     "http://127.0.0.1:42123".to_string()

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -299,7 +299,16 @@ pub struct CompileCacheEndpoint {
     pub url: String,
     /// Bearer token the proxy requires.
     pub token: String,
+    /// Absolute path to the compiler-wrapper executable — the running
+    /// `turbo` binary itself, which embeds sccache and dispatches wrapper
+    /// invocations to it (see [`COMPILE_CACHE_WRAPPER_ENV`]).
+    pub wrapper: String,
 }
+
+/// Environment variable marking task processes whose `RUSTC_WRAPPER` is the
+/// turbo binary itself. The turbo entrypoint dispatches invocations carrying
+/// this marker to the embedded sccache instead of the normal CLI.
+pub const COMPILE_CACHE_WRAPPER_ENV: &str = "TURBO_SCCACHE_WRAPPER";
 
 /// A toolchain's contribution to a pruned repository. See
 /// [`Toolchain::prune_plan`].

--- a/crates/turborepo-turbo-json/src/future_flags.rs
+++ b/crates/turborepo-turbo-json/src/future_flags.rs
@@ -106,8 +106,9 @@ pub struct FutureFlags {
     ///
     /// Only engages in CI: cold environments are where a compile cache
     /// pays off, while local development is better served by cargo's own
-    /// incremental compilation (which sccache would disable). Requires
-    /// `sccache` on `PATH`; silently disabled otherwise.
+    /// incremental compilation (which sccache would disable). Nothing needs
+    /// to be installed: `turbo` embeds sccache and acts as the compiler
+    /// wrapper itself.
     #[serde(default)]
     #[schemars(skip)]
     pub experimental_cargo_sccache: bool,

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -274,11 +274,16 @@ whether anything changed; Cargo decides how and in what order to build.**
 - **Compile cache** (`Toolchain::compile_cache_env`, consumed by
   `ToolchainCommandProvider`; gated by `futureFlags.experimentalCargoSccache`):
   when enabled alongside `experimentalCargoWorkspaces` in a CI environment
-  with a linked Remote Cache and `sccache` on `PATH`, the run serves a
-  local HTTP proxy
+  with a linked Remote Cache, the run serves a local HTTP proxy
   (`turborepo-sccache-proxy`) that presents an sccache-compatible webdav
   storage backend and translates `GET`/`PUT`/`HEAD` into Remote Cache
-  artifact calls. Cargo tasks get `RUSTC_WRAPPER=sccache`,
+  artifact calls. Nothing needs installing: turbo embeds sccache as a
+  library (a Vercel fork of mozilla/sccache pinned in Cargo.toml, adding
+  an explicit-args entrypoint) and acts as the compiler wrapper itself —
+  `main.rs` dispatches invocations marked with `TURBO_SCCACHE_WRAPPER=1`
+  (and sccache's internal `SCCACHE_START_SERVER=1` respawn) to
+  `sccache::main_from_args`, alongside the LSP and Windows ctrl-c shims.
+  Cargo tasks get `RUSTC_WRAPPER=<turbo>`, the wrapper marker,
   `SCCACHE_WEBDAV_ENDPOINT`/`SCCACHE_WEBDAV_TOKEN`, and
   `CARGO_INCREMENTAL=0` injected at execution time; JavaScript injects
   nothing. Objects are fetched lazily per rustc invocation, so nothing is

--- a/crates/turborepo/Cargo.toml
+++ b/crates/turborepo/Cargo.toml
@@ -38,10 +38,12 @@ workspace = true
 anyhow = { workspace = true, features = ["backtrace"] }
 dhat = { workspace = true, optional = true }
 miette.workspace = true
+sccache = { workspace = true }
 turborepo-lib = { workspace = true, default-features = false }
 turborepo-lsp = { workspace = true, default-features = false }
 turborepo-query = { workspace = true }
 turborepo-query-api = { workspace = true }
+turborepo-repository = { workspace = true }
 turborepo-signals = { workspace = true }
 turborepo-ui = { workspace = true }
 

--- a/crates/turborepo/src/main.rs
+++ b/crates/turborepo/src/main.rs
@@ -92,6 +92,18 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
+    // Embedded sccache dispatch. These are hot per-rustc invocations from
+    // Cargo tasks (plus sccache's own background-server respawn), so they
+    // must bypass the normal CLI entirely. `main_from_args` never returns.
+    if let Some(args) = embedded_sccache_args(
+        std::env::args_os(),
+        std::env::var_os("SCCACHE_START_SERVER").is_some_and(|v| v == "1"),
+        std::env::var_os(turborepo_repository::toolchain::COMPILE_CACHE_WRAPPER_ENV)
+            .is_some_and(|v| v == "1"),
+    ) {
+        sccache::main_from_args(args);
+    }
+
     std::panic::set_hook(Box::new(turborepo_lib::panic_handler));
 
     let query_server: Arc<dyn turborepo_lib::QueryServer> = Arc::new(TurboQueryServer);
@@ -164,6 +176,52 @@ where
     }
 }
 
+/// Args for routing this invocation to the embedded sccache, or `None` for
+/// normal turbo operation. The returned args are shaped as an invocation of
+/// a binary named `sccache`.
+///
+/// Two invocation shapes route to sccache:
+///
+/// - The internal background-server respawn: sccache's client spawns
+///   `current_exe()` — this binary — with `SCCACHE_START_SERVER=1` and no
+///   meaningful args.
+/// - `RUSTC_WRAPPER` invocations from Cargo tasks: turbo injects itself as the
+///   wrapper (with the marker env var alongside), and cargo invokes `<wrapper>
+///   <compiler> <args...>`. The compiler must actually look like rustc so a
+///   stray `turbo` invocation inside a marked task environment cannot be
+///   misrouted into sccache executing its first argument.
+fn embedded_sccache_args<T>(
+    args: impl IntoIterator<Item = T>,
+    start_server: bool,
+    wrapper_marker: bool,
+) -> Option<Vec<std::ffi::OsString>>
+where
+    T: AsRef<OsStr>,
+{
+    if start_server {
+        return Some(vec!["sccache".into()]);
+    }
+    if !wrapper_marker {
+        return None;
+    }
+
+    let mut args = args.into_iter().skip(1);
+    let compiler = args.next()?;
+    let stem = std::path::Path::new(compiler.as_ref())
+        .file_stem()?
+        .to_str()?;
+    // `clippy-driver`: cargo clippy routes compilation through RUSTC_WRAPPER
+    // with the driver as the compiler argument.
+    if !matches!(stem, "rustc" | "clippy-driver") {
+        return None;
+    }
+
+    let mut sccache_args: Vec<std::ffi::OsString> =
+        vec!["sccache".into(), compiler.as_ref().to_owned()];
+    sccache_args.extend(args.map(|arg| arg.as_ref().to_owned()));
+    Some(sccache_args)
+}
+
 fn internal_lsp_command<T>(args: impl IntoIterator<Item = T>) -> Option<InternalLspCommand>
 where
     T: AsRef<OsStr>,
@@ -194,10 +252,71 @@ where
 mod tests {
     use std::ffi::OsString;
 
-    use super::{InternalLspCommand, internal_lsp_command};
+    use super::{InternalLspCommand, embedded_sccache_args, internal_lsp_command};
 
     fn args(args: &[&str]) -> Vec<OsString> {
         args.iter().map(OsString::from).collect()
+    }
+
+    #[test]
+    fn sccache_server_respawn_dispatches_regardless_of_args() {
+        assert_eq!(
+            embedded_sccache_args(args(&["turbo"]), true, false),
+            Some(args(&["sccache"]))
+        );
+    }
+
+    #[test]
+    fn sccache_wrapper_invocation_dispatches_with_marker() {
+        assert_eq!(
+            embedded_sccache_args(
+                args(&["turbo", "/toolchain/bin/rustc", "--crate-name", "foo"]),
+                false,
+                true,
+            ),
+            Some(args(&[
+                "sccache",
+                "/toolchain/bin/rustc",
+                "--crate-name",
+                "foo"
+            ]))
+        );
+        // Clippy routes compilation through the wrapper with its driver.
+        assert!(
+            embedded_sccache_args(args(&["turbo", "/bin/clippy-driver", "-vV"]), false, true)
+                .is_some()
+        );
+    }
+
+    /// Windows path parsing (`\` separators, `.exe`) only applies on
+    /// Windows, where `Path` handles both natively.
+    #[cfg(windows)]
+    #[test]
+    fn sccache_wrapper_dispatches_windows_compiler_paths() {
+        assert_eq!(
+            embedded_sccache_args(
+                args(&["turbo", r"C:\toolchain\rustc.exe", "-vV"]),
+                false,
+                true
+            ),
+            Some(args(&["sccache", r"C:\toolchain\rustc.exe", "-vV"]))
+        );
+    }
+
+    #[test]
+    fn sccache_wrapper_requires_marker_and_compiler_shape() {
+        // No marker: a normal turbo invocation, even if argv[1] is a path.
+        assert_eq!(
+            embedded_sccache_args(args(&["turbo", "/toolchain/bin/rustc"]), false, false),
+            None
+        );
+        // Marker leaked into a non-wrapper turbo invocation: first arg is
+        // not a compiler, so this must stay a normal turbo run.
+        assert_eq!(
+            embedded_sccache_args(args(&["turbo", "run", "build"]), false, true),
+            None
+        );
+        assert_eq!(embedded_sccache_args(args(&["turbo"]), false, true), None);
     }
 
     #[test]


### PR DESCRIPTION
## Why

The compile cache (#13288) required `sccache` on `PATH` — an install step in every adopting CI job, undercutting its "zero extra infrastructure" premise. sccache is a Rust lib+bin crate, so turbo can link it and act as the compiler wrapper itself: enabling the flag becomes the entire setup.

The blocker was sccache's only public entrypoint, which reads `env::args_os()` and dispatches on argv[0]'s file name — any other name triggers compiler-masquerade mode (and, when the name resolves back to itself, the fork-loop also reported in mozilla/sccache#2754). We carry a small patch on the existing `vercel/sccache` fork (branch `vercel/main-from-args`, based on the `v0.16.0` tag) adding `main_from_args`/`try_parse_from`: explicit args, no argv[0] heuristics, `SCCACHE_START_SERVER` respawn intact. The fork is public, so anonymous `cargo build` works for OSS contributors, and the rev is pinned in `Cargo.lock`.

## What

- `sccache` git dependency (`default-features = false, features = ["webdav"]` — no cloud backends, just the protocol our proxy speaks).
- Multicall dispatch in `crates/turborepo/src/main.rs` alongside the LSP/ctrl-c shims: invocations carrying `TURBO_SCCACHE_WRAPPER=1` with a compiler-shaped first argument (`rustc`/`clippy-driver`), or sccache's internal `SCCACHE_START_SERVER=1` respawn, route to `sccache::main_from_args`.
- Injection now sets `RUSTC_WRAPPER=<current turbo binary>` + the marker env var instead of `"sccache"`; the `which sccache` PATH check is deleted.
- Docs: flag docs and ARCHITECTURE.md no longer mention a PATH requirement.

## How

- **Misroute safety**: dispatch requires the marker env (only present in Cargo task environments turbo itself decorated) *and* a compiler-shaped argv[1] — a stray `turbo run build` inside a marked environment stays a normal turbo run, and sccache can never be handed an arbitrary first argument to execute.
- **Server respawn**: sccache's client spawns `current_exe()` with `SCCACHE_START_SERVER=1`; that's the turbo binary, whose dispatch routes it back into the embedded server. Verified end-to-end with the built binary: wrapper passthrough, background-server self-spawn, and a real `cargo build` miss→hit cycle through `RUSTC_WRAPPER=turbo`.
- **Lockfile**: `byteorder` 1.4.3→1.5.0, `serde_json` 1.0.149→1.0.146 (sccache upstream caps `<1.0.147`), plus sccache's tree. `cargo-deny check licenses` passes (Apache-2.0 allowlisted).

## Why two local servers?

A fair review question: the goal was sccache's invocation-hashing logic, yet a run spawns both sccache's background server and turbo's proxy. Each is load-bearing:

- **sccache's server** is the price of the hashing brain being fast. Cargo invokes the wrapper hundreds of times per build, so each invocation must cost ~nothing; sccache's architecture amortizes config parsing, compiler detection, and storage connections into one resident process with disposable thin clients. It ships with the brain — removing it means reimplementing sccache's core, which is exactly what this PR avoids.
- **The proxy is a credential boundary, not plumbing.** The alternative (patching the fork so the embedded server talks to the Remote Cache directly via `turborepo-api-client`) requires the server to construct credentials from its environment — putting the real team cache token in the env of every rustc invocation and every third-party `build.rs`, held by a daemon that outlives turbo. With the proxy, task processes only ever see a loopback URL plus a locally-scoped bearer token that's worthless once the proxy dies with the run; the real token never leaves turbo's own process.

Both listeners are loopback-only. The configuration where this genuinely collapses to one process is a future native wrapper (compilation-unit caching inside turbo's daemon, no sccache at all); the trait surface and injection here don't care what the wrapper is, so that door stays open.

## Testing

- Dispatch unit tests (respawn, wrapper shape, marker/compiler guards; Windows path case gated `cfg(windows)`).
- Updated `compile_cache_env` test; `cargo lint`, fmt, and touched-crate suites green.
- Manual: debug turbo as `RUSTC_WRAPPER` on a scratch crate — compile requests served, cache miss on cold build, hit after `cargo clean`.

## Follow-ups

- Drop the now-unneeded `mozilla-actions/sccache-action` step from #13292 once this merges.
- Measure release binary size delta from CI artifacts (spike suggests low single-digit MB after dep sharing).
