### PR TITLE
fix: Prune Bun production workspace dev dependencies

### DIFF
--- a/apps/docs/content/docs/reference/prune.mdx
+++ b/apps/docs/content/docs/reference/prune.mdx
@@ -215,7 +215,7 @@ Respect `.gitignore` file(s) when copying files to the output directory.
 
 Default: `false`
 
-Exclude in-workspace packages listed only in `devDependencies` when selecting which packages to include in the pruned output. Only workspace packages reachable through `dependencies` (and non-optional peer workspace dependencies) are included.
+Exclude in-workspace packages listed only in `devDependencies` when selecting which packages to include in the pruned output. Only workspace packages reachable through `dependencies` (and non-optional peer workspace dependencies) are included. For Bun repositories, references to excluded workspaces are also removed from the pruned manifests and lockfile so the output can be installed with a frozen lockfile.
 
 ### Including `globalDependencies`
 

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -182,6 +182,30 @@ pub async fn prune(
     let mut workspace_paths = Vec::new();
     let mut workspace_names = Vec::new();
     let workspaces = prune.internal_dependencies();
+    let retained_workspace_names: HashSet<_> = workspaces
+        .iter()
+        .filter_map(|workspace| match workspace {
+            PackageName::Root => None,
+            PackageName::Other(name) => Some(name.as_str()),
+        })
+        .collect();
+    let excluded_dev_workspaces = if prune.production
+        && prune.package_graph.package_manager().lockfile_manager() == &PackageManager::Bun
+    {
+        prune
+            .package_graph
+            .packages()
+            .filter_map(|(workspace, _)| match workspace {
+                PackageName::Root => None,
+                PackageName::Other(name) if !retained_workspace_names.contains(name.as_str()) => {
+                    Some(name.clone())
+                }
+                PackageName::Other(_) => None,
+            })
+            .collect()
+    } else {
+        HashSet::new()
+    };
     // Only JavaScript packages participate in the JS lockfile subgraph:
     // other toolchains' external-dependency keys (e.g. Cargo's rustc and
     // crates.io identities) mean nothing to it and must not leak in.
@@ -226,7 +250,11 @@ pub async fn prune(
                 workspace_names.push(workspace);
                 continue;
             }
-            prune.copy_workspace(entry.package_json_path(), &entry.package_json)?;
+            prune.copy_workspace(
+                entry.package_json_path(),
+                &entry.package_json,
+                &excluded_dev_workspaces,
+            )?;
             let parent = entry
                 .package_json_path()
                 .parent()
@@ -357,7 +385,10 @@ pub async fn prune(
 
     let original_contents = prune.root.resolve(package_json()).read_to_string()?;
     let original_value: serde_json::Value = serde_json::from_str(&original_contents)?;
-    if !original_patches.is_empty() || original_value.get("workspaces").is_some() {
+    if !original_patches.is_empty()
+        || original_value.get("workspaces").is_some()
+        || !excluded_dev_workspaces.is_empty()
+    {
         let pruned_json = if original_patches.is_empty() {
             prune.package_graph.root_package_json().clone()
         } else {
@@ -370,6 +401,7 @@ pub async fn prune(
 
         let mut pruned_value = serde_json::to_value(&pruned_json)?;
         prune_package_json_workspaces(&mut pruned_value, &workspace_paths);
+        prune_package_json_dev_dependencies(&mut pruned_value, &excluded_dev_workspaces);
         // Merge into the original JSON value so package.json key order stays stable.
         let merged = merge_preserving_key_order(&original_value, &pruned_value);
         let mut pruned_json_contents = serde_json::to_string_pretty(&merged)?;
@@ -507,6 +539,43 @@ fn sync_prune_finalize_files(
             warn!("unable to synchronize finalized prune file {path:?}: {error}");
         }
     }
+}
+
+fn workspace_dependency_target<'a>(name: &'a str, version: &'a str) -> Option<&'a str> {
+    let specifier = version.strip_prefix("workspace:")?;
+    match specifier.rsplit_once('@') {
+        Some((target, "*" | "^" | "~")) if !target.is_empty() => Some(target),
+        _ => Some(name),
+    }
+}
+
+fn prune_package_json_dev_dependencies(
+    package_json: &mut serde_json::Value,
+    excluded_workspaces: &HashSet<String>,
+) -> bool {
+    let Some(dev_dependencies) = package_json
+        .get_mut("devDependencies")
+        .and_then(serde_json::Value::as_object_mut)
+    else {
+        return false;
+    };
+
+    let original_len = dev_dependencies.len();
+    dev_dependencies.retain(|name, version| {
+        let Some(version) = version.as_str() else {
+            return true;
+        };
+        workspace_dependency_target(name, version)
+            .is_none_or(|target| !excluded_workspaces.contains(target))
+    });
+    let changed = dev_dependencies.len() != original_len;
+    let remove_dev_dependencies = dev_dependencies.is_empty();
+    if remove_dev_dependencies {
+        if let Some(package_json) = package_json.as_object_mut() {
+            package_json.remove("devDependencies");
+        }
+    }
+    changed
 }
 
 fn prune_package_json_workspaces(package_json: &mut serde_json::Value, workspace_paths: &[String]) {
@@ -886,8 +955,22 @@ impl<'a> Prune<'a> {
         &self,
         package_json_path: &AnchoredSystemPath,
         workspace_package_json: &PackageJson,
+        excluded_dev_workspaces: &HashSet<String>,
     ) -> Result<(), Error> {
         let package_json_path = self.root.resolve(package_json_path);
+        let pruned_package_json = if excluded_dev_workspaces.is_empty() {
+            None
+        } else {
+            let mut value: serde_json::Value =
+                serde_json::from_str(&package_json_path.read_to_string()?)?;
+            if prune_package_json_dev_dependencies(&mut value, excluded_dev_workspaces) {
+                let mut contents = serde_json::to_string_pretty(&value)?;
+                contents.push('\n');
+                Some(contents)
+            } else {
+                None
+            }
+        };
         let original_dir = package_json_path
             .parent()
             .ok_or_else(|| Error::WorkspaceAtFilesystemRoot)?;
@@ -902,14 +985,22 @@ impl<'a> Prune<'a> {
             self.use_gitignore,
             Some(&self.root),
         )?;
+        if let Some(contents) = &pruned_package_json {
+            target_dir
+                .resolve(package_json())
+                .create_with_contents(contents)?;
+        }
 
         if self.docker {
             let docker_workspace_dir = self.docker_directory().resolve(&relative_workspace_dir);
             docker_workspace_dir.ensure_dir()?;
-            turborepo_fs::copy_file(
-                &package_json_path,
-                docker_workspace_dir.resolve(package_json()),
-            )?;
+            let docker_package_json = docker_workspace_dir.resolve(package_json());
+            if let Some(contents) = &pruned_package_json {
+                docker_package_json.ensure_dir()?;
+                docker_package_json.create_with_contents(contents)?;
+            } else {
+                turborepo_fs::copy_file(&package_json_path, docker_package_json)?;
+            }
             self.create_docker_bin_stubs(
                 workspace_package_json,
                 original_dir,

--- a/crates/turborepo-lockfiles/src/bun/subgraph.rs
+++ b/crates/turborepo-lockfiles/src/bun/subgraph.rs
@@ -7,6 +7,14 @@ use super::{
     PackageInfo, PackageKey, data::WorkspaceEntry,
 };
 
+fn workspace_dependency_target<'a>(name: &'a str, version: &'a str) -> Option<&'a str> {
+    let specifier = version.strip_prefix("workspace:")?;
+    match specifier.rsplit_once('@') {
+        Some((target, "*" | "^" | "~")) if !target.is_empty() => Some(target),
+        _ => Some(name),
+    }
+}
+
 impl BunLockfile {
     fn include_duplicate_alias_children(&self, pruned_data: &mut BunLockfileData) {
         loop {
@@ -83,15 +91,48 @@ impl BunLockfile {
             patched_dependencies: Map::new(),
         };
 
+        let retained_workspace_names: HashSet<_> = workspace_packages
+            .iter()
+            .filter_map(|path| {
+                self.data
+                    .workspaces
+                    .get(path)
+                    .map(|workspace| workspace.name.as_str())
+            })
+            .collect();
+        let all_workspace_names: HashSet<_> = self
+            .data
+            .workspaces
+            .iter()
+            .filter_map(|(path, workspace)| (!path.is_empty()).then_some(workspace.name.as_str()))
+            .collect();
+        let prune_workspace_dev_dependencies = |entry: &WorkspaceEntry| {
+            let mut entry = entry.clone();
+            if let Some(dev_dependencies) = &mut entry.dev_dependencies {
+                dev_dependencies.retain(|name, version| {
+                    workspace_dependency_target(name, version).is_none_or(|target| {
+                        !all_workspace_names.contains(target)
+                            || retained_workspace_names.contains(target)
+                    })
+                });
+                if dev_dependencies.is_empty() {
+                    entry.dev_dependencies = None;
+                }
+            }
+            entry
+        };
+
         if let Some(root) = self.data.workspaces.get("") {
-            pruned_data.workspaces.insert("".to_string(), root.clone());
+            pruned_data
+                .workspaces
+                .insert("".to_string(), prune_workspace_dev_dependencies(root));
         }
 
         for ws_path in workspace_packages {
             if let Some(entry) = self.data.workspaces.get(ws_path) {
                 pruned_data
                     .workspaces
-                    .insert(ws_path.clone(), entry.clone());
+                    .insert(ws_path.clone(), prune_workspace_dev_dependencies(entry));
             }
         }
 

--- a/lockfile-tests/check-lockfiles.ts
+++ b/lockfile-tests/check-lockfiles.ts
@@ -38,6 +38,8 @@ interface FixtureMeta {
   pruneTargets?: string[];
   /** Run `turbo prune --docker` and validate `out/json`. */
   docker?: boolean;
+  /** Run `turbo prune --production`. */
+  production?: boolean;
   /**
    * Additionally assert that every package in the pruned lockfile can resolve
    * its declared dependencies (via `npm ls`). Catches stranded transitive deps
@@ -223,6 +225,7 @@ function buildTestCases(
         targetWorkspace: { name: target },
         label,
         docker: fixture.meta.docker,
+        production: fixture.meta.production,
         expectedFailure: isExpected
       });
     }

--- a/lockfile-tests/fixtures/bun-v1-issue-13365/bun.lock
+++ b/lockfile-tests/fixtures/bun-v1-issue-13365/bun.lock
@@ -1,0 +1,43 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "repro-root",
+      "devDependencies": {
+        "tooling": "workspace:*",
+      },
+    },
+    "packages/app": {
+      "name": "app",
+      "version": "0.0.0",
+      "dependencies": {
+        "lodash": "4.17.21",
+      },
+    },
+    "packages/tooling": {
+      "name": "tooling",
+      "version": "0.0.0",
+      "dependencies": {
+        "is-even": "1.0.0",
+      },
+    },
+  },
+  "packages": {
+    "app": ["app@workspace:packages/app"],
+
+    "is-buffer": ["is-buffer@1.1.6", "", {}, "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="],
+
+    "is-even": ["is-even@1.0.0", "", { "dependencies": { "is-odd": "^0.1.2" } }, "sha512-LEhnkAdJqic4Dbqn58A0y52IXoHWlsueqQkKfMfdEnIYG8A1sm/GHidKkS6yvXlMoRrkM34csHnXQtOqcb+Jzg=="],
+
+    "is-number": ["is-number@3.0.0", "", { "dependencies": { "kind-of": "^3.0.2" } }, "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg=="],
+
+    "is-odd": ["is-odd@0.1.2", "", { "dependencies": { "is-number": "^3.0.0" } }, "sha512-Ri7C2K7o5IrUU9UEI8losXJCCD/UtsaIrkR5sxIcFg4xQ9cRJXlWA5DQvTE0yDc0krvSNLsRGXN11UPS6KyfBw=="],
+
+    "kind-of": ["kind-of@3.2.2", "", { "dependencies": { "is-buffer": "^1.1.5" } }, "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ=="],
+
+    "lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
+
+    "tooling": ["tooling@workspace:packages/tooling"],
+  }
+}

--- a/lockfile-tests/fixtures/bun-v1-issue-13365/meta.json
+++ b/lockfile-tests/fixtures/bun-v1-issue-13365/meta.json
@@ -1,0 +1,8 @@
+{
+  "packageManager": "bun",
+  "packageManagerVersion": "bun@1.3.13",
+  "lockfileName": "bun.lock",
+  "docker": true,
+  "production": true,
+  "pruneTargets": ["app"]
+}

--- a/lockfile-tests/fixtures/bun-v1-issue-13365/package.json
+++ b/lockfile-tests/fixtures/bun-v1-issue-13365/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "repro-root",
+  "private": true,
+  "packageManager": "bun@1.3.13",
+  "workspaces": ["packages/*"],
+  "devDependencies": {
+    "tooling": "workspace:*"
+  }
+}

--- a/lockfile-tests/fixtures/bun-v1-issue-13365/packages/app/package.json
+++ b/lockfile-tests/fixtures/bun-v1-issue-13365/packages/app/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "app",
+  "version": "0.0.0",
+  "dependencies": {
+    "lodash": "4.17.21"
+  }
+}

--- a/lockfile-tests/fixtures/bun-v1-issue-13365/packages/tooling/package.json
+++ b/lockfile-tests/fixtures/bun-v1-issue-13365/packages/tooling/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "tooling",
+  "version": "0.0.0",
+  "dependencies": {
+    "is-even": "1.0.0"
+  }
+}

--- a/lockfile-tests/fixtures/bun-v1-issue-13365/turbo.json
+++ b/lockfile-tests/fixtures/bun-v1-issue-13365/turbo.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {}
+}

--- a/lockfile-tests/runners/local.ts
+++ b/lockfile-tests/runners/local.ts
@@ -458,7 +458,7 @@ export class LocalRunner {
           // turbo prune
           const pruneCommand = `turbo prune ${targetWorkspace.name}${
             tc.docker ? " --docker" : ""
-          }`;
+          }${tc.production ? " --production" : ""}`;
           log(`[${label}] ${pruneCommand}`);
           const pruneResult = await exec(pruneCommand, tmpDir, {
             PATH: fullPath

--- a/lockfile-tests/types.ts
+++ b/lockfile-tests/types.ts
@@ -19,6 +19,7 @@ export interface TestCase {
   };
   label: string;
   docker?: boolean;
+  production?: boolean;
   expectedFailure?: boolean;
 }
 


### PR DESCRIPTION
## Why

`turbo prune --production` can exclude a root dev-only workspace while leaving its `workspace:*` reference in Bun manifests and `bun.lock`. Bun then rejects the pruned output during a frozen install.

Closes #13365

## What

Keep Bun production-prune manifests and lockfile workspace entries synchronized when dev-only workspaces are excluded. Extend `check-lockfiles` with production-prune support and the reported regression fixture.

## How

Validated with all 70 Bun lockfile fixture cases, focused production-prune integration tests, 82 Bun lockfile unit tests, and Clippy.