### PR TITLE
ci: Fetch release commit parent

### DIFF
--- a/.github/workflows/turborepo-release.yml
+++ b/.github/workflows/turborepo-release.yml
@@ -534,6 +534,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ needs.stage.outputs.stage-branch }}
+          fetch-depth: 2
           filter: blob:none
           persist-credentials: false
 


### PR DESCRIPTION
### Description

Fetch two commits in the npm publish checkout so `turbo-releaser` can log the staging commit with `git format-patch HEAD~1`.

The releaser migration exposed a latent shallow-checkout issue: the old Makefile piped `git format-patch` to `cat`, which masked the failure, while the new direct invocation correctly propagates it.

Fixes the failure in https://github.com/vercel/turborepo/actions/runs/29647142920/job/88088833759.

### Testing Instructions

- `pnpm exec oxfmt --check .github/workflows/turborepo-release.yml`
- `pnpm exec oxlint --deny-warnings .github/workflows/turborepo-release.yml`
- Verified `git format-patch HEAD~1 --stdout` succeeds in a depth-two clone
- Pre-push hooks