### PR TITLE
fix: Refactor `turbo watch`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8236,6 +8236,7 @@ dependencies = [
  "bitflags 1.3.2",
  "fsevent-sys",
  "futures",
+ "ignore",
  "libc",
  "notify",
  "radix_trie",

--- a/crates/turborepo-daemon/src/lib.rs
+++ b/crates/turborepo-daemon/src/lib.rs
@@ -56,9 +56,7 @@ pub trait PackageChangesWatcher: Send + Sync {
 /// Arguments passed to a PackageChangesWatcher factory
 pub struct PackageChangesWatcherArgs {
     pub repo_root: AbsoluteSystemPathBuf,
-    pub file_events: turborepo_filewatch::OptionalWatch<
-        broadcast::Receiver<Result<notify::Event, turborepo_filewatch::NotifyError>>,
-    >,
+    pub file_events: turborepo_filewatch::WatchSource,
     pub hash_watcher: std::sync::Arc<turborepo_filewatch::hash_watcher::HashWatcher>,
     pub custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
     pub allow_no_package_manager: bool,

--- a/crates/turborepo-daemon/src/server.rs
+++ b/crates/turborepo-daemon/src/server.rs
@@ -31,7 +31,7 @@ use turborepo_filewatch::{
     globwatcher::{Error as GlobWatcherError, GlobError, GlobSet, GlobWatcher},
     hash_watcher::{Error as HashWatcherError, HashSpec, HashWatcher, InputGlobs},
     package_watcher::{PackageWatchError, PackageWatcher},
-    FileSystemWatcher, WatchError,
+    FileSystemWatcher, WatchError, WatchScope,
 };
 use turborepo_repository::package_manager;
 use turborepo_scm::SCM;
@@ -148,22 +148,22 @@ impl<W: PackageChangesWatcher + 'static> FileWatching<W> {
         F: Fn(PackageChangesWatcherArgs) -> W + Send + Sync + 'static,
     {
         let watcher = Arc::new(FileSystemWatcher::new_with_default_cookie_dir(&repo_root)?);
-        let recv = watcher.watch();
+        let source = watcher.source();
 
         let cookie_writer = CookieWriter::new(
             watcher.cookie_dir(),
             Duration::from_millis(100),
-            recv.clone(),
+            source.clone(),
         );
         let glob_watcher = Arc::new(GlobWatcher::new(
             repo_root.clone(),
             cookie_writer.clone(),
-            recv.clone(),
+            source.clone(),
         ));
         let package_watcher = Arc::new(
             PackageWatcher::new(
                 repo_root.clone(),
-                recv.clone(),
+                source.clone(),
                 cookie_writer,
                 allow_no_package_manager,
             )
@@ -173,7 +173,7 @@ impl<W: PackageChangesWatcher + 'static> FileWatching<W> {
         let hash_watcher = Arc::new(HashWatcher::new(
             repo_root.clone(),
             package_watcher.watch_discovery(),
-            recv.clone(),
+            source,
             scm,
         ));
 
@@ -193,10 +193,9 @@ impl<W: PackageChangesWatcher + 'static> FileWatching<W> {
     pub fn get_or_init_package_changes_watcher(&self) -> Arc<W> {
         self.package_changes_watcher
             .get_or_init(|| {
-                let recv = self.watcher.watch();
                 let args = PackageChangesWatcherArgs {
                     repo_root: self.repo_root.clone(),
-                    file_events: recv,
+                    file_events: self.watcher.source(),
                     hash_watcher: self.hash_watcher.clone(),
                     custom_turbo_json_path: self.custom_turbo_json_path.clone(),
                     allow_no_package_manager: self.allow_no_package_manager,
@@ -500,9 +499,13 @@ async fn watch_root<W: PackageChangesWatcher + 'static>(
     trigger_shutdown: mpsc::Sender<()>,
     mut exit_signal: oneshot::Receiver<()>,
 ) -> Result<(), WatchError> {
+    let watched_root = root.clone();
     let mut recv_events = filewatching_access
         .watcher
-        .subscribe()
+        .source()
+        .subscribe(WatchScope::predicate(move |path| {
+            path == watched_root.as_std_path()
+        }))
         .await
         // we can only encounter an error here if the file watcher is closed (a recv error)
         .map_err(|_| WatchError::Setup("file watching shut down".to_string()))?;
@@ -524,7 +527,7 @@ async fn watch_root<W: PackageChangesWatcher + 'static>(
                     // before triggering a shutdown
                     Ok(event) if event.paths.iter().any(|p| p == (&root as &AbsoluteSystemPath)) => !root.exists(),
                     Ok(_) => false,
-                    Err(_) => true
+                    Err(error) => !error.is_invalidation()
                 };
                 if should_trigger_shutdown {
                     warn!("Root watcher triggering shutdown");

--- a/crates/turborepo-devtools/src/watcher.rs
+++ b/crates/turborepo-devtools/src/watcher.rs
@@ -5,12 +5,11 @@
 
 use std::{path::Path, time::Duration};
 
-use notify::Event;
 use thiserror::Error;
 use tokio::sync::{broadcast, oneshot};
 use tracing::{debug, trace, warn};
 use turbopath::AbsoluteSystemPathBuf;
-use turborepo_filewatch::{FileSystemWatcher, NotifyError, OptionalWatch};
+use turborepo_filewatch::{FileSystemWatcher, WatchScope, WatchSource};
 
 /// Errors that can occur during file watching
 #[derive(Debug, Error)]
@@ -65,7 +64,7 @@ impl DevtoolsWatcher {
         // Spawn watcher task
         tokio::spawn(watch_loop(
             repo_root,
-            file_watcher.watch(),
+            file_watcher.source(),
             event_tx,
             exit_rx,
         ));
@@ -104,13 +103,12 @@ fn is_relevant_file(path: &Path) -> bool {
 /// Main watch loop that processes file events
 async fn watch_loop(
     _repo_root: AbsoluteSystemPathBuf,
-    mut file_events_lazy: OptionalWatch<broadcast::Receiver<Result<Event, NotifyError>>>,
+    file_events: WatchSource,
     event_tx: broadcast::Sender<WatchEvent>,
     exit_rx: oneshot::Receiver<()>,
 ) {
-    // Get the receiver and immediately resubscribe to drop the SomeRef
-    // (which is not Send) before entering the select loop
-    let Ok(mut file_events) = file_events_lazy.get().await.map(|r| r.resubscribe()) else {
+    let scope = WatchScope::predicate(|path| !is_in_ignored_dir(path) && is_relevant_file(path));
+    let Ok(mut file_events) = file_events.subscribe(scope).await else {
         warn!("File watching not available");
         return;
     };
@@ -143,28 +141,16 @@ async fn watch_loop(
             result = file_events.recv() => {
                 match result {
                     Ok(Ok(event)) => {
-                        // Check if any of the changed files are relevant
-                        let has_relevant_change = event.paths.iter().any(|path| {
-                            // Skip ignored directories
-                            if is_in_ignored_dir(path) {
-                                return false;
-                            }
-
-                            // Check if it's a relevant file
-                            if is_relevant_file(path) {
-                                trace!("Relevant file changed: {:?}", path);
-                                return true;
-                            }
-
-                            false
-                        });
+                        let has_relevant_change = !event.paths.is_empty();
 
                         if has_relevant_change {
+                            trace!(paths = ?event.paths, "Relevant files changed");
                             pending_rebuild = true;
                         }
                     }
                     Ok(Err(e)) => {
                         warn!("File watch error: {:?}", e);
+                        pending_rebuild = true;
                     }
                     Err(broadcast::error::RecvError::Lagged(n)) => {
                         warn!("File watcher lagged by {} events, triggering rebuild", n);

--- a/crates/turborepo-filewatch/Cargo.toml
+++ b/crates/turborepo-filewatch/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 
 [dependencies]
 futures = { workspace = true }
+ignore = "0.4.22"
 notify = { workspace = true }
 radix_trie = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/turborepo-filewatch/src/cookies.rs
+++ b/crates/turborepo-filewatch/src/cookies.rs
@@ -41,13 +41,13 @@ use futures::FutureExt;
 use notify::EventKind;
 use thiserror::Error;
 use tokio::{
-    sync::{broadcast, mpsc, oneshot, watch},
+    sync::{mpsc, oneshot, watch},
     time::error::Elapsed,
 };
 use tracing::trace;
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, PathRelation};
 
-use crate::{NotifyError, OptionalWatch, optional_watch::SomeRef};
+use crate::{OptionalWatch, WatchSource, optional_watch::SomeRef};
 
 #[derive(Debug, Error)]
 pub enum CookieError {
@@ -132,6 +132,10 @@ impl<T> CookieWatcher<T> {
         }
     }
 
+    pub(crate) fn root(&self) -> &AbsoluteSystemPath {
+        &self.cookie_root
+    }
+
     /// Check if this request can be handled immediately. If so, return it. If
     /// not, queue it
     pub(crate) fn check_request(&mut self, cookied_request: CookiedRequest<T>) -> Option<T> {
@@ -189,23 +193,24 @@ impl CookieWriter {
     pub fn new_with_default_cookie_dir(
         repo_root: &AbsoluteSystemPath,
         timeout: Duration,
-        recv: OptionalWatch<broadcast::Receiver<Result<notify::Event, NotifyError>>>,
+        source: impl Into<WatchSource>,
     ) -> Self {
         let cookie_root = repo_root.join_components(&[".turbo", "cookies"]);
-        Self::new(&cookie_root, timeout, recv)
+        Self::new(&cookie_root, timeout, source)
     }
 
     pub fn new(
         cookie_root: &AbsoluteSystemPath,
         timeout: Duration,
-        mut recv: OptionalWatch<broadcast::Receiver<Result<notify::Event, NotifyError>>>,
+        source: impl Into<WatchSource>,
     ) -> Self {
+        let source = source.into();
         let (cookie_request_sender_tx, cookie_request_sender_lazy) = OptionalWatch::new();
         let (exit_ch, exit_signal) = mpsc::channel(16);
         tokio::spawn({
             let root = cookie_root.to_owned();
             async move {
-                if recv.get().await.is_err() {
+                if source.ready().await.is_err() {
                     // here we need to wait for confirmation that the watching end is ready
                     // before we start sending requests. this has the side effect of not
                     // enabling the cookie writing mechanism until the watcher is ready
@@ -524,7 +529,7 @@ mod test {
     use turbopath::AbsoluteSystemPathBuf;
 
     use super::{CookieWatcher, CookiedRequest};
-    use crate::{NotifyError, OptionalWatch, cookies::CookieWriter};
+    use crate::{NotifyError, WatchSource, cookies::CookieWriter};
 
     struct TestQuery {
         resp: oneshot::Sender<()>,
@@ -588,9 +593,9 @@ mod test {
             .unwrap();
 
         let (send_file_events, file_events) = broadcast::channel(16);
-        let recv = OptionalWatch::once(file_events.resubscribe());
+        let (_source_tx, source) = WatchSource::channel();
         let (reqs_tx, reqs_rx) = mpsc::channel(16);
-        let cookie_writer = CookieWriter::new(&path, Duration::from_secs(2), recv);
+        let cookie_writer = CookieWriter::new(&path, Duration::from_secs(2), source);
         let (exit_tx, exit_rx) = oneshot::channel();
 
         let service = TestService {
@@ -652,9 +657,9 @@ mod test {
             .unwrap();
 
         let (send_file_events, file_events) = broadcast::channel(16);
-        let recv = OptionalWatch::once(file_events.resubscribe());
+        let (_source_tx, source) = WatchSource::channel();
         let (reqs_tx, reqs_rx) = mpsc::channel(16);
-        let cookie_writer = CookieWriter::new(&path, Duration::from_secs(2), recv);
+        let cookie_writer = CookieWriter::new(&path, Duration::from_secs(2), source);
         let (exit_tx, exit_rx) = oneshot::channel();
 
         let service = TestService {

--- a/crates/turborepo-filewatch/src/fsevent.rs
+++ b/crates/turborepo-filewatch/src/fsevent.rs
@@ -20,13 +20,16 @@
 
 use std::{
     collections::HashMap,
-    ffi::{CStr, CString},
+    ffi::{CStr, CString, OsStr},
     fmt,
     io::ErrorKind,
     os::{raw, unix::prelude::MetadataExt},
     path::{Path, PathBuf},
     ptr,
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
     thread,
 };
 
@@ -143,6 +146,15 @@ impl DeviceContext {
         self.mount_point
             .join(device_relative.trim_start_matches(std::path::MAIN_SEPARATOR))
     }
+
+    fn bytes_to_absolute(&self, device_relative: &[u8]) -> PathBuf {
+        use std::os::unix::ffi::OsStrExt;
+
+        let relative = device_relative
+            .strip_prefix(b"/")
+            .unwrap_or(device_relative);
+        self.mount_point.join(OsStr::from_bytes(relative))
+    }
 }
 
 /// FSEvents-based `Watcher` implementation.
@@ -194,6 +206,8 @@ pub struct FsEventWatcher {
     /// Device context for path transformation. Set when the first path is
     /// watched. All subsequent paths must be on the same device.
     device_context: Option<DeviceContext>,
+    /// Last event observed by the callback, used to resume after watch changes.
+    latest_event_id: Arc<AtomicU64>,
 }
 
 impl fmt::Debug for FsEventWatcher {
@@ -374,6 +388,7 @@ struct StreamContextInfo {
     /// Device context for converting device-relative paths back to absolute
     /// paths.
     device_context: DeviceContext,
+    latest_event_id: Arc<AtomicU64>,
 }
 
 // Free the context when the stream created by `FSEventStreamCreate` is
@@ -453,6 +468,7 @@ impl FsEventWatcher {
             runloop: None,
             recursive_info: HashMap::new(),
             device_context: None,
+            latest_event_id: Arc::new(AtomicU64::new(0)),
         })
     }
 
@@ -495,6 +511,10 @@ impl FsEventWatcher {
 
             // Wait for the thread to shut down.
             let _ = thread_handle.join();
+            let latest_event_id = self.latest_event_id.load(Ordering::Acquire);
+            if latest_event_id != 0 {
+                self.since_when = latest_event_id;
+            }
         }
     }
 
@@ -613,6 +633,7 @@ impl FsEventWatcher {
             event_handler: self.event_handler.clone(),
             recursive_info: self.recursive_info.clone(),
             device_context: device_context.clone(),
+            latest_event_id: self.latest_event_id.clone(),
         }));
 
         let stream_context = fs::FSEventStreamContext {
@@ -727,27 +748,23 @@ unsafe fn callback_impl(
     num_events: libc::size_t,                        // size_t numEvents
     event_paths: *mut libc::c_void,                  // void *eventPaths
     event_flags: *const fs::FSEventStreamEventFlags, // const FSEventStreamEventFlags eventFlags[]
-    _event_ids: *const fs::FSEventStreamEventId,     // const FSEventStreamEventId eventIds[]
+    event_ids: *const fs::FSEventStreamEventId,      // const FSEventStreamEventId eventIds[]
 ) {
     let event_paths = event_paths as *const *const libc::c_char;
     let info = info as *const StreamContextInfo;
     let event_handler = unsafe { &(*info).event_handler };
     let device_context = unsafe { &(*info).device_context };
+    let latest_event_id = unsafe { &(*info).latest_event_id };
 
     for p in 0..num_events {
-        // SAFETY: We must not panic in this extern "C" callback.
-        // Handle invalid UTF-8 gracefully by skipping the event.
-        let raw_path = match unsafe { CStr::from_ptr(*event_paths.add(p)) }.to_str() {
-            Ok(s) => s,
-            Err(_) => {
-                // Skip events with non-UTF8 paths rather than panic.
-                // This is rare but possible with malformed filesystem entries.
-                continue;
-            }
-        };
+        let event_id = unsafe { *event_ids.add(p) };
+        latest_event_id.fetch_max(event_id, Ordering::Release);
+        // SAFETY: The FSEvents path is a NUL-terminated byte string valid for
+        // this callback. Preserve its bytes because Unix paths need not be UTF-8.
+        let raw_path = unsafe { CStr::from_ptr(*event_paths.add(p)) };
 
         // Use DeviceContext to convert device-relative path back to absolute
-        let path = device_context.to_absolute(raw_path);
+        let path = device_context.bytes_to_absolute(raw_path.to_bytes());
 
         let flag = unsafe { *event_flags.add(p) };
         // Use from_bits_truncate to handle unknown flags gracefully instead of
@@ -872,6 +889,21 @@ fn test_device_context_round_trips_non_root_mount_paths() {
 
     assert_eq!(device_relative, "/project/file.txt");
     assert_eq!(device_context.to_absolute(&device_relative), absolute_path);
+}
+
+#[test]
+fn test_device_context_preserves_non_utf8_paths() {
+    use std::os::unix::ffi::OsStrExt;
+
+    let device_context = DeviceContext {
+        device_id: 1,
+        mount_point: PathBuf::from("/Volumes/Data"),
+    };
+    let path = device_context.bytes_to_absolute(b"/repo/invalid-\xff");
+    assert_eq!(
+        path.as_os_str().as_bytes(),
+        b"/Volumes/Data/repo/invalid-\xff"
+    );
 }
 
 /// A temporary RAM disk volume for testing FSEvents on non-root filesystems.

--- a/crates/turborepo-filewatch/src/globwatcher.rs
+++ b/crates/turborepo-filewatch/src/globwatcher.rs
@@ -1,7 +1,12 @@
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
     future::IntoFuture,
+    path::PathBuf,
     str::FromStr,
+    sync::{
+        Arc, RwLock,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
     time::Duration,
 };
 
@@ -9,15 +14,188 @@ use notify::Event;
 use thiserror::Error;
 use tokio::sync::{broadcast, mpsc, oneshot};
 use tracing::{debug, warn};
-use turbopath::{AbsoluteSystemPathBuf, RelativeUnixPath};
+use turbopath::{AbsoluteSystemPathBuf, PathRelation, RelativeUnixPath};
 use wax::{Any, Glob, Program};
 
 use crate::{
-    NotifyError, OptionalWatch,
+    NotifyError, OptionalWatch, WatchInterest, WatchScope, WatchSource, WatchSubscription,
     cookies::{CookieError, CookieWatcher, CookieWriter, CookiedRequest},
 };
 
 type Hash = String;
+type RegistrationId = u64;
+type SharedGlobState = Arc<RwLock<GlobState>>;
+
+#[derive(Clone, Default)]
+struct RouteNode {
+    children: HashMap<String, RouteNode>,
+    glob_sets: HashSet<usize>,
+}
+
+/// An immutable snapshot of all active and pending glob sets. Literal prefixes
+/// route an event to a small set of possible matches; only those sets pay the
+/// cost of exact include/exclude matching.
+#[derive(Clone, Default)]
+struct GlobRoutingIndex {
+    root: RouteNode,
+    root_only: HashSet<usize>,
+    unprefixed: HashSet<usize>,
+    glob_sets: Vec<Option<GlobSet>>,
+    glob_set_ids: HashMap<GlobSet, usize>,
+    references: Vec<usize>,
+    free_ids: Vec<usize>,
+}
+
+impl GlobRoutingIndex {
+    #[cfg(test)]
+    fn from_glob_sets(glob_sets: impl IntoIterator<Item = GlobSet>) -> Self {
+        let mut index = Self::default();
+        for glob_set in glob_sets {
+            index.insert(glob_set);
+        }
+        index
+    }
+
+    /// Adds one logical registration without rebuilding existing routes. The
+    /// returned count is useful for asserting that registration work is bounded
+    /// by the new glob's size rather than the number of existing registrations.
+    fn insert(&mut self, glob_set: GlobSet) -> usize {
+        if let Some(&id) = self.glob_set_ids.get(&glob_set) {
+            self.references[id] += 1;
+            return 0;
+        }
+
+        let id = self.free_ids.pop().unwrap_or(self.glob_sets.len());
+        if id == self.glob_sets.len() {
+            self.glob_sets.push(None);
+            self.references.push(0);
+        }
+        self.glob_sets[id] = Some(glob_set.clone());
+        self.references[id] = 1;
+        self.glob_set_ids.insert(glob_set.clone(), id);
+
+        let mut work = 0;
+        for raw in glob_set.include.keys() {
+            work += 1;
+            let prefix = literal_prefix(raw);
+            if prefix.as_os_str().is_empty() {
+                // A component glob cannot cross a separator. In contrast, a
+                // leading glob with a separator (notably **/...) can match at
+                // arbitrary depth and must remain a repository-wide fallback.
+                let routes = if raw.contains('/') {
+                    &mut self.unprefixed
+                } else {
+                    &mut self.root_only
+                };
+                routes.insert(id);
+                continue;
+            }
+
+            let mut node = &mut self.root;
+            for component in prefix.iter() {
+                work += 1;
+                node = node
+                    .children
+                    .entry(component.to_string_lossy().into_owned())
+                    .or_default();
+            }
+            node.glob_sets.insert(id);
+        }
+        work
+    }
+
+    fn remove(&mut self, glob_set: &GlobSet) {
+        let Some(&id) = self.glob_set_ids.get(glob_set) else {
+            return;
+        };
+        self.references[id] -= 1;
+        if self.references[id] != 0 {
+            return;
+        }
+
+        for raw in glob_set.include.keys() {
+            let prefix = literal_prefix(raw);
+            if prefix.as_os_str().is_empty() {
+                if raw.contains('/') {
+                    self.unprefixed.remove(&id);
+                } else {
+                    self.root_only.remove(&id);
+                }
+            } else {
+                remove_route(&mut self.root, &mut prefix.iter(), id);
+            }
+        }
+        self.glob_set_ids.remove(glob_set);
+        self.glob_sets[id] = None;
+        self.free_ids.push(id);
+    }
+
+    fn matches(&self, path: &RelativeUnixPath) -> bool {
+        self.candidates(path).into_iter().any(|id| {
+            self.glob_sets[id]
+                .as_ref()
+                .is_some_and(|set| set.matches(path))
+        })
+    }
+
+    fn candidates(&self, path: &RelativeUnixPath) -> Vec<usize> {
+        let mut candidates = self.unprefixed.clone();
+
+        let components = path.as_str().split('/').collect::<Vec<_>>();
+        if components.len() == 1 {
+            for &id in &self.root_only {
+                candidates.insert(id);
+            }
+        }
+
+        let mut node = &self.root;
+        for component in components {
+            let Some(child) = node.children.get(component) else {
+                break;
+            };
+            node = child;
+            for &id in &node.glob_sets {
+                candidates.insert(id);
+            }
+        }
+
+        candidates.into_iter().collect()
+    }
+}
+
+fn remove_route<'a>(
+    node: &mut RouteNode,
+    components: &mut impl Iterator<Item = &'a std::ffi::OsStr>,
+    id: usize,
+) -> bool {
+    if let Some(component) = components.next() {
+        let component = component.to_string_lossy();
+        if let Some(child) = node.children.get_mut(component.as_ref())
+            && remove_route(child, components, id)
+        {
+            node.children.remove(component.as_ref());
+        }
+    } else {
+        node.glob_sets.remove(&id);
+    }
+    node.children.is_empty() && node.glob_sets.is_empty()
+}
+
+fn literal_prefix(raw: &str) -> PathBuf {
+    let mut prefix = PathBuf::new();
+    for component in raw.split('/') {
+        if component
+            .chars()
+            .any(|character| matches!(character, '*' | '?' | '[' | ']' | '{' | '}'))
+        {
+            break;
+        }
+        if !component.is_empty() && component != "." {
+            prefix.push(component.replace("\\:", ":"));
+        }
+    }
+    prefix
+}
 
 #[derive(Clone)]
 pub struct GlobSet {
@@ -142,6 +320,10 @@ impl GlobSet {
                 .iter()
                 .all(|raw_glob| !raw_glob.starts_with("../"))
     }
+
+    pub(crate) fn literal_prefixes(&self) -> impl Iterator<Item = PathBuf> + '_ {
+        self.include.keys().map(|raw| literal_prefix(raw))
+    }
 }
 
 #[derive(Debug, Error)]
@@ -171,6 +353,7 @@ impl From<oneshot::error::RecvError> for Error {
 }
 
 pub struct GlobWatcher {
+    root: AbsoluteSystemPathBuf,
     cookie_writer: CookieWriter,
     // _exit_ch exists to trigger a close on the receiver when an instance
     // of this struct is dropped. The task that is receiving events will exit,
@@ -178,13 +361,46 @@ pub struct GlobWatcher {
     // to be notified of a close.
     _exit_ch: oneshot::Sender<()>,
     query_ch_lazy: OptionalWatch<mpsc::Sender<CookiedRequest<Query>>>,
+    state: SharedGlobState,
+    physical_interest: WatchInterest,
+    next_registration_id: AtomicU64,
+    control_ch: mpsc::UnboundedSender<Control>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Registration {
+    id: RegistrationId,
+    hash: Hash,
+    glob_set: GlobSet,
+    cancelled: Arc<AtomicBool>,
+}
+
+#[derive(Clone)]
+struct ActiveRegistration {
+    id: RegistrationId,
+    glob_set: GlobSet,
+}
+
+#[derive(Default)]
+struct GlobState {
+    pending: HashMap<RegistrationId, Registration>,
+    active: HashMap<Hash, ActiveRegistration>,
+    active_ids: HashMap<RegistrationId, Hash>,
+    routing_index: GlobRoutingIndex,
+    physical_prefixes: HashMap<PathBuf, usize>,
+}
+
+enum Control {
+    Cancel {
+        id: RegistrationId,
+        done: oneshot::Sender<()>,
+    },
 }
 
 #[derive(Debug)]
 pub enum Query {
     WatchGlobs {
-        hash: Hash,
-        glob_set: GlobSet,
+        registration: Registration,
         resp: oneshot::Sender<Result<(), Error>>,
     },
     GetChangedGlobs {
@@ -198,7 +414,7 @@ struct GlobTracker {
     root: AbsoluteSystemPathBuf,
 
     /// maintains the list of <GlobSet> to watch for a given hash
-    hash_globs: HashMap<Hash, GlobSet>,
+    state: SharedGlobState,
 
     /// maps a string glob to the compiled glob and the hashes for which this
     /// glob hasn't changed
@@ -206,24 +422,38 @@ struct GlobTracker {
 
     exit_signal: oneshot::Receiver<()>,
 
-    recv: broadcast::Receiver<Result<Event, NotifyError>>,
+    recv: WatchSubscription,
 
     query_recv: mpsc::Receiver<CookiedRequest<Query>>,
 
+    control_recv: mpsc::UnboundedReceiver<Control>,
+
     cookie_watcher: CookieWatcher<Query>,
+
+    physical_interest: WatchInterest,
 }
 
 impl GlobWatcher {
     pub fn new(
         root: AbsoluteSystemPathBuf,
         cookie_writer: CookieWriter,
-        mut recv: OptionalWatch<broadcast::Receiver<Result<Event, NotifyError>>>,
+        source: impl Into<WatchSource>,
     ) -> Self {
+        let source = source.into();
         let (exit_ch, exit_signal) = tokio::sync::oneshot::channel();
         let (query_ch_tx, query_ch_lazy) = OptionalWatch::new();
+        let (control_ch, control_recv) = mpsc::unbounded_channel();
         let cookie_root = cookie_writer.root().to_owned();
+        let state = Arc::new(RwLock::new(GlobState::default()));
+        let physical_interest = WatchInterest::new();
+        physical_interest.extend([cookie_root.as_std_path().to_owned()]);
+        let scope = dynamic_watch_scope(root.clone(), cookie_root.clone(), state.clone())
+            .with_physical_interest(physical_interest.clone());
+        let tracker_state = state.clone();
+        let tracker_physical_interest = physical_interest.clone();
+        let watcher_root = root.clone();
         tokio::task::spawn(async move {
-            let Ok(recv) = recv.get().await.map(|r| r.resubscribe()) else {
+            let Ok(recv) = source.subscribe(scope).await else {
                 // if this fails, it means that the filewatcher is not available
                 // so starting the glob tracker is pointless
                 return;
@@ -237,14 +467,26 @@ impl GlobWatcher {
                 return;
             }
 
-            GlobTracker::new(root, cookie_root, exit_signal, recv, query_recv)
-                .watch()
-                .await
+            GlobTracker::new(
+                root,
+                cookie_root,
+                exit_signal,
+                recv,
+                (query_recv, control_recv),
+                (tracker_state, tracker_physical_interest),
+            )
+            .watch()
+            .await
         });
         Self {
+            root: watcher_root,
             cookie_writer,
             _exit_ch: exit_ch,
             query_ch_lazy,
+            state,
+            physical_interest,
+            next_registration_id: AtomicU64::new(0),
+            control_ch,
         }
     }
 
@@ -259,13 +501,40 @@ impl GlobWatcher {
         timeout: Duration,
     ) -> Result<(), Error> {
         let (tx, rx) = oneshot::channel();
-        let req = Query::WatchGlobs {
+        let registration = Registration {
+            id: self.next_registration_id.fetch_add(1, Ordering::Relaxed),
             hash,
             glob_set: globs,
+            cancelled: Arc::new(AtomicBool::new(false)),
+        };
+        let added_paths = self.add_pending(registration.clone());
+        self.physical_interest.extend(added_paths);
+        self.physical_interest.flush().await;
+        let req = Query::WatchGlobs {
+            registration: registration.clone(),
             resp: tx,
         };
-        self.send_request(req).await?;
-        tokio::time::timeout(timeout, rx).await??
+        if let Err(error) = self.send_request(req).await {
+            registration.cancelled.store(true, Ordering::Release);
+            self.remove_registration_direct(registration.id);
+            return Err(error);
+        }
+
+        match tokio::time::timeout(timeout, rx).await {
+            Ok(Ok(result)) => result,
+            Ok(Err(error)) => {
+                self.cancel_registration(&registration).await;
+                Err(error.into())
+            }
+            Err(error) => {
+                // Mark first, then rendezvous with the single tracker task. If
+                // commit is in progress, the cancellation is processed after it
+                // and removes precisely this generation before Timeout escapes.
+                registration.cancelled.store(true, Ordering::Release);
+                self.cancel_registration(&registration).await;
+                Err(error.into())
+            }
+        }
     }
 
     /// Get the globs that have changed for a given hash.
@@ -301,6 +570,189 @@ impl GlobWatcher {
         query_ch.send(cookied_request).await?;
         Ok(())
     }
+
+    fn add_pending(&self, registration: Registration) -> Vec<PathBuf> {
+        let mut state = self
+            .state
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.routing_index.insert(registration.glob_set.clone());
+        let added_paths = add_physical_prefixes(&mut state, &self.root, &registration.glob_set);
+        state.pending.insert(registration.id, registration);
+        added_paths
+    }
+
+    async fn cancel_registration(&self, registration: &Registration) {
+        registration.cancelled.store(true, Ordering::Release);
+        let (done, completed) = oneshot::channel();
+        if self
+            .control_ch
+            .send(Control::Cancel {
+                id: registration.id,
+                done,
+            })
+            .is_ok()
+        {
+            let _ = completed.await;
+        } else {
+            // The tracker is gone, so no commit can race this direct cleanup.
+            self.remove_registration_direct(registration.id);
+        }
+    }
+
+    fn remove_registration_direct(&self, id: RegistrationId) {
+        let removed_paths = {
+            let mut state = self
+                .state
+                .write()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            remove_registration_state(&mut state, id).is_some_and(|removed| removed.removed_path)
+        };
+        if removed_paths {
+            replace_physical_interest(
+                &self.state,
+                &self.physical_interest,
+                &self.root,
+                self.cookie_writer.root(),
+            );
+        }
+    }
+}
+
+fn add_physical_prefixes(
+    state: &mut GlobState,
+    root: &AbsoluteSystemPathBuf,
+    glob_set: &GlobSet,
+) -> Vec<PathBuf> {
+    let mut added = Vec::new();
+    for prefix in glob_set.literal_prefixes() {
+        let count = state.physical_prefixes.entry(prefix.clone()).or_default();
+        if *count == 0 {
+            added.push(root.as_std_path().join(&prefix));
+        }
+        *count += 1;
+    }
+    added
+}
+
+fn remove_physical_prefixes(state: &mut GlobState, glob_set: &GlobSet) -> bool {
+    let mut removed = false;
+    for prefix in glob_set.literal_prefixes() {
+        let Some(count) = state.physical_prefixes.get_mut(&prefix) else {
+            continue;
+        };
+        *count -= 1;
+        if *count == 0 {
+            state.physical_prefixes.remove(&prefix);
+            removed = true;
+        }
+    }
+    removed
+}
+
+fn replace_physical_interest(
+    state: &SharedGlobState,
+    physical_interest: &WatchInterest,
+    root: &AbsoluteSystemPathBuf,
+    cookie_root: &turbopath::AbsoluteSystemPath,
+) {
+    let paths = state
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .physical_prefixes
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>();
+    physical_interest.replace(
+        paths
+            .into_iter()
+            .map(|prefix| root.as_std_path().join(prefix))
+            .chain(std::iter::once(cookie_root.as_std_path().to_owned())),
+    );
+}
+
+struct RemovedRegistration {
+    hash: Option<Hash>,
+    glob_set: GlobSet,
+    removed_path: bool,
+}
+
+fn commit_registration_state(
+    state: &mut GlobState,
+    registration: &Registration,
+) -> Option<(Option<ActiveRegistration>, bool)> {
+    state.pending.remove(&registration.id)?;
+    let previous = state.active.remove(&registration.hash);
+    let removed_path = if let Some(previous) = &previous {
+        state.active_ids.remove(&previous.id);
+        state.routing_index.remove(&previous.glob_set);
+        remove_physical_prefixes(state, &previous.glob_set)
+    } else {
+        false
+    };
+    state.active.insert(
+        registration.hash.clone(),
+        ActiveRegistration {
+            id: registration.id,
+            glob_set: registration.glob_set.clone(),
+        },
+    );
+    state
+        .active_ids
+        .insert(registration.id, registration.hash.clone());
+    Some((previous, removed_path))
+}
+
+fn remove_registration_state(
+    state: &mut GlobState,
+    id: RegistrationId,
+) -> Option<RemovedRegistration> {
+    let registration = state
+        .pending
+        .remove(&id)
+        .map(|pending| (None, pending.glob_set))
+        .or_else(|| {
+            let hash = state.active_ids.remove(&id)?;
+            state
+                .active
+                .remove(&hash)
+                .map(|active| (Some(hash), active.glob_set))
+        });
+    let (hash, glob_set) = registration?;
+    state.routing_index.remove(&glob_set);
+    let removed_path = remove_physical_prefixes(state, &glob_set);
+    Some(RemovedRegistration {
+        hash,
+        glob_set,
+        removed_path,
+    })
+}
+
+fn dynamic_watch_scope(
+    root: AbsoluteSystemPathBuf,
+    cookie_root: AbsoluteSystemPathBuf,
+    state: SharedGlobState,
+) -> WatchScope {
+    WatchScope::predicate(move |path| {
+        let Ok(path) = AbsoluteSystemPathBuf::try_from(path.to_owned()) else {
+            return false;
+        };
+
+        // Queries are ordered by cookie events, so cookies must remain in scope even
+        // when no output globs have been registered yet.
+        if cookie_root.relation_to_path(&path) == PathRelation::Parent {
+            return true;
+        }
+
+        let Ok(relative_path) = root.anchor(&path) else {
+            return false;
+        };
+        let relative_path = relative_path.to_unix();
+        let state = state
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.routing_index.matches(&relative_path)
+    })
 }
 
 #[derive(Debug, Error)]
@@ -316,17 +768,25 @@ impl GlobTracker {
         root: AbsoluteSystemPathBuf,
         cookie_root: AbsoluteSystemPathBuf,
         exit_signal: oneshot::Receiver<()>,
-        recv: broadcast::Receiver<Result<Event, NotifyError>>,
-        query_recv: mpsc::Receiver<CookiedRequest<Query>>,
+        recv: WatchSubscription,
+        receivers: (
+            mpsc::Receiver<CookiedRequest<Query>>,
+            mpsc::UnboundedReceiver<Control>,
+        ),
+        shared: (SharedGlobState, WatchInterest),
     ) -> Self {
+        let (query_recv, control_recv) = receivers;
+        let (state, physical_interest) = shared;
         Self {
             root,
-            hash_globs: HashMap::new(),
+            state,
             glob_statuses: HashMap::new(),
             exit_signal,
             recv,
             query_recv,
+            control_recv,
             cookie_watcher: CookieWatcher::new(cookie_root),
+            physical_interest,
         }
     }
 
@@ -338,17 +798,37 @@ impl GlobTracker {
 
     fn handle_query(&mut self, query: Query) {
         match query {
-            Query::WatchGlobs {
-                hash,
-                glob_set,
-                resp,
-            } => {
+            Query::WatchGlobs { registration, resp } => {
+                if resp.is_closed() || registration.cancelled.load(Ordering::Acquire) {
+                    self.remove_registration(registration.id);
+                    return;
+                }
+                let hash = registration.hash.clone();
+                let glob_set = registration.glob_set.clone();
                 debug!("watching globs {:?} for hash {}", glob_set, hash);
                 // Assume cookie handling has happened external to this component.
                 // Other tasks _could_ write to the
                 // same output directories, however we are relying on task
                 // execution dependencies to prevent that.
-                for (glob_str, glob) in glob_set.include.iter() {
+                let Some((previous, removed_path)) = ({
+                    let mut state = self
+                        .state
+                        .write()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner());
+                    commit_registration_state(&mut state, &registration)
+                }) else {
+                    return;
+                };
+                if let Some(previous) = previous {
+                    for glob_str in previous.glob_set.include.keys() {
+                        if let Some((_, hashes)) = self.glob_statuses.get_mut(glob_str) {
+                            hashes.remove(&hash);
+                        }
+                    }
+                    self.glob_statuses
+                        .retain(|_, (_, hashes)| !hashes.is_empty());
+                }
+                for (glob_str, glob) in &glob_set.include {
                     let glob_str = glob_str.to_owned();
                     let (_, hashes) = self
                         .glob_statuses
@@ -356,7 +836,14 @@ impl GlobTracker {
                         .or_insert_with(|| (glob.clone(), HashSet::new()));
                     hashes.insert(hash.clone());
                 }
-                self.hash_globs.insert(hash.clone(), glob_set);
+                if removed_path {
+                    replace_physical_interest(
+                        &self.state,
+                        &self.physical_interest,
+                        &self.root,
+                        self.cookie_watcher.root(),
+                    );
+                }
                 let _ = resp.send(Ok(()));
             }
             Query::GetChangedGlobs {
@@ -367,17 +854,60 @@ impl GlobTracker {
                 // Assume cookie handling has happened external to this component.
                 // Build a set of candidate globs that *may* have changed.
                 // An empty set translates to all globs have not changed.
-                if let Some(unchanged_globs) = self.hash_globs.get(&hash) {
+                let state = self
+                    .state
+                    .read()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                if let Some(active) = state.active.get(&hash) {
                     candidates.retain(|glob_str| {
                         // We are keeping the globs from candidates that
                         // we don't have a record of as unchanged.
                         // If we do have a record, drop it from candidates.
-                        !unchanged_globs.include.contains_key(glob_str)
+                        !active.glob_set.include.contains_key(glob_str)
                     });
                 }
                 // If the client has gone away, we don't care about the error
                 let _ = resp.send(Ok(candidates));
             }
+        }
+    }
+
+    fn handle_control(&mut self, control: Control) {
+        match control {
+            Control::Cancel { id, done } => {
+                self.remove_registration(id);
+                let _ = done.send(());
+            }
+        }
+    }
+
+    fn remove_registration(&mut self, id: RegistrationId) {
+        let removed = self
+            .state
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut state = removed;
+        let removed = remove_registration_state(&mut state, id);
+        drop(state);
+        let Some(removed) = removed else {
+            return;
+        };
+        if let Some(hash) = removed.hash {
+            for glob_str in removed.glob_set.include.keys() {
+                if let Some((_, hashes)) = self.glob_statuses.get_mut(glob_str) {
+                    hashes.remove(&hash);
+                }
+            }
+            self.glob_statuses
+                .retain(|_, (_, hashes)| !hashes.is_empty());
+        }
+        if removed.removed_path {
+            replace_physical_interest(
+                &self.state,
+                &self.physical_interest,
+                &self.root,
+                self.cookie_watcher.root(),
+            );
         }
     }
 
@@ -416,7 +946,9 @@ impl GlobTracker {
     async fn watch(mut self) {
         loop {
             tokio::select! {
+                biased;
                 _ = &mut self.exit_signal => return,
+                Some(control) = self.control_recv.recv() => self.handle_control(control),
                 Some(query) = self.query_recv.recv().into_future() => self.handle_cookied_query(query),
                 file_event = self.recv.recv().into_future() => self.handle_file_event(file_event)
             }
@@ -430,49 +962,128 @@ impl GlobTracker {
             "encountered filewatching error, flushing all globs: {}",
             err
         );
-        self.hash_globs.clear();
+        {
+            let mut state = self
+                .state
+                .write()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let active = std::mem::take(&mut state.active);
+            state.active_ids.clear();
+            for registration in active.into_values() {
+                state.routing_index.remove(&registration.glob_set);
+                remove_physical_prefixes(&mut state, &registration.glob_set);
+            }
+        }
         self.glob_statuses.clear();
+        replace_physical_interest(
+            &self.state,
+            &self.physical_interest,
+            &self.root,
+            self.cookie_watcher.root(),
+        );
     }
 
     fn handle_path_change(&mut self, path: &RelativeUnixPath) {
-        self.glob_statuses
-            .retain(|glob_str, (glob, hashes_for_glob)| {
-                // If this is not a match, we aren't modifying this glob, bail early and mark
-                // for retention.
-                if !glob.is_match(path) {
+        let (removed_path, added_paths) = {
+            let mut state = self
+                .state
+                .write()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let (_, removed_path, added_paths) =
+                invalidate_path_candidates(&mut state, &mut self.glob_statuses, path, &self.root);
+            (removed_path, added_paths)
+        };
+        if removed_path {
+            replace_physical_interest(
+                &self.state,
+                &self.physical_interest,
+                &self.root,
+                self.cookie_watcher.root(),
+            );
+        } else {
+            self.physical_interest.extend(added_paths);
+        }
+    }
+}
+
+fn invalidate_path_candidates(
+    state: &mut GlobState,
+    glob_statuses: &mut HashMap<String, (Glob<'static>, HashSet<Hash>)>,
+    path: &RelativeUnixPath,
+    root: &AbsoluteSystemPathBuf,
+) -> (usize, bool, Vec<PathBuf>) {
+    let candidate_globs = state
+        .routing_index
+        .candidates(path)
+        .into_iter()
+        .flat_map(|id| {
+            state.routing_index.glob_sets[id]
+                .iter()
+                .flat_map(|glob_set| glob_set.include.keys().cloned())
+        })
+        .collect::<HashSet<_>>();
+    let mut inspected = 0;
+    let mut changes = Vec::new();
+
+    for glob_str in &candidate_globs {
+        let remove_status = {
+            let Some((glob, hashes_for_glob)) = glob_statuses.get_mut(glob_str) else {
+                continue;
+            };
+            inspected += 1;
+            if !glob.is_match(path) {
+                continue;
+            }
+
+            hashes_for_glob.retain(|hash| {
+                let Some(active) = state.active.get_mut(hash) else {
+                    // This shouldn't ever happen, but if we aren't tracking this hash at
+                    // all, we don't need to keep it in the set of hashes that are relevant
+                    // for this glob.
+                    debug_assert!(
+                        false,
+                        "A glob is referencing a hash that we are not tracking. This is most \
+                         likely an internal bookkeeping error in globwatcher.rs"
+                    );
+                    return false;
+                };
+                // If we match an exclusion, don't invalidate this hash.
+                if active.glob_set.exclude.is_match(path) {
                     return true;
                 }
-                // We have a match. Check which hashes need invalidation.
-                hashes_for_glob.retain(|hash| {
-                    let Some(glob_set) = self.hash_globs.get_mut(hash) else {
-                        // This shouldn't ever happen, but if we aren't tracking this hash at
-                        // all, we don't need to keep it in the set of hashes that are relevant
-                        // for this glob.
-                        debug_assert!(
-                            false,
-                            "A glob is referencing a hash that we are not tracking. This is most \
-                             likely an internal bookkeeping error in globwatcher.rs"
-                        );
-                        return false;
-                    };
-                    // If we match an exclusion, don't invalidate this hash
-                    if glob_set.exclude.is_match(path) {
-                        return true;
-                    }
-                    // We didn't match an exclusion, we can remove this glob
-                    debug!("file change at {} invalidated glob {}", path, glob_str);
-                    glob_set.include.remove(glob_str);
 
-                    // We removed the last include, we can stop tracking this hash
-                    if glob_set.include.is_empty() {
-                        self.hash_globs.remove(hash);
-                    }
+                debug!("file change at {} invalidated glob {}", path, glob_str);
+                let previous = active.glob_set.clone();
+                active.glob_set.include.remove(glob_str);
+                let next = (!active.glob_set.include.is_empty()).then(|| active.glob_set.clone());
+                changes.push((hash.clone(), previous, next));
 
-                    false
-                });
-                !hashes_for_glob.is_empty()
+                false
             });
+            hashes_for_glob.is_empty()
+        };
+
+        if remove_status {
+            glob_statuses.remove(glob_str);
+        }
     }
+
+    let mut removed_path = false;
+    let mut added_paths = Vec::new();
+    for (hash, previous, next) in changes {
+        state.routing_index.remove(&previous);
+        removed_path |= remove_physical_prefixes(state, &previous);
+        if let Some(next) = next {
+            state.routing_index.insert(next.clone());
+            added_paths.extend(add_physical_prefixes(state, root, &next));
+        } else {
+            if let Some(active) = state.active.remove(&hash) {
+                state.active_ids.remove(&active.id);
+            }
+        }
+    }
+
+    (inspected, removed_path, added_paths)
 }
 
 #[cfg(test)]
@@ -480,17 +1091,272 @@ mod test {
     use std::{
         collections::{HashMap, HashSet},
         str::FromStr,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
         time::Duration,
     };
 
-    use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
+    use notify::{Event, EventKind, event::CreateKind};
+    use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, RelativeUnixPath};
     use wax::{Glob, any};
 
     use crate::{
-        FileSystemWatcher,
+        FileSystemWatcher, WatchSource,
         cookies::CookieWriter,
-        globwatcher::{GlobSet, GlobWatcher},
+        globwatcher::{
+            ActiveRegistration, GlobRoutingIndex, GlobSet, GlobState, GlobWatcher, Registration,
+            add_physical_prefixes, commit_registration_state, invalidate_path_candidates,
+            remove_registration_state,
+        },
     };
+
+    fn relative(path: &str) -> &RelativeUnixPath {
+        RelativeUnixPath::new(path).unwrap()
+    }
+
+    #[test]
+    fn routing_index_rejects_unrelated_literal_prefixes_without_candidates() {
+        let index = GlobRoutingIndex::from_glob_sets([
+            GlobSet::from_raw(vec!["apps/web/dist/**".to_string()], vec![]).unwrap(),
+            GlobSet::from_raw(vec!["packages/api/generated/**".to_string()], vec![]).unwrap(),
+        ]);
+
+        assert_eq!(index.candidates(relative("docs/unrelated.md")).len(), 0);
+        assert!(!index.matches(relative("docs/unrelated.md")));
+        assert!(index.matches(relative("apps/web/dist/output.js")));
+    }
+
+    #[test]
+    fn routing_index_distinguishes_root_only_and_recursive_wildcards() {
+        let root_only =
+            GlobRoutingIndex::from_glob_sets([
+                GlobSet::from_raw(vec!["*.js".to_string()], vec![]).unwrap()
+            ]);
+        assert!(root_only.matches(relative("output.js")));
+        assert!(
+            root_only
+                .candidates(relative("nested/output.js"))
+                .is_empty()
+        );
+        assert!(!root_only.matches(relative("nested/output.js")));
+
+        let recursive = GlobRoutingIndex::from_glob_sets([GlobSet::from_raw(
+            vec!["**/*.js".to_string()],
+            vec!["vendor/**".to_string()],
+        )
+        .unwrap()]);
+        assert!(recursive.matches(relative("nested/output.js")));
+        assert!(!recursive.matches(relative("vendor/output.js")));
+    }
+
+    fn state_from_globs(hash_globs: HashMap<String, GlobSet>) -> GlobState {
+        let mut state = GlobState::default();
+        for (id, (hash, glob_set)) in hash_globs.into_iter().enumerate() {
+            let id = id as u64;
+            state.routing_index.insert(glob_set.clone());
+            state.active_ids.insert(id, hash.clone());
+            state
+                .active
+                .insert(hash, ActiveRegistration { id, glob_set });
+        }
+        state
+    }
+
+    #[test]
+    fn registration_index_updates_are_linear_at_scale() {
+        let mut index = GlobRoutingIndex::default();
+        let mut work = 0;
+        for registration in 0..5_000 {
+            work += index.insert(
+                GlobSet::from_raw(vec![format!("apps/app-{registration}/dist/**")], vec![])
+                    .unwrap(),
+            );
+        }
+
+        // One include plus three literal components per registration. This is
+        // independent of how many routes were already registered.
+        assert_eq!(work, 20_000);
+        assert_eq!(index.glob_set_ids.len(), 5_000);
+    }
+
+    #[test]
+    fn incremental_state_preserves_shared_routes_and_physical_interests() {
+        let (root, _tmp) = temp_dir();
+        let glob_set = GlobSet::from_raw(vec!["shared/dist/**".to_string()], vec![]).unwrap();
+        let mut state = GlobState::default();
+        for id in [1, 2] {
+            let registration = Registration {
+                id,
+                hash: format!("hash-{id}"),
+                glob_set: glob_set.clone(),
+                cancelled: Arc::new(AtomicBool::new(false)),
+            };
+            state.routing_index.insert(glob_set.clone());
+            add_physical_prefixes(&mut state, &root, &glob_set);
+            state.pending.insert(id, registration);
+        }
+
+        assert!(state.routing_index.matches(relative("shared/dist/file")));
+        assert_eq!(
+            state
+                .physical_prefixes
+                .values()
+                .copied()
+                .collect::<Vec<_>>(),
+            [2]
+        );
+
+        remove_registration_state(&mut state, 1).unwrap();
+        assert!(state.routing_index.matches(relative("shared/dist/file")));
+        assert_eq!(
+            state
+                .physical_prefixes
+                .values()
+                .copied()
+                .collect::<Vec<_>>(),
+            [1]
+        );
+
+        remove_registration_state(&mut state, 2).unwrap();
+        assert!(!state.routing_index.matches(relative("shared/dist/file")));
+        assert!(state.physical_prefixes.is_empty());
+    }
+
+    #[test]
+    fn timeout_at_commit_cancels_exact_registration_generation() {
+        let glob_set = GlobSet::from_raw(vec!["dist/**".to_string()], vec![]).unwrap();
+        let registration = Registration {
+            id: 41,
+            hash: "hash".to_string(),
+            glob_set: glob_set.clone(),
+            cancelled: Arc::new(AtomicBool::new(false)),
+        };
+        let mut state = GlobState::default();
+        state.routing_index.insert(glob_set);
+        state.pending.insert(registration.id, registration.clone());
+
+        // Deterministically model the boundary that used to race: state was
+        // committed, but the response had not yet been observed at the deadline.
+        assert!(commit_registration_state(&mut state, &registration).is_some());
+        registration.cancelled.store(true, Ordering::Release);
+        assert!(remove_registration_state(&mut state, registration.id).is_some());
+        assert!(!state.active.contains_key("hash"));
+
+        // A delayed cancellation for generation 41 must not remove a newer
+        // registration for the same hash.
+        state.active.insert(
+            "hash".to_string(),
+            ActiveRegistration {
+                id: 42,
+                glob_set: registration.glob_set,
+            },
+        );
+        state.active_ids.insert(42, "hash".to_string());
+        assert!(remove_registration_state(&mut state, 41).is_none());
+        assert_eq!(state.active["hash"].id, 42);
+    }
+
+    #[test]
+    fn path_invalidation_inspects_only_routing_candidates_at_scale() {
+        let mut hash_globs = HashMap::new();
+        let mut glob_statuses = HashMap::new();
+
+        for index in 0..1_000 {
+            let hash = format!("hash-{index}");
+            let raw_glob = format!("apps/app-{index}/dist/**");
+            let glob_set = GlobSet::from_raw(vec![raw_glob.clone()], vec![]).unwrap();
+            hash_globs.insert(hash.clone(), glob_set);
+            glob_statuses.insert(
+                raw_glob.clone(),
+                (
+                    Glob::from_str(&raw_glob).unwrap().to_owned(),
+                    HashSet::from([hash]),
+                ),
+            );
+        }
+
+        let (root, _tmp) = temp_dir();
+        let mut state = state_from_globs(hash_globs);
+        let (inspected, _, _) = invalidate_path_candidates(
+            &mut state,
+            &mut glob_statuses,
+            relative("docs/unrelated.md"),
+            &root,
+        );
+        assert_eq!(inspected, 0);
+        assert_eq!(state.active.len(), 1_000);
+        assert_eq!(glob_statuses.len(), 1_000);
+
+        let (inspected, _, _) = invalidate_path_candidates(
+            &mut state,
+            &mut glob_statuses,
+            relative("apps/app-517/dist/output.js"),
+            &root,
+        );
+        assert_eq!(inspected, 1);
+        assert!(!state.active.contains_key("hash-517"));
+        assert!(!glob_statuses.contains_key("apps/app-517/dist/**"));
+        assert_eq!(state.active.len(), 999);
+        assert_eq!(glob_statuses.len(), 999);
+    }
+
+    #[test]
+    fn candidate_invalidation_preserves_shared_glob_exclusions_and_cleanup() {
+        let raw_glob = "packages/shared/dist/**".to_string();
+        let excluded_hash = "excluded".to_string();
+        let invalidated_hash = "invalidated".to_string();
+        let excluded_set = GlobSet::from_raw(
+            vec![raw_glob.clone()],
+            vec!["packages/shared/dist/cache/**".to_string()],
+        )
+        .unwrap();
+        let invalidated_set = GlobSet::from_raw(vec![raw_glob.clone()], vec![]).unwrap();
+        let hash_globs = HashMap::from([
+            (excluded_hash.clone(), excluded_set.clone()),
+            (invalidated_hash.clone(), invalidated_set.clone()),
+        ]);
+        let mut glob_statuses = HashMap::from([(
+            raw_glob.clone(),
+            (
+                Glob::from_str(&raw_glob).unwrap().to_owned(),
+                HashSet::from([excluded_hash.clone(), invalidated_hash.clone()]),
+            ),
+        )]);
+        let (root, _tmp) = temp_dir();
+        let mut state = state_from_globs(hash_globs);
+
+        assert_eq!(
+            invalidate_path_candidates(
+                &mut state,
+                &mut glob_statuses,
+                relative("packages/shared/dist/cache/item"),
+                &root,
+            )
+            .0,
+            1
+        );
+        assert!(state.active.contains_key(&excluded_hash));
+        assert!(!state.active.contains_key(&invalidated_hash));
+        assert_eq!(
+            glob_statuses[&raw_glob].1,
+            HashSet::from([excluded_hash.clone()])
+        );
+
+        assert_eq!(
+            invalidate_path_candidates(
+                &mut state,
+                &mut glob_statuses,
+                relative("packages/shared/dist/output"),
+                &root,
+            )
+            .0,
+            1
+        );
+        assert!(state.active.is_empty());
+        assert!(glob_statuses.is_empty());
+    }
 
     fn temp_dir() -> (AbsoluteSystemPathBuf, tempfile::TempDir) {
         let tmp = tempfile::tempdir().unwrap();
@@ -542,6 +1408,60 @@ mod test {
         next_path.join_component("cache").create_dir_all().unwrap();
     }
 
+    #[tokio::test]
+    async fn timed_out_registration_removes_pending_interest() {
+        let (repo_root, _tmp_dir) = temp_dir();
+        let (event_sender, source) = WatchSource::channel();
+        let cookie_root = repo_root.join_components(&[".turbo", "cookies"]);
+        let cookie_writer = CookieWriter::new(&cookie_root, Duration::from_secs(1), source.clone());
+        let watcher = GlobWatcher::new(repo_root, cookie_writer, source);
+        let globs = GlobSet::from_raw(vec!["dist/**".to_string()], vec![]).unwrap();
+
+        assert!(
+            watcher
+                .watch_globs("hash".to_string(), globs, Duration::from_millis(20))
+                .await
+                .is_err()
+        );
+        assert!(
+            watcher
+                .state
+                .read()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .pending
+                .is_empty()
+        );
+        assert!(
+            watcher
+                .state
+                .read()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .routing_index
+                .glob_sets
+                .iter()
+                .all(Option::is_none)
+        );
+
+        event_sender
+            .send(Ok(Event::new(EventKind::Create(CreateKind::File))
+                .add_path(
+                    cookie_root
+                        .join_component("1.cookie")
+                        .as_std_path()
+                        .to_owned(),
+                )))
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(
+            !watcher
+                .state
+                .read()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .active
+                .contains_key("hash")
+        );
+    }
+
     fn make_includes(raw: &[&str]) -> HashMap<String, Glob<'static>> {
         raw.iter()
             .map(|raw_glob| {
@@ -563,7 +1483,7 @@ mod test {
         let cookie_dir = watcher.cookie_dir().to_owned();
         let recv = watcher.watch();
         let cookie_writer = CookieWriter::new(&cookie_dir, Duration::from_secs(2), recv.clone());
-        let glob_watcher = GlobWatcher::new(repo_root.clone(), cookie_writer, recv);
+        let glob_watcher = GlobWatcher::new(repo_root.clone(), cookie_writer, watcher.source());
 
         let raw_includes = &["my-pkg/dist/**", "my-pkg/.next/**"];
         let raw_excludes = ["my-pkg/.next/cache/**"];
@@ -647,7 +1567,7 @@ mod test {
         let recv = watcher.watch();
         let cookie_writer = CookieWriter::new(&cookie_dir, Duration::from_secs(2), recv.clone());
 
-        let glob_watcher = GlobWatcher::new(repo_root.clone(), cookie_writer, recv);
+        let glob_watcher = GlobWatcher::new(repo_root.clone(), cookie_writer, watcher.source());
 
         let raw_includes = &["my-pkg/dist/**", "my-pkg/.next/**"];
         let raw_excludes: [&str; 0] = [];
@@ -742,7 +1662,7 @@ mod test {
         let recv = watcher.watch();
         let cookie_writer = CookieWriter::new(&cookie_dir, Duration::from_secs(2), recv.clone());
 
-        let glob_watcher = GlobWatcher::new(repo_root.clone(), cookie_writer, recv);
+        let glob_watcher = GlobWatcher::new(repo_root.clone(), cookie_writer, watcher.source());
 
         // On windows, we expect different sanitization before the
         // globs are passed in, due to alternative data streams in files.
@@ -811,7 +1731,7 @@ mod test {
         let cookie_dir = watcher.cookie_dir().to_owned();
         let recv = watcher.watch();
         let cookie_writer = CookieWriter::new(&cookie_dir, timeout, recv.clone());
-        let glob_watcher = GlobWatcher::new(repo_root.clone(), cookie_writer, recv);
+        let glob_watcher = GlobWatcher::new(repo_root.clone(), cookie_writer, watcher.source());
 
         // Simulate notify_outputs_written: construct GlobSet from string slices
         // (the same conversion InProcessOutputWatcher will do)
@@ -851,7 +1771,7 @@ mod test {
         let cookie_dir = watcher.cookie_dir().to_owned();
         let recv = watcher.watch();
         let cookie_writer = CookieWriter::new(&cookie_dir, timeout, recv.clone());
-        let glob_watcher = GlobWatcher::new(repo_root.clone(), cookie_writer, recv);
+        let glob_watcher = GlobWatcher::new(repo_root.clone(), cookie_writer, watcher.source());
 
         let include_globs = vec!["my-pkg/dist/**".to_string()];
         let exclude_globs: Vec<String> = vec![];
@@ -893,7 +1813,7 @@ mod test {
         let cookie_dir = watcher.cookie_dir().to_owned();
         let recv = watcher.watch();
         let cookie_writer = CookieWriter::new(&cookie_dir, timeout, recv.clone());
-        let glob_watcher = GlobWatcher::new(repo_root.clone(), cookie_writer, recv);
+        let glob_watcher = GlobWatcher::new(repo_root.clone(), cookie_writer, watcher.source());
 
         let include_globs = vec!["my-pkg/.next/**".to_string()];
         let exclude_globs = vec!["my-pkg/.next/cache/**".to_string()];

--- a/crates/turborepo-filewatch/src/hash_watcher.rs
+++ b/crates/turborepo-filewatch/src/hash_watcher.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{HashMap, HashSet},
     sync::{
-        Arc,
+        Arc, RwLock,
         atomic::{AtomicUsize, Ordering},
     },
     time::Duration,
@@ -20,7 +20,7 @@ use turborepo_repository::discovery::DiscoveryResponse;
 use turborepo_scm::{Error as SCMError, GitHashes, SCM};
 
 use crate::{
-    NotifyError, OptionalWatch,
+    RepositoryIgnore, WatchInterest, WatchScope, WatchSource,
     debouncer::Debouncer,
     globwatcher::{GlobError, GlobSet},
     package_watcher::DiscoveryData,
@@ -127,9 +127,10 @@ impl HashWatcher {
     pub fn new(
         repo_root: AbsoluteSystemPathBuf,
         package_discovery: watch::Receiver<Option<DiscoveryData>>,
-        file_events: OptionalWatch<broadcast::Receiver<Result<Event, NotifyError>>>,
+        file_events: impl Into<WatchSource>,
         scm: SCM,
     ) -> Self {
+        let file_events = file_events.into();
         let (exit_tx, exit_rx) = oneshot::channel();
         let (query_tx, query_rx) = mpsc::channel(16);
         // Track the slowest-to-hash files so a stalled startup (e.g. a large
@@ -208,6 +209,164 @@ enum HashState {
 // conversion, if we decide we want to add the radix_trie dependency to
 // turbopath.
 struct FileHashes(Trie<String, HashMap<InputGlobs, HashState>>);
+
+struct PackageWatchScope {
+    inputs: HashSet<InputGlobs>,
+}
+
+struct WatchScopeState {
+    initialized: bool,
+    packages: Trie<String, PackageWatchScope>,
+}
+
+impl Default for WatchScopeState {
+    fn default() -> Self {
+        Self {
+            initialized: false,
+            packages: Trie::new(),
+        }
+    }
+}
+
+struct DynamicWatchScope {
+    repo_root: AbsoluteSystemPathBuf,
+    state: Arc<RwLock<WatchScopeState>>,
+    physical_interest: WatchInterest,
+}
+
+impl DynamicWatchScope {
+    fn new(
+        repo_root: AbsoluteSystemPathBuf,
+        repository_ignore: RepositoryIgnore,
+    ) -> (Self, WatchScope) {
+        let state = Arc::new(RwLock::new(WatchScopeState::default()));
+        let dynamic = Self {
+            repo_root: repo_root.clone(),
+            state: state.clone(),
+            physical_interest: WatchInterest::new(),
+        };
+        let physical_interest = dynamic.physical_interest.clone();
+        let scope = WatchScope::predicate(move |path| {
+            let Ok(absolute_path) = AbsoluteSystemPathBuf::try_from(path) else {
+                return true;
+            };
+            let Ok(path) = repo_root.anchor(&absolute_path) else {
+                return false;
+            };
+            let state = state
+                .read()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if !state.initialized {
+                // Subscribe conservatively until package discovery has been applied, avoiding
+                // a gap between subscription creation and the first dynamic scope update.
+                return repository_ignore.is_relevant(absolute_path.as_std_path(), false);
+            }
+            let Some(package_trie) = state.packages.get_ancestor(path.as_str()) else {
+                return false;
+            };
+            let Some(package) = package_trie.value() else {
+                return false;
+            };
+            let Some(package_path) = package_trie
+                .key()
+                .and_then(|path| AnchoredSystemPath::new(path).ok())
+            else {
+                return false;
+            };
+            let Some(path_in_package) = path.strip_prefix(package_path) else {
+                return false;
+            };
+            let path_in_package = path_in_package.to_unix();
+            let default_relevant =
+                repository_ignore.is_relevant(absolute_path.as_std_path(), false);
+
+            package.inputs.iter().any(|inputs| match inputs {
+                InputGlobs::Default => default_relevant,
+                InputGlobs::DefaultWithExtras(globs) => {
+                    globs.matches(&path_in_package) || default_relevant
+                }
+                InputGlobs::Specific(globs) => globs.matches(&path_in_package),
+            })
+        })
+        .with_physical_interest(physical_interest);
+        (dynamic, scope)
+    }
+
+    /// Replace the complete scope after package discovery changes the
+    /// repository layout. Queries should use `insert` so adding N input
+    /// specs remains O(N).
+    fn replace(&self, hashes: &FileHashes) {
+        let mut packages = Trie::new();
+        for package_path in hashes.0.keys() {
+            let Some(states) = hashes.0.get(package_path) else {
+                continue;
+            };
+            let package = PackageWatchScope {
+                inputs: states.keys().cloned().collect(),
+            };
+            packages.insert(package_path.clone(), package);
+        }
+        *self
+            .state
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = WatchScopeState {
+            initialized: true,
+            packages,
+        };
+
+        let state = self
+            .state
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        self.physical_interest
+            .replace(state.packages.iter().flat_map(|(package_path, package)| {
+                let package_root = self.repo_root.as_std_path().join(package_path);
+                package.inputs.iter().flat_map(move |inputs| match inputs {
+                    InputGlobs::Default => Vec::new(),
+                    InputGlobs::DefaultWithExtras(globs) | InputGlobs::Specific(globs) => globs
+                        .literal_prefixes()
+                        .map(|prefix| package_root.join(prefix))
+                        .collect(),
+                })
+            }));
+    }
+
+    fn insert(&self, spec: &HashSpec) {
+        let mut state = self
+            .state
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(package) = state.packages.get_mut(spec.package_path.as_str()) {
+            package.inputs.insert(spec.inputs.clone());
+        } else {
+            state.packages.insert(
+                spec.package_path.as_str().to_owned(),
+                PackageWatchScope {
+                    inputs: HashSet::from([spec.inputs.clone()]),
+                },
+            );
+        }
+    }
+
+    fn prepare_spec(&self, spec: &HashSpec) {
+        let package_root = self
+            .repo_root
+            .as_std_path()
+            .join(spec.package_path.as_str());
+        let paths = match &spec.inputs {
+            InputGlobs::Default => Vec::new(),
+            InputGlobs::DefaultWithExtras(globs) | InputGlobs::Specific(globs) => globs
+                .literal_prefixes()
+                .map(|prefix| package_root.join(prefix))
+                .collect(),
+        };
+        self.physical_interest.extend(paths);
+    }
+
+    async fn flush(&self) {
+        self.physical_interest.flush().await;
+    }
+}
 
 impl FileHashes {
     fn new() -> Self {
@@ -353,14 +512,15 @@ impl Subscriber {
         }
     }
 
-    async fn watch(
-        mut self,
-        mut exit_rx: oneshot::Receiver<()>,
-        mut file_events: OptionalWatch<broadcast::Receiver<Result<Event, NotifyError>>>,
-    ) {
+    async fn watch(mut self, mut exit_rx: oneshot::Receiver<()>, file_events: WatchSource) {
         debug!("starting file hash watcher");
-        let mut file_events_recv = match file_events.get().await {
-            Ok(r) => r.resubscribe(),
+        let repository_ignore = file_events
+            .repository_ignore()
+            .unwrap_or_else(|| RepositoryIgnore::new(self.repo_root.as_std_path()));
+        let (dynamic_scope, scope) =
+            DynamicWatchScope::new(self.repo_root.clone(), repository_ignore);
+        let mut file_events_recv = match file_events.subscribe(scope).await {
+            Ok(subscription) => subscription,
             Err(e) => {
                 debug!("file hash watcher exited: {:?}", e);
                 return;
@@ -371,6 +531,8 @@ impl Subscriber {
 
         let mut package_data = self.package_discovery.borrow().to_owned();
         self.handle_package_data_update(&package_data, &mut hashes, &hash_update_tx);
+        dynamic_scope.replace(&hashes);
+        let mut package_discovery_open = true;
         // We've gotten the ready signal from filewatching, and *some* state from
         // package discovery, but there is no guarantee that package discovery
         // is ready. This means that initial queries may be returned with errors
@@ -391,14 +553,35 @@ impl Subscriber {
                     debug!("file hash watcher exited");
                     return;
                 },
-                _ = self.package_discovery.changed() => {
-                    self.package_discovery.borrow().clone_into(&mut package_data);
-                    self.handle_package_data_update(&package_data, &mut hashes, &hash_update_tx);
+                package_discovery_result = self.package_discovery.changed(), if package_discovery_open => {
+                    if package_discovery_result.is_ok() {
+                        self.package_discovery.borrow().clone_into(&mut package_data);
+                        self.handle_package_data_update(&package_data, &mut hashes, &hash_update_tx);
+                        dynamic_scope.replace(&hashes);
+                    } else {
+                        // `changed()` remains immediately ready after all senders are dropped.
+                        // Disable this biased branch so it cannot starve the remaining inputs,
+                        // while retaining the most recently observed package and hash state.
+                        package_discovery_open = false;
+                    }
                 },
                 file_event = file_events_recv.recv() => {
                     match file_event {
                         Ok(Ok(event)) => {
-                            self.handle_file_event(event, &mut hashes, &hash_update_tx);
+                            if event
+                                .paths
+                                .iter()
+                                .any(|path| AbsoluteSystemPathBuf::try_from(path.as_path()).is_err())
+                            {
+                                self.flush_and_rehash(
+                                    &mut hashes,
+                                    &hash_update_tx,
+                                    &package_data,
+                                    "non-UTF-8 file event",
+                                );
+                            } else {
+                                self.handle_file_event(event, &mut hashes, &hash_update_tx);
+                            }
                         },
                         Ok(Err(e)) => {
                             debug!("file watcher error: {:?}", e);
@@ -424,7 +607,7 @@ impl Subscriber {
                     }
                 },
                 Some(query) = self.query_rx.recv() => {
-                    self.handle_query(query, &mut hashes, &hash_update_tx);
+                    self.handle_query(query, &mut hashes, &hash_update_tx, &dynamic_scope).await;
                 }
             }
         }
@@ -446,11 +629,12 @@ impl Subscriber {
 
     // We currently only support a single query, getting hashes for a given
     // HashSpec.
-    fn handle_query(
+    async fn handle_query(
         &self,
         query: Query,
         hashes: &mut FileHashes,
         hash_update_tx: &mpsc::Sender<HashUpdate>,
+        dynamic_scope: &DynamicWatchScope,
     ) {
         //trace!("handling query {query:?}");
         match query {
@@ -484,6 +668,13 @@ impl Subscriber {
                 {
                     // in this scenario, we know the package exists, but we aren't tracking these
                     // particular inputs. Queue a hash request for them.
+                    //
+                    // Ensure ignored literal roots are physically watched and the logical scope
+                    // includes the spec before taking its baseline hash. This closes the window
+                    // in which a change after the baseline could otherwise be filtered out.
+                    dynamic_scope.prepare_spec(&spec);
+                    dynamic_scope.flush().await;
+                    dynamic_scope.insert(&spec);
                     let (version, debouncer) = self.queue_package_hash(&spec, hash_update_tx, true);
                     // this request will likely time out. However, if the client has asked for
                     // this spec once, they might ask again, and we can start tracking it.
@@ -764,9 +955,9 @@ mod tests {
     };
     use turborepo_scm::{GitHashes, OidHash, SCM};
 
-    use super::{FileHashes, HashState, Subscriber, Version};
+    use super::{DynamicWatchScope, FileHashes, HashState, Query, Subscriber, Version};
     use crate::{
-        FileSystemWatcher,
+        FileSystemWatcher, RepositoryIgnore, WatchSource,
         cookies::CookieWriter,
         debouncer::Debouncer,
         globwatcher::GlobSet,
@@ -905,6 +1096,53 @@ mod tests {
         assert!(status.success(), "git checkout failed");
 
         commit_all(repo_root);
+    }
+
+    #[test]
+    fn dynamic_watch_scope_inserts_hash_specs_incrementally() {
+        let (_tmp, repo_root) = setup_fixture();
+        let foo_path = AnchoredSystemPathBuf::from_raw("packages/foo").unwrap();
+        let bar_path = AnchoredSystemPathBuf::from_raw("packages/bar").unwrap();
+        let mut hashes = FileHashes::new();
+        for package_path in [foo_path.clone(), bar_path.clone()] {
+            hashes.insert(
+                HashSpec {
+                    package_path,
+                    inputs: InputGlobs::Default,
+                },
+                HashState::Unavailable("test".to_owned()),
+            );
+        }
+
+        let (scope, _watch_scope) = DynamicWatchScope::new(
+            repo_root.clone(),
+            RepositoryIgnore::new(repo_root.as_std_path()),
+        );
+        scope.replace(&hashes);
+
+        let inputs =
+            InputGlobs::Specific(GlobSet::from_raw_unfiltered(vec!["out/**".to_owned()]).unwrap());
+        scope.insert(&HashSpec {
+            package_path: foo_path.clone(),
+            inputs: inputs.clone(),
+        });
+
+        let state = scope
+            .state
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert!(
+            state
+                .packages
+                .get(foo_path.as_str())
+                .unwrap()
+                .inputs
+                .contains(&inputs)
+        );
+        assert_eq!(
+            state.packages.get(bar_path.as_str()).unwrap().inputs.len(),
+            1
+        );
     }
 
     #[tokio::test]
@@ -1237,6 +1475,52 @@ mod tests {
         let decoy = root.join_components(&["apps", "foodecoy"]);
         let result = hashes.get_changed_specs(&decoy);
         assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn closed_package_discovery_does_not_starve_queries_or_shutdown() {
+        let tmp = tempdir().unwrap();
+        let repo_root = AbsoluteSystemPathBuf::try_from(tmp.path())
+            .unwrap()
+            .to_realpath()
+            .unwrap();
+        let (package_discovery_tx, package_discovery_rx) = tokio::sync::watch::channel(None);
+        let (query_tx, query_rx) = tokio::sync::mpsc::channel(1);
+        let (exit_tx, exit_rx) = tokio::sync::oneshot::channel();
+        let (file_event_tx, file_events) = WatchSource::channel();
+        let subscriber = Subscriber::new(repo_root, package_discovery_rx, SCM::Manual, query_rx);
+        let handle = tokio::spawn(subscriber.watch(exit_rx, file_events));
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while file_event_tx.receiver_count() == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("subscriber should start");
+
+        drop(package_discovery_tx);
+        let unknown_spec = HashSpec {
+            package_path: AnchoredSystemPathBuf::from_raw("packages/unknown").unwrap(),
+            inputs: InputGlobs::Default,
+        };
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+        query_tx
+            .send(Query::GetHash(unknown_spec, response_tx))
+            .await
+            .unwrap();
+        let response = tokio::time::timeout(Duration::from_secs(1), response_rx)
+            .await
+            .expect("closed package discovery must not starve queries")
+            .unwrap();
+        assert_matches!(response, Err(super::Error::UnknownPackage(_)));
+
+        drop(file_event_tx);
+        tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("subscriber should stop when file watching closes")
+            .unwrap();
+        drop(exit_tx);
     }
 
     #[tokio::test]

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -24,7 +24,19 @@
 #![allow(clippy::mutable_key_type)]
 #![allow(clippy::result_large_err)]
 
-use std::{fmt::Debug, future::IntoFuture, path::Path, sync::Arc, time::Duration};
+#[cfg(not(feature = "manual_recursive_watch"))]
+use std::sync::atomic::AtomicBool;
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Debug,
+    future::IntoFuture,
+    path::{Path, PathBuf},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
 
 // windows -> no recursive watch, watch ancestors
 // linux -> recursive watch, watch ancestors
@@ -37,19 +49,11 @@ use notify::event::EventKind;
 use notify::{Config, RecommendedWatcher};
 use notify::{Event, EventHandler, RecursiveMode, Watcher};
 use thiserror::Error;
-use tokio::sync::{broadcast, mpsc, watch::error::RecvError};
+use tokio::sync::{broadcast, mpsc, watch};
 use tracing::{debug, error, warn};
 use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf, PathRelation};
 #[cfg(feature = "manual_recursive_watch")]
-use {
-    notify::{
-        ErrorKind,
-        event::{CreateKind, EventAttributes},
-    },
-    std::io,
-    tracing::trace,
-    walkdir::WalkDir,
-};
+use {notify::event::CreateKind, tracing::trace, walkdir::WalkDir};
 
 pub mod cookies;
 mod debouncer;
@@ -59,9 +63,11 @@ pub mod globwatcher;
 pub mod hash_watcher;
 mod optional_watch;
 pub mod package_watcher;
+mod repository_ignore;
 mod scm_resource;
 
 pub use optional_watch::OptionalWatch;
+pub use repository_ignore::RepositoryIgnore;
 
 #[cfg(not(target_os = "macos"))]
 type Backend = RecommendedWatcher;
@@ -69,6 +75,398 @@ type Backend = RecommendedWatcher;
 type Backend = FsEventWatcher;
 
 type EventResult = Result<Event, notify::Error>;
+
+const EVENT_CHANNEL_CAPACITY: usize = 1024;
+
+type EventFilter = dyn Fn(&mut Event) + Send + Sync;
+
+#[derive(Default)]
+struct PhysicalInterestState {
+    paths: HashSet<PathBuf>,
+    controls: Vec<mpsc::UnboundedSender<WatcherControl>>,
+}
+
+/// Mutable, explicit physical watch roots for paths that ordinary git-aware
+/// recursion would omit. A root may be nonexistent; Linux watches its nearest
+/// existing ancestor and extends the watch when the path is created.
+#[derive(Clone, Default)]
+pub struct WatchInterest(Arc<Mutex<PhysicalInterestState>>);
+
+impl WatchInterest {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn replace(&self, paths: impl IntoIterator<Item = PathBuf>) {
+        let paths = paths.into_iter().collect();
+        let mut state = self
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.paths == paths {
+            return;
+        }
+        state.paths = paths;
+        state
+            .controls
+            .retain(|control| control.send(WatcherControl::Refresh(None)).is_ok());
+    }
+
+    pub fn extend(&self, paths: impl IntoIterator<Item = PathBuf>) {
+        let mut state = self
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let previous_len = state.paths.len();
+        state.paths.extend(paths);
+        if state.paths.len() == previous_len {
+            return;
+        }
+        state
+            .controls
+            .retain(|control| control.send(WatcherControl::Refresh(None)).is_ok());
+    }
+
+    /// Waits until every attached Linux driver has applied the current roots.
+    /// This is a no-op for detached interests and non-Linux backends.
+    pub async fn flush(&self) {
+        let controls = self
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .controls
+            .clone();
+        for control in controls {
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            if control.send(WatcherControl::Refresh(Some(tx))).is_ok() {
+                let _ = rx.await;
+            }
+        }
+    }
+
+    fn bind(&self, control: mpsc::UnboundedSender<WatcherControl>) {
+        #[cfg(not(feature = "manual_recursive_watch"))]
+        let _ = control;
+        #[cfg(feature = "manual_recursive_watch")]
+        {
+            let mut state = self
+                .0
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            state.controls.push(control.clone());
+            let _ = control.send(WatcherControl::Refresh(None));
+        }
+    }
+
+    #[cfg(feature = "manual_recursive_watch")]
+    fn paths(&self) -> Vec<PathBuf> {
+        self.0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .paths
+            .iter()
+            .cloned()
+            .collect()
+    }
+}
+
+#[derive(Debug)]
+enum WatcherControl {
+    Refresh(Option<tokio::sync::oneshot::Sender<()>>),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SourceState {
+    Starting,
+    Ready,
+    Closed,
+}
+
+#[derive(Debug, Error)]
+pub enum SubscribeError {
+    #[error("file watching closed before the subscription was ready")]
+    Closed,
+}
+
+/// Declares which filesystem paths are relevant to a watcher consumer.
+#[derive(Clone)]
+pub struct WatchScope {
+    filter: Arc<EventFilter>,
+    physical: Option<WatchInterest>,
+}
+
+impl WatchScope {
+    pub fn all() -> Self {
+        Self {
+            filter: Arc::new(|_| {}),
+            physical: None,
+        }
+    }
+
+    pub fn predicate(predicate: impl Fn(&Path) -> bool + Send + Sync + 'static) -> Self {
+        Self {
+            filter: Arc::new(move |event| event.paths.retain(|path| predicate(path))),
+            physical: None,
+        }
+    }
+
+    pub fn event_filter(filter: impl Fn(&mut Event) + Send + Sync + 'static) -> Self {
+        Self {
+            filter: Arc::new(filter),
+            physical: None,
+        }
+    }
+
+    /// Adds explicit physical coverage without changing event filtering.
+    pub fn with_physical_interest(mut self, interest: WatchInterest) -> Self {
+        self.physical = Some(interest);
+        self
+    }
+
+    fn filter(&self, event: &mut Event) {
+        (self.filter)(event);
+    }
+}
+
+#[derive(Clone)]
+struct SubscriptionEntry {
+    scope: WatchScope,
+    sender: broadcast::Sender<Result<Event, NotifyError>>,
+}
+
+struct SubscriptionRegistry {
+    next_id: AtomicU64,
+    state: Mutex<SubscriptionRegistryState>,
+    control: mpsc::UnboundedSender<WatcherControl>,
+}
+
+#[derive(Default)]
+struct SubscriptionRegistryState {
+    closed: bool,
+    entries: HashMap<u64, SubscriptionEntry>,
+}
+
+impl SubscriptionRegistry {
+    fn new(control: mpsc::UnboundedSender<WatcherControl>) -> Self {
+        Self {
+            next_id: AtomicU64::new(0),
+            state: Mutex::new(SubscriptionRegistryState::default()),
+            control,
+        }
+    }
+
+    fn close(&self) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.closed = true;
+        state.entries.clear();
+    }
+
+    #[cfg(feature = "manual_recursive_watch")]
+    fn physical_paths(&self) -> Vec<PathBuf> {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .entries
+            .values()
+            .filter_map(|entry| entry.scope.physical.as_ref())
+            .flat_map(WatchInterest::paths)
+            .collect()
+    }
+}
+
+/// A demand-driven source of filesystem events. Each subscription receives only
+/// paths matching its declared scope, so irrelevant bursts do not consume its
+/// bounded channel capacity.
+#[derive(Clone)]
+pub struct WatchSource {
+    ready: watch::Receiver<SourceState>,
+    registry: Arc<SubscriptionRegistry>,
+    repository_ignore: Option<RepositoryIgnore>,
+}
+
+impl WatchSource {
+    #[doc(hidden)]
+    pub fn channel() -> (WatchEventSender, Self) {
+        let (control, _control_rx) = mpsc::unbounded_channel();
+        let registry = Arc::new(SubscriptionRegistry::new(control));
+        let (ready_tx, ready) = watch::channel(SourceState::Starting);
+        let source = Self {
+            ready,
+            registry: registry.clone(),
+            repository_ignore: None,
+        };
+        let _ = ready_tx.send(SourceState::Ready);
+        (
+            WatchEventSender {
+                ready: ready_tx,
+                registry,
+                repository_ignore: None,
+            },
+            source,
+        )
+    }
+
+    #[doc(hidden)]
+    pub fn channel_for_root(root: &Path) -> (WatchEventSender, Self) {
+        let (mut sender, mut source) = Self::channel();
+        let repository_ignore = RepositoryIgnore::new(root);
+        sender.repository_ignore = Some(repository_ignore.clone());
+        source.repository_ignore = Some(repository_ignore);
+        (sender, source)
+    }
+
+    pub fn repository_ignore(&self) -> Option<RepositoryIgnore> {
+        self.repository_ignore.clone()
+    }
+
+    pub async fn ready(&self) -> Result<(), SubscribeError> {
+        let mut ready = self.ready.clone();
+        let state = ready
+            .wait_for(|state| *state != SourceState::Starting)
+            .await
+            .map_err(|_| SubscribeError::Closed)?;
+        if *state == SourceState::Closed {
+            return Err(SubscribeError::Closed);
+        }
+        Ok(())
+    }
+
+    pub async fn subscribe(&self, scope: WatchScope) -> Result<WatchSubscription, SubscribeError> {
+        let id = self.registry.next_id.fetch_add(1, Ordering::Relaxed);
+        let (sender, receiver) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
+        {
+            let mut state = self
+                .registry
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if state.closed {
+                return Err(SubscribeError::Closed);
+            }
+            state.entries.insert(
+                id,
+                SubscriptionEntry {
+                    scope: scope.clone(),
+                    sender,
+                },
+            );
+        }
+
+        // Registration must precede readiness: on Linux the initial physical
+        // walk and readiness cookie can depend on this coverage.
+        if let Some(interest) = &scope.physical {
+            interest.bind(self.registry.control.clone());
+        } else {
+            let _ = self.registry.control.send(WatcherControl::Refresh(None));
+        }
+
+        if let Err(error) = self.ready().await {
+            self.registry
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .entries
+                .remove(&id);
+            return Err(error);
+        }
+
+        Ok(WatchSubscription {
+            id,
+            receiver,
+            registry: self.registry.clone(),
+        })
+    }
+}
+
+pub struct WatchEventSender {
+    ready: watch::Sender<SourceState>,
+    registry: Arc<SubscriptionRegistry>,
+    repository_ignore: Option<RepositoryIgnore>,
+}
+
+impl WatchEventSender {
+    pub fn receiver_count(&self) -> usize {
+        self.registry
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .entries
+            .len()
+    }
+
+    pub fn send(
+        &self,
+        event: Result<Event, NotifyError>,
+    ) -> Result<(), broadcast::error::SendError<Result<Event, NotifyError>>> {
+        let git_control_changed =
+            if let (Some(repository_ignore), Ok(event)) = (&self.repository_ignore, &event) {
+                let invalidates = event
+                    .paths
+                    .iter()
+                    .any(|path| repository_ignore.invalidates_consumers(path));
+                let refresh = event
+                    .paths
+                    .iter()
+                    .any(|path| repository_ignore.should_refresh(path));
+                if refresh {
+                    repository_ignore.refresh();
+                }
+                invalidates
+            } else {
+                false
+            };
+        if git_control_changed {
+            route_event(
+                &self.registry,
+                Err(NotifyError::invalidation(
+                    "Git index or exclude state changed",
+                )),
+            );
+            return Ok(());
+        }
+        match &event {
+            Ok(event) => route_event(&self.registry, Ok(event)),
+            Err(error) => route_event(&self.registry, Err(error.clone())),
+        }
+        Ok(())
+    }
+}
+
+impl Drop for WatchEventSender {
+    fn drop(&mut self) {
+        self.registry.close();
+        let _ = self.ready.send(SourceState::Closed);
+    }
+}
+
+pub struct WatchSubscription {
+    id: u64,
+    receiver: broadcast::Receiver<Result<Event, NotifyError>>,
+    registry: Arc<SubscriptionRegistry>,
+}
+
+impl WatchSubscription {
+    pub async fn recv(
+        &mut self,
+    ) -> Result<Result<Event, NotifyError>, broadcast::error::RecvError> {
+        self.receiver.recv().await
+    }
+}
+
+impl Drop for WatchSubscription {
+    fn drop(&mut self) {
+        self.registry
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .entries
+            .remove(&self.id);
+        let _ = self.registry.control.send(WatcherControl::Refresh(None));
+    }
+}
 
 #[derive(Debug, Error)]
 pub enum WatchError {
@@ -78,6 +476,8 @@ pub enum WatchError {
     Stopped(#[from] std::sync::mpsc::RecvError),
     #[error("enumerating recursive watch: {0}")]
     WalkDir(#[from] walkdir::Error),
+    #[error("enumerating git-aware recursive watch: {0}")]
+    Ignore(#[from] ignore::Error),
     #[error("filewatching failed to start: {0}")]
     Setup(String),
 }
@@ -86,23 +486,49 @@ pub enum WatchError {
 // Clone. We provide a wrapper that uses an Arc to implement Clone so that we
 // can send errors on a broadcast channel.
 #[derive(Clone, Debug, Error)]
-#[error("{0}")]
-pub struct NotifyError(Arc<notify::Error>);
+#[error("{error}")]
+pub struct NotifyError {
+    error: Arc<notify::Error>,
+    invalidation: bool,
+}
+
+impl NotifyError {
+    fn invalidation(message: &str) -> Self {
+        Self {
+            error: Arc::new(notify::Error::generic(message)),
+            invalidation: true,
+        }
+    }
+
+    fn fatal(message: String) -> Self {
+        Self {
+            error: Arc::new(notify::Error::generic(&message)),
+            invalidation: false,
+        }
+    }
+
+    pub fn is_invalidation(&self) -> bool {
+        self.invalidation
+    }
+}
 
 impl From<notify::Error> for NotifyError {
     fn from(value: notify::Error) -> Self {
-        Self(Arc::new(value))
+        Self {
+            error: Arc::new(value),
+            invalidation: false,
+        }
     }
 }
 
 pub struct FileSystemWatcher {
-    receiver: OptionalWatch<broadcast::Receiver<Result<Event, NotifyError>>>,
     // _exit_ch exists to trigger a close on the receiver when an instance
     // of this struct is dropped. The task that is receiving events will exit,
     // dropping the other sender for the broadcast channel, causing all receivers
     // to be notified of a close.
     _exit_ch: tokio::sync::oneshot::Sender<()>,
     cookie_dir: AbsoluteSystemPathBuf,
+    source: WatchSource,
 }
 
 impl FileSystemWatcher {
@@ -125,79 +551,148 @@ impl FileSystemWatcher {
             )));
         }
 
-        let (file_events_receiver_tx, file_events_receiver_lazy) = OptionalWatch::new();
-        let (send_file_events, mut recv_file_events) = mpsc::channel(1024);
+        let (send_file_events, mut recv_file_events) = mpsc::unbounded_channel();
         let (exit_ch, exit_signal) = tokio::sync::oneshot::channel();
+        let (ready_tx, ready_rx) = watch::channel(SourceState::Starting);
+        let (watch_control_tx, watch_control_rx) = mpsc::unbounded_channel();
+        let registry = Arc::new(SubscriptionRegistry::new(watch_control_tx));
+        let repository_ignore = RepositoryIgnore::new(root.as_std_path());
+        let source_repository_ignore = repository_ignore.clone();
+        #[cfg(not(feature = "manual_recursive_watch"))]
+        let backend_ready = Arc::new(AtomicBool::new(false));
+        #[cfg(not(feature = "manual_recursive_watch"))]
+        let ordered_driver_delivery = Arc::new(AtomicBool::new(false));
 
         tokio::task::spawn({
             let cookie_dir = cookie_dir.clone();
             let watch_root = root.to_owned();
+            let registry = registry.clone();
+            let repository_ignore = repository_ignore.clone();
+            #[cfg(not(feature = "manual_recursive_watch"))]
+            let backend_ready = backend_ready.clone();
+            #[cfg(not(feature = "manual_recursive_watch"))]
+            let ordered_driver_delivery = ordered_driver_delivery.clone();
             async move {
                 // this task never yields, so run it in the blocking threadpool
                 let watch_root_task = watch_root.clone();
                 let cookie_dir_task = cookie_dir.clone();
+                let task_repository_ignore = repository_ignore.clone();
+                #[cfg(not(feature = "manual_recursive_watch"))]
+                let task_backend_ready = backend_ready.clone();
+                #[cfg(not(feature = "manual_recursive_watch"))]
+                let task_ordered_driver_delivery = ordered_driver_delivery.clone();
+                #[cfg(not(feature = "manual_recursive_watch"))]
+                let task_registry = registry.clone();
                 let task = tokio::task::spawn_blocking(move || {
                     setup_cookie_dir(&cookie_dir_task)?;
-                    run_watcher(&watch_root_task, send_file_events)
+                    run_watcher(
+                        &watch_root_task,
+                        &cookie_dir_task,
+                        send_file_events,
+                        &task_repository_ignore,
+                        #[cfg(not(feature = "manual_recursive_watch"))]
+                        task_backend_ready,
+                        #[cfg(not(feature = "manual_recursive_watch"))]
+                        task_ordered_driver_delivery,
+                        #[cfg(not(feature = "manual_recursive_watch"))]
+                        task_registry,
+                    )
                 });
 
-                let Ok(Ok(watcher)) = task.await else {
+                let Ok(Ok((mut watcher, watched))) = task.await else {
                     // if the watcher fails, just return. we don't set the event sender, and other
                     // services will never start
                     error!(
                         "file watcher failed to start. watch mode and other daemon-dependent \
                          features will not work"
                     );
+                    registry.close();
+                    let _ = ready_tx.send(SourceState::Closed);
                     return;
                 };
 
                 // Ensure we are ready to receive new events, not events for existing state
                 debug!("waiting for initial filesystem cookie");
-                if let Err(e) = wait_for_cookie(&cookie_dir, &mut recv_file_events).await {
-                    // if we can't get a cookie here, we should not make the file
-                    // watching available to downstream services
-                    error!(
-                        "failed to wait for initial filesystem cookie: {}. This means the file \
-                         system event backend (e.g. FSEvents on macOS) is not delivering events. \
-                         watch mode will not work. Try running `turbo daemon clean` and retrying.",
-                        e
-                    );
-                    return;
-                }
+                let mut watch_control_rx = watch_control_rx;
+                let initial_watched = match wait_for_cookie(
+                    &cookie_dir,
+                    &watch_root,
+                    &mut watcher,
+                    &mut recv_file_events,
+                    &registry,
+                    &mut watch_control_rx,
+                    watched,
+                )
+                .await
+                {
+                    Ok(watched) => watched,
+                    Err(e) => {
+                        // if we can't get a cookie here, we should not make the file
+                        // watching available to downstream services
+                        error!(
+                            "failed to wait for initial filesystem cookie: {}. This means the \
+                             file system event backend (e.g. FSEvents on macOS) is not delivering \
+                             events. watch mode will not work. Try running `turbo daemon clean` \
+                             and retrying.",
+                            e
+                        );
+                        registry.close();
+                        let _ = ready_tx.send(SourceState::Closed);
+                        return;
+                    }
+                };
                 debug!("filewatching ready");
 
-                let (sender, receiver) = broadcast::channel(1024);
+                // Keep the bounded channel as the startup handoff (and as the
+                // Linux mutation queue), but route directly after the cookie
+                // has established readiness on non-mutating backends.
+                #[cfg(not(feature = "manual_recursive_watch"))]
+                backend_ready.store(true, Ordering::Release);
 
-                if file_events_receiver_tx.send(Some(receiver)).is_err() {
-                    // if this fails, it means that nobody is listening (and
-                    // nobody ever will) likely because the
-                    // watcher has been dropped. We can just exit early.
-                    tracing::debug!("no downstream listeners, exiting");
-                    return;
+                if ready_tx.send(SourceState::Ready).is_err() {
+                    tracing::debug!("no scoped downstream listeners");
                 }
 
-                watch_events(watcher, watch_root, recv_file_events, exit_signal, sender).await;
+                watch_events(
+                    watcher,
+                    watch_root,
+                    cookie_dir,
+                    recv_file_events,
+                    exit_signal,
+                    registry.clone(),
+                    watch_control_rx,
+                    initial_watched,
+                    repository_ignore,
+                )
+                .await;
+                registry.close();
+                let _ = ready_tx.send(SourceState::Closed);
             }
         });
 
         Ok(Self {
-            receiver: file_events_receiver_lazy,
             _exit_ch: exit_ch,
             cookie_dir,
+            source: WatchSource {
+                ready: ready_rx,
+                registry,
+                repository_ignore: Some(source_repository_ignore),
+            },
         })
     }
 
     /// A convenience method around the sender watcher that waits for file
     /// watching to be ready and then returns a handle to the file stream.
-    pub async fn subscribe(
-        &self,
-    ) -> Result<broadcast::Receiver<Result<Event, NotifyError>>, RecvError> {
-        let mut receiver = self.receiver.clone();
-        receiver.get().await.map(|r| r.resubscribe())
+    pub async fn subscribe(&self) -> Result<WatchSubscription, SubscribeError> {
+        self.source.subscribe(WatchScope::all()).await
     }
 
-    pub fn watch(&self) -> OptionalWatch<broadcast::Receiver<Result<Event, NotifyError>>> {
-        self.receiver.clone()
+    pub fn watch(&self) -> WatchSource {
+        self.source()
+    }
+
+    pub fn source(&self) -> WatchSource {
+        self.source.clone()
     }
 
     pub fn cookie_dir(&self) -> &AbsoluteSystemPath {
@@ -222,41 +717,156 @@ fn setup_cookie_dir(cookie_dir: &AbsoluteSystemPath) -> Result<(), WatchError> {
 }
 
 #[cfg(not(any(feature = "watch_ancestors", feature = "manual_recursive_watch")))]
+#[allow(clippy::too_many_arguments)]
 async fn watch_events(
-    _watcher: Backend,
-    _watch_root: AbsoluteSystemPathBuf,
-    mut recv_file_events: mpsc::Receiver<EventResult>,
+    mut watcher: Backend,
+    watch_root: AbsoluteSystemPathBuf,
+    _cookie_dir: AbsoluteSystemPathBuf,
+    mut recv_file_events: mpsc::UnboundedReceiver<EventResult>,
     exit_signal: tokio::sync::oneshot::Receiver<()>,
-    broadcast_sender: broadcast::Sender<Result<Event, NotifyError>>,
+    registry: Arc<SubscriptionRegistry>,
+    _watch_control_rx: mpsc::UnboundedReceiver<WatcherControl>,
+    mut watched: HashSet<PathBuf>,
+    repository_ignore: RepositoryIgnore,
 ) {
     let mut exit_signal = exit_signal;
     'outer: loop {
         tokio::select! {
             _ = &mut exit_signal => break 'outer,
             Some(event) = recv_file_events.recv().into_future() => {
-                // we don't care if we fail to send, it just means no one is currently watching
-                let _ = broadcast_sender.send(event.map_err(NotifyError::from));
+                if let Err(error) = route_non_mutating_backend_event(
+                    &watch_root,
+                    &registry,
+                    &repository_ignore,
+                    &mut watcher,
+                    &mut watched,
+                    event,
+                ) {
+                    route_fatal_driver_error(
+                        &registry,
+                        "failed to refresh Git control watches",
+                        &error,
+                    );
+                    break 'outer;
+                }
             }
         }
     }
 }
 
 #[cfg(any(feature = "watch_ancestors", feature = "manual_recursive_watch"))]
+#[allow(clippy::too_many_arguments)]
 async fn watch_events(
     #[cfg(feature = "manual_recursive_watch")] mut watcher: Backend,
-    #[cfg(not(feature = "manual_recursive_watch"))] _watcher: Backend,
+    #[cfg(not(feature = "manual_recursive_watch"))] mut watcher: Backend,
     watch_root: AbsoluteSystemPathBuf,
-    mut recv_file_events: mpsc::Receiver<EventResult>,
+    #[cfg(feature = "manual_recursive_watch")] cookie_dir: AbsoluteSystemPathBuf,
+    #[cfg(not(feature = "manual_recursive_watch"))] _cookie_dir: AbsoluteSystemPathBuf,
+    mut recv_file_events: mpsc::UnboundedReceiver<EventResult>,
     exit_signal: tokio::sync::oneshot::Receiver<()>,
-    broadcast_sender: broadcast::Sender<Result<Event, NotifyError>>,
+    registry: Arc<SubscriptionRegistry>,
+    #[cfg(feature = "manual_recursive_watch")] mut watch_control_rx: mpsc::UnboundedReceiver<
+        WatcherControl,
+    >,
+    #[cfg(not(feature = "manual_recursive_watch"))] _watch_control_rx: mpsc::UnboundedReceiver<
+        WatcherControl,
+    >,
+    #[cfg(feature = "manual_recursive_watch")] mut watched: HashSet<PathBuf>,
+    #[cfg(not(feature = "manual_recursive_watch"))] mut watched: HashSet<PathBuf>,
+    repository_ignore: RepositoryIgnore,
 ) {
     let mut exit_signal = exit_signal;
+    #[cfg(feature = "manual_recursive_watch")]
+    let mut explicit_watched =
+        match explicit_watch_paths(watch_root.as_std_path(), &registry.physical_paths()) {
+            Ok(watched) => watched,
+            Err(error) => {
+                warn!("failed to initialize explicit filesystem watches: {error}");
+                route_fatal_driver_error(
+                    &registry,
+                    "failed to initialize explicit filesystem watches",
+                    &error,
+                );
+                return;
+            }
+        };
     'outer: loop {
         tokio::select! {
             _ = &mut exit_signal => break 'outer,
+            _control = async {
+                #[cfg(feature = "manual_recursive_watch")]
+                {
+                    watch_control_rx.recv().await
+                }
+                #[cfg(not(feature = "manual_recursive_watch"))]
+                std::future::pending::<Option<WatcherControl>>().await
+            } => {
+                #[cfg(feature = "manual_recursive_watch")]
+                if let Some(WatcherControl::Refresh(ack)) = _control {
+                    let mut acknowledgements = ack.into_iter().collect::<Vec<_>>();
+                    while let Ok(WatcherControl::Refresh(ack)) = watch_control_rx.try_recv() {
+                        acknowledgements.extend(ack);
+                    }
+                    let explicit = registry.physical_paths();
+                    if let Err(error) = refresh_explicit_watches(
+                        watch_root.as_std_path(),
+                        cookie_dir.as_std_path(),
+                        &explicit,
+                        &mut watcher,
+                        &mut watched,
+                        &mut explicit_watched,
+                        &repository_ignore,
+                    ) {
+                        warn!("failed to refresh explicit filesystem watches: {error}");
+                        route_fatal_driver_error(
+                            &registry,
+                            "failed to refresh explicit filesystem watches",
+                            &error,
+                        );
+                        break 'outer;
+                    }
+                    for acknowledgement in acknowledgements {
+                        let _ = acknowledgement.send(());
+                    }
+                }
+            }
             Some(event) = recv_file_events.recv().into_future() => {
+                #[cfg(not(feature = "manual_recursive_watch"))]
+                {
+                    if let Err(error) = route_non_mutating_backend_event(
+                        &watch_root,
+                        &registry,
+                        &repository_ignore,
+                        &mut watcher,
+                        &mut watched,
+                        event,
+                    ) {
+                        route_fatal_driver_error(
+                            &registry,
+                            "failed to refresh Git control watches",
+                            &error,
+                        );
+                        break 'outer;
+                    }
+                    continue;
+                }
+                #[cfg(feature = "manual_recursive_watch")]
                 match event {
+                    #[allow(unused_mut)]
                     Ok(mut event) => {
+                        let repository_state_changed = event
+                            .paths
+                            .iter()
+                            .any(|path| repository_ignore.should_refresh(path));
+                        let previous_controls = repository_state_changed
+                            .then(|| repository_ignore.control_paths());
+                        let git_control_changed = event
+                            .paths
+                            .iter()
+                            .any(|path| repository_ignore.invalidates_consumers(path));
+                        if repository_state_changed {
+                            repository_ignore.refresh();
+                        }
                         // Note that we need to filter relevant events
                         // before doing manual recursive watching so that
                         // we don't try to add watches to siblings of the
@@ -266,34 +876,246 @@ async fn watch_events(
 
                         #[cfg(feature = "manual_recursive_watch")]
                         {
+                            if matches!(event.kind, EventKind::Remove(_)) {
+                                for removed in &event.paths {
+                                    watched.retain(|path| !path.starts_with(removed));
+                                    explicit_watched.retain(|path| !path.starts_with(removed));
+                                }
+                            }
+                            if repository_state_changed
+                                && let Err(error) = add_control_watches(
+                                    watch_root.as_std_path(),
+                                    &repository_ignore.control_paths(),
+                                    &mut watcher,
+                                    &mut watched,
+                                )
+                            {
+                                route_fatal_driver_error(
+                                    &registry,
+                                    "failed to refresh Git control watches",
+                                    &error,
+                                );
+                                break 'outer;
+                            }
+                            if let Some(previous_controls) = previous_controls.as_deref()
+                                && let Err(error) = reconcile_control_watches(
+                                    watch_root.as_std_path(),
+                                    previous_controls,
+                                    &repository_ignore.control_paths(),
+                                    &mut watcher,
+                                    &mut watched,
+                                    |path| {
+                                        repository_ignore.is_relevant(path, true)
+                                            || explicit_watched.contains(path)
+                                            || cookie_dir.as_std_path().starts_with(path)
+                                            || path.starts_with(cookie_dir.as_std_path())
+                                    },
+                                )
+                            {
+                                route_fatal_driver_error(
+                                    &registry,
+                                    "failed to reconcile Git control watches",
+                                    &error,
+                                );
+                                break 'outer;
+                            }
+                            if repository_state_changed
+                                && let Err(error) = reconcile_ordinary_watches(
+                                watch_root.as_std_path(),
+                                cookie_dir.as_std_path(),
+                                &registry.physical_paths(),
+                                &mut watcher,
+                                &mut watched,
+                                &repository_ignore,
+                            ) {
+                                warn!("failed to reconcile git-aware filesystem watches: {error}");
+                                route_fatal_driver_error(
+                                    &registry,
+                                    "failed to reconcile git-aware filesystem watches",
+                                    &error,
+                                );
+                                break 'outer;
+                            }
                             if event.kind == EventKind::Create(CreateKind::Folder) {
                                 for new_path in &event.paths {
-                                    if let Err(err) = manually_add_recursive_watches(new_path, &mut watcher, Some(&broadcast_sender)) {
-                                        match err {
-                                            WatchError::WalkDir(err) => {
-                                                // Likely the path no longer exists
-                                                debug!("encountered error watching filesystem {}", err);
-                                                continue;
-                                            },
-                                            _ => {
-                                                warn!("encountered error watching filesystem {}", err);
-                                                break 'outer;
+                                    let explicit = registry.physical_paths();
+                                    if explicit.iter().any(|interest| {
+                                        interest.starts_with(new_path) || new_path.starts_with(interest)
+                                    }) {
+                                        if let Err(error) = refresh_explicit_watches(
+                                            watch_root.as_std_path(),
+                                            cookie_dir.as_std_path(),
+                                            &explicit,
+                                            &mut watcher,
+                                            &mut watched,
+                                            &mut explicit_watched,
+                                            &repository_ignore,
+                                        ) {
+                                            warn!("failed to refresh materialized explicit filesystem watches: {error}");
+                                            route_fatal_driver_error(
+                                                &registry,
+                                                "failed to refresh materialized explicit filesystem watches",
+                                                &error,
+                                            );
+                                            break 'outer;
+                                        }
+                                        route_materialized_interests(
+                                            &registry,
+                                            &explicit,
+                                            new_path,
+                                        );
+                                    } else {
+                                        let result = add_ordinary_watches(
+                                            watch_root.as_std_path(),
+                                            new_path,
+                                            &mut watcher,
+                                            &mut watched,
+                                            Some(&registry),
+                                            &repository_ignore,
+                                        );
+                                        if let Err(err) = result {
+                                            match err {
+                                                WatchError::WalkDir(err) => {
+                                                    // Likely the path no longer exists
+                                                    debug!("encountered error watching filesystem {}", err);
+                                                    continue;
+                                                },
+                                                _ => {
+                                                    warn!("encountered error watching filesystem {}", err);
+                                                    route_fatal_driver_error(
+                                                        &registry,
+                                                        "failed to extend recursive filesystem watches",
+                                                        &err,
+                                                    );
+                                                    break 'outer;
+                                                }
                                             }
-
                                         }
                                     }
                                 }
                             }
                         }
-                        // we don't care if we fail to send, it just means no one is currently watching
-                        let _ = broadcast_sender.send(Ok(event));
+                        if git_control_changed {
+                            route_event(
+                                &registry,
+                                Err(NotifyError::invalidation(
+                                    "Git index or exclude state changed",
+                                )),
+                            );
+                        } else {
+                            route_event(&registry, Ok(&event));
+                        }
                     },
                     Err(error) => {
-                        // we don't care if we fail to send, it just means no one is currently watching
-                        let _ = broadcast_sender.send(Err(NotifyError::from(error)));
+                        let error = NotifyError::from(error);
+                        route_event(&registry, Err(error.clone()));
                     }
                 }
             }
+        }
+    }
+}
+
+#[cfg(not(feature = "manual_recursive_watch"))]
+fn route_non_mutating_backend_event(
+    watch_root: &AbsoluteSystemPath,
+    registry: &SubscriptionRegistry,
+    repository_ignore: &RepositoryIgnore,
+    watcher: &mut Backend,
+    watched: &mut HashSet<PathBuf>,
+    event: EventResult,
+) -> Result<(), WatchError> {
+    match event {
+        #[allow(unused_mut)]
+        Ok(mut event) => {
+            let repository_state_changed = event
+                .paths
+                .iter()
+                .any(|path| repository_ignore.should_refresh(path));
+            let git_control_changed = event
+                .paths
+                .iter()
+                .any(|path| repository_ignore.invalidates_consumers(path));
+            if repository_state_changed {
+                let previous_controls = repository_ignore.control_paths();
+                repository_ignore.refresh();
+                reconcile_control_watches(
+                    watch_root.as_std_path(),
+                    &previous_controls,
+                    &repository_ignore.control_paths(),
+                    watcher,
+                    watched,
+                    |path| non_mutating_ordinary_owner(watch_root.as_std_path(), path),
+                )?;
+            }
+
+            #[cfg(feature = "watch_ancestors")]
+            filter_relevant(watch_root, &mut event);
+            #[cfg(not(feature = "watch_ancestors"))]
+            let _ = watch_root;
+
+            if git_control_changed {
+                route_event(
+                    registry,
+                    Err(NotifyError::invalidation(
+                        "Git index or exclude state changed",
+                    )),
+                );
+            } else {
+                route_event(registry, Ok(&event));
+            }
+        }
+        Err(error) => route_event(registry, Err(NotifyError::from(error))),
+    }
+    Ok(())
+}
+
+fn route_fatal_driver_error(registry: &SubscriptionRegistry, context: &str, error: &WatchError) {
+    route_event(
+        registry,
+        Err(NotifyError::fatal(format!("{context}: {error}"))),
+    );
+}
+
+fn route_event(registry: &SubscriptionRegistry, event: Result<&Event, NotifyError>) {
+    let event = match event {
+        Ok(event) if event.need_rescan() => Err(NotifyError::invalidation(
+            "file watching backend requires a full rescan",
+        )),
+        event => event,
+    };
+    let entries: Vec<_> = registry
+        .state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .entries
+        .iter()
+        .map(|(id, entry)| (*id, entry.clone()))
+        .collect();
+    let mut closed = Vec::new();
+    for (id, entry) in entries {
+        let scoped_event = match &event {
+            Ok(event) => {
+                let mut event = (*event).clone();
+                entry.scope.filter(&mut event);
+                if event.paths.is_empty() {
+                    continue;
+                }
+                Ok(event)
+            }
+            Err(error) => Err((*error).clone()),
+        };
+        if entry.sender.send(scoped_event).is_err() {
+            closed.push(id);
+        }
+    }
+    if !closed.is_empty() {
+        let mut entries = registry
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        for id in closed {
+            entries.entries.remove(&id);
         }
     }
 }
@@ -358,31 +1180,47 @@ fn watch_parents(root: &AbsoluteSystemPath, watcher: &mut Backend) -> Result<(),
 }
 
 #[cfg(not(feature = "manual_recursive_watch"))]
-fn watch_recursively(root: &AbsoluteSystemPath, watcher: &mut Backend) -> Result<(), WatchError> {
+fn watch_recursively(
+    root: &AbsoluteSystemPath,
+    watcher: &mut Backend,
+    _watched: &mut HashSet<PathBuf>,
+    _repository_ignore: &RepositoryIgnore,
+) -> Result<(), WatchError> {
     watcher.watch(root.as_std_path(), RecursiveMode::Recursive)?;
     Ok(())
 }
 
-#[cfg(feature = "manual_recursive_watch")]
 fn is_not_found(err: &notify::Error) -> bool {
-    if let ErrorKind::Io(ref io_err) = err.kind {
-        io_err.kind() == io::ErrorKind::NotFound
+    if let notify::ErrorKind::Io(ref io_err) = err.kind {
+        io_err.kind() == std::io::ErrorKind::NotFound
     } else {
         false
     }
 }
 
 #[cfg(feature = "manual_recursive_watch")]
-fn watch_recursively(root: &AbsoluteSystemPath, watcher: &mut Backend) -> Result<(), WatchError> {
-    // Don't synthesize initial events
-    manually_add_recursive_watches(root.as_std_path(), watcher, None)
+fn watch_recursively(
+    root: &AbsoluteSystemPath,
+    watcher: &mut Backend,
+    watched: &mut HashSet<PathBuf>,
+    repository_ignore: &RepositoryIgnore,
+) -> Result<(), WatchError> {
+    add_ordinary_watches(
+        root.as_std_path(),
+        root.as_std_path(),
+        watcher,
+        watched,
+        None,
+        repository_ignore,
+    )
 }
 
 #[cfg(feature = "manual_recursive_watch")]
-fn manually_add_recursive_watches(
+fn add_unignored_recursive_watches(
     root: &Path,
     watcher: &mut Backend,
-    sender: Option<&broadcast::Sender<Result<Event, NotifyError>>>,
+    watched: &mut HashSet<PathBuf>,
+    _registry: Option<&SubscriptionRegistry>,
 ) -> Result<(), WatchError> {
     // Note that WalkDir yields the root as well as doing the walk.
     // filter_entry prunes entire subtrees so we never descend into
@@ -398,6 +1236,9 @@ fn manually_add_recursive_watches(
     {
         let dir = dir?;
         if dir.file_type().is_dir() {
+            if !watched.insert(dir.path().to_owned()) {
+                continue;
+            }
             trace!("manually watching {}", dir.path().display());
             match watcher.watch(dir.path(), RecursiveMode::NonRecursive) {
                 Ok(()) => {}
@@ -407,37 +1248,471 @@ fn manually_add_recursive_watches(
                 Err(e) => return Err(e.into()),
             }
         }
-        if let Some(sender) = sender.as_ref() {
-            let create_kind = if dir.file_type().is_dir() {
-                CreateKind::Folder
-            } else {
-                CreateKind::File
-            };
+    }
+    Ok(())
+}
+
+#[cfg(feature = "manual_recursive_watch")]
+fn add_ordinary_watches(
+    repo_root: &Path,
+    subtree: &Path,
+    watcher: &mut Backend,
+    watched: &mut HashSet<PathBuf>,
+    registry: Option<&SubscriptionRegistry>,
+    repository_ignore: &RepositoryIgnore,
+) -> Result<(), WatchError> {
+    let mut paths: Vec<_> = ordinary_watch_paths(repo_root, subtree, repository_ignore)?
+        .into_iter()
+        .collect();
+    paths.sort_by_key(|path| path.components().count());
+    for path in paths {
+        if !watched.insert(path.clone()) {
+            continue;
+        }
+        watcher.watch(&path, RecursiveMode::NonRecursive)?;
+        if let Some(registry) = registry {
             let event = Event {
-                paths: vec![dir.path().to_owned()],
-                kind: EventKind::Create(create_kind),
-                attrs: EventAttributes::default(),
+                paths: vec![path],
+                kind: EventKind::Create(CreateKind::Folder),
+                attrs: Default::default(),
             };
-            // It's ok if we fail to send, it means we're shutting down
-            let _ = sender.send(Ok(event));
+            route_event(registry, Ok(&event));
         }
     }
     Ok(())
 }
 
+#[cfg(feature = "manual_recursive_watch")]
+fn ordinary_watch_paths(
+    repo_root: &Path,
+    subtree: &Path,
+    repository_ignore: &RepositoryIgnore,
+) -> Result<HashSet<PathBuf>, WatchError> {
+    let subtree = subtree.to_owned();
+    let mut paths = HashSet::new();
+    for entry in WalkDir::new(repo_root).into_iter().filter_entry(|entry| {
+        let path = entry.path();
+        (subtree.starts_with(path) || path.starts_with(&subtree))
+            && !matches!(entry.file_name().to_str(), Some(".git" | "node_modules"))
+            && (path == repo_root || repository_ignore.is_relevant(path, true))
+    }) {
+        let entry = entry?;
+        if entry.file_type().is_dir() {
+            paths.insert(entry.into_path());
+        }
+    }
+    Ok(paths)
+}
+
+#[cfg(feature = "manual_recursive_watch")]
+fn reconcile_ordinary_watches(
+    repo_root: &Path,
+    cookie_dir: &Path,
+    explicit: &[PathBuf],
+    watcher: &mut Backend,
+    watched: &mut HashSet<PathBuf>,
+    repository_ignore: &RepositoryIgnore,
+) -> Result<(), WatchError> {
+    let desired = ordinary_watch_paths(repo_root, repo_root, repository_ignore)?;
+    for path in &desired {
+        if watched.insert(path.clone()) {
+            watcher.watch(path, RecursiveMode::NonRecursive)?;
+        }
+    }
+
+    let stale: Vec<_> = watched
+        .iter()
+        .filter(|path| {
+            !desired.contains(*path)
+                && !cookie_dir.starts_with(path)
+                && !path.starts_with(cookie_dir)
+                && !explicit
+                    .iter()
+                    .any(|interest| interest.starts_with(path) || path.starts_with(interest))
+                && !repository_ignore
+                    .control_paths()
+                    .iter()
+                    .any(|control| control.starts_with(path) || path.starts_with(control))
+        })
+        .cloned()
+        .collect();
+    for path in stale {
+        match watcher.unwatch(&path) {
+            Ok(()) => {
+                watched.remove(&path);
+            }
+            Err(error) if is_not_found(&error) => {
+                watched.remove(&path);
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "manual_recursive_watch")]
+fn add_explicit_watches(
+    repo_root: &Path,
+    interests: &[PathBuf],
+    watcher: &mut Backend,
+    watched: &mut HashSet<PathBuf>,
+) -> Result<(), WatchError> {
+    for path in explicit_watch_paths(repo_root, interests)? {
+        if watched.insert(path.clone()) {
+            watcher.watch(&path, RecursiveMode::NonRecursive)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "manual_recursive_watch")]
+fn explicit_watch_paths(
+    repo_root: &Path,
+    interests: &[PathBuf],
+) -> Result<HashSet<PathBuf>, WatchError> {
+    let mut paths = HashSet::new();
+    for interest in interests.iter().filter(|path| path.starts_with(repo_root)) {
+        let mut guard = interest.parent().unwrap_or(repo_root);
+        while !guard.is_dir() {
+            let Some(parent) = guard.parent() else {
+                break;
+            };
+            guard = parent;
+        }
+        if guard.starts_with(repo_root) {
+            paths.insert(guard.to_owned());
+        }
+
+        let target_is_dir = interest.is_dir();
+        let mut existing = if target_is_dir {
+            interest.as_path()
+        } else {
+            interest.parent().unwrap_or(repo_root)
+        };
+        while !existing.is_dir() {
+            let Some(parent) = existing.parent() else {
+                break;
+            };
+            existing = parent;
+        }
+        if existing.starts_with(repo_root) {
+            if target_is_dir && existing == interest {
+                for entry in WalkDir::new(existing)
+                    .follow_links(false)
+                    .into_iter()
+                    .filter_entry(|entry| {
+                        !matches!(entry.file_name().to_str(), Some(".git" | "node_modules"))
+                    })
+                {
+                    let entry = entry?;
+                    if entry.file_type().is_dir() {
+                        paths.insert(entry.into_path());
+                    }
+                }
+            } else {
+                paths.insert(existing.to_owned());
+            }
+        }
+    }
+    Ok(paths)
+}
+
+#[cfg(feature = "manual_recursive_watch")]
+fn refresh_explicit_watches(
+    repo_root: &Path,
+    cookie_dir: &Path,
+    interests: &[PathBuf],
+    watcher: &mut Backend,
+    watched: &mut HashSet<PathBuf>,
+    explicit_watched: &mut HashSet<PathBuf>,
+    repository_ignore: &RepositoryIgnore,
+) -> Result<(), WatchError> {
+    let desired = explicit_watch_paths(repo_root, interests)?;
+    for path in desired.difference(explicit_watched) {
+        if watched.insert(path.clone()) {
+            watcher.watch(path, RecursiveMode::NonRecursive)?;
+        }
+    }
+
+    let stale: Vec<_> = explicit_watched.difference(&desired).cloned().collect();
+    let controls = repository_ignore.control_paths();
+    for path in stale {
+        if !repository_ignore.is_relevant(&path, true)
+            && !cookie_dir.starts_with(&path)
+            && !path.starts_with(cookie_dir)
+            && !controls
+                .iter()
+                .any(|control| control.starts_with(&path) || path.starts_with(control))
+        {
+            match watcher.unwatch(&path) {
+                Ok(()) => {
+                    watched.remove(&path);
+                }
+                Err(error) if is_not_found(&error) => {
+                    watched.remove(&path);
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
+    }
+    *explicit_watched = desired;
+    Ok(())
+}
+
+#[cfg(feature = "manual_recursive_watch")]
+fn route_materialized_interests(
+    registry: &SubscriptionRegistry,
+    interests: &[PathBuf],
+    created: &Path,
+) {
+    let paths: Vec<_> = interests
+        .iter()
+        .filter(|interest| interest.starts_with(created) || created.starts_with(interest))
+        .filter(|interest| interest.exists())
+        .flat_map(|interest| {
+            if interest.is_dir() {
+                WalkDir::new(interest)
+                    .follow_links(false)
+                    .into_iter()
+                    .filter_map(Result::ok)
+                    .map(|entry| entry.into_path())
+                    .collect()
+            } else {
+                vec![interest.clone()]
+            }
+        })
+        .collect();
+    if paths.is_empty() {
+        return;
+    }
+    let event = Event {
+        paths,
+        kind: EventKind::Create(CreateKind::Any),
+        attrs: Default::default(),
+    };
+    route_event(registry, Ok(&event));
+}
+
 fn run_watcher(
     root: &AbsoluteSystemPath,
-    sender: mpsc::Sender<EventResult>,
-) -> Result<Backend, WatchError> {
-    let mut watcher = make_watcher(move |res| {
-        let _ = sender.blocking_send(res);
+    cookie_dir: &AbsoluteSystemPath,
+    sender: mpsc::UnboundedSender<EventResult>,
+    repository_ignore: &RepositoryIgnore,
+    #[cfg(not(feature = "manual_recursive_watch"))] backend_ready: Arc<AtomicBool>,
+    #[cfg(not(feature = "manual_recursive_watch"))] ordered_driver_delivery: Arc<AtomicBool>,
+    #[cfg(not(feature = "manual_recursive_watch"))] registry: Arc<SubscriptionRegistry>,
+) -> Result<(Backend, HashSet<PathBuf>), WatchError> {
+    #[cfg(feature = "manual_recursive_watch")]
+    let mut watcher = make_watcher(move |event| {
+        let _ = sender.send(event);
     })?;
+    #[cfg(not(feature = "manual_recursive_watch"))]
+    let mut watcher = {
+        let watch_root = root.to_owned();
+        let readiness_cookie = cookie_dir.join_component(".turbo-cookie");
+        let repository_ignore = repository_ignore.clone();
+        make_watcher(move |event| {
+            dispatch_non_mutating_backend_event(
+                &backend_ready,
+                &ordered_driver_delivery,
+                &sender,
+                &readiness_cookie,
+                &watch_root,
+                &registry,
+                &repository_ignore,
+                event,
+            );
+        })?
+    };
 
-    watch_recursively(root, &mut watcher)?;
+    let mut watched = HashSet::new();
+    watch_recursively(root, &mut watcher, &mut watched, repository_ignore)?;
+
+    add_control_watches(
+        root.as_std_path(),
+        &repository_ignore.control_paths(),
+        &mut watcher,
+        &mut watched,
+    )?;
+
+    #[cfg(feature = "manual_recursive_watch")]
+    add_unignored_recursive_watches(cookie_dir.as_std_path(), &mut watcher, &mut watched, None)?;
 
     #[cfg(feature = "watch_ancestors")]
     watch_parents(root, &mut watcher)?;
-    Ok(watcher)
+    Ok((watcher, watched))
+}
+
+#[cfg(not(feature = "manual_recursive_watch"))]
+#[allow(clippy::too_many_arguments)]
+fn dispatch_non_mutating_backend_event(
+    backend_ready: &AtomicBool,
+    ordered_driver_delivery: &AtomicBool,
+    startup_sender: &mpsc::UnboundedSender<EventResult>,
+    readiness_cookie: &AbsoluteSystemPath,
+    watch_root: &AbsoluteSystemPath,
+    registry: &SubscriptionRegistry,
+    repository_ignore: &RepositoryIgnore,
+    event: EventResult,
+) {
+    if backend_ready.load(Ordering::Acquire) && !ordered_driver_delivery.load(Ordering::Acquire) {
+        let requires_driver = event.as_ref().is_ok_and(|event| {
+            event
+                .paths
+                .iter()
+                .any(|path| repository_ignore.should_refresh(path))
+        });
+        if requires_driver {
+            // Refreshing RepositoryIgnore can spawn Git and walk the worktree.
+            // Backend callback threads only classify control events and hand
+            // them to the async driver; ordinary bursts remain direct.
+            ordered_driver_delivery.store(true, Ordering::Release);
+            let _ = startup_sender.send(event);
+        } else {
+            route_direct_non_mutating_event(watch_root, registry, event);
+        }
+    } else {
+        let establishes_readiness = event.as_ref().is_ok_and(|event| {
+            event
+                .paths
+                .iter()
+                .any(|path| path == readiness_cookie.as_std_path())
+        });
+        if startup_sender.send(event).is_ok() && establishes_readiness {
+            // Event handlers are invoked in backend order. Publishing only
+            // after the cookie is queued keeps pre-ready events on the startup
+            // channel while allowing the next callback to route directly.
+            backend_ready.store(true, Ordering::Release);
+        }
+    }
+}
+
+#[cfg(not(feature = "manual_recursive_watch"))]
+fn route_direct_non_mutating_event(
+    watch_root: &AbsoluteSystemPath,
+    registry: &SubscriptionRegistry,
+    event: EventResult,
+) {
+    match event {
+        #[allow(unused_mut)]
+        Ok(mut event) => {
+            #[cfg(feature = "watch_ancestors")]
+            filter_relevant(watch_root, &mut event);
+            #[cfg(not(feature = "watch_ancestors"))]
+            let _ = watch_root;
+            route_event(registry, Ok(&event));
+        }
+        Err(error) => route_event(registry, Err(NotifyError::from(error))),
+    }
+}
+
+fn add_control_watches(
+    repo_root: &Path,
+    controls: &[PathBuf],
+    watcher: &mut Backend,
+    watched: &mut HashSet<PathBuf>,
+) -> Result<(), WatchError> {
+    for parent in control_watch_parents(repo_root, controls) {
+        if parent.is_dir() && watched.insert(parent.to_owned()) {
+            watcher.watch(&parent, RecursiveMode::NonRecursive)?;
+        }
+    }
+    Ok(())
+}
+
+fn reconcile_control_watches(
+    repo_root: &Path,
+    previous_controls: &[PathBuf],
+    current_controls: &[PathBuf],
+    watcher: &mut Backend,
+    watched: &mut HashSet<PathBuf>,
+    is_owned_elsewhere: impl Fn(&Path) -> bool,
+) -> Result<(), WatchError> {
+    let (additions, removals) = control_watch_changes(
+        repo_root,
+        previous_controls,
+        current_controls,
+        watched,
+        is_owned_elsewhere,
+    );
+
+    for parent in additions {
+        watcher.watch(&parent, RecursiveMode::NonRecursive)?;
+        watched.insert(parent);
+    }
+    for stale in removals {
+        match watcher.unwatch(&stale) {
+            Ok(()) => {
+                watched.remove(&stale);
+            }
+            Err(error) if is_not_found(&error) => {
+                watched.remove(&stale);
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(())
+}
+
+fn control_watch_changes(
+    repo_root: &Path,
+    previous_controls: &[PathBuf],
+    current_controls: &[PathBuf],
+    watched: &HashSet<PathBuf>,
+    is_owned_elsewhere: impl Fn(&Path) -> bool,
+) -> (HashSet<PathBuf>, HashSet<PathBuf>) {
+    let previous = control_watch_parents(repo_root, previous_controls);
+    let current = control_watch_parents(repo_root, current_controls);
+    let additions = current
+        .iter()
+        .filter(|parent| parent.is_dir() && !watched.contains(*parent))
+        .cloned()
+        .collect();
+    let removals = previous
+        .difference(&current)
+        .filter(|stale| watched.contains(*stale) && !is_owned_elsewhere(stale))
+        .cloned()
+        .collect();
+    (additions, removals)
+}
+
+fn control_watch_parents(repo_root: &Path, controls: &[PathBuf]) -> HashSet<PathBuf> {
+    #[cfg(not(target_os = "macos"))]
+    let _ = repo_root;
+    controls
+        .iter()
+        .filter_map(|control| {
+            let parent = control.parent()?;
+            #[cfg(target_os = "macos")]
+            {
+                use std::os::unix::fs::MetadataExt;
+
+                let root_device = std::fs::metadata(repo_root).map(|metadata| metadata.dev());
+                let parent_device = std::fs::metadata(parent).map(|metadata| metadata.dev());
+                if matches!((root_device, parent_device), (Ok(root), Ok(parent)) if root != parent)
+                {
+                    debug!(
+                        path = %control.display(),
+                        "skipping cross-device Git control watch"
+                    );
+                    return None;
+                }
+            }
+            Some(parent.to_owned())
+        })
+        .collect()
+}
+
+#[cfg(not(feature = "manual_recursive_watch"))]
+fn non_mutating_ordinary_owner(repo_root: &Path, path: &Path) -> bool {
+    if path == repo_root {
+        return true;
+    }
+    #[cfg(feature = "watch_ancestors")]
+    if repo_root.starts_with(path) {
+        return true;
+    }
+    false
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -455,8 +1730,13 @@ fn make_watcher<F: EventHandler>(event_handler: F) -> Result<Backend, notify::Er
 /// than receiving events from existing state, which some backends can do.
 async fn wait_for_cookie(
     cookie_dir: &AbsoluteSystemPath,
-    recv: &mut mpsc::Receiver<EventResult>,
-) -> Result<(), WatchError> {
+    _watch_root: &AbsoluteSystemPath,
+    _watcher: &mut Backend,
+    recv: &mut mpsc::UnboundedReceiver<EventResult>,
+    _registry: &SubscriptionRegistry,
+    watch_control_rx: &mut mpsc::UnboundedReceiver<WatcherControl>,
+    #[allow(unused_mut)] mut watched: HashSet<PathBuf>,
+) -> Result<HashSet<PathBuf>, WatchError> {
     // TODO: should this be passed in? Currently the caller guarantees that the
     // directory is empty, but it could be the responsibility of the
     // filewatcher...
@@ -464,16 +1744,38 @@ async fn wait_for_cookie(
     cookie_path
         .create_with_contents("cookie")
         .map_err(|e| WatchError::Setup(format!("failed to write cookie to {cookie_path}: {e}")))?;
+    let deadline = tokio::time::Instant::now() + Duration::from_millis(2000);
     loop {
-        let event = tokio::time::timeout(Duration::from_millis(2000), recv.recv())
-            .await
-            .map_err(|e| WatchError::Setup(format!("waiting for cookie timed out: {e}")))?
-            .ok_or_else(|| {
-                WatchError::Setup(
-                    "filewatching closed before cookie file  was observed".to_string(),
-                )
-            })?
-            .map_err(|err| WatchError::Setup(format!("initial watch encountered errors: {err}")))?;
+        let event = tokio::select! {
+            biased;
+            control = watch_control_rx.recv() => {
+                if let Some(WatcherControl::Refresh(ack)) = control {
+                    let mut acknowledgements = ack.into_iter().collect::<Vec<_>>();
+                    while let Ok(WatcherControl::Refresh(ack)) = watch_control_rx.try_recv() {
+                        acknowledgements.extend(ack);
+                    }
+                    #[cfg(feature = "manual_recursive_watch")]
+                    add_explicit_watches(
+                        _watch_root.as_std_path(),
+                        &_registry.physical_paths(),
+                        _watcher,
+                        &mut watched,
+                    )?;
+                    for acknowledgement in acknowledgements {
+                        let _ = acknowledgement.send(());
+                    }
+                }
+                continue;
+            }
+            event = tokio::time::timeout_at(deadline, recv.recv()) => {
+                event
+                    .map_err(|e| WatchError::Setup(format!("waiting for cookie timed out: {e}")))?
+                    .ok_or_else(|| WatchError::Setup(
+                        "filewatching closed before cookie file was observed".to_string(),
+                    ))?
+                    .map_err(|err| WatchError::Setup(format!("initial watch encountered errors: {err}")))?
+            }
+        };
         if event.paths.iter().any(|path| {
             let path: &Path = path;
             path == (&cookie_path as &AbsoluteSystemPath)
@@ -483,27 +1785,291 @@ async fn wait_for_cookie(
             if let Err(e) = cookie_path.remove() {
                 warn!("failed to remove cookie file {e}");
             }
-            return Ok(());
+            return Ok(watched);
         }
     }
 }
 
 #[cfg(test)]
 mod test {
-    use std::{assert_matches, sync::atomic::AtomicUsize, time::Duration};
+    use std::{
+        assert_matches,
+        path::Path,
+        sync::{Arc, atomic::AtomicUsize},
+        time::Duration,
+    };
 
     #[cfg(not(target_os = "windows"))]
     use notify::event::RenameMode;
     use notify::{Event, EventKind, event::ModifyKind};
-    use tokio::sync::broadcast;
+    use tokio::sync::{broadcast, mpsc};
     use turbopath::{AbsoluteSystemPath, AbsoluteSystemPathBuf};
 
-    use crate::{FileSystemWatcher, NotifyError};
+    use crate::FileSystemWatcher;
 
     fn temp_dir() -> (AbsoluteSystemPathBuf, tempfile::TempDir) {
         let tmp = tempfile::tempdir().unwrap();
         let path = AbsoluteSystemPathBuf::try_from(tmp.path()).unwrap();
         (path, tmp)
+    }
+
+    #[test]
+    fn control_watch_changes_add_new_and_preserve_other_owners() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("repo");
+        let added = temp.path().join("added");
+        let removed = temp.path().join("removed");
+        let ordinary = root.clone();
+        let explicit = temp.path().join("explicit");
+        for directory in [&root, &added, &removed, &explicit] {
+            std::fs::create_dir_all(directory).unwrap();
+        }
+        let previous = [
+            removed.join("control"),
+            ordinary.join("control"),
+            explicit.join("control"),
+        ];
+        let current = [added.join("control")];
+        let watched = [removed.clone(), ordinary.clone(), explicit.clone()]
+            .into_iter()
+            .collect();
+
+        let (additions, removals) =
+            super::control_watch_changes(&root, &previous, &current, &watched, |path| {
+                path == ordinary || path == explicit
+            });
+
+        assert_eq!(additions, [added].into_iter().collect());
+        assert_eq!(removals, [removed].into_iter().collect());
+    }
+
+    #[tokio::test]
+    async fn scoped_subscription_drops_irrelevant_burst_before_channel() {
+        let (control, _control_rx) = mpsc::unbounded_channel();
+        let registry = Arc::new(super::SubscriptionRegistry::new(control));
+        let (_ready_tx, ready) = tokio::sync::watch::channel(super::SourceState::Ready);
+        let source = super::WatchSource {
+            ready,
+            registry: registry.clone(),
+            repository_ignore: None,
+        };
+        let mut subscription = source
+            .subscribe(super::WatchScope::predicate(|path| {
+                !path
+                    .components()
+                    .any(|component| component.as_os_str() == ".cache")
+            }))
+            .await
+            .unwrap();
+
+        for index in 0..30_000 {
+            let event = Event {
+                paths: vec![Path::new("repo/.cache").join(format!("output-{index}"))],
+                kind: EventKind::Create(notify::event::CreateKind::File),
+                attrs: Default::default(),
+            };
+            super::route_event(&registry, Ok(&event));
+        }
+
+        let source_path = Path::new("repo/src/index.ts").to_path_buf();
+        let event = Event {
+            paths: vec![source_path.clone()],
+            kind: EventKind::Create(notify::event::CreateKind::File),
+            attrs: Default::default(),
+        };
+        super::route_event(&registry, Ok(&event));
+
+        let received = subscription.recv().await.unwrap().unwrap();
+        assert_eq!(received.paths, vec![source_path]);
+    }
+
+    #[cfg(not(feature = "manual_recursive_watch"))]
+    #[tokio::test]
+    async fn post_ready_backend_events_route_without_bounded_channel() {
+        let (repo_root, _tmp) = temp_dir();
+        let repo_root = repo_root.to_realpath().unwrap();
+        let (control, _control_rx) = mpsc::unbounded_channel();
+        let registry = Arc::new(super::SubscriptionRegistry::new(control));
+        let (_ready_tx, ready) = tokio::sync::watch::channel(super::SourceState::Ready);
+        let source = super::WatchSource {
+            ready,
+            registry: registry.clone(),
+            repository_ignore: None,
+        };
+        let expected = repo_root.join_components(&["src", "index.ts"]);
+        let mut subscription = source
+            .subscribe(super::WatchScope::predicate({
+                let expected = expected.clone();
+                move |path| path == expected.as_std_path()
+            }))
+            .await
+            .unwrap();
+        let (startup_sender, mut startup_receiver) = mpsc::unbounded_channel();
+        let backend_ready = std::sync::atomic::AtomicBool::new(true);
+        let ordered_driver_delivery = std::sync::atomic::AtomicBool::new(false);
+        let repository_ignore = super::RepositoryIgnore::new(repo_root.as_std_path());
+
+        for index in 0..30_000 {
+            super::dispatch_non_mutating_backend_event(
+                &backend_ready,
+                &ordered_driver_delivery,
+                &startup_sender,
+                &repo_root.join_components(&[".turbo", "cookies", ".turbo-cookie"]),
+                &repo_root,
+                &registry,
+                &repository_ignore,
+                Ok(
+                    Event::new(EventKind::Create(notify::event::CreateKind::File)).add_path(
+                        repo_root
+                            .join_components(&[".cache", &format!("output-{index}")])
+                            .as_std_path()
+                            .to_owned(),
+                    ),
+                ),
+            );
+        }
+        super::dispatch_non_mutating_backend_event(
+            &backend_ready,
+            &ordered_driver_delivery,
+            &startup_sender,
+            &repo_root.join_components(&[".turbo", "cookies", ".turbo-cookie"]),
+            &repo_root,
+            &registry,
+            &repository_ignore,
+            Ok(
+                Event::new(EventKind::Create(notify::event::CreateKind::File))
+                    .add_path(expected.as_std_path().to_owned()),
+            ),
+        );
+
+        assert!(startup_receiver.try_recv().is_err());
+        let event = subscription.recv().await.unwrap().unwrap();
+        assert_eq!(event.paths, vec![expected.as_std_path().to_owned()]);
+    }
+
+    #[cfg(not(feature = "manual_recursive_watch"))]
+    #[test]
+    fn post_ready_ignore_events_are_deferred_to_driver() {
+        let (repo_root, _tmp) = temp_dir();
+        let repo_root = repo_root.to_realpath().unwrap();
+        let (control, _control_rx) = mpsc::unbounded_channel();
+        let registry = Arc::new(super::SubscriptionRegistry::new(control));
+        let (startup_sender, mut startup_receiver) = mpsc::unbounded_channel();
+        let backend_ready = std::sync::atomic::AtomicBool::new(true);
+        let ordered_driver_delivery = std::sync::atomic::AtomicBool::new(false);
+        let repository_ignore = super::RepositoryIgnore::new(repo_root.as_std_path());
+        let gitignore = repo_root.join_component(".gitignore");
+
+        super::dispatch_non_mutating_backend_event(
+            &backend_ready,
+            &ordered_driver_delivery,
+            &startup_sender,
+            &repo_root.join_components(&[".turbo", "cookies", ".turbo-cookie"]),
+            &repo_root,
+            &registry,
+            &repository_ignore,
+            Ok(Event::new(EventKind::Modify(ModifyKind::Any))
+                .add_path(gitignore.as_std_path().to_owned())),
+        );
+
+        let queued = startup_receiver.try_recv().unwrap().unwrap();
+        assert_eq!(queued.paths, vec![gitignore.as_std_path().to_owned()]);
+
+        let source = repo_root.join_components(&["src", "index.ts"]);
+        super::dispatch_non_mutating_backend_event(
+            &backend_ready,
+            &ordered_driver_delivery,
+            &startup_sender,
+            &repo_root.join_components(&[".turbo", "cookies", ".turbo-cookie"]),
+            &repo_root,
+            &registry,
+            &repository_ignore,
+            Ok(Event::new(EventKind::Modify(ModifyKind::Any))
+                .add_path(source.as_std_path().to_owned())),
+        );
+        let queued = startup_receiver.try_recv().unwrap().unwrap();
+        assert_eq!(queued.paths, vec![source.as_std_path().to_owned()]);
+    }
+
+    #[cfg(feature = "manual_recursive_watch")]
+    #[tokio::test]
+    async fn fatal_driver_failure_reaches_subscriber_before_close() {
+        let (control, _control_rx) = mpsc::unbounded_channel();
+        let registry = Arc::new(super::SubscriptionRegistry::new(control));
+        let (_ready_tx, ready) = tokio::sync::watch::channel(super::SourceState::Ready);
+        let source = super::WatchSource {
+            ready,
+            registry: registry.clone(),
+            repository_ignore: None,
+        };
+        let mut subscription = source.subscribe(super::WatchScope::all()).await.unwrap();
+
+        super::route_fatal_driver_error(
+            &registry,
+            "failed to reconcile filesystem watches",
+            &super::WatchError::Setup("injected failure".to_string()),
+        );
+        registry.close();
+
+        let error = subscription.recv().await.unwrap().unwrap_err();
+        assert!(!error.is_invalidation());
+        assert!(error.to_string().contains("injected failure"));
+    }
+
+    #[tokio::test]
+    async fn rescan_events_bypass_subscription_scopes() {
+        let (sender, source) = super::WatchSource::channel();
+        let mut first = source
+            .subscribe(super::WatchScope::predicate(|path| path.ends_with("first")))
+            .await
+            .unwrap();
+        let mut second = source
+            .subscribe(super::WatchScope::predicate(|path| {
+                path.ends_with("second")
+            }))
+            .await
+            .unwrap();
+        sender
+            .send(Ok(Event::new(EventKind::Other)
+                .set_flag(notify::event::Flag::Rescan)
+                .add_path(Path::new("outside-both-scopes").to_path_buf())))
+            .unwrap();
+
+        assert!(first.recv().await.unwrap().is_err());
+        assert!(second.recv().await.unwrap().is_err());
+    }
+
+    #[tokio::test]
+    async fn dropping_scoped_subscription_unregisters_it() {
+        let (control, _control_rx) = mpsc::unbounded_channel();
+        let registry = Arc::new(super::SubscriptionRegistry::new(control));
+        let (_ready_tx, ready) = tokio::sync::watch::channel(super::SourceState::Ready);
+        let source = super::WatchSource {
+            ready,
+            registry: registry.clone(),
+            repository_ignore: None,
+        };
+        let subscription = source.subscribe(super::WatchScope::all()).await.unwrap();
+        assert_eq!(
+            registry
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .entries
+                .len(),
+            1
+        );
+
+        drop(subscription);
+
+        assert!(
+            registry
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .entries
+                .is_empty()
+        );
     }
 
     macro_rules! expect_filesystem_event {
@@ -527,10 +2093,7 @@ mod test {
 
     static WATCH_COUNT: AtomicUsize = AtomicUsize::new(0);
 
-    async fn expect_watching(
-        recv: &mut broadcast::Receiver<Result<Event, NotifyError>>,
-        dirs: &[&AbsoluteSystemPath],
-    ) {
+    async fn expect_watching(recv: &mut super::WatchSubscription, dirs: &[&AbsoluteSystemPath]) {
         for dir in dirs {
             let count = WATCH_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             let filename = dir.join_component(format!("test-{count}").as_str());
@@ -931,7 +2494,7 @@ mod test {
     // Verify that node_modules and .git are excluded from inotify watch
     // registration on Linux to avoid exhausting the OS watch limit in large
     // monorepos. No .gitignore is needed — these are hardcoded exclusions.
-    #[cfg(feature = "manual_recursive_watch")]
+    #[cfg(all(feature = "manual_recursive_watch", not(target_os = "macos")))]
     #[tokio::test]
     async fn test_file_watching_hardcoded_exclusions() {
         let (repo_root, _tmp_repo_root) = temp_dir();
@@ -994,6 +2557,183 @@ mod test {
         }
     }
 
+    #[cfg(all(feature = "manual_recursive_watch", not(target_os = "macos")))]
+    async fn assert_unseen_before_sentinel(
+        recv: &mut super::WatchSubscription,
+        unseen: &AbsoluteSystemPath,
+        sentinel: &AbsoluteSystemPath,
+    ) {
+        loop {
+            let event = tokio::time::timeout(Duration::from_secs(3), recv.recv())
+                .await
+                .expect("timed out waiting for sentinel")
+                .expect("watch source closed")
+                .expect("filewatching error");
+            assert!(
+                event.paths.iter().all(|path| !path.starts_with(unseen)),
+                "received event from physically pruned tree: {:?}",
+                event.paths
+            );
+            if event.paths.iter().any(|path| path == sentinel) {
+                return;
+            }
+        }
+    }
+
+    #[cfg(all(feature = "manual_recursive_watch", not(target_os = "macos")))]
+    #[tokio::test]
+    async fn ignored_startup_tree_is_not_watched() {
+        let (repo_root, _tmp) = temp_dir();
+        let repo_root = repo_root.to_realpath().unwrap();
+        repo_root
+            .join_component(".gitignore")
+            .create_with_contents("ignored/\n")
+            .unwrap();
+        let ignored = repo_root.join_components(&["ignored", "nested"]);
+        ignored.create_dir_all().unwrap();
+
+        let watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root).unwrap();
+        let mut recv = watcher.subscribe().await.unwrap();
+        let unseen = ignored.join_component("file");
+        unseen.create_with_contents("ignored").unwrap();
+        let sentinel = repo_root.join_component("sentinel");
+        sentinel.create_with_contents("seen").unwrap();
+        assert_unseen_before_sentinel(&mut recv, &unseen, &sentinel).await;
+    }
+
+    #[cfg(all(feature = "manual_recursive_watch", not(target_os = "macos")))]
+    #[tokio::test]
+    async fn explicit_ignored_interest_is_watched() {
+        let (repo_root, _tmp) = temp_dir();
+        let repo_root = repo_root.to_realpath().unwrap();
+        repo_root
+            .join_component(".gitignore")
+            .create_with_contents("ignored/\n")
+            .unwrap();
+        let ignored = repo_root.join_component("ignored");
+        ignored.create_dir_all().unwrap();
+
+        let watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root).unwrap();
+        let interest = super::WatchInterest::new();
+        interest.replace([ignored.as_std_path().to_owned()]);
+        let mut recv = watcher
+            .source()
+            .subscribe(super::WatchScope::all().with_physical_interest(interest.clone()))
+            .await
+            .unwrap();
+        interest.flush().await;
+
+        let file = ignored.join_component("output");
+        file.create_with_contents("watched").unwrap();
+        expect_filesystem_event!(recv, file, EventKind::Create(_));
+    }
+
+    #[cfg(all(feature = "manual_recursive_watch", not(target_os = "macos")))]
+    #[tokio::test]
+    async fn nonexistent_explicit_interest_is_watched_after_creation() {
+        let (repo_root, _tmp) = temp_dir();
+        let repo_root = repo_root.to_realpath().unwrap();
+        repo_root
+            .join_component(".gitignore")
+            .create_with_contents("ignored/\n")
+            .unwrap();
+        let future_dir = repo_root.join_components(&["ignored", "generated", "deep"]);
+
+        let watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root).unwrap();
+        let interest = super::WatchInterest::new();
+        interest.replace([future_dir.as_std_path().to_owned()]);
+        let mut recv = watcher
+            .source()
+            .subscribe(super::WatchScope::all().with_physical_interest(interest.clone()))
+            .await
+            .unwrap();
+        interest.flush().await;
+
+        future_dir.create_dir_all().unwrap();
+        let file = future_dir.join_component("input");
+        file.create_with_contents("watched").unwrap();
+        expect_filesystem_event!(recv, file, EventKind::Create(_));
+    }
+
+    #[cfg(all(feature = "manual_recursive_watch", not(target_os = "macos")))]
+    #[tokio::test]
+    async fn existing_ignored_interest_is_watched_after_recreation() {
+        let (repo_root, _tmp) = temp_dir();
+        let repo_root = repo_root.to_realpath().unwrap();
+        repo_root
+            .join_component(".gitignore")
+            .create_with_contents("ignored/\n")
+            .unwrap();
+        let ignored = repo_root.join_component("ignored");
+        ignored.create_dir_all().unwrap();
+
+        let watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root).unwrap();
+        let interest = super::WatchInterest::new();
+        interest.replace([ignored.as_std_path().to_owned()]);
+        let mut recv = watcher
+            .source()
+            .subscribe(super::WatchScope::all().with_physical_interest(interest.clone()))
+            .await
+            .unwrap();
+        interest.flush().await;
+
+        ignored.remove_dir_all().unwrap();
+        expect_filesystem_event!(recv, ignored, EventKind::Remove(_));
+        ignored.create_dir_all().unwrap();
+        let file = ignored.join_component("recreated-output");
+        file.create_with_contents("watched").unwrap();
+        expect_filesystem_event!(recv, file, EventKind::Create(_));
+    }
+
+    #[cfg(all(feature = "manual_recursive_watch", not(target_os = "macos")))]
+    #[tokio::test]
+    async fn newly_created_uninterested_ignored_dir_is_not_recursed() {
+        let (repo_root, _tmp) = temp_dir();
+        let repo_root = repo_root.to_realpath().unwrap();
+        repo_root
+            .join_component(".gitignore")
+            .create_with_contents("ignored/\n")
+            .unwrap();
+        let watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root).unwrap();
+        let mut recv = watcher.subscribe().await.unwrap();
+
+        let ignored = repo_root.join_components(&["ignored", "nested"]);
+        ignored.create_dir_all().unwrap();
+        let unseen = ignored.join_component("file");
+        unseen.create_with_contents("ignored").unwrap();
+        let sentinel = repo_root.join_component("sentinel");
+        sentinel.create_with_contents("seen").unwrap();
+        assert_unseen_before_sentinel(&mut recv, &unseen, &sentinel).await;
+    }
+
+    #[cfg(all(feature = "manual_recursive_watch", not(target_os = "macos")))]
+    #[tokio::test]
+    async fn gitignore_changes_reconcile_physical_watches() {
+        let (repo_root, _tmp) = temp_dir();
+        let repo_root = repo_root.to_realpath().unwrap();
+        let gitignore = repo_root.join_component(".gitignore");
+        gitignore.create_with_contents("ignored/\n").unwrap();
+        let ignored = repo_root.join_component("ignored");
+        ignored.create_dir_all().unwrap();
+
+        let watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root).unwrap();
+        let mut recv = watcher.subscribe().await.unwrap();
+
+        gitignore.create_with_contents("").unwrap();
+        expect_filesystem_event!(recv, gitignore, EventKind::Modify(_));
+        let newly_visible = ignored.join_component("visible");
+        newly_visible.create_with_contents("visible").unwrap();
+        expect_filesystem_event!(recv, newly_visible, EventKind::Create(_));
+
+        gitignore.create_with_contents("ignored/\n").unwrap();
+        expect_filesystem_event!(recv, gitignore, EventKind::Modify(_));
+        let newly_hidden = ignored.join_component("hidden");
+        newly_hidden.create_with_contents("hidden").unwrap();
+        let sentinel = repo_root.join_component("sentinel-after-reignore");
+        sentinel.create_with_contents("seen").unwrap();
+        assert_unseen_before_sentinel(&mut recv, &newly_hidden, &sentinel).await;
+    }
+
     #[tokio::test]
     async fn test_close() {
         let (repo_root, _tmp_repo_root) = temp_dir();
@@ -1017,5 +2757,33 @@ mod test {
         })
         .await
         .unwrap();
+    }
+
+    #[tokio::test]
+    async fn scoped_subscription_closes_with_watcher() {
+        let (repo_root, _tmp_repo_root) = temp_dir();
+        let repo_root = repo_root.to_realpath().unwrap();
+
+        let watcher = FileSystemWatcher::new_with_default_cookie_dir(&repo_root).unwrap();
+        let source = watcher.source();
+        let mut subscription = source.subscribe(super::WatchScope::all()).await.unwrap();
+        drop(watcher);
+
+        tokio::time::timeout(Duration::from_millis(100), async {
+            loop {
+                if matches!(
+                    subscription.recv().await,
+                    Err(broadcast::error::RecvError::Closed)
+                ) {
+                    break;
+                }
+            }
+        })
+        .await
+        .unwrap();
+        assert!(matches!(
+            source.subscribe(super::WatchScope::all()).await,
+            Err(super::SubscribeError::Closed)
+        ));
     }
 }

--- a/crates/turborepo-filewatch/src/lib.rs
+++ b/crates/turborepo-filewatch/src/lib.rs
@@ -411,10 +411,7 @@ impl WatchEventSender {
                     .paths
                     .iter()
                     .any(|path| repository_ignore.should_refresh(path));
-                if refresh {
-                    repository_ignore.refresh();
-                }
-                invalidates
+                invalidates || (refresh && repository_ignore.refresh())
             } else {
                 false
             };
@@ -860,12 +857,12 @@ async fn watch_events(
                             .any(|path| repository_ignore.should_refresh(path));
                         let previous_controls = repository_state_changed
                             .then(|| repository_ignore.control_paths());
-                        let git_control_changed = event
+                        let mut git_control_changed = event
                             .paths
                             .iter()
                             .any(|path| repository_ignore.invalidates_consumers(path));
                         if repository_state_changed {
-                            repository_ignore.refresh();
+                            git_control_changed |= repository_ignore.refresh();
                         }
                         // Note that we need to filter relevant events
                         // before doing manual recursive watching so that
@@ -1032,13 +1029,13 @@ fn route_non_mutating_backend_event(
                 .paths
                 .iter()
                 .any(|path| repository_ignore.should_refresh(path));
-            let git_control_changed = event
+            let mut git_control_changed = event
                 .paths
                 .iter()
                 .any(|path| repository_ignore.invalidates_consumers(path));
             if repository_state_changed {
                 let previous_controls = repository_ignore.control_paths();
-                repository_ignore.refresh();
+                git_control_changed |= repository_ignore.refresh();
                 reconcile_control_watches(
                     watch_root.as_std_path(),
                     &previous_controls,
@@ -1683,6 +1680,9 @@ fn control_watch_parents(repo_root: &Path, controls: &[PathBuf]) -> HashSet<Path
         .iter()
         .filter_map(|control| {
             let parent = control.parent()?;
+            if !cfg!(feature = "manual_recursive_watch") && parent.starts_with(repo_root) {
+                return None;
+            }
             #[cfg(target_os = "macos")]
             {
                 use std::os::unix::fs::MetadataExt;

--- a/crates/turborepo-filewatch/src/package_watcher.rs
+++ b/crates/turborepo-filewatch/src/package_watcher.rs
@@ -5,7 +5,7 @@ use std::{
     collections::HashMap,
     path::Path,
     sync::{
-        Arc,
+        Arc, RwLock,
         atomic::{AtomicUsize, Ordering},
     },
     time::Duration,
@@ -32,16 +32,15 @@ use turborepo_repository::{
 };
 
 use crate::{
-    NotifyError,
+    SubscribeError, WatchScope, WatchSource, WatchSubscription,
     cookies::{CookieRegister, CookieWriter, CookiedOptionalWatch},
     debouncer::Debouncer,
-    optional_watch::OptionalWatch,
 };
 
 #[derive(Debug, Error)]
 enum PackageWatcherProcessError {
     #[error("filewatching not available, so package watching is not available")]
-    Filewatching(watch::error::RecvError),
+    Filewatching(SubscribeError),
     #[error("filewatching closed, package watching no longer available")]
     FilewatchingClosed(broadcast::error::RecvError),
 }
@@ -87,14 +86,23 @@ impl PackageWatcher {
     /// to populate the state before we can watch.
     pub fn new(
         root: AbsoluteSystemPathBuf,
-        recv: OptionalWatch<broadcast::Receiver<Result<Event, NotifyError>>>,
+        source: impl Into<WatchSource>,
         cookie_writer: CookieWriter,
         allow_no_package_manager: bool,
     ) -> Result<Self, package_manager::Error> {
+        let source = source.into();
         let (exit_tx, exit_rx) = oneshot::channel();
-        let subscriber = Subscriber::new(root, cookie_writer, allow_no_package_manager)?;
+        let repository_ignore = source
+            .repository_ignore()
+            .unwrap_or_else(|| crate::RepositoryIgnore::new(root.as_std_path()));
+        let subscriber = Subscriber::new(
+            root,
+            cookie_writer,
+            allow_no_package_manager,
+            repository_ignore,
+        )?;
         let package_discovery_lazy = subscriber.package_discovery();
-        let handle = tokio::spawn(subscriber.watch(exit_rx, recv));
+        let handle = tokio::spawn(subscriber.watch(exit_rx, source));
         Ok(Self {
             _exit_tx: exit_tx,
             _handle: handle,
@@ -141,6 +149,8 @@ struct Subscriber {
     repo_root: AbsoluteSystemPathBuf,
     // This is the list of paths that will trigger rediscovering everything.
     invalidation_paths: Vec<AbsoluteSystemPathBuf>,
+    watch_scope: WatchScope,
+    workspace_globs: Arc<RwLock<Option<WorkspaceGlobs>>>,
 
     package_discovery_tx: watch::Sender<Option<DiscoveryData>>,
     package_discovery_lazy: CookiedOptionalWatch<DiscoveryData, ()>,
@@ -198,16 +208,57 @@ impl Subscriber {
         repo_root: AbsoluteSystemPathBuf,
         writer: CookieWriter,
         allow_no_package_manager: bool,
+        repository_ignore: crate::RepositoryIgnore,
     ) -> Result<Self, package_manager::Error> {
+        let cookie_root = writer.root().to_owned();
         let (package_discovery_tx, cookie_tx, package_discovery_lazy) =
             CookiedOptionalWatch::new(writer);
         let invalidation_paths = INVALIDATION_PATHS
             .iter()
             .map(|p| repo_root.join_component(p))
-            .collect();
+            .collect::<Vec<_>>();
+        let workspace_globs = Arc::new(RwLock::new(None::<WorkspaceGlobs>));
+        let watch_scope = {
+            let repo_root = repo_root.clone();
+            let invalidation_paths = invalidation_paths.clone();
+            let workspace_globs = workspace_globs.clone();
+            WatchScope::predicate(move |path| {
+                if invalidation_paths
+                    .iter()
+                    .any(|invalidation_path| path == invalidation_path.as_std_path())
+                    || path.starts_with(cookie_root.as_std_path())
+                {
+                    return true;
+                }
+
+                let Ok(path) = AbsoluteSystemPath::from_std_path(path) else {
+                    return false;
+                };
+                let workspace_path = if path.file_name() == Some("package.json") {
+                    let Some(parent) = path.parent() else {
+                        return false;
+                    };
+                    parent
+                } else {
+                    path
+                };
+                let workspace_globs = workspace_globs
+                    .read()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                let Some(globs) = workspace_globs.as_ref() else {
+                    return path.file_name() == Some("package.json")
+                        && repository_ignore.is_relevant(path.as_std_path(), false);
+                };
+                globs
+                    .target_is_workspace(&repo_root, workspace_path)
+                    .unwrap_or(false)
+            })
+        };
         Ok(Self {
             repo_root,
             invalidation_paths,
+            watch_scope,
+            workspace_globs,
             package_discovery_tx,
             package_discovery_lazy,
             cookie_tx,
@@ -244,13 +295,10 @@ impl Subscriber {
         (version, debouncer)
     }
 
-    async fn watch_process(
-        mut self,
-        mut recv: OptionalWatch<broadcast::Receiver<Result<Event, NotifyError>>>,
-    ) -> PackageWatcherProcessError {
+    async fn watch_process(mut self, source: WatchSource) -> PackageWatcherProcessError {
         tracing::debug!("starting package watcher");
-        let mut recv = match recv.get().await {
-            Ok(r) => r.resubscribe(),
+        let mut recv: WatchSubscription = match source.subscribe(self.watch_scope.clone()).await {
+            Ok(subscription) => subscription,
             Err(e) => return PackageWatcherProcessError::Filewatching(e),
         };
 
@@ -298,18 +346,15 @@ impl Subscriber {
             // we may have a higher version number, at which point we would
             // ignore this update, as we know it is stale.
             if package_result.version == *version {
+                self.update_workspace_globs(&package_result.state);
                 self.write_state(&package_result.state);
                 *state = State::Ready(Box::new(package_result.state));
             }
         }
     }
 
-    async fn watch(
-        self,
-        exit_rx: oneshot::Receiver<()>,
-        recv: OptionalWatch<broadcast::Receiver<Result<Event, NotifyError>>>,
-    ) {
-        let process = tokio::spawn(self.watch_process(recv));
+    async fn watch(self, exit_rx: oneshot::Receiver<()>, source: WatchSource) {
+        let process = tokio::spawn(self.watch_process(source));
         tokio::select! {
             biased;
             _ = exit_rx => {
@@ -327,6 +372,17 @@ impl Subscriber {
 
     fn package_discovery(&self) -> CookiedOptionalWatch<DiscoveryData, ()> {
         self.package_discovery_lazy.clone()
+    }
+
+    fn update_workspace_globs(&self, state: &PackageState) {
+        let globs = match state {
+            PackageState::ValidWorkspaces { filter, .. } => Some((**filter).clone()),
+            PackageState::NoPackageManager(_) | PackageState::InvalidGlobs(_) => None,
+        };
+        *self
+            .workspace_globs
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = globs;
     }
 
     fn path_invalidates_everything(&self, path: &Path) -> bool {

--- a/crates/turborepo-filewatch/src/repository_ignore.rs
+++ b/crates/turborepo-filewatch/src/repository_ignore.rs
@@ -21,6 +21,7 @@ pub struct RepositoryIgnore {
     match_root: Arc<PathBuf>,
     snapshot: Arc<RwLock<Snapshot>>,
     control_paths: Arc<RwLock<HashSet<PathBuf>>>,
+    index_path: Arc<RwLock<Option<PathBuf>>>,
 }
 
 #[derive(Default)]
@@ -53,6 +54,7 @@ impl RepositoryIgnore {
             match_root,
             snapshot: Arc::new(RwLock::new(snapshot)),
             control_paths: Arc::new(RwLock::new(control_paths)),
+            index_path: Arc::new(RwLock::new(context.index)),
         }
     }
 
@@ -61,7 +63,7 @@ impl RepositoryIgnore {
     }
 
     /// Re-read repository ignore rules and tracked index state.
-    pub fn refresh(&self) {
+    pub fn refresh(&self) -> bool {
         // Re-discovering the context makes an explicit refresh observe changes
         // to core.excludesFile as well as changes to the exclude file itself.
         let context = GitContext::discover(&self.match_root);
@@ -72,9 +74,22 @@ impl RepositoryIgnore {
             context.control_paths(&self.match_root);
         let replacement = Snapshot::load(&self.match_root, &context);
         *self
+            .index_path
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = context.index;
+        let mut snapshot = self
             .snapshot
             .write()
-            .unwrap_or_else(|poisoned| poisoned.into_inner()) = replacement;
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let tracked_relevance_changed = snapshot
+            .tracked
+            .symmetric_difference(&replacement.tracked)
+            .any(|path| {
+                snapshot.path_is_ignored(&self.match_root, path, false)
+                    || replacement.path_is_ignored(&self.match_root, path, false)
+            });
+        *snapshot = replacement;
+        tracked_relevance_changed
     }
 
     pub fn is_gitignore(path: &Path) -> bool {
@@ -108,7 +123,13 @@ impl RepositoryIgnore {
     /// so it must invalidate every consumer.
     pub fn invalidates_consumers(&self, path: &Path) -> bool {
         if self.is_control_path(path) {
-            return true;
+            let path = normalize_event_path(&self.root, &self.match_root, path);
+            return self
+                .index_path
+                .read()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .as_ref()
+                != Some(&path);
         }
         if !Self::is_gitignore(path) {
             return false;
@@ -361,6 +382,22 @@ impl Snapshot {
         }
         false
     }
+
+    fn path_is_ignored(&self, turbo_root: &Path, relative: &Path, is_dir: bool) -> bool {
+        if self.is_ignored(turbo_root, turbo_root, true) {
+            return true;
+        }
+        let mut candidate = turbo_root.to_path_buf();
+        let components = relative.components().collect::<Vec<_>>();
+        for (index, component) in components.iter().enumerate() {
+            candidate.push(component.as_os_str());
+            let candidate_is_dir = index + 1 != components.len() || is_dir;
+            if self.is_ignored(&candidate, turbo_root, candidate_is_dir) {
+                return true;
+            }
+        }
+        false
+    }
 }
 
 fn build_matcher(base: &Path, path: &Path) -> Option<Arc<Gitignore>> {
@@ -591,6 +628,26 @@ mod tests {
         let controls = model.control_paths();
         assert!(!controls.contains(&fs::canonicalize(&global).unwrap()));
         assert!(controls.contains(&fs::canonicalize(&replacement_global).unwrap()));
+    }
+
+    #[test]
+    fn index_refresh_invalidates_only_when_ignore_relevance_changes() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        git(root, &["init", "-q"]);
+        fs::write(root.join(".gitignore"), "ignored.txt\n").unwrap();
+        fs::write(root.join("visible.txt"), "visible").unwrap();
+        fs::write(root.join("ignored.txt"), "ignored").unwrap();
+
+        let model = RepositoryIgnore::new(root);
+        git(root, &["add", "visible.txt"]);
+        assert!(!model.refresh(), "tracking an unignored path is irrelevant");
+
+        git(root, &["add", "-f", "ignored.txt"]);
+        assert!(
+            model.refresh(),
+            "tracking an ignored path changes relevance"
+        );
     }
 
     #[test]

--- a/crates/turborepo-filewatch/src/repository_ignore.rs
+++ b/crates/turborepo-filewatch/src/repository_ignore.rs
@@ -1,0 +1,657 @@
+#[cfg(unix)]
+use std::ffi::OsString;
+use std::{
+    collections::{HashMap, HashSet},
+    fs,
+    path::{Component, Path, PathBuf},
+    process::Command,
+    sync::{Arc, RwLock},
+};
+
+use ignore::{Match, gitignore::Gitignore};
+use tracing::warn;
+
+/// A repository-wide, immutable-at-read-time view of Git's ignore rules.
+///
+/// Refreshes build a new snapshot and swap it under one `RwLock`; event-path
+/// checks only take a read lock and never touch the filesystem or spawn Git.
+#[derive(Clone)]
+pub struct RepositoryIgnore {
+    root: Arc<PathBuf>,
+    match_root: Arc<PathBuf>,
+    snapshot: Arc<RwLock<Snapshot>>,
+    control_paths: Arc<RwLock<HashSet<PathBuf>>>,
+}
+
+#[derive(Default)]
+struct Snapshot {
+    worktree_root: PathBuf,
+    matchers: HashMap<PathBuf, Arc<Gitignore>>,
+    info_exclude: Option<Arc<Gitignore>>,
+    global_exclude: Option<Arc<Gitignore>>,
+    tracked: HashSet<PathBuf>,
+    tracked_ancestors: HashSet<PathBuf>,
+}
+
+#[derive(Clone)]
+struct GitContext {
+    worktree_root: PathBuf,
+    index: Option<PathBuf>,
+    info_exclude: Option<PathBuf>,
+    global_exclude: Option<PathBuf>,
+}
+
+impl RepositoryIgnore {
+    pub fn new(root: &Path) -> Self {
+        let root = Arc::new(normalize_lexically(root));
+        let match_root = Arc::new(normalize_path(&root));
+        let context = GitContext::discover(&match_root);
+        let control_paths = context.control_paths(&match_root);
+        let snapshot = Snapshot::load(&match_root, &context);
+        Self {
+            root,
+            match_root,
+            snapshot: Arc::new(RwLock::new(snapshot)),
+            control_paths: Arc::new(RwLock::new(control_paths)),
+        }
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Re-read repository ignore rules and tracked index state.
+    pub fn refresh(&self) {
+        // Re-discovering the context makes an explicit refresh observe changes
+        // to core.excludesFile as well as changes to the exclude file itself.
+        let context = GitContext::discover(&self.match_root);
+        *self
+            .control_paths
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) =
+            context.control_paths(&self.match_root);
+        let replacement = Snapshot::load(&self.match_root, &context);
+        *self
+            .snapshot
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = replacement;
+    }
+
+    pub fn is_gitignore(path: &Path) -> bool {
+        path.file_name().is_some_and(|name| name == ".gitignore")
+    }
+
+    pub fn should_refresh(&self, path: &Path) -> bool {
+        Self::is_gitignore(path)
+            || self
+                .control_paths
+                .read()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .contains(&normalize_event_path(&self.root, &self.match_root, path))
+    }
+
+    pub fn is_control_path(&self, path: &Path) -> bool {
+        !Self::is_gitignore(path)
+            && self
+                .control_paths
+                .read()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .contains(&normalize_event_path(&self.root, &self.match_root, path))
+    }
+
+    /// Returns whether changing `path` requires conservative invalidation.
+    ///
+    /// Ignore files inside the Turbo root are ordinary filesystem inputs: once
+    /// the snapshot is refreshed, consumers can apply their normal scoped
+    /// semantics to the event. An inherited ignore file cannot be represented
+    /// by an in-root event (and may change the relevance of the root itself),
+    /// so it must invalidate every consumer.
+    pub fn invalidates_consumers(&self, path: &Path) -> bool {
+        if self.is_control_path(path) {
+            return true;
+        }
+        if !Self::is_gitignore(path) {
+            return false;
+        }
+        let path = normalize_event_path(&self.root, &self.match_root, path);
+        !path.starts_with(self.match_root.as_path())
+    }
+
+    pub fn control_paths(&self) -> Vec<PathBuf> {
+        self.control_paths
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .iter()
+            .cloned()
+            .collect()
+    }
+
+    /// Returns whether a path should participate in default Git-aware inputs.
+    /// Explicit input globs should be checked before this method.
+    pub fn is_relevant(&self, path: &Path, is_dir: bool) -> bool {
+        let path = normalize_event_path(&self.root, &self.match_root, path);
+        let Ok(relative) = path.strip_prefix(self.match_root.as_path()) else {
+            return false;
+        };
+        if relative
+            .components()
+            .any(|component| component.as_os_str() == ".git")
+        {
+            return false;
+        }
+        if Self::is_gitignore(&path) {
+            return true;
+        }
+
+        let snapshot = self
+            .snapshot
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if snapshot.tracked.contains(relative)
+            || (is_dir && snapshot.tracked_ancestors.contains(relative))
+        {
+            return true;
+        }
+
+        // A parent .gitignore may ignore the Turbo root itself. Git cannot
+        // re-include anything below an ignored directory, so check the root and
+        // then every descendant ancestor in order.
+        if snapshot.is_ignored(self.match_root.as_path(), self.match_root.as_path(), true) {
+            return false;
+        }
+        let mut candidate = self.match_root.as_path().to_path_buf();
+        let components = relative.components().collect::<Vec<_>>();
+        for (index, component) in components.iter().enumerate() {
+            candidate.push(component.as_os_str());
+            let candidate_is_dir = index + 1 != components.len() || is_dir;
+            if snapshot.is_ignored(&candidate, self.match_root.as_path(), candidate_is_dir) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl GitContext {
+    fn discover(root: &Path) -> Self {
+        let worktree_root = command_path(root, &["rev-parse", "--show-toplevel"], false, root)
+            .unwrap_or_else(|| root.to_path_buf());
+        let index = git_path(root, "index");
+        let info_exclude = git_path(root, "info/exclude");
+        let discovered_global_exclude = command_path(
+            root,
+            &["config", "--path", "--null", "--get", "core.excludesFile"],
+            true,
+            &worktree_root,
+        );
+        #[cfg(target_os = "macos")]
+        let global_exclude = discovered_global_exclude.and_then(|exclude| {
+            if paths_share_device(root, &exclude) {
+                Some(exclude)
+            } else {
+                warn!(
+                    path = %exclude.display(),
+                    "ignoring cross-device global excludes because changes cannot be watched"
+                );
+                None
+            }
+        });
+        #[cfg(not(target_os = "macos"))]
+        let global_exclude = discovered_global_exclude;
+        Self {
+            worktree_root,
+            index,
+            info_exclude,
+            global_exclude,
+        }
+    }
+
+    fn control_paths(&self, root: &Path) -> HashSet<PathBuf> {
+        let mut paths = HashSet::new();
+        paths.extend(self.index.iter().cloned());
+        paths.extend(self.info_exclude.iter().cloned());
+        paths.extend(self.global_exclude.iter().cloned());
+        // These files can change core.excludesFile. They are also useful
+        // controls in linked worktrees, where the administrative directory is
+        // outside the worktree.
+        paths.extend(git_path(root, "config"));
+        paths.extend(git_path(root, "config.worktree"));
+        paths.extend(
+            directories_between(&self.worktree_root, root)
+                .into_iter()
+                .map(|directory| directory.join(".gitignore")),
+        );
+        paths
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn paths_share_device(left: &Path, right: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    matches!(
+        (fs::metadata(left), fs::metadata(right)),
+        (Ok(left), Ok(right)) if left.dev() == right.dev()
+    )
+}
+
+impl Snapshot {
+    fn load(root: &Path, context: &GitContext) -> Self {
+        let mut snapshot = Self {
+            worktree_root: context.worktree_root.clone(),
+            ..Self::default()
+        };
+        snapshot.load_matchers(root, context);
+        snapshot.load_tracked(root);
+        snapshot
+    }
+
+    fn load_matchers(&mut self, root: &Path, context: &GitContext) {
+        let mut loaded = HashSet::new();
+
+        // Git consults every .gitignore from the worktree root down to the
+        // directory containing the path. This includes ancestors of a nested
+        // Turbo root.
+        for directory in directories_between(&context.worktree_root, root) {
+            let path = directory.join(".gitignore");
+            self.add_directory_matcher(&path, &mut loaded);
+        }
+
+        // Discover all descendants without applying ignore/ripgrep pruning.
+        // Whether a discovered file is reachable is handled by ancestor checks
+        // in is_relevant, matching Git's ignored-directory rule.
+        let mut walk = ignore::WalkBuilder::new(root);
+        walk.hidden(false)
+            .parents(false)
+            .require_git(false)
+            .ignore(false)
+            .git_ignore(false)
+            .git_exclude(false)
+            .git_global(false)
+            .filter_entry(|entry| entry.file_name() != ".git");
+        for entry in walk.build().filter_map(Result::ok).filter(|entry| {
+            entry.file_type().is_some_and(|kind| kind.is_file())
+                && entry.file_name() == ".gitignore"
+        }) {
+            self.add_directory_matcher(entry.path(), &mut loaded);
+        }
+
+        self.info_exclude = context
+            .info_exclude
+            .as_deref()
+            .and_then(|path| build_matcher(&context.worktree_root, path));
+        self.global_exclude = context
+            .global_exclude
+            .as_deref()
+            .and_then(|path| build_matcher(&context.worktree_root, path));
+    }
+
+    fn add_directory_matcher(&mut self, path: &Path, loaded: &mut HashSet<PathBuf>) {
+        let path = normalize_path(path);
+        if !loaded.insert(path.clone()) || !path.is_file() {
+            return;
+        }
+        let Some(parent) = path.parent() else {
+            return;
+        };
+        if let Some(matcher) = build_matcher(parent, &path) {
+            self.matchers.insert(parent.to_path_buf(), matcher);
+        }
+    }
+
+    fn load_tracked(&mut self, root: &Path) {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(&self.worktree_root)
+            .args(["ls-files", "-z", "--cached", "--full-name"])
+            .output();
+        let Ok(output) = output else {
+            return;
+        };
+        if !output.status.success() {
+            return;
+        }
+        for raw in output
+            .stdout
+            .split(|byte| *byte == 0)
+            .filter(|raw| !raw.is_empty())
+        {
+            let absolute = normalize_lexically(&self.worktree_root.join(bytes_to_path(raw)));
+            let Ok(path) = absolute.strip_prefix(root) else {
+                continue;
+            };
+            let path = path.to_path_buf();
+            self.tracked.insert(path.clone());
+            let mut ancestor = path.parent();
+            while let Some(path) = ancestor.filter(|path| !path.as_os_str().is_empty()) {
+                self.tracked_ancestors.insert(path.to_path_buf());
+                ancestor = path.parent();
+            }
+        }
+    }
+
+    fn is_ignored(&self, path: &Path, turbo_root: &Path, is_dir: bool) -> bool {
+        let mut directory = path.parent().unwrap_or(turbo_root);
+        loop {
+            if let Some(matcher) = self.matchers.get(directory) {
+                match matcher.matched(path, is_dir) {
+                    Match::None => {}
+                    Match::Ignore(_) => return true,
+                    Match::Whitelist(_) => return false,
+                }
+            }
+            if directory == self.worktree_root {
+                break;
+            }
+            let Some(parent) = directory.parent() else {
+                break;
+            };
+            directory = parent;
+        }
+
+        for matcher in [&self.info_exclude, &self.global_exclude]
+            .into_iter()
+            .flatten()
+        {
+            match matcher.matched(path, is_dir) {
+                Match::None => {}
+                Match::Ignore(_) => return true,
+                Match::Whitelist(_) => return false,
+            }
+        }
+        false
+    }
+}
+
+fn build_matcher(base: &Path, path: &Path) -> Option<Arc<Gitignore>> {
+    if !path.is_file() {
+        return None;
+    }
+    let mut builder = ignore::gitignore::GitignoreBuilder::new(base);
+    if let Some(error) = builder.add(path) {
+        warn!(%error, path = %path.display(), "invalid Git ignore file");
+    }
+    match builder.build() {
+        Ok(matcher) if !matcher.is_empty() => Some(Arc::new(matcher)),
+        Ok(_) => None,
+        Err(error) => {
+            warn!(%error, path = %path.display(), "invalid Git ignore file");
+            None
+        }
+    }
+}
+
+fn directories_between(base: &Path, descendant: &Path) -> Vec<PathBuf> {
+    let Ok(relative) = descendant.strip_prefix(base) else {
+        return vec![descendant.to_path_buf()];
+    };
+    let mut directories = vec![base.to_path_buf()];
+    let mut current = base.to_path_buf();
+    for component in relative.components() {
+        current.push(component.as_os_str());
+        directories.push(current.clone());
+    }
+    directories
+}
+
+fn git_path(root: &Path, name: &str) -> Option<PathBuf> {
+    command_path(root, &["rev-parse", "--git-path", name], false, root)
+}
+
+fn command_path(
+    root: &Path,
+    args: &[&str],
+    nul_terminated: bool,
+    relative_base: &Path,
+) -> Option<PathBuf> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let terminator = if nul_terminated { 0 } else { b'\n' };
+    let raw = output.stdout.split(|byte| *byte == terminator).next()?;
+    let raw = raw.strip_suffix(b"\r").unwrap_or(raw);
+    if raw.is_empty() {
+        return None;
+    }
+    let path = bytes_to_path(raw);
+    let path = if path.is_absolute() {
+        path
+    } else {
+        relative_base.join(path)
+    };
+    Some(normalize_path(&path))
+}
+
+fn bytes_to_path(raw: &[u8]) -> PathBuf {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStringExt;
+        PathBuf::from(OsString::from_vec(raw.to_vec()))
+    }
+    #[cfg(not(unix))]
+    {
+        PathBuf::from(String::from_utf8_lossy(raw).into_owned())
+    }
+}
+
+fn normalize_event_path(root: &Path, match_root: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        let path = normalize_lexically(path);
+        path.strip_prefix(root)
+            .map_or(path.clone(), |relative| match_root.join(relative))
+    } else {
+        normalize_lexically(&match_root.join(path))
+    }
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| normalize_lexically(path))
+}
+
+fn normalize_lexically(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                let can_pop = normalized
+                    .components()
+                    .next_back()
+                    .is_some_and(|last| matches!(last, Component::Normal(_)));
+                if can_pop {
+                    normalized.pop();
+                } else if !path.is_absolute() {
+                    normalized.push(component.as_os_str());
+                }
+            }
+            Component::Normal(part) => normalized.push(part),
+        }
+    }
+    normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::Path, process::Command};
+
+    use super::{RepositoryIgnore, normalize_lexically};
+
+    fn git(root: &Path, args: &[&str]) {
+        assert!(
+            Command::new("git")
+                .arg("-C")
+                .arg(root)
+                .args(args)
+                .status()
+                .unwrap()
+                .success()
+        );
+    }
+
+    #[test]
+    fn nested_root_uses_all_git_ignore_sources_with_correct_precedence() {
+        let temp = tempfile::tempdir().unwrap();
+        let worktree = temp.path().join("worktree");
+        let root = worktree.join("projects/turbo");
+        fs::create_dir_all(root.join("pkg/kept")).unwrap();
+        git(&worktree, &["init", "-q"]);
+
+        let global = temp.path().join("global-ignore");
+        fs::write(&global, "*.global\nprecedence.txt\n").unwrap();
+        git(
+            &worktree,
+            &["config", "core.excludesFile", "../global-ignore"],
+        );
+        fs::write(worktree.join(".gitignore"), "*.parent\nprecedence.txt\n").unwrap();
+        fs::write(
+            worktree.join("projects/.gitignore"),
+            "!turbo/precedence.txt\n",
+        )
+        .unwrap();
+        fs::write(root.join(".gitignore"), "root.tmp\n!precedence.txt\n").unwrap();
+        fs::write(root.join("pkg/.gitignore"), "*.tmp\n!kept/\n").unwrap();
+        fs::write(root.join(".ignore"), "visible.txt\n").unwrap();
+        fs::write(root.join("tracked.global"), "tracked").unwrap();
+        fs::write(worktree.join(".git/info/exclude"), "*.info\n").unwrap();
+        git(&worktree, &["add", "-f", "projects/turbo/tracked.global"]);
+
+        let model = RepositoryIgnore::new(&root);
+        assert!(!model.is_relevant(&root.join("value.parent"), false));
+        assert!(!model.is_relevant(&root.join("value.global"), false));
+        assert!(!model.is_relevant(&root.join("value.info"), false));
+        assert!(!model.is_relevant(&root.join("root.tmp"), false));
+        assert!(!model.is_relevant(&root.join("pkg/nope.tmp"), false));
+        assert!(model.is_relevant(&root.join("pkg/kept/value.txt"), false));
+        assert!(model.is_relevant(&root.join("precedence.txt"), false));
+        assert!(model.is_relevant(&root.join("tracked.global"), false));
+        assert!(model.is_relevant(&root.join("visible.txt"), false));
+
+        let normalized_global = fs::canonicalize(&global).unwrap();
+        assert!(
+            model
+                .control_paths()
+                .iter()
+                .any(|path| path == &normalized_global)
+        );
+        assert!(
+            model
+                .control_paths()
+                .iter()
+                .any(|path| path == &fs::canonicalize(worktree.join(".gitignore")).unwrap())
+        );
+        assert!(model.should_refresh(&normalized_global));
+    }
+
+    #[test]
+    fn refreshes_global_excludes_and_nested_rules() {
+        let temp = tempfile::tempdir().unwrap();
+        let worktree = temp.path().join("worktree");
+        let root = worktree.join("nested/turbo");
+        fs::create_dir_all(root.join("pkg")).unwrap();
+        git(&worktree, &["init", "-q"]);
+        let global = temp.path().join("global-ignore");
+        fs::write(&global, "before.txt\n").unwrap();
+        git(
+            &worktree,
+            &["config", "core.excludesFile", global.to_str().unwrap()],
+        );
+        fs::write(root.join("pkg/.gitignore"), "before.tmp\n").unwrap();
+
+        let model = RepositoryIgnore::new(&root);
+        assert!(!model.is_relevant(&root.join("before.txt"), false));
+        assert!(!model.is_relevant(&root.join("pkg/before.tmp"), false));
+
+        fs::write(&global, "after.txt\n").unwrap();
+        fs::write(root.join("pkg/.gitignore"), "after.tmp\n").unwrap();
+        model.refresh();
+        assert!(model.is_relevant(&root.join("before.txt"), false));
+        assert!(model.is_relevant(&root.join("pkg/before.tmp"), false));
+        assert!(!model.is_relevant(&root.join("after.txt"), false));
+        assert!(!model.is_relevant(&root.join("pkg/after.tmp"), false));
+
+        let replacement_global = temp.path().join("replacement-global-ignore");
+        fs::write(&replacement_global, "replacement.txt\n").unwrap();
+        git(
+            &worktree,
+            &[
+                "config",
+                "core.excludesFile",
+                replacement_global.to_str().unwrap(),
+            ],
+        );
+        model.refresh();
+        let controls = model.control_paths();
+        assert!(!controls.contains(&fs::canonicalize(&global).unwrap()));
+        assert!(controls.contains(&fs::canonicalize(&replacement_global).unwrap()));
+    }
+
+    #[test]
+    fn only_inherited_gitignore_changes_conservatively_invalidate() {
+        let temp = tempfile::tempdir().unwrap();
+        let worktree = temp.path().join("worktree");
+        let root = worktree.join("nested/turbo");
+        fs::create_dir_all(root.join("pkg")).unwrap();
+        git(&worktree, &["init", "-q"]);
+        let inherited = worktree.join("nested/.gitignore");
+        let root_ignore = root.join(".gitignore");
+        let nested = root.join("pkg/.gitignore");
+        fs::write(&inherited, "ignored\n").unwrap();
+        fs::write(&root_ignore, "ignored\n").unwrap();
+        fs::write(&nested, "ignored\n").unwrap();
+
+        let model = RepositoryIgnore::new(&root);
+        assert!(model.should_refresh(&inherited));
+        assert!(model.invalidates_consumers(&inherited));
+        assert!(model.should_refresh(&root_ignore));
+        assert!(!model.invalidates_consumers(&root_ignore));
+        assert!(model.should_refresh(&nested));
+        assert!(!model.invalidates_consumers(&nested));
+    }
+
+    #[test]
+    fn normalizes_parent_components_without_io() {
+        assert_eq!(
+            normalize_lexically(Path::new("/repo/nested/../.git/info/exclude")),
+            Path::new("/repo/.git/info/exclude")
+        );
+        assert_eq!(
+            normalize_lexically(Path::new("../../repo/./file")),
+            Path::new("../../repo/file")
+        );
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn tracked_non_utf8_paths_remain_relevant() {
+        use std::{ffi::OsString, os::unix::ffi::OsStringExt};
+
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        git(root, &["init", "-q"]);
+        fs::write(root.join(".gitignore"), "*\n").unwrap();
+        let name = OsString::from_vec(b"tracked-\xff".to_vec());
+        let path = root.join(name);
+        fs::write(&path, "tracked").unwrap();
+        assert!(
+            Command::new("git")
+                .arg("-C")
+                .arg(root)
+                .args(["add", "-f", "--"])
+                .arg(&path)
+                .status()
+                .unwrap()
+                .success()
+        );
+
+        let model = RepositoryIgnore::new(root);
+        assert!(model.is_relevant(&path, false));
+    }
+}

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -2,10 +2,9 @@ use std::{
     cell::RefCell,
     collections::{HashMap, HashSet},
     ops::DerefMut,
-    sync::Arc,
+    sync::{Arc, RwLock},
 };
 
-use ignore::gitignore::Gitignore;
 use notify::Event;
 use radix_trie::{Trie, TrieCommon};
 use tokio::sync::{broadcast, oneshot, Mutex};
@@ -13,7 +12,7 @@ use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPath, AnchoredSystemPathBuf
 use turborepo_daemon::{PackageChangeEvent, PackageChangesWatcher as PackageChangesWatcherTrait};
 use turborepo_filewatch::{
     hash_watcher::{HashSpec, HashWatcher, InputGlobs},
-    NotifyError, OptionalWatch,
+    RepositoryIgnore, WatchScope, WatchSource,
 };
 use turborepo_repository::{
     change_mapper::{
@@ -62,7 +61,7 @@ impl PackageChangesWatcher {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         repo_root: AbsoluteSystemPathBuf,
-        file_events_lazy: OptionalWatch<broadcast::Receiver<Result<Event, NotifyError>>>,
+        file_events: WatchSource,
         hash_watcher: Arc<HashWatcher>,
         custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
         single_package: bool,
@@ -74,7 +73,7 @@ impl PackageChangesWatcher {
             broadcast::channel(CHANGE_EVENT_CHANNEL_CAPACITY);
         let subscriber = Subscriber::new(
             repo_root,
-            file_events_lazy,
+            file_events,
             package_change_events_tx,
             hash_watcher,
             custom_turbo_json_path,
@@ -120,9 +119,11 @@ impl Default for ChangedFiles {
 }
 
 struct Subscriber {
-    file_events_lazy: OptionalWatch<broadcast::Receiver<Result<Event, NotifyError>>>,
+    file_events: WatchSource,
     changed_files: Mutex<RefCell<ChangedFiles>>,
     repo_root: AbsoluteSystemPathBuf,
+    repository_ignore: RepositoryIgnore,
+    watch_spec: Arc<RwLock<WatchSpec>>,
     package_change_events_tx: broadcast::Sender<PackageChangeEvent>,
     hash_watcher: Arc<HashWatcher>,
     custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
@@ -134,18 +135,18 @@ struct Subscriber {
     extra_toolchains: Vec<Arc<dyn Toolchain>>,
 }
 
-// This is a workaround because `ignore` doesn't match against a path's
-// ancestors, i.e. if we have `foo/bar/baz` and the .gitignore has `foo/`, it
-// won't match.
-fn ancestors_is_ignored(gitignore: &Gitignore, path: &AnchoredSystemPath) -> bool {
-    path.ancestors().enumerate().any(|(idx, p)| {
-        let is_dir = idx != 0;
-        gitignore.matched(p, is_dir).is_ignore()
-    })
-}
-
 fn is_in_git_folder(path: &AnchoredSystemPath) -> bool {
     path.components().any(|c| c.as_str() == ".git")
+}
+
+#[cfg(test)]
+fn ancestors_is_ignored(
+    gitignore: &ignore::gitignore::Gitignore,
+    path: &AnchoredSystemPath,
+) -> bool {
+    path.ancestors()
+        .enumerate()
+        .any(|(index, ancestor)| gitignore.matched(ancestor, index != 0).is_ignore())
 }
 
 struct RepoState {
@@ -188,7 +189,7 @@ enum FileChangeAction {
 fn classify_changed_files(
     trie: &Trie<String, ()>,
     repo_root: &AbsoluteSystemPathBuf,
-    root_gitignore: &Gitignore,
+    repository_ignore: &RepositoryIgnore,
     custom_turbo_json_path: Option<&AbsoluteSystemPathBuf>,
     change_mapper: &ChangeMapper<'_, GlobalDepsPackageChangeMapper<'_>>,
     watch_spec: &WatchSpec,
@@ -261,7 +262,11 @@ fn classify_changed_files(
             };
             repo_root.anchor(p).ok()
         })
-        .filter(|p| !(ancestors_is_ignored(root_gitignore, p) || is_in_git_folder(p)))
+        .filter(|p| {
+            repository_ignore
+                .is_relevant(repo_root.as_std_path().join(p.as_path()).as_path(), false)
+                && !is_in_git_folder(p)
+        })
         // Toolchain build byproducts (e.g. Cargo's target/) are written
         // continuously by the very tasks a change would re-trigger; letting
         // them through would create a feedback loop. Usually gitignored and
@@ -310,7 +315,7 @@ impl Subscriber {
     #[allow(clippy::too_many_arguments)]
     fn new(
         repo_root: AbsoluteSystemPathBuf,
-        file_events_lazy: OptionalWatch<broadcast::Receiver<Result<Event, NotifyError>>>,
+        file_events: WatchSource,
         package_change_events_tx: broadcast::Sender<PackageChangeEvent>,
         hash_watcher: Arc<HashWatcher>,
         custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
@@ -350,10 +355,20 @@ impl Subscriber {
             }
         });
 
+        let repository_ignore = file_events
+            .repository_ignore()
+            .unwrap_or_else(|| RepositoryIgnore::new(repo_root.as_std_path()));
+        let mut watch_spec = WatchSpec::default();
+        for toolchain in &extra_toolchains {
+            watch_spec.extend(toolchain.watch_spec());
+        }
+
         Subscriber {
             repo_root,
-            file_events_lazy,
+            file_events,
             changed_files: Default::default(),
+            repository_ignore,
+            watch_spec: Arc::new(RwLock::new(watch_spec)),
             package_change_events_tx,
             hash_watcher,
             custom_turbo_json_path: normalized_custom_path,
@@ -363,7 +378,7 @@ impl Subscriber {
         }
     }
 
-    async fn initialize_repo_state(&self) -> Option<(RepoState, Gitignore)> {
+    async fn initialize_repo_state(&self) -> Option<RepoState> {
         let Ok(root_package_json) =
             PackageJson::load(&self.repo_root.join_component("package.json"))
         else {
@@ -411,16 +426,16 @@ impl Subscriber {
         .ok()
         .cloned();
 
-        let gitignore_path = self.repo_root.join_component(".gitignore");
-        let (root_gitignore, _) = Gitignore::new(&gitignore_path);
+        *self
+            .watch_spec
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) =
+            pkg_dep_graph.toolchains().watch_spec();
 
-        Some((
-            RepoState {
-                root_turbo_json,
-                pkg_dep_graph,
-            },
-            root_gitignore,
-        ))
+        Some(RepoState {
+            root_turbo_json,
+            pkg_dep_graph,
+        })
     }
 
     async fn is_same_hash(
@@ -458,18 +473,73 @@ impl Subscriber {
 
     /// Send a Rediscover event and reinitialize repo state. Returns the new
     /// state tuple on success, or `None` if the caller should break.
-    async fn rediscover_and_reinit(&self) -> Option<(RepoState, Gitignore)> {
+    async fn rediscover_and_reinit(&self) -> Option<RepoState> {
         let _ = self
             .package_change_events_tx
             .send(PackageChangeEvent::Rediscover);
         self.initialize_repo_state().await
     }
 
-    async fn watch(mut self, exit_rx: oneshot::Receiver<()>) {
+    async fn watch(self, exit_rx: oneshot::Receiver<()>) {
         let timeout_secs = startup_timeout_secs();
+        let repo_root = self.repo_root.clone();
+        let repository_ignore = self.repository_ignore.clone();
+        let watch_spec = self.watch_spec.clone();
+        let gitignore_path = repo_root.join_component(".gitignore");
+        let config_paths = [
+            repo_root.join_component(CONFIG_FILE),
+            repo_root.join_component(CONFIG_FILE_JSONC),
+        ];
+        let custom_config_path = self.custom_turbo_json_path.clone();
+        let scope = WatchScope::event_filter(move |event| {
+            event.paths.retain(|path| {
+                if path.to_str().is_none() {
+                    return true;
+                }
+                let Ok(absolute_path) = AbsoluteSystemPathBuf::try_from(path.as_path()) else {
+                    return false;
+                };
+                if absolute_path == gitignore_path
+                    || config_paths.contains(&absolute_path)
+                    || custom_config_path
+                        .as_ref()
+                        .is_some_and(|config_path| absolute_path == *config_path)
+                {
+                    return true;
+                }
+                let Ok(path) = repo_root.anchor(&absolute_path) else {
+                    return false;
+                };
+                let watch_spec = watch_spec
+                    .read()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                let in_ignored_prefix = watch_spec.ignore_prefixes.iter().any(|prefix| {
+                    path.components()
+                        .next()
+                        .is_some_and(|component| component.as_str() == prefix)
+                });
+                if in_ignored_prefix {
+                    return false;
+                }
+                let is_definition = watch_spec
+                    .definition_paths
+                    .iter()
+                    .any(|definition| path.to_unix().as_str() == definition)
+                    || watch_spec.definition_file_names.iter().any(|name| {
+                        path.as_path()
+                            .file_name()
+                            .is_some_and(|file_name| file_name == name.as_str())
+                    });
+                if is_definition {
+                    return true;
+                }
+                repository_ignore.is_relevant(absolute_path.as_std_path(), false)
+                    && !is_in_git_folder(&path)
+            });
+        });
         let file_events_result = tokio::time::timeout(
             std::time::Duration::from_secs(timeout_secs),
-            self.file_events_lazy.get(),
+            self.file_events.subscribe(scope),
         )
         .await;
         let Ok(mut file_events) = file_events_result
@@ -481,7 +551,7 @@ impl Subscriber {
                 );
             })
             .and_then(|r| {
-                r.map(|r| r.resubscribe()).map_err(|_| {
+                r.map_err(|_| {
                     tracing::debug!("file watching shut down, package watcher not available");
                 })
             })
@@ -495,24 +565,30 @@ impl Subscriber {
             loop {
                 match file_events.recv().await {
                     Ok(Ok(Event { paths, .. })) => {
-                        if let ChangedFiles::Some(trie) =
-                            self.changed_files.lock().await.borrow_mut().deref_mut()
-                        {
+                        let changed_files = self.changed_files.lock().await;
+                        let mut changed_files = changed_files.borrow_mut();
+                        let mut non_utf8 = false;
+                        if let ChangedFiles::Some(trie) = changed_files.deref_mut() {
                             for path in paths {
                                 if let Some(path) = path.to_str() {
                                     trie.insert(path.to_string(), ());
                                 } else {
-                                    tracing::debug!(
+                                    tracing::warn!(
                                         ?path,
-                                        "skipping non-UTF-8 path from file watcher"
+                                        "non-UTF-8 file event requires conservative rediscovery"
                                     );
+                                    non_utf8 = true;
+                                    break;
                                 }
                             }
+                        }
+                        if non_utf8 {
+                            *changed_files = ChangedFiles::All;
                         }
                     }
                     Ok(Err(err)) => {
                         tracing::error!("file event error: {:?}", err);
-                        break;
+                        *self.changed_files.lock().await.borrow_mut() = ChangedFiles::All;
                     }
                     Err(broadcast::error::RecvError::Lagged(_)) => {
                         tracing::warn!("file event lagged");
@@ -532,8 +608,7 @@ impl Subscriber {
         let changes_fut = async {
             let root_pkg = WorkspacePackage::root();
 
-            let Some((mut repo_state, mut root_gitignore)) = self.initialize_repo_state().await
-            else {
+            let Some(mut repo_state) = self.initialize_repo_state().await else {
                 return;
             };
             // Pre-populate hash baselines for all known packages. Without
@@ -569,13 +644,11 @@ impl Subscriber {
             // pattern. The borrow checker prevents extracting this into a method
             // because `change_mapper` borrows from `repo_state`.
             macro_rules! rediscover {
-                ($self:expr, $repo_state:ident, $root_gitignore:ident, $change_mapper:ident) => {{
-                    let Some((new_state, new_gitignore)) = $self.rediscover_and_reinit().await
-                    else {
+                ($self:expr, $repo_state:ident, $change_mapper:ident) => {{
+                    let Some(new_state) = $self.rediscover_and_reinit().await else {
                         break;
                     };
                     $repo_state = new_state;
-                    $root_gitignore = new_gitignore;
                     $change_mapper = match $repo_state.get_change_mapper() {
                         Some(m) => m,
                         None => break,
@@ -600,24 +673,15 @@ impl Subscriber {
                 };
 
                 let ChangedFiles::Some(trie) = changed_files else {
-                    rediscover!(self, repo_state, root_gitignore, change_mapper);
+                    rediscover!(self, repo_state, change_mapper);
                     continue;
                 };
-
-                // Handle .gitignore changes before classification so that
-                // co-occurring file changes in the same batch are still processed
-                // with the updated gitignore rules.
-                let gitignore_path = self.repo_root.join_component(".gitignore");
-                if trie.get(gitignore_path.as_str()).is_some() {
-                    let (new_root_gitignore, _) = Gitignore::new(&gitignore_path);
-                    root_gitignore = new_root_gitignore;
-                }
 
                 let watch_spec = repo_state.pkg_dep_graph.toolchains().watch_spec();
                 let action = classify_changed_files(
                     &trie,
                     &self.repo_root,
-                    &root_gitignore,
+                    &self.repository_ignore,
                     self.custom_turbo_json_path.as_ref(),
                     &change_mapper,
                     &watch_spec,
@@ -629,19 +693,19 @@ impl Subscriber {
                         tracing::info!(
                             "Detected change to turbo configuration file. Triggering rediscovery."
                         );
-                        rediscover!(self, repo_state, root_gitignore, change_mapper);
+                        rediscover!(self, repo_state, change_mapper);
                         continue;
                     }
                     FileChangeAction::MapperFailed => {
                         tracing::info!("Change mapper failed. Triggering rediscovery.");
-                        rediscover!(self, repo_state, root_gitignore, change_mapper);
+                        rediscover!(self, repo_state, change_mapper);
                         continue;
                     }
                     FileChangeAction::NoRelevantChanges => {
                         continue;
                     }
                     FileChangeAction::PackagesChanged(PackageChanges::All(_), _) => {
-                        rediscover!(self, repo_state, root_gitignore, change_mapper);
+                        rediscover!(self, repo_state, change_mapper);
                     }
                     FileChangeAction::PackagesChanged(
                         PackageChanges::Some(filtered_pkgs),
@@ -703,7 +767,9 @@ mod test {
     use radix_trie::Trie;
     use tokio::sync::{broadcast, watch};
     use turbopath::{AbsoluteSystemPathBuf, AnchoredSystemPathBuf};
-    use turborepo_filewatch::{hash_watcher::HashWatcher, NotifyError, OptionalWatch};
+    use turborepo_filewatch::{
+        hash_watcher::HashWatcher, NotifyError, OptionalWatch, WatchEventSender, WatchSource,
+    };
     use turborepo_repository::{
         change_mapper::{ChangeMapper, GlobalDepsPackageChangeMapper, PackageChanges},
         package_graph::{PackageGraph, PackageGraphBuilder},
@@ -714,7 +780,7 @@ mod test {
 
     use super::{
         ancestors_is_ignored, classify_changed_files, is_in_git_folder, ChangedFiles,
-        FileChangeAction, PackageChangeEvent, PackageChangesWatcher, CONFIG_FILE,
+        FileChangeAction, PackageChangeEvent, PackageChangesWatcher, RepositoryIgnore, CONFIG_FILE,
     };
 
     fn anchored(s: &str) -> AnchoredSystemPathBuf {
@@ -810,7 +876,11 @@ mod test {
                 GlobalDepsPackageChangeMapper::new(&self.pkg_graph, std::iter::empty::<&str>())
                     .unwrap();
             let change_mapper = ChangeMapper::new(&self.pkg_graph, vec![], mapper);
-            let gitignore = gitignore_from_lines(self.repo_root.as_str(), gitignore_lines);
+            self.repo_root
+                .join_component(".gitignore")
+                .create_with_contents(gitignore_lines.join("\n"))
+                .unwrap();
+            let gitignore = RepositoryIgnore::new(self.repo_root.as_std_path());
             classify_changed_files(
                 trie,
                 &self.repo_root,
@@ -1246,7 +1316,7 @@ mod test {
         // .gitignore
         let gitignore = repo_root.join_component(".gitignore");
         gitignore
-            .create_with_contents("node_modules/\n.turbo/\n".as_bytes())
+            .create_with_contents("node_modules/\n.turbo/\n.cache/\n".as_bytes())
             .unwrap();
 
         // Package a
@@ -1296,11 +1366,11 @@ mod test {
     /// Holds onto channels that must stay alive for the test watcher to work.
     struct TestWatcherHandle {
         watcher: PackageChangesWatcher,
-        file_events_tx: broadcast::Sender<Result<notify::Event, NotifyError>>,
+        file_events_tx: WatchEventSender,
         // These must be kept alive to prevent the HashWatcher from busy-looping
         // on closed channels.
         _pkg_discovery_tx: watch::Sender<Option<Result<DiscoveryResponse, String>>>,
-        _hash_events_tx: broadcast::Sender<Result<notify::Event, NotifyError>>,
+        _hash_events_tx: WatchEventSender,
     }
 
     /// Create a PackageChangesWatcher backed by a synthetic file event channel.
@@ -1313,9 +1383,7 @@ mod test {
         single_package: bool,
         allow_no_package_manager: bool,
     ) -> TestWatcherHandle {
-        let (file_events_tx, file_events_rx) = broadcast::channel(128);
-        let (opt_tx, opt_watch) = OptionalWatch::new();
-        opt_tx.send(Some(file_events_rx)).unwrap();
+        let (file_events_tx, file_events) = WatchSource::channel_for_root(repo_root.as_std_path());
 
         // Keep the discovery sender alive so the HashWatcher doesn't busy-loop
         // on a closed watch channel. The hash watcher subscriber won't find any
@@ -1326,20 +1394,18 @@ mod test {
         let scm = SCM::new(repo_root);
 
         // Keep hash events sender alive too
-        let (hash_events_tx, hash_events_rx) = broadcast::channel(128);
-        let (hash_opt_tx, hash_opt_watch) = OptionalWatch::new();
-        hash_opt_tx.send(Some(hash_events_rx)).unwrap();
+        let (hash_events_tx, hash_events) = WatchSource::channel_for_root(repo_root.as_std_path());
 
         let hash_watcher = Arc::new(HashWatcher::new(
             repo_root.clone(),
             pkg_discovery_rx,
-            hash_opt_watch,
+            hash_events,
             scm,
         ));
 
         let watcher = PackageChangesWatcher::new(
             repo_root.clone(),
-            opt_watch,
+            file_events,
             hash_watcher,
             None,
             single_package,
@@ -1438,8 +1504,7 @@ mod test {
             GlobalDepsPackageChangeMapper::new(&pkg_graph, std::iter::empty::<&str>()).unwrap();
         let change_mapper = ChangeMapper::new(&pkg_graph, vec![], mapper);
 
-        let gitignore_path = repo_root.join_component(".gitignore");
-        let (gitignore, _) = ignore::gitignore::Gitignore::new(&gitignore_path);
+        let gitignore = RepositoryIgnore::new(repo_root.as_std_path());
 
         let changed_file = repo_root.join_components(&["packages", "a", "index.ts"]);
         let mut trie = Trie::new();
@@ -1806,6 +1871,34 @@ mod test {
             matches!(event, Some(PackageChangeEvent::Rediscover)),
             "expected Rediscover from turbo.json sentinel, got {:?}",
             event
+        );
+    }
+
+    #[tokio::test]
+    async fn ignored_burst_does_not_hide_following_source_change() {
+        let (_tmp, repo_root) = setup_git_repo();
+        let handle = create_test_watcher(&repo_root);
+        let mut rx = handle.watcher.package_change_events_rx.resubscribe();
+
+        let _ = recv_event(&mut rx, Duration::from_secs(2)).await;
+        for index in 0..30_000 {
+            let ignored_path =
+                repo_root.join_components(&["packages", "a", ".cache", &index.to_string()]);
+            handle
+                .file_events_tx
+                .send(Ok(make_notify_event_from(&[&ignored_path])))
+                .unwrap();
+        }
+        let source_path = repo_root.join_components(&["packages", "a", "index.ts"]);
+        handle
+            .file_events_tx
+            .send(Ok(make_notify_event_from(&[&source_path])))
+            .unwrap();
+
+        let event = recv_event(&mut rx, Duration::from_secs(5)).await;
+        assert!(
+            matches!(event, Some(PackageChangeEvent::Package { .. })),
+            "ignored burst should not cause rediscovery before source change, got {event:?}"
         );
     }
 }

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -273,21 +273,21 @@ impl WatchClient {
         let watcher = Arc::new(FileSystemWatcher::new_with_default_cookie_dir(
             &base.repo_root,
         )?);
-        let recv = watcher.watch();
+        let source = watcher.source();
         let cookie_writer = CookieWriter::new(
             watcher.cookie_dir(),
             Duration::from_millis(100),
-            recv.clone(),
+            source.clone(),
         );
         let glob_watcher = Arc::new(GlobWatcher::new(
             base.repo_root.clone(),
             cookie_writer.clone(),
-            recv.clone(),
+            source.clone(),
         ));
         let package_watcher = Arc::new(
             PackageWatcher::new(
                 base.repo_root.clone(),
-                recv.clone(),
+                source.clone(),
                 cookie_writer,
                 base.opts().repo_opts.allow_no_package_manager,
             )
@@ -297,7 +297,7 @@ impl WatchClient {
         let hash_watcher = Arc::new(HashWatcher::new(
             base.repo_root.clone(),
             package_watcher.watch_discovery(),
-            recv.clone(),
+            source,
             scm,
         ));
         // The watcher builds its own package graph; register the same
@@ -312,7 +312,7 @@ impl WatchClient {
         }
         let package_changes_watcher = PackageChangesWatcher::new(
             base.repo_root.clone(),
-            recv,
+            watcher.source(),
             hash_watcher.clone(),
             custom_turbo_json_path,
             base.opts().run_opts.single_package,

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -463,6 +463,52 @@ The core task graph consists of:
   can restore outputs without forcing non-cacheable tasks to rerun. Persistent
   non-interruptible tasks are excluded because watch mode cannot restart them
 
+#### Watch Event Routing (`crates/turborepo-filewatch`, `crates/turborepo-lib/src/package_changes_watcher.rs`)
+
+- `FileSystemWatcher` owns the platform watcher and exposes a demand-driven
+  `WatchSource`. Scoped consumers subscribe with a `WatchScope`; path filtering
+  occurs before that consumer's bounded event channel, so irrelevant events
+  cannot make it lag. Package changes, package discovery, input hashing,
+  output-glob tracking, cookies, devtools, and daemon root monitoring all use
+  independent scopes; there is no repository-wide raw event broadcast.
+- Package-change detection declares a source-input scope that drops `.git`,
+  paths excluded by repository and nested Git ignore rules, and toolchain
+  build-byproduct prefixes. Tracked files and their ancestor directories remain
+  relevant even when an ignore pattern matches. It always
+  admits `.gitignore`, `turbo.json`, `turbo.jsonc`, an in-repository custom
+  Turbo config, and toolchain workspace-definition files.
+- The shared repository model reloads all inherited and nested `.gitignore`
+  matchers before routing an event containing any `.gitignore`; it also applies
+  `.git/info/exclude` and `core.excludesFile`, but deliberately does not
+  interpret ripgrep `.ignore` files. On macOS, a global excludes file on a
+  different device is conservatively not applied because one FSEvents stream
+  cannot monitor both devices. The package scope
+  refreshes the merged toolchain `WatchSpec` whenever the package graph is
+  initialized or rediscovered. Turbo config and toolchain definition changes
+  trigger full rediscovery after routing.
+- Git index and `.git/info/exclude` control paths are watched separately so
+  tracked-file and exclude state stays current without exposing `.git` events
+  to normal consumers. Backend rescan signals bypass path scopes and invoke
+  each consumer's conservative recovery.
+- Output and hash watchers retain their independent event requirements: ignored
+  outputs and explicitly configured inputs may still be relevant to those
+  consumers. Git-ignore filtering is therefore consumer-specific rather than a
+  global filesystem policy.
+- On Linux, ordinary inotify registration uses a Git-aware directory walk and
+  does not descend into ignored trees. Hash and output scopes publish explicit
+  physical interests for ignored paths; the driver watches their nearest
+  existing ancestor and extends coverage when future directories appear.
+  `.gitignore` changes reconcile installed ordinary watches, including removing
+  newly ignored coverage while preserving explicit interests and cookies.
+  Explicit leading-wildcard inputs may require broad package coverage; these
+  still hard-exclude `.git` and `node_modules`.
+- Backends that do not require runtime watch-tree mutation route events directly
+  from their callback into scoped subscriptions after the readiness cookie,
+  avoiding a shared bounded ingress queue for ignored bursts.
+- Subscriptions unregister on drop. The source can be created before the run or
+  task graph because consumers register interests as those interests become
+  known.
+
 ### 4. Task Visitor (`crates/turborepo-lib/src/task_graph/visitor/`)
 
 The task graph visitor handles task execution:


### PR DESCRIPTION
## Summary

- replace the shared raw filesystem event broadcast with scoped, demand-driven subscriptions for package changes, hashing, outputs, discovery, cookies, devtools, and daemon root monitoring
- model inherited and nested Git ignores, global excludes, tracked exceptions, dynamic Git controls, and explicit ignored input/output interests
- prune ordinary ignored trees from Linux inotify coverage while preserving explicit coverage, and route non-mutating backends directly after readiness
- add scoped recovery for backend rescans/errors and document the watcher architecture

Closes #13402

## Validation

- `cargo test -p turborepo-filewatch --lib` focused and platform-independent coverage
- Linux all-feature filewatch test binary in Docker: 68/68 passed
- `cargo test -p turborepo-lib package_changes_watcher::test`
- `cargo clippy -p turborepo-filewatch --all-targets --all-features -- -D warnings`
- `cargo clippy -p turborepo-lib -p turborepo-daemon -p turborepo-devtools --all-targets -- -D warnings`
- `cargo check -p turborepo-filewatch --target x86_64-pc-windows-gnu`
- original Linux reproduction with three repeated 100,000-file bursts: zero package/hash lag, one package build each, and one web-server start

## Notes

Native macOS FSEvents stress was limited by local stream exhaustion after repeated test runs; focused FSEvents path/rescan tests and macOS compilation pass.