### PR TITLE
feat: Infer Cargo workspace tasks

### DIFF
--- a/apps/docs/content/docs/guides/multi-language.mdx
+++ b/apps/docs/content/docs/guides/multi-language.mdx
@@ -83,6 +83,15 @@ Then, add a `package.json` to the directory:
 
 Now, when you use `turbo build`, the `"build"` script in `./cli/package.json` will be included into the tasks that `turbo` runs.
 
+<Callout type="info" title="Experimental Cargo workspaces">
+  Cargo workspaces can instead opt into native discovery with
+  `futureFlags.experimentalCargoWorkspaces`. Cargo tasks are then available
+  without wrapper `package.json` scripts or empty `tasks` entries: entrypoints
+  get `build`, single-binary crates also get `run`/`dev`, and the workspace gets
+  `test`, `check`, `clippy`/`lint`, `bench`, and `doc`/`docs`. Normal task
+  definitions still configure or override these defaults.
+</Callout>
+
 ## Caching build artifacts
 
 Ensure that the outputs for your builds are being cached with [the outputs key](/docs/reference/configuration#outputs) in `turbo.json`. In the case of a Rust CLI being compiled with cargo, a release build would be created in the `target/release` directory and we can cache it using:

--- a/apps/docs/content/docs/guides/multi-language.mdx
+++ b/apps/docs/content/docs/guides/multi-language.mdx
@@ -83,15 +83,6 @@ Then, add a `package.json` to the directory:
 
 Now, when you use `turbo build`, the `"build"` script in `./cli/package.json` will be included into the tasks that `turbo` runs.
 
-<Callout type="info" title="Experimental Cargo workspaces">
-  Cargo workspaces can instead opt into native discovery with
-  `futureFlags.experimentalCargoWorkspaces`. Cargo tasks are then available
-  without wrapper `package.json` scripts or empty `tasks` entries: entrypoints
-  get `build`, single-binary crates also get `run`/`dev`, and the workspace gets
-  `test`, `check`, `clippy`/`lint`, `bench`, and `doc`/`docs`. Normal task
-  definitions still configure or override these defaults.
-</Callout>
-
 ## Caching build artifacts
 
 Ensure that the outputs for your builds are being cached with [the outputs key](/docs/reference/configuration#outputs) in `turbo.json`. In the case of a Rust CLI being compiled with cargo, a release build would be created in the `target/release` directory and we can cache it using:

--- a/crates/turborepo-engine/src/builder.rs
+++ b/crates/turborepo-engine/src/builder.rs
@@ -200,8 +200,21 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
 
             // Collect tasks from each workspace and its extends chain
             for workspace in self.workspaces.iter() {
-                let workspace_tasks =
-                    TaskInheritanceResolver::new(turbo_json_loader).resolve(workspace)?;
+                let implicit_tasks = if let Some(package) =
+                    self.package_graph.package_info(workspace)
+                    && let Some(toolchain) = self.package_graph.toolchains().get(&package.toolchain)
+                {
+                    toolchain
+                        .registered_tasks(package)
+                        .into_iter()
+                        .map(TaskName::from)
+                        .collect()
+                } else {
+                    HashSet::new()
+                };
+                let workspace_tasks = TaskInheritanceResolver::new(turbo_json_loader)
+                    .with_implicit_tasks(implicit_tasks)
+                    .resolve(workspace)?;
                 tasks_set.extend(workspace_tasks);
             }
 
@@ -226,7 +239,13 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                 .task_id()
                 .unwrap_or_else(|| TaskId::new(workspace.as_ref(), task.task()));
 
-            if Self::has_task_definition_in_run(turbo_json_loader, workspace, task, &task_id)? {
+            if Self::has_task_definition_or_registered(
+                turbo_json_loader,
+                self.package_graph,
+                workspace,
+                task,
+                &task_id,
+            )? {
                 missing_tasks.remove(task.as_inner());
 
                 // Even if a task definition was found, we _only_ want to add it as an entry
@@ -347,8 +366,9 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
                     let task_name: TaskName<'static> =
                         TaskName::from(task_id.task().to_string()).into_owned();
                     let task_id_owned = task_id.as_inner().clone().into_owned();
-                    Self::has_task_definition_in_run(
+                    Self::has_task_definition_or_registered(
                         turbo_json_loader,
+                        self.package_graph,
                         &PackageName::Root,
                         &task_name,
                         &task_id_owned,

--- a/crates/turborepo-engine/src/builder/definitions.rs
+++ b/crates/turborepo-engine/src/builder/definitions.rs
@@ -43,7 +43,13 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
             let task_id = task_name
                 .task_id()
                 .unwrap_or_else(|| TaskId::new(package.as_str(), task_name.task()));
-            if Self::has_task_definition_in_run(loader, package, task_name, &task_id)? {
+            if Self::has_task_definition_or_registered(
+                loader,
+                package_graph,
+                package,
+                task_name,
+                &task_id,
+            )? {
                 return Ok(true);
             }
         }
@@ -65,6 +71,35 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
             &mut HashSet::new(),
         )?;
         Ok(result.has_definition())
+    }
+
+    pub(super) fn has_task_definition_or_registered(
+        loader: &L,
+        package_graph: &PackageGraph,
+        workspace: &PackageName,
+        task_name: &TaskName<'static>,
+        task_id: &TaskId,
+    ) -> Result<bool, BuilderError> {
+        let result = Self::has_task_definition_in_run_inner(
+            loader,
+            workspace,
+            task_name,
+            task_id,
+            &mut HashSet::new(),
+        )?;
+        if result.has_definition() || result.is_excluded() {
+            return Ok(result.has_definition());
+        }
+
+        Ok(package_graph
+            .package_info(&PackageName::from(task_id.package()))
+            .and_then(|package| {
+                package_graph
+                    .toolchains()
+                    .get(&package.toolchain)
+                    .map(|toolchain| (package, toolchain))
+            })
+            .is_some_and(|(package, toolchain)| toolchain.registers_task(package, task_id.task())))
     }
 
     fn has_task_definition_in_run_inner(
@@ -217,6 +252,9 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         let defines_task = package_info
             .zip(toolchain)
             .is_some_and(|(info, toolchain)| toolchain.defines_task(info, task_id.task()));
+        let registered_task = package_info
+            .zip(toolchain)
+            .is_some_and(|(info, toolchain)| toolchain.registers_task(info, task_id.task()));
 
         // Most tasks resolve to an identical definition: the same turbo.json
         // chain and task name, differing only by the package's depth (for
@@ -257,6 +295,7 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
             task_name,
             self.is_single,
             self.should_validate_engine,
+            registered_task,
         )?;
 
         // Resolve the task's `command` override across all five precedence
@@ -407,12 +446,25 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
     ) -> Result<Vec<ProcessedTaskDefinition>, BuilderError> {
         let package_name = PackageName::from(task_id.package());
         let turbo_json_chain = self.turbo_json_chain(turbo_json_loader, &package_name)?;
+        let registered_task = self
+            .package_graph
+            .package_info(&package_name)
+            .and_then(|package| {
+                self.package_graph
+                    .toolchains()
+                    .get(&package.toolchain)
+                    .map(|toolchain| (package, toolchain))
+            })
+            .is_some_and(|(package, toolchain)| {
+                toolchain.registers_task(package, task_id.as_inner().task())
+            });
         Ok(Self::resolve_task_definitions_from_chain(
             turbo_json_chain,
             task_id,
             task_name,
             self.is_single,
             self.should_validate_engine,
+            registered_task,
         )?
         .into_iter()
         .map(|(definition, _)| definition)
@@ -433,6 +485,7 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         task_name: &TaskName,
         is_single: bool,
         should_validate_engine: bool,
+        registered_task: bool,
     ) -> Result<Vec<(ProcessedTaskDefinition, bool)>, BuilderError> {
         let root_used_scoped_key = |turbo_json: &TurboJson| {
             turbo_json
@@ -489,7 +542,7 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
         }
 
         if is_single {
-            return match task_definitions.is_empty() {
+            return match task_definitions.is_empty() && !registered_task {
                 true => {
                     let (span, text) = task_id.span_and_text("turbo.json");
                     Err(BuilderError::MissingRootTaskInTurboJson(Box::new(
@@ -510,7 +563,7 @@ impl<'a, L: TurboJsonLoader> EngineBuilder<'a, L> {
             }
         }
 
-        if task_definitions.is_empty() && should_validate_engine {
+        if task_definitions.is_empty() && should_validate_engine && !registered_task {
             let (span, text) = task_id.span_and_text("turbo.json");
             return Err(BuilderError::MissingPackageTask(Box::new(
                 MissingPackageTaskError {

--- a/crates/turborepo-engine/src/builder/inheritance.rs
+++ b/crates/turborepo-engine/src/builder/inheritance.rs
@@ -36,6 +36,7 @@ pub struct TaskInheritanceResolver<'a, L: TurboJsonLoader> {
     /// Controls validation of `extends: false` usage.
     /// Set to `Validate` at entry point, `Skip` in recursive calls.
     validation_mode: ValidationMode,
+    implicit_tasks: HashSet<TaskName<'static>>,
 }
 
 /// Internal state for recursive resolution.
@@ -57,7 +58,16 @@ impl<'a, L: TurboJsonLoader> TaskInheritanceResolver<'a, L> {
         Self {
             loader,
             validation_mode: ValidationMode::Validate,
+            implicit_tasks: HashSet::new(),
         }
+    }
+
+    pub fn with_implicit_tasks(
+        mut self,
+        tasks: impl IntoIterator<Item = TaskName<'static>>,
+    ) -> Self {
+        self.implicit_tasks.extend(tasks);
+        self
     }
 
     /// Resolves all tasks from the given workspace and its extends chain.
@@ -66,7 +76,7 @@ impl<'a, L: TurboJsonLoader> TaskInheritanceResolver<'a, L> {
         workspace: &PackageName,
     ) -> Result<HashSet<TaskName<'static>>, BuilderError> {
         let mut state = ResolutionState {
-            tasks: HashSet::new(),
+            tasks: self.implicit_tasks.clone(),
             excluded_tasks: HashSet::new(),
             visited: HashSet::new(),
         };
@@ -136,6 +146,7 @@ impl<'a, L: TurboJsonLoader> TaskInheritanceResolver<'a, L> {
             let child_resolver = TaskInheritanceResolver {
                 loader: self.loader,
                 validation_mode: ValidationMode::Skip,
+                implicit_tasks: HashSet::new(),
             };
 
             // Use separate state for child to collect its tasks/exclusions,
@@ -161,6 +172,7 @@ impl<'a, L: TurboJsonLoader> TaskInheritanceResolver<'a, L> {
             let child_resolver = TaskInheritanceResolver {
                 loader: self.loader,
                 validation_mode: ValidationMode::Skip,
+                implicit_tasks: HashSet::new(),
             };
 
             // Use separate state for child, sharing visited set
@@ -219,7 +231,9 @@ impl<'a, L: TurboJsonLoader> TaskInheritanceResolver<'a, L> {
         state: &mut ResolutionState,
     ) -> Result<(), BuilderError> {
         // Validate that the task exists in the extends chain (only at entry point)
-        if self.validation_mode == ValidationMode::Validate && !inherited_tasks.contains(task_name)
+        if self.validation_mode == ValidationMode::Validate
+            && !inherited_tasks.contains(task_name)
+            && !self.implicit_tasks.contains(task_name)
         {
             let Some(extends) = task_def.extends.as_ref() else {
                 return Ok(());
@@ -239,6 +253,8 @@ impl<'a, L: TurboJsonLoader> TaskInheritanceResolver<'a, L> {
         if task_def.has_config_beyond_extends() {
             // Has other config - this is a fresh definition, add it
             state.tasks.insert(task_name.clone());
+        } else {
+            state.tasks.remove(task_name);
         }
         // Track as excluded (propagates to parent packages)
         state.excluded_tasks.insert(task_name.clone());

--- a/crates/turborepo-lib/src/run/mod.rs
+++ b/crates/turborepo-lib/src/run/mod.rs
@@ -539,6 +539,14 @@ impl Run {
                     .or_insert_with(Vec::new)
                     .push(name.to_string())
             }
+            if let Some(toolchain) = self.pkg_dep_graph.toolchains().get(&info.toolchain) {
+                for task_name in toolchain.registered_tasks(info) {
+                    tasks
+                        .entry(task_name)
+                        .or_insert_with(Vec::new)
+                        .push(name.to_string());
+                }
+            }
         }
 
         Ok(tasks)

--- a/crates/turborepo-query/src/lib.rs
+++ b/crates/turborepo-query/src/lib.rs
@@ -379,7 +379,7 @@ impl PackagePredicate {
     fn check_has(pkg: &Package, field: &PackageFields, value: &Any) -> bool {
         match (field, &value.0) {
             (PackageFields::Name, Value::String(name)) => pkg.get_name().as_str() == name,
-            (PackageFields::TaskName, Value::String(name)) => pkg.get_tasks().contains_key(name),
+            (PackageFields::TaskName, Value::String(name)) => pkg.get_task_names().contains(name),
             _ => false,
         }
     }
@@ -679,7 +679,7 @@ impl RepositoryQuery {
             .collect::<Result<Vec<_>, Error>>()?
             .into_iter()
             .filter(|ct| {
-                let has_script = ct.task.script.is_some();
+                let executes = ct.task.executes();
                 let task_ok = tasks.as_ref().is_none_or(|names| {
                     if names.is_empty() {
                         true
@@ -691,7 +691,7 @@ impl RepositoryQuery {
                     }
                 });
                 let package_ok = filter.as_ref().is_none_or(|f| f.check(&ct.task.package));
-                has_script && task_ok && package_ok
+                executes && task_ok && package_ok
             })
             .collect();
 

--- a/crates/turborepo-query/src/package.rs
+++ b/crates/turborepo-query/src/package.rs
@@ -55,6 +55,20 @@ impl Package {
 
     pub fn get_task_names(&self) -> BTreeSet<String> {
         let packages = HashSet::from([self.name.clone()]);
+        let registered_tasks: HashSet<_> = self
+            .run
+            .pkg_dep_graph()
+            .package_info(&self.name)
+            .and_then(|package| {
+                self.run
+                    .pkg_dep_graph()
+                    .toolchains()
+                    .get(&package.toolchain)
+                    .map(|toolchain| toolchain.registered_tasks(package))
+            })
+            .unwrap_or_default()
+            .into_iter()
+            .collect();
         self.get_tasks()
             .into_keys()
             .chain(
@@ -62,7 +76,8 @@ impl Package {
                     .engine()
                     .task_ids_for_packages(&packages)
                     .into_iter()
-                    .map(|task| task.task().to_string()),
+                    .map(|task| task.task().to_string())
+                    .filter(|task| registered_tasks.contains(task)),
             )
             .collect()
     }

--- a/crates/turborepo-query/src/package.rs
+++ b/crates/turborepo-query/src/package.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, fmt, sync::Arc};
+use std::{
+    collections::{BTreeSet, HashMap, HashSet},
+    fmt,
+    sync::Arc,
+};
 
 use async_graphql::Object;
 use itertools::Itertools;
@@ -47,6 +51,20 @@ impl Package {
                     .collect()
             })
             .unwrap_or_default()
+    }
+
+    pub fn get_task_names(&self) -> BTreeSet<String> {
+        let packages = HashSet::from([self.name.clone()]);
+        self.get_tasks()
+            .into_keys()
+            .chain(
+                self.run
+                    .engine()
+                    .task_ids_for_packages(&packages)
+                    .into_iter()
+                    .map(|task| task.task().to_string()),
+            )
+            .collect()
     }
 
     pub fn direct_dependents_count(&self) -> usize {
@@ -225,13 +243,13 @@ impl Package {
     }
 
     async fn tasks(&self) -> Array<RepositoryTask> {
-        self.get_tasks()
+        let scripts = self.get_tasks();
+        self.get_task_names()
             .into_iter()
-            .sorted_by(|a, b| a.0.cmp(&b.0))
-            .map(|(name, script)| RepositoryTask {
+            .map(|name| RepositoryTask {
+                script: scripts.get(&name).cloned(),
                 name,
                 package: self.clone(),
-                script: Some(script),
             })
             .collect()
     }

--- a/crates/turborepo-query/src/task.rs
+++ b/crates/turborepo-query/src/task.rs
@@ -4,6 +4,7 @@ use async_graphql::{Json, Object};
 use turborepo_engine::TaskNode;
 use turborepo_errors::Spanned;
 use turborepo_task_id::TaskId;
+use turborepo_types::TaskCommandOverride;
 
 use crate::{package::Package, Array, Error, QueryRun};
 
@@ -23,6 +24,34 @@ impl RepositoryTask {
             package,
             script,
         })
+    }
+
+    pub fn executes(&self) -> bool {
+        let task_id = TaskId::from_static(self.package.get_name().to_string(), self.name.clone());
+        match self
+            .package
+            .run()
+            .engine()
+            .task_definition(&task_id)
+            .and_then(|definition| definition.command.as_ref())
+        {
+            Some(TaskCommandOverride::Argv(_)) => true,
+            Some(TaskCommandOverride::OptOut) => false,
+            None => self
+                .package
+                .run()
+                .pkg_dep_graph()
+                .package_info(self.package.get_name())
+                .and_then(|package| {
+                    self.package
+                        .run()
+                        .pkg_dep_graph()
+                        .toolchains()
+                        .get(&package.toolchain)
+                        .map(|toolchain| (package, toolchain))
+                })
+                .is_some_and(|(package, toolchain)| toolchain.defines_task(package, &self.name)),
+        }
     }
 
     fn collect_and_sort<'a>(

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -2319,6 +2319,7 @@ mod test {
         let details = |deliverables| CargoPackageDetails {
             kind: CargoPackageKind::Entrypoint,
             deliverables,
+            manifest_alters_output_layout: false,
             dir: "crate".to_string(),
         };
         let deliverable = |name: &str, kind| Deliverable {

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -356,15 +356,26 @@ pub struct CargoPackageDetails {
     pub dir: String,
 }
 
+const ENTRYPOINT_SUBCOMMANDS: &[(&str, &str)] =
+    &[("build", "build"), ("run", "run"), ("dev", "run")];
+
+const WORKSPACE_SUBCOMMANDS: &[(&str, &str)] = &[
+    ("test", "test"),
+    ("check", "check"),
+    ("lint", "clippy"),
+    ("clippy", "clippy"),
+    ("doc", "doc"),
+    ("docs", "doc"),
+    ("bench", "bench"),
+];
+
 /// Map a Turborepo task name to the Cargo subcommand that implements it for
 /// an entrypoint crate. Entrypoints only build and run — verification verbs
 /// happen at workspace scope.
 pub fn entrypoint_subcommand(task: &str) -> Option<&'static str> {
-    match task {
-        "build" => Some("build"),
-        "run" | "dev" => Some("run"),
-        _ => None,
-    }
+    ENTRYPOINT_SUBCOMMANDS
+        .iter()
+        .find_map(|(name, subcommand)| (*name == task).then_some(*subcommand))
 }
 
 /// Map a Turborepo task name to the Cargo subcommand that implements it at
@@ -374,14 +385,27 @@ pub fn entrypoint_subcommand(task: &str) -> Option<&'static str> {
 /// (`cargo build --package=<crate>`), and a workspace-wide build would
 /// duplicate that work in a second cargo process.
 pub fn workspace_subcommand(task: &str) -> Option<&'static str> {
-    match task {
-        "test" => Some("test"),
-        "check" => Some("check"),
-        "lint" | "clippy" => Some("clippy"),
-        "doc" | "docs" => Some("doc"),
-        "bench" => Some("bench"),
-        _ => None,
-    }
+    WORKSPACE_SUBCOMMANDS
+        .iter()
+        .find_map(|(name, subcommand)| (*name == task).then_some(*subcommand))
+}
+
+fn registered_tasks(details: &CargoPackageDetails) -> impl Iterator<Item = &'static str> {
+    let runnable = details
+        .deliverables
+        .iter()
+        .filter(|deliverable| deliverable.kind == DeliverableKind::Bin)
+        .count()
+        == 1;
+    let tasks = match details.kind {
+        CargoPackageKind::Entrypoint => ENTRYPOINT_SUBCOMMANDS,
+        CargoPackageKind::Workspace => WORKSPACE_SUBCOMMANDS,
+        CargoPackageKind::Library => &[],
+    };
+    tasks
+        .iter()
+        .filter(move |(task, _)| runnable || !matches!(*task, "run" | "dev"))
+        .map(|(task, _)| *task)
 }
 
 /// The Cargo subcommand a task resolves to for a package, given its
@@ -1116,6 +1140,21 @@ impl Toolchain for CargoToolchain {
             .then_some(false);
 
         toolchain::TaskDefaults { cache }
+    }
+
+    fn registered_tasks(&self, package: &crate::package_graph::PackageInfo) -> Vec<String> {
+        package
+            .package_name()
+            .and_then(|name| self.package_details(&name))
+            .map(|details| registered_tasks(&details).map(str::to_string).collect())
+            .unwrap_or_default()
+    }
+
+    fn registers_task(&self, package: &crate::package_graph::PackageInfo, task: &str) -> bool {
+        package
+            .package_name()
+            .and_then(|name| self.package_details(&name))
+            .is_some_and(|details| registered_tasks(&details).any(|registered| registered == task))
     }
 
     /// Route rustc invocations through the embedded sccache, with the
@@ -2274,6 +2313,36 @@ mod test {
     use turbopath::{AbsoluteSystemPathBuf, IntoUnix};
 
     use super::*;
+
+    #[test]
+    fn only_unambiguous_binaries_register_run_tasks() {
+        let details = |deliverables| CargoPackageDetails {
+            kind: CargoPackageKind::Entrypoint,
+            deliverables,
+            dir: "crate".to_string(),
+        };
+        let deliverable = |name: &str, kind| Deliverable {
+            name: name.to_string(),
+            kind,
+        };
+
+        for entrypoint in [
+            details(vec![deliverable("ffi", DeliverableKind::Cdylib)]),
+            details(vec![
+                deliverable("one", DeliverableKind::Bin),
+                deliverable("two", DeliverableKind::Bin),
+            ]),
+        ] {
+            let tasks: Vec<_> = registered_tasks(&entrypoint).collect();
+            assert_eq!(tasks, ["build"]);
+        }
+
+        let binary = details(vec![deliverable("app", DeliverableKind::Bin)]);
+        assert_eq!(
+            registered_tasks(&binary).collect::<Vec<_>>(),
+            ["build", "run", "dev"]
+        );
+    }
 
     fn tempdir_root() -> (tempfile::TempDir, AbsoluteSystemPathBuf) {
         let tmp = tempfile::tempdir().unwrap();

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -252,6 +252,21 @@ pub trait Toolchain: Send + Sync {
         false
     }
 
+    /// Task names this toolchain makes available without an explicit
+    /// turbo.json definition. These act as lowest-precedence empty task
+    /// definitions; normal task configuration still overrides them.
+    fn registered_tasks(&self, package: &crate::package_graph::PackageInfo) -> Vec<String> {
+        let _ = package;
+        Vec::new()
+    }
+
+    /// Whether [`Toolchain::registered_tasks`] contains `task`.
+    fn registers_task(&self, package: &crate::package_graph::PackageInfo, task: &str) -> bool {
+        self.registered_tasks(package)
+            .iter()
+            .any(|registered| registered == task)
+    }
+
     /// Whether this toolchain defines an executable command for `task` in
     /// `package`. Tasks without one are phantom/transit tasks (they exist
     /// solely for dependency ordering via `dependsOn: ["^task"]`): they do

--- a/crates/turborepo-schema-gen/src/main.rs
+++ b/crates/turborepo-schema-gen/src/main.rs
@@ -816,6 +816,12 @@ export interface FutureFlags {
    * crates remain graph nodes, but their tasks are no-ops because Cargo
    * builds them through dependency closures.
    *
+   * Entrypoints implicitly register `build`; crates with one binary also
+   * register `run` and `dev`. The workspace package registers `test`,
+   * `check`, `clippy`/`lint`, `bench`, and `doc`/`docs`. Normal task
+   * definitions configure or override these defaults, and package
+   * configuration can exclude them with `extends: false`.
+   *
    * Task caching uses Cargo-derived inputs and caches entrypoint build
    * deliverables. This feature is experimental.
    *

--- a/crates/turborepo-turbo-json/src/future_flags.rs
+++ b/crates/turborepo-turbo-json/src/future_flags.rs
@@ -99,6 +99,12 @@ pub struct FutureFlags {
     /// crates remain graph nodes, but their tasks are no-ops because Cargo
     /// builds them through dependency closures.
     ///
+    /// Entrypoints implicitly register `build`; crates with one binary also
+    /// register `run` and `dev`. The workspace package registers `test`,
+    /// `check`, `clippy`/`lint`, `bench`, and `doc`/`docs`. Normal task
+    /// definitions configure or override these defaults, and package
+    /// configuration can exclude them with `extends: false`.
+    ///
     /// Task caching uses Cargo-derived inputs and caches entrypoint build
     /// deliverables. This feature is experimental.
     #[serde(default)]

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -223,6 +223,16 @@ whether anything changed; Cargo decides how and in what order to build.**
   time without the "waiting for file lock" noise. Run summaries derive display
   commands from the same verb tables via `Toolchain::task_display_command`, so
   display cannot drift from execution.
+- **Task registration** (`Toolchain::registered_tasks`): entrypoints implicitly
+  register `build`; crates with exactly one binary also register `run` and its
+  `dev` alias. The workspace package registers `test`, `check`, `clippy`/`lint`,
+  `bench`, and `doc`/`docs`; libraries register nothing. These act as empty task
+  definitions at the lowest precedence, so normal `tasks` entries configure or
+  override them and package configuration can exclude them with
+  `extends: false`. Registration is package-aware, so the defaults do not make
+  same-named JavaScript scripts runnable without their usual turbo.json
+  definition. The names come from the same verb tables as command resolution
+  and participate in task suggestions and add-all/query graph construction.
 - **Hashing** (`Toolchain::derived_task_io`, consumed by
   `turborepo-engine/src/builder/definitions.rs`): entrypoint tasks hash
   their own sources plus their transitive dependency crates' sources

--- a/crates/turborepo/tests/cargo_workspace_test.rs
+++ b/crates/turborepo/tests/cargo_workspace_test.rs
@@ -1628,7 +1628,7 @@ fn test_command_override_on_cargo_packages() {
 /// JavaScript project involved.
 #[test]
 fn test_pure_cargo_workspace_dry_run_has_no_package_json() {
-    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = cargo_tempdir();
     setup_cargo_pure_workspace(tempdir.path());
 
     let output = run_turbo(tempdir.path(), &["build", "--dry-run=json"]);
@@ -1673,7 +1673,7 @@ fn test_pure_cargo_workspace_dry_run_has_no_package_json() {
 
 #[test]
 fn test_pure_cargo_workspace_rejects_malformed_package_json() {
-    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = cargo_tempdir();
     setup_cargo_pure_workspace(tempdir.path());
     fs::write(tempdir.path().join("package.json"), "{").unwrap();
 
@@ -1688,7 +1688,7 @@ fn test_pure_cargo_workspace_rejects_malformed_package_json() {
 /// the result, and restores it — all without a package.json.
 #[test]
 fn test_pure_cargo_workspace_filtered_execution() {
-    let tempdir = tempfile::tempdir().unwrap();
+    let tempdir = cargo_tempdir();
     setup_cargo_pure_workspace(tempdir.path());
 
     // Cold: executes cargo and produces the binary.
@@ -1733,5 +1733,212 @@ fn test_pure_cargo_workspace_filtered_execution() {
     assert!(
         !tempdir.path().join("package.json").exists(),
         "turbo must not create a package.json during execution"
+    );
+}
+
+#[test]
+fn test_cargo_tasks_are_registered_without_task_configuration() {
+    let tempdir = cargo_tempdir();
+    setup_cargo_monorepo(tempdir.path());
+    fs::write(
+        tempdir.path().join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": { "experimentalCargoWorkspaces": true },
+  "tasks": {}
+}"#,
+    )
+    .unwrap();
+
+    for (task, expected_command) in [
+        ("build", "cargo build --package=app --locked"),
+        ("run", "cargo run --package=app --locked"),
+        ("dev", "cargo run --package=app --locked"),
+    ] {
+        let output = run_turbo(
+            tempdir.path(),
+            &["run", task, "--filter=app", "--dry-run=json"],
+        );
+        assert!(output.status.success(), "{task} failed: {output:?}");
+        let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        let task_id = format!("app#{task}");
+        let definition = json["tasks"]
+            .as_array()
+            .and_then(|tasks| tasks.iter().find(|item| item["taskId"] == task_id))
+            .unwrap_or_else(|| panic!("app#{task} in graph"));
+        assert_eq!(definition["command"], expected_command);
+    }
+
+    for (task, subcommand) in [
+        ("test", "test"),
+        ("check", "check"),
+        ("clippy", "clippy"),
+        ("lint", "clippy"),
+        ("bench", "bench"),
+        ("doc", "doc"),
+        ("docs", "doc"),
+    ] {
+        let output = run_turbo(
+            tempdir.path(),
+            &["run", task, "--filter=acme", "--dry-run=json"],
+        );
+        assert!(output.status.success(), "{task} failed: {output:?}");
+        let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        let task_id = format!("acme#{task}");
+        let definition = json["tasks"]
+            .as_array()
+            .and_then(|tasks| tasks.iter().find(|item| item["taskId"] == task_id))
+            .unwrap_or_else(|| panic!("acme#{task} in graph"));
+        assert_eq!(
+            definition["command"],
+            format!("cargo {subcommand} --workspace --locked")
+        );
+    }
+}
+
+#[test]
+fn test_implicit_cargo_tasks_are_package_aware_and_configurable() {
+    let tempdir = cargo_tempdir();
+    setup_cargo_monorepo(tempdir.path());
+    fs::write(
+        tempdir.path().join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": { "experimentalCargoWorkspaces": true },
+  "tasks": { "build": { "cache": false } }
+}"#,
+    )
+    .unwrap();
+
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "build", "--filter=app", "--dry-run=json"],
+    );
+    assert!(
+        output.status.success(),
+        "configured build failed: {output:?}"
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let build = json["tasks"]
+        .as_array()
+        .and_then(|tasks| tasks.iter().find(|task| task["taskId"] == "app#build"))
+        .expect("app#build in graph");
+    assert_eq!(build["command"], "cargo build --package=app --locked");
+    assert_eq!(build["resolvedTaskDefinition"]["cache"], false);
+
+    fs::write(
+        tempdir.path().join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": { "experimentalCargoWorkspaces": true },
+  "tasks": {}
+}"#,
+    )
+    .unwrap();
+    let output = run_turbo(
+        tempdir.path(),
+        &["run", "build", "--filter=js-pkg", "--dry-run=json"],
+    );
+    assert!(
+        output.status.success(),
+        "filtered JS build failed: {output:?}"
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(json["tasks"].as_array().is_some_and(Vec::is_empty));
+
+    let output = run_turbo(tempdir.path(), &["run", "biuld", "--filter=app"]);
+    assert!(!output.status.success(), "unknown task must fail");
+}
+
+#[test]
+fn test_query_discovers_and_excludes_implicit_cargo_tasks() {
+    let tempdir = cargo_tempdir();
+    setup_cargo_monorepo(tempdir.path());
+    fs::write(
+        tempdir.path().join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": { "experimentalCargoWorkspaces": true },
+  "tasks": {}
+}"#,
+    )
+    .unwrap();
+
+    let query = |package: &str| {
+        let query =
+            format!("query {{ package(name: \"{package}\") {{ tasks {{ items {{ name }} }} }} }}");
+        let output = run_turbo(tempdir.path(), &["query", &query]);
+        assert!(output.status.success(), "query failed: {output:?}");
+        let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        json["data"]["package"]["tasks"]["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|task| task["name"].as_str())
+            .map(str::to_string)
+            .collect::<Vec<_>>()
+    };
+
+    let app_tasks = query("app");
+    assert!(app_tasks.iter().any(|task| task == "build"));
+    assert!(app_tasks.iter().any(|task| task == "run"));
+    assert!(app_tasks.iter().any(|task| task == "dev"));
+    assert!(!app_tasks.iter().any(|task| task == "lint"));
+
+    let workspace_tasks = query("acme");
+    assert!(workspace_tasks.iter().any(|task| task == "clippy"));
+    assert!(workspace_tasks.iter().any(|task| task == "lint"));
+    assert!(workspace_tasks.iter().any(|task| task == "docs"));
+
+    fs::write(
+        tempdir.path().join("crates/app/turbo.json"),
+        r#"{
+  "extends": ["//"],
+  "tasks": { "build": { "extends": false } }
+}"#,
+    )
+    .unwrap();
+    assert!(!query("app").iter().any(|task| task == "build"));
+}
+
+#[test]
+fn test_affected_tasks_include_implicit_cargo_commands() {
+    let tempdir = cargo_tempdir();
+    setup_cargo_monorepo(tempdir.path());
+    fs::write(
+        tempdir.path().join("turbo.json"),
+        r#"{
+  "$schema": "https://turborepo.dev/schema.json",
+  "futureFlags": { "experimentalCargoWorkspaces": true },
+  "tasks": {}
+}"#,
+    )
+    .unwrap();
+    fs::write(
+        tempdir.path().join("crates/app/src/main.rs"),
+        "fn main() { println!(\"changed\"); }\n",
+    )
+    .unwrap();
+
+    let output = run_turbo(
+        tempdir.path(),
+        &[
+            "query",
+            "query { affectedTasks(tasks: [\"build\", \"lint\"]) { items { name package { name } \
+             } } }",
+        ],
+    );
+    assert!(output.status.success(), "query failed: {output:?}");
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let tasks = json["data"]["affectedTasks"]["items"].as_array().unwrap();
+    assert!(
+        tasks
+            .iter()
+            .any(|task| task["name"] == "build" && task["package"]["name"] == "app")
+    );
+    assert!(
+        tasks
+            .iter()
+            .any(|task| task["name"] == "lint" && task["package"]["name"] == "acme")
     );
 }

--- a/packages/turbo-types/schemas/schema.json
+++ b/packages/turbo-types/schemas/schema.json
@@ -301,7 +301,7 @@
           "type": "boolean"
         },
         "experimentalCargoWorkspaces": {
-          "description": "Treat the crates of a Cargo workspace as Turborepo packages.\n\nWhen enabled, Rust crates are discovered via `cargo metadata` and participate in the package graph: they resolve in `--filter` expressions, propagate `--affected`, and appear in `turbo query`. Entrypoint `build`, `run`, and `dev` tasks execute per crate, while verification tasks execute on the synthetic workspace package. Library crates remain graph nodes, but their tasks are no-ops because Cargo builds them through dependency closures.\n\nTask caching uses Cargo-derived inputs and caches entrypoint build deliverables. This feature is experimental.",
+          "description": "Treat the crates of a Cargo workspace as Turborepo packages.\n\nWhen enabled, Rust crates are discovered via `cargo metadata` and participate in the package graph: they resolve in `--filter` expressions, propagate `--affected`, and appear in `turbo query`. Entrypoint `build`, `run`, and `dev` tasks execute per crate, while verification tasks execute on the synthetic workspace package. Library crates remain graph nodes, but their tasks are no-ops because Cargo builds them through dependency closures.\n\nEntrypoints implicitly register `build`; crates with one binary also register `run` and `dev`. The workspace package registers `test`, `check`, `clippy`/`lint`, `bench`, and `doc`/`docs`. Normal task definitions configure or override these defaults, and package configuration can exclude them with `extends: false`.\n\nTask caching uses Cargo-derived inputs and caches entrypoint build deliverables. This feature is experimental.",
           "default": false,
           "type": "boolean"
         },

--- a/packages/turbo-types/src/types/config-v2.ts
+++ b/packages/turbo-types/src/types/config-v2.ts
@@ -314,6 +314,12 @@ export interface FutureFlags {
    * crates remain graph nodes, but their tasks are no-ops because Cargo
    * builds them through dependency closures.
    *
+   * Entrypoints implicitly register `build`; crates with one binary also
+   * register `run` and `dev`. The workspace package registers `test`,
+   * `check`, `clippy`/`lint`, `bench`, and `doc`/`docs`. Normal task
+   * definitions configure or override these defaults, and package
+   * configuration can exclude them with `extends: false`.
+   *
    * Task caching uses Cargo-derived inputs and caches entrypoint build
    * deliverables. This feature is experimental.
    *


### PR DESCRIPTION
## Why
Cargo workspace users currently have to repeat Turborepo task names even though the Cargo toolchain already owns the verb mapping. This makes opt-in configuration verbose and lets documentation drift from execution behavior.

## What
Cargo now contributes package-aware implicit task definitions at the lowest precedence, including the generic `dev`, `lint`, and `docs` aliases. Normal task definitions still configure, override, or exclude these defaults, while JavaScript task registration remains unchanged.

## How
The toolchain registration API feeds engine resolution, task suggestions, query, and affected-task discovery from the same Cargo verb tables used for execution. Coverage includes native verbs and aliases, mixed JS/Cargo isolation, overrides, exclusions, query behavior, affected tasks, and non-runnable Cargo entrypoints.