### PR TITLE
ci: Fix change detection on push events

### DIFF
--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -109,6 +109,20 @@ jobs:
             # For pushes, use the before and after SHAs
             BASE_COMMIT="${{ github.event.before }}"
             HEAD_COMMIT="${{ github.event.after }}"
+
+            # The shallow checkout doesn't contain the before commit; fetch
+            # it by SHA (a depth-1 fetch brings its tree, which is all a
+            # diff needs). An all-zero SHA (branch creation) or a failed
+            # fetch (force push discarding the old commit) means there is
+            # no base to compare against: report everything as changed so
+            # every test runs.
+            if [[ "$BASE_COMMIT" =~ ^0+$ ]] || ! git fetch --no-tags --depth=1 origin "$BASE_COMMIT"; then
+              echo "No usable base commit; treating all paths as changed"
+              for name in docs native-lib rest rust; do
+                echo "$name=true" >> "$GITHUB_OUTPUT"
+              done
+              exit 0
+            fi
           fi
 
           echo "Comparing changes between $BASE_COMMIT and $HEAD_COMMIT"


### PR DESCRIPTION
## Why

Every push-to-main Test run has been broken by change detection. `find-changes` diffs `github.event.before..after` on push events, but the shallow checkout (`fetch-depth: 1`) doesn't contain the `before` commit → `fatal: bad object`. Historically the piped `git diff`s swallowed this and reported **no changes** — `js_native_packages` has silently skipped on every push to main since the filter was added. A later-added bare command substitution turned it into a hard failure under bash `-e`: the [first push run after #13303](https://github.com/vercel/turborepo/actions/runs/28876881284) failed outright in `find-changes` with everything downstream skipped.

## What

On push events, fetch the base commit by SHA before diffing, and when no base is usable, report every path as changed.

## How

- A `--depth=1` fetch of the `before` SHA brings its tree — all a two-commit diff needs. Works regardless of how many commits the push contained.
- Fallback (all-zero `before` on branch creation, or a force push that discarded the old commit): all filter outputs set to `true`, so **all tests run rather than none** — the safe failure direction for a test-skipping optimization.
- PR-event path is untouched.

To verify: the first push-to-main run after merge should have `find-changes` succeed and actually schedule the downstream jobs — including `js_native_packages`, which will also be the first real exercise of the OIDC remote cache auth from #13303 on main.