### PR TITLE
fix: Only mark a task as running once its process actually spawns

### DIFF
--- a/crates/turborepo-lockfiles/src/pnpm/data.rs
+++ b/crates/turborepo-lockfiles/src/pnpm/data.rs
@@ -574,13 +574,22 @@ impl PnpmLockfile {
         for dependency in pruned_packages.keys() {
             let dp = DepPath::parse(self.version(), dependency.as_str())?;
 
-            let patch_key = format!("{}@{}", dp.name, dp.version);
-            if let Some(patch) = patches.get(&patch_key).filter(|patch| {
+            let hash_matches = |patch: &PatchFile| {
                 // In V7 patch hash isn't included in packages key, so no need to check
                 matches!(self.version(), SupportedLockfileVersion::V7AndV9)
                     || dp.patch_hash() == Some(patch.hash())
-            }) {
+            };
+
+            let patch_key = format!("{}@{}", dp.name, dp.version);
+            if let Some(patch) = patches.get(&patch_key).filter(|patch| hash_matches(patch)) {
                 pruned_patches.insert(patch_key, patch.clone());
+                continue;
+            }
+
+            if let Some((range_key, patch)) = Self::find_version_range_patch(patches, &dp)
+                && hash_matches(patch)
+            {
+                pruned_patches.insert(range_key.clone(), patch.clone());
                 continue;
             }
 
@@ -590,6 +599,31 @@ impl PnpmLockfile {
             }
         }
         Ok(pruned_patches)
+    }
+
+    /// pnpm allows patch keys to target a semver range, e.g. `foo@^2.0.0` or
+    /// `foo@<=2.1.0`. Returns the first patch whose range matches the
+    /// dependency's version.
+    fn find_version_range_patch<'a>(
+        patches: &'a Map<String, PatchFile>,
+        dp: &DepPath,
+    ) -> Option<(&'a String, &'a PatchFile)> {
+        let version = Version::parse(dp.version).ok()?;
+        patches.iter().find(|(key, _)| {
+            let Some(range) = key
+                .strip_prefix(dp.name)
+                .and_then(|rest| rest.strip_prefix('@'))
+            else {
+                return false;
+            };
+            // A bare version key is an exact match in pnpm (handled by the
+            // direct lookup above), not a caret range like VersionReq would
+            // treat it.
+            if Version::parse(range).is_ok() {
+                return false;
+            }
+            semver::VersionReq::parse(range).is_ok_and(|req| req.matches(&version))
+        })
     }
 
     // Create a projection of all fields in the lockfile that could affect all
@@ -2198,6 +2232,129 @@ snapshots:
 
         assert!(packages.contains_key("lodash@4.17.21"));
         assert!(!packages.contains_key("is-odd@3.0.1"));
+        assert_eq!(pruned_lockfile.patched_dependencies, Some(BTreeMap::new()));
+    }
+
+    /// Regression test for https://github.com/vercel/turborepo/issues/13301
+    ///
+    /// pnpm supports semver ranges in `patchedDependencies` keys (e.g.
+    /// `is-odd@<=3.0.1`). Patches whose range matches a package in the pruned
+    /// closure must be kept.
+    #[test]
+    fn test_subgraph_keeps_version_range_patched_dependencies() {
+        let yaml = r#"lockfileVersion: '9.0'
+
+patchedDependencies:
+  is-odd@<=3.0.1:
+    hash: abc
+    path: patches/is-odd.patch
+  '@scope/pkg@^1.0.0':
+    hash: def
+    path: patches/scope-pkg.patch
+  lodash@>=5.0.0:
+    hash: ghi
+    path: patches/lodash.patch
+
+importers:
+
+  .: {}
+
+  apps/web:
+    dependencies:
+      is-odd:
+        specifier: 3.0.1
+        version: 3.0.1
+      '@scope/pkg':
+        specifier: 1.2.3
+        version: 1.2.3
+      lodash:
+        specifier: 4.17.21
+        version: 4.17.21
+
+packages:
+
+  is-odd@3.0.1:
+    resolution: {integrity: sha512-bbb}
+    patched: true
+
+  '@scope/pkg@1.2.3':
+    resolution: {integrity: sha512-ccc}
+    patched: true
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-aaa}
+
+snapshots:
+
+  is-odd@3.0.1: {}
+
+  '@scope/pkg@1.2.3': {}
+
+  lodash@4.17.21: {}
+"#;
+        let lockfile = PnpmLockfile::from_bytes(yaml.as_bytes()).unwrap();
+
+        let workspace_packages = vec!["apps/web".to_string()];
+        let resolved_packages = vec![
+            "is-odd@3.0.1".to_string(),
+            "@scope/pkg@1.2.3".to_string(),
+            "lodash@4.17.21".to_string(),
+        ];
+        let pruned = lockfile
+            .subgraph(&workspace_packages, &resolved_packages)
+            .unwrap();
+
+        let pruned_bytes = pruned.encode().unwrap();
+        let pruned_lockfile = PnpmLockfile::from_bytes(&pruned_bytes).unwrap();
+        let patches = pruned_lockfile
+            .patched_dependencies
+            .as_ref()
+            .expect("should have patched dependencies");
+
+        assert!(patches.contains_key("is-odd@<=3.0.1"));
+        assert!(patches.contains_key("@scope/pkg@^1.0.0"));
+        // lodash@4.17.21 does not satisfy >=5.0.0
+        assert!(!patches.contains_key("lodash@>=5.0.0"));
+    }
+
+    /// A bare version patch key is an exact match in pnpm, not a caret range.
+    /// `is-odd@3.0.0` must not apply to `is-odd@3.0.1`.
+    #[test]
+    fn test_subgraph_does_not_treat_exact_patch_key_as_range() {
+        let yaml = r#"lockfileVersion: '9.0'
+
+patchedDependencies:
+  is-odd@3.0.0:
+    hash: abc
+    path: patches/is-odd.patch
+
+importers:
+
+  .: {}
+
+  apps/web:
+    dependencies:
+      is-odd:
+        specifier: 3.0.1
+        version: 3.0.1
+
+packages:
+
+  is-odd@3.0.1:
+    resolution: {integrity: sha512-bbb}
+
+snapshots:
+
+  is-odd@3.0.1: {}
+"#;
+        let lockfile = PnpmLockfile::from_bytes(yaml.as_bytes()).unwrap();
+
+        let pruned = lockfile
+            .subgraph(&["apps/web".to_string()], &["is-odd@3.0.1".to_string()])
+            .unwrap();
+
+        let pruned_bytes = pruned.encode().unwrap();
+        let pruned_lockfile = PnpmLockfile::from_bytes(&pruned_bytes).unwrap();
         assert_eq!(pruned_lockfile.patched_dependencies, Some(BTreeMap::new()));
     }
 

--- a/crates/turborepo-run-cache/src/lib.rs
+++ b/crates/turborepo-run-cache/src/lib.rs
@@ -417,7 +417,7 @@ impl TaskCache {
         result: turborepo_ui::tui::event::CacheResult,
     ) {
         if let Some(sender) = tui_sender {
-            sender.status(message, result);
+            sender.status(message, result, self.task_output_logs.into());
         }
         if !message.is_empty() {
             let line = format!("{message}\n");

--- a/crates/turborepo-task-executor/src/exec.rs
+++ b/crates/turborepo-task-executor/src/exec.rs
@@ -363,8 +363,6 @@ where
         task_handle: &mut turborepo_log::grouping::TaskHandle,
         telemetry: &PackageTaskEventBuilder,
     ) -> Result<ExecOutcome, InternalError> {
-        task_output.start(self.task_cache.output_logs().into());
-
         if !self.task_cache.is_caching_disabled() {
             let missing_platform_env = self.platform_env.validate(&self.execution_env);
             if !missing_platform_env.is_empty() {
@@ -429,6 +427,12 @@ where
             Some(group) => Some(serial_group_lock(group).lock_owned().await),
             None => None,
         };
+
+        // The task is only presented as running once its process is about
+        // to exist. Everything before this point — cache restore, waiting
+        // on the serial group — happens while the task is still pending,
+        // and cache hits finish without ever starting.
+        task_output.start(self.task_cache.output_logs().into());
 
         // Spawn the process
         let cmd = self.cmd.clone();

--- a/crates/turborepo-ui/src/sender.rs
+++ b/crates/turborepo-ui/src/sender.rs
@@ -30,9 +30,15 @@ impl UISender {
         }
     }
 
-    pub fn status(&self, task: String, status: String, result: CacheResult) {
+    pub fn status(
+        &self,
+        task: String,
+        status: String,
+        result: CacheResult,
+        output_logs: OutputLogs,
+    ) {
         match self {
-            UISender::Tui(sender) => sender.status(task, status, result),
+            UISender::Tui(sender) => sender.status(task, status, result, output_logs),
         }
     }
     fn set_stdin(&self, task: String, stdin: Box<dyn std::io::Write + Send>) {
@@ -115,12 +121,13 @@ impl TaskSender {
         self.handle.set_stdin(self.name.clone(), stdin);
     }
 
-    pub fn status(&self, status: &str, result: CacheResult) {
+    pub fn status(&self, status: &str, result: CacheResult, output_logs: OutputLogs) {
         // Since this will be rendered via ratatui we any ANSI escape codes will not be
         // handled.
         // TODO: prevent the status from having ANSI codes in this scenario
         let status = console::strip_ansi_codes(status).into_owned();
-        self.handle.status(self.name.clone(), status, result);
+        self.handle
+            .status(self.name.clone(), status, result, output_logs);
     }
 }
 

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -506,8 +506,11 @@ impl<W> App<W> {
         Ok(())
     }
 
-    /// Mark the given running task as finished
-    /// Errors if given task wasn't a running task
+    /// Mark the given running or planned task as finished.
+    ///
+    /// A task is only marked as started once its process actually spawns,
+    /// so cache hits legitimately finish straight from the planned state —
+    /// they never ran. Errors if the task is unknown or already finished.
     #[tracing::instrument(skip(self, result))]
     pub fn finish_task(&mut self, task: &str, result: TaskResult) -> Result<(), Error> {
         debug!("finishing task {task}");
@@ -518,16 +521,32 @@ impl<W> App<W> {
             .task_name(self.selected_task_index)?
             .to_string();
 
-        let running_idx = self
+        let finished = if let Some(running_idx) = self
             .tasks_by_status
             .running
             .iter()
             .position(|running| running.name() == task)
-            .ok_or_else(|| Error::TaskNotFound { name: task.into() })?;
-
-        let running = self.tasks_by_status.running.remove(running_idx);
-        self.tasks_by_status
-            .insert_finished_task(running.finish(result));
+        {
+            self.tasks_by_status
+                .running
+                .remove(running_idx)
+                .finish(result)
+        } else {
+            let planned_idx = self
+                .tasks_by_status
+                .planned
+                .iter()
+                .position(|planned| planned.name() == task)
+                .ok_or_else(|| Error::TaskNotFound { name: task.into() })?;
+            // start().finish() back to back: a task that never ran has a
+            // (truthful) zero duration.
+            self.tasks_by_status
+                .planned
+                .remove(planned_idx)
+                .start()
+                .finish(result)
+        };
+        self.tasks_by_status.insert_finished_task(finished);
 
         self.tasks
             .get_mut(task)
@@ -725,6 +744,7 @@ impl<W> App<W> {
         task: String,
         status: String,
         result: CacheResult,
+        output_logs: OutputLogs,
     ) -> Result<(), Error> {
         let task = self
             .tasks
@@ -734,6 +754,9 @@ impl<W> App<W> {
             })?;
         task.status = Some(status);
         task.cache_result = Some(result);
+        // Cache hits finish without ever starting, so `StartTask` cannot be
+        // relied on to deliver the output verbosity before persistence.
+        task.output_logs = Some(output_logs);
         Ok(())
     }
 
@@ -1551,8 +1574,9 @@ fn update(
             task,
             status,
             result,
+            output_logs,
         } => {
-            app.set_status(task, status, result)?;
+            app.set_status(task, status, result, output_logs)?;
         }
         Event::InternalStop => {
             debug!("shutting down due to internal failure");
@@ -2137,13 +2161,89 @@ mod test {
         assert_eq!(app.task_list_scroll.selected(), Some(1), "selected b");
         assert_eq!(app.tasks_by_status.task_name(1)?, "b", "selected b");
         // set status for a
-        app.set_status("a".to_string(), "building".to_string(), CacheResult::Hit)?;
+        app.set_status(
+            "a".to_string(),
+            "building".to_string(),
+            CacheResult::Hit,
+            OutputLogs::Full,
+        )?;
 
         assert_eq!(
             app.tasks.get("a").unwrap().status.as_deref(),
             Some("building")
         );
         assert!(app.tasks.get("b").unwrap().status.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_finish_task_from_planned_state() -> Result<(), Error> {
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())
+            .expect("Failed to create AbsoluteSystemPathBuf");
+
+        let mut app: App<Vec<u8>> = App::new_for_test(
+            100,
+            100,
+            vec!["a".to_string(), "b".to_string()],
+            PreferenceLoader::new(&repo_root),
+            2048,
+        );
+
+        // Cache hits finish without ever starting: planned -> finished.
+        app.finish_task("a", TaskResult::CacheHit)?;
+        assert!(
+            app.tasks_by_status
+                .finished
+                .iter()
+                .any(|task| task.name() == "a"),
+            "task should be finished"
+        );
+        assert!(
+            !app.tasks_by_status
+                .planned
+                .iter()
+                .any(|task| task.name() == "a"),
+            "task should no longer be planned"
+        );
+        // Persistence on TUI exit covers finished tasks, so the replayed
+        // logs of a never-started cache hit still land in the terminal.
+        assert!(
+            app.tasks_by_status
+                .tasks_started()
+                .contains(&"a".to_string())
+        );
+
+        // Unknown tasks remain a hard error.
+        assert!(app.finish_task("missing", TaskResult::Success).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_set_status_carries_output_logs() -> Result<(), Error> {
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())
+            .expect("Failed to create AbsoluteSystemPathBuf");
+
+        let mut app: App<Vec<u8>> = App::new_for_test(
+            100,
+            100,
+            vec!["a".to_string()],
+            PreferenceLoader::new(&repo_root),
+            2048,
+        );
+
+        app.set_status(
+            "a".to_string(),
+            "cache hit, replaying logs".to_string(),
+            CacheResult::Hit,
+            OutputLogs::HashOnly,
+        )?;
+        assert_eq!(
+            app.tasks.get("a").unwrap().output_logs,
+            Some(OutputLogs::HashOnly),
+            "status must deliver output verbosity for tasks that never start"
+        );
         Ok(())
     }
 
@@ -2830,6 +2930,7 @@ mod test {
     fn test_should_start_terminal_on_cache_miss() {
         // Cache miss should trigger terminal start
         let miss_event = Event::Status {
+            output_logs: OutputLogs::Full,
             task: "task-a".to_string(),
             status: "building".to_string(),
             // This includes cache bypasses via `--force`
@@ -2845,6 +2946,7 @@ mod test {
     fn test_should_not_start_terminal_on_cache_hit() {
         // Cache hit should NOT trigger terminal start
         let hit_event = Event::Status {
+            output_logs: OutputLogs::Full,
             task: "task-a".to_string(),
             status: "cached".to_string(),
             result: CacheResult::Hit,
@@ -2915,8 +3017,18 @@ mod test {
 
         // Simulate a full cache hit scenario:
         // 1. Set status as cache hit (this doesn't start the task in running state)
-        app.set_status("a".to_string(), "cached".to_string(), CacheResult::Hit)?;
-        app.set_status("b".to_string(), "cached".to_string(), CacheResult::Hit)?;
+        app.set_status(
+            "a".to_string(),
+            "cached".to_string(),
+            CacheResult::Hit,
+            OutputLogs::Full,
+        )?;
+        app.set_status(
+            "b".to_string(),
+            "cached".to_string(),
+            CacheResult::Hit,
+            OutputLogs::Full,
+        )?;
 
         // 2. Start and finish tasks with CacheHit result
         app.start_task("a", OutputLogs::Full)?;
@@ -3421,7 +3533,12 @@ mod test {
         // The run proceeds: each task gets StartTask, Status(Hit), EndTask(CacheHit).
         for task in &tasks {
             app.start_task(task, OutputLogs::Full)?;
-            app.set_status(task.clone(), "cached".to_string(), CacheResult::Hit)?;
+            app.set_status(
+                task.clone(),
+                "cached".to_string(),
+                CacheResult::Hit,
+                OutputLogs::Full,
+            )?;
             app.finish_task(task, TaskResult::CacheHit)?;
         }
 

--- a/crates/turborepo-ui/src/tui/event.rs
+++ b/crates/turborepo-ui/src/tui/event.rs
@@ -21,6 +21,10 @@ pub enum Event {
         task: String,
         status: String,
         result: CacheResult,
+        /// The task's configured output verbosity. Carried here (in
+        /// addition to `StartTask`) because cache hits finish without ever
+        /// starting, and log persistence must still respect the setting.
+        output_logs: OutputLogs,
     },
     PaneSizeQuery(oneshot::Sender<PaneSize>),
     Stop(oneshot::Sender<()>),

--- a/crates/turborepo-ui/src/tui/handle.rs
+++ b/crates/turborepo-ui/src/tui/handle.rs
@@ -68,12 +68,19 @@ impl TuiSender {
         self.primary.send(Event::EndTask { task, result }).ok();
     }
 
-    pub fn status(&self, task: String, status: String, result: CacheResult) {
+    pub fn status(
+        &self,
+        task: String,
+        status: String,
+        result: CacheResult,
+        output_logs: OutputLogs,
+    ) {
         self.primary
             .send(Event::Status {
                 task,
                 status,
                 result,
+                output_logs,
             })
             .ok();
     }

--- a/crates/turborepo/tests/common/mod.rs
+++ b/crates/turborepo/tests/common/mod.rs
@@ -28,6 +28,25 @@ pub fn turbo_output_filters() -> Vec<(&'static str, &'static str)> {
     ]
 }
 
+/// Env keys in the test process that can carry real turbo configuration
+/// into spawned turbo children — TURBO_TEAM/TURBO_TOKEN exported by CI
+/// credential steps, VERCEL_ARTIFACTS_* on Vercel builds, or a developer's
+/// local settings. Tests assert against turbo's defaults, so every harness
+/// that spawns turbo must remove these before applying its own vars;
+/// per-test overrides (explicit env sets after removal) still win because
+/// later ops on a key replace earlier ones.
+pub fn ambient_turbo_env_keys() -> Vec<std::ffi::OsString> {
+    std::env::vars_os()
+        .map(|(key, _)| key)
+        .filter(|key| {
+            let key = key.to_string_lossy();
+            key.starts_with("TURBO_")
+                || key == "VERCEL_ARTIFACTS_OWNER"
+                || key == "VERCEL_ARTIFACTS_TOKEN"
+        })
+        .collect()
+}
+
 /// Return a pre-configured `Command` for the turbo binary with all standard
 /// env var suppression applied. Callers can chain `.arg()`, `.env()`, etc.
 /// before calling `.output()`.
@@ -37,6 +56,9 @@ pub fn turbo_command(test_dir: &Path) -> assert_cmd::Command {
     if corepack_dir.exists() {
         cmd.env("PATH", setup::prepend_to_path(&corepack_dir))
             .env("COREPACK_HOME", setup::corepack_home());
+    }
+    for key in ambient_turbo_env_keys() {
+        cmd.env_remove(&key);
     }
     cmd.env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
         .env("TURBO_GLOBAL_WARNING_DISABLED", "1")

--- a/crates/turborepo/tests/daemon_test.rs
+++ b/crates/turborepo/tests/daemon_test.rs
@@ -7,6 +7,9 @@ use common::setup;
 fn run_daemon_status(dir: &std::path::Path, env_val: &str, extra_args: &[&str]) -> String {
     let config_dir = tempfile::tempdir().unwrap();
     let mut cmd = assert_cmd::Command::cargo_bin("turbo").unwrap();
+    for key in common::ambient_turbo_env_keys() {
+        cmd.env_remove(&key);
+    }
     cmd.env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
         .env("TURBO_GLOBAL_WARNING_DISABLED", "1")
         .env("TURBO_PRINT_VERSION_DISABLED", "1")

--- a/crates/turborepo/tests/dry_json.rs
+++ b/crates/turborepo/tests/dry_json.rs
@@ -115,6 +115,9 @@ fn test_monorepo_env_var_in_summary() -> Result<(), anyhow::Error> {
 
     let config_dir = tempfile::tempdir()?;
     let mut cmd = assert_cmd::Command::cargo_bin("turbo")?;
+    for key in common::ambient_turbo_env_keys() {
+        cmd.env_remove(&key);
+    }
     cmd.env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
         .env("TURBO_GLOBAL_WARNING_DISABLED", "1")
         .env("TURBO_PRINT_VERSION_DISABLED", "1")

--- a/crates/turborepo/tests/graceful_shutdown_test.rs
+++ b/crates/turborepo/tests/graceful_shutdown_test.rs
@@ -180,10 +180,11 @@ mod unix {
 
     fn spawn_noninteractive_turbo(test_dir: &Path) -> ChildGuard {
         let mut cmd = Command::new(turbo_bin());
-        cmd.arg("run")
-            .arg("dev")
-            .arg("--filter=app-a")
-            .env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
+        cmd.arg("run").arg("dev").arg("--filter=app-a");
+        for key in common::ambient_turbo_env_keys() {
+            cmd.env_remove(&key);
+        }
+        cmd.env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
             .env("TURBO_GLOBAL_WARNING_DISABLED", "1")
             .env("TURBO_PRINT_VERSION_DISABLED", "1")
             .env("DO_NOT_TRACK", "1")
@@ -202,8 +203,11 @@ mod unix {
         cmd.arg(turbo_node_wrapper())
             .arg("run")
             .arg("dev")
-            .arg("--filter=app-a")
-            .env("TURBO_BINARY_PATH", turbo_bin())
+            .arg("--filter=app-a");
+        for key in common::ambient_turbo_env_keys() {
+            cmd.env_remove(&key);
+        }
+        cmd.env("TURBO_BINARY_PATH", turbo_bin())
             .env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
             .env("TURBO_GLOBAL_WARNING_DISABLED", "1")
             .env("TURBO_PRINT_VERSION_DISABLED", "1")
@@ -258,6 +262,9 @@ mod unix {
         command.arg("dev");
         command.arg("--filter=app-a");
         command.cwd(test_dir);
+        for key in common::ambient_turbo_env_keys() {
+            command.env_remove(&key);
+        }
         command.env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1");
         command.env("TURBO_GLOBAL_WARNING_DISABLED", "1");
         command.env("TURBO_PRINT_VERSION_DISABLED", "1");

--- a/crates/turborepo/tests/prune_test.rs
+++ b/crates/turborepo/tests/prune_test.rs
@@ -199,6 +199,60 @@ patchedDependencies:
     }
 }
 
+/// Regression test for https://github.com/vercel/turborepo/issues/13301
+///
+/// pnpm supports semver ranges in `patchedDependencies` keys (e.g.
+/// `is-number@<=7.0.0`). Prune must keep patches whose range matches a
+/// package in the pruned closure.
+#[test]
+fn test_prune_docker_keeps_version_range_patches() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup::copy_fixture("monorepo_with_root_dep", tempdir.path()).unwrap();
+
+    // Rewrite the exact patch key to a semver range everywhere it's declared.
+    for file in ["pnpm-lock.yaml", "package.json"] {
+        let path = tempdir.path().join(file);
+        let contents = fs::read_to_string(&path).unwrap();
+        fs::write(
+            &path,
+            contents
+                .replace("is-number@7.0.0:", "is-number@<=7.0.0:")
+                .replace("\"is-number@7.0.0\"", "\"is-number@<=7.0.0\""),
+        )
+        .unwrap();
+    }
+
+    let output = run_turbo(tempdir.path(), &["prune", "web", "--docker"]);
+    assert!(
+        output.status.success(),
+        "prune --docker failed: {}",
+        combined_output(&output)
+    );
+
+    let pruned_lockfile = fs::read_to_string(tempdir.path().join("out/pnpm-lock.yaml")).unwrap();
+    assert!(
+        pruned_lockfile.contains("is-number@<=7.0.0"),
+        "pruned lockfile should retain range patch key:\n{pruned_lockfile}"
+    );
+
+    let pkg_json: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(tempdir.path().join("out/json/package.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        pkg_json["pnpm"]["patchedDependencies"]["is-number@<=7.0.0"],
+        "patches/is-number@7.0.0.patch"
+    );
+
+    assert!(
+        tempdir
+            .path()
+            .join("out/json/patches/is-number@7.0.0.patch")
+            .exists(),
+        "patch file should be copied into pruned output"
+    );
+}
+
 #[test]
 fn test_prune_rejects_patch_paths_with_parent_dir() {
     let tempdir = tempfile::tempdir().unwrap();

--- a/crates/turborepo/tests/stdin_eof_startup_test.rs
+++ b/crates/turborepo/tests/stdin_eof_startup_test.rs
@@ -22,9 +22,11 @@ fn setup_stdin_eof_fixture() -> tempfile::TempDir {
 fn spawn_turbo_run_dev(test_dir: &Path, config_dir: &Path) -> Child {
     let turbo_bin = assert_cmd::cargo::cargo_bin("turbo");
     let mut cmd = Command::new(turbo_bin);
-    cmd.arg("run")
-        .arg("dev")
-        .env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
+    cmd.arg("run").arg("dev");
+    for key in common::ambient_turbo_env_keys() {
+        cmd.env_remove(&key);
+    }
+    cmd.env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
         .env("TURBO_GLOBAL_WARNING_DISABLED", "1")
         .env("TURBO_PRINT_VERSION_DISABLED", "1")
         .env("TURBO_CONFIG_DIR_PATH", config_dir)

--- a/crates/turborepo/tests/watch_test.rs
+++ b/crates/turborepo/tests/watch_test.rs
@@ -113,6 +113,9 @@ fn spawn_turbo_watch_with_tasks_and_stdio(
     for task in tasks {
         cmd.arg(task);
     }
+    for key in common::ambient_turbo_env_keys() {
+        cmd.env_remove(&key);
+    }
     cmd.env("TURBO_TELEMETRY_MESSAGE_DISABLED", "1")
         .env("TURBO_GLOBAL_WARNING_DISABLED", "1")
         .env("TURBO_PRINT_VERSION_DISABLED", "1")


### PR DESCRIPTION
## Why

In a Cargo-enabled repo, the TUI showed a column of `»` running tasks whose processes didn't exist. The running marker fired at the very top of task execution — before the cache check and before the serial-group lock. For JS tasks that gap is milliseconds and invisible; Cargo's serial group (one cargo at a time, because they'd fight over the build directory) stretched it to minutes of tasks claiming to run while queued.

## What

`task_output.start()` moves to immediately before the process spawn, after serial-group acquisition. States now tell the truth:

| Situation | Before | After |
|---|---|---|
| Waiting on serial group | `»` running, empty pane | pending — same as waiting on a dependency |
| Holding the lock / executing | `»` | `»` |
| Cache hit | brief false `»` flash | pending → ✓ directly (it never ran; duration truthfully ~0) |
| JS task wrapping cargo (e.g. napi builds) | unchanged | unchanged — its process is real, and cargo self-reports "Blocking waiting for file lock" |

## How

Two consequences the move forces, both handled:

- **Cache hits never start**, so `finish_task` learns the planned → finished transition (`start().finish()` back to back). Unknown task names remain a hard error — this is a legitimate state transition, not event-swallowing. Persistence on TUI exit is unaffected: `tasks_started()` reads the finished/running lists, which now include these tasks.
- **`StartTask` was the only carrier of the task's `outputLogs` setting.** A never-started cache hit would have defaulted to full log persistence, ignoring `hash-only`/`new-only`. `Event::Status` — which every cache-restore path already emits before any start — now carries `output_logs` too, threaded through `TaskSender::status` → `UISender` → `TuiSender`.

Exit-path audit: the only `execute_inner` return remaining before the new start location is the cache-hit return (verified — no `?` operators in between), and spawn-failure paths sit after the start call, keeping start→finish ordering.

`start()` is a no-op outside the TUI, so stream/grouped log modes are untouched (their "cache miss, executing" lines come from the run cache, not this signal).

Tests: `finish_task` planned→finished (+ unknown-name error + `tasks_started` inclusion), `set_status` delivering `output_logs`; existing UI/executor/run-cache/cargo-workspace suites green.

Follow-ups deliberately not in this PR: run-summary durations still include serial-group wait (`tracker.start()` unmoved); batching contended cargo invocations into one process remains a parked design discussion.