### PR TITLE
test: Scrub ambient turbo configuration from integration test children

### DIFF
--- a/crates/turborepo/tests/common/mod.rs
+++ b/crates/turborepo/tests/common/mod.rs
@@ -28,6 +28,25 @@ pub fn turbo_output_filters() -> Vec<(&'static str, &'static str)> {
     ]
 }
 
+/// Env keys in the test process that can carry real turbo configuration
+/// into spawned turbo children — TURBO_TEAM/TURBO_TOKEN exported by CI
+/// credential steps, VERCEL_ARTIFACTS_* on Vercel builds, or a developer's
+/// local settings. Tests assert against turbo's defaults, so every harness
+/// that spawns turbo must remove these before applying its own vars;
+/// per-test overrides (explicit env sets after removal) still win because
+/// later ops on a key replace earlier ones.
+pub fn ambient_turbo_env_keys() -> Vec<std::ffi::OsString> {
+    std::env::vars_os()
+        .map(|(key, _)| key)
+        .filter(|key| {
+            let key = key.to_string_lossy();
+            key.starts_with("TURBO_")
+                || key == "VERCEL_ARTIFACTS_OWNER"
+                || key == "VERCEL_ARTIFACTS_TOKEN"
+        })
+        .collect()
+}
+
 /// Return a pre-configured `Command` for the turbo binary with all standard
 /// env var suppression applied. Callers can chain `.arg()`, `.env()`, etc.
 /// before calling `.output()`.
@@ -37,6 +56,9 @@ pub fn turbo_command(test_dir: &Path) -> assert_cmd::Command {
     if corepack_dir.exists() {
         cmd.env("PATH", setup::prepend_to_path(&corepack_dir))
             .env("COREPACK_HOME", setup::corepack_home());
+    }
+    for key in ambient_turbo_env_keys() {
+        cmd.env_remove(&key);
     }
     cmd.env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
         .env("TURBO_GLOBAL_WARNING_DISABLED", "1")

--- a/crates/turborepo/tests/daemon_test.rs
+++ b/crates/turborepo/tests/daemon_test.rs
@@ -7,6 +7,9 @@ use common::setup;
 fn run_daemon_status(dir: &std::path::Path, env_val: &str, extra_args: &[&str]) -> String {
     let config_dir = tempfile::tempdir().unwrap();
     let mut cmd = assert_cmd::Command::cargo_bin("turbo").unwrap();
+    for key in common::ambient_turbo_env_keys() {
+        cmd.env_remove(&key);
+    }
     cmd.env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
         .env("TURBO_GLOBAL_WARNING_DISABLED", "1")
         .env("TURBO_PRINT_VERSION_DISABLED", "1")

--- a/crates/turborepo/tests/dry_json.rs
+++ b/crates/turborepo/tests/dry_json.rs
@@ -115,6 +115,9 @@ fn test_monorepo_env_var_in_summary() -> Result<(), anyhow::Error> {
 
     let config_dir = tempfile::tempdir()?;
     let mut cmd = assert_cmd::Command::cargo_bin("turbo")?;
+    for key in common::ambient_turbo_env_keys() {
+        cmd.env_remove(&key);
+    }
     cmd.env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
         .env("TURBO_GLOBAL_WARNING_DISABLED", "1")
         .env("TURBO_PRINT_VERSION_DISABLED", "1")

--- a/crates/turborepo/tests/graceful_shutdown_test.rs
+++ b/crates/turborepo/tests/graceful_shutdown_test.rs
@@ -180,10 +180,11 @@ mod unix {
 
     fn spawn_noninteractive_turbo(test_dir: &Path) -> ChildGuard {
         let mut cmd = Command::new(turbo_bin());
-        cmd.arg("run")
-            .arg("dev")
-            .arg("--filter=app-a")
-            .env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
+        cmd.arg("run").arg("dev").arg("--filter=app-a");
+        for key in common::ambient_turbo_env_keys() {
+            cmd.env_remove(&key);
+        }
+        cmd.env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
             .env("TURBO_GLOBAL_WARNING_DISABLED", "1")
             .env("TURBO_PRINT_VERSION_DISABLED", "1")
             .env("DO_NOT_TRACK", "1")
@@ -202,8 +203,11 @@ mod unix {
         cmd.arg(turbo_node_wrapper())
             .arg("run")
             .arg("dev")
-            .arg("--filter=app-a")
-            .env("TURBO_BINARY_PATH", turbo_bin())
+            .arg("--filter=app-a");
+        for key in common::ambient_turbo_env_keys() {
+            cmd.env_remove(&key);
+        }
+        cmd.env("TURBO_BINARY_PATH", turbo_bin())
             .env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
             .env("TURBO_GLOBAL_WARNING_DISABLED", "1")
             .env("TURBO_PRINT_VERSION_DISABLED", "1")
@@ -258,6 +262,9 @@ mod unix {
         command.arg("dev");
         command.arg("--filter=app-a");
         command.cwd(test_dir);
+        for key in common::ambient_turbo_env_keys() {
+            command.env_remove(&key);
+        }
         command.env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1");
         command.env("TURBO_GLOBAL_WARNING_DISABLED", "1");
         command.env("TURBO_PRINT_VERSION_DISABLED", "1");

--- a/crates/turborepo/tests/stdin_eof_startup_test.rs
+++ b/crates/turborepo/tests/stdin_eof_startup_test.rs
@@ -22,9 +22,11 @@ fn setup_stdin_eof_fixture() -> tempfile::TempDir {
 fn spawn_turbo_run_dev(test_dir: &Path, config_dir: &Path) -> Child {
     let turbo_bin = assert_cmd::cargo::cargo_bin("turbo");
     let mut cmd = Command::new(turbo_bin);
-    cmd.arg("run")
-        .arg("dev")
-        .env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
+    cmd.arg("run").arg("dev");
+    for key in common::ambient_turbo_env_keys() {
+        cmd.env_remove(&key);
+    }
+    cmd.env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
         .env("TURBO_GLOBAL_WARNING_DISABLED", "1")
         .env("TURBO_PRINT_VERSION_DISABLED", "1")
         .env("TURBO_CONFIG_DIR_PATH", config_dir)

--- a/crates/turborepo/tests/watch_test.rs
+++ b/crates/turborepo/tests/watch_test.rs
@@ -113,6 +113,9 @@ fn spawn_turbo_watch_with_tasks_and_stdio(
     for task in tasks {
         cmd.arg(task);
     }
+    for key in common::ambient_turbo_env_keys() {
+        cmd.env_remove(&key);
+    }
     cmd.env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
         .env("TURBO_GLOBAL_WARNING_DISABLED", "1")
         .env("TURBO_PRINT_VERSION_DISABLED", "1")


### PR DESCRIPTION
## Why

Integration tests assert against `turbo`'s config defaults, but the spawned turbo children inherit the test process environment. When real configuration is present, tests like `test_config_defaults` and `test_prune_composable_config` fail on values leaking in.

## What

A single source of truth in the common harness, `ambient_turbo_env_keys()` — every env key turbo reads (`TURBO_*` prefix plus `VERCEL_ARTIFACTS_OWNER`/`VERCEL_ARTIFACTS_TOKEN`, per `turborepo-config`'s `override_env`) — removed at every place tests spawn turbo: the shared `turbo_command()`, and the hand-rolled spawns in `graceful_shutdown_test`, `watch_test`, `stdin_eof_startup_test`, `daemon_test`, and `dry_json`.

## How

Removal happens before each harness applies its own vars, so per-test overrides still win — later env ops on a key replace earlier ones (proven by `test_config_team_flag_beats_env`, which sets `TURBO_TEAM` explicitly and passes).
