### PR TITLE
refactor: Rename the Cargo toolchain id to rust

### DIFF
--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -342,7 +342,7 @@ mod test {
             // JS package without any scripts.
             ("c", "build"),
             // The synthetic Cargo workspace package.
-            ("cargo", "test"),
+            ("rust", "test"),
             // A binary crate.
             ("my-crate", "build"),
         ] {
@@ -367,7 +367,7 @@ mod test {
         tasks.sort();
         // "c#build" is absent: no script defines it. Both Cargo tasks are
         // present without any package.json involvement.
-        assert_eq!(tasks, vec!["a#build", "cargo#test", "my-crate#build"]);
+        assert_eq!(tasks, vec!["a#build", "my-crate#build", "rust#test"]);
     }
 
     #[tokio::test]

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -18,8 +18,8 @@
 //!
 //! A synthetic package named [`WORKSPACE_PACKAGE_NAME`], anchored at the
 //! root `Cargo.toml` and depending on every crate, represents the workspace
-//! itself; it will host workspace-scoped verification verbs (`cargo test
-//! --workspace`, ...) once command resolution gains a toolchain surface.
+//! itself; it hosts the workspace-scoped verification verbs (`rust#test` →
+//! `cargo test --workspace`, ...; see [`workspace_subcommand`]).
 //!
 //! Support is experimental and gated behind
 //! `futureFlags.experimentalCargoWorkspaces`.
@@ -46,8 +46,10 @@ pub const CARGO_TOML: &str = "Cargo.toml";
 pub const CARGO_LOCK: &str = "Cargo.lock";
 
 /// Name of the synthetic package that represents the Cargo workspace itself.
-/// A real workspace member with this name is skipped with a warning.
-pub const WORKSPACE_PACKAGE_NAME: &str = "cargo";
+/// Matches the toolchain id ([`ToolchainId::RUST`]): task keys read
+/// `rust#test`, `rust#lint`. A real workspace member with this name is
+/// skipped with a warning.
+pub const WORKSPACE_PACKAGE_NAME: &str = "rust";
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -446,7 +448,7 @@ impl CargoToolchain {
 
 impl Toolchain for CargoToolchain {
     fn id(&self) -> ToolchainId {
-        ToolchainId::CARGO
+        ToolchainId::RUST
     }
 
     fn task_command(
@@ -754,7 +756,7 @@ impl Toolchain for CargoToolchain {
         let dependency_globs = || {
             let mut globs: Vec<String> = dependencies
                 .iter()
-                .filter(|dep| dep.toolchain == ToolchainId::CARGO)
+                .filter(|dep| dep.toolchain == ToolchainId::RUST)
                 .filter(|dep| {
                     dep.package_name()
                         .and_then(|dep_name| self.package_details(&dep_name))
@@ -1589,7 +1591,7 @@ checksum = "abc123"
         write_fixture_workspace(&root);
 
         let toolchain = CargoToolchain::new(root.clone());
-        assert_eq!(toolchain.id(), ToolchainId::CARGO);
+        assert_eq!(toolchain.id(), ToolchainId::RUST);
 
         let mut packages = toolchain.discover_packages().await.unwrap();
         packages.sort_by(|a, b| {
@@ -1604,7 +1606,7 @@ checksum = "abc123"
             .iter()
             .map(|p| p.descriptor.name.as_ref().unwrap().as_inner().as_str())
             .collect();
-        assert_eq!(names, vec!["app", "cargo", "lib-a", "lib-a-test-util"]);
+        assert_eq!(names, vec!["app", "lib-a", "lib-a-test-util", "rust"]);
 
         let app = &packages[0];
         assert_eq!(
@@ -1618,7 +1620,7 @@ checksum = "abc123"
 
         // The synthetic workspace package is anchored at the root manifest
         // and depends on every crate.
-        let workspace = &packages[1];
+        let workspace = &packages[3];
         assert_eq!(workspace.manifest_path, root.join_component(CARGO_TOML));
         let workspace_deps = workspace.descriptor.dependencies.as_ref().unwrap();
         assert_eq!(workspace_deps.len(), 3);
@@ -1637,7 +1639,7 @@ checksum = "abc123"
             app_externals.iter().any(|p| p.key == "rustc"),
             "compiler version stamps the closure, got {app_externals:?}"
         );
-        let lib_a_externals = packages[2].external_dependencies.as_ref().unwrap();
+        let lib_a_externals = packages[1].external_dependencies.as_ref().unwrap();
         assert!(
             !lib_a_externals.iter().any(|p| p.key == "serde"),
             "a serde bump must not invalidate lib-a, got {lib_a_externals:?}"
@@ -1664,7 +1666,7 @@ checksum = "abc123"
                 manifest_rel.replace('/', std::path::MAIN_SEPARATOR_STR),
             )
             .unwrap(),
-            toolchain: ToolchainId::CARGO,
+            toolchain: ToolchainId::RUST,
             ..Default::default()
         }
     }

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -1984,16 +1984,13 @@ mod test {
 
             // All packages present, tagged with their toolchain.
             let app = pkg_graph.package_info(&PackageName::from("app")).unwrap();
-            assert_eq!(app.toolchain, crate::toolchain::ToolchainId::CARGO);
+            assert_eq!(app.toolchain, crate::toolchain::ToolchainId::RUST);
             let js_pkg = pkg_graph
                 .package_info(&PackageName::from("js-pkg"))
                 .unwrap();
             assert_eq!(js_pkg.toolchain, crate::toolchain::ToolchainId::JAVASCRIPT);
-            let workspace_pkg = pkg_graph.package_info(&PackageName::from("cargo")).unwrap();
-            assert_eq!(
-                workspace_pkg.toolchain,
-                crate::toolchain::ToolchainId::CARGO
-            );
+            let workspace_pkg = pkg_graph.package_info(&PackageName::from("rust")).unwrap();
+            assert_eq!(workspace_pkg.toolchain, crate::toolchain::ToolchainId::RUST);
 
             // Crate path dependencies became graph edges.
             let app_deps = pkg_graph
@@ -2004,7 +2001,7 @@ mod test {
                 "app should depend on lib-a, got {app_deps:?}"
             );
             let workspace_deps = pkg_graph
-                .immediate_dependencies(&PackageNode::Workspace(PackageName::from("cargo")))
+                .immediate_dependencies(&PackageNode::Workspace(PackageName::from("rust")))
                 .unwrap();
             assert!(
                 workspace_deps.contains(&PackageNode::Workspace(PackageName::from("app")))

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -25,7 +25,7 @@
 //! 2. [`ToolchainId`] is an open identifier, never a closed enum. A future
 //!    toolchain (or plugin) mints a new id without touching existing code.
 //! 3. All toolchain lookups go through the [`ToolchainRegistry`]. Scattered
-//!    per-toolchain branch points (`if id == "cargo"`) are a design defect.
+//!    per-toolchain branch points (`if id == "rust"`) are a design defect.
 //!
 //! # Known debt
 //!
@@ -67,10 +67,11 @@ impl ToolchainId {
     /// manifests, regardless of package manager or runtime.
     pub const JAVASCRIPT: ToolchainId = ToolchainId(Cow::Borrowed("javascript"));
 
-    /// The Cargo toolchain: Rust crates discovered from a Cargo workspace
-    /// (see [`crate::cargo`]). Experimental, gated behind
-    /// `futureFlags.experimentalCargoWorkspaces`.
-    pub const CARGO: ToolchainId = ToolchainId(Cow::Borrowed("cargo"));
+    /// The Rust toolchain: crates discovered from a Cargo workspace (see
+    /// [`crate::cargo`]). Named for the language — the public axis users
+    /// think in — while the implementation is Cargo-specific.
+    /// Experimental, gated behind `futureFlags.experimentalCargoWorkspaces`.
+    pub const RUST: ToolchainId = ToolchainId(Cow::Borrowed("rust"));
 
     pub fn new(id: impl Into<Cow<'static, str>>) -> Self {
         Self(id.into())
@@ -686,9 +687,9 @@ mod tests {
         assert_eq!(js.as_str(), "javascript");
 
         // Any string is a valid id; no closed set to extend.
-        let custom = ToolchainId::new("cargo");
+        let custom = ToolchainId::new("gleam");
         assert_ne!(custom, js);
-        assert_eq!(custom.to_string(), "cargo");
+        assert_eq!(custom.to_string(), "gleam");
         let dynamic = ToolchainId::new(String::from("python-uv"));
         assert_eq!(dynamic.as_str(), "python-uv");
     }
@@ -825,10 +826,10 @@ mod tests {
 
         let mut registry = ToolchainRegistry::new();
         registry.register(Arc::new(Fake(ToolchainId::JAVASCRIPT)));
-        registry.register(Arc::new(Fake(ToolchainId::new("cargo"))));
+        registry.register(Arc::new(Fake(ToolchainId::new("gleam"))));
 
         assert!(registry.get(&ToolchainId::JAVASCRIPT).is_some());
-        assert!(registry.get(&ToolchainId::new("cargo")).is_some());
+        assert!(registry.get(&ToolchainId::new("gleam")).is_some());
         assert!(registry.get(&ToolchainId::new("zig")).is_none());
         assert_eq!(registry.iter().count(), 2);
     }

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -187,14 +187,15 @@ whether anything changed; Cargo decides how and in what order to build.**
   workspace's deliverables. *Libraries* exist in the package graph — so
   `--filter` and `--affected` propagate through them — but their tasks are
   no-ops: Cargo builds them implicitly as part of an entrypoint's closure. A
-  synthetic *workspace* package (named `cargo`) depends on every crate and
+  synthetic *workspace* package (named `rust`, matching the toolchain id)
+  depends on every crate and
   hosts workspace-scoped verbs.
 - **Execution** (`Toolchain::task_command`, adapted into the provider chain
   by `ToolchainCommandProvider` in `turborepo-task-executor`): entrypoint
   `build`/`run`/`dev` tasks run `cargo <verb> --package=<crate>` — one cargo
   process that builds the crate's whole dependency closure with Cargo's own
-  parallelism. Verification verbs run once at workspace scope: `cargo#test`
-  → `cargo test --workspace`, `cargo#lint` → `cargo clippy --workspace`,
+  parallelism. Verification verbs run once at workspace scope: `rust#test`
+  → `cargo test --workspace`, `rust#lint` → `cargo clippy --workspace`,
   etc. Cargo commands (except `cargo run`) share a mutually-exclusive
   serial group: concurrent cargo processes serialize on the build-directory
   lock anyway, so the executor runs one at a time without the "waiting for
@@ -268,7 +269,7 @@ whether anything changed; Cargo decides how and in what order to build.**
   sync its own lockfile; failure downgrades to a warning. In docker
   layout, the json layer carries the root manifest, each kept crate's
   `Cargo.toml`, and the pruned lock; sources go to the full layer. A
-  package anchored at the repo root (the synthetic `cargo` package) is not
+  package anchored at the repo root (the synthetic `rust` package) is not
   a pruneable target.
 
 - **Compile cache** (`Toolchain::compile_cache_env`, consumed by

--- a/crates/turborepo/tests/cargo_workspace_test.rs
+++ b/crates/turborepo/tests/cargo_workspace_test.rs
@@ -253,14 +253,14 @@ fn test_prune_js_target_unaffected_by_cargo() {
     assert!(!out.join("Cargo.toml").exists());
 }
 
-/// The synthetic `cargo` package has no directory of its own and is not a
+/// The synthetic `rust` package has no directory of its own and is not a
 /// pruneable target.
 #[test]
 fn test_prune_cargo_workspace_package_rejected() {
     let tempdir = tempfile::tempdir().unwrap();
     setup_cargo_monorepo(tempdir.path());
 
-    let output = run_turbo(tempdir.path(), &["prune", "cargo"]);
+    let output = run_turbo(tempdir.path(), &["prune", "rust"]);
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(


### PR DESCRIPTION
## Why

Setting up for the experimental `command` feature. The override's per-toolchain map uses toolchain ids as user-facing keys, which exposed a taxonomy inconsistency: `"javascript"` names a language, `"cargo"` names a build tool. Toolchains are now named by **language** — the axis users think in, and the only one with an answer for every ecosystem (JS has no single build tool to name; prior art: moonrepo, Pants).

## What

- `ToolchainId`'s public string: `"cargo"` → `"rust"` (const renamed `CARGO` → `RUST`).
- The synthetic workspace package follows: task keys read `rust#test`, `rust#lint`; `turbo prune rust` is the (rejected, as before) prune target.
- What deliberately keeps its name: `CargoToolchain` (the implementation *is* Cargo-specific — `cargo metadata` discovery, verb tables), `futureFlags.experimentalCargoWorkspaces` (names the feature), and the `"cargo"` serial group (names the binary whose build-dir lock it serializes).

## How

Safe now because every surface is behind the experimental flag — no released behavior changes.