### PR TITLE
chore: Update tar to 7.5.18

### DIFF
--- a/packages/turbo-releaser/package.json
+++ b/packages/turbo-releaser/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "commander": "11.0.0",
     "semver": "7.5.2",
-    "tar": "7.5.16"
+    "tar": "7.5.18"
   },
   "devDependencies": {
     "@turbo/tsconfig": "workspace:*",

--- a/packages/turbo-utils/package.json
+++ b/packages/turbo-utils/package.json
@@ -52,7 +52,7 @@
     "json5": "2.2.3",
     "ora": "4.1.1",
     "picocolors": "1.0.1",
-    "tar": "7.5.16",
+    "tar": "7.5.18",
     "typescript": "npm:@typescript/typescript6@^6.0.1",
     "typescript-7": "npm:typescript@7.0.1-rc",
     "update-check": "1.5.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -849,8 +849,8 @@ importers:
         specifier: 1.0.1
         version: 1.0.1
       tar:
-        specifier: 7.5.16
-        version: 7.5.16
+        specifier: 7.5.18
+        version: 7.5.18
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.1
         version: '@typescript/typescript6@6.0.1'
@@ -9433,10 +9433,6 @@ packages:
 
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
-
-  tar@7.5.16:
-    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
-    engines: {node: '>=18'}
 
   tar@7.5.18:
     resolution: {integrity: sha512-PwA+nJl+AzsS9hRqtNRRq8/kTdNPoOLEPXpz9WBaErNm4+TFedJyQFJLITWdsmIBnwNS/TwXf1NV5Ak1KITc8g==}
@@ -19574,14 +19570,6 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
-
-  tar@7.5.16:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.3
-      minizlib: 3.1.0
-      yallist: 5.0.0
 
   tar@7.5.18:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -623,8 +623,8 @@ importers:
         specifier: 7.5.2
         version: 7.5.2
       tar:
-        specifier: 7.5.16
-        version: 7.5.16
+        specifier: 7.5.18
+        version: 7.5.18
     devDependencies:
       '@turbo/tsconfig':
         specifier: workspace:*
@@ -9436,6 +9436,10 @@ packages:
 
   tar@7.5.16:
     resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
+    engines: {node: '>=18'}
+
+  tar@7.5.18:
+    resolution: {integrity: sha512-PwA+nJl+AzsS9hRqtNRRq8/kTdNPoOLEPXpz9WBaErNm4+TFedJyQFJLITWdsmIBnwNS/TwXf1NV5Ak1KITc8g==}
     engines: {node: '>=18'}
 
   terminal-link@4.0.0:
@@ -19572,6 +19576,14 @@ snapshots:
       - react-native-b4a
 
   tar@7.5.16:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
+  tar@7.5.18:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0


### PR DESCRIPTION
## Summary
- update every direct `tar` dependency from 7.5.16 to 7.5.18
- cover both `@turbo/releaser` and `@turbo/utils`
- refresh the pnpm lockfile and remove the remaining 7.5.16 entry
- address CVE-2026-59874 / GHSA-8x88-c5mf-7j5w

## Testing
- `pnpm --filter @turbo/releaser test`
- `pnpm --filter @turbo/releaser build`
- `pnpm --filter @turbo/releaser check-types`
- `pnpm --filter @turbo/utils exec jest --runInBand`
- `pnpm --filter @turbo/utils check-types`
- `pnpm install --frozen-lockfile --ignore-scripts`
- pre-push format and TOML checks