### PR TITLE
fix: Pin a flag-aware turbo canary for the eve-agent deployment

### DIFF
--- a/apps/agents/vercel.json
+++ b/apps/agents/vercel.json
@@ -1,3 +1,3 @@
 {
-  "installCommand": "pnpm install --filter=examples-agent..."
+  "installCommand": "pnpm install --filter=examples-agent... && pnpm --workspace-root add --save-dev turbo@2.10.5-canary.1 --config.minimum-release-age=0"
 }


### PR DESCRIPTION
## Why

`turborepo-eve-agent` production deployments have been failing since #13283: the Vercel builder uses a turbo that predates `futureFlags.experimentalCargoWorkspaces` and errors on the unknown key. The dogfood PR (#13292) adds `experimentalCargoSccache`, which needs a canary either way.

## What

Installs `turbo@2.10.5-canary.1` into the workspace root during the install step, same pattern as `apps/docs/vercel.json` — the builder detects the workspace turbo and uses it for the build.

## How

Remove the pin (restoring the plain install command) once a stable release knows both future flags. Verify via the Vercel deployment check on this PR.