### PR TITLE
fix: Isolate Command Overrides From Toolchain Cache I/O

### DIFF
--- a/crates/turborepo-engine/src/builder/definitions.rs
+++ b/crates/turborepo-engine/src/builder/definitions.rs
@@ -288,7 +288,11 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                 .into_iter()
                 .map(|(definition, _)| definition),
         );
-        if let Some((info, toolchain)) = package_info.zip(toolchain) {
+        // Toolchain defaults describe the command the toolchain synthesizes.
+        // An override owns its behavior, including the generic cache default.
+        if should_apply_toolchain_defaults(command_override.as_ref())
+            && let Some((info, toolchain)) = package_info.zip(toolchain)
+        {
             let defaults = toolchain.task_defaults(info, task_id.as_inner().task());
             if processed_task_definition.cache.is_none() {
                 processed_task_definition.cache = defaults.cache.map(Spanned::new);
@@ -685,6 +689,10 @@ fn resolve_command_override(
     }
 }
 
+fn should_apply_toolchain_defaults(command: Option<&TaskCommandOverride>) -> bool {
+    command.is_none()
+}
+
 /// Native hash wiring describes a toolchain-synthesized command. An argv
 /// override executes arbitrary user-selected work, so only turbo.json can
 /// soundly describe its inputs, outputs, and environment.
@@ -833,6 +841,17 @@ mod command_override_tests {
             resolve_command_override(None, None, Some((&rust_pkg, &rust)), "test"),
             None,
         );
+    }
+
+    #[test]
+    fn only_native_commands_inherit_toolchain_defaults() {
+        assert!(super::should_apply_toolchain_defaults(None));
+        assert!(!super::should_apply_toolchain_defaults(Some(
+            &TaskCommandOverride::Argv(vec!["node".to_string()])
+        )));
+        assert!(!super::should_apply_toolchain_defaults(Some(
+            &TaskCommandOverride::OptOut
+        )));
     }
 
     #[test]

--- a/crates/turborepo-engine/src/builder/definitions.rs
+++ b/crates/turborepo-engine/src/builder/definitions.rs
@@ -330,9 +330,11 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         // the toolchain derives automatically", so explicit `inputs` can
         // append without forfeiting automatic invalidation; explicit inputs
         // without `$TURBO_DEFAULT$` take full control.
-        if let Some((info, toolchain)) = package_info
-            .zip(toolchain)
-            .filter(|(info, toolchain)| toolchain.derives_task_io(info, task_id.as_inner().task()))
+        if inherits_toolchain_task_io(task_def.command.as_ref())
+            && let Some((info, toolchain)) =
+                package_info.zip(toolchain).filter(|(info, toolchain)| {
+                    toolchain.derives_task_io(info, task_id.as_inner().task())
+                })
         {
             let wants_automatic_inputs = !had_explicit_inputs || task_def.inputs.default;
             // Only assembled when the toolchain will actually use it:
@@ -683,6 +685,13 @@ fn resolve_command_override(
     }
 }
 
+/// Native hash wiring describes a toolchain-synthesized command. An argv
+/// override executes arbitrary user-selected work, so only turbo.json can
+/// soundly describe its inputs, outputs, and environment.
+fn inherits_toolchain_task_io(command: Option<&TaskCommandOverride>) -> bool {
+    !matches!(command, Some(TaskCommandOverride::Argv(_)))
+}
+
 #[cfg(test)]
 mod command_override_tests {
     use turborepo_errors::Spanned;
@@ -692,7 +701,7 @@ mod command_override_tests {
     };
     use turborepo_types::TaskCommandOverride;
 
-    use super::{ProcessedCommand, resolve_command_override};
+    use super::{ProcessedCommand, inherits_toolchain_task_io, resolve_command_override};
 
     /// A toolchain stub whose only knob is whether the package authors the
     /// task — the single toolchain property the resolver consults.
@@ -824,5 +833,24 @@ mod command_override_tests {
             resolve_command_override(None, None, Some((&rust_pkg, &rust)), "test"),
             None,
         );
+    }
+
+    #[test]
+    fn synthesized_commands_inherit_toolchain_task_io() {
+        assert!(inherits_toolchain_task_io(None));
+    }
+
+    #[test]
+    fn command_opt_out_preserves_toolchain_task_io() {
+        assert!(inherits_toolchain_task_io(Some(
+            &TaskCommandOverride::OptOut
+        )));
+    }
+
+    #[test]
+    fn argv_override_does_not_inherit_toolchain_task_io() {
+        assert!(!inherits_toolchain_task_io(Some(
+            &TaskCommandOverride::Argv(vec!["node".to_string(), "build.js".to_string(),])
+        )));
     }
 }

--- a/crates/turborepo-task-executor/src/command.rs
+++ b/crates/turborepo-task-executor/src/command.rs
@@ -204,6 +204,10 @@ impl<'a, M: MfeConfigProvider> ToolchainCommandProvider<'a, M> {
     }
 }
 
+fn should_inject_toolchain_compile_cache(command_override: Option<&TaskCommandOverride>) -> bool {
+    command_override.is_none()
+}
+
 impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
     for ToolchainCommandProvider<'a, M>
 {
@@ -226,7 +230,8 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
         // directions: an opt-out is an explicit no-op (same outcome as a
         // missing script), and an argv replaces the toolchain's own
         // resolution while the toolchain keeps framing it.
-        let override_command = match self.command_overrides.get(task_id) {
+        let command_override = self.command_overrides.get(task_id);
+        let override_command = match command_override {
             Some(TaskCommandOverride::OptOut) => return Ok(None),
             Some(TaskCommandOverride::Argv(argv)) => Some(argv.as_slice()),
             None => None,
@@ -283,7 +288,9 @@ impl<'a, M: MfeConfigProvider, E: From<CommandProviderError>> CommandProvider<E>
         // environment (competing configuration suppresses it, ambient
         // settings are tolerated) and returns exactly what to inject; see
         // `Toolchain::compile_cache_env`.
-        if let Some(endpoint) = self.compile_cache {
+        if should_inject_toolchain_compile_cache(command_override)
+            && let Some(endpoint) = self.compile_cache
+        {
             let vars = toolchain.compile_cache_env(endpoint, environment);
             if vars.is_empty() {
                 debug!("no compile cache env to inject for {task_id}");
@@ -536,6 +543,17 @@ mod tests {
         fn config_filename(&self, package_name: &str) -> Option<String> {
             (package_name == "web").then(|| "web/microfrontends.json".to_owned())
         }
+    }
+
+    #[test]
+    fn command_override_suppresses_toolchain_compile_cache() {
+        assert!(should_inject_toolchain_compile_cache(None));
+        assert!(!should_inject_toolchain_compile_cache(Some(
+            &TaskCommandOverride::Argv(vec!["node".to_string()])
+        )));
+        assert!(!should_inject_toolchain_compile_cache(Some(
+            &TaskCommandOverride::OptOut
+        )));
     }
 
     fn create_test_repo() -> (TempDir, AbsoluteSystemPathBuf, PathBuf) {

--- a/crates/turborepo-types/src/lib.rs
+++ b/crates/turborepo-types/src/lib.rs
@@ -956,16 +956,15 @@ pub struct TaskDefinition {
 }
 
 /// A task's resolved `command` override.
-///
-/// Replaces the process argv the toolchain would have constructed. The
-/// toolchain still owns the frame: working directory, serial grouping,
-/// hash wiring, and env composition.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TaskCommandOverride {
     /// Explicitly no command: the task is a no-op for this package.
     OptOut,
-    /// The argv to execute: program first, arguments after. Executed
-    /// directly — no shell.
+    /// Replaces the process argv the toolchain would have constructed: program
+    /// first, arguments after, executed directly with no shell. The toolchain
+    /// still owns the working directory and serial grouping, but its derived
+    /// inputs, outputs, and hash environment do not apply; turbo.json is
+    /// authoritative for the arbitrary command's task-level hash wiring.
     Argv(Vec<String>),
 }
 

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -372,7 +372,9 @@ The core task graph consists of:
   Because an argv override is otherwise arbitrary, it does not inherit the
   native command's toolchain-derived inputs, outputs, default-input behavior,
   or hash environment; its turbo.json `inputs`, `outputs`, and `env` are the
-  authoritative task-level I/O configuration.
+  authoritative task-level I/O configuration. Toolchain task defaults and
+  execution-only compile-cache environment injection likewise apply only to
+  native toolchain-resolved commands.
 
 #### Engine Execution (`crates/turborepo-lib/src/engine/execute.rs`)
 

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -369,6 +369,10 @@ The core task graph consists of:
   (`TaskHashable.commandOverride`/`commandOptOut`). Toolchains place the
   argv in their frame: cwd is the package directory, nothing is prepended,
   and Cargo keeps its serial group when the override still invokes cargo.
+  Because an argv override is otherwise arbitrary, it does not inherit the
+  native command's toolchain-derived inputs, outputs, default-input behavior,
+  or hash environment; its turbo.json `inputs`, `outputs`, and `env` are the
+  authoritative task-level I/O configuration.
 
 #### Engine Execution (`crates/turborepo-lib/src/engine/execute.rs`)
 

--- a/crates/turborepo/tests/cargo_workspace_test.rs
+++ b/crates/turborepo/tests/cargo_workspace_test.rs
@@ -230,6 +230,90 @@ fn test_cargo_build_executes_caches_and_restores() {
 }
 
 #[test]
+fn test_cargo_command_override_uses_only_configured_io() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_cargo_monorepo(tempdir.path());
+    fs::write(
+        tempdir.path().join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": {
+    "experimentalCargoWorkspaces": true,
+    "experimentalTaskCommand": true
+  },
+  "tasks": {
+    "app#build": {
+      "command": [
+        "node",
+        "-e",
+        "require('fs').writeFileSync('custom-output.txt', process.env.OVERRIDE_ENV)"
+      ],
+      "inputs": ["Cargo.toml"],
+      "outputs": ["custom-output.txt"],
+      "env": ["OVERRIDE_ENV"]
+    }
+  }
+}"#,
+    )
+    .unwrap();
+
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "build", "--filter=app", "--dry-run=json"],
+    );
+    assert!(output.status.success(), "dry-run failed: {output:?}");
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("dry-run emits JSON");
+    let build = json["tasks"]
+        .as_array()
+        .and_then(|tasks| tasks.iter().find(|task| task["taskId"] == "app#build"))
+        .expect("app#build in graph");
+    let definition = &build["resolvedTaskDefinition"];
+    assert_eq!(definition["inputs"], serde_json::json!(["Cargo.toml"]));
+    assert_eq!(
+        definition["outputs"],
+        serde_json::json!(["custom-output.txt"])
+    );
+    assert_eq!(definition["env"], serde_json::json!(["OVERRIDE_ENV"]));
+
+    // A stale Cargo deliverable present on the override's cache miss must not
+    // become one of that arbitrary command's cached outputs.
+    let bin = tempdir
+        .path()
+        .join("target")
+        .join("debug")
+        .join(if cfg!(windows) { "app.exe" } else { "app" });
+    fs::create_dir_all(bin.parent().unwrap()).unwrap();
+    fs::write(&bin, "stale cargo deliverable").unwrap();
+
+    let run = || {
+        let mut command = std::process::Command::new(env!("CARGO_BIN_EXE_turbo"));
+        command
+            .args(["run", "build", "--filter=app", "--log-order", "grouped"])
+            .env("OVERRIDE_ENV", "configured")
+            .current_dir(tempdir.path())
+            .output()
+            .expect("turbo runs")
+    };
+    let output = run();
+    assert!(output.status.success(), "override failed: {output:?}");
+    let custom_output = tempdir.path().join("crates/app/custom-output.txt");
+    assert_eq!(fs::read_to_string(&custom_output).unwrap(), "configured");
+
+    fs::remove_file(&bin).unwrap();
+    fs::remove_file(&custom_output).unwrap();
+    let output = run();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "cache restore failed: {output:?}");
+    assert!(
+        stdout.contains("FULL TURBO"),
+        "expected cache hit: {stdout}"
+    );
+    assert!(custom_output.exists(), "configured output must be restored");
+    assert!(!bin.exists(), "Cargo deliverable must not be restored");
+}
+
+#[test]
 fn test_cargo_run_and_dev_default_to_uncached() {
     let tempdir = tempfile::tempdir().unwrap();
     setup_cargo_monorepo(tempdir.path());

--- a/crates/turborepo/tests/cargo_workspace_test.rs
+++ b/crates/turborepo/tests/cargo_workspace_test.rs
@@ -391,6 +391,72 @@ fn test_explicit_cache_overrides_cargo_run_default() {
 }
 
 #[test]
+fn test_command_override_uses_generic_cache_default_across_toolchains() {
+    let tempdir = tempfile::tempdir().unwrap();
+    setup_cargo_monorepo(tempdir.path());
+    fs::write(
+        tempdir.path().join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": {
+    "experimentalCargoWorkspaces": true,
+    "experimentalTaskCommand": true
+  },
+  "tasks": {
+    "app#run": { "command": ["node", "-e", "console.log('cargo')"] },
+    "js-pkg#run": { "command": ["node", "-e", "console.log('js')"] },
+    "app#dev": {
+      "command": ["node", "-e", "console.log('explicit')"],
+      "cache": false
+    }
+  }
+}"#,
+    )
+    .unwrap();
+
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "run",
+            "run",
+            "--filter=app",
+            "--filter=js-pkg",
+            "--dry-run=json",
+        ],
+    );
+    assert!(output.status.success(), "run dry-run failed: {output:?}");
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("dry-run emits JSON");
+    let tasks = json["tasks"].as_array().expect("tasks array");
+    for task_id in ["app#run", "js-pkg#run"] {
+        let task = tasks
+            .iter()
+            .find(|task| task["taskId"] == task_id)
+            .unwrap_or_else(|| panic!("{task_id} in graph"));
+        assert_eq!(
+            task["resolvedTaskDefinition"]["cache"], true,
+            "{task_id} should use the generic cache default"
+        );
+    }
+
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "dev", "--filter=app", "--dry-run=json"],
+    );
+    assert!(output.status.success(), "dev dry-run failed: {output:?}");
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("dry-run emits JSON");
+    let dev = json["tasks"]
+        .as_array()
+        .and_then(|tasks| tasks.iter().find(|task| task["taskId"] == "app#dev"))
+        .expect("app#dev in graph");
+    assert_eq!(
+        dev["resolvedTaskDefinition"]["cache"], false,
+        "explicit cache configuration must win"
+    );
+}
+
+#[test]
 fn test_dependency_crate_change_invalidates_entrypoint() {
     let tempdir = tempfile::tempdir().unwrap();
     setup_cargo_monorepo(tempdir.path());


### PR DESCRIPTION
## Why

Authoritative command argv can execute arbitrary work, but Cargo tasks still inherited native Cargo hash inputs and deliverable outputs. Cache hits could therefore restore artifacts the overridden command never produced.

## What

Treat argv overrides as owning their task-level inputs, outputs, and hash environment. Native synthesized commands and command opt-outs retain existing behavior.

## How

Gate toolchain-derived I/O in the engine, cover all override states with focused unit tests, and verify via Cargo E2E that only configured I/O is reported and restored.