### PR TITLE
fix: Surface create-turbo Git failures

### DIFF
--- a/packages/turbo-utils/__tests__/examples.test.ts
+++ b/packages/turbo-utils/__tests__/examples.test.ts
@@ -7,6 +7,7 @@ import {
   afterEach
 } from "@jest/globals";
 import { Readable, PassThrough } from "node:stream";
+import { execFileSync } from "node:child_process";
 import {
   mkdirSync,
   rmSync,
@@ -24,11 +25,36 @@ import {
   isPathSafe,
   isLinkEntry,
   streamingExtract,
-  downloadAndExtractRepo
+  downloadAndExtractRepo,
+  downloadAndExtractExample
 } from "../src/examples";
+
+jest.mock("node:child_process", () => ({
+  ...jest.requireActual<typeof import("node:child_process")>(
+    "node:child_process"
+  ),
+  execFileSync: jest.fn()
+}));
+
+jest.mock("node:fs", () => ({
+  ...jest.requireActual<typeof import("node:fs")>("node:fs"),
+  rmSync: jest.fn()
+}));
+
+const actualFs = jest.requireActual<typeof import("node:fs")>("node:fs");
+const mockExecFileSync = jest.mocked(execFileSync);
+const mockRmSync = jest.mocked(rmSync);
 
 describe("examples", () => {
   const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    mockExecFileSync.mockReset();
+    mockRmSync.mockReset();
+    mockRmSync.mockImplementation((path, options) => {
+      actualFs.rmSync(path, options);
+    });
+  });
 
   afterEach(() => {
     global.fetch = originalFetch;
@@ -92,6 +118,84 @@ describe("examples", () => {
           process.env.https_proxy = originalEnv;
         }
       }
+    });
+  });
+
+  describe("downloadAndExtractExample", () => {
+    let root: string;
+
+    beforeEach(() => {
+      root = join(
+        tmpdir(),
+        `turbo-example-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      );
+      mkdirSync(root, { recursive: true });
+      global.fetch = jest.fn(() =>
+        Promise.resolve({ ok: false, status: 503 } as Response)
+      ) as typeof fetch;
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+      actualFs.rmSync(root, { recursive: true, force: true });
+    });
+
+    it("reports stderr from a failed Git command before falling back", async () => {
+      const gitError = Object.assign(new Error("Command failed"), {
+        stderr: Buffer.from("fatal: repository access denied")
+      });
+      mockExecFileSync.mockImplementation(() => {
+        throw gitError;
+      });
+      const consoleError = jest
+        .spyOn(console, "error")
+        .mockReturnValue(undefined);
+
+      await expect(downloadAndExtractExample(root, "basic")).rejects.toThrow(
+        "Failed to download: 503"
+      );
+
+      expect(
+        consoleError.mock.calls.some((args) =>
+          args.join(" ").includes("fatal: repository access denied")
+        )
+      ).toBe(true);
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://codeload.github.com/vercel/turborepo/tar.gz/main",
+        expect.any(Object)
+      );
+    });
+
+    it("falls back when the temporary directory cannot be removed", async () => {
+      mockExecFileSync.mockImplementation(() => {
+        throw new Error("Git failed");
+      });
+      const cleanupError = Object.assign(new Error("File is locked"), {
+        code: "EPERM"
+      });
+      mockRmSync.mockImplementation(() => {
+        throw cleanupError;
+      });
+      const consoleError = jest
+        .spyOn(console, "error")
+        .mockReturnValue(undefined);
+
+      await expect(downloadAndExtractExample(root, "basic")).rejects.toThrow(
+        "Failed to download: 503"
+      );
+
+      expect(mockRmSync).toHaveBeenCalledWith(join(root, ".turbo-clone-temp"), {
+        recursive: true,
+        force: true,
+        maxRetries: 5,
+        retryDelay: 100
+      });
+      expect(
+        consoleError.mock.calls.some((args) =>
+          args.join(" ").includes("File is locked")
+        )
+      ).toBe(true);
+      expect(global.fetch).toHaveBeenCalled();
     });
   });
 

--- a/packages/turbo-utils/src/examples.ts
+++ b/packages/turbo-utils/src/examples.ts
@@ -496,6 +496,43 @@ function assertSafeGitArgument(value: string, description: string): void {
   }
 }
 
+function formatError(error: unknown): string {
+  if (error && typeof error === "object" && "stderr" in error) {
+    const { stderr } = error as { stderr?: unknown };
+    if (typeof stderr === "string" || Buffer.isBuffer(stderr)) {
+      const output = stderr.toString().trim();
+      if (output) {
+        return output;
+      }
+    }
+  }
+
+  return error instanceof Error ? error.message : String(error);
+}
+
+function runGit(args: Array<string>, cwd?: string): void {
+  try {
+    execFileSync("git", args, { cwd, stdio: "pipe" });
+  } catch (error) {
+    throw new Error(`\`git ${args[0]}\` failed:\n${formatError(error)}`);
+  }
+}
+
+function cleanupCloneDirectory(tempDir: string): void {
+  try {
+    rmSync(tempDir, {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 100
+    });
+  } catch (error) {
+    warn(
+      `Unable to remove temporary directory ${tempDir}:\n${formatError(error)}`
+    );
+  }
+}
+
 export async function downloadAndExtractExample(root: string, name: string) {
   // Validate example name to prevent path traversal and argument injection
   // Only allow alphanumeric characters, hyphens, and underscores
@@ -512,45 +549,32 @@ export async function downloadAndExtractExample(root: string, name: string) {
 
   try {
     // Clone with partial clone (no blobs) and no checkout
-    execFileSync(
-      "git",
-      [
-        "clone",
-        "--filter=blob:none",
-        "--no-checkout",
-        "--depth",
-        "1",
-        "--sparse",
-        "https://github.com/vercel/turborepo.git",
-        tempDir
-      ],
-      { stdio: "pipe" }
-    );
+    runGit([
+      "clone",
+      "--filter=blob:none",
+      "--no-checkout",
+      "--depth",
+      "1",
+      "--sparse",
+      "https://github.com/vercel/turborepo.git",
+      tempDir
+    ]);
 
     // Set up sparse checkout for just the example we want
-    execFileSync("git", ["sparse-checkout", "set", `examples/${name}`], {
-      cwd: tempDir,
-      stdio: "pipe"
-    });
+    runGit(["sparse-checkout", "set", `examples/${name}`], tempDir);
 
     // Checkout the files
-    execFileSync("git", ["checkout"], {
-      cwd: tempDir,
-      stdio: "pipe"
-    });
+    runGit(["checkout"], tempDir);
 
     // Copy the example files to the root
     const examplePath = join(tempDir, "examples", name);
     cpSync(examplePath, normalizedRoot, { recursive: true });
   } catch (gitError) {
-    // Clean up temp directory if git clone failed partway through
-    rmSync(tempDir, { recursive: true, force: true });
-
-    // Fall back to tarball download if git is not available
     warn(
-      "Git is not available. Downloading example via tarball (slower).\n" +
-        "For faster downloads, install git: https://git-scm.com/downloads"
+      `Git download failed:\n${formatError(gitError)}\n` +
+        "Falling back to downloading the example via tarball."
     );
+    cleanupCloneDirectory(tempDir);
 
     await streamingExtract({
       url: "https://codeload.github.com/vercel/turborepo/tar.gz/main",
@@ -565,5 +589,5 @@ export async function downloadAndExtractExample(root: string, name: string) {
   }
 
   // Clean up the temp directory on success
-  rmSync(tempDir, { recursive: true, force: true });
+  cleanupCloneDirectory(tempDir);
 }


### PR DESCRIPTION
## Why

`create-turbo` hides stderr from sparse Git checkout failures. On Windows, a locked temporary directory can also replace the original error and prevent the tarball fallback, leaving users without actionable diagnostics. This improves the failure path reported in #13367.

## What

Git failures now retain command context and stderr. Temporary-directory cleanup tolerates transient locks and cannot block fallback or mask the primary failure.