### PR TITLE
ci: Include VS Code extension type checks

### DIFF
--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -266,7 +266,8 @@ jobs:
           test -f out/turborepo-lsp-win32-x64.exe
 
       - name: Compile extension
-        run: pnpm --filter turbo-vsc run test-compile
+        working-directory: packages/turbo-vsc
+        run: pnpm run check-types
 
       - name: Package VSIX
         working-directory: packages/turbo-vsc

--- a/packages/turbo-vsc/package.json
+++ b/packages/turbo-vsc/package.json
@@ -39,7 +39,7 @@
     "copy-win32-arm64": "cp out/artifacts/turborepo-lsp-aarch64-pc-windows-msvc/turborepo-lsp.exe out/turborepo-lsp-win32-arm64.exe",
     "copy": "pnpm run copy-darwin-arm64 && pnpm run copy-darwin-x64 && pnpm run copy-win32-arm64 && pnpm run copy-win32-x64 && pnpm run copy-linux-arm64 && pnpm run copy-linux-x64",
     "test": "node --import tsx --test src/*.test.ts",
-    "test-compile": "tsc -p ./ --noEmit"
+    "check-types": "tsc -p ./ --noEmit"
   },
   "dependencies": {
     "brace-expansion": "2.0.3",


### PR DESCRIPTION
## Summary

- Rename the VS Code extension compile check to the standard `check-types` task
- Make the ordinary JS package test graph discover and run it
- Keep the LSP packaging workflow invoking the renamed task from its package directory