### PR TITLE
refactor: Add graph-local ecosystem contributions

### DIFF
--- a/crates/turborepo-lib/src/commands/daemon.rs
+++ b/crates/turborepo-lib/src/commands/daemon.rs
@@ -348,14 +348,10 @@ pub async fn daemon_server(
             move |args| {
                 // Mirror the run builder: the daemon-side watcher must see
                 // the same package set a run would.
-                let mut extra_toolchains: Vec<
-                    std::sync::Arc<dyn turborepo_repository::toolchain::Toolchain>,
-                > = Vec::new();
-                if cargo_enabled {
-                    extra_toolchains.push(turborepo_repository::cargo::CargoToolchain::new(
-                        args.repo_root.clone(),
-                    ));
-                }
+                let ecosystem_adapters = crate::run::builder::configured_ecosystem_adapters(
+                    &args.repo_root,
+                    cargo_enabled,
+                );
                 PackageChangesWatcher::new(
                     args.repo_root,
                     args.file_events,
@@ -363,7 +359,7 @@ pub async fn daemon_server(
                     args.custom_turbo_json_path,
                     false,
                     args.allow_no_package_manager,
-                    extra_toolchains,
+                    ecosystem_adapters,
                 )
             }
         },

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -755,10 +755,11 @@ impl<'a> Prune<'a> {
 
         let mut graph_builder = PackageGraph::builder(&base.repo_root, root_package_json)
             .with_allow_no_package_manager(allow_missing_package_manager);
-        if crate::run::builder::cargo_enabled(&base.opts().future_flags) {
-            graph_builder = graph_builder.with_toolchain(
-                turborepo_repository::cargo::CargoToolchain::new(base.repo_root.clone()),
-            );
+        for adapter in crate::run::builder::configured_ecosystem_adapters(
+            &base.repo_root,
+            crate::run::builder::cargo_enabled(&base.opts().future_flags),
+        ) {
+            graph_builder = graph_builder.with_ecosystem_adapter(adapter);
         }
         let package_graph = graph_builder.build().await?;
 

--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -374,7 +374,7 @@ mod test {
             .with_package_discovery(DummyDiscovery(
                 turbopath::AbsoluteSystemPathBuf::try_from(tmp.path()).unwrap(),
             ))
-            .with_toolchain(turborepo_repository::cargo::CargoToolchain::new(
+            .with_ecosystem_adapter(turborepo_repository::cargo::CargoAdapter::new(
                 root.to_owned(),
             ))
             .build()

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -2,7 +2,7 @@ use std::{
     cell::RefCell,
     collections::{HashMap, HashSet},
     ops::DerefMut,
-    sync::{Arc, RwLock},
+    sync::Arc,
 };
 
 use notify::Event;
@@ -19,8 +19,8 @@ use turborepo_repository::{
         ChangeMapper, GlobalDepsPackageChangeMapper, LockfileContents, PackageChanges,
     },
     package_graph::{PackageGraph, PackageGraphBuilder, PackageName, WorkspacePackage},
-    package_json::PackageJson,
-    toolchain::{Toolchain, WatchSpec},
+    package_json::{self, PackageJson},
+    toolchain::{EcosystemAdapter, WatchSpec},
 };
 use turborepo_scm::GitHashes;
 
@@ -66,7 +66,7 @@ impl PackageChangesWatcher {
         custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
         single_package: bool,
         allow_no_package_manager: bool,
-        extra_toolchains: Vec<Arc<dyn Toolchain>>,
+        ecosystem_adapters: Vec<Arc<dyn EcosystemAdapter>>,
     ) -> Self {
         let (exit_tx, exit_rx) = oneshot::channel();
         let (package_change_events_tx, package_change_events_rx) =
@@ -79,7 +79,7 @@ impl PackageChangesWatcher {
             custom_turbo_json_path,
             single_package,
             allow_no_package_manager,
-            extra_toolchains,
+            ecosystem_adapters,
         );
 
         let _handle = tokio::spawn(subscriber.watch(exit_rx));
@@ -123,16 +123,16 @@ struct Subscriber {
     changed_files: Mutex<RefCell<ChangedFiles>>,
     repo_root: AbsoluteSystemPathBuf,
     repository_ignore: RepositoryIgnore,
-    watch_spec: Arc<RwLock<WatchSpec>>,
+    watch_spec: WatchSpec,
     package_change_events_tx: broadcast::Sender<PackageChangeEvent>,
     hash_watcher: Arc<HashWatcher>,
     custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
     single_package: bool,
     allow_no_package_manager: bool,
-    /// Toolchains registered in addition to JavaScript (e.g. Cargo when
+    /// Ecosystem adapters registered in addition to JavaScript (e.g. Cargo when
     /// futureFlags.experimentalCargoWorkspaces is enabled), mirroring the
     /// run builder so the watcher sees the same package graph a run would.
-    extra_toolchains: Vec<Arc<dyn Toolchain>>,
+    ecosystem_adapters: Vec<Arc<dyn EcosystemAdapter>>,
 }
 
 fn is_in_git_folder(path: &AnchoredSystemPath) -> bool {
@@ -321,7 +321,7 @@ impl Subscriber {
         custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
         single_package: bool,
         allow_no_package_manager: bool,
-        extra_toolchains: Vec<Arc<dyn Toolchain>>,
+        ecosystem_adapters: Vec<Arc<dyn EcosystemAdapter>>,
     ) -> Self {
         // Try to canonicalize the custom path to match what the file watcher reports
         let normalized_custom_path = custom_turbo_json_path.map(|path| {
@@ -359,8 +359,8 @@ impl Subscriber {
             .repository_ignore()
             .unwrap_or_else(|| RepositoryIgnore::new(repo_root.as_std_path()));
         let mut watch_spec = WatchSpec::default();
-        for toolchain in &extra_toolchains {
-            watch_spec.extend(toolchain.watch_spec());
+        for adapter in &ecosystem_adapters {
+            watch_spec.extend(adapter.watch_spec());
         }
 
         Subscriber {
@@ -368,28 +368,37 @@ impl Subscriber {
             file_events,
             changed_files: Default::default(),
             repository_ignore,
-            watch_spec: Arc::new(RwLock::new(watch_spec)),
+            watch_spec,
             package_change_events_tx,
             hash_watcher,
             custom_turbo_json_path: normalized_custom_path,
             single_package,
             allow_no_package_manager,
-            extra_toolchains,
+            ecosystem_adapters,
         }
     }
 
     async fn initialize_repo_state(&self) -> Option<RepoState> {
-        let Ok(root_package_json) =
-            PackageJson::load(&self.repo_root.join_component("package.json"))
-        else {
-            tracing::debug!("no package.json found, package watcher not available");
-            return None;
+        let package_json_path = self.repo_root.join_component("package.json");
+        let root_package_json = match PackageJson::load(&package_json_path) {
+            Ok(package_json) => Some(package_json),
+            Err(package_json::Error::Io(error))
+                if error.kind() == std::io::ErrorKind::NotFound
+                    && !self.ecosystem_adapters.is_empty() =>
+            {
+                None
+            }
+            Err(error) => {
+                tracing::debug!(%error, "package watcher root package unavailable");
+                return None;
+            }
         };
-        let mut builder = PackageGraphBuilder::new(&self.repo_root, root_package_json.clone())
-            .with_single_package_mode(self.single_package)
-            .with_allow_no_package_manager(self.allow_no_package_manager);
-        for toolchain in &self.extra_toolchains {
-            builder = builder.with_toolchain(toolchain.clone());
+        let mut builder =
+            PackageGraphBuilder::new_optional(&self.repo_root, root_package_json.clone())
+                .with_single_package_mode(self.single_package)
+                .with_allow_no_package_manager(self.allow_no_package_manager);
+        for adapter in &self.ecosystem_adapters {
+            builder = builder.with_ecosystem_adapter(adapter.clone());
         }
         let Ok(pkg_dep_graph) = builder.build().await else {
             tracing::debug!("package graph not available, package watcher not available");
@@ -418,6 +427,10 @@ impl Subscriber {
 
         let reader = TurboJsonReader::new(self.repo_root.clone());
         let root_turbo_json = if self.single_package {
+            let Some(root_package_json) = root_package_json else {
+                tracing::debug!("single-package watching requires a root package.json");
+                return None;
+            };
             UnifiedTurboJsonLoader::single_package(reader, config_path, root_package_json)
         } else {
             UnifiedTurboJsonLoader::workspace(reader, config_path, pkg_dep_graph.packages())
@@ -425,12 +438,6 @@ impl Subscriber {
         .load(&PackageName::Root)
         .ok()
         .cloned();
-
-        *self
-            .watch_spec
-            .write()
-            .unwrap_or_else(|poisoned| poisoned.into_inner()) =
-            pkg_dep_graph.toolchains().watch_spec();
 
         Some(RepoState {
             root_turbo_json,
@@ -471,13 +478,15 @@ impl Subscriber {
         true
     }
 
-    /// Send a Rediscover event and reinitialize repo state. Returns the new
-    /// state tuple on success, or `None` if the caller should break.
+    /// Build a replacement repository state and publish Rediscover only after
+    /// it succeeds. A failed candidate leaves the current state active so a
+    /// later file event can retry.
     async fn rediscover_and_reinit(&self) -> Option<RepoState> {
+        let state = self.initialize_repo_state().await?;
         let _ = self
             .package_change_events_tx
             .send(PackageChangeEvent::Rediscover);
-        self.initialize_repo_state().await
+        Some(state)
     }
 
     async fn watch(self, exit_rx: oneshot::Receiver<()>) {
@@ -510,9 +519,6 @@ impl Subscriber {
                 let Ok(path) = repo_root.anchor(&absolute_path) else {
                     return false;
                 };
-                let watch_spec = watch_spec
-                    .read()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner());
                 let in_ignored_prefix = watch_spec.ignore_prefixes.iter().any(|prefix| {
                     path.components()
                         .next()
@@ -646,7 +652,7 @@ impl Subscriber {
             macro_rules! rediscover {
                 ($self:expr, $repo_state:ident, $change_mapper:ident) => {{
                     let Some(new_state) = $self.rediscover_and_reinit().await else {
-                        break;
+                        continue;
                     };
                     $repo_state = new_state;
                     $change_mapper = match $repo_state.get_change_mapper() {
@@ -677,14 +683,13 @@ impl Subscriber {
                     continue;
                 };
 
-                let watch_spec = repo_state.pkg_dep_graph.toolchains().watch_spec();
                 let action = classify_changed_files(
                     &trie,
                     &self.repo_root,
                     &self.repository_ignore,
                     self.custom_turbo_json_path.as_ref(),
                     &change_mapper,
-                    &watch_spec,
+                    &self.watch_spec,
                 );
                 tracing::debug!(?action, "classified file changes");
 
@@ -771,10 +776,11 @@ mod test {
         hash_watcher::HashWatcher, NotifyError, OptionalWatch, WatchEventSender, WatchSource,
     };
     use turborepo_repository::{
+        cargo::CargoAdapter,
         change_mapper::{ChangeMapper, GlobalDepsPackageChangeMapper, PackageChanges},
         package_graph::{PackageGraph, PackageGraphBuilder},
         package_json::PackageJson,
-        toolchain::WatchSpec,
+        toolchain::{EcosystemAdapter, WatchSpec},
     };
     use turborepo_scm::SCM;
 
@@ -1383,6 +1389,20 @@ mod test {
         single_package: bool,
         allow_no_package_manager: bool,
     ) -> TestWatcherHandle {
+        create_test_watcher_with_adapters(
+            repo_root,
+            single_package,
+            allow_no_package_manager,
+            Vec::new(),
+        )
+    }
+
+    fn create_test_watcher_with_adapters(
+        repo_root: &AbsoluteSystemPathBuf,
+        single_package: bool,
+        allow_no_package_manager: bool,
+        ecosystem_adapters: Vec<Arc<dyn EcosystemAdapter>>,
+    ) -> TestWatcherHandle {
         let (file_events_tx, file_events) = WatchSource::channel_for_root(repo_root.as_std_path());
 
         // Keep the discovery sender alive so the HashWatcher doesn't busy-loop
@@ -1410,7 +1430,7 @@ mod test {
             None,
             single_package,
             allow_no_package_manager,
-            Vec::new(),
+            ecosystem_adapters,
         );
 
         TestWatcherHandle {
@@ -1443,6 +1463,81 @@ mod test {
             matches!(event, Some(PackageChangeEvent::Rediscover)),
             "expected Rediscover, got {:?}",
             event
+        );
+    }
+
+    #[tokio::test]
+    async fn cargo_only_watcher_initializes_from_adapter() {
+        let (_tmp, repo_root) = setup_git_repo();
+        std::fs::remove_file(repo_root.join_component("package.json").as_std_path()).unwrap();
+        std::fs::remove_file(repo_root.join_component("package-lock.json").as_std_path()).unwrap();
+        let crate_dir = repo_root.join_components(&["crates", "app"]);
+        crate_dir.join_component("src").create_dir_all().unwrap();
+        let workspace_manifest = b"[workspace]\nmembers = [\"crates/*\"]\nresolver = \"2\"\n\n[workspace.metadata]\nname = \"fixture\"\n";
+        let workspace_manifest_path = repo_root.join_component("Cargo.toml");
+        repo_root
+            .join_component("Cargo.toml")
+            .create_with_contents(workspace_manifest)
+            .unwrap();
+        crate_dir
+            .join_component("Cargo.toml")
+            .create_with_contents(
+                b"[package]\nname = \"app\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+            )
+            .unwrap();
+        crate_dir
+            .join_components(&["src", "lib.rs"])
+            .create_with_contents(b"")
+            .unwrap();
+        repo_root
+            .join_component("Cargo.lock")
+            .create_with_contents(
+                b"version = 4\n\n[[package]]\nname = \"app\"\nversion = \"0.1.0\"\n",
+            )
+            .unwrap();
+
+        let handle = create_test_watcher_with_adapters(
+            &repo_root,
+            false,
+            false,
+            vec![CargoAdapter::new(repo_root.clone())],
+        );
+        let mut rx = handle.watcher.package_change_events_rx.resubscribe();
+
+        let event = recv_event(&mut rx, Duration::from_secs(2)).await;
+        assert!(
+            matches!(event, Some(PackageChangeEvent::Rediscover)),
+            "expected Cargo-only watcher initialization, got {event:?}"
+        );
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        workspace_manifest_path
+            .create_with_contents(b"[workspace\nmembers = [")
+            .unwrap();
+        handle
+            .file_events_tx
+            .send(Ok(make_notify_event_from(&[&workspace_manifest_path])))
+            .unwrap();
+        assert!(
+            recv_event(&mut rx, Duration::from_millis(500))
+                .await
+                .is_none(),
+            "failed repository candidates must not be published"
+        );
+
+        workspace_manifest_path
+            .create_with_contents(workspace_manifest)
+            .unwrap();
+        handle
+            .file_events_tx
+            .send(Ok(make_notify_event_from(&[&workspace_manifest_path])))
+            .unwrap();
+        assert!(
+            matches!(
+                recv_event(&mut rx, Duration::from_secs(2)).await,
+                Some(PackageChangeEvent::Rediscover)
+            ),
+            "watcher must retry after a failed repository candidate"
         );
     }
 

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -573,10 +573,11 @@ impl RunBuilder {
                     .with_closure_hasher(std::sync::Arc::new(
                         turborepo_task_hash::hash_sorted_closures,
                     ));
-            if cargo_enabled(&self.opts.future_flags) {
-                builder = builder.with_toolchain(turborepo_repository::cargo::CargoToolchain::new(
-                    self.repo_root.to_owned(),
-                ));
+            for adapter in configured_ecosystem_adapters(
+                &self.repo_root,
+                cargo_enabled(&self.opts.future_flags),
+            ) {
+                builder = builder.with_ecosystem_adapter(adapter);
             }
 
             let graph = builder
@@ -1392,6 +1393,20 @@ pub(crate) fn cargo_enabled(future_flags: &turborepo_turbo_json::FutureFlags) ->
     future_flags.experimental_cargo_workspaces
 }
 
+pub(crate) fn configured_ecosystem_adapters(
+    repo_root: &AbsoluteSystemPath,
+    cargo_enabled: bool,
+) -> Vec<std::sync::Arc<dyn turborepo_repository::toolchain::EcosystemAdapter>> {
+    let mut adapters = Vec::new();
+    if cargo_enabled {
+        adapters.push(
+            turborepo_repository::cargo::CargoAdapter::new(repo_root.to_owned())
+                as std::sync::Arc<dyn turborepo_repository::toolchain::EcosystemAdapter>,
+        );
+    }
+    adapters
+}
+
 fn origins_match(url1: &str, url2: &str) -> bool {
     let (Ok(url1), Ok(url2)) = (Url::parse(url1), Url::parse(url2)) else {
         return false;
@@ -1416,8 +1431,10 @@ mod task_io_context_tests {
     use turborepo_env::EnvironmentVariableMap;
     use turborepo_hash::TaskHashable;
     use turborepo_repository::{
-        cargo::CargoToolchain,
-        toolchain::{DiscoverPackagesFuture, Toolchain, ToolchainId, ToolchainRegistry},
+        cargo::CargoAdapter,
+        toolchain::{
+            DiscoverPackagesFuture, EcosystemAdapter, Toolchain, ToolchainId, ToolchainRegistry,
+        },
     };
     use turborepo_types::EnvMode;
 
@@ -1447,14 +1464,18 @@ mod task_io_context_tests {
         let alpha = ToolchainId::new("alpha");
         let beta = ToolchainId::new("beta");
         let mut toolchains = ToolchainRegistry::new();
-        toolchains.register(Arc::new(Stub {
-            id: alpha.clone(),
-            environment: vec!["ALPHA_*"],
-        }));
-        toolchains.register(Arc::new(Stub {
-            id: beta.clone(),
-            environment: vec!["BETA_KEY"],
-        }));
+        toolchains
+            .register(Arc::new(Stub {
+                id: alpha.clone(),
+                environment: vec!["ALPHA_*"],
+            }))
+            .unwrap();
+        toolchains
+            .register(Arc::new(Stub {
+                id: beta.clone(),
+                environment: vec!["BETA_KEY"],
+            }))
+            .unwrap();
         let environment = EnvironmentVariableMap::from(HashMap::from([
             ("ALPHA_TARGET".to_string(), "alpha".to_string()),
             ("BETA_KEY".to_string(), "beta".to_string()),
@@ -1473,12 +1494,20 @@ mod task_io_context_tests {
         assert_eq!(beta_environment.get("UNDECLARED_SECRET"), None);
     }
 
-    #[test]
-    fn cargo_projection_keeps_only_rustup_selection_environment() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cargo_projection_keeps_only_rustup_selection_environment() {
         let root = tempfile::tempdir().unwrap();
         let root = AbsoluteSystemPathBuf::try_from(root.path()).unwrap();
         let mut toolchains = ToolchainRegistry::new();
-        toolchains.register(CargoToolchain::new(root));
+        toolchains
+            .register(
+                CargoAdapter::new(root)
+                    .contribute()
+                    .await
+                    .unwrap()
+                    .prepared_runtime,
+            )
+            .unwrap();
         let environment = EnvironmentVariableMap::from(HashMap::from([
             ("RUSTUP_HOME".to_string(), "/rustup".to_string()),
             ("RUSTUP_TOOLCHAIN".to_string(), "stable-host".to_string()),
@@ -1498,10 +1527,12 @@ mod task_io_context_tests {
     fn projected_task_hash(layout: &str, secret: &str) -> String {
         let alpha = ToolchainId::new("alpha");
         let mut toolchains = ToolchainRegistry::new();
-        toolchains.register(Arc::new(Stub {
-            id: alpha.clone(),
-            environment: vec!["ALPHA_*"],
-        }));
+        toolchains
+            .register(Arc::new(Stub {
+                id: alpha.clone(),
+                environment: vec!["ALPHA_*"],
+            }))
+            .unwrap();
         let environment = EnvironmentVariableMap::from(HashMap::from([
             ("ALPHA_TARGET".to_string(), layout.to_string()),
             ("UNDECLARED_SECRET".to_string(), secret.to_string()),

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -302,14 +302,10 @@ impl WatchClient {
         ));
         // The watcher builds its own package graph; register the same
         // toolchains a run would so it watches the same package set.
-        let mut extra_toolchains: Vec<
-            std::sync::Arc<dyn turborepo_repository::toolchain::Toolchain>,
-        > = Vec::new();
-        if crate::run::builder::cargo_enabled(&base.opts().future_flags) {
-            extra_toolchains.push(turborepo_repository::cargo::CargoToolchain::new(
-                base.repo_root.clone(),
-            ));
-        }
+        let ecosystem_adapters = crate::run::builder::configured_ecosystem_adapters(
+            &base.repo_root,
+            crate::run::builder::cargo_enabled(&base.opts().future_flags),
+        );
         let package_changes_watcher = PackageChangesWatcher::new(
             base.repo_root.clone(),
             watcher.source(),
@@ -317,7 +313,7 @@ impl WatchClient {
             custom_turbo_json_path,
             base.opts().run_opts.single_package,
             base.opts().repo_opts.allow_no_package_manager,
-            extra_toolchains,
+            ecosystem_adapters,
         );
 
         // Subscribe before building the Run so we don't miss the initial

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -44,7 +44,10 @@ use turborepo_errors::Spanned;
 
 use crate::{
     package_json::PackageJson,
-    toolchain::{self, DiscoverPackagesFuture, DiscoveredPackage, Toolchain, ToolchainId},
+    toolchain::{
+        self, ContributeFuture, DiscoveredPackage, EcosystemAdapter, EcosystemContribution,
+        EcosystemContributionFuture, Toolchain, ToolchainId,
+    },
 };
 
 /// The conventional file name for a Cargo manifest.
@@ -982,16 +985,23 @@ fn cargo_output_layout(
     })
 }
 
-/// The Cargo toolchain. Registered in the
-/// [`crate::toolchain::ToolchainRegistry`] when
-/// `futureFlags.experimentalCargoWorkspaces` is enabled and the repository
-/// root contains a `Cargo.toml`.
+/// Stateless, reusable Cargo discovery input. Every contribution contains a
+/// newly prepared runtime, so rediscovery cannot alter an existing graph.
+pub struct CargoAdapter {
+    repo_root: AbsoluteSystemPathBuf,
+}
+
+impl CargoAdapter {
+    pub fn new(repo_root: AbsoluteSystemPathBuf) -> Arc<Self> {
+        Arc::new(Self { repo_root })
+    }
+}
+
+/// Immutable Cargo behavior prepared for one package graph.
 pub struct CargoToolchain {
     repo_root: AbsoluteSystemPathBuf,
-    /// Per-package details recorded during discovery, consumed by command
-    /// resolution. Keyed by package name.
-    details: std::sync::Mutex<HashMap<String, CargoPackageDetails>>,
-    workspace_details: std::sync::Mutex<Option<CargoWorkspaceDetails>>,
+    details: HashMap<String, CargoPackageDetails>,
+    workspace_details: Option<CargoWorkspaceDetails>,
     /// The cargo binary, resolved lazily so runs without Cargo tasks never
     /// pay for a PATH scan.
     cargo_binary: std::sync::OnceLock<Result<std::path::PathBuf, which::Error>>,
@@ -1004,35 +1014,25 @@ enum CargoCommandError {
 }
 
 impl CargoToolchain {
-    pub fn new(repo_root: AbsoluteSystemPathBuf) -> Arc<Self> {
+    fn prepared(
+        repo_root: AbsoluteSystemPathBuf,
+        details: HashMap<String, CargoPackageDetails>,
+        workspace_details: Option<CargoWorkspaceDetails>,
+    ) -> Arc<Self> {
         Arc::new(Self {
             repo_root,
-            details: std::sync::Mutex::new(HashMap::new()),
-            workspace_details: std::sync::Mutex::new(None),
+            details,
+            workspace_details,
             cargo_binary: std::sync::OnceLock::new(),
         })
     }
 
-    fn package_details(&self, package: &str) -> Option<CargoPackageDetails> {
-        self.details
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .get(package)
-            .cloned()
+    fn package_details(&self, package: &str) -> Option<&CargoPackageDetails> {
+        self.details.get(package)
     }
 
-    fn record_details(&self, package: String, details: CargoPackageDetails) {
-        self.details
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .insert(package, details);
-    }
-
-    fn workspace_details(&self) -> Option<CargoWorkspaceDetails> {
-        self.workspace_details
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .clone()
+    fn workspace_details(&self) -> Option<&CargoWorkspaceDetails> {
+        self.workspace_details.as_ref()
     }
 }
 
@@ -1151,7 +1151,7 @@ impl Toolchain for CargoToolchain {
             .package_name()
             .and_then(|name| self.package_details(&name))
             .map(|details| {
-                registered_tasks(&details)
+                registered_tasks(details)
                     .into_iter()
                     .map(str::to_string)
                     .collect()
@@ -1163,7 +1163,7 @@ impl Toolchain for CargoToolchain {
         package
             .package_name()
             .and_then(|name| self.package_details(&name))
-            .is_some_and(|details| registered_tasks(&details).contains(&task))
+            .is_some_and(|details| registered_tasks(details).contains(&task))
     }
 
     /// Route rustc invocations through the embedded sccache, with the
@@ -1254,11 +1254,8 @@ impl Toolchain for CargoToolchain {
     }
 
     fn additional_affected_packages(&self, package: &str) -> Vec<String> {
-        let details = self
+        let mut affected: Vec<_> = self
             .details
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let mut affected: Vec<_> = details
             .iter()
             .filter(|(_, details)| details.kind != CargoPackageKind::Workspace)
             .filter(|(_, details)| {
@@ -1280,10 +1277,7 @@ impl Toolchain for CargoToolchain {
         prefer_workspace: bool,
     ) -> Option<Vec<String>> {
         let subcommand = library_subcommand(task)?;
-        let details = self
-            .details
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let details = &self.details;
         if subcommand == "build" {
             let crates: Vec<_> = candidates
                 .iter()
@@ -1330,10 +1324,6 @@ impl Toolchain for CargoToolchain {
                 .cloned()
                 .collect(),
         )
-    }
-
-    fn watch_spec(&self) -> toolchain::WatchSpec {
-        watch_spec()
     }
 
     /// Prune the Cargo workspace machinery around the kept crates:
@@ -1537,8 +1527,8 @@ impl Toolchain for CargoToolchain {
                             .and_then(|workspace| {
                                 let layout = cargo_output_layout(
                                     &self.repo_root,
-                                    &workspace,
-                                    &details,
+                                    workspace,
+                                    details,
                                     context,
                                 )?;
                                 let effective_target =
@@ -1580,8 +1570,10 @@ impl Toolchain for CargoToolchain {
 
         Some(io)
     }
+}
 
-    fn discover_packages(&self) -> DiscoverPackagesFuture<'_> {
+impl CargoAdapter {
+    fn prepare(&self) -> EcosystemContributionFuture<'_, Arc<CargoToolchain>> {
         Box::pin(async move {
             // Discovery spawns `cargo metadata` synchronously, so keep it off
             // the async runtime like the JavaScript manifest-parsing path.
@@ -1596,7 +1588,14 @@ impl Toolchain for CargoToolchain {
                     turborepo_rayon_compat::block_in_place(|| validate_lockfile(&self.repo_root))
                         .map_err(|err| toolchain::Error::Failed(Box::new(err)))?;
                 }
-                return Ok(Vec::new());
+                return Ok(EcosystemContribution {
+                    packages: Vec::new(),
+                    prepared_runtime: CargoToolchain::prepared(
+                        self.repo_root.clone(),
+                        HashMap::new(),
+                        None,
+                    ),
+                });
             }
 
             // Using Turborepo with Rust requires naming the workspace: the
@@ -1636,24 +1635,19 @@ impl Toolchain for CargoToolchain {
                     ))
                 })
                 .map_err(|err| toolchain::Error::Failed(Box::new(err)))?;
-            if let Some(target_directory) = target_directory {
+            let workspace_details = target_directory.map(|target_directory| {
                 let startup_environment = CargoHomeEnvironment::current();
                 let config = cargo_config_influence(&self.repo_root, &startup_environment);
-                *self
-                    .workspace_details
-                    .lock()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner()) =
-                    Some(CargoWorkspaceDetails {
-                        target_directory,
-                        host_target,
-                        supported_targets,
-                        repository_config_alters_output_layout: config
-                            .repository_alters_output_layout,
-                        repository_config_untracked: config.repository_config_untracked,
-                        external_config_present: config.external_present,
-                        manifest_alters_profile_dirs: manifest_alters_profile_dirs(&self.repo_root),
-                    });
-            }
+                CargoWorkspaceDetails {
+                    target_directory,
+                    host_target,
+                    supported_targets,
+                    repository_config_alters_output_layout: config.repository_alters_output_layout,
+                    repository_config_untracked: config.repository_config_untracked,
+                    external_config_present: config.external_present,
+                    manifest_alters_profile_dirs: manifest_alters_profile_dirs(&self.repo_root),
+                }
+            });
             let workspace_externals: HashSet<turborepo_lockfiles::Package> = closures
                 .values()
                 .flatten()
@@ -1663,6 +1657,7 @@ impl Toolchain for CargoToolchain {
 
             let mut packages = Vec::with_capacity(crates.len() + 1);
             let mut crate_names = Vec::with_capacity(crates.len());
+            let mut details = HashMap::with_capacity(crates.len() + 1);
             for cargo_crate in crates {
                 let dependencies = cargo_crate
                     .internal_dependencies
@@ -1682,7 +1677,7 @@ impl Toolchain for CargoToolchain {
                     })
                     .map(|dir| dir.to_unix().to_string())
                     .unwrap_or_default();
-                self.record_details(
+                details.insert(
                     cargo_crate.name.clone(),
                     CargoPackageDetails {
                         kind,
@@ -1715,7 +1710,7 @@ impl Toolchain for CargoToolchain {
             // name`. It depends on every crate so `--affected` and
             // dependent-filters propagate crate changes to it.
             if !crate_names.is_empty() {
-                self.record_details(
+                details.insert(
                     workspace_name.clone(),
                     CargoPackageDetails {
                         kind: CargoPackageKind::Workspace,
@@ -1742,7 +1737,35 @@ impl Toolchain for CargoToolchain {
                 });
             }
 
-            Ok(packages)
+            Ok(EcosystemContribution {
+                packages,
+                prepared_runtime: CargoToolchain::prepared(
+                    self.repo_root.clone(),
+                    details,
+                    workspace_details,
+                ),
+            })
+        })
+    }
+}
+
+impl EcosystemAdapter for CargoAdapter {
+    fn id(&self) -> ToolchainId {
+        ToolchainId::RUST
+    }
+
+    fn watch_spec(&self) -> toolchain::WatchSpec {
+        watch_spec()
+    }
+
+    fn contribute(&self) -> ContributeFuture<'_> {
+        Box::pin(async move {
+            let contribution = self.prepare().await?;
+            let prepared_runtime: Arc<dyn Toolchain> = contribution.prepared_runtime;
+            Ok(EcosystemContribution {
+                packages: contribution.packages,
+                prepared_runtime,
+            })
         })
     }
 }
@@ -2737,10 +2760,11 @@ dependencies = ["lib-a"]
         write(&root, &["src", "lib.rs"], "");
         generate_lockfile(&root);
 
-        let error = CargoToolchain::new(root)
-            .discover_packages()
+        let error = CargoAdapter::new(root)
+            .prepare()
             .await
-            .unwrap_err();
+            .err()
+            .expect("root package must fail");
         assert!(
             error.to_string().contains("root-package")
                 && error.to_string().contains("root Cargo.toml"),
@@ -3452,8 +3476,11 @@ release: 1.96.0-nightly\n",
             "[workspace]\nmembers = [\"crates/*\"]\nresolver = \"2\"\n",
         );
 
-        let toolchain = CargoToolchain::new(root.clone());
-        let err = toolchain.discover_packages().await.unwrap_err();
+        let err = CargoAdapter::new(root.clone())
+            .prepare()
+            .await
+            .err()
+            .expect("missing workspace name must fail");
         assert!(
             err.to_string().contains("[workspace.metadata]"),
             "the error must show the fix, got: {err}"
@@ -3536,7 +3563,7 @@ release: 1.96.0-nightly\n",
     #[test]
     fn test_compile_cache_env_routes_rustc_through_sccache() {
         let (_tmp, root) = tempdir_root();
-        let toolchain = CargoToolchain::new(root);
+        let toolchain = CargoToolchain::prepared(root, HashMap::new(), None);
         let endpoint = toolchain::CompileCacheEndpoint {
             url: "http://127.0.0.1:42123".to_string(),
             token: "proxy-token".to_string(),
@@ -3573,7 +3600,7 @@ release: 1.96.0-nightly\n",
     #[test]
     fn test_compile_cache_env_stands_down_for_competing_configuration() {
         let (_tmp, root) = tempdir_root();
-        let toolchain = CargoToolchain::new(root);
+        let toolchain = CargoToolchain::prepared(root, HashMap::new(), None);
         let endpoint = toolchain::CompileCacheEndpoint {
             url: "http://127.0.0.1:42123".to_string(),
             token: "proxy-token".to_string(),
@@ -3604,7 +3631,7 @@ release: 1.96.0-nightly\n",
         // a competing compiler cache: the injection proceeds and the
         // explicit value is left alone.
         let (_tmp, root) = tempdir_root();
-        let toolchain = CargoToolchain::new(root);
+        let toolchain = CargoToolchain::prepared(root, HashMap::new(), None);
         let endpoint = toolchain::CompileCacheEndpoint {
             url: "http://127.0.0.1:42123".to_string(),
             token: "proxy-token".to_string(),
@@ -3637,10 +3664,10 @@ release: 1.96.0-nightly\n",
         let (_tmp, root) = tempdir_root();
         write_fixture_workspace(&root);
 
-        let toolchain = CargoToolchain::new(root.clone());
-        assert_eq!(toolchain.id(), ToolchainId::RUST);
+        let contribution = CargoAdapter::new(root.clone()).prepare().await.unwrap();
+        assert_eq!(contribution.prepared_runtime.id(), ToolchainId::RUST);
 
-        let mut packages = toolchain.discover_packages().await.unwrap();
+        let mut packages = contribution.packages;
         packages.sort_by(|a, b| {
             a.descriptor
                 .name
@@ -3703,8 +3730,8 @@ release: 1.96.0-nightly\n",
     #[tokio::test(flavor = "multi_thread")]
     async fn test_cargo_toolchain_empty_without_manifest() {
         let (_tmp, root) = tempdir_root();
-        let toolchain = CargoToolchain::new(root);
-        assert!(toolchain.discover_packages().await.unwrap().is_empty());
+        let contribution = CargoAdapter::new(root).prepare().await.unwrap();
+        assert!(contribution.packages.is_empty());
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -3712,8 +3739,8 @@ release: 1.96.0-nightly\n",
         let (_tmp, root) = tempdir_root();
         write(&root, &["Cargo.toml"], "[workspace]\nmembers = []\n");
 
-        let toolchain = CargoToolchain::new(root);
-        assert!(toolchain.discover_packages().await.unwrap().is_empty());
+        let contribution = CargoAdapter::new(root).prepare().await.unwrap();
+        assert!(contribution.packages.is_empty());
     }
 
     fn package_info(name: &str, manifest_rel: &str) -> crate::package_graph::PackageInfo {
@@ -3740,9 +3767,11 @@ release: 1.96.0-nightly\n",
         let (_tmp, root) = tempdir_root();
         write_fixture_workspace(&root);
 
-        let toolchain = CargoToolchain::new(root.clone());
-        // Discovery records the per-package details command resolution uses.
-        toolchain.discover_packages().await.unwrap();
+        let toolchain = CargoAdapter::new(root.clone())
+            .prepare()
+            .await
+            .unwrap()
+            .prepared_runtime;
 
         let app = package_info("app", "crates/app/Cargo.toml");
         let lib_a = package_info("lib-a", "crates/lib-a/Cargo.toml");
@@ -3928,8 +3957,11 @@ release: 1.96.0-nightly\n",
         let (_tmp, root) = tempdir_root();
         write_fixture_workspace(&root);
 
-        let toolchain = CargoToolchain::new(root.clone());
-        toolchain.discover_packages().await.unwrap();
+        let toolchain = CargoAdapter::new(root.clone())
+            .prepare()
+            .await
+            .unwrap()
+            .prepared_runtime;
 
         let lib_a = package_info("lib-a", "crates/lib-a/Cargo.toml");
         let workspace = package_info("fixture-ws", "Cargo.toml");
@@ -3973,8 +4005,11 @@ release: 1.96.0-nightly\n",
         let (_tmp, root) = tempdir_root();
         write_fixture_workspace(&root);
 
-        let toolchain = CargoToolchain::new(root.clone());
-        toolchain.discover_packages().await.unwrap();
+        let toolchain = CargoAdapter::new(root.clone())
+            .prepare()
+            .await
+            .unwrap()
+            .prepared_runtime;
 
         let app = package_info("app", "crates/app/Cargo.toml");
         let lib_a = package_info("lib-a", "crates/lib-a/Cargo.toml");

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -23,7 +23,8 @@ use crate::{
     package_json::{DependencyKind, PackageJson},
     package_manager::{PackageManager, pnpm::PnpmCatalogs},
     toolchain::{
-        DiscoveredPackage, JavaScriptToolchain, Toolchain, ToolchainId, ToolchainRegistry,
+        DiscoveredPackage, DuplicateToolchainError, EcosystemAdapter, JavaScriptToolchain,
+        Toolchain, ToolchainId, ToolchainRegistry,
     },
 };
 
@@ -46,6 +47,7 @@ pub struct PackageGraphBuilder<'a, T> {
     /// are discovered alongside JavaScript packages; name collisions across
     /// toolchains are a hard error.
     extra_toolchains: Vec<Arc<dyn Toolchain>>,
+    ecosystem_adapters: Vec<Arc<dyn EcosystemAdapter>>,
 }
 
 #[derive(Debug, Diagnostic, thiserror::Error)]
@@ -69,6 +71,25 @@ pub enum Error {
     PackageJson(#[from] crate::package_json::Error),
     #[error("package.json must have a name field:\n{0}")]
     PackageJsonMissingName(AbsoluteSystemPathBuf),
+    #[error("package contributed by toolchain {toolchain} must have a name:\n{manifest}")]
+    AdapterPackageMissingName {
+        toolchain: ToolchainId,
+        manifest: AbsoluteSystemPathBuf,
+    },
+    #[error("package contributed by toolchain {toolchain} is outside the repository:\n{manifest}")]
+    AdapterPackageOutsideRepository {
+        toolchain: ToolchainId,
+        manifest: AbsoluteSystemPathBuf,
+    },
+    #[error("ecosystem adapter {adapter} prepared a runtime for a different toolchain: {runtime}")]
+    AdapterRuntimeMismatch {
+        adapter: ToolchainId,
+        runtime: ToolchainId,
+    },
+    #[error("ecosystem adapters are not supported in single-package mode")]
+    AdapterInSinglePackageMode,
+    #[error(transparent)]
+    DuplicateToolchain(#[from] DuplicateToolchainError),
     #[error(transparent)]
     Lockfile(#[from] turborepo_lockfiles::Error),
     #[error(transparent)]
@@ -114,9 +135,9 @@ impl<'a> PackageGraphBuilder<'a, LocalPackageDiscoveryBuilder> {
     /// Build over a repository that may have no root `package.json`. When
     /// `root_package_json` is `None`, the JavaScript toolchain contributes
     /// nothing (no package manager, no lockfile); the graph is populated
-    /// entirely by the extra toolchains registered via
-    /// [`PackageGraphBuilder::with_toolchain`] (Cargo). When it is `Some`,
-    /// this behaves exactly like [`PackageGraphBuilder::new`].
+    /// entirely by ecosystem adapters registered via
+    /// [`PackageGraphBuilder::with_ecosystem_adapter`] (Cargo). When it is
+    /// `Some`, this behaves exactly like [`PackageGraphBuilder::new`].
     pub fn new_optional(
         repo_root: &'a AbsoluteSystemPath,
         root_package_json: Option<PackageJson>,
@@ -136,6 +157,7 @@ impl<'a> PackageGraphBuilder<'a, LocalPackageDiscoveryBuilder> {
             defer_closures: false,
             closure_hasher: None,
             extra_toolchains: Vec::new(),
+            ecosystem_adapters: Vec::new(),
         }
     }
 
@@ -199,6 +221,13 @@ impl<'a, P> PackageGraphBuilder<'a, P> {
         self
     }
 
+    /// Register a reusable discovery adapter. Its fresh prepared runtime is
+    /// committed to the graph only after all contributed packages validate.
+    pub fn with_ecosystem_adapter(mut self, adapter: Arc<dyn EcosystemAdapter>) -> Self {
+        self.ecosystem_adapters.push(adapter);
+        self
+    }
+
     /// Set the package discovery strategy to use. Note that whatever strategy
     /// selected here will be wrapped in a `CachingPackageDiscovery` to
     /// prevent unnecessary work during building.
@@ -217,6 +246,7 @@ impl<'a, P> PackageGraphBuilder<'a, P> {
             defer_closures: self.defer_closures,
             closure_hasher: self.closure_hasher,
             extra_toolchains: self.extra_toolchains,
+            ecosystem_adapters: self.ecosystem_adapters,
         }
     }
 }
@@ -231,6 +261,9 @@ where
     #[tracing::instrument(skip(self))]
     pub async fn build(mut self) -> Result<PackageGraph, Error> {
         let is_single_package = self.is_single_package;
+        if is_single_package && !self.ecosystem_adapters.is_empty() {
+            return Err(Error::AdapterInSinglePackageMode);
+        }
 
         // If no pre-supplied lockfile, start reading it on a blocking thread
         // concurrently with package discovery + JSON parsing. A pure Cargo
@@ -298,9 +331,10 @@ struct BuildState<'a, S, T> {
     /// pure Cargo workspace, where there is no JavaScript project to resolve
     /// a package manager or lockfile from.
     javascript: Option<Arc<JavaScriptToolchain<T>>>,
-    /// Every toolchain contributing packages, JavaScript included. Package
-    /// discovery goes through this and only this.
+    /// Prepared behavior runtimes, plus compatibility toolchains (including
+    /// JavaScript) that still own their discovery.
     toolchains: ToolchainRegistry,
+    ecosystem_adapters: Vec<Arc<dyn EcosystemAdapter>>,
 }
 
 // Allows us to perform workspace discovery and parse package jsons
@@ -342,6 +376,7 @@ where
             package_discovery,
             package_manager: _,
             extra_toolchains,
+            ecosystem_adapters,
         } = builder;
         // Pure Cargo workspace: with no root package.json there is no
         // JavaScript project, so the JavaScript toolchain is neither
@@ -388,11 +423,11 @@ where
             // JavaScript registers first: its packages claim names before any
             // other toolchain's, so a cross-toolchain collision surfaces as the
             // non-JS package failing to add.
-            toolchains.register(javascript.clone());
+            toolchains.register(javascript.clone())?;
             Some(javascript)
         };
         for toolchain in extra_toolchains {
-            toolchains.register(toolchain);
+            toolchains.register(toolchain)?;
         }
 
         Ok(BuildState {
@@ -412,6 +447,7 @@ where
             state: std::marker::PhantomData,
             javascript,
             toolchains,
+            ecosystem_adapters,
         })
     }
 }
@@ -501,6 +537,45 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             discovered.extend(packages.into_iter().map(|package| (id.clone(), package)));
         }
 
+        let mut prepared_runtimes = Vec::with_capacity(self.ecosystem_adapters.len());
+        for adapter in &self.ecosystem_adapters {
+            let id = adapter.id();
+            let contribution = adapter.contribute().await?;
+            let runtime_id = contribution.prepared_runtime.id();
+            if runtime_id != id {
+                return Err(Error::AdapterRuntimeMismatch {
+                    adapter: id,
+                    runtime: runtime_id,
+                });
+            }
+            for package in &contribution.packages {
+                if package
+                    .descriptor
+                    .name
+                    .as_ref()
+                    .is_none_or(|name| name.as_inner().is_empty())
+                {
+                    return Err(Error::AdapterPackageMissingName {
+                        toolchain: id.clone(),
+                        manifest: package.manifest_path.clone(),
+                    });
+                }
+                if !self.repo_root.contains(&package.manifest_path) {
+                    return Err(Error::AdapterPackageOutsideRepository {
+                        toolchain: id.clone(),
+                        manifest: package.manifest_path.clone(),
+                    });
+                }
+            }
+            discovered.extend(
+                contribution
+                    .packages
+                    .into_iter()
+                    .map(|package| (id.clone(), package)),
+            );
+            prepared_runtimes.push(contribution.prepared_runtime);
+        }
+
         self.workspaces.reserve(discovered.len());
         self.node_lookup.reserve(discovered.len());
 
@@ -519,6 +594,11 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
                 Err(err) => return Err(err),
             }
         }
+        // A collision returns before the prepared runtimes enter even this
+        // build-local registry; no adapter-owned state was mutated either way.
+        for runtime in prepared_runtimes {
+            self.toolchains.register(runtime)?;
+        }
 
         let Self {
             repo_root,
@@ -532,6 +612,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             lockfile,
             javascript,
             toolchains,
+            ecosystem_adapters: _,
             defer_closures,
             closure_hasher,
             ..
@@ -548,6 +629,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             lockfile,
             javascript,
             toolchains,
+            ecosystem_adapters: Vec::new(),
             defer_closures,
             closure_hasher,
             package_jsons: None,
@@ -567,6 +649,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             lockfile,
             javascript,
             toolchains,
+            ecosystem_adapters: _,
             repo_root,
             ..
         } = self;
@@ -776,6 +859,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             state: std::marker::PhantomData,
             javascript,
             toolchains,
+            ecosystem_adapters: Vec::new(),
         })
     }
 }
@@ -1020,7 +1104,7 @@ impl PackageInfo {
 
 #[cfg(test)]
 mod test {
-    use std::{assert_matches, collections::HashMap};
+    use std::{assert_matches, collections::HashMap, sync::Arc};
 
     use turborepo_errors::Spanned;
 
@@ -1042,6 +1126,114 @@ mod test {
         ) -> Result<crate::discovery::DiscoveryResponse, crate::discovery::Error> {
             self.discover_packages().await
         }
+    }
+
+    struct FakeRuntime(ToolchainId);
+
+    impl Toolchain for FakeRuntime {
+        fn id(&self) -> ToolchainId {
+            self.0.clone()
+        }
+    }
+
+    struct FakeAdapter {
+        id: ToolchainId,
+        runtime_id: ToolchainId,
+        package: DiscoveredPackage,
+    }
+
+    impl EcosystemAdapter for FakeAdapter {
+        fn id(&self) -> ToolchainId {
+            self.id.clone()
+        }
+
+        fn watch_spec(&self) -> crate::toolchain::WatchSpec {
+            crate::toolchain::WatchSpec::default()
+        }
+
+        fn contribute(&self) -> crate::toolchain::ContributeFuture<'_> {
+            let packages = vec![self.package.clone()];
+            let runtime: Arc<dyn Toolchain> = Arc::new(FakeRuntime(self.runtime_id.clone()));
+            Box::pin(async move {
+                Ok(crate::toolchain::EcosystemContribution {
+                    packages,
+                    prepared_runtime: runtime,
+                })
+            })
+        }
+    }
+
+    fn fake_adapter(
+        root: &AbsoluteSystemPath,
+        id: &str,
+        runtime_id: &str,
+        name: Option<&str>,
+    ) -> Arc<dyn EcosystemAdapter> {
+        Arc::new(FakeAdapter {
+            id: ToolchainId::new(id.to_string()),
+            runtime_id: ToolchainId::new(runtime_id.to_string()),
+            package: DiscoveredPackage {
+                descriptor: PackageJson {
+                    name: name.map(|name| Spanned::new(name.to_string())),
+                    ..Default::default()
+                },
+                manifest_path: root.join_component(&format!("{id}.toml")),
+                external_dependencies: None,
+            },
+        })
+    }
+
+    #[tokio::test]
+    async fn adapter_runtime_id_must_match_contribution_id() {
+        let root = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPathBuf::try_from(root.path()).unwrap();
+        let result = PackageGraphBuilder::new_optional(&root, None)
+            .with_ecosystem_adapter(fake_adapter(&root, "rust", "other", Some("app")))
+            .build()
+            .await;
+
+        assert!(matches!(result, Err(Error::AdapterRuntimeMismatch { .. })));
+    }
+
+    #[tokio::test]
+    async fn adapter_packages_require_names() {
+        let root = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPathBuf::try_from(root.path()).unwrap();
+        let result = PackageGraphBuilder::new_optional(&root, None)
+            .with_ecosystem_adapter(fake_adapter(&root, "rust", "rust", None))
+            .build()
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(Error::AdapterPackageMissingName { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn adapter_ids_must_be_unique() {
+        let root = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPathBuf::try_from(root.path()).unwrap();
+        let result = PackageGraphBuilder::new_optional(&root, None)
+            .with_ecosystem_adapter(fake_adapter(&root, "rust", "rust", Some("app")))
+            .with_ecosystem_adapter(fake_adapter(&root, "rust", "rust", Some("lib")))
+            .build()
+            .await;
+
+        assert!(matches!(result, Err(Error::DuplicateToolchain(_))));
+    }
+
+    #[tokio::test]
+    async fn adapters_are_rejected_in_single_package_mode() {
+        let root = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPathBuf::try_from(root.path()).unwrap();
+        let result = PackageGraphBuilder::new_optional(&root, None)
+            .with_single_package_mode(true)
+            .with_ecosystem_adapter(fake_adapter(&root, "rust", "rust", Some("app")))
+            .build()
+            .await;
+
+        assert!(matches!(result, Err(Error::AdapterInSinglePackageMode)));
     }
 
     // Regression test: connect_internal_dependencies must produce correct

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -1974,7 +1974,7 @@ version = "0.1.0"
                 map
             }))
             .with_lockfile(Some(Box::new(MockLockfile {})))
-            .with_toolchain(crate::cargo::CargoToolchain::new(root.clone()))
+            .with_ecosystem_adapter(crate::cargo::CargoAdapter::new(root.clone()))
             .build()
             .await
             .unwrap();
@@ -2048,7 +2048,7 @@ version = "0.1.0"
         write_cargo_workspace_fixture(&root);
 
         let pkg_graph = PackageGraph::builder_optional(&root, None)
-            .with_toolchain(crate::cargo::CargoToolchain::new(root.clone()))
+            .with_ecosystem_adapter(crate::cargo::CargoAdapter::new(root.clone()))
             .build()
             .await
             .unwrap();
@@ -2084,6 +2084,127 @@ version = "0.1.0"
         );
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_cargo_rediscovery_prepares_graph_local_runtime() {
+        let (_tmp, root) = canonical_tempdir();
+        write_cargo_workspace_fixture(&root);
+        let adapter = crate::cargo::CargoAdapter::new(root.clone());
+
+        let graph_a = PackageGraph::builder_optional(&root, None)
+            .with_ecosystem_adapter(adapter.clone())
+            .build()
+            .await
+            .unwrap();
+        let app_name = PackageName::from("app");
+        let app_a = graph_a.package_info(&app_name).unwrap();
+        assert!(
+            graph_a
+                .toolchains()
+                .get(&crate::toolchain::ToolchainId::RUST)
+                .unwrap()
+                .defines_task(app_a, "run")
+        );
+
+        // Rediscovery through the same adapter sees `app` change from an
+        // entrypoint to a library. Graph A must retain its original behavior.
+        std::fs::write(
+            root.join_components(&["rust", "app", "Cargo.toml"])
+                .as_std_path(),
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\nedition = \
+             \"2021\"\n\n[dependencies]\nlib-a = { path = \"../lib-a\" }\n",
+        )
+        .unwrap();
+        std::fs::remove_file(
+            root.join_components(&["rust", "app", "src", "main.rs"])
+                .as_std_path(),
+        )
+        .unwrap();
+        std::fs::write(
+            root.join_components(&["rust", "app", "src", "lib.rs"])
+                .as_std_path(),
+            "",
+        )
+        .unwrap();
+
+        let graph_b = PackageGraph::builder_optional(&root, None)
+            .with_ecosystem_adapter(adapter.clone())
+            .build()
+            .await
+            .unwrap();
+        let app_b = graph_b.package_info(&app_name).unwrap();
+        assert!(
+            !graph_b
+                .toolchains()
+                .get(&crate::toolchain::ToolchainId::RUST)
+                .unwrap()
+                .defines_task(app_b, "run")
+        );
+        assert!(graph_a.package_info(&app_name).is_some());
+        assert!(
+            graph_a
+                .toolchains()
+                .get(&crate::toolchain::ToolchainId::RUST)
+                .unwrap()
+                .defines_task(app_a, "run")
+        );
+
+        // A memberless contribution must not retain behavior from either
+        // earlier graph.
+        std::fs::write(
+            root.join_component("Cargo.toml").as_std_path(),
+            "[workspace]\nmembers = []\n",
+        )
+        .unwrap();
+        let graph_c = PackageGraph::builder_optional(&root, None)
+            .with_ecosystem_adapter(adapter.clone())
+            .build()
+            .await
+            .unwrap();
+        assert!(graph_c.package_info(&app_name).is_none());
+        assert!(
+            !graph_c
+                .toolchains()
+                .get(&crate::toolchain::ToolchainId::RUST)
+                .unwrap()
+                .defines_task(app_a, "run")
+        );
+
+        // A later contribution that core rejects must likewise have no route
+        // to mutate any successfully constructed graph. Restore `app` as an
+        // entrypoint so leaking the rejected runtime would be observable on B.
+        write_cargo_workspace_fixture(&root);
+        let failed = PackageGraph::builder(
+            &root,
+            PackageJson::from_value(json!({ "name": "root" })).unwrap(),
+        )
+        .with_package_discovery(MockDiscovery)
+        .with_package_jsons(Some(HashMap::from([(
+            root.join_components(&["js-app", "package.json"]),
+            PackageJson::from_value(json!({ "name": "app" })).unwrap(),
+        )])))
+        .with_lockfile(Some(Box::new(MockLockfile {})))
+        .with_ecosystem_adapter(adapter)
+        .build()
+        .await;
+        assert!(matches!(failed, Err(Error::DuplicateWorkspace { .. })));
+        assert!(graph_a.package_info(&app_name).is_some());
+        assert!(graph_b.package_info(&app_name).is_some());
+        assert!(
+            graph_a
+                .toolchains()
+                .get(&crate::toolchain::ToolchainId::RUST)
+                .unwrap()
+                .defines_task(app_a, "run")
+        );
+        assert!(
+            !graph_b
+                .toolchains()
+                .get(&crate::toolchain::ToolchainId::RUST)
+                .unwrap()
+                .defines_task(app_b, "run")
+        );
+    }
+
     /// A crate and a JS package sharing a name is a hard error, like any
     /// other duplicate package name.
     #[tokio::test(flavor = "multi_thread")]
@@ -2105,7 +2226,7 @@ version = "0.1.0"
             map
         }))
         .with_lockfile(Some(Box::new(MockLockfile {})))
-        .with_toolchain(crate::cargo::CargoToolchain::new(root.clone()))
+        .with_ecosystem_adapter(crate::cargo::CargoAdapter::new(root.clone()))
         .build()
         .await;
 

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -1,17 +1,15 @@
 //! Toolchains: the abstraction that makes Turborepo generic over language
 //! ecosystems.
 //!
-//! A [`Toolchain`] answers ecosystem-specific questions about packages —
-//! starting with "which packages exist?" — so that the package graph and the
-//! rest of the system never branch on a specific ecosystem. JavaScript is the
-//! first implementation ([`JavaScriptToolchain`]); additional toolchains
-//! (e.g. Cargo) register alongside it in the [`ToolchainRegistry`].
+//! An [`EcosystemAdapter`] discovers packages and prepares a graph-local
+//! [`Toolchain`] runtime. The runtime answers ecosystem-specific behavioral
+//! questions, so the package graph and the rest of the system never branch on
+//! a specific ecosystem. JavaScript temporarily combines these roles for
+//! compatibility; Cargo uses the split model.
 //!
-//! The trait grows one concern at a time (discovery today; command
-//! resolution, derived task inputs/outputs, external-dependency hashing,
-//! watch triggers, and prune participation as they are needed), and every
-//! concern must ship with real implementations for every registered
-//! toolchain.
+//! `Toolchain` remains a compatibility runtime while those behavioral answers
+//! move into core-owned contribution data. New discovery state belongs in
+//! [`EcosystemContribution`], not on a `Toolchain` implementation.
 //!
 //! # Design rules
 //!
@@ -141,6 +139,30 @@ pub enum Error {
 pub type DiscoverPackagesFuture<'a> =
     Pin<Box<dyn Future<Output = Result<Vec<DiscoveredPackage>, Error>> + Send + 'a>>;
 
+/// A complete, graph-local contribution from an ecosystem adapter.
+///
+/// Discovery and preparation happen together, but core owns committing both:
+/// the runtime is registered only after every package has been accepted by the
+/// package graph builder.
+pub struct EcosystemContribution<R> {
+    pub packages: Vec<DiscoveredPackage>,
+    pub prepared_runtime: R,
+}
+
+pub type EcosystemContributionFuture<'a, R> =
+    Pin<Box<dyn Future<Output = Result<EcosystemContribution<R>, Error>> + Send + 'a>>;
+pub type ContributeFuture<'a> = EcosystemContributionFuture<'a, Arc<dyn Toolchain>>;
+
+/// Stateless, reusable input to package graph construction.
+///
+/// Each call prepares a fresh immutable behavior runtime for the graph being
+/// built. Adapters must not expose partially discovered state.
+pub trait EcosystemAdapter: Send + Sync {
+    fn id(&self) -> ToolchainId;
+    fn watch_spec(&self) -> WatchSpec;
+    fn contribute(&self) -> ContributeFuture<'_>;
+}
+
 /// A command resolved by a toolchain for a task, as plain data. The executor
 /// turns it into a process, applying the task's environment, stdin policy,
 /// and any decorations that are not toolchain concerns (e.g.
@@ -193,8 +215,11 @@ pub trait Toolchain: Send + Sync {
     /// This toolchain's identifier.
     fn id(&self) -> ToolchainId;
 
-    /// Discover this toolchain's packages.
-    fn discover_packages(&self) -> DiscoverPackagesFuture<'_>;
+    /// Compatibility discovery path. Prepared runtimes should leave this at
+    /// its empty default; adapters own discovery for core-built graphs.
+    fn discover_packages(&self) -> DiscoverPackagesFuture<'_> {
+        Box::pin(async { Ok(Vec::new()) })
+    }
 
     /// Resolve the command that implements `task` for `package`, or `None`
     /// when the toolchain defines no command for it — the task is then a
@@ -597,19 +622,26 @@ pub struct ToolchainRegistry {
     toolchains: Vec<Arc<dyn Toolchain>>,
 }
 
+#[derive(Debug, thiserror::Error)]
+#[error("toolchain {0:?} was registered more than once")]
+pub struct DuplicateToolchainError(ToolchainId);
+
 impl ToolchainRegistry {
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Register a toolchain. Registration order is discovery order.
-    pub fn register(&mut self, toolchain: Arc<dyn Toolchain>) {
-        debug_assert!(
-            self.get(&toolchain.id()).is_none(),
-            "toolchain {} registered twice",
-            toolchain.id()
-        );
+    pub fn register(
+        &mut self,
+        toolchain: Arc<dyn Toolchain>,
+    ) -> Result<(), DuplicateToolchainError> {
+        let id = toolchain.id();
+        if self.get(&id).is_some() {
+            return Err(DuplicateToolchainError(id));
+        }
         self.toolchains.push(toolchain);
+        Ok(())
     }
 
     pub fn get(&self, id: &ToolchainId) -> Option<&dyn Toolchain> {
@@ -1079,12 +1111,21 @@ mod tests {
         }
 
         let mut registry = ToolchainRegistry::new();
-        registry.register(Arc::new(Fake(ToolchainId::JAVASCRIPT)));
-        registry.register(Arc::new(Fake(ToolchainId::new("gleam"))));
+        registry
+            .register(Arc::new(Fake(ToolchainId::JAVASCRIPT)))
+            .unwrap();
+        registry
+            .register(Arc::new(Fake(ToolchainId::new("gleam"))))
+            .unwrap();
 
         assert!(registry.get(&ToolchainId::JAVASCRIPT).is_some());
         assert!(registry.get(&ToolchainId::new("gleam")).is_some());
         assert!(registry.get(&ToolchainId::new("zig")).is_none());
         assert_eq!(registry.iter().count(), 2);
+        assert!(
+            registry
+                .register(Arc::new(Fake(ToolchainId::new("gleam"))))
+                .is_err()
+        );
     }
 }

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -148,10 +148,14 @@ topological (`^`) dependencies.
 
 #### Toolchains (`crates/turborepo-repository/src/toolchain.rs`)
 
-The package graph is generic over language toolchains. A `Toolchain` answers
-ecosystem-specific questions — which packages exist, what command a task
-runs, what hash wiring a task derives — so graph construction and execution
-never branch on a specific ecosystem. All lookups go through the
+The package graph is generic over ecosystems. An `EcosystemAdapter` is a
+stateless, reusable graph-construction input: each contribution contains
+discovered packages plus a fresh immutable `Toolchain` behavior runtime. Core
+validates ecosystem identity, package names and paths, and duplicate
+registrations before committing the prepared runtime to the resulting graph. A
+failed build publishes nothing, and watcher rediscovery cannot mutate earlier
+graphs. A `Toolchain` answers behavioral questions —
+what command a task runs and what hash wiring it derives. All lookups go through the
 `ToolchainRegistry` (carried by the `PackageGraph`); `ToolchainId` is an
 open string identifier, not a closed enum; and trait methods are
 coarse-grained and data-in/data-out, keeping the door open to out-of-process
@@ -182,7 +186,8 @@ root and adds them to the package graph. Cargo workspaces can stand alone or
 coexist with JavaScript workspaces; a root `package.json` and JavaScript package
 manager are only required when JavaScript packages participate. Cargo-only
 repositories may omit `package.json`; when one exists, it must still be valid.
-`CargoToolchain` is the second `Toolchain` implementation.
+`CargoAdapter` performs discovery and prepares an immutable, graph-local
+`CargoToolchain`; its only interior memoization is lazy Cargo binary lookup.
 
 Turborepo does not replace Cargo. Cargo is itself a build system with its
 own dependency graph, scheduler, and incremental cache (`target/`), so the
@@ -313,8 +318,8 @@ whether anything changed; Cargo decides how and in what order to build.**
   requested process, and library artifacts have no stable final path to restore.
   An explicit turbo.json `cache` setting overrides the toolchain default.
 
-- **Watch mode** (`Toolchain::watch_spec`, consumed by
-  `turborepo-lib/src/package_changes_watcher.rs`): each toolchain declares
+- **Watch mode** (`EcosystemAdapter::watch_spec`, consumed by
+  `turborepo-lib/src/package_changes_watcher.rs`): each adapter declares
   its workspace-definition files and build-byproduct directories. For
   Cargo, any `Cargo.toml` or the root `Cargo.lock` triggers full
   rediscovery (the crate set or its edges may have changed), while events
@@ -322,10 +327,12 @@ whether anything changed; Cargo decides how and in what order to build.**
   continuously during builds, and the feedback loop must not depend on a
   `.gitignore` entry (`Cargo.toml` files under `target/` are build
   byproducts, not workspace definition). The watcher builds its package
-  graph with the same toolchains a run would register, so watch sees the
+  graph with the same adapters a run would register, so watch sees the
   same package set. JavaScript declares nothing extra: workspace
   redefinition is caught by the change mapper's conservative
-  all-packages fallback. Known gap: the hash watcher's content-hash dedup
+  all-packages fallback. Watch builds a complete replacement graph before
+  publishing a rediscovery event; invalid candidates retain the current graph
+  and later filesystem events retry. Known gap: the hash watcher's content-hash dedup
   is JS-glob-based, so a no-op save inside a crate re-runs its tasks as a
   fast cache hit rather than being suppressed.
 


### PR DESCRIPTION
## Motivation

The first Cargo workspace implementation made `CargoToolchain` responsible for both discovering repository state and answering runtime questions about the resulting package graph. To support those runtime callbacks, discovery wrote package and workspace details into mutable maps on the toolchain.

That ownership does not match the architecture we want for additional ecosystems. Turborepo core should own repository snapshots, package graph construction, validation, caching, filtering, affectedness, and execution. Ecosystem integrations should be inputs that describe native repository facts and nuances using core primitives. They should not remain mutable services that can change the meaning of an already-built graph.

This ownership is wrong for every command because a package graph should be an immutable, self-contained repository snapshot. Watch mode makes the resulting correctness bug especially visible because it reuses one adapter across multiple graph generations. Rediscovery could mutate behavior shared by the old and new graphs: removed crates could remain in toolchain state, package and workspace details could come from different discovery generations, and a failed candidate could affect state even though core never accepted its graph.

A Cargo-local lock or atomic map replacement would repair part of that bug, but it would leave snapshot lifecycle in the wrong layer. This PR instead establishes the first core-owned contribution boundary.

## Approach

- `EcosystemAdapter` is a reusable repository input. Each inspection returns an `EcosystemContribution` containing discovered packages and a fresh immutable, graph-local compatibility runtime.
- `PackageGraphBuilder` validates ecosystem identity, package names and paths, duplicate registrations, and cross-ecosystem package collisions before installing the prepared runtime in the resulting graph.
- `CargoAdapter` performs Cargo discovery using local state. `CargoToolchain` contains only immutable details for one accepted graph, plus lazy Cargo binary lookup as operational memoization.
- Run, watch, daemon, and prune use the same centralized adapter construction path.
- Watch interests remain adapter-owned. Rediscovery constructs a complete candidate before notifying consumers; invalid candidates leave the current graph active and later filesystem events retry.

This gives every accepted graph a stable view of its Cargo packages and behavior. Rediscovering through the same adapter creates a new graph without changing prior graphs.

## Migration Boundary

This is intentionally the first slice, not the completed toolchain architecture. `Toolchain` and `ToolchainRegistry` remain as graph-local compatibility runtimes for command resolution, task defaults, derived task I/O, affectedness, and prune behavior. JavaScript also remains on the legacy combined discovery/runtime path.

Follow-up work can move those callbacks into neutral package, task, invalidation, input/output, watch, and prune contribution data. Establishing immutable graph-local ownership first lets that migration happen without another Cargo-specific snapshot mechanism.

This supersedes #13434, which fixed stale discovery state inside `CargoToolchain` but reinforced toolchain-owned snapshot publication.

## Behavior Changes

- Cargo rediscovery no longer mutates previously built package graphs.
- Failed watcher candidates are not published and do not terminate future rediscovery attempts.
- Cargo-only repositories can initialize package watching without a root `package.json`.
- Ecosystem adapters are explicitly rejected in single-package mode instead of being silently ignored.

## Testing

- `cargo test -p turborepo-repository`
- `cargo test -p turborepo-lib package_changes_watcher --lib`
- `cargo test -p turbo --test cargo_workspace_test`
- `cargo clippy -p turborepo-repository -p turborepo-lib --all-targets -- -D warnings`
- `cargo fmt --package turborepo-repository --package turborepo-lib --package turbo --check`