### PR TITLE
perf: Skip regex passes for glob patterns without metacharacters

### DIFF
--- a/crates/turborepo-globwalk/examples/glob_preprocess_bench.rs
+++ b/crates/turborepo-globwalk/examples/glob_preprocess_bench.rs
@@ -1,0 +1,197 @@
+//! Micro-benchmark for the glob-preprocessing fast paths.
+//!
+//! Compares the previous regex-based implementations of `fix_glob_pattern` and
+//! `escape_glob_literals` against the current ones (which skip the regex engine
+//! when the input has no `**` token / no glob metacharacters).
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo run -p globwalk --release --example glob_preprocess_bench
+//! ```
+//!
+//! The example is dependency-free (uses `std::time` and the `regex` crate that
+//! `globwalk` already depends on) so it runs offline and produces directly
+//! comparable before/after numbers.
+
+// This is a throwaway benchmark harness; the regex reference impls genuinely
+// need to unwrap their (statically valid) patterns.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::{
+    borrow::Cow,
+    hint::black_box,
+    sync::OnceLock,
+    time::{Duration, Instant},
+};
+
+use globwalk::fix_glob_pattern;
+use regex::Regex;
+
+// --- Previous ("old") implementations, copied verbatim from the pre-change
+// --- source so the benchmark measures the same work the old code did. ---
+
+fn old_double_doublestar() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"\*\*(?:/\*\*)+").unwrap())
+}
+fn old_leading_doublestar() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"\*\*(?P<suffix>[^*/]+)").unwrap())
+}
+fn old_trailing_doublestar() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"(?P<prefix>[^*/]+)\*\*").unwrap())
+}
+fn old_glob_literals() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"(?<literal>[\?\*\$:<>\(\)\[\]{},])").unwrap())
+}
+
+fn old_fix_glob_pattern(pattern: &str) -> Cow<'_, str> {
+    let p0: Cow<'_, str> = Cow::Borrowed(pattern);
+    let p1 = old_double_doublestar().replace(&p0, "**");
+    let p2 = old_leading_doublestar().replace(&p1, "**/*$suffix");
+    let p3 = old_trailing_doublestar().replace(&p2, "$prefix*/**");
+    match p3 {
+        Cow::Borrowed(s) if std::ptr::eq(s, pattern) => Cow::Borrowed(pattern),
+        Cow::Borrowed(s) => Cow::Owned(s.to_string()),
+        Cow::Owned(s) => Cow::Owned(s),
+    }
+}
+
+fn old_escape_glob_literals(literal_glob: &str) -> Cow<'_, str> {
+    old_glob_literals().replace_all(literal_glob, "\\$literal")
+}
+
+// --- Current ("new") escape implementation. `fix_glob_pattern` is exercised
+// --- through the public API; `escape_glob_literals` is private, so its current
+// --- logic is mirrored here (kept in sync with `src/lib.rs`). ---
+
+#[inline]
+fn is_glob_literal(c: char) -> bool {
+    matches!(
+        c,
+        '?' | '*' | '$' | ':' | '<' | '>' | '(' | ')' | '[' | ']' | '{' | '}' | ','
+    )
+}
+
+fn new_escape_glob_literals(literal_glob: &str) -> Cow<'_, str> {
+    if !literal_glob.contains(is_glob_literal) {
+        return Cow::Borrowed(literal_glob);
+    }
+    let mut escaped = String::with_capacity(literal_glob.len() + 8);
+    for c in literal_glob.chars() {
+        if is_glob_literal(c) {
+            escaped.push('\\');
+        }
+        escaped.push(c);
+    }
+    Cow::Owned(escaped)
+}
+
+/// Globs representative of what turbo feeds through preprocessing: task
+/// input/output globs, workspace globs, and base paths. The majority contain no
+/// `**` token / no metacharacters, which is exactly the case the fast paths
+/// target.
+fn corpus() -> Vec<String> {
+    let globs = [
+        "package.json",
+        "tsconfig.json",
+        "src/index.ts",
+        "dist",
+        "dist/",
+        ".next",
+        "build",
+        "src/*.ts",
+        "*.js",
+        "lib/**",
+        "**/*.ts",
+        "src/**/*.tsx",
+        "packages/*/package.json",
+        "apps/*/dist/**",
+        "!**/*.test.ts",
+        "coverage/**",
+        "node_modules",
+        "README.md",
+        "public/assets/images/logo.svg",
+        "very/deeply/nested/directory/structure/without/any/globs/file.json",
+    ];
+    globs.iter().map(|s| s.to_string()).collect()
+}
+
+/// Absolute-ish base paths, the typical input to `escape_glob_literals`.
+fn base_path_corpus() -> Vec<String> {
+    [
+        "/home/user/projects/monorepo",
+        "/home/user/projects/monorepo/apps/web",
+        "/home/user/projects/monorepo/packages/ui/src",
+        "/var/lib/ci/workspace/build/output",
+        "/Users/dev/code/company/very/deep/package/path",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect()
+}
+
+fn bench<F>(iters: u32, corpus: &[String], mut f: F) -> Duration
+where
+    F: FnMut(&str) -> usize,
+{
+    // Warm up.
+    for _ in 0..5 {
+        for s in corpus {
+            black_box(f(black_box(s)));
+        }
+    }
+    let start = Instant::now();
+    for _ in 0..iters {
+        for s in corpus {
+            black_box(f(black_box(s)));
+        }
+    }
+    start.elapsed()
+}
+
+fn report(label: &str, calls: u64, old: Duration, new: Duration) {
+    let old_ns = old.as_nanos() as f64 / calls as f64;
+    let new_ns = new.as_nanos() as f64 / calls as f64;
+    let speedup = old_ns / new_ns;
+    println!("{label}");
+    println!("  old (regex): {old_ns:8.1} ns/call  ({old:?} total)");
+    println!("  new (fast) : {new_ns:8.1} ns/call  ({new:?} total)");
+    println!(
+        "  speedup    : {speedup:.2}x  ({:.1}% faster)\n",
+        (1.0 - new_ns / old_ns) * 100.0
+    );
+}
+
+fn main() {
+    // Correctness gate: the benchmark must only compare identical behavior.
+    for s in corpus().iter().chain(base_path_corpus().iter()) {
+        assert_eq!(
+            old_fix_glob_pattern(s).as_ref(),
+            fix_glob_pattern(s).as_ref(),
+            "fix_glob_pattern diverged for {s:?}"
+        );
+        assert_eq!(
+            old_escape_glob_literals(s).as_ref(),
+            new_escape_glob_literals(s).as_ref(),
+            "escape_glob_literals diverged for {s:?}"
+        );
+    }
+
+    let iters: u32 = 200_000;
+
+    let fix_corpus = corpus();
+    let calls = iters as u64 * fix_corpus.len() as u64;
+    let old = bench(iters, &fix_corpus, |s| old_fix_glob_pattern(s).len());
+    let new = bench(iters, &fix_corpus, |s| fix_glob_pattern(s).len());
+    report("fix_glob_pattern (mixed task glob corpus)", calls, old, new);
+
+    let esc_corpus = base_path_corpus();
+    let calls = iters as u64 * esc_corpus.len() as u64;
+    let old = bench(iters, &esc_corpus, |s| old_escape_glob_literals(s).len());
+    let new = bench(iters, &esc_corpus, |s| new_escape_glob_literals(s).len());
+    report("escape_glob_literals (base path corpus)", calls, old, new);
+}

--- a/crates/turborepo-globwalk/src/lib.rs
+++ b/crates/turborepo-globwalk/src/lib.rs
@@ -59,17 +59,35 @@ fn join_unix_like_paths(a: &str, b: &str) -> String {
     [a.trim_end_matches('/'), "/", b.trim_start_matches('/')].concat()
 }
 
-fn glob_literals() -> Option<&'static Regex> {
-    static RE: OnceLock<Option<Regex>> = OnceLock::new();
-    RE.get_or_init(|| Regex::new(r"(?<literal>[\?\*\$:<>\(\)\[\]{},])").ok())
-        .as_ref()
+/// Characters that `wax` treats as glob metacharacters but that we escape when
+/// they appear literally in a path. Kept in sync with the character class in
+/// the former `glob_literals` regex (`[\?\*\$:<>\(\)\[\]{},]`).
+#[inline]
+fn is_glob_literal(c: char) -> bool {
+    matches!(
+        c,
+        '?' | '*' | '$' | ':' | '<' | '>' | '(' | ')' | '[' | ']' | '{' | '}' | ','
+    )
 }
 
 fn escape_glob_literals(literal_glob: &str) -> Cow<'_, str> {
-    let Some(glob_literals) = glob_literals() else {
+    // Fast path: paths rarely contain glob metacharacters (a base path is the
+    // common input), so scan first and return a borrow without allocating or
+    // touching the regex engine when there is nothing to escape.
+    if !literal_glob.contains(is_glob_literal) {
         return Cow::Borrowed(literal_glob);
-    };
-    glob_literals.replace_all(literal_glob, "\\$literal")
+    }
+
+    // Each metacharacter is prefixed with a single backslash, mirroring the
+    // previous `replace_all(_, "\\$literal")` behavior exactly.
+    let mut escaped = String::with_capacity(literal_glob.len() + 8);
+    for c in literal_glob.chars() {
+        if is_glob_literal(c) {
+            escaped.push('\\');
+        }
+        escaped.push(c);
+    }
+    Cow::Owned(escaped)
 }
 
 #[tracing::instrument(skip(include, exclude))]
@@ -159,6 +177,20 @@ pub fn fix_glob_pattern(pattern: &str) -> Cow<'_, str> {
             converted
         }
     };
+
+    // Fast path: every normalization below only rewrites patterns containing a
+    // `**` token — all three regexes require the literal substring `**` to
+    // match. When the pattern has none, running the regex engine is guaranteed
+    // to be a no-op, so skip straight to the return logic. `str::contains` uses
+    // a fast substring search, avoiding three regex scans for the common case
+    // (e.g. `package.json`, `dist`, `src/*.ts`).
+    if !p0.contains("**") {
+        return match p0 {
+            Cow::Borrowed(s) if std::ptr::eq(s, pattern) => Cow::Borrowed(pattern),
+            Cow::Borrowed(s) => Cow::Owned(s.to_string()),
+            Cow::Owned(s) => Cow::Owned(s),
+        };
+    }
 
     // Chain regex replacements, taking advantage of Cow<str>:
     // - If no match, replace() returns Cow::Borrowed pointing to the input
@@ -267,7 +299,7 @@ fn add_trailing_double_star(exclude_paths: &mut Vec<String>, glob: &str) {
 fn add_doublestar_to_dir(base: &AbsoluteSystemPath, glob: &mut String) {
     // If the glob has a glob literal in it e.g. *
     // then skip trying to read it as a file path.
-    if glob_literals().is_some_and(|glob_literals| glob_literals.is_match(&*glob)) {
+    if glob.contains(is_glob_literal) {
         return;
     }
 
@@ -2191,6 +2223,88 @@ mod test {
             escape_glob_literals("?*$:<>()[]{},"),
             r"\?\*\$\:\<\>\(\)\[\]\{\}\,"
         );
+    }
+
+    /// Reference implementation of `escape_glob_literals` using the original
+    /// regex, kept here so we can prove the hand-rolled scanner is
+    /// byte-for-byte equivalent over a large corpus.
+    fn ref_escape_glob_literals(literal_glob: &str) -> String {
+        use regex::Regex;
+        let re = Regex::new(r"(?<literal>[\?\*\$:<>\(\)\[\]{},])").unwrap();
+        re.replace_all(literal_glob, "\\$literal").into_owned()
+    }
+
+    /// Reference implementation of `fix_glob_pattern` that always runs the
+    /// regex chain (i.e. without the `**` fast path), so we can prove the
+    /// fast path never changes the result.
+    fn ref_fix_glob_pattern(pattern: &str) -> String {
+        let p1 = crate::double_doublestar()
+            .map(|re| re.replace(pattern, "**").into_owned())
+            .unwrap_or_else(|| pattern.to_string());
+        let p2 = crate::leading_doublestar()
+            .map(|re| re.replace(&p1, "**/*$suffix").into_owned())
+            .unwrap_or(p1);
+        crate::trailing_doublestar()
+            .map(|re| re.replace(&p2, "$prefix*/**").into_owned())
+            .unwrap_or(p2)
+    }
+
+    /// A corpus that exercises both the fast path (no `**`) and the regex path,
+    /// plus every escapable metacharacter.
+    fn glob_corpus() -> Vec<String> {
+        let bases = [
+            "",
+            "package.json",
+            "src/lib.rs",
+            "dist",
+            "dist/",
+            "src/*.ts",
+            "packages/*/package.json",
+            "**",
+            "**/**",
+            "**/**/**",
+            "**/*.ts",
+            "src/**/*.ts",
+            "**token/foo",
+            "**token**",
+            "a/**/**/b",
+            "foo**bar",
+            "?*$:<>()[]{},",
+            "a(b)c",
+            "list,of,things",
+            "weird[name]/**",
+            "no-metacharacters-here/deeply/nested/path/file.txt",
+            "/absolute/base/path/to/a/monorepo/package",
+        ];
+        let mut corpus: Vec<String> = bases.iter().map(|s| s.to_string()).collect();
+        // A few longer synthetic paths to stress the scanners.
+        for depth in [4usize, 16, 64] {
+            corpus.push(vec!["segment"; depth].join("/"));
+            corpus.push(format!("{}/**/*.rs", vec!["dir"; depth].join("/")));
+        }
+        corpus
+    }
+
+    #[test]
+    fn escape_glob_literals_matches_regex_reference() {
+        for input in glob_corpus() {
+            assert_eq!(
+                escape_glob_literals(&input).as_ref(),
+                ref_escape_glob_literals(&input),
+                "escape mismatch for input {input:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn fix_glob_pattern_fast_path_matches_regex_reference() {
+        for input in glob_corpus() {
+            assert_eq!(
+                fix_glob_pattern(&input).as_ref(),
+                ref_fix_glob_pattern(&input),
+                "fix_glob_pattern mismatch for input {input:?}"
+            );
+        }
     }
 
     #[test_case("**/*.ts", false ; "simple glob no cleaning")]


### PR DESCRIPTION
## Summary

`turborepo-globwalk` runs the `regex` engine over every glob pattern and base
path during glob preprocessing (`preprocess_paths_and_globs`), which happens for
every task's input/output globs, every workspace glob, and manual SCM hashing.
Most of these strings contain no glob metacharacters at all, yet each one still
paid for one-to-three full regex scans.

This change adds cheap fast paths that skip the regex engine when it is provably
a no-op:

- **`fix_glob_pattern`** ran three regex `replace` passes on every pattern. All
  three regexes (`\*\*(?:/\*\*)+`, `\*\*(?P<suffix>[^*/]+)`,
  `(?P<prefix>[^*/]+)\*\*`) require the literal substring `**` to match, so when
  a pattern has no `**` the result is guaranteed unchanged. We now short-circuit
  with a single `str::contains("**")` substring search (e.g. `package.json`,
  `dist`, `src/*.ts`).
- **`escape_glob_literals`** used a regex `replace_all` to backslash-escape the
  character class `[\?\*\$:<>\(\)\[\]{},]`. It is replaced with a direct byte
  scan that returns a borrow when nothing needs escaping and otherwise produces
  byte-for-byte identical output. The now-unused `glob_literals` regex is
  removed; `add_doublestar_to_dir`'s metacharacter check uses the same scanner.

Behavior is unchanged — these are pure algorithmic shortcuts.

## Benchmark

A dependency-free benchmark (`examples/glob_preprocess_bench.rs`, uses only
`std::time` and the already-present `regex` crate) compares the previous
regex-based implementations against the new ones over realistic corpora. It
asserts the two implementations produce identical output before timing.

```
cargo run -p globwalk --release --example glob_preprocess_bench
```

Representative results (Linux, release build):

| function | old (regex) | new (fast path) | speedup |
|---|---|---|---|
| `fix_glob_pattern` (mixed task-glob corpus) | ~190 ns/call | ~81 ns/call | **~2.3x** (~57% faster) |
| `escape_glob_literals` (base-path corpus) | ~117 ns/call | ~48 ns/call | **~2.5x** (~59% faster) |

Stable across repeated runs (2.1–2.5x).

## Correctness

- All 164 existing `globwalk` tests pass, plus 2 new differential tests
  (`escape_glob_literals_matches_regex_reference`,
  `fix_glob_pattern_fast_path_matches_regex_reference`) that assert byte-for-byte
  equivalence against the original regex implementations over a corpus covering
  both fast and slow paths and every escapable metacharacter.
- The benchmark itself asserts equivalence over its corpus before measuring.
- `cargo clippy -p globwalk --all-targets` is clean, `cargo fmt --check` passes,
  and dependent crates (`turborepo-scm`, `turborepo-repository`) build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)