### PR TITLE
fix: Preserve colors in TUI output

### DIFF
--- a/crates/turborepo-ghostty/src/convert.rs
+++ b/crates/turborepo-ghostty/src/convert.rs
@@ -5,21 +5,21 @@ pub fn rgb_color(c: style::RgbColor) -> Color {
     Color::Rgb(c.r, c.g, c.b)
 }
 
-fn resolve_color(color: &style::StyleColor, palette: &[style::RgbColor; 256]) -> Option<Color> {
+fn resolve_color(color: &style::StyleColor) -> Option<Color> {
     match color {
         style::StyleColor::None => None,
         style::StyleColor::Rgb(c) => Some(rgb_color(*c)),
-        style::StyleColor::Palette(idx) => Some(rgb_color(palette[idx.0 as usize])),
+        style::StyleColor::Palette(idx) => Some(Color::Indexed(idx.0)),
     }
 }
 
-pub fn style(s: &style::Style, palette: &[style::RgbColor; 256]) -> Style {
+pub fn style(s: &style::Style) -> Style {
     let mut result = Style::default();
 
-    if let Some(fg) = resolve_color(&s.fg_color, palette) {
+    if let Some(fg) = resolve_color(&s.fg_color) {
         result = result.fg(fg);
     }
-    if let Some(bg) = resolve_color(&s.bg_color, palette) {
+    if let Some(bg) = resolve_color(&s.bg_color) {
         result = result.bg(bg);
     }
 

--- a/crates/turborepo-ghostty/src/widget.rs
+++ b/crates/turborepo-ghostty/src/widget.rs
@@ -1,12 +1,11 @@
 use libghostty_vt::{
     RenderState, Terminal,
     render::{CellIterator, CursorViewport, CursorVisualStyle, RowIterator},
-    style::RgbColor,
 };
 use ratatui::{
     buffer::Buffer,
     layout::{Position, Rect},
-    style::{Color, Modifier},
+    style::Modifier,
     widgets::Widget,
 };
 
@@ -61,17 +60,9 @@ impl<'a, 'alloc, 'cb> TerminalWidget<'a, 'alloc, 'cb> {
     }
 }
 
-fn rgb_to_color(color: RgbColor) -> Color {
-    Color::Rgb(color.r, color.g, color.b)
-}
-
 impl Widget for &mut TerminalWidget<'_, '_, '_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let Ok(snapshot) = self.render_state.update(self.terminal) else {
-            return;
-        };
-
-        let Ok(colors) = snapshot.colors() else {
             return;
         };
 
@@ -137,29 +128,8 @@ impl Widget for &mut TerminalWidget<'_, '_, '_> {
                     },
                 };
 
-                // Unset cell colors map to `Color::Reset` so the host
-                // terminal's own theme shows through, rather than Ghostty's
-                // built-in default colors (which would paint a black
-                // background on light-themed terminals).
-                let fg = cell
-                    .fg_color()
-                    .ok()
-                    .flatten()
-                    .map(rgb_to_color)
-                    .unwrap_or(Color::Reset);
-                let bg = cell
-                    .bg_color()
-                    .ok()
-                    .flatten()
-                    .map(rgb_to_color)
-                    .unwrap_or(Color::Reset);
-
                 let cell_style = cell.style().ok();
-                let mut ratatui_style = cell_style
-                    .as_ref()
-                    .map(|style| convert::style(style, &colors.palette))
-                    .unwrap_or_default();
-                ratatui_style = ratatui_style.fg(fg).bg(bg);
+                let mut ratatui_style = cell_style.as_ref().map(convert::style).unwrap_or_default();
 
                 if row_selection.is_some_and(|selection| {
                     col_idx >= selection.start_x && col_idx <= selection.end_x
@@ -185,7 +155,7 @@ impl Widget for &mut TerminalWidget<'_, '_, '_> {
 
 #[cfg(test)]
 mod tests {
-    use ratatui::{Terminal, backend::TestBackend, widgets::Widget};
+    use ratatui::{Terminal, backend::TestBackend, style::Color, widgets::Widget};
 
     use super::*;
     use crate::Parser;
@@ -232,5 +202,72 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn renders_ansi_palette_color() {
+        let (cols, rows): (u16, u16) = (20, 5);
+        let backend = TestBackend::new(cols, rows);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+
+        let mut parser = Parser::try_new(rows, cols, 0).expect("parser");
+        parser.process(b"\x1b[31mRed\x1b[0m");
+        terminal
+            .draw(|frame| {
+                let mut widget =
+                    TerminalWidget::new(&mut parser.terminal, &mut parser.render_state);
+                widget.render(frame.area(), frame.buffer_mut());
+            })
+            .expect("draw");
+
+        let buf = terminal.backend().buffer();
+        let cell = &buf[ratatui::layout::Position::new(0, 0)];
+        assert_eq!(cell.symbol(), "R");
+        assert_eq!(cell.fg, Color::Indexed(1));
+    }
+
+    #[test]
+    fn renders_truecolor() {
+        let (cols, rows): (u16, u16) = (20, 5);
+        let backend = TestBackend::new(cols, rows);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+
+        let mut parser = Parser::try_new(rows, cols, 0).expect("parser");
+        parser.process(b"\x1b[38;2;12;34;56mColor\x1b[0m");
+        terminal
+            .draw(|frame| {
+                let mut widget =
+                    TerminalWidget::new(&mut parser.terminal, &mut parser.render_state);
+                widget.render(frame.area(), frame.buffer_mut());
+            })
+            .expect("draw");
+
+        let buf = terminal.backend().buffer();
+        let cell = &buf[ratatui::layout::Position::new(0, 0)];
+        assert_eq!(cell.symbol(), "C");
+        assert_eq!(cell.fg, Color::Rgb(12, 34, 56));
+    }
+
+    #[test]
+    fn leaves_default_colors_reset() {
+        let (cols, rows): (u16, u16) = (20, 5);
+        let backend = TestBackend::new(cols, rows);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+
+        let mut parser = Parser::try_new(rows, cols, 0).expect("parser");
+        parser.process(b"Plain");
+        terminal
+            .draw(|frame| {
+                let mut widget =
+                    TerminalWidget::new(&mut parser.terminal, &mut parser.render_state);
+                widget.render(frame.area(), frame.buffer_mut());
+            })
+            .expect("draw");
+
+        let buf = terminal.backend().buffer();
+        let cell = &buf[ratatui::layout::Position::new(0, 0)];
+        assert_eq!(cell.symbol(), "P");
+        assert_eq!(cell.fg, Color::Reset);
+        assert_eq!(cell.bg, Color::Reset);
     }
 }


### PR DESCRIPTION
## Why

The Ghostty-backed TUI replaced task ANSI colors with resolved default terminal colors, making output appear black or gray. Fixes #13379.

## What

Preserve ANSI palette indices and explicit RGB styles while leaving unspecified colors controlled by the user's terminal theme.

## How

Added regression coverage for indexed ANSI colors, truecolor, and default colors. Verified with `cargo test -p turborepo-ghostty`; required pre-push format and TOML checks pass.