### PR TITLE
fix: Allow outputs outside package roots

### DIFF
--- a/crates/turborepo-run-cache/src/incremental.rs
+++ b/crates/turborepo-run-cache/src/incremental.rs
@@ -823,11 +823,37 @@ mod tests {
     }
 
     #[test]
+    fn collect_partition_files_allows_paths_outside_package() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_path = tmp.path().join("repo");
+        let pkg_path = repo_path.join("packages/pkg");
+        let shared_path = repo_path.join("packages/shared");
+        std::fs::create_dir_all(&pkg_path).unwrap();
+        std::fs::create_dir_all(&shared_path).unwrap();
+        std::fs::write(shared_path.join("output.txt"), b"output").unwrap();
+
+        let repo = AbsoluteSystemPathBuf::try_from(repo_path.to_str().unwrap()).unwrap();
+        let pkg_dir = AbsoluteSystemPathBuf::try_from(pkg_path.to_str().unwrap()).unwrap();
+        let outputs = TaskOutputs {
+            inclusions: vec!["../shared/**".into()],
+            exclusions: vec![],
+        };
+
+        let files = collect_partition_files(&repo, &pkg_dir, &outputs).unwrap();
+        let expected = AnchoredSystemPathBuf::from_raw(format!(
+            "packages{}shared{}output.txt",
+            std::path::MAIN_SEPARATOR_STR,
+            std::path::MAIN_SEPARATOR_STR
+        ))
+        .unwrap();
+
+        assert!(files.contains(&expected));
+    }
+
+    #[test]
     fn collect_partition_files_paths_resolve_to_package_dir() {
-        // Verifies the critical invariant: repo-relative paths from
-        // collect_partition_files, when joined with repo_root, point to
-        // files inside the package directory. This is what makes cache
-        // extraction (anchored at repo_root) restore files to the right place.
+        // Cache entries are repo-relative so extraction restores files to their
+        // original locations.
         let tmp = tempfile::tempdir().unwrap();
         let repo = AbsoluteSystemPathBuf::try_from(tmp.path().to_str().unwrap()).unwrap();
 

--- a/crates/turborepo-run-cache/src/lib.rs
+++ b/crates/turborepo-run-cache/src/lib.rs
@@ -1484,6 +1484,33 @@ mod test {
     }
 
     #[tokio::test]
+    async fn save_outputs_allows_glob_that_escapes_package_root() {
+        let temp = tempdir().unwrap();
+        let repo_dir = temp.path().join("repo");
+        std::fs::create_dir_all(repo_dir.join("packages/pkg")).unwrap();
+        std::fs::create_dir_all(repo_dir.join("packages/shared")).unwrap();
+        std::fs::write(repo_dir.join("packages/shared/output.txt"), b"output").unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(repo_dir.as_path()).unwrap();
+        let mut task_cache =
+            task_cache_for_outputs(&repo_root, vec!["packages/pkg/../shared/**".to_string()]);
+        let telemetry = PackageTaskEventBuilder::new("pkg", "build");
+
+        task_cache
+            .save_outputs(Duration::from_millis(10), &telemetry)
+            .await
+            .unwrap();
+
+        let expected = AnchoredSystemPathBuf::from_raw(format!(
+            "packages{}shared{}output.txt",
+            std::path::MAIN_SEPARATOR_STR,
+            std::path::MAIN_SEPARATOR_STR
+        ))
+        .unwrap();
+
+        assert!(task_cache.expanded_outputs().contains(&expected));
+    }
+
+    #[tokio::test]
     async fn save_outputs_rejects_glob_that_escapes_repo_root() {
         let temp = tempdir().unwrap();
         let repo_dir = temp.path().join("repo");

--- a/crates/turborepo-turbo-json/src/error.rs
+++ b/crates/turborepo-turbo-json/src/error.rs
@@ -214,15 +214,6 @@ pub enum Error {
         text: NamedSource<String>,
     },
 
-    #[error("`outputs` cannot contain path traversal.")]
-    #[diagnostic(help("Use `$TURBO_ROOT$` to declare outputs relative to the repository root."))]
-    OutputPathTraversal {
-        #[label("path traversal found here")]
-        span: Option<SourceSpan>,
-        #[source_code]
-        text: NamedSource<String>,
-    },
-
     #[error("found absolute path in `cacheDir`")]
     #[diagnostic(help("If absolute paths are required, use `--cache-dir` or `TURBO_CACHE_DIR`."))]
     AbsoluteCacheDir {

--- a/crates/turborepo-turbo-json/src/lib.rs
+++ b/crates/turborepo-turbo-json/src/lib.rs
@@ -922,6 +922,14 @@ mod tests {
         }
         ; "with .next (windows)"
     )]
+    #[test_case(
+        r#"["../shared/**", "!../shared/cache/**"]"#,
+        TaskOutputs {
+            inclusions: vec!["../shared/**".to_string()],
+            exclusions: vec!["../shared/cache/**".to_string()]
+        }
+        ; "outside package"
+    )]
     fn test_deserialize_task_outputs(
         task_outputs_str: &str,
         expected_task_outputs: TaskOutputs,

--- a/crates/turborepo-turbo-json/src/processed.rs
+++ b/crates/turborepo-turbo-json/src/processed.rs
@@ -24,10 +24,6 @@ const TURBO_EXTENDS: &str = "$TURBO_EXTENDS$";
 const ENV_PIPELINE_DELIMITER: &str = "$";
 const TOPOLOGICAL_PIPELINE_DELIMITER: &str = "^";
 
-fn contains_parent_dir_segment(glob: &str) -> bool {
-    glob.split('/').any(|segment| segment == "..")
-}
-
 /// Helper function to check for and remove $TURBO_EXTENDS$ from an array
 /// Returns (processed_array, extends_found)
 fn extract_turbo_extends(
@@ -114,14 +110,7 @@ impl ProcessedGlob {
 
     /// Creates a ProcessedGlob for outputs (validates as output field)
     pub fn from_spanned_output(value: Spanned<UnescapedString>) -> Result<Self, Error> {
-        let source = value.clone();
-        let glob = Self::from_spanned_internal(value, "outputs")?;
-        if contains_parent_dir_segment(&glob.glob) {
-            let (span, text) = source.span_and_text("turbo.json");
-            return Err(Error::OutputPathTraversal { span, text });
-        }
-
-        Ok(glob)
+        Self::from_spanned_internal(value, "outputs")
     }
 
     /// Creates a ProcessedGlob for inputs (validates as input field)
@@ -1104,42 +1093,9 @@ mod tests {
     #[test_case("./../../target.txt" ; "leading current directory")]
     #[test_case("!../../target.txt" ; "negated traversal")]
     #[test_case("../../{file1,file2,fileN}" ; "brace expansion")]
-    fn test_processed_outputs_reject_parent_directory_segments(input: &str) {
-        let result = ProcessedGlob::from_spanned_output(
-            Spanned::new(UnescapedString::from(input.to_string()))
-                .with_path(Arc::from("turbo.json"))
-                .with_text(format!("\"{}\"", input))
-                .with_range(1..input.len() + 1),
-        );
-
-        assert_matches!(result, Err(Error::OutputPathTraversal { .. }));
-    }
-
-    // No literal `..` segment (no shell/URL/unicode decoding happens before
-    // globbing), so these inert literals must not be rejected as traversal.
-    #[test_case("%2e%2e/target.txt" ; "url encoded dots")]
-    #[test_case("．．/target.txt" ; "full width dots")]
-    #[test_case("..\\target.txt" ; "windows backslash")]
-    #[test_case("~/target.txt" ; "leading tilde")]
-    #[test_case("dist/**" ; "ordinary glob")]
-    fn test_processed_outputs_allow_dotdot_lookalikes(input: &str) {
-        let result = ProcessedGlob::from_spanned_output(
-            Spanned::new(UnescapedString::from(input.to_string()))
-                .with_path(Arc::from("turbo.json"))
-                .with_text(format!("\"{}\"", input))
-                .with_range(1..input.len() + 1),
-        );
-
-        assert!(
-            !matches!(result, Err(Error::OutputPathTraversal { .. })),
-            "{input} should not be rejected as path traversal"
-        );
-    }
-
-    #[test]
-    fn test_processed_outputs_allow_turbo_root() {
+    fn test_processed_outputs_allow_parent_directory_segments(input: &str) {
         let result = ProcessedGlob::from_spanned_output(Spanned::new(UnescapedString::from(
-            "$TURBO_ROOT$/README.md",
+            input.to_string(),
         )));
 
         assert!(result.is_ok());
@@ -1161,7 +1117,7 @@ mod tests {
     }
 
     #[test]
-    fn test_incremental_outputs_reject_parent_directory_segments() {
+    fn test_incremental_outputs_allow_parent_directory_segments() {
         let raw_task = RawTaskDefinition {
             incremental: Some(vec![crate::raw::RawIncrementalPartition {
                 outputs: Some(vec![Spanned::new(UnescapedString::from("../target.txt"))]),
@@ -1172,13 +1128,11 @@ mod tests {
 
         let result = ProcessedTaskDefinition::from_raw(raw_task, &FutureFlags::default());
 
-        assert_matches!(result, Err(Error::OutputPathTraversal { .. }));
+        assert!(result.is_ok());
     }
 
-    // Negated incremental outputs share the same `from_spanned_output` path
-    // (`!` stripped before the segment check), so traversal is still rejected.
     #[test]
-    fn test_incremental_negated_outputs_reject_parent_directory_segments() {
+    fn test_incremental_negated_outputs_allow_parent_directory_segments() {
         let raw_task = RawTaskDefinition {
             incremental: Some(vec![crate::raw::RawIncrementalPartition {
                 outputs: Some(vec![
@@ -1192,7 +1146,7 @@ mod tests {
 
         let result = ProcessedTaskDefinition::from_raw(raw_task, &FutureFlags::default());
 
-        assert_matches!(result, Err(Error::OutputPathTraversal { .. }));
+        assert!(result.is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Why

PR #13290 treated package boundaries as a trust boundary and rejected intentional `..` output paths. Users are trusted within their repository; only paths resolving outside the repository root must be blocked.

## What

Restore support for package-relative output traversal while retaining repository-root and symlink escape protections.

## How

Remove context-free traversal rejection during `turbo.json` processing and cover normal and incremental cache collection across package boundaries.

Verified with:

- `cargo test -p turborepo-turbo-json`
- `cargo test -p turborepo-run-cache`
- `cargo clippy -p turborepo-turbo-json -p turborepo-run-cache --tests -- -D warnings`