### PR TITLE
fix: Make npm prune rehoisting deterministic and complete

### DIFF
--- a/crates/turborepo-lockfiles/src/npm.rs
+++ b/crates/turborepo-lockfiles/src/npm.rs
@@ -322,7 +322,7 @@ impl NpmLockfile {
             candidates.entry(hoisted_key).or_default().push(key.clone());
         }
 
-        let to_rehoist: Vec<(String, String)> = candidates
+        let mut to_rehoist: Vec<(String, String)> = candidates
             .into_iter()
             .filter_map(|(hoisted_key, nested_keys)| {
                 if nested_keys.len() == 1 {
@@ -335,8 +335,12 @@ impl NpmLockfile {
                 }
             })
             .collect();
+        // Candidates come from HashMap iteration; sort so relocation placement
+        // decisions below don't depend on hash ordering.
+        // See https://github.com/vercel/turborepo/issues/13321
+        to_rehoist.sort();
 
-        for (nested_key, hoisted_key) in to_rehoist {
+        for (nested_key, hoisted_key) in &to_rehoist {
             // Remove old hoisted entry and its sub-deps.
             let old_prefix = format!("{hoisted_key}/");
             let old_sub: Vec<String> = pruned
@@ -347,10 +351,10 @@ impl NpmLockfile {
             for k in old_sub {
                 pruned.remove(&k);
             }
-            pruned.remove(&hoisted_key);
+            pruned.remove(hoisted_key);
 
             // Promote nested entry.
-            if let Some(pkg) = pruned.remove(&nested_key) {
+            if let Some(pkg) = pruned.remove(nested_key) {
                 pruned.insert(hoisted_key.clone(), pkg);
             }
 
@@ -368,18 +372,27 @@ impl NpmLockfile {
                     pruned.insert(new_key, pkg);
                 }
             }
+        }
 
-            // Promoting the package changed its position in the tree, so any of
-            // its transitive deps that were resolved through workspace-nested
-            // siblings (e.g. `apps/app-a/node_modules/mime`) are no longer
-            // reachable from the new hoisted position. Walk the promoted
-            // package's dependency closure and relocate any stranded versions.
+        // Promoting a package changes its position in the tree, so any of its
+        // transitive deps that were resolved through workspace-nested siblings
+        // (e.g. `apps/app-a/node_modules/mime`) are no longer reachable from
+        // the new hoisted position. Walk each promoted package's dependency
+        // closure and relocate any stranded versions.
+        //
+        // This runs as a separate pass after all promotions: a relocation can
+        // copy a sibling to the root slot and remove its nested source, and if
+        // that sibling were itself a still-pending promotion candidate, the
+        // interleaved processing would remove the root entry and then find
+        // nothing left to promote, dropping the package entirely.
+        // See https://github.com/vercel/turborepo/issues/13321
+        for (nested_key, hoisted_key) in &to_rehoist {
             let mut visited = std::collections::HashSet::new();
             Self::relocate_stranded_closure(
                 pruned,
                 original_packages,
-                &nested_key,
-                &hoisted_key,
+                nested_key,
+                hoisted_key,
                 &mut visited,
             );
         }
@@ -1165,6 +1178,118 @@ mod test {
             Some("1.0.2"),
             "hoisted encodeurl@1.0.2 (what send@0.17.2 needs) should remain"
         );
+    }
+
+    // Regression test for https://github.com/vercel/turborepo/issues/13321
+    //
+    // The original lockfile has dev-only hoisted copies of send/http-errors/
+    // fresh at the root, and the app workspace has its own nested copies of
+    // all three (send@1.2.1 depending on the nested http-errors@2.0.1 and
+    // fresh@2.0.0). Pruning to the app makes all three nested entries rehoist
+    // candidates. Candidate processing order used to come from HashMap
+    // iteration, and relocate_stranded_closure ran interleaved with
+    // promotions: if send was promoted first, its relocation moved the nested
+    // http-errors/fresh to the root and removed the nested sources, then the
+    // still-queued http-errors/fresh candidates removed the root entries and
+    // found nothing left to promote — dropping the packages entirely.
+    //
+    // Run the prune repeatedly since the old failure depended on hash order.
+    #[test]
+    fn test_subgraph_rehoist_is_deterministic_and_complete() {
+        let json = r#"{
+            "lockfileVersion": 3,
+            "requires": true,
+            "packages": {
+                "": {
+                    "name": "monorepo",
+                    "workspaces": ["apps/*"],
+                    "devDependencies": {
+                        "fresh": "0.5.2",
+                        "http-errors": "2.0.0",
+                        "send": "0.19.0"
+                    }
+                },
+                "node_modules/app": {
+                    "resolved": "apps/app",
+                    "link": true
+                },
+                "node_modules/fresh": {
+                    "version": "0.5.2",
+                    "dev": true
+                },
+                "node_modules/http-errors": {
+                    "version": "2.0.0",
+                    "dev": true
+                },
+                "node_modules/send": {
+                    "version": "0.19.0",
+                    "dev": true,
+                    "dependencies": {
+                        "fresh": "0.5.2",
+                        "http-errors": "2.0.0"
+                    }
+                },
+                "apps/app": {
+                    "version": "1.0.0",
+                    "dependencies": { "send": "^1.2.1" }
+                },
+                "apps/app/node_modules/fresh": {
+                    "version": "2.0.0"
+                },
+                "apps/app/node_modules/http-errors": {
+                    "version": "2.0.1"
+                },
+                "apps/app/node_modules/send": {
+                    "version": "1.2.1",
+                    "dependencies": {
+                        "fresh": "^2.0.0",
+                        "http-errors": "^2.0.0"
+                    }
+                }
+            }
+        }"#;
+
+        let lockfile = NpmLockfile::load(json.as_bytes()).unwrap();
+
+        let workspace_packages = vec!["apps/app".to_string()];
+        let packages = vec![
+            "apps/app/node_modules/send".to_string(),
+            "apps/app/node_modules/http-errors".to_string(),
+            "apps/app/node_modules/fresh".to_string(),
+        ];
+
+        let mut first_encoded: Option<Vec<u8>> = None;
+        for run in 0..32 {
+            let pruned = lockfile.subgraph(&workspace_packages, &packages).unwrap();
+            let encoded = pruned.encode().unwrap();
+            let reparsed: NpmLockfile = NpmLockfile::load(&encoded).unwrap();
+
+            // The promoted send@1.2.1 must always be able to resolve its
+            // production deps at their correct versions.
+            for (key, version) in [
+                ("node_modules/send", "1.2.1"),
+                ("node_modules/http-errors", "2.0.1"),
+                ("node_modules/fresh", "2.0.0"),
+            ] {
+                assert_eq!(
+                    reparsed
+                        .packages
+                        .get(key)
+                        .and_then(|p| p.version.as_deref()),
+                    Some(version),
+                    "run {run}: expected {key}@{version} in pruned lockfile"
+                );
+            }
+
+            // The pruned output must be byte-for-byte identical across runs.
+            match &first_encoded {
+                None => first_encoded = Some(encoded),
+                Some(first) => assert_eq!(
+                    first, &encoded,
+                    "run {run}: pruned lockfile differs between runs"
+                ),
+            }
+        }
     }
 
     #[test]

--- a/lockfile-tests/fixtures/issue-13321/apps/app-1/package.json
+++ b/lockfile-tests/fixtures/issue-13321/apps/app-1/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "app-1",
+  "version": "1.0.0",
+  "dependencies": {
+    "send": "0.19.0"
+  }
+}

--- a/lockfile-tests/fixtures/issue-13321/apps/app-2/package.json
+++ b/lockfile-tests/fixtures/issue-13321/apps/app-2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "app-2",
+  "version": "1.0.0",
+  "dependencies": {
+    "send": "1.2.1"
+  }
+}

--- a/lockfile-tests/fixtures/issue-13321/meta.json
+++ b/lockfile-tests/fixtures/issue-13321/meta.json
@@ -1,0 +1,9 @@
+{
+  "packageManager": "npm",
+  "packageManagerVersion": "npm@11.7.0",
+  "lockfileName": "package-lock.json",
+  "pruneTargets": ["app-2"],
+  "docker": true,
+  "validateResolution": true,
+  "frozenInstallCommand": ["npm", "ci"]
+}

--- a/lockfile-tests/fixtures/issue-13321/package-lock.json
+++ b/lockfile-tests/fixtures/issue-13321/package-lock.json
@@ -1,0 +1,330 @@
+{
+  "name": "turbo-prune-issue-13321",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "turbo-prune-issue-13321",
+      "workspaces": [
+        "apps/*"
+      ]
+    },
+    "apps/app-1": {
+      "version": "1.0.0",
+      "dependencies": {
+        "send": "0.19.0"
+      }
+    },
+    "apps/app-2": {
+      "version": "1.0.0",
+      "dependencies": {
+        "send": "1.2.1"
+      }
+    },
+    "apps/app-2/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "apps/app-2/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "apps/app-2/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "apps/app-2/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "apps/app-2/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "apps/app-2/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/app-1": {
+      "resolved": "apps/app-1",
+      "link": true
+    },
+    "node_modules/app-2": {
+      "resolved": "apps/app-2",
+      "link": true
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    }
+  }
+}

--- a/lockfile-tests/fixtures/issue-13321/package.json
+++ b/lockfile-tests/fixtures/issue-13321/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "turbo-prune-issue-13321",
+  "private": true,
+  "workspaces": [
+    "apps/*"
+  ],
+  "packageManager": "npm@11.7.0"
+}

--- a/lockfile-tests/fixtures/issue-13321/turbo.json
+++ b/lockfile-tests/fixtures/issue-13321/turbo.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {}
+}


### PR DESCRIPTION
### Why

Fixes #13321. `turbo prune` on npm lockfiles could nondeterministically drop packages from the pruned lockfile, producing Docker images that fail at runtime with errors like `Cannot find module 'http-errors'`.

### What

In `rehoist_packages`, promotion candidates come from `HashMap` iteration and were processed in random order, with `relocate_stranded_closure` running interleaved after each promotion. A relocation could copy a sibling package to the root slot and remove its nested source; if that sibling was itself a still-queued promotion candidate, its turn would then remove the root entry and find nothing left to promote — silently dropping the package.

### How

- Split `rehoist_packages` into two phases: perform all promotions first, then run stranded-closure relocation for each promoted package. A relocation can no longer consume the nested source of a pending promotion.
- Sort the candidate list so relocation placement decisions don't depend on hash ordering — pruned output is now byte-identical across runs.

### Testing

- Unit test `test_subgraph_rehoist_is_deterministic_and_complete` replicates the issue's lockfile shape, runs the prune 32 times, and asserts the promoted package's deps survive and output is byte-stable. It fails reliably on the pre-fix code.
- New `lockfile-tests/fixtures/issue-13321` fixture (real npm@11.7.0 lockfile): `app-1` depends on `send@0.19.0` (tree hoisted at root), `app-2` on `send@1.2.1` (six conflicting deps nested under the workspace). Pruning to `app-2` makes all six nested entries rehoist candidates. Verified the harness fails on a pre-fix binary (`npm ls` reports unresolvable deps) and passes post-fix; the full `--pm npm` suite (35 cases) passes.

Note: root-workspace devDependencies can't reproduce this — they're part of the prune closure, so their hoisted entries are protected from rehoisting. The stale hoisted copies must belong to a pruned-away workspace, hence the two-app fixture layout.