### PR TITLE
chore: Avoid duplicate N-API Cargo build

### DIFF
--- a/packages/turbo-repository/rust/turbo.json
+++ b/packages/turbo-repository/rust/turbo.json
@@ -1,0 +1,11 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      // The parent package's N-API build consumes this task's Cargo-derived
+      // transitive input hash, but performs the specialized build itself.
+      "command": null,
+      "dependsOn": []
+    }
+  }
+}

--- a/packages/turbo-repository/turbo.json
+++ b/packages/turbo-repository/turbo.json
@@ -3,10 +3,9 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      // The napi crate is a real Turborepo package: depending on its build
-      // task invalidates this one whenever the crate's transitive Rust
-      // sources change — a cross-toolchain edge scoped to the crate's
-      // actual closure rather than a global "any Rust changed" bit.
+      // The napi crate's build task is a hash-only dependency: it invalidates
+      // this task whenever the crate's transitive Rust sources change without
+      // running Cargo before the specialized N-API build runs it here.
       // CARGO_BUILD_JOBS only affects parallelism, not artifacts, so it no
       // longer participates in the hash.
       "dependsOn": ["turborepo-napi#build"],


### PR DESCRIPTION
## Summary

- make the inferred `turborepo-napi#build` task a hash-only dependency
- retain Cargo-derived transitive Rust input hashing without running a preliminary Cargo build
- let `@turbo/repository#build` perform the specialized N-API build exactly once

## Testing

- `turbo run build --filter=@turbo/repository --dry`
- `turbo run build --filter=@turbo/repository --log-order=stream`
- `turbo run test --filter=@turbo/repository --log-order=stream` (21 passing)
- pre-push hooks