### PR TITLE
fix: Hash Cargo build environment inputs

### DIFF
--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -390,15 +390,92 @@ pub fn pass_through_uses_separator(subcommand: &str) -> bool {
     matches!(subcommand, "test" | "bench" | "run" | "clippy")
 }
 
-/// Environment variables that change what Cargo builds or where it writes
-/// artifacts. These participate in a crate task's hash so flipping them
-/// invalidates the cache. `RUSTC_WRAPPER` is included so enabling a compile
-/// cache like sccache invalidates prior task results.
+/// Standard Cargo and cc-rs environment variables that can change build
+/// outputs or select the tools that produce them. Patterns cover Cargo's
+/// profile/target configuration and cc-rs's target-qualified forms without
+/// pulling unrelated Cargo credentials or network settings into task hashes.
+/// Build-script-specific variables remain explicit task config.
 pub const HASHED_ENV_VARS: &[&str] = &[
-    "RUSTFLAGS",
+    // Compiler and rustdoc selection and flags.
+    "RUSTC",
     "RUSTC_WRAPPER",
+    "RUSTC_WORKSPACE_WRAPPER",
+    "RUSTC_BOOTSTRAP",
+    "RUSTFLAGS",
+    "CARGO_ENCODED_RUSTFLAGS",
+    "RUSTDOC",
+    "RUSTDOCFLAGS",
+    "CARGO_ENCODED_RUSTDOCFLAGS",
+    // Environment equivalents of Cargo's [build] configuration.
     "CARGO_TARGET_DIR",
+    "CARGO_BUILD_TARGET_DIR",
+    "CARGO_BUILD_BUILD_DIR",
     "CARGO_BUILD_TARGET",
+    "CARGO_BUILD_RUSTC",
+    "CARGO_BUILD_RUSTC_WRAPPER",
+    "CARGO_BUILD_RUSTC_WORKSPACE_WRAPPER",
+    "CARGO_BUILD_RUSTDOC",
+    "CARGO_BUILD_RUSTFLAGS",
+    "CARGO_BUILD_RUSTDOCFLAGS",
+    "CARGO_INCREMENTAL",
+    "CARGO_BUILD_INCREMENTAL",
+    // Cargo normalizes profile names and target triples into these families.
+    "CARGO_PROFILE_*",
+    "CARGO_TARGET_*",
+    // Native toolchain variables recognized by cc-rs. `VAR_*` covers both
+    // raw and underscore-normalized target suffixes.
+    "CC",
+    "CC_*",
+    "HOST_CC",
+    "TARGET_CC",
+    "CFLAGS",
+    "CFLAGS_*",
+    "HOST_CFLAGS",
+    "TARGET_CFLAGS",
+    "CXX",
+    "CXX_*",
+    "HOST_CXX",
+    "TARGET_CXX",
+    "CXXFLAGS",
+    "CXXFLAGS_*",
+    "HOST_CXXFLAGS",
+    "TARGET_CXXFLAGS",
+    "CXXSTDLIB",
+    "CXXSTDLIB_*",
+    "HOST_CXXSTDLIB",
+    "TARGET_CXXSTDLIB",
+    "AR",
+    "AR_*",
+    "HOST_AR",
+    "TARGET_AR",
+    "ARFLAGS",
+    "ARFLAGS_*",
+    "HOST_ARFLAGS",
+    "TARGET_ARFLAGS",
+    "RANLIB",
+    "RANLIB_*",
+    "HOST_RANLIB",
+    "TARGET_RANLIB",
+    "RANLIBFLAGS",
+    "RANLIBFLAGS_*",
+    "HOST_RANLIBFLAGS",
+    "TARGET_RANLIBFLAGS",
+    "NVCC",
+    "NVCC_*",
+    "HOST_NVCC",
+    "TARGET_NVCC",
+    "CRATE_CC_NO_DEFAULTS",
+    "CROSS_COMPILE",
+    // SDK selection is consumed directly by cc-rs on these platforms.
+    "SDKROOT",
+    "MACOSX_DEPLOYMENT_TARGET",
+    "IPHONEOS_DEPLOYMENT_TARGET",
+    "WATCHOS_DEPLOYMENT_TARGET",
+    "TVOS_DEPLOYMENT_TARGET",
+    "XROS_DEPLOYMENT_TARGET",
+    "WASI_SDK_PATH",
+    "WASI_SYSROOT",
+    "WASM_MUSL_SYSROOT",
 ];
 
 /// Rewrite the workspace root Cargo.toml for a pruned repository containing
@@ -2482,6 +2559,11 @@ release: 1.96.0-nightly\n",
         );
         assert_eq!(io.package_default_inputs, Some(true));
         assert!(io.env.contains(&"RUSTC_WRAPPER".to_string()));
+        assert!(io.env.contains(&"CARGO_ENCODED_RUSTFLAGS".to_string()));
+        assert!(io.env.contains(&"CARGO_PROFILE_*".to_string()));
+        assert!(io.env.contains(&"CARGO_TARGET_*".to_string()));
+        assert!(io.env.contains(&"CC_*".to_string()));
+        assert!(io.env.contains(&"TARGET_CFLAGS".to_string()));
         assert!(
             io.output_globs.contains(&"../../target/*/app".to_string()),
             "bin deliverable is cached with a wildcard profile, got {:?}",

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -212,9 +212,12 @@ whether anything changed; Cargo decides how and in what order to build.**
   their own sources plus their transitive dependency crates' sources
   (flattened, so invalidation doesn't depend on `dependsOn` wiring), the
   workspace files (root `Cargo.toml`, `.cargo/config*`, `rust-toolchain*`),
-  and cargo-relevant env vars (`RUSTFLAGS`, `RUSTC_WRAPPER`,
-  `CARGO_TARGET_DIR`, `CARGO_BUILD_TARGET`). The workspace package hashes
-  all crate directories instead of default-hashing the repo root.
+  and standard Cargo/cc-rs environment inputs: compiler and rustdoc selection
+  and flags, Cargo build/profile/target configuration, native compiler and
+  archiver settings (including target-qualified forms), and platform SDK
+  selection. Arbitrary variables consumed by project-specific build scripts
+  remain explicit task `env` configuration. The workspace package hashes all
+  crate directories instead of default-hashing the repo root.
   `$TURBO_DEFAULT$` in a Cargo task's `inputs` means "everything turbo
   derives automatically", so extra inputs (e.g. a file embedded via
   `include_str!` from outside any crate directory) are additive.

--- a/crates/turborepo/tests/cargo_workspace_test.rs
+++ b/crates/turborepo/tests/cargo_workspace_test.rs
@@ -12,7 +12,20 @@ mod common;
 
 use std::{fs, path::Path};
 
-use common::{run_turbo, setup};
+use common::{run_turbo, run_turbo_with_env, setup};
+
+fn cargo_build_hash(dir: &Path, env: &[(&str, &str)]) -> String {
+    let output = run_turbo_with_env(dir, &["build", "--filter=app", "--dry-run=json"], env);
+    assert!(output.status.success(), "dry-run failed: {output:?}");
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("dry-run emits JSON");
+    json["tasks"]
+        .as_array()
+        .and_then(|tasks| tasks.iter().find(|task| task["taskId"] == "app#build"))
+        .and_then(|task| task["hash"].as_str())
+        .expect("app#build has a hash")
+        .to_string()
+}
 
 fn setup_cargo_monorepo(dir: &Path) {
     setup::setup_integration_test(dir, "cargo_monorepo", "npm@10.5.0", false).unwrap();
@@ -68,6 +81,34 @@ fn test_cargo_packages_in_task_graph() {
     assert!(
         outputs.iter().any(|o| o.ends_with("target/*/app")),
         "bin deliverable must be an output, got {outputs:?}"
+    );
+}
+
+#[test]
+fn test_cargo_semantic_environment_changes_task_hash() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_cargo_monorepo(tempdir.path());
+
+    let baseline = cargo_build_hash(tempdir.path(), &[]);
+    for (name, value) in [
+        ("CARGO_ENCODED_RUSTFLAGS", "--cfg\x1fturbo_env_hash_test"),
+        ("RUSTDOCFLAGS", "--cfg turbo_env_hash_test"),
+        ("CARGO_PROFILE_DEV_LTO", "true"),
+        ("CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER", "clang"),
+        ("CC_aarch64_unknown_linux_gnu", "clang"),
+        ("TARGET_CFLAGS", "-DTURBO_ENV_HASH_TEST"),
+        ("CROSS_COMPILE", "aarch64-linux-gnu-"),
+        ("WASI_SYSROOT", "/opt/wasi-sysroot"),
+        ("WASM_MUSL_SYSROOT", "/opt/wasm-musl-sysroot"),
+    ] {
+        let hash = cargo_build_hash(tempdir.path(), &[(name, value)]);
+        assert_ne!(hash, baseline, "{name} must participate in the task hash");
+    }
+
+    let network_only = cargo_build_hash(tempdir.path(), &[("CARGO_HTTP_TIMEOUT", "120")]);
+    assert_eq!(
+        network_only, baseline,
+        "Cargo network settings must not invalidate build outputs"
     );
 }
 


### PR DESCRIPTION
## Why
Cargo and common Rust build scripts consume environment variables that can change compiler selection, profiles, target configuration, native toolchains, and final artifacts. Omitting those inputs allowed different builds to share a Turborepo task hash.

## What
Cargo tasks now derive hashes from standard Cargo compiler/build/profile/target variables and cc-rs compiler, archiver, sysroot, and SDK settings. Unrelated Cargo network and credential configuration remains excluded, while project-specific build-script variables remain explicit task configuration.

## How
Added end-to-end coverage proving representative exact and wildcard variables change the task hash while a network-only setting does not. Verified 316 repository tests, 15 Cargo E2Es, workspace lint, formatting, pre-push hooks, and independent code/documentation review.