### PR TITLE
fix: Prevent Cargo run tasks from being cached

### DIFF
--- a/crates/turborepo-engine/src/builder/definitions.rs
+++ b/crates/turborepo-engine/src/builder/definitions.rs
@@ -283,11 +283,17 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
             task_id.as_inner().task(),
         );
 
-        let processed_task_definition = ProcessedTaskDefinition::from_iter(
+        let mut processed_task_definition = ProcessedTaskDefinition::from_iter(
             chain_definitions
                 .into_iter()
                 .map(|(definition, _)| definition),
         );
+        if let Some((info, toolchain)) = package_info.zip(toolchain) {
+            let defaults = toolchain.task_defaults(info, task_id.as_inner().task());
+            if processed_task_definition.cache.is_none() {
+                processed_task_definition.cache = defaults.cache.map(Spanned::new);
+            }
+        }
         let had_explicit_inputs = processed_task_definition.inputs.is_some();
         let mut task_def =
             TaskDefinition::from_processed(processed_task_definition, &path_to_root)?;

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -550,6 +550,21 @@ impl Toolchain for CargoToolchain {
         display_command(details.kind, task, &name)
     }
 
+    fn task_defaults(
+        &self,
+        package: &crate::package_graph::PackageInfo,
+        task: &str,
+    ) -> toolchain::TaskDefaults {
+        let cache = package
+            .package_name()
+            .and_then(|name| self.package_details(&name))
+            .and_then(|details| task_subcommand(details.kind, task))
+            .is_some_and(|subcommand| subcommand == "run")
+            .then_some(false);
+
+        toolchain::TaskDefaults { cache }
+    }
+
     /// Route rustc invocations through the embedded sccache, with the
     /// Turborepo-served endpoint as its webdav storage backend. The wrapper
     /// is the running turbo binary itself (which dispatches invocations
@@ -1953,6 +1968,12 @@ checksum = "abc123"
             Some("cargo test --workspace")
         );
         assert_eq!(toolchain.task_display_command(&lib_a, "build"), None);
+
+        assert_eq!(toolchain.task_defaults(&app, "run").cache, Some(false));
+        assert_eq!(toolchain.task_defaults(&app, "dev").cache, Some(false));
+        assert_eq!(toolchain.task_defaults(&app, "build").cache, None);
+        assert_eq!(toolchain.task_defaults(&workspace, "test").cache, None);
+        assert_eq!(toolchain.task_defaults(&lib_a, "run").cache, None);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -262,6 +262,18 @@ pub trait Toolchain: Send + Sync {
         false
     }
 
+    /// Defaults this toolchain supplies for `task` when turbo.json does not
+    /// configure the corresponding field. Explicit user configuration always
+    /// wins.
+    fn task_defaults(
+        &self,
+        package: &crate::package_graph::PackageInfo,
+        task: &str,
+    ) -> TaskDefaults {
+        let _ = (package, task);
+        TaskDefaults::default()
+    }
+
     /// Hash wiring this toolchain derives for `task` in `package`, beyond
     /// what turbo.json declares: extra input globs and env vars that
     /// participate in the task hash, output globs to cache, and whether the
@@ -412,6 +424,14 @@ pub struct WatchSpec {
     /// they are written by the very tasks a change would re-trigger, and
     /// must not feed back into the watcher even when not gitignored.
     pub ignore_prefixes: Vec<String>,
+}
+
+/// Default task behavior supplied by a toolchain. See
+/// [`Toolchain::task_defaults`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TaskDefaults {
+    /// Whether task logs and outputs are cacheable.
+    pub cache: Option<bool>,
 }
 
 impl WatchSpec {

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -235,7 +235,9 @@ whether anything changed; Cargo decides how and in what order to build.**
   tarballing it fights Cargo instead of leaning on it (it is also
   multi-gigabyte). For fine-grained compile caching, `RUSTC_WRAPPER`
   (sccache) is the sound layer, and it participates in task hashes so
-  toggling it invalidates caches.
+  toggling it invalidates caches. Entrypoint `run` and `dev` tasks default to
+  `cache: false`, because a cache hit must not suppress the requested process;
+  an explicit turbo.json `cache` setting overrides the toolchain default.
 
 - **Watch mode** (`Toolchain::watch_spec`, consumed by
   `turborepo-lib/src/package_changes_watcher.rs`): each toolchain declares
@@ -318,10 +320,10 @@ hint pointing at the flag. Released turbo versions hard-error on unknown
 End-to-end coverage lives in `crates/turborepo/tests/cargo_workspace_test.rs`
 against the `cargo_monorepo` fixture (a mixed npm + Cargo workspace):
 graph shape, execution, caching, deliverable restoration, cross-crate
-invalidation, and the filter hint. `turbo query` serves Cargo packages
-through the same graph. Discovery adds roughly 170ms to invocations on a
-~60-crate workspace (`cargo metadata`, `rustc --version`, and lockfile
-parsing); daemon-side caching is the optimization path if that ever
+invalidation, uncached `run`/`dev` execution, and the filter hint. `turbo query`
+serves Cargo packages through the same graph. Discovery adds roughly 170ms to
+invocations on a ~60-crate workspace (`cargo metadata`, `rustc --version`, and
+lockfile parsing); daemon-side caching is the optimization path if that ever
 matters.
 
 ### 3. Task Graph (`crates/turborepo-lib/src/engine/`)

--- a/crates/turborepo/tests/cargo_workspace_test.rs
+++ b/crates/turborepo/tests/cargo_workspace_test.rs
@@ -118,6 +118,83 @@ fn test_cargo_build_executes_caches_and_restores() {
 }
 
 #[test]
+fn test_cargo_run_and_dev_default_to_uncached() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_cargo_monorepo(tempdir.path());
+
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "run", "--filter=app", "--dry-run=json"],
+    );
+    assert!(output.status.success(), "run dry-run failed: {output:?}");
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("dry-run emits JSON");
+    let run = json["tasks"]
+        .as_array()
+        .and_then(|tasks| tasks.iter().find(|task| task["taskId"] == "app#run"))
+        .expect("app#run in graph");
+    assert_eq!(run["resolvedTaskDefinition"]["cache"], false);
+
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "dev", "--filter=app", "--dry-run=json"],
+    );
+    assert!(output.status.success(), "dev dry-run failed: {output:?}");
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("dry-run emits JSON");
+    let dev = json["tasks"]
+        .as_array()
+        .and_then(|tasks| tasks.iter().find(|task| task["taskId"] == "app#dev"))
+        .expect("app#dev in graph");
+    assert_eq!(dev["resolvedTaskDefinition"]["cache"], false);
+
+    for _ in 0..2 {
+        let output = run_turbo(
+            tempdir.path(),
+            &["run", "run", "--filter=app", "--log-order", "grouped"],
+        );
+        assert!(output.status.success(), "cargo run failed: {output:?}");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("cache bypass"),
+            "cargo run must execute every time: {stdout}"
+        );
+        assert!(
+            stdout.contains("hello from lib-a"),
+            "cargo run must start the requested process: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn test_explicit_cache_overrides_cargo_run_default() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_cargo_monorepo(tempdir.path());
+    fs::write(
+        tempdir.path().join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": { "experimentalCargoWorkspaces": true },
+  "tasks": { "run": { "cache": true } }
+}"#,
+    )
+    .unwrap();
+
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "run", "--filter=app", "--dry-run=json"],
+    );
+    assert!(output.status.success(), "run dry-run failed: {output:?}");
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("dry-run emits JSON");
+    let run = json["tasks"]
+        .as_array()
+        .and_then(|tasks| tasks.iter().find(|task| task["taskId"] == "app#run"))
+        .expect("app#run in graph");
+    assert_eq!(run["resolvedTaskDefinition"]["cache"], true);
+}
+
+#[test]
 fn test_dependency_crate_change_invalidates_entrypoint() {
     let tempdir = tempfile::tempdir().unwrap();
     setup_cargo_monorepo(tempdir.path());

--- a/turborepo-tests/integration/fixtures/cargo_monorepo/turbo.json
+++ b/turborepo-tests/integration/fixtures/cargo_monorepo/turbo.json
@@ -5,6 +5,8 @@
     "build": {
       "outputs": ["dist/**"],
       "dependsOn": ["^build"]
-    }
+    },
+    "run": {},
+    "dev": {}
   }
 }


### PR DESCRIPTION
## Why
Cargo `run` and `dev` tasks inherited `cache: true`, allowing a cache hit to suppress the requested process entirely. This is a release blocker for reliable Rust support.

## What
Toolchains can now provide task defaults. Cargo entrypoint `run` and `dev` tasks default to `cache: false`, while explicit turbo.json configuration remains authoritative. Architecture documentation and regression coverage reflect the behavior.

## How
Verified with `cargo lint`, formatting hooks, and the full `cargo_workspace_test` integration suite. The tests confirm both execution tasks bypass cache and explicit `cache: true` still wins.