### PR TITLE
Update brace-expansion dependency version

### DIFF
--- a/packages/turbo-codemod/package.json
+++ b/packages/turbo-codemod/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^7.10.1",
-    "brace-expansion": "1.1.13",
+    "brace-expansion": "5.0.7",
     "commander": "9.5.0",
     "diff": "5.2.2",
     "find-up": "4.1.0",


### PR DESCRIPTION
brace-expansion through 5.0.6 is vulnerable to denial of service. The expand() function exhibits exponential-time complexity in the number of consecutive non-expanding '{}' brace groups. An attacker who passes a crafted string to expand(), directly or transitively, can cause significant CPU consumption and event-loop blocking. The max option does not mitigate this, as it bounds the output size rather than the recursion work.

