### PR TITLE
fix: Continue TUI text selection beyond viewport

### DIFF
--- a/crates/turborepo-ghostty/src/parser.rs
+++ b/crates/turborepo-ghostty/src/parser.rs
@@ -2,6 +2,7 @@ use libghostty_vt::{
     RenderState, Terminal,
     error::Error as GhosttyInnerError,
     fmt::{Format, Formatter, FormatterOptions},
+    screen::TrackedGridRef,
     selection::{FormatOptions, Selection},
     terminal::{Options as TerminalOptions, Point, PointCoordinate, ScrollViewport},
 };
@@ -16,9 +17,10 @@ pub struct Parser {
     pub terminal: Terminal<'static, 'static>,
     pub render_state: RenderState<'static>,
     selection_start: Option<(u16, u16)>,
-    /// Last viewport selection endpoints, used to refresh grid refs before
-    /// copy.
+    /// Last viewport selection endpoints, retained for introspection.
     selection_range: Option<(u16, u16, u16, u16)>,
+    selection_start_ref: Option<TrackedGridRef>,
+    selection_end_ref: Option<TrackedGridRef>,
     max_scrollback: usize,
 }
 
@@ -36,6 +38,8 @@ impl Parser {
             render_state,
             selection_start: None,
             selection_range: None,
+            selection_start_ref: None,
+            selection_end_ref: None,
             max_scrollback: scrollback_len,
         })
     }
@@ -94,6 +98,8 @@ impl Parser {
     pub fn clear_selection(&mut self) -> Result<()> {
         self.selection_start = None;
         self.selection_range = None;
+        self.selection_start_ref = None;
+        self.selection_end_ref = None;
         self.terminal.set_selection(None)?;
         Ok(())
     }
@@ -106,19 +112,31 @@ impl Parser {
         end_col: u16,
     ) -> Result<()> {
         self.selection_range = Some((start_row, start_col, end_row, end_col));
+        if self.selection_start_ref.is_none() {
+            self.selection_start_ref = Some(
+                self.terminal
+                    .track_grid_ref(viewport_point(start_row, start_col))?,
+            );
+        }
+        self.selection_end_ref = Some(
+            self.terminal
+                .track_grid_ref(viewport_point(end_row, end_col))?,
+        );
         self.refresh_selection()
     }
 
     fn refresh_selection(&mut self) -> Result<()> {
-        let Some((start_row, start_col, end_row, end_col)) = self.selection_range else {
+        let (Some(start), Some(end)) = (&self.selection_start_ref, &self.selection_end_ref) else {
             self.terminal.set_selection(None)?;
             return Ok(());
         };
-
-        let start = self
-            .terminal
-            .grid_ref(viewport_point(start_row, start_col))?;
-        let end = self.terminal.grid_ref(viewport_point(end_row, end_col))?;
+        let (Some(start), Some(end)) = (
+            start.snapshot(&self.terminal)?,
+            end.snapshot(&self.terminal)?,
+        ) else {
+            self.terminal.set_selection(None)?;
+            return Ok(());
+        };
         let selection = Selection::new(start, end, false);
         self.terminal.set_selection(Some(&selection))?;
         Ok(())
@@ -168,6 +186,8 @@ impl Parser {
         self.terminal.reset();
         self.selection_start = None;
         self.selection_range = None;
+        self.selection_start_ref = None;
+        self.selection_end_ref = None;
     }
 
     pub fn max_scrollback(&self) -> usize {

--- a/crates/turborepo-ghostty/src/parser.rs
+++ b/crates/turborepo-ghostty/src/parser.rs
@@ -104,6 +104,13 @@ impl Parser {
         Ok(())
     }
 
+    pub fn begin_selection(&mut self, row: u16, col: u16) -> Result<()> {
+        self.clear_selection()?;
+        self.selection_start = Some((row, col));
+        self.selection_start_ref = Some(self.terminal.track_grid_ref(viewport_point(row, col))?);
+        Ok(())
+    }
+
     pub fn update_selection(
         &mut self,
         start_row: u16,
@@ -111,13 +118,17 @@ impl Parser {
         end_row: u16,
         end_col: u16,
     ) -> Result<()> {
-        self.selection_range = Some((start_row, start_col, end_row, end_col));
         if self.selection_start_ref.is_none() {
-            self.selection_start_ref = Some(
-                self.terminal
-                    .track_grid_ref(viewport_point(start_row, start_col))?,
-            );
+            self.begin_selection(start_row, start_col)?;
         }
+        self.update_selection_end(end_row, end_col)
+    }
+
+    pub fn update_selection_end(&mut self, end_row: u16, end_col: u16) -> Result<()> {
+        let Some((start_row, start_col)) = self.selection_start else {
+            return Ok(());
+        };
+        self.selection_range = Some((start_row, start_col, end_row, end_col));
         self.selection_end_ref = Some(
             self.terminal
                 .track_grid_ref(viewport_point(end_row, end_col))?,
@@ -130,10 +141,15 @@ impl Parser {
             self.terminal.set_selection(None)?;
             return Ok(());
         };
-        let (Some(start), Some(end)) = (
+        let snapshots = (
             start.snapshot(&self.terminal)?,
             end.snapshot(&self.terminal)?,
-        ) else {
+        );
+        let (Some(start), Some(end)) = snapshots else {
+            self.selection_start = None;
+            self.selection_range = None;
+            self.selection_start_ref = None;
+            self.selection_end_ref = None;
             self.terminal.set_selection(None)?;
             return Ok(());
         };
@@ -156,6 +172,14 @@ impl Parser {
 
     pub fn has_selection(&self) -> bool {
         self.selection_range.is_some()
+            && self
+                .selection_start_ref
+                .as_ref()
+                .is_some_and(TrackedGridRef::has_value)
+            && self
+                .selection_end_ref
+                .as_ref()
+                .is_some_and(TrackedGridRef::has_value)
     }
 
     pub fn selection_range(&self) -> Option<(u16, u16, u16, u16)> {
@@ -239,6 +263,41 @@ mod selection_tests {
         let text = parser.selected_text().expect("selected text");
         assert_eq!(text.as_deref(), Some("hello"));
         assert!(parser.has_selection());
+    }
+
+    #[test]
+    fn pinned_anchor_survives_output_before_drag() {
+        let mut parser = Parser::try_new(2, 40, 100).expect("parser");
+        parser.process(b"anchor\r\nnext");
+        parser.begin_selection(0, 0).expect("begin selection");
+        assert!(!parser.has_selection());
+        assert_eq!(parser.selected_text().expect("selected text"), None);
+
+        parser.process(b"\r\nnew");
+        parser
+            .update_selection_end(1, 2)
+            .expect("update selection end");
+        let text = parser
+            .selected_text()
+            .expect("selected text")
+            .expect("selection");
+        assert!(text.starts_with("anchor"));
+    }
+
+    #[test]
+    fn invalid_selection_refs_clear_logical_state() {
+        let mut parser = Parser::try_new(2, 40, 1).expect("parser");
+        parser.process(b"anchor\r\nnext");
+        parser.begin_selection(0, 0).expect("begin selection");
+        parser
+            .update_selection_end(1, 3)
+            .expect("update selection end");
+        assert!(parser.has_selection());
+
+        parser.terminal.reset();
+        parser.prepare_render().expect("prepare render");
+        assert!(!parser.has_selection());
+        assert_eq!(parser.selection_range(), None);
     }
 
     #[test]

--- a/crates/turborepo-ghostty/src/parser.rs
+++ b/crates/turborepo-ghostty/src/parser.rs
@@ -111,6 +111,14 @@ impl Parser {
         Ok(())
     }
 
+    pub fn cancel_incomplete_selection(&mut self) {
+        if self.selection_range.is_none() {
+            self.selection_start = None;
+            self.selection_start_ref = None;
+            self.selection_end_ref = None;
+        }
+    }
+
     pub fn update_selection(
         &mut self,
         start_row: u16,
@@ -282,6 +290,19 @@ mod selection_tests {
             .expect("selected text")
             .expect("selection");
         assert!(text.starts_with("anchor"));
+    }
+
+    #[test]
+    fn cancelling_incomplete_selection_releases_anchor() {
+        let mut parser = Parser::try_new(2, 40, 100).expect("parser");
+        parser.process(b"anchor");
+        parser.begin_selection(0, 0).expect("begin selection");
+
+        parser.cancel_incomplete_selection();
+
+        assert_eq!(parser.selection_start, None);
+        assert!(parser.selection_start_ref.is_none());
+        assert!(!parser.has_selection());
     }
 
     #[test]

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -990,6 +990,7 @@ impl<W> App<W> {
     }
 
     pub fn copy_selection(&mut self) -> Result<(), Error> {
+        self.cancel_selection_drag();
         let task = self.get_full_task_mut()?;
         let Some(text) = task.copy_selection() else {
             return Ok(());
@@ -1386,6 +1387,7 @@ fn handle_toggle_stream(
     scope: &StreamScope,
     color_config: ColorConfig,
 ) -> Result<(), Error> {
+    app.cancel_selection_drag();
     match *display {
         DisplayState::Tui => {
             let Some(term) = terminal.as_mut() else {
@@ -3836,6 +3838,88 @@ mod test {
         app.clear_task_logs()?;
         assert!(!app.get_full_task()?.has_pending_selection_anchor());
         assert!(app.selection_drag_task.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn manual_copy_cancels_selection_drag_and_autoscroll() -> Result<(), Error> {
+        use crossterm::event::{MouseButton, MouseEventKind};
+
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())
+            .expect("Failed to create AbsoluteSystemPathBuf");
+        let mut app: App<Vec<u8>> = App::new(
+            10,
+            80,
+            vec!["app-a".to_string()],
+            PreferenceLoader::new(&repo_root),
+            2048,
+        )?;
+        app.process_output("app-a", b"zero\none\ntwo\nthree\nfour\nfive")?;
+        let pane_column = app.size.task_list_width();
+
+        app.handle_mouse(mouse_event(
+            MouseEventKind::Down(MouseButton::Left),
+            2,
+            pane_column,
+        ))?;
+        app.handle_mouse(mouse_event(
+            MouseEventKind::Drag(MouseButton::Left),
+            0,
+            pane_column,
+        ))?;
+        assert!(app.selection_autoscroll.is_some());
+
+        app.copy_selection()?;
+        assert!(app.selection_drag_task.is_none());
+        assert!(app.selection_autoscroll.is_none());
+        assert!(!app.get_full_task()?.is_selecting());
+        Ok(())
+    }
+
+    #[test]
+    fn stream_toggle_cancels_selection_drag_and_autoscroll() -> Result<(), Error> {
+        use crossterm::event::{MouseButton, MouseEventKind};
+
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())
+            .expect("Failed to create AbsoluteSystemPathBuf");
+        let mut app: App<Box<dyn io::Write + Send>> = App::new_for_test(
+            10,
+            80,
+            vec!["app-a".to_string()],
+            PreferenceLoader::new(&repo_root),
+            2048,
+        );
+        let pane_column = app.size.task_list_width();
+
+        app.handle_mouse(mouse_event(
+            MouseEventKind::Down(MouseButton::Left),
+            2,
+            pane_column,
+        ))?;
+        app.handle_mouse(mouse_event(
+            MouseEventKind::Drag(MouseButton::Left),
+            0,
+            pane_column,
+        ))?;
+        assert!(app.selection_autoscroll.is_some());
+
+        let mut terminal = None;
+        let mut display = DisplayState::Inactive;
+        let sink = TerminalSink::new(ColorConfig::new(true));
+        handle_toggle_stream(
+            &mut terminal,
+            &mut display,
+            &mut app,
+            &sink,
+            &StreamScope::All,
+            ColorConfig::new(true),
+        )?;
+
+        assert!(app.selection_drag_task.is_none());
+        assert!(app.selection_autoscroll.is_none());
+        assert!(!app.get_full_task()?.is_selecting());
         Ok(())
     }
 

--- a/crates/turborepo-ui/src/tui/app.rs
+++ b/crates/turborepo-ui/src/tui/app.rs
@@ -24,6 +24,7 @@ use crate::tui::popup::{popup, popup_area};
 
 pub const FRAMERATE: Duration = Duration::from_millis(3);
 const RESIZE_DEBOUNCE_DELAY: Duration = Duration::from_millis(10);
+const SELECTION_AUTOSCROLL_INTERVAL: Duration = Duration::from_millis(50);
 /// How long the pane footer shows "Copied to clipboard" after a copy.
 const CLIPBOARD_NOTICE_DURATION: Duration = Duration::from_secs(2);
 
@@ -78,6 +79,17 @@ pub struct App<W> {
     /// stream sink. Lets repeated TUI<->stream toggles backfill only the new
     /// output instead of re-printing the whole history each time.
     replayed_offsets: BTreeMap<String, usize>,
+    selection_drag_task: Option<String>,
+    selection_autoscroll: Option<SelectionAutoscroll>,
+}
+
+#[derive(Clone)]
+struct SelectionAutoscroll {
+    task: String,
+    direction: Direction,
+    row: u16,
+    column: u16,
+    next_scroll_at: Instant,
 }
 
 impl<W> App<W> {
@@ -138,6 +150,8 @@ impl<W> App<W> {
             showing_log_panel: false,
             clipboard_notice_expiry: None,
             replayed_offsets: BTreeMap::new(),
+            selection_drag_task: None,
+            selection_autoscroll: None,
         })
     }
 
@@ -178,6 +192,7 @@ impl<W> App<W> {
     }
 
     fn update_sidebar_toggle(&mut self) {
+        self.cancel_selection_drag();
         let value = !self.preferences.is_task_list_visible();
         self.preferences.set_is_task_list_visible(Some(value));
         // Resize terminal outputs to match new pane width
@@ -211,6 +226,25 @@ impl<W> App<W> {
         self.tasks
             .get_mut(&active_task)
             .ok_or(Error::TaskNotFound { name: active_task })
+    }
+
+    fn cancel_selection_drag(&mut self) {
+        self.selection_autoscroll = None;
+        if let Some(task_name) = self.selection_drag_task.take()
+            && let Some(task) = self.tasks.get_mut(&task_name)
+        {
+            task.cancel_selection_drag();
+        }
+    }
+
+    fn cancel_selection_drag_if_task_changed(&mut self) {
+        let task_changed = self
+            .selection_drag_task
+            .as_deref()
+            .is_some_and(|task_name| self.active_task().ok() != Some(task_name));
+        if task_changed {
+            self.cancel_selection_drag();
+        }
     }
 
     fn persist_active_task(&mut self) -> Result<(), Error> {
@@ -280,6 +314,7 @@ impl<W> App<W> {
             self.task_list_scroll.select(Some(self.selected_task_index));
         }
 
+        self.cancel_selection_drag_if_task_changed();
         self.is_task_selection_pinned = true;
         self.persist_active_task().ok();
     }
@@ -301,6 +336,7 @@ impl<W> App<W> {
             self.task_list_scroll.select(Some(self.selected_task_index));
         }
 
+        self.cancel_selection_drag_if_task_changed();
         self.is_task_selection_pinned = true;
         self.persist_active_task().ok();
     }
@@ -334,6 +370,7 @@ impl<W> App<W> {
     }
 
     pub fn enter_search(&mut self) -> Result<(), Error> {
+        self.cancel_selection_drag();
         // Ensure task list is visible when searching
         if !self.preferences.is_task_list_visible() {
             self.preferences.set_is_task_list_visible(Some(true));
@@ -349,6 +386,7 @@ impl<W> App<W> {
     }
 
     pub fn exit_search(&mut self, restore_scroll: bool) {
+        self.cancel_selection_drag();
         let mut prev_focus = LayoutSections::TaskList;
         mem::swap(&mut self.section_focus, &mut prev_focus);
         match prev_focus {
@@ -365,6 +403,7 @@ impl<W> App<W> {
     }
 
     pub fn lock_search(&mut self) {
+        self.cancel_selection_drag();
         if let LayoutSections::Search { results, .. } = &self.section_focus {
             self.section_focus = LayoutSections::SearchLocked {
                 results: results.clone(),
@@ -373,6 +412,7 @@ impl<W> App<W> {
     }
 
     pub fn search_scroll(&mut self, direction: Direction) -> Result<(), Error> {
+        self.cancel_selection_drag();
         let LayoutSections::Search { results, .. } = &self.section_focus else {
             debug!("scrolling search while not searching");
             return Ok(());
@@ -388,6 +428,7 @@ impl<W> App<W> {
     }
 
     pub fn search_enter_char(&mut self, c: char) -> Result<(), Error> {
+        self.cancel_selection_drag();
         let LayoutSections::Search { results, .. } = &mut self.section_focus else {
             debug!("modifying search query while not searching");
             return Ok(());
@@ -398,6 +439,7 @@ impl<W> App<W> {
     }
 
     pub fn search_remove_char(&mut self) -> Result<(), Error> {
+        self.cancel_selection_drag();
         let LayoutSections::Search { results, .. } = &mut self.section_focus else {
             debug!("modified search query while not searching");
             return Ok(());
@@ -760,7 +802,28 @@ impl<W> App<W> {
         Ok(())
     }
 
-    pub fn handle_mouse(&mut self, mut event: crossterm::event::MouseEvent) -> Result<(), Error> {
+    pub fn handle_mouse(&mut self, event: crossterm::event::MouseEvent) -> Result<(), Error> {
+        self.handle_mouse_at(event, Instant::now())
+    }
+
+    fn handle_mouse_at(
+        &mut self,
+        mut event: crossterm::event::MouseEvent,
+        now: Instant,
+    ) -> Result<(), Error> {
+        let is_selection_down = matches!(
+            event.kind,
+            crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left)
+        );
+        let is_selection_drag = matches!(
+            event.kind,
+            crossterm::event::MouseEventKind::Drag(crossterm::event::MouseButton::Left)
+        );
+
+        if is_selection_down {
+            self.cancel_selection_drag();
+        }
+
         // Releasing the left button ends a selection wherever the cursor is,
         // so handle it before any hit-testing. Whatever was selected gets
         // copied to the clipboard automatically.
@@ -771,13 +834,26 @@ impl<W> App<W> {
             let shift_held = event
                 .modifiers
                 .contains(crossterm::event::KeyModifiers::SHIFT);
-            let task = self.get_full_task_mut()?;
-            let was_selecting = task.is_selecting();
-            task.handle_mouse(event)?;
+            let drag_task_is_active = self
+                .selection_drag_task
+                .as_deref()
+                .is_some_and(|task_name| self.active_task().ok() == Some(task_name));
+            if !drag_task_is_active {
+                self.cancel_selection_drag();
+                return Ok(());
+            }
+            let should_copy = {
+                let task = self.get_full_task_mut()?;
+                let was_selecting = task.is_selecting();
+                task.handle_mouse(event)?;
+                was_selecting && task.has_selection() && !shift_held
+            };
+            self.selection_drag_task = None;
+            self.selection_autoscroll = None;
             // Shift prevents the automatic copy, leaving the selection in
             // place so the user can still copy it with `c` or dismiss it by
             // clicking.
-            if was_selecting && task.has_selection() && !shift_held {
+            if should_copy {
                 self.copy_selection()?;
             }
             return Ok(());
@@ -788,8 +864,26 @@ impl<W> App<W> {
         // shifted mouse events). End the drag and keep the selection, the
         // same outcome as an observed shift-release.
         if matches!(event.kind, crossterm::event::MouseEventKind::Moved) {
-            self.get_full_task_mut()?.handle_mouse(event)?;
+            if self
+                .selection_drag_task
+                .as_deref()
+                .is_some_and(|task_name| self.active_task().ok() == Some(task_name))
+            {
+                self.get_full_task_mut()?.handle_mouse(event)?;
+            }
+            self.cancel_selection_drag();
             return Ok(());
+        }
+
+        if is_selection_drag {
+            let drag_task_is_active = self
+                .selection_drag_task
+                .as_deref()
+                .is_some_and(|task_name| self.active_task().ok() == Some(task_name));
+            if !drag_task_is_active {
+                self.cancel_selection_drag();
+                return Ok(());
+            }
         }
 
         // Only offset by table width if the sidebar is visible
@@ -800,19 +894,40 @@ impl<W> App<W> {
             0
         };
         let pane_left_padding = self.size.pane_left_padding_with_sidebar(has_sidebar);
+        let pane_rows = self.size.pane_rows();
         debug!("original mouse event: {event:?}, table_width: {table_width}");
-        // We give a 1 cell buffer to make it easier to select the first column of a row
-        if event.row > 0 && event.column >= table_width {
-            // Subtract 1 from the y axis due to the title of the pane
-            event.row -= 1;
+        // Mouse-down events must start in the content. Drags may reach the pane titles
+        // to scroll.
+        if event.column >= table_width && (event.row > 0 || is_selection_drag) {
+            let selection_scroll = if is_selection_drag && event.row == 0 {
+                Some(Direction::Up)
+            } else if is_selection_drag && event.row > pane_rows {
+                Some(Direction::Down)
+            } else {
+                None
+            };
+            event.row = event.row.saturating_sub(1).min(pane_rows.saturating_sub(1));
             // Subtract the width of the table and the pane's link-safe left padding.
             event.column = event
                 .column
                 .saturating_sub(table_width.saturating_add(pane_left_padding));
             debug!("translated mouse event: {event:?}");
 
+            let task_name = self.active_task()?.to_owned();
             let task = self.get_full_task_mut()?;
-            task.handle_mouse(event)?;
+            task.handle_mouse_with_scroll(event, selection_scroll)?;
+            if is_selection_down && task.is_selecting() {
+                self.selection_drag_task = Some(task_name.clone());
+            }
+            self.selection_autoscroll = selection_scroll.map(|direction| SelectionAutoscroll {
+                task: task_name,
+                direction,
+                row: event.row,
+                column: event.column,
+                next_scroll_at: now + SELECTION_AUTOSCROLL_INTERVAL,
+            });
+        } else if is_selection_drag {
+            self.selection_autoscroll = None;
         } else if event.column < table_width
             && matches!(
                 event.kind,
@@ -823,6 +938,32 @@ impl<W> App<W> {
         }
 
         Ok(())
+    }
+
+    fn tick_selection_autoscroll(&mut self, now: Instant) -> Result<bool, Error> {
+        let Some(mut selection_autoscroll) = self.selection_autoscroll.take() else {
+            return Ok(false);
+        };
+        let is_active_task = self.active_task()? == selection_autoscroll.task;
+
+        if !is_active_task {
+            self.cancel_selection_drag();
+            return Ok(false);
+        }
+
+        if now < selection_autoscroll.next_scroll_at {
+            self.selection_autoscroll = Some(selection_autoscroll);
+            return Ok(false);
+        }
+
+        self.get_full_task_mut()?.continue_selection_drag(
+            selection_autoscroll.direction,
+            selection_autoscroll.row,
+            selection_autoscroll.column,
+        )?;
+        selection_autoscroll.next_scroll_at = now + SELECTION_AUTOSCROLL_INTERVAL;
+        self.selection_autoscroll = Some(selection_autoscroll);
+        Ok(true)
     }
 
     /// Selects the task whose row in the task list was clicked. Clicks on the
@@ -876,6 +1017,7 @@ impl<W> App<W> {
 
     fn select_task(&mut self, task_name: &str) -> Result<(), Error> {
         if !self.is_task_selection_pinned {
+            self.cancel_selection_drag_if_task_changed();
             return Ok(());
         }
 
@@ -890,6 +1032,7 @@ impl<W> App<W> {
         };
         self.selected_task_index = new_index_to_highlight;
         self.task_list_scroll.select(Some(new_index_to_highlight));
+        self.cancel_selection_drag_if_task_changed();
 
         Ok(())
     }
@@ -899,9 +1042,11 @@ impl<W> App<W> {
         self.is_task_selection_pinned = false;
         self.task_list_scroll.select(Some(0));
         self.selected_task_index = 0;
+        self.cancel_selection_drag_if_task_changed();
     }
 
     pub fn resize(&mut self, rows: u16, cols: u16) {
+        self.cancel_selection_drag();
         self.size.resize(rows, cols);
         let pane_rows = self.size.pane_rows();
         let pane_cols = self
@@ -925,6 +1070,7 @@ impl<W> App<W> {
     }
 
     pub fn clear_task_logs(&mut self) -> Result<(), Error> {
+        self.cancel_selection_drag();
         let task = self.get_full_task_mut()?;
         task.clear_logs();
         Ok(())
@@ -1179,6 +1325,10 @@ async fn run_app_inner(
             needs_rerender = true;
         }
 
+        if matches!(event, Event::Tick) && app.tick_selection_autoscroll(Instant::now())? {
+            needs_rerender = true;
+        }
+
         // The "Copied to clipboard" notice expires on its own, so ticks must
         // trigger a rerender when it does.
         if app.clear_expired_clipboard_notice() {
@@ -1300,6 +1450,9 @@ async fn drain_after_stop(
 
     while let Some(event) = receiver.recv().await {
         if !matches!(event, Event::Tick) {
+            needs_rerender = true;
+        }
+        if matches!(event, Event::Tick) && app.tick_selection_autoscroll(Instant::now())? {
             needs_rerender = true;
         }
         update(app, event, None)?;
@@ -1768,6 +1921,19 @@ mod test {
 
     use super::*;
     use crate::{ColorConfig, tui::event::CacheResult};
+
+    fn mouse_event(
+        kind: crossterm::event::MouseEventKind,
+        row: u16,
+        column: u16,
+    ) -> crossterm::event::MouseEvent {
+        crossterm::event::MouseEvent {
+            kind,
+            column,
+            row,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        }
+    }
 
     #[test]
     fn record_restore_error_keeps_first_error_and_continues() {
@@ -3417,6 +3583,259 @@ mod test {
         assert!(app.get_full_task()?.has_selection());
         assert!(app.clipboard_notice_expiry.is_none());
 
+        Ok(())
+    }
+
+    #[test]
+    fn selection_autoscroll_continues_on_ticks_and_stops_away_from_boundary() -> Result<(), Error> {
+        use crossterm::event::{MouseButton, MouseEventKind};
+
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())
+            .expect("Failed to create AbsoluteSystemPathBuf");
+        let mut app: App<Vec<u8>> = App::new(
+            10,
+            80,
+            vec!["app-a".to_string()],
+            PreferenceLoader::new(&repo_root),
+            2048,
+        )?;
+        app.process_output(
+            "app-a",
+            b"zero\none\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nnine\nten\neleven",
+        )?;
+        app.get_full_task_mut()?.scroll_to_top()?;
+        let pane_column = app.size.task_list_width();
+        let footer_row = app.size.pane_rows() + 1;
+        let start = Instant::now();
+
+        app.handle_mouse_at(
+            mouse_event(MouseEventKind::Down(MouseButton::Left), 2, pane_column),
+            start,
+        )?;
+        app.handle_mouse_at(
+            mouse_event(
+                MouseEventKind::Drag(MouseButton::Left),
+                footer_row,
+                pane_column,
+            ),
+            start,
+        )?;
+        let first_offset = app
+            .get_full_task()?
+            .parser
+            .terminal
+            .scrollbar()
+            .expect("scrollbar should be available")
+            .offset;
+        assert!(first_offset > 0);
+        let first_selection = app
+            .get_full_task_mut()?
+            .copy_selection()
+            .expect("drag should select text");
+
+        assert!(!app.tick_selection_autoscroll(
+            start + SELECTION_AUTOSCROLL_INTERVAL - Duration::from_millis(1)
+        )?);
+        assert!(app.tick_selection_autoscroll(start + SELECTION_AUTOSCROLL_INTERVAL)?);
+        let second_offset = app
+            .get_full_task()?
+            .parser
+            .terminal
+            .scrollbar()
+            .expect("scrollbar should be available")
+            .offset;
+        assert!(second_offset > first_offset);
+        let second_selection = app
+            .get_full_task_mut()?
+            .copy_selection()
+            .expect("autoscroll should preserve the selection");
+        assert!(second_selection.len() > first_selection.len());
+
+        app.handle_mouse_at(
+            mouse_event(MouseEventKind::Drag(MouseButton::Left), 2, pane_column),
+            start + SELECTION_AUTOSCROLL_INTERVAL,
+        )?;
+        assert!(!app.tick_selection_autoscroll(start + SELECTION_AUTOSCROLL_INTERVAL * 2)?);
+        assert_eq!(
+            app.get_full_task()?
+                .parser
+                .terminal
+                .scrollbar()
+                .expect("scrollbar should be available")
+                .offset,
+            second_offset
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn selection_autoscroll_stops_on_release() -> Result<(), Error> {
+        use crossterm::event::{KeyModifiers, MouseButton, MouseEventKind};
+
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())
+            .expect("Failed to create AbsoluteSystemPathBuf");
+        let mut app: App<Vec<u8>> = App::new(
+            10,
+            80,
+            vec!["app-a".to_string()],
+            PreferenceLoader::new(&repo_root),
+            2048,
+        )?;
+        app.process_output("app-a", b"zero\none\ntwo\nthree\nfour\nfive\nsix\nseven")?;
+        let pane_column = app.size.task_list_width();
+        let start = Instant::now();
+
+        app.handle_mouse_at(
+            mouse_event(MouseEventKind::Down(MouseButton::Left), 2, pane_column),
+            start,
+        )?;
+        app.handle_mouse_at(
+            mouse_event(MouseEventKind::Drag(MouseButton::Left), 0, pane_column),
+            start,
+        )?;
+        let mut release = mouse_event(MouseEventKind::Up(MouseButton::Left), 0, pane_column);
+        release.modifiers = KeyModifiers::SHIFT;
+        app.handle_mouse_at(release, start)?;
+        let offset = app
+            .get_full_task()?
+            .parser
+            .terminal
+            .scrollbar()
+            .expect("scrollbar should be available")
+            .offset;
+
+        assert!(!app.tick_selection_autoscroll(start + SELECTION_AUTOSCROLL_INTERVAL)?);
+        assert_eq!(
+            app.get_full_task()?
+                .parser
+                .terminal
+                .scrollbar()
+                .expect("scrollbar should be available")
+                .offset,
+            offset
+        );
+        assert!(app.get_full_task()?.has_selection());
+        Ok(())
+    }
+
+    #[test]
+    fn selection_drag_is_cancelled_on_task_navigation_and_reordering() -> Result<(), Error> {
+        use crossterm::event::{MouseButton, MouseEventKind};
+
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())
+            .expect("Failed to create AbsoluteSystemPathBuf");
+        let mut app: App<()> = App::new_for_test(
+            10,
+            80,
+            vec![
+                "app-a".to_string(),
+                "app-b".to_string(),
+                "app-c".to_string(),
+            ],
+            PreferenceLoader::new(&repo_root),
+            2048,
+        );
+        let pane_column = app.size.task_list_width();
+
+        app.handle_mouse(mouse_event(
+            MouseEventKind::Down(MouseButton::Left),
+            2,
+            pane_column,
+        ))?;
+        app.next();
+        assert!(!app.tasks["app-a"].has_pending_selection_anchor());
+        assert!(app.selection_drag_task.is_none());
+
+        app.reset_scroll();
+        app.handle_mouse(mouse_event(
+            MouseEventKind::Down(MouseButton::Left),
+            2,
+            pane_column,
+        ))?;
+        app.start_task("app-c", OutputLogs::Full)?;
+        assert_eq!(app.active_task()?, "app-c");
+        assert!(!app.tasks["app-a"].has_pending_selection_anchor());
+        assert!(app.selection_drag_task.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn parser_reconstruction_cancels_selection_drag_and_autoscroll() -> Result<(), Error> {
+        use crossterm::event::{MouseButton, MouseEventKind};
+
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())
+            .expect("Failed to create AbsoluteSystemPathBuf");
+        let mut app: App<()> = App::new_for_test(
+            10,
+            80,
+            vec!["app-a".to_string()],
+            PreferenceLoader::new(&repo_root),
+            2048,
+        );
+        let pane_column = app.size.task_list_width();
+        let start = Instant::now();
+
+        app.handle_mouse_at(
+            mouse_event(MouseEventKind::Down(MouseButton::Left), 2, pane_column),
+            start,
+        )?;
+        app.resize(11, 81);
+        assert!(!app.get_full_task()?.has_pending_selection_anchor());
+        assert!(app.selection_drag_task.is_none());
+
+        let pane_column = app.size.task_list_width();
+        app.handle_mouse_at(
+            mouse_event(MouseEventKind::Down(MouseButton::Left), 2, pane_column),
+            start,
+        )?;
+        app.handle_mouse_at(
+            mouse_event(MouseEventKind::Drag(MouseButton::Left), 0, pane_column),
+            start,
+        )?;
+        assert!(app.selection_autoscroll.is_some());
+        app.update_sidebar_toggle();
+        assert!(app.selection_drag_task.is_none());
+        assert!(app.selection_autoscroll.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn search_and_clear_logs_cancel_selection_drag() -> Result<(), Error> {
+        use crossterm::event::{MouseButton, MouseEventKind};
+
+        let repo_root_tmp = tempdir()?;
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_root_tmp.path())
+            .expect("Failed to create AbsoluteSystemPathBuf");
+        let mut app: App<()> = App::new_for_test(
+            10,
+            80,
+            vec!["app-a".to_string()],
+            PreferenceLoader::new(&repo_root),
+            2048,
+        );
+        let pane_column = app.size.task_list_width();
+
+        app.handle_mouse(mouse_event(
+            MouseEventKind::Down(MouseButton::Left),
+            2,
+            pane_column,
+        ))?;
+        app.enter_search()?;
+        assert!(!app.get_full_task()?.has_pending_selection_anchor());
+        assert!(app.selection_drag_task.is_none());
+
+        app.handle_mouse(mouse_event(
+            MouseEventKind::Down(MouseButton::Left),
+            2,
+            pane_column,
+        ))?;
+        app.clear_task_logs()?;
+        assert!(!app.get_full_task()?.has_pending_selection_anchor());
+        assert!(app.selection_drag_task.is_none());
         Ok(())
     }
 

--- a/crates/turborepo-ui/src/tui/input.rs
+++ b/crates/turborepo-ui/src/tui/input.rs
@@ -496,6 +496,21 @@ mod test {
     const SHIFT_H: KeyEvent = KeyEvent::new(KeyCode::Char('H'), KeyModifiers::SHIFT);
     const S: KeyEvent = KeyEvent::new(KeyCode::Char('s'), KeyModifiers::empty());
 
+    #[test]
+    fn forwards_left_mouse_release() {
+        let event = crossterm::event::MouseEvent {
+            kind: crossterm::event::MouseEventKind::Up(crossterm::event::MouseButton::Left),
+            column: 0,
+            row: 0,
+            modifiers: KeyModifiers::empty(),
+        };
+
+        assert!(matches!(
+            in_find().handle_crossterm_event(crossterm::event::Event::Mouse(event)),
+            Some(Event::Mouse(_))
+        ));
+    }
+
     #[test_case(in_find(), H, Some(Event::SearchEnterChar('h')) ; "h while searching")]
     #[test_case(in_list(), H, Some(Event::ToggleStream { scope: StreamScope::SelectedTask }) ; "h streams selected task")]
     #[test_case(in_list(), S, Some(Event::ToggleStream { scope: StreamScope::All }) ; "s streams all tasks")]

--- a/crates/turborepo-ui/src/tui/term_output.rs
+++ b/crates/turborepo-ui/src/tui/term_output.rs
@@ -163,6 +163,14 @@ impl<W> TerminalOutput<W> {
     }
 
     pub fn handle_mouse(&mut self, event: crossterm::event::MouseEvent) -> Result<(), Error> {
+        self.handle_mouse_with_scroll(event, None)
+    }
+
+    pub fn handle_mouse_with_scroll(
+        &mut self,
+        event: crossterm::event::MouseEvent,
+        selection_scroll: Option<Direction>,
+    ) -> Result<(), Error> {
         match event.kind {
             crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left) => {
                 self.parser.clear_selection()?;
@@ -178,6 +186,17 @@ impl<W> TerminalOutput<W> {
             }
             crossterm::event::MouseEventKind::Drag(crossterm::event::MouseButton::Left) => {
                 if let Some((start_row, start_col)) = self.selection_start {
+                    // Pin the anchor before scrolling. Ghostty's tracked grid
+                    // reference then keeps it attached to the original log cell.
+                    if let Some(direction) = selection_scroll {
+                        self.parser.update_selection(
+                            start_row,
+                            start_col,
+                            event.row,
+                            event.column,
+                        )?;
+                        self.scroll(direction)?;
+                    }
                     self.parser
                         .update_selection(start_row, start_col, event.row, event.column)?;
                 }
@@ -198,6 +217,29 @@ impl<W> TerminalOutput<W> {
             }
         }
         Ok(())
+    }
+
+    pub fn continue_selection_drag(
+        &mut self,
+        direction: Direction,
+        row: u16,
+        column: u16,
+    ) -> Result<(), Error> {
+        self.scroll(direction)?;
+        if let Some((start_row, start_col)) = self.selection_start {
+            self.parser
+                .update_selection(start_row, start_col, row, column)?;
+        }
+        Ok(())
+    }
+
+    pub fn cancel_selection_drag(&mut self) {
+        self.selection_start = None;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn has_pending_selection_anchor(&self) -> bool {
+        self.selection_start.is_some()
     }
 
     pub fn copy_selection(&mut self) -> Option<String> {

--- a/crates/turborepo-ui/src/tui/term_output.rs
+++ b/crates/turborepo-ui/src/tui/term_output.rs
@@ -173,32 +173,28 @@ impl<W> TerminalOutput<W> {
     ) -> Result<(), Error> {
         match event.kind {
             crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left) => {
-                self.parser.clear_selection()?;
                 // Shift held at click time means the user is preventing the
                 // copy before it starts, so don't anchor a selection. Most
                 // terminals never deliver shifted mouse events (shift
                 // bypasses mouse capture for native selection), but honor
                 // them when they do arrive.
-                self.selection_start = (!event
+                let selection_start = (!event
                     .modifiers
                     .contains(crossterm::event::KeyModifiers::SHIFT))
                 .then_some((event.row, event.column));
+                if let Some((row, column)) = selection_start {
+                    self.parser.begin_selection(row, column)?;
+                } else {
+                    self.parser.clear_selection()?;
+                }
+                self.selection_start = selection_start;
             }
             crossterm::event::MouseEventKind::Drag(crossterm::event::MouseButton::Left) => {
-                if let Some((start_row, start_col)) = self.selection_start {
-                    // Pin the anchor before scrolling. Ghostty's tracked grid
-                    // reference then keeps it attached to the original log cell.
+                if self.selection_start.is_some() {
                     if let Some(direction) = selection_scroll {
-                        self.parser.update_selection(
-                            start_row,
-                            start_col,
-                            event.row,
-                            event.column,
-                        )?;
                         self.scroll(direction)?;
                     }
-                    self.parser
-                        .update_selection(start_row, start_col, event.row, event.column)?;
+                    self.parser.update_selection_end(event.row, event.column)?;
                 }
             }
             crossterm::event::MouseEventKind::ScrollDown => (),
@@ -225,11 +221,11 @@ impl<W> TerminalOutput<W> {
         row: u16,
         column: u16,
     ) -> Result<(), Error> {
-        self.scroll(direction)?;
-        if let Some((start_row, start_col)) = self.selection_start {
-            self.parser
-                .update_selection(start_row, start_col, row, column)?;
+        if self.selection_start.is_none() {
+            return Ok(());
         }
+        self.scroll(direction)?;
+        self.parser.update_selection_end(row, column)?;
         Ok(())
     }
 
@@ -343,6 +339,78 @@ mod newline_tests {
         // layer so `App` can copy it before clearing the highlight.
         assert!(!output.is_selecting());
         assert!(output.has_selection());
+        Ok(())
+    }
+
+    #[test]
+    fn click_without_drag_has_no_selection() -> Result<(), Error> {
+        use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+
+        let mut output: TerminalOutput<()> = TerminalOutput::new(10, 40, None, 100)?;
+        output.process(b"hello world\r\n");
+        output.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 0,
+            row: 0,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        })?;
+
+        assert!(!output.has_selection());
+        assert_eq!(output.copy_selection(), None);
+        Ok(())
+    }
+
+    #[test]
+    fn mouse_down_pins_anchor_before_output_arrives() -> Result<(), Error> {
+        use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+
+        let mut output: TerminalOutput<()> = TerminalOutput::new(2, 40, None, 100)?;
+        output.process(b"anchor\r\nnext");
+        output.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 0,
+            row: 0,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        })?;
+        output.process(b"\r\nnew");
+        output.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: 2,
+            row: 1,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        })?;
+
+        assert!(
+            output
+                .copy_selection()
+                .is_some_and(|text| text.starts_with("anchor"))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn selection_tick_without_anchor_does_not_scroll() -> Result<(), Error> {
+        let mut output: TerminalOutput<()> = TerminalOutput::new(2, 40, None, 100)?;
+        output.process(b"zero\r\none\r\ntwo\r\nthree");
+        output.scroll_to_top()?;
+        let before = output
+            .parser
+            .terminal
+            .scrollbar()
+            .expect("scrollbar")
+            .offset;
+
+        output.continue_selection_drag(Direction::Down, 1, 0)?;
+
+        assert_eq!(
+            output
+                .parser
+                .terminal
+                .scrollbar()
+                .expect("scrollbar")
+                .offset,
+            before
+        );
         Ok(())
     }
 

--- a/crates/turborepo-ui/src/tui/term_output.rs
+++ b/crates/turborepo-ui/src/tui/term_output.rs
@@ -202,14 +202,14 @@ impl<W> TerminalOutput<W> {
             // Hover means the button is up; drop any stale drag anchor from
             // a release that the terminal never delivered to us.
             crossterm::event::MouseEventKind::Moved => {
-                self.selection_start = None;
+                self.cancel_selection_drag();
             }
             crossterm::event::MouseEventKind::Down(_) => (),
             crossterm::event::MouseEventKind::Drag(_) => (),
             crossterm::event::MouseEventKind::ScrollLeft
             | crossterm::event::MouseEventKind::ScrollRight => (),
             crossterm::event::MouseEventKind::Up(_) => {
-                self.selection_start = None;
+                self.cancel_selection_drag();
             }
         }
         Ok(())
@@ -231,6 +231,7 @@ impl<W> TerminalOutput<W> {
 
     pub fn cancel_selection_drag(&mut self) {
         self.selection_start = None;
+        self.parser.cancel_incomplete_selection();
     }
 
     #[cfg(test)]
@@ -357,6 +358,13 @@ mod newline_tests {
 
         assert!(!output.has_selection());
         assert_eq!(output.copy_selection(), None);
+        output.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Up(MouseButton::Left),
+            column: 0,
+            row: 0,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        })?;
+        assert_eq!(output.parser.selection_start(), None);
         Ok(())
     }
 


### PR DESCRIPTION
## Why
TUI text selection stopped after the last mouse-drag event, so holding the pointer beyond the log viewport could not select longer output.

## What
Selection now scrolls continuously while a boundary drag is held. Ghostty-tracked anchors keep the range stable as output and scrollback move, and selection state is cancelled when its viewport or task becomes invalid.

## How
- Hold a drag on the top or bottom log boundary and verify scrolling continues until release.
- Verify release, task changes, resize, stream mode, search, and log clearing stop autoscroll.
- `cargo test -p turborepo-ui --features tui --lib`
- `cargo test -p turborepo-ghostty --lib`
- `cargo clippy -p turborepo-ui -p turborepo-ghostty --all-targets --features turborepo-ui/tui -- -D warnings`