### PR TITLE
refactor: Add `Toolchain` output availability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8150,6 +8150,7 @@ dependencies = [
  "tracing",
  "turbopath",
  "turborepo-config",
+ "turborepo-env",
  "turborepo-errors",
  "turborepo-graph-utils",
  "turborepo-lockfiles",

--- a/crates/turborepo-engine/Cargo.toml
+++ b/crates/turborepo-engine/Cargo.toml
@@ -21,6 +21,7 @@ tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 turbopath = { workspace = true }
 turborepo-config = { path = "../turborepo-config" }
+turborepo-env = { workspace = true }
 turborepo-errors = { workspace = true }
 turborepo-graph-utils = { path = "../turborepo-graph-utils" }
 turborepo-repository = { path = "../turborepo-repository" }

--- a/crates/turborepo-engine/src/builder.rs
+++ b/crates/turborepo-engine/src/builder.rs
@@ -58,6 +58,7 @@ pub struct EngineBuilder<'a, L: TurboJsonLoader> {
     /// prepended to every task's inputs instead of being included in the
     /// global hash.
     global_deps: Vec<String>,
+    global_env: Vec<String>,
     pass_through_args: Vec<String>,
     requested_tasks: Vec<String>,
     /// Each toolchain receives only the startup environment keys it declared.
@@ -85,6 +86,7 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
             validator: Validator::new(),
             future_flags: FutureFlags::default(),
             global_deps: Vec::new(),
+            global_env: Vec::new(),
             pass_through_args: Vec::new(),
             requested_tasks: Vec::new(),
             environments: HashMap::new(),
@@ -99,6 +101,11 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
 
     pub fn with_global_deps(mut self, global_deps: Vec<String>) -> Self {
         self.global_deps = global_deps;
+        self
+    }
+
+    pub fn with_global_env(mut self, global_env: Vec<String>) -> Self {
+        self.global_env = global_env;
         self
     }
 

--- a/crates/turborepo-engine/src/builder.rs
+++ b/crates/turborepo-engine/src/builder.rs
@@ -55,6 +55,9 @@ pub struct EngineBuilder<'a, L: TurboJsonLoader> {
     /// prepended to every task's inputs instead of being included in the
     /// global hash.
     global_deps: Vec<String>,
+    task_args: Vec<String>,
+    /// Only keys requested by registered toolchains for I/O derivation.
+    environment: HashMap<String, String>,
 }
 
 impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
@@ -78,6 +81,8 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
             validator: Validator::new(),
             future_flags: FutureFlags::default(),
             global_deps: Vec::new(),
+            task_args: Vec::new(),
+            environment: HashMap::new(),
         }
     }
 
@@ -89,6 +94,16 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
 
     pub fn with_global_deps(mut self, global_deps: Vec<String>) -> Self {
         self.global_deps = global_deps;
+        self
+    }
+
+    pub fn with_task_io_context(
+        mut self,
+        task_args: Vec<String>,
+        environment: HashMap<String, String>,
+    ) -> Self {
+        self.task_args = task_args;
+        self.environment = environment;
         self
     }
 

--- a/crates/turborepo-engine/src/builder.rs
+++ b/crates/turborepo-engine/src/builder.rs
@@ -17,7 +17,10 @@ use itertools::Itertools;
 use turbopath::{AbsoluteSystemPath, AnchoredSystemPathBuf, RelativeUnixPathBuf};
 use turborepo_errors::Spanned;
 use turborepo_graph_utils as graph;
-use turborepo_repository::package_graph::{PackageGraph, PackageName, PackageNode, ROOT_PKG_NAME};
+use turborepo_repository::{
+    package_graph::{PackageGraph, PackageName, PackageNode, ROOT_PKG_NAME},
+    toolchain::{TaskIOEnvironment, ToolchainId},
+};
 use turborepo_task_id::{TaskId, TaskName};
 use turborepo_turbo_json::{FutureFlags, TurboJson, Validator};
 use turborepo_types::TaskDefinition;
@@ -55,9 +58,10 @@ pub struct EngineBuilder<'a, L: TurboJsonLoader> {
     /// prepended to every task's inputs instead of being included in the
     /// global hash.
     global_deps: Vec<String>,
-    task_args: Vec<String>,
-    /// Only keys requested by registered toolchains for I/O derivation.
-    environment: HashMap<String, String>,
+    pass_through_args: Vec<String>,
+    requested_tasks: Vec<String>,
+    /// Each toolchain receives only the startup environment keys it declared.
+    environments: HashMap<ToolchainId, TaskIOEnvironment>,
 }
 
 impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
@@ -81,8 +85,9 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
             validator: Validator::new(),
             future_flags: FutureFlags::default(),
             global_deps: Vec::new(),
-            task_args: Vec::new(),
-            environment: HashMap::new(),
+            pass_through_args: Vec::new(),
+            requested_tasks: Vec::new(),
+            environments: HashMap::new(),
         }
     }
 
@@ -99,11 +104,13 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
 
     pub fn with_task_io_context(
         mut self,
-        task_args: Vec<String>,
-        environment: HashMap<String, String>,
+        pass_through_args: Vec<String>,
+        requested_tasks: Vec<String>,
+        environments: HashMap<ToolchainId, TaskIOEnvironment>,
     ) -> Self {
-        self.task_args = task_args;
-        self.environment = environment;
+        self.pass_through_args = pass_through_args;
+        self.requested_tasks = requested_tasks;
+        self.environments = environments;
         self
     }
 

--- a/crates/turborepo-engine/src/builder/definitions.rs
+++ b/crates/turborepo-engine/src/builder/definitions.rs
@@ -367,7 +367,7 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                     .get(&info.toolchain)
                     .unwrap_or(&empty_environment),
             };
-            if let Some(derived) = toolchain.derived_task_io(
+            if let Some(mut derived) = toolchain.derived_task_io(
                 info,
                 task_id.as_inner().task(),
                 path_to_root.as_str(),
@@ -375,6 +375,13 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                 wants_automatic_inputs,
                 &context,
             ) {
+                if task_io_env_exclusion_conflict(
+                    &task_def.env,
+                    &self.global_env,
+                    context.environment,
+                ) {
+                    derived.outputs = turborepo_repository::toolchain::DerivedOutputs::Unavailable;
+                }
                 apply_derived_task_io(
                     &mut task_def,
                     derived,
@@ -651,6 +658,31 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
 /// Levels 1–2 arrive merged as `scoped_command` (most specific already
 /// won); level 4 as `unscoped_command`. `None` means levels 3/5 are in
 /// charge: the toolchain resolves the command as it always has.
+fn task_io_env_exclusion_conflict(
+    task_env: &[String],
+    global_env: &[String],
+    environment: &turborepo_repository::toolchain::TaskIOEnvironment,
+) -> bool {
+    let exclusions: Vec<&str> = task_env
+        .iter()
+        .chain(global_env)
+        .filter(|pattern| pattern.starts_with('!'))
+        .map(String::as_str)
+        .collect();
+    if exclusions.is_empty() {
+        return false;
+    }
+    let projected = turborepo_env::EnvironmentVariableMap::from(
+        environment
+            .iter()
+            .map(|(name, value)| (name.to_string(), value.to_string()))
+            .collect::<HashMap<_, _>>(),
+    );
+    projected
+        .wildcard_map_from_wildcards_unresolved(&exclusions)
+        .map_or(true, |matches| !matches.exclusions.is_empty())
+}
+
 fn apply_derived_task_io(
     task_def: &mut TaskDefinition,
     derived: turborepo_repository::toolchain::DerivedTaskIO,

--- a/crates/turborepo-engine/src/builder/definitions.rs
+++ b/crates/turborepo-engine/src/builder/definitions.rs
@@ -288,6 +288,7 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                 .into_iter()
                 .map(|(definition, _)| definition),
         );
+        let had_explicit_cache = processed_task_definition.cache.is_some();
         // Toolchain defaults describe the command the toolchain synthesizes.
         // An override owns its behavior, including the generic cache default.
         if should_apply_toolchain_defaults(command_override.as_ref())
@@ -299,6 +300,7 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
             }
         }
         let had_explicit_inputs = processed_task_definition.inputs.is_some();
+        let had_explicit_outputs = processed_task_definition.outputs.is_some();
         let mut task_def =
             TaskDefinition::from_processed(processed_task_definition, &path_to_root)?;
         task_def.command = command_override;
@@ -356,24 +358,25 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                     _ => None,
                 })
                 .collect();
+            let context = turborepo_repository::toolchain::TaskIOContext {
+                task_args: &self.task_args,
+                environment: &self.environment,
+            };
             if let Some(derived) = toolchain.derived_task_io(
                 info,
                 task_id.as_inner().task(),
                 path_to_root.as_str(),
                 &dependencies,
                 wants_automatic_inputs,
+                &context,
             ) {
-                task_def.inputs.globs.extend(derived.input_globs);
-                if let Some(default) = derived.package_default_inputs {
-                    task_def.inputs.default = default;
-                }
-                for var in derived.env {
-                    if !task_def.env.contains(&var) {
-                        task_def.env.push(var);
-                    }
-                }
-                task_def.env.sort();
-                task_def.outputs.inclusions.extend(derived.output_globs);
+                apply_derived_task_io(
+                    &mut task_def,
+                    derived,
+                    toolchain.task_io_env_vars(),
+                    had_explicit_outputs,
+                    had_explicit_cache,
+                );
             }
         }
 
@@ -643,6 +646,41 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
 /// Levels 1–2 arrive merged as `scoped_command` (most specific already
 /// won); level 4 as `unscoped_command`. `None` means levels 3/5 are in
 /// charge: the toolchain resolves the command as it always has.
+fn apply_derived_task_io(
+    task_def: &mut TaskDefinition,
+    derived: turborepo_repository::toolchain::DerivedTaskIO,
+    task_io_env_vars: &[&str],
+    had_explicit_outputs: bool,
+    had_explicit_cache: bool,
+) {
+    for var in task_io_env_vars {
+        if !task_def.env.iter().any(|existing| existing == var) {
+            task_def.env.push((*var).to_string());
+        }
+    }
+    task_def.inputs.globs.extend(derived.input_globs);
+    if let Some(default) = derived.package_default_inputs {
+        task_def.inputs.default = default;
+    }
+    for var in derived.env {
+        if !task_def.env.contains(&var) {
+            task_def.env.push(var);
+        }
+    }
+    task_def.env.sort();
+    match derived.outputs {
+        turborepo_repository::toolchain::DerivedOutputs::Resolved(outputs) => {
+            task_def.outputs.inclusions.extend(outputs);
+        }
+        turborepo_repository::toolchain::DerivedOutputs::Unavailable
+            if !had_explicit_outputs && !had_explicit_cache =>
+        {
+            task_def.cache = false;
+        }
+        turborepo_repository::toolchain::DerivedOutputs::Unavailable => {}
+    }
+}
+
 fn resolve_command_override(
     scoped_command: Option<ProcessedCommand>,
     unscoped_command: Option<ProcessedCommand>,
@@ -871,5 +909,63 @@ mod command_override_tests {
         assert!(!inherits_toolchain_task_io(Some(
             &TaskCommandOverride::Argv(vec!["node".to_string(), "build.js".to_string(),])
         )));
+    }
+}
+
+#[cfg(test)]
+mod derived_io_tests {
+    use turborepo_repository::toolchain::{DerivedOutputs, DerivedTaskIO};
+    use turborepo_types::TaskDefinition;
+
+    use super::apply_derived_task_io;
+
+    #[test]
+    fn unavailable_outputs_disable_only_implicit_caching() {
+        let unavailable = || DerivedTaskIO {
+            outputs: DerivedOutputs::Unavailable,
+            ..Default::default()
+        };
+
+        let mut implicit = TaskDefinition::default();
+        apply_derived_task_io(&mut implicit, unavailable(), &[], false, false);
+        assert!(!implicit.cache);
+
+        let mut explicit_outputs = TaskDefinition::default();
+        explicit_outputs
+            .outputs
+            .inclusions
+            .push("configured/**".to_string());
+        apply_derived_task_io(&mut explicit_outputs, unavailable(), &[], true, false);
+        assert!(explicit_outputs.cache);
+        assert_eq!(explicit_outputs.outputs.inclusions, ["configured/**"]);
+
+        for cache in [true, false] {
+            let mut explicit_cache = TaskDefinition {
+                cache,
+                ..Default::default()
+            };
+            apply_derived_task_io(&mut explicit_cache, unavailable(), &[], false, true);
+            assert_eq!(explicit_cache.cache, cache);
+        }
+    }
+
+    #[test]
+    fn resolved_outputs_and_declared_environment_are_applied() {
+        let mut task = TaskDefinition::default();
+        apply_derived_task_io(
+            &mut task,
+            DerivedTaskIO {
+                env: vec!["DERIVED_ENV".to_string()],
+                outputs: DerivedOutputs::Resolved(vec!["dist/file".to_string()]),
+                ..Default::default()
+            },
+            &["LAYOUT_*"],
+            false,
+            false,
+        );
+
+        assert_eq!(task.outputs.inclusions, ["dist/file"]);
+        assert_eq!(task.env, ["DERIVED_ENV", "LAYOUT_*"]);
+        assert!(task.cache);
     }
 }

--- a/crates/turborepo-engine/src/builder/definitions.rs
+++ b/crates/turborepo-engine/src/builder/definitions.rs
@@ -10,7 +10,7 @@ use turborepo_task_id::{TaskId, TaskName};
 use turborepo_turbo_json::{
     HasConfigBeyondExtends, ProcessedCommand, ProcessedTaskDefinition, RawTaskDefinition, TurboJson,
 };
-use turborepo_types::{TaskCommandOverride, TaskDefinition};
+use turborepo_types::{TaskArgs, TaskCommandOverride, TaskDefinition};
 
 use super::EngineBuilder;
 use crate::{
@@ -358,9 +358,14 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                     _ => None,
                 })
                 .collect();
+            let task_args = TaskArgs::new(&self.pass_through_args, &self.requested_tasks);
+            let empty_environment = turborepo_repository::toolchain::TaskIOEnvironment::default();
             let context = turborepo_repository::toolchain::TaskIOContext {
-                task_args: &self.task_args,
-                environment: &self.environment,
+                task_args: task_args.args_for_task(task_id.as_inner()),
+                environment: self
+                    .environments
+                    .get(&info.toolchain)
+                    .unwrap_or(&empty_environment),
             };
             if let Some(derived) = toolchain.derived_task_io(
                 info,

--- a/crates/turborepo-engine/src/builder/test.rs
+++ b/crates/turborepo-engine/src/builder/test.rs
@@ -1,4 +1,7 @@
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{Arc, Mutex},
+};
 
 use insta::{assert_json_snapshot, assert_snapshot};
 use serde_json::json;
@@ -12,6 +15,10 @@ use turborepo_repository::{
     package_graph::{PackageGraph, PackageName},
     package_json::PackageJson,
     package_manager::PackageManager,
+    toolchain::{
+        DerivedOutputs, DerivedTaskIO, DiscoverPackagesFuture, DiscoveredPackage, TaskIOContext,
+        Toolchain, ToolchainId,
+    },
 };
 use turborepo_task_id::{TaskId, TaskName};
 use turborepo_turbo_json::{
@@ -19,7 +26,9 @@ use turborepo_turbo_json::{
 };
 use turborepo_types::{OutputLogsMode, TaskDefinition};
 
-use crate::{BuilderError, Built, CyclicExtends, EngineBuilder, TaskInheritanceResolver, TaskNode};
+use crate::{
+    BuilderError, Built, CyclicExtends, Engine, EngineBuilder, TaskInheritanceResolver, TaskNode,
+};
 
 /// Test implementation of TurboJsonLoader that returns pre-configured
 /// TurboJson structures without reading from disk.
@@ -108,6 +117,117 @@ impl PackageDiscovery for MockDiscovery {
     > {
         self.discover_packages().await
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SeenTaskIO {
+    args: Option<Vec<String>>,
+    layout_env: Option<String>,
+}
+
+type StubIOEngineResult = (
+    Engine<Built, TaskDefinition>,
+    Arc<Mutex<HashMap<String, SeenTaskIO>>>,
+);
+
+struct StubIOToolchain {
+    repo_root: AbsoluteSystemPathBuf,
+    outputs: DerivedOutputs,
+    environment: Vec<&'static str>,
+    seen: Arc<Mutex<HashMap<String, SeenTaskIO>>>,
+}
+
+impl Toolchain for StubIOToolchain {
+    fn id(&self) -> ToolchainId {
+        ToolchainId::new("stub-io")
+    }
+
+    fn discover_packages(&self) -> DiscoverPackagesFuture<'_> {
+        Box::pin(async move {
+            let package = |name: &str, dependencies: &[(&str, &str)]| DiscoveredPackage {
+                descriptor: PackageJson {
+                    name: Some(Spanned::new(name.to_string())),
+                    dependencies: Some(
+                        dependencies
+                            .iter()
+                            .map(|(name, version)| (name.to_string(), version.to_string()))
+                            .collect(),
+                    ),
+                    ..Default::default()
+                },
+                manifest_path: self
+                    .repo_root
+                    .join_components(&["packages", name, "stub.json"]),
+                external_dependencies: Some(HashSet::new()),
+            };
+            Ok(vec![
+                package("app", &[("lib", "workspace:*")]),
+                package("lib", &[]),
+            ])
+        })
+    }
+
+    fn defines_task(
+        &self,
+        _package: &turborepo_repository::package_graph::PackageInfo,
+        task: &str,
+    ) -> bool {
+        matches!(task, "build" | "test")
+    }
+
+    fn derives_task_io(
+        &self,
+        package: &turborepo_repository::package_graph::PackageInfo,
+        task: &str,
+    ) -> bool {
+        self.defines_task(package, task)
+    }
+
+    fn task_io_env_vars(&self) -> &[&str] {
+        &self.environment
+    }
+
+    fn derived_task_io(
+        &self,
+        package: &turborepo_repository::package_graph::PackageInfo,
+        task: &str,
+        _path_to_root: &str,
+        _dependencies: &[&turborepo_repository::package_graph::PackageInfo],
+        _wants_automatic_inputs: bool,
+        context: &TaskIOContext<'_>,
+    ) -> Option<DerivedTaskIO> {
+        let package_name = package.package_name()?;
+        self.seen.lock().unwrap().insert(
+            format!("{package_name}#{task}"),
+            SeenTaskIO {
+                args: context.task_args.map(<[String]>::to_vec),
+                layout_env: context.environment.get("STUB_LAYOUT").map(str::to_string),
+            },
+        );
+        Some(DerivedTaskIO {
+            outputs: self.outputs.clone(),
+            ..Default::default()
+        })
+    }
+}
+
+fn stub_io_package_graph(
+    repo_root: &turbopath::AbsoluteSystemPath,
+    toolchain: Arc<StubIOToolchain>,
+) -> PackageGraph {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(
+        PackageGraph::builder(repo_root, PackageJson::default())
+            .with_package_discovery(MockDiscovery)
+            .with_lockfile(Some(Box::new(MockLockfile)))
+            .with_package_jsons(Some(HashMap::new()))
+            .with_toolchain(toolchain)
+            .build(),
+    )
+    .unwrap()
 }
 
 macro_rules! package_jsons {

--- a/crates/turborepo-engine/src/builder/test/core.rs
+++ b/crates/turborepo-engine/src/builder/test/core.rs
@@ -951,6 +951,7 @@ fn stub_io_engine(
     task: &str,
     pass_through_args: Vec<String>,
     requested_tasks: Vec<String>,
+    global_env: Vec<String>,
 ) -> StubIOEngineResult {
     let repo_root_dir = TempDir::with_prefix("stub-io").unwrap();
     let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
@@ -965,7 +966,10 @@ fn stub_io_engine(
     let loader = TestTurboJsonLoader::new(
         vec![(
             PackageName::Root,
-            turbo_json(json!({ "tasks": task_definition })),
+            turbo_json(json!({
+                "globalEnv": global_env.clone(),
+                "tasks": task_definition
+            })),
         )]
         .into_iter()
         .collect(),
@@ -980,6 +984,7 @@ fn stub_io_engine(
     let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
         .with_tasks(Some(Spanned::new(TaskName::from(task).into_owned())))
         .with_workspaces(vec![PackageName::from("app")])
+        .with_global_env(global_env)
         .with_task_io_context(pass_through_args, requested_tasks, environments)
         .build()
         .unwrap();
@@ -997,6 +1002,7 @@ fn test_task_io_args_align_with_execution_for_dependencies() {
         "test",
         vec!["--requested".to_string()],
         vec!["test".to_string()],
+        Vec::new(),
     );
     let seen = seen.lock().unwrap();
     assert_eq!(
@@ -1034,6 +1040,7 @@ fn test_unavailable_outputs_respect_merged_task_configuration() {
             "build",
             Vec::new(),
             vec!["build".to_string()],
+            Vec::new(),
         );
         let task = engine
             .task_definition(&TaskId::new("app", "build"))
@@ -1041,5 +1048,75 @@ fn test_unavailable_outputs_respect_merged_task_configuration() {
         assert_eq!(task.cache, expected_cache);
         assert_eq!(task.outputs.inclusions, expected_outputs);
         assert!(task.env.contains(&"STUB_LAYOUT".to_string()));
+    }
+}
+
+#[test]
+fn test_layout_env_exclusions_disable_implicit_outputs_in_all_env_modes() {
+    for env_mode in ["strict", "loose"] {
+        for exclusion in ["!STUB_LAYOUT", "!STUB_*"] {
+            let (engine, seen) = stub_io_engine(
+                json!({
+                    "build": {
+                        "env": [exclusion],
+                        "envMode": env_mode
+                    }
+                }),
+                DerivedOutputs::Resolved(vec!["automatic-output".to_string()]),
+                "build",
+                Vec::new(),
+                vec!["build".to_string()],
+                Vec::new(),
+            );
+            let task = engine
+                .task_definition(&TaskId::new("app", "build"))
+                .unwrap();
+            assert!(!task.cache, "{env_mode} {exclusion} must fail closed");
+            assert!(task.outputs.inclusions.is_empty());
+            assert!(task.env.contains(&exclusion.to_string()));
+            assert!(task.env.contains(&"STUB_LAYOUT".to_string()));
+            assert_eq!(
+                seen.lock().unwrap().get("app#build").unwrap().layout_env,
+                Some("layout-value".to_string())
+            );
+        }
+    }
+
+    let (engine, _) = stub_io_engine(
+        json!({ "build": { "envMode": "loose" } }),
+        DerivedOutputs::Resolved(vec!["automatic-output".to_string()]),
+        "build",
+        Vec::new(),
+        vec!["build".to_string()],
+        vec!["!STUB_*".to_string()],
+    );
+    let task = engine
+        .task_definition(&TaskId::new("app", "build"))
+        .unwrap();
+    assert!(!task.cache, "global env exclusions must also fail closed");
+    assert!(task.outputs.inclusions.is_empty());
+}
+
+#[test]
+fn test_nonconflicting_env_exclusions_keep_resolved_outputs() {
+    for env_mode in ["strict", "loose"] {
+        let (engine, _) = stub_io_engine(
+            json!({
+                "build": {
+                    "env": ["!UNRELATED_*"],
+                    "envMode": env_mode
+                }
+            }),
+            DerivedOutputs::Resolved(vec!["automatic-output".to_string()]),
+            "build",
+            Vec::new(),
+            vec!["build".to_string()],
+            Vec::new(),
+        );
+        let task = engine
+            .task_definition(&TaskId::new("app", "build"))
+            .unwrap();
+        assert!(task.cache);
+        assert_eq!(task.outputs.inclusions, ["automatic-output"]);
     }
 }

--- a/crates/turborepo-engine/src/builder/test/core.rs
+++ b/crates/turborepo-engine/src/builder/test/core.rs
@@ -944,3 +944,102 @@ fn test_path_to_root() {
         "../.."
     );
 }
+
+fn stub_io_engine(
+    task_definition: serde_json::Value,
+    outputs: turborepo_repository::toolchain::DerivedOutputs,
+    task: &str,
+    pass_through_args: Vec<String>,
+    requested_tasks: Vec<String>,
+) -> StubIOEngineResult {
+    let repo_root_dir = TempDir::with_prefix("stub-io").unwrap();
+    let repo_root = AbsoluteSystemPathBuf::new(repo_root_dir.path().to_str().unwrap()).unwrap();
+    let seen = Arc::new(Mutex::new(HashMap::new()));
+    let toolchain = Arc::new(StubIOToolchain {
+        repo_root: repo_root.clone(),
+        outputs,
+        environment: vec!["STUB_LAYOUT"],
+        seen: seen.clone(),
+    });
+    let package_graph = stub_io_package_graph(&repo_root, toolchain);
+    let loader = TestTurboJsonLoader::new(
+        vec![(
+            PackageName::Root,
+            turbo_json(json!({ "tasks": task_definition })),
+        )]
+        .into_iter()
+        .collect(),
+    );
+    let environments = HashMap::from([(
+        ToolchainId::new("stub-io"),
+        turborepo_repository::toolchain::TaskIOEnvironment::new(HashMap::from([(
+            "STUB_LAYOUT".to_string(),
+            "layout-value".to_string(),
+        )])),
+    )]);
+    let engine = EngineBuilder::new(&repo_root, &package_graph, &loader, false)
+        .with_tasks(Some(Spanned::new(TaskName::from(task).into_owned())))
+        .with_workspaces(vec![PackageName::from("app")])
+        .with_task_io_context(pass_through_args, requested_tasks, environments)
+        .build()
+        .unwrap();
+    (engine, seen)
+}
+
+#[test]
+fn test_task_io_args_align_with_execution_for_dependencies() {
+    let (_engine, seen) = stub_io_engine(
+        json!({
+            "test": { "dependsOn": ["^build"] },
+            "build": {}
+        }),
+        DerivedOutputs::Resolved(Vec::new()),
+        "test",
+        vec!["--requested".to_string()],
+        vec!["test".to_string()],
+    );
+    let seen = seen.lock().unwrap();
+    assert_eq!(
+        seen.get("app#test"),
+        Some(&SeenTaskIO {
+            args: Some(vec!["--requested".to_string()]),
+            layout_env: Some("layout-value".to_string()),
+        })
+    );
+    assert_eq!(
+        seen.get("lib#build"),
+        Some(&SeenTaskIO {
+            args: None,
+            layout_env: Some("layout-value".to_string()),
+        })
+    );
+}
+
+#[test]
+fn test_unavailable_outputs_respect_merged_task_configuration() {
+    for (definition, expected_cache, expected_outputs) in [
+        (json!({ "build": {} }), false, Vec::<String>::new()),
+        (json!({ "build": { "cache": true } }), true, Vec::new()),
+        (json!({ "build": { "cache": false } }), false, Vec::new()),
+        (
+            json!({ "build": { "outputs": ["configured/**"] } }),
+            true,
+            vec!["configured/**".to_string()],
+        ),
+        (json!({ "build": { "outputs": [] } }), true, Vec::new()),
+    ] {
+        let (engine, _) = stub_io_engine(
+            definition,
+            DerivedOutputs::Unavailable,
+            "build",
+            Vec::new(),
+            vec!["build".to_string()],
+        );
+        let task = engine
+            .task_definition(&TaskId::new("app", "build"))
+            .unwrap();
+        assert_eq!(task.cache, expected_cache);
+        assert_eq!(task.outputs.inclusions, expected_outputs);
+        assert!(task.env.contains(&"STUB_LAYOUT".to_string()));
+    }
+}

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -52,13 +52,23 @@ use crate::{
 fn project_task_io_environment(
     toolchains: &turborepo_repository::toolchain::ToolchainRegistry,
     environment: &EnvironmentVariableMap,
-) -> Result<HashMap<String, String>, turborepo_env::Error> {
-    let mut projected = EnvironmentVariableMap::default();
-    for toolchain in toolchains.iter() {
-        let selected = environment.from_wildcards(toolchain.task_io_env_vars())?;
-        projected.union(&selected);
-    }
-    Ok(projected.into_inner())
+) -> Result<
+    HashMap<
+        turborepo_repository::toolchain::ToolchainId,
+        turborepo_repository::toolchain::TaskIOEnvironment,
+    >,
+    turborepo_env::Error,
+> {
+    toolchains
+        .iter()
+        .map(|toolchain| {
+            let selected = environment.from_wildcards(toolchain.task_io_env_vars())?;
+            Ok((
+                toolchain.id(),
+                turborepo_repository::toolchain::TaskIOEnvironment::new(selected.into_inner()),
+            ))
+        })
+        .collect()
 }
 
 pub struct RunBuilder {
@@ -1115,6 +1125,7 @@ impl RunBuilder {
         .with_global_deps(global_deps_for_task_inputs)
         .with_task_io_context(
             self.opts.run_opts.pass_through_args.clone(),
+            self.opts.run_opts.tasks.clone(),
             task_io_environment,
         )
         .with_tasks(tasks);
@@ -1202,49 +1213,107 @@ mod task_io_context_tests {
     use std::{collections::HashMap, sync::Arc};
 
     use turborepo_env::EnvironmentVariableMap;
+    use turborepo_hash::TaskHashable;
     use turborepo_repository::toolchain::{
         DiscoverPackagesFuture, Toolchain, ToolchainId, ToolchainRegistry,
     };
+    use turborepo_types::EnvMode;
 
     use super::project_task_io_environment;
 
-    struct Stub;
+    struct Stub {
+        id: ToolchainId,
+        environment: Vec<&'static str>,
+    }
 
     impl Toolchain for Stub {
         fn id(&self) -> ToolchainId {
-            ToolchainId::new("stub")
+            self.id.clone()
         }
 
         fn discover_packages(&self) -> DiscoverPackagesFuture<'_> {
             Box::pin(async { Ok(Vec::new()) })
         }
 
-        fn task_io_env_vars(&self) -> &'static [&'static str] {
-            &["LAYOUT_*", "EXACT_LAYOUT"]
+        fn task_io_env_vars(&self) -> &[&str] {
+            &self.environment
         }
     }
 
     #[test]
-    fn projection_includes_declared_environment_only() {
+    fn projection_is_isolated_per_toolchain() {
+        let alpha = ToolchainId::new("alpha");
+        let beta = ToolchainId::new("beta");
         let mut toolchains = ToolchainRegistry::new();
-        toolchains.register(Arc::new(Stub));
+        toolchains.register(Arc::new(Stub {
+            id: alpha.clone(),
+            environment: vec!["ALPHA_*"],
+        }));
+        toolchains.register(Arc::new(Stub {
+            id: beta.clone(),
+            environment: vec!["BETA_KEY"],
+        }));
         let environment = EnvironmentVariableMap::from(HashMap::from([
-            ("LAYOUT_TARGET".to_string(), "target".to_string()),
-            ("EXACT_LAYOUT".to_string(), "exact".to_string()),
+            ("ALPHA_TARGET".to_string(), "alpha".to_string()),
+            ("BETA_KEY".to_string(), "beta".to_string()),
             ("UNDECLARED_SECRET".to_string(), "secret".to_string()),
         ]));
 
         let projected = project_task_io_environment(&toolchains, &environment).unwrap();
         assert_eq!(projected.len(), 2);
-        assert_eq!(
-            projected.get("LAYOUT_TARGET").map(String::as_str),
-            Some("target")
-        );
-        assert_eq!(
-            projected.get("EXACT_LAYOUT").map(String::as_str),
-            Some("exact")
-        );
-        assert!(!projected.contains_key("UNDECLARED_SECRET"));
+        let alpha_environment = projected.get(&alpha).unwrap();
+        assert_eq!(alpha_environment.get("ALPHA_TARGET"), Some("alpha"));
+        assert_eq!(alpha_environment.get("BETA_KEY"), None);
+        assert_eq!(alpha_environment.get("UNDECLARED_SECRET"), None);
+        let beta_environment = projected.get(&beta).unwrap();
+        assert_eq!(beta_environment.get("BETA_KEY"), Some("beta"));
+        assert_eq!(beta_environment.get("ALPHA_TARGET"), None);
+        assert_eq!(beta_environment.get("UNDECLARED_SECRET"), None);
+    }
+
+    fn projected_task_hash(layout: &str, secret: &str) -> String {
+        let alpha = ToolchainId::new("alpha");
+        let mut toolchains = ToolchainRegistry::new();
+        toolchains.register(Arc::new(Stub {
+            id: alpha.clone(),
+            environment: vec!["ALPHA_*"],
+        }));
+        let environment = EnvironmentVariableMap::from(HashMap::from([
+            ("ALPHA_TARGET".to_string(), layout.to_string()),
+            ("UNDECLARED_SECRET".to_string(), secret.to_string()),
+        ]));
+        let projected = project_task_io_environment(&toolchains, &environment).unwrap();
+        let layout = projected
+            .get(&alpha)
+            .and_then(|environment| environment.get("ALPHA_TARGET"))
+            .unwrap();
+        let declared = vec!["ALPHA_*".to_string()];
+
+        TaskHashable {
+            global_hash: "global",
+            task_dependency_hashes: Vec::new(),
+            hash_of_files: "files",
+            external_deps_hash: None,
+            package_dir: None,
+            task: "build",
+            outputs: Default::default(),
+            pass_through_args: &[],
+            env: &declared,
+            resolved_env_vars: vec![format!("ALPHA_TARGET={layout}")],
+            pass_through_env: &[],
+            env_mode: EnvMode::Strict,
+            command_override: &[],
+            command_opt_out: false,
+        }
+        .calculate_task_hash()
+        .unwrap()
+    }
+
+    #[test]
+    fn projected_declared_environment_changes_task_hash_only() {
+        let baseline = projected_task_hash("one", "secret-one");
+        assert_ne!(baseline, projected_task_hash("two", "secret-one"));
+        assert_eq!(baseline, projected_task_hash("one", "secret-two"));
     }
 }
 

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -49,6 +49,18 @@ use crate::{
     turbo_json::{TurboJson, TurboJsonReader, UnifiedTurboJsonLoader},
 };
 
+fn project_task_io_environment(
+    toolchains: &turborepo_repository::toolchain::ToolchainRegistry,
+    environment: &EnvironmentVariableMap,
+) -> Result<HashMap<String, String>, turborepo_env::Error> {
+    let mut projected = EnvironmentVariableMap::default();
+    for toolchain in toolchains.iter() {
+        let selected = environment.from_wildcards(toolchain.task_io_env_vars())?;
+        projected.union(&selected);
+    }
+    Ok(projected.into_inner())
+}
+
 pub struct RunBuilder {
     processes: ProcessManager,
     opts: Opts,
@@ -791,6 +803,7 @@ impl RunBuilder {
             &root_turbo_json,
             engine_pkgs,
             &turbo_json_loader,
+            &env_at_execution_start,
         )?;
 
         let task_access = {
@@ -815,6 +828,7 @@ impl RunBuilder {
                 &root_turbo_json,
                 engine_pkgs,
                 &turbo_json_loader,
+                &env_at_execution_start,
             )?;
         }
 
@@ -1072,6 +1086,7 @@ impl RunBuilder {
         root_turbo_json: &TurboJson,
         filtered_pkgs: impl Iterator<Item = &'a PackageName>,
         turbo_json_loader: &impl turborepo_engine::TurboJsonLoader,
+        environment: &EnvironmentVariableMap,
     ) -> Result<Engine, Error> {
         let tasks = self.opts.run_opts.tasks.iter().map(|task| {
             // TODO: Pull span info from command
@@ -1084,6 +1099,9 @@ impl RunBuilder {
         } else {
             Vec::new()
         };
+        let task_io_environment =
+            project_task_io_environment(pkg_dep_graph.toolchains(), environment)
+                .map_err(Error::Env)?;
         let mut builder = EngineBuilder::new(
             &self.repo_root,
             pkg_dep_graph,
@@ -1095,6 +1113,10 @@ impl RunBuilder {
         .with_workspaces(filtered_pkgs.cloned().collect())
         .with_future_flags(self.opts.future_flags)
         .with_global_deps(global_deps_for_task_inputs)
+        .with_task_io_context(
+            self.opts.run_opts.pass_through_args.clone(),
+            task_io_environment,
+        )
         .with_tasks(tasks);
 
         if self.add_all_tasks {
@@ -1173,6 +1195,57 @@ fn origins_match(url1: &str, url2: &str) -> bool {
 
 fn has_userinfo(url: &Url) -> bool {
     !url.username().is_empty() || url.password().is_some()
+}
+
+#[cfg(test)]
+mod task_io_context_tests {
+    use std::{collections::HashMap, sync::Arc};
+
+    use turborepo_env::EnvironmentVariableMap;
+    use turborepo_repository::toolchain::{
+        DiscoverPackagesFuture, Toolchain, ToolchainId, ToolchainRegistry,
+    };
+
+    use super::project_task_io_environment;
+
+    struct Stub;
+
+    impl Toolchain for Stub {
+        fn id(&self) -> ToolchainId {
+            ToolchainId::new("stub")
+        }
+
+        fn discover_packages(&self) -> DiscoverPackagesFuture<'_> {
+            Box::pin(async { Ok(Vec::new()) })
+        }
+
+        fn task_io_env_vars(&self) -> &'static [&'static str] {
+            &["LAYOUT_*", "EXACT_LAYOUT"]
+        }
+    }
+
+    #[test]
+    fn projection_includes_declared_environment_only() {
+        let mut toolchains = ToolchainRegistry::new();
+        toolchains.register(Arc::new(Stub));
+        let environment = EnvironmentVariableMap::from(HashMap::from([
+            ("LAYOUT_TARGET".to_string(), "target".to_string()),
+            ("EXACT_LAYOUT".to_string(), "exact".to_string()),
+            ("UNDECLARED_SECRET".to_string(), "secret".to_string()),
+        ]));
+
+        let projected = project_task_io_environment(&toolchains, &environment).unwrap();
+        assert_eq!(projected.len(), 2);
+        assert_eq!(
+            projected.get("LAYOUT_TARGET").map(String::as_str),
+            Some("target")
+        );
+        assert_eq!(
+            projected.get("EXACT_LAYOUT").map(String::as_str),
+            Some("exact")
+        );
+        assert!(!projected.contains_key("UNDECLARED_SECRET"));
+    }
 }
 
 #[cfg(test)]

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -1123,6 +1123,7 @@ impl RunBuilder {
         .with_workspaces(filtered_pkgs.cloned().collect())
         .with_future_flags(self.opts.future_flags)
         .with_global_deps(global_deps_for_task_inputs)
+        .with_global_env(root_turbo_json.global_env.clone())
         .with_task_io_context(
             self.opts.run_opts.pass_through_args.clone(),
             self.opts.run_opts.tasks.clone(),

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -2525,9 +2525,9 @@ release: 1.96.0-nightly\n",
         let app = package_info("app", "crates/app/Cargo.toml");
         let lib_a = package_info("lib-a", "crates/lib-a/Cargo.toml");
         let workspace = package_info("fixture-ws", "Cargo.toml");
-        let environment = HashMap::new();
+        let environment = toolchain::TaskIOEnvironment::default();
         let context = toolchain::TaskIOContext {
-            task_args: &[],
+            task_args: None,
             environment: &environment,
         };
 

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -1010,6 +1010,7 @@ impl Toolchain for CargoToolchain {
         path_to_root: &str,
         dependencies: &[&crate::package_graph::PackageInfo],
         wants_automatic_inputs: bool,
+        _context: &toolchain::TaskIOContext<'_>,
     ) -> Option<toolchain::DerivedTaskIO> {
         let name = package.package_name()?;
         let details = self.package_details(&name)?;
@@ -1060,7 +1061,10 @@ impl Toolchain for CargoToolchain {
                     io.input_globs.extend(dependency_globs());
                 }
                 if subcommand == "build" {
-                    io.output_globs = deliverable_output_globs(path_to_root, &details.deliverables);
+                    io.outputs = toolchain::DerivedOutputs::Resolved(deliverable_output_globs(
+                        path_to_root,
+                        &details.deliverables,
+                    ));
                 }
             }
             // The workspace package's directory is the repo root, so
@@ -2521,6 +2525,11 @@ release: 1.96.0-nightly\n",
         let app = package_info("app", "crates/app/Cargo.toml");
         let lib_a = package_info("lib-a", "crates/lib-a/Cargo.toml");
         let workspace = package_info("fixture-ws", "Cargo.toml");
+        let environment = HashMap::new();
+        let context = toolchain::TaskIOContext {
+            task_args: &[],
+            environment: &environment,
+        };
 
         // defines_task mirrors the verb tables.
         assert!(toolchain.defines_task(&app, "build"));
@@ -2533,7 +2542,7 @@ release: 1.96.0-nightly\n",
         // hashing), deliverables as outputs.
         let deps = [&lib_a];
         let io = toolchain
-            .derived_task_io(&app, "build", "../..", &deps, true)
+            .derived_task_io(&app, "build", "../..", &deps, true, &context)
             .expect("entrypoint build derives IO");
         assert!(
             !io.input_globs
@@ -2565,20 +2574,19 @@ release: 1.96.0-nightly\n",
         assert!(io.env.contains(&"CARGO_TARGET_*".to_string()));
         assert!(io.env.contains(&"CC_*".to_string()));
         assert!(io.env.contains(&"TARGET_CFLAGS".to_string()));
+        let toolchain::DerivedOutputs::Resolved(outputs) = &io.outputs else {
+            panic!("Cargo's existing wildcard outputs must remain resolved");
+        };
         assert!(
-            io.output_globs.contains(&"../../target/*/app".to_string()),
-            "bin deliverable is cached with a wildcard profile, got {:?}",
-            io.output_globs
+            outputs.contains(&"../../target/*/app".to_string()),
+            "bin deliverable keeps its wildcard profile, got {outputs:?}"
         );
-        assert!(
-            io.output_globs
-                .contains(&"../../target/*/app.exe".to_string())
-        );
+        assert!(outputs.contains(&"../../target/*/app.exe".to_string()));
 
         // Explicit inputs without $TURBO_DEFAULT$: workspace files still
         // apply, but no closure globs and no default-hashing override.
         let io = toolchain
-            .derived_task_io(&app, "build", "../..", &deps, false)
+            .derived_task_io(&app, "build", "../..", &deps, false, &context)
             .expect("entrypoint build derives IO");
         assert!(io.input_globs.contains(&"../../Cargo.toml".to_string()));
         assert!(!io.input_globs.iter().any(|glob| glob.contains("lib-a")));
@@ -2586,26 +2594,26 @@ release: 1.96.0-nightly\n",
 
         // Non-build entrypoint verbs cache no deliverables.
         let io = toolchain
-            .derived_task_io(&app, "dev", "../..", &deps, true)
+            .derived_task_io(&app, "dev", "../..", &deps, true, &context)
             .expect("entrypoint dev derives IO");
-        assert!(io.output_globs.is_empty());
+        assert_eq!(io.outputs, toolchain::DerivedOutputs::Resolved(Vec::new()));
 
         // The workspace package hashes crate directories instead of the
         // repo root's default file set.
         let deps = [&app, &lib_a];
         let io = toolchain
-            .derived_task_io(&workspace, "test", "", &deps, true)
+            .derived_task_io(&workspace, "test", "", &deps, true, &context)
             .expect("workspace test derives IO");
         assert_eq!(io.package_default_inputs, Some(false));
         assert!(io.input_globs.contains(&"crates/app/**".to_string()));
         assert!(io.input_globs.contains(&"crates/lib-a/**".to_string()));
         assert!(io.input_globs.contains(&"Cargo.toml".to_string()));
-        assert!(io.output_globs.is_empty());
+        assert_eq!(io.outputs, toolchain::DerivedOutputs::Resolved(Vec::new()));
 
         // Libraries derive nothing.
         assert!(
             toolchain
-                .derived_task_io(&lib_a, "build", "../..", &[], true)
+                .derived_task_io(&lib_a, "build", "../..", &[], true, &context)
                 .is_none()
         );
     }

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -483,6 +483,12 @@ impl TaskIOEnvironment {
         }
     }
 
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.values
+            .iter()
+            .map(|(name, value)| (name.as_str(), value.as_str()))
+    }
+
     #[cfg(test)]
     fn case_insensitive(values: std::collections::HashMap<String, String>) -> Self {
         Self {

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -278,7 +278,7 @@ pub trait Toolchain: Send + Sync {
     /// The run retains only matching keys, and the engine automatically adds
     /// every declared pattern to the task's hashed environment when derived I/O
     /// applies.
-    fn task_io_env_vars(&self) -> &'static [&'static str] {
+    fn task_io_env_vars(&self) -> &[&str] {
         &[]
     }
 
@@ -457,11 +457,52 @@ impl WatchSpec {
     }
 }
 
+/// Platform-aware environment projection for one toolchain's I/O derivation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskIOEnvironment {
+    values: std::collections::HashMap<String, String>,
+    case_insensitive: bool,
+}
+
+impl TaskIOEnvironment {
+    pub fn new(values: std::collections::HashMap<String, String>) -> Self {
+        Self {
+            values,
+            case_insensitive: cfg!(windows),
+        }
+    }
+
+    pub fn get(&self, name: &str) -> Option<&str> {
+        if self.case_insensitive {
+            self.values
+                .iter()
+                .find(|(key, _)| key.eq_ignore_ascii_case(name))
+                .map(|(_, value)| value.as_str())
+        } else {
+            self.values.get(name).map(String::as_str)
+        }
+    }
+
+    #[cfg(test)]
+    fn case_insensitive(values: std::collections::HashMap<String, String>) -> Self {
+        Self {
+            values,
+            case_insensitive: true,
+        }
+    }
+}
+
+impl Default for TaskIOEnvironment {
+    fn default() -> Self {
+        Self::new(Default::default())
+    }
+}
+
 /// Run-scoped inputs that can affect toolchain-derived task I/O.
 #[derive(Debug, Clone, Copy)]
 pub struct TaskIOContext<'a> {
-    pub task_args: &'a [String],
-    pub environment: &'a std::collections::HashMap<String, String>,
+    pub task_args: Option<&'a [String]>,
+    pub environment: &'a TaskIOEnvironment,
 }
 
 /// Whether a toolchain can resolve a task's automatic outputs.
@@ -923,6 +964,18 @@ mod tests {
         );
         assert_eq!(cmd.cwd, repo_root.resolve(package.package_path()));
         assert_eq!(cmd.serial_group, None);
+    }
+
+    #[test]
+    fn task_io_environment_supports_windows_casing() {
+        let environment = TaskIOEnvironment::case_insensitive(std::collections::HashMap::from([(
+            "Cargo_Build_Target".to_string(),
+            "x86_64-pc-windows-msvc".to_string(),
+        )]));
+        assert_eq!(
+            environment.get("CARGO_BUILD_TARGET"),
+            Some("x86_64-pc-windows-msvc")
+        );
     }
 
     #[cfg(windows)]

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -274,6 +274,14 @@ pub trait Toolchain: Send + Sync {
         TaskDefaults::default()
     }
 
+    /// Startup environment patterns this toolchain needs to derive task I/O.
+    /// The run retains only matching keys, and the engine automatically adds
+    /// every declared pattern to the task's hashed environment when derived I/O
+    /// applies.
+    fn task_io_env_vars(&self) -> &'static [&'static str] {
+        &[]
+    }
+
     /// Hash wiring this toolchain derives for `task` in `package`, beyond
     /// what turbo.json declares: extra input globs and env vars that
     /// participate in the task hash, output globs to cache, and whether the
@@ -297,6 +305,7 @@ pub trait Toolchain: Send + Sync {
         path_to_root: &str,
         dependencies: &[&crate::package_graph::PackageInfo],
         wants_automatic_inputs: bool,
+        context: &TaskIOContext<'_>,
     ) -> Option<DerivedTaskIO> {
         let _ = (
             package,
@@ -304,6 +313,7 @@ pub trait Toolchain: Send + Sync {
             path_to_root,
             dependencies,
             wants_automatic_inputs,
+            context,
         );
         None
     }
@@ -447,6 +457,29 @@ impl WatchSpec {
     }
 }
 
+/// Run-scoped inputs that can affect toolchain-derived task I/O.
+#[derive(Debug, Clone, Copy)]
+pub struct TaskIOContext<'a> {
+    pub task_args: &'a [String],
+    pub environment: &'a std::collections::HashMap<String, String>,
+}
+
+/// Whether a toolchain can resolve a task's automatic outputs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DerivedOutputs {
+    /// Output paths relative to the package directory. An empty list means the
+    /// task has no toolchain-derived outputs.
+    Resolved(Vec<String>),
+    /// The task produces outputs, but their paths cannot be resolved safely.
+    Unavailable,
+}
+
+impl Default for DerivedOutputs {
+    fn default() -> Self {
+        Self::Resolved(Vec::new())
+    }
+}
+
 /// Hash wiring derived by a toolchain for one task. See
 /// [`Toolchain::derived_task_io`].
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -458,8 +491,7 @@ pub struct DerivedTaskIO {
     pub package_default_inputs: Option<bool>,
     /// Env vars that participate in the task hash.
     pub env: Vec<String>,
-    /// Output globs to cache, relative to the package directory.
-    pub output_globs: Vec<String>,
+    pub outputs: DerivedOutputs,
 }
 
 /// The set of toolchains contributing packages to the repository.
@@ -709,6 +741,7 @@ impl<P: PackageDiscovery + Send + Sync> Toolchain for JavaScriptToolchain<P> {
         _path_to_root: &str,
         _dependencies: &[&crate::package_graph::PackageInfo],
         _wants_automatic_inputs: bool,
+        _context: &TaskIOContext<'_>,
     ) -> Option<DerivedTaskIO> {
         // Deliberately nothing: for JavaScript, turbo.json is the whole
         // story — inputs default to the package's files, outputs are

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -165,10 +165,12 @@ a narrow, platform-aware startup-environment projection keyed by toolchain.
 Dependency tasks do not inherit arguments for a different requested task, each
 toolchain can observe only the variables it declares, Windows lookup remains
 case-insensitive, and every declared pattern automatically participates in task
-hashing. Derived outputs distinguish exact/resolved paths from unavailable
-automatic resolution.
-When outputs are unavailable, the engine disables implicit caching so a log-only
-hit cannot suppress execution, while explicit `outputs`, `cache: true`, and
+hashing. If a user env exclusion matches a projected toolchain I/O variable,
+automatic outputs become unavailable rather than deriving cacheable paths from
+an unhashed value. Derived outputs distinguish exact/resolved paths from
+unavailable automatic resolution. When outputs are unavailable, the engine
+disables implicit caching so a log-only hit cannot suppress execution, while
+explicit `outputs`, `cache: true`, and
 `cache: false` remain authoritative.
 
 #### Experimental Cargo Support (`crates/turborepo-repository/src/cargo.rs`)

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -160,10 +160,13 @@ through the trait. Machinery that predates the abstraction and has no trait
 surface yet (package-manager resolution for dependency splitting, the JS
 lockfile closure phase) is documented as known debt in the module.
 
-Toolchain-derived I/O receives task arguments plus a narrow startup-environment
-projection declared by each toolchain; undeclared variables are not retained,
-and every declared pattern automatically participates in task hashing. Derived
-outputs distinguish exact/resolved paths from unavailable automatic resolution.
+Toolchain-derived I/O receives the same task-scoped arguments as execution plus
+a narrow, platform-aware startup-environment projection keyed by toolchain.
+Dependency tasks do not inherit arguments for a different requested task, each
+toolchain can observe only the variables it declares, Windows lookup remains
+case-insensitive, and every declared pattern automatically participates in task
+hashing. Derived outputs distinguish exact/resolved paths from unavailable
+automatic resolution.
 When outputs are unavailable, the engine disables implicit caching so a log-only
 hit cannot suppress execution, while explicit `outputs`, `cache: true`, and
 `cache: false` remain authoritative.

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -160,6 +160,14 @@ through the trait. Machinery that predates the abstraction and has no trait
 surface yet (package-manager resolution for dependency splitting, the JS
 lockfile closure phase) is documented as known debt in the module.
 
+Toolchain-derived I/O receives task arguments plus a narrow startup-environment
+projection declared by each toolchain; undeclared variables are not retained,
+and every declared pattern automatically participates in task hashing. Derived
+outputs distinguish exact/resolved paths from unavailable automatic resolution.
+When outputs are unavailable, the engine disables implicit caching so a log-only
+hit cannot suppress execution, while explicit `outputs`, `cache: true`, and
+`cache: false` remain authoritative.
+
 #### Experimental Cargo Support (`crates/turborepo-repository/src/cargo.rs`)
 
 Behind `futureFlags.experimentalCargoWorkspaces` in the root turbo.json,


### PR DESCRIPTION
## Why
Toolchains need a generic way to report when automatic output paths cannot be resolved. Without that distinction, a cacheable log-only task can suppress required execution, and passing the full startup environment would expose unrelated values.

## What
Add a toolchain I/O context with task arguments and narrowly projected declared environment variables, plus resolved and unavailable derived-output states. Unavailable outputs disable only implicit caching; explicit outputs and explicit cache true/false remain authoritative.

## How
Project only toolchain-declared environment patterns into engine construction and automatically hash those declarations. Apply derived output availability centrally in the engine, adapt Cargo by wrapping its existing wildcard outputs as resolved, and cover fallback, explicit intent, hashing, projection, and undeclared-variable exclusion with generic tests.

Stack 1/4. Cargo output behavior remains unchanged in this PR.