### PR TITLE
chore: Fix typos in with-solid example and globwatch comment

### DIFF
--- a/crates/turborepo-globwatch/src/lib.rs
+++ b/crates/turborepo-globwatch/src/lib.rs
@@ -497,7 +497,7 @@ fn glob_to_paths(glob: &str) -> Vec<PathBuf> {
         .into_iter()
         .filter_map(|(not_sep, chunk)| (not_sep).then_some(chunk));
 
-    // multi cartisian product allows us to get all the possible combinations
+    // multi cartesian product allows us to get all the possible combinations
     // of path components for each chunk. for example, if we have a glob
     // `{a,b}/1/{c,d}`, it will lazily yield the following sets of segments:
     //   ["a", "1", "c"]

--- a/examples/with-solid/packages/ui/src/components/button/button.tsx
+++ b/examples/with-solid/packages/ui/src/components/button/button.tsx
@@ -1,11 +1,11 @@
 import { cn } from "../../utils/index";
-import { ButtonElement, PrimitveButtonProps } from "@Configs/primitives";
+import { ButtonElement, PrimitiveButtonProps } from "@Configs/primitives";
 import { Component, JSX, splitProps } from "solid-js";
 import { Dynamic } from "solid-js/web";
 
 // Button props
 interface ButtonWrapperProps
-  extends PrimitveButtonProps,
+  extends PrimitiveButtonProps,
     JSX.ButtonHTMLAttributes<HTMLButtonElement> {
   asChild?: keyof JSX.IntrinsicElements | Component<any>;
   children?: JSX.Element;

--- a/examples/with-solid/packages/ui/src/config/primitives/primitive.ts
+++ b/examples/with-solid/packages/ui/src/config/primitives/primitive.ts
@@ -7,7 +7,7 @@ import { JSX } from "solid-js";
 
 // Button
 type ButtonElement = HTMLButtonElement;
-type PrimitveButtonProps = JSX.IntrinsicElements["button"];
+type PrimitiveButtonProps = JSX.IntrinsicElements["button"];
 
 // Div
 type DivElement = HTMLDivElement;
@@ -24,7 +24,7 @@ type PrimitiveSpanProps = JSX.IntrinsicElements['span'];
 // exports
 export type {
     ButtonElement,
-    PrimitveButtonProps,
+    PrimitiveButtonProps,
     DivElement,
     PrimitiveDivProps,
     SpanElement,


### PR DESCRIPTION
### Description

Fixes two typos found by running a `typos` spell-check sweep across the repository:

- `examples/with-solid`: rename the `PrimitveButtonProps` type to `PrimitiveButtonProps` in `packages/ui/src/config/primitives/primitive.ts` and its usages in `packages/ui/src/components/button/button.tsx`, matching its correctly spelled `PrimitiveDivProps` / `PrimitiveSpanProps` siblings.
- `crates/turborepo-globwatch`: fix "cartisian" → "cartesian" in the `glob_to_paths` code comment.

No behavior changes.

### Testing

- `cargo test -p globwatch`: 17 passed, 0 failed (covers `glob_to_paths`, where the edited comment lives)
- `tsc --noEmit -p tsconfig.app.json` in `examples/with-solid/packages/ui`: clean after the rename
- `typos` reports the changed files clean; remaining repo-wide hits are false positives (crate names, usernames, hash fragments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)