### PR TITLE
chore: Hash embedded frameworks data in Rust builds

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -107,11 +107,21 @@
       "persistent": true,
       "env": ["AI_GATEWAY_API_KEY"]
     },
-    // turborepo-lib embeds version.txt via include_str!; it lives outside
-    // every crate directory, so the automatic crate-closure hashing can't
-    // see it. $TURBO_DEFAULT$ keeps the automatic inputs and appends it.
+    // These entrypoints embed files outside every crate directory, so the
+    // automatic crate-closure hashing cannot see them. $TURBO_DEFAULT$ keeps
+    // the automatic inputs and appends the external files.
     "turbo#build": {
-      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/version.txt"]
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/version.txt",
+        "$TURBO_ROOT$/packages/turbo-types/src/json/frameworks.json"
+      ]
+    },
+    "turborepo-lsp#build": {
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/packages/turbo-types/src/json/frameworks.json"
+      ]
     },
     "package-checks": {
       "dependsOn": ["package:types"]


### PR DESCRIPTION
## Summary

- add the JS-owned `frameworks.json` embedded by `turborepo-frameworks` to the inferred CLI build inputs
- add the same external input to the inferred LSP build
- retain Cargo-derived crate closure hashing with `$TURBO_DEFAULT$`

The workspace test command already hashes the repository root, so it does not need an additional explicit input.

## Testing

- verified both resolved build definitions include `packages/turbo-types/src/json/frameworks.json`
- verified a content-only change updates both `turbo#build` and `turborepo-lsp#build` hashes
- pre-push hooks