### PR TITLE
test: Send complete oversized artifact body

### DIFF
--- a/crates/turborepo-api-client/src/lib.rs
+++ b/crates/turborepo-api-client/src/lib.rs
@@ -1809,11 +1809,12 @@ mod test {
 
         let oversized =
             usize::try_from(turborepo_vercel_api_mock::MAX_INCREMENTAL_ARTIFACT_SIZE + 1).unwrap();
+        let oversized_body = Bytes::from(vec![0; oversized]);
         assert!(
             client
                 .put_incremental_artifact(
                     &key,
-                    tokio_stream::once(Ok(Bytes::new())),
+                    tokio_stream::once(Ok(oversized_body)),
                     oversized,
                     &publish_token,
                     None,


### PR DESCRIPTION
## Why
The incremental artifact protocol test declared an oversized `Content-Length` while streaming an empty body. That malformed request can leave the Windows HTTP transport waiting indefinitely and consume the entire CI timeout.

## What
Make the oversized request well-formed while preserving the payload-size rejection coverage.

## How
Verified with `cargo nextest run -p turborepo-api-client test_incremental_artifact_protocol`.