### PR TITLE
feat: Require a user-declared name for the Cargo workspace package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@ members = [
 [workspace.package]
 edition = "2024"
 
+[workspace.metadata]
+# The Cargo workspace's name as a Turborepo package: task keys
+# (`turborepo-crates#test`) and filters (`--filter=turborepo-crates`).
+name = "turborepo-crates"
+
 [workspace.metadata.groups]
 # Only the libraries, does not include the turborepo binary.
 # That way we don't have to build the Go code

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,50 +1,448 @@
-# devEngines.packageManager PR Plan
+# PLAN.md — Task `command` Overrides
 
-This plan breaks the `devEngines.packageManager` work from `SPEC.md` into reviewable PRs.
+## Problem
 
-## PR 1: Rust support for `devEngines.packageManager`
+Turborepo synthesizes task commands from toolchain conventions: package.json
+scripts for JavaScript, verb tables for Cargo (`test` → `cargo test
+--workspace`). There is no way to redefine what a task runs.
 
-- Add structured `PackageJson.dev_engines` support.
-- Preserve unknown and ignored `devEngines` fields during serialization.
-- Implement Rust detection precedence: top-level `packageManager`, then `devEngines.packageManager`, then missing-declaration error.
-- Validate supported names, exact semver versions, malformed objects, whitespace, and empty values.
-- Reuse existing pnpm and Yarn version mapping.
-- Add lockfile mismatch validation.
-- Wire `dangerouslyDisablePackageManagerCheck` to bypass declaration validation and use existing implicit detection behavior.
-- Update Rust diagnostics and messaging to recommend `devEngines.packageManager`.
-- Add Rust unit coverage and representative CLI integration coverage.
+Motivating case: running Rust tests through `cargo nextest run`. Cargo has no
+native remapping (aliases cannot shadow built-in commands, by explicit cargo
+policy), and baking nextest detection into turbo makes the verb table a
+registry of third-party tools — next comes `cargo-llvm-cov`, then miri. The
+tool-agnostic fix: turbo.json — turbo's own task-definition surface — defines
+the command.
 
-## PR 2: TypeScript detection parity
+## Principle
 
-- Update `@turbo/workspaces` package-manager detection to support `devEngines.packageManager`.
-- Match Rust precedence, validation, exact-semver-only behavior, array rejection, malformed-object handling, and ignored unknown properties.
-- Update TypeScript user-facing errors to prefer `devEngines.packageManager`.
-- Add TypeScript detection tests.
+**`command` replaces the process argv. The toolchain keeps owning everything
+else.**
 
-## PR 3: Codemod update
+A task command is two separable things:
 
-- Keep the `add-package-manager` transformer name.
-- Write `devEngines.packageManager` instead of top-level `packageManager`.
-- Treat existing top-level `packageManager` as already set.
-- Treat existing `devEngines.packageManager` as already set.
-- Shallow-merge into existing `devEngines`.
-- Update codemod description and logging.
-- Add tests for output shape, merge behavior, and idempotency for both declaration fields.
+1. **argv** — the process to spawn
+2. **frame** — everything the toolchain wraps around it: working directory,
+   serial grouping, hash wiring (crate-closure input globs,
+   `HASHED_ENV_VARS`, external-dependency hashing), env composition
+   (compile-cache injection, MFE vars), display
 
-## PR 4: Workspace conversion tooling
+`command` swaps only the argv. An overridden `acme#test` still hashes by the
+crate closure, still serializes with other cargo invocations, still receives
+`RUSTC_WRAPPER` injection when the compile cache runs. The frame is untouched
+— that is what makes one field behave identically across toolchains.
 
-- Update add, remove, and convert behavior to handle both declaration fields.
-- Remove stale top-level `packageManager` when converting to a new manager so precedence cannot keep resolving to the old manager.
-- Preserve either declaration field when it identifies a different manager than the one being removed.
-- Add tests for add, remove, convert, stale top-level removal, and preservation behavior.
+## Prerequisite: toolchain naming (PR 0 — shipped, #13311)
 
-## PR 5: Docs and user-facing copy
+Toolchains are named by **language**, not build tool — the axis users think
+in, and the one with an answer for every ecosystem (prior art: moonrepo,
+Pants):
 
-- Update docs, errors, comments, and generated schema descriptions to prefer `devEngines.packageManager`.
-- Mention top-level `packageManager` only as legacy or backward-compatible support where useful.
-- Update `dangerouslyDisablePackageManagerCheck` descriptions to mention both declaration fields or use declaration-neutral wording.
+- `ToolchainId::JAVASCRIPT` stays `"javascript"`.
+- `ToolchainId::CARGO` renames `"cargo"` → `"rust"`. Safe now: every
+  surface is behind `experimentalCargoWorkspaces`. The flag keeps its name —
+  it describes the feature (Cargo workspace support), not the toolchain
+  identity.
 
-## PR 6: Examples, templates, and scaffolding
+**Alias** (resolved at parse time): `typescript` → `javascript`. Using an
+alias and its canonical name in the same map is an error:
 
-- Update examples, templates, and new project scaffolding to write `devEngines.packageManager`.
-- This PR should happen after a stable release includes `devEngines.packageManager` detection support, so generated projects remain compatible with currently supported Turborepo versions.
+```
+Error: `command` defines both "typescript" and "javascript" — these are the
+same toolchain. Use one key.
+```
+
+There is no `cargo` alias: a `"cargo"` key gets the unknown-toolchain error
+with a did-you-mean pointing at `"rust"` — corrected, not accepted.
+
+## Prerequisite: the workspace package is named by the user (PR 0.5)
+
+The synthetic Cargo workspace package previously took a magic reserved name
+(`cargo`, then `rust`). Magic names are a design defect: they collide with
+real packages (today a crate named `rust` is silently skipped), they confuse
+(`rust#test` names a package nobody defined), and they overload the
+toolchain id.
+
+**Rule: using Turborepo with Rust requires naming the Cargo workspace**, in
+the root `Cargo.toml`, via cargo's sanctioned free-form surface:
+
+```toml
+[workspace]
+members = ["crates/*"]
+
+[workspace.metadata]
+name = "acme"
+```
+
+Task keys, filters, and the TUI use that name: `acme#test`,
+`--filter=acme`. This is not extra ceremony — it is the rule every package
+already follows (JS packages without a `name` are errors); cargo just has
+no native slot for this particular package's name, so we designate one.
+The key is deliberately **un-namespaced** (not `metadata.turbo`): a
+workspace's name is a property of the workspace with universally shared
+semantics, not tool-specific configuration. No existing Rust tool names
+workspaces at all, so this mints an agnostic proto-convention; if cargo
+ever grows native workspace names, we read those and deprecate this.
+
+- **One source, no fallbacks.** A root `[package] name` is _not_ consulted:
+  in non-virtual workspaces the root package is also a real crate, and
+  reusing its name would conflate the two (and mint two packages with one
+  name at one directory).
+- **Missing name = hard, actionable error** at any turbo invocation while
+  the flag is on:
+
+  ```
+  Error: The Cargo workspace has no name.
+
+  Turborepo needs a name for the workspace's tasks (`<name>#test`),
+  filters (`--filter=<name>`), and configuration. Add one to the root
+  Cargo.toml:
+
+      [workspace.metadata]
+      name = "my-workspace"
+  ```
+
+- **Collisions get honest.** A workspace name that matches any crate or JS
+  package is a discovery error naming both parties. The reserved-name
+  skip-with-warning hack is deleted.
+- **Validation**: non-empty, no `#`, not `//`, unique across the graph.
+  Warn (not error) on `rust`/`javascript` — legal, but re-introduces the
+  confusion this removes.
+- **Disambiguation this creates**: the _toolchain id_ (`"rust"`,
+  `"javascript"`) keys the per-toolchain `command` map and never appears as
+  a package name; the _workspace package name_ is the user's.
+- **Dogfood**: this repository names its workspace `turborepo-crates`.
+
+Examples throughout this document use a workspace named `acme`.
+
+## API
+
+```jsonc
+// turbo.json (root)
+{
+  "futureFlags": { "experimentalTaskCommand": true },
+  "tasks": {
+    /* see forms below */
+  }
+}
+```
+
+- **Shape**: argv array — executed directly, no shell, no `&&`, no
+  interpolation. It is a _command_, not a _script_ (a "script" implies shell
+  semantics package.json owns; we deliberately don't provide them).
+- **Flag**: using `command` without `futureFlags.experimentalTaskCommand` is
+  a **hard error** — never a silent strip, because ignoring it would change
+  _what executes_. (The silent-strip pattern used for `incremental` is only
+  safe for optimizations.) Gating hook exists:
+  `ProcessedTaskDefinition::from_raw` already receives `&FutureFlags`
+  (processed.rs:599).
+- **Schema**: `#[schemars(skip)]` while experimental.
+
+### The three value forms
+
+```jsonc
+// 1. Argv array — allowed everywhere.
+//    At unscoped root: the default for EVERY package, all toolchains.
+//    Always valid regardless of repo composition (a toolchain-agnostic
+//    command like this is exactly the mixed-repo use case).
+"clean": { "command": ["rm", "-rf", "dist", ".turbo"] },
+
+// 2. Per-toolchain map — unscoped root only (scoped positions already
+//    know their toolchain; a map there is noise → validation error).
+"test": {
+  "command": {
+    "rust": ["cargo", "nextest", "run"],
+    "javascript": ["vitest", "run"]
+  }
+},
+
+// 3. Opt-out — null or [], scoped positions only (a default of nothing
+//    is meaningless → validation error at unscoped root).
+"acme#test": { "command": null }
+```
+
+Raw schema is a tri-state (serde must distinguish _absent_ from _null_):
+`RawCommand::{Argv(Vec<Spanned<UnescapedString>>), OptOut, PerToolchain(Map)}`
+— dispatched on JSON shape (array / null / object) via biome-deserialize.
+
+### Execution model
+
+**`command` is the complete argv: element 0 is the program, the rest are its
+arguments. Nothing is prepended, by any toolchain.**
+
+```jsonc
+"web#thing": { "command": ["node", "--run", "thing", "stuff"] }
+// spawns: node --run thing stuff        (cwd: packages/web)
+// NOT:    pnpm run node --run thing stuff
+```
+
+The JS toolchain's `pnpm run <task>` construction is what the override
+_replaces_ — exactly as the cargo verb table is what an `acme#test` override
+replaces. Keeping the package-manager indirection would make the field mean
+"script name to pass to the package manager", a different and weaker feature.
+
+- **Program resolution**: argv[0] resolves via the OS's normal spawn
+  semantics — absolute paths as-is, bare names through `PATH`, relative
+  paths (`["./scripts/build.sh"]`) against the cwd, which is the package
+  directory.
+- **Uniformity**: this rule is toolchain-independent. The toolchain
+  contributes the frame (cwd, serial group, env composition, hash wiring) —
+  never argv content.
+- Aside: Node 22+'s `node --run <script>` reads package.json scripts and
+  adds `node_modules/.bin` to `PATH` itself — a legitimate way to run a
+  script with `.bin` resolution but without the package-manager process.
+
+## Precedence (highest → lowest)
+
+| #   | Source                                                           | Nature                                                             |
+| --- | ---------------------------------------------------------------- | ------------------------------------------------------------------ |
+| 1   | `command` in a Package Configuration                             | package explicitly redefines itself                                |
+| 2   | `command` on a package-scoped root key (`web#test`, `acme#test`) | root explicitly targets one package                                |
+| 3   | **Package-authored** native definition — package.json script     | the toolchain's native, user-written definition wins over defaults |
+| 4   | `command` on an unscoped root task (array or map)                | toolchain-agnostic / per-toolchain default                         |
+| 5   | **Toolchain-synthesized** command — cargo verb table             | turbo's fallback, authored by nobody                               |
+
+Cargo has nothing at level 3 (crates don't author task commands), so an
+unscoped `rust` command beats the verb table:
+`"test": { "command": { "rust": ["cargo", "nextest", "run"] } }` means
+`turbo test` runs nextest; without it, the verb table gives `cargo test`.
+For JS, a package.json script shadows the unscoped default — leaning into
+what the toolchain does natively.
+
+Resolution consults levels 3 and 5 through the toolchain (`defines_task` /
+verb tables), so all five levels meet in **one resolver function** — the
+single point of truth, heavily tested.
+
+## Semantics matrix
+
+### A. Explicit override vs native (levels 1–2 vs 3)
+
+```jsonc
+// JS package `web`, package.json: "scripts": { "test": "jest" }
+"web#test": { "command": ["vitest", "run"] }
+// Runs: vitest run (cwd packages/web). jest never enters the picture. Silent.
+
+// Cargo workspace package:
+"acme#test": { "command": ["cargo", "nextest", "run", "--workspace"] }
+// Runs nextest, serialized with other cargo tasks, crate-closure hashed.
+```
+
+### B. Unscoped defaults (level 4) and the "every package" rule
+
+An unscoped `command` grants the task to every package it covers (bare
+array: all packages; map: packages of the listed toolchains). Two canonical
+Rust-test patterns:
+
+```jsonc
+// Pattern A — one workspace-wide run (current CI shape):
+"acme#test": { "command": ["cargo", "nextest", "run", "--workspace"] }
+
+// Pattern B — per-crate test tasks, individually cached and
+// affected-aware; opt the workspace package out to avoid running the
+// suite twice:
+"test": { "command": { "rust": ["cargo", "nextest", "run"] } },
+"acme#test": { "command": null }
+// Each crate runs `cargo nextest run` from its own directory (cwd =
+// package dir ⇒ that crate's tests), serialized on the cargo group.
+```
+
+### C. Tasks that exist only through `command`
+
+```jsonc
+// No "coverage" verb exists; now the task does:
+"acme#coverage": {
+  "command": ["cargo", "llvm-cov", "--workspace"],
+  "outputs": ["coverage/**"]
+},
+// Library crates map no verbs; command gives them one:
+"turborepo-scm#fuzz": { "command": ["cargo", "fuzz", "run", "scm"] }
+```
+
+Existence surfaces that compose
+`command.is_some() || toolchain.defines_task(...)`: engine builder
+(`defines_task`, definitions.rs:217 — global-deps hashing), TUI task list
+(`tasks_with_command`), watch mode (same call).
+
+### D. Package Configurations
+
+```jsonc
+// packages/web/turbo.json
+{
+  "extends": ["//"],
+  "tasks": {
+    "test": { "command": ["vitest", "run", "--shard=1/2"] } // level 1
+  }
+}
+```
+
+Unscoped is the natural form here (the file scopes it); `pkg#task` syntax
+stays forbidden in Package Configurations (existing
+`UnnecessaryPackageTaskSyntax`). Map form: forbidden (toolchain already
+known). The synthetic `rust` package's "package config" _is_ the root
+turbo.json (root-at-repo-root reuse, loader.rs:471-478) — `acme#test` in
+root is its only configuration point.
+
+### E. Merge across the extends chain
+
+`command` merges **atomically** (scalar semantics, extend.rs `set_field!`):
+the most specific definition's whole value wins; maps never deep-merge.
+`$TURBO_EXTENDS$` inside `command` is a validation error (appending argv
+fragments has no coherent meaning). Within one file, key specificity is
+unchanged: `web#test` beats `test` (either/or lookup, lib.rs:238-255).
+
+Other fields remain independently mergeable — a package can override
+`command` while inheriting root's `outputs`.
+
+### F. The frame, per toolchain
+
+| Frame property                  | JavaScript                                                                                       | Rust                                                                                                                    |
+| ------------------------------- | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| cwd                             | package directory                                                                                | package directory (the workspace package's dir _is_ the repo root)                                                      |
+| serial group                    | none                                                                                             | `"cargo"` iff `argv[0] == "cargo"` — the toolchain knowing its own binary's build-dir locking, not third-party sniffing |
+| env                             | per env-mode, as today                                                                           | per env-mode, as today                                                                                                  |
+| compile-cache injection         | n/a                                                                                              | applies (conflict classification already tolerates/detects user wrappers)                                               |
+| PATH                            | **verbatim — no `node_modules/.bin`** (override bypasses the package manager; documented v1 gap) | verbatim                                                                                                                |
+| hash wiring (`derived_task_io`) | unchanged                                                                                        | crate-closure globs, `HASHED_ENV_VARS`, external-dep hashing — unchanged                                                |
+
+### G. Pass-through args
+
+Appended verbatim — turbo can't know an arbitrary command's separator
+convention:
+
+```
+turbo test -- -E 'test(scm)'
+# → cargo nextest run --workspace -E 'test(scm)'
+```
+
+With a per-toolchain map, pass-through args append to **every** toolchain's
+command in the run — `turbo test -- --watch` reaches both vitest and
+nextest. Identical to today's behavior with heterogeneous package scripts,
+not new. Hashed as today (`pass_through_args` is already in `TaskHashable`).
+
+### H. Data from the outside
+
+**1. Environment variables reaching the process — works, per env-mode
+(frame, unchanged).** Everything in loose mode; declared `env` /
+`passThroughEnv` / `globalPassThroughEnv` in strict mode. The existing
+hashing rule applies unchanged — if the variable changes behavior, declare
+it:
+
+```jsonc
+"test": {
+  "command": { "rust": ["cargo", "nextest", "run"] },
+  "env": ["NEXTEST_PROFILE"]   // hashed: profile change ⇒ cache miss
+}
+```
+
+```bash
+NEXTEST_PROFILE=ci turbo test   # nextest reads it from its environment
+```
+
+**2. Ad-hoc CLI flags — works, via pass-through args** (section G).
+
+**3. Interpolating variables _into_ the argv — deliberately no.**
+
+```jsonc
+"test": { "command": ["cargo", "nextest", "run", "--profile", "$PROFILE"] }
+// passes the literal string "$PROFILE" — there is no shell
+```
+
+No-shell is the core contract (cross-platform determinism, no quoting hell,
+hashable-as-written). Interpolation would force answers to: Windows `%VAR%`
+vs `$VAR`, escaping literal dollars, and — worst — whether the _hash_
+covers the template or the resolved value (resolved ⇒ per-machine cache
+divergence unless the var is also declared; template ⇒ stale caches when
+the var changes). That's a shell's job. Two explicit escape hatches:
+
+```jsonc
+// (a) Most tools read configuration from env directly — case 1 covers it:
+//     NEXTEST_PROFILE=ci turbo test
+
+// (b) If you truly need shell semantics, say so — you own the shell:
+"deploy": { "command": ["bash", "-c", "deploy.sh --target $DEPLOY_TARGET"] }
+```
+
+Friendliness: a **warning** (not error) when an argv element matches
+`$IDENTIFIER` / `%IDENTIFIER%` — _"command arguments are not
+shell-interpolated; `$PROFILE` will be passed literally"_ — since a literal
+dollar-argument is almost always a mistake, but occasionally legitimate.
+
+### I. Hashing
+
+The resolved command joins `TaskHashable` (new field + capnp schema;
+`TaskDefinitionHashInfo` gains a `command()` accessor, turborepo-types
+lib.rs:1269-1303). Editing a command invalidates exactly the affected tasks.
+Capnp change ⇒ one-time global hash bust on upgrade (standard).
+
+### J. Presentation
+
+Run summary / dry-run show the joined resolved argv. TUI shows the task via
+existence composition. `--graph` unchanged (graph shape is
+command-independent except for tasks existing only via `command`).
+
+### K. Single-package mode
+
+Unscoped is the only syntax and unambiguous — array and opt-out allowed,
+map allowed (degenerate but harmless).
+
+## Validation matrix (config-load time)
+
+| Condition                                                       | Outcome                                                              |
+| --------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `command` present, flag off                                     | error: requires `futureFlags.experimentalTaskCommand`                |
+| Map form in scoped position (root `pkg#task` or Package Config) | error: toolchain already determined; use an array                    |
+| `null` / `[]` at unscoped root                                  | error: a default of nothing is meaningless                           |
+| Unknown toolchain key                                           | error + did-you-mean (`"cargo"` → `"rust"`; known toolchains listed) |
+| Alias + canonical in one map (`typescript` + `javascript`)      | error: same toolchain, use one key                                   |
+| `rust` key without `experimentalCargoWorkspaces`                | error pointing at the flag                                           |
+| `$TURBO_EXTENDS$` inside `command`                              | error: command is atomic                                             |
+| Empty string element in argv                                    | error                                                                |
+| Argv element looks like `$VAR` / `%VAR%`                        | warning: passed literally, not interpolated                          |
+
+## Implementation map
+
+| Layer                                         | Change                                                                                                                                                                                                                                             |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `turborepo-repository` (PR 0, shipped #13311) | `ToolchainId` `"cargo"`→`"rust"`                                                                                                                                                                                                                   |
+| `turborepo-repository` (PR 0.5)               | delete `WORKSPACE_PACKAGE_NAME`; read `[workspace.metadata] name` during discovery (`cargo metadata` emits `workspace_metadata`); missing-name error; collision + validation checks; dogfood `name = "turborepo-crates"` in this repo's Cargo.toml |
+| `turborepo-turbo-json`                        | `RawTaskDefinition.command` tri-state; alias resolution; atomic merge; flag gate + validation matrix in `from_raw` (receives `&FutureFlags` already)                                                                                               |
+| `turborepo-types`                             | `TaskDefinition.command`; `TaskDefinitionHashInfo::command()`                                                                                                                                                                                      |
+| `turborepo-engine`                            | `from_processed`; five-level resolver; `defines_task` composition (definitions.rs:217)                                                                                                                                                             |
+| `turborepo-repository`                        | `Toolchain::task_command`/`task_display_command` gain `override_command: Option<&[String]>`; JS + Cargo place it in their frames; shared argv-split helper                                                                                         |
+| `turborepo-task-executor`                     | `ToolchainCommandProvider` receives resolved-override lookup (`HashMap<TaskId, Vec<String>>` built by the visitor — no engine dependency)                                                                                                          |
+| `turborepo-lib`                               | visitor builds the lookup (exec.rs:56-62); TUI `tasks_with_command` composition                                                                                                                                                                    |
+| `turborepo-task-hash`                         | `TaskHashable.command` + proto.capnp + population (lib.rs:538-552)                                                                                                                                                                                 |
+
+## Test plan
+
+- naming (PR 0.5): missing `[workspace.metadata] name` ⇒ actionable error;
+  name collision with a crate / JS package ⇒ discovery error; invalid names
+  (`#`, `//`, empty) rejected; `rust`/`javascript` warn; fixtures renamed
+- turbo-json: tri-state parse (array/null/map), alias resolution + conflict,
+  atomic merge, full validation matrix, Package Config scoping
+- resolver: all five precedence levels, per-toolchain map fan-out, opt-out,
+  script-shadows-default, verb-table-loses-to-default
+- toolchain unit: JS override (cwd, bypasses pm), cargo override
+  (serial-group heuristic both ways), library-crate command
+- engine/TUI: existence composition
+- hashing: ±command ⇒ hash change; map key change ⇒ only that toolchain's
+  tasks invalidate
+- e2e: `acme#test` nextest override + Pattern B fixture; dry-run JSON shows
+  argv
+- dogfood: this repo adopts Pattern A (then evaluates B) after a canary
+  knows the field
+
+## Rollout
+
+1. `unknown_fields = deny` ⇒ turbos predating the field hard-error on
+   turbo.jsons using it. Sequence: land → canary → adoption (same dance as
+   every field/flag).
+2. PR series: **PR 0** rename (shipped) → **PR 0.5** workspace naming →
+   **PR 1** schema/flag/validation → **PR 2**
+   resolver + toolchain/executor plumbing + hashing → **PR 3** dogfood flip.
+
+## Out of scope (recorded)
+
+- Shell-string form (a future `script` field would be the honest spelling)
+- `node_modules/.bin` PATH augmentation for JS overrides
+- Per-toolchain pass-through separator awareness
+- Batching contended cargo invocations (parked separately)

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,448 +1,50 @@
-# PLAN.md — Task `command` Overrides
+# devEngines.packageManager PR Plan
 
-## Problem
+This plan breaks the `devEngines.packageManager` work from `SPEC.md` into reviewable PRs.
 
-Turborepo synthesizes task commands from toolchain conventions: package.json
-scripts for JavaScript, verb tables for Cargo (`test` → `cargo test
---workspace`). There is no way to redefine what a task runs.
+## PR 1: Rust support for `devEngines.packageManager`
 
-Motivating case: running Rust tests through `cargo nextest run`. Cargo has no
-native remapping (aliases cannot shadow built-in commands, by explicit cargo
-policy), and baking nextest detection into turbo makes the verb table a
-registry of third-party tools — next comes `cargo-llvm-cov`, then miri. The
-tool-agnostic fix: turbo.json — turbo's own task-definition surface — defines
-the command.
+- Add structured `PackageJson.dev_engines` support.
+- Preserve unknown and ignored `devEngines` fields during serialization.
+- Implement Rust detection precedence: top-level `packageManager`, then `devEngines.packageManager`, then missing-declaration error.
+- Validate supported names, exact semver versions, malformed objects, whitespace, and empty values.
+- Reuse existing pnpm and Yarn version mapping.
+- Add lockfile mismatch validation.
+- Wire `dangerouslyDisablePackageManagerCheck` to bypass declaration validation and use existing implicit detection behavior.
+- Update Rust diagnostics and messaging to recommend `devEngines.packageManager`.
+- Add Rust unit coverage and representative CLI integration coverage.
 
-## Principle
+## PR 2: TypeScript detection parity
 
-**`command` replaces the process argv. The toolchain keeps owning everything
-else.**
+- Update `@turbo/workspaces` package-manager detection to support `devEngines.packageManager`.
+- Match Rust precedence, validation, exact-semver-only behavior, array rejection, malformed-object handling, and ignored unknown properties.
+- Update TypeScript user-facing errors to prefer `devEngines.packageManager`.
+- Add TypeScript detection tests.
 
-A task command is two separable things:
+## PR 3: Codemod update
 
-1. **argv** — the process to spawn
-2. **frame** — everything the toolchain wraps around it: working directory,
-   serial grouping, hash wiring (crate-closure input globs,
-   `HASHED_ENV_VARS`, external-dependency hashing), env composition
-   (compile-cache injection, MFE vars), display
+- Keep the `add-package-manager` transformer name.
+- Write `devEngines.packageManager` instead of top-level `packageManager`.
+- Treat existing top-level `packageManager` as already set.
+- Treat existing `devEngines.packageManager` as already set.
+- Shallow-merge into existing `devEngines`.
+- Update codemod description and logging.
+- Add tests for output shape, merge behavior, and idempotency for both declaration fields.
 
-`command` swaps only the argv. An overridden `acme#test` still hashes by the
-crate closure, still serializes with other cargo invocations, still receives
-`RUSTC_WRAPPER` injection when the compile cache runs. The frame is untouched
-— that is what makes one field behave identically across toolchains.
+## PR 4: Workspace conversion tooling
 
-## Prerequisite: toolchain naming (PR 0 — shipped, #13311)
+- Update add, remove, and convert behavior to handle both declaration fields.
+- Remove stale top-level `packageManager` when converting to a new manager so precedence cannot keep resolving to the old manager.
+- Preserve either declaration field when it identifies a different manager than the one being removed.
+- Add tests for add, remove, convert, stale top-level removal, and preservation behavior.
 
-Toolchains are named by **language**, not build tool — the axis users think
-in, and the one with an answer for every ecosystem (prior art: moonrepo,
-Pants):
+## PR 5: Docs and user-facing copy
 
-- `ToolchainId::JAVASCRIPT` stays `"javascript"`.
-- `ToolchainId::CARGO` renames `"cargo"` → `"rust"`. Safe now: every
-  surface is behind `experimentalCargoWorkspaces`. The flag keeps its name —
-  it describes the feature (Cargo workspace support), not the toolchain
-  identity.
+- Update docs, errors, comments, and generated schema descriptions to prefer `devEngines.packageManager`.
+- Mention top-level `packageManager` only as legacy or backward-compatible support where useful.
+- Update `dangerouslyDisablePackageManagerCheck` descriptions to mention both declaration fields or use declaration-neutral wording.
 
-**Alias** (resolved at parse time): `typescript` → `javascript`. Using an
-alias and its canonical name in the same map is an error:
+## PR 6: Examples, templates, and scaffolding
 
-```
-Error: `command` defines both "typescript" and "javascript" — these are the
-same toolchain. Use one key.
-```
-
-There is no `cargo` alias: a `"cargo"` key gets the unknown-toolchain error
-with a did-you-mean pointing at `"rust"` — corrected, not accepted.
-
-## Prerequisite: the workspace package is named by the user (PR 0.5)
-
-The synthetic Cargo workspace package previously took a magic reserved name
-(`cargo`, then `rust`). Magic names are a design defect: they collide with
-real packages (today a crate named `rust` is silently skipped), they confuse
-(`rust#test` names a package nobody defined), and they overload the
-toolchain id.
-
-**Rule: using Turborepo with Rust requires naming the Cargo workspace**, in
-the root `Cargo.toml`, via cargo's sanctioned free-form surface:
-
-```toml
-[workspace]
-members = ["crates/*"]
-
-[workspace.metadata]
-name = "acme"
-```
-
-Task keys, filters, and the TUI use that name: `acme#test`,
-`--filter=acme`. This is not extra ceremony — it is the rule every package
-already follows (JS packages without a `name` are errors); cargo just has
-no native slot for this particular package's name, so we designate one.
-The key is deliberately **un-namespaced** (not `metadata.turbo`): a
-workspace's name is a property of the workspace with universally shared
-semantics, not tool-specific configuration. No existing Rust tool names
-workspaces at all, so this mints an agnostic proto-convention; if cargo
-ever grows native workspace names, we read those and deprecate this.
-
-- **One source, no fallbacks.** A root `[package] name` is _not_ consulted:
-  in non-virtual workspaces the root package is also a real crate, and
-  reusing its name would conflate the two (and mint two packages with one
-  name at one directory).
-- **Missing name = hard, actionable error** at any turbo invocation while
-  the flag is on:
-
-  ```
-  Error: The Cargo workspace has no name.
-
-  Turborepo needs a name for the workspace's tasks (`<name>#test`),
-  filters (`--filter=<name>`), and configuration. Add one to the root
-  Cargo.toml:
-
-      [workspace.metadata]
-      name = "my-workspace"
-  ```
-
-- **Collisions get honest.** A workspace name that matches any crate or JS
-  package is a discovery error naming both parties. The reserved-name
-  skip-with-warning hack is deleted.
-- **Validation**: non-empty, no `#`, not `//`, unique across the graph.
-  Warn (not error) on `rust`/`javascript` — legal, but re-introduces the
-  confusion this removes.
-- **Disambiguation this creates**: the _toolchain id_ (`"rust"`,
-  `"javascript"`) keys the per-toolchain `command` map and never appears as
-  a package name; the _workspace package name_ is the user's.
-- **Dogfood**: this repository names its workspace `turborepo-crates`.
-
-Examples throughout this document use a workspace named `acme`.
-
-## API
-
-```jsonc
-// turbo.json (root)
-{
-  "futureFlags": { "experimentalTaskCommand": true },
-  "tasks": {
-    /* see forms below */
-  }
-}
-```
-
-- **Shape**: argv array — executed directly, no shell, no `&&`, no
-  interpolation. It is a _command_, not a _script_ (a "script" implies shell
-  semantics package.json owns; we deliberately don't provide them).
-- **Flag**: using `command` without `futureFlags.experimentalTaskCommand` is
-  a **hard error** — never a silent strip, because ignoring it would change
-  _what executes_. (The silent-strip pattern used for `incremental` is only
-  safe for optimizations.) Gating hook exists:
-  `ProcessedTaskDefinition::from_raw` already receives `&FutureFlags`
-  (processed.rs:599).
-- **Schema**: `#[schemars(skip)]` while experimental.
-
-### The three value forms
-
-```jsonc
-// 1. Argv array — allowed everywhere.
-//    At unscoped root: the default for EVERY package, all toolchains.
-//    Always valid regardless of repo composition (a toolchain-agnostic
-//    command like this is exactly the mixed-repo use case).
-"clean": { "command": ["rm", "-rf", "dist", ".turbo"] },
-
-// 2. Per-toolchain map — unscoped root only (scoped positions already
-//    know their toolchain; a map there is noise → validation error).
-"test": {
-  "command": {
-    "rust": ["cargo", "nextest", "run"],
-    "javascript": ["vitest", "run"]
-  }
-},
-
-// 3. Opt-out — null or [], scoped positions only (a default of nothing
-//    is meaningless → validation error at unscoped root).
-"acme#test": { "command": null }
-```
-
-Raw schema is a tri-state (serde must distinguish _absent_ from _null_):
-`RawCommand::{Argv(Vec<Spanned<UnescapedString>>), OptOut, PerToolchain(Map)}`
-— dispatched on JSON shape (array / null / object) via biome-deserialize.
-
-### Execution model
-
-**`command` is the complete argv: element 0 is the program, the rest are its
-arguments. Nothing is prepended, by any toolchain.**
-
-```jsonc
-"web#thing": { "command": ["node", "--run", "thing", "stuff"] }
-// spawns: node --run thing stuff        (cwd: packages/web)
-// NOT:    pnpm run node --run thing stuff
-```
-
-The JS toolchain's `pnpm run <task>` construction is what the override
-_replaces_ — exactly as the cargo verb table is what an `acme#test` override
-replaces. Keeping the package-manager indirection would make the field mean
-"script name to pass to the package manager", a different and weaker feature.
-
-- **Program resolution**: argv[0] resolves via the OS's normal spawn
-  semantics — absolute paths as-is, bare names through `PATH`, relative
-  paths (`["./scripts/build.sh"]`) against the cwd, which is the package
-  directory.
-- **Uniformity**: this rule is toolchain-independent. The toolchain
-  contributes the frame (cwd, serial group, env composition, hash wiring) —
-  never argv content.
-- Aside: Node 22+'s `node --run <script>` reads package.json scripts and
-  adds `node_modules/.bin` to `PATH` itself — a legitimate way to run a
-  script with `.bin` resolution but without the package-manager process.
-
-## Precedence (highest → lowest)
-
-| #   | Source                                                           | Nature                                                             |
-| --- | ---------------------------------------------------------------- | ------------------------------------------------------------------ |
-| 1   | `command` in a Package Configuration                             | package explicitly redefines itself                                |
-| 2   | `command` on a package-scoped root key (`web#test`, `acme#test`) | root explicitly targets one package                                |
-| 3   | **Package-authored** native definition — package.json script     | the toolchain's native, user-written definition wins over defaults |
-| 4   | `command` on an unscoped root task (array or map)                | toolchain-agnostic / per-toolchain default                         |
-| 5   | **Toolchain-synthesized** command — cargo verb table             | turbo's fallback, authored by nobody                               |
-
-Cargo has nothing at level 3 (crates don't author task commands), so an
-unscoped `rust` command beats the verb table:
-`"test": { "command": { "rust": ["cargo", "nextest", "run"] } }` means
-`turbo test` runs nextest; without it, the verb table gives `cargo test`.
-For JS, a package.json script shadows the unscoped default — leaning into
-what the toolchain does natively.
-
-Resolution consults levels 3 and 5 through the toolchain (`defines_task` /
-verb tables), so all five levels meet in **one resolver function** — the
-single point of truth, heavily tested.
-
-## Semantics matrix
-
-### A. Explicit override vs native (levels 1–2 vs 3)
-
-```jsonc
-// JS package `web`, package.json: "scripts": { "test": "jest" }
-"web#test": { "command": ["vitest", "run"] }
-// Runs: vitest run (cwd packages/web). jest never enters the picture. Silent.
-
-// Cargo workspace package:
-"acme#test": { "command": ["cargo", "nextest", "run", "--workspace"] }
-// Runs nextest, serialized with other cargo tasks, crate-closure hashed.
-```
-
-### B. Unscoped defaults (level 4) and the "every package" rule
-
-An unscoped `command` grants the task to every package it covers (bare
-array: all packages; map: packages of the listed toolchains). Two canonical
-Rust-test patterns:
-
-```jsonc
-// Pattern A — one workspace-wide run (current CI shape):
-"acme#test": { "command": ["cargo", "nextest", "run", "--workspace"] }
-
-// Pattern B — per-crate test tasks, individually cached and
-// affected-aware; opt the workspace package out to avoid running the
-// suite twice:
-"test": { "command": { "rust": ["cargo", "nextest", "run"] } },
-"acme#test": { "command": null }
-// Each crate runs `cargo nextest run` from its own directory (cwd =
-// package dir ⇒ that crate's tests), serialized on the cargo group.
-```
-
-### C. Tasks that exist only through `command`
-
-```jsonc
-// No "coverage" verb exists; now the task does:
-"acme#coverage": {
-  "command": ["cargo", "llvm-cov", "--workspace"],
-  "outputs": ["coverage/**"]
-},
-// Library crates map no verbs; command gives them one:
-"turborepo-scm#fuzz": { "command": ["cargo", "fuzz", "run", "scm"] }
-```
-
-Existence surfaces that compose
-`command.is_some() || toolchain.defines_task(...)`: engine builder
-(`defines_task`, definitions.rs:217 — global-deps hashing), TUI task list
-(`tasks_with_command`), watch mode (same call).
-
-### D. Package Configurations
-
-```jsonc
-// packages/web/turbo.json
-{
-  "extends": ["//"],
-  "tasks": {
-    "test": { "command": ["vitest", "run", "--shard=1/2"] } // level 1
-  }
-}
-```
-
-Unscoped is the natural form here (the file scopes it); `pkg#task` syntax
-stays forbidden in Package Configurations (existing
-`UnnecessaryPackageTaskSyntax`). Map form: forbidden (toolchain already
-known). The synthetic `rust` package's "package config" _is_ the root
-turbo.json (root-at-repo-root reuse, loader.rs:471-478) — `acme#test` in
-root is its only configuration point.
-
-### E. Merge across the extends chain
-
-`command` merges **atomically** (scalar semantics, extend.rs `set_field!`):
-the most specific definition's whole value wins; maps never deep-merge.
-`$TURBO_EXTENDS$` inside `command` is a validation error (appending argv
-fragments has no coherent meaning). Within one file, key specificity is
-unchanged: `web#test` beats `test` (either/or lookup, lib.rs:238-255).
-
-Other fields remain independently mergeable — a package can override
-`command` while inheriting root's `outputs`.
-
-### F. The frame, per toolchain
-
-| Frame property                  | JavaScript                                                                                       | Rust                                                                                                                    |
-| ------------------------------- | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
-| cwd                             | package directory                                                                                | package directory (the workspace package's dir _is_ the repo root)                                                      |
-| serial group                    | none                                                                                             | `"cargo"` iff `argv[0] == "cargo"` — the toolchain knowing its own binary's build-dir locking, not third-party sniffing |
-| env                             | per env-mode, as today                                                                           | per env-mode, as today                                                                                                  |
-| compile-cache injection         | n/a                                                                                              | applies (conflict classification already tolerates/detects user wrappers)                                               |
-| PATH                            | **verbatim — no `node_modules/.bin`** (override bypasses the package manager; documented v1 gap) | verbatim                                                                                                                |
-| hash wiring (`derived_task_io`) | unchanged                                                                                        | crate-closure globs, `HASHED_ENV_VARS`, external-dep hashing — unchanged                                                |
-
-### G. Pass-through args
-
-Appended verbatim — turbo can't know an arbitrary command's separator
-convention:
-
-```
-turbo test -- -E 'test(scm)'
-# → cargo nextest run --workspace -E 'test(scm)'
-```
-
-With a per-toolchain map, pass-through args append to **every** toolchain's
-command in the run — `turbo test -- --watch` reaches both vitest and
-nextest. Identical to today's behavior with heterogeneous package scripts,
-not new. Hashed as today (`pass_through_args` is already in `TaskHashable`).
-
-### H. Data from the outside
-
-**1. Environment variables reaching the process — works, per env-mode
-(frame, unchanged).** Everything in loose mode; declared `env` /
-`passThroughEnv` / `globalPassThroughEnv` in strict mode. The existing
-hashing rule applies unchanged — if the variable changes behavior, declare
-it:
-
-```jsonc
-"test": {
-  "command": { "rust": ["cargo", "nextest", "run"] },
-  "env": ["NEXTEST_PROFILE"]   // hashed: profile change ⇒ cache miss
-}
-```
-
-```bash
-NEXTEST_PROFILE=ci turbo test   # nextest reads it from its environment
-```
-
-**2. Ad-hoc CLI flags — works, via pass-through args** (section G).
-
-**3. Interpolating variables _into_ the argv — deliberately no.**
-
-```jsonc
-"test": { "command": ["cargo", "nextest", "run", "--profile", "$PROFILE"] }
-// passes the literal string "$PROFILE" — there is no shell
-```
-
-No-shell is the core contract (cross-platform determinism, no quoting hell,
-hashable-as-written). Interpolation would force answers to: Windows `%VAR%`
-vs `$VAR`, escaping literal dollars, and — worst — whether the _hash_
-covers the template or the resolved value (resolved ⇒ per-machine cache
-divergence unless the var is also declared; template ⇒ stale caches when
-the var changes). That's a shell's job. Two explicit escape hatches:
-
-```jsonc
-// (a) Most tools read configuration from env directly — case 1 covers it:
-//     NEXTEST_PROFILE=ci turbo test
-
-// (b) If you truly need shell semantics, say so — you own the shell:
-"deploy": { "command": ["bash", "-c", "deploy.sh --target $DEPLOY_TARGET"] }
-```
-
-Friendliness: a **warning** (not error) when an argv element matches
-`$IDENTIFIER` / `%IDENTIFIER%` — _"command arguments are not
-shell-interpolated; `$PROFILE` will be passed literally"_ — since a literal
-dollar-argument is almost always a mistake, but occasionally legitimate.
-
-### I. Hashing
-
-The resolved command joins `TaskHashable` (new field + capnp schema;
-`TaskDefinitionHashInfo` gains a `command()` accessor, turborepo-types
-lib.rs:1269-1303). Editing a command invalidates exactly the affected tasks.
-Capnp change ⇒ one-time global hash bust on upgrade (standard).
-
-### J. Presentation
-
-Run summary / dry-run show the joined resolved argv. TUI shows the task via
-existence composition. `--graph` unchanged (graph shape is
-command-independent except for tasks existing only via `command`).
-
-### K. Single-package mode
-
-Unscoped is the only syntax and unambiguous — array and opt-out allowed,
-map allowed (degenerate but harmless).
-
-## Validation matrix (config-load time)
-
-| Condition                                                       | Outcome                                                              |
-| --------------------------------------------------------------- | -------------------------------------------------------------------- |
-| `command` present, flag off                                     | error: requires `futureFlags.experimentalTaskCommand`                |
-| Map form in scoped position (root `pkg#task` or Package Config) | error: toolchain already determined; use an array                    |
-| `null` / `[]` at unscoped root                                  | error: a default of nothing is meaningless                           |
-| Unknown toolchain key                                           | error + did-you-mean (`"cargo"` → `"rust"`; known toolchains listed) |
-| Alias + canonical in one map (`typescript` + `javascript`)      | error: same toolchain, use one key                                   |
-| `rust` key without `experimentalCargoWorkspaces`                | error pointing at the flag                                           |
-| `$TURBO_EXTENDS$` inside `command`                              | error: command is atomic                                             |
-| Empty string element in argv                                    | error                                                                |
-| Argv element looks like `$VAR` / `%VAR%`                        | warning: passed literally, not interpolated                          |
-
-## Implementation map
-
-| Layer                                         | Change                                                                                                                                                                                                                                             |
-| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `turborepo-repository` (PR 0, shipped #13311) | `ToolchainId` `"cargo"`→`"rust"`                                                                                                                                                                                                                   |
-| `turborepo-repository` (PR 0.5)               | delete `WORKSPACE_PACKAGE_NAME`; read `[workspace.metadata] name` during discovery (`cargo metadata` emits `workspace_metadata`); missing-name error; collision + validation checks; dogfood `name = "turborepo-crates"` in this repo's Cargo.toml |
-| `turborepo-turbo-json`                        | `RawTaskDefinition.command` tri-state; alias resolution; atomic merge; flag gate + validation matrix in `from_raw` (receives `&FutureFlags` already)                                                                                               |
-| `turborepo-types`                             | `TaskDefinition.command`; `TaskDefinitionHashInfo::command()`                                                                                                                                                                                      |
-| `turborepo-engine`                            | `from_processed`; five-level resolver; `defines_task` composition (definitions.rs:217)                                                                                                                                                             |
-| `turborepo-repository`                        | `Toolchain::task_command`/`task_display_command` gain `override_command: Option<&[String]>`; JS + Cargo place it in their frames; shared argv-split helper                                                                                         |
-| `turborepo-task-executor`                     | `ToolchainCommandProvider` receives resolved-override lookup (`HashMap<TaskId, Vec<String>>` built by the visitor — no engine dependency)                                                                                                          |
-| `turborepo-lib`                               | visitor builds the lookup (exec.rs:56-62); TUI `tasks_with_command` composition                                                                                                                                                                    |
-| `turborepo-task-hash`                         | `TaskHashable.command` + proto.capnp + population (lib.rs:538-552)                                                                                                                                                                                 |
-
-## Test plan
-
-- naming (PR 0.5): missing `[workspace.metadata] name` ⇒ actionable error;
-  name collision with a crate / JS package ⇒ discovery error; invalid names
-  (`#`, `//`, empty) rejected; `rust`/`javascript` warn; fixtures renamed
-- turbo-json: tri-state parse (array/null/map), alias resolution + conflict,
-  atomic merge, full validation matrix, Package Config scoping
-- resolver: all five precedence levels, per-toolchain map fan-out, opt-out,
-  script-shadows-default, verb-table-loses-to-default
-- toolchain unit: JS override (cwd, bypasses pm), cargo override
-  (serial-group heuristic both ways), library-crate command
-- engine/TUI: existence composition
-- hashing: ±command ⇒ hash change; map key change ⇒ only that toolchain's
-  tasks invalidate
-- e2e: `acme#test` nextest override + Pattern B fixture; dry-run JSON shows
-  argv
-- dogfood: this repo adopts Pattern A (then evaluates B) after a canary
-  knows the field
-
-## Rollout
-
-1. `unknown_fields = deny` ⇒ turbos predating the field hard-error on
-   turbo.jsons using it. Sequence: land → canary → adoption (same dance as
-   every field/flag).
-2. PR series: **PR 0** rename (shipped) → **PR 0.5** workspace naming →
-   **PR 1** schema/flag/validation → **PR 2**
-   resolver + toolchain/executor plumbing + hashing → **PR 3** dogfood flip.
-
-## Out of scope (recorded)
-
-- Shell-string form (a future `script` field would be the honest spelling)
-- `node_modules/.bin` PATH augmentation for JS overrides
-- Per-toolchain pass-through separator awareness
-- Batching contended cargo invocations (parked separately)
+- Update examples, templates, and new project scaffolding to write `devEngines.packageManager`.
+- This PR should happen after a stable release includes `devEngines.packageManager` detection support, so generated projects remain compatible with currently supported Turborepo versions.

--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -320,7 +320,10 @@ mod test {
 
         // A minimal Cargo workspace with one binary crate.
         root.join_component("Cargo.toml")
-            .create_with_contents("[workspace]\nmembers = [\"crates/*\"]\nresolver = \"2\"\n")
+            .create_with_contents(
+                "[workspace]\nmembers = [\"crates/*\"]\nresolver = \
+                 \"2\"\n\n[workspace.metadata]\nname = \"acme\"\n",
+            )
             .unwrap();
         let crate_dir = root.join_components(&["crates", "my-crate"]);
         crate_dir.join_component("src").create_dir_all().unwrap();
@@ -342,7 +345,7 @@ mod test {
             // JS package without any scripts.
             ("c", "build"),
             // The synthetic Cargo workspace package.
-            ("rust", "test"),
+            ("acme", "test"),
             // A binary crate.
             ("my-crate", "build"),
         ] {
@@ -367,7 +370,7 @@ mod test {
         tasks.sort();
         // "c#build" is absent: no script defines it. Both Cargo tasks are
         // present without any package.json involvement.
-        assert_eq!(tasks, vec!["a#build", "my-crate#build", "rust#test"]);
+        assert_eq!(tasks, vec!["a#build", "acme#test", "my-crate#build"]);
     }
 
     #[tokio::test]

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -16,10 +16,17 @@
 //!   `--filter` and `--affected` propagate through them): being buildable is
 //!   not the same as being an entrypoint.
 //!
-//! A synthetic package named [`WORKSPACE_PACKAGE_NAME`], anchored at the
-//! root `Cargo.toml` and depending on every crate, represents the workspace
-//! itself; it hosts the workspace-scoped verification verbs (`rust#test` →
-//! `cargo test --workspace`, ...; see [`workspace_subcommand`]).
+//! A synthetic package anchored at the root `Cargo.toml` and depending on
+//! every crate represents the workspace itself; it hosts the
+//! workspace-scoped verification verbs (`<name>#test` → `cargo test
+//! --workspace`, ...; see [`workspace_subcommand`]). Its name is declared
+//! by the user in the root manifest — using Turborepo with Rust requires
+//! naming the workspace:
+//!
+//! ```toml
+//! [workspace.metadata]
+//! name = "acme"
+//! ```
 //!
 //! Support is experimental and gated behind
 //! `futureFlags.experimentalCargoWorkspaces`.
@@ -45,12 +52,6 @@ pub const CARGO_TOML: &str = "Cargo.toml";
 /// The conventional file name for a Cargo lockfile.
 pub const CARGO_LOCK: &str = "Cargo.lock";
 
-/// Name of the synthetic package that represents the Cargo workspace itself.
-/// Matches the toolchain id ([`ToolchainId::RUST`]): task keys read
-/// `rust#test`, `rust#lint`. A real workspace member with this name is
-/// skipped with a warning.
-pub const WORKSPACE_PACKAGE_NAME: &str = "rust";
-
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("failed to run `cargo metadata`: {0}")]
@@ -67,6 +68,22 @@ pub enum Error {
     ManifestParse(#[from] Box<toml_edit::TomlError>),
     #[error("root Cargo.toml has no [workspace] table")]
     NotAWorkspace,
+    #[error(
+        "The Cargo workspace has no name.\n\nTurborepo needs a name for the workspace's tasks \
+         (`<name>#test`), filters (`--filter=<name>`), and configuration. Add one to the root \
+         Cargo.toml:\n\n    [workspace.metadata]\n    name = \"my-workspace\""
+    )]
+    MissingWorkspaceName,
+    #[error(
+        "invalid Cargo workspace name {name:?}: {reason}. Set a valid name in the root Cargo.toml \
+         under `[workspace.metadata] name`."
+    )]
+    InvalidWorkspaceName { name: String, reason: String },
+    #[error(
+        "the Cargo workspace name {name:?} collides with the crate of the same name at {dir}. \
+         Pick a different `[workspace.metadata] name`."
+    )]
+    WorkspaceNameCollision { name: String, dir: String },
     #[error("Cannot prune a Cargo workspace without a Cargo.lock; run a build to generate it.")]
     MissingLockfile,
     #[error("failed to read workspace file: {0}")]
@@ -147,7 +164,7 @@ pub enum CargoPackageKind {
     /// A crate with `bin`/`cdylib`/`staticlib` targets: a deliverable.
     /// `build`/`run` tasks execute `cargo <verb> --package=<crate>`.
     Entrypoint,
-    /// The synthetic [`WORKSPACE_PACKAGE_NAME`] package hosting
+    /// The synthetic user-named workspace package hosting
     /// workspace-scoped verification verbs (`cargo test --workspace`, ...).
     Workspace,
 }
@@ -178,7 +195,7 @@ pub fn entrypoint_subcommand(task: &str) -> Option<&'static str> {
 }
 
 /// Map a Turborepo task name to the Cargo subcommand that implements it at
-/// workspace scope (the synthetic [`WORKSPACE_PACKAGE_NAME`] package).
+/// workspace scope (the synthetic user-named workspace package).
 ///
 /// `build` is deliberately absent: building is entrypoint-scoped
 /// (`cargo build --package=<crate>`), and a workspace-wide build would
@@ -809,9 +826,25 @@ impl Toolchain for CargoToolchain {
         Box::pin(async move {
             // Discovery spawns `cargo metadata` synchronously, so keep it off
             // the async runtime like the JavaScript manifest-parsing path.
-            let crates =
+            let workspace =
                 turborepo_rayon_compat::block_in_place(|| discover_crates(&self.repo_root))
                     .map_err(|err| toolchain::Error::Failed(Box::new(err)))?;
+            let crates = workspace.crates;
+
+            // Using Turborepo with Rust requires naming the workspace: the
+            // synthetic workspace package is a real package (task keys,
+            // filters), and every package must have a name. Only enforced
+            // when there are crates to host — a memberless manifest doesn't
+            // demand a name for nothing.
+            let workspace_name = match workspace.name {
+                Some(name) => name,
+                None if crates.is_empty() => String::new(),
+                None => {
+                    return Err(toolchain::Error::Failed(Box::new(
+                        Error::MissingWorkspaceName,
+                    )));
+                }
+            };
 
             // Each crate becomes a package. Internal dependencies are
             // expressed as `workspace:*` specifiers in the synthesized
@@ -887,11 +920,12 @@ impl Toolchain for CargoToolchain {
             }
 
             // The synthetic workspace package, anchored at the root
-            // Cargo.toml. It depends on every crate so `--affected` and
+            // Cargo.toml and named by the user via `[workspace.metadata]
+            // name`. It depends on every crate so `--affected` and
             // dependent-filters propagate crate changes to it.
             if !crate_names.is_empty() {
                 self.record_details(
-                    WORKSPACE_PACKAGE_NAME.to_string(),
+                    workspace_name.clone(),
                     CargoPackageDetails {
                         kind: CargoPackageKind::Workspace,
                         deliverables: Vec::new(),
@@ -904,7 +938,7 @@ impl Toolchain for CargoToolchain {
                     .collect();
                 packages.push(DiscoveredPackage {
                     descriptor: PackageJson {
-                        name: Some(Spanned::new(WORKSPACE_PACKAGE_NAME.to_string())),
+                        name: Some(Spanned::new(workspace_name)),
                         dependencies: Some(dependencies),
                         ..Default::default()
                     },
@@ -999,22 +1033,38 @@ impl CargoCrate {
     }
 }
 
+/// The result of Cargo workspace discovery: the member crates plus the
+/// user-declared workspace name.
+#[derive(Debug)]
+pub struct DiscoveredWorkspace {
+    /// The workspace's name from `[workspace.metadata] name`, validated
+    /// against the crate set when present. Not required at this layer —
+    /// it only becomes mandatory when the workspace package is actually
+    /// synthesized (see [`Toolchain::discover_packages`]), so manifests
+    /// without members don't demand a name for nothing.
+    pub name: Option<String>,
+    pub crates: Vec<CargoCrate>,
+}
+
 /// Discover all Rust crates in the Cargo workspace rooted at `repo_root` by
 /// invoking `cargo metadata --no-deps`.
 ///
-/// Returns an empty vec if `repo_root` has no `Cargo.toml`. A root manifest
-/// that exists but that Cargo rejects is an error — the user opted into
-/// Cargo support, so silently discovering nothing would be misleading.
+/// Returns an empty workspace if `repo_root` has no `Cargo.toml`. A root
+/// manifest that exists but that Cargo rejects is an error — the user opted
+/// into Cargo support, so silently discovering nothing would be misleading.
 /// `--no-deps` skips registry resolution, so no lockfile or network access
 /// is required.
 ///
 /// Crates whose manifests live outside the repository root, or whose names
 /// are invalid, are skipped with a warning. A `[package]` in the root
 /// manifest is skipped too: its directory would be the entire repository.
-pub fn discover_crates(repo_root: &AbsoluteSystemPath) -> Result<Vec<CargoCrate>, Error> {
+pub fn discover_crates(repo_root: &AbsoluteSystemPath) -> Result<DiscoveredWorkspace, Error> {
     let root_manifest_path = repo_root.join_component(CARGO_TOML);
     if !root_manifest_path.exists() {
-        return Ok(Vec::new());
+        return Ok(DiscoveredWorkspace {
+            name: None,
+            crates: Vec::new(),
+        });
     }
 
     let output = std::process::Command::new("cargo")
@@ -1036,11 +1086,54 @@ pub fn discover_crates(repo_root: &AbsoluteSystemPath) -> Result<Vec<CargoCrate>
     }
     let metadata: Metadata = serde_json::from_slice(&output.stdout)?;
 
-    Ok(connect_crates(parse_members(
-        repo_root,
-        &root_manifest_path,
-        metadata,
-    )))
+    let name = workspace_name(&metadata)?;
+    let crates = connect_crates(parse_members(repo_root, &root_manifest_path, metadata));
+
+    if let Some(name) = &name
+        && let Some(collision) = crates.iter().find(|c| &c.name == name)
+    {
+        return Err(Error::WorkspaceNameCollision {
+            name: name.clone(),
+            dir: collision
+                .manifest_path
+                .parent()
+                .map(|dir| dir.to_string())
+                .unwrap_or_default(),
+        });
+    }
+
+    Ok(DiscoveredWorkspace { name, crates })
+}
+
+/// Extract and validate the user-declared workspace name from the
+/// `[workspace.metadata]` table. The name becomes a package name — it
+/// appears in task keys (`<name>#test`) and `--filter` expressions — so it
+/// follows the same shape rules as crate names.
+fn workspace_name(metadata: &Metadata) -> Result<Option<String>, Error> {
+    let Some(value) = metadata.metadata.get("name") else {
+        return Ok(None);
+    };
+    let Some(name) = value.as_str() else {
+        return Err(Error::InvalidWorkspaceName {
+            name: value.to_string(),
+            reason: "must be a string".to_string(),
+        });
+    };
+    if !is_valid_crate_name(name) {
+        return Err(Error::InvalidWorkspaceName {
+            name: name.to_string(),
+            reason: "names may only contain alphanumeric characters, `-`, and `_`".to_string(),
+        });
+    }
+    // Legal, but re-introduces exactly the toolchain-id/package-name
+    // confusion user-chosen names exist to remove.
+    if name == "rust" || name == "javascript" {
+        tracing::warn!(
+            "the Cargo workspace is named {name:?}, which is also a toolchain id; consider a more \
+             distinctive name"
+        );
+    }
+    Ok(Some(name.to_string()))
 }
 
 /// A workspace member parsed from `cargo metadata`, before dependency edges
@@ -1104,14 +1197,6 @@ fn parse_members(
         if !is_valid_crate_name(&package.name) {
             tracing::warn!(
                 "skipping Cargo manifest {manifest_path}: invalid crate name {:?}",
-                package.name
-            );
-            continue;
-        }
-        if package.name == WORKSPACE_PACKAGE_NAME {
-            tracing::warn!(
-                "skipping Cargo crate {:?}: the name is reserved for Turborepo's synthetic \
-                 workspace package",
                 package.name
             );
             continue;
@@ -1257,6 +1342,10 @@ fn reaches(adjacency: &HashMap<&str, BTreeSet<&str>>, start: &str, target: &str)
 #[derive(Debug, Deserialize)]
 struct Metadata {
     packages: Vec<MetadataPackage>,
+    /// The `[workspace.metadata]` table, serialized as JSON. Carries the
+    /// user-declared workspace name.
+    #[serde(default)]
+    metadata: serde_json::Value,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1316,7 +1405,8 @@ mod test {
         write(
             root,
             &["Cargo.toml"],
-            "[workspace]\nmembers = [\"crates/*\"]\nresolver = \"2\"\n",
+            "[workspace]\nmembers = [\"crates/*\"]\nresolver = \
+             \"2\"\n\n[workspace.metadata]\nname = \"fixture-ws\"\n",
         );
         write(
             root,
@@ -1374,7 +1464,7 @@ checksum = "abc123"
         let (_tmp, root) = tempdir_root();
         write_fixture_workspace(&root);
 
-        let mut crates = discover_crates(&root).unwrap();
+        let mut crates = discover_crates(&root).unwrap().crates;
         crates.sort_by(|a, b| a.name.cmp(&b.name));
 
         assert_eq!(
@@ -1414,7 +1504,80 @@ checksum = "abc123"
     #[test]
     fn test_discover_crates_not_a_workspace() {
         let (_tmp, root) = tempdir_root();
-        assert!(discover_crates(&root).unwrap().is_empty());
+        let workspace = discover_crates(&root).unwrap();
+        assert!(workspace.crates.is_empty());
+        assert!(workspace.name.is_none());
+    }
+
+    #[test]
+    fn test_workspace_name_discovered_and_validated() {
+        let (_tmp, root) = tempdir_root();
+        write_fixture_workspace(&root);
+
+        let workspace = discover_crates(&root).unwrap();
+        assert_eq!(workspace.name.as_deref(), Some("fixture-ws"));
+
+        // A name colliding with a crate is an error naming the crate's
+        // location, not a silent skip.
+        write(
+            &root,
+            &["Cargo.toml"],
+            "[workspace]\nmembers = [\"crates/*\"]\nresolver = \
+             \"2\"\n\n[workspace.metadata]\nname = \"lib-a\"\n",
+        );
+        let err = discover_crates(&root).unwrap_err();
+        assert!(
+            matches!(err, Error::WorkspaceNameCollision { ref name, .. } if name == "lib-a"),
+            "expected collision error, got: {err}"
+        );
+
+        // Shape rules match crate names: `#` can never appear in a task key.
+        write(
+            &root,
+            &["Cargo.toml"],
+            "[workspace]\nmembers = [\"crates/*\"]\nresolver = \
+             \"2\"\n\n[workspace.metadata]\nname = \"bad#name\"\n",
+        );
+        assert!(matches!(
+            discover_crates(&root).unwrap_err(),
+            Error::InvalidWorkspaceName { .. }
+        ));
+
+        // A non-string name is rejected rather than coerced.
+        write(
+            &root,
+            &["Cargo.toml"],
+            "[workspace]\nmembers = [\"crates/*\"]\nresolver = \
+             \"2\"\n\n[workspace.metadata]\nname = 42\n",
+        );
+        assert!(matches!(
+            discover_crates(&root).unwrap_err(),
+            Error::InvalidWorkspaceName { .. }
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_missing_workspace_name_is_an_error() {
+        let (_tmp, root) = tempdir_root();
+        write_fixture_workspace(&root);
+        // Remove the name: crates exist, so the workspace package would be
+        // synthesized — and every package must have a name.
+        write(
+            &root,
+            &["Cargo.toml"],
+            "[workspace]\nmembers = [\"crates/*\"]\nresolver = \"2\"\n",
+        );
+
+        let toolchain = CargoToolchain::new(root.clone());
+        let err = toolchain.discover_packages().await.unwrap_err();
+        assert!(
+            err.to_string().contains("[workspace.metadata]"),
+            "the error must show the fix, got: {err}"
+        );
+
+        // Crate discovery itself still works: the name is only mandatory
+        // for package synthesis.
+        assert_eq!(discover_crates(&root).unwrap().crates.len(), 3);
     }
 
     #[test]
@@ -1444,7 +1607,7 @@ checksum = "abc123"
         );
         write(&root, &["crates", "member", "src", "lib.rs"], "");
 
-        let crates = discover_crates(&root).unwrap();
+        let crates = discover_crates(&root).unwrap().crates;
         assert_eq!(
             crates.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
             vec!["member"],
@@ -1477,7 +1640,7 @@ checksum = "abc123"
         );
         write(&root, &["tools", "helper", "src", "lib.rs"], "");
 
-        let mut crates = discover_crates(&root).unwrap();
+        let mut crates = discover_crates(&root).unwrap().crates;
         crates.sort_by(|a, b| a.name.cmp(&b.name));
         assert_eq!(
             crates.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
@@ -1606,7 +1769,7 @@ checksum = "abc123"
             .iter()
             .map(|p| p.descriptor.name.as_ref().unwrap().as_inner().as_str())
             .collect();
-        assert_eq!(names, vec!["app", "lib-a", "lib-a-test-util", "rust"]);
+        assert_eq!(names, vec!["app", "fixture-ws", "lib-a", "lib-a-test-util"]);
 
         let app = &packages[0];
         assert_eq!(
@@ -1620,7 +1783,7 @@ checksum = "abc123"
 
         // The synthetic workspace package is anchored at the root manifest
         // and depends on every crate.
-        let workspace = &packages[3];
+        let workspace = &packages[1];
         assert_eq!(workspace.manifest_path, root.join_component(CARGO_TOML));
         let workspace_deps = workspace.descriptor.dependencies.as_ref().unwrap();
         assert_eq!(workspace_deps.len(), 3);
@@ -1639,7 +1802,7 @@ checksum = "abc123"
             app_externals.iter().any(|p| p.key == "rustc"),
             "compiler version stamps the closure, got {app_externals:?}"
         );
-        let lib_a_externals = packages[1].external_dependencies.as_ref().unwrap();
+        let lib_a_externals = packages[2].external_dependencies.as_ref().unwrap();
         assert!(
             !lib_a_externals.iter().any(|p| p.key == "serde"),
             "a serde bump must not invalidate lib-a, got {lib_a_externals:?}"
@@ -1686,7 +1849,7 @@ checksum = "abc123"
 
         let app = package_info("app", "crates/app/Cargo.toml");
         let lib_a = package_info("lib-a", "crates/lib-a/Cargo.toml");
-        let workspace = package_info(WORKSPACE_PACKAGE_NAME, "Cargo.toml");
+        let workspace = package_info("fixture-ws", "Cargo.toml");
 
         // Entrypoint build: scoped to the crate, serialized on the cargo
         // group, run from the workspace root.
@@ -1784,7 +1947,7 @@ checksum = "abc123"
 
         let app = package_info("app", "crates/app/Cargo.toml");
         let lib_a = package_info("lib-a", "crates/lib-a/Cargo.toml");
-        let workspace = package_info(WORKSPACE_PACKAGE_NAME, "Cargo.toml");
+        let workspace = package_info("fixture-ws", "Cargo.toml");
 
         // defines_task mirrors the verb tables.
         assert!(toolchain.defines_task(&app, "build"));

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -1915,7 +1915,8 @@ mod test {
         };
         write(
             &["Cargo.toml"],
-            "[workspace]\nmembers = [\"rust/*\"]\nresolver = \"2\"\n",
+            "[workspace]\nmembers = [\"rust/*\"]\nresolver = \"2\"\n\n[workspace.metadata]\nname \
+             = \"acme\"\n",
         );
         write(
             &["rust", "app", "Cargo.toml"],
@@ -1989,7 +1990,7 @@ mod test {
                 .package_info(&PackageName::from("js-pkg"))
                 .unwrap();
             assert_eq!(js_pkg.toolchain, crate::toolchain::ToolchainId::JAVASCRIPT);
-            let workspace_pkg = pkg_graph.package_info(&PackageName::from("rust")).unwrap();
+            let workspace_pkg = pkg_graph.package_info(&PackageName::from("acme")).unwrap();
             assert_eq!(workspace_pkg.toolchain, crate::toolchain::ToolchainId::RUST);
 
             // Crate path dependencies became graph edges.
@@ -2001,7 +2002,7 @@ mod test {
                 "app should depend on lib-a, got {app_deps:?}"
             );
             let workspace_deps = pkg_graph
-                .immediate_dependencies(&PackageNode::Workspace(PackageName::from("rust")))
+                .immediate_dependencies(&PackageNode::Workspace(PackageName::from("acme")))
                 .unwrap();
             assert!(
                 workspace_deps.contains(&PackageNode::Workspace(PackageName::from("app")))

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -187,15 +187,15 @@ whether anything changed; Cargo decides how and in what order to build.**
   workspace's deliverables. *Libraries* exist in the package graph — so
   `--filter` and `--affected` propagate through them — but their tasks are
   no-ops: Cargo builds them implicitly as part of an entrypoint's closure. A
-  synthetic *workspace* package (named `rust`, matching the toolchain id)
-  depends on every crate and
-  hosts workspace-scoped verbs.
+  synthetic *workspace* package — named by the user via
+  `[workspace.metadata] name` in the root Cargo.toml, a hard requirement —
+  depends on every crate and hosts workspace-scoped verbs.
 - **Execution** (`Toolchain::task_command`, adapted into the provider chain
   by `ToolchainCommandProvider` in `turborepo-task-executor`): entrypoint
   `build`/`run`/`dev` tasks run `cargo <verb> --package=<crate>` — one cargo
   process that builds the crate's whole dependency closure with Cargo's own
-  parallelism. Verification verbs run once at workspace scope: `rust#test`
-  → `cargo test --workspace`, `rust#lint` → `cargo clippy --workspace`,
+  parallelism. Verification verbs run once at workspace scope: `<name>#test`
+  → `cargo test --workspace`, `<name>#lint` → `cargo clippy --workspace`,
   etc. Cargo commands (except `cargo run`) share a mutually-exclusive
   serial group: concurrent cargo processes serialize on the build-directory
   lock anyway, so the executor runs one at a time without the "waiting for
@@ -269,7 +269,7 @@ whether anything changed; Cargo decides how and in what order to build.**
   sync its own lockfile; failure downgrades to a warning. In docker
   layout, the json layer carries the root manifest, each kept crate's
   `Cargo.toml`, and the pruned lock; sources go to the full layer. A
-  package anchored at the repo root (the synthetic `rust` package) is not
+  package anchored at the repo root (the synthetic workspace package) is not
   a pruneable target.
 
 - **Compile cache** (`Toolchain::compile_cache_env`, consumed by

--- a/crates/turborepo/tests/cargo_workspace_test.rs
+++ b/crates/turborepo/tests/cargo_workspace_test.rs
@@ -253,14 +253,14 @@ fn test_prune_js_target_unaffected_by_cargo() {
     assert!(!out.join("Cargo.toml").exists());
 }
 
-/// The synthetic `rust` package has no directory of its own and is not a
-/// pruneable target.
+/// The synthetic workspace package has no directory of its own and is not
+/// a pruneable target.
 #[test]
 fn test_prune_cargo_workspace_package_rejected() {
     let tempdir = tempfile::tempdir().unwrap();
     setup_cargo_monorepo(tempdir.path());
 
-    let output = run_turbo(tempdir.path(), &["prune", "rust"]);
+    let output = run_turbo(tempdir.path(), &["prune", "acme"]);
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(

--- a/turborepo-tests/integration/fixtures/cargo_monorepo/Cargo.toml
+++ b/turborepo-tests/integration/fixtures/cargo_monorepo/Cargo.toml
@@ -1,3 +1,6 @@
 [workspace]
 members = ["crates/*"]
 resolver = "2"
+
+[workspace.metadata]
+name = "acme"


### PR DESCRIPTION
## Why

The synthetic Cargo workspace package took a magic reserved name (`cargo`, renamed `rust` in #13311). Magic names are a defect three ways: they collide with real packages (a crate named `rust` was *silently skipped with a warning*), they confuse (`rust#test` names a package nobody defined), and they overload the toolchain id — `rust` meant both "the toolchain" and "a package," which matters once the `command` design uses toolchain ids as map keys.

## What

Using Turborepo with Rust now requires naming the workspace in the root Cargo.toml:

```toml
[workspace.metadata]
name = "my-workspace"
```

Task keys, filters, and the TUI use that name: `my-workspace#test`, `--filter=my-workspace`.

- **Missing name** (with members present) → hard, actionable error showing the exact TOML to paste. Memberless manifests need no name; crate discovery itself (`discover_crates`) works without one.
- **Collision with a crate** → discovery error naming both parties. The reserved-name skip hack is deleted.
- **Shape rules** match crate names (the name becomes a package name); non-string values rejected; `rust`/`javascript` warn as confusing-but-legal.
- This repo's workspace: `turborepo-crates`.

## How

- One source, no fallbacks: a root `[package] name` is *not* consulted (in non-virtual workspaces the root package is also a real crate; reusing its name conflates the two).
- This isn't extra ceremony — it's the rule every package already follows (JS packages without a `name` are errors); cargo just has no native slot for this package's name.
- `cargo metadata` already emits `[workspace.metadata]` as top-level `metadata` JSON; discovery reads `name` from it. `WORKSPACE_PACKAGE_NAME` is gone; `discover_crates` returns `DiscoveredWorkspace { name, crates }`.
- Consistency with the released canary: old turbos ignore the metadata, so adding the name to this repo is forward-compatible; the requirement only bites once this change releases.

Tests: name parse/validation/collision/non-string, missing-name error message content, memberless exemption; all fixtures named; existing discovery/command/e2e suites updated and green.
