### PR TITLE
fix: Isolate Cargo artifact outputs

### DIFF
--- a/crates/turborepo-engine/src/builder.rs
+++ b/crates/turborepo-engine/src/builder.rs
@@ -55,6 +55,10 @@ pub struct EngineBuilder<'a, L: TurboJsonLoader> {
     /// prepended to every task's inputs instead of being included in the
     /// global hash.
     global_deps: Vec<String>,
+    task_args: Vec<String>,
+    /// Only keys explicitly requested by registered toolchains for I/O
+    /// derivation, not the full startup environment.
+    environment: HashMap<String, String>,
 }
 
 impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
@@ -78,6 +82,8 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
             validator: Validator::new(),
             future_flags: FutureFlags::default(),
             global_deps: Vec::new(),
+            task_args: Vec::new(),
+            environment: HashMap::new(),
         }
     }
 
@@ -89,6 +95,16 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
 
     pub fn with_global_deps(mut self, global_deps: Vec<String>) -> Self {
         self.global_deps = global_deps;
+        self
+    }
+
+    pub fn with_task_io_context(
+        mut self,
+        task_args: Vec<String>,
+        environment: HashMap<String, String>,
+    ) -> Self {
+        self.task_args = task_args;
+        self.environment = environment;
         self
     }
 

--- a/crates/turborepo-engine/src/builder/definitions.rs
+++ b/crates/turborepo-engine/src/builder/definitions.rs
@@ -299,6 +299,8 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
             }
         }
         let had_explicit_inputs = processed_task_definition.inputs.is_some();
+        let had_explicit_outputs = processed_task_definition.outputs.is_some();
+        let had_explicit_cache = processed_task_definition.cache.is_some();
         let mut task_def =
             TaskDefinition::from_processed(processed_task_definition, &path_to_root)?;
         task_def.command = command_override;
@@ -356,13 +358,23 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                     _ => None,
                 })
                 .collect();
+            let context = turborepo_repository::toolchain::TaskIOContext {
+                task_args: &self.task_args,
+                environment: &self.environment,
+            };
             if let Some(derived) = toolchain.derived_task_io(
                 info,
                 task_id.as_inner().task(),
                 path_to_root.as_str(),
                 &dependencies,
                 wants_automatic_inputs,
+                &context,
             ) {
+                for var in toolchain.task_io_env_vars() {
+                    if !task_def.env.iter().any(|existing| existing == var) {
+                        task_def.env.push((*var).to_string());
+                    }
+                }
                 task_def.inputs.globs.extend(derived.input_globs);
                 if let Some(default) = derived.package_default_inputs {
                     task_def.inputs.default = default;
@@ -373,7 +385,17 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                     }
                 }
                 task_def.env.sort();
-                task_def.outputs.inclusions.extend(derived.output_globs);
+                match derived.outputs {
+                    turborepo_repository::toolchain::DerivedOutputs::Resolved(outputs) => {
+                        task_def.outputs.inclusions.extend(outputs);
+                    }
+                    turborepo_repository::toolchain::DerivedOutputs::Unavailable
+                        if !had_explicit_outputs && !had_explicit_cache =>
+                    {
+                        task_def.cache = false;
+                    }
+                    _ => {}
+                }
             }
         }
 

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -791,6 +791,7 @@ impl RunBuilder {
             &root_turbo_json,
             engine_pkgs,
             &turbo_json_loader,
+            &env_at_execution_start,
         )?;
 
         let task_access = {
@@ -815,6 +816,7 @@ impl RunBuilder {
                 &root_turbo_json,
                 engine_pkgs,
                 &turbo_json_loader,
+                &env_at_execution_start,
             )?;
         }
 
@@ -1072,6 +1074,7 @@ impl RunBuilder {
         root_turbo_json: &TurboJson,
         filtered_pkgs: impl Iterator<Item = &'a PackageName>,
         turbo_json_loader: &impl turborepo_engine::TurboJsonLoader,
+        environment: &EnvironmentVariableMap,
     ) -> Result<Engine, Error> {
         let tasks = self.opts.run_opts.tasks.iter().map(|task| {
             // TODO: Pull span info from command
@@ -1084,6 +1087,13 @@ impl RunBuilder {
         } else {
             Vec::new()
         };
+        let mut task_io_environment = EnvironmentVariableMap::default();
+        for toolchain in pkg_dep_graph.toolchains().iter() {
+            let selected = environment
+                .from_wildcards(toolchain.task_io_env_vars())
+                .map_err(Error::Env)?;
+            task_io_environment.union(&selected);
+        }
         let mut builder = EngineBuilder::new(
             &self.repo_root,
             pkg_dep_graph,
@@ -1095,6 +1105,10 @@ impl RunBuilder {
         .with_workspaces(filtered_pkgs.cloned().collect())
         .with_future_flags(self.opts.future_flags)
         .with_global_deps(global_deps_for_task_inputs)
+        .with_task_io_context(
+            self.opts.run_opts.pass_through_args.clone(),
+            task_io_environment.into_inner(),
+        )
         .with_tasks(tasks);
 
         if self.add_all_tasks {

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -38,7 +38,7 @@ use std::{
 };
 
 use serde::Deserialize;
-use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
+use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
 use turborepo_errors::Spanned;
 
 use crate::{
@@ -131,7 +131,7 @@ pub enum Error {
     InvalidRustcOutput { reason: &'static str },
 }
 
-fn parse_rustc_identity(stdout: &[u8]) -> Result<turborepo_lockfiles::Package, Error> {
+fn parse_rustc_info(stdout: &[u8]) -> Result<(turborepo_lockfiles::Package, String), Error> {
     let stdout = std::str::from_utf8(stdout)?;
     let lines: Vec<&str> = stdout
         .lines()
@@ -150,7 +150,7 @@ fn parse_rustc_identity(stdout: &[u8]) -> Result<turborepo_lockfiles::Package, E
     let mut hosts = lines
         .iter()
         .filter_map(|line| line.strip_prefix("host:").map(str::trim));
-    hosts
+    let host = hosts
         .next()
         .filter(|host| !host.is_empty())
         .ok_or(Error::InvalidRustcOutput {
@@ -162,10 +162,18 @@ fn parse_rustc_identity(stdout: &[u8]) -> Result<turborepo_lockfiles::Package, E
         });
     }
 
-    Ok(turborepo_lockfiles::Package {
-        key: "rustc".to_string(),
-        version: lines.join("\n"),
-    })
+    Ok((
+        turborepo_lockfiles::Package {
+            key: "rustc".to_string(),
+            version: lines.join("\n"),
+        },
+        host.to_string(),
+    ))
+}
+
+#[cfg(test)]
+fn parse_rustc_identity(stdout: &[u8]) -> Result<turborepo_lockfiles::Package, Error> {
+    parse_rustc_info(stdout).map(|(identity, _)| identity)
 }
 
 /// The Rust compiler version and host triple, as a hashable external-dependency
@@ -178,6 +186,12 @@ fn parse_rustc_identity(stdout: &[u8]) -> Result<turborepo_lockfiles::Package, E
 pub fn rustc_identity(
     repo_root: &AbsoluteSystemPath,
 ) -> Result<turborepo_lockfiles::Package, Error> {
+    rustc_info(repo_root).map(|(identity, _)| identity)
+}
+
+fn rustc_info(
+    repo_root: &AbsoluteSystemPath,
+) -> Result<(turborepo_lockfiles::Package, String), Error> {
     let output = std::process::Command::new("rustc")
         .arg("-vV")
         .current_dir(repo_root.as_std_path())
@@ -189,7 +203,19 @@ pub fn rustc_identity(
         });
     }
 
-    parse_rustc_identity(&output.stdout)
+    parse_rustc_info(&output.stdout)
+}
+
+fn rustc_supported_targets(repo_root: &AbsoluteSystemPath) -> HashSet<String> {
+    std::process::Command::new("rustc")
+        .args(["--print", "target-list"])
+        .current_dir(repo_root.as_std_path())
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|stdout| stdout.lines().map(str::to_string).collect())
+        .unwrap_or_default()
 }
 
 /// Per-crate external dependency closures from Cargo.lock, for the crates'
@@ -324,6 +350,7 @@ pub struct CargoPackageDetails {
     /// The crate's deliverable targets (empty for libraries and the
     /// workspace package).
     pub deliverables: Vec<Deliverable>,
+    pub manifest_alters_output_layout: bool,
     /// The crate's directory, repo-root-relative in unix form (empty for
     /// the synthetic workspace package).
     pub dir: String,
@@ -401,14 +428,17 @@ pub const HASHED_ENV_VARS: &[&str] = &[
     "RUSTC_WRAPPER",
     "RUSTC_WORKSPACE_WRAPPER",
     "RUSTC_BOOTSTRAP",
+    "RUSTUP_HOME",
     "RUSTFLAGS",
     "CARGO_ENCODED_RUSTFLAGS",
     "RUSTDOC",
     "RUSTDOCFLAGS",
     "CARGO_ENCODED_RUSTDOCFLAGS",
     // Environment equivalents of Cargo's [build] configuration.
+    "CARGO_HOME",
     "CARGO_TARGET_DIR",
     "CARGO_BUILD_TARGET_DIR",
+    "CARGO_BUILD_ARTIFACT_DIR",
     "CARGO_BUILD_BUILD_DIR",
     "CARGO_BUILD_TARGET",
     "CARGO_BUILD_RUSTC",
@@ -421,6 +451,7 @@ pub const HASHED_ENV_VARS: &[&str] = &[
     "CARGO_BUILD_INCREMENTAL",
     // Cargo normalizes profile names and target triples into these families.
     "CARGO_PROFILE_*",
+    "CARGO_PROFILE_*_DIR_NAME",
     "CARGO_TARGET_*",
     // Native toolchain variables recognized by cc-rs. `VAR_*` covers both
     // raw and underscore-normalized target suffixes.
@@ -476,6 +507,15 @@ pub const HASHED_ENV_VARS: &[&str] = &[
     "WASI_SDK_PATH",
     "WASI_SYSROOT",
     "WASM_MUSL_SYSROOT",
+];
+
+const TASK_IO_ENV_VARS: &[&str] = &[
+    "CARGO_BUILD_TARGET",
+    "CARGO_BUILD_ARTIFACT_DIR",
+    "CARGO_HOME",
+    "CARGO_PROFILE_*_DIR_NAME",
+    "RUSTC",
+    "CARGO_BUILD_RUSTC",
 ];
 
 /// Rewrite the workspace root Cargo.toml for a pruned repository containing
@@ -601,44 +641,306 @@ fn crate_source_globs(prefix: &str, crate_path: &str) -> [String; 2] {
     [format!("{base}/**"), format!("!{base}/.turbo/**")]
 }
 
-/// Output globs for an entrypoint crate's `build` task: the artifacts Cargo
-/// places in `target/<profile>/` — uplifted binaries plus cdylib/staticlib
-/// libraries. These are the workspace's deliverables — the only artifacts
-/// worth caching at the task level. Cargo's internal `target/` state (deps,
-/// fingerprints) is deliberately not cached: it is Cargo's own incremental
-/// cache, and tarballing it fights Cargo instead of leaning on it.
-///
-/// The profile segment is a wildcard, so `--release` and custom profiles
-/// (`--profile=my-profile`) are cached without configuration — pass-through
-/// args participate in the task hash, so each profile gets its own cache
-/// entry. Every platform's file name is emitted for each deliverable
-/// (`.so`, `.dylib`, `.dll`, ...); globs that match nothing contribute
-/// nothing. The compiler host triple in [`rustc_identity`] segments task
-/// hashes by host platform.
-///
-/// Builds using `CARGO_TARGET_DIR` or `--target <triple>` write elsewhere
-/// (`CARGO_TARGET_DIR` and `CARGO_BUILD_TARGET` are hashed, but the
-/// artifact locations differ); declare explicit `outputs` in turbo.json for
-/// those layouts.
-pub fn deliverable_output_globs(prefix: &str, deliverables: &[Deliverable]) -> Vec<String> {
+#[derive(Debug, Clone)]
+struct CargoWorkspaceDetails {
+    target_directory: AbsoluteSystemPathBuf,
+    host_target: String,
+    supported_targets: HashSet<String>,
+    repository_config_selects_target: bool,
+    repository_config_selects_rustc: bool,
+    repository_config_alters_output_layout: bool,
+    repository_config_escapes: bool,
+    external_config_present: bool,
+    manifest_alters_profile_dirs: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CargoTargetPlatform {
+    Unix,
+    Apple,
+    WindowsMsvc,
+    WindowsGnu,
+}
+
+fn target_platform(target: &str) -> Option<CargoTargetPlatform> {
+    if target.is_empty()
+        || !target
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        return None;
+    }
+    let parts: Vec<&str> = target.split('-').collect();
+    if parts.contains(&"windows") {
+        return if parts.contains(&"msvc") {
+            Some(CargoTargetPlatform::WindowsMsvc)
+        } else if parts.iter().any(|part| matches!(*part, "gnu" | "gnullvm")) {
+            Some(CargoTargetPlatform::WindowsGnu)
+        } else {
+            None
+        };
+    }
+    if parts.contains(&"apple") && parts.contains(&"darwin") {
+        return Some(CargoTargetPlatform::Apple);
+    }
+    parts
+        .iter()
+        .any(|part| {
+            matches!(
+                *part,
+                "linux"
+                    | "android"
+                    | "freebsd"
+                    | "netbsd"
+                    | "openbsd"
+                    | "dragonfly"
+                    | "solaris"
+                    | "illumos"
+            )
+        })
+        .then_some(CargoTargetPlatform::Unix)
+}
+
+fn deliverable_basename(deliverable: &Deliverable, platform: CargoTargetPlatform) -> String {
+    let name = &deliverable.name;
+    match (deliverable.kind, platform) {
+        (
+            DeliverableKind::Bin,
+            CargoTargetPlatform::WindowsMsvc | CargoTargetPlatform::WindowsGnu,
+        ) => {
+            format!("{name}.exe")
+        }
+        (DeliverableKind::Bin, _) => name.clone(),
+        (DeliverableKind::Cdylib, CargoTargetPlatform::Apple) => format!("lib{name}.dylib"),
+        (
+            DeliverableKind::Cdylib,
+            CargoTargetPlatform::WindowsMsvc | CargoTargetPlatform::WindowsGnu,
+        ) => format!("{name}.dll"),
+        (DeliverableKind::Cdylib, CargoTargetPlatform::Unix) => format!("lib{name}.so"),
+        (DeliverableKind::Staticlib, CargoTargetPlatform::WindowsMsvc) => format!("{name}.lib"),
+        (DeliverableKind::Staticlib, _) => format!("lib{name}.a"),
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct CargoLayout {
+    profile: String,
+    target: Option<String>,
+    target_directory: AbsoluteSystemPathBuf,
+}
+
+fn set_once(slot: &mut Option<String>, value: String) -> Option<()> {
+    if slot.is_some() || value.is_empty() {
+        return None;
+    }
+    *slot = Some(value);
+    Some(())
+}
+
+fn contains_glob_syntax(value: &str) -> bool {
+    value
+        .bytes()
+        .any(|byte| matches!(byte, b'*' | b'?' | b'[' | b']' | b'{' | b'}'))
+}
+
+fn target_directory_within_repo(
+    repo_root: &AbsoluteSystemPath,
+    target_directory: &AbsoluteSystemPath,
+) -> bool {
+    if !repo_root.contains(target_directory) {
+        return false;
+    }
+    let Ok(real_repo_root) = dunce::canonicalize(repo_root.as_std_path()) else {
+        return false;
+    };
+    let mut existing_ancestor = target_directory.as_std_path();
+    while !existing_ancestor.exists() {
+        let Some(parent) = existing_ancestor.parent() else {
+            return false;
+        };
+        existing_ancestor = parent;
+    }
+    dunce::canonicalize(existing_ancestor)
+        .is_ok_and(|ancestor| ancestor.starts_with(real_repo_root))
+}
+
+fn cargo_layout(
+    repo_root: &AbsoluteSystemPath,
+    workspace: &CargoWorkspaceDetails,
+    args: &[String],
+    environment: &HashMap<String, String>,
+) -> Option<CargoLayout> {
+    if workspace.external_config_present
+        || workspace.manifest_alters_profile_dirs
+        || workspace.repository_config_alters_output_layout
+        || workspace.repository_config_selects_rustc
+        || environment.contains_key("RUSTC")
+        || environment.contains_key("CARGO_BUILD_RUSTC")
+        || environment.contains_key("CARGO_BUILD_ARTIFACT_DIR")
+        || environment
+            .keys()
+            .any(|name| name.starts_with("CARGO_PROFILE_") && name.ends_with("_DIR_NAME"))
+    {
+        return None;
+    }
+
+    let mut release = false;
+    let mut profile = None;
+    let mut target = None;
+    let mut target_directory = None;
+    let mut index = 0;
+    while index < args.len() {
+        let arg = &args[index];
+        let separate_value = |index: &mut usize| {
+            *index += 1;
+            args.get(*index)
+                .cloned()
+                .filter(|value| !value.is_empty() && !value.starts_with('-'))
+        };
+        match arg.as_str() {
+            "-r" | "--release" if !release => release = true,
+            "-r" | "--release" => return None,
+            "--profile" => set_once(&mut profile, separate_value(&mut index)?)?,
+            "--target" => set_once(&mut target, separate_value(&mut index)?)?,
+            "--target-dir" => set_once(&mut target_directory, separate_value(&mut index)?)?,
+            "--features" | "-F" | "--jobs" | "-j" | "--color" | "--message-format" => {
+                separate_value(&mut index)?;
+            }
+            "-q"
+            | "-v"
+            | "--quiet"
+            | "--verbose"
+            | "--future-incompat-report"
+            | "--keep-going"
+            | "--all-features"
+            | "--no-default-features"
+            | "--timings"
+            | "--ignore-rust-version"
+            | "--locked"
+            | "--offline"
+            | "--frozen" => {}
+            _ if arg.starts_with("--profile=") => {
+                set_once(&mut profile, arg["--profile=".len()..].to_string())?
+            }
+            _ if arg.starts_with("--target=") => {
+                set_once(&mut target, arg["--target=".len()..].to_string())?
+            }
+            _ if arg.starts_with("--target-dir=") => set_once(
+                &mut target_directory,
+                arg["--target-dir=".len()..].to_string(),
+            )?,
+            _ if [
+                "--features=",
+                "--jobs=",
+                "--color=",
+                "--message-format=",
+                "--timings=",
+            ]
+            .iter()
+            .any(|prefix| {
+                arg.strip_prefix(prefix)
+                    .is_some_and(|value| !value.is_empty())
+            }) => {}
+            _ if arg.len() > 2
+                && (arg.starts_with("-F")
+                    || arg.starts_with("-j")
+                    || (arg.starts_with('-') && arg[1..].bytes().all(|byte| byte == b'v'))) => {}
+            _ => return None,
+        }
+        index += 1;
+    }
+    if release && profile.is_some() {
+        return None;
+    }
+    let profile = if release {
+        "release".to_string()
+    } else {
+        match profile.as_deref() {
+            None | Some("dev" | "test") => "debug".to_string(),
+            Some("release" | "bench") => "release".to_string(),
+            Some(profile)
+                if profile
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_')) =>
+            {
+                profile.to_string()
+            }
+            Some(_) => return None,
+        }
+    };
+
+    if target.is_none() {
+        target = environment.get("CARGO_BUILD_TARGET").cloned();
+    }
+    if target.as_deref().is_some_and(|target| {
+        target.is_empty()
+            || (target != workspace.host_target && !workspace.supported_targets.contains(target))
+    }) {
+        return None;
+    }
+    if target.is_none() && workspace.repository_config_selects_target {
+        return None;
+    }
+
+    let target_directory = if let Some(target_directory) = target_directory {
+        if contains_glob_syntax(&target_directory) {
+            return None;
+        }
+        let path = std::path::Path::new(&target_directory);
+        if path
+            .components()
+            .any(|component| component == std::path::Component::ParentDir)
+        {
+            return None;
+        }
+        let path = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            repo_root.as_std_path().join(path)
+        };
+        AbsoluteSystemPathBuf::new(path.to_str()?.to_string()).ok()?
+    } else {
+        workspace.target_directory.clone()
+    };
+    if !target_directory_within_repo(repo_root, &target_directory)
+        || contains_glob_syntax(target_directory.as_str())
+    {
+        return None;
+    }
+
+    Some(CargoLayout {
+        profile,
+        target,
+        target_directory,
+    })
+}
+
+fn deliverable_output_paths(
+    repo_root: &AbsoluteSystemPath,
+    package: &crate::package_graph::PackageInfo,
+    workspace: &CargoWorkspaceDetails,
+    args: &[String],
+    environment: &HashMap<String, String>,
+    deliverables: &[Deliverable],
+) -> Option<Vec<String>> {
+    let layout = cargo_layout(repo_root, workspace, args, environment)?;
+    let effective_target = layout.target.as_deref().unwrap_or(&workspace.host_target);
+    let platform = target_platform(effective_target)?;
+    let package_dir = repo_root.resolve(package.package_path());
+    let target_directory =
+        AnchoredSystemPathBuf::relative_path_between(&package_dir, &layout.target_directory)
+            .to_unix();
+    let mut directory = target_directory.to_string();
+    if let Some(target) = &layout.target {
+        directory = join_prefix(&directory, target);
+    }
+    directory = join_prefix(&directory, &layout.profile);
+
     deliverables
         .iter()
-        .flat_map(|deliverable| {
-            let name = &deliverable.name;
-            let basenames = match deliverable.kind {
-                DeliverableKind::Bin => vec![name.clone(), format!("{name}.exe")],
-                DeliverableKind::Cdylib => vec![
-                    format!("lib{name}.so"),
-                    format!("lib{name}.dylib"),
-                    format!("{name}.dll"),
-                ],
-                DeliverableKind::Staticlib => {
-                    vec![format!("lib{name}.a"), format!("{name}.lib")]
-                }
-            };
-            basenames
-                .into_iter()
-                .map(move |basename| join_prefix(prefix, &format!("target/*/{basename}")))
+        .map(|deliverable| {
+            let basename = deliverable_basename(deliverable, platform);
+            (!contains_glob_syntax(&basename)).then(|| join_prefix(&directory, &basename))
         })
         .collect()
 }
@@ -652,6 +954,7 @@ pub struct CargoToolchain {
     /// Per-package details recorded during discovery, consumed by command
     /// resolution. Keyed by package name.
     details: std::sync::Mutex<HashMap<String, CargoPackageDetails>>,
+    workspace_details: std::sync::Mutex<Option<CargoWorkspaceDetails>>,
     /// The cargo binary, resolved lazily so runs without Cargo tasks never
     /// pay for a PATH scan.
     cargo_binary: std::sync::OnceLock<Result<std::path::PathBuf, which::Error>>,
@@ -668,6 +971,7 @@ impl CargoToolchain {
         Arc::new(Self {
             repo_root,
             details: std::sync::Mutex::new(HashMap::new()),
+            workspace_details: std::sync::Mutex::new(None),
             cargo_binary: std::sync::OnceLock::new(),
         })
     }
@@ -686,11 +990,22 @@ impl CargoToolchain {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .insert(package, details);
     }
+
+    fn workspace_details(&self) -> Option<CargoWorkspaceDetails> {
+        self.workspace_details
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
 }
 
 impl Toolchain for CargoToolchain {
     fn id(&self) -> ToolchainId {
         ToolchainId::RUST
+    }
+
+    fn task_io_env_vars(&self) -> &'static [&'static str] {
+        TASK_IO_ENV_VARS
     }
 
     fn task_command(
@@ -1010,6 +1325,7 @@ impl Toolchain for CargoToolchain {
         path_to_root: &str,
         dependencies: &[&crate::package_graph::PackageInfo],
         wants_automatic_inputs: bool,
+        context: &toolchain::TaskIOContext<'_>,
     ) -> Option<toolchain::DerivedTaskIO> {
         let name = package.package_name()?;
         let details = self.package_details(&name)?;
@@ -1025,6 +1341,14 @@ impl Toolchain for CargoToolchain {
             env: HASHED_ENV_VARS.iter().map(|var| var.to_string()).collect(),
             ..Default::default()
         };
+        if self
+            .workspace_details()
+            .is_some_and(|workspace| workspace.repository_config_escapes)
+        {
+            io.input_globs.retain(|glob| {
+                !glob.ends_with(".cargo/config.toml") && !glob.ends_with(".cargo/config")
+            });
+        }
 
         // Source globs for the crates whose code this task compiles,
         // filtered to real crates (the synthetic workspace package has no
@@ -1060,7 +1384,21 @@ impl Toolchain for CargoToolchain {
                     io.input_globs.extend(dependency_globs());
                 }
                 if subcommand == "build" {
-                    io.output_globs = deliverable_output_globs(path_to_root, &details.deliverables);
+                    io.outputs = (!details.manifest_alters_output_layout)
+                        .then(|| self.workspace_details())
+                        .flatten()
+                        .and_then(|workspace| {
+                            deliverable_output_paths(
+                                &self.repo_root,
+                                package,
+                                &workspace,
+                                context.task_args,
+                                context.environment,
+                                &details.deliverables,
+                            )
+                        })
+                        .map(toolchain::DerivedOutputs::Resolved)
+                        .unwrap_or(toolchain::DerivedOutputs::Unavailable);
                 }
             }
             // The workspace package's directory is the repo root, so
@@ -1088,6 +1426,7 @@ impl Toolchain for CargoToolchain {
             let workspace =
                 turborepo_rayon_compat::block_in_place(|| discover_crates(&self.repo_root))
                     .map_err(|err| toolchain::Error::Failed(Box::new(err)))?;
+            let target_directory = workspace.target_directory.clone();
             let crates = workspace.crates;
 
             if crates.is_empty() {
@@ -1121,14 +1460,39 @@ impl Toolchain for CargoToolchain {
             // invalidates crates that actually depend on it, and a toolchain
             // change invalidates everything.
             let all_names: Vec<String> = crates.iter().map(|c| c.name.clone()).collect();
-            let (rustc, mut closures) = turborepo_rayon_compat::block_in_place(|| {
-                validate_lockfile(&self.repo_root)?;
-                Ok::<_, Error>((
-                    rustc_identity(&self.repo_root)?,
-                    external_closures(&self.repo_root, &all_names)?,
-                ))
-            })
-            .map_err(|err| toolchain::Error::Failed(Box::new(err)))?;
+            let startup_environment: HashMap<String, String> = std::env::vars().collect();
+            let config_influence = cargo_config_influence(&self.repo_root, &startup_environment);
+            let (rustc, host_target, supported_targets, mut closures) =
+                turborepo_rayon_compat::block_in_place(|| {
+                    validate_lockfile(&self.repo_root)?;
+                    let (rustc, host_target) = rustc_info(&self.repo_root)?;
+                    Ok::<_, Error>((
+                        rustc,
+                        host_target,
+                        rustc_supported_targets(&self.repo_root),
+                        external_closures(&self.repo_root, &all_names)?,
+                    ))
+                })
+                .map_err(|err| toolchain::Error::Failed(Box::new(err)))?;
+            if let Some(target_directory) = target_directory {
+                *self
+                    .workspace_details
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner()) =
+                    Some(CargoWorkspaceDetails {
+                        target_directory,
+                        host_target,
+                        supported_targets,
+                        repository_config_selects_target: config_influence
+                            .repository_selects_target,
+                        repository_config_selects_rustc: config_influence.repository_selects_rustc,
+                        repository_config_alters_output_layout: config_influence
+                            .repository_alters_output_layout,
+                        repository_config_escapes: config_influence.repository_config_escapes,
+                        external_config_present: config_influence.external_present,
+                        manifest_alters_profile_dirs: manifest_alters_profile_dirs(&self.repo_root),
+                    });
+            }
             let workspace_externals: HashSet<turborepo_lockfiles::Package> = closures
                 .values()
                 .flatten()
@@ -1162,6 +1526,7 @@ impl Toolchain for CargoToolchain {
                     CargoPackageDetails {
                         kind,
                         deliverables: cargo_crate.deliverables,
+                        manifest_alters_output_layout: cargo_crate.manifest_alters_output_layout,
                         dir,
                     },
                 );
@@ -1193,6 +1558,7 @@ impl Toolchain for CargoToolchain {
                     CargoPackageDetails {
                         kind: CargoPackageKind::Workspace,
                         deliverables: Vec::new(),
+                        manifest_alters_output_layout: false,
                         dir: String::new(),
                     },
                 );
@@ -1287,6 +1653,7 @@ pub struct CargoCrate {
     /// The crate's deliverable targets. Non-empty exactly when the crate is
     /// an entrypoint (has `bin`/`cdylib`/`staticlib` targets).
     pub deliverables: Vec<Deliverable>,
+    pub manifest_alters_output_layout: bool,
 }
 
 impl CargoCrate {
@@ -1313,6 +1680,142 @@ pub struct DiscoveredWorkspace {
     /// filtered must still run full validation rather than be mistaken for a
     /// memberless virtual workspace.
     pub has_packages: bool,
+    pub target_directory: Option<AbsoluteSystemPathBuf>,
+}
+
+fn manifest_alters_profile_dirs(repo_root: &AbsoluteSystemPath) -> bool {
+    let Ok(contents) = repo_root.join_component(CARGO_TOML).read_to_string() else {
+        return true;
+    };
+    let Ok(manifest) = contents.parse::<toml_edit::DocumentMut>() else {
+        return true;
+    };
+    manifest
+        .get("profile")
+        .and_then(toml_edit::Item::as_table_like)
+        .is_some_and(|profiles| {
+            profiles
+                .iter()
+                .any(|(_, profile)| profile.get("dir-name").is_some())
+        })
+}
+
+#[derive(Debug, Default)]
+struct CargoConfigInfluence {
+    repository_selects_target: bool,
+    repository_selects_rustc: bool,
+    repository_alters_output_layout: bool,
+    repository_config_escapes: bool,
+    external_present: bool,
+}
+
+fn config_build_keys(
+    repo_root: &AbsoluteSystemPath,
+    path: &std::path::Path,
+) -> Option<(bool, bool, bool, bool)> {
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return None,
+        Err(_) => return Some((true, true, true, false)),
+    }
+    let contained = dunce::canonicalize(repo_root.as_std_path())
+        .ok()
+        .zip(dunce::canonicalize(path).ok())
+        .is_some_and(|(root, config)| config.starts_with(root));
+    if !contained {
+        return Some((false, false, true, true));
+    }
+    let contents = match std::fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(_) => return Some((true, true, true, false)),
+    };
+    let config = match contents.parse::<toml_edit::DocumentMut>() {
+        Ok(config) => config,
+        Err(_) => return Some((true, true, true, false)),
+    };
+    let build = config.get("build");
+    let profile_dir_name = config
+        .get("profile")
+        .and_then(toml_edit::Item::as_table_like)
+        .is_some_and(|profiles| {
+            profiles
+                .iter()
+                .any(|(_, profile)| profile.get("dir-name").is_some())
+        });
+    Some((
+        build.and_then(|build| build.get("target")).is_some(),
+        build.and_then(|build| build.get("rustc")).is_some(),
+        build.and_then(|build| build.get("artifact-dir")).is_some()
+            || profile_dir_name
+            || config.get("include").is_some(),
+        false,
+    ))
+}
+
+fn cargo_home_candidates(
+    repo_root: &AbsoluteSystemPath,
+    environment: &HashMap<String, String>,
+    windows: bool,
+) -> Vec<std::path::PathBuf> {
+    if let Some(cargo_home) = environment.get("CARGO_HOME") {
+        let cargo_home = std::path::Path::new(cargo_home);
+        return vec![if cargo_home.is_absolute() {
+            cargo_home.to_path_buf()
+        } else {
+            repo_root.as_std_path().join(cargo_home)
+        }];
+    }
+
+    let mut candidates = Vec::new();
+    if windows && let Some(user_profile) = environment.get("USERPROFILE") {
+        candidates.push(std::path::Path::new(user_profile).join(".cargo"));
+    }
+    if let Some(home) = environment.get("HOME") {
+        let home = std::path::Path::new(home).join(".cargo");
+        if !candidates.contains(&home) {
+            candidates.push(home);
+        }
+    }
+    candidates
+}
+
+fn cargo_config_influence(
+    repo_root: &AbsoluteSystemPath,
+    environment: &HashMap<String, String>,
+) -> CargoConfigInfluence {
+    let repository_cargo = repo_root.as_std_path().join(".cargo");
+    let mut influence = CargoConfigInfluence::default();
+    for name in ["config.toml", "config"] {
+        if let Some((target, rustc, output_layout, escapes)) =
+            config_build_keys(repo_root, &repository_cargo.join(name))
+        {
+            influence.repository_selects_target |= target;
+            influence.repository_selects_rustc |= rustc;
+            influence.repository_alters_output_layout |= output_layout;
+            influence.repository_config_escapes |= escapes;
+        }
+    }
+
+    let ancestor_cargo_homes = repo_root
+        .as_std_path()
+        .ancestors()
+        .skip(1)
+        .map(|ancestor| ancestor.join(".cargo"));
+    let cargo_homes = cargo_home_candidates(repo_root, environment, cfg!(windows));
+    for cargo_home in ancestor_cargo_homes.chain(cargo_homes) {
+        if cargo_home == repository_cargo {
+            continue;
+        }
+        for name in ["config.toml", "config"] {
+            let path = cargo_home.join(name);
+            match std::fs::symlink_metadata(path) {
+                Ok(_) => influence.external_present = true,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(_) => influence.external_present = true,
+            }
+        }
+    }
+    influence
 }
 
 /// Discover all Rust crates in the Cargo workspace rooted at `repo_root` by
@@ -1334,6 +1837,7 @@ pub fn discover_crates(repo_root: &AbsoluteSystemPath) -> Result<DiscoveredWorks
             name: None,
             crates: Vec::new(),
             has_packages: false,
+            target_directory: None,
         });
     }
 
@@ -1358,6 +1862,7 @@ pub fn discover_crates(repo_root: &AbsoluteSystemPath) -> Result<DiscoveredWorks
 
     let has_packages = !metadata.packages.is_empty();
     let name = workspace_name(&metadata)?;
+    let target_directory = metadata_path(&metadata.target_directory);
     let crates = connect_crates(parse_members(repo_root, &root_manifest_path, metadata));
 
     if let Some(name) = &name
@@ -1377,6 +1882,7 @@ pub fn discover_crates(repo_root: &AbsoluteSystemPath) -> Result<DiscoveredWorks
         name,
         crates,
         has_packages,
+        target_directory,
     })
 }
 
@@ -1418,6 +1924,7 @@ struct ParsedCrate {
     manifest_path: AbsoluteSystemPathBuf,
     dependencies: Vec<ResolvedDep>,
     deliverables: Vec<Deliverable>,
+    manifest_alters_output_layout: bool,
 }
 
 /// A path dependency resolved to the directory Cargo reports for it.
@@ -1438,6 +1945,32 @@ fn metadata_path(path: &str) -> Option<AbsoluteSystemPathBuf> {
             .to_owned(),
     )
     .ok()
+}
+
+fn manifest_alters_output_layout(manifest_path: &AbsoluteSystemPath) -> bool {
+    let Ok(contents) = manifest_path.read_to_string() else {
+        return true;
+    };
+    let Ok(manifest) = contents.parse::<toml_edit::DocumentMut>() else {
+        return true;
+    };
+    let enables_per_package_target = manifest
+        .get("cargo-features")
+        .and_then(toml_edit::Item::as_array)
+        .is_some_and(|features| {
+            features
+                .iter()
+                .any(|feature| feature.as_str() == Some("per-package-target"))
+        });
+    let package_selects_target = manifest.get("package").is_some_and(|package| {
+        package.get("default-target").is_some() || package.get("forced-target").is_some()
+    });
+    let target_renames_output = ["bin", "example", "test", "bench"]
+        .iter()
+        .filter_map(|kind| manifest.get(kind)?.as_array_of_tables())
+        .flatten()
+        .any(|target| target.contains_key("filename"));
+    enables_per_package_target || package_selects_target || target_renames_output
 }
 
 fn parse_members(
@@ -1514,11 +2047,13 @@ fn parse_members(
             })
             .collect();
 
+        let manifest_alters_output_layout = manifest_alters_output_layout(&manifest_path);
         parsed.push(ParsedCrate {
             name: package.name,
             manifest_path,
             dependencies,
             deliverables,
+            manifest_alters_output_layout,
         });
     }
     parsed
@@ -1585,6 +2120,7 @@ fn connect_crates(parsed: Vec<ParsedCrate>) -> Vec<CargoCrate> {
             name: parsed_crate.name,
             manifest_path: parsed_crate.manifest_path,
             deliverables: parsed_crate.deliverables,
+            manifest_alters_output_layout: parsed_crate.manifest_alters_output_layout,
         })
         .collect()
 }
@@ -1617,6 +2153,7 @@ fn reaches(adjacency: &HashMap<&str, BTreeSet<&str>>, start: &str, target: &str)
 #[derive(Debug, Deserialize)]
 struct Metadata {
     packages: Vec<MetadataPackage>,
+    target_directory: String,
     /// The `[workspace.metadata]` table, serialized as JSON. Carries the
     /// user-declared workspace name.
     #[serde(default)]
@@ -1908,6 +2445,476 @@ dependencies = ["lib-a"]
             error.to_string().contains("root-package")
                 && error.to_string().contains("root Cargo.toml"),
             "unexpected validation result: {error}"
+        );
+    }
+
+    fn string_args(args: &[&str]) -> Vec<String> {
+        args.iter().map(|arg| (*arg).to_string()).collect()
+    }
+
+    fn output_test_workspace(root: &AbsoluteSystemPath) -> CargoWorkspaceDetails {
+        CargoWorkspaceDetails {
+            target_directory: root.join_component("target"),
+            host_target: "x86_64-unknown-linux-gnu".to_string(),
+            supported_targets: HashSet::from([
+                "x86_64-unknown-linux-gnu".to_string(),
+                "aarch64-unknown-linux-gnu".to_string(),
+            ]),
+            repository_config_selects_target: false,
+            repository_config_selects_rustc: false,
+            repository_config_alters_output_layout: false,
+            repository_config_escapes: false,
+            external_config_present: false,
+            manifest_alters_profile_dirs: false,
+        }
+    }
+
+    #[test]
+    fn test_cargo_layout_profiles_and_precedence() {
+        let (_tmp, root) = tempdir_root();
+        let workspace = output_test_workspace(&root);
+        let environment = HashMap::new();
+        for (args, expected) in [
+            (vec![], "debug"),
+            (string_args(&["-r"]), "release"),
+            (string_args(&["--release"]), "release"),
+            (string_args(&["--profile", "ci"]), "ci"),
+            (string_args(&["--profile=ci"]), "ci"),
+            (string_args(&["--profile=dev"]), "debug"),
+            (string_args(&["--profile=test"]), "debug"),
+            (string_args(&["--profile=release"]), "release"),
+            (string_args(&["--profile=bench"]), "release"),
+        ] {
+            assert_eq!(
+                cargo_layout(&root, &workspace, &args, &environment)
+                    .expect("layout resolves")
+                    .profile,
+                expected
+            );
+        }
+
+        for args in [
+            string_args(&["--release", "--profile=ci"]),
+            string_args(&["--release=true"]),
+            string_args(&["-r", "-r"]),
+            string_args(&["--profile"]),
+            string_args(&["--profile", "--target=x86_64-unknown-linux-gnu"]),
+            string_args(&["--profile=bad/name"]),
+            string_args(&["--profile=ci", "--profile=release"]),
+        ] {
+            assert!(cargo_layout(&root, &workspace, &args, &environment).is_none());
+        }
+    }
+
+    #[test]
+    fn test_cargo_layout_allows_known_layout_neutral_flags() {
+        let (_tmp, root) = tempdir_root();
+        let workspace = output_test_workspace(&root);
+        let args = string_args(&[
+            "--features",
+            "one,two",
+            "-Fthree",
+            "--no-default-features",
+            "--all-features",
+            "--locked",
+            "--offline",
+            "--frozen",
+            "--keep-going",
+            "--ignore-rust-version",
+            "--future-incompat-report",
+            "--message-format=json",
+            "--color",
+            "never",
+            "-j4",
+            "-vv",
+            "--timings",
+        ]);
+        assert!(cargo_layout(&root, &workspace, &args, &HashMap::new()).is_some());
+
+        for args in [
+            string_args(&["--future-output-layout"]),
+            string_args(&["-Zfuture-layout"]),
+            string_args(&["positional"]),
+            string_args(&["--"]),
+        ] {
+            assert!(cargo_layout(&root, &workspace, &args, &HashMap::new()).is_none());
+        }
+    }
+
+    #[test]
+    fn test_cargo_layout_targets_and_target_directories() {
+        let (_tmp, root) = tempdir_root();
+        let workspace = output_test_workspace(&root);
+        let environment = HashMap::from([(
+            "CARGO_BUILD_TARGET".to_string(),
+            "aarch64-unknown-linux-gnu".to_string(),
+        )]);
+        let layout = cargo_layout(&root, &workspace, &[], &environment).unwrap();
+        assert_eq!(layout.target.as_deref(), Some("aarch64-unknown-linux-gnu"));
+
+        let args = string_args(&[
+            "--target=x86_64-unknown-linux-gnu",
+            "--target-dir",
+            "artifacts",
+        ]);
+        let layout = cargo_layout(&root, &workspace, &args, &environment).unwrap();
+        assert_eq!(layout.target.as_deref(), Some("x86_64-unknown-linux-gnu"));
+        assert_eq!(layout.target_directory, root.join_component("artifacts"));
+
+        for args in [
+            string_args(&["--target"]),
+            string_args(&["--target=a", "--target=b"]),
+            string_args(&["--target-dir"]),
+            string_args(&["--target-dir=a", "--target-dir=b"]),
+        ] {
+            assert!(cargo_layout(&root, &workspace, &args, &environment).is_none());
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_cargo_target_directory_rejects_symlink_escape() {
+        let (_tmp, root) = tempdir_root();
+        let repo = root.join_component("repo");
+        let outside = root.join_component("outside");
+        std::fs::create_dir_all(repo.as_std_path()).unwrap();
+        std::fs::create_dir_all(outside.as_std_path()).unwrap();
+        std::os::unix::fs::symlink(
+            outside.as_std_path(),
+            repo.join_component("escape").as_std_path(),
+        )
+        .unwrap();
+        let mut workspace = output_test_workspace(&repo);
+        workspace.target_directory = repo.join_components(&["escape", "target"]);
+        assert!(cargo_layout(&repo, &workspace, &[], &HashMap::new()).is_none());
+        assert!(!outside.join_component("target").exists());
+    }
+
+    #[test]
+    fn test_cargo_deliverable_basenames_are_platform_exact() {
+        let bin = Deliverable {
+            name: "app".to_string(),
+            kind: DeliverableKind::Bin,
+        };
+        let cdylib = Deliverable {
+            name: "ffi".to_string(),
+            kind: DeliverableKind::Cdylib,
+        };
+        let staticlib = Deliverable {
+            name: "ffi".to_string(),
+            kind: DeliverableKind::Staticlib,
+        };
+        assert_eq!(deliverable_basename(&bin, CargoTargetPlatform::Unix), "app");
+        assert_eq!(
+            deliverable_basename(&bin, CargoTargetPlatform::WindowsMsvc),
+            "app.exe"
+        );
+        assert_eq!(
+            deliverable_basename(&cdylib, CargoTargetPlatform::Unix),
+            "libffi.so"
+        );
+        assert_eq!(
+            deliverable_basename(&cdylib, CargoTargetPlatform::Apple),
+            "libffi.dylib"
+        );
+        assert_eq!(
+            deliverable_basename(&cdylib, CargoTargetPlatform::WindowsGnu),
+            "ffi.dll"
+        );
+        assert_eq!(
+            deliverable_basename(&staticlib, CargoTargetPlatform::WindowsMsvc),
+            "ffi.lib"
+        );
+        assert_eq!(
+            deliverable_basename(&staticlib, CargoTargetPlatform::WindowsGnu),
+            "libffi.a"
+        );
+        assert!(target_platform("custom-target.json").is_none());
+        assert!(target_platform("thumbv7em-none-eabihf").is_none());
+    }
+
+    #[test]
+    fn test_cargo_deliverable_output_path_matrix_has_no_wildcards() {
+        let (_tmp, root) = tempdir_root();
+        let workspace = output_test_workspace(&root);
+        let package = package_info("app", "crates/app/Cargo.toml");
+        let deliverables = [Deliverable {
+            name: "app".to_string(),
+            kind: DeliverableKind::Bin,
+        }];
+        let cases = [
+            (vec![], HashMap::new(), "../../target/debug/app"),
+            (
+                string_args(&["--release"]),
+                HashMap::new(),
+                "../../target/release/app",
+            ),
+            (
+                string_args(&["--profile=ci"]),
+                HashMap::new(),
+                "../../target/ci/app",
+            ),
+            (
+                string_args(&["--target=x86_64-unknown-linux-gnu"]),
+                HashMap::new(),
+                "../../target/x86_64-unknown-linux-gnu/debug/app",
+            ),
+            (
+                vec![],
+                HashMap::from([(
+                    "CARGO_BUILD_TARGET".to_string(),
+                    "x86_64-unknown-linux-gnu".to_string(),
+                )]),
+                "../../target/x86_64-unknown-linux-gnu/debug/app",
+            ),
+            (
+                string_args(&["--target-dir=artifacts"]),
+                HashMap::new(),
+                "../../artifacts/debug/app",
+            ),
+        ];
+        for (args, environment, expected) in cases {
+            let outputs = deliverable_output_paths(
+                &root,
+                &package,
+                &workspace,
+                &args,
+                &environment,
+                &deliverables,
+            )
+            .expect("outputs resolve");
+            assert_eq!(outputs, vec![expected]);
+            assert!(outputs.iter().all(|output| !output.contains('*')));
+        }
+    }
+
+    #[test]
+    fn test_cargo_output_resolution_fails_closed() {
+        let (_tmp, root) = tempdir_root();
+        let workspace = output_test_workspace(&root);
+        let package = package_info("app", "crates/app/Cargo.toml");
+        let deliverables = [Deliverable {
+            name: "app".to_string(),
+            kind: DeliverableKind::Bin,
+        }];
+        for args in [
+            string_args(&["--config", "build.target-dir='other'"]),
+            string_args(&["--config=build.target-dir='other'"]),
+            string_args(&["--target=custom.json"]),
+            string_args(&["--target=x86_64-unknown-linux-*"]),
+            string_args(&["--target=custom-unknown-linux-gnu"]),
+            string_args(&["--target-dir=target/*"]),
+            string_args(&["--target-dir=../target"]),
+            string_args(&["--artifact-dir=dist"]),
+            string_args(&["--bin=other"]),
+            string_args(&["--manifest-path=other/Cargo.toml"]),
+            string_args(&["-pother"]),
+        ] {
+            assert!(
+                deliverable_output_paths(
+                    &root,
+                    &package,
+                    &workspace,
+                    &args,
+                    &HashMap::new(),
+                    &deliverables,
+                )
+                .is_none(),
+                "unsupported args must fail closed: {args:?}"
+            );
+        }
+
+        let mut configured_target = workspace.clone();
+        configured_target.repository_config_selects_target = true;
+        assert!(
+            deliverable_output_paths(
+                &root,
+                &package,
+                &configured_target,
+                &[],
+                &HashMap::new(),
+                &deliverables,
+            )
+            .is_none()
+        );
+
+        for name in [
+            "RUSTC",
+            "CARGO_BUILD_RUSTC",
+            "CARGO_BUILD_ARTIFACT_DIR",
+            "CARGO_PROFILE_CI_DIR_NAME",
+        ] {
+            let environment = HashMap::from([(name.to_string(), "custom-rustc".to_string())]);
+            assert!(
+                deliverable_output_paths(
+                    &root,
+                    &package,
+                    &workspace,
+                    &[],
+                    &environment,
+                    &deliverables,
+                )
+                .is_none()
+            );
+        }
+        let mut configured_rustc = workspace.clone();
+        configured_rustc.repository_config_selects_rustc = true;
+        assert!(
+            deliverable_output_paths(
+                &root,
+                &package,
+                &configured_rustc,
+                &[],
+                &HashMap::new(),
+                &deliverables,
+            )
+            .is_none()
+        );
+        let mut custom_profile_directory = workspace.clone();
+        custom_profile_directory.manifest_alters_profile_dirs = true;
+        assert!(
+            deliverable_output_paths(
+                &root,
+                &package,
+                &custom_profile_directory,
+                &[],
+                &HashMap::new(),
+                &deliverables,
+            )
+            .is_none()
+        );
+        let mut external_config = workspace.clone();
+        external_config.external_config_present = true;
+        assert!(
+            deliverable_output_paths(
+                &root,
+                &package,
+                &external_config,
+                &[],
+                &HashMap::new(),
+                &deliverables,
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn test_cargo_config_influence_distinguishes_repository_and_external_config() {
+        let (_tmp, root) = tempdir_root();
+        let repo = root.join_component("repo");
+        std::fs::create_dir_all(repo.as_std_path()).unwrap();
+        write(
+            &repo,
+            &[".cargo", "config.toml"],
+            "[build]\ntarget = \"x86_64-unknown-linux-gnu\"\nrustc = \"rustc\"\ntarget-dir = \
+             \"target\"\n",
+        );
+        let influence = cargo_config_influence(&repo, &HashMap::new());
+        assert!(influence.repository_selects_target);
+        assert!(influence.repository_selects_rustc);
+        assert!(!influence.repository_alters_output_layout);
+        assert!(!influence.external_present);
+
+        write(
+            &repo,
+            &[".cargo", "config.toml"],
+            "[build]\nartifact-dir = \"artifacts\"\n\n[profile.ci]\ndir-name = \"profile-dir\"\n",
+        );
+        assert!(cargo_config_influence(&repo, &HashMap::new()).repository_alters_output_layout);
+
+        write(
+            &root,
+            &[".cargo", "config.toml"],
+            "[build]\ntarget-dir = \"external-target\"\n",
+        );
+        assert!(cargo_config_influence(&repo, &HashMap::new()).external_present);
+        write(&root, &[".cargo", "config.toml"], "[net]\nretry = 3\n");
+        assert!(cargo_config_influence(&repo, &HashMap::new()).external_present);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_repository_cargo_config_rejects_symlink_escape() {
+        let (_tmp, root) = tempdir_root();
+        let repo = root.join_component("repo");
+        let outside = root.join_component("outside-config.toml");
+        std::fs::create_dir_all(repo.join_component(".cargo").as_std_path()).unwrap();
+        outside
+            .create_with_contents("[build]\ntarget-dir = \"outside\"\n")
+            .unwrap();
+        std::os::unix::fs::symlink(
+            outside.as_std_path(),
+            repo.join_components(&[".cargo", "config.toml"])
+                .as_std_path(),
+        )
+        .unwrap();
+        let influence = cargo_config_influence(&repo, &HashMap::new());
+        assert!(influence.repository_alters_output_layout);
+        assert!(influence.repository_config_escapes);
+    }
+
+    #[test]
+    fn test_manifest_output_layout_overrides_fail_closed() {
+        let (_tmp, root) = tempdir_root();
+        let manifest = root.join_component("Cargo.toml");
+        write(
+            &root,
+            &["Cargo.toml"],
+            "cargo-features = [\"different-binary-name\"]\n\n[[bin]]\nname = \"app\"\nfilename = \
+             \"renamed\"\n",
+        );
+        assert!(manifest_alters_output_layout(&manifest));
+        for contents in [
+            "cargo-features = [\"per-package-target\"]\n\n[package]\nname = \"app\"\nversion = \
+             \"0.1.0\"\n",
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\ndefault-target = \
+             \"x86_64-unknown-linux-gnu\"\n",
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\nforced-target = \
+             \"x86_64-unknown-linux-gnu\"\n",
+        ] {
+            write(&root, &["Cargo.toml"], contents);
+            assert!(manifest_alters_output_layout(&manifest));
+        }
+
+        write(
+            &root,
+            &["Cargo.toml"],
+            "[workspace]\nmembers = []\n\n[profile.ci]\ninherits = \"dev\"\ndir-name = \
+             \"custom-dir\"\n",
+        );
+        assert!(manifest_alters_profile_dirs(&root));
+
+        write(
+            &root,
+            &["Cargo.toml"],
+            "[workspace]\nmembers = []\n\n[profile.ci]\ninherits = \"dev\"\n",
+        );
+        assert!(!manifest_alters_output_layout(&manifest));
+        assert!(!manifest_alters_profile_dirs(&root));
+    }
+
+    #[test]
+    fn test_cargo_home_candidates_cover_windows_user_profile_conservatively() {
+        let (_tmp, root) = tempdir_root();
+        let environment = HashMap::from([
+            ("USERPROFILE".to_string(), "/user-profile".to_string()),
+            ("HOME".to_string(), "/home".to_string()),
+        ]);
+        assert_eq!(
+            cargo_home_candidates(&root, &environment, true),
+            vec![
+                std::path::PathBuf::from("/user-profile/.cargo"),
+                std::path::PathBuf::from("/home/.cargo"),
+            ]
+        );
+
+        let environment = HashMap::from([
+            ("CARGO_HOME".to_string(), "isolated-cargo".to_string()),
+            ("USERPROFILE".to_string(), "/ignored".to_string()),
+        ]);
+        assert_eq!(
+            cargo_home_candidates(&root, &environment, true),
+            vec![root.as_std_path().join("isolated-cargo")]
         );
     }
 
@@ -2521,6 +3528,11 @@ release: 1.96.0-nightly\n",
         let app = package_info("app", "crates/app/Cargo.toml");
         let lib_a = package_info("lib-a", "crates/lib-a/Cargo.toml");
         let workspace = package_info("fixture-ws", "Cargo.toml");
+        let environment = HashMap::new();
+        let context = toolchain::TaskIOContext {
+            task_args: &[],
+            environment: &environment,
+        };
 
         // defines_task mirrors the verb tables.
         assert!(toolchain.defines_task(&app, "build"));
@@ -2533,7 +3545,7 @@ release: 1.96.0-nightly\n",
         // hashing), deliverables as outputs.
         let deps = [&lib_a];
         let io = toolchain
-            .derived_task_io(&app, "build", "../..", &deps, true)
+            .derived_task_io(&app, "build", "../..", &deps, true, &context)
             .expect("entrypoint build derives IO");
         assert!(
             !io.input_globs
@@ -2561,24 +3573,32 @@ release: 1.96.0-nightly\n",
         assert_eq!(io.package_default_inputs, Some(true));
         assert!(io.env.contains(&"RUSTC_WRAPPER".to_string()));
         assert!(io.env.contains(&"CARGO_ENCODED_RUSTFLAGS".to_string()));
+        assert!(io.env.contains(&"CARGO_HOME".to_string()));
         assert!(io.env.contains(&"CARGO_PROFILE_*".to_string()));
         assert!(io.env.contains(&"CARGO_TARGET_*".to_string()));
         assert!(io.env.contains(&"CC_*".to_string()));
         assert!(io.env.contains(&"TARGET_CFLAGS".to_string()));
         assert!(
-            io.output_globs.contains(&"../../target/*/app".to_string()),
-            "bin deliverable is cached with a wildcard profile, got {:?}",
-            io.output_globs
+            TASK_IO_ENV_VARS
+                .iter()
+                .all(|name| io.env.iter().any(|hashed| hashed == name)),
+            "every Cargo task-I/O environment key must also be hashed"
         );
-        assert!(
-            io.output_globs
-                .contains(&"../../target/*/app.exe".to_string())
+        let expected = if cfg!(windows) {
+            "../../target/debug/app.exe"
+        } else {
+            "../../target/debug/app"
+        };
+        assert_eq!(
+            io.outputs,
+            toolchain::DerivedOutputs::Resolved(vec![expected.to_string()])
         );
+        assert!(!expected.contains('*'));
 
         // Explicit inputs without $TURBO_DEFAULT$: workspace files still
         // apply, but no closure globs and no default-hashing override.
         let io = toolchain
-            .derived_task_io(&app, "build", "../..", &deps, false)
+            .derived_task_io(&app, "build", "../..", &deps, false, &context)
             .expect("entrypoint build derives IO");
         assert!(io.input_globs.contains(&"../../Cargo.toml".to_string()));
         assert!(!io.input_globs.iter().any(|glob| glob.contains("lib-a")));
@@ -2586,26 +3606,34 @@ release: 1.96.0-nightly\n",
 
         // Non-build entrypoint verbs cache no deliverables.
         let io = toolchain
-            .derived_task_io(&app, "dev", "../..", &deps, true)
+            .derived_task_io(&app, "dev", "../..", &deps, true, &context)
             .expect("entrypoint dev derives IO");
-        assert!(io.output_globs.is_empty());
+        assert_eq!(io.outputs, toolchain::DerivedOutputs::None);
+
+        let mut renamed = toolchain.package_details("app").unwrap();
+        renamed.manifest_alters_output_layout = true;
+        toolchain.record_details("app".to_string(), renamed);
+        let io = toolchain
+            .derived_task_io(&app, "build", "../..", &deps, true, &context)
+            .expect("renamed entrypoint still derives inputs");
+        assert_eq!(io.outputs, toolchain::DerivedOutputs::Unavailable);
 
         // The workspace package hashes crate directories instead of the
         // repo root's default file set.
         let deps = [&app, &lib_a];
         let io = toolchain
-            .derived_task_io(&workspace, "test", "", &deps, true)
+            .derived_task_io(&workspace, "test", "", &deps, true, &context)
             .expect("workspace test derives IO");
         assert_eq!(io.package_default_inputs, Some(false));
         assert!(io.input_globs.contains(&"crates/app/**".to_string()));
         assert!(io.input_globs.contains(&"crates/lib-a/**".to_string()));
         assert!(io.input_globs.contains(&"Cargo.toml".to_string()));
-        assert!(io.output_globs.is_empty());
+        assert_eq!(io.outputs, toolchain::DerivedOutputs::None);
 
         // Libraries derive nothing.
         assert!(
             toolchain
-                .derived_task_io(&lib_a, "build", "../..", &[], true)
+                .derived_task_io(&lib_a, "build", "../..", &[], true, &context)
                 .is_none()
         );
     }

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -274,6 +274,14 @@ pub trait Toolchain: Send + Sync {
         TaskDefaults::default()
     }
 
+    /// Startup environment variables this toolchain needs to derive task I/O.
+    /// The engine retains only these declared keys rather than the full process
+    /// environment. The engine automatically adds every declared key to the
+    /// task's hashed environment when derived I/O applies.
+    fn task_io_env_vars(&self) -> &'static [&'static str] {
+        &[]
+    }
+
     /// Hash wiring this toolchain derives for `task` in `package`, beyond
     /// what turbo.json declares: extra input globs and env vars that
     /// participate in the task hash, output globs to cache, and whether the
@@ -297,6 +305,7 @@ pub trait Toolchain: Send + Sync {
         path_to_root: &str,
         dependencies: &[&crate::package_graph::PackageInfo],
         wants_automatic_inputs: bool,
+        context: &TaskIOContext<'_>,
     ) -> Option<DerivedTaskIO> {
         let _ = (
             package,
@@ -304,6 +313,7 @@ pub trait Toolchain: Send + Sync {
             path_to_root,
             dependencies,
             wants_automatic_inputs,
+            context,
         );
         None
     }
@@ -447,6 +457,25 @@ impl WatchSpec {
     }
 }
 
+/// Run-scoped inputs that can affect toolchain-derived task I/O.
+#[derive(Debug, Clone, Copy)]
+pub struct TaskIOContext<'a> {
+    pub task_args: &'a [String],
+    pub environment: &'a std::collections::HashMap<String, String>,
+}
+
+/// Whether a toolchain can resolve a task's automatic outputs exactly.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum DerivedOutputs {
+    /// The task has no toolchain-derived outputs.
+    #[default]
+    None,
+    /// Exact output paths, relative to the package directory.
+    Resolved(Vec<String>),
+    /// The task produces outputs, but their paths cannot be resolved safely.
+    Unavailable,
+}
+
 /// Hash wiring derived by a toolchain for one task. See
 /// [`Toolchain::derived_task_io`].
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -458,8 +487,7 @@ pub struct DerivedTaskIO {
     pub package_default_inputs: Option<bool>,
     /// Env vars that participate in the task hash.
     pub env: Vec<String>,
-    /// Output globs to cache, relative to the package directory.
-    pub output_globs: Vec<String>,
+    pub outputs: DerivedOutputs,
 }
 
 /// The set of toolchains contributing packages to the repository.
@@ -709,6 +737,7 @@ impl<P: PackageDiscovery + Send + Sync> Toolchain for JavaScriptToolchain<P> {
         _path_to_root: &str,
         _dependencies: &[&crate::package_graph::PackageInfo],
         _wants_automatic_inputs: bool,
+        _context: &TaskIOContext<'_>,
     ) -> Option<DerivedTaskIO> {
         // Deliberately nothing: for JavaScript, turbo.json is the whole
         // story — inputs default to the package's files, outputs are

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -243,20 +243,47 @@ whether anything changed; Cargo decides how and in what order to build.**
   or incomplete lockfiles are hard errors. Turborepo never creates or refreshes
   the source lockfile; users do that explicitly with Cargo and commit the
   result.
-- **Caching**: task caches store logs plus, for entrypoint builds, the
-  deliverables: bins (`target/*/<bin>`) and cdylib/staticlib artifacts
-  (`target/*/lib<name>.{so,dylib,a}`, `<name>.{dll,lib}` — all platform
-  spellings are emitted; unmatched globs contribute nothing). The profile
-  segment is a wildcard, so `--release` and custom profiles cache without
-  configuration — pass-through args participate in the task hash, giving
-  each profile its own cache entry. Cargo's internal `target/` state is
-  deliberately never cached — it is Cargo's own incremental cache, and
-  tarballing it fights Cargo instead of leaning on it (it is also
-  multi-gigabyte). For fine-grained compile caching, `RUSTC_WRAPPER`
-  (sccache) is the sound layer, and it participates in task hashes so
-  toggling it invalidates caches. Entrypoint `run` and `dev` tasks default to
-  `cache: false`, because a cache hit must not suppress the requested process;
-  an explicit turbo.json `cache` setting overrides the toolchain default.
+- **Caching**: task caches store logs plus, for entrypoint builds, only each
+  exact effective deliverable path. Engine construction passes task arguments
+  and only the startup environment keys declared by registered toolchains
+  through a toolchain-neutral I/O context; it does not retain the full process
+  environment. Cargo combines those with metadata's effective
+  `target_directory`, rustc's host triple, and rustc's supported-target list to
+  resolve the profile (`dev`/`test` to `debug`, `release`/`bench` to `release`,
+  or a custom profile), an explicit target segment, and the single
+  platform-correct basename for each bin/cdylib/staticlib. Toolchain-declared
+  I/O environment keys are automatically added to task hashing by the engine.
+  `CARGO_HOME`, `CARGO_TARGET_DIR`, config `target-dir`,
+  `--target-dir`, `CARGO_BUILD_TARGET`, and `--target` are hashed and therefore
+  produce isolated paths; no profile, target, or platform wildcard is emitted.
+  Repository `.cargo/config*` content is hashed; a config symlink resolving
+  outside the canonical repository is not hashed or trusted and fails closed.
+  Any ancestor or Cargo-home config file cannot be hashed by repository inputs
+  and makes automatic output resolution unavailable, regardless of which
+  settings it currently contains. `RUSTC`, `CARGO_BUILD_RUSTC`, and repository
+  `build.rustc` also fail closed
+  rather than applying the bare-rustc host probe to another compiler. Target
+  directories must remain inside the canonical repository through their
+  nearest existing ancestor, so symlink escapes fail closed. Manifest-defined
+  target `filename`, per-package `default-target`/`forced-target`, and profile
+  `dir-name` overrides likewise disable automatic outputs because metadata does
+  not expose their exact effective paths. Repository config `build.artifact-dir`,
+  profile `dir-name`, config includes, `CARGO_BUILD_ARTIFACT_DIR`, and
+  `CARGO_PROFILE_*_DIR_NAME` are also bounded fail-closed controls. Argument
+  parsing explicitly recognizes output-layout flags and a
+  fixed set of common layout-neutral `cargo build` flags; unknown options fail
+  closed so future Cargo output controls cannot silently inherit caching.
+  Cargo's internal target state (`deps`, fingerprints, incremental objects)
+  remains uncached. Unsupported target formats and invocation/config cases
+  whose layout cannot be resolved conservatively produce a distinct
+  "automatic outputs unavailable" result. The engine disables automatic
+  caching in that case when the user configured neither outputs nor cache
+  behavior, preventing a log-only hit from suppressing a required Cargo build;
+  explicit task I/O and
+  cache intent remain authoritative. For fine-grained compile caching,
+  `RUSTC_WRAPPER` (sccache) remains the sound layer. Entrypoint `run` and `dev`
+  tasks default to `cache: false`, because a hit must not suppress the requested
+  process; an explicit turbo.json `cache` setting overrides that default.
 
 - **Watch mode** (`Toolchain::watch_spec`, consumed by
   `turborepo-lib/src/package_changes_watcher.rs`): each toolchain declares

--- a/crates/turborepo/tests/cargo_workspace_test.rs
+++ b/crates/turborepo/tests/cargo_workspace_test.rs
@@ -12,7 +12,130 @@ mod common;
 
 use std::{fs, path::Path};
 
-use common::{run_turbo, run_turbo_with_env, setup};
+use common::setup;
+
+const AMBIENT_CARGO_LAYOUT_ENV: &[&str] = &[
+    "CARGO_HOME",
+    "CARGO_TARGET_DIR",
+    "CARGO_BUILD_TARGET_DIR",
+    "CARGO_BUILD_TARGET",
+    "CARGO_BUILD_ARTIFACT_DIR",
+    "RUSTC",
+    "CARGO_BUILD_RUSTC",
+    "HOME",
+    "USERPROFILE",
+    "RUSTUP_HOME",
+];
+
+fn ambient_cargo_layout_env_keys() -> Vec<std::ffi::OsString> {
+    let mut keys: Vec<_> = AMBIENT_CARGO_LAYOUT_ENV
+        .iter()
+        .map(std::ffi::OsString::from)
+        .collect();
+    keys.extend(std::env::vars_os().filter_map(|(name, _)| {
+        let name_string = name.to_string_lossy();
+        (name_string.starts_with("CARGO_PROFILE_") && name_string.ends_with("_DIR_NAME"))
+            .then_some(name)
+    }));
+    keys
+}
+
+fn cargo_ancestors_are_clean(dir: &Path) -> bool {
+    dir.ancestors().skip(1).all(|ancestor| {
+        ["config.toml", "config"]
+            .iter()
+            .all(|name| !ancestor.join(".cargo").join(name).exists())
+    })
+}
+
+fn cargo_tempdir() -> tempfile::TempDir {
+    let current = std::env::current_dir().expect("current directory is available");
+    let drive_root = current
+        .ancestors()
+        .last()
+        .expect("current directory has a filesystem root");
+    if let Ok(tempdir) = tempfile::Builder::new()
+        .prefix("turbo-cargo-")
+        .tempdir_in(drive_root)
+        && cargo_ancestors_are_clean(tempdir.path())
+    {
+        return tempdir;
+    }
+
+    let tempdir = tempfile::tempdir().expect("fallback Cargo fixture root is available");
+    assert!(
+        cargo_ancestors_are_clean(tempdir.path()),
+        "cannot create a Cargo fixture without inherited ancestor config"
+    );
+    tempdir
+}
+
+fn isolated_cargo_environment(dir: &Path) -> (std::path::PathBuf, std::path::PathBuf) {
+    let home = dir.join(".test-home");
+    let cargo_home = home.join(".cargo");
+    fs::create_dir_all(&cargo_home).unwrap();
+    (home, cargo_home)
+}
+
+fn rustup_home() -> Option<std::path::PathBuf> {
+    std::env::var_os("RUSTUP_HOME")
+        .map(std::path::PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("HOME").map(|home| std::path::Path::new(&home).join(".rustup"))
+        })
+        .or_else(|| {
+            std::env::var_os("USERPROFILE").map(|home| std::path::Path::new(&home).join(".rustup"))
+        })
+}
+
+fn cargo_command(dir: &Path) -> std::process::Command {
+    let (home, cargo_home) = isolated_cargo_environment(dir);
+    let mut command = std::process::Command::new("cargo");
+    for name in ambient_cargo_layout_env_keys() {
+        command.env_remove(name);
+    }
+    command
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .env("CARGO_HOME", cargo_home)
+        .current_dir(dir);
+    if let Some(rustup_home) = rustup_home() {
+        command.env("RUSTUP_HOME", rustup_home);
+    }
+    command
+}
+
+fn run_turbo(dir: &Path, args: &[&str]) -> std::process::Output {
+    run_turbo_with_env(dir, args, &[])
+}
+
+fn run_turbo_with_env(
+    dir: &Path,
+    args: &[&str],
+    environment: &[(&str, &str)],
+) -> std::process::Output {
+    let (home, cargo_home) = isolated_cargo_environment(dir);
+    let config_dir = tempfile::tempdir().expect("failed to create config tempdir");
+    let mut command = common::turbo_command(dir);
+    for name in ambient_cargo_layout_env_keys() {
+        command.env_remove(name);
+    }
+    command
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .env("CARGO_HOME", &cargo_home)
+        .env("TURBO_CONFIG_DIR_PATH", config_dir.path());
+    if let Some(rustup_home) = rustup_home() {
+        command.env("RUSTUP_HOME", rustup_home);
+    }
+    for (name, value) in environment {
+        command.env(name, value);
+    }
+    command
+        .args(args)
+        .output()
+        .expect("failed to execute turbo")
+}
 
 fn cargo_build_hash(dir: &Path, env: &[(&str, &str)]) -> String {
     let output = run_turbo_with_env(dir, &["build", "--filter=app", "--dry-run=json"], env);
@@ -31,12 +154,106 @@ fn setup_cargo_monorepo(dir: &Path) {
     setup::setup_integration_test(dir, "cargo_monorepo", "npm@10.5.0", false).unwrap();
 }
 
+fn cargo_binary(dir: &Path, segments: &[&str]) -> std::path::PathBuf {
+    let mut path = dir.to_path_buf();
+    path.extend(segments);
+    path.push(if cfg!(windows) { "app.exe" } else { "app" });
+    path
+}
+
+fn rustc_host_target() -> String {
+    let output = std::process::Command::new("rustc")
+        .arg("-vV")
+        .output()
+        .expect("rustc runs");
+    assert!(output.status.success());
+    String::from_utf8(output.stdout)
+        .expect("rustc output is UTF-8")
+        .lines()
+        .find_map(|line| line.strip_prefix("host: "))
+        .expect("rustc reports host target")
+        .to_string()
+}
+
+fn alternate_host_target(host: &str) -> &'static str {
+    if host == "x86_64-unknown-linux-gnu" {
+        "aarch64-unknown-linux-gnu"
+    } else {
+        "x86_64-unknown-linux-gnu"
+    }
+}
+
+fn run_cargo_build(dir: &Path, cargo_args: &[&str], env: &[(&str, &str)]) -> std::process::Output {
+    let mut args = vec!["build", "--filter=app", "--log-order", "grouped"];
+    if !cargo_args.is_empty() {
+        args.push("--");
+        args.extend_from_slice(cargo_args);
+    }
+    run_turbo_with_env(dir, &args, env)
+}
+
+fn cargo_build_definition(
+    dir: &Path,
+    cargo_args: &[&str],
+    env: &[(&str, &str)],
+) -> serde_json::Value {
+    let mut args = vec!["build", "--filter=app", "--dry-run=json"];
+    if !cargo_args.is_empty() {
+        args.push("--");
+        args.extend_from_slice(cargo_args);
+    }
+    let output = run_turbo_with_env(dir, &args, env);
+    assert!(output.status.success(), "dry-run failed: {output:?}");
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("dry-run JSON");
+    json["tasks"]
+        .as_array()
+        .and_then(|tasks| tasks.iter().find(|task| task["taskId"] == "app#build"))
+        .expect("app#build in graph")
+        .clone()
+}
+
+fn assert_isolated_restoration(
+    first_args: &[&str],
+    first_path: &[&str],
+    second_args: &[&str],
+    second_path: &[&str],
+    first_env: &[(&str, &str)],
+    second_env: &[(&str, &str)],
+) {
+    let tempdir = cargo_tempdir();
+    setup_cargo_monorepo(tempdir.path());
+    let first = cargo_binary(tempdir.path(), first_path);
+    let second = cargo_binary(tempdir.path(), second_path);
+
+    let output = run_cargo_build(tempdir.path(), first_args, first_env);
+    assert!(output.status.success(), "first build failed: {output:?}");
+    assert!(first.exists(), "first deliverable missing: {first:?}");
+    let output = run_cargo_build(tempdir.path(), second_args, second_env);
+    assert!(output.status.success(), "second build failed: {output:?}");
+    assert!(second.exists(), "second deliverable missing: {second:?}");
+
+    fs::remove_file(&first).unwrap();
+    fs::remove_file(&second).unwrap();
+    let output = run_cargo_build(tempdir.path(), second_args, second_env);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "restore failed: {output:?}");
+    assert!(
+        stdout.contains("FULL TURBO"),
+        "expected cache hit: {stdout}"
+    );
+    assert!(second.exists(), "effective deliverable was not restored");
+    assert!(
+        !first.exists(),
+        "cache restored a deliverable from another Cargo layout"
+    );
+}
+
 /// The fixture's turbo.json opts in via
 /// `futureFlags.experimentalCargoWorkspaces`; no environment variable is
 /// involved anywhere.
 #[test]
 fn test_cargo_packages_in_task_graph() {
-    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = cargo_tempdir();
     setup_cargo_monorepo(tempdir.path());
 
     let output = run_turbo(tempdir.path(), &["build", "--dry-run=json"]);
@@ -78,15 +295,23 @@ fn test_cargo_packages_in_task_graph() {
         .as_array()
         .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
         .unwrap_or_default();
+    let expected_output = if cfg!(windows) {
+        "../../target/debug/app.exe"
+    } else {
+        "../../target/debug/app"
+    };
+    assert!(outputs.contains(&expected_output));
     assert!(
-        outputs.iter().any(|o| o.ends_with("target/*/app")),
-        "bin deliverable must be an output, got {outputs:?}"
+        outputs
+            .iter()
+            .filter(|output| output.contains("target/"))
+            .all(|output| !output.contains('*'))
     );
 }
 
 #[test]
 fn test_cargo_semantic_environment_changes_task_hash() {
-    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = cargo_tempdir();
     setup_cargo_monorepo(tempdir.path());
 
     let baseline = cargo_build_hash(tempdir.path(), &[]);
@@ -114,7 +339,7 @@ fn test_cargo_semantic_environment_changes_task_hash() {
 
 #[test]
 fn test_cargo_workspace_requires_lockfile() {
-    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = cargo_tempdir();
     setup_cargo_monorepo(tempdir.path());
     let lockfile = tempdir.path().join("Cargo.lock");
     fs::remove_file(&lockfile).unwrap();
@@ -135,7 +360,7 @@ fn test_cargo_workspace_requires_lockfile() {
 
 #[test]
 fn test_cargo_workspace_rejects_stale_lockfile() {
-    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = cargo_tempdir();
     setup_cargo_monorepo(tempdir.path());
     let lockfile = tempdir.path().join("Cargo.lock");
     let original_lockfile = fs::read_to_string(&lockfile).unwrap();
@@ -167,7 +392,7 @@ fn test_cargo_workspace_rejects_stale_lockfile() {
 
 #[test]
 fn test_cargo_workspace_rejects_excluded_path_dependency() {
-    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = cargo_tempdir();
     setup_cargo_monorepo(tempdir.path());
 
     let root_manifest = tempdir.path().join("Cargo.toml");
@@ -195,9 +420,8 @@ fn test_cargo_workspace_rejects_excluded_path_dependency() {
     )
     .unwrap();
     fs::write(local.join("src/lib.rs"), "pub fn local() {}\n").unwrap();
-    let status = std::process::Command::new("cargo")
+    let status = cargo_command(tempdir.path())
         .arg("generate-lockfile")
-        .current_dir(tempdir.path())
         .status()
         .expect("cargo generate-lockfile runs");
     assert!(status.success());
@@ -226,7 +450,7 @@ fn test_cargo_workspace_rejects_excluded_path_dependency() {
 
 #[test]
 fn test_cargo_build_executes_caches_and_restores() {
-    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = cargo_tempdir();
     setup_cargo_monorepo(tempdir.path());
 
     // Cold: executes cargo.
@@ -271,8 +495,577 @@ fn test_cargo_build_executes_caches_and_restores() {
 }
 
 #[test]
+fn test_cargo_debug_and_release_caches_are_isolated_both_directions() {
+    assert_isolated_restoration(
+        &[],
+        &["target", "debug"],
+        &["--release"],
+        &["target", "release"],
+        &[],
+        &[],
+    );
+    assert_isolated_restoration(
+        &["--release"],
+        &["target", "release"],
+        &[],
+        &["target", "debug"],
+        &[],
+        &[],
+    );
+}
+
+#[test]
+fn test_cargo_custom_profile_cache_is_exact() {
+    let tempdir = cargo_tempdir();
+    setup_cargo_monorepo(tempdir.path());
+    let manifest = tempdir.path().join("Cargo.toml");
+    let contents = fs::read_to_string(&manifest).unwrap();
+    fs::write(
+        &manifest,
+        format!("{contents}\n[profile.ci]\ninherits = \"dev\"\n"),
+    )
+    .unwrap();
+    let debug = cargo_binary(tempdir.path(), &["target", "debug"]);
+    let custom = cargo_binary(tempdir.path(), &["target", "ci"]);
+
+    assert!(run_cargo_build(tempdir.path(), &[], &[]).status.success());
+    assert!(
+        run_cargo_build(tempdir.path(), &["--profile=ci"], &[])
+            .status
+            .success()
+    );
+    fs::remove_file(&debug).unwrap();
+    fs::remove_file(&custom).unwrap();
+    let output = run_cargo_build(tempdir.path(), &["--profile=ci"], &[]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "restore failed: {output:?}");
+    assert!(
+        stdout.contains("FULL TURBO"),
+        "expected cache hit: {stdout}"
+    );
+    assert!(custom.exists());
+    assert!(!debug.exists());
+}
+
+#[test]
+fn test_cargo_test_and_bench_profile_directories_restore_exactly() {
+    assert_isolated_restoration(
+        &["--release"],
+        &["target", "release"],
+        &["--profile=test"],
+        &["target", "debug"],
+        &[],
+        &[],
+    );
+    assert_isolated_restoration(
+        &[],
+        &["target", "debug"],
+        &["--profile=bench"],
+        &["target", "release"],
+        &[],
+        &[],
+    );
+}
+
+#[test]
+fn test_cargo_explicit_host_target_cache_is_exact() {
+    let host = rustc_host_target();
+    let target_arg = format!("--target={host}");
+    assert_isolated_restoration(
+        &[],
+        &["target", "debug"],
+        &[&target_arg],
+        &["target", &host, "debug"],
+        &[],
+        &[],
+    );
+}
+
+#[test]
+fn test_cargo_build_target_environment_cache_is_exact() {
+    let host = rustc_host_target();
+    assert_isolated_restoration(
+        &[],
+        &["target", "debug"],
+        &[],
+        &["target", &host, "debug"],
+        &[],
+        &[("CARGO_BUILD_TARGET", &host)],
+    );
+}
+
+#[test]
+fn test_cargo_target_precedence_restores_effective_host_output() {
+    let host = rustc_host_target();
+    let lower_target = alternate_host_target(&host);
+
+    let tempdir = cargo_tempdir();
+    setup_cargo_monorepo(tempdir.path());
+    let cargo_config = tempdir.path().join(".cargo");
+    fs::create_dir_all(&cargo_config).unwrap();
+    fs::write(
+        cargo_config.join("config.toml"),
+        format!("[build]\ntarget = \"{lower_target}\"\n"),
+    )
+    .unwrap();
+    let artifact = cargo_binary(tempdir.path(), &["target", &host, "debug"]);
+    let environment = [("CARGO_BUILD_TARGET", host.as_str())];
+    assert!(
+        run_cargo_build(tempdir.path(), &[], &environment)
+            .status
+            .success()
+    );
+    fs::remove_file(&artifact).unwrap();
+    let output = run_cargo_build(tempdir.path(), &[], &environment);
+    assert!(String::from_utf8_lossy(&output.stdout).contains("FULL TURBO"));
+    assert!(
+        artifact.exists(),
+        "environment target did not override config"
+    );
+
+    let tempdir = cargo_tempdir();
+    setup_cargo_monorepo(tempdir.path());
+    let target_arg = format!("--target={host}");
+    let artifact = cargo_binary(tempdir.path(), &["target", &host, "debug"]);
+    let environment = [("CARGO_BUILD_TARGET", lower_target)];
+    assert!(
+        run_cargo_build(tempdir.path(), &[&target_arg], &environment)
+            .status
+            .success()
+    );
+    fs::remove_file(&artifact).unwrap();
+    let output = run_cargo_build(tempdir.path(), &[&target_arg], &environment);
+    assert!(String::from_utf8_lossy(&output.stdout).contains("FULL TURBO"));
+    assert!(artifact.exists(), "CLI target did not override environment");
+}
+
+#[test]
+fn test_cargo_repository_config_target_is_uncached_and_target_qualified() {
+    let tempdir = cargo_tempdir();
+    setup_cargo_monorepo(tempdir.path());
+    fs::write(
+        tempdir.path().join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": { "experimentalCargoWorkspaces": true },
+  "tasks": { "build": { "dependsOn": ["^build"] } }
+}"#,
+    )
+    .unwrap();
+    let host = rustc_host_target();
+    let cargo_config = tempdir.path().join(".cargo");
+    fs::create_dir_all(&cargo_config).unwrap();
+    fs::write(
+        cargo_config.join("config.toml"),
+        format!("[build]\ntarget = \"{host}\"\n"),
+    )
+    .unwrap();
+    let artifact = cargo_binary(tempdir.path(), &["target", &host, "debug"]);
+
+    for _ in 0..2 {
+        let output = run_cargo_build(tempdir.path(), &[], &[]);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(output.status.success(), "build failed: {output:?}");
+        assert!(stdout.contains("cache bypass"), "expected bypass: {stdout}");
+        assert!(artifact.exists(), "target-qualified artifact missing");
+    }
+}
+
+#[test]
+fn test_cargo_per_package_target_manifest_is_uncached() {
+    let tempdir = cargo_tempdir();
+    setup_cargo_monorepo(tempdir.path());
+    fs::write(
+        tempdir.path().join("rust-toolchain.toml"),
+        "[toolchain]\nchannel = \"nightly-2026-04-10\"\n",
+    )
+    .unwrap();
+    fs::write(
+        tempdir.path().join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": { "experimentalCargoWorkspaces": true },
+  "tasks": { "build": { "dependsOn": ["^build"] } }
+}"#,
+    )
+    .unwrap();
+    let host = rustc_host_target();
+    let manifest = tempdir.path().join("crates/app/Cargo.toml");
+    let contents = fs::read_to_string(&manifest).unwrap();
+    fs::write(
+        &manifest,
+        format!(
+            "cargo-features = [\"per-package-target\"]\n{}",
+            contents.replacen(
+                "[package]",
+                &format!("[package]\ndefault-target = \"{host}\""),
+                1,
+            )
+        ),
+    )
+    .unwrap();
+
+    for _ in 0..2 {
+        let output = run_cargo_build(tempdir.path(), &[], &[]);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(output.status.success(), "build failed: {output:?}");
+        assert!(stdout.contains("cache bypass"), "expected bypass: {stdout}");
+    }
+}
+
+#[test]
+fn test_cargo_repository_config_and_layout_env_controls_fail_closed() {
+    for config in [
+        "[build]\nartifact-dir = \"copied-artifacts\"\n",
+        "[profile.ci]\ninherits = \"dev\"\ndir-name = \"profile-output\"\n",
+    ] {
+        let tempdir = cargo_tempdir();
+        setup_cargo_monorepo(tempdir.path());
+        fs::write(
+            tempdir.path().join("turbo.json"),
+            r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": { "experimentalCargoWorkspaces": true },
+  "tasks": { "build": { "dependsOn": ["^build"] } }
+}"#,
+        )
+        .unwrap();
+        let cargo_config = tempdir.path().join(".cargo");
+        fs::create_dir_all(&cargo_config).unwrap();
+        fs::write(cargo_config.join("config.toml"), config).unwrap();
+        let task = cargo_build_definition(tempdir.path(), &[], &[]);
+        assert_eq!(task["resolvedTaskDefinition"]["cache"], false);
+    }
+
+    let tempdir = cargo_tempdir();
+    setup_cargo_monorepo(tempdir.path());
+    fs::write(
+        tempdir.path().join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": { "experimentalCargoWorkspaces": true },
+  "tasks": { "build": { "dependsOn": ["^build"] } }
+}"#,
+    )
+    .unwrap();
+    for (name, value) in [
+        ("CARGO_BUILD_ARTIFACT_DIR", "copied-artifacts"),
+        ("CARGO_PROFILE_CI_DIR_NAME", "profile-output"),
+    ] {
+        let task = cargo_build_definition(tempdir.path(), &[], &[(name, value)]);
+        assert_eq!(task["resolvedTaskDefinition"]["cache"], false);
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn test_cargo_repository_config_symlink_escape_is_uncached() {
+    let fixture = cargo_tempdir();
+    let repo = fixture.path().join("repo");
+    fs::create_dir_all(&repo).unwrap();
+    setup_cargo_monorepo(&repo);
+    fs::write(
+        repo.join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": { "experimentalCargoWorkspaces": true },
+  "tasks": { "build": { "dependsOn": ["^build"] } }
+}"#,
+    )
+    .unwrap();
+    let host = rustc_host_target();
+    let outside_config = fixture.path().join("outside-config.toml");
+    fs::write(&outside_config, format!("[build]\ntarget = \"{host}\"\n")).unwrap();
+    fs::create_dir_all(repo.join(".cargo")).unwrap();
+    std::os::unix::fs::symlink(&outside_config, repo.join(".cargo/config.toml")).unwrap();
+    let artifact = cargo_binary(&repo, &["target", &host, "debug"]);
+
+    for _ in 0..2 {
+        let output = run_cargo_build(&repo, &[], &[]);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(output.status.success(), "build failed: {output:?}");
+        assert!(stdout.contains("cache bypass"), "expected bypass: {stdout}");
+        assert!(artifact.exists());
+    }
+}
+
+#[test]
+fn test_cargo_target_dir_argument_cache_is_exact() {
+    assert_isolated_restoration(
+        &[],
+        &["target", "debug"],
+        &["--target-dir=argument-target"],
+        &["argument-target", "debug"],
+        &[],
+        &[],
+    );
+}
+
+#[test]
+fn test_cargo_target_directory_environment_cache_is_exact() {
+    assert_isolated_restoration(
+        &[],
+        &["target", "debug"],
+        &[],
+        &["cargo-target", "debug"],
+        &[],
+        &[("CARGO_TARGET_DIR", "cargo-target")],
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_cargo_symlink_target_directory_escape_is_uncached() {
+    let fixture = cargo_tempdir();
+    let repo = fixture.path().join("repo");
+    fs::create_dir_all(&repo).unwrap();
+    setup_cargo_monorepo(&repo);
+    fs::write(
+        repo.join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": { "experimentalCargoWorkspaces": true },
+  "tasks": { "build": { "dependsOn": ["^build"] } }
+}"#,
+    )
+    .unwrap();
+    let outside = fixture.path().join("contained-outside-repo");
+    fs::create_dir_all(&outside).unwrap();
+    std::os::unix::fs::symlink(&outside, repo.join("escape")).unwrap();
+    let artifact = cargo_binary(&outside, &["build", "debug"]);
+
+    for _ in 0..2 {
+        let output = run_cargo_build(&repo, &[], &[("CARGO_TARGET_DIR", "escape/build")]);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(output.status.success(), "build failed: {output:?}");
+        assert!(stdout.contains("cache bypass"), "expected bypass: {stdout}");
+        assert!(artifact.exists());
+    }
+}
+
+#[test]
+fn test_cargo_config_target_directory_cache_is_exact() {
+    let tempdir = cargo_tempdir();
+    setup_cargo_monorepo(tempdir.path());
+    let default = cargo_binary(tempdir.path(), &["target", "debug"]);
+    assert!(run_cargo_build(tempdir.path(), &[], &[]).status.success());
+
+    let cargo_config = tempdir.path().join(".cargo");
+    fs::create_dir_all(&cargo_config).unwrap();
+    fs::write(
+        cargo_config.join("config.toml"),
+        "[build]\ntarget-dir = \"configured-target\"\n",
+    )
+    .unwrap();
+    let configured = cargo_binary(tempdir.path(), &["configured-target", "debug"]);
+    assert!(run_cargo_build(tempdir.path(), &[], &[]).status.success());
+    fs::remove_file(&default).unwrap();
+    fs::remove_file(&configured).unwrap();
+
+    let output = run_cargo_build(tempdir.path(), &[], &[]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "restore failed: {output:?}");
+    assert!(
+        stdout.contains("FULL TURBO"),
+        "expected cache hit: {stdout}"
+    );
+    assert!(configured.exists());
+    assert!(!default.exists());
+}
+
+#[test]
+fn test_cargo_target_dir_precedence_restores_only_effective_output() {
+    let tempdir = cargo_tempdir();
+    setup_cargo_monorepo(tempdir.path());
+    let cargo_config = tempdir.path().join(".cargo");
+    fs::create_dir_all(&cargo_config).unwrap();
+    fs::write(
+        cargo_config.join("config.toml"),
+        "[build]\ntarget-dir = \"config-target\"\n",
+    )
+    .unwrap();
+    let config = cargo_binary(tempdir.path(), &["config-target", "debug"]);
+    let environment = cargo_binary(tempdir.path(), &["env-target", "debug"]);
+    let cli = cargo_binary(tempdir.path(), &["cli-target", "debug"]);
+
+    assert!(run_cargo_build(tempdir.path(), &[], &[]).status.success());
+    assert!(
+        run_cargo_build(tempdir.path(), &[], &[("CARGO_TARGET_DIR", "env-target")],)
+            .status
+            .success()
+    );
+    assert!(
+        run_cargo_build(
+            tempdir.path(),
+            &["--target-dir=cli-target"],
+            &[("CARGO_TARGET_DIR", "env-target")],
+        )
+        .status
+        .success()
+    );
+    assert!(config.exists() && environment.exists() && cli.exists());
+    fs::remove_file(&config).unwrap();
+    fs::remove_file(&environment).unwrap();
+    fs::remove_file(&cli).unwrap();
+
+    let output = run_cargo_build(tempdir.path(), &[], &[("CARGO_TARGET_DIR", "env-target")]);
+    assert!(String::from_utf8_lossy(&output.stdout).contains("FULL TURBO"));
+    assert!(environment.exists());
+    assert!(!config.exists() && !cli.exists());
+    fs::remove_file(&environment).unwrap();
+
+    let output = run_cargo_build(
+        tempdir.path(),
+        &["--target-dir=cli-target"],
+        &[("CARGO_TARGET_DIR", "env-target")],
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("FULL TURBO"));
+    assert!(cli.exists());
+    assert!(!config.exists() && !environment.exists());
+}
+
+#[test]
+fn test_cargo_external_cargo_home_config_is_uncached_in_strict_mode() {
+    let tempdir = cargo_tempdir();
+    setup_cargo_monorepo(tempdir.path());
+    fs::write(
+        tempdir.path().join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": { "experimentalCargoWorkspaces": true },
+  "tasks": { "build": { "dependsOn": ["^build"] } }
+}"#,
+    )
+    .unwrap();
+    let cargo_home = tempdir.path().join("external-cargo-home");
+    fs::create_dir_all(&cargo_home).unwrap();
+    let target_dir = tempdir.path().join("cargo-home-target");
+    let target_dir_toml = target_dir.to_string_lossy().replace('\\', "\\\\");
+    fs::write(
+        cargo_home.join("config.toml"),
+        format!("[build]\ntarget-dir = \"{target_dir_toml}\"\n"),
+    )
+    .unwrap();
+    let cargo_home = cargo_home.to_string_lossy();
+
+    for _ in 0..2 {
+        let output = run_cargo_build(tempdir.path(), &[], &[("CARGO_HOME", cargo_home.as_ref())]);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(output.status.success(), "build failed: {output:?}");
+        assert!(stdout.contains("cache bypass"), "expected bypass: {stdout}");
+        assert!(cargo_binary(&target_dir, &["debug"]).exists());
+    }
+}
+
+#[test]
+fn test_cargo_compiler_overrides_disable_automatic_caching() {
+    for name in ["RUSTC", "CARGO_BUILD_RUSTC"] {
+        let tempdir = cargo_tempdir();
+        setup_cargo_monorepo(tempdir.path());
+        fs::write(
+            tempdir.path().join("turbo.json"),
+            r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": { "experimentalCargoWorkspaces": true },
+  "tasks": { "build": { "dependsOn": ["^build"] } }
+}"#,
+        )
+        .unwrap();
+        for _ in 0..2 {
+            let output = run_cargo_build(tempdir.path(), &[], &[(name, "rustc")]);
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            assert!(output.status.success(), "{name} build failed: {output:?}");
+            assert!(stdout.contains("cache bypass"), "{name} cached: {stdout}");
+        }
+    }
+}
+
+#[test]
+fn test_cargo_unresolved_layout_is_uncached_without_explicit_outputs() {
+    let tempdir = cargo_tempdir();
+    setup_cargo_monorepo(tempdir.path());
+    fs::write(
+        tempdir.path().join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": { "experimentalCargoWorkspaces": true },
+  "tasks": { "build": { "dependsOn": ["^build"] } }
+}"#,
+    )
+    .unwrap();
+    let cargo_args = ["--config", "build.target-dir='other-target'"];
+
+    for _ in 0..2 {
+        let output = run_cargo_build(tempdir.path(), &cargo_args, &[]);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(output.status.success(), "build failed: {output:?}");
+        assert!(
+            stdout.contains("cache bypass"),
+            "unresolved automatic outputs must not cache logs: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn test_cargo_unresolved_layout_preserves_explicit_cache_intent() {
+    for cache in [true, false] {
+        let tempdir = cargo_tempdir();
+        setup_cargo_monorepo(tempdir.path());
+        fs::write(
+            tempdir.path().join("turbo.json"),
+            format!(
+                r#"{{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": {{ "experimentalCargoWorkspaces": true }},
+  "tasks": {{ "app#build": {{ "cache": {cache} }} }}
+}}"#
+            ),
+        )
+        .unwrap();
+        let task = cargo_build_definition(
+            tempdir.path(),
+            &["--config", "build.target-dir='other-target'"],
+            &[],
+        );
+        assert_eq!(task["resolvedTaskDefinition"]["cache"], cache);
+    }
+}
+
+#[test]
+fn test_cargo_unresolved_layout_preserves_explicit_outputs() {
+    let tempdir = cargo_tempdir();
+    setup_cargo_monorepo(tempdir.path());
+    let output_name = if cfg!(windows) { "app.exe" } else { "app" };
+    fs::write(
+        tempdir.path().join("turbo.json"),
+        format!(
+            r#"{{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": {{ "experimentalCargoWorkspaces": true }},
+  "tasks": {{ "app#build": {{ "outputs": ["../../other-target/debug/{output_name}"] }} }}
+}}"#
+        ),
+    )
+    .unwrap();
+    let cargo_args = ["--config", "build.target-dir='other-target'"];
+    let output = run_cargo_build(tempdir.path(), &cargo_args, &[]);
+    assert!(output.status.success(), "build failed: {output:?}");
+    let artifact = cargo_binary(tempdir.path(), &["other-target", "debug"]);
+    assert!(artifact.exists(), "explicit output was not produced");
+    fs::remove_file(&artifact).unwrap();
+    let output = run_cargo_build(tempdir.path(), &cargo_args, &[]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "cache hit failed: {output:?}");
+    assert!(
+        stdout.contains("FULL TURBO"),
+        "expected cache hit: {stdout}"
+    );
+    assert!(artifact.exists(), "explicit output was not restored");
+}
+
+#[test]
 fn test_cargo_command_override_uses_only_configured_io() {
-    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = cargo_tempdir();
     setup_cargo_monorepo(tempdir.path());
     fs::write(
         tempdir.path().join("turbo.json"),
@@ -328,13 +1121,11 @@ fn test_cargo_command_override_uses_only_configured_io() {
     fs::write(&bin, "stale cargo deliverable").unwrap();
 
     let run = || {
-        let mut command = std::process::Command::new(env!("CARGO_BIN_EXE_turbo"));
-        command
-            .args(["run", "build", "--filter=app", "--log-order", "grouped"])
-            .env("OVERRIDE_ENV", "configured")
-            .current_dir(tempdir.path())
-            .output()
-            .expect("turbo runs")
+        run_turbo_with_env(
+            tempdir.path(),
+            &["run", "build", "--filter=app", "--log-order", "grouped"],
+            &[("OVERRIDE_ENV", "configured")],
+        )
     };
     let output = run();
     assert!(output.status.success(), "override failed: {output:?}");
@@ -356,7 +1147,7 @@ fn test_cargo_command_override_uses_only_configured_io() {
 
 #[test]
 fn test_cargo_run_and_dev_default_to_uncached() {
-    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = cargo_tempdir();
     setup_cargo_monorepo(tempdir.path());
 
     let output = run_turbo(
@@ -405,7 +1196,7 @@ fn test_cargo_run_and_dev_default_to_uncached() {
 
 #[test]
 fn test_explicit_cache_overrides_cargo_run_default() {
-    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = cargo_tempdir();
     setup_cargo_monorepo(tempdir.path());
     fs::write(
         tempdir.path().join("turbo.json"),
@@ -433,7 +1224,7 @@ fn test_explicit_cache_overrides_cargo_run_default() {
 
 #[test]
 fn test_command_override_uses_generic_cache_default_across_toolchains() {
-    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = cargo_tempdir();
     setup_cargo_monorepo(tempdir.path());
     fs::write(
         tempdir.path().join("turbo.json"),
@@ -499,7 +1290,7 @@ fn test_command_override_uses_generic_cache_default_across_toolchains() {
 
 #[test]
 fn test_dependency_crate_change_invalidates_entrypoint() {
-    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = cargo_tempdir();
     setup_cargo_monorepo(tempdir.path());
 
     let output = run_turbo(tempdir.path(), &["build", "--filter=app"]);
@@ -531,13 +1322,12 @@ fn test_dependency_crate_change_invalidates_entrypoint() {
 /// pruned output with `cargo build --locked`.
 #[test]
 fn test_prune_produces_buildable_cargo_workspace() {
-    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = cargo_tempdir();
     setup_cargo_monorepo(tempdir.path());
 
     // Prune requires a lockfile; generate it the way a real repo has one.
-    let status = std::process::Command::new("cargo")
+    let status = cargo_command(tempdir.path())
         .arg("generate-lockfile")
-        .current_dir(tempdir.path())
         .status()
         .expect("cargo generate-lockfile runs");
     assert!(status.success());
@@ -565,9 +1355,8 @@ fn test_prune_produces_buildable_cargo_workspace() {
 
     // The decisive assertion: the pruned workspace builds with the pruned
     // lockfile, strictly.
-    let build = std::process::Command::new("cargo")
+    let build = cargo_command(&out)
         .args(["build", "--locked", "-p", "app"])
-        .current_dir(&out)
         .output()
         .expect("cargo build runs");
     assert!(
@@ -575,7 +1364,7 @@ fn test_prune_produces_buildable_cargo_workspace() {
         "pruned workspace must build --locked: {}",
         String::from_utf8_lossy(&build.stderr)
     );
-    let run = std::process::Command::new(out.join("target/debug/app"))
+    let run = std::process::Command::new(cargo_binary(&out, &["target", "debug"]))
         .output()
         .expect("pruned binary runs");
     assert!(
@@ -588,11 +1377,10 @@ fn test_prune_produces_buildable_cargo_workspace() {
 /// dependencies (manifests + lockfile), the full layer carries sources.
 #[test]
 fn test_prune_docker_layout_for_cargo() {
-    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = cargo_tempdir();
     setup_cargo_monorepo(tempdir.path());
-    let status = std::process::Command::new("cargo")
+    let status = cargo_command(tempdir.path())
         .arg("generate-lockfile")
-        .current_dir(tempdir.path())
         .status()
         .expect("cargo generate-lockfile runs");
     assert!(status.success());
@@ -620,9 +1408,8 @@ fn test_prune_docker_layout_for_cargo() {
     let json_lock = fs::read(out.join("json/Cargo.lock")).unwrap();
     assert_eq!(full_lock, json_lock, "docker lockfiles must stay in sync");
 
-    let build = std::process::Command::new("cargo")
+    let build = cargo_command(&out.join("full"))
         .args(["build", "--locked", "-p", "app"])
-        .current_dir(out.join("full"))
         .output()
         .expect("cargo build runs");
     assert!(
@@ -636,7 +1423,7 @@ fn test_prune_docker_layout_for_cargo() {
 /// Cargo workspace files.
 #[test]
 fn test_prune_js_target_unaffected_by_cargo() {
-    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = cargo_tempdir();
     setup_cargo_monorepo(tempdir.path());
 
     let output = run_turbo(tempdir.path(), &["prune", "js-pkg"]);
@@ -650,7 +1437,7 @@ fn test_prune_js_target_unaffected_by_cargo() {
 
 #[test]
 fn test_prune_js_docker_target_skips_cargo_finalization() {
-    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = cargo_tempdir();
     setup_cargo_monorepo(tempdir.path());
 
     let output = run_turbo(tempdir.path(), &["prune", "js-pkg", "--docker"]);
@@ -673,7 +1460,7 @@ fn test_prune_js_docker_target_skips_cargo_finalization() {
 /// a pruneable target.
 #[test]
 fn test_prune_cargo_workspace_package_rejected() {
-    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = cargo_tempdir();
     setup_cargo_monorepo(tempdir.path());
 
     let output = run_turbo(tempdir.path(), &["prune", "acme"]);
@@ -687,7 +1474,7 @@ fn test_prune_cargo_workspace_package_rejected() {
 
 #[test]
 fn test_filter_hint_when_cargo_disabled() {
-    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = cargo_tempdir();
     setup_cargo_monorepo(tempdir.path());
 
     // Remove the opt-in: crates vanish from the graph, and filtering for
@@ -715,7 +1502,7 @@ fn test_filter_hint_when_cargo_disabled() {
 /// via the `rust` map key, and defines tasks even for library crates.
 #[test]
 fn test_command_override_on_cargo_packages() {
-    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = cargo_tempdir();
     setup_cargo_monorepo(tempdir.path());
 
     fs::write(


### PR DESCRIPTION
## Why
Cargo output wildcards could cache stale deliverables from another profile, target, target directory, or platform. Restoring those artifacts could corrupt builds, while log-only cache hits for unresolved layouts could suppress required Cargo execution.

## What
Resolve and cache only exact effective Cargo deliverable paths across profile, target, target directory, and platform selection. Unknown or externally influenced layouts fail closed by disabling automatic caching while preserving explicit outputs and cache intent.

## How
Pass narrowly projected, automatically hashed layout context into toolchain I/O derivation; use Cargo metadata and rustc host/target data; validate config, manifest, environment, argument, platform, and path-containment controls conservatively. Validated with 327 repository tests, complete engine/lib suites, 38 Cargo E2Es, cargo lint, cargo fmt, and final diff reviews.