### PR TITLE
fix: Pin VS Code extension macOS runners

### DIFF
--- a/.github/workflows/lsp.yml
+++ b/.github/workflows/lsp.yml
@@ -51,9 +51,9 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-latest
+          - host: macos-15-xlarge
             target: "x86_64-apple-darwin"
-          - host: macos-latest
+          - host: macos-15-xlarge
             target: "aarch64-apple-darwin"
           - host: ubuntu-latest
             prepare: "sudo apt-get update && sudo apt-get install -y curl musl-tools"


### PR DESCRIPTION
## Why

The VS Code extension release failed for both Darwin targets because Zig 0.15.2 could not link against the moving `macos-latest` runner image:

- https://github.com/vercel/turborepo/actions/runs/29382101590/job/87250192280
- https://github.com/vercel/turborepo/actions/runs/29382101590/job/87250192300

The main release jobs built the same targets successfully on `macos-15-xlarge` in the same run.

## What

Pin both LSP Darwin matrix entries to the known-good `macos-15-xlarge` image.

## Validation

- `pnpm exec oxfmt --check .github/workflows/lsp.yml`
- `git diff --check`
- Pre-push hooks: `turbo run format check:toml`