### PR TITLE
ci: Authenticate to Remote Cache via OIDC token exchange

### DIFF
--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -382,16 +382,25 @@ jobs:
       - find-changes
     if: ${{ needs.find-changes.outputs.is-release-pr != 'true' && github.event_name == 'push' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # For the OIDC token exchanged for a Remote Cache access token.
+      id-token: write
     env:
-      TURBO_TOKEN: ${{ github.event_name == 'pull_request' && 'unused' || secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ github.event_name == 'pull_request' && 'unused' || vars.TURBO_TEAM }}
-      TURBO_CACHE: ${{ github.event_name == 'pull_request' && 'local:rw' || 'remote:rw' }}
+      TURBO_CACHE: remote:rw
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
+
+      # Exchanges a GitHub OIDC token for a short-lived Remote Cache access
+      # token, exported as TURBO_TOKEN/TURBO_TEAM for subsequent steps.
+      - name: Set up Turborepo Remote Cache
+        uses: vercel/setup-turborepo-remote-cache-action@e3e5e565104ce34a9609db885e5cf7b59238479c # main
+        with:
+          team: ${{ vars.TURBO_TEAM }}
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -423,9 +432,11 @@ jobs:
       - find-changes
     if: ${{ needs.find-changes.outputs.is-release-pr != 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # For the OIDC token exchanged for a Remote Cache access token.
+      id-token: write
     env:
-      TURBO_TOKEN: ${{ github.event_name == 'pull_request' && 'unused' || secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ github.event_name == 'pull_request' && 'unused' || vars.TURBO_TEAM }}
       TURBO_CACHE: ${{ github.event_name == 'pull_request' && 'local:rw' || 'remote:rw' }}
       CARGO_INCREMENTAL: 0
     steps:
@@ -433,6 +444,16 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
+
+      # Exchanges a GitHub OIDC token for a short-lived Remote Cache access
+      # token, exported as TURBO_TOKEN/TURBO_TEAM for subsequent steps.
+      # Push events only: fork PRs cannot mint OIDC tokens, and PR runs use
+      # the local cache anyway.
+      - name: Set up Turborepo Remote Cache
+        if: github.event_name == 'push'
+        uses: vercel/setup-turborepo-remote-cache-action@e3e5e565104ce34a9609db885e5cf7b59238479c # main
+        with:
+          team: ${{ vars.TURBO_TEAM }}
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
@@ -469,9 +490,11 @@ jobs:
           - 20
           - 22
           - 24
+    permissions:
+      contents: read
+      # For the OIDC token exchanged for a Remote Cache access token.
+      id-token: write
     env:
-      TURBO_TOKEN: ${{ github.event_name == 'pull_request' && 'unused' || secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ github.event_name == 'pull_request' && 'unused' || vars.TURBO_TEAM }}
       TURBO_CACHE: ${{ github.event_name == 'pull_request' && 'local:rw' || 'remote:rw' }}
     steps:
       - name: Determine fetch depth
@@ -485,6 +508,16 @@ jobs:
           ref: ${{ github.ref }}
           fetch-depth: ${{ steps.fetch-depth.outputs.depth  }}
           persist-credentials: false
+
+      # Exchanges a GitHub OIDC token for a short-lived Remote Cache access
+      # token, exported as TURBO_TOKEN/TURBO_TEAM for subsequent steps.
+      # Push events only: fork PRs cannot mint OIDC tokens, and PR runs use
+      # the local cache anyway.
+      - name: Set up Turborepo Remote Cache
+        if: github.event_name == 'push'
+        uses: vercel/setup-turborepo-remote-cache-action@e3e5e565104ce34a9609db885e5cf7b59238479c # main
+        with:
+          team: ${{ vars.TURBO_TEAM }}
 
       - name: Setup Environment
         uses: ./.github/actions/setup-environment


### PR DESCRIPTION
## Why

The repo's `TURBO_TOKEN` secret has no Remote Cache write permission — every push-to-main run logs `Remote caching unavailable (Authentication failed)` and writes nothing to the remote task cache. This also blocks the sccache compile cache (#13292), which needs working write credentials in CI.

## What

The three jobs that use remote caching (`check-examples`, `check-lockfiles`, `js_native_packages`) now exchange a GitHub OIDC token for a short-lived scoped access token via [`vercel/setup-turborepo-remote-cache-action`](https://github.com/vercel/setup-turborepo-remote-cache-action), instead of reading `secrets.TURBO_TOKEN`. Jobs gain `id-token: write`; the `'unused'` placeholder env vars are gone.

## How

- The action runs on **push events only**: fork PRs can't mint OIDC tokens, and PR runs already use `TURBO_CACHE=local:rw`, which never consults credentials.
- Pinned to the action's main SHA — it has no release tag yet (worth tagging `v1` before the docs in #13140 ship).
- Matching Turborepo CLI OIDC policy already exists on the team, proven end-to-end from GHA on the bench branch: [populate](https://github.com/vercel/turborepo/actions/runs/28873653923) / [warm read](https://github.com/vercel/turborepo/actions/runs/28874070404) — note the policy must cover `main`, not just the bench branch.
- `turborepo-release.yml` also references `secrets.TURBO_TOKEN`, but as a Vercel deploy token for subdomain aliasing — unrelated, untouched.

To verify after merge: the first push-to-main run should show remote task-cache writes succeeding in the three jobs (no `Authentication failed` warnings).