### PR TITLE
Filter sensitive environment variables in spawn

### DIFF
--- a/apps/agents/agent/lib/repo.ts
+++ b/apps/agents/agent/lib/repo.ts
@@ -193,7 +193,19 @@ export async function runCommand(
   timeoutMs: number
 ): Promise<CommandResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, { cwd, shell: false });
+    // 1. استنساخ متغيرات البيئة الحالية وتصفيتها من الأسرار الحساسة
+    const safeEnv = { ...process.env };
+    delete safeEnv.GITHUB_APP_PRIVATE_KEY;
+    delete safeEnv.GITHUB_APP_ID;
+    delete safeEnv.GITHUB_INSTALLATION_ID;
+
+    // 2. تمرير الكائن الآمن 'safeEnv' إلى خاصية env
+    const child = spawn(command, args, { 
+      cwd, 
+      shell: false, 
+      env: safeEnv 
+    });
+    
     const commandLine = [command, ...args].join(" ");
     let stdout = "";
     let stderr = "";


### PR DESCRIPTION
The application's command runner (`apps/agents/agent/lib/repo.ts`) executes example scripts using the `child_process.spawn()` method. However, it fails to provide a restricted or sanitized environment configuration object (`env`).

In Node.js, when `spawn` is called without an explicit `env` option, the child process automatically inherits the full environment variables (`process.env`) of the parent process. Because the main Agent process holds highly sensitive GitHub App credentials, any unapproved or modified script executed by the agent can access, read, and exfiltrate the `GITHUB_APP_PRIVATE_KEY`, `GITHUB_APP_ID`, and `GITHUB_INSTALLATION_ID`.