### PR TITLE
ci: Disable telemetry messages in workflows

### DIFF
--- a/.github/workflows/docs-alias-failure-notification.yml
+++ b/.github/workflows/docs-alias-failure-notification.yml
@@ -4,6 +4,9 @@
 
 name: Docs Alias Failure Notification
 
+env:
+  TURBO_TELEMETRY_MESSAGE_DISABLED: "1"
+
 on:
   workflow_run:
     workflows: ["Release"]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,8 @@
 name: Docs checks
 
+env:
+  TURBO_TELEMETRY_MESSAGE_DISABLED: "1"
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,5 +1,8 @@
 name: Lint pull request title
 
+env:
+  TURBO_TELEMETRY_MESSAGE_DISABLED: "1"
+
 on:
   pull_request:
     types:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,7 @@ concurrency:
 
 env:
   RUSTFLAGS: "-D warnings"
+  TURBO_TELEMETRY_MESSAGE_DISABLED: "1"
 
 permissions:
   contents: read

--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -5,6 +5,9 @@
 
 name: LSP
 
+env:
+  TURBO_TELEMETRY_MESSAGE_DISABLED: "1"
+
 run-name: LSP ${{ inputs.ref || github.ref_name }}
 
 on:

--- a/.github/workflows/pr-clean-caches.yml
+++ b/.github/workflows/pr-clean-caches.yml
@@ -1,4 +1,8 @@
 name: Cleanup branch caches
+
+env:
+  TURBO_TELEMETRY_MESSAGE_DISABLED: "1"
+
 on:
   pull_request:
     types: [opened, closed, reopened, synchronize]

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -1,4 +1,8 @@
 name: JS Package Tests
+
+env:
+  TURBO_TELEMETRY_MESSAGE_DISABLED: "1"
+
 on:
   pull_request:
 

--- a/.github/workflows/turborepo-compare-cache-item.yml
+++ b/.github/workflows/turborepo-compare-cache-item.yml
@@ -1,5 +1,8 @@
 name: Compare Cache Item
 
+env:
+  TURBO_TELEMETRY_MESSAGE_DISABLED: "1"
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/turborepo-library-release.yml
+++ b/.github/workflows/turborepo-library-release.yml
@@ -1,5 +1,8 @@
 name: Library Release
 
+env:
+  TURBO_TELEMETRY_MESSAGE_DISABLED: "1"
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -23,6 +23,7 @@ name: Release
 
 env:
   CARGO_PROFILE_RELEASE_LTO: true
+  TURBO_TELEMETRY_MESSAGE_DISABLED: "1"
   HUSKY: "0"
   RELEASE_TURBO_CLI: true # TODO: do we need this?
 

--- a/.github/workflows/turborepo-test.yml
+++ b/.github/workflows/turborepo-test.yml
@@ -1,4 +1,8 @@
 name: Test
+
+env:
+  TURBO_TELEMETRY_MESSAGE_DISABLED: "1"
+
 on:
   pull_request:
   push:

--- a/.github/workflows/update-examples-on-release.yml
+++ b/.github/workflows/update-examples-on-release.yml
@@ -1,5 +1,8 @@
 name: Update examples to latest
 
+env:
+  TURBO_TELEMETRY_MESSAGE_DISABLED: "1"
+
 on:
   workflow_dispatch:
   workflow_call:


### PR DESCRIPTION
## Why

GitHub Actions should not emit Turbo telemetry notices in CI logs.

## What

Disable the telemetry message for every repository workflow.

## How

Set `TURBO_TELEMETRY_MESSAGE_DISABLED=1` at workflow scope. Verified workflow formatting and ran the repository pre-push hooks.
