### PR TITLE
fix: Stop ambient CARGO_INCREMENTAL from suppressing compile cache injection

### DIFF
--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -528,15 +528,32 @@ impl Toolchain for CargoToolchain {
     ///
     /// These are injected at execution time only and deliberately do not
     /// participate in the task hash: a compile cache is output-transparent,
-    /// so enabling it must not invalidate existing task artifacts. A
-    /// user-supplied `RUSTC_WRAPPER` (which does participate, via
-    /// [`HASHED_ENV_VARS`]) suppresses this injection entirely — see
-    /// [`Toolchain::compile_cache_env`].
+    /// so enabling it must not invalidate existing task artifacts.
+    ///
+    /// Composition with the task environment:
+    ///
+    /// - A pre-existing `RUSTC_WRAPPER` or any `SCCACHE_*` variable signals a
+    ///   competing compiler-cache configuration; injecting on top of it could
+    ///   hijack that setup's backend, so the whole set stands down.
+    ///   (`RUSTC_WRAPPER` participates in task hashes via [`HASHED_ENV_VARS`],
+    ///   so a user wrapper also invalidates caches — the injected one
+    ///   deliberately does not.)
+    /// - A pre-existing `CARGO_INCREMENTAL` is common CI hygiene, not a
+    ///   competing cache: the rest is injected and the explicit value is left
+    ///   alone. (When absent, `CARGO_INCREMENTAL=0` is injected because sccache
+    ///   cannot cache incrementally-compiled crates.)
     fn compile_cache_env(
         &self,
         endpoint: &toolchain::CompileCacheEndpoint,
+        task_env: &std::collections::HashMap<String, String>,
     ) -> Vec<(String, String)> {
-        vec![
+        if task_env.contains_key("RUSTC_WRAPPER")
+            || task_env.keys().any(|key| key.starts_with("SCCACHE_"))
+        {
+            return Vec::new();
+        }
+
+        let mut vars = vec![
             ("RUSTC_WRAPPER".to_string(), endpoint.wrapper.clone()),
             (
                 toolchain::COMPILE_CACHE_WRAPPER_ENV.to_string(),
@@ -548,8 +565,11 @@ impl Toolchain for CargoToolchain {
                 "SCCACHE_SERVER_PORT".to_string(),
                 endpoint.server_port.to_string(),
             ),
-            ("CARGO_INCREMENTAL".to_string(), "0".to_string()),
-        ]
+        ];
+        if !task_env.contains_key("CARGO_INCREMENTAL") {
+            vars.push(("CARGO_INCREMENTAL".to_string(), "0".to_string()));
+        }
+        vars
     }
 
     fn defines_task(&self, package: &crate::package_graph::PackageInfo, task: &str) -> bool {
@@ -1460,7 +1480,7 @@ checksum = "abc123"
             server_port: 46123,
         };
         assert_eq!(
-            toolchain.compile_cache_env(&endpoint),
+            toolchain.compile_cache_env(&endpoint, &std::collections::HashMap::new()),
             vec![
                 ("RUSTC_WRAPPER".to_string(), "/path/to/turbo".to_string()),
                 ("TURBO_SCCACHE_WRAPPER".to_string(), "1".to_string()),
@@ -1480,6 +1500,61 @@ checksum = "abc123"
         // user-supplied wrapper invalidates task results (the injected one
         // is execution-only and deliberately does not).
         assert!(HASHED_ENV_VARS.contains(&"RUSTC_WRAPPER"));
+    }
+
+    #[test]
+    fn test_compile_cache_env_stands_down_for_competing_configuration() {
+        let (_tmp, root) = tempdir_root();
+        let toolchain = CargoToolchain::new(root);
+        let endpoint = toolchain::CompileCacheEndpoint {
+            url: "http://127.0.0.1:42123".to_string(),
+            token: "proxy-token".to_string(),
+            wrapper: "/path/to/turbo".to_string(),
+            server_port: 46123,
+        };
+
+        // A user-supplied wrapper wins; injecting SCCACHE_* on top of it
+        // could hijack its backend, so nothing is injected.
+        let env = std::collections::HashMap::from([(
+            "RUSTC_WRAPPER".to_string(),
+            "/home/user/bin/my-wrapper".to_string(),
+        )]);
+        assert!(toolchain.compile_cache_env(&endpoint, &env).is_empty());
+
+        // Any SCCACHE_* variable signals a user-managed sccache setup.
+        let env = std::collections::HashMap::from([(
+            "SCCACHE_GHA_ENABLED".to_string(),
+            "true".to_string(),
+        )]);
+        assert!(toolchain.compile_cache_env(&endpoint, &env).is_empty());
+    }
+
+    #[test]
+    fn test_compile_cache_env_tolerates_ambient_cargo_incremental() {
+        // CI images commonly export CARGO_INCREMENTAL=0 (this repository's
+        // own setup-environment action does). That is ambient hygiene, not
+        // a competing compiler cache: the injection proceeds and the
+        // explicit value is left alone.
+        let (_tmp, root) = tempdir_root();
+        let toolchain = CargoToolchain::new(root);
+        let endpoint = toolchain::CompileCacheEndpoint {
+            url: "http://127.0.0.1:42123".to_string(),
+            token: "proxy-token".to_string(),
+            wrapper: "/path/to/turbo".to_string(),
+            server_port: 46123,
+        };
+        let env =
+            std::collections::HashMap::from([("CARGO_INCREMENTAL".to_string(), "0".to_string())]);
+
+        let vars = toolchain.compile_cache_env(&endpoint, &env);
+        assert!(
+            vars.iter().any(|(key, _)| key == "RUSTC_WRAPPER"),
+            "injection must proceed despite ambient CARGO_INCREMENTAL"
+        );
+        assert!(
+            !vars.iter().any(|(key, _)| key == "CARGO_INCREMENTAL"),
+            "an explicit CARGO_INCREMENTAL must not be overridden"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -281,12 +281,22 @@ pub trait Toolchain: Send + Sync {
     /// front of the remote cache that a compiler wrapper like sccache can
     /// use as its storage backend).
     ///
-    /// An empty result means the toolchain has no compile-cache integration
-    /// (the JavaScript default). The executor never applies these variables
-    /// over ones already present in the task's environment: a user-supplied
-    /// configuration (e.g. their own `RUSTC_WRAPPER`) always wins.
-    fn compile_cache_env(&self, endpoint: &CompileCacheEndpoint) -> Vec<(String, String)> {
-        let _ = endpoint;
+    /// `task_env` is the environment the task process will receive; the
+    /// toolchain decides how its injection composes with it. Only the
+    /// toolchain knows which pre-existing variables signal a *competing*
+    /// configuration that must win (e.g. a user-supplied `RUSTC_WRAPPER`)
+    /// versus ones that are merely common ambient settings (e.g. CI images
+    /// exporting `CARGO_INCREMENTAL=0`, which is exactly what the compile
+    /// cache wants anyway). The executor injects the returned variables
+    /// verbatim; an empty result means inject nothing — either no
+    /// integration exists (the JavaScript default) or the toolchain chose
+    /// to stand down.
+    fn compile_cache_env(
+        &self,
+        endpoint: &CompileCacheEndpoint,
+        task_env: &std::collections::HashMap<String, String>,
+    ) -> Vec<(String, String)> {
+        let _ = (endpoint, task_env);
         Vec::new()
     }
 }

--- a/crates/turborepo-task-executor/src/command.rs
+++ b/crates/turborepo-task-executor/src/command.rs
@@ -262,17 +262,17 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
             cmd.env("TURBO_MFE_PORT", port.to_string());
         }
 
+        // The toolchain decides how the injection composes with the task's
+        // environment (competing configuration suppresses it, ambient
+        // settings are tolerated) and returns exactly what to inject; see
+        // `Toolchain::compile_cache_env`.
         if let Some(endpoint) = self.compile_cache {
-            match compile_cache_env_to_inject(toolchain.compile_cache_env(endpoint), environment) {
-                Ok(vars) => {
-                    for (key, value) in vars {
-                        cmd.env(key, value);
-                    }
-                }
-                Err(conflict) => debug!(
-                    "not injecting compile cache env for {task_id}: task environment already sets \
-                     {conflict}"
-                ),
+            let vars = toolchain.compile_cache_env(endpoint, environment);
+            if vars.is_empty() {
+                debug!("no compile cache env to inject for {task_id}");
+            }
+            for (key, value) in vars {
+                cmd.env(key, value);
             }
         }
 
@@ -281,29 +281,6 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
         cmd.open_stdin();
 
         Ok(Some(cmd))
-    }
-}
-
-/// The compile-cache variables to apply for a task, given what the
-/// toolchain wants injected
-/// ([`turborepo_repository::toolchain::Toolchain::compile_cache_env`], empty
-/// for toolchains without an integration) and the task's environment.
-///
-/// Never overrides variables the task environment already sets: a
-/// user-supplied configuration (e.g. their own `RUSTC_WRAPPER` pointing at
-/// a different cache) wins, and partially applying ours on top of theirs
-/// could hijack its backend — so one conflicting variable suppresses the
-/// whole set. Returns the conflicting variable name as the error.
-fn compile_cache_env_to_inject(
-    vars: Vec<(String, String)>,
-    environment: &EnvironmentVariableMap,
-) -> Result<Vec<(String, String)>, String> {
-    match vars
-        .iter()
-        .find(|(key, _)| environment.contains_key(key.as_str()))
-    {
-        Some((conflict, _)) => Err(conflict.clone()),
-        None => Ok(vars),
     }
 }
 
@@ -757,51 +734,6 @@ mod tests {
             .command(&task_id, &EnvironmentVariableMap::default())
             .unwrap();
         assert!(cmd.is_none(), "expected no cmd, got {cmd:?}");
-    }
-
-    #[test]
-    fn test_compile_cache_env_injected_when_unconflicted() {
-        let vars = vec![
-            ("RUSTC_WRAPPER".to_owned(), "sccache".to_owned()),
-            ("SCCACHE_WEBDAV_ENDPOINT".to_owned(), "http://x".to_owned()),
-        ];
-        let environment = EnvironmentVariableMap::from(HashMap::from([(
-            "PATH".to_owned(),
-            "/usr/bin".to_owned(),
-        )]));
-        assert_eq!(
-            compile_cache_env_to_inject(vars.clone(), &environment),
-            Ok(vars)
-        );
-    }
-
-    #[test]
-    fn test_compile_cache_env_suppressed_entirely_on_conflict() {
-        // A user-supplied RUSTC_WRAPPER must suppress the whole set:
-        // injecting only SCCACHE_* on top of it could hijack the backend of
-        // the user's own wrapper.
-        let vars = vec![
-            ("RUSTC_WRAPPER".to_owned(), "sccache".to_owned()),
-            ("SCCACHE_WEBDAV_ENDPOINT".to_owned(), "http://x".to_owned()),
-        ];
-        let environment = EnvironmentVariableMap::from(HashMap::from([(
-            "RUSTC_WRAPPER".to_owned(),
-            "/home/user/bin/my-wrapper".to_owned(),
-        )]));
-        assert_eq!(
-            compile_cache_env_to_inject(vars, &environment),
-            Err("RUSTC_WRAPPER".to_owned())
-        );
-    }
-
-    #[test]
-    fn test_empty_compile_cache_env_injects_nothing() {
-        // The JavaScript default: no compile-cache integration.
-        let environment = EnvironmentVariableMap::default();
-        assert_eq!(
-            compile_cache_env_to_inject(Vec::new(), &environment),
-            Ok(Vec::new())
-        );
     }
 
     #[tokio::test]

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -293,10 +293,13 @@ whether anything changed; Cargo decides how and in what order to build.**
   background server captures it at startup and outlives the run: the port
   is derived from the repo root and the bearer token is persisted at
   `.turbo/sccache-proxy-token`. Injection is execution-only and does not
-  participate in task hashes (a compile cache is output-transparent); a
-  user-supplied `RUSTC_WRAPPER` in the task environment suppresses the
-  whole injected set, and every unmet precondition disables the proxy
-  softly. CI-only by design: cold environments are where a compile cache
+  participate in task hashes (a compile cache is output-transparent). The
+  toolchain decides how injection composes with the task environment: a
+  user-supplied `RUSTC_WRAPPER` or any `SCCACHE_*` variable signals a
+  competing compiler-cache configuration and suppresses the whole injected
+  set, while an ambient `CARGO_INCREMENTAL` (CI images commonly export
+  `=0`) is tolerated — injection proceeds without overriding it. Every
+  unmet precondition disables the proxy softly. CI-only by design: cold environments are where a compile cache
   pays off, while local development is served by cargo's own incremental
   compilation — which the injected `CARGO_INCREMENTAL=0` would disable.
   Lifecycle: started in `Run::execute_visitor` before the visitor,


### PR DESCRIPTION
## Why

The compile cache engaged nowhere in CI — discovered while trying to produce GHA proof for #13292. The executor's conflict guard suppressed the *entire* injection when any injected key already existed in the task environment. This repository's own `setup-environment` action exports `CARGO_INCREMENTAL=0`, `globalPassThroughEnv` carries it into every task env, and so the guard tripped on every CI run: no wrapper, no proxy traffic, identical timings (bench runs [28838729601](https://github.com/vercel/turborepo/actions/runs/28838729601) and [28838893571](https://github.com/vercel/turborepo/actions/runs/28838893571) — proxy started, zero requests). The irony: the pre-existing value was `0`, exactly what the injection would have set.

## What

The composition decision moves from the executor into `Toolchain::compile_cache_env`, which now receives the task environment and returns exactly what to inject:

- A pre-existing `RUSTC_WRAPPER` or any `SCCACHE_*` variable signals a *competing* compiler-cache configuration → the whole set stands down (injecting on top could hijack that setup's backend).
- A pre-existing `CARGO_INCREMENTAL` is ambient CI hygiene, not a competing cache → injection proceeds, the explicit value is left alone.

The executor injects the returned variables verbatim, staying free of toolchain knowledge (per the toolchain design rules).

## How

Only the toolchain can classify its own environment variables — the executor's generic "any overlap suppresses all" rule had no way to distinguish a user's wrapper from a CI image's `CARGO_INCREMENTAL=0`. Covered by three `compile_cache_env` tests: clean env (full set), competing config (`RUSTC_WRAPPER` / `SCCACHE_GHA_ENABLED` → empty), ambient `CARGO_INCREMENTAL` (injected minus the override).

After this ships in a canary, the bench workflow on `shew/sccache-bench` re-runs without its `env -u CARGO_INCREMENTAL` workaround.