### PR TITLE
fix: Make the sccache compile cache actually cache

### DIFF
--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -151,7 +151,9 @@ jobs:
           echo "Checking path patterns..."
 
           check_paths "docs" "docs/"
-          check_paths "native-lib" "packages/turbo-repository/,crates/"
+          # Root turbo.json is included because it configures the Cargo task
+          # pipeline these packages build through (futureFlags, task defs).
+          check_paths "native-lib" "packages/turbo-repository/,crates/,turbo.json"
 
           # Handle the "rest" pattern - files that are NOT in examples/ or docs/
           CHANGED_FILES=$(git diff --name-only $BASE_COMMIT $HEAD_COMMIT)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8695,6 +8695,7 @@ dependencies = [
  "bytes",
  "futures",
  "hex",
+ "opendal",
  "port_scanner",
  "rand 0.9.3",
  "reqwest",

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -1049,6 +1049,7 @@ impl Run {
             url: server.endpoint(),
             token,
             wrapper,
+            server_port: turborepo_sccache_proxy::derive_server_port(&self.repo_root),
         };
         let shutdown = server.shutdown_handle();
         info!("sccache compile cache proxy listening on {}", endpoint.url);

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -544,6 +544,10 @@ impl Toolchain for CargoToolchain {
             ),
             ("SCCACHE_WEBDAV_ENDPOINT".to_string(), endpoint.url.clone()),
             ("SCCACHE_WEBDAV_TOKEN".to_string(), endpoint.token.clone()),
+            (
+                "SCCACHE_SERVER_PORT".to_string(),
+                endpoint.server_port.to_string(),
+            ),
             ("CARGO_INCREMENTAL".to_string(), "0".to_string()),
         ]
     }
@@ -1453,6 +1457,7 @@ checksum = "abc123"
             url: "http://127.0.0.1:42123".to_string(),
             token: "proxy-token".to_string(),
             wrapper: "/path/to/turbo".to_string(),
+            server_port: 46123,
         };
         assert_eq!(
             toolchain.compile_cache_env(&endpoint),
@@ -1467,6 +1472,7 @@ checksum = "abc123"
                     "SCCACHE_WEBDAV_TOKEN".to_string(),
                     "proxy-token".to_string()
                 ),
+                ("SCCACHE_SERVER_PORT".to_string(), "46123".to_string()),
                 ("CARGO_INCREMENTAL".to_string(), "0".to_string()),
             ]
         );

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -303,6 +303,11 @@ pub struct CompileCacheEndpoint {
     /// `turbo` binary itself, which embeds sccache and dispatches wrapper
     /// invocations to it (see [`COMPILE_CACHE_WRAPPER_ENV`]).
     pub wrapper: String,
+    /// Port for the compile cache's background server, stable per
+    /// repository. Isolates turbo's server from any user- or image-managed
+    /// sccache server on the global default port, whose storage
+    /// configuration would otherwise capture turbo's wrapper traffic.
+    pub server_port: u16,
 }
 
 /// Environment variable marking task processes whose `RUSTC_WRAPPER` is the

--- a/crates/turborepo-sccache-proxy/Cargo.toml
+++ b/crates/turborepo-sccache-proxy/Cargo.toml
@@ -22,6 +22,12 @@ turborepo-api-client = { workspace = true }
 turborepo-types = { workspace = true }
 
 [dev-dependencies]
+# The same webdav client (and version) sccache uses for storage; the
+# regression tests must exercise the proxy through the real client, not
+# hand-rolled HTTP.
+opendal = { version = "0.55.0", default-features = false, features = [
+  "services-webdav",
+] }
 port_scanner = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 tempfile = { workspace = true }

--- a/crates/turborepo-sccache-proxy/src/lib.rs
+++ b/crates/turborepo-sccache-proxy/src/lib.rs
@@ -33,10 +33,9 @@ use std::sync::Arc;
 use axum::{
     Router,
     body::Body,
-    extract::{Path, State},
+    extract::State,
     http::{HeaderMap, StatusCode, header},
     response::{IntoResponse, Response},
-    routing::head,
 };
 use sha2::{Digest, Sha256};
 use tokio::net::TcpListener;
@@ -77,6 +76,18 @@ pub fn derive_port(repo_root: &AbsoluteSystemPath) -> u16 {
     // Two bytes of the digest are ample for a 3000-slot range.
     let n = u16::from_be_bytes([digest[0], digest[1]]);
     PORT_RANGE_START + (n % PORT_RANGE_LEN)
+}
+
+/// Derive the port for the sccache background server itself
+/// (`SCCACHE_SERVER_PORT`), also stable per repository but distinct from
+/// the proxy port. Without this, sccache uses its global default (4226):
+/// a developer's or CI image's own sccache server would then capture
+/// turbo's wrapper traffic with whatever storage *it* was started with,
+/// silently bypassing the Remote Cache — and vice versa.
+pub fn derive_server_port(repo_root: &AbsoluteSystemPath) -> u16 {
+    let digest = Sha256::digest(repo_root.as_str().as_bytes());
+    let n = u16::from_be_bytes([digest[2], digest[3]]);
+    PORT_RANGE_START + PORT_RANGE_LEN + (n % PORT_RANGE_LEN)
 }
 
 /// Load the per-repository bearer token, creating it on first use.
@@ -172,9 +183,12 @@ impl SccacheProxyServer {
             auth,
             expected_authorization: format!("Bearer {token}"),
         });
-        let router = Router::new()
-            .route("/{*key}", head(handle_head).get(handle_get).put(handle_put))
-            .with_state(state);
+        // A single fallback dispatcher rather than per-method routes: the
+        // webdav surface opendal (sccache's storage client) speaks includes
+        // extension methods (`PROPFIND`, `MKCOL`) that axum's method routers
+        // don't cover, plus the root path `/` that a `/{*key}` wildcard
+        // doesn't match.
+        let router = Router::new().fallback(handle_request).with_state(state);
 
         let (shutdown_tx, _) = tokio::sync::broadcast::channel(1);
         Ok(Self {
@@ -218,14 +232,106 @@ fn authorized(state: &ProxyState, headers: &HeaderMap) -> bool {
         .is_some_and(|value| value == state.expected_authorization)
 }
 
-async fn handle_get(
+/// Dispatch a request by method. opendal's webdav backend (sccache's
+/// storage client) uses `GET` for reads, but its write path first stats
+/// ancestor "directories" with `PROPFIND` and creates them with `MKCOL`
+/// before `PUT`ting the object. The Remote Cache is a flat object store, so
+/// collections are purely virtual: `MKCOL` always succeeds and `PROPFIND`
+/// reports every directory-shaped path as an existing collection.
+async fn handle_request(
     State(state): State<Arc<ProxyState>>,
-    Path(key): Path<String>,
-    headers: HeaderMap,
+    request: axum::extract::Request,
 ) -> Response {
-    if !authorized(&state, &headers) {
+    let (parts, body) = request.into_parts();
+    if !authorized(&state, &parts.headers) {
         return StatusCode::UNAUTHORIZED.into_response();
     }
+    let key = parts.uri.path().trim_start_matches('/').to_string();
+
+    match parts.method.as_str() {
+        "GET" => handle_get(state, key).await,
+        "HEAD" => handle_head(state, key).await,
+        "PUT" => {
+            let body = match axum::body::to_bytes(body, MAX_OBJECT_SIZE).await {
+                Ok(bytes) => bytes,
+                Err(err) => {
+                    warn!("sccache proxy rejected body for key {key}: {err}");
+                    return StatusCode::PAYLOAD_TOO_LARGE.into_response();
+                }
+            };
+            handle_put(state, key, body).await
+        }
+        "MKCOL" => StatusCode::CREATED.into_response(),
+        "PROPFIND" => handle_propfind(state, key).await,
+        "OPTIONS" => (
+            [(header::ALLOW, "OPTIONS, GET, HEAD, PUT, MKCOL, PROPFIND")],
+            "",
+        )
+            .into_response(),
+        _ => StatusCode::METHOD_NOT_ALLOWED.into_response(),
+    }
+}
+
+/// Compilation units are single objects; anything larger than this is not a
+/// plausible cache entry.
+const MAX_OBJECT_SIZE: usize = 512 * 1024 * 1024;
+
+/// Minimal WebDAV `207 Multistatus` answer for a stat. Directory-shaped
+/// paths (root or trailing slash) always exist as collections; object paths
+/// are answered from the Remote Cache.
+async fn handle_propfind(state: Arc<ProxyState>, key: String) -> Response {
+    fn multistatus(href: &str, resourcetype: &str, content_length: Option<u64>) -> Response {
+        // The cache has no meaningful mtimes; opendal's parser requires the
+        // field to be present, not truthful.
+        let length_prop = content_length
+            .map(|len| format!("<D:getcontentlength>{len}</D:getcontentlength>"))
+            .unwrap_or_default();
+        let body = format!(
+            r#"<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:">
+  <D:response>
+    <D:href>/{href}</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:resourcetype>{resourcetype}</D:resourcetype>
+        <D:getlastmodified>Thu, 01 Jan 1970 00:00:00 GMT</D:getlastmodified>
+        {length_prop}
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+</D:multistatus>"#
+        );
+        (
+            StatusCode::MULTI_STATUS,
+            [(header::CONTENT_TYPE, "application/xml; charset=utf-8")],
+            body,
+        )
+            .into_response()
+    }
+
+    if key.is_empty() || key.ends_with('/') {
+        return multistatus(&key, "<D:collection/>", None);
+    }
+    let id = artifact_id_for_key(&key);
+    match state
+        .client
+        .artifact_exists(&id, state.token(), state.team_id(), state.team_slug())
+        .await
+    {
+        Ok(Some(response)) => {
+            let content_length = response.content_length();
+            multistatus(&key, "", content_length.or(Some(0)))
+        }
+        Ok(None) => StatusCode::NOT_FOUND.into_response(),
+        Err(err) => {
+            warn!("sccache proxy stat failed for key {key}: {err}");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+async fn handle_get(state: Arc<ProxyState>, key: String) -> Response {
     let id = artifact_id_for_key(&key);
     match state
         .client
@@ -247,14 +353,7 @@ async fn handle_get(
     }
 }
 
-async fn handle_head(
-    State(state): State<Arc<ProxyState>>,
-    Path(key): Path<String>,
-    headers: HeaderMap,
-) -> Response {
-    if !authorized(&state, &headers) {
-        return StatusCode::UNAUTHORIZED.into_response();
-    }
+async fn handle_head(state: Arc<ProxyState>, key: String) -> Response {
     let id = artifact_id_for_key(&key);
     match state
         .client
@@ -270,15 +369,7 @@ async fn handle_head(
     }
 }
 
-async fn handle_put(
-    State(state): State<Arc<ProxyState>>,
-    Path(key): Path<String>,
-    headers: HeaderMap,
-    body: bytes::Bytes,
-) -> Response {
-    if !authorized(&state, &headers) {
-        return StatusCode::UNAUTHORIZED.into_response();
-    }
+async fn handle_put(state: Arc<ProxyState>, key: String, body: bytes::Bytes) -> Response {
     let id = artifact_id_for_key(&key);
     let len = body.len();
     let stream = futures::stream::once(async move { Ok(body) });
@@ -374,6 +465,64 @@ mod tests {
         let port = derive_port(root);
         assert_eq!(port, derive_port(root));
         assert!((PORT_RANGE_START..PORT_RANGE_START + PORT_RANGE_LEN).contains(&port));
+    }
+
+    #[test]
+    fn derived_server_port_is_stable_and_disjoint_from_proxy_range() {
+        let root = if cfg!(windows) {
+            AbsoluteSystemPath::new("C:\\some\\repo").expect("path")
+        } else {
+            AbsoluteSystemPath::new("/some/repo").expect("path")
+        };
+        let port = derive_server_port(root);
+        assert_eq!(port, derive_server_port(root));
+        assert!(
+            (PORT_RANGE_START + PORT_RANGE_LEN..PORT_RANGE_START + 2 * PORT_RANGE_LEN)
+                .contains(&port)
+        );
+        assert_ne!(port, derive_port(root));
+        // Never sccache's global default, which a user-managed server may own.
+        assert_ne!(port, 4226);
+    }
+
+    /// The proxy must be writable and readable through the exact webdav
+    /// client sccache uses (opendal), whose write path stats ancestors with
+    /// PROPFIND and creates them with MKCOL before PUT. Hand-rolled HTTP in
+    /// the other tests would not catch a missing method — this is the test
+    /// for the 100%-write-failure bug found in dogfooding.
+    #[tokio::test]
+    async fn opendal_webdav_client_round_trip() {
+        let (backend_port, backend) = start_backend().await;
+        let bearer = "opendal-test-token";
+        let (server, port) = start_proxy(backend_port, bearer).await;
+        let shutdown = server.shutdown_handle();
+        let proxy = tokio::spawn(server.run());
+
+        let builder = opendal::services::Webdav::default()
+            .endpoint(&format!("http://127.0.0.1:{port}"))
+            .token(bearer);
+        let op = opendal::Operator::new(builder).expect("operator").finish();
+
+        // sccache's startup check writes and reads a probe object.
+        op.write(".sccache_check", "a".as_bytes())
+            .await
+            .expect("probe write through opendal");
+
+        // Fan-out shaped key, exactly like sccache cache entries.
+        let key = "b/2/1/b21968b0f44324b39f68e21c5a8c2eb7608964f9089a2e19d35710b33fa7c4cb";
+        assert!(
+            op.read(key).await.is_err(),
+            "read before write must be a miss"
+        );
+        op.write(key, "object bytes".as_bytes())
+            .await
+            .expect("cache write through opendal");
+        let read = op.read(key).await.expect("cache read through opendal");
+        assert_eq!(read.to_bytes().as_ref(), b"object bytes");
+
+        let _ = shutdown.send(());
+        let _ = proxy.await;
+        backend.abort();
     }
 
     #[test]


### PR DESCRIPTION
## Why

End-to-end dogfooding against the real Remote Cache (which CI cannot do on PRs — placeholder credentials) surfaced two bugs that made the compile cache pure overhead: a cold 430-crate build produced **812 cache write errors and a 0% hit rate**, so the follow-up build paid per-object network misses on top of full compilation.

1. **The proxy didn't speak opendal's write dialect.** sccache's storage client stats ancestor "directories" with `PROPFIND` and creates them with `MKCOL` before any `PUT`. The proxy only routed `GET`/`HEAD`/`PUT`, so storage initialization failed and every write died without reaching a handler — silently, since unrouted methods produce no proxy logs. The existing tests missed it because they drove the proxy with hand-rolled HTTP instead of the real client.
2. **sccache's background server used the global default port (4226).** Any user- or CI-image-managed sccache server already on that port captures turbo's wrapper traffic with whatever storage *it* was started with — silently bypassing the Remote Cache (this exact hijack corrupted the first measurement attempt).

## What

- The proxy serves the webdav write surface: `MKCOL` always succeeds (collections are virtual — the Remote Cache is a flat object store), `PROPFIND` answers directory-shaped paths as existing collections and object paths from `artifact_exists`, with the minimal multistatus body opendal's parser requires. Routing moved to a single method dispatcher (also fixes the unmatched root path `/`).
- `SCCACHE_SERVER_PORT` is injected alongside the other wrapper env, derived per repository in a range disjoint from the proxy's.
- Root `turbo.json` joins the `native-lib` CI path filter, so future-flag changes run `js_native_packages` — the job that exercises Cargo tasks (the dogfood PR's job was silently skipped without this).

## How

Regression coverage now goes through the genuine article: a dev-dep on opendal `0.55` (sccache's exact webdav client version) doing the probe-write/fan-out-key write/read cycle against the proxy + mock API. That test fails on the old router with the exact production error (`missing field getlastmodified` → storage init failure).

Measured **locally** (M-series macOS, debug-build turbo as the wrapper, production Remote Cache) on a 430-crate cold build, `cargo clean` between runs, `--force` — CI cannot produce these numbers until this ships in a canary, since PR runs use placeholder credentials by design:

| | wall | compile cache |
|---|---|---|
| populate | 107s | 406 misses stored, 0 write errors |
| rebuild | **42s** | **406/406 hits (100%)** |

~2.5x — with an unoptimized debug turbo as the wrapper; release binaries in CI should do better. The rebuild also validated endpoint stability: its wrapper invocations were served by the persistent server spawned in the first run.

First GitHub-Actions-visible verification will be consecutive push-to-main runs of `js_native_packages` once this is in the canary the dogfood PR (#13292) runs on: look for `sccache compile cache proxy listening` in the logs and compare `turborepo-napi#build` wall time across runs.
