### PR TITLE
chore: Harden turbo-vsc to invoke turbo without a shell

### DIFF
--- a/packages/turbo-vsc/src/extension.ts
+++ b/packages/turbo-vsc/src/extension.ts
@@ -299,10 +299,6 @@ function updateStatusBarItem(running: boolean) {
   toolbar.show();
 }
 
-function quoteCommand(command: string) {
-  return command.includes(" ") ? `"${command.replace(/"/g, '\\"')}"` : command;
-}
-
 function executableNames(name: string) {
   return process.platform === "win32"
     ? [`${name}.exe`, `${name}.cmd`, `${name}`]

--- a/packages/turbo-vsc/src/turbo-run-terminal-options.test.ts
+++ b/packages/turbo-vsc/src/turbo-run-terminal-options.test.ts
@@ -54,6 +54,25 @@ for (const [index, taskName] of invalidTaskNames.entries()) {
   });
 }
 
+const metacharacterPaths = [
+  "/tmp/$(touch /tmp/pwned)/turbo",
+  "/tmp/`touch /tmp/pwned`/turbo",
+  "/tmp/a; touch /tmp/pwned/turbo",
+  "/tmp/a | sh/turbo",
+  "/tmp/a && calc/turbo"
+];
+
+for (const [index, turboPath] of metacharacterPaths.entries()) {
+  test(`keeps metacharacter turbo path ${index} as a literal executable`, () => {
+    const options = createTurboRunTerminalOptions(turboPath, "build");
+
+    // shellPath is handed to VS Code as the executable, not a /bin/sh string,
+    // so metacharacters must survive verbatim rather than being interpreted.
+    assert.equal(options.shellPath, turboPath);
+    assert.deepEqual(options.shellArgs, ["run", "build"]);
+  });
+}
+
 test("rejects non-string task names", () => {
   assert.equal(sanitizeTurboRunTaskName(undefined), undefined);
   assert.equal(sanitizeTurboRunTaskName(["build"]), undefined);


### PR DESCRIPTION
Cleanup and hardening for the turbo-vsc extension. No behavior change for normal paths.

## What

- Remove the dead `quoteCommand` helper. Its last call sites were dropped in the earlier `execFile` refactor, so nothing builds a shell command string from `turbo.path` anymore.
- Add tests proving a `turbo.path` with shell metacharacters (`$(...)`, backticks, `;`, `|`, `&&`) is passed as a literal executable and never interpreted by a shell.

## Notes

- All process sinks already use `execFileSync`/`execFile` with argv arrays.
- The `turbo.run` terminal spawns the binary via `shellPath` with args as a `shellArgs` array, so no path or arg goes through a shell.
- Typecheck clean, 30/30 tests pass.