### PR TITLE
refactor: Add ecosystem contribution boundary

### DIFF
--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -1447,14 +1447,18 @@ mod task_io_context_tests {
         let alpha = ToolchainId::new("alpha");
         let beta = ToolchainId::new("beta");
         let mut toolchains = ToolchainRegistry::new();
-        toolchains.register(Arc::new(Stub {
-            id: alpha.clone(),
-            environment: vec!["ALPHA_*"],
-        }));
-        toolchains.register(Arc::new(Stub {
-            id: beta.clone(),
-            environment: vec!["BETA_KEY"],
-        }));
+        toolchains
+            .register(Arc::new(Stub {
+                id: alpha.clone(),
+                environment: vec!["ALPHA_*"],
+            }))
+            .unwrap();
+        toolchains
+            .register(Arc::new(Stub {
+                id: beta.clone(),
+                environment: vec!["BETA_KEY"],
+            }))
+            .unwrap();
         let environment = EnvironmentVariableMap::from(HashMap::from([
             ("ALPHA_TARGET".to_string(), "alpha".to_string()),
             ("BETA_KEY".to_string(), "beta".to_string()),
@@ -1478,7 +1482,7 @@ mod task_io_context_tests {
         let root = tempfile::tempdir().unwrap();
         let root = AbsoluteSystemPathBuf::try_from(root.path()).unwrap();
         let mut toolchains = ToolchainRegistry::new();
-        toolchains.register(CargoToolchain::new(root));
+        toolchains.register(CargoToolchain::new(root)).unwrap();
         let environment = EnvironmentVariableMap::from(HashMap::from([
             ("RUSTUP_HOME".to_string(), "/rustup".to_string()),
             ("RUSTUP_TOOLCHAIN".to_string(), "stable-host".to_string()),
@@ -1498,10 +1502,12 @@ mod task_io_context_tests {
     fn projected_task_hash(layout: &str, secret: &str) -> String {
         let alpha = ToolchainId::new("alpha");
         let mut toolchains = ToolchainRegistry::new();
-        toolchains.register(Arc::new(Stub {
-            id: alpha.clone(),
-            environment: vec!["ALPHA_*"],
-        }));
+        toolchains
+            .register(Arc::new(Stub {
+                id: alpha.clone(),
+                environment: vec!["ALPHA_*"],
+            }))
+            .unwrap();
         let environment = EnvironmentVariableMap::from(HashMap::from([
             ("ALPHA_TARGET".to_string(), layout.to_string()),
             ("UNDECLARED_SECRET".to_string(), secret.to_string()),

--- a/crates/turborepo-repository/src/package_graph/builder.rs
+++ b/crates/turborepo-repository/src/package_graph/builder.rs
@@ -23,7 +23,8 @@ use crate::{
     package_json::{DependencyKind, PackageJson},
     package_manager::{PackageManager, pnpm::PnpmCatalogs},
     toolchain::{
-        DiscoveredPackage, JavaScriptToolchain, Toolchain, ToolchainId, ToolchainRegistry,
+        DiscoveredPackage, DuplicateToolchainError, EcosystemAdapter, JavaScriptToolchain,
+        Toolchain, ToolchainId, ToolchainRegistry,
     },
 };
 
@@ -46,6 +47,7 @@ pub struct PackageGraphBuilder<'a, T> {
     /// are discovered alongside JavaScript packages; name collisions across
     /// toolchains are a hard error.
     extra_toolchains: Vec<Arc<dyn Toolchain>>,
+    ecosystem_adapters: Vec<Arc<dyn EcosystemAdapter>>,
 }
 
 #[derive(Debug, Diagnostic, thiserror::Error)]
@@ -69,6 +71,25 @@ pub enum Error {
     PackageJson(#[from] crate::package_json::Error),
     #[error("package.json must have a name field:\n{0}")]
     PackageJsonMissingName(AbsoluteSystemPathBuf),
+    #[error("package contributed by toolchain {toolchain} must have a name:\n{manifest}")]
+    AdapterPackageMissingName {
+        toolchain: ToolchainId,
+        manifest: AbsoluteSystemPathBuf,
+    },
+    #[error("package contributed by toolchain {toolchain} is outside the repository:\n{manifest}")]
+    AdapterPackageOutsideRepository {
+        toolchain: ToolchainId,
+        manifest: AbsoluteSystemPathBuf,
+    },
+    #[error("ecosystem adapter {adapter} prepared a runtime for a different toolchain: {runtime}")]
+    AdapterRuntimeMismatch {
+        adapter: ToolchainId,
+        runtime: ToolchainId,
+    },
+    #[error("ecosystem adapters are not supported in single-package mode")]
+    AdapterInSinglePackageMode,
+    #[error(transparent)]
+    DuplicateToolchain(#[from] DuplicateToolchainError),
     #[error(transparent)]
     Lockfile(#[from] turborepo_lockfiles::Error),
     #[error(transparent)]
@@ -114,9 +135,9 @@ impl<'a> PackageGraphBuilder<'a, LocalPackageDiscoveryBuilder> {
     /// Build over a repository that may have no root `package.json`. When
     /// `root_package_json` is `None`, the JavaScript toolchain contributes
     /// nothing (no package manager, no lockfile); the graph is populated
-    /// entirely by the extra toolchains registered via
-    /// [`PackageGraphBuilder::with_toolchain`] (Cargo). When it is `Some`,
-    /// this behaves exactly like [`PackageGraphBuilder::new`].
+    /// entirely by ecosystem adapters registered via
+    /// [`PackageGraphBuilder::with_ecosystem_adapter`] (Cargo). When it is
+    /// `Some`, this behaves exactly like [`PackageGraphBuilder::new`].
     pub fn new_optional(
         repo_root: &'a AbsoluteSystemPath,
         root_package_json: Option<PackageJson>,
@@ -136,6 +157,7 @@ impl<'a> PackageGraphBuilder<'a, LocalPackageDiscoveryBuilder> {
             defer_closures: false,
             closure_hasher: None,
             extra_toolchains: Vec::new(),
+            ecosystem_adapters: Vec::new(),
         }
     }
 
@@ -199,6 +221,13 @@ impl<'a, P> PackageGraphBuilder<'a, P> {
         self
     }
 
+    /// Register a reusable discovery adapter. Its fresh prepared runtime is
+    /// committed to the graph only after all contributed packages validate.
+    pub fn with_ecosystem_adapter(mut self, adapter: Arc<dyn EcosystemAdapter>) -> Self {
+        self.ecosystem_adapters.push(adapter);
+        self
+    }
+
     /// Set the package discovery strategy to use. Note that whatever strategy
     /// selected here will be wrapped in a `CachingPackageDiscovery` to
     /// prevent unnecessary work during building.
@@ -217,6 +246,7 @@ impl<'a, P> PackageGraphBuilder<'a, P> {
             defer_closures: self.defer_closures,
             closure_hasher: self.closure_hasher,
             extra_toolchains: self.extra_toolchains,
+            ecosystem_adapters: self.ecosystem_adapters,
         }
     }
 }
@@ -231,6 +261,9 @@ where
     #[tracing::instrument(skip(self))]
     pub async fn build(mut self) -> Result<PackageGraph, Error> {
         let is_single_package = self.is_single_package;
+        if is_single_package && !self.ecosystem_adapters.is_empty() {
+            return Err(Error::AdapterInSinglePackageMode);
+        }
 
         // If no pre-supplied lockfile, start reading it on a blocking thread
         // concurrently with package discovery + JSON parsing. A pure Cargo
@@ -298,9 +331,10 @@ struct BuildState<'a, S, T> {
     /// pure Cargo workspace, where there is no JavaScript project to resolve
     /// a package manager or lockfile from.
     javascript: Option<Arc<JavaScriptToolchain<T>>>,
-    /// Every toolchain contributing packages, JavaScript included. Package
-    /// discovery goes through this and only this.
+    /// Prepared behavior runtimes, plus compatibility toolchains (including
+    /// JavaScript) that still own their discovery.
     toolchains: ToolchainRegistry,
+    ecosystem_adapters: Vec<Arc<dyn EcosystemAdapter>>,
 }
 
 // Allows us to perform workspace discovery and parse package jsons
@@ -342,6 +376,7 @@ where
             package_discovery,
             package_manager: _,
             extra_toolchains,
+            ecosystem_adapters,
         } = builder;
         // Pure Cargo workspace: with no root package.json there is no
         // JavaScript project, so the JavaScript toolchain is neither
@@ -388,11 +423,11 @@ where
             // JavaScript registers first: its packages claim names before any
             // other toolchain's, so a cross-toolchain collision surfaces as the
             // non-JS package failing to add.
-            toolchains.register(javascript.clone());
+            toolchains.register(javascript.clone())?;
             Some(javascript)
         };
         for toolchain in extra_toolchains {
-            toolchains.register(toolchain);
+            toolchains.register(toolchain)?;
         }
 
         Ok(BuildState {
@@ -412,6 +447,7 @@ where
             state: std::marker::PhantomData,
             javascript,
             toolchains,
+            ecosystem_adapters,
         })
     }
 }
@@ -501,6 +537,45 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             discovered.extend(packages.into_iter().map(|package| (id.clone(), package)));
         }
 
+        let mut prepared_runtimes = Vec::with_capacity(self.ecosystem_adapters.len());
+        for adapter in &self.ecosystem_adapters {
+            let id = adapter.id();
+            let contribution = adapter.contribute().await?;
+            let runtime_id = contribution.prepared_runtime.id();
+            if runtime_id != id {
+                return Err(Error::AdapterRuntimeMismatch {
+                    adapter: id,
+                    runtime: runtime_id,
+                });
+            }
+            for package in &contribution.packages {
+                if package
+                    .descriptor
+                    .name
+                    .as_ref()
+                    .is_none_or(|name| name.as_inner().is_empty())
+                {
+                    return Err(Error::AdapterPackageMissingName {
+                        toolchain: id.clone(),
+                        manifest: package.manifest_path.clone(),
+                    });
+                }
+                if !self.repo_root.contains(&package.manifest_path) {
+                    return Err(Error::AdapterPackageOutsideRepository {
+                        toolchain: id.clone(),
+                        manifest: package.manifest_path.clone(),
+                    });
+                }
+            }
+            discovered.extend(
+                contribution
+                    .packages
+                    .into_iter()
+                    .map(|package| (id.clone(), package)),
+            );
+            prepared_runtimes.push(contribution.prepared_runtime);
+        }
+
         self.workspaces.reserve(discovered.len());
         self.node_lookup.reserve(discovered.len());
 
@@ -519,6 +594,11 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
                 Err(err) => return Err(err),
             }
         }
+        // A collision returns before the prepared runtimes enter even this
+        // build-local registry; no adapter-owned state was mutated either way.
+        for runtime in prepared_runtimes {
+            self.toolchains.register(runtime)?;
+        }
 
         let Self {
             repo_root,
@@ -532,6 +612,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             lockfile,
             javascript,
             toolchains,
+            ecosystem_adapters: _,
             defer_closures,
             closure_hasher,
             ..
@@ -548,6 +629,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             lockfile,
             javascript,
             toolchains,
+            ecosystem_adapters: Vec::new(),
             defer_closures,
             closure_hasher,
             package_jsons: None,
@@ -567,6 +649,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedPackageManage
             lockfile,
             javascript,
             toolchains,
+            ecosystem_adapters: _,
             repo_root,
             ..
         } = self;
@@ -776,6 +859,7 @@ impl<'a, T: PackageDiscovery + Send + Sync> BuildState<'a, ResolvedWorkspaces, T
             state: std::marker::PhantomData,
             javascript,
             toolchains,
+            ecosystem_adapters: Vec::new(),
         })
     }
 }
@@ -1020,7 +1104,7 @@ impl PackageInfo {
 
 #[cfg(test)]
 mod test {
-    use std::{assert_matches, collections::HashMap};
+    use std::{assert_matches, collections::HashMap, sync::Arc};
 
     use turborepo_errors::Spanned;
 
@@ -1042,6 +1126,114 @@ mod test {
         ) -> Result<crate::discovery::DiscoveryResponse, crate::discovery::Error> {
             self.discover_packages().await
         }
+    }
+
+    struct FakeRuntime(ToolchainId);
+
+    impl Toolchain for FakeRuntime {
+        fn id(&self) -> ToolchainId {
+            self.0.clone()
+        }
+    }
+
+    struct FakeAdapter {
+        id: ToolchainId,
+        runtime_id: ToolchainId,
+        package: DiscoveredPackage,
+    }
+
+    impl EcosystemAdapter for FakeAdapter {
+        fn id(&self) -> ToolchainId {
+            self.id.clone()
+        }
+
+        fn watch_spec(&self) -> crate::toolchain::WatchSpec {
+            crate::toolchain::WatchSpec::default()
+        }
+
+        fn contribute(&self) -> crate::toolchain::ContributeFuture<'_> {
+            let packages = vec![self.package.clone()];
+            let runtime: Arc<dyn Toolchain> = Arc::new(FakeRuntime(self.runtime_id.clone()));
+            Box::pin(async move {
+                Ok(crate::toolchain::EcosystemContribution {
+                    packages,
+                    prepared_runtime: runtime,
+                })
+            })
+        }
+    }
+
+    fn fake_adapter(
+        root: &AbsoluteSystemPath,
+        id: &str,
+        runtime_id: &str,
+        name: Option<&str>,
+    ) -> Arc<dyn EcosystemAdapter> {
+        Arc::new(FakeAdapter {
+            id: ToolchainId::new(id.to_string()),
+            runtime_id: ToolchainId::new(runtime_id.to_string()),
+            package: DiscoveredPackage {
+                descriptor: PackageJson {
+                    name: name.map(|name| Spanned::new(name.to_string())),
+                    ..Default::default()
+                },
+                manifest_path: root.join_component(&format!("{id}.toml")),
+                external_dependencies: None,
+            },
+        })
+    }
+
+    #[tokio::test]
+    async fn adapter_runtime_id_must_match_contribution_id() {
+        let root = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPathBuf::try_from(root.path()).unwrap();
+        let result = PackageGraphBuilder::new_optional(&root, None)
+            .with_ecosystem_adapter(fake_adapter(&root, "rust", "other", Some("app")))
+            .build()
+            .await;
+
+        assert!(matches!(result, Err(Error::AdapterRuntimeMismatch { .. })));
+    }
+
+    #[tokio::test]
+    async fn adapter_packages_require_names() {
+        let root = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPathBuf::try_from(root.path()).unwrap();
+        let result = PackageGraphBuilder::new_optional(&root, None)
+            .with_ecosystem_adapter(fake_adapter(&root, "rust", "rust", None))
+            .build()
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(Error::AdapterPackageMissingName { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn adapter_ids_must_be_unique() {
+        let root = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPathBuf::try_from(root.path()).unwrap();
+        let result = PackageGraphBuilder::new_optional(&root, None)
+            .with_ecosystem_adapter(fake_adapter(&root, "rust", "rust", Some("app")))
+            .with_ecosystem_adapter(fake_adapter(&root, "rust", "rust", Some("lib")))
+            .build()
+            .await;
+
+        assert!(matches!(result, Err(Error::DuplicateToolchain(_))));
+    }
+
+    #[tokio::test]
+    async fn adapters_are_rejected_in_single_package_mode() {
+        let root = tempfile::tempdir().unwrap();
+        let root = AbsoluteSystemPathBuf::try_from(root.path()).unwrap();
+        let result = PackageGraphBuilder::new_optional(&root, None)
+            .with_single_package_mode(true)
+            .with_ecosystem_adapter(fake_adapter(&root, "rust", "rust", Some("app")))
+            .build()
+            .await;
+
+        assert!(matches!(result, Err(Error::AdapterInSinglePackageMode)));
     }
 
     // Regression test: connect_internal_dependencies must produce correct

--- a/crates/turborepo-repository/src/toolchain.rs
+++ b/crates/turborepo-repository/src/toolchain.rs
@@ -1,17 +1,15 @@
 //! Toolchains: the abstraction that makes Turborepo generic over language
 //! ecosystems.
 //!
-//! A [`Toolchain`] answers ecosystem-specific questions about packages —
-//! starting with "which packages exist?" — so that the package graph and the
-//! rest of the system never branch on a specific ecosystem. JavaScript is the
-//! first implementation ([`JavaScriptToolchain`]); additional toolchains
-//! (e.g. Cargo) register alongside it in the [`ToolchainRegistry`].
+//! An [`EcosystemAdapter`] discovers packages and prepares a graph-local
+//! [`Toolchain`] runtime. The runtime answers ecosystem-specific behavioral
+//! questions, so the package graph and the rest of the system never branch on
+//! a specific ecosystem. JavaScript temporarily combines these roles for
+//! compatibility; Cargo uses the split model.
 //!
-//! The trait grows one concern at a time (discovery today; command
-//! resolution, derived task inputs/outputs, external-dependency hashing,
-//! watch triggers, and prune participation as they are needed), and every
-//! concern must ship with real implementations for every registered
-//! toolchain.
+//! `Toolchain` remains a compatibility runtime while those behavioral answers
+//! move into core-owned contribution data. New discovery state belongs in
+//! [`EcosystemContribution`], not on a `Toolchain` implementation.
 //!
 //! # Design rules
 //!
@@ -141,6 +139,30 @@ pub enum Error {
 pub type DiscoverPackagesFuture<'a> =
     Pin<Box<dyn Future<Output = Result<Vec<DiscoveredPackage>, Error>> + Send + 'a>>;
 
+/// A complete, graph-local contribution from an ecosystem adapter.
+///
+/// Discovery and preparation happen together, but core owns committing both:
+/// the runtime is registered only after every package has been accepted by the
+/// package graph builder.
+pub struct EcosystemContribution<R> {
+    pub packages: Vec<DiscoveredPackage>,
+    pub prepared_runtime: R,
+}
+
+pub type EcosystemContributionFuture<'a, R> =
+    Pin<Box<dyn Future<Output = Result<EcosystemContribution<R>, Error>> + Send + 'a>>;
+pub type ContributeFuture<'a> = EcosystemContributionFuture<'a, Arc<dyn Toolchain>>;
+
+/// Stateless, reusable input to package graph construction.
+///
+/// Each call prepares a fresh immutable behavior runtime for the graph being
+/// built. Adapters must not expose partially discovered state.
+pub trait EcosystemAdapter: Send + Sync {
+    fn id(&self) -> ToolchainId;
+    fn watch_spec(&self) -> WatchSpec;
+    fn contribute(&self) -> ContributeFuture<'_>;
+}
+
 /// A command resolved by a toolchain for a task, as plain data. The executor
 /// turns it into a process, applying the task's environment, stdin policy,
 /// and any decorations that are not toolchain concerns (e.g.
@@ -193,8 +215,11 @@ pub trait Toolchain: Send + Sync {
     /// This toolchain's identifier.
     fn id(&self) -> ToolchainId;
 
-    /// Discover this toolchain's packages.
-    fn discover_packages(&self) -> DiscoverPackagesFuture<'_>;
+    /// Compatibility discovery path. Prepared runtimes should leave this at
+    /// its empty default; adapters own discovery for core-built graphs.
+    fn discover_packages(&self) -> DiscoverPackagesFuture<'_> {
+        Box::pin(async { Ok(Vec::new()) })
+    }
 
     /// Resolve the command that implements `task` for `package`, or `None`
     /// when the toolchain defines no command for it — the task is then a
@@ -597,19 +622,26 @@ pub struct ToolchainRegistry {
     toolchains: Vec<Arc<dyn Toolchain>>,
 }
 
+#[derive(Debug, thiserror::Error)]
+#[error("toolchain {0:?} was registered more than once")]
+pub struct DuplicateToolchainError(ToolchainId);
+
 impl ToolchainRegistry {
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Register a toolchain. Registration order is discovery order.
-    pub fn register(&mut self, toolchain: Arc<dyn Toolchain>) {
-        debug_assert!(
-            self.get(&toolchain.id()).is_none(),
-            "toolchain {} registered twice",
-            toolchain.id()
-        );
+    pub fn register(
+        &mut self,
+        toolchain: Arc<dyn Toolchain>,
+    ) -> Result<(), DuplicateToolchainError> {
+        let id = toolchain.id();
+        if self.get(&id).is_some() {
+            return Err(DuplicateToolchainError(id));
+        }
         self.toolchains.push(toolchain);
+        Ok(())
     }
 
     pub fn get(&self, id: &ToolchainId) -> Option<&dyn Toolchain> {
@@ -1079,12 +1111,21 @@ mod tests {
         }
 
         let mut registry = ToolchainRegistry::new();
-        registry.register(Arc::new(Fake(ToolchainId::JAVASCRIPT)));
-        registry.register(Arc::new(Fake(ToolchainId::new("gleam"))));
+        registry
+            .register(Arc::new(Fake(ToolchainId::JAVASCRIPT)))
+            .unwrap();
+        registry
+            .register(Arc::new(Fake(ToolchainId::new("gleam"))))
+            .unwrap();
 
         assert!(registry.get(&ToolchainId::JAVASCRIPT).is_some());
         assert!(registry.get(&ToolchainId::new("gleam")).is_some());
         assert!(registry.get(&ToolchainId::new("zig")).is_none());
         assert_eq!(registry.iter().count(), 2);
+        assert!(
+            registry
+                .register(Arc::new(Fake(ToolchainId::new("gleam"))))
+                .is_err()
+        );
     }
 }

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -148,14 +148,16 @@ topological (`^`) dependencies.
 
 #### Toolchains (`crates/turborepo-repository/src/toolchain.rs`)
 
-The package graph is generic over language toolchains. A `Toolchain` answers
-ecosystem-specific questions — which packages exist, what command a task
-runs, what hash wiring a task derives — so graph construction and execution
-never branch on a specific ecosystem. All lookups go through the
-`ToolchainRegistry` (carried by the `PackageGraph`); `ToolchainId` is an
-open string identifier, not a closed enum; and trait methods are
-coarse-grained and data-in/data-out, keeping the door open to out-of-process
-plugin adapters. JavaScript is the first, production implementation: its
+The package graph is generic over ecosystems. An `EcosystemAdapter` is a
+reusable graph-construction input: each contribution contains discovered
+packages plus a fresh graph-local compatibility runtime. Core validates
+ecosystem identity, package names and paths, and duplicate registrations before
+committing that runtime to the resulting graph. `Toolchain` remains the runtime
+compatibility surface while its behavioral callbacks move into contribution
+data. All runtime lookups go through the `ToolchainRegistry` (carried by the
+`PackageGraph`); `ToolchainId` is an open string identifier, not a closed enum;
+and trait methods are coarse-grained and data-in/data-out, keeping the door open
+to out-of-process plugin adapters. JavaScript is the first, production implementation: its
 discovery, script command construction, and phantom-task detection flow
 through the trait. Machinery that predates the abstraction and has no trait
 surface yet (package-manager resolution for dependency splitting, the JS


### PR DESCRIPTION
## Stack

1 of 3 in the core-owned toolchain contribution stack.

- **#13436** Add ecosystem contribution boundary
- #13437 Prepare Cargo state per package graph
- #13438 Publish watch rediscovery transactionally

## Motivation

A package graph should be an immutable, self-contained repository snapshot. The existing `Toolchain` abstraction combines repository discovery with runtime behavior, which lets ecosystem objects retain mutable state outside core graph construction. Before migrating Cargo, core needs a boundary where ecosystems contribute repository facts and core validates and accepts them.

## Changes

- add reusable `EcosystemAdapter` and graph-local `EcosystemContribution` primitives
- teach `PackageGraphBuilder` to validate ecosystem identity, package names and paths, duplicate IDs, and runtime identity
- install prepared compatibility runtimes only after contributed packages are accepted
- make duplicate `ToolchainRegistry` registration fallible in release builds
- reject adapters in single-package mode instead of silently skipping them
- add generic fake-adapter coverage for the contribution invariants

This PR intentionally does not migrate a production ecosystem. The next PR uses this boundary to make Cargo discovery graph-local.

## Testing

- `cargo test -p turborepo-repository adapter_ --lib`
- `cargo check -p turborepo-repository -p turborepo-lib`