### PR TITLE
feat: Add portable incremental artifact protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9047,10 +9047,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "base64 0.22.1",
  "futures-util",
  "port_scanner",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tokio",
  "turborepo-vercel-api",

--- a/crates/turborepo-api-client/src/error.rs
+++ b/crates/turborepo-api-client/src/error.rs
@@ -23,6 +23,8 @@ pub enum Error {
     InvalidHeader(#[from] ToStrError),
     #[error("Error parsing '{url}' as URL: {err}")]
     InvalidUrl { url: String, err: url::ParseError },
+    #[error("incremental artifact key must be 64 lowercase hexadecimal characters")]
+    InvalidIncrementalArtifactKey,
     #[error("Unknown caching status: {0}")]
     UnknownCachingStatus(String, #[backtrace] Backtrace),
     #[error("Unknown status {code}: {message}")]

--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -1809,11 +1809,12 @@ mod test {
 
         let oversized =
             usize::try_from(turborepo_vercel_api_mock::MAX_INCREMENTAL_ARTIFACT_SIZE + 1).unwrap();
+        let oversized_body = Bytes::from(vec![0; oversized]);
         assert!(
             client
                 .put_incremental_artifact(
                     &key,
-                    tokio_stream::once(Ok(Bytes::new())),
+                    tokio_stream::once(Ok(oversized_body)),
                     oversized,
                     &publish_token,
                     None,

--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -121,6 +121,32 @@ pub trait CacheClient {
     ) -> impl Future<Output = Result<CachingStatusResponse>> + Send;
 }
 
+pub trait IncrementalCacheClient {
+    fn fetch_incremental_artifact(
+        &self,
+        key: &str,
+        token: &SecretString,
+        team_id: Option<&str>,
+        team_slug: Option<&str>,
+    ) -> impl Future<Output = Result<Option<Response>>> + Send;
+    fn incremental_artifact_exists(
+        &self,
+        key: &str,
+        token: &SecretString,
+        team_id: Option<&str>,
+        team_slug: Option<&str>,
+    ) -> impl Future<Output = Result<Option<Response>>> + Send;
+    fn put_incremental_artifact(
+        &self,
+        key: &str,
+        artifact_body: impl tokio_stream::Stream<Item = Result<bytes::Bytes>> + Send + Sync + 'static,
+        body_len: usize,
+        publish_token: &SecretString,
+        team_id: Option<&str>,
+        team_slug: Option<&str>,
+    ) -> impl Future<Output = Result<()>> + Send;
+}
+
 pub trait TokenClient {
     fn get_metadata(
         &self,
@@ -463,6 +489,83 @@ impl CacheClient for APIClient {
     }
 }
 
+impl IncrementalCacheClient for APIClient {
+    #[tracing::instrument(skip_all)]
+    async fn fetch_incremental_artifact(
+        &self,
+        key: &str,
+        token: &SecretString,
+        team_id: Option<&str>,
+        team_slug: Option<&str>,
+    ) -> Result<Option<Response>> {
+        self.get_incremental_artifact(key, token, team_id, team_slug, Method::GET)
+            .await
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn incremental_artifact_exists(
+        &self,
+        key: &str,
+        token: &SecretString,
+        team_id: Option<&str>,
+        team_slug: Option<&str>,
+    ) -> Result<Option<Response>> {
+        self.get_incremental_artifact(key, token, team_id, team_slug, Method::HEAD)
+            .await
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn put_incremental_artifact(
+        &self,
+        key: &str,
+        artifact_body: impl tokio_stream::Stream<Item = Result<bytes::Bytes>> + Send + Sync + 'static,
+        body_length: usize,
+        publish_token: &SecretString,
+        team_id: Option<&str>,
+        team_slug: Option<&str>,
+    ) -> Result<()> {
+        Self::validate_incremental_artifact_key(key)?;
+        let mut request_url = self.make_url(&format!("/v8/artifacts/incremental/{key}"))?;
+        let mut allow_auth = true;
+
+        if self.use_preflight {
+            let preflight_response = self
+                .do_preflight(
+                    publish_token,
+                    request_url.clone(),
+                    "PUT",
+                    "Authorization, Content-Length, Content-Type, User-Agent",
+                )
+                .await?;
+            allow_auth = preflight_response.allow_authorization_header;
+            request_url = preflight_response.location;
+        }
+
+        let mut request_builder = self
+            .upload_request(Method::PUT, request_url)
+            .header("Content-Type", "application/octet-stream")
+            .header("Content-Length", body_length)
+            .header("User-Agent", self.user_agent.clone())
+            .body(Body::wrap_stream(artifact_body));
+        if allow_auth {
+            request_builder = request_builder.bearer_auth(publish_token.expose());
+        }
+        let request_builder = Self::add_team_params(request_builder, team_id, team_slug);
+
+        let response =
+            retry::make_retryable_request(request_builder, retry::RetryStrategy::Connection)
+                .await?
+                .into_response();
+
+        if response.status() == StatusCode::FORBIDDEN {
+            return Err(Self::handle_403(response).await);
+        }
+
+        response.error_for_status()?;
+        Ok(())
+    }
+}
+
 #[derive(Deserialize, Debug)]
 struct VercelAppTokenIntrospectionResponse {
     active: bool,
@@ -611,6 +714,62 @@ impl TokenClient for APIClient {
 }
 
 impl APIClient {
+    fn validate_incremental_artifact_key(key: &str) -> Result<()> {
+        if key.len() == 64
+            && key
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            Ok(())
+        } else {
+            Err(Error::InvalidIncrementalArtifactKey)
+        }
+    }
+
+    async fn get_incremental_artifact(
+        &self,
+        key: &str,
+        token: &SecretString,
+        team_id: Option<&str>,
+        team_slug: Option<&str>,
+        method: Method,
+    ) -> Result<Option<Response>> {
+        Self::validate_incremental_artifact_key(key)?;
+        let mut request_url = self.make_url(&format!("/v8/artifacts/incremental/{key}"))?;
+        let mut allow_auth = true;
+
+        if self.use_preflight {
+            let preflight_response = self
+                .do_preflight(
+                    token,
+                    request_url.clone(),
+                    method.as_str(),
+                    "Authorization, User-Agent",
+                )
+                .await?;
+            allow_auth = preflight_response.allow_authorization_header;
+            request_url = preflight_response.location;
+        }
+
+        let mut request_builder = self
+            .api_request(method, request_url)
+            .header("User-Agent", self.user_agent.clone());
+        if allow_auth {
+            request_builder = request_builder.bearer_auth(token.expose());
+        }
+        let request_builder = Self::add_team_params(request_builder, team_id, team_slug);
+
+        let response =
+            retry::make_retryable_request(request_builder, retry::RetryStrategy::Timeout).await?;
+        let response = response.into_response();
+
+        match response.status() {
+            StatusCode::FORBIDDEN => Err(Self::handle_403(response).await),
+            StatusCode::NOT_FOUND => Ok(None),
+            _ => Ok(Some(response.error_for_status()?)),
+        }
+    }
+
     /// Create a new APIClient.
     ///
     /// # Arguments
@@ -1199,8 +1358,8 @@ mod test {
     use url::Url;
 
     use crate::{
-        APIAuth, APIClient, AnonAPIClient, CacheClient, Client, SecretString, TokenClient,
-        telemetry::TelemetryClient,
+        APIAuth, APIClient, AnonAPIClient, CacheClient, Client, IncrementalCacheClient,
+        SecretString, TokenClient, telemetry::TelemetryClient,
     };
 
     #[test]
@@ -1568,6 +1727,134 @@ mod test {
             response.status,
             turborepo_vercel_api::CachingStatus::Enabled
         ));
+        assert_eq!(
+            response
+                .incremental_artifacts_v1()
+                .map(|capability| capability.max_artifact_size),
+            Some(turborepo_vercel_api_mock::MAX_INCREMENTAL_ARTIFACT_SIZE)
+        );
+
+        handle.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_incremental_artifact_protocol() -> Result<()> {
+        let port = port_scanner::request_open_port().unwrap();
+        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+        let handle = tokio::spawn(start_test_server(port, Some(ready_tx)));
+        tokio::time::timeout(Duration::from_secs(5), ready_rx).await??;
+
+        let client = APIClient::new(
+            format!("http://localhost:{port}"),
+            Some(Duration::from_secs(5)),
+            Some(Duration::from_secs(10)),
+            "2.0.0",
+            true,
+        )?;
+        let read_token = SecretString::new(turborepo_vercel_api_mock::EXPECTED_TOKEN.to_string());
+        let publish_token = SecretString::new(
+            turborepo_vercel_api_mock::EXPECTED_INCREMENTAL_PUBLISH_TOKEN.to_string(),
+        );
+        let key = "a".repeat(64);
+        let initial = Bytes::from_static(b"initial incremental artifact");
+
+        client
+            .put_incremental_artifact(
+                &key,
+                tokio_stream::once(Ok(initial.clone())),
+                initial.len(),
+                &publish_token,
+                None,
+                None,
+            )
+            .await?;
+
+        let head = client
+            .incremental_artifact_exists(&key, &read_token, None, None)
+            .await?
+            .expect("uploaded artifact should exist");
+        assert_eq!(
+            head.headers()
+                .get("content-length")
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.parse::<usize>().ok()),
+            Some(initial.len())
+        );
+        assert!(
+            head.headers()
+                .get("content-digest")
+                .and_then(|value| value.to_str().ok())
+                .is_some_and(|value| value.starts_with("sha-256=:"))
+        );
+
+        let replacement = Bytes::from_static(b"replacement incremental artifact");
+        client
+            .put_incremental_artifact(
+                &key,
+                tokio_stream::once(Ok(replacement.clone())),
+                replacement.len(),
+                &publish_token,
+                None,
+                None,
+            )
+            .await?;
+        let fetched = client
+            .fetch_incremental_artifact(&key, &read_token, None, None)
+            .await?
+            .expect("replacement artifact should exist")
+            .bytes()
+            .await?;
+        assert_eq!(fetched, replacement);
+
+        let oversized =
+            usize::try_from(turborepo_vercel_api_mock::MAX_INCREMENTAL_ARTIFACT_SIZE + 1).unwrap();
+        assert!(
+            client
+                .put_incremental_artifact(
+                    &key,
+                    tokio_stream::once(Ok(Bytes::new())),
+                    oversized,
+                    &publish_token,
+                    None,
+                    None,
+                )
+                .await
+                .is_err()
+        );
+        let preserved = client
+            .fetch_incremental_artifact(&key, &read_token, None, None)
+            .await?
+            .expect("failed replacement should preserve the artifact")
+            .bytes()
+            .await?;
+        assert_eq!(preserved, replacement);
+
+        assert!(
+            client
+                .put_incremental_artifact(
+                    &key,
+                    tokio_stream::once(Ok(Bytes::new())),
+                    0,
+                    &read_token,
+                    None,
+                    None,
+                )
+                .await
+                .is_err()
+        );
+        assert!(
+            client
+                .fetch_incremental_artifact(&key, &publish_token, None, None)
+                .await
+                .is_err()
+        );
+        assert!(
+            client
+                .incremental_artifact_exists(&"A".repeat(64), &read_token, None, None)
+                .await
+                .is_err()
+        );
 
         handle.abort();
         Ok(())

--- a/crates/turborepo-auth/src/auth/login.rs
+++ b/crates/turborepo-auth/src/auth/login.rs
@@ -761,6 +761,7 @@ mod tests {
 
             Ok(CachingStatusResponse {
                 status: CachingStatus::Enabled,
+                capabilities: None,
             })
         }
     }

--- a/crates/turborepo-auth/src/lib.rs
+++ b/crates/turborepo-auth/src/lib.rs
@@ -1240,6 +1240,7 @@ mod tests {
                     };
                     Ok(CachingStatusResponse {
                         status: caching_status,
+                        capabilities: None,
                     })
                 }
                 MockCachingResponse::Error(MockErrorType::Error) => {

--- a/crates/turborepo-vercel-api-mock/Cargo.toml
+++ b/crates/turborepo-vercel-api-mock/Cargo.toml
@@ -12,10 +12,12 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 axum = { workspace = true }
+base64 = "0.22"
 futures-util = "0.3.31"
 port_scanner = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 turborepo-vercel-api = { workspace = true }

--- a/crates/turborepo-vercel-api-mock/src/lib.rs
+++ b/crates/turborepo-vercel-api-mock/src/lib.rs
@@ -13,15 +13,20 @@ use axum::{
     response::IntoResponse,
     routing::{get, head, options, post, put},
 };
+use base64::{Engine, engine::general_purpose::STANDARD};
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use tokio::{net::TcpListener, sync::Mutex};
 use turborepo_vercel_api::{
-    AnalyticsEvent, CachingStatus, CachingStatusResponse, Membership, Role, Team, TeamsResponse,
-    User, UserResponse, telemetry::TelemetryEvent,
+    AnalyticsEvent, CachingCapabilities, CachingStatus, CachingStatusResponse,
+    IncrementalArtifactsCapability, Membership, Role, Team, TeamsResponse, User, UserResponse,
+    telemetry::TelemetryEvent,
 };
 
 pub const EXPECTED_TOKEN: &str = "expected_token";
+pub const EXPECTED_INCREMENTAL_PUBLISH_TOKEN: &str = "expected_incremental_publish_token";
+pub const MAX_INCREMENTAL_ARTIFACT_SIZE: u64 = 1024 * 1024;
 pub const EXPECTED_USER_ID: &str = "expected_user_id";
 pub const EXPECTED_USERNAME: &str = "expected_username";
 pub const EXPECTED_EMAIL: &str = "expected_email";
@@ -51,6 +56,41 @@ struct VercelAppTokenRevokeRequest {
 /// Per-artifact SCM metadata: (sha, dirty_hash).
 type ArtifactScmMetadata = HashMap<String, (Option<String>, Option<String>)>;
 
+fn authorized(headers: &HeaderMap, token: &str) -> bool {
+    headers
+        .get("authorization")
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value == format!("Bearer {token}"))
+}
+
+fn valid_incremental_key(key: &str) -> bool {
+    key.len() == 64
+        && key
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn incremental_headers(body: &[u8]) -> Option<HeaderMap> {
+    let mut headers = HeaderMap::new();
+    headers.insert(CONTENT_LENGTH, HeaderValue::from(body.len()));
+    let digest = format!("sha-256=:{}:", STANDARD.encode(Sha256::digest(body)));
+    headers.insert("content-digest", HeaderValue::from_str(&digest).ok()?);
+    Some(headers)
+}
+
+fn forbidden(message: &str) -> axum::response::Response {
+    (
+        StatusCode::FORBIDDEN,
+        Json(serde_json::json!({
+            "error": {
+                "code": "forbidden",
+                "message": message,
+            }
+        })),
+    )
+        .into_response()
+}
+
 pub async fn start_test_server(
     port: u16,
     ready_tx: Option<tokio::sync::oneshot::Sender<()>>,
@@ -69,6 +109,11 @@ pub async fn start_test_server(
     let post_analytics_events_ref = get_analytics_events_ref.clone();
 
     let telemetry_events_ref = Arc::new(Mutex::new(Vec::new()));
+
+    let incremental_artifacts_ref = Arc::new(Mutex::new(HashMap::<String, Vec<u8>>::new()));
+    let get_incremental_artifacts_ref = incremental_artifacts_ref.clone();
+    let head_incremental_artifacts_ref = incremental_artifacts_ref.clone();
+    let put_incremental_artifacts_ref = incremental_artifacts_ref.clone();
 
     let app = Router::new()
         .route(
@@ -114,7 +159,115 @@ pub async fn start_test_server(
             get(|| async {
                 Json(CachingStatusResponse {
                     status: CachingStatus::Enabled,
+                    capabilities: Some(CachingCapabilities {
+                        incremental_artifacts_v1: Some(IncrementalArtifactsCapability {
+                            max_artifact_size: MAX_INCREMENTAL_ARTIFACT_SIZE,
+                        }),
+                    }),
                 })
+            }),
+        )
+        .route(
+            "/v8/artifacts/incremental/{key}",
+            options(|| async {
+                let mut headers = HeaderMap::new();
+                headers.insert(
+                    "Access-Control-Allow-Headers",
+                    HeaderValue::from_static(
+                        "Authorization, Content-Length, Content-Type, User-Agent",
+                    ),
+                );
+                headers
+            }),
+        )
+        .route(
+            "/v8/artifacts/incremental/{key}",
+            put(
+                |Path(key): Path<String>, headers: HeaderMap, body: Body| async move {
+                    if !authorized(&headers, EXPECTED_INCREMENTAL_PUBLISH_TOKEN) {
+                        return forbidden("token cannot publish incremental artifacts");
+                    }
+                    if !valid_incremental_key(&key) {
+                        return StatusCode::BAD_REQUEST.into_response();
+                    }
+                    let Some(content_length) = headers
+                        .get(CONTENT_LENGTH)
+                        .and_then(|value| value.to_str().ok())
+                        .and_then(|value| value.parse::<u64>().ok())
+                    else {
+                        return StatusCode::BAD_REQUEST.into_response();
+                    };
+                    if content_length > MAX_INCREMENTAL_ARTIFACT_SIZE {
+                        return StatusCode::PAYLOAD_TOO_LARGE.into_response();
+                    }
+
+                    let mut artifact = Vec::with_capacity(content_length as usize);
+                    let mut body_stream = body.into_data_stream();
+                    while let Some(chunk) = body_stream.next().await {
+                        let Ok(chunk) = chunk else {
+                            return StatusCode::BAD_REQUEST.into_response();
+                        };
+                        artifact.extend_from_slice(&chunk);
+                        if artifact.len() as u64 > MAX_INCREMENTAL_ARTIFACT_SIZE {
+                            return StatusCode::PAYLOAD_TOO_LARGE.into_response();
+                        }
+                    }
+                    if artifact.len() as u64 != content_length {
+                        return StatusCode::BAD_REQUEST.into_response();
+                    }
+
+                    put_incremental_artifacts_ref
+                        .lock()
+                        .await
+                        .insert(key, artifact);
+                    StatusCode::CREATED.into_response()
+                },
+            ),
+        )
+        .route(
+            "/v8/artifacts/incremental/{key}",
+            get(|Path(key): Path<String>, headers: HeaderMap| async move {
+                if !authorized(&headers, EXPECTED_TOKEN) {
+                    return forbidden("token cannot read incremental artifacts");
+                }
+                if !valid_incremental_key(&key) {
+                    return StatusCode::BAD_REQUEST.into_response();
+                }
+                let Some(artifact) = get_incremental_artifacts_ref
+                    .lock()
+                    .await
+                    .get(&key)
+                    .cloned()
+                else {
+                    return StatusCode::NOT_FOUND.into_response();
+                };
+                let Some(headers) = incremental_headers(&artifact) else {
+                    return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+                };
+                (StatusCode::OK, headers, artifact).into_response()
+            }),
+        )
+        .route(
+            "/v8/artifacts/incremental/{key}",
+            head(|Path(key): Path<String>, headers: HeaderMap| async move {
+                if !authorized(&headers, EXPECTED_TOKEN) {
+                    return forbidden("token cannot read incremental artifacts");
+                }
+                if !valid_incremental_key(&key) {
+                    return StatusCode::BAD_REQUEST.into_response();
+                }
+                let Some(artifact) = head_incremental_artifacts_ref
+                    .lock()
+                    .await
+                    .get(&key)
+                    .cloned()
+                else {
+                    return StatusCode::NOT_FOUND.into_response();
+                };
+                let Some(headers) = incremental_headers(&artifact) else {
+                    return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+                };
+                (StatusCode::OK, headers).into_response()
             }),
         )
         .route(

--- a/crates/turborepo-vercel-api/src/lib.rs
+++ b/crates/turborepo-vercel-api/src/lib.rs
@@ -32,6 +32,33 @@ pub enum CachingStatus {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CachingStatusResponse {
     pub status: CachingStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<CachingCapabilities>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CachingCapabilities {
+    #[serde(
+        rename = "incremental-artifacts-v1",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub incremental_artifacts_v1: Option<IncrementalArtifactsCapability>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IncrementalArtifactsCapability {
+    pub max_artifact_size: u64,
+}
+
+impl CachingStatusResponse {
+    pub fn incremental_artifacts_v1(&self) -> Option<&IncrementalArtifactsCapability> {
+        self.capabilities
+            .as_ref()?
+            .incremental_artifacts_v1
+            .as_ref()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -154,6 +181,29 @@ mod tests {
     use turborepo_types::SecretString;
 
     use crate::{AnalyticsEvent, CacheEvent, CacheSource, VerificationResponse, VerifiedSsoUser};
+
+    #[test]
+    fn status_without_capabilities_remains_compatible() {
+        let status: crate::CachingStatusResponse =
+            serde_json::from_str(r#"{"status":"enabled"}"#).unwrap();
+
+        assert!(status.incremental_artifacts_v1().is_none());
+    }
+
+    #[test]
+    fn status_exposes_incremental_artifact_limit() {
+        let status: crate::CachingStatusResponse = serde_json::from_str(
+            r#"{"status":"enabled","capabilities":{"incremental-artifacts-v1":{"maxArtifactSize":1048576}}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            status
+                .incremental_artifacts_v1()
+                .map(|capability| capability.max_artifact_size),
+            Some(1_048_576)
+        );
+    }
 
     #[test]
     fn verified_sso_user_debug_redacts_token() {


### PR DESCRIPTION
## Why

Remote Cache providers need a portable, optional contract for storing reusable incremental build state independently from exact task artifacts. Establishing the client contract and conformance mock first lets provider and runtime work proceed.

## What

Adds `incremental-artifacts-v1` capability negotiation and client operations for monolithic incremental artifacts. The conformance mock covers strict compatibility keys, maximum object size, SHA-256 content digests, atomic replacement, preflight behavior, and independent read/publish authorization. Endpoint documentation remains intentionally deferred.

## How

Validated with:

- `cargo test -p turborepo-vercel-api -p turborepo-api-client`
- `cargo check -p turborepo-auth`
- `cargo clippy -p turborepo-vercel-api -p turborepo-vercel-api-mock -p turborepo-api-client --all-targets -- -D warnings`

Reviewers can exercise the complete protocol flow through `test_incremental_artifact_protocol`.