### PR TITLE
refactor: Prepare Cargo state per package graph

### DIFF
--- a/crates/turborepo-lib/src/commands/daemon.rs
+++ b/crates/turborepo-lib/src/commands/daemon.rs
@@ -348,14 +348,10 @@ pub async fn daemon_server(
             move |args| {
                 // Mirror the run builder: the daemon-side watcher must see
                 // the same package set a run would.
-                let mut extra_toolchains: Vec<
-                    std::sync::Arc<dyn turborepo_repository::toolchain::Toolchain>,
-                > = Vec::new();
-                if cargo_enabled {
-                    extra_toolchains.push(turborepo_repository::cargo::CargoToolchain::new(
-                        args.repo_root.clone(),
-                    ));
-                }
+                let ecosystem_adapters = crate::run::builder::configured_ecosystem_adapters(
+                    &args.repo_root,
+                    cargo_enabled,
+                );
                 PackageChangesWatcher::new(
                     args.repo_root,
                     args.file_events,
@@ -363,7 +359,7 @@ pub async fn daemon_server(
                     args.custom_turbo_json_path,
                     false,
                     args.allow_no_package_manager,
-                    extra_toolchains,
+                    ecosystem_adapters,
                 )
             }
         },

--- a/crates/turborepo-lib/src/commands/prune.rs
+++ b/crates/turborepo-lib/src/commands/prune.rs
@@ -755,10 +755,11 @@ impl<'a> Prune<'a> {
 
         let mut graph_builder = PackageGraph::builder(&base.repo_root, root_package_json)
             .with_allow_no_package_manager(allow_missing_package_manager);
-        if crate::run::builder::cargo_enabled(&base.opts().future_flags) {
-            graph_builder = graph_builder.with_toolchain(
-                turborepo_repository::cargo::CargoToolchain::new(base.repo_root.clone()),
-            );
+        for adapter in crate::run::builder::configured_ecosystem_adapters(
+            &base.repo_root,
+            crate::run::builder::cargo_enabled(&base.opts().future_flags),
+        ) {
+            graph_builder = graph_builder.with_ecosystem_adapter(adapter);
         }
         let package_graph = graph_builder.build().await?;
 

--- a/crates/turborepo-lib/src/engine/mod.rs
+++ b/crates/turborepo-lib/src/engine/mod.rs
@@ -374,7 +374,7 @@ mod test {
             .with_package_discovery(DummyDiscovery(
                 turbopath::AbsoluteSystemPathBuf::try_from(tmp.path()).unwrap(),
             ))
-            .with_toolchain(turborepo_repository::cargo::CargoToolchain::new(
+            .with_ecosystem_adapter(turborepo_repository::cargo::CargoAdapter::new(
                 root.to_owned(),
             ))
             .build()

--- a/crates/turborepo-lib/src/package_changes_watcher.rs
+++ b/crates/turborepo-lib/src/package_changes_watcher.rs
@@ -20,7 +20,7 @@ use turborepo_repository::{
     },
     package_graph::{PackageGraph, PackageGraphBuilder, PackageName, WorkspacePackage},
     package_json::PackageJson,
-    toolchain::{Toolchain, WatchSpec},
+    toolchain::{EcosystemAdapter, WatchSpec},
 };
 use turborepo_scm::GitHashes;
 
@@ -66,7 +66,7 @@ impl PackageChangesWatcher {
         custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
         single_package: bool,
         allow_no_package_manager: bool,
-        extra_toolchains: Vec<Arc<dyn Toolchain>>,
+        ecosystem_adapters: Vec<Arc<dyn EcosystemAdapter>>,
     ) -> Self {
         let (exit_tx, exit_rx) = oneshot::channel();
         let (package_change_events_tx, package_change_events_rx) =
@@ -79,7 +79,7 @@ impl PackageChangesWatcher {
             custom_turbo_json_path,
             single_package,
             allow_no_package_manager,
-            extra_toolchains,
+            ecosystem_adapters,
         );
 
         let _handle = tokio::spawn(subscriber.watch(exit_rx));
@@ -129,10 +129,10 @@ struct Subscriber {
     custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
     single_package: bool,
     allow_no_package_manager: bool,
-    /// Toolchains registered in addition to JavaScript (e.g. Cargo when
+    /// Ecosystem adapters registered in addition to JavaScript (e.g. Cargo when
     /// futureFlags.experimentalCargoWorkspaces is enabled), mirroring the
     /// run builder so the watcher sees the same package graph a run would.
-    extra_toolchains: Vec<Arc<dyn Toolchain>>,
+    ecosystem_adapters: Vec<Arc<dyn EcosystemAdapter>>,
 }
 
 fn is_in_git_folder(path: &AnchoredSystemPath) -> bool {
@@ -321,7 +321,7 @@ impl Subscriber {
         custom_turbo_json_path: Option<AbsoluteSystemPathBuf>,
         single_package: bool,
         allow_no_package_manager: bool,
-        extra_toolchains: Vec<Arc<dyn Toolchain>>,
+        ecosystem_adapters: Vec<Arc<dyn EcosystemAdapter>>,
     ) -> Self {
         // Try to canonicalize the custom path to match what the file watcher reports
         let normalized_custom_path = custom_turbo_json_path.map(|path| {
@@ -359,8 +359,8 @@ impl Subscriber {
             .repository_ignore()
             .unwrap_or_else(|| RepositoryIgnore::new(repo_root.as_std_path()));
         let mut watch_spec = WatchSpec::default();
-        for toolchain in &extra_toolchains {
-            watch_spec.extend(toolchain.watch_spec());
+        for adapter in &ecosystem_adapters {
+            watch_spec.extend(adapter.watch_spec());
         }
 
         Subscriber {
@@ -374,7 +374,7 @@ impl Subscriber {
             custom_turbo_json_path: normalized_custom_path,
             single_package,
             allow_no_package_manager,
-            extra_toolchains,
+            ecosystem_adapters,
         }
     }
 
@@ -388,8 +388,8 @@ impl Subscriber {
         let mut builder = PackageGraphBuilder::new(&self.repo_root, root_package_json.clone())
             .with_single_package_mode(self.single_package)
             .with_allow_no_package_manager(self.allow_no_package_manager);
-        for toolchain in &self.extra_toolchains {
-            builder = builder.with_toolchain(toolchain.clone());
+        for adapter in &self.ecosystem_adapters {
+            builder = builder.with_ecosystem_adapter(adapter.clone());
         }
         let Ok(pkg_dep_graph) = builder.build().await else {
             tracing::debug!("package graph not available, package watcher not available");

--- a/crates/turborepo-lib/src/run/builder.rs
+++ b/crates/turborepo-lib/src/run/builder.rs
@@ -573,10 +573,11 @@ impl RunBuilder {
                     .with_closure_hasher(std::sync::Arc::new(
                         turborepo_task_hash::hash_sorted_closures,
                     ));
-            if cargo_enabled(&self.opts.future_flags) {
-                builder = builder.with_toolchain(turborepo_repository::cargo::CargoToolchain::new(
-                    self.repo_root.to_owned(),
-                ));
+            for adapter in configured_ecosystem_adapters(
+                &self.repo_root,
+                cargo_enabled(&self.opts.future_flags),
+            ) {
+                builder = builder.with_ecosystem_adapter(adapter);
             }
 
             let graph = builder
@@ -1392,6 +1393,20 @@ pub(crate) fn cargo_enabled(future_flags: &turborepo_turbo_json::FutureFlags) ->
     future_flags.experimental_cargo_workspaces
 }
 
+pub(crate) fn configured_ecosystem_adapters(
+    repo_root: &AbsoluteSystemPath,
+    cargo_enabled: bool,
+) -> Vec<std::sync::Arc<dyn turborepo_repository::toolchain::EcosystemAdapter>> {
+    let mut adapters = Vec::new();
+    if cargo_enabled {
+        adapters.push(
+            turborepo_repository::cargo::CargoAdapter::new(repo_root.to_owned())
+                as std::sync::Arc<dyn turborepo_repository::toolchain::EcosystemAdapter>,
+        );
+    }
+    adapters
+}
+
 fn origins_match(url1: &str, url2: &str) -> bool {
     let (Ok(url1), Ok(url2)) = (Url::parse(url1), Url::parse(url2)) else {
         return false;
@@ -1416,8 +1431,10 @@ mod task_io_context_tests {
     use turborepo_env::EnvironmentVariableMap;
     use turborepo_hash::TaskHashable;
     use turborepo_repository::{
-        cargo::CargoToolchain,
-        toolchain::{DiscoverPackagesFuture, Toolchain, ToolchainId, ToolchainRegistry},
+        cargo::CargoAdapter,
+        toolchain::{
+            DiscoverPackagesFuture, EcosystemAdapter, Toolchain, ToolchainId, ToolchainRegistry,
+        },
     };
     use turborepo_types::EnvMode;
 
@@ -1477,12 +1494,20 @@ mod task_io_context_tests {
         assert_eq!(beta_environment.get("UNDECLARED_SECRET"), None);
     }
 
-    #[test]
-    fn cargo_projection_keeps_only_rustup_selection_environment() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cargo_projection_keeps_only_rustup_selection_environment() {
         let root = tempfile::tempdir().unwrap();
         let root = AbsoluteSystemPathBuf::try_from(root.path()).unwrap();
         let mut toolchains = ToolchainRegistry::new();
-        toolchains.register(CargoToolchain::new(root)).unwrap();
+        toolchains
+            .register(
+                CargoAdapter::new(root)
+                    .contribute()
+                    .await
+                    .unwrap()
+                    .prepared_runtime,
+            )
+            .unwrap();
         let environment = EnvironmentVariableMap::from(HashMap::from([
             ("RUSTUP_HOME".to_string(), "/rustup".to_string()),
             ("RUSTUP_TOOLCHAIN".to_string(), "stable-host".to_string()),

--- a/crates/turborepo-lib/src/run/watch.rs
+++ b/crates/turborepo-lib/src/run/watch.rs
@@ -302,14 +302,10 @@ impl WatchClient {
         ));
         // The watcher builds its own package graph; register the same
         // toolchains a run would so it watches the same package set.
-        let mut extra_toolchains: Vec<
-            std::sync::Arc<dyn turborepo_repository::toolchain::Toolchain>,
-        > = Vec::new();
-        if crate::run::builder::cargo_enabled(&base.opts().future_flags) {
-            extra_toolchains.push(turborepo_repository::cargo::CargoToolchain::new(
-                base.repo_root.clone(),
-            ));
-        }
+        let ecosystem_adapters = crate::run::builder::configured_ecosystem_adapters(
+            &base.repo_root,
+            crate::run::builder::cargo_enabled(&base.opts().future_flags),
+        );
         let package_changes_watcher = PackageChangesWatcher::new(
             base.repo_root.clone(),
             watcher.source(),
@@ -317,7 +313,7 @@ impl WatchClient {
             custom_turbo_json_path,
             base.opts().run_opts.single_package,
             base.opts().repo_opts.allow_no_package_manager,
-            extra_toolchains,
+            ecosystem_adapters,
         );
 
         // Subscribe before building the Run so we don't miss the initial

--- a/crates/turborepo-repository/src/cargo.rs
+++ b/crates/turborepo-repository/src/cargo.rs
@@ -44,7 +44,10 @@ use turborepo_errors::Spanned;
 
 use crate::{
     package_json::PackageJson,
-    toolchain::{self, DiscoverPackagesFuture, DiscoveredPackage, Toolchain, ToolchainId},
+    toolchain::{
+        self, ContributeFuture, DiscoveredPackage, EcosystemAdapter, EcosystemContribution,
+        EcosystemContributionFuture, Toolchain, ToolchainId,
+    },
 };
 
 /// The conventional file name for a Cargo manifest.
@@ -982,16 +985,23 @@ fn cargo_output_layout(
     })
 }
 
-/// The Cargo toolchain. Registered in the
-/// [`crate::toolchain::ToolchainRegistry`] when
-/// `futureFlags.experimentalCargoWorkspaces` is enabled and the repository
-/// root contains a `Cargo.toml`.
+/// Stateless, reusable Cargo discovery input. Every contribution contains a
+/// newly prepared runtime, so rediscovery cannot alter an existing graph.
+pub struct CargoAdapter {
+    repo_root: AbsoluteSystemPathBuf,
+}
+
+impl CargoAdapter {
+    pub fn new(repo_root: AbsoluteSystemPathBuf) -> Arc<Self> {
+        Arc::new(Self { repo_root })
+    }
+}
+
+/// Immutable Cargo behavior prepared for one package graph.
 pub struct CargoToolchain {
     repo_root: AbsoluteSystemPathBuf,
-    /// Per-package details recorded during discovery, consumed by command
-    /// resolution. Keyed by package name.
-    details: std::sync::Mutex<HashMap<String, CargoPackageDetails>>,
-    workspace_details: std::sync::Mutex<Option<CargoWorkspaceDetails>>,
+    details: HashMap<String, CargoPackageDetails>,
+    workspace_details: Option<CargoWorkspaceDetails>,
     /// The cargo binary, resolved lazily so runs without Cargo tasks never
     /// pay for a PATH scan.
     cargo_binary: std::sync::OnceLock<Result<std::path::PathBuf, which::Error>>,
@@ -1004,35 +1014,25 @@ enum CargoCommandError {
 }
 
 impl CargoToolchain {
-    pub fn new(repo_root: AbsoluteSystemPathBuf) -> Arc<Self> {
+    fn prepared(
+        repo_root: AbsoluteSystemPathBuf,
+        details: HashMap<String, CargoPackageDetails>,
+        workspace_details: Option<CargoWorkspaceDetails>,
+    ) -> Arc<Self> {
         Arc::new(Self {
             repo_root,
-            details: std::sync::Mutex::new(HashMap::new()),
-            workspace_details: std::sync::Mutex::new(None),
+            details,
+            workspace_details,
             cargo_binary: std::sync::OnceLock::new(),
         })
     }
 
-    fn package_details(&self, package: &str) -> Option<CargoPackageDetails> {
-        self.details
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .get(package)
-            .cloned()
+    fn package_details(&self, package: &str) -> Option<&CargoPackageDetails> {
+        self.details.get(package)
     }
 
-    fn record_details(&self, package: String, details: CargoPackageDetails) {
-        self.details
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .insert(package, details);
-    }
-
-    fn workspace_details(&self) -> Option<CargoWorkspaceDetails> {
-        self.workspace_details
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .clone()
+    fn workspace_details(&self) -> Option<&CargoWorkspaceDetails> {
+        self.workspace_details.as_ref()
     }
 }
 
@@ -1151,7 +1151,7 @@ impl Toolchain for CargoToolchain {
             .package_name()
             .and_then(|name| self.package_details(&name))
             .map(|details| {
-                registered_tasks(&details)
+                registered_tasks(details)
                     .into_iter()
                     .map(str::to_string)
                     .collect()
@@ -1163,7 +1163,7 @@ impl Toolchain for CargoToolchain {
         package
             .package_name()
             .and_then(|name| self.package_details(&name))
-            .is_some_and(|details| registered_tasks(&details).contains(&task))
+            .is_some_and(|details| registered_tasks(details).contains(&task))
     }
 
     /// Route rustc invocations through the embedded sccache, with the
@@ -1254,11 +1254,8 @@ impl Toolchain for CargoToolchain {
     }
 
     fn additional_affected_packages(&self, package: &str) -> Vec<String> {
-        let details = self
+        let mut affected: Vec<_> = self
             .details
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let mut affected: Vec<_> = details
             .iter()
             .filter(|(_, details)| details.kind != CargoPackageKind::Workspace)
             .filter(|(_, details)| {
@@ -1280,10 +1277,7 @@ impl Toolchain for CargoToolchain {
         prefer_workspace: bool,
     ) -> Option<Vec<String>> {
         let subcommand = library_subcommand(task)?;
-        let details = self
-            .details
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let details = &self.details;
         if subcommand == "build" {
             let crates: Vec<_> = candidates
                 .iter()
@@ -1332,6 +1326,8 @@ impl Toolchain for CargoToolchain {
         )
     }
 
+    // Compatibility runtime hook. Watch interests move fully onto the adapter
+    // in the follow-up watcher transaction change.
     fn watch_spec(&self) -> toolchain::WatchSpec {
         watch_spec()
     }
@@ -1537,8 +1533,8 @@ impl Toolchain for CargoToolchain {
                             .and_then(|workspace| {
                                 let layout = cargo_output_layout(
                                     &self.repo_root,
-                                    &workspace,
-                                    &details,
+                                    workspace,
+                                    details,
                                     context,
                                 )?;
                                 let effective_target =
@@ -1580,8 +1576,10 @@ impl Toolchain for CargoToolchain {
 
         Some(io)
     }
+}
 
-    fn discover_packages(&self) -> DiscoverPackagesFuture<'_> {
+impl CargoAdapter {
+    fn prepare(&self) -> EcosystemContributionFuture<'_, Arc<CargoToolchain>> {
         Box::pin(async move {
             // Discovery spawns `cargo metadata` synchronously, so keep it off
             // the async runtime like the JavaScript manifest-parsing path.
@@ -1596,7 +1594,14 @@ impl Toolchain for CargoToolchain {
                     turborepo_rayon_compat::block_in_place(|| validate_lockfile(&self.repo_root))
                         .map_err(|err| toolchain::Error::Failed(Box::new(err)))?;
                 }
-                return Ok(Vec::new());
+                return Ok(EcosystemContribution {
+                    packages: Vec::new(),
+                    prepared_runtime: CargoToolchain::prepared(
+                        self.repo_root.clone(),
+                        HashMap::new(),
+                        None,
+                    ),
+                });
             }
 
             // Using Turborepo with Rust requires naming the workspace: the
@@ -1636,24 +1641,19 @@ impl Toolchain for CargoToolchain {
                     ))
                 })
                 .map_err(|err| toolchain::Error::Failed(Box::new(err)))?;
-            if let Some(target_directory) = target_directory {
+            let workspace_details = target_directory.map(|target_directory| {
                 let startup_environment = CargoHomeEnvironment::current();
                 let config = cargo_config_influence(&self.repo_root, &startup_environment);
-                *self
-                    .workspace_details
-                    .lock()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner()) =
-                    Some(CargoWorkspaceDetails {
-                        target_directory,
-                        host_target,
-                        supported_targets,
-                        repository_config_alters_output_layout: config
-                            .repository_alters_output_layout,
-                        repository_config_untracked: config.repository_config_untracked,
-                        external_config_present: config.external_present,
-                        manifest_alters_profile_dirs: manifest_alters_profile_dirs(&self.repo_root),
-                    });
-            }
+                CargoWorkspaceDetails {
+                    target_directory,
+                    host_target,
+                    supported_targets,
+                    repository_config_alters_output_layout: config.repository_alters_output_layout,
+                    repository_config_untracked: config.repository_config_untracked,
+                    external_config_present: config.external_present,
+                    manifest_alters_profile_dirs: manifest_alters_profile_dirs(&self.repo_root),
+                }
+            });
             let workspace_externals: HashSet<turborepo_lockfiles::Package> = closures
                 .values()
                 .flatten()
@@ -1663,6 +1663,7 @@ impl Toolchain for CargoToolchain {
 
             let mut packages = Vec::with_capacity(crates.len() + 1);
             let mut crate_names = Vec::with_capacity(crates.len());
+            let mut details = HashMap::with_capacity(crates.len() + 1);
             for cargo_crate in crates {
                 let dependencies = cargo_crate
                     .internal_dependencies
@@ -1682,7 +1683,7 @@ impl Toolchain for CargoToolchain {
                     })
                     .map(|dir| dir.to_unix().to_string())
                     .unwrap_or_default();
-                self.record_details(
+                details.insert(
                     cargo_crate.name.clone(),
                     CargoPackageDetails {
                         kind,
@@ -1715,7 +1716,7 @@ impl Toolchain for CargoToolchain {
             // name`. It depends on every crate so `--affected` and
             // dependent-filters propagate crate changes to it.
             if !crate_names.is_empty() {
-                self.record_details(
+                details.insert(
                     workspace_name.clone(),
                     CargoPackageDetails {
                         kind: CargoPackageKind::Workspace,
@@ -1742,7 +1743,35 @@ impl Toolchain for CargoToolchain {
                 });
             }
 
-            Ok(packages)
+            Ok(EcosystemContribution {
+                packages,
+                prepared_runtime: CargoToolchain::prepared(
+                    self.repo_root.clone(),
+                    details,
+                    workspace_details,
+                ),
+            })
+        })
+    }
+}
+
+impl EcosystemAdapter for CargoAdapter {
+    fn id(&self) -> ToolchainId {
+        ToolchainId::RUST
+    }
+
+    fn watch_spec(&self) -> toolchain::WatchSpec {
+        watch_spec()
+    }
+
+    fn contribute(&self) -> ContributeFuture<'_> {
+        Box::pin(async move {
+            let contribution = self.prepare().await?;
+            let prepared_runtime: Arc<dyn Toolchain> = contribution.prepared_runtime;
+            Ok(EcosystemContribution {
+                packages: contribution.packages,
+                prepared_runtime,
+            })
         })
     }
 }
@@ -2737,10 +2766,11 @@ dependencies = ["lib-a"]
         write(&root, &["src", "lib.rs"], "");
         generate_lockfile(&root);
 
-        let error = CargoToolchain::new(root)
-            .discover_packages()
+        let error = CargoAdapter::new(root)
+            .prepare()
             .await
-            .unwrap_err();
+            .err()
+            .expect("root package must fail");
         assert!(
             error.to_string().contains("root-package")
                 && error.to_string().contains("root Cargo.toml"),
@@ -3452,8 +3482,11 @@ release: 1.96.0-nightly\n",
             "[workspace]\nmembers = [\"crates/*\"]\nresolver = \"2\"\n",
         );
 
-        let toolchain = CargoToolchain::new(root.clone());
-        let err = toolchain.discover_packages().await.unwrap_err();
+        let err = CargoAdapter::new(root.clone())
+            .prepare()
+            .await
+            .err()
+            .expect("missing workspace name must fail");
         assert!(
             err.to_string().contains("[workspace.metadata]"),
             "the error must show the fix, got: {err}"
@@ -3536,7 +3569,7 @@ release: 1.96.0-nightly\n",
     #[test]
     fn test_compile_cache_env_routes_rustc_through_sccache() {
         let (_tmp, root) = tempdir_root();
-        let toolchain = CargoToolchain::new(root);
+        let toolchain = CargoToolchain::prepared(root, HashMap::new(), None);
         let endpoint = toolchain::CompileCacheEndpoint {
             url: "http://127.0.0.1:42123".to_string(),
             token: "proxy-token".to_string(),
@@ -3573,7 +3606,7 @@ release: 1.96.0-nightly\n",
     #[test]
     fn test_compile_cache_env_stands_down_for_competing_configuration() {
         let (_tmp, root) = tempdir_root();
-        let toolchain = CargoToolchain::new(root);
+        let toolchain = CargoToolchain::prepared(root, HashMap::new(), None);
         let endpoint = toolchain::CompileCacheEndpoint {
             url: "http://127.0.0.1:42123".to_string(),
             token: "proxy-token".to_string(),
@@ -3604,7 +3637,7 @@ release: 1.96.0-nightly\n",
         // a competing compiler cache: the injection proceeds and the
         // explicit value is left alone.
         let (_tmp, root) = tempdir_root();
-        let toolchain = CargoToolchain::new(root);
+        let toolchain = CargoToolchain::prepared(root, HashMap::new(), None);
         let endpoint = toolchain::CompileCacheEndpoint {
             url: "http://127.0.0.1:42123".to_string(),
             token: "proxy-token".to_string(),
@@ -3637,10 +3670,10 @@ release: 1.96.0-nightly\n",
         let (_tmp, root) = tempdir_root();
         write_fixture_workspace(&root);
 
-        let toolchain = CargoToolchain::new(root.clone());
-        assert_eq!(toolchain.id(), ToolchainId::RUST);
+        let contribution = CargoAdapter::new(root.clone()).prepare().await.unwrap();
+        assert_eq!(contribution.prepared_runtime.id(), ToolchainId::RUST);
 
-        let mut packages = toolchain.discover_packages().await.unwrap();
+        let mut packages = contribution.packages;
         packages.sort_by(|a, b| {
             a.descriptor
                 .name
@@ -3703,8 +3736,8 @@ release: 1.96.0-nightly\n",
     #[tokio::test(flavor = "multi_thread")]
     async fn test_cargo_toolchain_empty_without_manifest() {
         let (_tmp, root) = tempdir_root();
-        let toolchain = CargoToolchain::new(root);
-        assert!(toolchain.discover_packages().await.unwrap().is_empty());
+        let contribution = CargoAdapter::new(root).prepare().await.unwrap();
+        assert!(contribution.packages.is_empty());
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -3712,8 +3745,8 @@ release: 1.96.0-nightly\n",
         let (_tmp, root) = tempdir_root();
         write(&root, &["Cargo.toml"], "[workspace]\nmembers = []\n");
 
-        let toolchain = CargoToolchain::new(root);
-        assert!(toolchain.discover_packages().await.unwrap().is_empty());
+        let contribution = CargoAdapter::new(root).prepare().await.unwrap();
+        assert!(contribution.packages.is_empty());
     }
 
     fn package_info(name: &str, manifest_rel: &str) -> crate::package_graph::PackageInfo {
@@ -3740,9 +3773,11 @@ release: 1.96.0-nightly\n",
         let (_tmp, root) = tempdir_root();
         write_fixture_workspace(&root);
 
-        let toolchain = CargoToolchain::new(root.clone());
-        // Discovery records the per-package details command resolution uses.
-        toolchain.discover_packages().await.unwrap();
+        let toolchain = CargoAdapter::new(root.clone())
+            .prepare()
+            .await
+            .unwrap()
+            .prepared_runtime;
 
         let app = package_info("app", "crates/app/Cargo.toml");
         let lib_a = package_info("lib-a", "crates/lib-a/Cargo.toml");
@@ -3928,8 +3963,11 @@ release: 1.96.0-nightly\n",
         let (_tmp, root) = tempdir_root();
         write_fixture_workspace(&root);
 
-        let toolchain = CargoToolchain::new(root.clone());
-        toolchain.discover_packages().await.unwrap();
+        let toolchain = CargoAdapter::new(root.clone())
+            .prepare()
+            .await
+            .unwrap()
+            .prepared_runtime;
 
         let lib_a = package_info("lib-a", "crates/lib-a/Cargo.toml");
         let workspace = package_info("fixture-ws", "Cargo.toml");
@@ -3973,8 +4011,11 @@ release: 1.96.0-nightly\n",
         let (_tmp, root) = tempdir_root();
         write_fixture_workspace(&root);
 
-        let toolchain = CargoToolchain::new(root.clone());
-        toolchain.discover_packages().await.unwrap();
+        let toolchain = CargoAdapter::new(root.clone())
+            .prepare()
+            .await
+            .unwrap()
+            .prepared_runtime;
 
         let app = package_info("app", "crates/app/Cargo.toml");
         let lib_a = package_info("lib-a", "crates/lib-a/Cargo.toml");

--- a/crates/turborepo-repository/src/package_graph/mod.rs
+++ b/crates/turborepo-repository/src/package_graph/mod.rs
@@ -1974,7 +1974,7 @@ version = "0.1.0"
                 map
             }))
             .with_lockfile(Some(Box::new(MockLockfile {})))
-            .with_toolchain(crate::cargo::CargoToolchain::new(root.clone()))
+            .with_ecosystem_adapter(crate::cargo::CargoAdapter::new(root.clone()))
             .build()
             .await
             .unwrap();
@@ -2048,7 +2048,7 @@ version = "0.1.0"
         write_cargo_workspace_fixture(&root);
 
         let pkg_graph = PackageGraph::builder_optional(&root, None)
-            .with_toolchain(crate::cargo::CargoToolchain::new(root.clone()))
+            .with_ecosystem_adapter(crate::cargo::CargoAdapter::new(root.clone()))
             .build()
             .await
             .unwrap();
@@ -2084,6 +2084,127 @@ version = "0.1.0"
         );
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_cargo_rediscovery_prepares_graph_local_runtime() {
+        let (_tmp, root) = canonical_tempdir();
+        write_cargo_workspace_fixture(&root);
+        let adapter = crate::cargo::CargoAdapter::new(root.clone());
+
+        let graph_a = PackageGraph::builder_optional(&root, None)
+            .with_ecosystem_adapter(adapter.clone())
+            .build()
+            .await
+            .unwrap();
+        let app_name = PackageName::from("app");
+        let app_a = graph_a.package_info(&app_name).unwrap();
+        assert!(
+            graph_a
+                .toolchains()
+                .get(&crate::toolchain::ToolchainId::RUST)
+                .unwrap()
+                .defines_task(app_a, "run")
+        );
+
+        // Rediscovery through the same adapter sees `app` change from an
+        // entrypoint to a library. Graph A must retain its original behavior.
+        std::fs::write(
+            root.join_components(&["rust", "app", "Cargo.toml"])
+                .as_std_path(),
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\nedition = \
+             \"2021\"\n\n[dependencies]\nlib-a = { path = \"../lib-a\" }\n",
+        )
+        .unwrap();
+        std::fs::remove_file(
+            root.join_components(&["rust", "app", "src", "main.rs"])
+                .as_std_path(),
+        )
+        .unwrap();
+        std::fs::write(
+            root.join_components(&["rust", "app", "src", "lib.rs"])
+                .as_std_path(),
+            "",
+        )
+        .unwrap();
+
+        let graph_b = PackageGraph::builder_optional(&root, None)
+            .with_ecosystem_adapter(adapter.clone())
+            .build()
+            .await
+            .unwrap();
+        let app_b = graph_b.package_info(&app_name).unwrap();
+        assert!(
+            !graph_b
+                .toolchains()
+                .get(&crate::toolchain::ToolchainId::RUST)
+                .unwrap()
+                .defines_task(app_b, "run")
+        );
+        assert!(graph_a.package_info(&app_name).is_some());
+        assert!(
+            graph_a
+                .toolchains()
+                .get(&crate::toolchain::ToolchainId::RUST)
+                .unwrap()
+                .defines_task(app_a, "run")
+        );
+
+        // A memberless contribution must not retain behavior from either
+        // earlier graph.
+        std::fs::write(
+            root.join_component("Cargo.toml").as_std_path(),
+            "[workspace]\nmembers = []\n",
+        )
+        .unwrap();
+        let graph_c = PackageGraph::builder_optional(&root, None)
+            .with_ecosystem_adapter(adapter.clone())
+            .build()
+            .await
+            .unwrap();
+        assert!(graph_c.package_info(&app_name).is_none());
+        assert!(
+            !graph_c
+                .toolchains()
+                .get(&crate::toolchain::ToolchainId::RUST)
+                .unwrap()
+                .defines_task(app_a, "run")
+        );
+
+        // A later contribution that core rejects must likewise have no route
+        // to mutate any successfully constructed graph. Restore `app` as an
+        // entrypoint so leaking the rejected runtime would be observable on B.
+        write_cargo_workspace_fixture(&root);
+        let failed = PackageGraph::builder(
+            &root,
+            PackageJson::from_value(json!({ "name": "root" })).unwrap(),
+        )
+        .with_package_discovery(MockDiscovery)
+        .with_package_jsons(Some(HashMap::from([(
+            root.join_components(&["js-app", "package.json"]),
+            PackageJson::from_value(json!({ "name": "app" })).unwrap(),
+        )])))
+        .with_lockfile(Some(Box::new(MockLockfile {})))
+        .with_ecosystem_adapter(adapter)
+        .build()
+        .await;
+        assert!(matches!(failed, Err(Error::DuplicateWorkspace { .. })));
+        assert!(graph_a.package_info(&app_name).is_some());
+        assert!(graph_b.package_info(&app_name).is_some());
+        assert!(
+            graph_a
+                .toolchains()
+                .get(&crate::toolchain::ToolchainId::RUST)
+                .unwrap()
+                .defines_task(app_a, "run")
+        );
+        assert!(
+            !graph_b
+                .toolchains()
+                .get(&crate::toolchain::ToolchainId::RUST)
+                .unwrap()
+                .defines_task(app_b, "run")
+        );
+    }
+
     /// A crate and a JS package sharing a name is a hard error, like any
     /// other duplicate package name.
     #[tokio::test(flavor = "multi_thread")]
@@ -2105,7 +2226,7 @@ version = "0.1.0"
             map
         }))
         .with_lockfile(Some(Box::new(MockLockfile {})))
-        .with_toolchain(crate::cargo::CargoToolchain::new(root.clone()))
+        .with_ecosystem_adapter(crate::cargo::CargoAdapter::new(root.clone()))
         .build()
         .await;
 

--- a/crates/turborepo/ARCHITECTURE.md
+++ b/crates/turborepo/ARCHITECTURE.md
@@ -184,7 +184,8 @@ root and adds them to the package graph. Cargo workspaces can stand alone or
 coexist with JavaScript workspaces; a root `package.json` and JavaScript package
 manager are only required when JavaScript packages participate. Cargo-only
 repositories may omit `package.json`; when one exists, it must still be valid.
-`CargoToolchain` is the second `Toolchain` implementation.
+`CargoAdapter` performs discovery and prepares an immutable, graph-local
+`CargoToolchain`; its only interior memoization is lazy Cargo binary lookup.
 
 Turborepo does not replace Cargo. Cargo is itself a build system with its
 own dependency graph, scheduler, and incremental cache (`target/`), so the


### PR DESCRIPTION
## Stack

2 of 3 in the core-owned toolchain contribution stack.

- #13436 Add ecosystem contribution boundary
- **#13437** Prepare Cargo state per package graph
- #13438 Publish watch rediscovery transactionally

## Motivation

`CargoToolchain` currently performs discovery and stores the discovered package and workspace details that later runtime callbacks consume. In watch mode the same toolchain instance is reused across graph generations, but the ownership problem applies to every command: the package graph is not self-contained when its meaning depends on mutable state owned outside the graph.

A Cargo-local lock would repair stale reads while leaving snapshot lifecycle in the wrong layer. Cargo should instead inspect the repository, return a contribution to core, and prepare immutable behavior for exactly one accepted package graph.

## Changes

- split stateless, reusable `CargoAdapter` discovery from immutable `CargoToolchain` runtime behavior
- build all Cargo package and workspace details locally before returning a contribution
- migrate run, watch, daemon, prune, and engine setup to the adapter boundary
- centralize production adapter construction so command paths cannot drift
- give every package graph its own Cargo runtime while retaining current command, hashing, affectedness, and prune callbacks as compatibility behavior
- add lifecycle tests covering entrypoint-to-library changes, memberless rediscovery, and rejected graph candidates

The final PR moves watch ownership fully onto adapters and makes candidate publication transactional.

## Testing

- `cargo test -p turborepo-repository test_cargo_rediscovery_prepares_graph_local_runtime --lib`
- `cargo test -p turbo --test cargo_workspace_test`
- `cargo check -p turborepo-lib`