### PR TITLE
fix: Match JIT inputs for affected tasks

### DIFF
--- a/crates/turborepo-types/src/task_input_matching.rs
+++ b/crates/turborepo-types/src/task_input_matching.rs
@@ -10,9 +10,9 @@
 //!
 //! # Glob precedence
 //!
-//! Exclusions are evaluated first. If any exclusion pattern matches a file,
-//! the file is rejected regardless of inclusion patterns. Pattern ordering
-//! in the `inputs` array does not affect matching behavior.
+//! Within each input mode, exclusions are evaluated first. If an exclusion
+//! pattern matches a file, the file is rejected from that mode regardless of
+//! inclusion patterns. Startup and JIT inputs are then combined as a union.
 
 use turbopath::{AnchoredSystemPathBuf, RelativeUnixPathBuf};
 use wax::Program;
@@ -22,19 +22,22 @@ use crate::TaskInputs;
 /// Pre-compiled glob patterns for efficient matching against many files.
 ///
 /// Created via [`compile_globs`]. Exclusions take priority over inclusions
-/// (see [`check_compiled_globs`] for precedence rules). When `default` is
-/// true, all in-package files match unless excluded.
+/// within each input mode (see [`check_compiled_globs`] for precedence rules).
+/// When a mode's default is true, all in-package files match unless excluded.
 pub struct CompiledGlobs {
     inclusions: Vec<wax::Glob<'static>>,
     exclusions: Vec<wax::Glob<'static>>,
+    jit_inclusions: Vec<wax::Glob<'static>>,
+    jit_exclusions: Vec<wax::Glob<'static>>,
     /// True when `$TURBO_DEFAULT$` was present in the task's inputs,
     /// meaning all files within the package directory match by default.
     default: bool,
+    jit_default: bool,
     eager: bool,
-    has_jit_inputs: bool,
     /// True when any glob starts with `../`, indicating cross-package
     /// file references (from `$TURBO_ROOT$` expansion).
     has_traversal_globs: bool,
+    jit_has_traversal_globs: bool,
 }
 
 /// Pre-compiles a task's input globs for efficient matching against many files.
@@ -45,15 +48,20 @@ pub struct CompiledGlobs {
 /// `inputs: []` or a missing `inputs` key), the compiled result will match
 /// all files — see [`check_compiled_globs`] for details.
 pub fn compile_globs(inputs: &TaskInputs) -> CompiledGlobs {
-    let (inclusions, exclusions, eager_has_traversal) = compile_patterns(&inputs.globs);
+    let (inclusions, exclusions, has_traversal_globs) = compile_patterns(&inputs.globs);
+    let (jit_inclusions, jit_exclusions, jit_has_traversal_globs) =
+        compile_patterns(&inputs.jit_globs);
 
     CompiledGlobs {
         inclusions,
         exclusions,
+        jit_inclusions,
+        jit_exclusions,
         default: inputs.default,
+        jit_default: inputs.jit_default,
         eager: inputs.eager,
-        has_jit_inputs: inputs.has_jit_inputs(),
-        has_traversal_globs: eager_has_traversal,
+        has_traversal_globs,
+        jit_has_traversal_globs,
     }
 }
 
@@ -133,10 +141,6 @@ pub fn file_matches_compiled_inputs(
     pkg_prefix_slash: &str,
     compiled: &CompiledGlobs,
 ) -> bool {
-    if compiled.has_jit_inputs {
-        return true;
-    }
-
     let file_relative_to_pkg = if pkg_str.is_empty() {
         Some(file_unix)
     } else {
@@ -146,7 +150,7 @@ pub fn file_matches_compiled_inputs(
     // Files outside the package dir only match if there are traversal globs
     // (e.g. `../../jest.config.js` from a $TURBO_ROOT$ reference).
     let Some(relative_path) = file_relative_to_pkg else {
-        if !compiled.has_traversal_globs {
+        if !compiled.has_traversal_globs && !compiled.jit_has_traversal_globs {
             return false;
         }
 
@@ -157,16 +161,24 @@ pub fn file_matches_compiled_inputs(
         }
         relative.push_str(file_unix);
 
-        // `default` (from $TURBO_DEFAULT$) only covers files *inside* the
-        // package. For traversal paths (files outside the package, typically
-        // from $TURBO_ROOT$), only explicit inclusion globs should match.
-        return check_compiled_globs(
-            &relative,
-            &compiled.inclusions,
-            &compiled.exclusions,
-            false,
-            false,
-        );
+        // Defaults only cover files inside the package. Keep startup and JIT
+        // matching separate so exclusions in one mode do not affect the other.
+        return (compiled.has_traversal_globs
+            && check_compiled_globs(
+                &relative,
+                &compiled.inclusions,
+                &compiled.exclusions,
+                false,
+                false,
+            ))
+            || (compiled.jit_has_traversal_globs
+                && check_compiled_globs(
+                    &relative,
+                    &compiled.jit_inclusions,
+                    &compiled.jit_exclusions,
+                    false,
+                    false,
+                ));
     };
 
     check_compiled_globs(
@@ -175,6 +187,12 @@ pub fn file_matches_compiled_inputs(
         &compiled.exclusions,
         compiled.default,
         compiled.eager,
+    ) || check_compiled_globs(
+        relative_path,
+        &compiled.jit_inclusions,
+        &compiled.jit_exclusions,
+        compiled.jit_default,
+        false,
     )
 }
 
@@ -506,25 +524,48 @@ mod tests {
     }
 
     #[test]
-    fn jit_inputs_are_conservatively_affected() {
+    fn jit_inputs_can_match_files_excluded_from_startup_inputs() {
         let inputs = TaskInputs {
             globs: vec!["!src/generated/**".to_string()],
             jit_globs: vec!["src/generated/**".to_string()],
             ..Default::default()
         };
 
-        assert_match("packages/lib-a/README.md", "packages/lib-a", &inputs, true);
+        assert_match(
+            "packages/lib-a/src/generated/client.ts",
+            "packages/lib-a",
+            &inputs,
+            true,
+        );
     }
 
     #[test]
-    fn jit_traversal_is_conservatively_affected() {
+    fn jit_inputs_respect_startup_exclusions_and_package_boundaries() {
+        let inputs = TaskInputs {
+            globs: vec!["!**/*.md".to_string()],
+            default: true,
+            jit_globs: vec!["src/gen/**".to_string()],
+            ..Default::default()
+        };
+
+        assert_match("packages/lib-a/README.md", "packages/lib-a", &inputs, false);
+        assert_match(
+            "packages/lib-b/src/index.ts",
+            "packages/lib-a",
+            &inputs,
+            false,
+        );
+    }
+
+    #[test]
+    fn jit_traversal_only_matches_declared_files() {
         let inputs = TaskInputs {
             jit_globs: vec!["../../schema.json".to_string()],
             eager: false,
             ..Default::default()
         };
 
-        assert_match("other.json", "packages/lib-a", &inputs, true);
+        assert_match("other.json", "packages/lib-a", &inputs, false);
         assert_match("schema.json", "packages/lib-a", &inputs, true);
     }
 


### PR DESCRIPTION
## Summary

- match startup and JIT task inputs independently before combining their results
- preserve exclusions and package boundaries for tasks with JIT inputs
- restrict JIT traversal inputs to explicitly declared files
- add regressions for excluded Markdown files and unrelated packages

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p turborepo-types task_input_matching`
- `cargo test -p turborepo-engine affected`
- `cargo clippy -p turborepo-types --all-targets -- -D warnings`
- pre-push formatting and TOML checks

Closes #13422